### PR TITLE
[E2E] Fix flaky sidebar tests

### DIFF
--- a/frontend/test/metabase/scenarios/collections/collections-sidebar.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections-sidebar.cy.spec.js
@@ -10,10 +10,12 @@ describe("collections sidebar (metabase#15006)", () => {
     restore();
     cy.signInAsAdmin();
     cy.viewport(480, 800);
+    cy.intercept("GET", "/api/collection/*").as("fetchCollections");
     cy.visit("/collection/root");
   });
 
   it("should be able to toggle collections sidebar when switched to mobile screen size", () => {
+    cy.wait("@fetchCollections");
     navigationSidebar().should("have.attr", "aria-hidden", "true");
     openNavigationSidebar();
 
@@ -26,13 +28,18 @@ describe("collections sidebar (metabase#15006)", () => {
   });
 
   it("should close collections sidebar when collection is clicked in mobile screen size", () => {
+    cy.wait("@fetchCollections");
     openNavigationSidebar();
 
     navigationSidebar().within(() => {
       cy.findByText("First collection").click();
     });
+    cy.wait("@fetchCollections");
 
     navigationSidebar().should("have.attr", "aria-hidden", "true");
-    cy.findByText("First collection");
+    cy.findByTestId("collection-name-heading").should(
+      "have.text",
+      "First collection",
+    );
   });
 });


### PR DESCRIPTION
Mobile sidebar tests started flacking and this PR should fix this by ensuring we do all the UI queries after page content is loaded

Failure in GHA: https://github.com/metabase/metabase/actions/runs/2073152742

![collections sidebar (metabase#15006) -- should close collections sidebar when collection is clicked in mobile screen size (failed) (attempt 3)](https://user-images.githubusercontent.com/31325167/161147022-35df505d-31dd-4fb2-b4f5-e33576a75a41.png)

