### PR TITLE
SQL editor: explicit trigger of autocomplete

### DIFF
--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
@@ -40,6 +40,8 @@ import {
 
 import "./NativeQueryEditor.css";
 
+const AUTOCOMPLETE_DEBOUNCE_DURATION = 700;
+
 @ExplicitSize()
 @Snippets.loadList({ loadingAndErrorWrapper: false })
 @SnippetCollections.loadList({ loadingAndErrorWrapper: false })
@@ -336,6 +338,12 @@ export default class NativeQueryEditor extends Component {
     }
   }
 
+  _retriggerAutocomplete = _.debounce(() => {
+    if (this._editor.completer?.popup?.isOpen) {
+      this._editor.execCommand("startAutocomplete");
+    }
+  }, AUTOCOMPLETE_DEBOUNCE_DURATION);
+
   onChange() {
     const { query } = this.props;
     if (this._editor && !this._localUpdate) {
@@ -347,6 +355,8 @@ export default class NativeQueryEditor extends Component {
           .update(this.props.setDatasetQuery);
       }
     }
+
+    this._retriggerAutocomplete();
   }
 
   toggleEditor = () => {

--- a/frontend/test/metabase/scenarios/native/reproductions/20625-prefix-match.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/reproductions/20625-prefix-match.cy.spec.js
@@ -1,0 +1,24 @@
+import { restore, openNativeEditor } from "__support__/e2e/cypress";
+
+describe("issue 20625", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsNormalUser();
+    cy.intercept("GET", "/api/database/*/autocomplete_suggestions**").as(
+      "autocomplete",
+    );
+  });
+
+  it("should continue to request more prefix matches (metabase#20625)", () => {
+    openNativeEditor().type("s");
+
+    // autocomplete_suggestions?prefix=s
+    cy.wait("@autocomplete");
+
+    // can't use cy.type because it does not simulate the bug
+    cy.realPress("o");
+
+    // autocomplete_suggestions?prefix=so
+    cy.wait("@autocomplete");
+  });
+});


### PR DESCRIPTION
How to verify:

Do the following while opening DevTools and watching the Network panel (filter for Fetch/XHR only)

1. New, Native/SQL query, Sample Database
2. Type `p` and watch the call to `/api/database/1/autocomplete_suggestions?prefix=p`

![image](https://user-images.githubusercontent.com/7288/157934901-b9ed40ce-3b50-4403-b842-4ceeb4326e5a.png)


3. Now continue to add more characters, e.g. so that the input becomes `pass`

**Before this PR**

Note that there is no more call to `/api/database/1/autocomplete_suggestions`. This is evident from that Network panel.

The reason is that Ace (or the way we use it) assumes that the matches from the completer (see the above screenshots, an array from `PEOPLE` to `PRODUCT_ID`) are impartial (i.e. the result is complete, not just a subset) and time-invariant (i.e. the result won't change over time). Therefore, when `pass` is the input, Ace does not try to trigger the completer again. Instead, it will go through the previous matches and try to find a match with `pass`.

**After this PR**

Whenever the input is changed **and** there is a completion popup, we fire off an explicit request for autocomplete. This forces Ace to invoke the completer again, hence why there is a subsequent API call to `/api/database/1/autocomplete_suggestions?prefix=pass`:

![image](https://user-images.githubusercontent.com/7288/157934852-34f59004-e2ee-465b-9649-1c143800a1c2.png)
