### PR TITLE
Scroll to selected event when opening the sidebar

### DIFF
--- a/frontend/src/metabase/timelines/questions/components/EventCard/EventCard.tsx
+++ b/frontend/src/metabase/timelines/questions/components/EventCard/EventCard.tsx
@@ -4,6 +4,7 @@ import Settings from "metabase/lib/settings";
 import { parseTimestamp } from "metabase/lib/time";
 import { formatDateTimeWithUnit } from "metabase/lib/formatting";
 import EntityMenu from "metabase/components/EntityMenu";
+import { useScrollOnMount } from "metabase/hooks/use-scroll-on-mount";
 import { Timeline, TimelineEvent } from "metabase-types/api";
 import {
   CardAside,
@@ -16,7 +17,6 @@ import {
   CardRoot,
   CardTitle,
 } from "./EventCard.styled";
-import { useScrollOnMount } from "metabase/hooks/use-scroll-on-mount";
 
 export interface EventCardProps {
   event: TimelineEvent;

--- a/frontend/src/metabase/timelines/questions/components/EventCard/EventCard.tsx
+++ b/frontend/src/metabase/timelines/questions/components/EventCard/EventCard.tsx
@@ -16,6 +16,7 @@ import {
   CardRoot,
   CardTitle,
 } from "./EventCard.styled";
+import { useScrollOnMount } from "metabase/hooks/use-scroll-on-mount";
 
 export interface EventCardProps {
   event: TimelineEvent;
@@ -34,6 +35,7 @@ const EventCard = ({
   onArchive,
   onToggle,
 }: EventCardProps): JSX.Element => {
+  const selectedRef = useScrollOnMount();
   const menuItems = getMenuItems(event, timeline, onEdit, onArchive);
   const dateMessage = getDateMessage(event);
   const creatorMessage = getCreatorMessage(event);
@@ -47,7 +49,11 @@ const EventCard = ({
   }, []);
 
   return (
-    <CardRoot isSelected={isSelected} onClick={handleEventClick}>
+    <CardRoot
+      ref={isSelected ? selectedRef : null}
+      isSelected={isSelected}
+      onClick={handleEventClick}
+    >
       <CardIconContainer>
         <CardIcon name={event.icon} />
       </CardIconContainer>

--- a/frontend/src/metabase/visualizations/lib/timelines.js
+++ b/frontend/src/metabase/visualizations/lib/timelines.js
@@ -184,13 +184,13 @@ function renderEventTicks({
       eventLine.classed("hover", isSelected(d, selectedEventIds));
     })
     .on("click", function(d) {
-      onOpenTimelines();
-
       if (isSelected(d, selectedEventIds)) {
         onDeselectTimelineEvents();
       } else {
         onSelectTimelineEvents(d);
       }
+
+      onOpenTimelines();
     });
 }
 


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/20289

How to test:
- Open a timeseries question
- Make sure you have more than 10 events available in the events sidebar. If not, create missing events
- Close the sidebar and click on the event in the chart
- Make sure the sidebar was opened and scrolled down to the selected event

<img width="1352" alt="Screenshot 2022-03-29 at 17 41 29" src="https://user-images.githubusercontent.com/8542534/160637725-2ab078d0-c10a-4e1b-bdfc-c21b26e0bbf1.png">
