### PR TITLE
fix percy

### DIFF
--- a/.github/workflows/percy-issue-comment.yml
+++ b/.github/workflows/percy-issue-comment.yml
@@ -71,18 +71,8 @@ jobs:
         uses: ./.github/actions/prepare-frontend
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
-
-      - name: Get Cypress cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/Cypress
-          key: ${{ runner.os }}-Cypress-${{ hashFiles('**/yarn.lock') }}
-      - name: Ensure that Cypress is ready
-        run: |
-          yarn cypress install
-          yarn cypress cache path
-          yarn cypress cache list
-          yarn cypress verify
+      - name: Prepare cypress environment
+        uses: ./.github/actions/prepare-cypress
 
       - uses: actions/download-artifact@v2
         name: Retrieve uberjar artifact

--- a/.github/workflows/percy-issue-comment.yml
+++ b/.github/workflows/percy-issue-comment.yml
@@ -55,9 +55,9 @@ jobs:
         uses: ./.github/actions/prepare-uberjar-artifact
 
   percy:
-    timeout-minutes: 30
+    timeout-minutes: 45
+    runs-on: buildjet-8vcpu-ubuntu-2004
     needs: [build, pr_info]
-    runs-on: ubuntu-20.04
     env:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/percy-issue-comment.yml
+++ b/.github/workflows/percy-issue-comment.yml
@@ -55,7 +55,7 @@ jobs:
         uses: ./.github/actions/prepare-uberjar-artifact
 
   percy:
-    timeout-minutes: 45
+    timeout-minutes: 30
     runs-on: buildjet-8vcpu-ubuntu-2004
     needs: [build, pr_info]
     env:

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -4,8 +4,8 @@ name: Percy
 on:
   push:
     branches:
-    # - master
-    # - "release-**"
+      - master
+      - "release-**"
     paths-ignore:
       - "docs/**"
       - "**.md"

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -36,7 +36,7 @@ jobs:
         uses: ./.github/actions/prepare-uberjar-artifact
 
   percy:
-    timeout-minutes: 45
+    timeout-minutes: 30
     runs-on: buildjet-8vcpu-ubuntu-2004
     needs: build
     steps:

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -4,8 +4,8 @@ name: Percy
 on:
   push:
     branches:
-      - master
-      - "release-**"
+    # - master
+    # - "release-**"
     paths-ignore:
       - "docs/**"
       - "**.md"
@@ -36,8 +36,8 @@ jobs:
         uses: ./.github/actions/prepare-uberjar-artifact
 
   percy:
-    runs-on: ubuntu-20.04
-    timeout-minutes: 30
+    timeout-minutes: 45
+    runs-on: buildjet-8vcpu-ubuntu-2004
     needs: build
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Percy's job started taking too long after the Cypress upgrade.

This PR changes Percy's jobs to use more powerful buildjet agents.
Example job: https://github.com/metabase/metabase/runs/5607621036?check_suite_focus=true