### PR TITLE
Fix failed to restore non-nil setting during tests

### DIFF
--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -379,7 +379,9 @@
                            (throw e))))]
     (if-let [env-var-value (and (not raw-setting?) (#'setting/env-var-value setting-k))]
       (do-with-temp-env-var-value setting env-var-value thunk)
-      (let [original-value (db/select-one-field :value Setting :key setting-k)]
+      (let [original-value (if raw-setting?
+                             (db/select-one-field :value Setting :key setting-k)
+                             (#'setting/get setting-k))]
         (try
          (if raw-setting?
            (upsert-raw-setting! original-value setting-k value)


### PR DESCRIPTION
This PR fixes cases where the `with-temporary-setting-values` macro failed to restore the original value for settings that have non-nil value.

Example of failed case: https://app.circleci.com/pipelines/github/metabase/metabase/32972/workflows/e625bb8c-e231-4eca-a0ff-acfd219b236a