### PR TITLE
Use TippyPopover in the AddMemberTypeahead component

### DIFF
--- a/frontend/src/metabase/admin/people/components/AddRow.jsx
+++ b/frontend/src/metabase/admin/people/components/AddRow.jsx
@@ -1,41 +1,49 @@
-import React from "react";
+import React, { forwardRef } from "react";
 import PropTypes from "prop-types";
 import { t } from "ttag";
 import cx from "classnames";
 
-export const AddRow = ({
-  value,
-  isValid,
-  placeholder,
-  onKeyDown,
-  onChange,
-  onDone,
-  onCancel,
-  children,
-}) => (
-  <div className="my2 pl1 p1 bordered border-brand rounded relative flex align-center">
-    {children}
-    <input
-      className="input--borderless h3 ml1 flex-full"
-      type="text"
-      value={value}
-      placeholder={placeholder}
-      autoFocus
-      onKeyDown={onKeyDown}
-      onChange={onChange}
-    />
-    <span className="link no-decoration cursor-pointer" onClick={onCancel}>
-      {t`Cancel`}
-    </span>
-    <button
-      className={cx("Button ml2", { "Button--primary": !!isValid })}
-      disabled={!isValid}
-      onClick={onDone}
+export const AddRow = forwardRef(function AddRow(
+  {
+    value,
+    isValid,
+    placeholder,
+    onKeyDown,
+    onChange,
+    onDone,
+    onCancel,
+    children,
+  },
+  ref,
+) {
+  return (
+    <div
+      ref={ref}
+      className="my2 pl1 p1 bordered border-brand rounded relative flex align-center"
     >
-      {t`Add`}
-    </button>
-  </div>
-);
+      {children}
+      <input
+        className="input--borderless h3 ml1 flex-full"
+        type="text"
+        value={value}
+        placeholder={placeholder}
+        autoFocus
+        onKeyDown={onKeyDown}
+        onChange={onChange}
+      />
+      <span className="link no-decoration cursor-pointer" onClick={onCancel}>
+        {t`Cancel`}
+      </span>
+      <button
+        className={cx("Button ml2", { "Button--primary": !!isValid })}
+        disabled={!isValid}
+        onClick={onDone}
+      >
+        {t`Add`}
+      </button>
+    </div>
+  );
+});
 
 AddRow.propTypes = {
   value: PropTypes.string.isRequired,

--- a/frontend/src/metabase/admin/people/components/AddRow.jsx
+++ b/frontend/src/metabase/admin/people/components/AddRow.jsx
@@ -49,7 +49,7 @@ AddRow.propTypes = {
   value: PropTypes.string.isRequired,
   isValid: PropTypes.bool.isRequired,
   placeholder: PropTypes.string,
-  onKeyDown: PropTypes.func.isRequired,
+  onKeyDown: PropTypes.func,
   onChange: PropTypes.func.isRequired,
   onDone: PropTypes.func.isRequired,
   onCancel: PropTypes.func.isRequired,

--- a/frontend/src/metabase/admin/people/components/group-members/AddMemberRow.jsx
+++ b/frontend/src/metabase/admin/people/components/group-members/AddMemberRow.jsx
@@ -1,15 +1,25 @@
-/* eslint-disable react/prop-types */
 import React, { useMemo, useRef } from "react";
+import PropTypes from "prop-types";
 import cx from "classnames";
 
 import Icon from "metabase/components/Icon";
 import TippyPopover from "metabase/components/Popover/TippyPopover";
 import UserAvatar from "metabase/components/UserAvatar";
-
 import { color } from "metabase/lib/colors";
 import Typeahead from "metabase/hoc/Typeahead";
 
 import { AddRow } from "../AddRow";
+
+AddMemberRow.propTypes = {
+  users: PropTypes.array.isRequired,
+  text: PropTypes.string.isRequired,
+  selectedUsers: PropTypes.array.isRequired,
+  onCancel: PropTypes.func.isRequired,
+  onDone: PropTypes.func.isRequired,
+  onTextChange: PropTypes.func.isRequired,
+  onSuggestionAccepted: PropTypes.func.isRequired,
+  onRemoveUserFromSelection: PropTypes.func.isRequired,
+};
 
 export default function AddMemberRow({
   users,
@@ -68,6 +78,15 @@ const getColorPalette = () => [
   color("accent4"),
 ];
 
+const AddMemberTypeaheadPopoverPropTypes = {
+  suggestions: PropTypes.array,
+  selectedSuggestion: PropTypes.object,
+  onSuggestionAccepted: PropTypes.func.isRequired,
+  target: PropTypes.shape({
+    current: PropTypes.instanceOf(Element),
+  }),
+};
+
 const AddMemberTypeaheadPopover = Typeahead({
   optionFilter: (text, user) =>
     (user.common_name || "").toLowerCase().includes(text.toLowerCase()),
@@ -103,21 +122,27 @@ const AddMemberTypeaheadPopover = Typeahead({
   );
 });
 
-const AddMemberAutocompleteSuggestion = ({
-  user,
-  color,
-  selected,
-  onClick,
-}) => (
-  <div
-    className={cx("px2 py1 cursor-pointer", { "bg-brand": selected })}
-    onClick={onClick}
-  >
-    <span className="inline-block mr2">
-      <UserAvatar background={color} user={user} />
-    </span>
-    <span className={cx("h3", { "text-white": selected })}>
-      {user.common_name}
-    </span>
-  </div>
-);
+AddMemberTypeaheadPopover.propTypes = AddMemberTypeaheadPopoverPropTypes;
+
+AddMemberAutocompleteSuggestion.propTypes = {
+  user: PropTypes.object.isRequired,
+  color: PropTypes.string.isRequired,
+  selected: PropTypes.bool,
+  onClick: PropTypes.func.isRequired,
+};
+
+function AddMemberAutocompleteSuggestion({ user, color, selected, onClick }) {
+  return (
+    <div
+      className={cx("px2 py1 cursor-pointer", { "bg-brand": selected })}
+      onClick={onClick}
+    >
+      <span className="inline-block mr2">
+        <UserAvatar background={color} user={user} />
+      </span>
+      <span className={cx("h3", { "text-white": selected })}>
+        {user.common_name}
+      </span>
+    </div>
+  );
+}


### PR DESCRIPTION
This migration won't look quite like other popover migrations that are coming because we are using a popover in conjunction with the `Typeahead` HOC. We can't wrap the `Popover` around the target element because of how `Typeahead` works, so the original Popover wrapped an absolutely positioned div beneath the target input component. I've updated the code to use a ref so that `TippyPopover` can wrap the `AddRow` component input without any hacks. The benefit of this is that popover placement works much better. Here's a list of everything I did in this PR:

1. Wrapped the `AddRow` component in a `forwardRef`
2. Fixed a noisy PropTypes error in `AddRow`
3. Added a `useRef` to `AddMemberRow` and attached it to `AddRow`
4. Renamed `AddMemberTypeahead` to `AddMemberTypeaheadPopover` and made it use `TippyPopover` + the `AddRow` ref via its `reference` prop.
5. Updated the props of the popover to match the original styling (`offset` can be 0 here because the popover now targets the `AddRow` component instead of something beneath it).
6. Added PropTypes to the file

Before:

https://user-images.githubusercontent.com/13057258/159058580-b5f8f346-160c-464d-a8b4-61f589dd4625.mov

After:

https://user-images.githubusercontent.com/13057258/159058607-fd76ee80-7354-46f9-b6ec-ab97eaa93ee5.mov



