### PR TITLE
Events BE fixes - Hydrate :collection on timelines and default icon "star"

### DIFF
--- a/src/metabase/api/timeline.clj
+++ b/src/metabase/api/timeline.clj
@@ -34,7 +34,7 @@
    archived (s/maybe su/BooleanString)}
   (let [archived? (Boolean/parseBoolean archived)
         timelines (db/select Timeline [:where [:= :archived archived?]])]
-    (cond->> (hydrate timelines :creator)
+    (cond->> (hydrate timelines :creator :collection)
       (= include "events")
       (map #(timeline-event/include-events-singular % {:events/all?  archived?})))))
 
@@ -48,7 +48,7 @@
    end      (s/maybe su/TemporalString)}
   (let [archived? (Boolean/parseBoolean archived)
         timeline  (api/read-check (Timeline id))]
-    (cond-> (hydrate timeline :creator)
+    (cond-> (hydrate timeline :creator :collection)
       (= include "events")
       (timeline-event/include-events-singular {:events/all?  archived?
                                                :events/start (when start (u.date/parse start))

--- a/src/metabase/api/timeline_event.clj
+++ b/src/metabase/api/timeline_event.clj
@@ -30,12 +30,13 @@
                       {:status-code 404})))
     (collection/check-write-perms-for-collection (:collection_id timeline)))
   ;; todo: revision system
-  (let [parsed (if (nil? timestamp)
-                 (throw (ex-info (tru "Timestamp cannot be null") {:status-code 400}))
-                 (u.date/parse timestamp))]
-    (db/insert! TimelineEvent (assoc body
-                                     :creator_id api/*current-user-id*
-                                     :timestamp parsed))))
+  (let [parsed-timestamp (if (nil? timestamp)
+                           (throw (ex-info (tru "Timestamp cannot be null") {:status-code 400}))
+                           (u.date/parse timestamp))
+        evt              (merge body {:creator_id api/*current-user-id*
+                                      :timestamp  parsed-timestamp})]
+    (db/insert! TimelineEvent (cond-> evt
+                                (nil? icon) (assoc :icon "star")))))
 
 (api/defendpoint GET "/:id"
   "Fetch the [[TimelineEvent]] with `id`."

--- a/test/metabase/api/timeline_test.clj
+++ b/test/metabase/api/timeline_test.clj
@@ -34,7 +34,13 @@
                    (events-of (mt/user-http-request :rasta :get 200 "timeline")))))
           (testing "check that we only get archived timelines when `archived=true`"
             (is (= #{"Timeline C"}
-                   (events-of (mt/user-http-request :rasta :get 200 "timeline" :archived true))))))))))
+                   (events-of (mt/user-http-request :rasta :get 200 "timeline" :archived true)))))
+          (testing "check that `:collection` key is hydrated on each timeline"
+            (is (= #{id}
+                   (->> (mt/user-http-request :rasta :get 200 "timeline")
+                         (filter (comp #{id} :collection_id))
+                        (map #(get-in % [:collection :id]))
+                        set)))))))))
 
 (deftest get-timeline-test
   (testing "GET /api/timeline/:id"


### PR DESCRIPTION
Epic: #20289 
Addressing Backend Fixes for issues raised in [this Notion doc.](https://www.notion.so/metabase/9f1737a3a4d64005b904dfc900291545?v=3b2d1b2922734ad8bb0d347c4ca9ffcd)

### Fixes
- [x] Hydrate timelines with `:collection` for endpoints: `GET /api/timeline` and `GET /api/timeline/:id`
  - supersedes #21043 because can_write can be determined via the data within `"collection"`
  - also lets the frontend determine personal collections, which can be used to address concerns about personal collections cluttering the Events sidebar
- [x] Default icon value is "star" on timeline-event endpoints when used via API. Otherwise, the icon is handled by the Frontend