### PR TITLE
MBQL generative test suite [WIP] [ci skip]

### DIFF
--- a/src/metabase/query_processor/util/add_alias_info.clj
+++ b/src/metabase/query_processor/util/add_alias_info.clj
@@ -171,13 +171,14 @@
 (defn- field-source-table-alias
   "Determine the appropriate `::source-table` alias for a `field-clause`."
   {:arglists '([inner-query field-clause])}
-  [{:keys [source-table source-query], :as inner-query} [_ _id-or-name {:keys [join-alias]}, :as field-clause]]
+  [{:keys [source-table source-query], :as inner-query} [_ id-or-name {:keys [join-alias]}, :as field-clause]]
   (let [table-id            (field-table-id field-clause)
         join-is-this-level? (field-is-from-join-in-this-level? inner-query field-clause)]
     (cond
       join-is-this-level?                      join-alias
       (and table-id (= table-id source-table)) table-id
       source-query                             ::source
+      (string? id-or-name)                     source-table
       :else
       (throw (ex-info (trs "Cannot determine the source table or query for Field clause {0}" (pr-str field-clause))
                       {:type   qp.error-type/invalid-query

--- a/test/metabase/mbql/generate.clj
+++ b/test/metabase/mbql/generate.clj
@@ -81,8 +81,9 @@
 (defn random-query []
   (rand-nth (gens/sample (query-generator (mt/id)))))
 
-(defn test-random-query []
+(defn test-random-query-noshrink []
   (let [query (random-query)]
     (mt/with-native-query-testing-context query
       (t/is (some? (mt/rows
                     (qp/process-query query)))))))
+

--- a/test/metabase/mbql/generate.clj
+++ b/test/metabase/mbql/generate.clj
@@ -1,0 +1,89 @@
+(ns metabase.mbql.generate
+  (:require
+   [clojure.test :as t]
+   [clojure.test.check.generators :as gens]
+   [metabase.mbql.generate.aggregations :as gen.aggregations]
+   [metabase.mbql.generate.common :as gen.common]
+   [metabase.mbql.generate.data :as gen.data]
+   [metabase.mbql.generate.expressions :as gen.expressions]
+   [metabase.query-processor :as qp]
+   [metabase.test :as mt]
+   [metabase.util :as u]
+   [toucan.db :as db]))
+
+(defn fields-generator [field-generator]
+  (gens/such-that seq (gens/vector-distinct field-generator)))
+
+(def limit-generator
+  (gens/large-integer* {:min 1}))
+
+(defn order-by-generator [field-generator]
+  ;; TODO -- order by expression references or aggregation references. I don't think arbitary expressions are currently
+  ;; allowed.
+  (gens/such-that seq
+                  (gens/vector-distinct (gens/let [field field-generator
+                                                   direction (gens/elements #{:asc :desc})]
+                                          [direction field]))
+                  1000))
+
+(defn inner-query-generator [field-generator]
+  (gens/let [expressions (gens/one-of [(gens/return nil)
+                                       (gen.expressions/expressions-map-generator field-generator)])]
+    (let [expression-refs-generator (when (seq expressions)
+                                      (gens/elements (for [[expression-name] expressions]
+                                                       ;; TODO
+                                                       [:expression expression-name {:base-type :type/Number}])))
+          field-expr-generator      (gens/one-of (filter some? [field-generator
+                                                                expression-refs-generator]))]
+      (gens/let [aggregations (gens/one-of [(gens/return nil)
+                                            (gen.aggregations/aggregations-generator field-expr-generator)])]
+        (let [ag-refs                 (for [i (range (count aggregations))]
+                                        [:aggregation i {:base-type :type/Number}])
+              ag-refs-generator       (when (seq ag-refs)
+                                        (gens/elements ag-refs))
+              field-expr-ag-generator (gens/one-of (filter some? [field-expr-generator
+                                                                  ag-refs-generator]))]
+          (gens/let [breakout (gens/one-of [(gens/return nil)
+                                            (fields-generator field-expr-generator)])
+                     m (gen.common/optional-map-generator
+                        { ;; TODO -- fields should exclude stuff in breakout.
+                         :fields   (gens/let [fields (fields-generator field-expr-generator)]
+                                     (not-empty (vec (remove (set breakout) fields))))
+                         ;; :filter      (gens/return :TODO-filter)
+                         ;; :joins       (gens/return :TODO-joins)
+                         :limit    limit-generator
+                         ;; if we have a breakout (i.e. a GROUP BY) we can only sort by aggregation references or breakout columns
+                         :order-by (order-by-generator
+                                    (if (seq breakout)
+                                      (gens/one-of (filter some? [(gens/elements breakout)
+                                                                  ag-refs-generator]))
+                                      field-expr-ag-generator))})]
+            (merge (when (seq breakout)
+                     {:breakout breakout})
+                   (when (seq expressions)
+                     {:expressions expressions})
+                   (when (seq aggregations)
+                     {:aggregation aggregations})
+                   m)))))))
+
+(defn query-generator [database-or-id]
+  (gens/let [source-table-id (gen.data/source-table-id-generator database-or-id)
+             inner-query     (inner-query-generator (gen.data/field-generator source-table-id))]
+    {:database (u/the-id database-or-id)
+     :type :query
+     :query (merge {:source-table source-table-id
+                    :-source-table-name (db/select-one-field :name 'Table :id source-table-id)}
+                   inner-query)}))
+
+;; TODO expressions
+;; TODO `:source-query` with or without `:source-metadata`
+;; TODO `:joins`
+
+(defn random-query []
+  (rand-nth (gens/sample (query-generator (mt/id)))))
+
+(defn test-random-query []
+  (let [query (random-query)]
+    (mt/with-native-query-testing-context query
+      (t/is (some? (mt/rows
+                    (qp/process-query query)))))))

--- a/test/metabase/mbql/generate.clj
+++ b/test/metabase/mbql/generate.clj
@@ -70,12 +70,11 @@
   (gens/let [source-table-id (gen.data/source-table-id-generator database-or-id)
              inner-query     (inner-query-generator (gen.data/field-generator source-table-id))]
     {:database (u/the-id database-or-id)
-     :type :query
-     :query (merge {:source-table source-table-id
-                    :-source-table-name (db/select-one-field :name 'Table :id source-table-id)}
+     :type     :query
+     :query    (merge {:source-table       source-table-id
+                       :-source-table-name (db/select-one-field :name 'Table :id source-table-id)}
                    inner-query)}))
 
-;; TODO expressions
 ;; TODO `:source-query` with or without `:source-metadata`
 ;; TODO `:joins`
 

--- a/test/metabase/mbql/generate/aggregations.clj
+++ b/test/metabase/mbql/generate/aggregations.clj
@@ -42,6 +42,7 @@
                 #_:sum-where
                 #_:case
                 (gen.expressions/numeric-expression-generator (gen.data/numeric-field-generator field-generator))
+                (gen.expressions/string-expression-generator)
                 ]))
 
 ;; TODO -- string aggregations

--- a/test/metabase/mbql/generate/aggregations.clj
+++ b/test/metabase/mbql/generate/aggregations.clj
@@ -57,8 +57,8 @@
   (gens/such-that
    seq
    (gen.common/optional-map-generator
-    {:name         gens/string
-     :display-name (gens/such-that seq gens/string)})
+    {:name         (gen.common/nonblank-string)
+     :display-name (gens/such-that seq (gen.common/nonblank-string))})
    1000))
 
 (defn wrapped-aggregation-generator [field-generator]

--- a/test/metabase/mbql/generate/aggregations.clj
+++ b/test/metabase/mbql/generate/aggregations.clj
@@ -57,7 +57,7 @@
    seq
    (gen.common/optional-map-generator
     {:name         gens/string
-     :display-name gens/string})
+     :display-name (gens/such-that seq gens/string)})
    1000))
 
 (defn wrapped-aggregation-generator [field-generator]

--- a/test/metabase/mbql/generate/aggregations.clj
+++ b/test/metabase/mbql/generate/aggregations.clj
@@ -1,0 +1,73 @@
+(ns metabase.mbql.generate.aggregations
+  (:require
+   [clojure.test.check.generators :as gens]
+   [metabase.mbql.generate.data :as gen.data]
+   [metabase.mbql.generate.common :as gen.common]
+   [metabase.mbql.generate.expressions :as gen.expressions]))
+
+(defn- fieldless-count-aggregation [k]
+  (gens/return [k]))
+
+(defn- field-count-aggregation [k field-generator]
+  (gens/let [field field-generator]
+    [k field]))
+
+(defn- numeric-aggregation-generator [k field-generator]
+  (let [numeric-field-generator (gen.data/numeric-field-generator field-generator)
+        arg-generator           (gens/one-of [numeric-field-generator
+                                              (gen.expressions/numeric-expression-generator numeric-field-generator)])]
+    (gens/let [arg arg-generator]
+      [k arg])))
+
+(defn simple-aggregation-generator [field-generator]
+  (gens/one-of [(fieldless-count-aggregation :count)
+                (field-count-aggregation :count field-generator)
+                (fieldless-count-aggregation :cum-count)
+                (field-count-aggregation :cum-count field-generator)
+                (field-count-aggregation :distinct field-generator)
+                (numeric-aggregation-generator :avg field-generator)
+                (numeric-aggregation-generator :sum field-generator)
+                (numeric-aggregation-generator :cum-sum field-generator)
+                (numeric-aggregation-generator :stddev field-generator)
+                (numeric-aggregation-generator :min field-generator)
+                (numeric-aggregation-generator :max field-generator)
+                ;; TODO -- these depend on whether or not the database supports it.
+                (numeric-aggregation-generator :median field-generator)
+                (numeric-aggregation-generator :percentile field-generator)
+                (numeric-aggregation-generator :var field-generator)
+                ;; TODO
+                #_:metric
+                #_:share
+                #_:count-where
+                #_:sum-where
+                #_:case
+                (gen.expressions/numeric-expression-generator (gen.data/numeric-field-generator field-generator))
+                ]))
+
+;; TODO -- string aggregations
+
+(defn unwrapped-aggregation-generator [field-generator]
+  (let [numeric-field-generator (gen.data/numeric-field-generator field-generator)]
+    (gens/one-of [(gen.expressions/numeric-expression-generator (gens/one-of [numeric-field-generator
+                                                                              (simple-aggregation-generator numeric-field-generator)]))
+                  (simple-aggregation-generator field-generator)])))
+
+(def options-generator
+  (gens/such-that
+   seq
+   (gen.common/optional-map-generator
+    {:name         gens/string
+     :display-name gens/string})
+   1000))
+
+(defn wrapped-aggregation-generator [field-generator]
+  (gens/let [ag (unwrapped-aggregation-generator field-generator)
+             options options-generator]
+    [:aggregation-options ag options]))
+
+(defn aggregation-generator [field-generator]
+  (gens/one-of [(wrapped-aggregation-generator field-generator)
+                (unwrapped-aggregation-generator field-generator)]))
+
+(defn aggregations-generator [field-generator]
+  (gens/vector-distinct (aggregation-generator field-generator) {:min-elements 1}))

--- a/test/metabase/mbql/generate/common.clj
+++ b/test/metabase/mbql/generate/common.clj
@@ -1,5 +1,8 @@
 (ns metabase.mbql.generate.common
-  (:require [clojure.test.check.generators :as gens]))
+  (:require [clojure.string :as str]
+            [clojure.test.check.generators :as gens]))
+
+(defn nonblank-string [] (gens/fmap str/join (gens/vector gens/char 1 100)))
 
 (defn optional-map-generator [m]
   (let [generators (for [[k generator] m]

--- a/test/metabase/mbql/generate/common.clj
+++ b/test/metabase/mbql/generate/common.clj
@@ -1,0 +1,10 @@
+(ns metabase.mbql.generate.common
+  (:require [clojure.test.check.generators :as gens]))
+
+(defn optional-map-generator [m]
+  (let [generators (for [[k generator] m]
+                     (gens/one-of [(gens/return nil)
+                                   (gens/let [v generator]
+                                     [k v])]))]
+    (gens/let [result (apply gens/tuple generators)]
+      (into {} result))))

--- a/test/metabase/mbql/generate/data.clj
+++ b/test/metabase/mbql/generate/data.clj
@@ -1,0 +1,27 @@
+(ns metabase.mbql.generate.data
+  (:require
+   [clojure.test.check.generators :as gens]
+   [metabase.models :refer [Field Table]]
+   [metabase.util :as u]
+   [toucan.db :as db]))
+
+(defn source-table-id-generator [database-or-id]
+  (let [table-ids (db/select-ids Table :db_id (u/the-id database-or-id))]
+    (assert (seq table-ids))
+    (gens/elements table-ids)))
+
+(defn field-generator [table-or-id]
+  (gens/let [field      (gens/elements (db/select Field :table_id (u/the-id table-or-id)))
+             id-or-name (gens/elements [(:id field)
+                                        (:name field)])
+             options    (gens/return {:-id       (:id field)
+                                      :-name     (:name field)
+                                      :base-type (:base_type field)})]
+    [:field id-or-name options]))
+
+(defn numeric-field-generator [field-generator]
+  (gens/such-that
+   (fn [[_ _ {:keys [base-type]}]]
+     (isa? base-type :type/Number))
+   field-generator
+   1000))

--- a/test/metabase/mbql/generate/expressions.clj
+++ b/test/metabase/mbql/generate/expressions.clj
@@ -20,7 +20,7 @@
    (n-ary-expression-generator operator arg-generator 1))
   ([operator arg-generator min-card]
   (gens/let [members (gen/vector arg-generator min-card 5)]
-    (vec (flatten [operator members])))))
+    (vec (concat [operator] members)))))
 
 (defn comparison-generator
   [comparand-generator]

--- a/test/metabase/mbql/generate/expressions.clj
+++ b/test/metabase/mbql/generate/expressions.clj
@@ -1,0 +1,48 @@
+(ns metabase.mbql.generate.expressions
+  (:require
+   [clojure.spec.gen.alpha :as gen]
+   [clojure.test.check.generators :as gens]
+   [metabase.mbql.generate.data :as gen.data]))
+
+(defn unary-expression-generator
+  [operator arg-generator]
+  (gens/let [arg arg-generator]
+    [operator arg]))
+
+(defn binary-expression-generator
+  [operator lhs-generator rhs-generator]
+  (gens/let [lhs lhs-generator
+             rhs rhs-generator]
+    [operator lhs rhs]))
+
+(defn numeric-expression-generator [arg-generator]
+  (let [arg-generator (gens/one-of [arg-generator
+                                    gens/int
+                                    (gens/double* {:infinite? false, :NaN? false})
+                                    ;; TODO -- BigInteger or BigDecimal?
+                                    (gen/delay (numeric-expression-generator arg-generator))])]
+    (gens/one-of [
+                  ;; TODO -- these are all actually 2 or more args
+                  (binary-expression-generator :+ arg-generator arg-generator)
+                  (binary-expression-generator :- arg-generator arg-generator)
+                  (binary-expression-generator :/ arg-generator arg-generator)
+                  (binary-expression-generator :* arg-generator arg-generator)
+                  (unary-expression-generator :floor arg-generator)
+                  (unary-expression-generator :ceil arg-generator)
+                  (unary-expression-generator :round arg-generator)
+                  (unary-expression-generator :abs arg-generator)
+                  ;; `:advanced-math-expressions`
+                  (binary-expression-generator :power arg-generator arg-generator)
+                  (unary-expression-generator :sqrt arg-generator)
+                  (unary-expression-generator :exp arg-generator)
+                  (unary-expression-generator :log arg-generator)
+                  ;; TODO
+                  #_coalesce
+                  #_case])))
+
+;; TODO -- string expressions.
+
+(defn expressions-map-generator [field-generator]
+  (let [numeric-field-generator      (gen.data/numeric-field-generator field-generator)
+        numeric-expression-generator (numeric-expression-generator numeric-field-generator)]
+    (gens/map (gens/such-that seq gens/string 1000) numeric-expression-generator)))


### PR DESCRIPTION
Implements #20951

This is currently about 75% done

The idea here is to generate an MBQL query based on a certain Database/Table where everything makes sense, e.g. we only references Fields from the source Table (or a joined table or source query), only do numeric expressions or numeric aggregations like `min` on numeric fields, etc. Then we take this query and run it and see if it barfs or not. This stuff is currently all working.

The framework is mostly in place but there's still a lot more stuff to do:

TODO:

- [ ] `:where` clause
- [ ] String expressions
- [ ] source queries and source query field references
- [ ] source query metadata (optional)
- [ ] joins and join field references
- [ ] native source queries?
- [ ] constraints, middleware options, and other option flags
- [ ] parameters?
- [ ] Binning
- [ ] Date/time bucketing
- [ ] implicitly joined fields 
- [ ] implement shrinking for more easily finding cause of failures 
- [ ] maybe get `spec.alpha` to work here and leverage that more

### Does it work?

Even in the current incomplete state this has already caught some bugs, for example it generated the query

```clojure
(mt/mbql-query users
  {:expressions {"*&ÇPÈ×"         [:log -5.5]
                 "+×$½"           [:log *ID/BigInteger]
                 "2ôõ¦"         [:/ [:* 1 -8] [:log 3.0]]
                 "BrÏËfÔ"   [:/ 3 4.0]
                 "²ÄVG"           [:log -4]
                 "·¹æ"      [:sqrt *ID/BigInteger]
                 "èÏ±"            [:abs [:log [:round 0.328125]]]
                 "ëÉ^&µð" [:log -1.0]}
   :breakout    [*ID/BigInteger
                 [:expression "ëÉ^&µð" {:base-type :type/Number}]
                 [:field %password {:base-type :type/Text}]
                 [:expression "+×$½" {:base-type :type/Number}]]
   :aggregation [[:power -4 [:floor [:/ [:expression "·¹æ" {:base-type :type/Number}] [:floor -1.2890625]]]]
                 [:- [:sqrt -5.140625] [:abs -2.0]]
                 [:aggregation-options [:avg [:floor [:* 1.0 *ID/BigInteger]]] {:display-name "E\\"}]]
   :limit       15})
```

which compiles to 

```sql
SELECT 
  "source"."ID" AS "ID",
  "source"."ëÉ^&µð" AS "ëÉ^&µð",
  "source"."PASSWORD" AS "PASSWORD",
  "source"."+×$½" AS "+×$½",
  power(-4, floor((CAST("source"."·¹æ" AS float) / CASE WHEN floor(-1.2890625) = 0 THEN NULL ELSE floor(-1.2890625) END))) AS "power",
  (sqrt(-5.140625) - abs(-2.0)) AS "expression",
  avg(floor((1.0 * "source"."ID"))) AS "avg" 
FROM 
  (
  SELECT 
    "PUBLIC"."USERS"."ID" AS "ID",
    "PUBLIC"."USERS"."NAME" AS "NAME",
    "PUBLIC"."USERS"."LAST_LOGIN" AS "LAST_LOGIN",
    log10(-5.5) AS "*&ÇPÈ×",
    log10("PUBLIC"."USERS"."ID") AS "+×$½",
    (CAST((1 * -8) AS float) / CASE WHEN log10(3.0) = 0 THEN NULL ELSE log10(3.0) END) AS "2ôõ¦",
    (CAST(3.0 AS float) / CASE WHEN 4.0 = 0 THEN NULL ELSE 4.0 END) AS "BrÏËfÔ",
    log10(-4) AS "²ÄVG",
    sqrt("PUBLIC"."USERS"."ID") AS "·¹æ",
    abs(log10(round(0.328125))) AS "èÏ±",
    log10(-1.0) AS "ëÉ^&µð" 
  FROM 
    "PUBLIC"."USERS") "source" 
GROUP BY 
  "source"."ID",
  "source"."ëÉ^&µð",
  "source"."PASSWORD",
  "source"."+×$½" 
ORDER BY 
  "source"."ID" ASC,
  "source"."ëÉ^&µð" ASC,
  "source"."PASSWORD" ASC,
  "source"."+×$½" ASC 
LIMIT 15
```

which in turn fails with a 

```
Column "source.PASSWORD" not found
```

error which looks like a clear bug.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/21788)
<!-- Reviewable:end -->
