### PR TITLE
Models E2E tests: ensure query and table view before assertions

### DIFF
--- a/frontend/test/metabase/scenarios/models/models-metadata.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models-metadata.cy.spec.js
@@ -16,6 +16,7 @@ describe("scenarios > models metadata", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
+    cy.intercept("POST", "/api/card/*/query").as("cardQuery");
   });
 
   it("should edit GUI model metadata", () => {
@@ -42,7 +43,10 @@ describe("scenarios > models metadata", () => {
     );
 
     cy.findByText("Customize metadata").click();
+
+    cy.wait(["@cardQuery", "@cardQuery"]);
     cy.url().should("include", "/metadata");
+    cy.findByTextEnsureVisible("Product ID");
 
     openColumnOptions("Subtotal");
 
@@ -83,7 +87,10 @@ describe("scenarios > models metadata", () => {
     );
 
     cy.findByText("Customize metadata").click();
+
+    cy.wait(["@cardQuery", "@cardQuery"]);
     cy.url().should("include", "/metadata");
+    cy.findByTextEnsureVisible("PRODUCT_ID");
 
     openColumnOptions("SUBTOTAL");
 
@@ -112,6 +119,8 @@ describe("scenarios > models metadata", () => {
       },
     }).then(({ body: { id: nativeModelId } }) => {
       cy.visit(`/model/${nativeModelId}/metadata`);
+      cy.wait("@cardQuery");
+      cy.findByTextEnsureVisible("PRODUCT_ID");
     });
 
     openColumnOptions("SUBTOTAL");
@@ -124,6 +133,9 @@ describe("scenarios > models metadata", () => {
     cy.findByText("Tax ($)").should("not.exist");
     openDetailsSidebar();
     cy.findByText("Customize metadata").click();
+
+    cy.wait(["@cardQuery", "@cardQuery"]);
+    cy.findByTextEnsureVisible("TAX");
 
     // Revision 2
     openColumnOptions("TAX");


### PR DESCRIPTION
### Before this PR

Running `frontend/test/metabase/scenarios/models/models-metadata.cy.spec.js` could lead to this failure:

![scenarios  models metadata -- should allow reverting to a specific metadata revision (failed)](https://user-images.githubusercontent.com/7288/159449300-d32ef833-5d06-4c57-adda-d1a6c566feb0.png)

### After this PR

With the solution of guarding some assertions with the proper query, likely the failure will cease to cause problems.