### PR TITLE
Revert "Bump executor (#21036)"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,6 @@ executors:
       - image: metabase/qa-databases:postgres-sample-12
       - image: metabase/qa-databases:mongo-sample-4.0
       - image: metabase/qa-databases:mysql-sample-8
-    resource_class: xlarge
 
   java-8:
     working_directory: /home/circleci/metabase/metabase/


### PR DESCRIPTION
This reverts commit 160c3c7231cb1340ee19b98b16937d90828a8b94.

tl;dr The promised gains in the test speed proved to be close to useless. We're now experiencing long queues and jobs waiting to start for more than an hour. All that with greatly increased cost.