### PR TITLE
Auth E2E tests: wait for the dataset to load before assertions

### DIFF
--- a/frontend/test/metabase/scenarios/onboarding/auth/signin.cy.spec.js
+++ b/frontend/test/metabase/scenarios/onboarding/auth/signin.cy.spec.js
@@ -11,6 +11,7 @@ describe("scenarios > auth > signin", () => {
   beforeEach(() => {
     restore();
     cy.signOut();
+    cy.intercept("POST", "/api/dataset").as("dataset");
   });
 
   it("should redirect to  /auth/login", () => {
@@ -59,6 +60,7 @@ describe("scenarios > auth > signin", () => {
     browse().click();
     cy.contains("Sample Database").click();
     cy.contains("Orders").click();
+    cy.wait("@dataset");
     cy.contains("37.65");
 
     // signout and reload page with question hash in url
@@ -71,6 +73,7 @@ describe("scenarios > auth > signin", () => {
     cy.findByText("Sign in").click();
 
     // order table should load after login
+    cy.wait("@dataset");
     cy.contains("37.65");
   });
 


### PR DESCRIPTION
### Before this PR

We can spot this failure in `frontend/test/metabase/scenarios/onboarding/auth/signin.cy.spec.js`

![scenarios  auth  signin -- should redirect to a unsaved question after login (failed) (attempt 3)](https://user-images.githubusercontent.com/7288/159093090-8ca4b2d4-f28e-49d6-ad6c-19e48465ebe6.png)

### After this PR

Can't let that happen anymore!