### PR TITLE
Reverting Github Actions cache to v2

### DIFF
--- a/.github/actions/prepare-backend/action.yml
+++ b/.github/actions/prepare-backend/action.yml
@@ -25,7 +25,7 @@ runs:
         curl -O https://download.clojure.org/install/linux-install-${{ inputs.clojure-version }}.sh &&
         sudo bash ./linux-install-${{ inputs.clojure-version }}.sh
     - name: Get M2 cache
-      uses: actions/cache@v3
+      uses: actions/cache@v2
       with:
         path: |
           ~/.m2

--- a/.github/actions/prepare-cypress/action.yml
+++ b/.github/actions/prepare-cypress/action.yml
@@ -3,7 +3,7 @@ runs:
   using: "composite"
   steps:
     - name: Get Cypress cache
-      uses: actions/cache@v3
+      uses: actions/cache@v2
       with:
         path: ~/.cache/Cypress
         key: ${{ runner.os }}-Cypress-${{ hashFiles('**/yarn.lock') }}

--- a/.github/actions/prepare-frontend/action.yml
+++ b/.github/actions/prepare-frontend/action.yml
@@ -8,12 +8,12 @@ runs:
         node-version: 14.x
         cache: 'yarn'
     - name: Get M2 cache
-      uses: actions/cache@v3
+      uses: actions/cache@v2
       with:
         path: ~/.m2
         key: ${{ runner.os }}-cljs-${{ hashFiles('**/shadow-cljs.edn') }}
     - name: Get node_modules cache
-      uses: actions/cache@v3
+      uses: actions/cache@v2
       with:
         path: node_modules
         key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}


### PR DESCRIPTION
After upgrading GitHub actions cache (#21234) we are seeing some failures inconsistently

https://github.com/metabase/metabase/runs/5769859731?check_suite_focus=true

<img width="1014" alt="Screen Shot 2022-03-31 at 08 38 49" src="https://user-images.githubusercontent.com/17742979/161046849-0d26e28d-4aae-4a9a-8dee-39d30ae5caf2.png">

So, I'm reverting to avoid those