### PR TITLE
feature level permission based routing

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/index.ts
@@ -1,0 +1,13 @@
+import { hasPremiumFeature } from "metabase-enterprise/settings";
+import { PLUGIN_FEATURE_LEVEL_PERMISSIONS } from "metabase/plugins";
+import {
+  canAccessSettings,
+  canAccessDataModel,
+  canAccessDatabaseManagement,
+} from "./utils";
+
+if (hasPremiumFeature("advanced_permissions")) {
+  PLUGIN_FEATURE_LEVEL_PERMISSIONS.canAccessSettings = canAccessSettings;
+  PLUGIN_FEATURE_LEVEL_PERMISSIONS.canAccessDataModel = canAccessDataModel;
+  PLUGIN_FEATURE_LEVEL_PERMISSIONS.canAccessDatabaseManagement = canAccessDatabaseManagement;
+}

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/utils.ts
@@ -1,0 +1,10 @@
+import { User } from "metabase-types/api";
+
+export const canAccessSettings = (user: User) =>
+  canAccessDataModel(user) || canAccessDatabaseManagement(user);
+
+export const canAccessDataModel = (user?: User) =>
+  user?.can_access_data_model ?? false;
+
+export const canAccessDatabaseManagement = (user?: User) =>
+  user?.can_access_database_management ?? false;

--- a/enterprise/frontend/src/metabase-enterprise/plugins.js
+++ b/enterprise/frontend/src/metabase-enterprise/plugins.js
@@ -20,5 +20,6 @@ import "./sharing";
 import "./moderation";
 import "./advanced_config";
 import "./advanced_permissions";
+import "./feature_level_permissions";
 import "./audit_app";
 import "./license";

--- a/frontend/src/metabase-types/api/mocks/user.ts
+++ b/frontend/src/metabase-types/api/mocks/user.ts
@@ -14,6 +14,8 @@ export const createMockUser = ({
   personal_collection_id = 1,
   date_joined = new Date().toISOString(),
   last_login = new Date().toISOString(),
+  can_access_data_model = false,
+  can_access_database_management = false,
 }: Partial<User> = {}): User => ({
   id,
   common_name,
@@ -28,4 +30,6 @@ export const createMockUser = ({
   personal_collection_id,
   date_joined,
   last_login,
+  can_access_data_model,
+  can_access_database_management,
 });

--- a/frontend/src/metabase-types/api/user.ts
+++ b/frontend/src/metabase-types/api/user.ts
@@ -12,4 +12,6 @@ export interface User {
   last_login: string;
   has_invited_second_user: boolean;
   personal_collection_id: number;
+  can_access_data_model: boolean;
+  can_access_database_management: boolean;
 }

--- a/frontend/src/metabase/admin/permissions/routes.jsx
+++ b/frontend/src/metabase/admin/permissions/routes.jsx
@@ -13,7 +13,7 @@ import {
 } from "metabase/plugins";
 
 const getRoutes = () => (
-  <Route title={t`Permissions`} path="permissions">
+  <Route title={t`Permissions`}>
     <IndexRedirect to="data" />
 
     <Route path="data" component={DataPermissionsPage}>

--- a/frontend/src/metabase/admin/routes.jsx
+++ b/frontend/src/metabase/admin/routes.jsx
@@ -6,11 +6,16 @@ import { t } from "ttag";
 import {
   PLUGIN_ADMIN_ROUTES,
   PLUGIN_ADMIN_USER_MENU_ROUTES,
+  PLUGIN_FEATURE_LEVEL_PERMISSIONS,
 } from "metabase/plugins";
+
+import { routerActions } from "react-router-redux";
+import { UserAuthWrapper } from "redux-auth-wrapper";
 
 import { withBackground } from "metabase/hoc/Background";
 import { ModalRoute } from "metabase/hoc/ModalRoute";
 
+import RedirectToAllowedSettings from "./settings/containers/RedirectToAllowedSettings";
 import AdminApp from "metabase/admin/app/components/AdminApp";
 import NewUserModal from "metabase/admin/people/containers/NewUserModal";
 import UserSuccessModal from "metabase/admin/people/containers/UserSuccessModal";
@@ -54,10 +59,31 @@ import GroupDetailApp from "metabase/admin/people/containers/GroupDetailApp";
 // Permissions
 import getAdminPermissionsRoutes from "metabase/admin/permissions/routes";
 
-const getRoutes = (store, IsAdmin) => (
-  <Route path="/admin" component={withBackground("bg-white")(IsAdmin)}>
+const createRouteGuard = userPredicate => {
+  const Wrapper = UserAuthWrapper({
+    predicate: currentUser =>
+      currentUser?.is_superuser || userPredicate(currentUser),
+    failureRedirectPath: "/unauthorized",
+    authSelector: state => state.currentUser,
+    allowRedirectBack: false,
+    wrapperDisplayName: "RouteGuard",
+    redirectAction: routerActions.replace,
+  });
+
+  return Wrapper(({ children }) => children);
+};
+
+const DataModelGuard = createRouteGuard(
+  PLUGIN_FEATURE_LEVEL_PERMISSIONS.canAccessDataModel,
+);
+
+const getRoutes = (store, CanAccessSettings, IsAdmin) => (
+  <Route
+    path="/admin"
+    component={withBackground("bg-white")(CanAccessSettings)}
+  >
     <Route title={t`Admin`} component={AdminApp}>
-      <IndexRedirect to="settings" />
+      <IndexRoute component={RedirectToAllowedSettings} />
 
       <Route path="databases" title={t`Databases`}>
         <IndexRoute component={DatabaseListApp} />
@@ -65,92 +91,98 @@ const getRoutes = (store, IsAdmin) => (
         <Route path=":databaseId" component={DatabaseEditApp} />
       </Route>
 
-      <Route path="datamodel" title={t`Data Model`} component={DataModelApp}>
-        <IndexRedirect to="database" />
-        <Route path="database" component={MetadataEditorApp} />
-        <Route path="database/:databaseId" component={MetadataEditorApp} />
-        <Route
-          path="database/:databaseId/:mode"
-          component={MetadataEditorApp}
-        />
-        <Route
-          path="database/:databaseId/:mode/:tableId"
-          component={MetadataEditorApp}
-        />
-        <Route
-          path="database/:databaseId/:mode/:tableId/settings"
-          component={TableSettingsApp}
-        />
-        <Route path="database/:databaseId/:mode/:tableId/:fieldId">
-          <IndexRedirect to="general" />
-          <Route path=":section" component={FieldApp} />
+      <Route path="datamodel" component={DataModelGuard}>
+        <Route title={t`Data Model`} component={DataModelApp}>
+          <IndexRedirect to="database" />
+          <Route path="database" component={MetadataEditorApp} />
+          <Route path="database/:databaseId" component={MetadataEditorApp} />
+          <Route
+            path="database/:databaseId/:mode"
+            component={MetadataEditorApp}
+          />
+          <Route
+            path="database/:databaseId/:mode/:tableId"
+            component={MetadataEditorApp}
+          />
+          <Route
+            path="database/:databaseId/:mode/:tableId/settings"
+            component={TableSettingsApp}
+          />
+          <Route path="database/:databaseId/:mode/:tableId/:fieldId">
+            <IndexRedirect to="general" />
+            <Route path=":section" component={FieldApp} />
+          </Route>
+          <Route path="metrics" component={MetricListApp} />
+          <Route path="metric/create" component={MetricApp} />
+          <Route path="metric/:id" component={MetricApp} />
+          <Route path="segments" component={SegmentListApp} />
+          <Route path="segment/create" component={SegmentApp} />
+          <Route path="segment/:id" component={SegmentApp} />
+          <Route path=":entity/:id/revisions" component={RevisionHistoryApp} />
         </Route>
-        <Route path="metrics" component={MetricListApp} />
-        <Route path="metric/create" component={MetricApp} />
-        <Route path="metric/:id" component={MetricApp} />
-        <Route path="segments" component={SegmentListApp} />
-        <Route path="segment/create" component={SegmentApp} />
-        <Route path="segment/:id" component={SegmentApp} />
-        <Route path=":entity/:id/revisions" component={RevisionHistoryApp} />
       </Route>
 
       {/* PEOPLE */}
-      <Route path="people" title={t`People`} component={AdminPeopleApp}>
-        <IndexRoute component={PeopleListingApp} />
+      <Route path="people" component={IsAdmin}>
+        <Route title={t`People`} component={AdminPeopleApp}>
+          <IndexRoute component={PeopleListingApp} />
 
-        {/*NOTE: this must come before the other routes otherwise it will be masked by them*/}
-        <Route path="groups" title={t`Groups`}>
-          <IndexRoute component={GroupsListingApp} />
-          <Route path=":groupId" component={GroupDetailApp} />
-        </Route>
+          {/*NOTE: this must come before the other routes otherwise it will be masked by them*/}
+          <Route path="groups" title={t`Groups`}>
+            <IndexRoute component={GroupsListingApp} />
+            <Route path=":groupId" component={GroupDetailApp} />
+          </Route>
 
-        <Route path="" component={PeopleListingApp}>
-          <ModalRoute path="new" modal={NewUserModal} />
-        </Route>
+          <Route path="" component={PeopleListingApp}>
+            <ModalRoute path="new" modal={NewUserModal} />
+          </Route>
 
-        <Route path=":userId" component={PeopleListingApp}>
-          <ModalRoute path="edit" modal={EditUserModal} />
-          <ModalRoute path="success" modal={UserSuccessModal} />
-          <ModalRoute path="reset" modal={UserPasswordResetModal} />
-          <ModalRoute path="deactivate" modal={UserActivationModal} />
-          <ModalRoute path="reactivate" modal={UserActivationModal} />
-          {PLUGIN_ADMIN_USER_MENU_ROUTES.map(getRoutes => getRoutes(store))}
+          <Route path=":userId" component={PeopleListingApp}>
+            <ModalRoute path="edit" modal={EditUserModal} />
+            <ModalRoute path="success" modal={UserSuccessModal} />
+            <ModalRoute path="reset" modal={UserPasswordResetModal} />
+            <ModalRoute path="deactivate" modal={UserActivationModal} />
+            <ModalRoute path="reactivate" modal={UserActivationModal} />
+            {PLUGIN_ADMIN_USER_MENU_ROUTES.map(getRoutes => getRoutes(store))}
+          </Route>
         </Route>
       </Route>
 
       {/* Troubleshooting */}
-      <Route
-        path="troubleshooting"
-        title={t`Troubleshooting`}
-        component={TroubleshootingApp}
-      >
-        <IndexRedirect to="help" />
-        <Route path="help" component={Help} />
-        <Route path="tasks" component={TasksApp}>
-          <ModalRoute path=":taskId" modal={TaskModal} />
+      <Route path="troubleshooting" component={IsAdmin}>
+        <Route title={t`Troubleshooting`} component={TroubleshootingApp}>
+          <IndexRedirect to="help" />
+          <Route path="help" component={Help} />
+          <Route path="tasks" component={TasksApp}>
+            <ModalRoute path=":taskId" modal={TaskModal} />
+          </Route>
+          <Route path="jobs" component={JobInfoApp}>
+            <ModalRoute
+              path=":jobKey"
+              modal={JobTriggersModal}
+              modalProps={{ wide: true }}
+            />
+          </Route>
+          <Route path="logs" component={Logs} />
         </Route>
-        <Route path="jobs" component={JobInfoApp}>
-          <ModalRoute
-            path=":jobKey"
-            modal={JobTriggersModal}
-            modalProps={{ wide: true }}
-          />
-        </Route>
-        <Route path="logs" component={Logs} />
       </Route>
 
       {/* SETTINGS */}
-      <Route path="settings" title={t`Settings`}>
-        <IndexRedirect to="setup" />
-        <Route
-          path="premium-embedding-license"
-          component={PremiumEmbeddingLicensePage}
-        />
-        <Route path="*" component={SettingsEditorApp} />
+      <Route path="settings" component={IsAdmin}>
+        <Route title={t`Settings`}>
+          <IndexRedirect to="setup" />
+          <Route
+            path="premium-embedding-license"
+            component={PremiumEmbeddingLicensePage}
+          />
+          <Route path="*" component={SettingsEditorApp} />
+        </Route>
       </Route>
 
       {/* PERMISSIONS */}
-      <React.Fragment>{getAdminPermissionsRoutes(store)}</React.Fragment>
+      <Route path="permissions" component={IsAdmin}>
+        {getAdminPermissionsRoutes(store)}
+      </Route>
 
       {/* PLUGINS */}
       <React.Fragment>

--- a/frontend/src/metabase/admin/routes.jsx
+++ b/frontend/src/metabase/admin/routes.jsx
@@ -6,11 +6,7 @@ import { t } from "ttag";
 import {
   PLUGIN_ADMIN_ROUTES,
   PLUGIN_ADMIN_USER_MENU_ROUTES,
-  PLUGIN_FEATURE_LEVEL_PERMISSIONS,
 } from "metabase/plugins";
-
-import { routerActions } from "react-router-redux";
-import { UserAuthWrapper } from "redux-auth-wrapper";
 
 import { withBackground } from "metabase/hoc/Background";
 import { ModalRoute } from "metabase/hoc/ModalRoute";
@@ -59,25 +55,13 @@ import GroupDetailApp from "metabase/admin/people/containers/GroupDetailApp";
 // Permissions
 import getAdminPermissionsRoutes from "metabase/admin/permissions/routes";
 
-const createRouteGuard = userPredicate => {
-  const Wrapper = UserAuthWrapper({
-    predicate: currentUser =>
-      currentUser?.is_superuser || userPredicate(currentUser),
-    failureRedirectPath: "/unauthorized",
-    authSelector: state => state.currentUser,
-    allowRedirectBack: false,
-    wrapperDisplayName: "RouteGuard",
-    redirectAction: routerActions.replace,
-  });
-
-  return Wrapper(({ children }) => children);
-};
-
-const DataModelGuard = createRouteGuard(
-  PLUGIN_FEATURE_LEVEL_PERMISSIONS.canAccessDataModel,
-);
-
-const getRoutes = (store, CanAccessSettings, IsAdmin) => (
+const getRoutes = (
+  store,
+  CanAccessSettings,
+  IsAdmin,
+  CanAccessDataModel,
+  CanAccessDatabaseManagement,
+) => (
   <Route
     path="/admin"
     component={withBackground("bg-white")(CanAccessSettings)}
@@ -85,13 +69,17 @@ const getRoutes = (store, CanAccessSettings, IsAdmin) => (
     <Route title={t`Admin`} component={AdminApp}>
       <IndexRoute component={RedirectToAllowedSettings} />
 
-      <Route path="databases" title={t`Databases`}>
+      <Route
+        path="databases"
+        title={t`Databases`}
+        component={CanAccessDatabaseManagement}
+      >
         <IndexRoute component={DatabaseListApp} />
         <Route path="create" component={DatabaseEditApp} />
         <Route path=":databaseId" component={DatabaseEditApp} />
       </Route>
 
-      <Route path="datamodel" component={DataModelGuard}>
+      <Route path="datamodel" component={CanAccessDataModel}>
         <Route title={t`Data Model`} component={DataModelApp}>
           <IndexRedirect to="database" />
           <Route path="database" component={MetadataEditorApp} />

--- a/frontend/src/metabase/admin/settings/containers/RedirectToAllowedSettings.jsx
+++ b/frontend/src/metabase/admin/settings/containers/RedirectToAllowedSettings.jsx
@@ -1,0 +1,34 @@
+import { connect } from "react-redux";
+import { push } from "react-router-redux";
+import { getUser } from "metabase/selectors/user";
+import { PLUGIN_FEATURE_LEVEL_PERMISSIONS } from "metabase/plugins";
+
+const mapStateToProps = (state, props) => ({
+  user: getUser(state),
+  path: props.location.pathname,
+});
+
+const mapDispatchToProps = {
+  push,
+};
+
+const RedirectToAllowedSettings = ({ user, push }) => {
+  if (user.is_superuser) {
+    push("/admin/settings");
+  } else if (PLUGIN_FEATURE_LEVEL_PERMISSIONS.canAccessDataModel(user)) {
+    push("/admin/datamodel");
+  } else if (
+    PLUGIN_FEATURE_LEVEL_PERMISSIONS.canAccessDatabaseManagement(user)
+  ) {
+    push("/admin/databases");
+  } else if (user != null) {
+    push("/unauthorized");
+  }
+
+  return null;
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(RedirectToAllowedSettings);

--- a/frontend/src/metabase/nav/components/AdminNavbar/AdminNavbar.tsx
+++ b/frontend/src/metabase/nav/components/AdminNavbar/AdminNavbar.tsx
@@ -1,6 +1,9 @@
 import React from "react";
 import { t } from "ttag";
-import { PLUGIN_ADMIN_NAV_ITEMS } from "metabase/plugins";
+import {
+  PLUGIN_ADMIN_NAV_ITEMS,
+  PLUGIN_FEATURE_LEVEL_PERMISSIONS,
+} from "metabase/plugins";
 import MetabaseSettings from "metabase/lib/settings";
 import { AdminNavItem } from "./AdminNavItem";
 import StoreLink from "../StoreLink";
@@ -13,12 +16,21 @@ import {
   AdminNavbarItems,
   AdminNavbarRoot,
 } from "./AdminNavbar.styled";
+import { User } from "metabase-types/types/User";
 
 interface AdminNavbarProps {
   path: string;
+  user: User;
 }
 
-export const AdminNavbar = ({ path: currentPath }: AdminNavbarProps) => {
+export const AdminNavbar = ({ path: currentPath, user }: AdminNavbarProps) => {
+  const isAdmin = user.is_superuser;
+  const canAccessDataModel =
+    isAdmin || PLUGIN_FEATURE_LEVEL_PERMISSIONS.canAccessDataModel(user);
+  const canAccessDatabaseManagement =
+    isAdmin ||
+    PLUGIN_FEATURE_LEVEL_PERMISSIONS.canAccessDatabaseManagement(user);
+
   return (
     <AdminNavbarRoot className="Nav">
       <AdminLogoLink to="/admin" data-metabase-event={"Navbar;Logo"}>
@@ -29,50 +41,67 @@ export const AdminNavbar = ({ path: currentPath }: AdminNavbarProps) => {
       </AdminLogoLink>
 
       <AdminNavbarItems>
-        <AdminNavItem
-          name={t`Settings`}
-          path="/admin/settings"
-          currentPath={currentPath}
-          key="admin-nav-settings"
-        />
-        <AdminNavItem
-          name={t`People`}
-          path="/admin/people"
-          currentPath={currentPath}
-          key="admin-nav-people"
-        />
-        <AdminNavItem
-          name={t`Data Model`}
-          path="/admin/datamodel"
-          currentPath={currentPath}
-          key="admin-nav-datamodel"
-        />
-        <AdminNavItem
-          name={t`Databases`}
-          path="/admin/databases"
-          currentPath={currentPath}
-          key="admin-nav-databases"
-        />
-        <AdminNavItem
-          name={t`Permissions`}
-          path="/admin/permissions"
-          currentPath={currentPath}
-          key="admin-nav-permissions"
-        />
-        {PLUGIN_ADMIN_NAV_ITEMS.map(({ name, path }) => (
+        {isAdmin && (
+          <>
+            <AdminNavItem
+              name={t`Settings`}
+              path="/admin/settings"
+              currentPath={currentPath}
+              key="admin-nav-settings"
+            />
+
+            <AdminNavItem
+              name={t`People`}
+              path="/admin/people"
+              currentPath={currentPath}
+              key="admin-nav-people"
+            />
+          </>
+        )}
+
+        {canAccessDataModel && (
           <AdminNavItem
-            name={name}
-            path={path}
+            name={t`Data Model`}
+            path="/admin/datamodel"
             currentPath={currentPath}
-            key={`admin-nav-${name}`}
+            key="admin-nav-datamodel"
           />
-        ))}
-        <AdminNavItem
-          name={t`Troubleshooting`}
-          path="/admin/troubleshooting"
-          currentPath={currentPath}
-          key="admin-nav-troubleshooting"
-        />
+        )}
+        {canAccessDatabaseManagement && (
+          <AdminNavItem
+            name={t`Databases`}
+            path="/admin/databases"
+            currentPath={currentPath}
+            key="admin-nav-databases"
+          />
+        )}
+
+        {isAdmin && (
+          <>
+            <AdminNavItem
+              name={t`Permissions`}
+              path="/admin/permissions"
+              currentPath={currentPath}
+              key="admin-nav-permissions"
+            />
+
+            {PLUGIN_ADMIN_NAV_ITEMS.map(({ name, path }) => (
+              <AdminNavItem
+                name={name}
+                path={path}
+                currentPath={currentPath}
+                key={`admin-nav-${name}`}
+              />
+            ))}
+
+            <AdminNavItem
+              name={t`Troubleshooting`}
+              path="/admin/troubleshooting"
+              currentPath={currentPath}
+              key="admin-nav-troubleshooting"
+            />
+          </>
+        )}
       </AdminNavbarItems>
 
       {!MetabaseSettings.isPaidPlan() && <StoreLink />}

--- a/frontend/src/metabase/nav/components/ProfileLink.jsx
+++ b/frontend/src/metabase/nav/components/ProfileLink.jsx
@@ -1,10 +1,11 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-
 import { t } from "ttag";
 import _ from "underscore";
+
 import { capitalize } from "metabase/lib/formatting";
 import { color, darken } from "metabase/lib/colors";
+import { PLUGIN_FEATURE_LEVEL_PERMISSIONS } from "metabase/plugins";
 
 import MetabaseSettings from "metabase/lib/settings";
 import * as Urls from "metabase/lib/urls";
@@ -35,7 +36,10 @@ export default class ProfileLink extends Component {
 
   generateOptionsForUser = () => {
     const { tag } = MetabaseSettings.get("version");
-    const admin = this.props.user.is_superuser;
+    const { user } = this.props;
+    const canAccessSettings =
+      user.is_superuser ||
+      PLUGIN_FEATURE_LEVEL_PERMISSIONS.canAccessSettings(user);
 
     return [
       {
@@ -44,7 +48,7 @@ export default class ProfileLink extends Component {
         link: Urls.accountSettings(),
         event: `Navbar;Profile Dropdown;Edit Profile`,
       },
-      admin && {
+      canAccessSettings && {
         title: t`Admin settings`,
         icon: null,
         link: "/admin",

--- a/frontend/src/metabase/nav/containers/Navbar.jsx
+++ b/frontend/src/metabase/nav/containers/Navbar.jsx
@@ -88,7 +88,7 @@ export default class Navbar extends Component {
   renderAdminNav() {
     return (
       <>
-        <AdminNavbar path={this.props.path} />
+        <AdminNavbar {...this.props} />
         {this.renderModal()}
       </>
     );

--- a/frontend/src/metabase/plugins/index.js
+++ b/frontend/src/metabase/plugins/index.js
@@ -106,3 +106,9 @@ export const PLUGIN_ADVANCED_PERMISSIONS = {
   addTablePermissionOptions: (permissions, _value) => permissions,
   isBlockPermission: _value => false,
 };
+
+export const PLUGIN_FEATURE_LEVEL_PERMISSIONS = {
+  canAccessSettings: _user => false,
+  canAccessDataModel: _user => false,
+  canAccessDatabaseManagement: _user => false,
+};

--- a/frontend/src/metabase/routes.jsx
+++ b/frontend/src/metabase/routes.jsx
@@ -1,6 +1,9 @@
 import React from "react";
 
-import { PLUGIN_LANDING_PAGE } from "metabase/plugins";
+import {
+  PLUGIN_LANDING_PAGE,
+  PLUGIN_FEATURE_LEVEL_PERMISSIONS,
+} from "metabase/plugins";
 
 import { Route } from "metabase/hoc/Title";
 import { Redirect, IndexRedirect, IndexRoute } from "react-router";
@@ -124,6 +127,17 @@ const UserIsNotAuthenticated = UserAuthWrapper({
   redirectAction: routerActions.replace,
 });
 
+const UserCanAccessSettings = UserAuthWrapper({
+  predicate: currentUser =>
+    currentUser?.is_superuser ||
+    PLUGIN_FEATURE_LEVEL_PERMISSIONS.canAccessSettings(currentUser),
+  failureRedirectPath: "/unauthorized",
+  authSelector: state => state.currentUser,
+  allowRedirectBack: false,
+  wrapperDisplayName: "UserCanAccessSettings",
+  redirectAction: routerActions.replace,
+});
+
 const IsAuthenticated = MetabaseIsSetup(
   UserIsAuthenticated(({ children }) => children),
 );
@@ -133,6 +147,10 @@ const IsAdmin = MetabaseIsSetup(
 
 const IsNotAuthenticated = MetabaseIsSetup(
   UserIsNotAuthenticated(({ children }) => children),
+);
+
+const CanAccessSettings = MetabaseIsSetup(
+  UserIsAuthenticated(UserCanAccessSettings(({ children }) => children)),
 );
 
 export const getRoutes = store => (
@@ -340,7 +358,7 @@ export const getRoutes = store => (
       {getAccountRoutes(store, IsAuthenticated)}
 
       {/* ADMIN */}
-      {getAdminRoutes(store, IsAdmin)}
+      {getAdminRoutes(store, CanAccessSettings, IsAdmin)}
     </Route>
 
     {/* INTERNAL */}


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/20380
[Product doc](https://www.notion.so/metabase/Add-feature-level-permissions-to-groups-8027685681774932ac7221131f061295)

Allows non-admin users to access admin settings: data model & database management

## How to verify

### OSS
Nothing should've changed


### Enterprise

#### Setup
**Option 1:** mock user API response and set `can_access_data_model` and `can_access_database_management` to true
**Option 2:** `enterprise/frontend/src/metabase-enterprise/feature_level_permissions/utils.ts`: change the following functions `canAccessDataModel` and `canAccessDatabaseManagement` to return `true` 

- Login as a non-admin user and open the main page
- Ensure when you mocked any of `can_access_data_model` or `can_access_database_management` the menu shows "Admin settings" item
- Ensure when you go to "Admin settings" it opens the first available tab

Revert mocks
- Ensure regular users have no access to the "Admin settings"
