### PR TITLE
Add concurrency to E2E tests on `pull_request`

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -8,6 +8,10 @@ on:
       - "**.md"
       - ".circleci/**"
 
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   build:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -8,7 +8,7 @@ on:
       - "**.md"
       - ".circleci/**"
 
-concurrency: 
+concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 


### PR DESCRIPTION
@ariya WDYT about adding concurrency for this workflow only?

It should not only be safe thing to do but even a desired behavior, imo. I cannot imagine a scenario in which we want to keep the old job running in the current PR. This should also help us save some resources in open (ready for review) PRs with a lot of commits (`synchronize` trigger).