### PR TITLE
[E2E] Simplify field metadata tests

### DIFF
--- a/frontend/test/metabase/scenarios/visualizations/table.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/table.cy.spec.js
@@ -51,16 +51,7 @@ describe("scenarios > visualizations > table", () => {
   it("should show field metadata in a popover when hovering over a table column header", () => {
     openPeopleTable({ mode: "notebook", limit: 2 });
 
-    cy.findByTestId("fields-picker").click();
-    popover().within(() => {
-      cy.findByText("Select none").click();
-      cy.findByText("City").click();
-      cy.findByText("State").click();
-      cy.findByText("Birth Date").click();
-      cy.findByText("Latitude").click();
-    });
-
-    cy.findByText("Custom column").click();
+    cy.icon("add_data").click();
 
     popover().within(() => {
       enterCustomColumnDetails({
@@ -68,7 +59,16 @@ describe("scenarios > visualizations > table", () => {
         name: "CustomColumn",
       });
 
-      cy.findByText("Done").click();
+      cy.button("Done").click();
+    });
+
+    cy.findByTestId("fields-picker").click();
+    popover().within(() => {
+      cy.findByText("Select none").click();
+      cy.findByText("City").click();
+      cy.findByText("State").click();
+      cy.findByText("Birth Date").click();
+      cy.findByText("Latitude").click();
     });
 
     visualize();

--- a/frontend/test/metabase/scenarios/visualizations/table.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/table.cy.spec.js
@@ -152,7 +152,7 @@ describe("scenarios > visualizations > table", () => {
     summarize();
 
     cy.findAllByTestId("dimension-list-item-name")
-      .first()
+      .contains("CustomColumn")
       .click();
 
     cy.icon("table2").click();

--- a/frontend/test/metabase/scenarios/visualizations/table.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/table.cy.spec.js
@@ -49,9 +49,8 @@ describe("scenarios > visualizations > table", () => {
   });
 
   it("should show field metadata in a popover when hovering over a table column header", () => {
-    openPeopleTable();
+    openPeopleTable({ mode: "notebook" });
 
-    cy.icon("notebook").click();
     cy.findByTestId("fields-picker").click();
     popover().within(() => {
       cy.findByText("Select none").click();

--- a/frontend/test/metabase/scenarios/visualizations/table.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/table.cy.spec.js
@@ -159,9 +159,11 @@ describe("scenarios > visualizations > table", () => {
 
     cy.wait("@dataset");
 
-    cy.get(".cellData")
-      .contains("Count")
-      .trigger("mouseenter");
+    cy.get(".Visualization").within(() => {
+      // Make sure new table results loaded with Custom column and Count columns
+      cy.contains(ccName);
+      cy.contains("Count").trigger("mouseenter");
+    });
 
     popover().within(() => {
       cy.contains("No special type");

--- a/frontend/test/metabase/scenarios/visualizations/table.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/table.cy.spec.js
@@ -16,7 +16,7 @@ describe("scenarios > visualizations > table", () => {
   });
 
   it("should allow to display any column as link with extrapolated url and text", () => {
-    openPeopleTable();
+    openPeopleTable({ limit: 2 });
 
     cy.findByText("City").click();
 
@@ -170,7 +170,7 @@ describe("scenarios > visualizations > table", () => {
   });
 
   it("should show the field metadata popover for a foreign key field (metabase#19577)", () => {
-    openOrdersTable();
+    openOrdersTable({ limit: 2 });
 
     cy.findByText("Product ID").trigger("mouseenter");
 
@@ -194,7 +194,7 @@ describe("scenarios > visualizations > table", () => {
   });
 
   it.skip("should close the colum popover on subsequent click (metabase#16789)", () => {
-    openPeopleTable();
+    openPeopleTable({ limit: 2 });
 
     cy.findByText("City").click();
     popover().within(() => {

--- a/frontend/test/metabase/scenarios/visualizations/table.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/table.cy.spec.js
@@ -155,7 +155,7 @@ describe("scenarios > visualizations > table", () => {
       .contains("CustomColumn")
       .click();
 
-    cy.icon("table2").click();
+    cy.wait("@dataset");
 
     cy.get(".cellData")
       .contains("Count")

--- a/frontend/test/metabase/scenarios/visualizations/table.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/table.cy.spec.js
@@ -49,6 +49,8 @@ describe("scenarios > visualizations > table", () => {
   });
 
   it("should show field metadata in a popover when hovering over a table column header", () => {
+    const ccName = "Foo";
+
     openPeopleTable({ mode: "notebook", limit: 2 });
 
     cy.icon("add_data").click();
@@ -56,7 +58,7 @@ describe("scenarios > visualizations > table", () => {
     popover().within(() => {
       enterCustomColumnDetails({
         formula: "concat([Name], [Name])",
-        name: "CustomColumn",
+        name: ccName,
       });
 
       cy.button("Done").click();
@@ -127,7 +129,7 @@ describe("scenarios > visualizations > table", () => {
         },
       ],
       [
-        "CustomColumn",
+        ccName,
         () => {
           // semantic type
           cy.contains("No special type");
@@ -152,7 +154,7 @@ describe("scenarios > visualizations > table", () => {
     summarize();
 
     cy.findAllByTestId("dimension-list-item-name")
-      .contains("CustomColumn")
+      .contains(ccName)
       .click();
 
     cy.wait("@dataset");

--- a/frontend/test/metabase/scenarios/visualizations/table.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/table.cy.spec.js
@@ -49,7 +49,7 @@ describe("scenarios > visualizations > table", () => {
   });
 
   it("should show field metadata in a popover when hovering over a table column header", () => {
-    openPeopleTable({ mode: "notebook" });
+    openPeopleTable({ mode: "notebook", limit: 2 });
 
     cy.findByTestId("fields-picker").click();
     popover().within(() => {


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Simplifies and speeds up field metadata tests in `frontend/test/metabase/scenarios/visualizations/table.cy.spec.js`
- Fixes a flake in one of the longer running tests
    - Previous attempt: https://github.com/metabase/metabase/pull/21619
- Explanation of what's wrong with this test and what can be improved - in [this comment](https://github.com/metabase/metabase/pull/21619#issuecomment-1097256795)

tl;dr It's absolutely unnecessary to load all table results in tests where we do assertions on table headers or maybe one or two top rows. Always limit the number of results if you don't need all of them.

### Note for reviewers
I've broken down changes in logical smaller commits to make it easier to follow the logic and to review these changes.