### PR TITLE
tweak style of Add your own data button to better fit sidebar

### DIFF
--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.styled.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.styled.tsx
@@ -115,11 +115,9 @@ export const AddYourOwnDataLink = styled(SidebarLink)`
   background: ${color("brand")};
   border-radius: 8px;
   color: ${color("white")};
-  float: left;
   margin: ${space(1)};
   padding: 2px 6px;
   transition: background-color 0.3s linear;
-  width: auto;
 
   @media (prefers-reduced-motion) {
     transition: none;

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarView.tsx
@@ -126,7 +126,7 @@ function MainNavbarView({
               </BrowseLink>
               {!hasOwnDatabase && (
                 <AddYourOwnDataLink
-                  icon="database"
+                  icon="add"
                   url={ADD_YOUR_OWN_DATA_URL}
                   isSelected={
                     isMiscLinkSelected &&

--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -54,7 +54,9 @@ describe("collection permissions", () => {
                   it("should offer to save dashboard to root collection from a dashboard page (metabase#16832)", () => {
                     cy.visit("/collection/root");
                     cy.findByText("Orders in a dashboard").click();
-                    cy.icon("add").click();
+                    appBar().within(() => {
+                      cy.icon("add").click();
+                    });
                     popover()
                       .findByText("Dashboard")
                       .click();


### PR DESCRIPTION
Small visual tweaks to the "Add your own data" CTA button to make it feel a bit better in the new sidebar. Switched the icon from database to add to better communicate the action (and differentiate it from the Browse data link) and made the button full width.

How to test:
- Fire up a brand new instance of Metabase and complete setup without adding a database
- You should see this updated styling

Before:
![image](https://user-images.githubusercontent.com/5248953/164248398-fec1e7cd-2be3-4da3-87f9-f523c2e89e7e.png)


After:
![image](https://user-images.githubusercontent.com/5248953/164247973-4ed42d98-e306-4d0b-992d-b55c64db8ab0.png)
