### PR TITLE
15876 fix time random casting with without timezone

### DIFF
--- a/frontend/src/metabase/lib/formatting.js
+++ b/frontend/src/metabase/lib/formatting.js
@@ -462,9 +462,9 @@ export function formatTime(value) {
   const m = parseTime(value);
   if (!m.isValid()) {
     return String(value);
-  } else {
-    return m.format("LT");
   }
+
+  return m.format("LT");
 }
 
 export function formatTimeWithUnit(value, unit, options = {}) {

--- a/frontend/src/metabase/lib/time.js
+++ b/frontend/src/metabase/lib/time.js
@@ -103,16 +103,15 @@ export function parseTime(value) {
   if (moment.isMoment(value)) {
     return value;
   } else if (typeof value === "string") {
-    return moment.parseZone(value, [
-      "HH:mm:SS.sssZZ",
-      "HH:mm:SS.sss",
+    return moment(value, [
+      "HH:mm:ss.sss[Z]",
       "HH:mm:SS.sss",
       "HH:mm:SS",
       "HH:mm",
     ]);
-  } else {
-    return moment.utc(value);
   }
+
+  return moment.utc(value);
 }
 
 // @deprecated - use formatTimeWithUnit(hour, "hour-of-day")

--- a/frontend/test/metabase/lib/formatting.unit.spec.js
+++ b/frontend/test/metabase/lib/formatting.unit.spec.js
@@ -7,6 +7,7 @@ import {
   formatValue,
   formatUrl,
   formatDateTimeWithUnit,
+  formatTime,
   formatTimeWithUnit,
   slugify,
 } from "metabase/lib/formatting";
@@ -520,6 +521,28 @@ describe("formatting", () => {
         "Sun",
       );
     });
+  });
+
+  describe("formatTime", () => {
+    const FORMAT_TIME_TESTS = [
+      ["01:02:03.456+07:00", "1:02 AM"],
+      ["01:02", "1:02 AM"],
+      ["22:29:59.26816+01:00", "10:29 PM"],
+      ["22:29:59.412459+01:00", "10:29 PM"],
+      ["19:14:42.926221+01:00", "7:14 PM"],
+      ["19:14:42.13202+01:00", "7:14 PM"],
+      ["13:38:58.987352+01:00", "1:38 PM"],
+      ["13:38:58.001001+01:00", "1:38 PM"],
+      ["17:01:23+01:00", "5:01 PM"],
+    ];
+
+    test.each(FORMAT_TIME_TESTS)(
+      `parseTime(%p) to be %p`,
+      (value, resultStr) => {
+        const result = formatTime(value);
+        expect(result).toBe(resultStr);
+      },
+    );
   });
 
   describe("formatTimeWithUnit", () => {

--- a/frontend/test/metabase/lib/time.unit.spec.js
+++ b/frontend/test/metabase/lib/time.unit.spec.js
@@ -59,19 +59,26 @@ describe("time", () => {
   });
 
   describe("parseTime", () => {
-    it("parse timezones", () => {
-      const result = parseTime("01:02:03.456+07:00");
+    const PARSE_TIME_TESTS = [
+      ["01:02:03.456+07:00", "1:02 AM"],
+      ["01:02", "1:02 AM"],
+      ["22:29:59.26816+01:00", "10:29 PM"],
+      ["22:29:59.412459+01:00", "10:29 PM"],
+      ["19:14:42.926221+01:00", "7:14 PM"],
+      ["19:14:42.13202+01:00", "7:14 PM"],
+      ["13:38:58.987352+01:00", "1:38 PM"],
+      ["13:38:58.001001+01:00", "1:38 PM"],
+      ["17:01:23+01:00", "5:01 PM"],
+    ];
 
-      expect(moment.isMoment(result)).toBe(true);
-      expect(result.format("h:mm A")).toBe("1:02 AM");
-    });
-
-    it("parse time without seconds", () => {
-      const result = parseTime("01:02");
-
-      expect(moment.isMoment(result)).toBe(true);
-      expect(result.format("h:mm A")).toBe("1:02 AM");
-    });
+    test.each(PARSE_TIME_TESTS)(
+      `parseTime(%p) to be %p`,
+      (value, resultStr) => {
+        const result = parseTime(value);
+        expect(moment.isMoment(result)).toBe(true);
+        expect(result.format("h:mm A")).toBe(resultStr);
+      },
+    );
   });
 
   describe("getRelativeTimeAbbreviated", () => {

--- a/frontend/test/metabase/scenarios/question/reproductions/15876-postgres-cast-time.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/15876-postgres-cast-time.cy.spec.js
@@ -41,7 +41,7 @@ const correctValues = [
   },
 ];
 
-describe.skip("issue 15876", () => {
+describe("issue 15876", () => {
   beforeEach(() => {
     restore("postgres-12");
     cy.signInAsAdmin();


### PR DESCRIPTION
Fixes #15876.

- [x] Fix for the `parseTime` method
- [x] New tests added for the `parseTime` method
- [x] Tests created for the `formatTime` method

__Before__

Using the repro steps from https://github.com/metabase/metabase/issues/15876#issuecomment-830210005.
![image](https://user-images.githubusercontent.com/348552/160804890-0bf3f314-8674-4f7b-9d3e-b3ec8f7079b9.png)

__After__

All the dates are normalised regardless of the milliseconds.
![image](https://user-images.githubusercontent.com/348552/160805430-ec03866e-6226-4086-bc5c-925e4f0aab2a.png)
