### PR TITLE
[E2E] Fix flaking collection tests

### DIFF
--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -261,8 +261,12 @@ describe("scenarios > collection_defaults", () => {
 
       it("should see a child collection in a sidebar even with revoked access to its parent (metabase#14114)", () => {
         cy.visit("/");
-        cy.findByText("Child");
-        cy.findByText("Parent").should("not.exist");
+
+        cy.get("main").within(() => {
+          cy.findByText("Child");
+          cy.findByText("Parent").should("not.exist");
+        });
+
         cy.findByText("Browse all items").click();
 
         navigationSidebar().within(() => {
@@ -554,7 +558,7 @@ describe("scenarios > collection_defaults", () => {
 
       cy.visit("/");
       // There is already a collection named "First collection" in the default snapshot
-      cy.findByText("First collection");
+      cy.get("main").findByText("First collection");
     });
   });
 });


### PR DESCRIPTION
With the new collection sidebar being open by default, tests started failing because the same collection is now visible both in the sidebar and in the main area of the page.

This PR scopes the search to the `main` element.

### CircleCI

https://app.circleci.com/pipelines/github/metabase/metabase/32401/workflows/f1dfd525-607e-4883-a22a-d30d53eabe4d/jobs/1657148/artifacts
![image](https://user-images.githubusercontent.com/31325167/161261550-b75a340b-c7bc-45bd-8967-98d7587e5be8.png)

### GitHub Actions
https://github.com/metabase/metabase/actions/runs/2076628967
![scenarios  collection_defaults -- Collection related issues reproductions -- collections list on the home page shouldn't depend on the name of the first 50 objects (metabase#16784) (failed)](https://user-images.githubusercontent.com/31325167/161261754-19e8d5ce-66d9-4328-82fa-f86d44c2c69a.png)

