### PR TITLE
Custom expression: fix the confusion of function vs field

### DIFF
--- a/frontend/src/metabase/lib/expressions/diagnostics.js
+++ b/frontend/src/metabase/lib/expressions/diagnostics.js
@@ -18,7 +18,6 @@ import {
   useShorthands,
   adjustCase,
   adjustOptions,
-  transformNoArgFunction,
 } from "metabase/lib/expressions/recursive-parser";
 import { tokenize, TOKEN, OPERATOR } from "metabase/lib/expressions/tokenizer";
 
@@ -125,7 +124,6 @@ function prattCompiler(source, startRule, query) {
       passes: [
         adjustOptions,
         useShorthands,
-        transformNoArgFunction,
         adjustCase,
         expr => resolve(expr, startRule, resolveMBQLField),
       ],

--- a/frontend/src/metabase/lib/expressions/recursive-parser.js
+++ b/frontend/src/metabase/lib/expressions/recursive-parser.js
@@ -303,30 +303,11 @@ export const adjustCase = tree =>
     return node;
   });
 
-// [ "dimension", "count "] becomes ["count"], since Count is a valid no-arg function
-export const transformNoArgFunction = tree =>
-  modify(tree, node => {
-    if (Array.isArray(node)) {
-      const [operator, ...operands] = node;
-      if (operands.length === 1 && operator === "dimension") {
-        const text = operands[0];
-        const fn = getMBQLName(text.trim().toLowerCase());
-
-        // refering a function with no args?
-        if (fn && MBQL_CLAUSES[fn].args.length === 0) {
-          return [fn];
-        }
-      }
-    }
-    return node;
-  });
-
 const pipe = (...fns) => x => fns.reduce((v, f) => f(v), x);
 
 export const parse = pipe(
   recursiveParse,
   adjustOptions,
   useShorthands,
-  transformNoArgFunction,
   adjustCase,
 );

--- a/frontend/test/metabase/lib/expressions/recursive-parser.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/recursive-parser.unit.spec.js
@@ -5,7 +5,6 @@ describe("metabase/lib/expressions/recursive-parser", () => {
   const mockResolve = (kind, name) => [kind, name];
   const process = (source, type) => resolve(parse(source), type, mockResolve);
   const filter = expr => process(expr, "boolean");
-  const aggregation = expr => process(expr, "aggregation");
 
   // handy references
   const X = ["segment", "X"];
@@ -156,8 +155,47 @@ describe("metabase/lib/expressions/recursive-parser", () => {
   });
 
   it("should detect aggregation functions with no argument", () => {
-    expect(aggregation("COUNT/2")).toEqual(["/", ["count"], 2]);
+    const mockResolve = (kind, name) => {
+      if ("ABC".indexOf(name) >= 0) {
+        return [kind, name];
+      }
+      throw new ReferenceError(`Unknown ["${kind}", "${name}"]`);
+    };
+    const type = "aggregation";
+    const aggregation = expr => resolve(parse(expr), type, mockResolve);
+
+    // sanity check first
+    expect(aggregation("SUM(A)")).toEqual(["sum", ["dimension", "A"]]);
+    expect(aggregation("Max(B)")).toEqual(["max", ["dimension", "B"]]);
+    expect(aggregation("Average(C)")).toEqual(["avg", ["dimension", "C"]]);
+
+    // functions without argument, hence no "()"
+    expect(aggregation("Count")).toEqual(["count"]);
+    expect(aggregation("CumulativeCount")).toEqual(["cum-count"]);
+
+    // mixed them in some arithmetic
+    expect(aggregation("COUNT/B")).toEqual(["/", ["count"], ["metric", "B"]]);
     expect(aggregation("1+CumulativeCount")).toEqual(["+", 1, ["cum-count"]]);
+  });
+
+  it("should prioritize existing metrics over functions", () => {
+    const mockResolve = (kind, name) => {
+      if (name === "Count" || "ABC".indexOf(name) >= 0) {
+        return [kind, name];
+      }
+      throw new ReferenceError(`Unknown ["${kind}", "${name}"]`);
+    };
+    const type = "aggregation";
+    const aggregation = expr => resolve(parse(expr), type, mockResolve);
+
+    // sanity check first
+    expect(aggregation("SUM(A)")).toEqual(["sum", ["dimension", "A"]]);
+    expect(aggregation("Max(B)")).toEqual(["max", ["dimension", "B"]]);
+    expect(aggregation("Average(C)")).toEqual(["avg", ["dimension", "C"]]);
+
+    // Count is recognized as a metric instead of a function
+    expect(aggregation("[Count]")).toEqual(["metric", "Count"]);
+    expect(aggregation("[Count] + 7")).toEqual(["+", ["metric", "Count"], 7]);
   });
 
   it("should resolve segments", () => {

--- a/frontend/test/metabase/scenarios/custom-column/reproductions/21513-cc-confusion-field-function.cy.spec.js
+++ b/frontend/test/metabase/scenarios/custom-column/reproductions/21513-cc-confusion-field-function.cy.spec.js
@@ -6,7 +6,7 @@ import {
   enterCustomColumnDetails,
 } from "__support__/e2e/cypress";
 
-describe.skip("issue 21513", () => {
+describe("issue 21513", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();


### PR DESCRIPTION
To verify:
1. New, Question, Sample Database, Products
2. Summarize, Count, group by Category
3. Custom Column and enter `Count / 2`
4. Press Tab

### Before this PR

There is a diagnostics message complaining about the expression: `Expecting number but found function Count returning aggregation`.

![image](https://user-images.githubusercontent.com/7288/162344808-9dc43121-de3b-4e2b-b508-3a947540f730.png)

### After this PR

![image](https://user-images.githubusercontent.com/7288/162344705-fc6a527f-cebd-4d09-ae89-685737bc6b0f.png)

### Note

This issue is a regression caused by the previous PR #20432. That PR is apparently not entirely correct since it prioritize detecting `Count` as a function with zero argument, even in the situation where `Count` is a perfectly valid field.

This PR takes a different approach. It optimistically treat `Count` as a field reference. But when the resolver fails to recognize it, because there is no such field, then it falls back to assuming it as a function.

