### PR TITLE
Backport Disallow FDW connections in SQLite

### DIFF
--- a/modules/drivers/sqlite/src/metabase/driver/sqlite.clj
+++ b/modules/drivers/sqlite/src/metabase/driver/sqlite.clj
@@ -66,7 +66,9 @@
       :as   details}]
   (merge {:subprotocol "sqlite"
           :subname     db}
-         (dissoc details :db)))
+         (dissoc details :db)
+         ;; disallow "FDW" (connecting to other SQLite databases on the local filesystem) -- see https://github.com/metabase/metaboat/issues/152
+         {:limit_attached 0}))
 
 ;; We'll do regex pattern matching here for determining Field types because SQLite types can have optional lengths,
 ;; e.g. NVARCHAR(100) or NUMERIC(10,5) See also http://www.sqlite.org/datatype3.html

--- a/modules/drivers/sqlite/test/metabase/driver/sqlite_test.clj
+++ b/modules/drivers/sqlite/test/metabase/driver/sqlite_test.clj
@@ -1,15 +1,18 @@
 (ns metabase.driver.sqlite-test
-  (:require [clojure.java.jdbc :as jdbc]
+  (:require [clojure.java.io :as io]
+            [clojure.java.jdbc :as jdbc]
             [clojure.test :refer :all]
             [metabase.driver :as driver]
             [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
             [metabase.models.database :refer [Database]]
             [metabase.models.table :refer [Table]]
+            [metabase.query-processor :as qp]
             [metabase.query-processor-test :as qp.test]
             [metabase.sync :as sync]
             [metabase.test :as mt]
             [metabase.test.data :as data]
             [metabase.test.util :as tu]
+            [metabase.util :as u]
             [toucan.db :as db]
             [toucan.hydrate :refer [hydrate]]))
 
@@ -203,3 +206,55 @@
                      (mt/run-mbql-query :datetime_table
                                         {:fields [$col_timestamp $col_date $col_datetime]
                                          :filter [:= $test_case "null"]}))))))))))
+
+(deftest duplicate-identifiers-test
+  (testing "Make sure duplicate identifiers (even with different cases) get unique aliases"
+    (mt/test-driver :sqlite
+      (mt/dataset sample-dataset
+        (is (= '{:select   [source.CATEGORY_2 AS CATEGORY_2
+                            count (*)         AS count]
+                 :from     [{:select [products.id              AS id
+                                      products.ean             AS ean
+                                      products.title           AS title
+                                      products.category        AS category
+                                      products.vendor          AS vendor
+                                      products.price           AS price
+                                      products.rating          AS rating
+                                      products.created_at      AS created_at
+                                      (products.category || ?) AS CATEGORY_2]
+                             :from   [products]}
+                            source]
+                 :group-by [source.CATEGORY_2]
+                 :order-by [source.CATEGORY_2 ASC]
+                 :limit    [1]}
+               (sql.qp-test-util/query->sql-map
+                (mt/mbql-query products
+                  {:expressions {:CATEGORY [:concat $category "2"]}
+                   :breakout    [:expression :CATEGORY]
+                   :aggregation [:count]
+                   :order-by    [[:asc [:expression :CATEGORY]]]
+                   :limit       1}))))))))
+
+(deftest disallow-fdw-to-other-databases-test
+  (testing "Don't allow connections to other SQLite databases with ATTACH DATABASE (https://github.com/metabase/metaboat/issues/152)"
+    (mt/test-driver :sqlite
+      ;; force creation of the sample dataset file
+      (mt/dataset sample-dataset
+        (mt/id))
+      (let [file (io/file "sample-dataset.sqlite")
+            path (.getAbsolutePath file)]
+        (is (.exists file))
+        (testing "Attach the sample dataset as an FDW called fdw_test"
+          (testing "Detach it if it already exists from a previous test run"
+            (u/ignore-exceptions
+              (qp/process-query (mt/native-query {:query "DETACH DATABASE fdw_test;"}))))
+          (testing "Attempting to attach it should fail"
+            (is (thrown-with-msg?
+                 clojure.lang.ExceptionInfo
+                 #"SQL error or missing database \(too many attached databases - max 0\)"
+                 (qp/process-query (mt/native-query {:query (format "ATTACH DATABASE 'file:%s' as fdw_test;" path)}))))))
+        (testing "Attempt to query the FDW -- shouldn't work"
+          (is (thrown-with-msg?
+               clojure.lang.ExceptionInfo
+               #"SQL error or missing database \(no such table: fdw_test\.products\)"
+               (qp/process-query (mt/native-query {:query "SELECT count(*) FROM fdw_test.products;"})))))))))


### PR DESCRIPTION
This is the backport of https://github.com/metabase/metabase/pull/21525 to the `release-x.41.x`

This fixes Fixes https://github.com/metabase/metaboat/issues/152