### PR TITLE
[E2E] Remove type delay to avoid lose of focus

### DIFF
--- a/frontend/test/metabase/scenarios/native-filters/helpers/e2e-field-filter-helpers.js
+++ b/frontend/test/metabase/scenarios/native-filters/helpers/e2e-field-filter-helpers.js
@@ -28,7 +28,7 @@ export function setWidgetType(type) {
 export function addWidgetStringFilter(value) {
   popover()
     .find("input")
-    .type(`${value}{enter}`);
+    .type(`${value}{enter}`, { delay: 0 });
   cy.button("Add filter").click();
 }
 
@@ -161,7 +161,9 @@ function addSimpleNumberFilter(value) {
  * @param {string} value
  */
 function enterDefaultValue(value) {
-  cy.findByPlaceholderText("Enter a default value...").type(`${value}{enter}`);
+  cy.findByPlaceholderText("Enter a default value...").type(`${value}{enter}`, {
+    delay: 0,
+  });
   cy.button("Add filter").click();
 }
 
@@ -170,7 +172,7 @@ function enterDefaultValue(value) {
  * @param {string} result
  */
 export function pickDefaultValue(searchTerm, result) {
-  cy.findByPlaceholderText("Enter a default value...").type(searchTerm);
+  cy.findByPlaceholderText("Enter a default value...").type(searchTerm, { delay: 0} );
   popover()
     .findByText(result)
     .click();

--- a/frontend/test/metabase/scenarios/native-filters/helpers/e2e-field-filter-helpers.js
+++ b/frontend/test/metabase/scenarios/native-filters/helpers/e2e-field-filter-helpers.js
@@ -172,7 +172,9 @@ function enterDefaultValue(value) {
  * @param {string} result
  */
 export function pickDefaultValue(searchTerm, result) {
-  cy.findByPlaceholderText("Enter a default value...").type(searchTerm, { delay: 0} );
+  cy.findByPlaceholderText("Enter a default value...").type(searchTerm, {
+    delay: 0,
+  });
   popover()
     .findByText(result)
     .click();


### PR DESCRIPTION
### Status
PENDING REVIEW 

### What does this PR accomplish?
- This PR is to remove a flaky we were having when the typing was being interrupted by the autocomplete. To accomplish that the typing delay was removed.

<img width="1055" alt="Screen Shot 2022-04-04 at 12 11 17" src="https://user-images.githubusercontent.com/17742979/161574838-07979d07-01a5-43ae-960f-908586cb2ec6.png">

<img width="1091" alt="Screen Shot 2022-04-04 at 12 09 13" src="https://user-images.githubusercontent.com/17742979/161574452-75650dbf-72eb-456c-b8e2-88be1764c893.png">

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/native-filters/sql-field-filter-string.cy.spec.js`
- All tests should pass

### Screenshots:

![Screen Shot 2022-04-04 at 12 10 53](https://user-images.githubusercontent.com/17742979/161574763-583d686f-f79a-40ee-ae91-06ca9132ddb3.png)

