### PR TITLE
Update download and upload actions to latests on v.2

### DIFF
--- a/.github/actions/prepare-uberjar-artifact/action.yml
+++ b/.github/actions/prepare-uberjar-artifact/action.yml
@@ -9,7 +9,7 @@ runs:
       run: sha256sum ./target/uberjar/metabase.jar > SHA256.sum
       shell: bash
     - name: Upload JARs as artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v2.3.1
       with:
         name: metabase-${{ matrix.edition }}-uberjar
         path: |

--- a/.github/workflows/e2e-master.yml
+++ b/.github/workflows/e2e-master.yml
@@ -118,7 +118,7 @@ jobs:
     - name: Run Snowplow micro
       uses: ./.github/actions/run-snowplow-micro
 
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v2.1.0
       name: Retrieve uberjar artifact for ${{ matrix.edition }}
       with:
         name: metabase-${{ matrix.edition }}-uberjar

--- a/.github/workflows/e2e-master.yml
+++ b/.github/workflows/e2e-master.yml
@@ -138,7 +138,7 @@ jobs:
         TERM: xterm
 
     - name: Upload Cypress recording upon failure
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v2.3.1
       if: failure()
       with:
         name: cypress-recording-${{ matrix.folder }}-${{ matrix.edition }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -121,7 +121,7 @@ jobs:
         TERM: xterm
 
     - name: Upload Cypress recording upon failure
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v2.3.1
       if: failure()
       with:
         name: cypress-recording-${{ matrix.folder }}-${{ matrix.edition }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -106,7 +106,7 @@ jobs:
     - name: Run Snowplow micro
       uses: ./.github/actions/run-snowplow-micro
 
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v2.1.0
       name: Retrieve uberjar artifact for ${{ matrix.edition }}
       with:
         name: metabase-${{ matrix.edition }}-uberjar

--- a/.github/workflows/percy-issue-comment.yml
+++ b/.github/workflows/percy-issue-comment.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Prepare cypress environment
         uses: ./.github/actions/prepare-cypress
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v2.1.0
         name: Retrieve uberjar artifact
         with:
           name: metabase-oss-uberjar

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Prepare cypress environment
         uses: ./.github/actions/prepare-cypress
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v2.1.0
         name: Retrieve uberjar artifact
         with:
           name: metabase-oss-uberjar

--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -49,7 +49,7 @@ jobs:
         java-version: ${{ matrix.java-version }}
         distribution: 'temurin'
     - run: java -version
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v2.1.0
       name: Retrieve uberjar artifact
       with:
         name: metabase-${{ matrix.edition }}-uberjar
@@ -78,7 +78,7 @@ jobs:
     - name: Check out the code (Dockerfile needed)
       uses: actions/checkout@v3
     - name: Download uploaded artifacts to insert into container
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v2.1.0
       with:
         name: metabase-${{ matrix.edition }}-uberjar
         path: bin/docker/


### PR DESCRIPTION
As we know, we have an issue with ```Error: An error occurred while attempting to decompress the response stream
A 200 response code has been received while attempting to download an artifact``` becoming very often related to this [Github Issue](https://github.com/actions/download-artifact/issues/151) 

We already also know that v.3 (which has breaking changes) does not work as expected and v.2 is showing the issues.

Since there are quite a few fixes in the release notes for v.2.x related to bugfixes, it is worth trying to see if we get any different results.