### PR TITLE
Remove unsupported flag from the `open` mode in Cypress [ci skip]

### DIFF
--- a/package.json
+++ b/package.json
@@ -303,7 +303,7 @@
     "test-cypress-no-build": "yarn && ELECTRON_EXTRA_LAUNCH_ARGS=\"--force-prefers-reduced-motion\" babel-node ./frontend/test/__runner__/run_cypress_tests.js",
     "test-visual": "ELECTRON_EXTRA_LAUNCH_ARGS=\"--force-prefers-reduced-motion\" yarn build && ./bin/build-for-test && yarn test-visual-no-build",
     "test-visual-no-build": "percy exec -- yarn test-cypress-no-build --spec \"./frontend/test/metabase-visual/**/*.cy.spec.js\"",
-    "test-visual-open": "percy exec -- yarn test-cypress-open --spec \"./frontend/test/metabase-visual/**/*.cy.spec.js\"",
+    "test-visual-open": "percy exec -- yarn test-cypress-open",
     "prepare": "husky install",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",


### PR DESCRIPTION
Cypress doesn't support `--spec` flag in the open mode.