### PR TITLE
Make event icons responsible

### DIFF
--- a/frontend/src/metabase/entities/timeline-events/forms.js
+++ b/frontend/src/metabase/entities/timeline-events/forms.js
@@ -29,7 +29,6 @@ const createForm = ({ timelines }) => {
       name: "icon",
       title: t`Icon`,
       type: "select",
-      initial: "star",
       options: getTimelineIcons(),
       validate: validate.required(),
     },
@@ -40,7 +39,6 @@ const createForm = ({ timelines }) => {
     {
       name: "time_matters",
       type: "hidden",
-      initial: false,
     },
     {
       name: "timeline_id",

--- a/frontend/src/metabase/entities/timelines/forms.js
+++ b/frontend/src/metabase/entities/timelines/forms.js
@@ -21,7 +21,6 @@ const createForm = () => {
       name: "icon",
       title: t`Default icon`,
       type: "select",
-      initial: "star",
       options: getTimelineIcons(),
       validate: validate.required(),
     },

--- a/frontend/src/metabase/timelines/collections/components/NewTimelineModal/NewTimelineModal.tsx
+++ b/frontend/src/metabase/timelines/collections/components/NewTimelineModal/NewTimelineModal.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useMemo } from "react";
 import { t } from "ttag";
 import Form from "metabase/containers/Form";
 import forms from "metabase/entities/timelines/forms";
+import { getDefaultTimelineIcon } from "metabase/lib/timelines";
 import { canonicalCollectionId } from "metabase/collections/utils";
 import ModalHeader from "metabase/timelines/common/components/ModalHeader";
 import { Collection, Timeline } from "metabase-types/api";
@@ -21,7 +22,10 @@ const NewTimelineModal = ({
   onClose,
 }: NewTimelineModalProps): JSX.Element => {
   const initialValues = useMemo(() => {
-    return { collection_id: canonicalCollectionId(collection.id) };
+    return {
+      collection_id: canonicalCollectionId(collection.id),
+      icon: getDefaultTimelineIcon(),
+    };
   }, [collection]);
 
   const handleSubmit = useCallback(

--- a/frontend/src/metabase/visualizations/components/LineAreaBarChart.css
+++ b/frontend/src/metabase/visualizations/components/LineAreaBarChart.css
@@ -251,6 +251,7 @@ text.value-label-white {
 
 .dc-chart .events-axis .event-tick {
   cursor: pointer;
+  pointer-events: all;
 }
 
 .dc-chart .events-axis .event-tick .event-icon {

--- a/frontend/src/metabase/visualizations/components/LineAreaBarChart.css
+++ b/frontend/src/metabase/visualizations/components/LineAreaBarChart.css
@@ -249,26 +249,26 @@ text.value-label-white {
 
 /* timeline events */
 
-.dc-chart .events-axis .event-tick {
+.dc-chart .event-axis .event-tick {
   cursor: pointer;
   pointer-events: all;
 }
 
-.dc-chart .events-axis .event-tick .event-icon {
+.dc-chart .event-axis .event-icon {
   stroke: var(--color-text-light);
   fill: var(--color-text-light);
 }
 
-.dc-chart .events-axis .event-tick.hover .event-icon {
+.dc-chart .event-axis .event-text {
+  fill: var(--color-text-light);
+}
+
+.dc-chart .event-axis .event-tick.hover .event-icon {
   stroke: var(--color-brand);
   fill: var(--color-brand);
 }
 
-.dc-chart .events-axis .event-tick text {
-  fill: var(--color-text-light);
-}
-
-.dc-chart .events-axis .event-tick.hover text {
+.dc-chart .event-axis .event-tick.hover .event-text {
   fill: var(--color-brand);
 }
 

--- a/frontend/src/metabase/visualizations/components/LineAreaBarChart.css
+++ b/frontend/src/metabase/visualizations/components/LineAreaBarChart.css
@@ -249,36 +249,36 @@ text.value-label-white {
 
 /* timeline events */
 
-.dc-chart .event-axis .event-tick {
+.LineAreaBarChart .dc-chart .event-axis .event-tick {
   cursor: pointer;
   pointer-events: all;
 }
 
-.dc-chart .event-axis .event-icon {
+.LineAreaBarChart .dc-chart .event-axis .event-icon {
   stroke: var(--color-text-light);
   fill: var(--color-text-light);
 }
 
-.dc-chart .event-axis .event-text {
+.LineAreaBarChart .dc-chart .event-axis .event-text {
   fill: var(--color-text-light);
 }
 
-.dc-chart .event-axis .event-tick.hover .event-icon {
+.LineAreaBarChart .dc-chart .event-axis .event-tick.hover .event-icon {
   stroke: var(--color-brand);
   fill: var(--color-brand);
 }
 
-.dc-chart .event-axis .event-tick.hover .event-text {
+.LineAreaBarChart .dc-chart .event-axis .event-tick.hover .event-text {
   fill: var(--color-brand);
 }
 
-.dc-chart .event-line {
+.LineAreaBarChart .dc-chart .event-line {
   stroke: var(--color-brand);
   stroke-width: 2;
   opacity: 0.2;
   pointer-events: none;
 }
 
-.dc-chart .event-line.hover {
+.LineAreaBarChart .dc-chart .event-line.hover {
   opacity: 1;
 }

--- a/frontend/src/metabase/visualizations/components/LineAreaBarChart.css
+++ b/frontend/src/metabase/visualizations/components/LineAreaBarChart.css
@@ -255,8 +255,9 @@ text.value-label-white {
 }
 
 .LineAreaBarChart .dc-chart .event-axis .event-icon {
-  stroke: var(--color-text-light);
   fill: var(--color-text-light);
+  stroke: var(--color-text-light);
+  shape-rendering: geometricPrecision;
 }
 
 .LineAreaBarChart .dc-chart .event-axis .event-text {
@@ -264,8 +265,8 @@ text.value-label-white {
 }
 
 .LineAreaBarChart .dc-chart .event-axis .event-tick.hover .event-icon {
-  stroke: var(--color-brand);
   fill: var(--color-brand);
+  stroke: var(--color-brand);
 }
 
 .LineAreaBarChart .dc-chart .event-axis .event-tick.hover .event-text {

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
@@ -403,7 +403,7 @@ function onRenderAddTimelineEvents(
   },
 ) {
   renderEvents(chart, {
-    timelineEvents,
+    events: timelineEvents,
     selectedTimelineEventIds,
     xDomain,
     xInterval,

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
@@ -404,7 +404,7 @@ function onRenderAddTimelineEvents(
 ) {
   renderEvents(chart, {
     events: timelineEvents,
-    selectedTimelineEventIds,
+    selectedEventIds: selectedTimelineEventIds,
     xDomain,
     xInterval,
     isTimeseries,

--- a/frontend/src/metabase/visualizations/lib/timelines.js
+++ b/frontend/src/metabase/visualizations/lib/timelines.js
@@ -92,6 +92,7 @@ function hasEventText(events, eventIndex, eventScale, eventDates) {
 }
 
 function renderEventLines({
+  chart,
   brush,
   eventScale,
   eventDates,
@@ -99,7 +100,7 @@ function renderEventLines({
   selectedEventIds,
 }) {
   const eventLines = brush.selectAll(".event-line").data(eventGroups);
-  const brushHeight = brush.select(".background").attr("height");
+  const brushHeight = chart.effectiveWidth();
   eventLines.exit().remove();
 
   eventLines
@@ -220,6 +221,7 @@ export function renderEvents(
 
   if (brush) {
     renderEventLines({
+      chart,
       brush,
       eventScale,
       eventDates,

--- a/frontend/src/metabase/visualizations/lib/timelines.js
+++ b/frontend/src/metabase/visualizations/lib/timelines.js
@@ -13,7 +13,7 @@ const ICON_DISTANCE = ICON_SIZE;
 const TEXT_X = 10;
 const TEXT_Y = 16;
 const TEXT_DISTANCE = ICON_SIZE * 1.75;
-const RECT_SIZE = ICON_SIZE;
+const RECT_SIZE = ICON_SIZE * 2;
 
 function getXAxis(chart) {
   return chart.svg().select(".axis.x");

--- a/frontend/src/metabase/visualizations/lib/timelines.js
+++ b/frontend/src/metabase/visualizations/lib/timelines.js
@@ -4,10 +4,14 @@ import { ICON_PATHS } from "metabase/icon_paths";
 import { stretchTimeseriesDomain } from "./apply_axis";
 import timeseriesScale from "./timeseriesScale";
 
-const EVENT_ICON_OFFSET_X = -16;
-const EVENT_ICON_MARGIN_TOP = 10;
-const EVENT_GROUP_COUNT_MARGIN_LEFT = 10;
-const EVENT_GROUP_COUNT_MARGIN_TOP = EVENT_ICON_MARGIN_TOP + 8;
+const ICON_SCALE = 0.45;
+const ICON_LARGE_SCALE = 0.35;
+const ICON_SIZE = 16;
+const ICON_X = -ICON_SIZE;
+const ICON_Y = 10;
+const TEXT_X = 10;
+const TEXT_Y = ICON_Y + 8;
+const RECT_SIZE = 32;
 
 function getEventGroups(events, xInterval) {
   return _.groupBy(events, event =>
@@ -89,7 +93,7 @@ function renderEventTicks(
     const iconPath = ICON_PATHS[iconName].path
       ? ICON_PATHS[iconName].path
       : ICON_PATHS[iconName];
-    const iconScale = iconName === "mail" ? 0.4 : 0.45;
+    const iconScale = iconName === "mail" ? ICON_LARGE_SCALE : ICON_SCALE;
 
     const eventLine = brush
       .append("line")
@@ -111,19 +115,20 @@ function renderEventTicks(
       .attr("class", "event-icon")
       .attr("d", iconPath)
       .attr("aria-label", `${iconName} icon`)
-      .attr(
-        "transform",
-        `scale(${iconScale}) translate(${EVENT_ICON_OFFSET_X},${EVENT_ICON_MARGIN_TOP})`,
-      );
+      .attr("transform", `scale(${iconScale}) translate(${ICON_X},${ICON_Y})`);
+
+    eventTick
+      .append("rect")
+      .attr("fill", "none")
+      .attr("width", RECT_SIZE)
+      .attr("height", RECT_SIZE)
+      .attr("transform", `scale(${iconScale}) translate(${ICON_X}, ${ICON_Y})`);
 
     if (!isOnlyOneEvent) {
       eventTick
         .append("text")
         .text(group.length)
-        .attr(
-          "transform",
-          `translate(${EVENT_GROUP_COUNT_MARGIN_LEFT},${EVENT_GROUP_COUNT_MARGIN_TOP})`,
-        );
+        .attr("transform", `translate(${TEXT_X},${TEXT_Y})`);
     }
 
     eventTick

--- a/frontend/src/metabase/visualizations/lib/timelines.js
+++ b/frontend/src/metabase/visualizations/lib/timelines.js
@@ -211,6 +211,6 @@ export function renderEvents(
   }
 }
 
-export function hasEventAxis({ timelineEvents = [], xDomain, isTimeseries }) {
+export function hasEventAxis({ timelineEvents = [], isTimeseries }) {
   return isTimeseries && timelineEvents.length > 0;
 }

--- a/frontend/src/metabase/visualizations/lib/timelines.js
+++ b/frontend/src/metabase/visualizations/lib/timelines.js
@@ -1,19 +1,25 @@
-import d3 from "d3";
 import _ from "underscore";
-import { ICON_PATHS } from "metabase/icon_paths";
 import { stretchTimeseriesDomain } from "./apply_axis";
 import timeseriesScale from "./timeseriesScale";
 
-const ICON_SCALE = 0.45;
-const ICON_LARGE_SCALE = 0.35;
-const ICON_SIZE = 16;
-const ICON_X = -ICON_SIZE;
-const ICON_Y = 10;
-const TEXT_X = 10;
-const TEXT_Y = ICON_Y + 8;
-const RECT_SIZE = 32;
+function getXAxis(chart) {
+  return chart.svg().select(".axis.x");
+}
 
-function getEventGroups(events, xInterval) {
+function getBrush(chart) {
+  return chart.svg().select(".brush");
+}
+
+function getEventScale(axis, xDomain, xInterval) {
+  const axisNode = axis.select("path.domain").node();
+  const axisBounds = axisNode.getBoundingClientRect();
+
+  return timeseriesScale(xInterval)
+    .domain(stretchTimeseriesDomain(xDomain, xInterval))
+    .range([0, axisBounds.width]);
+}
+
+function getEventMapping(events, xInterval) {
   return _.groupBy(events, event =>
     event.timestamp
       .clone()
@@ -22,172 +28,37 @@ function getEventGroups(events, xInterval) {
   );
 }
 
-function getEventTicks(eventGroups) {
-  return Object.keys(eventGroups).map(value => new Date(parseInt(value)));
+function getEventKeys(eventMapping) {
+  return Object.keys(eventMapping).map(value => new Date(parseInt(value)));
 }
 
-function getTranslateFromStyle(value) {
-  const style = value.replace("translate(", "").replace(")", "");
-  const [x, y] = style.split(",");
-  return [parseFloat(x), parseFloat(y)];
-}
-
-function getXAxis(chart) {
-  return chart.svg().select(".axis.x");
-}
-
-function getEventAxis(xAxis, xDomain, xInterval, eventTicks) {
-  const xAxisDomainLine = xAxis.select("path.domain").node();
-  const { width: axisWidth } = xAxisDomainLine.getBoundingClientRect();
-  xAxis.selectAll("event-axis").remove();
-
-  const scale = timeseriesScale(xInterval)
-    .domain(stretchTimeseriesDomain(xDomain, xInterval))
-    .range([0, axisWidth]);
-
-  const eventsAxisGenerator = d3.svg
-    .axis()
-    .scale(scale)
-    .orient("bottom")
-    .ticks(eventTicks.length)
-    .tickValues(eventTicks);
-
-  const eventsAxis = xAxis
-    .append("g")
-    .attr("class", "events-axis")
-    .call(eventsAxisGenerator);
-
-  eventsAxis.select("path.domain").remove();
-  return eventsAxis;
-}
-
-function renderEventTicks(
-  chart,
-  {
-    eventAxis,
-    eventGroups,
-    selectedEventIds,
-    onHoverChange,
-    onOpenTimelines,
-    onSelectTimelineEvents,
-    onDeselectTimelineEvents,
-  },
-) {
-  const svg = chart.svg();
-  const brush = svg.select("g.brush");
+function renderEventLines({ brush, eventScale, eventKeys }) {
+  const eventLines = brush.selectAll(".event-line").data(eventKeys);
   const brushHeight = brush.select("rect.background").attr("height");
 
-  svg.selectAll(".event-tick").remove();
-  svg.selectAll(".event-line").remove();
+  eventLines
+    .enter()
+    .append("line")
+    .attr("class", "event-line")
+    .attr("x1", d => eventScale(d))
+    .attr("x2", d => eventScale(d))
+    .attr("y1", 0)
+    .attr("y2", brushHeight);
 
-  Object.values(eventGroups).forEach(group => {
-    const defaultTick = eventAxis.select(".tick");
-    const transformStyle = defaultTick.attr("transform");
-    const [tickX] = getTranslateFromStyle(transformStyle);
-    defaultTick.remove();
-
-    const isSelected = group.some(event => selectedEventIds.includes(event.id));
-    const isOnlyOneEvent = group.length === 1;
-    const iconName = isOnlyOneEvent ? group[0].icon : "star";
-
-    const iconPath = ICON_PATHS[iconName].path
-      ? ICON_PATHS[iconName].path
-      : ICON_PATHS[iconName];
-    const iconScale = iconName === "mail" ? ICON_LARGE_SCALE : ICON_SCALE;
-
-    const eventLine = brush
-      .append("line")
-      .attr("class", "event-line")
-      .classed("hover", isSelected)
-      .attr("x1", tickX)
-      .attr("x2", tickX)
-      .attr("y1", "0")
-      .attr("y2", brushHeight);
-
-    const eventTick = eventAxis
-      .append("g")
-      .attr("class", "event-tick")
-      .classed("hover", isSelected)
-      .attr("transform", transformStyle);
-
-    const eventIcon = eventTick
-      .append("path")
-      .attr("class", "event-icon")
-      .attr("d", iconPath)
-      .attr("aria-label", `${iconName} icon`)
-      .attr("transform", `scale(${iconScale}) translate(${ICON_X},${ICON_Y})`);
-
-    eventTick
-      .append("rect")
-      .attr("fill", "none")
-      .attr("width", RECT_SIZE)
-      .attr("height", RECT_SIZE)
-      .attr("transform", `scale(${iconScale}) translate(${ICON_X}, ${ICON_Y})`);
-
-    if (!isOnlyOneEvent) {
-      eventTick
-        .append("text")
-        .text(group.length)
-        .attr("transform", `translate(${TEXT_X},${TEXT_Y})`);
-    }
-
-    eventTick
-      .on("mousemove", () => {
-        onHoverChange({
-          element: eventIcon.node(),
-          timelineEvents: group,
-        });
-        eventTick.classed("hover", true);
-        eventLine.classed("hover", true);
-      })
-      .on("mouseleave", () => {
-        onHoverChange(null);
-        eventTick.classed("hover", isSelected);
-        eventLine.classed("hover", isSelected);
-      })
-      .on("click", () => {
-        onOpenTimelines();
-        if (isSelected) {
-          onDeselectTimelineEvents(group);
-        } else {
-          onSelectTimelineEvents(group);
-        }
-      });
-  });
+  eventLines.exit().remove();
 }
 
-export function renderEvents(
-  chart,
-  {
-    timelineEvents = [],
-    selectedTimelineEventIds = [],
-    xDomain,
-    xInterval,
-    isTimeseries,
-    onHoverChange,
-    onOpenTimelines,
-    onSelectTimelineEvents,
-    onDeselectTimelineEvents,
-  },
-) {
-  const xAxis = getXAxis(chart);
-  if (!xAxis || !isTimeseries || !timelineEvents.length) {
-    return;
+export function renderEvents(chart, { events = [], xDomain, xInterval }) {
+  const axis = getXAxis(chart);
+  const brush = getBrush(chart);
+
+  const eventScale = getEventScale(axis, xDomain, xInterval);
+  const eventMapping = getEventMapping(events, xInterval);
+  const eventKeys = getEventKeys(eventMapping);
+
+  if (brush) {
+    renderEventLines({ brush, eventScale, eventKeys });
   }
-
-  const eventGroups = getEventGroups(timelineEvents, xInterval);
-  const eventTicks = getEventTicks(eventGroups);
-
-  const eventAxis = getEventAxis(xAxis, xDomain, xInterval, eventTicks);
-  renderEventTicks(chart, {
-    eventAxis,
-    eventGroups,
-    selectedEventIds: selectedTimelineEventIds,
-    onHoverChange,
-    onOpenTimelines,
-    onSelectTimelineEvents,
-    onDeselectTimelineEvents,
-  });
 }
 
 export function hasEventAxis({ timelineEvents = [], xDomain, isTimeseries }) {

--- a/frontend/src/metabase/visualizations/lib/timelines.js
+++ b/frontend/src/metabase/visualizations/lib/timelines.js
@@ -86,6 +86,7 @@ function renderEventLines({
 
 function renderEventAxis({
   axis,
+  brush,
   eventScale,
   eventDates,
   eventGroups,
@@ -96,6 +97,7 @@ function renderEventAxis({
   onDeselectTimelineEvents,
 }) {
   const eventAxis = axis.selectAll(".event-axis").data([eventGroups]);
+  const eventLines = brush.selectAll(".event-line").data(eventGroups);
   eventAxis.exit().remove();
 
   eventAxis
@@ -134,15 +136,24 @@ function renderEventAxis({
     .text(d => d.length);
 
   eventTicks
-    .on("mousemove", d => {
+    .on("mousemove", function(d) {
       const eventTick = d3.select(this);
-      const eventIcon = eventTick.select(".event-icon");
+      const eventIcon = eventTicks.filter(data => d === data);
+      const eventLine = eventLines.filter(data => d === data);
+
       onHoverChange({ element: eventIcon.node(), timelineEvents: d });
+      eventTick.classed("hover", true);
+      eventLine.classed("hover", true);
     })
-    .on("mouseleave", () => {
+    .on("mouseleave", function(d) {
+      const eventTick = d3.select(this);
+      const eventLine = eventLines.filter(data => d === data);
+
       onHoverChange(null);
+      eventTick.classed("hover", false);
+      eventLine.classed("hover", false);
     })
-    .on("click", d => {
+    .on("click", function(d) {
       onOpenTimelines();
 
       if (isSelected(d, selectedEventIds)) {
@@ -187,6 +198,7 @@ export function renderEvents(
   if (axis) {
     renderEventAxis({
       axis,
+      brush,
       eventScale,
       eventDates,
       eventGroups,

--- a/frontend/src/metabase/visualizations/lib/timelines.js
+++ b/frontend/src/metabase/visualizations/lib/timelines.js
@@ -71,6 +71,10 @@ function getIconTransform(icon) {
   return `scale(${scale}) translate(${ICON_X}, ${ICON_Y})`;
 }
 
+function getIconLabel(icon) {
+  return `${icon} icon`;
+}
+
 function isEventWithin(eventIndex, eventScale, eventDates, eventDistance) {
   const thisDate = eventDates[eventIndex];
   const prevDate = eventDates[eventIndex - 1];
@@ -156,6 +160,9 @@ function renderEventTicks({
     )
     .attr("transform", (d, i) =>
       getIconTransform(getIcon(d, i, eventScale, eventDates)),
+    )
+    .attr("aria-label", (d, i) =>
+      getIconLabel(getIcon(d, i, eventScale, eventDates)),
     );
 
   eventTicks

--- a/frontend/src/metabase/visualizations/lib/timelines.js
+++ b/frontend/src/metabase/visualizations/lib/timelines.js
@@ -9,8 +9,10 @@ const ICON_SCALE = 0.45;
 const ICON_LARGE_SCALE = 0.35;
 const ICON_X = -ICON_SIZE;
 const ICON_Y = 10;
+const ICON_DISTANCE = ICON_SIZE;
 const TEXT_X = 10;
-const TEXT_Y = ICON_Y + 8;
+const TEXT_Y = 16;
+const TEXT_DISTANCE = ICON_SIZE * 1.75;
 const RECT_SIZE = ICON_SIZE;
 
 function getXAxis(chart) {
@@ -49,7 +51,7 @@ function isSelected(events, selectedEventIds) {
 }
 
 function getIcon(events, eventIndex, eventScale, eventDates) {
-  if (isIconNarrow(eventIndex, eventScale, eventDates)) {
+  if (isEventNarrow(eventIndex, eventScale, eventDates)) {
     return "unknown";
   } else {
     return events.length === 1 ? events[0].icon : "star";
@@ -67,14 +69,26 @@ function getIconTransform(events, eventIndex, eventScale, eventDates) {
   return `scale(${scale}) translate(${ICON_X}, ${ICON_Y})`;
 }
 
-function isIconNarrow(eventIndex, eventScale, eventDates) {
+function isEventWithin(eventIndex, eventScale, eventDates, eventDistance) {
   const thisDate = eventDates[eventIndex];
   const prevDate = eventDates[eventIndex - 1];
   const nextDate = eventDates[eventIndex + 1];
-  const prevDiff = prevDate && eventScale(thisDate) - eventScale(prevDate);
-  const nextDiff = nextDate && eventScale(nextDate) - eventScale(thisDate);
+  const prevDistance = prevDate && eventScale(thisDate) - eventScale(prevDate);
+  const nextDistance = nextDate && eventScale(nextDate) - eventScale(thisDate);
 
-  return prevDiff < ICON_SIZE || nextDiff < ICON_SIZE;
+  return prevDistance < eventDistance || nextDistance < eventDistance;
+}
+
+function isEventNarrow(eventIndex, eventScale, eventDates) {
+  return isEventWithin(eventIndex, eventScale, eventDates, ICON_DISTANCE);
+}
+
+function hasEventText(events, eventIndex, eventScale, eventDates) {
+  if (events.length > 1) {
+    return !isEventWithin(eventIndex, eventScale, eventDates, TEXT_DISTANCE);
+  } else {
+    return false;
+  }
 }
 
 function renderEventLines({
@@ -148,7 +162,7 @@ function renderEventTicks({
     );
 
   eventTicks
-    .filter(d => d.length > 1)
+    .filter((d, i) => hasEventText(d, i, eventScale, eventDates))
     .append("text")
     .attr("class", "event-text")
     .attr("transform", `translate(${TEXT_X},${TEXT_Y})`)

--- a/frontend/src/metabase/visualizations/lib/timelines.js
+++ b/frontend/src/metabase/visualizations/lib/timelines.js
@@ -49,6 +49,7 @@ function renderEventLines({
 }) {
   const eventLines = brush.selectAll(".event-line").data(eventGroups);
   const brushHeight = brush.select(".background").attr("height");
+  eventLines.exit().remove();
 
   eventLines
     .enter()
@@ -59,8 +60,24 @@ function renderEventLines({
     .attr("x2", (d, i) => eventScale(eventDates[i]))
     .attr("y1", "0")
     .attr("y2", brushHeight);
+}
 
-  eventLines.exit().remove();
+function renderEventTicks({
+  axis,
+  eventScale,
+  eventDates,
+  eventGroups,
+  selectedEventIds,
+}) {
+  const eventTicks = axis.selectAll(".event-tick").data(eventGroups);
+  eventTicks.exit().remove();
+
+  eventTicks
+    .enter()
+    .append("g")
+    .attr("class", "event-tick")
+    .classed("selected", d => isSelected(d, selectedEventIds))
+    .attr("transform", (d, i) => `translate(${eventScale(eventDates[i])}, 0)`);
 }
 
 export function renderEvents(
@@ -74,6 +91,16 @@ export function renderEvents(
   const eventMapping = getEventMapping(events, xInterval);
   const eventDates = getEventDates(eventMapping);
   const eventGroups = getEventGroups(eventMapping);
+
+  if (axis) {
+    renderEventTicks({
+      axis,
+      eventScale,
+      eventDates,
+      eventGroups,
+      selectedEventIds,
+    });
+  }
 
   if (brush) {
     renderEventLines({

--- a/frontend/src/metabase/visualizations/lib/timelines.js
+++ b/frontend/src/metabase/visualizations/lib/timelines.js
@@ -84,7 +84,7 @@ function renderEventLines({
     .attr("y2", brushHeight);
 }
 
-function renderEventAxis({
+function renderEventTicks({
   axis,
   brush,
   eventScale,
@@ -196,7 +196,7 @@ export function renderEvents(
   }
 
   if (axis) {
-    renderEventAxis({
+    renderEventTicks({
       axis,
       brush,
       eventScale,

--- a/frontend/src/metabase/visualizations/lib/timelines.js
+++ b/frontend/src/metabase/visualizations/lib/timelines.js
@@ -11,7 +11,7 @@ function getBrush(chart) {
 }
 
 function getEventScale(axis, xDomain, xInterval) {
-  const axisNode = axis.select("path.domain").node();
+  const axisNode = axis.select(".domain").node();
   const axisBounds = axisNode.getBoundingClientRect();
 
   return timeseriesScale(xInterval)
@@ -28,36 +28,61 @@ function getEventMapping(events, xInterval) {
   );
 }
 
-function getEventKeys(eventMapping) {
+function getEventDates(eventMapping) {
   return Object.keys(eventMapping).map(value => new Date(parseInt(value)));
 }
 
-function renderEventLines({ brush, eventScale, eventKeys }) {
-  const eventLines = brush.selectAll(".event-line").data(eventKeys);
-  const brushHeight = brush.select("rect.background").attr("height");
+function getEventGroups(eventMapping) {
+  return Object.values(eventMapping);
+}
+
+function isSelected(events, selectedEventIds) {
+  return events.some(event => selectedEventIds.includes(event.id));
+}
+
+function renderEventLines({
+  brush,
+  eventScale,
+  eventDates,
+  eventGroups,
+  selectedEventIds,
+}) {
+  const eventLines = brush.selectAll(".event-line").data(eventGroups);
+  const brushHeight = brush.select(".background").attr("height");
 
   eventLines
     .enter()
     .append("line")
     .attr("class", "event-line")
-    .attr("x1", d => eventScale(d))
-    .attr("x2", d => eventScale(d))
-    .attr("y1", 0)
+    .classed("selected", d => isSelected(d, selectedEventIds))
+    .attr("x1", (d, i) => eventScale(eventDates[i]))
+    .attr("x2", (d, i) => eventScale(eventDates[i]))
+    .attr("y1", "0")
     .attr("y2", brushHeight);
 
   eventLines.exit().remove();
 }
 
-export function renderEvents(chart, { events = [], xDomain, xInterval }) {
+export function renderEvents(
+  chart,
+  { events = [], selectedEventIds, xDomain, xInterval },
+) {
   const axis = getXAxis(chart);
   const brush = getBrush(chart);
 
   const eventScale = getEventScale(axis, xDomain, xInterval);
   const eventMapping = getEventMapping(events, xInterval);
-  const eventKeys = getEventKeys(eventMapping);
+  const eventDates = getEventDates(eventMapping);
+  const eventGroups = getEventGroups(eventMapping);
 
   if (brush) {
-    renderEventLines({ brush, eventScale, eventKeys });
+    renderEventLines({
+      brush,
+      eventScale,
+      eventDates,
+      eventGroups,
+      selectedEventIds,
+    });
   }
 }
 

--- a/frontend/src/metabase/visualizations/lib/timelines.js
+++ b/frontend/src/metabase/visualizations/lib/timelines.js
@@ -100,7 +100,7 @@ function renderEventLines({
   selectedEventIds,
 }) {
   const eventLines = brush.selectAll(".event-line").data(eventGroups);
-  const brushHeight = chart.effectiveWidth();
+  const brushHeight = chart.effectiveHeight();
   eventLines.exit().remove();
 
   eventLines

--- a/frontend/src/metabase/visualizations/lib/timelines.js
+++ b/frontend/src/metabase/visualizations/lib/timelines.js
@@ -89,7 +89,7 @@ function renderEventTicks(
     const iconPath = ICON_PATHS[iconName].path
       ? ICON_PATHS[iconName].path
       : ICON_PATHS[iconName];
-    const iconScale = iconName === "mail" ? 0.45 : 0.5;
+    const iconScale = iconName === "mail" ? 0.4 : 0.45;
 
     const eventLine = brush
       .append("line")

--- a/frontend/src/metabase/visualizations/lib/timelines.js
+++ b/frontend/src/metabase/visualizations/lib/timelines.js
@@ -58,13 +58,15 @@ function getIcon(events, eventIndex, eventScale, eventDates) {
   }
 }
 
-function getIconPath(events, eventIndex, eventScale, eventDates) {
-  const icon = getIcon(events, eventIndex, eventScale, eventDates);
-  return ICON_PATHS[icon].path ? ICON_PATHS[icon].path : ICON_PATHS[icon];
+function getIconPath(icon) {
+  return ICON_PATHS[icon].path ?? ICON_PATHS[icon];
 }
 
-function getIconTransform(events, eventIndex, eventScale, eventDates) {
-  const icon = getIcon(events, eventIndex, eventScale, eventDates);
+function getIconFillRule(icon) {
+  return ICON_PATHS[icon].attrs?.fillRule;
+}
+
+function getIconTransform(icon) {
   const scale = icon === "mail" ? ICON_LARGE_SCALE : ICON_SCALE;
   return `scale(${scale}) translate(${ICON_X}, ${ICON_Y})`;
 }
@@ -148,9 +150,12 @@ function renderEventTicks({
   eventTicks
     .append("path")
     .attr("class", "event-icon")
-    .attr("d", (d, i) => getIconPath(d, i, eventScale, eventDates))
+    .attr("d", (d, i) => getIconPath(getIcon(d, i, eventScale, eventDates)))
+    .attr("fill-rule", (d, i) =>
+      getIconFillRule(getIcon(d, i, eventScale, eventDates)),
+    )
     .attr("transform", (d, i) =>
-      getIconTransform(d, i, eventScale, eventDates),
+      getIconTransform(getIcon(d, i, eventScale, eventDates)),
     );
 
   eventTicks
@@ -159,7 +164,7 @@ function renderEventTicks({
     .attr("width", RECT_SIZE)
     .attr("height", RECT_SIZE)
     .attr("transform", (d, i) =>
-      getIconTransform(d, i, eventScale, eventDates),
+      getIconTransform(getIcon(d, i, eventScale, eventDates)),
     );
 
   eventTicks
@@ -203,8 +208,8 @@ export function renderEvents(
   {
     events = [],
     selectedEventIds = [],
-    xDomain,
-    xInterval,
+    xDomain = [],
+    xInterval = {},
     onHoverChange,
     onOpenTimelines,
     onSelectTimelineEvents,
@@ -213,7 +218,6 @@ export function renderEvents(
 ) {
   const axis = getXAxis(chart);
   const brush = getBrush(chart);
-
   const eventScale = getEventScale(chart, xDomain, xInterval);
   const eventMapping = getEventMapping(events, xInterval);
   const eventDates = getEventDates(eventMapping);

--- a/frontend/src/metabase/visualizations/lib/timelines.js
+++ b/frontend/src/metabase/visualizations/lib/timelines.js
@@ -1,4 +1,5 @@
 import _ from "underscore";
+import { ICON_PATHS } from "metabase/icon_paths";
 import { stretchTimeseriesDomain } from "./apply_axis";
 import timeseriesScale from "./timeseriesScale";
 
@@ -10,13 +11,10 @@ function getBrush(chart) {
   return chart.svg().select(".brush");
 }
 
-function getEventScale(axis, xDomain, xInterval) {
-  const axisNode = axis.select(".domain").node();
-  const axisBounds = axisNode.getBoundingClientRect();
-
+function getEventScale(chart, xDomain, xInterval) {
   return timeseriesScale(xInterval)
     .domain(stretchTimeseriesDomain(xDomain, xInterval))
-    .range([0, axisBounds.width]);
+    .range([0, chart.effectiveWidth()]);
 }
 
 function getEventMapping(events, xInterval) {
@@ -38,6 +36,15 @@ function getEventGroups(eventMapping) {
 
 function isSelected(events, selectedEventIds) {
   return events.some(event => selectedEventIds.includes(event.id));
+}
+
+function getIcon(events) {
+  return events.length === 1 ? events[0].icon : "star";
+}
+
+function getIconPath(events) {
+  const icon = getIcon(events);
+  return ICON_PATHS[icon].path ? ICON_PATHS[icon].path : ICON_PATHS[icon];
 }
 
 function renderEventLines({
@@ -78,6 +85,12 @@ function renderEventTicks({
     .attr("class", "event-tick")
     .classed("selected", d => isSelected(d, selectedEventIds))
     .attr("transform", (d, i) => `translate(${eventScale(eventDates[i])}, 0)`);
+
+  eventTicks
+    .append("path")
+    .attr("class", "event-icon")
+    .attr("d", d => getIconPath(d))
+    .attr("transform", "scale(0.5) translate(-16, 10)");
 }
 
 export function renderEvents(
@@ -87,7 +100,7 @@ export function renderEvents(
   const axis = getXAxis(chart);
   const brush = getBrush(chart);
 
-  const eventScale = getEventScale(axis, xDomain, xInterval);
+  const eventScale = getEventScale(chart, xDomain, xInterval);
   const eventMapping = getEventMapping(events, xInterval);
   const eventDates = getEventDates(eventMapping);
   const eventGroups = getEventGroups(eventMapping);

--- a/frontend/src/metabase/visualizations/lib/timelines.js
+++ b/frontend/src/metabase/visualizations/lib/timelines.js
@@ -183,8 +183,8 @@ function renderEventTicks({
       const eventLine = eventLines.filter(data => d === data);
 
       onHoverChange(null);
-      eventTick.classed("hover", false);
-      eventLine.classed("hover", false);
+      eventTick.classed("hover", isSelected(d, selectedEventIds));
+      eventLine.classed("hover", isSelected(d, selectedEventIds));
     })
     .on("click", function(d) {
       onOpenTimelines();

--- a/frontend/src/metabase/visualizations/lib/timelines.js
+++ b/frontend/src/metabase/visualizations/lib/timelines.js
@@ -7,6 +7,8 @@ const ICON_SCALE = 0.45;
 const ICON_LARGE_SCALE = 0.35;
 const ICON_X = -16;
 const ICON_Y = 10;
+const TEXT_X = 10;
+const TEXT_Y = ICON_Y + 8;
 const RECT_SIZE = 32;
 
 function getXAxis(chart) {
@@ -118,6 +120,13 @@ function renderEventAxis({
     .attr("width", RECT_SIZE)
     .attr("height", RECT_SIZE)
     .attr("transform", d => getIconTransform(d));
+
+  eventTicks
+    .filter(d => d.length > 1)
+    .append("text")
+    .attr("class", "event-text")
+    .attr("transform", `translate(${TEXT_X},${TEXT_Y})`)
+    .text(d => d.length);
 }
 
 export function renderEvents(


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/20289

Changes:
- Refactors events rendering to idiomatic d3 code
- Removes event count where there is no space
- Changes event icons to dots when there is no space

How to test:
- Change a timeseries question and several events close to each other
- Resize the browser window

<img width="893" alt="Screenshot 2022-03-21 at 22 38 48" src="https://user-images.githubusercontent.com/8542534/159351201-251bbc9b-6cd9-4573-a2bb-878bd9229b32.png">
<img width="782" alt="Screenshot 2022-03-21 at 22 39 01" src="https://user-images.githubusercontent.com/8542534/159351226-f62a1e53-d016-427d-8f0b-ce3ba416a4cb.png">
<img width="597" alt="Screenshot 2022-03-21 at 22 39 20" src="https://user-images.githubusercontent.com/8542534/159351232-0250930e-ddd8-4332-b568-94a419d53899.png">
<img width="501" alt="Screenshot 2022-03-21 at 22 39 32" src="https://user-images.githubusercontent.com/8542534/159351239-2c1a6fe7-3e6a-447e-b717-c7f46f6c5427.png">
<img width="499" alt="Screenshot 2022-03-21 at 22 39 49" src="https://user-images.githubusercontent.com/8542534/159351249-ec58753a-f8bb-495e-a7e0-b95295cb3bfe.png">
