### PR TITLE
Use TippyPopover in TokenField's DefaultTokenFieldLayout

### DIFF
--- a/frontend/src/metabase/components/TokenField.jsx
+++ b/frontend/src/metabase/components/TokenField.jsx
@@ -6,9 +6,8 @@ import { findDOMNode } from "react-dom";
 import _ from "underscore";
 import cx from "classnames";
 
-import OnClickOutsideWrapper from "metabase/components/OnClickOutsideWrapper";
 import Icon from "metabase/components/Icon";
-import Popover from "metabase/components/Popover";
+import TippyPopover from "metabase/components/Popover/TippyPopover";
 import { TokenFieldAddon, TokenFieldItem } from "./TokenField.styled";
 
 import {
@@ -616,22 +615,15 @@ const DefaultTokenFieldLayout = ({
   isFocused,
   onClose,
 }) => (
-  <OnClickOutsideWrapper handleDismissal={onClose}>
-    <div>
-      {valuesList}
-      <Popover
-        isOpen={isFocused && !!optionsList}
-        hasArrow={false}
-        tetherOptions={{
-          attachment: "top left",
-          targetAttachment: "bottom left",
-          targetOffset: "10 0",
-        }}
-      >
-        {optionsList}
-      </Popover>
-    </div>
-  </OnClickOutsideWrapper>
+  <div>
+    <TippyPopover
+      visible={isFocused && !!optionsList}
+      content={<div>{optionsList}</div>}
+      placement="bottom-start"
+    >
+      <div>{valuesList}</div>
+    </TippyPopover>
+  </div>
 );
 
 DefaultTokenFieldLayout.propTypes = {

--- a/frontend/test/metabase/pulse/pulse.unit.spec.js
+++ b/frontend/test/metabase/pulse/pulse.unit.spec.js
@@ -16,7 +16,7 @@ const TEST_USERS = [
 
 describe("recipient picker", () => {
   describe("focus", () => {
-    it("should be focused if there are no recipients", () => {
+    it("should be focused if there are no recipients", async () => {
       render(
         <RecipientPicker
           recipients={[]}
@@ -26,8 +26,8 @@ describe("recipient picker", () => {
         />,
       );
       // Popover with all names should be open on focus
-      screen.getByText("Barb");
-      screen.getByText("Dustin");
+      await screen.findByText("Barb");
+      await screen.findByText("Dustin");
     });
     it("should not be focused if there are existing recipients", () => {
       render(


### PR DESCRIPTION
Related to https://github.com/metabase/metabase/issues/18951

A simple migration. This component is used in the sharing sidebar when selecting users:

https://user-images.githubusercontent.com/13057258/161168928-690c3888-f8bf-40b8-8877-da512d0e6e92.mov

**Testing**
1. Go to a dashboard
2. Click on the share icon in the header
3. Click the email option (this assumes you've set that up already)
4. Click on the user input and a popover should appear
5. Test at different viewport heights. Should work about the same as the previous popover.
