### PR TITLE
fix links to schemas with schema names containing slashes

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/data-model-permission.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/data-model-permission.ts
@@ -1,5 +1,7 @@
 import { push } from "react-router-redux";
 import { GroupsPermissions } from "metabase-types/api";
+import { t } from "ttag";
+import { getGroupFocusPermissionsUrl } from "metabase/admin/permissions/utils/urls";
 import { UNABLE_TO_CHANGE_ADMIN_PERMISSIONS } from "metabase/admin/permissions/constants/messages";
 import {
   EntityId,
@@ -12,7 +14,6 @@ import {
   getSchemasPermission,
   getTablesPermission,
 } from "metabase/admin/permissions/utils/graph";
-import { t } from "ttag";
 
 export const DATA_MODEL_PERMISSION_REQUIRES_DATA_ACCESS = t`Data model access requires full data access.`;
 
@@ -35,18 +36,6 @@ export const DATA_MODEL_PERMISSION_OPTIONS = {
     icon: "permissions_limited",
     iconColor: "warning",
   },
-};
-
-const buildControlledActionUrl = (
-  entityId: EntityId,
-  groupId: number,
-  permissionSubject: PermissionSubject,
-) => {
-  if (permissionSubject === "schemas") {
-    return `/admin/permissions/data/group/${groupId}/database/${entityId.databaseId}`;
-  }
-
-  return `/admin/permissions/data/group/${groupId}/database/${entityId.databaseId}/schema/${entityId.schemaName}`;
 };
 
 const getPermissionValue = (
@@ -108,9 +97,7 @@ export const buildDataModelPermission = (
     postActions: hasChildEntities
       ? {
           controlled: () =>
-            push(
-              buildControlledActionUrl(entityId, groupId, permissionSubject),
-            ),
+            push(getGroupFocusPermissionsUrl(groupId, entityId)),
         }
       : undefined,
   };

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/download-permission.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/download-permission.ts
@@ -13,6 +13,7 @@ import {
   getSchemasPermission,
   getTablesPermission,
 } from "metabase/admin/permissions/utils/graph";
+import { getGroupFocusPermissionsUrl } from "metabase/admin/permissions/utils/urls";
 import { PLUGIN_ADVANCED_PERMISSIONS } from "metabase/plugins";
 
 export const DOWNLOAD_PERMISSION_REQUIRES_DATA_ACCESS = t`Download results access requires full data access.`;
@@ -42,18 +43,6 @@ export const DOWNLOAD_PERMISSION_OPTIONS = {
     icon: "permissions_limited",
     iconColor: "warning",
   },
-};
-
-const buildControlledActionUrl = (
-  entityId: EntityId,
-  groupId: number,
-  permissionSubject: PermissionSubject,
-) => {
-  if (permissionSubject === "schemas") {
-    return `/admin/permissions/data/group/${groupId}/database/${entityId.databaseId}`;
-  }
-
-  return `/admin/permissions/data/group/${groupId}/database/${entityId.databaseId}/schema/${entityId.schemaName}`;
 };
 
 const getPermissionValue = (
@@ -120,9 +109,7 @@ export const buildDownloadPermission = (
     postActions: hasChildEntities
       ? {
           controlled: () =>
-            push(
-              buildControlledActionUrl(entityId, groupId, permissionSubject),
-            ),
+            push(getGroupFocusPermissionsUrl(groupId, entityId)),
         }
       : undefined,
   };

--- a/frontend/src/metabase/admin/permissions/utils/urls.js
+++ b/frontend/src/metabase/admin/permissions/utils/urls.js
@@ -14,12 +14,18 @@ export const getDatabaseFocusPermissionsUrl = entityId => {
 
   if (isTableEntityId(entityId)) {
     return entityId.schemaName != null
-      ? `${DATABASES_BASE_PATH}/${entityId.databaseId}/schema/${entityId.schemaName}/table/${entityId.tableId}`
+      ? `${DATABASES_BASE_PATH}/${
+          entityId.databaseId
+        }/schema/${encodeURIComponent(entityId.schemaName)}/table/${
+          entityId.tableId
+        }`
       : `${DATABASES_BASE_PATH}/${entityId.databaseId}/table/${entityId.tableId}`;
   }
 
   if (isSchemaEntityId(entityId)) {
-    return `${DATABASES_BASE_PATH}/${entityId.databaseId}/schema/${entityId.schemaName}`;
+    return `${DATABASES_BASE_PATH}/${
+      entityId.databaseId
+    }/schema/${encodeURIComponent(entityId.schemaName)}`;
   }
 
   if (isDatabaseEntityId(entityId)) {
@@ -41,6 +47,10 @@ export const getGroupFocusPermissionsUrl = (groupId, entityId) => {
   }
 
   if (isSchemaEntityId(entityId)) {
-    return `${GROUPS_BASE_PATH}/${groupId}/database/${entityId.databaseId}/schema/${entityId.schemaName}`;
+    return `${GROUPS_BASE_PATH}/${groupId}/database/${
+      entityId.databaseId
+    }/schema/${encodeURIComponent(entityId.schemaName)}`;
   }
+
+  return GROUPS_BASE_PATH;
 };

--- a/frontend/src/metabase/admin/permissions/utils/urls.unit.spec.js
+++ b/frontend/src/metabase/admin/permissions/utils/urls.unit.spec.js
@@ -22,6 +22,16 @@ describe("getDatabaseFocusPermissionsUrl", () => {
     expect(url).toEqual("/admin/permissions/data/database/1/schema/my_schema");
   });
 
+  it("when entityId is a schema id it returns database permissions url", () => {
+    const url = getDatabaseFocusPermissionsUrl({
+      databaseId: 1,
+      schemaName: "my_schemas/schema",
+    });
+    expect(url).toEqual(
+      "/admin/permissions/data/database/1/schema/my_schemas%2Fschema",
+    );
+  });
+
   it("when entityId is a table id with schema it returns table permissions url", () => {
     const url = getDatabaseFocusPermissionsUrl({
       databaseId: 1,
@@ -60,6 +70,16 @@ describe("getGroupFocusPermissionsUrl", () => {
     });
     expect(url).toEqual(
       "/admin/permissions/data/group/1/database/1/schema/my_schema",
+    );
+  });
+
+  it("encodes schema names with slashes", () => {
+    const url = getGroupFocusPermissionsUrl(1, {
+      databaseId: 1,
+      schemaName: "my_schemas/schema",
+    });
+    expect(url).toEqual(
+      "/admin/permissions/data/group/1/database/1/schema/my_schemas%2Fschema",
     );
   });
 });

--- a/frontend/src/metabase/browse/containers/SchemaBrowser.jsx
+++ b/frontend/src/metabase/browse/containers/SchemaBrowser.jsx
@@ -47,7 +47,9 @@ function SchemaBrowser(props) {
               {schemas.map(schema => (
                 <SchemaGridItem key={schema.id}>
                   <Link
-                    to={`/browse/${dbId}/schema/${schema.name}`}
+                    to={`/browse/${dbId}/schema/${encodeURIComponent(
+                      schema.name,
+                    )}`}
                     mb={1}
                     hover={{ color: color("accent2") }}
                     data-metabase-event={`${ANALYTICS_CONTEXT};Schema Click`}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/15454

## How to verify
- Connect a database with a schema containing `/` in its name
- Find the schema on the [Browse page](http://localhost:3000/browse) and click on it
- Ensure it opens the list of tables for the schema
- Go to the [Data permissions page](http://localhost:3000/admin/permissions/data/)
- Find the schema and select it
- Ensure it opens the list of table permissions for the schema