### PR TITLE
Fix padding for error messages in setup

### DIFF
--- a/frontend/src/metabase/components/form/CustomForm.jsx
+++ b/frontend/src/metabase/components/form/CustomForm.jsx
@@ -241,7 +241,7 @@ CustomFormSubmit.contextTypes = {
 };
 
 export const CustomFormMessage = (props, { error }) =>
-  error ? <FormMessage message={error} formError /> : null;
+  error ? <FormMessage {...props} message={error} formError /> : null;
 CustomFormMessage.contextTypes = {
   error: PropTypes.string,
 };
@@ -314,7 +314,7 @@ export const CustomFormFooter = (
         </Button>
       )}
       <div className="flex-full" />
-      <CustomFormMessage />
+      <CustomFormMessage className="ml1" noPadding />
       {footerExtraButtons}
     </div>
   );

--- a/frontend/src/metabase/components/form/FormMessage.jsx
+++ b/frontend/src/metabase/components/form/FormMessage.jsx
@@ -9,7 +9,7 @@ export const UNKNOWN_ERROR_MESSAGE = t`Unknown error encountered`;
 
 export default class FormMessage extends Component {
   render() {
-    const { className, formSuccess, message } = this.props;
+    const { className, message, formSuccess, noPadding } = this.props;
 
     const treatedMessage = getMessage(this.props);
 
@@ -17,6 +17,7 @@ export default class FormMessage extends Component {
       <FormMessageStyled
         className={className}
         visible={!!message}
+        noPadding={noPadding}
         hasSucceeded={formSuccess}
       >
         {treatedMessage}

--- a/frontend/src/metabase/components/form/FormMessage.styled.jsx
+++ b/frontend/src/metabase/components/form/FormMessage.styled.jsx
@@ -9,7 +9,7 @@ export const FormMessageStyled = styled.span`
     hasSucceeded ? color("success") : color("error")};
   float: left;
   opacity: 0;
-  padding-bottom: ${space(2)};
+  padding-bottom: ${({ noPadding }) => (noPadding ? "" : space(2))};
   transition: none;
   width: 100%;
 


### PR DESCRIPTION
Related to https://github.com/metabase/metabase/issues/10646

Slightly fixes padding for error messages in our forms. 

How to test:
- Run a fresh Metabase instance
- On the database step enter some invalid info and click `Next`
- You should see an error message as on the screenshot below

<img width="753" alt="Screenshot 2022-04-18 at 15 44 29" src="https://user-images.githubusercontent.com/8542534/163811435-12661406-334d-4b90-a658-8c34f5395874.png">
