### PR TITLE
Make partial= test helper take exactly two arguments

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -16,7 +16,7 @@
                       (clojure.core.logic/matcha)
                       (clojure.core.logic/run)
                       (metabase.test/with-temporary-setting-values)
-                      (clojure.test/is [query= sql=])
+                      (clojure.test/is [query= sql= partial=])
                       (toucan.util.test/with-temp*)
                       (metabase.test/with-temp*)
                       (taoensso.nippy/extend-freeze)

--- a/test/metabase/test_runner/assert_exprs.clj
+++ b/test/metabase/test_runner/assert_exprs.clj
@@ -119,10 +119,9 @@
 
 (defmethod t/assert-expr 'partial=
   [message [_ expected actual :as form]]
-  `(do
-     (assert (= 2 ~(count (rest form))) "partial= expects exactly 2 arguments")
-     (t/do-report
-       (partial=-report ~message ~expected ~actual))))
+  (assert (= (count (rest form)) 2) "partial= expects exactly 2 arguments")
+  `(t/do-report
+    (partial=-report ~message ~expected ~actual)))
 
 (defn sql=-report
   [message expected query]

--- a/test/metabase/test_runner/assert_exprs.clj
+++ b/test/metabase/test_runner/assert_exprs.clj
@@ -69,7 +69,7 @@
            `(t/do-report
              (query=-report ~message ~expected ~actual)))))
 
-;; `partial=` is like `=` but only compares stuff (using [[data/diff]] that's in `expected`. Anything else is ignored.
+;; `partial=` is like `=` but only compares stuff (using [[data/diff]]) that's in `expected`. Anything else is ignored.
 
 (defn- remove-keys-not-in-expected
   "Remove all the extra stuff (i.e. extra map keys or extra sequence elements) from the `actual` diff that's not
@@ -118,10 +118,10 @@
      :diffs    [[actual [only-in-expected only-in-actual]]]}))
 
 (defmethod t/assert-expr 'partial=
-  [message [_ expected & actuals]]
-  `(do ~@(for [actual actuals]
-           `(t/do-report
-             (partial=-report ~message ~expected ~actual)))))
+  [message [_ expected actual]]
+  {:pre [(some? expected) (some? actual)]}
+  `(t/do-report
+     (partial=-report ~message ~expected ~actual)))
 
 (defn sql=-report
   [message expected query]

--- a/test/metabase/test_runner/assert_exprs.clj
+++ b/test/metabase/test_runner/assert_exprs.clj
@@ -118,10 +118,11 @@
      :diffs    [[actual [only-in-expected only-in-actual]]]}))
 
 (defmethod t/assert-expr 'partial=
-  [message [_ expected actual]]
-  {:pre [(some? expected) (some? actual)]}
-  `(t/do-report
-     (partial=-report ~message ~expected ~actual)))
+  [message [_ expected actual :as form]]
+  `(do
+     (assert (= 2 ~(count (rest form))) "partial= expects exactly 2 arguments")
+     (t/do-report
+       (partial=-report ~message ~expected ~actual))))
 
 (defn sql=-report
   [message expected query]


### PR DESCRIPTION
Fixes #21454.

`(= 2) ;=> true` and `partial=` followed that pattern. It leads to
confusing test assertions that silently succeed.

It's possible to extend this to support >= 2 arguments instead, but I'm
keeping it simple for now.