### PR TITLE
Make "Invite someone" button not overlapping with other elements

### DIFF
--- a/frontend/src/metabase/components/AdminPaneLayout.jsx
+++ b/frontend/src/metabase/components/AdminPaneLayout.jsx
@@ -4,6 +4,8 @@ import React from "react";
 import Button from "metabase/core/components/Button";
 import Link from "metabase/core/components/Link";
 
+import { Container, HeadingContainer } from "./AdminPaneLayout.styled";
+
 const AdminPaneTitle = ({
   title,
   description,
@@ -12,28 +14,33 @@ const AdminPaneTitle = ({
   buttonDisabled,
   buttonLink,
   headingContent,
-}) => (
-  <section className="clearfix px2">
-    {buttonText && buttonLink && (
-      <Link to={buttonLink} className="inline-block float-right">
-        <Button primary>{buttonText}</Button>
-      </Link>
-    )}
-    {buttonText && buttonAction && (
-      <Button
-        className="float-right"
-        primary={!buttonDisabled}
-        disabled={buttonDisabled}
-        onClick={buttonAction}
-      >
-        {buttonText}
-      </Button>
-    )}
-    {headingContent && <React.Fragment>{headingContent}</React.Fragment>}
-    {title && <h2 className="PageTitle">{title}</h2>}
-    {description && <p className="text-measure">{description}</p>}
-  </section>
-);
+}) => {
+  const buttonClassName = "ml-auto flex-no-shrink";
+  return (
+    <Container>
+      <HeadingContainer>
+        {headingContent && <React.Fragment>{headingContent}</React.Fragment>}
+        {title && <h2 className="PageTitle">{title}</h2>}
+        {buttonText && buttonLink && (
+          <Link to={buttonLink} className={buttonClassName}>
+            <Button primary>{buttonText}</Button>
+          </Link>
+        )}
+        {buttonText && buttonAction && (
+          <Button
+            className={buttonClassName}
+            primary={!buttonDisabled}
+            disabled={buttonDisabled}
+            onClick={buttonAction}
+          >
+            {buttonText}
+          </Button>
+        )}
+      </HeadingContainer>
+      {description && <p className="text-measure">{description}</p>}
+    </Container>
+  );
+};
 
 const AdminPaneLayout = ({
   title,

--- a/frontend/src/metabase/components/AdminPaneLayout.styled.jsx
+++ b/frontend/src/metabase/components/AdminPaneLayout.styled.jsx
@@ -1,0 +1,13 @@
+import styled from "@emotion/styled";
+
+export const Container = styled.section`
+  padding-left: 1rem;
+  padding-right: 1rem;
+`;
+
+export const HeadingContainer = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0 1rem;
+`;

--- a/frontend/test/metabase/scenarios/admin/people/people.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/people/people.cy.spec.js
@@ -100,7 +100,7 @@ describe("scenarios > admin > people", () => {
       cy.contains("Email address already in use.");
     });
 
-    it.skip("'Invite someone' button shouldn't be covered/blocked on smaller screen sizes (metabase#16350)", () => {
+    it("'Invite someone' button shouldn't be covered/blocked on smaller screen sizes (metabase#16350)", () => {
       cy.viewport(1000, 600);
 
       cy.visit("/admin/people");


### PR DESCRIPTION
Fixes #16350

There is some notable space between the button and content below it due to how I make the button a flex item, since flex and floating siblings don't play nice.

## People settings
### Before
![localhost_3000_admin_people (2)](https://user-images.githubusercontent.com/1937582/160372261-31895eee-9c90-40c4-94b0-9085eba6d119.png)

### After
![localhost_3000_admin_people (3)](https://user-images.githubusercontent.com/1937582/160372290-7af24b3e-10cf-4762-be7a-432172dfd382.png)

## Group settings
### Before
![localhost_3000_admin_people](https://user-images.githubusercontent.com/1937582/160372132-7d05ae0d-96ae-4d59-ad46-7c1390c96eaf.png)

### After
![localhost_3000_admin_people (1)](https://user-images.githubusercontent.com/1937582/160372208-1f630676-ef10-4315-8710-6fe562566208.png)
