### PR TITLE
Fix download question data on embedded dashboard

### DIFF
--- a/frontend/src/metabase/components/DownloadButton.jsx
+++ b/frontend/src/metabase/components/DownloadButton.jsx
@@ -53,10 +53,10 @@ const handleSubmit = async (
   if (method === `POST`) {
     options.body = formData;
   } else if (method === `GET`) {
-    options.query = formData;
+    options.query = formData.toString();
   }
 
-  fetch(url, options)
+  fetch(method === `POST` ? url : url + '?' + options.query, options)
     .then(async res => {
       const blob = await res.blob();
       const url = URL.createObjectURL(blob);


### PR DESCRIPTION
When the embedded dashboard is filtered and then downloaded the download results are not filtered.

Solution : When handleSubmit and call fetch function, method GET on fetch function not allow options.  