### PR TITLE
Increase E2E QA DBs timeout

### DIFF
--- a/frontend/test/__support__/e2e/helpers/e2e-qa-databases-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-qa-databases-helpers.js
@@ -53,8 +53,9 @@ function addQADatabase(engine, db_display_name, port) {
         schedule_type: "hourly",
       },
     },
-  }).then(({ status }) => {
+  }).then(({ status, body }) => {
     expect(status).to.equal(200);
+    cy.wrap(body.id).as(`${engine}ID`);
   });
 
   // Make sure we have all the metadata because we'll need to use it in tests

--- a/frontend/test/__support__/e2e/helpers/e2e-qa-databases-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-qa-databases-helpers.js
@@ -72,12 +72,12 @@ function assertOnDatabaseMetadata(engine) {
 }
 
 function recursiveCheck(id, i = 0) {
-  // Let's not wait more than 2s for the sync to finish
+  // Let's not wait more than 5s for the sync to finish
   if (i === 20) {
-    throw new Error();
+    throw new Error("The sync is taking too long. Something is wrong.");
   }
 
-  cy.wait(100);
+  cy.wait(250);
 
   cy.request("GET", `/api/database/${id}`).then(({ body: database }) => {
     if (database.initial_sync_status !== "complete") {

--- a/frontend/test/snapshot-creators/qa-db.cy.snap.js
+++ b/frontend/test/snapshot-creators/qa-db.cy.snap.js
@@ -14,18 +14,19 @@ describe("qa databases snapshots", () => {
   it("creates snapshots for supported qa databases", () => {
     addPostgresDatabase();
     snapshot("postgres-12");
+    deleteDatabase("postgresID");
 
     restoreAndAuthenticate();
 
-    cy.wait(1000);
     addMySQLDatabase();
     snapshot("mysql-8");
+    deleteDatabase("mysqlID");
 
     restoreAndAuthenticate();
 
-    cy.wait(1000);
     addMongoDatabase();
     snapshot("mongo-4");
+    deleteDatabase("mongoID");
 
     restore("blank");
   });
@@ -34,4 +35,10 @@ describe("qa databases snapshots", () => {
 function restoreAndAuthenticate() {
   restore("default");
   cy.signInAsAdmin();
+}
+
+function deleteDatabase(idAlias) {
+  cy.get("@" + idAlias).then(id => {
+    return cy.request("DELETE", `/api/database/${id}`);
+  });
 }


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Increases the timeout needed for QA DBs to finish syncing their metadata
- Introduces a "hack" that seems to prevent race conditions by deleting previously added database before we attempt to restore a testing snapshot
- This same principle was used [HERE](https://github.com/metabase/metabase/blob/master/frontend/test/snapshot-creators/default.cy.snap.js#L249:L253) - please take a look and observe the comments

### Notes:
- Adding MongoDB via `POST` request takes significantly longer than PostreSQL or MySQL. 10s vs 75ms, respectively!
    - This was probably the reason why @noahmoss saw the reduced flakiness when he moved Mongo to the end of the queue (see: https://github.com/metabase/metabase/pull/19311/files#r766951446)
- Deleting a database after the snapshot of it has been taken is a workaround and not a final solution. It seems better than arbitrary waiting for 1000ms. This indicates the possible race condition when one DB sync somehow interferes with the other one, but it's hard to reproduce in the real world environment. I guess in order to reproduce it, one would need to:
1. Add a database programmatically
2. Shut down the Metabase instance interrupting the sync
3. Spin up the Metabase instance again
4. Add a new database programmatically and observe how its sync isn't able to finish