### PR TITLE
Fix changing column order/visibility via sidebar is inconsistent #13455

### DIFF
--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -323,6 +323,7 @@ export function normalizeQuery(query, tableMetadata) {
     return query;
   }
   if (query.query) {
+    // sort query.fields
     if (tableMetadata) {
       query = updateIn(query, ["query", "fields"], fields => {
         fields = fields
@@ -334,6 +335,23 @@ export function normalizeQuery(query, tableMetadata) {
           JSON.stringify(b).localeCompare(JSON.stringify(a)),
         );
       });
+    }
+
+    // sort query.joins[int].fields
+    if (query.query.joins) {
+      query = updateIn(query, ["query", "joins"], joins =>
+        joins.map(joinedTable => {
+          if (!joinedTable.fields || joinedTable.fields === "all") {
+            return joinedTable;
+          }
+
+          const joinedTableFields = [...joinedTable.fields];
+          joinedTableFields.sort((a, b) =>
+            JSON.stringify(b).localeCompare(JSON.stringify(a)),
+          );
+          return { ...joinedTable, fields: joinedTableFields };
+        }),
+      );
     }
     ["aggregation", "breakout", "filter", "joins", "order-by"].forEach(
       clauseList => {

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx
@@ -59,9 +59,11 @@ export default class ChartSettingOrderedColumns extends Component {
   };
 
   handleSortEnd = ({ oldIndex, newIndex }) => {
-    const fields = [...this.props.value];
-    fields.splice(newIndex, 0, fields.splice(oldIndex, 1)[0]);
-    this.props.onChange(fields);
+    const enabledColumns = [...this.props.value].filter(columnSetting =>
+      findColumnForColumnSetting(this.props.columns, columnSetting),
+    );
+    enabledColumns.splice(newIndex, 0, enabledColumns.splice(oldIndex, 1)[0]);
+    this.props.onChange(enabledColumns);
   };
 
   handleEdit = columnSetting => {

--- a/frontend/src/metabase/visualizations/visualizations/Table.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Table.jsx
@@ -173,7 +173,9 @@ export default class Table extends Component {
         // otherwise it will be overwritten by `getDefault` below
         card.visualization_settings["table.columns"].length !== 0 &&
         _.all(
-          card.visualization_settings["table.columns"],
+          card.visualization_settings["table.columns"].filter(
+            columnSetting => columnSetting.enabled,
+          ),
           columnSetting =>
             findColumnIndexForColumnSetting(data.cols, columnSetting) >= 0,
         ),

--- a/frontend/test/metabase/scenarios/question/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/settings.cy.spec.js
@@ -72,7 +72,7 @@ describe("scenarios > question > settings", () => {
         .should("not.exist");
     });
 
-    it.skip("should preserve correct order of columns after column removal via sidebar (metabase#13455)", () => {
+    it("should preserve correct order of columns after column removal via sidebar (metabase#13455)", () => {
       cy.viewport(2000, 1200);
       // Orders join Products
       visitQuestionAdhoc({
@@ -138,6 +138,10 @@ describe("scenarios > question > settings", () => {
         cy.icon("play")
           .last()
           .click();
+
+        // Prevent performing actions while the query is being executed.
+        // Which caused some race condition and failed the test.
+        cy.findByText(/Doing science/).should("not.exist");
       }
 
       function findColumnAtIndex(column_name, index) {

--- a/frontend/test/metabase/scenarios/question/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/settings.cy.spec.js
@@ -130,9 +130,33 @@ describe("scenarios > question > settings", () => {
       cy.findByText("Visible columns").click();
       findColumnAtIndex("Products → Category", 5);
 
+      // https://github.com/metabase/metabase/pull/21338#pullrequestreview-928807257
+
+      // Add "Address"
+      cy.findByText("Address")
+        .siblings(".Icon-add")
+        .click();
       /**
        * Helper functions related to THIS test only
        */
+      // The result automatically load when adding new fields
+      cy.wait("@dataset");
+
+      // Refresh @sidebarColumns as we added a new field
+      cy.findByText("Click and drag to change their order")
+        .parent()
+        .find(".cursor-grab")
+        .as("sidebarColumns"); // Store all columns in an array
+
+      findColumnAtIndex("User → Address", -1).as("user-address");
+
+      cy.get("@user-address")
+        .trigger("mousedown", 0, 0, { force: true })
+        .trigger("mousemove", 5, 5, { force: true })
+        .trigger("mousemove", 0, -50, { force: true })
+        .trigger("mouseup", 0, -50, { force: true });
+
+      findColumnAtIndex("User → Address", 15);
 
       function reloadResults() {
         cy.icon("play")
@@ -141,11 +165,12 @@ describe("scenarios > question > settings", () => {
 
         // Prevent performing actions while the query is being executed.
         // Which caused some race condition and failed the test.
-        cy.findByText(/Doing science/).should("not.exist");
+        cy.wait("@dataset");
       }
 
       function findColumnAtIndex(column_name, index) {
-        cy.get("@sidebarColumns")
+        return cy
+          .get("@sidebarColumns")
           .eq(index)
           .contains(column_name);
       }


### PR DESCRIPTION
Fixes #13455

I'm not exactly sure if this will break anything else. But basically, there are 3 problems in #13455
1. Changing column order the first time will always show the "Play-button"
1. Changing joined table column order after the first time will show the "Play-button".
    <img src='https://user-images.githubusercontent.com/1447303/95860173-f9447700-0d5f-11eb-8dfc-276e8c52d014.png' />
1. Changing column order and visibility will revert the order after clicking the "Play-button".

So, there are 2 approaches to fixing this issue.
1. Make it so that the "Play-button" never shows.
2. Fix the result after clicking "Play-button" given there are column order and visibility settings changed to be consistent.

Let's see what causes each problem in detail.

## 1. Changing column order the first time will always show the "Play-button"
The root cause is from how we're determining if the visualization is *dirty* or not.
https://github.com/metabase/metabase/blob/e6c0cbfdd44460d7f98bbfd40e4fbe1b11bc12d1/frontend/src/metabase/query_builder/selectors.js#L361-L366

The first time when we change the column order the `query.joins[int].fields` will change from `all` to an array of fields
### Before column reordering
![image](https://user-images.githubusercontent.com/1937582/160796415-1981a92e-2649-4681-973f-f2f3ab520780.png)

### After column reordering
![image](https://user-images.githubusercontent.com/1937582/160796620-b569d157-09d1-4dde-be66-453c8382361f.png)

There's no way at the moment to verify if the `all` and an array of fields are equal. Or it would be hacky.

## 2. Changing joined table column order after the first time will show the "Play-button".
I traced it back to https://github.com/metabase/metabase/issues/10466 which [added the logic to sort `query.fields`](https://github.com/metabase/metabase/pull/11311/files#diff-2fc40467e8370b516c4ce51320cd4d159278808493231640527a65f51d06e65aR170). But there's no place that we sort `query.joins[int].fields`. That's why the "Play-button" will only appear when we sort the joined table columns, but not the primary table columns.

## 3. Changing column order and visibility will revert the order after clicking the "Play-button".
It's because of how we compute the series settings.
From here
https://github.com/metabase/metabase/blob/8220d653e7fde7eb1797a9a515b4fda5126ed76f/frontend/src/metabase/visualizations/components/Visualization.jsx#L147
it eventually calls
https://github.com/metabase/metabase/blob/bceca3b31e90e6ab5d23ed4937b439e466baefbd/frontend/src/metabase/visualizations/lib/settings.js#L94-L98
which calls
https://github.com/metabase/metabase/blob/444d16c81b7d31c83e1bdc9d3aa926097b2769c7/frontend/src/metabase/visualizations/visualizations/Table.jsx#L169-L179

if you look carefully at the validator
https://github.com/metabase/metabase/blob/444d16c81b7d31c83e1bdc9d3aa926097b2769c7/frontend/src/metabase/visualizations/visualizations/Table.jsx#L175-L179
it tries to match column settings with data columns which are changed after we run the query after hiding a column.

![image](https://user-images.githubusercontent.com/1937582/160801977-d542cdef-4304-47b4-8f9e-b793184ad403.png)

You could see that this will always fail as we have less `data.cols` than the column settings. I'm not sure if this will break other functionality or not, but it seems to me we should only test the enabled column. As those columns with `enabled: false` will not be present in the `data.cols`
![image](https://user-images.githubusercontent.com/1937582/160802324-3e2ffbab-0f53-4544-afc8-1ed483d691f3.png)

## Summary
This PR addresses 2. and 3. but not 1. as it would require the work to match `"all"` with an array of fields.