### PR TITLE
Fix string quoting in custom expression

### DIFF
--- a/frontend/src/metabase/lib/expressions/tokenizer.js
+++ b/frontend/src/metabase/lib/expressions/tokenizer.js
@@ -209,6 +209,9 @@ export function tokenize(expression) {
             case "v":
               value += "\x0b";
               break;
+            case '"':
+              value += '"';
+              break;
             default:
               value += seq;
               break;

--- a/frontend/test/metabase/lib/expressions/index.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/index.unit.spec.js
@@ -1,0 +1,73 @@
+import { quoteString, unquoteString } from "metabase/lib/expressions/";
+
+describe("metabase/lib/expressions/format", () => {
+  // double- and single-quote
+  const dq = str => quoteString(str, '"');
+  const sq = str => quoteString(str, "'");
+
+  describe("quoteString", () => {
+    it("should enclose a string literal with double quotes", () => {
+      expect(dq("A")).toEqual('"A"');
+      expect(dq("XYZ")).toEqual('"XYZ"');
+    });
+
+    it("should enclose a string literal with single quotes", () => {
+      expect(sq("B")).toEqual("'B'");
+      expect(sq("PQR")).toEqual("'PQR'");
+    });
+
+    it("should escape quotes inside the string literal", () => {
+      expect(dq('C"D')).toEqual('"C\\"D"');
+      expect(sq("E'F")).toEqual("'E\\'F'");
+    });
+
+    it("should escape some special characters in a double-quoted string", () => {
+      expect(dq("\b")).toEqual('"\\b"');
+      expect(dq("Tab: \t")).toEqual('"Tab: \\t"');
+      expect(dq("CR: \r")).toEqual('"CR: \\r"');
+      expect(dq("LF: \n")).toEqual('"LF: \\n"');
+      expect(dq("FF: \f")).toEqual('"FF: \\f"');
+      expect(dq("Backslash: \\")).toEqual('"Backslash: \\"');
+    });
+
+    it("should escape some special characters in a single-quoted string", () => {
+      expect(sq("\b")).toEqual("'\\b'");
+      expect(sq("Tab: \t")).toEqual("'Tab: \\t'");
+      expect(sq("CR: \r")).toEqual("'CR: \\r'");
+      expect(sq("LF: \n")).toEqual("'LF: \\n'");
+      expect(sq("FF: \f")).toEqual("'FF: \\f'");
+      expect(sq("Backslash: \\")).toEqual("'Backslash: \\'");
+    });
+  });
+
+  describe("unquoteString", () => {
+    it("should handle double-quoted strings", () => {
+      expect(unquoteString('"A"')).toEqual("A");
+      expect(unquoteString('"PQ"')).toEqual("PQ");
+      expect(unquoteString('"XYZ"')).toEqual("XYZ");
+      expect(unquoteString('"foo bar"')).toEqual("foo bar");
+    });
+
+    it("should handle single-quoted strings", () => {
+      expect(unquoteString("'A'")).toEqual("A");
+      expect(unquoteString("'PQ'")).toEqual("PQ");
+      expect(unquoteString("'XYZ'")).toEqual("XYZ");
+      expect(unquoteString("'foo bar'")).toEqual("foo bar");
+    });
+
+    it("should perform faithful round-trip operations with double-quoted strings", () => {
+      const rt = str => unquoteString(quoteString(str, "'"));
+      expect(rt("A")).toEqual("A");
+      expect(rt("PQ")).toEqual("PQ");
+      expect(rt("XYZ")).toEqual("XYZ");
+      expect(rt("foo bar")).toEqual("foo bar");
+      expect(rt("\b")).toEqual("\b");
+      expect(rt("Tab: \t")).toEqual("Tab: \t");
+      expect(rt("CR: \r")).toEqual("CR: \r");
+      expect(rt("LF: \n")).toEqual("LF: \n");
+      expect(rt("FF: \f")).toEqual("FF: \f");
+      expect(rt("Backslash: \\")).toEqual("Backslash: \\");
+      expect(rt("\b\t\r\n\f\\").length).toEqual(6);
+    });
+  });
+});


### PR DESCRIPTION
Custom expression does not follow JSON standard (RFC 4627) and therefore
it's not possible to use use JSON.stringify to quote a string literal.

How to verify manually:
1. New, Question, Sample Database, Products table
2. Custom Column, type `lower("c:\command.com")` and call it e.g. `test`

### Before this PR

As the focus switches to the column name, the expression is unnecessarily modified to `lower("c:\\command.com")`. Note the duplicated blackslashes.

![image](https://user-images.githubusercontent.com/7288/159030218-363a7d2e-fc65-4ba5-b305-48578f723433.png)

In fact, it's worse because continuous focus and defocus of the custom expression editor keeps adding more blackslashes infinitely.

![image](https://user-images.githubusercontent.com/7288/159030624-83da1249-f5e6-4c30-a0a5-3250dc2d0495.png)

### After this PR

Expressions containing `\` does not incorrectly become longer and longer.

![image](https://user-images.githubusercontent.com/7288/159030907-e9bbdcac-776d-423f-9fcb-33b859a7c37f.png)
