### PR TITLE
19671 scrollbar for title card on firefox

### DIFF
--- a/frontend/src/metabase/css/dashboard.css
+++ b/frontend/src/metabase/css/dashboard.css
@@ -156,9 +156,11 @@
 }
 
 .DashCard .Card {
-  box-shadow: 0px 1px 3px var(--color-shadow);
-  border-color: transparent;
+  border: none;
+  /* border-color: transparent; */
   border-radius: 8px;
+  box-shadow: 0px 1px 3px var(--color-shadow);
+  overflow: hidden;
 }
 
 @media (prefers-reduced-motion) {

--- a/frontend/src/metabase/css/dashboard.css
+++ b/frontend/src/metabase/css/dashboard.css
@@ -157,10 +157,8 @@
 
 .DashCard .Card {
   border: none;
-  /* border-color: transparent; */
   border-radius: 8px;
   box-shadow: 0px 1px 3px var(--color-shadow);
-  overflow: hidden;
 }
 
 @media (prefers-reduced-motion) {

--- a/frontend/src/metabase/visualizations/visualizations/Text/Text.css
+++ b/frontend/src/metabase/visualizations/visualizations/Text/Text.css
@@ -10,27 +10,32 @@
   overflow-x: hidden;
   overflow-y: auto;
   padding: 0;
+  width: 100%;
 }
+
 :local .Text .text-card-textarea {
-  padding: 0.25em 0.75em;
+  border-radius: var(--default-border-radius);
   font-size: 1.143em;
+  height: inherit;
   line-height: 1.602em;
+  min-height: unset;
+  outline: none;
+  padding: 0.25em 0.75em;
   pointer-events: all;
   resize: none;
-  outline: none;
-  border-radius: var(--default-border-radius);
-  min-height: unset;
-  height: inherit;
+  width: 100%;
 }
 :local .Text .text-card-textarea:focus {
   border-color: var(--color-brand);
   background-color: white;
   box-shadow: 0 1px 7px var(--color-shadow);
 }
+
 :local .Text .text-card-markdown {
   height: 100%;
-  padding: 0.5em 0.75em;
+  padding: 0.5em 16px;
   pointer-events: all;
+  width: 100%;
 }
 
 :local .Text .text-card-markdown h1,
@@ -86,14 +91,14 @@
 
 :local .text-card-markdown ul {
   font-size: 16px;
-  margin: 0.5em 0 0.5em 0;
-  padding: 0 1.5em;
+  margin: 0;
+  padding: 0.5em 1.5em;
   list-style-type: disc;
 }
 :local .text-card-markdown ol {
   font-size: 16px;
-  margin: 0.5em 0 0.5em 0;
-  padding: 0 1.5em;
+  margin: 0;
+  padding: 0.5em 1.5em;
   list-style-type: decimal;
 }
 

--- a/frontend/src/metabase/visualizations/visualizations/Text/Text.css
+++ b/frontend/src/metabase/visualizations/visualizations/Text/Text.css
@@ -3,12 +3,13 @@
 }
 
 :local .Text {
+  border: none;
+  border-radius: 8px;
   display: flex;
   flex-direction: column;
   height: 100%;
   justify-content: center;
-  overflow-x: hidden;
-  overflow-y: auto;
+  overflow: hidden;
   padding: 0;
   width: 100%;
 }
@@ -33,6 +34,8 @@
 
 :local .Text .text-card-markdown {
   height: 100%;
+  overflow-x: hidden;
+  overflow-y: auto;
   padding: 0.5em 16px;
   pointer-events: all;
   width: 100%;
@@ -53,7 +56,11 @@
 :local .Text .text-card-markdown h3:first-child,
 :local .Text .text-card-markdown h4:first-child,
 :local .Text .text-card-markdown h5:first-child,
-:local .Text .text-card-markdown h6:first-child {
+:local .Text .text-card-markdown h6:first-child,
+:local .Text .text-card-markdown p:first-child,
+:local .Text .text-card-markdown ul:first-child,
+:local .Text .text-card-markdown ol:first-child,
+:local .Text .text-card-markdown table:first-child {
   margin-top: 0.125em;
 }
 
@@ -62,7 +69,11 @@
 :local .Text .text-card-markdown h3:last-child,
 :local .Text .text-card-markdown h4:last-child,
 :local .Text .text-card-markdown h5:last-child,
-:local .Text .text-card-markdown h6:last-child {
+:local .Text .text-card-markdown h6:last-child,
+:local .Text .text-card-markdown p:last-child,
+:local .Text .text-card-markdown ul:last-child,
+:local .Text .text-card-markdown ol:last-child,
+:local .Text .text-card-markdown table:last-child {
   margin-bottom: 0.125em;
 }
 
@@ -130,7 +141,7 @@
   border-collapse: collapse;
   border-spacing: 0;
 
-  margin: 1em 0 1em 0;
+  margin: 1em 0;
   width: 100%;
   font-family: Monaco, monospace;
   font-size: 12.64px;

--- a/frontend/src/metabase/visualizations/visualizations/Text/Text.css
+++ b/frontend/src/metabase/visualizations/visualizations/Text/Text.css
@@ -5,9 +5,11 @@
 :local .Text {
   display: flex;
   flex-direction: column;
-  justify-content: center;
-  padding: 0.5em 0.75em;
   height: 100%;
+  justify-content: center;
+  overflow-x: hidden;
+  overflow-y: auto;
+  padding: 0;
 }
 :local .Text .text-card-textarea {
   padding: 0.25em 0.75em;
@@ -27,35 +29,53 @@
 }
 :local .Text .text-card-markdown {
   height: 100%;
-  overflow: auto;
+  padding: 0.5em 0.75em;
   pointer-events: all;
+}
+
+:local .Text .text-card-markdown h1,
+:local .Text .text-card-markdown h2,
+:local .Text .text-card-markdown h3,
+:local .Text .text-card-markdown h4,
+:local .Text .text-card-markdown h5,
+:local .Text .text-card-markdown h6 {
+  margin: 0.375em 0 0.25em 0;
+  padding-right: 1.5em;
+}
+
+:local .Text .text-card-markdown h1:first-child,
+:local .Text .text-card-markdown h2:first-child,
+:local .Text .text-card-markdown h3:first-child,
+:local .Text .text-card-markdown h4:first-child,
+:local .Text .text-card-markdown h5:first-child,
+:local .Text .text-card-markdown h6:first-child {
+  margin-top: 0.125em;
+}
+
+:local .Text .text-card-markdown h1:last-child,
+:local .Text .text-card-markdown h2:last-child,
+:local .Text .text-card-markdown h3:last-child,
+:local .Text .text-card-markdown h4:last-child,
+:local .Text .text-card-markdown h5:last-child,
+:local .Text .text-card-markdown h6:last-child {
+  margin-bottom: 0.125em;
 }
 
 :local .Text .text-card-markdown h1 {
   font-weight: 900;
   font-size: 1.831em;
-  margin: 0.375em 0 0.25em 0;
-  padding-right: 1.5em;
 }
 :local .Text .text-card-markdown h2 {
   font-size: 1.627em;
-  margin: 0.375em 0 0.25em 0;
-  padding-right: 1.5em;
 }
 :local .Text .text-card-markdown h3 {
   font-size: 1.447em;
-  margin: 0.375em 0 0.25em 0;
-  padding-right: 1.5em;
 }
 :local .Text .text-card-markdown h4 {
   font-size: 1.286em;
-  margin: 0.375em 0 0.25em 0;
-  padding-right: 1.5em;
 }
 :local .Text .text-card-markdown h5 {
   font-size: 1.143em;
-  margin: 0.375em 0 0.25em 0;
-  padding-right: 1.5em;
 }
 :local .Text .text-card-markdown p {
   font-size: 1.143em;

--- a/frontend/src/metabase/visualizations/visualizations/Text/Text.css
+++ b/frontend/src/metabase/visualizations/visualizations/Text/Text.css
@@ -48,7 +48,6 @@
 :local .Text .text-card-markdown h5,
 :local .Text .text-card-markdown h6 {
   margin: 0.375em 0 0.25em 0;
-  padding-right: 1.5em;
 }
 
 :local .Text .text-card-markdown h1:first-child,
@@ -97,7 +96,7 @@
   font-size: 1.143em;
   line-height: 1.602em;
   padding: 0;
-  margin: 0 1.5em 0.5em 0;
+  margin: 0 0 0.5em 0;
 }
 
 :local .text-card-markdown ul {

--- a/frontend/src/metabase/visualizations/visualizations/Text/Text.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Text/Text.jsx
@@ -128,28 +128,29 @@ export default class Text extends Component {
           )}
         </div>
       );
-    } else {
-      return (
-        <div
-          className={cx(className, styles.Text, {
-            /* if the card is not showing a background we should adjust the left
-             * padding to help align the titles with the wrapper */
-            pl0: !settings["dashcard.background"],
-            "Text--single-row": isSingleRow,
-          })}
-        >
-          <ReactMarkdown
-            remarkPlugins={REMARK_PLUGINS}
-            className={cx(
-              "full flex-full flex flex-column text-card-markdown",
-              styles["text-card-markdown"],
-              getSettingsStyle(settings),
-            )}
-          >
-            {settings.text}
-          </ReactMarkdown>
-        </div>
-      );
     }
+
+    return (
+      <div
+        className={cx(className, styles.Text, {
+          // if the card is not showing a background
+          // we should adjust the left padding
+          // to help align the titles with the wrapper
+          pl0: !settings["dashcard.background"],
+          "Text--single-row": isSingleRow,
+        })}
+      >
+        <ReactMarkdown
+          remarkPlugins={REMARK_PLUGINS}
+          className={cx(
+            "full flex-full flex flex-column text-card-markdown",
+            styles["text-card-markdown"],
+            getSettingsStyle(settings),
+          )}
+        >
+          {settings.text}
+        </ReactMarkdown>
+      </div>
+    );
   }
 }

--- a/frontend/src/metabase/visualizations/visualizations/Text/Text.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Text/Text.jsx
@@ -95,11 +95,7 @@ export default class Text extends Component {
 
   render() {
     const { className, gridSize, settings, isEditing } = this.props;
-
     const isSingleRow = gridSize && gridSize.height === 1;
-    if (isSingleRow) {
-      settings["text.align_vertical"] = "middle";
-    }
 
     if (isEditing) {
       return (

--- a/frontend/src/metabase/visualizations/visualizations/Text/Text.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Text/Text.jsx
@@ -95,7 +95,11 @@ export default class Text extends Component {
 
   render() {
     const { className, gridSize, settings, isEditing } = this.props;
+
     const isSingleRow = gridSize && gridSize.height === 1;
+    if (isSingleRow) {
+      settings["text.align_vertical"] = "middle";
+    }
 
     if (isEditing) {
       return (

--- a/frontend/src/metabase/visualizations/visualizations/Text/index.ts
+++ b/frontend/src/metabase/visualizations/visualizations/Text/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Text";

--- a/frontend/test/metabase/scenarios/dashboard/text-box.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/text-box.cy.spec.js
@@ -96,7 +96,8 @@ describe("scenarios > dashboard > text-box", () => {
 
       // The test fails if there is no scroll bar
       cy.get(".text-card-markdown")
-        .should("have.css", "overflow", "auto")
+        .should("have.css", "overflow-x", "hidden")
+        .should("have.css", "overflow-y", "auto")
         .scrollTo("bottom");
     });
 

--- a/frontend/test/metabase/scenarios/dashboard/text-box.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/text-box.cy.spec.js
@@ -88,7 +88,7 @@ describe("scenarios > dashboard > text-box", () => {
 
     it("should have a scroll bar for long text (metabase#8333)", () => {
       addTextBox(
-        "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam ut fermentum erat, nec sagittis justo. Vivamus vitae ipsum semper, consectetur odio at, rutrum nisi. Fusce maximus consequat porta. Mauris libero mi, viverra ac hendrerit quis, rhoncus quis ante. Pellentesque molestie ut felis non congue. Vivamus finibus ligula id fringilla rutrum. Donec quis dignissim ligula, vitae tempor urna.\n\nDonec quis enim porta, porta lacus vel, maximus lacus. Sed iaculis leo tortor, vel tempor velit tempus vitae. Nulla facilisi. Vivamus quis sagittis magna. Aenean eu eros augue. Sed euismod pulvinar laoreet. Morbi commodo, sem sed dictum faucibus, sem ante ultrices libero, nec ornare risus lacus eget velit. Etiam sagittis lectus non erat tristique tempor. Sed in ipsum urna. Sed venenatis turpis at orci feugiat, ut gravida lectus luctus.",
       );
       cy.findByText("Save").click();
 


### PR DESCRIPTION
Fixes #19671.

__After on Chrome__

![image](https://user-images.githubusercontent.com/348552/164293842-3b589126-5839-44e7-ae8e-c69af9f603d4.png)

__After on Firefox__

<img width="839" alt="image" src="https://user-images.githubusercontent.com/348552/164294077-490522d7-7018-4f62-9820-89ac678261ec.png">

__After on Safari__

<img width="1023" alt="image" src="https://user-images.githubusercontent.com/348552/164294225-4ac535b3-3d6a-411e-84c3-d82183bc76a5.png">
