### PR TITLE
Improve performance of editing labels in chart settings

### DIFF
--- a/frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeries.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeries.jsx
@@ -5,6 +5,7 @@ import ColorPicker from "metabase/components/ColorPicker";
 import { SegmentedControl } from "metabase/components/SegmentedControl";
 import Icon from "metabase/components/Icon";
 import IconWrapper from "metabase/components/IconWrapper";
+import InputBlurChange from "metabase/components/InputBlurChange";
 
 // various props injected by chartSettingNestedSettings HOC
 export default class ChartNestedSettingSeries extends React.Component {
@@ -45,13 +46,13 @@ export default class ChartNestedSettingSeries extends React.Component {
                       onChangeObjectSettings(single, { color: value })
                     }
                   />
-                  <input
+                  <InputBlurChange
                     className="input flex-full ml1 align-self-stretch"
                     // set vertical padding to 0 and use align-self-stretch to match siblings
                     style={{ paddingTop: 0, paddingBottom: 0 }}
                     size={1}
                     value={settings.title}
-                    onChange={e =>
+                    onBlurChange={e =>
                       onChangeObjectSettings(single, { title: e.target.value })
                     }
                   />


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/19683
Fixes https://github.com/metabase/metabase/issues/21452

How to test:
- Create a new line chart without saving
- Go to settings and change the series label
- Make sure there are no `dataset` requests when you type

`InputBlurChange` is already used for other text-based chart settings, as far as I was able to find out.

<img width="889" alt="Screenshot 2022-04-15 at 14 01 18" src="https://user-images.githubusercontent.com/8542534/163563507-df2af0ea-c078-4318-9ddd-a37a06f829f7.png">
