### PR TITLE
[E2E] Refactor `parameters-embedded` spec into `embedding-dashboard`

### DIFF
--- a/frontend/test/__support__/e2e/helpers/e2e-embedding-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-embedding-helpers.js
@@ -78,3 +78,16 @@ function getHiddenFilters(filters) {
 function getEmbeddableObject(payload) {
   return Object.keys(payload.resource)[0];
 }
+
+/**
+ * Grab iframe `src` via UI and open it,
+ * but make sure user is signed out.
+ */
+export function visitIframe() {
+  cy.document().then(doc => {
+    const iframe = doc.querySelector("iframe");
+
+    cy.signOut();
+    cy.visit(iframe.src);
+  });
+}

--- a/frontend/test/metabase/scenarios/embedding/embedding-dashboard.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/embedding-dashboard.cy.spec.js
@@ -131,6 +131,45 @@ describe("scenarios > embedding > dashboard parameters", () => {
       cy.get(".ScalarValue")
         .invoke("text")
         .should("eq", "1");
+
+      cy.log(
+        "Sanity check: lets make sure we can disable all previously set parameters",
+      );
+      cy.signInAsAdmin();
+
+      cy.get("@dashboardId").then(dashboardId => {
+        visitDashboard(dashboardId);
+      });
+
+      cy.icon("share").click();
+      cy.findByText("Sharing and embedding").click();
+      cy.findByText("Embed this dashboard in an application").click();
+
+      cy.findByText("Locked").click();
+      popover()
+        .contains("Disabled")
+        .click();
+
+      cy.findByText("Editable").click();
+      popover()
+        .contains("Disabled")
+        .click();
+
+      publishChanges(({ request }) => {
+        const actual = request.body.embedding_params;
+
+        const expected = { name: "disabled", id: "disabled" };
+
+        assert.deepEqual(actual, expected);
+      });
+
+      visitIframe();
+
+      filterWidget().should("not.exist");
+
+      cy.get(".ScalarValue")
+        .invoke("text")
+        .should("eq", "2,500");
     });
   });
 

--- a/frontend/test/metabase/scenarios/embedding/embedding-dashboard.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/embedding-dashboard.cy.spec.js
@@ -66,7 +66,7 @@ const dashboardDetails = {
   ],
 };
 
-describe("scenarios > dashboard > parameters-embedded", () => {
+describe("scenarios > embedding > dashboard parameters", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();

--- a/frontend/test/metabase/scenarios/embedding/embedding-dashboard.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/embedding-dashboard.cy.spec.js
@@ -7,64 +7,15 @@ import {
   visitIframe,
 } from "__support__/e2e/cypress";
 
+import {
+  questionDetails,
+  dashboardDetails,
+  mapParameters,
+} from "./embedding-dashboard";
+
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { ORDERS, PEOPLE } = SAMPLE_DATABASE;
-
-const questionDetails = {
-  native: {
-    query:
-      "SELECT COUNT(*) FROM people WHERE {{id}} AND {{name}} AND {{source}} /* AND {{user_id}} */",
-    "template-tags": {
-      id: {
-        id: "3fce42dd-fac7-c87d-e738-d8b3fc9d6d56",
-        name: "id",
-        display_name: "Id",
-        type: "dimension",
-        dimension: ["field", PEOPLE.ID, null],
-        "widget-type": "id",
-        default: null,
-      },
-      name: {
-        id: "1fe12d96-8cf7-49e4-05a3-6ed1aea24490",
-        name: "name",
-        display_name: "Name",
-        type: "dimension",
-        dimension: ["field", PEOPLE.NAME, null],
-        "widget-type": "category",
-        default: null,
-      },
-      source: {
-        id: "aed3c67a-820a-966b-d07b-ddf54a7f2e5e",
-        name: "source",
-        display_name: "Source",
-        type: "dimension",
-        dimension: ["field", PEOPLE.SOURCE, null],
-        "widget-type": "category",
-        default: null,
-      },
-      user_id: {
-        id: "cd4bb37d-8404-488e-f66a-6545a261bbe0",
-        name: "user_id",
-        display_name: "User",
-        type: "dimension",
-        dimension: ["field", ORDERS.USER_ID, null],
-        "widget-type": "id",
-        default: null,
-      },
-    },
-  },
-  display: "scalar",
-};
-
-const dashboardDetails = {
-  parameters: [
-    { name: "Id", slug: "id", id: "1", type: "id" },
-    { name: "Name", slug: "name", id: "2", type: "category" },
-    { name: "Source", slug: "source", id: "3", type: "category" },
-    { name: "User", slug: "user_id", id: "4", type: "id" },
-  ],
-};
 
 describe("scenarios > embedding > dashboard parameters", () => {
   beforeEach(() => {
@@ -249,45 +200,6 @@ describe("scenarios > embedding > dashboard parameters", () => {
     });
   });
 });
-
-function mapParameters({ id, card_id, dashboard_id } = {}) {
-  return cy.request("PUT", `/api/dashboard/${dashboard_id}/cards`, {
-    cards: [
-      {
-        id,
-        card_id,
-        row: 0,
-        col: 0,
-        sizeX: 18,
-        sizeY: 6,
-        series: [],
-        visualization_settings: {},
-        parameter_mappings: [
-          {
-            parameter_id: "1",
-            card_id,
-            target: ["dimension", ["template-tag", "id"]],
-          },
-          {
-            parameter_id: "2",
-            card_id,
-            target: ["dimension", ["template-tag", "name"]],
-          },
-          {
-            parameter_id: "3",
-            card_id,
-            target: ["dimension", ["template-tag", "source"]],
-          },
-          {
-            parameter_id: "4",
-            card_id,
-            target: ["dimension", ["template-tag", "user_id"]],
-          },
-        ],
-      },
-    ],
-  });
-}
 
 function openFilterOptions(name) {
   filterWidget()

--- a/frontend/test/metabase/scenarios/embedding/embedding-dashboard.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/embedding-dashboard.cy.spec.js
@@ -92,7 +92,7 @@ describe("scenarios > embedding > dashboard parameters", () => {
   });
 
   context("UI", () => {
-    beforeEach(() => {
+    it("should be disabled by default but able to be set to editable and/or locked (metabase#20357)", () => {
       cy.get("@dashboardId").then(dashboardId => {
         visitDashboard(dashboardId);
       });
@@ -100,9 +100,7 @@ describe("scenarios > embedding > dashboard parameters", () => {
       cy.icon("share").click();
       cy.findByText("Sharing and embedding").click();
       cy.findByText("Embed this dashboard in an application").click();
-    });
 
-    it("should be disabled by default but able to be set to editable and/or locked (metabase#20357)", () => {
       cy.findByRole("heading", { name: "Parameters" })
         .parent()
         .as("allParameters")

--- a/frontend/test/metabase/scenarios/embedding/embedding-dashboard.js
+++ b/frontend/test/metabase/scenarios/embedding/embedding-dashboard.js
@@ -1,0 +1,101 @@
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+
+const { ORDERS, PEOPLE } = SAMPLE_DATABASE;
+
+export const questionDetails = {
+  native: {
+    query:
+      "SELECT COUNT(*) FROM people WHERE {{id}} AND {{name}} AND {{source}} /* AND {{user_id}} */",
+    "template-tags": {
+      id: {
+        id: "3fce42dd-fac7-c87d-e738-d8b3fc9d6d56",
+        name: "id",
+        display_name: "Id",
+        type: "dimension",
+        dimension: ["field", PEOPLE.ID, null],
+        "widget-type": "id",
+        default: null,
+      },
+      name: {
+        id: "1fe12d96-8cf7-49e4-05a3-6ed1aea24490",
+        name: "name",
+        display_name: "Name",
+        type: "dimension",
+        dimension: ["field", PEOPLE.NAME, null],
+        "widget-type": "category",
+        default: null,
+      },
+      source: {
+        id: "aed3c67a-820a-966b-d07b-ddf54a7f2e5e",
+        name: "source",
+        display_name: "Source",
+        type: "dimension",
+        dimension: ["field", PEOPLE.SOURCE, null],
+        "widget-type": "category",
+        default: null,
+      },
+      user_id: {
+        id: "cd4bb37d-8404-488e-f66a-6545a261bbe0",
+        name: "user_id",
+        display_name: "User",
+        type: "dimension",
+        dimension: ["field", ORDERS.USER_ID, null],
+        "widget-type": "id",
+        default: null,
+      },
+    },
+  },
+  display: "scalar",
+};
+
+// Define dashboard filters
+const idFilter = { name: "Id", slug: "id", id: "1", type: "id" };
+
+const nameFilter = { name: "Name", slug: "name", id: "2", type: "category" };
+
+const sourceFilter = {
+  name: "Source",
+  slug: "source",
+  id: "3",
+  type: "category",
+};
+
+const userFilter = { name: "User", slug: "user_id", id: "4", type: "id" };
+
+const parameters = [idFilter, nameFilter, sourceFilter, userFilter];
+
+export const dashboardDetails = {
+  parameters,
+};
+
+function getParameterMappings(parameters, card_id) {
+  const parameter_mappings = [];
+
+  parameters.map(({ id, slug }) => {
+    parameter_mappings.push({
+      parameter_id: id,
+      card_id,
+      target: ["dimension", ["template-tag", slug]],
+    });
+  });
+
+  return parameter_mappings;
+}
+
+export function mapParameters({ id, card_id, dashboard_id } = {}) {
+  return cy.request("PUT", `/api/dashboard/${dashboard_id}/cards`, {
+    cards: [
+      {
+        id,
+        card_id,
+        row: 0,
+        col: 0,
+        sizeX: 18,
+        sizeY: 6,
+        series: [],
+        visualization_settings: {},
+        parameter_mappings: getParameterMappings(parameters, card_id),
+      },
+    ],
+  });
+}

--- a/frontend/test/metabase/scenarios/embedding/parameters-embedded.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/parameters-embedded.cy.spec.js
@@ -91,23 +91,30 @@ describe("scenarios > dashboard > parameters-embedded", () => {
   });
 
   context("UI", () => {
-    it("should be disabled by default but able to be set to editable (metabase#20357)", () => {
-      visitDashboard(2);
+    beforeEach(() => {
+      cy.get("@dashboardId").then(dashboardId => {
+        visitDashboard(dashboardId);
+      });
+
       cy.icon("share").click();
       cy.findByText("Sharing and embedding").click();
       cy.findByText("Embed this dashboard in an application").click();
+    });
 
-      cy.get(".Modal--full").within(() => {
-        // verify that all the parameters on the dashboard are defaulted to disabled
-        cy.findAllByText("Disabled").should("have.length", 4);
+    it("should be disabled by default but able to be set to editable (metabase#20357)", () => {
+      cy.findByRole("heading", { name: "Parameters" })
+        .parent()
+        .within(() => {
+          // verify that all the parameters on the dashboard are defaulted to disabled
+          cy.findAllByText("Disabled").should("have.length", 4);
 
-        // select the dropdown next to the Id parameter so that we can set it to editable
-        cy.findByText("Id")
-          .parent()
-          .within(() => {
-            cy.findByText("Disabled").click();
-          });
-      });
+          // select the dropdown next to the Id parameter so that we can set it to editable
+          cy.findByText("Id")
+            .parent()
+            .within(() => {
+              cy.findByText("Disabled").click();
+            });
+        });
 
       cy.findByText("Editable").click();
 
@@ -138,11 +145,6 @@ describe("scenarios > dashboard > parameters-embedded", () => {
     });
 
     it("should let parameters be locked to a specific value (metabase#20357)", () => {
-      visitDashboard(2);
-      cy.icon("share").click();
-      cy.findByText("Sharing and embedding").click();
-      cy.findByText("Embed this dashboard in an application").click();
-
       cy.findByText("Parameters");
       cy.get(".Modal--full").within(() => {
         cy.findAllByText("Disabled").should("have.length", 4);

--- a/frontend/test/metabase/scenarios/embedding/parameters-embedded.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/parameters-embedded.cy.spec.js
@@ -53,8 +53,6 @@ describe("scenarios > dashboard > parameters-embedded", () => {
     cy.request("PUT", `/api/setting/embedding-secret-key`, {
       value: METABASE_SECRET_KEY,
     });
-    cy.request("PUT", `/api/setting/enable-embedding`, { value: true });
-    cy.request("PUT", `/api/setting/enable-public-sharing`, { value: true });
   });
 
   describe("embedded parameters", () => {

--- a/frontend/test/metabase/scenarios/embedding/parameters-embedded.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/parameters-embedded.cy.spec.js
@@ -10,12 +10,8 @@ const METABASE_SECRET_KEY =
 
 // Calling jwt.sign was failing in cypress (in browser issue maybe?). These
 // tokens just hard code dashboardId=2 and questionId=3
-const QUESTION_JWT_TOKEN =
-  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyZXNvdXJjZSI6eyJxdWVzdGlvbiI6M30sInBhcmFtcyI6e30sImlhdCI6MTU3OTU1OTg3NH0.alV205oYgfyWuwLNQSLVgfHop1tpevX4C26Xal-bia8";
 const DASHBOARD_JWT_TOKEN =
   "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyZXNvdXJjZSI6eyJkYXNoYm9hcmQiOjJ9LCJwYXJhbXMiOnt9LCJpYXQiOjE1Nzk1NjAxMTF9.LjOiTp4p2lV3b2VpSjcg0GuSaE2O0xhHwc59JDYcBJI";
-
-// NOTE: some overlap with parameters.cy.spec.js
 
 describe("scenarios > dashboard > parameters-embedded", () => {
   let dashboardId, questionId, dashcardId;
@@ -51,7 +47,7 @@ describe("scenarios > dashboard > parameters-embedded", () => {
   });
 
   describe("embedded parameters", () => {
-    it("should be disabled by default but able to be set to editable", () => {
+    it("should be disabled by default but able to be set to editable (metabase#20357)", () => {
       visitDashboard(2);
       cy.icon("share").click();
       cy.findByText("Sharing and embedding").click();
@@ -142,28 +138,6 @@ describe("scenarios > dashboard > parameters-embedded", () => {
       cy.get(".Card").within(() => {
         cy.contains("2");
       });
-    });
-  });
-
-  describe("embedded question", () => {
-    beforeEach(() => {
-      cy.request("PUT", `/api/card/${questionId}`, {
-        embedding_params: {
-          id: "enabled",
-          name: "enabled",
-          source: "enabled",
-          user_id: "enabled",
-        },
-        enable_embedding: true,
-      });
-      cy.signOut();
-    });
-
-    sharedParametersTests(() => {
-      cy.visit(`/embed/question/${QUESTION_JWT_TOKEN}`);
-      // wait for question to load/run
-      cy.contains("Test Question");
-      cy.contains("2,500");
     });
   });
 

--- a/frontend/test/metabase/scenarios/embedding/parameters-embedded.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/parameters-embedded.cy.spec.js
@@ -1,6 +1,5 @@
 import { restore, popover, visitDashboard } from "__support__/e2e/cypress";
 
-import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { ORDERS, PEOPLE } = SAMPLE_DATABASE;
@@ -12,6 +11,52 @@ const METABASE_SECRET_KEY =
 // tokens just hard code dashboardId=2 and questionId=3
 const DASHBOARD_JWT_TOKEN =
   "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyZXNvdXJjZSI6eyJkYXNoYm9hcmQiOjJ9LCJwYXJhbXMiOnt9LCJpYXQiOjE1Nzk1NjAxMTF9.LjOiTp4p2lV3b2VpSjcg0GuSaE2O0xhHwc59JDYcBJI";
+
+const questionDetails = {
+  native: {
+    query:
+      "SELECT COUNT(*) FROM people WHERE {{id}} AND {{name}} AND {{source}} /* AND {{user_id}} */",
+    "template-tags": {
+      id: {
+        id: "3fce42dd-fac7-c87d-e738-d8b3fc9d6d56",
+        name: "id",
+        display_name: "Id",
+        type: "dimension",
+        dimension: ["field", PEOPLE.ID, null],
+        "widget-type": "id",
+        default: null,
+      },
+      name: {
+        id: "1fe12d96-8cf7-49e4-05a3-6ed1aea24490",
+        name: "name",
+        display_name: "Name",
+        type: "dimension",
+        dimension: ["field", PEOPLE.NAME, null],
+        "widget-type": "category",
+        default: null,
+      },
+      source: {
+        id: "aed3c67a-820a-966b-d07b-ddf54a7f2e5e",
+        name: "source",
+        display_name: "Source",
+        type: "dimension",
+        dimension: ["field", PEOPLE.SOURCE, null],
+        "widget-type": "category",
+        default: null,
+      },
+      user_id: {
+        id: "cd4bb37d-8404-488e-f66a-6545a261bbe0",
+        name: "user_id",
+        display_name: "User",
+        type: "dimension",
+        dimension: ["field", ORDERS.USER_ID, null],
+        "widget-type": "id",
+        default: null,
+      },
+    },
+    display: "scalar",
+  },
+};
 
 describe("scenarios > dashboard > parameters-embedded", () => {
   let dashboardId, questionId, dashcardId;
@@ -30,7 +75,7 @@ describe("scenarios > dashboard > parameters-embedded", () => {
       cy.request("PUT", `/api/field/${id}`, { has_field_values: "search" }),
     );
 
-    createQuestion().then(res => {
+    cy.createNativeQuestion(questionDetails).then(res => {
       questionId = res.body.id;
       createDashboard().then(res => {
         dashboardId = res.body.id;
@@ -204,62 +249,6 @@ function sharedParametersTests(visitUrl) {
     cy.contains(".ScalarValue", "2");
   });
 }
-
-const createQuestion = () =>
-  cy.request("PUT", "/api/card/3", {
-    name: "Test Question",
-    dataset_query: {
-      type: "native",
-      native: {
-        query:
-          "SELECT COUNT(*) FROM people WHERE {{id}} AND {{name}} AND {{source}} /* AND {{user_id}} */",
-        "template-tags": {
-          id: {
-            id: "3fce42dd-fac7-c87d-e738-d8b3fc9d6d56",
-            name: "id",
-            display_name: "Id",
-            type: "dimension",
-            dimension: ["field", PEOPLE.ID, null],
-            "widget-type": "id",
-            default: null,
-          },
-          name: {
-            id: "1fe12d96-8cf7-49e4-05a3-6ed1aea24490",
-            name: "name",
-            display_name: "Name",
-            type: "dimension",
-            dimension: ["field", PEOPLE.NAME, null],
-            "widget-type": "category",
-            default: null,
-          },
-          source: {
-            id: "aed3c67a-820a-966b-d07b-ddf54a7f2e5e",
-            name: "source",
-            display_name: "Source",
-            type: "dimension",
-            dimension: ["field", PEOPLE.SOURCE, null],
-            "widget-type": "category",
-            default: null,
-          },
-          user_id: {
-            id: "cd4bb37d-8404-488e-f66a-6545a261bbe0",
-            name: "user_id",
-            display_name: "User",
-            type: "dimension",
-            dimension: ["field", ORDERS.USER_ID, null],
-            "widget-type": "id",
-            default: null,
-          },
-        },
-      },
-      database: SAMPLE_DB_ID,
-    },
-    display: "scalar",
-    description: null,
-    visualization_settings: {},
-    collection_id: null,
-    result_metadata: null,
-  });
 
 const createDashboard = () =>
   cy.request("POST", "/api/dashboard", {

--- a/frontend/test/metabase/scenarios/embedding/parameters-embedded.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/parameters-embedded.cy.spec.js
@@ -3,6 +3,7 @@ import {
   popover,
   visitDashboard,
   visitEmbeddedPage,
+  filterWidget,
 } from "__support__/e2e/cypress";
 
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
@@ -210,36 +211,41 @@ describe("scenarios > dashboard > parameters-embedded", () => {
       });
     });
 
-    it("should allow searching PEOPLE.ID by PEOPLE.NAME", () => {
-      cy.contains("Id").click();
-      popover()
-        .find('[placeholder="Search by Name or enter an ID"]')
-        .type("Aly");
-      popover().contains("Alycia McCullough - 2016");
-    });
+    it("should work for all filters", () => {
+      cy.log("should allow searching PEOPLE.ID by PEOPLE.NAME");
 
-    it("should allow searching PEOPLE.NAME by PEOPLE.NAME", () => {
-      cy.contains("Name").click();
-      popover()
-        .find('[placeholder="Search by Name"]')
-        .type("Aly");
-      popover().contains("Alycia McCullough");
-    });
+      openFilterOptions("Id");
+      popover().within(() => {
+        cy.findByPlaceholderText("Search by Name or enter an ID").type("Aly");
 
-    it("should show values for PEOPLE.SOURCE", () => {
-      cy.contains("Source").click();
+        cy.contains("Alycia McCullough - 2016");
+      });
+
+      cy.log("should allow searching PEOPLE.NAME by PEOPLE.NAME");
+
+      openFilterOptions("Name");
+      popover().within(() => {
+        cy.findByPlaceholderText("Search by Name").type("Aly");
+
+        cy.contains("Alycia McCullough");
+      });
+
+      cy.log("should show values for PEOPLE.SOURCE");
+
+      openFilterOptions("Source");
       popover().contains("Affiliate");
-    });
 
-    it("should allow searching ORDER.USER_ID by PEOPLE.NAME", () => {
-      cy.contains("User").click();
-      popover()
-        .find('[placeholder="Search by Name or enter an ID"]')
-        .type("Aly");
-      popover().contains("Alycia McCullough - 2016");
-    });
+      cy.log("should allow searching ORDER.USER_ID by PEOPLE.NAME");
 
-    it("should accept url parameters", () => {
+      openFilterOptions("User");
+      popover().within(() => {
+        cy.findByPlaceholderText("Search by Name or enter an ID").type("Aly");
+
+        cy.contains("Alycia McCullough - 2016");
+      });
+
+      cy.log("should accept url parameters");
+
       cy.url().then(url => cy.visit(url + "?id=1&id=3"));
       cy.contains(".ScalarValue", "2");
     });
@@ -283,4 +289,10 @@ function mapParameters({ id, card_id, dashboard_id } = {}) {
       },
     ],
   });
+}
+
+function openFilterOptions(name) {
+  filterWidget()
+    .contains(name)
+    .click();
 }

--- a/frontend/test/metabase/scenarios/embedding/parameters-embedded.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/parameters-embedded.cy.spec.js
@@ -1,9 +1,4 @@
-import {
-  restore,
-  popover,
-  visitQuestion,
-  visitDashboard,
-} from "__support__/e2e/cypress";
+import { restore, popover, visitDashboard } from "__support__/e2e/cypress";
 
 import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
@@ -150,34 +145,6 @@ describe("scenarios > dashboard > parameters-embedded", () => {
     });
   });
 
-  describe("private question", () => {
-    beforeEach(cy.signInAsAdmin);
-
-    sharedParametersTests(() => {
-      visitQuestion(questionId);
-      // wait for question to load/run
-      cy.contains("Test Question");
-      cy.contains("2,500");
-    });
-  });
-
-  describe("public question", () => {
-    let uuid;
-    beforeEach(() => {
-      cy.request("POST", `/api/card/${questionId}/public_link`).then(
-        res => (uuid = res.body.uuid),
-      );
-      cy.signOut();
-    });
-
-    sharedParametersTests(() => {
-      cy.visit(`/public/question/${uuid}`);
-      // wait for question to load/run
-      cy.contains("Test Question");
-      cy.contains("2,500");
-    });
-  });
-
   describe("embedded question", () => {
     beforeEach(() => {
       cy.request("PUT", `/api/card/${questionId}`, {
@@ -196,34 +163,6 @@ describe("scenarios > dashboard > parameters-embedded", () => {
       cy.visit(`/embed/question/${QUESTION_JWT_TOKEN}`);
       // wait for question to load/run
       cy.contains("Test Question");
-      cy.contains("2,500");
-    });
-  });
-
-  describe("private dashboard", () => {
-    beforeEach(cy.signInAsAdmin);
-
-    sharedParametersTests(() => {
-      visitDashboard(dashboardId);
-      // wait for question to load/run
-      cy.contains("Test Dashboard");
-      cy.contains("2,500");
-    });
-  });
-
-  describe("public dashboard", () => {
-    let uuid;
-    beforeEach(() => {
-      cy.request("POST", `/api/dashboard/${dashboardId}/public_link`).then(
-        res => (uuid = res.body.uuid),
-      );
-      cy.signOut();
-    });
-
-    sharedParametersTests(() => {
-      cy.visit(`/public/dashboard/${uuid}`);
-      // wait for question to load/run
-      cy.contains("Test Dashboard");
       cy.contains("2,500");
     });
   });

--- a/frontend/test/metabase/scenarios/embedding/parameters-embedded.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/parameters-embedded.cy.spec.js
@@ -58,6 +58,14 @@ const questionDetails = {
   },
 };
 
+const dashboardDetails = {
+  parameters: [
+    { name: "Id", slug: "id", id: "1", type: "id" },
+    { name: "Name", slug: "name", id: "2", type: "category" },
+    { name: "Source", slug: "source", id: "3", type: "category" },
+    { name: "User", slug: "user_id", id: "4", type: "id" },
+  ],
+};
 describe("scenarios > dashboard > parameters-embedded", () => {
   let dashboardId, questionId, dashcardId;
 
@@ -77,7 +85,7 @@ describe("scenarios > dashboard > parameters-embedded", () => {
 
     cy.createNativeQuestion(questionDetails).then(res => {
       questionId = res.body.id;
-      createDashboard().then(res => {
+      cy.createDashboard(dashboardDetails).then(res => {
         dashboardId = res.body.id;
         addCardToDashboard({ dashboardId, questionId }).then(res => {
           dashcardId = res.body.id;
@@ -249,18 +257,6 @@ function sharedParametersTests(visitUrl) {
     cy.contains(".ScalarValue", "2");
   });
 }
-
-const createDashboard = () =>
-  cy.request("POST", "/api/dashboard", {
-    name: "Test Dashboard",
-    collection_id: null,
-    parameters: [
-      { name: "Id", slug: "id", id: "1", type: "id" },
-      { name: "Name", slug: "name", id: "2", type: "category" },
-      { name: "Source", slug: "source", id: "3", type: "category" },
-      { name: "User", slug: "user_id", id: "4", type: "id" },
-    ],
-  });
 
 const addCardToDashboard = ({ dashboardId, questionId }) =>
   cy.request("POST", `/api/dashboard/${dashboardId}/cards`, {

--- a/frontend/test/metabase/scenarios/embedding/parameters-embedded.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/parameters-embedded.cy.spec.js
@@ -90,7 +90,7 @@ describe("scenarios > dashboard > parameters-embedded", () => {
     });
   });
 
-  describe("embedded parameters", () => {
+  context("UI", () => {
     it("should be disabled by default but able to be set to editable (metabase#20357)", () => {
       visitDashboard(2);
       cy.icon("share").click();
@@ -185,7 +185,7 @@ describe("scenarios > dashboard > parameters-embedded", () => {
     });
   });
 
-  describe("embedded dashboard", () => {
+  context("API", () => {
     beforeEach(() => {
       cy.get("@dashboardId").then(dashboardId => {
         cy.request("PUT", `/api/dashboard/${dashboardId}`, {

--- a/frontend/test/metabase/scenarios/embedding/parameters-embedded.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/parameters-embedded.cy.spec.js
@@ -54,8 +54,8 @@ const questionDetails = {
         default: null,
       },
     },
-    display: "scalar",
   },
+  display: "scalar",
 };
 
 const dashboardDetails = {


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Adds **embedding tests for the dashboard parameters** for both UI and API context
- It started out as a refactor of the old `frontend/test/metabase/scenarios/embedding/parameters-embedded.cy.spec.js` which was way too convoluted
    - On top of that, the setup was done in a _fragile*_ way, using an [anti-pattern](https://docs.cypress.io/guides/references/best-practices#Assigning-Return-Values) of first defining a variable and then assigning a return value to it
    - Removed the use of [hard coded JWT tokens](https://github.com/metabase/metabase/pull/21292/files#diff-263b2beee8923eaffd75ca80c93e083d5d2d40fe74bb29cf96b7bb5b4fb0425eL16-L21) and uses our new embedding JWT signing helper
- It ended up as a full-fledged and greatly improved spec for testing embedding dashboard parameters
- [Removes a lot of unrelated or duplicated tests](https://github.com/metabase/metabase/pull/21292/commits/43884b9806138106b0bc6ce4026734ae50a2320e)
    - Regular questions and dashboards, public sharing
    - Embedded questions (already covered)
- That left us with just the embedding dashboard tests

_*Note: Although the whole embedding group was passing when I ran it using our `buildjet` machines, this spec was almost constantly failing when I stress-tested it in my fork with the default GH runners (ubuntu-latest). With these new changes, that flakiness should be completely removed._ 

The whole spec is now divided into two `context`s, just like `embedding-native.cy.spec.js` is. They are UI and API respectively.

### UI
I've refactored great work by @daltojohnso that was done in https://github.com/metabase/metabase/pull/20635, and merged those two tests into one UI check. It sped things up. Also, I've added one more important UI assertion. We're now also checking that it's possible to disable previously enabled / locked parameters.

### API
Another anti-pattern of [using many smaller tests](https://docs.cypress.io/guides/references/best-practices#Creating-tiny-tests-with-a-single-assertion) where one longer one would suffice.

These changes contributed to the overall stability and significant speed improvements (without compromising the coverage; on contrary  - we are now covering more cases)

Before
![image](https://user-images.githubusercontent.com/31325167/160478524-fbad1802-3853-4c25-92af-fbf68622901b.png)

After
![image](https://user-images.githubusercontent.com/31325167/160477711-f7ecf961-d2f9-4af2-93cf-14789c20d514.png)
