### PR TITLE
[E2E] Deprecate the `/question/new` route for simple mode

### DIFF
--- a/docs/developers-guide/e2e-tests.md
+++ b/docs/developers-guide/e2e-tests.md
@@ -38,7 +38,7 @@ describe("homepage",() => {
 
 We strongly prefer using selectors like `cy.findByText()` and `cy.findByLabelText()` from [`@testing-library/cypress`](https://github.com/testing-library/cypress-testing-library) since they encourage writing tests that don't depend on implementation details like CSS class names.
 
-Try to avoid repeatedly testing pieces of the application incidentally. For example, if you want to test something about the query builder, jump straight there using a URL like `cy.visit("/question/new?database=1&table=2");` rather than starting from the home page, clicking "Ask a question", etc.
+Try to avoid repeatedly testing pieces of the application incidentally. For example, if you want to test something about the query builder, jump straight there using a helper like `openOrdersTable()` rather than starting from the home page, clicking "New", then "Question", etc.
 
 ## Cypress Documentation
 

--- a/frontend/test/metabase-visual/notebook/notebook.cy.spec.js
+++ b/frontend/test/metabase-visual/notebook/notebook.cy.spec.js
@@ -87,8 +87,9 @@ describe("visual tests > notebook > Run buttons", () => {
 
   // This tests that the run buttons are the correct size on the Native query page
   it("in Native Query render correctly", () => {
-    cy.visit("/question/new");
-    cy.findByText("Native query").click();
+    cy.visit("/");
+    cy.findByText("New").click();
+    cy.findByText("SQL query").click();
 
     // Check that we're on the blank question page
     cy.findByText("Here's where your results will appear");

--- a/frontend/test/metabase/scenarios/admin/datamodel/field.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/field.cy.spec.js
@@ -3,6 +3,7 @@ import {
   withDatabase,
   visitAlias,
   popover,
+  startNewQuestion,
 } from "__support__/e2e/cypress";
 
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
@@ -131,8 +132,7 @@ describe.skip("scenarios > admin > datamodel > field", () => {
       cy.findByText("Saved!");
 
       // check that it appears in QB
-      cy.visit("/question/new");
-      cy.findByText("Simple question").click();
+      startNewQuestion();
       cy.findByText("sqlite").click();
       cy.findByText("Number With Nulls").click();
       cy.findByText("nothin");

--- a/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
@@ -203,8 +203,9 @@ describe("binning related reproductions", () => {
       );
     });
 
-    it("should work for simple question", () => {
-      openSummarizeOptions("Simple question");
+    it("should work for simple mode", () => {
+      openSummarizeOptions("Simple mode");
+
       changeBinningForDimension({
         name: "Average of Subtotal",
         fromBinning: "Auto binned",
@@ -214,8 +215,8 @@ describe("binning related reproductions", () => {
       cy.get(".bar");
     });
 
-    it("should work for custom question", () => {
-      openSummarizeOptions("Custom question");
+    it("should work for notebook mode", () => {
+      openSummarizeOptions("Notebook mode");
 
       cy.findByText("Pick the metric you want to see").click();
       cy.findByText("Count of rows").click();
@@ -252,13 +253,11 @@ describe("binning related reproductions", () => {
         },
       });
 
-      cy.intercept("POST", "/api/dataset").as("dataset");
-
-      cy.visit("/question/new");
-      cy.findByText("Simple question").click();
+      startNewQuestion();
       cy.findByText("Saved Questions").click();
       cy.findByText("SQL Binning").click();
-      cy.wait("@dataset");
+
+      visualize();
       summarize();
     });
 
@@ -298,12 +297,12 @@ describe("binning related reproductions", () => {
 });
 
 function openSummarizeOptions(questionType) {
-  cy.visit("/question/new");
-  cy.findByText(questionType).click();
+  startNewQuestion();
   cy.findByText("Saved Questions").click();
   cy.findByText("16379").click();
 
-  if (questionType === "Simple question") {
+  if (questionType === "Simple mode") {
+    visualize();
     summarize();
   }
 }

--- a/frontend/test/metabase/scenarios/binning/qb-explicit-joins.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/qb-explicit-joins.cy.spec.js
@@ -65,13 +65,13 @@ describe("scenarios > binning > from a saved QB question with explicit joins", (
     cy.intercept("POST", "/api/dataset").as("dataset");
   });
 
-  context("via simple question", () => {
+  context("via simple mode", () => {
     beforeEach(() => {
-      cy.visit("/question/new");
-      cy.findByText("Simple question").click();
+      startNewQuestion();
       cy.findByText("Saved Questions").click();
       cy.findByText("QB Binning").click();
-      cy.wait("@dataset");
+
+      visualize();
       summarize();
     });
 
@@ -128,7 +128,7 @@ describe("scenarios > binning > from a saved QB question with explicit joins", (
     });
   });
 
-  context("via custom question", () => {
+  context("via notebook mode", () => {
     beforeEach(() => {
       startNewQuestion();
       cy.findByText("Saved Questions").click();
@@ -197,10 +197,10 @@ describe("scenarios > binning > from a saved QB question with explicit joins", (
 
   context("via column popover", () => {
     beforeEach(() => {
-      cy.visit("/question/new");
-      cy.findByText("Simple question").click();
+      startNewQuestion();
       cy.findByText("Saved Questions").click();
       cy.findByText("QB Binning").click();
+      visualize();
     });
 
     it("should work for time series", () => {
@@ -297,6 +297,10 @@ function assertQueryBuilderState({
   cy.get(visualizaitonSelector);
 
   cy.findByText(title);
+
+  cy.get(".y-axis-label")
+    .invoke("text")
+    .should("eq", "Count");
 
   values &&
     cy.get(".axis.x").within(() => {

--- a/frontend/test/metabase/scenarios/binning/sql.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/sql.cy.spec.js
@@ -34,11 +34,10 @@ describe("scenarios > binning > from a saved sql question", () => {
 
   context("via simple question", () => {
     beforeEach(() => {
-      cy.visit("/question/new");
-      cy.findByText("Simple question").click();
+      startNewQuestion();
       cy.findByText("Saved Questions").click();
       cy.findByText("SQL Binning").click();
-      cy.wait("@dataset");
+      visualize();
       cy.findByTextEnsureVisible("LONGITUDE");
       summarize();
     });
@@ -163,11 +162,10 @@ describe("scenarios > binning > from a saved sql question", () => {
 
   context("via column popover", () => {
     beforeEach(() => {
-      cy.visit("/question/new");
-      cy.findByText("Simple question").click();
+      startNewQuestion();
       cy.findByText("Saved Questions").click();
       cy.findByText("SQL Binning").click();
-      cy.wait("@dataset");
+      visualize();
       cy.findByTextEnsureVisible("LONGITUDE");
     });
 

--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -7,6 +7,7 @@ import {
   navigationSidebar,
   closeNavigationSidebar,
   openNavigationSidebar,
+  startNewQuestion,
 } from "__support__/e2e/cypress";
 import { displaySidebarChildOf } from "./helpers/e2e-collections-sidebar.js";
 import { USERS, USER_GROUPS } from "__support__/e2e/cypress_data";
@@ -415,8 +416,7 @@ describe("scenarios > collection_defaults", () => {
         cy.findByText("Orders");
       });
 
-      cy.visit("/question/new");
-      cy.findByText("Simple question").click();
+      startNewQuestion();
       popover().within(() => {
         cy.findByText("Saved Questions").click();
         // Note: collection name's first letter is capitalized

--- a/frontend/test/metabase/scenarios/dashboard/x-rays.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/x-rays.cy.spec.js
@@ -4,6 +4,7 @@ import {
   visitQuestionAdhoc,
   popover,
   summarize,
+  startNewQuestion,
 } from "__support__/e2e/cypress";
 
 import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
@@ -82,8 +83,7 @@ describe("scenarios > x-rays", () => {
         native: { query: "select * from people" },
       });
 
-      cy.visit("/question/new");
-      cy.findByText("Simple question").click();
+      startNewQuestion();
       cy.findByText("Saved Questions").click();
       cy.findByText("15655").click();
       summarize();

--- a/frontend/test/metabase/scenarios/dashboard/x-rays.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/x-rays.cy.spec.js
@@ -4,6 +4,7 @@ import {
   visitQuestionAdhoc,
   popover,
   summarize,
+  visualize,
   startNewQuestion,
 } from "__support__/e2e/cypress";
 
@@ -86,6 +87,7 @@ describe("scenarios > x-rays", () => {
       startNewQuestion();
       cy.findByText("Saved Questions").click();
       cy.findByText("15655").click();
+      visualize();
       summarize();
       getDimensionByName({ name: "SOURCE" }).click();
       cy.button("Done").click();

--- a/frontend/test/metabase/scenarios/downloads/downloads.cy.spec.js
+++ b/frontend/test/metabase/scenarios/downloads/downloads.cy.spec.js
@@ -1,4 +1,9 @@
-import { restore, downloadAndAssert } from "__support__/e2e/cypress";
+import {
+  restore,
+  downloadAndAssert,
+  startNewQuestion,
+  visualize,
+} from "__support__/e2e/cypress";
 
 const testCases = ["csv", "xlsx"];
 
@@ -10,11 +15,11 @@ describe("scenarios > question > download", () => {
 
   testCases.forEach(fileType => {
     it(`downloads ${fileType} file`, () => {
-      cy.visit("/question/new");
-      cy.findByText("Simple question").click();
+      startNewQuestion();
       cy.findByText("Saved Questions").click();
       cy.findByText("Orders, Count").click();
 
+      visualize();
       cy.contains("18,760");
 
       downloadAndAssert({ fileType }, sheet => {

--- a/frontend/test/metabase/scenarios/native/data_ref.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/data_ref.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore } from "__support__/e2e/cypress";
+import { restore, openNativeEditor } from "__support__/e2e/cypress";
 
 describe("scenarios > native question > data reference sidebar", () => {
   beforeEach(() => {
@@ -7,8 +7,7 @@ describe("scenarios > native question > data reference sidebar", () => {
   });
 
   it("should load needed data", () => {
-    cy.visit("/question/new");
-    cy.findByText("Native query").click();
+    openNativeEditor();
     cy.icon("reference").click();
     // Force-clicking was needed here because Cypress complains that "ORDERS" is covered by a <div>
     // TODO: Maybe re-think the structure of that component because that div seems unnecessary anyway

--- a/frontend/test/metabase/scenarios/native/native-mysql.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/native-mysql.cy.spec.js
@@ -44,7 +44,9 @@ describe("scenatios > question > native > mysql", () => {
   });
 
   it("can save a native MySQL query", () => {
-    cy.get(".ace_content").type(`SELECT * FROM ORDERS`);
+    openNativeEditor({ databaseName: MYSQL_DB_NAME }).type(
+      `SELECT * FROM ORDERS`,
+    );
     cy.get(".NativeQueryEditor .Icon-play").click();
 
     cy.wait("@dataset");

--- a/frontend/test/metabase/scenarios/native/native-mysql.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/native-mysql.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, modal } from "__support__/e2e/cypress";
+import { restore, modal, openNativeEditor } from "__support__/e2e/cypress";
 
 const MYSQL_DB_NAME = "QA MySQL8";
 
@@ -9,15 +9,11 @@ describe("scenatios > question > native > mysql", () => {
 
     restore("mysql-8");
     cy.signInAsAdmin();
-
-    cy.visit("/question/new");
-    cy.contains("Native query").click();
-    cy.contains(MYSQL_DB_NAME).click();
   });
 
   it("can write a native MySQL query with a field filter", () => {
     // Write Native query that includes a filter
-    cy.get(".ace_content").type(
+    openNativeEditor({ databaseName: MYSQL_DB_NAME }).type(
       `SELECT TOTAL, CATEGORY FROM ORDERS LEFT JOIN PRODUCTS ON ORDERS.PRODUCT_ID = PRODUCTS.ID [[WHERE PRODUCTS.ID = {{id}}]];`,
       {
         parseSpecialCharSequences: false,

--- a/frontend/test/metabase/scenarios/native/snippets/snippet-permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/snippets/snippet-permissions.cy.spec.js
@@ -13,8 +13,7 @@ describeEE("scenarios > question > snippets", () => {
   });
 
   it("can create a snippet", () => {
-    cy.visit("/question/new");
-    cy.contains("Native query").click();
+    openNativeEditor();
     cy.icon("snippet").click();
     cy.contains("Create a snippet").click();
     modal().within(() => {
@@ -66,8 +65,7 @@ describeEE("scenarios > question > snippets", () => {
     });
 
     // Grant access
-    cy.visit("/question/new");
-    cy.contains("Native query").click();
+    openNativeEditor();
     cy.icon("snippet").click();
 
     cy.findByTestId("sidebar-right")
@@ -111,15 +109,14 @@ describeEE("scenarios > question > snippets", () => {
   });
 
   it("should let you create a snippet folder and move a snippet into it", () => {
-    cy.visit("/question/new");
-    cy.contains("Native query").click();
-
     // create snippet via API
     cy.request("POST", "/api/native-query-snippet", {
       content: "snippet 1",
       name: "snippet 1",
       collection_id: null,
     });
+
+    openNativeEditor();
 
     // create folder
     cy.icon("snippet").click();

--- a/frontend/test/metabase/scenarios/onboarding/reference/databases.cy.spec.js
+++ b/frontend/test/metabase/scenarios/onboarding/reference/databases.cy.spec.js
@@ -1,4 +1,4 @@
-import { popover, restore } from "__support__/e2e/cypress";
+import { popover, restore, startNewQuestion } from "__support__/e2e/cypress";
 
 describe("scenarios > reference > databases", () => {
   beforeEach(() => {
@@ -69,8 +69,7 @@ describe("scenarios > reference > databases", () => {
     });
 
     it("should sort databases in new UI based question data selection popover", () => {
-      checkQuestionSourceDatabasesOrder("Simple question");
-      checkQuestionSourceDatabasesOrder("Custom question");
+      checkQuestionSourceDatabasesOrder();
     });
 
     it.skip("should sort databases in new native question data selection popover", () => {
@@ -97,8 +96,7 @@ function checkQuestionSourceDatabasesOrder(question_type) {
       ? ".List-item-title"
       : ".List-section-title";
 
-  cy.visit("/question/new");
-  cy.findByText(question_type).click();
+  startNewQuestion();
   popover().within(() => {
     cy.get(selector)
       .as("databaseName")

--- a/frontend/test/metabase/scenarios/permissions/reproductions/13347-cannot-select-saved-question-in-database-without-data-permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/reproductions/13347-cannot-select-saved-question-in-database-without-data-permissions.cy.spec.js
@@ -1,4 +1,8 @@
-import { restore, withDatabase } from "__support__/e2e/cypress";
+import {
+  restore,
+  withDatabase,
+  startNewQuestion,
+} from "__support__/e2e/cypress";
 import { USER_GROUPS } from "__support__/e2e/cypress_data";
 
 const { ALL_USERS_GROUP } = USER_GROUPS;
@@ -44,8 +48,7 @@ describe.skip("issue 13347", () => {
     it(`${test.toUpperCase()} version:\n should be able to select question (from "Saved Questions") which belongs to the database user doesn't have data-permissions for (metabase#13347)`, () => {
       cy.signIn("none");
 
-      cy.visit("/question/new");
-      cy.findByText("Simple question").click();
+      startNewQuestion();
       cy.findByText("Saved Questions").click();
 
       test === "QB" ? cy.findByText("Q1").click() : cy.findByText("Q2").click();

--- a/frontend/test/metabase/scenarios/question/loading.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/loading.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore } from "__support__/e2e/cypress";
+import { restore, startNewQuestion } from "__support__/e2e/cypress";
 
 describe("scenarios > question > loading behavior", () => {
   beforeEach(() => {
@@ -16,8 +16,7 @@ describe("scenarios > question > loading behavior", () => {
     });
     // let the other preload happen since it matches the actual call from the component
     cy.route({ url: "/api/database?saved=true" }).as("fetch1");
-    cy.visit("/question/new");
-    cy.contains("Simple question").click();
+    startNewQuestion();
 
     cy.route({ url: "/api/database/1/schemas" }).as("fetch2");
     cy.route({ url: "/api/database/1/schema/PUBLIC" }).as("fetch3");

--- a/frontend/test/metabase/scenarios/question/nested.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nested.cy.spec.js
@@ -8,6 +8,7 @@ import {
   getDimensionByName,
   summarize,
   visitDashboard,
+  startNewQuestion,
 } from "__support__/e2e/cypress";
 
 import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
@@ -47,6 +48,10 @@ describe("scenarios > question > nested (metabase#12568)", () => {
       { loadMetadata: true, interceptAlias: "secondCardQuery" },
     );
 
+    startNewQuestion();
+
+    cy.contains("Saved Questions").click();
+
     // [quarantine] The whole CI was timing out
     // Create a complex native question
     // cy.createNativeQuestion({
@@ -83,10 +88,8 @@ describe("scenarios > question > nested (metabase#12568)", () => {
   });
 
   it("should allow Distribution on a Saved Simple Question", () => {
-    cy.visit("/question/new");
-    cy.contains("Simple question").click();
-    cy.contains("Saved Questions").click();
     cy.contains("GH_12568: Simple").click();
+    visualize();
     cy.contains("Count").click();
     cy.contains("Distribution").click();
     cy.contains("Count by Count: Auto binned");
@@ -94,10 +97,8 @@ describe("scenarios > question > nested (metabase#12568)", () => {
   });
 
   it("should allow Sum over time on a Saved Simple Question", () => {
-    cy.visit("/question/new");
-    cy.contains("Simple question").click();
-    cy.contains("Saved Questions").click();
     cy.contains("GH_12568: Simple").click();
+    visualize();
     cy.contains("Count").click();
     cy.contains("Sum over time").click();
     cy.contains("Sum of Count");
@@ -105,10 +106,8 @@ describe("scenarios > question > nested (metabase#12568)", () => {
   });
 
   it("should allow Distribution on a Saved SQL Question", () => {
-    cy.visit("/question/new");
-    cy.contains("Simple question").click();
-    cy.contains("Saved Questions").click();
     cy.contains("GH_12568: SQL").click();
+    visualize();
     cy.contains("COUNT").click();
     cy.contains("Distribution").click();
     cy.contains("Count by COUNT: Auto binned");
@@ -117,10 +116,8 @@ describe("scenarios > question > nested (metabase#12568)", () => {
 
   // [quarantine] The whole CI was timing out
   it.skip("should allow Sum over time on a Saved SQL Question", () => {
-    cy.visit("/question/new");
-    cy.contains("Simple question").click();
-    cy.contains("Saved Questions").click();
     cy.contains("GH_12568: SQL").click();
+    visualize();
     cy.contains("COUNT").click();
     cy.contains("Sum over time").click();
     cy.contains("Sum of COUNT");
@@ -129,10 +126,8 @@ describe("scenarios > question > nested (metabase#12568)", () => {
 
   // [quarantine] The whole CI was timing out
   it.skip("should allow Distribution on a Saved complex SQL Question", () => {
-    cy.visit("/question/new");
-    cy.contains("Simple question").click();
-    cy.contains("Saved Questions").click();
     cy.contains("GH_12568: Complex SQL").click();
+    visualize();
     cy.contains("Items Sold").click();
     cy.contains("Distribution").click();
     cy.contains("Count by Items Sold: Auto binned");
@@ -292,8 +287,7 @@ describe("scenarios > question > nested", () => {
       "Related issue [#14629](https://github.com/metabase/metabase/issues/14629)",
     );
 
-    cy.server();
-    cy.route("POST", "/api/dataset").as("dataset");
+    cy.intercept("POST", "/api/dataset").as("dataset");
 
     cy.log("Remap Product ID's display value to `title`");
     remapDisplayValueToFK({
@@ -308,14 +302,14 @@ describe("scenarios > question > nested", () => {
     });
 
     // Try to use saved question as a base for a new / nested question
-    cy.visit("/question/new");
-    cy.findByText("Simple question").click();
+    startNewQuestion();
     cy.findByText("Saved Questions").click();
     cy.findByText("Orders (remapped)").click();
 
-    cy.wait("@dataset").then(xhr => {
-      expect(xhr.response.body.error).not.to.exist;
+    visualize(response => {
+      expect(response.body.error).not.to.exist;
     });
+
     cy.findAllByText("Awesome Concrete Shoes");
   });
 
@@ -342,14 +336,14 @@ describe("scenarios > question > nested", () => {
         ordersJoinProducts(QUESTION_NAME);
 
         // Start new question from a saved one
-        cy.visit("/question/new");
-        cy.findByText("Simple question").click();
+        startNewQuestion();
         cy.findByText("Saved Questions").click();
         cy.findByText(QUESTION_NAME).click();
 
-        cy.wait("@dataset").then(xhr => {
-          expect(xhr.response.body.error).not.to.exist;
+        visualize(response => {
+          expect(response.body.error).not.to.exist;
         });
+
         cy.contains("37.65");
       });
 
@@ -365,32 +359,30 @@ describe("scenarios > question > nested", () => {
         );
 
         // Start new question from already saved nested question
-        cy.visit("/question/new");
-        cy.findByText("Simple question").click();
+        startNewQuestion();
         cy.findByText("Saved Questions").click();
         cy.findByText(SECOND_QUESTION_NAME).click();
 
-        cy.wait("@dataset").then(xhr => {
-          expect(xhr.response.body.error).not.to.exist;
+        visualize(response => {
+          expect(response.body.error).not.to.exist;
         });
+
         cy.contains("37.65");
       });
     });
   });
 
   it("'distribution' should work on a joined table from a saved question (metabase#14787)", () => {
-    cy.intercept("POST", "/api/dataset").as("dataset");
-
     // Set the display really wide and really tall to avoid any scrolling
     cy.viewport(1600, 1200);
 
     ordersJoinProducts("14787");
     // This repro depends on these exact steps - it has to be opened from the saved questions
-    cy.visit("/question/new");
-    cy.findByText("Simple question").click();
+    startNewQuestion();
     cy.findByText("Saved Questions").click();
     cy.findByText("14787").click();
-    cy.wait("@dataset");
+
+    visualize();
 
     // The column title
     cy.findByText("Products → Category").click();
@@ -398,6 +390,7 @@ describe("scenarios > question > nested", () => {
     cy.wait("@dataset");
 
     summarize();
+
     cy.findByText("Group by")
       .parent()
       .within(() => {
@@ -431,8 +424,6 @@ describe("scenarios > question > nested", () => {
 
   ["count", "average"].forEach(test => {
     it(`${test.toUpperCase()}:\n should be able to use aggregation functions on saved native question (metabase#15397)`, () => {
-      cy.intercept("POST", "/api/dataset").as("dataset");
-
       cy.createNativeQuestion(
         {
           name: "15397",
@@ -444,12 +435,11 @@ describe("scenarios > question > nested", () => {
         { loadMetadata: true },
       );
 
-      cy.visit("/question/new");
-      cy.findByText("Simple question").click();
+      startNewQuestion();
       cy.findByText("Saved Questions").click();
       cy.findByText("15397").click();
 
-      cy.wait("@dataset");
+      visualize();
       summarize();
 
       if (test === "average") {
@@ -528,10 +518,10 @@ describe("scenarios > question > nested", () => {
       cy.get(".ScalarValue").findByText(value);
 
       // Start new question based on the saved one
-      cy.visit("/question/new");
-      cy.findByText("Simple question").click();
+      startNewQuestion();
       cy.findByText("Saved Questions").click();
       cy.findByText(name).click();
+      visualize();
       cy.get(".ScalarValue").findByText(value);
     }
   });

--- a/frontend/test/metabase/scenarios/question/new.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/new.cy.spec.js
@@ -39,14 +39,9 @@ describe("scenarios > question > new", () => {
       });
     }
 
-    // First test UI for Simple question
-    cy.visit("/question/new");
-    cy.findByText("Simple question").click();
-    cy.findByText("Pick your data");
-    cy.findByText("Sample3").isVisibleInPopover();
-
-    // Then move to the Custom question UI
     startNewQuestion();
+
+    cy.contains("Pick your starting data");
     cy.findByText("Sample3").isVisibleInPopover();
   });
 
@@ -71,31 +66,6 @@ describe("scenarios > question > new", () => {
   });
 
   describe("data picker search", () => {
-    describe("on a (simple) question page", () => {
-      beforeEach(() => {
-        cy.visit("/question/new");
-        cy.findByText("Simple question").click();
-        cy.findByPlaceholderText("Search for a table…").type("Ord");
-      });
-
-      it("should allow to search saved questions", () => {
-        cy.findByText("Orders, Count").click();
-        cy.findByText("18,760");
-      });
-
-      it("should allow to search and select tables", () => {
-        cy.findAllByText("Orders")
-          .closest("li")
-          .findByText("Table in")
-          .parent()
-          .findByTestId("search-result-item-name")
-          .click();
-        cy.url().should("include", "question#");
-        cy.findByText("Sample Database");
-        cy.findByText("Orders");
-      });
-    });
-
     describe("on a (custom) question page", () => {
       beforeEach(() => {
         startNewQuestion();
@@ -135,31 +105,6 @@ describe("scenarios > question > new", () => {
   });
 
   describe("saved question picker", () => {
-    describe("on a (simple) question page", () => {
-      beforeEach(() => {
-        cy.visit("/question/new");
-        cy.findByText("Simple question").click();
-        cy.findByText("Saved Questions").click();
-      });
-
-      it("should display the collection tree on the left side", () => {
-        popover().findByText("Our analytics");
-      });
-
-      it("should display the saved questions list on the right side", () => {
-        cy.findByText("Orders, Count, Grouped by Created At (year)");
-        cy.findByText("Orders");
-        cy.findByText("Orders, Count").click();
-        cy.findByText("18,760");
-      });
-
-      it("should perform a search scoped to saved questions", () => {
-        cy.findByPlaceholderText("Search for a question…").type("Grouped");
-        cy.findByText("Orders, Count, Grouped by Created At (year)").click();
-        cy.findByText("1,994");
-      });
-    });
-
     describe("on a (custom) question page", () => {
       beforeEach(() => {
         startNewQuestion();
@@ -223,14 +168,6 @@ describe("scenarios > question > new", () => {
   });
 
   describe("ask a (simple) question", () => {
-    it("should load orders table", () => {
-      cy.visit("/question/new");
-      cy.contains("Simple question").click();
-      cy.contains("Sample Database").click();
-      cy.contains("Orders").click();
-      cy.contains("37.65");
-    });
-
     it.skip("should handle (removing) multiple metrics when one is sorted (metabase#13990)", () => {
       cy.intercept("POST", `/api/dataset`).as("dataset");
 
@@ -412,7 +349,7 @@ describe("scenarios > question > new", () => {
 
     it("summarizing by distinct datetime should allow granular selection (metabase#13098)", () => {
       // Go straight to orders table in custom questions
-      cy.visit("/question/new?database=1&table=2&mode=notebook");
+      openOrdersTable({ mode: "notebook" });
 
       summarize({ mode: "notebook" });
       popover().within(() => {

--- a/frontend/test/metabase/scenarios/question/query-external.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/query-external.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, startNewQuestion } from "__support__/e2e/cypress";
+import { restore, startNewQuestion, visualize } from "__support__/e2e/cypress";
 
 const supportedDatabases = [
   {
@@ -27,7 +27,7 @@ supportedDatabases.forEach(({ database, snapshotName, dbName }) => {
       cy.findByText(dbName).click();
       cy.findByText("Orders").click();
 
-      cy.wait("@dataset");
+      visualize();
       cy.contains("37.65");
     });
   });

--- a/frontend/test/metabase/scenarios/question/query-external.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/query-external.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore } from "__support__/e2e/cypress";
+import { restore, startNewQuestion } from "__support__/e2e/cypress";
 
 const supportedDatabases = [
   {
@@ -23,8 +23,7 @@ supportedDatabases.forEach(({ database, snapshotName, dbName }) => {
     });
 
     it(`can query ${database} database`, () => {
-      cy.visit("/question/new");
-      cy.findByText("Simple question").click();
+      startNewQuestion();
       cy.findByText(dbName).click();
       cy.findByText("Orders").click();
 

--- a/frontend/test/metabase/scenarios/question/reproductions/13263-postgres-show-row-details-on-pk-click.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/13263-postgres-show-row-details-on-pk-click.js
@@ -1,4 +1,4 @@
-import { restore } from "__support__/e2e/cypress";
+import { restore, startNewQuestion } from "__support__/e2e/cypress";
 
 const PG_DB_NAME = "QA Postgres12";
 
@@ -8,11 +8,8 @@ export function issue13263() {
       restore("postgres-12");
       cy.signInAsAdmin();
 
-      cy.visit("/question/new");
-      cy.findByText("Simple question").click();
-      cy.findByText(PG_DB_NAME)
-        .should("be.visible")
-        .click();
+      startNewQuestion();
+      cy.findByTextEnsureVisible(PG_DB_NAME).click();
       cy.findByTextEnsureVisible("Orders").click();
     });
 

--- a/frontend/test/metabase/scenarios/question/reproductions/13263-postgres-show-row-details-on-pk-click.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/13263-postgres-show-row-details-on-pk-click.js
@@ -1,4 +1,4 @@
-import { restore, startNewQuestion } from "__support__/e2e/cypress";
+import { restore, startNewQuestion, visualize } from "__support__/e2e/cypress";
 
 const PG_DB_NAME = "QA Postgres12";
 
@@ -11,6 +11,7 @@ export function issue13263() {
       startNewQuestion();
       cy.findByTextEnsureVisible(PG_DB_NAME).click();
       cy.findByTextEnsureVisible("Orders").click();
+      visualize();
     });
 
     it("should show row details when clicked on its entity key (metabase#13263)", () => {

--- a/frontend/test/metabase/scenarios/question/reproductions/14957-unable-to-save-question-before-query-executed.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/14957-unable-to-save-question-before-query-executed.js
@@ -1,4 +1,4 @@
-import { restore, modal } from "__support__/e2e/cypress";
+import { restore, modal, openNativeEditor } from "__support__/e2e/cypress";
 
 const PG_DB_NAME = "QA Postgres12";
 
@@ -7,16 +7,12 @@ export function issue14957() {
     beforeEach(() => {
       restore("postgres-12");
       cy.signInAsAdmin();
-
-      cy.visit("/question/new");
-      cy.findByText("Native query").click();
-      cy.findByText(PG_DB_NAME)
-        .should("be.visible")
-        .click();
     });
 
     it("should save a question before query has been executed (metabase#14957)", () => {
-      cy.get(".ace_content").type("select pg_sleep(60)");
+      openNativeEditor({ databaseName: PG_DB_NAME }).type(
+        "select pg_sleep(60)",
+      );
 
       cy.findByText("Save").click();
 

--- a/frontend/test/metabase/scenarios/question/saved.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/saved.cy.spec.js
@@ -5,6 +5,7 @@ import {
   openOrdersTable,
   summarize,
   visitQuestion,
+  startNewQuestion,
 } from "__support__/e2e/cypress";
 
 describe("scenarios > question > saved", () => {
@@ -134,13 +135,12 @@ describe("scenarios > question > saved", () => {
     cy.findByText(/This is a question/i).should("not.exist");
   });
 
-  it("should be able to use integer filter on a saved native query (metabase#15808)", () => {
+  it("should be able to use integer filter on a nested query based on a saved native question (metabase#15808)", () => {
     cy.createNativeQuestion({
       name: "15808",
       native: { query: "select * from products" },
     });
-    cy.visit("/question/new");
-    cy.findByText("Simple question").click();
+    startNewQuestion();
     cy.findByText("Saved Questions").click();
     cy.findByText("15808").click();
     cy.findAllByText("Filter")

--- a/frontend/test/metabase/scenarios/question/saved.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/saved.cy.spec.js
@@ -6,6 +6,7 @@ import {
   summarize,
   visitQuestion,
   startNewQuestion,
+  visualize,
 } from "__support__/e2e/cypress";
 
 describe("scenarios > question > saved", () => {
@@ -143,6 +144,7 @@ describe("scenarios > question > saved", () => {
     startNewQuestion();
     cy.findByText("Saved Questions").click();
     cy.findByText("15808").click();
+    visualize();
     cy.findAllByText("Filter")
       .first()
       .click();

--- a/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
@@ -9,6 +9,7 @@ import {
   summarize,
   visitQuestion,
   visitDashboard,
+  startNewQuestion,
 } from "__support__/e2e/cypress";
 
 import { USER_GROUPS, SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
@@ -281,8 +282,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
     // There's a slight hiccup in the UI with nested questions when we Summarize by City below.
     // Because there's only 5 rows, it automatically switches to the chart, but issues another
     // dataset request. So we wait for the dataset to load.
-    cy.server();
-    cy.route("POST", "/api/dataset").as("dataset");
+    cy.intercept("POST", "/api/dataset").as("dataset");
 
     // People in CA
     cy.createQuestion({
@@ -290,8 +290,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
       query: { "source-table": PEOPLE_ID, limit: 5 },
     });
     // Build a new question off that grouping by City
-    cy.visit("/question/new");
-    cy.contains("Simple question").click();
+    startNewQuestion();
     cy.contains("Saved Questions").click();
     cy.contains("CA People").click();
     cy.contains("Hudson Borer");


### PR DESCRIPTION
### Status
PENDING CI

### What does this PR accomplish?
- Replaces the occurrences of using the `/question/new` route for "Simple question" which doesn't even exist anymore. That's why we call it the simple mode.
- Replacing these routes in tests was not as straightforward as doing the same thing for the "custom question" (https://github.com/metabase/metabase/pull/21558)

This PR deals with the E2E tests in the broader initiative to [remove the deprecated `/question/new` route](https://github.com/metabase/metabase/issues/19677).
