### PR TITLE
SQL snippets should not always have scrollbars

### DIFF
--- a/frontend/src/metabase/query_builder/components/template_tags/snippet-sidebar/SnippetRow.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/snippet-sidebar/SnippetRow.jsx
@@ -68,8 +68,8 @@ class SnippetRow extends React.Component {
           <div className="px3 pb2 pt1">
             {description && <p className="text-medium mt0">{description}</p>}
             <pre
-              className="bg-light bordered rounded p1 text-monospace text-small text-pre-wrap overflow-scroll overflow-x-scroll"
-              style={{ maxHeight: 320 }}
+              className="bg-light bordered rounded p1 text-monospace text-small text-pre-wrap"
+              style={{ maxHeight: 320, overflow: "auto" }}
             >
               {content}
             </pre>

--- a/frontend/src/metabase/query_builder/components/template_tags/snippet-sidebar/SnippetRow.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/snippet-sidebar/SnippetRow.jsx
@@ -68,8 +68,8 @@ class SnippetRow extends React.Component {
           <div className="px3 pb2 pt1">
             {description && <p className="text-medium mt0">{description}</p>}
             <pre
-              className="bg-light bordered rounded p1 text-monospace text-small text-pre-wrap"
-              style={{ maxHeight: 320, overflow: "auto" }}
+              className="bg-light bordered rounded p1 text-monospace text-small text-pre-wrap overflow-auto"
+              style={{ maxHeight: 320 }}
             >
               {content}
             </pre>

--- a/frontend/test/metabase/scenarios/native/reproductions/21550-snippet-scrollbar.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/reproductions/21550-snippet-scrollbar.cy.spec.js
@@ -1,6 +1,6 @@
 import { restore, modal, openNativeEditor } from "__support__/e2e/cypress";
 
-describe.skip("issue 21550", () => {
+describe("issue 21550", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();


### PR DESCRIPTION
Instead, the (vertical) scrollbar should appear only when necessary.

To verify:
1. New, SQL query
2. Click on `SQL Snippets` to display the snippets sidebar
3. `+` to add a new snippet, e.g. `select * from people`
4. Give it a name and click `Save`

**Before this PR**

Both scrollbar are visible, despite the fact that there is no need to scroll at all.

![image](https://user-images.githubusercontent.com/7288/163842369-5d7cdecc-b593-476a-8626-2e1e3e11a2d0.png)

**After this PR**

Clean look, with no scrollbars.

![image](https://user-images.githubusercontent.com/7288/163842510-c6c54db0-92cd-4044-bc57-d16d9e5cc441.png)

**Note**

If the snippet is really long, i.e. spanning multiple lines, scrolling is needed and the scrollbar is present automatically.

![image](https://user-images.githubusercontent.com/7288/163842620-5ab86197-13be-468f-b257-74a8921f8a3f.png)

