### PR TITLE
[E2E] Log output to file and store it as an artifact

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -122,10 +122,13 @@ jobs:
       run: yarn run test-cypress-no-build --folder ${{ matrix.folder }} --record --key ${{ secrets.CURRENTS_KEY }} --group ${{ matrix.folder }}-${{ matrix.edition }} --ci-build-id "${{ github.run_id }}-${{ github.run_attempt }}"
       env:
         TERM: xterm
+
     - name: Upload Cypress recording upon failure
       uses: actions/upload-artifact@v3
       if: failure()
       with:
         name: cypress-recording-${{ matrix.folder }}-${{ matrix.edition }}
-        path: ./cypress
+        path: |
+          ./cypress
+          ./logs/test.log
         if-no-files-found: ignore

--- a/frontend/test/__runner__/log4j2.xml
+++ b/frontend/test/__runner__/log4j2.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration>
   <Appenders>
-    <Console name="STDOUT" target="SYSTEM_OUT">
+    <File name="TestLogs" fileName="logs/test.log">
       <PatternLayout pattern="%d{MM-dd HH:mm:ss} %highlight{%p} %style{%c{2}}{bright} :: %m%n">
         <replace regex=":basic-auth \\[.*\\]" replacement=":basic-auth [redacted]"/>
       </PatternLayout>
-    </Console>
+    </File>
   </Appenders>
 
   <Loggers>
@@ -13,7 +13,7 @@
     <Logger name="com.mchange" level="ERROR"/>
 
     <Root level="ERROR">
-      <AppenderRef ref="STDOUT"/>
+      <AppenderRef ref="TestLogs"/>
     </Root>
   </Loggers>
 </Configuration>


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- Instead of logging the stacktrace and middleware errors to the console, let's store that in a file as @pawit-metabase suggested
- We upload that log as an artifact bundled together with Cypress screenshots and videos

When you unzip the downloaded artifact (for example `cypress-recording-admin-ee`) you should now see `logs` directory
```
.
├── cypress-recording-admin-ee
│   ├── cypress
│   │   ├── screenshots
│   │   └── videos
│   └── logs
│       └── test.log
```