### PR TITLE
[E2E] Fix table spec flaky

### DIFF
--- a/frontend/test/__support__/e2e/helpers/e2e-notebook-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-notebook-helpers.js
@@ -18,7 +18,10 @@ export function getNotebookStep(type, { stage = 0, index = 0 } = {}) {
  * @param {function} callback
  */
 export function visualize(callback) {
-  cy.intercept("POST", "/api/dataset").as("dataset");
+  cy.intercept("POST", "/api/dataset", req => {
+    // override the previously-declared stub to just continue the request instead of stubbing
+    req.continue();
+  }).as("dataset");
 
   cy.button("Visualize").click();
 

--- a/frontend/test/metabase/scenarios/visualizations/table.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/table.cy.spec.js
@@ -156,6 +156,8 @@ describe("scenarios > visualizations > table", () => {
       .first()
       .click();
 
+    cy.wait("@dataset");
+
     cy.icon("table2").click();
 
     cy.get(".cellData")


### PR DESCRIPTION
### Status
PENDING REVIEW 

### What does this PR accomplish?
Fixes one flaky related to Tables in slow connections.

The failure was due to a race condition. The load of the dataset was taking longer than the time to `cy.get()` starts, so it was getting from the previous page, so, not returning `contains("Count")`

<img width="1079" alt="Screen Shot 2022-04-12 at 12 19 58" src="https://user-images.githubusercontent.com/17742979/162996549-82e61723-40cd-4c80-a430-95232c74d084.png">

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/visualizations/table.cy.spec.js`
-  Change the network connection on Chrome to `Fast 3G`
- All tests should pass

### Screenshots:

Failing:
<img width="2056" alt="Screen Shot 2022-04-12 at 12 13 32" src="https://user-images.githubusercontent.com/17742979/162996782-b2248595-397e-49c0-9e11-52f9e9f9adbc.png">

Passing:
<img width="2055" alt="Screen Shot 2022-04-12 at 12 12 34" src="https://user-images.githubusercontent.com/17742979/162996794-7322b7d3-75ec-4c6c-b0e5-a4d8cc489f07.png">

