### PR TITLE
Fix performance of collections when editing

### DIFF
--- a/frontend/src/metabase/lib/entities.js
+++ b/frontend/src/metabase/lib/entities.js
@@ -421,12 +421,12 @@ export function createEntity(def) {
   );
 
   const getList = createSelector(
-    [state => state, getEntityIds],
+    [getEntities, getEntityIds],
     // delegate to getObject
-    (state, entityIds) =>
+    (entities, entityIds) =>
       entityIds &&
       entityIds
-        .map(entityId => entity.selectors.getObject(state, { entityId }))
+        .map(entityId => entity.selectors.getObject({ entities }, { entityId }))
         .filter(e => e != null), // deleted entities might remain in lists
   );
 

--- a/frontend/src/metabase/lib/entities.js
+++ b/frontend/src/metabase/lib/entities.js
@@ -391,7 +391,7 @@ export function createEntity(def) {
   const getObject = createCachedSelector(
     [getEntities, getEntityId],
     (entities, entityId) => denormalize(entityId, entity.schema, entities),
-  )((state, { entityId }) =>
+  )((state, { entityId } = {}) =>
     typeof entityId === "object" ? JSON.stringify(entityId) : entityId,
   ); // must stringify objects
 
@@ -420,15 +420,17 @@ export function createEntity(def) {
     entities => entities && entities.metadata,
   );
 
-  const getList = createSelector(
+  const getList = createCachedSelector(
     [getEntities, getEntityIds],
     // delegate to getObject
     (entities, entityIds) =>
       entityIds &&
       entityIds
         .map(entityId => entity.selectors.getObject({ entities }, { entityId }))
-        .filter(e => e != null), // deleted entities might remain in lists
-  );
+        .filter(e => e != null), // deleted entities might remain in lists,
+  )((state, { entityQuery } = {}) => {
+    return entityQuery ? JSON.stringify(entityQuery) : "";
+  });
 
   // REQUEST STATE SELECTORS
 


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/19297

There are underlying issues while the collection list was rendered each time someone enters a value in a form:
- `getList` selector relied on the whole `state`, making it rerun each time the state changes
- `getList` was called with different arguments because it was used with different `entityQuery`

The solution is similar to how `getObject` is implemented:
- Make sure the selector doesn't rely on pieces of state that are changed by `redux-form`, e.g. the whole state
- Cache `reselector` selectors with `createCachedSelector`.
https://github.com/metabase/metabase/blob/29595dfcfbbe8b1bdc483f188f244f47cc035d24/frontend/src/metabase/lib/entities.js#L391

How to test:
- Open `/collection/root/new_collection`
- Run React profiler
- Focus and blur the first field in the form
- Make sure that the collection list is not re-rendered each time

**Before**
<img width="1728" alt="Screenshot 2022-04-18 at 11 50 07" src="https://user-images.githubusercontent.com/8542534/163783363-837a8eb3-99f9-4e40-a72e-a54dc8b8c84f.png">

**After**
<img width="847" alt="Screenshot 2022-04-18 at 11 49 18" src="https://user-images.githubusercontent.com/8542534/163783400-12fe973b-99f6-4707-b278-2637039820cd.png">
