### PR TITLE
[E2E] Experiment running `binning` test group as PR check

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -59,6 +59,7 @@ jobs:
         java-version: [11]
         edition: [ee]
         folder:
+          - "binning"
           - "downloads"
           - "moderation"
     services:


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Following the steps of https://github.com/metabase/metabase/pull/21492 and the tasks that @ariya started, we're now adding `binning` test group to PR checks using GitHub actions.

Analyzing the flakes report I didn't see any binning related failure in the last 90 days on GHA so this should be pretty safe thing to do.

There's one more important check we need to make. Let's see if the number of passing tests is the same for both OSS and EE versions.

tl;dr It is. Because binning tests are version agnostic.

But here's the data:
[binning OSS](https://github.com/metabase/metabase/runs/6028242059?check_suite_focus=true) vs [binning EE](https://github.com/metabase/metabase/runs/6028243293?check_suite_focus=true)
| e2e-tests-binning                       | total | passing | pending  |
|---------------------------|--------|-------|-------|
| OSS                  | 77   | 67  | 10  |
| EE                 | 77   | 67  | 10  |


### The next steps
After we make sure this group runs without major hiccups on GitHub (for at least a week?), remove it from CircleCI.