### PR TITLE
Add :can_write to the :collection hydration for timelines

### DIFF
--- a/src/metabase/api/timeline.clj
+++ b/src/metabase/api/timeline.clj
@@ -39,7 +39,7 @@
    archived (s/maybe su/BooleanString)}
   (let [archived? (Boolean/parseBoolean archived)
         timelines (map timeline/hydrate-root-collection (db/select Timeline [:where [:= :archived archived?]]))]
-    (cond->> (hydrate timelines :creator :collection)
+    (cond->> (hydrate timelines :creator [:collection :can_write])
       (= include "events")
       (map #(timeline-event/include-events-singular % {:events/all?  archived?})))))
 
@@ -53,7 +53,7 @@
    end      (s/maybe su/TemporalString)}
   (let [archived? (Boolean/parseBoolean archived)
         timeline  (api/read-check (Timeline id))]
-    (cond-> (hydrate timeline :creator :collection)
+    (cond-> (hydrate timeline :creator [:collection :can_write])
       ;; `collection_id` `nil` means we need to assoc 'root' collection
       ;; because hydrate `:collection` needs a proper `:id` to work.
       (nil? (:collection_id timeline))

--- a/src/metabase/models/timeline.clj
+++ b/src/metabase/models/timeline.clj
@@ -44,7 +44,7 @@
                               :collection_id collection-id
                               :archived (boolean archived?))
                    :creator
-                   :collection)
+                   [:collection :can_write])
     (nil? collection-id) (->> (map hydrate-root-collection))
     events? (timeline-event/include-events options)))
 

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -1285,6 +1285,10 @@
                (->> (timelines-request card-a false)
                     (map #(get-in % [:collection :id]))
                     set))))
+      (testing "check that `:can_write` key is hydrated"
+        (is (every?
+             #(contains? % :can_write)
+             (map :collection (timelines-request card-a false)))))
       (testing "Only un-archived timelines in the collection of the card are returned"
         (is (= #{"Timeline B"}
                (timeline-names (timelines-request card-b false)))))

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -1486,6 +1486,10 @@
                (->> (timelines-request coll-a false)
                     (map #(get-in % [:collection :id]))
                     set))))
+      (testing "check that `:can_write` key is hydrated"
+        (is (every?
+             #(contains? % :can_write)
+             (map :collection (timelines-request coll-a false)))))
       (testing "Only un-archived timelines in the collection of the card are returned"
         (is (= #{"Timeline B"}
                (timeline-names (timelines-request coll-b false)))))


### PR DESCRIPTION
Epic: #20289 

Oh baby, it's another small thing I overlooked. Oops. At least it's fixable. And now I've also got some tests to make
sure can_write is there.