### PR TITLE
Run `backend.js` with `node` rather than `babel-node`

### DIFF
--- a/frontend/test/__runner__/backend.js
+++ b/frontend/test/__runner__/backend.js
@@ -1,11 +1,11 @@
-import fs from "fs-promise";
-import os from "os";
-import path from "path";
-import { spawn } from "child_process";
+const fs = require("fs-promise");
+const os = require("os");
+const path = require("path");
+const { spawn } = require("child_process");
 
-import fetch from "isomorphic-fetch";
+const fetch = require("isomorphic-fetch");
 
-export const DEFAULT_DB_KEY = "/test_db_fixture.db";
+const DEFAULT_DB_KEY = "/test_db_fixture.db";
 
 let testDbId = 0;
 const getDbFile = () =>
@@ -14,7 +14,7 @@ const getDbFile = () =>
 let port = 4000;
 const getPort = () => port++;
 
-export const BackendResource = createSharedResource("BackendResource", {
+const BackendResource = createSharedResource("BackendResource", {
   getKey({ dbKey = DEFAULT_DB_KEY }) {
     return dbKey || {};
   },
@@ -124,7 +124,7 @@ export const BackendResource = createSharedResource("BackendResource", {
   },
 });
 
-export async function isReady(host) {
+async function isReady(host) {
   try {
     const response = await fetch(`${host}/api/health`);
     if (response.status === 200) {
@@ -191,3 +191,5 @@ function createSharedResource(
 function delay(duration) {
   return new Promise((resolve, reject) => setTimeout(resolve, duration));
 }
+
+module.exports = { DEFAULT_DB_KEY, BackendResource, isReady };

--- a/frontend/test/__runner__/backend.js
+++ b/frontend/test/__runner__/backend.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 const fs = require("fs-promise");
 const os = require("os");
 const path = require("path");

--- a/package.json
+++ b/package.json
@@ -297,7 +297,7 @@
     "ci": "yarn ci-frontend && yarn ci-backend",
     "ci-frontend": "yarn lint && yarn test",
     "ci-backend": "clojure -X:dev:ee:ee-dev:drivers:drivers-dev:eastwood && clojure -X:dev:test",
-    "test-cypress-run": "babel-node ./frontend/test/__runner__/run_cypress_tests.js",
+    "test-cypress-run": "node ./frontend/test/__runner__/run_cypress_tests.js",
     "test-cypress-open": "./bin/build-for-test && yarn test-cypress-run --open",
     "test-cypress-open-no-backend": "E2E_HOST='http://localhost:3000' yarn test-cypress-run --open",
     "test-cypress": "yarn build && ./bin/build-for-test && yarn test-cypress-run",


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Converts `backend.js` (file used to spin up the separate backend for Cypress) to use NodeJS modules, which allows us to run it using `node`, rather than `babel-node`
- We had to use Babel previously because we used ES modules

### Why?
Although we will not see any significant performance improvements on a file this size, this was mostly done for the sake of consistency. All other scripts used for E2E tests can be run with pure NodeJS.