### PR TITLE
E2E on master: only a subset of selective test groups for now

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -49,17 +49,11 @@ jobs:
         edition: [oss, ee]
         folder:
           - "custom-column"
-          - "dashboard"
           - "dashboard-filters"
           - "dashboard-filters-sql"
           - "downloads"
           - "moderation"
-          - "native"
-          - "native-filters"
           - "permissions"
-          - "question"
-          - "sharing"
-          - "smoketest"
     services:
       maildev:
         image: maildev/maildev


### PR DESCRIPTION
Due to Cypress upgrade, we observed failing and/or flakey E2E tests. Rather than disabling this completely, let's narrow down to a few good tests for now while robustifying the rest of them.

For the necessary context, refer to PR #20266.
