### PR TITLE
Change event icon sizes in chart

### DIFF
--- a/frontend/src/metabase/visualizations/components/LineAreaBarChart.css
+++ b/frontend/src/metabase/visualizations/components/LineAreaBarChart.css
@@ -251,6 +251,7 @@ text.value-label-white {
 
 .dc-chart .events-axis .event-tick {
   cursor: pointer;
+  pointer-events: all;
 }
 
 .dc-chart .events-axis .event-tick .event-icon {

--- a/frontend/src/metabase/visualizations/lib/timelines.js
+++ b/frontend/src/metabase/visualizations/lib/timelines.js
@@ -4,10 +4,14 @@ import { ICON_PATHS } from "metabase/icon_paths";
 import { stretchTimeseriesDomain } from "./apply_axis";
 import timeseriesScale from "./timeseriesScale";
 
-const EVENT_ICON_OFFSET_X = -16;
-const EVENT_ICON_MARGIN_TOP = 10;
-const EVENT_GROUP_COUNT_MARGIN_LEFT = 10;
-const EVENT_GROUP_COUNT_MARGIN_TOP = EVENT_ICON_MARGIN_TOP + 8;
+const ICON_SCALE = 0.45;
+const ICON_LARGE_SCALE = 0.35;
+const ICON_SIZE = 16;
+const ICON_X = -ICON_SIZE;
+const ICON_Y = 10;
+const TEXT_X = 10;
+const TEXT_Y = ICON_Y + 8;
+const RECT_SIZE = 32;
 
 function getEventGroups(events, xInterval) {
   return _.groupBy(events, event =>
@@ -89,7 +93,7 @@ function renderEventTicks(
     const iconPath = ICON_PATHS[iconName].path
       ? ICON_PATHS[iconName].path
       : ICON_PATHS[iconName];
-    const iconScale = iconName === "mail" ? 0.4 : 0.45;
+    const iconScale = iconName === "mail" ? ICON_LARGE_SCALE : ICON_SCALE;
 
     const eventLine = brush
       .append("line")
@@ -111,19 +115,20 @@ function renderEventTicks(
       .attr("class", "event-icon")
       .attr("d", iconPath)
       .attr("aria-label", `${iconName} icon`)
-      .attr(
-        "transform",
-        `scale(${iconScale}) translate(${EVENT_ICON_OFFSET_X},${EVENT_ICON_MARGIN_TOP})`,
-      );
+      .attr("transform", `scale(${iconScale}) translate(${ICON_X},${ICON_Y})`);
+
+    eventTick
+      .append("rect")
+      .attr("fill", "none")
+      .attr("width", RECT_SIZE)
+      .attr("height", RECT_SIZE)
+      .attr("transform", `scale(${iconScale}) translate(${ICON_X}, ${ICON_Y})`);
 
     if (!isOnlyOneEvent) {
       eventTick
         .append("text")
         .text(group.length)
-        .attr(
-          "transform",
-          `translate(${EVENT_GROUP_COUNT_MARGIN_LEFT},${EVENT_GROUP_COUNT_MARGIN_TOP})`,
-        );
+        .attr("transform", `translate(${TEXT_X},${TEXT_Y})`);
     }
 
     eventTick

--- a/frontend/src/metabase/visualizations/lib/timelines.js
+++ b/frontend/src/metabase/visualizations/lib/timelines.js
@@ -89,7 +89,7 @@ function renderEventTicks(
     const iconPath = ICON_PATHS[iconName].path
       ? ICON_PATHS[iconName].path
       : ICON_PATHS[iconName];
-    const iconScale = iconName === "mail" ? 0.45 : 0.5;
+    const iconScale = iconName === "mail" ? 0.4 : 0.45;
 
     const eventLine = brush
       .append("line")


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/20289

Changes:
- Makes event icons smaller
- Adds an invisible rectangle to increase the clickable area of the icons

How to test:
- Open a timeseries question and create several events within the question's time range
- Make sure that icons remain clickable

<img width="967" alt="Screenshot 2022-03-21 at 16 27 04" src="https://user-images.githubusercontent.com/8542534/159270553-2fa2ae21-3048-425f-9efc-fdd90248b39d.png">
