### PR TITLE
Remove cancel-in-progress to avoid errors on Master

### DIFF
--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -9,10 +9,6 @@ on:
     - ".**"
     - "test*"
 
-concurrency:
-  group: ${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   build:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Removing the `cancel-in-progress` to avoid errors on master due to concurrency builds.
