### PR TITLE
[E2E] Explicitly point to the running Snowplow micro

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -3,7 +3,7 @@ name: E2E Tests
 on:
   push:
     branches:
-      - 'master'
+      - 'e2e-snowplow-url'
 
 jobs:
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -3,7 +3,7 @@ name: E2E Tests
 on:
   push:
     branches:
-      - 'e2e-snowplow-url'
+      - 'master'
 
 jobs:
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -44,6 +44,7 @@ jobs:
       QA_DB_ENABLED: true
       ENTERPRISE_TOKEN: ${{ secrets.ENTERPRISE_TOKEN }}
       MB_SNOWPLOW_AVAILABLE: true
+      MB_SNOWPLOW_URL: "http://localhost:9090"  # Snowplow micro
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
### Before this PR

Error in `frontend/test/metabase/scenarios/question/timelines.cy.spec.js`, because of the failure to post to Snowplow.

![scenarios  collections  timelines -- should send snowplow events when creating a timeline event (failed)](https://user-images.githubusercontent.com/7288/160750428-653cc4e8-cf4f-47b7-a0dc-372c342eaabc.png)


### After this PR

No more Snowplow failure, since the URL for the running Snowplow (micro) is explicitly set.
See this run: https://github.com/metabase/metabase/actions/runs/2062452715.

![image](https://user-images.githubusercontent.com/7288/160750757-ed2691ff-4db0-4c0f-afbf-4d7827a000a4.png)
