### PR TITLE
Search E2E test: ensure that the People table is really loaded

### DIFF
--- a/frontend/test/metabase/scenarios/onboarding/search/recently-viewed.cy.spec.js
+++ b/frontend/test/metabase/scenarios/onboarding/search/recently-viewed.cy.spec.js
@@ -4,11 +4,16 @@ describe(`search > recently viewed`, () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
+    cy.intercept("POST", "/api/dataset").as("dataset");
   });
 
   it("shows list of recently viewed items", () => {
     cy.visit("/browse/1-sample-database");
+
+    // "People" table
     cy.findByTextEnsureVisible("People").click();
+    cy.wait("@dataset");
+    cy.findByTextEnsureVisible("Address");
 
     // "Orders" question
     cy.visit("/question/1");


### PR DESCRIPTION
### Before this PR

There could be the following failure on the search test:

![search  recently viewed -- shows list of recently viewed items (failed)](https://user-images.githubusercontent.com/7288/159166768-560132b6-3780-459d-b741-7dadcac090da.png)

### After this PR

The failure happened because the previous visit to the People table wasn't completed yet, but then it was navigated away. Thus, the People table wasn't properly registered as "recently visited".

The fix is to wait until the People dataset is fully loaded and its corresponding table view is completely constructed.