### PR TITLE
Mongo E2E test: fix race condition between typing and dataset

### DIFF
--- a/frontend/test/metabase/scenarios/native/native-mongo.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/native-mongo.cy.spec.js
@@ -5,6 +5,7 @@ const MONGO_DB_NAME = "QA Mongo4";
 describe("scenarios > question > native > mongo", () => {
   before(() => {
     cy.intercept("POST", "/api/card").as("createQuestion");
+    cy.intercept("POST", "/api/dataset").as("dataset");
 
     restore("mongo-4");
     cy.signInAsNormalUser();
@@ -24,13 +25,19 @@ describe("scenarios > question > native > mongo", () => {
       parseSpecialCharSequences: false,
     });
     cy.get(".NativeQueryEditor .Icon-play").click();
-    cy.findByText("18,760");
+
+    cy.wait("@dataset");
+
+    cy.findByTextEnsureVisible("18,760");
 
     cy.findByText("Save").click();
 
+    cy.findByTextEnsureVisible("Save question");
+
     modal().within(() => {
       cy.findByLabelText("Name")
-        .focus()
+        .clear()
+        .should("have.value", "")
         .type("mongo count");
 
       cy.button("Save")

--- a/frontend/test/metabase/scenarios/native/native-mongo.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/native-mongo.cy.spec.js
@@ -37,7 +37,7 @@ describe("scenarios > question > native > mongo", () => {
     modal().within(() => {
       cy.findByLabelText("Name")
         .clear()
-        .should("have.value", "")
+        .should("be.empty")
         .type("mongo count");
 
       cy.button("Save")


### PR DESCRIPTION
### Before this PR

Sometimes, `native-mongo.cy.spec.js` failed like this:

![scenarios  question  native  mongo -- can save a native MongoDB query (failed) (attempt 3)](https://user-images.githubusercontent.com/7288/158918925-a46c0da2-220f-4efb-a476-abd968e0f30d.png)

### After this PR

It should not fail anymore.