### PR TITLE
Remove flicker in SQL editing autocomplete

### DIFF
--- a/frontend/test/metabase/scenarios/native/reproductions/21034-autocomplete-flicker.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/reproductions/21034-autocomplete-flicker.cy.spec.js
@@ -1,6 +1,6 @@
 import { restore, openNativeEditor } from "__support__/e2e/cypress";
 
-describe.skip("issue 21034", () => {
+describe("issue 21034", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();


### PR DESCRIPTION
To reproduce, follow these steps while opening DevTools and watching the Network panel (filter for Fetch/XHR only)

1. New, Native/SQL query, Sample Database
2. Type `p` (and watch the call to `/api/database/1/autocomplete_suggestions?prefix=p`)
3. After sometime, there is a flicker in the UI, particularly the suggestion popover (and another API call in the background)

### Before this PR

Two calls to the `autocomplete_suggestions` API.

![image](https://user-images.githubusercontent.com/7288/160496536-f04cfb0c-a26a-4276-9cea-a39bbd5afe0e.png)

### After this PR

Only one call, hence no flickering.

![Screenshot_20220328_151715](https://user-images.githubusercontent.com/7288/160496590-4f82b4f2-81f0-45b4-8232-0b75eec89605.png)

