### PR TITLE
Skip repro for 8406 due to #21026

### DIFF
--- a/frontend/test/metabase/scenarios/collections/personal-collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/personal-collections.cy.spec.js
@@ -48,7 +48,8 @@ describe("personal collections", () => {
       cy.icon("pencil").should("not.exist");
     });
 
-    it("shouldn't be able to change permission levels for sub-collections in personal collections (metabase#8406)", () => {
+    // Quarantined because of the failures in CI caused by metabase#21026
+    it.skip("shouldn't be able to change permission levels for sub-collections in personal collections (metabase#8406)", () => {
       cy.visit("/collection/root");
       cy.findByText("Your personal collection").click();
       // Create new collection inside admin's personal collection and navigate to it


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Skips the repro for 8406 due to failures in CI caused by #21026 

The examples of this failure:
- https://app.circleci.com/pipelines/github/metabase/metabase/31098/workflows/44e16c83-69ce-4f41-91c6-519c37420994/jobs/1568788/artifacts
    - Open the `personal-collections` video and you'll see it's stuck on an infinite loading loop

Also, see [this comment](https://github.com/metabase/metabase/issues/21026#issuecomment-1072408973).