### PR TITLE
Currency input formatting

### DIFF
--- a/frontend/src/metabase/components/FieldValuesWidget.jsx
+++ b/frontend/src/metabase/components/FieldValuesWidget.jsx
@@ -15,8 +15,7 @@ import AutoExpanding from "metabase/hoc/AutoExpanding";
 import { MetabaseApi } from "metabase/services";
 import { addRemappings, fetchFieldValues } from "metabase/redux/metadata";
 import { defer } from "metabase/lib/promise";
-import { stripId, getCurrencySymbol } from "metabase/lib/formatting";
-import { isCurrency } from "metabase/lib/schema_metadata";
+import { stripId } from "metabase/lib/formatting";
 import { fetchDashboardParameterValues } from "metabase/dashboard/actions";
 import { getDashboardParameterValuesCache } from "metabase/dashboard/selectors";
 
@@ -375,12 +374,6 @@ export class FieldValuesWidget extends Component {
     );
   };
 
-  extractFieldSettings = field => {
-    const fieldId = field?.id;
-    const fieldMetadata = field?.metadata?.fields[fieldId];
-    return fieldMetadata?.settings;
-  };
-
   render() {
     const {
       value,
@@ -392,6 +385,7 @@ export class FieldValuesWidget extends Component {
       className,
       style,
       parameter,
+      prefix,
     } = this.props;
     const { loadingState } = this.state;
 
@@ -412,12 +406,6 @@ export class FieldValuesWidget extends Component {
     const isLoading = loadingState === "LOADING";
     const isFetchingList = this.shouldList() && isLoading;
     const hasListData = this.hasList();
-
-    const fieldSettings = this.extractFieldSettings(fields[0]);
-    const currencyPrefix =
-      isCurrency(fields[0]) && fieldSettings?.currency
-        ? getCurrencySymbol(fieldSettings.currency)
-        : null;
 
     return (
       <div
@@ -442,7 +430,7 @@ export class FieldValuesWidget extends Component {
         )}
         {!hasListData && !isFetchingList && (
           <TokenField
-            prefix={currencyPrefix}
+            prefix={prefix}
             value={value.filter(v => v != null)}
             onChange={onChange}
             placeholder={placeholder}

--- a/frontend/src/metabase/components/FieldValuesWidget.jsx
+++ b/frontend/src/metabase/components/FieldValuesWidget.jsx
@@ -15,7 +15,8 @@ import AutoExpanding from "metabase/hoc/AutoExpanding";
 import { MetabaseApi } from "metabase/services";
 import { addRemappings, fetchFieldValues } from "metabase/redux/metadata";
 import { defer } from "metabase/lib/promise";
-import { stripId } from "metabase/lib/formatting";
+import { stripId, getCurrencySymbol } from "metabase/lib/formatting";
+import { isCurrency } from "metabase/lib/schema_metadata";
 import { fetchDashboardParameterValues } from "metabase/dashboard/actions";
 import { getDashboardParameterValuesCache } from "metabase/dashboard/selectors";
 
@@ -374,6 +375,12 @@ export class FieldValuesWidget extends Component {
     );
   };
 
+  extractFieldSettings = field => {
+    const fieldId = field?.id;
+    const fieldMetadata = field?.metadata?.fields[fieldId];
+    return fieldMetadata?.settings;
+  };
+
   render() {
     const {
       value,
@@ -406,6 +413,12 @@ export class FieldValuesWidget extends Component {
     const isFetchingList = this.shouldList() && isLoading;
     const hasListData = this.hasList();
 
+    const fieldSettings = this.extractFieldSettings(fields[0]);
+    const currencyPrefix =
+      isCurrency(fields[0]) && fieldSettings?.currency
+        ? getCurrencySymbol(fieldSettings.currency)
+        : null;
+
     return (
       <div
         style={{
@@ -429,6 +442,7 @@ export class FieldValuesWidget extends Component {
         )}
         {!hasListData && !isFetchingList && (
           <TokenField
+            prefix={currencyPrefix}
             value={value.filter(v => v != null)}
             onChange={onChange}
             placeholder={placeholder}

--- a/frontend/src/metabase/components/TokenField.jsx
+++ b/frontend/src/metabase/components/TokenField.jsx
@@ -506,7 +506,11 @@ export default class TokenField extends Component {
         style={{ maxHeight: 130, ...style }}
         onMouseDownCapture={this.onMouseDownCapture}
       >
-        {!!prefix && <span className="text-medium mb1 py1 pr1">{prefix}</span>}
+        {!!prefix && (
+          <span className="text-medium mb1 py1 pr1" data-testid="input-prefix">
+            {prefix}
+          </span>
+        )}
         {value.map((v, index) => (
           <TokenFieldItem key={index} isValid={validateValue(v)}>
             <span

--- a/frontend/src/metabase/components/TokenField.jsx
+++ b/frontend/src/metabase/components/TokenField.jsx
@@ -454,6 +454,7 @@ export default class TokenField extends Component {
       valueStyle,
       optionsStyle,
       optionsClassName,
+      prefix,
     } = this.props;
     let {
       inputValue,
@@ -500,11 +501,12 @@ export default class TokenField extends Component {
       <ul
         className={cx(
           className,
-          "pl1 pt1 pb0 pr0 flex flex-wrap bg-white scroll-x scroll-y",
+          "pl1 pt1 pb0 pr0 flex align-center flex-wrap bg-white scroll-x scroll-y",
         )}
         style={{ maxHeight: 130, ...style }}
         onMouseDownCapture={this.onMouseDownCapture}
       >
+        {!!prefix && <span className="text-medium mb1 py1 pr1">{prefix}</span>}
         {value.map((v, index) => (
           <TokenFieldItem key={index} isValid={validateValue(v)}>
             <span

--- a/frontend/src/metabase/lib/formatting.js
+++ b/frontend/src/metabase/lib/formatting.js
@@ -44,6 +44,7 @@ import {
   renderLinkURLForClick,
 } from "metabase/lib/formatting/link";
 import { NULL_DISPLAY_VALUE, NULL_NUMERIC_VALUE } from "metabase/lib/constants";
+import { currency } from "cljs/metabase.shared.util.currency";
 
 // a one or two character string specifying the decimal and grouping separator characters
 
@@ -106,6 +107,15 @@ export function numberFormatterForOptions(options) {
     minimumSignificantDigits: options.minimumSignificantDigits,
     maximumSignificantDigits: options.maximumSignificantDigits,
   });
+}
+
+let currencyMapCache;
+export function getCurrencySymbol(currencyCode) {
+  if (!currencyMapCache) {
+    // only turn the array into a map if we call this function
+    currencyMapCache = Object.fromEntries(currency);
+  }
+  return currencyMapCache[currencyCode]?.symbol || currencyCode;
 }
 
 export function formatNumber(number, options = {}) {

--- a/frontend/src/metabase/lib/formatting.js
+++ b/frontend/src/metabase/lib/formatting.js
@@ -115,7 +115,7 @@ export function getCurrencySymbol(currencyCode) {
     // only turn the array into a map if we call this function
     currencyMapCache = Object.fromEntries(currency);
   }
-  return currencyMapCache[currencyCode]?.symbol || currencyCode;
+  return currencyMapCache[currencyCode]?.symbol || currencyCode || "$";
 }
 
 export function formatNumber(number, options = {}) {

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DefaultPicker.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DefaultPicker.jsx
@@ -13,7 +13,10 @@ import FieldValuesWidget from "metabase/components/FieldValuesWidget";
 import {
   getFilterArgumentFormatOptions,
   isFuzzyOperator,
+  isCurrency,
 } from "metabase/lib/schema_metadata";
+
+import { getCurrencySymbol } from "metabase/lib/formatting";
 
 import {
   BetweenLayoutContainer,
@@ -61,6 +64,18 @@ export default function DefaultPicker({
   const isBetweenLayout =
     operator.name === "between" && operatorFields.length === 2;
 
+  const extractFieldSettings = field => {
+    const fieldId = field?.id;
+    const fieldMetadata = field?.metadata?.fields[fieldId];
+    return fieldMetadata?.settings;
+  };
+
+  const fieldSettings = extractFieldSettings(field);
+  const currencyPrefix =
+    isCurrency(field) && fieldSettings?.currency
+      ? getCurrencySymbol(fieldSettings.currency)
+      : null;
+
   const fieldWidgets = operatorFields
     .map((operatorField, index) => {
       let values, onValuesChange;
@@ -102,6 +117,7 @@ export default function DefaultPicker({
             multi={operator.multi}
             placeholder={placeholder}
             fields={underlyingField ? [underlyingField] : []}
+            prefix={currencyPrefix}
             disablePKRemappingForSearch={true}
             autoFocus={index === 0}
             alwaysShowOptions={operator.fields.length === 1}
@@ -132,6 +148,7 @@ export default function DefaultPicker({
             values={values}
             onValuesChange={onValuesChange}
             placeholder={placeholder}
+            prefix={currencyPrefix}
             multi={operator.multi}
             onCommit={onCommit}
           />

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DefaultPicker.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DefaultPicker.jsx
@@ -143,7 +143,6 @@ export default function DefaultPicker({
         return (
           <NumberPicker
             key={index}
-            field={field}
             autoFocus={index === 0}
             values={values}
             onValuesChange={onValuesChange}

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DefaultPicker.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DefaultPicker.jsx
@@ -127,6 +127,7 @@ export default function DefaultPicker({
         return (
           <NumberPicker
             key={index}
+            field={field}
             autoFocus={index === 0}
             values={values}
             onValuesChange={onValuesChange}

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DefaultPicker.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DefaultPicker.jsx
@@ -65,9 +65,33 @@ export default function DefaultPicker({
     operator.name === "between" && operatorFields.length === 2;
 
   const extractFieldSettings = field => {
+    const visualizationSettings = filter
+      ?.query()
+      ?.question()
+      ?.settings();
+
+    // map column settings by field id
+    const parsedVisualizationSettings = Object.fromEntries(
+      Object.entries(visualizationSettings?.column_settings || {}).map(
+        ([key, value]) => {
+          try {
+            // destringify the keys eg: '["ref",["field",39,null]]' to find field ids
+            const fieldId = JSON.parse(key)[1][1];
+            return [fieldId, value];
+          } catch (err) {
+            return [null, null];
+          }
+        },
+      ),
+    );
+
     const fieldId = field?.id;
     const fieldMetadata = field?.metadata?.fields[fieldId];
-    return fieldMetadata?.settings;
+
+    return {
+      ...(fieldMetadata?.settings || {}),
+      ...(parsedVisualizationSettings[fieldId] || {}),
+    };
   };
 
   const fieldSettings = extractFieldSettings(field);

--- a/frontend/src/metabase/query_builder/components/filters/pickers/NumberPicker.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/NumberPicker.jsx
@@ -3,8 +3,6 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { t } from "ttag";
 import TextPicker from "./TextPicker";
-import { isCurrency } from "metabase/lib/schema_metadata";
-import { getCurrencySymbol } from "metabase/lib/formatting";
 
 export default class NumberPicker extends Component {
   constructor(props) {
@@ -53,18 +51,11 @@ export default class NumberPicker extends Component {
 
   render() {
     const values = this.state.stringValues.slice(0, this.props.values.length);
-
-    const fieldSettings = this.extractFieldSettings(this.props.field);
-    const currencyPrefix =
-      isCurrency(this.props.field) && fieldSettings?.currency
-        ? getCurrencySymbol(fieldSettings.currency)
-        : null;
-
     return (
       <TextPicker
         {...this.props}
         isSingleLine
-        prefix={currencyPrefix}
+        prefix={this.props.prefix}
         values={values}
         validations={this.state.validations}
         onValuesChange={values => this.onValuesChange(values)}

--- a/frontend/src/metabase/query_builder/components/filters/pickers/NumberPicker.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/NumberPicker.jsx
@@ -3,6 +3,8 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { t } from "ttag";
 import TextPicker from "./TextPicker";
+import { isCurrency } from "metabase/lib/schema_metadata";
+import { getCurrencySymbol } from "metabase/lib/formatting";
 
 export default class NumberPicker extends Component {
   constructor(props) {
@@ -43,12 +45,26 @@ export default class NumberPicker extends Component {
     });
   }
 
+  extractFieldSettings = field => {
+    const fieldId = field?.id;
+    const fieldMetadata = field?.metadata?.fields[fieldId];
+    return fieldMetadata?.settings;
+  };
+
   render() {
     const values = this.state.stringValues.slice(0, this.props.values.length);
+
+    const fieldSettings = this.extractFieldSettings(this.props.field);
+    const currencyPrefix =
+      isCurrency(this.props.field) && fieldSettings?.currency
+        ? getCurrencySymbol(fieldSettings.currency)
+        : null;
+
     return (
       <TextPicker
         {...this.props}
         isSingleLine
+        prefix={currencyPrefix}
         values={values}
         validations={this.state.validations}
         onValuesChange={values => this.onValuesChange(values)}

--- a/frontend/src/metabase/query_builder/components/filters/pickers/NumberPicker.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/NumberPicker.jsx
@@ -43,12 +43,6 @@ export default class NumberPicker extends Component {
     });
   }
 
-  extractFieldSettings = field => {
-    const fieldId = field?.id;
-    const fieldMetadata = field?.metadata?.fields[fieldId];
-    return fieldMetadata?.settings;
-  };
-
   render() {
     const values = this.state.stringValues.slice(0, this.props.values.length);
     return (

--- a/frontend/src/metabase/query_builder/components/filters/pickers/TextPicker.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/TextPicker.jsx
@@ -56,6 +56,7 @@ export default class TextPicker extends Component {
       onCommit,
       isSingleLine,
       autoFocus,
+      prefix,
     } = this.props;
     const hasInvalidValues = _.some(validations, v => v === false);
 
@@ -67,7 +68,15 @@ export default class TextPicker extends Component {
 
     return (
       <div>
-        <div className="FilterInput px1 pt1 relative">
+        <div className="FilterInput px1 pt1 relative flex align-center">
+          {!!prefix && (
+            <span
+              className="text-medium px1"
+              style={{ marginRight: -30, width: 30, zIndex: 2 }}
+            >
+              {prefix}
+            </span>
+          )}
           {!isSingleLine && (
             <AutosizeTextarea
               className={cx("input block full border-purple", {
@@ -89,6 +98,11 @@ export default class TextPicker extends Component {
               className={cx("input block full border-purple", {
                 "border-error": hasInvalidValues,
               })}
+              style={{
+                paddingLeft: this.props.prefix
+                  ? `${this.props.prefix.length}.2rem`
+                  : "",
+              }}
               type="text"
               value={this.state.fieldString}
               onChange={e => this.setValue(e.target.value)}

--- a/frontend/src/metabase/query_builder/components/filters/pickers/TextPicker.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/TextPicker.jsx
@@ -71,6 +71,7 @@ export default class TextPicker extends Component {
         <div className="FilterInput px1 pt1 relative flex align-center">
           {!!prefix && (
             <span
+              data-testid="input-prefix"
               className="text-medium px1"
               style={{ marginRight: -30, width: 30, zIndex: 2 }}
             >

--- a/frontend/src/metabase/visualizations/lib/settings/column.js
+++ b/frontend/src/metabase/visualizations/lib/settings/column.js
@@ -24,6 +24,7 @@ function getVisualizationRaw(...args) {
 import {
   formatColumn,
   numberFormatterForOptions,
+  getCurrencySymbol,
 } from "metabase/lib/formatting";
 import {
   getDateFormatFromStyle,
@@ -302,7 +303,7 @@ export const NUMBER_COLUMN_SETTINGS = {
     widget: "radio",
     getProps: (column, settings) => {
       const c = settings["currency"] || "USD";
-      const symbol = getCurrency(c, "symbol");
+      const symbol = getCurrencySymbol(c);
       const code = getCurrency(c, "code");
       const name = getCurrency(c, "name");
       return {
@@ -328,7 +329,7 @@ export const NUMBER_COLUMN_SETTINGS = {
     },
     getDefault: (column, settings) => {
       const c = settings["currency"] || "USD";
-      return getCurrency(c, "symbol") !== getCurrency(c, "code")
+      return getCurrencySymbol(c) !== getCurrency(c, "code")
         ? "symbol"
         : "code";
     },
@@ -401,6 +402,9 @@ export const NUMBER_COLUMN_SETTINGS = {
         settings["number_style"] === "currency" &&
         settings["currency_in_header"]
       ) {
+        if (settings["currency_style"] === "symbol") {
+          return getCurrencySymbol(settings["currency"]);
+        }
         return getCurrency(settings["currency"], settings["currency_style"]);
       }
       return null;

--- a/frontend/test/metabase/components/FieldValuesWidget.unit.spec.js
+++ b/frontend/test/metabase/components/FieldValuesWidget.unit.spec.js
@@ -166,23 +166,23 @@ describe("FieldValuesWidget", () => {
 
       expect(screen.queryByText("AZ")).toBeNull();
       expect(screen.queryByText("Facebook")).toBeNull();
+    });
+  });
 
-      describe("prefix", () => {
-        it("should render a passed prefix", () => {
-          renderFieldValuesWidget({
-            fields: [mock(PRODUCTS.PRICE, { has_field_values: "none" })],
-            prefix: "$$$",
-          });
-          expect(screen.getByTestId("input-prefix")).toHaveTextContent("$$$");
-        });
-
-        it("should not render a prefix if omitted", () => {
-          renderFieldValuesWidget({
-            fields: [mock(PRODUCTS.PRICE, { has_field_values: "none" })],
-          });
-          expect(screen.queryByTestId("input-prefix")).toBeNull();
-        });
+  describe("prefix", () => {
+    it("should render a passed prefix", () => {
+      renderFieldValuesWidget({
+        fields: [mock(PRODUCTS.PRICE, { has_field_values: "none" })],
+        prefix: "$$$",
       });
+      expect(screen.getByTestId("input-prefix")).toHaveTextContent("$$$");
+    });
+
+    it("should not render a prefix if omitted", () => {
+      renderFieldValuesWidget({
+        fields: [mock(PRODUCTS.PRICE, { has_field_values: "none" })],
+      });
+      expect(screen.queryByTestId("input-prefix")).toBeNull();
     });
   });
 });

--- a/frontend/test/metabase/components/FieldValuesWidget.unit.spec.js
+++ b/frontend/test/metabase/components/FieldValuesWidget.unit.spec.js
@@ -166,6 +166,23 @@ describe("FieldValuesWidget", () => {
 
       expect(screen.queryByText("AZ")).toBeNull();
       expect(screen.queryByText("Facebook")).toBeNull();
+
+      describe("prefix", () => {
+        it("should render a passed prefix", () => {
+          renderFieldValuesWidget({
+            fields: [mock(PRODUCTS.PRICE, { has_field_values: "none" })],
+            prefix: "$$$",
+          });
+          expect(screen.getByTestId("input-prefix")).toHaveTextContent("$$$");
+        });
+
+        it("should not render a prefix if omitted", () => {
+          renderFieldValuesWidget({
+            fields: [mock(PRODUCTS.PRICE, { has_field_values: "none" })],
+          });
+          expect(screen.queryByTestId("input-prefix")).toBeNull();
+        });
+      });
     });
   });
 });

--- a/frontend/test/metabase/components/FieldValuesWidget.unit.spec.js
+++ b/frontend/test/metabase/components/FieldValuesWidget.unit.spec.js
@@ -33,7 +33,7 @@ describe("FieldValuesWidget", () => {
 
       it("should have 'Enter some text' as the placeholder text", () => {
         renderFieldValuesWidget({ ...props });
-        screen.findByLabelText("Enter some text");
+        screen.getByPlaceholderText("Enter some text");
       });
     });
     describe("has_field_values = list", () => {
@@ -47,16 +47,19 @@ describe("FieldValuesWidget", () => {
         expect(fetchFieldValues).toHaveBeenCalledWith(PRODUCTS.CATEGORY.id);
       });
 
-      it("should not have 'Search the list' as the placeholder text for fields with less or equal than 10 values", () => {
+      // current version of this component always shows the search box
+      it.skip("should not have 'Search the list' as the placeholder text for fields with less or equal than 10 values", async () => {
         renderFieldValuesWidget({ ...props });
-        expect(screen.queryByLabelText("Search the list")).toBeNull();
+        expect(
+          await screen.queryByPlaceholderText("Search the list"),
+        ).toBeNull();
       });
 
-      it("should have 'Search the list' as the placeholder text for fields with less than 10 values", () => {
+      it("should have 'Enter some text' as the placeholder text for fields with more than 10 values", () => {
         renderFieldValuesWidget({
           fields: [mock(PRODUCTS.TITLE, { has_field_values: "list" })],
         });
-        screen.findByLabelText("Search the list");
+        screen.getByPlaceholderText("Enter some text");
       });
     });
 
@@ -73,7 +76,7 @@ describe("FieldValuesWidget", () => {
 
       it("should have 'Search by Category' as the placeholder text", () => {
         renderFieldValuesWidget({ ...props });
-        screen.findByLabelText("Search the list");
+        screen.getByPlaceholderText("Search by Category");
       });
     });
   });
@@ -84,7 +87,7 @@ describe("FieldValuesWidget", () => {
         renderFieldValuesWidget({
           fields: [mock(ORDERS.PRODUCT_ID, { has_field_values: "none" })],
         });
-        screen.findByLabelText("Enter an ID");
+        screen.getByPlaceholderText("Enter an ID");
       });
     });
 
@@ -98,7 +101,7 @@ describe("FieldValuesWidget", () => {
             }),
           ],
         });
-        screen.findByLabelText("Search the list");
+        screen.getByPlaceholderText("Search the list");
       });
     });
 
@@ -112,10 +115,10 @@ describe("FieldValuesWidget", () => {
             }),
           ],
         });
-        screen.findByLabelText("Search by Category or enter an ID");
+        screen.getByPlaceholderText("Search by Category or enter an ID");
       });
 
-      it("should not duplicate 'ID' in placeholder when ID itself is searchable", () => {
+      it("should not duplicate 'ID' in placeholder when ID itself is searchable", async () => {
         const fields = [
           mock(ORDERS.PRODUCT_ID, {
             base_type: "type/Text",
@@ -123,19 +126,19 @@ describe("FieldValuesWidget", () => {
           }),
         ];
         renderFieldValuesWidget({ fields });
-        screen.findByLabelText("Search by Product");
+        screen.getByPlaceholderText("Search by Product");
       });
     });
   });
 
   describe("multiple fields", () => {
-    it("list multiple fields together", () => {
+    it("list multiple fields together", async () => {
       const fields = [
         mock(PEOPLE.SOURCE, { has_field_values: "list" }),
         mock(PEOPLE.STATE, { has_field_values: "list" }),
       ];
       renderFieldValuesWidget({ fields });
-      screen.findByLabelText("Search the list");
+      screen.getByPlaceholderText("Search the list");
 
       screen.getByText("AZ");
       screen.getByText("Facebook");
@@ -147,7 +150,7 @@ describe("FieldValuesWidget", () => {
         mock(PEOPLE.STATE, { has_field_values: "list" }),
       ];
       renderFieldValuesWidget({ fields });
-      screen.findByLabelText("Search");
+      screen.getByPlaceholderText("Search");
 
       expect(screen.queryByText("AZ")).toBeNull();
       expect(screen.queryByText("Facebook")).toBeNull();
@@ -159,7 +162,7 @@ describe("FieldValuesWidget", () => {
         mock(PEOPLE.STATE, { has_field_values: "list" }),
       ];
       renderFieldValuesWidget({ fields });
-      screen.findByLabelText("Enter some text");
+      screen.getByPlaceholderText("Enter some text");
 
       expect(screen.queryByText("AZ")).toBeNull();
       expect(screen.queryByText("Facebook")).toBeNull();

--- a/frontend/test/metabase/components/TokenField.unit.spec.js
+++ b/frontend/test/metabase/components/TokenField.unit.spec.js
@@ -108,6 +108,16 @@ describe("TokenField", () => {
     expect(screen.queryByText("bar")).toBeNull();
   });
 
+  it("should render input prefix with prefix prop", () => {
+    render(<TokenFieldWithStateAndDefaults prefix="$$$" />);
+    expect(screen.getByTestId("input-prefix")).toHaveTextContent("$$$");
+  });
+
+  it("should not render input prefix without prefix prop", () => {
+    render(<TokenFieldWithStateAndDefaults />);
+    expect(screen.queryByTestId("input-prefix")).toBeNull();
+  });
+
   it("should render with 1 options and 1 values", () => {
     render(
       <TokenFieldWithStateAndDefaults value={["foo"]} options={["bar"]} />,

--- a/frontend/test/metabase/lib/formatting.unit.spec.js
+++ b/frontend/test/metabase/lib/formatting.unit.spec.js
@@ -10,6 +10,7 @@ import {
   formatTime,
   formatTimeWithUnit,
   slugify,
+  getCurrencySymbol,
 } from "metabase/lib/formatting";
 import ExternalLink from "metabase/core/components/ExternalLink";
 import { TYPE } from "metabase/lib/types";
@@ -603,6 +604,28 @@ describe("formatting", () => {
 
     it("should slugify diacritics", () => {
       expect(slugify("än umlaut")).toEqual("%C3%A4n_umlaut");
+    });
+  });
+
+  describe("getCurrencySymbol", () => {
+    const currencySymbols = [
+      ["USD", "$"],
+      ["EUR", "€"],
+      ["GBP", "£"],
+      ["JPY", "¥"],
+      ["CNY", "CN¥"],
+      ["CAD", "CA$"],
+      ["AUD", "AU$"],
+      ["NZD", "NZ$"],
+      ["HKD", "HK$"],
+      ["BTC", "₿"],
+      ["OOPS", "OOPS"],
+    ];
+
+    currencySymbols.forEach(([currency, symbol]) => {
+      it(`should get a ${symbol} for ${currency}`, () => {
+        expect(getCurrencySymbol(currency)).toEqual(symbol);
+      });
     });
   });
 });

--- a/frontend/test/metabase/query_builder/components/filters/pickers/NumberPicker.unit.spec.js
+++ b/frontend/test/metabase/query_builder/components/filters/pickers/NumberPicker.unit.spec.js
@@ -1,0 +1,47 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import NumberPicker from "metabase/query_builder/components/filters/pickers/NumberPicker";
+
+describe("NumberPicker", () => {
+  it("should display provided values", () => {
+    const spy = jest.fn();
+    render(<NumberPicker values={[16, 17]} onValuesChange={spy} />);
+    screen.getByDisplayValue("16, 17");
+  });
+
+  it("should fire onValuesChange function on change", async () => {
+    const spy = jest.fn();
+    render(<NumberPicker values={[16, 17]} onValuesChange={spy} />);
+
+    await fireEvent.change(
+      screen.getByPlaceholderText("Enter desired number"),
+      { target: { value: 18 } },
+    );
+    expect(spy).toHaveBeenCalledWith([18]);
+  });
+
+  it("should display error border on non-numeric values", async () => {
+    const spy = jest.fn();
+    const { container } = render(
+      <NumberPicker values={["foo", "bar"]} onValuesChange={spy} />,
+    );
+    expect(container.querySelectorAll(".border-error")).toHaveLength(1);
+  });
+
+  it("should display prefix if prefix prop is populated", async () => {
+    const spy = jest.fn();
+    render(
+      <NumberPicker values={[16, 17]} prefix="$$$" onValuesChange={spy} />,
+    );
+
+    expect(screen.getByTestId("input-prefix")).toHaveTextContent("$$$");
+  });
+
+  it("should not display prefix if prefix prop is not populated", async () => {
+    const spy = jest.fn();
+    render(<NumberPicker values={["foo", "bar"]} onValuesChange={spy} />);
+
+    expect(screen.queryByTestId("input-prefix")).toBeNull();
+  });
+});

--- a/frontend/test/metabase/query_builder/components/filters/pickers/TextPicker.unit.spec.js
+++ b/frontend/test/metabase/query_builder/components/filters/pickers/TextPicker.unit.spec.js
@@ -1,0 +1,38 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import TextPicker from "metabase/query_builder/components/filters/pickers/TextPicker";
+
+describe("TextPicker", () => {
+  it("should display provided values", () => {
+    const spy = jest.fn();
+    render(<TextPicker values={["foo", "bar"]} onValuesChange={spy} />);
+    screen.getByDisplayValue("foo, bar");
+  });
+
+  it("should fire onValuesChange function on change", async () => {
+    const spy = jest.fn();
+    render(<TextPicker values={["foo", "bar"]} onValuesChange={spy} />);
+
+    await fireEvent.change(screen.getByPlaceholderText("Enter desired text"), {
+      target: { value: "baz" },
+    });
+    expect(spy).toHaveBeenCalledWith(["baz"]);
+  });
+
+  it("should display prefix if prefix prop is populated", async () => {
+    const spy = jest.fn();
+    render(
+      <TextPicker values={["foo", "bar"]} prefix="$$$" onValuesChange={spy} />,
+    );
+
+    expect(screen.getByTestId("input-prefix")).toHaveTextContent("$$$");
+  });
+
+  it("should not display prefix if prefix prop is not populated", async () => {
+    const spy = jest.fn();
+    render(<TextPicker values={["foo", "bar"]} onValuesChange={spy} />);
+
+    expect(screen.queryByTestId("input-prefix")).toBeNull();
+  });
+});

--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -799,6 +799,37 @@ describe("scenarios > question > filter", () => {
     }
   });
 
+  describe("currency filters", () => {
+    beforeEach(() => {
+      // set the currency on the Orders/Discount column to Euro
+      cy.visit("/admin/datamodel/database/1/table/2");
+      // this value isn't actually selected, it's just the default
+      cy.findByText("US Dollar").click();
+      cy.findByText("Euro").click();
+
+      openOrdersTable();
+    });
+
+    it("should show correct currency symbols in currency single field filter", () => {
+      cy.findByText("Discount (€)").click();
+      cy.findByText("Filter by this column").click();
+      cy.findByTestId("input-prefix").should("contain", "€");
+    });
+
+    it("should show correct currency symbols in currency between field filter", () => {
+      cy.findByText("Discount (€)").click();
+      cy.findByText("Filter by this column").click();
+      cy.findByText("Equal to").click();
+      cy.findByText("Between").click();
+
+      cy.findAllByTestId("input-prefix").then(els => {
+        expect(els).to.have.lengthOf(2);
+        expect(els[0].innerText).to.equal("€");
+        expect(els[1].innerText).to.equal("€");
+      });
+    });
+  });
+
   describe("specific combination of filters can cause frontend reload or blank screen (metabase#16198)", () => {
     it("shouldn't display chosen category in a breadcrumb (metabase#16198-1)", () => {
       visitQuestionAdhoc({

--- a/shared/src/metabase/shared/util/currency.cljc
+++ b/shared/src/metabase/shared/util/currency.cljc
@@ -151,7 +151,7 @@
           :rounding 0,
           :code "BRL",
           :name_plural "Brazilian reals"}],
-   [:BTC {:symbol "BTC",
+   [:BTC {:symbol "₿",
           :name "Bitcoin",
           :symbol_native "BTC",
           :decimal_digits 8,


### PR DESCRIPTION
## Changes
- for currency inputs, show the correct currency symbol (if available) in the input
- added support for bitcoin symbol
- added unit and e2e tests
- fixed broken existing unit tests for FieldValuesWidget

## Screenshots
case | image
--- | ---
between yuan | ![Screenshot from 2022-03-31 14-48-37](https://user-images.githubusercontent.com/30528226/161147248-88bb5851-b90c-47cd-baa2-af1000bd344a.png)
between euro | ![Screenshot from 2022-03-31 14-34-33](https://user-images.githubusercontent.com/30528226/161147251-8782ff12-3530-4577-aebf-19523783cff8.png)
native query param | ![Screenshot from 2022-03-31 13-11-49](https://user-images.githubusercontent.com/30528226/161147255-d216b4c1-995a-43a3-9b36-4ed1aec4c061.png)
filter sidebar | ![Screenshot from 2022-03-31 13-10-36](https://user-images.githubusercontent.com/30528226/161147256-1d45e751-b49c-4d9d-8a7f-3da3b60c8340.png) 
non-currency input | ![Screenshot from 2022-03-31 13-17-04](https://user-images.githubusercontent.com/30528226/161147253-2ab38367-da66-4bf8-846e-b5ab89ff268a.png)

## Misgivings
- I don't love the hacky negative margin for the between inputs, but I also hate to fundamentally restructure that component for such a small change 