### PR TITLE
Show the events time range in the sidebar

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/View.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View.jsx
@@ -166,6 +166,7 @@ export default class View extends React.Component {
       runQuestionQuery,
       visibleTimelineIds,
       selectedTimelineEventIds,
+      xDomain,
       showTimelines,
       hideTimelines,
       onOpenModal,
@@ -196,6 +197,7 @@ export default class View extends React.Component {
           timelines={timelines}
           visibleTimelineIds={visibleTimelineIds}
           selectedTimelineEventIds={selectedTimelineEventIds}
+          xDomain={xDomain}
           onShowTimelines={showTimelines}
           onHideTimelines={hideTimelines}
           onOpenModal={onOpenModal}

--- a/frontend/src/metabase/query_builder/components/view/View.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View.jsx
@@ -6,6 +6,7 @@ import _ from "underscore";
 import ExplicitSize from "metabase/components/ExplicitSize";
 import Popover from "metabase/components/Popover";
 import QueryValidationError from "metabase/query_builder/components/QueryValidationError";
+import { SIDEBAR_SIZES } from "metabase/query_builder/constants";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 
 import NativeQuery from "metabase-lib/lib/queries/NativeQuery";
@@ -406,6 +407,7 @@ export default class View extends React.Component {
       card,
       databases,
       isShowingNewbModal,
+      isShowingTimelineSidebar,
       queryBuilderMode,
       fitClassNames,
       closeQbNewbModal,
@@ -434,6 +436,9 @@ export default class View extends React.Component {
 
     const leftSidebar = this.getLeftSidebar();
     const rightSidebar = this.getRightSidebar();
+    const rightSidebarWidth = isShowingTimelineSidebar
+      ? SIDEBAR_SIZES.TIMELINE
+      : SIDEBAR_SIZES.NORMAL;
 
     return (
       <div className={fitClassNames}>
@@ -450,7 +455,11 @@ export default class View extends React.Component {
               {leftSidebar}
             </ViewSidebar>
             {this.renderMain({ leftSidebar, rightSidebar })}
-            <ViewSidebar side="right" isOpen={!!rightSidebar}>
+            <ViewSidebar
+              side="right"
+              isOpen={!!rightSidebar}
+              width={rightSidebarWidth}
+            >
               {rightSidebar}
             </ViewSidebar>
           </QueryBuilderContentContainer>

--- a/frontend/src/metabase/query_builder/components/view/sidebars/TimelineSidebar/TimelineSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/TimelineSidebar/TimelineSidebar.tsx
@@ -1,6 +1,9 @@
 import React, { useCallback } from "react";
 import { t } from "ttag";
+import { Moment } from "moment";
 import Question from "metabase-lib/lib/Question";
+import Settings from "metabase/lib/settings";
+import { formatDateTimeWithUnit } from "metabase/lib/formatting";
 import { MODAL_TYPES } from "metabase/query_builder/constants";
 import SidebarContent from "metabase/query_builder/components/SidebarContent";
 import TimelinePanel from "metabase/timelines/questions/containers/TimelinePanel";
@@ -11,6 +14,7 @@ export interface TimelineSidebarProps {
   timelines: Timeline[];
   visibleTimelineIds: number[];
   selectedTimelineEventIds: number[];
+  xDomain?: [Moment, Moment];
   onShowTimelines?: (timelines: Timeline[]) => void;
   onHideTimelines?: (timelines: Timeline[]) => void;
   onOpenModal?: (modal: string, modalContext?: unknown) => void;
@@ -22,6 +26,7 @@ const TimelineSidebar = ({
   timelines,
   visibleTimelineIds,
   selectedTimelineEventIds,
+  xDomain,
   onOpenModal,
   onShowTimelines,
   onHideTimelines,
@@ -50,7 +55,7 @@ const TimelineSidebar = ({
   );
 
   return (
-    <SidebarContent title={t`Events`} onClose={onClose}>
+    <SidebarContent title={formatTitle(xDomain)} onClose={onClose}>
       <TimelinePanel
         timelines={timelines}
         collectionId={question.collectionId()}
@@ -62,6 +67,16 @@ const TimelineSidebar = ({
       />
     </SidebarContent>
   );
+};
+
+const formatTitle = (xDomain?: [Moment, Moment]) => {
+  return xDomain
+    ? t`Events from ${formatDate(xDomain[0])} to ${formatDate(xDomain[1])}`
+    : t`Events`;
+};
+
+const formatDate = (date: Moment) => {
+  return formatDateTimeWithUnit(date, "day", Settings.formattingOptions());
 };
 
 export default TimelineSidebar;

--- a/frontend/src/metabase/query_builder/components/view/sidebars/TimelineSidebar/TimelineSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/TimelineSidebar/TimelineSidebar.tsx
@@ -2,8 +2,6 @@ import React, { useCallback } from "react";
 import { t } from "ttag";
 import { Moment } from "moment";
 import Question from "metabase-lib/lib/Question";
-import Settings from "metabase/lib/settings";
-import { formatDateTimeWithUnit } from "metabase/lib/formatting";
 import { MODAL_TYPES } from "metabase/query_builder/constants";
 import SidebarContent from "metabase/query_builder/components/SidebarContent";
 import TimelinePanel from "metabase/timelines/questions/containers/TimelinePanel";
@@ -55,28 +53,19 @@ const TimelineSidebar = ({
   );
 
   return (
-    <SidebarContent title={formatTitle(xDomain)} onClose={onClose}>
+    <SidebarContent title={t`Events`} onClose={onClose}>
       <TimelinePanel
         timelines={timelines}
         collectionId={question.collectionId()}
         visibleTimelineIds={visibleTimelineIds}
         selectedEventIds={selectedTimelineEventIds}
+        xDomain={xDomain}
         onNewEvent={handleNewEvent}
         onEditEvent={handleEditEvent}
         onToggleTimeline={handleToggleTimeline}
       />
     </SidebarContent>
   );
-};
-
-const formatTitle = (xDomain?: [Moment, Moment]) => {
-  return xDomain
-    ? t`Events ${formatDate(xDomain[0])} — ${formatDate(xDomain[1])}`
-    : t`Events`;
-};
-
-const formatDate = (date: Moment) => {
-  return formatDateTimeWithUnit(date, "day", Settings.formattingOptions());
 };
 
 export default TimelineSidebar;

--- a/frontend/src/metabase/query_builder/components/view/sidebars/TimelineSidebar/TimelineSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/TimelineSidebar/TimelineSidebar.tsx
@@ -53,19 +53,28 @@ const TimelineSidebar = ({
   );
 
   return (
-    <SidebarContent title={t`Events`} onClose={onClose}>
+    <SidebarContent title={formatTitle(xDomain)} onClose={onClose}>
       <TimelinePanel
         timelines={timelines}
         collectionId={question.collectionId()}
         visibleTimelineIds={visibleTimelineIds}
         selectedEventIds={selectedTimelineEventIds}
-        xDomain={xDomain}
         onNewEvent={handleNewEvent}
         onEditEvent={handleEditEvent}
         onToggleTimeline={handleToggleTimeline}
       />
     </SidebarContent>
   );
+};
+
+const formatTitle = (xDomain?: [Moment, Moment]) => {
+  return xDomain
+    ? t`Events between ${formatDate(xDomain[0])} and ${formatDate(xDomain[1])}`
+    : t`Events`;
+};
+
+const formatDate = (date: Moment) => {
+  return date.format("ll");
 };
 
 export default TimelineSidebar;

--- a/frontend/src/metabase/query_builder/components/view/sidebars/TimelineSidebar/TimelineSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/TimelineSidebar/TimelineSidebar.tsx
@@ -71,7 +71,7 @@ const TimelineSidebar = ({
 
 const formatTitle = (xDomain?: [Moment, Moment]) => {
   return xDomain
-    ? t`Events from ${formatDate(xDomain[0])} to ${formatDate(xDomain[1])}`
+    ? t`Events ${formatDate(xDomain[0])} — ${formatDate(xDomain[1])}`
     : t`Events`;
 };
 

--- a/frontend/src/metabase/query_builder/constants.js
+++ b/frontend/src/metabase/query_builder/constants.js
@@ -20,5 +20,5 @@ export const MODAL_TYPES = {
 
 export const SIDEBAR_SIZES = {
   NORMAL: 355,
-  TIMELINE: 416,
+  TIMELINE: 300,
 };

--- a/frontend/src/metabase/query_builder/constants.js
+++ b/frontend/src/metabase/query_builder/constants.js
@@ -17,3 +17,8 @@ export const MODAL_TYPES = {
   NEW_EVENT: "new-event",
   EDIT_EVENT: "edit-event",
 };
+
+export const SIDEBAR_SIZES = {
+  NORMAL: 355,
+  TIMELINE: 416,
+};

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
@@ -68,6 +68,7 @@ import {
   getVisibleTimelineEvents,
   getSelectedTimelineEventIds,
   getFilteredTimelines,
+  getTimeseriesXDomain,
 } from "../selectors";
 import * as actions from "../actions";
 
@@ -120,6 +121,7 @@ const mapStateToProps = (state, props) => {
     timelineEvents: getVisibleTimelineEvents(state),
     visibleTimelineIds: getVisibleTimelineIds(state),
     selectedTimelineEventIds: getSelectedTimelineEventIds(state),
+    xDomain: getTimeseriesXDomain(state),
 
     result: getFirstQueryResult(state),
     results: getQueryResults(state),

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -603,13 +603,13 @@ const getIsTimeseries = createSelector(
   settings => settings && isTimeseries(settings),
 );
 
-const getTimeseriesXValues = createSelector(
+export const getTimeseriesXValues = createSelector(
   [getIsTimeseries, getTransformedSeries, getVisualizationSettings],
   (isTimeseries, series, settings) =>
     isTimeseries && series && settings && getXValues({ series, settings }),
 );
 
-const getTimeseriesXDomain = createSelector(
+export const getTimeseriesXDomain = createSelector(
   [getIsTimeseries, getTimeseriesXValues],
   (isTimeseries, xValues) => xValues && isTimeseries && d3.extent(xValues),
 );

--- a/frontend/src/metabase/timelines/questions/components/TimelinePanel/TimelinePanel.styled.tsx
+++ b/frontend/src/metabase/timelines/questions/components/TimelinePanel/TimelinePanel.styled.tsx
@@ -5,11 +5,6 @@ export const PanelRoot = styled.div`
   margin: 0 1.5rem;
 `;
 
-export const PanelCaption = styled.div`
-  color: ${color("text-medium")};
-  margin-bottom: 1rem;
-`;
-
 export const PanelToolbar = styled.div`
   margin-bottom: 1rem;
 `;

--- a/frontend/src/metabase/timelines/questions/components/TimelinePanel/TimelinePanel.styled.tsx
+++ b/frontend/src/metabase/timelines/questions/components/TimelinePanel/TimelinePanel.styled.tsx
@@ -1,7 +1,13 @@
 import styled from "@emotion/styled";
+import { color } from "metabase/lib/colors";
 
 export const PanelRoot = styled.div`
   margin: 0 1.5rem;
+`;
+
+export const PanelCaption = styled.div`
+  color: ${color("text-medium")};
+  margin-bottom: 1rem;
 `;
 
 export const PanelToolbar = styled.div`

--- a/frontend/src/metabase/timelines/questions/components/TimelinePanel/TimelinePanel.tsx
+++ b/frontend/src/metabase/timelines/questions/components/TimelinePanel/TimelinePanel.tsx
@@ -1,16 +1,20 @@
 import React from "react";
 import { t } from "ttag";
+import { Moment } from "moment";
+import Settings from "metabase/lib/settings";
+import { formatDateTimeWithUnit } from "metabase/lib/formatting";
 import Button from "metabase/core/components/Button";
 import { Collection, Timeline, TimelineEvent } from "metabase-types/api";
 import TimelineList from "../TimelineList";
 import TimelineEmptyState from "../TimelineEmptyState";
-import { PanelRoot, PanelToolbar } from "./TimelinePanel.styled";
+import { PanelCaption, PanelRoot, PanelToolbar } from "./TimelinePanel.styled";
 
 export interface TimelinePanelProps {
   timelines: Timeline[];
   collection: Collection;
   visibleTimelineIds?: number[];
   selectedEventIds?: number[];
+  xDomain?: [Moment, Moment];
   onNewEvent?: () => void;
   onEditEvent?: (event: TimelineEvent) => void;
   onArchiveEvent?: (event: TimelineEvent) => void;
@@ -22,6 +26,7 @@ const TimelinePanel = ({
   collection,
   visibleTimelineIds,
   selectedEventIds,
+  xDomain,
   onNewEvent,
   onEditEvent,
   onArchiveEvent,
@@ -32,6 +37,9 @@ const TimelinePanel = ({
 
   return (
     <PanelRoot>
+      {!isEmpty && xDomain && (
+        <PanelCaption>{formatCaption(xDomain)}</PanelCaption>
+      )}
       {!isEmpty && canWrite && (
         <PanelToolbar>
           <Button onClick={onNewEvent}>{t`Add an event`}</Button>
@@ -55,6 +63,14 @@ const TimelinePanel = ({
       )}
     </PanelRoot>
   );
+};
+
+const formatCaption = (xDomain: [Moment, Moment]) => {
+  return t`${formatDate(xDomain[0])} — ${formatDate(xDomain[1])}`;
+};
+
+const formatDate = (date: Moment) => {
+  return formatDateTimeWithUnit(date, "day", Settings.formattingOptions());
 };
 
 export default TimelinePanel;

--- a/frontend/src/metabase/timelines/questions/components/TimelinePanel/TimelinePanel.tsx
+++ b/frontend/src/metabase/timelines/questions/components/TimelinePanel/TimelinePanel.tsx
@@ -1,20 +1,16 @@
 import React from "react";
 import { t } from "ttag";
-import { Moment } from "moment";
-import Settings from "metabase/lib/settings";
-import { formatDateTimeWithUnit } from "metabase/lib/formatting";
 import Button from "metabase/core/components/Button";
 import { Collection, Timeline, TimelineEvent } from "metabase-types/api";
 import TimelineList from "../TimelineList";
 import TimelineEmptyState from "../TimelineEmptyState";
-import { PanelCaption, PanelRoot, PanelToolbar } from "./TimelinePanel.styled";
+import { PanelRoot, PanelToolbar } from "./TimelinePanel.styled";
 
 export interface TimelinePanelProps {
   timelines: Timeline[];
   collection: Collection;
   visibleTimelineIds?: number[];
   selectedEventIds?: number[];
-  xDomain?: [Moment, Moment];
   onNewEvent?: () => void;
   onEditEvent?: (event: TimelineEvent) => void;
   onArchiveEvent?: (event: TimelineEvent) => void;
@@ -26,7 +22,6 @@ const TimelinePanel = ({
   collection,
   visibleTimelineIds,
   selectedEventIds,
-  xDomain,
   onNewEvent,
   onEditEvent,
   onArchiveEvent,
@@ -37,9 +32,6 @@ const TimelinePanel = ({
 
   return (
     <PanelRoot>
-      {!isEmpty && xDomain && (
-        <PanelCaption>{formatCaption(xDomain)}</PanelCaption>
-      )}
       {!isEmpty && canWrite && (
         <PanelToolbar>
           <Button onClick={onNewEvent}>{t`Add an event`}</Button>
@@ -63,14 +55,6 @@ const TimelinePanel = ({
       )}
     </PanelRoot>
   );
-};
-
-const formatCaption = (xDomain: [Moment, Moment]) => {
-  return t`${formatDate(xDomain[0])} — ${formatDate(xDomain[1])}`;
-};
-
-const formatDate = (date: Moment) => {
-  return formatDateTimeWithUnit(date, "day", Settings.formattingOptions());
 };
 
 export default TimelinePanel;


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/20289

Show the time range in a way that makes it clear that only events from the range are shown.

<img width="1250" alt="Screenshot 2022-03-28 at 22 14 53" src="https://user-images.githubusercontent.com/8542534/160560902-4bc5f470-ea88-4f35-83d4-e74bd0c16a85.png">
