### PR TITLE
Browsing | Hide sidebar for questions, models and dashboards on page open

### DIFF
--- a/frontend/src/metabase/App.jsx
+++ b/frontend/src/metabase/App.jsx
@@ -59,11 +59,23 @@ const getErrorComponent = ({ status, data, context }) => {
 
 const PATHS_WITHOUT_NAVBAR = [/\/model\/.*\/query/, /\/model\/.*\/metadata/];
 
+const PATHS_WITH_COLLAPSED_NAVBAR = [
+  /\/model\/.*/,
+  /\/question\/.*/,
+  /\/dashboard\/.*/,
+];
+
+function checkIsSidebarInitiallyOpen(locationPathName) {
+  return !PATHS_WITH_COLLAPSED_NAVBAR.some(pattern =>
+    pattern.test(locationPathName),
+  );
+}
+
 @connect(mapStateToProps, mapDispatchToProps)
 export default class App extends Component {
   state = {
     errorInfo: undefined,
-    sidebarOpen: true,
+    sidebarOpen: checkIsSidebarInitiallyOpen(this.props.location.pathname),
   };
 
   constructor(props) {

--- a/frontend/src/metabase/App.jsx
+++ b/frontend/src/metabase/App.jsx
@@ -60,9 +60,9 @@ const getErrorComponent = ({ status, data, context }) => {
 const PATHS_WITHOUT_NAVBAR = [/\/model\/.*\/query/, /\/model\/.*\/metadata/];
 
 const PATHS_WITH_COLLAPSED_NAVBAR = [
-  /\/model\/.*/,
-  /\/question\/.*/,
-  /\/dashboard\/.*/,
+  /\/model.*/,
+  /\/question.*/,
+  /\/dashboard.*/,
 ];
 
 function checkIsSidebarInitiallyOpen(locationPathName) {


### PR DESCRIPTION
This PR makes the navigation sidebar hidden by default on question, model, and dashboard pages. When any other page is open, the sidebar is open by default. It only happens when you open a new Metabase tab, so if you open a collection page in a new tab, and then open a dashboard, the sidebar won't collapse.

### To Verify

1. Open the homepage, reload the page, the sidebar should be open
2. Open a collection, reload the page, the sidebar should be open
3. Open a saved question, reload the page, the sidebar should be collapsed
4. Open an ad-hoc question, reload the page, the sidebar should be collapsed
5. Open a model, reload the page, the sidebar should be collapsed
6. Open a dashboard, reload the page, the sidebar should be collapsed

### Demo

https://user-images.githubusercontent.com/17258145/158862038-74900fba-8000-4d55-a778-7604921574ed.mp4

