### PR TITLE
Do not render timeline events for non-timeseries chart

### DIFF
--- a/frontend/src/metabase/visualizations/lib/timelines.js
+++ b/frontend/src/metabase/visualizations/lib/timelines.js
@@ -209,12 +209,17 @@ export function renderEvents(
   {
     events = [],
     selectedEventIds = [],
+    isTimeseries,
     onHoverChange,
     onOpenTimelines,
     onSelectTimelineEvents,
     onDeselectTimelineEvents,
   },
 ) {
+  if (!isTimeseries) {
+    return;
+  }
+
   const axis = getAxis(chart);
   const brush = getBrush(chart);
   const scale = getScale(chart);

--- a/frontend/test/metabase/scenarios/question/timelines.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/timelines.cy.spec.js
@@ -1,4 +1,13 @@
-import { restore, visitQuestion, sidebar } from "__support__/e2e/cypress";
+import {
+  restore,
+  visitQuestion,
+  sidebar,
+  visitQuestionAdhoc,
+} from "__support__/e2e/cypress";
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+
+const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
 
 describe("scenarios > collections > timelines", () => {
   beforeEach(() => {
@@ -168,6 +177,62 @@ describe("scenarios > collections > timelines", () => {
 
       cy.findByText("Releases").should("be.visible");
       cy.findByText("Release notes").should("be.visible");
+    });
+
+    it("should show events for ad-hoc questions", () => {
+      cy.createTimelineWithEvents({
+        timeline: { name: "Releases" },
+        events: [{ name: "RC1", timestamp: "2018-10-20T00:00:00Z" }],
+      });
+
+      visitQuestionAdhoc({
+        dataset_query: {
+          type: "query",
+          query: {
+            "source-table": ORDERS_ID,
+            aggregation: [["count"]],
+            breakout: [["field", ORDERS.CREATED_AT, null]],
+          },
+          database: SAMPLE_DB_ID,
+        },
+        display: "bar",
+        visualization_settings: {
+          "graph.dimensions": ["TOTAL"],
+          "graph.metrics": ["count"],
+        },
+      });
+
+      cy.findByText("Visualization").should("be.visible");
+      cy.findByLabelText("star icon").should("be.visible");
+    });
+
+    it("should not show events for non-timeseries questions", () => {
+      cy.createTimelineWithEvents({
+        timeline: { name: "Releases" },
+        events: [{ name: "RC1", timestamp: "2018-10-20T00:00:00Z" }],
+      });
+
+      visitQuestionAdhoc({
+        dataset_query: {
+          type: "query",
+          query: {
+            "source-table": ORDERS_ID,
+            aggregation: [["count"]],
+            breakout: [
+              ["field", ORDERS.TOTAL, { binning: { strategy: "default" } }],
+            ],
+          },
+          database: SAMPLE_DB_ID,
+        },
+        display: "bar",
+        visualization_settings: {
+          "graph.dimensions": ["TOTAL"],
+          "graph.metrics": ["count"],
+        },
+      });
+
+      cy.findByText("Visualization").should("be.visible");
+      cy.findByLabelText("star icon").should("not.exist");
     });
   });
 


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/20289
Regression after https://github.com/metabase/metabase/pull/21497

How to test:
- Create an event. The date can be arbitrary .
- Open a non-timeseries question.
- You shouldn't see events on the X-axis.