### PR TITLE
Timelines and events no nil icons

### DIFF
--- a/src/metabase/api/timeline.clj
+++ b/src/metabase/api/timeline.clj
@@ -1,7 +1,6 @@
 (ns metabase.api.timeline
   "/api/timeline endpoints."
   (:require [compojure.core :refer [DELETE GET POST PUT]]
-            [honeysql.core :as hsql]
             [metabase.api.common :as api]
             [metabase.models.collection :as collection]
             [metabase.models.timeline :as timeline :refer [Timeline]]

--- a/src/metabase/api/timeline.clj
+++ b/src/metabase/api/timeline.clj
@@ -1,6 +1,7 @@
 (ns metabase.api.timeline
   "/api/timeline endpoints."
   (:require [compojure.core :refer [DELETE GET POST PUT]]
+            [honeysql.core :as hsql]
             [metabase.api.common :as api]
             [metabase.models.collection :as collection]
             [metabase.models.timeline :as timeline :refer [Timeline]]
@@ -39,16 +40,19 @@
   {include  (s/maybe Include)
    archived (s/maybe su/BooleanString)}
   (let [archived? (Boolean/parseBoolean archived)
-        timelines (->> (db/select Timeline
-                         {:where    [:and
-                                     [:= :archived archived?]
-                                     (collection/visible-collection-ids->honeysql-filter-clause
-                                      (collection/permissions-set->visible-collection-ids @api/*current-user-permissions-set*))]
-                          :order-by [[:%lower.name :asc]]})
+        timelines (->> (db/query
+                        {:select   [[(hsql/call :coalesce :icon timeline/DefaultIcon) :icon] :*]
+                         :from     [Timeline]
+                         :where    [:and
+                                    [:= :archived archived?]
+                                    (collection/visible-collection-ids->honeysql-filter-clause
+                                     (collection/permissions-set->visible-collection-ids @api/*current-user-permissions-set*))]
+                         :order-by [[:%lower.name :asc]]})
+                       (map #(dissoc % :icon_2))
                        (map timeline/hydrate-root-collection))]
-    (cond->> (hydrate timelines :creator [:collection :can_write])
+    (cond-> (hydrate timelines :creator [:collection :can_write])
       (= include "events")
-      (map #(timeline-event/include-events-singular % {:events/all? archived?})))))
+      (timeline-event/include-events {:events/all? archived?}))))
 
 (api/defendpoint GET "/:id"
   "Fetch the [[Timeline]] with `id`. Include `include=events` to unarchived events included on the timeline. Add
@@ -65,6 +69,10 @@
       ;; because hydrate `:collection` needs a proper `:id` to work.
       (nil? (:collection_id timeline))
       timeline/hydrate-root-collection
+
+      ;; if a timeline was added with the API, it's possible that `:icon` is `nil`
+      (nil? (:icon timeline))
+      (assoc :icon timeline/DefaultIcon)
 
       (= include "events")
       (timeline-event/include-events-singular {:events/all?  archived?

--- a/src/metabase/models/timeline.clj
+++ b/src/metabase/models/timeline.clj
@@ -47,32 +47,34 @@
   [timeline-ids {:events/keys [all? start end]}]
   (let [timeline-icon {:select [[(hsql/call :coalesce :icon DefaultIcon) :tl_icon]
                                 [:id :tl_id]]
-                       :from [Timeline]}
-        query {:select [[(hsql/call :coalesce :icon :tl_icon) :icon] :*]
-               :from [TimelineEvent]
-               :where [:and
-                       ;; in our collections
-                        [:in :timeline_id timeline-ids]
-                        (when-not all?
-                          [:= :archived false])
-                        (when (or start end)
-                          [:or
-                           ;; absolute time in bounds
-                           [:and
-                            [:= :time_matters true]
-                            ;; less than or equal?
-                            (when start
-                              [:<= start :timestamp])
-                            (when end
-                              [:<= :timestamp end])]
-                           ;; non-specic time in bounds
-                           [:and
-                            [:= :time_matters false]
-                            (when start
-                              [:<= (hx/->date start) (hx/->date :timestamp)])
-                            (when end
-                              [:<= (hx/->date :timestamp) (hx/->date end)])]])]
-                :left-join [[timeline-icon :tl] [:= :timeline_id :tl_id]]}]
+                       :from   [Timeline]}
+        query         {:select    [[(hsql/call :coalesce :icon :tl_icon) :icon]
+                                   :description :archived :timezone :time_matters :name
+                                   :timeline_id :creator_id :updated_at :id :timestamp :created_at]
+                       :from      [TimelineEvent]
+                       :where     [:and
+                               ;; in our collections
+                               [:in :timeline_id timeline-ids]
+                               (when-not all?
+                                 [:= :archived false])
+                               (when (or start end)
+                                 [:or
+                                  ;; absolute time in bounds
+                                  [:and
+                                   [:= :time_matters true]
+                                   ;; less than or equal?
+                                   (when start
+                                     [:<= start :timestamp])
+                                   (when end
+                                     [:<= :timestamp end])]
+                                  ;; non-specic time in bounds
+                                  [:and
+                                   [:= :time_matters false]
+                                   (when start
+                                     [:<= (hx/->date start) (hx/->date :timestamp)])
+                                   (when end
+                                     [:<= (hx/->date :timestamp) (hx/->date end)])]])]
+                       :left-join [[timeline-icon :tl] [:= :timeline_id :tl_id]]}]
     (hydrate (map #(dissoc % :icon_2 :tl_id :tl_icon) (db/query query)) :creator)))
 
 (defn include-events

--- a/src/metabase/models/timeline.clj
+++ b/src/metabase/models/timeline.clj
@@ -1,9 +1,11 @@
 (ns metabase.models.timeline
-  (:require [metabase.models.collection :as collection]
+  (:require [honeysql.core :as hsql]
+            [metabase.models.collection :as collection]
             [metabase.models.interface :as i]
             [metabase.models.permissions :as perms]
-            [metabase.models.timeline-event :as timeline-event]
+            [metabase.models.timeline-event :refer [TimelineEvent]]
             [metabase.util :as u]
+            [metabase.util.honeysql-extensions :as hx]
             [schema.core :as s]
             [toucan.db :as db]
             [toucan.hydrate :refer [hydrate]]
@@ -35,6 +37,63 @@
     (assoc timeline :collection (root-collection))
     timeline))
 
+
+;;;; hydration
+
+(defn- fetch-events
+  "Fetch events for timelines in `timeline-ids`. Can include optional `start` and `end` dates in the options map, as
+  well as `all?`. By default, will return only unarchived events, unless `all?` is truthy and will return all events
+  regardless of archive state."
+  [timeline-ids {:events/keys [all? start end]}]
+  (let [timeline-icon {:select [[(hsql/call :coalesce :icon DefaultIcon) :tl_icon]
+                                [:id :tl_id]]
+                       :from [Timeline]}
+        query {:select [[(hsql/call :coalesce :icon :tl_icon) :icon] :*]
+               :from [TimelineEvent]
+               :where [:and
+                       ;; in our collections
+                        [:in :timeline_id timeline-ids]
+                        (when-not all?
+                          [:= :archived false])
+                        (when (or start end)
+                          [:or
+                           ;; absolute time in bounds
+                           [:and
+                            [:= :time_matters true]
+                            ;; less than or equal?
+                            (when start
+                              [:<= start :timestamp])
+                            (when end
+                              [:<= :timestamp end])]
+                           ;; non-specic time in bounds
+                           [:and
+                            [:= :time_matters false]
+                            (when start
+                              [:<= (hx/->date start) (hx/->date :timestamp)])
+                            (when end
+                              [:<= (hx/->date :timestamp) (hx/->date end)])]])]
+                :left-join [[timeline-icon :tl] [:= :timeline_id :tl_id]]}]
+    (hydrate (map #(dissoc % :icon_2 :tl_id :tl_icon) (db/query query)) :creator)))
+
+(defn include-events
+  "Include events on `timelines` passed in. Options are optional and include whether to return unarchived events or all
+  events regardless of archive status (`all?`), and `start` and `end` parameters for events."
+  [timelines options]
+  (if-not (seq timelines)
+    []
+    (let [timeline-id->events (->> (fetch-events (map :id timelines) options)
+                                   (group-by :timeline_id))]
+      (for [{:keys [id] :as timeline} timelines]
+        (let [events (timeline-id->events id)]
+          (when timeline
+            (assoc timeline :events (if events events []))))))))
+
+(defn include-events-singular
+  "Similar to [[include-events]] but allows for passing a single timeline not in a collection."
+  ([timeline] (include-events-singular timeline {}))
+  ([timeline options]
+   (first (include-events [timeline] options))))
+
 (defn timelines-for-collection
   "Load timelines based on `collection-id` passed in (nil means the root collection). Hydrates the events on each
   timeline at `:events` on the timeline."
@@ -45,13 +104,18 @@
                    :creator
                    [:collection :can_write])
     (nil? collection-id) (->> (map hydrate-root-collection))
-    events? (timeline-event/include-events options)))
+    events? (include-events options)))
+
+(defn- post-select
+  [{:keys [icon] :as timeline}]
+  (assoc timeline :icon (or icon DefaultIcon)))
 
 (u/strict-extend (class Timeline)
   models/IModel
   (merge
    models/IModelDefaults
-   {:properties (constantly {:timestamped? true})})
+   {:properties (constantly {:timestamped? true})
+    :post-select post-select})
 
   i/IObjectPermissions
   perms/IObjectPermissionsForParentCollection)

--- a/src/metabase/models/timeline_event.clj
+++ b/src/metabase/models/timeline_event.clj
@@ -1,10 +1,8 @@
 (ns metabase.models.timeline-event
   (:require [metabase.models.interface :as i]
             [metabase.util :as u]
-            [metabase.util.honeysql-extensions :as hx]
             [schema.core :as s]
             [toucan.db :as db]
-            [toucan.hydrate :refer [hydrate]]
             [toucan.models :as models]))
 
 (models/defmodel TimelineEvent :timeline_event)
@@ -24,64 +22,21 @@
                      (db/select-one 'Timeline :id (:timeline_id event)))]
     (i/perms-objects-set timeline read-or-write)))
 
-;;;; hydration
-
-(defn- fetch-events
-  "Fetch events for timelines in `timeline-ids`. Can include optional `start` and `end` dates in the options map, as
-  well as `all?`. By default, will return only unarchived events, unless `all?` is truthy and will return all events
-  regardless of archive state."
-  [timeline-ids {:events/keys [all? start end]}]
-  (let [clause {:where [:and
-                        ;; in our collections
-                        [:in :timeline_id timeline-ids]
-                        (when-not all?
-                          [:= :archived false])
-                        (when (or start end)
-                          [:or
-                           ;; absolute time in bounds
-                           [:and
-                            [:= :time_matters true]
-                            ;; less than or equal?
-                            (when start
-                              [:<= start :timestamp])
-                            (when end
-                              [:<= :timestamp end])]
-                           ;; non-specic time in bounds
-                           [:and
-                            [:= :time_matters false]
-                            (when start
-                              [:<= (hx/->date start) (hx/->date :timestamp)])
-                            (when end
-                              [:<= (hx/->date :timestamp) (hx/->date end)])]])]}]
-    (hydrate (db/select TimelineEvent clause) :creator)))
-
-(defn include-events
-  "Include events on `timelines` passed in. Options are optional and include whether to return unarchived events or all
-  events regardless of archive status (`all?`), and `start` and `end` parameters for events."
-  [timelines options]
-  (if-not (seq timelines)
-    []
-    (let [timeline-id->events (->> (fetch-events (map :id timelines) options)
-                                   (group-by :timeline_id))]
-      (for [{:keys [id] :as timeline} timelines]
-        (let [events (timeline-id->events id)]
-          (when timeline
-            (assoc timeline :events (if events events []))))))))
-
-(defn include-events-singular
-  "Similar to [[include-events]] but allows for passing a single timeline not in a collection."
-  ([timeline] (include-events-singular timeline {}))
-  ([timeline options]
-   (first (include-events [timeline] options))))
-
 ;;;; model
+
+(defn- post-select
+  [{:keys [icon timeline_id] :as event}]
+  (if icon
+    event
+    (assoc event :icon (db/select-one-field :icon 'Timeline :id timeline_id))))
 
 (u/strict-extend (class TimelineEvent)
   models/IModel
   (merge
    models/IModelDefaults
    ;; todo: add hydration keys??
-   {:properties (constantly {:timestamped? true})})
+   {:properties  (constantly {:timestamped? true})
+    :post-select post-select})
 
   i/IObjectPermissions
   (merge

--- a/test/metabase/api/timeline_event_test.clj
+++ b/test/metabase/api/timeline_event_test.clj
@@ -21,6 +21,7 @@
   (testing "GET /api/timeline-event/:id"
     (mt/with-temp* [Collection    [collection {:name "Important Data"}]
                     Timeline      [timeline {:name          "Important Events"
+                                             :icon          "balloon"
                                              :collection_id (u/the-id collection)}]
                     TimelineEvent [event {:name         "Very Important Event"
                                           :timestamp    (java.time.OffsetDateTime/now)
@@ -29,7 +30,11 @@
       (testing "check that we get the timeline-event with `id`"
         (is (= "Very Important Event"
                (->> (mt/user-http-request :rasta :get 200 (str "timeline-event/" (u/the-id event)))
-                    :name)))))))
+                    :name))))
+      (testing "check that we get the timeline's icon."
+        (is (= "balloon"
+               (->> (mt/user-http-request :rasta :get 200 (str "timeline-event/" (u/the-id event)))
+                    :icon)))))))
 
 (deftest create-timeline-event-test
   (testing "POST /api/timeline-event"

--- a/test/metabase/api/timeline_test.clj
+++ b/test/metabase/api/timeline_test.clj
@@ -200,15 +200,16 @@
 (deftest timeline-hydration-test
   (testing "GET /api/timeline/:id?include=events"
     (mt/with-temp Collection [collection {:name "Important Data"}]
-      (mt/with-temp* [Timeline      [empty-tl {:name "Empty TL"
+      (mt/with-temp* [Timeline      [empty-tl {:name          "Empty TL"
                                                :collection_id (u/the-id collection)}]
-                      Timeline      [unarchived-tl {:name "Un-archived Events TL"
+                      Timeline      [unarchived-tl {:name          "Un-archived Events TL"
                                                     :collection_id (u/the-id collection)}]
-                      Timeline      [archived-tl {:name "Archived Events TL"
+                      Timeline      [archived-tl {:name          "Archived Events TL"
                                                   :collection_id (u/the-id collection)}]
-                      Timeline      [timeline {:name "All Events TL"
+                      Timeline      [timeline {:name          "All Events TL"
                                                :collection_id (u/the-id collection)}]]
         (mt/with-temp* [TimelineEvent [event-a {:name        "event-a"
+                                                :icon        "balloon"
                                                 :timeline_id (u/the-id unarchived-tl)}]
                         TimelineEvent [event-b {:name        "event-b"
                                                 :timeline_id (u/the-id unarchived-tl)}]
@@ -225,6 +226,8 @@
                                                 :archived    true}]]
           (testing "a timeline with no events returns an empty list"
             (is (= '() (:events (include-events-request empty-tl false)))))
+          (testing "the events on a timeline have appropriate icons."
+            (is (= #{"star" "balloon"} (set (map :icon (:events (include-events-request unarchived-tl true)))))))
           (testing "a timeline with both (un-)archived events"
             (testing "Returns only unarchived events when archived is false"
               (is (= #{"event-e"}

--- a/test/metabase/models/timeline_event_test.clj
+++ b/test/metabase/models/timeline_event_test.clj
@@ -2,7 +2,7 @@
   "Tests for TimelineEvent model namespace."
   (:require [clojure.test :refer :all]
             [metabase.models.collection :refer [Collection]]
-            [metabase.models.timeline :refer [Timeline]]
+            [metabase.models.timeline :as timeline :refer [Timeline]]
             [metabase.models.timeline-event :as te :refer [TimelineEvent]]
             [metabase.test :as mt]
             [metabase.util :as u]))
@@ -23,7 +23,7 @@
                                         :archived true}]]
       (testing "only unarchived events by default"
         (is (= #{"un-1" "un-2"}
-               (names (te/include-events [tl-a tl-b] {})))))
+               (names (timeline/include-events [tl-a tl-b] {})))))
       (testing "all events when specified"
         (is (= #{"un-1" "un-2" "archived-1" "archived-2"}
-               (names (te/include-events [tl-a tl-b] {:events/all? true}))))))))
+               (names (timeline/include-events [tl-a tl-b] {:events/all? true}))))))))


### PR DESCRIPTION
The frontend sends Timelines and Events with an icon, so the app-db stores those values. But it is possible to use the API to add timelines and events without specifying icons.

The default Icon is 'star', and is applied as follows:

Timelines:
- Timeline :icon exists -> use that icon for the timeline
- Timeline :icon nil       -> set to default (star) in a post-select

Timeline Events:
- Timeline Event :icon exits -> use that icon for that event
- Timeline Event :icon nil -> use the value from the Timeline (if it's nil, it will be post-selected as 'star', otherwise it'll use the Timeline's value)