### PR TITLE
Fix test failure caused by floating point variance between devices

### DIFF
--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -18,7 +18,8 @@
             [potemkin :as p]
             [ring.util.codec :as codec]
             [weavejester.dependency :as dep])
-  (:import [java.net InetAddress InetSocketAddress Socket]
+  (:import [java.math MathContext RoundingMode]
+           [java.net InetAddress InetSocketAddress Socket]
            [java.text Normalizer Normalizer$Form]
            (java.util Locale PriorityQueue)
            java.util.concurrent.TimeoutException
@@ -365,10 +366,25 @@
 (defn round-to-decimals
   "Round (presumabily floating-point) `number` to `decimal-place`. Returns a `Double`.
 
-     (round-to-decimals 2 35.5058998M) -> 35.51"
+  Rounds by decimal places, no matter how many significant figures the number has. See [[round-to-precision]].
+
+    (round-to-decimals 2 35.5058998M) -> 35.51"
   ^Double [^Integer decimal-place, ^Number number]
   {:pre [(integer? decimal-place) (number? number)]}
   (double (.setScale (bigdec number) decimal-place BigDecimal/ROUND_HALF_UP)))
+
+(defn round-to-precision
+  "Round (presumably floating-point) `number` to a precision of `sig-figures`. Returns a `Double`.
+
+  This rounds by significant figures, not decimal places. See [[round-to-decimals]] for that.
+
+    (round-to-precision 4 1234567.89) -> 123500.0"
+  ^Double [^Integer sig-figures ^Number number]
+  {:pre [(integer? sig-figures) (number? number)]}
+  (-> number
+      bigdec
+      (.round (MathContext. sig-figures RoundingMode/HALF_EVEN))
+      double))
 
 (defn real-number?
   "Is `x` a real number (i.e. not a `NaN` or an `Infinity`)?"

--- a/test/metabase/sync/analyze/fingerprint/insights_test.clj
+++ b/test/metabase/sync/analyze/fingerprint/insights_test.clj
@@ -1,6 +1,7 @@
 (ns metabase.sync.analyze.fingerprint.insights-test
   (:require [clojure.test :refer :all]
-            [metabase.sync.analyze.fingerprint.insights :as i :refer :all]))
+            [metabase.sync.analyze.fingerprint.insights :as i :refer :all]
+            [metabase.util :as u]))
 
 (def ^:private cols [{:base_type :type/DateTime} {:base_type :type/Number}])
 
@@ -89,16 +90,6 @@
                    ["2018-12-02",179,3311]
                    ["2018-12-03",144,2525]])
 
-(defn- round
-  "Returns a function that rounds a double to the specified number of significant figures."
-  [precision]
-  (let [mc (java.math.MathContext. precision java.math.RoundingMode/HALF_EVEN)]
-    (fn [n]
-      (-> n
-          bigdec
-          (.round mc)
-          double))))
-
 (deftest timeseries-insight-test
   (is (= [{:last-value     144,
            :previous-value 179,
@@ -122,7 +113,7 @@
                                    {:base_type :type/Number}])
                         ts)
              ; This value varies between machines (M1 Macs? JVMs?) so round it to avoid test failures.
-             (update-in [0 :best-fit 1] (round 6)))))
+             (update-in [0 :best-fit 1] #(u/round-to-precision 6 %)))))
   (testing "We should robustly survive weird values such as NaN, Infinity, and nil"
     (is (= [{:last-value     20.0
              :previous-value 10.0

--- a/test/metabase/sync/analyze/fingerprint/insights_test.clj
+++ b/test/metabase/sync/analyze/fingerprint/insights_test.clj
@@ -89,13 +89,23 @@
                    ["2018-12-02",179,3311]
                    ["2018-12-03",144,2525]])
 
+(defn- round
+  "Returns a function that rounds a double to the specified number of significant figures."
+  [precision]
+  (let [mc (java.math.MathContext. precision java.math.RoundingMode/HALF_EVEN)]
+    (fn [n]
+      (-> n
+          bigdec
+          (.round mc)
+          double))))
+
 (deftest timeseries-insight-test
   (is (= [{:last-value     144,
            :previous-value 179,
            :last-change    -0.19553072625698323,
            :slope          -7.671473413418271,
            :offset         137234.92983406168,
-           :best-fit       [:* 1.5672560913548484E227 [:exp [:* -0.02899533549378612 :x]]],
+           :best-fit [:* 1.56726E227 [:exp [:* -0.02899533549378612 :x]]],
            :unit           :day,
            :col            nil}
           {:last-value     2525,
@@ -106,11 +116,13 @@
            :best-fit       [:+ 8915371.843617931 [:* -498.764272733624 :x]],
            :col            nil,
            :unit           :day}]
-         (transduce identity
-                    (insights [{:base_type :type/DateTime}
-                               {:base_type :type/Number}
-                               {:base_type :type/Number}])
-                    ts)))
+         (-> (transduce identity
+                        (insights [{:base_type :type/DateTime}
+                                   {:base_type :type/Number}
+                                   {:base_type :type/Number}])
+                        ts)
+             ; This value varies between machines (M1 Macs? JVMs?) so round it to avoid test failures.
+             (update-in [0 :best-fit 1] (round 6)))))
   (testing "We should robustly survive weird values such as NaN, Infinity, and nil"
     (is (= [{:last-value     20.0
              :previous-value 10.0

--- a/test/metabase/util_test.clj
+++ b/test/metabase/util_test.clj
@@ -364,3 +364,13 @@
     true  "cam@metabase.com"          "metabase.com"
     false "cam.saul+1@metabase.co.uk" "metabase.com"
     true  "cam.saul+1@metabase.com"   "metabase.com"))
+
+(deftest ^:parallel round-to-precision-test
+  (are [exp figs n]
+       (is (= exp (u/round-to-precision figs n)))
+       1.0     1 1.234
+       1.2     2 1.234
+       1.3     2 1.278
+       1.3     2 1.251
+       12300.0 3 12345.67
+       0.00321 3 0.003209817))


### PR DESCRIPTION
Cause is unclear - M1 Macs, different JVM versions?

Rounding to 6 significant figures sidesteps the issue.

