### PR TITLE
Browsing | Handle long item names in the sidebar

### DIFF
--- a/frontend/src/metabase/collections/components/CollectionSidebar/Bookmarks/Bookmarks.tsx
+++ b/frontend/src/metabase/collections/components/CollectionSidebar/Bookmarks/Bookmarks.tsx
@@ -4,7 +4,10 @@ import { t } from "ttag";
 import * as Urls from "metabase/lib/urls";
 
 import Link from "metabase/collections/components/CollectionSidebar/CollectionSidebarLink";
-import { LabelContainer } from "../Collections/CollectionsList/CollectionsList.styled";
+import {
+  LabelContainer,
+  LabelText,
+} from "../Collections/CollectionsList/CollectionsList.styled";
 import BookmarksRoot, {
   BookmarkLinkRoot,
   BookmarkTypeIcon,
@@ -38,7 +41,7 @@ const Label = ({ name, type }: LabelProps) => {
   return (
     <LabelContainer>
       <BookmarkTypeIcon name={iconName} />
-      {name}
+      <LabelText>{name}</LabelText>
     </LabelContainer>
   );
 };

--- a/frontend/src/metabase/collections/components/CollectionSidebar/Collections/CollectionsList/CollectionsList.jsx
+++ b/frontend/src/metabase/collections/components/CollectionSidebar/Collections/CollectionsList/CollectionsList.jsx
@@ -8,6 +8,7 @@ import {
   ChildrenContainer,
   ExpandCollectionButton,
   LabelContainer,
+  LabelText,
 } from "./CollectionsList.styled";
 
 import CollectionLink from "metabase/collections/components/CollectionSidebar/CollectionSidebarLink";
@@ -58,7 +59,7 @@ function Label({ action, depth, collection, isOpen }) {
         collection={collection}
         targetOffsetX={targetOffsetX}
       />
-      {name}
+      <LabelText>{name}</LabelText>
     </LabelContainer>
   );
 }

--- a/frontend/src/metabase/collections/components/CollectionSidebar/Collections/CollectionsList/CollectionsList.styled.jsx
+++ b/frontend/src/metabase/collections/components/CollectionSidebar/Collections/CollectionsList/CollectionsList.styled.jsx
@@ -1,9 +1,11 @@
+import React from "react";
 import styled from "@emotion/styled";
 import { PLUGIN_COLLECTIONS } from "metabase/plugins";
 import {
   ROOT_COLLECTION,
   PERSONAL_COLLECTIONS,
 } from "metabase/entities/collections";
+import Tooltip from "metabase/components/Tooltip";
 import { CollectionIcon } from "metabase/collections/components/CollectionIcon";
 
 const { isRegularCollection } = PLUGIN_COLLECTIONS;
@@ -42,9 +44,9 @@ export const ExpandCollectionButton = styled(IconButtonWrapper)`
   position: absolute;
 `;
 
-const COLLECTION_NAME_LABEL_WIDTH = Math.round(
-  parseInt(SIDEBAR_WIDTH, 10) * 0.75,
-);
+const ITEM_NAME_LENGTH_TOOLTIP_THRESHOLD = 35;
+
+const ITEM_NAME_LABEL_WIDTH = Math.round(parseInt(SIDEBAR_WIDTH, 10) * 0.75);
 
 export const LabelContainer = styled.div`
   display: flex;
@@ -52,9 +54,20 @@ export const LabelContainer = styled.div`
   position: relative;
 `;
 
-export const LabelText = styled.span`
-  width: ${COLLECTION_NAME_LABEL_WIDTH}px;
+const Label = styled.span`
+  width: ${ITEM_NAME_LABEL_WIDTH}px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 `;
+
+export function LabelText({ children: itemName }) {
+  if (itemName.length >= ITEM_NAME_LENGTH_TOOLTIP_THRESHOLD) {
+    return (
+      <Tooltip tooltip={itemName} maxWidth={null}>
+        <Label>{itemName}</Label>
+      </Tooltip>
+    );
+  }
+  return itemName;
+}

--- a/frontend/src/metabase/collections/components/CollectionSidebar/Collections/CollectionsList/CollectionsList.styled.jsx
+++ b/frontend/src/metabase/collections/components/CollectionSidebar/Collections/CollectionsList/CollectionsList.styled.jsx
@@ -8,7 +8,7 @@ import { CollectionIcon } from "metabase/collections/components/CollectionIcon";
 
 const { isRegularCollection } = PLUGIN_COLLECTIONS;
 
-import { SIDEBAR_SPACER } from "metabase/collections/constants";
+import { SIDEBAR_SPACER, SIDEBAR_WIDTH } from "metabase/collections/constants";
 import { color } from "metabase/lib/colors";
 
 import IconButtonWrapper from "metabase/components/IconButtonWrapper";
@@ -42,8 +42,19 @@ export const ExpandCollectionButton = styled(IconButtonWrapper)`
   position: absolute;
 `;
 
+const COLLECTION_NAME_LABEL_WIDTH = Math.round(
+  parseInt(SIDEBAR_WIDTH, 10) * 0.75,
+);
+
 export const LabelContainer = styled.div`
   display: flex;
   align-items: center;
   position: relative;
+`;
+
+export const LabelText = styled.span`
+  width: ${COLLECTION_NAME_LABEL_WIDTH}px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 `;


### PR DESCRIPTION
This PR makes it ellipsify long item names in the sidebar (bookmarks and collections)

### To Verify

1. Create a collection and a question with long names
2. Make sure their names are truncated in the sidebar

### Demo

**Before**
<img width="316" alt="before-long-name" src="https://user-images.githubusercontent.com/17258145/158855465-1b227246-1460-486a-8429-e20290358ecd.png">

**After**
<img width="314" alt="CleanShot 2022-03-17 at 16 51 28@2x" src="https://user-images.githubusercontent.com/17258145/158855479-f917f4c9-2cfd-441f-9d61-23062e448ff7.png">

