### PR TITLE
Bookmark display and authority keys

### DIFF
--- a/src/metabase/models/bookmark.clj
+++ b/src/metabase/models/bookmark.clj
@@ -26,6 +26,7 @@
    :type                         (s/enum :card :collection :dashboard)
    :item_id                      su/IntGreaterThanZero
    :name                         su/NonBlankString
+   (s/optional-key :display)     (s/maybe s/Str)
    (s/optional-key :description) (s/maybe s/Str)})
 
 (s/defn ^:private normalize-bookmark-result :- BookmarkResult
@@ -47,7 +48,7 @@
     (merge
      {:id      (str (name ttype) "-" item-id-str)
       :type    ttype}
-     (select-keys normalized-result [:item_id :name :description]))))
+     (select-keys normalized-result [:item_id :name :description :display]))))
 
 (defn- bookmarks-union-query
   [id]
@@ -82,6 +83,7 @@
         {:select    [[:bookmark.created_at :created_at]
                      [:card.id (db/qualify 'Card :item_id)]
                      [:card.name (db/qualify 'Card :name)]
+                     [:card.display (db/qualify 'Card :display)]
                      [:card.description (db/qualify 'Card :description)]
                      [:card.archived (db/qualify 'Card :archived)]
                      [:dashboard.id (db/qualify 'Dashboard :item_id)]

--- a/src/metabase/models/bookmark.clj
+++ b/src/metabase/models/bookmark.clj
@@ -22,12 +22,13 @@
   "Shape of a bookmark returned for user. Id is a string because it is a concatenation of the model and the model's
   id. This is required for the frontend entity loading system and does not refer to any particular bookmark id,
   although the compound key can be inferred from it."
-  {:id                           s/Str
-   :type                         (s/enum :card :collection :dashboard)
-   :item_id                      su/IntGreaterThanZero
-   :name                         su/NonBlankString
-   (s/optional-key :display)     (s/maybe s/Str)
-   (s/optional-key :description) (s/maybe s/Str)})
+  {:id                               s/Str
+   :type                             (s/enum :card :collection :dashboard)
+   :item_id                          su/IntGreaterThanZero
+   :name                             su/NonBlankString
+   (s/optional-key :display)         (s/maybe s/Str)
+   (s/optional-key :authority_level) (s/maybe s/Str)
+   (s/optional-key :description)     (s/maybe s/Str)})
 
 (s/defn ^:private normalize-bookmark-result :- BookmarkResult
   "Normalizes bookmark results. Bookmarks are left joined against the card, collection, and dashboard tables, but only
@@ -48,7 +49,7 @@
     (merge
      {:id      (str (name ttype) "-" item-id-str)
       :type    ttype}
-     (select-keys normalized-result [:item_id :name :description :display]))))
+     (select-keys normalized-result [:item_id :name :description :display :authority_level]))))
 
 (defn- bookmarks-union-query
   [id]
@@ -92,6 +93,7 @@
                      [:dashboard.archived (db/qualify 'Dashboard :archived)]
                      [:collection.id (db/qualify 'Collection :item_id)]
                      [:collection.name (db/qualify 'Collection :name)]
+                     [:collection.authority_level (db/qualify 'Collection :authority_level)]
                      [:collection.description (db/qualify 'Collection :description)]
                      [:collection.archived (db/qualify 'Collection :archived)]]
          :from      [[(bookmarks-union-query id) :bookmark]]

--- a/test/metabase/api/bookmark_test.clj
+++ b/test/metabase/api/bookmark_test.clj
@@ -11,7 +11,7 @@
 (deftest bookmarks-test
   (testing "POST /api/bookmark/:model/:model-id"
     (mt/with-temp* [Collection [collection {:name "Test Collection"}]
-                    Card       [card {:name "Test Card"}]
+                    Card       [card {:name "Test Card" :display "area"}]
                     Dashboard  [dashboard {:name "Test Dashboard"}]]
       (testing "check that we can bookmark a Collection"
         (is (= (u/the-id collection)
@@ -21,6 +21,12 @@
         (is (= (u/the-id card)
                (->> (mt/user-http-request :rasta :post 200 (str "bookmark/card/" (u/the-id card)))
                     :card_id))))
+      (testing "check a card bookmark has `:display` key"
+        (is (= "area"
+               (->> (mt/user-http-request :rasta :get 200 "bookmark")
+                    (filter #(= (:type % ) "card"))
+                    first
+                    :display))))
       (testing "check that we can bookmark a Dashboard"
         (is (= (u/the-id dashboard)
                (->> (mt/user-http-request :rasta :post 200 (str "bookmark/dashboard/" (u/the-id dashboard)))


### PR DESCRIPTION
Bookmark results will now show a 'display' key when the bookmark is of a saved card.
Bookmark results will now show an 'authority_level' key when the bookmark is of an Official Collection.

Both of these changes can be used to discern which icons should be used to display the bookmarks on the Frontend.


This does not change the db in any way, it just pulls additional data from the left-join in the query already.

NOTE: supersedes #21042 which I goofed up and abandoned.