### PR TITLE
Update bookmark list when archiving Dashboards in Collection page 

### DIFF
--- a/frontend/src/metabase/entities/bookmarks.js
+++ b/frontend/src/metabase/entities/bookmarks.js
@@ -1,6 +1,6 @@
 import { createEntity } from "metabase/lib/entities";
-import Collection from "metabase/entities/collections";
-import Dashboard from "metabase/entities/dashboards";
+import Collections from "metabase/entities/collections";
+import Dashboards from "metabase/entities/dashboards";
 import Questions from "metabase/entities/questions";
 import { BookmarkSchema } from "metabase/schema";
 import { BookmarkApi } from "metabase/services";
@@ -30,6 +30,11 @@ const Bookmarks = createEntity({
       return state;
     }
 
+    if (type === Dashboards.actionTypes.UPDATE && payload?.object?.archived) {
+      state[`dashboard-${payload?.object?.id}`] = undefined;
+      return state;
+    }
+
     return state;
   },
 });
@@ -37,8 +42,8 @@ const Bookmarks = createEntity({
 function getEntityFor(type) {
   const entities = {
     card: Questions,
-    collection: Collection,
-    dashboard: Dashboard,
+    collection: Collections,
+    dashboard: Dashboards,
   };
 
   return entities[type];

--- a/frontend/test/metabase/scenarios/collections/bookmarks.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/bookmarks.cy.spec.js
@@ -76,12 +76,12 @@ describe("Bookmarks in a collection page", () => {
     addThenRemoveBookmarkTo("Orders Model");
   });
 
-  it("removes item from bookmarks list when it is archived", () => {
-    const itemName = "Orders";
+  it("removes items from bookmarks list when they are archived", () => {
+    // A question
+    bookmarkThenArchive("Orders");
 
-    addBookmarkTo(itemName);
-
-    archive(itemName);
+    // A dashboard
+    bookmarkThenArchive("Orders in a dashboard");
 
     navigationSidebar().within(() => {
       cy.findByText("Collections").should("not.exist");
@@ -119,44 +119,49 @@ describe("Bookmarks in a collection page", () => {
   });
 });
 
-function addThenRemoveBookmarkTo(itemName) {
-  addBookmarkTo(itemName);
-  removeBookmarkFrom(itemName);
+function addThenRemoveBookmarkTo(name) {
+  addBookmarkTo(name);
+  removeBookmarkFrom(name);
 }
 
-function addBookmarkTo(itemName) {
+function addBookmarkTo(name) {
   cy.visit("/collection/root");
 
-  openEllipsisMenuFor(itemName);
+  openEllipsisMenuFor(name);
   cy.findByText("Bookmark").click();
 
   navigationSidebar().within(() => {
     getSectionTitle(/Bookmarks/);
-    cy.findByText(itemName);
+    cy.findByText(name);
   });
 }
 
-function removeBookmarkFrom(itemName) {
-  openEllipsisMenuFor(itemName);
+function removeBookmarkFrom(name) {
+  openEllipsisMenuFor(name);
 
   cy.findByText("Remove bookmark").click();
 
   navigationSidebar().within(() => {
     getSectionTitle(/Bookmarks/).should("not.exist");
-    cy.findByText(itemName).should("not.exist");
+    cy.findByText(name).should("not.exist");
   });
 }
 
-function openEllipsisMenuFor(item) {
+function openEllipsisMenuFor(name) {
   cy.get("td")
-    .contains(item)
+    .contains(name)
     .closest("tr")
     .find(".Icon-ellipsis")
     .click({ force: true });
 }
 
-function archive(itemName) {
-  openEllipsisMenuFor(itemName);
+function bookmarkThenArchive(name) {
+  addBookmarkTo(name);
+  archive(name);
+}
+
+function archive(name) {
+  openEllipsisMenuFor(name);
   popover().within(() => {
     cy.findByText("Archive").click();
   });


### PR DESCRIPTION
### How to Test

1. Create, save and bookmark a Dashboard.
2. Go to http://localhost:3000/collection/root

You should see your dashboard in the bookmarks list.

3. From the main collection list of items, open the ellipsis menu for your dashboard and click on `Archive`.

Your dashboard should no longer be displayed (1) in the collection’s item list and (2) in the bookmarks list on the left.
