### PR TITLE
Upgrade MySQL/MariaDB JDBC driver to version 2.7.5

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -117,7 +117,7 @@
   org.graalvm.js/js                         {:mvn/version "21.2.0"}           ; JavaScript engine
   org.liquibase/liquibase-core              {:mvn/version "3.6.3"               ; migration management (Java lib)
                                              :exclusions  [ch.qos.logback/logback-classic]}
-  org.mariadb.jdbc/mariadb-java-client      {:mvn/version "2.6.2"}              ; MySQL/MariaDB driver
+  org.mariadb.jdbc/mariadb-java-client      {:mvn/version "2.7.5"}              ; MySQL/MariaDB driver
   org.postgresql/postgresql                 {:mvn/version "42.2.23"}            ; Postgres driver
   org.slf4j/slf4j-api                       {:mvn/version "1.7.32"}             ; abstraction for logging frameworks -- allows end user to plug in desired logging framework at deployment time
   org.tcrawley/dynapath                     {:mvn/version "1.1.0"}              ; Dynamically add Jars (e.g. Oracle or Vertica) to classpath


### PR DESCRIPTION
As requested by @flamber, as this seems to fix few issues.

This is just a one-line subset of major backed dependencies update in PR #19827. 