### PR TITLE
[E2E] Quick fix for the table spec [ci skip]

### DIFF
--- a/frontend/test/metabase/scenarios/visualizations/table.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/table.cy.spec.js
@@ -73,6 +73,9 @@ describe("scenarios > visualizations > table", () => {
       cy.findByText("Latitude").click();
     });
 
+    // Click anywhere else to close the popover which is blocking the Visualize button
+    cy.get(".QueryBuilder").click(0, 0);
+
     visualize();
 
     [


### PR DESCRIPTION
Changes from this PR https://github.com/metabase/metabase/pull/21647 were passing in CircleCI, but when we ran tests using GHA, that spec is failing.
https://github.com/metabase/metabase/actions/runs/2161231565

![scenarios  visualizations  table -- should show field metadata in a popover when hovering over a table column header (failed) (attempt 2)](https://user-images.githubusercontent.com/31325167/163195389-3c5960fe-b212-47c3-b314-ce27a02a064b.png)

The problem seems to be that the popover is blocking the "Visualize" button so Cypress cannot click on it.

This PR fixes that.

https://user-images.githubusercontent.com/31325167/163200957-761bd319-cd04-4f1c-b6c6-f7db86dff82e.mp4


