### PR TITLE
Smoketest admin E2E: guard assertions with element visibility check

### DIFF
--- a/frontend/test/metabase/scenarios/smoketest/admin_setup.cy.spec.js
+++ b/frontend/test/metabase/scenarios/smoketest/admin_setup.cy.spec.js
@@ -402,7 +402,7 @@ describe("smoketest > admin_setup", () => {
       cy.wait(1)
         .findByText("Discount")
         .should("not.exist");
-      cy.findByText("Sale ($)");
+      cy.findByTextEnsureVisible("Sale ($)");
 
       cy.findByText("Created At").should("not.exist");
 
@@ -419,7 +419,7 @@ describe("smoketest > admin_setup", () => {
       cy.findByText("Custom column");
 
       cy.findByText("Filter").click();
-      cy.findByText("Sale");
+      cy.findByTextEnsureVisible("Sale ($)");
       cy.findByText("Discount").should("not.exist");
 
       cy.findByText("Created At").should("not.exist");
@@ -452,7 +452,7 @@ describe("smoketest > admin_setup", () => {
       cy.visit("/browse/1");
       cy.findByText("Test Table").click();
 
-      cy.findByText("Product ID");
+      cy.findByTextEnsureVisible("Product ID");
       cy.findAllByText("Awesome Concrete Shoes");
       cy.findAllByText("Mediocre Wooden Bench");
       cy.get(".Table-ID")
@@ -492,7 +492,7 @@ describe("smoketest > admin_setup", () => {
         .find(".Icon-eye_crossed_out")
         .click({ force: true });
 
-      cy.findByText("1 Hidden Table");
+      cy.findByTextEnsureVisible("1 Hidden Table");
 
       // Check table hidden on home page
       cy.visit("/");
@@ -504,8 +504,8 @@ describe("smoketest > admin_setup", () => {
 
       cy.visit("/browse/1");
 
-      cy.findByText("Learn about our data");
-      cy.findByText("People");
+      cy.findByTextEnsureVisible("Learn about our data");
+      cy.findByTextEnsureVisible("People");
       cy.findByText("Reviews").should("not.exist");
 
       // Check table hidden in notebook editor
@@ -534,7 +534,7 @@ describe("smoketest > admin_setup", () => {
 
       cy.findByText("Browse all items").click();
 
-      cy.findByText("Orders, Count");
+      cy.findByTextEnsureVisible("Orders, Count");
       cy.findByText("Orders, Count, Grouped by Created At (year)").should(
         "not.exist",
       );
@@ -556,9 +556,9 @@ describe("smoketest > admin_setup", () => {
       cy.findByTextEnsureVisible("Sample Database").click();
       cy.findByTextEnsureVisible("Test Table").click();
 
-      cy.findByText("Visualization");
+      cy.findByTextEnsureVisible("Visualization");
       cy.findByText("Discount").should("not.exist");
-      cy.findByText("Sale ($)");
+      cy.findByTextEnsureVisible("Sale ($)");
       cy.findByText("Created At").should("not.exist");
 
       // Check column formatting


### PR DESCRIPTION
### Before this PR

Among few failures in `frontend/test/metabase/scenarios/smoketest/admin_setup.cy.spec.js`, some looks like this:

![smoketest  admin_setup -- data model changes by admin reflected with user -- should reflect changes to column name, visibility, and formatting in the notebook editor for admin (failed)](https://user-images.githubusercontent.com/7288/159100138-2807c609-1774-4e37-973e-5c2759f8bb7d.png)


### After this PR

Those failures aren't going to make a come back!