### PR TITLE
Reset dashboard state when leaving the page

### DIFF
--- a/frontend/src/metabase/dashboard/actions.js
+++ b/frontend/src/metabase/dashboard/actions.js
@@ -80,6 +80,7 @@ const dashboard = new schema.Entity("dashboard", {
 // action constants
 
 export const INITIALIZE = "metabase/dashboard/INITIALIZE";
+export const RESET = "metabase/dashboard/RESET";
 
 export const SET_EDITING_DASHBOARD = "metabase/dashboard/SET_EDITING_DASHBOARD";
 
@@ -143,6 +144,7 @@ export const SET_SHOW_LOADING_COMPLETE_FAVICON =
   "metabase/dashboard/SET_SHOW_LOADING_COMPLETE_FAVICON";
 
 export const initialize = createAction(INITIALIZE);
+export const reset = createAction(RESET);
 export const setEditingDashboard = createAction(SET_EDITING_DASHBOARD);
 
 export const setSidebar = createAction(SET_SIDEBAR);

--- a/frontend/src/metabase/dashboard/containers/DashboardApp.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp.jsx
@@ -133,6 +133,10 @@ export default class DashboardApp extends Component {
     }
   }
 
+  componentWillUnmount() {
+    this.props.reset();
+  }
+
   render() {
     const { editingOnLoad, addCardOnLoad } = this.state;
 

--- a/frontend/src/metabase/dashboard/reducers.js
+++ b/frontend/src/metabase/dashboard/reducers.js
@@ -34,6 +34,7 @@ import {
   SAVE_DASHBOARD_AND_CARDS,
   SET_DASHBOARD_SEEN,
   SET_SHOW_LOADING_COMPLETE_FAVICON,
+  RESET,
 } from "./actions";
 
 import { isVirtualDashCard, syncParametersAndEmbeddingParams } from "./utils";
@@ -44,6 +45,7 @@ const dashboardId = handleActions(
     [FETCH_DASHBOARD]: {
       next: (state, { payload: { dashboardId } }) => dashboardId,
     },
+    [RESET]: { next: state => null },
   },
   null,
 );
@@ -54,6 +56,7 @@ const isEditing = handleActions(
     [SET_EDITING_DASHBOARD]: {
       next: (state, { payload }) => (payload ? payload : null),
     },
+    [RESET]: { next: state => null },
   },
   null,
 );
@@ -65,6 +68,7 @@ const hasSeenLoadedDashboard = handleActions(
     [SET_DASHBOARD_SEEN]: {
       next: state => true,
     },
+    [RESET]: { next: state => false },
   },
   false,
 );
@@ -76,6 +80,7 @@ const showLoadingCompleteFavicon = handleActions(
     [SET_SHOW_LOADING_COMPLETE_FAVICON]: {
       next: (state, { payload }) => payload,
     },
+    [RESET]: { next: state => false },
   },
   false,
 );
@@ -224,6 +229,7 @@ const isAddParameterPopoverOpen = handleActions(
     [SHOW_ADD_PARAMETER_POPOVER]: () => true,
     [HIDE_ADD_PARAMETER_POPOVER]: () => false,
     [INITIALIZE]: () => false,
+    [RESET]: () => false,
   },
   false,
 );
@@ -247,6 +253,7 @@ const dashcardData = handleActions(
           .dissoc(oldDashcardId)
           .value(),
     },
+    [RESET]: { next: state => ({}) },
   },
   {},
 );
@@ -275,6 +282,7 @@ const parameterValues = handleActions(
     [FETCH_DASHBOARD]: {
       next: (state, { payload: { parameterValues } }) => parameterValues,
     },
+    [RESET]: { next: state => ({}) },
   },
   {},
 );
@@ -289,6 +297,7 @@ const parameterValuesSearchCache = handleActions(
       next: (state, { payload }) =>
         payload ? assoc(state, payload.cacheKey, payload.results) : state,
     },
+    [RESET]: { next: state => ({}) },
   },
   {},
 );
@@ -346,6 +355,12 @@ const loadingDashCards = handleActions(
         };
       },
     },
+    [RESET]: {
+      next: state => ({
+        ...state,
+        isLoadingComplete: false,
+      }),
+    },
   },
   {
     dashcardIds: [],
@@ -358,6 +373,9 @@ const loadingDashCards = handleActions(
 const DEFAULT_SIDEBAR = { props: {} };
 const sidebar = handleActions(
   {
+    [INITIALIZE]: {
+      next: () => DEFAULT_SIDEBAR,
+    },
     [SET_SIDEBAR]: {
       next: (state, { payload: { name, props } }) => ({
         name,
@@ -367,14 +385,14 @@ const sidebar = handleActions(
     [CLOSE_SIDEBAR]: {
       next: () => DEFAULT_SIDEBAR,
     },
-    [INITIALIZE]: {
-      next: () => DEFAULT_SIDEBAR,
-    },
     [SET_EDITING_DASHBOARD]: {
       next: (state, { payload: isEditing }) =>
         isEditing ? state : DEFAULT_SIDEBAR,
     },
     [REMOVE_PARAMETER]: {
+      next: () => DEFAULT_SIDEBAR,
+    },
+    [RESET]: {
       next: () => DEFAULT_SIDEBAR,
     },
   },


### PR DESCRIPTION
Fixes a bug with the new navigation remaining hidden if you exit a dashboard page with a browser back button in the editing mode.

Before, we were not hiding the navbar because it was only at the top of the page. But having both sidebar and app bar doesn't make a lot of sense while you're editing a dashboard, so we made them hide. However, if you leave the dashboard page using a browser back button, the dashboard state won't be reset, so `isEditing` property will stay `true` and the navigation won't show up. Fixed by adding a new `reset` dashboard action dispatched when a dashboard is unmounted and cleans up the dashboard's redux state.

### To Verify

1. Open a dashboard, click the pencil icon on the right side of the dashboard header to turn on the editing mode
2. Make sure the app bar and the sidebar are hidden and you can only see the dashboard + the blue edit bar at the top
3. Click the browser back button. Ensure the nav worked correctly and you can now see the app bar and the sidebar

### Demo

**Before**

https://user-images.githubusercontent.com/17258145/161563311-d04209cf-ee66-4195-b943-4130c592f166.mp4

**After**

https://user-images.githubusercontent.com/17258145/161563335-491a54ad-be51-4d10-b7f6-c3d96d957add.mp4


