### PR TITLE
DB detail editing permission enforcement

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/common.clj
@@ -12,7 +12,8 @@
            {:can_access_setting      (perms/set-has-general-permission-of-type? permissions-set :setting)
             :can_access_subscription (perms/set-has-general-permission-of-type? permissions-set :subscription)
             :can_access_monitoring   (perms/set-has-general-permission-of-type? permissions-set :monitoring)
-            :can_access_data_model   (perms/set-has-partial-permissions? permissions-set "/data-model/")})))
+            :can_access_data_model   (perms/set-has-partial-permissions? permissions-set "/data-model/")
+            :can_access_db_details   (perms/set-has-partial-permissions? permissions-set "/details/")})))
 
 (defn current-user-has-general-permissions?
   "Check if `*current-user*` has permissions for a general permissions of type `perm-type`."

--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions.clj
@@ -123,7 +123,9 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 (defn data-model-write-perms-path
-  "Returns the permissions path required to edit the data model for a table specified by `path-components`."
+  "Returns the permissions path required to edit the data model for a table specified by `path-components`.
+  This is a simple wrapper around `perms/feature-perms-path`, but it lives in an EE namespace to ensure that data model
+  permissions only work when EE code can be loaded."
   [& path-components]
   (apply (partial perms/feature-perms-path :data-model :all) path-components))
 
@@ -176,6 +178,13 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                          Data model permissions                                                |
 ;;; +----------------------------------------------------------------------------------------------------------------+
+
+(defn db-details-write-perms-path
+  "Returns the permissions path required to edit the database details for the provided database ID.
+  This is a simple wrapper around `perms/feature-perms-path`, but it lives in an EE namespace to ensure that database
+  permissions only work when EE code can be loaded."
+  [db-id]
+  (perms/feature-perms-path :details :yes db-id))
 
 (s/defn update-db-details-permissions!
   "Update the DB details permissions for a database."

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -22,14 +22,16 @@
           (is (= {:can_access_setting      true
                   :can_access_subscription true
                   :can_access_monitoring   true
-                  :can_access_data_model   true}
+                  :can_access_data_model   true
+                  :can_access_db_details   true}
                  (user-permissions :crowberto))))
 
         (testing "non-admin users should only have subscriptions enabled by default"
           (is (= {:can_access_setting      false
                   :can_access_subscription true
                   :can_access_monitoring   false
-                  :can_access_data_model   false}
+                  :can_access_data_model   false
+                  :can_access_db_details   false}
                  (user-permissions :rasta))))
 
         (testing "can_access_data_model is true if a user has any data model perms"
@@ -42,6 +44,12 @@
                                                                                id-3 :none
                                                                                id-4 :none}}}))
             (is (partial= {:can_access_data_model   true}
+                          (user-permissions :rasta)))))
+
+        (testing "can_access_db_details is true if a user has any details perms"
+          (mt/with-model-cleanup [Permissions]
+            (ee-perms/update-db-details-permissions! (u/the-id (group/all-users)) (mt/id) :yes)
+            (is (partial= {:can_access_db_details true}
                           (user-permissions :rasta)))))))))
 
 

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -1,9 +1,11 @@
 (ns metabase-enterprise.advanced-permissions.common-test
   (:require [cheshire.core :as json]
+            [clojure.core.memoize :as memoize]
             [clojure.test :refer :all]
             [metabase-enterprise.advanced-permissions.models.permissions :as ee-perms]
-            [metabase.models :refer [Field Permissions Table]]
+            [metabase.models :refer [Database Field Permissions Table]]
             [metabase.models.database :as database]
+            [metabase.models.field :as field]
             [metabase.models.permissions :as perms]
             [metabase.models.permissions-group :as group]
             [metabase.public-settings.premium-features-test :as premium-features-test]
@@ -53,10 +55,12 @@
     (premium-features-test/with-premium-features #{:advanced-permissions}
       (mt/with-model-cleanup [Permissions]
         (@#'perms/update-group-permissions! all-users-group-id graph)
+        (memoize/memo-clear! @#'field/cached-perms-object-set)
         (f)))))
 
 (defmacro ^:private with-all-users-data-perms
-  "Runs `f` with perms for the All Users group temporarily set to the values in `graph`"
+  "Runs `f` with perms for the All Users group temporarily set to the values in `graph`. Also enables the advanced
+  permissions feature flag, and clears the (5 second TTL) cache used for Field permissions, for convenience."
   [graph & body]
   `(do-with-all-user-data-perms ~graph (fn [] ~@body)))
 
@@ -79,6 +83,11 @@
     (let [{table-id :id, schema :schema, db-id :db_id} (Table table-id)]
       (testing "PUT /api/field/:id"
         (let [endpoint (format "field/%d" field-id)]
+          (testing "a non-admin cannot update field metadata if the advanced-permissions feature flag is not present"
+            (with-all-users-data-perms {db-id {:data-model {:schemas {schema {table-id :all}}}}}
+              (premium-features-test/with-premium-features #{}
+                (mt/user-http-request :rasta :put 403 endpoint {:name "Field Test 4"}))))
+
           (testing "a non-admin cannot update field metadata if they have no data model permissions for the DB"
             (with-all-users-data-perms {db-id {:data-model {:schemas :none}}}
               (mt/user-http-request :rasta :put 403 endpoint {:name "Field Test 2"})))
@@ -108,23 +117,28 @@
 
       (testing "POST /api/field/:id/rescan_values"
         (testing "A non-admin can trigger a rescan of field values if they have data model perms for the table"
-          (with-all-users-data-perms {(mt/id) {:data-model {:schemas {"PUBLIC" {table-id :none}}}}}
+          (with-all-users-data-perms {(mt/id) {:data-model {:schemas {schema {table-id :none}}}}}
             (mt/user-http-request :rasta :post 403 (format "field/%d/rescan_values" field-id)))
-          (with-all-users-data-perms {(mt/id) {:data-model {:schemas {"PUBLIC" {table-id :all}}}}}
+          (with-all-users-data-perms {(mt/id) {:data-model {:schemas {schema {table-id :all}}}}}
             (mt/user-http-request :rasta :post 200 (format "field/%d/rescan_values" field-id)))))
 
       (testing "POST /api/field/:id/discard_values"
         (testing "A non-admin can discard field values if they have data model perms for the table"
-          (with-all-users-data-perms {(mt/id) {:data-model {:schemas {"PUBLIC" {table-id :none}}}}}
+          (with-all-users-data-perms {(mt/id) {:data-model {:schemas {schema {table-id :none}}}}}
             (mt/user-http-request :rasta :post 403 (format "field/%d/discard_values" field-id)))
 
-          (with-all-users-data-perms {(mt/id) {:data-model {:schemas {"PUBLIC" {table-id :all}}}}}
+          (with-all-users-data-perms {(mt/id) {:data-model {:schemas {schema {table-id :all}}}}}
             (mt/user-http-request :rasta :post 200 (format "field/%d/discard_values" field-id))))))))
 
 (deftest update-table-test
   (mt/with-temp Table [{table-id :id} {:db_id (mt/id) :schema "PUBLIC"}]
     (testing "PUT /api/table/:id"
       (let [endpoint (format "table/%d" table-id)]
+        (testing "a non-admin cannot update table metadata if the advanced-permissions feature flag is not present"
+          (with-all-users-data-perms {(mt/id) {:data-model {:schemas :all}}}
+            (premium-features-test/with-premium-features #{}
+              (mt/user-http-request :rasta :put 403 endpoint {:name "Table Test 2"}))))
+
         (testing "a non-admin cannot update table metadata if they have no data model permissions for the DB"
           (with-all-users-data-perms {(mt/id) {:data-model {:schemas :none}}}
             (mt/user-http-request :rasta :put 403 endpoint {:name "Table Test 2"})))
@@ -177,3 +191,39 @@
           (with-all-users-data-perms {(mt/id) {:data-model {:schemas {"PUBLIC" {table-id :all}}}}}
             (mt/user-http-request :rasta :put 200 (format "table/%d/fields/order" table-id)
                                   {:request-options {:body (json/encode [field-2-id field-1-id])}})))))))
+
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                  Database details permission enforcement                                       |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+(deftest update-database-test
+  (testing "PUT /api/database/:id"
+    (mt/with-temp Database [{db-id :id}]
+      (testing "A non-admin cannot update database metadata if the advanced-permissions feature flag is not present"
+        (with-all-users-data-perms {db-id {:details :yes}}
+          (premium-features-test/with-premium-features #{}
+            (mt/user-http-request :rasta :put 403 (format "database/%d" db-id) {:name "Database Test"}))))
+
+      (testing "A non-admin cannot update database metadata if they do not have DB details permissions"
+        (with-all-users-data-perms {db-id {:details :no}}
+          (mt/user-http-request :rasta :put 403 (format "database/%d" db-id) {:name "Database Test"})))
+
+      (testing "A non-admin can update database metadata if they have DB details permissions"
+        (with-all-users-data-perms {db-id {:details :yes}}
+          (mt/user-http-request :rasta :put 200 (format "database/%d" db-id) {:name "Database Test"}))))))
+
+(deftest delete-database-test
+  (mt/with-temp Database [{db-id :id}]
+    (testing "A non-admin cannot delete a database if the advanced-permissions feature flag is not present"
+      (with-all-users-data-perms {db-id {:details :yes}}
+        (premium-features-test/with-premium-features #{}
+          (mt/user-http-request :rasta :delete 403 (format "database/%d" db-id)))))
+
+    (testing "A non-admin cannot update database metadata if they do not have DB details permissions"
+      (with-all-users-data-perms {db-id {:details :no}}
+        (mt/user-http-request :rasta :delete 403 (format "database/%d" db-id))))
+
+    (testing "A non-admin can update database metadata if they have DB details permissions"
+      (with-all-users-data-perms {db-id {:details :yes}}
+        (mt/user-http-request :rasta :put 200 (format "database/%d" db-id) {:name "Database Test"})))))

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -227,3 +227,17 @@
     (testing "A non-admin can update database metadata if they have DB details permissions"
       (with-all-users-data-perms {db-id {:details :yes}}
         (mt/user-http-request :rasta :put 200 (format "database/%d" db-id) {:name "Database Test"})))))
+
+(deftest db-operations-test
+  (mt/with-temp Database [{db-id :id}]
+    (testing "A non-admin can trigger a sync of the DB schema if they have DB details permissions"
+      (with-all-users-data-perms {db-id {:details :yes}}
+        (mt/user-http-request :rasta :post 200 (format "database/%d/sync_schema" db-id))))
+
+    (testing "A non-admin can trigger a re-scan of field values if they have DB details permissions"
+      (with-all-users-data-perms {db-id {:details :yes}}
+        (mt/user-http-request :rasta :post 200 (format "database/%d/rescan_values" db-id))))
+
+    (testing "A non-admin can discard saved field values if they have DB details permissions"
+      (with-all-users-data-perms {db-id {:details :yes}}
+        (mt/user-http-request :rasta :post 200 (format "database/%d/discard_values" db-id))))))

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -680,9 +680,8 @@
 (api/defendpoint POST "/:id/sync_schema"
   "Trigger a manual update of the schema metadata for this `Database`."
   [id]
-  (api/check-superuser)
   ;; just wrap this in a future so it happens async
-  (api/let-404 [db (Database id)]
+  (let [db (api/write-check (Database id))]
     (future
       (sync-metadata/sync-db-metadata! db)
       (analyze/analyze-db! db)))
@@ -694,9 +693,8 @@
 (api/defendpoint POST "/:id/rescan_values"
   "Trigger a manual scan of the field values for this `Database`."
   [id]
-  (api/check-superuser)
   ;; just wrap this is a future so it happens async
-  (api/let-404 [db (Database id)]
+  (let [db (api/write-check (Database id))]
     (future
       (sync-field-values/update-field-values! db)))
   {:status :ok})
@@ -720,8 +718,7 @@
 (api/defendpoint POST "/:id/discard_values"
   "Discards all saved field values for this `Database`."
   [id]
-  (api/check-superuser)
-  (delete-all-field-values-for-database! id)
+  (delete-all-field-values-for-database! (api/write-check (Database id)))
   {:status :ok})
 
 

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -594,9 +594,8 @@
    points_of_interest (s/maybe s/Str)
    auto_run_queries   (s/maybe s/Bool)
    cache_ttl          (s/maybe su/IntGreaterThanZero)}
-  (api/check-superuser)
   ;; TODO - ensure that custom schedules and let-user-control-scheduling go in lockstep
-  (api/let-404 [existing-database (Database id)]
+  (let [existing-database (api/write-check (Database id))]
     (let [details    (driver.u/db-details-client->server engine details)
           details    (upsert-sensitive-fields existing-database details)
           conn-error (when (some? details)
@@ -654,7 +653,7 @@
 (api/defendpoint DELETE "/:id"
   "Delete a `Database`."
   [id]
-  (api/let-404 [db (Database id)]
+  (let [db (api/write-check (Database id))]
     (api/write-check db)
     (db/delete! Database :id id)
     (events/publish-event! :database-delete db))

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -183,8 +183,10 @@
       handle-secrets-changes
       (assoc :initial_sync_status "incomplete")))
 
-(defn- perms-objects-set [database _]
-  #{(perms/data-perms-path (u/the-id database))})
+(defn- perms-objects-set [database read-or-write]
+  #{(case read-or-write
+      :read (perms/data-perms-path (u/the-id database))
+      :write (perms/db-details-write-perms-path (u/the-id database)))})
 
 (u/strict-extend (class Database)
   models/IModel
@@ -207,7 +209,7 @@
   (merge i/IObjectPermissionsDefaults
          {:perms-objects-set perms-objects-set
           :can-read?         (partial i/current-user-has-partial-permissions? :read)
-          :can-write?        i/superuser?}))
+          :can-write?        (partial i/current-user-has-full-permissions? :write)}))
 
 
 ;;; ---------------------------------------------- Hydration / Util Fns ----------------------------------------------

--- a/src/metabase/models/permissions.clj
+++ b/src/metabase/models/permissions.clj
@@ -487,10 +487,22 @@
   permissions path for the table. Otherwise, defaults to the root path ('/'), thus restricting writes to admins."
   [db-id schema table-id]
   (let [f (u/ignore-exceptions
-           (classloader/require ' metabase-enterprise.advanced-permissions.models.permissions)
-           (resolve ' metabase-enterprise.advanced-permissions.models.permissions/data-model-write-perms-path))]
-    (if (and f premium-features/enable-advanced-permissions?)
+           (classloader/require 'metabase-enterprise.advanced-permissions.models.permissions)
+           (resolve 'metabase-enterprise.advanced-permissions.models.permissions/data-model-write-perms-path))]
+    (if (and f (premium-features/enable-advanced-permissions?))
       (f db-id schema table-id)
+      "/")))
+
+(s/defn db-details-write-perms-path :- Path
+  "Returns the permission path required to edit the table specified by the provided args, or a field in the table.
+  If Enterprise Edition code is available, and a valid :advanced-permissions token is present, returns the DB details
+  permissions path for the table. Otherwise, defaults to the root path ('/'), thus restricting writes to admins."
+  [db-id]
+  (let [f (u/ignore-exceptions
+           (classloader/require 'metabase-enterprise.advanced-permissions.models.permissions)
+           (resolve 'metabase-enterprise.advanced-permissions.models.permissions/db-details-write-perms-path))]
+    (if (and f (premium-features/enable-advanced-permissions?))
+      (f db-id)
       "/")))
 
 (s/defn general-perms-path :- Path


### PR DESCRIPTION
Updates the `Database` model so that a write check will pass if a user has DB details permissions for the database.

Updates relevant endpoints to do write checks, rather than superuser checks.

Adds new tests and modifies some existing tests. 