### PR TITLE
Make events work for native queries

### DIFF
--- a/frontend/src/metabase-lib/lib/Question.ts
+++ b/frontend/src/metabase-lib/lib/Question.ts
@@ -1201,20 +1201,6 @@ export default class Question {
     return a.isDirtyComparedTo(b);
   }
 
-  hasBreakoutByDateTime() {
-    if (!this.isStructured()) {
-      return false;
-    }
-
-    const query = this.query() as StructuredQuery;
-    const breakouts = query.breakouts();
-
-    return breakouts.some(breakout => {
-      const field = breakout.field();
-      return field.isDate() || field.isTime();
-    });
-  }
-
   // Internal methods
   _serializeForUrl({
     includeOriginalCardId = true,

--- a/frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx
+++ b/frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx
@@ -28,8 +28,8 @@ export default class TimeseriesFilterWidget extends Component {
   }
 
   UNSAFE_componentWillReceiveProps(nextProps) {
-    const { query } = nextProps;
-    const breakouts = query.breakouts();
+    const { question, query } = nextProps;
+    const breakouts = question.isStructured() && query.breakouts();
     if (breakouts && breakouts.length > 0) {
       const filters = query.filters();
 

--- a/frontend/src/metabase/query_builder/components/view/QuestionTimelineWidget/QuestionTimelineWidget.tsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionTimelineWidget/QuestionTimelineWidget.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { t } from "ttag";
-import Question from "metabase-lib/lib/Question";
 import { TimelineIcon } from "./QuestionTimelineWidget.styled";
 
 export interface QuestionTimelineWidgetProps {
@@ -27,13 +26,13 @@ const QuestionTimelineWidget = ({
 };
 
 export interface QuestionTimelineWidgetOpts {
-  question: Question;
+  isTimeseries?: boolean;
 }
 
 QuestionTimelineWidget.shouldRender = ({
-  question,
+  isTimeseries,
 }: QuestionTimelineWidgetOpts) => {
-  return question.hasBreakoutByDateTime();
+  return isTimeseries;
 };
 
 export default QuestionTimelineWidget;

--- a/frontend/src/metabase/query_builder/components/view/View.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View.jsx
@@ -219,9 +219,15 @@ export default class View extends React.Component {
       isShowingTemplateTagsEditor,
       isShowingDataReference,
       isShowingSnippetSidebar,
+      isShowingTimelineSidebar,
       toggleTemplateTagsEditor,
       toggleDataReference,
       toggleSnippetSidebar,
+      showTimelines,
+      hideTimelines,
+      selectTimelineEvents,
+      deselectTimelineEvents,
+      onCloseTimelines,
     } = this.props;
 
     if (isShowingTemplateTagsEditor) {
@@ -236,6 +242,19 @@ export default class View extends React.Component {
 
     if (isShowingSnippetSidebar) {
       return <SnippetSidebar {...this.props} onClose={toggleSnippetSidebar} />;
+    }
+
+    if (isShowingTimelineSidebar) {
+      return (
+        <TimelineSidebar
+          {...this.props}
+          onShowTimelines={showTimelines}
+          onHideTimelines={hideTimelines}
+          onSelectTimelineEvents={selectTimelineEvents}
+          onDeselectTimelineEvents={deselectTimelineEvents}
+          onClose={onCloseTimelines}
+        />
+      );
     }
 
     return null;

--- a/frontend/src/metabase/query_builder/components/view/ViewFooter.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewFooter.jsx
@@ -58,8 +58,8 @@ const ViewFooter = ({
   isPreviewing,
   isResultDirty,
   isVisualized,
+  isTimeseries,
   queryBuilderMode,
-
   isShowingFilterSidebar,
   onAddFilter,
   onCloseFilter,
@@ -199,7 +199,7 @@ const ViewFooter = ({
               }
             />
           ),
-          QuestionTimelineWidget.shouldRender({ question }) && (
+          QuestionTimelineWidget.shouldRender({ isTimeseries }) && (
             <QuestionTimelineWidget
               key="timelines"
               className="mx1 hide sm-show"

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
@@ -77,6 +77,7 @@ import {
   getIsAnySidebarOpen,
   getDocumentTitle,
   getPageFavicon,
+  getIsTimeseries,
 } from "../selectors";
 import * as actions from "../actions";
 
@@ -151,6 +152,7 @@ const mapStateToProps = (state, props) => {
     isNativeEditorOpen: getIsNativeEditorOpen(state),
     isVisualized: getIsVisualized(state),
     isLiveResizable: getIsLiveResizable(state),
+    isTimeseries: getIsTimeseries(state),
 
     parameters: getParameters(state),
     databaseFields: getDatabaseFields(state),

--- a/frontend/src/metabase/query_builder/reducers.js
+++ b/frontend/src/metabase/query_builder/reducers.js
@@ -108,6 +108,7 @@ const CLOSED_NATIVE_EDITOR_SIDEBARS = {
   isShowingSnippetSidebar: false,
   isShowingDataReference: false,
   isShowingQuestionDetailsSidebar: false,
+  isShowingTimelineSidebar: false,
 };
 
 // various ui state options
@@ -290,6 +291,7 @@ export const uiControls = handleActions(
     [onOpenTimelines]: state => ({
       ...state,
       ...UI_CONTROLS_SIDEBAR_DEFAULTS,
+      ...CLOSED_NATIVE_EDITOR_SIDEBARS,
       isShowingTimelineSidebar: true,
     }),
     [onCloseTimelines]: state => ({

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -642,7 +642,7 @@ function isEventWithinDomain(event, xDomain) {
   return event.timestamp.isBetween(xDomain[0], xDomain[1], undefined, "[]");
 }
 
-const getIsTimeseries = createSelector(
+export const getIsTimeseries = createSelector(
   [getVisualizationSettings],
   settings => settings && isTimeseries(settings),
 );

--- a/frontend/test/metabase/modes/TimeseriesFilterWidget.unit.spec.js
+++ b/frontend/test/metabase/modes/TimeseriesFilterWidget.unit.spec.js
@@ -11,6 +11,7 @@ import {
 
 const getTimeseriesFilterWidget = question => (
   <TimeseriesFilterWidget
+    question={question}
     card={question.card()}
     query={question.query()}
     setDatasetQuery={() => {}}

--- a/frontend/test/metabase/scenarios/question/timelines.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/timelines.cy.spec.js
@@ -1,4 +1,10 @@
-import { restore, visitQuestion, sidebar } from "__support__/e2e/cypress";
+import {
+  restore,
+  visitQuestion,
+  sidebar,
+  visitQuestionAdhoc,
+} from "__support__/e2e/cypress";
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 
 describe("scenarios > collections > timelines", () => {
   beforeEach(() => {
@@ -168,6 +174,31 @@ describe("scenarios > collections > timelines", () => {
 
       cy.findByText("Releases").should("be.visible");
       cy.findByText("Release notes").should("be.visible");
+    });
+
+    it("should show events for native queries", () => {
+      cy.createTimelineWithEvents({
+        timeline: { name: "Releases" },
+        events: [{ name: "RC1", timestamp: "2018-10-20T00:00:00Z" }],
+      });
+
+      visitQuestionAdhoc({
+        dataset_query: {
+          type: "native",
+          native: {
+            query: "SELECT ID, CREATED_AT FROM ORDERS",
+          },
+          database: SAMPLE_DB_ID,
+        },
+        display: "line",
+        visualization_settings: {
+          "graph.dimensions": ["CREATED_AT"],
+          "graph.metrics": ["ID"],
+        },
+      });
+
+      cy.findByText("Visualization").should("be.visible");
+      cy.findByLabelText("star icon").should("be.visible");
     });
   });
 


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/20289

How to test:
- Create a native question `SELECT ID, CREATED_AT FROM ORDERS`
- Make sure it's possible to create events and they are displayed on the chart

<img width="1728" alt="Screenshot 2022-04-11 at 17 35 04" src="https://user-images.githubusercontent.com/8542534/162764924-9f7df1ca-7931-4cec-b0c4-4d7d69cee6d0.png">
