### PR TITLE
Browsing | Manage sidebar state with redux

### DIFF
--- a/frontend/src/metabase/App.jsx
+++ b/frontend/src/metabase/App.jsx
@@ -9,6 +9,7 @@ import AppBar from "metabase/nav/containers/AppBar";
 import Navbar from "metabase/nav/containers/Navbar";
 import * as Urls from "metabase/lib/urls";
 
+import { toggleNavbar, getIsNavbarOpen } from "metabase/redux/app";
 import { IFRAMED, initializeIframeResizer } from "metabase/lib/dom";
 
 import UndoListing from "metabase/containers/UndoListing";
@@ -31,13 +32,15 @@ import { AppContentContainer, AppContent } from "./App.styled";
 export const MODAL_NEW_DASHBOARD = "MODAL_NEW_DASHBOARD";
 export const MODAL_NEW_COLLECTION = "MODAL_NEW_COLLECTION";
 
-const mapStateToProps = (state, props) => ({
+const mapStateToProps = state => ({
   errorPage: state.app.errorPage,
+  isSidebarOpen: getIsNavbarOpen(state),
   currentUser: state.currentUser,
 });
 
 const mapDispatchToProps = {
   onChangeLocation: push,
+  toggleNavbar,
 };
 
 const getErrorComponent = ({ status, data, context }) => {
@@ -64,22 +67,9 @@ const getErrorComponent = ({ status, data, context }) => {
 
 const PATHS_WITHOUT_NAVBAR = [/\/model\/.*\/query/, /\/model\/.*\/metadata/];
 
-const PATHS_WITH_COLLAPSED_NAVBAR = [
-  /\/model.*/,
-  /\/question.*/,
-  /\/dashboard.*/,
-];
-
-function checkIsSidebarInitiallyOpen(locationPathName) {
-  return !PATHS_WITH_COLLAPSED_NAVBAR.some(pattern =>
-    pattern.test(locationPathName),
-  );
-}
-
 class App extends Component {
   state = {
     errorInfo: undefined,
-    sidebarOpen: checkIsSidebarInitiallyOpen(this.props.location.pathname),
   };
 
   constructor(props) {
@@ -116,10 +106,6 @@ class App extends Component {
       return false;
     }
     return !PATHS_WITHOUT_NAVBAR.some(pattern => pattern.test(pathname));
-  };
-
-  toggleSidebar = () => {
-    this.setState({ sidebarOpen: !this.state.sidebarOpen });
   };
 
   closeModal = () => {
@@ -172,8 +158,15 @@ class App extends Component {
   };
 
   render() {
-    const { children, location, errorPage, onChangeLocation } = this.props;
-    const { errorInfo, sidebarOpen } = this.state;
+    const {
+      isSidebarOpen,
+      children,
+      location,
+      errorPage,
+      onChangeLocation,
+      toggleNavbar,
+    } = this.props;
+    const { errorInfo } = this.state;
     const hasAppBar = this.hasAppBar();
     return (
       <ScrollToTop>
@@ -183,9 +176,9 @@ class App extends Component {
           <>
             {hasAppBar && (
               <AppBar
-                isSidebarOpen={sidebarOpen}
+                isSidebarOpen={isSidebarOpen}
                 location={location}
-                onToggleSidebarClick={this.toggleSidebar}
+                onToggleSidebarClick={toggleNavbar}
                 onNewClick={this.setModal}
                 onChangeLocation={onChangeLocation}
               />
@@ -194,7 +187,7 @@ class App extends Component {
               hasAppBar={hasAppBar}
               isAdminApp={this.isAdminApp()}
             >
-              {this.hasNavbar() && sidebarOpen && (
+              {this.hasNavbar() && isSidebarOpen && (
                 <Navbar location={location} />
               )}
               <AppContent>{children}</AppContent>

--- a/frontend/src/metabase/App.jsx
+++ b/frontend/src/metabase/App.jsx
@@ -187,8 +187,8 @@ class App extends Component {
               hasAppBar={hasAppBar}
               isAdminApp={this.isAdminApp()}
             >
-              {this.hasNavbar() && isSidebarOpen && (
-                <Navbar location={location} />
+              {this.hasNavbar() && (
+                <Navbar isOpen={isSidebarOpen} location={location} />
               )}
               <AppContent>{children}</AppContent>
               {this.renderModal()}

--- a/frontend/src/metabase/nav/containers/Navbar.jsx
+++ b/frontend/src/metabase/nav/containers/Navbar.jsx
@@ -83,7 +83,7 @@ export default class Navbar extends Component {
   }
 
   renderMainNav() {
-    const { hasDataAccess, router, user } = this.props;
+    const { isOpen, hasDataAccess, router, user } = this.props;
     const collectionId = Urls.extractCollectionId(router.params.slug);
     const isRoot = collectionId === "root";
 
@@ -94,6 +94,7 @@ export default class Navbar extends Component {
         // NOTE: DO NOT REMOVE `Nav` CLASS FOR NOW, USED BY MODALS, FULLSCREEN DASHBOARD, ETC
         // TODO: hide nav using state in redux instead?
         className="Nav"
+        isOpen={isOpen}
       >
         <CollectionSidebar
           isRoot={isRoot}

--- a/frontend/src/metabase/nav/containers/Navbar.styled.tsx
+++ b/frontend/src/metabase/nav/containers/Navbar.styled.tsx
@@ -1,8 +1,19 @@
 import styled from "@emotion/styled";
+import { css } from "@emotion/react";
 import { color } from "metabase/lib/colors";
 import { breakpointMinSmall, space } from "metabase/styled-components/theme";
 
-export const NavRoot = styled.div`
+const openNavbarCSS = css`
+  width: 324px;
+  position: relative;
+`;
+
+const closedNavbarCSS = css`
+  width: 0;
+  visibility: hidden;
+`;
+
+export const NavRoot = styled.div<{ isOpen: boolean }>`
   position: fixed;
   align-items: center;
   padding: 0.5rem 0;
@@ -13,8 +24,7 @@ export const NavRoot = styled.div`
   border-right: 1px solid ${color("border")};
 
   ${breakpointMinSmall} {
-    width: 324px;
-    position: relative;
+    ${props => (props.isOpen ? openNavbarCSS : closedNavbarCSS)};
   }
 `;
 

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
@@ -418,7 +418,7 @@ export default class NativeQueryEditor extends Component {
     return (
       <div className="NativeQueryEditor bg-light full">
         {hasTopBar && (
-          <div className="flex align-center">
+          <div className="flex align-center" data-testid="native-query-top-bar">
             <div className={!isNativeEditorOpen ? "hide sm-show" : ""}>
               <DataSourceSelectors
                 isNativeEditorOpen={isNativeEditorOpen}

--- a/frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx
@@ -117,7 +117,7 @@ export function FilterHeader({ className, question, expanded }) {
     return null;
   }
   return (
-    <FilterHeaderContainer className={className}>
+    <FilterHeaderContainer className={className} data-testid="qb-filters-panel">
       <div className="flex flex-wrap align-center">
         {filters.map((filter, index) => (
           <PopoverWithTrigger

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -121,7 +121,11 @@ export function ViewTitleHeader(props) {
 
   return (
     <>
-      <ViewHeaderContainer className={className} style={style}>
+      <ViewHeaderContainer
+        className={className}
+        style={style}
+        data-testid="qb-header"
+      >
         {isDataset ? (
           <DatasetLeftSide {...props} />
         ) : isSaved ? (

--- a/frontend/src/metabase/redux/app.js
+++ b/frontend/src/metabase/redux/app.js
@@ -1,6 +1,10 @@
 import { push, LOCATION_CHANGE } from "react-router-redux";
 
-import { combineReducers, handleActions } from "metabase/lib/redux";
+import {
+  combineReducers,
+  createAction,
+  handleActions,
+} from "metabase/lib/redux";
 import { openInBlankWindow, shouldOpenInBlankWindow } from "metabase/lib/dom";
 
 export const SET_ERROR_PAGE = "metabase/app/SET_ERROR_PAGE";
@@ -28,6 +32,40 @@ const errorPage = handleActions(
   null,
 );
 
+const PATHS_WITH_COLLAPSED_NAVBAR = [
+  /\/model.*/,
+  /\/question.*/,
+  /\/dashboard.*/,
+];
+
+function checkIsSidebarInitiallyOpen() {
+  return !PATHS_WITH_COLLAPSED_NAVBAR.some(pattern =>
+    pattern.test(window.location.pathname),
+  );
+}
+
+export const OPEN_NAVBAR = "metabase/app/OPEN_NAVBAR";
+export const CLOSE_NAVBAR = "metabase/app/CLOSE_NAVBAR";
+export const TOGGLE_NAVBAR = "metabase/app/TOGGLE_NAVBAR";
+
+export const openNavbar = createAction(OPEN_NAVBAR);
+export const closeNavbar = createAction(CLOSE_NAVBAR);
+export const toggleNavbar = createAction(TOGGLE_NAVBAR);
+
+export function getIsNavbarOpen(state) {
+  return state.app.isNavbarOpen;
+}
+
+const isNavbarOpen = handleActions(
+  {
+    [OPEN_NAVBAR]: () => true,
+    [TOGGLE_NAVBAR]: isOpen => !isOpen,
+    [CLOSE_NAVBAR]: () => false,
+  },
+  checkIsSidebarInitiallyOpen(),
+);
+
 export default combineReducers({
   errorPage,
+  isNavbarOpen,
 });

--- a/frontend/test/metabase/scenarios/collections/collection-types.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collection-types.cy.spec.js
@@ -204,7 +204,9 @@ function testOfficialBadgePresence(expectBadge = true) {
   assertHasCollectionBadge(expectBadge);
 
   // Question Page
-  cy.findByText(COLLECTION_NAME).click();
+  cy.get("main")
+    .findByText(COLLECTION_NAME)
+    .click();
   cy.findByText("Official Question").click();
   assertHasCollectionBadge(expectBadge);
 
@@ -347,7 +349,8 @@ function assertSearchResultBadge(itemName, opts) {
 }
 
 function assertHasCollectionBadge(expectBadge = true) {
-  cy.findByText(COLLECTION_NAME)
+  cy.get("main")
+    .findByText(COLLECTION_NAME)
     .parent()
     .within(() => {
       cy.icon("badge").should(expectBadge ? "exist" : "not.exist");

--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -419,10 +419,12 @@ describe("scenarios > collection_defaults", () => {
 
       cy.visit("/question/new");
       cy.findByText("Simple question").click();
-      cy.findByText("Saved Questions").click();
-      // Note: collection name's first letter is capitalized
-      cy.findByText(/foo:bar/i).click();
-      cy.findByText("Orders");
+      popover().within(() => {
+        cy.findByText("Saved Questions").click();
+        // Note: collection name's first letter is capitalized
+        cy.findByText(/foo:bar/i).click();
+        cy.findByText("Orders");
+      });
     });
 
     it("collections without sub-collections shouldn't have chevron icon (metabase#14753)", () => {
@@ -474,9 +476,11 @@ describe("scenarios > collection_defaults", () => {
         .should("be.visible")
         .click();
 
-      cy.findByText("Saved Questions").click();
-      cy.findByText("First collection");
-      cy.findByText("Second collection").should("not.exist");
+      popover().within(() => {
+        cy.findByText("Saved Questions").click();
+        cy.findByText("First collection");
+        cy.findByText("Second collection").should("not.exist");
+      });
     });
 
     describe("bulk actions", () => {

--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -16,6 +16,7 @@ import {
   popover,
   appBar,
   navigationSidebar,
+  modal,
   openNativeEditor,
   visitQuestion,
   visitDashboard,
@@ -451,8 +452,10 @@ describe("collection permissions", () => {
                       cy.findByText("Move").click();
                     });
                     cy.location("pathname").should("eq", "/dashboard/1/move");
-                    cy.findByText("First collection").click();
-                    clickButton("Move");
+                    modal().within(() => {
+                      cy.findByText("First collection").click();
+                      clickButton("Move");
+                    });
                   });
 
                   it("should be able to move/undo move a dashboard", () => {

--- a/frontend/test/metabase/scenarios/collections/timelines.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/timelines.cy.spec.js
@@ -286,7 +286,9 @@ describe("scenarios > collections > timelines", () => {
       openMenu("Releases");
       cy.findByText("Unarchive timeline").click();
       cy.findByText("No timelines found");
-      cy.findByLabelText("chevronleft icon").click();
+      cy.get(".Modal").within(() => {
+        cy.icon("chevronleft").click();
+      });
       cy.findByText("Releases");
     });
 
@@ -308,7 +310,9 @@ describe("scenarios > collections > timelines", () => {
       cy.findByText("Delete timeline").click();
       cy.findByText("Delete").click();
       cy.findByText("No timelines found");
-      cy.findByLabelText("chevronleft icon").click();
+      cy.get(".Modal").within(() => {
+        cy.icon("chevronleft").click();
+      });
       cy.findByText("Our analytics events");
     });
   });

--- a/frontend/test/metabase/scenarios/dashboard/bookmarks.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/bookmarks.cy.spec.js
@@ -1,4 +1,8 @@
-import { restore, sidebar, visitDashboard } from "__support__/e2e/cypress";
+import {
+  restore,
+  navigationSidebar,
+  visitDashboard,
+} from "__support__/e2e/cypress";
 
 describe("scenarios > dashboard > bookmarks", () => {
   beforeEach(() => {
@@ -15,7 +19,7 @@ describe("scenarios > dashboard > bookmarks", () => {
 
     cy.visit("/collection/root");
 
-    sidebar().within(() => {
+    navigationSidebar().within(() => {
       // Find the bookmark and click on it to visit dashboard page again
       cy.findByText("Orders in a dashboard").click();
     });
@@ -32,7 +36,7 @@ describe("scenarios > dashboard > bookmarks", () => {
 
     cy.wait("@fetchRootCollectionItems");
 
-    sidebar().within(() => {
+    navigationSidebar().within(() => {
       cy.findByText("Orders in a dashboard").should("not.exist");
     });
   });

--- a/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
@@ -440,8 +440,9 @@ describe("scenarios > dashboard", () => {
     assertScrollBarExists();
     cy.icon("share").click();
     cy.findByText("Sharing and embedding").click();
-    // Fullscreen modal opens - close it now
-    cy.icon("close").click();
+    cy.get(".Modal--full").within(() => {
+      cy.icon("close").click();
+    });
     cy.get(".Modal--full").should("not.exist");
     assertScrollBarExists();
   });

--- a/frontend/test/metabase/scenarios/models/models.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models.cy.spec.js
@@ -63,7 +63,8 @@ describe("scenarios > models", () => {
       table: "Orders",
     });
 
-    cy.findAllByText("Our analytics")
+    cy.findByTestId("qb-header")
+      .findAllByText("Our analytics")
       .first()
       .click();
     getCollectionItemRow("Orders Model").within(() => {
@@ -111,7 +112,8 @@ describe("scenarios > models", () => {
       table: "Orders",
     });
 
-    cy.findAllByText("Our analytics")
+    cy.findByTestId("qb-header")
+      .findAllByText("Our analytics")
       .first()
       .click();
     getCollectionItemRow("Orders Model").within(() => {

--- a/frontend/test/metabase/scenarios/models/reproductions/19737-data-picker-not-showing-moved-model.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/reproductions/19737-data-picker-not-showing-moved-model.cy.spec.js
@@ -22,10 +22,11 @@ describe("issue 19737", () => {
       .should("be.visible")
       .click();
 
-    cy.findByText("Models").click();
-
-    cy.findByText("Your personal collection").click();
-    cy.findByText(modelName);
+    popover().within(() => {
+      cy.findByText("Models").click();
+      cy.findByText("Your personal collection").click();
+      cy.findByText(modelName);
+    });
   });
 
   it("should not show duplicate models in the data picker after it's moved from a custom collection without refreshing (metabase#19737)", () => {
@@ -44,10 +45,11 @@ describe("issue 19737", () => {
       .click();
 
     // Open question picker (this is crucial) so the collection list are loaded.
-    cy.findByText("Models").click();
-
-    cy.findByText("First collection").click();
-    cy.findByText(modelName);
+    popover().within(() => {
+      cy.findByText("Models").click();
+      cy.findByText("First collection").click();
+      cy.findByText(modelName);
+    });
 
     // Use back button to so the state is kept
     cy.go("back");
@@ -64,10 +66,11 @@ describe("issue 19737", () => {
       .should("be.visible")
       .click();
 
-    cy.findByText("Models").click();
-
-    cy.findByText("First collection").click();
-    cy.findByText("Nothing here");
+    popover().within(() => {
+      cy.findByText("Models").click();
+      cy.findByText("First collection").click();
+      cy.findByText("Nothing here");
+    });
   });
 });
 

--- a/frontend/test/metabase/scenarios/native-filters/sql-field-filter-category.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native-filters/sql-field-filter-category.cy.spec.js
@@ -36,8 +36,10 @@ describe("scenarios > filters > sql filters > field filter > Category", () => {
   it("should work despite it not showing up in the widget type list", () => {
     cy.findByText("Showing 42 rows");
 
-    cy.icon("close").click();
-    cy.findByText("Field Filter").click();
+    cy.findByTestId("native-query-top-bar").within(() => {
+      cy.icon("close").click();
+      cy.findByText("Field Filter").click();
+    });
 
     popover().within(() => {
       cy.findByText("Gizmo").click();

--- a/frontend/test/metabase/scenarios/native/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/native.cy.spec.js
@@ -5,6 +5,7 @@ import {
   openNativeEditor,
   visitQuestionAdhoc,
   summarize,
+  sidebar,
 } from "__support__/e2e/cypress";
 
 import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
@@ -146,9 +147,13 @@ describe("scenarios > question > native", () => {
       cy.findByText("Done").click();
       cy.get(".ScalarValue").contains("1");
 
-      cy.icon("close").click();
+      cy.findByTestId("qb-filters-panel").within(() => {
+        cy.icon("close").click();
+      });
       summarize();
-      cy.icon("close").click();
+      sidebar().within(() => {
+        cy.icon("close").click();
+      });
       cy.findByText("Done").click();
     });
   });

--- a/frontend/test/metabase/scenarios/question/bookmarks.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/bookmarks.cy.spec.js
@@ -1,4 +1,9 @@
-import { restore, sidebar, visitQuestion } from "__support__/e2e/cypress";
+import {
+  restore,
+  navigationSidebar,
+  sidebar,
+  visitQuestion,
+} from "__support__/e2e/cypress";
 import { getSidebarSectionTitle as getSectionTitle } from "__support__/e2e/helpers/e2e-collection-helpers";
 
 describe("scenarios > question > bookmarks", () => {
@@ -13,7 +18,7 @@ describe("scenarios > question > bookmarks", () => {
 
     cy.visit("/collection/root");
 
-    sidebar().within(() => {
+    navigationSidebar().within(() => {
       getSectionTitle(/Bookmarks/);
       cy.findByText("Orders");
     });
@@ -40,7 +45,9 @@ function toggleBookmark() {
 
   cy.intercept("/api/bookmark/card/*").as("toggleBookmark");
 
-  cy.icon("bookmark").click();
+  sidebar().within(() => {
+    cy.icon("bookmark").click();
+  });
 
   cy.wait("@toggleBookmark");
 }

--- a/frontend/test/metabase/scenarios/question/new.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/new.cy.spec.js
@@ -150,7 +150,7 @@ describe("scenarios > question > new", () => {
       });
 
       it("should display the collection tree on the left side", () => {
-        cy.findByText("Our analytics");
+        popover().findByText("Our analytics");
       });
 
       it("should display the saved questions list on the right side", () => {
@@ -174,7 +174,7 @@ describe("scenarios > question > new", () => {
       });
 
       it("should display the collection tree on the left side", () => {
-        cy.findByText("Our analytics");
+        popover().findByText("Our analytics");
       });
 
       it("should display the saved questions list on the right side", () => {
@@ -193,9 +193,11 @@ describe("scenarios > question > new", () => {
         // Try to choose a different saved question
         cy.findByTestId("data-step-cell").click();
 
-        cy.findByText("Our analytics");
-        cy.findByText("Orders");
-        cy.findByText("Orders, Count, Grouped by Created At (year)").click();
+        popover().within(() => {
+          cy.findByText("Our analytics");
+          cy.findByText("Orders");
+          cy.findByText("Orders, Count, Grouped by Created At (year)").click();
+        });
 
         visualize();
 

--- a/frontend/test/metabase/scenarios/question/nulls.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nulls.cy.spec.js
@@ -195,8 +195,8 @@ describe("scenarios > question > null", () => {
       sidebar().within(() => {
         // remove pre-selected "Count"
         cy.icon("close").click();
-        cy.findByText("Add a metric").click();
       });
+      cy.findByText("Add a metric").click();
       // dropdown immediately opens with the new set of metrics to choose from
       popover().within(() => {
         cy.findByText("Cumulative sum of ...").click();

--- a/frontend/test/metabase/scenarios/question/nulls.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nulls.cy.spec.js
@@ -2,6 +2,7 @@ import {
   restore,
   openOrdersTable,
   popover,
+  sidebar,
   summarize,
   visitDashboard,
 } from "__support__/e2e/cypress";
@@ -191,9 +192,12 @@ describe("scenarios > question > null", () => {
       openOrdersTable();
 
       summarize();
-      // remove pre-selected "Count"
-      cy.icon("close").click();
-      cy.findByText("Add a metric").click();
+      sidebar().within(() => {
+        // remove pre-selected "Count"
+        cy.icon("close").click();
+        cy.findByText("Add a metric").click();
+      });
+      // dropdown immediately opens with the new set of metrics to choose from
       popover().within(() => {
         cy.findByText("Cumulative sum of ...").click();
         cy.findByText("Discount").click();

--- a/frontend/test/metabase/scenarios/smoketest/user.cy.spec.js
+++ b/frontend/test/metabase/scenarios/smoketest/user.cy.spec.js
@@ -166,9 +166,11 @@ describe("smoketest > user", () => {
     // Delete summary from sidebar
 
     summarize();
-    cy.icon("close")
-      .first()
-      .click();
+    sidebar().within(() => {
+      cy.icon("close")
+        .first()
+        .click();
+    });
     cy.findByText("Done").click();
 
     cy.findByText("Average of Rating by Category").should("not.exist");


### PR DESCRIPTION
This PR moves the navigation sidebar state to Redux (`state.app.isNavbarOpen`) since we'll need to access & manage it from different places (e.g. hide when a user starts editing a dashboard or opens a query builder sidebar). Also, this PR makes it hide the sidebar via CSS by adding `visibility: hidden` style. Removing and adding the whole component to the DOM could be pretty slow. Also, it makes it possible to load the sidebar "in the background" when you open e.g. a QB or a dashboard where the sidebar is supposed to be hidden by default. In this way, it feels quicker.

On the other hand, switching to the `visibility: hidden` approach broke a few E2E tests. Let's say we have a query builder test doing `findByText("Our analytics")`. By default, the nav sidebar is hidden when you open the query builder, so "Our analytics" could only appear in the QB header as expected. Now when the sidebar is hidden with `visibility: hidden`, it gets mounted in the DOM and we have one more "Our analytics" string, so the query fails. These tests are fixed