### PR TITLE
Update Kerberos branch reference

### DIFF
--- a/.github/workflows/presto-kerberos-integration-test.yml
+++ b/.github/workflows/presto-kerberos-integration-test.yml
@@ -37,8 +37,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: metabase/presto-kerberos-docker
-          # use a custom branch if/until upstream (mik-laj/presto-kerberos-docker) can be fixed with PRs 23 and 24
-          ref: hacked-dec-2021
+          ref: master
           token: ${{ secrets.GITHUB_TOKEN }}
           path: presto-kerberos-docker
       - name: Bring up Presto+Kerberos cluster


### PR DESCRIPTION
https://github.com/metabase/presto-kerberos-docker `master` branch has been updated with the latest commits from https://github.com/mik-laj/presto-kerberos-docker + [Setting up test_data catalog with memory connector](https://github.com/metabase/presto-kerberos-docker/commit/96391ea0a1d3119cb6954f35e29be2b394ba8ad8). So we are good to use this as default for now.