### PR TITLE
Removing `native` since was running twice

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -61,7 +61,6 @@ jobs:
           - "moderation"
           - "native"
           - "native-filters"
-          - "native"
           - "permissions"
           - "question"
           - "sharing"


### PR DESCRIPTION
Just removing `native` from Cypress run since it was happening 2x times
