### PR TITLE
[E2E] Fix flake in repro for #10829

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard-filters/parameters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/parameters.cy.spec.js
@@ -289,10 +289,10 @@ describe("scenarios > dashboard > parameters", () => {
     cy.button("Save").click();
     cy.wait("@dashcardQuery");
 
-    // cy.log("Filter name should be 'unnamed' and the value cleared");
+    cy.log("Filter name should be 'unnamed' and the value cleared");
     filterWidget().contains(/unnamed/i);
 
-    // cy.log("URL should reset");
+    cy.log("URL should reset");
     cy.location("search").should("eq", "");
   });
 

--- a/frontend/test/metabase/scenarios/dashboard-filters/parameters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/parameters.cy.spec.js
@@ -199,7 +199,7 @@ describe("scenarios > dashboard > parameters", () => {
     cy.findByText("Add filter").click();
   });
 
-  it("should remove previously deleted dashboard parameter from URL (metabase#10829)", () => {
+  it("should remove parameter from URL after its name has been removed (metabase#10829)", () => {
     // Mirrored issue in metabase-enterprise#275
     cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
       "dashcardQuery",

--- a/frontend/test/metabase/scenarios/dashboard-filters/parameters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/parameters.cy.spec.js
@@ -4,12 +4,13 @@ import {
   restore,
   openNativeEditor,
   visitDashboard,
+  filterWidget,
 } from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 // NOTE: some overlap with parameters-embedded.cy.spec.js
 
-const { PRODUCTS } = SAMPLE_DATABASE;
+const { ORDERS_ID, ORDERS, PRODUCTS } = SAMPLE_DATABASE;
 
 describe("scenarios > dashboard > parameters", () => {
   beforeEach(() => {
@@ -200,58 +201,99 @@ describe("scenarios > dashboard > parameters", () => {
 
   it("should remove previously deleted dashboard parameter from URL (metabase#10829)", () => {
     // Mirrored issue in metabase-enterprise#275
+    cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
+      "dashcardQuery",
+    );
 
-    // Go directly to "Orders in a dashboard" dashboard
-    visitDashboard(1);
-    cy.findByTextEnsureVisible("Created At");
+    const questionDetails = {
+      query: {
+        "source-table": ORDERS_ID,
+        limit: 5,
+      },
+    };
 
-    // Add filter and save dashboard
-    cy.icon("pencil").click();
-    cy.icon("filter").click();
-    cy.findByText("Text or Category").click();
-    cy.findByText("Ends with").click();
+    const filter = {
+      name: "Text ends with",
+      slug: "text_ends_with",
+      id: "88a1257c",
+      type: "string/ends-with",
+      sectionId: "string",
+    };
 
-    // map the parameter to the Category field
-    selectFilter(cy.get(".DashCard"), "Category");
+    const dashboardDetails = {
+      parameters: [filter],
+    };
 
-    cy.findByText("Save").click();
+    cy.createQuestionAndDashboard({ questionDetails, dashboardDetails }).then(
+      ({ body: { id, card_id, dashboard_id } }) => {
+        cy.request("PUT", `/api/dashboard/${dashboard_id}/cards`, {
+          cards: [
+            {
+              id,
+              card_id,
+              row: 0,
+              col: 0,
+              sizeX: 12,
+              sizeY: 8,
+              series: [],
+              visualization_settings: {},
+              parameter_mappings: [
+                {
+                  parameter_id: filter.id,
+                  card_id,
+                  target: [
+                    "dimension",
+                    [
+                      "field",
+                      PRODUCTS.CATEGORY,
+                      {
+                        "source-field": ORDERS.PRODUCT_ID,
+                      },
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+        });
 
-    // wait for saving to finish
-    cy.contains("You're editing this dashboard.").should("not.exist");
+        visitDashboard(dashboard_id);
+        cy.findByTextEnsureVisible("Created At");
+      },
+    );
 
     // populate the filter input
-    cy.findByText("Text ends with").click();
-    popover()
-      .find("input")
-      .type("zmo");
-
-    popover()
-      .contains("Add filter")
-      .click();
+    filterWidget().click();
+    cy.findByPlaceholderText("Enter some text").type("zmo{enter}");
+    cy.button("Add filter").click();
 
     cy.log(
       "**URL is updated correctly with the given parameter at this point**",
     );
-    cy.url().should("include", "text_ends_with=zmo");
+    cy.location("search").should("eq", "?text_ends_with=zmo");
 
     // Remove filter name
     cy.icon("pencil").click();
     cy.get(".Dashboard")
       .find(".Icon-gear")
       .click();
+
     cy.findByDisplayValue("Text ends with")
-      .click()
       .clear()
       .blur();
-    cy.findByText("Save").click();
-    cy.wait("@dashboard");
-    cy.findByText("You're editing this dashboard.").should("not.exist");
 
-    cy.log("Filter name should be 'unnamed' and the value cleared");
-    cy.findByText(/unnamed/i);
+    cy.findByDisplayValue("unnamed");
 
-    cy.log("URL should reset");
-    cy.location("pathname").should("eq", "/dashboard/1");
+    cy.location("search").should("eq", "?unnamed=zmo");
+
+    cy.button("Save").click();
+    cy.wait("@dashcardQuery");
+
+    // cy.log("Filter name should be 'unnamed' and the value cleared");
+    filterWidget().contains(/unnamed/i);
+
+    // cy.log("URL should reset");
+    cy.location("search").should("eq", "");
   });
 
   it("should allow linked question to be changed without breaking (metabase#9299)", () => {

--- a/frontend/test/metabase/scenarios/dashboard-filters/parameters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/parameters.cy.spec.js
@@ -241,7 +241,8 @@ describe("scenarios > dashboard > parameters", () => {
       .click();
     cy.findByDisplayValue("Text ends with")
       .click()
-      .clear();
+      .clear()
+      .blur();
     cy.findByText("Save").click();
     cy.wait("@dashboard");
     cy.findByText("You're editing this dashboard.").should("not.exist");


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Fixes the flake in repro for #10829 which occurred infrequently (see the [test history](https://app.currents.dev/instance/11718aa4-a178-45d7-96a2-8939dee53b76/test/r7))
- Speeds up and makes repro more robust by using the API to set things up
 
![image](https://user-images.githubusercontent.com/31325167/163565826-35a5c704-ed21-4361-85b8-87020b8016d3.png)

For some reason, after Cypress cleared the input field (deletes parameter's name), UI repopulates that name before the save. After I added `blur` that doesn't seem to happen anymore.