### PR TITLE
Validate Card query Field Filters match query Database when saving

### DIFF
--- a/test/metabase/models/on_demand_test.clj
+++ b/test/metabase/models/on_demand_test.clj
@@ -4,7 +4,7 @@
             [metabase.models.card :refer [Card]]
             [metabase.models.dashboard :as dashboard :refer [Dashboard]]
             [metabase.models.database :refer [Database]]
-            [metabase.models.field :refer [Field]]
+            [metabase.models.field :as field :refer [Field]]
             [metabase.models.field-values :as field-values]
             [metabase.models.table :refer [Table]]
             [metabase.test :as mt]
@@ -29,7 +29,7 @@
    :native   {:query "SELECT AVG(SUBTOTAL) AS \"Average Price\"\nFROM ORDERS"}})
 
 (defn- native-query-with-template-tag [field-or-id]
-  {:database (data/id)
+  {:database (field/field-id->database-id (u/the-id field-or-id))
    :type     "native"
    :native   {:query         "SELECT AVG(SUBTOTAL) AS \"Average Price\"\nFROM ORDERS nWHERE {{category}}"
               :template-tags {:category {:name         "category"


### PR DESCRIPTION
Fixes #14145

When first saving a Card or on update we now validate that any Field filter template tag parameters for native queries match the Database the query is against. If not, we return a 400 response with a nice error message like 

```
Invalid Field Filter: Field 164574 "PRODUCTS"."CATEGORY" belongs to Database 2276 "sample-dataset", 
but the query is against Database 2275 "test-data"
```

Note that the error is not currently visible in the Query Builder because of #21597, but you can see it in the API response.