### PR TITLE
[E2E] Expand embedding native tests

### DIFF
--- a/frontend/test/__support__/e2e/helpers/e2e-embedding-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-embedding-helpers.js
@@ -4,7 +4,12 @@ const jwtSignLocation =
   "frontend/test/__support__/e2e/external/e2e-jwt-sign.js";
 
 export function visitEmbeddedPage(payload) {
-  const stringifiedPayload = JSON.stringify(payload);
+  const payloadWithExpiration = {
+    ...payload,
+    exp: Math.round(Date.now() / 1000) + 10 * 60, // 10 minute expiration
+  };
+
+  const stringifiedPayload = JSON.stringify(payloadWithExpiration);
 
   cy.exec(
     `node  ${jwtSignLocation} '${stringifiedPayload}' ${METABASE_SECRET_KEY}`,

--- a/frontend/test/__support__/e2e/helpers/e2e-embedding-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-embedding-helpers.js
@@ -9,8 +9,14 @@ const jwtSignLocation =
  * @param {object} payload
  * @param {{setFilters: string, hideFilters:string}}
  *
- * @examlpe
- * visitEmbeddedPage(payload, { setFilters: "id=92&source=Organic", hideFilters: "created_at, state" });
+ * @example
+ * visitEmbeddedPage(payload, {
+ *   // We divide filter values with an ampersand
+ *   setFilters: "id=92&source=Organic",
+ *   // We divide multiple hidden filters with coma.
+ *   // Make sure there are no spaces in between!
+ *   hideFilters: "created_at,state"
+ * });
  */
 export function visitEmbeddedPage(
   payload,

--- a/frontend/test/__support__/e2e/helpers/e2e-embedding-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-embedding-helpers.js
@@ -11,9 +11,25 @@ export function visitEmbeddedPage(payload) {
 
   const stringifiedPayload = JSON.stringify(payloadWithExpiration);
 
+  const embeddableObject = getEmbeddableObject(payload);
+
+  const urlRoot = `/embed/${embeddableObject}/`;
+  // Style is hard coded for now because we're not concerned with testing its properties
+  const style = "#bordered=true&titled=true";
+
   cy.exec(
     `node  ${jwtSignLocation} '${stringifiedPayload}' ${METABASE_SECRET_KEY}`,
   ).then(({ stdout: token }) => {
-    cy.visit("/embed/question/" + token + "#bordered=true&titled=true");
+    cy.visit(urlRoot + token + style);
   });
+}
+
+/**
+ * Extract the embeddable object type from the payload
+ *
+ * @param {object} payload
+ * @returns ("question"|"dashboard")
+ */
+function getEmbeddableObject(payload) {
+  return Object.keys(payload.resource)[0];
 }

--- a/frontend/test/metabase/scenarios/embedding/embedding-native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/embedding-native.cy.spec.js
@@ -289,6 +289,41 @@ describe("scenarios > embedding > native questions", () => {
         cy.contains("35.7").should("not.exist");
       });
     });
+
+    it("should lock all parameters", () => {
+      cy.get("@questionId").then(questionId => {
+        cy.request("PUT", `/api/card/${questionId}`, {
+          enable_embedding: true,
+          embedding_params: {
+            id: "locked",
+            product_id: "locked",
+            state: "locked",
+            created_at: "locked",
+            total: "locked",
+            source: "locked",
+          },
+        });
+
+        const payload = {
+          resource: { question: questionId },
+          params: {
+            id: [92, 96, 102, 104],
+            product_id: [140],
+            state: ["AK", "TX"],
+            created_at: "Q3-2018",
+            total: [10],
+            source: ["Organic"],
+          },
+        };
+
+        visitEmbeddedPage(payload);
+
+        cy.findByTestId("table-row").should("have.length", 1);
+        cy.findByText("66.8");
+
+        filterWidget().should("not.exist");
+      });
+    });
   });
 });
 

--- a/frontend/test/metabase/scenarios/embedding/embedding-native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/embedding-native.cy.spec.js
@@ -1,7 +1,7 @@
 import { restore, popover, filterWidget } from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
-const { ORDERS, PEOPLE, PRODUCTS } = SAMPLE_DATABASE;
+const { ORDERS, PEOPLE } = SAMPLE_DATABASE;
 
 const query = `
 SELECT orders.id, orders.product_id, orders.created_at AS production_date, orders.total, people.state, people.name, people.source
@@ -84,13 +84,6 @@ describe("scenarios > embedding > native questions", () => {
 
     restore();
     cy.signInAsAdmin();
-
-    // Remap Product ID -> Product Title
-    cy.request("POST", `/api/field/${ORDERS.PRODUCT_ID}/dimension`, {
-      name: "Product ID as Title",
-      type: "external",
-      human_readable_field_id: PRODUCTS.TITLE,
-    });
 
     cy.createNativeQuestion(questionDetails, { visitQuestion: true });
 

--- a/frontend/test/metabase/scenarios/embedding/embedding-native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/embedding-native.cy.spec.js
@@ -79,8 +79,6 @@ const questionDetails = {
 
 describe("scenarios > embedding > native questions", () => {
   beforeEach(() => {
-    cy.intercept("PUT", "/api/card/*").as("publishChanges");
-
     restore();
     cy.signInAsAdmin();
 
@@ -90,8 +88,7 @@ describe("scenarios > embedding > native questions", () => {
   it("should not display disabled parameters", () => {
     enableSharing();
 
-    cy.button("Publish").click();
-    cy.wait(["@publishChanges", "@publishChanges"]);
+    publishChanges();
 
     cy.document().then(doc => {
       const iframe = doc.querySelector("iframe");
@@ -129,8 +126,7 @@ describe("scenarios > embedding > native questions", () => {
       .blur();
     cy.button("Add filter").click();
 
-    cy.button("Publish").click();
-    cy.wait(["@publishChanges", "@publishChanges"]);
+    publishChanges();
 
     cy.document().then(doc => {
       const iframe = doc.querySelector("iframe");
@@ -209,4 +205,11 @@ function enableSharing() {
   cy.icon("share").click();
   cy.findByText("Embed this question in an application").click();
   cy.wait("@sessionProperties");
+}
+
+function publishChanges() {
+  cy.intercept("PUT", "/api/card/*").as("publishChanges");
+
+  cy.button("Publish").click();
+  cy.wait(["@publishChanges", "@publishChanges"]);
 }

--- a/frontend/test/metabase/scenarios/embedding/embedding-native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/embedding-native.cy.spec.js
@@ -86,127 +86,134 @@ describe("scenarios > embedding > native questions", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
-
-    cy.createNativeQuestion(questionDetails, {
-      visitQuestion: true,
-      wrapId: true,
-    });
   });
 
-  it("should not display disabled parameters", () => {
-    enableSharing();
-
-    publishChanges(({ request }) => {
-      assert.deepEqual(request.body.embedding_params, {});
-    });
-
-    cy.document().then(doc => {
-      const iframe = doc.querySelector("iframe");
-
-      cy.signOut();
-      cy.visit(iframe.src);
-    });
-
-    cy.contains("Lora Cronin");
-    cy.contains("Organic");
-    cy.contains("39.58");
-
-    filterWidget().should("not.exist");
-  });
-
-  it("should display and work with enabled parameters while hiding the locked one", () => {
-    enableSharing();
-
-    setParameter("Order ID", "Editable");
-    setParameter("Created At", "Editable");
-    setParameter("Total", "Locked");
-    setParameter("State", "Editable");
-    setParameter("Product ID", "Editable");
-
-    // We must enter a value for a locked parameter
-    cy.findByText("Preview Locked Parameters")
-      .parent()
-      .within(() => {
-        cy.findByText("Total").click();
+  context("UI", () => {
+    beforeEach(() => {
+      cy.createNativeQuestion(questionDetails, {
+        visitQuestion: true,
       });
 
-    // Total is greater than or equal to 0
-    cy.findByPlaceholderText("Enter a number")
-      .type("0")
-      .blur();
-    cy.button("Add filter").click();
-
-    publishChanges(({ request }) => {
-      const actual = request.body.embedding_params;
-
-      const expected = {
-        id: "enabled",
-        created_at: "enabled",
-        total: "locked",
-        state: "enabled",
-        product_id: "enabled",
-      };
-
-      assert.deepEqual(actual, expected);
+      enableSharing();
     });
 
-    cy.document().then(doc => {
-      const iframe = doc.querySelector("iframe");
+    it("should not display disabled parameters", () => {
+      publishChanges(({ request }) => {
+        assert.deepEqual(request.body.embedding_params, {});
+      });
 
-      cy.signOut();
-      cy.visit(iframe.src);
+      cy.document().then(doc => {
+        const iframe = doc.querySelector("iframe");
+
+        cy.signOut();
+        cy.visit(iframe.src);
+      });
+
+      cy.contains("Lora Cronin");
+      cy.contains("Organic");
+      cy.contains("39.58");
+
+      filterWidget().should("not.exist");
     });
 
-    cy.contains("Organic");
-    cy.contains("Twitter").should("not.exist");
+    it("should display and work with enabled parameters while hiding the locked one", () => {
+      setParameter("Order ID", "Editable");
+      setParameter("Created At", "Editable");
+      setParameter("Total", "Locked");
+      setParameter("State", "Editable");
+      setParameter("Product ID", "Editable");
 
-    // Created At: Q2, 2018
-    filterWidget()
-      .contains("Created At")
-      .click();
-    cy.findByTestId("select-button").click();
-    popover()
-      .contains("2018")
-      .click();
-    cy.findByText("Q2").click();
+      // We must enter a value for a locked parameter
+      cy.findByText("Preview Locked Parameters")
+        .parent()
+        .within(() => {
+          cy.findByText("Total").click();
+        });
 
-    // State: is not KS
-    filterWidget()
-      .contains("State")
-      .click();
-    cy.findByPlaceholderText("Search the list").type("KS");
-    cy.findByTestId("KS-filter-value").click();
-    cy.button("Add filter").click();
+      // Total is greater than or equal to 0
+      cy.findByPlaceholderText("Enter a number")
+        .type("0")
+        .blur();
+      cy.button("Add filter").click();
 
-    cy.findByText("Logan Weber").should("not.exist");
+      publishChanges(({ request }) => {
+        const actual = request.body.embedding_params;
 
-    // Product ID is 10
-    cy.findByPlaceholderText("Product ID").type("10{enter}");
+        const expected = {
+          id: "enabled",
+          created_at: "enabled",
+          total: "locked",
+          state: "enabled",
+          product_id: "enabled",
+        };
 
-    cy.contains("Affiliate").should("not.exist");
+        assert.deepEqual(actual, expected);
+      });
 
-    // Let's try to remove one filter
-    cy.findByText("Q2, 2018")
-      .siblings(".Icon-close")
-      .click();
+      cy.document().then(doc => {
+        const iframe = doc.querySelector("iframe");
 
-    // Order ID is 926 - there should be only one result after this
-    filterWidget()
-      .contains("Order ID")
-      .click();
-    cy.findByPlaceholderText("Enter an ID").type("926");
-    cy.button("Add filter").click();
+        cy.signOut();
+        cy.visit(iframe.src);
+      });
 
-    cy.findByTestId("table-row").should("have.length", 1);
+      cy.contains("Organic");
+      cy.contains("Twitter").should("not.exist");
 
-    cy.findByText("December 29, 2018, 4:54 AM");
-    cy.findByText("CO");
-    cy.findByText("Sid Mills").should("not.exist");
+      // Created At: Q2, 2018
+      filterWidget()
+        .contains("Created At")
+        .click();
+      cy.findByTestId("select-button").click();
+      popover()
+        .contains("2018")
+        .click();
+      cy.findByText("Q2").click();
 
-    cy.location("search").should("eq", "?id=926&state=KS&product_id=10");
+      // State: is not KS
+      filterWidget()
+        .contains("State")
+        .click();
+      cy.findByPlaceholderText("Search the list").type("KS");
+      cy.findByTestId("KS-filter-value").click();
+      cy.button("Add filter").click();
+
+      cy.findByText("Logan Weber").should("not.exist");
+
+      // Product ID is 10
+      cy.findByPlaceholderText("Product ID").type("10{enter}");
+
+      cy.contains("Affiliate").should("not.exist");
+
+      // Let's try to remove one filter
+      cy.findByText("Q2, 2018")
+        .siblings(".Icon-close")
+        .click();
+
+      // Order ID is 926 - there should be only one result after this
+      filterWidget()
+        .contains("Order ID")
+        .click();
+      cy.findByPlaceholderText("Enter an ID").type("926");
+      cy.button("Add filter").click();
+
+      cy.findByTestId("table-row").should("have.length", 1);
+
+      cy.findByText("December 29, 2018, 4:54 AM");
+      cy.findByText("CO");
+      cy.findByText("Sid Mills").should("not.exist");
+
+      cy.location("search").should("eq", "?id=926&state=KS&product_id=10");
+    });
   });
 
   context("API", () => {
+    beforeEach(() => {
+      cy.createNativeQuestion(questionDetails, {
+        wrapId: true,
+      });
+    });
+
     it("should hide filters via url", () => {
       cy.get("@questionId").then(questionId => {
         cy.request("PUT", `/api/card/${questionId}`, {

--- a/frontend/test/metabase/scenarios/embedding/embedding-native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/embedding-native.cy.spec.js
@@ -13,7 +13,7 @@ SELECT orders.id, orders.product_id, orders.created_at AS production_date, order
 FROM orders LEFT JOIN people ON orders.user_id = people.id
 WHERE true
   [[AND {{id}}]]
-  [[AND orders.product_id = {{productId}}]]
+  [[AND orders.product_id = {{product_id}}]]
   [[AND {{created_at}}]]
   [[AND {{total}}]]
   [[AND {{state}}]]
@@ -203,7 +203,7 @@ describe("scenarios > embedding > native questions", () => {
     cy.findByText("CO");
     cy.findByText("Sid Mills").should("not.exist");
 
-    cy.location("search").should("eq", "?id=926&state=KS&productId=10");
+    cy.location("search").should("eq", "?id=926&state=KS&product_id=10");
   });
 
   context("API", () => {

--- a/frontend/test/metabase/scenarios/embedding/embedding-native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/embedding-native.cy.spec.js
@@ -79,20 +79,17 @@ const questionDetails = {
 
 describe("scenarios > embedding > native questions", () => {
   beforeEach(() => {
-    cy.intercept("GET", "/api/session/properties").as("sessionProperties");
     cy.intercept("PUT", "/api/card/*").as("publishChanges");
 
     restore();
     cy.signInAsAdmin();
 
     cy.createNativeQuestion(questionDetails, { visitQuestion: true });
-
-    cy.icon("share").click();
-    cy.findByText("Embed this question in an application").click();
-    cy.wait("@sessionProperties");
   });
 
   it("should not display disabled parameters", () => {
+    enableSharing();
+
     cy.button("Publish").click();
     cy.wait(["@publishChanges", "@publishChanges"]);
 
@@ -111,6 +108,8 @@ describe("scenarios > embedding > native questions", () => {
   });
 
   it("should display and work with enabled parameters while hiding the locked one", () => {
+    enableSharing();
+
     setParameter("Order ID", "Editable");
     setParameter("Created At", "Editable");
     setParameter("Total", "Locked");
@@ -202,4 +201,12 @@ function setParameter(name, filter) {
   popover()
     .contains(filter)
     .click();
+}
+
+function enableSharing() {
+  cy.intercept("GET", "/api/session/properties").as("sessionProperties");
+
+  cy.icon("share").click();
+  cy.findByText("Embed this question in an application").click();
+  cy.wait("@sessionProperties");
 }

--- a/frontend/test/metabase/scenarios/embedding/embedding-native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/embedding-native.cy.spec.js
@@ -64,9 +64,9 @@ const questionDetails = {
         "widget-type": "string/!=",
         default: null,
       },
-      productId: {
+      product_id: {
         id: "c967d72e-3687-aa01-8c47-458f7905305f",
-        name: "productId",
+        name: "product_id",
         "display-name": "Product ID",
         type: "number",
         default: null,

--- a/frontend/test/metabase/scenarios/embedding/reproductions/20845-locked-numeric-param.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/reproductions/20845-locked-numeric-param.cy.spec.js
@@ -51,7 +51,6 @@ defaultFilterValues.forEach(value => {
             params: {
               qty_locked: type === "string" ? "15" : 15, // IMPORTANT: integer
             },
-            exp: Math.round(Date.now() / 1000) + 10 * 60, // 10 minute expiration
           });
         });
 


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Expands native embedding test coverage with tests that rely on programatic token generation, rather than the UI flow
- Greatly expands the `visitEmbeddedPage` helper and makes it possible to work with both dashboards and questions
    - Document the helper using JSDoc
    - Simplifies payload by setting abstracting away the expiration property
    - Also adds the ability to set filter values via URL
    - and to [hide filters via URL](https://www.metabase.com/docs/latest/administration-guide/13-embedding.html#hiding-parameters)
- Separates tests in two major categories - UI and API

This PR grew a bit more than I originally anticipated and could have been easily broken down in two parts:
1. embedding helper improvements
2. API tests

But if it doesn't create a major headache I'd appreciate the review for this PR in its current form. Sorry for the possible inconvenience.