### PR TITLE
E2E tests on master: use Buildjet 4vCPU

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -34,7 +34,7 @@ jobs:
       uses: ./.github/actions/prepare-uberjar-artifact
 
   e2e-tests:
-    runs-on: buildjet-2vcpu-ubuntu-2004
+    runs-on: buildjet-4vcpu-ubuntu-2004
     timeout-minutes: 30
     needs: build
     name: e2e-tests-${{ matrix.folder }}-${{ matrix.edition }}


### PR DESCRIPTION
### Before this PR

On some unlucky days, a test run can go beyond the 30-minute timeout. See e.g. this one https://github.com/metabase/metabase/runs/5618470870.

![image](https://user-images.githubusercontent.com/7288/159175406-69b8e461-2018-45f5-9222-3b35f80665e9.png)


### After this PR

With the tests running on a 4-vCPU machine, hope we will never cross that 30-minute mark anymore.