### PR TITLE
Group-by fix for JSON columns.

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
@@ -17,7 +17,6 @@
             [metabase.query-processor.error-type :as error-type]
             [metabase.query-processor.store :as qp.store]
             [metabase.query-processor.util.add-alias-info :as add]
-            [metabase.query-processor.util.nest-query :as nest-query]
             [metabase.util :as u]
             [metabase.util.date-2 :as u.date]
             [metabase.util.honeysql-extensions :as hx]

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
@@ -566,24 +566,6 @@
   [_ t]
   (format "timestamp \"%s %s\"" (u.date/format-sql (t/local-date-time t)) (.getId (t/zone-id t))))
 
-;; In `ORDER BY` and `GROUP BY`, unlike other SQL drivers, BigQuery requires that we refer to Fields using the alias we
-;; gave them in the `SELECT` clause, rather than repeating their definitions.
-;;
-;; See #17536 and #18742
-(defn- rewrite-fields-to-force-using-column-aliases
-  "Rewrite `:field` clauses to force them to use the column alias regardless of where they appear."
-  [form]
-  (mbql.u/replace form
-    [:field id-or-name opts]
-    [:field id-or-name (-> opts
-                           (assoc ::add/source-alias        (::add/desired-alias opts)
-                                  ::add/source-table        ::add/none
-                                  ;; sort of a HACK but this key will tell the SQL QP not to apply casting here either.
-                                  ::nest-query/outer-select true)
-                           ;; don't want to do temporal bucketing or binning inside the order by or breakout either.
-                           ;; That happens inside the `SELECT`
-                           (dissoc :temporal-unit :binning))]))
-
 (defmethod sql.qp/apply-top-level-clause [:bigquery-cloud-sdk :breakout]
   [driver top-level-clause honeysql-form query]
   ;; If stuff in `:fields` still needs to be qualified like `dataset.table.field`, just the stuff in `:group-by` should
@@ -592,7 +574,7 @@
   (let [parent-method (partial (get-method sql.qp/apply-top-level-clause [:sql :breakout])
                                driver top-level-clause honeysql-form)
         qualified     (parent-method query)
-        unqualified   (parent-method (update query :breakout rewrite-fields-to-force-using-column-aliases))]
+        unqualified   (parent-method (update query :breakout sql.qp/rewrite-fields-to-force-using-column-aliases))]
     (merge qualified
            (select-keys unqualified #{:group-by}))))
 
@@ -600,13 +582,13 @@
   [driver clause]
   ((get-method sql.qp/->honeysql [:sql :asc])
    driver
-   (rewrite-fields-to-force-using-column-aliases clause)))
+   (sql.qp/rewrite-fields-to-force-using-column-aliases clause)))
 
 (defmethod sql.qp/->honeysql [:bigquery-cloud-sdk :desc]
   [driver clause]
   ((get-method sql.qp/->honeysql [:sql :desc])
    driver
-   (rewrite-fields-to-force-using-column-aliases clause)))
+   (sql.qp/rewrite-fields-to-force-using-column-aliases clause)))
 
 (defn- reconcile-temporal-types
   "Make sure the temporal types of fields and values in filter clauses line up."

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -337,7 +337,7 @@
 (defmethod sql.qp/->honeysql [:postgres :desc]
   [driver clause]
   (let [stored-field-id (second (second clause))
-        stored-field    (when (and (integer? stored-field-id) (> 0 stored-field-id))
+        stored-field    (when (integer? stored-field-id)
                           (qp.store/field stored-field-id))
         new-clause      (if (field/json-field? stored-field)
                           (sql.qp/rewrite-fields-to-force-using-column-aliases clause)
@@ -347,7 +347,7 @@
 (defmethod sql.qp/->honeysql [:postgres :asc]
   [driver clause]
   (let [stored-field-id (second (second clause))
-        stored-field    (when (and (integer? stored-field-id) (> 0 stored-field-id))
+        stored-field    (when (integer? stored-field-id)
                           (qp.store/field stored-field-id))
         new-clause      (if (field/json-field? stored-field)
                           (sql.qp/rewrite-fields-to-force-using-column-aliases clause)

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -281,15 +281,6 @@
     (pretty [_]
       (format "%s::%s" (pr-str expr) (name psql-type)))))
 
-(defn lol 
-  ([x] ["published" "published" "published" "published" "published" "published"])
-  ([x y] ["published" "published" "published" "published" "published" "published"]))
-
-(defmethod hformat/parameterize :dealio [_ value pname]
-  "$1")
-
-(def num-fields (atom 0))
-
 (defn- json-query [identifier nfc-field]
   (letfn [(handle-name [x] (if (number? x) (str x) (name x)))]
     (let [field-type           (:database_type nfc-field)
@@ -326,7 +317,9 @@
   (let [parent-method (partial (get-method sql.qp/apply-top-level-clause [:sql :breakout])
                                driver top-level-clause honeysql-form)
         qualified     (parent-method query)
-        unqualified   (parent-method (update query :breakout sql.qp/rewrite-fields-to-force-using-column-aliases))]
+        unqualified   (parent-method (update query
+                                             :breakout
+                                             sql.qp/rewrite-fields-to-force-using-column-aliases))]
     (if (any? some shit breakout-fields some shit)
       (merge qualified
              (select-keys unqualified #{:group-by}))

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -311,21 +311,34 @@
       :else
       identifier)))
 
-
-(defmethod apply-top-level-clause [:postgres :breakout]
-  [driver _ honeysql-form {breakout-fields :breakout, fields-fields :fields :as _query}]
+(defmethod sql.qp/apply-top-level-clause [:postgres :breakout]
+  [driver clause honeysql-form {breakout-fields :breakout, fields-fields :fields :as query}]
   (let [parent-method (partial (get-method sql.qp/apply-top-level-clause [:sql :breakout])
-                               driver top-level-clause honeysql-form)
+                               driver clause honeysql-form)
         qualified     (parent-method query)
         unqualified   (parent-method (update query
                                              :breakout
                                              sql.qp/rewrite-fields-to-force-using-column-aliases))]
-    (if (any? some shit breakout-fields some shit)
+    (println breakout-fields)
+    (println fields-fields)
+    (if (or
+          (some some? breakout-fields)
+          (some some? fields-fields))
       (merge qualified
              (select-keys unqualified #{:group-by}))
       qualified)))
 
-;;; asc and desc maybe?
+(defmethod sql.qp/->honeysql [:postgres :asc]
+  [driver clause]
+  ((get-method sql.qp/->honeysql [:sql :asc])
+   driver
+   (sql.qp/rewrite-fields-to-force-using-column-aliases clause)))
+
+(defmethod sql.qp/->honeysql [:postgres :asc]
+  [driver clause]
+  ((get-method sql.qp/->honeysql [:sql :asc])
+   driver
+   (sql.qp/rewrite-fields-to-force-using-column-aliases clause)))
 
 (defmethod unprepare/unprepare-value [:postgres Date]
   [_ value]

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -337,7 +337,7 @@
 (defmethod sql.qp/->honeysql [:postgres :desc]
   [driver clause]
   (let [stored-field-id (second (second clause))
-        stored-field    (when (integer? stored-field-id)
+        stored-field    (when (and (integer? stored-field-id) (> 0 stored-field-id))
                           (qp.store/field stored-field-id))
         new-clause      (if (field/json-field? stored-field)
                           (sql.qp/rewrite-fields-to-force-using-column-aliases clause)
@@ -347,7 +347,7 @@
 (defmethod sql.qp/->honeysql [:postgres :asc]
   [driver clause]
   (let [stored-field-id (second (second clause))
-        stored-field    (when (integer? stored-field-id)
+        stored-field    (when (and (integer? stored-field-id) (> 0 stored-field-id))
                           (qp.store/field stored-field-id))
         new-clause      (if (field/json-field? stored-field)
                           (sql.qp/rewrite-fields-to-force-using-column-aliases clause)

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -604,7 +604,9 @@
                            (assoc ::add/source-alias        (::add/desired-alias opts)
                                   ::add/source-table        ::add/none
                                   ;; sort of a HACK but this key will tell the SQL QP not to apply casting here either.
-                                  ::nest-query/outer-select true)
+                                  ::nest-query/outer-select true
+                                  ;; used to indicate that this is a forced alias
+                                  ::forced-alias            true)
                            ;; don't want to do temporal bucketing or binning inside the order by or breakout either.
                            ;; That happens inside the `SELECT`
                            (dissoc :temporal-unit :binning))]))

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -595,7 +595,7 @@
 ;;
 ;; See #17536 and #18742
 
-(defn- rewrite-fields-to-force-using-column-aliases
+(defn rewrite-fields-to-force-using-column-aliases
   "Rewrite `:field` clauses to force them to use the column alias regardless of where they appear."
   [form]
   (mbql.u/replace form

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -589,6 +589,25 @@
       [honeysql-form field-alias]
       honeysql-form)))
 
+;; Certain SQL drivers require that we refer to Fields using the alias we give in the `SELECT` clause in
+;; `ORDER BY` and `GROUP BY` rather than repeating definitions.
+;; BigQuery does this generally, other DB's require this in JSON columns.
+;;
+;; See #17536 and #18742
+
+(defn- rewrite-fields-to-force-using-column-aliases
+  "Rewrite `:field` clauses to force them to use the column alias regardless of where they appear."
+  [form]
+  (mbql.u/replace form
+    [:field id-or-name opts]
+    [:field id-or-name (-> opts
+                           (assoc ::add/source-alias        (::add/desired-alias opts)
+                                  ::add/source-table        ::add/none
+                                  ;; sort of a HACK but this key will tell the SQL QP not to apply casting here either.
+                                  ::nest-query/outer-select true)
+                           ;; don't want to do temporal bucketing or binning inside the order by or breakout either.
+                           ;; That happens inside the `SELECT`
+                           (dissoc :temporal-unit :binning))]))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                                Clause Handlers                                                 |

--- a/src/metabase/models/field.clj
+++ b/src/metabase/models/field.clj
@@ -332,6 +332,11 @@
                        table-name))))
         field-name))
 
+(defn json-field?
+  "Return true if field is a JSON field, false if not."
+  [field]
+  (some? (:nfc_path field)))
+
 (defn qualified-name
   "Return a combined qualified name for `field`, e.g. `table_name.parent_field_name.field_name`."
   [field]

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -291,6 +291,36 @@
         (is (= ["(boop.bleh#>> ?::text[])::boolean " "{boop,foobar,1234}"]
                (hsql/format (#'postgres/json-query boop-identifier boolean-boop-field))))))))
 
+(deftest json-alias-test
+  (mt/test-driver :postgres
+    (testing "json breakouts and order bys have alias coercion"
+      (drop-if-exists-and-create-db! "json-alias-test")
+      (let [details   (mt/dbdef->connection-details :postgres :db {:database-name "json-alias-test"})
+            spec      (sql-jdbc.conn/connection-details->spec :postgres details)
+            json-part (json/generate-string {:bob :dobbs})
+            insert    (str "CREATE TABLE json_alias_test (json_part JSON NOT NULL);"
+                         (format "INSERT INTO json_alias_test (json_part) VALUES ('%s');" json-part))]
+        (jdbc/with-db-connection [conn (sql-jdbc.conn/connection-details->spec :postgres details)]
+          (jdbc/execute! spec [insert]))
+        (mt/with-temp* [Database [database {:engine :postgres, :details details}]
+                        Table    [table    {:db_id (u/the-id database) :name "json_alias_test"}]
+                        Field    [field    {:table_id (u/the-id table)
+                                            :nfc_path [:bob
+                                                       "injection' OR 1=1--' AND released = 1"
+                                                       (keyword "injection' OR 1=1--' AND released = 1")],
+                                            :name "json_alias_test"}]]
+          (let [compile-res (qp/compile
+                              {:database (u/the-id database)
+                               :type     :query
+                               :query    {:source-table (u/the-id table)
+                                          :aggregation  [[:count]]
+                                          :breakout     [[:field (u/the-id field) nil]]}})]
+            (is (= (str "SELECT (\"json_alias_test\".\"bob\"#>> ?::text[])::VARCHAR  "
+                        "AS \"json_alias_test\", count(*) AS \"count\" FROM \"json_alias_test\" "
+                        "GROUP BY \"json_alias_test\" ORDER BY \"json_alias_test\" ASC")
+                   (:query compile-res)))
+            (is (= '("{injection' OR 1=1--' AND released = 1,injection' OR 1=1--' AND released = 1}") (:params compile-res)))))))))
+
 (deftest describe-nested-field-columns-test
   (mt/test-driver :postgres
     (testing "describes json columns and gives types for ones with coherent schemas only"

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -302,13 +302,14 @@
                          (format "INSERT INTO json_alias_test (json_part) VALUES ('%s');" json-part))]
         (jdbc/with-db-connection [conn (sql-jdbc.conn/connection-details->spec :postgres details)]
           (jdbc/execute! spec [insert]))
-        (mt/with-temp* [Database [database {:engine :postgres, :details details}]
-                        Table    [table    {:db_id (u/the-id database) :name "json_alias_test"}]
-                        Field    [field    {:table_id (u/the-id table)
-                                            :nfc_path [:bob
-                                                       "injection' OR 1=1--' AND released = 1"
-                                                       (keyword "injection' OR 1=1--' AND released = 1")],
-                                            :name "json_alias_test"}]]
+        (mt/with-temp* [Database [database    {:engine :postgres, :details details}]
+                        Table    [table       {:db_id (u/the-id database) :name "json_alias_test"}]
+                        Field    [dummy-field {}]
+                        Field    [field       {:table_id (u/the-id table)
+                                               :nfc_path [:bob
+                                                          "injection' OR 1=1--' AND released = 1"
+                                                          (keyword "injection' OR 1=1--' AND released = 1")],
+                                               :name     "json_alias_test"}]]
           (let [compile-res (qp/compile
                               {:database (u/the-id database)
                                :type     :query

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -304,7 +304,6 @@
           (jdbc/execute! spec [insert]))
         (mt/with-temp* [Database [database    {:engine :postgres, :details details}]
                         Table    [table       {:db_id (u/the-id database) :name "json_alias_test"}]
-                        Field    [dummy-field {}]
                         Field    [field       {:table_id (u/the-id table)
                                                :nfc_path [:bob
                                                           "injection' OR 1=1--' AND released = 1"


### PR DESCRIPTION
This is basically similar to the old BigQuery problem #17536, but for JSON columns. Underlying problem is still that of multiplicity of JSON fields. Still pursuant to #21534. Specific issue this fixes is now #21759

Field value and aggregations and aggregations with orderings were separately not working. This is because when the JSON field is reference the end honeySQL representation of it is duplicated - but there necessarily needs to be a parameter for it. Therefore, we force the alias exactly in the same manner as Jeff's attack on #17536, as in literally the same exact code, I just moved it to sql.query-processor.clj.