### PR TITLE
Add a cache section to model details sidebar

### DIFF
--- a/frontend/src/metabase-types/api/collection.ts
+++ b/frontend/src/metabase-types/api/collection.ts
@@ -2,6 +2,8 @@ export type CollectionId = number | "root";
 
 export type CollectionContentModel = "card" | "dataset";
 
+export type CollectionAuthorityLevel = "official" | null;
+
 export interface Collection {
   id: CollectionId;
   name: string;

--- a/frontend/src/metabase-types/api/index.ts
+++ b/frontend/src/metabase-types/api/index.ts
@@ -11,5 +11,6 @@ export * from "./slack";
 export * from "./user";
 export * from "./group";
 export * from "./permissions";
+export * from "./question";
 export * from "./dataset";
 export * from "./models";

--- a/frontend/src/metabase-types/api/index.ts
+++ b/frontend/src/metabase-types/api/index.ts
@@ -12,3 +12,4 @@ export * from "./user";
 export * from "./group";
 export * from "./permissions";
 export * from "./dataset";
+export * from "./models";

--- a/frontend/src/metabase-types/api/models.ts
+++ b/frontend/src/metabase-types/api/models.ts
@@ -1,4 +1,11 @@
-import { BaseUser, CollectionId, UserId } from "metabase-types/api";
+import {
+  BaseUser,
+  CollectionId,
+  CollectionAuthorityLevel,
+  DatabaseId,
+  UserId,
+} from "metabase-types/api";
+import { CardId } from "metabase-types/types/Card";
 
 export interface ModelCacheRefreshJob {
   id: number;
@@ -6,15 +13,15 @@ export interface ModelCacheRefreshJob {
   error: string | null;
   active: boolean;
 
-  card_id: number;
+  card_id: CardId;
   card_name: string;
 
   collection_id: CollectionId;
   collection_name: string;
-  collection_authority_level: "official" | null;
+  collection_authority_level: CollectionAuthorityLevel;
 
   columns: string[];
-  database_id: number;
+  database_id: DatabaseId;
   database_name: string;
   schema_name: string;
   table_name: string;

--- a/frontend/src/metabase-types/api/models.ts
+++ b/frontend/src/metabase-types/api/models.ts
@@ -1,11 +1,11 @@
 import {
   BaseUser,
+  CardId,
   CollectionId,
   CollectionAuthorityLevel,
   DatabaseId,
   UserId,
 } from "metabase-types/api";
-import { CardId } from "metabase-types/types/Card";
 
 export interface ModelCacheRefreshStatus {
   id: number;

--- a/frontend/src/metabase-types/api/models.ts
+++ b/frontend/src/metabase-types/api/models.ts
@@ -7,7 +7,7 @@ import {
 } from "metabase-types/api";
 import { CardId } from "metabase-types/types/Card";
 
-export interface ModelCacheRefreshJob {
+export interface ModelCacheRefreshStatus {
   id: number;
   state: "refreshing" | "persisted" | "error";
   error: string | null;

--- a/frontend/src/metabase-types/api/question.ts
+++ b/frontend/src/metabase-types/api/question.ts
@@ -1,0 +1,1 @@
+export type CardId = number;

--- a/frontend/src/metabase/admin/tasks/containers/ModelCacheRefreshJobs/ModelCacheRefreshJobModal.tsx
+++ b/frontend/src/metabase/admin/tasks/containers/ModelCacheRefreshJobs/ModelCacheRefreshJobModal.tsx
@@ -9,7 +9,7 @@ import ModalContent from "metabase/components/ModalContent";
 import { State } from "metabase-types/store";
 import PersistedModels from "metabase/entities/persisted-models";
 
-import { ModelCacheRefreshJob } from "metabase-types/api";
+import { ModelCacheRefreshStatus } from "metabase-types/api";
 
 import { ErrorBox } from "./ModelCacheRefreshJobs.styled";
 
@@ -21,8 +21,8 @@ type ModelCacheRefreshJobModalOwnProps = {
 };
 
 type ModelCacheRefreshJobModalStateProps = {
-  job?: ModelCacheRefreshJob;
-  onRefresh: (job: ModelCacheRefreshJob) => void;
+  job?: ModelCacheRefreshStatus;
+  onRefresh: (job: ModelCacheRefreshStatus) => void;
 };
 
 type ModelCacheRefreshJobModalProps = ModelCacheRefreshJobModalOwnProps &
@@ -41,7 +41,7 @@ function mapStateToProps(
 }
 
 const mapDispatchToProps = {
-  onRefresh: (job: ModelCacheRefreshJob) =>
+  onRefresh: (job: ModelCacheRefreshStatus) =>
     PersistedModels.objectActions.refreshCache(job),
 };
 

--- a/frontend/src/metabase/admin/tasks/containers/ModelCacheRefreshJobs/ModelCacheRefreshJobModal.tsx
+++ b/frontend/src/metabase/admin/tasks/containers/ModelCacheRefreshJobs/ModelCacheRefreshJobModal.tsx
@@ -9,7 +9,8 @@ import ModalContent from "metabase/components/ModalContent";
 import { State } from "metabase-types/store";
 import PersistedModels from "metabase/entities/persisted-models";
 
-import { ModelCacheRefreshJob } from "./types";
+import { ModelCacheRefreshJob } from "metabase-types/api";
+
 import { ErrorBox } from "./ModelCacheRefreshJobs.styled";
 
 type ModelCacheRefreshJobModalOwnProps = {

--- a/frontend/src/metabase/admin/tasks/containers/ModelCacheRefreshJobs/ModelCacheRefreshJobs.tsx
+++ b/frontend/src/metabase/admin/tasks/containers/ModelCacheRefreshJobs/ModelCacheRefreshJobs.tsx
@@ -15,7 +15,7 @@ import * as Urls from "metabase/lib/urls";
 
 import { usePagination } from "metabase/hooks/use-pagination";
 
-import { ModelCacheRefreshJob } from "metabase-types/api";
+import { ModelCacheRefreshStatus } from "metabase-types/api";
 
 import {
   ErrorBox,
@@ -25,7 +25,7 @@ import {
 } from "./ModelCacheRefreshJobs.styled";
 
 type JobTableItemProps = {
-  job: ModelCacheRefreshJob;
+  job: ModelCacheRefreshStatus;
   onRefresh: () => void;
 };
 
@@ -87,11 +87,11 @@ const PAGE_SIZE = 20;
 
 type Props = {
   children: JSX.Element;
-  onRefresh: (job: ModelCacheRefreshJob) => void;
+  onRefresh: (job: ModelCacheRefreshStatus) => void;
 };
 
 type PersistedModelsListLoaderProps = {
-  persistedModels: ModelCacheRefreshJob[];
+  persistedModels: ModelCacheRefreshStatus[];
   metadata: {
     total: number;
     limit: number | null;
@@ -100,7 +100,7 @@ type PersistedModelsListLoaderProps = {
 };
 
 const mapDispatchToProps = {
-  onRefresh: (job: ModelCacheRefreshJob) =>
+  onRefresh: (job: ModelCacheRefreshStatus) =>
     PersistedModels.objectActions.refreshCache(job),
 };
 

--- a/frontend/src/metabase/admin/tasks/containers/ModelCacheRefreshJobs/ModelCacheRefreshJobs.tsx
+++ b/frontend/src/metabase/admin/tasks/containers/ModelCacheRefreshJobs/ModelCacheRefreshJobs.tsx
@@ -15,7 +15,8 @@ import * as Urls from "metabase/lib/urls";
 
 import { usePagination } from "metabase/hooks/use-pagination";
 
-import { ModelCacheRefreshJob } from "./types";
+import { ModelCacheRefreshJob } from "metabase-types/api";
+
 import {
   ErrorBox,
   IconButtonContainer,

--- a/frontend/src/metabase/entities/persisted-models.js
+++ b/frontend/src/metabase/entities/persisted-models.js
@@ -22,7 +22,6 @@ const PersistedModels = createEntity({
 
   api: {
     get: ({ id, type }, ...args) => {
-      console.log({ id, type });
       return type === "byModelId"
         ? PersistedModelsApi.getForModel({ id }, ...args)
         : PersistedModelSchema.get({ id }, ...args);

--- a/frontend/src/metabase/entities/persisted-models.js
+++ b/frontend/src/metabase/entities/persisted-models.js
@@ -6,12 +6,9 @@ import { CardApi, PersistedModelsApi } from "metabase/services";
 const REFRESH_CACHE = "metabase/entities/persistedModels/REFRESH_CACHE";
 
 const getPersistedModelInfoByModelId = createSelector(
-  [
-    state => Object.values(state.entities.persistedModels),
-    (state, props) => props.entityId,
-  ],
+  [state => state.entities.persistedModels, (state, props) => props.entityId],
   (persistedModels, modelId) =>
-    persistedModels.find(info => info.card_id === modelId),
+    Object.values(persistedModels).find(info => info.card_id === modelId),
 );
 
 const PersistedModels = createEntity({

--- a/frontend/src/metabase/entities/persisted-models.js
+++ b/frontend/src/metabase/entities/persisted-models.js
@@ -1,8 +1,18 @@
+import { createSelector } from "reselect";
 import { PersistedModelSchema } from "metabase/schema";
 import { createEntity } from "metabase/lib/entities";
-import { CardApi } from "metabase/services";
+import { CardApi, PersistedModelsApi } from "metabase/services";
 
 const REFRESH_CACHE = "metabase/entities/persistedModels/REFRESH_CACHE";
+
+const getPersistedModelInfoByModelId = createSelector(
+  [
+    state => Object.values(state.entities.persistedModels),
+    (state, props) => props.entityId,
+  ],
+  (persistedModels, modelId) =>
+    persistedModels.find(info => info.card_id === modelId),
+);
 
 const PersistedModels = createEntity({
   name: "persistedModels",
@@ -10,11 +20,24 @@ const PersistedModels = createEntity({
   path: "/api/persist",
   schema: PersistedModelSchema,
 
+  api: {
+    get: ({ id, type }, ...args) => {
+      console.log({ id, type });
+      return type === "byModelId"
+        ? PersistedModelsApi.getForModel({ id }, ...args)
+        : PersistedModelSchema.get({ id }, ...args);
+    },
+  },
+
   objectActions: {
     refreshCache: async job => {
       await CardApi.refreshModelCache({ id: job.card_id });
       return { type: REFRESH_CACHE, payload: job };
     },
+  },
+
+  selectors: {
+    getByModelId: getPersistedModelInfoByModelId,
   },
 
   reducer: (state = {}, { type, payload }) => {

--- a/frontend/src/metabase/query_builder/components/view/sidebars/ModelCacheSection/ModelCacheSection.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/ModelCacheSection/ModelCacheSection.styled.tsx
@@ -1,0 +1,45 @@
+import styled from "@emotion/styled";
+
+import Icon from "metabase/components/Icon";
+
+import { color } from "metabase/lib/colors";
+
+export const Row = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+export const StatusContainer = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+export const StatusLabel = styled.span`
+  font-size: 0.875rem;
+  font-weight: bold;
+  color: ${color("text-dark")};
+`;
+
+export const LastRefreshTimeLabel = styled.span`
+  display: block;
+  font-size: 0.875rem;
+  font-weight: 400;
+  color: ${color("text-medium")};
+  margin-top: 4px;
+`;
+
+export const IconButton = styled.button`
+  display: flex;
+  cursor: pointer;
+`;
+
+export const ErrorIcon = styled(Icon)`
+  color: ${color("error")};
+  margin-top: 1px;
+  margin-left: 4px;
+`;
+
+export const RefreshIcon = styled(Icon)`
+  color: ${color("text-dark")};
+`;

--- a/frontend/src/metabase/query_builder/components/view/sidebars/ModelCacheSection/ModelCacheSection.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/ModelCacheSection/ModelCacheSection.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { t, jt } from "ttag";
+import { t } from "ttag";
 import moment from "moment";
 import { connect } from "react-redux";
 
@@ -35,7 +35,7 @@ function getStatusMessage(job: ModelCacheRefreshStatus) {
     return t`Refreshing model cache`;
   }
   const lastRefreshTime = moment(job.refresh_end).fromNow();
-  return jt`Model last cached ${lastRefreshTime}`;
+  return t`Model last cached ${lastRefreshTime}`;
 }
 
 const mapDispatchToProps = {
@@ -68,7 +68,7 @@ function ModelCacheSection({ model, onRefresh }: Props) {
               </StatusContainer>
               {isError && (
                 <LastRefreshTimeLabel>
-                  {jt`Last attempt ${lastRefreshTime}`}
+                  {t`Last attempt ${lastRefreshTime}`}
                 </LastRefreshTimeLabel>
               )}
             </div>

--- a/frontend/src/metabase/query_builder/components/view/sidebars/ModelCacheSection/ModelCacheSection.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/ModelCacheSection/ModelCacheSection.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+import { t, jt } from "ttag";
+import moment from "moment";
+import { connect } from "react-redux";
+
+import PersistedModels from "metabase/entities/persisted-models";
+
+import Question from "metabase-lib/lib/Question";
+import { ModelCacheRefreshJob } from "metabase-types/api";
+
+import {
+  Row,
+  StatusContainer,
+  StatusLabel,
+  LastRefreshTimeLabel,
+  IconButton,
+  ErrorIcon,
+  RefreshIcon,
+} from "./ModelCacheSection.styled";
+
+type Props = {
+  model: Question;
+  onRefresh: (job: ModelCacheRefreshJob) => void;
+};
+
+type LoaderRenderProps = {
+  persistedModels: ModelCacheRefreshJob[];
+};
+
+function getStatusMessage(job: ModelCacheRefreshJob) {
+  if (job.state === "error") {
+    return t`Failed to update model cache`;
+  }
+  if (job.state === "refreshing") {
+    return t`Refreshing model cache`;
+  }
+  const lastRefreshTime = moment(job.refresh_end).fromNow();
+  return jt`Model last cached ${lastRefreshTime}`;
+}
+
+const mapDispatchToProps = {
+  onRefresh: (job: ModelCacheRefreshJob) =>
+    PersistedModels.objectActions.refreshCache(job),
+};
+
+function ModelCacheSection({ model, onRefresh }: Props) {
+  return (
+    <PersistedModels.ListLoader
+      query={{
+        limit: 100,
+        offset: 0,
+      }}
+    >
+      {({ persistedModels }: LoaderRenderProps) => {
+        const job = persistedModels.find(job => job.card_id === model.id());
+        if (!job) {
+          return null;
+        }
+
+        const isError = job.state === "error";
+        const lastRefreshTime = moment(job.refresh_end).fromNow();
+
+        return (
+          <Row>
+            <div>
+              <StatusContainer>
+                <StatusLabel>{getStatusMessage(job)}</StatusLabel>
+                {isError && <ErrorIcon name="warning" size={14} />}
+              </StatusContainer>
+              {isError && (
+                <LastRefreshTimeLabel>
+                  {jt`Last attempt ${lastRefreshTime}`}
+                </LastRefreshTimeLabel>
+              )}
+            </div>
+            <IconButton onClick={() => onRefresh(job)}>
+              <RefreshIcon name="refresh" tooltip={t`Refresh now`} size={14} />
+            </IconButton>
+          </Row>
+        );
+      }}
+    </PersistedModels.ListLoader>
+  );
+}
+
+export default connect(null, mapDispatchToProps)(ModelCacheSection);

--- a/frontend/src/metabase/query_builder/components/view/sidebars/ModelCacheSection/ModelCacheSection.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/ModelCacheSection/ModelCacheSection.tsx
@@ -24,7 +24,7 @@ type Props = {
 };
 
 type LoaderRenderProps = {
-  persistedModels: ModelCacheRefreshStatus[];
+  persistedModel: ModelCacheRefreshStatus;
 };
 
 function getStatusMessage(job: ModelCacheRefreshStatus) {
@@ -45,26 +45,25 @@ const mapDispatchToProps = {
 
 function ModelCacheSection({ model, onRefresh }: Props) {
   return (
-    <PersistedModels.ListLoader
-      query={{
-        limit: 100,
-        offset: 0,
-      }}
+    <PersistedModels.Loader
+      id={model.id()}
+      entityQuery={{ type: "byModelId" }}
+      selectorName="getByModelId"
+      loadingAndErrorWrapper={false}
     >
-      {({ persistedModels }: LoaderRenderProps) => {
-        const job = persistedModels.find(job => job.card_id === model.id());
-        if (!job) {
+      {({ persistedModel }: LoaderRenderProps) => {
+        if (!persistedModel) {
           return null;
         }
 
-        const isError = job.state === "error";
-        const lastRefreshTime = moment(job.refresh_end).fromNow();
+        const isError = persistedModel.state === "error";
+        const lastRefreshTime = moment(persistedModel.refresh_end).fromNow();
 
         return (
           <Row>
             <div>
               <StatusContainer>
-                <StatusLabel>{getStatusMessage(job)}</StatusLabel>
+                <StatusLabel>{getStatusMessage(persistedModel)}</StatusLabel>
                 {isError && <ErrorIcon name="warning" size={14} />}
               </StatusContainer>
               {isError && (
@@ -73,13 +72,13 @@ function ModelCacheSection({ model, onRefresh }: Props) {
                 </LastRefreshTimeLabel>
               )}
             </div>
-            <IconButton onClick={() => onRefresh(job)}>
+            <IconButton onClick={() => onRefresh(persistedModel)}>
               <RefreshIcon name="refresh" tooltip={t`Refresh now`} size={14} />
             </IconButton>
           </Row>
         );
       }}
-    </PersistedModels.ListLoader>
+    </PersistedModels.Loader>
   );
 }
 

--- a/frontend/src/metabase/query_builder/components/view/sidebars/ModelCacheSection/ModelCacheSection.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/ModelCacheSection/ModelCacheSection.tsx
@@ -6,7 +6,7 @@ import { connect } from "react-redux";
 import PersistedModels from "metabase/entities/persisted-models";
 
 import Question from "metabase-lib/lib/Question";
-import { ModelCacheRefreshJob } from "metabase-types/api";
+import { ModelCacheRefreshStatus } from "metabase-types/api";
 
 import {
   Row,
@@ -20,14 +20,14 @@ import {
 
 type Props = {
   model: Question;
-  onRefresh: (job: ModelCacheRefreshJob) => void;
+  onRefresh: (job: ModelCacheRefreshStatus) => void;
 };
 
 type LoaderRenderProps = {
-  persistedModels: ModelCacheRefreshJob[];
+  persistedModels: ModelCacheRefreshStatus[];
 };
 
-function getStatusMessage(job: ModelCacheRefreshJob) {
+function getStatusMessage(job: ModelCacheRefreshStatus) {
   if (job.state === "error") {
     return t`Failed to update model cache`;
   }
@@ -39,7 +39,7 @@ function getStatusMessage(job: ModelCacheRefreshJob) {
 }
 
 const mapDispatchToProps = {
-  onRefresh: (job: ModelCacheRefreshJob) =>
+  onRefresh: (job: ModelCacheRefreshStatus) =>
     PersistedModels.objectActions.refreshCache(job),
 };
 

--- a/frontend/src/metabase/query_builder/components/view/sidebars/ModelCacheSection/index.ts
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/ModelCacheSection/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ModelCacheSection";

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebarPanel.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebarPanel.jsx
@@ -14,6 +14,7 @@ import {
   ModerationSectionContainer,
 } from "./QuestionDetailsSidebarPanel.styled";
 import DatasetManagementSection from "./DatasetManagementSection";
+import ModelCacheSection from "./ModelCacheSection";
 
 QuestionDetailsSidebarPanel.propTypes = {
   question: PropTypes.object.isRequired,
@@ -59,6 +60,7 @@ function QuestionDetailsSidebarPanel({
           description={description}
           onEdit={onDescriptionEdit}
         />
+        {isDataset && <ModelCacheSection model={question} />}
         <BorderedSectionContainer>
           {isDataset && canWrite && (
             <DatasetManagementSection dataset={question} />

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -426,6 +426,8 @@ export const PermissionsApi = {
 };
 
 export const PersistedModelsApi = {
+  get: GET("/api/persist/:id"),
+  getForModel: GET("/api/persist/card/:id"),
   enablePersistence: POST("/api/persist/enable"),
   disablePersistence: POST("/api/persist/disable"),
   setRefreshInterval: POST("/api/persist/set-interval"),


### PR DESCRIPTION
Adds a section about model cache to the details sidebar. The section shows the current state of the cache (persisted correctly / refreshing now / failed to refresh) + the latest refresh timestamp and a button to manually trigger a refresh

### To Verify

1. Sign in as an admin
2. Go to `/admin/settings/caching` and enable model persistence
3. Spin up a sample PostgreSQL DB from [metabase/metabase-qa](https://github.com/metabase/metabase-qa) in Docker
4. Go to `/admin/databases`, connect the new PSQL DB and enable model persistence for the DB (click the "Enable model persistence" button on the DB page's sidebar)
5. Create a few questions using PSQL data, turn them into models, and enable persistence for them (click the "database" icon in the model details sidebar)
6. Refresh the page and open the details sidebar again. You should now see a section saying when the last cache refresh has happened
7. Click the refresh button
8. Refresh the page, and open the details sidebar again
9. Ensure the last cache refresh timestamp has changed to "a few seconds ago"

### Demo

<img width="413" alt="CleanShot 2022-04-19 at 19 45 06@2x" src="https://user-images.githubusercontent.com/17258145/164074302-be94d578-fc4d-4971-b214-6caa1fe2f88d.png">

![CleanShot 2022-04-19 at 19 42 50](https://user-images.githubusercontent.com/17258145/164074317-a4e6c67a-2cea-454f-9c3d-d87bc90e83d7.gif)

