### PR TITLE
remove explicit z-index on DateOperatorSelector

### DIFF
--- a/frontend/src/metabase/query_builder/components/filters/DateOperatorSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/DateOperatorSelector.jsx
@@ -2,7 +2,6 @@
 import React, { Component } from "react";
 
 import _ from "underscore";
-import cx from "classnames";
 
 import Select, { Option } from "metabase/core/components/Select";
 
@@ -11,7 +10,7 @@ export default class DateOperatorSelector extends Component {
     const { className, operator, operators, onOperatorChange } = this.props;
 
     return (
-      <div className={cx(className, "relative z3")} style={{ minWidth: 100 }}>
+      <div className={className} style={{ minWidth: 100 }}>
         <Select
           value={_.findWhere(operators, { name: operator })}
           onChange={e => onOperatorChange(e.target.value)}


### PR DESCRIPTION
## Before

- opening a date filter in the sidebar, then switching to the notebook editor would persist the DateOperatorSelector Dropdown above the notebook editor
![issue](https://user-images.githubusercontent.com/30528226/159368348-7d17903a-cb38-4bc7-bcca-0c7ab4a1937d.gif)


## Changes
- remove "relative" and "z3" classes from the component, that appear to be leftover from a prior version of the component that had absolutely positioned children.

## After

- The DateOperatorSelector Dropdown is properly hidden when opening the notebook, resolving #18079

https://user-images.githubusercontent.com/30528226/159368367-25847b4f-d5d4-4df2-8f54-da7f4cfbbc6b.mp4


- various other uses of the component don't suffer regressions
![Screenshot from 2022-03-21 15-15-56](https://user-images.githubusercontent.com/30528226/159368401-bd67be9d-6bb6-4a78-81cc-74cd275d6c37.png)
![Screenshot from 2022-03-21 15-44-59](https://user-images.githubusercontent.com/30528226/159368778-3405b509-4116-45a3-adde-2143aa85ef5a.png)

