### PR TITLE
Bring Metabot tooltip back

### DIFF
--- a/frontend/src/metabase/home/homepage/components/HomeGreeting/HomeGreeting.tsx
+++ b/frontend/src/metabase/home/homepage/components/HomeGreeting/HomeGreeting.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from "react";
 import _ from "underscore";
 import { t } from "ttag";
+import Tooltip from "metabase/components/Tooltip";
 import { User } from "metabase-types/api";
 import {
   GreetingLogo,
@@ -21,7 +22,14 @@ const HomeGreeting = ({
 
   return (
     <GreetingRoot>
-      {showLogo && <GreetingLogo />}
+      {showLogo && (
+        <Tooltip
+          tooltip={t`Don't tell anyone, but you're my favorite.`}
+          placement="bottom"
+        >
+          <GreetingLogo />
+        </Tooltip>
+      )}
       <GreetingMessage showLogo={showLogo}>{message}</GreetingMessage>
     </GreetingRoot>
   );


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/21322

On the new homepage the tooltip that was shown when the user hovers Metabot logo was lost. This PR brings it back.

<img width="964" alt="Screenshot 2022-04-11 at 13 55 59" src="https://user-images.githubusercontent.com/8542534/162726499-71b4e759-8ea5-491b-b0f8-d969bad17b68.png">
