### PR TITLE
Add settings to manage model persistence globally

### DIFF
--- a/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.unit.spec.js
+++ b/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.unit.spec.js
@@ -6,7 +6,12 @@ import Sidebar from "./Sidebar";
 
 it("syncs database schema", () => {
   const databaseId = 1;
-  const database = { id: databaseId, initial_sync_status: "complete" };
+  const database = {
+    id: databaseId,
+    initial_sync_status: "complete",
+    supportsPersistence: () => true,
+    isPersisted: () => false,
+  };
   const syncDatabaseSchema = jest.fn();
 
   render(
@@ -22,7 +27,12 @@ it("syncs database schema", () => {
 
 it("rescans database field values", () => {
   const databaseId = 1;
-  const database = { id: databaseId, initial_sync_status: "complete" };
+  const database = {
+    id: databaseId,
+    initial_sync_status: "complete",
+    supportsPersistence: () => true,
+    isPersisted: () => false,
+  };
   const rescanDatabaseFields = jest.fn();
 
   render(
@@ -38,7 +48,12 @@ it("rescans database field values", () => {
 
 it("discards saved field values", () => {
   const databaseId = 1;
-  const database = { id: databaseId, initial_sync_status: "complete" };
+  const database = {
+    id: databaseId,
+    initial_sync_status: "complete",
+    supportsPersistence: () => true,
+    isPersisted: () => false,
+  };
   const discardSavedFieldValues = jest.fn();
 
   render(
@@ -70,7 +85,12 @@ it("discards saved field values", () => {
 it("removes database", () => {
   const databaseId = 1;
   const name = "DB Name";
-  const database = { id: databaseId, name };
+  const database = {
+    id: databaseId,
+    name,
+    supportsPersistence: () => true,
+    isPersisted: () => false,
+  };
   const deleteDatabase = jest.fn();
 
   render(<Sidebar database={database} deleteDatabase={deleteDatabase} />);
@@ -100,7 +120,12 @@ it("removes database", () => {
 
 it("shows loading indicator when a sync is in progress", () => {
   const databaseId = 1;
-  const database = { id: databaseId, initial_sync_status: "incomplete" };
+  const database = {
+    id: databaseId,
+    initial_sync_status: "incomplete",
+    supportsPersistence: () => true,
+    isPersisted: () => false,
+  };
 
   render(<Sidebar database={database} />);
 

--- a/frontend/src/metabase/admin/settings/components/widgets/PersistedModelRefreshIntervalWidget.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/PersistedModelRefreshIntervalWidget.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+
+import Radio from "metabase/core/components/Radio";
+
+import { PersistedModelsApi } from "metabase/services";
+
+type Props = {
+  setting: {
+    key: string;
+    value: number;
+    default: number;
+    options: Record<string, string>;
+  };
+  disabled?: boolean;
+  onChangeSetting: (setting: string, value: unknown) => void;
+};
+
+const PersistedModelRefreshIntervalWidget = ({
+  setting,
+  disabled,
+  onChangeSetting,
+}: Props) => {
+  return (
+    <Radio
+      className="mt2"
+      variant="bubble"
+      disabled={disabled}
+      value={setting.value || setting.default}
+      onChange={async hours => {
+        await PersistedModelsApi.setRefreshInterval({ hours });
+        onChangeSetting(setting.key, hours);
+      }}
+      options={Object.entries(setting.options).map(([value, name]) => ({
+        name,
+        value: Number(value),
+      }))}
+    />
+  );
+};
+
+export default PersistedModelRefreshIntervalWidget;

--- a/frontend/src/metabase/admin/settings/components/widgets/PersistingModelsToggleWidget.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/PersistingModelsToggleWidget.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { t } from "ttag";
+
+import Toggle from "metabase/core/components/Toggle";
+
+import { PersistedModelsApi } from "metabase/services";
+
+type Props = {
+  setting: {
+    key: string;
+    value: boolean | string;
+    default: number;
+    options: Record<string, string>;
+  };
+  disabled?: boolean;
+  onChangeSetting: (setting: string, value: unknown) => void;
+};
+
+const PersistingModelsToggleWidget = ({
+  setting,
+  onChangeSetting,
+  disabled,
+}: Props) => {
+  const value = setting.value == null ? setting.default : setting.value;
+  const on = value === true || value === "true";
+
+  async function onChange() {
+    if (disabled) {
+      return;
+    }
+    if (on) {
+      await PersistedModelsApi.disablePersistence();
+    } else {
+      await PersistedModelsApi.enablePersistence();
+    }
+    onChangeSetting(setting.key, !on);
+  }
+
+  return (
+    <div className="flex align-center pt1">
+      <Toggle value={on} onChange={onChange} />
+      <span className="text-bold mx1">{on ? t`Enabled` : t`Disabled`}</span>
+    </div>
+  );
+};
+
+export default PersistingModelsToggleWidget;

--- a/frontend/src/metabase/admin/settings/components/widgets/SectionDivider.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/SectionDivider.tsx
@@ -1,0 +1,10 @@
+import styled from "@emotion/styled";
+import { color } from "metabase/lib/colors";
+
+const SectionDivider = styled.div`
+  width: 100%;
+  height: 1px;
+  background-color: ${color("border")};
+`;
+
+export default SectionDivider;

--- a/frontend/src/metabase/admin/settings/selectors.js
+++ b/frontend/src/metabase/admin/settings/selectors.js
@@ -367,7 +367,7 @@ const SECTIONS = updateSectionsWithPlugins({
     settings: [
       {
         key: "enable-query-caching",
-        display_name: t`Enable Caching`,
+        display_name: t`Saved questions`,
         type: "boolean",
       },
       {

--- a/frontend/src/metabase/admin/settings/selectors.js
+++ b/frontend/src/metabase/admin/settings/selectors.js
@@ -21,6 +21,7 @@ import EmbeddingLegalese from "./components/widgets/EmbeddingLegalese";
 import FormattingWidget from "./components/widgets/FormattingWidget";
 import { PremiumEmbeddingLinkWidget } from "./components/widgets/PremiumEmbeddingLinkWidget";
 import PersistedModelRefreshIntervalWidget from "./components/widgets/PersistedModelRefreshIntervalWidget";
+import PersistingModelsToggleWidget from "./components/widgets/PersistingModelsToggleWidget";
 import SectionDivider from "./components/widgets/SectionDivider";
 import SettingsUpdatesForm from "./components/SettingsUpdatesForm/SettingsUpdatesForm";
 import SettingsEmailForm from "./components/SettingsEmailForm";
@@ -400,14 +401,21 @@ const SECTIONS = updateSectionsWithPlugins({
         widget: SectionDivider,
       },
       {
-        key: "persisted-model-refresh-interval-hours",
-        display_name: t`Refresh models cache interval`,
+        key: "enabled-persisted-models",
+        display_name: t`Models`,
         description: jt`Enabling cache will create tables for your models in a dedicated schema and Metabase will refresh them on a schedule. Questions based on your models will query these tables. ${(
           <ExternalLink
             key="model-caching-link"
-            href="https://metabase.com"
+            href={MetabaseSettings.docsUrl("users-guide/models")}
           >{t`Learn more`}</ExternalLink>
         )}.`,
+        type: "boolean",
+        widget: PersistingModelsToggleWidget,
+      },
+      {
+        key: "persisted-model-refresh-interval-hours",
+        description: "",
+        display_name: t`Refresh every`,
         type: "radio",
         options: {
           1: t`Hour`,
@@ -418,6 +426,7 @@ const SECTIONS = updateSectionsWithPlugins({
           24: t`24 hours`,
         },
         widget: PersistedModelRefreshIntervalWidget,
+        getHidden: settings => !settings["enabled-persisted-models"],
       },
     ],
   },

--- a/frontend/src/metabase/admin/settings/selectors.js
+++ b/frontend/src/metabase/admin/settings/selectors.js
@@ -1,7 +1,10 @@
+/* eslint-disable react/display-name */
+import React from "react";
 import _ from "underscore";
 import { createSelector } from "reselect";
+import { t, jt } from "ttag";
+import ExternalLink from "metabase/core/components/ExternalLink";
 import MetabaseSettings from "metabase/lib/settings";
-import { t } from "ttag";
 import CustomGeoJSONWidget from "./components/widgets/CustomGeoJSONWidget";
 import SettingsLicense from "./components/SettingsLicense";
 import SiteUrlWidget from "./components/widgets/SiteUrlWidget";
@@ -17,6 +20,8 @@ import SecretKeyWidget from "./components/widgets/SecretKeyWidget";
 import EmbeddingLegalese from "./components/widgets/EmbeddingLegalese";
 import FormattingWidget from "./components/widgets/FormattingWidget";
 import { PremiumEmbeddingLinkWidget } from "./components/widgets/PremiumEmbeddingLinkWidget";
+import PersistedModelRefreshIntervalWidget from "./components/widgets/PersistedModelRefreshIntervalWidget";
+import SectionDivider from "./components/widgets/SectionDivider";
 import SettingsUpdatesForm from "./components/SettingsUpdatesForm/SettingsUpdatesForm";
 import SettingsEmailForm from "./components/SettingsEmailForm";
 import SettingsSetupList from "./components/SettingsSetupList";
@@ -390,6 +395,29 @@ const SECTIONS = updateSectionsWithPlugins({
         type: "number",
         getHidden: settings => !settings["enable-query-caching"],
         allowValueCollection: true,
+      },
+      {
+        widget: SectionDivider,
+      },
+      {
+        key: "persisted-model-refresh-interval-hours",
+        display_name: t`Refresh models cache interval`,
+        description: jt`Enabling cache will create tables for your models in a dedicated schema and Metabase will refresh them on a schedule. Questions based on your models will query these tables. ${(
+          <ExternalLink
+            key="model-caching-link"
+            href="https://metabase.com"
+          >{t`Learn more`}</ExternalLink>
+        )}.`,
+        type: "radio",
+        options: {
+          1: t`Hour`,
+          2: t`2 hours`,
+          3: t`3 hours`,
+          6: t`6 hours`,
+          12: t`12 hours`,
+          24: t`24 hours`,
+        },
+        widget: PersistedModelRefreshIntervalWidget,
       },
     ],
   },

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -425,6 +425,8 @@ export const PermissionsApi = {
 };
 
 export const PersistedModelsApi = {
+  enablePersistence: POST("/api/persist/enable"),
+  disablePersistence: POST("/api/persist/disable"),
   setRefreshInterval: POST("/api/persist/set-interval"),
 };
 

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -424,6 +424,10 @@ export const PermissionsApi = {
   deleteGroup: DELETE("/api/permissions/group/:id"),
 };
 
+export const PersistedModelsApi = {
+  setRefreshInterval: POST("/api/persist/set-interval"),
+};
+
 export const SetupApi = {
   create: POST("/api/setup"),
   validate_db: POST("/api/setup/validate"),

--- a/frontend/test/metabase/query_builder/components/QuestionActionButtons.unit.spec.js
+++ b/frontend/test/metabase/query_builder/components/QuestionActionButtons.unit.spec.js
@@ -31,9 +31,13 @@ function setup({
       database: () => ({
         hasFeature: feature =>
           feature === "nested-queries" ? questionDatabaseSupportsModels : true,
+        supportsPersistence: () => false,
+        isPersisted: () => false,
       }),
     }),
     isDataset: () => isDataModel,
+    isSaved: () => true,
+    isPersisted: () => false,
   };
 
   const settingsState = {


### PR DESCRIPTION
Adds model persistence settings to `/admin/settings/caching` page. From there, you can enable caching and select the cache refresh interval. The next step is to make the rest of the UI respect the settings: e.g. hide/disable persistence controls when it's turned off globally.

### Demo

![CleanShot 2022-04-08 at 15 30 00](https://user-images.githubusercontent.com/17258145/162462815-9ff87208-c9b5-487e-bbb3-8ba19cc55af2.gif)

