### PR TITLE
[E2E] Split Cypress run command on multiple lines

### DIFF
--- a/.github/workflows/e2e-master.yml
+++ b/.github/workflows/e2e-master.yml
@@ -128,7 +128,12 @@ jobs:
         mv version.properties resources/
 
     - name: Run Cypress tests on ${{ matrix.folder }}
-      run: yarn run test-cypress-no-build --folder ${{ matrix.folder }} --record --key ${{ secrets.CURRENTS_KEY }} --group ${{ matrix.folder }}-${{ matrix.edition }} --ci-build-id "${{ github.run_id }}-${{ github.run_attempt }}"
+      run: |
+        yarn run test-cypress-no-build \
+          --folder ${{ matrix.folder }} \
+          --record --key ${{ secrets.CURRENTS_KEY }} \
+          --group ${{ matrix.folder }}-${{ matrix.edition }} \
+          --ci-build-id "${{ github.run_id }}-${{ github.run_attempt }}"
       env:
         TERM: xterm
 

--- a/.github/workflows/e2e-master.yml
+++ b/.github/workflows/e2e-master.yml
@@ -3,7 +3,7 @@ name: E2E Tests
 on:
   push:
     branches:
-      - 'e2e-multi-line-workflow-run-command'
+      - "master"
     paths-ignore:
       - "docs/**"
       - "**.md"

--- a/.github/workflows/e2e-master.yml
+++ b/.github/workflows/e2e-master.yml
@@ -3,7 +3,7 @@ name: E2E Tests
 on:
   push:
     branches:
-      - 'master'
+      - 'e2e-multi-line-workflow-run-command'
     paths-ignore:
       - "docs/**"
       - "**.md"


### PR DESCRIPTION
Let's make `e2e` workflow file a bit easier to read.
