### PR TITLE
Hide subscriptions and alerts editing buttons in account settings

### DIFF
--- a/frontend/src/metabase/account/notifications/components/NotificationCard/NotificationCard.jsx
+++ b/frontend/src/metabase/account/notifications/components/NotificationCard/NotificationCard.jsx
@@ -24,9 +24,17 @@ const propTypes = {
   user: PropTypes.object.isRequired,
   onUnsubscribe: PropTypes.func,
   onArchive: PropTypes.func,
+  isEditable: PropTypes.bool,
 };
 
-const NotificationCard = ({ item, type, user, onUnsubscribe, onArchive }) => {
+const NotificationCard = ({
+  item,
+  type,
+  user,
+  isEditable,
+  onUnsubscribe,
+  onArchive,
+}) => {
   const hasArchive = canArchive(item, user);
 
   const onUnsubscribeClick = useCallback(() => {
@@ -54,14 +62,15 @@ const NotificationCard = ({ item, type, user, onUnsubscribe, onArchive }) => {
           </NotificationMessage>
         </NotificationDescription>
       </NotificationContent>
-      {!hasArchive && (
+
+      {isEditable && !hasArchive && (
         <NotificationIcon
           name="close"
           tooltip={t`Unsubscribe`}
           onClick={onUnsubscribeClick}
         />
       )}
-      {hasArchive && (
+      {isEditable && hasArchive && (
         <NotificationIcon
           name="close"
           tooltip={t`Delete`}

--- a/frontend/src/metabase/account/notifications/components/NotificationCard/NotificationCard.unit.spec.js
+++ b/frontend/src/metabase/account/notifications/components/NotificationCard/NotificationCard.unit.spec.js
@@ -132,6 +132,7 @@ describe("NotificationCard", () => {
         user={user}
         onUnsubscribe={onUnsubscribe}
         onArchive={onArchive}
+        isEditable
       />,
     );
 
@@ -157,12 +158,32 @@ describe("NotificationCard", () => {
         user={creator}
         onUnsubscribe={onUnsubscribe}
         onArchive={onArchive}
+        isEditable
       />,
     );
 
     fireEvent.click(screen.getByLabelText("close icon"));
     expect(onUnsubscribe).toHaveBeenCalledWith(alert, "alert");
     expect(onArchive).not.toHaveBeenCalled();
+  });
+
+  it("should hide archive button when not editable", () => {
+    const creator = getUser();
+    const alert = getAlert({ creator });
+    const onUnsubscribe = jest.fn();
+    const onArchive = jest.fn();
+
+    render(
+      <NotificationCard
+        item={alert}
+        type="alert"
+        user={creator}
+        onUnsubscribe={onUnsubscribe}
+        onArchive={onArchive}
+      />,
+    );
+
+    expect(screen.queryByLabelText("close icon")).toBeNull();
   });
 
   it("should archive when the user is the creator and not subscribed", () => {
@@ -178,6 +199,7 @@ describe("NotificationCard", () => {
         user={creator}
         onUnsubscribe={onUnsubscribe}
         onArchive={onArchive}
+        isEditable
       />,
     );
 
@@ -202,6 +224,7 @@ describe("NotificationCard", () => {
         user={creator}
         onUnsubscribe={onUnsubscribe}
         onArchive={onArchive}
+        isEditable
       />,
     );
 

--- a/frontend/src/metabase/account/notifications/components/NotificationList/NotificationList.jsx
+++ b/frontend/src/metabase/account/notifications/components/NotificationList/NotificationList.jsx
@@ -15,6 +15,7 @@ const propTypes = {
   items: PropTypes.array.isRequired,
   user: PropTypes.object.isRequired,
   children: PropTypes.node,
+  canManageSubscriptions: PropTypes.bool,
   onHelp: PropTypes.func,
   onUnsubscribe: PropTypes.func,
   onArchive: PropTypes.func,
@@ -24,6 +25,7 @@ const NotificationList = ({
   items,
   user,
   children,
+  canManageSubscriptions,
   onHelp,
   onUnsubscribe,
   onArchive,
@@ -46,6 +48,7 @@ const NotificationList = ({
           item={item}
           type={type}
           user={user}
+          isEditable={canManageSubscriptions}
           onUnsubscribe={onUnsubscribe}
           onArchive={onArchive}
         />

--- a/frontend/src/metabase/account/notifications/containers/NotificationsApp/NotificationsApp.jsx
+++ b/frontend/src/metabase/account/notifications/containers/NotificationsApp/NotificationsApp.jsx
@@ -2,7 +2,11 @@ import { connect } from "react-redux";
 import _ from "underscore";
 import Alerts from "metabase/entities/alerts";
 import Pulses from "metabase/entities/pulses";
-import { getUser, getUserId } from "metabase/selectors/user";
+import {
+  getUser,
+  getUserId,
+  canManageSubscriptions,
+} from "metabase/selectors/user";
 import {
   navigateToArchive,
   navigateToHelp,
@@ -14,6 +18,7 @@ import NotificationList from "../../components/NotificationList";
 const mapStateToProps = (state, props) => ({
   user: getUser(state),
   items: getNotifications(props),
+  canManageSubscriptions: canManageSubscriptions(state),
 });
 
 const mapDispatchToProps = {


### PR DESCRIPTION
## Changes

Hide archive/unsubscribe buttons from the Account Settings -> Notifications tab

<img width="616" alt="Screenshot 2022-04-08 at 00 37 54" src="https://user-images.githubusercontent.com/14301985/162364545-d1e4d7d2-00c9-472b-aa6b-baac6f9124cf.png">

## How to verify
- Create a Test User
- Ensure Subscriptions & Alerts general permission is revoked from "All Users"
- As a Test User go to Account Settings -> [Notifications](http://localhost:3000/account/notifications) and ensure there are no archive/unsubscribe buttons

