### PR TITLE
Repro #15876: Incorrect casting to `TIME`

### DIFF
--- a/frontend/test/metabase/scenarios/question/reproductions/15876-postgres-cast-time.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/15876-postgres-cast-time.cy.spec.js
@@ -1,5 +1,7 @@
 import { restore } from "__support__/e2e/cypress";
 
+const PG_DB_ID = 2;
+
 const questionDetails = {
   native: {
     query: `select mytz as "ts", mytz::text as "tsAStext", state, mytz::time as "time - LOOK AT THIS COLUMN", mytz::time::text as "timeAStext", mytz::time(0) as "time(0) - ALL INCORRECT", mytz::time(3) as "time(3) - MOSTLY WORKING" from (
@@ -14,7 +16,7 @@ const questionDetails = {
       select '2016-05-12 11:01:23-04:00'::timestamptz, 'ALWAYS incorrect'
   )x`,
   },
-  database: 2,
+  database: PG_DB_ID,
 };
 
 // time, time(0), time(3)

--- a/frontend/test/metabase/scenarios/question/reproductions/15876-postgres-cast-time.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/15876-postgres-cast-time.cy.spec.js
@@ -1,0 +1,59 @@
+import { restore } from "__support__/e2e/cypress";
+
+const questionDetails = {
+  native: {
+    query: `select mytz as "ts", mytz::text as "tsAStext", state, mytz::time as "time - LOOK AT THIS COLUMN", mytz::time::text as "timeAStext", mytz::time(0) as "time(0) - ALL INCORRECT", mytz::time(3) as "time(3) - MOSTLY WORKING" from (
+      select '2016-05-04 16:29:59.268160-04:00'::timestamptz as mytz, 'incorrect' AS state union all
+      select '2016-05-04 16:29:59.412459-04:00'::timestamptz, 'good' union all
+      select '2016-05-08 13:14:42.926221-04:00'::timestamptz, 'incorrect' union all
+      select '2016-05-08 13:14:42.132020-04:00'::timestamptz, 'good' union all
+      select '2016-05-10 07:38:58.987352-04:00'::timestamptz, 'incorrect' union all
+      select '2016-05-10 07:38:58.001001-04:00'::timestamptz, 'good' union all
+      select '2016-05-12 11:01:23.000000-04:00'::timestamptz, 'ALWAYS incorrect' union all
+      select '2016-05-12 11:01:23.000-04:00'::timestamptz, 'ALWAYS incorrect' union all
+      select '2016-05-12 11:01:23-04:00'::timestamptz, 'ALWAYS incorrect'
+  )x`,
+  },
+  database: 2,
+};
+
+// time, time(0), time(3)
+const castColumns = 3;
+
+const correctValues = [
+  {
+    value: "1:29 PM",
+    rows: 2,
+  },
+  {
+    value: "10:14 AM",
+    rows: 2,
+  },
+  {
+    value: "4:38 AM",
+    rows: 2,
+  },
+  {
+    value: "8:01 AM",
+    rows: 3,
+  },
+];
+
+describe.skip("issue 15876", () => {
+  beforeEach(() => {
+    restore("postgres-12");
+    cy.signInAsAdmin();
+  });
+
+  it("should correctly cast to `TIME` (metabase#15876)", () => {
+    cy.createNativeQuestion(questionDetails, { visitQuestion: true });
+
+    cy.get(".Visualization").within(() => {
+      correctValues.forEach(({ value, rows }) => {
+        const count = rows * castColumns;
+
+        cy.findAllByText(value).should("have.length", count);
+      });
+    });
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #15876 

### How to test this manually?
- `yarn test-cypress-open`
- `15876-postgres-cast-time.cy.spec.js`
- Unskip repro
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/160624420-46926c53-d648-47dd-9ce5-e0ccf8271e82.png)

