### PR TITLE
Add autolink support and better email link handling to backend Markdown parsing

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -39,9 +39,9 @@
   com.snowplowanalytics/snowplow-java-tracker
                                             {:mvn/version "0.11.0"}             ; Snowplow analytics
   com.taoensso/nippy                        {:mvn/version "3.1.1"}              ; Fast serialization (i.e., GZIP) library for Clojure
-  com.vladsch.flexmark/flexmark             {:mvn/version "0.64.0"}             ; Markdown parsing
+  com.vladsch.flexmark/flexmark             {:mvn/version "0.62.2"}             ; Markdown parsing
   com.vladsch.flexmark/flexmark-ext-autolink
-                                            {:mvn/version "0.64.0"}             ; Flexmark extension for auto-linking bare URLs
+                                            {:mvn/version "0.62.2"}             ; Flexmark extension for auto-linking bare URLs
   commons-codec/commons-codec               {:mvn/version "1.15"}               ; Apache Commons -- useful codec util fns
   commons-io/commons-io                     {:mvn/version "2.11.0"}             ; Apache Commons -- useful IO util fns
   commons-validator/commons-validator       {:mvn/version "1.7"                 ; Apache Commons -- useful validation util fns

--- a/deps.edn
+++ b/deps.edn
@@ -39,7 +39,9 @@
   com.snowplowanalytics/snowplow-java-tracker
                                             {:mvn/version "0.11.0"}             ; Snowplow analytics
   com.taoensso/nippy                        {:mvn/version "3.1.1"}              ; Fast serialization (i.e., GZIP) library for Clojure
-  com.vladsch.flexmark/flexmark             {:mvn/version "0.62.2"}             ; Markdown parsing
+  com.vladsch.flexmark/flexmark             {:mvn/version "0.64.0"}             ; Markdown parsing
+  com.vladsch.flexmark/flexmark-ext-autolink
+                                            {:mvn/version "0.64.0"}             ; Flexmark extension for auto-linking bare URLs
   commons-codec/commons-codec               {:mvn/version "1.15"}               ; Apache Commons -- useful codec util fns
   commons-io/commons-io                     {:mvn/version "2.11.0"}             ; Apache Commons -- useful IO util fns
   commons-validator/commons-validator       {:mvn/version "1.7"                 ; Apache Commons -- useful validation util fns
@@ -141,8 +143,8 @@
                                                            org.clojure/tools.logging
                                                            org.clojure/tools.namespace]}
   user-agent/user-agent                     {:mvn/version "0.1.0"}              ; User-Agent string parser, for Login History page & elsewhere
-  weavejester/dependency                    {:mvn/version "0.2.1"}              ; Dependency graphs and topological sorting
-  }
+  weavejester/dependency                    {:mvn/version "0.2.1"}}             ; Dependency graphs and topological sorting
+
  ;; !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
  ;; !!         PLEASE KEEP NEW DEPENDENCIES ABOVE ALPHABETICALLY ORGANIZED AND ADD COMMENTS EXPLAINING THEM.         !!
  ;; !!                            *PLEASE DO NOT* ADD NEW ONES TO THE BOTTOM OF THE LIST.                            !!

--- a/src/metabase/pulse/markdown.clj
+++ b/src/metabase/pulse/markdown.clj
@@ -263,7 +263,9 @@
       :link-ref
       (if-let [resolved-uri (resolve-uri (-> attrs :reference :attrs :url))]
         (str "<" resolved-uri "|" joined-content ">")
-        joined-content)
+        ;; If this was parsed as a link-ref but has no reference, assume it was just a pair of square brackets and
+        ;; restore them. This is a known discrepency between flexmark-java and Markdown rendering on the frontend.
+        (str "[" joined-content "]"))
 
       :auto-link
       (str "<" (:href attrs) ">")
@@ -309,6 +311,16 @@
 
       joined-content)))
 
+(defn- empty-link-ref?
+  "Returns true if this node was parsed as a link ref, but has no references. This probably means the original text
+  was just a pair of square brackets, and not an actual link ref. This is a known discrepency between flexmark-java
+  and Markdown rendering on the frontend."
+  [^Node node]
+  (and (instance? LinkRef node)
+       (-> (.getDocument node)
+           (.get Parser/REFERENCES)
+           empty?)))
+
 (def ^:private renderer
   "An instance of a Flexmark HTML renderer"
   (let [options    (.. (MutableDataSet.)
@@ -318,9 +330,10 @@
                      (^LinkResolver apply [_this ^LinkResolverBasicContext _context]
                        (reify LinkResolver
                          (resolveLink [_this node _context link]
-                           (if-let [url (if (instance? MailLink node)
-                                          (.getUrl link)
-                                          (resolve-uri (.getUrl link)))]
+                           (if-let [url (cond
+                                          (instance? MailLink node) (.getUrl link)
+                                          (empty-link-ref? node) nil
+                                          :else (resolve-uri (.getUrl link)))]
                              (.. link
                                  (withStatus LinkStatus/VALID)
                                  (withUrl url))

--- a/src/metabase/pulse/markdown.clj
+++ b/src/metabase/pulse/markdown.clj
@@ -23,7 +23,7 @@
   "An instance of a Flexmark parser"
   (let [options (.. (MutableDataSet.)
                     (set Parser/EXTENSIONS [(AutolinkExtension/create)]))]
-    (delay (.build (Parser/builder options)))))
+    (.build (Parser/builder options))))
 
 (def ^:private node-to-tag-mapping
   "Mappings from Flexmark AST nodes to keyword tags"
@@ -325,7 +325,7 @@
                                  (withStatus LinkStatus/VALID)
                                  (withUrl url))
                              link)))))]
-    (delay (.build (.linkResolverFactory (HtmlRenderer/builder options) lr-factory)))))
+    (.build (.linkResolverFactory (HtmlRenderer/builder options) lr-factory))))
 
 (defmulti process-markdown
   "Converts a markdown string from a virtual card into a form that can be sent to a channel
@@ -334,12 +334,12 @@
 
 (defmethod process-markdown :mrkdwn
   [markdown _]
-  (-> (.parse ^Parser @parser ^String markdown)
+  (-> (.parse ^Parser parser ^String markdown)
       to-clojure
       ast->mrkdwn
       str/trim))
 
 (defmethod process-markdown :html
   [markdown _]
-  (let [ast (.parse ^Parser @parser ^String markdown)]
-    (.render ^HtmlRenderer @renderer ^Document ast)))
+  (let [ast (.parse ^Parser parser ^String markdown)]
+    (.render ^HtmlRenderer renderer ^Document ast)))

--- a/test/metabase/pulse/markdown_test.clj
+++ b/test/metabase/pulse/markdown_test.clj
@@ -165,7 +165,11 @@
   (testing "HTML entities (outside of HTML tags) are converted to Unicode"
     (is (= "&" (mrkdwn "&amp;")))
     (is (= ">" (mrkdwn "&gt;")))
-    (is (= "ℋ" (mrkdwn "&HilbertSpace;")))))
+    (is (= "ℋ" (mrkdwn "&HilbertSpace;"))))
+
+  (testing "Square brackets that aren't used for a link are left as-is (#20993)"
+    (is (= "[]"     (mrkdwn "[]")))
+    (is (= "[test]" (mrkdwn "[test]")))))
 
 (defn- html
   [markdown]
@@ -198,6 +202,14 @@
            (html "https://metabase.com")))
     (is (= "<p><a href=\"mailto:test@metabase.com\">test@metabase.com</a></p>\n"
            (html "test@metabase.com"))))
+
+  (testing "Link references render as normal links"
+    (is (= "<p><a href=\"https://metabase.com\">metabase</a></p>\n"
+           (html "[metabase]: https://metabase.com\n[metabase]"))))
+
+  (testing "Lone square brackets are preserved as-is (#20993)"
+    (is (= "<p>[]</p>\n"     (html "[]")))
+    (is (= "<p>[test]</p>\n" (html "[test]"))))
 
   (testing "HTML in the source markdown is escaped properly, but HTML entities are retained"
     (is (= "<p>&lt;h1&gt;header&lt;/h1&gt;</p>\n" (html "<h1>header</h1>")))

--- a/test/metabase/pulse/markdown_test.clj
+++ b/test/metabase/pulse/markdown_test.clj
@@ -74,8 +74,13 @@
       (is (= "<https://example.com/foo|Metabase>"   (mrkdwn "[Metabase](/foo)")))))
 
   (testing "Auto-links are preserved"
-    (is (= "<http://metabase.com>"      (mrkdwn "<http://metabase.com>")))
-    (is (= "<mailto:test@metabase.com>" (mrkdwn "<mailto:test@metabase.com>"))))
+    (is (= "<http://metabase.com>"                        (mrkdwn "<http://metabase.com>")))
+    (is (= "<mailto:test@metabase.com>"                   (mrkdwn "<mailto:test@metabase.com>")))
+    (is (= "<mailto:test@metabase.com|test@metabase.com>" (mrkdwn "<test@metabase.com>"))))
+
+  (testing "Bare URLs and email addresses are parsed as links"
+    (is (= "<https://metabase.com>"                       (mrkdwn "https://metabase.com")))
+    (is (= "<mailto:test@metabase.com|test@metabase.com>" (mrkdwn "test@metabase.com"))))
 
   (testing "Link references render as normal links"
     (is (= "<https://metabase.com|metabase>" (mrkdwn "[metabase]: https://metabase.com\n[metabase]")))
@@ -187,6 +192,12 @@
                (html "![alt-text](image.png)")))
         (is (= "<p><a href=\"https://example.com/dashboard/1\">dashboard 1</a></p>\n"
                (html "[dashboard 1](/dashboard/1)"))))))
+
+  (testing "Bare URLs and email addresses are converted to links"
+    (is (= "<p><a href=\"https://metabase.com\">https://metabase.com</a></p>\n"
+           (html "https://metabase.com")))
+    (is (= "<p><a href=\"mailto:test@metabase.com\">test@metabase.com</a></p>\n"
+           (html "test@metabase.com"))))
 
   (testing "HTML in the source markdown is escaped properly, but HTML entities are retained"
     (is (= "<p>&lt;h1&gt;header&lt;/h1&gt;</p>\n" (html "<h1>header</h1>")))


### PR DESCRIPTION
Adds `flexmark-ext-autolink` as a new dependency, since it's not included by default in `flexmark-java`. Adds the `AutoLinkExtension` as a parser extension. 

Also tweaks handling of mail links so that they're linked correctly in both email and Slack, and adds relevant tests.

Resolves #21001