### PR TITLE
Turn `modifyObstructiveCode` off in Cypress settings

### DIFF
--- a/frontend/test/__support__/e2e/cypress-snapshots.json
+++ b/frontend/test/__support__/e2e/cypress-snapshots.json
@@ -3,5 +3,6 @@
   "pluginsFile": "frontend/test/__support__/e2e/cypress-plugins.js",
   "integrationFolder": "frontend/test/snapshot-creators",
   "supportFile": "frontend/test/__support__/e2e/cypress.js",
+  "modifyObstructiveCode": false,
   "videoUploadOnPasses": false
 }

--- a/frontend/test/__support__/e2e/cypress.json
+++ b/frontend/test/__support__/e2e/cypress.json
@@ -5,6 +5,7 @@
   "supportFile": "frontend/test/__support__/e2e/cypress.js",
   "videoUploadOnPasses": false,
   "chromeWebSecurity": false,
+  "modifyObstructiveCode": false,
   "projectId": "KetpiS",
   "viewportHeight": 800,
   "viewportWidth": 1280,


### PR DESCRIPTION
### Status
PENDING CI

### What does this PR accomplish?
- Tries to remove some overhead in Cypress by turning off `modifyObstructiveCode` setting.

While searching for the keyword [`overhead`](https://github.com/cypress-io/cypress/issues?q=is%3Aopen+label%3A%22type%3A+performance+%F0%9F%8F%83%E2%80%8D%E2%99%80%EF%B8%8F%22+overhead) in Cypress issues, I stumbled upon an interesting performance enhancement "trick".

For more context, please see this answer:
https://github.com/cypress-io/cypress/issues/8156#issuecomment-675322251

and read this:
https://docs.cypress.io/guides/references/configuration#modifyObstructiveCode

### Comparison
- Before: https://github.com/metabase/metabase/actions/runs/2069993299
- After: https://github.com/metabase/metabase/actions/runs/2069996430

| Job                       | Before | After | Gain  |
|---------------------------|--------|-------|-------|
| admin-ee                  | 9:03   | 7:16  | 1:47  |
| admin-oss                 | 8:22   | 7:15  | 1:07  |
| binning-ee                | 4:35   | 4:42  | -0:07 |
| binning-oss               | 5:04   | 4:51  | 0:13  |
| collections-ee            | 7:40   | 8:33  | -0:53 |
| collections-oss           | 8:46   | 7:44  | 1:02  |
| custom-column-ee          | 5:08   | 4:21  | 0:47  |
| custom-column-oss         | 4:56   | 4:16  | 0:40  |
| dashboard-ee              | 6:28   | 5:27  | 1:01  |
| dashboard-oss             | 6:00   | 5:04  | 0:56  |
| dashboard-filters-ee      | 8:10   | 7:28  | 0:42  |
| dashboard-filters-oss     | 8:13   | 6:41  | 1:32  |
| dashboard-filters-sql-ee  | 5:36   | 0:00  | err   |
| dashboard-filters-sql-oss | 5:12   | 4:39  | 0:33  |
| downloads-ee              | 2:36   | 2:12  | 0:14  |
| downloads-oss             | 2:54   | 1:55  | 0:59  |
| embedding-ee              | 3:38   | 0:00  | err   |
| embedding-oss             | 4:10   | 3:30  | 0:40  |
| joins-ee                  | 4:35   | 3:28  | 1:07  |
| joins-oss                 | 3:47   | 3:05  | 0:42  |
| models-ee                 | 5:29   | 5:06  | 0:23  |
| models-oss                | 4:46   | 3:44  | 1:02  |
| moderation-ee             | 1:41   | 1:13  | 0:28  |
| moderation-oss            | 1:06   | 1:05  | 0:01  |
| native-ee                 | 5:31   | 4:02  | 1:29  |
| native-oss                | 4:34   | 3:28  | 1:06  |
| native-filters-ee         | 10:24  | 9:18  | 1:06  |
| native-filters-oss        | 9:11   | 6:22  | 2:49  |
| permissions-ee            | 3:44   | 2:39  | 1:05  |
| permissions-oss           | 2:06   | 1:45  | 0:21  |
| question-ee               | 12:37  | 11:09 | 1:28  |
| question-oss              | 12:47  | 8:41  | 3:06  |
| sharing-ee                | 5:26   | 4:30  | 0:56  |
| sharing-oss               | 4:48   | 3:13  | 1:35  |
| visualizations-ee         | 8:30   | 6:17  | 2:13  |
| visualizations-oss        | 7:58   | 5:32  | 2:26  |