### PR TITLE
Browsing | Refactor `Tree` component

### DIFF
--- a/frontend/src/metabase/admin/permissions/components/FilterableTree/FilterableTree.styled.tsx
+++ b/frontend/src/metabase/admin/permissions/components/FilterableTree/FilterableTree.styled.tsx
@@ -1,5 +1,6 @@
 import styled from "@emotion/styled";
-import { color } from "metabase/lib/colors";
+import { Tree } from "metabase/components/tree";
+import { color, lighten } from "metabase/lib/colors";
 
 export const FilterableTreeRoot = styled.div`
   display: flex;
@@ -23,4 +24,15 @@ export const ItemGroupsDivider = styled.hr`
 
 export const EmptyStateContainer = styled.div`
   margin-top: 6.25rem;
+`;
+
+export const AdminTreeNode = styled(Tree.Node)`
+  color: ${props => (props.isSelected ? color("white") : color("text-medium"))};
+
+  background-color: ${props => (props.isSelected ? color("accent7") : "unset")};
+
+  &:hover {
+    background-color: ${props =>
+      props.isSelected ? color("accent7") : lighten(color("accent7"), 0.6)};
+  }
 `;

--- a/frontend/src/metabase/admin/permissions/components/FilterableTree/FilterableTree.tsx
+++ b/frontend/src/metabase/admin/permissions/components/FilterableTree/FilterableTree.tsx
@@ -12,6 +12,7 @@ import {
   FilterableTreeRoot,
   FilterInputContainer,
   ItemGroupsDivider,
+  AdminTreeNode,
 } from "./FilterableTree.styled";
 import { searchItems } from "./utils";
 import { ITreeNodeItem } from "metabase/components/tree/types";
@@ -63,10 +64,10 @@ export const FilterableTree = ({
       <FilterableTreeContainer>
         {filteredList && (
           <Tree
-            colorScheme="admin"
             data={filteredList}
             selectedId={selectedId}
             onSelect={onSelect}
+            TreeNode={AdminTreeNode}
             emptyState={
               <EmptyStateContainer>
                 {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */}
@@ -85,10 +86,10 @@ export const FilterableTree = ({
             return (
               <React.Fragment key={index}>
                 <Tree
-                  colorScheme="admin"
                   data={items}
                   selectedId={selectedId}
                   onSelect={onSelect}
+                  TreeNode={AdminTreeNode}
                 />
                 {!isLastGroup && <ItemGroupsDivider />}
               </React.Fragment>

--- a/frontend/src/metabase/components/tree/Tree.tsx
+++ b/frontend/src/metabase/components/tree/Tree.tsx
@@ -5,7 +5,6 @@ import { ColorScheme, ITreeNodeItem } from "./types";
 
 interface TreeProps {
   data: ITreeNodeItem[];
-  onSelect: (item: ITreeNodeItem) => void;
   selectedId?: ITreeNodeItem["id"];
   colorScheme?: ColorScheme;
   emptyState?: React.ReactNode;
@@ -13,7 +12,6 @@ interface TreeProps {
 
 export function Tree({
   data,
-  onSelect,
   selectedId,
   colorScheme = "default",
   emptyState = null,
@@ -41,7 +39,6 @@ export function Tree({
     <TreeNodeList
       colorScheme={colorScheme}
       items={data}
-      onSelect={onSelect}
       onToggleExpand={handleToggleExpand}
       expandedIds={expandedIds}
       selectedId={selectedId}

--- a/frontend/src/metabase/components/tree/Tree.tsx
+++ b/frontend/src/metabase/components/tree/Tree.tsx
@@ -1,21 +1,15 @@
 import React, { useState, useCallback } from "react";
 import { TreeNodeList } from "./TreeNodeList";
 import { getInitialExpandedIds } from "./utils";
-import { ColorScheme, ITreeNodeItem } from "./types";
+import { ITreeNodeItem } from "./types";
 
 interface TreeProps {
   data: ITreeNodeItem[];
   selectedId?: ITreeNodeItem["id"];
-  colorScheme?: ColorScheme;
   emptyState?: React.ReactNode;
 }
 
-export function Tree({
-  data,
-  selectedId,
-  colorScheme = "default",
-  emptyState = null,
-}: TreeProps) {
+export function Tree({ data, selectedId, emptyState = null }: TreeProps) {
   const [expandedIds, setExpandedIds] = useState(
     new Set(selectedId != null ? getInitialExpandedIds(selectedId, data) : []),
   );
@@ -37,7 +31,6 @@ export function Tree({
 
   return (
     <TreeNodeList
-      colorScheme={colorScheme}
       items={data}
       onToggleExpand={handleToggleExpand}
       expandedIds={expandedIds}

--- a/frontend/src/metabase/components/tree/Tree.tsx
+++ b/frontend/src/metabase/components/tree/Tree.tsx
@@ -8,6 +8,7 @@ interface TreeProps {
   data: ITreeNodeItem[];
   selectedId?: ITreeNodeItem["id"];
   emptyState?: React.ReactNode;
+  onSelect?: (item: ITreeNodeItem) => void;
   TreeNode?: TreeNodeComponent;
 }
 
@@ -15,6 +16,7 @@ export function Tree({
   data,
   selectedId,
   emptyState = null,
+  onSelect,
   TreeNode = DefaultTreeNode,
 }: TreeProps) {
   const [expandedIds, setExpandedIds] = useState(
@@ -40,10 +42,11 @@ export function Tree({
     <TreeNodeList
       items={data}
       TreeNode={TreeNode}
-      onToggleExpand={handleToggleExpand}
       expandedIds={expandedIds}
       selectedId={selectedId}
       depth={0}
+      onSelect={onSelect}
+      onToggleExpand={handleToggleExpand}
     />
   );
 }

--- a/frontend/src/metabase/components/tree/Tree.tsx
+++ b/frontend/src/metabase/components/tree/Tree.tsx
@@ -12,7 +12,7 @@ interface TreeProps {
   TreeNode?: TreeNodeComponent;
 }
 
-export function Tree({
+function BaseTree({
   data,
   selectedId,
   emptyState = null,
@@ -50,3 +50,7 @@ export function Tree({
     />
   );
 }
+
+export const Tree = Object.assign(BaseTree, {
+  Node: DefaultTreeNode,
+});

--- a/frontend/src/metabase/components/tree/Tree.tsx
+++ b/frontend/src/metabase/components/tree/Tree.tsx
@@ -1,15 +1,22 @@
 import React, { useState, useCallback } from "react";
 import { TreeNodeList } from "./TreeNodeList";
+import { TreeNode as DefaultTreeNode } from "./TreeNode";
 import { getInitialExpandedIds } from "./utils";
-import { ITreeNodeItem } from "./types";
+import { ITreeNodeItem, TreeNodeComponent } from "./types";
 
 interface TreeProps {
   data: ITreeNodeItem[];
   selectedId?: ITreeNodeItem["id"];
   emptyState?: React.ReactNode;
+  TreeNode?: TreeNodeComponent;
 }
 
-export function Tree({ data, selectedId, emptyState = null }: TreeProps) {
+export function Tree({
+  data,
+  selectedId,
+  emptyState = null,
+  TreeNode = DefaultTreeNode,
+}: TreeProps) {
   const [expandedIds, setExpandedIds] = useState(
     new Set(selectedId != null ? getInitialExpandedIds(selectedId, data) : []),
   );
@@ -32,6 +39,7 @@ export function Tree({ data, selectedId, emptyState = null }: TreeProps) {
   return (
     <TreeNodeList
       items={data}
+      TreeNode={TreeNode}
       onToggleExpand={handleToggleExpand}
       expandedIds={expandedIds}
       selectedId={selectedId}

--- a/frontend/src/metabase/components/tree/TreeNode.styled.tsx
+++ b/frontend/src/metabase/components/tree/TreeNode.styled.tsx
@@ -2,34 +2,17 @@ import styled from "@emotion/styled";
 import { css } from "@emotion/react";
 import colors, { lighten } from "metabase/lib/colors";
 import Icon, { IconProps } from "metabase/components/Icon";
-import { ColorScheme } from "./types";
-
-const COLOR_SCHEMES = {
-  admin: {
-    text: () => colors["text-medium"],
-    background: () => colors["accent7"],
-  },
-  default: {
-    text: () => colors["brand"],
-    background: () => colors["brand"],
-  },
-};
 
 interface TreeNodeRootProps {
   isSelected: boolean;
   depth: number;
-  colorScheme: ColorScheme;
 }
 
 export const TreeNodeRoot = styled.li<TreeNodeRootProps>`
   display: flex;
   align-items: center;
-  color: ${props =>
-    props.isSelected
-      ? colors["white"]
-      : COLOR_SCHEMES[props.colorScheme].text()};
-  background-color: ${props =>
-    props.isSelected ? COLOR_SCHEMES[props.colorScheme].background() : "unset"};
+  color: ${props => (props.isSelected ? colors["white"] : colors["brand"])};
+  background-color: ${props => (props.isSelected ? colors["brand"] : "unset")};
   padding-left: ${props => props.depth + 0.5}rem;
   padding-right: 0.5rem;
   cursor: pointer;
@@ -37,9 +20,7 @@ export const TreeNodeRoot = styled.li<TreeNodeRootProps>`
 
   &:hover {
     background-color: ${props =>
-      props.isSelected
-        ? COLOR_SCHEMES[props.colorScheme].background()
-        : lighten(COLOR_SCHEMES[props.colorScheme].background(), 0.6)};
+      props.isSelected ? colors["brand"] : lighten(colors["brand"], 0.6)};
   }
 `;
 

--- a/frontend/src/metabase/components/tree/TreeNode.tsx
+++ b/frontend/src/metabase/components/tree/TreeNode.tsx
@@ -14,9 +14,17 @@ import {
 import { TreeNodeProps } from "./types";
 
 // eslint-disable-next-line react/display-name
-export const TreeNode = React.memo(
+const BaseTreeNode = React.memo(
   React.forwardRef<HTMLLIElement, TreeNodeProps>(function TreeNode(
-    { isExpanded, isSelected, hasChildren, onToggleExpand, depth, item },
+    {
+      item,
+      depth,
+      isExpanded,
+      isSelected,
+      hasChildren,
+      onToggleExpand,
+      ...props
+    },
     ref,
   ) {
     const { name, icon } = item;
@@ -36,13 +44,14 @@ export const TreeNode = React.memo(
 
     return (
       <TreeNodeRoot
-        ref={ref}
         role="menuitem"
         tabIndex={0}
-        depth={depth}
         onClick={onToggleExpand}
+        {...props}
+        depth={depth}
         isSelected={isSelected}
         onKeyDown={handleKeyDown}
+        ref={ref}
       >
         <ExpandToggleButton hidden={!hasChildren}>
           <ExpandToggleIcon
@@ -62,3 +71,11 @@ export const TreeNode = React.memo(
     );
   }),
 );
+
+export const TreeNode = Object.assign(BaseTreeNode, {
+  Root: TreeNodeRoot,
+  ExpandToggleButton,
+  ExpandToggleIcon,
+  NameContainer,
+  IconContainer,
+});

--- a/frontend/src/metabase/components/tree/TreeNode.tsx
+++ b/frontend/src/metabase/components/tree/TreeNode.tsx
@@ -19,7 +19,7 @@ export interface TreeNodeProps {
   hasChildren: boolean;
   isExpanded: boolean;
   isSelected: boolean;
-  onToggleExpand: (id: ITreeNodeItem["id"]) => void;
+  onToggleExpand: () => void;
 }
 
 // eslint-disable-next-line react/display-name
@@ -28,21 +28,17 @@ export const TreeNode = React.memo(
     { isExpanded, isSelected, hasChildren, onToggleExpand, depth, item },
     ref,
   ) {
-    const { name, icon, id } = item;
+    const { name, icon } = item;
 
     const iconProps = _.isObject(icon) ? icon : { name: icon };
-
-    const handleSelect = () => {
-      onToggleExpand(id);
-    };
 
     const handleKeyDown: React.KeyboardEventHandler = ({ key }) => {
       switch (key) {
         case "ArrowRight":
-          !isExpanded && onToggleExpand(id);
+          !isExpanded && onToggleExpand();
           break;
         case "ArrowLeft":
-          isExpanded && onToggleExpand(id);
+          isExpanded && onToggleExpand();
           break;
       }
     };
@@ -53,7 +49,7 @@ export const TreeNode = React.memo(
         role="menuitem"
         tabIndex={0}
         depth={depth}
-        onClick={handleSelect}
+        onClick={onToggleExpand}
         isSelected={isSelected}
         onKeyDown={handleKeyDown}
       >

--- a/frontend/src/metabase/components/tree/TreeNode.tsx
+++ b/frontend/src/metabase/components/tree/TreeNode.tsx
@@ -20,7 +20,6 @@ export interface TreeNodeProps {
   isExpanded: boolean;
   isSelected: boolean;
   colorScheme: "default" | "admin";
-  onSelect: (item: ITreeNodeItem) => void;
   onToggleExpand: (id: ITreeNodeItem["id"]) => void;
 }
 
@@ -32,7 +31,6 @@ export const TreeNode = React.memo(
       isSelected,
       hasChildren,
       onToggleExpand,
-      onSelect,
       depth,
       item,
       colorScheme,
@@ -44,15 +42,11 @@ export const TreeNode = React.memo(
     const iconProps = _.isObject(icon) ? icon : { name: icon };
 
     const handleSelect = () => {
-      onSelect(item);
       onToggleExpand(id);
     };
 
     const handleKeyDown: React.KeyboardEventHandler = ({ key }) => {
       switch (key) {
-        case "Enter":
-          onSelect(item);
-          break;
         case "ArrowRight":
           !isExpanded && onToggleExpand(id);
           break;

--- a/frontend/src/metabase/components/tree/TreeNode.tsx
+++ b/frontend/src/metabase/components/tree/TreeNode.tsx
@@ -22,6 +22,7 @@ const BaseTreeNode = React.memo(
       isExpanded,
       isSelected,
       hasChildren,
+      onSelect,
       onToggleExpand,
       ...props
     },
@@ -31,8 +32,20 @@ const BaseTreeNode = React.memo(
 
     const iconProps = _.isObject(icon) ? icon : { name: icon };
 
+    function onClick() {
+      if (typeof onSelect === "function") {
+        onSelect();
+      }
+      onToggleExpand();
+    }
+
     const handleKeyDown: React.KeyboardEventHandler = ({ key }) => {
       switch (key) {
+        case "Enter":
+          if (typeof onSelect === "function") {
+            onSelect();
+          }
+          break;
         case "ArrowRight":
           !isExpanded && onToggleExpand();
           break;
@@ -46,7 +59,7 @@ const BaseTreeNode = React.memo(
       <TreeNodeRoot
         role="menuitem"
         tabIndex={0}
-        onClick={onToggleExpand}
+        onClick={onClick}
         {...props}
         depth={depth}
         isSelected={isSelected}

--- a/frontend/src/metabase/components/tree/TreeNode.tsx
+++ b/frontend/src/metabase/components/tree/TreeNode.tsx
@@ -33,18 +33,14 @@ const BaseTreeNode = React.memo(
     const iconProps = _.isObject(icon) ? icon : { name: icon };
 
     function onClick() {
-      if (typeof onSelect === "function") {
-        onSelect();
-      }
+      onSelect?.();
       onToggleExpand();
     }
 
     const handleKeyDown: React.KeyboardEventHandler = ({ key }) => {
       switch (key) {
         case "Enter":
-          if (typeof onSelect === "function") {
-            onSelect();
-          }
+          onSelect?.();
           break;
         case "ArrowRight":
           !isExpanded && onToggleExpand();

--- a/frontend/src/metabase/components/tree/TreeNode.tsx
+++ b/frontend/src/metabase/components/tree/TreeNode.tsx
@@ -19,22 +19,13 @@ export interface TreeNodeProps {
   hasChildren: boolean;
   isExpanded: boolean;
   isSelected: boolean;
-  colorScheme: "default" | "admin";
   onToggleExpand: (id: ITreeNodeItem["id"]) => void;
 }
 
 // eslint-disable-next-line react/display-name
 export const TreeNode = React.memo(
   React.forwardRef<HTMLLIElement, TreeNodeProps>(function TreeNode(
-    {
-      isExpanded,
-      isSelected,
-      hasChildren,
-      onToggleExpand,
-      depth,
-      item,
-      colorScheme,
-    },
+    { isExpanded, isSelected, hasChildren, onToggleExpand, depth, item },
     ref,
   ) {
     const { name, icon, id } = item;
@@ -61,7 +52,6 @@ export const TreeNode = React.memo(
         ref={ref}
         role="menuitem"
         tabIndex={0}
-        colorScheme={colorScheme}
         depth={depth}
         onClick={handleSelect}
         isSelected={isSelected}

--- a/frontend/src/metabase/components/tree/TreeNode.tsx
+++ b/frontend/src/metabase/components/tree/TreeNode.tsx
@@ -11,16 +11,7 @@ import {
   NameContainer,
   IconContainer,
 } from "./TreeNode.styled";
-import { ITreeNodeItem } from "./types";
-
-export interface TreeNodeProps {
-  item: ITreeNodeItem;
-  depth: number;
-  hasChildren: boolean;
-  isExpanded: boolean;
-  isSelected: boolean;
-  onToggleExpand: () => void;
-}
+import { TreeNodeProps } from "./types";
 
 // eslint-disable-next-line react/display-name
 export const TreeNode = React.memo(

--- a/frontend/src/metabase/components/tree/TreeNodeList.tsx
+++ b/frontend/src/metabase/components/tree/TreeNodeList.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { useScrollOnMount } from "metabase/hooks/use-scroll-on-mount";
-import { ITreeNodeItem } from "./types";
-import { TreeNode } from "./TreeNode";
+import { ITreeNodeItem, TreeNodeComponent } from "./types";
 
 interface TreeNodeListProps {
   items: ITreeNodeItem[];
@@ -9,6 +8,7 @@ interface TreeNodeListProps {
   selectedId?: ITreeNodeItem["id"];
   depth: number;
   onToggleExpand: (id: ITreeNodeItem["id"]) => void;
+  TreeNode: TreeNodeComponent;
 }
 
 export function TreeNodeList({
@@ -17,6 +17,7 @@ export function TreeNodeList({
   expandedIds,
   selectedId,
   depth,
+  TreeNode,
 }: TreeNodeListProps) {
   const selectedRef = useScrollOnMount();
 
@@ -44,6 +45,7 @@ export function TreeNodeList({
               <TreeNodeList
                 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                 items={item.children!}
+                TreeNode={TreeNode}
                 onToggleExpand={onToggleExpand}
                 expandedIds={expandedIds}
                 selectedId={selectedId}

--- a/frontend/src/metabase/components/tree/TreeNodeList.tsx
+++ b/frontend/src/metabase/components/tree/TreeNodeList.tsx
@@ -8,15 +8,17 @@ interface TreeNodeListProps {
   selectedId?: ITreeNodeItem["id"];
   depth: number;
   onToggleExpand: (id: ITreeNodeItem["id"]) => void;
+  onSelect?: (item: ITreeNodeItem) => void;
   TreeNode: TreeNodeComponent;
 }
 
 export function TreeNodeList({
   items,
-  onToggleExpand,
   expandedIds,
   selectedId,
   depth,
+  onSelect,
+  onToggleExpand,
   TreeNode,
 }: TreeNodeListProps) {
   const selectedRef = useScrollOnMount();
@@ -28,14 +30,17 @@ export function TreeNodeList({
         const hasChildren =
           Array.isArray(item.children) && item.children.length > 0;
         const isExpanded = hasChildren && expandedIds.has(item.id);
-        const onToggle = () => onToggleExpand(item.id);
+        const onItemSelect =
+          typeof onSelect === "function" ? () => onSelect(item) : undefined;
+        const onItemToggle = () => onToggleExpand(item.id);
 
         return (
           <React.Fragment key={item.id}>
             <TreeNode
               ref={isSelected ? selectedRef : null}
               item={item}
-              onToggleExpand={onToggle}
+              onSelect={onItemSelect}
+              onToggleExpand={onItemToggle}
               isSelected={isSelected}
               isExpanded={isExpanded}
               hasChildren={hasChildren}
@@ -45,11 +50,12 @@ export function TreeNodeList({
               <TreeNodeList
                 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                 items={item.children!}
-                TreeNode={TreeNode}
-                onToggleExpand={onToggleExpand}
                 expandedIds={expandedIds}
                 selectedId={selectedId}
                 depth={depth + 1}
+                onSelect={onSelect}
+                onToggleExpand={onToggleExpand}
+                TreeNode={TreeNode}
               />
             )}
           </React.Fragment>

--- a/frontend/src/metabase/components/tree/TreeNodeList.tsx
+++ b/frontend/src/metabase/components/tree/TreeNodeList.tsx
@@ -5,18 +5,16 @@ import { TreeNode } from "./TreeNode";
 
 interface TreeNodeListProps {
   items: ITreeNodeItem[];
-  onToggleExpand: (id: ITreeNodeItem["id"]) => void;
-  onSelect: (item: ITreeNodeItem) => void;
   expandedIds: Set<ITreeNodeItem["id"]>;
   selectedId?: ITreeNodeItem["id"];
   depth: number;
   colorScheme: ColorScheme;
+  onToggleExpand: (id: ITreeNodeItem["id"]) => void;
 }
 
 export function TreeNodeList({
   items,
   onToggleExpand,
-  onSelect,
   expandedIds,
   selectedId,
   depth,
@@ -39,7 +37,6 @@ export function TreeNodeList({
               colorScheme={colorScheme}
               item={item}
               onToggleExpand={onToggleExpand}
-              onSelect={onSelect}
               isSelected={isSelected}
               isExpanded={isExpanded}
               hasChildren={hasChildren}
@@ -51,7 +48,6 @@ export function TreeNodeList({
                 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                 items={item.children!}
                 onToggleExpand={onToggleExpand}
-                onSelect={onSelect}
                 expandedIds={expandedIds}
                 selectedId={selectedId}
                 depth={depth + 1}

--- a/frontend/src/metabase/components/tree/TreeNodeList.tsx
+++ b/frontend/src/metabase/components/tree/TreeNodeList.tsx
@@ -27,13 +27,14 @@ export function TreeNodeList({
         const hasChildren =
           Array.isArray(item.children) && item.children.length > 0;
         const isExpanded = hasChildren && expandedIds.has(item.id);
+        const onToggle = () => onToggleExpand(item.id);
 
         return (
           <React.Fragment key={item.id}>
             <TreeNode
               ref={isSelected ? selectedRef : null}
               item={item}
-              onToggleExpand={onToggleExpand}
+              onToggleExpand={onToggle}
               isSelected={isSelected}
               isExpanded={isExpanded}
               hasChildren={hasChildren}

--- a/frontend/src/metabase/components/tree/TreeNodeList.tsx
+++ b/frontend/src/metabase/components/tree/TreeNodeList.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useScrollOnMount } from "metabase/hooks/use-scroll-on-mount";
-import { ColorScheme, ITreeNodeItem } from "./types";
+import { ITreeNodeItem } from "./types";
 import { TreeNode } from "./TreeNode";
 
 interface TreeNodeListProps {
@@ -8,7 +8,6 @@ interface TreeNodeListProps {
   expandedIds: Set<ITreeNodeItem["id"]>;
   selectedId?: ITreeNodeItem["id"];
   depth: number;
-  colorScheme: ColorScheme;
   onToggleExpand: (id: ITreeNodeItem["id"]) => void;
 }
 
@@ -18,7 +17,6 @@ export function TreeNodeList({
   expandedIds,
   selectedId,
   depth,
-  colorScheme,
 }: TreeNodeListProps) {
   const selectedRef = useScrollOnMount();
 
@@ -34,7 +32,6 @@ export function TreeNodeList({
           <React.Fragment key={item.id}>
             <TreeNode
               ref={isSelected ? selectedRef : null}
-              colorScheme={colorScheme}
               item={item}
               onToggleExpand={onToggleExpand}
               isSelected={isSelected}
@@ -44,7 +41,6 @@ export function TreeNodeList({
             />
             {isExpanded && (
               <TreeNodeList
-                colorScheme={colorScheme}
                 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                 items={item.children!}
                 onToggleExpand={onToggleExpand}

--- a/frontend/src/metabase/components/tree/types.ts
+++ b/frontend/src/metabase/components/tree/types.ts
@@ -1,3 +1,4 @@
+import React from "react";
 import { IconProps } from "../Icon";
 
 export interface ITreeNodeItem {
@@ -15,3 +16,9 @@ export interface TreeNodeProps {
   isSelected: boolean;
   onToggleExpand: () => void;
 }
+
+export type TreeNodeComponent = React.ComponentType<
+  TreeNodeProps & {
+    ref: any;
+  }
+>;

--- a/frontend/src/metabase/components/tree/types.ts
+++ b/frontend/src/metabase/components/tree/types.ts
@@ -6,5 +6,3 @@ export interface ITreeNodeItem {
   icon: string | IconProps;
   children?: ITreeNodeItem[];
 }
-
-export type ColorScheme = "admin" | "default";

--- a/frontend/src/metabase/components/tree/types.ts
+++ b/frontend/src/metabase/components/tree/types.ts
@@ -19,7 +19,5 @@ export interface TreeNodeProps {
 }
 
 export type TreeNodeComponent = React.ComponentType<
-  TreeNodeProps & {
-    ref: any;
-  }
+  TreeNodeProps & React.RefAttributes<HTMLLIElement>
 >;

--- a/frontend/src/metabase/components/tree/types.ts
+++ b/frontend/src/metabase/components/tree/types.ts
@@ -6,3 +6,12 @@ export interface ITreeNodeItem {
   icon: string | IconProps;
   children?: ITreeNodeItem[];
 }
+
+export interface TreeNodeProps {
+  item: ITreeNodeItem;
+  depth: number;
+  hasChildren: boolean;
+  isExpanded: boolean;
+  isSelected: boolean;
+  onToggleExpand: () => void;
+}

--- a/frontend/src/metabase/components/tree/types.ts
+++ b/frontend/src/metabase/components/tree/types.ts
@@ -14,6 +14,7 @@ export interface TreeNodeProps {
   hasChildren: boolean;
   isExpanded: boolean;
   isSelected: boolean;
+  onSelect?: () => void;
   onToggleExpand: () => void;
 }
 


### PR DESCRIPTION
I'm planning to reuse `Tree` for the collection sidebar tree. One of the things blocking this is that the `TreeNode` component has its own UI and only handles `<li>` element clicks via Tree's `onSelect`prop. The collections sidebar actually requires the `TreeNode` to have a slightly different shape:

* use anchor links to collection pages instead of click handles
* have some extra components to handle drag-n-drop features

This PR refactors the `Tree` component to match these requirements:

* makes `onSelect` prop optional
* adds an optional `TreeNode` prop to `Tree`, so it's possible to provide a custom node component
* removes `colorScheme` prop in favor of emotion styling. You can see how `Tree` was restyled to match the admin app color scheme [here](https://github.com/metabase/metabase/blob/44d572434b0bd298f1202d5276de8c76f3d43932/frontend/src/metabase/admin/permissions/components/FilterableTree/FilterableTree.styled.tsx#L29)

### To Verify

1. Sign in as an admin
2. Go to `/admin/permissions/collections/root`
3. Make sure the collection sidebar on the left looks & works as usually
4. Go to the homepage, then "New" > "Question"
5. Pick "Saved questions" from the data source popover
6. Make sure the collection sidebar on the left looks & works as usually