### PR TITLE
Remove extra decimals in small x-axis scales

### DIFF
--- a/frontend/src/metabase/visualizations/lib/apply_axis.js
+++ b/frontend/src/metabase/visualizations/lib/apply_axis.js
@@ -285,7 +285,8 @@ export function applyChartQuantitativeXAxis(
   }
 
   // pad the domain slightly to prevent clipping
-  xDomain = [xDomain[0] - xInterval * 0.75, xDomain[1] + xInterval * 0.75];
+  const pad = Math.round(xInterval * 0.75 * 10) / 10;
+  xDomain = [xDomain[0] - pad, xDomain[1] + pad];
 
   chart.x(scale.domain(xDomain)).xUnits(dc.units.fp.precision(xInterval));
 }


### PR DESCRIPTION
## Before

- For low-value x-axis scales, we got tons of funny looking decimal places instead of a nice round 0 on our graphs' linear x-axes

![Screenshot from 2022-03-25 13-21-39](https://user-images.githubusercontent.com/30528226/160187695-dbd0a02b-2d78-4542-8eff-dedd0d63df5d.png)

bar chart | line chart
--- | ---
![Screenshot from 2022-03-25 13-18-58](https://user-images.githubusercontent.com/30528226/160187586-d65f9146-66c9-435f-9b07-66661121ba91.png) | ![Screenshot from 2022-03-25 13-18-46](https://user-images.githubusercontent.com/30528226/160187587-71a849f6-e964-426d-8978-8fbc13124729.png)


## Changes
- for small numbers, we were hitting a floating-point precision issue when adding padding to our chart axes
- added some rounding to our x-axis padding
- Resolves #15188 

## After

- no extra digits on graphs with low-value x axes

bar chart | line chart
--- | ---
![Screenshot from 2022-03-25 13-16-05](https://user-images.githubusercontent.com/30528226/160188349-1369b855-bad4-43e5-a329-14d8469250af.png) | ![Screenshot from 2022-03-25 13-17-47](https://user-images.githubusercontent.com/30528226/160188347-2d864109-148d-4810-9b89-cc3a41f3e234.png)

- other graphs continue to function properly, and have an appropriate amount of x-padding

![Screenshot from 2022-03-25 13-14-28](https://user-images.githubusercontent.com/30528226/160188477-99811291-34f0-44a3-8958-a5eb50e8f891.png)
