### PR TITLE
Fix error and new question pages layout

### DIFF
--- a/frontend/src/metabase/containers/ErrorPages.jsx
+++ b/frontend/src/metabase/containers/ErrorPages.jsx
@@ -2,8 +2,6 @@
 import React from "react";
 import { t } from "ttag";
 
-import fitViewport from "metabase/hoc/FitViewPort";
-
 import Icon from "metabase/components/Icon";
 import EmptyState from "metabase/components/EmptyState";
 import ErrorDetails from "metabase/components/ErrorDetails/ErrorDetails";
@@ -11,16 +9,12 @@ import ErrorDetails from "metabase/components/ErrorDetails/ErrorDetails";
 import NoResults from "assets/img/no_results.svg";
 import { ErrorPageRoot } from "./ErrorPages.styled";
 
-const ErrorPageWrapper = fitViewport(({ fitClassNames, children }) => (
-  <ErrorPageRoot className={fitClassNames}>{children}</ErrorPageRoot>
-));
-
 export const GenericError = ({
   title = t`Something's gone wrong`,
   message = t`We've run into an error. You can try refreshing the page, or just go back.`,
   details = null,
 }) => (
-  <ErrorPageWrapper>
+  <ErrorPageRoot>
     <EmptyState
       title={title}
       message={message}
@@ -29,34 +23,34 @@ export const GenericError = ({
       }
     />
     <ErrorDetails className="pt2" details={details} centered />
-  </ErrorPageWrapper>
+  </ErrorPageRoot>
 );
 
 export const NotFound = () => (
-  <ErrorPageWrapper>
+  <ErrorPageRoot>
     <EmptyState
       illustrationElement={<img src={NoResults} />}
       title={t`We're a little lost...`}
       message={t`The page you asked for couldn't be found.`}
     />
-  </ErrorPageWrapper>
+  </ErrorPageRoot>
 );
 
 export const Unauthorized = () => (
-  <ErrorPageWrapper>
+  <ErrorPageRoot>
     <EmptyState
       title={t`Sorry, you don’t have permission to see that.`}
       illustrationElement={<Icon name="key" size={100} />}
     />
-  </ErrorPageWrapper>
+  </ErrorPageRoot>
 );
 
 export const Archived = ({ entityName, linkTo }) => (
-  <ErrorPageWrapper>
+  <ErrorPageRoot>
     <EmptyState
       title={t`This ${entityName} has been archived`}
       illustrationElement={<Icon name="view_archive" size={100} />}
       link={linkTo}
     />
-  </ErrorPageWrapper>
+  </ErrorPageRoot>
 );

--- a/frontend/src/metabase/containers/ErrorPages.styled.tsx
+++ b/frontend/src/metabase/containers/ErrorPages.styled.tsx
@@ -2,6 +2,8 @@ import styled from "@emotion/styled";
 
 export const ErrorPageRoot = styled.div`
   display: flex;
+  width: 100%;
+  height: 100%;
   flex-direction: column;
   justify-content: center;
   align-items: center;

--- a/frontend/src/metabase/new_query/containers/NewQueryOptions.jsx
+++ b/frontend/src/metabase/new_query/containers/NewQueryOptions.jsx
@@ -6,8 +6,6 @@ import { push } from "react-router-redux";
 
 import { t } from "ttag";
 
-import fitViewport from "metabase/hoc/FitViewPort";
-
 import { Grid } from "metabase/components/Grid";
 
 import NewQueryOption from "metabase/new_query/components/NewQueryOption";
@@ -36,7 +34,6 @@ const mapDispatchToProps = {
   push,
 };
 
-@fitViewport
 @connect(mapStateToProps, mapDispatchToProps)
 export default class NewQueryOptions extends Component {
   componentDidMount() {

--- a/frontend/src/metabase/new_query/containers/NewQueryOptions.styled.tsx
+++ b/frontend/src/metabase/new_query/containers/NewQueryOptions.styled.tsx
@@ -10,6 +10,12 @@ const getPercentage = (number: number): string => {
 };
 
 export const QueryOptionsRoot = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  height: 100%;
+
   margin: auto 0.5rem;
 
   ${breakpointMinSmall} {


### PR DESCRIPTION
Seems like `fitViewport` stopped working properly for some pages with new nav changes. Fixing 🔨 

### Before

<img width="1458" alt="error-before" src="https://user-images.githubusercontent.com/17258145/160702147-61e19488-cf71-41bd-a0b9-e1724a0b32ef.png">

<img width="1455" alt="new-q-before" src="https://user-images.githubusercontent.com/17258145/160702144-e688a634-dcad-4248-87ad-82eeaccb7fb9.png">

### After

<img width="1176" alt="error-after" src="https://user-images.githubusercontent.com/17258145/160702196-a21dbd79-9a39-4dda-9a6f-222b234e0b9c.png">


<img width="1456" alt="new-q-after" src="https://user-images.githubusercontent.com/17258145/160702178-29245d1a-8e50-4518-944d-05db8e81b7dc.png">

