### PR TITLE
Use option's icon in case it exists for selected items

### DIFF
--- a/frontend/src/metabase/core/components/Select/Select.jsx
+++ b/frontend/src/metabase/core/components/Select/Select.jsx
@@ -148,16 +148,6 @@ export default class Select extends Component {
   };
 
   renderItemIcon = item => {
-    if (this.itemIsSelected(item)) {
-      return (
-        <Icon
-          name="check"
-          size={14}
-          color={color("text-dark")}
-          style={{ minWidth: MIN_ICON_WIDTH }}
-        />
-      );
-    }
     const icon = this.props.optionIconFn(item);
     if (icon) {
       return (
@@ -169,6 +159,18 @@ export default class Select extends Component {
         />
       );
     }
+
+    if (this.itemIsSelected(item)) {
+      return (
+        <Icon
+          name="check"
+          size={14}
+          color={color("text-dark")}
+          style={{ minWidth: MIN_ICON_WIDTH }}
+        />
+      );
+    }
+
     return <span style={{ minWidth: MIN_ICON_WIDTH }} />;
   };
 


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/20289

How to test:
- Open the edit modal for an existing timeline event
- Try to change its icon
- Make sure that the current icon remains visible, and it's not replaced by the check mark

<img width="666" alt="Screenshot 2022-03-22 at 13 35 41" src="https://user-images.githubusercontent.com/8542534/159463047-283dabb1-6306-4fbb-8f88-154611860a9d.png">
