### PR TITLE
Resolve node-forge to v1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -252,7 +252,8 @@
     "ansi-html": "https://registry.npmjs.org/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
     "prismjs": "1.27.0",
     "nanoid": "3.1.31",
-    "minimist": "1.2.6"
+    "minimist": "1.2.6",
+    "node-forge": "1.3.0"
   },
   "scripts": {
     "concurrently": "yarn && concurrently --kill-others -p name",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15509,10 +15509,10 @@ node-fetch@^2.6.1:
   dependencies:
     whatwg-url "^5.0.0"
 
-node-forge@^1.2.0:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.2.1.tgz#82794919071ef2eb5c509293325cec8afd0fd53c"
-  integrity sha512-Fcvtbb+zBcZXbTTVwqGA5W+MKBj56UjVRevvchv5XrcyXbmNdesfZL37nlcWOfpgHhgmxApw3tQbTr4CqNmX4w==
+node-forge@1.3.0, node-forge@^1.2.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.0.tgz#37a874ea723855f37db091e6c186e5b67a01d4b2"
+  integrity sha512-08ARB91bUi6zNKzVmaj3QO7cr397uiDT2nJ63cHjyNtCTWIgvS47j3eT0WfzUwS9+6Z5YshRaoasFkXCKrIYbA==
 
 node-int64@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
This is to address https://github.com/advisories/GHSA-2r2c-g63r-vccr.

```
$ yarn why node-forge
yarn why v1.22.17
[1/4] Why do we have the module "node-forge"...?
[2/4] Initialising dependency graph...
[3/4] Finding dependency...
[4/4] Calculating file sizes...
=> Found "node-forge@1.3.0"
info Reasons this module exists
   - "webpack-dev-server#selfsigned" depends on it
   - Hoisted from "webpack-dev-server#selfsigned#node-forge"
info Disk size without dependencies: "1.74MB"
info Disk size with unique dependencies: "1.74MB"
info Disk size with transitive dependencies: "1.74MB"
info Number of shared dependencies: 0
Done in 0.81s.
```
