### PR TITLE
Remove unnecessary steps from the `e2e` job

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -3,7 +3,7 @@ name: E2E Tests
 on:
   push:
     branches:
-      - 'master'
+      - 'e2e-optimize-e2e-job'
     paths-ignore:
       - "docs/**"
       - "**.md"
@@ -52,6 +52,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        java-version: [11]
         edition: [oss, ee]
         folder:
           - "admin"
@@ -107,8 +108,11 @@ jobs:
     - uses: actions/checkout@v3
     - name: Prepare front-end environment
       uses: ./.github/actions/prepare-frontend
-    - name: Prepare back-end environment
-      uses: ./.github/actions/prepare-backend
+    - name: Prepare JDK ${{ matrix.java-version }}
+      uses: actions/setup-java@v3
+      with:
+        java-version: ${{ matrix.java-version }}
+        distribution: 'temurin'
     - name: Prepare cypress environment
       uses: ./.github/actions/prepare-cypress
     - name: Run Snowplow micro

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -3,7 +3,7 @@ name: E2E Tests
 on:
   push:
     branches:
-      - 'e2e-optimize-e2e-job'
+      - 'master'
     paths-ignore:
       - "docs/**"
       - "**.md"


### PR DESCRIPTION
Once again, the credit goes to @pawit-metabase for this suggestion.

We don't need to install clojure or to get the M2 cache in `e2e` job.
This PR removes `prepare-backend` step and only prepares the JDK.

It's not so much about the speed improvement (because we're saving only 10s pre run), as much as it is about removing the confusion for anyone who might be looking at these steps in the future.