### PR TITLE
Fix data model perms graph to always include "schemas" key at top level

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions_test.clj
@@ -160,7 +160,7 @@
       (premium-features-test/with-premium-features #{:advanced-permissions}
         (testing "Data model perms for an entire DB can be set and revoked"
           (ee-perms/update-db-data-model-permissions! group-id (mt/id) {:schemas :all})
-          (is (= :all
+          (is (= {:schemas :all}
                  (data-model-perms-by-group-id group-id)))
 
           (ee-perms/update-db-data-model-permissions! group-id (mt/id) {:schemas :none})

--- a/src/metabase/models/permissions/parse.clj
+++ b/src/metabase/models/permissions/parse.clj
@@ -107,7 +107,7 @@
     ;; data model perms
     [:data-model db-node]          (path2 db-node)
     [:dm-db db-id]                 (let [db-id (Long/parseUnsignedLong db-id)]
-                                     [:db db-id :data-model :all])
+                                     [:db db-id :data-model :schemas :all])
     [:dm-db db-id db-node]         (let [db-id (Long/parseUnsignedLong db-id)]
                                      (into [:db db-id :data-model :schemas] (path2 db-node)))
     [:dm-schema schema-name]       [schema-name :all]

--- a/test/metabase/models/permissions/parse_test.clj
+++ b/test/metabase/models/permissions/parse_test.clj
@@ -26,7 +26,7 @@
       "/download/limited/db/3/schema/PUBLIC/"         {:db {3 {:download {:schemas {"PUBLIC" :limited}}}}}
       "/download/db/3/schema/PUBLIC/table/4/"         {:db {3 {:download {:schemas {"PUBLIC" {4 :full}}}}}}
       "/download/limited/db/3/schema/PUBLIC/table/4/" {:db {3 {:download {:schemas {"PUBLIC" {4 :limited}}}}}}
-      "/data-model/db/3/"                             {:db {3 {:data-model :all}}}
+      "/data-model/db/3/"                             {:db {3 {:data-model {:schemas :all}}}}
       "/data-model/db/3/schema/PUBLIC/"               {:db {3 {:data-model {:schemas {"PUBLIC" :all}}}}}
       "/data-model/db/3/schema/PUBLIC/table/4/"       {:db {3 {:data-model {:schemas {"PUBLIC" {4 :all}}}}}}
       "/details/db/3/"                                {:db {3 {:details :yes}}})))


### PR DESCRIPTION
Tiny fix to include `schemas` in the data model perms graph even when the perms are `all` for the entire DB