### PR TITLE
Search E2E tests: ensure element visibility before assertions

### DIFF
--- a/frontend/test/metabase/scenarios/onboarding/search/recently-viewed.cy.spec.js
+++ b/frontend/test/metabase/scenarios/onboarding/search/recently-viewed.cy.spec.js
@@ -8,14 +8,14 @@ describe(`search > recently viewed`, () => {
 
   it("shows list of recently viewed items", () => {
     cy.visit("/browse/1-sample-database");
-    cy.findByText("People").click();
+    cy.findByTextEnsureVisible("People").click();
 
     // "Orders" question
     cy.visit("/question/1");
 
     // "Orders in a dashboard" dashboard
     cy.visit("/dashboard/1");
-    cy.findByText("Product ID");
+    cy.findByTextEnsureVisible("Product ID");
 
     // inside the "Orders in a dashboard" dashboard, the order is queried again,
     // which elicits a ViewLog entry


### PR DESCRIPTION
### Before this PR

Sometime `frontend/test/metabase/scenarios/onboarding/search/recently-viewed.cy.spec.js` failed like this:

![search  recently viewed -- shows list of recently viewed items (failed) (attempt 2)](https://user-images.githubusercontent.com/7288/159092923-fd6a7689-5a27-40fc-a5ee-1d830f18cac6.png)

### After this PR

It shouldn't happen anymore.
