### PR TITLE
Nav visual changes

### DIFF
--- a/frontend/src/metabase/App.jsx
+++ b/frontend/src/metabase/App.jsx
@@ -131,7 +131,10 @@ export default class App extends Component {
     const { location, onChangeLocation } = this.props;
     return (
       <AppBar>
-        <LogoIconWrapper onClick={this.toggleSidebar}>
+        <LogoIconWrapper
+          onClick={this.toggleSidebar}
+          sidebarOpen={this.state.sidebarOpen}
+        >
           <LogoIcon size={24} />
         </LogoIconWrapper>
         <SearchBarContainer>
@@ -202,20 +205,22 @@ export default class App extends Component {
 
     return (
       <ScrollToTop>
-        <AppContentContainer isAdminApp={this.isAdminApp()}>
-          {this.hasNavbar() && sidebarOpen && <Navbar location={location} />}
-          {errorPage ? (
-            getErrorComponent(errorPage)
-          ) : (
-            <AppContent>
-              {this.hasAppBar() && this.renderAppBar()}
-              {children}
+        {errorPage ? (
+          getErrorComponent(errorPage)
+        ) : (
+          <>
+            {this.hasAppBar() && this.renderAppBar()}
+            <AppContentContainer isAdminApp={this.isAdminApp()}>
+              {this.hasNavbar() && sidebarOpen && (
+                <Navbar location={location} />
+              )}
+              <AppContent>{children}</AppContent>
               {this.renderModal()}
-            </AppContent>
-          )}
-          <UndoListing />
-          <StatusListing />
-        </AppContentContainer>
+              <UndoListing />
+              <StatusListing />
+            </AppContentContainer>
+          </>
+        )}
         <AppErrorCard errorInfo={errorInfo} />
       </ScrollToTop>
     );

--- a/frontend/src/metabase/App.jsx
+++ b/frontend/src/metabase/App.jsx
@@ -187,7 +187,7 @@ export default class App extends Component {
     }
   }
 
-  renderModal() {
+  renderModal = () => {
     const { modal } = this.state;
 
     if (modal) {
@@ -197,7 +197,7 @@ export default class App extends Component {
     } else {
       return null;
     }
-  }
+  };
 
   render() {
     const { children, location, errorPage } = this.props;
@@ -212,7 +212,7 @@ export default class App extends Component {
             {this.hasAppBar() && this.renderAppBar()}
             <AppContentContainer isAdminApp={this.isAdminApp()}>
               {this.hasNavbar() && sidebarOpen && (
-                <Navbar location={location} />
+                <Navbar location={location} renderModal={this.renderModal} />
               )}
               <AppContent>{children}</AppContent>
               {this.renderModal()}

--- a/frontend/src/metabase/App.styled.tsx
+++ b/frontend/src/metabase/App.styled.tsx
@@ -1,11 +1,17 @@
 import styled from "@emotion/styled";
+import { css } from "@emotion/react";
 import { color } from "metabase/lib/colors";
+
+const adminCss = css`
+  flex-direction: column;
+`;
 
 export const AppContentContainer = styled.div<{ isAdminApp: boolean }>`
   display: flex;
   position: relative;
   height: calc(100vh - 61px);
   overflow: hidden;
+  ${props => props.isAdminApp && adminCss}
 `;
 
 export const AppContent = styled.div`

--- a/frontend/src/metabase/App.styled.tsx
+++ b/frontend/src/metabase/App.styled.tsx
@@ -4,7 +4,7 @@ import { color } from "metabase/lib/colors";
 export const AppContentContainer = styled.div<{ isAdminApp: boolean }>`
   display: flex;
   position: relative;
-  height: calc(100vh - 60px);
+  height: calc(100vh - 61px);
   overflow: hidden;
 `;
 
@@ -15,16 +15,12 @@ export const AppContent = styled.div`
 `;
 
 export const AppBar = styled.div`
+  position: relative;
   display: flex;
   align-items: center;
   width: 100%;
-  position: relative;
-  padding-left: 1rem;
-  padding-right: 1rem;
-
   background-color: ${color("bg-white")};
   border-bottom: 1px solid ${color("border")};
-
   z-index: 4;
 `;
 

--- a/frontend/src/metabase/App.styled.tsx
+++ b/frontend/src/metabase/App.styled.tsx
@@ -2,6 +2,8 @@ import styled from "@emotion/styled";
 import { css } from "@emotion/react";
 import { color } from "metabase/lib/colors";
 
+import { NAV_HEIGHT } from "metabase/nav/constants";
+
 const adminCss = css`
   flex-direction: column;
 `;
@@ -9,7 +11,7 @@ const adminCss = css`
 export const AppContentContainer = styled.div<{ isAdminApp: boolean }>`
   display: flex;
   position: relative;
-  height: calc(100vh - 61px);
+  height: calc(100vh - ${NAV_HEIGHT});
   overflow: hidden;
   ${props => props.isAdminApp && adminCss}
 `;
@@ -30,7 +32,7 @@ export const AppBar = styled.div`
   z-index: 4;
 `;
 
-export const LogoIconWrapper = styled.div`
+export const LogoIconWrapper = styled.div<{ sidebarOpen: boolean }>`
   cursor: pointer;
   height: 60px;
   width: 80px;

--- a/frontend/src/metabase/App.styled.tsx
+++ b/frontend/src/metabase/App.styled.tsx
@@ -1,25 +1,17 @@
 import styled from "@emotion/styled";
-import { css } from "@emotion/react";
-import Icon from "metabase/components/Icon";
 import { color } from "metabase/lib/colors";
 
-const coreAppCss = css`
-  display: flex;
-`;
-
 export const AppContentContainer = styled.div<{ isAdminApp: boolean }>`
+  display: flex;
   position: relative;
-  height: 100vh;
-
-  ${props => !props.isAdminApp && coreAppCss}
+  height: calc(100vh - 60px);
+  overflow: hidden;
 `;
 
 export const AppContent = styled.div`
-  display: flex;
-  flex-direction: column;
   width: 100%;
-  height: 100%;
   overflow: auto;
+  background-color: ${color("bg-white")};
 `;
 
 export const AppBar = styled.div`
@@ -38,4 +30,14 @@ export const AppBar = styled.div`
 
 export const LogoIconWrapper = styled.div`
   cursor: pointer;
+  height: 60px;
+  width: 80px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: ${props =>
+    props.sidebarOpen ? color("bg-medium") : "transparent"};
+  &:hover {
+    background-color: ${color("bg-medium")};
+  }
 `;

--- a/frontend/src/metabase/collections/components/CollectionSidebar/CollectionSidebar.styled.jsx
+++ b/frontend/src/metabase/collections/components/CollectionSidebar/CollectionSidebar.styled.jsx
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
 import { css } from "@emotion/react";
 import { space } from "metabase/styled-components/theme";
-import { darken, color } from "metabase/lib/colors";
+import { color } from "metabase/lib/colors";
 import Icon from "metabase/components/Icon";
 import { breakpointMinSmall } from "metabase/styled-components/theme/media-queries";
 
@@ -49,7 +49,7 @@ export const Sidebar = styled.aside`
 `;
 
 export const SidebarHeading = styled.h4`
-  color: ${darken(color("white"), 0.075)};
+  color: ${color("text-medium")};
   font-weight: 700;
   font-size: 11px;
   margin-left: ${space(2)};

--- a/frontend/src/metabase/collections/components/CollectionSidebar/CollectionSidebarFooter/CollectionSidebarFooter.styled.jsx
+++ b/frontend/src/metabase/collections/components/CollectionSidebar/CollectionSidebarFooter/CollectionSidebarFooter.styled.jsx
@@ -1,6 +1,5 @@
 import styled from "@emotion/styled";
 
-import { color } from "metabase/lib/colors";
 import { space } from "metabase/styled-components/theme";
 
 import GenericIcon from "metabase/components/Icon";
@@ -19,7 +18,6 @@ export const Icon = styled(GenericIcon)`
 
 export const Link = styled(GenericLink)`
   align-items: center;
-  color: ${color("white")};
   display: flex;
   font-weight: 700;
   margin-top: ${space(2)};

--- a/frontend/src/metabase/collections/components/CollectionSidebar/CollectionSidebarLink/CollectionSidebarLink.jsx
+++ b/frontend/src/metabase/collections/components/CollectionSidebar/CollectionSidebarLink/CollectionSidebarLink.jsx
@@ -26,7 +26,7 @@ const CollectionSidebarLink = styled(Link)`
   flex-shrink: 0;
   align-items: center;
   font-weight: bold;
-  color: ${props => (props.selected ? color("brand") : "white")};
+  color: ${props => (props.selected ? color("brand") : "text-medium")};
   background-color: ${props =>
     props.selected
       ? color("brand-light")

--- a/frontend/src/metabase/collections/components/CollectionSidebar/CollectionSidebarLink/CollectionSidebarLink.jsx
+++ b/frontend/src/metabase/collections/components/CollectionSidebar/CollectionSidebarLink/CollectionSidebarLink.jsx
@@ -6,7 +6,7 @@ import { space } from "metabase/styled-components/theme";
 import { SIDEBAR_SPACER } from "metabase/collections/constants";
 
 const dimmedIconCss = css`
-  fill: ${color("white")};
+  fill: ${color("brand")};
   opacity: 0.8;
 `;
 

--- a/frontend/src/metabase/collections/components/Layout.jsx
+++ b/frontend/src/metabase/collections/components/Layout.jsx
@@ -2,5 +2,4 @@ import styled from "@emotion/styled";
 
 export const PageWrapper = styled.div`
   overflow: hidden;
-  height: 100vh;
 `;

--- a/frontend/src/metabase/components/CollectionLanding/CollectionLanding.styled.jsx
+++ b/frontend/src/metabase/components/CollectionLanding/CollectionLanding.styled.jsx
@@ -4,7 +4,6 @@ import { breakpointMinSmall } from "metabase/styled-components/theme/media-queri
 
 export const ContentBox = styled.div`
   display: ${props => (props.shouldDisplayMobileSidebar ? "none" : "block")};
-  height: 100%;
   overflow-y: auto;
   padding-bottom: 64px;
 

--- a/frontend/src/metabase/lib/colors.ts
+++ b/frontend/src/metabase/lib/colors.ts
@@ -57,7 +57,7 @@ export const aliases: Record<string, string> = {
   database: "accent2",
   dashboard: "brand",
   pulse: "accent4",
-  nav: "brand",
+  nav: "bg-light",
 };
 export const harmony: string[] = [];
 // DEPRECATED: we should remove these and use `colors` directly

--- a/frontend/src/metabase/lib/colors.ts
+++ b/frontend/src/metabase/lib/colors.ts
@@ -57,7 +57,7 @@ export const aliases: Record<string, string> = {
   database: "accent2",
   dashboard: "brand",
   pulse: "accent4",
-  nav: "bg-light",
+  nav: "bg-medium",
 };
 export const harmony: string[] = [];
 // DEPRECATED: we should remove these and use `colors` directly

--- a/frontend/src/metabase/nav/components/SearchBar.jsx
+++ b/frontend/src/metabase/nav/components/SearchBar.jsx
@@ -68,9 +68,6 @@ export default class SearchBar extends React.Component {
         >
           <Icon name="search" ml={["10px", 2]} />
           <SearchInput
-            py={2}
-            pr={[0, 2]}
-            pl={1}
             ref={ref => (this.searchInput = ref)}
             value={searchText}
             maxLength={200}

--- a/frontend/src/metabase/nav/components/SearchBar.styled.jsx
+++ b/frontend/src/metabase/nav/components/SearchBar.styled.jsx
@@ -1,14 +1,13 @@
 import styled from "@emotion/styled";
-import { space } from "styled-system";
 
 import { color } from "metabase/lib/colors";
+import { space } from "metabase/styled-components/theme";
 
 export const SearchWrapper = styled.div`
   display: flex;
   align-items: center;
   position: relative;
-  background-color: white;
-  border: 1px solid #ddd;
+  background-color: ${color("bg-medium")};
   border-radius: 6px;
   flex: 1 1 auto;
   max-width: 50em;
@@ -17,17 +16,16 @@ export const SearchWrapper = styled.div`
 `;
 
 export const SearchInput = styled.input`
-  ${space};
   background-color: transparent;
   width: 100%;
   border: none;
   color: ${color("text-dark")};
-  font-size: 0.8em;
+  padding: ${space(2)};
   font-weight: 700;
   &:focus {
     outline: none;
   }
   &::placeholder {
-    color: ${color("text-medium")};
+    color: ${color("text-dark")};
   }
 `;

--- a/frontend/src/metabase/nav/constants.js
+++ b/frontend/src/metabase/nav/constants.js
@@ -1,3 +1,4 @@
 import { color, lighten } from "metabase/lib/colors";
 
 export const getDefaultSearchColor = () => lighten(color("nav"), 0.07);
+export const NAV_HEIGHT = "61px";

--- a/frontend/src/metabase/nav/containers/Navbar.jsx
+++ b/frontend/src/metabase/nav/containers/Navbar.jsx
@@ -66,7 +66,7 @@ export default class Navbar extends Component {
     return (
       <>
         <AdminNavbar {...this.props} />
-        {this.renderModal()}
+        {this.props.renderModal()}
       </>
     );
   }
@@ -87,7 +87,7 @@ export default class Navbar extends Component {
             </Link>
           </li>
         </ul>
-        {this.renderModal()}
+        {this.props.renderModal()}
       </nav>
     );
   }

--- a/frontend/src/metabase/nav/containers/Navbar.jsx
+++ b/frontend/src/metabase/nav/containers/Navbar.jsx
@@ -108,8 +108,7 @@ export default class Navbar extends Component {
       <NavRoot
         // NOTE: DO NOT REMOVE `Nav` CLASS FOR NOW, USED BY MODALS, FULLSCREEN DASHBOARD, ETC
         // TODO: hide nav using state in redux instead?
-        className="Nav relative bg-brand text-white z3 flex-no-shrink overflow-auto relative pb4"
-        style={{ paddingBottom: 100 }}
+        className="Nav"
       >
         <LogoLinkContainer>
           <Link

--- a/frontend/src/metabase/nav/containers/Navbar.jsx
+++ b/frontend/src/metabase/nav/containers/Navbar.jsx
@@ -32,12 +32,7 @@ const mapStateToProps = (state, props) => ({
   hasDataAccess: getHasDataAccess(state),
 });
 
-import { getDefaultSearchColor } from "metabase/nav/constants";
-import {
-  ProfileLinkContainer,
-  LogoLinkContainer,
-  NavRoot,
-} from "./Navbar.styled";
+import { ProfileLinkContainer, NavRoot } from "./Navbar.styled";
 import CollectionSidebar from "../../collections/containers/CollectionSidebar/CollectionSidebar";
 import Footer from "metabase/collections/components/CollectionSidebar/CollectionSidebarFooter";
 
@@ -110,21 +105,16 @@ export default class Navbar extends Component {
         // TODO: hide nav using state in redux instead?
         className="Nav"
       >
-        <LogoLinkContainer>
-          <Link
-            to="/"
-            data-metabase-event={"Navbar;Logo"}
-            className="relative cursor-pointer z2 rounded flex justify-center transition-background"
-            p={1}
-            mx={1}
-            hover={{ backgroundColor: getDefaultSearchColor() }}
-          >
-            {t`Home`}
-          </Link>
-          <ProfileLinkContainer>
-            <ProfileLink {...this.props} user={user} />
-          </ProfileLinkContainer>
-        </LogoLinkContainer>
+        <Link
+          to="/"
+          data-metabase-event={"Navbar;Logo"}
+          className="relative cursor-pointer z2 rounded flex transition-background bg-brand-hover text-bold"
+          p={1}
+          mx={1}
+        >
+          <Icon name="home" />
+          {t`Home`}
+        </Link>
         <CollectionSidebar
           isRoot={isRoot}
           handleToggleMobileSidebar={() => {
@@ -152,6 +142,9 @@ export default class Navbar extends Component {
           </Link>
         )}
         <Footer isAdmin={user.is_superuser} />
+        <ProfileLinkContainer>
+          <ProfileLink {...this.props} user={user} />
+        </ProfileLinkContainer>
       </NavRoot>
     );
   }

--- a/frontend/src/metabase/nav/containers/Navbar.styled.tsx
+++ b/frontend/src/metabase/nav/containers/Navbar.styled.tsx
@@ -3,7 +3,7 @@ import { color } from "metabase/lib/colors";
 import { breakpointMinSmall } from "metabase/styled-components/theme";
 
 export const NavRoot = styled.div`
-  position: relative;
+  position: fixed;
   width: 320px;
   align-items: center;
   padding: 0.5rem 0;
@@ -12,6 +12,10 @@ export const NavRoot = styled.div`
   z-index: 3;
   flex-shrink: 0;
   border-right: 1px solid ${color("border")};
+
+  ${breakpointMinSmall} {
+    position: relative;
+  }
 `;
 
 export const LogoLinkContainer = styled.div`

--- a/frontend/src/metabase/nav/containers/Navbar.styled.tsx
+++ b/frontend/src/metabase/nav/containers/Navbar.styled.tsx
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
-import { breakpointMinSmall, space } from "metabase/styled-components/theme";
+import { breakpointMinSmall } from "metabase/styled-components/theme";
 
 export const NavRoot = styled.div`
   position: relative;
@@ -12,7 +12,6 @@ export const NavRoot = styled.div`
   z-index: 3;
   flex-shrink: 0;
   border-right: 1px solid ${color("border")};
-  padding-bottom: ${space(4)};
 `;
 
 export const LogoLinkContainer = styled.div`

--- a/frontend/src/metabase/nav/containers/Navbar.styled.tsx
+++ b/frontend/src/metabase/nav/containers/Navbar.styled.tsx
@@ -6,7 +6,7 @@ export const NavRoot = styled.div`
   position: relative;
   width: 320px;
   align-items: center;
-  padding: 0.5rem 1rem 0.5rem 0;
+  padding: 0.5rem 0;
   background-color: ${color("nav")};
   overflow: auto;
   z-index: 3;

--- a/frontend/src/metabase/nav/containers/Navbar.styled.tsx
+++ b/frontend/src/metabase/nav/containers/Navbar.styled.tsx
@@ -1,12 +1,18 @@
 import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
-import { breakpointMinSmall } from "metabase/styled-components/theme";
+import { breakpointMinSmall, space } from "metabase/styled-components/theme";
 
 export const NavRoot = styled.div`
+  position: relative;
   width: 320px;
   align-items: center;
   padding: 0.5rem 1rem 0.5rem 0;
   background-color: ${color("nav")};
+  overflow: auto;
+  z-index: 3;
+  flex-shrink: 0;
+  border-right: 1px solid ${color("border")};
+  padding-bottom: ${space(4)};
 `;
 
 export const LogoLinkContainer = styled.div`

--- a/frontend/src/metabase/nav/containers/Navbar.styled.tsx
+++ b/frontend/src/metabase/nav/containers/Navbar.styled.tsx
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
-import { breakpointMinSmall } from "metabase/styled-components/theme";
+import { breakpointMinSmall, space } from "metabase/styled-components/theme";
 
 export const NavRoot = styled.div`
   position: fixed;
@@ -16,13 +16,6 @@ export const NavRoot = styled.div`
     width: 324px;
     position: relative;
   }
-`;
-
-export const LogoLinkContainer = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  min-width: 4rem;
 `;
 
 export const LogoIconContainer = styled.div`
@@ -64,4 +57,7 @@ export const EntityMenuContainer = styled.div`
 
 export const ProfileLinkContainer = styled.div`
   margin-left: auto;
+  position: absolute;
+  bottom: 0;
+  right: ${space(2)};
 `;

--- a/frontend/src/metabase/nav/containers/Navbar.styled.tsx
+++ b/frontend/src/metabase/nav/containers/Navbar.styled.tsx
@@ -4,7 +4,6 @@ import { breakpointMinSmall } from "metabase/styled-components/theme";
 
 export const NavRoot = styled.div`
   position: fixed;
-  width: 320px;
   align-items: center;
   padding: 0.5rem 0;
   background-color: ${color("nav")};
@@ -14,6 +13,7 @@ export const NavRoot = styled.div`
   border-right: 1px solid ${color("border")};
 
   ${breakpointMinSmall} {
+    width: 324px;
     position: relative;
   }
 `;

--- a/frontend/src/metabase/query_builder/components/view/View.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/view/View.styled.tsx
@@ -8,7 +8,6 @@ import { color } from "metabase/lib/colors";
 import { breakpointMaxSmall } from "metabase/styled-components/theme/media-queries";
 
 import { ViewTitleHeader } from "./ViewHeader";
-import { SIDEBAR_WIDTH } from "metabase/collections/constants";
 import { NAV_HEIGHT } from "metabase/nav/constants";
 
 export const QueryBuilderViewRoot = styled.div`

--- a/frontend/src/metabase/query_builder/components/view/View.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/view/View.styled.tsx
@@ -14,7 +14,7 @@ export const QueryBuilderViewRoot = styled.div`
   display: flex;
   flex-direction: column;
   background-color: ${color("bg-white")};
-  height: calc(100vh - 49px);
+  height: calc(100vh - 61px);
   position: relative;
 `;
 

--- a/frontend/src/metabase/query_builder/components/view/View.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/view/View.styled.tsx
@@ -9,12 +9,13 @@ import { breakpointMaxSmall } from "metabase/styled-components/theme/media-queri
 
 import { ViewTitleHeader } from "./ViewHeader";
 import { SIDEBAR_WIDTH } from "metabase/collections/constants";
+import { NAV_HEIGHT } from "metabase/nav/constants";
 
 export const QueryBuilderViewRoot = styled.div`
   display: flex;
   flex-direction: column;
   background-color: ${color("bg-white")};
-  height: calc(100vh - 61px);
+  height: calc(100vh - ${NAV_HEIGHT});
   position: relative;
 `;
 


### PR DESCRIPTION
Now that things are structurally more where we want them with the new nav, this branch starts fixing up the styling to account for the change. Here are the big moves

- Background set to white (we'll be accomodating for those changes by increasing 
- Move from brand blue to a more neutral color for the sidebar to make having that open less intense than before
- Position the sidebar nav below the top nav bar to make opening / closing less jarring

Still being worked out
- Hover and selected states for the side nav
- The exact interaction of the trigger to open the side nav
- Some contrast tweaks for collections to account for the new white background