### PR TITLE
Browsing | Improve mobile sidebar

### DIFF
--- a/frontend/src/metabase/App.jsx
+++ b/frontend/src/metabase/App.jsx
@@ -25,7 +25,7 @@ import StatusListing from "metabase/status/containers/StatusListing";
 import CollectionCreate from "metabase/collections/containers/CollectionCreate";
 import { getIsEditing as getIsEditingDashboard } from "metabase/dashboard/selectors";
 
-import { toggleNavbar, getIsNavbarOpen } from "metabase/redux/app";
+import { toggleNavbar, closeNavbar, getIsNavbarOpen } from "metabase/redux/app";
 import { IFRAMED, initializeIframeResizer } from "metabase/lib/dom";
 
 import { AppContentContainer, AppContent } from "./App.styled";
@@ -43,6 +43,7 @@ const mapStateToProps = state => ({
 const mapDispatchToProps = {
   onChangeLocation: push,
   toggleNavbar,
+  closeNavbar,
 };
 
 const getErrorComponent = ({ status, data, context }) => {
@@ -169,6 +170,7 @@ class App extends Component {
       errorPage,
       onChangeLocation,
       toggleNavbar,
+      closeNavbar,
     } = this.props;
     const { errorInfo } = this.state;
     const hasAppBar = this.hasAppBar();
@@ -182,8 +184,9 @@ class App extends Component {
               <AppBar
                 isSidebarOpen={isSidebarOpen}
                 location={location}
-                onToggleSidebarClick={toggleNavbar}
                 onNewClick={this.setModal}
+                onToggleSidebarClick={toggleNavbar}
+                handleCloseSidebar={closeNavbar}
                 onChangeLocation={onChangeLocation}
               />
             )}

--- a/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.jsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.jsx
@@ -20,14 +20,12 @@ import {
   DescriptionHeading,
   MenuContainer,
   TitleContent,
-  ToggleMobileSidebarIcon,
 } from "./CollectionHeader.styled";
 
-function Title({ collection, handleToggleMobileSidebar }) {
+function Title({ collection }) {
   return (
     <div>
       <TitleContent>
-        <ToggleMobileSidebarIcon onClick={handleToggleMobileSidebar} />
         <PLUGIN_COLLECTION_COMPONENTS.CollectionAuthorityLevelIcon
           collection={collection}
           mr={1}

--- a/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.styled.jsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.styled.jsx
@@ -25,20 +25,6 @@ export const MenuContainer = styled.div`
   align-self: start;
 `;
 
-export const ToggleMobileSidebarIcon = styled(Icon)`
-  cursor: pointer;
-  margin: ${space(0)} ${space(2)} 0 ${space(1)};
-
-  ${breakpointMinSmall} {
-    display: none;
-  }
-`;
-
-ToggleMobileSidebarIcon.defaultProps = {
-  name: "burger",
-  size: 20,
-};
-
 export const DescriptionTooltipIcon = styled(Icon)`
   color: ${color("bg-dark")};
   margin-left: ${space(1)};

--- a/frontend/src/metabase/collections/components/CollectionSidebar/CollectionSidebar.styled.tsx
+++ b/frontend/src/metabase/collections/components/CollectionSidebar/CollectionSidebar.styled.tsx
@@ -18,11 +18,7 @@ export const LoadingTitle = styled.h2`
   margin-top: ${space(1)};
 `;
 
-interface SidebarProps {
-  shouldDisplayMobileSidebar: boolean;
-}
-
-export const Sidebar = styled.aside<SidebarProps>`
+export const Sidebar = styled.aside`
   bottom: 0;
   display: flex;
   box-sizing: border-box;
@@ -33,19 +29,6 @@ export const Sidebar = styled.aside<SidebarProps>`
   padding-top: ${space(1)};
   width: 0;
   background-color: transparent;
-
-  ${({ shouldDisplayMobileSidebar }) =>
-    shouldDisplayMobileSidebar &&
-    css`
-      box-shadow: 5px 0px 8px rgba(0, 0, 0, 0.35),
-        40px 0px rgba(5, 14, 31, 0.32);
-      width: calc(100vw - 40px);
-
-      ${breakpointMinSmall} {
-        box-shadow: none;
-        width: ${SIDEBAR_WIDTH};
-      }
-    `}
 
   ${breakpointMinSmall} {
     width: ${SIDEBAR_WIDTH};
@@ -92,22 +75,3 @@ export const ToggleListDisplayButton = styled(Icon)<
       transform: rotate(90deg) translate(-1px, -1px);
     `}
 `;
-
-export const ToggleMobileSidebarIcon = styled(Icon)`
-  color: ${color("brand")};
-  // margin sizes hard-coded
-  // for icon to land on
-  // same position as burger icon
-  // when sidebar is hidden in mobile
-  margin: -4px ${space(2)} 0 30px;
-
-  ${breakpointMinSmall} {
-    cursor: pointer;
-    display: none;
-  }
-`;
-
-ToggleMobileSidebarIcon.defaultProps = {
-  name: "close",
-  size: 20,
-};

--- a/frontend/src/metabase/collections/components/CollectionSidebar/Collections/Collections.jsx
+++ b/frontend/src/metabase/collections/components/CollectionSidebar/Collections/Collections.jsx
@@ -12,7 +12,6 @@ import { Container } from "./Collections.styled";
 const propTypes = {
   collectionId: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   currentUserId: PropTypes.number,
-  handleToggleMobileSidebar: PropTypes.func.isRequired,
   list: PropTypes.array,
   onClose: PropTypes.func.isRequired,
   onOpen: PropTypes.func.isRequired,
@@ -22,7 +21,6 @@ const propTypes = {
 export default function Collections({
   collectionId,
   currentUserId,
-  handleToggleMobileSidebar,
   list,
   onClose,
   onOpen,
@@ -41,7 +39,6 @@ export default function Collections({
     <Container>
       <div>
         <CollectionsList
-          handleToggleMobileSidebar={handleToggleMobileSidebar}
           openCollections={openCollections}
           onClose={onClose}
           onOpen={onOpen}
@@ -51,7 +48,6 @@ export default function Collections({
         />
       </div>
       <CollectionsList
-        handleToggleMobileSidebar={handleToggleMobileSidebar}
         openCollections={openCollections}
         onClose={onClose}
         onOpen={onOpen}

--- a/frontend/src/metabase/collections/components/CollectionSidebar/Collections/CollectionsList/CollectionsList.jsx
+++ b/frontend/src/metabase/collections/components/CollectionSidebar/Collections/CollectionsList/CollectionsList.jsx
@@ -69,7 +69,6 @@ function Collection({
   depth,
   currentCollection,
   filter,
-  handleToggleMobileSidebar,
   initialIcon,
   onClose,
   onOpen,
@@ -91,7 +90,6 @@ function Collection({
           // expand to show sub collections
           function handleClick() {
             action(collection.id);
-            handleToggleMobileSidebar();
           }
 
           return (
@@ -121,7 +119,6 @@ function Collection({
       {children && isOpen && (
         <ChildrenContainer>
           <CollectionsList
-            handleToggleMobileSidebar={handleToggleMobileSidebar}
             openCollections={openCollections}
             onOpen={onOpen}
             onClose={onClose}
@@ -139,7 +136,6 @@ function Collection({
 function CollectionsList({
   collections,
   filter,
-  handleToggleMobileSidebar,
   initialIcon,
   depth = 1,
   ...otherProps
@@ -153,7 +149,6 @@ function CollectionsList({
           collection={collection}
           depth={depth}
           filter={filter}
-          handleToggleMobileSidebar={handleToggleMobileSidebar}
           initialIcon={initialIcon}
           key={collection.id}
           {...otherProps}

--- a/frontend/src/metabase/collections/components/CollectionSidebar/Collections/CollectionsList/CollectionsList.unit.spec.js
+++ b/frontend/src/metabase/collections/components/CollectionSidebar/Collections/CollectionsList/CollectionsList.unit.spec.js
@@ -11,7 +11,6 @@ describe("CollectionsList", () => {
         collections={collections}
         openCollections={openCollections}
         filter={() => true}
-        handleToggleMobileSidebar={() => false}
         {...props}
       />,
       { withRouter: true, withDND: true },

--- a/frontend/src/metabase/collections/components/CollectionSidebar/RootCollectionLink/RootCollectionLink.jsx
+++ b/frontend/src/metabase/collections/components/CollectionSidebar/RootCollectionLink/RootCollectionLink.jsx
@@ -12,14 +12,10 @@ import CollectionLink from "metabase/collections/components/CollectionSidebar/Co
 import { Container } from "./RootCollectionLink.styled";
 
 const propTypes = {
-  handleToggleMobileSidebar: PropTypes.func.isRequired,
   isRoot: PropTypes.bool.isRequired,
 };
 
-export default function RootCollectionLink({
-  handleToggleMobileSidebar,
-  isRoot,
-}) {
+export default function RootCollectionLink({ isRoot }) {
   return (
     <Collection.Loader id={ROOT_COLLECTION.id}>
       {({ collection: root }) => (
@@ -28,7 +24,6 @@ export default function RootCollectionLink({
             {({ highlighted, hovered }) => (
               <CollectionLink
                 to={Urls.collection({ id: ROOT_COLLECTION.id })}
-                onClick={handleToggleMobileSidebar}
                 selected={isRoot}
                 highlighted={highlighted}
                 hovered={hovered}

--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -60,7 +60,6 @@ function CollectionContent({
   deleteBookmark,
   isAdmin,
   isRoot,
-  handleToggleMobileSidebar,
   metadata,
   isNavbarOpen,
 }) {
@@ -184,7 +183,6 @@ function CollectionContent({
                   collection,
                   collectionList,
                 )}
-                handleToggleMobileSidebar={handleToggleMobileSidebar}
               />
               <PinnedItemOverview
                 items={pinnedItems}

--- a/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebar.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebar.jsx
@@ -13,7 +13,6 @@ import {
   LoadingTitle,
   Sidebar,
   SidebarHeading,
-  ToggleMobileSidebarIcon,
 } from "metabase/collections/components/CollectionSidebar/CollectionSidebar.styled";
 
 import RootCollectionLink from "metabase/collections/components/CollectionSidebar/RootCollectionLink";
@@ -54,8 +53,6 @@ CollectionSidebar.propTypes = {
   allFetched: PropTypes.bool,
   loading: PropTypes.bool,
   list: PropTypes.arrayOf(PropTypes.object),
-  shouldDisplayMobileSidebar: PropTypes.bool,
-  handleToggleMobileSidebar: PropTypes.func,
 };
 
 function CollectionSidebar({
@@ -68,8 +65,6 @@ function CollectionSidebar({
   allFetched,
   loading,
   list,
-  shouldDisplayMobileSidebar,
-  handleToggleMobileSidebar,
 }) {
   const [openCollections, setOpenCollections] = useState([]);
 
@@ -103,10 +98,7 @@ function CollectionSidebar({
   }, [collectionId, loading]);
 
   return (
-    <Sidebar
-      role="tree"
-      shouldDisplayMobileSidebar={shouldDisplayMobileSidebar}
-    >
+    <Sidebar role="tree">
       {allFetched ? (
         <React.Fragment>
           <Bookmarks bookmarks={bookmarks} deleteBookmark={deleteBookmark} />
@@ -115,17 +107,12 @@ function CollectionSidebar({
             <SidebarHeading>{t`Collections`}</SidebarHeading>
           )}
 
-          <ToggleMobileSidebarIcon onClick={handleToggleMobileSidebar} />
-          <RootCollectionLink
-            isRoot={isRoot}
-            handleToggleMobileSidebar={handleToggleMobileSidebar}
-          />
+          <RootCollectionLink isRoot={isRoot} />
           <Collections
             list={list}
             openCollections={openCollections}
             collectionId={collectionId}
             currentUserId={currentUser.id}
-            handleToggleMobileSidebar={handleToggleMobileSidebar}
             onOpen={onOpen}
             onClose={onClose}
           />

--- a/frontend/src/metabase/components/CollectionLanding/CollectionLanding.jsx
+++ b/frontend/src/metabase/components/CollectionLanding/CollectionLanding.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import React, { useState } from "react";
+import React from "react";
 
 import { extractCollectionId } from "metabase/lib/urls";
 
@@ -8,25 +8,13 @@ import CollectionContent from "metabase/collections/containers/CollectionContent
 import { ContentBox } from "./CollectionLanding.styled";
 
 const CollectionLanding = ({ params: { slug }, children }) => {
-  const [shouldDisplayMobileSidebar, setShouldDisplayMobileSidebar] = useState(
-    false,
-  );
-
-  const handleToggleMobileSidebar = () =>
-    setShouldDisplayMobileSidebar(!shouldDisplayMobileSidebar);
-
   const collectionId = extractCollectionId(slug);
   const isRoot = collectionId === "root";
 
   return (
     <PageWrapper>
-      <ContentBox shouldDisplayMobileSidebar={shouldDisplayMobileSidebar}>
-        <CollectionContent
-          isRoot={isRoot}
-          collectionId={collectionId}
-          handleToggleMobileSidebar={handleToggleMobileSidebar}
-          shouldDisplayMobileSidebar={shouldDisplayMobileSidebar}
-        />
+      <ContentBox>
+        <CollectionContent isRoot={isRoot} collectionId={collectionId} />
       </ContentBox>
       {
         // Need to have this here so the child modals will show up

--- a/frontend/src/metabase/components/CollectionLanding/CollectionLanding.styled.jsx
+++ b/frontend/src/metabase/components/CollectionLanding/CollectionLanding.styled.jsx
@@ -3,7 +3,6 @@ import styled from "@emotion/styled";
 import { breakpointMinSmall } from "metabase/styled-components/theme/media-queries";
 
 export const ContentBox = styled.div`
-  display: ${props => (props.shouldDisplayMobileSidebar ? "none" : "block")};
   overflow-y: auto;
 
   ${breakpointMinSmall} {

--- a/frontend/src/metabase/components/EntityMenu.jsx
+++ b/frontend/src/metabase/components/EntityMenu.jsx
@@ -139,7 +139,10 @@ class EntityMenu extends Component {
                                   }
                                   event={item.event && item.event}
                                   link={item.link}
-                                  onClose={() => this.toggleMenu()}
+                                  onClose={() => {
+                                    this.toggleMenu();
+                                    item?.onClose?.();
+                                  }}
                                 />
                               </li>
                             );

--- a/frontend/src/metabase/lib/dom.js
+++ b/frontend/src/metabase/lib/dom.js
@@ -444,3 +444,8 @@ export function getMainElement() {
   const [main] = document.getElementsByTagName("main");
   return main;
 }
+
+export function isSmallScreen() {
+  const mediaQuery = window.matchMedia("(max-width: 40em)");
+  return mediaQuery && mediaQuery.matches;
+}

--- a/frontend/src/metabase/nav/components/ProfileLink.jsx
+++ b/frontend/src/metabase/nav/components/ProfileLink.jsx
@@ -23,6 +23,7 @@ export default class ProfileLink extends Component {
 
   static propTypes = {
     user: PropTypes.object.isRequired,
+    handleCloseNavbar: PropTypes.func.isRequired,
   };
 
   openModal = modalName => {
@@ -35,7 +36,7 @@ export default class ProfileLink extends Component {
 
   generateOptionsForUser = () => {
     const { tag } = MetabaseSettings.get("version");
-    const { user } = this.props;
+    const { user, handleCloseNavbar } = this.props;
     const isAdmin = user.is_superuser;
     const canAccessSettings =
       isAdmin || PLUGIN_FEATURE_LEVEL_PERMISSIONS.canAccessSettings(user);
@@ -46,6 +47,7 @@ export default class ProfileLink extends Component {
         icon: null,
         link: Urls.accountSettings(),
         event: `Navbar;Profile Dropdown;Edit Profile`,
+        onClose: handleCloseNavbar,
       },
       canAccessSettings && {
         title: t`Admin settings`,
@@ -58,6 +60,7 @@ export default class ProfileLink extends Component {
         icon: null,
         link: "/activity",
         event: `Navbar;Profile Dropdown;Activity ${tag}`,
+        onClose: handleCloseNavbar,
       },
       {
         title: t`Help`,

--- a/frontend/src/metabase/nav/components/SearchBar.tsx
+++ b/frontend/src/metabase/nav/components/SearchBar.tsx
@@ -1,4 +1,10 @@
-import React, { useEffect, useCallback, useRef, useState } from "react";
+import React, {
+  FocusEvent,
+  useEffect,
+  useCallback,
+  useRef,
+  useState,
+} from "react";
 import { t } from "ttag";
 import { Location, LocationDescriptorObject } from "history";
 
@@ -24,6 +30,7 @@ type SearchAwareLocation = Location<{ q?: string }>;
 
 type Props = {
   location: SearchAwareLocation;
+  onFocus?: (e: FocusEvent<HTMLInputElement>) => void;
   onChangeLocation: (nextLocation: LocationDescriptorObject) => void;
 };
 
@@ -39,7 +46,7 @@ function getSearchTextFromLocation(location: SearchAwareLocation) {
   return "";
 }
 
-function SearchBar({ location, onChangeLocation }: Props) {
+function SearchBar({ location, onFocus, onChangeLocation }: Props) {
   const [searchText, setSearchText] = useState<string>(() =>
     getSearchTextFromLocation(location),
   );
@@ -108,6 +115,7 @@ function SearchBar({ location, onChangeLocation }: Props) {
           placeholder={t`Search` + "…"}
           maxLength={200}
           onClick={setActive}
+          onFocus={onFocus}
           onChange={onTextChange}
           onKeyPress={handleInputKeyPress}
           ref={searchInput}

--- a/frontend/src/metabase/nav/containers/AppBar.tsx
+++ b/frontend/src/metabase/nav/containers/AppBar.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback } from "react";
 import { t } from "ttag";
 import { Location, LocationDescriptorObject } from "history";
 
@@ -14,28 +14,37 @@ import {
 } from "metabase/nav/containers/Navbar.styled";
 
 import Database from "metabase/entities/databases";
+import { isSmallScreen } from "metabase/lib/dom";
 
 import { AppBarRoot, LogoIconWrapper, SidebarButton } from "./AppBar.styled";
 
 type Props = {
   isSidebarOpen: boolean;
   location: Location;
-  onToggleSidebarClick: () => void;
   onNewClick: () => void;
+  onToggleSidebarClick: () => void;
+  handleCloseSidebar: () => void;
   onChangeLocation: (nextLocation: LocationDescriptorObject) => void;
 };
 
 function AppBar({
   isSidebarOpen,
   location,
-  onToggleSidebarClick,
   onNewClick,
+  onToggleSidebarClick,
+  handleCloseSidebar,
   onChangeLocation,
 }: Props) {
+  const onLogoClick = useCallback(() => {
+    if (isSmallScreen()) {
+      handleCloseSidebar();
+    }
+  }, [handleCloseSidebar]);
+
   return (
     <AppBarRoot id="mainAppBar">
       <LogoIconWrapper>
-        <Link to="/" data-metabase-event="Navbar;Logo">
+        <Link to="/" onClick={onLogoClick} data-metabase-event="Navbar;Logo">
           <LogoIcon size={24} />
         </Link>
       </LogoIconWrapper>

--- a/frontend/src/metabase/nav/containers/AppBar.tsx
+++ b/frontend/src/metabase/nav/containers/AppBar.tsx
@@ -35,7 +35,7 @@ function AppBar({
   handleCloseSidebar,
   onChangeLocation,
 }: Props) {
-  const onLogoClick = useCallback(() => {
+  const closeSidebarForSmallScreens = useCallback(() => {
     if (isSmallScreen()) {
       handleCloseSidebar();
     }
@@ -44,7 +44,11 @@ function AppBar({
   return (
     <AppBarRoot id="mainAppBar">
       <LogoIconWrapper>
-        <Link to="/" onClick={onLogoClick} data-metabase-event="Navbar;Logo">
+        <Link
+          to="/"
+          onClick={closeSidebarForSmallScreens}
+          data-metabase-event="Navbar;Logo"
+        >
           <LogoIcon size={24} />
         </Link>
       </LogoIconWrapper>
@@ -56,7 +60,11 @@ function AppBar({
       </Tooltip>
       <SearchBarContainer>
         <SearchBarContent>
-          <SearchBar location={location} onChangeLocation={onChangeLocation} />
+          <SearchBar
+            location={location}
+            onChangeLocation={onChangeLocation}
+            onFocus={closeSidebarForSmallScreens}
+          />
         </SearchBarContent>
       </SearchBarContainer>
       <NewButton setModal={onNewClick} />

--- a/frontend/src/metabase/nav/containers/MainNavbar/BookmarkList/BookmarkList.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/BookmarkList/BookmarkList.tsx
@@ -25,6 +25,7 @@ const mapDispatchToProps = {
 interface CollectionSidebarBookmarksProps {
   bookmarks: Bookmark[];
   selectedItem?: SelectedEntityItem;
+  onSelect: () => void;
   onDeleteBookmark: (bookmark: Bookmark) => void;
 }
 
@@ -50,6 +51,7 @@ function BookmarkIcon({ bookmark }: { bookmark: Bookmark }) {
 const BookmarkList = ({
   bookmarks,
   selectedItem,
+  onSelect,
   onDeleteBookmark,
 }: CollectionSidebarBookmarksProps) => {
   const onToggleBookmarks = useCallback(isVisible => {
@@ -72,6 +74,7 @@ const BookmarkList = ({
           url={url}
           icon={<BookmarkIcon bookmark={bookmark} />}
           isSelected={isSelected}
+          onClick={onSelect}
           right={
             <button onClick={onRemove}>
               <Tooltip tooltip={t`Remove bookmark`} placement="bottom">
@@ -84,7 +87,7 @@ const BookmarkList = ({
         </SidebarBookmarkItem>
       );
     },
-    [selectedItem, onDeleteBookmark],
+    [selectedItem, onSelect, onDeleteBookmark],
   );
 
   return (

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.styled.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.styled.tsx
@@ -1,26 +1,19 @@
 import styled from "@emotion/styled";
 
-import { NAV_SIDEBAR_WIDTH } from "metabase/nav/constants";
-
 import { color } from "metabase/lib/colors";
 import { space } from "metabase/styled-components/theme";
-import { breakpointMinSmall } from "metabase/styled-components/theme/media-queries";
 
 export const Sidebar = styled.aside`
   display: flex;
   flex-direction: column;
   box-sizing: border-box;
   padding-top: ${space(1)};
-  width: 0;
+  width: 100%;
 
   overflow-x: hidden;
   overflow-y: auto;
 
   background-color: transparent;
-
-  ${breakpointMinSmall} {
-    width: ${NAV_SIDEBAR_WIDTH};
-  }
 `;
 
 export const SidebarHeading = styled.h4`

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.styled.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.styled.tsx
@@ -1,19 +1,27 @@
 import styled from "@emotion/styled";
 
+import { NAV_SIDEBAR_WIDTH } from "metabase/nav/constants";
+
 import { color } from "metabase/lib/colors";
 import { space } from "metabase/styled-components/theme";
 
-export const Sidebar = styled.aside`
+export const Sidebar = styled.aside<{ isOpen: boolean }>`
   display: flex;
   flex-direction: column;
   box-sizing: border-box;
   padding-top: ${space(1)};
-  width: 100%;
+  width: ${NAV_SIDEBAR_WIDTH};
+  background-color: transparent;
 
   overflow-x: hidden;
   overflow-y: auto;
 
-  background-color: transparent;
+  opacity: ${props => (props.isOpen ? 1 : 0)};
+  transition: opacity 0.2s;
+
+  @media (prefers-reduced-motion) {
+    transition: none;
+  }
 `;
 
 export const SidebarHeading = styled.h4`

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer.tsx
@@ -38,6 +38,7 @@ interface CollectionTreeItem extends Collection {
 }
 
 type Props = {
+  isOpen: boolean;
   currentUser: User;
   bookmarks: Bookmark[];
   collections: Collection[];
@@ -54,6 +55,7 @@ type Props = {
 };
 
 function MainNavbarContainer({
+  isOpen,
   currentUser,
   collections = [],
   rootCollection,
@@ -109,7 +111,7 @@ function MainNavbarContainer({
   }, [rootCollection, collections, currentUser]);
 
   return (
-    <Sidebar>
+    <Sidebar isOpen={isOpen}>
       {allFetched && rootCollection ? (
         <MainNavbarView
           {...props}

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer.tsx
@@ -50,6 +50,7 @@ type Props = {
   params: {
     slug?: string;
   };
+  closeNavbar: () => void;
 };
 
 function MainNavbarContainer({
@@ -60,6 +61,7 @@ function MainNavbarContainer({
   allFetched,
   location,
   params,
+  closeNavbar,
   ...props
 }: Props) {
   const selectedItem = useMemo<SelectedItem>(() => {
@@ -115,6 +117,7 @@ function MainNavbarContainer({
           collections={collectionTree}
           selectedItem={selectedItem}
           hasDataAccess={hasDataAccess}
+          handleCloseNavbar={closeNavbar}
         />
       ) : (
         <LoadingContainer>

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarView.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React, { useCallback, useMemo } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
@@ -14,6 +14,7 @@ import {
   getCollectionIcon,
   PERSONAL_COLLECTIONS,
 } from "metabase/entities/collections";
+import { isSmallScreen } from "metabase/lib/dom";
 import * as Urls from "metabase/lib/urls";
 
 import { SelectedItem } from "./types";
@@ -32,6 +33,7 @@ type Props = {
   collections: CollectionTreeItem[];
   selectedItem: SelectedItem;
   hasDataAccess: boolean;
+  handleCloseNavbar: () => void;
 };
 
 const BROWSE_URL = "/browse";
@@ -44,6 +46,7 @@ function MainNavbarView({
   collections,
   selectedItem,
   hasDataAccess,
+  handleCloseNavbar,
 }: Props) {
   const isMiscLinkSelected = selectedItem.type === "unknown";
   const isCollectionSelected =
@@ -59,6 +62,12 @@ function MainNavbarView({
     );
   }, []);
 
+  const onItemSelect = useCallback(() => {
+    if (isSmallScreen()) {
+      handleCloseNavbar();
+    }
+  }, [handleCloseNavbar]);
+
   return (
     <>
       {bookmarks.length > 0 && (
@@ -68,6 +77,7 @@ function MainNavbarView({
             selectedItem={
               selectedItem.type !== "unknown" ? selectedItem : undefined
             }
+            onSelect={onItemSelect}
           />
           <SidebarHeading>{t`Collections`}</SidebarHeading>
         </>
@@ -75,6 +85,7 @@ function MainNavbarView({
       <Tree
         data={collections}
         selectedId={isCollectionSelected ? selectedItem.id : undefined}
+        onSelect={onItemSelect}
         TreeNode={CollectionLink}
         role="tree"
       />
@@ -86,6 +97,7 @@ function MainNavbarView({
             isSelected={
               isMiscLinkSelected && selectedItem.url.startsWith(BROWSE_URL)
             }
+            onClick={onItemSelect}
             data-metabase-event="NavBar;Data Browse"
           >
             {t`Browse data`}
@@ -98,6 +110,7 @@ function MainNavbarView({
             isSelected={
               selectedItem.type === "collection" && selectedItem.id === "users"
             }
+            onClick={onItemSelect}
           >
             {t`Other users' personal collections`}
           </SidebarLink>
@@ -108,6 +121,7 @@ function MainNavbarView({
           isSelected={
             isMiscLinkSelected && selectedItem.url.startsWith(ARCHIVE_URL)
           }
+          onClick={onItemSelect}
         >
           {t`View archive`}
         </SidebarLink>

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarView.tsx
@@ -127,7 +127,7 @@ function MainNavbarView({
         </SidebarLink>
       </ul>
       <ProfileLinkContainer>
-        <ProfileLink user={currentUser} />
+        <ProfileLink user={currentUser} handleCloseNavbar={onItemSelect} />
       </ProfileLinkContainer>
     </>
   );

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarCollectionLink.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarCollectionLink.tsx
@@ -11,6 +11,7 @@ import CollectionDropTarget from "metabase/containers/dnd/CollectionDropTarget";
 import { CollectionIcon } from "metabase/collections/components/CollectionIcon";
 
 import { PLUGIN_COLLECTIONS } from "metabase/plugins";
+import { composeEventHandlers } from "metabase/lib/compose-event-handlers";
 
 import { FullWidthLink, NameContainer, NodeRoot } from "./SidebarItems.styled";
 
@@ -27,6 +28,7 @@ const SidebarCollectionLink = React.forwardRef<
     item: collection,
     url,
     depth,
+    onSelect,
     isExpanded,
     isSelected,
     hasChildren,
@@ -75,7 +77,7 @@ const SidebarCollectionLink = React.forwardRef<
                 size={12}
               />
             </TreeNode.ExpandToggleButton>
-            <FullWidthLink to={url} onKeyDown={onKeyDown}>
+            <FullWidthLink to={url} onClick={onSelect} onKeyDown={onKeyDown}>
               <TreeNode.IconContainer transparent={isRegular}>
                 <CollectionIcon collection={collection} />
               </TreeNode.IconContainer>

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarLink.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarLink.tsx
@@ -12,6 +12,7 @@ interface Props {
   icon: string | IconProps | React.ReactElement;
   isSelected?: boolean;
   right?: React.ReactNode;
+  onClick?: () => void;
 }
 
 function isIconPropsObject(

--- a/frontend/src/metabase/nav/containers/Navbar.jsx
+++ b/frontend/src/metabase/nav/containers/Navbar.jsx
@@ -10,6 +10,8 @@ import Link from "metabase/core/components/Link";
 import LogoIcon from "metabase/components/LogoIcon";
 import { AdminNavbar } from "../components/AdminNavbar";
 
+import { closeNavbar } from "metabase/redux/app";
+
 import { getPath, getContext, getUser } from "../selectors";
 import {
   getHasDataAccess,
@@ -31,6 +33,7 @@ import MainNavbar from "./MainNavbar";
 
 const mapDispatchToProps = {
   onChangeLocation: push,
+  closeNavbar,
 };
 
 @Database.loadList({
@@ -71,11 +74,15 @@ export default class Navbar extends Component {
   }
 
   renderMainNav() {
-    const { isOpen, location, params } = this.props;
+    const { isOpen, location, params, closeNavbar } = this.props;
     // NOTE: DO NOT REMOVE `Nav` CLASS FOR NOW, USED BY MODALS, FULLSCREEN DASHBOARD, ETC
     return (
       <NavRoot className="Nav" isOpen={isOpen}>
-        <MainNavbar location={location} params={params} />
+        <MainNavbar
+          location={location}
+          params={params}
+          closeNavbar={closeNavbar}
+        />
       </NavRoot>
     );
   }

--- a/frontend/src/metabase/nav/containers/Navbar.jsx
+++ b/frontend/src/metabase/nav/containers/Navbar.jsx
@@ -79,6 +79,7 @@ export default class Navbar extends Component {
     return (
       <NavRoot className="Nav" isOpen={isOpen}>
         <MainNavbar
+          isOpen={isOpen}
           location={location}
           params={params}
           closeNavbar={closeNavbar}

--- a/frontend/src/metabase/nav/containers/Navbar.jsx
+++ b/frontend/src/metabase/nav/containers/Navbar.jsx
@@ -40,11 +40,6 @@ const mapDispatchToProps = {
 @withRouter
 @connect(mapStateToProps, mapDispatchToProps)
 export default class Navbar extends Component {
-  state = {
-    modal: null,
-    shouldDisplayMobileSidebar: false,
-  };
-
   static propTypes = {
     context: PropTypes.string.isRequired,
     path: PropTypes.string.isRequired,

--- a/frontend/src/metabase/nav/containers/Navbar.jsx
+++ b/frontend/src/metabase/nav/containers/Navbar.jsx
@@ -77,7 +77,7 @@ export default class Navbar extends Component {
     const { isOpen, location, params, closeNavbar } = this.props;
     // NOTE: DO NOT REMOVE `Nav` CLASS FOR NOW, USED BY MODALS, FULLSCREEN DASHBOARD, ETC
     return (
-      <NavRoot className="Nav" isOpen={isOpen}>
+      <NavRoot className="Nav" isOpen={isOpen} aria-hidden={!isOpen}>
         <MainNavbar
           isOpen={isOpen}
           location={location}

--- a/frontend/src/metabase/nav/containers/Navbar.styled.tsx
+++ b/frontend/src/metabase/nav/containers/Navbar.styled.tsx
@@ -30,7 +30,7 @@ export const NavRoot = styled.div<{ isOpen: boolean }>`
 
   overflow: auto;
   overflow-x: hidden;
-  z-index: 3;
+  z-index: 4;
 
   border-right: 1px solid ${color("border")};
 

--- a/frontend/src/metabase/nav/containers/Navbar.styled.tsx
+++ b/frontend/src/metabase/nav/containers/Navbar.styled.tsx
@@ -1,8 +1,12 @@
 import styled from "@emotion/styled";
 import { css } from "@emotion/react";
 import { color } from "metabase/lib/colors";
-import { breakpointMinSmall } from "metabase/styled-components/theme";
+
 import { NAV_SIDEBAR_WIDTH } from "../constants";
+import {
+  breakpointMaxSmall,
+  breakpointMinSmall,
+} from "metabase/styled-components/theme";
 
 const openNavbarCSS = css`
   visibility: visible;
@@ -27,6 +31,11 @@ export const NavRoot = styled.div<{ isOpen: boolean }>`
   border-right: 1px solid ${color("border")};
 
   ${props => props.isOpen && openNavbarCSS};
+
+  ${breakpointMaxSmall} {
+    position: absolute;
+    top: 0;
+    left: 0;
   }
 `;
 

--- a/frontend/src/metabase/nav/containers/Navbar.styled.tsx
+++ b/frontend/src/metabase/nav/containers/Navbar.styled.tsx
@@ -32,6 +32,12 @@ export const NavRoot = styled.div<{ isOpen: boolean }>`
 
   border-right: 1px solid ${color("border")};
 
+  transition: width 0.2s;
+
+  @media (prefers-reduced-motion) {
+    transition: none;
+  }
+
   ${props => props.isOpen && openNavbarCSS};
 
   ${breakpointMaxSmall} {
@@ -63,6 +69,12 @@ export const SearchBarContent = styled.div`
   margin-left: auto;
   padding-top: 0.25rem;
   padding-bottom: 0.25rem;
+
+  transition: max-width 0.2s;
+
+  @media (prefers-reduced-motion) {
+    transition: none;
+  }
 
   ${breakpointMaxSmall} {
     max-width: 60vw;

--- a/frontend/src/metabase/nav/containers/Navbar.styled.tsx
+++ b/frontend/src/metabase/nav/containers/Navbar.styled.tsx
@@ -63,6 +63,10 @@ export const SearchBarContent = styled.div`
   margin-left: auto;
   padding-top: 0.25rem;
   padding-bottom: 0.25rem;
+
+  ${breakpointMaxSmall} {
+    max-width: 60vw;
+  }
 `;
 
 export const EntityMenuContainer = styled.div`

--- a/frontend/src/metabase/nav/containers/Navbar.styled.tsx
+++ b/frontend/src/metabase/nav/containers/Navbar.styled.tsx
@@ -9,7 +9,6 @@ import {
 } from "metabase/styled-components/theme";
 
 const openNavbarCSS = css`
-  visibility: visible;
   width: ${NAV_SIDEBAR_WIDTH};
 
   ${breakpointMaxSmall} {
@@ -20,7 +19,6 @@ const openNavbarCSS = css`
 export const NavRoot = styled.div<{ isOpen: boolean }>`
   width: 0;
   height: 100%;
-  visibility: hidden;
 
   position: relative;
   flex-shrink: 0;

--- a/frontend/src/metabase/nav/containers/Navbar.styled.tsx
+++ b/frontend/src/metabase/nav/containers/Navbar.styled.tsx
@@ -73,7 +73,6 @@ export const EntityMenuContainer = styled.div`
   display: flex;
   position: relative;
   align-items: center;
-  margin-left: auto;
   padding-left: 0.5rem;
   z-index: 2;
 

--- a/frontend/src/metabase/nav/containers/Navbar.styled.tsx
+++ b/frontend/src/metabase/nav/containers/Navbar.styled.tsx
@@ -11,6 +11,10 @@ import {
 const openNavbarCSS = css`
   visibility: visible;
   width: ${NAV_SIDEBAR_WIDTH};
+
+  ${breakpointMaxSmall} {
+    width: 90vw;
+  }
 `;
 
 export const NavRoot = styled.div<{ isOpen: boolean }>`

--- a/frontend/src/metabase/nav/containers/Navbar.styled.tsx
+++ b/frontend/src/metabase/nav/containers/Navbar.styled.tsx
@@ -11,6 +11,7 @@ const openNavbarCSS = css`
 
 const closedNavbarCSS = css`
   width: 0;
+  height: 100%;
   visibility: hidden;
 `;
 

--- a/frontend/src/metabase/nav/containers/Navbar.styled.tsx
+++ b/frontend/src/metabase/nav/containers/Navbar.styled.tsx
@@ -16,13 +16,15 @@ const closedNavbarCSS = css`
 
 export const NavRoot = styled.div<{ isOpen: boolean }>`
   position: fixed;
+  flex-shrink: 0;
   align-items: center;
   padding: 0.5rem 0;
   background-color: ${color("nav")};
+
   overflow: auto;
   overflow-x: hidden;
   z-index: 3;
-  flex-shrink: 0;
+
   border-right: 1px solid ${color("border")};
 
   ${breakpointMinSmall} {

--- a/frontend/src/metabase/nav/containers/Navbar.styled.tsx
+++ b/frontend/src/metabase/nav/containers/Navbar.styled.tsx
@@ -5,18 +5,16 @@ import { breakpointMinSmall } from "metabase/styled-components/theme";
 import { NAV_SIDEBAR_WIDTH } from "../constants";
 
 const openNavbarCSS = css`
-  position: relative;
+  visibility: visible;
   width: ${NAV_SIDEBAR_WIDTH};
 `;
 
-const closedNavbarCSS = css`
+export const NavRoot = styled.div<{ isOpen: boolean }>`
   width: 0;
   height: 100%;
   visibility: hidden;
-`;
 
-export const NavRoot = styled.div<{ isOpen: boolean }>`
-  position: fixed;
+  position: relative;
   flex-shrink: 0;
   align-items: center;
   padding: 0.5rem 0;
@@ -28,8 +26,7 @@ export const NavRoot = styled.div<{ isOpen: boolean }>`
 
   border-right: 1px solid ${color("border")};
 
-  ${breakpointMinSmall} {
-    ${props => (props.isOpen ? openNavbarCSS : closedNavbarCSS)};
+  ${props => props.isOpen && openNavbarCSS};
   }
 `;
 

--- a/frontend/src/metabase/nav/containers/Navbar.styled.tsx
+++ b/frontend/src/metabase/nav/containers/Navbar.styled.tsx
@@ -2,10 +2,11 @@ import styled from "@emotion/styled";
 import { css } from "@emotion/react";
 import { color } from "metabase/lib/colors";
 import { breakpointMinSmall } from "metabase/styled-components/theme";
+import { NAV_SIDEBAR_WIDTH } from "../constants";
 
 const openNavbarCSS = css`
-  width: 324px;
   position: relative;
+  width: ${NAV_SIDEBAR_WIDTH};
 `;
 
 const closedNavbarCSS = css`

--- a/frontend/src/metabase/redux/app.js
+++ b/frontend/src/metabase/redux/app.js
@@ -5,7 +5,11 @@ import {
   createAction,
   handleActions,
 } from "metabase/lib/redux";
-import { openInBlankWindow, shouldOpenInBlankWindow } from "metabase/lib/dom";
+import {
+  isSmallScreen,
+  openInBlankWindow,
+  shouldOpenInBlankWindow,
+} from "metabase/lib/dom";
 
 export const SET_ERROR_PAGE = "metabase/app/SET_ERROR_PAGE";
 export function setErrorPage(error) {
@@ -39,8 +43,11 @@ const PATHS_WITH_COLLAPSED_NAVBAR = [
 ];
 
 function checkIsSidebarInitiallyOpen() {
-  return !PATHS_WITH_COLLAPSED_NAVBAR.some(pattern =>
-    pattern.test(window.location.pathname),
+  return (
+    !isSmallScreen() &&
+    !PATHS_WITH_COLLAPSED_NAVBAR.some(pattern =>
+      pattern.test(window.location.pathname),
+    )
   );
 }
 

--- a/frontend/test/metabase/scenarios/collections/collections-sidebar.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections-sidebar.cy.spec.js
@@ -1,43 +1,38 @@
-import { restore, sidebar } from "__support__/e2e/cypress";
+import {
+  restore,
+  navigationSidebar,
+  openNavigationSidebar,
+  closeNavigationSidebar,
+} from "__support__/e2e/cypress";
 
-describe.skip("collections sidebar (metabase#15006)", () => {
+describe("collections sidebar (metabase#15006)", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
-
+    cy.viewport(480, 800);
     cy.visit("/collection/root");
   });
 
   it("should be able to toggle collections sidebar when switched to mobile screen size", () => {
-    cy.icon("close").should("not.be.visible");
-    cy.icon("burger").should("not.be.visible");
+    navigationSidebar().should("have.attr", "aria-hidden", "true");
+    openNavigationSidebar();
 
-    // resize window to mobile form factor
-    cy.viewport(480, 800);
-
-    sidebar().should("not.be.visible");
-
-    cy.icon("burger").click();
-    cy.icon("burger").should("not.be.visible");
-
-    sidebar().within(() => {
+    navigationSidebar().within(() => {
       cy.findByText("First collection");
-      cy.icon("close").click();
     });
 
-    cy.icon("burger");
+    closeNavigationSidebar();
+    navigationSidebar().should("have.attr", "aria-hidden", "true");
   });
 
   it("should close collections sidebar when collection is clicked in mobile screen size", () => {
-    cy.viewport(480, 800);
-    cy.icon("burger").click();
+    openNavigationSidebar();
 
-    sidebar().should("be.visible");
-
-    sidebar().within(() => {
+    navigationSidebar().within(() => {
       cy.findByText("First collection").click();
     });
 
-    cy.icon("burger");
+    navigationSidebar().should("have.attr", "aria-hidden", "true");
+    cy.findByText("First collection");
   });
 });


### PR DESCRIPTION
The navigation sidebar doesn't look and feel good on the mobile in its current state, so this PR should make it better ✨ 

* for desktop/tablet the sidebar should work without any noticeable changes
* for mobile the sidebar will now overlap page content instead of pushing it like on the desktop
* the mobile sidebar will now take more horizontal space (`90vw`)
* the search input in the top app bar will become smaller for mobile to free up some space
* clicking on a bookmark/collection/link in the mobile sidebar will also close the sidebar
* clicking on the homepage link in the navbar or focusing the search input will close the sidebar
* added a basic in-out transition (width + opacity), need a look from the design team though

### To Verify

Ensure the bullet points below are actually true 😄 

### Demo

**Before**

![sidebar-before](https://user-images.githubusercontent.com/17258145/160851068-3db980f9-f6e1-4410-b91e-1af8eefbf40e.gif)

**After**

![sidebar-after](https://user-images.githubusercontent.com/17258145/160851069-3a72131c-1c49-4935-be93-59a7264d1772.gif)

