### PR TITLE
Browse fix bulk actions

### DIFF
--- a/frontend/src/metabase/collections/components/BulkActions.jsx
+++ b/frontend/src/metabase/collections/components/BulkActions.jsx
@@ -3,7 +3,6 @@ import React from "react";
 import { t, msgid, ngettext } from "ttag";
 import _ from "underscore";
 
-import { Grid } from "metabase/components/Grid";
 import BulkActionBar from "metabase/components/BulkActionBar";
 import Button from "metabase/core/components/Button";
 import Modal from "metabase/components/Modal";
@@ -17,9 +16,6 @@ import {
   ActionBarContent,
   ActionBarText,
   ActionControlsRoot,
-  ActionGridItem,
-  ActionGridItemContent,
-  ActionGridPlaceholder,
 } from "./BulkActions.styled";
 
 const BulkActionControls = ({ onArchive, onMove }) => (
@@ -66,37 +62,29 @@ function BulkActions(props) {
     onCloseModal,
     onMove,
     onCopy,
+    isNavbarOpen,
   } = props;
   return (
-    <BulkActionBar showing={selected.length > 0}>
+    <BulkActionBar showing={selected.length > 0} isNavbarOpen={isNavbarOpen}>
       {/* NOTE: these padding and grid sizes must be carefully matched
                    to the main content above to ensure the bulk checkbox lines up */}
       <ActionBarContent>
-        <Grid>
-          <ActionGridPlaceholder />
-          <ActionGridItem>
-            <ActionGridItemContent>
-              <SelectionControls {...props} />
-              <BulkActionControls
-                onArchive={
-                  _.all(selected, item => item.setArchived) ? onArchive : null
-                }
-                onMove={
-                  _.all(selected, item => item.setCollection)
-                    ? onMoveStart
-                    : null
-                }
-              />
-              <ActionBarText>
-                {ngettext(
-                  msgid`${selected.length} item selected`,
-                  `${selected.length} items selected`,
-                  selected.length,
-                )}
-              </ActionBarText>
-            </ActionGridItemContent>
-          </ActionGridItem>
-        </Grid>
+        <SelectionControls {...props} />
+        <BulkActionControls
+          onArchive={
+            _.all(selected, item => item.setArchived) ? onArchive : null
+          }
+          onMove={
+            _.all(selected, item => item.setCollection) ? onMoveStart : null
+          }
+        />
+        <ActionBarText>
+          {ngettext(
+            msgid`${selected.length} item selected`,
+            `${selected.length} items selected`,
+            selected.length,
+          )}
+        </ActionBarText>
       </ActionBarContent>
       {!_.isEmpty(selectedItems) && selectedAction === "copy" && (
         <Modal onClose={onCloseModal}>

--- a/frontend/src/metabase/collections/components/BulkActions.styled.tsx
+++ b/frontend/src/metabase/collections/components/BulkActions.styled.tsx
@@ -4,6 +4,9 @@ import { breakpointMinSmall } from "metabase/styled-components/theme";
 export const ActionBarContent = styled.div`
   padding: 0.5rem 1rem;
   display: flex;
+  align-items: center;
+  width: 90%;
+  margin: 0 auto;
 
   ${breakpointMinSmall} {
     padding-left: 2rem;

--- a/frontend/src/metabase/collections/components/BulkActions.styled.tsx
+++ b/frontend/src/metabase/collections/components/BulkActions.styled.tsx
@@ -1,5 +1,17 @@
 import styled from "@emotion/styled";
 import { breakpointMinSmall } from "metabase/styled-components/theme";
+import { color } from "metabase/lib/colors";
+
+import { SIDEBAR_WIDTH } from "metabase/collections/constants";
+
+export const FixedBottomBar = styled.div<{ isNavbarOpen: boolean }>`
+  position: fixed;
+  bottom: 0;
+  left: ${props => (props.isNavbarOpen ? SIDEBAR_WIDTH : 0)};
+  right: 0;
+  border-top: 1px solid ${color("border")};
+  background-color: ${color("white")};
+`;
 
 export const ActionBarContent = styled.div`
   padding: 0.5rem 1rem;

--- a/frontend/src/metabase/collections/components/BulkActions.styled.tsx
+++ b/frontend/src/metabase/collections/components/BulkActions.styled.tsx
@@ -1,9 +1,9 @@
 import styled from "@emotion/styled";
 import { breakpointMinSmall } from "metabase/styled-components/theme";
-import { GridItem } from "metabase/components/Grid";
 
 export const ActionBarContent = styled.div`
   padding: 0.5rem 1rem;
+  display: flex;
 
   ${breakpointMinSmall} {
     padding-left: 2rem;
@@ -17,31 +17,4 @@ export const ActionBarText = styled.div`
 
 export const ActionControlsRoot = styled.div`
   margin-left: 0.5rem;
-`;
-
-export const ActionGridItem = styled(GridItem)`
-  width: 100%;
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
-
-  ${breakpointMinSmall} {
-    width: 66.66%;
-    padding-left: 1rem;
-    padding-right: 1rem;
-  }
-`;
-
-export const ActionGridItemContent = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  padding: 0 1rem;
-`;
-
-export const ActionGridPlaceholder = styled.div`
-  width: 100%;
-
-  ${breakpointMinSmall} {
-    width: 33.33%;
-  }
 `;

--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -10,6 +10,7 @@ import Search from "metabase/entities/search";
 import { getUserIsAdmin } from "metabase/selectors/user";
 import { getMetadata } from "metabase/selectors/metadata";
 import { getIsBookmarked } from "metabase/collections/selectors";
+import { getIsNavbarOpen } from "metabase/redux/app";
 
 import BulkActions from "metabase/collections/components/BulkActions";
 import CollectionEmptyState from "metabase/components/CollectionEmptyState";
@@ -41,6 +42,7 @@ function mapStateToProps(state, props) {
     isAdmin: getUserIsAdmin(state),
     isBookmarked: getIsBookmarked(state, props),
     metadata: getMetadata(state),
+    isNavbarOpen: getIsNavbarOpen(state),
   };
 }
 
@@ -60,6 +62,7 @@ function CollectionContent({
   isRoot,
   handleToggleMobileSidebar,
   metadata,
+  isNavbarOpen,
 }) {
   const [isBookmarked, setIsBookmarked] = useState(false);
   const [selectedItems, setSelectedItems] = useState(null);
@@ -269,6 +272,7 @@ function CollectionContent({
                         hasUnselected={hasUnselected}
                         selectedItems={selectedItems}
                         selectedAction={selectedAction}
+                        isNavbarOpen={isNavbarOpen}
                       />
                     </CollectionTable>
                   );

--- a/frontend/src/metabase/components/BulkActionBar.jsx
+++ b/frontend/src/metabase/components/BulkActionBar.jsx
@@ -4,14 +4,16 @@ import styled from "@emotion/styled";
 import Card from "metabase/components/Card";
 import { Motion, spring } from "react-motion";
 
+import { SIDEBAR_WIDTH } from "metabase/collections/constants";
+
 const FixedBottomBar = styled.div`
   position: fixed;
   bottom: 0;
-  left: 0;
+  left: ${props => (props.isNavbarOpen ? SIDEBAR_WIDTH : 0)};
   right: 0;
 `;
 
-const BulkActionBar = ({ children, showing }) => (
+const BulkActionBar = ({ children, showing, isNavbarOpen }) => (
   <Motion
     defaultStyle={{
       opacity: 0,
@@ -30,6 +32,7 @@ const BulkActionBar = ({ children, showing }) => (
           transform: `translateY(${translateY}px)`,
         }}
         data-testid="bulk-action-bar"
+        isNavbarOpen={isNavbarOpen}
       >
         <Card>{children}</Card>
       </FixedBottomBar>

--- a/frontend/src/metabase/components/BulkActionBar.jsx
+++ b/frontend/src/metabase/components/BulkActionBar.jsx
@@ -1,8 +1,8 @@
 /* eslint-disable react/prop-types */
 import React from "react";
 import styled from "@emotion/styled";
-import Card from "metabase/components/Card";
 import { Motion, spring } from "react-motion";
+import { color } from "metabase/lib/colors";
 
 import { SIDEBAR_WIDTH } from "metabase/collections/constants";
 
@@ -11,6 +11,8 @@ const FixedBottomBar = styled.div`
   bottom: 0;
   left: ${props => (props.isNavbarOpen ? SIDEBAR_WIDTH : 0)};
   right: 0;
+  border-top: 1px solid ${color("border")};
+  background-color: ${color("white")};
 `;
 
 const BulkActionBar = ({ children, showing, isNavbarOpen }) => (
@@ -27,14 +29,12 @@ const BulkActionBar = ({ children, showing, isNavbarOpen }) => (
     {({ opacity, translateY }) => (
       <FixedBottomBar
         style={{
-          borderRadius: 0,
-          opacity,
           transform: `translateY(${translateY}px)`,
         }}
         data-testid="bulk-action-bar"
         isNavbarOpen={isNavbarOpen}
       >
-        <Card>{children}</Card>
+        {children}
       </FixedBottomBar>
     )}
   </Motion>

--- a/frontend/src/metabase/components/BulkActionBar.tsx
+++ b/frontend/src/metabase/components/BulkActionBar.tsx
@@ -1,21 +1,19 @@
 /* eslint-disable react/prop-types */
 import React from "react";
-import styled from "@emotion/styled";
 import { Motion, spring } from "react-motion";
-import { color } from "metabase/lib/colors";
+import { FixedBottomBar } from "metabase/collections/components/BulkActions.styled";
 
-import { SIDEBAR_WIDTH } from "metabase/collections/constants";
+interface BulkActionBarProps {
+  children: React.ReactNode;
+  showing: boolean;
+  isNavbarOpen: boolean;
+}
 
-const FixedBottomBar = styled.div`
-  position: fixed;
-  bottom: 0;
-  left: ${props => (props.isNavbarOpen ? SIDEBAR_WIDTH : 0)};
-  right: 0;
-  border-top: 1px solid ${color("border")};
-  background-color: ${color("white")};
-`;
-
-const BulkActionBar = ({ children, showing, isNavbarOpen }) => (
+const BulkActionBar = ({
+  children,
+  showing,
+  isNavbarOpen,
+}: BulkActionBarProps) => (
   <Motion
     defaultStyle={{
       opacity: 0,
@@ -26,7 +24,7 @@ const BulkActionBar = ({ children, showing, isNavbarOpen }) => (
       translateY: showing ? spring(0) : spring(100),
     }}
   >
-    {({ opacity, translateY }) => (
+    {({ translateY }) => (
       <FixedBottomBar
         style={{
           transform: `translateY(${translateY}px)`,


### PR DESCRIPTION
Fixes layout of the bulk actions bar to factor in whether the new sidebar nav. Includes some general housekeeping.

Before:
![Screen Shot 2022-03-29 at 11 30 49 AM](https://user-images.githubusercontent.com/5248953/160648700-f5f7c793-97e1-488f-8394-3c13024d45fd.png)
![Screen Shot 2022-03-29 at 11 30 46 AM](https://user-images.githubusercontent.com/5248953/160648701-5ffb9209-7b2a-4869-a03e-e101ccd90e70.png)

After:
![Screen Shot 2022-03-29 at 11 29 02 AM](https://user-images.githubusercontent.com/5248953/160648344-2ca8264d-fdf2-407f-8eab-d296e2758133.png)
![Screen Shot 2022-03-29 at 11 28 55 AM](https://user-images.githubusercontent.com/5248953/160648347-37347442-2eed-43c8-84ea-86f729a28647.png)


https://www.loom.com/share/34509d1f5d134fd0a2d61fda2953cbee

## How to test
- Go to a collection with a couple of unpinned items with the sidebar either open or closed. Click one of the checkboxes next to an item name to select the item.
- The action bar should slide up and and the content should be aligned with the collection content.
- Close (or open) the navbar from the top nav and the layout should adjust and keep the same width as the collection content.