### PR TITLE
Toggle bookmarks list visibility

### DIFF
--- a/frontend/src/metabase/collections/components/CollectionSidebar/Bookmarks/Bookmarks.tsx
+++ b/frontend/src/metabase/collections/components/CollectionSidebar/Bookmarks/Bookmarks.tsx
@@ -61,9 +61,7 @@ const CollectionSidebarBookmarks = ({
   };
 
   const toggleBookmarkListVisibility = () => {
-    const booleanForLocalStorage = new Boolean(
-      !shouldDisplayBookmarks,
-    ).toString();
+    const booleanForLocalStorage = (!shouldDisplayBookmarks).toString();
     localStorage.setItem("shouldDisplayBookmarks", booleanForLocalStorage);
 
     setShouldDisplayBookmarks(!shouldDisplayBookmarks);

--- a/frontend/src/metabase/collections/components/CollectionSidebar/Bookmarks/Bookmarks.tsx
+++ b/frontend/src/metabase/collections/components/CollectionSidebar/Bookmarks/Bookmarks.tsx
@@ -14,7 +14,10 @@ import BookmarksRoot, {
   BookmarkTypeIcon,
 } from "./Bookmarks.styled";
 
-import { SidebarHeading } from "metabase/collections/components/CollectionSidebar/CollectionSidebar.styled";
+import {
+  SidebarHeading,
+  ToggleListDisplayButton,
+} from "metabase/collections/components/CollectionSidebar/CollectionSidebar.styled";
 
 import { Bookmark, BookmarkableEntities, Bookmarks } from "metabase-types/api";
 
@@ -43,7 +46,11 @@ const CollectionSidebarBookmarks = ({
   bookmarks,
   deleteBookmark,
 }: CollectionSidebarBookmarksProps) => {
-  const [shouldDisplayBookmarks, setShouldDisplayBookmarks] = useState(true);
+  const storedShouldDisplayBookmarks =
+    localStorage.getItem("shouldDisplayBookmarks") !== "false";
+  const [shouldDisplayBookmarks, setShouldDisplayBookmarks] = useState(
+    storedShouldDisplayBookmarks,
+  );
 
   if (bookmarks.length === 0) {
     return null;
@@ -54,13 +61,23 @@ const CollectionSidebarBookmarks = ({
   };
 
   const toggleBookmarkListVisibility = () => {
+    const booleanForLocalStorage = new Boolean(
+      !shouldDisplayBookmarks,
+    ).toString();
+    localStorage.setItem("shouldDisplayBookmarks", booleanForLocalStorage);
+
     setShouldDisplayBookmarks(!shouldDisplayBookmarks);
   };
 
   return (
     <BookmarksRoot>
       <SidebarHeading onClick={toggleBookmarkListVisibility}>
-        {t`Bookmarks`}
+        {t`Bookmarks`}{" "}
+        <ToggleListDisplayButton
+          name="play"
+          shouldDisplayBookmarks={shouldDisplayBookmarks}
+          size="8"
+        />
       </SidebarHeading>
 
       {shouldDisplayBookmarks && (
@@ -68,11 +85,13 @@ const CollectionSidebarBookmarks = ({
           {bookmarks.map((bookmark, index) => {
             const { id, name, type } = bookmark;
             const url = Urls.bookmark({ id, name, type });
+
             return (
               <BookmarkContainer key={`bookmark-${id}`}>
                 <Link to={url}>
                   <Label name={name} type={type} />
                 </Link>
+
                 <button onClick={() => handleDeleteBookmark(bookmark)}>
                   <Tooltip tooltip={t`Remove bookmark`} placement="bottom">
                     <Icon name="bookmark" />

--- a/frontend/src/metabase/collections/components/CollectionSidebar/Bookmarks/Bookmarks.tsx
+++ b/frontend/src/metabase/collections/components/CollectionSidebar/Bookmarks/Bookmarks.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { t } from "ttag";
 
 import * as Urls from "metabase/lib/urls";
@@ -43,6 +43,8 @@ const CollectionSidebarBookmarks = ({
   bookmarks,
   deleteBookmark,
 }: CollectionSidebarBookmarksProps) => {
+  const [shouldDisplayBookmarks, setShouldDisplayBookmarks] = useState(true);
+
   if (bookmarks.length === 0) {
     return null;
   }
@@ -51,28 +53,36 @@ const CollectionSidebarBookmarks = ({
     deleteBookmark(id.toString(), type);
   };
 
+  const toggleBookmarkListVisibility = () => {
+    setShouldDisplayBookmarks(!shouldDisplayBookmarks);
+  };
+
   return (
     <BookmarksRoot>
-      <SidebarHeading>{t`Bookmarks`}</SidebarHeading>
+      <SidebarHeading onClick={toggleBookmarkListVisibility}>
+        {t`Bookmarks`}
+      </SidebarHeading>
 
-      <BookmarkListRoot>
-        {bookmarks.map((bookmark, index) => {
-          const { id, name, type, display } = bookmark;
-          const url = Urls.bookmark({ id, name, type });
-          return (
-            <BookmarkContainer key={`bookmark-${id}`}>
-              <Link to={url}>
-                <Label name={name} type={type} display={display} />
-              </Link>
-              <button onClick={() => handleDeleteBookmark(bookmark)}>
-                <Tooltip tooltip={t`Remove bookmark`} placement="bottom">
-                  <Icon name="bookmark" />
-                </Tooltip>
-              </button>
-            </BookmarkContainer>
-          );
-        })}
-      </BookmarkListRoot>
+      {shouldDisplayBookmarks && (
+        <BookmarkListRoot>
+          {bookmarks.map((bookmark, index) => {
+            const { id, name, type } = bookmark;
+            const url = Urls.bookmark({ id, name, type });
+            return (
+              <BookmarkContainer key={`bookmark-${id}`}>
+                <Link to={url}>
+                  <Label name={name} type={type} />
+                </Link>
+                <button onClick={() => handleDeleteBookmark(bookmark)}>
+                  <Tooltip tooltip={t`Remove bookmark`} placement="bottom">
+                    <Icon name="bookmark" />
+                  </Tooltip>
+                </button>
+              </BookmarkContainer>
+            );
+          })}
+        </BookmarkListRoot>
+      )}
     </BookmarksRoot>
   );
 };

--- a/frontend/src/metabase/collections/components/CollectionSidebar/CollectionSidebar.styled.jsx
+++ b/frontend/src/metabase/collections/components/CollectionSidebar/CollectionSidebar.styled.jsx
@@ -55,6 +55,13 @@ export const SidebarHeading = styled.h4`
   font-weight: 700;
   margin-left: ${space(3)};
   text-transform: uppercase;
+  user-select: none;
+
+  ${({ onClick }) =>
+    onClick &&
+    css`
+      cursor: pointer;
+    `};
 `;
 
 export const ToggleMobileSidebarIcon = styled(Icon)`

--- a/frontend/src/metabase/collections/components/CollectionSidebar/CollectionSidebar.styled.jsx
+++ b/frontend/src/metabase/collections/components/CollectionSidebar/CollectionSidebar.styled.jsx
@@ -32,8 +32,8 @@ export const Sidebar = styled.aside`
   width: 0;
   background-color: ${color("white")};
 
-  ${props =>
-    props.shouldDisplayMobileSidebar &&
+  ${({ shouldDisplayMobileSidebar }) =>
+    shouldDisplayMobileSidebar &&
     css`
       box-shadow: 5px 0px 8px rgba(0, 0, 0, 0.35),
         40px 0px rgba(5, 14, 31, 0.32);
@@ -62,6 +62,17 @@ export const SidebarHeading = styled.h4`
     css`
       cursor: pointer;
     `};
+`;
+
+export const ToggleListDisplayButton = styled(Icon)`
+  margin-left: ${space(2)};
+  transform: translate(0px, -1px);
+
+  ${({ shouldDisplayBookmarks }) =>
+    shouldDisplayBookmarks &&
+    css`
+      transform: rotate(90deg);
+    `}
 `;
 
 export const ToggleMobileSidebarIcon = styled(Icon)`

--- a/frontend/src/metabase/collections/components/CollectionSidebar/CollectionSidebar.styled.jsx
+++ b/frontend/src/metabase/collections/components/CollectionSidebar/CollectionSidebar.styled.jsx
@@ -71,7 +71,7 @@ export const ToggleListDisplayButton = styled(Icon)`
   ${({ shouldDisplayBookmarks }) =>
     shouldDisplayBookmarks &&
     css`
-      transform: rotate(90deg);
+      transform: rotate(90deg) translate(-1px, -1px);
     `}
 `;
 

--- a/frontend/src/metabase/collections/components/CollectionSidebar/CollectionSidebar.styled.jsx
+++ b/frontend/src/metabase/collections/components/CollectionSidebar/CollectionSidebar.styled.jsx
@@ -65,7 +65,7 @@ export const SidebarHeading = styled.h4`
 `;
 
 export const ToggleListDisplayButton = styled(Icon)`
-  margin-left: ${space(2)};
+  margin-left: 12px;
   transform: translate(0px, -1px);
 
   ${({ shouldDisplayBookmarks }) =>

--- a/frontend/src/metabase/collections/components/CollectionSidebar/CollectionSidebar.styled.jsx
+++ b/frontend/src/metabase/collections/components/CollectionSidebar/CollectionSidebar.styled.jsx
@@ -52,10 +52,16 @@ export const Sidebar = styled.aside`
 
 export const SidebarHeading = styled.h4`
   color: ${color("text-medium")};
+  font-size: 12px;
+  letter-spacing: 0.5px;
   font-weight: 700;
   margin-left: ${space(3)};
   text-transform: uppercase;
   user-select: none;
+
+  &:hover {
+    color: ${color("text-dark")};
+  }
 
   ${({ onClick }) =>
     onClick &&
@@ -65,7 +71,7 @@ export const SidebarHeading = styled.h4`
 `;
 
 export const ToggleListDisplayButton = styled(Icon)`
-  margin-left: 12px;
+  margin-left: 4px;
   transform: translate(0px, -1px);
 
   ${({ shouldDisplayBookmarks }) =>

--- a/frontend/src/metabase/collections/components/CollectionSidebar/CollectionSidebar.styled.tsx
+++ b/frontend/src/metabase/collections/components/CollectionSidebar/CollectionSidebar.styled.tsx
@@ -18,7 +18,11 @@ export const LoadingTitle = styled.h2`
   margin-top: ${space(1)};
 `;
 
-export const Sidebar = styled.aside`
+interface SidebarProps {
+  shouldDisplayMobileSidebar: boolean;
+}
+
+export const Sidebar = styled.aside<SidebarProps>`
   bottom: 0;
   display: flex;
   box-sizing: border-box;
@@ -70,8 +74,19 @@ export const SidebarHeading = styled.h4`
     `};
 `;
 
+<<<<<<< HEAD:frontend/src/metabase/collections/components/CollectionSidebar/CollectionSidebar.styled.jsx
 export const ToggleListDisplayButton = styled(Icon)`
   margin-left: 4px;
+=======
+interface ToggleListDisplayButtonProps {
+  shouldDisplayBookmarks: boolean;
+}
+
+export const ToggleListDisplayButton = styled(Icon)<
+  ToggleListDisplayButtonProps
+>`
+  margin-left: 12px;
+>>>>>>> cfd4786d55 (Convert file to TypeScript):frontend/src/metabase/collections/components/CollectionSidebar/CollectionSidebar.styled.tsx
   transform: translate(0px, -1px);
 
   ${({ shouldDisplayBookmarks }) =>

--- a/frontend/src/metabase/collections/components/CollectionSidebar/CollectionSidebar.styled.tsx
+++ b/frontend/src/metabase/collections/components/CollectionSidebar/CollectionSidebar.styled.tsx
@@ -57,27 +57,23 @@ export const Sidebar = styled.aside<SidebarProps>`
 export const SidebarHeading = styled.h4`
   color: ${color("text-medium")};
   font-size: 12px;
-  letter-spacing: 0.5px;
   font-weight: 700;
+  letter-spacing: 0.5px;
   margin-left: ${space(3)};
   text-transform: uppercase;
   user-select: none;
-
-  &:hover {
-    color: ${color("text-dark")};
-  }
 
   ${({ onClick }) =>
     onClick &&
     css`
       cursor: pointer;
+
+      &:hover {
+        color: ${color("text-dark")};
+      }
     `};
 `;
 
-<<<<<<< HEAD:frontend/src/metabase/collections/components/CollectionSidebar/CollectionSidebar.styled.jsx
-export const ToggleListDisplayButton = styled(Icon)`
-  margin-left: 4px;
-=======
 interface ToggleListDisplayButtonProps {
   shouldDisplayBookmarks: boolean;
 }
@@ -85,8 +81,7 @@ interface ToggleListDisplayButtonProps {
 export const ToggleListDisplayButton = styled(Icon)<
   ToggleListDisplayButtonProps
 >`
-  margin-left: 12px;
->>>>>>> cfd4786d55 (Convert file to TypeScript):frontend/src/metabase/collections/components/CollectionSidebar/CollectionSidebar.styled.tsx
+  margin-left: 4px;
   transform: translate(0px, -1px);
 
   ${({ shouldDisplayBookmarks }) =>

--- a/frontend/test/__support__/e2e/helpers/e2e-collection-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-collection-helpers.js
@@ -20,5 +20,6 @@ export function openNewCollectionItemFlowFor(type) {
 }
 
 export function getSidebarSectionTitle(title) {
-  return cy.findAllByRole("heading", { name: title });
+  const name = new RegExp(title);
+  return cy.findAllByRole("heading", { name });
 }

--- a/frontend/test/__support__/e2e/helpers/e2e-collection-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-collection-helpers.js
@@ -19,7 +19,6 @@ export function openNewCollectionItemFlowFor(type) {
     .click();
 }
 
-export function getSidebarSectionTitle(title) {
-  const name = new RegExp(title);
+export function getSidebarSectionTitle(name) {
   return cy.findAllByRole("heading", { name });
 }

--- a/frontend/test/metabase-visual/collections/bookmarks.cy.spec.js
+++ b/frontend/test/metabase-visual/collections/bookmarks.cy.spec.js
@@ -17,7 +17,7 @@ describe("Bookmarks in a collection page", () => {
     cy.visit("/collection/1");
 
     sidebar().within(() => {
-      getSectionTitle("Bookmarks");
+      getSectionTitle(/Bookmarks/);
     });
 
     cy.percySnapshot();

--- a/frontend/test/metabase/scenarios/collections/bookmarks.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/bookmarks.cy.spec.js
@@ -31,7 +31,7 @@ describe("Bookmarks in a collection page", () => {
     cy.icon("bookmark").click();
 
     sidebar().within(() => {
-      getSectionTitle("Bookmarks");
+      getSectionTitle(/Bookmarks/);
       cy.findByText(adminPersonalCollectionName);
 
       // Once there is a list of bookmarks,
@@ -47,7 +47,7 @@ describe("Bookmarks in a collection page", () => {
     sidebar().within(() => {
       cy.findByText(adminPersonalCollectionName).should("not.exist");
 
-      getSectionTitle("Bookmarks").should("not.exist");
+      getSectionTitle(/Bookmarks/).should("not.exist");
 
       // Once there is no list of bookmarks,
       // we remove the heading for the list of collections
@@ -73,7 +73,7 @@ describe("Bookmarks in a collection page", () => {
       cy.icon("bookmark").click({ force: true });
     });
 
-    getSectionTitle("Bookmarks").should("not.exist");
+    getSectionTitle(/Bookmarks/).should("not.exist");
   });
 
   it("can toggle bookmark list visibility", () => {
@@ -83,11 +83,11 @@ describe("Bookmarks in a collection page", () => {
     cy.icon("bookmark").click();
 
     sidebar().within(() => {
-      getSectionTitle("Bookmarks").click();
+      getSectionTitle(/Bookmarks/).click();
 
       cy.findByText(adminPersonalCollectionName).should("not.exist");
 
-      getSectionTitle("Bookmarks").click();
+      getSectionTitle(/Bookmarks/).click();
 
       cy.findByText(adminPersonalCollectionName);
     });
@@ -101,7 +101,7 @@ function addThenRemoveBookmarkTo(itemName) {
   cy.findByText("Bookmark").click();
 
   sidebar().within(() => {
-    getSectionTitle("Bookmarks");
+    getSectionTitle(/Bookmarks/);
     cy.findByText(itemName);
   });
 
@@ -110,7 +110,7 @@ function addThenRemoveBookmarkTo(itemName) {
   cy.findByText("Remove bookmark").click();
 
   sidebar().within(() => {
-    getSectionTitle("Bookmarks").should("not.exist");
+    getSectionTitle(/Bookmarks/).should("not.exist");
     cy.findByText(itemName).should("not.exist");
   });
 }

--- a/frontend/test/metabase/scenarios/collections/bookmarks.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/bookmarks.cy.spec.js
@@ -75,6 +75,23 @@ describe("Bookmarks in a collection page", () => {
 
     getSectionTitle("Bookmarks").should("not.exist");
   });
+
+  it("can toggle bookmark list visibility", () => {
+    cy.visit("/collection/1");
+
+    // Add bookmark
+    cy.icon("bookmark").click();
+
+    sidebar().within(() => {
+      getSectionTitle("Bookmarks").click();
+
+      cy.findByText(adminPersonalCollectionName).should("not.exist");
+
+      getSectionTitle("Bookmarks").click();
+
+      cy.findByText(adminPersonalCollectionName);
+    });
+  });
 });
 
 function addThenRemoveBookmarkTo(itemName) {

--- a/frontend/test/metabase/scenarios/question/bookmarks.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/bookmarks.cy.spec.js
@@ -14,7 +14,7 @@ describe("scenarios > question > bookmarks", () => {
     cy.visit("/collection/root");
 
     sidebar().within(() => {
-      getSectionTitle("Bookmarks");
+      getSectionTitle(/Bookmarks/);
       cy.findByText("Orders");
     });
 
@@ -29,7 +29,7 @@ describe("scenarios > question > bookmarks", () => {
 
     cy.wait("@fetchRootCollectionItems");
 
-    getSectionTitle("Bookmarks").should("not.exist");
+    getSectionTitle(/Bookmarks/).should("not.exist");
   });
 });
 


### PR DESCRIPTION
### How to Test

1. Add one or more bookmarks.
2. Go to a collection page
3. On the left sidebar, click on the `Bookmarks` heading

This should toggle the visibility of the bookmarks list.

State should be preserved if you reload the page on the same browser.

<img width="500" alt="image" src="https://user-images.githubusercontent.com/380816/159975737-9e6b3f9b-8822-4651-aa6e-54c15c6486aa.png">
