### PR TITLE
Repro  #21135: CC with the same names as the existing columns causes confusion in the expression editor

### DIFF
--- a/frontend/test/metabase/scenarios/custom-column/reproductions/21135-cc-same-name-as-existing-column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/custom-column/reproductions/21135-cc-same-name-as-existing-column.cy.spec.js
@@ -34,6 +34,11 @@ describe.skip("issue 21135", () => {
     // to narrow the results to the preview area to avoid false positive result.
     cy.get("[class*=PreviewRoot]").within(() => {
       cy.findByText("Rustic Paper Wallet");
+
+      cy.findAllByText("Price").should("have.length", 2);
+
+      cy.findByText("29.46"); // actual Price column
+      cy.findByText("31.46"); // custom column
     });
   });
 });

--- a/frontend/test/metabase/scenarios/custom-column/reproductions/21135-cc-same-name-as-existing-column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/custom-column/reproductions/21135-cc-same-name-as-existing-column.cy.spec.js
@@ -1,0 +1,56 @@
+import { restore } from "__support__/e2e/cypress";
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+
+const { PRODUCTS_ID, PRODUCTS } = SAMPLE_DATABASE;
+
+const questionDetails = {
+  name: "21135",
+  query: {
+    "source-table": PRODUCTS_ID,
+    limit: 5,
+    expressions: { Price: ["+", ["field", PRODUCTS.PRICE, null], 2] },
+  },
+};
+
+describe.skip("issue 21135", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    cy.createQuestion(questionDetails, { visitQuestion: true });
+
+    switchToNotebookView();
+  });
+
+  it("should handle cc with the same name as the table column (metabase#21135)", () => {
+    cy.findAllByTestId("notebook-cell-item")
+      .contains("Price")
+      .click();
+    cy.button("Update").click();
+
+    previewCustomColumnNotebookStep();
+
+    // We should probably use data-testid or some better selector but it is crucial
+    // to narrow the results to the preview area to avoid false positive result.
+    cy.get("[class*=PreviewRoot]").within(() => {
+      cy.findByText("Rustic Paper Wallet");
+    });
+  });
+});
+
+function switchToNotebookView() {
+  cy.intercept("GET", "/api/database/1/schema/PUBLIC").as("publicSchema");
+
+  cy.icon("notebook").click();
+  cy.wait("@publicSchema");
+}
+
+function previewCustomColumnNotebookStep() {
+  cy.intercept("POST", "/api/dataset").as("dataset");
+
+  cy.findByTestId("step-expression-0-0")
+    .find(".Icon-play")
+    .click();
+
+  cy.wait("@dataset");
+}


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #21135

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/custom-column/reproductions/21135-cc-same-name-as-existing-column.cy.spec.js`
- Unskip repro
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
<img width="1679" alt="image" src="https://user-images.githubusercontent.com/31325167/159335322-6b5ff4dd-538a-4209-a8b7-9746788cc246.png">
