### PR TITLE
Restrict custom mapping values access

### DIFF
--- a/frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx
@@ -56,25 +56,37 @@ export default class FieldRemapping extends React.Component {
     throw new Error(t`Unrecognized mapping type`);
   };
 
-  getAvailableMappingTypes = () => {
-    const { field } = this.props;
+  hasForeignKeys = () =>
+    this.props.field.semantic_type === "type/FK" &&
+    this.getForeignKeys().length > 0;
 
-    const hasForeignKeys =
-      field.semantic_type === "type/FK" && this.getForeignKeys().length > 0;
+  hasMappableNumeralValues = () => {
+    const { field } = this.props;
 
     // Only show the "custom" option if we have some values that can be mapped to user-defined custom values
     // (for a field without user-defined remappings, every key of `field.remappings` has value `undefined`)
-    const hasMappableNumeralValues =
+    return (
       field.remapping.size > 0 &&
       [...field.remapping.keys()].every(
         key => typeof key === "number" || key === null,
-      );
+      )
+    );
+  };
 
-    return [
+  getAvailableMappingTypes = () => {
+    const mappingTypes = [
       MAP_OPTIONS.original,
-      ...(hasForeignKeys ? [MAP_OPTIONS.foreign] : []),
-      ...(hasMappableNumeralValues > 0 ? [MAP_OPTIONS.custom] : []),
+      ...(this.hasForeignKeys() ? [MAP_OPTIONS.foreign] : []),
+      ...(this.hasMappableNumeralValues() > 0 ? [MAP_OPTIONS.custom] : []),
     ];
+
+    const selectedType = this.getMappingTypeForField(this.props.field);
+
+    if (!mappingTypes.includes(selectedType)) {
+      mappingTypes.push(selectedType);
+    }
+
+    return mappingTypes;
   };
 
   getFKTargetTableEntityNameOrNull = () => {
@@ -247,7 +259,11 @@ export default class FieldRemapping extends React.Component {
   };
 
   render() {
-    const { field, table, fields } = this.props;
+    const { field, table, fields, fieldsError } = this.props;
+    const isFieldsAccessRestricted = fieldsError?.status === 403;
+
+    console.log(">>isFieldsAccessRestricted", isFieldsAccessRestricted);
+
     const {
       isChoosingInitialFkTarget,
       hasChanged,
@@ -271,57 +287,64 @@ export default class FieldRemapping extends React.Component {
             optionValueFn={o => o}
             className="inline-block"
           />
-          {mappingType === MAP_OPTIONS.foreign && [
-            <SelectSeparator classname="flex" key="foreignKeySeparator" />,
-            <PopoverWithTrigger
-              key="foreignKeyName"
-              ref={this.fkPopover}
-              triggerElement={
-                <SelectButton
-                  hasValue={hasFKMappingValue}
-                  className={cx({
-                    "border-error": dismissedInitialFkTargetPopover,
-                    "border-dark": !dismissedInitialFkTargetPopover,
-                  })}
-                >
-                  {fkMappingField ? (
-                    fkMappingField.display_name
-                  ) : (
-                    <span className="text-medium">{t`Choose a field`}</span>
-                  )}
-                </SelectButton>
-              }
-              isInitiallyOpen={isChoosingInitialFkTarget}
-              onClose={this.onFkPopoverDismiss}
-            >
-              <FieldList
-                className="text-purple"
-                field={fkMappingField}
-                fieldOptions={{
-                  count: 0,
-                  dimensions: [],
-                  fks: this.getForeignKeys(),
-                }}
-                table={table}
-                onFieldChange={this.onForeignKeyFieldChange}
-                hideSingleSectionTitle
-              />
-            </PopoverWithTrigger>,
-            dismissedInitialFkTargetPopover && (
-              <div className="text-error ml2">{t`Please select a column to use for display.`}</div>
-            ),
-          ]}
+          {mappingType === MAP_OPTIONS.foreign && (
+            <>
+              <SelectSeparator classname="flex" key="foreignKeySeparator" />,
+              <PopoverWithTrigger
+                key="foreignKeyName"
+                ref={this.fkPopover}
+                triggerElement={
+                  <SelectButton
+                    hasValue={hasFKMappingValue}
+                    className={cx({
+                      "border-error": dismissedInitialFkTargetPopover,
+                      "border-dark": !dismissedInitialFkTargetPopover,
+                    })}
+                  >
+                    {fkMappingField ? (
+                      fkMappingField.display_name
+                    ) : (
+                      <span className="text-medium">{t`Choose a field`}</span>
+                    )}
+                  </SelectButton>
+                }
+                isInitiallyOpen={isChoosingInitialFkTarget}
+                onClose={this.onFkPopoverDismiss}
+              >
+                <FieldList
+                  className="text-purple"
+                  field={fkMappingField}
+                  fieldOptions={{
+                    count: 0,
+                    dimensions: [],
+                    fks: this.getForeignKeys(),
+                  }}
+                  table={table}
+                  onFieldChange={this.onForeignKeyFieldChange}
+                  hideSingleSectionTitle
+                />
+              </PopoverWithTrigger>
+              {dismissedInitialFkTargetPopover && (
+                <div className="text-error ml2">{t`Please select a column to use for display.`}</div>
+              )}
+            </>
+          )}
         </FieldMappingContainer>
         {hasChanged && hasFKMappingValue && <RemappingNamingTip />}
-        {mappingType === MAP_OPTIONS.custom && (
-          <div className="mt3">
-            {hasChanged && <RemappingNamingTip />}
-            <ValueRemappings
-              remappings={field && field.remapping}
-              updateRemappings={this.onUpdateRemappings}
-            />
-          </div>
-        )}
+        {mappingType === MAP_OPTIONS.custom &&
+          (isFieldsAccessRestricted ? (
+            <div className="pt2 text-error">
+              {t`You need unrestricted data access on this table to map custom display values.`}
+            </div>
+          ) : (
+            <div className="mt3">
+              {hasChanged && <RemappingNamingTip />}
+              <ValueRemappings
+                remappings={field && field.remapping}
+                updateRemappings={this.onUpdateRemappings}
+              />
+            </div>
+          ))}
       </div>
     );
   }

--- a/frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx
@@ -260,15 +260,13 @@ export default class FieldRemapping extends React.Component {
 
   render() {
     const { field, table, fields, fieldsError } = this.props;
-    const isFieldsAccessRestricted = fieldsError?.status === 403;
-
-    console.log(">>isFieldsAccessRestricted", isFieldsAccessRestricted);
-
     const {
       isChoosingInitialFkTarget,
       hasChanged,
       dismissedInitialFkTargetPopover,
     } = this.state;
+
+    const isFieldsAccessRestricted = fieldsError?.status === 403;
 
     const mappingType = this.getMappingTypeForField(field);
     const isFKMapping = mappingType === MAP_OPTIONS.foreign;

--- a/frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx
@@ -59,6 +59,10 @@ const mapStateToProps = (state, props) => {
     databaseId,
     fieldId,
     field: Fields.selectors.getObjectUnfiltered(state, { entityId: fieldId }),
+    fieldsError: Fields.selectors.getError(state, {
+      entityId: fieldId,
+      requestType: "values",
+    }),
     tableId: parseInt(props.params.tableId),
     metadata: getMetadata(state),
     idfields: Databases.selectors.getIdfields(state, { databaseId }),
@@ -157,6 +161,7 @@ export default class FieldApp extends React.Component {
     const {
       metadata,
       field,
+      fieldsError,
       databaseId,
       tableId,
       idfields,
@@ -217,6 +222,7 @@ export default class FieldApp extends React.Component {
               {section == null || section === "general" ? (
                 <FieldGeneralPane
                   field={field}
+                  fieldsError={fieldsError}
                   idfields={idfields}
                   table={table}
                   metadata={metadata}
@@ -244,6 +250,7 @@ export default class FieldApp extends React.Component {
 
 const FieldGeneralPane = ({
   field,
+  fieldsError,
   idfields,
   table,
   metadata,
@@ -343,6 +350,7 @@ const FieldGeneralPane = ({
         field={field}
         table={table}
         fields={metadata.fields}
+        fieldsError={fieldsError}
         updateFieldProperties={onUpdateFieldProperties}
         updateFieldValues={onUpdateFieldValues}
         updateFieldDimension={onUpdateFieldDimension}


### PR DESCRIPTION
## Changes

Restrict custom mapping access [(conversation)]( https://metaboat.slack.com/archives/C0312QQCHLP/p1650047700902939?thread_ts=1650037458.019659&cid=C0312QQCHLP
)

- Create a Test User and login under it in a separate window
- As an admin open the [Quantity field of the Orders table in the data model page](http://localhost:3000/admin/datamodel/database/1/table/2/10/general)
- Set "Filtering on this field" to "A list of values"
- Set "Display values" to "Custom mapping"
- Open the [data permissions page](http://localhost:3000/admin/permissions/data/group/1) and set Data Access permission to "No self-service", Manage data model permission to "Yes"
- As a test user open the [Quantity field of the Orders table in the data model page](http://localhost:3000/admin/datamodel/database/1/table/2/10/general)
- Ensure it shows a message that describes the lack of access
