### PR TITLE
Fix mixed up order-by on recent_views

### DIFF
--- a/src/metabase/api/activity.clj
+++ b/src/metabase/api/activity.clj
@@ -145,7 +145,7 @@
                                                  (when-not all-users? [:= (db/qualify ViewLog :user_id) *current-user-id*])
                                                  [:in :model #{"dashboard" "table"}]
                                                  [:= :bm.id nil]]
-                                     :order-by  [[:model :desc] [:max_ts :desc]]
+                                     :order-by  [[:max_ts :desc] [:model :desc]]
                                      :limit     views-limit
                                      :left-join [[DashboardBookmark :bm]
                                                  [:and


### PR DESCRIPTION
Ordering by model desc first will push all dashboard logs below table.
The order by just needed to be swapped so the time comes first.
