### PR TITLE
Add new `valid-path-format?` predicate for schema validation to fix downgrading issues generically

### DIFF
--- a/src/metabase/models/permissions.clj
+++ b/src/metabase/models/permissions.clj
@@ -302,9 +302,19 @@
                       (seq path))
              (re-matches path-regex path))))
 
+(defn valid-path-format?
+  "Is `path` a string with a valid permissions path format? This is a less strict version of [[valid-path?]] which
+  just checks that the path components contain alphanumeric characters or dashes, and slashes are in the right place.
+  This should be used for schema validation in most places, to preserve downgradability when new permissions paths are
+  added."
+  ^Boolean [^String path]
+  (boolean (when (and (string? path)
+                      (seq path))
+             (re-matches #"^/((\w|-)+/)*$" path))))
+
 (def Path
-  "Schema for a valid permissions path."
-  (s/pred valid-path? "Valid permissions path"))
+  "Schema for a permissions path with a valid format."
+  (s/pred valid-path-format? "Valid permissions path"))
 
 (defn- assert-not-admin-group
   "Check to make sure the `:group_id` for `permissions` entry isn't the admin group."

--- a/src/metabase/models/permissions.clj
+++ b/src/metabase/models/permissions.clj
@@ -304,13 +304,13 @@
 
 (defn valid-path-format?
   "Is `path` a string with a valid permissions path format? This is a less strict version of [[valid-path?]] which
-  just checks that the path components contain alphanumeric characters or dashes, and slashes are in the right place.
+  just checks that the path components contain alphanumeric characters or dashes, separated by slashes
   This should be used for schema validation in most places, to preserve downgradability when new permissions paths are
   added."
   ^Boolean [^String path]
   (boolean (when (and (string? path)
                       (seq path))
-             (re-matches #"^/((\w|-)+/)*$" path))))
+             (re-matches #"^/((\w|-)*/)*$" path))))
 
 (def Path
   "Schema for a permissions path with a valid format."

--- a/src/metabase/models/permissions.clj
+++ b/src/metabase/models/permissions.clj
@@ -310,7 +310,7 @@
   ^Boolean [^String path]
   (boolean (when (and (string? path)
                       (seq path))
-             (re-matches #"^/((\w|-)*/)*$" path))))
+             (re-matches (re-pattern (str "^/(" path-char "*/)*$")) path))))
 
 (def Path
   "Schema for a permissions path with a valid format."

--- a/test/metabase/models/permissions_test.clj
+++ b/test/metabase/models/permissions_test.clj
@@ -199,6 +199,7 @@
             ["/asdf/"
              "/asdf/ghjk/"
              "/asdf-ghjk/"
+             "/adsf//"
              "/"
              "/asdf/1/ghkl/"]]
       (testing (pr-str path)
@@ -208,11 +209,8 @@
   (testing "invalid paths"
     (doseq [path
             [""
-             "//"
              "/asdf"
              "asdf/"
-             "/asdf//"
-             "/asdf//asdf/"
              "123"
              nil
              {}

--- a/test/metabase/models/permissions_test.clj
+++ b/test/metabase/models/permissions_test.clj
@@ -193,6 +193,38 @@
           (is (= expected
                  (perms/valid-path? path))))))))
 
+(deftest valid-path-format-test
+  (testing "valid paths"
+    (doseq [path
+            ["/asdf/"
+             "/asdf/ghjk/"
+             "/asdf-ghjk/"
+             "/"
+             "/asdf/1/ghkl/"]]
+      (testing (pr-str path)
+        (is (= true
+               (perms/valid-path-format? path))))))
+
+  (testing "invalid paths"
+    (doseq [path
+            [""
+             "//"
+             "/asdf"
+             "asdf/"
+             "/asdf//"
+             "/asdf//asdf/"
+             "123"
+             nil
+             {}
+             []
+             true
+             false
+             (keyword "/asdf/")
+             1234]]
+      (testing (pr-str path)
+        (is (= false
+               (perms/valid-path-format? path)))))))
+
 
 ;;; -------------------------------------------------- data-perms-path ---------------------------------------------------
 

--- a/test/metabase/models/permissions_test.clj
+++ b/test/metabase/models/permissions_test.clj
@@ -14,54 +14,59 @@
 
 ;;; ----------------------------------------------- valid-path? -----------------------------------------------
 
+(def ^:private valid-paths
+  ["/db/1/"
+   "/db/1/native/"
+   "/db/1/schema/"
+   "/db/1/schema/public/"
+   "/db/1/schema/PUBLIC/"
+   "/db/1/schema//"
+   "/db/1/schema/1234/"
+   "/db/1/schema/public/table/1/"
+   "/db/1/schema/PUBLIC/table/1/"
+   "/db/1/schema//table/1/"
+   "/db/1/schema/public/table/1/"
+   "/db/1/schema/PUBLIC/table/1/"
+   "/db/1/schema//table/1/"
+   "/db/1/schema/1234/table/1/"
+   "/db/1/schema/PUBLIC/table/1/query/"
+   "/db/1/schema/PUBLIC/table/1/query/segmented/"
+   ;; download permissions
+   "/download/db/1/"
+   "/download/limited/db/1/"
+   "/download/db/1/native/"
+   "/download/limited/db/1/native/"
+   "/download/db/1/schema/PUBLIC/"
+   "/download/limited/db/1/schema/PUBLIC/"
+   "/download/db/1/schema/PUBLIC/table/1/"
+   "/download/limited/db/1/schema/PUBLIC/table/1/"
+   ;; block permissions
+   "/block/db/1/"
+   "/block/db/1000/"
+   ;; full admin (everything) root permissions
+   "/"])
+
+(def ^:private valid-paths-with-slashes
+  [;; COMPANY-NET\ should get escaped to COMPANY-NET\\
+   "/db/16/schema/COMPANY-NET\\\\john.doe/"
+   ;; COMPANY-NET/ should get escaped to COMPANY-NET\/
+   "/db/16/schema/COMPANY-NET\\/john.doe/"
+   ;; my\schema should get escaped to my\\schema
+   "/db/1/schema/my\\\\schema/table/1/"
+   ;; my\\schema should get escaped to my\\\\schema
+   "/db/1/schema/my\\\\\\\\schema/table/1/"
+   ;; my/schema should get escaped to my\/schema
+   "/db/1/schema/my\\/schema/table/1/"])
+
 (deftest valid-path-test
   (testing "valid paths"
-    (doseq [path
-            ["/db/1/"
-             "/db/1/native/"
-             "/db/1/schema/"
-             "/db/1/schema/public/"
-             "/db/1/schema/PUBLIC/"
-             "/db/1/schema//"
-             "/db/1/schema/1234/"
-             "/db/1/schema/public/table/1/"
-             "/db/1/schema/PUBLIC/table/1/"
-             "/db/1/schema//table/1/"
-             "/db/1/schema/public/table/1/"
-             "/db/1/schema/PUBLIC/table/1/"
-             "/db/1/schema//table/1/"
-             "/db/1/schema/1234/table/1/"
-             "/db/1/schema/PUBLIC/table/1/query/"
-             "/db/1/schema/PUBLIC/table/1/query/segmented/"
-             ;; download permissions
-             "/download/db/1/"
-             "/download/limited/db/1/"
-             "/download/db/1/native/"
-             "/download/limited/db/1/native/"
-             "/download/db/1/schema/PUBLIC/"
-             "/download/limited/db/1/schema/PUBLIC/"
-             "/download/db/1/schema/PUBLIC/table/1/"
-             "/download/limited/db/1/schema/PUBLIC/table/1/"
-             ;; block permissions
-             "/block/db/1/"
-             "/block/db/1000/"
-             ;; full admin (everything) root permissions
-             "/"]]
+    (doseq [path valid-paths]
       (testing (pr-str path)
         (is (= true
                (perms/valid-path? path)))))
 
     (testing "\nWe should allow slashes in permissions paths? (#8693, #13263)\n"
-      (doseq [path [;; COMPANY-NET\ should get escaped to COMPANY-NET\\
-                    "/db/16/schema/COMPANY-NET\\\\john.doe/"
-                    ;; COMPANY-NET/ should get escaped to COMPANY-NET\/
-                    "/db/16/schema/COMPANY-NET\\/john.doe/"
-                    ;; my\schema should get escaped to my\\schema
-                    "/db/1/schema/my\\\\schema/table/1/"
-                    ;; my\\schema should get escaped to my\\\\schema
-                    "/db/1/schema/my\\\\\\\\schema/table/1/"
-                    ;; my/schema should get escaped to my\/schema
-                    "/db/1/schema/my\\/schema/table/1/"]]
+      (doseq [path valid-paths-with-slashes]
         (testing (pr-str path)
           (is (= true
                  (perms/valid-path? path)))))))
@@ -194,14 +199,20 @@
                  (perms/valid-path? path))))))))
 
 (deftest valid-path-format-test
-  (testing "valid paths"
-    (doseq [path
-            ["/asdf/"
-             "/asdf/ghjk/"
-             "/asdf-ghjk/"
-             "/adsf//"
-             "/"
-             "/asdf/1/ghkl/"]]
+  (testing "known valid paths"
+    (doseq [path (concat valid-paths valid-paths-with-slashes)]
+      (testing (pr-str path)
+        (is (= true
+               (perms/valid-path-format? path))))))
+
+  (testing "unknown paths with valid path format"
+    (doseq [path ["/asdf/"
+                  "/asdf/ghjk/"
+                  "/asdf-ghjk/"
+                  "/adsf//"
+                  "/asdf/1/ghkl/"
+                  "/asdf\\/ghkl/"
+                  "/asdf\\\\ghkl/"]]
       (testing (pr-str path)
         (is (= true
                (perms/valid-path-format? path))))))


### PR DESCRIPTION
In https://github.com/metabase/metabase/pull/21040 I tried to fix issues with downgrading after new permission paths are added, by just removing schema validation from the few functions that I thought were causing all the issues. But @flamber [pointed out](https://github.com/metabase/metabase/issues/20470#issuecomment-1079015483) that there's still an issue in search, so I think we need a more generic solution.

Here I've added a new `valid-path-format?` predicate that just checks that the basic permissions path format is what we expect (i.e. alphanumeric or dashes, with components separated by forward slashes), and I've switched the `Path` schema to use this function instead of `valid-path?`. `valid-path?` is still used in a few places where we actually want to make sure we're dealing with _known_ permissions paths, like when we're writing a new path to the DB.

This should hopefully solve future problems where someone uses the innocent-looking `Path` schema in a helper function and breaks downgrading all over again.