### PR TITLE
Create a collection from sidebar menu

### DIFF
--- a/frontend/src/metabase/collections/containers/CollectionCreate.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionCreate.jsx
@@ -2,7 +2,9 @@
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import { getValues } from "redux-form";
+import { withRouter } from "react-router";
 import { goBack } from "react-router-redux";
+import _ from "underscore";
 
 import Collection from "metabase/entities/collections";
 import { PLUGIN_COLLECTIONS } from "metabase/plugins";
@@ -26,8 +28,7 @@ const mapDispatchToProps = {
   goBack,
 };
 
-@connect(mapStateToProps, mapDispatchToProps)
-export default class CollectionCreate extends Component {
+class CollectionCreate extends Component {
   handleClose = () => {
     const { goBack, onClose } = this.props;
     return onClose ? onClose() : goBack();
@@ -55,3 +56,8 @@ export default class CollectionCreate extends Component {
     );
   }
 }
+
+export default _.compose(
+  withRouter,
+  connect(mapStateToProps, mapDispatchToProps),
+)(CollectionCreate);

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { t } from "ttag";
 import { connect } from "react-redux";
 import _ from "underscore";
@@ -159,23 +159,20 @@ function MainNavbarContainer({
     return [root, ...buildCollectionTree(preparedCollections)];
   }, [rootCollection, collections, currentUser]);
 
-  const reorderBookmarks = ({
-    newIndex,
-    oldIndex,
-  }: {
-    newIndex: number;
-    oldIndex: number;
-  }) => {
-    const bookmarksToBeReordered =
-      orderedBookmarks.length > 0 ? [...orderedBookmarks] : [...bookmarks];
-    const element = bookmarksToBeReordered[oldIndex];
+  const reorderBookmarks = useCallback(
+    ({ newIndex, oldIndex }) => {
+      const bookmarksToBeReordered =
+        orderedBookmarks.length > 0 ? [...orderedBookmarks] : [...bookmarks];
+      const element = bookmarksToBeReordered[oldIndex];
 
-    bookmarksToBeReordered.splice(oldIndex, 1);
-    bookmarksToBeReordered.splice(newIndex, 0, element);
+      bookmarksToBeReordered.splice(oldIndex, 1);
+      bookmarksToBeReordered.splice(newIndex, 0, element);
 
-    setOrderedBookmarks(bookmarksToBeReordered as any);
-    Bookmarks.actions.reorder(bookmarksToBeReordered);
-  };
+      setOrderedBookmarks(bookmarksToBeReordered as any);
+      Bookmarks.actions.reorder(bookmarksToBeReordered);
+    },
+    [bookmarks, orderedBookmarks],
+  );
 
   return (
     <Sidebar className="Nav" isOpen={isOpen} aria-hidden={!isOpen}>

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer.tsx
@@ -7,6 +7,8 @@ import { IconProps } from "metabase/components/Icon";
 import LoadingSpinner from "metabase/components/LoadingSpinner";
 
 import { BookmarksType, Collection, User } from "metabase-types/api";
+import { State } from "metabase-types/store";
+
 import Bookmarks from "metabase/entities/bookmarks";
 import Collections, {
   ROOT_COLLECTION,
@@ -35,7 +37,7 @@ import {
   LoadingTitle,
 } from "./MainNavbar.styled";
 
-function mapStateToProps(state: unknown) {
+function mapStateToProps(state: State) {
   return {
     currentUser: getUser(state),
     hasDataAccess: getHasDataAccess(state),

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer.tsx
@@ -1,9 +1,12 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { t } from "ttag";
 import { connect } from "react-redux";
+import { push } from "react-router-redux";
+import { LocationDescriptor } from "history";
 import _ from "underscore";
 
 import { IconProps } from "metabase/components/Icon";
+import Modal from "metabase/components/Modal";
 import LoadingSpinner from "metabase/components/LoadingSpinner";
 
 import { BookmarksType, Collection, User } from "metabase-types/api";
@@ -28,6 +31,8 @@ import {
 } from "metabase/collections/utils";
 import * as Urls from "metabase/lib/urls";
 
+import CollectionCreate from "metabase/collections/containers/CollectionCreate";
+
 import { SelectedItem } from "./types";
 import MainNavbarView from "./MainNavbarView";
 import {
@@ -36,6 +41,8 @@ import {
   LoadingContainer,
   LoadingTitle,
 } from "./MainNavbar.styled";
+
+type NavbarModal = "MODAL_NEW_COLLECTION" | null;
 
 function mapStateToProps(state: State) {
   return {
@@ -49,6 +56,7 @@ const mapDispatchToProps = {
   openNavbar,
   closeNavbar,
   logout,
+  onChangeLocation: push,
 };
 
 interface CollectionTreeItem extends Collection {
@@ -74,6 +82,7 @@ type Props = {
   openNavbar: () => void;
   closeNavbar: () => void;
   logout: () => void;
+  onChangeLocation: (location: LocationDescriptor) => void;
 };
 
 function MainNavbarContainer({
@@ -90,9 +99,11 @@ function MainNavbarContainer({
   openNavbar,
   closeNavbar,
   logout,
+  onChangeLocation,
   ...props
 }: Props) {
   const [orderedBookmarks, setOrderedBookmarks] = useState([]);
+  const [modal, setModal] = useState<NavbarModal>(null);
 
   useEffect(() => {
     if (bookmarks?.length !== orderedBookmarks?.length) {
@@ -176,33 +187,58 @@ function MainNavbarContainer({
     [bookmarks, orderedBookmarks],
   );
 
+  const onCreateNewCollection = useCallback(() => {
+    setModal("MODAL_NEW_COLLECTION");
+  }, []);
+
+  const closeModal = useCallback(() => setModal(null), []);
+
+  const renderModalContent = useCallback(() => {
+    if (modal === "MODAL_NEW_COLLECTION") {
+      return (
+        <CollectionCreate
+          onClose={closeModal}
+          onSaved={(collection: Collection) => {
+            closeModal();
+            onChangeLocation(Urls.collection(collection));
+          }}
+        />
+      );
+    }
+    return null;
+  }, [modal, closeModal, onChangeLocation]);
+
   return (
-    <Sidebar className="Nav" isOpen={isOpen} aria-hidden={!isOpen}>
-      <NavRoot isOpen={isOpen}>
-        {allFetched && rootCollection ? (
-          <MainNavbarView
-            {...props}
-            bookmarks={
-              orderedBookmarks.length > 0 ? orderedBookmarks : bookmarks
-            }
-            isOpen={isOpen}
-            currentUser={currentUser}
-            collections={collectionTree}
-            hasOwnDatabase={hasOwnDatabase}
-            selectedItem={selectedItem}
-            hasDataAccess={hasDataAccess}
-            reorderBookmarks={reorderBookmarks}
-            handleCloseNavbar={closeNavbar}
-            handleLogout={logout}
-          />
-        ) : (
-          <LoadingContainer>
-            <LoadingSpinner />
-            <LoadingTitle>{t`Loading…`}</LoadingTitle>
-          </LoadingContainer>
-        )}
-      </NavRoot>
-    </Sidebar>
+    <>
+      <Sidebar className="Nav" isOpen={isOpen} aria-hidden={!isOpen}>
+        <NavRoot isOpen={isOpen}>
+          {allFetched && rootCollection ? (
+            <MainNavbarView
+              {...props}
+              bookmarks={
+                orderedBookmarks.length > 0 ? orderedBookmarks : bookmarks
+              }
+              isOpen={isOpen}
+              currentUser={currentUser}
+              collections={collectionTree}
+              hasOwnDatabase={hasOwnDatabase}
+              selectedItem={selectedItem}
+              hasDataAccess={hasDataAccess}
+              reorderBookmarks={reorderBookmarks}
+              handleCreateNewCollection={onCreateNewCollection}
+              handleCloseNavbar={closeNavbar}
+              handleLogout={logout}
+            />
+          ) : (
+            <LoadingContainer>
+              <LoadingSpinner />
+              <LoadingTitle>{t`Loading…`}</LoadingTitle>
+            </LoadingContainer>
+          )}
+        </NavRoot>
+      </Sidebar>
+      {modal && <Modal onClose={closeModal}>{renderModalContent()}</Modal>}
+    </>
   );
 }
 

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarView.tsx
@@ -49,6 +49,7 @@ type Props = {
   selectedItem: SelectedItem;
   handleCloseNavbar: () => void;
   handleLogout: () => void;
+  handleCreateNewCollection: () => void;
   reorderBookmarks: ({
     newIndex,
     oldIndex,
@@ -72,6 +73,7 @@ function MainNavbarView({
   selectedItem,
   hasDataAccess,
   reorderBookmarks,
+  handleCreateNewCollection,
   handleCloseNavbar,
   handleLogout,
 }: Props) {
@@ -115,7 +117,10 @@ function MainNavbarView({
         )}
 
         <SidebarSection>
-          <CollectionSectionHeading currentUser={currentUser} />
+          <CollectionSectionHeading
+            currentUser={currentUser}
+            handleCreateNewCollection={handleCreateNewCollection}
+          />
           <Tree
             data={collections}
             selectedId={isCollectionSelected ? selectedItem.id : undefined}
@@ -175,14 +180,25 @@ function MainNavbarView({
 
 interface CollectionSectionHeadingProps {
   currentUser: User;
+  handleCreateNewCollection: () => void;
 }
 
 function CollectionSectionHeading({
   currentUser,
+  handleCreateNewCollection,
 }: CollectionSectionHeadingProps) {
   const renderMenu = useCallback(
     ({ closePopover }) => (
       <CollectionMenuList>
+        <SidebarLink
+          icon="add"
+          onClick={() => {
+            closePopover();
+            handleCreateNewCollection();
+          }}
+        >
+          {t`New collection`}
+        </SidebarLink>
         {currentUser.is_superuser && (
           <SidebarLink
             icon={getCollectionIcon(PERSONAL_COLLECTIONS)}
@@ -201,7 +217,7 @@ function CollectionSectionHeading({
         </SidebarLink>
       </CollectionMenuList>
     ),
-    [currentUser],
+    [currentUser, handleCreateNewCollection],
   );
 
   return (

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarView.tsx
@@ -181,18 +181,22 @@ function CollectionSectionHeading({
   currentUser,
 }: CollectionSectionHeadingProps) {
   const renderMenu = useCallback(
-    ({ onClose }) => (
+    ({ closePopover }) => (
       <CollectionMenuList>
         {currentUser.is_superuser && (
           <SidebarLink
             icon={getCollectionIcon(PERSONAL_COLLECTIONS)}
             url={OTHER_USERS_COLLECTIONS_URL}
-            onClick={onClose}
+            onClick={closePopover}
           >
             {t`Other users' personal collections`}
           </SidebarLink>
         )}
-        <SidebarLink icon="view_archive" url={ARCHIVE_URL} onClick={onClose}>
+        <SidebarLink
+          icon="view_archive"
+          url={ARCHIVE_URL}
+          onClick={closePopover}
+        >
           {t`View archive`}
         </SidebarLink>
       </CollectionMenuList>

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarItems.styled.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarItems.styled.tsx
@@ -35,11 +35,14 @@ const activeColorCSS = css`
   color: ${color("brand")};
 `;
 
+function getTextColor(isSelected: boolean) {
+  return isSelected ? color("brand") : darken(color("text-medium"), 0.25);
+}
+
 export const NodeRoot = styled(TreeNode.Root)<{
   hasDefaultIconStyle?: boolean;
 }>`
-  color: ${props =>
-    props.isSelected ? color("brand") : darken(color("text-medium"), 0.25)};
+  color: ${props => getTextColor(props.isSelected)};
 
   background-color: ${props =>
     props.isSelected ? lighten(color("brand"), 0.6) : "unset"};
@@ -78,10 +81,29 @@ export const CollectionNodeRoot = styled(NodeRoot)<{ hovered?: boolean }>`
     `}
 `;
 
-export const FullWidthLink = styled(Link)`
+const itemContentStyle = css`
   display: flex;
   align-items: center;
   width: 100%;
+`;
+
+export const FullWidthButton = styled.button<{ isSelected: boolean }>`
+  cursor: pointer;
+  ${itemContentStyle}
+
+  ${TreeNode.NameContainer} {
+    font-weight: 700;
+    color: ${props => getTextColor(props.isSelected)};
+    text-align: start;
+
+    &:hover {
+      color: ${color("brand")};
+    }
+  }
+`;
+
+export const FullWidthLink = styled(Link)`
+  ${itemContentStyle}
 `;
 
 const ITEM_NAME_LENGTH_TOOLTIP_THRESHOLD = 35;

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarLink.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarLink.tsx
@@ -28,6 +28,14 @@ function isIconPropsObject(
   return _.isObject(icon);
 }
 
+function disableImageDragging(e: React.MouseEvent) {
+  // https://www.redips.net/firefox/disable-image-dragging/
+
+  // Also seems to prevent other hickups when dragging items
+  // right after having dragged other items
+  e.preventDefault();
+}
+
 function SidebarLink({
   children,
   icon,
@@ -55,13 +63,7 @@ function SidebarLink({
       depth={0}
       isSelected={isSelected}
       hasDefaultIconStyle={hasDefaultIconStyle}
-      onMouseDown={e => {
-        // https://www.redips.net/firefox/disable-image-dragging/
-
-        // Also seems to prevent other hickups when dragging items
-        // right after having dragged other items
-        e.preventDefault();
-      }}
+      onMouseDown={disableImageDragging}
       {...props}
     >
       {React.isValidElement(left) && left}

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarLink.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarLink.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useMemo } from "react";
 import _ from "underscore";
 
 import { TreeNode } from "metabase/components/tree/TreeNode";
@@ -9,11 +9,12 @@ import {
   NameContainer,
   NodeRoot,
   SidebarIcon,
+  FullWidthButton,
 } from "./SidebarItems.styled";
 
 interface Props {
   children: string;
-  url: string;
+  url?: string;
   icon: string | IconProps | React.ReactElement;
   isSelected?: boolean;
   hasDefaultIconStyle?: boolean;
@@ -21,6 +22,10 @@ interface Props {
   right?: React.ReactNode;
   onClick?: () => void;
 }
+
+type ContentProps = {
+  children: React.ReactNode;
+};
 
 function isIconPropsObject(
   icon: string | IconProps | React.ReactNode,
@@ -58,6 +63,14 @@ function SidebarLink({
     );
   }, [icon, isSelected]);
 
+  const Content = useMemo(() => {
+    return url
+      ? (props: ContentProps) => <FullWidthLink {...props} to={url} />
+      : (props: ContentProps) => (
+          <FullWidthButton {...props} isSelected={isSelected} />
+        );
+  }, [url, isSelected]);
+
   return (
     <NodeRoot
       depth={0}
@@ -67,10 +80,10 @@ function SidebarLink({
       {...props}
     >
       {React.isValidElement(left) && left}
-      <FullWidthLink to={url}>
+      <Content>
         {icon && renderIcon()}
         <NameContainer>{children}</NameContainer>
-      </FullWidthLink>
+      </Content>
       {React.isValidElement(right) && right}
     </NodeRoot>
   );


### PR DESCRIPTION
This PR adds an ability to create a new collection from the navigation sidebar "ellipsis" menu. Also fixes a small bug when clicking "Other users' personal collections" or "View archive" menu options was not closing the collection menu.

### To Verify

1. Open any page and open the navbar
2. Click the "ellipsis" icon next to the "Collections" header
3. Click "New collection"
4. Fill in new collection details
5. Click "Save"
6. Ensure the collection was created and you ended up on its page (`/collection/:id`)

### Demo

https://user-images.githubusercontent.com/17258145/164233721-cc300ae6-ffe2-4390-bf3f-b150f15da4cd.mp4


