### PR TITLE
Adding key for Dashboard Subscriptions button

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashboardActions.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardActions.jsx
@@ -52,7 +52,7 @@ export const getDashboardActions = (
     // Getting notifications with static text-only cards doesn't make a lot of sense
     if (canCreateSubscription) {
       buttons.push(
-        <Tooltip tooltip={t`Subscriptions`}>
+        <Tooltip tooltip={t`Subscriptions`} key="dashboard-subscriptions">
           <span>
             <DashboardHeaderButton
               disabled={!canManageSubscriptions}


### PR DESCRIPTION
Small 1 liner to clean up the console a bit. The Dashboard Subscriptions button was missing a key.
Before: 
![image](https://user-images.githubusercontent.com/1328979/164041105-593cf34e-6638-48b3-89e5-1f80b00e86f8.png)
After:
![image](https://user-images.githubusercontent.com/1328979/164041470-795239ec-34a5-4ebf-ad7c-9c44e14e19b9.png)

