### PR TITLE
Default Icon for Timelines / Events and Root Collection Hydration

### DIFF
--- a/src/metabase/api/timeline.clj
+++ b/src/metabase/api/timeline.clj
@@ -3,7 +3,7 @@
   (:require [compojure.core :refer [DELETE GET POST PUT]]
             [metabase.api.common :as api]
             [metabase.models.collection :as collection]
-            [metabase.models.timeline :refer [Timeline]]
+            [metabase.models.timeline :as timeline :refer [Timeline]]
             [metabase.models.timeline-event :as timeline-event :refer [TimelineEvent]]
             [metabase.util :as u]
             [metabase.util.date-2 :as u.date]
@@ -21,7 +21,7 @@
   [:as {{:keys [name description icon collection_id archived], :as body} :body}]
   {name          su/NonBlankString
    description   (s/maybe s/Str)
-   icon          (s/maybe timeline-event/Icons)
+   icon          (s/maybe timeline/Icons)
    collection_id (s/maybe su/IntGreaterThanZero)
    archived      (s/maybe s/Bool)}
   (collection/check-write-perms-for-collection collection_id)
@@ -29,7 +29,7 @@
             body
             {:creator_id api/*current-user-id*}
             (when-not icon
-              {:icon timeline-event/DefaultIcon}))]
+              {:icon timeline/DefaultIcon}))]
     (db/insert! Timeline tl)))
 
 (api/defendpoint GET "/"
@@ -65,7 +65,7 @@
   [id :as {{:keys [name description icon collection_id archived] :as timeline-updates} :body}]
   {name          (s/maybe su/NonBlankString)
    description   (s/maybe s/Str)
-   icon          (s/maybe timeline-event/Icons)
+   icon          (s/maybe timeline/Icons)
    collection_id (s/maybe su/IntGreaterThanZero)
    archived      (s/maybe s/Bool)}
   (let [existing (api/write-check Timeline id)

--- a/src/metabase/api/timeline.clj
+++ b/src/metabase/api/timeline.clj
@@ -25,7 +25,12 @@
    collection_id (s/maybe su/IntGreaterThanZero)
    archived      (s/maybe s/Bool)}
   (collection/check-write-perms-for-collection collection_id)
-  (db/insert! Timeline (assoc body :creator_id api/*current-user-id*)))
+  (let [tl (merge
+            body
+            {:creator_id api/*current-user-id*}
+            (when-not icon
+              {:icon timeline-event/DefaultIcon}))]
+    (db/insert! Timeline tl)))
 
 (api/defendpoint GET "/"
   "Fetch a list of [[Timelines]]. Can include `archived=true` to return archived timelines."

--- a/src/metabase/api/timeline.clj
+++ b/src/metabase/api/timeline.clj
@@ -32,17 +32,6 @@
               {:icon timeline/DefaultIcon}))]
     (db/insert! Timeline tl)))
 
-(api/defendpoint GET "/"
-  "Fetch a list of [[Timelines]]. Can include `archived=true` to return archived timelines."
-  [include archived]
-  {include (s/maybe Include)
-   archived (s/maybe su/BooleanString)}
-  (let [archived? (Boolean/parseBoolean archived)
-        timelines (db/select Timeline [:where [:= :archived archived?]])]
-    (cond->> (hydrate timelines :creator :collection)
-      (= include "events")
-      (map #(timeline-event/include-events-singular % {:events/all?  archived?})))))
-
 ;; todo: should this fn move into `metabase.model.collection`?
 ;; a nearly identical fn exists in `metabase.api.collection`
 (defn- root-collection
@@ -50,6 +39,21 @@
   (-> (collection/root-collection-with-ui-details nil)
       collection/personal-collection-with-ui-details
       (hydrate :parent_id :effective_location [:effective_ancestors :can_write] :can_write)))
+
+(api/defendpoint GET "/"
+  "Fetch a list of [[Timelines]]. Can include `archived=true` to return archived timelines."
+  [include archived]
+  {include (s/maybe Include)
+   archived (s/maybe su/BooleanString)}
+  (let [archived? (Boolean/parseBoolean archived)
+        hydrate-root-collection (fn [tl]
+                                  (if (nil? (:collection_id tl))
+                                    (assoc tl :collection (root-collection))
+                                    tl))
+        timelines (map hydrate-root-collection (db/select Timeline [:where [:= :archived archived?]]))]
+    (cond->> (hydrate timelines :creator :collection)
+      (= include "events")
+      (map #(timeline-event/include-events-singular % {:events/all?  archived?})))))
 
 (api/defendpoint GET "/:id"
   "Fetch the [[Timeline]] with `id`. Include `include=events` to unarchived events included on the timeline. Add

--- a/src/metabase/api/timeline_event.clj
+++ b/src/metabase/api/timeline_event.clj
@@ -4,7 +4,7 @@
             [metabase.analytics.snowplow :as snowplow]
             [metabase.api.common :as api]
             [metabase.models.collection :as collection]
-            [metabase.models.timeline :refer [Timeline]]
+            [metabase.models.timeline :as timeline :refer [Timeline]]
             [metabase.models.timeline-event :as timeline-event :refer [TimelineEvent]]
             [metabase.util :as u]
             [metabase.util.date-2 :as u.date]
@@ -21,7 +21,7 @@
    timestamp    su/TemporalString
    time_matters (s/maybe s/Bool)
    timezone     s/Str
-   icon         (s/maybe timeline-event/Icons)
+   icon         (s/maybe timeline/Icons)
    timeline_id  su/IntGreaterThanZero
    source       (s/maybe timeline-event/Sources)
    question_id  (s/maybe su/IntGreaterThanZero)
@@ -63,7 +63,7 @@
    timestamp    (s/maybe su/TemporalString)
    time_matters (s/maybe s/Bool)
    timezone     (s/maybe s/Str)
-   icon         (s/maybe timeline-event/Icons)
+   icon         (s/maybe timeline/Icons)
    timeline_id  (s/maybe su/IntGreaterThanZero)
    archived     (s/maybe s/Bool)}
   (let [existing (api/write-check TimelineEvent id)

--- a/src/metabase/models/timeline.clj
+++ b/src/metabase/models/timeline.clj
@@ -9,6 +9,16 @@
 
 (models/defmodel Timeline :timeline)
 
+;;;; schemas
+
+(def Icons
+  "Timeline and TimelineEvent icon string Schema"
+  (s/enum "star" "balloons" "mail" "warning" "bell" "cloud"))
+
+(def DefaultIcon
+  "Timeline default icon"
+  "star")
+
 ;;;; functions
 
 (defn timelines-for-collection

--- a/src/metabase/models/timeline.clj
+++ b/src/metabase/models/timeline.clj
@@ -3,6 +3,7 @@
             [metabase.models.permissions :as perms]
             [metabase.models.timeline-event :as timeline-event]
             [metabase.util :as u]
+            [schema.core :as s]
             [toucan.db :as db]
             [toucan.hydrate :refer [hydrate]]
             [toucan.models :as models]))

--- a/src/metabase/models/timeline_event.clj
+++ b/src/metabase/models/timeline_event.clj
@@ -11,16 +11,10 @@
 
 ;;;; schemas
 
-(def Icons
-  "Timeline and TimelineEvent icon string Schema"
-  (s/enum "star" "balloons" "mail" "warning" "bell" "cloud"))
-
 (def Sources
   "Timeline Event Source Schema. For Snowplow Events, where the Event is created from is important.
   Events are added from one of three sources: `collections`, `questions` (cards in backend code), or directly with an API call. An API call is indicated by having no source key in the `timeline-event` request."
   (s/enum "collections" "question"))
-
-(def DefaultIcon "star")
 
 ;;;; permissions
 

--- a/src/metabase/models/timeline_event.clj
+++ b/src/metabase/models/timeline_event.clj
@@ -20,6 +20,8 @@
   Events are added from one of three sources: `collections`, `questions` (cards in backend code), or directly with an API call. An API call is indicated by having no source key in the `timeline-event` request."
   (s/enum "collections" "question"))
 
+(def DefaultIcon "star")
+
 ;;;; permissions
 
 (defn- perms-objects-set

--- a/test/metabase/api/timeline_test.clj
+++ b/test/metabase/api/timeline_test.clj
@@ -50,6 +50,10 @@
         (is (= "Timeline A"
                (->> (mt/user-http-request :rasta :get 200 (str "timeline/" (u/the-id tl-a)))
                     :name))))
+      (testing "check that we hydrate the timeline's `:collection` key"
+        (is (= "root"
+               (-> (mt/user-http-request :rasta :get 200 (str "timeline/" (u/the-id tl-a)))
+                   (get-in [:collection :id])))))
       (testing "check that we get the timeline with the id specified, even if the timeline is archived"
         (is (= "Timeline B"
                (->> (mt/user-http-request :rasta :get 200 (str "timeline/" (u/the-id tl-b)))
@@ -117,9 +121,12 @@
                                   {:name          "Rasta's TL"
                                    :creator_id    (u/the-id (mt/fetch-user :rasta))
                                    :collection_id id})
-            ;; check the collection to see if the timeline is there
-            (is (= "Rasta's TL"
-                   (-> (db/select-one Timeline :collection_id id) :name)))))))))
+            (testing "check the collection to see if the timeline is there"
+              (is (= "Rasta's TL"
+                     (-> (db/select-one Timeline :collection_id id) :name))))
+            (testing "Check that the icon is 'star' by default"
+              (is (= "star"
+                     (-> (db/select-one-field :icon Timeline :collection_id id)))))))))))
 
 (deftest update-timeline-test
   (testing "PUT /api/timeline/:id"


### PR DESCRIPTION
Epic: #20289 

## Hydration of :collection when the Timeline is on the /root collection

The hydration mechanism for collections works when the collection_id is not nil, but otherwise doesn't provide the needed information. A root-collection function lets the endpoint provide the needed data now.

## Default Icons for Timelines

There was a discussion on Slack regarding intended behaviour with icons for Timelines and Timeline Events. 'Default Icon' has at least 2 ways of looking at it:

1. The Default icon is displayed _when no icon was specified by the user_, which is saved in the app-db by allowing 'null' icon value. That is, we would happily accept 'null' as a valid icon, and the Frontend would then display an event's icon with the following logic: `event.icon || timeline.icon || "star"`. The backend would not have to care about defaults in this case. This would mean that if a user changes a timeline's icon later on, all events without their own icons set would then have that new default icon.

2. The Default icon to use as each event's icon. That is, a Timeline has a default icon (saved explicitly by the backend at the POST endpoint), and all events created on that timeline will _also_ by default save their icon as that default. So, if a user creates a Timeline without setting an icon, the default icon is saved to the app-db as "star". Then, if a few events are created, they will also have "star" as their icon. Supposing a user then alters the Timeline's icon to "balloons", all existing events _will not change_ their icons, but all **new events** will have their icon saved as "balloons".

In both cases, if the icon is explicitly set by the user, that value is respected.

**We are using option 2.**
This behaviour is already essentially how the frontend works: FE always explicitly sets the value for "icon" to "star" if the user didn't change anything (think of a drop-down menu that has its first item selected as the value if you don't open it to pick your own). The events for that timeline then have a default icon derived from that Timeline's icon. The backend will always receive values for "icon" from the frontend. We just want to make the API usage mirror this behaviour.

### How the Backend works with icons
The `DefaultIcon` in `metabase.models.timeline` is set to "star". Any time a new timeline is created via the `POST /api/timeline` endpoint, if "icon" exists in the request, use that value (or error if it's not valid according to the `Icons` spec) otherwise merge `{:icon "star"}` into the data and save to the db.

Any time a timeline-event is created via the `POST /api/timeline-event` endpoint, use "icon" if provided, otherwise `(db/select-one-field :icon Timeline :id timeline_id)` is used to get the Timeline's icon and save the event to the db with that as the icon value.