### PR TITLE
E2E repro 17514: another element visibility check before assert

### DIFF
--- a/frontend/test/metabase/scenarios/question/reproductions/17514-ui-overlay.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/17514-ui-overlay.cy.spec.js
@@ -119,6 +119,7 @@ describe("issue 17514", () => {
       removeJoinedTable();
 
       visualize();
+      cy.findByTextEnsureVisible("Subtotal");
 
       cy.findByText("Save").click();
 
@@ -134,6 +135,7 @@ describe("issue 17514", () => {
       cy.findByText("Products").click();
 
       visualize();
+      cy.findByTextEnsureVisible("Subtotal");
 
       // Cypress cannot click elements that are blocked by an overlay so this will immediately fail if the issue is not fixed
       cy.findByText("110.93").click();


### PR DESCRIPTION
### Before this PR

I missed one check in the previous PR #21121, therefore this one failed randomly:

![issue 17514 -- scenario 2 -- should not show the run overlay because ofth references to the orphaned fields (metabase#17514-1) (failed)](https://user-images.githubusercontent.com/7288/159944458-c42c230a-8e16-4279-99bd-5aa29531e100.png)


### After this PR

Fail no more.