### PR TITLE
Try to load bookmarks into DashboardApp

### DIFF
--- a/frontend/src/metabase/dashboard/containers/DashboardApp.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp.jsx
@@ -6,6 +6,7 @@ import fitViewport from "metabase/hoc/FitViewPort";
 import title from "metabase/hoc/Title";
 import titleWithLoadingTime from "metabase/hoc/TitleWithLoadingTime";
 
+import Bookmark from "metabase/entities/bookmarks";
 import Dashboard from "metabase/dashboard/components/Dashboard/Dashboard";
 
 import { fetchDatabaseMetadata } from "metabase/redux/metadata";
@@ -72,6 +73,7 @@ const mapDispatchToProps = {
   onChangeLocation: push,
 };
 
+@Bookmark.loadList()
 @connect(mapStateToProps, mapDispatchToProps)
 @fitViewport
 @title(({ dashboard }) => dashboard && dashboard.name)


### PR DESCRIPTION
At this point, this PR is to get help from people

## How to Check

Visit a dashboard page

### Current outcome

The page freezes.

In dev console you see a warning in infinite loop.

### Desired outcome

Load list of Bookmarks and inject into props of `frontend/src/metabase/dashboard/containers/DashboardApp.jsx`