### PR TITLE
[e2e] use maildev version 1.1.0 (backport)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ executors:
     working_directory: /home/circleci/metabase/metabase/
     docker:
       - image: metabase/ci:circleci-java-8-clj-1.10.3.929-07-27-2021-node-browsers
-      - image: maildev/maildev
+      - image: maildev/maildev:1.1.0
       - image: metabase/qa-databases:postgres-sample-12
       - image: metabase/qa-databases:mongo-sample-4.0
       - image: metabase/qa-databases:mysql-sample-8

--- a/.github/workflows/percy-issue-comment.yml
+++ b/.github/workflows/percy-issue-comment.yml
@@ -141,7 +141,7 @@ jobs:
           jar xf target/uberjar/metabase.jar version.properties
           mv version.properties resources/
       - name: Run maildev
-        run: docker run -d -p 80:80 -p 25:25 maildev/maildev
+        run: docker run -d -p 80:80 -p 25:25 maildev/maildev:1.1.0
       - name: Percy Test
         run: yarn run test-visual-no-build
         env:

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -134,7 +134,7 @@ jobs:
           jar xf target/uberjar/metabase.jar version.properties
           mv version.properties resources/
       - name: Run maildev
-        run: docker run -d -p 80:80 -p 25:25 maildev/maildev
+        run: docker run -d -p 80:80 -p 25:25 maildev/maildev:1.1.0
       - name: Percy Test
         run: yarn run test-visual-no-build
         env:

--- a/frontend/test/__support__/e2e/helpers/e2e-email-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-email-helpers.js
@@ -3,7 +3,7 @@ const INBOX_INTERVAL = 100;
 
 /**
  * Make sure you have webmail Docker image running locally:
- * `docker run -p 80:80 -p 25:25 maildev/maildev`
+ * `docker run -p 80:80 -p 25:25 maildev/maildev:1.1.0`
  *
  * or
  *

--- a/frontend/test/metabase/scenarios/README.md
+++ b/frontend/test/metabase/scenarios/README.md
@@ -2,7 +2,7 @@
 
 ## Running
 
-- If you are running tests that include `alert > email_alert`, run `docker run -p 80:80 -p 25:25 maildev/maildev` in terminal first for setting up email through your localhost
+- If you are running tests that include `alert > email_alert`, run `docker run -p 80:80 -p 25:25 maildev/maildev:1.1.0` in terminal first for setting up email through your localhost
 
 ## Metabase QA DB Tests
 


### PR DESCRIPTION
New releases of maildev were recently made which has UI changes as well as changing the default port from 25 to 1025, causing tests to fail.

While we may want to upgrade maildev in the future, let's stick to the old version first to unbreak all the tests.

This is a manual backport of #21333
