### PR TITLE
Fix flake in repro 17514 for good

### DIFF
--- a/frontend/test/metabase/scenarios/question/reproductions/17514-ui-overlay.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/17514-ui-overlay.cy.spec.js
@@ -56,6 +56,11 @@ describe("issue 17514", () => {
         ({ body: card }) => {
           const { card_id, dashboard_id } = card;
 
+          cy.intercept(
+            "POST",
+            `/api/dashboard/${dashboard_id}/dashcard/*/card/${card_id}/query`,
+          ).as("cardQuery");
+
           const mapFilterToCard = {
             parameter_mappings: [
               {
@@ -70,10 +75,8 @@ describe("issue 17514", () => {
 
           visitDashboard(dashboard_id);
 
-          cy.intercept(
-            "POST",
-            `/api/dashboard/${dashboard_id}/dashcard/*/card/${card_id}/query`,
-          ).as("cardQuery");
+          cy.wait("@cardQuery");
+          cy.findByText("110.93").should("be.visible");
         },
       );
     });


### PR DESCRIPTION
Failure in GHA:
https://github.com/metabase/metabase/runs/5789028412?check_suite_focus=true

![issue 17514 -- scenario 1 -- should not show the run overlay when we apply dashboard filter on a question with removed column and then click through its title (metabase#17514-1) (failed) (attempt 2)](https://user-images.githubusercontent.com/31325167/161295342-c6bee184-bd27-4593-a7d5-50e6478b6f15.png)

### Reason
- Card didn't fully load before we clicked on the `palette` icon, which causes an error in FE
    - That error will not be visible in production, but it will show up as a full screen overlay in tests, thus obstructing any other DOM interaction and making the test fail

In order to reproduce this manually, I needed to throttle the speed to the Slow 3G.
1. open a dashboard with the card
2. as soon as "pencil" icon appears click on it (don't wait until the query comes back and card populates its contents)
3. hover over the card and click on the "palette" icon (visualization options)
4. you'll be greeted with a FE error

![image](https://user-images.githubusercontent.com/31325167/161296067-b4f1dba6-28a3-4f82-a0d4-77b02f601a41.png)

## Important
Since version 9 (not quite sure which exact version), Cypress made `intercept`s work like `cy.route` did previously. Which means that the place where you define the intercept matters.
- Before version 9: wherever you define the intercept, it will be registered even before the test starts (think of it like hoisting in JS)
- After version 9: intercepted route will be registered only after the `intercept`

### The fix
- Register (intercept) the route before we visit the dashboard
- Wait for the selected route (basically, wait for the card query to load)
- Additionally, make sure card contents rendered
- Only and only then edit the dashboard and proceed with the test