### PR TITLE
Add event creation to the query builder

### DIFF
--- a/frontend/src/metabase/entities/timeline-events.js
+++ b/frontend/src/metabase/entities/timeline-events.js
@@ -1,12 +1,14 @@
 import { t } from "ttag";
 import { TimelineEventSchema } from "metabase/schema";
 import { createEntity, undo } from "metabase/lib/entities";
+import forms from "./timeline-events/forms";
 
 const TimelineEvents = createEntity({
   name: "timelineEvents",
   nameOne: "timelineEvent",
   path: "/api/timeline-event",
   schema: TimelineEventSchema,
+  forms,
 
   objectActions: {
     setArchived: ({ id }, archived, opts) =>

--- a/frontend/src/metabase/entities/timeline-events/forms.js
+++ b/frontend/src/metabase/entities/timeline-events/forms.js
@@ -3,7 +3,7 @@ import { hasTimePart, parseTimestamp } from "metabase/lib/time";
 import { getTimelineIcons } from "metabase/lib/timeline";
 import validate from "metabase/lib/validate";
 
-const createForm = () => {
+const createForm = ({ timelines }) => {
   return [
     {
       name: "name",
@@ -44,23 +44,24 @@ const createForm = () => {
     },
     {
       name: "timeline_id",
-      type: "hidden",
+      type: timelines.length > 1 ? "select" : "hidden",
+      options: timelines.map(t => ({ name: t.name, value: t.id })),
     },
   ];
 };
 
-const normalizeForm = timeline => {
-  const timestamp = parseTimestamp(timeline.timestamp);
+const normalizeForm = values => {
+  const timestamp = parseTimestamp(values.timestamp);
 
   return {
-    ...timeline,
+    ...values,
     time_matters: hasTimePart(timestamp),
   };
 };
 
 export default {
-  collection: {
-    fields: createForm,
+  details: ({ timelines = [] } = {}) => ({
+    fields: createForm({ timelines }),
     normalize: normalizeForm,
-  },
+  }),
 };

--- a/frontend/src/metabase/entities/timeline-events/forms.js
+++ b/frontend/src/metabase/entities/timeline-events/forms.js
@@ -1,6 +1,6 @@
 import { t } from "ttag";
 import { hasTimePart, parseTimestamp } from "metabase/lib/time";
-import { getTimelineIcons } from "metabase/lib/timeline";
+import { getTimelineIcons } from "metabase/lib/timelines";
 import validate from "metabase/lib/validate";
 
 const createForm = ({ timelines }) => {

--- a/frontend/src/metabase/entities/timeline-events/forms.js
+++ b/frontend/src/metabase/entities/timeline-events/forms.js
@@ -44,6 +44,7 @@ const createForm = ({ timelines }) => {
     },
     {
       name: "timeline_id",
+      title: t`Timeline`,
       type: timelines.length > 1 ? "select" : "hidden",
       options: timelines.map(t => ({ name: t.name, value: t.id })),
     },

--- a/frontend/src/metabase/entities/timelines.js
+++ b/frontend/src/metabase/entities/timelines.js
@@ -4,7 +4,7 @@ import _ from "underscore";
 import { TimelineSchema } from "metabase/schema";
 import { TimelineApi } from "metabase/services";
 import { createEntity, undo } from "metabase/lib/entities";
-import { getDefaultTimeline } from "metabase/lib/timeline";
+import { getDefaultTimeline } from "metabase/lib/timelines";
 import TimelineEvents from "./timeline-events";
 import forms from "./timelines/forms";
 

--- a/frontend/src/metabase/entities/timelines/forms.js
+++ b/frontend/src/metabase/entities/timelines/forms.js
@@ -2,36 +2,38 @@ import { t } from "ttag";
 import { getTimelineIcons } from "metabase/lib/timeline";
 import validate from "metabase/lib/validate";
 
-const FORM_FIELDS = [
-  {
-    name: "name",
-    title: t`Timeline name`,
-    placeholder: t`Product releases`,
-    autoFocus: true,
-    validate: validate.required().maxLength(255),
-  },
-  {
-    name: "description",
-    title: t`Description`,
-    type: "text",
-    validate: validate.maxLength(255),
-  },
-  {
-    name: "icon",
-    title: t`Default icon`,
-    type: "select",
-    initial: "star",
-    options: getTimelineIcons(),
-    validate: validate.required(),
-  },
-  {
-    name: "collection_id",
-    type: "hidden",
-  },
-];
+const createForm = () => {
+  return [
+    {
+      name: "name",
+      title: t`Timeline name`,
+      placeholder: t`Product releases`,
+      autoFocus: true,
+      validate: validate.required().maxLength(255),
+    },
+    {
+      name: "description",
+      title: t`Description`,
+      type: "text",
+      validate: validate.maxLength(255),
+    },
+    {
+      name: "icon",
+      title: t`Default icon`,
+      type: "select",
+      initial: "star",
+      options: getTimelineIcons(),
+      validate: validate.required(),
+    },
+    {
+      name: "collection_id",
+      type: "hidden",
+    },
+  ];
+};
 
 export default {
-  collection: {
-    fields: FORM_FIELDS,
+  details: {
+    fields: createForm(),
   },
 };

--- a/frontend/src/metabase/entities/timelines/forms.js
+++ b/frontend/src/metabase/entities/timelines/forms.js
@@ -1,5 +1,5 @@
 import { t } from "ttag";
-import { getTimelineIcons } from "metabase/lib/timeline";
+import { getTimelineIcons } from "metabase/lib/timelines";
 import validate from "metabase/lib/validate";
 
 const createForm = () => {

--- a/frontend/src/metabase/lib/timelines.ts
+++ b/frontend/src/metabase/lib/timelines.ts
@@ -1,4 +1,3 @@
-import moment from "moment-timezone";
 import { t } from "ttag";
 import { Collection, Timeline } from "metabase-types/api";
 import { canonicalCollectionId } from "metabase/collections/utils";
@@ -9,12 +8,8 @@ export const getDefaultTimeline = (
   return {
     name: t`${collection.name} events`,
     collection_id: canonicalCollectionId(collection.id),
-    icon: "star",
+    icon: getDefaultTimelineIcon(),
   };
-};
-
-export const getDefaultTimezone = () => {
-  return moment.tz.guess();
 };
 
 export const getTimelineIcons = () => {
@@ -26,4 +21,8 @@ export const getTimelineIcons = () => {
     { name: t`Bell`, value: "bell", icon: "bell" },
     { name: t`Cloud`, value: "cloud", icon: "cloud" },
   ];
+};
+
+export const getDefaultTimelineIcon = () => {
+  return "star";
 };

--- a/frontend/src/metabase/query_builder/components/QueryModals.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryModals.jsx
@@ -22,6 +22,7 @@ import { CreateAlertModalContent } from "metabase/query_builder/components/Alert
 import { ImpossibleToCreateModelModal } from "metabase/query_builder/components/ImpossibleToCreateModelModal";
 import NewDatasetModal from "metabase/query_builder/components/NewDatasetModal";
 import EntityCopyModal from "metabase/entities/containers/EntityCopyModal";
+import NewEventModal from "metabase/timelines/questions/containers/NewEventModal";
 import EditEventModal from "metabase/timelines/questions/containers/EditEventModal";
 
 export default class QueryModals extends React.Component {
@@ -219,6 +220,14 @@ export default class QueryModals extends React.Component {
     ) : modal === MODAL_TYPES.CAN_NOT_CREATE_MODEL ? (
       <Modal onClose={onCloseModal}>
         <ImpossibleToCreateModelModal onClose={onCloseModal} />
+      </Modal>
+    ) : modal === MODAL_TYPES.NEW_EVENT ? (
+      <Modal onClose={onCloseModal}>
+        <NewEventModal
+          cardId={question.id()}
+          collectionId={question.collectionId()}
+          onClose={onCloseModal}
+        />
       </Modal>
     ) : modal === MODAL_TYPES.EDIT_EVENT ? (
       <Modal onClose={onCloseModal}>

--- a/frontend/src/metabase/query_builder/components/QueryModals.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryModals.jsx
@@ -23,6 +23,7 @@ import { ImpossibleToCreateModelModal } from "metabase/query_builder/components/
 import NewDatasetModal from "metabase/query_builder/components/NewDatasetModal";
 import EntityCopyModal from "metabase/entities/containers/EntityCopyModal";
 import NewEventModal from "metabase/timelines/questions/containers/NewEventModal";
+import NewEventWithTimelineModal from "metabase/timelines/questions/containers/NewEventWithTimelineModal";
 import EditEventModal from "metabase/timelines/questions/containers/EditEventModal";
 
 export default class QueryModals extends React.Component {
@@ -225,6 +226,13 @@ export default class QueryModals extends React.Component {
       <Modal onClose={onCloseModal}>
         <NewEventModal
           cardId={question.id()}
+          collectionId={question.collectionId()}
+          onClose={onCloseModal}
+        />
+      </Modal>
+    ) : modal === MODAL_TYPES.NEW_EVENT_WITH_TIMELINE ? (
+      <Modal onClose={onCloseModal}>
+        <NewEventWithTimelineModal
           collectionId={question.collectionId()}
           onClose={onCloseModal}
         />

--- a/frontend/src/metabase/query_builder/components/view/sidebars/TimelineSidebar/TimelineSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/TimelineSidebar/TimelineSidebar.tsx
@@ -23,6 +23,17 @@ const TimelineSidebar = ({
   onHideTimeline,
   onClose,
 }: TimelineSidebarProps) => {
+  const handleNewEvent = useCallback(() => {
+    onOpenModal?.(MODAL_TYPES.NEW_EVENT);
+  }, [onOpenModal]);
+
+  const handleEditEvent = useCallback(
+    (event: TimelineEvent) => {
+      onOpenModal?.(MODAL_TYPES.EDIT_EVENT, event.id);
+    },
+    [onOpenModal],
+  );
+
   const handleToggleTimeline = useCallback(
     (timeline: Timeline, isVisible: boolean) => {
       if (isVisible) {
@@ -34,13 +45,6 @@ const TimelineSidebar = ({
     [onShowTimeline, onHideTimeline],
   );
 
-  const handleEditEvent = useCallback(
-    (event: TimelineEvent) => {
-      onOpenModal?.(MODAL_TYPES.EDIT_EVENT, event.id);
-    },
-    [onOpenModal],
-  );
-
   return (
     <SidebarContent title={t`Events`} onClose={onClose}>
       <TimelinePanel
@@ -48,8 +52,9 @@ const TimelineSidebar = ({
         collectionId={question.collectionId()}
         visibility={visibility}
         isVisibleByDefault={question.isSaved()}
-        onToggleTimeline={handleToggleTimeline}
+        onNewEvent={handleNewEvent}
         onEditEvent={handleEditEvent}
+        onToggleTimeline={handleToggleTimeline}
       />
     </SidebarContent>
   );

--- a/frontend/src/metabase/query_builder/components/view/sidebars/TimelineSidebar/TimelineSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/TimelineSidebar/TimelineSidebar.tsx
@@ -27,6 +27,10 @@ const TimelineSidebar = ({
     onOpenModal?.(MODAL_TYPES.NEW_EVENT);
   }, [onOpenModal]);
 
+  const handleNewEventWithTimeline = useCallback(() => {
+    onOpenModal?.(MODAL_TYPES.NEW_EVENT_WITH_TIMELINE);
+  }, [onOpenModal]);
+
   const handleEditEvent = useCallback(
     (event: TimelineEvent) => {
       onOpenModal?.(MODAL_TYPES.EDIT_EVENT, event.id);
@@ -53,6 +57,7 @@ const TimelineSidebar = ({
         visibility={visibility}
         isVisibleByDefault={question.isSaved()}
         onNewEvent={handleNewEvent}
+        onNewEventWithTimeline={handleNewEventWithTimeline}
         onEditEvent={handleEditEvent}
         onToggleTimeline={handleToggleTimeline}
       />

--- a/frontend/src/metabase/query_builder/constants.js
+++ b/frontend/src/metabase/query_builder/constants.js
@@ -15,5 +15,6 @@ export const MODAL_TYPES = {
   TURN_INTO_DATASET: "turn-into-dataset",
   CAN_NOT_CREATE_MODEL: "can-not-create-model",
   NEW_EVENT: "new-event",
+  NEW_EVENT_WITH_TIMELINE: "new-event-with-timeline",
   EDIT_EVENT: "edit-event",
 };

--- a/frontend/src/metabase/query_builder/constants.js
+++ b/frontend/src/metabase/query_builder/constants.js
@@ -14,5 +14,6 @@ export const MODAL_TYPES = {
   EMBED: "embed",
   TURN_INTO_DATASET: "turn-into-dataset",
   CAN_NOT_CREATE_MODEL: "can-not-create-model",
+  NEW_EVENT: "new-event",
   EDIT_EVENT: "edit-event",
 };

--- a/frontend/src/metabase/timelines/collections/components/EditEventModal/EditEventModal.tsx
+++ b/frontend/src/metabase/timelines/collections/components/EditEventModal/EditEventModal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useMemo } from "react";
 import { t } from "ttag";
 import Form from "metabase/containers/Form";
 import forms from "metabase/entities/timeline-events/forms";
@@ -33,6 +33,8 @@ const EditEventModal = ({
   onCancel,
   onClose,
 }: EditEventModalProps): JSX.Element => {
+  const form = useMemo(() => forms.details(), []);
+
   const handleSubmit = useCallback(
     async (event: TimelineEvent) => {
       await onSubmit(event, timeline, collection);
@@ -49,7 +51,7 @@ const EditEventModal = ({
       <ModalHeader title={t`Edit event`} onClose={onClose} />
       <ModalBody>
         <Form
-          form={forms.collection}
+          form={form}
           initialValues={event}
           isModal={true}
           onSubmit={handleSubmit}

--- a/frontend/src/metabase/timelines/collections/components/EditTimelineModal/EditTimelineModal.tsx
+++ b/frontend/src/metabase/timelines/collections/components/EditTimelineModal/EditTimelineModal.tsx
@@ -39,7 +39,7 @@ const EditTimelineModal = ({
       <ModalHeader title={t`Edit event timeline`} onClose={onClose} />
       <ModalBody>
         <Form
-          form={forms.collection}
+          form={forms.details}
           initialValues={timeline}
           isModal={true}
           onSubmit={handleSubmit}

--- a/frontend/src/metabase/timelines/collections/components/NewEventModal/NewEventModal.tsx
+++ b/frontend/src/metabase/timelines/collections/components/NewEventModal/NewEventModal.tsx
@@ -26,6 +26,8 @@ const NewEventModal = ({
   onCancel,
   onClose,
 }: NewEventModalProps): JSX.Element => {
+  const form = useMemo(() => forms.details(), []);
+
   const initialValues = useMemo(
     () => ({
       timeline_id: timeline?.id,
@@ -47,7 +49,7 @@ const NewEventModal = ({
       <ModalHeader title={t`New event`} onClose={onClose} />
       <ModalBody>
         <Form
-          form={forms.collection}
+          form={form}
           initialValues={initialValues}
           isModal={true}
           onSubmit={handleSubmit}

--- a/frontend/src/metabase/timelines/collections/components/NewEventModal/NewEventModal.tsx
+++ b/frontend/src/metabase/timelines/collections/components/NewEventModal/NewEventModal.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useMemo } from "react";
 import { t } from "ttag";
 import { getDefaultTimezone } from "metabase/lib/time";
+import { getDefaultTimelineIcon } from "metabase/lib/timelines";
 import Form from "metabase/containers/Form";
 import forms from "metabase/entities/timeline-events/forms";
 import ModalHeader from "metabase/timelines/common/components/ModalHeader";
@@ -31,7 +32,7 @@ const NewEventModal = ({
   const initialValues = useMemo(
     () => ({
       timeline_id: timeline?.id,
-      icon: timeline?.icon,
+      icon: timeline ? timeline.icon : getDefaultTimelineIcon(),
       timezone: getDefaultTimezone(),
     }),
     [timeline],

--- a/frontend/src/metabase/timelines/collections/components/NewTimelineModal/NewTimelineModal.tsx
+++ b/frontend/src/metabase/timelines/collections/components/NewTimelineModal/NewTimelineModal.tsx
@@ -36,7 +36,7 @@ const NewTimelineModal = ({
       <ModalHeader title={t`New event timeline`} onClose={onClose} />
       <ModalBody>
         <Form
-          form={forms.collection}
+          form={forms.details}
           initialValues={initialValues}
           isModal={true}
           onSubmit={handleSubmit}

--- a/frontend/src/metabase/timelines/questions/components/EditEventModal/EditEventModal.tsx
+++ b/frontend/src/metabase/timelines/questions/components/EditEventModal/EditEventModal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useMemo } from "react";
 import { t } from "ttag";
 import Form from "metabase/containers/Form";
 import forms from "metabase/entities/timeline-events/forms";
@@ -19,6 +19,8 @@ const EditEventModal = ({
   onArchive,
   onClose,
 }: EditEventModalProps): JSX.Element => {
+  const form = useMemo(() => forms.details(), []);
+
   const handleSubmit = useCallback(
     async (event: TimelineEvent) => {
       await onSubmit(event);
@@ -37,7 +39,7 @@ const EditEventModal = ({
       <ModalHeader title={t`Edit event`} onClose={onClose} />
       <ModalBody>
         <Form
-          form={forms.collection}
+          form={form}
           initialValues={event}
           isModal={true}
           onSubmit={handleSubmit}

--- a/frontend/src/metabase/timelines/questions/components/NewEventModal/NewEventModal.styled.tsx
+++ b/frontend/src/metabase/timelines/questions/components/NewEventModal/NewEventModal.styled.tsx
@@ -1,0 +1,5 @@
+import styled from "@emotion/styled";
+
+export const ModalBody = styled.div`
+  padding: 2rem;
+`;

--- a/frontend/src/metabase/timelines/questions/components/NewEventModal/NewEventModal.tsx
+++ b/frontend/src/metabase/timelines/questions/components/NewEventModal/NewEventModal.tsx
@@ -5,17 +5,19 @@ import { getDefaultTimelineIcon } from "metabase/lib/timelines";
 import Form from "metabase/containers/Form";
 import forms from "metabase/entities/timeline-events/forms";
 import ModalHeader from "metabase/timelines/common/components/ModalHeader";
-import { Timeline, TimelineEvent } from "metabase-types/api";
+import { Collection, Timeline, TimelineEvent } from "metabase-types/api";
 import { ModalBody } from "./NewEventModal.styled";
 
 export interface NewEventModalProps {
   timelines: Timeline[];
-  onSubmit: (values: Partial<TimelineEvent>) => void;
+  collection: Collection;
+  onSubmit: (values: Partial<TimelineEvent>, collection: Collection) => void;
   onClose?: () => void;
 }
 
 const NewEventModal = ({
   timelines,
+  collection,
   onSubmit,
   onClose,
 }: NewEventModalProps): JSX.Element => {
@@ -35,10 +37,10 @@ const NewEventModal = ({
 
   const handleSubmit = useCallback(
     async (values: Partial<TimelineEvent>) => {
-      await onSubmit(values);
+      await onSubmit(values, collection);
       onClose?.();
     },
-    [onSubmit, onClose],
+    [collection, onSubmit, onClose],
   );
 
   return (

--- a/frontend/src/metabase/timelines/questions/components/NewEventModal/NewEventModal.tsx
+++ b/frontend/src/metabase/timelines/questions/components/NewEventModal/NewEventModal.tsx
@@ -9,14 +9,14 @@ import { Collection, Timeline, TimelineEvent } from "metabase-types/api";
 import { ModalBody } from "./NewEventModal.styled";
 
 export interface NewEventModalProps {
-  timelines: Timeline[];
+  timelines?: Timeline[];
   collection: Collection;
   onSubmit: (values: Partial<TimelineEvent>, collection: Collection) => void;
   onClose?: () => void;
 }
 
 const NewEventModal = ({
-  timelines,
+  timelines = [],
   collection,
   onSubmit,
   onClose,

--- a/frontend/src/metabase/timelines/questions/components/NewEventModal/NewEventModal.tsx
+++ b/frontend/src/metabase/timelines/questions/components/NewEventModal/NewEventModal.tsx
@@ -1,0 +1,60 @@
+import React, { useCallback, useMemo } from "react";
+import { t } from "ttag";
+import { getDefaultTimezone } from "metabase/lib/time";
+import { getDefaultTimelineIcon } from "metabase/lib/timelines";
+import Form from "metabase/containers/Form";
+import forms from "metabase/entities/timeline-events/forms";
+import ModalHeader from "metabase/timelines/common/components/ModalHeader";
+import { Timeline, TimelineEvent } from "metabase-types/api";
+import { ModalBody } from "./NewEventModal.styled";
+
+export interface NewEventModalProps {
+  timelines: Timeline[];
+  onSubmit: (values: Partial<TimelineEvent>) => void;
+  onClose?: () => void;
+}
+
+const NewEventModal = ({
+  timelines,
+  onSubmit,
+  onClose,
+}: NewEventModalProps): JSX.Element => {
+  const form = useMemo(() => forms.details({ timelines }), [timelines]);
+  const hasTimelines = timelines.length > 0;
+  const hasOneTimeline = timelines.length === 1;
+  const defaultTimeline = timelines[0];
+
+  const initialValues = useMemo(
+    () => ({
+      timeline_id: hasTimelines ? defaultTimeline.id : null,
+      icon: hasOneTimeline ? defaultTimeline.icon : getDefaultTimelineIcon(),
+      timezone: getDefaultTimezone(),
+    }),
+    [defaultTimeline, hasTimelines, hasOneTimeline],
+  );
+
+  const handleSubmit = useCallback(
+    async (values: Partial<TimelineEvent>) => {
+      await onSubmit(values);
+      onClose?.();
+    },
+    [onSubmit, onClose],
+  );
+
+  return (
+    <div>
+      <ModalHeader title={t`New event`} onClose={onClose} />
+      <ModalBody>
+        <Form
+          form={form}
+          initialValues={initialValues}
+          isModal={true}
+          onSubmit={handleSubmit}
+          onClose={onClose}
+        />
+      </ModalBody>
+    </div>
+  );
+};
+
+export default NewEventModal;

--- a/frontend/src/metabase/timelines/questions/components/NewEventModal/index.ts
+++ b/frontend/src/metabase/timelines/questions/components/NewEventModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./NewEventModal";

--- a/frontend/src/metabase/timelines/questions/components/TimelineCard/TimelineCard.styled.tsx
+++ b/frontend/src/metabase/timelines/questions/components/TimelineCard/TimelineCard.styled.tsx
@@ -3,6 +3,12 @@ import { color } from "metabase/lib/colors";
 import CheckBox from "metabase/core/components/CheckBox";
 import Icon from "metabase/components/Icon";
 
+export const CardRoot = styled.div`
+  &:not(:last-child) {
+    margin-bottom: 1.5rem;
+  }
+`;
+
 export const CardHeader = styled.div`
   display: flex;
   align-items: center;

--- a/frontend/src/metabase/timelines/questions/components/TimelineCard/TimelineCard.tsx
+++ b/frontend/src/metabase/timelines/questions/components/TimelineCard/TimelineCard.tsx
@@ -15,6 +15,7 @@ import {
   CardLabel,
   CardCheckbox,
   CardIcon,
+  CardRoot,
 } from "./TimelineCard.styled";
 
 export interface TimelineCardProps {
@@ -53,7 +54,7 @@ const TimelineCard = ({
   }, []);
 
   return (
-    <div>
+    <CardRoot>
       <CardHeader onClick={handleHeaderClick}>
         <CardCheckbox
           checked={isVisible}
@@ -76,7 +77,7 @@ const TimelineCard = ({
           ))}
         </CardContent>
       )}
-    </div>
+    </CardRoot>
   );
 };
 

--- a/frontend/src/metabase/timelines/questions/components/TimelineEmptyState/TimelineEmptyState.styled.tsx
+++ b/frontend/src/metabase/timelines/questions/components/TimelineEmptyState/TimelineEmptyState.styled.tsx
@@ -1,6 +1,7 @@
 import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
 import Icon from "metabase/components/Icon";
+import Button from "metabase/core/components/Button";
 
 export const EmptyStateRoot = styled.div`
   display: flex;
@@ -10,16 +11,20 @@ export const EmptyStateRoot = styled.div`
 `;
 
 export const EmptyStateIcon = styled(Icon)`
-  color: ${color("text-medium")};
+  color: ${color("text-light")};
   width: 5rem;
   height: 5rem;
   margin-bottom: 2.5rem;
 `;
 
 export const EmptyStateText = styled.div`
-  color: ${color("text-medium")};
+  color: ${color("text-dark")};
   font-size: 0.875rem;
   line-height: 1.5rem;
   text-align: center;
   max-width: 19.375rem;
+`;
+
+export const EmptyStateButton = styled(Button)`
+  margin-top: 1.5rem;
 `;

--- a/frontend/src/metabase/timelines/questions/components/TimelineEmptyState/TimelineEmptyState.tsx
+++ b/frontend/src/metabase/timelines/questions/components/TimelineEmptyState/TimelineEmptyState.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { t } from "ttag";
 import { Collection } from "metabase-types/api";
 import {
+  EmptyStateButton,
   EmptyStateIcon,
   EmptyStateRoot,
   EmptyStateText,
@@ -9,10 +10,12 @@ import {
 
 export interface TimelineEmptyStateProps {
   collection: Collection;
+  onNewEventWithTimeline?: () => void;
 }
 
 const TimelineEmptyState = ({
   collection,
+  onNewEventWithTimeline,
 }: TimelineEmptyStateProps): JSX.Element => {
   const canWrite = collection.can_write;
 
@@ -24,6 +27,11 @@ const TimelineEmptyState = ({
           ? t`Add events to Metabase to show helpful context alongside your data.`
           : t`Events in Metabase let you see helpful context alongside your data.`}
       </EmptyStateText>
+      {canWrite && (
+        <EmptyStateButton primary onClick={onNewEventWithTimeline}>
+          {t`Add an event`}
+        </EmptyStateButton>
+      )}
     </EmptyStateRoot>
   );
 };

--- a/frontend/src/metabase/timelines/questions/components/TimelinePanel/TimelinePanel.styled.tsx
+++ b/frontend/src/metabase/timelines/questions/components/TimelinePanel/TimelinePanel.styled.tsx
@@ -3,3 +3,7 @@ import styled from "@emotion/styled";
 export const PanelRoot = styled.div`
   margin: 0 1.5rem;
 `;
+
+export const PanelToolbar = styled.div`
+  margin-bottom: 1rem;
+`;

--- a/frontend/src/metabase/timelines/questions/components/TimelinePanel/TimelinePanel.tsx
+++ b/frontend/src/metabase/timelines/questions/components/TimelinePanel/TimelinePanel.tsx
@@ -12,6 +12,7 @@ export interface TimelinePanelProps {
   visibility?: Record<number, boolean>;
   isVisibleByDefault?: boolean;
   onNewEvent?: () => void;
+  onNewEventWithTimeline?: () => void;
   onEditEvent?: (event: TimelineEvent) => void;
   onArchiveEvent?: (event: TimelineEvent) => void;
   onToggleTimeline?: (timeline: Timeline, isVisible: boolean) => void;
@@ -23,6 +24,7 @@ const TimelinePanel = ({
   visibility,
   isVisibleByDefault,
   onNewEvent,
+  onNewEventWithTimeline,
   onEditEvent,
   onArchiveEvent,
   onToggleTimeline,
@@ -48,7 +50,10 @@ const TimelinePanel = ({
           onArchiveEvent={onArchiveEvent}
         />
       ) : (
-        <TimelineEmptyState collection={collection} />
+        <TimelineEmptyState
+          collection={collection}
+          onNewEventWithTimeline={onNewEventWithTimeline}
+        />
       )}
     </PanelRoot>
   );

--- a/frontend/src/metabase/timelines/questions/components/TimelinePanel/TimelinePanel.tsx
+++ b/frontend/src/metabase/timelines/questions/components/TimelinePanel/TimelinePanel.tsx
@@ -1,17 +1,20 @@
 import React from "react";
+import { t } from "ttag";
+import Button from "metabase/core/components/Button";
 import { Collection, Timeline, TimelineEvent } from "metabase-types/api";
 import TimelineList from "../TimelineList";
 import TimelineEmptyState from "../TimelineEmptyState";
-import { PanelRoot } from "./TimelinePanel.styled";
+import { PanelRoot, PanelToolbar } from "./TimelinePanel.styled";
 
 export interface TimelinePanelProps {
   timelines: Timeline[];
   collection: Collection;
   visibility?: Record<number, boolean>;
   isVisibleByDefault?: boolean;
-  onToggleTimeline?: (timeline: Timeline, isVisible: boolean) => void;
+  onNewEvent?: () => void;
   onEditEvent?: (event: TimelineEvent) => void;
   onArchiveEvent?: (event: TimelineEvent) => void;
+  onToggleTimeline?: (timeline: Timeline, isVisible: boolean) => void;
 }
 
 const TimelinePanel = ({
@@ -19,14 +22,21 @@ const TimelinePanel = ({
   collection,
   visibility,
   isVisibleByDefault,
-  onToggleTimeline,
+  onNewEvent,
   onEditEvent,
   onArchiveEvent,
+  onToggleTimeline,
 }: TimelinePanelProps): JSX.Element => {
   const isEmpty = timelines.length === 0;
+  const canWrite = collection.can_write;
 
   return (
     <PanelRoot>
+      {!isEmpty && canWrite && (
+        <PanelToolbar>
+          <Button onClick={onNewEvent}>{t`Add an event`}</Button>
+        </PanelToolbar>
+      )}
       {!isEmpty ? (
         <TimelineList
           timelines={timelines}

--- a/frontend/src/metabase/timelines/questions/containers/NewEventModal/NewEventModal.tsx
+++ b/frontend/src/metabase/timelines/questions/containers/NewEventModal/NewEventModal.tsx
@@ -1,0 +1,38 @@
+import { connect } from "react-redux";
+import _ from "underscore";
+import Collections, { ROOT_COLLECTION } from "metabase/entities/collections";
+import Timelines from "metabase/entities/timelines";
+import TimelineEvents from "metabase/entities/timeline-events";
+import { TimelineEvent } from "metabase-types/api";
+import { State } from "metabase-types/store";
+import NewEventModal from "../../components/NewEventModal";
+
+interface TimelinePanelProps {
+  cardId?: number;
+  collectionId?: number;
+}
+
+const timelineProps = {
+  query: (state: State, props: TimelinePanelProps) => ({
+    cardId: props.cardId,
+    include: "events",
+  }),
+};
+
+const collectionProps = {
+  id: (state: State, props: TimelinePanelProps) => {
+    return props.collectionId ?? ROOT_COLLECTION.id;
+  },
+};
+
+const mapDispatchToProps = (dispatch: any) => ({
+  onSubmit: async (values: Partial<TimelineEvent>) => {
+    await dispatch(TimelineEvents.actions.create(values));
+  },
+});
+
+export default _.compose(
+  Timelines.loadList(timelineProps),
+  Collections.load(collectionProps),
+  connect(null, mapDispatchToProps),
+)(NewEventModal);

--- a/frontend/src/metabase/timelines/questions/containers/NewEventModal/index.ts
+++ b/frontend/src/metabase/timelines/questions/containers/NewEventModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./NewEventModal";

--- a/frontend/src/metabase/timelines/questions/containers/NewEventWithTimelineModal/NewEventWithTimelineModal.tsx
+++ b/frontend/src/metabase/timelines/questions/containers/NewEventWithTimelineModal/NewEventWithTimelineModal.tsx
@@ -2,7 +2,7 @@ import { connect } from "react-redux";
 import _ from "underscore";
 import Collections, { ROOT_COLLECTION } from "metabase/entities/collections";
 import Timelines from "metabase/entities/timelines";
-import { TimelineEvent } from "metabase-types/api";
+import { Collection, TimelineEvent } from "metabase-types/api";
 import { State } from "metabase-types/store";
 import NewEventModal from "../../components/NewEventModal";
 
@@ -17,8 +17,8 @@ const collectionProps = {
 };
 
 const mapDispatchToProps = (dispatch: any) => ({
-  onSubmit: async (values: Partial<TimelineEvent>) => {
-    await dispatch(Timelines.actions.createWithEvent(values));
+  onSubmit: async (values: Partial<TimelineEvent>, collection: Collection) => {
+    await dispatch(Timelines.actions.createWithEvent(values, collection));
   },
 });
 

--- a/frontend/src/metabase/timelines/questions/containers/NewEventWithTimelineModal/NewEventWithTimelineModal.tsx
+++ b/frontend/src/metabase/timelines/questions/containers/NewEventWithTimelineModal/NewEventWithTimelineModal.tsx
@@ -1,0 +1,28 @@
+import { connect } from "react-redux";
+import _ from "underscore";
+import Collections, { ROOT_COLLECTION } from "metabase/entities/collections";
+import Timelines from "metabase/entities/timelines";
+import { TimelineEvent } from "metabase-types/api";
+import { State } from "metabase-types/store";
+import NewEventModal from "../../components/NewEventModal";
+
+interface TimelinePanelProps {
+  collectionId?: number;
+}
+
+const collectionProps = {
+  id: (state: State, props: TimelinePanelProps) => {
+    return props.collectionId ?? ROOT_COLLECTION.id;
+  },
+};
+
+const mapDispatchToProps = (dispatch: any) => ({
+  onSubmit: async (values: Partial<TimelineEvent>) => {
+    await dispatch(Timelines.actions.createWithEvent(values));
+  },
+});
+
+export default _.compose(
+  Collections.load(collectionProps),
+  connect(null, mapDispatchToProps),
+)(NewEventModal);

--- a/frontend/src/metabase/timelines/questions/containers/NewEventWithTimelineModal/index.ts
+++ b/frontend/src/metabase/timelines/questions/containers/NewEventWithTimelineModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./NewEventWithTimelineModal";


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/20289

Changes:
- Adds a modal to create an event within an existing timeline
- Adds a modal to create a default timeline with an event

How to test:
- Run a fresh Metabase instance or archive all timelines.
- Go to a saved question and open the event sidebar by clicking on the calendar icon in the bottom right corner.
- You should see an empty state. Click `Add an event`, fill our the form and click `Create`. It should create a default timeline and an event within the collection that the question belongs to.
- When there is an existing timeline, there should be `Add an event` button in the sidebar above the timeline list. Click the button and create an event. It should be possible to choose an existing timeline.

<img width="365" alt="Screenshot 2022-03-14 at 17 38 43" src="https://user-images.githubusercontent.com/8542534/158195476-ca515281-9ed8-42b5-a06d-6d30ab99b9d8.png">
<img width="659" alt="Screenshot 2022-03-14 at 17 38 48" src="https://user-images.githubusercontent.com/8542534/158195483-d46f7897-8e2a-44d1-a37f-3548428dc2a9.png">
<img width="1728" alt="Screenshot 2022-03-14 at 17 21 14" src="https://user-images.githubusercontent.com/8542534/158195457-7a08910b-ad3b-4091-83af-19de92e8f1ab.png">
<img width="666" alt="Screenshot 2022-03-14 at 17 21 26" src="https://user-images.githubusercontent.com/8542534/158195474-37c6530d-6d15-4466-bc80-9c21b002b41f.png">
