### PR TITLE
[E2E] Introduce `visitDashboard` helper

### DIFF
--- a/frontend/test/__support__/e2e/helpers/e2e-misc-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-misc-helpers.js
@@ -150,3 +150,17 @@ export function visitQuestion(id) {
 
   cy.wait("@" + alias);
 }
+
+/**
+ * Visit a dashboard and wait for its query to load.
+ *
+ * @param {number} id
+ */
+export function visitDashboard(id) {
+  //  The very last request when visiting dashboard always checks the collection it is in.
+  cy.intercept("GET", `/api/collection/*`).as("getParentCollection");
+
+  cy.visit(`/dashboard/${id}`);
+
+  cy.wait("@getParentCollection");
+}

--- a/frontend/test/__support__/e2e/helpers/e2e-misc-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-misc-helpers.js
@@ -154,13 +154,26 @@ export function visitQuestion(id) {
 /**
  * Visit a dashboard and wait for its query to load.
  *
+ * NOTE: Avoid using this helper if you need to explicitly wait for
+ * and assert on the individual dashcard queries.
+ *
  * @param {number} id
  */
 export function visitDashboard(id) {
-  //  The very last request when visiting dashboard always checks the collection it is in.
+  cy.intercept("GET", `/api/dashboard/${id}`).as("getDashboard");
+  // The very last request when visiting dashboard always checks the collection it is in.
+  // That is - IF user has the permission to view that dashboard!
   cy.intercept("GET", `/api/collection/*`).as("getParentCollection");
 
   cy.visit(`/dashboard/${id}`);
 
-  cy.wait("@getParentCollection");
+  // If users doesn't have permissions to even view the dashboard,
+  // the last request for them would be `getDashboard`.
+  cy.wait("@getDashboard").then(({ response: { statusCode } }) => {
+    canViewDashboard(statusCode) && cy.wait("@getParentCollection");
+  });
+}
+
+function canViewDashboard(statusCode) {
+  return statusCode !== 403;
 }

--- a/frontend/test/metabase-visual/dashboard/filter-sidebar.cy.spec.js
+++ b/frontend/test/metabase-visual/dashboard/filter-sidebar.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore } from "__support__/e2e/cypress";
+import { restore, visitDashboard } from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { ORDERS_ID } = SAMPLE_DATABASE;
@@ -14,7 +14,7 @@ describe("visual tests > dashboard > filter sidebar", () => {
 
     cy.createQuestionAndDashboard({ questionDetails }).then(
       ({ body: { card_id, dashboard_id } }) => {
-        cy.visit(`/dashboard/${dashboard_id}`);
+        visitDashboard(dashboard_id);
       },
     );
   });

--- a/frontend/test/metabase-visual/dashboard/fullscreen.cy.spec.js
+++ b/frontend/test/metabase-visual/dashboard/fullscreen.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore } from "__support__/e2e/cypress";
+import { restore, visitDashboard } from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
@@ -45,7 +45,7 @@ describe("visual tests > dashboard > fullscreen", () => {
           ],
         });
 
-        cy.visit(`/dashboard/${dashboard_id}`);
+        visitDashboard(dashboard_id);
       },
     );
   });

--- a/frontend/test/metabase-visual/dashboard/parameters-widget.cy.spec.js
+++ b/frontend/test/metabase-visual/dashboard/parameters-widget.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore } from "__support__/e2e/cypress";
+import { restore, visitDashboard } from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { PRODUCTS_ID } = SAMPLE_DATABASE;
@@ -36,7 +36,7 @@ describe("visual tests > dashboard > parameters widget", () => {
 
         cy.editDashboardCard(card, updatedSize);
 
-        cy.visit(`/dashboard/${dashboard_id}`);
+        visitDashboard(dashboard_id);
       },
     );
   });

--- a/frontend/test/metabase-visual/static-visualizations/funnel.cy.spec.js
+++ b/frontend/test/metabase-visual/static-visualizations/funnel.cy.spec.js
@@ -3,6 +3,7 @@ import {
   setupSMTP,
   openEmailPage,
   sendSubscriptionsEmail,
+  visitDashboard,
 } from "__support__/e2e/cypress";
 
 import { USERS, SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
@@ -22,7 +23,7 @@ describe("static visualizations", () => {
       dashboardName,
       questions: [createFunnelBarQuestion()],
     }).then(({ dashboard }) => {
-      cy.visit(`/dashboard/${dashboard.id}`);
+      visitDashboard(dashboard.id);
 
       sendSubscriptionsEmail(`${admin.first_name} ${admin.last_name}`);
 

--- a/frontend/test/metabase-visual/static-visualizations/line-area-bar-combo.cy.spec.js
+++ b/frontend/test/metabase-visual/static-visualizations/line-area-bar-combo.cy.spec.js
@@ -3,6 +3,7 @@ import {
   setupSMTP,
   openEmailPage,
   sendSubscriptionsEmail,
+  visitDashboard,
 } from "__support__/e2e/cypress";
 
 import { USERS, SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
@@ -31,7 +32,7 @@ describe("static visualizations", () => {
           createOneDimensionTwoMetricsQuestion(type),
         ],
       }).then(({ dashboard }) => {
-        cy.visit(`/dashboard/${dashboard.id}`);
+        visitDashboard(dashboard.id);
 
         sendSubscriptionsEmail(`${admin.first_name} ${admin.last_name}`);
 

--- a/frontend/test/metabase-visual/static-visualizations/progress-bar.cy.spec.js
+++ b/frontend/test/metabase-visual/static-visualizations/progress-bar.cy.spec.js
@@ -3,6 +3,7 @@ import {
   setupSMTP,
   openEmailPage,
   sendSubscriptionsEmail,
+  visitDashboard,
 } from "__support__/e2e/cypress";
 
 import { USERS, SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
@@ -27,7 +28,7 @@ describe("static visualizations", () => {
         createProgressBarQuestion({ value: 2000, goal: 1000 }),
       ],
     }).then(({ dashboard }) => {
-      cy.visit(`/dashboard/${dashboard.id}`);
+      visitDashboard(dashboard.id);
 
       sendSubscriptionsEmail(`${admin.first_name} ${admin.last_name}`);
 

--- a/frontend/test/metabase-visual/static-visualizations/waterfall.cy.spec.js
+++ b/frontend/test/metabase-visual/static-visualizations/waterfall.cy.spec.js
@@ -3,6 +3,7 @@ import {
   setupSMTP,
   openEmailPage,
   sendSubscriptionsEmail,
+  visitDashboard,
 } from "__support__/e2e/cypress";
 
 import { USERS, SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
@@ -26,7 +27,7 @@ describe("static visualizations", () => {
         createWaterfallQuestion({ showTotal: false }),
       ],
     }).then(({ dashboard }) => {
-      cy.visit(`/dashboard/${dashboard.id}`);
+      visitDashboard(dashboard.id);
 
       sendSubscriptionsEmail(`${admin.first_name} ${admin.last_name}`);
 

--- a/frontend/test/metabase/scenarios/collections/items-metadata.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/items-metadata.cy.spec.js
@@ -1,4 +1,8 @@
-import { restore, visitQuestion } from "__support__/e2e/cypress";
+import {
+  restore,
+  visitQuestion,
+  visitDashboard,
+} from "__support__/e2e/cypress";
 import { USERS } from "__support__/e2e/cypress_data";
 
 describe("scenarios > collection items metadata", () => {
@@ -12,7 +16,7 @@ describe("scenarios > collection items metadata", () => {
     });
 
     it("should display last edit moment for dashboards", () => {
-      cy.visit("/dashboard/1");
+      visitDashboard(1);
       changeDashboard();
       cy.findByText(/Edited a few seconds ago/i);
     });
@@ -27,7 +31,7 @@ describe("scenarios > collection items metadata", () => {
   describe("last editor", () => {
     it("should display if user is the last editor", () => {
       cy.signInAsAdmin();
-      cy.visit("/dashboard/1");
+      visitDashboard(1);
       cy.findByText(/Edited .* by you/i);
       visitQuestion(1);
       cy.findByText(/Edited .* by you/i);
@@ -39,7 +43,7 @@ describe("scenarios > collection items metadata", () => {
       const expectedName = `${first_name} ${last_name.charAt(0)}.`;
 
       cy.signIn("normal");
-      cy.visit("/dashboard/1");
+      visitDashboard(1);
       cy.findByText(new RegExp(`Edited .* by ${expectedName}`, "i"));
       visitQuestion(1);
       cy.findByText(new RegExp(`Edited .* by ${expectedName}`, "i"));

--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -17,6 +17,7 @@ import {
   sidebar,
   openNativeEditor,
   visitQuestion,
+  visitDashboard,
 } from "__support__/e2e/cypress";
 import { displaySidebarChildOf } from "./helpers/e2e-collections-sidebar.js";
 import { USERS } from "__support__/e2e/cypress_data";
@@ -407,7 +408,7 @@ describe("collection permissions", () => {
               describe("managing dashboard from the dashboard's edit menu", () => {
                 beforeEach(() => {
                   cy.route("PUT", "/api/dashboard/1").as("updateDashboard");
-                  cy.visit("/dashboard/1");
+                  visitDashboard(1);
                   cy.icon("ellipsis").click();
                 });
 
@@ -592,7 +593,7 @@ describe("collection permissions", () => {
             describe("managing dashboard from the dashboard's edit menu", () => {
               it("should not be offered to edit dashboard details for dashboard in collections they have `read` access to (metabase#15280)", () => {
                 cy.intercept("GET", "/api/collection/root").as("collections");
-                cy.visit("/dashboard/1");
+                visitDashboard(1);
                 cy.icon("ellipsis")
                   .should("be.visible")
                   .click();
@@ -603,7 +604,7 @@ describe("collection permissions", () => {
 
               it("should not be offered to archive dashboard in collections they have `read` access to (metabase#15280)", () => {
                 cy.intercept("GET", "/api/collection/root").as("collections");
-                cy.visit("/dashboard/1");
+                visitDashboard(1);
                 cy.icon("ellipsis")
                   .should("be.visible")
                   .click();
@@ -615,7 +616,7 @@ describe("collection permissions", () => {
               it("should be offered to duplicate dashboard in collections they have `read` access to", () => {
                 cy.intercept("GET", "/api/collection/root").as("collections");
                 const { first_name, last_name } = USERS[user];
-                cy.visit("/dashboard/1");
+                visitDashboard(1);
                 cy.wait("@collections");
                 cy.icon("ellipsis")
                   .should("be.visible")
@@ -710,7 +711,7 @@ describe("collection permissions", () => {
               });
 
               it("should be able to revert the dashboard (metabase#15237)", () => {
-                cy.visit("/dashboard/1");
+                visitDashboard(1);
                 cy.icon("ellipsis").click();
                 cy.findByText("Revision history").click();
                 clickRevert("created this");
@@ -777,7 +778,7 @@ describe("collection permissions", () => {
             describe(`${user} user`, () => {
               it("should not see dashboard revert buttons (metabase#13229)", () => {
                 cy.signIn(user);
-                cy.visit("/dashboard/1");
+                visitDashboard(1);
                 cy.icon("ellipsis").click();
                 cy.findByText("Revision history").click();
                 cy.findAllByRole("button", { name: "Revert" }).should(
@@ -861,7 +862,7 @@ function assertOnRequest(xhr_alias) {
 }
 
 function visitAndEditDashboard(id) {
-  cy.visit(`/dashboard/${id}`);
+  visitDashboard(id);
   cy.icon("pencil").click();
 }
 

--- a/frontend/test/metabase/scenarios/custom-column/reproductions/18747-cc-connected-to-dashboard-parameter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/custom-column/reproductions/18747-cc-connected-to-dashboard-parameter.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, popover } from "__support__/e2e/cypress";
+import { restore, popover, visitDashboard } from "__support__/e2e/cypress";
 
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
@@ -33,7 +33,7 @@ describe("issue 18747", () => {
             },
           ],
         }).then(() => {
-          cy.visit(`/dashboard/${dashboard_id}`);
+          visitDashboard(dashboard_id);
         });
       },
     );

--- a/frontend/test/metabase/scenarios/custom-column/reproductions/19744-cc-after-aggregation-limited-filters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/custom-column/reproductions/19744-cc-after-aggregation-limited-filters.cy.spec.js
@@ -3,6 +3,7 @@ import {
   editDashboard,
   visitQuestionAdhoc,
   popover,
+  visitDashboard,
 } from "__support__/e2e/cypress";
 
 import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
@@ -84,6 +85,6 @@ function addQuestionToDashboardAndVisit() {
       });
     });
 
-    cy.visit(`/dashboard/${id}`);
+    visitDashboard(id);
   });
 }

--- a/frontend/test/metabase/scenarios/dashboard-filters-sql/dashboard-filters-sql-date.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters-sql/dashboard-filters-sql-date.cy.spec.js
@@ -6,6 +6,7 @@ import {
   saveDashboard,
   setFilter,
   visitQuestion,
+  visitDashboard,
 } from "__support__/e2e/cypress";
 
 import { DASHBOARD_SQL_DATE_FILTERS } from "./helpers/e2e-dashboard-filter-sql-data-objects";
@@ -28,7 +29,7 @@ Object.entries(DASHBOARD_SQL_DATE_FILTERS).forEach(
           ({ body: { card_id, dashboard_id } }) => {
             visitQuestion(card_id);
 
-            cy.visit(`/dashboard/${dashboard_id}`);
+            visitDashboard(dashboard_id);
           },
         );
 

--- a/frontend/test/metabase/scenarios/dashboard-filters-sql/dashboard-filters-sql-id.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters-sql/dashboard-filters-sql-id.cy.spec.js
@@ -6,6 +6,7 @@ import {
   saveDashboard,
   setFilter,
   visitQuestion,
+  visitDashboard,
 } from "__support__/e2e/cypress";
 
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
@@ -104,7 +105,7 @@ function prepareDashboardWithFilterConnectedTo(rowId) {
     ({ body: { card_id, dashboard_id } }) => {
       visitQuestion(card_id);
 
-      cy.visit(`/dashboard/${dashboard_id}`);
+      visitDashboard(dashboard_id);
     },
   );
 

--- a/frontend/test/metabase/scenarios/dashboard-filters-sql/dashboard-filters-sql-location.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters-sql/dashboard-filters-sql-location.cy.spec.js
@@ -6,6 +6,7 @@ import {
   saveDashboard,
   setFilter,
   visitQuestion,
+  visitDashboard,
 } from "__support__/e2e/cypress";
 
 import { DASHBOARD_SQL_LOCATION_FILTERS } from "./helpers/e2e-dashboard-filter-sql-data-objects";
@@ -28,7 +29,7 @@ Object.entries(DASHBOARD_SQL_LOCATION_FILTERS).forEach(
           ({ body: { card_id, dashboard_id } }) => {
             visitQuestion(card_id);
 
-            cy.visit(`/dashboard/${dashboard_id}`);
+            visitDashboard(dashboard_id);
           },
         );
 

--- a/frontend/test/metabase/scenarios/dashboard-filters-sql/dashboard-filters-sql-number.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters-sql/dashboard-filters-sql-number.cy.spec.js
@@ -6,6 +6,7 @@ import {
   saveDashboard,
   setFilter,
   visitQuestion,
+  visitDashboard,
 } from "__support__/e2e/cypress";
 
 import { DASHBOARD_SQL_NUMBER_FILTERS } from "./helpers/e2e-dashboard-filter-sql-data-objects";
@@ -28,7 +29,7 @@ Object.entries(DASHBOARD_SQL_NUMBER_FILTERS).forEach(
           ({ body: { card_id, dashboard_id } }) => {
             visitQuestion(card_id);
 
-            cy.visit(`/dashboard/${dashboard_id}`);
+            visitDashboard(dashboard_id);
           },
         );
 

--- a/frontend/test/metabase/scenarios/dashboard-filters-sql/dashboard-filters-sql-required-field-filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters-sql/dashboard-filters-sql-required-field-filter.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, filterWidget } from "__support__/e2e/cypress";
+import { restore, filterWidget, visitDashboard } from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { PRODUCTS } = SAMPLE_DATABASE;
@@ -58,7 +58,7 @@ describe("scenarios > dashboard > filters > SQL > field filter > required ", () 
 
       cy.editDashboardCard(dashboardCard, mapFilterToCard);
 
-      cy.visit(`/dashboard/${dashboard_id}`);
+      visitDashboard(dashboard_id);
     });
   });
 

--- a/frontend/test/metabase/scenarios/dashboard-filters-sql/dashboard-filters-sql-required-simple-filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters-sql/dashboard-filters-sql-required-simple-filter.cy.spec.js
@@ -4,6 +4,7 @@ import {
   sidebar,
   editDashboard,
   saveDashboard,
+  visitDashboard,
 } from "__support__/e2e/cypress";
 
 const questionDetails = {
@@ -61,7 +62,7 @@ describe("scenarios > dashboard > filters > SQL > simple filter > required ", ()
 
       cy.editDashboardCard(dashboardCard, mapFilterToCard);
 
-      cy.visit(`/dashboard/${dashboard_id}`);
+      visitDashboard(dashboard_id);
     });
   });
 

--- a/frontend/test/metabase/scenarios/dashboard-filters-sql/dashboard-filters-sql-text-category.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters-sql/dashboard-filters-sql-text-category.cy.spec.js
@@ -6,6 +6,7 @@ import {
   saveDashboard,
   setFilter,
   visitQuestion,
+  visitDashboard,
 } from "__support__/e2e/cypress";
 
 import { DASHBOARD_SQL_TEXT_FILTERS } from "./helpers/e2e-dashboard-filter-sql-data-objects";
@@ -28,7 +29,7 @@ Object.entries(DASHBOARD_SQL_TEXT_FILTERS).forEach(
           ({ body: { card_id, dashboard_id } }) => {
             visitQuestion(card_id);
 
-            cy.visit(`/dashboard/${dashboard_id}`);
+            visitDashboard(dashboard_id);
           },
         );
 

--- a/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-date.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-date.cy.spec.js
@@ -5,6 +5,7 @@ import {
   editDashboard,
   saveDashboard,
   setFilter,
+  visitDashboard,
 } from "__support__/e2e/cypress";
 
 import { DASHBOARD_DATE_FILTERS } from "./helpers/e2e-dashboard-filter-data-objects";
@@ -19,7 +20,7 @@ Object.entries(DASHBOARD_DATE_FILTERS).forEach(
         restore();
         cy.signInAsAdmin();
 
-        cy.visit("/dashboard/1");
+        visitDashboard(1);
 
         editDashboard();
         setFilter("Time", filter);

--- a/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-explicit-join.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-explicit-join.cy.spec.js
@@ -1,4 +1,9 @@
-import { restore, filterWidget, popover } from "__support__/e2e/cypress";
+import {
+  restore,
+  filterWidget,
+  popover,
+  visitDashboard,
+} from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
@@ -66,7 +71,7 @@ describe("scenarios > dashboard > filters", () => {
 
         cy.editDashboardCard(dashboardCard, updatedCardDetails);
 
-        cy.visit(`/dashboard/${dashboard_id}`);
+        visitDashboard(dashboard_id);
       },
     );
   });

--- a/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-id.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-id.cy.spec.js
@@ -6,6 +6,7 @@ import {
   saveDashboard,
   setFilter,
   checkFilterLabelAndValue,
+  visitDashboard,
 } from "__support__/e2e/cypress";
 
 import { addWidgetStringFilter } from "../native-filters/helpers/e2e-field-filter-helpers";
@@ -15,7 +16,7 @@ describe("scenarios > dashboard > filters > ID", () => {
     restore();
     cy.signInAsAdmin();
 
-    cy.visit("/dashboard/1");
+    visitDashboard(1);
 
     editDashboard();
     setFilter("ID");

--- a/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-location.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-location.cy.spec.js
@@ -5,6 +5,7 @@ import {
   editDashboard,
   saveDashboard,
   setFilter,
+  visitDashboard,
 } from "__support__/e2e/cypress";
 
 import { DASHBOARD_LOCATION_FILTERS } from "./helpers/e2e-dashboard-filter-data-objects";
@@ -17,7 +18,7 @@ Object.entries(DASHBOARD_LOCATION_FILTERS).forEach(
         restore();
         cy.signInAsAdmin();
 
-        cy.visit("/dashboard/1");
+        visitDashboard(1);
 
         editDashboard();
         setFilter("Location", filter);

--- a/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-number.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-number.cy.spec.js
@@ -5,6 +5,7 @@ import {
   editDashboard,
   saveDashboard,
   setFilter,
+  visitDashboard,
 } from "__support__/e2e/cypress";
 
 import { DASHBOARD_NUMBER_FILTERS } from "./helpers/e2e-dashboard-filter-data-objects";
@@ -19,7 +20,7 @@ Object.entries(DASHBOARD_NUMBER_FILTERS).forEach(
         restore();
         cy.signInAsAdmin();
 
-        cy.visit("/dashboard/1");
+        visitDashboard(1);
 
         editDashboard();
         setFilter("Number", filter);

--- a/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-text-category.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-text-category.cy.spec.js
@@ -5,6 +5,7 @@ import {
   editDashboard,
   saveDashboard,
   setFilter,
+  visitDashboard,
 } from "__support__/e2e/cypress";
 
 import { DASHBOARD_TEXT_FILTERS } from "./helpers/e2e-dashboard-filter-data-objects";
@@ -17,7 +18,7 @@ Object.entries(DASHBOARD_TEXT_FILTERS).forEach(
         restore();
         cy.signInAsAdmin();
 
-        cy.visit("/dashboard/1");
+        visitDashboard(1);
 
         editDashboard();
         setFilter("Text or Category", filter);

--- a/frontend/test/metabase/scenarios/dashboard-filters/old-parameters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/old-parameters.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, popover } from "__support__/e2e/cypress";
+import { restore, popover, visitDashboard } from "__support__/e2e/cypress";
 // NOTE: some overlap with parameters-embedded.cy.spec.js
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
@@ -53,7 +53,7 @@ describe("scenarios > dashboard > OLD parameters", () => {
               ],
             });
 
-            cy.visit(`/dashboard/${dashboard_id}`);
+            visitDashboard(dashboard_id);
           });
         });
       });
@@ -113,7 +113,7 @@ describe("scenarios > dashboard > OLD parameters", () => {
               ],
             });
 
-            cy.visit(`/dashboard/${dashboard_id}`);
+            visitDashboard(dashboard_id);
           });
         });
       });
@@ -182,7 +182,7 @@ describe("scenarios > dashboard > OLD parameters", () => {
               ],
             });
 
-            cy.visit(`/dashboard/${dashboard_id}`);
+            visitDashboard(dashboard_id);
           });
         });
       });

--- a/frontend/test/metabase/scenarios/dashboard-filters/parameters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/parameters.cy.spec.js
@@ -3,6 +3,7 @@ import {
   popover,
   restore,
   openNativeEditor,
+  visitDashboard,
 } from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
@@ -17,7 +18,7 @@ describe("scenarios > dashboard > parameters", () => {
   });
 
   it("should be visible if previously added", () => {
-    cy.visit("/dashboard/1");
+    visitDashboard(1);
     cy.findByText("Baker").should("not.exist");
 
     // Add a filter
@@ -130,7 +131,7 @@ describe("scenarios > dashboard > parameters", () => {
   });
 
   it("should not search field for results non-exact parameter string operators", () => {
-    cy.visit("/dashboard/1");
+    visitDashboard(1);
 
     // Add a filter tied to a field that triggers a search for field values
     cy.icon("pencil").click();
@@ -177,7 +178,7 @@ describe("scenarios > dashboard > parameters", () => {
     // Mirrored issue in metabase-enterprise#275
 
     // Go directly to "Orders in a dashboard" dashboard
-    cy.visit("/dashboard/1");
+    visitDashboard(1);
 
     // Add filter and save dashboard
     cy.icon("pencil").click();
@@ -296,7 +297,7 @@ describe("scenarios > dashboard > parameters", () => {
     cy.findByText("New question").should("not.exist");
 
     cy.log("Bug was breaking the dashboard at this point");
-    cy.visit("/dashboard/1");
+    visitDashboard(1);
     // error was always ending in "is undefined" when dashboard broke in the past
     cy.contains(/is undefined$/).should("not.exist");
     cy.findByText("Orders in a dashboard");
@@ -358,7 +359,7 @@ describe("scenarios > dashboard > parameters", () => {
           });
         });
 
-        cy.visit(`/dashboard/${dashboard_id}`);
+        visitDashboard(dashboard_id);
       });
     });
 
@@ -422,7 +423,7 @@ describe("scenarios > dashboard > parameters", () => {
             });
           });
 
-          cy.visit(`/dashboard/${dashboard_id}`);
+          visitDashboard(dashboard_id);
         });
       });
     });
@@ -436,7 +437,7 @@ describe("scenarios > dashboard > parameters", () => {
   });
 
   it("should be removable from dashboard", () => {
-    cy.visit("/dashboard/1");
+    visitDashboard(1);
     // Add a filter
     addCityFilterWithDefault();
 
@@ -452,7 +453,7 @@ describe("scenarios > dashboard > parameters", () => {
 
   describe("when the user does not have self service data permissions", () => {
     beforeEach(() => {
-      cy.visit("/dashboard/1");
+      visitDashboard(1);
       addCityFilterWithDefault();
 
       cy.signIn("nodata");

--- a/frontend/test/metabase/scenarios/dashboard-filters/reproductions/12614-nested-show-fields.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/reproductions/12614-nested-show-fields.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, popover } from "__support__/e2e/cypress";
+import { restore, popover, visitDashboard } from "__support__/e2e/cypress";
 
 describe("issue 12614", () => {
   beforeEach(() => {
@@ -42,7 +42,7 @@ function createDashboardWithNestedCard() {
           .createDashboard("Q2 in a dashboard")
           .then(({ body: { id: dashId } }) => {
             cy.request("POST", `/api/dashboard/${dashId}/cards`, { cardId });
-            cy.visit(`/dashboard/${dashId}`);
+            visitDashboard(dashId);
           }),
       ),
   );

--- a/frontend/test/metabase/scenarios/dashboard-filters/reproductions/12720-no-data-permissions-connected-filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/reproductions/12720-no-data-permissions-connected-filter.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore } from "__support__/e2e/cypress";
+import { restore, visitDashboard } from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { ORDERS } = SAMPLE_DATABASE;
@@ -103,7 +103,7 @@ describe.skip("issue 12720", () => {
 });
 
 function clickThrough(title) {
-  cy.visit("/dashboard/1");
+  visitDashboard(1);
   cy.wait("@cardQuery");
   cy.wait("@sqlQuery");
   cy.get(".LegendItem")

--- a/frontend/test/metabase/scenarios/dashboard-filters/reproductions/12985-dropdown-search.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/reproductions/12985-dropdown-search.cy.spec.js
@@ -1,4 +1,9 @@
-import { restore, filterWidget, popover } from "__support__/e2e/cypress";
+import {
+  restore,
+  filterWidget,
+  popover,
+  visitDashboard,
+} from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { PRODUCTS_ID, PRODUCTS } = SAMPLE_DATABASE;
@@ -77,7 +82,7 @@ describe("issue 12985 > dashboard filter dropdown/search", () => {
               ],
             });
           });
-          cy.visit(`/dashboard/${DASHBOARD_ID}`);
+          visitDashboard(DASHBOARD_ID);
         });
       });
     });
@@ -155,7 +160,7 @@ describe("issue 12985 > dashboard filter dropdown/search", () => {
             ],
           });
         });
-        cy.visit(`/dashboard/${DASHBOARD_ID}`);
+        visitDashboard(DASHBOARD_ID);
       });
     });
 

--- a/frontend/test/metabase/scenarios/dashboard-filters/reproductions/13960-do-not-preserve-cleared-default-filter-on-refresh.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/reproductions/13960-do-not-preserve-cleared-default-filter-on-refresh.cy.spec.js
@@ -55,14 +55,7 @@ describe("issue 13960", () => {
 
         cy.editDashboardCard(dashboardCard, mapFiltersToCard);
 
-        cy.intercept(
-          "POST",
-          `/api/dashboard/${dashboard_id}/dashcard/*/card/${card_id}/query`,
-        ).as("cardQuery");
-
         visitDashboard(dashboard_id);
-
-        cy.wait("@cardQuery");
       },
     );
 
@@ -87,6 +80,8 @@ describe("issue 13960", () => {
     cy.location("search").should("eq", "?category=&id=1");
 
     cy.reload();
+    // Alias was previously defined in `visitDashboard()` helper function
+    cy.wait("@getParentCollection");
 
     cy.findByText("13960");
     cy.findAllByText("Doohickey").should("not.exist");

--- a/frontend/test/metabase/scenarios/dashboard-filters/reproductions/13960-do-not-preserve-cleared-default-filter-on-refresh.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/reproductions/13960-do-not-preserve-cleared-default-filter-on-refresh.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, filterWidget } from "__support__/e2e/cypress";
+import { restore, filterWidget, visitDashboard } from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
@@ -60,7 +60,7 @@ describe("issue 13960", () => {
           `/api/dashboard/${dashboard_id}/dashcard/*/card/${card_id}/query`,
         ).as("cardQuery");
 
-        cy.visit(`/dashboard/${dashboard_id}`);
+        visitDashboard(dashboard_id);
 
         cy.wait("@cardQuery");
       },

--- a/frontend/test/metabase/scenarios/dashboard-filters/reproductions/15119-nodata-should-not-use-dash-filters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/reproductions/15119-nodata-should-not-use-dash-filters.cy.spec.js
@@ -1,4 +1,9 @@
-import { restore, filterWidget, popover } from "__support__/e2e/cypress";
+import {
+  restore,
+  filterWidget,
+  popover,
+  visitDashboard,
+} from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
@@ -49,7 +54,7 @@ describe("issue 15119", () => {
         });
 
         cy.signIn("nodata");
-        cy.visit(`/dashboard/${dashboard_id}`);
+        visitDashboard(dashboard_id);
       },
     );
 

--- a/frontend/test/metabase/scenarios/dashboard-filters/reproductions/15279-gracefully-deal-with-corrupted-filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/reproductions/15279-gracefully-deal-with-corrupted-filter.cy.spec.js
@@ -36,7 +36,6 @@ describe("issue 15279", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
-    cy.intercept("GET", "/api/dashboard/*/params/*/values").as("values");
   });
 
   it("a corrupted parameter filter should still appear in the UI (metabase #15279)", () => {
@@ -78,6 +77,8 @@ describe("issue 15279", () => {
         visitDashboard(dashboard_id);
       },
     );
+
+    cy.intercept("GET", "/api/dashboard/*/params/*/values").as("values");
 
     // Check that list filter works
     filterWidget()

--- a/frontend/test/metabase/scenarios/dashboard-filters/reproductions/15279-gracefully-deal-with-corrupted-filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/reproductions/15279-gracefully-deal-with-corrupted-filter.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, filterWidget } from "__support__/e2e/cypress";
+import { restore, filterWidget, visitDashboard } from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { PEOPLE, PEOPLE_ID } = SAMPLE_DATABASE;
@@ -75,7 +75,7 @@ describe("issue 15279", () => {
           ],
         });
 
-        cy.visit(`/dashboard/${dashboard_id}`);
+        visitDashboard(dashboard_id);
       },
     );
 

--- a/frontend/test/metabase/scenarios/dashboard-filters/reproductions/15689-allow-multiple-selections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/reproductions/15689-allow-multiple-selections.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, filterWidget } from "__support__/e2e/cypress";
+import { restore, filterWidget, visitDashboard } from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { PEOPLE, PEOPLE_ID } = SAMPLE_DATABASE;
@@ -49,7 +49,7 @@ describe("issue 15689", () => {
           ],
         });
 
-        cy.visit(`/dashboard/${dashboard_id}`);
+        visitDashboard(dashboard_id);
       },
     );
 

--- a/frontend/test/metabase/scenarios/dashboard-filters/reproductions/15695-do-not-limit-number-of-results.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/reproductions/15695-do-not-limit-number-of-results.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, filterWidget } from "__support__/e2e/cypress";
+import { restore, filterWidget, visitDashboard } from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
@@ -54,7 +54,7 @@ describe("issue 15695", () => {
           ],
         });
 
-        cy.visit(`/dashboard/${dashboard_id}`);
+        visitDashboard(dashboard_id);
       },
     );
 

--- a/frontend/test/metabase/scenarios/dashboard-filters/reproductions/16103-additional-requests-dropdown.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/reproductions/16103-additional-requests-dropdown.cy.spec.js
@@ -2,6 +2,7 @@ import {
   restore,
   expectedRouteCalls,
   filterWidget,
+  visitDashboard,
 } from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
@@ -56,7 +57,7 @@ describe.skip("issue 16103", () => {
       ],
     });
 
-    cy.visit("/dashboard/1");
+    visitDashboard(1);
 
     filterWidget().click();
     expectedRouteCalls({ route_alias: "fetchFromDB", calls: 1 });

--- a/frontend/test/metabase/scenarios/dashboard-filters/reproductions/17139-do-not-reset-filters-on-edit.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/reproductions/17139-do-not-reset-filters-on-edit.cy.spec.js
@@ -6,6 +6,7 @@ import {
   cancelEditingDashboard,
   saveDashboard,
   checkFilterLabelAndValue,
+  visitDashboard,
 } from "__support__/e2e/cypress";
 
 import { setMonthAndYear } from "../../native-filters/helpers/e2e-date-filter-helpers";
@@ -14,7 +15,7 @@ describe.skip("issue 17139", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
-    cy.visit("/dashboard/1");
+    visitDashboard(1);
 
     editDashboard();
 

--- a/frontend/test/metabase/scenarios/dashboard-filters/reproductions/17211-false-no-matching-filter-alert.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/reproductions/17211-false-no-matching-filter-alert.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, filterWidget } from "__support__/e2e/cypress";
+import { restore, filterWidget, visitDashboard } from "__support__/e2e/cypress";
 
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
@@ -58,7 +58,7 @@ describe("issue 17211", () => {
           ],
         });
 
-        cy.visit(`/dashboard/${dashboard_id}`);
+        visitDashboard(dashboard_id);
       },
     );
   });

--- a/frontend/test/metabase/scenarios/dashboard-filters/reproductions/17212-nested-id-filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/reproductions/17212-nested-id-filter.cy.spec.js
@@ -26,14 +26,7 @@ describe.skip("issue 17212", () => {
 
       cy.createQuestionAndDashboard({ questionDetails }).then(
         ({ body: { card_id, dashboard_id } }) => {
-          cy.intercept(
-            "POST",
-            `/api/dashboard/${dashboard_id}/dashcard/*/card/${card_id}/query`,
-          ).as("cardQuery");
-
           visitDashboard(dashboard_id);
-
-          cy.wait("@cardQuery");
         },
       );
     });

--- a/frontend/test/metabase/scenarios/dashboard-filters/reproductions/17212-nested-id-filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/reproductions/17212-nested-id-filter.cy.spec.js
@@ -3,6 +3,7 @@ import {
   editDashboard,
   setFilter,
   popover,
+  visitDashboard,
 } from "__support__/e2e/cypress";
 
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
@@ -30,7 +31,7 @@ describe.skip("issue 17212", () => {
             `/api/dashboard/${dashboard_id}/dashcard/*/card/${card_id}/query`,
           ).as("cardQuery");
 
-          cy.visit(`/dashboard/${dashboard_id}`);
+          visitDashboard(dashboard_id);
 
           cy.wait("@cardQuery");
         },

--- a/frontend/test/metabase/scenarios/dashboard-filters/reproductions/17551-include-today-in-all-time-next-filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/reproductions/17551-include-today-in-all-time-next-filter.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, filterWidget } from "__support__/e2e/cypress";
+import { restore, filterWidget, visitDashboard } from "__support__/e2e/cypress";
 import { setAdHocFilter } from "../../native-filters/helpers/e2e-date-filter-helpers";
 
 describe("issue 17551", () => {
@@ -54,7 +54,7 @@ describe("issue 17551", () => {
 
         cy.editDashboardCard(card, mapFilterToCard);
 
-        cy.visit(`/dashboard/${dashboard_id}`);
+        visitDashboard(dashboard_id);
       });
     });
   });

--- a/frontend/test/metabase/scenarios/dashboard-filters/reproductions/17775-filter-custom-column-date.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/reproductions/17775-filter-custom-column-date.cy.spec.js
@@ -4,6 +4,7 @@ import {
   filterWidget,
   editDashboard,
   saveDashboard,
+  visitDashboard,
 } from "__support__/e2e/cypress";
 
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
@@ -43,7 +44,7 @@ describe.skip("issue 17775", () => {
 
         cy.editDashboardCard(dashboardCard, updatedSize);
 
-        cy.visit(`/dashboard/${dashboard_id}`);
+        visitDashboard(dashboard_id);
       },
     );
 

--- a/frontend/test/metabase/scenarios/dashboard-filters/reproductions/19494-wrong-default-value-multiple-cards-same-question.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/reproductions/19494-wrong-default-value-multiple-cards-same-question.cy.spec.js
@@ -3,6 +3,7 @@ import {
   popover,
   editDashboard,
   saveDashboard,
+  visitDashboard,
 } from "__support__/e2e/cypress";
 
 const filter1 = {
@@ -47,7 +48,7 @@ describe("issue 19494", () => {
   it("should correctly apply different filters with default values to all cards of the same question (metabase#19494)", () => {
     // Instead of using the API to connect filters to the cards,
     // let's use UI to replicate user experience as closely as possible
-    cy.visit("/dashboard/1");
+    visitDashboard(1);
 
     editDashboard();
 

--- a/frontend/test/metabase/scenarios/dashboard-filters/reproductions/20656-dashboard-breaks-for-user-without-card-permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/reproductions/20656-dashboard-breaks-for-user-without-card-permissions.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, filterWidget } from "__support__/e2e/cypress";
+import { restore, filterWidget, visitDashboard } from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
@@ -49,7 +49,7 @@ describe("issue 20656", () => {
 
       cy.signInAsNormalUser();
 
-      cy.visit(`/dashboard/${dashboard_id}`);
+      visitDashboard(dashboard_id);
     });
 
     // Make sure the filter widget is there

--- a/frontend/test/metabase/scenarios/dashboard-filters/reproductions/6660-sub-day-resolutions-relative-date.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/reproductions/6660-sub-day-resolutions-relative-date.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, popover } from "__support__/e2e/cypress";
+import { restore, popover, visitDashboard } from "__support__/e2e/cypress";
 
 describe("issue 6660", () => {
   beforeEach(() => {
@@ -7,7 +7,7 @@ describe("issue 6660", () => {
   });
 
   it("should show sub-day resolutions in relative date filter (metabase#6660)", () => {
-    cy.visit("/dashboard/1");
+    visitDashboard(1);
     cy.icon("pencil").click();
     cy.icon("filter").click();
 

--- a/frontend/test/metabase/scenarios/dashboard/bookmarks.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/bookmarks.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, sidebar } from "__support__/e2e/cypress";
+import { restore, sidebar, visitDashboard } from "__support__/e2e/cypress";
 
 describe("scenarios > dashboard > bookmarks", () => {
   beforeEach(() => {
@@ -7,7 +7,7 @@ describe("scenarios > dashboard > bookmarks", () => {
   });
 
   it("should add and then remove bookmark", () => {
-    cy.visit("/dashboard/1");
+    visitDashboard(1);
 
     cy.icon("ellipsis").click();
 

--- a/frontend/test/metabase/scenarios/dashboard/caching.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/caching.cy.spec.js
@@ -3,6 +3,7 @@ import {
   describeEE,
   mockSessionProperty,
   modal,
+  visitDashboard,
 } from "__support__/e2e/cypress";
 
 describeEE("scenarios > dashboard > caching", () => {
@@ -14,7 +15,7 @@ describeEE("scenarios > dashboard > caching", () => {
 
   it("can set cache ttl for a saved question", () => {
     cy.intercept("PUT", "/api/dashboard/1").as("updateDashboard");
-    cy.visit("/dashboard/1");
+    visitDashboard(1);
 
     openEditingModalForm();
     modal().within(() => {

--- a/frontend/test/metabase/scenarios/dashboard/chained-filters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/chained-filters.cy.spec.js
@@ -2,6 +2,7 @@ import {
   restore,
   popover,
   showDashboardCardActions,
+  visitDashboard,
 } from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
@@ -122,7 +123,7 @@ describe("scenarios > dashboard > chained filter", () => {
   for (const has_field_values of ["search", "list"]) {
     it(`limit ${has_field_values} options based on linked filter`, () => {
       cy.request("PUT", `/api/field/${PEOPLE.CITY}`, { has_field_values }),
-        cy.visit("/dashboard/1");
+        visitDashboard(1);
       // start editing
       cy.icon("pencil").click();
 
@@ -250,7 +251,7 @@ describe("scenarios > dashboard > chained filter", () => {
         },
         enable_embedding: true,
       });
-      cy.visit(`/dashboard/${dashboardId}`);
+      visitDashboard(dashboardId);
     });
 
     // First make sure normal filtering works - we reuse the chained filter test above.
@@ -344,7 +345,7 @@ describe("scenarios > dashboard > chained filter", () => {
           });
         });
 
-        cy.visit(`/dashboard/${DASHBOARD_ID}`);
+        visitDashboard(DASHBOARD_ID);
         cy.icon("pencil").click();
         showDashboardCardActions();
         cy.icon("click").click();

--- a/frontend/test/metabase/scenarios/dashboard/click-behavior.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/click-behavior.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore } from "__support__/e2e/cypress";
+import { restore, visitDashboard } from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const {
@@ -47,7 +47,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
                 ],
               });
 
-              cy.visit(`/dashboard/${dashboardId}`);
+              visitDashboard(dashboardId);
 
               cy.intercept(
                 "POST",
@@ -134,7 +134,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
             ],
           });
 
-          cy.visit(`/dashboard/${dashboard_id}`);
+          visitDashboard(dashboard_id);
 
           cy.intercept(
             "POST",

--- a/frontend/test/metabase/scenarios/dashboard/click-behavior.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/click-behavior.cy.spec.js
@@ -135,16 +135,10 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
           });
 
           visitDashboard(dashboard_id);
-
-          cy.intercept(
-            "POST",
-            `/api/dashboard/${dashboard_id}/dashcard/*/card/${card_id}/query`,
-          ).as("cardQuery");
         },
       );
     });
 
-    cy.wait("@cardQuery");
     cy.get(".cellData")
       .contains("5")
       .first()

--- a/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
@@ -476,15 +476,14 @@ describe("scenarios > dashboard > dashboard drill", () => {
             ],
           });
         });
-        cy.server();
-        cy.route(
+
+        visitDashboard(DASHBOARD_ID);
+
+        cy.intercept(
           "POST",
           `/api/dashboard/${DASHBOARD_ID}/dashcard/*/card/${QUESTION_ID}/query`,
         ).as("cardQuery");
 
-        visitDashboard(DASHBOARD_ID);
-
-        cy.wait("@cardQuery");
         cy.get(".bar")
           .eq(14) // August 2017 (Total of 12 reviews, 9 unique days)
           .click({ force: true });
@@ -723,13 +722,8 @@ describe("scenarios > dashboard > dashboard drill", () => {
               ],
             });
           });
-          cy.intercept(
-            "POST",
-            `/api/dashboard/${DASHBOARD_ID}/dashcard/*/card/${QUESTION2_ID}/query`,
-          ).as("secondCardQuery");
 
           visitDashboard(DASHBOARD_ID);
-          cy.wait("@secondCardQuery");
 
           cy.get(".bar")
             .first()

--- a/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
@@ -4,6 +4,7 @@ import {
   popover,
   filterWidget,
   showDashboardCardActions,
+  visitDashboard,
 } from "__support__/e2e/cypress";
 
 import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
@@ -25,9 +26,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
   });
 
   it("should handle URL click through on a table", () => {
-    createDashboardWithQuestion({}, dashboardId =>
-      cy.visit(`/dashboard/${dashboardId}`),
-    );
+    createDashboardWithQuestion({}, dashboardId => visitDashboard(dashboardId));
     cy.icon("pencil").click();
     showDashboardCardActions();
     cy.icon("click").click();
@@ -106,7 +105,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
           visualization_settings: clickBehavior,
         });
 
-        cy.visit(`/dashboard/${dashboard_id}`);
+        visitDashboard(dashboard_id);
       },
     );
 
@@ -141,7 +140,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
       questionId => {
         createDashboard(
           { questionId, visualization_settings: dashCardSettings },
-          dashboardIdA => cy.visit(`/dashboard/${dashboardIdA}`),
+          dashboardIdA => visitDashboard(dashboardIdA),
         );
       },
     );
@@ -153,9 +152,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
   });
 
   it("should handle question click through on a table", () => {
-    createDashboardWithQuestion({}, dashboardId =>
-      cy.visit(`/dashboard/${dashboardId}`),
-    );
+    createDashboardWithQuestion({}, dashboardId => visitDashboard(dashboardId));
     cy.icon("pencil").click();
     showDashboardCardActions();
     cy.icon("click").click();
@@ -201,7 +198,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
           createDashboardWithQuestion(
             { dashboardName: "end dash" },
             dashboardIdB => {
-              cy.visit(`/dashboard/${dashboardIdA}`);
+              visitDashboard(dashboardIdA);
             },
           );
         },
@@ -246,9 +243,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
 
   // This was flaking. Example: https://dashboard.cypress.io/projects/a394u1/runs/2109/test-results/91a15b66-4b80-40bf-b569-de28abe21f42
   it.skip("should handle cross-filter on a table", () => {
-    createDashboardWithQuestion({}, dashboardId =>
-      cy.visit(`/dashboard/${dashboardId}`),
-    );
+    createDashboardWithQuestion({}, dashboardId => visitDashboard(dashboardId));
     cy.icon("pencil").click();
     showDashboardCardActions();
     cy.icon("click").click();
@@ -395,7 +390,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
     cy.server();
     cy.route("POST", "/api/dataset").as("dataset");
 
-    cy.visit("/dashboard/1");
+    visitDashboard(1);
     // Product ID in the first row (query fails for User ID as well)
     cy.findByText("105").click();
     cy.findByText("View details").click();
@@ -487,7 +482,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
           `/api/dashboard/${DASHBOARD_ID}/dashcard/*/card/${QUESTION_ID}/query`,
         ).as("cardQuery");
 
-        cy.visit(`/dashboard/${DASHBOARD_ID}`);
+        visitDashboard(DASHBOARD_ID);
 
         cy.wait("@cardQuery");
         cy.get(".bar")
@@ -530,7 +525,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
     createQuestion({ visualization_settings: questionSettings }, questionId => {
       createDashboard(
         { questionId, visualization_settings: dashCardSettings },
-        dashboardIdA => cy.visit(`/dashboard/${dashboardIdA}`),
+        dashboardIdA => visitDashboard(dashboardIdA),
       );
     });
 
@@ -580,7 +575,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
           });
         });
 
-        cy.visit(`/dashboard/${DASHBOARD_ID}`);
+        visitDashboard(DASHBOARD_ID);
         cy.icon("pencil").click();
         // Edit "Visualization options"
         showDashboardCardActions();
@@ -733,7 +728,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
             `/api/dashboard/${DASHBOARD_ID}/dashcard/*/card/${QUESTION2_ID}/query`,
           ).as("secondCardQuery");
 
-          cy.visit(`/dashboard/${DASHBOARD_ID}`);
+          visitDashboard(DASHBOARD_ID);
           cy.wait("@secondCardQuery");
 
           cy.get(".bar")
@@ -820,7 +815,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
         ],
       });
 
-      cy.visit("/dashboard/1");
+      visitDashboard(1);
     });
 
     it("should correctly drill-through on Orders filter (metabase#11503-1)", () => {

--- a/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
@@ -8,6 +8,7 @@ import {
   sidebar,
   modal,
   openNewCollectionItemFlowFor,
+  visitDashboard,
 } from "__support__/e2e/cypress";
 
 import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
@@ -54,7 +55,7 @@ describe("scenarios > dashboard", () => {
   });
 
   it("should update the name and description", () => {
-    cy.visit("/dashboard/1");
+    visitDashboard(1);
 
     cy.icon("ellipsis").click();
     // update title
@@ -70,7 +71,7 @@ describe("scenarios > dashboard", () => {
     });
 
     // refresh page and check that title/desc were updated
-    cy.visit("/dashboard/1");
+    visitDashboard(1);
     cy.findByText("Orders per year")
       .next()
       .trigger("mouseenter");
@@ -78,7 +79,7 @@ describe("scenarios > dashboard", () => {
   });
 
   it("should add a filter", () => {
-    cy.visit("/dashboard/1");
+    visitDashboard(1);
     cy.icon("pencil").click();
     cy.icon("filter").click();
     // Adding location/state doesn't make much sense for this case,
@@ -103,7 +104,7 @@ describe("scenarios > dashboard", () => {
   });
 
   it("should add a question", () => {
-    cy.visit("/dashboard/1");
+    visitDashboard(1);
     cy.icon("pencil").click();
     cy.get(".QueryBuilder-section .Icon-add").click();
     cy.findByText("Orders, Count").click();
@@ -243,7 +244,7 @@ describe("scenarios > dashboard", () => {
           });
         });
 
-        cy.visit(`/dashboard/${dashboardId}`);
+        visitDashboard(dashboardId);
         cy.get(".leaflet-marker-icon") // pin icon
           .eq(0)
           .click({ force: true });
@@ -282,7 +283,7 @@ describe("scenarios > dashboard", () => {
           ],
         });
 
-        cy.visit(`/dashboard/${dashboard_id}`);
+        visitDashboard(dashboard_id);
       },
     );
 
@@ -349,7 +350,7 @@ describe("scenarios > dashboard", () => {
     cy.route(`/api/field/${PRODUCTS.CATEGORY}`).as("fetchField");
     cy.route(`/api/field/${PRODUCTS.CATEGORY}/values`).as("fetchFieldValues");
 
-    cy.visit("/dashboard/1");
+    visitDashboard(1);
 
     filterWidget()
       .as("filterWidget")
@@ -409,7 +410,7 @@ describe("scenarios > dashboard", () => {
       },
     );
     cy.signInAsNormalUser();
-    cy.visit("/dashboard/1");
+    visitDashboard(1);
 
     cy.wait("@loadDashboard");
     cy.findByText("Orders in a dashboard");
@@ -434,7 +435,7 @@ describe("scenarios > dashboard", () => {
       ],
     });
 
-    cy.visit("/dashboard/1");
+    visitDashboard(1);
     cy.contains("37.65");
     assertScrollBarExists();
     cy.icon("share").click();
@@ -447,7 +448,7 @@ describe("scenarios > dashboard", () => {
 
   it("should show values of added dashboard card via search immediately (metabase#15959)", () => {
     cy.intercept("GET", "/api/search*").as("search");
-    cy.visit("/dashboard/1");
+    visitDashboard(1);
     cy.icon("pencil").click();
     cy.icon("add")
       .last()

--- a/frontend/test/metabase/scenarios/dashboard/dashboard_data_permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard_data_permissions.cy.spec.js
@@ -2,10 +2,11 @@ import {
   restore,
   popover,
   selectDashboardFilter,
+  visitDashboard,
 } from "__support__/e2e/cypress";
 
 function filterDashboard(suggests = true) {
-  cy.visit("/dashboard/1");
+  visitDashboard(1);
   cy.contains("Orders");
 
   // We should get a suggested response and be able to click it if we're an admin
@@ -29,7 +30,7 @@ describe("support > permissions (metabase#8472)", () => {
     cy.signInAsAdmin();
 
     // Setup a dashboard with a text filter
-    cy.visit("/dashboard/1");
+    visitDashboard(1);
     // click pencil icon to edit
     cy.icon("pencil").click();
 

--- a/frontend/test/metabase/scenarios/dashboard/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/permissions.cy.spec.js
@@ -63,6 +63,8 @@ describe("scenarios > dashboard > permissions", () => {
     });
 
     cy.createDashboard().then(({ body: { id: dashId } }) => {
+      dashboardId = dashId;
+
       cy.request("POST", `/api/dashboard/${dashId}/cards`, {
         cardId: firstQuestionId,
       }).then(({ body: { id: dashCardIdA } }) => {
@@ -91,12 +93,11 @@ describe("scenarios > dashboard > permissions", () => {
           });
         });
       });
-      dashboardId = dashId;
-      visitDashboard(dashId);
     });
   });
 
   it("should let admins view all cards in a dashboard", () => {
+    visitDashboard(dashboardId);
     // Admin can see both questions
     cy.findByText("First Question");
     cy.findByText("foo");

--- a/frontend/test/metabase/scenarios/dashboard/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/permissions.cy.spec.js
@@ -1,6 +1,6 @@
 import _ from "underscore";
 import { assoc } from "icepick";
-import { restore } from "__support__/e2e/cypress";
+import { restore, visitDashboard } from "__support__/e2e/cypress";
 import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 
 describe("scenarios > dashboard > permissions", () => {
@@ -92,7 +92,7 @@ describe("scenarios > dashboard > permissions", () => {
         });
       });
       dashboardId = dashId;
-      cy.visit(`/dashboard/${dashId}`);
+      visitDashboard(dashId);
     });
   });
 
@@ -106,7 +106,7 @@ describe("scenarios > dashboard > permissions", () => {
 
   it("should display dashboards with some cards locked down", () => {
     cy.signIn("nodata");
-    cy.visit(`/dashboard/${dashboardId}`);
+    visitDashboard(dashboardId);
     cy.findByText("Sorry, you don't have permission to see this card.");
     cy.findByText("Second Question");
     cy.findByText("bar");
@@ -114,7 +114,7 @@ describe("scenarios > dashboard > permissions", () => {
 
   it("should display an error if they don't have perms for the dashboard", () => {
     cy.signIn("nocollection");
-    cy.visit(`/dashboard/${dashboardId}`);
+    visitDashboard(dashboardId);
     cy.findByText("Sorry, you don’t have permission to see that.");
   });
 });

--- a/frontend/test/metabase/scenarios/dashboard/reproductions/18454-card-description.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/reproductions/18454-card-description.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore } from "__support__/e2e/cypress";
+import { restore, visitDashboard } from "__support__/e2e/cypress";
 
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
@@ -48,7 +48,7 @@ function createDashboardWithQuestionWithDescription() {
         ],
       });
 
-      cy.visit(`/dashboard/${dashboard_id}`);
+      visitDashboard(dashboard_id);
 
       cy.intercept(
         "POST",

--- a/frontend/test/metabase/scenarios/dashboard/reproductions/18454-card-description.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/reproductions/18454-card-description.cy.spec.js
@@ -6,54 +6,33 @@ const { PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
 
 const CARD_DESCRIPTION = "CARD_DESCRIPTION";
 
+const questionDetails = {
+  name: "18454 Question",
+  description: CARD_DESCRIPTION,
+  query: {
+    "source-table": PRODUCTS_ID,
+    aggregation: [["count"]],
+    breakout: [["field", PRODUCTS.CATEGORY, null]],
+  },
+  display: "line",
+};
+
 describe("issue 18454", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
+
+    cy.createQuestionAndDashboard({ questionDetails }).then(
+      ({ body: { id, card_id, dashboard_id } }) => {
+        visitDashboard(dashboard_id);
+      },
+    );
   });
 
   it("should show card descriptions (metabase#18454)", () => {
-    createDashboardWithQuestionWithDescription();
+    cy.get(".DashCard").realHover();
+    cy.icon("info").trigger("mouseenter", { force: true });
 
-    cy.wait("@cardQuery");
-    cy.icon("info").realHover();
     cy.findByText(CARD_DESCRIPTION);
   });
 });
-
-function createDashboardWithQuestionWithDescription() {
-  const questionDetails = {
-    name: "18454 Question",
-    description: CARD_DESCRIPTION,
-    query: {
-      "source-table": PRODUCTS_ID,
-      aggregation: [["count"]],
-      breakout: [["field", PRODUCTS.CATEGORY, null]],
-    },
-    display: "line",
-  };
-
-  cy.createQuestionAndDashboard({ questionDetails }).then(
-    ({ body: { id, card_id, dashboard_id } }) => {
-      cy.request("PUT", `/api/dashboard/${dashboard_id}/cards`, {
-        cards: [
-          {
-            id,
-            card_id,
-            row: 0,
-            col: 0,
-            sizeX: 12,
-            sizeY: 10,
-          },
-        ],
-      });
-
-      visitDashboard(dashboard_id);
-
-      cy.intercept(
-        "POST",
-        `/api/dashboard/${dashboard_id}/dashcard/*/card/${card_id}/query`,
-      ).as("cardQuery");
-    },
-  );
-}

--- a/frontend/test/metabase/scenarios/dashboard/reproductions/20637-add-series-to-dashcard.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/reproductions/20637-add-series-to-dashcard.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore } from "__support__/e2e/cypress";
+import { restore, visitDashboard } from "__support__/e2e/cypress";
 
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
@@ -86,7 +86,7 @@ function createQuestionsAndDashboard() {
             ],
           });
 
-          cy.visit(`/dashboard/${dashboard_id}`);
+          visitDashboard(dashboard_id);
 
           cy.intercept(
             "POST",

--- a/frontend/test/metabase/scenarios/dashboard/reproductions/20637-add-series-to-dashcard.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/reproductions/20637-add-series-to-dashcard.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, visitDashboard } from "__support__/e2e/cypress";
+import { restore } from "__support__/e2e/cypress";
 
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
@@ -86,7 +86,7 @@ function createQuestionsAndDashboard() {
             ],
           });
 
-          visitDashboard(dashboard_id);
+          cy.visit(`/dashboard/${dashboard_id}`);
 
           cy.intercept(
             "POST",

--- a/frontend/test/metabase/scenarios/dashboard/text-box.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/text-box.cy.spec.js
@@ -2,6 +2,7 @@ import {
   restore,
   showDashboardCardActions,
   popover,
+  visitDashboard,
 } from "__support__/e2e/cypress";
 
 function addTextBox(string) {
@@ -21,7 +22,7 @@ describe("scenarios > dashboard > text-box", () => {
   describe("Editing", () => {
     beforeEach(() => {
       // Create text box card
-      cy.visit("/dashboard/1");
+      visitDashboard(1);
       addTextBox("Text *text* __text__");
     });
 
@@ -57,7 +58,7 @@ describe("scenarios > dashboard > text-box", () => {
       cy.createDashboard().then(({ body: { id } }) => {
         cy.intercept("PUT", `/api/dashboard/${id}`).as("dashboardUpdated");
 
-        cy.visit(`/dashboard/${id}`);
+        visitDashboard(id);
       });
     });
 
@@ -115,7 +116,7 @@ describe("scenarios > dashboard > text-box", () => {
   });
 
   it("should let you add a parameter to a dashboard with a text box (metabase#11927)", () => {
-    cy.visit("/dashboard/1");
+    visitDashboard(1);
     // click pencil icon to edit
     cy.icon("pencil").click();
     // add text box with text

--- a/frontend/test/metabase/scenarios/dashboard/title-drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/title-drill.cy.spec.js
@@ -1,4 +1,9 @@
-import { restore, filterWidget, popover } from "__support__/e2e/cypress";
+import {
+  restore,
+  filterWidget,
+  popover,
+  visitDashboard,
+} from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
@@ -21,7 +26,7 @@ describe("scenarios > dashboard > title drill", () => {
 
       cy.createNativeQuestionAndDashboard({ questionDetails }).then(
         ({ body: { dashboard_id } }) => {
-          cy.visit(`/dashboard/${dashboard_id}`);
+          visitDashboard(dashboard_id);
         },
       );
     });
@@ -121,7 +126,7 @@ describe("scenarios > dashboard > title drill", () => {
             ],
           });
 
-          cy.visit(`/dashboard/${dashboard_id}`);
+          visitDashboard(dashboard_id);
           checkScalarResult("200");
         },
       );
@@ -230,7 +235,7 @@ describe("scenarios > dashboard > title drill", () => {
             `/api/dashboard/${dashboard_id}/dashcard/*/card/${card_id}/query`,
           ).as("cardQuery");
 
-          cy.visit(`/dashboard/${dashboard_id}`);
+          visitDashboard(dashboard_id);
         },
       );
     });

--- a/frontend/test/metabase/scenarios/dashboard/visualizaiton-options.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/visualizaiton-options.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore } from "__support__/e2e/cypress";
+import { restore, visitDashboard } from "__support__/e2e/cypress";
 
 describe("scenarios > dashboard > visualization options", () => {
   beforeEach(() => {
@@ -7,7 +7,7 @@ describe("scenarios > dashboard > visualization options", () => {
   });
 
   it("column reordering should work (metabase#16229)", () => {
-    cy.visit("/dashboard/1");
+    visitDashboard(1);
     cy.icon("pencil").click();
     cy.get(".Card").realHover();
     cy.icon("palette").click();

--- a/frontend/test/metabase/scenarios/embedding/embedding-smoketests.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/embedding-smoketests.cy.spec.js
@@ -1,4 +1,10 @@
-import { restore, visitQuestion, isEE, isOSS } from "__support__/e2e/cypress";
+import {
+  restore,
+  visitQuestion,
+  isEE,
+  isOSS,
+  visitDashboard,
+} from "__support__/e2e/cypress";
 
 const embeddingPage = "/admin/settings/embedding_in_other_applications";
 const licenseUrl = "https://metabase.com/license/embedding";
@@ -84,7 +90,7 @@ describe("scenarios > embedding > smoke tests", () => {
     });
 
     it("should not let you embed the dashboard", () => {
-      cy.visit("/dashboard/1");
+      visitDashboard(1);
 
       cy.icon("share").click();
       cy.findByText("Sharing and embedding").click();
@@ -229,7 +235,7 @@ function visitAndEnableSharing(object) {
   }
 
   if (object === "dashboard") {
-    cy.visit("/dashboard/1");
+    visitDashboard(1);
 
     cy.icon("share").click();
     cy.findByText("Sharing and embedding").click();

--- a/frontend/test/metabase/scenarios/embedding/embedding-snippets.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/embedding-snippets.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, popover } from "__support__/e2e/cypress";
+import { restore, popover, visitDashboard } from "__support__/e2e/cypress";
 
 describe("scenarios > embedding > code snippets", () => {
   beforeEach(() => {
@@ -7,7 +7,7 @@ describe("scenarios > embedding > code snippets", () => {
   });
 
   it("dashboard should have the correct embed snippet", () => {
-    cy.visit("/dashboard/1");
+    visitDashboard(1);
     cy.icon("share").click();
     cy.findByText("Sharing and embedding").click();
     cy.contains(/Embed this .* in an application/).click();

--- a/frontend/test/metabase/scenarios/embedding/parameters-embedded.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/parameters-embedded.cy.spec.js
@@ -1,4 +1,9 @@
-import { restore, popover, visitQuestion } from "__support__/e2e/cypress";
+import {
+  restore,
+  popover,
+  visitQuestion,
+  visitDashboard,
+} from "__support__/e2e/cypress";
 
 import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
@@ -54,7 +59,7 @@ describe("scenarios > dashboard > parameters-embedded", () => {
 
   describe("embedded parameters", () => {
     it("should be disabled by default but able to be set to editable", () => {
-      cy.visit("/dashboard/2");
+      visitDashboard(2);
       cy.icon("share").click();
       cy.findByText("Sharing and embedding").click();
       cy.findByText("Embed this dashboard in an application").click();
@@ -100,7 +105,7 @@ describe("scenarios > dashboard > parameters-embedded", () => {
     });
 
     it("should let parameters be locked to a specific value (metabase#20357)", () => {
-      cy.visit("/dashboard/2");
+      visitDashboard(2);
       cy.icon("share").click();
       cy.findByText("Sharing and embedding").click();
       cy.findByText("Embed this dashboard in an application").click();
@@ -201,7 +206,7 @@ describe("scenarios > dashboard > parameters-embedded", () => {
     beforeEach(cy.signInAsAdmin);
 
     sharedParametersTests(() => {
-      cy.visit(`/dashboard/${dashboardId}`);
+      visitDashboard(dashboardId);
       // wait for question to load/run
       cy.contains("Test Dashboard");
       cy.contains("2,500");

--- a/frontend/test/metabase/scenarios/embedding/reproductions/20393-public-dashboard-nested-card-with-parameters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/reproductions/20393-public-dashboard-nested-card-with-parameters.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, popover } from "__support__/e2e/cypress";
+import { restore, popover, visitDashboard } from "__support__/e2e/cypress";
 
 describe("issue 20393", () => {
   beforeEach(() => {
@@ -64,7 +64,7 @@ function createDashboardWithNestedCard() {
           .createDashboard("Q2 in a dashboard")
           .then(({ body: { id: dashId } }) => {
             cy.request("POST", `/api/dashboard/${dashId}/cards`, { cardId });
-            cy.visit(`/dashboard/${dashId}`);
+            visitDashboard(dashId);
           }),
       ),
   );

--- a/frontend/test/metabase/scenarios/embedding/reproductions/20438-dashboard-filter-single-value.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/reproductions/20438-dashboard-filter-single-value.cy.spec.js
@@ -1,4 +1,9 @@
-import { restore, filterWidget, popover } from "__support__/e2e/cypress";
+import {
+  restore,
+  filterWidget,
+  popover,
+  visitDashboard,
+} from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { PRODUCTS } = SAMPLE_DATABASE;
@@ -68,7 +73,7 @@ describe("issue 20438", () => {
           embedding_params: { [filter.slug]: "enabled" },
         });
 
-        cy.visit(`/dashboard/${dashboard_id}`);
+        visitDashboard(dashboard_id);
       },
     );
   });

--- a/frontend/test/metabase/scenarios/models/models.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models.cy.spec.js
@@ -11,6 +11,7 @@ import {
   summarize,
   filter,
   visitQuestion,
+  visitDashboard,
 } from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 import {
@@ -536,7 +537,7 @@ describe("scenarios > models", () => {
     it("should allow adding models to dashboards", () => {
       cy.intercept("GET", "/api/dashboard/*").as("fetchDashboard");
       cy.createDashboard().then(({ body: { id: dashboardId } }) => {
-        cy.visit(`/dashboard/${dashboardId}`);
+        visitDashboard(dashboardId);
         cy.icon("pencil").click();
         cy.get(".QueryBuilder-section .Icon-add").click();
         sidebar()

--- a/frontend/test/metabase/scenarios/models/models.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models.cy.spec.js
@@ -536,6 +536,7 @@ describe("scenarios > models", () => {
 
     it("should allow adding models to dashboards", () => {
       cy.intercept("GET", "/api/dashboard/*").as("fetchDashboard");
+
       cy.createDashboard().then(({ body: { id: dashboardId } }) => {
         visitDashboard(dashboardId);
         cy.icon("pencil").click();
@@ -544,7 +545,9 @@ describe("scenarios > models", () => {
           .findByText("Orders Model")
           .click();
         cy.button("Save").click();
-        cy.wait("@fetchDashboard");
+        // The first fetch happened when visiting dashboard, and the second one upon saving it.
+        // We need to wait for both.
+        cy.wait(["@fetchDashboard", "@fetchDashboard"]);
         cy.findByText("Orders Model");
       });
     });

--- a/frontend/test/metabase/scenarios/onboarding/home/activity-page.cy.spec.js
+++ b/frontend/test/metabase/scenarios/onboarding/home/activity-page.cy.spec.js
@@ -6,6 +6,7 @@ import {
   sidebar,
   editDashboard,
   saveDashboard,
+  visitDashboard,
 } from "__support__/e2e/cypress";
 
 describe("metabase > scenarios > home > activity-page", () => {
@@ -58,7 +59,7 @@ describe("metabase > scenarios > home > activity-page", () => {
   it("should respect the (added to dashboard) card id in the link (metabase#18547)", () => {
     cy.intercept("GET", `/api/dashboard/1`).as("dashboard");
 
-    cy.visit("/dashboard/1");
+    visitDashboard(1);
     cy.wait("@dashboard");
 
     editDashboard();

--- a/frontend/test/metabase/scenarios/onboarding/search/recently-viewed.cy.spec.js
+++ b/frontend/test/metabase/scenarios/onboarding/search/recently-viewed.cy.spec.js
@@ -1,4 +1,8 @@
-import { restore, visitQuestion } from "__support__/e2e/cypress";
+import {
+  restore,
+  visitQuestion,
+  visitDashboard,
+} from "__support__/e2e/cypress";
 
 describe(`search > recently viewed`, () => {
   beforeEach(() => {
@@ -19,7 +23,7 @@ describe(`search > recently viewed`, () => {
     visitQuestion(1);
 
     // "Orders in a dashboard" dashboard
-    cy.visit("/dashboard/1");
+    visitDashboard(1);
     cy.findByTextEnsureVisible("Product ID");
 
     // inside the "Orders in a dashboard" dashboard, the order is queried again,

--- a/frontend/test/metabase/scenarios/permissions/sandboxes.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/sandboxes.cy.spec.js
@@ -12,6 +12,7 @@ import {
   summarize,
   filter,
   visitQuestion,
+  visitDashboard,
 } from "__support__/e2e/cypress";
 import { USER_GROUPS, SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 
@@ -898,7 +899,7 @@ describeEE("formatting > sandboxes", () => {
       });
 
       cy.signInAsSandboxedUser();
-      cy.visit("/dashboard/1");
+      visitDashboard(1);
       cy.icon("share").click();
       cy.findByText("Dashboard subscriptions").click();
       // We're starting without email or Slack being set up so it's expected to see the following:
@@ -1026,7 +1027,7 @@ describeEE("formatting > sandboxes", () => {
       });
 
       cy.signInAsSandboxedUser();
-      cy.visit("/dashboard/1");
+      visitDashboard(1);
       cy.icon("share").click();
       cy.findByText("Dashboard subscriptions").click();
       cy.findByText("Email it").click();

--- a/frontend/test/metabase/scenarios/question/nested.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nested.cy.spec.js
@@ -7,6 +7,7 @@ import {
   visualize,
   getDimensionByName,
   summarize,
+  visitDashboard,
 } from "__support__/e2e/cypress";
 
 import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
@@ -214,8 +215,8 @@ describe("scenarios > question > nested", () => {
       },
     );
 
-    cy.createDashboard().then(({ body: { id: DASBOARD_ID } }) => {
-      cy.visit(`/dashboard/${DASBOARD_ID}`);
+    cy.createDashboard().then(({ body: { id: DASHBOARD_ID } }) => {
+      visitDashboard(DASHBOARD_ID);
     });
 
     // Add Q2 to that dashboard

--- a/frontend/test/metabase/scenarios/question/nulls.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nulls.cy.spec.js
@@ -3,6 +3,7 @@ import {
   openOrdersTable,
   popover,
   summarize,
+  visitDashboard,
 } from "__support__/e2e/cypress";
 
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
@@ -153,7 +154,7 @@ describe("scenarios > question > null", () => {
             });
           });
 
-          cy.visit(`/dashboard/${DASHBOARD_ID}`);
+          visitDashboard(DASHBOARD_ID);
           cy.log("P0 regression in v0.37.1!");
           cy.findByTestId("loading-spinner").should("not.exist");
           cy.findByText("13801_Q1");

--- a/frontend/test/metabase/scenarios/question/reproductions/17514-ui-overlay.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/17514-ui-overlay.cy.spec.js
@@ -56,11 +56,6 @@ describe("issue 17514", () => {
         ({ body: card }) => {
           const { card_id, dashboard_id } = card;
 
-          cy.intercept(
-            "POST",
-            `/api/dashboard/${dashboard_id}/dashcard/*/card/${card_id}/query`,
-          ).as("cardQuery");
-
           const mapFilterToCard = {
             parameter_mappings: [
               {
@@ -75,7 +70,10 @@ describe("issue 17514", () => {
 
           visitDashboard(dashboard_id);
 
-          cy.wait("@cardQuery");
+          cy.intercept(
+            "POST",
+            `/api/dashboard/${dashboard_id}/dashcard/*/card/${card_id}/query`,
+          ).as("cardQuery");
         },
       );
     });

--- a/frontend/test/metabase/scenarios/question/reproductions/17514-ui-overlay.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/17514-ui-overlay.cy.spec.js
@@ -5,6 +5,7 @@ import {
   saveDashboard,
   editDashboard,
   visualize,
+  visitDashboard,
 } from "__support__/e2e/cypress";
 
 import { setAdHocFilter } from "../../native-filters/helpers/e2e-date-filter-helpers";
@@ -72,7 +73,7 @@ describe("issue 17514", () => {
 
           cy.editDashboardCard(card, mapFilterToCard);
 
-          cy.visit(`/dashboard/${dashboard_id}`);
+          visitDashboard(dashboard_id);
 
           cy.wait("@cardQuery");
         },

--- a/frontend/test/metabase/scenarios/question/view.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/view.cy.spec.js
@@ -4,6 +4,7 @@ import {
   popover,
   filter,
   visitQuestion,
+  visitDashboard,
 } from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
@@ -132,7 +133,7 @@ describe("scenarios > question > view", () => {
     it("should be able to filter Q by Vendor as user (from Dashboard) (metabase#12654)", () => {
       // Navigate to Q from Dashboard
       cy.signIn("nodata");
-      cy.visit("/dashboard/2");
+      visitDashboard(2);
       cy.findByText("Question").click();
 
       // Filter by category and vendor

--- a/frontend/test/metabase/scenarios/sharing/approved-domains.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/approved-domains.cy.spec.js
@@ -5,6 +5,7 @@ import {
   setupSMTP,
   sidebar,
   visitQuestion,
+  visitDashboard,
 } from "__support__/e2e/cypress";
 
 const allowedDomain = "metabase.test";
@@ -55,7 +56,7 @@ describeEE("scenarios > sharing > approved domains (EE)", () => {
   });
 
   it("should validate approved email domains for a dashboard subscription (metabase#17977)", () => {
-    cy.visit("/dashboard/1");
+    visitDashboard(1);
     cy.icon("share").click();
     cy.findByText("Dashboard subscriptions").click();
     cy.findByText("Email it").click();
@@ -71,7 +72,7 @@ describeEE("scenarios > sharing > approved domains (EE)", () => {
   });
 
   it("should validate approved email domains for a dashboard subscription in the audit app", () => {
-    cy.visit("/dashboard/1");
+    visitDashboard(1);
     cy.icon("share").click();
     cy.findByText("Dashboard subscriptions").click();
     cy.findByText("Email it").click();

--- a/frontend/test/metabase/scenarios/sharing/public.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/public.cy.spec.js
@@ -3,6 +3,7 @@ import {
   popover,
   modal,
   visitQuestion,
+  visitDashboard,
 } from "__support__/e2e/cypress";
 
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
@@ -165,7 +166,7 @@ describe.skip("scenarios > public", () => {
     it("should allow users to create public dashboards", () => {
       cy.request("PUT", "/api/setting/enable-public-sharing", { value: true });
 
-      cy.visit(`/dashboard/${dashboardId}`);
+      visitDashboard(dashboardId);
 
       cy.icon("share").click();
       cy.contains("Sharing and embedding").click();
@@ -190,7 +191,7 @@ describe.skip("scenarios > public", () => {
         value: "http://localhost:4000/", // Cypress.config().baseUrl
       });
 
-      cy.visit(`/dashboard/${dashboardId}`);
+      visitDashboard(dashboardId);
 
       cy.icon("share").click();
       cy.contains("Sharing and embedding").click();

--- a/frontend/test/metabase/scenarios/sharing/reproductions/17657.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/reproductions/17657.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, sidebar } from "__support__/e2e/cypress";
+import { restore, sidebar, visitDashboard } from "__support__/e2e/cypress";
 import { USERS } from "__support__/e2e/cypress_data";
 
 const {
@@ -14,7 +14,7 @@ describe("issue 17657", () => {
   });
 
   it("frontend should gracefully handle the case of a subscription without a recipient (metabase#17657)", () => {
-    cy.visit("/dashboard/1");
+    visitDashboard(1);
 
     cy.icon("share").click();
     cy.findByText("Dashboard subscriptions").click();

--- a/frontend/test/metabase/scenarios/sharing/reproductions/17658.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/reproductions/17658.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, setupSMTP } from "__support__/e2e/cypress";
+import { restore, setupSMTP, visitDashboard } from "__support__/e2e/cypress";
 
 describe("issue 17658", () => {
   beforeEach(() => {
@@ -12,7 +12,7 @@ describe("issue 17658", () => {
   });
 
   it("should delete dashboard subscription from any collection (metabase#17658)", () => {
-    cy.visit("/dashboard/1");
+    visitDashboard(1);
 
     cy.icon("share").click();
     cy.findByText("Dashboard subscriptions").click();

--- a/frontend/test/metabase/scenarios/sharing/reproductions/18009-nodata-creates-subscription-receives-error.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/reproductions/18009-nodata-creates-subscription-receives-error.cy.spec.js
@@ -1,4 +1,9 @@
-import { restore, popover, setupSMTP } from "__support__/e2e/cypress";
+import {
+  restore,
+  popover,
+  setupSMTP,
+  visitDashboard,
+} from "__support__/e2e/cypress";
 
 describe.skip("issue 18009", () => {
   beforeEach(() => {
@@ -11,7 +16,7 @@ describe.skip("issue 18009", () => {
   });
 
   it("nodata user should be able to create and receive an email subscription without errors (metabase#18009)", () => {
-    cy.visit("/dashboard/1");
+    visitDashboard(1);
 
     cy.icon("share").click();
     cy.findByText("Dashboard subscriptions").click();

--- a/frontend/test/metabase/scenarios/sharing/reproductions/18344-subscription-shows-original-question-name.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/reproductions/18344-subscription-shows-original-question-name.cy.spec.js
@@ -3,6 +3,7 @@ import {
   editDashboard,
   saveDashboard,
   setupSMTP,
+  visitDashboard,
 } from "__support__/e2e/cypress";
 
 import { USERS } from "__support__/e2e/cypress_data";
@@ -19,7 +20,7 @@ describe("issue 18344", () => {
     setupSMTP();
 
     // Rename the question
-    cy.visit("/dashboard/1");
+    visitDashboard(1);
 
     editDashboard();
 

--- a/frontend/test/metabase/scenarios/sharing/reproductions/18352-subscription-int64-value-card.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/reproductions/18352-subscription-int64-value-card.cy.spec.js
@@ -1,4 +1,9 @@
-import { restore, setupSMTP, visitQuestion } from "__support__/e2e/cypress";
+import {
+  restore,
+  setupSMTP,
+  visitQuestion,
+  visitDashboard,
+} from "__support__/e2e/cypress";
 import { USERS } from "__support__/e2e/cypress_data";
 
 const {
@@ -23,7 +28,7 @@ describe("issue 18352", () => {
       ({ body: { card_id, dashboard_id } }) => {
         visitQuestion(card_id);
 
-        cy.visit(`/dashboard/${dashboard_id}`);
+        visitDashboard(dashboard_id);
       },
     );
   });

--- a/frontend/test/metabase/scenarios/sharing/reproductions/18669-test-email-with-parameters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/reproductions/18669-test-email-with-parameters.cy.spec.js
@@ -4,6 +4,7 @@ import {
   restore,
   setupSMTP,
   sidebar,
+  visitDashboard,
 } from "__support__/e2e/cypress";
 
 import { USERS, SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
@@ -21,7 +22,7 @@ describeEE("issue 18669", () => {
     cy.createQuestionAndDashboard({ questionDetails, dashboardDetails }).then(
       ({ body: card }) => {
         cy.editDashboardCard(card, getFilterMapping(card));
-        cy.visit(`/dashboard/${card.dashboard_id}`);
+        visitDashboard(card.dashboard_id);
       },
     );
   });

--- a/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
@@ -6,6 +6,7 @@ import {
   sidebar,
   mockSlackConfigured,
   isOSS,
+  visitDashboard,
 } from "__support__/e2e/cypress";
 import { USERS } from "__support__/e2e/cypress_data";
 const { admin } = USERS;
@@ -18,7 +19,7 @@ describe("scenarios > dashboard > subscriptions", () => {
 
   it.skip("should not allow sharing if there are no dashboard cards", () => {
     cy.createDashboard().then(({ body: { id: DASHBOARD_ID } }) => {
-      cy.visit(`/dashboard/${DASHBOARD_ID}`);
+      visitDashboard(DASHBOARD_ID);
     });
     cy.findByText("This dashboard is looking empty.");
 
@@ -34,7 +35,7 @@ describe("scenarios > dashboard > subscriptions", () => {
 
   it("should allow sharing if dashboard contains only text cards (metabase#15077)", () => {
     cy.createDashboard().then(({ body: { id: DASHBOARD_ID } }) => {
-      cy.visit(`/dashboard/${DASHBOARD_ID}`);
+      visitDashboard(DASHBOARD_ID);
     });
     cy.icon("pencil").click();
     cy.icon("string").click();
@@ -230,7 +231,7 @@ describe("scenarios > dashboard > subscriptions", () => {
     it("should include text cards (metabase#15744)", () => {
       const TEXT_CARD = "FooBar";
 
-      cy.visit("/dashboard/1");
+      visitDashboard(1);
       cy.icon("pencil").click();
       cy.icon("string").click();
       cy.findByPlaceholderText(
@@ -368,7 +369,7 @@ describe("scenarios > dashboard > subscriptions", () => {
 // Helper functions
 function openDashboardSubscriptions(dashboard_id = 1) {
   // Orders in a dashboard
-  cy.visit(`/dashboard/${dashboard_id}`);
+  visitDashboard(dashboard_id);
   cy.icon("share").click();
   cy.findByText("Dashboard subscriptions").click();
 }

--- a/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
@@ -8,6 +8,7 @@ import {
   visualize,
   summarize,
   visitQuestion,
+  visitDashboard,
 } from "__support__/e2e/cypress";
 
 import { USER_GROUPS, SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
@@ -166,7 +167,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
               });
             });
 
-            cy.visit(`/dashboard/${DASHBOARD_ID}`);
+            visitDashboard(DASHBOARD_ID);
 
             cy.log("The first series line");
             cy.get(".sub.enable-dots._0")
@@ -248,7 +249,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
               });
             });
 
-            cy.visit(`/dashboard/${DASHBOARD_ID}`);
+            visitDashboard(DASHBOARD_ID);
 
             cy.log("The first series line");
             cy.get(".sub.enable-dots._0")
@@ -603,7 +604,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
           });
         });
 
-        cy.visit(`/dashboard/${DASHBOARD_ID}`);
+        visitDashboard(DASHBOARD_ID);
       });
     });
 

--- a/frontend/test/metabase/scenarios/visualizations/drillthroughs/dash_drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/drillthroughs/dash_drill.cy.spec.js
@@ -1,5 +1,5 @@
 // Imported from drillthroughs.e2e.spec.js
-import { restore } from "__support__/e2e/cypress";
+import { restore, visitDashboard } from "__support__/e2e/cypress";
 
 import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
@@ -109,7 +109,7 @@ describe("scenarios > visualizations > drillthroughs > dash_drill", () => {
                 sizeY: 12,
               });
 
-              cy.visit(`/dashboard/${DASHBOARD_ID}`);
+              visitDashboard(DASHBOARD_ID);
               cy.findByText(DASHBOARD_NAME);
 
               cy.wait("@cardQuery"); // wait for the title to be re-rendered before we can click on it
@@ -200,7 +200,7 @@ describe("scenarios > visualizations > drillthroughs > dash_drill", () => {
             ).as("cardQuery");
             cy.route("POST", `/api/dataset`).as("dataset");
 
-            cy.visit(`/dashboard/${DASHBOARD_ID}`);
+            visitDashboard(DASHBOARD_ID);
 
             cy.wait("@cardQuery");
             cy.findByText(QUESTION_NAME).click();
@@ -233,7 +233,7 @@ function addCardToNewDashboard(dashboard_name, card_id) {
         sizeY: 4,
       });
       // Visit newly created dashboard
-      cy.visit(`/dashboard/${DASHBOARD_ID}`);
+      visitDashboard(DASHBOARD_ID);
     },
   );
 }

--- a/frontend/test/metabase/scenarios/visualizations/drillthroughs/dash_drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/drillthroughs/dash_drill.cy.spec.js
@@ -96,11 +96,11 @@ describe("scenarios > visualizations > drillthroughs > dash_drill", () => {
               // We need to do this because Cypress sees the string that is "card title" before card is fully rendered.
               // That string then gets detached from DOM just prior to this XHR and gets re-rendered again inside a new DOM element.
               // Cypress was complaining it cannot click on a detached element.
-              cy.server();
-              cy.route(
+
+              cy.intercept(
                 "POST",
                 `/api/dashboard/${DASHBOARD_ID}/dashcard/*/card/${CARD_ID}/query`,
-              ).as("cardQuery");
+              ).as("dashCardQuery");
 
               // Add previously created question to the new dashboard
               cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
@@ -112,7 +112,7 @@ describe("scenarios > visualizations > drillthroughs > dash_drill", () => {
               visitDashboard(DASHBOARD_ID);
               cy.findByText(DASHBOARD_NAME);
 
-              cy.wait("@cardQuery"); // wait for the title to be re-rendered before we can click on it
+              cy.wait("@dashCardQuery"); // wait for the title to be re-rendered before we can click on it
               cy.findByText(CARD_NAME).click();
             },
           );
@@ -193,16 +193,11 @@ describe("scenarios > visualizations > drillthroughs > dash_drill", () => {
                 ],
               });
             });
-            cy.server();
-            cy.route(
-              "POST",
-              `/api/dashboard/${DASHBOARD_ID}/dashcard/*/card/${QUESTION_ID}/query`,
-            ).as("cardQuery");
-            cy.route("POST", `/api/dataset`).as("dataset");
+
+            cy.intercept("POST", "/api/dataset").as("dataset");
 
             visitDashboard(DASHBOARD_ID);
 
-            cy.wait("@cardQuery");
             cy.findByText(QUESTION_NAME).click();
 
             cy.wait("@dataset");

--- a/frontend/test/metabase/scenarios/visualizations/gauge.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/gauge.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore } from "__support__/e2e/cypress";
+import { restore, visitDashboard } from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { ORDERS_ID } = SAMPLE_DATABASE;
@@ -34,7 +34,7 @@ describe("scenarios > visualizations > gauge chart", () => {
           ],
         });
 
-        cy.visit(`/dashboard/${dashboard_id}`);
+        visitDashboard(dashboard_id);
       },
     );
 

--- a/frontend/test/metabase/scenarios/visualizations/gauge.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/gauge.cy.spec.js
@@ -7,7 +7,6 @@ describe("scenarios > visualizations > gauge chart", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
-    cy.intercept(`/api/dashboard/*/dashcard/*/card/*/query`).as("cardQuery");
   });
 
   it("should not rerender on gauge arc hover (metabase#15980)", () => {
@@ -38,7 +37,6 @@ describe("scenarios > visualizations > gauge chart", () => {
       },
     );
 
-    cy.wait("@cardQuery");
     cy.findByTestId("gauge-arc-1").trigger("mousemove");
     cy.findByText("Something went wrong").should("not.exist");
   });

--- a/frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js
@@ -1,4 +1,9 @@
-import { restore, visitQuestionAdhoc, popover } from "__support__/e2e/cypress";
+import {
+  restore,
+  visitQuestionAdhoc,
+  popover,
+  visitDashboard,
+} from "__support__/e2e/cypress";
 
 import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
@@ -227,7 +232,7 @@ describe("scenarios > visualizations > line chart", () => {
               firstCardId: question1Id,
               secondCardId: question2Id,
             });
-            cy.visit(`/dashboard/${dashboardId}`);
+            visitDashboard(dashboardId);
 
             // Rename both series
             renameSeries([
@@ -277,7 +282,7 @@ describe("scenarios > visualizations > line chart", () => {
               secondCardId: question2Id,
             });
 
-            cy.visit(`/dashboard/${dashboardId}`);
+            visitDashboard(dashboardId);
 
             renameSeries([
               ["16249_Q3", RENAMED_FIRST_SERIES],

--- a/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
@@ -4,6 +4,7 @@ import {
   popover,
   sidebar,
   visitQuestion,
+  visitDashboard,
 } from "__support__/e2e/cypress";
 
 import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
@@ -544,7 +545,7 @@ describe("scenarios > visualizations > pivot tables", () => {
                 ],
               });
               cy.log("Open the dashboard");
-              cy.visit(`/dashboard/${DASHBOARD_ID}`);
+              visitDashboard(DASHBOARD_ID);
             });
           },
         );

--- a/frontend/test/metabase/scenarios/visualizations/scalar.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/scalar.cy.spec.js
@@ -1,4 +1,8 @@
-import { restore, visitQuestionAdhoc } from "__support__/e2e/cypress";
+import {
+  restore,
+  visitQuestionAdhoc,
+  visitDashboard,
+} from "__support__/e2e/cypress";
 
 import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
@@ -52,7 +56,7 @@ describe("scenarios > visualizations > scalar", () => {
               ],
             });
           });
-          cy.visit(`/dashboard/${dashboardId}`);
+          visitDashboard(dashboardId);
           cy.findByText("1.5T");
         });
       });


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- Adds new `visitDashboard` E2E helper whose aim is to simplify code and to greatly reduce the overall flakiness
- It automatically waits for the last request* when one visits the dashboard
    - *it depends whether that user has the permissions to view the dashboard or not, but helper takes that into account
- Applies new helper to all related tests