### PR TITLE
Select timeline events from the sidebar

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/View.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View.jsx
@@ -168,6 +168,8 @@ export default class View extends React.Component {
       selectedTimelineEventIds,
       showTimelines,
       hideTimelines,
+      selectTimelineEvents,
+      deselectTimelineEvents,
       onOpenModal,
       onCloseSummary,
       onCloseFilter,
@@ -198,6 +200,8 @@ export default class View extends React.Component {
           selectedTimelineEventIds={selectedTimelineEventIds}
           onShowTimelines={showTimelines}
           onHideTimelines={hideTimelines}
+          onSelectTimelineEvents={selectTimelineEvents}
+          onDeselectTimelineEvents={deselectTimelineEvents}
           onOpenModal={onOpenModal}
           onClose={onCloseTimelines}
         />

--- a/frontend/src/metabase/query_builder/components/view/sidebars/TimelineSidebar/TimelineSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/TimelineSidebar/TimelineSidebar.tsx
@@ -13,6 +13,8 @@ export interface TimelineSidebarProps {
   selectedTimelineEventIds: number[];
   onShowTimelines?: (timelines: Timeline[]) => void;
   onHideTimelines?: (timelines: Timeline[]) => void;
+  onSelectTimelineEvents?: (timelineEvents: TimelineEvent[]) => void;
+  onDeselectTimelineEvents?: () => void;
   onOpenModal?: (modal: string, modalContext?: unknown) => void;
   onClose?: () => void;
 }
@@ -25,6 +27,8 @@ const TimelineSidebar = ({
   onOpenModal,
   onShowTimelines,
   onHideTimelines,
+  onSelectTimelineEvents,
+  onDeselectTimelineEvents,
   onClose,
 }: TimelineSidebarProps) => {
   const handleNewEvent = useCallback(() => {
@@ -36,6 +40,17 @@ const TimelineSidebar = ({
       onOpenModal?.(MODAL_TYPES.EDIT_EVENT, event.id);
     },
     [onOpenModal],
+  );
+
+  const handleToggleEvent = useCallback(
+    (event: TimelineEvent, isSelected: boolean) => {
+      if (isSelected) {
+        onSelectTimelineEvents?.([event]);
+      } else {
+        onDeselectTimelineEvents?.();
+      }
+    },
+    [onSelectTimelineEvents, onDeselectTimelineEvents],
   );
 
   const handleToggleTimeline = useCallback(
@@ -58,6 +73,7 @@ const TimelineSidebar = ({
         selectedEventIds={selectedTimelineEventIds}
         onNewEvent={handleNewEvent}
         onEditEvent={handleEditEvent}
+        onToggleEvent={handleToggleEvent}
         onToggleTimeline={handleToggleTimeline}
       />
     </SidebarContent>

--- a/frontend/src/metabase/query_builder/reducers.js
+++ b/frontend/src/metabase/query_builder/reducers.js
@@ -528,8 +528,7 @@ export const selectedTimelineEventIds = handleActions(
       next: (state, { payload: events = [] }) => events.map(e => e.id),
     },
     [DESELECT_TIMELINE_EVENTS]: {
-      next: (state, { payload: events = [] }) =>
-        _.without(state, ...events.map(e => e.id)),
+      next: () => [],
     },
     [HIDE_TIMELINES]: {
       next: (state, { payload: timelines }) =>

--- a/frontend/src/metabase/timelines/questions/components/EventCard/EventCard.styled.tsx
+++ b/frontend/src/metabase/timelines/questions/components/EventCard/EventCard.styled.tsx
@@ -14,6 +14,7 @@ export const CardRoot = styled.div<CardRootProps>`
     ${props => (props.isSelected ? color("brand") : "transparent")};
   background-color: ${props =>
     props.isSelected ? alpha("brand", 0.03) : "transparent"};
+  cursor: pointer;
 `;
 
 export const CardIcon = styled(Icon)`
@@ -68,4 +69,5 @@ export const CardCreatorInfo = styled.div`
 
 export const CardAside = styled.div`
   flex: 0 0 auto;
+  align-self: start;
 `;

--- a/frontend/src/metabase/timelines/questions/components/EventCard/EventCard.styled.tsx
+++ b/frontend/src/metabase/timelines/questions/components/EventCard/EventCard.styled.tsx
@@ -15,6 +15,10 @@ export const CardRoot = styled.div<CardRootProps>`
   background-color: ${props =>
     props.isSelected ? alpha("brand", 0.03) : "transparent"};
   cursor: pointer;
+
+  &:hover {
+    background-color: ${alpha("brand", 0.03)};
+  }
 `;
 
 export const CardIcon = styled(Icon)`

--- a/frontend/src/metabase/timelines/questions/components/EventCard/EventCard.tsx
+++ b/frontend/src/metabase/timelines/questions/components/EventCard/EventCard.tsx
@@ -1,4 +1,4 @@
-import React, { memo } from "react";
+import React, { memo, SyntheticEvent, useCallback } from "react";
 import { t } from "ttag";
 import Settings from "metabase/lib/settings";
 import { parseTimestamp } from "metabase/lib/time";
@@ -23,6 +23,7 @@ export interface EventCardProps {
   isSelected?: boolean;
   onEdit?: (event: TimelineEvent) => void;
   onArchive?: (event: TimelineEvent) => void;
+  onToggle?: (event: TimelineEvent, isSelected: boolean) => void;
 }
 
 const EventCard = ({
@@ -31,13 +32,22 @@ const EventCard = ({
   isSelected,
   onEdit,
   onArchive,
+  onToggle,
 }: EventCardProps): JSX.Element => {
   const menuItems = getMenuItems(event, timeline, onEdit, onArchive);
   const dateMessage = getDateMessage(event);
   const creatorMessage = getCreatorMessage(event);
 
+  const handleEventClick = useCallback(() => {
+    onToggle?.(event, !isSelected);
+  }, [event, isSelected, onToggle]);
+
+  const handleAsideClick = useCallback((event: SyntheticEvent) => {
+    event.stopPropagation();
+  }, []);
+
   return (
-    <CardRoot isSelected={isSelected}>
+    <CardRoot isSelected={isSelected} onClick={handleEventClick}>
       <CardIconContainer>
         <CardIcon name={event.icon} />
       </CardIconContainer>
@@ -50,7 +60,7 @@ const EventCard = ({
         <CardCreatorInfo>{creatorMessage}</CardCreatorInfo>
       </CardBody>
       {menuItems.length > 0 && (
-        <CardAside>
+        <CardAside onClick={handleAsideClick}>
           <EntityMenu items={menuItems} triggerIcon="ellipsis" />
         </CardAside>
       )}

--- a/frontend/src/metabase/timelines/questions/components/TimelineCard/TimelineCard.tsx
+++ b/frontend/src/metabase/timelines/questions/components/TimelineCard/TimelineCard.tsx
@@ -26,6 +26,7 @@ export interface TimelineCardProps {
   selectedEventIds?: number[];
   onEditEvent?: (event: TimelineEvent) => void;
   onArchiveEvent?: (event: TimelineEvent) => void;
+  onToggleEvent?: (event: TimelineEvent, isSelected: boolean) => void;
   onToggleTimeline?: (timeline: Timeline, isVisible: boolean) => void;
 }
 
@@ -34,9 +35,10 @@ const TimelineCard = ({
   isDefault,
   isVisible,
   selectedEventIds = [],
-  onToggleTimeline,
   onEditEvent,
   onArchiveEvent,
+  onToggleEvent,
+  onToggleTimeline,
 }: TimelineCardProps): JSX.Element => {
   const events = getEvents(timeline.events);
   const isEventSelected = events.some(e => selectedEventIds.includes(e.id));
@@ -46,16 +48,16 @@ const TimelineCard = ({
     setIsExpanded(isExpanded => !isExpanded);
   }, []);
 
+  const handleCheckboxClick = useCallback((event: MouseEvent) => {
+    event.stopPropagation();
+  }, []);
+
   const handleCheckboxChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
       onToggleTimeline?.(timeline, event.target.checked);
     },
     [timeline, onToggleTimeline],
   );
-
-  const handleCheckboxClick = useCallback((event: MouseEvent) => {
-    event.stopPropagation();
-  }, []);
 
   useEffect(() => {
     if (isEventSelected) {
@@ -68,8 +70,8 @@ const TimelineCard = ({
       <CardHeader onClick={handleHeaderClick}>
         <CardCheckbox
           checked={isVisible}
-          onChange={handleCheckboxChange}
           onClick={handleCheckboxClick}
+          onChange={handleCheckboxChange}
         />
         <CardLabel>
           <Ellipsified tooltipMaxWidth="100%">{timeline.name}</Ellipsified>
@@ -86,6 +88,7 @@ const TimelineCard = ({
               isSelected={selectedEventIds.includes(event.id)}
               onEdit={onEditEvent}
               onArchive={onArchiveEvent}
+              onToggle={onToggleEvent}
             />
           ))}
         </CardContent>

--- a/frontend/src/metabase/timelines/questions/components/TimelineList/TimelineList.tsx
+++ b/frontend/src/metabase/timelines/questions/components/TimelineList/TimelineList.tsx
@@ -8,6 +8,7 @@ export interface TimelineListProps {
   selectedEventIds?: number[];
   onEditEvent?: (event: TimelineEvent) => void;
   onArchiveEvent?: (event: TimelineEvent) => void;
+  onToggleEvent?: (event: TimelineEvent, isSelected: boolean) => void;
   onToggleTimeline?: (timeline: Timeline, isVisible: boolean) => void;
 }
 
@@ -17,6 +18,7 @@ const TimelineList = ({
   selectedEventIds = [],
   onEditEvent,
   onArchiveEvent,
+  onToggleEvent,
   onToggleTimeline,
 }: TimelineListProps): JSX.Element => {
   return (
@@ -30,6 +32,7 @@ const TimelineList = ({
           selectedEventIds={selectedEventIds}
           onToggleTimeline={onToggleTimeline}
           onEditEvent={onEditEvent}
+          onToggleEvent={onToggleEvent}
           onArchiveEvent={onArchiveEvent}
         />
       ))}

--- a/frontend/src/metabase/timelines/questions/components/TimelinePanel/TimelinePanel.tsx
+++ b/frontend/src/metabase/timelines/questions/components/TimelinePanel/TimelinePanel.tsx
@@ -14,6 +14,7 @@ export interface TimelinePanelProps {
   onNewEvent?: () => void;
   onEditEvent?: (event: TimelineEvent) => void;
   onArchiveEvent?: (event: TimelineEvent) => void;
+  onToggleEvent?: (event: TimelineEvent, isSelected: boolean) => void;
   onToggleTimeline?: (timeline: Timeline, isVisible: boolean) => void;
 }
 
@@ -25,6 +26,7 @@ const TimelinePanel = ({
   onNewEvent,
   onEditEvent,
   onArchiveEvent,
+  onToggleEvent,
   onToggleTimeline,
 }: TimelinePanelProps): JSX.Element => {
   const isEmpty = timelines.length === 0;
@@ -44,6 +46,7 @@ const TimelinePanel = ({
           selectedEventIds={selectedEventIds}
           onToggleTimeline={onToggleTimeline}
           onEditEvent={onEditEvent}
+          onToggleEvent={onToggleEvent}
           onArchiveEvent={onArchiveEvent}
         />
       ) : (

--- a/frontend/src/metabase/visualizations/lib/timelines.js
+++ b/frontend/src/metabase/visualizations/lib/timelines.js
@@ -187,7 +187,7 @@ function renderEventTicks({
       onOpenTimelines();
 
       if (isSelected(d, selectedEventIds)) {
-        onDeselectTimelineEvents(d);
+        onDeselectTimelineEvents();
       } else {
         onSelectTimelineEvents(d);
       }


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/20289

How to test:
- Open a timeseries question. Click on the calendar icon in the bottom right corner.
- Create several events
- Click an event in the sidebar and make sure it's highlighted in the chart
- Make sure it's possible to select and deselect events interchangeably from the chart and the sidebar

<img width="1119" alt="Screenshot 2022-03-28 at 20 42 00" src="https://user-images.githubusercontent.com/8542534/160456053-031c4eff-6b07-4e93-af5b-8333f22c80ce.png">
<img width="1120" alt="Screenshot 2022-03-28 at 20 42 08" src="https://user-images.githubusercontent.com/8542534/160456074-7b3e6163-a11e-43ba-8d3e-d03a474ef2d0.png">
