### PR TITLE
Timelines permissions

### DIFF
--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -273,9 +273,9 @@
   [model search-ctx :- SearchContext]
   (-> (base-query-for-model model search-ctx)
       ;; TODO: get this working
-      #_(h/left-join [CollectionBookmark :bookmark]
+      (h/left-join [CollectionBookmark :bookmark]
                    [:and
-                    [:= :bookmark.collection_id 1 :collection.id]
+                    [:= :bookmark.collection_id :collection.id]
                     [:= :bookmark.user_id api/*current-user-id*]])
       (add-collection-join-and-where-clauses :collection.id search-ctx)))
 

--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -7,7 +7,7 @@
             [honeysql.helpers :as h]
             [metabase.api.common :as api]
             [metabase.db :as mdb]
-            [metabase.models.bookmark :refer [CardBookmark DashboardBookmark]]
+            [metabase.models.bookmark :refer [CardBookmark CollectionBookmark DashboardBookmark]]
             [metabase.models.collection :as coll :refer [Collection]]
             [metabase.models.interface :as mi]
             [metabase.models.metric :refer [Metric]]
@@ -272,6 +272,11 @@
 (s/defmethod search-query-for-model "collection"
   [model search-ctx :- SearchContext]
   (-> (base-query-for-model model search-ctx)
+      ;; TODO: get this working
+      #_(h/left-join [CollectionBookmark :bookmark]
+                   [:and
+                    [:= :bookmark.collection_id 1 :collection.id]
+                    [:= :bookmark.user_id api/*current-user-id*]])
       (add-collection-join-and-where-clauses :collection.id search-ctx)))
 
 (s/defmethod search-query-for-model "database"
@@ -283,7 +288,7 @@
   (-> (base-query-for-model model search-ctx)
       (h/left-join [DashboardBookmark :bookmark]
                    [:and
-                    [:= :dashboard.id :bookmark.dashboard_id]
+                    [:= :bookmark.dashboard_id :dashboard.id ]
                     [:= :bookmark.user_id api/*current-user-id*]])
       (add-collection-join-and-where-clauses :dashboard.collection_id search-ctx)))
 

--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -272,7 +272,6 @@
 (s/defmethod search-query-for-model "collection"
   [model search-ctx :- SearchContext]
   (-> (base-query-for-model model search-ctx)
-      ;; TODO: get this working
       (h/left-join [CollectionBookmark :bookmark]
                    [:and
                     [:= :bookmark.collection_id :collection.id]

--- a/src/metabase/api/timeline.clj
+++ b/src/metabase/api/timeline.clj
@@ -35,13 +35,20 @@
 (api/defendpoint GET "/"
   "Fetch a list of [[Timelines]]. Can include `archived=true` to return archived timelines."
   [include archived]
-  {include (s/maybe Include)
+  {include  (s/maybe Include)
    archived (s/maybe su/BooleanString)}
   (let [archived? (Boolean/parseBoolean archived)
-        timelines (map timeline/hydrate-root-collection (db/select Timeline [:where [:= :archived archived?]]))]
+        timelines (->> (db/select Timeline
+                         {:where    [:and
+                                     [:= :archived archived?]
+                                     (collection/visible-collection-ids->honeysql-filter-clause
+                                      :collection_id
+                                      (collection/permissions-set->visible-collection-ids @api/*current-user-permissions-set*))]
+                          :order-by [[:%lower.name :asc]]})
+                       (map timeline/hydrate-root-collection))]
     (cond->> (hydrate timelines :creator [:collection :can_write])
       (= include "events")
-      (map #(timeline-event/include-events-singular % {:events/all?  archived?})))))
+      (map #(timeline-event/include-events-singular % {:events/all? archived?})))))
 
 (api/defendpoint GET "/:id"
   "Fetch the [[Timeline]] with `id`. Include `include=events` to unarchived events included on the timeline. Add

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -96,7 +96,7 @@
   [:id :name :description :archived :updated_at])
 
 (def ^:private bookmark-col
-  "Case statement to return boolean values of `:bookmark` for Card and Dashboard."
+  "Case statement to return boolean values of `:bookmark` for Card, Collection and Dashboard."
   [(hsql/call :case [:not= :bookmark.id nil] true :else false) :bookmark])
 
 (def ^:private dashboardcard-count-col
@@ -154,7 +154,8 @@
 (defmethod columns-for-model "collection"
   [_]
   (conj (remove #{:updated_at} default-columns) [:id :collection_id] [:name :collection_name]
-        [:authority_level :collection_authority_level]))
+        [:authority_level :collection_authority_level]
+        bookmark-col))
 
 (defmethod columns-for-model "segment"
   [_]

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -153,7 +153,7 @@
 
 (defmethod columns-for-model "collection"
   [_]
-  (conj (remove #{:updated_at} default-columns) [:id :collection_id] [:name :collection_name]
+  (conj (remove #{:updated_at} default-columns) [:collection.id :collection_id] [:name :collection_name]
         [:authority_level :collection_authority_level]
         bookmark-col))
 

--- a/src/metabase/search/scoring.clj
+++ b/src/metabase/search/scoring.clj
@@ -183,6 +183,13 @@
       1
       0)))
 
+(defn- bookmarked-score
+  [{:keys [model collection_position]}]
+  (when (#{"card" "collection" "dashboard"} model)
+    (if ((fnil pos? 0) collection_position)
+      1
+      0)))
+
 (defn- dashboard-count-score
   [{:keys [model dashboardcard_count]}]
   (when (= model "card")
@@ -237,6 +244,9 @@
   [{:weight 2
     :score  (pinned-score result)
     :name   "pinned"}
+   {:weight 2
+    :score  (bookmarked-score result)
+    :name   "bookmarked"}
    {:weight 3/2
     :score  (recency-score result)
     :name   "recency"}

--- a/src/metabase/search/scoring.clj
+++ b/src/metabase/search/scoring.clj
@@ -184,9 +184,9 @@
       0)))
 
 (defn- bookmarked-score
-  [{:keys [model collection_position]}]
+  [{:keys [model bookmark]}]
   (when (#{"card" "collection" "dashboard"} model)
-    (if ((fnil pos? 0) collection_position)
+    (if bookmark
       1
       0)))
 

--- a/test/metabase/api/search_test.clj
+++ b/test/metabase/api/search_test.clj
@@ -59,6 +59,7 @@
    (apply array-map kvs)))
 
 (def ^:private test-collection (make-result "collection test collection"
+                                            :bookmark false
                                             :model "collection"
                                             :collection {:id true, :name true :authority_level nil}
                                             :updated_at false))

--- a/test/metabase/search/scoring_test.clj
+++ b/test/metabase/search/scoring_test.clj
@@ -265,6 +265,21 @@
                 (map :result)
                 (map :name))))))
 
+(deftest bookmarked-test
+  (let [search-string     "my card"
+        labeled-results   {:a {:name "my card a" :model "dashboard"}
+                           :b {:name "my card b" :model "dashboard" :bookmark true :collection_position 1}
+                           :c {:name "my card c" :model "dashboard" :bookmark true}}
+        {:keys [a b c]} labeled-results]
+    (is (= (map :name [b c a])
+           (->> labeled-results
+                vals
+                (map (partial search/score-and-result search-string))
+                (sort-by :score)
+                reverse
+                (map :result)
+                (map :name))))))
+
 (deftest score-and-result-test
   (testing "If all scores are 0, does not divide by zero"
     (let [scorer (reify search/ResultScore


### PR DESCRIPTION
`GET /api/timeline` returns a list of timelines. We need to check permissions via the collection, and we want to do this efficiently. 

Use the existing functions in `metabase.models.collection` to build a :where clause that filters Timelines which the user actually has permissions for.

The `:can_write` key is then filled using the hydration system.
