### PR TITLE
Fix the loading indicator on the dashboard sharing sidebar

### DIFF
--- a/frontend/src/metabase/sharing/components/SharingSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/SharingSidebar.jsx
@@ -10,6 +10,7 @@ import {
   AddEditSlackSidebar,
   AddEditEmailSidebar,
 } from "metabase/sharing/components/AddEditSidebar";
+import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 import Sidebar from "metabase/dashboard/components/Sidebar";
 import Pulses from "metabase/entities/pulses";
 import User from "metabase/entities/users";
@@ -106,6 +107,7 @@ const mapDispatchToProps = {
 
 @Pulses.loadList({
   query: (state, { dashboard }) => ({ dashboard_id: dashboard.id }),
+  loadingAndErrorWrapper: false,
 })
 @User.loadList({ loadingAndErrorWrapper: false })
 @connect(mapStateToProps, mapDispatchToProps)
@@ -133,6 +135,10 @@ class SharingSidebar extends React.Component {
     params: PropTypes.object,
   };
 
+  componentDidMount() {
+    this.props.fetchPulseFormInput();
+  }
+
   setPulse = pulse => {
     this.props.updateEditingPulse(pulse);
   };
@@ -153,10 +159,6 @@ class SharingSidebar extends React.Component {
       cards: nonTextCardsFromDashboard(dashboard),
     };
     this.setPulse(newPulse);
-  };
-
-  componentDidMount = async () => {
-    await this.props.fetchPulseFormInput();
   };
 
   onChannelPropertyChange = (index, name, value) => {
@@ -264,9 +266,14 @@ class SharingSidebar extends React.Component {
       dashboard,
     } = this.props;
 
-    // protect from empty values that will mess this up
-    if (!formInput.channels || !pulse) {
-      return <Sidebar />;
+    const isLoading = !pulses || !users || !pulse || !formInput?.channels;
+
+    if (isLoading) {
+      return (
+        <Sidebar>
+          <LoadingAndErrorWrapper loading />
+        </Sidebar>
+      );
     }
 
     if (editingMode === "list-pulses" && pulses.length > 0) {


### PR DESCRIPTION
Related to #18774 

The `SharingSidebar` component depends on a lot of state that we need to fetch in separate requests. Currently, we only show a loading indicator for one specific request, the request for pulses, and once that request is resolved the `SharingSidebar` shows a blank `Sidebar` component, which is pretty confusing and looks kind of broken when the other requests are slow, which, as this issue indicates, is something that can happen not infrequently.

I've kept the fix here fairly simple. I'm checking several more values in the `render` method to determine whether we are in a loading state, and I'm adding a `LoadingAndErrorWrapper` to the Sidebar component to keep the look consistent across all the different requests.

Before:

https://user-images.githubusercontent.com/13057258/159979616-d3281c6c-8994-474c-9a62-b4131d6419d2.mov

After:

https://user-images.githubusercontent.com/13057258/159979640-a08dd4d3-64ea-47e0-b3a1-0faf04f85ec2.mov


