### PR TITLE
[E2E] Fix `permissions` flakes

### DIFF
--- a/frontend/test/metabase/scenarios/permissions/sandboxes.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/sandboxes.cy.spec.js
@@ -1018,6 +1018,8 @@ describeEE("formatting > sandboxes", () => {
     });
 
     it("sandboxed user should receive sandboxed dashboard subscription", () => {
+      cy.intercept("POST", "/api/pulse/test").as("emailSent");
+
       setupSMTP();
 
       cy.sandboxTable({
@@ -1035,7 +1037,7 @@ describeEE("formatting > sandboxes", () => {
       cy.findByPlaceholderText("Enter user names or email addresses").click();
       cy.findByText("User 1").click();
       cy.findByText("Send email now").click();
-      cy.findByText("Email sent");
+      cy.wait("@emailSent");
       cy.request("GET", "http://localhost:80/email").then(({ body }) => {
         expect(body[0].html).to.include("Orders in a dashboard");
         expect(body[0].html).to.include("37.65");

--- a/frontend/test/metabase/scenarios/permissions/sandboxes.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/sandboxes.cy.spec.js
@@ -131,8 +131,9 @@ describeEE("formatting > sandboxes", () => {
     describe("question with joins", () => {
       it("should be sandboxed even after applying a filter to the question", () => {
         cy.log("Open saved question with joins");
-        cy.visit("/collection/root");
-        cy.findByText(QUESTION_NAME).click();
+        cy.get("@questionId").then(id => {
+          visitQuestion(id);
+        });
 
         cy.log("Make sure user is initially sandboxed");
         cy.get(".TableInteractive-cellWrapper--firstColumn").should(
@@ -759,9 +760,6 @@ describeEE("formatting > sandboxes", () => {
     });
 
     it("should be able to use summarize columns from joined table based on a saved question (metabase#14766)", () => {
-      cy.server();
-      cy.route("POST", "/api/dataset").as("dataset");
-
       createJoinedQuestion("14766_joined");
 
       cy.visit("/question/new");
@@ -801,9 +799,7 @@ describeEE("formatting > sandboxes", () => {
 
       cy.signOut();
       cy.signInAsSandboxedUser();
-      createJoinedQuestion("14841").then(({ body: { id: QUESTION_ID } }) => {
-        visitQuestion(QUESTION_ID);
-      });
+      createJoinedQuestion("14841", { visitQuestion: true });
 
       cy.findByText("Settings").click();
       cy.findByTestId("sidebar-left")
@@ -1047,24 +1043,27 @@ describeEE("formatting > sandboxes", () => {
   });
 });
 
-function createJoinedQuestion(name) {
-  return cy.createQuestion({
-    name,
+function createJoinedQuestion(name, { visitQuestion = false } = {}) {
+  return cy.createQuestion(
+    {
+      name,
 
-    query: {
-      "source-table": ORDERS_ID,
-      joins: [
-        {
-          fields: "all",
-          "source-table": PRODUCTS_ID,
-          condition: [
-            "=",
-            ["field", ORDERS.PRODUCT_ID, null],
-            ["field", PRODUCTS.ID, { "join-alias": "Products" }],
-          ],
-          alias: "Products",
-        },
-      ],
+      query: {
+        "source-table": ORDERS_ID,
+        joins: [
+          {
+            fields: "all",
+            "source-table": PRODUCTS_ID,
+            condition: [
+              "=",
+              ["field", ORDERS.PRODUCT_ID, null],
+              ["field", PRODUCTS.ID, { "join-alias": "Products" }],
+            ],
+            alias: "Products",
+          },
+        ],
+      },
     },
-  });
+    { wrapId: true, visitQuestion },
+  );
 }


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Attempts to fix the most recent flakes in `permissions` E2E CI group (both flakes were in `frontend/test/metabase/scenarios/permissions/sandboxes.cy.spec.js`)

The failed run on GHA:
https://github.com/metabase/metabase/runs/5600596767?check_suite_focus=true

1. `sandboxed user should receive sandboxed dashboard subscription`
![formatting  sandboxes -- Sandboxing reproductions -- sandboxed user should receive sandboxed dashboard subscription (failed)](https://user-images.githubusercontent.com/31325167/159018943-2f849d73-4cdc-4f6f-b3c9-908435c5576c.png)

Reason:
Sending email took too long and Cypress couldn't find an UI element "Email sent"

Solution:
Explicitly wait until the request resolves.

2. `should be sandboxed even after applying a filter to the question`

![formatting  sandboxes -- normal user -- question with joins -- should be sandboxed even after applying a filter to the question (failed)](https://user-images.githubusercontent.com/31325167/159019398-f1ea5244-58e7-4624-b1db-4cc607efda59.png)

Reason:
Cypress asserts on the table before results fully load.

Solution:
Explicitly wait for the query metadata to load.
This mechanism was already implemented in the helper `visitQuestion`, so I made sure to be able to obtain question's ID and from there it was a breeeze.
