### PR TITLE
[E2E] Fix xrays flake

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard/x-rays.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/x-rays.cy.spec.js
@@ -163,7 +163,7 @@ describe("scenarios > x-rays", () => {
     cy.findByText("How these transactions are distributed");
   });
 
-  it("should be able to click the title of an x-ray dashcard to see it in the query builder", () => {
+  it("should be able to click the title of an x-ray dashcard to see it in the query builder (metabase#19405)", () => {
     const timeout = { timeout: 10000 };
 
     cy.visit(`/auto/dashboard/table/${ORDERS_ID}`);

--- a/frontend/test/metabase/scenarios/dashboard/x-rays.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/x-rays.cy.spec.js
@@ -26,20 +26,18 @@ describe("scenarios > x-rays", () => {
 
   it("should exist on homepage when person first signs in", () => {
     cy.visit("/");
-    cy.contains("A look at your People table");
+
     cy.contains("A look at your Orders table");
     cy.contains("A look at your Products table");
     cy.contains("A look at your Reviews table");
-  });
 
-  it("should be populated", () => {
-    cy.visit("/");
-    cy.findByText("People table").click();
+    // Let's explore one of our tables
+    cy.contains("A look at your People table").click();
 
-    cy.findByText("Something's gone wrong").should("not.exist");
     cy.findByText("Here's an overview of the people in your People table");
     cy.findByText("Overview");
     cy.findByText("Per state");
+
     cy.get(".Card").should("have.length", 11);
   });
 
@@ -168,8 +166,7 @@ describe("scenarios > x-rays", () => {
   it("should be able to click the title of an x-ray dashcard to see it in the query builder", () => {
     const timeout = { timeout: 10000 };
 
-    cy.visit("/");
-    cy.contains("A look at your Orders table").click();
+    cy.visit(`/auto/dashboard/table/${ORDERS_ID}`);
 
     // confirm results of "Total transactions" card are present
     cy.findByText("18,760", timeout);

--- a/frontend/test/metabase/scenarios/dashboard/x-rays.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/x-rays.cy.spec.js
@@ -148,11 +148,11 @@ describe("scenarios > x-rays", () => {
   });
 
   it("should be able to save an x-ray as a dashboard and visit it immediately (metabase#18028)", () => {
-    cy.visit("/");
-    cy.contains("A look at your Orders table").click();
+    cy.intercept("GET", "/app/assets/geojson/**").as("geojson");
 
-    // There are a lot of spinners in this dashboard. Give them some time to disappear.
-    cy.findByTestId("loading-spinner", { timeout: 10000 }).should("not.exist");
+    cy.visit(`/auto/dashboard/table/${ORDERS_ID}`);
+
+    cy.wait("@geojson", { timeout: 10000 });
 
     cy.button("Save this").click();
 


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- This is a successor to the https://github.com/metabase/metabase/pull/21379
- After that fix, another flake started appearing

Example of the failed run
https://github.com/metabase/metabase/actions/runs/2070848886

Screenshot from the failed run
![scenarios  x-rays -- should be able to save an x-ray as a dashboard and visit it immediately (metabase#18028) (failed) (attempt 3)](https://user-images.githubusercontent.com/31325167/161104833-f6c62d34-4dbd-4337-a087-75e1f107a3ad.png)


### The fix
- Wait for the last and the longest request to finish (loading geojson).


Note:
Stress-tested this file and ran the whole file x10 in GHA - all green!
https://github.com/metabase/metabase/actions/runs/2072091251