### PR TITLE
Don't copy collection_position when copying card

### DIFF
--- a/frontend/src/metabase/query_builder/components/QueryModals.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryModals.jsx
@@ -207,6 +207,7 @@ export default class QueryModals extends React.Component {
               ...this.props.card,
               ...formValues,
               description: formValues.description || null,
+              collection_position: null,
             });
             return { payload: { object } };
           }}


### PR DESCRIPTION
Fixes #21483 

Explicitly setting `collection_position` to null in the function where we trigger the cloning.

https://user-images.githubusercontent.com/13057258/164114011-3b3fd629-0beb-43e3-aad3-0d594865f48f.mov

**Testing**
1. In any collection pin a question
1. Open that question
1. Use the "Duplicate this question" button and save in the same collection (that's the default location)
1. Go back to the collection and note that the duplicate is also pinned and rendered
