### PR TITLE
Fix navigating back in timeline details modal

### DIFF
--- a/frontend/src/metabase/timelines/collections/containers/TimelineDetailsModal/TimelineDetailsModal.tsx
+++ b/frontend/src/metabase/timelines/collections/containers/TimelineDetailsModal/TimelineDetailsModal.tsx
@@ -38,8 +38,8 @@ const mapDispatchToProps = (dispatch: any) => ({
   onArchive: async (event: TimelineEvent) => {
     await dispatch(TimelineEvents.actions.setArchived(event, true));
   },
-  onGoBack: (timeline: Timeline, collection: Collection) => {
-    dispatch(push(Urls.timelinesInCollection(collection)));
+  onGoBack: (timeline: Timeline) => {
+    dispatch(push(Urls.timelinesInCollection(timeline.collection)));
   },
 });
 


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/20289

Fixes navigating back from timeline details.

How to test:
- Go to a non-root collection and create at least 2 timelines. 
- When browsing timeline details, click Back button in the modal header.
- Make sure you are in the collection you originally was.

<img width="971" alt="Screenshot 2022-04-12 at 18 19 45" src="https://user-images.githubusercontent.com/8542534/162996531-4ba435f1-129f-40c1-aafa-6e0bdb959fae.png">
<img width="839" alt="Screenshot 2022-04-12 at 18 19 49" src="https://user-images.githubusercontent.com/8542534/162996561-60d265c2-2875-49bc-90dd-e9e0f6e6e55a.png">
