### PR TITLE
Bump executor for E2E on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,7 @@ executors:
       - image: metabase/qa-databases:postgres-sample-12
       - image: metabase/qa-databases:mongo-sample-4.0
       - image: metabase/qa-databases:mysql-sample-8
+    resource_class: xlarge
 
   java-8:
     working_directory: /home/circleci/metabase/metabase/


### PR DESCRIPTION
After updating the executor on the E2E we could see improvements on the time. The machines were hitting the processor limit with the small one.

Some examples:

e2e-tests-visualizations-oss | 10m23s --> 7m18s (42% faster)
e2e-tests-models-oss | 6m55s --> 5m10s  (33% faster)
e2e-tests-question-oss | 12m1s --> 8m55s  (34% faster)
