### PR TITLE
FE: Subscriptions management permission

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/general_permissions/api.js
+++ b/enterprise/frontend/src/metabase-enterprise/general_permissions/api.js
@@ -1,0 +1,8 @@
+import _ from "underscore";
+
+import { GET, PUT } from "metabase/lib/api";
+
+export const GeneralPermissionsApi = {
+  graph: GET("/api/ee/advanced-permissions/general/graph"),
+  updateGraph: PUT("api/ee/advanced-permissions/general/graph"),
+};

--- a/enterprise/frontend/src/metabase-enterprise/general_permissions/constants.ts
+++ b/enterprise/frontend/src/metabase-enterprise/general_permissions/constants.ts
@@ -1,0 +1,16 @@
+import { t } from "ttag";
+
+export const GENERAL_PERMISSIONS_OPTIONS = {
+  yes: {
+    label: t`Yes`,
+    value: "yes",
+    icon: "check",
+    iconColor: "success",
+  },
+  no: {
+    label: t`No`,
+    value: "no",
+    icon: "close",
+    iconColor: "danger",
+  },
+};

--- a/enterprise/frontend/src/metabase-enterprise/general_permissions/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/general_permissions/index.ts
@@ -1,0 +1,16 @@
+import { PLUGIN_GENERAL_PERMISSIONS, PLUGIN_REDUCERS } from "metabase/plugins";
+import { hasPremiumFeature } from "metabase-enterprise/settings";
+
+import getRoutes from "./routes";
+import { t } from "ttag";
+import { canManageSubscriptions } from "./selectors";
+import generalPermissionsReducer from "./reducer";
+
+if (hasPremiumFeature("advanced_permissions")) {
+  PLUGIN_GENERAL_PERMISSIONS.getRoutes = getRoutes;
+  PLUGIN_GENERAL_PERMISSIONS.tabs = [{ name: t`General`, value: `general` }];
+  PLUGIN_GENERAL_PERMISSIONS.selectors = {
+    canManageSubscriptions,
+  };
+  PLUGIN_REDUCERS.generalPermissionsPlugin = generalPermissionsReducer;
+}

--- a/enterprise/frontend/src/metabase-enterprise/general_permissions/pages/GeneralPermissionsPage/GeneralPermissionsPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/general_permissions/pages/GeneralPermissionsPage/GeneralPermissionsPage.tsx
@@ -1,0 +1,87 @@
+import _ from "underscore";
+import { Route } from "react-router";
+import React, { useCallback, useEffect } from "react";
+import { connect } from "react-redux";
+
+import { PermissionsEditor } from "metabase/admin/permissions/components/PermissionsEditor";
+
+import Groups from "metabase/entities/groups";
+import {
+  getGeneralPermissionEditor,
+  getIsDirty,
+} from "metabase-enterprise/general_permissions/selectors";
+
+import PermissionsPageLayout from "metabase/admin/permissions/components/PermissionsPageLayout";
+import {
+  initializeGeneralPermissions,
+  saveGeneralPermissions,
+  updateGeneralPermission,
+} from "metabase-enterprise/general_permissions/reducer";
+import { GeneralPermissionsState } from "metabase-enterprise/general_permissions/types/state";
+
+const mapDispatchToProps = {
+  initialize: initializeGeneralPermissions,
+  updatePermission: updateGeneralPermission,
+  savePermissions: saveGeneralPermissions,
+};
+
+const mapStateToProps = (state: GeneralPermissionsState) => {
+  return {
+    permissionEditor: getGeneralPermissionEditor(state),
+    isDirty: getIsDirty(state),
+  };
+};
+
+interface GeneralPermissionsPageProps {
+  isDirty: boolean;
+  permissionEditor: any;
+  initialize: () => void;
+  savePermissions: () => void;
+  updatePermission: any;
+  route: Route;
+}
+
+const GeneralPermissionsPage = ({
+  permissionEditor,
+  isDirty,
+  initialize,
+  savePermissions,
+  updatePermission,
+  route,
+}: GeneralPermissionsPageProps) => {
+  useEffect(() => {
+    initialize();
+  }, [initialize]);
+
+  const handlePermissionChange = useCallback(
+    (item, permission, value) => {
+      updatePermission({
+        groupId: item.id,
+        permission,
+        value,
+      });
+    },
+    [updatePermission],
+  );
+  return (
+    <PermissionsPageLayout
+      tab="general"
+      isDirty={isDirty}
+      route={route}
+      onSave={savePermissions}
+      onLoad={() => initialize()}
+    >
+      {permissionEditor && (
+        <PermissionsEditor
+          {...permissionEditor}
+          onChange={handlePermissionChange}
+        />
+      )}
+    </PermissionsPageLayout>
+  );
+};
+
+export default _.compose(
+  Groups.loadList(),
+  connect(mapStateToProps, mapDispatchToProps),
+)(GeneralPermissionsPage);

--- a/enterprise/frontend/src/metabase-enterprise/general_permissions/pages/GeneralPermissionsPage/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/general_permissions/pages/GeneralPermissionsPage/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./GeneralPermissionsPage";

--- a/enterprise/frontend/src/metabase-enterprise/general_permissions/reducer.js
+++ b/enterprise/frontend/src/metabase-enterprise/general_permissions/reducer.js
@@ -1,0 +1,111 @@
+import { assocIn } from "icepick";
+
+import {
+  createAction,
+  createThunkAction,
+  handleActions,
+  combineReducers,
+} from "metabase/lib/redux";
+import * as MetabaseAnalytics from "metabase/lib/analytics";
+import { GeneralPermissionsApi } from "./api";
+
+const INITIALIZE_GENERAL_PERMISSIONS =
+  "metabase-enterprise/general-permissions/INITIALIZE_GENERAL_PERMISSIONS";
+export const initializeGeneralPermissions = createThunkAction(
+  INITIALIZE_GENERAL_PERMISSIONS,
+  () => async dispatch => {
+    dispatch(loadGeneralPermissions());
+  },
+);
+
+const LOAD_GENERAL_PERMISSIONS =
+  "metabase-enterprise/general-permissions/LOAD_GENERAL_PERMISSIONS";
+export const loadGeneralPermissions = createThunkAction(
+  LOAD_GENERAL_PERMISSIONS,
+  () => () => {
+    return GeneralPermissionsApi.graph();
+  },
+);
+
+const UPDATE_GENERAL_PERMISSION =
+  "metabase-enterprise/general-permissions/UPDATE_GENERAL_PERMISSION";
+export const updateGeneralPermission = createAction(
+  UPDATE_GENERAL_PERMISSION,
+  ({ groupId, permission, value }) => {
+    MetabaseAnalytics.trackStructEvent("General Permissions", "save");
+    return {
+      groupId,
+      permission: permission.permission,
+      value,
+    };
+  },
+);
+
+const SAVE_GENERAL_PERMISSIONS =
+  "metabase-enterprise/general-permissions/data/SAVE_GENERAL_PERMISSIONS";
+export const saveGeneralPermissions = createThunkAction(
+  SAVE_GENERAL_PERMISSIONS,
+  () => async (_dispatch, getState) => {
+    MetabaseAnalytics.trackStructEvent("General Permissions", "save");
+
+    const {
+      generalPermissions,
+      generalPermissionsRevision,
+    } = getState().plugins.generalPermissionsPlugin;
+
+    const result = await GeneralPermissionsApi.updateGraph({
+      groups: generalPermissions,
+      revision: generalPermissionsRevision,
+    });
+
+    return result;
+  },
+);
+
+const generalPermissions = handleActions(
+  {
+    [LOAD_GENERAL_PERMISSIONS]: {
+      next: (_state, { payload }) => payload.groups,
+    },
+    [SAVE_GENERAL_PERMISSIONS]: {
+      next: (_state, { payload }) => payload.groups,
+    },
+    [UPDATE_GENERAL_PERMISSION]: {
+      next: (state, { payload }) => {
+        const { groupId, permission, value } = payload;
+        return assocIn(state, [groupId, permission], value);
+      },
+    },
+  },
+  null,
+);
+
+const originalGeneralPermissions = handleActions(
+  {
+    [LOAD_GENERAL_PERMISSIONS]: {
+      next: (_state, { payload }) => payload.groups,
+    },
+    [SAVE_GENERAL_PERMISSIONS]: {
+      next: (_state, { payload }) => payload.groups,
+    },
+  },
+  null,
+);
+
+const generalPermissionsRevision = handleActions(
+  {
+    [LOAD_GENERAL_PERMISSIONS]: {
+      next: (_state, { payload }) => payload.revision,
+    },
+    [SAVE_GENERAL_PERMISSIONS]: {
+      next: (_state, { payload }) => payload.revision,
+    },
+  },
+  null,
+);
+
+export default combineReducers({
+  generalPermissions,
+  originalGeneralPermissions,
+  generalPermissionsRevision,
+});

--- a/enterprise/frontend/src/metabase-enterprise/general_permissions/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/general_permissions/routes.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+import { Route } from "metabase/hoc/Title";
+
+import GeneralPermissionsPage from "./pages/GeneralPermissionsPage";
+
+const getRoutes = () => (
+  <Route path="general" component={GeneralPermissionsPage} />
+);
+
+export default getRoutes;

--- a/enterprise/frontend/src/metabase-enterprise/general_permissions/selectors.ts
+++ b/enterprise/frontend/src/metabase-enterprise/general_permissions/selectors.ts
@@ -1,0 +1,67 @@
+import _ from "underscore";
+import { t } from "ttag";
+import { createSelector } from "reselect";
+import { Group } from "metabase-types/api";
+import { isAdminGroup } from "metabase/lib/groups";
+import { UNABLE_TO_CHANGE_ADMIN_PERMISSIONS } from "metabase/admin/permissions/constants/messages";
+import { getOrderedGroups } from "metabase/admin/permissions/selectors/data-permissions/groups";
+import { GENERAL_PERMISSIONS_OPTIONS } from "./constants";
+import { getIn } from "icepick";
+import { GeneralPermissionsState } from "./types/state";
+
+export const canManageSubscriptions = (state: GeneralPermissionsState) =>
+  state.currentUser.can_access_subscription;
+
+export const getIsDirty = createSelector(
+  (state: GeneralPermissionsState) =>
+    state.plugins.generalPermissionsPlugin?.generalPermissions,
+  state => state.plugins.generalPermissionsPlugin?.originalGeneralPermissions,
+  (permissions, originalPermissions) =>
+    !_.isEqual(permissions, originalPermissions),
+);
+
+export const getGeneralPermissionEditor = createSelector(
+  (state: GeneralPermissionsState) =>
+    state.plugins.generalPermissionsPlugin?.generalPermissions,
+  getOrderedGroups,
+  (permissions, groups: Group[][]) => {
+    if (!permissions || groups == null) {
+      return null;
+    }
+
+    const entities = groups.flat().map(group => {
+      const isAdmin = isAdminGroup(group);
+
+      const subscriptionValue =
+        getIn(permissions, [group.id, "subscription"]) ?? "no";
+
+      return {
+        id: group.id,
+        name: group.name,
+        permissions: [
+          {
+            permission: "subscription",
+            isDisabled: isAdmin,
+            disabledTooltip: isAdmin
+              ? UNABLE_TO_CHANGE_ADMIN_PERMISSIONS
+              : null,
+            value: subscriptionValue,
+            options: [
+              GENERAL_PERMISSIONS_OPTIONS.yes,
+              GENERAL_PERMISSIONS_OPTIONS.no,
+            ],
+          },
+        ],
+      };
+    });
+
+    return {
+      filterPlaceholder: t`Search for a group`,
+      columns: [
+        { name: `General settings access` },
+        { name: `Subscriptions and Alerts` },
+      ],
+      entities,
+    };
+  },
+);

--- a/enterprise/frontend/src/metabase-enterprise/general_permissions/selectors.ts
+++ b/enterprise/frontend/src/metabase-enterprise/general_permissions/selectors.ts
@@ -10,7 +10,7 @@ import { getIn } from "icepick";
 import { GeneralPermissionsState } from "./types/state";
 
 export const canManageSubscriptions = (state: GeneralPermissionsState) =>
-  state.currentUser.can_access_subscription;
+  state.currentUser.permissions.can_access_subscription;
 
 export const getIsDirty = createSelector(
   (state: GeneralPermissionsState) =>

--- a/enterprise/frontend/src/metabase-enterprise/general_permissions/types/permissions.ts
+++ b/enterprise/frontend/src/metabase-enterprise/general_permissions/types/permissions.ts
@@ -1,0 +1,12 @@
+import { GroupId } from "metabase-types/api";
+
+export type GeneralPermissionKey = "subscription";
+export type GeneralPermissionValue = "yes" | "no";
+
+export type GroupGeneralPermissions = {
+  [key in GeneralPermissionKey]: GeneralPermissionValue;
+};
+
+export type GeneralPermissions = {
+  [key: GroupId]: GroupGeneralPermissions;
+};

--- a/enterprise/frontend/src/metabase-enterprise/general_permissions/types/state.ts
+++ b/enterprise/frontend/src/metabase-enterprise/general_permissions/types/state.ts
@@ -1,0 +1,13 @@
+import { State } from "metabase-types/store";
+import { GeneralPermissions } from "./permissions";
+import { UserWithPermissions } from "./user";
+
+export interface GeneralPermissionsState extends State {
+  currentUser: UserWithPermissions;
+  plugins: {
+    generalPermissionsPlugin: {
+      generalPermissions: GeneralPermissions;
+      originalGeneralPermissions: GeneralPermissions;
+    };
+  };
+}

--- a/enterprise/frontend/src/metabase-enterprise/general_permissions/types/user.ts
+++ b/enterprise/frontend/src/metabase-enterprise/general_permissions/types/user.ts
@@ -1,0 +1,7 @@
+import { User } from "metabase-types/api";
+
+export interface UserWithPermissions extends User {
+  can_access_monitoring: boolean;
+  can_access_settings: boolean;
+  can_access_subscription: boolean;
+}

--- a/enterprise/frontend/src/metabase-enterprise/general_permissions/types/user.ts
+++ b/enterprise/frontend/src/metabase-enterprise/general_permissions/types/user.ts
@@ -1,7 +1,9 @@
 import { User } from "metabase-types/api";
 
 export interface UserWithPermissions extends User {
-  can_access_monitoring: boolean;
-  can_access_settings: boolean;
-  can_access_subscription: boolean;
+  permissions: {
+    can_access_monitoring: boolean;
+    can_access_settings: boolean;
+    can_access_subscription: boolean;
+  };
 }

--- a/enterprise/frontend/src/metabase-enterprise/plugins.js
+++ b/enterprise/frontend/src/metabase-enterprise/plugins.js
@@ -23,3 +23,4 @@ import "./advanced_permissions";
 import "./audit_app";
 import "./license";
 import "./feature_level_permissions";
+import "./general_permissions";

--- a/frontend/src/metabase-types/store/mocks/state.ts
+++ b/frontend/src/metabase-types/store/mocks/state.ts
@@ -1,3 +1,4 @@
+import { createMockUser } from "metabase-types/api/mocks";
 import { State } from "metabase-types/store";
 import {
   createMockAdminState,
@@ -6,6 +7,7 @@ import {
 } from "metabase-types/store/mocks";
 
 export const createMockState = (opts?: Partial<State>): State => ({
+  currentUser: createMockUser(),
   admin: createMockAdminState(),
   settings: createMockSettingsState(),
   entities: createMockEntitiesState(),

--- a/frontend/src/metabase-types/store/state.ts
+++ b/frontend/src/metabase-types/store/state.ts
@@ -1,7 +1,9 @@
+import { User } from "metabase-types/types/User";
 import { AdminState } from "./admin";
 import { EntitiesState } from "./entities";
 import { SettingsState } from "./settings";
 export interface State {
+  currentUser: User;
   admin: AdminState;
   settings: SettingsState;
   entities: EntitiesState;

--- a/frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsTabs.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsTabs.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import { t } from "ttag";
 
 import Radio from "metabase/core/components/Radio";
+import { PLUGIN_GENERAL_PERMISSIONS } from "metabase/plugins";
 
 const propTypes = {
   tab: PropTypes.oneOf(["data", "collections"]).isRequired,
@@ -15,8 +16,9 @@ export const PermissionsTabs = ({ tab, onChangeTab }) => (
       colorScheme="accent7"
       value={tab}
       options={[
-        { name: t`Data permissions`, value: `data` },
-        { name: t`Collection permissions`, value: `collections` },
+        { name: t`Data`, value: `data` },
+        { name: t`Collections`, value: `collections` },
+        ...PLUGIN_GENERAL_PERMISSIONS.tabs,
       ]}
       onOptionClick={onChangeTab}
       variant="underlined"

--- a/frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/index.js
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/index.js
@@ -1,1 +1,1 @@
-export * from "./PermissionsPageLayout";
+export { default } from "./PermissionsPageLayout";

--- a/frontend/src/metabase/admin/permissions/pages/CollectionPermissionsPage/CollectionPermissionsPage.jsx
+++ b/frontend/src/metabase/admin/permissions/pages/CollectionPermissionsPage/CollectionPermissionsPage.jsx
@@ -13,7 +13,7 @@ import {
   PermissionsEditorEmptyState,
   permissionEditorPropTypes,
 } from "../../components/PermissionsEditor";
-import PermissionsPageLayout from "../../components/PermissionsPageLayout/PermissionsPageLayout";
+import PermissionsPageLayout from "../../components/PermissionsPageLayout";
 import {
   initializeCollectionPermissions,
   updateCollectionPermission,

--- a/frontend/src/metabase/admin/permissions/routes.jsx
+++ b/frontend/src/metabase/admin/permissions/routes.jsx
@@ -10,6 +10,7 @@ import DataPermissionsPage from "./pages/DataPermissionsPage/DataPermissionsPage
 import {
   PLUGIN_ADMIN_PERMISSIONS_TABLE_ROUTES,
   PLUGIN_ADMIN_PERMISSIONS_TABLE_GROUP_ROUTES,
+  PLUGIN_GENERAL_PERMISSIONS,
 } from "metabase/plugins";
 
 const getRoutes = () => (
@@ -37,6 +38,8 @@ const getRoutes = () => (
     <Route path="collections" component={CollectionPermissionsPage}>
       <Route path=":collectionId" />
     </Route>
+
+    {PLUGIN_GENERAL_PERMISSIONS.getRoutes()}
   </Route>
 );
 

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/group-sidebar.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/group-sidebar.ts
@@ -2,15 +2,10 @@ import { createSelector } from "reselect";
 import { t } from "ttag";
 import _ from "underscore";
 
-import Groups from "metabase/entities/groups";
-
 import { State } from "metabase-types/store";
 import { Group } from "metabase-types/api";
-import { isAdminGroup, isDefaultGroup } from "metabase/lib/groups";
 import { RawGroupRouteParams } from "../../types";
-
-const isPinnedGroup = (group: Group) =>
-  isAdminGroup(group) || isDefaultGroup(group);
+import { getOrderedGroups } from "./groups";
 
 const getGroupRouteParams = (
   _state: State,
@@ -25,12 +20,12 @@ const getGroupRouteParams = (
 };
 
 export const getGroupsSidebar = createSelector(
-  Groups.selectors.getList,
+  getOrderedGroups,
   getGroupRouteParams,
-  (groups: Group[], params) => {
+  (groups: Group[][], params) => {
     const { groupId } = params;
 
-    const [pinnedGroups, unpinnedGroups] = _.partition(groups, isPinnedGroup);
+    const [pinnedGroups, unpinnedGroups] = groups;
 
     const pinnedGroupItems = pinnedGroups.map(group => ({
       ...group,

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/group-sidebar.unit.spec.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/group-sidebar.unit.spec.ts
@@ -31,13 +31,13 @@ describe("getGroupsDataPermissionEditor", () => {
 
     expect(entities).toHaveLength(3);
     expect(entities?.map(entity => entity.name)).toEqual([
+      "All Users",
       "Group starting with full access",
       "Group starting with no access at all",
-      "All Users",
     ]);
 
     const [accessPermission, nativeQueryPermission] =
-      entities?.[0].permissions ?? [];
+      entities?.[1].permissions ?? [];
     expect(accessPermission.value).toEqual("all");
     expect(accessPermission.options).toEqual([
       {

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/groups.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/groups.ts
@@ -1,0 +1,14 @@
+import { createSelector } from "reselect";
+import _ from "underscore";
+
+import Groups from "metabase/entities/groups";
+import { Group } from "metabase-types/api";
+import { isAdminGroup, isDefaultGroup } from "metabase/lib/groups";
+
+const isPinnedGroup = (group: Group) =>
+  isAdminGroup(group) || isDefaultGroup(group);
+
+export const getOrderedGroups = createSelector(
+  Groups.selectors.getList,
+  (groups: Group[]) => _.partition(groups, isPinnedGroup),
+);

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/permission-editor.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/permission-editor.ts
@@ -26,6 +26,7 @@ import Schema from "metabase-lib/lib/metadata/Schema";
 import { DataRouteParams, RawGroupRouteParams } from "../../types";
 import { State } from "metabase-types/store";
 import { PLUGIN_FEATURE_LEVEL_PERMISSIONS } from "metabase/plugins";
+import { getOrderedGroups } from "./groups";
 
 export const getIsLoadingDatabaseTables = (
   state: State,
@@ -245,15 +246,17 @@ export const getGroupsDataPermissionEditor = createSelector(
   getMetadataWithHiddenTables,
   getRouteParams,
   getDataPermissions,
-  Groups.selectors.getList,
-  (metadata, params, permissions, groups: Group[]) => {
+  getOrderedGroups,
+  (metadata, params, permissions, groups: Group[][]) => {
     const { databaseId, schemaName, tableId } = params;
 
     if (!permissions || databaseId == null) {
       return null;
     }
 
-    const defaultGroup = _.find(groups, isDefaultGroup);
+    const sortedGroups = groups.flat();
+
+    const defaultGroup = _.find(sortedGroups, isDefaultGroup);
 
     if (!defaultGroup) {
       throw new Error("No default group found");
@@ -266,7 +269,7 @@ export const getGroupsDataPermissionEditor = createSelector(
       ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.dataColumns,
     ];
 
-    const entities = groups.map(group => {
+    const entities = sortedGroups.map(group => {
       const isAdmin = isAdminGroup(group);
       let groupPermissions;
 

--- a/frontend/src/metabase/components/Header.jsx
+++ b/frontend/src/metabase/components/Header.jsx
@@ -154,9 +154,7 @@ class Header extends Component {
               key={sectionIndex}
               className="Header-buttonSection"
             >
-              {section.map((button, buttonIndex) => (
-                <div key={buttonIndex}>{button}</div>
-              ))}
+              {section}
             </HeaderButtonSection>
           )
         );

--- a/frontend/src/metabase/dashboard/components/DashboardActions.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardActions.jsx
@@ -8,7 +8,6 @@ import FullscreenIcon from "metabase/components/icons/FullscreenIcon";
 import Icon from "metabase/components/Icon";
 import MetabaseSettings from "metabase/lib/settings";
 import NightModeIcon from "metabase/components/icons/NightModeIcon";
-import PopoverWithTrigger from "metabase/components/PopoverWithTrigger";
 import RefreshWidget from "metabase/dashboard/components/RefreshWidget";
 import Tooltip from "metabase/components/Tooltip";
 
@@ -19,6 +18,7 @@ export const getDashboardActions = (
   {
     dashboard,
     isAdmin,
+    canManageSubscriptions,
     isEditing = false,
     isEmpty = false,
     isFullscreen,
@@ -47,71 +47,31 @@ export const getDashboardActions = (
 
   const canShareDashboard = hasCards;
 
-  // Getting notifications with static text-only cards doesn't make a lot of sense
-  const canSubscribeToDashboard = hasDataCards;
-
   if (!isEditing && !isEmpty && !isPublic) {
-    const extraButtonClassNames =
-      "bg-brand-hover text-white-hover py2 px3 text-bold block cursor-pointer";
-
-    if (canSubscribeToDashboard) {
+    // Getting notifications with static text-only cards doesn't make a lot of sense
+    if (hasDataCards) {
       buttons.push(
-        <PopoverWithTrigger
-          ref="popover"
-          disabled={!canShareDashboard}
-          triggerElement={
-            <Tooltip
-              tooltip={
-                canShareDashboard
-                  ? t`Sharing`
-                  : t`Add data to share this dashboard`
-              }
-            >
-              <DashboardHeaderButton>
-                <Icon
-                  name="share"
-                  className={cx({
-                    "text-brand-hover": canShareDashboard,
-                    "text-light": !canShareDashboard,
-                  })}
-                />
-              </DashboardHeaderButton>
-            </Tooltip>
+        <Tooltip
+          tooltip={
+            canManageSubscriptions
+              ? t`Subscriptions`
+              : t`You don't have permission to create a subscription for this dashboard`
           }
         >
-          <div className="py1">
-            <div>
-              <a
-                className={extraButtonClassNames}
-                data-metabase-event={"Dashboard;Subscriptions"}
-                onClick={() => {
-                  self.refs.popover.close();
-                  onSharingClick();
-                }}
-              >
-                {t`Dashboard subscriptions`}
-              </a>
-            </div>
-            <div>
-              <DashboardSharingEmbeddingModal
-                additionalClickActions={() => self.refs.popover.close()}
-                dashboard={dashboard}
-                enabled={
-                  !isEditing &&
-                  !isFullscreen &&
-                  ((isPublicLinksEnabled &&
-                    (isAdmin || dashboard.public_uuid)) ||
-                    (isEmbeddingEnabled && isAdmin))
-                }
-                linkClassNames={extraButtonClassNames}
-                linkText={t`Sharing and embedding`}
-                key="dashboard-embed"
-              />
-            </div>
-          </div>
-        </PopoverWithTrigger>,
+          <span>
+            <DashboardHeaderButton
+              disabled={!canManageSubscriptions}
+              onClick={onSharingClick}
+              data-metabase-event={"Dashboard;Subscriptions"}
+            >
+              <Icon size={18} name="subscription" />
+            </DashboardHeaderButton>
+          </span>
+        </Tooltip>,
       );
-    } else {
+    }
+
+    if (canShareDashboard) {
       buttons.push(
         <DashboardSharingEmbeddingModal
           key="dashboard-embed"

--- a/frontend/src/metabase/dashboard/containers/DashboardApp.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp.jsx
@@ -38,7 +38,10 @@ import {
   getFavicon,
 } from "../selectors";
 import { getDatabases, getMetadata } from "metabase/selectors/metadata";
-import { getUserIsAdmin } from "metabase/selectors/user";
+import {
+  getUserIsAdmin,
+  canManageSubscriptions,
+} from "metabase/selectors/user";
 
 import * as dashboardActions from "../actions";
 import { parseHashOptions } from "metabase/lib/browser";
@@ -50,6 +53,7 @@ const mapStateToProps = (state, props) => {
   return {
     dashboardId: props.dashboardId || Urls.extractEntityId(props.params.slug),
 
+    canManageSubscriptions: canManageSubscriptions(state, props),
     isAdmin: getUserIsAdmin(state, props),
     isNavbarOpen: getIsNavbarOpen(state),
     isEditing: getIsEditing(state, props),

--- a/frontend/src/metabase/dashboard/containers/DashboardHeader.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardHeader.jsx
@@ -342,6 +342,7 @@ export default class DashboardHeader extends Component {
     if (extraButtons.length > 0 && !isEditing) {
       buttons.push(
         <TippyPopoverWithTrigger
+          key="extra-actions-menu"
           placement="bottom-end"
           renderTrigger={({ onClick }) => (
             <DashboardHeaderButton onClick={onClick}>

--- a/frontend/src/metabase/dashboard/containers/DashboardHeader.styled.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardHeader.styled.jsx
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import colors from "metabase/lib/colors";
+import { color } from "metabase/lib/colors";
 
 export const DashboardHeaderButton = styled.button`
   display: flex;
@@ -7,15 +7,19 @@ export const DashboardHeaderButton = styled.button`
   justify-content: center;
   padding: 8px 12px;
   border-radius: 6px;
-  color: ${props => (props.isActive ? colors["brand"] : colors["text-dark"])};
+  color: ${props => (props.isActive ? color("brand") : color("text-dark"))};
   background-color: ${props =>
-    props.isActive ? colors["brand-light"] : "transparent"};
+    props.isActive ? color("brand-light") : "transparent"};
   transition: all 200ms;
-  cursor: pointer;
 
-  &:hover {
-    color: ${props => (props.isActive ? colors["white"] : colors["brand"])};
+  &:hover:enabled {
+    cursor: pointer;
+    color: ${props => (props.isActive ? color("white") : color("brand"))};
     background-color: ${props =>
-      props.isActive ? colors["brand"] : "transparent"};
+      props.isActive ? color("brand") : "transparent"};
+  }
+
+  &:disabled {
+    color: ${color("text-light")};
   }
 `;

--- a/frontend/src/metabase/icon_paths.ts
+++ b/frontend/src/metabase/icon_paths.ts
@@ -403,6 +403,10 @@ export const ICON_PATHS: Record<string, any> = {
       fillRule: "evenodd",
     },
   },
+  subscription: {
+    svg:
+      '<path fill-rule="evenodd" clip-rule="evenodd" d="M5 1a5 5 0 0 0-5 5v18a5 5 0 0 0 5 5h13v-4H6c-1.105 0-2 .105-2-1V8.777L16 14l12-5.223V15h4V6a5 5 0 0 0-5-5H5Zm21 4H6l10 4.625L26 5Z" /><path d="M23.25 14a1 1 0 0 0-1 1v4.25H18a1 1 0 0 0-1 1v2.5a1 1 0 0 0 1 1h4.25V28a1 1 0 0 0 1 1h2.5a1 1 0 0 0 1-1v-4.25H31a1 1 0 0 0 1-1v-2.5a1 1 0 0 0-1-1h-4.25V15a1 1 0 0 0-1-1h-2.5Z" />',
+  },
   straight: "M2.1 27.101L0 23.516 29.9 6 32 9.585z",
   stepped: "M13.946 17.892v8H1V22h9.054v-8h9V6H32v3.892h-9.054v8z",
   sort:

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -1,4 +1,5 @@
 import { t } from "ttag";
+import React from "react";
 import PluginPlaceholder from "metabase/plugins/components/PluginPlaceholder";
 import {
   DatabaseEntityId,
@@ -112,6 +113,8 @@ export const PLUGIN_CACHING = {
   getQuestionsImplicitCacheTTL: () => null,
 };
 
+export const PLUGIN_REDUCERS = {} as any;
+
 export const PLUGIN_ADVANCED_PERMISSIONS = {
   addDatabasePermissionOptions: (permissions: any[]) => permissions,
   addSchemaPermissionOptions: (permissions: any[], _value: string) =>
@@ -136,4 +139,12 @@ export const PLUGIN_FEATURE_LEVEL_PERMISSIONS = {
     return [] as any;
   },
   dataColumns: [] as any,
+};
+
+export const PLUGIN_GENERAL_PERMISSIONS = {
+  getRoutes: (): React.ReactNode => null,
+  tabs: [] as any,
+  selectors: {
+    canManageSubscriptions: (_state: any) => true,
+  },
 };

--- a/frontend/src/metabase/query_builder/components/view/QuestionAlertWidget.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionAlertWidget.jsx
@@ -26,8 +26,25 @@ export default class QuestionAlertWidget extends React.Component {
   };
 
   render() {
-    const { question, questionAlerts, onCreateAlert, className } = this.props;
+    const {
+      question,
+      questionAlerts,
+      onCreateAlert,
+      className,
+      canManageSubscriptions,
+    } = this.props;
     const { isOpen, isFrozen } = this.state;
+
+    if (!canManageSubscriptions) {
+      return (
+        <Icon
+          name="bell"
+          tooltip={t`You don't have permission to share data from this saved question`}
+          className={cx(className, "text-light")}
+        />
+      );
+    }
+
     if (question.isSaved() && Object.values(questionAlerts).length > 0) {
       return (
         <span onClick={this.open}>

--- a/frontend/src/metabase/query_builder/components/view/ViewFooter.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewFooter.jsx
@@ -54,6 +54,7 @@ const ViewFooter = ({
   questionAlerts,
   visualizationSettings,
   isAdmin,
+  canManageSubscriptions,
   isPreviewing,
   isResultDirty,
   isVisualized,
@@ -178,6 +179,7 @@ const ViewFooter = ({
             <QuestionAlertWidget
               key="alerts"
               className="mx1 hide sm-show"
+              canManageSubscriptions={canManageSubscriptions}
               question={question}
               questionAlerts={questionAlerts}
               onCreateAlert={() =>

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
@@ -11,7 +11,11 @@ import Timelines from "metabase/entities/timelines";
 import { closeNavbar } from "metabase/redux/app";
 import { MetabaseApi } from "metabase/services";
 import { getMetadata } from "metabase/selectors/metadata";
-import { getUser, getUserIsAdmin } from "metabase/selectors/user";
+import {
+  getUser,
+  getUserIsAdmin,
+  canManageSubscriptions,
+} from "metabase/selectors/user";
 
 import { useForceUpdate } from "metabase/hooks/use-force-update";
 import { useOnMount } from "metabase/hooks/use-on-mount";
@@ -94,6 +98,7 @@ const timelineProps = {
 const mapStateToProps = (state, props) => {
   return {
     user: getUser(state, props),
+    canManageSubscriptions: canManageSubscriptions(state, props),
     isAdmin: getUserIsAdmin(state, props),
     fromUrl: props.location.query.from,
 

--- a/frontend/src/metabase/reducers-main.js
+++ b/frontend/src/metabase/reducers-main.js
@@ -1,7 +1,9 @@
 // Reducers needed for main application
 
 import { combineReducers } from "redux";
+import _ from "underscore";
 
+import { PLUGIN_REDUCERS } from "metabase/plugins";
 import commonReducers from "./reducers-common";
 
 /* admin */
@@ -42,4 +44,5 @@ export default {
   revisions,
   setup: combineReducers(setup),
   admin,
+  plugins: combineReducers(PLUGIN_REDUCERS),
 };

--- a/frontend/src/metabase/selectors/user.js
+++ b/frontend/src/metabase/selectors/user.js
@@ -1,3 +1,4 @@
+import { PLUGIN_GENERAL_PERMISSIONS } from "metabase/plugins";
 import { createSelector } from "reselect";
 
 export const getUser = state => state.currentUser;
@@ -7,6 +8,14 @@ export const getUserId = createSelector([getUser], user => user?.id);
 export const getUserIsAdmin = createSelector(
   [getUser],
   user => (user && user.is_superuser) || false,
+);
+
+export const canManageSubscriptions = createSelector(
+  [
+    getUserIsAdmin,
+    state => PLUGIN_GENERAL_PERMISSIONS.selectors.canManageSubscriptions(state),
+  ],
+  (isAdmin, canManageSubscriptions) => isAdmin || canManageSubscriptions,
 );
 
 export const getUserAttributes = createSelector(

--- a/frontend/test/__support__/e2e/helpers/e2e-email-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-email-helpers.js
@@ -59,8 +59,7 @@ export const openEmailPage = emailSubject => {
 };
 
 export const sendSubscriptionsEmail = recipient => {
-  cy.icon("share").click();
-  cy.findByText("Dashboard subscriptions").click();
+  cy.icon("subscription").click();
 
   cy.findByText("Email it").click();
   cy.findByPlaceholderText("Enter user names or email addresses")

--- a/frontend/test/__support__/e2e/helpers/e2e-permissions-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-permissions-helpers.js
@@ -69,3 +69,13 @@ export function isPermissionDisabled(index, permission, isDisabled) {
     .closest("a")
     .should("have.attr", "aria-disabled", isDisabled.toString());
 }
+
+export function assertPermissionForItem(
+  item,
+  permissionColumnIndex,
+  permissionValue,
+) {
+  getPermissionRowPermissions(item)
+    .eq(permissionColumnIndex)
+    .should("have.text", permissionValue);
+}

--- a/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
@@ -439,7 +439,6 @@ describe("scenarios > dashboard", () => {
     cy.contains("37.65");
     assertScrollBarExists();
     cy.icon("share").click();
-    cy.findByText("Sharing and embedding").click();
     cy.get(".Modal--full").within(() => {
       cy.icon("close").click();
     });

--- a/frontend/test/metabase/scenarios/embedding/embedding-dashboard.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/embedding-dashboard.cy.spec.js
@@ -49,7 +49,6 @@ describe("scenarios > embedding > dashboard parameters", () => {
       });
 
       cy.icon("share").click();
-      cy.findByText("Sharing and embedding").click();
       cy.findByText("Embed this dashboard in an application").click();
 
       cy.findByRole("heading", { name: "Parameters" })
@@ -142,7 +141,6 @@ describe("scenarios > embedding > dashboard parameters", () => {
       });
 
       cy.icon("share").click();
-      cy.findByText("Sharing and embedding").click();
       cy.findByText("Embed this dashboard in an application").click();
 
       cy.findByText("Locked").click();

--- a/frontend/test/metabase/scenarios/embedding/embedding-smoketests.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/embedding-smoketests.cy.spec.js
@@ -93,7 +93,6 @@ describe("scenarios > embedding > smoke tests", () => {
       visitDashboard(1);
 
       cy.icon("share").click();
-      cy.findByText("Sharing and embedding").click();
 
       ensureEmbeddingIsDisabled();
     });
@@ -238,7 +237,6 @@ function visitAndEnableSharing(object) {
     visitDashboard(1);
 
     cy.icon("share").click();
-    cy.findByText("Sharing and embedding").click();
     cy.findByText(/Embed this (question|dashboard) in an application/).click();
   }
 }

--- a/frontend/test/metabase/scenarios/embedding/embedding-snippets.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/embedding-snippets.cy.spec.js
@@ -9,7 +9,6 @@ describe("scenarios > embedding > code snippets", () => {
   it("dashboard should have the correct embed snippet", () => {
     visitDashboard(1);
     cy.icon("share").click();
-    cy.findByText("Sharing and embedding").click();
     cy.contains(/Embed this .* in an application/).click();
     cy.contains("Code").click();
 

--- a/frontend/test/metabase/scenarios/embedding/reproductions/20393-public-dashboard-nested-card-with-parameters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/reproductions/20393-public-dashboard-nested-card-with-parameters.cy.spec.js
@@ -32,7 +32,6 @@ describe("issue 20393", () => {
 
     // open the sharing modal and enable sharing
     cy.icon("share").click();
-    cy.findByText("Sharing and embedding").click();
     cy.findByRole("switch").click();
 
     // navigate to the public dashboard link

--- a/frontend/test/metabase/scenarios/embedding/reproductions/20438-dashboard-filter-single-value.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/reproductions/20438-dashboard-filter-single-value.cy.spec.js
@@ -80,7 +80,6 @@ describe("issue 20438", () => {
 
   it("dashboard filter connected to the field filter should work with a single value in embedded dashboards (metabase#20438)", () => {
     cy.icon("share").click();
-    cy.findByText("Sharing and embedding").click();
     cy.findByText("Embed this dashboard in an application").click();
 
     cy.document().then(doc => {

--- a/frontend/test/metabase/scenarios/permissions/admin-permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/admin-permissions.cy.spec.js
@@ -85,7 +85,7 @@ describeOSS("scenarios > admin > permissions", () => {
 
       // Switching to data permissions page
       cy.get("label")
-        .contains("Data permissions")
+        .contains("Data")
         .click();
 
       modal().within(() => {
@@ -101,7 +101,7 @@ describeOSS("scenarios > admin > permissions", () => {
 
       // Switching to data permissions page again
       cy.get("label")
-        .contains("Data permissions")
+        .contains("Data")
         .click();
 
       modal().within(() => {
@@ -225,7 +225,7 @@ describeOSS("scenarios > admin > permissions", () => {
 
       // Switching to collection permissions page
       cy.get("label")
-        .contains("Collection permissions")
+        .contains("Collection")
         .click();
 
       modal().within(() => {
@@ -241,7 +241,7 @@ describeOSS("scenarios > admin > permissions", () => {
 
       // Switching to collection permissions page again
       cy.get("label")
-        .contains("Collection permissions")
+        .contains("Collection")
         .click();
 
       modal().within(() => {

--- a/frontend/test/metabase/scenarios/permissions/general-permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/general-permissions.cy.spec.js
@@ -1,0 +1,86 @@
+import {
+  restore,
+  modal,
+  describeEE,
+  modifyPermission,
+} from "__support__/e2e/cypress";
+
+const SUBSCRIPTIONS_INDEX = 0;
+
+describeEE("scenarios > admin > permissions > general", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  describe("revoked permission", () => {
+    beforeEach(() => {
+      cy.visit("/admin/permissions/general");
+
+      modifyPermission("All Users", SUBSCRIPTIONS_INDEX, "No");
+      modifyPermission("data", SUBSCRIPTIONS_INDEX, "No");
+      modifyPermission("collection", SUBSCRIPTIONS_INDEX, "No");
+
+      cy.button("Save changes").click();
+
+      modal().within(() => {
+        cy.findByText("Save permissions?");
+        cy.findByText("Are you sure you want to do this?");
+        cy.button("Yes").click();
+      });
+
+      cy.signInAsNormalUser();
+    });
+
+    it("revokes ability to create dashboard subscriptions", () => {
+      cy.visit("/dashboard/1");
+      cy.icon("subscription")
+        .as("subscriptionsButton")
+        .realHover();
+
+      cy.findByText(
+        "You don't have permission to create a subscription for this dashboard",
+      );
+
+      cy.get("@subscriptionsButton").click();
+      cy.findByText("Create a dashboard subscription").should("not.exist");
+    });
+
+    it("revokes ability to create question alerts", () => {
+      cy.visit("/question/1");
+      cy.icon("bell")
+        .as("subscriptionsButton")
+        .realHover();
+      cy.findByText(
+        "You don't have permission to share data from this saved question",
+      );
+
+      cy.findByText(
+        "To send alerts, an admin needs to set up email integration.",
+      ).should("not.exist");
+
+      cy.get("@subscriptionsButton").click();
+      cy.findByText("Create a dashboard subscription").should("not.exist");
+    });
+  });
+
+  describe("granted permission", () => {
+    beforeEach(() => {
+      cy.signInAsNormalUser();
+    });
+
+    it("gives ability to create dashboard subscriptions", () => {
+      cy.visit("/dashboard/1");
+      cy.icon("subscription").click();
+      cy.findByText("Create a dashboard subscription");
+    });
+
+    it("gives ability to create question alerts", () => {
+      cy.visit("/question/1");
+      cy.icon("bell").click();
+      cy.findByText(
+        "To send alerts, an admin needs to set up email integration.",
+      );
+    });
+  });
+});

--- a/frontend/test/metabase/scenarios/permissions/general-permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/general-permissions.cy.spec.js
@@ -18,8 +18,6 @@ describeEE("scenarios > admin > permissions > general", () => {
       cy.visit("/admin/permissions/general");
 
       modifyPermission("All Users", SUBSCRIPTIONS_INDEX, "No");
-      modifyPermission("data", SUBSCRIPTIONS_INDEX, "No");
-      modifyPermission("collection", SUBSCRIPTIONS_INDEX, "No");
 
       cy.button("Save changes").click();
 

--- a/frontend/test/metabase/scenarios/permissions/sandboxes.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/sandboxes.cy.spec.js
@@ -901,7 +901,7 @@ describeEE("formatting > sandboxes", () => {
       cy.signInAsSandboxedUser();
       visitDashboard(1);
       cy.icon("share").click();
-      cy.findByText("Dashboard subscriptions").click();
+      cy.icon("subscription").click();
       // We're starting without email or Slack being set up so it's expected to see the following:
       cy.findByText("Create a dashboard subscription");
       cy.findAllByRole("link", { name: "set up email" });
@@ -1029,7 +1029,7 @@ describeEE("formatting > sandboxes", () => {
       cy.signInAsSandboxedUser();
       visitDashboard(1);
       cy.icon("share").click();
-      cy.findByText("Dashboard subscriptions").click();
+      cy.icon("subscription").click();
       cy.findByText("Email it").click();
       cy.findByPlaceholderText("Enter user names or email addresses").click();
       cy.findByText("User 1").click();

--- a/frontend/test/metabase/scenarios/permissions/sandboxes.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/sandboxes.cy.spec.js
@@ -900,7 +900,6 @@ describeEE("formatting > sandboxes", () => {
 
       cy.signInAsSandboxedUser();
       visitDashboard(1);
-      cy.icon("share").click();
       cy.icon("subscription").click();
       // We're starting without email or Slack being set up so it's expected to see the following:
       cy.findByText("Create a dashboard subscription");
@@ -1028,7 +1027,6 @@ describeEE("formatting > sandboxes", () => {
 
       cy.signInAsSandboxedUser();
       visitDashboard(1);
-      cy.icon("share").click();
       cy.icon("subscription").click();
       cy.findByText("Email it").click();
       cy.findByPlaceholderText("Enter user names or email addresses").click();

--- a/frontend/test/metabase/scenarios/sharing/approved-domains.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/approved-domains.cy.spec.js
@@ -5,10 +5,12 @@ import {
   sidebar,
   visitQuestion,
   visitDashboard,
+  modal,
 } from "__support__/e2e/cypress";
 
 const allowedDomain = "metabase.test";
 const deniedDomain = "metabase.example";
+const allowedEmail = `mailer@${allowedDomain}`;
 const deniedEmail = `mailer@${deniedDomain}`;
 const subscriptionError = `You're only allowed to email subscriptions to addresses ending in ${allowedDomain}`;
 const alertError = `You're only allowed to email alerts to addresses ending in ${allowedDomain}`;
@@ -38,7 +40,7 @@ describeEE("scenarios > sharing > approved domains (EE)", () => {
   it("should validate approved email domains for a dashboard subscription (metabase#17977)", () => {
     visitDashboard(1);
     cy.icon("share").click();
-    cy.findByText("Dashboard subscriptions").click();
+    cy.icon("subscription").click();
     cy.findByText("Email it").click();
 
     sidebar().within(() => {
@@ -47,6 +49,28 @@ describeEE("scenarios > sharing > approved domains (EE)", () => {
       // Reproduces metabase#17977
       cy.button("Send email now").should("be.disabled");
       cy.button("Done").should("be.disabled");
+      cy.findByText(subscriptionError);
+    });
+  });
+
+  it("should validate approved email domains for a dashboard subscription in the audit app", () => {
+    visitDashboard(1);
+    cy.icon("share").click();
+    cy.icon("subscription").click();
+    cy.findByText("Email it").click();
+
+    sidebar().within(() => {
+      addEmailRecipient(allowedEmail);
+      cy.button("Done").click();
+    });
+
+    cy.visit("/admin/audit/subscriptions/subscriptions");
+    cy.findByText("1").click();
+
+    modal().within(() => {
+      addEmailRecipient(deniedEmail);
+
+      cy.button("Update").should("be.disabled");
       cy.findByText(subscriptionError);
     });
   });

--- a/frontend/test/metabase/scenarios/sharing/approved-domains.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/approved-domains.cy.spec.js
@@ -39,7 +39,6 @@ describeEE("scenarios > sharing > approved domains (EE)", () => {
 
   it("should validate approved email domains for a dashboard subscription (metabase#17977)", () => {
     visitDashboard(1);
-    cy.icon("share").click();
     cy.icon("subscription").click();
     cy.findByText("Email it").click();
 
@@ -55,7 +54,6 @@ describeEE("scenarios > sharing > approved domains (EE)", () => {
 
   it("should validate approved email domains for a dashboard subscription in the audit app", () => {
     visitDashboard(1);
-    cy.icon("share").click();
     cy.icon("subscription").click();
     cy.findByText("Email it").click();
 

--- a/frontend/test/metabase/scenarios/sharing/public.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/public.cy.spec.js
@@ -169,7 +169,6 @@ describe.skip("scenarios > public", () => {
       visitDashboard(dashboardId);
 
       cy.icon("share").click();
-      cy.contains("Sharing and embedding").click();
 
       cy.contains("Enable sharing")
         .parent()
@@ -194,7 +193,6 @@ describe.skip("scenarios > public", () => {
       visitDashboard(dashboardId);
 
       cy.icon("share").click();
-      cy.contains("Sharing and embedding").click();
 
       cy.contains(".cursor-pointer", "Embed this dashboard")
         .should("not.be.disabled")

--- a/frontend/test/metabase/scenarios/sharing/reproductions/17657.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/reproductions/17657.cy.spec.js
@@ -17,7 +17,7 @@ describe("issue 17657", () => {
     visitDashboard(1);
 
     cy.icon("share").click();
-    cy.findByText("Dashboard subscriptions").click();
+    cy.icon("subscription").click();
 
     cy.findByText(/^Emailed monthly/).click();
 

--- a/frontend/test/metabase/scenarios/sharing/reproductions/17657.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/reproductions/17657.cy.spec.js
@@ -16,7 +16,6 @@ describe("issue 17657", () => {
   it("frontend should gracefully handle the case of a subscription without a recipient (metabase#17657)", () => {
     visitDashboard(1);
 
-    cy.icon("share").click();
     cy.icon("subscription").click();
 
     cy.findByText(/^Emailed monthly/).click();

--- a/frontend/test/metabase/scenarios/sharing/reproductions/17658.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/reproductions/17658.cy.spec.js
@@ -15,7 +15,7 @@ describe("issue 17658", () => {
     visitDashboard(1);
 
     cy.icon("share").click();
-    cy.findByText("Dashboard subscriptions").click();
+    cy.icon("subscription").click();
 
     cy.findByText(/^Emailed monthly/).click();
 

--- a/frontend/test/metabase/scenarios/sharing/reproductions/17658.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/reproductions/17658.cy.spec.js
@@ -14,7 +14,6 @@ describe("issue 17658", () => {
   it("should delete dashboard subscription from any collection (metabase#17658)", () => {
     visitDashboard(1);
 
-    cy.icon("share").click();
     cy.icon("subscription").click();
 
     cy.findByText(/^Emailed monthly/).click();

--- a/frontend/test/metabase/scenarios/sharing/reproductions/18009-nodata-creates-subscription-receives-error.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/reproductions/18009-nodata-creates-subscription-receives-error.cy.spec.js
@@ -19,7 +19,7 @@ describe.skip("issue 18009", () => {
     visitDashboard(1);
 
     cy.icon("share").click();
-    cy.findByText("Dashboard subscriptions").click();
+    cy.icon("subscription").click();
 
     cy.findByText("Email it").click();
 

--- a/frontend/test/metabase/scenarios/sharing/reproductions/18009-nodata-creates-subscription-receives-error.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/reproductions/18009-nodata-creates-subscription-receives-error.cy.spec.js
@@ -18,7 +18,6 @@ describe.skip("issue 18009", () => {
   it("nodata user should be able to create and receive an email subscription without errors (metabase#18009)", () => {
     visitDashboard(1);
 
-    cy.icon("share").click();
     cy.icon("subscription").click();
 
     cy.findByText("Email it").click();

--- a/frontend/test/metabase/scenarios/sharing/reproductions/18344-subscription-shows-original-question-name.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/reproductions/18344-subscription-shows-original-question-name.cy.spec.js
@@ -41,7 +41,7 @@ describe("issue 18344", () => {
   it("subscription should not include original question name when it's been renamed in the dashboard (metabase#18344)", () => {
     // Send a test email subscription
     cy.icon("share").click();
-    cy.findByText("Dashboard subscriptions").click();
+    cy.icon("subscription").click();
     cy.findByText("Email it").click();
 
     cy.findByPlaceholderText("Enter user names or email addresses").click();

--- a/frontend/test/metabase/scenarios/sharing/reproductions/18344-subscription-shows-original-question-name.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/reproductions/18344-subscription-shows-original-question-name.cy.spec.js
@@ -40,7 +40,6 @@ describe("issue 18344", () => {
 
   it("subscription should not include original question name when it's been renamed in the dashboard (metabase#18344)", () => {
     // Send a test email subscription
-    cy.icon("share").click();
     cy.icon("subscription").click();
     cy.findByText("Email it").click();
 

--- a/frontend/test/metabase/scenarios/sharing/reproductions/18352-subscription-int64-value-card.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/reproductions/18352-subscription-int64-value-card.cy.spec.js
@@ -35,7 +35,7 @@ describe("issue 18352", () => {
 
   it("should send the card with the INT64 values (metabase#18352)", () => {
     cy.icon("share").click();
-    cy.findByText("Dashboard subscriptions").click();
+    cy.icon("subscription").click();
 
     cy.findByText("Email it").click();
 

--- a/frontend/test/metabase/scenarios/sharing/reproductions/18352-subscription-int64-value-card.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/reproductions/18352-subscription-int64-value-card.cy.spec.js
@@ -34,7 +34,6 @@ describe("issue 18352", () => {
   });
 
   it("should send the card with the INT64 values (metabase#18352)", () => {
-    cy.icon("share").click();
     cy.icon("subscription").click();
 
     cy.findByText("Email it").click();

--- a/frontend/test/metabase/scenarios/sharing/reproductions/18669-test-email-with-parameters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/reproductions/18669-test-email-with-parameters.cy.spec.js
@@ -29,7 +29,7 @@ describeEE("issue 18669", () => {
 
   it("should send a test email with non-default parameters (metabase#18669)", () => {
     cy.icon("share").click();
-    cy.findByText("Dashboard subscriptions").click();
+    cy.icon("subscription").click();
     cy.findByText("Email it").click();
 
     cy.findByPlaceholderText("Enter user names or email addresses")

--- a/frontend/test/metabase/scenarios/sharing/reproductions/18669-test-email-with-parameters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/reproductions/18669-test-email-with-parameters.cy.spec.js
@@ -28,7 +28,6 @@ describeEE("issue 18669", () => {
   });
 
   it("should send a test email with non-default parameters (metabase#18669)", () => {
-    cy.icon("share").click();
     cy.icon("subscription").click();
     cy.findByText("Email it").click();
 

--- a/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
@@ -28,8 +28,7 @@ describe("scenarios > dashboard > subscriptions", () => {
       .should("have.attr", "aria-disabled", "true")
       .click();
 
-    cy.findByText("Dashboard subscriptions").should("not.exist");
-    cy.findByText("Sharing and embedding").should("not.exist");
+    cy.icon("subscription").should("not.exist");
     cy.findByText(/Share this dashboard with people *./i).should("not.exist");
   });
 
@@ -52,8 +51,7 @@ describe("scenarios > dashboard > subscriptions", () => {
     // without a menu with sharing and dashboard subscription options.
     // Dashboard subscriptions are not shown because
     // getting notifications with static text-only cards doesn't make a lot of sense
-    cy.findByText("Dashboard subscriptions").should("not.exist");
-    cy.findByText("Sharing and embedding").should("not.exist");
+    cy.icon("subscription").should("not.exist");
     cy.findByText(/Share this dashboard with people *./i);
   });
 
@@ -370,8 +368,7 @@ describe("scenarios > dashboard > subscriptions", () => {
 function openDashboardSubscriptions(dashboard_id = 1) {
   // Orders in a dashboard
   visitDashboard(dashboard_id);
-  cy.icon("share").click();
-  cy.findByText("Dashboard subscriptions").click();
+  cy.icon("subscription").click();
 }
 
 function assignRecipient({ user = admin, dashboard_id = 1 } = {}) {

--- a/frontend/test/metabase/scenarios/smoketest/admin_setup.cy.spec.js
+++ b/frontend/test/metabase/scenarios/smoketest/admin_setup.cy.spec.js
@@ -667,7 +667,7 @@ describe("smoketest > admin_setup", () => {
 
       // SQL queries permissions (table)
 
-      cy.findByText("Data permissions").click();
+      cy.findByText("Data").click();
 
       cy.findByText("data").click();
       cy.icon("check")
@@ -748,7 +748,7 @@ describe("smoketest > admin_setup", () => {
 
       // Modify permissions for top-level collection
 
-      cy.findByText("Collection permissions").click();
+      cy.findByText("Collection").click();
       cy.icon("close")
         .eq(1)
         .click();
@@ -779,7 +779,7 @@ describe("smoketest > admin_setup", () => {
       cy.findByText("Save permissions?");
 
       cy.findByText("Yes").click();
-      cy.findByText("Collection permissions").click();
+      cy.findByText("Collection").click();
 
       cy.icon("eye");
     });

--- a/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
@@ -626,9 +626,6 @@ describe("scenarios > visualizations > pivot tables", () => {
           cy.visit("collection/root");
           cy.findByText(test.subject).click();
           cy.icon("share").click();
-          if (test.case === "dashboard") {
-            cy.findByText("Sharing and embedding").click();
-          }
         });
 
         it("should display pivot table in a public link", () => {


### PR DESCRIPTION
# Subscription management permission

This PR adds new subscriptions management permission which is available in Metabase EE.

<img width="607" alt="Screenshot 2022-03-28 at 22 51 43" src="https://user-images.githubusercontent.com/14301985/160523326-86a8f9ff-be19-430b-8284-a7b281d07b43.png">


## How to verify
- Run Metabase EE
- Create "Test User"
- Login as an admin in one window, login as "Test User" in another window

### Granted
- As an admin go to [General Permissions management](http://localhost:3000/admin/permissions/general) and ensure "Subscriptions" permission for "All Users" is "Yes"
- Ensure "Test User" can create question alerts and dashboard subscriptions

### Revoked
- As an admin go to [General Permissions management](http://localhost:3000/admin/permissions/general) and ensure "Subscriptions" permission for "All Users" is "No"
- Ensure "Test User" is unable to create question alerts or dashboard subscriptions
