### PR TITLE
Fix combined series dashcard not showing correct column title in tooltip

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard.jsx
@@ -198,6 +198,7 @@ export default class DashCard extends Component {
               }
               isPreviewing={this.state.isPreviewingCard}
               onPreviewToggle={this.handlePreviewToggle}
+              dashboard={dashboard}
             />
           </DashboardCardActionsPanel>
         ) : null}
@@ -317,6 +318,7 @@ const DashCardActionButtons = ({
   showClickBehaviorSidebar,
   onPreviewToggle,
   isPreviewing,
+  dashboard,
 }) => {
   const buttons = [];
 
@@ -338,6 +340,7 @@ const DashCardActionButtons = ({
         <ChartSettingsButton
           series={series}
           onReplaceAllVisualizationSettings={onReplaceAllVisualizationSettings}
+          dashboard={dashboard}
         />,
       );
     }
@@ -373,7 +376,11 @@ const DashCardActionButtons = ({
   );
 };
 
-const ChartSettingsButton = ({ series, onReplaceAllVisualizationSettings }) => (
+const ChartSettingsButton = ({
+  series,
+  onReplaceAllVisualizationSettings,
+  dashboard,
+}) => (
   <ModalWithTrigger
     wide
     tall
@@ -394,6 +401,7 @@ const ChartSettingsButton = ({ series, onReplaceAllVisualizationSettings }) => (
       series={series}
       onChange={onReplaceAllVisualizationSettings}
       isDashboard
+      dashboard={dashboard}
     />
   </ModalWithTrigger>
 );

--- a/frontend/src/metabase/visualizations/components/ChartSettings.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings.jsx
@@ -159,6 +159,7 @@ class ChartSettings extends Component {
       noPreview,
       children,
       setSidebarPropsOverride,
+      dashboard,
     } = this.props;
     const { currentWidget } = this.state;
 
@@ -322,6 +323,7 @@ class ChartSettings extends Component {
                   showTitle
                   isEditing
                   isDashboard
+                  dashboard={dashboard}
                   isSettings
                   showWarnings
                   onUpdateVisualizationSettings={this.handleChangeSettings}

--- a/frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx
+++ b/frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx
@@ -492,6 +492,7 @@ function transformSingleSeries(s, series, seriesIndex) {
         ]
           .filter(n => n)
           .join(": "),
+        originalCardName: card.name,
         _breakoutValue: breakoutValue,
         _breakoutColumn: cols[seriesColumnIndex],
       },
@@ -535,6 +536,7 @@ function transformSingleSeries(s, series, seriesIndex) {
         card: {
           ...card,
           name: name,
+          originalCardName: card.name,
           _seriesIndex: seriesIndex,
           // use underlying column name as the seriesKey since it should be unique
           // EXCEPT for dashboard multiseries, so check seriesIndex == 0

--- a/frontend/src/metabase/visualizations/lib/apply_tooltips.js
+++ b/frontend/src/metabase/visualizations/lib/apply_tooltips.js
@@ -53,8 +53,8 @@ export function getClickHoverObject(
   const isAddedSeriesOnDashcard = isDashboardAddedSeries(card, dashboard);
 
   function getColumnDisplayName(col, colIndex, card) {
-    // `visualization_settings.series_settings` use `card.name` and
-    // not `column.name` for renamed series when the `seriesIndex > 0`;
+    // when the series we are looking at is an added series on a dashcard,
+    // the `visualization_settings.series_settings` will be keyed by `card.name`
     // check for `columnIndex === 1` because only the first metric column
     // should be renamed by this setting
     const colKey =

--- a/frontend/src/metabase/visualizations/lib/apply_tooltips.js
+++ b/frontend/src/metabase/visualizations/lib/apply_tooltips.js
@@ -32,11 +32,17 @@ export function getClickHoverObject(
   const isBar = classList.includes("bar");
   const isSingleSeriesBar = isBar && !isMultiseries;
 
-  function getColumnDisplayName(col) {
-    const title = getIn(settings, ["series_settings", col.name, "title"]);
+  function getColumnDisplayName(col, colIndex, card) {
+    // `visualization_settings.series_settings` use `card.name` and
+    // not `column.name` for renamed series when the `seriesIndex > 0`;
+    // check for `columnIndex === 1` because only the first metric column
+    // should be renamed by this setting
+    const colKey = seriesIndex > 0 && colIndex === 1 ? card.name : col.name;
+    const colTitle = getIn(settings, ["series_settings", colKey, "title"]);
+
     // don't replace with series title for breakout multiseries since the series title is shown in the breakout value
-    if (!isBreakoutMultiseries && title) {
-      return title;
+    if (!isBreakoutMultiseries && colTitle) {
+      return colTitle;
     }
 
     return getFriendlyName(col);
@@ -114,7 +120,7 @@ export function getClickHoverObject(
           };
         }
         return {
-          key: getColumnDisplayName(col),
+          key: getColumnDisplayName(col, i, card),
           value: formatNull(aggregatedRow[i]),
           col: col,
         };

--- a/frontend/src/metabase/visualizations/lib/apply_tooltips.js
+++ b/frontend/src/metabase/visualizations/lib/apply_tooltips.js
@@ -3,12 +3,29 @@
 import d3 from "d3";
 import moment from "moment";
 import { getIn } from "icepick";
+import _ from "underscore";
 
 import { formatValue } from "metabase/lib/formatting";
 
 import { isNormalized, isStacked, formatNull } from "./renderer_utils";
 import { determineSeriesIndexFromElement } from "./tooltip";
 import { getFriendlyName } from "./utils";
+
+function isDashboardAddedSeries(card, dashboard) {
+  if (!dashboard) {
+    return false;
+  }
+
+  for (const dashCard of dashboard.ordered_cards) {
+    for (const addedCard of dashCard.series || []) {
+      if (addedCard.id === card.id) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
 
 export function getClickHoverObject(
   d,
@@ -22,6 +39,7 @@ export function getClickHoverObject(
     event,
     element,
     settings,
+    dashboard,
   },
 ) {
   let { cols } = series[seriesIndex].data;
@@ -32,6 +50,7 @@ export function getClickHoverObject(
   const isBar = classList.includes("bar");
   const isSingleSeriesBar = isBar && !isMultiseries;
   const isCardNamedDerivedFromColumn = cols.some(col => col.name === card.name);
+  const isAddedSeriesOnDashcard = isDashboardAddedSeries(card, dashboard);
 
   function getColumnDisplayName(col, colIndex, card) {
     // `visualization_settings.series_settings` use `card.name` and
@@ -39,7 +58,7 @@ export function getClickHoverObject(
     // check for `columnIndex === 1` because only the first metric column
     // should be renamed by this setting
     const colKey =
-      seriesIndex > 0 && colIndex === 1 && !isCardNamedDerivedFromColumn
+      isAddedSeriesOnDashcard && !isCardNamedDerivedFromColumn && colIndex === 1
         ? card.name
         : col.name;
     const colTitle = getIn(settings, ["series_settings", colKey, "title"]);
@@ -232,7 +251,14 @@ function aggregateRows(rows) {
 }
 
 export function setupTooltips(
-  { settings, series, isScalarSeries, onHoverChange, onVisualizationClick },
+  {
+    settings,
+    series,
+    isScalarSeries,
+    onHoverChange,
+    onVisualizationClick,
+    dashboard,
+  },
   datas,
   chart,
   { isBrushing },
@@ -267,6 +293,7 @@ export function setupTooltips(
       event: d3.event,
       element: target,
       settings,
+      dashboard,
     });
   };
 

--- a/frontend/src/metabase/visualizations/lib/apply_tooltips.js
+++ b/frontend/src/metabase/visualizations/lib/apply_tooltips.js
@@ -31,13 +31,17 @@ export function getClickHoverObject(
   const isBreakoutMultiseries = isMultiseries && card._breakoutColumn;
   const isBar = classList.includes("bar");
   const isSingleSeriesBar = isBar && !isMultiseries;
+  const isCardNamedDerivedFromColumn = cols.some(col => col.name === card.name);
 
   function getColumnDisplayName(col, colIndex, card) {
     // `visualization_settings.series_settings` use `card.name` and
     // not `column.name` for renamed series when the `seriesIndex > 0`;
     // check for `columnIndex === 1` because only the first metric column
     // should be renamed by this setting
-    const colKey = seriesIndex > 0 && colIndex === 1 ? card.name : col.name;
+    const colKey =
+      seriesIndex > 0 && colIndex === 1 && !isCardNamedDerivedFromColumn
+        ? card.name
+        : col.name;
     const colTitle = getIn(settings, ["series_settings", colKey, "title"]);
 
     // don't replace with series title for breakout multiseries since the series title is shown in the breakout value

--- a/frontend/test/metabase/scenarios/visualizations/line-bar-tooltips.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/line-bar-tooltips.cy.spec.js
@@ -1,0 +1,495 @@
+import { restore, popover, visitDashboard } from "__support__/e2e/cypress";
+
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+
+const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
+
+describe("scenarios > visualizations > line/bar chart > tooltips", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  describe("> single series question on dashboard", () => {
+    beforeEach(() => {
+      setup({
+        question: {
+          name: "Q1",
+          query: {
+            "source-table": ORDERS_ID,
+            aggregation: [["sum", ["field", ORDERS.TOTAL, null]]],
+            breakout: [
+              ["field", ORDERS.CREATED_AT, { "temporal-unit": "year" }],
+            ],
+          },
+          display: "line",
+        },
+      }).then(dashboardId => {
+        visitDashboard(dashboardId);
+      });
+    });
+
+    it("should show updated column titles in tooltips after editing them via Visualization Options", () => {
+      const originalTooltipText = [
+        ["Created At", "2016"],
+        ["Sum of Total", "42,156.87"],
+      ];
+
+      const updatedTooltipText = [
+        ["Created At", "2016"],
+        ["Custom", "42,156.87"],
+      ];
+
+      const seriesIndex = 0;
+
+      showTooltipForFirstCircleInSeries(seriesIndex);
+      testTooltipText(originalTooltipText);
+
+      openDashCardVisualizationOptions();
+
+      updateColumnTitle(originalTooltipText[1][0], updatedTooltipText[1][0]);
+
+      saveDashCardVisualizationOptions();
+
+      showTooltipForFirstCircleInSeries(seriesIndex);
+      testTooltipText(updatedTooltipText);
+    });
+  });
+
+  describe("> single series question on dashboard with added series", () => {
+    beforeEach(() => {
+      setup({
+        question: {
+          name: "Q1",
+          query: {
+            "source-table": ORDERS_ID,
+            aggregation: [["sum", ["field", ORDERS.TOTAL, null]]],
+            breakout: [
+              ["field", ORDERS.CREATED_AT, { "temporal-unit": "year" }],
+            ],
+          },
+          display: "line",
+        },
+        addedSeriesQuestion: {
+          name: "Q2",
+          query: {
+            "source-table": ORDERS_ID,
+            aggregation: [["avg", ["field", ORDERS.TOTAL, null]]],
+            breakout: [
+              ["field", ORDERS.CREATED_AT, { "temporal-unit": "year" }],
+            ],
+          },
+          display: "line",
+        },
+      }).then(dashboardId => {
+        visitDashboard(dashboardId);
+      });
+    });
+
+    it("should show updated column titles in tooltips after editing them via Visualization Options", () => {
+      const originalSeriesIndex = 0;
+      const addedSeriesIndex = 1;
+      const originalSeriesTooltipText = [
+        ["Created At", "2016"],
+        ["Sum of Total", "42,156.87"],
+      ];
+      const updatedOriginalSeriesTooltipText = [
+        ["Created At", "2016"],
+        ["Custom Q1", "42,156.87"],
+      ];
+
+      const addedSeriesTooltipText = [
+        ["Created At", "2016"],
+        ["Average of Total", "56.66"],
+      ];
+      const updatedAddedSeriesTooltipText = [
+        ["Created At", "2016"],
+        ["Custom Q2", "56.66"],
+      ];
+
+      showTooltipForFirstCircleInSeries(originalSeriesIndex);
+      testTooltipText(originalSeriesTooltipText);
+
+      showTooltipForFirstCircleInSeries(addedSeriesIndex);
+      testTooltipText(addedSeriesTooltipText);
+
+      openDashCardVisualizationOptions();
+
+      updateColumnTitle("Q1", updatedOriginalSeriesTooltipText[1][0]);
+      updateColumnTitle("Q2", updatedAddedSeriesTooltipText[1][0]);
+
+      saveDashCardVisualizationOptions();
+
+      showTooltipForFirstCircleInSeries(originalSeriesIndex);
+      testTooltipText(updatedOriginalSeriesTooltipText);
+
+      showTooltipForFirstCircleInSeries(addedSeriesIndex);
+      testTooltipText(updatedAddedSeriesTooltipText);
+    });
+  });
+
+  describe("> multi series question on dashboard", () => {
+    beforeEach(() => {
+      setup({
+        question: {
+          name: "Q1",
+          query: {
+            "source-table": ORDERS_ID,
+            aggregation: [
+              ["avg", ["field", ORDERS.TOTAL, null]],
+              ["cum-sum", ["field", ORDERS.QUANTITY, null]],
+            ],
+            breakout: [
+              ["field", ORDERS.CREATED_AT, { "temporal-unit": "year" }],
+            ],
+          },
+          display: "line",
+        },
+      }).then(dashboardId => {
+        visitDashboard(dashboardId);
+      });
+    });
+
+    it("should show updated column titles in tooltips after editing them via Visualization Options", () => {
+      const originalTooltipText = [
+        ["Created At", "2016"],
+        ["Average of Total", "56.66"],
+        ["Sum of Quantity", "3,236"],
+      ];
+
+      const updatedTooltipText = [
+        ["Created At", "2016"],
+        ["Custom 1", "56.66"],
+        ["Custom 2", "3,236"],
+      ];
+
+      const seriesIndex = 0;
+
+      showTooltipForFirstCircleInSeries(seriesIndex);
+      testTooltipText(originalTooltipText);
+
+      openDashCardVisualizationOptions();
+
+      updateColumnTitle(originalTooltipText[1][0], updatedTooltipText[1][0]);
+      updateColumnTitle(originalTooltipText[2][0], updatedTooltipText[2][0]);
+
+      saveDashCardVisualizationOptions();
+
+      showTooltipForFirstCircleInSeries(seriesIndex);
+      testTooltipText(updatedTooltipText);
+    });
+  });
+
+  describe("> multi series question on dashboard with added question", () => {
+    beforeEach(() => {
+      setup({
+        question: {
+          name: "Q1",
+          query: {
+            "source-table": ORDERS_ID,
+            aggregation: [
+              ["avg", ["field", ORDERS.TOTAL, null]],
+              ["cum-sum", ["field", ORDERS.QUANTITY, null]],
+            ],
+            breakout: [
+              ["field", ORDERS.CREATED_AT, { "temporal-unit": "year" }],
+            ],
+          },
+          display: "line",
+        },
+        addedSeriesQuestion: {
+          name: "Q2",
+          query: {
+            "source-table": ORDERS_ID,
+            aggregation: [
+              ["avg", ["field", ORDERS.DISCOUNT, null]],
+              ["sum", ["field", ORDERS.DISCOUNT, null]],
+            ],
+            breakout: [
+              ["field", ORDERS.CREATED_AT, { "temporal-unit": "year" }],
+            ],
+          },
+          display: "line",
+        },
+      }).then(dashboardId => {
+        visitDashboard(dashboardId);
+      });
+    });
+
+    it("should show updated column titles in tooltips after editing them via Visualization Options", () => {
+      const originalIndices = [0, 1];
+      const addedIndices = [2, 3];
+      const originalSeriesTooltipText = [
+        ["Created At", "2016"],
+        ["Average of Total", "56.66"],
+        ["Sum of Quantity", "3,236"],
+      ];
+      const updatedOriginalSeriesTooltipText = [
+        ["Created At", "2016"],
+        ["Q1 Custom 1", "56.66"],
+        ["Q1 Custom 2", "3,236"],
+      ];
+
+      const addedSeriesTooltipText = [
+        ["Created At", "2016"],
+        ["Average of Discount", "5.03"],
+        ["Sum of Discount", "342.09"],
+      ];
+      const updatedAddedSeriesTooltipText = [
+        ["Created At", "2016"],
+        ["Q2 Custom 1", "5.03"],
+        ["Q2 Custom 2", "342.09"],
+      ];
+
+      originalIndices.forEach(index => {
+        showTooltipForFirstCircleInSeries(index);
+        testTooltipText(originalSeriesTooltipText);
+      });
+      addedIndices.forEach(index => {
+        showTooltipForFirstCircleInSeries(index);
+        testTooltipText(addedSeriesTooltipText);
+      });
+
+      openDashCardVisualizationOptions();
+
+      updateColumnTitle(
+        `Q1: ${originalSeriesTooltipText[1][0]}`,
+        updatedOriginalSeriesTooltipText[1][0],
+      );
+      updateColumnTitle(
+        `Q1: ${originalSeriesTooltipText[2][0]}`,
+        updatedOriginalSeriesTooltipText[2][0],
+      );
+
+      updateColumnTitle(
+        `Q2: ${addedSeriesTooltipText[1][0]}`,
+        updatedAddedSeriesTooltipText[1][0],
+      );
+      updateColumnTitle(
+        `Q2: ${addedSeriesTooltipText[2][0]}`,
+        updatedAddedSeriesTooltipText[2][0],
+      );
+
+      saveDashCardVisualizationOptions();
+
+      originalIndices.forEach(index => {
+        showTooltipForFirstCircleInSeries(index);
+        testTooltipText(updatedOriginalSeriesTooltipText);
+      });
+      addedIndices.forEach(index => {
+        showTooltipForFirstCircleInSeries(index);
+        testTooltipText(updatedAddedSeriesTooltipText);
+      });
+    });
+  });
+
+  describe("> bar chart question on dashboard", () => {
+    beforeEach(() => {
+      setup({
+        question: {
+          name: "Q1",
+          query: {
+            "source-table": ORDERS_ID,
+            aggregation: [["sum", ["field", ORDERS.TOTAL, null]]],
+            breakout: [
+              ["field", ORDERS.CREATED_AT, { "temporal-unit": "year" }],
+            ],
+          },
+          display: "bar",
+        },
+      }).then(dashboardId => {
+        visitDashboard(dashboardId);
+      });
+    });
+
+    it("should show updated column titles in tooltips after editing them via Visualization Options", () => {
+      const originalTooltipText = [
+        ["Created At", "2016"],
+        ["Sum of Total", "42,156.87"],
+      ];
+
+      const updatedTooltipText = [
+        ["Created At", "2016"],
+        ["Custom", "42,156.87"],
+      ];
+
+      const seriesIndex = 0;
+
+      showTooltipForFirstBarInSeries(seriesIndex);
+      testTooltipText(originalTooltipText);
+
+      openDashCardVisualizationOptions();
+
+      updateColumnTitle(originalTooltipText[1][0], updatedTooltipText[1][0]);
+
+      saveDashCardVisualizationOptions();
+
+      showTooltipForFirstBarInSeries(seriesIndex);
+      testTooltipText(updatedTooltipText);
+    });
+  });
+
+  describe("> bar chart question on dashboard with added series", () => {
+    beforeEach(() => {
+      setup({
+        question: {
+          name: "Q1",
+          query: {
+            "source-table": ORDERS_ID,
+            aggregation: [["sum", ["field", ORDERS.TOTAL, null]]],
+            breakout: [
+              ["field", ORDERS.CREATED_AT, { "temporal-unit": "year" }],
+            ],
+          },
+          display: "bar",
+        },
+        addedSeriesQuestion: {
+          name: "Q2",
+          query: {
+            "source-table": ORDERS_ID,
+            aggregation: [["avg", ["field", ORDERS.TOTAL, null]]],
+            breakout: [
+              ["field", ORDERS.CREATED_AT, { "temporal-unit": "year" }],
+            ],
+          },
+          display: "bar",
+        },
+      }).then(dashboardId => {
+        visitDashboard(dashboardId);
+      });
+    });
+
+    it("should show updated column titles in tooltips after editing them via Visualization Options", () => {
+      const originalSeriesIndex = 0;
+      const addedSeriesIndex = 1;
+      const originalSeriesTooltipText = [
+        ["Created At", "2016"],
+        ["Sum of Total", "42,156.87"],
+      ];
+      const updatedOriginalSeriesTooltipText = [
+        ["Created At", "2016"],
+        ["Custom Q1", "42,156.87"],
+      ];
+
+      const addedSeriesTooltipText = [
+        ["Created At", "2016"],
+        ["Average of Total", "56.66"],
+      ];
+      const updatedAddedSeriesTooltipText = [
+        ["Created At", "2016"],
+        ["Custom Q2", "56.66"],
+      ];
+
+      showTooltipForFirstBarInSeries(originalSeriesIndex);
+      testTooltipText(originalSeriesTooltipText);
+
+      showTooltipForFirstBarInSeries(addedSeriesIndex);
+      testTooltipText(addedSeriesTooltipText);
+
+      openDashCardVisualizationOptions();
+
+      updateColumnTitle("Q1", updatedOriginalSeriesTooltipText[1][0]);
+      updateColumnTitle("Q2", updatedAddedSeriesTooltipText[1][0]);
+
+      saveDashCardVisualizationOptions();
+
+      showTooltipForFirstBarInSeries(originalSeriesIndex);
+      testTooltipText(updatedOriginalSeriesTooltipText);
+
+      showTooltipForFirstBarInSeries(addedSeriesIndex);
+      testTooltipText(updatedAddedSeriesTooltipText);
+    });
+  });
+});
+
+function setup({ question, addedSeriesQuestion }) {
+  return cy.createQuestion(question).then(({ body: { id: card1Id } }) => {
+    if (addedSeriesQuestion) {
+      cy.createQuestion(addedSeriesQuestion).then(
+        ({ body: { id: card2Id } }) => {
+          return setupDashboard(card1Id, card2Id);
+        },
+      );
+    } else {
+      return setupDashboard(card1Id);
+    }
+  });
+}
+
+function setupDashboard(cardId, addedSeriesCardId) {
+  return cy.createDashboard().then(({ body: { id: dashboardId } }) => {
+    return cy
+      .request("POST", `/api/dashboard/${dashboardId}/cards`, {
+        cardId,
+      })
+      .then(({ body: { id: dashCardId } }) => {
+        return cy.request("PUT", `/api/dashboard/${dashboardId}/cards`, {
+          cards: [
+            {
+              id: dashCardId,
+              card_id: cardId,
+              row: 0,
+              col: 0,
+              sizeX: 18,
+              sizeY: 12,
+              parameter_mappings: [],
+              series: addedSeriesCardId ? [{ id: addedSeriesCardId }] : [],
+            },
+          ],
+        });
+      })
+      .then(() => {
+        return dashboardId;
+      });
+  });
+}
+
+function showTooltipForFirstCircleInSeries(series_index) {
+  cy.get(`.sub._${series_index}`)
+    .as("firstSeries")
+    .find("circle")
+    .first()
+    .trigger("mousemove", { force: true });
+}
+
+function showTooltipForFirstBarInSeries(series_index) {
+  cy.get(`.sub._${series_index}`)
+    .as("firstSeries")
+    .find(".bar")
+    .first()
+    .trigger("mousemove", { force: true });
+}
+
+function testPairedTooltipValues(val1, val2) {
+  cy.contains(val1)
+    .closest("td")
+    .siblings("td")
+    .findByText(val2);
+}
+
+function testTooltipText(rowPairs = []) {
+  popover().within(() => {
+    rowPairs.forEach(([label, value]) => {
+      testPairedTooltipValues(label, value);
+    });
+  });
+}
+
+function openDashCardVisualizationOptions() {
+  cy.icon("pencil").click();
+  cy.get(".Card").realHover();
+  cy.icon("palette").click();
+}
+
+function updateColumnTitle(originalText, updatedText) {
+  cy.findByDisplayValue(originalText)
+    .clear()
+    .type(updatedText);
+}
+
+function saveDashCardVisualizationOptions() {
+  cy.get(".Modal").within(() => {
+    cy.findByText("Done").click();
+  });
+  cy.findByText("Save").click();
+}

--- a/frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js
@@ -201,7 +201,7 @@ describe("scenarios > visualizations > line chart", () => {
       .should("have.length", 2);
   });
 
-  describe.skip("tooltip of combined dashboard cards (multi-series) should show the correct column title (metabase#16249", () => {
+  describe("tooltip of combined dashboard cards (multi-series) should show the correct column title (metabase#16249", () => {
     const RENAMED_FIRST_SERIES = "Foo";
     const RENAMED_SECOND_SERIES = "Bar";
 
@@ -441,5 +441,5 @@ function showTooltipForFirstCircleInSeries(series_index) {
     .as("firstSeries")
     .find("circle")
     .first()
-    .realHover();
+    .trigger("mousemove", { force: true });
 }


### PR DESCRIPTION
Fixes #16249 

I took @ranquild's original fix for this particular bug from https://github.com/metabase/metabase/pull/17946 but as you can see from the comments below there are a lot of very specific scenarios that needed handling. Gross stuff. To summarize:

1. #16249 seems to be specific to dashcards where we've added additional series. These additional series have odd viz settings keys to try to ensure they are unique.
2. When a single series is added to a dashcard, its viz settings key is USUALLY the card name.
3. When a multi series is added to a dashcard, its viz settings key is the card name combined with the column display name
4. Sometimes, the card name is not the card name but a column name -- see https://github.com/metabase/metabase/blob/a5d951b0a77ca85856fe1d651b6e98c480225746/frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx#L524 for where the card name is altered. I've added a prop to this "card" so that we can preserve the original card name in the object

The old regression #18210 was hitting the scenario where the card name is a column name. In this scenario we should be relying on the column name as the viz settings key. Confused yet?

In addition to the above changes to `apply_tooltip`, I needed to lace the `dashboard` object through to the `ChartSettings` component so that we have access to it when applying tooltips to Visualizations within the modal.

**Testing**
Follow the repro steps in #16249 to reproduce the original issue
Follow the repro steps in #18210 to make sure we are not re-regressing
If you can think of other ways to test this, go for it.
