### PR TITLE
Always show the pivot option in settings if it is enabled

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/Table.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Table.jsx
@@ -86,7 +86,11 @@ export default class Table extends Component {
       section: t`Columns`,
       title: t`Pivot the table`,
       widget: "toggle",
-      getHidden: ([{ card, data }]) => data && data.cols.length !== 3,
+      getHidden: ([{ card, data }], visualization_settings) => {
+        const isPivoted = visualization_settings["table.pivot"];
+        const numCols = data?.cols?.length;
+        return numCols !== 3 && !isPivoted;
+      },
       getDefault: ([{ card, data }]) =>
         data &&
         data.cols.length === 3 &&


### PR DESCRIPTION
Resolves #9874

This PR makes it so that the pivot toggle isn't hidden if the table is already pivoted. Currently, the toggle disappears immediately if the criteria (there are exactly 3 columns) isn't met.

This at the very least lets users turn pivoting off if they decide to alter a question and then return to viz settings to disable pivot mode.


https://user-images.githubusercontent.com/13057258/166496318-90d367d8-adad-41b4-acc1-a8519583a1ab.mov


**Testing**
1. new native question, `select 1, 2, 3`, run the question
2. open "Settings" sidebar
3. toggle to pivot the table
4. update the question to `select 1, 2` and rerun the query
5. the pivot toggle should still show
6. toggle the toggle and it should disappear