### PR TITLE
Fix `[:relative-datetime :current]` inside `:between` filter clause

### DIFF
--- a/shared/src/metabase/mbql/util.cljc
+++ b/shared/src/metabase/mbql/util.cljc
@@ -240,9 +240,12 @@
   `<unit>` is inferred from the `:field` the clause is being compared to (if any), otherwise falls back to `default.`"
   [m]
   (mbql.match/replace m
-    [clause field [:relative-datetime :current & _]]
-    [clause field [:relative-datetime 0 (or (mbql.match/match-one field [:field _ (opts :guard :temporal-unit)] (:temporal-unit opts))
-                                            :default)]]))
+    [clause field & (args :guard (partial some (partial = [:relative-datetime :current])))]
+    (let [temporal-unit (or (mbql.match/match-one field [:field _ {:temporal-unit temporal-unit}] temporal-unit)
+                            :default)]
+      (into [clause field] (mbql.match/replace args
+                             [:relative-datetime :current]
+                             [:relative-datetime 0 temporal-unit])))))
 
 (s/defn desugar-filter-clause :- mbql.s/Filter
   "Rewrite various 'syntatic sugar' filter clauses like `:time-interval` and `:inside` as simpler, logically

--- a/shared/test/metabase/mbql/util_test.cljc
+++ b/shared/test/metabase/mbql/util_test.cljc
@@ -307,7 +307,7 @@
       (doseq [x    [relative absolute]
               y    [relative absolute]
               unit [:week :default]]
-        (t/testing (pr-str [:between 'field relative absolute])
+        (t/testing (pr-str [:between 'field x y])
           (t/is (= [:between
                     [:field 1 {:temporal-unit unit}]
                     (expected x unit)

--- a/shared/test/metabase/mbql/util_test.cljc
+++ b/shared/test/metabase/mbql/util_test.cljc
@@ -296,6 +296,28 @@
                [:field 1 {:temporal-unit :week, :binning {:strategy :default}}]
                [:relative-datetime :current]])))))
 
+(t/deftest relative-datetime-current-inside-between-test
+  (t/testing ":relative-datetime should work inside a :between clause (#19606)\n"
+    (let [absolute "2022-03-11T15:48:00-08:00"
+          relative [:relative-datetime :current]
+          expected (fn [v unit]
+                     (condp = v
+                       absolute absolute
+                       relative [:relative-datetime 0 unit]))]
+      (doseq [x    [relative absolute]
+              y    [relative absolute]
+              unit [:week :default]]
+        (t/testing (pr-str [:between 'field relative absolute])
+          (t/is (= [:between
+                    [:field 1 {:temporal-unit unit}]
+                    (expected x unit)
+                    (expected y unit)]
+                   (mbql.u/desugar-filter-clause
+                    [:between
+                     [:field 1 {:temporal-unit unit}]
+                     x
+                     y]))))))))
+
 (t/deftest ^:parallel desugar-other-filter-clauses-test
   (t/testing "desugaring := and :!= with extra args"
     (t/is (= [:or

--- a/shared/test/metabase/mbql/util_test.cljc
+++ b/shared/test/metabase/mbql/util_test.cljc
@@ -307,7 +307,7 @@
       (doseq [x    [relative absolute]
               y    [relative absolute]
               unit [:week :default]]
-        (t/testing (pr-str [:between 'field x y])
+        (t/testing (pr-str [:between [:field 1 {:temporal-unit unit}] x y])
           (t/is (= [:between
                     [:field 1 {:temporal-unit unit}]
                     (expected x unit)

--- a/test/metabase/query_processor/middleware/desugar_test.clj
+++ b/test/metabase/query_processor/middleware/desugar_test.clj
@@ -2,8 +2,8 @@
   (:require [clojure.test :refer :all]
             [metabase.query-processor.middleware.desugar :as desugar]))
 
-;; actual desugaring logic and tests are in the MBQL lib
-(deftest e2e-test
+;; actual desugaring logic and tests are in [[metabase.mbql.util-test]]
+(deftest ^:parallel e2e-test
   (is (= {:database 1
           :type     :query
           :query    {:source-table 1


### PR DESCRIPTION
Fixes #19606

The filter desugar logic incorrectly assumed all filter clauses were of the form `[operator field value]` and did not handle clauses like `:between` that allow multiple values.