### PR TITLE
Fix a flake in repro for #15655 [ci skip]

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard/x-rays.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/x-rays.cy.spec.js
@@ -91,8 +91,11 @@ describe("scenarios > x-rays", () => {
 
   ["X-ray", "Compare to the rest"].forEach(action => {
     it(`"${action.toUpperCase()}" should work on a nested question made from base native question (metabase#15655)`, () => {
+      // TODO: Remove this when #15655 gets fixed
       cy.skipOn(action === "Compare to the rest");
+
       cy.intercept("GET", "/api/automagic-dashboards/**").as("xray");
+
       cy.createNativeQuestion({
         name: "15655",
         native: { query: "select * from people" },
@@ -109,11 +112,13 @@ describe("scenarios > x-rays", () => {
         .first()
         .click({ force: true });
       cy.findByText(action).click();
+
       cy.wait("@xray").then(xhr => {
         expect(xhr.response.body.cause).not.to.exist;
         expect(xhr.response.statusCode).not.to.eq(500);
       });
-      cy.findByText(/A closer look at the number of/);
+
+      cy.findByRole("heading", { name: /^A closer look at the number of/ });
       cy.get(".DashCard");
     });
 


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- Attempts to fix a newly appearing flake in `frontend/test/metabase/scenarios/dashboard/x-rays.cy.spec.js`

One of the failed runs: https://github.com/metabase/metabase/runs/5768212658?check_suite_focus=true

Looking at the failing screenshot doesn't help me much, and I couldn't reproduce this issue locally.
![scenarios  x-rays -- X-RAY should work on a nested question made from base native question (metabase#15655) (failed) (attempt 2)](https://user-images.githubusercontent.com/31325167/161048412-2d4cd312-faea-4e7d-af57-c9ea22b5c907.png)

While watching the video recording, unfortunately it is not possible to see the exact error that Cypress logs. I can only see that it fails on this particular string.

So as a solution, I made it a bit more specific.

Here's a screenshot from a local run showing that this works
![image](https://user-images.githubusercontent.com/31325167/161049328-8ab0571d-8613-4c69-a0d0-a5fe3452392c.png)

