### PR TITLE
docs - remove enterprise refs

### DIFF
--- a/docs/administration-guide/06-collections.md
+++ b/docs/administration-guide/06-collections.md
@@ -22,7 +22,7 @@ By default, any new collection will have the same permissions settings as the co
 
 One great feature in Metabase is that you can pin the most important couple of items in each of your collections to the top. Pinning an item in a collection turns it into a big, eye-catching card that will help make sure that folks who are browsing your Metabase instance will always know what's most important. And if you pin a question, Metabase will display a preview of its visualization. 
 
-Any user with curate permissions for a collection can pin items in it, making it easy to delegate curation responsibilities to other members of your team. To pin something, select the **pin icon** next to the item's name. Note that collections themselves can't be pinned, but if you're running [Metabase Pro or Enterprise Edition](https://www.metabase.com/pricing), admins can designate [Offical Collections][offical-collections].
+Any user with curate permissions for a collection can pin items in it, making it easy to delegate curation responsibilities to other members of your team. To pin something, select the **pin icon** next to the item's name. Note that collections themselves can't be pinned, but if you're running [a paid plan](https://www.metabase.com/pricing), admins can designate [Offical Collections][offical-collections].
 
 ### Setting permissions for collections
 

--- a/docs/administration-guide/10-single-sign-on.md
+++ b/docs/administration-guide/10-single-sign-on.md
@@ -86,7 +86,7 @@ Metabase Pro and Enterprise Editions ship with more advanced LDAP features.
 
 {% include plans-blockquote.html feature="LDAP user attribute syncing" %}
 
-If you're running [Metabase Pro or Enterprise Edition](https://www.metabase.com/pricing) and using [data sandboxes](../enterprise-guide/data-sandboxes.md), you can use existing LDAP [user attributes](../enterprise-guide/data-sandboxes.html#getting-user-attributes) when granting sandboxed access.
+If you're running a [paid version of Metabase](https://www.metabase.com/pricing) and using [data sandboxes](../enterprise-guide/data-sandboxes.md), you can use existing LDAP [user attributes](../enterprise-guide/data-sandboxes.html#getting-user-attributes) when granting sandboxed access.
 
 ### LDAP group membership filter
 

--- a/docs/administration-guide/sso.md
+++ b/docs/administration-guide/sso.md
@@ -7,7 +7,7 @@ We recommend that you set up Single Sign-on for your Metabase installation.
 - [Google Sign-in](https://www.metabase.com/docs/latest/administration-guide/10-single-sign-on.html)
 - [LDAP](https://www.metabase.com/docs/latest/administration-guide/10-single-sign-on.html#enabling-ldap-authentication)
 
-## SSO for Metabase Pro and Enterprise Editions
+## SSO for Metabase paid versions
 
 With paid versions, you have more options to help manage lots of people and groups.
 

--- a/docs/enterprise-guide/authenticating-with-saml-azure-ad.md
+++ b/docs/enterprise-guide/authenticating-with-saml-azure-ad.md
@@ -2,8 +2,6 @@
 
 {% include plans-blockquote.html feature="SAML authentication" %}
 
-To enable SAML authentication and use Azure AD as an identity provider, you need to have [Metabase Enterprise Edition](https://www.metabase.com/enterprise/index.html).
-
 ## Steps
 
 - [Enable SAML in Metabase](#enable-saml-in-metabase)

--- a/docs/enterprise-guide/authenticating-with-saml.md
+++ b/docs/enterprise-guide/authenticating-with-saml.md
@@ -2,7 +2,7 @@
 
 {% include plans-blockquote.html feature="SAML authentication" %}
 
-The open source edition of Metabase includes the option to set up single sign-on (SSO) with [Google Sign-in or LDAP](../administration-guide/10-single-sign-on.md), but the Enterprise edition of Metabase additionally lets you connect your SAML- or JWT-based SSO. Integrating your SSO with Metabase allows you to:
+The open source edition of Metabase includes the option to set up single sign-on (SSO) with [Google Sign-in or LDAP](../administration-guide/10-single-sign-on.md), but the [some plans](https://www.metabase.com/pricing) let you connect your SAML- or JWT-based SSO. Integrating your SSO with Metabase allows you to:
 
 - automatically pass user attributes from your SSO to Metabase in order to power data sandboxes
 - let your users access Metabase without re-authenticating.

--- a/docs/enterprise-guide/cache.md
+++ b/docs/enterprise-guide/cache.md
@@ -2,7 +2,7 @@
 
 {% include plans-blockquote.html feature="Question-specific caching" %}
 
-All Metabase editions include global caching controls. The Enterprise edition includes additional caching options that let you control caching for each database, as well as individual questions.
+All Metabase editions include global caching controls. Some plans include additional caching options that let you control caching for each database, as well as individual questions.
 
 ## Caching per database
 

--- a/docs/enterprise-guide/dashboard-subscriptions.md
+++ b/docs/enterprise-guide/dashboard-subscriptions.md
@@ -3,15 +3,13 @@
 
 {% include plans-blockquote.html feature="Dashboard subscription filter customization" %}
 
-This page covers the Enterprise Edition features for [dashboard subscriptions](../users-guide/dashboard-subscriptions.md).
-
-The Enterprise Edition lets you customize which filter values to apply to each subscription. That way you can send different groups of people an email (or Slack message) the contents of the dashboard with different filters applied. You only need to maintain one dashboard, which you can use to send results relevant to each subscriber.
+You can customize which filter values to apply to each [dashboard subscriptions](../users-guide/dashboard-subscriptions.md). That way you can send different groups of people an email (or Slack message) the contents of the dashboard with different filters applied. You only need to maintain one dashboard, which you can use to send results relevant to each subscriber.
 
 ### Setting filter values
 
 You can set values for each filter on the dashboard. If you have any dashboard filters with default values, you can override those defaults for a given subscription, or leave them as-is.
 
-Here's the sidebar in Enterprise Edition where you can set the filter values:
+Here's the sidebar where you can set the filter values:
 
 ![Setting a filter value](./images/dashboard-subscriptions/set-filter-values.png)
 

--- a/docs/enterprise-guide/data-sandboxes.md
+++ b/docs/enterprise-guide/data-sandboxes.md
@@ -2,7 +2,7 @@
 
 {% include plans-blockquote.html feature="Data sandboxes" %}
 
-Data sandboxes are a powerful and flexible permissions tool in Metabase Enterprise Edition that allow you to grant filtered access to specific tables. If you haven't already, check out our [overview of how permissions work in Metabase][permissions-overview].
+Data sandboxes are a powerful and flexible permissions tool that allow you to grant filtered access to specific tables. If you haven't already, check out our [overview of how permissions work in Metabase][permissions-overview].
 
 Say you have users who you want to be able to log into your Metabase instance, but who should only be able to view data that pertains to them. For example, you might have some customers or partners who you want to let view your Orders table, but you only want them to see their orders. Sandboxes let you do just that.
 

--- a/docs/enterprise-guide/full-app-embedding.md
+++ b/docs/enterprise-guide/full-app-embedding.md
@@ -2,7 +2,7 @@
 
 {% include plans-blockquote.html feature="Full-app embedding" %}
 
-The open-source edition of Metabase allows you to [embed standalone charts or dashboards](../administration-guide/13-embedding.md) in your own web applications for simple situations. But what if you want to provide your users with a more interactive, browsable experience? Metabase Enterprise Edition allows you to embed the entire Metabase app within your own web app, allowing you to provide [drill-through](https://www.metabase.com/learn/basics/questions/drill-through.html) for your embedded charts and dashboards, or even embed the graphical query builder, or collections of dashboards and charts.
+The open-source edition of Metabase allows you to [embed standalone charts or dashboards](../administration-guide/13-embedding.md) in your own web applications for simple situations. But what if you want to provide your users with a more interactive, browsable experience? Some plans allow you to embed the entire Metabase app within your own web app, allowing you to provide [drill-through](https://www.metabase.com/learn/basics/questions/drill-through.html) for your embedded charts and dashboards, or even embed the graphical query builder, or collections of dashboards and charts.
 
 You'll be putting the whole Metabase app into an iframe, and the SSO integration you've set up with Metabase will be used to make sure the embedded Metabase respects the collection and data permissions you've set up for your user groups. Clicking on charts and graphs in the embed will do just what they do in Metabase itself. You can even display a specific Metabase collection in an embed to allow your users to browse through all the dashboards and questions that you've made available to them. The only difference is that Metabase's top nav bar and global search will not be rendered in your iframe.
 
@@ -10,7 +10,7 @@ You'll be putting the whole Metabase app into an iframe, and the SSO integration
 
 To get this going, you're going to need:
 
-- An Enterprise Edition instance of Metabase that contains the dashboards and charts that you'd like to embed.
+- A [paid plan of Metabase](https://www.metabase.com/pricing) that includes full-app embedding.
 - A separate web application that you want to embed your dashboards and charts in.
 
 ### Enabling embedding in Metabase

--- a/docs/enterprise-guide/sql-snippets.md
+++ b/docs/enterprise-guide/sql-snippets.md
@@ -2,7 +2,7 @@
 
 {% include plans-blockquote.html feature="SQL snippet controls" %}
 
-This article covers **SQL snippet folders**, which are an Enterprise feature for organizing and permissioning snippets. You can learn more about [how SQL snippets work in our User Guide](../users-guide/sql-snippets.md).
+This article covers **SQL snippet folders**, which allow you to organize and set permissions on [SQL snippets]](../users-guide/sql-snippets.md).
 
 Folder permissions should not be considered a security feature, but instead a feature that helps organize and standardize snippets. Although folders are distinct and separate from Collections, they both serve an organizational function: Collections gather and permission dashboards and questions; folders gather and permission snippets. For more info, see the [discussion on permissions below](#permissions).
 
@@ -26,7 +26,7 @@ You can create a SQL snippet folder from the **Snippets** menu in the [SQL edito
 
 ### Creating a new SQL snippet
 
-When creating a SQL snippet in the Enterprise Edition, you'll also see an additional option to add that snippet to an existing folder (the **Folder this should be in** option).
+On [some plans](https://www.metabase.com/pricing), when creating a SQL snippet, you'll also see an additional option to add that snippet to an existing folder (the **Folder this should be in** option).
 
 ![Add a snippet enterprise modal](./images/sql-snippets/enterprise-add-snippet.png)
 

--- a/docs/operations-guide/environment-variables.md
+++ b/docs/operations-guide/environment-variables.md
@@ -67,7 +67,7 @@ Middleware that enforces validation of the client via the request header `X-Meta
 
 ### `MB_APPLICATION_COLORS`
 
-Only available in Enterprise Edition<br>
+Only available in [some plans](https://www.metabase.com/pricing)<br>
 Type: string<br>
 Default: `"{}"`
 
@@ -89,7 +89,7 @@ See [MB_JDBC_DATA_WAREHOUSE_MAX_CONNECTION_POOL_SIZE](#mb_jdbc_data_warehouse_ma
 
 ### `MB_APPLICATION_FAVICON_URL`
 
-Only available in Enterprise Edition<br>
+Only available in [some plans](https://www.metabase.com/pricing)<br>
 Type: string<br>
 Default: `"frontend_client/favicon.ico"`
 
@@ -97,7 +97,7 @@ Path or URL to favicon file.
 
 ### `MB_APPLICATION_LOGO_URL`
 
-Only available in Enterprise Edition<br>
+Only available in [some plans](https://www.metabase.com/pricing)<br>
 Type: string<br>
 Default: `"app/assets/img/logo.svg"`
 
@@ -105,7 +105,7 @@ Path or URL to logo file. For best results use SVG format.
 
 ### `MB_APPLICATION_NAME`
 
-Only available in Enterprise Edition<br>
+Only available in [some plans](https://www.metabase.com/pricing)<br>
 Type: string<br>
 Default: `"Metabase"`
 
@@ -299,7 +299,7 @@ SMTP username.
 
 ### `MB_EMBEDDING_APP_ORIGIN`
 
-Only available in Enterprise Edition<br>
+Only available in [some plans](https://www.metabase.com/pricing)<br>
 Type: string<br>
 Default: `null`
 
@@ -328,7 +328,7 @@ Allow using a saved question as the source for other queries.
 
 ### `MB_ENABLE_PASSWORD_LOGIN`
 
-Only available in Enterprise Edition<br>
+Only available in [some plans](https://www.metabase.com/pricing)<br>
 Type: boolean<br>
 Default: `true`
 
@@ -528,7 +528,7 @@ Password for Java TrustStore file.
 
 ### `MB_JWT_ATTRIBUTE_EMAIL`
 
-Only available in Enterprise Edition<br>
+Only available in [some plans](https://www.metabase.com/pricing)<br>
 Type: string<br>
 Default: `"email"`
 
@@ -536,7 +536,7 @@ Key to retrieve the JWT user's email address.
 
 ### `MB_JWT_ATTRIBUTE_FIRSTNAME`
 
-Only available in Enterprise Edition<br>
+Only available in [some plans](https://www.metabase.com/pricing)<br>
 Type: string<br>
 Default: `"first_name"`
 
@@ -544,7 +544,7 @@ Key to retrieve the JWT user's first name.
 
 ### `MB_JWT_ATTRIBUTE_GROUPS`
 
-Only available in Enterprise Edition<br>
+Only available in [some plans](https://www.metabase.com/pricing)<br>
 Type: string<br>
 Default: `"groups"`
 
@@ -552,7 +552,7 @@ Key to retrieve the JWT user's groups.
 
 ### `MB_JWT_ATTRIBUTE_LASTNAME`
 
-Only available in Enterprise Edition<br>
+Only available in [some plans](https://www.metabase.com/pricing)<br>
 Type: string<br>
 Default: `"groups"`
 
@@ -560,7 +560,7 @@ Key to retrieve the JWT user's last name.
 
 ### `MB_JWT_ENABLED`
 
-Only available in Enterprise Edition<br>
+Only available in [some plans](https://www.metabase.com/pricing)<br>
 Type: boolean<br>
 Default: `false`
 
@@ -568,7 +568,7 @@ When set to `true`, will enable JWT authentication with the options configured i
 
 ### `MB_JWT_GROUP_MAPPINGS`
 
-Only available in Enterprise Edition<br>
+Only available in [some plans](https://www.metabase.com/pricing)<br>
 Type: string<br>
 Default: `"{}"`
 
@@ -576,7 +576,7 @@ JSON object containing JWT to Metabase group mappings. Should be in the form: `'
 
 ### `MB_JWT_GROUP_SYNC`
 
-Only available in Enterprise Edition<br>
+Only available in [some plans](https://www.metabase.com/pricing)<br>
 Type: boolean<br>
 Default: `false`
 
@@ -584,7 +584,7 @@ Enable group membership synchronization with JWT.
 
 ### `MB_JWT_IDENTITY_PROVIDER_URI`
 
-Only available in Enterprise Edition<br>
+Only available in [some plans](https://www.metabase.com/pricing)<br>
 Type: string<br>
 Default: `null`
 
@@ -592,7 +592,7 @@ URL of JWT based login page.
 
 ### `MB_JWT_SHARED_SECRET`
 
-Only available in Enterprise Edition<br>
+Only available in [some plans](https://www.metabase.com/pricing)<br>
 Type: string<br>
 Default: `null`
 
@@ -600,7 +600,7 @@ String used to seed the private key used to validate JWT messages.
 
 ### `MB_LANDING_PAGE`
 
-Only available in Enterprise Edition<br>
+Only available in [some plans](https://www.metabase.com/pricing)<br>
 Type: string<br>
 Default: `""`
 
@@ -692,7 +692,7 @@ Use SSL, TLS or plain text.
 
 ### `MB_LDAP_SYNC_USER_ATTRIBUTES`
 
-Only available in Enterprise Edition<br>
+Only available in [some plans](https://www.metabase.com/pricing)<br>
 Type: boolean<br>
 Default: `true`
 
@@ -700,7 +700,7 @@ Sync user attributes when someone logs in via LDAP.
 
 ### `MB_LDAP_SYNC_USER_ATTRIBUTES_BLACKLIST`
 
-Only available in Enterprise Edition<br>
+Only available in [some plans](https://www.metabase.com/pricing)<br>
 Type: string<br>
 Default: `"userPassword,dn,distinguishedName"`
 
@@ -736,7 +736,7 @@ Comma-separated namespaces to trace. **WARNING:** Could log sensitive informatio
 
 ### `MB_NOTIFICATION_LINK_BASE_URL`
 
-Only available in Enterprise Edition<br>
+Only available in [some plans](https://www.metabase.com/pricing)<br>
 Type: string<br>
 Default: `null`
 
@@ -774,7 +774,7 @@ The location is where custom third-party drivers should be added. Then Metabase 
 Type: string<br>
 Default: `null`
 
-Token for Enterprise Edition and Premium features.
+Token for [some plans](https://www.metabase.com/pricing) and Premium features.
 
 ### `MB_QP_CACHE_BACKEND`
 
@@ -836,7 +836,7 @@ Connection timezone to use when executing queries. Defaults to system timezone.
 
 ### `MB_SAML_APPLICATION_NAME`
 
-Only available in Enterprise Edition<br>
+Only available in [some plans](https://www.metabase.com/pricing)<br>
 Type: string<br>
 Default: `"Metabase"`
 
@@ -844,7 +844,7 @@ This application name will be used for requests to the Identity Provider.
 
 ### `MB_SAML_ATTRIBUTE_EMAIL`
 
-Only available in Enterprise Edition<br>
+Only available in [some plans](https://www.metabase.com/pricing)<br>
 Type: string<br>
 Default: `"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"`
 
@@ -852,7 +852,7 @@ SAML attribute for the user's email address.
 
 ### `MB_SAML_ATTRIBUTE_FIRSTNAME`
 
-Only available in Enterprise Edition<br>
+Only available in [some plans](https://www.metabase.com/pricing)<br>
 Type: string<br>
 Default: `"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname"`
 
@@ -860,7 +860,7 @@ SAML attribute for the user's first name.
 
 ### `MB_SAML_ATTRIBUTE_GROUP`
 
-Only available in Enterprise Edition<br>
+Only available in [some plans](https://www.metabase.com/pricing)<br>
 Type: string<br>
 Default: `"member_of"`
 
@@ -868,7 +868,7 @@ SAML attribute for group syncing.
 
 ### `MB_SAML_ATTRIBUTE_LASTNAME`
 
-Only available in Enterprise Edition<br>
+Only available in [some plans](https://www.metabase.com/pricing)<br>
 Type: string<br>
 Default: `"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname"`
 
@@ -876,7 +876,7 @@ SAML attribute for the user's last name.
 
 ### `MB_SAML_ENABLED`
 
-Only available in Enterprise Edition<br>
+Only available in [some plans](https://www.metabase.com/pricing)<br>
 Type: boolean<br>
 Default: `false`
 
@@ -884,7 +884,7 @@ When set to `true`, will enable SAML authentication with the options configured 
 
 ### `MB_SAML_GROUP_MAPPINGS`
 
-Only available in Enterprise Edition<br>
+Only available in [some plans](https://www.metabase.com/pricing)<br>
 Type: string<br>
 Default: `"{}"`
 
@@ -892,7 +892,7 @@ JSON object containing SAML to Metabase group mappings. Should be in the form: `
 
 ### `MB_SAML_GROUP_SYNC`
 
-Only available in Enterprise Edition<br>
+Only available in [some plans](https://www.metabase.com/pricing)<br>
 Type: boolean<br>
 Default: `false`
 
@@ -900,7 +900,7 @@ Enable group membership synchronization with SAML.
 
 ### `MB_SAML_IDENTITY_PROVIDER_CERTIFICATE`
 
-Only available in Enterprise Edition<br>
+Only available in [some plans](https://www.metabase.com/pricing)<br>
 Type: string<br>
 Default: `null`
 
@@ -908,7 +908,7 @@ Encoded certificate for the identity provider, provided as the content, not a fi
 
 ### `MB_SAML_IDENTITY_PROVIDER_URI`
 
-Only available in Enterprise Edition<br>
+Only available in [some plans](https://www.metabase.com/pricing)<br>
 Type: string<br>
 Default: `null`
 
@@ -916,7 +916,7 @@ This is the URL where your users go to log in to your identity provider. Dependi
 
 ### `MB_SAML_IDENTITY_PROVIDER_ISSUER`
 
-Only available in Enterprise Edition<br>
+Only available in [some plans](https://www.metabase.com/pricing)<br>
 Type: string<br>
 Default: `null`
 
@@ -924,7 +924,7 @@ This is a unique identifier for the IdP. Often referred to as Entity ID or simpl
 
 ### `MB_SAML_KEYSTORE_ALIAS`
 
-Only available in Enterprise Edition<br>
+Only available in [some plans](https://www.metabase.com/pricing)<br>
 Type: string<br>
 Default: `"metabase"`
 
@@ -932,7 +932,7 @@ Alias for the key that Metabase should use for signing SAML requests.
 
 ### `MB_SAML_KEYSTORE_PASSWORD`
 
-Only available in Enterprise Edition<br>
+Only available in [some plans](https://www.metabase.com/pricing)<br>
 Type: string<br>
 Default: `"changeit"`
 
@@ -940,7 +940,7 @@ Password for opening the KeyStore.
 
 ### `MB_SAML_KEYSTORE_PATH`
 
-Only available in Enterprise Edition<br>
+Only available in [some plans](https://www.metabase.com/pricing)<br>
 Type: string<br>
 Default: `null`
 
@@ -948,7 +948,7 @@ Absolute path to the KeyStore file to use for signing SAML requests.
 
 ### `MB_SEND_NEW_SSO_USER_ADMIN_EMAIL`
 
-Only available in Enterprise Edition<br>
+Only available in [some plans](https://www.metabase.com/pricing)<br>
 Type: boolean<br>
 Default: `true`
 

--- a/docs/troubleshooting-guide/loading-from-h2.md
+++ b/docs/troubleshooting-guide/loading-from-h2.md
@@ -43,7 +43,7 @@ Command failed with exception: Unsupported database file version or invalid file
     java -jar metabase.jar load-from-h2 /path/to/metabase.db # do not include .mv.db
     ```
 
-If you're using [Metabase Enterprise Edition][enterprise], you can use [serialization][serialization-docs] to snapshot your application database. Serialization is useful when you want to [preload questions and dashboards][serialization-learn] in a new Metabase instance.
+If you're using a [paid version of Metabase][enterprise], you can use [serialization][serialization-docs] to snapshot your application database. Serialization is useful when you want to [preload questions and dashboards][serialization-learn] in a new Metabase instance.
 
 ## Are you trying to downgrade?
 
@@ -126,7 +126,7 @@ Exception in thread "main" java.lang.AssertionError: Assert failed: Unable to co
 3.  Move Metabase to a faster server (in particular, a server with faster disks).
 
 [backup]: ../operations-guide/backing-up-metabase-application-data.md
-[enterprise]: /enterprise/
+[enterprise]: https://www.metabase.com/pricing
 [migrate]: ../operations-guide/migrating-from-h2.md
 [serialization-docs]: ../enterprise-guide/serialization.md
 [serialization-learn]: /learn/administration/serialization.html

--- a/docs/troubleshooting-guide/permissions.md
+++ b/docs/troubleshooting-guide/permissions.md
@@ -34,7 +34,7 @@ Remember that everyone is a member of the **All Users** group; this is why we re
 
 **Steps to take:**
 
-1. If you're running [Metabase Pro or Enterprise Edition](https://www.metabase.com/pricing), you can block group access to an entire database. This means that if you've blocked a group's access to a database, members of that group will not ever seen any data from this database, regardless of their permissions at the Collection level. 
+1. If you're running a [paid version of Metabase](https://www.metabase.com/pricing), you can block group access to an entire database. This means that if you've blocked a group's access to a database, members of that group will not ever seen any data from this database, regardless of their permissions at the Collection level. 
 2. In the **Admin Panel**'s **Permissions tab**, change data permissions for your user group to **Block** and save your changes.
 3. Using an incognito window, log in as the person in question to confirm that they can no longer view saved questions or dashboards that include information from the blocked database.
 

--- a/docs/users-guide/dashboard-subscriptions.md
+++ b/docs/users-guide/dashboard-subscriptions.md
@@ -54,9 +54,9 @@ You can add multiple subscriptions to a single dashboard. To add a subscription,
 
 To remove a subscription from a dashboard, select the subscription you'd like to remove. At the bottom of the sidebar, select **Delete this subscription**. Follow the instructions on the modal that pops up to confirm you'd like to delete the subscription.
 
-## Enterprise Edition: customize filter values for each dashboard subscription
+## Customize filter values for each dashboard subscription
 
-Metabase Enterprise Edition allows you to [customize filter values for each subscription](../enterprise-guide/dashboard-subscriptions.md), so you can set up subscriptions with different filter values applied for different subscribers.
+Some plans allow you to [customize filter values for each subscription](../enterprise-guide/dashboard-subscriptions.md), so you can set up subscriptions with different filter values applied for different subscribers.
 
 ### Related reading
 

--- a/docs/users-guide/interactive-dashboards.md
+++ b/docs/users-guide/interactive-dashboards.md
@@ -72,7 +72,7 @@ Once you select the column that contains the value you want to pass, the sidebar
 
 In the example above, when a user clicks on the **Orders by product category** card, Metabase will pass the clicked `Product -> Category` to the destination dashboard ("Interactive Dashboard"), which will then filter its cards by that `Category`.
 
-You can also send the currently selected value of a dashboard filter on the current dashboard to the destination. And if you're using [Metabase Enterprise Edition](https://www.metabase.com/enterprise/scale/index.html), you can pass a user attribute provided by SSO to the destination, too. Those user attributes will show up as options when you click on one of the destination's filters (provided the values are compatible with that filter).
+You can also send the currently selected value of a dashboard filter on the current dashboard to the destination. In [some plans](https://www.metabase.com/pricing), you can pass a user attribute provided by SSO to the destination, too. Those user attributes will show up as options when you click on one of the destination's filters (provided the values are compatible with that filter).
 
 When displaying questions as tables, you can select different click behaviors for different columns in the table. You can also modify the contents of the cells in a given column, replacing the value with custom text. For example, if you had a column that listed categories, you could change the text in the cell to read: "Click for details about {% raw %}{{Category}}{% endraw %}", where `Category` is the name of your column.
 

--- a/docs/users-guide/sql-snippets.md
+++ b/docs/users-guide/sql-snippets.md
@@ -89,7 +89,7 @@ Note: two snippets cannot share the same name, as even if a snippet is archived,
 
 Any user who has SQL editor permissions to at least one of your connected databases will be able to view the snippets sidebar, and will be able to create, edit, and archive or unarchive any and all snippets — even snippets intended to be used with databases the user does NOT have SQL editing access to.
 
-[Metabase Enterprise Edition](https://www.metabase.com/enterprise/scale/index.html) contains additional functionality for organizing snippets into folders and setting permissions on those folders. See our [docs on SQL snippet folders and permissions](../enterprise-guide/sql-snippets.html).
+Some plans contain additional functionality for organizing snippets into folders and setting permissions on those folders. See our [docs on SQL snippet folders and permissions](../enterprise-guide/sql-snippets.html).
 
 ### Learn more
 


### PR DESCRIPTION
Changes explicit references to Enterprise Edition to paid versions/plans to account for Pro plans (and future plans).