### PR TITLE
Downgrade buildJet instance of Percy

### DIFF
--- a/.github/workflows/percy-issue-comment.yml
+++ b/.github/workflows/percy-issue-comment.yml
@@ -68,7 +68,7 @@ jobs:
 
   percy:
     timeout-minutes: 30
-    runs-on: buildjet-4vcpu-ubuntu-2004
+    runs-on: buildjet-2vcpu-ubuntu-2004
     needs: [build, pr_info]
     env:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/percy-issue-comment.yml
+++ b/.github/workflows/percy-issue-comment.yml
@@ -44,7 +44,7 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     needs: pr_info
-    timeout-minutes: 60
+    timeout-minutes: 30
     strategy:
       matrix:
         edition: [oss]
@@ -68,7 +68,7 @@ jobs:
 
   percy:
     timeout-minutes: 30
-    runs-on: buildjet-8vcpu-ubuntu-2004
+    runs-on: buildjet-4vcpu-ubuntu-2004
     needs: [build, pr_info]
     env:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/percy-issue-comment.yml
+++ b/.github/workflows/percy-issue-comment.yml
@@ -68,7 +68,7 @@ jobs:
 
   percy:
     timeout-minutes: 30
-    runs-on: buildjet-2vcpu-ubuntu-2004
+    runs-on: buildjet-4vcpu-ubuntu-2004
     needs: [build, pr_info]
     env:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -4,7 +4,7 @@ name: Percy
 on:
   push:
     branches:
-      - percy-downgrade
+      - master
       - "release-**"
     paths-ignore:
       - "docs/**"
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: buildjet-2vcpu-ubuntu-2004
     timeout-minutes: 25
     strategy:
       matrix:
@@ -37,7 +37,7 @@ jobs:
 
   percy:
     timeout-minutes: 30
-    runs-on: buildjet-2vcpu-ubuntu-2004
+    runs-on: buildjet-4vcpu-ubuntu-2004
     needs: build
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -4,7 +4,7 @@ name: Percy
 on:
   push:
     branches:
-      - master
+      - percy-downgrade
       - "release-**"
     paths-ignore:
       - "docs/**"
@@ -16,7 +16,7 @@ on:
 jobs:
   build:
     runs-on: buildjet-2vcpu-ubuntu-2004
-    timeout-minutes: 60
+    timeout-minutes: 25
     strategy:
       matrix:
         edition: [oss]
@@ -37,7 +37,7 @@ jobs:
 
   percy:
     timeout-minutes: 30
-    runs-on: buildjet-8vcpu-ubuntu-2004
+    runs-on: buildjet-4vcpu-ubuntu-2004
     needs: build
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build:
-    runs-on: buildjet-2vcpu-ubuntu-2004
+    runs-on: ubuntu-20.04
     timeout-minutes: 25
     strategy:
       matrix:
@@ -37,7 +37,7 @@ jobs:
 
   percy:
     timeout-minutes: 30
-    runs-on: buildjet-4vcpu-ubuntu-2004
+    runs-on: buildjet-2vcpu-ubuntu-2004
     needs: build
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
After some tests, it was possible to see that moving from 8vCPU to 4vCPU doesn't increase the overall time, but if we added 
a 2vCPU we have timeouts. So we are sticking with 4vCP

### 4vCPU
v<img width="1342" alt="Screen Shot 2022-03-31 at 13 51 22" src="https://user-images.githubusercontent.com/17742979/161109902-4a0998a0-6fba-46f1-aab5-5f8445db0e7b.png">

### 8vCPU
<img width="1132" alt="Screen Shot 2022-03-31 at 13 59 32" src="https://user-images.githubusercontent.com/17742979/161110095-f079d425-1ba2-4ce2-965e-a5027f64b7c7.png">


### 2vCPU
<img width="1464" alt="Screen Shot 2022-03-31 at 13 51 13" src="https://user-images.githubusercontent.com/17742979/161109897-e930725b-d1c6-41f5-b800-0841b78bb4f9.png">
