### PR TITLE
Fix error in send-abandonment-emails task

### DIFF
--- a/src/metabase/core.clj
+++ b/src/metabase/core.clj
@@ -39,6 +39,7 @@
         (str (deferred-trs "Metabase Enterprise Edition extensions are PRESENT.")
              "\n\n"
              (deferred-trs "Usage of Metabase Enterprise Edition features are subject to the Metabase Commercial License.")
+             " "
              (deferred-trs "See {0} for details." "https://www.metabase.com/license/commercial/"))
         (deferred-trs "Metabase Enterprise Edition extensions are NOT PRESENT."))))
 

--- a/test/metabase/task/follow_up_emails_test.clj
+++ b/test/metabase/task/follow_up_emails_test.clj
@@ -20,6 +20,9 @@
              (-> @inbox vals first count))))))
 
 (deftest should-send-abandoment-email-test
+  (testing "Make sure zero-arity version works (#12068)"
+    (testing `(follow-up-emails/should-send-abandoment-email?)
+      (is (boolean? (#'follow-up-emails/should-send-abandoment-email?)))))
   (testing "Conditions where abandonment emails should be sent"
     (doseq [now               [(t/zoned-date-time) (t/offset-date-time) (t/instant)]
             instance-creation [0 1 5 nil]


### PR DESCRIPTION
Fixes #12068

There was a bug here where we were passing in maps like `{:last-user <Temporal>}` to a function that expected `<Temporal>`... easy fix.