### PR TITLE
Set visualization mode via QB state when we are zoomed in on a specific row

### DIFF
--- a/frontend/src/metabase/query_builder/components/VisualizationResult.jsx
+++ b/frontend/src/metabase/query_builder/components/VisualizationResult.jsx
@@ -17,6 +17,7 @@ const ALLOWED_VISUALIZATION_PROPS = [
   "tableHeaderHeight",
   "scrollToColumn",
   "renderTableHeaderWrapper",
+  "mode",
 ];
 
 export default class VisualizationResult extends Component {

--- a/frontend/src/metabase/query_builder/components/view/View.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View.jsx
@@ -347,6 +347,7 @@ export default class View extends React.Component {
               onEditSeries={onEditSeries}
               onRemoveSeries={onRemoveSeries}
               onEditBreakout={onEditBreakout}
+              mode={queryMode}
             />
           </StyledDebouncedFrame>
         )}

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -31,6 +31,8 @@ import {
   getXValues,
   isTimeseries,
 } from "metabase/visualizations/lib/renderer_utils";
+import Mode from "metabase-lib/lib/Mode";
+import ObjectMode from "metabase/modes/components/modes/ObjectMode";
 
 export const getUiControls = state => state.qb.uiControls;
 
@@ -439,8 +441,9 @@ const isZoomingRow = createSelector(
 );
 
 export const getMode = createSelector(
-  [getLastRunQuestion],
-  question => question && question.mode(),
+  [getLastRunQuestion, isZoomingRow],
+  (question, isZoomingRow) =>
+    isZoomingRow ? new Mode(question, ObjectMode) : question && question.mode(),
 );
 
 export const getIsObjectDetail = createSelector(

--- a/frontend/test/metabase/scenarios/visualizations/object_detail.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/object_detail.cy.spec.js
@@ -96,7 +96,7 @@ describe("scenarios > question > object details", () => {
       .contains("8");
   });
 
-  it.skip("should not offer drill-through on the object detail records (metabase#20560)", () => {
+  it("should not offer drill-through on the object detail records (metabase#20560)", () => {
     openPeopleTable({ limit: 2 });
 
     cy.get(".Table-ID")


### PR DESCRIPTION
Resolves #20560 

The changes in https://github.com/metabase/metabase/pull/20101 push a lot of the object detail logic up to the level of the QB. There was some logic in the `Visualization` component that relied on the specific Question to determine what Mode we are in, but because the Question doesn't have a filter on it, it evaluates to being in "segment" mode and not "object" mode.

The solution I've arrived at in this PR is to evaluate what Mode we are in at the selector level, overriding `question.mode()` when `isZoomingRow` is true. There was already a way to pass `mode` as a prop to the `Visualization` component so I just had to lace the state through `View` and down to `Visualization`.

**Testing**
1. Go to the People table in the Query Builder
2. Click on a cell in the ID. The view should change to the object detail view and you should see the specific ID you clicked in the url, set as `objectId`
3. Hover mouse over a value in the details view. The cursor should indicate that it is text. Clicking should not make a menu appear.

Alternate approach
1. Go to the People table in the Query Builder
2. Click on the ID column header, click "Filter by this column" and set a filter matching a single ID
3. Adding the filter should take you to the object detail view. You won't see `objectId` in the URL.
4. Hover mouse over a value in the details view. The cursor should indicate that it is text. Clicking should not make a menu appear.
