### PR TITLE
Automatically select timeline when its event is selected in the sidebar

### DIFF
--- a/frontend/src/metabase/timelines/questions/components/TimelineCard/TimelineCard.tsx
+++ b/frontend/src/metabase/timelines/questions/components/TimelineCard/TimelineCard.tsx
@@ -55,11 +55,22 @@ const TimelineCard = ({
     event.stopPropagation();
   }, []);
 
-  const handleCheckboxChange = useCallback(
+  const handleToggleTimeline = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
       onToggleTimeline?.(timeline, event.target.checked);
     },
     [timeline, onToggleTimeline],
+  );
+
+  const handleToggleEvent = useCallback(
+    (event: TimelineEvent, isSelected: boolean) => {
+      onToggleEvent?.(event, isSelected);
+
+      if (isSelected && !isVisible) {
+        onToggleTimeline?.(timeline, true);
+      }
+    },
+    [timeline, isVisible, onToggleTimeline, onToggleEvent],
   );
 
   useEffect(() => {
@@ -74,7 +85,7 @@ const TimelineCard = ({
         <CardCheckbox
           checked={isVisible}
           onClick={handleCheckboxClick}
-          onChange={handleCheckboxChange}
+          onChange={handleToggleTimeline}
         />
         <CardLabel>
           <Ellipsified tooltipMaxWidth="100%">
@@ -94,7 +105,7 @@ const TimelineCard = ({
               onEdit={onEditEvent}
               onMove={onMoveEvent}
               onArchive={onArchiveEvent}
-              onToggle={onToggleEvent}
+              onToggle={handleToggleEvent}
             />
           ))}
         </CardContent>

--- a/frontend/src/metabase/timelines/questions/components/TimelineCard/TimelineCard.unit.spec.tsx
+++ b/frontend/src/metabase/timelines/questions/components/TimelineCard/TimelineCard.unit.spec.tsx
@@ -39,6 +39,22 @@ describe("TimelineCard", () => {
 
     expect(props.onToggleTimeline).toHaveBeenCalled();
   });
+
+  it("should make a timeline visible when its even is selected", () => {
+    const props = getProps({
+      timeline: createMockTimeline({
+        name: "Releases",
+        events: [createMockTimelineEvent({ name: "RC" })],
+      }),
+      isVisible: false,
+    });
+
+    render(<TimelineCard {...props} />);
+    userEvent.click(screen.getByText("Releases"));
+    userEvent.click(screen.getByText("RC"));
+
+    expect(props.onToggleTimeline).toHaveBeenCalledWith(props.timeline, true);
+  });
 });
 
 const getProps = (opts?: Partial<TimelineCardProps>): TimelineCardProps => ({


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/20289
Demo https://www.loom.com/share/c61fd42f0f8a48f9aa007edd4420537c

How to test:
- Open a timeseries question 
- Create events if there are none
- When a timeline is not selected in the sidebar, expand it and select an event
- Make sure that the timeline is selected and the event is visible in the chart

<img width="302" alt="Screenshot 2022-04-11 at 14 23 54" src="https://user-images.githubusercontent.com/8542534/162730143-6779be92-810b-4fa0-9bd6-e13b8b44af12.png">
