### PR TITLE
Use new endpoint for model cache refresh modal

### DIFF
--- a/frontend/src/metabase/entities/persisted-models.js
+++ b/frontend/src/metabase/entities/persisted-models.js
@@ -43,6 +43,8 @@ const PersistedModels = createEntity({
         [payload.id]: {
           ...state[payload.id],
           state: "refreshing",
+          refresh_begin: new Date().toUTCString(),
+          refresh_end: null,
         },
       };
     }


### PR DESCRIPTION
#21551 added a simple page to monitor models cache refreshes to Admin > Tools. People can click on a failing cache refresh row item to see a detailed error message in a modal. 

We've just recently added a `/api/persisted/:id` endpoint to retrieve the cache refresh item. Before that, the modal was using the object from Redux as a temporary solution. This PR makes the modal use the `:id` endpoint.

### To Verify

1. Sign in as an admin
2. Go to `/admin/settings/caching` and enable model persistence
3. Spin up a sample PostgreSQL DB from [metabase/metabase-qa](https://github.com/metabase/metabase-qa) in Docker
4. Go to `/admin/databases`, connect the new PSQL DB and enable model persistence for the DB (click "Enable model persistence" button on DB page's sidebar)
5. Create a few questions using PSQL data, turn them into models and enable persistence for them (click the "database" icon in model details sidebar)
6. Go to `/admin/tools/model-caching`, ensure you see model cache refresh status records
7. Restart PSQL in Docker and manually refresh cache on `/admin/tools/model-caching`, this will make the records failing
8. Ensure you can click on the erroring row and see a model with problem details