### PR TITLE
Skip failing visual test caused by #21026

### DIFF
--- a/frontend/test/metabase-visual/admin/permissions.cy.spec.js
+++ b/frontend/test/metabase-visual/admin/permissions.cy.spec.js
@@ -40,7 +40,8 @@ describe("visual tests > admin > permissions", () => {
       cy.percySnapshot();
     });
 
-    it("modal", () => {
+    // This revealed the infinite loop which resulted in metabase#21026
+    it.skip("modal", () => {
       cy.visit("/collection/root/permissions");
       cy.findByText("Group name");
       cy.percySnapshot();


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Skips the failing test caused by #21026
- In a way, this is also a reproduction of that issue
    - The problem is that it was failing intermittently so I am not sure if it should be labeled as a repro?

It's important to merge this ASAP because our CI is red. Once the underlying issue is fixed, we can try enabling it again.