### PR TITLE
Fixes to DB and data model perm enforcement for users without data perms

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -317,4 +317,10 @@
     (testing "A non-admin with block perms for a DB can fetch the DB if they have DB details permissions"
       (with-all-users-data-perms {db-id {:data {:native :none, :schemas :block}
                                          :details :yes}}
-        (mt/user-http-request :rasta :get 200 (format "database/%d" db-id))))))
+        (mt/user-http-request :rasta :get 200 (format "database/%d" db-id))))
+
+    (testing "The returned database contains a :details field for a user iwth DB details permissions"
+      (with-all-users-data-perms {db-id {:data {:native :none, :schemas :block}
+                                         :details :yes}}
+        (is (partial= {:details {}}
+             (mt/user-http-request :rasta :get 200 (format "database/%d" db-id))))))))

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -325,6 +325,23 @@
                                          :details :yes}}
         (mt/user-http-request :rasta :get 200 (format "database/%d" db-id))))
 
+    (testing "A non-admin without self-service perms for a DB can fetch the DB if they have data model permissions"
+      (with-all-users-data-perms {db-id {:data    {:native :none :schemas :none}
+                                         :details    :no
+                                         :data-model {:schemas :all}}}
+        (mt/user-http-request :rasta :get 200 (format "database/%d" db-id))))
+
+    (testing "A non-admin with block perms perms for a DB can fetch the DB if they have data model permissions"
+      (with-all-users-data-perms {db-id {:data    {:native :none :schemas :block}
+                                         :details    :no
+                                         :data-model {:schemas :all}}}
+        (mt/user-http-request :rasta :get 200 (format "database/%d" db-id))))
+
+    (testing "A non-admin with block perms for a DB can fetch the DB if they have DB details permissions"
+      (with-all-users-data-perms {db-id {:data    {:native :none :schemas :block}
+                                         :details :yes}}
+        (mt/user-http-request :rasta :get 200 (format "database/%d" db-id))))
+
     (testing "The returned database contains a :details field for a user with DB details permissions"
       (with-all-users-data-perms {db-id {:data    {:native :none :schemas :block}
                                          :details :yes}}

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -2,7 +2,6 @@
   (:require [cheshire.core :as json]
             [clojure.core.memoize :as memoize]
             [clojure.test :refer :all]
-            [metabase-enterprise.advanced-permissions.models.permissions :as ee-perms]
             [metabase.models :refer [Database Field Permissions Table]]
             [metabase.models.database :as database]
             [metabase.models.field :as field]

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -75,10 +75,10 @@
 ;;; |                                        Data model permission enforcement                                       |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-(deftest fetch-databases-exclude-uneditable-data-model-test
-  (testing "GET /api/database?exclude_uneditable_data_model=true"
+(deftest fetch-databases-include-editable-data-model-test
+  (testing "GET /api/database?include_editable_data_model=true"
     (letfn [(get-test-db
-              ([] (get-test-db "database?exclude_uneditable_data_model=true"))
+              ([] (get-test-db "database?include_editable_data_model=true"))
               ([url] (->> (mt/user-http-request :rasta :get 200 url)
                           :data
                           (filter (fn [db] (= (mt/id) (:id db))))
@@ -102,7 +102,7 @@
             (is (partial= {:id (mt/id)} (get-test-db))))
 
           (testing "if include=tables, only tables with data model perms are included"
-            (is (= [id-1] (->> (get-test-db "database?exclude_uneditable_data_model=true&include=tables")
+            (is (= [id-1] (->> (get-test-db "database?include_editable_data_model=true&include=tables")
                                :tables
                                (map :id))))))))))
 

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -229,6 +229,30 @@
             (mt/user-http-request :rasta :put 200 (format "table/%d/fields/order" table-id)
                                   {:request-options {:body (json/encode [field-2-id field-1-id])}})))))))
 
+(deftest fetch-table-test
+  (testing "GET /api/table/:id"
+    (mt/with-temp Table [{table-id :id} {:db_id (mt/id) :schema "PUBLIC"}]
+      (testing "A non-admin without self-service perms for a table cannot fetch the table normally"
+        (with-all-users-data-perms {(mt/id) {:data {:native :none, :schemas :none}}}
+          (mt/user-http-request :rasta :get 403 (format "table/%d" table-id))))
+
+      (testing "A non-admin without self-service perms for a table can fetch the table if they have data model perms for
+               the DB"
+        (with-all-users-data-perms {(mt/id) {:data {:native :none, :schemas :none}
+                                             :data-model {:schemas :all}}}
+          (mt/user-http-request :rasta :get 200 (format "table/%d" table-id))))
+
+      (testing "A non-admin without self-service perms for a table can fetch the table if they have data model perms for
+               the schema"
+        (with-all-users-data-perms {(mt/id) {:data {:native :none, :schemas :none}
+                                             :data-model {:schemas {"PUBLIC" :all}}}}
+          (mt/user-http-request :rasta :get 200 (format "table/%d" table-id))))
+
+      (testing "A non-admin without self-service perms for a table can fetch the table if they have data model perms for
+               the table"
+        (with-all-users-data-perms {(mt/id) {:data {:native :none, :schemas :none}
+                                             :data-model {:schemas {"PUBLIC" {table-id :all}}}}}
+          (mt/user-http-request :rasta :get 200 (format "table/%d" table-id)))))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                  Database details permission enforcement                                       |
@@ -278,3 +302,19 @@
     (testing "A non-admin can discard saved field values if they have DB details permissions"
       (with-all-users-data-perms {db-id {:details :yes}}
         (mt/user-http-request :rasta :post 200 (format "database/%d/discard_values" db-id))))))
+
+(deftest fetch-db-test
+  (mt/with-temp Database [{db-id :id}]
+    (testing "A non-admin without self-service perms for a DB cannot fetch the DB normally"
+      (with-all-users-data-perms {db-id {:data {:native :none, :schemas :none}}}
+        (mt/user-http-request :rasta :get 403 (format "database/%d" db-id))))
+
+    (testing "A non-admin without self-service perms for a DB can fetch the DB if they have DB details permissions"
+      (with-all-users-data-perms {db-id {:data {:native :none, :schemas :none}
+                                         :details :yes}}
+        (mt/user-http-request :rasta :get 200 (format "database/%d" db-id))))
+
+    (testing "A non-admin with block perms for a DB can fetch the DB if they have DB details permissions"
+      (with-all-users-data-perms {db-id {:data {:native :none, :schemas :block}
+                                         :details :yes}}
+        (mt/user-http-request :rasta :get 200 (format "database/%d" db-id))))))

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -15,7 +15,6 @@
   [graph f]
   (let [all-users-group-id  (u/the-id (group/all-users))
         current-graph       (get-in (perms/data-perms-graph) [:groups all-users-group-id])]
-    (def my-current-graph current-graph)
     (premium-features-test/with-premium-features #{:advanced-permissions}
       (memoize/memo-clear! @#'field/cached-perms-object-set)
       (try
@@ -23,7 +22,7 @@
           (@#'perms/update-group-permissions! all-users-group-id graph)
           (f))
         (finally
-          (@#'perms/update-group-permissions! 1 my-current-graph))))))
+          (@#'perms/update-group-permissions! all-users-group-id my-current-graph))))))
 
 (defmacro ^:private with-all-users-data-perms
   "Runs `f` with perms for the All Users group temporarily set to the values in `graph`. Also enables the advanced

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -22,7 +22,7 @@
           (@#'perms/update-group-permissions! all-users-group-id graph)
           (f))
         (finally
-          (@#'perms/update-group-permissions! all-users-group-id graph))))))
+          (@#'perms/update-group-permissions! all-users-group-id current-graph))))))
 
 (defmacro ^:private with-all-users-data-perms
   "Runs `f` with perms for the All Users group temporarily set to the values in `graph`. Also enables the advanced

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -325,23 +325,6 @@
                                          :details :yes}}
         (mt/user-http-request :rasta :get 200 (format "database/%d" db-id))))
 
-    (testing "A non-admin without self-service perms for a DB can fetch the DB if they have data model permissions"
-      (with-all-users-data-perms {db-id {:data    {:native :none :schemas :none}
-                                         :details    :no
-                                         :data-model {:schemas :all}}}
-        (mt/user-http-request :rasta :get 200 (format "database/%d" db-id))))
-
-    (testing "A non-admin with block perms perms for a DB can fetch the DB if they have data model permissions"
-      (with-all-users-data-perms {db-id {:data    {:native :none :schemas :block}
-                                         :details    :no
-                                         :data-model {:schemas :all}}}
-        (mt/user-http-request :rasta :get 200 (format "database/%d" db-id))))
-
-    (testing "A non-admin with block perms for a DB can fetch the DB if they have DB details permissions"
-      (with-all-users-data-perms {db-id {:data    {:native :none :schemas :block}
-                                         :details :yes}}
-        (mt/user-http-request :rasta :get 200 (format "database/%d" db-id))))
-
     (testing "The returned database contains a :details field for a user with DB details permissions"
       (with-all-users-data-perms {db-id {:data    {:native :none :schemas :block}
                                          :details :yes}}

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -319,7 +319,7 @@
                                          :details :yes}}
         (mt/user-http-request :rasta :get 200 (format "database/%d" db-id))))
 
-    (testing "The returned database contains a :details field for a user iwth DB details permissions"
+    (testing "The returned database contains a :details field for a user with DB details permissions"
       (with-all-users-data-perms {db-id {:data {:native :none, :schemas :block}
                                          :details :yes}}
         (is (partial= {:details {}}

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -22,7 +22,7 @@
           (@#'perms/update-group-permissions! all-users-group-id graph)
           (f))
         (finally
-          (@#'perms/update-group-permissions! all-users-group-id my-current-graph))))))
+          (@#'perms/update-group-permissions! all-users-group-id graph))))))
 
 (defmacro ^:private with-all-users-data-perms
   "Runs `f` with perms for the All Users group temporarily set to the values in `graph`. Also enables the advanced

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/index.ts
@@ -25,11 +25,7 @@ if (hasPremiumFeature("advanced_permissions")) {
   PLUGIN_FEATURE_LEVEL_PERMISSIONS.getDownloadWidgetMessageOverride = getDownloadWidgetMessageOverride;
   PLUGIN_FEATURE_LEVEL_PERMISSIONS.canDownloadResults = canDownloadResults;
 
-  PLUGIN_FEATURE_LEVEL_PERMISSIONS.tableMetadataQueryProps = {
-    include_editable_data_model: true,
-  };
-
-  PLUGIN_FEATURE_LEVEL_PERMISSIONS.databaseDataModelQueryProps = {
+  PLUGIN_FEATURE_LEVEL_PERMISSIONS.dataModelQueryProps = {
     include_editable_data_model: true,
   };
 

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/index.ts
@@ -26,11 +26,11 @@ if (hasPremiumFeature("advanced_permissions")) {
   PLUGIN_FEATURE_LEVEL_PERMISSIONS.canDownloadResults = canDownloadResults;
 
   PLUGIN_FEATURE_LEVEL_PERMISSIONS.tableMetadataQueryProps = {
-    exclude_uneditable: true,
+    include_editable_data_model: true,
   };
 
   PLUGIN_FEATURE_LEVEL_PERMISSIONS.databaseDataModelQueryProps = {
-    exclude_uneditable_data_model: true,
+    include_editable_data_model: true,
   };
 
   PLUGIN_FEATURE_LEVEL_PERMISSIONS.databaseDetailsQueryProps = {

--- a/frontend/src/metabase-types/entities/database.ts
+++ b/frontend/src/metabase-types/entities/database.ts
@@ -1,5 +1,5 @@
 import { Database } from "metabase-types/api";
 
 export interface DatabaseEntity extends Database {
-  fetchIdfields: () => void;
+  fetchIdfields: (query: any) => void;
 }

--- a/frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx
@@ -12,9 +12,9 @@ import { PLUGIN_FEATURE_LEVEL_PERMISSIONS } from "metabase/plugins";
 
 @withRouter
 @Databases.loadList({
-  query: () => ({
-    ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.databaseDataModelQueryProps,
-  }),
+  query: {
+    ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.dataModelQueryProps,
+  },
 })
 export default class MetadataHeader extends Component {
   static propTypes = {

--- a/frontend/src/metabase/admin/datamodel/components/database/MetadataSchema/MetadataSchema.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/MetadataSchema/MetadataSchema.tsx
@@ -94,7 +94,9 @@ const MetadataSchema = ({ table }: MetadataSchemaProps) => {
 export default _.compose(
   Tables.load({
     id: (_state: State, { tableId }: { tableId: number }) => tableId,
-    ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.tableMetadataQueryProps,
+    query: {
+      ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.dataModelQueryProps,
+    },
     wrapped: true,
   }),
   withTableMetadataLoaded,

--- a/frontend/src/metabase/admin/datamodel/components/database/MetadataSchema/MetadataSchema.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/MetadataSchema/MetadataSchema.tsx
@@ -5,7 +5,7 @@ import withTableMetadataLoaded from "metabase/admin/datamodel/hoc/withTableMetad
 import Tables from "metabase/entities/tables";
 import { Field, Table } from "metabase-types/api";
 import { State } from "metabase-types/store";
-import { getFieldRawName } from "../../../utils";
+import { PLUGIN_FEATURE_LEVEL_PERMISSIONS } from "metabase/plugins";
 import {
   ColumnNameCell,
   DataTypeCell,
@@ -94,6 +94,7 @@ const MetadataSchema = ({ table }: MetadataSchemaProps) => {
 export default _.compose(
   Tables.load({
     id: (_state: State, { tableId }: { tableId: number }) => tableId,
+    ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.tableMetadataQueryProps,
     wrapped: true,
   }),
   withTableMetadataLoaded,

--- a/frontend/src/metabase/admin/datamodel/components/database/MetadataTable/MetadataTable.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/MetadataTable/MetadataTable.tsx
@@ -19,6 +19,7 @@ import {
   VisibilityType,
 } from "./MetadataTable.styled";
 import { Field } from "metabase-types/api/field";
+import { PLUGIN_FEATURE_LEVEL_PERMISSIONS } from "metabase/plugins";
 
 const getDescriptionPlaceholder = () => t`No table description yet`;
 
@@ -157,10 +158,16 @@ const MetadataTable = ({
 export default _.compose(
   Databases.load({
     id: (_state: State, { databaseId }: { databaseId: number }) => databaseId,
+    query: () => ({
+      ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.databaseDataModelQueryProps,
+    }),
     wrapped: true,
   }),
   Tables.load({
     id: (_state: State, { tableId }: { tableId: number }) => tableId,
+    query: () => ({
+      ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.tableMetadataQueryProps,
+    }),
     wrapped: true,
     selectorName: "getObjectUnfiltered",
   }),

--- a/frontend/src/metabase/admin/datamodel/components/database/MetadataTable/MetadataTable.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/MetadataTable/MetadataTable.tsx
@@ -38,7 +38,9 @@ const MetadataTable = ({
 }: MetadataTableProps) => {
   const [tab, setTab] = useState("columns");
   useEffect(() => {
-    database?.fetchIdfields();
+    database?.fetchIdfields({
+      ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.dataModelQueryProps,
+    });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [database?.id]);
 
@@ -158,16 +160,16 @@ const MetadataTable = ({
 export default _.compose(
   Databases.load({
     id: (_state: State, { databaseId }: { databaseId: number }) => databaseId,
-    query: () => ({
-      ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.databaseDataModelQueryProps,
-    }),
+    query: {
+      ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.dataModelQueryProps,
+    },
     wrapped: true,
   }),
   Tables.load({
     id: (_state: State, { tableId }: { tableId: number }) => tableId,
-    query: () => ({
-      ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.tableMetadataQueryProps,
-    }),
+    query: {
+      ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.dataModelQueryProps,
+    },
     wrapped: true,
     selectorName: "getObjectUnfiltered",
   }),

--- a/frontend/src/metabase/admin/datamodel/components/database/MetadataTablePicker.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/MetadataTablePicker.jsx
@@ -13,7 +13,7 @@ const RELOAD_INTERVAL = 2000;
   query: (state, { databaseId }) => ({
     dbId: databaseId,
     include_hidden: true,
-    ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.tableMetadataQueryProps,
+    ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.dataModelQueryProps,
   }),
   reloadInterval: (state, props, tables = []) => {
     return tables.some(t => isSyncInProgress(t)) ? RELOAD_INTERVAL : 0;

--- a/frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx
@@ -57,9 +57,9 @@ const mapDispatchToProps = {
 @connect(mapStateToProps, mapDispatchToProps)
 @Databases.load({
   id: (state, props) => props.databaseId,
-  query: () => ({
-    ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.databaseDataModelQueryProps,
-  }),
+  query: {
+    ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.dataModelQueryProps,
+  },
   loadingAndErrorWrapper: false,
 })
 class MetadataEditor extends Component {

--- a/frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx
@@ -16,6 +16,7 @@ import {
   databases as Databases,
   fields as Fields,
 } from "metabase/entities";
+import { PLUGIN_FEATURE_LEVEL_PERMISSIONS } from "metabase/plugins";
 
 const propTypes = {
   databaseId: PropTypes.number,
@@ -56,6 +57,9 @@ const mapDispatchToProps = {
 @connect(mapStateToProps, mapDispatchToProps)
 @Databases.load({
   id: (state, props) => props.databaseId,
+  query: () => ({
+    ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.databaseDataModelQueryProps,
+  }),
   loadingAndErrorWrapper: false,
 })
 class MetadataEditor extends Component {

--- a/frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx
@@ -10,6 +10,7 @@ import Section, { SectionHeader } from "../components/Section";
 
 import Databases from "metabase/entities/databases";
 import Tables from "metabase/entities/tables";
+import { PLUGIN_FEATURE_LEVEL_PERMISSIONS } from "metabase/plugins";
 
 import { rescanTableFieldValues, discardTableFieldValues } from "../table";
 
@@ -45,9 +46,17 @@ export default class TableSettingsApp extends Component {
   }
 }
 
-@Databases.load({ id: (state, { databaseId }) => databaseId })
+@Databases.load({
+  id: (state, { databaseId }) => databaseId,
+  query: {
+    ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.dataModelQueryProps,
+  },
+})
 @Tables.load({
   id: (state, { tableId }) => tableId,
+  query: {
+    ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.dataModelQueryProps,
+  },
   selectorName: "getObjectUnfiltered",
 })
 class Nav extends Component {

--- a/frontend/src/metabase/admin/datamodel/hoc/withTableMetadataLoaded.js
+++ b/frontend/src/metabase/admin/datamodel/hoc/withTableMetadataLoaded.js
@@ -22,7 +22,7 @@ export default ComposedComponent => {
       this.props.table.fetchMetadataAndForeignTables({
         params: {
           include_sensitive_fields: true,
-          ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.tableMetadataQueryProps,
+          ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.dataModelQueryProps,
         },
       });
     }

--- a/frontend/src/metabase/admin/datamodel/hoc/withTableMetadataLoaded.js
+++ b/frontend/src/metabase/admin/datamodel/hoc/withTableMetadataLoaded.js
@@ -1,5 +1,6 @@
 /* eslint-disable react/prop-types */
 import React, { Component } from "react";
+import { PLUGIN_FEATURE_LEVEL_PERMISSIONS } from "metabase/plugins";
 
 export default ComposedComponent => {
   class TableMetadataLoader extends Component {
@@ -19,7 +20,10 @@ export default ComposedComponent => {
 
     fetch() {
       this.props.table.fetchMetadataAndForeignTables({
-        params: { include_sensitive_fields: true },
+        params: {
+          include_sensitive_fields: true,
+          ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.tableMetadataQueryProps,
+        },
       });
     }
 

--- a/frontend/src/metabase/entities/databases.js
+++ b/frontend/src/metabase/entities/databases.js
@@ -56,8 +56,10 @@ const Databases = createEntity({
 
     fetchIdfields: createThunkAction(
       FETCH_DATABASE_IDFIELDS,
-      ({ id }) => async () =>
-        normalize(await MetabaseApi.db_idfields({ dbId: id }), [Fields.schema]),
+      ({ id }, params = {}) => async () =>
+        normalize(await MetabaseApi.db_idfields({ dbId: id, ...params }), [
+          Fields.schema,
+        ]),
     ),
 
     fetchSchemas: ({ id }) => Schemas.actions.fetchList({ dbId: id }),

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -141,8 +141,7 @@ export const PLUGIN_FEATURE_LEVEL_PERMISSIONS = {
   getDataColumns: (_subject: PermissionSubject) => [] as any,
   getDownloadWidgetMessageOverride: (_result: Dataset): string | null => null,
   canDownloadResults: (_result: Dataset): boolean => true,
-  tableMetadataQueryProps: {} as any,
-  databaseDataModelQueryProps: {} as any,
+  dataModelQueryProps: {} as any,
   databaseDetailsQueryProps: {} as any,
 };
 

--- a/frontend/test/metabase/scenarios/permissions/data-model-permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/data-model-permissions.cy.spec.js
@@ -18,7 +18,7 @@ describeEE("scenarios > admin > permissions", () => {
     cy.intercept("PUT", "/api/field/*").as("fieldUpdate");
     cy.intercept(
       "GET",
-      "/api/table/2/query_metadata?include_sensitive_fields=true",
+      "/api/table/2/query_metadata?include_sensitive_fields=true&include_editable_data_model=true",
     ).as("tableMetadataFetch");
   });
 

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -330,11 +330,11 @@
   {include (s/maybe (s/enum "tables" "tables.fields"))}
   (let [include-editable-data-model? (Boolean/parseBoolean include_editable_data_model)]
     (cond-> (api/check-404 (Database id))
-      (not include-editable-data-model?) api/write-check
-      true                              add-expanded-schedules
-      true                              (get-database-hydrate-include include)
-      mi/can-write?                     secret/expand-db-details-inferred-secret-values
-      include-editable-data-model?      (check-db-data-model-perms include-editable-data-model?))))
+      (not include-editable-data-model?) api/read-check
+      true                               add-expanded-schedules
+      true                               (get-database-hydrate-include include)
+      mi/can-write?                      secret/expand-db-details-inferred-secret-values
+      include-editable-data-model?       (check-db-data-model-perms include-editable-data-model?))))
 
 
 ;;; ----------------------------------------- GET /api/database/:id/metadata -----------------------------------------

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -318,9 +318,9 @@
 
 (api/defendpoint GET "/:id"
   "Get a single Database with `id`. Optionally pass `?include=tables` or `?include=tables.fields` to include the Tables
-  belonging to this database, or the Tables and Fields, respectively.  If the requestor is an admin, then certain
-  inferred secret values will also be included in the returned details (see
-  [[metabase.models.secret/admin-expand-db-details-inferred-secret-values]] for full details).
+  belonging to this database, or the Tables and Fields, respectively.  If the requestor has write permissions for the DB
+  (i.e. is an admin or has data model permissions), then certain inferred secret values will also be included in the
+  returned details (see [[metabase.models.secret/expand-db-details-inferred-secret-values]] for full details).
 
   Passing include_editable_data_model will only return tables for which the current user has data model editing
   permissions, if Enterprise Edition code is available and a token with the advanced-permissions feature is present.

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -304,8 +304,8 @@
               add-expanded-schedules
               (get-database-hydrate-include include))
 
-    api/*is-superuser?* ; for admins, expand inferred secret values in db-details
-    secret/admin-expand-db-details-inferred-secret-values))
+    mi/can-write?
+    secret/expand-db-details-inferred-secret-values))
 
 
 ;;; ----------------------------------------- GET /api/database/:id/metadata -----------------------------------------

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -750,8 +750,11 @@
   "Does the current user have permissions to know the schema with `schema-name` exists? (Do they have permissions to see
   at least some of its tables?)"
   [database-id schema-name]
-  (perms/set-has-partial-permissions? @api/*current-user-permissions-set*
-                                      (perms/data-perms-path database-id schema-name)))
+  (or
+   (perms/set-has-partial-permissions? @api/*current-user-permissions-set*
+                                       (perms/data-perms-path database-id schema-name))
+   (perms/set-has-full-permissions? @api/*current-user-permissions-set*
+                                    (perms/data-model-write-perms-path database-id schema-name))))
 
 (api/defendpoint GET "/:id/schemas"
   "Returns a list of all the schemas found for the database `id`"

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -184,12 +184,11 @@
 
 (defn- perms-objects-set [{db-id :id} read-or-write]
   #{(case read-or-write
-      ;; We should let a user read a DB if they have write perms for the DB details, write perms for the DB data model,
-      ;; *or* self-service data access. Since a user can have one or the other, we use `i/has-any-permissions?` to check
-      ;; all three permission sets in the `can-read?` implementation.
-      :read       (perms/data-perms-path db-id)
-      :data-model (perms/data-model-write-perms-path db-id)
-      :write     (perms/db-details-write-perms-path db-id))})
+      ;; We should let a user read a DB if they have write perms for the DB details *or* self-service data access.
+      ;; Since a user can have one or the other, we use `i/has-any-permissions?` to check both read and write permission
+      ;; sets in the `can-read?` implementation.
+      :read (perms/data-perms-path db-id)
+      :write (perms/db-details-write-perms-path db-id))})
 
 (u/strict-extend (class Database)
   models/IModel
@@ -213,7 +212,6 @@
          {:perms-objects-set perms-objects-set
           :can-read?         (i/has-any-permissions?
                               (partial i/current-user-has-partial-permissions? :read)
-                              (partial i/current-user-has-partial-permissions? :data-model)
                               (partial i/current-user-has-full-permissions? :write))
           :can-write?        (partial i/current-user-has-full-permissions? :write)}))
 

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -184,11 +184,12 @@
 
 (defn- perms-objects-set [{db-id :id} read-or-write]
   #{(case read-or-write
-      ;; We should let a user read a DB if they have write perms for the DB details *or* self-service data access.
-      ;; Since a user can have one or the other, we use `i/has-any-permissions?` to check both read and write permission
-      ;; sets in the `can-read?` implementation.
-      :read (perms/data-perms-path db-id)
-      :write (perms/db-details-write-perms-path db-id))})
+      ;; We should let a user read a DB if they have write perms for the DB details, write perms for the DB data model,
+      ;; *or* self-service data access. Since a user can have one or the other, we use `i/has-any-permissions?` to check
+      ;; all three permission sets in the `can-read?` implementation.
+      :read       (perms/data-perms-path db-id)
+      :data-model (perms/data-model-write-perms-path db-id)
+      :write     (perms/db-details-write-perms-path db-id))})
 
 (u/strict-extend (class Database)
   models/IModel
@@ -212,6 +213,7 @@
          {:perms-objects-set perms-objects-set
           :can-read?         (i/has-any-permissions?
                               (partial i/current-user-has-partial-permissions? :read)
+                              (partial i/current-user-has-partial-permissions? :data-model)
                               (partial i/current-user-has-full-permissions? :write))
           :can-write?        (partial i/current-user-has-full-permissions? :write)}))
 

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -187,8 +187,7 @@
     ;; We should let a user read a DB if they have write perms for the DB details *or* self-service data access.
     ;; Since a user can have one or the other, we use `i/current-user-has-any-partial-permissions?` as the
     ;; `can-read?` implementation.
-    :read #{(perms/data-perms-path db-id)
-            (perms/db-details-write-perms-path db-id)}
+    :read #{(perms/data-perms-path db-id)}
     :write #{(perms/db-details-write-perms-path db-id)}))
 
 (u/strict-extend (class Database)
@@ -211,7 +210,9 @@
   i/IObjectPermissions
   (merge i/IObjectPermissionsDefaults
          {:perms-objects-set perms-objects-set
-          :can-read?         (partial i/current-user-has-any-partial-permissions? :read)
+          :can-read?         (i/check-any
+                              (partial i/current-user-has-partial-permissions? :read)
+                              (partial i/current-user-has-full-permissions? :write))
           :can-write?        (partial i/current-user-has-full-permissions? :write)}))
 
 

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -183,12 +183,12 @@
       (assoc :initial_sync_status "incomplete")))
 
 (defn- perms-objects-set [{db-id :id} read-or-write]
-  #{(case read-or-write)
-    ;; We should let a user read a DB if they have write perms for the DB details *or* self-service data access.
-    ;; Since a user can have one or the other, we use `i/has-any-permissions?` to check both read and write permission
-    ;; sets in the `can-read?` implementation.
-    :read (perms/data-perms-path db-id)
-    :write (perms/db-details-write-perms-path db-id)})
+  #{(case read-or-write
+      ;; We should let a user read a DB if they have write perms for the DB details *or* self-service data access.
+      ;; Since a user can have one or the other, we use `i/has-any-permissions?` to check both read and write permission
+      ;; sets in the `can-read?` implementation.
+      :read (perms/data-perms-path db-id)
+      :write (perms/db-details-write-perms-path db-id))})
 
 (u/strict-extend (class Database)
   models/IModel

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -354,4 +354,3 @@
     (->> ((apply juxt permission-check-fns) object)
          (some true?)
          boolean)))
-

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -342,3 +342,11 @@
   permissions for the paths returned by its implementation of `perms-objects-set`. (`read-or-write` is either `:read` or
   `:write` and passed to `perms-objects-set`; you'll usually want to partially bind it in the implementation map)."
   (partial check-perms-with-fn 'metabase.models.permissions/set-has-partial-permissions-for-set?))
+
+(def ^{:arglists '([read-or-write entity object-id] [read-or-write object] [perms-set])}
+  current-user-has-any-partial-permissions?
+  "Implementation of `can-read?`/`can-write?` for the old permissions system. `true` if the current user has *partial*
+  permissions for any one of the the paths returned by its implementation of `perms-objects-set`. (`read-or-write` is
+  either `:read` or `:write` and passed to `perms-objects-set`; you'll usually want to partially bind it in the
+  implementation map)."
+  (partial check-perms-with-fn 'metabase.models.permissions/set-has-any-partial-permissions-for-set?))

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -241,11 +241,11 @@
   "Methods for determining whether the current user has read/write permissions for a given object. See documentation
   for [[metabase.models.permissions]] for a high-level overview of the Metabase permissions system."
 
-  (perms-objects-set [instance ^clojure.lang.Keyword perm-type]
+  (perms-objects-set [instance ^clojure.lang.Keyword read-or-write]
     "Return a set of permissions object paths that a user must have access to in order to access this object. This
-    should be something like #{\"/db/1/schema/public/table/20/\"}. `perm-type` will typically be either `:read` or
-    `:write`, depending on which permissions set we're fetching (these will be the same sets for most models; they can
-    ignore this param).")
+    should be something like #{\"/db/1/schema/public/table/20/\"}. `read-or-write` will be either `:read` or `:write`,
+    depending on which permissions set we're fetching (these will be the same sets for most models; they can ignore
+    this param).")
 
   (can-read? [instance] [entity ^Integer id]
     "Return whether `*current-user*` has *read* permissions for an object. You should typically use one of these
@@ -317,13 +317,13 @@
   (contains? (current-user-permissions-set) "/"))
 
 (defn- check-perms-with-fn
-  ([fn-symb perm-type entity object-id]
+  ([fn-symb read-or-write entity object-id]
    (or (current-user-has-root-permissions?)
-       (check-perms-with-fn fn-symb perm-type (entity object-id))))
+       (check-perms-with-fn fn-symb read-or-write (entity object-id))))
 
-  ([fn-symb perm-type object]
+  ([fn-symb read-or-write object]
    (and object
-        (check-perms-with-fn fn-symb (perms-objects-set object perm-type))))
+        (check-perms-with-fn fn-symb (perms-objects-set object read-or-write))))
 
   ([fn-symb perms-set]
    (let [f (requiring-resolve fn-symb)]
@@ -331,21 +331,21 @@
      (u/prog1 (f (current-user-permissions-set) perms-set)
        (log/tracef "Perms check: %s -> %s" (pr-str (list fn-symb (current-user-permissions-set) perms-set)) <>)))))
 
-(def ^{:arglists '([perm-type entity object-id] [perm-type object] [perms-set])}
+(def ^{:arglists '([read-or-write entity object-id] [read-or-write object] [perms-set])}
   current-user-has-full-permissions?
   "Implementation of `can-read?`/`can-write?` for the old permissions system. `true` if the current user has *full*
-  permissions for the paths returned by its implementation of `perms-objects-set`. (`perm-type` is typically `:read` or
+  permissions for the paths returned by its implementation of `perms-objects-set`. (`read-or-write` is either `:read` or
   `:write` and passed to `perms-objects-set`; you'll usually want to partially bind it in the implementation map)."
   (partial check-perms-with-fn 'metabase.models.permissions/set-has-full-permissions-for-set?))
 
-(def ^{:arglists '([perm-type entity object-id] [perm-type object] [perms-set])}
+(def ^{:arglists '([read-or-write entity object-id] [read-or-write object] [perms-set])}
   current-user-has-partial-permissions?
   "Implementation of `can-read?`/`can-write?` for the old permissions system. `true` if the current user has *partial*
-  permissions for the paths returned by its implementation of `perms-objects-set`. (`perm-type` is typically `:read` or
+  permissions for the paths returned by its implementation of `perms-objects-set`. (`read-or-write` is either `:read` or
   `:write` and passed to `perms-objects-set`; you'll usually want to partially bind it in the implementation map)."
   (partial check-perms-with-fn 'metabase.models.permissions/set-has-partial-permissions-for-set?))
 
-(defn check-any
+(defn has-any-permissions?
   "Accepts multiple permission-checking functions, such as the ones returned by `current-user-has-full-permissions?`
   and `current-user-has-partial-permissions?`, and returns a function which returns true if any permission functions
   return true."

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -241,11 +241,11 @@
   "Methods for determining whether the current user has read/write permissions for a given object. See documentation
   for [[metabase.models.permissions]] for a high-level overview of the Metabase permissions system."
 
-  (perms-objects-set [instance ^clojure.lang.Keyword read-or-write]
+  (perms-objects-set [instance ^clojure.lang.Keyword perm-type]
     "Return a set of permissions object paths that a user must have access to in order to access this object. This
-    should be something like #{\"/db/1/schema/public/table/20/\"}. `read-or-write` will be either `:read` or `:write`,
-    depending on which permissions set we're fetching (these will be the same sets for most models; they can ignore
-    this param).")
+    should be something like #{\"/db/1/schema/public/table/20/\"}. `perm-type` will typically be either `:read` or
+    `:write`, depending on which permissions set we're fetching (these will be the same sets for most models; they
+    can ignore this param).")
 
   (can-read? [instance] [entity ^Integer id]
     "Return whether `*current-user*` has *read* permissions for an object. You should typically use one of these
@@ -317,13 +317,13 @@
   (contains? (current-user-permissions-set) "/"))
 
 (defn- check-perms-with-fn
-  ([fn-symb read-or-write entity object-id]
+  ([fn-symb perm-type entity object-id]
    (or (current-user-has-root-permissions?)
-       (check-perms-with-fn fn-symb read-or-write (entity object-id))))
+       (check-perms-with-fn fn-symb perm-type (entity object-id))))
 
-  ([fn-symb read-or-write object]
+  ([fn-symb perm-type object]
    (and object
-        (check-perms-with-fn fn-symb (perms-objects-set object read-or-write))))
+        (check-perms-with-fn fn-symb (perms-objects-set object perm-type))))
 
   ([fn-symb perms-set]
    (let [f (requiring-resolve fn-symb)]
@@ -331,18 +331,20 @@
      (u/prog1 (f (current-user-permissions-set) perms-set)
        (log/tracef "Perms check: %s -> %s" (pr-str (list fn-symb (current-user-permissions-set) perms-set)) <>)))))
 
-(def ^{:arglists '([read-or-write entity object-id] [read-or-write object] [perms-set])}
+(def ^{:arglists '([perm-type entity object-id] [perm-type object] [perms-set])}
   current-user-has-full-permissions?
   "Implementation of `can-read?`/`can-write?` for the old permissions system. `true` if the current user has *full*
-  permissions for the paths returned by its implementation of `perms-objects-set`. (`read-or-write` is either `:read` or
-  `:write` and passed to `perms-objects-set`; you'll usually want to partially bind it in the implementation map)."
+  permissions for the paths returned by its implementation of `perms-objects-set`. (`perm-type` is typically either
+  `:read` or `:write` and passed to `perms-objects-set`; you'll usually want to partially bind it in the implementation
+  map)."
   (partial check-perms-with-fn 'metabase.models.permissions/set-has-full-permissions-for-set?))
 
-(def ^{:arglists '([read-or-write entity object-id] [read-or-write object] [perms-set])}
+(def ^{:arglists '([perm-type entity object-id] [perm-type object] [perms-set])}
   current-user-has-partial-permissions?
   "Implementation of `can-read?`/`can-write?` for the old permissions system. `true` if the current user has *partial*
-  permissions for the paths returned by its implementation of `perms-objects-set`. (`read-or-write` is either `:read` or
-  `:write` and passed to `perms-objects-set`; you'll usually want to partially bind it in the implementation map)."
+  permissions for the paths returned by its implementation of `perms-objects-set`. (`perm-type` is typically either
+  `:read` or `:write` and passed to `perms-objects-set`; you'll usually want to partially bind it in the implementation
+  map)."
   (partial check-perms-with-fn 'metabase.models.permissions/set-has-partial-permissions-for-set?))
 
 (defn has-any-permissions?

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -241,11 +241,11 @@
   "Methods for determining whether the current user has read/write permissions for a given object. See documentation
   for [[metabase.models.permissions]] for a high-level overview of the Metabase permissions system."
 
-  (perms-objects-set [instance ^clojure.lang.Keyword perm-type]
+  (perms-objects-set [instance ^clojure.lang.Keyword read-or-write]
     "Return a set of permissions object paths that a user must have access to in order to access this object. This
-    should be something like #{\"/db/1/schema/public/table/20/\"}. `perm-type` will typically be either `:read` or
-    `:write`, depending on which permissions set we're fetching (these will be the same sets for most models; they
-    can ignore this param).")
+    should be something like #{\"/db/1/schema/public/table/20/\"}. `read-or-write` will be either `:read` or `:write`,
+    depending on which permissions set we're fetching (these will be the same sets for most models; they can ignore
+    this param).")
 
   (can-read? [instance] [entity ^Integer id]
     "Return whether `*current-user*` has *read* permissions for an object. You should typically use one of these
@@ -317,13 +317,13 @@
   (contains? (current-user-permissions-set) "/"))
 
 (defn- check-perms-with-fn
-  ([fn-symb perm-type entity object-id]
+  ([fn-symb read-or-write entity object-id]
    (or (current-user-has-root-permissions?)
-       (check-perms-with-fn fn-symb perm-type (entity object-id))))
+       (check-perms-with-fn fn-symb read-or-write (entity object-id))))
 
-  ([fn-symb perm-type object]
+  ([fn-symb read-or-write object]
    (and object
-        (check-perms-with-fn fn-symb (perms-objects-set object perm-type))))
+        (check-perms-with-fn fn-symb (perms-objects-set object read-or-write))))
 
   ([fn-symb perms-set]
    (let [f (requiring-resolve fn-symb)]
@@ -331,20 +331,18 @@
      (u/prog1 (f (current-user-permissions-set) perms-set)
        (log/tracef "Perms check: %s -> %s" (pr-str (list fn-symb (current-user-permissions-set) perms-set)) <>)))))
 
-(def ^{:arglists '([perm-type entity object-id] [perm-type object] [perms-set])}
+(def ^{:arglists '([read-or-write entity object-id] [read-or-write object] [perms-set])}
   current-user-has-full-permissions?
   "Implementation of `can-read?`/`can-write?` for the old permissions system. `true` if the current user has *full*
-  permissions for the paths returned by its implementation of `perms-objects-set`. (`perm-type` is typically either
-  `:read` or `:write` and passed to `perms-objects-set`; you'll usually want to partially bind it in the implementation
-  map)."
+  permissions for the paths returned by its implementation of `perms-objects-set`. (`read-or-write` is either `:read` or
+  `:write` and passed to `perms-objects-set`; you'll usually want to partially bind it in the implementation map)."
   (partial check-perms-with-fn 'metabase.models.permissions/set-has-full-permissions-for-set?))
 
-(def ^{:arglists '([perm-type entity object-id] [perm-type object] [perms-set])}
+(def ^{:arglists '([read-or-write entity object-id] [read-or-write object] [perms-set])}
   current-user-has-partial-permissions?
   "Implementation of `can-read?`/`can-write?` for the old permissions system. `true` if the current user has *partial*
-  permissions for the paths returned by its implementation of `perms-objects-set`. (`perm-type` is typically either
-  `:read` or `:write` and passed to `perms-objects-set`; you'll usually want to partially bind it in the implementation
-  map)."
+  permissions for the paths returned by its implementation of `perms-objects-set`. (`read-or-write` is either `:read` or
+  `:write` and passed to `perms-objects-set`; you'll usually want to partially bind it in the implementation map)."
   (partial check-perms-with-fn 'metabase.models.permissions/set-has-partial-permissions-for-set?))
 
 (defn has-any-permissions?

--- a/src/metabase/models/permissions.clj
+++ b/src/metabase/models/permissions.clj
@@ -563,13 +563,6 @@
   (every? (partial set-has-partial-permissions? permissions-set)
           paths-set))
 
-(s/defn set-has-any-partial-permissions-for-set? :- s/Bool
-  "Do the permissions paths in `permissions-set` grant *partial* access to *any* the object paths in `paths-set`?"
-  [permissions-set paths-set]
-  (boolean
-   (some (partial set-has-partial-permissions? permissions-set)
-         paths-set)))
-
 (s/defn set-has-general-permission-of-type? :- s/Bool
   "Does `permissions-set` grant *full* access to a general permission of type `perm-type`?"
   [permissions-set perm-type]

--- a/src/metabase/models/permissions.clj
+++ b/src/metabase/models/permissions.clj
@@ -566,8 +566,9 @@
 (s/defn set-has-any-partial-permissions-for-set? :- s/Bool
   "Do the permissions paths in `permissions-set` grant *partial* access to *any* the object paths in `paths-set`?"
   [permissions-set paths-set]
-  (some (partial set-has-partial-permissions? permissions-set)
-        paths-set))
+  (boolean
+   (some (partial set-has-partial-permissions? permissions-set)
+         paths-set)))
 
 (s/defn set-has-general-permission-of-type? :- s/Bool
   "Does `permissions-set` grant *full* access to a general permission of type `perm-type`?"

--- a/src/metabase/models/permissions.clj
+++ b/src/metabase/models/permissions.clj
@@ -563,6 +563,12 @@
   (every? (partial set-has-partial-permissions? permissions-set)
           paths-set))
 
+(s/defn set-has-any-partial-permissions-for-set? :- s/Bool
+  "Do the permissions paths in `permissions-set` grant *partial* access to *any* the object paths in `paths-set`?"
+  [permissions-set paths-set]
+  (some (partial set-has-partial-permissions? permissions-set)
+        paths-set))
+
 (s/defn set-has-general-permission-of-type? :- s/Bool
   "Does `permissions-set` grant *full* access to a general permission of type `perm-type`?"
   [permissions-set perm-type]

--- a/src/metabase/models/permissions.clj
+++ b/src/metabase/models/permissions.clj
@@ -485,12 +485,12 @@
   "Returns the permission path required to edit the table specified by the provided args, or a field in the table.
   If Enterprise Edition code is available, and a valid :advanced-permissions token is present, returns the data model
   permissions path for the table. Otherwise, defaults to the root path ('/'), thus restricting writes to admins."
-  [db-id schema table-id]
+  [& path-components]
   (let [f (u/ignore-exceptions
            (classloader/require 'metabase-enterprise.advanced-permissions.models.permissions)
            (resolve 'metabase-enterprise.advanced-permissions.models.permissions/data-model-write-perms-path))]
     (if (and f (premium-features/enable-advanced-permissions?))
-      (f db-id schema table-id)
+      (apply f path-components)
       "/")))
 
 (s/defn db-details-write-perms-path :- Path

--- a/src/metabase/models/secret.clj
+++ b/src/metabase/models/secret.clj
@@ -258,11 +258,11 @@
       (= :file-path src) ; for file path sources only, populate the value
       (assoc (subprop "-value") (value->string secret*)))))
 
-(defn admin-expand-db-details-inferred-secret-values
-  "Expand certain inferred secret sub-properties in the `database` `:details`, for the purpose of serving admin
-  requests (ex: to edit an existing database or view its current details).  This is to populate certain values that
-  shouldn't be stored in the details blob itself, but which can be derived from the details->secret association itself.
-  Refer to the docstring for [[expand-inferred-secret-values]] for full details."
+(defn expand-db-details-inferred-secret-values
+  "Expand certain inferred secret sub-properties in the `database` `:details`, for the purpose of serving requests by
+  users with write permissions for the DB (ex: to edit an existing database or view its current details). This is to
+  populate certain values that shouldn't be stored in the details blob itself, but which can be derived from the
+  details->secret association itself. Refer to the docstring for [[expand-inferred-secret-values]] for full details."
   {:added "0.42.0"}
   [database]
   (update database :details (fn [details]

--- a/src/metabase/models/table.clj
+++ b/src/metabase/models/table.clj
@@ -54,7 +54,7 @@
   ;;     data-model permissions for othe table
   ;;   * Else, you must be an admin
   (case read-or-write
-    :read #{(perms/data-perms-path db-id)}
+    :read #{(perms/table-read-path table-id)}
     :write #{(perms/data-model-write-perms-path db-id schema table-id)}))
 
 (u/strict-extend (class Table)

--- a/src/metabase/models/table.clj
+++ b/src/metabase/models/table.clj
@@ -45,15 +45,18 @@
 (defn- pre-delete [{:keys [db_id schema id]}]
   (db/delete! Permissions :object [:like (str (perms/data-perms-path db_id schema id) "%")]))
 
-(defn- perms-objects-set [table read-or-write]
-  ;; To read (e.g., fetch metadata) a Table you (predictably) have read permissions
+(defn- perms-objects-set [{db-id :db_id, schema :schema, table-id :id} read-or-write]
+  ;; To read (e.g., fetch metadata) a Table you either must have data permissions for the Table, or write permissions
+  ;; for the Table (detailed below).
+  ;;
   ;; To write a Table (e.g. update its metadata):
   ;;   * If Enterprise Edition code is available and the :advanced-permissions feature is enabled, you must have
   ;;     data-model permissions for othe table
   ;;   * Else, you must be an admin
-  #{(case read-or-write
-      :read  (perms/table-read-path table)
-      :write (perms/data-model-write-perms-path (:db_id table) (:schema table) (:id table)))})
+  (case read-or-write
+    :read #{(perms/data-perms-path db-id)
+            (perms/data-model-write-perms-path db-id schema table-id)}
+    :write #{(perms/data-model-write-perms-path db-id schema table-id)}))
 
 (u/strict-extend (class Table)
   models/IModel
@@ -67,7 +70,7 @@
           :pre-delete     pre-delete})
   i/IObjectPermissions
   (merge i/IObjectPermissionsDefaults
-         {:can-read?         (partial i/current-user-has-full-permissions? :read)
+         {:can-read?         (partial i/current-user-has-any-partial-permissions? :read)
           :can-write?        (partial i/current-user-has-full-permissions? :write)
           :perms-objects-set perms-objects-set}))
 

--- a/src/metabase/models/table.clj
+++ b/src/metabase/models/table.clj
@@ -45,7 +45,7 @@
 (defn- pre-delete [{:keys [db_id schema id]}]
   (db/delete! Permissions :object [:like (str (perms/data-perms-path db_id schema id) "%")]))
 
-(defn- perms-objects-set [{db-id :db_id, schema :schema, table-id :id} read-or-write]
+(defn- perms-objects-set [{db-id :db_id, schema :schema, table-id :id, :as table} read-or-write]
   ;; To read (e.g., fetch metadata) a Table you must have either self-service data permissions for the Table, or write
   ;; permissions for the Table (detailed below). Since a user can have one or the other, we use `i/has-any-permissions?`
   ;; to check both read and write permission sets in the `can-read?` implementation.
@@ -55,7 +55,7 @@
   ;;     data-model permissions for othe table
   ;;   * Else, you must be an admin
   #{(case read-or-write
-      :read (perms/table-read-path table-id)
+      :read  (perms/table-read-path table)
       :write (perms/data-model-write-perms-path db-id schema table-id))})
 
 (u/strict-extend (class Table)

--- a/src/metabase/models/table.clj
+++ b/src/metabase/models/table.clj
@@ -54,8 +54,7 @@
   ;;     data-model permissions for othe table
   ;;   * Else, you must be an admin
   (case read-or-write
-    :read #{(perms/data-perms-path db-id)
-            (perms/data-model-write-perms-path db-id schema table-id)}
+    :read #{(perms/data-perms-path db-id)}
     :write #{(perms/data-model-write-perms-path db-id schema table-id)}))
 
 (u/strict-extend (class Table)
@@ -70,7 +69,9 @@
           :pre-delete     pre-delete})
   i/IObjectPermissions
   (merge i/IObjectPermissionsDefaults
-         {:can-read?         (partial i/current-user-has-any-partial-permissions? :read)
+         {:can-read?         (i/check-any
+                              (partial i/current-user-has-full-permissions? :read)
+                              (partial i/current-user-has-full-permissions? :write))
           :can-write?        (partial i/current-user-has-full-permissions? :write)
           :perms-objects-set perms-objects-set}))
 


### PR DESCRIPTION
### The problem

We added new feature-level permissions that can give a user write access for a DB's connection details and/or its data model. However, these permissions are orthogonal to data perms: a user can have permissions to manage a DB and its data model while not having permission to access its data.

Currently, the way read permissions are implemented for the `Database` and `Table` models only checks for data permissions. This causes `GET` requests to fail for users without data permissions, but with DB details or data model permissions.

### The solution

Essentially, when doing read permission checks on `Database` or `Table` models, we need to check for access to two separate permissions paths: the read permissions path for the DB/Table, _or_ the relevant feature-level write permissions path (DB details or data model). A user should be given read permissions for the model if they have access to at least one of these two paths.

I've implemented this by adding a new `has-any-permissions?` function in `metabase.models.interface` which essentially combines two existing permission checking functions into one. This seemed to be like a straightforward approach that didn't require refactoring too much of the existing code.

I've also updated a couple more spots to call `can-write?` instead of just doing a superuser check, so that they pass for users with the relevant feature-level perms as well. (These are spots that I missed in the first pass)