### PR TITLE
Add buttons to persist/unpersist a database and a model for PoC

### DIFF
--- a/frontend/src/metabase-lib/lib/Question.ts
+++ b/frontend/src/metabase-lib/lib/Question.ts
@@ -323,6 +323,10 @@ export default class Question {
     return this._card && this._card.dataset;
   }
 
+  isPersisted() {
+    return this._card && this._card.persisted;
+  }
+
   setDataset(dataset) {
     return this.setCard(assoc(this.card(), "dataset", dataset));
   }

--- a/frontend/src/metabase-lib/lib/metadata/Database.ts
+++ b/frontend/src/metabase-lib/lib/metadata/Database.ts
@@ -96,6 +96,14 @@ export default class Database extends Base {
     return this.hasFeature("expressions") && this.hasFeature("left-join");
   }
 
+  isPersisted() {
+    return this.details["persist-models"];
+  }
+
+  supportsModelPersistence() {
+    return this.hasFeature("persist-models");
+  }
+
   canWrite() {
     return this.native_permissions === "write";
   }

--- a/frontend/src/metabase-lib/lib/metadata/Database.ts
+++ b/frontend/src/metabase-lib/lib/metadata/Database.ts
@@ -96,14 +96,6 @@ export default class Database extends Base {
     return this.hasFeature("expressions") && this.hasFeature("left-join");
   }
 
-  isPersisted() {
-    return this.details["persist-models"];
-  }
-
-  supportsModelPersistence() {
-    return this.hasFeature("persist-models");
-  }
-
   canWrite() {
     return this.native_permissions === "write";
   }

--- a/frontend/src/metabase-lib/lib/metadata/Database.ts
+++ b/frontend/src/metabase-lib/lib/metadata/Database.ts
@@ -100,6 +100,14 @@ export default class Database extends Base {
     return this.native_permissions === "write";
   }
 
+  isPersisted() {
+    return this.details["persist-models"];
+  }
+
+  supportsPersistence() {
+    return this.hasFeature("persist-models");
+  }
+
   // QUESTIONS
   newQuestion() {
     return this.question()

--- a/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.jsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.jsx
@@ -87,9 +87,9 @@ const DatabaseEditAppSidebar = ({
               </li>
             )}
 
-            {database.supportsModelPersistence() && (
+            {database.features["persist-models"] && (
               <li className="mt2">
-                {database.isPersisted() ? (
+                {database.details["persist-models"] ? (
                   <ActionButton
                     actionFn={() => unpersistDatabase(database.id)}
                     className="Button Button--danger"

--- a/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.jsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.jsx
@@ -16,6 +16,8 @@ const propTypes = {
   syncDatabaseSchema: PropTypes.func.isRequired,
   rescanDatabaseFields: PropTypes.func.isRequired,
   discardSavedFieldValues: PropTypes.func.isRequired,
+  persistDatabase: PropTypes.func.isRequired,
+  unpersistDatabase: PropTypes.func.isRequired,
 };
 
 const DatabaseEditAppSidebar = ({
@@ -24,6 +26,8 @@ const DatabaseEditAppSidebar = ({
   syncDatabaseSchema,
   rescanDatabaseFields,
   discardSavedFieldValues,
+  persistDatabase,
+  unpersistDatabase,
 }) => {
   const discardSavedFieldValuesModal = useRef();
   const deleteDatabaseModal = useRef();
@@ -80,6 +84,30 @@ const DatabaseEditAppSidebar = ({
                     onAction={() => discardSavedFieldValues(database.id)}
                   />
                 </ModalWithTrigger>
+              </li>
+            )}
+
+            {database.supportsModelPersistence() && (
+              <li className="mt2">
+                {database.isPersisted() ? (
+                  <ActionButton
+                    actionFn={() => unpersistDatabase(database.id)}
+                    className="Button Button--danger"
+                    normalText={t`Disable model persistence`}
+                    activeText={t`Disabling…`}
+                    failedText={t`Disabling failed`}
+                    successText={t`Disabled`}
+                  />
+                ) : (
+                  <ActionButton
+                    actionFn={() => persistDatabase(database.id)}
+                    className="Button Button--danger"
+                    normalText={t`Enable model persistence`}
+                    activeText={t`Enabling…`}
+                    failedText={t`Enabling failed`}
+                    successText={t`Enabled`}
+                  />
+                )}
               </li>
             )}
 

--- a/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.jsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.jsx
@@ -87,9 +87,9 @@ const DatabaseEditAppSidebar = ({
               </li>
             )}
 
-            {database.features["persist-models"] && (
+            {database.supportsPersistence() && (
               <li className="mt2">
-                {database.details["persist-models"] ? (
+                {database.isPersisted() ? (
                   <ActionButton
                     actionFn={() => unpersistDatabase(database.id)}
                     className="Button Button--danger"

--- a/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx
@@ -15,6 +15,7 @@ import Sidebar from "metabase/admin/databases/components/DatabaseEditApp/Sidebar
 import DriverWarning from "metabase/containers/DriverWarning";
 
 import Databases from "metabase/entities/databases";
+import { getMetadata } from "metabase/selectors/metadata";
 
 import {
   getEditingDatabase,
@@ -48,8 +49,11 @@ const DATABASE_FORM_NAME = "database";
 const mapStateToProps = state => {
   const database = getEditingDatabase(state);
   const formValues = getValues(state.form[DATABASE_FORM_NAME]);
+  const metadata = getMetadata(state);
+
   return {
     database,
+    metadata,
     databaseCreationStep: getDatabaseCreationStep(state),
     selectedEngine: formValues ? formValues.engine : undefined,
     initializeError: getInitializeError(state),
@@ -78,6 +82,7 @@ export default class DatabaseEditApp extends Component {
 
   static propTypes = {
     database: PropTypes.object,
+    metadata: PropTypes.object,
     databaseCreationStep: PropTypes.string,
     params: PropTypes.object.isRequired,
     reset: PropTypes.func.isRequired,
@@ -101,6 +106,7 @@ export default class DatabaseEditApp extends Component {
   render() {
     const {
       database,
+      metadata,
       deleteDatabase,
       discardSavedFieldValues,
       selectedEngine,
@@ -191,7 +197,7 @@ export default class DatabaseEditApp extends Component {
 
           {editingExistingDatabase && (
             <Sidebar
-              database={database}
+              database={metadata.database(database.id)}
               deleteDatabase={deleteDatabase}
               discardSavedFieldValues={discardSavedFieldValues}
               rescanDatabaseFields={rescanDatabaseFields}

--- a/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx
@@ -31,6 +31,8 @@ import {
   discardSavedFieldValues,
   deleteDatabase,
   selectEngine,
+  persistDatabase,
+  unpersistDatabase,
 } from "../database";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 import {
@@ -61,6 +63,8 @@ const mapDispatchToProps = {
   syncDatabaseSchema,
   rescanDatabaseFields,
   discardSavedFieldValues,
+  persistDatabase,
+  unpersistDatabase,
   deleteDatabase,
   selectEngine,
 };
@@ -81,6 +85,8 @@ export default class DatabaseEditApp extends Component {
     syncDatabaseSchema: PropTypes.func.isRequired,
     rescanDatabaseFields: PropTypes.func.isRequired,
     discardSavedFieldValues: PropTypes.func.isRequired,
+    persistDatabase: PropTypes.func.isRequired,
+    unpersistDatabase: PropTypes.func.isRequired,
     deleteDatabase: PropTypes.func.isRequired,
     saveDatabase: PropTypes.func.isRequired,
     selectEngine: PropTypes.func.isRequired,
@@ -101,6 +107,8 @@ export default class DatabaseEditApp extends Component {
       initializeError,
       rescanDatabaseFields,
       syncDatabaseSchema,
+      persistDatabase,
+      unpersistDatabase,
     } = this.props;
     const editingExistingDatabase = database?.id != null;
     const addingNewDatabase = !editingExistingDatabase;
@@ -188,6 +196,8 @@ export default class DatabaseEditApp extends Component {
               discardSavedFieldValues={discardSavedFieldValues}
               rescanDatabaseFields={rescanDatabaseFields}
               syncDatabaseSchema={syncDatabaseSchema}
+              persistDatabase={persistDatabase}
+              unpersistDatabase={unpersistDatabase}
             />
           )}
         </DatabaseEditMain>

--- a/frontend/src/metabase/admin/databases/database.js
+++ b/frontend/src/metabase/admin/databases/database.js
@@ -6,6 +6,7 @@ import {
   handleActions,
 } from "metabase/lib/redux";
 import { push } from "react-router-redux";
+import Database from "metabase-lib/lib/metadata/Database";
 import * as MetabaseAnalytics from "metabase/lib/analytics";
 import MetabaseSettings from "metabase/lib/settings";
 
@@ -106,7 +107,8 @@ export const initializeDatabase = function(databaseId) {
         const action = await dispatch(
           Databases.actions.fetch({ id: databaseId }, { reload: true }),
         );
-        const database = Databases.HACK_getObjectFromAction(action);
+        const payload = Databases.HACK_getObjectFromAction(action);
+        const database = new Database(payload);
         dispatch.action(INITIALIZE_DATABASE, database);
 
         // If the new scheduling toggle isn't set, run the migration

--- a/frontend/src/metabase/admin/databases/database.js
+++ b/frontend/src/metabase/admin/databases/database.js
@@ -30,7 +30,7 @@ export const ADD_SAMPLE_DATABASE_FAILED =
 export const ADDING_SAMPLE_DATABASE =
   "metabase/admin/databases/ADDING_SAMPLE_DATABASE";
 export const DELETE_DATABASE = "metabase/admin/databases/DELETE_DATABASE";
-export const PERSIST_DATABASE = "metabase/admin/databases/DELETE_DATABASE";
+export const PERSIST_DATABASE = "metabase/admin/databases/PERSIST_DATABASE";
 export const UNPERSIST_DATABASE = "metabase/admin/databases/UNPERSIST_DATABASE";
 export const SYNC_DATABASE_SCHEMA =
   "metabase/admin/databases/SYNC_DATABASE_SCHEMA";
@@ -294,7 +294,7 @@ export const persistDatabase = createThunkAction(
 );
 
 export const unpersistDatabase = createThunkAction(
-  PERSIST_DATABASE,
+  UNPERSIST_DATABASE,
   databaseId => async () => {
     await MetabaseApi.db_persist({ dbId: databaseId });
   },
@@ -320,10 +320,10 @@ const editingDatabase = handleActions(
     [UPDATE_DATABASE]: (state, { payload }) => payload.database || state,
     [DELETE_DATABASE]: (state, { payload }) => null,
     [SELECT_ENGINE]: (state, { payload }) => ({ ...state, engine: payload }),
-    [PERSIST_DATABASE]: state =>
-      assocIn(state, ["details", "persist-models"], true),
-    [UNPERSIST_DATABASE]: state =>
-      assocIn(state, ["details", "persist-models"], false),
+    [PERSIST_DATABASE]: (state, { error }) =>
+      assocIn(state, ["details", "persist-models"], !error),
+    [UNPERSIST_DATABASE]: (state, { error }) =>
+      assocIn(state, ["details", "persist-models"], !!error),
     [SET_DATABASE_CREATION_STEP]: (state, { payload: { database } }) =>
       database,
   },

--- a/frontend/src/metabase/admin/databases/database.js
+++ b/frontend/src/metabase/admin/databases/database.js
@@ -296,7 +296,7 @@ export const persistDatabase = createThunkAction(
 export const unpersistDatabase = createThunkAction(
   UNPERSIST_DATABASE,
   databaseId => async () => {
-    await MetabaseApi.db_persist({ dbId: databaseId });
+    await MetabaseApi.db_unpersist({ dbId: databaseId });
   },
 );
 

--- a/frontend/src/metabase/admin/databases/database.js
+++ b/frontend/src/metabase/admin/databases/database.js
@@ -6,7 +6,6 @@ import {
   handleActions,
 } from "metabase/lib/redux";
 import { push } from "react-router-redux";
-import Database from "metabase-lib/lib/metadata/Database";
 import * as MetabaseAnalytics from "metabase/lib/analytics";
 import MetabaseSettings from "metabase/lib/settings";
 
@@ -107,8 +106,7 @@ export const initializeDatabase = function(databaseId) {
         const action = await dispatch(
           Databases.actions.fetch({ id: databaseId }, { reload: true }),
         );
-        const payload = Databases.HACK_getObjectFromAction(action);
-        const database = new Database(payload);
+        const database = Databases.HACK_getObjectFromAction(action);
         dispatch.action(INITIALIZE_DATABASE, database);
 
         // If the new scheduling toggle isn't set, run the migration

--- a/frontend/src/metabase/admin/databases/database.js
+++ b/frontend/src/metabase/admin/databases/database.js
@@ -1,4 +1,5 @@
 import { createAction } from "redux-actions";
+import { assocIn } from "icepick";
 import {
   combineReducers,
   createThunkAction,
@@ -29,6 +30,8 @@ export const ADD_SAMPLE_DATABASE_FAILED =
 export const ADDING_SAMPLE_DATABASE =
   "metabase/admin/databases/ADDING_SAMPLE_DATABASE";
 export const DELETE_DATABASE = "metabase/admin/databases/DELETE_DATABASE";
+export const PERSIST_DATABASE = "metabase/admin/databases/DELETE_DATABASE";
+export const UNPERSIST_DATABASE = "metabase/admin/databases/UNPERSIST_DATABASE";
 export const SYNC_DATABASE_SCHEMA =
   "metabase/admin/databases/SYNC_DATABASE_SCHEMA";
 export const RESCAN_DATABASE_FIELDS =
@@ -283,6 +286,20 @@ export const discardSavedFieldValues = createThunkAction(
   },
 );
 
+export const persistDatabase = createThunkAction(
+  PERSIST_DATABASE,
+  databaseId => async () => {
+    await MetabaseApi.db_persist({ dbId: databaseId });
+  },
+);
+
+export const unpersistDatabase = createThunkAction(
+  PERSIST_DATABASE,
+  databaseId => async () => {
+    await MetabaseApi.db_persist({ dbId: databaseId });
+  },
+);
+
 export const closeSyncingModal = createThunkAction(
   CLOSE_SYNCING_MODAL,
   function() {
@@ -303,6 +320,10 @@ const editingDatabase = handleActions(
     [UPDATE_DATABASE]: (state, { payload }) => payload.database || state,
     [DELETE_DATABASE]: (state, { payload }) => null,
     [SELECT_ENGINE]: (state, { payload }) => ({ ...state, engine: payload }),
+    [PERSIST_DATABASE]: state =>
+      assocIn(state, ["details", "persist-models"], true),
+    [UNPERSIST_DATABASE]: state =>
+      assocIn(state, ["details", "persist-models"], false),
     [SET_DATABASE_CREATION_STEP]: (state, { payload: { database } }) =>
       database,
   },

--- a/frontend/src/metabase/lib/data-modeling/utils.ts
+++ b/frontend/src/metabase/lib/data-modeling/utils.ts
@@ -18,8 +18,8 @@ export function checkDatabaseSupportsModels(database?: Database | null) {
   return database && database.hasFeature("nested-queries");
 }
 
-export function checkDatabaseSupportsPersistence(database?: Database | null) {
-  return database && database.supportsPersistence();
+export function checkDatabaseCanPersistDatasets(database?: Database | null) {
+  return database && database.supportsPersistence() && database.isPersisted();
 }
 
 export function checkCanBeModel(question: Question) {

--- a/frontend/src/metabase/lib/data-modeling/utils.ts
+++ b/frontend/src/metabase/lib/data-modeling/utils.ts
@@ -18,6 +18,10 @@ export function checkDatabaseSupportsModels(database?: Database | null) {
   return database && database.hasFeature("nested-queries");
 }
 
+export function checkDatabaseSupportsPersistence(database?: Database | null) {
+  return database && database.supportsPersistence();
+}
+
 export function checkCanBeModel(question: Question) {
   const query = question.query();
 

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -1685,3 +1685,13 @@ export const showTimelinesForCollection = collectionId => (
 
   dispatch(showTimelines(collectionTimelines));
 };
+
+export const PERSIST_DATASET = "metabase/qb/PERSIST_DATASET";
+export const persistDataset = createAction(PERSIST_DATASET, ({ id }) =>
+  CardApi.persist({ id }),
+);
+
+export const UNPERSIST_DATASET = "metabase/qb/UNPERSIST_DATASET";
+export const unpersistDataset = createAction(UNPERSIST_DATASET, ({ id }) =>
+  CardApi.unpersist({ id }),
+);

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -1687,11 +1687,11 @@ export const showTimelinesForCollection = collectionId => (
 };
 
 export const PERSIST_DATASET = "metabase/qb/PERSIST_DATASET";
-export const persistDataset = createAction(PERSIST_DATASET, ({ id }) =>
+export const persistDataset = createAction(PERSIST_DATASET, id =>
   CardApi.persist({ id }),
 );
 
 export const UNPERSIST_DATASET = "metabase/qb/UNPERSIST_DATASET";
-export const unpersistDataset = createAction(UNPERSIST_DATASET, ({ id }) =>
+export const unpersistDataset = createAction(UNPERSIST_DATASET, id =>
   CardApi.unpersist({ id }),
 );

--- a/frontend/src/metabase/query_builder/components/QuestionActionButtons.jsx
+++ b/frontend/src/metabase/query_builder/components/QuestionActionButtons.jsx
@@ -37,8 +37,8 @@ QuestionActionButtons.propTypes = {
   onOpenModal: PropTypes.func.isRequired,
   isBookmarked: PropTypes.bool.isRequired,
   toggleBookmark: PropTypes.func.isRequired,
-  persistModel: PropTypes.func.isRequired,
-  unpersistModel: PropTypes.func.isRequired,
+  persistDataset: PropTypes.func.isRequired,
+  unpersistDataset: PropTypes.func.isRequired,
 };
 
 function mapStateToProps(state) {
@@ -54,9 +54,10 @@ function QuestionActionButtons({
   onOpenModal,
   isBookmarked,
   toggleBookmark,
-  persistModel,
-  unpersistModel,
+  persistDataset,
+  unpersistDataset,
 }) {
+  const isSaved = question.isSaved();
   const isDataset = question.isDataset();
   const isPersisted = question.isPersisted();
 
@@ -70,8 +71,9 @@ function QuestionActionButtons({
     areNestedQueriesEnabled &&
     checkDatabaseSupportsModels(question.query().database());
 
-  const canPersistModel =
+  const canPersistDataset =
     canWrite &&
+    isSaved &&
     isDataset &&
     checkDatabaseSupportsPersistence(question.query().database());
 
@@ -126,14 +128,14 @@ function QuestionActionButtons({
           />
         </Tooltip>
       )}
-      {canPersistModel &&
+      {canPersistDataset &&
         (isPersisted ? (
           <Tooltip tooltip={t`Unpersist model`}>
             <Button
               onlyIcon
               icon="database"
               iconSize={ICON_SIZE}
-              onClick={() => unpersistModel(question.id())}
+              onClick={() => unpersistDataset(question.id())}
             />
           </Tooltip>
         ) : (
@@ -142,7 +144,7 @@ function QuestionActionButtons({
               onlyIcon
               icon="database"
               iconSize={ICON_SIZE}
-              onClick={() => persistModel(question.id())}
+              onClick={() => persistDataset(question.id())}
             />
           </Tooltip>
         ))}

--- a/frontend/src/metabase/query_builder/components/QuestionActionButtons.jsx
+++ b/frontend/src/metabase/query_builder/components/QuestionActionButtons.jsx
@@ -8,6 +8,7 @@ import colors from "metabase/lib/colors";
 import {
   checkDatabaseSupportsModels,
   checkCanBeModel,
+  checkDatabaseSupportsPersistence,
 } from "metabase/lib/data-modeling/utils";
 
 import { MODAL_TYPES } from "metabase/query_builder/constants";
@@ -22,6 +23,8 @@ export const EDIT_TESTID = "edit-details-button";
 export const ADD_TO_DASH_TESTID = "add-to-dashboard-button";
 export const MOVE_TESTID = "move-button";
 export const TURN_INTO_DATASET_TESTID = "turn-into-dataset";
+export const PERSIST_DATASET_TESTID = "persist-dataset";
+export const UNPERSIST_DATASET_TESTID = "unpersist-dataset";
 export const CLONE_TESTID = "clone-button";
 export const ARCHIVE_TESTID = "archive-button";
 
@@ -34,6 +37,8 @@ QuestionActionButtons.propTypes = {
   onOpenModal: PropTypes.func.isRequired,
   isBookmarked: PropTypes.bool.isRequired,
   toggleBookmark: PropTypes.func.isRequired,
+  persistModel: PropTypes.func.isRequired,
+  unpersistModel: PropTypes.func.isRequired,
 };
 
 function mapStateToProps(state) {
@@ -49,8 +54,11 @@ function QuestionActionButtons({
   onOpenModal,
   isBookmarked,
   toggleBookmark,
+  persistModel,
+  unpersistModel,
 }) {
   const isDataset = question.isDataset();
+  const isPersisted = question.isPersisted();
 
   const duplicateTooltip = isDataset
     ? t`Duplicate this model`
@@ -61,6 +69,11 @@ function QuestionActionButtons({
     !isDataset &&
     areNestedQueriesEnabled &&
     checkDatabaseSupportsModels(question.query().database());
+
+  const canPersistModel =
+    canWrite &&
+    isDataset &&
+    checkDatabaseSupportsPersistence(question.query().database());
 
   const bookmarkButtonColor = isBookmarked ? colors["brand"] : "";
 
@@ -113,6 +126,26 @@ function QuestionActionButtons({
           />
         </Tooltip>
       )}
+      {canPersistModel &&
+        (isPersisted ? (
+          <Tooltip tooltip={t`Unpersist model`}>
+            <Button
+              onlyIcon
+              icon="database"
+              iconSize={ICON_SIZE}
+              onClick={() => unpersistModel(question.id())}
+            />
+          </Tooltip>
+        ) : (
+          <Tooltip tooltip={t`Persist model`}>
+            <Button
+              onlyIcon
+              icon="database"
+              iconSize={ICON_SIZE}
+              onClick={() => persistModel(question.id())}
+            />
+          </Tooltip>
+        ))}
       {canWrite && (
         <Tooltip tooltip={duplicateTooltip}>
           <Button

--- a/frontend/src/metabase/query_builder/components/QuestionActionButtons.jsx
+++ b/frontend/src/metabase/query_builder/components/QuestionActionButtons.jsx
@@ -8,7 +8,7 @@ import colors from "metabase/lib/colors";
 import {
   checkDatabaseSupportsModels,
   checkCanBeModel,
-  checkDatabaseSupportsPersistence,
+  checkDatabaseCanPersistDatasets,
 } from "metabase/lib/data-modeling/utils";
 
 import { MODAL_TYPES } from "metabase/query_builder/constants";
@@ -75,7 +75,7 @@ function QuestionActionButtons({
     canWrite &&
     isSaved &&
     isDataset &&
-    checkDatabaseSupportsPersistence(question.query().database());
+    checkDatabaseCanPersistDatasets(question.query().database());
 
   const bookmarkButtonColor = isBookmarked ? colors["brand"] : "";
 

--- a/frontend/src/metabase/query_builder/components/view/View.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View.jsx
@@ -129,6 +129,8 @@ export default class View extends React.Component {
       onCloseChartType,
       isBookmarked,
       toggleBookmark,
+      persistDataset,
+      unpersistDataset,
     } = this.props;
 
     if (isShowingChartSettingsSidebar) {
@@ -148,6 +150,8 @@ export default class View extends React.Component {
           onOpenModal={onOpenModal}
           isBookmarked={isBookmarked}
           toggleBookmark={toggleBookmark}
+          persistDataset={persistDataset}
+          unpersistDataset={unpersistDataset}
         />
       );
     }

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebar.jsx
@@ -9,6 +9,8 @@ QuestionDetailsSidebar.propTypes = {
   onOpenModal: PropTypes.func.isRequired,
   isBookmarked: PropTypes.bool.isRequired,
   toggleBookmark: PropTypes.func.isRequired,
+  persistDataset: PropTypes.func.isRequired,
+  unpersistDataset: PropTypes.func.isRequired,
 };
 
 function QuestionDetailsSidebar({
@@ -16,6 +18,8 @@ function QuestionDetailsSidebar({
   onOpenModal,
   isBookmarked,
   toggleBookmark,
+  persistDataset,
+  unpersistDataset,
 }) {
   const [view, setView] = useState(view);
 
@@ -29,6 +33,8 @@ function QuestionDetailsSidebar({
           onOpenModal={onOpenModal}
           isBookmarked={isBookmarked}
           toggleBookmark={toggleBookmark}
+          persistDataset={persistDataset}
+          unpersistDataset={unpersistDataset}
         />
       );
   }

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebarPanel.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebarPanel.jsx
@@ -20,6 +20,8 @@ QuestionDetailsSidebarPanel.propTypes = {
   onOpenModal: PropTypes.func.isRequired,
   isBookmarked: PropTypes.bool.isRequired,
   toggleBookmark: PropTypes.func.isRequired,
+  persistDataset: PropTypes.func.isRequired,
+  unpersistDataset: PropTypes.func.isRequired,
 };
 
 function QuestionDetailsSidebarPanel({
@@ -27,6 +29,8 @@ function QuestionDetailsSidebarPanel({
   onOpenModal,
   isBookmarked,
   toggleBookmark,
+  persistDataset,
+  unpersistDataset,
 }) {
   const isDataset = question.isDataset();
   const canWrite = question.canWrite();
@@ -47,6 +51,8 @@ function QuestionDetailsSidebarPanel({
           onOpenModal={onOpenModal}
           isBookmarked={isBookmarked}
           toggleBookmark={toggleBookmark}
+          persistDataset={persistDataset}
+          unpersistDataset={unpersistDataset}
         />
         <ClampedDescription
           visibleLines={8}

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -117,7 +117,7 @@ export const CardApi = {
   update: PUT("/api/card/:id"),
   delete: DELETE("/api/card/:id"),
   persist: POST("/api/card/:id/persist"),
-  unpersist: POST("/api/card/:cardId/unpersist"),
+  unpersist: POST("/api/card/:id/unpersist"),
   query: POST("/api/card/:cardId/query"),
   query_pivot: POST("/api/card/pivot/:cardId/query"),
   bookmark: {

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -115,7 +115,9 @@ export const CardApi = {
   create: POST("/api/card"),
   get: GET("/api/card/:cardId"),
   update: PUT("/api/card/:id"),
-  delete: DELETE("/api/card/:cardId"),
+  delete: DELETE("/api/card/:id"),
+  persist: POST("/api/card/:id/persist"),
+  unpersist: POST("/api/card/:cardId/unpersist"),
   query: POST("/api/card/:cardId/query"),
   query_pivot: POST("/api/card/pivot/:cardId/query"),
   bookmark: {

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -253,6 +253,8 @@ export const MetabaseApi = {
   db_sync_schema: POST("/api/database/:dbId/sync_schema"),
   db_rescan_values: POST("/api/database/:dbId/rescan_values"),
   db_discard_values: POST("/api/database/:dbId/discard_values"),
+  db_persist: POST("/api/database/:dbId/persist"),
+  db_unpersist: POST("/api/database/:dbId/unpersist"),
   db_get_db_ids_with_deprecated_drivers: GET("/db-ids-with-deprecated-drivers"),
   table_list: GET("/api/table"),
   // table_get:                   GET("/api/table/:tableId"),


### PR DESCRIPTION
Relies on:
- `card.persisted`
- `database.features["persist-models"]`
- `database.details["persist-models"]`
-  `POST("/api/card/:cardId/persist")`
- `POST("/api/card/:cardId/unpersist")`
- `POST("/api/database/:dbId/persist")`
- `POST("/api/database/:dbId/unpersist")`

Known issues:
- After persiting/unpersisting a model, a page refresh is required for the UI to reflect the `persisted` status

<img width="365" alt="Screenshot 2022-03-30 at 16 08 26" src="https://user-images.githubusercontent.com/8542534/160841827-920648e9-f530-47df-be5b-265c69df0f2d.png">

<img width="439" alt="Screenshot 2022-03-30 at 14 55 29" src="https://user-images.githubusercontent.com/8542534/160828958-f4728b17-acce-4e82-a9df-5cecbc2767f0.png">
