### PR TITLE
[E2E] Reinforce repro for #17514

### DIFF
--- a/frontend/test/metabase/scenarios/question/reproductions/17514-ui-overlay.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/17514-ui-overlay.cy.spec.js
@@ -130,7 +130,7 @@ describe("issue 17514", () => {
       });
     });
 
-    it("should not show the run overlay because ofth references to the orphaned fields (metabase#17514-1)", () => {
+    it("should not show the run overlay because of the references to the orphaned fields (metabase#17514-2)", () => {
       openNotebookMode();
 
       cy.findByText("Join data").click();

--- a/frontend/test/metabase/scenarios/question/reproductions/17514-ui-overlay.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/17514-ui-overlay.cy.spec.js
@@ -88,9 +88,12 @@ describe("issue 17514", () => {
       closeModal();
 
       saveDashboard();
+      cy.wait("@getDashboard");
 
       filterWidget().click();
       setAdHocFilter({ timeBucket: "Years" });
+
+      cy.location("search").should("eq", "?date_filter=past30years");
       cy.wait("@cardQuery");
 
       cy.findByText("Previous 30 Years");


### PR DESCRIPTION
### Before this PR

The query sometimes gets cancelled and the test fails because we are waiting for that query.
![issue 17514 -- scenario 1 -- should not show the run overlay when we apply dashboard filter on a question with removed column and then click through its title (metabase#17514-1) (failed) (attempt 2)](https://user-images.githubusercontent.com/31325167/161128548-043f514e-d644-4e75-a17a-abf06707f6e9.png)

Failure: https://github.com/metabase/metabase/actions/runs/2072638586

### Now
Should have a few more guards in place and hopefully shouldn't happen any more.

![image](https://user-images.githubusercontent.com/31325167/161129727-3f625f2d-420e-4b5a-bad4-6d44dfcbc25b.png)

*NOTE:
I was able to reproduce the original failure while running Cypress locally. That's why I'm providing the local "burning" screenshot