### PR TITLE
Fix Time Series Fill When Grouping by Minute

### DIFF
--- a/frontend/src/metabase/visualizations/lib/timeseries.js
+++ b/frontend/src/metabase/visualizations/lib/timeseries.js
@@ -66,7 +66,7 @@ const TIMESERIES_INTERVALS = [
 
 // mapping from Metabase "unit" to d3 intervals above
 const INTERVAL_INDEX_BY_UNIT = {
-  minute: 1,
+  minute: 5,
   hour: 9,
   day: 13,
   week: 14,

--- a/frontend/test/metabase/visualizations/lib/timeseries.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/timeseries.unit.spec.js
@@ -155,6 +155,34 @@ describe("visualization.lib.timeseries", () => {
         expect(count).toBe(expectedCount);
       });
     });
+
+    const units = ["minute", "hour", "day", "week", "month", "year"];
+
+    units.forEach(testUnit => {
+      it(`should return one ${testUnit} when ${testUnit} interval is set`, () => {
+        const { interval, count } = computeTimeseriesDataInverval(
+          [
+            new Date("2019-01-01").toISOString(),
+            new Date("2020-01-01").toISOString(),
+          ],
+          testUnit,
+        );
+        expect(interval).toBe(testUnit);
+        expect(count).toBe(1);
+      });
+    });
+
+    it("should return 3 months for quarter interval", () => {
+      const { interval, count } = computeTimeseriesDataInverval(
+        [
+          new Date("2019-01-01").toISOString(),
+          new Date("2020-01-01").toISOString(),
+        ],
+        "quarter",
+      );
+      expect(interval).toBe("month");
+      expect(count).toBe(3);
+    });
   });
 
   describe("getTimezone", () => {


### PR DESCRIPTION
## Before

- When grouping timeseries data by minute, and setting "replace missing values" to "none" or "zero", the data would still be connected, when it should have a gap.

![Screenshot from 2022-03-29 11-09-06](https://user-images.githubusercontent.com/30528226/160667668-5daba7d9-03d2-46d3-ab0b-8d24db0ff9a0.png)

## Changes

- `metabase/visulations/lib/fill_data.js` > `fillMissingValuesInData()` is responsible for filling a data series with zero or null values, which is what prevents a line chart from drawing a continuous line when "replace missing values" is set to "zero" or "none"
- for performance reasons, fillMissingValuesInData() will not fill more than 10,000 values.  So it should be able to show about 6 days of values for every minute.

![Screenshot from 2022-03-29 11-13-05](https://user-images.githubusercontent.com/30528226/160668074-7df01486-e0c0-471a-9dfe-1430705a84c1.png)

- However, when the xInterval was set to "minute", internally, it was actually being set to "second" - which made the number of intervals too great to render at all (more than 10,000), so the function was never filling per-minute time series with zeroes or nulls at all.
- As it turns out, there was just an array index reference pointing to the per-second value, rather than the per minute one in `INTERVAL_INDEX_BY_UNIT`, and fixing this allows us to render zeroes and nulls in per-minute time series, resolving https://github.com/metabase/metabase/issues/16037
- Added unit tests to cover explicit time intervals in computeTimeSeriesDataInterval()

## After

Correctly inserts null or zero data into data grouped by minute

By Day | By Hour | By Minute
--- | --- |---
![Screenshot from 2022-03-29 11-07-09](https://user-images.githubusercontent.com/30528226/160680822-123fc22f-4f3b-4a3b-a5ec-4c83ae68eb5a.png) | ![Screenshot from 2022-03-29 11-06-30](https://user-images.githubusercontent.com/30528226/160680828-7568b6f6-0d70-47fa-a6ff-f5c58bd825f8.png) | ![Screenshot from 2022-03-29 11-06-44](https://user-images.githubusercontent.com/30528226/160680826-623c7108-7e0c-4f4c-905f-8b6aa685cad2.png) 
