### PR TITLE
Browsing | Fix main app bar when user is not signed in

### DIFF
--- a/frontend/src/metabase/App.jsx
+++ b/frontend/src/metabase/App.jsx
@@ -91,7 +91,13 @@ export default class App extends Component {
   };
 
   render() {
-    const { children, location, errorPage, onChangeLocation } = this.props;
+    const {
+      children,
+      location,
+      errorPage,
+      onChangeLocation,
+      currentUser,
+    } = this.props;
     const { errorInfo } = this.state;
 
     return (
@@ -104,27 +110,32 @@ export default class App extends Component {
             getErrorComponent(errorPage)
           ) : (
             <div className="full overflow-auto flex flex-column">
-              <div
-                className="full flex align-center bg-white border-bottom px2 relative z4"
-                id="mainAppBar"
-              >
-                <Icon
-                  name="burger"
-                  className="text-brand-hover cursor-pointer"
-                  onClick={() => this.toggleSidebar()}
-                />
-                <SearchBarContainer>
-                  <SearchBarContent>
-                    <SearchBar
-                      location={location}
-                      onChangeLocation={onChangeLocation}
+              {currentUser && (
+                <div
+                  className="full flex align-center bg-white border-bottom px2 relative z4"
+                  id="mainAppBar"
+                >
+                  <Icon
+                    name="burger"
+                    className="text-brand-hover cursor-pointer"
+                    onClick={() => this.toggleSidebar()}
+                  />
+                  <SearchBarContainer>
+                    <SearchBarContent>
+                      <SearchBar
+                        location={location}
+                        onChangeLocation={onChangeLocation}
+                      />
+                    </SearchBarContent>
+                  </SearchBarContainer>
+                  <div className="ml-auto">
+                    <ProfileLink
+                      {...this.props}
+                      user={this.props.currentUser}
                     />
-                  </SearchBarContent>
-                </SearchBarContainer>
-                <div className="ml-auto">
-                  <ProfileLink {...this.props} user={this.props.currentUser} />
+                  </div>
                 </div>
-              </div>
+              )}
               {children}
             </div>
           )}

--- a/frontend/src/metabase/nav/components/ProfileLink.jsx
+++ b/frontend/src/metabase/nav/components/ProfileLink.jsx
@@ -38,7 +38,7 @@ export default class ProfileLink extends Component {
     const { tag } = MetabaseSettings.get("version");
     const { user } = this.props;
     const canAccessSettings =
-      user?.is_superuser ||
+      user.is_superuser ||
       PLUGIN_FEATURE_LEVEL_PERMISSIONS.canAccessSettings(user);
 
     return [


### PR DESCRIPTION
This PR hides the new app bar when a user is not signed in (e.g. on setup or login pages)

### To Verify

1. Launch a clean Metabase instance or sign out
2. Make sure you don't see the app bar at the top of the page

### Demo

**Before**
<img width="1509" alt="CleanShot 2022-03-17 at 13 45 04@2x" src="https://user-images.githubusercontent.com/17258145/158824214-1cec5c0c-56aa-42b2-9677-7fe87625b256.png">

**After**

<img width="1505" alt="CleanShot 2022-03-17 at 13 44 30@2x" src="https://user-images.githubusercontent.com/17258145/158824182-8a53e2c8-9044-4434-8632-cceafbe9db15.png">
