### PR TITLE
Fix data selector popover alignment

### DIFF
--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -1050,7 +1050,6 @@ export class UnconnectedDataSelector extends Component {
         containerClassName={this.props.containerClassName}
         triggerElement={this.getTriggerElement}
         triggerClasses={this.getTriggerClasses()}
-        horizontalAttachments={["center", "left", "right"]}
         hasArrow={this.props.hasArrow}
         tetherOptions={this.props.tetherOptions}
         sizeToFit


### PR DESCRIPTION
Fixes QB data source selector popover position, so it doesn't overlap the nav sidebar

### Demo

**Before**

<img width="1501" alt="before" src="https://user-images.githubusercontent.com/17258145/161567614-e6efb817-11a0-43dc-be68-52d712d1a546.png">

**After**

<img width="1508" alt="after" src="https://user-images.githubusercontent.com/17258145/161567630-19595f0c-f4ee-492f-8e12-26f56552de84.png">

