### PR TITLE
Add unit tests demonstrating ExpressionDimension bug

### DIFF
--- a/frontend/test/metabase-lib/lib/Dimension.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/Dimension.unit.spec.js
@@ -723,6 +723,39 @@ describe("Dimension", () => {
     });
   });
 
+  describe("ExpressionDimension using `concat('foo ', 'bar')` expression", () => {
+    // this one passes
+    it("should return a field of type 'type/Text' for a dimension without a query", () => {
+      const dimension = Dimension.parseMBQL(
+        ["expression", "concat('foo ', 'bar')"],
+        metadata,
+      );
+
+      expect(dimension.field().semantic_type).toEqual("type/Text");
+    });
+
+    // this one fails with both "concat('foo ', 'bar')" and ["concat", "foo ", "bar"]
+    it("should return a field type of 'type/Text' for a dimension with a query", () => {
+      const query = new StructuredQuery(ORDERS.question(), {
+        type: "query",
+        database: SAMPLE_DATABASE.id,
+        // expressions: { foo: "concat('foo ', 'bar')" },
+        expressions: { foo: ["concat", "foo ", "bar"] },
+        query: {
+          "source-table": ORDERS.id,
+        },
+      });
+
+      const dimension = Dimension.parseMBQL(
+        ["expression", "foo"],
+        metadata,
+        query,
+      );
+
+      expect(dimension.field().semantic_type).toEqual("type/Text");
+    });
+  });
+
   describe("Field with join-alias", () => {
     const dimension = Dimension.parseMBQL(
       ["field", ORDERS.TOTAL.id, { "join-alias": "join1" }],


### PR DESCRIPTION
Looks like this is only broken when we parse the dimension using a query, which is what happens when we build out the parameter widgets in dashboards.

Some of what I wrote here might be slightly relevant: https://github.com/metabase/metabase/pull/21132#discussion_r832526774

When we have access to a query when parsing a dimension, that often (never always...) means we have access to a `card` with `result_metadata`. Do you think it'd ever make sense, instead of re-parsing the expression, to rely on what comes with `result_metadata`? We now do this for FieldDimensions, but obviously they don't have the nice fallback of simply re-parsing 🙂 