### PR TITLE
Show site-url placeholder message when using MB_SITE_URL env var

### DIFF
--- a/frontend/src/metabase/admin/settings/components/widgets/SiteUrlWidget.jsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/SiteUrlWidget.jsx
@@ -1,7 +1,12 @@
-/* eslint-disable react/prop-types */
 import React, { Component } from "react";
+import PropTypes from "prop-types";
 
 import InputWithSelectPrefix from "metabase/components/InputWithSelectPrefix";
+
+const propTypes = {
+  setting: PropTypes.object.isRequired,
+  onChange: PropTypes.func.isRequired,
+};
 
 export default class SiteUrlWidget extends Component {
   render() {
@@ -13,7 +18,10 @@ export default class SiteUrlWidget extends Component {
         prefixes={["https://", "http://"]}
         defaultPrefix="http://"
         caseInsensitivePrefix={true}
+        placeholder={setting.placeholder}
       />
     );
   }
 }
+
+SiteUrlWidget.propTypes = propTypes;

--- a/frontend/src/metabase/components/InputWithSelectPrefix.jsx
+++ b/frontend/src/metabase/components/InputWithSelectPrefix.jsx
@@ -1,5 +1,5 @@
-/* eslint-disable react/prop-types */
 import React, { Component } from "react";
+import PropTypes from "prop-types";
 
 import Select, { Option } from "metabase/core/components/Select";
 import InputBlurChange from "./InputBlurChange";
@@ -22,6 +22,14 @@ function splitValue({
 
   return prefix ? [prefix, value.slice(prefix.length)] : [defaultPrefix, value];
 }
+
+const propTypes = {
+  value: PropTypes.string,
+  prefixes: PropTypes.arrayOf(PropTypes.string),
+  defaultPrefix: PropTypes.string,
+  caseInsensitivePrefix: PropTypes.bool,
+  onChange: PropTypes.func,
+};
 
 export default class InputWithSelectPrefix extends Component {
   constructor(props) {
@@ -79,3 +87,5 @@ export default class InputWithSelectPrefix extends Component {
     );
   }
 }
+
+InputWithSelectPrefix.propTypes = propTypes;

--- a/frontend/src/metabase/components/InputWithSelectPrefix.jsx
+++ b/frontend/src/metabase/components/InputWithSelectPrefix.jsx
@@ -29,6 +29,7 @@ const propTypes = {
   defaultPrefix: PropTypes.string,
   caseInsensitivePrefix: PropTypes.bool,
   onChange: PropTypes.func,
+  placeholder: PropTypes.string,
 };
 
 export default class InputWithSelectPrefix extends Component {
@@ -80,7 +81,7 @@ export default class InputWithSelectPrefix extends Component {
           type="text"
           className="Form-input flex-full borderless"
           value={rest}
-          placeholder={"foo"}
+          placeholder={this.props.placeholder}
           onBlurChange={e => this.setState({ rest: e.target.value })}
         />
       </div>


### PR DESCRIPTION
Resolves #20773 

According to https://github.com/metabase/metabase/issues/20773#issuecomment-1101667258 we shouldn't show the site-url when it is set via environment variable. Here, I'm replacing the static placeholder "foo" with the `placeholder` value coming from https://github.com/metabase/metabase/blob/1d05883a68fd7ed4d186aad56d99511d77e95203/frontend/src/metabase/admin/settings/utils.js#L14 so that it reads `Using MB_SITE_URL` when the site-url is set via environmental variable:

<img width="637" alt="Screen Shot 2022-04-18 at 12 40 26 PM" src="https://user-images.githubusercontent.com/13057258/163866956-9b721d26-1688-47e4-ac47-12640a52bcda.png">

**Testing**
Run the BE locally using `MB_SITE_URL="http://localhost:3100/metabase/" clojure -M:run`
You should see the placeholder shown above

Running the BE without `MB_SITE_URL` should still show the `site-url` value.