### PR TITLE
Repro #21160: Number filter, comma separated values

### DIFF
--- a/frontend/test/metabase/scenarios/native-filters/reproductions/21160.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native-filters/reproductions/21160.cy.spec.js
@@ -1,0 +1,59 @@
+import { restore } from "__support__/e2e/cypress";
+
+const filterName = "Number comma";
+
+const questionDetails = {
+  native: {
+    query: "select count(*) from orders where user_id in ({{number_comma}})",
+    "template-tags": {
+      number_comma: {
+        id: "d8870111-7b0f-26f2-81ce-6ec911e54048",
+        name: "number_comma",
+        "display-name": filterName,
+        type: "number",
+      },
+    },
+  },
+  display: "scalar",
+};
+
+describe("issue 21160", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    cy.createNativeQuestion(questionDetails, { visitQuestion: true });
+  });
+
+  it("number filter should work with values separated by comma (metabase#21160)", () => {
+    getInput().type("1,2,3{enter}", { delay: 0 });
+
+    runQuery();
+    resultAssertion("21");
+
+    getInput()
+      .clear()
+      .type("123,456,789,321{enter}");
+
+    runQuery();
+    resultAssertion("18");
+  });
+});
+
+function runQuery() {
+  cy.findByTestId("qb-header").within(() => {
+    cy.icon("play").click();
+  });
+
+  cy.wait("@cardQuery");
+}
+
+function resultAssertion(res) {
+  cy.get(".ScalarValue")
+    .invoke("text")
+    .should("eq", res);
+}
+
+function getInput() {
+  return cy.findByPlaceholderText(filterName);
+}


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #21160

### How to test this manually?
- `yarn test-cypress-open`
- `metabase/scenarios/native-filters/reproductions/21160.cy.spec.js`
- All tests should pass

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
<img width="1680" alt="image" src="https://user-images.githubusercontent.com/31325167/163831767-208ff8f8-c706-46bf-8fa5-a6ab5a4b55b5.png">

