### PR TITLE
Cleanup and schema for bookmarks

### DIFF
--- a/src/metabase/api/bookmark.clj
+++ b/src/metabase/api/bookmark.clj
@@ -28,6 +28,8 @@
 (api/defendpoint GET "/"
   "Fetch all bookmarks for the user"
   []
+  ;; already sorted by created_at in query. Can optionally use user sort preferences here and not in the function
+  ;; below
   (bookmarks/bookmarks-for-user api/*current-user-id*))
 
 (api/defendpoint POST "/:model/:id"

--- a/src/metabase/models/bookmark.clj
+++ b/src/metabase/models/bookmark.clj
@@ -1,7 +1,12 @@
 (ns metabase.models.bookmark
   (:require [clojure.string :as str]
             [metabase.db.connection :as mdb]
+            [metabase.models.card :refer [Card]]
+            [metabase.models.collection :refer [Collection]]
+            [metabase.models.dashboard :refer [Dashboard]]
             [metabase.util.honeysql-extensions :as hx]
+            [metabase.util.schema :as su]
+            [schema.core :as s]
             [toucan.db :as db]
             [toucan.models :as models]))
 
@@ -9,33 +14,40 @@
 (models/defmodel DashboardBookmark :dashboard_bookmark)
 (models/defmodel CollectionBookmark :collection_bookmark)
 
-(defn- remove-nil-values [m]
-  (into {} (remove (comp nil? second) m)))
-
 (defn- unqualify-key
   [k]
-  (-> k
-      name
-      (str/split #"\.")
-      last
-      keyword))
+  (-> (str/split (name k) #"\.") peek keyword))
 
-(defn- normalize-bookmark-result
+(def BookmarkResult
+  "Shape of a bookmark returned for user. Id is a string because it is a concatenation of the model and the model's
+  id. This is required for the frontend entity loading system and does not refer to any particular bookmark id,
+  although the compound key can be inferred from it."
+  {:id                           s/Str
+   :type                         (s/enum :card :collection :dashboard)
+   :item_id                      su/IntGreaterThanZero
+   :name                         su/NonBlankString
+   (s/optional-key :description) (s/maybe s/Str)})
+
+(s/defn ^:private normalize-bookmark-result :- BookmarkResult
+  "Normalizes bookmark results. Bookmarks are left joined against the card, collection, and dashboard tables, but only
+  points to one of them. Normalizes it so it has an id (concatenation of model and model-id), type, item_id, name, and
+  description."
   [result]
-  (let [lookup {"report_card" "card" "report_dashboard" "dashboard" "collection" "collection"}
-        ttype (-> (keys result)
-                  first
-                  name
-                  (str/split #"\.")
-                  first
-                  lookup
-                  keyword)
+  (let [result            (into {} (remove (comp nil? second) result))
+        lookup            {"report_card" "card" "report_dashboard" "dashboard" "collection" "collection"}
+        ttype             (-> (keys result)
+                              first
+                              name
+                              (str/split #"\.")
+                              first
+                              lookup
+                              keyword)
         normalized-result (zipmap (map unqualify-key (keys result)) (vals result))
-        item-id-str (str (:item_id normalized-result))]
-    (-> normalized-result
-        (assoc :type ttype)
-        (assoc :id (str (name ttype) "-" item-id-str))
-        (dissoc :created_at))))
+        item-id-str       (str (:item_id normalized-result))]
+    (merge
+     {:id      (str (name ttype) "-" item-id-str)
+      :type    ttype}
+     (select-keys normalized-result [:item_id :name :description]))))
 
 (defn- bookmarks-union-query
   [id]
@@ -45,25 +57,26 @@
                            [as-null :collection_id]
                            :id
                            :created_at]
-                  :from   [:card_bookmark]
+                  :from   [CardBookmark]
                   :where  [:= :user_id id]}
                  {:select [[as-null :card_id]
                            :dashboard_id
                            [as-null :collection_id]
                            :id
                            :created_at]
-                  :from   [:dashboard_bookmark]
+                  :from   [DashboardBookmark]
                   :where  [:= :user_id id]}
                  {:select [[as-null :card_id]
                            [as-null :dashboard_id]
                            :collection_id
                            :id
                            :created_at]
-                  :from   [:collection_bookmark]
+                  :from   [CollectionBookmark]
                   :where  [:= :user_id id]}]}))
 
-(defn bookmarks-for-user
-  "Get all bookmarks for a user"
+(s/defn bookmarks-for-user :- [BookmarkResult]
+  "Get all bookmarks for a user. Each bookmark will have a string id made of the model and model-id, a type, and
+  item_id, name, and description from the underlying bookmarked item."
   [id]
   (->> (db/query
         {:select    [[:bookmark.created_at :created_at]
@@ -80,10 +93,12 @@
                      [:collection.description (db/qualify 'Collection :description)]
                      [:collection.archived (db/qualify 'Collection :archived)]]
          :from      [[(bookmarks-union-query id) :bookmark]]
-         :left-join [[:report_card :card] [:= :bookmark.card_id :card.id]
-                     [:report_dashboard :dashboard] [:= :bookmark.dashboard_id :dashboard.id]
-                     :collection [:= :bookmark.collection_id :collection.id]]})
-       (map remove-nil-values)
-       (sort-by :created_at)
-       (map normalize-bookmark-result)
-       (remove :archived)))
+         :left-join [[Card :card] [:= :bookmark.card_id :card.id]
+                     [Dashboard :dashboard] [:= :bookmark.dashboard_id :dashboard.id]
+                     [Collection :collection] [:= :bookmark.collection_id :collection.id]]
+         :where     (into [:and]
+                          (for [table [:card :dashboard :collection]
+                                :let [field (keyword (str (name table) "." "archived"))]]
+                            [:or [:= field false] [:= field nil]]))
+         :order-by [[:created_at :desc]]})
+       (map normalize-bookmark-result)))


### PR DESCRIPTION
- sorting in query so don't have to sort in memory afterwards, and
leaves open spot on the api to sort with user preferences if
present (future work)
- adds schema so we know what these bookmarks look like, and return an
explicit structure instead of threading through dissoc and assoc
- combined the remove-nil-values into the normalize function since it
set up preconditions necessary for the normalize.
- use Models in query so we don't have to hardcode the underlying table
