### PR TITLE
Binning should not error for datasets with only a single row

### DIFF
--- a/src/metabase/query_processor/middleware/binning.clj
+++ b/src/metabase/query_processor/middleware/binning.clj
@@ -63,9 +63,12 @@
 
 (s/defn ^:private calculate-num-bins :- su/IntGreaterThanZero
   "Calculate number of bins of width `bin-width` required to cover interval [`min-value`, `max-value`]."
-  [min-value :- s/Num, max-value :- s/Num, bin-width :- (s/constrained s/Num (complement neg?) "number >= 0")]
-  (long (Math/ceil (/ (- max-value min-value)
-                      bin-width))))
+  [min-value :- s/Num
+   max-value :- s/Num
+   bin-width :- (s/constrained s/Num (complement neg?) "number >= 0")]
+  (max (long (Math/ceil (/ (- max-value min-value)
+                           bin-width)))
+       1))
 
 (s/defn ^:private resolve-default-strategy :- [(s/one (s/enum :bin-width :num-bins) "strategy")
                                                (s/one {:bin-width s/Num, :num-bins su/IntGreaterThanZero} "opts")]

--- a/test/metabase/test/data/interface.clj
+++ b/test/metabase/test/data/interface.clj
@@ -408,7 +408,7 @@
 ;; TODO - not sure everything below belongs in this namespace
 
 (s/defn ^:private dataset-field-definition :- ValidFieldDefinition
-  [{:keys [coercion-strategy base-type] :as field-definition-map} :- DatasetFieldDefinition]
+  [field-definition-map :- DatasetFieldDefinition]
   "Parse a Field definition (from a `defdatset` form or EDN file) and return a FieldDefinition instance for
   comsumption by various test-data-loading methods."
   ;; if definition uses a coercion strategy they need to provide the effective-type


### PR DESCRIPTION
Fixes #13914

The coordinates being negative was a red herring. The failing example @flamber provided in #13914 only failed because we calculated the number of bins by doing `(/ (- max min) bin-size)` and when there's only one row, `(/ (- x x) bin-size)` equals `(/ 0 bin-size)` equals `0`. (Just to clarify, I also tested this with multiple rows with negative coordinates, which worked even before this PR.) The fix here is to fallback to one bin rather than failing entirely -- seems a little weird but I don't know how else we could possibly bin a single row.