### PR TITLE
handle long schema names

### DIFF
--- a/frontend/src/metabase/browse/containers/SchemaBrowser.jsx
+++ b/frontend/src/metabase/browse/containers/SchemaBrowser.jsx
@@ -8,9 +8,7 @@ import Database from "metabase/entities/databases";
 import Card from "metabase/components/Card";
 import EntityItem from "metabase/components/EntityItem";
 import { Grid } from "metabase/components/Grid";
-import Icon from "metabase/components/Icon";
 import Link from "metabase/core/components/Link";
-import Tooltip from "metabase/components/Tooltip";
 
 import TableBrowser from "metabase/browse/containers/TableBrowser";
 import * as Urls from "metabase/lib/urls";
@@ -18,11 +16,7 @@ import { color } from "metabase/lib/colors";
 
 import BrowseHeader from "metabase/browse/components/BrowseHeader";
 import { ANALYTICS_CONTEXT } from "metabase/browse/constants";
-import {
-  SchemaCardActions,
-  SchemaCardContent,
-  SchemaGridItem,
-} from "./SchemaBrowser.styled";
+import { SchemaGridItem } from "./SchemaBrowser.styled";
 
 function SchemaBrowser(props) {
   const { schemas, params } = props;
@@ -60,20 +54,12 @@ function SchemaBrowser(props) {
                     className="overflow-hidden"
                   >
                     <Card hoverable px={1}>
-                      <SchemaCardContent>
-                        <EntityItem
-                          name={schema.name}
-                          iconName="folder"
-                          iconColor={color("accent2")}
-                          item={schema}
-                        />
-                        <SchemaCardActions>
-                          <Icon name="reference" />
-                          <Tooltip tooltip={t`X-ray this schema`}>
-                            <Icon name="bolt" mx={1} />
-                          </Tooltip>
-                        </SchemaCardActions>
-                      </SchemaCardContent>
+                      <EntityItem
+                        name={schema.name}
+                        iconName="folder"
+                        iconColor={color("accent2")}
+                        item={schema}
+                      />
                     </Card>
                   </Link>
                 </SchemaGridItem>

--- a/frontend/src/metabase/browse/containers/SchemaBrowser.styled.tsx
+++ b/frontend/src/metabase/browse/containers/SchemaBrowser.styled.tsx
@@ -16,12 +16,3 @@ export const SchemaGridItem = styled(GridItem)`
     width: 33.33%;
   }
 `;
-
-export const SchemaCardContent = styled.div`
-  display: flex;
-  align-items: center;
-`;
-
-export const SchemaCardActions = styled.div`
-  margin-left: auto;
-`;


### PR DESCRIPTION
## Before

- Long schema names would overflow in the browse view
- Broken x-ray and learn buttons would appear on schema (these actions don't actually work for schema)

![Screenshot from 2022-03-25 10-02-54](https://user-images.githubusercontent.com/30528226/160157547-2ab540c3-d367-4aed-8365-3cbca39299b5.png)

## Changes

- removed x-ray and learn buttons from schema browser
- without the flex styling for those buttons, the overflow issue fixed itself :smile: 
- Resolves #18581 

## After
- schema names no longer overflow
- meaningless actions no longer appear

desktop | mobile
--- | ---
![Screenshot from 2022-03-25 10-04-53](https://user-images.githubusercontent.com/30528226/160157842-6531992f-8293-4239-84f1-6d2aa91b8815.png) | ![Screenshot from 2022-03-25 09-47-16](https://user-images.githubusercontent.com/30528226/160157582-59b46237-19c4-47c5-aee2-68d2703bcbff.png)
