### PR TITLE
Disable "Starting From" option in dashboard "All Options" datetime widget

### DIFF
--- a/frontend/src/metabase/parameters/components/widgets/DateAllOptionsWidget.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/DateAllOptionsWidget.tsx
@@ -94,6 +94,7 @@ const DateAllOptionsWidget = ({
         onFilterChange={setFilter}
         onCommit={commitAndClose}
         hideTimeSelectors
+        disableStartingFrom
         hideExcludeOperators
         hideEmptinessOperators
         disableOperatorSelection={disableOperatorSelection}

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePicker.tsx
@@ -230,6 +230,7 @@ type Props = {
   operators?: DateOperator[];
 
   hideTimeSelectors?: boolean;
+  disableStartingFrom?: boolean;
   hideExcludeOperators?: boolean;
   hideEmptinessOperators?: boolean;
   disableOperatorSelection?: boolean;

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RelativeDatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RelativeDatePicker.tsx
@@ -151,6 +151,7 @@ type Props = {
   offsetFormatter: (value: number) => number;
   primaryColor?: string;
   reverseIconDirection?: boolean;
+  disableStartingFrom?: boolean;
 };
 
 const RelativeDatePicker: React.FC<Props> = props => {
@@ -162,6 +163,7 @@ const RelativeDatePicker: React.FC<Props> = props => {
     className,
     primaryColor,
     reverseIconDirection,
+    disableStartingFrom,
   } = props;
 
   const startingFrom = getStartingFrom(filter);
@@ -176,16 +178,18 @@ const RelativeDatePicker: React.FC<Props> = props => {
 
   const optionsContent = (
     <OptionsContainer>
-      <OptionButton
-        icon="arrow_left_to_line"
-        reverseIconDirection={reverseIconDirection}
-        onClick={() => {
-          setOptionsVisible(false);
-          onFilterChange(setStartingFrom(filter));
-        }}
-      >
-        {t`Starting from...`}
-      </OptionButton>
+      {!disableStartingFrom ? (
+        <OptionButton
+          icon="arrow_left_to_line"
+          reverseIconDirection={reverseIconDirection}
+          onClick={() => {
+            setOptionsVisible(false);
+            onFilterChange(setStartingFrom(filter));
+          }}
+        >
+          {t`Starting from...`}
+        </OptionButton>
+      ) : null}
       <OptionButton
         selected={includeCurrent}
         primaryColor={primaryColor}


### PR DESCRIPTION
Serialization/deserialization code for relative datetime "Starting from..." is broken so this disables the option in the dashboard "All options" datetime widget.

When trying to set `Starting from` in a dashboard filter, the following error results:

![image](https://user-images.githubusercontent.com/653604/163887403-02170df1-e7eb-478d-9687-696b09d86a54.png)


<details>
  <summary>This is due to a parsing error on the backend (note the malformed string from the frontend)</summary>

```
[backend] 2022-04-18 19:06:15,109 DEBUG middleware.log :: POST /api/dashboard/1/dashcard/1/card/1/query 202 [ASYNC: completed] 180.3 ms (42 DB calls) App DB connections: 0/10 Jetty threads: 4/50 (5 idle, 0 queued) (69 total active threads) Queries in flight: 0 (0 queued); h2 DB 1 connections: 0/1 (0 threads blocked)
[backend] 2022-04-18 19:06:30,089 ERROR middleware.catch-exceptions :: Error processing query: null
[backend] {:database_id 1,
[backend]  :started_at #t "2022-04-18T19:06:30.010-03:00[America/Sao_Paulo]",
[backend]  :error_type :invalid-parameter,
[backend]  :json_query
[backend]  {:constraints {:max-results 10000, :max-results-bare-rows 2000},
[backend]   :type :query,
[backend]   :middleware {:js-int-to-string? true, :ignore-cached-results? false},
[backend]   :database 1,
[backend]   :query {:source-table 2},
[backend]   :parameters
[backend]   [{:type :date/all-options,
[backend]     :value "pastNaNrelative-datetime,0,days",
[backend]     :target [:dimension [:field 12 nil]],
[backend]     :id "9e2216a4"}],
[backend]   :async? true,
[backend]   :cache-ttl nil},
[backend]  :native nil,
[backend]  :status :failed,
[backend]  :class clojure.lang.ExceptionInfo,
[backend]  :stacktrace
[backend]  ["--> driver.common.parameters.dates$eval60443$date_string__GT_filter__60448$fn__60449.invoke(dates.clj:325)"
[backend]   "driver.common.parameters.dates$eval60443$date_string__GT_filter__60448.invoke(dates.clj:320)"
[backend]   "query_processor.middleware.parameters.mbql$eval60645$build_filter_clause__60650$fn__60660.invoke(mbql.clj:57)"
[backend]   "query_processor.middleware.parameters.mbql$eval60645$build_filter_clause__60650.invoke(mbql.clj:44)"
[backend]   "query_processor.middleware.parameters.mbql$expand.invokeStatic(mbql.clj:86)"
[backend]   "query_processor.middleware.parameters.mbql$expand.invoke(mbql.clj:72)"
[backend]   "query_processor.middleware.parameters$expand_mbql_params.invokeStatic(parameters.clj:36)"
[backend]   "query_processor.middleware.parameters$expand_mbql_params.invoke(parameters.clj:32)"
[backend]   "query_processor.middleware.parameters$expand_one.invokeStatic(parameters.clj:48)"
[backend]   "query_processor.middleware.parameters$expand_one.invoke(parameters.clj:40)"
[backend]   "query_processor.middleware.parameters$expand_all$replace_60754__60755.invoke(parameters.clj:58)"
[backend]   "mbql.util.match.impl$replace_in_collection$iter__29161__29165$fn__29166.invoke(impl.cljc:44)"
[backend]   "mbql.util.match.impl$replace_in_collection.invokeStatic(impl.cljc:43)"
[backend]   "mbql.util.match.impl$replace_in_collection.invoke(impl.cljc:38)"
[backend]   "query_processor.middleware.parameters$expand_all$replace_60754__60755.invoke(parameters.clj:58)"
[backend]   "query_processor.middleware.parameters$expand_all.invokeStatic(parameters.clj:58)"
[backend]   "query_processor.middleware.parameters$expand_all.invoke(parameters.clj:52)"
[backend]   "query_processor.middleware.parameters$expand_all.invokeStatic(parameters.clj:55)"
[backend]   "query_processor.middleware.parameters$expand_all.invoke(parameters.clj:52)"
[backend]   "query_processor.middleware.parameters$expand_parameters.invokeStatic(parameters.clj:76)"
[backend]   "query_processor.middleware.parameters$expand_parameters.invoke(parameters.clj:72)"
[backend]   "query_processor.middleware.parameters$eval60770$substitute_parameters_STAR___60775$fn__60776.invoke(parameters.clj:81)"
[backend]   "query_processor.middleware.parameters$eval60770$substitute_parameters_STAR___60775.invoke(parameters.clj:78)"
[backend]   "query_processor.middleware.parameters$substitute_parameters.invokeStatic(parameters.clj:108)"
[backend]   "query_processor.middleware.parameters$substitute_parameters.invoke(parameters.clj:100)"
[backend]   "query_processor$preprocess_STAR_$fn__62237.invoke(query_processor.clj:124)"
[backend]   "query_processor$preprocess_STAR_.invokeStatic(query_processor.clj:122)"
[backend]   "query_processor$preprocess_STAR_.invoke(query_processor.clj:117)"
[backend]   "query_processor$fn__62245$combined_pre_process__62246$combined_pre_process_STAR___62247.invoke(query_processor.clj:204)"
[backend]   "query_processor.middleware.resolve_database_and_driver$resolve_database_and_driver$fn__61044$fn__61049.invoke(resolve_database_and_driver.clj:35)"
[backend]   "driver$do_with_driver.invokeStatic(driver.clj:75)"
[backend]   "driver$do_with_driver.invoke(driver.clj:71)"
[backend]   "query_processor.middleware.resolve_database_and_driver$resolve_database_and_driver$fn__61044.invoke(resolve_database_and_driver.clj:34)"
[backend]   "query_processor.middleware.fetch_source_query$resolve_card_id_source_tables$fn__59651.invoke(fetch_source_query.clj:281)"
[backend]   "query_processor.middleware.store$initialize_store$fn__61878$fn__61879.invoke(store.clj:11)"
[backend]   "query_processor.store$do_with_store.invokeStatic(store.clj:44)"
[backend]   "query_processor.store$do_with_store.invoke(store.clj:38)"
[backend]   "query_processor.middleware.store$initialize_store$fn__61878.invoke(store.clj:10)"
[backend]   "query_processor.middleware.normalize_query$normalize$fn__59863.invoke(normalize_query.clj:22)"
[backend]   "query_processor.middleware.constraints$add_default_userland_constraints$fn__47482.invoke(constraints.clj:52)"
[backend]   "query_processor.middleware.process_userland_query$process_userland_query$fn__60917.invoke(process_userland_query.clj:145)"
[backend]   "query_processor.middleware.catch_exceptions$catch_exceptions$fn__58801.invoke(catch_exceptions.clj:162)"
[backend]   "query_processor.reducible$async_qp$qp_STAR___47684$thunk__47686.invoke(reducible.clj:100)"
[backend]   "query_processor.reducible$async_qp$qp_STAR___47684$fn__47688.invoke(reducible.clj:105)"],
[backend]  :card_id 1,
[backend]  :context :dashboard,
[backend]  :error "Don't know how to parse date string \"pastNaNrelative-datetime,0,days\"",
[backend]  :row_count 0,
[backend]  :running_time 0,
[backend]  :preprocessed nil,
[backend]  :ex-data {:type :invalid-parameter, :date-string "pastNaNrelative-datetime,0,days"},
[backend]  :data {:rows [], :cols []}}
[backend]
[backend] 2022-04-18 19:06:30,093 DEBUG middleware.log :: POST /api/dashboard/1/dashcard/1/card/1/query 202 [ASYNC: completed] 116.1 ms (13 DB calls) App DB connections: 0/10 Jetty threads: 4/50 (4 idle, 0 queued) (70 total active threads) Queries in flight: 0 (0 queued)
```
</details>
