### PR TITLE
Browsing | Automatically hide sidebar for questions, models and dashboards

### DIFF
--- a/frontend/src/metabase/App.jsx
+++ b/frontend/src/metabase/App.jsx
@@ -87,12 +87,16 @@ export default class App extends Component {
     this.setState({ errorInfo });
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(prevProps) {
+    const { pathname: previousPathName } = prevProps.location;
     const { pathname } = this.props.location;
     const { sidebarOpen } = this.state;
-    const shouldSidebarBeVisible = getNextSidebarVisibilityState(pathname);
-    if (sidebarOpen !== shouldSidebarBeVisible) {
-      this.setState({ sidebarOpen: shouldSidebarBeVisible });
+    const isLocationChange = previousPathName !== pathname;
+    if (isLocationChange) {
+      const shouldSidebarBeVisible = getNextSidebarVisibilityState(pathname);
+      if (sidebarOpen !== shouldSidebarBeVisible) {
+        this.setState({ sidebarOpen: shouldSidebarBeVisible });
+      }
     }
   }
 

--- a/frontend/src/metabase/App.jsx
+++ b/frontend/src/metabase/App.jsx
@@ -59,11 +59,23 @@ const getErrorComponent = ({ status, data, context }) => {
 
 const PATHS_WITHOUT_NAVBAR = [/\/model\/.*\/query/, /\/model\/.*\/metadata/];
 
+const PATHS_WITH_COLLAPSED_NAVBAR = [
+  /\/model\/.*/,
+  /\/question\/.*/,
+  /\/dashboard\/.*/,
+];
+
+function checkIsSidebarInitiallyOpen(locationPathName) {
+  return !PATHS_WITH_COLLAPSED_NAVBAR.some(pattern =>
+    pattern.test(locationPathName),
+  );
+}
+
 @connect(mapStateToProps, mapDispatchToProps)
 export default class App extends Component {
   state = {
     errorInfo: undefined,
-    sidebarOpen: true,
+    sidebarOpen: checkIsSidebarInitiallyOpen(this.props.location.pathname),
   };
 
   constructor(props) {

--- a/frontend/src/metabase/App.jsx
+++ b/frontend/src/metabase/App.jsx
@@ -65,7 +65,7 @@ const PATHS_WITH_COLLAPSED_NAVBAR = [
   /\/dashboard\/.*/,
 ];
 
-function checkIsSidebarInitiallyOpen(locationPathName) {
+function getNextSidebarVisibilityState(locationPathName) {
   return !PATHS_WITH_COLLAPSED_NAVBAR.some(pattern =>
     pattern.test(locationPathName),
   );
@@ -75,7 +75,7 @@ function checkIsSidebarInitiallyOpen(locationPathName) {
 export default class App extends Component {
   state = {
     errorInfo: undefined,
-    sidebarOpen: checkIsSidebarInitiallyOpen(this.props.location.pathname),
+    sidebarOpen: getNextSidebarVisibilityState(this.props.location.pathname),
   };
 
   constructor(props) {
@@ -85,6 +85,15 @@ export default class App extends Component {
 
   componentDidCatch(error, errorInfo) {
     this.setState({ errorInfo });
+  }
+
+  componentDidUpdate() {
+    const { pathname } = this.props.location;
+    const { sidebarOpen } = this.state;
+    const shouldSidebarBeVisible = getNextSidebarVisibilityState(pathname);
+    if (sidebarOpen !== shouldSidebarBeVisible) {
+      this.setState({ sidebarOpen: shouldSidebarBeVisible });
+    }
   }
 
   hasNavbar = () => {

--- a/frontend/src/metabase/App.jsx
+++ b/frontend/src/metabase/App.jsx
@@ -60,9 +60,9 @@ const getErrorComponent = ({ status, data, context }) => {
 const PATHS_WITHOUT_NAVBAR = [/\/model\/.*\/query/, /\/model\/.*\/metadata/];
 
 const PATHS_WITH_COLLAPSED_NAVBAR = [
-  /\/model\/.*/,
-  /\/question\/.*/,
-  /\/dashboard\/.*/,
+  /\/model.*/,
+  /\/question.*/,
+  /\/dashboard.*/,
 ];
 
 function getNextSidebarVisibilityState(locationPathName) {


### PR DESCRIPTION
### To Verify

1. Open the homepage, reload the page, the sidebar should be open
2. Open a collection, reload the page, the sidebar should be open
3. Open a saved question, reload the page, the sidebar should be collapsed
4. Open an ad-hoc question, reload the page, the sidebar should be collapsed
5. Open a model, reload the page, the sidebar should be collapsed
6. Open a dashboard, reload the page, the sidebar should be collapsed
7. From any collection page, open a model, a saved question, and a dashboard. The sidebar should collapse once the page changes. Also ensure you can still open/close the sidebar with the "burger" icon at the top left

### Demo

https://user-images.githubusercontent.com/17258145/158862170-2c6005c7-c5b8-4b2c-8c7e-f0c15b5ad6ba.mp4


