### PR TITLE
Fix database model persistence button states

### DIFF
--- a/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.jsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.jsx
@@ -101,8 +101,8 @@ const DatabaseEditAppSidebar = ({
                       className="Button Button--danger"
                       normalText={t`Disable model persistence`}
                       activeText={t`Disabling…`}
-                      failedText={t`Disabling failed`}
-                      successText={t`Disabled`}
+                      failedText={t`Failed`}
+                      successText={t`Done`}
                     />
                   ) : (
                     <ActionButton
@@ -110,8 +110,8 @@ const DatabaseEditAppSidebar = ({
                       className="Button Button--danger"
                       normalText={t`Enable model persistence`}
                       activeText={t`Enabling…`}
-                      failedText={t`Enabling failed`}
-                      successText={t`Enabled`}
+                      failedText={t`Failed`}
+                      successText={t`Done`}
                     />
                   )}
                 </li>

--- a/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.jsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.jsx
@@ -19,6 +19,7 @@ const propTypes = {
   persistDatabase: PropTypes.func.isRequired,
   unpersistDatabase: PropTypes.func.isRequired,
   isAdmin: PropTypes.bool,
+  isModelPersistenceEnabled: PropTypes.bool,
 };
 
 const DatabaseEditAppSidebar = ({
@@ -30,6 +31,7 @@ const DatabaseEditAppSidebar = ({
   persistDatabase,
   unpersistDatabase,
   isAdmin,
+  isModelPersistenceEnabled,
 }) => {
   const discardSavedFieldValuesModal = useRef();
   const deleteDatabaseModal = useRef();
@@ -89,29 +91,31 @@ const DatabaseEditAppSidebar = ({
               </li>
             )}
 
-            {isAdmin && database.supportsPersistence() && (
-              <li className="mt2">
-                {database.isPersisted() ? (
-                  <ActionButton
-                    actionFn={() => unpersistDatabase(database.id)}
-                    className="Button Button--danger"
-                    normalText={t`Disable model persistence`}
-                    activeText={t`Disabling…`}
-                    failedText={t`Disabling failed`}
-                    successText={t`Disabled`}
-                  />
-                ) : (
-                  <ActionButton
-                    actionFn={() => persistDatabase(database.id)}
-                    className="Button Button--danger"
-                    normalText={t`Enable model persistence`}
-                    activeText={t`Enabling…`}
-                    failedText={t`Enabling failed`}
-                    successText={t`Enabled`}
-                  />
-                )}
-              </li>
-            )}
+            {isAdmin &&
+              isModelPersistenceEnabled &&
+              database.supportsPersistence() && (
+                <li className="mt2">
+                  {database.isPersisted() ? (
+                    <ActionButton
+                      actionFn={() => unpersistDatabase(database.id)}
+                      className="Button Button--danger"
+                      normalText={t`Disable model persistence`}
+                      activeText={t`Disabling…`}
+                      failedText={t`Disabling failed`}
+                      successText={t`Disabled`}
+                    />
+                  ) : (
+                    <ActionButton
+                      actionFn={() => persistDatabase(database.id)}
+                      className="Button Button--danger"
+                      normalText={t`Enable model persistence`}
+                      activeText={t`Enabling…`}
+                      failedText={t`Enabling failed`}
+                      successText={t`Enabled`}
+                    />
+                  )}
+                </li>
+              )}
             {isAdmin && (
               <li className="mt2">
                 <ModalWithTrigger

--- a/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.jsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.jsx
@@ -67,6 +67,31 @@ const DatabaseEditAppSidebar = ({
                 successText={t`Scan triggered!`}
               />
             </li>
+            {isAdmin &&
+              isModelPersistenceEnabled &&
+              database.supportsPersistence() && (
+                <li className="mt2">
+                  {database.isPersisted() ? (
+                    <ActionButton
+                      actionFn={() => unpersistDatabase(database.id)}
+                      className="Button"
+                      normalText={t`Disable model persistence`}
+                      activeText={t`Disabling…`}
+                      failedText={t`Failed`}
+                      successText={t`Done`}
+                    />
+                  ) : (
+                    <ActionButton
+                      actionFn={() => persistDatabase(database.id)}
+                      className="Button"
+                      normalText={t`Enable model persistence`}
+                      activeText={t`Enabling…`}
+                      failedText={t`Failed`}
+                      successText={t`Done`}
+                    />
+                  )}
+                </li>
+              )}
           </ol>
         </div>
 
@@ -91,31 +116,6 @@ const DatabaseEditAppSidebar = ({
               </li>
             )}
 
-            {isAdmin &&
-              isModelPersistenceEnabled &&
-              database.supportsPersistence() && (
-                <li className="mt2">
-                  {database.isPersisted() ? (
-                    <ActionButton
-                      actionFn={() => unpersistDatabase(database.id)}
-                      className="Button Button--danger"
-                      normalText={t`Disable model persistence`}
-                      activeText={t`Disabling…`}
-                      failedText={t`Failed`}
-                      successText={t`Done`}
-                    />
-                  ) : (
-                    <ActionButton
-                      actionFn={() => persistDatabase(database.id)}
-                      className="Button Button--danger"
-                      normalText={t`Enable model persistence`}
-                      activeText={t`Enabling…`}
-                      failedText={t`Failed`}
-                      successText={t`Done`}
-                    />
-                  )}
-                </li>
-              )}
             {isAdmin && (
               <li className="mt2">
                 <ModalWithTrigger

--- a/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx
@@ -16,7 +16,8 @@ import DriverWarning from "metabase/containers/DriverWarning";
 import { getUserIsAdmin } from "metabase/selectors/user";
 
 import Databases from "metabase/entities/databases";
-import { getMetadata } from "metabase/selectors/metadata";
+
+import Database from "metabase-lib/lib/metadata/Database";
 
 import {
   getEditingDatabase,
@@ -50,11 +51,9 @@ const DATABASE_FORM_NAME = "database";
 const mapStateToProps = state => {
   const database = getEditingDatabase(state);
   const formValues = getValues(state.form[DATABASE_FORM_NAME]);
-  const metadata = getMetadata(state);
 
   return {
-    database,
-    metadata,
+    database: database ? new Database(database) : undefined,
     databaseCreationStep: getDatabaseCreationStep(state),
     selectedEngine: formValues ? formValues.engine : undefined,
     initializeError: getInitializeError(state),
@@ -109,7 +108,6 @@ export default class DatabaseEditApp extends Component {
   render() {
     const {
       database,
-      metadata,
       deleteDatabase,
       discardSavedFieldValues,
       selectedEngine,
@@ -201,7 +199,7 @@ export default class DatabaseEditApp extends Component {
 
           {editingExistingDatabase && (
             <Sidebar
-              database={metadata.database(database.id)}
+              database={database}
               isAdmin={isAdmin}
               deleteDatabase={deleteDatabase}
               discardSavedFieldValues={discardSavedFieldValues}

--- a/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx
@@ -16,6 +16,7 @@ import DriverWarning from "metabase/containers/DriverWarning";
 import { getUserIsAdmin } from "metabase/selectors/user";
 
 import Databases from "metabase/entities/databases";
+import { getSetting } from "metabase/selectors/settings";
 
 import Database from "metabase-lib/lib/metadata/Database";
 
@@ -58,6 +59,7 @@ const mapStateToProps = state => {
     selectedEngine: formValues ? formValues.engine : undefined,
     initializeError: getInitializeError(state),
     isAdmin: getUserIsAdmin(state),
+    isModelPersistenceEnabled: getSetting(state, "enabled-persisted-models"),
   };
 };
 
@@ -98,6 +100,7 @@ export default class DatabaseEditApp extends Component {
     selectEngine: PropTypes.func.isRequired,
     location: PropTypes.object,
     isAdmin: PropTypes.bool,
+    isModelPersistenceEnabled: PropTypes.bool,
   };
 
   async componentDidMount() {
@@ -117,6 +120,7 @@ export default class DatabaseEditApp extends Component {
       persistDatabase,
       unpersistDatabase,
       isAdmin,
+      isModelPersistenceEnabled,
     } = this.props;
     const editingExistingDatabase = database?.id != null;
     const addingNewDatabase = !editingExistingDatabase;
@@ -201,6 +205,7 @@ export default class DatabaseEditApp extends Component {
             <Sidebar
               database={database}
               isAdmin={isAdmin}
+              isModelPersistenceEnabled={isModelPersistenceEnabled}
               deleteDatabase={deleteDatabase}
               discardSavedFieldValues={discardSavedFieldValues}
               rescanDatabaseFields={rescanDatabaseFields}

--- a/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.unit.spec.js
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.unit.spec.js
@@ -60,10 +60,18 @@ function mockSettings({ cachingEnabled = false }) {
 
 async function setup({ cachingEnabled = false } = {}) {
   mockSettings({ cachingEnabled });
+
+  const settingsReducer = () => ({
+    values: {
+      "enabled-persisted-models": false,
+    },
+  });
+
   renderWithProviders(<DatabaseEditApp />, {
     withRouter: true,
-    reducers: { admin },
+    reducers: { admin, settings: settingsReducer },
   });
+
   await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
 }
 

--- a/frontend/src/metabase/admin/databases/database.js
+++ b/frontend/src/metabase/admin/databases/database.js
@@ -1,5 +1,5 @@
+import _ from "underscore";
 import { createAction } from "redux-actions";
-import { assocIn } from "icepick";
 import {
   combineReducers,
   createThunkAction,
@@ -320,10 +320,24 @@ const editingDatabase = handleActions(
     [UPDATE_DATABASE]: (state, { payload }) => payload.database || state,
     [DELETE_DATABASE]: (state, { payload }) => null,
     [SELECT_ENGINE]: (state, { payload }) => ({ ...state, engine: payload }),
-    [PERSIST_DATABASE]: (state, { error }) =>
-      assocIn(state, ["details", "persist-models"], !error),
-    [UNPERSIST_DATABASE]: (state, { error }) =>
-      assocIn(state, ["details", "persist-models"], !!error),
+    [PERSIST_DATABASE]: (state, { error }) => {
+      if (error) {
+        return state;
+      }
+      return {
+        ...state,
+        features: [...state.features, "persist-models-enabled"],
+      };
+    },
+    [UNPERSIST_DATABASE]: (state, { error }) => {
+      if (error) {
+        return state;
+      }
+      return {
+        ...state,
+        features: _.without(state.features, "persist-models-enabled"),
+      };
+    },
     [SET_DATABASE_CREATION_STEP]: (state, { payload: { database } }) =>
       database,
   },

--- a/frontend/src/metabase/selectors/settings.js
+++ b/frontend/src/metabase/selectors/settings.js
@@ -2,6 +2,8 @@ import { createSelector } from "reselect";
 
 export const getSettings = state => state.settings.values;
 
+export const getSetting = (state, key) => getSettings(state)[key];
+
 // NOTE: these are "public" settings
 export const getIsPublicSharingEnabled = state =>
   state.settings.values["enable-public-sharing"];


### PR DESCRIPTION
Fixes a few things about the "Enable/disable model persistence" button on the database editing page. It should actually be a toggle field in the database form "Advanced options" section, but it's a bit tricky to add it there, so this PR should just make the current state of it feel a bit more right:

* the button will be hidden if model caching is turned off globally at `/admin/settings/caching`
* fix button turns back into its original state after clicking (ie you click "Enable model persistence", it turns into "Enabled" and then turns back to "Enable model persistence". It's expected to be "Disable model persistence" after than)
* moved the button from the "Danger zone" to the "Actions" section in the sidebar

### To Verify

1. Sign in as an admin
2. Connect a database that supports model persistence, e.g. PostgreSQL from [metabase/metabase-qa](https://github.com/metabase/metabase-qa)
3. Go to `/admin/settings/caching` and turn off model caching
4. Open the PostgreSQL connection page (`/admin/databases/:dbId`), reload the page. Ensure you don't see "Enable model persistence" / "Disable model persistence" button
5. Go back to `/admin/settings/caching` and enable model caching
6. Go back to the DB page and ensure you now see the "Enable model persistence" / "Disable model persistence" button in the "Actions" section
7. Click "Enable" / "Disable". It should become "Done" and in a few seconds the label should contain the opposite action (e.g. you clicked "Enable" and it should become "Disable" or vice-versa)

### Demo

**Before**

https://user-images.githubusercontent.com/17258145/163056412-b420b7c7-4592-4136-bcae-e4326ee13d52.mp4


**After**

https://user-images.githubusercontent.com/17258145/163056428-4aca0e32-ab7c-42cd-a538-44a99fd8f33c.mp4


