### PR TITLE
Propagate alias for expressions in nested queries with duplicate col names

### DIFF
--- a/test/metabase/query_processor/util/add_alias_info_test.clj
+++ b/test/metabase/query_processor/util/add_alias_info_test.clj
@@ -12,7 +12,7 @@
 
 (comment h2/keep-me)
 
-(deftest normalize-clause-test
+(deftest ^:parallel normalize-clause-test
   (is (= [:expression "wow"]
          (#'add/normalize-clause [:expression "wow"])
          (#'add/normalize-clause [:expression "wow" nil])
@@ -394,12 +394,8 @@
                                               "double_price"
                                               {:base-type          :type/Integer
                                                ::add/source-table  ::add/source
-                                               ;; TODO -- these don't agree with the source query (maybe they should
-                                               ;; both be prefixed by another `COOL.` I think) although I'm not sure it
-                                               ;; makes sense to try to assume this stuff either. Arguably the field
-                                               ;; clause should be `[:field "COOL.double_price" ...]` or something
-                                               ::add/source-alias  "double_price"
-                                               ::add/desired-alias "COOL.double_price"
+                                               ::add/source-alias  "COOL.double_price"
+                                               ::add/desired-alias "COOL.COOL.double_price"
                                                ::add/position      0}]]
                             {:aggregation [[:aggregation-options [:count] {:name               "COOL.count"
                                                                            ::add/position      1
@@ -606,3 +602,38 @@
                                                                    :temporal-unit      :month}]]}
                                    :alias        "Q2"}]})
                 [:field (mt/id :products :created_at) {:join-alias "Q2"}])))))))
+
+(deftest ^:parallel expression-from-source-query-alias-test
+  (testing "Make sure we use the exported alias from the source query for expressions (#21131)"
+    (let [source-query {:source-table 3
+                        :expressions  {"PRICE" [:+
+                                                [:field 2 {::add/source-table  3
+                                                           ::add/source-alias  "price"
+                                                           ::add/desired-alias "price"
+                                                           ::add/position      1}]
+                                                2]}
+                        :fields       [[:field 2 {::add/source-table  3
+                                                  ::add/source-alias  "price"
+                                                  ::add/desired-alias "price"
+                                                  ::add/position      1}]
+                                       [:expression "PRICE" {::add/desired-alias "PRICE_2"
+                                                             ::add/position      2}]]}]
+      (testing `add/exports
+        (is (= #{[:field 2 {::add/source-table  3
+                            ::add/source-alias  "price"
+                            ::add/desired-alias "price"
+                            ::add/position      1}]
+                 [:expression "PRICE" {::add/desired-alias "PRICE_2"
+                                       ::add/position      2}]}
+               (#'add/exports source-query))))
+      (testing `add/matching-field-in-source-query
+        (is (= [:expression "PRICE" {::add/desired-alias "PRICE_2"
+                                     ::add/position      2}]
+               (#'add/matching-field-in-source-query
+                {:source-query source-query}
+                [:field "PRICE" {:base-type :type/Float}]))))
+      (testing `add/field-alias-in-source-query
+        (is (= "PRICE_2"
+               (#'add/field-alias-in-source-query
+                {:source-query source-query}
+                [:field "PRICE" {:base-type :type/Float}])))))))

--- a/test/metabase/query_processor_test/expressions_test.clj
+++ b/test/metabase/query_processor_test/expressions_test.clj
@@ -482,3 +482,20 @@
             (is (= [["Doohickey" 42 2 "Doohickey" 42 2]]
                    (mt/formatted-rows [str int int str int int]
                      (qp/process-query query))))))))))
+
+(deftest nested-expressions-with-existing-names-test
+  (testing "Expressions with the same name as existing columns should work correctly in nested queries (#21131)"
+    (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries :expressions)
+      (mt/dataset sample-dataset
+        (doseq [expression-name ["PRICE" "price"]]
+          (testing (format "Expression name = %s" (pr-str expression-name))
+            (let [query (mt/mbql-query products
+                          {:source-query {:source-table $$products
+                                          :expressions  {expression-name [:+ $price 2]}
+                                          :fields       [$id $price [:expression expression-name]]
+                                          :order-by     [[:asc $id]]
+                                          :limit        2}})]
+              (mt/with-native-query-testing-context query
+                (is (= [[1 29.46 31.46] [2 70.08 72.08]]
+                       (mt/formatted-rows [int 2.0 2.0]
+                         (qp/process-query query))))))))))))


### PR DESCRIPTION
Fixes #21131

The root issue here is were weren't correctly determining that a field like `[:field "price" ...]` corresponded to an expression `price` (via expression ref `[:expression "price" ...]`) in the source query, so the alias used in the source query was not being passed along to the level above it. 