### PR TITLE
Fix XLSX exports that include NaN or Infinity

### DIFF
--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -351,10 +351,11 @@
 (defmethod set-cell! Number
   [^Cell cell value id-or-name]
   (.setCellValue cell (double value))
-  (let [styles         (u/one-or-many (cell-style id-or-name))]
-    (if (rounds-to-int? value)
-      (.setCellStyle cell (or (first styles) (cell-style :integer)))
-      (.setCellStyle cell (or (second styles) (cell-style :float))))))
+  (let [styles (u/one-or-many (cell-style id-or-name))]
+    (u/ignore-exceptions
+      (if (rounds-to-int? value)
+        (.setCellStyle cell (or (first styles) (cell-style :integer)))
+        (.setCellStyle cell (or (second styles) (cell-style :float)))))))
 
 (defmethod set-cell! Boolean
   [^Cell cell value _]

--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -350,12 +350,14 @@
 
 (defmethod set-cell! Number
   [^Cell cell value id-or-name]
-  (.setCellValue cell (double value))
-  (let [styles (u/one-or-many (cell-style id-or-name))]
-    (u/ignore-exceptions
-      (if (rounds-to-int? value)
-        (.setCellStyle cell (or (first styles) (cell-style :integer)))
-        (.setCellStyle cell (or (second styles) (cell-style :float)))))))
+  (let [v (double value)]
+    (.setCellValue cell v)
+    (when-not (or (.isInfinite v)
+                  (.isNaN v))
+      (let [styles (u/one-or-many (cell-style id-or-name))]
+        (if (rounds-to-int? v)
+          (.setCellStyle cell (or (first styles) (cell-style :integer)))
+          (.setCellStyle cell (or (second styles) (cell-style :float))))))))
 
 (defmethod set-cell! Boolean
   [^Cell cell value _]

--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -352,8 +352,7 @@
   [^Cell cell value id-or-name]
   (let [v (double value)]
     (.setCellValue cell v)
-    (when-not (or (.isInfinite v)
-                  (.isNaN v))
+    (when (u/real-number? v)
       (let [styles (u/one-or-many (cell-style id-or-name))]
         (if (rounds-to-int? v)
           (.setCellStyle cell (or (first styles) (cell-style :integer)))

--- a/src/metabase/sync/analyze/fingerprint/fingerprinters.clj
+++ b/src/metabase/sync/analyze/fingerprint/fingerprinters.clj
@@ -209,16 +209,9 @@
   ([^Histogram histogram] histogram)
   ([^Histogram histogram x] (hist/insert-simple! histogram x)))
 
-(defn real-number?
-  "Is `x` a real number (i.e. not a `NaN` or an `Infinity`)?"
-  [x]
-  (and (number? x)
-       (not (Double/isNaN x))
-       (not (Double/isInfinite x))))
-
 (deffingerprinter :type/Number
   (redux/post-complete
-   ((filter real-number?) histogram)
+   ((filter u/real-number?) histogram)
    (fn [h]
      (let [{q1 0.25 q3 0.75} (hist/percentiles h 0.25 0.75)]
        (robust-map

--- a/src/metabase/sync/analyze/fingerprint/insights.clj
+++ b/src/metabase/sync/analyze/fingerprint/insights.clj
@@ -8,6 +8,7 @@
             [metabase.models.field :as field]
             [metabase.sync.analyze.fingerprint.fingerprinters :as f]
             [metabase.sync.util :as sync-util]
+            [metabase.util :as u]
             [metabase.util.date-2 :as u.date]
             [metabase.util.i18n :refer [trs]]
             [redux.core :as redux])

--- a/src/metabase/sync/analyze/fingerprint/insights.clj
+++ b/src/metabase/sync/analyze/fingerprint/insights.clj
@@ -126,7 +126,7 @@
               (map #(assoc % :mae (transduce identity
                                              (mae (comp (:model %) first) second)
                                              validation-set)))
-              (filter (comp f/real-number? :mae))
+              (filter (comp u/real-number? :mae))
               not-empty
               (apply min-key :mae)
               :formula))))
@@ -195,7 +195,7 @@
                (redux/post-complete
                 (let [y-position (:position number-col)
                       yfn        #(nth % y-position)]
-                  ((filter (comp f/real-number? yfn))
+                  ((filter (comp u/real-number? yfn))
                    (redux/juxt ((map yfn) (last-n 2))
                                ((map xfn) (last-n 2))
                                (stats/simple-linear-regression xfn yfn)

--- a/src/metabase/sync/analyze/fingerprint/insights.clj
+++ b/src/metabase/sync/analyze/fingerprint/insights.clj
@@ -109,7 +109,7 @@
                              (stats/simple-linear-regression (comp (stats/somef x-link-fn) fx)
                                                              (comp (stats/somef y-link-fn) fy))
                              (fn [[offset slope]]
-                               (when (every? f/real-number? [offset slope])
+                               (when (every? u/real-number? [offset slope])
                                  {:model   (model offset slope)
                                   :formula (formula offset slope)}))))
                           (apply redux/juxt))

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -370,6 +370,13 @@
   {:pre [(integer? decimal-place) (number? number)]}
   (double (.setScale (bigdec number) decimal-place BigDecimal/ROUND_HALF_UP)))
 
+(defn real-number?
+  "Is `x` a real number (i.e. not a `NaN` or an `Infinity`)?"
+  [x]
+  (and (number? x)
+       (not (Double/isNaN x))
+       (not (Double/isInfinite x))))
+
 (defn- check-protocol-impl-method-map
   "Check that the methods expected for `protocol` are all implemented by `method-map`, and that no extra methods are
    provided. Used internally by `strict-extend`."

--- a/test/metabase/query_processor/streaming/xlsx_test.clj
+++ b/test/metabase/query_processor/streaming/xlsx_test.clj
@@ -436,7 +436,15 @@
       (is (= ["GB"]
              (second (xlsx-export [{:id 0, :name "Col"}] {} [["GB"]]))))
       (is (= ["Portugal"]
-             (second (xlsx-export [{:id 0, :name "Col"}] {} [["Portugal"]])))))))
+             (second (xlsx-export [{:id 0, :name "Col"}] {} [["Portugal"]]))))))
+  (testing "NaN and infinity values (#21343)"
+    ;; These values apparently are represented as error codes, which are parsed here into keywords
+    (is (= [:NUM]
+           (second (xlsx-export [{:id 0, :name "Col"}] {} [[##NaN]]))))
+    (is (= [:DIV0]
+           (second (xlsx-export [{:id 0, :name "Col"}] {} [[##Inf]]))))
+    (is (= [:DIV0]
+           (second (xlsx-export [{:id 0, :name "Col"}] {} [[##-Inf]]))))))
 
 (defrecord ^:private SampleNastyClass [^String v])
 

--- a/test/metabase/query_processor/streaming/xlsx_test.clj
+++ b/test/metabase/query_processor/streaming/xlsx_test.clj
@@ -399,6 +399,12 @@
   (testing "ints"
     (is (= [1.0]
            (second (xlsx-export [{:id 0, :name "Col"}] {} [[1]])))))
+  (testing "bigints"
+    (is (= [1.0]
+           (second (xlsx-export [{:id 0, :name "Col"}] {} [[1N]])))))
+  (testing "bigdecimals"
+    (is (= [1.23]
+           (second (xlsx-export [{:id 0, :name "Col"}] {} [[1.23M]])))))
   (testing "numbers that round to ints"
     (is (= [2.00001]
            (second (xlsx-export [{:id 0, :name "Col"}] {} [[2.00001]])))))


### PR DESCRIPTION
`rounds-to-int?` is throwing for these values since it tries to coerce the number to a `bigdec`. Let's just ignore any exceptions from that helper function to ensure that the export doesn't fail when unexpected stuff is passed in there.

Resolves #21343