### PR TITLE
[E2E] Fix binning click-related flakes

### DIFF
--- a/frontend/test/__support__/e2e/helpers/e2e-dimension-list-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-dimension-list-helpers.js
@@ -48,7 +48,7 @@ export function changeBinningForDimension({
   if (fromBinning) {
     binningButton.should("have.text", fromBinning);
   }
-  binningButton.click();
+  binningButton.click({ force: true });
 
   cy.findByText(toBinning).click();
 }


### PR DESCRIPTION
The failure in CircleCi
https://app.circleci.com/pipelines/github/metabase/metabase/32499/workflows/a62c288f-0a96-4581-b875-d4751ebf6f98/jobs/1663051/artifacts

![image](https://user-images.githubusercontent.com/31325167/161398611-0f6d120d-4b85-4ad4-a85f-c5557dcbb080.png)

The breakout text element is usually hidden for Cypress, so we need to force-click in order for the test to reliably pass.
This PR adjusts the helper function, which will have an impact on a lot of related tests.