### PR TITLE
Add metadata info popovers to dimension icons in the query builder

### DIFF
--- a/frontend/src/metabase/components/MetadataInfo/TableInfoPopover/TableInfoPopover.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/TableInfoPopover/TableInfoPopover.tsx
@@ -18,7 +18,7 @@ interface TableSubset {
 
 const propTypes = {
   table: PropTypes.shape({
-    id: PropTypes.oneOf([PropTypes.number, PropTypes.string]),
+    id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     description: PropTypes.string,
   }).isRequired,
   children: PropTypes.node,

--- a/frontend/src/metabase/query_builder/components/DimensionList.jsx
+++ b/frontend/src/metabase/query_builder/components/DimensionList.jsx
@@ -7,6 +7,7 @@ import AccordionList from "metabase/core/components/AccordionList";
 import Icon from "metabase/components/Icon";
 import PopoverWithTrigger from "metabase/components/PopoverWithTrigger";
 import Tooltip from "metabase/components/Tooltip";
+import DimensionInfoPopover from "metabase/components/MetadataInfo/DimensionInfoPopover";
 
 import { FieldDimension } from "metabase-lib/lib/Dimension";
 import { DimensionPicker } from "./DimensionPicker";
@@ -172,6 +173,19 @@ export default class DimensionList extends Component {
     );
   }
 
+  renderItemIcon = item => {
+    if (item.dimension) {
+      const dimension = this._getDimensionFromItem(item);
+      if (dimension) {
+        return (
+          <DimensionInfoPopover dimension={dimension}>
+            <Icon name={dimension.icon()} size={18} />
+          </DimensionInfoPopover>
+        );
+      }
+    }
+  };
+
   _getDimensionFromItem(item) {
     const {
       enableSubDimensions,
@@ -235,6 +249,7 @@ export default class DimensionList extends Component {
         onChange={this.handleChange}
         itemIsSelected={this.itemIsSelected}
         renderItemExtra={this.renderItemExtra}
+        renderItemIcon={this.renderItemIcon}
         getItemClassName={() => "hover-parent hover--display"}
       />
     );

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.jsx
@@ -6,6 +6,7 @@ import { color } from "metabase/lib/colors";
 
 import Icon from "metabase/components/Icon";
 import Popover from "metabase/components/Popover";
+import DimensionInfoPopover from "metabase/components/MetadataInfo/DimensionInfoPopover";
 
 import { ListItemStyled, UlStyled } from "./ExpressionEditorSuggestions.styled";
 
@@ -98,6 +99,15 @@ export default class ExpressionEditorSuggestions extends React.Component {
             const { icon } = suggestion;
             const { normal, highlighted } = colorForIcon(icon);
 
+            const iconComponent = (
+              <Icon
+                name={icon}
+                color={isHighlighted ? highlighted : normal}
+                size="14"
+                className="mr1"
+              />
+            );
+
             const key = `$suggstion-${i}`;
             const listItem = (
               <ListItemStyled
@@ -105,12 +115,13 @@ export default class ExpressionEditorSuggestions extends React.Component {
                 isHighlighted={isHighlighted}
                 className="flex align-center px2 cursor-pointer text-white-hover bg-brand-hover hover-parent hover--inherit"
               >
-                <Icon
-                  name={icon}
-                  color={isHighlighted ? highlighted : normal}
-                  size="14"
-                  className="mr1"
-                />
+                {suggestion.dimension ? (
+                  <DimensionInfoPopover dimension={suggestion.dimension}>
+                    {iconComponent}
+                  </DimensionInfoPopover>
+                ) : (
+                  iconComponent
+                )}
                 <SuggestionSpan
                   suggestion={suggestion}
                   isHighlighted={isHighlighted}

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/DimensionList/DimensionListItem/DimensionListItem.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/DimensionList/DimensionListItem/DimensionListItem.jsx
@@ -6,6 +6,7 @@ import Tooltip from "metabase/components/Tooltip";
 import PopoverWithTrigger from "metabase/components/PopoverWithTrigger";
 import { DimensionPicker } from "metabase/query_builder/components/DimensionPicker";
 import Icon from "metabase/components/Icon";
+import DimensionInfoPopover from "metabase/components/MetadataInfo/DimensionInfoPopover";
 
 import { getSelectedSubDimensionName } from "../utils";
 
@@ -76,7 +77,9 @@ export const DimensionListItem = ({
     >
       <DimensionListItemContent>
         <DimensionListItemTitleContainer onClick={handleChange}>
-          <DimensionListItemIcon name={iconName} size={18} />
+          <DimensionInfoPopover dimension={dimension}>
+            <DimensionListItemIcon name={iconName} size={18} />
+          </DimensionInfoPopover>
           <DimensionListItemTitle data-testid="dimension-list-item-name">
             {name}
           </DimensionListItemTitle>


### PR DESCRIPTION
This PR adds `DimensionInfoPopover` back to various lists of dimensions found in the query builder, this time when hovering over the icon of a dimension instead of the entire list item.

I've added the popover back to the following places in the notebook view of the QB:
1. Dimensions in the "Add filters to narrow your answer" button popover
2. Dimensions in the "Pick the metric you want to see" button popover
3. Dimensions in the "Pick a column to group by" button popover
4. Dimensions that appear in the custom expression suggestion list

And in the simple view of the QB:
1. Dimensions in the Filter sidebar
2. Dimensions in the Summarize sidebar

FYI: Simple mode also already shows the DimensionInfoPopover when hovering over the _entire_ column header when looking at a Table visualization and the TableInfoPopover when hovering over the table name found in the header of a saved question. These haven't changed.

**Testing**
1. Go to one of the places listed above
2. Hover mouse over the icon and wait for a popover to appear (should take 1 second)
4. If there are other types of objects (eg functions in the custom expression popover or segments/metrics in some of the other popovers), hovering over the icon should do nothing