### PR TITLE
Use date_joined for showing popular items on the homepage until the backend is fixed

### DIFF
--- a/frontend/src/metabase/home/homepage/components/HomeContent/HomeContent.tsx
+++ b/frontend/src/metabase/home/homepage/components/HomeContent/HomeContent.tsx
@@ -39,7 +39,7 @@ const isPopularSection = ({
     !user.is_installer &&
     user.has_question_and_dashboard &&
     popularItems.length > 0 &&
-    (isWithinWeek(user.first_login) || !recentItems.length)
+    (isWithinWeek(user.date_joined) || !recentItems.length)
   );
 };
 

--- a/frontend/src/metabase/home/homepage/components/HomeContent/HomeContent.unit.spec.tsx
+++ b/frontend/src/metabase/home/homepage/components/HomeContent/HomeContent.unit.spec.tsx
@@ -32,7 +32,7 @@ describe("HomeContent", () => {
       user: createMockUser({
         is_installer: false,
         has_question_and_dashboard: true,
-        first_login: "2020-01-05T00:00:00Z",
+        date_joined: "2020-01-05T00:00:00Z",
       }),
       databases: [createMockDatabase()],
       recentItems: [createMockRecentItem()],
@@ -49,7 +49,7 @@ describe("HomeContent", () => {
       user: createMockUser({
         is_installer: false,
         has_question_and_dashboard: true,
-        first_login: "2020-01-05T00:00:00Z",
+        date_joined: "2020-01-05T00:00:00Z",
       }),
       databases: [createMockDatabase()],
       recentItems: [],
@@ -66,7 +66,7 @@ describe("HomeContent", () => {
       user: createMockUser({
         is_installer: false,
         has_question_and_dashboard: true,
-        first_login: "2020-01-01T00:00:00Z",
+        date_joined: "2020-01-01T00:00:00Z",
       }),
       databases: [createMockDatabase()],
       recentItems: [createMockRecentItem()],
@@ -82,7 +82,7 @@ describe("HomeContent", () => {
       user: createMockUser({
         is_installer: true,
         has_question_and_dashboard: false,
-        first_login: "2020-01-10T00:00:00Z",
+        date_joined: "2020-01-10T00:00:00Z",
       }),
       databases: [createMockDatabase()],
       recentItems: [],
@@ -98,7 +98,7 @@ describe("HomeContent", () => {
       user: createMockUser({
         is_installer: true,
         has_question_and_dashboard: false,
-        first_login: "2020-01-10T00:00:00Z",
+        date_joined: "2020-01-10T00:00:00Z",
       }),
       databases: [createMockDatabase()],
       recentItems: [createMockRecentItem()],
@@ -114,7 +114,7 @@ describe("HomeContent", () => {
       user: createMockUser({
         is_installer: true,
         has_question_and_dashboard: false,
-        first_login: "2020-01-10T00:00:00Z",
+        date_joined: "2020-01-10T00:00:00Z",
       }),
       databases: [],
       recentItems: [],


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/21322

Currently `first_login` returns incorrect dates. To unblock the release, use `date_joined` which is very close to what `first_login` should be.

How to test:
- There are unit tests that test this