### PR TITLE
Browsing | Show sidebar on collection pages when embedding

### DIFF
--- a/frontend/src/metabase/App.jsx
+++ b/frontend/src/metabase/App.jsx
@@ -70,6 +70,8 @@ const getErrorComponent = ({ status, data, context }) => {
 
 const PATHS_WITHOUT_NAVBAR = [/\/model\/.*\/query/, /\/model\/.*\/metadata/];
 
+const EMBEDDED_ROUTES_WITH_NAVBAR = ["/collection", "/archive"];
+
 class App extends Component {
   state = {
     errorInfo: undefined,
@@ -95,8 +97,13 @@ class App extends Component {
       isEditingDashboard,
       location: { pathname },
     } = this.props;
-    if (!currentUser || IFRAMED || isEditingDashboard) {
+    if (!currentUser || isEditingDashboard) {
       return false;
+    }
+    if (IFRAMED) {
+      return EMBEDDED_ROUTES_WITH_NAVBAR.some(path =>
+        pathname.startsWith(path),
+      );
     }
     return !PATHS_WITHOUT_NAVBAR.some(pattern => pattern.test(pathname));
   };

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarView.tsx
@@ -14,7 +14,7 @@ import {
   getCollectionIcon,
   PERSONAL_COLLECTIONS,
 } from "metabase/entities/collections";
-import { isSmallScreen } from "metabase/lib/dom";
+import { IFRAMED, isSmallScreen } from "metabase/lib/dom";
 import * as Urls from "metabase/lib/urls";
 
 import { SelectedItem } from "./types";
@@ -90,7 +90,7 @@ function MainNavbarView({
         role="tree"
       />
       <ul>
-        {hasDataAccess && (
+        {hasDataAccess && !IFRAMED && (
           <SidebarLink
             icon="table_spaced"
             url={BROWSE_URL}
@@ -126,9 +126,11 @@ function MainNavbarView({
           {t`View archive`}
         </SidebarLink>
       </ul>
-      <ProfileLinkContainer>
-        <ProfileLink user={currentUser} handleCloseNavbar={onItemSelect} />
-      </ProfileLinkContainer>
+      {!IFRAMED && (
+        <ProfileLinkContainer>
+          <ProfileLink user={currentUser} handleCloseNavbar={onItemSelect} />
+        </ProfileLinkContainer>
+      )}
     </>
   );
 }


### PR DESCRIPTION
In the scope of the new navigation project, the collection sidebar became a new navbar. Right now, when Metabase is embedded, we hide all the navigation components, so the sidebar will be hidden too.

However, when the collections sidebar used to be a part of the collection page, it was still available when embedding and people were using it to present reports. This PR makes Metabase show a limited sidebar on `/collection` and `/archive` routes not to break these use-cases.

The navigation in embedded Metabase is slightly changed though:

* the top app bar will always be hidden as by default
* the collections sidebar won't show the "Browse data" link
* the collections sidebar won't show the gear icon with links to account settings, admin app, etc.

⚠️ The sidebar look on the screenshot is far from final and it won't get into a release in this state. This PR will only make it show up in full-app embedding scenario

### To Verify

In order to test this e2e, you will need to spin up an app with SSO that embeds Metabase. You can use a [sample app](https://github.com/metabase/sso-examples/tree/master/app-embed-example) from our [docs](https://www.metabase.com/docs/latest/enterprise-guide/full-app-embedding.html#setting-things-up-in-your-web-app). What you'll need is to spin up Metabase from this branch locally and spin up the sample app via `npm run dev` (Docker setup won't work as it also starts its own Metabase Enterprise instance using the docker image without any changes from this branch).

Once you set up the sample app, go to `localhost:3001`, open any question/dashboard and then open a collection via the collection badge. Ensure you can see the sidebar without the "Browse data" link and the "gear" icon at the bottom.

### Demo

<img width="1370" alt="CleanShot 2022-03-30 at 16 07 06@2x" src="https://user-images.githubusercontent.com/17258145/160870680-c7af7372-3225-4e30-b244-7c7d93af7657.png">

