### PR TITLE
Handle Default Timelines

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -11341,7 +11341,7 @@ databaseChangeLog:
                 remarks: Boolean value indicating if the timeline is the default one for the containing Collection
                 name: default
                 type: boolean
-                value: false
+                defaultValue: false
                 constraints:
                   nullable: false
             tableName: timeline

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -11333,13 +11333,13 @@ databaseChangeLog:
   - changeSet:
       id: v43.00-051
       author: adam-james
-      comment: Added 0.43.0 - is_default boolean on timelines
+      comment: Added 0.43.0 - default boolean on timelines to indicate default timeline for a collection
       changes:
         - addColumn:
             columns:
             - column:
                 remarks: Boolean value indicating if the timeline is the default one for the containing Collection
-                name: is_default
+                name: default
                 type: boolean
                 value: false
                 constraints:

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -11333,13 +11333,13 @@ databaseChangeLog:
   - changeSet:
       id: v43.00-051
       author: adam-james
-      comment: Added 0.43.0 - default_name boolean on timelines
+      comment: Added 0.43.0 - is_default boolean on timelines
       changes:
         - addColumn:
             columns:
             - column:
-                remarks: Boolean value indicating if the timeline name is user provided or defaulted
-                name: default_name
+                remarks: Boolean value indicating if the timeline is the default one for the containing Collection
+                name: is_default
                 type: boolean
                 value: false
                 constraints:

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -11330,6 +11330,22 @@ databaseChangeLog:
                 AND p.object = '/general/subscription/'
               WHERE p.object IS NULL;
 
+  - changeSet:
+      id: v43.00-051
+      author: adam-james
+      comment: Added 0.43.0 - default_name boolean on timelines
+      changes:
+        - addColumn:
+            columns:
+            - column:
+                remarks: Boolean value indicating if the timeline name is user provided or defaulted
+                name: default_name
+                type: boolean
+                value: false
+                constraints:
+                  nullable: false
+            tableName: timeline
+
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/src/metabase/api/timeline.clj
+++ b/src/metabase/api/timeline.clj
@@ -20,7 +20,7 @@
   "Create a new [[Timeline]]."
   [:as {{:keys [name default description icon collection_id archived], :as body} :body}]
   {name          su/NonBlankString
-   default       s/Bool
+   default       (s/maybe s/Bool)
    description   (s/maybe s/Str)
    icon          (s/maybe timeline/Icons)
    collection_id (s/maybe su/IntGreaterThanZero)

--- a/src/metabase/api/timeline.clj
+++ b/src/metabase/api/timeline.clj
@@ -18,9 +18,9 @@
 
 (api/defendpoint POST "/"
   "Create a new [[Timeline]]."
-  [:as {{:keys [name default_name description icon collection_id archived], :as body} :body}]
+  [:as {{:keys [name default description icon collection_id archived], :as body} :body}]
   {name          su/NonBlankString
-   default_name  s/Bool
+   default       s/Bool
    description   (s/maybe s/Str)
    icon          (s/maybe timeline/Icons)
    collection_id (s/maybe su/IntGreaterThanZero)
@@ -68,9 +68,9 @@
 (api/defendpoint PUT "/:id"
   "Update the [[Timeline]] with `id`. Returns the timeline without events. Archiving a timeline will archive all of the
   events in that timeline."
-  [id :as {{:keys [name default_name description icon collection_id archived] :as timeline-updates} :body}]
+  [id :as {{:keys [name default description icon collection_id archived] :as timeline-updates} :body}]
   {name          (s/maybe su/NonBlankString)
-   default_name  (s/maybe s/Bool)
+   default       (s/maybe s/Bool)
    description   (s/maybe s/Str)
    icon          (s/maybe timeline/Icons)
    collection_id (s/maybe su/IntGreaterThanZero)

--- a/src/metabase/api/timeline.clj
+++ b/src/metabase/api/timeline.clj
@@ -18,8 +18,9 @@
 
 (api/defendpoint POST "/"
   "Create a new [[Timeline]]."
-  [:as {{:keys [name description icon collection_id archived], :as body} :body}]
+  [:as {{:keys [name default_name description icon collection_id archived], :as body} :body}]
   {name          su/NonBlankString
+   default_name  s/Bool
    description   (s/maybe s/Str)
    icon          (s/maybe timeline/Icons)
    collection_id (s/maybe su/IntGreaterThanZero)
@@ -67,8 +68,9 @@
 (api/defendpoint PUT "/:id"
   "Update the [[Timeline]] with `id`. Returns the timeline without events. Archiving a timeline will archive all of the
   events in that timeline."
-  [id :as {{:keys [name description icon collection_id archived] :as timeline-updates} :body}]
+  [id :as {{:keys [name default_name description icon collection_id archived] :as timeline-updates} :body}]
   {name          (s/maybe su/NonBlankString)
+   default_name  (s/maybe s/Bool)
    description   (s/maybe s/Str)
    icon          (s/maybe timeline/Icons)
    collection_id (s/maybe su/IntGreaterThanZero)

--- a/test/metabase/api/timeline_test.clj
+++ b/test/metabase/api/timeline_test.clj
@@ -129,6 +129,7 @@
             ;; make an API call to create a timeline
             (mt/user-http-request :rasta :post 200 "timeline"
                                   {:name          "Rasta's TL"
+                                   :default_name  false
                                    :creator_id    (u/the-id (mt/fetch-user :rasta))
                                    :collection_id id})
             (testing "check the collection to see if the timeline is there"

--- a/test/metabase/api/timeline_test.clj
+++ b/test/metabase/api/timeline_test.clj
@@ -129,7 +129,7 @@
             ;; make an API call to create a timeline
             (mt/user-http-request :rasta :post 200 "timeline"
                                   {:name          "Rasta's TL"
-                                   :default_name  false
+                                   :default       false
                                    :creator_id    (u/the-id (mt/fetch-user :rasta))
                                    :collection_id id})
             (testing "check the collection to see if the timeline is there"

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -198,7 +198,7 @@
    Timeline
    (fn [_]
      {:name       "Timeline of bird squawks"
-      :is_default false
+      :default    false
       :creator_id (rasta-id)})
 
    TimelineEvent

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -198,6 +198,7 @@
    Timeline
    (fn [_]
      {:name       "Timeline of bird squawks"
+      :default_name true
       :creator_id (rasta-id)})
 
    TimelineEvent
@@ -242,6 +243,7 @@
                    #'Segment
                    #'Table
                    #'TaskHistory
+                   #'Timeline
                    #'User]]
   (remove-watch model-var ::reload)
   (add-watch

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -198,7 +198,7 @@
    Timeline
    (fn [_]
      {:name       "Timeline of bird squawks"
-      :default_name true
+      :is_default false
       :creator_id (rasta-id)})
 
    TimelineEvent


### PR DESCRIPTION
When creating timelines, we want to have a default so that users don't have to think about manually creating a timeline before adding events.

This means there is a notion of 'default' for a timeline that we need to keep somewhere.