### PR TITLE
Attempt to fix SummarizeSidebar flakiness

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/AggregationItem/AggregationItem.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/AggregationItem/AggregationItem.jsx
@@ -14,9 +14,10 @@ const propTypes = {
   aggregation: PropTypes.object,
   index: PropTypes.number.isRequired,
   query: PropTypes.object,
+  onRemove: PropTypes.func,
 };
 
-export const AggregationItem = ({ aggregation, index, query }) => {
+export const AggregationItem = ({ aggregation, index, query, onRemove }) => {
   return (
     <PopoverWithTrigger
       triggerClasses="flex-full"
@@ -32,6 +33,9 @@ export const AggregationItem = ({ aggregation, index, query }) => {
               name="close"
               onClick={() => {
                 updateAndRunQuery(query.removeAggregation(index));
+                if (typeof onRemove === "function") {
+                  onRemove(aggregation, index);
+                }
               }}
             />
           )}

--- a/frontend/test/metabase/scenarios/question/nulls.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nulls.cy.spec.js
@@ -192,7 +192,7 @@ describe("scenarios > question > null", () => {
       summarize();
       // remove pre-selected "Count"
       cy.icon("close").click();
-      // dropdown immediately opens with the new set of metrics to choose from
+      cy.findByText("Add a metric").click();
       popover().within(() => {
         cy.findByText("Cumulative sum of ...").click();
         cy.findByText("Discount").click();


### PR DESCRIPTION
This PR is an attempt to fix flakiness at some E2E tests using the QB summarization sidebar. @nemanjaglumac has explained a problem [in this slack message](https://metaboat.slack.com/archives/C505ZNNH4/p1647516994125529).

Sometimes when Cypress was opening a summarization sidebar, it would show a default view with a list of dimensions and then almost immediately reset to an empty state when only the "Add a metric" button is displayed. We haven't found a good way to reproduce it locally, so our guess is that it's some race condition that can pop up in a busy Circle CI environment.

My theory is that it's caused by the way we set the default "count" aggregation to a query once a sidebar is open. I believe it's some sort of a shortcut since "count" is the most widely used aggregation out there. So there is a code taking the `query` and adding the "count" aggregation to it. It had to happen only when a question is in a clean state. Once the question was changed, we had to stop appending the default aggregation. It was done with an internal `isModified` state. My guess is that because Cypress is fast, it was opening a sidebar in a moment when the question wasn't fully available in the redux state. So the sidebar was mounting, handling the question change a few times, losing the default aggregation, and getting into a blank state.

This PR refactors the way the sidebar appends the default "count" aggregation. Now it will stop appending it only after a user has explicitly removed the aggregation. So now the aggregation should be kept even during the loading process.

### To Verify

There is no way (that we know) to reproduce the flakiness thing, but I'd appreciate if you play around with the summarization sidebar to ensure it works as expected