### PR TITLE
Inform the user when a database driver isn't official

### DIFF
--- a/bin/build-drivers/src/build_drivers/lint_manifest_file.clj
+++ b/bin/build-drivers/src/build_drivers/lint_manifest_file.clj
@@ -19,6 +19,9 @@
 (s/def ::description string?)
 (s/def ::info (spell/keys :req-un [::name ::version ::description]))
 
+(s/def ::address string?)
+(s/def ::contact-info (spell/keys :req-un [::name ::address]))
+
 (def ^:private property-types #{"string" "textFile" "boolean" "secret" "info" "schema-filters"})
 
 (s/def ::display-name string?)
@@ -57,4 +60,4 @@
 (s/def ::init (s/coll-of (s/multi-spec init-step-type #(get % :step))))
 
 (s/def ::plugin-manifest
-  (spell/keys :req-un [::info ::driver] :opt-un [::init]))
+  (spell/keys :req-un [::info ::driver] :opt-un [::contact-info ::init]))

--- a/bin/build-drivers/src/build_drivers/lint_manifest_file.clj
+++ b/bin/build-drivers/src/build_drivers/lint_manifest_file.clj
@@ -20,7 +20,8 @@
 (s/def ::info (spell/keys :req-un [::name ::version ::description]))
 
 (s/def ::address string?)
-(s/def ::contact-info (spell/keys :req-un [::name ::address]))
+(s/def ::contact-info (spell/keys :req-un [::name]
+                                  :opt-un [::address]))
 
 (def ^:private property-types #{"string" "textFile" "boolean" "secret" "info" "schema-filters"})
 

--- a/docs/developers-guide/drivers/plugins.md
+++ b/docs/developers-guide/drivers/plugins.md
@@ -9,6 +9,9 @@ info:
   name: Metabase SQLite Driver
   version: 1.0.0-SNAPSHOT-3.25.2
   description: Allows Metabase to connect to SQLite databases.
+contact-info:
+  name: Toucan McBird
+  info: toucan.mcbird@example.com
 driver:
   name: sqlite
   display-name: SQLite

--- a/docs/developers-guide/drivers/plugins.md
+++ b/docs/developers-guide/drivers/plugins.md
@@ -11,7 +11,7 @@ info:
   description: Allows Metabase to connect to SQLite databases.
 contact-info:
   name: Toucan McBird
-  info: toucan.mcbird@example.com
+  address: toucan.mcbird@example.com
 driver:
   name: sqlite
   display-name: SQLite

--- a/frontend/src/metabase-types/api/mocks/settings.ts
+++ b/frontend/src/metabase-types/api/mocks/settings.ts
@@ -3,6 +3,9 @@ import { Engine, Settings, Version } from "metabase-types/api";
 export const createMockEngine = (opts?: Partial<Engine>): Engine => ({
   "driver-name": "PostgreSQL",
   "superseded-by": undefined,
+  source: {
+    type: "official",
+  },
   ...opts,
 });
 
@@ -10,6 +13,18 @@ export const createMockEngines = (
   opts?: Record<string, Engine>,
 ): Record<string, Engine> => ({
   postgres: createMockEngine(),
+  communityEngine: createMockEngine({
+    "driver-name": "CommunityEngine",
+    source: {
+      type: "community",
+    },
+  }),
+  partnerEngine: createMockEngine({
+    "driver-name": "PartnerEngine",
+    source: {
+      type: "partner",
+    },
+  }),
   ...opts,
 });
 

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -1,6 +1,12 @@
+export interface EngineSource {
+  type?: "official" | "community" | "partner";
+  name?: string;
+  contact?: string;
+}
 export interface Engine {
   "driver-name": string;
   "superseded-by": string | undefined;
+  source: EngineSource;
 }
 
 export interface Version {

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -1,10 +1,10 @@
+export interface EngineSourceContact {
+  name?: string;
+  address?: string;
+}
 export interface EngineSource {
   type?: "official" | "community" | "partner";
-  name?: string;
-  contact?: {
-    name?: string;
-    address?: string;
-  };
+  contact?: EngineSourceContact;
 }
 export interface Engine {
   "driver-name": string;

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -1,7 +1,10 @@
 export interface EngineSource {
   type?: "official" | "community" | "partner";
   name?: string;
-  contact?: string;
+  contact?: {
+    name?: string;
+    address?: string;
+  };
 }
 export interface Engine {
   "driver-name": string;

--- a/frontend/src/metabase/components/DriverWarning/DriverWarning.stories.tsx
+++ b/frontend/src/metabase/components/DriverWarning/DriverWarning.stories.tsx
@@ -17,9 +17,29 @@ Template.args = {
     presto: createMockEngine({
       "driver-name": "Presto (Deprecated Driver)",
       "superseded-by": "presto-jdbc",
+      source: {
+        type: "official",
+      },
     }),
     "presto-jdbc": createMockEngine({
       "driver-name": "Presto",
+      source: {
+        type: "official",
+      },
+    }),
+    communityEngine: createMockEngine({
+      "driver-name": "CommunityEngine",
+      source: {
+        type: "community",
+      },
+    }),
+    partnerEngine: createMockEngine({
+      "driver-name": "PartnerEngine",
+      source: {
+        type: "partner",
+        name: "Parners Incorporated",
+        contact: "https://example.com/contact",
+      },
     }),
   },
 };
@@ -33,5 +53,17 @@ New.args = {
 export const Deprecated = Template.bind({});
 Deprecated.args = {
   engine: "presto",
+  ...Template.args,
+};
+
+export const Community = Template.bind({});
+Community.args = {
+  engine: "communityEngine",
+  ...Template.args,
+};
+
+export const Partner = Template.bind({});
+Partner.args = {
+  engine: "partnerEngine",
   ...Template.args,
 };

--- a/frontend/src/metabase/components/DriverWarning/DriverWarning.stories.tsx
+++ b/frontend/src/metabase/components/DriverWarning/DriverWarning.stories.tsx
@@ -37,8 +37,10 @@ Template.args = {
       "driver-name": "PartnerEngine",
       source: {
         type: "partner",
-        name: "Parners Incorporated",
-        contact: "https://example.com/contact",
+        contact: {
+          name: "Parners Incorporated",
+          address: "https://example.com/contact",
+        },
       },
     }),
   },

--- a/frontend/src/metabase/components/DriverWarning/DriverWarning.styled.tsx
+++ b/frontend/src/metabase/components/DriverWarning/DriverWarning.styled.tsx
@@ -6,6 +6,8 @@ export interface WarningRootProps {
 }
 
 export const WarningRoot = styled.div<WarningRootProps>`
+  display: flex;
+  align-items: center;
   margin-bottom: 2rem;
   padding: 1rem 0.75rem;
   color: ${color("text-medium")};

--- a/frontend/src/metabase/components/DriverWarning/DriverWarning.tsx
+++ b/frontend/src/metabase/components/DriverWarning/DriverWarning.tsx
@@ -3,6 +3,7 @@ import { jt, t } from "ttag";
 import _ from "underscore";
 import { Engine } from "metabase-types/api";
 import { WarningLink, WarningRoot } from "./DriverWarning.styled";
+import Icon from "metabase/components/Icon";
 
 export interface DriverWarningProps {
   engine?: string;
@@ -14,11 +15,16 @@ export interface DriverWarningProps {
 const DriverWarning = ({
   engine: engineKey,
   engines,
-  hasBorder,
   onChange,
 }: DriverWarningProps): JSX.Element | null => {
   const engine = engineKey ? engines[engineKey] : undefined;
+
+  if (!engine) {
+    return null;
+  }
+
   const engineName = engine?.["driver-name"];
+  const engineSourceType = engine?.source?.type || "community";
 
   const newEngineKey = engine?.["superseded-by"];
   const newEngine = newEngineKey ? engines[newEngineKey] : undefined;
@@ -29,34 +35,120 @@ const DriverWarning = ({
   const oldEngine = oldEngineKey ? engines[oldEngineKey] : undefined;
   const handleChangeToOld = () => oldEngineKey && onChange?.(oldEngineKey);
 
+  const warnings = [];
+
   if (newEngine) {
-    return (
-      <WarningRoot hasBorder={hasBorder}>
-        {t`This driver will be removed in a future release.`}{" "}
-        {jt`We recommend you upgrade to the ${(
-          <WarningLink key="link" onClick={handleChangeToNew}>
-            {t`new ${newEngineName} driver`}
-          </WarningLink>
-        )}.`}
-      </WarningRoot>
+    warnings.push(
+      <NewEngineWarning
+        key="new"
+        engineName={newEngineName || ""}
+        handleChange={handleChangeToNew}
+      />,
     );
   }
 
   if (oldEngine) {
-    return (
-      <WarningRoot>
-        {t`This is our new ${engineName} driver.`}{" "}
-        {t`The old driver has been deprecated and will be removed in a future release.`}{" "}
-        {jt`If you really need to use it, you can ${(
-          <WarningLink key="link" onClick={handleChangeToOld}>
-            {t`find it here`}
-          </WarningLink>
-        )}.`}
-      </WarningRoot>
+    warnings.push(
+      <OldEngineWarning
+        key="old"
+        engineName={engineName}
+        handleChange={handleChangeToOld}
+      />,
     );
   }
 
-  return null;
+  if (engineSourceType === "community") {
+    warnings.push(<CommunityDriverWarning key="community" />);
+  } else if (engineSourceType === "partner") {
+    warnings.push(
+      <PartnerDriverWarning
+        key="partner"
+        sourceName={engine?.source?.name}
+        sourceContact={engine?.source?.contact}
+      />,
+    );
+  }
+
+  return <>{warnings}</>;
+};
+
+const NewEngineWarning = ({
+  engineName,
+  handleChange,
+}: {
+  engineName: string;
+  handleChange: () => void;
+}) => (
+  <WarningRoot hasBorder>
+    <p>
+      {t`This driver will be removed in a future release.`}{" "}
+      {jt`We recommend you upgrade to the ${(
+        <WarningLink key="link" onClick={handleChange}>
+          {t`new ${engineName} driver`}
+        </WarningLink>
+      )}.`}
+    </p>
+  </WarningRoot>
+);
+
+const OldEngineWarning = ({
+  engineName,
+  handleChange,
+}: {
+  engineName: string;
+  handleChange: () => void;
+}) => (
+  <WarningRoot>
+    <p>
+      {t`This is our new ${engineName} driver.`}{" "}
+      {t`The old driver has been deprecated and will be removed in a future release.`}{" "}
+      {jt`If you really need to use it, you can ${(
+        <WarningLink key="link" onClick={handleChange}>
+          {t`find it here`}
+        </WarningLink>
+      )}.`}
+    </p>
+  </WarningRoot>
+);
+
+const CommunityDriverWarning = () => (
+  <WarningRoot hasBorder>
+    <Icon name="info" className="pr2" />
+    <p>
+      {t`This is a community-developed driver and not supported by Metabase. `}
+    </p>
+  </WarningRoot>
+);
+
+const PartnerDriverWarning = ({
+  sourceName,
+  sourceContact,
+}: {
+  sourceName: string | undefined;
+  sourceContact: string | undefined;
+}) => {
+  const contactLink = sourceContact ? (
+    <WarningLink
+      href={
+        sourceContact.includes("@") ? `mailto:${sourceContact}` : sourceContact
+      }
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      {sourceName || "our partner"}
+    </WarningLink>
+  ) : null;
+
+  return (
+    <WarningRoot hasBorder>
+      <Icon name="info" className="pr2" />
+      <p>
+        {t`This is a partner-developed driver. Though Metabase can’t provide support for it, if you need help you can contact the fine folks at `}
+        {contactLink}
+        {!contactLink && (sourceName || "our partner")}.
+      </p>
+    </WarningRoot>
+  );
 };
 
 export default DriverWarning;

--- a/frontend/src/metabase/components/DriverWarning/DriverWarning.tsx
+++ b/frontend/src/metabase/components/DriverWarning/DriverWarning.tsx
@@ -23,10 +23,10 @@ const DriverWarning = ({
     return null;
   }
 
-  const engineName = engine?.["driver-name"];
+  const engineName = engine["driver-name"];
   const engineSourceType = engine?.source?.type || "community";
 
-  const newEngineKey = engine?.["superseded-by"];
+  const newEngineKey = engine["superseded-by"];
   const newEngine = newEngineKey ? engines[newEngineKey] : undefined;
   const newEngineName = newEngine?.["driver-name"];
   const handleChangeToNew = () => newEngineKey && onChange?.(newEngineKey);

--- a/frontend/src/metabase/components/DriverWarning/DriverWarning.tsx
+++ b/frontend/src/metabase/components/DriverWarning/DriverWarning.tsx
@@ -63,8 +63,8 @@ const DriverWarning = ({
     warnings.push(
       <PartnerDriverWarning
         key="partner"
-        sourceName={engine?.source?.name}
-        sourceContact={engine?.source?.contact}
+        sourceName={engine?.source?.contact?.name}
+        sourceContact={engine?.source?.contact?.address}
       />,
     );
   }

--- a/frontend/src/metabase/components/DriverWarning/DriverWarning.tsx
+++ b/frontend/src/metabase/components/DriverWarning/DriverWarning.tsx
@@ -8,7 +8,6 @@ import Icon from "metabase/components/Icon";
 export interface DriverWarningProps {
   engine?: string;
   engines: Record<string, Engine>;
-  hasBorder?: boolean;
   onChange?: (engine: string) => void;
 }
 
@@ -98,7 +97,7 @@ const OldEngineWarning = ({
   engineName: string;
   handleChange: () => void;
 }) => (
-  <WarningRoot>
+  <WarningRoot hasBorder>
     <p>
       {t`This is our new ${engineName} driver.`}{" "}
       {t`The old driver has been deprecated and will be removed in a future release.`}{" "}

--- a/frontend/src/metabase/components/DriverWarning/DriverWarning.unit.spec.tsx
+++ b/frontend/src/metabase/components/DriverWarning/DriverWarning.unit.spec.tsx
@@ -15,6 +15,48 @@ describe("DriverWarning", () => {
     "presto-jdbc": createMockEngine({
       "driver-name": "Presto",
     }),
+    deprecatedCommunity: createMockEngine({
+      "driver-name": "Community (Deprecated Driver)",
+      "superseded-by": "communityEngine",
+      source: {
+        type: "community",
+      },
+    }),
+    communityEngine: createMockEngine({
+      "driver-name": "CommunityEngine",
+      source: {
+        type: "community",
+      },
+    }),
+    partnerEngine: createMockEngine({
+      "driver-name": "PartnerEngine",
+      source: {
+        type: "partner",
+        name: "Parners Incorporated",
+        contact: "https://example.com/contact",
+      },
+    }),
+    anonymousPartnerEngine: createMockEngine({
+      "driver-name": "AnonymousPartnerEngine",
+      source: {
+        type: "partner",
+      },
+    }),
+    partnerWithoutContactInfoEngine: createMockEngine({
+      "driver-name": "PartnerWithoutContactInfoEngine",
+      source: {
+        type: "partner",
+        name: "Parners Incorporated Two",
+      },
+    }),
+    partnerEngineWithEmail: createMockEngine({
+      "driver-name": "PartnerEngineWithEmail",
+      source: {
+        type: "partner",
+        name: "Parners Incorporated Three",
+        contact: "contactus@example.com",
+      },
+    }),
   };
 
   it("should render a warning when the driver is deprecated", () => {
@@ -32,8 +74,72 @@ describe("DriverWarning", () => {
     expect(screen.queryByText(/driver/)).not.toBeInTheDocument();
   });
 
-  it("should render nothing when there is no new driver", () => {
+  it("should render a warning when the driver is new", () => {
+    render(<DriverWarning engine="presto-jdbc" engines={engines} />);
+    expect(screen.getByText(/This is our new Presto/)).toBeInTheDocument();
+  });
+
+  it("should render nothing when there is no new driver, and the driver is official", () => {
     render(<DriverWarning engine="postgres" engines={engines} />);
     expect(screen.queryByText(/driver/)).not.toBeInTheDocument();
+  });
+
+  it("should render a community driver warning for drivers from community sources", () => {
+    render(<DriverWarning engine="communityEngine" engines={engines} />);
+    expect(
+      screen.queryByText(/community-developed driver/),
+    ).toBeInTheDocument();
+  });
+
+  it("should render both community and deprecated warnings together", () => {
+    render(<DriverWarning engine="deprecatedCommunity" engines={engines} />);
+    expect(
+      screen.queryByText(/community-developed driver/),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/This driver will be removed/)).toBeInTheDocument();
+  });
+
+  it("should render a partner driver warning for drivers from partner sources", () => {
+    render(<DriverWarning engine="partnerEngine" engines={engines} />);
+    expect(screen.queryByText(/partner-developed driver/)).toBeInTheDocument();
+  });
+
+  it("should render a partner contact information web link", () => {
+    const { container } = render(
+      <DriverWarning engine="partnerEngine" engines={engines} />,
+    );
+    expect(container.querySelector("a")).toHaveAttribute(
+      "href",
+      "https://example.com/contact",
+    );
+  });
+
+  it("should render a partner contact information email link", () => {
+    const { container } = render(
+      <DriverWarning engine="partnerEngineWithEmail" engines={engines} />,
+    );
+    expect(container.querySelector("a")).toHaveAttribute(
+      "href",
+      "mailto:contactus@example.com",
+    );
+  });
+
+  it("should render a partner warning when missing contact name", () => {
+    const { container } = render(
+      <DriverWarning engine="anonymousPartnerEngine" engines={engines} />,
+    );
+    expect(container.querySelector("a")).toBeNull();
+  });
+
+  it("should render a partner warning when missing contact information", () => {
+    const { container } = render(
+      <DriverWarning
+        engine="partnerWithoutContactInfoEngine"
+        engines={engines}
+      />,
+    );
+    expect(container.querySelector("a")).toBeNull();
+    screen.getByText(/partner-developed driver/);
+    screen.getByText(/Parners Incorporated Two/);
   });
 });

--- a/frontend/src/metabase/components/DriverWarning/DriverWarning.unit.spec.tsx
+++ b/frontend/src/metabase/components/DriverWarning/DriverWarning.unit.spec.tsx
@@ -32,8 +32,10 @@ describe("DriverWarning", () => {
       "driver-name": "PartnerEngine",
       source: {
         type: "partner",
-        name: "Parners Incorporated",
-        contact: "https://example.com/contact",
+        contact: {
+          name: "Parners Incorporated",
+          address: "https://example.com/contact",
+        },
       },
     }),
     anonymousPartnerEngine: createMockEngine({
@@ -46,15 +48,19 @@ describe("DriverWarning", () => {
       "driver-name": "PartnerWithoutContactInfoEngine",
       source: {
         type: "partner",
-        name: "Parners Incorporated Two",
+        contact: {
+          name: "Parners Incorporated Two",
+        },
       },
     }),
     partnerEngineWithEmail: createMockEngine({
       "driver-name": "PartnerEngineWithEmail",
       source: {
         type: "partner",
-        name: "Parners Incorporated Three",
-        contact: "contactus@example.com",
+        contact: {
+          name: "Parners Incorporated Three",
+          address: "contactus@example.com",
+        },
       },
     }),
   };

--- a/frontend/src/metabase/setup/components/DatabaseStep/DatabaseStep.tsx
+++ b/frontend/src/metabase/setup/components/DatabaseStep/DatabaseStep.tsx
@@ -140,7 +140,6 @@ const DatabaseForm = ({
           <FormField name="engine" onChange={handleEngineChange} />
           <DriverWarning
             engine={values.engine}
-            hasBorder={true}
             onChange={engine => onChangeField("engine", engine)}
           />
           {_.reject(formFields, { name: "engine" }).map(({ name }) => (

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -233,6 +233,16 @@
 (defmethod display-name :default [driver]
   (str/capitalize (name driver)))
 
+(defmulti contact-info
+  "The contact information for the driver"
+  {:added "0.43.0" :arglists '([driver])}
+  dispatch-on-uninitialized-driver
+  :hierarchy #'hierarchy)
+
+(defmethod contact-info :default
+  [_]
+  nil)
+
 (defmulti can-connect?
   "Check whether we can connect to a `Database` with `details-map` and perform a simple query. For example, a SQL
   database might try running a query like `SELECT 1;`. This function should return truthy if a connection to the DB

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -316,6 +316,22 @@
                  db-details
                  secret-names->props))))
 
+(def official-drivers
+  "List of all official drivers"
+  ["bigquery-cloud-sdk" "druid" "googleanalytics" "h2" "mongo" "mysql" "postgres" "presto" "presto-jdbc" "redshift" "snowflake" "sparksql" "sqlite" "sqlserver"])
+
+(def partner-drivers
+  "List of other drivers in the partnership program"
+  ["firebolt"])
+
+(defn driver-source
+  "Return the source type of the driver: official, partner, or community"
+  [driver-name]
+  (cond
+    (contains? (set official-drivers) driver-name) "official"
+    (contains? (set partner-drivers) driver-name) "partner"
+    :else "community"))
+
 (defn available-drivers-info
   "Return info about all currently available drivers, including their connection properties fields and supported
   features. The output of `driver/connection-properties` is passed through `connection-props-server->client` before
@@ -329,7 +345,8 @@
                                    (log/error e (trs "Unable to determine connection properties for driver {0}" driver))))]
                  :when  props]
              ;; TODO - maybe we should rename `details-fields` -> `connection-properties` on the FE as well?
-             [driver {:details-fields props
+             [driver {:source {:type (driver-source (name driver))}
+                      :details-fields props
                       :driver-name    (driver/display-name driver)
                       :superseded-by  (driver/superseded-by driver)}])))
 

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -345,7 +345,8 @@
                                    (log/error e (trs "Unable to determine connection properties for driver {0}" driver))))]
                  :when  props]
              ;; TODO - maybe we should rename `details-fields` -> `connection-properties` on the FE as well?
-             [driver {:source {:type (driver-source (name driver))}
+             [driver {:source {:type (driver-source (name driver))
+                               :source (driver/contact-info driver)}
                       :details-fields props
                       :driver-name    (driver/display-name driver)
                       :superseded-by  (driver/superseded-by driver)}])))

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -317,19 +317,19 @@
                  secret-names->props))))
 
 (def official-drivers
-  "List of all official drivers"
-  ["bigquery-cloud-sdk" "druid" "googleanalytics" "h2" "mongo" "mysql" "postgres" "presto" "presto-jdbc" "redshift" "snowflake" "sparksql" "sqlite" "sqlserver"])
+  "The set of all official drivers"
+  #{"bigquery-cloud-sdk" "druid" "googleanalytics" "h2" "mongo" "mysql" "postgres" "presto" "presto-jdbc" "redshift" "snowflake" "sparksql" "sqlite" "sqlserver"})
 
 (def partner-drivers
-  "List of other drivers in the partnership program"
-  ["firebolt"])
+  "The set of other drivers in the partnership program"
+  #{"firebolt"})
 
 (defn driver-source
   "Return the source type of the driver: official, partner, or community"
   [driver-name]
   (cond
-    (contains? (set official-drivers) driver-name) "official"
-    (contains? (set partner-drivers) driver-name) "partner"
+    (contains? official-drivers driver-name) "official"
+    (contains? partner-drivers driver-name) "partner"
     :else "community"))
 
 (defn available-drivers-info

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -346,7 +346,7 @@
                  :when  props]
              ;; TODO - maybe we should rename `details-fields` -> `connection-properties` on the FE as well?
              [driver {:source {:type (driver-source (name driver))
-                               :source (driver/contact-info driver)}
+                               :contact (driver/contact-info driver)}
                       :details-fields props
                       :driver-name    (driver/display-name driver)
                       :superseded-by  (driver/superseded-by driver)}])))

--- a/src/metabase/plugins/lazy_loaded_driver.clj
+++ b/src/metabase/plugins/lazy_loaded_driver.clj
@@ -61,6 +61,7 @@
   "Register a basic shell of a Metabase driver using the information from its Metabase plugin"
   [{:keys                                                                                            [add-to-classpath!]
     init-steps                                                                                       :init
+    contact-info                                                                                     :contact-info
     superseded-by                                                                                    :superseded-by
     {driver-name :name, :keys [abstract display-name parent], :or {abstract false}, :as driver-info} :driver}]
   {:pre [(map? driver-info)]}
@@ -80,6 +81,7 @@
     (doseq [[^MultiFn multifn, f]
             {driver/initialize!           (make-initialize! driver add-to-classpath! init-steps)
              driver/display-name          (when display-name (constantly display-name))
+             driver/contact-info          (when contact-info (constantly contact-info))
              driver/connection-properties (constantly connection-props)
              driver/superseded-by         (constantly (keyword superseded-by))}]
       (when f

--- a/src/metabase/plugins/lazy_loaded_driver.clj
+++ b/src/metabase/plugins/lazy_loaded_driver.clj
@@ -81,7 +81,7 @@
     (doseq [[^MultiFn multifn, f]
             {driver/initialize!           (make-initialize! driver add-to-classpath! init-steps)
              driver/display-name          (when display-name (constantly display-name))
-             driver/contact-info          (when contact-info (constantly contact-info))
+             driver/contact-info          (constantly contact-info)
              driver/connection-properties (constantly connection-props)
              driver/superseded-by         (constantly (keyword superseded-by))}]
       (when f


### PR DESCRIPTION
## Back End

This will be reflected in the call to `/api/session/properties`.

### Before

The response looks like this (illustrated only for one database engine, some parts are omitted for brevity):

```json
{
    "humanization-strategy": "simple",
    "email-smtp-username": null,
    "ssl-certificate-public-key": null,
    "slack-app-token": null,
    "engines": {
        "mongo": {
            "details-fields": [],
            "driver-name": "MongoDB",
            "superseded-by": null
    }
}
```

### After

Note `engines.postgres.source.type`:

```json
{
    "humanization-strategy": "simple",
    "email-smtp-username": null,
    "ssl-certificate-public-key": null,
    "slack-app-token": null,
    "engines": {
        "mongo": {
            "source": {
                "type": "official",
                "contact": {
                    "name": "Toucan McBird",
                    "address": "toucan.mcbird@example.com"
                }
            },
            "details-fields": [],
            "driver-name": "MongoDB",
            "superseded-by": null
    }
}
```

and this is due the following addition to the plugin manifest for the Mongo driver (illustrative example, IRL this happens to any **non-official** drivers only):

```diff
--- a/modules/drivers/mongo/resources/metabase-plugin.yaml
+++ b/modules/drivers/mongo/resources/metabase-plugin.yaml
@@ -2,6 +2,9 @@ info:
   name: Metabase MongoDB Driver
   version: 1.0.0-SNAPSHOT-3.9.0
   description: Allows Metabase to connect to MongoDB databases.
+contact-info:
+  name: Toucan McBird
+  address: toucan.mcbird@example.com
 driver:
   name: mongo
   display-name: MongoDB
```
## Front End

## Changes

- added community and partner driver source warnings 
- refactored warning component to be able to show multiple warnings (e.g. deprecated community driver)
- added unit tests and updated storybook

## Screenshots

*(sql server and sqllite were marked as community/partner just for testing purposes)*

state | image
--- | ---
partner driver warning with contact link | ![Screenshot from 2022-04-01 13-23-27](https://user-images.githubusercontent.com/30528226/161337205-12fff626-5dc2-4d29-9ff4-48c7f726f2f0.png)
partner driver warning missing contact info | ![Screenshot from 2022-04-01 13-22-57](https://user-images.githubusercontent.com/30528226/161337206-aadb3069-5225-443f-8273-17b3ecee44d4.png)
community driver warning in setup wizard | ![Screenshot from 2022-04-01 14-26-54](https://user-images.githubusercontent.com/30528226/161337204-3b432ad4-003b-44bf-b8c4-ce92b82572f4.png)