### PR TITLE
Custom expression: fix error message on unknown field

### DIFF
--- a/frontend/src/metabase/lib/expressions/diagnostics.js
+++ b/frontend/src/metabase/lib/expressions/diagnostics.js
@@ -100,13 +100,13 @@ function prattCompiler(source, startRule, query) {
     if (kind === "metric") {
       const metric = parseMetric(name, options);
       if (!metric) {
-        throw new ResolverError(t`Unknown Field: ${name}`, node);
+        throw new ResolverError(t`Unknown Metric: ${name}`, node);
       }
       return ["metric", metric.id];
     } else if (kind === "segment") {
       const segment = parseSegment(name, options);
       if (!segment) {
-        throw new ResolverError(t`Unknown Field: ${name}`, node);
+        throw new ResolverError(t`Unknown Segment: ${name}`, node);
       }
       return ["segment", segment.id];
     } else {


### PR DESCRIPTION
To verify:

1. New Question, Sample Database, Orders table
2. Summarize, Custom Expression, type `sum([Total]) * [Quantity]`

### Before this PR

`Unknown Field` is incorrect since if `Quantity` is that position (in the custom expression), it could only be a metric.

![image](https://user-images.githubusercontent.com/7288/162097922-7e33a7cd-13e1-4370-bcb9-53ca50711caf.png)

### After this PR

The error message is exactly like in v41 or earlier.

![Screenshot_20220406_163501](https://user-images.githubusercontent.com/7288/162098046-06784299-a965-4a8c-bd10-00f67b11943e.png)
