### PR TITLE
Allow creating events with 12:00AM

### DIFF
--- a/frontend/src/metabase/components/form/widgets/FormDateWidget/FormDateWidget.tsx
+++ b/frontend/src/metabase/components/form/widgets/FormDateWidget/FormDateWidget.tsx
@@ -12,33 +12,30 @@ import { FormField } from "./types";
 export interface FormDateWidgetProps {
   field: FormField;
   placeholder?: string;
-  hasTime?: boolean;
+  values: Record<string, unknown>;
   readOnly?: boolean;
   autoFocus?: boolean;
   tabIndex?: number;
+  hasTimeField?: string;
+  onChangeField?: (field: string, value: unknown) => void;
 }
 
 const FormDateWidget = forwardRef(function FormDateWidget(
   {
     field,
     placeholder,
-    hasTime,
+    values,
     readOnly,
     autoFocus,
     tabIndex,
+    hasTimeField = "",
+    onChangeField,
   }: FormDateWidgetProps,
   ref: Ref<HTMLDivElement>,
 ) {
   const value = useMemo(() => {
     return field.value ? parseTimestamp(field.value) : undefined;
   }, [field]);
-
-  const handleChange = useCallback(
-    (newValue?: Moment) => {
-      field.onChange?.(newValue?.format());
-    },
-    [field],
-  );
 
   const handleFocus = useCallback(() => {
     field.onFocus?.(field.value);
@@ -48,12 +45,26 @@ const FormDateWidget = forwardRef(function FormDateWidget(
     field.onBlur?.(field.value);
   }, [field]);
 
+  const handleChange = useCallback(
+    (newValue?: Moment) => {
+      field.onChange?.(newValue?.format());
+    },
+    [field],
+  );
+
+  const handleHasTimeChange = useCallback(
+    (hasTime: boolean) => {
+      onChangeField?.(hasTimeField, hasTime);
+    },
+    [hasTimeField, onChangeField],
+  );
+
   return (
     <DateWidget
       ref={ref}
       value={value}
       placeholder={placeholder}
-      hasTime={hasTime}
+      hasTime={Boolean(values[hasTimeField])}
       dateFormat={getNumericDateStyleFromSettings()}
       timeFormat={getTimeStyleFromSettings()}
       is24HourMode={has24HourModeSetting()}
@@ -63,9 +74,10 @@ const FormDateWidget = forwardRef(function FormDateWidget(
       fullWidth
       tabIndex={tabIndex}
       aria-labelledby={`${field.name}-label`}
-      onChange={handleChange}
       onFocus={handleFocus}
       onBlur={handleBlur}
+      onChange={handleChange}
+      onHasTimeChange={handleHasTimeChange}
     />
   );
 });

--- a/frontend/src/metabase/core/components/DateInput/DateInput.tsx
+++ b/frontend/src/metabase/core/components/DateInput/DateInput.tsx
@@ -11,7 +11,6 @@ import React, {
 } from "react";
 import moment, { Moment } from "moment";
 import { t } from "ttag";
-import { hasTimePart } from "metabase/lib/time";
 import Input from "metabase/core/components/Input";
 
 const DATE_FORMAT = "MM/DD/YYYY";
@@ -70,7 +69,7 @@ const DateInput = forwardRef(function DateInput(
   const valueText = useMemo(() => {
     if (!value) {
       return "";
-    } else if (hasTime && hasTimePart(value)) {
+    } else if (hasTime) {
       return value.format(dateTimeFormat);
     } else {
       return value.format(dateFormat);

--- a/frontend/src/metabase/core/components/DateSelector/DateSelector.stories.tsx
+++ b/frontend/src/metabase/core/components/DateSelector/DateSelector.stories.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Moment } from "moment";
+import moment, { Moment } from "moment";
 import { ComponentStory } from "@storybook/react";
 import DateSelector from "./DateSelector";
 
@@ -9,7 +9,7 @@ export default {
 };
 
 const Template: ComponentStory<typeof DateSelector> = args => {
-  const [value, setValue] = useState<Moment>();
+  const [value, setValue] = useState(args.value);
   return <DateSelector {...args} value={value} onChange={setValue} />;
 };
 
@@ -17,5 +17,6 @@ export const Default = Template.bind({});
 
 export const WithTime = Template.bind({});
 WithTime.args = {
+  value: moment("2015-01-01"),
   hasTime: true,
 };

--- a/frontend/src/metabase/core/components/DateSelector/DateSelector.tsx
+++ b/frontend/src/metabase/core/components/DateSelector/DateSelector.tsx
@@ -8,7 +8,6 @@ import React, {
 } from "react";
 import moment, { Moment } from "moment";
 import { t } from "ttag";
-import { hasTimePart } from "metabase/lib/time";
 import TimeInput from "metabase/core/components/TimeInput";
 import Calendar from "metabase/components/Calendar";
 import {
@@ -25,6 +24,7 @@ export interface DateSelectorProps {
   hasTime?: boolean;
   is24HourMode?: boolean;
   onChange?: (date?: Moment) => void;
+  onHasTimeChange?: (hasTime: boolean) => void;
   onSubmit?: () => void;
 }
 
@@ -36,6 +36,7 @@ const DateSelector = forwardRef(function DateSelector(
     hasTime,
     is24HourMode,
     onChange,
+    onHasTimeChange,
     onSubmit,
   }: DateSelectorProps,
   ref: Ref<HTMLDivElement>,
@@ -55,13 +56,15 @@ const DateSelector = forwardRef(function DateSelector(
   const handleTimeClick = useCallback(() => {
     const newValue = value ?? today;
     onChange?.(newValue);
-  }, [value, today, onChange]);
+    onHasTimeChange?.(true);
+  }, [value, today, onChange, onHasTimeChange]);
 
   const handleTimeClear = useCallback(
     (newValue: Moment) => {
       onChange?.(newValue);
+      onHasTimeChange?.(false);
     },
-    [onChange],
+    [onChange, onHasTimeChange],
   );
 
   return (

--- a/frontend/src/metabase/core/components/DateSelector/DateSelector.tsx
+++ b/frontend/src/metabase/core/components/DateSelector/DateSelector.tsx
@@ -41,7 +41,6 @@ const DateSelector = forwardRef(function DateSelector(
   ref: Ref<HTMLDivElement>,
 ): JSX.Element {
   const today = useMemo(() => moment().startOf("date"), []);
-  const [isTimeShown, setIsTimeShown] = useState(hasTime && hasTimePart(value));
 
   const handleDateChange = useCallback(
     (unused1: string, unused2: string, date: Moment) => {
@@ -56,13 +55,11 @@ const DateSelector = forwardRef(function DateSelector(
   const handleTimeClick = useCallback(() => {
     const newValue = value ?? today;
     onChange?.(newValue);
-    setIsTimeShown(true);
   }, [value, today, onChange]);
 
   const handleTimeClear = useCallback(
     (newValue: Moment) => {
       onChange?.(newValue);
-      setIsTimeShown(false);
     },
     [onChange],
   );
@@ -75,7 +72,7 @@ const DateSelector = forwardRef(function DateSelector(
         isRangePicker={false}
         onChange={handleDateChange}
       />
-      {value && isTimeShown && (
+      {value && hasTime && (
         <SelectorTimeContainer>
           <TimeInput
             value={value}
@@ -86,7 +83,7 @@ const DateSelector = forwardRef(function DateSelector(
         </SelectorTimeContainer>
       )}
       <SelectorFooter>
-        {hasTime && !isTimeShown && (
+        {!hasTime && (
           <SelectorTimeButton icon="clock" borderless onClick={handleTimeClick}>
             {t`Add time`}
           </SelectorTimeButton>

--- a/frontend/src/metabase/core/components/DateWidget/DateWidget.tsx
+++ b/frontend/src/metabase/core/components/DateWidget/DateWidget.tsx
@@ -24,6 +24,7 @@ export interface DateWidgetProps extends DateWidgetAttributes {
   error?: boolean;
   fullWidth?: boolean;
   onChange?: (date?: Moment) => void;
+  onHasTimeChange?: (hasTime: boolean) => void;
 }
 
 const DateWidget = forwardRef(function DateWidget(
@@ -36,6 +37,7 @@ const DateWidget = forwardRef(function DateWidget(
     error,
     fullWidth,
     onChange,
+    onHasTimeChange,
     ...props
   }: DateWidgetProps,
   ref: Ref<HTMLDivElement>,
@@ -60,6 +62,7 @@ const DateWidget = forwardRef(function DateWidget(
           hasTime={hasTime}
           is24HourMode={is24HourMode}
           onChange={onChange}
+          onHasTimeChange={onHasTimeChange}
           onSubmit={handleClose}
         />
       }

--- a/frontend/src/metabase/entities/timeline-events/forms.js
+++ b/frontend/src/metabase/entities/timeline-events/forms.js
@@ -1,5 +1,4 @@
 import { t } from "ttag";
-import { hasTimePart, parseTimestamp } from "metabase/lib/time";
 import { getTimelineIcons } from "metabase/lib/timelines";
 import validate from "metabase/lib/validate";
 
@@ -16,7 +15,7 @@ const createForm = ({ timelines }) => {
       name: "timestamp",
       title: t`Date`,
       type: "date",
-      hasTime: true,
+      hasTimeField: "time_matters",
       validate: validate.required(),
     },
     {
@@ -59,18 +58,8 @@ const createForm = ({ timelines }) => {
   ];
 };
 
-const normalizeForm = values => {
-  const timestamp = parseTimestamp(values.timestamp);
-
-  return {
-    ...values,
-    time_matters: hasTimePart(timestamp),
-  };
-};
-
 export default {
   details: ({ timelines = [] } = {}) => ({
     fields: createForm({ timelines }),
-    normalize: normalizeForm,
   }),
 };

--- a/frontend/src/metabase/timelines/collections/components/NewEventModal/NewEventModal.tsx
+++ b/frontend/src/metabase/timelines/collections/components/NewEventModal/NewEventModal.tsx
@@ -35,6 +35,7 @@ const NewEventModal = ({
       icon: timeline ? timeline.icon : getDefaultTimelineIcon(),
       timezone: getDefaultTimezone(),
       source: "collections",
+      time_matters: false,
     }),
     [timeline],
   );

--- a/frontend/src/metabase/timelines/questions/components/NewEventModal/NewEventModal.tsx
+++ b/frontend/src/metabase/timelines/questions/components/NewEventModal/NewEventModal.tsx
@@ -41,6 +41,7 @@ const NewEventModal = ({
       timezone: getDefaultTimezone(),
       source: "question",
       question_id: cardId,
+      time_matters: false,
     };
   }, [cardId, availableTimelines]);
 

--- a/frontend/test/metabase/scenarios/collections/timelines.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/timelines.cy.spec.js
@@ -132,6 +132,24 @@ describe("scenarios > collections > timelines", () => {
       cy.findByText(/10:20 AM/).should("be.visible");
     });
 
+    it("should create an event with date and time at midnight", () => {
+      cy.visit("/collection/root");
+
+      cy.findByLabelText("calendar icon").click();
+      cy.findByText("Add an event").click();
+
+      cy.findByLabelText("Event name").type("RC1");
+      cy.findByRole("button", { name: "calendar icon" }).click();
+      cy.findByText("15").click();
+      cy.findByText("Add time").click();
+      cy.findByText("Done").click();
+      cy.findByText("Create").click();
+
+      cy.findByText("Our analytics events").should("be.visible");
+      cy.findByText("RC1").should("be.visible");
+      cy.findByText(/12:00 AM/).should("be.visible");
+    });
+
     it("should edit an event", () => {
       cy.createTimelineWithEvents({ events: [{ name: "RC1" }] });
       cy.visit("/collection/root/timelines");

--- a/frontend/test/metabase/scenarios/collections/timelines.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/timelines.cy.spec.js
@@ -19,7 +19,7 @@ describe("scenarios > collections > timelines", () => {
 
     it("should create the first event and timeline", () => {
       cy.visit("/collection/root");
-      cy.findByLabelText("calendar icon").click();
+      cy.icon("calendar").click();
 
       cy.findByText("Add an event").click();
       cy.findByLabelText("Event name").type("RC1");
@@ -28,7 +28,7 @@ describe("scenarios > collections > timelines", () => {
 
       cy.findByText("RC1").should("be.visible");
       cy.findByText("October 20, 2020").should("be.visible");
-      cy.findByLabelText("star icon").should("be.visible");
+      cy.icon("star").should("be.visible");
 
       cy.findByText("Add an event").click();
       cy.findByLabelText("Event name").type("RC2");
@@ -39,13 +39,13 @@ describe("scenarios > collections > timelines", () => {
 
       cy.findByText("RC2").should("be.visible");
       cy.findByText("May 12, 2021").should("be.visible");
-      cy.findByLabelText("balloons icon").should("be.visible");
+      cy.icon("balloons").should("be.visible");
     });
 
     it("should create an event in a personal collection", () => {
       cy.visit("/collection/root");
       cy.findByText("Your personal collection").click();
-      cy.findByLabelText("calendar icon").click();
+      cy.icon("calendar").click();
 
       cy.findByText("Add an event").click();
       cy.findByLabelText("Event name").type("RC1");
@@ -77,7 +77,7 @@ describe("scenarios > collections > timelines", () => {
     it("should create an event with date", () => {
       cy.visit("/collection/root");
 
-      cy.findByLabelText("calendar icon").click();
+      cy.icon("calendar").click();
       cy.findByText("Add an event").click();
 
       cy.findByLabelText("Event name").type("RC1");
@@ -94,7 +94,7 @@ describe("scenarios > collections > timelines", () => {
     it("should create an event with description", () => {
       cy.visit("/collection/root");
 
-      cy.findByLabelText("calendar icon").click();
+      cy.icon("calendar").click();
       cy.findByText("Add an event").click();
 
       cy.findByLabelText("Event name").type("RC1");
@@ -111,7 +111,7 @@ describe("scenarios > collections > timelines", () => {
     it("should create an event with date and time", () => {
       cy.visit("/collection/root");
 
-      cy.findByLabelText("calendar icon").click();
+      cy.icon("calendar").click();
       cy.findByText("Add an event").click();
 
       cy.findByLabelText("Event name").type("RC1");
@@ -135,7 +135,7 @@ describe("scenarios > collections > timelines", () => {
     it("should create an event with date and time at midnight", () => {
       cy.visit("/collection/root");
 
-      cy.findByLabelText("calendar icon").click();
+      cy.icon("calendar").click();
       cy.findByText("Add an event").click();
 
       cy.findByLabelText("Event name").type("RC1");
@@ -371,7 +371,7 @@ describe("scenarios > collections > timelines", () => {
       cy.signIn("readonly");
       cy.visit("/collection/root");
 
-      cy.findByLabelText("calendar icon").click();
+      cy.icon("calendar").click();
       cy.findByText("Our analytics events").should("be.visible");
       cy.findByText("Add an event").should("not.exist");
     });
@@ -386,7 +386,7 @@ describe("scenarios > collections > timelines", () => {
 
       cy.signIn("readonly");
       cy.visit("/collection/root");
-      cy.findByLabelText("calendar icon").click();
+      cy.icon("calendar").click();
       cy.findByText("Releases").should("be.visible");
       cy.findByText("Add an event").should("not.exist");
     });
@@ -411,7 +411,7 @@ describeWithSnowplow("scenarios > collections > timelines", () => {
     cy.visit("/collection/root");
 
     // 3 - pageview
-    cy.findByLabelText("calendar icon").click();
+    cy.icon("calendar").click();
 
     cy.findByText("Add an event").click();
     cy.findByLabelText("Event name").type("Event");
@@ -430,5 +430,5 @@ const openMenu = name => {
     .findByText(name)
     .parent()
     .parent()
-    .within(() => cy.findByLabelText("ellipsis icon").click());
+    .within(() => cy.icon("ellipsis").click());
 };

--- a/frontend/test/metabase/scenarios/question/timelines.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/timelines.cy.spec.js
@@ -18,7 +18,7 @@ describe("scenarios > collections > timelines", () => {
       cy.wait("@collections");
       cy.findByTextEnsureVisible("Visualization");
 
-      cy.findByLabelText("calendar icon").click();
+      cy.icon("calendar").click();
       cy.findByTextEnsureVisible("Add an event").click();
 
       cy.findByLabelText("Event name").type("RC1");
@@ -40,7 +40,7 @@ describe("scenarios > collections > timelines", () => {
       cy.wait("@collections");
       cy.findByTextEnsureVisible("Visualization");
 
-      cy.findByLabelText("calendar icon").click();
+      cy.icon("calendar").click();
       cy.findByTextEnsureVisible("Add an event").click();
 
       cy.findByLabelText("Event name").type("RC2");
@@ -63,7 +63,7 @@ describe("scenarios > collections > timelines", () => {
       cy.wait("@collections");
       cy.findByTextEnsureVisible("Visualization");
 
-      cy.findByLabelText("calendar icon").click();
+      cy.icon("calendar").click();
       cy.findByText("Releases");
       sidebar().within(() => {
         cy.icon("ellipsis").click();
@@ -90,7 +90,7 @@ describe("scenarios > collections > timelines", () => {
       cy.wait("@collections");
       cy.findByTextEnsureVisible("Visualization");
 
-      cy.findByLabelText("calendar icon").click();
+      cy.icon("calendar").click();
       cy.findByText("Releases");
       sidebar().within(() => {
         cy.icon("ellipsis").click();
@@ -118,7 +118,7 @@ describe("scenarios > collections > timelines", () => {
       });
 
       visitQuestion(3);
-      cy.findByLabelText("calendar icon").click();
+      cy.icon("calendar").click();
 
       cy.findByText("Releases").should("be.visible");
       cy.findByText("Release notes").should("be.visible");
@@ -131,7 +131,7 @@ describe("scenarios > collections > timelines", () => {
       visitQuestion(3);
       cy.findByTextEnsureVisible("Created At");
 
-      cy.findByLabelText("calendar icon").click();
+      cy.icon("calendar").click();
       cy.findByTextEnsureVisible(/Events in Metabase/);
       cy.findByText("Add an event").should("not.exist");
     });
@@ -147,7 +147,7 @@ describe("scenarios > collections > timelines", () => {
       visitQuestion(3);
       cy.findByTextEnsureVisible("Created At");
 
-      cy.findByLabelText("calendar icon").click();
+      cy.icon("calendar").click();
       cy.findByTextEnsureVisible("Releases");
       cy.findByText("Add an event").should("not.exist");
       sidebar().within(() => {


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/20289

How to test:
- Go to a collection and click on the calendar icon in the header
- Click "Add an event"
- Enter a name for the event
- Click on the calendar icon in `Date` field, click `Add time`, and then `Done`
- Make sure that the event was created with `12:00 AM` time
- Please note that there a cypress test with exact same steps is added in this PR, so you don't need to check it manually.

<img width="652" alt="Screenshot 2022-04-07 at 11 26 00" src="https://user-images.githubusercontent.com/8542534/162147461-17c0e672-5b27-4099-b1c8-63c92acdadfb.png">
