### PR TITLE
Increase no_output_timeout to DB tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -715,7 +715,7 @@ jobs:
         type: string
       timeout:
         type: string
-        default: 15m
+        default: 20m
       before-steps:
         type: steps
         default: []


### PR DESCRIPTION
We are having some failures on DB tests due to `Too long with no output (exceeded 15m0s): context deadline exceeded`.

So this PR increase this to 20 min to avoid breaking the test in the middle of it.

Ex: https://app.circleci.com/pipelines/github/metabase/metabase/30936/workflows/9fdeec18-b78e-4142-9b75-b6d4c69ef1e2/jobs/1556492

This is happening to `be-tests-sparksql-ee` , `be-tests-mysql-latest-ee` and others in a intermittent way