### PR TITLE
Adding hover state for web notifications toaster dismiss button

### DIFF
--- a/frontend/src/metabase/components/Toaster/Toaster.styled.tsx
+++ b/frontend/src/metabase/components/Toaster/Toaster.styled.tsx
@@ -57,7 +57,8 @@ export const ToasterButton = styled.button`
 export const ToasterDismiss = styled.button`
   cursor: pointer;
   transition: color 200ms ease;
-  &:hover .Icon-close {
+  color: ${color("bg-dark")};
+  &:hover {
     color: ${lighten("bg-dark", 0.3)};
   }
 `;

--- a/frontend/src/metabase/components/Toaster/Toaster.styled.tsx
+++ b/frontend/src/metabase/components/Toaster/Toaster.styled.tsx
@@ -1,7 +1,5 @@
 import styled from "@emotion/styled";
-
 import { alpha, color, lighten } from "metabase/lib/colors";
-import Icon from "metabase/components/Icon";
 
 interface ToasterContainerProps {
   show: boolean;
@@ -56,10 +54,10 @@ export const ToasterButton = styled.button`
   }
 `;
 
-export const ToasterDismiss = styled(Icon)`
+export const ToasterDismiss = styled.button`
   cursor: pointer;
   transition: color 200ms ease;
-  &:hover {
+  &:hover .Icon-close {
     color: ${lighten("bg-dark", 0.3)};
   }
 `;

--- a/frontend/src/metabase/components/Toaster/Toaster.styled.tsx
+++ b/frontend/src/metabase/components/Toaster/Toaster.styled.tsx
@@ -1,6 +1,7 @@
 import styled from "@emotion/styled";
 
-import { alpha, color } from "metabase/lib/colors";
+import { alpha, color, lighten } from "metabase/lib/colors";
+import Icon from "metabase/components/Icon";
 
 interface ToasterContainerProps {
   show: boolean;
@@ -52,5 +53,13 @@ export const ToasterButton = styled.button`
   &:hover {
     cursor: pointer;
     background-color: ${alpha(color("bg-white"), 0.3)};
+  }
+`;
+
+export const ToasterDismiss = styled(Icon)`
+  cursor: pointer;
+  transition: color 200ms ease;
+  &:hover {
+    color: ${lighten("bg-dark", 0.3)};
   }
 `;

--- a/frontend/src/metabase/components/Toaster/Toaster.tsx
+++ b/frontend/src/metabase/components/Toaster/Toaster.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect, HTMLAttributes } from "react";
 import { t } from "ttag";
 import Icon from "metabase/components/Icon";
-import { color } from "metabase/lib/colors";
 
 import {
   ToasterContainer,
@@ -53,7 +52,7 @@ const Toaster = ({
         {confirmText}
       </ToasterButton>
       <ToasterDismiss onClick={onDismiss} aria-label="Close">
-        <Icon name="close" color={color("bg-dark")} />
+        <Icon name="close" />
       </ToasterDismiss>
     </ToasterContainer>
   ) : null;

--- a/frontend/src/metabase/components/Toaster/Toaster.tsx
+++ b/frontend/src/metabase/components/Toaster/Toaster.tsx
@@ -49,12 +49,12 @@ const Toaster = ({
   return render ? (
     <ToasterContainer show={open} fixed={fixed} className={className}>
       <ToasterMessage>{message}</ToasterMessage>
-      <ToasterButton onClick={onConfirm}>{confirmText}</ToasterButton>
-      <ToasterDismiss
-        name="close"
-        color={color("bg-dark")}
-        onClick={onDismiss}
-      />
+      <ToasterButton onClick={onConfirm} aria-label="Confirm">
+        {confirmText}
+      </ToasterButton>
+      <ToasterDismiss onClick={onDismiss} aria-label="Close">
+        <Icon name="close" color={color("bg-dark")} />
+      </ToasterDismiss>
     </ToasterContainer>
   ) : null;
 };

--- a/frontend/src/metabase/components/Toaster/Toaster.tsx
+++ b/frontend/src/metabase/components/Toaster/Toaster.tsx
@@ -7,6 +7,7 @@ import {
   ToasterContainer,
   ToasterMessage,
   ToasterButton,
+  ToasterDismiss,
 } from "./Toaster.styled";
 
 export interface ToasterProps extends HTMLAttributes<HTMLAnchorElement> {
@@ -49,7 +50,11 @@ const Toaster = ({
     <ToasterContainer show={open} fixed={fixed} className={className}>
       <ToasterMessage>{message}</ToasterMessage>
       <ToasterButton onClick={onConfirm}>{confirmText}</ToasterButton>
-      <Icon name="close" color={color("bg-dark")} onClick={onDismiss} />
+      <ToasterDismiss
+        name="close"
+        color={color("bg-dark")}
+        onClick={onDismiss}
+      />
     </ToasterContainer>
   ) : null;
 };


### PR DESCRIPTION
Dismiss icon was missing any indication that it was clickable. Added `cursor:pointer` and hover state 
![image](https://user-images.githubusercontent.com/1328979/164048318-270f1ffe-cbba-4e58-bd18-663d3b92ef7d.png)
