### PR TITLE
Set HTML language to match site settings

### DIFF
--- a/resources/frontend_client/index_template.html
+++ b/resources/frontend_client/index_template.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{{language}}}" translate="no">
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />

--- a/src/metabase/server/routes/index.clj
+++ b/src/metabase/server/routes/index.clj
@@ -77,6 +77,7 @@
       :googleAnalyticsJS  (load-inline-js "index_ganalytics")
       :bootstrapJSON      (escape-script (json/generate-string public-settings))
       :localizationJSON   (escape-script (load-localization))
+      :language           (hiccup.util/escape-html (public-settings/site-locale))
       :favicon            (hiccup.util/escape-html (public-settings/application-favicon-url))
       :applicationName    (hiccup.util/escape-html (public-settings/application-name))
       :uri                (hiccup.util/escape-html uri)


### PR DESCRIPTION
## Before

- The html document language was always set to `en` regardless of metabase's own internal settings, messing up users' ability to properly use browser-translation tools (or causing browsers to unnecessarily prompt users to translate already-localized content)

## Changes

- Pull from metabase's site settings to set the appropriate html language
- resolves #21374

## After

- html lang changes based on metabase settings

![Screenshot from 2022-04-19 13-53-22](https://user-images.githubusercontent.com/30528226/164084863-3090ec13-31d5-4df2-adb3-5c28794b140c.png)

