### PR TITLE
Count only non-archived events

### DIFF
--- a/frontend/src/metabase/timelines/collections/components/TimelineCard/TimelineCard.tsx
+++ b/frontend/src/metabase/timelines/collections/components/TimelineCard/TimelineCard.tsx
@@ -26,7 +26,7 @@ const TimelineCard = ({
 }: TimelineCardProps): JSX.Element => {
   const timelineUrl = Urls.timelineInCollection(timeline, collection);
   const menuItems = getMenuItems(timeline, collection, onUnarchive);
-  const eventCount = timeline.events?.length;
+  const eventCount = getEventCount(timeline);
   const hasDescription = Boolean(timeline.description);
   const hasMenuItems = menuItems.length > 0;
   const hasEventCount = !hasMenuItems && eventCount != null;
@@ -56,6 +56,10 @@ const TimelineCard = ({
       )}
     </CardRoot>
   );
+};
+
+const getEventCount = (timeline: Timeline) => {
+  return timeline.events ? timeline.events.filter(e => !e.archived).length : 0;
 };
 
 const getMenuItems = (

--- a/frontend/src/metabase/timelines/collections/components/TimelineCard/TimelineCard.unit.spec.tsx
+++ b/frontend/src/metabase/timelines/collections/components/TimelineCard/TimelineCard.unit.spec.tsx
@@ -11,7 +11,11 @@ describe("TimelineCard", () => {
   it("should render timeline", () => {
     const props = getProps({
       timeline: createMockTimeline({
-        events: [createMockTimelineEvent(), createMockTimelineEvent()],
+        events: [
+          createMockTimelineEvent(),
+          createMockTimelineEvent(),
+          createMockTimelineEvent({ archived: true }),
+        ],
       }),
     });
 


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/20289

Fixes a bug where archived events were included into the total event count.

How to test: 
- Existing e2e tests should pass
- There is an updated unit test for this