### PR TITLE
propagate permissions fix

### DIFF
--- a/frontend/test/metabase/scenarios/permissions/reproductions/20436-incorrect-display-of-database-permissions-level.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/reproductions/20436-incorrect-display-of-database-permissions-level.cy.spec.js
@@ -5,7 +5,7 @@ const { ALL_USERS_GROUP } = USER_GROUPS;
 
 const url = `/admin/permissions/data/group/${ALL_USERS_GROUP}`;
 
-describe.skip("issue 20436", () => {
+describe("issue 20436", () => {
   beforeEach(() => {
     cy.intercept("PUT", "/api/permissions/graph").as("updatePermissions");
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/20436

Databases can be fetched with or without tables. When tables were not included, metadata contained databases with empty `tables`, even though they were fetched in separate requests.

## How to verify
Check the original issue for repro steps