### PR TITLE
Fix pie chart settings formatting

### DIFF
--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingColorsPicker.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingColorsPicker.jsx
@@ -5,20 +5,20 @@ import ChartSettingColorPicker from "./ChartSettingColorPicker";
 
 export default class ChartSettingColorsPicker extends Component {
   render() {
-    const { value, onChange, seriesTitles } = this.props;
+    const { value, onChange, seriesValues, seriesTitles } = this.props;
     return (
       <div>
-        {seriesTitles.map((title, index) => (
+        {seriesValues.map((key, index) => (
           <ChartSettingColorPicker
             key={index}
             onChange={color =>
               onChange({
                 ...value,
-                [title]: color,
+                [key]: color,
               })
             }
-            title={title}
-            value={value[title]}
+            title={seriesTitles[index]}
+            value={value[key]}
           />
         ))}
       </div>

--- a/frontend/src/metabase/visualizations/visualizations/PieChart.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PieChart.jsx
@@ -137,10 +137,11 @@ export default class PieChart extends Component {
           ? getColorsForValues(settings["pie._dimensionValues"])
           : [],
       getProps: (series, settings) => ({
-        seriesTitles: settings["pie._dimensionValues"] || [],
+        seriesValues: settings["pie._dimensionValues"] || [],
+        seriesTitles: settings["pie._dimensionTitles"] || [],
       }),
       getDisabled: (series, settings) => !settings["pie._dimensionValues"],
-      readDependencies: ["pie._dimensionValues"],
+      readDependencies: ["pie._dimensionValues", "pie._dimensionTitles"],
     },
     // this setting recomputes color assignment using pie.colors as the existing
     // assignments in case the user previous modified pie.colors and a new value
@@ -186,10 +187,34 @@ export default class PieChart extends Component {
         settings,
       ) => {
         const dimensionIndex = settings["pie._dimensionIndex"];
-        return dimensionIndex >= 0
-          ? // cast to string because getColorsForValues expects strings
-            rows.map(row => String(row[dimensionIndex]))
-          : null;
+        if (dimensionIndex == null || dimensionIndex < 0) {
+          return null;
+        }
+
+        return rows.map(row => String(row[dimensionIndex]));
+      },
+      readDependencies: ["pie._dimensionIndex"],
+    },
+    "pie._dimensionTitles": {
+      getValue: (
+        [
+          {
+            data: { rows, cols },
+          },
+        ],
+        settings,
+      ) => {
+        const dimensionIndex = settings["pie._dimensionIndex"];
+        if (dimensionIndex == null || dimensionIndex < 0) {
+          return null;
+        }
+
+        return rows.map(row =>
+          formatValue(
+            row[dimensionIndex],
+            settings.column(cols[dimensionIndex]),
+          ),
+        );
       },
       readDependencies: ["pie._dimensionIndex"],
     },

--- a/frontend/test/metabase/scenarios/visualizations/reproductions/21504-pie-settings-formatting.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/reproductions/21504-pie-settings-formatting.cy.spec.js
@@ -1,0 +1,32 @@
+import { restore, visitQuestionAdhoc } from "__support__/e2e/cypress";
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+
+const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
+
+describe("issue 21504", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsNormalUser();
+  });
+
+  it("should format pie chart settings (metabase#21504)", () => {
+    visitQuestionAdhoc({
+      dataset_query: {
+        type: "query",
+        query: {
+          "source-table": ORDERS_ID,
+          aggregation: [["count"]],
+          breakout: [
+            ["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }],
+          ],
+        },
+        database: SAMPLE_DB_ID,
+      },
+      display: "pie",
+    });
+
+    cy.findByText("Settings").click();
+    cy.findByText("April, 2016").should("be.visible");
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/21504

How to test:
- Create a pie chart based on Orders, Sum of Quantity per Created At (month).
- Open chart settings. Make sure that dates are formatting in the same way as labels on the chart.
- There is also a new cypress test for this case.

<img width="705" alt="Screenshot 2022-04-15 at 13 38 21" src="https://user-images.githubusercontent.com/8542534/163561527-4f4f0bf4-460d-4088-8d30-5b32bc5ad3e5.png">
