### PR TITLE
Hydrate Collections on Timelines for card/collection endpoints

### DIFF
--- a/src/metabase/models/timeline.clj
+++ b/src/metabase/models/timeline.clj
@@ -30,6 +30,7 @@
       (hydrate :parent_id :effective_location [:effective_ancestors :can_write] :can_write)))
 
 (defn hydrate-root-collection
+  "Hydrate `:collection` on [[Timelines]] when the id is `nil`."
   [{:keys [collection_id] :as timeline}]
   (if (nil? collection_id)
     (assoc timeline :collection (root-collection))

--- a/src/metabase/models/timeline.clj
+++ b/src/metabase/models/timeline.clj
@@ -1,5 +1,6 @@
 (ns metabase.models.timeline
-  (:require [metabase.models.interface :as i]
+  (:require [metabase.models.collection :as collection]
+            [metabase.models.interface :as i]
             [metabase.models.permissions :as perms]
             [metabase.models.timeline-event :as timeline-event]
             [metabase.util :as u]
@@ -22,6 +23,18 @@
 
 ;;;; functions
 
+(defn- root-collection
+  []
+  (-> (collection/root-collection-with-ui-details nil)
+      collection/personal-collection-with-ui-details
+      (hydrate :parent_id :effective_location [:effective_ancestors :can_write] :can_write)))
+
+(defn hydrate-root-collection
+  [{:keys [collection_id] :as timeline}]
+  (if (nil? collection_id)
+    (assoc timeline :collection (root-collection))
+    timeline))
+
 (defn timelines-for-collection
   "Load timelines based on `collection-id` passed in (nil means the root collection). Hydrates the events on each
   timeline at `:events` on the timeline."
@@ -29,7 +42,9 @@
   (cond-> (hydrate (db/select Timeline
                               :collection_id collection-id
                               :archived (boolean archived?))
-                   :creator)
+                   :creator
+                   :collection)
+    (nil? collection-id) (->> (map hydrate-root-collection))
     events? (timeline-event/include-events options)))
 
 (u/strict-extend (class Timeline)

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -1280,6 +1280,11 @@
       (testing "Timelines in the collection of the card are returned"
         (is (= #{"Timeline A"}
                (timeline-names (timelines-request card-a false)))))
+      (testing "Timelines in the collection have a hydrated `:collection` key"
+        (is (= #{(u/the-id coll-a)}
+               (->> (timelines-request card-a false)
+                    (map #(get-in % [:collection :id]))
+                    set))))
       (testing "Only un-archived timelines in the collection of the card are returned"
         (is (= #{"Timeline B"}
                (timeline-names (timelines-request card-b false)))))

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -1481,6 +1481,11 @@
       (testing "Timelines in the collection of the card are returned"
         (is (= #{"Timeline A"}
                (timeline-names (timelines-request coll-a false)))))
+      (testing "Timelines in the collection have a hydrated `:collection` key"
+        (is (= #{(u/the-id coll-a)}
+               (->> (timelines-request coll-a false)
+                    (map #(get-in % [:collection :id]))
+                    set))))
       (testing "Only un-archived timelines in the collection of the card are returned"
         (is (= #{"Timeline B"}
                (timeline-names (timelines-request coll-b false)))))


### PR DESCRIPTION
Epic: #20289 

This adds collection hydration on previously missed endpoints:

- `GET /api/collection/root/timelines`
- `GET /api/collection/:id/timelines`
- `GET /api/car/:id/timelines`