### PR TITLE
Clean up SearchBar component

### DIFF
--- a/frontend/src/metabase/hooks/use-toggle.ts
+++ b/frontend/src/metabase/hooks/use-toggle.ts
@@ -1,6 +1,11 @@
 import { useState, useCallback } from "react";
 
-export function useToggle(initialValue = false) {
+type ToggleHookResult = [
+  boolean,
+  { turnOn: () => void; turnOff: () => void; toggle: () => void },
+];
+
+export function useToggle(initialValue = false): ToggleHookResult {
   const [value, setValue] = useState(initialValue);
 
   const turnOn = useCallback(() => setValue(true), []);

--- a/frontend/src/metabase/nav/components/SearchBar.jsx
+++ b/frontend/src/metabase/nav/components/SearchBar.jsx
@@ -61,6 +61,10 @@ export default class SearchBar extends React.Component {
     }
   }
 
+  onChange = e => {
+    this.setState({ searchText: e.target.value });
+  };
+
   handleKeyUp = e => {
     const FORWARD_SLASH_KEY = 191;
     if (
@@ -72,6 +76,19 @@ export default class SearchBar extends React.Component {
     }
   };
 
+  handleKeyPress = e => {
+    const { searchText } = this.state;
+    const hasSearchQuery =
+      typeof searchText === "string" && searchText.trim().length > 0;
+
+    if (e.key === "Enter" && hasSearchQuery) {
+      this.props.onChangeLocation({
+        pathname: "search",
+        query: { q: searchText.trim() },
+      });
+    }
+  };
+
   render() {
     const { active, searchText } = this.state;
     return (
@@ -79,19 +96,14 @@ export default class SearchBar extends React.Component {
         <SearchWrapper onClick={this.setActive} active={active}>
           <SearchIcon />
           <SearchInput
-            ref={ref => (this.searchInput = ref)}
             value={searchText}
-            maxLength={200}
             placeholder={t`Search` + "…"}
+            maxLength={200}
             onClick={this.setActive}
-            onChange={e => this.setState({ searchText: e.target.value })}
-            onKeyPress={e => {
-              if (e.key === "Enter" && (searchText || "").trim().length > 0) {
-                this.props.onChangeLocation({
-                  pathname: "search",
-                  query: { q: searchText.trim() },
-                });
-              }
+            onChange={this.onChange}
+            onKeyPress={this.handleKeyPress}
+            ref={ref => {
+              this.searchInput = ref;
             }}
           />
           {active && MetabaseSettings.searchTypeaheadEnabled() && (

--- a/frontend/src/metabase/nav/components/SearchBar.jsx
+++ b/frontend/src/metabase/nav/components/SearchBar.jsx
@@ -1,10 +1,12 @@
 /* eslint-disable react/prop-types */
-import React from "react";
+import React, { useEffect, useCallback, useRef, useState } from "react";
 import ReactDOM from "react-dom";
 import { t } from "ttag";
 
 import OnClickOutsideWrapper from "metabase/components/OnClickOutsideWrapper";
 
+import { usePrevious } from "metabase/hooks/use-previous";
+import { useToggle } from "metabase/hooks/use-toggle";
 import MetabaseSettings from "metabase/lib/settings";
 
 import { SearchResults } from "./SearchResults";
@@ -19,106 +21,98 @@ import {
 
 const ALLOWED_SEARCH_FOCUS_ELEMENTS = new Set(["BODY", "A"]);
 
-export default class SearchBar extends React.Component {
-  state = {
-    active: false,
-    searchText: "",
-  };
-
-  UNSAFE_componentWillMount() {
-    this._updateSearchTextFromUrl(this.props);
-    window.addEventListener("keyup", this.handleKeyUp);
-  }
-
-  componentWillUnmount() {
-    window.removeEventListener("keyup", this.handleKeyUp);
-  }
-
-  UNSAFE_componentWillReceiveProps(nextProps) {
-    if (this.props.location.pathname !== nextProps.location.pathname) {
-      this._updateSearchTextFromUrl(nextProps);
-    }
-    // deactivate search on navigation
-    if (this.props.location !== nextProps.location) {
-      this.setInactive();
-    }
-  }
-
-  setActive = () => {
-    this.setState({ active: true });
-  };
-
-  setInactive = () => {
-    this.setState({ active: false });
-  };
-
-  _updateSearchTextFromUrl(props) {
-    const components = props.location.pathname.split("/");
-    if (components[components.length - 1] === "search") {
-      this.setState({ searchText: props.location.query.q });
-    } else {
-      this.setState({ searchText: "" });
-    }
-  }
-
-  onChange = e => {
-    this.setState({ searchText: e.target.value });
-  };
-
-  handleKeyUp = e => {
-    const FORWARD_SLASH_KEY = 191;
-    if (
-      e.keyCode === FORWARD_SLASH_KEY &&
-      ALLOWED_SEARCH_FOCUS_ELEMENTS.has(document.activeElement.tagName)
-    ) {
-      ReactDOM.findDOMNode(this.searchInput).focus();
-      this.setActive();
-    }
-  };
-
-  handleKeyPress = e => {
-    const { searchText } = this.state;
-    const hasSearchQuery =
-      typeof searchText === "string" && searchText.trim().length > 0;
-
-    if (e.key === "Enter" && hasSearchQuery) {
-      this.props.onChangeLocation({
-        pathname: "search",
-        query: { q: searchText.trim() },
-      });
-    }
-  };
-
-  render() {
-    const { active, searchText } = this.state;
-    return (
-      <OnClickOutsideWrapper handleDismissal={this.setInactive}>
-        <SearchWrapper onClick={this.setActive} active={active}>
-          <SearchIcon />
-          <SearchInput
-            value={searchText}
-            placeholder={t`Search` + "…"}
-            maxLength={200}
-            onClick={this.setActive}
-            onChange={this.onChange}
-            onKeyPress={this.handleKeyPress}
-            ref={ref => {
-              this.searchInput = ref;
-            }}
-          />
-          {active && MetabaseSettings.searchTypeaheadEnabled() && (
-            <SearchResultsFloatingContainer>
-              {searchText.trim().length > 0 ? (
-                <SearchResultsContainer>
-                  <SearchResults searchText={searchText.trim()} />
-                </SearchResultsContainer>
-              ) : (
-                <RecentsList />
-              )}
-            </SearchResultsFloatingContainer>
-          )}
-        </SearchWrapper>
-      </OnClickOutsideWrapper>
-    );
-  }
+function isSearchPageLocation(location) {
+  const components = location.pathname.split("/");
+  return components[components.length - 1];
 }
+
+function SearchBar({ location, onChangeLocation }) {
+  const [searchText, setSearchText] = useState(() =>
+    isSearchPageLocation(location) ? location.query.q : "",
+  );
+
+  const [isActive, { turnOn: setActive, turnOff: setInactive }] = useToggle(
+    false,
+  );
+
+  const previousLocation = usePrevious(location);
+  const searchInput = useRef(null);
+
+  const onTextChange = useCallback(e => {
+    setSearchText(e.target.value);
+  }, []);
+
+  useEffect(() => {
+    const FORWARD_SLASH_KEY = 191;
+
+    function focusOnForwardSlashPress(e) {
+      if (
+        e.keyCode === FORWARD_SLASH_KEY &&
+        ALLOWED_SEARCH_FOCUS_ELEMENTS.has(document.activeElement.tagName)
+      ) {
+        ReactDOM.findDOMNode(searchInput.current).focus();
+        setActive();
+      }
+    }
+
+    window.addEventListener("keyup", focusOnForwardSlashPress);
+    return () => window.removeEventListener("keyup", focusOnForwardSlashPress);
+  }, [setActive]);
+
+  useEffect(() => {
+    if (previousLocation?.pathname !== location.pathname) {
+      setSearchText(isSearchPageLocation(location) ? location.query.q : "");
+    }
+  }, [previousLocation, location]);
+
+  useEffect(() => {
+    if (previousLocation !== location) {
+      // deactivate search when page changes
+      setInactive();
+    }
+  }, [previousLocation, location, setInactive]);
+
+  const handleInputKeyPress = useCallback(
+    e => {
+      const hasSearchQuery =
+        typeof searchText === "string" && searchText.trim().length > 0;
+
+      if (e.key === "Enter" && hasSearchQuery) {
+        onChangeLocation({
+          pathname: "search",
+          query: { q: searchText.trim() },
+        });
+      }
+    },
+    [searchText, onChangeLocation],
+  );
+
+  return (
+    <OnClickOutsideWrapper handleDismissal={setInactive}>
+      <SearchWrapper onClick={setActive} active={isActive}>
+        <SearchIcon />
+        <SearchInput
+          value={searchText}
+          placeholder={t`Search` + "…"}
+          maxLength={200}
+          onClick={setActive}
+          onChange={onTextChange}
+          onKeyPress={handleInputKeyPress}
+          ref={searchInput}
+        />
+        {isActive && MetabaseSettings.searchTypeaheadEnabled() && (
+          <SearchResultsFloatingContainer>
+            {searchText.trim().length > 0 ? (
+              <SearchResultsContainer>
+                <SearchResults searchText={searchText.trim()} />
+              </SearchResultsContainer>
+            ) : (
+              <RecentsList />
+            )}
+          </SearchResultsFloatingContainer>
+        )}
+      </SearchWrapper>
+    </OnClickOutsideWrapper>
+  );
+}
+export default SearchBar;

--- a/frontend/src/metabase/nav/components/SearchBar.jsx
+++ b/frontend/src/metabase/nav/components/SearchBar.jsx
@@ -25,9 +25,11 @@ export default class SearchBar extends React.Component {
     this._updateSearchTextFromUrl(this.props);
     window.addEventListener("keyup", this.handleKeyUp);
   }
+
   componentWillUnmount() {
     window.removeEventListener("keyup", this.handleKeyUp);
   }
+
   UNSAFE_componentWillReceiveProps(nextProps) {
     if (this.props.location.pathname !== nextProps.location.pathname) {
       this._updateSearchTextFromUrl(nextProps);
@@ -37,6 +39,7 @@ export default class SearchBar extends React.Component {
       this.setState({ active: false });
     }
   }
+
   _updateSearchTextFromUrl(props) {
     const components = props.location.pathname.split("/");
     if (components[components.length - 1] === "search") {
@@ -45,6 +48,7 @@ export default class SearchBar extends React.Component {
       this.setState({ searchText: "" });
     }
   }
+
   handleKeyUp = e => {
     const FORWARD_SLASH_KEY = 191;
     if (

--- a/frontend/src/metabase/nav/components/SearchBar.jsx
+++ b/frontend/src/metabase/nav/components/SearchBar.jsx
@@ -36,9 +36,17 @@ export default class SearchBar extends React.Component {
     }
     // deactivate search on navigation
     if (this.props.location !== nextProps.location) {
-      this.setState({ active: false });
+      this.setInactive();
     }
   }
+
+  setActive = () => {
+    this.setState({ active: true });
+  };
+
+  setInactive = () => {
+    this.setState({ active: false });
+  };
 
   _updateSearchTextFromUrl(props) {
     const components = props.location.pathname.split("/");
@@ -56,27 +64,22 @@ export default class SearchBar extends React.Component {
       ALLOWED_SEARCH_FOCUS_ELEMENTS.has(document.activeElement.tagName)
     ) {
       ReactDOM.findDOMNode(this.searchInput).focus();
-      this.setState({ active: true });
+      this.setActive();
     }
   };
 
   render() {
     const { active, searchText } = this.state;
     return (
-      <OnClickOutsideWrapper
-        handleDismissal={() => this.setState({ active: false })}
-      >
-        <SearchWrapper
-          onClick={() => this.setState({ active: true })}
-          active={active}
-        >
+      <OnClickOutsideWrapper handleDismissal={this.setInactive}>
+        <SearchWrapper onClick={this.setActive} active={active}>
           <Icon name="search" ml={["10px", 2]} />
           <SearchInput
             ref={ref => (this.searchInput = ref)}
             value={searchText}
             maxLength={200}
             placeholder={t`Search` + "…"}
-            onClick={() => this.setState({ active: true })}
+            onClick={this.setActive}
             onChange={e => this.setState({ searchText: e.target.value })}
             onKeyPress={e => {
               if (e.key === "Enter" && (searchText || "").trim().length > 0) {

--- a/frontend/src/metabase/nav/components/SearchBar.jsx
+++ b/frontend/src/metabase/nav/components/SearchBar.jsx
@@ -3,15 +3,19 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { t } from "ttag";
 
-import Card from "metabase/components/Card";
-import Icon from "metabase/components/Icon";
 import OnClickOutsideWrapper from "metabase/components/OnClickOutsideWrapper";
 
 import MetabaseSettings from "metabase/lib/settings";
 
-import { SearchInput, SearchWrapper } from "./SearchBar.styled";
 import { SearchResults } from "./SearchResults";
 import RecentsList from "./RecentsList";
+import {
+  SearchWrapper,
+  SearchIcon,
+  SearchInput,
+  SearchResultsFloatingContainer,
+  SearchResultsContainer,
+} from "./SearchBar.styled";
 
 const ALLOWED_SEARCH_FOCUS_ELEMENTS = new Set(["BODY", "A"]);
 
@@ -73,7 +77,7 @@ export default class SearchBar extends React.Component {
     return (
       <OnClickOutsideWrapper handleDismissal={this.setInactive}>
         <SearchWrapper onClick={this.setActive} active={active}>
-          <Icon name="search" ml={["10px", 2]} />
+          <SearchIcon />
           <SearchInput
             ref={ref => (this.searchInput = ref)}
             value={searchText}
@@ -91,19 +95,15 @@ export default class SearchBar extends React.Component {
             }}
           />
           {active && MetabaseSettings.searchTypeaheadEnabled() && (
-            <div className="absolute left right text-dark" style={{ top: 60 }}>
+            <SearchResultsFloatingContainer>
               {searchText.trim().length > 0 ? (
-                <Card
-                  className="overflow-y-auto"
-                  style={{ maxHeight: 400 }}
-                  py={1}
-                >
+                <SearchResultsContainer>
                   <SearchResults searchText={searchText.trim()} />
-                </Card>
+                </SearchResultsContainer>
               ) : (
                 <RecentsList />
               )}
-            </div>
+            </SearchResultsFloatingContainer>
           )}
         </SearchWrapper>
       </OnClickOutsideWrapper>

--- a/frontend/src/metabase/nav/components/SearchBar.styled.jsx
+++ b/frontend/src/metabase/nav/components/SearchBar.styled.jsx
@@ -4,14 +4,16 @@ import { color } from "metabase/lib/colors";
 
 export const SearchWrapper = styled.div`
   display: flex;
+  flex: 1 1 auto;
   align-items: center;
+  max-width: 50em;
+
   position: relative;
+
   background-color: ${color("bg-light")};
   border: 1px solid ${color("border")};
   border-radius: 6px;
-  flex: 1 1 auto;
-  max-width: 50em;
-  align-items: center;
+
   transition: background 150ms;
 
   &:hover {
@@ -20,12 +22,14 @@ export const SearchWrapper = styled.div`
 `;
 
 export const SearchInput = styled.input`
-  background-color: transparent;
   width: 100%;
-  border: none;
-  color: ${color("text-dark")};
   padding: 10px 12px;
   font-weight: 700;
+
+  color: ${color("text-dark")};
+  background-color: transparent;
+  border: none;
+
   &:focus {
     outline: none;
   }

--- a/frontend/src/metabase/nav/components/SearchBar.styled.jsx
+++ b/frontend/src/metabase/nav/components/SearchBar.styled.jsx
@@ -1,5 +1,8 @@
 import styled from "@emotion/styled";
 
+import Card from "metabase/components/Card";
+import Icon from "metabase/components/Icon";
+
 import { color } from "metabase/lib/colors";
 
 export const SearchWrapper = styled.div`
@@ -36,4 +39,27 @@ export const SearchInput = styled.input`
   &::placeholder {
     color: ${color("text-dark")};
   }
+`;
+
+export const SearchIcon = styled(Icon)`
+  margin-left: 10px;
+`;
+
+SearchIcon.defaultProps = {
+  name: "search",
+};
+
+export const SearchResultsFloatingContainer = styled.div`
+  position: absolute;
+  top: 60px;
+  left: 0;
+  right: 0;
+  color: ${color("text-dark")};
+`;
+
+export const SearchResultsContainer = styled(Card)`
+  padding-top: 8px;
+  padding-bottom: 8px;
+  overflow-y: auto;
+  max-height: 400px;
 `;

--- a/frontend/src/metabase/nav/components/SearchBar.styled.tsx
+++ b/frontend/src/metabase/nav/components/SearchBar.styled.tsx
@@ -45,10 +45,6 @@ export const SearchIcon = styled(Icon)`
   margin-left: 10px;
 `;
 
-SearchIcon.defaultProps = {
-  name: "search",
-};
-
 export const SearchResultsFloatingContainer = styled.div`
   position: absolute;
   top: 60px;

--- a/frontend/src/metabase/nav/containers/AppBar.tsx
+++ b/frontend/src/metabase/nav/containers/AppBar.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { t } from "ttag";
+import { Location, LocationDescriptorObject } from "history";
 
 import Link from "metabase/core/components/Link";
 import Tooltip from "metabase/components/Tooltip";
@@ -16,17 +17,12 @@ import Database from "metabase/entities/databases";
 
 import { AppBarRoot, LogoIconWrapper, SidebarButton } from "./AppBar.styled";
 
-type Location = {
-  pathname: string;
-  query: Record<string, string>;
-};
-
 type Props = {
   isSidebarOpen: boolean;
   location: Location;
   onToggleSidebarClick: () => void;
   onNewClick: () => void;
-  onChangeLocation: (nextLocation: Location) => void;
+  onChangeLocation: (nextLocation: LocationDescriptorObject) => void;
 };
 
 function AppBar({


### PR DESCRIPTION
The PR cleans up the `SearchBar` component (the one at the top navbar) to match our current FE guidelines:

* extracted styled-components
* converted to a functional component
* converted to TypeScript
* misc fixes

### To Verify

1. Open any page
2. Click the search bar, ensure you can see the recent list, and open them
3. Fill in a query, make sure you can see the loading progress and the results in the floating menu below the menu
4. Hit enter, you should end up on the `/search` route
5. Make sure your query is set as a `q` query parameter in the URL. Reload the page, ensure you still see the same results and the `q` query parameter remains in place
6. Click on the logo icon at the top left. Ensure the search input is reset (no query)