### PR TITLE
E2E for repros: check dataset and table view before assertions

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard-filters/reproductions/15279-gracefully-deal-with-corrupted-filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/reproductions/15279-gracefully-deal-with-corrupted-filter.cy.spec.js
@@ -36,6 +36,7 @@ describe("issue 15279", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
+    cy.intercept("GET", "/api/dashboard/*/params/*/values").as("values");
   });
 
   it("a corrupted parameter filter should still appear in the UI (metabase #15279)", () => {
@@ -82,6 +83,9 @@ describe("issue 15279", () => {
     filterWidget()
       .contains("List")
       .click();
+
+    cy.wait("@values");
+    cy.findByTextEnsureVisible("Add filter");
 
     cy.findByPlaceholderText("Enter some text")
       .type("Organic")

--- a/frontend/test/metabase/scenarios/question/reproductions/17514-ui-overlay.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/17514-ui-overlay.cy.spec.js
@@ -46,6 +46,7 @@ describe("issue 17514", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
+    cy.intercept("POST", "/api/dataset").as("dataset");
   });
 
   describe("scenario 1", () => {
@@ -96,6 +97,8 @@ describe("issue 17514", () => {
       cy.findByText("Previous 30 Years");
 
       cy.findByText("17514").click();
+      cy.wait("@dataset");
+      cy.findByTextEnsureVisible("Subtotal");
 
       // Cypress cannot click elements that are blocked by an overlay so this will immediately fail if the issue is not fixed
       cy.findByText("110.93").click();

--- a/frontend/test/metabase/scenarios/question/reproductions/9027-new-questions-not-in-saved-questions-immediately.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/9027-new-questions-not-in-saved-questions-immediately.cy.spec.js
@@ -44,10 +44,14 @@ function goToSavedQuestionPickerAndAssertQuestion(questionName, exists = true) {
 }
 
 function saveQuestion(name) {
+  cy.intercept("POST", "/api/card").as("saveQuestion");
   cy.findByText("Save").click();
-  cy.findByLabelText("Name").type(name);
+  cy.findByLabelText("Name")
+    .clear()
+    .type(name);
   cy.button("Save").click();
   cy.button("Not now").click();
+  cy.wait("@saveQuestion");
 }
 
 function archiveQuestion(questionName) {


### PR DESCRIPTION
### Before this PR

There were some instances of eager assertions in some repros, while led to sporadic failures, e.g.:

![issue 17514 -- scenario 1 -- should not show the run overlay when we apply dashboard filter on a question with removed column and then click through its title (metabase#17514-1) (failed)](https://user-images.githubusercontent.com/7288/159178585-51d78d6a-5792-4bc3-863a-c07625d1e81a.png)

### After this PR

Won't happen anymore, suppressed by the enforcement of the proper sequencing.
