### PR TITLE
Fix MongoDB's native query preview overflow

### DIFF
--- a/frontend/src/metabase/lib/engine.js
+++ b/frontend/src/metabase/lib/engine.js
@@ -78,9 +78,9 @@ export function getEngineSupportsFirewall(engine) {
 export function formatJsonQuery(query, engine) {
   if (engine === "googleanalytics") {
     return formatGAQuery(query);
-  } else {
-    return JSON.stringify(query, null, 2);
   }
+
+  return JSON.stringify(query, null, 2);
 }
 
 export function formatNativeQuery(query, engine) {

--- a/frontend/src/metabase/lib/engine.js
+++ b/frontend/src/metabase/lib/engine.js
@@ -79,7 +79,7 @@ export function formatJsonQuery(query, engine) {
   if (engine === "googleanalytics") {
     return formatGAQuery(query);
   } else {
-    return JSON.stringify(query);
+    return JSON.stringify(query, null, 2);
   }
 }
 

--- a/frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx
+++ b/frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx
@@ -88,6 +88,7 @@ export default class NativeQueryButton extends React.Component {
           <SqlIconButton iconSize={size} onClick={this.handleOpen} />
         </Tooltip>
         <Modal
+          style={{ padding: "1em" }}
           isOpen={this.state.open}
           title={title}
           footer={

--- a/frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx
+++ b/frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx
@@ -10,7 +10,11 @@ import Tooltip from "metabase/components/Tooltip";
 import { formatNativeQuery, getEngineNativeType } from "metabase/lib/engine";
 import { MetabaseApi } from "metabase/services";
 
-import { SqlIconButton } from "./NativeQueryButton.styled";
+import {
+  NativeCodeWrapper,
+  NativeCodeContainer,
+  SqlIconButton,
+} from "./NativeQueryButton.styled";
 
 const STRINGS = {
   "": {
@@ -96,7 +100,11 @@ export default class NativeQueryButton extends React.Component {
           onClose={this.handleClose}
         >
           <LoadingAndErrorWrapper loading={loading} error={error}>
-            <pre className="mb3 p2 sql-code">{this.getFormattedQuery()}</pre>
+            <NativeCodeWrapper>
+              <NativeCodeContainer className="p2 sql-code">
+                {this.getFormattedQuery()}
+              </NativeCodeContainer>
+            </NativeCodeWrapper>
           </LoadingAndErrorWrapper>
         </Modal>
       </span>

--- a/frontend/src/metabase/query_builder/components/view/NativeQueryButton.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/view/NativeQueryButton.styled.jsx
@@ -1,7 +1,12 @@
 import styled from "@emotion/styled";
 
 import { color } from "metabase/lib/colors";
-import { space } from "metabase/styled-components/theme";
+import {
+  breakpointMinHeightExtraSmall,
+  breakpointMinHeightMedium,
+  breakpointMinHeightSmall,
+  space,
+} from "metabase/styled-components/theme";
 import Button from "metabase/core/components/Button";
 
 export const SqlIconButton = styled(Button)`
@@ -37,11 +42,23 @@ export const NativeCodeContainer = styled.code`
   box-sizing: border-box;
   display: inline-block;
   margin: 0;
-  max-height: 30vh;
+  max-height: 20vh;
   max-width: 100%;
   overflow: auto;
   vertical-align: bottom;
   white-space: pre;
   width: 100%;
   word-break: break-all;
+
+  ${breakpointMinHeightExtraSmall} {
+    max-height: 25vh;
+  }
+
+  ${breakpointMinHeightSmall} {
+    max-height: 45vh;
+  }
+
+  ${breakpointMinHeightMedium} {
+    max-height: 60vh;
+  }
 `;

--- a/frontend/src/metabase/query_builder/components/view/NativeQueryButton.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/view/NativeQueryButton.styled.jsx
@@ -21,3 +21,27 @@ export const SqlIconButton = styled(Button)`
 SqlIconButton.defaultProps = {
   icon: "sql",
 };
+
+export const NativeCodeWrapper = styled.pre`
+  box-sizing: border-box;
+  display: inline-block;
+  margin: 0;
+  padding: 0;
+  max-width: 100%;
+  overflow: hidden;
+  vertical-align: bottom;
+  width: 100%;
+`;
+
+export const NativeCodeContainer = styled.code`
+  box-sizing: border-box;
+  display: inline-block;
+  margin: 0;
+  max-height: 30vh;
+  max-width: 100%;
+  overflow: auto;
+  vertical-align: bottom;
+  white-space: pre;
+  width: 100%;
+  word-break: break-all;
+`;

--- a/frontend/src/metabase/styled-components/theme/media-queries.ts
+++ b/frontend/src/metabase/styled-components/theme/media-queries.ts
@@ -9,3 +9,11 @@ export const breakpointMaxSmall = "@media screen and (max-width: 40em)";
 export const breakpointMaxMedium = "@media screen and (max-width: 60em)";
 export const breakpointMaxLarge = "@media screen and (max-width: 80em)";
 export const breakpointMaxExtraLarge = "@media screen and (max-width: 120em)";
+
+export const breakpointMinHeightExtraSmall =
+  "@media screen and (min-height: 20em)";
+export const breakpointMinHeightSmall = "@media screen and (min-height: 30em)";
+export const breakpointMinHeightMedium = "@media screen and (min-height: 45em)";
+export const breakpointMinHeightLarge = "@media screen and (min-height: 60em)";
+export const breakpointMinHeightExtraLarge =
+  "@media screen and (min-height: 80em)";


### PR DESCRIPTION
Fixes #21018

There could be 2 simple ways to fix this. By replacing this line https://github.com/metabase/metabase/blob/59d222b88eac438938b515a709dbea457ee4fc37/frontend/src/metabase/lib/engine.js#L82
with 
1. Add space between each key to allow text to wrap
    ```js
    return String(JSON.stringify(query)).replaceAll('","', '", "');
    ```
2. Use JSON.stringify's builtin `space`
    ```js
    return return JSON.stringify(query, null, 2);
    ```

### Screenshots
#### Before the fix
![image](https://user-images.githubusercontent.com/1937582/161724182-a720c0d5-8842-4d00-b7e7-d5edbbebdc60.png)

#### After the first option
![localhost_3000_question_notebook (3)](https://user-images.githubusercontent.com/1937582/161723181-bfda5e74-b337-4427-b46b-536ec242105d.png)

#### After the second option
![localhost_3000_question_notebook (2)](https://user-images.githubusercontent.com/1937582/161723066-f1a196fe-8884-42bf-b531-35f324aa3cda.png)

I personally think the second option looks better, so I went with it.