### PR TITLE
Ignore running E2E workflow when not needed

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -8,8 +8,6 @@ on:
       - "docs/**"
       - "**.md"
       - ".circleci/**"
-      - ".github/**"
-      - ".**"
 
 jobs:
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
       - 'master'
+    paths-ignore:
+      - "docs/**"
+      - "**.md"
+      - ".circleci/**"
+      - ".github/**"
 
 jobs:
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -9,6 +9,7 @@ on:
       - "**.md"
       - ".circleci/**"
       - ".github/**"
+      - ".**"
 
 jobs:
 


### PR DESCRIPTION
Adding `paths-ignore:` to GitHub not run the workflow when not needed