### PR TITLE
FE: Download permission users UI

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/constants.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/constants.ts
@@ -32,6 +32,6 @@ export const DOWNLOAD_PERMISSION_OPTIONS = {
 export const DATA_COLUMNS = [
   {
     name: t`Download results`,
-    hint: t`If you grant someone permissions to download data from a database, you won't be able to schema or table level for native queries.`,
+    hint: t`Downloads of native queries are only allowed if a group has download permissions for the entire database.`,
   },
 ];

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/index.ts
@@ -8,6 +8,10 @@ import {
 
 import { getFeatureLevelDataPermissions } from "./permissions";
 import { DATA_COLUMNS } from "./constants";
+import {
+  canDownloadResults,
+  getDownloadWidgetMessageOverride,
+} from "./query-downloads";
 
 if (hasPremiumFeature("advanced_permissions")) {
   PLUGIN_FEATURE_LEVEL_PERMISSIONS.canAccessSettings = canAccessSettings;
@@ -16,4 +20,6 @@ if (hasPremiumFeature("advanced_permissions")) {
 
   PLUGIN_FEATURE_LEVEL_PERMISSIONS.getFeatureLevelDataPermissions = getFeatureLevelDataPermissions;
   PLUGIN_FEATURE_LEVEL_PERMISSIONS.dataColumns = DATA_COLUMNS;
+  PLUGIN_FEATURE_LEVEL_PERMISSIONS.getDownloadWidgetMessageOverride = getDownloadWidgetMessageOverride;
+  PLUGIN_FEATURE_LEVEL_PERMISSIONS.canDownloadResults = canDownloadResults;
 }

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permissions.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permissions.ts
@@ -10,8 +10,8 @@ import {
   getFieldsPermission,
   getSchemasPermission,
   getTablesPermission,
-  isRestrictivePermission,
 } from "metabase/admin/permissions/utils/graph";
+import { PLUGIN_ADVANCED_PERMISSIONS } from "metabase/plugins";
 import { push } from "react-router-redux";
 import {
   DOWNLOAD_PERMISSION_OPTIONS,
@@ -66,12 +66,15 @@ const buildDownloadPermission = (
 ) => {
   const hasChildEntities = permissionSubject !== "fields";
 
-  const value = isRestrictivePermission(dataAccessPermissionValue)
+  const value = PLUGIN_ADVANCED_PERMISSIONS.isBlockPermission(
+    dataAccessPermissionValue,
+  )
     ? DOWNLOAD_PERMISSION_OPTIONS.none.value
     : getPermissionValue(permissions, groupId, entityId, permissionSubject);
 
   const isDisabled =
-    isAdmin || isRestrictivePermission(dataAccessPermissionValue);
+    isAdmin ||
+    PLUGIN_ADVANCED_PERMISSIONS.isBlockPermission(dataAccessPermissionValue);
 
   return {
     permission: "download",

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/query-downloads.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/query-downloads.ts
@@ -1,0 +1,13 @@
+import { t } from "ttag";
+import { Dataset } from "metabase-types/api/dataset";
+
+export const canDownloadResults = (result: Dataset) =>
+  result.data?.download_perms !== "none";
+
+export const getDownloadWidgetMessageOverride = (result: Dataset) => {
+  if (result.data?.download_perms === "limited") {
+    return t`The maximum download size is 10 thousand rows.`;
+  }
+
+  return null;
+};

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/query-downloads.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/query-downloads.ts
@@ -6,7 +6,7 @@ export const canDownloadResults = (result: Dataset) =>
 
 export const getDownloadWidgetMessageOverride = (result: Dataset) => {
   if (result.data?.download_perms === "limited") {
-    return t`The maximum download size is 10 thousand rows.`;
+    return t`You have permission to download up to 10 thousand rows.`;
   }
 
   return null;

--- a/frontend/src/metabase-types/api/dataset.ts
+++ b/frontend/src/metabase-types/api/dataset.ts
@@ -1,0 +1,19 @@
+import { DownloadPermission } from "./permissions";
+
+export interface DatasetColumn {
+  display_name: string;
+  source: string;
+  name: string;
+}
+
+export interface Dataset {
+  data: {
+    rows: any[][];
+    cols: DatasetColumn[];
+    rows_truncated: number;
+    download_perms?: DownloadPermission;
+  };
+  database_id: number;
+  row_count: number;
+  running_time: number;
+}

--- a/frontend/src/metabase-types/api/index.ts
+++ b/frontend/src/metabase-types/api/index.ts
@@ -11,3 +11,4 @@ export * from "./slack";
 export * from "./user";
 export * from "./group";
 export * from "./permissions";
+export * from "./dataset";

--- a/frontend/src/metabase/admin/permissions/components/PermissionsSelect/PermissionsSelect.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsSelect/PermissionsSelect.jsx
@@ -2,6 +2,8 @@ import React, { useState, memo } from "react";
 import PropTypes from "prop-types";
 
 import PopoverWithTrigger from "metabase/components/PopoverWithTrigger";
+import { lighten } from "metabase/lib/colors";
+import Icon from "metabase/components/Icon";
 import Toggle from "metabase/core/components/Toggle";
 import Tooltip from "metabase/components/Tooltip";
 
@@ -73,6 +75,13 @@ export const PermissionsSelect = memo(function PermissionsSelect({
           <WarningIcon />
         </Tooltip>
       )}
+
+      <Icon
+        style={{ visibility: isDisabled ? "hidden" : "visible" }}
+        name="chevrondown"
+        size={16}
+        color={lighten("text-light", 0.15)}
+      />
     </PermissionsSelectRoot>
   );
 

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -10,6 +10,7 @@ import {
   Bookmark,
   GroupsPermissions,
   User,
+  Dataset,
 } from "metabase-types/api";
 import { State } from "metabase-types/store";
 
@@ -139,6 +140,8 @@ export const PLUGIN_FEATURE_LEVEL_PERMISSIONS = {
     return [] as any;
   },
   dataColumns: [] as any,
+  getDownloadWidgetMessageOverride: (_result: Dataset): string | null => null,
+  canDownloadResults: (_result: Dataset): boolean => true,
 };
 
 export const PLUGIN_GENERAL_PERMISSIONS = {

--- a/frontend/src/metabase/public/containers/PublicQuestion.jsx
+++ b/frontend/src/metabase/public/containers/PublicQuestion.jsx
@@ -3,7 +3,6 @@ import React, { Component } from "react";
 import { connect } from "react-redux";
 
 import Visualization from "metabase/visualizations/components/Visualization";
-import QueryDownloadWidget from "metabase/query_builder/components/QueryDownloadWidget";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 import ExplicitSize from "metabase/components/ExplicitSize";
 import EmbedFrame from "../components/EmbedFrame";
@@ -173,20 +172,8 @@ export default class PublicQuestion extends Component {
   };
 
   render() {
-    const {
-      params: { uuid, token },
-      metadata,
-    } = this.props;
+    const { metadata } = this.props;
     const { card, result, initialized, parameterValues } = this.state;
-
-    const actionButtons = result && (
-      <QueryDownloadWidget
-        className="m1 text-medium-hover"
-        uuid={uuid}
-        token={token}
-        result={result}
-      />
-    );
 
     const parameters =
       card && getValueAndFieldIdPopulatedParametersFromCard(card, metadata);
@@ -196,7 +183,6 @@ export default class PublicQuestion extends Component {
         name={card && card.name}
         description={card && card.description}
         parameters={initialized ? parameters : []}
-        actionButtons={actionButtons}
         parameterValues={parameterValues}
         setParameterValue={this.setParameterValue}
       >

--- a/frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx
@@ -11,6 +11,7 @@ import Icon from "metabase/components/Icon";
 import LoadingSpinner from "metabase/components/LoadingSpinner";
 import DownloadButton from "metabase/components/DownloadButton";
 import Tooltip from "metabase/components/Tooltip";
+import { PLUGIN_FEATURE_LEVEL_PERMISSIONS } from "metabase/plugins";
 
 import * as Urls from "metabase/lib/urls";
 
@@ -24,6 +25,10 @@ import {
 } from "./QueryDownloadWidget.styled";
 
 const EXPORT_FORMATS = Urls.exportFormats;
+
+const getLimitedDownloadSizeText = result =>
+  PLUGIN_FEATURE_LEVEL_PERMISSIONS.getDownloadWidgetMessageOverride(result) ??
+  t`The maximum download size is 1 million rows.`;
 
 const QueryDownloadWidget = ({
   className,
@@ -56,7 +61,7 @@ const QueryDownloadWidget = ({
           {result.data != null && result.data.rows_truncated != null && (
             <WidgetMessage>
               <p>{t`Your answer has a large number of rows so it could take a while to download.`}</p>
-              <p>{t`The maximum download size is 1 million rows.`}</p>
+              <p>{getLimitedDownloadSizeText(result)}</p>
             </WidgetMessage>
           )}
           <div>
@@ -288,6 +293,9 @@ QueryDownloadWidget.defaultProps = {
 };
 
 QueryDownloadWidget.shouldRender = ({ result, isResultDirty }) =>
-  !isResultDirty && result && !result.error;
+  !isResultDirty &&
+  result &&
+  !result.error &&
+  PLUGIN_FEATURE_LEVEL_PERMISSIONS.canDownloadResults(result);
 
 export default QueryDownloadWidget;

--- a/frontend/test/metabase/scenarios/permissions/download-permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/download-permissions.cy.spec.js
@@ -5,7 +5,9 @@ import {
   assertPermissionTable,
   modifyPermission,
   isPermissionDisabled,
+  downloadAndAssert,
 } from "__support__/e2e/cypress";
+const xlsx = require("xlsx");
 
 const DATA_ACCESS_PERMISSION_INDEX = 0;
 const DOWNLOAD_PERMISSION_INDEX = 2;
@@ -129,4 +131,39 @@ describeEE("scenarios > admin > permissions", () => {
       ["readonly", "No self-service", "No", "No"],
     ]);
   });
+
+  it.skip("restricts users from downloading questions", () => {
+    cy.signInAsNormalUser();
+    cy.visit("/question/1");
+
+    cy.findByText("Showing first 2,000 rows");
+    cy.icon("download").should("not.exist");
+  });
+
+  it.skip("restricts users from downloading questions", () => {
+    cy.visit("/admin/permissions/data/database/1");
+    const groupName = "data";
+
+    modifyPermission(groupName, DOWNLOAD_PERMISSION_INDEX, "10 thousand rows");
+
+    cy.button("Save changes").click();
+
+    modal().within(() => {
+      cy.findByText("Save permissions?");
+      cy.findByText("Are you sure you want to do this?");
+      cy.button("Yes").click();
+    });
+
+    cy.signInAsNormalUser();
+    cy.visit("/question/1");
+
+    cy.icon("download").click();
+
+    downloadAndAssert({ fileType: "xlsx" }, assertion);
+  });
 });
+
+function assertion(sheet) {
+  const range = xlsx.utils.decode_range(sheet["!ref"]);
+  expect(range.e.r).to.eq(10001);
+}

--- a/frontend/test/metabase/scenarios/permissions/download-permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/download-permissions.cy.spec.js
@@ -4,7 +4,6 @@ import {
   describeEE,
   assertPermissionTable,
   modifyPermission,
-  isPermissionDisabled,
   downloadAndAssert,
 } from "__support__/e2e/cypress";
 const xlsx = require("xlsx");
@@ -20,14 +19,6 @@ describeEE("scenarios > admin > permissions", () => {
 
   it("allows changing download results permission for a database", () => {
     cy.visit("/admin/permissions/data/database/1");
-
-    // Download permission is disabled when there is no data access
-    cy.findByText("All Users")
-      .closest("tr")
-      .as("allUsersRow")
-      .within(() => {
-        isPermissionDisabled(DOWNLOAD_PERMISSION_INDEX, "No", true);
-      });
 
     modifyPermission("All Users", DATA_ACCESS_PERMISSION_INDEX, "Unrestricted");
 
@@ -51,14 +42,6 @@ describeEE("scenarios > admin > permissions", () => {
 
   it("allows changing download results permission for a table", () => {
     cy.visit("/admin/permissions/data/database/1/table/1");
-
-    // Download permission is disabled when there is no data access
-    cy.findByText("All Users")
-      .closest("tr")
-      .as("allUsersRow")
-      .within(() => {
-        isPermissionDisabled(DOWNLOAD_PERMISSION_INDEX, "No", true);
-      });
 
     modifyPermission("All Users", DATA_ACCESS_PERMISSION_INDEX, "Unrestricted");
 


### PR DESCRIPTION
[Product doc](https://www.notion.so/metabase/Add-feature-level-permissions-to-groups-8027685681774932ac7221131f061295)
Epic: https://github.com/metabase/metabase/issues/20380

## Changes
Update download results UI for users that use Metabase EE.

## How to verify

### Setup
- Checkout this branch and then merge https://github.com/metabase/metabase/pull/21021 into it
- Run Metabase EE
- Create a "Test Group" and a "Test User"
- Go to [data permissions](http://localhost:3000/admin/permissions/data/group/1) and set Download Results permission to "No" for "All Users"

### Database level download permission
- As an admin create a structured question through New -> Question form raw Orders table
- Change "Sample database" download permission for Test Group to No
    - Ensure "Test User" cannot download results because there is no download button
- Change "Sample database" download permission for Test Group to 10k
    - Ensure "Test User" can download results, but the download popup mention the 10k rows limitation and the results file contains only 10k rows
- Change "Sample database" download permission for Test Group to 1m
    - Ensure "Test User" can download results, the download popup mention the 1m rows limitation and the results file contains all ~18k rows from the Orders table
  
- Check that the steps above are valid for an unsaved structured question
- Check that the steps above are valid for a native question
- Check similarly structured queries when limiting certain tables granularly

### Native queries
- As an admin create a native question `select * from orders`
- Change only Products table download permission for Test Group to No
    - Ensure "Test User" cannot download results. Even though we limited download permission to only the Products table, without native query introspection we cannot guarantee that a SQL created by a user does not read the Products table.
- Change only Products table download permission for Test Group to 10k while all other tables to 1m
    - Ensure "Test User" can download only 10k results. In order to guarantee that users won't download more than 10k rows of the Products table from native questions, we have to limit downloads for all native queries that use the database to 10k
     