### PR TITLE
[E2E] Dedicate the current E2E tests for master only

### DIFF
--- a/.github/workflows/e2e-master.yml
+++ b/.github/workflows/e2e-master.yml
@@ -12,7 +12,7 @@ on:
 jobs:
 
   build:
-    runs-on: buildjet-2vcpu-ubuntu-2004
+    runs-on: ubuntu-20.04
     timeout-minutes: 25
     strategy:
       matrix:
@@ -38,7 +38,7 @@ jobs:
       uses: ./.github/actions/prepare-uberjar-artifact
 
   e2e-tests:
-    runs-on: buildjet-4vcpu-ubuntu-2004
+    runs-on: ubuntu-20.04
     timeout-minutes: 30
     needs: build
     name: e2e-tests-${{ matrix.folder }}-${{ matrix.edition }}


### PR DESCRIPTION
While experimenting with the migration of PR checks,`e2e-master.yml` is dedicated to run on master, with GitHub hosted runner.

Yes, there are duplicated runs in various places (building Uberjar etc), but this is intended as the temporary stopgap.