### PR TITLE
Don't automatically expand sidebar on mobile screen

### DIFF
--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -25,6 +25,7 @@ import PaginationControls from "metabase/components/PaginationControls";
 import { useOnMount } from "metabase/hooks/use-on-mount";
 import { usePagination } from "metabase/hooks/use-pagination";
 import { useListSelect } from "metabase/hooks/use-list-select";
+import { isSmallScreen } from "metabase/lib/dom";
 import {
   CollectionEmptyContent,
   CollectionMain,
@@ -83,7 +84,9 @@ function CollectionContent({
   } = useListSelect(itemKeyFn);
 
   useOnMount(() => {
-    openNavbar();
+    if (!isSmallScreen()) {
+      openNavbar();
+    }
   });
 
   useEffect(() => {

--- a/frontend/src/metabase/home/containers/ArchiveApp.jsx
+++ b/frontend/src/metabase/home/containers/ArchiveApp.jsx
@@ -16,6 +16,8 @@ import listSelect from "metabase/hoc/ListSelect";
 
 import { openNavbar } from "metabase/redux/app";
 import { getUserIsAdmin } from "metabase/selectors/user";
+import { isSmallScreen } from "metabase/lib/dom";
+
 import {
   ArchiveBarContent,
   ArchiveBarText,
@@ -44,7 +46,9 @@ const ROW_HEIGHT = 68;
 @connect(mapStateToProps, mapDispatchToProps)
 export default class ArchiveApp extends Component {
   componentDidMount() {
-    this.props.openNavbar();
+    if (!isSmallScreen()) {
+      this.props.openNavbar();
+    }
   }
 
   render() {

--- a/frontend/src/metabase/home/homepage/components/Homepage/Homepage.tsx
+++ b/frontend/src/metabase/home/homepage/components/Homepage/Homepage.tsx
@@ -3,6 +3,7 @@ import { t } from "ttag";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 import EmptyState from "metabase/components/EmptyState";
 import { useOnMount } from "metabase/hooks/use-on-mount";
+import { isSmallScreen } from "metabase/lib/dom";
 import CollectionSection from "../CollectionSection";
 import DatabaseSection from "../DatabaseSection";
 import GreetingSection from "../GreetingSection";
@@ -58,7 +59,9 @@ const Homepage = ({
   allError,
 }: HomepageProps): JSX.Element => {
   useOnMount(() => {
-    openNavbar();
+    if (!isSmallScreen()) {
+      openNavbar();
+    }
   });
 
   return (


### PR DESCRIPTION
This PR fixes a regression caused by #21358 not handling mobile screens. It made it automatically expand the sidebar on the homepage, collection, and archive pages as they're much more usable with the sidebar open. The problem is that it was doing that all the time and it doesn't work well for mobile.

### To Verify

1. Open Metabase and make the window narrow as if you're using a phone (or just turn on the mobile mode in dev tools.
2. Open the homepage and reload the page. The sidebar should be closed by default.
3. Open a collection and reload the page. The sidebar should be closed by default.
4. Open the sidebar and try to open a collection. The sidebar should automatically close and you should appear on the tapped collection page.
5. Open the archive and reload the page. The sidebar should be closed by default.
6. Go back to desktop view. Open a dashboard, close the sidebar and click the collection badge in the dashboard header. You should end up on the collection page and the sidebar should be expanded.

### Demo

| **Before**  | **After** |
| ------------- | ------------- |
| ![before](https://user-images.githubusercontent.com/17258145/161246837-960626ad-439c-43db-88af-3172fd6baf14.gif)  | ![after](https://user-images.githubusercontent.com/17258145/161246849-a6058b5a-8670-443b-88eb-ab342d8709af.gif)  |

