### PR TITLE
Migrate snippet sidebar to TippyPopoverWithTrigger

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx
@@ -4,7 +4,7 @@ import { t } from "ttag";
 
 import MetabaseSettings from "metabase/lib/settings";
 import { canonicalCollectionId } from "metabase/collections/utils";
-import PopoverWithTrigger from "metabase/components/PopoverWithTrigger";
+import TippyPopoverWithTrigger from "metabase/components/PopoverWithTrigger/TippyPopoverWithTrigger";
 import AccordionList from "metabase/core/components/AccordionList";
 import Icon from "metabase/components/Icon";
 
@@ -29,22 +29,22 @@ export default class CollectionOptionsButton extends React.Component {
         // cap the large ellipsis so it doesn't increase the row height
         style={{ height: ICON_SIZE }}
       >
-        <PopoverWithTrigger
-          triggerElement={
+        <TippyPopoverWithTrigger
+          triggerContent={
             <Icon name="ellipsis" size={20} className="hover-child" />
           }
-        >
-          {({ onClose }) => (
+          placement="bottom-end"
+          popoverContent={({ closePopover }) => (
             <AccordionList
               className="text-brand"
               sections={[{ items }]}
               onChange={item => {
                 item.onClick();
-                onClose();
+                closePopover();
               }}
             />
           )}
-        </PopoverWithTrigger>
+        />
       </div>
     );
   }

--- a/enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx
@@ -30,9 +30,8 @@ export default class CollectionOptionsButton extends React.Component {
         style={{ height: ICON_SIZE }}
       >
         <TippyPopoverWithTrigger
-          triggerContent={
-            <Icon name="ellipsis" size={20} className="hover-child" />
-          }
+          triggerClasses="hover-child"
+          triggerContent={<Icon name="ellipsis" size={20} />}
           placement="bottom-end"
           popoverContent={({ closePopover }) => (
             <AccordionList

--- a/frontend/src/metabase/components/PopoverWithTrigger/ControlledPopoverWithTrigger.styled.tsx
+++ b/frontend/src/metabase/components/PopoverWithTrigger/ControlledPopoverWithTrigger.styled.tsx
@@ -1,0 +1,12 @@
+import styled from "@emotion/styled";
+
+import Button from "metabase/core/components/Button";
+
+export const TriggerButton = styled(Button)`
+  padding: 0;
+  border: none;
+
+  &:hover {
+    background: unset;
+  }
+`;

--- a/frontend/src/metabase/components/PopoverWithTrigger/ControlledPopoverWithTrigger.tsx
+++ b/frontend/src/metabase/components/PopoverWithTrigger/ControlledPopoverWithTrigger.tsx
@@ -6,6 +6,8 @@ import TippyPopover, {
   ITippyPopoverProps,
 } from "metabase/components/Popover/TippyPopover";
 
+import { TriggerButton } from "./ControlledPopoverWithTrigger.styled";
+
 export type ControlledPopoverWithTriggerProps = Omit<
   ITippyPopoverProps,
   // this is explicitly a "controlled" component, so we need to remove TippyPopover's optional `visible` prop and make it required
@@ -65,20 +67,19 @@ function ControlledPopoverWithTrigger({
   const computedTrigger = _.isFunction(renderTrigger) ? (
     renderTrigger({ visible, onClick: handleTriggerClick })
   ) : (
-    <button
+    <TriggerButton
+      disabled={disabled}
       className={cx(
         triggerClasses,
         visible && triggerClassesOpen,
         !visible && triggerClassesClose,
-        disabled && "cursor-default",
-        "no-decoration",
       )}
       aria-disabled={disabled}
       style={triggerStyle}
       onClick={handleTriggerClick}
     >
       {triggerContent}
-    </button>
+    </TriggerButton>
   );
 
   const computedPopoverContent = _.isFunction(popoverContent)

--- a/frontend/src/metabase/components/PopoverWithTrigger/ControlledPopoverWithTrigger.tsx
+++ b/frontend/src/metabase/components/PopoverWithTrigger/ControlledPopoverWithTrigger.tsx
@@ -31,7 +31,7 @@ export type PopoverWithTriggerContent =
   | React.ReactNode
   | ((args: PopoverWithTriggerContentArgs) => React.ReactNode);
 type PopoverWithTriggerContentArgs = {
-  onClose: () => void;
+  closePopover: () => void;
 };
 
 export type RenderTrigger = (
@@ -82,7 +82,7 @@ function ControlledPopoverWithTrigger({
   );
 
   const computedPopoverContent = _.isFunction(popoverContent)
-    ? popoverContent({ onClose })
+    ? popoverContent({ closePopover: onClose })
     : popoverContent;
 
   return (

--- a/frontend/src/metabase/components/PopoverWithTrigger/ControlledPopoverWithTrigger.unit.spec.tsx
+++ b/frontend/src/metabase/components/PopoverWithTrigger/ControlledPopoverWithTrigger.unit.spec.tsx
@@ -128,8 +128,8 @@ describe("ControlledPopoverWithTrigger", () => {
 
   describe("popoverContent fn prop", () => {
     beforeEach(() => {
-      const popoverContent: PopoverWithTriggerContent = ({ onClose }) => (
-        <button onClick={onClose}>popover content</button>
+      const popoverContent: PopoverWithTriggerContent = ({ closePopover }) => (
+        <button onClick={closePopover}>popover content</button>
       );
 
       setup({

--- a/frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx
@@ -13,7 +13,7 @@ import {
   PLUGIN_SNIPPET_SIDEBAR_HEADER_BUTTONS,
 } from "metabase/plugins";
 import Icon from "metabase/components/Icon";
-import PopoverWithTrigger from "metabase/components/PopoverWithTrigger";
+import TippyPopoverWithTrigger from "metabase/components/PopoverWithTrigger/TippyPopoverWithTrigger";
 import SidebarContent from "metabase/query_builder/components/SidebarContent";
 import SidebarHeader from "metabase/query_builder/components/SidebarHeader";
 import SnippetRow from "./snippet-sidebar/SnippetRow";
@@ -202,9 +202,9 @@ export default class SnippetSidebar extends React.Component {
                 )}
 
                 {snippetCollection.can_write && (
-                  <PopoverWithTrigger
+                  <TippyPopoverWithTrigger
                     triggerClasses="flex"
-                    triggerElement={
+                    triggerContent={
                       <Icon
                         className={cx(
                           { hide: showSearch },
@@ -214,8 +214,8 @@ export default class SnippetSidebar extends React.Component {
                         size={HEADER_ICON_SIZE}
                       />
                     }
-                  >
-                    {({ onClose }) => (
+                    placement="bottom-end"
+                    popoverContent={({ closePopover }) => (
                       <div className="flex flex-column">
                         {[
                           {
@@ -232,7 +232,7 @@ export default class SnippetSidebar extends React.Component {
                             className="p2 bg-medium-hover flex cursor-pointer text-brand-hover"
                             onClick={() => {
                               onClick();
-                              onClose();
+                              closePopover();
                             }}
                           >
                             <Icon
@@ -245,7 +245,7 @@ export default class SnippetSidebar extends React.Component {
                         ))}
                       </div>
                     )}
-                  </PopoverWithTrigger>
+                  />
                 )}
                 <Icon
                   className={cx(


### PR DESCRIPTION
Related to https://github.com/metabase/metabase/issues/18951

1. Renamed the `onClose` function we pass to `popoverContent` when it is a function to `closePopover` to better describe what it does.
2. Fixed the trigger button styling when using TippyPopoverWithTrigger's `triggerContent` prop. Instead of a plain `button`, I'm using our `Button` component but without its padding, background, or border styling so that it doesn't interfere with the styling of the `triggerContent`. The big gain here is that `Button` is keyboard accessible.
3. Migrated two PopoverWithTriggers that are right next to each other. Nothing major to note here besides that I moved the `hover-child` class on one `triggerContent` Icon to the `triggerClasses` prop so that the outline around the button works properly when the button is invisible.

https://user-images.githubusercontent.com/13057258/158913070-5fdb749e-0e9f-4d8d-aa01-a7418588a5e3.mov


