### PR TITLE
Expand collections on drag-n-drop hover

### DIFF
--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarCollectionLink.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarCollectionLink.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 import React, { useCallback, KeyboardEvent } from "react";
 import _ from "underscore";
 
@@ -21,22 +20,30 @@ import {
   SidebarIcon,
 } from "./SidebarItems.styled";
 
-// eslint-disable-next-line react/display-name
-const SidebarCollectionLink = React.forwardRef<HTMLLIElement, TreeNodeProps>(
+type DroppableProps = {
+  hovered: boolean;
+  highlighted: boolean;
+};
+
+type Props = DroppableProps &
+  Omit<TreeNodeProps, "item"> & {
+    collection: Collection;
+  };
+
+const SidebarCollectionLink = React.forwardRef<HTMLLIElement, Props>(
   function SidebarCollectionLink(
     {
-      item,
+      collection,
+      hovered,
       depth,
       onSelect,
       isExpanded,
       isSelected,
       hasChildren,
       onToggleExpand,
-    },
+    }: Props,
     ref,
   ) {
-    const collection = (item as unknown) as Collection;
-
     const { name } = collection;
     const url = Urls.collection(collection);
 
@@ -63,37 +70,55 @@ const SidebarCollectionLink = React.forwardRef<HTMLLIElement, TreeNodeProps>(
     );
 
     return (
-      <div data-testid="sidebar-collection-link-root">
-        <CollectionDropTarget collection={collection}>
-          {({ hovered }: { hovered: boolean }) => (
-            <CollectionNodeRoot
-              role="treeitem"
-              depth={depth}
-              isSelected={isSelected}
-              hovered={hovered}
-              onClick={onToggleExpand}
-              hasDefaultIconStyle={isRegularCollection}
-              ref={ref}
-            >
-              <ExpandToggleButton hidden={!hasChildren}>
-                <TreeNode.ExpandToggleIcon
-                  isExpanded={isExpanded}
-                  name="chevronright"
-                  size={12}
-                />
-              </ExpandToggleButton>
-              <FullWidthLink to={url} onClick={onSelect} onKeyDown={onKeyDown}>
-                <TreeNode.IconContainer transparent={false}>
-                  <SidebarIcon {...icon} isSelected={isSelected} />
-                </TreeNode.IconContainer>
-                <NameContainer>{name}</NameContainer>
-              </FullWidthLink>
-            </CollectionNodeRoot>
-          )}
-        </CollectionDropTarget>
-      </div>
+      <CollectionNodeRoot
+        role="treeitem"
+        depth={depth}
+        isSelected={isSelected}
+        hovered={hovered}
+        onClick={onToggleExpand}
+        hasDefaultIconStyle={isRegularCollection}
+        ref={ref}
+      >
+        <ExpandToggleButton hidden={!hasChildren}>
+          <TreeNode.ExpandToggleIcon
+            isExpanded={isExpanded}
+            name="chevronright"
+            size={12}
+          />
+        </ExpandToggleButton>
+        <FullWidthLink to={url} onClick={onSelect} onKeyDown={onKeyDown}>
+          <TreeNode.IconContainer transparent={false}>
+            <SidebarIcon {...icon} isSelected={isSelected} />
+          </TreeNode.IconContainer>
+          <NameContainer>{name}</NameContainer>
+        </FullWidthLink>
+      </CollectionNodeRoot>
     );
   },
 );
 
-export default SidebarCollectionLink;
+const DroppableSidebarCollectionLink = React.forwardRef<
+  HTMLLIElement,
+  TreeNodeProps
+>(function DroppableSidebarCollectionLink(
+  { item, ...props }: TreeNodeProps,
+  ref,
+) {
+  const collection = (item as unknown) as Collection;
+  return (
+    <div data-testid="sidebar-collection-link-root">
+      <CollectionDropTarget collection={collection}>
+        {(droppableProps: DroppableProps) => (
+          <SidebarCollectionLink
+            {...props}
+            {...droppableProps}
+            collection={collection}
+            ref={ref}
+          />
+        )}
+      </CollectionDropTarget>
+    </div>
+  );
+});
+
+export default DroppableSidebarCollectionLink;

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarCollectionLink.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarCollectionLink.tsx
@@ -31,7 +31,7 @@ type Props = DroppableProps &
     collection: Collection;
   };
 
-const TIME_BEFORE_EXPANDING_ON_HOVER = 500;
+const TIME_BEFORE_EXPANDING_ON_HOVER = 600;
 
 const SidebarCollectionLink = React.forwardRef<HTMLLIElement, Props>(
   function SidebarCollectionLink(


### PR DESCRIPTION
Resolves #14755 

This PR makes collections in the sidebar expand on drag-n-drop hover to make it easier to move stuff around. The collection is going to expand after a quick timeout (500ms for now).

### To Verify

1. Create a collection with children (e.g. A > B > C)
2. Open another collection with some content
3. Start dragging an item from the collection and hover it over a collection with children
4. Ensure the collections isn't expanded instantly, so if you're just moving an item to a different collection it won't mess it up
5. Stop dragging at a collection with children, it should expand in a moment revealing its child collections
6. Hover any child collection and eventually drop an item into a new collection, ensure the move worked as expected
7. Ensure other aspects of DND work as expected

### Demo

https://user-images.githubusercontent.com/17258145/164241977-ccd17482-7237-4e87-89c4-e446da5e11ca.mp4
