### PR TITLE
Reverting E2E machines on Buildjet for 4vCPU

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -8,7 +8,7 @@ on:
 jobs:
 
   build:
-    runs-on: buildjet-8vcpu-ubuntu-2004
+    runs-on: buildjet-2vcpu-ubuntu-2004
     timeout-minutes: 25
     strategy:
       matrix:
@@ -34,7 +34,7 @@ jobs:
       uses: ./.github/actions/prepare-uberjar-artifact
 
   e2e-tests:
-    runs-on: buildjet-8vcpu-ubuntu-2004
+    runs-on: buildjet-4vcpu-ubuntu-2004
     timeout-minutes: 30
     needs: build
     name: e2e-tests-${{ matrix.folder }}-${{ matrix.edition }}


### PR DESCRIPTION
Reverting https://github.com/metabase/metabase/pull/21346

To avoid concurrencies on Github the same way happened on Circle CI, I've bumped down the machines used on BuildJet. This will allow us to have more space in our current infra (368vCPU and 1152 GB RAM)
