### PR TITLE
Fix E2E binning sidebar flakes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1246,14 +1246,26 @@ workflows:
               edition: ["ee", "oss"]
               folder:
                 [
+                  "admin",
                   "binning",
-                  "binning",
-                  "binning",
-                  "binning",
-                  "binning",
-                  "binning",
-                  "binning",
-                  "binning",
+                  "collections",
+                  "custom-column",
+                  "dashboard",
+                  "dashboard-filters",
+                  "dashboard-filters-sql",
+                  "downloads",
+                  "embedding",
+                  "joins",
+                  "models",
+                  "moderation",
+                  "native",
+                  "native-filters",
+                  "onboarding",
+                  "permissions",
+                  "question",
+                  "sharing",
+                  "smoketest",
+                  "visualizations",
                 ]
           name: e2e-tests-<< matrix.folder >>-<< matrix.edition >>
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1246,26 +1246,14 @@ workflows:
               edition: ["ee", "oss"]
               folder:
                 [
-                  "admin",
                   "binning",
-                  "collections",
-                  "custom-column",
-                  "dashboard",
-                  "dashboard-filters",
-                  "dashboard-filters-sql",
-                  "downloads",
-                  "embedding",
-                  "joins",
-                  "models",
-                  "moderation",
-                  "native",
-                  "native-filters",
-                  "onboarding",
-                  "permissions",
-                  "question",
-                  "sharing",
-                  "smoketest",
-                  "visualizations",
+                  "binning",
+                  "binning",
+                  "binning",
+                  "binning",
+                  "binning",
+                  "binning",
+                  "binning",
                 ]
           name: e2e-tests-<< matrix.folder >>-<< matrix.edition >>
           requires:

--- a/frontend/test/__support__/e2e/helpers/e2e-bi-basics-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-bi-basics-helpers.js
@@ -20,6 +20,9 @@ function initiateAction(actionType, mode) {
       .find(`.Icon-${icon}`)
       .click();
   } else {
+    // This line could potentially reduce or completely eliminate binning flakes where sidebar renders empty because of the race condition
+    cy.findByText(/^Doing science/).should("not.exist");
+
     cy.findByTestId("qb-header-action-panel")
       .contains(actionType)
       .click();


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Attempts to fix a few remaining flakes in the binning e2e group where the sidebar renders empty, instead of with the pre-selected "Count" aggregation

NOTE:
This seems to be happening only in CircleCI. I don't remember seeing it when we run Cypress using GitHub Actions.

The example of the latest failed run:
https://app.circleci.com/pipelines/github/metabase/metabase/30975/workflows/e35ad715-766d-43ca-956f-1e3d7a0f2b35/jobs/1559350

### Explanation
When one clicks on the "Summarize" button from the simple question mode, the sidebar opens with the "Count" selected by default. Due to some race condition, it sometimes renders without that aggregation, offering one to "Add a metric". This is where Cypress tests are failing.

Looking at the recorded videos of the failed runs, I've noticed something strange which was hard to catch before. Notice how UI first renders sidebar correctly at time mark 0:06
![image](https://user-images.githubusercontent.com/31325167/158862514-a10367c4-e061-41f8-b234-b804e7e7931a.png)

but then, a few milliseconds later at 0:07 it rerenders and it shows "Add a metric"
![image](https://user-images.githubusercontent.com/31325167/158862729-918ecb60-21f8-472a-9559-20e0552e6fa6.png)

Seeing that the table results still haven't loaded in the first screenshot (note the "Doing science ...") made me think that this could be the root cause. We're explicitly waiting for the `dataset` XHR to load, which **should have been** enough and which should've ensured that the result was rendered on the page. Apparently, sometimes there can be a slight UI lag that is enough to cause the race condition which results in the test failure as seen in the screenshots above.
