### PR TITLE
Repro #21559: Bar chart created from scalars in a dashboard is shown as a scalar in subscription

### DIFF
--- a/frontend/test/metabase/scenarios/sharing/reproductions/21559-subscription-bar-sent-as-scalar.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/reproductions/21559-subscription-bar-sent-as-scalar.cy.spec.js
@@ -1,0 +1,80 @@
+import {
+  restore,
+  visitDashboard,
+  editDashboard,
+  saveDashboard,
+  setupSMTP,
+} from "__support__/e2e/cypress";
+
+import { USERS } from "__support__/e2e/cypress_data";
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+
+const { admin } = USERS;
+
+const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
+
+const q1Details = {
+  name: "21559-1",
+  query: {
+    "source-table": ORDERS_ID,
+    aggregation: [["avg", ["field", ORDERS.TOTAL, null]]],
+  },
+  display: "scalar",
+};
+
+const q2Details = {
+  name: "21559-2",
+  query: {
+    "source-table": PRODUCTS_ID,
+    aggregation: [["avg", ["field", PRODUCTS.PRICE, null]]],
+  },
+  display: "scalar",
+};
+
+describe.skip("issue 21559", () => {
+  beforeEach(() => {
+    cy.intercept("POST", "/api/pulse/test").as("emailSent");
+    restore();
+    cy.signInAsAdmin();
+
+    setupSMTP();
+
+    cy.createQuestionAndDashboard({
+      questionDetails: q1Details,
+    }).then(({ body: { dashboard_id } }) => {
+      cy.createQuestion(q2Details);
+
+      visitDashboard(dashboard_id);
+      editDashboard();
+    });
+  });
+
+  it("should respect dashboard card visualization (metabase#21559)", () => {
+    cy.findByTestId("add-series-button").click({ force: true });
+
+    cy.findByText(q2Details.name).click();
+    cy.get(".AddSeriesModal").within(() => {
+      cy.findByText("Done").click();
+    });
+
+    // Make sure visualization changed to bars
+    cy.get(".bar").should("have.length", 2);
+
+    saveDashboard();
+
+    cy.icon("subscription").click();
+    cy.findByText("Email it").click();
+
+    cy.findByPlaceholderText("Enter user names or email addresses")
+      .click()
+      .type(`${admin.first_name} ${admin.last_name}{enter}`)
+      .blur(); // blur is needed to close the popover
+
+    cy.findByText("Send email now").click();
+    cy.wait("@emailSent");
+    cy.request("GET", "http://localhost:80/email").then(({ body }) => {
+      expect(body[0].html).to.include("img"); // Bar chart is sent as img (inline attachment)
+      expect(body[0].html).not.to.include("80.52"); // Scalar displays its value in HTML
+    });
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #21559 

### How to test this manually?
- `yarn test-cypress-open`
- `scenarios/sharing/reproductions/21559-subscription-bar-sent-as-scalar.cy.spec.js`
- Unskip repro
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/162810843-d3b3fabe-b100-4103-b515-e2cdd0f427aa.png)

![image](https://user-images.githubusercontent.com/31325167/162810960-0dbf50c5-9e64-47be-a8ca-4937f5b0c129.png)


