### PR TITLE
Robustify timeline E2E tests

### DIFF
--- a/frontend/test/metabase/scenarios/question/timelines.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/timelines.cy.spec.js
@@ -8,18 +8,25 @@ describe("scenarios > collections > timelines", () => {
   describe("as admin", () => {
     beforeEach(() => {
       cy.signInAsAdmin();
+      cy.intercept("GET", "/api/collection/root").as("collections");
+      cy.intercept("POST", "/api/timeline-event").as("timelineEvent");
+      cy.intercept("PUT", "/api/timeline-event/**").as("putTimelineEvent");
     });
 
     it("should create the first event and timeline", () => {
       visitQuestion(3);
+      cy.wait("@collections");
+      cy.findByTextEnsureVisible("Visualization");
+
       cy.findByLabelText("calendar icon").click();
-      cy.button("Add an event").click();
+      cy.findByTextEnsureVisible("Add an event").click();
 
       cy.findByLabelText("Event name").type("RC1");
       cy.findByLabelText("Date").type("10/20/2018");
       cy.button("Create").click();
+      cy.wait("@timelineEvent");
 
-      cy.findByText("Our analytics events");
+      cy.findByTextEnsureVisible("Our analytics events");
       cy.findByText("RC1");
     });
 
@@ -30,14 +37,18 @@ describe("scenarios > collections > timelines", () => {
       });
 
       visitQuestion(3);
+      cy.wait("@collections");
+      cy.findByTextEnsureVisible("Visualization");
+
       cy.findByLabelText("calendar icon").click();
-      cy.button("Add an event").click();
+      cy.findByTextEnsureVisible("Add an event").click();
 
       cy.findByLabelText("Event name").type("RC2");
       cy.findByLabelText("Date").type("10/30/2018");
       cy.button("Create").click();
+      cy.wait("@timelineEvent");
 
-      cy.findByText("Releases");
+      cy.findByTextEnsureVisible("Releases");
       cy.findByText("RC1");
       cy.findByText("RC2");
     });
@@ -49,17 +60,21 @@ describe("scenarios > collections > timelines", () => {
       });
 
       visitQuestion(3);
+      cy.wait("@collections");
+      cy.findByTextEnsureVisible("Visualization");
+
       cy.findByLabelText("calendar icon").click();
       cy.findByText("Releases");
       cy.findByLabelText("ellipsis icon").click();
-      cy.findByText("Edit event").click();
+      cy.findByTextEnsureVisible("Edit event").click();
 
       cy.findByLabelText("Event name")
         .clear()
         .type("RC2");
       cy.findByText("Update").click();
+      cy.wait("@putTimelineEvent");
 
-      cy.findByText("Releases");
+      cy.findByTextEnsureVisible("Releases");
       cy.findByText("RC2");
     });
 
@@ -70,13 +85,18 @@ describe("scenarios > collections > timelines", () => {
       });
 
       visitQuestion(3);
+      cy.wait("@collections");
+      cy.findByTextEnsureVisible("Visualization");
+
       cy.findByLabelText("calendar icon").click();
       cy.findByText("Releases");
       cy.findByLabelText("ellipsis icon").click();
-      cy.findByText("Archive event").click();
+      cy.findByTextEnsureVisible("Archive event").click();
+      cy.wait("@putTimelineEvent");
       cy.findByText("RC1").should("not.exist");
 
       cy.findByText("Undo").click();
+      cy.wait("@putTimelineEvent");
       cy.findByText("RC1");
     });
   });
@@ -85,9 +105,10 @@ describe("scenarios > collections > timelines", () => {
     it("should not allow creating default timelines", () => {
       cy.signIn("readonly");
       visitQuestion(3);
+      cy.findByTextEnsureVisible("Created At");
 
       cy.findByLabelText("calendar icon").click();
-      cy.findByText(/Events in Metabase/);
+      cy.findByTextEnsureVisible(/Events in Metabase/);
       cy.findByText("Add an event").should("not.exist");
     });
 
@@ -100,9 +121,10 @@ describe("scenarios > collections > timelines", () => {
       cy.signOut();
       cy.signIn("readonly");
       visitQuestion(3);
+      cy.findByTextEnsureVisible("Created At");
 
       cy.findByLabelText("calendar icon").click();
-      cy.findByText("Releases");
+      cy.findByTextEnsureVisible("Releases");
       cy.findByText("Add an event").should("not.exist");
       cy.findByLabelText("ellipsis icon").should("not.exist");
     });


### PR DESCRIPTION
### Before this PR

Sporadically, the tests in `frontend/test/metabase/scenarios/question/timelines.cy.spec.js` failed like this (among many other similar situations):

![scenarios  collections  timelines -- as admin -- should create the first event and timeline (failed)](https://user-images.githubusercontent.com/7288/159952951-79964f25-7b39-4fcf-985a-2b7b8b4be9c0.png)

### After this PR

It should happen much less (I can't confirm yet that I've tackled all cases) since the checks are synchronized with the relevant API calls to prevent race conditions.