### PR TITLE
Hide app bar in fullscreen dashboard

### DIFF
--- a/frontend/src/metabase/dashboard/hoc/DashboardControls.jsx
+++ b/frontend/src/metabase/dashboard/hoc/DashboardControls.jsx
@@ -186,10 +186,13 @@ export default ComposedComponent =>
         // when _showNav is called for the first time
         if (window.document) {
           const nav = window.document.querySelector(".Nav");
-          if (show && nav) {
+          const appBar = window.document.querySelector("#root > header");
+          if (show && nav && appBar) {
             nav.classList.remove("hide");
-          } else if (!show && nav) {
+            appBar.classList.remove("hide");
+          } else if (!show && nav && appBar) {
             nav.classList.add("hide");
+            appBar.classList.add("hide");
           }
         }
       }


### PR DESCRIPTION
This PR makes it hide the app bar in dashboard fullscreen mode since it the search and sidebar controls don't make much sense in there.

Not the cleanest solution, but doing it the right way would mean getting rid of the `DashboardControls` HOC completely: moving its state to Redux, reattaching listeners to other places. This change should lower the risk before the upcoming release

### To Verify

1. Open a dashboard
2. Click the "fullscreen" icon on the right side of the dashboard's header
3. Make sure you don't see the sidebar and the app bar (the one with the logo, sidebar toggle button and search bar)

### Demo

**Before**

![before](https://user-images.githubusercontent.com/17258145/161565156-690ced7b-1ca5-4241-b764-40ecdb8ee0a1.png)

**After**

![CleanShot 2022-04-04 at 15 21 54@2x](https://user-images.githubusercontent.com/17258145/161565190-0691b893-2077-4e28-bf04-c65ac4e45740.png)

