### PR TITLE
Fix markdown parsing of lone pairs of square brackets

### DIFF
--- a/src/metabase/pulse/markdown.clj
+++ b/src/metabase/pulse/markdown.clj
@@ -315,7 +315,7 @@
   "Returns true if this node was parsed as a link ref, but has no references. This probably means the original text
   was just a pair of square brackets, and not an actual link ref. This is a known discrepency between flexmark-java
   and Markdown rendering on the frontend."
-  [node]
+  [^Node node]
   (and (instance? LinkRef node)
        (-> (.getDocument node)
            (.get Parser/REFERENCES)

--- a/test/metabase/pulse/markdown_test.clj
+++ b/test/metabase/pulse/markdown_test.clj
@@ -165,7 +165,11 @@
   (testing "HTML entities (outside of HTML tags) are converted to Unicode"
     (is (= "&" (mrkdwn "&amp;")))
     (is (= ">" (mrkdwn "&gt;")))
-    (is (= "ℋ" (mrkdwn "&HilbertSpace;")))))
+    (is (= "ℋ" (mrkdwn "&HilbertSpace;"))))
+
+  (testing "Square brackets that aren't used for a link are left as-is (#20993)"
+    (is (= "[]"     (mrkdwn "[]")))
+    (is (= "[test]" (mrkdwn "[test]")))))
 
 (defn- html
   [markdown]
@@ -198,6 +202,14 @@
            (html "https://metabase.com")))
     (is (= "<p><a href=\"mailto:test@metabase.com\">test@metabase.com</a></p>\n"
            (html "test@metabase.com"))))
+
+  (testing "Link references render as normal links"
+    (is (= "<p><a href=\"https://metabase.com\">metabase</a></p>\n"
+           (html "[metabase]: https://metabase.com\n[metabase]"))))
+
+  (testing "Lone square brackets are preserved as-is (#20993)"
+    (is (= "<p>[]</p>\n"     (html "[]")))
+    (is (= "<p>[test]</p>\n" (html "[test]"))))
 
   (testing "HTML in the source markdown is escaped properly, but HTML entities are retained"
     (is (= "<p>&lt;h1&gt;header&lt;/h1&gt;</p>\n" (html "<h1>header</h1>")))


### PR DESCRIPTION
Special-casing for Markdown that includes square brackets that isn't part of link syntax, like `[test]`. On the frontend this just displays as-is, but our parser on the backend thinks it's a [link ref](https://www.markdownguide.org/basic-syntax/#reference-style-links) with no references. So we just need to detect this case and force it to what we want, in both the Slack and HTML pipelines.

Resolves #20993