### PR TITLE
[E2E] Deprecate `/question/new` route in tests for "Custom question"

### DIFF
--- a/frontend/test/metabase-visual/notebook/notebook.cy.spec.js
+++ b/frontend/test/metabase-visual/notebook/notebook.cy.spec.js
@@ -12,8 +12,7 @@ describe("visual tests > notebook > major UI elements", () => {
   });
 
   it("renders correctly", () => {
-    cy.visit("/question/new");
-    cy.findByText("Custom question").click();
+    startNewQuestion();
     cy.findByTextEnsureVisible("Sample Database").click();
     cy.findByTextEnsureVisible("Orders").click();
 
@@ -67,8 +66,7 @@ describe("visual tests > notebook > Run buttons", () => {
 
   // This tests that the run buttons are the correct size on the Custom question page
   it("in Custom Question render correctly", () => {
-    cy.visit("/question/new");
-    cy.findByText("Custom question").click();
+    startNewQuestion();
     cy.findByTextEnsureVisible("Sample Database").click();
     cy.findByTextEnsureVisible("Orders").click();
     // Waiting for notebook icon to load

--- a/frontend/test/metabase/scenarios/admin/datamodel/hide_tables.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/hide_tables.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore } from "__support__/e2e/cypress";
+import { restore, startNewQuestion } from "__support__/e2e/cypress";
 
 const ORDERS_URL = "/admin/datamodel/database/1/table/2";
 
@@ -39,8 +39,7 @@ describe("scenarios > admin > datamodel > hidden tables (metabase#9759)", () => 
 
     // It shouldn't show up as a normal user either
     cy.signInAsNormalUser();
-    cy.visit("/question/new");
-    cy.contains("Simple question").click();
+    startNewQuestion();
     cy.contains("Sample Database").click();
     cy.contains("Products");
     cy.contains("Orders").should("not.exist");

--- a/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
@@ -7,6 +7,7 @@ import {
   getBinningButtonForDimension,
   startNewQuestion,
   summarize,
+  openOrdersTable,
 } from "__support__/e2e/cypress";
 
 import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
@@ -26,8 +27,7 @@ describe("binning related reproductions", () => {
       native: { query: "select * from products limit 5" },
     });
 
-    cy.visit("/question/new");
-    cy.findByText("Custom question").click();
+    startNewQuestion();
     cy.findByText("Saved Questions").click();
     cy.findByText("16327").click();
 
@@ -89,8 +89,7 @@ describe("binning related reproductions", () => {
       { loadMetadata: true },
     );
 
-    cy.visit("/question/new");
-    cy.findByText("Custom question").click();
+    startNewQuestion();
     cy.findByText("Saved Questions").click();
     cy.findByText("17975").click();
 
@@ -119,10 +118,7 @@ describe("binning related reproductions", () => {
       { loadMetadata: true },
     );
 
-    cy.visit("/question/new");
-    cy.findByText("Custom question").click();
-    cy.findByTextEnsureVisible("Sample Database").click();
-    cy.findByTextEnsureVisible("Orders").click();
+    openOrdersTable({ mode: "notebook" });
 
     cy.icon("join_left_outer").click();
 

--- a/frontend/test/metabase/scenarios/binning/qb-explicit-joins.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/qb-explicit-joins.cy.spec.js
@@ -3,6 +3,7 @@ import {
   visualize,
   changeBinningForDimension,
   summarize,
+  startNewQuestion,
 } from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
@@ -129,8 +130,7 @@ describe("scenarios > binning > from a saved QB question with explicit joins", (
 
   context("via custom question", () => {
     beforeEach(() => {
-      cy.visit("/question/new");
-      cy.findByText("Custom question").click();
+      startNewQuestion();
       cy.findByText("Saved Questions").click();
       cy.findByText("QB Binning").click();
 

--- a/frontend/test/metabase/scenarios/binning/sql.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/sql.cy.spec.js
@@ -4,6 +4,7 @@ import {
   visualize,
   changeBinningForDimension,
   summarize,
+  startNewQuestion,
 } from "__support__/e2e/cypress";
 
 const questionDetails = {
@@ -95,8 +96,7 @@ describe("scenarios > binning > from a saved sql question", () => {
 
   context("via custom question", () => {
     beforeEach(() => {
-      cy.visit("/question/new");
-      cy.findByText("Custom question").click();
+      startNewQuestion();
       cy.findByText("Saved Questions").click();
       cy.findByText("SQL Binning").click();
 

--- a/frontend/test/metabase/scenarios/custom-column/reproductions/13751-cc-allow-strings-in-filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/custom-column/reproductions/13751-cc-allow-strings-in-filter.cy.spec.js
@@ -3,6 +3,7 @@ import {
   popover,
   visualize,
   restore,
+  startNewQuestion,
 } from "__support__/e2e/cypress";
 
 const CC_NAME = "C-States";
@@ -13,8 +14,7 @@ describe("issue 13751", () => {
     restore("postgres-12");
     cy.signInAsAdmin();
 
-    cy.visit("/question/new");
-    cy.findByText("Custom question").click();
+    startNewQuestion();
     cy.findByText(PG_DB_NAME)
       .should("be.visible")
       .click();

--- a/frontend/test/metabase/scenarios/custom-column/reproductions/14517-cc-do-not-remove-regex-escape-chars.cy.spec.js
+++ b/frontend/test/metabase/scenarios/custom-column/reproductions/14517-cc-do-not-remove-regex-escape-chars.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, popover } from "__support__/e2e/cypress";
+import { restore, popover, startNewQuestion } from "__support__/e2e/cypress";
 
 const PG_DB_NAME = "QA Postgres12";
 
@@ -11,8 +11,7 @@ describe.skip("postgres > question > custom columns", () => {
     restore("postgres-12");
     cy.signInAsAdmin();
 
-    cy.visit("/question/new");
-    cy.findByText("Custom question").click();
+    startNewQuestion();
     cy.findByText(PG_DB_NAME)
       .should("be.visible")
       .click();

--- a/frontend/test/metabase/scenarios/joins/joins-2.cy.spec.js
+++ b/frontend/test/metabase/scenarios/joins/joins-2.cy.spec.js
@@ -36,8 +36,7 @@ describe("scenarios > question > joined questions", () => {
       cy.intercept("/api/database/1/schema/PUBLIC").as("schema");
 
       // start a custom question with orders
-      cy.visit("/question/new");
-      cy.contains("Custom question").click();
+      startNewQuestion();
       cy.contains("Sample Database").click();
       cy.contains("Orders").click();
 
@@ -81,8 +80,7 @@ describe("scenarios > question > joined questions", () => {
       cy.intercept("/api/database/1/schema/PUBLIC").as("schema");
 
       cy.log("Start a custom question with Orders");
-      cy.visit("/question/new");
-      cy.findByText("Custom question").click();
+      startNewQuestion();
       cy.findByTextEnsureVisible("Sample Database").click();
       cy.findByTextEnsureVisible("Orders").click();
 
@@ -133,8 +131,7 @@ describe("scenarios > question > joined questions", () => {
       });
 
       // start a custom question with question a
-      cy.visit("/question/new");
-      cy.findByText("Custom question").click();
+      startNewQuestion();
       cy.findByText("Saved Questions").click();
       cy.findByText("question a").click();
 
@@ -548,8 +545,7 @@ function joinTwoSavedQuestions() {
       },
     }).then(() => {
       cy.intercept("/api/database/1/schema/PUBLIC").as("schema");
-      cy.visit(`/question/new`);
-      cy.findByText("Custom question").click();
+      startNewQuestion();
 
       popover().within(() => {
         cy.findByText("Saved Questions").click();

--- a/frontend/test/metabase/scenarios/joins/joins.cy.spec.js
+++ b/frontend/test/metabase/scenarios/joins/joins.cy.spec.js
@@ -4,6 +4,7 @@ import {
   popover,
   visualize,
   summarize,
+  startNewQuestion,
 } from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
@@ -29,8 +30,7 @@ describe("scenarios > question > joined questions", () => {
       query: { "source-table": ORDERS_ID },
     });
 
-    cy.visit("/question/new");
-    cy.findByText("Custom question").click();
+    startNewQuestion();
     cy.findByTextEnsureVisible("Sample Database").click();
     cy.findByTextEnsureVisible("Products").click();
 

--- a/frontend/test/metabase/scenarios/joins/reproductions/15342-mysql-correct-joins-order.cy.spec.js
+++ b/frontend/test/metabase/scenarios/joins/reproductions/15342-mysql-correct-joins-order.cy.spec.js
@@ -1,4 +1,9 @@
-import { restore, popover, visualize } from "__support__/e2e/cypress";
+import {
+  restore,
+  popover,
+  visualize,
+  startNewQuestion,
+} from "__support__/e2e/cypress";
 
 const MYSQL_DB_NAME = "QA MySQL8";
 
@@ -11,8 +16,7 @@ describe.skip("issue 15342", () => {
   });
 
   it("should correctly order joins for MySQL queries (metabase#15342)", () => {
-    cy.visit("/question/new");
-    cy.findByText("Custom question").click();
+    startNewQuestion();
     cy.findByText(MYSQL_DB_NAME).click();
     cy.findByText("People").click();
 

--- a/frontend/test/metabase/scenarios/joins/reproductions/18502-cannot-join-two-saved-questions-same-table.cy.spec.js
+++ b/frontend/test/metabase/scenarios/joins/reproductions/18502-cannot-join-two-saved-questions-same-table.cy.spec.js
@@ -1,4 +1,9 @@
-import { restore, popover, visualize } from "__support__/e2e/cypress";
+import {
+  restore,
+  popover,
+  visualize,
+  startNewQuestion,
+} from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { PEOPLE, PEOPLE_ID } = SAMPLE_DATABASE;
@@ -19,8 +24,7 @@ describe("issue 18502", () => {
     cy.createQuestion(question1);
     cy.createQuestion(question2);
 
-    cy.visit("/question/new");
-    cy.findByText("Custom question").click();
+    startNewQuestion();
     cy.findByText("Saved Questions").click();
 
     cy.findByText("18502#1").click();

--- a/frontend/test/metabase/scenarios/joins/reproductions/18512-cannot-join-two-saved-questions-with-same-implicit-explicit-grouped-field.cy.spec.js
+++ b/frontend/test/metabase/scenarios/joins/reproductions/18512-cannot-join-two-saved-questions-with-same-implicit-explicit-grouped-field.cy.spec.js
@@ -1,4 +1,9 @@
-import { restore, popover, visualize } from "__support__/e2e/cypress";
+import {
+  restore,
+  popover,
+  visualize,
+  startNewQuestion,
+} from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { PRODUCTS, PRODUCTS_ID, REVIEWS, REVIEWS_ID } = SAMPLE_DATABASE;
@@ -20,8 +25,7 @@ describe("issue 18512", () => {
     cy.createQuestion(question1);
     cy.createQuestion(question2);
 
-    cy.visit("/question/new");
-    cy.findByText("Custom question").click();
+    startNewQuestion();
     cy.findByText("Saved Questions").click();
 
     cy.findByText("18512#1").click();

--- a/frontend/test/metabase/scenarios/models/models.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models.cy.spec.js
@@ -12,8 +12,11 @@ import {
   filter,
   visitQuestion,
   visitDashboard,
+  startNewQuestion,
 } from "__support__/e2e/cypress";
+
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+
 import {
   turnIntoModel,
   assertIsModel,
@@ -189,8 +192,7 @@ describe("scenarios > models", () => {
     });
 
     it("transforms the data picker", () => {
-      cy.visit("/question/new");
-      cy.findByText("Custom question").click();
+      startNewQuestion();
 
       popover().within(() => {
         testDataPickerSearch({
@@ -238,8 +240,7 @@ describe("scenarios > models", () => {
 
     it("allows to create a question based on a model", () => {
       cy.intercept("/api/database/1/schema/PUBLIC").as("schema");
-      cy.visit("/question/new");
-      cy.findByText("Custom question").click();
+      startNewQuestion();
 
       popover().within(() => {
         cy.findByText("Models").click();
@@ -278,8 +279,7 @@ describe("scenarios > models", () => {
 
     it("should not display models if nested queries are disabled", () => {
       mockSessionProperty("enable-nested-queries", false);
-      cy.visit("/question/new");
-      cy.findByText("Custom question").click();
+      startNewQuestion();
       popover().within(() => {
         cy.findByText("Models").should("not.exist");
         cy.findByText("Saved Questions").should("not.exist");

--- a/frontend/test/metabase/scenarios/native/reproductions/15946-mongo-pre-select-table.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/reproductions/15946-mongo-pre-select-table.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, modal } from "__support__/e2e/cypress";
+import { restore, modal, startNewQuestion } from "__support__/e2e/cypress";
 
 const MONGO_DB_NAME = "QA Mongo4";
 
@@ -7,8 +7,7 @@ describe.skip("issue 15946", () => {
     restore("mongo-4");
     cy.signInAsAdmin();
 
-    cy.visit("/question/new");
-    cy.findByText("Custom question").click();
+    startNewQuestion();
     cy.findByText(MONGO_DB_NAME).click();
     cy.findByText("Orders").click();
   });

--- a/frontend/test/metabase/scenarios/permissions/sandboxes.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/sandboxes.cy.spec.js
@@ -13,7 +13,9 @@ import {
   filter,
   visitQuestion,
   visitDashboard,
+  startNewQuestion,
 } from "__support__/e2e/cypress";
+
 import { USER_GROUPS, SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
@@ -763,8 +765,7 @@ describeEE("formatting > sandboxes", () => {
     it("should be able to use summarize columns from joined table based on a saved question (metabase#14766)", () => {
       createJoinedQuestion("14766_joined");
 
-      cy.visit("/question/new");
-      cy.findByText("Custom question").click();
+      startNewQuestion();
       cy.findByText("Saved Questions").click();
       cy.findByText("14766_joined").click();
       cy.findByText("Pick the metric you want to see").click();

--- a/frontend/test/metabase/scenarios/question/nested.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nested.cy.spec.js
@@ -545,12 +545,15 @@ describe("scenarios > question > nested", () => {
       });
       // Window object gets recreated for every `cy.visit`
       // See: https://stackoverflow.com/a/65218352/8815185
-      cy.visit("/question/new", {
+      cy.visit("/", {
         onBeforeLoad(win) {
           cy.spy(win.console, "warn").as("consoleWarn");
         },
       });
-      cy.findByText("Custom question").click();
+      cy.findByText("New").click();
+      cy.findByText("Question")
+        .should("be.visible")
+        .click();
       cy.findByText("Saved Questions").click();
       cy.findByText("15725").click();
       cy.findByText("Pick the metric you want to see").click();

--- a/frontend/test/metabase/scenarios/question/new.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/new.cy.spec.js
@@ -46,8 +46,7 @@ describe("scenarios > question > new", () => {
     cy.findByText("Sample3").isVisibleInPopover();
 
     // Then move to the Custom question UI
-    cy.visit("/question/new");
-    cy.findByText("Custom question").click();
+    startNewQuestion();
     cy.findByText("Sample3").isVisibleInPopover();
   });
 
@@ -72,12 +71,9 @@ describe("scenarios > question > new", () => {
   });
 
   describe("data picker search", () => {
-    beforeEach(() => {
-      cy.visit("/question/new");
-    });
-
     describe("on a (simple) question page", () => {
       beforeEach(() => {
+        cy.visit("/question/new");
         cy.findByText("Simple question").click();
         cy.findByPlaceholderText("Search for a table…").type("Ord");
       });
@@ -102,7 +98,7 @@ describe("scenarios > question > new", () => {
 
     describe("on a (custom) question page", () => {
       beforeEach(() => {
-        cy.findByText("Custom question").click();
+        startNewQuestion();
         cy.findByPlaceholderText("Search for a table…").type("Ord");
       });
 
@@ -133,18 +129,15 @@ describe("scenarios > question > new", () => {
       cy.intercept("/api/search", req => {
         expect("Unexpected call to /api/search").to.be.false;
       });
-      cy.findByText("Custom question").click();
+      startNewQuestion();
       cy.findByPlaceholderText("Search for a table…").type("  ");
     });
   });
 
   describe("saved question picker", () => {
-    beforeEach(() => {
-      cy.visit("/question/new");
-    });
-
     describe("on a (simple) question page", () => {
       beforeEach(() => {
+        cy.visit("/question/new");
         cy.findByText("Simple question").click();
         cy.findByText("Saved Questions").click();
       });
@@ -169,7 +162,7 @@ describe("scenarios > question > new", () => {
 
     describe("on a (custom) question page", () => {
       beforeEach(() => {
-        cy.findByText("Custom question").click();
+        startNewQuestion();
         cy.findByText("Saved Questions").click();
       });
 

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -10,6 +10,7 @@ import {
   visualize,
   summarize,
   filter,
+  startNewQuestion,
 } from "__support__/e2e/cypress";
 
 import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
@@ -42,8 +43,7 @@ describe("scenarios > question > notebook", () => {
 
   it("should allow post-aggregation filters", () => {
     // start a custom question with orders
-    cy.visit("/question/new");
-    cy.contains("Custom question").click();
+    startNewQuestion();
     cy.contains("Sample Database").click();
     cy.contains("Orders").click();
 
@@ -195,8 +195,7 @@ describe("scenarios > question > notebook", () => {
   // flaky test (#19454)
   it.skip("should show an info popover for dimensions listened by the custom expression editor", () => {
     // start a custom question with orders
-    cy.visit("/question/new");
-    cy.contains("Custom question").click();
+    startNewQuestion();
     cy.contains("Sample Database").click();
     cy.contains("Orders").click();
 
@@ -220,8 +219,7 @@ describe("scenarios > question > notebook", () => {
       restore();
       cy.signInAsAdmin();
       cy.viewport(1280, 720);
-      cy.visit("/question/new");
-      cy.findByText("Custom question").click();
+      startNewQuestion();
       cy.findByTextEnsureVisible("Sample Database").click();
       cy.findByTextEnsureVisible("Orders").click();
     });
@@ -375,8 +373,7 @@ describe("scenarios > question > notebook", () => {
   // intentional simplification of "Select none" to quickly
   // fix users' pain caused by the inability to unselect all columns
   it("select no columns select the first one", () => {
-    cy.visit("/question/new");
-    cy.contains("Custom question").click();
+    startNewQuestion();
     cy.contains("Sample Database").click();
     cy.contains("Orders").click();
     cy.findByTestId("fields-picker").click();
@@ -398,8 +395,7 @@ describe("scenarios > question > notebook", () => {
 
   // flaky test
   it.skip("should show an info popover when hovering over a field picker option for a table", () => {
-    cy.visit("/question/new");
-    cy.contains("Custom question").click();
+    startNewQuestion();
     cy.contains("Sample Database").click();
     cy.contains("Orders").click();
 
@@ -419,8 +415,7 @@ describe("scenarios > question > notebook", () => {
     });
 
     // start a custom question with question a
-    cy.visit("/question/new");
-    cy.findByText("Custom question").click();
+    startNewQuestion();
     cy.findByText("Saved Questions").click();
     cy.findByText("question a").click();
 

--- a/frontend/test/metabase/scenarios/question/reproductions/15714-cc-postgres-percentile-accepts-two-params.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/15714-cc-postgres-percentile-accepts-two-params.js
@@ -1,4 +1,8 @@
-import { enterCustomColumnDetails, restore } from "__support__/e2e/cypress";
+import {
+  enterCustomColumnDetails,
+  restore,
+  startNewQuestion,
+} from "__support__/e2e/cypress";
 
 const PG_DB_NAME = "QA Postgres12";
 
@@ -8,8 +12,7 @@ export function issue15714() {
       restore("postgres-12");
       cy.signInAsAdmin();
 
-      cy.visit("/question/new");
-      cy.findByText("Custom question").click();
+      startNewQuestion();
       cy.findByText(PG_DB_NAME)
         .should("be.visible")
         .click();

--- a/frontend/test/metabase/scenarios/question/reproductions/17963-mongo-filter-expression-compare-two-fields.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/17963-mongo-filter-expression-compare-two-fields.js
@@ -1,4 +1,9 @@
-import { restore, popover, visualize } from "__support__/e2e/cypress";
+import {
+  restore,
+  popover,
+  visualize,
+  startNewQuestion,
+} from "__support__/e2e/cypress";
 
 export function issue17963() {
   describe("issue 17963", () => {
@@ -6,8 +11,7 @@ export function issue17963() {
       restore("mongo-4");
       cy.signInAsAdmin();
 
-      cy.visit("/question/new");
-      cy.findByText("Custom question").click();
+      startNewQuestion();
       cy.findByText("QA Mongo4").click();
       cy.findByText("Orders").click();
     });

--- a/frontend/test/metabase/scenarios/question/reproductions/18207-string-min-max.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/18207-string-min-max.js
@@ -3,6 +3,8 @@ import {
   popover,
   restore,
   visualize,
+  openProductsTable,
+  summarize,
 } from "__support__/e2e/cypress";
 
 export function issue18207() {
@@ -12,16 +14,12 @@ export function issue18207() {
 
       restore();
       cy.signInAsAdmin();
+
+      openProductsTable({ mode: "notebook" });
+      summarize({ mode: "notebook" });
     });
 
     it("should be possible to use MIN on a string column (metabase#18207)", () => {
-      cy.visit("/question/new");
-      cy.contains("Custom question").click();
-      cy.contains("Sample Database").click();
-      cy.contains("Products").click();
-
-      cy.contains("Pick the metric").click();
-
       cy.contains("Minimum of").click();
       cy.findByText("Price");
       cy.findByText("Rating");
@@ -33,13 +31,6 @@ export function issue18207() {
     });
 
     it("should be possible to use MAX on a string column (metabase#18207)", () => {
-      cy.visit("/question/new");
-      cy.contains("Custom question").click();
-      cy.contains("Sample Database").click();
-      cy.contains("Products").click();
-
-      cy.contains("Pick the metric").click();
-
       cy.contains("Maximum of").click();
       cy.findByText("Price");
       cy.findByText("Rating");
@@ -51,13 +42,6 @@ export function issue18207() {
     });
 
     it("should be not possible to use AVERAGE on a string column (metabase#18207)", () => {
-      cy.visit("/question/new");
-      cy.contains("Custom question").click();
-      cy.contains("Sample Database").click();
-      cy.contains("Products").click();
-
-      cy.contains("Pick the metric").click();
-
       cy.contains("Average of").click();
       cy.findByText("Price");
       cy.findByText("Rating");
@@ -65,12 +49,6 @@ export function issue18207() {
     });
 
     it("should be possible to group by a string expression (metabase#18207)", () => {
-      cy.visit("/question/new");
-      cy.contains("Custom question").click();
-      cy.contains("Sample Database").click();
-      cy.contains("Products").click();
-
-      cy.contains("Pick the metric").click();
       popover()
         .contains("Custom Expression")
         .click();

--- a/frontend/test/metabase/scenarios/question/reproductions/19341-disabled-nested-queries.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/19341-disabled-nested-queries.js
@@ -1,4 +1,9 @@
-import { restore, mockSessionProperty, popover } from "__support__/e2e/cypress";
+import {
+  restore,
+  mockSessionProperty,
+  popover,
+  startNewQuestion,
+} from "__support__/e2e/cypress";
 
 export function issue19341() {
   describe("issue 19341", () => {
@@ -19,8 +24,7 @@ export function issue19341() {
 
     it("should correctly disable nested queries (metabase#19341)", () => {
       // Test "Saved Questions" table is hidden in QB data selector
-      cy.visit("/question/new");
-      cy.findByText("Custom question").click();
+      startNewQuestion();
       popover().within(() => {
         // Wait until picker init
         // When working as expected, the test environment only has "Sample Database" DB

--- a/frontend/test/metabase/scenarios/question/reproductions/9027-new-questions-not-in-saved-questions-immediately.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/9027-new-questions-not-in-saved-questions-immediately.js
@@ -15,8 +15,7 @@ export function issue9027() {
       restore();
       cy.signInAsAdmin();
 
-      cy.visit("/question/new");
-      cy.findByText("Custom question").click();
+      startNewQuestion();
       cy.findByText("Saved Questions").click();
 
       // Wait for the existing questions to load


### PR DESCRIPTION
### Status
PENDING CI

### What does this PR accomplish?
- Replaces the occurrences of using the `/question/new` route for "Custom question" with the new `startNewQuestion` helper that will open the data picker by navigating to it directly

This PR deals with the E2E tests in the broader initiative to [remove the deprecated `/question/new` route](https://github.com/metabase/metabase/issues/19677).
