### PR TITLE
Downgrade Github actions to version 2

### DIFF
--- a/.github/actions/prepare-uberjar-artifact/action.yml
+++ b/.github/actions/prepare-uberjar-artifact/action.yml
@@ -9,7 +9,7 @@ runs:
       run: sha256sum ./target/uberjar/metabase.jar > SHA256.sum
       shell: bash
     - name: Upload JARs as artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v2
       with:
         name: metabase-${{ matrix.edition }}-uberjar
         path: |

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -109,7 +109,7 @@ jobs:
     - name: Run Snowlow micro
       uses: ./.github/actions/run-snowplow-micro
 
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v2
       name: Retrieve uberjar artifact for ${{ matrix.edition }}
       with:
         name: metabase-${{ matrix.edition }}-uberjar

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -123,7 +123,7 @@ jobs:
       env:
         TERM: xterm
     - name: Upload Cypress recording upon failure
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v2
       if: failure()
       with:
         name: cypress-recording-${{ matrix.folder }}-${{ matrix.edition }}

--- a/.github/workflows/percy-issue-comment.yml
+++ b/.github/workflows/percy-issue-comment.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Prepare cypress environment
         uses: ./.github/actions/prepare-cypress
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v2
         name: Retrieve uberjar artifact
         with:
           name: metabase-oss-uberjar

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Prepare cypress environment
         uses: ./.github/actions/prepare-cypress
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v2
         name: Retrieve uberjar artifact
         with:
           name: metabase-oss-uberjar

--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -50,7 +50,7 @@ jobs:
         java-version: ${{ matrix.java-version }}
         distribution: 'temurin'
     - run: java -version
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v2
       name: Retrieve uberjar artifact
       with:
         name: metabase-${{ matrix.edition }}-uberjar
@@ -79,7 +79,7 @@ jobs:
     - name: Check out the code (Dockerfile needed)
       uses: actions/checkout@v3
     - name: Download uploaded artifacts to insert into container
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v2
       with:
         name: metabase-${{ matrix.edition }}-uberjar
         path: bin/docker/
@@ -137,7 +137,7 @@ jobs:
       - name: Prepare cypress environment
         uses: ./.github/actions/prepare-cypress
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v2
         name: Retrieve uberjar artifact
         with:
           name: metabase-oss-uberjar


### PR DESCRIPTION
We are facing some issues with actions/download@v3 and/or actions/upload@v3. So for the moment, I'm reverting to the previously used v2



<img width="1715" alt="Screen Shot 2022-03-30 at 15 16 28" src="https://user-images.githubusercontent.com/17742979/160904852-946bf336-b91b-4b92-8c95-36eba06038a8.png">


Run failure example: https://github.com/metabase/metabase/runs/5759052315?check_suite_focus=true


Github related issues:

https://github.com/actions/download-artifact/issues/151
https://github.com/actions/upload-artifact/issues/270