### PR TITLE
Repro #21034: Autocomplete flicker in SQL Editor

### DIFF
--- a/frontend/test/metabase/scenarios/native/reproductions/21034-autocomplete-flicker.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/reproductions/21034-autocomplete-flicker.cy.spec.js
@@ -1,0 +1,28 @@
+import { restore, openNativeEditor } from "__support__/e2e/cypress";
+
+describe.skip("issue 21034", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+    openNativeEditor();
+    cy.intercept(
+      "GET",
+      "/api/database/**/autocomplete_suggestions?**",
+      cy.spy().as("suggestions"),
+    );
+  });
+
+  it("should not invoke API calls for autocomplete twice in a row (metabase#18148)", () => {
+    cy.get(".ace_content")
+      .should("be.visible")
+      .type("p");
+
+    // Wait until another explicit autocomplete is triggered
+    // See https://github.com/metabase/metabase/pull/20970
+    cy.wait(1000);
+
+    cy.get("@suggestions")
+      .its("callCount")
+      .should("equal", 1);
+  });
+});

--- a/frontend/test/metabase/scenarios/native/reproductions/21034-autocomplete-flicker.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/reproductions/21034-autocomplete-flicker.cy.spec.js
@@ -18,6 +18,7 @@ describe.skip("issue 21034", () => {
       .type("p");
 
     // Wait until another explicit autocomplete is triggered
+    // (slightly longer than AUTOCOMPLETE_DEBOUNCE_DURATION)
     // See https://github.com/metabase/metabase/pull/20970
     cy.wait(1000);
 


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #21034

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/native/reproductions/21034-autocomplete-flicker.cy.spec.js`
- Unskip repro
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix