### PR TITLE
FE: Data model permission

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/constants.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/constants.ts
@@ -1,37 +1,11 @@
 import { t } from "ttag";
 
-export const DOWNLOAD_PERMISSION_REQUIRES_DATA_ACCESS = t`Download results access requires full data access.`;
-
-export const DOWNLOAD_PERMISSION_OPTIONS = {
-  none: {
-    label: t`No`,
-    value: "none",
-    icon: "close",
-    iconColor: "danger",
-  },
-  limited: {
-    label: t`10 thousand rows`,
-    value: "limited",
-    icon: "10k",
-    iconColor: "accent7",
-  },
-  full: {
-    label: t`1 million rows`,
-    value: "full",
-    icon: "1m",
-    iconColor: "accent7",
-  },
-  controlled: {
-    label: t`Granular`,
-    value: "controlled",
-    icon: "permissions_limited",
-    iconColor: "warning",
-  },
-};
-
 export const DATA_COLUMNS = [
   {
     name: t`Download results`,
     hint: t`Downloads of native queries are only allowed if a group has download permissions for the entire database.`,
+  },
+  {
+    name: t`Manage data model`,
   },
 ];

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/index.ts
@@ -2,7 +2,7 @@ import { hasPremiumFeature } from "metabase-enterprise/settings";
 import { PLUGIN_FEATURE_LEVEL_PERMISSIONS } from "metabase/plugins";
 import { canAccessDataModel, canAccessDatabaseManagement } from "./utils";
 
-import { getFeatureLevelDataPermissions } from "./permissions";
+import { getFeatureLevelDataPermissions } from "./permission-management";
 import { DATA_COLUMNS } from "./constants";
 import {
   canDownloadResults,

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/index.ts
@@ -18,4 +18,12 @@ if (hasPremiumFeature("advanced_permissions")) {
   PLUGIN_FEATURE_LEVEL_PERMISSIONS.dataColumns = DATA_COLUMNS;
   PLUGIN_FEATURE_LEVEL_PERMISSIONS.getDownloadWidgetMessageOverride = getDownloadWidgetMessageOverride;
   PLUGIN_FEATURE_LEVEL_PERMISSIONS.canDownloadResults = canDownloadResults;
+
+  PLUGIN_FEATURE_LEVEL_PERMISSIONS.tableMetadataQueryProps = {
+    exclude_uneditable: true,
+  };
+
+  PLUGIN_FEATURE_LEVEL_PERMISSIONS.databaseQueryProps = {
+    exclude_uneditable: true,
+  };
 }

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/data-model-permission.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/data-model-permission.ts
@@ -1,0 +1,119 @@
+import { push } from "react-router-redux";
+import { GroupsPermissions } from "metabase-types/api";
+import { UNABLE_TO_CHANGE_ADMIN_PERMISSIONS } from "metabase/admin/permissions/constants/messages";
+import {
+  EntityId,
+  PermissionSubject,
+  SchemaEntityId,
+  TableEntityId,
+} from "metabase/admin/permissions/types";
+import {
+  getFieldsPermission,
+  getSchemasPermission,
+  getTablesPermission,
+  isRestrictivePermission,
+} from "metabase/admin/permissions/utils/graph";
+import { t } from "ttag";
+
+export const DATA_MODEL_PERMISSION_REQUIRES_DATA_ACCESS = t`Data model access requires full data access.`;
+
+export const DATA_MODEL_PERMISSION_OPTIONS = {
+  none: {
+    label: t`No`,
+    value: "none",
+    icon: "close",
+    iconColor: "danger",
+  },
+  edit: {
+    label: t`Edit`,
+    value: "all",
+    icon: "pencil",
+    iconColor: "accent7",
+  },
+  controlled: {
+    label: t`Granular`,
+    value: "controlled",
+    icon: "permissions_limited",
+    iconColor: "warning",
+  },
+};
+
+const buildControlledActionUrl = (
+  entityId: EntityId,
+  groupId: number,
+  permissionSubject: PermissionSubject,
+) => {
+  if (permissionSubject === "schemas") {
+    return `/admin/permissions/data/group/${groupId}/database/${entityId.databaseId}`;
+  }
+
+  return `/admin/permissions/data/group/${groupId}/database/${entityId.databaseId}/schema/${entityId.schemaName}`;
+};
+
+const getPermissionValue = (
+  permissions: GroupsPermissions,
+  groupId: number,
+  entityId: EntityId,
+  permissionSubject: PermissionSubject,
+) => {
+  switch (permissionSubject) {
+    case "fields":
+      return getFieldsPermission(
+        permissions,
+        groupId,
+        entityId as TableEntityId,
+        "data-model",
+      );
+    case "tables":
+      return getTablesPermission(
+        permissions,
+        groupId,
+        entityId as SchemaEntityId,
+        "data-model",
+      );
+    default:
+      return getSchemasPermission(permissions, groupId, entityId, "data-model");
+  }
+};
+
+export const buildDataModelPermission = (
+  entityId: EntityId,
+  groupId: number,
+  isAdmin: boolean,
+  permissions: GroupsPermissions,
+  dataAccessPermissionValue: string,
+  permissionSubject: PermissionSubject,
+) => {
+  const hasChildEntities = permissionSubject !== "fields";
+
+  const value = isRestrictivePermission(dataAccessPermissionValue)
+    ? DATA_MODEL_PERMISSION_OPTIONS.none.value
+    : getPermissionValue(permissions, groupId, entityId, permissionSubject);
+
+  const isDisabled =
+    isAdmin || isRestrictivePermission(dataAccessPermissionValue);
+
+  return {
+    permission: "data-model",
+    type: "data-model",
+    isDisabled,
+    disabledTooltip: isAdmin
+      ? UNABLE_TO_CHANGE_ADMIN_PERMISSIONS
+      : DATA_MODEL_PERMISSION_REQUIRES_DATA_ACCESS,
+    isHighlighted: isAdmin,
+    value,
+    options: [
+      DATA_MODEL_PERMISSION_OPTIONS.none,
+      ...(hasChildEntities ? [DATA_MODEL_PERMISSION_OPTIONS.controlled] : []),
+      DATA_MODEL_PERMISSION_OPTIONS.edit,
+    ],
+    postActions: hasChildEntities
+      ? {
+          controlled: () =>
+            push(
+              buildControlledActionUrl(entityId, groupId, permissionSubject),
+            ),
+        }
+      : undefined,
+  };
+};

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/data-model-permission.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/data-model-permission.ts
@@ -11,7 +11,6 @@ import {
   getFieldsPermission,
   getSchemasPermission,
   getTablesPermission,
-  isRestrictivePermission,
 } from "metabase/admin/permissions/utils/graph";
 import { t } from "ttag";
 
@@ -81,22 +80,21 @@ export const buildDataModelPermission = (
   groupId: number,
   isAdmin: boolean,
   permissions: GroupsPermissions,
-  dataAccessPermissionValue: string,
   permissionSubject: PermissionSubject,
 ) => {
   const hasChildEntities = permissionSubject !== "fields";
 
-  const value = isRestrictivePermission(dataAccessPermissionValue)
-    ? DATA_MODEL_PERMISSION_OPTIONS.none.value
-    : getPermissionValue(permissions, groupId, entityId, permissionSubject);
-
-  const isDisabled =
-    isAdmin || isRestrictivePermission(dataAccessPermissionValue);
+  const value = getPermissionValue(
+    permissions,
+    groupId,
+    entityId,
+    permissionSubject,
+  );
 
   return {
     permission: "data-model",
     type: "data-model",
-    isDisabled,
+    isDisabled: isAdmin,
     disabledTooltip: isAdmin
       ? UNABLE_TO_CHANGE_ADMIN_PERMISSIONS
       : DATA_MODEL_PERMISSION_REQUIRES_DATA_ACCESS,

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/download-permission.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/download-permission.ts
@@ -1,4 +1,5 @@
 import { push } from "react-router-redux";
+import { t } from "ttag";
 import { GroupsPermissions } from "metabase-types/api";
 import { UNABLE_TO_CHANGE_ADMIN_PERMISSIONS } from "metabase/admin/permissions/constants/messages";
 import {
@@ -12,7 +13,7 @@ import {
   getSchemasPermission,
   getTablesPermission,
 } from "metabase/admin/permissions/utils/graph";
-import { t } from "ttag";
+import { PLUGIN_ADVANCED_PERMISSIONS } from "metabase/plugins";
 
 export const DOWNLOAD_PERMISSION_REQUIRES_DATA_ACCESS = t`Download results access requires full data access.`;
 

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/download-permission.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/download-permission.ts
@@ -1,3 +1,4 @@
+import { push } from "react-router-redux";
 import { GroupsPermissions } from "metabase-types/api";
 import { UNABLE_TO_CHANGE_ADMIN_PERMISSIONS } from "metabase/admin/permissions/constants/messages";
 import {
@@ -11,12 +12,36 @@ import {
   getSchemasPermission,
   getTablesPermission,
 } from "metabase/admin/permissions/utils/graph";
-import { PLUGIN_ADVANCED_PERMISSIONS } from "metabase/plugins";
-import { push } from "react-router-redux";
-import {
-  DOWNLOAD_PERMISSION_OPTIONS,
-  DOWNLOAD_PERMISSION_REQUIRES_DATA_ACCESS,
-} from "./constants";
+import { t } from "ttag";
+
+export const DOWNLOAD_PERMISSION_REQUIRES_DATA_ACCESS = t`Download results access requires full data access.`;
+
+export const DOWNLOAD_PERMISSION_OPTIONS = {
+  none: {
+    label: t`No`,
+    value: "none",
+    icon: "close",
+    iconColor: "danger",
+  },
+  limited: {
+    label: t`10 thousand rows`,
+    value: "limited",
+    icon: "10k",
+    iconColor: "accent7",
+  },
+  full: {
+    label: t`1 million rows`,
+    value: "full",
+    icon: "1m",
+    iconColor: "accent7",
+  },
+  controlled: {
+    label: t`Granular`,
+    value: "controlled",
+    icon: "permissions_limited",
+    iconColor: "warning",
+  },
+};
 
 const buildControlledActionUrl = (
   entityId: EntityId,
@@ -56,7 +81,7 @@ const getPermissionValue = (
   }
 };
 
-const buildDownloadPermission = (
+export const buildDownloadPermission = (
   entityId: EntityId,
   groupId: number,
   isAdmin: boolean,
@@ -100,23 +125,4 @@ const buildDownloadPermission = (
         }
       : undefined,
   };
-};
-
-export const getFeatureLevelDataPermissions = (
-  entityId: EntityId,
-  groupId: number,
-  isAdmin: boolean,
-  permissions: GroupsPermissions,
-  dataAccessPermissionValue: string,
-  permissionSubject: PermissionSubject,
-) => {
-  const downloadPermission = buildDownloadPermission(
-    entityId,
-    groupId,
-    isAdmin,
-    permissions,
-    dataAccessPermissionValue,
-    permissionSubject,
-  );
-  return [downloadPermission];
 };

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/index.ts
@@ -1,0 +1,33 @@
+import { GroupsPermissions } from "metabase-types/api";
+import { EntityId, PermissionSubject } from "metabase/admin/permissions/types";
+import { buildDataModelPermission } from "./data-model-permission";
+import { buildDownloadPermission } from "./download-permission";
+
+export const getFeatureLevelDataPermissions = (
+  entityId: EntityId,
+  groupId: number,
+  isAdmin: boolean,
+  permissions: GroupsPermissions,
+  dataAccessPermissionValue: string,
+  permissionSubject: PermissionSubject,
+) => {
+  const downloadPermission = buildDownloadPermission(
+    entityId,
+    groupId,
+    isAdmin,
+    permissions,
+    dataAccessPermissionValue,
+    permissionSubject,
+  );
+
+  const dataModelPermission = buildDataModelPermission(
+    entityId,
+    groupId,
+    isAdmin,
+    permissions,
+    dataAccessPermissionValue,
+    permissionSubject,
+  );
+
+  return [downloadPermission, dataModelPermission];
+};

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/index.ts
@@ -25,7 +25,6 @@ export const getFeatureLevelDataPermissions = (
     groupId,
     isAdmin,
     permissions,
-    dataAccessPermissionValue,
     permissionSubject,
   );
 

--- a/frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx
@@ -10,9 +10,14 @@ import { DatabaseDataSelector } from "metabase/query_builder/components/DataSele
 import SaveStatus from "metabase/components/SaveStatus";
 import Toggle from "metabase/core/components/Toggle";
 import Icon from "metabase/components/Icon";
+import { PLUGIN_FEATURE_LEVEL_PERMISSIONS } from "metabase/plugins";
 
 @withRouter
-@Databases.loadList()
+@Databases.loadList({
+  query: () => ({
+    ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.databaseQueryProps,
+  }),
+})
 export default class MetadataHeader extends Component {
   static propTypes = {
     databaseId: PropTypes.number,
@@ -63,6 +68,7 @@ export default class MetadataHeader extends Component {
         />
         <div className="MetadataEditor-headerSection h2">
           <DatabaseDataSelector
+            databases={this.props.databases ?? []}
             selectedDatabaseId={this.props.databaseId}
             setDatabaseFn={id => this.props.selectDatabase({ id })}
             style={{ padding: 0, paddingLeft: 8 }}

--- a/frontend/src/metabase/admin/datamodel/components/database/MetadataTablePicker.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/MetadataTablePicker.jsx
@@ -4,15 +4,16 @@ import PropTypes from "prop-types";
 import _ from "underscore";
 import Tables from "metabase/entities/tables";
 import { isSyncInProgress } from "metabase/lib/syncing";
+import { PLUGIN_FEATURE_LEVEL_PERMISSIONS } from "metabase/plugins";
 import MetadataTableList from "./MetadataTableList";
 import MetadataSchemaList from "./MetadataSchemaList";
 
 const RELOAD_INTERVAL = 2000;
-
 @Tables.loadList({
   query: (state, { databaseId }) => ({
     dbId: databaseId,
     include_hidden: true,
+    ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.tableMetadataQueryProps,
   }),
   reloadInterval: (state, props, tables = []) => {
     return tables.some(t => isSyncInProgress(t)) ? RELOAD_INTERVAL : 0;

--- a/frontend/src/metabase/admin/datamodel/containers/DataModelApp/DataModelApp.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/DataModelApp/DataModelApp.jsx
@@ -7,6 +7,7 @@ import { t } from "ttag";
 import { useToggle } from "metabase/hooks/use-toggle";
 
 import Radio from "metabase/core/components/Radio";
+import { getUserIsAdmin } from "metabase/selectors/user";
 
 import { ModelEducationalModal } from "./ModelEducationalModal";
 import { NavBar, ModelEducationButton } from "./DataModelApp.styled";
@@ -17,7 +18,12 @@ const propTypes = {
     pathname: PropTypes.string.isRequired,
   }).isRequired,
   children: PropTypes.node.isRequired,
+  isAdmin: PropTypes.bool,
 };
+
+const mapStateToProps = state => ({
+  isAdmin: getUserIsAdmin(state),
+});
 
 const mapDispatchToProps = {
   onChangeTab: tab => push(`/admin/datamodel/${tab}`),
@@ -29,7 +35,12 @@ const TAB = {
   DATABASE: "database",
 };
 
-function DataModelApp({ children, onChangeTab, location: { pathname } }) {
+function DataModelApp({
+  children,
+  onChangeTab,
+  location: { pathname },
+  isAdmin,
+}) {
   const [
     isModelEducationalModalShown,
     { turnOn: showModelEducationalModal, turnOff: hideModelEducationalModal },
@@ -45,16 +56,22 @@ function DataModelApp({ children, onChangeTab, location: { pathname } }) {
     return TAB.DATABASE;
   }, [pathname]);
 
+  const options = [
+    { name: t`Data`, value: TAB.DATABASE },
+    ...(isAdmin
+      ? [
+          { name: t`Segments`, value: TAB.SEGMENTS },
+          { name: t`Metrics`, value: TAB.METRICS },
+        ]
+      : []),
+  ];
+
   return (
     <React.Fragment>
       <NavBar>
         <Radio
           value={currentTab}
-          options={[
-            { name: t`Data`, value: TAB.DATABASE },
-            { name: t`Segments`, value: TAB.SEGMENTS },
-            { name: t`Metrics`, value: TAB.METRICS },
-          ]}
+          options={options}
           onChange={onChangeTab}
           variant="underlined"
         />
@@ -73,4 +90,4 @@ function DataModelApp({ children, onChangeTab, location: { pathname } }) {
 
 DataModelApp.propTypes = propTypes;
 
-export default connect(null, mapDispatchToProps)(DataModelApp);
+export default connect(mapStateToProps, mapDispatchToProps)(DataModelApp);

--- a/frontend/src/metabase/admin/permissions/permissions.js
+++ b/frontend/src/metabase/admin/permissions/permissions.js
@@ -229,6 +229,8 @@ const dataPermissions = handleActions(
           );
         }
 
+        const shouldDowngradeNative = permissionInfo.type === "access";
+
         if (entityId.tableId != null) {
           const updatedPermissions = updateFieldsPermission(
             state,
@@ -237,6 +239,7 @@ const dataPermissions = handleActions(
             value,
             database,
             permissionInfo.permission,
+            shouldDowngradeNative,
           );
           return inferAndUpdateEntityPermissions(
             updatedPermissions,
@@ -244,6 +247,7 @@ const dataPermissions = handleActions(
             entityId,
             database,
             permissionInfo.permission,
+            shouldDowngradeNative,
           );
         } else if (entityId.schemaName != null) {
           return updateTablesPermission(
@@ -253,6 +257,7 @@ const dataPermissions = handleActions(
             value,
             database,
             permissionInfo.permission,
+            shouldDowngradeNative,
           );
         } else {
           return updateSchemasPermission(
@@ -262,6 +267,7 @@ const dataPermissions = handleActions(
             value,
             database,
             permissionInfo.permission,
+            shouldDowngradeNative,
           );
         }
       },

--- a/frontend/src/metabase/admin/permissions/types.ts
+++ b/frontend/src/metabase/admin/permissions/types.ts
@@ -37,6 +37,6 @@ export type TableEntityId = SchemaEntityId & {
 export type EntityId = DatabaseEntityId &
   Partial<Omit<TableEntityId, "databaseId">>;
 
-export type DataPermission = "data" | "download";
+export type DataPermission = "data" | "download" | "data-model";
 
 export type PermissionSubject = "schemas" | "tables" | "fields";

--- a/frontend/src/metabase/admin/permissions/utils/graph/data-permissions.ts
+++ b/frontend/src/metabase/admin/permissions/utils/graph/data-permissions.ts
@@ -251,6 +251,7 @@ export function inferAndUpdateEntityPermissions(
   entityId: EntityId,
   database: Database,
   permission: DataPermission,
+  downgradeNative?: boolean,
 ) {
   const { databaseId } = entityId;
   const schemaName = (entityId as SchemaEntityId).schemaName ?? "";
@@ -271,6 +272,7 @@ export function inferAndUpdateEntityPermissions(
       tablesPermissionValue,
       database,
       permission,
+      downgradeNative,
     );
   }
 
@@ -290,15 +292,19 @@ export function inferAndUpdateEntityPermissions(
       schemasPermissionValue,
       database,
       permission,
+      downgradeNative,
     );
-    permissions = downgradeNativePermissionsIfNeeded(
-      permissions,
-      groupId,
-      { databaseId },
-      schemasPermissionValue,
-      database,
-      permission,
-    );
+
+    if (downgradeNative) {
+      permissions = downgradeNativePermissionsIfNeeded(
+        permissions,
+        groupId,
+        { databaseId },
+        schemasPermissionValue,
+        database,
+        permission,
+      );
+    }
   }
 
   return permissions;
@@ -311,6 +317,7 @@ export function updateFieldsPermission(
   value: any,
   database: Database,
   permission: DataPermission,
+  downgradeNative?: boolean,
 ) {
   const { databaseId, tableId } = entityId;
   const schemaName = entityId.schemaName || "";
@@ -322,6 +329,7 @@ export function updateFieldsPermission(
     "controlled",
     database,
     permission,
+    downgradeNative,
   );
   permissions = updatePermission(
     permissions,
@@ -342,6 +350,7 @@ export function updateTablesPermission(
   value: any,
   database: Database,
   permission: DataPermission,
+  downgradeNative?: boolean,
 ) {
   const schema = database.schema(schemaName);
   const tableIds = schema?.tables.map((t: Table) => t.id);
@@ -353,6 +362,7 @@ export function updateTablesPermission(
     "controlled",
     database,
     permission,
+    downgradeNative,
   );
   permissions = updatePermission(
     permissions,
@@ -372,6 +382,7 @@ export function updateSchemasPermission(
   value: any,
   database: Database,
   permission: DataPermission,
+  downgradeNative?: boolean,
 ) {
   const schemaNames = database && database.schemaNames();
   const schemaNamesOrNoSchema =
@@ -381,14 +392,17 @@ export function updateSchemasPermission(
       ? schemaNames
       : [""];
 
-  permissions = downgradeNativePermissionsIfNeeded(
-    permissions,
-    groupId,
-    { databaseId },
-    value,
-    database,
-    permission,
-  );
+  if (downgradeNative) {
+    permissions = downgradeNativePermissionsIfNeeded(
+      permissions,
+      groupId,
+      { databaseId },
+      value,
+      database,
+      permission,
+    );
+  }
+
   return updatePermission(
     permissions,
     groupId,
@@ -415,6 +429,7 @@ export function updateNativePermission(
       "all",
       database,
       permission,
+      false,
     );
   }
   return updatePermission(

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -141,6 +141,8 @@ export const PLUGIN_FEATURE_LEVEL_PERMISSIONS = {
   dataColumns: [] as any,
   getDownloadWidgetMessageOverride: (_result: Dataset): string | null => null,
   canDownloadResults: (_result: Dataset): boolean => true,
+  tableMetadataQueryProps: {} as any,
+  databaseQueryProps: {} as any,
 };
 
 export const PLUGIN_GENERAL_PERMISSIONS = {

--- a/frontend/test/__support__/e2e/helpers/e2e-permissions-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-permissions-helpers.js
@@ -56,6 +56,16 @@ export function assertPermissionTable(rows) {
   });
 }
 
+export function assertPermissionForItem(
+  item,
+  permissionColumnIndex,
+  permissionValue,
+) {
+  getPermissionRowPermissions(item)
+    .eq(permissionColumnIndex)
+    .should("have.text", permissionValue);
+}
+
 /**
  * @param {string} index
  * @param {string} permission

--- a/frontend/test/__support__/e2e/helpers/e2e-permissions-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-permissions-helpers.js
@@ -79,13 +79,3 @@ export function isPermissionDisabled(index, permission, isDisabled) {
     .closest("a")
     .should("have.attr", "aria-disabled", isDisabled.toString());
 }
-
-export function assertPermissionForItem(
-  item,
-  permissionColumnIndex,
-  permissionValue,
-) {
-  getPermissionRowPermissions(item)
-    .eq(permissionColumnIndex)
-    .should("have.text", permissionValue);
-}

--- a/frontend/test/metabase/scenarios/permissions/admin-permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/admin-permissions.cy.spec.js
@@ -564,12 +564,12 @@ describeEE("scenarios > admin > permissions", () => {
     cy.button("Save").click();
 
     assertPermissionTable([
-      ["Administrators", "Unrestricted", "Yes", "1 million rows"],
-      ["All Users", "Sandboxed", "No", "1 million rows"],
-      ["collection", "No self-service", "No", "No"],
-      ["data", "Unrestricted", "Yes", "No"],
-      ["nosql", "Unrestricted", "No", "No"],
-      ["readonly", "No self-service", "No", "No"],
+      ["Administrators", "Unrestricted", "Yes", "1 million rows", "Edit"],
+      ["All Users", "Sandboxed", "No", "1 million rows", "No"],
+      ["collection", "No self-service", "No", "No", "No"],
+      ["data", "Unrestricted", "Yes", "No", "No"],
+      ["nosql", "Unrestricted", "No", "No", "No"],
+      ["readonly", "No self-service", "No", "No", "No"],
     ]);
 
     modifyPermission(
@@ -590,12 +590,12 @@ describeEE("scenarios > admin > permissions", () => {
     cy.button("Save changes").click();
 
     assertPermissionTable([
-      ["Administrators", "Unrestricted", "Yes", "1 million rows"],
-      ["All Users", "Sandboxed", "No", "1 million rows"],
-      ["collection", "No self-service", "No", "No"],
-      ["data", "Unrestricted", "Yes", "No"],
-      ["nosql", "Unrestricted", "No", "No"],
-      ["readonly", "No self-service", "No", "No"],
+      ["Administrators", "Unrestricted", "Yes", "1 million rows", "Edit"],
+      ["All Users", "Sandboxed", "No", "1 million rows", "No"],
+      ["collection", "No self-service", "No", "No", "No"],
+      ["data", "Unrestricted", "Yes", "No", "No"],
+      ["nosql", "Unrestricted", "No", "No", "No"],
+      ["readonly", "No self-service", "No", "No", "No"],
     ]);
   });
 

--- a/frontend/test/metabase/scenarios/permissions/data-model-permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/data-model-permissions.cy.spec.js
@@ -1,0 +1,107 @@
+import {
+  restore,
+  modal,
+  describeEE,
+  assertPermissionTable,
+  assertPermissionForItem,
+  modifyPermission,
+} from "__support__/e2e/cypress";
+
+const DATA_ACCESS_PERMISSION_INDEX = 0;
+const DATA_MODEL_PERMISSION_INDEX = 3;
+
+describeEE("scenarios > admin > permissions", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("allows changing data model permission for a database", () => {
+    cy.visit("/admin/permissions/data/database/1");
+
+    modifyPermission("All Users", DATA_ACCESS_PERMISSION_INDEX, "Unrestricted");
+    modifyPermission("All Users", DATA_MODEL_PERMISSION_INDEX, "Edit");
+
+    cy.button("Save changes").click();
+
+    modal().within(() => {
+      cy.findByText("Save permissions?");
+      cy.findByText("Are you sure you want to do this?");
+      cy.button("Yes").click();
+    });
+
+    assertPermissionForItem("All Users", DATA_MODEL_PERMISSION_INDEX, "Edit");
+  });
+
+  it("allows changing data model permission for a table", () => {
+    cy.visit("/admin/permissions/data/database/1/table/1");
+
+    modifyPermission("All Users", DATA_ACCESS_PERMISSION_INDEX, "Unrestricted");
+
+    modal().within(() => {
+      cy.findByText("Change access to this database to limited?");
+      cy.button("Change").click();
+    });
+
+    modifyPermission("All Users", DATA_MODEL_PERMISSION_INDEX, "Edit");
+
+    cy.button("Save changes").click();
+
+    modal().within(() => {
+      cy.findByText("Save permissions?");
+      cy.findByText("Are you sure you want to do this?");
+      cy.button("Yes").click();
+    });
+
+    assertPermissionForItem("All Users", DATA_MODEL_PERMISSION_INDEX, "Edit");
+
+    // Shows granular data model permission on the database level
+    cy.visit("/admin/permissions/data/database/1");
+
+    assertPermissionForItem(
+      "All Users",
+      DATA_MODEL_PERMISSION_INDEX,
+      "Granular",
+    );
+  });
+
+  it("sets the data model permission to `No` when the data access permission is revoked", () => {
+    cy.visit("/admin/permissions/data/database/1");
+    const groupName = "data";
+
+    modifyPermission(groupName, DATA_MODEL_PERMISSION_INDEX, "Edit");
+
+    cy.button("Save changes").click();
+
+    modal().within(() => {
+      cy.findByText("Save permissions?");
+      cy.findByText("Are you sure you want to do this?");
+      cy.button("Yes").click();
+    });
+
+    assertPermissionTable([
+      ["Administrators", "Unrestricted", "Yes", "1 million rows"],
+      ["All Users", "No self-service", "No", "No"],
+      ["collection", "No self-service", "No", "No"],
+      ["data", "Unrestricted", "Yes", "1 million rows"],
+      ["nosql", "Unrestricted", "No", "No"],
+      ["readonly", "No self-service", "No", "No"],
+    ]);
+
+    modifyPermission(
+      groupName,
+      DATA_ACCESS_PERMISSION_INDEX,
+      "No self-service",
+    );
+
+    cy.button("Save changes").click();
+
+    modal().within(() => {
+      cy.findByText("Save permissions?");
+      cy.findByText("Are you sure you want to do this?");
+      cy.button("Yes").click();
+    });
+
+    assertPermissionForItem("All Users", DATA_MODEL_PERMISSION_INDEX, "No");
+  });
+});

--- a/frontend/test/metabase/scenarios/permissions/data-model-permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/data-model-permissions.cy.spec.js
@@ -2,7 +2,6 @@ import {
   restore,
   modal,
   describeEE,
-  assertPermissionTable,
   assertPermissionForItem,
   modifyPermission,
 } from "__support__/e2e/cypress";
@@ -78,15 +77,6 @@ describeEE("scenarios > admin > permissions", () => {
       cy.findByText("Are you sure you want to do this?");
       cy.button("Yes").click();
     });
-
-    assertPermissionTable([
-      ["Administrators", "Unrestricted", "Yes", "1 million rows"],
-      ["All Users", "No self-service", "No", "No"],
-      ["collection", "No self-service", "No", "No"],
-      ["data", "Unrestricted", "Yes", "1 million rows"],
-      ["nosql", "Unrestricted", "No", "No"],
-      ["readonly", "No self-service", "No", "No"],
-    ]);
 
     modifyPermission(
       groupName,

--- a/frontend/test/metabase/scenarios/permissions/download-permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/download-permissions.cy.spec.js
@@ -2,7 +2,7 @@ import {
   restore,
   modal,
   describeEE,
-  assertPermissionTable,
+  assertPermissionForItem,
   modifyPermission,
   downloadAndAssert,
 } from "__support__/e2e/cypress";
@@ -21,6 +21,7 @@ describeEE("scenarios > admin > permissions", () => {
     cy.visit("/admin/permissions/data/database/1");
 
     modifyPermission("All Users", DATA_ACCESS_PERMISSION_INDEX, "Unrestricted");
+    modifyPermission("All Users", DOWNLOAD_PERMISSION_INDEX, "No");
 
     cy.button("Save changes").click();
 
@@ -30,14 +31,7 @@ describeEE("scenarios > admin > permissions", () => {
       cy.button("Yes").click();
     });
 
-    assertPermissionTable([
-      ["Administrators", "Unrestricted", "Yes", "1 million rows"],
-      ["All Users", "Unrestricted", "No", "1 million rows"],
-      ["collection", "No self-service", "No", "No"],
-      ["data", "Unrestricted", "Yes", "No"],
-      ["nosql", "Unrestricted", "No", "No"],
-      ["readonly", "No self-service", "No", "No"],
-    ]);
+    assertPermissionForItem("All Users", DOWNLOAD_PERMISSION_INDEX, "No");
   });
 
   it("allows changing download results permission for a table", () => {
@@ -50,6 +44,8 @@ describeEE("scenarios > admin > permissions", () => {
       cy.button("Change").click();
     });
 
+    modifyPermission("All Users", DOWNLOAD_PERMISSION_INDEX, "No");
+
     cy.button("Save changes").click();
 
     modal().within(() => {
@@ -58,17 +54,10 @@ describeEE("scenarios > admin > permissions", () => {
       cy.button("Yes").click();
     });
 
-    assertPermissionTable([
-      ["Administrators", "Unrestricted", "Yes", "1 million rows"],
-      ["All Users", "Unrestricted", "No", "1 million rows"],
-      ["collection", "No self-service", "No", "No"],
-      ["data", "Unrestricted", "Yes", "No"],
-      ["nosql", "Unrestricted", "No", "No"],
-      ["readonly", "No self-service", "No", "No"],
-    ]);
+    assertPermissionForItem("All Users", DOWNLOAD_PERMISSION_INDEX, "No");
   });
 
-  it.skip("sets the download permission to `No` when the data access permission is revoked", () => {
+  it("sets the download permission to `No` when the data access permission is revoked", () => {
     cy.visit("/admin/permissions/data/database/1");
     const groupName = "data";
 
@@ -82,14 +71,11 @@ describeEE("scenarios > admin > permissions", () => {
       cy.button("Yes").click();
     });
 
-    assertPermissionTable([
-      ["Administrators", "Unrestricted", "Yes", "1 million rows"],
-      ["All Users", "No self-service", "No", "1 million rows"],
-      ["collection", "No self-service", "No", "No"],
-      ["data", "Unrestricted", "Yes", "1 million rows"],
-      ["nosql", "Unrestricted", "No", "No"],
-      ["readonly", "No self-service", "No", "No"],
-    ]);
+    assertPermissionForItem(
+      groupName,
+      DOWNLOAD_PERMISSION_INDEX,
+      "1 million rows",
+    );
 
     modifyPermission(groupName, DATA_ACCESS_PERMISSION_INDEX, "Block");
     cy.button("Revoke access").click();
@@ -102,14 +88,7 @@ describeEE("scenarios > admin > permissions", () => {
       cy.button("Yes").click();
     });
 
-    assertPermissionTable([
-      ["Administrators", "Unrestricted", "Yes", "1 million rows"],
-      ["All Users", "No self-service", "No", "1 million rows"],
-      ["collection", "No self-service", "No", "No"],
-      ["data", "Block", "No", "No"],
-      ["nosql", "Unrestricted", "No", "No"],
-      ["readonly", "No self-service", "No", "No"],
-    ]);
+    assertPermissionForItem(groupName, DOWNLOAD_PERMISSION_INDEX, "No");
   });
 
   it("restricts users from downloading questions", () => {


### PR DESCRIPTION
## Full Data model permission FE

Epic: https://github.com/metabase/metabase/issues/20380
[Product doc](https://www.notion.so/metabase/Add-feature-level-permissions-to-groups-8027685681774932ac7221131f061295)

Disregard the branch name — it contains full FE for the data model permission.

Permission editor
<img width="1727" alt="Screenshot 2022-03-10 at 21 29 22" src="https://user-images.githubusercontent.com/14301985/157790862-7e04c551-0cd9-4850-8c94-a998e59f4108.png">

Non-admin users UI
<img width="1054" alt="Screenshot 2022-04-07 at 22 13 21" src="https://user-images.githubusercontent.com/14301985/162349720-02bf45aa-8ef7-4f46-a0d8-9d5fe1a1b08c.png">

## How to verify
- As an admin open [Data Permissions page](http://localhost:3000/admin/permissions/data/)
- Create a Test User and login under it in a separate window

### Database level

- Ensure the Test User has no access to the data model page
- Open a database in the permission editor
- Change "All Users" Data model permission for a database to "Edit" and save
- Ensure the Test User gets access to the data model editor for all tables
- As an admin, change permission granularly only for specific tables
- Ensure the Test User gets access only to the specific tables