### PR TITLE
Enabling Currents.dev on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -911,6 +911,9 @@ jobs:
       folder:
         type: string
         default: ""
+      currents-record:
+        type: boolean
+        default: false
       test-files:
         type: string
         default: ""
@@ -943,9 +946,12 @@ jobs:
                       name: Restore cached uberjar built in previous step
                       <<: *CacheKeyUberjar
                   - steps: << parameters.before-steps >>
-                # Make both `test-files` and `source-folder` parameters optional. Translates to: if `parameter` => run associated flag (`--spec` and `--folder`, respectively)
+                # Make both `test-files`,  `source-folder` and `currents-record` parameters optional. Translates to: if `parameter` => run associated flag (`--spec`, `--folder` and `--key $CURRENTS_KEY --record` respectively)
                 command: |
-                  run test-cypress-no-build <<# parameters.test-files >> --spec << parameters.test-files >> <</ parameters.test-files >> <<# parameters.source-folder >> --folder << parameters.source-folder >> <</ parameters.source-folder >>
+                  run test-cypress-no-build \
+                  <<# parameters.test-files >> --spec << parameters.test-files >> <</ parameters.test-files >> \
+                  <<# parameters.currents-record >> --key $CURRENTS_KEY --record << parameters.currents-record >> <</ parameters.currents-record >> \
+                  <<# parameters.source-folder >> --folder << parameters.source-folder >> --group << parameters.source-folder >> <</ parameters.source-folder >>
                 after-steps:
                   - store_artifacts:
                       path: /home/circleci/metabase/metabase/cypress
@@ -1273,6 +1279,7 @@ workflows:
             - snowplow-deps
           cypress-group: "<< matrix.folder >>-<< matrix.edition >>"
           source-folder: << matrix.folder >>
+          currents-record: true
           qa-db: true
           snowplow: true
           before-steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -950,7 +950,7 @@ jobs:
                 command: |
                   run test-cypress-no-build \
                   <<# parameters.test-files >> --spec << parameters.test-files >> <</ parameters.test-files >> \
-                  <<# parameters.currents-record >> --key $CURRENTS_KEY --record << parameters.currents-record >> <</ parameters.currents-record >> \
+                  <<# parameters.currents-record >> --key $CURRENTS_KEY --record <</ parameters.currents-record >> \
                   <<# parameters.source-folder >> --folder << parameters.source-folder >> --group << parameters.source-folder >> <</ parameters.source-folder >>
                 after-steps:
                   - store_artifacts:

--- a/frontend/test/__support__/e2e/cypress.json
+++ b/frontend/test/__support__/e2e/cypress.json
@@ -5,6 +5,7 @@
   "supportFile": "frontend/test/__support__/e2e/cypress.js",
   "videoUploadOnPasses": false,
   "chromeWebSecurity": false,
+  "projectId": "CJQWRC",
   "viewportHeight": 800,
   "viewportWidth": 1280,
   "retries": {


### PR DESCRIPTION
This PR enables the Cypress tests to send their results to  [Currents.dev](http://currents.dev/)

<img width="1101" alt="Screen Shot 2022-03-17 at 17 24 30" src="https://user-images.githubusercontent.com/17742979/158889236-337a3baa-5360-40f1-ac76-fdbfd28e7054.png">


Link to run: https://app.currents.dev/run/b2a895aadb5bf8597ca63c65bd8817a0