### PR TITLE
Making sure directory is there to restore cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -936,6 +936,10 @@ jobs:
       MB_SNOWPLOW_AVAILABLE: << parameters.snowplow >>
     steps:
       - attach-workspace
+      - run:
+          command: |
+            mkdir -p /home/circleci/metabase/metabase/target/uberjar/
+            mkdir -p /home/circleci/metabase/metabase/resources/
       - run-on-change:
           checksum: '{{ checksum ".BACKEND-CHECKSUMS" }}-{{ checksum ".FRONTEND-CHECKSUMS" }}-{{ checksum ".E2E-TESTS-CHECKSUMS" }}'
           steps:


### PR DESCRIPTION
### Problem

For some reason, after latest CCI outage the Restore Cache was being unable to work with the following error:

<img width="1748" alt="Screen Shot 2022-03-23 at 09 14 09" src="https://user-images.githubusercontent.com/17742979/159696696-e71e707e-c1db-401c-9644-f3295a9061c0.png">

###Solution

Making sure directories exist before retrieving the cache did the trick.

<img width="1747" alt="Screen Shot 2022-03-23 at 09 15 01" src="https://user-images.githubusercontent.com/17742979/159696834-f081b08d-98f7-4f7d-a1bf-5d20ac999d5d.png">
<img width="1750" alt="Screen Shot 2022-03-23 at 09 15 36" src="https://user-images.githubusercontent.com/17742979/159696931-b75cc564-711e-4594-9d9c-54d885277665.png">

