### PR TITLE
[E2E] Run EE only check on `pull_request`

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 25
     strategy:
       matrix:
-        edition: [oss, ee]
+        edition: [ee]
     env:
       MB_EDITION: ${{ matrix.edition }}
       INTERACTIVE: false
@@ -57,7 +57,7 @@ jobs:
       fail-fast: false
       matrix:
         java-version: [11]
-        edition: [oss, ee]
+        edition: [ee]
         folder:
           - "downloads"
           - "moderation"


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Optimizes E2E workflow (**on pull request**) so that it runs checks only against EE version of Metabase

Note:
This will not affect our workflows in CircleCi or E2E checks that run on `master`. They still run full suite against both OSS and EE versions.

### Why this change?
As the team grows, we're contributing more and are using more resources. We've already experienced queues and jobs waiting to be picked by runners due to too many concurrent runs. It's wasteful and completely unnecessary to run the full E2E test matrix on every PR request.

This will reduce the number of `buildjet` machines we need to use per PR. By cutting the number of jobs in half, we'll consequently have the ability to run 2x more concurrent PR checks than could before this change.

There is a very small and finite number of OSS-specific tests that EE check cannot cover. Everything else is either:
1. version agnostic (probably 95% of all tests) or
2. EE specific (which wouldn't even run on OSS version check) - see `moderation` table below

We still need to take into account that small OSS subset of tests, but that's outside of the scope of this PR. The most probable solution for this problem will look like this:

```
(e2e-tests.yml)
1. build
  - matrix [oss, ee]
  
2. e2e-oss*
  - uses oss-uberjar
  - runs only one hand-picked folder with OSS tests

4. e2e-ee
  - uses ee-uberjar
  - runs the full `folder` matrix against EE
  
* Alternatively, we can run the job #2 against both versions [oss, ee] if tests in that subset behave differently between versions.
```

### The next steps
- We continue to add battle-tested E2E CI groups to this workflow and observe how they behave on GHA. After they run smoothly for a while, we remove them from CircleCI.

_Once again, this will not affect the **full E2E matrix** that we run on `master`!_


### How to make sure this works?
Credit to @ariya for this super-simple hint: "Compare the total number of running tests on OSS vs EE". They should either be:
1. Greater on EE version (meaning subset of them are skipped and not run against OSS version) or
2. Absolutely the same (meaning there are no differences and both OSS and EE version run all tests equally)

There are currently only two groups that we run on every PR. Let's check their numbers:

[downloads OSS](https://github.com/metabase/metabase/runs/6028242514?check_suite_focus=true) vs [downloads EE](https://github.com/metabase/metabase/runs/6028243670?check_suite_focus=true)
| e2e-tests-downloads                       | total | passing | pending  |
|---------------------------|--------|-------|-------|
| OSS                  | 24   | 19  | 5  |
| EE                 | 24   | 19  | 5  |

[moderation OSS](https://github.com/metabase/metabase/runs/6028242747?check_suite_focus=true) vs [moderation EE](https://github.com/metabase/metabase/runs/6028243959?check_suite_focus=true)

| e2e-tests-moderation                       | total | passing | pending  |
|---------------------------|--------|-------|-------|
| OSS                  | 7   | -  | 7  |
| EE                 | 7   | 6  | 1  |

As expected, moderation skips ALL tests on OSS version because that feature isn't even available for OSS. This is just one example of how wasteful it was to blindly run all tests against both versions.