### PR TITLE
Don't log stack trace when opportunistically trying out SSL

### DIFF
--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -49,7 +49,6 @@
       ;; actually if we are going to `throw-exceptions` we'll rethrow the original but attempt to humanize the message
       ;; first
       (catch Throwable e
-        (log/error e (trs "Database connection error"))
         (throw (Exception. (str (driver/humanize-connection-error-message driver (.getMessage e))) e))))
     (try
       (can-connect-with-details? driver details-map :throw-exceptions)


### PR DESCRIPTION
When adding a new database, even if SSL option is not enabled, Metabase will try SSL first and fallback to no SSL only when connecting through SSL does not work. That is fine, however, a long stack trace containing SSL errors when SSL is not enabled can be confusing to the admin.

This PR keeps the same behavior but omits the log when trying SSL so the admin is not confused by the log message. Note that the error was actually being logged twice, once in `driver/util.clj` and another time in `api/database.clj`. I've removed the first logged and made the second log conditional.

Alternative for consideration: Don't automatically try SSL at all - #18545

Closes #21278