### PR TITLE
Admin E2E tests: guard assertions with element visibility check

### DIFF
--- a/frontend/test/metabase/scenarios/admin/settings/localization.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/localization.cy.spec.js
@@ -177,12 +177,17 @@ describe("scenarios > admin > localization", () => {
 
     visitQuestion(1);
     cy.findByTestId("loading-spinner").should("not.exist");
+    cy.findByTextEnsureVisible("Product ID");
 
     // create a date filter and set it to the 'On' view to see a specific date
     cy.findByText("Created At").click();
     cy.findByText("Filter by this column").click();
     cy.findByText("Previous").click();
     cy.findByText("On").click();
+
+    // ensure the date picker is ready
+    cy.findByTextEnsureVisible("Add a time");
+    cy.findByTextEnsureVisible("Update filter");
 
     // update the date input in the widget
     const date = new Date();

--- a/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
@@ -181,6 +181,7 @@ describe("scenarios > admin > settings", () => {
 
     openOrdersTable({ limit: 2 });
 
+    cy.findByTextEnsureVisible("Created At");
     cy.get(".cellData")
       .should("contain", "Created At")
       .and("contain", "2019/2/11, 21:40");
@@ -193,6 +194,7 @@ describe("scenarios > admin > settings", () => {
 
     openOrdersTable({ limit: 2 });
 
+    cy.findByTextEnsureVisible("Created At");
     cy.get(".cellData").and("contain", "2019/2/11, 9:40 PM");
   });
 


### PR DESCRIPTION
### Before this PR

Some tests in `frontend/test/metabase/scenarios/admin` occasionally failed because they did not wait until table view was fully constructed.

### After this PR

Should not happen anymore.