### PR TITLE
Speculative fix for E2E tests on MongoDB

### DIFF
--- a/frontend/test/metabase/scenarios/native/native-mongo.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/native-mongo.cy.spec.js
@@ -20,9 +20,11 @@ describe("scenarios > question > native > mongo", () => {
   });
 
   it("can save a native MongoDB query", () => {
-    cy.get(".ace_content").type(`[ { $count: "Total" } ]`, {
-      parseSpecialCharSequences: false,
-    });
+    cy.get(".ace_content")
+      .first()
+      .type(`[ { $count: "Total" } ]`, {
+        parseSpecialCharSequences: false,
+      });
     cy.get(".NativeQueryEditor .Icon-play").click();
     cy.findByText("18,760");
 


### PR DESCRIPTION
### Before this PR

Sometimes, `native-mongo.cy.spec.js` failed like this:

![scenarios  question  native  mongo -- can save a native MongoDB query (failed) (attempt 3)](https://user-images.githubusercontent.com/7288/158918925-a46c0da2-220f-4efb-a476-abd968e0f30d.png)

### After this PR

It should fail anymore.