### PR TITLE
Remove `permissions` group from the E2E on PR workflow

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -61,7 +61,6 @@ jobs:
         folder:
           - "downloads"
           - "moderation"
-          - "permissions"
     services:
       maildev:
         image: maildev/maildev:1.1.0


### PR DESCRIPTION
We tried it in https://github.com/metabase/metabase/pull/21561, but in just 4 days this group failed so many times because of the H2 locking issue that obstructs `restore` DB snapshot functionality. It became an obstacle. Sometimes it takes 2-3 reruns to make it green.

Until we solve H2 locking issue, we're better off without this group in GH E2E workflow that runs on PR.

For reference, see [this comment](https://github.com/metabase/metabase/pull/21561#pullrequestreview-937106943).