### PR TITLE
Browsing | Refactor navigation sidebar

### DIFF
--- a/frontend/src/metabase-types/api/collection.ts
+++ b/frontend/src/metabase-types/api/collection.ts
@@ -9,7 +9,7 @@ export interface Collection {
   archived: boolean;
   children?: Collection[];
 
-  personal_owner_id?: number | unknown;
+  personal_owner_id?: number;
 
   location?: string;
   effective_ancestors?: Collection[];

--- a/frontend/src/metabase/components/CollapseSection/CollapseSection.jsx
+++ b/frontend/src/metabase/components/CollapseSection/CollapseSection.jsx
@@ -12,23 +12,29 @@ const propTypes = {
   initialState: PropTypes.oneOf(["expanded", "collapsed"]),
   iconVariant: PropTypes.oneOf(["right-down", "up-down"]),
   iconPosition: PropTypes.oneOf(["left", "right"]),
+  iconSize: PropTypes.number,
+  onToggle: PropTypes.func,
 };
 
 function CollapseSection({
   initialState = "collapsed",
   iconVariant = "right-down",
   iconPosition = "left",
+  iconSize = 12,
   header,
   headerClass,
   className,
   bodyClass,
   children,
+  onToggle,
 }) {
   const [isExpanded, setIsExpanded] = useState(initialState === "expanded");
 
   const toggle = useCallback(() => {
-    setIsExpanded(isExpanded => !isExpanded);
-  }, []);
+    const nextState = !isExpanded;
+    setIsExpanded(!isExpanded);
+    onToggle?.(nextState);
+  }, [isExpanded, onToggle]);
 
   const onKeyDown = useCallback(
     e => {
@@ -44,6 +50,7 @@ function CollapseSection({
       isExpanded={isExpanded}
       variant={iconVariant}
       position={iconPosition}
+      size={iconSize}
     />
   );
 

--- a/frontend/src/metabase/components/CollapseSection/CollapseSection.styled.js
+++ b/frontend/src/metabase/components/CollapseSection/CollapseSection.styled.js
@@ -31,11 +31,13 @@ const ICON_VARIANTS = {
   },
 };
 
-export const ToggleIcon = styled(({ isExpanded, variant, ...props }) => {
-  const { collapsed, expanded } = ICON_VARIANTS[variant];
-  const name = isExpanded ? expanded : collapsed;
-  return <Icon name={name} size={12} {...props} />;
-})`
+export const ToggleIcon = styled(
+  ({ isExpanded, variant, size = 12, ...props }) => {
+    const { collapsed, expanded } = ICON_VARIANTS[variant];
+    const name = isExpanded ? expanded : collapsed;
+    return <Icon name={name} size={size} {...props} />;
+  },
+)`
   ${props => css`
     margin-${props.position === "left" ? "right" : "left"}: 0.5rem;
   `};

--- a/frontend/src/metabase/components/tree/Tree.tsx
+++ b/frontend/src/metabase/components/tree/Tree.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback, useEffect } from "react";
+import { usePrevious } from "metabase/hooks/use-previous";
 import { TreeNodeList } from "./TreeNodeList";
 import { TreeNode as DefaultTreeNode } from "./TreeNode";
 import { getInitialExpandedIds } from "./utils";
@@ -22,14 +23,19 @@ function BaseTree({
   const [expandedIds, setExpandedIds] = useState(
     new Set(selectedId != null ? getInitialExpandedIds(selectedId, data) : []),
   );
+  const previousSelectedId = usePrevious(selectedId);
 
   useEffect(() => {
-    if (selectedId && !expandedIds.has(selectedId)) {
+    if (
+      selectedId &&
+      previousSelectedId !== selectedId &&
+      !expandedIds.has(selectedId)
+    ) {
       setExpandedIds(
         prev => new Set([...prev, ...getInitialExpandedIds(selectedId, data)]),
       );
     }
-  }, [data, selectedId, expandedIds]);
+  }, [data, selectedId, previousSelectedId, expandedIds]);
 
   const handleToggleExpand = useCallback(
     itemId => {

--- a/frontend/src/metabase/components/tree/Tree.tsx
+++ b/frontend/src/metabase/components/tree/Tree.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback, useEffect } from "react";
+import _ from "underscore";
 import { usePrevious } from "metabase/hooks/use-previous";
 import { TreeNodeList } from "./TreeNodeList";
 import { TreeNode as DefaultTreeNode } from "./TreeNode";
@@ -34,8 +35,7 @@ function BaseTree({
     }
     const selectedItemChanged =
       previousSelectedId !== selectedId && !expandedIds.has(selectedId);
-    const itemsChanged = prevData !== data;
-    if (selectedItemChanged || itemsChanged) {
+    if (selectedItemChanged || !_.isEqual(data, prevData)) {
       setExpandedIds(
         prev => new Set([...prev, ...getInitialExpandedIds(selectedId, data)]),
       );

--- a/frontend/src/metabase/components/tree/Tree.tsx
+++ b/frontend/src/metabase/components/tree/Tree.tsx
@@ -24,18 +24,21 @@ function BaseTree({
     new Set(selectedId != null ? getInitialExpandedIds(selectedId, data) : []),
   );
   const previousSelectedId = usePrevious(selectedId);
+  const prevData = usePrevious(data);
 
   useEffect(() => {
-    if (
-      selectedId &&
-      previousSelectedId !== selectedId &&
-      !expandedIds.has(selectedId)
-    ) {
+    if (!selectedId) {
+      return;
+    }
+    const selectedItemChanged =
+      previousSelectedId !== selectedId && !expandedIds.has(selectedId);
+    const itemsChanged = prevData !== data;
+    if (selectedItemChanged || itemsChanged) {
       setExpandedIds(
         prev => new Set([...prev, ...getInitialExpandedIds(selectedId, data)]),
       );
     }
-  }, [data, selectedId, previousSelectedId, expandedIds]);
+  }, [prevData, data, selectedId, previousSelectedId, expandedIds]);
 
   const handleToggleExpand = useCallback(
     itemId => {

--- a/frontend/src/metabase/components/tree/Tree.tsx
+++ b/frontend/src/metabase/components/tree/Tree.tsx
@@ -8,6 +8,7 @@ import { ITreeNodeItem, TreeNodeComponent } from "./types";
 interface TreeProps {
   data: ITreeNodeItem[];
   selectedId?: ITreeNodeItem["id"];
+  role?: string;
   emptyState?: React.ReactNode;
   onSelect?: (item: ITreeNodeItem) => void;
   TreeNode?: TreeNodeComponent;
@@ -16,6 +17,7 @@ interface TreeProps {
 function BaseTree({
   data,
   selectedId,
+  role = "menu",
   emptyState = null,
   onSelect,
   TreeNode = DefaultTreeNode,
@@ -58,6 +60,7 @@ function BaseTree({
   return (
     <TreeNodeList
       items={data}
+      role={role}
       TreeNode={TreeNode}
       expandedIds={expandedIds}
       selectedId={selectedId}

--- a/frontend/src/metabase/components/tree/Tree.tsx
+++ b/frontend/src/metabase/components/tree/Tree.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from "react";
+import React, { useState, useCallback, useEffect } from "react";
 import { TreeNodeList } from "./TreeNodeList";
 import { TreeNode as DefaultTreeNode } from "./TreeNode";
 import { getInitialExpandedIds } from "./utils";
@@ -22,6 +22,14 @@ function BaseTree({
   const [expandedIds, setExpandedIds] = useState(
     new Set(selectedId != null ? getInitialExpandedIds(selectedId, data) : []),
   );
+
+  useEffect(() => {
+    if (selectedId && !expandedIds.has(selectedId)) {
+      setExpandedIds(
+        prev => new Set([...prev, ...getInitialExpandedIds(selectedId, data)]),
+      );
+    }
+  }, [data, selectedId, expandedIds]);
 
   const handleToggleExpand = useCallback(
     itemId => {

--- a/frontend/src/metabase/components/tree/TreeNode.styled.tsx
+++ b/frontend/src/metabase/components/tree/TreeNode.styled.tsx
@@ -58,9 +58,13 @@ export const NameContainer = styled.div`
   flex: 1;
 `;
 
-export const IconContainer = styled.div`
+export const IconContainer = styled.div<{ transparent?: boolean }>`
   display: flex;
   align-items: center;
   padding: 0.25rem;
-  opacity: 0.5;
+  opacity: ${props => (props.transparent ? 0.5 : 1)};
 `;
+
+IconContainer.defaultProps = {
+  transparent: true,
+};

--- a/frontend/src/metabase/components/tree/TreeNodeList.tsx
+++ b/frontend/src/metabase/components/tree/TreeNodeList.tsx
@@ -7,6 +7,7 @@ interface TreeNodeListProps {
   expandedIds: Set<ITreeNodeItem["id"]>;
   selectedId?: ITreeNodeItem["id"];
   depth: number;
+  role?: string;
   onToggleExpand: (id: ITreeNodeItem["id"]) => void;
   onSelect?: (item: ITreeNodeItem) => void;
   TreeNode: TreeNodeComponent;
@@ -14,6 +15,7 @@ interface TreeNodeListProps {
 
 export function TreeNodeList({
   items,
+  role,
   expandedIds,
   selectedId,
   depth,
@@ -24,7 +26,7 @@ export function TreeNodeList({
   const selectedRef = useScrollOnMount();
 
   return (
-    <ul role="menu">
+    <ul role={role}>
       {items.map(item => {
         const isSelected = selectedId === item.id;
         const hasChildren =

--- a/frontend/src/metabase/containers/dnd/ItemsDragLayer.jsx
+++ b/frontend/src/metabase/containers/dnd/ItemsDragLayer.jsx
@@ -43,7 +43,7 @@ export default class ItemsDragLayer extends React.Component {
           transform: `translate(${x}px, ${y}px)`,
           pointerEvents: "none",
           opacity: 0.65,
-          zIndex: 1,
+          zIndex: 999,
         }}
       >
         <DraggedItems

--- a/frontend/src/metabase/entities/collections.js
+++ b/frontend/src/metabase/entities/collections.js
@@ -351,9 +351,12 @@ export function buildCollectionTree(collections, { targetModels } = {}) {
           ...collection,
           schemaName: collection.originalName || collection.name,
           icon: getCollectionIcon(collection),
-          children: buildCollectionTree(collection.children || [], {
-            targetModels,
-          }),
+          children: buildCollectionTree(
+            collection.children?.filter(child => !child.archived) || [],
+            {
+              targetModels,
+            },
+          ),
         }
       : [];
   });

--- a/frontend/src/metabase/entities/collections/collections.js
+++ b/frontend/src/metabase/entities/collections/collections.js
@@ -1,7 +1,6 @@
 import _ from "underscore";
 import { createEntity, undo } from "metabase/lib/entities";
 
-import { color } from "metabase/lib/colors";
 import * as Urls from "metabase/lib/urls";
 
 import { CollectionSchema } from "metabase/schema";
@@ -10,42 +9,20 @@ import { createSelector } from "reselect";
 import { GET } from "metabase/lib/api";
 
 import { getUser, getUserPersonalCollectionId } from "metabase/selectors/user";
-import {
-  isPersonalCollection,
-  canonicalCollectionId,
-} from "metabase/collections/utils";
+import { canonicalCollectionId } from "metabase/collections/utils";
 
 import { t } from "ttag";
 
-import { PLUGIN_COLLECTIONS } from "metabase/plugins";
+import {
+  ROOT_COLLECTION,
+  PERSONAL_COLLECTION,
+  PERSONAL_COLLECTIONS,
+} from "./constants";
 import { getFormSelector } from "./forms";
+import { getCollectionIcon, getCollectionType } from "./utils";
 
 const listCollectionsTree = GET("/api/collection/tree");
 const listCollections = GET("/api/collection");
-
-export const ROOT_COLLECTION = {
-  id: "root",
-  name: t`Our analytics`,
-  location: "",
-  path: [],
-};
-
-export const PERSONAL_COLLECTION = {
-  id: undefined, // to be filled in by getExpandedCollectionsById
-  name: t`My personal collection`,
-  location: "/",
-  path: [ROOT_COLLECTION.id],
-  can_write: true,
-};
-
-// fake collection for admins that contains all other user's collections
-export const PERSONAL_COLLECTIONS = {
-  id: "personal", // placeholder id
-  name: t`All personal collections`,
-  location: "/",
-  path: [ROOT_COLLECTION.id],
-  can_write: false,
-};
 
 const Collections = createEntity({
   name: "collections",
@@ -143,41 +120,6 @@ const Collections = createEntity({
 });
 
 export default Collections;
-
-export function getCollectionIcon(collection, { tooltip = "default" } = {}) {
-  if (collection.id === PERSONAL_COLLECTIONS.id) {
-    return { name: "group" };
-  }
-  if (isPersonalCollection(collection)) {
-    return { name: "person" };
-  }
-  const authorityLevel =
-    PLUGIN_COLLECTIONS.AUTHORITY_LEVEL[collection.authority_level];
-
-  return authorityLevel
-    ? {
-        name: authorityLevel.icon,
-        color: color(authorityLevel.color),
-        tooltip: authorityLevel.tooltips?.[tooltip],
-      }
-    : { name: "folder" };
-}
-
-export function normalizedCollection(collection) {
-  if (canonicalCollectionId(collection.id) === null) {
-    return ROOT_COLLECTION;
-  }
-  return collection;
-}
-
-export const getCollectionType = (collectionId, state) =>
-  collectionId === null || collectionId === "root"
-    ? "root"
-    : collectionId === getUserPersonalCollectionId(state)
-    ? "personal"
-    : collectionId !== undefined
-    ? "other"
-    : null;
 
 // a "real" collection
 
@@ -324,40 +266,4 @@ function byCollectionUrlId(state, { params, location }) {
  */
 function byCollectionQueryParameter(state, { location }) {
   return location && location.query && location.query.collectionId;
-}
-
-function hasIntersection(list1, list2) {
-  if (!list2) {
-    return false;
-  }
-  return _.intersection(list1, list2).length > 0;
-}
-
-export function buildCollectionTree(collections, { targetModels } = {}) {
-  if (collections == null) {
-    return [];
-  }
-
-  const shouldFilterCollections = Array.isArray(targetModels);
-
-  return collections.flatMap(collection => {
-    const hasTargetModels =
-      !shouldFilterCollections ||
-      hasIntersection(targetModels, collection.below) ||
-      hasIntersection(targetModels, collection.here);
-
-    return hasTargetModels
-      ? {
-          ...collection,
-          schemaName: collection.originalName || collection.name,
-          icon: getCollectionIcon(collection),
-          children: buildCollectionTree(
-            collection.children?.filter(child => !child.archived) || [],
-            {
-              targetModels,
-            },
-          ),
-        }
-      : [];
-  });
 }

--- a/frontend/src/metabase/entities/collections/collections.js
+++ b/frontend/src/metabase/entities/collections/collections.js
@@ -18,7 +18,7 @@ import {
 import { t } from "ttag";
 
 import { PLUGIN_COLLECTIONS } from "metabase/plugins";
-import { getFormSelector } from "./collections/forms";
+import { getFormSelector } from "./forms";
 
 const listCollectionsTree = GET("/api/collection/tree");
 const listCollections = GET("/api/collection");

--- a/frontend/src/metabase/entities/collections/constants.js
+++ b/frontend/src/metabase/entities/collections/constants.js
@@ -1,0 +1,25 @@
+import { t } from "ttag";
+
+export const ROOT_COLLECTION = {
+  id: "root",
+  name: t`Our analytics`,
+  location: "",
+  path: [],
+};
+
+export const PERSONAL_COLLECTION = {
+  id: undefined, // to be filled in by getExpandedCollectionsById
+  name: t`My personal collection`,
+  location: "/",
+  path: [ROOT_COLLECTION.id],
+  can_write: true,
+};
+
+// fake collection for admins that contains all other user's collections
+export const PERSONAL_COLLECTIONS = {
+  id: "personal", // placeholder id
+  name: t`All personal collections`,
+  location: "/",
+  path: [ROOT_COLLECTION.id],
+  can_write: false,
+};

--- a/frontend/src/metabase/entities/collections/index.js
+++ b/frontend/src/metabase/entities/collections/index.js
@@ -1,2 +1,5 @@
+export * from "./constants";
 export * from "./collections";
+export * from "./utils";
+
 export { default } from "./collections";

--- a/frontend/src/metabase/entities/collections/index.js
+++ b/frontend/src/metabase/entities/collections/index.js
@@ -1,0 +1,2 @@
+export * from "./collections";
+export { default } from "./collections";

--- a/frontend/src/metabase/entities/collections/utils.js
+++ b/frontend/src/metabase/entities/collections/utils.js
@@ -1,0 +1,84 @@
+import _ from "underscore";
+
+import { color } from "metabase/lib/colors";
+
+import { getUserPersonalCollectionId } from "metabase/selectors/user";
+import {
+  isPersonalCollection,
+  canonicalCollectionId,
+} from "metabase/collections/utils";
+
+import { PLUGIN_COLLECTIONS } from "metabase/plugins";
+
+import { ROOT_COLLECTION, PERSONAL_COLLECTIONS } from "./constants";
+
+export function getCollectionIcon(collection, { tooltip = "default" } = {}) {
+  if (collection.id === PERSONAL_COLLECTIONS.id) {
+    return { name: "group" };
+  }
+  if (isPersonalCollection(collection)) {
+    return { name: "person" };
+  }
+  const authorityLevel =
+    PLUGIN_COLLECTIONS.AUTHORITY_LEVEL[collection.authority_level];
+
+  return authorityLevel
+    ? {
+        name: authorityLevel.icon,
+        color: color(authorityLevel.color),
+        tooltip: authorityLevel.tooltips?.[tooltip],
+      }
+    : { name: "folder" };
+}
+
+export function normalizedCollection(collection) {
+  if (canonicalCollectionId(collection.id) === null) {
+    return ROOT_COLLECTION;
+  }
+  return collection;
+}
+
+export const getCollectionType = (collectionId, state) =>
+  collectionId === null || collectionId === "root"
+    ? "root"
+    : collectionId === getUserPersonalCollectionId(state)
+    ? "personal"
+    : collectionId !== undefined
+    ? "other"
+    : null;
+
+function hasIntersection(list1, list2) {
+  if (!list2) {
+    return false;
+  }
+  return _.intersection(list1, list2).length > 0;
+}
+
+export function buildCollectionTree(collections, { targetModels } = {}) {
+  if (collections == null) {
+    return [];
+  }
+
+  const shouldFilterCollections = Array.isArray(targetModels);
+
+  return collections.flatMap(collection => {
+    const hasTargetModels =
+      !shouldFilterCollections ||
+      hasIntersection(targetModels, collection.below) ||
+      hasIntersection(targetModels, collection.here);
+
+    return hasTargetModels
+      ? {
+          ...collection,
+          schemaName: collection.originalName || collection.name,
+          icon: getCollectionIcon(collection),
+          children: buildCollectionTree(
+            collection.children?.filter(child => !child.archived) || [],
+            {
+              targetModels,
+            },
+          ),
+        }
+      : [];
+  });
+}

--- a/frontend/src/metabase/lib/urls.js
+++ b/frontend/src/metabase/lib/urls.js
@@ -366,5 +366,5 @@ export function extractCollectionId(slug) {
 export function bookmark({ type, id, name }) {
   const [, idInteger] = id.split("-");
 
-  return `${type}/${appendSlug(idInteger, slugg(name))}`;
+  return `/${type}/${appendSlug(idInteger, slugg(name))}`;
 }

--- a/frontend/src/metabase/nav/components/ProfileLink.jsx
+++ b/frontend/src/metabase/nav/components/ProfileLink.jsx
@@ -23,7 +23,6 @@ export default class ProfileLink extends Component {
 
   static propTypes = {
     user: PropTypes.object.isRequired,
-    context: PropTypes.string.isRequired,
   };
 
   openModal = modalName => {

--- a/frontend/src/metabase/nav/constants.js
+++ b/frontend/src/metabase/nav/constants.js
@@ -4,3 +4,4 @@ export const getDefaultSearchColor = () => lighten(color("nav"), 0.07);
 
 export const APP_BAR_HEIGHT = "52px";
 export const ADMIN_NAVBAR_HEIGHT = "65px";
+export const NAV_SIDEBAR_WIDTH = "324px";

--- a/frontend/src/metabase/nav/containers/MainNavbar/BookmarkList/BookmarkList.styled.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/BookmarkList/BookmarkList.styled.tsx
@@ -7,10 +7,6 @@ import { space } from "metabase/styled-components/theme";
 
 import { SidebarLink } from "../SidebarItems";
 
-export const BookmarkListRoot = styled.div`
-  margin: ${space(1)} 0;
-`;
-
 export const BookmarkTypeIcon = styled(Icon)`
   margin-right: 6px;
   opacity: 0.5;

--- a/frontend/src/metabase/nav/containers/MainNavbar/BookmarkList/BookmarkList.styled.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/BookmarkList/BookmarkList.styled.tsx
@@ -18,6 +18,7 @@ export const BookmarkListRoot = styled.div`
     opacity: 0;
     color: ${color("brand")};
     cursor: pointer;
+    margin-right: ${space(0)};
   }
 `;
 

--- a/frontend/src/metabase/nav/containers/MainNavbar/BookmarkList/BookmarkList.styled.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/BookmarkList/BookmarkList.styled.tsx
@@ -1,13 +1,22 @@
 import styled from "@emotion/styled";
 
+import Icon from "metabase/components/Icon";
+
 import { color } from "metabase/lib/colors";
 import { space } from "metabase/styled-components/theme";
 
-import Icon from "metabase/components/Icon";
+import { SidebarLink } from "../SidebarItems";
 
 export const BookmarkListRoot = styled.div`
   margin: ${space(1)} 0;
+`;
 
+export const BookmarkTypeIcon = styled(Icon)`
+  margin-right: 6px;
+  opacity: 0.5;
+`;
+
+export const SidebarBookmarkItem = styled(SidebarLink)`
   &:hover {
     button {
       opacity: 0.5;
@@ -16,13 +25,9 @@ export const BookmarkListRoot = styled.div`
 
   button {
     opacity: 0;
-    color: ${color("brand")};
+    color: ${props =>
+      props.isSelected ? color("text-white") : color("brand")};
     cursor: pointer;
     margin-right: ${space(0)};
   }
-`;
-
-export const BookmarkTypeIcon = styled(Icon)`
-  margin-right: 6px;
-  opacity: 0.5;
 `;

--- a/frontend/src/metabase/nav/containers/MainNavbar/BookmarkList/BookmarkList.styled.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/BookmarkList/BookmarkList.styled.tsx
@@ -1,0 +1,27 @@
+import styled from "@emotion/styled";
+
+import { color } from "metabase/lib/colors";
+import { space } from "metabase/styled-components/theme";
+
+import Icon from "metabase/components/Icon";
+
+export const BookmarkListRoot = styled.div`
+  margin: ${space(1)} 0;
+
+  &:hover {
+    button {
+      opacity: 0.5;
+    }
+  }
+
+  button {
+    opacity: 0;
+    color: ${color("brand")};
+    cursor: pointer;
+  }
+`;
+
+export const BookmarkTypeIcon = styled(Icon)`
+  margin-right: 6px;
+  opacity: 0.5;
+`;

--- a/frontend/src/metabase/nav/containers/MainNavbar/BookmarkList/BookmarkList.styled.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/BookmarkList/BookmarkList.styled.tsx
@@ -1,16 +1,9 @@
 import styled from "@emotion/styled";
 
-import Icon from "metabase/components/Icon";
-
 import { color } from "metabase/lib/colors";
 import { space } from "metabase/styled-components/theme";
 
 import { SidebarLink } from "../SidebarItems";
-
-export const BookmarkTypeIcon = styled(Icon)`
-  margin-right: 6px;
-  opacity: 0.5;
-`;
 
 export const SidebarBookmarkItem = styled(SidebarLink)`
   &:hover {

--- a/frontend/src/metabase/nav/containers/MainNavbar/BookmarkList/BookmarkList.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/BookmarkList/BookmarkList.tsx
@@ -13,8 +13,8 @@ import { SelectedItem } from "../types";
 import { BookmarkListRoot, SidebarBookmarkItem } from "./BookmarkList.styled";
 
 const mapDispatchToProps = {
-  onDeleteBookmark: ({ id, type }: Bookmark) =>
-    Bookmarks.actions.delete({ id: id.toString(), type }),
+  onDeleteBookmark: ({ item_id, type }: Bookmark) =>
+    Bookmarks.actions.delete({ id: item_id, type }),
 };
 
 function getIconForEntityType(type: BookmarkableEntities) {

--- a/frontend/src/metabase/nav/containers/MainNavbar/BookmarkList/BookmarkList.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/BookmarkList/BookmarkList.tsx
@@ -1,7 +1,8 @@
-import React from "react";
+import React, { useCallback, useState } from "react";
 import { t } from "ttag";
 import { connect } from "react-redux";
 
+import CollapseSection from "metabase/components/CollapseSection";
 import Icon from "metabase/components/Icon";
 import Tooltip from "metabase/components/Tooltip";
 
@@ -10,6 +11,7 @@ import Bookmarks from "metabase/entities/bookmarks";
 import * as Urls from "metabase/lib/urls";
 
 import { SelectedItem } from "../types";
+import { SidebarHeading } from "../MainNavbar.styled";
 import { BookmarkListRoot, SidebarBookmarkItem } from "./BookmarkList.styled";
 
 const mapDispatchToProps = {
@@ -32,13 +34,26 @@ interface CollectionSidebarBookmarksProps {
   onDeleteBookmark: (bookmark: Bookmark) => void;
 }
 
+const BOOKMARKS_INITIALLY_VISIBLE =
+  localStorage.getItem("shouldDisplayBookmarks") !== "false";
+
 const BookmarkList = ({
   bookmarks,
   selectedItem,
   onDeleteBookmark,
 }: CollectionSidebarBookmarksProps) => {
+  const onToggleBookmarks = useCallback(isVisible => {
+    localStorage.setItem("shouldDisplayBookmarks", String(isVisible));
+  }, []);
+
   return (
-    <BookmarkListRoot>
+    <CollapseSection
+      header={<SidebarHeading>{t`Bookmarks`}</SidebarHeading>}
+      initialState={BOOKMARKS_INITIALLY_VISIBLE ? "expanded" : "collapsed"}
+      iconPosition="right"
+      iconSize={8}
+      onToggle={onToggleBookmarks}
+    >
       {bookmarks.map(bookmark => {
         const { id, item_id, name, type } = bookmark;
         const isSelected =
@@ -65,7 +80,7 @@ const BookmarkList = ({
           </SidebarBookmarkItem>
         );
       })}
-    </BookmarkListRoot>
+    </CollapseSection>
   );
 };
 

--- a/frontend/src/metabase/nav/containers/MainNavbar/BookmarkList/BookmarkList.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/BookmarkList/BookmarkList.tsx
@@ -9,6 +9,7 @@ import { Bookmark, BookmarkableEntities } from "metabase-types/api";
 import Bookmarks from "metabase/entities/bookmarks";
 import * as Urls from "metabase/lib/urls";
 
+import { SelectedItem } from "../types";
 import { SidebarLink } from "../SidebarItems";
 import { BookmarkListRoot } from "./BookmarkList.styled";
 
@@ -28,19 +29,23 @@ function getIconForEntityType(type: BookmarkableEntities) {
 
 interface CollectionSidebarBookmarksProps {
   bookmarks: Bookmark[];
-  currentPathname: string;
+  selectedItem: SelectedItem;
   onDeleteBookmark: (bookmark: Bookmark) => void;
 }
 
 const BookmarkList = ({
   bookmarks,
-  currentPathname,
+  selectedItem,
   onDeleteBookmark,
 }: CollectionSidebarBookmarksProps) => {
   return (
     <BookmarkListRoot>
       {bookmarks.map(bookmark => {
-        const { id, name, type } = bookmark;
+        const { id, item_id, name, type } = bookmark;
+        const isSelected =
+          selectedItem.type !== "collection" &&
+          selectedItem.type === type &&
+          selectedItem.id === item_id;
         const url = Urls.bookmark(bookmark);
         const onRemove = () => onDeleteBookmark(bookmark);
         return (
@@ -48,7 +53,7 @@ const BookmarkList = ({
             key={`bookmark-${id}`}
             url={url}
             icon={getIconForEntityType(type)}
-            isSelected={currentPathname.startsWith(url)}
+            isSelected={isSelected}
             right={
               <button onClick={onRemove}>
                 <Tooltip tooltip={t`Remove bookmark`} placement="bottom">

--- a/frontend/src/metabase/nav/containers/MainNavbar/BookmarkList/BookmarkList.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/BookmarkList/BookmarkList.tsx
@@ -10,8 +10,7 @@ import Bookmarks from "metabase/entities/bookmarks";
 import * as Urls from "metabase/lib/urls";
 
 import { SelectedItem } from "../types";
-import { SidebarLink } from "../SidebarItems";
-import { BookmarkListRoot } from "./BookmarkList.styled";
+import { BookmarkListRoot, SidebarBookmarkItem } from "./BookmarkList.styled";
 
 const mapDispatchToProps = {
   onDeleteBookmark: ({ id, type }: Bookmark) =>
@@ -49,7 +48,7 @@ const BookmarkList = ({
         const url = Urls.bookmark(bookmark);
         const onRemove = () => onDeleteBookmark(bookmark);
         return (
-          <SidebarLink
+          <SidebarBookmarkItem
             key={`bookmark-${id}`}
             url={url}
             icon={getIconForEntityType(type)}
@@ -63,7 +62,7 @@ const BookmarkList = ({
             }
           >
             {name}
-          </SidebarLink>
+          </SidebarBookmarkItem>
         );
       })}
     </BookmarkListRoot>

--- a/frontend/src/metabase/nav/containers/MainNavbar/BookmarkList/BookmarkList.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/BookmarkList/BookmarkList.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { t } from "ttag";
+import { connect } from "react-redux";
+
+import Icon from "metabase/components/Icon";
+import Tooltip from "metabase/components/Tooltip";
+
+import { Bookmark, BookmarkableEntities } from "metabase-types/api";
+import Bookmarks from "metabase/entities/bookmarks";
+import * as Urls from "metabase/lib/urls";
+
+import { SidebarLink } from "../SidebarItems";
+import { BookmarkListRoot } from "./BookmarkList.styled";
+
+const mapDispatchToProps = {
+  onDeleteBookmark: ({ id, type }: Bookmark) =>
+    Bookmarks.actions.delete({ id: id.toString(), type }),
+};
+
+function getIconForEntityType(type: BookmarkableEntities) {
+  const icons = {
+    card: "grid",
+    collection: "folder",
+    dashboard: "dashboard",
+  };
+  return icons[type];
+}
+
+interface CollectionSidebarBookmarksProps {
+  bookmarks: Bookmark[];
+  currentPathname: string;
+  onDeleteBookmark: (bookmark: Bookmark) => void;
+}
+
+const BookmarkList = ({
+  bookmarks,
+  currentPathname,
+  onDeleteBookmark,
+}: CollectionSidebarBookmarksProps) => {
+  return (
+    <BookmarkListRoot>
+      {bookmarks.map(bookmark => {
+        const { id, name, type } = bookmark;
+        const url = Urls.bookmark(bookmark);
+        const onRemove = () => onDeleteBookmark(bookmark);
+        return (
+          <SidebarLink
+            key={`bookmark-${id}`}
+            url={url}
+            icon={getIconForEntityType(type)}
+            isSelected={currentPathname.startsWith(url)}
+            right={
+              <button onClick={onRemove}>
+                <Tooltip tooltip={t`Remove bookmark`} placement="bottom">
+                  <Icon name="bookmark" />
+                </Tooltip>
+              </button>
+            }
+          >
+            {name}
+          </SidebarLink>
+        );
+      })}
+    </BookmarkListRoot>
+  );
+};
+
+export default connect(null, mapDispatchToProps)(BookmarkList);

--- a/frontend/src/metabase/nav/containers/MainNavbar/BookmarkList/BookmarkList.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/BookmarkList/BookmarkList.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback } from "react";
 import { t } from "ttag";
 import { connect } from "react-redux";
 
@@ -12,7 +12,7 @@ import * as Urls from "metabase/lib/urls";
 
 import { SelectedItem } from "../types";
 import { SidebarHeading } from "../MainNavbar.styled";
-import { BookmarkListRoot, SidebarBookmarkItem } from "./BookmarkList.styled";
+import { SidebarBookmarkItem } from "./BookmarkList.styled";
 
 const mapDispatchToProps = {
   onDeleteBookmark: ({ item_id, type }: Bookmark) =>

--- a/frontend/src/metabase/nav/containers/MainNavbar/BookmarkList/BookmarkList.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/BookmarkList/BookmarkList.tsx
@@ -6,7 +6,7 @@ import CollapseSection from "metabase/components/CollapseSection";
 import Icon from "metabase/components/Icon";
 import Tooltip from "metabase/components/Tooltip";
 
-import { Bookmark, BookmarkableEntities } from "metabase-types/api";
+import { Bookmark } from "metabase-types/api";
 import Bookmarks from "metabase/entities/bookmarks";
 import * as Urls from "metabase/lib/urls";
 
@@ -18,15 +18,6 @@ const mapDispatchToProps = {
   onDeleteBookmark: ({ item_id, type }: Bookmark) =>
     Bookmarks.actions.delete({ id: item_id, type }),
 };
-
-function getIconForEntityType(type: BookmarkableEntities) {
-  const icons = {
-    card: "grid",
-    collection: "folder",
-    dashboard: "dashboard",
-  };
-  return icons[type];
-}
 
 interface CollectionSidebarBookmarksProps {
   bookmarks: Bookmark[];
@@ -60,13 +51,14 @@ const BookmarkList = ({
           selectedItem.type !== "collection" &&
           selectedItem.type === type &&
           selectedItem.id === item_id;
+        const icon = Bookmarks.objectSelectors.getIcon(bookmark);
         const url = Urls.bookmark(bookmark);
         const onRemove = () => onDeleteBookmark(bookmark);
         return (
           <SidebarBookmarkItem
             key={`bookmark-${id}`}
             url={url}
-            icon={getIconForEntityType(type)}
+            icon={icon}
             isSelected={isSelected}
             right={
               <button onClick={onRemove}>

--- a/frontend/src/metabase/nav/containers/MainNavbar/BookmarkList/BookmarkList.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/BookmarkList/BookmarkList.tsx
@@ -1,12 +1,15 @@
 import React, { useCallback } from "react";
 import { t } from "ttag";
 import { connect } from "react-redux";
+import _ from "underscore";
 
 import CollapseSection from "metabase/components/CollapseSection";
 import Icon from "metabase/components/Icon";
+import { TreeNode } from "metabase/components/tree/TreeNode";
 import Tooltip from "metabase/components/Tooltip";
 
 import { Bookmark } from "metabase-types/api";
+import { PLUGIN_COLLECTIONS } from "metabase/plugins";
 import Bookmarks from "metabase/entities/bookmarks";
 import * as Urls from "metabase/lib/urls";
 
@@ -28,6 +31,22 @@ interface CollectionSidebarBookmarksProps {
 const BOOKMARKS_INITIALLY_VISIBLE =
   localStorage.getItem("shouldDisplayBookmarks") !== "false";
 
+function BookmarkIcon({ bookmark }: { bookmark: Bookmark }) {
+  const icon = Bookmarks.objectSelectors.getIcon(bookmark);
+  const isOfficialCollection =
+    bookmark.type === "collection" &&
+    !PLUGIN_COLLECTIONS.isRegularCollection(bookmark);
+
+  // Make sure bookmarks have unified icon color except for official collections
+  const iconProps = isOfficialCollection ? icon : _.omit(icon, "color");
+
+  return (
+    <TreeNode.IconContainer transparent={!isOfficialCollection}>
+      <Icon {...iconProps} />
+    </TreeNode.IconContainer>
+  );
+}
+
 const BookmarkList = ({
   bookmarks,
   selectedItem,
@@ -45,14 +64,13 @@ const BookmarkList = ({
         selectedItem.type !== "collection" &&
         selectedItem.type === type &&
         selectedItem.id === item_id;
-      const icon = Bookmarks.objectSelectors.getIcon(bookmark);
       const url = Urls.bookmark(bookmark);
       const onRemove = () => onDeleteBookmark(bookmark);
       return (
         <SidebarBookmarkItem
           key={`bookmark-${id}`}
           url={url}
-          icon={icon}
+          icon={<BookmarkIcon bookmark={bookmark} />}
           isSelected={isSelected}
           right={
             <button onClick={onRemove}>

--- a/frontend/src/metabase/nav/containers/MainNavbar/BookmarkList/BookmarkList.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/BookmarkList/BookmarkList.tsx
@@ -10,7 +10,7 @@ import { Bookmark } from "metabase-types/api";
 import Bookmarks from "metabase/entities/bookmarks";
 import * as Urls from "metabase/lib/urls";
 
-import { SelectedItem } from "../types";
+import { SelectedEntityItem } from "../types";
 import { SidebarHeading } from "../MainNavbar.styled";
 import { SidebarBookmarkItem } from "./BookmarkList.styled";
 
@@ -21,7 +21,7 @@ const mapDispatchToProps = {
 
 interface CollectionSidebarBookmarksProps {
   bookmarks: Bookmark[];
-  selectedItem: SelectedItem;
+  selectedItem?: SelectedEntityItem;
   onDeleteBookmark: (bookmark: Bookmark) => void;
 }
 
@@ -37,6 +37,38 @@ const BookmarkList = ({
     localStorage.setItem("shouldDisplayBookmarks", String(isVisible));
   }, []);
 
+  const renderBookmark = useCallback(
+    bookmark => {
+      const { id, item_id, name, type } = bookmark;
+      const isSelected =
+        selectedItem &&
+        selectedItem.type !== "collection" &&
+        selectedItem.type === type &&
+        selectedItem.id === item_id;
+      const icon = Bookmarks.objectSelectors.getIcon(bookmark);
+      const url = Urls.bookmark(bookmark);
+      const onRemove = () => onDeleteBookmark(bookmark);
+      return (
+        <SidebarBookmarkItem
+          key={`bookmark-${id}`}
+          url={url}
+          icon={icon}
+          isSelected={isSelected}
+          right={
+            <button onClick={onRemove}>
+              <Tooltip tooltip={t`Remove bookmark`} placement="bottom">
+                <Icon name="bookmark" />
+              </Tooltip>
+            </button>
+          }
+        >
+          {name}
+        </SidebarBookmarkItem>
+      );
+    },
+    [selectedItem, onDeleteBookmark],
+  );
+
   return (
     <CollapseSection
       header={<SidebarHeading>{t`Bookmarks`}</SidebarHeading>}
@@ -45,33 +77,7 @@ const BookmarkList = ({
       iconSize={8}
       onToggle={onToggleBookmarks}
     >
-      {bookmarks.map(bookmark => {
-        const { id, item_id, name, type } = bookmark;
-        const isSelected =
-          selectedItem.type !== "collection" &&
-          selectedItem.type === type &&
-          selectedItem.id === item_id;
-        const icon = Bookmarks.objectSelectors.getIcon(bookmark);
-        const url = Urls.bookmark(bookmark);
-        const onRemove = () => onDeleteBookmark(bookmark);
-        return (
-          <SidebarBookmarkItem
-            key={`bookmark-${id}`}
-            url={url}
-            icon={icon}
-            isSelected={isSelected}
-            right={
-              <button onClick={onRemove}>
-                <Tooltip tooltip={t`Remove bookmark`} placement="bottom">
-                  <Icon name="bookmark" />
-                </Tooltip>
-              </button>
-            }
-          >
-            {name}
-          </SidebarBookmarkItem>
-        );
-      })}
+      {bookmarks.map(renderBookmark)}
     </CollapseSection>
   );
 };

--- a/frontend/src/metabase/nav/containers/MainNavbar/BookmarkList/index.ts
+++ b/frontend/src/metabase/nav/containers/MainNavbar/BookmarkList/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./BookmarkList";

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.styled.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.styled.tsx
@@ -1,0 +1,35 @@
+import styled from "@emotion/styled";
+
+import { SIDEBAR_WIDTH } from "metabase/collections/constants";
+
+import { color } from "metabase/lib/colors";
+import { space } from "metabase/styled-components/theme";
+import { breakpointMinSmall } from "metabase/styled-components/theme/media-queries";
+
+export const Sidebar = styled.aside`
+  display: flex;
+  flex-direction: column;
+  box-sizing: border-box;
+  padding-top: ${space(1)};
+  width: 0;
+
+  overflow-x: hidden;
+  overflow-y: auto;
+
+  background-color: transparent;
+
+  ${breakpointMinSmall} {
+    width: ${SIDEBAR_WIDTH};
+  }
+`;
+
+export const LoadingContainer = styled.div`
+  color: ${color("brand")};
+  text-align: center;
+`;
+
+export const LoadingTitle = styled.h2`
+  color: ${color("text-light")};
+  font-weight: 400;
+  margin-top: ${space(1)};
+`;

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.styled.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.styled.tsx
@@ -23,6 +23,14 @@ export const Sidebar = styled.aside`
   }
 `;
 
+export const SidebarHeading = styled.h4`
+  color: ${color("text-medium")};
+  font-weight: 700;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.45px;
+`;
+
 export const LoadingContainer = styled.div`
   color: ${color("brand")};
   text-align: center;

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.styled.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.styled.tsx
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 
-import { SIDEBAR_WIDTH } from "metabase/collections/constants";
+import { NAV_SIDEBAR_WIDTH } from "metabase/nav/constants";
 
 import { color } from "metabase/lib/colors";
 import { space } from "metabase/styled-components/theme";
@@ -19,7 +19,7 @@ export const Sidebar = styled.aside`
   background-color: transparent;
 
   ${breakpointMinSmall} {
-    width: ${SIDEBAR_WIDTH};
+    width: ${NAV_SIDEBAR_WIDTH};
   }
 `;
 

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.styled.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.styled.tsx
@@ -33,3 +33,8 @@ export const LoadingTitle = styled.h2`
   font-weight: 400;
   margin-top: ${space(1)};
 `;
+
+export const ProfileLinkContainer = styled.div`
+  margin-left: auto;
+  margin-right: ${space(2)};
+`;

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer.tsx
@@ -3,6 +3,7 @@ import { t } from "ttag";
 import { connect } from "react-redux";
 import _ from "underscore";
 
+import { IconProps } from "metabase/components/Icon";
 import LoadingSpinner from "metabase/components/LoadingSpinner";
 
 import { Bookmark, Collection, User } from "metabase-types/api";
@@ -10,14 +11,13 @@ import Bookmarks from "metabase/entities/bookmarks";
 import Collections, {
   ROOT_COLLECTION,
   getCollectionIcon,
+  buildCollectionTree,
 } from "metabase/entities/collections";
 import { getHasDataAccess } from "metabase/new_query/selectors";
 import { getUser } from "metabase/selectors/user";
 import {
-  buildCollectionTree,
   nonPersonalOrArchivedCollection,
   currentUserPersonalCollections,
-  CollectionTreeItem,
 } from "metabase/collections/utils";
 import * as Urls from "metabase/lib/urls";
 
@@ -30,6 +30,11 @@ function mapStateToProps(state: unknown) {
     currentUser: getUser(state),
     hasDataAccess: getHasDataAccess(state),
   };
+}
+
+interface CollectionTreeItem extends Collection {
+  icon: string | IconProps;
+  children: CollectionTreeItem[];
 }
 
 type Props = {

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer.tsx
@@ -11,6 +11,7 @@ import Collections, {
   ROOT_COLLECTION,
   getCollectionIcon,
 } from "metabase/entities/collections";
+import { getHasDataAccess } from "metabase/new_query/selectors";
 import { getUser } from "metabase/selectors/user";
 import {
   buildCollectionTree,
@@ -27,6 +28,7 @@ import { Sidebar, LoadingContainer, LoadingTitle } from "./MainNavbar.styled";
 function mapStateToProps(state: unknown) {
   return {
     currentUser: getUser(state),
+    hasDataAccess: getHasDataAccess(state),
   };
 }
 
@@ -35,6 +37,7 @@ type Props = {
   bookmarks: Bookmark[];
   collections: Collection[];
   rootCollection: Collection;
+  hasDataAccess: boolean;
   allFetched: boolean;
   location: {
     pathname: string;
@@ -48,6 +51,7 @@ function MainNavbarContainer({
   currentUser,
   collections = [],
   rootCollection,
+  hasDataAccess,
   allFetched,
   location,
   params,
@@ -105,6 +109,7 @@ function MainNavbarContainer({
           currentUser={currentUser}
           collections={collectionTree}
           selectedItem={selectedItem}
+          hasDataAccess={hasDataAccess}
         />
       ) : (
         <LoadingContainer>

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer.tsx
@@ -1,0 +1,105 @@
+import React, { useMemo } from "react";
+import { t } from "ttag";
+import { connect } from "react-redux";
+import _ from "underscore";
+
+import LoadingSpinner from "metabase/components/LoadingSpinner";
+
+import { Bookmark, Collection, User } from "metabase-types/api";
+import Collections, {
+  ROOT_COLLECTION,
+  getCollectionIcon,
+} from "metabase/entities/collections";
+import { getUser } from "metabase/selectors/user";
+import {
+  buildCollectionTree,
+  nonPersonalOrArchivedCollection,
+  currentUserPersonalCollections,
+  CollectionTreeItem,
+} from "metabase/collections/utils";
+
+import MainNavbarView from "./MainNavbarView";
+import { Sidebar, LoadingContainer, LoadingTitle } from "./MainNavbar.styled";
+
+function mapStateToProps(state: unknown) {
+  return {
+    currentUser: getUser(state),
+  };
+}
+
+type Props = {
+  currentUser: User;
+  bookmarks: Bookmark[];
+  collections: Collection[];
+  rootCollection: Collection;
+  allFetched: boolean;
+  location: {
+    pathname: string;
+  };
+};
+
+function MainNavbarContainer({
+  currentUser,
+  collections = [],
+  rootCollection,
+  allFetched,
+  location,
+  ...props
+}: Props) {
+  const collectionTree = useMemo<CollectionTreeItem[]>(() => {
+    if (!rootCollection) {
+      return [];
+    }
+
+    const preparedCollections = [];
+    const userPersonalCollections = currentUserPersonalCollections(
+      collections,
+      currentUser.id,
+    );
+    const nonPersonalOrArchivedCollections = collections.filter(
+      nonPersonalOrArchivedCollection,
+    );
+
+    preparedCollections.push(...userPersonalCollections);
+    preparedCollections.push(...nonPersonalOrArchivedCollections);
+
+    const root: CollectionTreeItem = {
+      ...rootCollection,
+      icon: getCollectionIcon(rootCollection),
+      children: [],
+    };
+
+    return [root, ...buildCollectionTree(preparedCollections)];
+  }, [rootCollection, collections, currentUser]);
+
+  return (
+    <Sidebar>
+      {allFetched && rootCollection ? (
+        <MainNavbarView
+          {...props}
+          currentUser={currentUser}
+          collections={collectionTree}
+          currentPathname={location.pathname}
+        />
+      ) : (
+        <LoadingContainer>
+          <LoadingSpinner />
+          <LoadingTitle>{t`Loading…`}</LoadingTitle>
+        </LoadingContainer>
+      )}
+    </Sidebar>
+  );
+}
+
+export default _.compose(
+  Collections.load({
+    id: ROOT_COLLECTION.id,
+    entityAlias: "rootCollection",
+    loadingAndErrorWrapper: false,
+  }),
+  Collections.loadList({
+    query: () => ({ tree: true }),
+    loadingAndErrorWrapper: false,
+  }),
+  connect(mapStateToProps),
+)(MainNavbarContainer);

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer.tsx
@@ -18,7 +18,9 @@ import {
   currentUserPersonalCollections,
   CollectionTreeItem,
 } from "metabase/collections/utils";
+import * as Urls from "metabase/lib/urls";
 
+import { SelectedItem } from "./types";
 import MainNavbarView from "./MainNavbarView";
 import { Sidebar, LoadingContainer, LoadingTitle } from "./MainNavbar.styled";
 
@@ -37,6 +39,9 @@ type Props = {
   location: {
     pathname: string;
   };
+  params: {
+    slug?: string;
+  };
 };
 
 function MainNavbarContainer({
@@ -45,8 +50,24 @@ function MainNavbarContainer({
   rootCollection,
   allFetched,
   location,
+  params,
   ...props
 }: Props) {
+  const selectedItem = useMemo<SelectedItem>(() => {
+    const { pathname } = location;
+    const { slug } = params;
+    if (pathname.startsWith("/collection")) {
+      return { type: "collection", id: Urls.extractEntityId(slug) };
+    }
+    if (pathname.startsWith("/dashboard")) {
+      return { type: "dashboard", id: Urls.extractEntityId(slug) };
+    }
+    if (pathname.startsWith("/question") || pathname.startsWith("/model")) {
+      return { type: "card", id: Urls.extractEntityId(slug) };
+    }
+    return { type: "unknown", url: pathname };
+  }, [location, params]);
+
   const collectionTree = useMemo<CollectionTreeItem[]>(() => {
     if (!rootCollection) {
       return [];
@@ -80,7 +101,7 @@ function MainNavbarContainer({
           {...props}
           currentUser={currentUser}
           collections={collectionTree}
-          currentPathname={location.pathname}
+          selectedItem={selectedItem}
         />
       ) : (
         <LoadingContainer>

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer.tsx
@@ -6,6 +6,7 @@ import _ from "underscore";
 import LoadingSpinner from "metabase/components/LoadingSpinner";
 
 import { Bookmark, Collection, User } from "metabase-types/api";
+import Bookmarks from "metabase/entities/bookmarks";
 import Collections, {
   ROOT_COLLECTION,
   getCollectionIcon,
@@ -92,6 +93,9 @@ function MainNavbarContainer({
 }
 
 export default _.compose(
+  Bookmarks.loadList({
+    loadingAndErrorWrapper: false,
+  }),
   Collections.load({
     id: ROOT_COLLECTION.id,
     entityAlias: "rootCollection",

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer.tsx
@@ -57,7 +57,10 @@ function MainNavbarContainer({
     const { pathname } = location;
     const { slug } = params;
     if (pathname.startsWith("/collection")) {
-      return { type: "collection", id: Urls.extractEntityId(slug) };
+      const id = pathname.startsWith("/collection/users")
+        ? "users"
+        : Urls.extractCollectionId(slug);
+      return { type: "collection", id };
     }
     if (pathname.startsWith("/dashboard")) {
       return { type: "dashboard", id: Urls.extractEntityId(slug) };

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarView.tsx
@@ -35,6 +35,8 @@ function MainNavbarView({
   selectedItem,
 }: Props) {
   const isMiscLinkSelected = selectedItem.type === "unknown";
+  const isCollectionSelected =
+    selectedItem.type === "collection" && selectedItem.id !== "users";
 
   const CollectionLink = useMemo(() => {
     return React.forwardRef<HTMLLIElement, TreeNodeProps>(
@@ -57,9 +59,7 @@ function MainNavbarView({
       )}
       <Tree
         data={collections}
-        selectedId={
-          selectedItem.type === "collection" ? selectedItem.id : undefined
-        }
+        selectedId={isCollectionSelected ? selectedItem.id : undefined}
         TreeNode={CollectionLink}
       />
       <ul>

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarView.tsx
@@ -79,8 +79,8 @@ function MainNavbarView({
               icon="table_spaced"
               url={OTHER_USERS_COLLECTIONS_URL}
               isSelected={
-                isMiscLinkSelected &&
-                selectedItem.url.startsWith(OTHER_USERS_COLLECTIONS_URL)
+                selectedItem.type === "collection" &&
+                selectedItem.id === "users"
               }
             >
               {t`Other users' personal collections`}

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarView.tsx
@@ -58,7 +58,6 @@ function MainNavbarView({
     <>
       {bookmarks.length > 0 && (
         <>
-          <SidebarHeading>{t`Bookmarks`}</SidebarHeading>
           <BookmarkList bookmarks={bookmarks} selectedItem={selectedItem} />
           <SidebarHeading>{t`Collections`}</SidebarHeading>
         </>

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarView.tsx
@@ -61,6 +61,7 @@ function MainNavbarView({
         data={collections}
         selectedId={isCollectionSelected ? selectedItem.id : undefined}
         TreeNode={CollectionLink}
+        role="tree"
       />
       <ul>
         <SidebarLink

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarView.tsx
@@ -1,0 +1,43 @@
+import React, { useMemo } from "react";
+import _ from "underscore";
+
+import { Tree } from "metabase/components/tree";
+import { TreeNodeProps } from "metabase/components/tree/types";
+
+import * as Urls from "metabase/lib/urls";
+import { CollectionTreeItem } from "metabase/collections/utils";
+
+import { SidebarCollectionLink } from "./SidebarItems";
+
+type Props = {
+  currentPathname: string;
+  collections: CollectionTreeItem[];
+};
+
+function MainNavbarView({ currentPathname, collections }: Props) {
+  const CollectionLink = useMemo(() => {
+    return React.forwardRef<HTMLLIElement, TreeNodeProps>(
+      function CollectionLink(props: TreeNodeProps, ref) {
+        const { item } = props;
+        const url = Urls.collection(item);
+        const isSelected = currentPathname.startsWith(url);
+        return (
+          <SidebarCollectionLink
+            {...props}
+            url={url}
+            isSelected={isSelected}
+            ref={ref}
+          />
+        );
+      },
+    );
+  }, [currentPathname]);
+
+  return (
+    <>
+      <Tree data={collections} TreeNode={CollectionLink} />
+    </>
+  );
+}
+
+export default MainNavbarView;

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarView.tsx
@@ -9,6 +9,10 @@ import { TreeNodeProps } from "metabase/components/tree/types";
 
 import ProfileLink from "metabase/nav/components/ProfileLink";
 
+import {
+  getCollectionIcon,
+  PERSONAL_COLLECTIONS,
+} from "metabase/entities/collections";
 import * as Urls from "metabase/lib/urls";
 import { CollectionTreeItem } from "metabase/collections/utils";
 
@@ -80,7 +84,7 @@ function MainNavbarView({
         )}
         {currentUser.is_superuser && (
           <SidebarLink
-            icon="table_spaced"
+            icon={getCollectionIcon(PERSONAL_COLLECTIONS)}
             url={OTHER_USERS_COLLECTIONS_URL}
             isSelected={
               selectedItem.type === "collection" && selectedItem.id === "users"

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarView.tsx
@@ -22,6 +22,7 @@ type Props = {
   bookmarks: Bookmark[];
   collections: CollectionTreeItem[];
   selectedItem: SelectedItem;
+  hasDataAccess: boolean;
 };
 
 const BROWSE_URL = "/browse";
@@ -33,6 +34,7 @@ function MainNavbarView({
   bookmarks,
   collections,
   selectedItem,
+  hasDataAccess,
 }: Props) {
   const isMiscLinkSelected = selectedItem.type === "unknown";
   const isCollectionSelected =
@@ -64,39 +66,38 @@ function MainNavbarView({
         role="tree"
       />
       <ul>
-        <SidebarLink
-          icon="table_spaced"
-          url={BROWSE_URL}
-          isSelected={
-            isMiscLinkSelected && selectedItem.url.startsWith(BROWSE_URL)
-          }
-          data-metabase-event="NavBar;Data Browse"
-        >
-          {t`Browse data`}
-        </SidebarLink>
-        {currentUser.is_superuser && (
-          <>
-            <SidebarLink
-              icon="table_spaced"
-              url={OTHER_USERS_COLLECTIONS_URL}
-              isSelected={
-                selectedItem.type === "collection" &&
-                selectedItem.id === "users"
-              }
-            >
-              {t`Other users' personal collections`}
-            </SidebarLink>
-            <SidebarLink
-              icon="view_archive"
-              url={ARCHIVE_URL}
-              isSelected={
-                isMiscLinkSelected && selectedItem.url.startsWith(ARCHIVE_URL)
-              }
-            >
-              {t`View archive`}
-            </SidebarLink>
-          </>
+        {hasDataAccess && (
+          <SidebarLink
+            icon="table_spaced"
+            url={BROWSE_URL}
+            isSelected={
+              isMiscLinkSelected && selectedItem.url.startsWith(BROWSE_URL)
+            }
+            data-metabase-event="NavBar;Data Browse"
+          >
+            {t`Browse data`}
+          </SidebarLink>
         )}
+        {currentUser.is_superuser && (
+          <SidebarLink
+            icon="table_spaced"
+            url={OTHER_USERS_COLLECTIONS_URL}
+            isSelected={
+              selectedItem.type === "collection" && selectedItem.id === "users"
+            }
+          >
+            {t`Other users' personal collections`}
+          </SidebarLink>
+        )}
+        <SidebarLink
+          icon="view_archive"
+          url={ARCHIVE_URL}
+          isSelected={
+            isMiscLinkSelected && selectedItem.url.startsWith(ARCHIVE_URL)
+          }
+        >
+          {t`View archive`}
+        </SidebarLink>
       </ul>
       <ProfileLinkContainer>
         <ProfileLink user={currentUser} />

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarView.tsx
@@ -12,15 +12,16 @@ import ProfileLink from "metabase/nav/components/ProfileLink";
 import * as Urls from "metabase/lib/urls";
 import { CollectionTreeItem } from "metabase/collections/utils";
 
+import { SelectedItem } from "./types";
 import BookmarkList from "./BookmarkList";
 import { SidebarCollectionLink, SidebarLink } from "./SidebarItems";
 import { SidebarHeading, ProfileLinkContainer } from "./MainNavbar.styled";
 
 type Props = {
   currentUser: User;
-  currentPathname: string;
   bookmarks: Bookmark[];
   collections: CollectionTreeItem[];
+  selectedItem: SelectedItem;
 };
 
 const BROWSE_URL = "/browse";
@@ -29,46 +30,45 @@ const ARCHIVE_URL = "/archive";
 
 function MainNavbarView({
   currentUser,
-  currentPathname,
   bookmarks,
   collections,
+  selectedItem,
 }: Props) {
+  const isMiscLinkSelected = selectedItem.type === "unknown";
+
   const CollectionLink = useMemo(() => {
     return React.forwardRef<HTMLLIElement, TreeNodeProps>(
       function CollectionLink(props: TreeNodeProps, ref) {
         const { item } = props;
         const url = Urls.collection(item);
-        const isSelected = currentPathname.startsWith(url);
-        return (
-          <SidebarCollectionLink
-            {...props}
-            url={url}
-            isSelected={isSelected}
-            ref={ref}
-          />
-        );
+        return <SidebarCollectionLink {...props} url={url} ref={ref} />;
       },
     );
-  }, [currentPathname]);
+  }, []);
 
   return (
     <>
       {bookmarks.length > 0 && (
         <>
           <SidebarHeading>{t`Bookmarks`}</SidebarHeading>
-          <BookmarkList
-            bookmarks={bookmarks}
-            currentPathname={currentPathname}
-          />
+          <BookmarkList bookmarks={bookmarks} selectedItem={selectedItem} />
           <SidebarHeading>{t`Collections`}</SidebarHeading>
         </>
       )}
-      <Tree data={collections} TreeNode={CollectionLink} />
+      <Tree
+        data={collections}
+        selectedId={
+          selectedItem.type === "collection" ? selectedItem.id : undefined
+        }
+        TreeNode={CollectionLink}
+      />
       <ul>
         <SidebarLink
           icon="table_spaced"
           url={BROWSE_URL}
-          isSelected={currentPathname.startsWith(BROWSE_URL)}
+          isSelected={
+            isMiscLinkSelected && selectedItem.url.startsWith(BROWSE_URL)
+          }
           data-metabase-event="NavBar;Data Browse"
         >
           {t`Browse data`}
@@ -78,16 +78,19 @@ function MainNavbarView({
             <SidebarLink
               icon="table_spaced"
               url={OTHER_USERS_COLLECTIONS_URL}
-              isSelected={currentPathname.startsWith(
-                OTHER_USERS_COLLECTIONS_URL,
-              )}
+              isSelected={
+                isMiscLinkSelected &&
+                selectedItem.url.startsWith(OTHER_USERS_COLLECTIONS_URL)
+              }
             >
               {t`Other users' personal collections`}
             </SidebarLink>
             <SidebarLink
               icon="view_archive"
               url={ARCHIVE_URL}
-              isSelected={currentPathname.startsWith(ARCHIVE_URL)}
+              isSelected={
+                isMiscLinkSelected && selectedItem.url.startsWith(ARCHIVE_URL)
+              }
             >
               {t`View archive`}
             </SidebarLink>

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarView.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
-import { User } from "metabase-types/api";
+import { Bookmark, User } from "metabase-types/api";
 
 import { Tree } from "metabase/components/tree";
 import { TreeNodeProps } from "metabase/components/tree/types";
@@ -12,12 +12,14 @@ import ProfileLink from "metabase/nav/components/ProfileLink";
 import * as Urls from "metabase/lib/urls";
 import { CollectionTreeItem } from "metabase/collections/utils";
 
+import BookmarkList from "./BookmarkList";
 import { SidebarCollectionLink, SidebarLink } from "./SidebarItems";
 import { SidebarHeading, ProfileLinkContainer } from "./MainNavbar.styled";
 
 type Props = {
   currentUser: User;
   currentPathname: string;
+  bookmarks: Bookmark[];
   collections: CollectionTreeItem[];
 };
 
@@ -25,7 +27,12 @@ const BROWSE_URL = "/browse";
 const OTHER_USERS_COLLECTIONS_URL = Urls.collection({ id: "users" });
 const ARCHIVE_URL = "/archive";
 
-function MainNavbarView({ currentUser, currentPathname, collections }: Props) {
+function MainNavbarView({
+  currentUser,
+  currentPathname,
+  bookmarks,
+  collections,
+}: Props) {
   const CollectionLink = useMemo(() => {
     return React.forwardRef<HTMLLIElement, TreeNodeProps>(
       function CollectionLink(props: TreeNodeProps, ref) {
@@ -46,6 +53,16 @@ function MainNavbarView({ currentUser, currentPathname, collections }: Props) {
 
   return (
     <>
+      {bookmarks.length > 0 && (
+        <>
+          <SidebarHeading>{t`Bookmarks`}</SidebarHeading>
+          <BookmarkList
+            bookmarks={bookmarks}
+            currentPathname={currentPathname}
+          />
+          <SidebarHeading>{t`Collections`}</SidebarHeading>
+        </>
+      )}
       <Tree data={collections} TreeNode={CollectionLink} />
       <ul>
         <SidebarLink

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarView.tsx
@@ -7,10 +7,13 @@ import { User } from "metabase-types/api";
 import { Tree } from "metabase/components/tree";
 import { TreeNodeProps } from "metabase/components/tree/types";
 
+import ProfileLink from "metabase/nav/components/ProfileLink";
+
 import * as Urls from "metabase/lib/urls";
 import { CollectionTreeItem } from "metabase/collections/utils";
 
 import { SidebarCollectionLink, SidebarLink } from "./SidebarItems";
+import { SidebarHeading, ProfileLinkContainer } from "./MainNavbar.styled";
 
 type Props = {
   currentUser: User;
@@ -74,6 +77,9 @@ function MainNavbarView({ currentUser, currentPathname, collections }: Props) {
           </>
         )}
       </ul>
+      <ProfileLinkContainer>
+        <ProfileLink user={currentUser} />
+      </ProfileLinkContainer>
     </>
   );
 }

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarView.tsx
@@ -2,8 +2,9 @@ import React, { useMemo } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
-import { Bookmark, User } from "metabase-types/api";
+import { Bookmark, Collection, User } from "metabase-types/api";
 
+import { IconProps } from "metabase/components/Icon";
 import { Tree } from "metabase/components/tree";
 import { TreeNodeProps } from "metabase/components/tree/types";
 
@@ -14,12 +15,16 @@ import {
   PERSONAL_COLLECTIONS,
 } from "metabase/entities/collections";
 import * as Urls from "metabase/lib/urls";
-import { CollectionTreeItem } from "metabase/collections/utils";
 
 import { SelectedItem } from "./types";
 import BookmarkList from "./BookmarkList";
 import { SidebarCollectionLink, SidebarLink } from "./SidebarItems";
 import { SidebarHeading, ProfileLinkContainer } from "./MainNavbar.styled";
+
+interface CollectionTreeItem extends Collection {
+  icon: string | IconProps;
+  children: CollectionTreeItem[];
+}
 
 type Props = {
   currentUser: User;

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarView.tsx
@@ -1,5 +1,8 @@
 import React, { useMemo } from "react";
+import { t } from "ttag";
 import _ from "underscore";
+
+import { User } from "metabase-types/api";
 
 import { Tree } from "metabase/components/tree";
 import { TreeNodeProps } from "metabase/components/tree/types";
@@ -7,14 +10,19 @@ import { TreeNodeProps } from "metabase/components/tree/types";
 import * as Urls from "metabase/lib/urls";
 import { CollectionTreeItem } from "metabase/collections/utils";
 
-import { SidebarCollectionLink } from "./SidebarItems";
+import { SidebarCollectionLink, SidebarLink } from "./SidebarItems";
 
 type Props = {
+  currentUser: User;
   currentPathname: string;
   collections: CollectionTreeItem[];
 };
 
-function MainNavbarView({ currentPathname, collections }: Props) {
+const BROWSE_URL = "/browse";
+const OTHER_USERS_COLLECTIONS_URL = Urls.collection({ id: "users" });
+const ARCHIVE_URL = "/archive";
+
+function MainNavbarView({ currentUser, currentPathname, collections }: Props) {
   const CollectionLink = useMemo(() => {
     return React.forwardRef<HTMLLIElement, TreeNodeProps>(
       function CollectionLink(props: TreeNodeProps, ref) {
@@ -36,6 +44,36 @@ function MainNavbarView({ currentPathname, collections }: Props) {
   return (
     <>
       <Tree data={collections} TreeNode={CollectionLink} />
+      <ul>
+        <SidebarLink
+          icon="table_spaced"
+          url={BROWSE_URL}
+          isSelected={currentPathname.startsWith(BROWSE_URL)}
+          data-metabase-event="NavBar;Data Browse"
+        >
+          {t`Browse data`}
+        </SidebarLink>
+        {currentUser.is_superuser && (
+          <>
+            <SidebarLink
+              icon="table_spaced"
+              url={OTHER_USERS_COLLECTIONS_URL}
+              isSelected={currentPathname.startsWith(
+                OTHER_USERS_COLLECTIONS_URL,
+              )}
+            >
+              {t`Other users' personal collections`}
+            </SidebarLink>
+            <SidebarLink
+              icon="view_archive"
+              url={ARCHIVE_URL}
+              isSelected={currentPathname.startsWith(ARCHIVE_URL)}
+            >
+              {t`View archive`}
+            </SidebarLink>
+          </>
+        )}
+      </ul>
     </>
   );
 }

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarView.tsx
@@ -63,7 +63,12 @@ function MainNavbarView({
     <>
       {bookmarks.length > 0 && (
         <>
-          <BookmarkList bookmarks={bookmarks} selectedItem={selectedItem} />
+          <BookmarkList
+            bookmarks={bookmarks}
+            selectedItem={
+              selectedItem.type !== "unknown" ? selectedItem : undefined
+            }
+          />
           <SidebarHeading>{t`Collections`}</SidebarHeading>
         </>
       )}

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarCollectionLink.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarCollectionLink.tsx
@@ -12,7 +12,7 @@ import { CollectionIcon } from "metabase/collections/components/CollectionIcon";
 
 import { PLUGIN_COLLECTIONS } from "metabase/plugins";
 
-import { FullWidthLink, NodeRoot } from "./SidebarItems.styled";
+import { FullWidthLink, NameContainer, NodeRoot } from "./SidebarItems.styled";
 
 interface SidebarItemLinkProps extends TreeNodeProps {
   url: string;
@@ -82,7 +82,7 @@ const SidebarCollectionLink = React.forwardRef<
               <TreeNode.IconContainer transparent={isRegular}>
                 <CollectionIcon collection={collection} />
               </TreeNode.IconContainer>
-              <TreeNode.NameContainer>{name}</TreeNode.NameContainer>
+              <NameContainer>{name}</NameContainer>
             </FullWidthLink>
           </NodeRoot>
         )}

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarCollectionLink.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarCollectionLink.tsx
@@ -65,13 +65,10 @@ const SidebarCollectionLink = React.forwardRef<
             depth={depth}
             isSelected={isSelected}
             hovered={hovered}
-            onClick={!isExpanded && hasChildren ? onToggleExpand : undefined}
+            onClick={onToggleExpand}
             ref={ref}
           >
-            <TreeNode.ExpandToggleButton
-              onClick={onToggleExpand}
-              hidden={!hasChildren}
-            >
+            <TreeNode.ExpandToggleButton hidden={!hasChildren}>
               <TreeNode.ExpandToggleIcon
                 isExpanded={isExpanded}
                 name="chevronright"

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarCollectionLink.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarCollectionLink.tsx
@@ -2,11 +2,15 @@
 import React, { useCallback, KeyboardEvent } from "react";
 import _ from "underscore";
 
+import { Collection } from "metabase-types/api";
+
 import { TreeNode } from "metabase/components/tree/TreeNode";
 import { TreeNodeProps } from "metabase/components/tree/types";
 
 import CollectionDropTarget from "metabase/containers/dnd/CollectionDropTarget";
 import { CollectionIcon } from "metabase/collections/components/CollectionIcon";
+
+import { PLUGIN_COLLECTIONS } from "metabase/plugins";
 
 import { FullWidthLink, NodeRoot } from "./SidebarItems.styled";
 
@@ -31,6 +35,9 @@ const SidebarCollectionLink = React.forwardRef<
   ref,
 ) {
   const { name } = collection;
+  const isRegular = PLUGIN_COLLECTIONS.isRegularCollection(
+    (collection as unknown) as Collection,
+  );
 
   const onKeyDown = useCallback(
     (event: KeyboardEvent) => {
@@ -72,7 +79,7 @@ const SidebarCollectionLink = React.forwardRef<
               />
             </TreeNode.ExpandToggleButton>
             <FullWidthLink to={url} onKeyDown={onKeyDown}>
-              <TreeNode.IconContainer>
+              <TreeNode.IconContainer transparent={isRegular}>
                 <CollectionIcon collection={collection} />
               </TreeNode.IconContainer>
               <TreeNode.NameContainer>{name}</TreeNode.NameContainer>

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarCollectionLink.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarCollectionLink.tsx
@@ -57,7 +57,7 @@ const SidebarCollectionLink = React.forwardRef<
   );
 
   return (
-    <div>
+    <div data-testid="sidebar-collection-link-root">
       <CollectionDropTarget collection={collection}>
         {({ hovered }: { hovered: boolean }) => (
           <NodeRoot

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarCollectionLink.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarCollectionLink.tsx
@@ -1,0 +1,87 @@
+/* eslint-disable react/prop-types */
+import React, { useCallback, KeyboardEvent } from "react";
+import _ from "underscore";
+
+import { TreeNode } from "metabase/components/tree/TreeNode";
+import { TreeNodeProps } from "metabase/components/tree/types";
+
+import CollectionDropTarget from "metabase/containers/dnd/CollectionDropTarget";
+import { CollectionIcon } from "metabase/collections/components/CollectionIcon";
+
+import { FullWidthLink, NodeRoot } from "./SidebarItems.styled";
+
+interface SidebarItemLinkProps extends TreeNodeProps {
+  url: string;
+}
+
+// eslint-disable-next-line react/display-name
+const SidebarCollectionLink = React.forwardRef<
+  HTMLLIElement,
+  SidebarItemLinkProps
+>(function SidebarCollectionLink(
+  {
+    item: collection,
+    url,
+    depth,
+    isExpanded,
+    isSelected,
+    hasChildren,
+    onToggleExpand,
+  },
+  ref,
+) {
+  const { name } = collection;
+
+  const onKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      if (!hasChildren) {
+        return;
+      }
+      switch (event.key) {
+        case "ArrowRight":
+          !isExpanded && onToggleExpand();
+          break;
+        case "ArrowLeft":
+          isExpanded && onToggleExpand();
+          break;
+      }
+    },
+    [isExpanded, hasChildren, onToggleExpand],
+  );
+
+  return (
+    <div>
+      <CollectionDropTarget collection={collection}>
+        {({ hovered }: { hovered: boolean }) => (
+          <NodeRoot
+            role="treeitem"
+            depth={depth}
+            isSelected={isSelected}
+            hovered={hovered}
+            onClick={!isExpanded && hasChildren ? onToggleExpand : undefined}
+            ref={ref}
+          >
+            <TreeNode.ExpandToggleButton
+              onClick={onToggleExpand}
+              hidden={!hasChildren}
+            >
+              <TreeNode.ExpandToggleIcon
+                isExpanded={isExpanded}
+                name="chevronright"
+                size={12}
+              />
+            </TreeNode.ExpandToggleButton>
+            <FullWidthLink to={url} onKeyDown={onKeyDown}>
+              <TreeNode.IconContainer>
+                <CollectionIcon collection={collection} />
+              </TreeNode.IconContainer>
+              <TreeNode.NameContainer>{name}</TreeNode.NameContainer>
+            </FullWidthLink>
+          </NodeRoot>
+        )}
+      </CollectionDropTarget>
+    </div>
+  );
+});
+
+export default SidebarCollectionLink;

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarItems.styled.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarItems.styled.tsx
@@ -1,0 +1,22 @@
+import styled from "@emotion/styled";
+import { css } from "@emotion/react";
+
+import { TreeNode } from "metabase/components/tree/TreeNode";
+import Link from "metabase/core/components/Link";
+
+import { color } from "metabase/lib/colors";
+
+export const NodeRoot = styled(TreeNode.Root)<{ hovered?: boolean }>`
+  ${props =>
+    props.hovered &&
+    css`
+      color: ${color("text-white")};
+      background-color: ${color("brand")};
+    `}
+`;
+
+export const FullWidthLink = styled(Link)`
+  display: flex;
+  align-items: center;
+  width: 100%;
+`;

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarItems.styled.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarItems.styled.tsx
@@ -1,8 +1,12 @@
+import React from "react";
 import styled from "@emotion/styled";
 import { css } from "@emotion/react";
 
 import { TreeNode } from "metabase/components/tree/TreeNode";
+import Tooltip from "metabase/components/Tooltip";
 import Link from "metabase/core/components/Link";
+
+import { NAV_SIDEBAR_WIDTH } from "metabase/nav/constants";
 
 import { color } from "metabase/lib/colors";
 
@@ -20,3 +24,26 @@ export const FullWidthLink = styled(Link)`
   align-items: center;
   width: 100%;
 `;
+
+const ITEM_NAME_LENGTH_TOOLTIP_THRESHOLD = 35;
+const ITEM_NAME_LABEL_WIDTH = Math.round(
+  parseInt(NAV_SIDEBAR_WIDTH, 10) * 0.75,
+);
+
+const ItemName = styled(TreeNode.NameContainer)`
+  width: ${ITEM_NAME_LABEL_WIDTH}px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+export function NameContainer({ children: itemName }: { children: string }) {
+  if (itemName.length >= ITEM_NAME_LENGTH_TOOLTIP_THRESHOLD) {
+    return (
+      <Tooltip tooltip={itemName} maxWidth="none">
+        <ItemName>{itemName}</ItemName>
+      </Tooltip>
+    );
+  }
+  return <TreeNode.NameContainer>{itemName}</TreeNode.NameContainer>;
+}

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarLink.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarLink.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import _ from "underscore";
+
+import { TreeNode } from "metabase/components/tree/TreeNode";
+import Icon from "metabase/components/Icon";
+
+import { FullWidthLink } from "./SidebarItems.styled";
+
+interface Props {
+  children: string;
+  url: string;
+  icon: string;
+  isSelected?: boolean;
+  right?: React.ReactNode;
+}
+
+function SidebarLink({
+  children,
+  icon,
+  url,
+  isSelected = false,
+  right = null,
+  ...props
+}: Props) {
+  return (
+    <TreeNode.Root depth={0} isSelected={isSelected} {...props}>
+      <FullWidthLink to={url}>
+        {icon && (
+          <TreeNode.IconContainer>
+            <Icon name={icon} />
+          </TreeNode.IconContainer>
+        )}
+        <TreeNode.NameContainer>{children}</TreeNode.NameContainer>
+      </FullWidthLink>
+      {React.isValidElement(right) && right}
+    </TreeNode.Root>
+  );
+}
+
+export default SidebarLink;

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarLink.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarLink.tsx
@@ -4,7 +4,7 @@ import _ from "underscore";
 import { TreeNode } from "metabase/components/tree/TreeNode";
 import Icon from "metabase/components/Icon";
 
-import { FullWidthLink } from "./SidebarItems.styled";
+import { FullWidthLink, NameContainer } from "./SidebarItems.styled";
 
 interface Props {
   children: string;
@@ -30,7 +30,7 @@ function SidebarLink({
             <Icon name={icon} />
           </TreeNode.IconContainer>
         )}
-        <TreeNode.NameContainer>{children}</TreeNode.NameContainer>
+        <NameContainer>{children}</NameContainer>
       </FullWidthLink>
       {React.isValidElement(right) && right}
     </TreeNode.Root>

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarLink.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarLink.tsx
@@ -2,14 +2,14 @@ import React from "react";
 import _ from "underscore";
 
 import { TreeNode } from "metabase/components/tree/TreeNode";
-import Icon from "metabase/components/Icon";
+import Icon, { IconProps } from "metabase/components/Icon";
 
 import { FullWidthLink, NameContainer } from "./SidebarItems.styled";
 
 interface Props {
   children: string;
   url: string;
-  icon: string;
+  icon: string | IconProps;
   isSelected?: boolean;
   right?: React.ReactNode;
 }
@@ -22,12 +22,13 @@ function SidebarLink({
   right = null,
   ...props
 }: Props) {
+  const iconProps = _.isObject(icon) ? icon : { name: icon };
   return (
     <TreeNode.Root depth={0} isSelected={isSelected} {...props}>
       <FullWidthLink to={url}>
-        {icon && (
+        {iconProps && (
           <TreeNode.IconContainer>
-            <Icon name={icon} />
+            <Icon {...iconProps} />
           </TreeNode.IconContainer>
         )}
         <NameContainer>{children}</NameContainer>

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarLink.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarLink.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback } from "react";
 import _ from "underscore";
 
 import { TreeNode } from "metabase/components/tree/TreeNode";
@@ -9,9 +9,15 @@ import { FullWidthLink, NameContainer } from "./SidebarItems.styled";
 interface Props {
   children: string;
   url: string;
-  icon: string | IconProps;
+  icon: string | IconProps | React.ReactElement;
   isSelected?: boolean;
   right?: React.ReactNode;
+}
+
+function isIconPropsObject(
+  icon: string | IconProps | React.ReactNode,
+): icon is IconProps {
+  return _.isObject(icon);
 }
 
 function SidebarLink({
@@ -22,15 +28,22 @@ function SidebarLink({
   right = null,
   ...props
 }: Props) {
-  const iconProps = _.isObject(icon) ? icon : { name: icon };
+  const renderIcon = useCallback(() => {
+    if (React.isValidElement(icon)) {
+      return icon;
+    }
+    const iconProps = isIconPropsObject(icon) ? icon : { name: icon };
+    return (
+      <TreeNode.IconContainer>
+        <Icon {...iconProps} />
+      </TreeNode.IconContainer>
+    );
+  }, [icon]);
+
   return (
     <TreeNode.Root depth={0} isSelected={isSelected} {...props}>
       <FullWidthLink to={url}>
-        {iconProps && (
-          <TreeNode.IconContainer>
-            <Icon {...iconProps} />
-          </TreeNode.IconContainer>
-        )}
+        {icon && renderIcon()}
         <NameContainer>{children}</NameContainer>
       </FullWidthLink>
       {React.isValidElement(right) && right}

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/index.ts
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/index.ts
@@ -1,0 +1,1 @@
+export { default as SidebarCollectionLink } from "./SidebarCollectionLink";

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/index.ts
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/index.ts
@@ -1,1 +1,2 @@
 export { default as SidebarCollectionLink } from "./SidebarCollectionLink";
+export { default as SidebarLink } from "./SidebarLink";

--- a/frontend/src/metabase/nav/containers/MainNavbar/index.ts
+++ b/frontend/src/metabase/nav/containers/MainNavbar/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./MainNavbarContainer";

--- a/frontend/src/metabase/nav/containers/MainNavbar/types.ts
+++ b/frontend/src/metabase/nav/containers/MainNavbar/types.ts
@@ -1,0 +1,11 @@
+type SelectedEntityItem = {
+  type: "card" | "collection" | "dashboard";
+  id?: number | string;
+};
+
+type SelectedNonEntityItem = {
+  type: "unknown";
+  url: string;
+};
+
+export type SelectedItem = SelectedEntityItem | SelectedNonEntityItem;

--- a/frontend/src/metabase/nav/containers/MainNavbar/types.ts
+++ b/frontend/src/metabase/nav/containers/MainNavbar/types.ts
@@ -1,4 +1,4 @@
-type SelectedEntityItem = {
+export type SelectedEntityItem = {
   type: "card" | "collection" | "dashboard";
   id?: number | string;
 };

--- a/frontend/src/metabase/nav/containers/Navbar.jsx
+++ b/frontend/src/metabase/nav/containers/Navbar.jsx
@@ -76,11 +76,11 @@ export default class Navbar extends Component {
   }
 
   renderMainNav() {
-    const { isOpen, location } = this.props;
+    const { isOpen, location, params } = this.props;
     // NOTE: DO NOT REMOVE `Nav` CLASS FOR NOW, USED BY MODALS, FULLSCREEN DASHBOARD, ETC
     return (
       <NavRoot className="Nav" isOpen={isOpen}>
-        <MainNavbar location={location} />
+        <MainNavbar location={location} params={params} />
       </NavRoot>
     );
   }

--- a/frontend/src/metabase/nav/containers/Navbar.jsx
+++ b/frontend/src/metabase/nav/containers/Navbar.jsx
@@ -6,16 +6,9 @@ import { connect } from "react-redux";
 import { push } from "react-router-redux";
 import { withRouter } from "react-router";
 
-import { t } from "ttag";
-
-import * as Urls from "metabase/lib/urls";
-import { color, darken } from "metabase/lib/colors";
-
-import Icon from "metabase/components/Icon";
 import Link from "metabase/core/components/Link";
 import LogoIcon from "metabase/components/LogoIcon";
 import { AdminNavbar } from "../components/AdminNavbar";
-import ProfileLink from "metabase/nav/components/ProfileLink";
 
 import { getPath, getContext, getUser } from "../selectors";
 import {
@@ -32,9 +25,9 @@ const mapStateToProps = (state, props) => ({
   hasDataAccess: getHasDataAccess(state),
 });
 
-import { ProfileLinkContainer, NavRoot } from "./Navbar.styled";
-import CollectionSidebar from "../../collections/containers/CollectionSidebar/CollectionSidebar";
-import Footer from "metabase/collections/components/CollectionSidebar/CollectionSidebarFooter";
+import { NavRoot } from "./Navbar.styled";
+
+import MainNavbar from "./MainNavbar";
 
 const mapDispatchToProps = {
   onChangeLocation: push,
@@ -83,49 +76,11 @@ export default class Navbar extends Component {
   }
 
   renderMainNav() {
-    const { isOpen, hasDataAccess, router, user } = this.props;
-    const collectionId = Urls.extractCollectionId(router.params.slug);
-    const isRoot = collectionId === "root";
-
-    const shouldDisplayMobileSidebar = this.state.shouldDisplayMobileSidebar;
-
+    const { isOpen, location } = this.props;
+    // NOTE: DO NOT REMOVE `Nav` CLASS FOR NOW, USED BY MODALS, FULLSCREEN DASHBOARD, ETC
     return (
-      <NavRoot
-        // NOTE: DO NOT REMOVE `Nav` CLASS FOR NOW, USED BY MODALS, FULLSCREEN DASHBOARD, ETC
-        // TODO: hide nav using state in redux instead?
-        className="Nav"
-        isOpen={isOpen}
-      >
-        <CollectionSidebar
-          isRoot={isRoot}
-          handleToggleMobileSidebar={() => {
-            this.setState({
-              shouldDisplayMobileSidebar: !this.state
-                .shouldDisplayMobileSidebar,
-            });
-          }}
-          collectionId={collectionId}
-          shouldDisplayMobileSidebar={shouldDisplayMobileSidebar}
-        />
-        {hasDataAccess && (
-          <Link
-            mr={[1, 2]}
-            to="browse"
-            p={1}
-            hover={{
-              backgroundColor: darken(color("brand")),
-            }}
-            className="flex align-center rounded transition-background ml2"
-            data-metabase-event={`NavBar;Data Browse`}
-          >
-            <Icon name="table_spaced" size={14} />
-            <h4 className="hide sm-show ml1 text-nowrap">{t`Browse data`}</h4>
-          </Link>
-        )}
-        <Footer isAdmin={user.is_superuser} />
-        <ProfileLinkContainer>
-          <ProfileLink {...this.props} user={user} />
-        </ProfileLinkContainer>
+      <NavRoot className="Nav" isOpen={isOpen}>
+        <MainNavbar location={location} />
       </NavRoot>
     );
   }

--- a/frontend/src/metabase/nav/containers/Navbar.styled.tsx
+++ b/frontend/src/metabase/nav/containers/Navbar.styled.tsx
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
 import { css } from "@emotion/react";
 import { color } from "metabase/lib/colors";
-import { breakpointMinSmall, space } from "metabase/styled-components/theme";
+import { breakpointMinSmall } from "metabase/styled-components/theme";
 
 const openNavbarCSS = css`
   width: 324px;
@@ -63,11 +63,4 @@ export const EntityMenuContainer = styled.div`
   ${breakpointMinSmall} {
     padding-left: 1rem;
   }
-`;
-
-export const ProfileLinkContainer = styled.div`
-  margin-left: auto;
-  position: absolute;
-  bottom: 0;
-  right: ${space(2)};
 `;

--- a/frontend/src/metabase/nav/containers/Navbar.styled.tsx
+++ b/frontend/src/metabase/nav/containers/Navbar.styled.tsx
@@ -19,6 +19,7 @@ export const NavRoot = styled.div<{ isOpen: boolean }>`
   padding: 0.5rem 0;
   background-color: ${color("nav")};
   overflow: auto;
+  overflow-x: hidden;
   z-index: 3;
   flex-shrink: 0;
   border-right: 1px solid ${color("border")};

--- a/frontend/test/metabase/scenarios/collections/collection-types.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collection-types.cy.spec.js
@@ -85,7 +85,7 @@ describeEE("collections types", () => {
 
     getSidebarCollectionChildrenFor("First collection").within(() => {
       expandCollectionChildren("Second collection");
-      cy.icon("badge").should("have.length", 3);
+      cy.icon("badge").should("have.length", 2);
       cy.icon("folder").should("not.exist");
     });
 
@@ -101,8 +101,7 @@ describeEE("collections types", () => {
     });
 
     getSidebarCollectionChildrenFor("First collection").within(() => {
-      expandCollectionChildren("Second collection");
-      cy.icon("folder").should("have.length", 3);
+      cy.icon("folder").should("have.length", 2);
       cy.icon("badge").should("not.exist");
     });
   });
@@ -281,18 +280,17 @@ function editCollection() {
 
 function expandCollectionChildren(collectionName) {
   cy.findByText(collectionName)
-    .parent()
+    .parentsUntil("[data-testid=sidebar-collection-link-root]")
     .find(".Icon-chevronright")
-    .eq(0) // there may be more nested icons, but we need the top level one
     .click();
 }
 
-function getSidebarCollectionChildrenFor(collectionName) {
+function getSidebarCollectionChildrenFor(item) {
   return navigationSidebar()
-    .findByText(collectionName)
-    .closest("a")
+    .findByText(item)
+    .parentsUntil("[data-testid=sidebar-collection-link-root]")
     .parent()
-    .parent();
+    .next("ul");
 }
 
 function setOfficial(official = true) {

--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -430,8 +430,9 @@ describe("scenarios > collection_defaults", () => {
       navigationSidebar()
         .findByText("Your personal collection")
         .parentsUntil("[data-testid=sidebar-collection-link-root]")
-        .find(".Icon-chevronright")
-        .should("not.exist");
+        .within(() => {
+          cy.icon("chevronright").should("not.be.visible");
+        });
 
       // Ensure if sub-collection is archived, the chevron is not displayed
       displaySidebarChildOf("First collection");

--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -432,7 +432,7 @@ describe("scenarios > collection_defaults", () => {
 
       navigationSidebar()
         .findByText("Your personal collection")
-        .parent()
+        .parentsUntil("[data-testid=sidebar-collection-link-root]")
         .find(".Icon-chevronright")
         .should("not.exist");
 
@@ -580,7 +580,6 @@ function selectItemUsingCheckbox(item, icon = "table") {
 function getSidebarCollectionChildrenFor(item) {
   return navigationSidebar()
     .findByText(item)
-    .closest("a")
-    .parent()
-    .parent();
+    .parentsUntil("[data-testid=sidebar-collection-link-root]")
+    .next("ul");
 }

--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -6,6 +6,7 @@ import {
   openOrdersTable,
   navigationSidebar,
   closeNavigationSidebar,
+  openNavigationSidebar,
 } from "__support__/e2e/cypress";
 import { displaySidebarChildOf } from "./helpers/e2e-collections-sidebar.js";
 import { USERS, USER_GROUPS } from "__support__/e2e/cypress_data";
@@ -347,23 +348,19 @@ describe("scenarios > collection_defaults", () => {
       });
       // Make sure the correct value is selected
       cy.findAllByTestId("select-button-content").contains(NEW_COLLECTION);
-      cy.findByText("Update")
-        .closest(".Button")
-        .should("not.be.disabled")
-        .click();
+      cy.button("Update").click();
       // Make sure modal closed
       cy.findByText("Update").should("not.exist");
 
       // Make sure sidebar updated (waiting for a specific XHR didn't help)
-      // Before update, "First collection" was expanded, thus showing "Second collection"
-      cy.findByText("Second collection").should("not.exist");
+      closeNavigationSidebar();
+      openNavigationSidebar();
 
       cy.log(
         "**New collection should immediately be open, showing nested children**",
       );
 
       getSidebarCollectionChildrenFor(NEW_COLLECTION).within(() => {
-        cy.icon("chevrondown").should("have.length", 2); // both target collection and "First collection" are open
         cy.findByText("First collection");
         cy.findByText("Second collection");
       });
@@ -581,5 +578,6 @@ function getSidebarCollectionChildrenFor(item) {
   return navigationSidebar()
     .findByText(item)
     .parentsUntil("[data-testid=sidebar-collection-link-root]")
+    .parent()
     .next("ul");
 }

--- a/frontend/test/metabase/scenarios/collections/helpers/e2e-collections-sidebar.js
+++ b/frontend/test/metabase/scenarios/collections/helpers/e2e-collections-sidebar.js
@@ -1,6 +1,6 @@
 export function displaySidebarChildOf(collectionName) {
   cy.findByText(collectionName)
-    .parent()
+    .parentsUntil("[data-testid=sidebar-collection-link-root]")
     .find(".Icon-chevronright")
     .eq(0) // there may be more nested icons, but we need the top level one
     .click();

--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -849,7 +849,7 @@ function pinItem(item) {
 
 function exposeChildrenFor(collectionName) {
   cy.findByText(collectionName)
-    .parent()
+    .parentsUntil("[data-testid=sidebar-collection-link-root]")
     .find(".Icon-chevronright")
     .eq(0) // there may be more nested icons, but we need the top level one
     .click();

--- a/frontend/test/metabase/scenarios/permissions/admin-permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/admin-permissions.cy.spec.js
@@ -169,7 +169,6 @@ describeOSS("scenarios > admin > permissions", () => {
         false,
       );
 
-      selectSidebarItem("First collection"); // Expand children
       selectSidebarItem("Second collection");
 
       assertPermissionTable([


### PR DESCRIPTION
The PR introduces a dedicated `MainNavbar` component instead of a combo of `CollectionSidebar` with some extra tweaks we currently have for the new navigation. The PR depends on some work from #21287 and #21288

This was a good opportunity to rethink how the collection sidebar tree used to work, so here are the most notable changes:

* completely switched to the `Tree` component that's used in the saved question picker. `Tree` has a lot of benefits (great work @alxnddr!):
   * a11y (HTML list markup, keyboard navigation support)
   * automatically expands selected item's parents when the tree mounts
   * scrolls to initially selected item on mount
* unified list item components used in the sidebar. Now bookmarks, collections, and links at the bottom are based on just two visual components sharing most of their code. As a result, it should be much easier to change their look consistently.
* fixed the selected element highlighting. Now when you open a bookmarked question/dashboard/model or open a link like "Browse data" or "Archive", the sidebar will highlight the selected element correctly
* fixed dragged collection item z-index. Previously, dragged element's z-index was lower than the sidebar's one, so the sidebar was overlapping it.

### To Verify

1. Open any page
2. Use the navigation sidebar and make sure nothing looks weird