### PR TITLE
Speed up cypress start time

### DIFF
--- a/frontend/test/__support__/e2e/cypress-snapshots.json
+++ b/frontend/test/__support__/e2e/cypress-snapshots.json
@@ -1,6 +1,6 @@
 {
   "testFiles": "**/*.cy.snap.js",
   "pluginsFile": "frontend/test/__support__/e2e/cypress-plugins.js",
-  "integrationFolder": "frontend/test",
+  "integrationFolder": "frontend/test/snapshot-creators",
   "supportFile": "frontend/test/__support__/e2e/cypress.js"
 }

--- a/frontend/test/__support__/e2e/cypress-snapshots.json
+++ b/frontend/test/__support__/e2e/cypress-snapshots.json
@@ -2,5 +2,6 @@
   "testFiles": "**/*.cy.snap.js",
   "pluginsFile": "frontend/test/__support__/e2e/cypress-plugins.js",
   "integrationFolder": "frontend/test/snapshot-creators",
-  "supportFile": "frontend/test/__support__/e2e/cypress.js"
+  "supportFile": "frontend/test/__support__/e2e/cypress.js",
+  "videoUploadOnPasses": false
 }

--- a/frontend/test/__support__/e2e/cypress.json
+++ b/frontend/test/__support__/e2e/cypress.json
@@ -1,7 +1,7 @@
 {
   "testFiles": "**/*.cy.spec.js",
   "pluginsFile": "frontend/test/__support__/e2e/cypress-plugins.js",
-  "integrationFolder": ".",
+  "integrationFolder": "frontend/test",
   "supportFile": "frontend/test/__support__/e2e/cypress.js",
   "videoUploadOnPasses": false,
   "chromeWebSecurity": false,


### PR DESCRIPTION
Two simple configuration changes to help Cypress start faster.

## 1. Set `integrationFolder` to be more specific
The previous setting sets the `integrationFolder` to be the entire project. This means Cypress will try to find test files in all  folders, including `node_modules`, which takes a lot of time and CPU. This setting alone shave ~50 seconds of start up time on a 4 vCPU VM. (Excluding starting Metabase and snapshots, this brings start time from 61 seconds to 6 seconds measuring from start until `(Run Starting)` text.)

Note: I've discovered this by running Cypress with `DEBUG=cypress*` and see what it's doing during start-up.

## 2. Set `"videoUploadOnPasses": false` for snapshots
This skips video compression unless the test failed. While compression only take 1 - 2 seconds per snapshot test (so 2 - 4 seconds in total), so the gain is not much, but it's just one line of option.