### PR TITLE
[E2E] Add `question` CI group to GitHub Actions

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -54,6 +54,7 @@ jobs:
           - "downloads"
           - "moderation"
           - "permissions"
+          - "question"
     services:
       maildev:
         image: maildev/maildev

--- a/frontend/test/metabase/scenarios/question/nested.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nested.cy.spec.js
@@ -378,6 +378,8 @@ describe("scenarios > question > nested", () => {
   });
 
   it("'distribution' should work on a joined table from a saved question (metabase#14787)", () => {
+    cy.intercept("POST", "/api/dataset").as("dataset");
+
     // Set the display really wide and really tall to avoid any scrolling
     cy.viewport(1600, 1200);
 
@@ -387,10 +389,13 @@ describe("scenarios > question > nested", () => {
     cy.findByText("Simple question").click();
     cy.findByText("Saved Questions").click();
     cy.findByText("14787").click();
+    cy.wait("@dataset");
 
     // The column title
     cy.findByText("Products → Category").click();
     cy.findByText("Distribution").click();
+    cy.wait("@dataset");
+
     summarize();
     cy.findByText("Group by")
       .parent()

--- a/frontend/test/metabase/scenarios/question/new.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/new.cy.spec.js
@@ -8,6 +8,7 @@ import {
   visualize,
   summarize,
   openNotebookEditor,
+  visitQuestion,
 } from "__support__/e2e/cypress";
 
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
@@ -437,7 +438,7 @@ describe("scenarios > question > new", () => {
 
     it("'read-only' user should be able to resize column width (metabase#9772)", () => {
       cy.signIn("readonly");
-      cy.visit("/question/1");
+      visitQuestion(1);
       cy.findByText("Tax")
         .closest(".TableInteractive-headerCellData")
         .as("headerCell")

--- a/frontend/test/metabase/scenarios/question/query-external.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/query-external.cy.spec.js
@@ -16,6 +16,8 @@ const supportedDatabases = [
 supportedDatabases.forEach(({ database, snapshotName, dbName }) => {
   describe("scenarios > question > query > external", () => {
     beforeEach(() => {
+      cy.intercept("POST", "/api/dataset").as("dataset");
+
       restore(snapshotName);
       cy.signInAsAdmin();
     });
@@ -26,6 +28,7 @@ supportedDatabases.forEach(({ database, snapshotName, dbName }) => {
       cy.findByText(dbName).click();
       cy.findByText("Orders").click();
 
+      cy.wait("@dataset");
       cy.contains("37.65");
     });
   });

--- a/frontend/test/metabase/scenarios/question/reproductions/17514-ui-overlay.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/17514-ui-overlay.cy.spec.js
@@ -91,6 +91,7 @@ describe("issue 17514", () => {
 
       filterWidget().click();
       setAdHocFilter({ timeBucket: "Years" });
+      cy.wait("@cardQuery");
 
       cy.findByText("Previous 30 Years");
 
@@ -104,8 +105,6 @@ describe("issue 17514", () => {
 
   describe("scenario 2", () => {
     beforeEach(() => {
-      cy.intercept("POST", "/api/dataset").as("dataset");
-
       cy.createQuestion(questionDetails, { visitQuestion: true });
 
       cy.findByTestId("viz-settings-button").click();
@@ -142,7 +141,7 @@ describe("issue 17514", () => {
 
 function openVisualizationOptions() {
   showDashboardCardActions();
-  cy.icon("palette").click();
+  cy.icon("palette").click({ force: true });
 }
 
 function hideColumn(columnName) {
@@ -165,6 +164,7 @@ function openNotebookMode() {
 
 function removeJoinedTable() {
   cy.findAllByText("Join data")
+    .first()
     .parent()
     .findByTestId("remove-step")
     .click({ force: true });


### PR DESCRIPTION
### Status
PENDING CI

### What does this PR accomplish?
- Adds `question` CI group to GitHub Actions
- Reinforces some of the tests that were flaking on my personal fork
    - This was the latest run that was finally green (https://github.com/nemanjaglumac/metabase/actions/runs/2005470456)
    - All the previous failed runs pointed me to the flakes that were fixed here

### Note
99% of all cases were flaking because of the premature assertions. We need to wait for the results to load explicitly.