### PR TITLE
Bump `clojure` CLI to the latest version in CI

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,5 +7,5 @@ RUN apt-key adv --refresh-keys --keyserver keyserver.ubuntu.com\
 RUN curl -fsSL https://deb.nodesource.com/setup_14.x | bash
 RUN apt-get update && apt-get -y install --no-install-recommends nodejs
 
-RUN curl -O https://download.clojure.org/install/linux-install-1.10.3.933.sh \
-  && bash ./linux-install-1.10.3.933.sh
+RUN curl -O https://download.clojure.org/install/linux-install-1.11.0.1100.sh \
+  && bash ./linux-install-1.11.0.1100.sh

--- a/.github/actions/prepare-backend/action.yml
+++ b/.github/actions/prepare-backend/action.yml
@@ -5,7 +5,7 @@ inputs:
     default: '11'
   clojure-version:
     required: true
-    default: '1.10.3.933'
+    default: '1.11.0.1100'
   m2-cache-key:
     description: 'Key to cache M2 packages from Maven Central'
     required: true

--- a/.github/scripts/run-presto-kerberos-integration-test.sh
+++ b/.github/scripts/run-presto-kerberos-integration-test.sh
@@ -9,9 +9,9 @@ export PATH="$PATH:$JAVA_HOME/bin"
 which java
 
 # install clojure version needed for Metabase
-curl -O https://download.clojure.org/install/linux-install-1.10.3.933.sh
-chmod +x linux-install-1.10.3.933.sh
-./linux-install-1.10.3.933.sh
+curl -O https://download.clojure.org/install/linux-install-1.11.0.1100.sh
+chmod +x linux-install-1.11.0.1100.sh
+./linux-install-1.11.0.1100.sh
 
 RESOURCES_DIR=/app/source/resources
 


### PR DESCRIPTION
As @dpsutton noted, we were using quite outdated version of clojure CLI [v1.10.3.933](https://clojure.org/releases/tools#v1.10.3.933) from July 28, 2021

This PR bumps that to the latest available version [v1.11.0.1100](https://clojure.org/releases/tools#v1.11.0.1100) from Mar, 28 2022.