### PR TITLE
Show x-rays when there is no question and dashboard

### DIFF
--- a/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx
+++ b/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx
@@ -22,6 +22,7 @@ import SyncedParametersList from "metabase/parameters/components/SyncedParameter
 
 import { getMetadata } from "metabase/selectors/metadata";
 
+import Collections from "metabase/entities/collections";
 import Dashboards from "metabase/entities/dashboards";
 import * as Urls from "metabase/lib/urls";
 import * as MetabaseAnalytics from "metabase/lib/analytics";
@@ -48,6 +49,7 @@ const mapStateToProps = (state, props) => ({
 
 const mapDispatchToProps = {
   saveDashboard: Dashboards.actions.save,
+  invalidateCollections: Collections.actions.invalidateLists,
 };
 
 @connect(mapStateToProps, mapDispatchToProps)
@@ -67,11 +69,17 @@ class AutomaticDashboardApp extends React.Component {
   }
 
   save = async () => {
-    const { dashboard, triggerToast, saveDashboard } = this.props;
+    const {
+      dashboard,
+      triggerToast,
+      saveDashboard,
+      invalidateCollections,
+    } = this.props;
     // remove the transient id before trying to save
     const { payload: newDashboard } = await saveDashboard(
       dissoc(dashboard, "id"),
     );
+    invalidateCollections();
     triggerToast(
       <div className="flex align-center">
         {t`Your dashboard was saved`}

--- a/frontend/src/metabase/home/homepage/components/HomeContent/HomeContent.tsx
+++ b/frontend/src/metabase/home/homepage/components/HomeContent/HomeContent.tsx
@@ -43,8 +43,8 @@ const isPopularSection = ({
   );
 };
 
-const isRecentSection = ({ recentItems }: HomeContentProps): boolean => {
-  return recentItems.length > 0;
+const isRecentSection = ({ user, recentItems }: HomeContentProps): boolean => {
+  return user.has_question_and_dashboard && recentItems.length > 0;
 };
 
 const isXraySection = ({ databases }: HomeContentProps): boolean => {

--- a/frontend/src/metabase/home/homepage/components/HomeContent/HomeContent.unit.spec.tsx
+++ b/frontend/src/metabase/home/homepage/components/HomeContent/HomeContent.unit.spec.tsx
@@ -93,6 +93,22 @@ describe("HomeContent", () => {
     expect(screen.getByText("XraySection")).toBeInTheDocument();
   });
 
+  it("should render x-rays for the installer when there is no question and dashboard", () => {
+    const props = getProps({
+      user: createMockUser({
+        is_installer: true,
+        has_question_and_dashboard: false,
+        first_login: "2020-01-10T00:00:00Z",
+      }),
+      databases: [createMockDatabase()],
+      recentItems: [createMockRecentItem()],
+    });
+
+    render(<HomeContent {...props} />);
+
+    expect(screen.getByText("XraySection")).toBeInTheDocument();
+  });
+
   it("should render nothing if there are no databases", () => {
     const props = getProps({
       user: createMockUser({

--- a/frontend/src/metabase/lib/entities.js
+++ b/frontend/src/metabase/lib/entities.js
@@ -338,6 +338,11 @@ export function createEntity(def) {
       };
     }),
 
+    invalidateLists: compose(
+      withAction(INVALIDATE_LISTS_ACTION),
+      withEntityActionDecorators("invalidateLists"),
+    )(() => null),
+
     // user defined actions should override defaults
     ...entity.objectActions,
     ...(def.actions || {}),


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/21322

Do not show recent items until there at least one question and dashboard accessible by the current user.

How to test:
- Run a fresh Metabase instance and complete setup without adding a database
- You should see x-rays on the homepage
- Open an x-ray dashboard and save it
- Come back to the homepage and reload it. You should now see your recent items.

Please note that you won't see the x-ray dashboard you just saved. It's a known issue and should be fixed on the backend.