### PR TITLE
Repro #21513: Custom Expression validator too strict when field name is the same as a function

### DIFF
--- a/frontend/test/metabase/scenarios/custom-column/reproductions/21513-cc-confusion-field-function.cy.spec.js
+++ b/frontend/test/metabase/scenarios/custom-column/reproductions/21513-cc-confusion-field-function.cy.spec.js
@@ -2,6 +2,7 @@ import {
   restore,
   popover,
   openProductsTable,
+  summarize,
   enterCustomColumnDetails,
 } from "__support__/e2e/cypress";
 
@@ -13,7 +14,7 @@ describe.skip("issue 21513", () => {
 
   it("should handle cc with the same name as an aggregation function (metabase#21513)", () => {
     openProductsTable({ mode: "notebook" });
-    cy.findByText("Summarize").click();
+    summarize({ mode: "notebook" });
     popover()
       .findByText("Count of rows")
       .click();

--- a/frontend/test/metabase/scenarios/custom-column/reproductions/21513-cc-confusion-field-function.cy.spec.js
+++ b/frontend/test/metabase/scenarios/custom-column/reproductions/21513-cc-confusion-field-function.cy.spec.js
@@ -1,0 +1,33 @@
+import {
+  restore,
+  popover,
+  openProductsTable,
+  enterCustomColumnDetails,
+} from "__support__/e2e/cypress";
+
+describe.skip("issue 21513", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should handle cc with the same name as an aggregation function (metabase#21513)", () => {
+    openProductsTable({ mode: "notebook" });
+    cy.findByText("Summarize").click();
+    popover()
+      .findByText("Count of rows")
+      .click();
+
+    cy.findByText("Pick a column to group by").click();
+    popover()
+      .findByText("Category")
+      .click();
+
+    cy.findByText("Custom column").click();
+    enterCustomColumnDetails({
+      formula: "[Count] * 2",
+      name: "Double Count",
+    });
+    cy.button("Done").should("not.be.disabled");
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #21513

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/custom-column/reproductions/21513-cc-confusion-field-function.cy.spec.js`
- Unskip repro
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshot

![image](https://user-images.githubusercontent.com/7288/162598751-a409cb94-d8e3-44cf-9f41-d086ed0d7788.png)
