### PR TITLE
Make sure we don't remove admin mappings when ldap-sync-admin-group is nil

### DIFF
--- a/src/metabase/db/data_migrations.clj
+++ b/src/metabase/db/data_migrations.clj
@@ -204,7 +204,9 @@
   ;;  But on upgrade, to make sure we don't unexpectedly begin adding or removing admin users:
   ;;  - for LDAP, if the `ldap-sync-admin-group` toggle is disabled, we remove all mapping for the admin group
   ;;  - for SAML, JWT, we remove all mapping for admin group, because they were previously never being synced
-  (when (= (raw-setting :ldap-sync-admin-group) "false")
+  ;; if `ldap-sync-admin-group` has never been written, getting raw-setting will return a `nil`, and nil could also be interpreted as disabled.
+  ;; so checking (not= x "true") is safer than (= x "false")
+  (when (not= (raw-setting :ldap-sync-admin-group) "true")
     (remove-admin-group-from-mappings-by-setting-key! :ldap-group-mappings))
   ;; sso are enterprise feature but we still run this even in OSS in case a customer
   ;; have switched from enterprise -> SSO and stil have this mapping in Setting table

--- a/test/metabase/db/data_migrations_test.clj
+++ b/test/metabase/db/data_migrations_test.clj
@@ -342,7 +342,6 @@
     [ldap-group-mappings    (json/generate-string ldap-group-mappings)
      saml-group-mappings    (json/generate-string sso-group-mappings)
      jwt-group-mappings     (json/generate-string sso-group-mappings)
-     ldap-sync-admin-group  "false"
      saml-enabled           "true"
      ldap-enabled           "true"
      jwt-enabled            "true"]


### PR DESCRIPTION
In https://github.com/metabase/metabase/pull/20991 we wrote a data-migration that'll remove Admin from the Group mappings for LDAP when the `ldap-sync-admin-group` setting is disabled.

In that PR, To check whether `ldap-sync-admin-group` is disabled, we check whether or not it's `false` in the Setting table. 

The problem with that is getting `ldap-sync-admin-group` from the Setting table could return a `nil` (because it has never been written into DB), and `nil` could also be interpreted as `disabled`.

This PR changes to check using  `(not= ldap-sync-admin-group "true")` logic instead.