### PR TITLE
Fallback cache keys & upgrade caching actions

### DIFF
--- a/.github/actions/prepare-backend/action.yml
+++ b/.github/actions/prepare-backend/action.yml
@@ -6,16 +6,12 @@ inputs:
   clojure-version:
     required: true
     default: '1.10.3.933'
-  m2-cache-key:
-    description: 'Key to cache M2 packages from Maven Central'
-    required: true
-    default: 'm2'
 
 runs:
   using: "composite"
   steps:
     - name: Prepare JDK ${{ inputs.java-version }}
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         java-version: ${{ inputs.java-version }}
         distribution: 'temurin'
@@ -25,9 +21,11 @@ runs:
         curl -O https://download.clojure.org/install/linux-install-${{ inputs.clojure-version }}.sh &&
         sudo bash ./linux-install-${{ inputs.clojure-version }}.sh
     - name: Get M2 cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ~/.m2
           ~/.gitlibs
-        key: ${{ runner.os }}-${{ inputs.m2-cache-key }}-${{ hashFiles('**/deps.edn') }}
+        key: ${{ runner.os }}-be-deps-${{ hashFiles('**/deps.edn') }}
+        restore-keys: |
+          ${{ runner.os }}-be-deps-

--- a/.github/actions/prepare-backend/action.yml
+++ b/.github/actions/prepare-backend/action.yml
@@ -6,6 +6,10 @@ inputs:
   clojure-version:
     required: true
     default: '1.10.3.933'
+  m2-cache-key:
+    description: 'Key to cache M2 packages from Maven Central'
+    required: true
+    default: 'm2'
 
 runs:
   using: "composite"
@@ -26,6 +30,6 @@ runs:
         path: |
           ~/.m2
           ~/.gitlibs
-        key: ${{ runner.os }}-be-deps-${{ hashFiles('**/deps.edn') }}
+        key: ${{ runner.os }}-${{ inputs.m2-cache-key }}-${{ hashFiles('**/deps.edn') }}
         restore-keys: |
-          ${{ runner.os }}-be-deps-
+          ${{ runner.os }}-${{ inputs.m2-cache-key }}-

--- a/.github/actions/prepare-cypress/action.yml
+++ b/.github/actions/prepare-cypress/action.yml
@@ -3,7 +3,7 @@ runs:
   using: "composite"
   steps:
     - name: Get Cypress cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/Cypress
         key: ${{ runner.os }}-Cypress-${{ hashFiles('**/yarn.lock') }}

--- a/.github/actions/prepare-frontend/action.yml
+++ b/.github/actions/prepare-frontend/action.yml
@@ -8,12 +8,12 @@ runs:
         node-version: 14.x
         cache: 'yarn'
     - name: Get M2 cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.m2
         key: ${{ runner.os }}-cljs-${{ hashFiles('**/shadow-cljs.edn') }}
     - name: Get node_modules cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: node_modules
         key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -42,7 +42,7 @@ jobs:
         java-version: [8, 11, 17]
     steps:
     - name: Prepare JRE (Java Run-time Environment)
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3
       with:
         java-package: jre
         java-version: ${{ matrix.java-version }}


### PR DESCRIPTION
Here I'm upgrading a few components
- setup-java (nothing to do with caching, although it has a caching feature but does not work with tools.deps)
- cache

Also, using the restore-keys (https://github.com/actions/cache#inputs) key to check for fallback keys
