### PR TITLE
Fix typo 'application' -> 'aplication'

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/api/application.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/api/application.clj
@@ -1,6 +1,6 @@
 (ns metabase-enterprise.advanced-permissions.api.application
-  "`/advanced-permisisons/aplication` Routes.
-  Implements the Permissions routes needed for aplication permission - a class of permissions that control access to features
+  "`/advanced-permisisons/application` Routes.
+  Implements the Permissions routes needed for application permission - a class of permissions that control access to features
   like access Setting pages, access monitoring tools ... etc"
   (:require [compojure.core :refer [GET PUT]]
             [metabase-enterprise.advanced-permissions.models.permissions.application-permissions :as a-perms]
@@ -12,16 +12,16 @@
   (api/check-superuser)
   (a-perms/graph))
 
-(defn- dejsonify-aplication-permissions
-  [aplication-permissions]
-  (into {} (for [[perm-type perm-value] aplication-permissions]
+(defn- dejsonify-application-permissions
+  [application-permissions]
+  (into {} (for [[perm-type perm-value] application-permissions]
              [perm-type (keyword perm-value)])))
 
 (defn- dejsonify-groups
   [groups]
-  (into {} (for [[group-id aplication-permissions] groups]
+  (into {} (for [[group-id application-permissions] groups]
              [(Integer/parseInt (name group-id))
-              (dejsonify-aplication-permissions aplication-permissions)])))
+              (dejsonify-application-permissions application-permissions)])))
 
 (defn- dejsonify-graph
   "Fix the types in the graph when it comes in from the API, e.g. converting things like `\"yes\"` to `:yes` and


### PR DESCRIPTION
Fix Typo 'application' -> 'aplication' in #21709