### PR TITLE
Quarantine caching e2e tests

### DIFF
--- a/frontend/test/metabase/scenarios/admin/settings/cache.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/cache.cy.spec.js
@@ -6,7 +6,11 @@ import {
 
 const nativeQuery = "select (random() * random() * random()), pg_sleep(2)";
 
-describe("scenarios > admin > settings > cache", () => {
+/**
+ * Disabled and quarantined until we fix the caching issues, and especially:
+ * https://github.com/metabase/metabase/issues/13262
+ */
+describe.skip("scenarios > admin > settings > cache", () => {
   beforeEach(() => {
     cy.intercept("POST", "/api/dataset").as("dataset");
     cy.intercept("POST", "/api/card/*/query").as("cardQuery");


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Disables the intermittently failing caching e2e test
- Test was failing because we had to implement an ugly workaround for the #13262 
- Until we solve that issue, it makes no sense to run this test

### CI Failures
The example of the most recent failure in the CI
https://app.circleci.com/pipelines/github/metabase/metabase/30687/workflows/9181e88f-a5e3-44a3-b2e4-756864b2af2b/jobs/1539509/artifacts