### PR TITLE
[E2E] Remove `binning` group from CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1252,7 +1252,6 @@ workflows:
               folder:
                 [
                   "admin",
-                  "binning",
                   "collections",
                   "custom-column",
                   "dashboard",


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Removes `binning` E2E group from CircleCI because we've been running it successfully using GitHub actions.