### PR TITLE
Reduce noise from emotion in developer console

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditNotificationEditModal/AuditNotificationEditModal.styled.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditNotificationEditModal/AuditNotificationEditModal.styled.jsx
@@ -6,7 +6,7 @@ import { space } from "metabase/styled-components/theme";
 export const ModalButton = styled(Button)`
   margin-right: ${({ fullwidth }) => (fullwidth ? "auto" : "")};
 
-  &:not(:first-child) {
+  &:not(:first-of-type) {
     margin-left: ${space(2)};
   }
 `;

--- a/frontend/src/metabase/admin/settings/components/SettingsLicense/SettingsLicense.styled.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsLicense/SettingsLicense.styled.tsx
@@ -8,7 +8,7 @@ export const SectionHeader = styled.h4`
   text-transform: uppercase;
   margin-bottom: 8px;
 
-  &:not(:first-child) {
+  &:not(:first-of-type) {
     margin-top: 40px;
   }
 `;

--- a/frontend/src/metabase/browse/components/TableBrowser/TableBrowser.styled.jsx
+++ b/frontend/src/metabase/browse/components/TableBrowser/TableBrowser.styled.jsx
@@ -29,7 +29,7 @@ export const TableLink = styled(Link)`
 export const TableActionLink = styled(Link)`
   line-height: initial;
 
-  &:not(:first-child) {
+  &:not(:first-of-type) {
     margin-left: ${space(1)};
   }
 `;

--- a/frontend/src/metabase/collections/components/BaseItemsTable.styled.jsx
+++ b/frontend/src/metabase/collections/components/BaseItemsTable.styled.jsx
@@ -15,12 +15,12 @@ export const Table = styled.table`
   border-collapse: unset;
 
   ${breakpointMaxMedium} {
-    & td:nth-child(${LAST_EDITED_BY_INDEX}),
-    th:nth-child(${LAST_EDITED_BY_INDEX}),
-    col:nth-child(${LAST_EDITED_BY_INDEX}),
-    td:nth-child(${LAST_EDITED_AT_INDEX}),
-    th:nth-child(${LAST_EDITED_AT_INDEX}),
-    col:nth-child(${LAST_EDITED_AT_INDEX}) {
+    & td:nth-of-type(${LAST_EDITED_BY_INDEX}),
+    th:nth-of-type(${LAST_EDITED_BY_INDEX}),
+    col:nth-of-type(${LAST_EDITED_BY_INDEX}),
+    td:nth-of-type(${LAST_EDITED_AT_INDEX}),
+    th:nth-of-type(${LAST_EDITED_AT_INDEX}),
+    col:nth-of-type(${LAST_EDITED_AT_INDEX}) {
       display: none;
     }
   }
@@ -92,7 +92,7 @@ export const TBody = styled.tbody`
 
     border-top: 1px solid ${color("border")};
 
-    &:first-child {
+    &:first-of-type {
       border-left: 1px solid ${color("border")};
     }
 
@@ -105,8 +105,8 @@ export const TBody = styled.tbody`
     background-color: transparent;
   }
 
-  tr:first-child {
-    td:first-child {
+  tr:first-of-type {
+    td:first-of-type {
       border-top-left-radius: 8px;
     }
 
@@ -123,7 +123,7 @@ export const TBody = styled.tbody`
         border-bottom-right-radius: 8px;
       }
 
-      &:first-child {
+      &:first-of-type {
         border-bottom-left-radius: 8px;
       }
     }

--- a/frontend/src/metabase/visualizations/components/legend/LegendItem.styled.jsx
+++ b/frontend/src/metabase/visualizations/components/legend/LegendItem.styled.jsx
@@ -8,7 +8,7 @@ export const LegendItemRoot = styled.div`
   min-width: 0;
   overflow: hidden;
 
-  &:not(:first-child) {
+  &:not(:first-of-type) {
     margin-top: ${({ isVertical }) => (isVertical ? "0.5rem" : "")};
     margin-left: ${({ isVertical }) => (isVertical ? "" : "0.75rem")};
   }


### PR DESCRIPTION
Emotion complains about `nth-child` and `first-child` CSS pseudo-selectors as "potentially unsafe when doing server-side rendering". Although we don't use SSR, these errors are quite annoying. This PR replaces the selectors with `nth-of-type` and `first-of-type` which should work mostly the same way. Not completely sure if thet have any drawbacks, so feedback is very appreciated