### PR TITLE
[E2E] Fix collection flakes

### DIFF
--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -213,29 +213,47 @@ describe("collection permissions", () => {
                       const { id: THIRD_COLLECTION_ID } = xhr.body.find(
                         collection => collection.slug === "third_collection",
                       );
+
+                      cy.intercept(
+                        "PUT",
+                        `/api/collection/${THIRD_COLLECTION_ID}`,
+                      ).as("editCollection");
+
                       cy.visit(`/collection/${THIRD_COLLECTION_ID}`);
                     });
+
                     cy.icon("pencil").click();
+
                     cy.findByText("Archive this collection").click();
                     cy.get(".Modal")
                       .findByText("Archive")
                       .click();
+
+                    cy.wait("@editCollection");
+
                     cy.findByTestId("collection-name-heading")
                       .as("title")
                       .contains("Second collection");
+
                     navigationSidebar().within(() => {
                       cy.findByText("First collection");
                       cy.findByText("Second collection");
                       cy.findByText("Third collection").should("not.exist");
                     });
+
                     // While we're here, we can test unarchiving the collection as well
                     cy.findByText("Archived collection");
                     cy.findByText("Undo").click();
+
+                    cy.wait("@editCollection");
+
                     cy.findByText(
                       "Sorry, you don’t have permission to see that.",
                     ).should("not.exist");
+
                     // We're still in the parent collection
                     cy.get("@title").contains("Second collection");
+
                     // But unarchived collection is now visible in the sidebar
                     navigationSidebar().within(() => {
                       cy.findByText("Third collection");


### PR DESCRIPTION
Failed runs in the CI

https://github.com/metabase/metabase/actions/runs/2104267631/attempts/1
https://github.com/metabase/metabase/actions/runs/2104267631/attempts/2

`collection-items-listing.cy.spec.js`
![scenarios  collection items listing -- sorting -- should allow to sort unpinned items by columns asc and desc (failed) (attempt 2)](https://user-images.githubusercontent.com/31325167/162072672-8056a241-886a-4ff6-82d7-820bdbbead5d.png)

`collections/permissions.cy.spec.js`
![collection permissions -- item management -- curate access -- admin user -- archive -- collections -- archiving sub-collection should redirect to its parent (failed) (attempt 2)](https://user-images.githubusercontent.com/31325167/162072847-daf8d327-41c7-43b9-a214-df49b3b1faac.png)


