### PR TITLE
make sure we pass :port when creating ssh tunnels

### DIFF
--- a/src/metabase/driver/sql_jdbc/connection.clj
+++ b/src/metabase/driver/sql_jdbc/connection.clj
@@ -252,7 +252,7 @@
 (defn details->connection-spec-for-testing-connection
   "Return an appropriate JDBC connection spec to test whether a set of connection details is valid (i.e., implementing
   `can-connect?`)."
-  [driver {:keys [port] :as details}]
+  [driver details]
   (let [details-with-tunnel (driver/incorporate-ssh-tunnel-details
                              driver
                              (update details :port #(or % (default-ssh-tunnel-target-port driver))))]

--- a/src/metabase/driver/sql_jdbc/connection.clj
+++ b/src/metabase/driver/sql_jdbc/connection.clj
@@ -96,12 +96,21 @@
     {:datasource (DataSources/pooledDataSource datasource (connection-pool/map->properties pool-properties))}
     (connection-pool/connection-pool-spec spec pool-properties)))
 
+(defn ^:private default-ssh-tunnel-target-port  [driver]
+  (when-let [port-info (some
+                        #(when (= "port" (:name %)) %)
+                        (driver/connection-properties driver))]
+    (or (:default port-info)
+        (:placeholder port-info))))
+
 (defn- create-pool!
   "Create a new C3P0 `ComboPooledDataSource` for connecting to the given `database`."
   [{:keys [id details], driver :engine, :as database}]
   {:pre [(map? database)]}
   (log/debug (u/format-color 'cyan (trs "Creating new connection pool for {0} database {1} ..." driver id)))
-  (let [details-with-tunnel (driver/incorporate-ssh-tunnel-details driver details) ;; If the tunnel is disabled this returned unchanged
+  (let [details-with-tunnel (driver/incorporate-ssh-tunnel-details  ;; If the tunnel is disabled this returned unchanged
+                             driver
+                             (update details :port #(or % (default-ssh-tunnel-target-port driver))))
         spec                (connection-details->spec driver details-with-tunnel)
         properties          (data-warehouse-connection-pool-properties driver database)]
     (merge
@@ -239,13 +248,6 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                             metabase.driver impls                                              |
 ;;; +----------------------------------------------------------------------------------------------------------------+
-
-(defn ^:private default-ssh-tunnel-target-port  [driver]
-  (when-let [port-info (some
-                        #(when (= "port" (:name %)) %)
-                        (driver/connection-properties driver))]
-    (or (:default port-info)
-        (:placeholder port-info))))
 
 (defn details->connection-spec-for-testing-connection
   "Return an appropriate JDBC connection spec to test whether a set of connection details is valid (i.e., implementing

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -52,7 +52,11 @@
       ;; actually if we are going to `throw-exceptions` we'll rethrow the original but attempt to humanize the message
       ;; first
       (catch Throwable e
-        (throw (Exception. (str (driver/humanize-connection-error-message driver (.getMessage e))) e))))
+        (throw (if-let [message (some->> (.getMessage e)
+                                         (driver/humanize-connection-error-message driver)
+                                         str)]
+                 (Exception. message e)
+                 e))))
     (try
       (can-connect-with-details? driver details-map :throw-exceptions)
       (catch Throwable e

--- a/src/metabase/util/ssh.clj
+++ b/src/metabase/util/ssh.clj
@@ -50,6 +50,7 @@
   callers responsibility to call `close-tunnel` on the returned connection object."
   [{:keys [^String tunnel-host ^Integer tunnel-port ^String tunnel-user tunnel-pass tunnel-private-key
            tunnel-private-key-passphrase host port]}]
+  {:pre [(integer? port)]}
   (let [^ConnectFuture conn-future (.connect client tunnel-user tunnel-host tunnel-port)
         ^SessionHolder conn-status (.verify conn-future default-ssh-timeout)
         hb-sec                     (public-settings/ssh-heartbeat-interval-sec)


### PR DESCRIPTION
fixes #20756.

When checking that an ssh tunnel can be opened, we need to know the target port. This was not being passed through, and the thrown exception's message was not being handled correctly.