### PR TITLE
Set US locale for the dev environment

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -191,6 +191,7 @@
                  "-Duser.timezone=UTC"
                  "-Dfile.encoding=UTF-8"
                  "-Duser.language=en"
+                 "-Duser.country=US"
                  ;; Exceptions that get thrown repeatedly are created without stacktraces as a performance
                  ;; optimization in newer Java versions. This makes debugging pretty hard when working on stuff
                  ;; locally -- prefer debuggability over performance for local dev work.


### PR DESCRIPTION
This is to prevent test failures on machines with non-US locales.  See
https://github.com/metabase/metabase/pull/20023#issuecomment-1024872051 for
details.
