### PR TITLE
Add :can_write to timelines

### DIFF
--- a/test/metabase/api/timeline_test.clj
+++ b/test/metabase/api/timeline_test.clj
@@ -3,6 +3,7 @@
   (:require [clojure.test :refer :all]
             [metabase.http-client :as http]
             [metabase.models.collection :refer [Collection]]
+            [metabase.models.permissions :as perms]
             [metabase.models.timeline :refer [Timeline]]
             [metabase.models.timeline-event :refer [TimelineEvent]]
             [metabase.server.middleware.util :as middleware.u]

--- a/test/metabase/api/timeline_test.clj
+++ b/test/metabase/api/timeline_test.clj
@@ -47,7 +47,15 @@
       (testing "check that we get the timeline with the id specified, even if the timeline is archived"
         (is (= "Timeline B"
                (->> (mt/user-http-request :rasta :get 200 (str "timeline/" (u/the-id tl-b)))
-                    :name)))))))
+                    :name)))))
+    (testing "check that `can_write` derives from the timeline's collection"
+      (mt/with-non-admin-groups-no-root-collection-perms
+        (mt/with-temp* [Collection [collection {:name "No-Write-Collection"}]
+                        Timeline [timeline {:name "Timeline A" :collection_id (u/the-id collection)}]]
+          (mt/with-group [g {:name "group"}] (perms/grant-collection-read-permissions! g collection)
+            (is (= false
+                   (->> (mt/user-http-request :rasta :get 200 (str "timeline/" (u/the-id timeline)))
+                        :can_write)))))))))
 
 (defn- timelines-range-request
   [timeline {:keys [start end]}]


### PR DESCRIPTION
Add a :can_write boolean to the timeline object for `GET /api/timeline` and `GET /api/timeline/:id` because, per a discussion in slack:

"the problem is that there is currently no way to check for write permissions when we show all timelines"

Prior, using collection.can_write worked, but there may be situations where all timelines are not from the same collection, so each must have can_write populated for the current user.