### PR TITLE
Browsing | Fix data reference & admin permissions layout

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditApp.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditApp.jsx
@@ -1,13 +1,17 @@
 /* eslint-disable react/prop-types */
 import React from "react";
 
+import fitViewport from "metabase/hoc/FitViewPort";
+
 import SidebarLayout from "../components/SidebarLayoutFixedWidth";
 import AuditSidebar from "../components/AuditSidebar";
 
+const Layout = fitViewport(SidebarLayout);
+
 const AuditApp = ({ children }) => (
-  <SidebarLayout sidebar={<AuditSidebar />}>
+  <Layout sidebar={<AuditSidebar />}>
     <div>{children}</div>
-  </SidebarLayout>
+  </Layout>
 );
 
 export default AuditApp;

--- a/frontend/src/metabase/App.jsx
+++ b/frontend/src/metabase/App.jsx
@@ -58,6 +58,7 @@ const getErrorComponent = ({ status, data, context }) => {
 };
 
 const PATHS_WITHOUT_NAVBAR = [/\/model\/.*\/query/, /\/model\/.*\/metadata/];
+const PATHS_WITHOUT_APP_BAR = [/\/admin\//];
 
 @connect(mapStateToProps, mapDispatchToProps)
 export default class App extends Component {
@@ -86,6 +87,17 @@ export default class App extends Component {
     return !PATHS_WITHOUT_NAVBAR.some(pattern => pattern.test(pathname));
   };
 
+  hasAppBar = () => {
+    const {
+      currentUser,
+      location: { pathname },
+    } = this.props;
+    return (
+      currentUser &&
+      !PATHS_WITHOUT_APP_BAR.some(pattern => pattern.test(pathname))
+    );
+  };
+
   toggleSidebar = () => {
     this.setState({ sidebarOpen: !this.state.sidebarOpen });
   };
@@ -96,7 +108,7 @@ export default class App extends Component {
 
     return (
       <ScrollToTop>
-        <div className="relative flex" style={{ height: "100vh" }}>
+        <div className="relative hello flex" style={{ height: "100vh" }}>
           {this.hasNavbar() && this.state.sidebarOpen && (
             <Navbar location={location} />
           )}
@@ -104,27 +116,32 @@ export default class App extends Component {
             getErrorComponent(errorPage)
           ) : (
             <div className="full overflow-auto flex flex-column">
-              <div
-                className="full flex align-center bg-white border-bottom px2 relative z4"
-                id="mainAppBar"
-              >
-                <Icon
-                  name="burger"
-                  className="text-brand-hover cursor-pointer"
-                  onClick={() => this.toggleSidebar()}
-                />
-                <SearchBarContainer>
-                  <SearchBarContent>
-                    <SearchBar
-                      location={location}
-                      onChangeLocation={onChangeLocation}
+              {this.hasAppBar() && (
+                <div
+                  className="full flex align-center bg-white border-bottom px2 relative z4"
+                  id="mainAppBar"
+                >
+                  <Icon
+                    name="burger"
+                    className="text-brand-hover cursor-pointer"
+                    onClick={() => this.toggleSidebar()}
+                  />
+                  <SearchBarContainer>
+                    <SearchBarContent>
+                      <SearchBar
+                        location={location}
+                        onChangeLocation={onChangeLocation}
+                      />
+                    </SearchBarContent>
+                  </SearchBarContainer>
+                  <div className="ml-auto">
+                    <ProfileLink
+                      {...this.props}
+                      user={this.props.currentUser}
                     />
-                  </SearchBarContent>
-                </SearchBarContainer>
-                <div className="ml-auto">
-                  <ProfileLink {...this.props} user={this.props.currentUser} />
+                  </div>
                 </div>
-              </div>
+              )}
               {children}
             </div>
           )}

--- a/frontend/src/metabase/App.styled.tsx
+++ b/frontend/src/metabase/App.styled.tsx
@@ -1,0 +1,48 @@
+import styled from "@emotion/styled";
+import { css } from "@emotion/react";
+import Icon from "metabase/components/Icon";
+import { color } from "metabase/lib/colors";
+
+const coreAppCss = css`
+  display: flex;
+`;
+
+export const AppContentContainer = styled.div<{ isAdminApp: boolean }>`
+  position: relative;
+  height: 100vh;
+
+  ${props => !props.isAdminApp && coreAppCss}
+`;
+
+export const AppContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  overflow: auto;
+`;
+
+export const AppBar = styled.div`
+  display: flex;
+  align-items: center;
+  width: 100%;
+  position: relative;
+  padding-left: 1rem;
+  padding-right: 1rem;
+
+  background-color: ${color("bg-white")};
+  border-bottom: 1px solid ${color("border")};
+
+  z-index: 4;
+`;
+
+export const SidebarVisibilityControlIcon = styled(Icon)`
+  cursor: pointer;
+
+  &:hover {
+    color: ${color("brand")};
+  }
+`;
+
+export const ProfileLinkContainer = styled.div`
+  margin-left: auto;
+`;

--- a/frontend/src/metabase/App.styled.tsx
+++ b/frontend/src/metabase/App.styled.tsx
@@ -18,6 +18,7 @@ export const AppContent = styled.div`
   display: flex;
   flex-direction: column;
   width: 100%;
+  height: 100%;
   overflow: auto;
 `;
 

--- a/frontend/src/metabase/admin/app/components/AdminApp/AdminApp.tsx
+++ b/frontend/src/metabase/admin/app/components/AdminApp/AdminApp.tsx
@@ -6,13 +6,6 @@ export interface AdminAppProps {
 }
 
 const AdminApp = ({ children }: AdminAppProps): JSX.Element => {
-  useEffect(() => {
-    const b = document.querySelector("body");
-    if (b) {
-      b.classList.add("Admin");
-    }
-    return () => b.classList.remove("Admin");
-  }, []);
   return (
     <>
       <DeprecationNotice />

--- a/frontend/src/metabase/components/SidebarLayout.jsx
+++ b/frontend/src/metabase/components/SidebarLayout.jsx
@@ -2,8 +2,6 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-import fitViewport from "metabase/hoc/FitViewPort";
-
 const SidebarLayout = ({ className, style, sidebar, children }) => (
   <div
     className={className}
@@ -41,4 +39,4 @@ SidebarLayout.propTypes = {
   children: PropTypes.element.isRequired,
 };
 
-export default fitViewport(SidebarLayout);
+export default SidebarLayout;

--- a/frontend/src/metabase/css/admin.css
+++ b/frontend/src/metabase/css/admin.css
@@ -6,10 +6,6 @@
   --page-header-padding: 2.375rem;
 }
 
-.Admin #mainAppBar {
-  display: none;
-}
-
 /* utility to get a simple common hover state for admin items */
 .HoverItem:hover {
   background-color: var(--color-bg-medium);


### PR DESCRIPTION
Fixes broken data reference and admin permissions page layouts.

### To Verify

1. Sign in as admin
2. Open `/reference/databases/1/tables/1`, ensure the layout isn't broken
3. Open `/admin/permissions/data/group`, ensure the permissions sidebar takes the full-screen height (check the border height)

### Demo

<details>
<summary>Data Reference</summary>

**Before**

<img width="1509" alt="data-reference-before" src="https://user-images.githubusercontent.com/17258145/159075781-6ae9d2cf-887d-48d5-9212-c1de3a4821d9.png">

**After**

<img width="1506" alt="data-reference-after" src="https://user-images.githubusercontent.com/17258145/159075900-173a93c7-a6e8-4850-9172-814b5a3cbbe5.png">

</details>



<details>
<summary>Admin Permissions</summary>

**Before**

<img width="1505" alt="permissions-after" src="https://user-images.githubusercontent.com/17258145/159075847-dff55678-940d-4a52-a994-ba5eb8404eaf.png">

**After**

<img width="1506" alt="admin-permissions-after" src="https://user-images.githubusercontent.com/17258145/159075801-d2081e35-f797-4fa3-bda9-47d2d14a5757.png">

</details>