### PR TITLE
[E2E] Fix admin datetime flakes

### DIFF
--- a/frontend/test/metabase/scenarios/admin/settings/localization.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/localization.cy.spec.js
@@ -170,10 +170,12 @@ describe("scenarios > admin > localization", () => {
     cy.findByText("January 7, 2018").click();
     cy.findByText("2018/1/7").click();
     cy.wait("@updateFormatting");
+    cy.findAllByTestId("select-button-content").should("contain", "2018/1/7");
 
     // update the time style setting to 24 hour
     cy.findByText("17:24 (24-hour clock)").click();
     cy.wait("@updateFormatting");
+    cy.findByDisplayValue("HH:mm").should("be.checked");
 
     visitQuestion(1);
     cy.findByTestId("loading-spinner").should("not.exist");

--- a/frontend/test/metabase/scenarios/admin/settings/localization.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/localization.cy.spec.js
@@ -160,6 +160,7 @@ describe("scenarios > admin > localization", () => {
   });
 
   it("should use date and time styling settings in the date filter widget (metabase#9151, metabase#12472)", () => {
+    cy.intercept("POST", "/api/dataset").as("dataset");
     cy.intercept("PUT", "/api/setting/custom-formatting").as(
       "updateFormatting",
     );
@@ -178,11 +179,9 @@ describe("scenarios > admin > localization", () => {
     cy.findByDisplayValue("HH:mm").should("be.checked");
 
     visitQuestion(1);
-    cy.findByTestId("loading-spinner").should("not.exist");
-    cy.findByTextEnsureVisible("Product ID");
 
     // create a date filter and set it to the 'On' view to see a specific date
-    cy.findByText("Created At").click();
+    cy.findByTextEnsureVisible("Created At").click();
     cy.findByText("Filter by this column").click();
     cy.findByText("Previous").click();
     cy.findByText("On").click();
@@ -212,7 +211,8 @@ describe("scenarios > admin > localization", () => {
       .type("56");
 
     // apply the date filter
-    cy.findByText("Update filter").click();
+    cy.button("Update filter").click();
+    cy.wait("@dataset");
 
     cy.findByTestId("loading-spinner").should("not.exist");
 

--- a/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
@@ -175,9 +175,11 @@ describe("scenarios > admin > settings", () => {
     cy.findByText("January 7, 2018").click({ force: true });
     cy.findByText("2018/1/7").click({ force: true });
     cy.wait("@saveFormatting");
+    cy.findAllByTestId("select-button-content").should("contain", "2018/1/7");
 
     cy.findByText("17:24 (24-hour clock)").click();
     cy.wait("@saveFormatting");
+    cy.findByDisplayValue("HH:mm").should("be.checked");
 
     openOrdersTable({ limit: 2 });
 
@@ -191,6 +193,7 @@ describe("scenarios > admin > settings", () => {
 
     cy.findByText("5:24 PM (12-hour clock)").click();
     cy.wait("@saveFormatting");
+    cy.findByDisplayValue("h:mm A").should("be.checked");
 
     openOrdersTable({ limit: 2 });
 


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- Fixes stubborn `admin` datetime localization / formatting flake

The previous attempt: https://github.com/metabase/metabase/pull/20691

### Explanation
Waiting for `PUT, **/custom-formatting` obviously wasn't enough to make sure FE applied the updated settings. Most of the time, this test works but there were occasional runs where this flake still creeps in. Settings do not save, so Cypress fails when it tries to assert on the correct date/time format being applied later on.

Example of the failed run: https://github.com/metabase/metabase/actions/runs/2083186895/attempts/1

`settings/settings`
![scenarios  admin  settings -- should correctly apply the globalized date formats (metabase#11394) and update the formatting (failed) (attempt 2)](https://user-images.githubusercontent.com/31325167/161443524-3e97ddbe-f429-46ab-aff7-53405dde583d.png)

`settings/localization`
![scenarios  admin  localization -- should use date and time styling settings in the date filter widget (metabase#9151, metabase#12472) (failed)](https://user-images.githubusercontent.com/31325167/161443540-c316f098-0c92-404d-82fa-a97c2d2c7c5a.png)

### The fix
Apart from waiting for the `PUT` request, make sure UI updated with the correct formatting.

