### PR TITLE
Custom expression: stricter acceptance of aggregation function

### DIFF
--- a/frontend/src/metabase/lib/expressions/resolver.js
+++ b/frontend/src/metabase/lib/expressions/resolver.js
@@ -48,9 +48,6 @@ const isCompatible = (a, b) => {
   if (a === "aggregation" && b === "number") {
     return true;
   }
-  if (a === "number" && b === "aggregation") {
-    return true;
-  }
   return false;
 };
 

--- a/frontend/test/metabase/lib/expressions/recursive-parser.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/recursive-parser.unit.spec.js
@@ -5,6 +5,7 @@ describe("metabase/lib/expressions/recursive-parser", () => {
   const mockResolve = (kind, name) => [kind, name];
   const process = (source, type) => resolve(parse(source), type, mockResolve);
   const filter = expr => process(expr, "boolean");
+  const aggregation = expr => process(expr, "aggregation");
 
   // handy references
   const X = ["segment", "X"];
@@ -150,8 +151,8 @@ describe("metabase/lib/expressions/recursive-parser", () => {
   });
 
   it("should detect aggregation functions with no argument", () => {
-    expect(process("COUNT/2")).toEqual(["/", ["count"], 2]);
-    expect(process("1+CumulativeCount")).toEqual(["+", 1, ["cum-count"]]);
+    expect(aggregation("COUNT/2")).toEqual(["/", ["count"], 2]);
+    expect(aggregation("1+CumulativeCount")).toEqual(["+", 1, ["cum-count"]]);
   });
 
   it("should resolve segments", () => {


### PR DESCRIPTION
How to verify:

1. New, Question, Sample Database, Products
2. Custom Column, type `Count / 3`

**Before this PR**

The expression for that custom column is incorrectly accepted, leading to a mysterious error:

![image](https://user-images.githubusercontent.com/7288/157766097-708d41a4-cd5c-4a69-9781-7fa7c0e30dce.png)


**After this PR**

That custom expression is rejected because it is not valid.

![image](https://user-images.githubusercontent.com/7288/157765839-0fa628c5-fabc-4855-b0fd-7d855e387a1c.png)

