### PR TITLE
Fix flakes in native filters spec

### DIFF
--- a/frontend/test/metabase/scenarios/native-filters/helpers/e2e-field-filter-helpers.js
+++ b/frontend/test/metabase/scenarios/native-filters/helpers/e2e-field-filter-helpers.js
@@ -28,7 +28,7 @@ export function setWidgetType(type) {
 export function addWidgetStringFilter(value) {
   popover()
     .find("input")
-    .type(value);
+    .type(`${value}{enter}`);
   cy.button("Add filter").click();
 }
 


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
-  Fixes a stubborn flake in `frontend/test/metabase/scenarios/native-filters/sql-field-filter-string.cy.spec.js` in `e2e-tests-native-filters` CI group

Examples of the failed run:
- https://github.com/metabase/metabase/actions/runs/2069996430
- https://github.com/metabase/metabase/actions/runs/2070848886
- https://github.com/metabase/metabase/actions/runs/2070400575

![scenarios  filters  sql filters  field filter  String -- should work for String is not -- when set through the filter widget (failed) (attempt 3)](https://user-images.githubusercontent.com/31325167/161088417-85081eca-88ee-4eca-bf84-b6eba75d4297.png)

Stress-tested this file x10 and it's passing:
https://github.com/metabase/metabase/runs/5772823348?check_suite_focus=true

The fix consists of pressing the `enter` after the full string has been typed in the input field. That makes sure the proper filter value will be accepted before we even press the "Add filter" button.
