### PR TITLE
Fix date parsing in DateInput

### DIFF
--- a/frontend/src/metabase/components/form/widgets/FormDateWidget/FormDateWidget.tsx
+++ b/frontend/src/metabase/components/form/widgets/FormDateWidget/FormDateWidget.tsx
@@ -1,7 +1,7 @@
 import React, { forwardRef, Ref, useCallback, useMemo } from "react";
 import { Moment } from "moment";
 import {
-  getDateStyleFromSettings,
+  getShortDateStyleFromSettings,
   getTimeStyleFromSettings,
   has24HourModeSetting,
   parseTimestamp,
@@ -54,7 +54,7 @@ const FormDateWidget = forwardRef(function FormDateWidget(
       value={value}
       placeholder={placeholder}
       hasTime={hasTime}
-      dateFormat={getDateStyleFromSettings()}
+      dateFormat={getShortDateStyleFromSettings()}
       timeFormat={getTimeStyleFromSettings()}
       is24HourMode={has24HourModeSetting()}
       readOnly={readOnly}

--- a/frontend/src/metabase/components/form/widgets/FormDateWidget/FormDateWidget.tsx
+++ b/frontend/src/metabase/components/form/widgets/FormDateWidget/FormDateWidget.tsx
@@ -1,7 +1,7 @@
 import React, { forwardRef, Ref, useCallback, useMemo } from "react";
 import { Moment } from "moment";
 import {
-  getShortDateStyleFromSettings,
+  getNumericDateStyleFromSettings,
   getTimeStyleFromSettings,
   has24HourModeSetting,
   parseTimestamp,
@@ -54,7 +54,7 @@ const FormDateWidget = forwardRef(function FormDateWidget(
       value={value}
       placeholder={placeholder}
       hasTime={hasTime}
-      dateFormat={getShortDateStyleFromSettings()}
+      dateFormat={getNumericDateStyleFromSettings()}
       timeFormat={getTimeStyleFromSettings()}
       is24HourMode={has24HourModeSetting()}
       readOnly={readOnly}

--- a/frontend/src/metabase/lib/time.js
+++ b/frontend/src/metabase/lib/time.js
@@ -202,7 +202,7 @@ export function getDateStyleFromSettings() {
   return customFormattingSettings?.["type/Temporal"]?.date_style;
 }
 
-export function getShortDateStyleFromSettings() {
+export function getNumericDateStyleFromSettings() {
   const dateStyle = getDateStyleFromSettings();
   return /\//.test(dateStyle) ? dateStyle : "M/D/YYYY";
 }

--- a/frontend/src/metabase/lib/time.js
+++ b/frontend/src/metabase/lib/time.js
@@ -202,6 +202,11 @@ export function getDateStyleFromSettings() {
   return customFormattingSettings?.["type/Temporal"]?.date_style;
 }
 
+export function getShortDateStyleFromSettings() {
+  const dateStyle = getDateStyleFromSettings();
+  return /\//.test(dateStyle) ? dateStyle : "M/D/YYYY";
+}
+
 export function getTimeStyleFromSettings() {
   const customFormattingSettings = MetabaseSettings.get("custom-formatting");
   return customFormattingSettings?.["type/Temporal"]?.time_style;


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/20289

How to test:
- Go to Admin > Settings > Localization and change date format to a format without a date separator, e.g. `day, month, date`.
- Go to collections, click on the calendar icon, try to create an event with a date by entering it via keyboard
- Make sure it is possible to enter a date and the event is saved correctly