### PR TITLE
Google Analytics: use service accounts for auth

### DIFF
--- a/docs/administration-guide/databases/google-analytics.md
+++ b/docs/administration-guide/databases/google-analytics.md
@@ -31,7 +31,7 @@ Here's the basic flow:
 > **You can only download the key once**. If you delete the key, you'll need to create another service account with
 > the same roles.
 
-## Adding the service account to your Google Analytics account
+### Adding the service account to your Google Analytics account
 
 The newly created service account will have an email address that looks similar to:
 

--- a/docs/administration-guide/databases/google-analytics.md
+++ b/docs/administration-guide/databases/google-analytics.md
@@ -6,29 +6,66 @@ This page provides information on how to create and manage a connection to a [Go
 
 You will need to have a [Google Cloud Platform][google-cloud] account and create the [project][google-cloud-create-project] you would like to use in Metabase. Consult the Google Cloud Platform documentation on how to [create and manage a project][google-cloud-management] if you do not have one.
 
-## Google Cloud Platform: creating OAuth client ID
+## Google Cloud Platform: creating a service account and JSON file
 
-To get the Client ID and Client Secret you will need, follow Google's Cloud Platform Help on [how to create an OAuth client ID][google-cloud-oauth]. For application type, select "Desktop App" (this avoids a `redirect_uri_mismatch` when requesting Auth Codes).
+You'll first need a [service account](https://cloud.google.com/iam/docs/service-accounts) JSON file that Metabase can
+use to access your Google Analytics dataset. Service accounts are intended for non-human users (such as applications
+like Metabase) to authenticate (who am I?) and authorize (what can I do?) their API calls.
+
+To create the service account JSON file, follow Google's documentation on [setting up a service
+account](https://cloud.google.com/iam/docs/creating-managing-service-accounts) for your Google Analytics dataset.
+Here's the basic flow:
+
+1. **Create service account**. From your Google Cloud Platform project console, open the main sidebar menu on the
+   left, go to the **IAM & Admin** section, and select **Service account**. The console will list existing service
+   accounts, if any. At the top of the screen, click on **+ CREATE SERVICE ACCOUNT**.
+
+2. **Fill out the service account details**. Name the service account, and add a description (the service account ID
+   will populate once you add a name). Then click the **Create** button.
+
+3. The **Service account permissions (optional)** section is not required. Click **Continue**.
+
+4. **Create key**. Once you have assigned roles to the service account, click on the **Create Key** button, and select
+   **JSON** for the **key type**. The JSON file will download to your computer.
+
+> **You can only download the key once**. If you delete the key, you'll need to create another service account with
+> the same roles.
+
+## Adding the service account to your Google Analytics account
+
+The newly created service account will have an email address that looks similar to:
+
+```
+my_service_account_name@my_project_id.iam.gserviceaccount.com
+```
+
+You must add this service account user to your Google Analytics account in order to use it. Add it by following the
+instructions [here][google-analytics-add-user]. Only Read and Analyze permissions are needed for Metabase.
 
 ### Enabling Google Analytics API
 
 To enable the Google Analytics API, go to <https://console.cloud.google.com/apis/api/analytics.googleapis.com/overview> in the Google Cloud Platform console. Double-check that the previously created project is selected and click on "Enable". For further documentation please refer to [Enable and disable APIs][google-enable-disable-apis].
 
-##### Adding the API scopes
-
-Refer to Google's Analytics API documentation to set up the required [scopes][google-oauth-scopes].
-
 ## Metabase: adding a Google Analytics dataset
 
 In your Metabase, click on **Settings** and select "Admin" to bring up the **Admin Panel**. In the **Databases** section, click on the **Add database** button, then select "Google Analytics" from the "Database type" dropdown and fill in the configuration settings:
 
-- **Display name** is the title of your database in Metabase.
+### Settings
 
-- To get the **Google Analytics Account ID**, go to [Google Analytics][google-analytics] and click the **Admin** cog.  In the admin tab, go to the **Account Settings** section: you will find the account ID below the "Basic Settings" heading.
+#### Display name
 
-- Paste the **Client ID** and **Client Secret** you created when setting up the OAuth client ID above. These credentials must be correctly associated to scopes allowing interaction with the Google Analytics API.
+**Name** is the title of your database in Metabase.
 
-- Once you've provided **Client ID** and **Client Secret** with valid scopes, a **Click here to get an auth code** link will appear over the **Auth Code** text box. Authorize the connection with your Google login credentials to see the Auth Code, then copy and paste the code into this box.
+#### Account ID
+
+To get the **Google Analytics Account ID**, go to [Google Analytics][google-analytics] and click the **Admin** cog. In
+the admin tab, go to the **Account Settings** section: you will find the account ID below the "Basic Settings"
+heading.
+
+#### Service account JSON file
+
+Upload the service account JSON file you created when following the steps above. The JSON file contains the
+credentials your Metabase application will need to read and query your dataset.
 
 ### Advanced settings
 
@@ -47,6 +84,7 @@ When you're done, click the **Save** button. A modal dialog will inform you that
 Give Metabase some time to sync with your Google Analytics dataset, then exit the **Admin Panel**, click on **Browse Data**, find your Google Analytics database, and start exploring. Once Metabase is finished syncing, you will see the names of your Properties & Apps in the data browser.
 
 [google-analytics]: https://cloud.google.com/analytics
+[google-analytics-add-user]: https://support.google.com/analytics/answer/1009702
 [google-cloud]: https://cloud.google.com/
 [google-cloud-create-project]: https://cloud.google.com/resource-manager/docs/creating-managing-projects#creating_a_project
 [google-cloud-management]: https://cloud.google.com/resource-manager/docs/creating-managing-projects

--- a/frontend/src/metabase/entities/databases/forms.js
+++ b/frontend/src/metabase/entities/databases/forms.js
@@ -36,7 +36,6 @@ const DATABASE_DETAIL_OVERRIDES = {
     description: (
       <div>
         <div>{getAuthCodeLink(engine, details)}</div>
-        <div>{getAuthCodeEnableAPILink(engine, details)}</div>
       </div>
     ),
   }),
@@ -159,19 +158,10 @@ const AUTH_URL_PREFIXES = {
     "https://accounts.google.com/o/oauth2/auth?redirect_uri=urn:ietf:wg:oauth:2.0:oob&response_type=code&scope=https://www.googleapis.com/auth/bigquery&client_id=",
   bigquery_with_drive:
     "https://accounts.google.com/o/oauth2/auth?redirect_uri=urn:ietf:wg:oauth:2.0:oob&response_type=code&scope=https://www.googleapis.com/auth/bigquery%20https://www.googleapis.com/auth/drive&client_id=",
-  googleanalytics:
-    "https://accounts.google.com/o/oauth2/auth?access_type=offline&redirect_uri=urn:ietf:wg:oauth:2.0:oob&response_type=code&scope=https://www.googleapis.com/auth/analytics.readonly&client_id=",
-};
-
-const ENABLE_API_PREFIXES = {
-  googleanalytics:
-    "https://console.developers.google.com/apis/api/analytics.googleapis.com/overview?project=",
 };
 
 const CREDENTIALS_URL_PREFIXES = {
   bigquery:
-    "https://console.developers.google.com/apis/credentials/oauthclient?project=",
-  googleanalytics:
     "https://console.developers.google.com/apis/credentials/oauthclient?project=",
 };
 
@@ -225,33 +215,6 @@ function getAuthCodeLink(engine, details) {
         )}
       </span>
     );
-  }
-}
-
-function getAuthCodeEnableAPILink(engine, details) {
-  // for Google Analytics we need to show a link for people to go to the Console to enable the GA API
-  if (AUTH_URL_PREFIXES[engine] && details["client-id"]) {
-    // projectID is just the first numeric part of the client-id.
-    // e.g. client-id might be 123436115855-q8z42hilmjf8iplnnu49n7jbudmxxdf.apps.googleusercontent.com
-    // then project-id would be 123436115855
-    const projectID =
-      details["client-id"] && (details["client-id"].match(/^\d+/) || [])[0];
-    if (ENABLE_API_PREFIXES[engine] && projectID) {
-      // URL looks like https://console.developers.google.com/apis/api/analytics.googleapis.com/overview?project=12343611585
-      const enableAPIURL = concatTrimmed(
-        ENABLE_API_PREFIXES[engine],
-        projectID,
-      );
-
-      return (
-        <span>
-          {t`To use Metabase with this data you must enable API access in the Google Developers Console.`}{" "}
-          {jt`${(
-            <ExternalLink href={enableAPIURL}>{t`Click here`}</ExternalLink>
-          )} to go to the console if you haven't already done so.`}
-        </span>
-      );
-    }
   }
 }
 

--- a/modules/drivers/google/src/metabase/driver/google.clj
+++ b/modules/drivers/google/src/metabase/driver/google.clj
@@ -67,7 +67,6 @@
   "The application name we should use for Google drivers. Requested by Google themselves -- see #2627"
   (create-application-name config/mb-version-info))
 
-
 (defn- fetch-access-and-refresh-tokens* [scopes, ^String client-id, ^String client-secret, ^String auth-code]
   {:pre  [(seq client-id) (seq client-secret) (seq auth-code)]
    :post [(seq (:access-token %)) (seq (:refresh-token %))]}

--- a/modules/drivers/googleanalytics/resources/metabase-plugin.yaml
+++ b/modules/drivers/googleanalytics/resources/metabase-plugin.yaml
@@ -15,21 +15,11 @@ driver:
       helper-text: You can find the Account ID in Google Analytics → Admin → Account Settings.
       placeholder: '1234567'
       required: true
-    - name: client-id
-      display-name: Client ID
-      helper-text: Find it in the "GA authentication" tab in Google Analytics Counter module settings and copy "Client ID".
-      placeholder: 1201327674725-y6ferb0feo1hfssr7t40o4aikqll46d4.apps.googleusercontent.com
+    - name: service-account-json
+      display-name: Service account JSON file
+      helper-text: This JSON file contains the credentials Metabase needs to read and query your dataset.
       required: true
-    - name: client-secret
-      display-name: Client Secret
-      helper-text: Go to the "GA authentication" tab in Google Analytics Counter module settings and copy "Client Secret".
-      placeholder: dJNi4utWgMzyIFo2JbnsK6Np
-      required: true
-    - name: auth-code
-      display-name: Auth Code
-      helper-text: Once you've provided Client ID and Client Secret, a link to get an auth code will appear. Authorize the connection and copy and paste the code here.
-      placeholder: 4/HSk-KtxkSzTt61j5zcbee2Rmm5JHkRFbL5gD5lgkXek
-      required: true
+      type: textFile
     - advanced-options-start
     - default-advanced-options
 init:

--- a/test/metabase/test/initialize/plugins.clj
+++ b/test/metabase/test/initialize/plugins.clj
@@ -7,6 +7,8 @@
             [metabase.util :as u]
             [yaml.core :as yaml]))
 
+;; [[metabase.plugins/load-local-plugin-manifests!]] actually does the same thing as the code below now; the only
+;; difference is this code also initializes plugins in `test_modules`. Besides that this code isn't needed
 (defn- driver-plugin-manifest [driver]
   (let [nm    (name driver)
         paths (mapv


### PR DESCRIPTION
Resolves #4812
Resolves #6613
Resolves #14624
Resolves #14578
Resolves #20876

This PR updates Google Analytics to use service accounts for authorization, similar to BigQuery. All new Google Analytics setups going forward will have to use service accounts, but existing ones using the OAuth OOB should continue to work for a little while.

We should probably warn people using the old style that they will need to reauthorize -- not sure if doing this in release notes is enough or if we want to display a warning in the admin panel as well -- if we do I'll have to think about how we can do that. We can do that as a follow-on.

I tried updating the dox here, please take a look and edit them if you don't like my changes.

Since the legacy `:bigquery` driver supported service account-based auth I was able to leverage that code and didn't need to change anything except for the connection properties to get this working. Manually tested and everything is working.