### PR TITLE
[E2E] Fix subscription flakes related to "Email sent" string

### DIFF
--- a/frontend/test/__support__/e2e/helpers/e2e-email-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-email-helpers.js
@@ -58,6 +58,11 @@ export const openEmailPage = emailSubject => {
   });
 };
 
+export const clickSend = () => {
+  cy.button("Send email now").click();
+  cy.button("Email sent", 30000);
+};
+
 export const sendSubscriptionsEmail = recipient => {
   cy.icon("subscription").click();
 
@@ -67,6 +72,5 @@ export const sendSubscriptionsEmail = recipient => {
     .type(`${recipient}{enter}`)
     .blur();
 
-  cy.button("Send email now").click();
-  cy.button("Email sent", 30000);
+  clickSend();
 };

--- a/frontend/test/metabase/scenarios/sharing/reproductions/18009-nodata-creates-subscription-receives-error.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/reproductions/18009-nodata-creates-subscription-receives-error.cy.spec.js
@@ -3,6 +3,7 @@ import {
   popover,
   setupSMTP,
   visitDashboard,
+  clickSend,
 } from "__support__/e2e/cypress";
 
 describe.skip("issue 18009", () => {
@@ -30,8 +31,7 @@ describe.skip("issue 18009", () => {
     // Click anywhere to close the popover that covers the "Send email now" button
     cy.findByText("To:").click();
 
-    cy.button("Send email now").click();
-    cy.findByText("Email sent");
+    clickSend();
 
     cy.request("GET", "http://localhost:80/email").then(({ body }) => {
       expect(body[0].html).not.to.include(

--- a/frontend/test/metabase/scenarios/sharing/reproductions/18344-subscription-shows-original-question-name.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/reproductions/18344-subscription-shows-original-question-name.cy.spec.js
@@ -4,6 +4,7 @@ import {
   saveDashboard,
   setupSMTP,
   visitDashboard,
+  clickSend,
 } from "__support__/e2e/cypress";
 
 import { USERS } from "__support__/e2e/cypress_data";
@@ -48,8 +49,7 @@ describe("issue 18344", () => {
     // Click this just to close the popover that is blocking the "Send email now" button
     cy.findByText(`To:`).click();
 
-    cy.button("Send email now").click();
-    cy.findByText("Email sent");
+    clickSend();
 
     cy.request("GET", "http://localhost:80/email").then(({ body }) => {
       expect(body[0].html).to.include("OrdersFoo");

--- a/frontend/test/metabase/scenarios/sharing/reproductions/18352-subscription-int64-value-card.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/reproductions/18352-subscription-int64-value-card.cy.spec.js
@@ -3,6 +3,7 @@ import {
   setupSMTP,
   visitQuestion,
   visitDashboard,
+  clickSend,
 } from "__support__/e2e/cypress";
 import { USERS } from "__support__/e2e/cypress_data";
 
@@ -43,8 +44,7 @@ describe("issue 18352", () => {
     // Click this just to close the popover that is blocking the "Send email now" button
     cy.findByText(`To:`).click();
 
-    cy.button("Send email now").click();
-    cy.findByText("Email sent");
+    clickSend();
 
     cy.request("GET", "http://localhost:80/email").then(
       ({ body: [{ html }] }) => {

--- a/frontend/test/metabase/scenarios/sharing/reproductions/18669-test-email-with-parameters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/reproductions/18669-test-email-with-parameters.cy.spec.js
@@ -5,6 +5,7 @@ import {
   setupSMTP,
   sidebar,
   visitDashboard,
+  clickSend,
 } from "__support__/e2e/cypress";
 
 import { USERS, SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
@@ -45,8 +46,7 @@ describeEE("issue 18669", () => {
       cy.button("Update filter").click();
     });
 
-    cy.button("Send email now").click();
-    cy.findByText("Email sent", { timeout: 10000 });
+    clickSend();
   });
 });
 

--- a/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
@@ -7,8 +7,10 @@ import {
   mockSlackConfigured,
   isOSS,
   visitDashboard,
+  clickSend,
 } from "__support__/e2e/cypress";
 import { USERS } from "__support__/e2e/cypress_data";
+
 const { admin } = USERS;
 
 describe("scenarios > dashboard > subscriptions", () => {
@@ -216,8 +218,7 @@ describe("scenarios > dashboard > subscriptions", () => {
       });
       // Click anywhere outside to close the popover
       cy.findByText("15705D").click();
-      cy.findByText("Send email now").click();
-      cy.findByText("Email sent");
+      clickSend();
       cy.request("GET", "http://localhost:80/email").then(({ body }) => {
         expect(body[0].html).not.to.include(
           "An error occurred while displaying this card.",
@@ -240,9 +241,7 @@ describe("scenarios > dashboard > subscriptions", () => {
       assignRecipient();
       // Click outside popover to close it and at the same time check that the text card content is shown as expected
       cy.findByText(TEXT_CARD).click();
-      cy.findByText("Send email now").click();
-      cy.findByText(/^Sending/);
-      cy.findByText("Email sent");
+      clickSend();
       cy.request("GET", "http://localhost:80/email").then(({ body }) => {
         expect(body[0].html).to.include(TEXT_CARD);
       });


### PR DESCRIPTION
According to stats, this is the top reported flake in the last 90 days.
<img width="781" alt="image" src="https://user-images.githubusercontent.com/31325167/161447169-cfbab08a-045e-4dbb-bdd7-c7f19ea0dd37.png">

It's actually quite silly. Depending on the external factors, the string "Email sent" can be slow to appear. Cypress times out and fails. 

![image](https://user-images.githubusercontent.com/31325167/161447204-dd4df3d6-4af6-4833-bb44-ae6e539a6d84.png)

This PR adds 30s timeout which should be enough to prevent the flake in the future.
