### PR TITLE
Ignore Empty Conditional Formatting Queries

### DIFF
--- a/frontend/src/metabase/visualizations/lib/table_format.js
+++ b/frontend/src/metabase/visualizations/lib/table_format.js
@@ -59,6 +59,9 @@ function getColumnIndexesByName(cols) {
   return colIndexes;
 }
 
+export const canCompareSubstrings = (a, b) =>
+  typeof a === "string" && typeof b === "string" && !!a.length && !!b.length;
+
 export const OPERATOR_FORMATTER_FACTORIES = {
   "<": (value, color) => v =>
     typeof value === "number" && v < value ? color : null,
@@ -73,21 +76,13 @@ export const OPERATOR_FORMATTER_FACTORIES = {
   "is-null": (_value, color) => v => (v === null ? color : null),
   "not-null": (_value, color) => v => (v !== null ? color : null),
   contains: (value, color) => v =>
-    typeof value === "string" && typeof v === "string" && v.indexOf(value) >= 0
-      ? color
-      : null,
+    canCompareSubstrings(value, v) && v.indexOf(value) >= 0 ? color : null,
   "does-not-contain": (value, color) => v =>
-    typeof value === "string" && typeof v === "string" && v.indexOf(value) < 0
-      ? color
-      : null,
+    canCompareSubstrings(value, v) && v.indexOf(value) < 0 ? color : null,
   "starts-with": (value, color) => v =>
-    typeof value === "string" && typeof v === "string" && v.startsWith(value)
-      ? color
-      : null,
+    canCompareSubstrings(value, v) && v.startsWith(value) ? color : null,
   "ends-with": (value, color) => v =>
-    typeof value === "string" && typeof v === "string" && v.endsWith(value)
-      ? color
-      : null,
+    canCompareSubstrings(value, v) && v.endsWith(value) ? color : null,
 };
 
 export function compileFormatter(

--- a/frontend/src/metabase/visualizations/lib/table_format.js
+++ b/frontend/src/metabase/visualizations/lib/table_format.js
@@ -62,6 +62,8 @@ function getColumnIndexesByName(cols) {
 export const canCompareSubstrings = (a, b) =>
   typeof a === "string" && typeof b === "string" && !!a.length && !!b.length;
 
+export const isEmptyString = val => typeof val === "string" && !val.length;
+
 export const OPERATOR_FORMATTER_FACTORIES = {
   "<": (value, color) => v =>
     typeof value === "number" && v < value ? color : null,
@@ -72,7 +74,8 @@ export const OPERATOR_FORMATTER_FACTORIES = {
   ">": (value, color) => v =>
     typeof value === "number" && v > value ? color : null,
   "=": (value, color) => v => (v === value ? color : null),
-  "!=": (value, color) => v => (v !== value ? color : null),
+  "!=": (value, color) => v =>
+    !isEmptyString(value) && v !== value ? color : null,
   "is-null": (_value, color) => v => (v === null ? color : null),
   "not-null": (_value, color) => v => (v !== null ? color : null),
   contains: (value, color) => v =>

--- a/frontend/test/metabase/visualizations/lib/table_format.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/table_format.unit.spec.js
@@ -24,6 +24,43 @@ describe("compileFormatter", () => {
     expect(supportedOperators).toEqual(definedOperators);
   });
 
+  it("properly ignores empty string searches for all text formatters", () => {
+    const textFormatters = [
+      "!=",
+      "contains",
+      "does-not-contain",
+      "starts-with",
+      "ends-with",
+    ];
+
+    textFormatters.forEach(factoryName => {
+      const factory = OPERATOR_FORMATTER_FACTORIES[factoryName]("", "#fff");
+      expect(factory("foo")).toBeNull();
+      expect(factory("")).toBeNull();
+      expect(factory(0)).toBeNull();
+    });
+  });
+
+  it("properly detects not equal text", () => {
+    const formatter = OPERATOR_FORMATTER_FACTORIES["!="]("foo", "#fff");
+
+    expect(formatter("")).toBe("#fff");
+    expect(formatter("bar")).toBe("#fff");
+    expect(formatter(0)).toBe("#fff");
+
+    expect(formatter("foo")).toBe(null);
+  });
+
+  it("properly detects not equal numbers", () => {
+    const formatter = OPERATOR_FORMATTER_FACTORIES["!="](17, "#fff");
+
+    expect(formatter("foo")).toBe("#fff");
+    expect(formatter(0)).toBe("#fff");
+    expect(formatter(16)).toBe("#fff");
+
+    expect(formatter(17)).toBe(null);
+  });
+
   it("properly detects contains text", () => {
     const formatter = OPERATOR_FORMATTER_FACTORIES.contains("foo", "#fff");
 

--- a/frontend/test/metabase/visualizations/lib/table_format.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/table_format.unit.spec.js
@@ -1,5 +1,6 @@
 import { ALL_OPERATOR_NAMES } from "metabase/visualizations/components/settings/ChartSettingsTableFormatting";
 import {
+  canCompareSubstrings,
   OPERATOR_FORMATTER_FACTORIES,
   compileFormatter,
 } from "metabase/visualizations/lib/table_format";
@@ -21,5 +22,83 @@ describe("compileFormatter", () => {
     const definedOperators = Object.keys(ALL_OPERATOR_NAMES).sort();
 
     expect(supportedOperators).toEqual(definedOperators);
+  });
+
+  it("properly detects contains text", () => {
+    const formatter = OPERATOR_FORMATTER_FACTORIES.contains("foo", "#fff");
+
+    expect(formatter("fooBar")).toBe("#fff");
+    expect(formatter("Barfoo")).toBe("#fff");
+    expect(formatter("bARfooBaz")).toBe("#fff");
+
+    expect(formatter("")).toBe(null);
+    expect(formatter("Foo")).toBe(null);
+    expect(formatter("Foobar")).toBe(null);
+    expect(formatter("not")).toBe(null);
+  });
+
+  it("properly detects does-not-contain text", () => {
+    const formatter = OPERATOR_FORMATTER_FACTORIES["does-not-contain"](
+      "foo",
+      "#fff",
+    );
+
+    expect(formatter("Foo")).toBe("#fff");
+    expect(formatter("Foobar")).toBe("#fff");
+    expect(formatter("not")).toBe("#fff");
+
+    expect(formatter("")).toBe(null);
+    expect(formatter("fooBar")).toBe(null);
+    expect(formatter("Barfoo")).toBe(null);
+    expect(formatter("bARfooBaz")).toBe(null);
+  });
+
+  it("properly detects starts with text", () => {
+    const formatter = OPERATOR_FORMATTER_FACTORIES["starts-with"](
+      "foo",
+      "#fff",
+    );
+
+    expect(formatter("fooBar")).toBe("#fff");
+    expect(formatter("foo")).toBe("#fff");
+    expect(formatter("fool")).toBe("#fff");
+
+    expect(formatter("")).toBe(null);
+    expect(formatter("Foo")).toBe(null);
+    expect(formatter("Barfoo")).toBe(null);
+    expect(formatter("bARfooBaz")).toBe(null);
+  });
+
+  it("properly detects ends with text", () => {
+    const formatter = OPERATOR_FORMATTER_FACTORIES["ends-with"]("foo", "#fff");
+
+    expect(formatter("Barfoo")).toBe("#fff");
+    expect(formatter("foo")).toBe("#fff");
+    expect(formatter("baz.foo")).toBe("#fff");
+
+    expect(formatter("")).toBe(null);
+    expect(formatter("fooBar")).toBe(null);
+    expect(formatter("food")).toBe(null);
+    expect(formatter("foo ")).toBe(null);
+  });
+});
+
+describe("canCompareSubstrings", () => {
+  it("should return true for strings", () => {
+    expect(canCompareSubstrings("foo", "bar")).toBe(true);
+  });
+
+  it("should return false for any non-strings", () => {
+    expect(canCompareSubstrings(1, 2)).toBe(false);
+    expect(canCompareSubstrings(1, "foo")).toBe(false);
+    expect(canCompareSubstrings(null, "foo")).toBe(false);
+    expect(canCompareSubstrings("foo", undefined)).toBe(false);
+    expect(canCompareSubstrings("foo", [])).toBe(false);
+  });
+
+  it("should return false for any empty strings", () => {
+    expect(canCompareSubstrings("", "foo")).toBe(false);
+    expect(canCompareSubstrings("foo", "")).toBe(false);
+    expect(canCompareSubstrings("", "")).toBe(false);
   });
 });


### PR DESCRIPTION
## Before

- adding a conditional formatting rule for `contains` ,`does-not-contain`, `starts-with`, `ends-with` or `!=`  with an empty query would match on all records
![Screenshot from 2022-03-24 10-09-22](https://user-images.githubusercontent.com/30528226/159975196-00e1beb2-4c67-420d-aa1a-15ef0d24fbe2.png)

## Changes

- filter out empty queries for these conditional formatting functions
- add unit tests for formatting matcher functions and canCompareSubstrings helper function
- Resolves #16822 

## After

- empty text conditional formatting rules don't match on anything until they have query text

no query text | query text
--- | ---
![Screenshot from 2022-03-24 10-06-16](https://user-images.githubusercontent.com/30528226/159975290-82471a75-7f2b-4171-a923-6bd35d690c6c.png) | ![Screenshot from 2022-03-24 10-05-52](https://user-images.githubusercontent.com/30528226/159975291-317a90e5-52b6-4af1-9b88-222b07d2ac9b.png)


