### PR TITLE
Move settings popover up so it doesn't overlap its button

### DIFF
--- a/frontend/src/metabase/components/EntityMenu.jsx
+++ b/frontend/src/metabase/components/EntityMenu.jsx
@@ -65,7 +65,7 @@ class EntityMenu extends Component {
           hasArrow={false}
           hasBackground={false}
           horizontalAttachments={["left", "right"]}
-          targetOffsetY={0}
+          targetOffsetY={20}
         >
           {/* Note: @kdoh 10/12/17
            * React Motion has a flow type problem with children see


### PR DESCRIPTION
### After

<img width="400" alt="image" src="https://user-images.githubusercontent.com/380816/163796279-689f7ec1-cc4d-44bd-be2e-76878f22981a.png">

### Before

<img width="400" alt="image" src="https://user-images.githubusercontent.com/380816/163796553-76670724-8fd8-41b3-a037-1fc82b1f9803.png">

