### PR TITLE
Upgrade `cypress-real-events` to the latest version `1.7.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -202,7 +202,7 @@
     "css-loader": "^0.28.7",
     "cypress": "^9.5.2",
     "cypress-grep": "^2.5.2",
-    "cypress-real-events": "^1.4.0",
+    "cypress-real-events": "^1.7.0",
     "documentation": "^13.2.5",
     "eslint": "7.32.0",
     "eslint-import-resolver-webpack": "^0.8.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9076,10 +9076,10 @@ cypress-grep@^2.5.2:
   dependencies:
     debug "4.3.1"
 
-cypress-real-events@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/cypress-real-events/-/cypress-real-events-1.4.0.tgz#39575031a4020581e0bbf105d7a306ee57d94f48"
-  integrity sha512-1s4BQN1D++vFSuaad0qKsWcoApM5tQqPBFyDJEa6JeCZIsAdgMdGLuKi5QNIdl5KTJix0jxglzFJAThyz3borQ==
+cypress-real-events@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/cypress-real-events/-/cypress-real-events-1.7.0.tgz#ad6a78de33af3af0e6437f5c713e30691c44472c"
+  integrity sha512-iyXp07j0V9sG3YClVDcvHN2DAQDgr+EjTID82uWDw6OZBlU3pXEBqTMNYqroz3bxlb0k+F74U81aZwzMNaKyew==
 
 cypress@*:
   version "6.4.0"


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Upgrades `cypress-real-events` library to the latest version
- Gets rid of the warning during installation

Before
`warning " > cypress-real-events@1.4.0" has incorrect peer dependency "cypress@^4.x || ^5.x || ^6.x || ^7.x".`

After
You shouldn't see this warning anymore.