### PR TITLE
[E2E] Fix 13455 flake

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -3,7 +3,7 @@ name: E2E Tests
 on:
   push:
     branches:
-      - 'e2e-fix-13455-flake'
+      - 'master'
     paths-ignore:
       - "docs/**"
       - "**.md"
@@ -53,6 +53,26 @@ jobs:
       fail-fast: false
       matrix:
         edition: [oss, ee]
+        folder:
+          - "admin"
+          - "binning"
+          - "collections"
+          - "custom-column"
+          - "dashboard"
+          - "dashboard-filters"
+          - "dashboard-filters-sql"
+          - "downloads"
+          - "embedding"
+          - "joins"
+          - "models"
+          - "moderation"
+          - "native"
+          - "native-filters"
+          - "onboarding"
+          - "permissions"
+          - "question"
+          - "sharing"
+          - "visualizations"
     services:
       maildev:
         image: maildev/maildev:1.1.0
@@ -103,8 +123,8 @@ jobs:
         jar xf target/uberjar/metabase.jar version.properties
         mv version.properties resources/
 
-    - name: Stress test the fix
-      run: yarn run test-cypress-no-build --spec "frontend/test/metabase/scenarios/question/settings.cy.spec.js" --env grep="13455",burn=20
+    - name: Run Cypress tests on ${{ matrix.folder }}
+      run: yarn run test-cypress-no-build --folder ${{ matrix.folder }} --record --key ${{ secrets.CURRENTS_KEY }} --group ${{ matrix.folder }}-${{ matrix.edition }} --ci-build-id "${{ github.run_id }}-${{ github.run_attempt }}"
       env:
         TERM: xterm
 
@@ -112,7 +132,7 @@ jobs:
       uses: actions/upload-artifact@v2
       if: failure()
       with:
-        name: cypress-recording-flake-fix-${{ matrix.edition }}
+        name: cypress-recording-${{ matrix.folder }}-${{ matrix.edition }}
         path: |
           ./cypress
           ./logs/test.log

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -3,7 +3,7 @@ name: E2E Tests
 on:
   push:
     branches:
-      - 'master'
+      - 'e2e-fix-13455-flake'
     paths-ignore:
       - "docs/**"
       - "**.md"
@@ -53,26 +53,6 @@ jobs:
       fail-fast: false
       matrix:
         edition: [oss, ee]
-        folder:
-          - "admin"
-          - "binning"
-          - "collections"
-          - "custom-column"
-          - "dashboard"
-          - "dashboard-filters"
-          - "dashboard-filters-sql"
-          - "downloads"
-          - "embedding"
-          - "joins"
-          - "models"
-          - "moderation"
-          - "native"
-          - "native-filters"
-          - "onboarding"
-          - "permissions"
-          - "question"
-          - "sharing"
-          - "visualizations"
     services:
       maildev:
         image: maildev/maildev:1.1.0
@@ -123,8 +103,8 @@ jobs:
         jar xf target/uberjar/metabase.jar version.properties
         mv version.properties resources/
 
-    - name: Run Cypress tests on ${{ matrix.folder }}
-      run: yarn run test-cypress-no-build --folder ${{ matrix.folder }} --record --key ${{ secrets.CURRENTS_KEY }} --group ${{ matrix.folder }}-${{ matrix.edition }} --ci-build-id "${{ github.run_id }}-${{ github.run_attempt }}"
+    - name: Stress test the fix
+      run: yarn run test-cypress-no-build --spec "frontend/test/metabase/scenarios/question/settings.cy.spec.js" --env grep="13455",burn=20
       env:
         TERM: xterm
 
@@ -132,7 +112,7 @@ jobs:
       uses: actions/upload-artifact@v2
       if: failure()
       with:
-        name: cypress-recording-${{ matrix.folder }}-${{ matrix.edition }}
+        name: cypress-recording-flake-fix-${{ matrix.edition }}
         path: |
           ./cypress
           ./logs/test.log

--- a/frontend/test/metabase/scenarios/question/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/settings.cy.spec.js
@@ -137,14 +137,15 @@ describe("scenarios > question > settings", () => {
       cy.findByText("Address")
         .siblings(".Icon-add")
         .click();
-      // The result automatically load when adding new fields
-      cy.wait("@dataset");
 
       // Refresh @sidebarColumns as we added a new field
       cy.findByText("Click and drag to change their order")
         .parent()
         .find(".cursor-grab")
         .as("sidebarColumns"); // Store all columns in an array
+      // The result automatically load when adding new fields but two requests are fired.
+      // Please see: https://github.com/metabase/metabase/pull/21338#discussion_r842816687
+      cy.wait(["@dataset", "@dataset"]);
 
       findColumnAtIndex("User → Address", -1).as("user-address");
 

--- a/frontend/test/metabase/scenarios/question/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/settings.cy.spec.js
@@ -136,9 +136,6 @@ describe("scenarios > question > settings", () => {
       cy.findByText("Address")
         .siblings(".Icon-add")
         .click();
-      /**
-       * Helper functions related to THIS test only
-       */
       // The result automatically load when adding new fields
       cy.wait("@dataset");
 
@@ -157,6 +154,9 @@ describe("scenarios > question > settings", () => {
         .trigger("mouseup", 0, -50, { force: true });
 
       findColumnAtIndex("User → Address", 15);
+      /**
+       * Helper functions related to THIS test only
+       */
 
       function reloadResults() {
         cy.icon("play")

--- a/frontend/test/metabase/scenarios/question/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/settings.cy.spec.js
@@ -114,19 +114,26 @@ describe("scenarios > question > settings", () => {
         .trigger("mouseup", 0, -300, { force: true });
 
       reloadResults();
+
       findColumnAtIndex("Products → Category", 5);
+
       // Remove "Total"
       getSidebarColumns()
         .contains("Total")
         .closest(".cursor-grab")
         .find(".Icon-close")
         .click();
+
       reloadResults();
+
       cy.findByText("117.03").should("not.exist");
+
       // This click doesn't do anything, but simply allows the array to be updated (test gives false positive without this step)
       cy.findByText("Visible columns").click();
+
       findColumnAtIndex("Products → Category", 5);
 
+      // We need to do some additional checks. Please see:
       // https://github.com/metabase/metabase/pull/21338#pullrequestreview-928807257
 
       // Add "Address"
@@ -140,6 +147,7 @@ describe("scenarios > question > settings", () => {
 
       findColumnAtIndex("User → Address", -1).as("user-address");
 
+      // Move it one place up
       cy.get("@user-address")
         .trigger("mousedown", 0, 0, { force: true })
         .trigger("mousemove", 5, 5, { force: true })

--- a/frontend/test/metabase/scenarios/question/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/settings.cy.spec.js
@@ -100,12 +100,8 @@ describe("scenarios > question > settings", () => {
       });
 
       cy.findByText("Settings").click();
-      cy.findByTextEnsureVisible("Click and drag to change their order")
-        .parent()
-        .find(".cursor-grab")
-        .as("sidebarColumns"); // Store all columns in an array
 
-      cy.get("@sidebarColumns")
+      getSidebarColumns()
         .eq("12")
         .as("prod-category")
         .contains(/Products? → Category/);
@@ -120,7 +116,7 @@ describe("scenarios > question > settings", () => {
       reloadResults();
       findColumnAtIndex("Products → Category", 5);
       // Remove "Total"
-      cy.get("@sidebarColumns")
+      getSidebarColumns()
         .contains("Total")
         .closest(".cursor-grab")
         .find(".Icon-close")
@@ -138,11 +134,6 @@ describe("scenarios > question > settings", () => {
         .siblings(".Icon-add")
         .click();
 
-      // Refresh @sidebarColumns as we added a new field
-      cy.findByText("Click and drag to change their order")
-        .parent()
-        .find(".cursor-grab")
-        .as("sidebarColumns"); // Store all columns in an array
       // The result automatically load when adding new fields but two requests are fired.
       // Please see: https://github.com/metabase/metabase/pull/21338#discussion_r842816687
       cy.wait(["@dataset", "@dataset"]);
@@ -156,9 +147,19 @@ describe("scenarios > question > settings", () => {
         .trigger("mouseup", 0, -50, { force: true });
 
       findColumnAtIndex("User → Address", -2);
+
       /**
        * Helper functions related to THIS test only
        */
+
+      function getSidebarColumns() {
+        return cy
+          .findByText("Click and drag to change their order")
+          .scrollIntoView()
+          .should("be.visible")
+          .parent()
+          .find(".cursor-grab");
+      }
 
       function reloadResults() {
         cy.icon("play")
@@ -171,8 +172,7 @@ describe("scenarios > question > settings", () => {
       }
 
       function findColumnAtIndex(column_name, index) {
-        return cy
-          .get("@sidebarColumns")
+        return getSidebarColumns()
           .eq(index)
           .contains(column_name);
       }

--- a/frontend/test/metabase/scenarios/question/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/settings.cy.spec.js
@@ -155,7 +155,7 @@ describe("scenarios > question > settings", () => {
         .trigger("mousemove", 0, -50, { force: true })
         .trigger("mouseup", 0, -50, { force: true });
 
-      findColumnAtIndex("User → Address", 15);
+      findColumnAtIndex("User → Address", -2);
       /**
        * Helper functions related to THIS test only
        */

--- a/frontend/test/metabase/scenarios/question/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/settings.cy.spec.js
@@ -92,6 +92,7 @@ describe("scenarios > question > settings", () => {
                 alias: "Products",
               },
             ],
+            limit: 5,
           },
           database: SAMPLE_DB_ID,
         },

--- a/frontend/test/metabase/scenarios/question/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/settings.cy.spec.js
@@ -72,7 +72,7 @@ describe("scenarios > question > settings", () => {
         .should("not.exist");
     });
 
-    it("should preserve correct order of columns after column removal via sidebar (metabase#13455)", () => {
+    it("should preserve correct order of columns after column removal or addition via sidebar (metabase#13455)", () => {
       cy.viewport(2000, 1200);
       // Orders join Products
       visitQuestionAdhoc({


### PR DESCRIPTION
Immediately after https://github.com/metabase/metabase/pull/21338 has been merged, the added e2e test started flaking. This PR attempts to fixing it.

I cannot see **exactly** why it started flaking, but my guess is that it has something to do with aliasing the contents that is changing. Thus, the solution consists in completely avoiding aliases and using the helper to always get "fresh" set of needed UI elements.

This is a stress-test run that came back green after testing this fix x20.
https://github.com/metabase/metabase/actions/runs/2098375694