### PR TITLE
Moving Currents.dev from CCI to GHA

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -467,7 +467,7 @@ commands:
                   - steps: << parameters.before-steps >>
                   - run:
                       name: << parameters.command-name >>
-                      command: << parameters.command >>
+                      command: yarn << parameters.command >>
                       no_output_timeout: 15m
                   - steps: << parameters.after-steps >>
       - unless:
@@ -477,7 +477,7 @@ commands:
             - steps: << parameters.before-steps >>
             - run:
                 name: << parameters.command-name >>
-                command: << parameters.command >>
+                command: yarn << parameters.command >>
                 no_output_timeout: 15m
             - steps: << parameters.after-steps >>
 
@@ -603,7 +603,7 @@ jobs:
             fi
       - run-yarn-command:
           command-name: Create static visualization js bundle
-          command: yarn build-static-viz
+          command: build-static-viz
       - persist_to_workspace:
           root: /home/circleci/
           paths:
@@ -911,9 +911,6 @@ jobs:
       folder:
         type: string
         default: ""
-      currents-record:
-        type: boolean
-        default: false
       test-files:
         type: string
         default: ""
@@ -952,18 +949,9 @@ jobs:
                   - steps: << parameters.before-steps >>
                   # Make both `test-files`,  `source-folder` and `currents-record` parameters optional. Translates to: if `parameter` => run associated flag (`--spec`, `--folder` and `--key $CURRENTS_KEY --record` respectively)
                 command: |
-                  if [[ $CIRCLE_BRANCH == release* || $CIRCLE_BRANCH == master ]]; then
-                  echo 'This is a release or master branch. Sending report to Currents.dev'
-                    yarn test-cypress-no-build \
-                    <<# parameters.test-files >> --spec << parameters.test-files >> <</ parameters.test-files >> \
-                    <<# parameters.currents-record >> --key $CURRENTS_KEY --record <</ parameters.currents-record >> \
-                    <<# parameters.source-folder >> --folder << parameters.source-folder >> --group << parameters.source-folder >> <</ parameters.source-folder >>
-                  else
-                  echo 'This is NOT a release or master branch. Will not send the report to Currents.dev'
-                    yarn test-cypress-no-build \
-                    <<# parameters.test-files >> --spec << parameters.test-files >> <</ parameters.test-files >> \
-                    <<# parameters.source-folder >> --folder << parameters.source-folder >> <</ parameters.source-folder >>
-                  fi
+                  run test-cypress-no-build \
+                  <<# parameters.test-files >> --spec << parameters.test-files >> <</ parameters.test-files >> \
+                  <<# parameters.source-folder >> --folder << parameters.source-folder >> <</ parameters.source-folder >>
                 after-steps:
                   - store_artifacts:
                       path: /home/circleci/metabase/metabase/cypress
@@ -1291,7 +1279,6 @@ workflows:
             - snowplow-deps
           cypress-group: "<< matrix.folder >>-<< matrix.edition >>"
           source-folder: << matrix.folder >>
-          currents-record: true
           qa-db: true
           snowplow: true
           before-steps:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -3,7 +3,7 @@ name: E2E Tests
 on:
   push:
     branches:
-      - 'master'
+      - 'moving-currents-GHA'
 
 jobs:
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -111,7 +111,7 @@ jobs:
         mv version.properties resources/
 
     - name: Run Cypress tests on ${{ matrix.folder }}
-      run: yarn run test-cypress-no-build --folder ${{ matrix.folder }} --record --key ${{ secrets.CURRENTS_KEY }} --group ${{matrix.folder}} --ci-build-id "${{ github.repository }}-${{ github.run_id }}-${{ github.run_attempt }}"
+      run: yarn run test-cypress-no-build --folder ${{ matrix.folder }} --record --key ${{ secrets.CURRENTS_KEY }} --group ${{matrix.folder}} --ci-build-id "${{ github.run_id }}-${{ github.run_attempt }}"
       env:
         TERM: xterm
     - name: Upload Cypress recording upon failure

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -110,8 +110,8 @@ jobs:
         jar xf target/uberjar/metabase.jar version.properties
         mv version.properties resources/
 
-    - run: yarn run test-cypress-no-build --folder ${{ matrix.folder }}
-      name: Run Cypress tests on ${{ matrix.folder }}
+    - name: Run Cypress tests on ${{ matrix.folder }}
+      run: yarn run test-cypress-no-build --folder ${{ matrix.folder }} --record --key ${{ secrets.CURRENTS_KEY }} --group ${{matrix.folder}}
       env:
         TERM: xterm
     - name: Upload Cypress recording upon failure

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -3,7 +3,7 @@ name: E2E Tests
 on:
   push:
     branches:
-      - 'moving-currents-GHA'
+      - 'master'
 
 jobs:
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -111,7 +111,7 @@ jobs:
         mv version.properties resources/
 
     - name: Run Cypress tests on ${{ matrix.folder }}
-      run: yarn run test-cypress-no-build --folder ${{ matrix.folder }} --record --key ${{ secrets.CURRENTS_KEY }} --group ${{matrix.folder}}
+      run: yarn run test-cypress-no-build --folder ${{ matrix.folder }} --record --key ${{ secrets.CURRENTS_KEY }} --group ${{matrix.folder}} --ci-build-id "${{ github.repository }}-${{ github.run_id }}-${{ github.run_attempt }}"
       env:
         TERM: xterm
     - name: Upload Cypress recording upon failure

--- a/frontend/test/__support__/e2e/cypress.json
+++ b/frontend/test/__support__/e2e/cypress.json
@@ -5,7 +5,7 @@
   "supportFile": "frontend/test/__support__/e2e/cypress.js",
   "videoUploadOnPasses": false,
   "chromeWebSecurity": false,
-  "projectId": "CJQWRC",
+  "projectId": "KetpiS",
   "viewportHeight": 800,
   "viewportWidth": 1280,
   "retries": {


### PR DESCRIPTION
Since we are moving from CCI to GHA on the E2E it makes sense to have Currents.dev running there for the metrics.

Obs: Once that we are ready to run E2E not only in master on GHA, we will need to add a condition to the step.