### PR TITLE
Show back button only when there are multiple timelines in a collection

### DIFF
--- a/frontend/src/metabase/entities/containers/EntityListLoader.jsx
+++ b/frontend/src/metabase/entities/containers/EntityListLoader.jsx
@@ -17,6 +17,7 @@ const propTypes = {
   wrapped: PropTypes.bool,
   debounced: PropTypes.bool,
   loadingAndErrorWrapper: PropTypes.bool,
+  LoadingAndErrorWrapper: PropTypes.elementType,
   keepListWhileLoading: PropTypes.bool,
   listName: PropTypes.string,
   selectorName: PropTypes.string,
@@ -41,6 +42,7 @@ const propTypes = {
 
 const defaultProps = {
   loadingAndErrorWrapper: true,
+  LoadingAndErrorWrapper: LoadingAndErrorWrapper,
   keepListWhileLoading: false,
   reload: false,
   wrapped: false,
@@ -56,6 +58,7 @@ const CONSUMED_PROPS = [
   "wrapped",
   "debounced",
   "loadingAndErrorWrapper",
+  "LoadingAndErrorWrapper",
   "selectorName",
 ];
 
@@ -245,7 +248,12 @@ class EntityListLoader extends React.Component {
   };
 
   render() {
-    const { allFetched, allError, loadingAndErrorWrapper } = this.props;
+    const {
+      allFetched,
+      allError,
+      loadingAndErrorWrapper,
+      LoadingAndErrorWrapper,
+    } = this.props;
     const { isReloading } = this.state;
 
     return loadingAndErrorWrapper ? (

--- a/frontend/src/metabase/timelines/collections/components/TimelineDetailsModal/TimelineDetailsModal.tsx
+++ b/frontend/src/metabase/timelines/collections/components/TimelineDetailsModal/TimelineDetailsModal.tsx
@@ -71,7 +71,7 @@ const TimelineDetailsModal = ({
       <ModalHeader
         title={title}
         onClose={onClose}
-        onGoBack={!isOnlyTimeline ? handleGoBack : undefined}
+        onGoBack={isArchive || !isOnlyTimeline ? handleGoBack : undefined}
       >
         {menuItems.length > 0 && (
           <EntityMenu items={menuItems} triggerIcon="ellipsis" />

--- a/frontend/src/metabase/timelines/collections/components/TimelineDetailsModal/TimelineDetailsModal.tsx
+++ b/frontend/src/metabase/timelines/collections/components/TimelineDetailsModal/TimelineDetailsModal.tsx
@@ -25,7 +25,7 @@ export interface TimelineDetailsModalProps {
   timeline: Timeline;
   collection: Collection;
   isArchive?: boolean;
-  isDefault?: boolean;
+  isOnlyTimeline?: boolean;
   onArchive?: (event: TimelineEvent) => void;
   onUnarchive?: (event: TimelineEvent) => void;
   onClose?: () => void;
@@ -36,7 +36,7 @@ const TimelineDetailsModal = ({
   timeline,
   collection,
   isArchive = false,
-  isDefault = false,
+  isOnlyTimeline = false,
   onArchive,
   onUnarchive,
   onClose,
@@ -55,8 +55,8 @@ const TimelineDetailsModal = ({
   }, [timeline, searchText, isArchive]);
 
   const menuItems = useMemo(() => {
-    return getMenuItems(timeline, collection, isArchive, isDefault);
-  }, [timeline, collection, isArchive, isDefault]);
+    return getMenuItems(timeline, collection, isArchive, isOnlyTimeline);
+  }, [timeline, collection, isArchive, isOnlyTimeline]);
 
   const handleGoBack = useCallback(() => {
     onGoBack?.(timeline, collection);
@@ -71,7 +71,7 @@ const TimelineDetailsModal = ({
       <ModalHeader
         title={title}
         onClose={onClose}
-        onGoBack={!isDefault ? handleGoBack : undefined}
+        onGoBack={!isOnlyTimeline ? handleGoBack : undefined}
       >
         {menuItems.length > 0 && (
           <EntityMenu items={menuItems} triggerIcon="ellipsis" />
@@ -139,7 +139,7 @@ const getMenuItems = (
   timeline: Timeline,
   collection: Collection,
   isArchive: boolean,
-  isDefault: boolean,
+  isOnlyTimeline: boolean,
 ) => {
   const items: MenuItem[] = [];
 
@@ -163,7 +163,7 @@ const getMenuItems = (
     });
   }
 
-  if (isDefault) {
+  if (isOnlyTimeline) {
     items.push({
       title: t`View archived timelines`,
       link: Urls.timelinesArchiveInCollection(collection),

--- a/frontend/src/metabase/timelines/collections/components/TimelineDetailsModal/TimelineDetailsModal.tsx
+++ b/frontend/src/metabase/timelines/collections/components/TimelineDetailsModal/TimelineDetailsModal.tsx
@@ -65,13 +65,14 @@ const TimelineDetailsModal = ({
   const isNotEmpty = events.length > 0;
   const isSearching = searchText.length > 0;
   const canWrite = timeline.collection?.can_write;
+  const canGoBack = isArchive || !isOnlyTimeline;
 
   return (
     <ModalRoot>
       <ModalHeader
         title={title}
         onClose={onClose}
-        onGoBack={isArchive || !isOnlyTimeline ? handleGoBack : undefined}
+        onGoBack={canGoBack ? handleGoBack : undefined}
       >
         {menuItems.length > 0 && (
           <EntityMenu items={menuItems} triggerIcon="ellipsis" />

--- a/frontend/src/metabase/timelines/collections/components/TimelineIndexModal/TimelineIndexModal.tsx
+++ b/frontend/src/metabase/timelines/collections/components/TimelineIndexModal/TimelineIndexModal.tsx
@@ -19,7 +19,6 @@ const TimelineIndexModal = ({
     return (
       <TimelineDetailsModal
         params={{ ...params, timelineId: timelines[0].id }}
-        isDefault={true}
         onClose={onClose}
       />
     );

--- a/frontend/src/metabase/timelines/collections/containers/EditEventModal/EditEventModal.tsx
+++ b/frontend/src/metabase/timelines/collections/containers/EditEventModal/EditEventModal.tsx
@@ -27,6 +27,7 @@ const timelineEventProps = {
 const collectionProps = {
   id: (state: State, props: ModalProps) =>
     Urls.extractCollectionId(props.params.slug),
+  LoadingAndErrorWrapper,
 };
 
 const mapDispatchToProps = (dispatch: any) => ({

--- a/frontend/src/metabase/timelines/collections/containers/EditTimelineModal/EditTimelineModal.tsx
+++ b/frontend/src/metabase/timelines/collections/containers/EditTimelineModal/EditTimelineModal.tsx
@@ -20,6 +20,7 @@ const timelineProps = {
 const collectionProps = {
   id: (state: State, props: ModalProps) =>
     Urls.extractCollectionId(props.params.slug),
+  LoadingAndErrorWrapper,
 };
 
 const mapDispatchToProps = (dispatch: any) => ({

--- a/frontend/src/metabase/timelines/collections/containers/NewEventModal/NewEventModal.tsx
+++ b/frontend/src/metabase/timelines/collections/containers/NewEventModal/NewEventModal.tsx
@@ -21,6 +21,7 @@ const timelineProps = {
 const collectionProps = {
   id: (state: State, props: ModalProps) =>
     Urls.extractCollectionId(props.params.slug),
+  LoadingAndErrorWrapper,
 };
 
 const mapDispatchToProps = (dispatch: any) => ({

--- a/frontend/src/metabase/timelines/collections/containers/TimelineArchiveModal/TimelineArchiveModal.tsx
+++ b/frontend/src/metabase/timelines/collections/containers/TimelineArchiveModal/TimelineArchiveModal.tsx
@@ -21,6 +21,7 @@ const timelineProps = {
 const collectionProps = {
   id: (state: State, props: ModalProps) =>
     Urls.extractCollectionId(props.params.slug),
+  LoadingAndErrorWrapper,
 };
 
 const mapStateToProps = () => ({

--- a/frontend/src/metabase/timelines/collections/containers/TimelineDetailsModal/TimelineDetailsModal.tsx
+++ b/frontend/src/metabase/timelines/collections/containers/TimelineDetailsModal/TimelineDetailsModal.tsx
@@ -9,11 +9,14 @@ import { Collection, Timeline, TimelineEvent } from "metabase-types/api";
 import { State } from "metabase-types/store";
 import TimelineDetailsModal from "../../components/TimelineDetailsModal";
 import LoadingAndErrorWrapper from "../../components/LoadingAndErrorWrapper";
-import { ModalProps } from "../../types";
+import { ModalParams } from "../../types";
 
-const timelineProps = {
-  id: (state: State, props: ModalProps) =>
-    Urls.extractEntityId(props.params.timelineId),
+interface ModalProps {
+  params: ModalParams;
+  timelines: Timeline[];
+}
+
+const timelinesProps = {
   query: { include: "events" },
   LoadingAndErrorWrapper,
 };
@@ -22,6 +25,15 @@ const collectionProps = {
   id: (state: State, props: ModalProps) =>
     Urls.extractCollectionId(props.params.slug),
   LoadingAndErrorWrapper,
+};
+
+const mapStateToProps = (state: State, { timelines, params }: ModalProps) => {
+  const timelineId = Urls.extractEntityId(params.timelineId);
+
+  return {
+    timeline: timelines.find(t => t.id === timelineId),
+    isOnlyTimeline: timelines.length === 1,
+  };
 };
 
 const mapDispatchToProps = (dispatch: any) => ({
@@ -34,7 +46,7 @@ const mapDispatchToProps = (dispatch: any) => ({
 });
 
 export default _.compose(
-  Timelines.load(timelineProps),
+  Timelines.loadList(timelinesProps),
   Collections.load(collectionProps),
-  connect(null, mapDispatchToProps),
+  connect(mapStateToProps, mapDispatchToProps),
 )(TimelineDetailsModal);

--- a/frontend/src/metabase/timelines/collections/containers/TimelineDetailsModal/TimelineDetailsModal.tsx
+++ b/frontend/src/metabase/timelines/collections/containers/TimelineDetailsModal/TimelineDetailsModal.tsx
@@ -21,6 +21,7 @@ const timelineProps = {
 const collectionProps = {
   id: (state: State, props: ModalProps) =>
     Urls.extractCollectionId(props.params.slug),
+  LoadingAndErrorWrapper,
 };
 
 const mapDispatchToProps = (dispatch: any) => ({

--- a/frontend/src/metabase/timelines/collections/containers/TimelineDetailsModal/TimelineDetailsModal.tsx
+++ b/frontend/src/metabase/timelines/collections/containers/TimelineDetailsModal/TimelineDetailsModal.tsx
@@ -16,24 +16,25 @@ interface ModalProps {
   timelines: Timeline[];
 }
 
+const timelineProps = {
+  id: (state: State, props: ModalProps) =>
+    Urls.extractEntityId(props.params.timelineId),
+  query: { include: "events" },
+  LoadingAndErrorWrapper,
+};
+
 const timelinesProps = {
   query: { include: "events" },
   LoadingAndErrorWrapper,
 };
 
+const mapStateToProps = (state: State, { timelines }: ModalProps) => ({
+  isOnlyTimeline: timelines.length === 1,
+});
+
 const collectionProps = {
   id: (state: State, props: ModalProps) =>
     Urls.extractCollectionId(props.params.slug),
-  LoadingAndErrorWrapper,
-};
-
-const mapStateToProps = (state: State, { timelines, params }: ModalProps) => {
-  const timelineId = Urls.extractEntityId(params.timelineId);
-
-  return {
-    timeline: timelines.find(t => t.id === timelineId),
-    isOnlyTimeline: timelines.length === 1,
-  };
 };
 
 const mapDispatchToProps = (dispatch: any) => ({
@@ -46,6 +47,7 @@ const mapDispatchToProps = (dispatch: any) => ({
 });
 
 export default _.compose(
+  Timelines.load(timelineProps),
   Timelines.loadList(timelinesProps),
   Collections.load(collectionProps),
   connect(mapStateToProps, mapDispatchToProps),

--- a/frontend/test/metabase/scenarios/collections/timelines.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/timelines.cy.spec.js
@@ -215,6 +215,23 @@ describe("scenarios > collections > timelines", () => {
       cy.findByText("No events found").should("be.visible");
     });
 
+    it("should show the back button in timeline details", () => {
+      cy.createTimeline({ name: "Releases" });
+      cy.createTimeline({ name: "Metrics" });
+
+      cy.visit(`/collection/root/timelines/1`);
+      cy.findByText("Releases");
+      cy.icon("chevronleft").should("be.visible");
+    });
+
+    it("should not show the back button for the single timeline", () => {
+      cy.createTimeline({ name: "Releases" });
+
+      cy.visit(`/collection/root/timelines/1`);
+      cy.findByText("Releases");
+      cy.icon("chevronleft").should("not.exist");
+    });
+
     it("should create an additional timeline", () => {
       cy.createTimelineWithEvents({
         timeline: { name: "Releases" },

--- a/frontend/test/metabase/scenarios/collections/timelines.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/timelines.cy.spec.js
@@ -215,16 +215,19 @@ describe("scenarios > collections > timelines", () => {
       cy.findByText("No events found").should("be.visible");
     });
 
-    it("should show the back button in timeline details", () => {
+    it("should allow navigating back to the list of timelines", () => {
       cy.createTimeline({ name: "Releases" });
       cy.createTimeline({ name: "Metrics" });
 
       cy.visit(`/collection/root/timelines/1`);
       cy.findByText("Releases");
-      cy.icon("chevronleft").should("be.visible");
+
+      cy.icon("chevronleft").click();
+      cy.findByText("Releases");
+      cy.findByText("Metrics");
     });
 
-    it("should not show the back button for the single timeline", () => {
+    it("should not allow navigating back when there is only one timeline in a collection", () => {
       cy.createTimeline({ name: "Releases" });
 
       cy.visit(`/collection/root/timelines/1`);


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/20289

When viewing timeline details, the back button should only be visible when there are multiple timelines in a collection.

How to test:
- There are 2 new cypress tests for cases when there should and should not be the button.

<img width="659" alt="Screenshot 2022-04-07 at 18 23 33" src="https://user-images.githubusercontent.com/8542534/162221762-781866d0-b4eb-4998-942e-e9c6c22e4fa6.png">
