### PR TITLE
Prevent the loss of Field metadata when converting Fields into FieldDimensions

### DIFF
--- a/frontend/src/metabase-lib/lib/Dimension.ts
+++ b/frontend/src/metabase-lib/lib/Dimension.ts
@@ -807,8 +807,11 @@ export class FieldDimension extends Dimension {
   }
 
   field(): Field {
-    if (this._field && this._field._trusted === true) {
-      return this._field;
+    if (
+      this._fieldInstance &&
+      this._fieldInstance._comesFromEndpoint === true
+    ) {
+      return this._fieldInstance;
     }
 
     const question = this.query()?.question();
@@ -919,8 +922,8 @@ export class FieldDimension extends Dimension {
       { ...this._options, ...options },
       this._metadata,
       this._query,
-      this._field && {
-        _field: this._field,
+      this._fieldInstance && {
+        _fieldInstance: this._fieldInstance,
       },
     );
   }

--- a/frontend/src/metabase-lib/lib/Dimension.ts
+++ b/frontend/src/metabase-lib/lib/Dimension.ts
@@ -807,6 +807,10 @@ export class FieldDimension extends Dimension {
   }
 
   field(): Field {
+    if (this._field && this._field._trusted === true) {
+      return this._field;
+    }
+
     const question = this.query()?.question();
     const lookupField = this.isIntegerFieldId() ? "id" : "name";
     const fieldMetadata = question
@@ -915,6 +919,9 @@ export class FieldDimension extends Dimension {
       { ...this._options, ...options },
       this._metadata,
       this._query,
+      this._field && {
+        _field: this._field,
+      },
     );
   }
 

--- a/frontend/src/metabase-lib/lib/Dimension.ts
+++ b/frontend/src/metabase-lib/lib/Dimension.ts
@@ -1035,7 +1035,7 @@ export class FieldDimension extends Dimension {
   }
 
   _dimensionForOption(option): FieldDimension {
-    const dimension = option.mbql
+    let dimension = option.mbql
       ? FieldDimension.parseMBQLOrWarn(option.mbql, this._metadata, this._query)
       : this;
 
@@ -1046,6 +1046,15 @@ export class FieldDimension extends Dimension {
         option,
       );
       return null;
+    }
+
+    // Field literal's sub-dimensions sometimes don't have a specified base-type
+    // This can break a query, so here we need to ensure it mirrors the parent dimension
+    if (this.getOption("base-type") && !dimension.getOption("base-type")) {
+      dimension = dimension.withOption(
+        "base-type",
+        this.getOption("base-type"),
+      );
     }
 
     const additionalProperties = {

--- a/frontend/src/metabase-lib/lib/metadata/Field.ts
+++ b/frontend/src/metabase-lib/lib/metadata/Field.ts
@@ -30,7 +30,7 @@ import {
   getIconForField,
   getFilterOperators,
 } from "metabase/lib/schema_metadata";
-import Dimension from "../Dimension";
+import { FieldDimension } from "../Dimension";
 import Table from "./Table";
 import Base from "./Base";
 /**
@@ -223,7 +223,18 @@ export default class Field extends Base {
   }
 
   dimension() {
-    return Dimension.parseMBQL(this.reference(), this.metadata, this.query);
+    const ref = this.reference();
+    const fieldDimension = new FieldDimension(
+      ref[1],
+      ref[2],
+      this.metadata,
+      this.query,
+      {
+        _field: this,
+      },
+    );
+
+    return fieldDimension;
   }
 
   sourceField() {

--- a/frontend/src/metabase-lib/lib/metadata/Field.ts
+++ b/frontend/src/metabase-lib/lib/metadata/Field.ts
@@ -230,7 +230,7 @@ export default class Field extends Base {
       this.metadata,
       this.query,
       {
-        _field: this,
+        _fieldInstance: this,
       },
     );
 

--- a/frontend/src/metabase/query_builder/components/BreakoutPopover.jsx
+++ b/frontend/src/metabase/query_builder/components/BreakoutPopover.jsx
@@ -20,12 +20,15 @@ const BreakoutPopover = ({
   if (!table) {
     return null;
   }
+
+  const fieldOptions = breakoutOptions || query.breakoutOptions(breakout);
+
   return (
     <FieldList
       className={cx(className, "text-green")}
       width={width}
       field={breakout}
-      fieldOptions={breakoutOptions || query.breakoutOptions(breakout)}
+      fieldOptions={fieldOptions}
       onFieldChange={field => {
         onChangeBreakout(field);
         if (onClose) {

--- a/frontend/src/metabase/selectors/metadata.js
+++ b/frontend/src/metabase/selectors/metadata.js
@@ -69,7 +69,13 @@ export const getShallowSegments = getNormalizedSegments;
 export const instantiateDatabase = obj => new Database(obj);
 export const instantiateSchema = obj => new Schema(obj);
 export const instantiateTable = obj => new Table(obj);
-export const instantiateField = obj => new Field({ ...obj, _trusted: true });
+// We need a way to distinguish field objects that come from the server
+// vs. those that are created client-side to handle lossy transformations between
+// Field instances and FieldDimension instances.
+// There are scenarios where we are failing to convert FieldDimensions back into Fields,
+// and as a safeguard we instantiate a new Field that is missing most of its properties.
+export const instantiateField = obj =>
+  new Field({ ...obj, _comesFromEndpoint: true });
 export const instantiateSegment = obj => new Segment(obj);
 export const instantiateMetric = obj => new Metric(obj);
 

--- a/frontend/src/metabase/selectors/metadata.js
+++ b/frontend/src/metabase/selectors/metadata.js
@@ -69,7 +69,7 @@ export const getShallowSegments = getNormalizedSegments;
 export const instantiateDatabase = obj => new Database(obj);
 export const instantiateSchema = obj => new Schema(obj);
 export const instantiateTable = obj => new Table(obj);
-export const instantiateField = obj => new Field(obj);
+export const instantiateField = obj => new Field({ ...obj, _trusted: true });
 export const instantiateSegment = obj => new Segment(obj);
 export const instantiateMetric = obj => new Metric(obj);
 

--- a/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
@@ -146,7 +146,14 @@ describe("binning related reproductions", () => {
       cy.findByText("CREATED_AT")
         .closest(".List-item")
         .findByText("by month");
+
+      cy.findByText("CREATED_AT").click();
     });
+
+    cy.findByText("Question 4 → Created At: Month");
+
+    visualize();
+    cy.get("circle");
   });
 
   it("should display date granularity on Summarize when opened from saved question (metabase#11439)", () => {

--- a/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
@@ -109,7 +109,7 @@ describe("binning related reproductions", () => {
     cy.findByText("CREATED_AT");
   });
 
-  it.skip("should render binning options when joining on the saved native question (metabase#18646)", () => {
+  it("should render binning options when joining on the saved native question (metabase#18646)", () => {
     cy.createNativeQuestion(
       {
         name: "18646",
@@ -133,13 +133,10 @@ describe("binning related reproductions", () => {
       .click();
 
     popover().within(() => {
-      cy.findByText("CREATED_AT")
-        .closest(".List-item")
-        .findByText("by month")
-        .click();
+      cy.findByText("ID").click();
     });
 
-    cy.findByText("Pick the metric you want to see").click();
+    cy.findByText("Summarize").click();
     cy.findByText("Count of rows").click();
 
     cy.findByText("Pick a column to group by").click();

--- a/frontend/test/metabase/scenarios/joins/joins-2.cy.spec.js
+++ b/frontend/test/metabase/scenarios/joins/joins-2.cy.spec.js
@@ -180,7 +180,7 @@ describe("scenarios > question > joined questions", () => {
 
       popover().within(() => {
         enterCustomColumnDetails({
-          formula: "[Question 5 → sum] / [Sum of Rating]",
+          formula: "[Question 5 → Sum of Rating] / [Sum of Rating]",
         });
 
         cy.findByPlaceholderText("Something nice and descriptive").type(


### PR DESCRIPTION
Fixes #18646

**Root cause**
1. In order to get a list of granularity/binning options for the dimensions found in a given query, we call `StructuredQuery.prototype.dimensionOptions`. This method collects these options from its joins via a call to `Join.prototype.joinedDimensionOptions`.
1. The Join instance's underlying table (coming from the `Join.prototype.joinedTable` method) is a virtual table in this scenario, because we're using a saved question in the join, with an id of something like `"card__123"`. This virtual table looks correct; it is retrievable via `metadata.table("card__123")` and it has a fully populated list of Fields with all metadata.
1. `joinedDimensionOptions` converts the fields found on the virtual table into `FieldDimension` instances. In this conversion process, `Field.prototype.dimension` returns the results from `Dimension.parseMBQL(this.reference(), this.metadata, this.query)`. The `this.query` value here is `undefined` because the field instance is treated as coming from a table (even if the table is actually a card, sort of), so when the Dimension is instantiated, all it has is the reference, eg something like `["field", "CREATED_AT", { "base-type": "type/DateTime" }]`.
1. When the above `FieldDimension` is converted back into a `Field` instance via `FieldDimension.prototype.field`, it does not have enough information to properly return it to its original form, so it hits the fallback at the end of the method and returns a `Field` with only an `id` and a `base-type`.
1. This is the point of no return -- we are very restricted in what we can do with this object. For granularity/binning to work, we rely on the presence of `dimension_options` on the field instance, and we no longer have way to access it.

**TLDR**: the Field --> FieldDimension --> Field transformation is lossy because we don't hold onto the field's `table_id`, which is needed to uniquely identify the fields on virtual tables.

In addition to the above, when creating the subdimensions for a given field, we are losing the `base-type` of the subdimension option, so the query will fail. One of the commits from https://github.com/metabase/metabase/pull/18921 fixes it: https://github.com/metabase/metabase/pull/21782/commits/d9170a4aae0f4bcae4aaca7755f6046eeb1ae02b

---
**Potential solution 1** 
1. When instantiating the `FieldDimension` from a field, preserve its `table_id` property.
1. Then, in `FieldDimension.prototype.field`, we can call `metadata.table(this.table_id)` to get the virtual table and then look for the field using `ref[1]` or `fieldIdOrName`.

**Potential solution 2**
1. When instantiating the `FieldDimension` directly from a `Field` instance set on the dimension instance a reference to the field instance.
1. Then, in `FieldDimension.prototype.field`, we can immediately check for the presence of this instance and return it.

---

**This PR uses solution 2. Here's why:**
1. The `FieldDimension.prototype.field` method **is a giant hack** and adding another hoop to jump through will probably end up hurting us in the long run. We potentially start running into scenarios where `table_id` is set on the dimension alongside a query. In that scenario, which `Field` do we use? Either/or? Or will there be a difference?
1. If we already have a reference to the `Field` instance, why can't we just hold onto it? It short circuits the giant hack field method, and it guarantees we preserve everything when we go from fields to dimensions to fields to dimensions.
1. We introduce some risk around relying on a bad field instance, but this is easily resolvable by identifying what fields can be trusted: fields found in the god `Metadata` object.

Regarding the addition of `_comesFromEndpoint`, this is obviously a hack, but I think it is a reasonable one to add, for now. We are willy nilly instantiating new `Field` instances in a number of places, and these client-side Field instances often do not contain all the field metadata. We should probably not be doing this to begin with, but for now, until we refactor this code, I think having some way of identifying _real_ instances will be useful.

---

**Testing**
1. Follow the steps in #18646