### PR TITLE
Display unfiltered events in data view for a question

### DIFF
--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -683,14 +683,12 @@ export const getTransformedTimelines = createSelector(
 export const getFilteredTimelines = createSelector(
   [getTransformedTimelines, getTimeseriesXDomain],
   (timelines, xDomain) => {
-    if (!xDomain) {
-      return [];
-    }
-
     return timelines
       .map(timeline =>
         updateIn(timeline, ["events"], events =>
-          events.filter(event => isEventWithinDomain(event, xDomain)),
+          xDomain
+            ? events.filter(event => isEventWithinDomain(event, xDomain))
+            : events,
         ),
       )
       .filter(timeline => timeline.events.length > 0);

--- a/frontend/test/metabase/scenarios/question/timelines.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/timelines.cy.spec.js
@@ -8,14 +8,14 @@ describe("scenarios > collections > timelines", () => {
   describe("as admin", () => {
     beforeEach(() => {
       cy.signInAsAdmin();
-      cy.intercept("GET", "/api/collection/root").as("collections");
-      cy.intercept("POST", "/api/timeline-event").as("timelineEvent");
-      cy.intercept("PUT", "/api/timeline-event/**").as("putTimelineEvent");
+      cy.intercept("GET", "/api/collection/root").as("getCollection");
+      cy.intercept("POST", "/api/timeline-event").as("createEvent");
+      cy.intercept("PUT", "/api/timeline-event/**").as("updateEvent");
     });
 
     it("should create the first event and timeline", () => {
       visitQuestion(3);
-      cy.wait("@collections");
+      cy.wait("@getCollection");
       cy.findByTextEnsureVisible("Visualization");
 
       cy.findByLabelText("calendar icon").click();
@@ -24,7 +24,7 @@ describe("scenarios > collections > timelines", () => {
       cy.findByLabelText("Event name").type("RC1");
       cy.findByLabelText("Date").type("10/20/2018");
       cy.button("Create").click();
-      cy.wait("@timelineEvent");
+      cy.wait("@createEvent");
 
       cy.findByTextEnsureVisible("Our analytics events");
       cy.findByText("RC1");
@@ -37,7 +37,7 @@ describe("scenarios > collections > timelines", () => {
       });
 
       visitQuestion(3);
-      cy.wait("@collections");
+      cy.wait("@getCollection");
       cy.findByTextEnsureVisible("Visualization");
 
       cy.findByLabelText("calendar icon").click();
@@ -46,7 +46,7 @@ describe("scenarios > collections > timelines", () => {
       cy.findByLabelText("Event name").type("RC2");
       cy.findByLabelText("Date").type("10/30/2018");
       cy.button("Create").click();
-      cy.wait("@timelineEvent");
+      cy.wait("@createEvent");
 
       cy.findByTextEnsureVisible("Releases");
       cy.findByText("RC1");
@@ -60,7 +60,7 @@ describe("scenarios > collections > timelines", () => {
       });
 
       visitQuestion(3);
-      cy.wait("@collections");
+      cy.wait("@getCollection");
       cy.findByTextEnsureVisible("Visualization");
 
       cy.findByLabelText("calendar icon").click();
@@ -74,10 +74,35 @@ describe("scenarios > collections > timelines", () => {
         .clear()
         .type("RC2");
       cy.findByText("Update").click();
-      cy.wait("@putTimelineEvent");
+      cy.wait("@updateEvent");
 
       cy.findByTextEnsureVisible("Releases");
       cy.findByText("RC2");
+    });
+
+    it("should display all events in data view", () => {
+      cy.createTimelineWithEvents({
+        timeline: { name: "Releases" },
+        events: [
+          { name: "v1", timestamp: "2015-01-01T00:00:00Z" },
+          { name: "v2", timestamp: "2017-01-01T00:00:00Z" },
+          { name: "v3", timestamp: "2020-01-01T00:00:00Z" },
+        ],
+      });
+
+      visitQuestion(3);
+      cy.wait("@getCollection");
+      cy.findByTextEnsureVisible("Visualization");
+
+      cy.findByLabelText("calendar icon").click();
+      cy.findByText("v1").should("not.exist");
+      cy.findByText("v2").should("be.visible");
+      cy.findByText("v3").should("be.visible");
+
+      cy.findByLabelText("table2 icon").click();
+      cy.findByText("v1").should("be.visible");
+      cy.findByText("v2").should("be.visible");
+      cy.findByText("v3").should("be.visible");
     });
 
     it("should archive and unarchive an event", () => {
@@ -87,20 +112,18 @@ describe("scenarios > collections > timelines", () => {
       });
 
       visitQuestion(3);
-      cy.wait("@collections");
+      cy.wait("@getCollection");
       cy.findByTextEnsureVisible("Visualization");
 
       cy.findByLabelText("calendar icon").click();
       cy.findByText("Releases");
-      sidebar().within(() => {
-        cy.icon("ellipsis").click();
-      });
+      sidebar().within(() => cy.icon("ellipsis").click());
       cy.findByTextEnsureVisible("Archive event").click();
-      cy.wait("@putTimelineEvent");
+      cy.wait("@updateEvent");
       cy.findByText("RC1").should("not.exist");
 
       cy.findByText("Undo").click();
-      cy.wait("@putTimelineEvent");
+      cy.wait("@updateEvent");
       cy.findByText("RC1");
     });
 
@@ -150,9 +173,7 @@ describe("scenarios > collections > timelines", () => {
       cy.findByLabelText("calendar icon").click();
       cy.findByTextEnsureVisible("Releases");
       cy.findByText("Add an event").should("not.exist");
-      sidebar().within(() => {
-        cy.icon("ellipsis").should("not.exist");
-      });
+      sidebar().within(() => cy.icon("ellipsis").should("not.exist"));
     });
   });
 });


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/20289

Currently events are not displayed in the query in data view because there is no `xInterval` for filtering. This PR solves this issue by displaying all events in such case.

How to test:
- The new cypress test should pass

<img width="701" alt="Screenshot 2022-04-07 at 00 04 43" src="https://user-images.githubusercontent.com/8542534/162061583-d1041915-9c87-4e94-bc1b-25ef7a623bef.png">
<img width="708" alt="Screenshot 2022-04-07 at 00 04 54" src="https://user-images.githubusercontent.com/8542534/162061601-f73c6277-3897-4a8d-81ec-4971319f072b.png">
