### PR TITLE
Migrate ExpressionEditorHelpText to TippyPopover

### DIFF
--- a/frontend/src/metabase/components/Popover/Popover.css
+++ b/frontend/src/metabase/components/Popover/Popover.css
@@ -45,6 +45,7 @@
 }
 
 .tippy-box[data-theme~="popover"] {
+  font-size: inherit;
   background-color: var(--color-bg-white);
   color: var(--color-text-default);
   border: 1px solid var(--color-border);

--- a/frontend/src/metabase/query_builder/components/ExpressionPopover.jsx
+++ b/frontend/src/metabase/query_builder/components/ExpressionPopover.jsx
@@ -16,6 +16,8 @@ export default class ExpressionPopover extends React.Component {
     isBlank: true,
   };
 
+  helpTextTarget = React.createRef();
+
   render() {
     const {
       title,
@@ -41,8 +43,9 @@ export default class ExpressionPopover extends React.Component {
             <h3 className="inline-block pl1">{title}</h3>
           </a>
         </div>
-        <div className="p1">
+        <div className="p1" ref={this.helpTextTarget}>
           <ExpressionEditorTextfield
+            helpTextTarget={this.helpTextTarget.current}
             startRule={startRule}
             expression={expression}
             query={query}

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText.tsx
@@ -5,7 +5,7 @@ import MetabaseSettings from "metabase/lib/settings";
 import colors from "metabase/lib/colors";
 import ExternalLink from "metabase/core/components/ExternalLink";
 import Icon from "metabase/components/Icon";
-import Popover from "metabase/components/Popover";
+import TippyPopover from "metabase/components/Popover/TippyPopover";
 
 type Arg = {
   name: string;
@@ -22,48 +22,55 @@ type HelpText = {
 interface HelpTextProps {
   helpText: HelpText;
   width: number;
+  target: Element;
 }
 
-const HelpText = ({ helpText, width }: HelpTextProps) =>
-  helpText ? (
-    <Popover
-      tetherOptions={{
-        attachment: "top left",
-        targetAttachment: "bottom left",
-      }}
-      style={{ width }}
-      isOpen
-    >
-      {/* Prevent stealing focus from input box causing the help text to be closed (metabase#17548) */}
-      <div onMouseDown={e => e.preventDefault()}>
-        <p
-          className="p2 m0 text-monospace text-bold"
-          style={{ background: colors["bg-yellow"] }}
-        >
-          {helpText.structure}
-        </p>
-        <div className="p2 border-top">
-          <p className="mt0 text-bold">{helpText.description}</p>
-          <p className="text-code m0 text-body">{helpText.example}</p>
-        </div>
-        <div className="p2 border-top">
-          {helpText.args.map(({ name, description }, index) => (
-            <div key={index}>
-              <h4 className="text-medium">{name}</h4>
-              <p className="mt1 text-bold">{description}</p>
+const HelpText = ({ helpText, width, target }: HelpTextProps) => {
+  if (!helpText) {
+    return null;
+  }
+
+  return (
+    <TippyPopover
+      maxWidth={width}
+      reference={target}
+      placement="bottom-start"
+      visible
+      content={
+        <>
+          {/* Prevent stealing focus from input box causing the help text to be closed (metabase#17548) */}
+          <div onMouseDown={e => e.preventDefault()}>
+            <p
+              className="p2 m0 text-monospace text-bold"
+              style={{ background: colors["bg-yellow"] }}
+            >
+              {helpText.structure}
+            </p>
+            <div className="p2 border-top">
+              <p className="mt0 text-bold">{helpText.description}</p>
+              <p className="text-code m0 text-body">{helpText.example}</p>
             </div>
-          ))}
-          <ExternalLink
-            className="link text-bold block my1"
-            target="_blank"
-            href={MetabaseSettings.docsUrl("users-guide/expressions")}
-          >
-            <Icon name="reference" size={12} className="mr1" />
-            {t`Learn more`}
-          </ExternalLink>
-        </div>
-      </div>
-    </Popover>
-  ) : null;
+            <div className="p2 border-top">
+              {helpText.args.map(({ name, description }, index) => (
+                <div key={index}>
+                  <h4 className="text-medium">{name}</h4>
+                  <p className="mt1 text-bold">{description}</p>
+                </div>
+              ))}
+              <ExternalLink
+                className="link text-bold block my1"
+                target="_blank"
+                href={MetabaseSettings.docsUrl("users-guide/expressions")}
+              >
+                <Icon name="reference" size={12} className="mr1" />
+                {t`Learn more`}
+              </ExternalLink>
+            </div>
+          </div>
+        </>
+      }
+    ></TippyPopover>
+  );
+};
 
 export default HelpText;

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -60,6 +60,7 @@ export default class ExpressionEditorTextfield extends React.Component {
     onError: PropTypes.func.isRequired,
     startRule: PropTypes.string.isRequired,
     onBlankChange: PropTypes.func,
+    helpTextTarget: PropTypes.instanceOf(Element).isRequired,
   };
 
   static defaultProps = {
@@ -445,7 +446,11 @@ export default class ExpressionEditorTextfield extends React.Component {
           />
         </EditorContainer>
         <ErrorMessage error={errorMessage} />
-        <HelpText helpText={this.state.helpText} width={this.props.width} />
+        <HelpText
+          target={this.props.helpTextTarget}
+          helpText={this.state.helpText}
+          width={this.props.width}
+        />
       </React.Fragment>
     );
   }

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx
@@ -30,6 +30,8 @@ export default class ExpressionWidget extends Component {
     name: "",
   };
 
+  helpTextTarget = React.createRef();
+
   UNSAFE_componentWillMount() {
     this.UNSAFE_componentWillReceiveProps(this.props);
   }
@@ -61,8 +63,9 @@ export default class ExpressionWidget extends Component {
       <div style={{ maxWidth: "600px" }}>
         <div className="p2">
           <div className="h5 text-uppercase text-medium text-bold">{t`Field formula`}</div>
-          <div>
+          <div ref={this.helpTextTarget}>
             <ExpressionEditorTextfield
+              helpTextTarget={this.helpTextTarget.current}
               expression={expression}
               query={query}
               onChange={parsedExpression =>


### PR DESCRIPTION
Related to #18951

### ExpressionPopover
#### Before the migration
![image](https://user-images.githubusercontent.com/1937582/162721647-cd25b05a-bb16-4f5b-8027-a97feb55967e.png)

#### After the migration
![image](https://user-images.githubusercontent.com/1937582/162721666-fdd60d9c-0ac3-449b-9910-b9e551866949.png)

### ExpressionWidget
#### Before the migration
![image](https://user-images.githubusercontent.com/1937582/162721761-96d17e9b-aa9f-4598-86a0-af69d27430eb.png)

#### After the migration
![image](https://user-images.githubusercontent.com/1937582/162721771-717a437a-0ff2-4cc8-ad06-af04fe8dbbb7.png)

### Note
`.tippy-box` has a `line-height: 1.4`, so the popover is a tad higher than the previous one.