### PR TITLE
Change from failure to warning on backport error

### DIFF
--- a/.github/workflows/auto-backport.yml
+++ b/.github/workflows/auto-backport.yml
@@ -134,3 +134,4 @@ jobs:
               repo: context.repo.repo,
               body: `@${{ needs.pr_info.outputs.author }} could not automatically create a backport PR 😩 [[Logs]](${runUrl})`
             })
+            core.notice('Backport Failed for some reason. Please, check it.')

--- a/.github/workflows/auto-backport.yml
+++ b/.github/workflows/auto-backport.yml
@@ -125,6 +125,7 @@ jobs:
       - uses: actions/github-script@v4
         with:
           script: |
+            const core = require('@actions/core');
             const { GITHUB_SERVER_URL, GITHUB_REPOSITORY, GITHUB_RUN_ID } = process.env;
             const runUrl = `${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}`
 

--- a/.github/workflows/auto-backport.yml
+++ b/.github/workflows/auto-backport.yml
@@ -134,4 +134,4 @@ jobs:
               repo: context.repo.repo,
               body: `@${{ needs.pr_info.outputs.author }} could not automatically create a backport PR 😩 [[Logs]](${runUrl})`
             })
-            core.notice('Backport Failed for some reason. Please, check it.')
+            core.warning('Backport Failed for some reason. Please, check it.')

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -119,6 +119,7 @@ jobs:
       - uses: actions/github-script@v4
         with:
           script: |
+            const core = require('@actions/core');
             const { GITHUB_SERVER_URL, GITHUB_REPOSITORY, GITHUB_RUN_ID} = process.env;
             const runUrl = `${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}`
             const author = context.payload.comment.user.login;
@@ -129,3 +130,4 @@ jobs:
               repo: context.repo.repo,
               body: `@${author} could not automatically a backport PR 😩 [[Logs]](${runUrl})`
             })
+            core.warning('Backport Failed for some reason. Please, check it.')


### PR DESCRIPTION
### Problem

Sometimes we have the pipeline failing due to an error on the backport, which actually is not an issue with the code at all.

<img width="429" alt="Screen Shot 2022-03-21 at 13 52 59" src="https://user-images.githubusercontent.com/17742979/159316483-762aba3f-da43-4f0d-9e54-6fb62aa5e19f.png">


We already warned the PR owner that the backport was not able, so that person can manually do it so.

<img width="1022" alt="Screen Shot 2022-03-21 at 13 53 21" src="https://user-images.githubusercontent.com/17742979/159316851-f6742057-788c-40fe-b125-3e6a1ba9f33d.png">

### Solution

Now we are explicating warning instead of failing the build using [core.warning].  (https://www.npmjs.com/package/@actions/core)