### PR TITLE
[E2E] Robustify visit question by applying `visitQuestion` helper

### DIFF
--- a/frontend/test/metabase/scenarios/admin/datamodel/table.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/table.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, filter } from "__support__/e2e/cypress";
+import { restore, filter, visitQuestion } from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
@@ -67,7 +67,7 @@ describe("scenarios > admin > databases > table", () => {
   describe.skip("turning table visibility off shouldn't prevent editing related question (metabase#15947)", () => {
     it("simple question (metabase#15947-1)", () => {
       turnTableVisibilityOff(ORDERS_ID);
-      cy.visit("/question/1");
+      visitQuestion(1);
       filter();
     });
 

--- a/frontend/test/metabase/scenarios/admin/settings/localization.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/localization.cy.spec.js
@@ -1,4 +1,8 @@
-import { restore, visitQuestionAdhoc } from "__support__/e2e/cypress";
+import {
+  restore,
+  visitQuestionAdhoc,
+  visitQuestion,
+} from "__support__/e2e/cypress";
 
 import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
@@ -171,7 +175,7 @@ describe("scenarios > admin > localization", () => {
     cy.findByText("17:24 (24-hour clock)").click();
     cy.wait("@updateFormatting");
 
-    cy.visit("/question/1");
+    visitQuestion(1);
     cy.findByTestId("loading-spinner").should("not.exist");
 
     // create a date filter and set it to the 'On' view to see a specific date

--- a/frontend/test/metabase/scenarios/auditing/auditing.cy.spec.js
+++ b/frontend/test/metabase/scenarios/auditing/auditing.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, describeEE } from "__support__/e2e/cypress";
+import { restore, describeEE, visitQuestion } from "__support__/e2e/cypress";
 import { USERS } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 const { normal } = USERS;
@@ -47,7 +47,7 @@ describeEE("audit > auditing", () => {
     });
 
     cy.log("Download a question");
-    cy.visit("/question/3");
+    visitQuestion(3);
     cy.icon("download").click();
     cy.request("POST", "/api/card/1/query/json");
 
@@ -60,7 +60,7 @@ describeEE("audit > auditing", () => {
     cy.findByText("My personal collection").should("not.exist");
 
     cy.log("View old existing question");
-    cy.visit("/question/2");
+    visitQuestion(2);
     cy.findByText("18,760");
 
     cy.log("View newly created admin's question");

--- a/frontend/test/metabase/scenarios/binning/qb-implicit-joins.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/qb-implicit-joins.cy.spec.js
@@ -3,6 +3,7 @@ import {
   changeBinningForDimension,
   visualize,
   summarize,
+  visitQuestion,
 } from "__support__/e2e/cypress";
 
 /**
@@ -21,7 +22,7 @@ describe("scenarios > binning > from a saved QB question using implicit joins", 
 
   context("via simple question", () => {
     beforeEach(() => {
-      cy.visit("/question/1");
+      visitQuestion(1);
       summarize();
     });
 

--- a/frontend/test/metabase/scenarios/collections/items-metadata.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/items-metadata.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore } from "__support__/e2e/cypress";
+import { restore, visitQuestion } from "__support__/e2e/cypress";
 import { USERS } from "__support__/e2e/cypress_data";
 
 describe("scenarios > collection items metadata", () => {
@@ -18,7 +18,7 @@ describe("scenarios > collection items metadata", () => {
     });
 
     it("should display last edit moment for questions", () => {
-      cy.visit("/question/1");
+      visitQuestion(1);
       changeQuestion();
       cy.findByText(/Edited a few seconds ago/i);
     });
@@ -29,7 +29,7 @@ describe("scenarios > collection items metadata", () => {
       cy.signInAsAdmin();
       cy.visit("/dashboard/1");
       cy.findByText(/Edited .* by you/i);
-      cy.visit("/question/1");
+      visitQuestion(1);
       cy.findByText(/Edited .* by you/i);
     });
 
@@ -41,7 +41,7 @@ describe("scenarios > collection items metadata", () => {
       cy.signIn("normal");
       cy.visit("/dashboard/1");
       cy.findByText(new RegExp(`Edited .* by ${expectedName}`, "i"));
-      cy.visit("/question/1");
+      visitQuestion(1);
       cy.findByText(new RegExp(`Edited .* by ${expectedName}`, "i"));
     });
 

--- a/frontend/test/metabase/scenarios/collections/permissions-baseline.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions-baseline.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore } from "__support__/e2e/cypress";
+import { restore, visitQuestion } from "__support__/e2e/cypress";
 
 describe("scenarios > permissions", () => {
   beforeEach(restore);
@@ -34,7 +34,7 @@ describe("scenarios > permissions", () => {
 
   it("should let a user with no data permissions view questions", () => {
     cy.signIn("nodata");
-    cy.visit("/question/1");
+    visitQuestion(1);
     cy.contains("February 11, 2019, 9:40 PM"); // check that the data loads
   });
 });

--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -16,6 +16,7 @@ import {
   popover,
   sidebar,
   openNativeEditor,
+  visitQuestion,
 } from "__support__/e2e/cypress";
 import { displaySidebarChildOf } from "./helpers/e2e-collections-sidebar.js";
 import { USERS } from "__support__/e2e/cypress_data";
@@ -331,7 +332,7 @@ describe("collection permissions", () => {
               describe("managing question from the question's details sidebar action buttons (metabase#11719)", () => {
                 beforeEach(() => {
                   cy.route("PUT", "/api/card/1").as("updateQuestion");
-                  cy.visit("/question/1");
+                  visitQuestion(1);
                   cy.findByTestId("saved-question-header-button").click();
                 });
 
@@ -535,7 +536,7 @@ describe("collection permissions", () => {
 
             describe("managing question from the question's details sidebar", () => {
               beforeEach(() => {
-                cy.visit("/question/1");
+                visitQuestion(1);
               });
 
               it("should not be offered to add question to dashboard inside a collection they have `read` access to", () => {
@@ -572,7 +573,7 @@ describe("collection permissions", () => {
               });
 
               it("should not offer a user the ability to update or clone the question", () => {
-                cy.visit("/question/1");
+                visitQuestion(1);
                 cy.findByTestId("saved-question-header-button").click();
 
                 cy.findByTestId("edit-details-button").should("not.exist");
@@ -736,7 +737,7 @@ describe("collection permissions", () => {
 
                 cy.skipOn(user === "nodata");
 
-                cy.visit("/question/1");
+                visitQuestion(1);
                 cy.wait("@cardQuery");
 
                 cy.findByTestId("revision-history-button").click();
@@ -755,7 +756,7 @@ describe("collection permissions", () => {
 
                 cy.skipOn(user === "nodata");
 
-                cy.visit("/question/1");
+                visitQuestion(1);
                 cy.wait("@cardQuery");
 
                 cy.findByTestId("saved-question-header-button").click();
@@ -786,7 +787,7 @@ describe("collection permissions", () => {
 
               it("should not see question revert buttons (metabase#13229)", () => {
                 cy.signIn(user);
-                cy.visit("/question/1");
+                visitQuestion(1);
                 cy.findByRole("button", { name: /Edited .*/ }).click();
 
                 cy.findAllByRole("button", { name: "Revert" }).should(

--- a/frontend/test/metabase/scenarios/embedding/reproductions/20634-locked-parameters-in-embedded-question.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/reproductions/20634-locked-parameters-in-embedded-question.cy.spec.js
@@ -5,24 +5,24 @@ describe("locked parameters in embedded question (metabase#20634)", () => {
     restore();
     cy.signInAsAdmin();
 
-    cy.createNativeQuestion({
-      name: "20634",
-      native: {
-        query: "select {{text}}",
-        "template-tags": {
-          text: {
-            id: "abc-123",
-            name: "text",
-            "display-name": "Text",
-            type: "text",
-            default: null,
+    cy.createNativeQuestion(
+      {
+        name: "20634",
+        native: {
+          query: "select {{text}}",
+          "template-tags": {
+            text: {
+              id: "abc-123",
+              name: "text",
+              "display-name": "Text",
+              type: "text",
+              default: null,
+            },
           },
         },
       },
-    }).then(({ body: { id } }) => {
-      cy.visit(`/question/${id}`);
-      cy.findByTestId("loading-spinner").should("not.exist");
-    });
+      { visitQuestion: true },
+    );
   });
 
   it("should let the user lock parameters to specific values", () => {

--- a/frontend/test/metabase/scenarios/models/models-revision-history.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models-revision-history.cy.spec.js
@@ -26,7 +26,7 @@ describe("scenarios > models > revision history", () => {
   });
 
   it("should allow reverting to a saved question state", () => {
-    visitQuestion(3);
+    cy.visit("/model/3");
     openDetailsSidebar();
     assertIsModel();
 

--- a/frontend/test/metabase/scenarios/models/models-revision-history.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models-revision-history.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, modal, filter } from "__support__/e2e/cypress";
+import { restore, modal, filter, visitQuestion } from "__support__/e2e/cypress";
 
 import {
   assertIsModel,
@@ -26,7 +26,7 @@ describe("scenarios > models > revision history", () => {
   });
 
   it("should allow reverting to a saved question state", () => {
-    cy.visit("/question/3");
+    visitQuestion(3);
     openDetailsSidebar();
     assertIsModel();
 
@@ -52,7 +52,7 @@ describe("scenarios > models > revision history", () => {
   it("should allow reverting to a model state", () => {
     cy.request("PUT", "/api/card/3", { dataset: false });
 
-    cy.visit("/question/3");
+    visitQuestion(3);
     openDetailsSidebar();
     assertIsQuestion();
 

--- a/frontend/test/metabase/scenarios/models/models.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models.cy.spec.js
@@ -171,7 +171,8 @@ describe("scenarios > models", () => {
 
   it("redirects to /model URL when opening a model with /question URL", () => {
     cy.request("PUT", "/api/card/1", { dataset: true });
-    visitQuestion(1);
+    // Important - do not use visitQuestion(1) here!
+    cy.visit("/question/1");
     cy.wait("@dataset");
     openDetailsSidebar();
     assertIsModel();
@@ -291,7 +292,7 @@ describe("scenarios > models", () => {
     });
 
     it("can create a question by filtering and summarizing a model", () => {
-      visitQuestion(1);
+      cy.visit("/model/1");
       cy.wait("@dataset");
 
       filter();
@@ -331,7 +332,7 @@ describe("scenarios > models", () => {
     });
 
     it("can create a question using table click actions", () => {
-      visitQuestion(1);
+      cy.visit("/model/1");
       cy.wait("@dataset");
 
       cy.findByText("Subtotal").click();
@@ -358,7 +359,7 @@ describe("scenarios > models", () => {
 
     it("can edit model info", () => {
       cy.intercept("PUT", "/api/card/1").as("updateCard");
-      visitQuestion(1);
+      cy.visit("/model/1");
       cy.wait("@dataset");
 
       openDetailsSidebar();

--- a/frontend/test/metabase/scenarios/models/models.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models.cy.spec.js
@@ -10,6 +10,7 @@ import {
   sidebar,
   summarize,
   filter,
+  visitQuestion,
 } from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 import {
@@ -35,7 +36,7 @@ describe("scenarios > models", () => {
 
   it("allows to turn a GUI question into a model", () => {
     cy.request("PUT", "/api/card/1", { name: "Orders Model" });
-    cy.visit("/question/1");
+    visitQuestion(1);
 
     turnIntoModel();
     assertIsModel();
@@ -123,7 +124,7 @@ describe("scenarios > models", () => {
   });
 
   it("changes model's display to table", () => {
-    cy.visit("/question/3");
+    visitQuestion(3);
 
     cy.get(".LineAreaBarChart");
     cy.get(".TableInteractive").should("not.exist");
@@ -135,7 +136,7 @@ describe("scenarios > models", () => {
   });
 
   it("allows to undo turning a question into a model", () => {
-    cy.visit("/question/3");
+    visitQuestion(3);
     cy.get(".LineAreaBarChart");
 
     turnIntoModel();
@@ -170,7 +171,7 @@ describe("scenarios > models", () => {
 
   it("redirects to /model URL when opening a model with /question URL", () => {
     cy.request("PUT", "/api/card/1", { dataset: true });
-    cy.visit("/question/1");
+    visitQuestion(1);
     cy.wait("@dataset");
     openDetailsSidebar();
     assertIsModel();
@@ -290,7 +291,7 @@ describe("scenarios > models", () => {
     });
 
     it("can create a question by filtering and summarizing a model", () => {
-      cy.visit("/question/1");
+      visitQuestion(1);
       cy.wait("@dataset");
 
       filter();
@@ -330,7 +331,7 @@ describe("scenarios > models", () => {
     });
 
     it("can create a question using table click actions", () => {
-      cy.visit("/question/1");
+      visitQuestion(1);
       cy.wait("@dataset");
 
       cy.findByText("Subtotal").click();
@@ -357,7 +358,7 @@ describe("scenarios > models", () => {
 
     it("can edit model info", () => {
       cy.intercept("PUT", "/api/card/1").as("updateCard");
-      cy.visit("/question/1");
+      visitQuestion(1);
       cy.wait("@dataset");
 
       openDetailsSidebar();

--- a/frontend/test/metabase/scenarios/moderation/question-moderation.cy.spec.js
+++ b/frontend/test/metabase/scenarios/moderation/question-moderation.cy.spec.js
@@ -1,4 +1,4 @@
-import { describeEE, restore } from "__support__/e2e/cypress";
+import { describeEE, restore, visitQuestion } from "__support__/e2e/cypress";
 
 describeEE("scenarios > saved question moderation", () => {
   describe("as an admin", () => {
@@ -6,7 +6,7 @@ describeEE("scenarios > saved question moderation", () => {
       restore();
       cy.signInAsAdmin();
 
-      cy.visit("/question/2");
+      visitQuestion(2);
     });
 
     it("should be able to verify a saved question", () => {
@@ -74,7 +74,7 @@ describeEE("scenarios > saved question moderation", () => {
     });
 
     it("should be able to see that a question has not been verified", () => {
-      cy.visit("/question/3");
+      visitQuestion(3);
 
       cy.icon("verified").should("not.exist");
 
@@ -94,7 +94,7 @@ describeEE("scenarios > saved question moderation", () => {
     });
 
     it("should be able to see that a question has been verified", () => {
-      cy.visit("/question/2");
+      visitQuestion(2);
 
       cy.icon("verified");
 
@@ -110,7 +110,7 @@ describeEE("scenarios > saved question moderation", () => {
     });
 
     it("should be able to see the question verification in the question's timeline", () => {
-      cy.visit("/question/2");
+      visitQuestion(2);
 
       cy.findByTestId("saved-question-header-button").click();
       cy.findByText("History").click();

--- a/frontend/test/metabase/scenarios/moderation/reproductions/18021-verified-badge-not-visible-in-recents.cy.spec.js
+++ b/frontend/test/metabase/scenarios/moderation/reproductions/18021-verified-badge-not-visible-in-recents.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, isEE } from "__support__/e2e/cypress";
+import { restore, isEE, visitQuestion } from "__support__/e2e/cypress";
 
 describe.skip("issue 18021", () => {
   beforeEach(() => {
@@ -14,7 +14,7 @@ describe.skip("issue 18021", () => {
       moderated_item_type: "card",
     });
 
-    cy.visit("/question/1");
+    visitQuestion(1);
 
     cy.findByTestId("saved-question-header-button").find(".Icon-verified");
   });

--- a/frontend/test/metabase/scenarios/onboarding/search/recently-viewed.cy.spec.js
+++ b/frontend/test/metabase/scenarios/onboarding/search/recently-viewed.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore } from "__support__/e2e/cypress";
+import { restore, visitQuestion } from "__support__/e2e/cypress";
 
 describe(`search > recently viewed`, () => {
   beforeEach(() => {
@@ -16,7 +16,7 @@ describe(`search > recently viewed`, () => {
     cy.findByTextEnsureVisible("Address");
 
     // "Orders" question
-    cy.visit("/question/1");
+    visitQuestion(1);
 
     // "Orders in a dashboard" dashboard
     cy.visit("/dashboard/1");

--- a/frontend/test/metabase/scenarios/permissions/admin-permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/admin-permissions.cy.spec.js
@@ -9,6 +9,7 @@ import {
   selectSidebarItem,
   assertSidebarItems,
   isPermissionDisabled,
+  visitQuestion,
 } from "__support__/e2e/cypress";
 
 const COLLECTION_ACCESS_PERMISSION_INDEX = 0;
@@ -508,7 +509,7 @@ describeOSS("scenarios > admin > permissions", () => {
   it.skip("block permission block access to questions that use blocked sources", () => {
     cy.signInAsNormalUser();
 
-    cy.visit("/question/1");
+    visitQuestion(1);
     cy.findAllByText("Orders");
 
     cy.signInAsAdmin();
@@ -527,7 +528,7 @@ describeOSS("scenarios > admin > permissions", () => {
 
     cy.signInAsNormalUser();
 
-    cy.visit("/question/1");
+    visitQuestion(1);
 
     cy.findAllByText("Orders").should("not.exist");
   });

--- a/frontend/test/metabase/scenarios/question/caching.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/caching.cy.spec.js
@@ -3,6 +3,7 @@ import {
   describeEE,
   mockSessionProperty,
   modal,
+  visitQuestion,
 } from "__support__/e2e/cypress";
 
 describeEE("scenarios > question > caching", () => {
@@ -14,7 +15,7 @@ describeEE("scenarios > question > caching", () => {
 
   it("can set cache ttl for a saved question", () => {
     cy.intercept("PUT", "/api/card/1").as("updateQuestion");
-    cy.visit("/question/1");
+    visitQuestion(1);
 
     openEditingModalForm();
     modal().within(() => {

--- a/frontend/test/metabase/scenarios/question/new.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/new.cy.spec.js
@@ -353,7 +353,7 @@ describe("scenarios > question > new", () => {
     });
 
     it("should show a table info popover when hovering over the table name in the header", () => {
-      cy.visit("/question/1");
+      visitQuestion(1);
 
       cy.findByTestId("question-table-badges").trigger("mouseenter");
 

--- a/frontend/test/metabase/scenarios/question/saved.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/saved.cy.spec.js
@@ -4,6 +4,7 @@ import {
   modal,
   openOrdersTable,
   summarize,
+  visitQuestion,
 } from "__support__/e2e/cypress";
 
 describe("scenarios > question > saved", () => {
@@ -64,7 +65,7 @@ describe("scenarios > question > saved", () => {
   });
 
   it("view and filter saved question", () => {
-    cy.visit("/question/1");
+    visitQuestion(1);
     cy.findAllByText("Orders"); // question and table name appears
 
     // filter to only orders with quantity=100
@@ -98,7 +99,7 @@ describe("scenarios > question > saved", () => {
     cy.route("POST", "/api/card").as("cardCreate");
     cy.route("POST", "/api/card/1/query").as("query");
 
-    cy.visit("/question/1");
+    visitQuestion(1);
     cy.wait("@query");
 
     cy.findByTestId("saved-question-header-button").click();
@@ -114,7 +115,7 @@ describe("scenarios > question > saved", () => {
   it("should revert a saved question to a previous version", () => {
     cy.intercept("PUT", "/api/card/**").as("updateQuestion");
 
-    cy.visit("/question/1");
+    visitQuestion(1);
     cy.findByTestId("saved-question-header-button").click();
     cy.findByText("History").click();
 
@@ -158,7 +159,7 @@ describe("scenarios > question > saved", () => {
   });
 
   it("should show table name in header with a table info popover on hover", () => {
-    cy.visit("/question/1");
+    visitQuestion(1);
     cy.findByTestId("question-table-badges").trigger("mouseenter");
     cy.findByText("9 columns");
   });

--- a/frontend/test/metabase/scenarios/question/summarization.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/summarization.cy.spec.js
@@ -4,6 +4,7 @@ import {
   getDimensionByName,
   getRemoveDimensionButton,
   summarize,
+  visitQuestion,
 } from "__support__/e2e/cypress";
 
 describe("scenarios > question > summarize sidebar", () => {
@@ -13,7 +14,7 @@ describe("scenarios > question > summarize sidebar", () => {
 
     cy.intercept("POST", "/api/dataset").as("dataset");
 
-    cy.visit("/question/1");
+    visitQuestion(1);
     summarize();
   });
 

--- a/frontend/test/metabase/scenarios/question/timelines.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/timelines.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore } from "__support__/e2e/cypress";
+import { restore, visitQuestion } from "__support__/e2e/cypress";
 
 describe("scenarios > collections > timelines", () => {
   beforeEach(() => {
@@ -11,7 +11,7 @@ describe("scenarios > collections > timelines", () => {
     });
 
     it("should create the first event and timeline", () => {
-      cy.visit("/question/3");
+      visitQuestion(3);
       cy.findByLabelText("calendar icon").click();
       cy.button("Add an event").click();
 
@@ -29,7 +29,7 @@ describe("scenarios > collections > timelines", () => {
         events: [{ name: "RC1", timestamp: "2018-10-20T00:00:00Z" }],
       });
 
-      cy.visit("/question/3");
+      visitQuestion(3);
       cy.findByLabelText("calendar icon").click();
       cy.button("Add an event").click();
 
@@ -48,7 +48,7 @@ describe("scenarios > collections > timelines", () => {
         events: [{ name: "RC1", timestamp: "2018-10-20T00:00:00Z" }],
       });
 
-      cy.visit("/question/3");
+      visitQuestion(3);
       cy.findByLabelText("calendar icon").click();
       cy.findByText("Releases");
       cy.findByLabelText("ellipsis icon").click();
@@ -69,7 +69,7 @@ describe("scenarios > collections > timelines", () => {
         events: [{ name: "RC1", timestamp: "2018-10-20T00:00:00Z" }],
       });
 
-      cy.visit("/question/3");
+      visitQuestion(3);
       cy.findByLabelText("calendar icon").click();
       cy.findByText("Releases");
       cy.findByLabelText("ellipsis icon").click();
@@ -84,7 +84,7 @@ describe("scenarios > collections > timelines", () => {
   describe("as readonly user", () => {
     it("should not allow creating default timelines", () => {
       cy.signIn("readonly");
-      cy.visit("/question/3");
+      visitQuestion(3);
 
       cy.findByLabelText("calendar icon").click();
       cy.findByText(/Events in Metabase/);
@@ -99,7 +99,7 @@ describe("scenarios > collections > timelines", () => {
       });
       cy.signOut();
       cy.signIn("readonly");
-      cy.visit("/question/3");
+      visitQuestion(3);
 
       cy.findByLabelText("calendar icon").click();
       cy.findByText("Releases");

--- a/frontend/test/metabase/scenarios/question/view.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/view.cy.spec.js
@@ -3,6 +3,7 @@ import {
   openOrdersTable,
   popover,
   filter,
+  visitQuestion,
 } from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
@@ -87,7 +88,7 @@ describe("scenarios > question > view", () => {
     });
 
     it("should show filters by search for Vendor", () => {
-      cy.visit("/question/4");
+      visitQuestion(4);
 
       cy.findAllByText("VENDOR")
         .first()
@@ -100,7 +101,7 @@ describe("scenarios > question > view", () => {
 
     it("should be able to filter Q by Category as no data user (from Q link) (metabase#12654)", () => {
       cy.signIn("nodata");
-      cy.visit("/question/4");
+      visitQuestion(4);
 
       // Filter by category and vendor
       // TODO: this should show values and allow searching

--- a/frontend/test/metabase/scenarios/sharing/approved-domains.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/approved-domains.cy.spec.js
@@ -4,6 +4,7 @@ import {
   restore,
   setupSMTP,
   sidebar,
+  visitQuestion,
 } from "__support__/e2e/cypress";
 
 const allowedDomain = "metabase.test";
@@ -22,7 +23,7 @@ describeEE("scenarios > sharing > approved domains (EE)", () => {
   });
 
   it("should validate approved email domains for a question alert", () => {
-    cy.visit("/question/1");
+    visitQuestion(1);
 
     cy.icon("bell").click();
     cy.findByText("Set up an alert").click();
@@ -36,7 +37,7 @@ describeEE("scenarios > sharing > approved domains (EE)", () => {
   });
 
   it("should validate approved email domains for a question alert in the audit app", () => {
-    cy.visit("/question/1");
+    visitQuestion(1);
     cy.icon("bell").click();
     cy.findByText("Set up an alert").click();
     cy.button("Done").click();

--- a/frontend/test/metabase/scenarios/smoketest/admin_setup.cy.spec.js
+++ b/frontend/test/metabase/scenarios/smoketest/admin_setup.cy.spec.js
@@ -6,6 +6,7 @@ import {
   openPeopleTable,
   visualize,
   openNotebookEditor,
+  visitQuestion,
 } from "__support__/e2e/cypress";
 import { USERS } from "__support__/e2e/cypress_data";
 
@@ -846,7 +847,7 @@ describe("smoketest > admin_setup", () => {
 
       cy.signOut();
       cy.signInAsNormalUser();
-      cy.visit("/question/1");
+      visitQuestion(1);
 
       // cy.findByText("Product ID");
       // cy.findByText("Quantity").should("not.exist");
@@ -934,7 +935,7 @@ describe("smoketest > admin_setup", () => {
       // This test will fail whenever the previous test fails
       cy.signIn("nocollection");
 
-      cy.visit("/question/4");
+      visitQuestion(4);
       cy.contains("sub-collection question").should("not.exist");
       cy.findByText("Sorry, you don’t have permission to see that.");
     });


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Tries to reduce the number of flakes by applying `visitQuestion` helper (it automatically waits for the results to load before moving to the next step)
- A lot of the recent flakes (after the Cypress upgrade) seem to occur due to the Cypress failing to wait until question (query) results fully load. This step should help with it.