### PR TITLE
Repro #21452: `POST` firing on each keystroke when changing series display name on cumulative calculations

### DIFF
--- a/frontend/test/metabase/scenarios/visualizations/reproductions/21452-xhr-on-every-char-for-rename.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/reproductions/21452-xhr-on-every-char-for-rename.cy.spec.js
@@ -1,0 +1,55 @@
+import { restore, visitQuestionAdhoc, popover } from "__support__/e2e/cypress";
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+
+const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
+
+const questionDetails = {
+  dataset_query: {
+    type: "query",
+    query: {
+      "source-table": ORDERS_ID,
+      aggregation: [["cum-sum", ["field", ORDERS.QUANTITY, null]]],
+      breakout: [["field", ORDERS.CREATED_AT, { "temporal-unit": "year" }]],
+    },
+    database: 1,
+  },
+  display: "line",
+};
+
+describe("issue 21452", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    visitQuestionAdhoc(questionDetails);
+
+    cy.findByText("Settings").click();
+  });
+
+  it("should not fire POST request after every character during display name change (metabase#21452)", () => {
+    cy.findByDisplayValue("Sum of Quantity")
+      .clear()
+      .type("Foo")
+      .blur();
+    // Blur will result in another POST request which is expected
+    cy.wait("@dataset");
+
+    cy.get("circle")
+      .first()
+      .realHover();
+
+    popover().within(() => {
+      testPairedTooltipValues("Created At", "2016");
+      testPairedTooltipValues("Foo", "3,236");
+    });
+
+    cy.get("@dataset.all").should("have.length", 2);
+  });
+});
+
+function testPairedTooltipValues(val1, val2) {
+  cy.contains(val1)
+    .closest("td")
+    .siblings("td")
+    .findByText(val2);
+}


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Reproduces #21452 

### How to test this manually?
- `yarn test-cypress-open`
- `metabase/scenarios/visualizations/reproductions/21452-xhr-on-every-char-for-rename.cy.spec.js`
- All tests should pass

### Additional notes:
- The bug was fixed in #21692

### Screenshots:

Before the fix:
![image](https://user-images.githubusercontent.com/31325167/163882420-1f60af8a-4f11-48e5-9101-ef13336a6a8d.png)

After the fix
![image](https://user-images.githubusercontent.com/31325167/163882763-efd6d4fe-49a0-41aa-81a6-53116a031891.png)

