### PR TITLE
improve the positioning of the settings trigger

### DIFF
--- a/frontend/src/metabase/components/Icon.tsx
+++ b/frontend/src/metabase/components/Icon.tsx
@@ -34,6 +34,10 @@ export const IconWrapper = styled.div<IconWrapperProps>`
   }
   ${hover};
   transition: all 300ms ease-in-out;
+
+  @media (prefers-reduced-motion) {
+    transition: none;
+  }
 `;
 
 IconWrapper.defaultProps = {

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.styled.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.styled.tsx
@@ -21,6 +21,7 @@ export const NavRoot = styled.nav<{ isOpen: boolean }>`
 
   overflow-x: hidden;
   overflow-y: auto;
+  padding-bottom: 4rem;
 
   opacity: ${props => (props.isOpen ? 1 : 0)};
   transition: opacity 0.2s;
@@ -93,7 +94,15 @@ export const LoadingTitle = styled.h2`
 `;
 
 export const ProfileLinkContainer = styled.div`
-  margin-left: auto;
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  padding: ${space(0)};
+  width: ${NAV_SIDEBAR_WIDTH};
+  border-top: 1px solid ${color("border")};
+  background-color: ${color("white")};
+  display: flex;
+  align-items: center;
   margin-right: ${space(2)};
   color: ${color("text-light")};
 `;

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.styled.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.styled.tsx
@@ -93,12 +93,12 @@ export const LoadingTitle = styled.h2`
   margin-top: ${space(1)};
 `;
 
-export const ProfileLinkContainer = styled.div`
+export const ProfileLinkContainer = styled.div<{ isOpen: boolean }>`
   position: fixed;
   bottom: 0;
   left: 0;
   padding: ${space(0)};
-  width: ${NAV_SIDEBAR_WIDTH};
+  width: ${props => (props.isOpen ? NAV_SIDEBAR_WIDTH : 0)};
   border-top: 1px solid ${color("border")};
   background-color: ${color("white")};
   display: flex;

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer.tsx
@@ -140,6 +140,7 @@ function MainNavbarContainer({
       {allFetched && rootCollection ? (
         <MainNavbarView
           {...props}
+          isOpen={isOpen}
           currentUser={currentUser}
           collections={collectionTree}
           selectedItem={selectedItem}

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarView.tsx
@@ -39,6 +39,7 @@ interface CollectionTreeItem extends Collection {
 }
 
 type Props = {
+  isOpen: boolean;
   currentUser: User;
   bookmarks: Bookmark[];
   collections: CollectionTreeItem[];
@@ -52,6 +53,7 @@ const OTHER_USERS_COLLECTIONS_URL = Urls.collection({ id: "users" });
 const ARCHIVE_URL = "/archive";
 
 function MainNavbarView({
+  isOpen,
   currentUser,
   bookmarks,
   collections,
@@ -125,7 +127,7 @@ function MainNavbarView({
         </ul>
       </div>
       {!IFRAMED && (
-        <ProfileLinkContainer>
+        <ProfileLinkContainer isOpen={isOpen}>
           <ProfileLink user={currentUser} handleCloseNavbar={onItemSelect} />
         </ProfileLinkContainer>
       )}


### PR DESCRIPTION
Previously the settings "gear" trigger to get to the admin app was positioned at the bottom of your bookmarks and collections, rather than being fixed to the window. 

Before:
![Screen Shot 2022-04-07 at 1 56 21 PM](https://user-images.githubusercontent.com/5248953/162266738-6dbca390-57b5-48ae-bcbb-f65150829881.png)
![Screen Shot 2022-04-07 at 1 56 15 PM](https://user-images.githubusercontent.com/5248953/162266761-92fbd5cc-00f0-4d0f-adca-5adc3ae83752.png)
(Where's my gear!)

After:
![Screen Shot 2022-04-07 at 1 53 51 PM](https://user-images.githubusercontent.com/5248953/162266511-e19d0d14-b609-473f-af2f-2d7ab88b318f.png)

This PR also adds padding to the bottom of the sidebar to account for the size of the fixed area for the trigger
![Screen Shot 2022-04-07 at 1 54 07 PM](https://user-images.githubusercontent.com/5248953/162266487-e4b6e6f2-d555-4c14-9c0a-d4de96b5710f.png)

