### PR TITLE
Tweak bookmark button position in sidebar items

### DIFF
--- a/frontend/src/metabase/nav/containers/MainNavbar/BookmarkList/BookmarkList.styled.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/BookmarkList/BookmarkList.styled.tsx
@@ -19,6 +19,6 @@ export const SidebarBookmarkItem = styled(SidebarLink)`
     color: ${props =>
       props.isSelected ? color("text-white") : color("brand")};
     cursor: pointer;
-    margin-right: ${space(0)};
+    margin-top: 3px;
   }
 `;


### PR DESCRIPTION
### After

Ribbon icon is better centered vertically, including optical adjustment, and not so far from the right edge of the link.

<img width="488" alt="image" src="https://user-images.githubusercontent.com/380816/162002760-a5d9f662-3d15-47f6-ba16-7a387e1e3812.png">

### Before

<img width="325" alt="image" src="https://user-images.githubusercontent.com/380816/162002904-11f358b8-2e93-4aab-839b-e8cd975337a5.png">
