### PR TITLE
Reverting the unifying Percy+Build PR

### DIFF
--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -8,7 +8,6 @@ on:
     - 'enterprise/frontend/test/**'
     - ".**"
     - "test*"
-    - "!frontend/test/metabase-visual/**"
 
 jobs:
   build:
@@ -121,34 +120,3 @@ jobs:
     - name: Retag and push images if branch
       if: ${{ !(startsWith(github.ref_name,'master') || startsWith(github.ref_name,'main') || startsWith(github.ref_name,'backport')) && matrix.edition == 'ee' }}
       run: docker tag localhost:5000/metabase-dev:${{ steps.extract_branch.outputs.branch }}-ee metabase/metabase-dev:${{ steps.extract_branch.outputs.branch }} && docker push metabase/metabase-dev:${{ steps.extract_branch.outputs.branch }}
-
-  percy:
-    name: Percy visual test
-    if: github.ref_name == 'master' || github.ref_name == 'main' || startsWith(github.ref_name,'release-')
-    runs-on: buildjet-8vcpu-ubuntu-2004
-    timeout-minutes: 30
-    needs: check_jar_health
-    steps:
-      - uses: actions/checkout@v3
-      - name: Prepare front-end environment
-        uses: ./.github/actions/prepare-frontend
-      - name: Prepare back-end environment
-        uses: ./.github/actions/prepare-backend
-      - name: Prepare cypress environment
-        uses: ./.github/actions/prepare-cypress
-
-      - uses: actions/download-artifact@v2
-        name: Retrieve uberjar artifact
-        with:
-          name: metabase-oss-uberjar
-      - name: Get the version info
-        run: |
-          jar xf target/uberjar/metabase.jar version.properties
-          mv version.properties resources/
-      - name: Run maildev
-        run: docker run -d -p 80:80 -p 25:25 maildev/maildev:1.1.0
-      - name: Percy Test
-        run: yarn run test-visual-no-build
-        env:
-          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
-        if: env.PERCY_TOKEN != null


### PR DESCRIPTION
Reverting as we don't need to do visual testing on each commit, which makes a lot of sense