### PR TITLE
Log execution context as collection for pinned.

### DIFF
--- a/frontend/src/metabase-lib/lib/Question.ts
+++ b/frontend/src/metabase-lib/lib/Question.ts
@@ -1054,6 +1054,7 @@ export default class Question {
     cancelDeferred,
     isDirty = false,
     ignoreCache = false,
+    collectionPreview = false,
   } = {}): Promise<[Dataset]> {
     // TODO Atte Keinänen 7/5/17: Should we clean this query with Query.cleanQuery(query) before executing it?
     const canUseCardApiEndpoint = !isDirty && this.isSaved();
@@ -1080,6 +1081,7 @@ export default class Question {
         dashboardId,
         dashcardId,
         ignore_cache: ignoreCache,
+        collection_preview: collectionPreview,
         parameters,
       };
       return [

--- a/frontend/src/metabase/collections/components/CollectionCardVisualization/CollectionCardVisualization.jsx
+++ b/frontend/src/metabase/collections/components/CollectionCardVisualization/CollectionCardVisualization.jsx
@@ -47,7 +47,10 @@ function CollectionCardVisualization({
               questionRef.current || new Question(card, metadata);
 
             return (
-              <QuestionResultLoader question={questionRef.current}>
+              <QuestionResultLoader
+                question={questionRef.current}
+                collectionPreview
+              >
                 {({ loading, error, reload, rawSeries, results, result }) => {
                   const shouldShowLoader = loading && results == null;
                   const { errorMessage, errorIcon } = getErrorProps(

--- a/frontend/src/metabase/containers/QuestionResultLoader.jsx
+++ b/frontend/src/metabase/containers/QuestionResultLoader.jsx
@@ -51,6 +51,8 @@ export class QuestionResultLoader extends React.Component {
    * load the result by calling question.apiGetResults
    */
   async _loadResult(question, onLoad, keepPreviousWhileLoading) {
+    const { collectionPreview } = this.props;
+
     // we need to have a question for anything to happen
     if (question) {
       try {
@@ -67,6 +69,7 @@ export class QuestionResultLoader extends React.Component {
         // call apiGetResults and pass our cancel to allow for cancelation
         const results = await question.apiGetResults({
           cancelDeferred: this._cancelDeferred,
+          collectionPreview,
         });
 
         // setState with our result, remove our cancel since we've finished

--- a/frontend/test/metabase/scenarios/onboarding/home/homepage.cy.spec.js
+++ b/frontend/test/metabase/scenarios/onboarding/home/homepage.cy.spec.js
@@ -7,88 +7,119 @@ describe("scenarios > home > homepage", () => {
     cy.intercept("GET", "/api/automagic-*/database/**").as("getXrayCandidates");
     cy.intercept("GET", "/api/activity/recent_views").as("getRecentItems");
     cy.intercept("GET", "/api/activity/popular_items").as("getPopularItems");
+    cy.intercept("GET", "/api/collection/*/items*").as("getCollectionItems");
+    cy.intercept("POST", `/api/card/**/*/query`).as("getQuestionQuery");
   });
 
-  it("should display x-rays for the sample database", () => {
-    restore("setup");
-    cy.signInAsAdmin();
+  describe("after setup", () => {
+    beforeEach(() => {
+      restore("setup");
+    });
 
-    cy.visit("/");
-    cy.wait("@getXrayCandidates");
-    cy.findByText("Try out these sample x-rays to see what Metabase can do.");
-    cy.findByText("Orders").click();
+    it("should display x-rays for the sample database", () => {
+      cy.signInAsAdmin();
 
-    cy.wait("@getXrayDashboard");
-    cy.findByText("More X-rays");
+      cy.visit("/");
+      cy.wait("@getXrayCandidates");
+      cy.findByText("Try out these sample x-rays to see what Metabase can do.");
+      cy.findByText("Orders").click();
+
+      cy.wait("@getXrayDashboard");
+      cy.findByText("More X-rays");
+    });
+
+    it("should display x-rays for a user database", () => {
+      cy.signInAsAdmin();
+      cy.addH2SampleDatabase({ name: "H2" });
+
+      cy.visit("/");
+      cy.wait("@getXrayCandidates");
+      cy.findByText("Here are some explorations of");
+      cy.findByText("H2");
+      cy.findByText("Orders").click();
+
+      cy.wait("@getXrayDashboard");
+      cy.findByText("More X-rays");
+    });
+
+    it("should allow switching between multiple schemas for x-rays", () => {
+      cy.signInAsAdmin();
+      cy.addH2SampleDatabase({ name: "H2" });
+      cy.intercept("/api/automagic-*/database/**", getXrayCandidates());
+
+      cy.visit("/");
+      cy.findByText(/Here are some explorations of the/);
+      cy.findByText("public");
+      cy.findByText("H2");
+      cy.findByText("Orders");
+      cy.findByText("People").should("not.exist");
+
+      cy.findByText("public").click();
+      cy.findByText("private").click();
+      cy.findByText("People");
+      cy.findByText("Orders").should("not.exist");
+    });
   });
 
-  it("should display x-rays for a user database", () => {
-    restore("setup");
-    cy.signInAsAdmin();
-    cy.addH2SampleDatabase({ name: "H2" });
+  describe("after content creation", () => {
+    beforeEach(() => {
+      restore("default");
+    });
 
-    cy.visit("/");
-    cy.wait("@getXrayCandidates");
-    cy.findByText("Here are some explorations of");
-    cy.findByText("H2");
-    cy.findByText("Orders").click();
+    it("should display recent items", () => {
+      cy.signInAsAdmin();
 
-    cy.wait("@getXrayDashboard");
-    cy.findByText("More X-rays");
-  });
+      visitDashboard(1);
+      cy.findByText("Orders in a dashboard");
 
-  it("should allow switching between multiple schemas for x-rays", () => {
-    restore("setup");
-    cy.signInAsAdmin();
-    cy.addH2SampleDatabase({ name: "H2" });
-    cy.intercept("/api/automagic-*/database/**", getXrayCandidates());
+      cy.visit("/");
+      cy.wait("@getRecentItems");
+      cy.findByText("Pick up where you left off");
 
-    cy.visit("/");
-    cy.findByText(/Here are some explorations of the/);
-    cy.findByText("public");
-    cy.findByText("H2");
-    cy.findByText("Orders");
-    cy.findByText("People").should("not.exist");
+      cy.findByText("Orders in a dashboard").click();
+      cy.wait("@getDashboard");
+      cy.findByText("Orders");
+    });
 
-    cy.findByText("public").click();
-    cy.findByText("private").click();
-    cy.findByText("People");
-    cy.findByText("Orders").should("not.exist");
-  });
+    it("should display popular items for a new user", () => {
+      cy.signInAsAdmin();
 
-  it("should display recent items", () => {
-    restore("default");
+      visitDashboard(1);
+      cy.findByText("Orders in a dashboard");
+      cy.signOut();
 
-    cy.signInAsAdmin();
-    visitDashboard(1);
-    cy.findByText("Orders in a dashboard");
+      cy.signInAsNormalUser();
+      cy.visit("/");
+      cy.wait("@getPopularItems");
+      cy.findByText("Here are some popular dashboards");
+      cy.findByText("Orders in a dashboard").click();
+      cy.wait("@getDashboard");
+      cy.findByText("Orders");
+    });
 
-    cy.visit("/");
-    cy.wait("@getRecentItems");
-    cy.findByText("Pick up where you left off");
+    it("should not show pinned questions in recent items when viewed in a collection", () => {
+      cy.signInAsAdmin();
 
-    cy.findByText("Orders in a dashboard").click();
-    cy.wait("@getDashboard");
-    cy.findByText("Orders");
-  });
+      visitDashboard(1);
+      cy.findByText("Orders in a dashboard");
 
-  it("should display popular items for a new user", () => {
-    restore("default");
+      cy.visit("/collection/root");
+      cy.wait("@getCollectionItems");
+      getQuestionRow("Orders, Count").within(() => cy.icon("pin").click());
+      cy.wait("@getCollectionItems");
+      cy.wait("@getQuestionQuery");
 
-    cy.signInAsAdmin();
-    visitDashboard(1);
-    cy.findByText("Orders in a dashboard");
-    cy.signOut();
-
-    cy.signInAsNormalUser();
-    cy.visit("/");
-    cy.wait("@getPopularItems");
-    cy.findByText("Here are some popular dashboards");
-    cy.findByText("Orders in a dashboard").click();
-    cy.wait("@getDashboard");
-    cy.findByText("Orders");
+      cy.visit("/");
+      cy.wait("@getRecentItems");
+      cy.findByText("Orders in a dashboard").should("be.visible");
+      cy.findByText("Orders, Count").should("not.exist");
+    });
   });
 });
+
+const getQuestionRow = name => {
+  return cy.findByText(name).closest("tr");
+};
 
 const getXrayCandidates = () => [
   {

--- a/frontend/test/metabase/scenarios/onboarding/home/homepage.cy.spec.js
+++ b/frontend/test/metabase/scenarios/onboarding/home/homepage.cy.spec.js
@@ -8,7 +8,7 @@ describe("scenarios > home > homepage", () => {
     cy.intercept("GET", "/api/activity/recent_views").as("getRecentItems");
     cy.intercept("GET", "/api/activity/popular_items").as("getPopularItems");
     cy.intercept("GET", "/api/collection/*/items*").as("getCollectionItems");
-    cy.intercept("POST", `/api/card/**/*/query`).as("getQuestionQuery");
+    cy.intercept("POST", `/api/card/*/query`).as("getQuestionQuery");
   });
 
   describe("after setup", () => {

--- a/frontend/test/metabase/scenarios/onboarding/home/homepage.cy.spec.js
+++ b/frontend/test/metabase/scenarios/onboarding/home/homepage.cy.spec.js
@@ -83,7 +83,6 @@ describe("scenarios > home > homepage", () => {
 
     it("should display popular items for a new user", () => {
       cy.signInAsAdmin();
-
       visitDashboard(1);
       cy.findByText("Orders in a dashboard");
       cy.signOut();

--- a/shared/src/metabase/mbql/schema.cljc
+++ b/shared/src/metabase/mbql/schema.cljc
@@ -1509,6 +1509,7 @@
 (def Context
   "Schema for `info.context`; used for informational purposes to record how a query was executed."
   (s/enum :ad-hoc
+          :collection
           :csv-download
           :dashboard
           :embedded-dashboard

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -656,8 +656,9 @@
 
 (api/defendpoint ^:streaming POST "/:card-id/query"
   "Run the query associated with a Card."
-  [card-id :as {{:keys [parameters ignore_cache dashboard_id], :or {ignore_cache false dashboard_id nil}} :body}]
+  [card-id :as {{:keys [parameters ignore_cache dashboard_id collection_preview], :or {ignore_cache false dashboard_id nil}} :body}]
   {ignore_cache (s/maybe s/Bool)
+   collection_preview (s/maybe s/Bool)
    dashboard_id (s/maybe su/IntGreaterThanZero)}
   ;; TODO -- we should probably warn if you pass `dashboard_id`, and tell you to use the new
   ;;
@@ -669,6 +670,7 @@
    :parameters   parameters
    :ignore_cache ignore_cache
    :dashboard-id dashboard_id
+   :context      (if collection_preview :collection :question)
    :middleware   {:process-viz-settings? false}))
 
 (api/defendpoint ^:streaming POST "/:card-id/query/:export-format"


### PR DESCRIPTION
A person who visits the front page and sees the list of Popular or "Pick up where you left off" items, would see pinned cards being added to those lists even when no one explicitly opened those cards (they just opened a collection that had them pinned). This changes the behaviour to give the pinned card queries a new `collection` context so we can exclude them from the Popular and "Pick up where you left off" lists.

![image](https://user-images.githubusercontent.com/105012/163871017-23af773b-163d-4eb0-9f5d-de57a824e846.png)


Introduce a new `context`, `collection` for pinned card queries.

This affects popular_items and recent_views, as before a pinned card
would be added to these lists because we had no way of determining if
the query was made automatically.

Existing contexts:
```
metabase=# select context, count(*) from query_execution group by context;
      context      | count
-------------------+-------
 ad-hoc            |  1474
 dashboard         |   307
 json-download     |    24
 embedded-question |     3
 xlsx-download     |    30
 pulse             |  1246
 map-tiles         |  1442
 question          |  1994
 csv-download      |    31
 public-question   |     3
 public-dashboard  |    12
 ```