### PR TITLE
Robustify E2E model tests by waiting for the dataset to arrive first

### DIFF
--- a/frontend/test/metabase/scenarios/models/models.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models.cy.spec.js
@@ -30,6 +30,7 @@ describe("scenarios > models", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
+    cy.intercept("POST", "/api/dataset").as("dataset");
   });
 
   it("allows to turn a GUI question into a model", () => {
@@ -170,6 +171,7 @@ describe("scenarios > models", () => {
   it("redirects to /model URL when opening a model with /question URL", () => {
     cy.request("PUT", "/api/card/1", { dataset: true });
     cy.visit("/question/1");
+    cy.wait("@dataset");
     openDetailsSidebar();
     assertIsModel();
     cy.url().should("include", "/model");
@@ -289,6 +291,7 @@ describe("scenarios > models", () => {
 
     it("can create a question by filtering and summarizing a model", () => {
       cy.visit("/question/1");
+      cy.wait("@dataset");
 
       filter();
       selectDimensionOptionFromSidebar("Discount");
@@ -328,6 +331,7 @@ describe("scenarios > models", () => {
 
     it("can create a question using table click actions", () => {
       cy.visit("/question/1");
+      cy.wait("@dataset");
 
       cy.findByText("Subtotal").click();
       selectFromDropdown("Sum over time");
@@ -354,6 +358,7 @@ describe("scenarios > models", () => {
     it("can edit model info", () => {
       cy.intercept("PUT", "/api/card/1").as("updateCard");
       cy.visit("/question/1");
+      cy.wait("@dataset");
 
       openDetailsSidebar();
       getDetailsSidebarActions().within(() => {


### PR DESCRIPTION
### Before this PR

Occasionally, `models.cy.spec.js` failed on CI due to the following:

![scenarios  models -- simple mode -- can create a question using table click actions (failed) (attempt 2)](https://user-images.githubusercontent.com/7288/158872115-348db2eb-a5b2-4cb3-921b-d21470ecf606.png)

### After this PR

That kind of failure should never (ever ever) happen again.