### PR TITLE
Dashboard drill E2E tests: ensure element visibility before assertions

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
@@ -670,6 +670,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
         cy.visit(`/dashboard/${DASHBOARD_ID}?date_filter=past30years`);
       });
     });
+    cy.findByTextEnsureVisible("Quantity");
     cy.get(".Table-ID")
       .first()
       // Mid-point check that this cell actually contains ID = 1


### PR DESCRIPTION
### Before this PR

Another race condition in `frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js`:

![scenarios  dashboard  dashboard drill -- should drill-through on PKFK to the object detail when filtered by explicit joined column (metabase%2315331) (failed)](https://user-images.githubusercontent.com/7288/159132966-d4f3d3a6-042e-4149-897e-4f588d3d96d5.png)

### After this PR

Can't happen anyway, we wait a bit until the table view is constructed (hence, the check for column name).