### PR TITLE
Data model permissions enforcement part 1

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/common.clj
@@ -10,7 +10,8 @@
     (assoc user :permissions
            {:can_access_setting      (perms/set-has-general-permission-of-type? permissions-set :setting)
             :can_access_subscription (perms/set-has-general-permission-of-type? permissions-set :subscription)
-            :can_access_monitoring   (perms/set-has-general-permission-of-type? permissions-set :monitoring)})))
+            :can_access_monitoring   (perms/set-has-general-permission-of-type? permissions-set :monitoring)
+            :can_access_data_model   (perms/set-has-partial-permissions? permissions-set "/data-model/")})))
 
 (defn current-user-has-general-permissions?
   "Check if `*current-user*` has permissions for a general permissions of type `perm-type`."

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/general_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/general_test.clj
@@ -63,21 +63,3 @@
                             :setting      "yes"
                             :subscription "no"}}
                           (:groups (mt/user-http-request :crowberto :put 200 "ee/advanced-permissions/general/graph" new-graph))))))))))
-
-(deftest current-user-test
-  (testing "GET /api/user/current returns additional fields if advanced-permissions is enabled"
-    (premium-features-test/with-premium-features #{:advanced-permissions}
-      (letfn [(user-general-permissions [user]
-                (-> (mt/user-http-request user :get 200 "user/current")
-                    :permissions))]
-        (testing "admins should have full general permisions"
-          (is (= {:can_access_setting true
-                  :can_access_subscription true
-                  :can_access_monitoring true}
-                 (user-general-permissions :crowberto))))
-
-        (testing "non-admin users should only have subscriptions enabled"
-          (is (= {:can_access_setting false
-                  :can_access_subscription true
-                  :can_access_monitoring false}
-                 (user-general-permissions :rasta))))))))

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -14,7 +14,7 @@
       (letfn [(user-permissions [user]
                 (-> (mt/user-http-request user :get 200 "user/current")
                     :permissions))]
-        (testing "admins should have full general permisions"
+        (testing "admins should have full advanced permisions"
           (is (= {:can_access_setting      true
                   :can_access_subscription true
                   :can_access_monitoring   true

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -1,7 +1,7 @@
 (ns metabase-enterprise.advanced-permissions.common-test
   (:require [clojure.test :refer :all]
             [metabase-enterprise.advanced-permissions.models.permissions :as ee-perms]
-            [metabase.models :refer [Permissions PermissionsGroup]]
+            [metabase.models :refer [Permissions]]
             [metabase.models.database :as database]
             [metabase.models.permissions-group :as group]
             [metabase.public-settings.premium-features-test :as premium-features-test]

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -1,0 +1,41 @@
+(ns metabase-enterprise.advanced-permissions.common-test
+  (:require [clojure.test :refer :all]
+            [metabase-enterprise.advanced-permissions.models.permissions :as ee-perms]
+            [metabase.models :refer [Permissions PermissionsGroup]]
+            [metabase.models.database :as database]
+            [metabase.models.permissions-group :as group]
+            [metabase.public-settings.premium-features-test :as premium-features-test]
+            [metabase.test :as mt]
+            [metabase.util :as u]))
+
+(deftest current-user-test
+  (testing "GET /api/user/current returns additional fields if advanced-permissions is enabled"
+    (premium-features-test/with-premium-features #{:advanced-permissions}
+      (letfn [(user-permissions [user]
+                (-> (mt/user-http-request user :get 200 "user/current")
+                    :permissions))]
+        (testing "admins should have full general permisions"
+          (is (= {:can_access_setting      true
+                  :can_access_subscription true
+                  :can_access_monitoring   true
+                  :can_access_data_model   true}
+                 (user-permissions :crowberto))))
+
+        (testing "non-admin users should only have subscriptions enabled by default"
+          (is (= {:can_access_setting      false
+                  :can_access_subscription true
+                  :can_access_monitoring   false
+                  :can_access_data_model   false}
+                 (user-permissions :rasta))))
+
+        (testing "can_access_data_model is true if a user has any data model perms"
+          (mt/with-model-cleanup [Permissions]
+            (let [[id-1 id-2 id-3 id-4] (map u/the-id (database/tables (mt/db)))]
+              (ee-perms/update-db-data-model-permissions! (u/the-id (group/all-users))
+                                                          (mt/id)
+                                                          {:schemas {"PUBLIC" {id-1 :all
+                                                                               id-2 :all
+                                                                               id-3 :all
+                                                                               id-4 :all}}}))
+            (is (partial= {:can_access_data_model   true}
+                          (user-permissions :rasta)))))))))

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -327,9 +327,10 @@
                           tables)))))
 
 (api/defendpoint GET "/:id/metadata"
-  "Get metadata about a `Database`, including all of its `Tables` and `Fields`.
-   By default only non-hidden tables and fields are returned. Passing include_hidden=true includes them.
-   Returns DB, fields, and field values."
+  "Get metadata about a `Database`, including all of its `Tables` and `Fields`. Returns DB, fields, and field values.
+  By default only non-hidden tables and fields are returned. Passing include_hidden=true includes them.
+  Passing exclude_uneditable=true will only return tables for which the current user has data model editing
+  permissions, if Enterprise Edition code is available and a token with the advanced-permissions feature is present."
   [id include_hidden exclude_uneditable]
   {include_hidden     (s/maybe su/BooleanString)
    exclude_uneditable (s/maybe su/BooleanString)}

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -281,6 +281,7 @@
              (assoc resp :tables (filter #(= "CATEGORIES" (:name %)) (:tables resp))))))))
 
 (deftest fetch-database-metadata-include-hidden-test
+  ;; NOTE: test for the exclude_uneditable parameter lives in metabase-enterprise.advanced-permissions.common-test
   (mt/with-temp-vals-in-db Table (mt/id :categories) {:visibility_type "hidden"}
     (mt/with-temp-vals-in-db Field (mt/id :venues :price) {:visibility_type "sensitive"}
       (testing "GET /api/database/:id/metadata?include_hidden=true"


### PR DESCRIPTION
Part 1 for enforcement of data model perms 
* Adds `:can_access_data_model` to `/api/user/current`
* Adds an `exclude_uneditable` flag to `/api/database/:id/metadata
* New `metabase-enterprise.advanced-permissions.common-test` namespace, which can hold misc tests for APIs that have different permissions-related behavior in EE