### PR TITLE
Fix a race condition when creating default timelines

### DIFF
--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -228,9 +228,18 @@ export const LdapApi = {
 };
 
 export const TimelineApi = {
-  getTimelines: GET("/api/timeline"),
-  getCardTimelines: GET("/api/card/:cardId/timelines"),
-  getCollectionTimelines: GET("/api/collection/:collectionId/timelines"),
+  list: GET("/api/timeline"),
+  listForCollection: GET("/api/collection/:collectionId/timelines"),
+  get: GET("/api/timeline/:id"),
+  create: POST("/api/timeline"),
+  update: PUT("/api/timeline/:id"),
+};
+
+export const TimelineEventApi = {
+  list: GET("/api/timeline-event"),
+  get: GET("/api/timeline-event/:id"),
+  create: POST("/api/timeline-event"),
+  update: PUT("/api/timeline-event/:id"),
 };
 
 export const MetabaseApi = {

--- a/frontend/src/metabase/timelines/questions/containers/NewEventModal/NewEventModal.tsx
+++ b/frontend/src/metabase/timelines/questions/containers/NewEventModal/NewEventModal.tsx
@@ -15,10 +15,7 @@ interface TimelinePanelProps {
 }
 
 const timelineProps = {
-  query: (state: State, props: TimelinePanelProps) => ({
-    cardId: props.cardId,
-    include: "events",
-  }),
+  query: { include: "events" },
 };
 
 const collectionProps = {


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/20289

Fixes the issue with reloading the timeline list before the event was created. This PR does it by manually calling API handlers and invaliding lists.

Before:
<img width="440" alt="Screenshot 2022-03-30 at 18 21 24" src="https://user-images.githubusercontent.com/8542534/160876319-a86cad0a-b5a2-483a-9618-39fb2ffab185.png">

After:
<img width="412" alt="Screenshot 2022-03-30 at 18 44 06" src="https://user-images.githubusercontent.com/8542534/160876369-d11f91e2-c70d-4aec-9b2e-b550eb418d94.png">
