### PR TITLE
Unskip repro for #20638

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
@@ -27,13 +27,13 @@ describe("scenarios > dashboard", () => {
     cy.signInAsAdmin();
   });
 
-  it("should create new dashboard and navigate to it from the nav bar", () => {
+  it("should create new dashboard and navigate to it from the nav bar and from the root collection (metabase#20638)", () => {
     // Create dashboard
     cy.visit("/");
     cy.icon("add").click();
     cy.findByText("Dashboard").click();
 
-    createDashboardUsingUI("Test Dash", "Desc");
+    createDashboardUsingUI("Dash A", "Desc A");
 
     cy.findByText("This dashboard is looking empty.");
     cy.findByText("You're editing this dashboard.");
@@ -41,14 +41,15 @@ describe("scenarios > dashboard", () => {
     // See it as a listed dashboard
     cy.visit("/collection/root?type=dashboard");
     cy.findByText("This dashboard is looking empty.").should("not.exist");
-    cy.findByText("Test Dash");
-  });
+    cy.findByText("Dash A");
 
-  it("should create new dashboard and navigate to it from the root collection (metabase#20638)", () => {
-    cy.visit("/collection/root");
+    cy.log(
+      "should create new dashboard and navigate to it from the root collection (metabase#20638)",
+    );
+
     openNewCollectionItemFlowFor("dashboard");
 
-    createDashboardUsingUI("Test Dash", "Desc");
+    createDashboardUsingUI("Dash B", "Desc B");
 
     cy.findByText("This dashboard is looking empty.");
     cy.findByText("You're editing this dashboard.");

--- a/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
@@ -44,7 +44,7 @@ describe("scenarios > dashboard", () => {
     cy.findByText("Test Dash");
   });
 
-  it.skip("should create new dashboard and navigate to it from the root collection (metabase#20638)", () => {
+  it("should create new dashboard and navigate to it from the root collection (metabase#20638)", () => {
     cy.visit("/collection/root");
     openNewCollectionItemFlowFor("dashboard");
 


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Unskips e2e reproduction for #20638 which was fixed in #20709 by @daltojohnso 
- Merges two related tests together
    - One that checks dashboard can be created from the home page and
    - the one that checks that dashboard can be created from the root collection (the actual repro for #20638)

This is one step in the broader initiative to [unskip forgotten repros for issues that were fixed](https://github.com/metabase/metabase/issues/21485).
