### PR TITLE
Fix signing in for users with non-default locale

### DIFF
--- a/frontend/src/metabase-types/api/mocks/user.ts
+++ b/frontend/src/metabase-types/api/mocks/user.ts
@@ -6,6 +6,7 @@ export const createMockUser = (opts?: Partial<User>): User => ({
   last_name: "Tableton",
   common_name: `Testy Tableton`,
   email: "user@metabase.test",
+  locale: null,
   google_auth: false,
   is_active: true,
   is_qbnewb: false,

--- a/frontend/src/metabase-types/api/user.ts
+++ b/frontend/src/metabase-types/api/user.ts
@@ -6,6 +6,7 @@ export interface User {
   last_name: string;
   common_name: string;
   email: string;
+  locale: string | null;
   google_auth: boolean;
   is_active: boolean;
   is_qbnewb: boolean;

--- a/frontend/src/metabase-types/store/state.ts
+++ b/frontend/src/metabase-types/store/state.ts
@@ -1,4 +1,4 @@
-import { User } from "metabase-types/types/User";
+import { User } from "metabase-types/api";
 import { AdminState } from "./admin";
 import { EntitiesState } from "./entities";
 import { FormState } from "./forms";

--- a/frontend/src/metabase/app.js
+++ b/frontend/src/metabase/app.js
@@ -12,7 +12,7 @@ import "number-to-locale-string";
 import "metabase/lib/i18n-debug";
 
 // set the locale before loading anything else
-import { loadLocalization } from "metabase/lib/i18n";
+import "metabase/lib/i18n";
 
 // NOTE: why do we need to load this here?
 import "metabase/lib/colors";
@@ -89,16 +89,6 @@ function _init(reducers, getRoutes, callback) {
   initializeEmbedding(store);
 
   store.dispatch(refreshSiteSettings());
-
-  MetabaseSettings.on("user-locale", async locale => {
-    // reload locale definition and site settings with the new locale
-    await Promise.all([
-      loadLocalization(locale),
-      store.dispatch(refreshSiteSettings({ locale })),
-    ]);
-    // force re-render of React application
-    root.forceUpdate();
-  });
 
   PLUGIN_APP_INIT_FUCTIONS.forEach(init => init({ root }));
 

--- a/frontend/src/metabase/auth/actions.ts
+++ b/frontend/src/metabase/auth/actions.ts
@@ -1,14 +1,13 @@
 import { push } from "react-router-redux";
 import { getIn } from "icepick";
 import { SessionApi, UtilApi } from "metabase/services";
+import Settings from "metabase/lib/settings";
 import { createThunkAction } from "metabase/lib/redux";
+import { loadLocalization } from "metabase/lib/i18n";
 import { clearGoogleAuthCredentials, deleteSession } from "metabase/lib/auth";
+import { clearCurrentUser, refreshCurrentUser } from "metabase/redux/user";
 import { refreshSiteSettings } from "metabase/redux/settings";
-import {
-  clearCurrentUser,
-  refreshCurrentUser,
-  loadUserLocalization,
-} from "metabase/redux/user";
+import { State } from "metabase-types/store";
 import {
   trackLogin,
   trackLoginGoogle,
@@ -16,6 +15,16 @@ import {
   trackPasswordReset,
 } from "./analytics";
 import { LoginData } from "./types";
+
+export const LOAD_USER_LOCALIZATION = "metabase/user/LOAD_USER_LOCALIZATION";
+export const loadUserLocalization = createThunkAction(
+  LOAD_USER_LOCALIZATION,
+  () => async (dispatch: any, getState: () => State) => {
+    const userLocale = getState().currentUser?.locale;
+    const siteLocale = Settings.get("site-locale");
+    await loadLocalization(userLocale ?? siteLocale ?? "en");
+  },
+);
 
 export const REFRESH_SESSION = "metabase/auth/REFRESH_SESSION";
 export const refreshSession = createThunkAction(

--- a/frontend/src/metabase/auth/actions.ts
+++ b/frontend/src/metabase/auth/actions.ts
@@ -16,9 +16,9 @@ import {
 } from "./analytics";
 import { LoginData } from "./types";
 
-export const LOAD_USER_LOCALIZATION = "metabase/user/LOAD_USER_LOCALIZATION";
-export const loadUserLocalization = createThunkAction(
-  LOAD_USER_LOCALIZATION,
+export const REFRESH_LOCALE = "metabase/user/REFRESH_LOCALE";
+export const refreshLocale = createThunkAction(
+  REFRESH_LOCALE,
   () => async (dispatch: any, getState: () => State) => {
     const userLocale = getState().currentUser?.locale;
     const siteLocale = Settings.get("site-locale");
@@ -34,7 +34,7 @@ export const refreshSession = createThunkAction(
       dispatch(refreshCurrentUser()),
       dispatch(refreshSiteSettings()),
     ]);
-    await dispatch(loadUserLocalization());
+    await dispatch(refreshLocale());
   },
 );
 
@@ -73,7 +73,7 @@ export const logout = createThunkAction(LOGOUT, () => {
     await deleteSession();
     await clearGoogleAuthCredentials();
     await dispatch(clearCurrentUser());
-    await dispatch(loadUserLocalization());
+    await dispatch(refreshLocale());
     trackLogout();
 
     dispatch(push("/auth/login"));

--- a/frontend/src/metabase/auth/actions.ts
+++ b/frontend/src/metabase/auth/actions.ts
@@ -1,12 +1,13 @@
 import { push } from "react-router-redux";
 import { getIn } from "icepick";
 import { SessionApi, UtilApi } from "metabase/services";
-import Settings from "metabase/lib/settings";
+import MetabaseSettings from "metabase/lib/settings";
 import { createThunkAction } from "metabase/lib/redux";
 import { loadLocalization } from "metabase/lib/i18n";
 import { clearGoogleAuthCredentials, deleteSession } from "metabase/lib/auth";
 import { clearCurrentUser, refreshCurrentUser } from "metabase/redux/user";
 import { refreshSiteSettings } from "metabase/redux/settings";
+import { getUser } from "metabase/selectors/user";
 import { State } from "metabase-types/store";
 import {
   trackLogin,
@@ -20,8 +21,8 @@ export const REFRESH_LOCALE = "metabase/user/REFRESH_LOCALE";
 export const refreshLocale = createThunkAction(
   REFRESH_LOCALE,
   () => async (dispatch: any, getState: () => State) => {
-    const userLocale = getState().currentUser?.locale;
-    const siteLocale = Settings.get("site-locale");
+    const userLocale = getUser(getState())?.locale;
+    const siteLocale = MetabaseSettings.get("site-locale");
     await loadLocalization(userLocale ?? siteLocale ?? "en");
   },
 );

--- a/frontend/src/metabase/auth/actions.ts
+++ b/frontend/src/metabase/auth/actions.ts
@@ -22,9 +22,10 @@ export const refreshSession = createThunkAction(
   REFRESH_SESSION,
   () => async (dispatch: any) => {
     await Promise.all([
-      dispatch(refreshCurrentUser()).then(() => loadUserLocalization()),
+      dispatch(refreshCurrentUser()),
       dispatch(refreshSiteSettings()),
     ]);
+    await dispatch(loadUserLocalization());
   },
 );
 

--- a/frontend/src/metabase/auth/actions.ts
+++ b/frontend/src/metabase/auth/actions.ts
@@ -1,10 +1,9 @@
-import { push } from "react-router-redux";
 import { getIn } from "icepick";
 import { SessionApi, UtilApi } from "metabase/services";
 import { createThunkAction } from "metabase/lib/redux";
 import { clearGoogleAuthCredentials, deleteSession } from "metabase/lib/auth";
 import { refreshSiteSettings } from "metabase/redux/settings";
-import { clearCurrentUser, refreshCurrentUser } from "metabase/redux/user";
+import { refreshCurrentUser } from "metabase/redux/user";
 import {
   trackLogin,
   trackLoginGoogle,
@@ -29,10 +28,10 @@ export const login = createThunkAction(
   LOGIN,
   (data: LoginData, redirectUrl = "/") => async (dispatch: any) => {
     await SessionApi.create(data);
+    await dispatch(refreshSession());
     trackLogin();
 
-    await dispatch(refreshSession());
-    dispatch(push(redirectUrl));
+    window.location.assign(redirectUrl);
   },
 );
 
@@ -42,10 +41,10 @@ export const loginGoogle = createThunkAction(
   (token: string, redirectUrl = "/") => async (dispatch: any) => {
     try {
       await SessionApi.createWithGoogleAuth({ token });
+      await dispatch(refreshSession());
       trackLoginGoogle();
 
-      await dispatch(refreshSession());
-      dispatch(push(redirectUrl));
+      window.location.assign(redirectUrl);
     } catch (error) {
       await clearGoogleAuthCredentials();
       throw error;
@@ -55,14 +54,12 @@ export const loginGoogle = createThunkAction(
 
 export const LOGOUT = "metabase/auth/LOGOUT";
 export const logout = createThunkAction(LOGOUT, () => {
-  return async (dispatch: any) => {
+  return async () => {
     await deleteSession();
     await clearGoogleAuthCredentials();
-    await dispatch(clearCurrentUser());
     trackLogout();
 
-    dispatch(push("/auth/login"));
-    window.location.reload();
+    window.location.assign("/auth/login");
   };
 });
 

--- a/frontend/src/metabase/lib/settings.ts
+++ b/frontend/src/metabase/lib/settings.ts
@@ -55,6 +55,7 @@ export type SettingName =
   | "admin-email"
   | "analytics-uuid"
   | "anon-tracking-enabled"
+  | "site-locale"
   | "user-locale"
   | "available-locales"
   | "available-timezones"

--- a/frontend/src/metabase/nav/components/ProfileLink.jsx
+++ b/frontend/src/metabase/nav/components/ProfileLink.jsx
@@ -24,6 +24,7 @@ export default class ProfileLink extends Component {
   static propTypes = {
     user: PropTypes.object.isRequired,
     handleCloseNavbar: PropTypes.func.isRequired,
+    handleLogout: PropTypes.func.isRequired,
   };
 
   openModal = modalName => {
@@ -81,7 +82,7 @@ export default class ProfileLink extends Component {
       {
         title: t`Sign out`,
         icon: null,
-        link: "auth/logout",
+        action: () => this.props.handleLogout(),
         event: `Navbar;Profile Dropdown;Logout`,
       },
     ].filter(Boolean);

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer.tsx
@@ -6,7 +6,7 @@ import _ from "underscore";
 import { IconProps } from "metabase/components/Icon";
 import LoadingSpinner from "metabase/components/LoadingSpinner";
 
-import { Bookmark, BookmarksType, Collection, User } from "metabase-types/api";
+import { BookmarksType, Collection, User } from "metabase-types/api";
 import Bookmarks from "metabase/entities/bookmarks";
 import Collections, {
   ROOT_COLLECTION,
@@ -14,6 +14,7 @@ import Collections, {
   buildCollectionTree,
 } from "metabase/entities/collections";
 import { openNavbar, closeNavbar } from "metabase/redux/app";
+import { logout } from "metabase/auth/actions";
 import {
   getHasOwnDatabase,
   getHasDataAccess,
@@ -40,6 +41,7 @@ function mapStateToProps(state: unknown) {
 const mapDispatchToProps = {
   openNavbar,
   closeNavbar,
+  logout,
 };
 
 interface CollectionTreeItem extends Collection {
@@ -64,6 +66,7 @@ type Props = {
   };
   openNavbar: () => void;
   closeNavbar: () => void;
+  logout: () => void;
 };
 
 function MainNavbarContainer({
@@ -79,6 +82,7 @@ function MainNavbarContainer({
   params,
   openNavbar,
   closeNavbar,
+  logout,
   ...props
 }: Props) {
   const [orderedBookmarks, setOrderedBookmarks] = useState([]);
@@ -180,8 +184,9 @@ function MainNavbarContainer({
           hasOwnDatabase={hasOwnDatabase}
           selectedItem={selectedItem}
           hasDataAccess={hasDataAccess}
-          handleCloseNavbar={closeNavbar}
           reorderBookmarks={reorderBookmarks}
+          handleCloseNavbar={closeNavbar}
+          handleLogout={logout}
         />
       ) : (
         <LoadingContainer>

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarView.tsx
@@ -1,8 +1,7 @@
 import React, { useCallback } from "react";
 import { t } from "ttag";
-import _ from "underscore";
 
-import { Bookmark, BookmarksType, Collection, User } from "metabase-types/api";
+import { BookmarksType, Collection, User } from "metabase-types/api";
 
 import { IconProps } from "metabase/components/Icon";
 import { Tree } from "metabase/components/tree";
@@ -47,6 +46,7 @@ type Props = {
   collections: CollectionTreeItem[];
   selectedItem: SelectedItem;
   handleCloseNavbar: () => void;
+  handleLogout: () => void;
   reorderBookmarks: ({
     newIndex,
     oldIndex,
@@ -69,8 +69,9 @@ function MainNavbarView({
   hasOwnDatabase,
   selectedItem,
   hasDataAccess,
-  handleCloseNavbar,
   reorderBookmarks,
+  handleCloseNavbar,
+  handleLogout,
 }: Props) {
   const isMiscLinkSelected = selectedItem.type === "unknown";
   const isCollectionSelected =
@@ -144,7 +145,11 @@ function MainNavbarView({
       </div>
       {!IFRAMED && (
         <ProfileLinkContainer isOpen={isOpen}>
-          <ProfileLink user={currentUser} handleCloseNavbar={onItemSelect} />
+          <ProfileLink
+            user={currentUser}
+            handleCloseNavbar={onItemSelect}
+            handleLogout={handleLogout}
+          />
         </ProfileLinkContainer>
       )}
     </SidebarContentRoot>

--- a/frontend/src/metabase/redux/user.js
+++ b/frontend/src/metabase/redux/user.js
@@ -33,12 +33,9 @@ export const LOAD_USER_LOCALIZATION = "metabase/user/LOAD_USER_LOCALIZATION";
 export const loadUserLocalization = createThunkAction(
   LOAD_USER_LOCALIZATION,
   () => async (dispatch, getState) => {
-    const user = getState().currentUser;
-    if (user && user.locale) {
-      await loadLocalization(user.locale);
-    } else {
-      await loadLocalization(Settings.get("site-locale"));
-    }
+    const userLocale = getState().currentUser?.locale;
+    const siteLocale = Settings.get("site-locale");
+    await loadLocalization(userLocale ?? siteLocale ?? "en");
   },
 );
 

--- a/frontend/src/metabase/redux/user.js
+++ b/frontend/src/metabase/redux/user.js
@@ -7,6 +7,8 @@ import {
 import { CLOSE_QB_NEWB_MODAL } from "metabase/query_builder/actions";
 
 import { UserApi } from "metabase/services";
+import { loadLocalization } from "metabase/lib/i18n";
+import Settings from "metabase/lib/settings";
 
 export const REFRESH_CURRENT_USER = "metabase/user/REFRESH_CURRENT_USER";
 export const refreshCurrentUser = createAction(REFRESH_CURRENT_USER, () => {
@@ -23,6 +25,19 @@ export const loadCurrentUser = createThunkAction(
   () => async (dispatch, getState) => {
     if (!getState().currentUser) {
       await dispatch(refreshCurrentUser());
+    }
+  },
+);
+
+export const LOAD_USER_LOCALIZATION = "metabase/user/LOAD_USER_LOCALIZATION";
+export const loadUserLocalization = createThunkAction(
+  LOAD_USER_LOCALIZATION,
+  () => async (dispatch, getState) => {
+    const user = getState().currentUser;
+    if (user && user.locale) {
+      await loadLocalization(user.locale);
+    } else {
+      await loadLocalization(Settings.get("user-locale"));
     }
   },
 );

--- a/frontend/src/metabase/redux/user.js
+++ b/frontend/src/metabase/redux/user.js
@@ -37,7 +37,7 @@ export const loadUserLocalization = createThunkAction(
     if (user && user.locale) {
       await loadLocalization(user.locale);
     } else {
-      await loadLocalization(Settings.get("user-locale"));
+      await loadLocalization(Settings.get("site-locale"));
     }
   },
 );

--- a/frontend/src/metabase/redux/user.js
+++ b/frontend/src/metabase/redux/user.js
@@ -1,14 +1,10 @@
 import {
   createAction,
-  handleActions,
   createThunkAction,
+  handleActions,
 } from "metabase/lib/redux";
-
-import { CLOSE_QB_NEWB_MODAL } from "metabase/query_builder/actions";
-
 import { UserApi } from "metabase/services";
-import Settings from "metabase/lib/settings";
-import { loadLocalization } from "metabase/lib/i18n";
+import { CLOSE_QB_NEWB_MODAL } from "metabase/query_builder/actions";
 
 export const REFRESH_CURRENT_USER = "metabase/user/REFRESH_CURRENT_USER";
 export const refreshCurrentUser = createAction(REFRESH_CURRENT_USER, () => {
@@ -26,16 +22,6 @@ export const loadCurrentUser = createThunkAction(
     if (!getState().currentUser) {
       await dispatch(refreshCurrentUser());
     }
-  },
-);
-
-export const LOAD_USER_LOCALIZATION = "metabase/user/LOAD_USER_LOCALIZATION";
-export const loadUserLocalization = createThunkAction(
-  LOAD_USER_LOCALIZATION,
-  () => async (dispatch, getState) => {
-    const userLocale = getState().currentUser?.locale;
-    const siteLocale = Settings.get("site-locale");
-    await loadLocalization(userLocale ?? siteLocale ?? "en");
   },
 );
 

--- a/frontend/src/metabase/redux/user.js
+++ b/frontend/src/metabase/redux/user.js
@@ -7,8 +7,8 @@ import {
 import { CLOSE_QB_NEWB_MODAL } from "metabase/query_builder/actions";
 
 import { UserApi } from "metabase/services";
-import { loadLocalization } from "metabase/lib/i18n";
 import Settings from "metabase/lib/settings";
+import { loadLocalization } from "metabase/lib/i18n";
 
 export const REFRESH_CURRENT_USER = "metabase/user/REFRESH_CURRENT_USER";
 export const refreshCurrentUser = createAction(REFRESH_CURRENT_USER, () => {


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/13082

The previous way of logging in didn't load localization for users with non-default locale (different to the one specified in admin settings). This PR fixes the issue by reloading the browser page, mostly to use the same code to load localization and to avoid weird edge cases. 

The PR also tweaks how logging out is performed to avoid an extra redirect for the user. Please note that `/auth/logout` URL is still available and it can be used for embedding purposes.

How to test:
- Go to admin settings and set the site locale, e.g. `English`.
- Go to account details for the current user and set another locale, e.g. `German`.
- Log out and log in again as the same user.
- Make sure that the app is localized in the language chosen in account details.
