### PR TITLE
Browsing | Fix dashboard UI

### DIFF
--- a/frontend/src/metabase/App.jsx
+++ b/frontend/src/metabase/App.jsx
@@ -23,6 +23,7 @@ import UndoListing from "metabase/containers/UndoListing";
 import StatusListing from "metabase/status/containers/StatusListing";
 
 import CollectionCreate from "metabase/collections/containers/CollectionCreate";
+import { getIsEditing as getIsEditingDashboard } from "metabase/dashboard/selectors";
 
 import { toggleNavbar, getIsNavbarOpen } from "metabase/redux/app";
 import { IFRAMED, initializeIframeResizer } from "metabase/lib/dom";
@@ -33,9 +34,10 @@ export const MODAL_NEW_DASHBOARD = "MODAL_NEW_DASHBOARD";
 export const MODAL_NEW_COLLECTION = "MODAL_NEW_COLLECTION";
 
 const mapStateToProps = state => ({
+  currentUser: state.currentUser,
   errorPage: state.app.errorPage,
   isSidebarOpen: getIsNavbarOpen(state),
-  currentUser: state.currentUser,
+  isEditingDashboard: getIsEditingDashboard(state),
 });
 
 const mapDispatchToProps = {
@@ -89,9 +91,10 @@ class App extends Component {
   hasNavbar = () => {
     const {
       currentUser,
+      isEditingDashboard,
       location: { pathname },
     } = this.props;
-    if (!currentUser || IFRAMED) {
+    if (!currentUser || IFRAMED || isEditingDashboard) {
       return false;
     }
     return !PATHS_WITHOUT_NAVBAR.some(pattern => pattern.test(pathname));
@@ -101,11 +104,15 @@ class App extends Component {
     const {
       currentUser,
       location: { pathname },
+      isEditingDashboard,
     } = this.props;
     if (!currentUser || IFRAMED || this.isAdminApp()) {
       return false;
     }
-    return !PATHS_WITHOUT_NAVBAR.some(pattern => pattern.test(pathname));
+    return (
+      !PATHS_WITHOUT_NAVBAR.some(pattern => pattern.test(pathname)) &&
+      !isEditingDashboard
+    );
   };
 
   closeModal = () => {

--- a/frontend/src/metabase/App.jsx
+++ b/frontend/src/metabase/App.jsx
@@ -106,13 +106,10 @@ class App extends Component {
       location: { pathname },
       isEditingDashboard,
     } = this.props;
-    if (!currentUser || IFRAMED || this.isAdminApp()) {
+    if (!currentUser || IFRAMED || this.isAdminApp() || isEditingDashboard) {
       return false;
     }
-    return (
-      !PATHS_WITHOUT_NAVBAR.some(pattern => pattern.test(pathname)) &&
-      !isEditingDashboard
-    );
+    return !PATHS_WITHOUT_NAVBAR.some(pattern => pattern.test(pathname));
   };
 
   closeModal = () => {

--- a/frontend/src/metabase/App.jsx
+++ b/frontend/src/metabase/App.jsx
@@ -4,21 +4,14 @@ import { connect } from "react-redux";
 import { push } from "react-router-redux";
 import _ from "underscore";
 
+import AppErrorCard from "metabase/components/AppErrorCard/AppErrorCard";
+import Modal from "metabase/components/Modal";
+import CreateDashboardModal from "metabase/components/CreateDashboardModal";
+
 import ScrollToTop from "metabase/hoc/ScrollToTop";
 import AppBar from "metabase/nav/containers/AppBar";
 import Navbar from "metabase/nav/containers/Navbar";
 import * as Urls from "metabase/lib/urls";
-
-import { toggleNavbar, getIsNavbarOpen } from "metabase/redux/app";
-import { IFRAMED, initializeIframeResizer } from "metabase/lib/dom";
-
-import UndoListing from "metabase/containers/UndoListing";
-import StatusListing from "metabase/status/containers/StatusListing";
-import AppErrorCard from "metabase/components/AppErrorCard/AppErrorCard";
-import Modal from "metabase/components/Modal";
-
-import CollectionCreate from "metabase/collections/containers/CollectionCreate";
-import CreateDashboardModal from "metabase/components/CreateDashboardModal";
 
 import {
   Archived,
@@ -26,6 +19,13 @@ import {
   GenericError,
   Unauthorized,
 } from "metabase/containers/ErrorPages";
+import UndoListing from "metabase/containers/UndoListing";
+import StatusListing from "metabase/status/containers/StatusListing";
+
+import CollectionCreate from "metabase/collections/containers/CollectionCreate";
+
+import { toggleNavbar, getIsNavbarOpen } from "metabase/redux/app";
+import { IFRAMED, initializeIframeResizer } from "metabase/lib/dom";
 
 import { AppContentContainer, AppContent } from "./App.styled";
 

--- a/frontend/src/metabase/collections/constants.js
+++ b/frontend/src/metabase/collections/constants.js
@@ -1,4 +1,4 @@
 // unit to use for calculating collection sidebar spacing (in px)
 export const SIDEBAR_SPACER = 10;
-export const SIDEBAR_WIDTH = "320px";
+export const SIDEBAR_WIDTH = "324px";
 export const ANALYTICS_CONTEXT = "Collection Landing";

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
@@ -3,6 +3,8 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import _ from "underscore";
 
+import { getMainElement } from "metabase/lib/dom";
+
 import DashboardControls from "../../hoc/DashboardControls";
 import { DashboardSidebars } from "../DashboardSidebars";
 import DashboardHeader from "metabase/dashboard/containers/DashboardHeader";
@@ -105,7 +107,7 @@ export default class Dashboard extends Component {
   componentDidMount() {
     this.loadDashboard(this.props.dashboardId);
 
-    const [main] = document.getElementsByTagName("main");
+    const main = getMainElement();
     main.addEventListener("scroll", this.throttleParameterWidgetStickiness, {
       passive: true,
     });
@@ -127,7 +129,7 @@ export default class Dashboard extends Component {
 
   componentWillUnmount() {
     this.props.cancelFetchDashboardCardData();
-    const [main] = document.getElementsByTagName("main");
+    const main = getMainElement();
     main.removeEventListener("scroll", this.throttleParameterWidgetStickiness);
     main.removeEventListener("resize", this.throttleParameterWidgetStickiness);
   }

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
@@ -95,19 +95,19 @@ export default class Dashboard extends Component {
     this.parametersAndCardsContainerRef = React.createRef();
   }
 
+  throttleParameterWidgetStickiness = _.throttle(
+    () => updateParametersWidgetStickiness(this),
+    SCROLL_THROTTLE_INTERVAL,
+  );
+
   // NOTE: all of these lifecycle methods should be replaced with DashboardData HoC in container
   componentDidMount() {
     this.loadDashboard(this.props.dashboardId);
 
-    const throttleParameterWidgetStickiness = _.throttle(
-      () => updateParametersWidgetStickiness(this),
-      SCROLL_THROTTLE_INTERVAL,
-    );
-
-    window.addEventListener("scroll", throttleParameterWidgetStickiness, {
+    window.addEventListener("scroll", this.throttleParameterWidgetStickiness, {
       passive: true,
     });
-    window.addEventListener("resize", throttleParameterWidgetStickiness, {
+    window.addEventListener("resize", this.throttleParameterWidgetStickiness, {
       passive: true,
     });
   }
@@ -125,9 +125,14 @@ export default class Dashboard extends Component {
 
   componentWillUnmount() {
     this.props.cancelFetchDashboardCardData();
-
-    window.removeEventListener("scroll", updateParametersWidgetStickiness);
-    window.removeEventListener("resize", updateParametersWidgetStickiness);
+    window.removeEventListener(
+      "scroll",
+      this.throttleParameterWidgetStickiness,
+    );
+    window.removeEventListener(
+      "resize",
+      this.throttleParameterWidgetStickiness,
+    );
   }
 
   async loadDashboard(dashboardId) {

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
@@ -42,6 +42,7 @@ export default class Dashboard extends Component {
     isEditing: PropTypes.oneOfType([PropTypes.bool, PropTypes.object])
       .isRequired,
     isEditingParameter: PropTypes.bool.isRequired,
+    isNavbarOpen: PropTypes.bool.isRequired,
 
     dashboard: PropTypes.object,
     dashboardId: PropTypes.number,
@@ -203,6 +204,7 @@ export default class Dashboard extends Component {
       isNightMode,
       isSharing,
       parameters,
+      isNavbarOpen,
       showAddQuestionSidebar,
       parameterValues,
       editingParameter,
@@ -280,6 +282,7 @@ export default class Dashboard extends Component {
                 {shouldRenderParametersWidgetInViewMode && (
                   <ParametersWidgetContainer
                     ref={element => (this.parametersWidgetRef = element)}
+                    isNavbarOpen={isNavbarOpen}
                     isSticky={isParametersWidgetSticky}
                   >
                     {parametersWidget}

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
@@ -104,10 +104,11 @@ export default class Dashboard extends Component {
   componentDidMount() {
     this.loadDashboard(this.props.dashboardId);
 
-    window.addEventListener("scroll", this.throttleParameterWidgetStickiness, {
+    const [main] = document.getElementsByTagName("main");
+    main.addEventListener("scroll", this.throttleParameterWidgetStickiness, {
       passive: true,
     });
-    window.addEventListener("resize", this.throttleParameterWidgetStickiness, {
+    main.addEventListener("resize", this.throttleParameterWidgetStickiness, {
       passive: true,
     });
   }
@@ -125,14 +126,9 @@ export default class Dashboard extends Component {
 
   componentWillUnmount() {
     this.props.cancelFetchDashboardCardData();
-    window.removeEventListener(
-      "scroll",
-      this.throttleParameterWidgetStickiness,
-    );
-    window.removeEventListener(
-      "resize",
-      this.throttleParameterWidgetStickiness,
-    );
+    const [main] = document.getElementsByTagName("main");
+    main.removeEventListener("scroll", this.throttleParameterWidgetStickiness);
+    main.removeEventListener("resize", this.throttleParameterWidgetStickiness);
   }
 
   async loadDashboard(dashboardId) {

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.jsx
@@ -9,6 +9,7 @@ import { space } from "metabase/styled-components/theme";
 import { FullWidthContainer } from "metabase/styled-components/layout/FullWidthContainer";
 
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
+import { APP_BAR_HEIGHT } from "metabase/nav/constants";
 import { SIDEBAR_WIDTH } from "metabase/collections/constants";
 
 // Class names are added here because we still use traditional css,
@@ -113,6 +114,7 @@ export const ParametersWidgetContainer = styled(FullWidthContainer)`
     css`
       width: calc(100% - ${SIDEBAR_WIDTH});
       left: ${SIDEBAR_WIDTH};
+      top: ${APP_BAR_HEIGHT};
     `}
 `;
 

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.jsx
@@ -9,6 +9,7 @@ import { space } from "metabase/styled-components/theme";
 import { FullWidthContainer } from "metabase/styled-components/layout/FullWidthContainer";
 
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
+import { SIDEBAR_WIDTH } from "metabase/collections/constants";
 
 // Class names are added here because we still use traditional css,
 // see dashboard.css
@@ -104,6 +105,14 @@ export const ParametersWidgetContainer = styled(FullWidthContainer)`
       position: fixed;
       top: 0;
       left: 0;
+    `}
+
+  ${({ isSticky, isNavbarOpen }) =>
+    isSticky &&
+    isNavbarOpen &&
+    css`
+      width: calc(100% - ${SIDEBAR_WIDTH});
+      left: ${SIDEBAR_WIDTH};
     `}
 `;
 

--- a/frontend/src/metabase/dashboard/components/Dashboard/stickyParameters.js
+++ b/frontend/src/metabase/dashboard/components/Dashboard/stickyParameters.js
@@ -1,3 +1,5 @@
+import { getMainElement } from "metabase/lib/dom";
+
 export const updateParametersWidgetStickiness = dashboard => {
   initializeWidgetOffsetTop(dashboard);
 
@@ -36,8 +38,7 @@ const checkIfParametersWidgetShouldBeSticky = dashboard => {
     dashboard.state.parametersWidgetOffsetTop ||
     dashboard.parametersWidgetRef.offsetTop;
 
-  const [main] = document.getElementsByTagName("main");
-  return main.scrollTop >= offsetTop;
+  return getMainElement().scrollTop >= offsetTop;
 };
 
 const updateParametersAndCardsContainerStyle = (dashboard, shouldBeSticky) => {

--- a/frontend/src/metabase/dashboard/components/Dashboard/stickyParameters.js
+++ b/frontend/src/metabase/dashboard/components/Dashboard/stickyParameters.js
@@ -36,7 +36,8 @@ const checkIfParametersWidgetShouldBeSticky = dashboard => {
     dashboard.state.parametersWidgetOffsetTop ||
     dashboard.parametersWidgetRef.offsetTop;
 
-  return window.scrollY >= offsetTop;
+  const [main] = document.getElementsByTagName("main");
+  return main.scrollTop >= offsetTop;
 };
 
 const updateParametersAndCardsContainerStyle = (dashboard, shouldBeSticky) => {

--- a/frontend/src/metabase/dashboard/components/Dashboard/stickyParameters.unit.spec.js
+++ b/frontend/src/metabase/dashboard/components/Dashboard/stickyParameters.unit.spec.js
@@ -1,8 +1,15 @@
 import { updateParametersWidgetStickiness } from "./stickyParameters";
 
+function mockMainElementScroll(scrollTop) {
+  const fakeMainElement = { scrollTop };
+  document.getElementsByTagName = () => [fakeMainElement];
+}
+
 it("initializes parametersWidgetOffsetTop", () => {
   const offsetTop = 100;
   const setState = jest.fn();
+
+  mockMainElementScroll(0);
 
   const dashboard = {
     parametersWidgetRef: { offsetTop },
@@ -22,7 +29,7 @@ it("makes filters sticky with enough scrolling down", () => {
   const offsetTop = 100;
   const setState = jest.fn();
 
-  global.window.scrollY = offsetTop + 1;
+  mockMainElementScroll(offsetTop + 1);
 
   const dashboard = {
     parametersWidgetRef: { offsetTop },
@@ -42,7 +49,7 @@ it("makes filters unsticky with enough scrolling up", () => {
   const offsetTop = 100;
   const setState = jest.fn();
 
-  global.window.scrollY = offsetTop - 1;
+  mockMainElementScroll(offsetTop - 1);
 
   const dashboard = {
     parametersWidgetRef: { offsetTop },
@@ -62,7 +69,7 @@ it("keeps filters sticky with enough scrolling down and already sticky", () => {
   const offsetTop = 100;
   const setState = jest.fn();
 
-  global.window.scrollY = offsetTop + 1;
+  mockMainElementScroll(offsetTop + 1);
 
   const dashboard = {
     parametersWidgetRef: { offsetTop },
@@ -80,7 +87,7 @@ it("keeps filters not sticky with enough scrolling up and already not sticky", (
   const offsetTop = 100;
   const setState = jest.fn();
 
-  global.window.scrollY = offsetTop - 1;
+  mockMainElementScroll(offsetTop - 1);
 
   const dashboard = {
     parametersWidgetRef: { offsetTop },

--- a/frontend/src/metabase/dashboard/containers/DashboardApp.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp.jsx
@@ -8,7 +8,7 @@ import titleWithLoadingTime from "metabase/hoc/TitleWithLoadingTime";
 import Dashboard from "metabase/dashboard/components/Dashboard/Dashboard";
 
 import { fetchDatabaseMetadata } from "metabase/redux/metadata";
-import { setErrorPage } from "metabase/redux/app";
+import { getIsNavbarOpen, setErrorPage } from "metabase/redux/app";
 
 import {
   getIsEditing,
@@ -42,6 +42,7 @@ const mapStateToProps = (state, props) => {
     dashboardId: props.dashboardId || Urls.extractEntityId(props.params.slug),
 
     isAdmin: getUserIsAdmin(state, props),
+    isNavbarOpen: getIsNavbarOpen(state),
     isEditing: getIsEditing(state, props),
     isSharing: getIsSharing(state, props),
     dashboardBeforeEditing: getDashboardBeforeEditing(state, props),

--- a/frontend/src/metabase/dashboard/reducers.js
+++ b/frontend/src/metabase/dashboard/reducers.js
@@ -53,7 +53,7 @@ const isEditing = handleActions(
       next: (state, { payload }) => (payload ? payload : null),
     },
   },
-  {},
+  null,
 );
 
 function newDashboard(before, after, isDirty) {

--- a/frontend/src/metabase/dashboard/reducers.unit.spec.js
+++ b/frontend/src/metabase/dashboard/reducers.unit.spec.js
@@ -21,7 +21,7 @@ describe("dashboard reducers", () => {
       dashcardData: {},
       dashcards: {},
       isAddParameterPopoverOpen: false,
-      isEditing: {},
+      isEditing: null,
       loadingDashCards: {
         dashcardIds: [],
         loadingIds: [],

--- a/frontend/src/metabase/lib/dom.js
+++ b/frontend/src/metabase/lib/dom.js
@@ -439,3 +439,8 @@ export function isReducedMotionPreferred() {
   const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
   return mediaQuery && mediaQuery.matches;
 }
+
+export function getMainElement() {
+  const [main] = document.getElementsByTagName("main");
+  return main;
+}

--- a/frontend/test/metabase-visual/dashboard/parameters-widget.cy.spec.js
+++ b/frontend/test/metabase-visual/dashboard/parameters-widget.cy.spec.js
@@ -44,7 +44,7 @@ describe("visual tests > dashboard > parameters widget", () => {
   it("is sticky in view mode", () => {
     cy.findByText("test question");
 
-    cy.scrollTo(0, 264);
+    cy.get("main").scrollTo(0, 264);
 
     cy.percySnapshot();
   });

--- a/frontend/test/metabase/scenarios/question/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/settings.cy.spec.js
@@ -213,6 +213,7 @@ describe("scenarios > question > settings", () => {
         .click();
       cy.contains("Yes please!").click();
       cy.contains("Orders in a dashboard").click();
+      cy.findByText("Cancel").click();
 
       // create a new question to see if the "add to a dashboard" modal is still there
       openNavigationSidebar();


### PR DESCRIPTION
This PR fixes sticky dashboard parameters panel behavior and hides `NavBar` and `AppBar` when editing a dashboard.

**Sticky dashboard parameters panel**
There is a behavior making the parameters panel stick to the top of the viewport when you scroll a long dashboard. It was broken when new navigation was introduced. Fixed by attaching the scroll event to the `main` HTML element instead of `window`. Also adds some code to fix the filters panel look when viewing a dashboard with an open navbar (sidebar).

### To Verify

1. Open a dashboard with filters that doesn't fit into a single viewport. E.g. an x-rayed sample database dashboard
2. With open navigation sidebar: scroll the page down, the filters should stick to the top
3. With closed navigation sidebar: scroll the page down, the filters should stick to the top
4. Go into dashboard editing mode (click the pencil icon). Ensure both the navigation sidebar and top app bar are hidden. Ensure the filters still stick to the top when you scroll down

### Demo

**Before**

https://user-images.githubusercontent.com/17258145/160008464-fe88d82e-e53e-42f4-97a1-71194b7abfe7.mp4

**After**

https://user-images.githubusercontent.com/17258145/160008476-7aa58c81-d45e-468f-b5eb-f341c56bd83b.mp4

