### PR TITLE
Decrease the margin between the event title and author

### DIFF
--- a/frontend/src/metabase/timelines/collections/components/EventCard/EventCard.styled.tsx
+++ b/frontend/src/metabase/timelines/collections/components/EventCard/EventCard.styled.tsx
@@ -78,7 +78,7 @@ export const CardDateInfo = styled.div`
 
 export const CardCreatorInfo = styled.div`
   color: ${color("text-medium")};
-  margin-top: 0.75rem;
+  margin-top: 0.25rem;
   font-size: 0.75rem;
 `;
 

--- a/frontend/src/metabase/timelines/questions/components/EventCard/EventCard.styled.tsx
+++ b/frontend/src/metabase/timelines/questions/components/EventCard/EventCard.styled.tsx
@@ -62,7 +62,7 @@ export const CardDateInfo = styled.div`
 
 export const CardCreatorInfo = styled.div`
   color: ${color("text-medium")};
-  margin-top: 0.75rem;
+  margin-top: 0.25rem;
   font-size: 0.75rem;
 `;
 


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/20289

<img width="657" alt="Screenshot 2022-03-28 at 22 23 54" src="https://user-images.githubusercontent.com/8542534/160471737-67324e54-703b-43a3-8ab3-341e61aa5810.png">
<img width="363" alt="Screenshot 2022-03-28 at 22 24 11" src="https://user-images.githubusercontent.com/8542534/160471747-33d1b686-842f-4211-bed9-bd1f08411836.png">
