### PR TITLE
Fix checks for template tags

### DIFF
--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -525,24 +525,25 @@ export const initializeQB = (location, params) => {
             }
           }
         }
+
+        const dbId = card.database_id;
+        let database = Databases.selectors.getObject(getState(), {
+          entityId: dbId,
+        });
+        // if we haven't already loaded this database, block on loading dbs now so we can check write permissions
+        if (!database) {
+          await dispatch(Databases.actions.fetchList());
+          database = Databases.selectors.getObject(getState(), {
+            entityId: dbId,
+          });
+        }
+
         // if this card has any snippet tags we might need to fetch snippets pending permissions
         if (
           Object.values(
             getIn(card, ["dataset_query", "native", "template-tags"]) || {},
           ).filter(t => t.type === "snippet").length > 0
         ) {
-          const dbId = card.database_id;
-          let database = Databases.selectors.getObject(getState(), {
-            entityId: dbId,
-          });
-          // if we haven't already loaded this database, block on loading dbs now so we can check write permissions
-          if (!database) {
-            await dispatch(Databases.actions.fetchList());
-            database = Databases.selectors.getObject(getState(), {
-              entityId: dbId,
-            });
-          }
-
           // database could still be missing if the user doesn't have any permissions
           // if the user has native permissions against this db, fetch snippets
           if (database && database.native_permissions === "write") {

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -525,25 +525,24 @@ export const initializeQB = (location, params) => {
             }
           }
         }
-
-        const dbId = card.database_id;
-        let database = Databases.selectors.getObject(getState(), {
-          entityId: dbId,
-        });
-        // if we haven't already loaded this database, block on loading dbs now so we can check features and write permissions
-        if (!database) {
-          await dispatch(Databases.actions.fetchList());
-          database = Databases.selectors.getObject(getState(), {
-            entityId: dbId,
-          });
-        }
-
         // if this card has any snippet tags we might need to fetch snippets pending permissions
         if (
           Object.values(
             getIn(card, ["dataset_query", "native", "template-tags"]) || {},
           ).filter(t => t.type === "snippet").length > 0
         ) {
+          const dbId = card.database_id;
+          let database = Databases.selectors.getObject(getState(), {
+            entityId: dbId,
+          });
+          // if we haven't already loaded this database, block on loading dbs now so we can check write permissions
+          if (!database) {
+            await dispatch(Databases.actions.fetchList());
+            database = Databases.selectors.getObject(getState(), {
+              entityId: dbId,
+            });
+          }
+
           // database could still be missing if the user doesn't have any permissions
           // if the user has native permissions against this db, fetch snippets
           if (database && database.native_permissions === "write") {
@@ -650,6 +649,10 @@ export const initializeQB = (location, params) => {
     // Fetch the question metadata (blocking)
     if (card) {
       await dispatch(loadMetadataForCard(card));
+    }
+    // Fetch all databases so switching between them works correctly
+    if (!Databases.selectors.getLoaded(getState())) {
+      await dispatch(Databases.actions.fetchList());
     }
 
     let question = card && new Question(card, getMetadata(getState()));

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -530,7 +530,7 @@ export const initializeQB = (location, params) => {
         let database = Databases.selectors.getObject(getState(), {
           entityId: dbId,
         });
-        // if we haven't already loaded this database, block on loading dbs now so we can check write permissions
+        // if we haven't already loaded this database, block on loading dbs now so we can check features and write permissions
         if (!database) {
           await dispatch(Databases.actions.fetchList());
           database = Databases.selectors.getObject(getState(), {


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/10927

The issue is cased by this check https://github.com/metabase/metabase/blob/5d5deac1da6aace93a09c017a3c213dcd8542399/frontend/src/metabase-lib/lib/queries/NativeQuery.ts#L419

Previously the database was loaded by the query builder only when there were snippets. It still worked in most cases because other UI components loaded databases, but there are edge cases when it doesn't work. That's why now we explicitly load the database when initializing the query builder.

How to test:
- Follow the steps https://github.com/metabase/metabase/issues/10927#issuecomment-815787298
