### PR TITLE
Fix E2E tests for new navigation UI

### DIFF
--- a/frontend/src/metabase/App.jsx
+++ b/frontend/src/metabase/App.jsx
@@ -108,8 +108,14 @@ class App extends Component {
   };
 
   hasAppBar = () => {
-    const { currentUser } = this.props;
-    return currentUser && !this.isAdminApp();
+    const {
+      currentUser,
+      location: { pathname },
+    } = this.props;
+    if (!currentUser || IFRAMED || this.isAdminApp()) {
+      return false;
+    }
+    return !PATHS_WITHOUT_NAVBAR.some(pattern => pattern.test(pathname));
   };
 
   toggleSidebar = () => {
@@ -168,14 +174,14 @@ class App extends Component {
   render() {
     const { children, location, errorPage, onChangeLocation } = this.props;
     const { errorInfo, sidebarOpen } = this.state;
-
+    const hasAppBar = this.hasAppBar();
     return (
       <ScrollToTop>
         {errorPage ? (
           getErrorComponent(errorPage)
         ) : (
           <>
-            {this.hasAppBar() && (
+            {hasAppBar && (
               <AppBar
                 isSidebarOpen={sidebarOpen}
                 location={location}
@@ -184,7 +190,10 @@ class App extends Component {
                 onChangeLocation={onChangeLocation}
               />
             )}
-            <AppContentContainer isAdminApp={this.isAdminApp()}>
+            <AppContentContainer
+              hasAppBar={hasAppBar}
+              isAdminApp={this.isAdminApp()}
+            >
               {this.hasNavbar() && sidebarOpen && (
                 <Navbar location={location} />
               )}

--- a/frontend/src/metabase/App.jsx
+++ b/frontend/src/metabase/App.jsx
@@ -2,28 +2,18 @@
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import { push } from "react-router-redux";
-import { t } from "ttag";
 import _ from "underscore";
 
 import ScrollToTop from "metabase/hoc/ScrollToTop";
+import AppBar from "metabase/nav/containers/AppBar";
 import Navbar from "metabase/nav/containers/Navbar";
-import SearchBar from "metabase/nav/components/SearchBar";
 import * as Urls from "metabase/lib/urls";
-import LogoIcon from "metabase/components/LogoIcon";
-import Link from "metabase/core/components/Link";
-import Tooltip from "metabase/components/Tooltip";
-
-import {
-  SearchBarContainer,
-  SearchBarContent,
-} from "metabase/nav/containers/Navbar.styled";
 
 import { IFRAMED, initializeIframeResizer } from "metabase/lib/dom";
 
 import UndoListing from "metabase/containers/UndoListing";
 import StatusListing from "metabase/status/containers/StatusListing";
 import AppErrorCard from "metabase/components/AppErrorCard/AppErrorCard";
-import NewButton from "metabase/nav/containers/NewButton";
 import Modal from "metabase/components/Modal";
 
 import CollectionCreate from "metabase/collections/containers/CollectionCreate";
@@ -36,15 +26,7 @@ import {
   Unauthorized,
 } from "metabase/containers/ErrorPages";
 
-import Database from "metabase/entities/databases";
-
-import {
-  AppContentContainer,
-  AppContent,
-  AppBar,
-  LogoIconWrapper,
-  SidebarButton,
-} from "./App.styled";
+import { AppContentContainer, AppContent } from "./App.styled";
 
 export const MODAL_NEW_DASHBOARD = "MODAL_NEW_DASHBOARD";
 export const MODAL_NEW_COLLECTION = "MODAL_NEW_COLLECTION";
@@ -134,36 +116,6 @@ class App extends Component {
     this.setState({ sidebarOpen: !this.state.sidebarOpen });
   };
 
-  renderAppBar = () => {
-    const { location, onChangeLocation } = this.props;
-    return (
-      <AppBar id="mainAppBar">
-        <LogoIconWrapper>
-          <Link to="/" data-metabase-event={"Navbar;Logo"}>
-            <LogoIcon size={24} />
-          </Link>
-        </LogoIconWrapper>
-        <Tooltip
-          tooltip={this.state.sidebarOpen ? t`Close sidebar` : t`Open sidebar`}
-        >
-          <SidebarButton
-            name={this.state.sidebarOpen ? "chevronleft" : "chevronright"}
-            onClick={this.toggleSidebar}
-          />
-        </Tooltip>
-        <SearchBarContainer>
-          <SearchBarContent>
-            <SearchBar
-              location={location}
-              onChangeLocation={onChangeLocation}
-            />
-          </SearchBarContent>
-        </SearchBarContainer>
-        <NewButton setModal={this.setModal} />
-      </AppBar>
-    );
-  };
-
   closeModal = () => {
     this.setState({ modal: null });
   };
@@ -214,7 +166,7 @@ class App extends Component {
   };
 
   render() {
-    const { children, location, errorPage } = this.props;
+    const { children, location, errorPage, onChangeLocation } = this.props;
     const { errorInfo, sidebarOpen } = this.state;
 
     return (
@@ -223,7 +175,15 @@ class App extends Component {
           getErrorComponent(errorPage)
         ) : (
           <>
-            {this.hasAppBar() && this.renderAppBar()}
+            {this.hasAppBar() && (
+              <AppBar
+                isSidebarOpen={sidebarOpen}
+                location={location}
+                onToggleSidebarClick={this.toggleSidebar}
+                onNewClick={this.setModal}
+                onChangeLocation={onChangeLocation}
+              />
+            )}
             <AppContentContainer isAdminApp={this.isAdminApp()}>
               {this.hasNavbar() && sidebarOpen && (
                 <Navbar location={location} />
@@ -241,7 +201,4 @@ class App extends Component {
   }
 }
 
-export default _.compose(
-  Database.loadList({ loadingAndErrorWrapper: false }),
-  connect(mapStateToProps, mapDispatchToProps),
-)(App);
+export default connect(mapStateToProps, mapDispatchToProps)(App);

--- a/frontend/src/metabase/App.jsx
+++ b/frontend/src/metabase/App.jsx
@@ -134,7 +134,7 @@ export default class App extends Component {
   renderAppBar = () => {
     const { location, onChangeLocation } = this.props;
     return (
-      <AppBar>
+      <AppBar id="mainAppBar">
         <LogoIconWrapper>
           <Link to="/" data-metabase-event={"Navbar;Logo"}>
             <LogoIcon size={24} />

--- a/frontend/src/metabase/App.jsx
+++ b/frontend/src/metabase/App.jsx
@@ -223,7 +223,7 @@ export default class App extends Component {
             {this.hasAppBar() && this.renderAppBar()}
             <AppContentContainer isAdminApp={this.isAdminApp()}>
               {this.hasNavbar() && sidebarOpen && (
-                <Navbar location={location} renderModal={this.renderModal} />
+                <Navbar location={location} />
               )}
               <AppContent>{children}</AppContent>
               {this.renderModal()}

--- a/frontend/src/metabase/App.jsx
+++ b/frontend/src/metabase/App.jsx
@@ -3,6 +3,8 @@ import React, { Component } from "react";
 import { connect } from "react-redux";
 import { push } from "react-router-redux";
 import { t } from "ttag";
+import _ from "underscore";
+
 import ScrollToTop from "metabase/hoc/ScrollToTop";
 import Navbar from "metabase/nav/containers/Navbar";
 import SearchBar from "metabase/nav/components/SearchBar";
@@ -33,6 +35,8 @@ import {
   GenericError,
   Unauthorized,
 } from "metabase/containers/ErrorPages";
+
+import Database from "metabase/entities/databases";
 
 import {
   AppContentContainer,
@@ -90,8 +94,7 @@ function checkIsSidebarInitiallyOpen(locationPathName) {
   );
 }
 
-@connect(mapStateToProps, mapDispatchToProps)
-export default class App extends Component {
+class App extends Component {
   state = {
     errorInfo: undefined,
     sidebarOpen: checkIsSidebarInitiallyOpen(this.props.location.pathname),
@@ -237,3 +240,8 @@ export default class App extends Component {
     );
   }
 }
+
+export default _.compose(
+  Database.loadList({ loadingAndErrorWrapper: false }),
+  connect(mapStateToProps, mapDispatchToProps),
+)(App);

--- a/frontend/src/metabase/App.styled.tsx
+++ b/frontend/src/metabase/App.styled.tsx
@@ -18,7 +18,7 @@ export const AppContentContainer = styled.div<{ isAdminApp: boolean }>`
   ${props => props.isAdminApp && adminCss}
 `;
 
-export const AppContent = styled.div`
+export const AppContent = styled.main`
   width: 100%;
   overflow: auto;
   background-color: ${color("content")};

--- a/frontend/src/metabase/App.styled.tsx
+++ b/frontend/src/metabase/App.styled.tsx
@@ -1,23 +1,23 @@
 import styled from "@emotion/styled";
-import { css } from "@emotion/react";
 import { color } from "metabase/lib/colors";
 
 import { NAV_HEIGHT } from "metabase/nav/constants";
 
-const adminCss = css`
-  flex-direction: column;
-`;
-
-export const AppContentContainer = styled.div<{ isAdminApp: boolean }>`
+export const AppContentContainer = styled.div<{
+  isAdminApp: boolean;
+  hasAppBar: boolean;
+}>`
   display: flex;
+  flex-direction: ${props => (props.isAdminApp ? "column" : "row")};
   position: relative;
-  height: calc(100vh - ${NAV_HEIGHT});
   overflow: hidden;
-  ${props => props.isAdminApp && adminCss}
+  height: ${props =>
+    props.hasAppBar ? `calc(100vh - ${NAV_HEIGHT})` : "100vh"};
+  background-color: ${color("content")};
 `;
 
 export const AppContent = styled.main`
   width: 100%;
+  height: 100%;
   overflow: auto;
-  background-color: ${color("content")};
 `;

--- a/frontend/src/metabase/App.styled.tsx
+++ b/frontend/src/metabase/App.styled.tsx
@@ -3,8 +3,6 @@ import { css } from "@emotion/react";
 import { color } from "metabase/lib/colors";
 
 import { NAV_HEIGHT } from "metabase/nav/constants";
-import { space } from "metabase/styled-components/theme";
-import Icon from "metabase/components/Icon";
 
 const adminCss = css`
   flex-direction: column;
@@ -22,42 +20,4 @@ export const AppContent = styled.main`
   width: 100%;
   overflow: auto;
   background-color: ${color("content")};
-`;
-
-export const AppBar = styled.div`
-  position: relative;
-  display: flex;
-  align-items: center;
-  width: 100%;
-  background-color: ${color("bg-white")};
-  border-bottom: 1px solid ${color("border")};
-  z-index: 4;
-`;
-
-export const LogoIconWrapper = styled.div`
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 6px;
-  padding: ${space(1)};
-  margin-left: ${space(1)};
-
-  &:hover {
-    background-color: ${color("bg-light")};
-  }
-`;
-
-export const SidebarButton = styled(Icon)`
-  border: 1px solid ${color("border")};
-  padding: ${space(1)};
-  border-radius: 4px;
-  margin-left: ${space(1)};
-  color: ${color("text-medium")};
-
-  &:hover {
-    color: ${color("brand")};
-    border-color: ${color("brand")};
-    cursor: pointer;
-  }
 `;

--- a/frontend/src/metabase/App.styled.tsx
+++ b/frontend/src/metabase/App.styled.tsx
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
 
-import { NAV_HEIGHT } from "metabase/nav/constants";
+import { APP_BAR_HEIGHT } from "metabase/nav/constants";
 
 export const AppContentContainer = styled.div<{
   isAdminApp: boolean;
@@ -12,8 +12,9 @@ export const AppContentContainer = styled.div<{
   position: relative;
   overflow: hidden;
   height: ${props =>
-    props.hasAppBar ? `calc(100vh - ${NAV_HEIGHT})` : "100vh"};
-  background-color: ${color("content")};
+    props.hasAppBar ? `calc(100vh - ${APP_BAR_HEIGHT})` : "100vh"};
+  background-color: ${props =>
+    color(props.isAdminApp ? "bg-white" : "content")};
 `;
 
 export const AppContent = styled.main`

--- a/frontend/src/metabase/account/notifications/components/NotificationList/NotificationList.jsx
+++ b/frontend/src/metabase/account/notifications/components/NotificationList/NotificationList.jsx
@@ -33,7 +33,7 @@ const NotificationList = ({
   }
 
   return (
-    <div>
+    <div data-testid="notifications-list">
       <NotificationHeader>
         <NotificationLabel>{t`You receive or created these`}</NotificationLabel>
         <NotificationButton onClick={onHelp}>

--- a/frontend/src/metabase/components/CollectionLanding/CollectionLanding.styled.jsx
+++ b/frontend/src/metabase/components/CollectionLanding/CollectionLanding.styled.jsx
@@ -5,7 +5,6 @@ import { breakpointMinSmall } from "metabase/styled-components/theme/media-queri
 export const ContentBox = styled.div`
   display: ${props => (props.shouldDisplayMobileSidebar ? "none" : "block")};
   overflow-y: auto;
-  padding-bottom: 64px;
 
   ${breakpointMinSmall} {
     display: block;

--- a/frontend/src/metabase/nav/components/AdminNavbar/AdminNavbar.styled.tsx
+++ b/frontend/src/metabase/nav/components/AdminNavbar/AdminNavbar.styled.tsx
@@ -2,13 +2,14 @@ import styled from "@emotion/styled";
 import Link from "metabase/core/components/Link";
 import { alpha, color, darken } from "metabase/lib/colors";
 import { breakpointMaxLarge } from "metabase/styled-components/theme";
+import { NAV_HEIGHT } from "../../constants";
 
 export const AdminNavbarRoot = styled.nav`
   padding: 0.5rem;
   background: ${color("admin-navbar")};
   color: ${color("white")};
   font-size: 0.85rem;
-  height: 65px;
+  height: ${NAV_HEIGHT};
   display: flex;
   align-items: center;
 `;

--- a/frontend/src/metabase/nav/components/AdminNavbar/AdminNavbar.styled.tsx
+++ b/frontend/src/metabase/nav/components/AdminNavbar/AdminNavbar.styled.tsx
@@ -2,14 +2,14 @@ import styled from "@emotion/styled";
 import Link from "metabase/core/components/Link";
 import { alpha, color, darken } from "metabase/lib/colors";
 import { breakpointMaxLarge } from "metabase/styled-components/theme";
-import { NAV_HEIGHT } from "../../constants";
+import { ADMIN_NAVBAR_HEIGHT } from "../../constants";
 
 export const AdminNavbarRoot = styled.nav`
   padding: 0.5rem;
   background: ${color("admin-navbar")};
   color: ${color("white")};
   font-size: 0.85rem;
-  height: ${NAV_HEIGHT};
+  height: ${ADMIN_NAVBAR_HEIGHT};
   display: flex;
   align-items: center;
 `;

--- a/frontend/src/metabase/nav/constants.js
+++ b/frontend/src/metabase/nav/constants.js
@@ -1,4 +1,6 @@
 import { color, lighten } from "metabase/lib/colors";
 
 export const getDefaultSearchColor = () => lighten(color("nav"), 0.07);
-export const NAV_HEIGHT = "61px";
+
+export const APP_BAR_HEIGHT = "52px";
+export const ADMIN_NAVBAR_HEIGHT = "65px";

--- a/frontend/src/metabase/nav/containers/AppBar.styled.tsx
+++ b/frontend/src/metabase/nav/containers/AppBar.styled.tsx
@@ -1,0 +1,44 @@
+import styled from "@emotion/styled";
+
+import Icon from "metabase/components/Icon";
+
+import { color } from "metabase/lib/colors";
+import { space } from "metabase/styled-components/theme";
+
+export const AppBarRoot = styled.div`
+  position: relative;
+  display: flex;
+  align-items: center;
+  width: 100%;
+  background-color: ${color("bg-white")};
+  border-bottom: 1px solid ${color("border")};
+  z-index: 4;
+`;
+
+export const LogoIconWrapper = styled.div`
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 6px;
+  padding: ${space(1)};
+  margin-left: ${space(1)};
+
+  &:hover {
+    background-color: ${color("bg-light")};
+  }
+`;
+
+export const SidebarButton = styled(Icon)`
+  border: 1px solid ${color("border")};
+  padding: ${space(1)};
+  border-radius: 4px;
+  margin-left: ${space(1)};
+  color: ${color("text-medium")};
+
+  &:hover {
+    color: ${color("brand")};
+    border-color: ${color("brand")};
+    cursor: pointer;
+  }
+`;

--- a/frontend/src/metabase/nav/containers/AppBar.styled.tsx
+++ b/frontend/src/metabase/nav/containers/AppBar.styled.tsx
@@ -5,11 +5,14 @@ import Icon from "metabase/components/Icon";
 import { color } from "metabase/lib/colors";
 import { space } from "metabase/styled-components/theme";
 
+import { APP_BAR_HEIGHT } from "../constants";
+
 export const AppBarRoot = styled.div`
   position: relative;
   display: flex;
   align-items: center;
   width: 100%;
+  height: ${APP_BAR_HEIGHT};
   background-color: ${color("bg-white")};
   border-bottom: 1px solid ${color("border")};
   z-index: 4;

--- a/frontend/src/metabase/nav/containers/AppBar.tsx
+++ b/frontend/src/metabase/nav/containers/AppBar.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { t } from "ttag";
+
+import Link from "metabase/core/components/Link";
+import Tooltip from "metabase/components/Tooltip";
+import LogoIcon from "metabase/components/LogoIcon";
+
+import SearchBar from "metabase/nav/components/SearchBar";
+import NewButton from "metabase/nav/containers/NewButton";
+import {
+  SearchBarContainer,
+  SearchBarContent,
+} from "metabase/nav/containers/Navbar.styled";
+
+import Database from "metabase/entities/databases";
+
+import { AppBarRoot, LogoIconWrapper, SidebarButton } from "./AppBar.styled";
+
+type Location = {
+  pathname: string;
+  query: Record<string, string>;
+};
+
+type Props = {
+  isSidebarOpen: boolean;
+  location: Location;
+  onToggleSidebarClick: () => void;
+  onNewClick: () => void;
+  onChangeLocation: (nextLocation: Location) => void;
+};
+
+function AppBar({
+  isSidebarOpen,
+  location,
+  onToggleSidebarClick,
+  onNewClick,
+  onChangeLocation,
+}: Props) {
+  return (
+    <AppBarRoot id="mainAppBar">
+      <LogoIconWrapper>
+        <Link to="/" data-metabase-event="Navbar;Logo">
+          <LogoIcon size={24} />
+        </Link>
+      </LogoIconWrapper>
+      <Tooltip tooltip={isSidebarOpen ? t`Close sidebar` : t`Open sidebar`}>
+        <SidebarButton
+          name={isSidebarOpen ? "chevronleft" : "chevronright"}
+          onClick={onToggleSidebarClick}
+        />
+      </Tooltip>
+      <SearchBarContainer>
+        <SearchBarContent>
+          <SearchBar location={location} onChangeLocation={onChangeLocation} />
+        </SearchBarContent>
+      </SearchBarContainer>
+      <NewButton setModal={onNewClick} />
+    </AppBarRoot>
+  );
+}
+
+export default Database.loadList({ loadingAndErrorWrapper: false })(AppBar);

--- a/frontend/src/metabase/nav/containers/Navbar.jsx
+++ b/frontend/src/metabase/nav/containers/Navbar.jsx
@@ -62,15 +62,6 @@ export default class Navbar extends Component {
     return this.props.path.startsWith(path);
   }
 
-  renderAdminNav() {
-    return (
-      <>
-        <AdminNavbar {...this.props} />
-        {this.props.renderModal()}
-      </>
-    );
-  }
-
   renderEmptyNav() {
     return (
       // NOTE: DO NOT REMOVE `Nav` CLASS FOR NOW, USED BY MODALS, FULLSCREEN DASHBOARD, ETC
@@ -87,7 +78,6 @@ export default class Navbar extends Component {
             </Link>
           </li>
         </ul>
-        {this.props.renderModal()}
       </nav>
     );
   }
@@ -148,7 +138,7 @@ export default class Navbar extends Component {
 
     switch (context) {
       case "admin":
-        return this.renderAdminNav();
+        return <AdminNavbar {...this.props} />;
       case "auth":
         return null;
       case "none":

--- a/frontend/src/metabase/nav/containers/index.ts
+++ b/frontend/src/metabase/nav/containers/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./AppBar";

--- a/frontend/src/metabase/new_query/selectors.js
+++ b/frontend/src/metabase/new_query/selectors.js
@@ -26,23 +26,25 @@ export const getPlainNativeQuery = state => {
   }
 };
 
-export const getHasDataAccess = createSelector(
-  [getDatabases],
-  (databaseMap = {}) =>
-    // This ensures there is at least one real (not saved questions) DB available
-    // If there is only the saved questions DB, it doesn't mean a user has data access
-    Object.values(databaseMap).some(db => !db.is_saved_questions),
+export const getDatabaseList = createSelector([getDatabases], databaseMap =>
+  Object.values(databaseMap ?? {}),
 );
 
-export const getHasNativeWrite = createSelector(
-  [getDatabases],
-  (databaseMap = {}) =>
-    Object.values(databaseMap).some(d => d.native_permissions === "write"),
+export const getHasDataAccess = createSelector([getDatabaseList], databases =>
+  // This ensures there is at least one real (not saved questions) DB available
+  // If there is only the saved questions DB, it doesn't mean a user has data access
+  databases.some(db => !db.is_saved_questions),
 );
 
-export const getHasDbWithJsonEngine = (state, props) => {
-  return (props.databases || []).some(database => {
-    const isJsonEngine = getEngineNativeType(database.engine) === "json";
-    return database.canWrite() && isJsonEngine;
-  });
-};
+export const getHasNativeWrite = createSelector([getDatabaseList], databases =>
+  databases.some(db => db.native_permissions === "write"),
+);
+
+const isJsonEngine = database =>
+  getEngineNativeType(database.engine) === "json";
+
+export const getHasDbWithJsonEngine = createSelector(
+  [getDatabaseList],
+  databases =>
+    databases.some(db => db.native_permissions === "write" && isJsonEngine(db)),
+);

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
@@ -407,7 +407,7 @@ function DatasetEditor(props) {
   });
 
   return (
-    <React.Fragment>
+    <>
       <DatasetEditBar
         title={dataset.displayName()}
         center={
@@ -474,7 +474,7 @@ function DatasetEditor(props) {
           {sidebar}
         </ViewSidebar>
       </Root>
-    </React.Fragment>
+    </>
   );
 }
 

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.styled.jsx
@@ -19,7 +19,7 @@ export const TabHintToastContainer = styled.div`
 `;
 
 export const DatasetEditBar = styled(EditBar)`
-  background-color: ${color("nav")};
+  background-color: ${color("brand")};
 `;
 
 export const TableHeaderColumnName = styled.div`

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.styled.jsx
@@ -82,11 +82,14 @@ FieldTypeIcon.defaultProps = { size: 14 };
 
 // Mirrors styling of some QB View div elements
 
+const EDIT_BAR_HEIGHT = "49px";
+
 export const Root = styled.div`
   display: flex;
   flex: 1 0 auto;
   position: relative;
   background-color: ${color("bg-white")};
+  height: calc(100vh - ${EDIT_BAR_HEIGHT});
 `;
 
 export const MainContainer = styled.div`

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/EditorTabs/EditorTabs.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/EditorTabs/EditorTabs.styled.tsx
@@ -11,7 +11,7 @@ export const TabBar = styled.ul`
 `;
 
 function getActiveTabColor() {
-  return darken("nav");
+  return darken("brand");
 }
 
 function getInactiveTabColor() {

--- a/frontend/src/metabase/query_builder/components/view/View.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/view/View.styled.tsx
@@ -8,13 +8,13 @@ import { color } from "metabase/lib/colors";
 import { breakpointMaxSmall } from "metabase/styled-components/theme/media-queries";
 
 import { ViewTitleHeader } from "./ViewHeader";
-import { NAV_HEIGHT } from "metabase/nav/constants";
+import { APP_BAR_HEIGHT } from "metabase/nav/constants";
 
 export const QueryBuilderViewRoot = styled.div`
   display: flex;
   flex-direction: column;
   background-color: ${color("bg-white")};
-  height: calc(100vh - ${NAV_HEIGHT});
+  height: calc(100vh - ${APP_BAR_HEIGHT});
   position: relative;
 `;
 

--- a/frontend/test/__support__/e2e/helpers/e2e-ui-elements-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-ui-elements-helpers.js
@@ -11,12 +11,32 @@ export function modal() {
 }
 
 export function sidebar() {
-  return cy.get("aside");
+  return cy.get("main aside");
+}
+
+export function navigationSidebar() {
+  return cy.get(".Nav");
+}
+
+export function appBar() {
+  return cy.get("#mainAppBar");
+}
+
+export function openNavigationSidebar() {
+  appBar()
+    .findByTestId("main-logo")
+    .click();
+}
+
+export function closeNavigationSidebar() {
+  appBar()
+    .findByTestId("main-logo")
+    .click();
 }
 
 export function browse() {
   // takes you to `/browse` (reflecting changes made in `0.38-collection-redesign)
-  return cy.get(".Nav .Icon-table_spaced");
+  return navigationSidebar().findByText("Browse data");
 }
 
 /**

--- a/frontend/test/__support__/e2e/helpers/e2e-ui-elements-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-ui-elements-helpers.js
@@ -23,15 +23,15 @@ export function appBar() {
 }
 
 export function openNavigationSidebar() {
-  appBar()
-    .findByTestId("main-logo")
-    .click();
+  appBar().within(() => {
+    cy.icon("chevronright").click();
+  });
 }
 
 export function closeNavigationSidebar() {
-  appBar()
-    .findByTestId("main-logo")
-    .click();
+  appBar().within(() => {
+    cy.icon("chevronleft").click();
+  });
 }
 
 export function browse() {

--- a/frontend/test/metabase-visual/collections/bookmarks.cy.spec.js
+++ b/frontend/test/metabase-visual/collections/bookmarks.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, sidebar } from "__support__/e2e/cypress";
+import { restore, navigationSidebar } from "__support__/e2e/cypress";
 import { getSidebarSectionTitle as getSectionTitle } from "__support__/e2e/helpers/e2e-collection-helpers";
 
 describe("Bookmarks in a collection page", () => {
@@ -12,7 +12,7 @@ describe("Bookmarks in a collection page", () => {
 
     cy.visit("/collection/1");
 
-    sidebar().within(() => {
+    navigationSidebar().within(() => {
       getSectionTitle("Bookmarks");
     });
 

--- a/frontend/test/metabase/scenarios/admin/people/people.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/people/people.cy.spec.js
@@ -215,7 +215,7 @@ describe("scenarios > admin > people", () => {
       generateGroups(51);
 
       cy.visit("/admin/people/groups");
-      cy.scrollTo("bottom");
+      cy.get("main").scrollTo("bottom");
       cy.findByText("readonly");
     });
 

--- a/frontend/test/metabase/scenarios/admin/settings/whitelabel-color-theme.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/whitelabel-color-theme.cy.spec.js
@@ -112,7 +112,7 @@ describeEE("formatting > whitelabel > color theme", () => {
       console.log(xhr.response.body["application-colors"]);
     });
 
-    cy.scrollTo("top");
+    cy.get("main").scrollTo("top");
 
     cy.log("Admin panel should be yellow");
     cy.get(".Nav").should(

--- a/frontend/test/metabase/scenarios/collections/bookmarks.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/bookmarks.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, sidebar } from "__support__/e2e/cypress";
+import { restore, navigationSidebar } from "__support__/e2e/cypress";
 import { USERS } from "__support__/e2e/cypress_data";
 import { getSidebarSectionTitle as getSectionTitle } from "__support__/e2e/helpers/e2e-collection-helpers";
 
@@ -30,7 +30,7 @@ describe("Bookmarks in a collection page", () => {
     // Add bookmark
     cy.icon("bookmark").click();
 
-    sidebar().within(() => {
+    navigationSidebar().within(() => {
       getSectionTitle("Bookmarks");
       cy.findByText(adminPersonalCollectionName);
 
@@ -44,7 +44,7 @@ describe("Bookmarks in a collection page", () => {
       cy.icon("bookmark").click();
     });
 
-    sidebar().within(() => {
+    navigationSidebar().within(() => {
       cy.findByText(adminPersonalCollectionName).should("not.exist");
 
       getSectionTitle("Bookmarks").should("not.exist");
@@ -69,7 +69,7 @@ describe("Bookmarks in a collection page", () => {
     // Add bookmark
     cy.icon("bookmark").click();
 
-    sidebar().within(() => {
+    navigationSidebar().within(() => {
       cy.icon("bookmark").click({ force: true });
     });
 
@@ -83,7 +83,7 @@ function addThenRemoveBookmarkTo(itemName) {
   openEllipsisMenuFor(itemName);
   cy.findByText("Bookmark").click();
 
-  sidebar().within(() => {
+  navigationSidebar().within(() => {
     getSectionTitle("Bookmarks");
     cy.findByText(itemName);
   });
@@ -92,7 +92,7 @@ function addThenRemoveBookmarkTo(itemName) {
 
   cy.findByText("Remove bookmark").click();
 
-  sidebar().within(() => {
+  navigationSidebar().within(() => {
     getSectionTitle("Bookmarks").should("not.exist");
     cy.findByText(itemName).should("not.exist");
   });

--- a/frontend/test/metabase/scenarios/collections/collection-types.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collection-types.cy.spec.js
@@ -1,10 +1,12 @@
 import {
   restore,
   modal,
-  navigationSidebar,
   describeEE,
   describeOSS,
   openNewCollectionItemFlowFor,
+  appBar,
+  navigationSidebar,
+  closeNavigationSidebar,
 } from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
@@ -198,6 +200,7 @@ function testOfficialBadgePresence(expectBadge = true) {
 
   // Dashboard Page
   cy.findByText("Official Dashboard").click();
+  closeNavigationSidebar();
   assertHasCollectionBadge(expectBadge);
 
   // Question Page
@@ -224,7 +227,7 @@ function testOfficialBadgeInSearch({
   question,
   expectBadge,
 }) {
-  cy.get(".Nav")
+  appBar()
     .findByPlaceholderText("Search…")
     .as("searchBar")
     .type(searchQuery);

--- a/frontend/test/metabase/scenarios/collections/collection-types.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collection-types.cy.spec.js
@@ -1,7 +1,7 @@
 import {
   restore,
   modal,
-  sidebar,
+  navigationSidebar,
   describeEE,
   describeOSS,
   openNewCollectionItemFlowFor,
@@ -264,7 +264,7 @@ function testOfficialQuestionBadgeInRegularDashboard(expectBadge = true) {
 }
 
 function openCollection(collectionName) {
-  sidebar()
+  navigationSidebar()
     .findByText(collectionName)
     .click();
 }
@@ -283,7 +283,7 @@ function expandCollectionChildren(collectionName) {
 }
 
 function getSidebarCollectionChildrenFor(collectionName) {
-  return sidebar()
+  return navigationSidebar()
     .findByText(collectionName)
     .closest("a")
     .parent()
@@ -326,7 +326,7 @@ function assertNoCollectionTypeInput() {
 }
 
 function assertSidebarIcon(collectionName, expectedIcon) {
-  sidebar()
+  navigationSidebar()
     .findByText(collectionName)
     .parent()
     .within(() => {

--- a/frontend/test/metabase/scenarios/collections/collections-sidebar.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections-sidebar.cy.spec.js
@@ -1,6 +1,6 @@
 import { restore, sidebar } from "__support__/e2e/cypress";
 
-describe("collections sidebar (metabase#15006)", () => {
+describe.skip("collections sidebar (metabase#15006)", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();

--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -4,7 +4,7 @@ import {
   modal,
   popover,
   openOrdersTable,
-  sidebar,
+  navigationSidebar,
 } from "__support__/e2e/cypress";
 import { displaySidebarChildOf } from "./helpers/e2e-collections-sidebar.js";
 import { USERS, USER_GROUPS } from "__support__/e2e/cypress_data";
@@ -133,7 +133,7 @@ describe("scenarios > collection_defaults", () => {
       it.skip("should expand/collapse collection tree by clicking on parent collection name (metabse#17339)", () => {
         cy.visit("/collection/root");
 
-        sidebar().within(() => {
+        navigationSidebar().within(() => {
           cy.findByText("First collection").click();
           cy.findByText("Second collection");
           cy.findByText("Third collection");
@@ -263,7 +263,7 @@ describe("scenarios > collection_defaults", () => {
         cy.findByText("Parent").should("not.exist");
         cy.findByText("Browse all items").click();
 
-        sidebar().within(() => {
+        navigationSidebar().within(() => {
           cy.findByText("Our analytics");
           cy.findByText("Child");
           cy.findByText("Parent").should("not.exist");
@@ -427,7 +427,7 @@ describe("scenarios > collection_defaults", () => {
     it("collections without sub-collections shouldn't have chevron icon (metabase#14753)", () => {
       cy.visit("/collection/root");
 
-      sidebar()
+      navigationSidebar()
         .findByText("Your personal collection")
         .parent()
         .find(".Icon-chevronright")
@@ -435,7 +435,7 @@ describe("scenarios > collection_defaults", () => {
 
       // Ensure if sub-collection is archived, the chevron is not displayed
       displaySidebarChildOf("First collection");
-      sidebar()
+      navigationSidebar()
         .findByText("Second collection")
         .click();
       cy.icon("pencil").click();
@@ -445,7 +445,7 @@ describe("scenarios > collection_defaults", () => {
       cy.get(".Modal")
         .findByRole("button", { name: "Archive" })
         .click();
-      sidebar()
+      navigationSidebar()
         .findByText("First collection")
         .parent()
         .find(".Icon-chevrondown")
@@ -535,7 +535,7 @@ describe("scenarios > collection_defaults", () => {
           cy.findByTestId("bulk-action-bar").should("not.be.visible");
 
           // Check that items were actually moved
-          sidebar()
+          navigationSidebar()
             .findByText("First collection")
             .click();
           cy.findByText("Orders");
@@ -572,7 +572,7 @@ function selectItemUsingCheckbox(item, icon = "table") {
 }
 
 function getSidebarCollectionChildrenFor(item) {
-  return sidebar()
+  return navigationSidebar()
     .findByText(item)
     .closest("a")
     .parent()

--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -5,6 +5,7 @@ import {
   popover,
   openOrdersTable,
   navigationSidebar,
+  closeNavigationSidebar,
 } from "__support__/e2e/cypress";
 import { displaySidebarChildOf } from "./helpers/e2e-collections-sidebar.js";
 import { USERS, USER_GROUPS } from "__support__/e2e/cypress_data";
@@ -467,6 +468,7 @@ describe("scenarios > collection_defaults", () => {
       });
 
       cy.visit("/");
+      closeNavigationSidebar();
       cy.findByText("New").click();
       cy.findByText("Question")
         .should("be.visible")

--- a/frontend/test/metabase/scenarios/collections/drag-and-drop.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/drag-and-drop.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, sidebar } from "__support__/e2e/cypress";
+import { restore, navigationSidebar } from "__support__/e2e/cypress";
 
 describe("scenarios > collections > drag and drop functionality", () => {
   beforeEach(() => {
@@ -13,7 +13,7 @@ describe("scenarios > collections > drag and drop functionality", () => {
     cy.findByText("First collection").click();
 
     cy.findByText("Orders").as("dragSubject");
-    sidebar()
+    navigationSidebar()
       .findByText("Our analytics")
       .as("dropTarget");
 

--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -14,7 +14,8 @@ import { onlyOn } from "@cypress/skip-test";
 import {
   restore,
   popover,
-  sidebar,
+  appBar,
+  navigationSidebar,
   openNativeEditor,
   visitQuestion,
 } from "__support__/e2e/cypress";
@@ -46,11 +47,11 @@ describe("collection permissions", () => {
               describe("create dashboard", () => {
                 it("should offer to save dashboard to a currently opened collection", () => {
                   cy.visit("/collection/root");
-                  sidebar().within(() => {
+                  navigationSidebar().within(() => {
                     displaySidebarChildOf("First collection");
                     cy.findByText("Second collection").click();
                   });
-                  cy.get(".Nav").within(() => {
+                  appBar().within(() => {
                     cy.icon("add").click();
                   });
                   cy.findByText("Dashboard").click();
@@ -224,7 +225,7 @@ describe("collection permissions", () => {
                     cy.findByTestId("collection-name-heading")
                       .as("title")
                       .contains("Second collection");
-                    sidebar().within(() => {
+                    navigationSidebar().within(() => {
                       cy.findByText("First collection");
                       cy.findByText("Second collection");
                       cy.findByText("Third collection").should("not.exist");
@@ -238,7 +239,7 @@ describe("collection permissions", () => {
                     // We're still in the parent collection
                     cy.get("@title").contains("Second collection");
                     // But unarchived collection is now visible in the sidebar
-                    sidebar().within(() => {
+                    navigationSidebar().within(() => {
                       cy.findByText("Third collection");
                     });
                   });

--- a/frontend/test/metabase/scenarios/collections/personal-collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/personal-collections.cy.spec.js
@@ -2,7 +2,7 @@ import {
   restore,
   popover,
   modal,
-  sidebar,
+  navigationSidebar,
   assertCanAddItemsToCollection,
   openNewCollectionItemFlowFor,
 } from "__support__/e2e/cypress";
@@ -54,7 +54,7 @@ describe("personal collections", () => {
       cy.findByText("Your personal collection").click();
       // Create new collection inside admin's personal collection and navigate to it
       addNewCollection("Foo");
-      sidebar()
+      navigationSidebar()
         .findByText("Foo")
         .click();
       assertCanAddItemsToCollection();
@@ -69,7 +69,7 @@ describe("personal collections", () => {
         cy.url().should("eq", String(location));
 
         // Check can't open permissions modal via URL for personal collection child
-        sidebar()
+        navigationSidebar()
           .findByText("Foo")
           .click();
         cy.location().then(location => {
@@ -86,7 +86,7 @@ describe("personal collections", () => {
       cy.findByLabelText("Name").type("Foo");
       cy.button("Create").click();
       // This repro could possibly change depending on the design decision for this feature implementation
-      sidebar().findByText("Foo");
+      navigationSidebar().findByText("Foo");
     });
   });
 
@@ -99,7 +99,7 @@ describe("personal collections", () => {
           cy.findByText("Your personal collection").click();
           // Create initial collection inside the personal collection and navigate inside it
           addNewCollection("Foo");
-          sidebar()
+          navigationSidebar()
             .as("sidebar")
             .findByText("Foo")
             .click();

--- a/frontend/test/metabase/scenarios/native-filters/sql-filters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native-filters/sql-filters.cy.spec.js
@@ -1,6 +1,7 @@
 import {
   restore,
   openNativeEditor,
+  closeNavigationSidebar,
   filterWidget,
   popover,
 } from "__support__/e2e/cypress";
@@ -56,6 +57,7 @@ describe("scenarios > filters > sql filters > basic filter types", () => {
 
       SQLFilter.openTypePickerFromDefaultFilterType();
       SQLFilter.chooseType("Number");
+      closeNavigationSidebar();
     });
 
     it("when set through the filter widget", () => {

--- a/frontend/test/metabase/scenarios/onboarding/notifications.cy.spec.js
+++ b/frontend/test/metabase/scenarios/onboarding/notifications.cy.spec.js
@@ -102,7 +102,7 @@ describe("scenarios > account > notifications", () => {
       cy.visit("/account/notifications");
 
       cy.findByText("Question");
-      cy.findByLabelText("close icon").click();
+      clickUnsubscribe();
 
       modal().within(() => {
         cy.findByText("Confirm you want to unsubscribe");
@@ -123,7 +123,7 @@ describe("scenarios > account > notifications", () => {
       cy.visit("/account/notifications");
 
       cy.findByText("Question");
-      cy.findByLabelText("close icon").click();
+      clickUnsubscribe();
 
       modal().within(() => {
         cy.findByText("Confirm you want to unsubscribe");
@@ -170,7 +170,7 @@ describe("scenarios > account > notifications", () => {
       cy.visit("/account/notifications");
 
       cy.findByText("Subscription");
-      cy.findByLabelText("close icon").click();
+      clickUnsubscribe();
 
       modal().within(() => {
         cy.findByText("Delete this subscription?");
@@ -181,3 +181,9 @@ describe("scenarios > account > notifications", () => {
     });
   });
 });
+
+function clickUnsubscribe() {
+  cy.findByTestId("notifications-list").within(() => {
+    cy.findByLabelText("close icon").click();
+  });
+}

--- a/frontend/test/metabase/scenarios/onboarding/search/search-typehead.cy.spec.js
+++ b/frontend/test/metabase/scenarios/onboarding/search/search-typehead.cy.spec.js
@@ -16,10 +16,12 @@ import { USERS } from "__support__/e2e/cypress_data";
 
       cy.findByPlaceholderText("Search…").type("pers");
       cy.findByTestId("loading-spinner").should("not.exist");
-      cy.findAllByText(/personal collection$/i).should(
-        "have.length",
-        personalCollectionsLength,
-      );
+      cy.findByTestId("search-results-list").within(() => {
+        cy.findAllByText(/personal collection$/i).should(
+          "have.length",
+          personalCollectionsLength,
+        );
+      });
     });
   });
 });

--- a/frontend/test/metabase/scenarios/question/reproductions/18978-18977-nested-question-nodata-user.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/18978-18977-nested-question-nodata-user.cy.spec.js
@@ -1,4 +1,9 @@
-import { restore, popover, visitQuestion } from "__support__/e2e/cypress";
+import {
+  restore,
+  popover,
+  openNavigationSidebar,
+  visitQuestion,
+} from "__support__/e2e/cypress";
 
 describe("18978, 18977", () => {
   beforeEach(() => {
@@ -14,11 +19,10 @@ describe("18978, 18977", () => {
     }).then(({ body: { id } }) => {
       cy.signIn("nodata");
       visitQuestion(id);
+      openNavigationSidebar();
 
-      cy.get(".Nav").within(() => {
-        cy.findByText(/Browse data/i).should("not.exist");
-        cy.icon("add").click();
-      });
+      cy.findByText(/Browse data/i).should("not.exist");
+      cy.icon("add").click();
 
       popover().within(() => {
         cy.findByText("Question").should("not.exist");

--- a/frontend/test/metabase/scenarios/question/reproductions/9027-new-questions-not-in-saved-questions-immediately.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/9027-new-questions-not-in-saved-questions-immediately.cy.spec.js
@@ -3,6 +3,8 @@ import {
   popover,
   openNativeEditor,
   openNotebookEditor,
+  openNavigationSidebar,
+  navigationSidebar,
 } from "__support__/e2e/cypress";
 
 const QUESTION_NAME = "Foo";
@@ -29,6 +31,7 @@ describe("issue 9027", () => {
 
   it("should display newly saved question in the 'Saved Questions' list immediately (metabase#9027)", () => {
     goToSavedQuestionPickerAndAssertQuestion(QUESTION_NAME);
+    openNavigationSidebar();
     archiveQuestion(QUESTION_NAME);
     goToSavedQuestionPickerAndAssertQuestion(QUESTION_NAME, false);
     unarchiveQuestion(QUESTION_NAME);
@@ -55,8 +58,9 @@ function saveQuestion(name) {
 }
 
 function archiveQuestion(questionName) {
-  cy.findByTestId("main-logo").click();
-  cy.findByText("Browse all items").click();
+  navigationSidebar()
+    .findByText("Our analytics")
+    .click();
   openEllipsisMenuFor(questionName);
   popover()
     .findByText("Archive")
@@ -64,8 +68,9 @@ function archiveQuestion(questionName) {
 }
 
 function unarchiveQuestion(questionName) {
-  cy.findByTestId("main-logo").click();
-  cy.findByText("Browse all items").click();
+  navigationSidebar()
+    .findByText("Our analytics")
+    .click();
   // Button is covered with an undo toast
   cy.findByText("View archive").click({ force: true });
   cy.findByText(questionName)

--- a/frontend/test/metabase/scenarios/question/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/settings.cy.spec.js
@@ -2,6 +2,7 @@ import {
   browse,
   restore,
   openOrdersTable,
+  openNavigationSidebar,
   visitQuestionAdhoc,
   popover,
   sidebar,
@@ -214,6 +215,7 @@ describe("scenarios > question > settings", () => {
       cy.contains("Orders in a dashboard").click();
 
       // create a new question to see if the "add to a dashboard" modal is still there
+      openNavigationSidebar();
       browse().click();
       cy.contains("Sample Database").click();
       cy.contains("Orders").click();

--- a/frontend/test/metabase/scenarios/smoketest/user.cy.spec.js
+++ b/frontend/test/metabase/scenarios/smoketest/user.cy.spec.js
@@ -3,6 +3,7 @@ import {
   sidebar,
   popover,
   visualize,
+  closeNavigationSidebar,
   openNotebookEditor,
   summarize,
 } from "__support__/e2e/cypress";
@@ -157,6 +158,7 @@ describe("smoketest > user", () => {
   it("should summarize via both the sidebar and notebook editor", () => {
     // Sidebar summary
 
+    closeNavigationSidebar();
     summarize();
     cy.findByText("Category").click();
     cy.findByText("Done").click();


### PR DESCRIPTION
This PR fixes most of the failing E2E tests caused by changes in core Metabase navigation (sidebar). There is one more visual test failing (checking sticky dashboard filters) and it's supposed to be fixed by #21233 (#21226 has to be merged first). After these three PRs are merged the CI for the new nav branch will become green 🙌 

Most of the tests fail because of the following reasons:

* some parts of the UI became invisible with an open sidebar. These are fixed by adding code that hides the sidebar before doing any assertions on the UI
* tests perform single element queries (like `findByText`), but now fail because the page now has multiple elements matching the query. Most of these happen when trying to do something with a collection name. Since the new sidebar is present on every page, the collections are also present in the DOM and queries like `findByText("Our analytics")` now fail. Fixed by updating UI queries to be more scoped (e.g. look for "Our analytics" in the QB header component instead of the whole page)
* `sidebar()` UI helper fails because there is now a new sidebar tag in the DOM all the time. Fixed by updating the `sidebar` helper to look for a sidebar tag inside `main` HTML tag (`main` doesn't contain the new sidebar component). On the other hand, the PR adds the `navigationSidebar` UI helper to retrieve the new sidebar. Because of this, had to replace `sidebar()` with `navigationSidebar()` almost anywhere in the collections E2E tests since there is no "collection sidebar" anymore.