### PR TITLE
Skip default setting update request for model persistence settings

### DIFF
--- a/frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx
+++ b/frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx
@@ -67,7 +67,7 @@ export default class SettingsEditorApp extends Component {
   }
 
   updateSetting = async (setting, newValue) => {
-    const { settingValues, updateSetting } = this.props;
+    const { settingValues, updateSetting, reloadSettings } = this.props;
 
     this.saveStatusRef.current.setSaving();
 
@@ -85,7 +85,9 @@ export default class SettingsEditorApp extends Component {
         );
       }
 
-      await updateSetting(setting);
+      if (!setting.disableDefaultUpdate) {
+        await updateSetting(setting);
+      }
 
       if (setting.onChanged) {
         await setting.onChanged(
@@ -94,6 +96,10 @@ export default class SettingsEditorApp extends Component {
           settingValues,
           this.handleChangeSetting,
         );
+      }
+
+      if (setting.disableDefaultUpdate) {
+        await reloadSettings();
       }
 
       this.saveStatusRef.current.setSaved();

--- a/frontend/src/metabase/admin/settings/selectors.js
+++ b/frontend/src/metabase/admin/settings/selectors.js
@@ -412,18 +412,13 @@ const SECTIONS = updateSectionsWithPlugins({
           >{t`Learn more`}</ExternalLink>
         )}.`,
         type: "boolean",
-        onChanged: async (
-          wasEnabled,
-          isEnabled,
-          settingsValues,
-          onChangeSetting,
-        ) => {
+        disableDefaultUpdate: true,
+        onChanged: async (wasEnabled, isEnabled) => {
           if (isEnabled) {
             await PersistedModelsApi.enablePersistence();
           } else {
             await PersistedModelsApi.disablePersistence();
           }
-          onChangeSetting("enabled-persisted-models", isEnabled);
         },
       },
       {
@@ -439,17 +434,11 @@ const SECTIONS = updateSectionsWithPlugins({
           12: t`12 hours`,
           24: t`24 hours`,
         },
+        disableDefaultUpdate: true,
         widget: PersistedModelRefreshIntervalWidget,
         getHidden: settings => !settings["enabled-persisted-models"],
-        onChanged: async (
-          oldValue,
-          newValue,
-          settingsValues,
-          onChangeSetting,
-        ) => {
-          await PersistedModelsApi.setRefreshInterval({ hours: newValue });
-          onChangeSetting("persisted-model-refresh-interval-hours", newValue);
-        },
+        onChanged: async (oldValue, newValue) =>
+          PersistedModelsApi.setRefreshInterval({ hours: newValue }),
       },
     ],
   },


### PR DESCRIPTION
Model persistence project brings a couple of new global Metabase settings to control caching:

* `enabled-persisted-models` is a global flag controlling if persistence is enabled
* `persisted-model-refresh-interval-hours` controls cache refresh intervals

Usually, settings are updated via `PUT /api/setting/:key` request (so for `enabled-persisted-models` it would be `PUT /api/setting/enabled-persisted-models`. The problem is that these settings should be changed via custom endpoints as the BE needs to do some work when they're changed. Before this PR, changing both settings with the admin UI would send two requests: the default `PUT /api/setting/:key` and a request to a setting-specific endpoint. This caused a race condition on the BE, so the end behavior could become unexpected.

This PR extends the admin settings editor API, so we can now skip the default `PUT /api/setting/:key` request for specific settings. In order to do that, the setting definition should have `disableDefaultUpdate: true`. In this case, the FE should either use `onBeforeChanged` or `onChanged` setting callbacks to do the logic and once they're done, the FE will refresh settings to keep the UI consistent. And the PR also patches the model persistence settings to use this new mechanism to avoid default `PUT` requests.

### To Verify

1. Sign in as an admin
2. Open the Network tab in developer tools 
3. Go to `/admin/settings/caching`
4. Turn on/off model caching
5. Ensure you can see a `POST /api/persist/enable` or `POST /api/persist/disable` request
6. Ensure you don't see a `PUT /api/setting/enabled-persisted-models` request
7. Ensure the UI reflects the changes
8. Turn on model persistence and change the refresh interval
9. Ensure you can see a `POST /api/persist/set-interval`
10. Ensure you don't see a `PUT /api/setting/persisted-model-refresh-interval-hours` request