### PR TITLE
Fix first_login so that it actually shows the earliest login

### DIFF
--- a/src/metabase/api/activity.clj
+++ b/src/metabase/api/activity.clj
@@ -149,7 +149,7 @@
                                      :limit     views-limit
                                      :left-join [[DashboardBookmark :bm]
                                                  [:and
-                                                  [:not [:= :model "table"]]
+                                                  [:= :model "dashboard"]
                                                   [:= :bm.user_id *current-user-id*]
                                                   [:= :model_id :bm.dashboard_id]]]})
         card-runs                 (->> (db/select [QueryExecution [:%min.executor_id :user_id] [(db/qualify QueryExecution :card_id) :model_id]

--- a/src/metabase/api/user.clj
+++ b/src/metabase/api/user.clj
@@ -176,12 +176,11 @@
                                                  (db/exists? 'Dashboard (perms-query user))))))
 
 (defn- add-first-login
-  "Adds `first_login` key to the `User` with a timestamp value."
-  [{:keys [user_id] :as user}]
+  "Adds `first_login` key to the `User` with the oldest timestamp from that user's login history. Otherwise give the current time, as it's the user's first login."
+  [{:keys [id] :as user}]
   (let [ts (or
-            (:timestamp (db/select-one [LoginHistory :timestamp] :user_id user_id
-                                       {:limit    1
-                                        :order-by [[:timestamp :desc]]}))
+            (:timestamp (db/select-one [LoginHistory :timestamp] :user_id id
+                                       {:order-by [[:timestamp :asc]]}))
             (t/offset-date-time))]
     (assoc user :first_login ts)))
 


### PR DESCRIPTION
### Fix first_login

Fixes a bug where the login displayed was actually the most recent login and the id was incorrect. Basically, all wrong.

Added some tests to the user api to check both `:first_login` and `:has_question_and_dashboard`.

Also addressed a tiny change in the query for `popular_items` which was from a separate PR. This has no change on the output.