### PR TITLE
Disallow nil for timeline/event icons

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -11480,6 +11480,27 @@ databaseChangeLog:
               SET object = REPLACE(object, '/general/', '/application/')
               WHERE object LIKE '/general/%';
 
+  - changeSet:
+      id: v43.00-059
+      author: adam-james
+      comment: Added 0.43.0 - disallow nil timeline icons
+      changes:
+        - addNotNullConstraint:
+            columnDataType: varchar(128)
+            tableName: timeline
+            columnName: icon
+            defaultNullValue: "star"
+  - changeSet:
+      id: v43.00-060
+      author: adam-james
+      comment: Added 0.43.0 - disallow nil timeline event icons
+      changes:
+        - addNotNullConstraint:
+            columnDataType: varchar(128)
+            tableName: timeline_event
+            columnName: icon
+            defaultNullValue: "star"
+
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -19,6 +19,7 @@
             [metabase.models.permissions-group :as group]
             [metabase.models.setting :as setting]
             [metabase.models.setting.cache :as setting.cache]
+            [metabase.models.timeline :as timeline]
             [metabase.plugins.classloader :as classloader]
             [metabase.task :as task]
             [metabase.test-runner.assert-exprs :as assert-exprs]
@@ -199,11 +200,13 @@
    (fn [_]
      {:name       "Timeline of bird squawks"
       :default    false
+      :icon       timeline/DefaultIcon
       :creator_id (rasta-id)})
 
    TimelineEvent
    (fn [_]
      {:name         "default timeline event"
+      :icon         timeline/DefaultIcon
       :timestamp    (t/zoned-date-time)
       :timezone     "US/Pacific"
       :time_matters true


### PR DESCRIPTION
Timelines and Events have a concept of a default icon (star). The frontend will always send values for the icons, so in typical use the app-db will not have null icons anyway, but this did still allow users of the API to create timelines and events with nil icons.

This was originally done to preserve the ability to change the default icon later, and to keep the idea of the icon as a frontend visual decision. But this non-nil approach also works and keeps things consistent between how the frontend uses the endpoints and how we will now require the API to be used.