### PR TITLE
Fix a flake in `models`

### DIFF
--- a/frontend/test/metabase/scenarios/models/models.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models.cy.spec.js
@@ -246,6 +246,7 @@ describe("scenarios > models", () => {
 
       cy.icon("join_left_outer").click();
       cy.wait("@schema");
+      cy.findAllByRole("option").should("have.length", 4);
       selectFromDropdown("Products");
 
       cy.findByText("Add filters to narrow your answer").click();


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Fixes a rare flake in `models.cy.spec.js` (that I could reproduce locally)
- It's a race condition related to rendering. Cypress first sees "Products" while not all tables are still loaded. When it attempts to click on it, all tables load and the "Orders" table is in that position. Thus, the test fails later because we joined "Orders" with "Orders" instead of "Orders" with Joins"

Failed run:
https://github.com/metabase/metabase/runs/5756224511?ch
![scenarios  models -- data picker -- allows to create a question based on a model (failed) (attempt 3)](https://user-images.githubusercontent.com/31325167/160912699-aa2be6c0-a46d-4c57-8196-f094c4d39ecd.png)
eck_suite_focus=true

Debugging a video recording:

Frame 1
Cypress finds "Products" and prepares to click using its coordinates
![image](https://user-images.githubusercontent.com/31325167/160912929-a1294c57-6194-48fb-8e31-f413c1aa4c3f.png)

Frame 2
The rest of the tables loaded and "Orders" is in the place where "Products" previously rendered
![image](https://user-images.githubusercontent.com/31325167/160913137-d54f7cb8-f729-47f7-9dc1-789f774681cd.png)
