### PR TITLE
Silence error message in render-pulse-email-test

### DIFF
--- a/test/metabase/email/messages_test.clj
+++ b/test/metabase/email/messages_test.clj
@@ -85,7 +85,9 @@
 (deftest render-pulse-email-test
   (testing "Email with few rows and columns can be rendered when tracing (#21166)"
     (tu/with-log-level [metabase.email :trace]
-      (let [result {:card {:name "card-name"}
+      (let [result {:card   {:name "card-name"
+                             :visualization_settings
+                             {:table.column_formatting []}}
                     :result {:data {:cols [{:name "x"} {:name "y"}]
                                     :rows [[0 0]
                                            [1 1]]}}}


### PR DESCRIPTION
The missing `table.column_formatting` field in the card description results in an error and an error message is printed. This change gets rid of this error message.