### PR TITLE
Custom expression: escape/unescape field name

### DIFF
--- a/frontend/src/metabase/lib/expressions/index.js
+++ b/frontend/src/metabase/lib/expressions/index.js
@@ -10,12 +10,29 @@ import {
   getMBQLName,
 } from "./config";
 
-export function unescapeString(string) {
+// Return a copy with brackets (`[` and `]`) being escaped
+function escapeString(string) {
   let str = "";
   for (let i = 0; i < string.length; ++i) {
     const ch = string[i];
-    if (ch !== "\\") {
-      str += ch;
+    if (ch === "[" || ch === "]") {
+      str += "\\";
+    }
+    str += ch;
+  }
+  return str;
+}
+
+// The opposite of escapeString
+export function unescapeString(string) {
+  let str = "";
+  for (let i = 0; i < string.length; ++i) {
+    const ch1 = string[i];
+    const ch2 = string[i + 1];
+    if (ch1 === "\\" && (ch2 === "[" || ch2 === "]")) {
+      // skip
+    } else {
+      str += ch1;
     }
   }
   return str;
@@ -121,16 +138,7 @@ function quoteString(string, character) {
   } else if (character === "'") {
     return swapQuotes(JSON.stringify(swapQuotes(string)));
   } else if (character === "[") {
-    let str = "[";
-    for (let i = 0; i < string.length; ++i) {
-      const ch = string[i];
-      if (ch === "[" || ch === "]") {
-        str += "\\";
-      }
-      str += ch;
-    }
-    str += "]";
-    return str;
+    return "[" + escapeString(string) + "]";
   } else if (character === "") {
     // unquoted
     return string;

--- a/frontend/src/metabase/lib/expressions/index.js
+++ b/frontend/src/metabase/lib/expressions/index.js
@@ -10,6 +10,17 @@ import {
   getMBQLName,
 } from "./config";
 
+export function unescapeString(string) {
+  let str = "";
+  for (let i = 0; i < string.length; ++i) {
+    const ch = string[i];
+    if (ch !== "\\") {
+      str += ch;
+    }
+  }
+  return str;
+}
+
 // IDENTIFIERS
 
 // can be double-quoted, but are not by default unless they have non-word characters or are reserved
@@ -110,11 +121,16 @@ function quoteString(string, character) {
   } else if (character === "'") {
     return swapQuotes(JSON.stringify(swapQuotes(string)));
   } else if (character === "[") {
-    // TODO: escape brackets
-    if (string.match(/\[|\]/)) {
-      throw new Error("String currently can't contain brackets: " + string);
+    let str = "[";
+    for (let i = 0; i < string.length; ++i) {
+      const ch = string[i];
+      if (ch === "[" || ch === "]") {
+        str += "\\";
+      }
+      str += ch;
     }
-    return `[${string}]`;
+    str += "]";
+    return str;
   } else if (character === "") {
     // unquoted
     return string;
@@ -129,8 +145,7 @@ function unquoteString(string) {
   } else if (character === "'") {
     return swapQuotes(JSON.parse(swapQuotes(string)));
   } else if (character === "[") {
-    // TODO: unescape brackets
-    return string.slice(1, -1);
+    return unescapeString(string).slice(1, -1);
   } else {
     throw new Error("Unknown quoting: " + string);
   }

--- a/frontend/src/metabase/lib/expressions/pratt/compiler.ts
+++ b/frontend/src/metabase/lib/expressions/pratt/compiler.ts
@@ -1,5 +1,6 @@
 import { t } from "ttag";
 
+import { unescapeString } from "metabase/lib/expressions/index";
 import {
   /* ALL_ASTYPES */ ADD,
   FIELD,
@@ -60,7 +61,7 @@ function compileField(node: Node): Expr {
   assert(node.token?.text, "Empty field name");
   // Slice off the leading and trailing brackets
   const name = node.token.text.slice(1, node.token.text.length - 1);
-  return withNode(["dimension", name], node);
+  return withNode(["dimension", unescapeString(name)], node);
 }
 
 function compileIdentifier(node: Node): Expr {

--- a/frontend/src/metabase/lib/expressions/recursive-parser.js
+++ b/frontend/src/metabase/lib/expressions/recursive-parser.js
@@ -1,7 +1,7 @@
 import { t } from "ttag";
 
 import { tokenize, TOKEN, OPERATOR as OP } from "./tokenizer";
-import { getMBQLName, MBQL_CLAUSES } from "./index";
+import { getMBQLName, MBQL_CLAUSES, unescapeString } from "./index";
 
 const COMPARISON_OPS = [
   OP.Equal,
@@ -70,7 +70,7 @@ function recursiveParse(source) {
 
   const field = name => {
     const ref = name[0] === "[" ? shrink(name) : name;
-    return ["dimension", ref];
+    return ["dimension", unescapeString(ref)];
   };
 
   // Primary ::= Literal |

--- a/frontend/test/metabase/lib/expressions/recursive-parser.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/recursive-parser.unit.spec.js
@@ -32,10 +32,7 @@ describe("metabase/lib/expressions/recursive-parser", () => {
 
   it("should parse bracketed field references (with escaping)", () => {
     expect(process("[Sale \\[2022\\]]")).toEqual(["dimension", "Sale [2022]"]);
-    expect(process("[\\(2021\\) Discount]")).toEqual([
-      "dimension",
-      "(2021) Discount",
-    ]);
+    expect(process("[Crazy\\test]")).toEqual(["dimension", "Crazy\\test"]);
   });
 
   it("should parse unary expressions", () => {

--- a/frontend/test/metabase/lib/expressions/recursive-parser.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/recursive-parser.unit.spec.js
@@ -30,6 +30,14 @@ describe("metabase/lib/expressions/recursive-parser", () => {
     expect(process("Discount")).toEqual(["dimension", "Discount"]);
   });
 
+  it("should parse bracketed field references (with escaping)", () => {
+    expect(process("[Sale \\[2022\\]]")).toEqual(["dimension", "Sale [2022]"]);
+    expect(process("[\\(2021\\) Discount]")).toEqual([
+      "dimension",
+      "(2021) Discount",
+    ]);
+  });
+
   it("should parse unary expressions", () => {
     expect(process("+6")).toEqual(["+", 6]);
     expect(process("++7")).toEqual(["+", ["+", 7]]);

--- a/frontend/test/metabase/scenarios/custom-column/custom-column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/custom-column/custom-column.cy.spec.js
@@ -492,7 +492,7 @@ describe("scenarios > question > custom column", () => {
     cy.contains("37.65");
   });
 
-  it.skip("should handle brackets in the name of the custom column (metabase#15316)", () => {
+  it("should handle brackets in the name of the custom column (metabase#15316)", () => {
     cy.createQuestion({
       name: "15316",
       query: {
@@ -507,14 +507,14 @@ describe("scenarios > question > custom column", () => {
     popover()
       .findByText("MyCC [2021]")
       .click();
-    cy.get("[class*=NotebookCellItem]")
+    cy.findAllByTestId("notebook-cell-item")
       .contains("Sum of MyCC [2021]")
       .click();
     popover().within(() => {
       cy.icon("chevronleft").click();
       cy.findByText("Custom Expression").click();
     });
-    cy.get("[contenteditable='true']").contains("Sum([MyCC [2021]])");
+    cy.get(".ace_line").contains("Sum([MyCC \\[2021\\]]");
   });
 
   it.skip("should work with `isNull` function (metabase#15922)", () => {


### PR DESCRIPTION
This way, if the field name contains `[` or `]`, this character will be handled properly (with escaping and unescaping at the right place).

**How to verify**

1. New, Question, Sample Database, Product
2. Custom Column, type `[Price] / 2`, name it as `Half [Price]` (note the square brackets)
3. Filter, `Half [Price]`, Greater than, `0`, and press Add Filter
4. Click on the filter, and then the left chevron and then choose Custom Expression  (to convert it)

**Before this PR**

The last step failed, and opening the browser console reveals the following error:

![image](https://user-images.githubusercontent.com/7288/157545220-52a4d989-b47d-4dae-b1bf-24a2da5107bf.png)

**After this PR**

The filter can be correctly converted to a custom expression.

![image](https://user-images.githubusercontent.com/7288/157545461-515ae111-dd78-49ab-b64a-09515b3e4d5d.png)


The query can be completed, previewed, and visualized as expected.

![image](https://user-images.githubusercontent.com/7288/157545624-39a8e16f-e0fa-4216-ba60-7999f9c88696.png)
