### PR TITLE
Catch exception during sync group

### DIFF
--- a/src/metabase/integrations/common.clj
+++ b/src/metabase/integrations/common.clj
@@ -35,7 +35,8 @@
          ;; [[metabase.models.permissions-group-membership/PermissionsGroupMembership]] will throw an exception.
          ;; but we don't want to block user from logging-in, so catch this exception and log a warning
          (if (= (ex-message e) (str pgm/fail-to-remove-last-admin-msg))
-           (log/warn "Attempted to remove the last admin.")
+           (log/warn "Attempted to remove the last admin during group sync!"
+                     "Check your SSO group mappings and make sure the Administrators group is mapped correctly.")
            (throw e)))))
     ;; add new memberships for any groups as needed
     (doseq [id    to-add

--- a/src/metabase/integrations/common.clj
+++ b/src/metabase/integrations/common.clj
@@ -4,7 +4,7 @@
             [clojure.set :as set]
             [clojure.tools.logging :as log]
             [metabase.models.permissions-group :as group]
-            [metabase.models.permissions-group-membership :refer [PermissionsGroupMembership]]
+            [metabase.models.permissions-group-membership :as pgm :refer [PermissionsGroupMembership]]
             [metabase.util :as u]
             [metabase.util.i18n :refer [trs]]
             [toucan.db :as db]))
@@ -28,7 +28,15 @@
     ;; remove membership from any groups as needed
     (when (seq to-remove)
       (log/debugf "Removing user %s from group(s) %s" user-id to-remove)
-      (db/delete! PermissionsGroupMembership :group_id [:in to-remove], :user_id user-id))
+      (try
+       (db/delete! PermissionsGroupMembership :group_id [:in to-remove], :user_id user-id)
+       (catch clojure.lang.ExceptionInfo e
+         ;; in case sync attempts to delete the last admin, the pre-delete hooks of
+         ;; [[metabase.models.permissions-group-membership/PermissionsGroupMembership]] will throw an exception.
+         ;; but we don't want to block user from logging-in, so catch this exception and log a warning
+         (if (= (ex-message e) (str pgm/fail-to-remove-last-admin-msg))
+           (log/warn "Attempted to remove the last admin.")
+           (throw e)))))
     ;; add new memberships for any groups as needed
     (doseq [id    to-add
             :when (not (excluded-group-ids id))]
@@ -36,6 +44,6 @@
       ;; if adding membership fails for one reason or another (i.e. if the group doesn't exist) log the error add the
       ;; user to the other groups rather than failing entirely
       (try
-        (db/insert! PermissionsGroupMembership :group_id id, :user_id user-id)
-        (catch Throwable e
-          (log/error e (trs "Error adding User {0} to Group {1}" user-id id)))))))
+       (db/insert! PermissionsGroupMembership :group_id id, :user_id user-id)
+       (catch Throwable e
+         (log/error e (trs "Error adding User {0} to Group {1}" user-id id)))))))

--- a/src/metabase/models/permissions_group_membership.clj
+++ b/src/metabase/models/permissions_group_membership.clj
@@ -8,6 +8,7 @@
 (models/defmodel PermissionsGroupMembership :permissions_group_membership)
 
 (def fail-to-remove-last-admin-msg
+  "Exception message when try to remove the last admin."
   (deferred-tru "You cannot remove the last member of the ''Admin'' group!"))
 
 (defonce ^:dynamic ^{:doc "Should we allow people to be added to or removed from the All Users permissions group? By

--- a/test/metabase/integrations/common_test.clj
+++ b/test/metabase/integrations/common_test.clj
@@ -103,17 +103,18 @@
           (is (= #{"All Users" "Administrators"}
                  (group-memberships user)))))))
 
-  (testing "Make sure the delete last admin exception are catched"
+  (testing "Make sure the delete last admin exception is catched"
     (with-user-in-groups [user [(group/admin)]]
-      (mt/with-log-level :warn
-        (let [log-warn-count (atom #{})]
-          (with-redefs [db/delete! (fn [model & _args]
-                                     (when (= model PermissionsGroupMembership)
-                                       (throw (ex-info (str pgm/fail-to-remove-last-admin-msg)
-                                                       {:status-code 400}))))
-                        log/warn (fn [msg & _args]
-                                   (swap! log-warn-count conj msg))]
-            ;; make sure sync run without throwing exception
-            (integrations.common/sync-group-memberships! user #{} #{(group/admin)})
-            ;; make sure we log a warning for that
-            (is (@log-warn-count "Attempted to remove the last admin."))))))))
+      (let [log-warn-count (atom #{})]
+        (with-redefs [db/delete! (fn [model & _args]
+                                   (when (= model PermissionsGroupMembership)
+                                     (throw (ex-info (str pgm/fail-to-remove-last-admin-msg)
+                                                     {:status-code 400}))))
+                      log/log* (fn [_logger _level _throwable msg]
+                                 (swap! log-warn-count conj msg))]
+          ;; make sure sync run without throwing exception
+          (integrations.common/sync-group-memberships! user #{} #{(group/admin)})
+          ;; make sure we log a msg for that
+          (is (@log-warn-count
+               (str "Attempted to remove the last admin during group sync! "
+                    "Check your SSO group mappings and make sure the Administrators group is mapped correctly."))))))))

--- a/test/metabase/integrations/common_test.clj
+++ b/test/metabase/integrations/common_test.clj
@@ -110,8 +110,9 @@
                                    (when (= model PermissionsGroupMembership)
                                      (throw (ex-info (str pgm/fail-to-remove-last-admin-msg)
                                                      {:status-code 400}))))
-                      log/log* (fn [_logger _level _throwable msg]
-                                 (swap! log-warn-count conj msg))]
+                      log/log*   (fn [_logger level _throwable msg]
+                                   (when (:= level :warn)
+                                     (swap! log-warn-count conj msg)))]
           ;; make sure sync run without throwing exception
           (integrations.common/sync-group-memberships! user #{} #{(group/admin)})
           ;; make sure we log a msg for that


### PR DESCRIPTION
During group sync, it's possible to set mapping in a way that sync will remove everyone from `admin` group.
But our permission_group_membership has a `pre-delete` hook that'll throw an exception if we try to delete the last admin.

However, this exception will prevent that last admin from logging in. 
So this PR will catch that exception and let the admin login.