### PR TITLE
Allow to update ldap setting without re-entering password

### DIFF
--- a/src/metabase/api/ldap.clj
+++ b/src/metabase/api/ldap.clj
@@ -86,6 +86,14 @@
         #"(?s).*"
         {:message message}))))
 
+(defn- update-password-if-needed
+  "Do not update password if `new-password` is an obfuscated value of the current password."
+  [new-password]
+  (let [current-password (setting/get :ldap-password)]
+    (if (= (setting/obfuscate-value current-password) new-password)
+      current-password
+      new-password)))
+
 (api/defendpoint PUT "/settings"
   "Update LDAP related settings. You must be a superuser to do this."
   [:as {settings :body}]
@@ -94,7 +102,8 @@
   (let [ldap-settings (-> settings
                           (select-keys (keys mb-settings->ldap-details))
                           (assoc :ldap-port (when-let [^String ldap-port (not-empty (str (:ldap-port settings)))]
-                                              (Long/parseLong ldap-port))))
+                                              (Long/parseLong ldap-port)))
+                          (update :ldap-password update-password-if-needed))
         ldap-details  (set/rename-keys ldap-settings mb-settings->ldap-details)
         results       (if-not (:ldap-enabled settings)
                         ;; when disabled just respond with a success message

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -953,7 +953,7 @@
       (cache/restore-cache!)
       (throw e))))
 
-(defn- obfuscate-value
+(defn obfuscate-value
   "Obfuscate the value of sensitive Setting. We'll still show the last 2 characters so admins can still check that the
   value is what's expected (e.g. the correct password).
 

--- a/test/metabase/api/ldap_test.clj
+++ b/test/metabase/api/ldap_test.clj
@@ -3,6 +3,7 @@
             [clojure.test :refer :all]
             [metabase.api.ldap :as ldap-api]
             [metabase.integrations.ldap :as ldap]
+            [metabase.models.setting :as setting]
             [metabase.test :as mt]
             [metabase.test.integrations.ldap :as ldap.test]))
 
@@ -35,6 +36,10 @@
         (mt/user-http-request :crowberto :put 200 "ldap/settings"
                               (assoc (ldap-test-details) :ldap-port "" :ldap-enabled false))
         (is (= 389 (ldap/ldap-port))))
+
+      (testing "Could update with obfuscated password"
+        (mt/user-http-request :crowberto :put 200 "ldap/settings"
+                              (update (ldap-test-details) :ldap-password #(setting/obfuscate-value %))))
 
       (testing "Requires superusers"
         (is (= "You don't have permissions to do that."


### PR DESCRIPTION
Fix https://github.com/metabase/metabase/issues/16708