### PR TITLE
Update Cypress to latest version - 9.5.4

### DIFF
--- a/.github/workflows/e2e-master.yml
+++ b/.github/workflows/e2e-master.yml
@@ -3,7 +3,7 @@ name: E2E Tests
 on:
   push:
     branches:
-      - "master"
+      - "cypress-9.5.4"
     paths-ignore:
       - "docs/**"
       - "**.md"
@@ -39,7 +39,7 @@ jobs:
 
   e2e-tests:
     runs-on: ubuntu-20.04
-    timeout-minutes: 30
+    timeout-minutes: 180
     needs: build
     name: e2e-tests-${{ matrix.folder }}-${{ matrix.edition }}
     env:
@@ -131,9 +131,8 @@ jobs:
       run: |
         yarn run test-cypress-no-build \
           --folder ${{ matrix.folder }} \
-          --record --key ${{ secrets.CURRENTS_KEY }} \
           --group ${{ matrix.folder }}-${{ matrix.edition }} \
-          --ci-build-id "${{ github.run_id }}-${{ github.run_attempt }}"
+          --env burn=10
       env:
         TERM: xterm
 

--- a/.github/workflows/e2e-master.yml
+++ b/.github/workflows/e2e-master.yml
@@ -131,7 +131,6 @@ jobs:
       run: |
         yarn run test-cypress-no-build \
           --folder ${{ matrix.folder }} \
-          --group ${{ matrix.folder }}-${{ matrix.edition }} \
           --env burn=10
       env:
         TERM: xterm

--- a/.github/workflows/e2e-master.yml
+++ b/.github/workflows/e2e-master.yml
@@ -3,7 +3,7 @@ name: E2E Tests
 on:
   push:
     branches:
-      - "cypress-9.5.4"
+      - "master"
     paths-ignore:
       - "docs/**"
       - "**.md"
@@ -131,7 +131,9 @@ jobs:
       run: |
         yarn run test-cypress-no-build \
           --folder ${{ matrix.folder }} \
-          --env burn=10
+          --record --key ${{ secrets.CURRENTS_KEY }} \
+          --group ${{ matrix.folder }}-${{ matrix.edition }} \
+          --ci-build-id "${{ github.run_id }}-${{ github.run_attempt }}"
       env:
         TERM: xterm
 

--- a/.github/workflows/e2e-master.yml
+++ b/.github/workflows/e2e-master.yml
@@ -39,7 +39,7 @@ jobs:
 
   e2e-tests:
     runs-on: ubuntu-20.04
-    timeout-minutes: 180
+    timeout-minutes: 30
     needs: build
     name: e2e-tests-${{ matrix.folder }}-${{ matrix.edition }}
     env:

--- a/package.json
+++ b/package.json
@@ -200,7 +200,7 @@
     "chromatic": "^6.3.3",
     "concurrently": "^3.1.0",
     "css-loader": "^0.28.7",
-    "cypress": "^9.5.3",
+    "cypress": "^9.5.4",
     "cypress-grep": "^2.13.1",
     "cypress-real-events": "^1.7.0",
     "documentation": "^13.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8976,10 +8976,10 @@ cypress-real-events@^1.7.0:
   resolved "https://registry.yarnpkg.com/cypress-real-events/-/cypress-real-events-1.7.0.tgz#ad6a78de33af3af0e6437f5c713e30691c44472c"
   integrity sha512-iyXp07j0V9sG3YClVDcvHN2DAQDgr+EjTID82uWDw6OZBlU3pXEBqTMNYqroz3bxlb0k+F74U81aZwzMNaKyew==
 
-cypress@^9.5.3:
-  version "9.5.3"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-9.5.3.tgz#7c56b50fc1f1aa69ef10b271d895aeb4a1d7999e"
-  integrity sha512-ItelIVmqMTnKYbo1JrErhsGgQGjWOxCpHT1TfMvwnIXKXN/OSlPjEK7rbCLYDZhejQL99PmUqul7XORI24Ik0A==
+cypress@^9.5.4:
+  version "9.5.4"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-9.5.4.tgz#49d9272f62eba12f2314faf29c2a865610e87550"
+  integrity sha512-6AyJAD8phe7IMvOL4oBsI9puRNOWxZjl8z1lgixJMcgJ85JJmyKeP6uqNA0dI1z14lmJ7Qklf2MOgP/xdAqJ/Q==
   dependencies:
     "@cypress/request" "^2.88.10"
     "@cypress/xvfb" "^1.2.4"


### PR DESCRIPTION
There's a new [release](https://docs.cypress.io/guides/references/changelog) of Cypress with bug fixes and other minor improvements and dependencies updates.