### PR TITLE
Fix question E2E flakes

### DIFF
--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -528,20 +528,20 @@ describe("scenarios > question > filter", () => {
     // Via the GUI, create a filter with "include-current" option
     filter({ mode: "notebook" });
     cy.findByText("Created At").click({ force: true });
-    cy.get("input[type='text']").type("{selectall}{del}5");
     cy.contains("Include today").click();
-    cy.findByText("Add filter").click();
+    cy.button("Add filter").click();
 
     // Switch to custom expression
-    cy.findByText("Created At Previous 5 Days").click();
+    cy.findByText("Created At Previous 30 Days").click();
+
     popover().within(() => {
       cy.icon("chevronleft").click();
       cy.findByText("Custom Expression").click();
     });
-    cy.findByText("Done").click();
+    cy.button("Done").click();
 
     // Back to GUI and "Include today" should be still checked
-    cy.findByText("Created At Previous 5 Days").click();
+    cy.findByText("Created At Previous 30 Days").click();
     cy.findByLabelText("Include today").should("be.checked");
   });
 

--- a/frontend/test/metabase/scenarios/question/view.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/view.cy.spec.js
@@ -2,9 +2,6 @@ import {
   restore,
   openOrdersTable,
   popover,
-  getAddDimensionButton,
-  summarize,
-  sidebar,
   filter,
 } from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
@@ -15,51 +12,6 @@ describe("scenarios > question > view", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
-  });
-
-  describe("summarize sidebar", () => {
-    it("should summarize by category and show a bar chart", () => {
-      openOrdersTable();
-
-      summarize();
-      cy.contains("Category").click();
-      cy.contains("Done").click();
-      cy.contains("Count by Product → Category");
-    });
-
-    it("should show orders by year and product category", () => {
-      openOrdersTable();
-
-      summarize();
-
-      sidebar()
-        .contains("Created At")
-        .click();
-      cy.findByText("Done").click();
-
-      cy.contains("Count by Created At: Month");
-
-      // Go back into sidebar
-      summarize();
-
-      sidebar()
-        .contains("by month")
-        .click();
-      cy.get(".PopoverBody")
-        .contains("Year")
-        .click();
-
-      cy.contains("Count by Created At: Year");
-
-      getAddDimensionButton({ name: "Category" }).click();
-
-      cy.contains("Done").click();
-
-      // check for title, legend, and x axis labels
-      cy.contains("Count by Created At: Year and Product → Category");
-      ["2016", "2017", "2018", "2019", "2020"].forEach(l => cy.contains(l));
-      ["Doohickey", "Gadget", "Gizmo", "Widget"].forEach(l => cy.contains(l));
-    });
   });
 
   describe("filter sidebar", () => {


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Fixes 3 most commonly seen flakes in `question` E2E group
---

1. `should show the real number of rows instead of HARD_ROW_LIMIT when loading (metabase#17397)` in `frontend/test/metabase/scenarios/question/notebook.cy.spec.js`

The example of a failure in CCI: https://app.circleci.com/pipelines/github/metabase/metabase/31022/workflows/5b74523a-88c8-40ac-ab83-9041fa50e1d7/jobs/1563442/artifacts
![image](https://user-images.githubusercontent.com/31325167/158995983-9ebbb5ee-c334-4a00-9762-1422a89ae3a8.png)

Solution: Throttle the network to slow down a response. This gives Cypress enough time to assert on the number of rows while the response is still loading.

Result - 20/20 attempts passing locally
<details>
  <summary>Click to see a screenshot</summary>

![image](https://user-images.githubusercontent.com/31325167/158996454-56b2a4a9-6f9b-480f-9f66-1317da39c9b9.png)

</details>

2. `should be able to convert time interval filter to custom expression (metabase#12457)` in `frontend/test/metabase/scenarios/question/filter.cy.spec.js`

The example of a failure in CCI: https://app.circleci.com/pipelines/github/metabase/metabase/31080/workflows/71f41c87-9613-479d-8bf5-03a57f6e4f42/jobs/1567418/artifacts
![image](https://user-images.githubusercontent.com/31325167/158996877-8720c7a7-fbfe-4a00-9a39-eb57777bc3a1.png)

Reason:
The test had some extra steps which were not necessary. Changing the number of days by doing `{selectall}{del}5` in an input field could fail from time to time.

Solution:
Remove the unnecessary step from the test and focus on the minimally needed repro.

3. Summarize sidebar (`should show orders by year and product category`) in `frontend/test/metabase/scenarios/question/view.cy.spec.js`

Those tests were redundant (duplicates). We're testing the same UI flow in MANY other places so it was safe to remove it from here.