### PR TITLE
Binning E2E tests: ensure dataset and table view before assertions

### DIFF
--- a/frontend/test/metabase/scenarios/binning/sql.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/sql.cy.spec.js
@@ -38,6 +38,7 @@ describe("scenarios > binning > from a saved sql question", () => {
       cy.findByText("Saved Questions").click();
       cy.findByText("SQL Binning").click();
       cy.wait("@dataset");
+      cy.findByTextEnsureVisible("LONGITUDE");
       summarize();
     });
 
@@ -166,6 +167,8 @@ describe("scenarios > binning > from a saved sql question", () => {
       cy.findByText("Simple question").click();
       cy.findByText("Saved Questions").click();
       cy.findByText("SQL Binning").click();
+      cy.wait("@dataset");
+      cy.findByTextEnsureVisible("LONGITUDE");
     });
 
     it("should work for time series", () => {


### PR DESCRIPTION
### Before this PR

Another premature assertion leads to this kind of failure. Note how the check for `CREATED_AT` happened before the call to `/api/dataset`.

![scenarios  binning  from a saved sql question -- via column popover -- should work for time series (failed)](https://user-images.githubusercontent.com/7288/159174979-2224053d-b23b-4dd5-bae5-34ce1e1985e6.png)

### After this PR

This should not happen, as we force the proper sequence of events.