### PR TITLE
Document Title and favicon updates for loading questions

### DIFF
--- a/frontend/src/metabase/dashboard/containers/DashboardApp.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp.jsx
@@ -2,7 +2,6 @@
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import { push } from "react-router-redux";
-import { t } from "ttag";
 
 import title from "metabase/hoc/Title";
 import favicon from "metabase/hoc/Favicon";
@@ -30,12 +29,8 @@ import {
   getIsAddParameterPopoverOpen,
   getSidebar,
   getShowAddQuestionSidebar,
-  getIsLoadingDashCards,
-  getTotalCards,
-  getCardsLoaded,
-  getHasSeenLoadedDashboard,
-  getIsLoadingDashCardsComplete,
   getFavicon,
+  getDocumentTitle,
 } from "../selectors";
 import { getDatabases, getMetadata } from "metabase/selectors/metadata";
 import {
@@ -74,12 +69,8 @@ const mapStateToProps = (state, props) => {
     isAddParameterPopoverOpen: getIsAddParameterPopoverOpen(state),
     sidebar: getSidebar(state),
     showAddQuestionSidebar: getShowAddQuestionSidebar(state),
-    isLoadingDashCards: getIsLoadingDashCards(state),
-    isLoadingDashCardsComplete: getIsLoadingDashCardsComplete(state),
-    totalDashCards: getTotalCards(state),
-    cardsLoaded: getCardsLoaded(state),
-    hasSeenLoadedDashboard: getHasSeenLoadedDashboard(state),
     pageFavicon: getFavicon(state),
+    documentTitle: getDocumentTitle(state),
   };
 };
 
@@ -93,28 +84,10 @@ const mapDispatchToProps = {
 
 @connect(mapStateToProps, mapDispatchToProps)
 @favicon(({ pageFavicon }) => pageFavicon)
-@title(
-  ({
-    dashboard,
-    isLoadingDashCards,
-    totalDashCards,
-    cardsLoaded,
-    hasSeenLoadedDashboard,
-    isLoadingDashCardsComplete,
-  }) => {
-    if (isLoadingDashCards) {
-      return {
-        title: t`${cardsLoaded}/${totalDashCards} loaded`,
-        titleIndex: 1,
-      };
-    }
-    if (isLoadingDashCardsComplete && !hasSeenLoadedDashboard) {
-      return t`Your dashboard is ready`;
-    } else {
-      return dashboard?.name;
-    }
-  },
-)
+@title(({ dashboard, documentTitle }) => ({
+  title: documentTitle || dashboard?.name,
+  titleIndex: 1,
+}))
 @titleWithLoadingTime("loadingStartTime")
 // NOTE: should use DashboardControls and DashboardData HoCs here?
 export default class DashboardApp extends Component {

--- a/frontend/src/metabase/dashboard/reducers.js
+++ b/frontend/src/metabase/dashboard/reducers.js
@@ -32,7 +32,7 @@ import {
   CLOSE_SIDEBAR,
   FETCH_DASHBOARD_PARAMETER_FIELD_VALUES,
   SAVE_DASHBOARD_AND_CARDS,
-  SET_DASHBOARD_SEEN,
+  SET_DOCUMENT_TITLE,
   SET_SHOW_LOADING_COMPLETE_FAVICON,
   RESET,
 } from "./actions";
@@ -61,28 +61,19 @@ const isEditing = handleActions(
   null,
 );
 
-const hasSeenLoadedDashboard = handleActions(
+const loadingControls = handleActions(
   {
-    [INITIALIZE]: { next: state => false },
-    [FETCH_DASHBOARD]: { next: state => false },
-    [SET_DASHBOARD_SEEN]: {
-      next: state => true,
-    },
-    [RESET]: { next: state => false },
+    [SET_DOCUMENT_TITLE]: (state, { payload }) => ({
+      ...state,
+      documentTitle: payload,
+    }),
+    [SET_SHOW_LOADING_COMPLETE_FAVICON]: (state, { payload }) => ({
+      ...state,
+      showLoadCompleteFavicon: payload,
+    }),
+    [RESET]: { next: state => ({}) },
   },
-  false,
-);
-
-const showLoadingCompleteFavicon = handleActions(
-  {
-    [INITIALIZE]: { next: state => false },
-    [FETCH_DASHBOARD]: { next: state => false },
-    [SET_SHOW_LOADING_COMPLETE_FAVICON]: {
-      next: (state, { payload }) => payload,
-    },
-    [RESET]: { next: state => false },
-  },
-  false,
+  {},
 );
 
 function newDashboard(before, after, isDirty) {
@@ -402,8 +393,7 @@ const sidebar = handleActions(
 export default combineReducers({
   dashboardId,
   isEditing,
-  hasSeenLoadedDashboard,
-  showLoadingCompleteFavicon,
+  loadingControls,
   dashboards,
   dashcards,
   dashcardData,

--- a/frontend/src/metabase/dashboard/reducers.unit.spec.js
+++ b/frontend/src/metabase/dashboard/reducers.unit.spec.js
@@ -32,8 +32,7 @@ describe("dashboard reducers", () => {
       parameterValuesSearchCache: {},
       sidebar: { props: {} },
       slowCards: {},
-      hasSeenLoadedDashboard: false,
-      showLoadingCompleteFavicon: false,
+      loadingControls: {},
     });
   });
 

--- a/frontend/src/metabase/dashboard/selectors.js
+++ b/frontend/src/metabase/dashboard/selectors.js
@@ -28,19 +28,10 @@ export const getDashcards = state => state.dashboard.dashcards;
 export const getCardData = state => state.dashboard.dashcardData;
 export const getSlowCards = state => state.dashboard.slowCards;
 export const getParameterValues = state => state.dashboard.parameterValues;
-export const getIsLoadingDashCards = state =>
-  state.dashboard.loadingDashCards.loadingIds.length > 0;
-export const getCardsLoaded = state =>
-  state.dashboard.loadingDashCards.dashcardIds.length -
-  state.dashboard.loadingDashCards.loadingIds.length;
-export const getTotalCards = state =>
-  state.dashboard.loadingDashCards.dashcardIds.length;
-export const getHasSeenLoadedDashboard = state =>
-  state.dashboard.hasSeenLoadedDashboard;
-export const getIsLoadingDashCardsComplete = state =>
-  state.dashboard.loadingDashCards.isLoadingComplete;
 export const getFavicon = state =>
-  state.dashboard.showLoadingCompleteFavicon ? LOAD_COMPLETE_FAVICON : null;
+  state.dashboard.loadingControls?.showLoadCompleteFavicon
+    ? LOAD_COMPLETE_FAVICON
+    : null;
 export const getLoadingStartTime = state =>
   state.dashboard.loadingDashCards.startTime;
 export const getIsAddParameterPopoverOpen = state =>
@@ -62,6 +53,8 @@ export const getDashboard = createSelector(
   (dashboardId, dashboards) => dashboards[dashboardId],
 );
 
+export const getLoadingDashCards = state => state.dashboard.loadingDashCards;
+
 export const getDashboardComplete = createSelector(
   [getDashboard, getDashcards],
   (dashboard, dashcards) =>
@@ -72,6 +65,9 @@ export const getDashboardComplete = createSelector(
         .filter(dc => !dc.isRemoved),
     },
 );
+
+export const getDocumentTitle = state =>
+  state.dashboard.loadingControls.documentTitle;
 
 export const getIsBookmarked = (state, props) =>
   props.bookmarks.some(

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
@@ -24,6 +24,7 @@ import { usePrevious } from "metabase/hooks/use-previous";
 
 import title from "metabase/hoc/Title";
 import titleWithLoadingTime from "metabase/hoc/TitleWithLoadingTime";
+import favicon from "metabase/hoc/Favicon";
 
 import View from "../components/view/View";
 
@@ -74,6 +75,8 @@ import {
   getFilteredTimelines,
   getTimeseriesXDomain,
   getIsAnySidebarOpen,
+  getDocumentTitle,
+  getPageFavicon,
 } from "../selectors";
 import * as actions from "../actions";
 
@@ -171,6 +174,8 @@ const mapStateToProps = (state, props) => {
     nativeEditorSelectedText: getNativeEditorSelectedText(state),
     modalSnippet: getModalSnippet(state),
     snippetCollectionId: getSnippetCollectionId(state),
+    documentTitle: getDocumentTitle(state),
+    pageFavicon: getPageFavicon(state),
   };
 };
 
@@ -369,6 +374,10 @@ export default _.compose(
   Bookmark.loadList(),
   Timelines.loadList(timelineProps),
   connect(mapStateToProps, mapDispatchToProps),
-  title(({ card }) => card?.name ?? t`Question`),
+  favicon(({ pageFavicon }) => pageFavicon),
+  title(({ card, documentTitle }) => ({
+    title: documentTitle || card?.name || t`Question`,
+    titleIndex: 1,
+  })),
   titleWithLoadingTime("queryStartTime"),
 )(QueryBuilder);

--- a/frontend/src/metabase/query_builder/reducers.js
+++ b/frontend/src/metabase/query_builder/reducers.js
@@ -63,6 +63,7 @@ import {
   DESELECT_TIMELINE_EVENTS,
   SET_DOCUMENT_TITLE,
   SET_SHOW_LOADING_COMPLETE_FAVICON,
+  SET_DOCUMENT_TITLE_TIMEOUT_ID,
 } from "./actions";
 
 const DEFAULT_UI_CONTROLS = {
@@ -89,6 +90,7 @@ const DEFAULT_UI_CONTROLS = {
 const DEFAULT_LOADING_CONTROLS = {
   showLoadCompleteFavicon: false,
   documentTitle: "",
+  timeoutId: "",
 };
 
 const UI_CONTROLS_SIDEBAR_DEFAULTS = {
@@ -311,6 +313,10 @@ export const loadingControls = handleActions(
     [SET_SHOW_LOADING_COMPLETE_FAVICON]: (state, { payload }) => ({
       ...state,
       showLoadCompleteFavicon: payload,
+    }),
+    [SET_DOCUMENT_TITLE_TIMEOUT_ID]: (state, { payload }) => ({
+      ...state,
+      timeoutId: payload,
     }),
   },
   DEFAULT_LOADING_CONTROLS,

--- a/frontend/src/metabase/query_builder/reducers.js
+++ b/frontend/src/metabase/query_builder/reducers.js
@@ -61,6 +61,8 @@ import {
   HIDE_TIMELINES,
   SELECT_TIMELINE_EVENTS,
   DESELECT_TIMELINE_EVENTS,
+  SET_DOCUMENT_TITLE,
+  SET_SHOW_LOADING_COMPLETE_FAVICON,
 } from "./actions";
 
 const DEFAULT_UI_CONTROLS = {
@@ -82,6 +84,11 @@ const DEFAULT_UI_CONTROLS = {
   previousQueryBuilderMode: false,
   snippetCollectionId: null,
   datasetEditorTab: "query", // "query" / "metadata"
+};
+
+const DEFAULT_LOADING_CONTROLS = {
+  showLoadCompleteFavicon: false,
+  documentTitle: "",
 };
 
 const UI_CONTROLS_SIDEBAR_DEFAULTS = {
@@ -293,6 +300,20 @@ export const uiControls = handleActions(
     }),
   },
   DEFAULT_UI_CONTROLS,
+);
+
+export const loadingControls = handleActions(
+  {
+    [SET_DOCUMENT_TITLE]: (state, { payload }) => ({
+      ...state,
+      documentTitle: payload,
+    }),
+    [SET_SHOW_LOADING_COMPLETE_FAVICON]: (state, { payload }) => ({
+      ...state,
+      showLoadCompleteFavicon: payload,
+    }),
+  },
+  DEFAULT_LOADING_CONTROLS,
 );
 
 export const zoomedRowObjectId = handleActions(

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -828,10 +828,16 @@ export const getDocumentTitle = createSelector(
   [getLoadingControls],
   loadingControls => loadingControls?.documentTitle,
 );
+
 export const getPageFavicon = createSelector(
   [getLoadingControls],
   loadingControls =>
     loadingControls?.showLoadCompleteFavicon
       ? LOAD_COMPLETE_FAVICON
       : undefined,
+);
+
+export const getTimeoutId = createSelector(
+  [getLoadingControls],
+  loadingControls => loadingControls.timeoutId,
 );

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -34,7 +34,10 @@ import {
 import Mode from "metabase-lib/lib/Mode";
 import ObjectMode from "metabase/modes/components/modes/ObjectMode";
 
+import { LOAD_COMPLETE_FAVICON } from "metabase/hoc/Favicon";
+
 export const getUiControls = state => state.qb.uiControls;
+const getLoadingControls = state => state.qb.loadingControls;
 
 export const getIsShowingTemplateTagsEditor = state =>
   getUiControls(state).isShowingTemplateTagsEditor;
@@ -819,4 +822,16 @@ export const isBasedOnExistingQuestion = createSelector(
   originalQuestion => {
     return originalQuestion != null;
   },
+);
+
+export const getDocumentTitle = createSelector(
+  [getLoadingControls],
+  loadingControls => loadingControls?.documentTitle,
+);
+export const getPageFavicon = createSelector(
+  [getLoadingControls],
+  loadingControls =>
+    loadingControls?.showLoadCompleteFavicon
+      ? LOAD_COMPLETE_FAVICON
+      : undefined,
 );


### PR DESCRIPTION
Similar to what we did for Dashboards, we update the text of the document title while loading the results of a question. Initially we show "Doing Science...", then "Still loading..." after 10 seconds. When complete we apply the same favicon logic as before: if they're currently on the page we change it for 3 seconds. Otherwise, we update the title to say "Your question is ready", change the favicon, and revert it 3 seconds after you revisit the page.

The title is now set in the actions, rather than passing a more complicated function to the `title HoC`. It simplifies the component, but it does spread out the logic of  what the current title is/should be.

![chrome_TrzJLejJON](https://user-images.githubusercontent.com/1328979/161299158-e17de12e-25e2-4bbb-8f2c-b30160d4aaaf.png)
![chrome_9vOarIebBL](https://user-images.githubusercontent.com/1328979/161299156-35aa17d9-1e09-49ad-8eb0-c43f4047498e.png)
![chrome_McQ49HzTsi](https://user-images.githubusercontent.com/1328979/161299157-1078db5d-008b-430d-aeeb-ed710c07f5d2.png)


