### PR TITLE
Clean up static chart components accessors

### DIFF
--- a/frontend/src/metabase/internal/pages/StaticVizPage.jsx
+++ b/frontend/src/metabase/internal/pages/StaticVizPage.jsx
@@ -66,14 +66,6 @@ import {
   LINE_AREA_BAR_DEFAULT_OPTIONS_7,
 } from "../../static-viz/components/LineAreaBarChart/constants";
 
-function setAccessorsForChartOptions(index, options) {
-  const optionsCopy = { ...options };
-  if (STATIC_CHART_DEFAULT_OPTIONS[index].accessors) {
-    optionsCopy.accessors = STATIC_CHART_DEFAULT_OPTIONS[index].accessors;
-  }
-  return optionsCopy;
-}
-
 function chartOptionsToStr(options) {
   if (typeof options === "object") {
     return JSON.stringify(options, null, 2);
@@ -82,7 +74,6 @@ function chartOptionsToStr(options) {
 }
 
 export default function StaticVizPage() {
-  const [staticChartTypeIndex, setStaticChartTypeIndex] = useState(-1);
   const [staticChartType, setStaticChartType] = useState(null);
   const [staticChartCustomOptions, setStaticChartCustomOptions] = useState(
     null,
@@ -92,7 +83,6 @@ export default function StaticVizPage() {
   function chartOptionsToObj(optionsStr) {
     try {
       const chartOptions = JSON.parse(optionsStr);
-      delete chartOptions["accessors"];
       setStaticChartError(null);
       return chartOptions;
     } catch (err) {
@@ -121,11 +111,10 @@ export default function StaticVizPage() {
             className="w-full mt1"
             onChange={e => {
               const index = parseInt(e.target.value);
-              setStaticChartTypeIndex(index);
               setStaticChartType(STATIC_CHART_TYPES[index]);
-              const chartOptions = { ...STATIC_CHART_DEFAULT_OPTIONS[index] };
-              delete chartOptions["accessors"];
-              setStaticChartCustomOptions(chartOptions);
+              setStaticChartCustomOptions({
+                ...STATIC_CHART_DEFAULT_OPTIONS[index],
+              });
             }}
           >
             <option id="">---</option>
@@ -162,10 +151,7 @@ export default function StaticVizPage() {
             <div className="text-code-plain w-full mt1">
               <StaticChart
                 type={staticChartType}
-                options={setAccessorsForChartOptions(
-                  staticChartTypeIndex,
-                  staticChartCustomOptions,
-                )}
+                options={{ ...staticChartCustomOptions }}
               />
             </div>
           )}

--- a/frontend/src/metabase/static-viz/components/CategoricalAreaChart/CategoricalAreaChart.jsx
+++ b/frontend/src/metabase/static-viz/components/CategoricalAreaChart/CategoricalAreaChart.jsx
@@ -15,13 +15,14 @@ import {
 } from "../../lib/axes";
 import { formatNumber } from "../../lib/numbers";
 import { truncateText } from "../../lib/text";
+import { POSITIONAL_ACCESSORS } from "../../constants/accessors";
 
 const propTypes = {
   data: PropTypes.array.isRequired,
   accessors: PropTypes.shape({
     x: PropTypes.func.isRequired,
     y: PropTypes.func.isRequired,
-  }).isRequired,
+  }),
   settings: PropTypes.shape({
     x: PropTypes.object,
     y: PropTypes.object,
@@ -59,7 +60,12 @@ const layout = {
   strokeDasharray: "4",
 };
 
-const CategoricalAreaChart = ({ data, accessors, settings, labels }) => {
+const CategoricalAreaChart = ({
+  data,
+  accessors = POSITIONAL_ACCESSORS,
+  settings,
+  labels,
+}) => {
   const colors = settings?.colors;
   const isVertical = data.length > 10;
   const xTickWidth = getXTickWidth(

--- a/frontend/src/metabase/static-viz/components/CategoricalAreaChart/CategoricalAreaChart.jsx
+++ b/frontend/src/metabase/static-viz/components/CategoricalAreaChart/CategoricalAreaChart.jsx
@@ -34,10 +34,6 @@ const propTypes = {
   }),
 };
 
-const defaultProps = {
-  accessors: POSITIONAL_ACCESSORS,
-};
-
 const layout = {
   width: 540,
   height: 300,
@@ -64,7 +60,12 @@ const layout = {
   strokeDasharray: "4",
 };
 
-const CategoricalAreaChart = ({ data, accessors, settings, labels }) => {
+const CategoricalAreaChart = ({
+  data,
+  accessors = POSITIONAL_ACCESSORS,
+  settings,
+  labels,
+}) => {
   const colors = settings?.colors;
   const isVertical = data.length > 10;
   const xTickWidth = getXTickWidth(
@@ -164,6 +165,5 @@ const CategoricalAreaChart = ({ data, accessors, settings, labels }) => {
 };
 
 CategoricalAreaChart.propTypes = propTypes;
-CategoricalAreaChart.defaultProps = defaultProps;
 
 export default CategoricalAreaChart;

--- a/frontend/src/metabase/static-viz/components/CategoricalAreaChart/CategoricalAreaChart.jsx
+++ b/frontend/src/metabase/static-viz/components/CategoricalAreaChart/CategoricalAreaChart.jsx
@@ -34,6 +34,10 @@ const propTypes = {
   }),
 };
 
+const defaultProps = {
+  accessors: POSITIONAL_ACCESSORS,
+};
+
 const layout = {
   width: 540,
   height: 300,
@@ -60,12 +64,7 @@ const layout = {
   strokeDasharray: "4",
 };
 
-const CategoricalAreaChart = ({
-  data,
-  accessors = POSITIONAL_ACCESSORS,
-  settings,
-  labels,
-}) => {
+const CategoricalAreaChart = ({ data, accessors, settings, labels }) => {
   const colors = settings?.colors;
   const isVertical = data.length > 10;
   const xTickWidth = getXTickWidth(
@@ -165,5 +164,6 @@ const CategoricalAreaChart = ({
 };
 
 CategoricalAreaChart.propTypes = propTypes;
+CategoricalAreaChart.defaultProps = defaultProps;
 
 export default CategoricalAreaChart;

--- a/frontend/src/metabase/static-viz/components/CategoricalAreaChart/constants.ts
+++ b/frontend/src/metabase/static-viz/components/CategoricalAreaChart/constants.ts
@@ -15,10 +15,6 @@ export const CATEGORICAL_AREA_CHART_DEFAULT_OPTIONS = {
     ["Roderick Herman", 50],
     ["Ruth Dougherty", 75],
   ],
-  accessors: {
-    x: (row: any[]) => row[0],
-    y: (row: any[]) => row[1],
-  },
   labels: {
     left: "Tasks",
     bottom: "People",

--- a/frontend/src/metabase/static-viz/components/CategoricalBarChart/CategoricalBarChart.jsx
+++ b/frontend/src/metabase/static-viz/components/CategoricalBarChart/CategoricalBarChart.jsx
@@ -15,13 +15,14 @@ import {
 } from "../../lib/axes";
 import { formatNumber } from "../../lib/numbers";
 import { truncateText } from "../../lib/text";
+import { POSITIONAL_ACCESSORS } from "../../constants/accessors";
 
 const propTypes = {
   data: PropTypes.array.isRequired,
   accessors: PropTypes.shape({
     x: PropTypes.func.isRequired,
     y: PropTypes.func.isRequired,
-  }).isRequired,
+  }),
   settings: PropTypes.shape({
     x: PropTypes.object,
     y: PropTypes.object,
@@ -58,7 +59,12 @@ const layout = {
   strokeDasharray: "4",
 };
 
-const CategoricalBarChart = ({ data, accessors, settings, labels }) => {
+const CategoricalBarChart = ({
+  data,
+  accessors = POSITIONAL_ACCESSORS,
+  settings,
+  labels,
+}) => {
   const colors = settings?.colors;
   const isVertical = data.length > 10;
   const xTickWidth = getXTickWidth(

--- a/frontend/src/metabase/static-viz/components/CategoricalBarChart/CategoricalBarChart.jsx
+++ b/frontend/src/metabase/static-viz/components/CategoricalBarChart/CategoricalBarChart.jsx
@@ -34,6 +34,10 @@ const propTypes = {
   }),
 };
 
+const defaultProps = {
+  accessors: POSITIONAL_ACCESSORS,
+};
+
 const layout = {
   width: 540,
   height: 300,
@@ -59,12 +63,7 @@ const layout = {
   strokeDasharray: "4",
 };
 
-const CategoricalBarChart = ({
-  data,
-  accessors = POSITIONAL_ACCESSORS,
-  settings,
-  labels,
-}) => {
+const CategoricalBarChart = ({ data, accessors, settings, labels }) => {
   const colors = settings?.colors;
   const isVertical = data.length > 10;
   const xTickWidth = getXTickWidth(
@@ -162,5 +161,6 @@ const CategoricalBarChart = ({
 };
 
 CategoricalBarChart.propTypes = propTypes;
+CategoricalBarChart.defaultProps = defaultProps;
 
 export default CategoricalBarChart;

--- a/frontend/src/metabase/static-viz/components/CategoricalBarChart/CategoricalBarChart.jsx
+++ b/frontend/src/metabase/static-viz/components/CategoricalBarChart/CategoricalBarChart.jsx
@@ -34,10 +34,6 @@ const propTypes = {
   }),
 };
 
-const defaultProps = {
-  accessors: POSITIONAL_ACCESSORS,
-};
-
 const layout = {
   width: 540,
   height: 300,
@@ -63,7 +59,12 @@ const layout = {
   strokeDasharray: "4",
 };
 
-const CategoricalBarChart = ({ data, accessors, settings, labels }) => {
+const CategoricalBarChart = ({
+  data,
+  accessors = POSITIONAL_ACCESSORS,
+  settings,
+  labels,
+}) => {
   const colors = settings?.colors;
   const isVertical = data.length > 10;
   const xTickWidth = getXTickWidth(
@@ -161,6 +162,5 @@ const CategoricalBarChart = ({ data, accessors, settings, labels }) => {
 };
 
 CategoricalBarChart.propTypes = propTypes;
-CategoricalBarChart.defaultProps = defaultProps;
 
 export default CategoricalBarChart;

--- a/frontend/src/metabase/static-viz/components/CategoricalBarChart/constants.ts
+++ b/frontend/src/metabase/static-viz/components/CategoricalBarChart/constants.ts
@@ -15,10 +15,6 @@ export const CATEGORICAL_BAR_CHART_DEFAULT_OPTIONS = {
     ["Roderick Herman", 50],
     ["Ruth Dougherty", 75],
   ],
-  accessors: {
-    x: (row: any[]) => row[0],
-    y: (row: any[]) => row[1],
-  },
   labels: {
     left: "Tasks",
     bottom: "People",

--- a/frontend/src/metabase/static-viz/components/CategoricalDonutChart/CategoricalDonutChart.jsx
+++ b/frontend/src/metabase/static-viz/components/CategoricalDonutChart/CategoricalDonutChart.jsx
@@ -5,6 +5,7 @@ import { Group } from "@visx/group";
 import { Pie } from "@visx/shape";
 import { Text } from "@visx/text";
 import { formatNumber } from "../../lib/numbers";
+import { DIMENSION_ACCESSORS } from "../../constants/accessors";
 
 const propTypes = {
   data: PropTypes.array,
@@ -37,7 +38,12 @@ const layout = {
   labelFontSize: 14,
 };
 
-const CategoricalDonutChart = ({ data, colors, accessors, settings }) => {
+const CategoricalDonutChart = ({
+  data,
+  colors,
+  accessors = DIMENSION_ACCESSORS,
+  settings,
+}) => {
   const innerWidth = layout.width - layout.margin * 2;
   const innerHeight = layout.height - layout.margin * 2;
   const outerRadius = Math.min(innerWidth, innerHeight) / 2;

--- a/frontend/src/metabase/static-viz/components/CategoricalDonutChart/CategoricalDonutChart.jsx
+++ b/frontend/src/metabase/static-viz/components/CategoricalDonutChart/CategoricalDonutChart.jsx
@@ -19,6 +19,10 @@ const propTypes = {
   }),
 };
 
+const defaultProps = {
+  accessors: DIMENSION_ACCESSORS,
+};
+
 const layout = {
   width: 540,
   height: 540,
@@ -38,12 +42,7 @@ const layout = {
   labelFontSize: 14,
 };
 
-const CategoricalDonutChart = ({
-  data,
-  colors,
-  accessors = DIMENSION_ACCESSORS,
-  settings,
-}) => {
+const CategoricalDonutChart = ({ data, colors, accessors, settings }) => {
   const innerWidth = layout.width - layout.margin * 2;
   const innerHeight = layout.height - layout.margin * 2;
   const outerRadius = Math.min(innerWidth, innerHeight) / 2;
@@ -108,5 +107,6 @@ const CategoricalDonutChart = ({
 };
 
 CategoricalDonutChart.propTypes = propTypes;
+CategoricalDonutChart.defaultProps = defaultProps;
 
 export default CategoricalDonutChart;

--- a/frontend/src/metabase/static-viz/components/CategoricalDonutChart/CategoricalDonutChart.jsx
+++ b/frontend/src/metabase/static-viz/components/CategoricalDonutChart/CategoricalDonutChart.jsx
@@ -19,10 +19,6 @@ const propTypes = {
   }),
 };
 
-const defaultProps = {
-  accessors: DIMENSION_ACCESSORS,
-};
-
 const layout = {
   width: 540,
   height: 540,
@@ -42,7 +38,12 @@ const layout = {
   labelFontSize: 14,
 };
 
-const CategoricalDonutChart = ({ data, colors, accessors, settings }) => {
+const CategoricalDonutChart = ({
+  data,
+  colors,
+  accessors = DIMENSION_ACCESSORS,
+  settings,
+}) => {
   const innerWidth = layout.width - layout.margin * 2;
   const innerHeight = layout.height - layout.margin * 2;
   const outerRadius = Math.min(innerWidth, innerHeight) / 2;
@@ -107,6 +108,5 @@ const CategoricalDonutChart = ({ data, colors, accessors, settings }) => {
 };
 
 CategoricalDonutChart.propTypes = propTypes;
-CategoricalDonutChart.defaultProps = defaultProps;
 
 export default CategoricalDonutChart;

--- a/frontend/src/metabase/static-viz/components/CategoricalDonutChart/constants.ts
+++ b/frontend/src/metabase/static-viz/components/CategoricalDonutChart/constants.ts
@@ -9,8 +9,4 @@ export const CATEGORICAL_DONUT_CHART_DEFAULT_OPTIONS = {
     donut: "#509EE3",
     cronut: "#DDECFA",
   },
-  accessors: {
-    dimension: (row: any[]) => row[0],
-    metric: (row: any[]) => row[1],
-  },
 };

--- a/frontend/src/metabase/static-viz/components/CategoricalLineChart/CategoricalLineChart.jsx
+++ b/frontend/src/metabase/static-viz/components/CategoricalLineChart/CategoricalLineChart.jsx
@@ -15,13 +15,14 @@ import {
 } from "../../lib/axes";
 import { formatNumber } from "../../lib/numbers";
 import { truncateText } from "../../lib/text";
+import { POSITIONAL_ACCESSORS } from "../../constants/accessors";
 
 const propTypes = {
   data: PropTypes.array.isRequired,
   accessors: PropTypes.shape({
     x: PropTypes.func.isRequired,
     y: PropTypes.func.isRequired,
-  }).isRequired,
+  }),
   settings: PropTypes.shape({
     x: PropTypes.object,
     y: PropTypes.object,
@@ -58,7 +59,12 @@ const layout = {
   strokeDasharray: "4",
 };
 
-const CategoricalLineChart = ({ data, accessors, settings, labels }) => {
+const CategoricalLineChart = ({
+  data,
+  accessors = POSITIONAL_ACCESSORS,
+  settings,
+  labels,
+}) => {
   const colors = settings?.colors;
   const isVertical = data.length > 10;
   const xTickWidth = getXTickWidth(

--- a/frontend/src/metabase/static-viz/components/CategoricalLineChart/CategoricalLineChart.jsx
+++ b/frontend/src/metabase/static-viz/components/CategoricalLineChart/CategoricalLineChart.jsx
@@ -34,6 +34,10 @@ const propTypes = {
   }),
 };
 
+const defaultProps = {
+  accessors: POSITIONAL_ACCESSORS,
+};
+
 const layout = {
   width: 540,
   height: 300,
@@ -59,12 +63,7 @@ const layout = {
   strokeDasharray: "4",
 };
 
-const CategoricalLineChart = ({
-  data,
-  accessors = POSITIONAL_ACCESSORS,
-  settings,
-  labels,
-}) => {
+const CategoricalLineChart = ({ data, accessors, settings, labels }) => {
   const colors = settings?.colors;
   const isVertical = data.length > 10;
   const xTickWidth = getXTickWidth(
@@ -156,5 +155,6 @@ const CategoricalLineChart = ({
 };
 
 CategoricalLineChart.propTypes = propTypes;
+CategoricalLineChart.defaultProps = defaultProps;
 
 export default CategoricalLineChart;

--- a/frontend/src/metabase/static-viz/components/CategoricalLineChart/CategoricalLineChart.jsx
+++ b/frontend/src/metabase/static-viz/components/CategoricalLineChart/CategoricalLineChart.jsx
@@ -34,10 +34,6 @@ const propTypes = {
   }),
 };
 
-const defaultProps = {
-  accessors: POSITIONAL_ACCESSORS,
-};
-
 const layout = {
   width: 540,
   height: 300,
@@ -63,7 +59,12 @@ const layout = {
   strokeDasharray: "4",
 };
 
-const CategoricalLineChart = ({ data, accessors, settings, labels }) => {
+const CategoricalLineChart = ({
+  data,
+  accessors = POSITIONAL_ACCESSORS,
+  settings,
+  labels,
+}) => {
   const colors = settings?.colors;
   const isVertical = data.length > 10;
   const xTickWidth = getXTickWidth(
@@ -155,6 +156,5 @@ const CategoricalLineChart = ({ data, accessors, settings, labels }) => {
 };
 
 CategoricalLineChart.propTypes = propTypes;
-CategoricalLineChart.defaultProps = defaultProps;
 
 export default CategoricalLineChart;

--- a/frontend/src/metabase/static-viz/components/CategoricalLineChart/constants.ts
+++ b/frontend/src/metabase/static-viz/components/CategoricalLineChart/constants.ts
@@ -15,10 +15,6 @@ export const CATEGORICAL_LINE_CHART_DEFAULT_OPTIONS = {
     ["Roderick Herman", 50],
     ["Ruth Dougherty", 75],
   ],
-  accessors: {
-    x: (row: any[]) => row[0],
-    y: (row: any[]) => row[1],
-  },
   labels: {
     left: "Tasks",
     bottom: "People",

--- a/frontend/src/metabase/static-viz/components/CategoricalWaterfallChart/CategoricalWaterfallChart.jsx
+++ b/frontend/src/metabase/static-viz/components/CategoricalWaterfallChart/CategoricalWaterfallChart.jsx
@@ -21,13 +21,14 @@ import {
   calculateWaterfallEntries,
   getWaterfallEntryColor,
 } from "metabase/static-viz/lib/waterfall";
+import { POSITIONAL_ACCESSORS } from "../../constants/accessors";
 
 const propTypes = {
   data: PropTypes.array.isRequired,
   accessors: PropTypes.shape({
     x: PropTypes.func.isRequired,
     y: PropTypes.func.isRequired,
-  }).isRequired,
+  }),
   settings: PropTypes.shape({
     x: PropTypes.object,
     y: PropTypes.object,
@@ -68,7 +69,12 @@ const layout = {
   maxTickWidth: 100,
 };
 
-const CategoricalWaterfallChart = ({ data, accessors, settings, labels }) => {
+const CategoricalWaterfallChart = ({
+  data,
+  accessors = POSITIONAL_ACCESSORS,
+  settings,
+  labels,
+}) => {
   const entries = calculateWaterfallEntries(
     data,
     accessors,

--- a/frontend/src/metabase/static-viz/components/CategoricalWaterfallChart/CategoricalWaterfallChart.jsx
+++ b/frontend/src/metabase/static-viz/components/CategoricalWaterfallChart/CategoricalWaterfallChart.jsx
@@ -41,6 +41,10 @@ const propTypes = {
   }),
 };
 
+const defaultProps = {
+  accessors: POSITIONAL_ACCESSORS,
+};
+
 const layout = {
   width: 540,
   height: 300,
@@ -69,12 +73,7 @@ const layout = {
   maxTickWidth: 100,
 };
 
-const CategoricalWaterfallChart = ({
-  data,
-  accessors = POSITIONAL_ACCESSORS,
-  settings,
-  labels,
-}) => {
+const CategoricalWaterfallChart = ({ data, accessors, settings, labels }) => {
   const entries = calculateWaterfallEntries(
     data,
     accessors,
@@ -180,5 +179,6 @@ const CategoricalWaterfallChart = ({
 };
 
 CategoricalWaterfallChart.propTypes = propTypes;
+CategoricalWaterfallChart.defaultProps = defaultProps;
 
 export default CategoricalWaterfallChart;

--- a/frontend/src/metabase/static-viz/components/CategoricalWaterfallChart/CategoricalWaterfallChart.jsx
+++ b/frontend/src/metabase/static-viz/components/CategoricalWaterfallChart/CategoricalWaterfallChart.jsx
@@ -41,10 +41,6 @@ const propTypes = {
   }),
 };
 
-const defaultProps = {
-  accessors: POSITIONAL_ACCESSORS,
-};
-
 const layout = {
   width: 540,
   height: 300,
@@ -73,7 +69,12 @@ const layout = {
   maxTickWidth: 100,
 };
 
-const CategoricalWaterfallChart = ({ data, accessors, settings, labels }) => {
+const CategoricalWaterfallChart = ({
+  data,
+  accessors = POSITIONAL_ACCESSORS,
+  settings,
+  labels,
+}) => {
   const entries = calculateWaterfallEntries(
     data,
     accessors,
@@ -179,6 +180,5 @@ const CategoricalWaterfallChart = ({ data, accessors, settings, labels }) => {
 };
 
 CategoricalWaterfallChart.propTypes = propTypes;
-CategoricalWaterfallChart.defaultProps = defaultProps;
 
 export default CategoricalWaterfallChart;

--- a/frontend/src/metabase/static-viz/components/CategoricalWaterfallChart/constants.ts
+++ b/frontend/src/metabase/static-viz/components/CategoricalWaterfallChart/constants.ts
@@ -13,10 +13,6 @@ export const CATEGORICAL_WATERFALL_CHART_DEFAULT_OPTIONS = {
     ["Stage 9", 100],
     ["Stage 10", -300],
   ],
-  accessors: {
-    x: (row: any[]) => row[0],
-    y: (row: any[]) => row[1],
-  },
   settings: {
     showTotal: true,
   },

--- a/frontend/src/metabase/static-viz/components/TimeSeriesAreaChart/TimeSeriesAreaChart.jsx
+++ b/frontend/src/metabase/static-viz/components/TimeSeriesAreaChart/TimeSeriesAreaChart.jsx
@@ -13,13 +13,14 @@ import {
 import { formatDate } from "../../lib/dates";
 import { formatNumber } from "../../lib/numbers";
 import { sortTimeSeries } from "../../lib/sort";
+import { DATE_ACCESSORS } from "../../constants/accessors";
 
 const propTypes = {
   data: PropTypes.array.isRequired,
   accessors: PropTypes.shape({
     x: PropTypes.func,
     y: PropTypes.func,
-  }).isRequired,
+  }),
   settings: PropTypes.shape({
     x: PropTypes.object,
     y: PropTypes.object,
@@ -58,7 +59,12 @@ const layout = {
   strokeDasharray: "4",
 };
 
-const TimeSeriesAreaChart = ({ data, accessors, settings, labels }) => {
+const TimeSeriesAreaChart = ({
+  data,
+  accessors = DATE_ACCESSORS,
+  settings,
+  labels,
+}) => {
   data = sortTimeSeries(data);
   const colors = settings?.colors;
   const yTickWidth = getYTickWidth(data, accessors, settings, layout.font.size);

--- a/frontend/src/metabase/static-viz/components/TimeSeriesAreaChart/TimeSeriesAreaChart.jsx
+++ b/frontend/src/metabase/static-viz/components/TimeSeriesAreaChart/TimeSeriesAreaChart.jsx
@@ -32,6 +32,10 @@ const propTypes = {
   }),
 };
 
+const defaultProps = {
+  accessors: DATE_ACCESSORS,
+};
+
 const layout = {
   width: 540,
   height: 300,
@@ -59,12 +63,7 @@ const layout = {
   strokeDasharray: "4",
 };
 
-const TimeSeriesAreaChart = ({
-  data,
-  accessors = DATE_ACCESSORS,
-  settings,
-  labels,
-}) => {
+const TimeSeriesAreaChart = ({ data, accessors, settings, labels }) => {
   data = sortTimeSeries(data);
   const colors = settings?.colors;
   const yTickWidth = getYTickWidth(data, accessors, settings, layout.font.size);
@@ -141,5 +140,6 @@ const TimeSeriesAreaChart = ({
 };
 
 TimeSeriesAreaChart.propTypes = propTypes;
+TimeSeriesAreaChart.defaultProps = defaultProps;
 
 export default TimeSeriesAreaChart;

--- a/frontend/src/metabase/static-viz/components/TimeSeriesAreaChart/TimeSeriesAreaChart.jsx
+++ b/frontend/src/metabase/static-viz/components/TimeSeriesAreaChart/TimeSeriesAreaChart.jsx
@@ -32,10 +32,6 @@ const propTypes = {
   }),
 };
 
-const defaultProps = {
-  accessors: DATE_ACCESSORS,
-};
-
 const layout = {
   width: 540,
   height: 300,
@@ -63,7 +59,12 @@ const layout = {
   strokeDasharray: "4",
 };
 
-const TimeSeriesAreaChart = ({ data, accessors, settings, labels }) => {
+const TimeSeriesAreaChart = ({
+  data,
+  accessors = DATE_ACCESSORS,
+  settings,
+  labels,
+}) => {
   data = sortTimeSeries(data);
   const colors = settings?.colors;
   const yTickWidth = getYTickWidth(data, accessors, settings, layout.font.size);
@@ -140,6 +141,5 @@ const TimeSeriesAreaChart = ({ data, accessors, settings, labels }) => {
 };
 
 TimeSeriesAreaChart.propTypes = propTypes;
-TimeSeriesAreaChart.defaultProps = defaultProps;
 
 export default TimeSeriesAreaChart;

--- a/frontend/src/metabase/static-viz/components/TimeSeriesAreaChart/constants.ts
+++ b/frontend/src/metabase/static-viz/components/TimeSeriesAreaChart/constants.ts
@@ -6,10 +6,6 @@ export const TIME_SERIES_AREA_CHART_DEFAULT_OPTIONS = {
     ["2020-06-10", 60],
     ["2020-12-10", 80],
   ],
-  accessors: {
-    x: (row: any[]) => new Date(row[0]).valueOf(),
-    y: (row: any[]) => row[1],
-  },
   settings: {
     x: {
       date_style: "MMM",

--- a/frontend/src/metabase/static-viz/components/TimeSeriesBarChart/TimeSeriesBarChart.jsx
+++ b/frontend/src/metabase/static-viz/components/TimeSeriesBarChart/TimeSeriesBarChart.jsx
@@ -13,13 +13,14 @@ import {
 import { formatDate } from "../../lib/dates";
 import { formatNumber } from "../../lib/numbers";
 import { sortTimeSeries } from "../../lib/sort";
+import { DATE_ACCESSORS } from "../../constants/accessors";
 
 const propTypes = {
   data: PropTypes.array.isRequired,
   accessors: PropTypes.shape({
     x: PropTypes.func.isRequired,
     y: PropTypes.func.isRequired,
-  }).isRequired,
+  }),
   settings: PropTypes.shape({
     x: PropTypes.object,
     y: PropTypes.object,
@@ -56,7 +57,12 @@ const layout = {
   strokeDasharray: "4",
 };
 
-const TimeSeriesBarChart = ({ data, accessors, settings, labels }) => {
+const TimeSeriesBarChart = ({
+  data,
+  accessors = DATE_ACCESSORS,
+  settings,
+  labels,
+}) => {
   data = sortTimeSeries(data);
   const colors = settings?.colors;
   const yTickWidth = getYTickWidth(data, accessors, settings, layout.font.size);

--- a/frontend/src/metabase/static-viz/components/TimeSeriesBarChart/TimeSeriesBarChart.jsx
+++ b/frontend/src/metabase/static-viz/components/TimeSeriesBarChart/TimeSeriesBarChart.jsx
@@ -32,10 +32,6 @@ const propTypes = {
   }),
 };
 
-const defaultProps = {
-  accessors: DATE_ACCESSORS,
-};
-
 const layout = {
   width: 540,
   height: 300,
@@ -61,7 +57,12 @@ const layout = {
   strokeDasharray: "4",
 };
 
-const TimeSeriesBarChart = ({ data, accessors, settings, labels }) => {
+const TimeSeriesBarChart = ({
+  data,
+  accessors = DATE_ACCESSORS,
+  settings,
+  labels,
+}) => {
   data = sortTimeSeries(data);
   const colors = settings?.colors;
   const yTickWidth = getYTickWidth(data, accessors, settings, layout.font.size);
@@ -135,6 +136,5 @@ const TimeSeriesBarChart = ({ data, accessors, settings, labels }) => {
 };
 
 TimeSeriesBarChart.propTypes = propTypes;
-TimeSeriesBarChart.defaultProps = defaultProps;
 
 export default TimeSeriesBarChart;

--- a/frontend/src/metabase/static-viz/components/TimeSeriesBarChart/TimeSeriesBarChart.jsx
+++ b/frontend/src/metabase/static-viz/components/TimeSeriesBarChart/TimeSeriesBarChart.jsx
@@ -32,6 +32,10 @@ const propTypes = {
   }),
 };
 
+const defaultProps = {
+  accessors: DATE_ACCESSORS,
+};
+
 const layout = {
   width: 540,
   height: 300,
@@ -57,12 +61,7 @@ const layout = {
   strokeDasharray: "4",
 };
 
-const TimeSeriesBarChart = ({
-  data,
-  accessors = DATE_ACCESSORS,
-  settings,
-  labels,
-}) => {
+const TimeSeriesBarChart = ({ data, accessors, settings, labels }) => {
   data = sortTimeSeries(data);
   const colors = settings?.colors;
   const yTickWidth = getYTickWidth(data, accessors, settings, layout.font.size);
@@ -136,5 +135,6 @@ const TimeSeriesBarChart = ({
 };
 
 TimeSeriesBarChart.propTypes = propTypes;
+TimeSeriesBarChart.defaultProps = defaultProps;
 
 export default TimeSeriesBarChart;

--- a/frontend/src/metabase/static-viz/components/TimeSeriesBarChart/constants.ts
+++ b/frontend/src/metabase/static-viz/components/TimeSeriesBarChart/constants.ts
@@ -8,10 +8,6 @@ export const TIME_SERIES_BAR_CHART_DEFAULT_OPTIONS = {
     ["2020-10-24", 10],
     ["2020-10-25", 15],
   ],
-  accessors: {
-    x: (row: any[]) => new Date(row[0]).valueOf(),
-    y: (row: any[]) => row[1],
-  },
   settings: {
     x: {
       date_style: "MM/DD/YYYY",

--- a/frontend/src/metabase/static-viz/components/TimeSeriesLineChart/TimeSeriesLineChart.jsx
+++ b/frontend/src/metabase/static-viz/components/TimeSeriesLineChart/TimeSeriesLineChart.jsx
@@ -32,6 +32,10 @@ const propTypes = {
   }),
 };
 
+const defaultProps = {
+  accessors: DATE_ACCESSORS,
+};
+
 const layout = {
   width: 540,
   height: 300,
@@ -57,12 +61,7 @@ const layout = {
   strokeDasharray: "4",
 };
 
-const TimeSeriesLineChart = ({
-  data,
-  accessors = DATE_ACCESSORS,
-  settings,
-  labels,
-}) => {
+const TimeSeriesLineChart = ({ data, accessors, settings, labels }) => {
   data = sortTimeSeries(data);
   const colors = settings?.colors;
   const yTickWidth = getYTickWidth(data, accessors, settings, layout.font.size);
@@ -131,5 +130,6 @@ const TimeSeriesLineChart = ({
 };
 
 TimeSeriesLineChart.propTypes = propTypes;
+TimeSeriesLineChart.defaultProps = defaultProps;
 
 export default TimeSeriesLineChart;

--- a/frontend/src/metabase/static-viz/components/TimeSeriesLineChart/TimeSeriesLineChart.jsx
+++ b/frontend/src/metabase/static-viz/components/TimeSeriesLineChart/TimeSeriesLineChart.jsx
@@ -13,13 +13,14 @@ import {
 import { formatDate } from "../../lib/dates";
 import { formatNumber } from "../../lib/numbers";
 import { sortTimeSeries } from "../../lib/sort";
+import { DATE_ACCESSORS } from "../../constants/accessors";
 
 const propTypes = {
   data: PropTypes.array.isRequired,
   accessors: PropTypes.shape({
     x: PropTypes.func,
     y: PropTypes.func,
-  }).isRequired,
+  }),
   settings: PropTypes.shape({
     x: PropTypes.object,
     y: PropTypes.object,
@@ -56,7 +57,12 @@ const layout = {
   strokeDasharray: "4",
 };
 
-const TimeSeriesLineChart = ({ data, accessors, settings, labels }) => {
+const TimeSeriesLineChart = ({
+  data,
+  accessors = DATE_ACCESSORS,
+  settings,
+  labels,
+}) => {
   data = sortTimeSeries(data);
   const colors = settings?.colors;
   const yTickWidth = getYTickWidth(data, accessors, settings, layout.font.size);

--- a/frontend/src/metabase/static-viz/components/TimeSeriesLineChart/TimeSeriesLineChart.jsx
+++ b/frontend/src/metabase/static-viz/components/TimeSeriesLineChart/TimeSeriesLineChart.jsx
@@ -32,10 +32,6 @@ const propTypes = {
   }),
 };
 
-const defaultProps = {
-  accessors: DATE_ACCESSORS,
-};
-
 const layout = {
   width: 540,
   height: 300,
@@ -61,7 +57,12 @@ const layout = {
   strokeDasharray: "4",
 };
 
-const TimeSeriesLineChart = ({ data, accessors, settings, labels }) => {
+const TimeSeriesLineChart = ({
+  data,
+  accessors = DATE_ACCESSORS,
+  settings,
+  labels,
+}) => {
   data = sortTimeSeries(data);
   const colors = settings?.colors;
   const yTickWidth = getYTickWidth(data, accessors, settings, layout.font.size);
@@ -130,6 +131,5 @@ const TimeSeriesLineChart = ({ data, accessors, settings, labels }) => {
 };
 
 TimeSeriesLineChart.propTypes = propTypes;
-TimeSeriesLineChart.defaultProps = defaultProps;
 
 export default TimeSeriesLineChart;

--- a/frontend/src/metabase/static-viz/components/TimeSeriesLineChart/constants.ts
+++ b/frontend/src/metabase/static-viz/components/TimeSeriesLineChart/constants.ts
@@ -6,10 +6,6 @@ export const TIME_SERIES_LINE_CHART_DEFAULT_OPTIONS = {
     ["2020-06-10", 60],
     ["2020-12-10", 80],
   ],
-  accessors: {
-    x: (row: any[]) => new Date(row[0]).valueOf(),
-    y: (row: any[]) => row[1],
-  },
   labels: {
     left: "Count",
     bottom: "Created At",

--- a/frontend/src/metabase/static-viz/components/TimeSeriesWaterfallChart/TimeSeriesWaterfallChart.jsx
+++ b/frontend/src/metabase/static-viz/components/TimeSeriesWaterfallChart/TimeSeriesWaterfallChart.jsx
@@ -19,13 +19,14 @@ import {
   getWaterfallEntryColor,
 } from "metabase/static-viz/lib/waterfall";
 import { sortTimeSeries } from "../../lib/sort";
+import { DATE_ACCESSORS } from "../../constants/accessors";
 
 const propTypes = {
   data: PropTypes.array.isRequired,
   accessors: PropTypes.shape({
     x: PropTypes.func.isRequired,
     y: PropTypes.func.isRequired,
-  }).isRequired,
+  }),
   settings: PropTypes.shape({
     x: PropTypes.object,
     y: PropTypes.object,
@@ -66,7 +67,12 @@ const layout = {
   strokeDasharray: "4",
 };
 
-const TimeSeriesWaterfallChart = ({ data, accessors, settings, labels }) => {
+const TimeSeriesWaterfallChart = ({
+  data,
+  accessors = DATE_ACCESSORS,
+  settings,
+  labels,
+}) => {
   data = sortTimeSeries(data);
   const colors = settings?.colors;
   const yTickWidth = getYTickWidth(data, accessors, settings, layout.font.size);

--- a/frontend/src/metabase/static-viz/components/TimeSeriesWaterfallChart/TimeSeriesWaterfallChart.jsx
+++ b/frontend/src/metabase/static-viz/components/TimeSeriesWaterfallChart/TimeSeriesWaterfallChart.jsx
@@ -39,10 +39,6 @@ const propTypes = {
   }),
 };
 
-const defaultProps = {
-  accessors: DATE_ACCESSORS,
-};
-
 const layout = {
   width: 540,
   height: 300,
@@ -71,7 +67,12 @@ const layout = {
   strokeDasharray: "4",
 };
 
-const TimeSeriesWaterfallChart = ({ data, accessors, settings, labels }) => {
+const TimeSeriesWaterfallChart = ({
+  data,
+  accessors = DATE_ACCESSORS,
+  settings,
+  labels,
+}) => {
   data = sortTimeSeries(data);
   const colors = settings?.colors;
   const yTickWidth = getYTickWidth(data, accessors, settings, layout.font.size);
@@ -153,6 +154,5 @@ const TimeSeriesWaterfallChart = ({ data, accessors, settings, labels }) => {
 };
 
 TimeSeriesWaterfallChart.propTypes = propTypes;
-TimeSeriesWaterfallChart.defaultProps = defaultProps;
 
 export default TimeSeriesWaterfallChart;

--- a/frontend/src/metabase/static-viz/components/TimeSeriesWaterfallChart/TimeSeriesWaterfallChart.jsx
+++ b/frontend/src/metabase/static-viz/components/TimeSeriesWaterfallChart/TimeSeriesWaterfallChart.jsx
@@ -39,6 +39,10 @@ const propTypes = {
   }),
 };
 
+const defaultProps = {
+  accessors: DATE_ACCESSORS,
+};
+
 const layout = {
   width: 540,
   height: 300,
@@ -67,12 +71,7 @@ const layout = {
   strokeDasharray: "4",
 };
 
-const TimeSeriesWaterfallChart = ({
-  data,
-  accessors = DATE_ACCESSORS,
-  settings,
-  labels,
-}) => {
+const TimeSeriesWaterfallChart = ({ data, accessors, settings, labels }) => {
   data = sortTimeSeries(data);
   const colors = settings?.colors;
   const yTickWidth = getYTickWidth(data, accessors, settings, layout.font.size);
@@ -154,5 +153,6 @@ const TimeSeriesWaterfallChart = ({
 };
 
 TimeSeriesWaterfallChart.propTypes = propTypes;
+TimeSeriesWaterfallChart.defaultProps = defaultProps;
 
 export default TimeSeriesWaterfallChart;

--- a/frontend/src/metabase/static-viz/components/TimeSeriesWaterfallChart/constants.ts
+++ b/frontend/src/metabase/static-viz/components/TimeSeriesWaterfallChart/constants.ts
@@ -12,10 +12,6 @@ export const TIME_SERIES_WATERFALL_CHART_DEFAULT_OPTIONS = {
     ["2020-10-27", 20],
     ["2020-10-28", -15],
   ],
-  accessors: {
-    x: (row: any[]) => new Date(row[0]).valueOf(),
-    y: (row: any[]) => row[1],
-  },
   labels: {
     left: "Count",
     bottom: "Created At",

--- a/frontend/src/metabase/static-viz/constants/accessors.ts
+++ b/frontend/src/metabase/static-viz/constants/accessors.ts
@@ -1,0 +1,14 @@
+export const POSITIONAL_ACCESSORS = {
+  x: (row: any[]) => row[0],
+  y: (row: any[]) => row[1],
+};
+
+export const DATE_ACCESSORS = {
+  x: (row: any[]) => new Date(row[0]).valueOf(),
+  y: (row: any[]) => row[1],
+};
+
+export const DIMENSION_ACCESSORS = {
+  dimension: (row: any[]) => row[0],
+  metric: (row: any[]) => row[1],
+};

--- a/frontend/src/metabase/static-viz/containers/StaticChart/StaticChart.unit.spec.js
+++ b/frontend/src/metabase/static-viz/containers/StaticChart/StaticChart.unit.spec.js
@@ -12,10 +12,6 @@ describe("StaticChart", () => {
             ["Gadget", 20],
             ["Widget", 31],
           ],
-          accessors: {
-            x: row => row[0],
-            y: row => row[1],
-          },
           settings: {
             y: {
               number_style: "currency",
@@ -46,10 +42,6 @@ describe("StaticChart", () => {
             ["Gadget", 20],
             ["Widget", 31],
           ],
-          accessors: {
-            x: row => row[0],
-            y: row => row[1],
-          },
           settings: {
             y: {
               number_style: "currency",
@@ -80,10 +72,6 @@ describe("StaticChart", () => {
             ["Gadget", 20],
             ["Widget", 31],
           ],
-          accessors: {
-            x: row => row[0],
-            y: row => row[1],
-          },
           settings: {
             y: {
               number_style: "currency",
@@ -118,10 +106,6 @@ describe("StaticChart", () => {
             donut: "#509EE3",
             cronut: "#DDECFA",
           },
-          accessors: {
-            dimension: row => row[0],
-            metric: row => row[1],
-          },
           settings: {
             metric: {
               number_style: "currency",
@@ -146,10 +130,6 @@ describe("StaticChart", () => {
             ["2010-11-07", 20],
             ["2020-11-08", 30],
           ],
-          accessors: {
-            x: row => new Date(row[0]).valueOf(),
-            y: row => row[1],
-          },
           settings: {
             x: {
               date_style: "dddd",
@@ -176,10 +156,6 @@ describe("StaticChart", () => {
             ["2010-11-07", 20],
             ["2020-11-08", 30],
           ],
-          accessors: {
-            x: row => new Date(row[0]).valueOf(),
-            y: row => row[1],
-          },
           settings: {
             x: {
               date_style: "MMM",
@@ -206,10 +182,6 @@ describe("StaticChart", () => {
             ["2010-11-07", 20],
             ["2020-11-08", 30],
           ],
-          accessors: {
-            x: row => new Date(row[0]).valueOf(),
-            y: row => row[1],
-          },
           settings: {
             x: {
               date_style: "dddd",

--- a/frontend/src/metabase/static-viz/lib/waterfall.unit.spec.js
+++ b/frontend/src/metabase/static-viz/lib/waterfall.unit.spec.js
@@ -1,9 +1,5 @@
+import { POSITIONAL_ACCESSORS } from "../constants/accessors";
 import { calculateWaterfallEntries } from "./waterfall";
-
-const accessors = {
-  x: row => row[0],
-  y: row => row[1],
-};
 
 describe("calculateWaterfallEntries", () => {
   it("calculates waterfall entries without total", () => {
@@ -12,7 +8,11 @@ describe("calculateWaterfallEntries", () => {
       ["2", -50],
       ["3", 10],
     ];
-    const entries = calculateWaterfallEntries(data, accessors, false);
+    const entries = calculateWaterfallEntries(
+      data,
+      POSITIONAL_ACCESSORS,
+      false,
+    );
 
     expect(entries).toStrictEqual([
       {
@@ -42,7 +42,7 @@ describe("calculateWaterfallEntries", () => {
       ["2", -50],
       ["3", 10],
     ];
-    const entries = calculateWaterfallEntries(data, accessors, true);
+    const entries = calculateWaterfallEntries(data, POSITIONAL_ACCESSORS, true);
 
     expect(entries).toStrictEqual([
       {
@@ -79,7 +79,7 @@ describe("calculateWaterfallEntries", () => {
       ["2", -200],
       ["3", 50],
     ];
-    const entries = calculateWaterfallEntries(data, accessors, true);
+    const entries = calculateWaterfallEntries(data, POSITIONAL_ACCESSORS, true);
 
     expect(entries).toStrictEqual([
       {

--- a/resources/frontend_shared/static_viz_interface.js
+++ b/resources/frontend_shared/static_viz_interface.js
@@ -14,26 +14,10 @@ function toJSMap(m) {
   return o;
 }
 
-const date_accessors = {
-  x: row => new Date(row[0]).valueOf(),
-  y: row => row[1],
-};
-
-const positional_accessors = {
-  x: row => row[0],
-  y: row => row[1],
-};
-
-const dimension_accessors = {
-  dimension: row => row[0],
-  metric: row => row[1],
-};
-
 function timeseries_line(data, labels, settings) {
   return StaticViz.RenderChart("timeseries/line", {
     data: toJSArray(data),
     labels: toJSMap(labels),
-    accessors: date_accessors,
     settings: JSON.parse(settings),
   });
 }
@@ -42,7 +26,6 @@ function timeseries_bar(data, labels, settings) {
   return StaticViz.RenderChart("timeseries/bar", {
     data: toJSArray(data),
     labels: toJSMap(labels),
-    accessors: date_accessors,
     settings: JSON.parse(settings),
   });
 }
@@ -51,7 +34,6 @@ function timeseries_area(data, labels, settings) {
   return StaticViz.RenderChart("timeseries/area", {
     data: toJSArray(data),
     labels: toJSMap(labels),
-    accessors: date_accessors,
     settings: JSON.parse(settings),
   });
 }
@@ -69,7 +51,6 @@ function timeseries_waterfall(data, labels, settings) {
   return StaticViz.RenderChart("timeseries/waterfall", {
     data: toJSArray(data),
     labels: toJSMap(labels),
-    accessors: date_accessors,
     settings: JSON.parse(settings),
   });
 }
@@ -85,7 +66,6 @@ function categorical_bar(data, labels, settings) {
   return StaticViz.RenderChart("categorical/bar", {
     data: toJSArray(data),
     labels: toJSMap(labels),
-    accessors: positional_accessors,
     settings: JSON.parse(settings),
   });
 }
@@ -94,7 +74,6 @@ function categorical_area(data, labels, settings) {
   return StaticViz.RenderChart("categorical/area", {
     data: toJSArray(data),
     labels: toJSMap(labels),
-    accessors: positional_accessors,
     settings: JSON.parse(settings),
   });
 }
@@ -103,7 +82,6 @@ function categorical_line(data, labels, settings) {
   return StaticViz.RenderChart("categorical/line", {
     data: toJSArray(data),
     labels: toJSMap(labels),
-    accessors: positional_accessors,
     settings: JSON.parse(settings),
   });
 }
@@ -112,7 +90,6 @@ function categorical_donut(rows, colors) {
   return StaticViz.RenderChart("categorical/donut", {
     data: toJSArray(rows),
     colors: toJSMap(colors),
-    accessors: dimension_accessors,
   });
 }
 
@@ -120,7 +97,6 @@ function categorical_waterfall(data, labels, settings) {
   return StaticViz.RenderChart("categorical/waterfall", {
     data: toJSArray(data),
     labels: toJSMap(labels),
-    accessors: positional_accessors,
     settings: JSON.parse(settings),
   });
 }


### PR DESCRIPTION
__Context__
Most of the static chart components use an `accessors` property:
- it has various attributes based on its type: `date`, `position` or `dimension`
- its attributes are JS methods
- `accessors` are fairly constants to the point where they are [hardcoded](https://github.com/metabase/metabase/blob/master/resources/frontend_shared/static_viz_interface.js#L17-L30) in the BE to render `static viz` charts

__Problems__
- They are redefined for every chart components and passed as a mandatory argument
- They cannot be edited out of the box in the simple editor to test the chart or `storybook`

__Solution__
- Create `constants` for the 3 types of accessors
- Keep the `accessors` argument available while not required

__Notes__
There should not be any visual changes.