### PR TITLE
parse canonical collection id when saving question

### DIFF
--- a/frontend/src/metabase/containers/SaveQuestionModal.jsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal.jsx
@@ -1,19 +1,16 @@
 /* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-
 import { CSSTransitionGroup } from "react-transition-group";
+import { t } from "ttag";
 
 import Form, { FormField, FormFooter } from "metabase/containers/Form";
 import ModalContent from "metabase/components/ModalContent";
 import Radio from "metabase/core/components/Radio";
-
 import * as Q_DEPRECATED from "metabase/lib/query";
 import { generateQueryDescription } from "metabase/lib/query/description";
-
 import validate from "metabase/lib/validate";
-
-import { t } from "ttag";
+import { canonicalCollectionId } from "metabase/collections/utils";
 
 import "./SaveQuestionModal.css";
 
@@ -47,6 +44,12 @@ export default class SaveQuestionModal extends Component {
     //     .setCollectionId(details.collection_id)
     let { card, originalCard, onCreate, onSave } = this.props;
 
+    const collection_id = canonicalCollectionId(
+      details.saveType === "overwrite"
+        ? originalCard.collection_id
+        : details.collection_id,
+    );
+
     card = {
       ...card,
       name:
@@ -60,10 +63,7 @@ export default class SaveQuestionModal extends Component {
           : details.description
           ? details.description.trim()
           : null,
-      collection_id:
-        details.saveType === "overwrite"
-          ? originalCard.collection_id
-          : details.collection_id,
+      collection_id,
     };
 
     if (details.saveType === "create") {

--- a/frontend/test/metabase/containers/SaveQuestionModal.unit.spec.js
+++ b/frontend/test/metabase/containers/SaveQuestionModal.unit.spec.js
@@ -196,7 +196,7 @@ describe("SaveQuestionModal", () => {
         ...question.card(),
         name: EXPECTED_SUGGESTED_NAME,
         description: null,
-        collection_id: undefined,
+        collection_id: null,
       });
     });
 
@@ -212,7 +212,7 @@ describe("SaveQuestionModal", () => {
         ...question.card(),
         name: "My favorite orders",
         description: "So many of them",
-        collection_id: undefined,
+        collection_id: null,
       });
     });
 
@@ -231,7 +231,25 @@ describe("SaveQuestionModal", () => {
         ...question.card(),
         name: "My favorite orders",
         description: "So many of them",
-        collection_id: undefined,
+        collection_id: null,
+      });
+    });
+
+    it('should correctly handle saving a question in the "root" collection', () => {
+      const question = getQuestion({
+        collection_id: "root",
+      });
+      const { onCreateMock } = renderSaveQuestionModal(question);
+
+      fillForm({ name: "foo", description: "bar" });
+      userEvent.click(screen.getByText("Save"));
+
+      expect(onCreateMock).toHaveBeenCalledTimes(1);
+      expect(onCreateMock).toHaveBeenCalledWith({
+        ...question.card(),
+        name: "foo",
+        description: "bar",
+        collection_id: null,
       });
     });
 


### PR DESCRIPTION
Fixes #21055 

If you look at the `CreateDashboardModal` you will see that it uses `Collection.selectors.getInitialCollectionId` which internally parses the correct collection ID using `canonicalCollectionId`. The `SaveQuestionModal` doesn't use this, and it isn't connected to redux, so I'm adding use of `canonicalCollectionId` directly in the `handleSubmit` of `SaveQuestionModal`.

**Testing**
From `/collection/root` click the + button and go through the flow to create and save a new question
The POST request to save the question shouldn't error

https://user-images.githubusercontent.com/13057258/159368541-d5728115-f2b3-486b-b60c-0e40754b7852.mov


