### PR TITLE
Mobile friendly search

### DIFF
--- a/frontend/src/metabase/hooks/use-keyboard-shortcut.ts
+++ b/frontend/src/metabase/hooks/use-keyboard-shortcut.ts
@@ -1,0 +1,18 @@
+import { useEffect } from "react";
+
+export function useKeyboardShortcut(
+  key: string,
+  callback: (e: KeyboardEvent) => void,
+) {
+  useEffect(() => {
+    function keyboardListener(e: KeyboardEvent) {
+      if (e.key === key) {
+        callback(e);
+      }
+    }
+    document.addEventListener("keyup", keyboardListener);
+    return () => {
+      document.removeEventListener("keyup", keyboardListener);
+    };
+  });
+}

--- a/frontend/src/metabase/hooks/use-on-click-outside.ts
+++ b/frontend/src/metabase/hooks/use-on-click-outside.ts
@@ -4,7 +4,7 @@ interface ValidRefTarget {
   contains(target: EventTarget | null): boolean;
 }
 
-export function useOnOutsideClick<T extends ValidRefTarget = HTMLDivElement>(
+export function useOnClickOutside<T extends ValidRefTarget = HTMLDivElement>(
   ref: RefObject<T>,
   callback: () => void,
 ) {

--- a/frontend/src/metabase/hooks/use-on-outside-click.ts
+++ b/frontend/src/metabase/hooks/use-on-outside-click.ts
@@ -1,0 +1,22 @@
+import { useEffect, RefObject } from "react";
+
+interface ValidRefTarget {
+  contains(target: EventTarget | null): boolean;
+}
+
+export function useOnOutsideClick<T extends ValidRefTarget = HTMLDivElement>(
+  ref: RefObject<T>,
+  callback: () => void,
+) {
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (ref.current && event.target && !ref.current.contains(event.target)) {
+        callback();
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [ref, callback]);
+}

--- a/frontend/src/metabase/nav/components/RecentsList.jsx
+++ b/frontend/src/metabase/nav/components/RecentsList.jsx
@@ -4,7 +4,6 @@ import { t } from "ttag";
 import _ from "underscore";
 
 import RecentViews from "metabase/entities/recent-views";
-import Card from "metabase/components/Card";
 import Text from "metabase/components/type/Text";
 import * as Urls from "metabase/lib/urls";
 import { isSyncCompleted } from "metabase/lib/syncing";
@@ -19,6 +18,7 @@ import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 
 import { getTranslatedEntityName } from "../utils";
 import {
+  Root,
   EmptyStateContainer,
   Header,
   RecentListItemContent,
@@ -51,7 +51,7 @@ function RecentsList({ list, loading }) {
   }
 
   return (
-    <Card py={1}>
+    <Root>
       <Header>{t`Recently viewed`}</Header>
       <LoadingAndErrorWrapper loading={loading} noWrapper>
         <React.Fragment>
@@ -104,7 +104,7 @@ function RecentsList({ list, loading }) {
           )}
         </React.Fragment>
       </LoadingAndErrorWrapper>
-    </Card>
+    </Root>
   );
 }
 

--- a/frontend/src/metabase/nav/components/RecentsList.styled.jsx
+++ b/frontend/src/metabase/nav/components/RecentsList.styled.jsx
@@ -1,5 +1,24 @@
 import styled from "@emotion/styled";
 
+import { color } from "metabase/lib/colors";
+import { breakpointMinSmall } from "metabase/styled-components/theme";
+
+export const Root = styled.div`
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+
+  background-color: ${color("bg-white")};
+  line-height: 24px;
+
+  box-shadow: 0 20px 20px ${color("shadow")};
+
+  ${breakpointMinSmall} {
+    border: 1px solid ${color("border")};
+    border-radius: 6px;
+    box-shadow: 0 7px 20px ${color("shadow")};
+  }
+`;
+
 export const EmptyStateContainer = styled.div`
   margin: 3rem 0;
 `;

--- a/frontend/src/metabase/nav/components/SearchBar.styled.tsx
+++ b/frontend/src/metabase/nav/components/SearchBar.styled.tsx
@@ -11,7 +11,7 @@ import {
   breakpointMinSmall,
 } from "metabase/styled-components/theme";
 
-export const SearchWrapper = styled.div`
+export const SearchInputContainer = styled.div`
   display: flex;
   flex: 1 1 auto;
   align-items: center;

--- a/frontend/src/metabase/nav/components/SearchBar.styled.tsx
+++ b/frontend/src/metabase/nav/components/SearchBar.styled.tsx
@@ -1,4 +1,5 @@
 import styled from "@emotion/styled";
+import { css } from "@emotion/react";
 
 import Icon from "metabase/components/Icon";
 
@@ -11,56 +12,108 @@ import {
   breakpointMinSmall,
 } from "metabase/styled-components/theme";
 
-export const SearchInputContainer = styled.div`
+const activeInputCSS = css`
+  border-radius: 6px;
+  justify-content: flex-start;
+`;
+
+export const SearchInputContainer = styled.div<{ isActive: boolean }>`
   display: flex;
   flex: 1 1 auto;
   align-items: center;
   position: relative;
-  max-width: 50em;
 
   background-color: ${color("bg-light")};
   border: 1px solid ${color("border")};
-  border-radius: 6px;
 
-  transition: background 150ms;
+  overflow: hidden;
+
+  transition: background 150ms, width 0.2s;
 
   &:hover {
     background-color: ${color("bg-medium")};
   }
+
+  @media (prefers-reduced-motion) {
+    transition: none;
+  }
+
+  ${breakpointMaxSmall} {
+    justify-content: center;
+    margin-left: auto;
+
+    width: 2rem;
+    height: 2rem;
+    border-radius: 99px;
+
+    ${props =>
+      props.isActive &&
+      css`
+        width: 95%;
+        ${activeInputCSS};
+      `}
+  }
+
+  ${breakpointMinSmall} {
+    max-width: 50em;
+    ${activeInputCSS};
+  }
 `;
 
-export const SearchInput = styled.input`
-  width: 100%;
-  padding: 10px 12px;
-  font-weight: 700;
-
-  color: ${color("text-dark")};
+export const SearchInput = styled.input<{ isActive: boolean }>`
   background-color: transparent;
   border: none;
+  color: ${color("text-dark")};
+  font-weight: 700;
 
   &:focus {
     outline: none;
   }
+
   &::placeholder {
     color: ${color("text-dark")};
+  }
+
+  ${breakpointMinSmall} {
+    padding: 10px 12px;
+  }
+
+  ${breakpointMaxSmall} {
+    width: 0;
+
+    ${props =>
+      props.isActive &&
+      css`
+        width: 100%;
+        padding-top: 10px;
+        padding-bottom: 10px;
+      `}
   }
 `;
 
 const ICON_MARGIN = "10px";
 
-export const SearchIcon = styled(Icon)`
-  margin-left: ${ICON_MARGIN};
+export const SearchIcon = styled(Icon)<{ isActive: boolean }>`
+  ${breakpointMaxSmall} {
+    margin-left: ${props => (props.isActive ? ICON_MARGIN : "3px")};
+    margin-right: ${props => (props.isActive ? ICON_MARGIN : 0)};
+    transition: margin 0.3s;
+  }
+
+  ${breakpointMinSmall} {
+    margin-left: ${ICON_MARGIN};
+  }
 `;
 
 export const ClearIconButton = styled.button`
-  position: absolute;
-  top: ${ICON_MARGIN};
-  right: ${ICON_MARGIN};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  width: 3rem;
+  height: 100%;
 
   color: ${color("text-light")};
-
-  padding: 0.5em;
-  margin: -0.5em;
 
   cursor: pointer;
 `;
@@ -78,7 +131,6 @@ export const SearchResultsFloatingContainer = styled.div`
 
   ${breakpointMinSmall} {
     top: 60px;
-    max-width: ;
   }
 `;
 

--- a/frontend/src/metabase/nav/components/SearchBar.styled.tsx
+++ b/frontend/src/metabase/nav/components/SearchBar.styled.tsx
@@ -15,6 +15,7 @@ export const SearchInputContainer = styled.div`
   display: flex;
   flex: 1 1 auto;
   align-items: center;
+  position: relative;
   max-width: 50em;
 
   background-color: ${color("bg-light")};
@@ -45,8 +46,23 @@ export const SearchInput = styled.input`
   }
 `;
 
+const ICON_MARGIN = "10px";
+
 export const SearchIcon = styled(Icon)`
-  margin-left: 10px;
+  margin-left: ${ICON_MARGIN};
+`;
+
+export const ClearIconButton = styled.button`
+  position: absolute;
+  top: ${ICON_MARGIN};
+  right: ${ICON_MARGIN};
+
+  color: ${color("text-light")};
+
+  padding: 0.5em;
+  margin: -0.5em;
+
+  cursor: pointer;
 `;
 
 export const SearchResultsFloatingContainer = styled.div`

--- a/frontend/src/metabase/nav/components/SearchBar.styled.tsx
+++ b/frontend/src/metabase/nav/components/SearchBar.styled.tsx
@@ -1,17 +1,21 @@
 import styled from "@emotion/styled";
 
-import Card from "metabase/components/Card";
 import Icon from "metabase/components/Icon";
 
+import { APP_BAR_HEIGHT } from "metabase/nav/constants";
+
 import { color } from "metabase/lib/colors";
+
+import {
+  breakpointMaxSmall,
+  breakpointMinSmall,
+} from "metabase/styled-components/theme";
 
 export const SearchWrapper = styled.div`
   display: flex;
   flex: 1 1 auto;
   align-items: center;
   max-width: 50em;
-
-  position: relative;
 
   background-color: ${color("bg-light")};
   border: 1px solid ${color("border")};
@@ -21,6 +25,10 @@ export const SearchWrapper = styled.div`
 
   &:hover {
     background-color: ${color("bg-medium")};
+  }
+
+  ${breakpointMinSmall} {
+    position: relative;
   }
 `;
 
@@ -47,15 +55,39 @@ export const SearchIcon = styled(Icon)`
 
 export const SearchResultsFloatingContainer = styled.div`
   position: absolute;
-  top: 60px;
   left: 0;
   right: 0;
+
   color: ${color("text-dark")};
+
+  ${breakpointMaxSmall} {
+    top: ${APP_BAR_HEIGHT};
+  }
+
+  ${breakpointMinSmall} {
+    top: 60px;
+  }
 `;
 
-export const SearchResultsContainer = styled(Card)`
-  padding-top: 8px;
-  padding-bottom: 8px;
+export const SearchResultsContainer = styled.div`
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
   overflow-y: auto;
-  max-height: 400px;
+
+  background-color: ${color("bg-white")};
+  line-height: 24px;
+
+  box-shadow: 0 20px 20px ${color("shadow")};
+
+  ${breakpointMaxSmall} {
+    height: calc(100vh - ${APP_BAR_HEIGHT});
+  }
+
+  ${breakpointMinSmall} {
+    max-height: 400px;
+
+    border: 1px solid ${color("border")};
+    border-radius: 6px;
+    box-shadow: 0 7px 20px ${color("shadow")};
+  }
 `;

--- a/frontend/src/metabase/nav/components/SearchBar.styled.tsx
+++ b/frontend/src/metabase/nav/components/SearchBar.styled.tsx
@@ -26,10 +26,6 @@ export const SearchInputContainer = styled.div`
   &:hover {
     background-color: ${color("bg-medium")};
   }
-
-  ${breakpointMinSmall} {
-    position: relative;
-  }
 `;
 
 export const SearchInput = styled.input`
@@ -66,6 +62,7 @@ export const SearchResultsFloatingContainer = styled.div`
 
   ${breakpointMinSmall} {
     top: 60px;
+    max-width: ;
   }
 `;
 

--- a/frontend/src/metabase/nav/components/SearchBar.tsx
+++ b/frontend/src/metabase/nav/components/SearchBar.tsx
@@ -5,7 +5,7 @@ import { Location, LocationDescriptorObject } from "history";
 import Icon from "metabase/components/Icon";
 
 import { useKeyboardShortcut } from "metabase/hooks/use-keyboard-shortcut";
-import { useOnOutsideClick } from "metabase/hooks/use-on-outside-click";
+import { useOnClickOutside } from "metabase/hooks/use-on-click-outside";
 import { usePrevious } from "metabase/hooks/use-previous";
 import { useToggle } from "metabase/hooks/use-toggle";
 import { isSmallScreen } from "metabase/lib/dom";
@@ -77,7 +77,7 @@ function SearchBar({
     setSearchText("");
   }, []);
 
-  useOnOutsideClick(container, setInactive);
+  useOnClickOutside(container, setInactive);
 
   useKeyboardShortcut("Escape", setInactive);
 

--- a/frontend/src/metabase/nav/components/SearchBar.tsx
+++ b/frontend/src/metabase/nav/components/SearchBar.tsx
@@ -34,6 +34,7 @@ type SearchAwareLocation = Location<{ q?: string }>;
 type Props = {
   location: SearchAwareLocation;
   onFocus?: (e: FocusEvent<HTMLInputElement>) => void;
+  onBlur?: (e: FocusEvent<HTMLInputElement>) => void;
   onChangeLocation: (nextLocation: LocationDescriptorObject) => void;
 };
 
@@ -49,7 +50,7 @@ function getSearchTextFromLocation(location: SearchAwareLocation) {
   return "";
 }
 
-function SearchBar({ location, onFocus, onChangeLocation }: Props) {
+function SearchBar({ location, onFocus, onBlur, onChangeLocation }: Props) {
   const [searchText, setSearchText] = useState<string>(() =>
     getSearchTextFromLocation(location),
   );
@@ -60,6 +61,11 @@ function SearchBar({ location, onFocus, onChangeLocation }: Props) {
 
   const previousLocation = usePrevious(location);
   const searchInput = useRef<HTMLInputElement>(null);
+
+  const onInputContainerClick = useCallback(() => {
+    searchInput.current?.focus();
+    setActive();
+  }, [setActive]);
 
   const onTextChange = useCallback(e => {
     setSearchText(e.target.value);
@@ -118,14 +124,19 @@ function SearchBar({ location, onFocus, onChangeLocation }: Props) {
   return (
     <OnClickOutsideWrapper handleDismissal={setInactive}>
       <>
-        <SearchInputContainer onClick={setActive}>
-          <SearchIcon name="search" />
+        <SearchInputContainer
+          isActive={isActive}
+          onClick={onInputContainerClick}
+        >
+          <SearchIcon name="search" isActive={isActive} />
           <SearchInput
+            isActive={isActive}
             value={searchText}
             placeholder={t`Search` + "…"}
             maxLength={200}
             onClick={setActive}
             onFocus={onFocus}
+            onBlur={onBlur}
             onChange={onTextChange}
             onKeyPress={handleInputKeyPress}
             ref={searchInput}

--- a/frontend/src/metabase/nav/components/SearchBar.tsx
+++ b/frontend/src/metabase/nav/components/SearchBar.tsx
@@ -8,10 +8,12 @@ import React, {
 import { t } from "ttag";
 import { Location, LocationDescriptorObject } from "history";
 
+import Icon from "metabase/components/Icon";
 import OnClickOutsideWrapper from "metabase/components/OnClickOutsideWrapper";
 
 import { usePrevious } from "metabase/hooks/use-previous";
 import { useToggle } from "metabase/hooks/use-toggle";
+import { isSmallScreen } from "metabase/lib/dom";
 import MetabaseSettings from "metabase/lib/settings";
 
 import { SearchResults } from "./SearchResults";
@@ -19,6 +21,7 @@ import RecentsList from "./RecentsList";
 import {
   SearchInputContainer,
   SearchIcon,
+  ClearIconButton,
   SearchInput,
   SearchResultsFloatingContainer,
   SearchResultsContainer,
@@ -60,6 +63,10 @@ function SearchBar({ location, onFocus, onChangeLocation }: Props) {
 
   const onTextChange = useCallback(e => {
     setSearchText(e.target.value);
+  }, []);
+
+  const onClear = useCallback(e => {
+    setSearchText("");
   }, []);
 
   useEffect(() => {
@@ -106,6 +113,8 @@ function SearchBar({ location, onFocus, onChangeLocation }: Props) {
     [searchText, onChangeLocation],
   );
 
+  const hasSearchText = searchText.trim().length > 0;
+
   return (
     <OnClickOutsideWrapper handleDismissal={setInactive}>
       <>
@@ -121,10 +130,15 @@ function SearchBar({ location, onFocus, onChangeLocation }: Props) {
             onKeyPress={handleInputKeyPress}
             ref={searchInput}
           />
+          {isSmallScreen() && hasSearchText && (
+            <ClearIconButton onClick={onClear}>
+              <Icon name="close" />
+            </ClearIconButton>
+          )}
         </SearchInputContainer>
         {isActive && MetabaseSettings.searchTypeaheadEnabled() && (
           <SearchResultsFloatingContainer>
-            {searchText.trim().length > 0 ? (
+            {hasSearchText ? (
               <SearchResultsContainer>
                 <SearchResults searchText={searchText.trim()} />
               </SearchResultsContainer>

--- a/frontend/src/metabase/nav/components/SearchBar.tsx
+++ b/frontend/src/metabase/nav/components/SearchBar.tsx
@@ -108,18 +108,20 @@ function SearchBar({ location, onFocus, onChangeLocation }: Props) {
 
   return (
     <OnClickOutsideWrapper handleDismissal={setInactive}>
-      <SearchInputContainer onClick={setActive}>
-        <SearchIcon name="search" />
-        <SearchInput
-          value={searchText}
-          placeholder={t`Search` + "…"}
-          maxLength={200}
-          onClick={setActive}
-          onFocus={onFocus}
-          onChange={onTextChange}
-          onKeyPress={handleInputKeyPress}
-          ref={searchInput}
-        />
+      <>
+        <SearchInputContainer onClick={setActive}>
+          <SearchIcon name="search" />
+          <SearchInput
+            value={searchText}
+            placeholder={t`Search` + "…"}
+            maxLength={200}
+            onClick={setActive}
+            onFocus={onFocus}
+            onChange={onTextChange}
+            onKeyPress={handleInputKeyPress}
+            ref={searchInput}
+          />
+        </SearchInputContainer>
         {isActive && MetabaseSettings.searchTypeaheadEnabled() && (
           <SearchResultsFloatingContainer>
             {searchText.trim().length > 0 ? (
@@ -131,7 +133,7 @@ function SearchBar({ location, onFocus, onChangeLocation }: Props) {
             )}
           </SearchResultsFloatingContainer>
         )}
-      </SearchInputContainer>
+      </>
     </OnClickOutsideWrapper>
   );
 }

--- a/frontend/src/metabase/nav/components/SearchBar.tsx
+++ b/frontend/src/metabase/nav/components/SearchBar.tsx
@@ -17,7 +17,7 @@ import MetabaseSettings from "metabase/lib/settings";
 import { SearchResults } from "./SearchResults";
 import RecentsList from "./RecentsList";
 import {
-  SearchWrapper,
+  SearchInputContainer,
   SearchIcon,
   SearchInput,
   SearchResultsFloatingContainer,
@@ -108,7 +108,7 @@ function SearchBar({ location, onFocus, onChangeLocation }: Props) {
 
   return (
     <OnClickOutsideWrapper handleDismissal={setInactive}>
-      <SearchWrapper onClick={setActive}>
+      <SearchInputContainer onClick={setActive}>
         <SearchIcon name="search" />
         <SearchInput
           value={searchText}
@@ -131,7 +131,7 @@ function SearchBar({ location, onFocus, onChangeLocation }: Props) {
             )}
           </SearchResultsFloatingContainer>
         )}
-      </SearchWrapper>
+      </SearchInputContainer>
     </OnClickOutsideWrapper>
   );
 }

--- a/frontend/src/metabase/nav/containers/AppBar.styled.tsx
+++ b/frontend/src/metabase/nav/containers/AppBar.styled.tsx
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
 
 import { color } from "metabase/lib/colors";
-import { space } from "metabase/styled-components/theme";
+import { breakpointMaxSmall, space } from "metabase/styled-components/theme";
 
 import { APP_BAR_HEIGHT } from "../constants";
 
@@ -27,5 +27,31 @@ export const LogoIconWrapper = styled.div`
 
   &:hover {
     background-color: ${color("bg-light")};
+  }
+`;
+
+export const SearchBarContainer = styled.div`
+  display: flex;
+  flex: 1 0 auto;
+  align-items: center;
+  padding-right: 1rem;
+  z-index: 1;
+`;
+
+export const SearchBarContent = styled.div`
+  width: 100%;
+  max-width: 500px;
+  margin-left: auto;
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
+
+  transition: max-width 0.2s;
+
+  @media (prefers-reduced-motion) {
+    transition: none;
+  }
+
+  ${breakpointMaxSmall} {
+    max-width: 60vw;
   }
 `;

--- a/frontend/src/metabase/nav/containers/AppBar.styled.tsx
+++ b/frontend/src/metabase/nav/containers/AppBar.styled.tsx
@@ -13,11 +13,23 @@ export const AppBarRoot = styled.header`
   position: relative;
   display: flex;
   align-items: center;
+  justify-content: space-between;
   width: 100%;
   height: ${APP_BAR_HEIGHT};
   background-color: ${color("bg-white")};
   border-bottom: 1px solid ${color("border")};
   z-index: 4;
+`;
+
+export const RowLeft = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+`;
+
+export const RowRight = styled(RowLeft)`
+  flex: 1;
+  justify-content: flex-end;
 `;
 
 export const LogoIconWrapper = styled.div`
@@ -36,29 +48,27 @@ export const LogoIconWrapper = styled.div`
 
 export const SearchBarContainer = styled.div`
   display: flex;
-  flex: 1 0 auto;
   align-items: center;
-  padding-right: 1rem;
+  margin-right: 1rem;
+
+  ${breakpointMaxSmall} {
+    width: 100%;
+  }
 `;
 
 export const SearchBarContent = styled.div`
-  width: 100%;
-  max-width: 500px;
-  margin-left: auto;
-  padding-top: 0.25rem;
-  padding-bottom: 0.25rem;
-
-  transition: max-width 0.2s;
+  // transition: width 0.2s;
 
   @media (prefers-reduced-motion) {
     transition: none;
   }
 
   ${breakpointMaxSmall} {
-    max-width: 60vw;
+    width: 100%;
   }
 
   ${breakpointMinSmall} {
     position: relative;
+    width: 500px;
   }
 `;

--- a/frontend/src/metabase/nav/containers/AppBar.styled.tsx
+++ b/frontend/src/metabase/nav/containers/AppBar.styled.tsx
@@ -35,7 +35,6 @@ export const SearchBarContainer = styled.div`
   flex: 1 0 auto;
   align-items: center;
   padding-right: 1rem;
-  z-index: 1;
 `;
 
 export const SearchBarContent = styled.div`

--- a/frontend/src/metabase/nav/containers/AppBar.styled.tsx
+++ b/frontend/src/metabase/nav/containers/AppBar.styled.tsx
@@ -1,7 +1,11 @@
 import styled from "@emotion/styled";
 
 import { color } from "metabase/lib/colors";
-import { breakpointMaxSmall, space } from "metabase/styled-components/theme";
+import {
+  breakpointMaxSmall,
+  breakpointMinSmall,
+  space,
+} from "metabase/styled-components/theme";
 
 import { APP_BAR_HEIGHT } from "../constants";
 
@@ -52,5 +56,9 @@ export const SearchBarContent = styled.div`
 
   ${breakpointMaxSmall} {
     max-width: 60vw;
+  }
+
+  ${breakpointMinSmall} {
+    position: relative;
   }
 `;

--- a/frontend/src/metabase/nav/containers/AppBar.styled.tsx
+++ b/frontend/src/metabase/nav/containers/AppBar.styled.tsx
@@ -57,12 +57,6 @@ export const SearchBarContainer = styled.div`
 `;
 
 export const SearchBarContent = styled.div`
-  // transition: width 0.2s;
-
-  @media (prefers-reduced-motion) {
-    transition: none;
-  }
-
   ${breakpointMaxSmall} {
     width: 100%;
   }

--- a/frontend/src/metabase/nav/containers/AppBar.tsx
+++ b/frontend/src/metabase/nav/containers/AppBar.tsx
@@ -9,16 +9,17 @@ import LogoIcon from "metabase/components/LogoIcon";
 import SearchBar from "metabase/nav/components/SearchBar";
 import SidebarButton from "metabase/nav/components/SidebarButton";
 import NewButton from "metabase/nav/containers/NewButton";
-import {
-  SearchBarContainer,
-  SearchBarContent,
-} from "metabase/nav/containers/Navbar.styled";
 
 import Database from "metabase/entities/databases";
 import { isMac } from "metabase/lib/browser";
 import { isSmallScreen } from "metabase/lib/dom";
 
-import { AppBarRoot, LogoIconWrapper } from "./AppBar.styled";
+import {
+  AppBarRoot,
+  LogoIconWrapper,
+  SearchBarContainer,
+  SearchBarContent,
+} from "./AppBar.styled";
 
 type Props = {
   isSidebarOpen: boolean;

--- a/frontend/src/metabase/nav/containers/AppBar.tsx
+++ b/frontend/src/metabase/nav/containers/AppBar.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import { t } from "ttag";
 import { Location, LocationDescriptorObject } from "history";
 
@@ -19,6 +19,8 @@ import {
   LogoIconWrapper,
   SearchBarContainer,
   SearchBarContent,
+  RowLeft,
+  RowRight,
 } from "./AppBar.styled";
 
 type Props = {
@@ -38,13 +40,20 @@ function AppBar({
   handleCloseSidebar,
   onChangeLocation,
 }: Props) {
+  const [isSearchActive, setSearchActive] = useState(false);
+
   const closeSidebarForSmallScreens = useCallback(() => {
     if (isSmallScreen()) {
       handleCloseSidebar();
+      setSearchActive(true);
     }
   }, [handleCloseSidebar]);
 
-  const sidebarButtonLabel = useMemo(() => {
+  const onStopSearching = useCallback(() => {
+    setSearchActive(false);
+  }, []);
+
+  const sidebarButtonTooltip = useMemo(() => {
     const message = isSidebarOpen ? t`Close sidebar` : t`Open sidebar`;
     const shortcut = isMac() ? "(⌘ + .)" : "(Ctrl + .)";
     return `${message} ${shortcut}`;
@@ -52,31 +61,38 @@ function AppBar({
 
   return (
     <AppBarRoot>
-      <LogoIconWrapper>
-        <Link
-          to="/"
-          onClick={closeSidebarForSmallScreens}
-          data-metabase-event="Navbar;Logo"
-        >
-          <LogoIcon size={24} />
-        </Link>
-      </LogoIconWrapper>
-      <Tooltip tooltip={sidebarButtonLabel}>
-        <SidebarButton
-          onClick={onToggleSidebarClick}
-          isSidebarOpen={isSidebarOpen}
-        />
-      </Tooltip>
-      <SearchBarContainer>
-        <SearchBarContent>
-          <SearchBar
-            location={location}
-            onChangeLocation={onChangeLocation}
-            onFocus={closeSidebarForSmallScreens}
-          />
-        </SearchBarContent>
-      </SearchBarContainer>
-      <NewButton setModal={onNewClick} />
+      <RowLeft>
+        <LogoIconWrapper>
+          <Link
+            to="/"
+            onClick={closeSidebarForSmallScreens}
+            data-metabase-event="Navbar;Logo"
+          >
+            <LogoIcon size={24} />
+          </Link>
+        </LogoIconWrapper>
+        {!isSearchActive && (
+          <Tooltip tooltip={sidebarButtonTooltip}>
+            <SidebarButton
+              isSidebarOpen={isSidebarOpen}
+              onClick={onToggleSidebarClick}
+            />
+          </Tooltip>
+        )}
+      </RowLeft>
+      <RowRight>
+        <SearchBarContainer>
+          <SearchBarContent>
+            <SearchBar
+              location={location}
+              onChangeLocation={onChangeLocation}
+              onFocus={closeSidebarForSmallScreens}
+              onBlur={onStopSearching}
+            />
+          </SearchBarContent>
+        </SearchBarContainer>
+        <NewButton setModal={onNewClick} />
+      </RowRight>
     </AppBarRoot>
   );
 }

--- a/frontend/src/metabase/nav/containers/AppBar.tsx
+++ b/frontend/src/metabase/nav/containers/AppBar.tsx
@@ -42,15 +42,23 @@ function AppBar({
 }: Props) {
   const [isSearchActive, setSearchActive] = useState(false);
 
-  const closeSidebarForSmallScreens = useCallback(() => {
+  const onLogoClick = useCallback(() => {
     if (isSmallScreen()) {
       handleCloseSidebar();
-      setSearchActive(true);
     }
   }, [handleCloseSidebar]);
 
-  const onStopSearching = useCallback(() => {
-    setSearchActive(false);
+  const onSearchActive = useCallback(() => {
+    if (isSmallScreen()) {
+      setSearchActive(true);
+      handleCloseSidebar();
+    }
+  }, [handleCloseSidebar]);
+
+  const onSearchInactive = useCallback(() => {
+    if (isSmallScreen()) {
+      setSearchActive(false);
+    }
   }, []);
 
   const sidebarButtonTooltip = useMemo(() => {
@@ -63,11 +71,7 @@ function AppBar({
     <AppBarRoot>
       <RowLeft>
         <LogoIconWrapper>
-          <Link
-            to="/"
-            onClick={closeSidebarForSmallScreens}
-            data-metabase-event="Navbar;Logo"
-          >
+          <Link to="/" onClick={onLogoClick} data-metabase-event="Navbar;Logo">
             <LogoIcon size={24} />
           </Link>
         </LogoIconWrapper>
@@ -86,8 +90,8 @@ function AppBar({
             <SearchBar
               location={location}
               onChangeLocation={onChangeLocation}
-              onFocus={closeSidebarForSmallScreens}
-              onBlur={onStopSearching}
+              onSearchActive={onSearchActive}
+              onSearchInactive={onSearchInactive}
             />
           </SearchBarContent>
         </SearchBarContainer>

--- a/frontend/src/metabase/nav/containers/Navbar.styled.tsx
+++ b/frontend/src/metabase/nav/containers/Navbar.styled.tsx
@@ -11,6 +11,8 @@ import {
 const openNavbarCSS = css`
   width: ${NAV_SIDEBAR_WIDTH};
 
+  border-right: 1px solid ${color("border")};
+
   ${breakpointMaxSmall} {
     width: 90vw;
   }
@@ -29,8 +31,6 @@ export const Sidebar = styled.aside<{ isOpen: boolean }>`
   overflow: auto;
   overflow-x: hidden;
   z-index: 4;
-
-  border-right: 1px solid ${color("border")};
 
   transition: width 0.2s;
 

--- a/frontend/src/metabase/nav/containers/Navbar.styled.tsx
+++ b/frontend/src/metabase/nav/containers/Navbar.styled.tsx
@@ -55,32 +55,6 @@ export const LogoIconContainer = styled.div`
   height: 2rem;
 `;
 
-export const SearchBarContainer = styled.div`
-  display: flex;
-  flex: 1 0 auto;
-  align-items: center;
-  padding-right: 1rem;
-  z-index: 1;
-`;
-
-export const SearchBarContent = styled.div`
-  width: 100%;
-  max-width: 500px;
-  margin-left: auto;
-  padding-top: 0.25rem;
-  padding-bottom: 0.25rem;
-
-  transition: max-width 0.2s;
-
-  @media (prefers-reduced-motion) {
-    transition: none;
-  }
-
-  ${breakpointMaxSmall} {
-    max-width: 60vw;
-  }
-`;
-
 export const EntityMenuContainer = styled.div`
   display: flex;
   position: relative;

--- a/frontend/src/metabase/nav/containers/NewButton.jsx
+++ b/frontend/src/metabase/nav/containers/NewButton.jsx
@@ -27,7 +27,7 @@ function NewButton({
 }) {
   return (
     <EntityMenu
-      className="hide sm-show mr1 ml-auto"
+      className="hide sm-show mr1"
       trigger={
         <Link
           mr={1}


### PR DESCRIPTION
This PR improves search UI/UX when Metabase is used with a mobile device. Currently, there are a few inconveniences about how search works on mobile:

* the search bar takes the app bar space no matter if you're needing it right now
* the search bar is pretty narrow. However, when you're searching on mobile, it's clear it's your main action right now, so it deserves some more focus
* the sidebar toggle button remains visible and takes space when you're searching
* the search results are displayed in a narrow popover

The PR changes the mobile UX/UX, so now:

* the search input is not visible at all, but there is a search icon on the right side of the app bar
* once you tap the icon, the sidebar toggle button disappears and the search icon expands into a full-width input
* a list of recent items takes full width, so it's easier to read
* search results take full width and height, so they're easier to see
* once a search query is entered, a "clear" button appears to clean the input

### To Verify

1. Open any non-admin page, ensure the desktop search behaves the same way it does on `master`
2. Make the window narrow or use a mobile mode from the browser's developer tools
3. Ensure the search input is not visible, but there is a search icon on the right side of the sidebar
4. Click the icon. Make sure sidebar's toggle button disappears and the icon expands into a full width input (except the logo)
5. Ensure the recent items list takes full width
6. Enter some query, ensure a list of search results takes full width and height and you can scroll it if there are many results
7. Ensure you can click a recent item and a search results item and actually open them
8. Ensure you can click outside of the input to dismiss search and that everything turns back into the original state: visible sidebar toggle button, no search input, search icon

### Demo

**Before** 

https://user-images.githubusercontent.com/17258145/161558058-fd9a43da-9e43-430f-ac2d-a53ea2ca9538.mp4 

**After**

https://user-images.githubusercontent.com/17258145/161558068-9b605244-bf60-4192-bb7b-fd117bc7d594.mp4

