### PR TITLE
tweak search result list position and active color

### DIFF
--- a/frontend/src/metabase/nav/components/SearchBar.styled.tsx
+++ b/frontend/src/metabase/nav/components/SearchBar.styled.tsx
@@ -23,7 +23,8 @@ export const SearchInputContainer = styled.div<{ isActive: boolean }>`
   align-items: center;
   position: relative;
 
-  background-color: ${color("bg-light")};
+  background-color: ${props =>
+    props.isActive ? color("bg-medium") : color("bg-light")};
   border: 1px solid ${color("border")};
 
   overflow: hidden;
@@ -130,7 +131,7 @@ export const SearchResultsFloatingContainer = styled.div`
   }
 
   ${breakpointMinSmall} {
-    top: 60px;
+    top: 42px;
   }
 `;
 


### PR DESCRIPTION
Small visual tweaks for the search bar in the nav.

- Moves the results closer to the search input
- Keeps the hover color when the search input is focused

Before:
<img width="1392" alt="Screen Shot 2022-04-13 at 3 28 08 PM" src="https://user-images.githubusercontent.com/5248953/163255599-fef91217-22b5-4ced-84ee-2f972f9f848e.png">

After:
<img width="1392" alt="Screen Shot 2022-04-13 at 3 27 49 PM" src="https://user-images.githubusercontent.com/5248953/163255610-85fa8830-d247-4713-b06c-c7c8c0e86525.png">

