### PR TITLE
Enable Custom expression for segments and metrics

### DIFF
--- a/frontend/src/metabase/css/query_builder.css
+++ b/frontend/src/metabase/css/query_builder.css
@@ -77,13 +77,11 @@
   display: flex;
   overflow-y: hidden;
   white-space: nowrap;
-  min-height: 55px;
 }
 
 .Query-filter {
   display: flex;
   flex-shrink: 0;
-  font-size: 0.75em;
   border: 2px solid transparent;
   border-radius: var(--default-border-radius);
 }

--- a/frontend/src/metabase/query_builder/components/Filter.jsx
+++ b/frontend/src/metabase/query_builder/components/Filter.jsx
@@ -11,6 +11,10 @@ import { getFilterArgumentFormatOptions } from "metabase/lib/schema_metadata";
 
 import { t, ngettext, msgid } from "ttag";
 
+import { color } from "metabase/lib/colors";
+
+import ViewPill from "metabase/query_builder/components/view/ViewPill";
+
 const DEFAULT_FILTER_RENDERER = ({ field, operator, values }) => {
   const items = [field, operator, ...values];
   // insert an "and" at the end if multiple values
@@ -32,7 +36,9 @@ const DEFAULT_FILTER_RENDERER = ({ field, operator, values }) => {
   );
 };
 
-export const OperatorFilter = ({
+const FilterPill = props => <ViewPill color={color("filter")} {...props} />;
+
+export const SimpleOperatorFilter = ({
   filter,
   metadata,
   maxDisplayValues,
@@ -80,10 +86,24 @@ export const OperatorFilter = ({
   });
 };
 
+export const ComplexOperatorFilter = ({ index, filter, removeFilter }) => {
+  return (
+    <FilterPill onRemove={() => removeFilter(index)}>
+      {filter.displayName()}
+    </FilterPill>
+  );
+};
+
+export const OperatorFilter = ({ filter, ...props }) =>
+  filter.displayName ? (
+    <ComplexOperatorFilter filter={filter} {...props} />
+  ) : (
+    <SimpleOperatorFilter filter={filter} {...props} />
+  );
+
 export const SegmentFilter = ({
   filter,
   metadata,
-  maxDisplayValues,
   children = DEFAULT_FILTER_RENDERER,
 }) => {
   const segment = metadata.segment(filter[1]);

--- a/frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx
@@ -140,7 +140,6 @@ export default class GuiQueryEditor extends React.Component {
                 query.filter(filter).update(setDatasetQuery)
               }
               onClose={() => this.filterPopover.current.close()}
-              showCustom={false}
             />
           </PopoverWithTrigger>
         </div>

--- a/frontend/src/metabase/query_builder/components/filters/FilterWidget.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/FilterWidget.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable react/prop-types */
 import React, { Component } from "react";
 
-import Icon from "metabase/components/Icon";
 import Popover from "metabase/components/Popover";
 import FilterPopover from "./FilterPopover";
 import FilterComponent from "metabase/query_builder/components/Filter";
@@ -128,23 +127,12 @@ export default class FilterWidget extends Component<Props, State> {
   }
 
   render() {
-    const { index, removeFilter } = this.props;
     return (
-      <div
-        className={cx("Query-filter p1 pl2", { selected: this.state.isOpen })}
-      >
+      <div className={cx("Query-filter", { selected: this.state.isOpen })}>
         <div className="flex justify-center" onClick={this.open}>
           {this.renderFilter()}
           {this.renderPopover()}
         </div>
-        {removeFilter && (
-          <a
-            className="text-light no-decoration px1 flex align-center"
-            onClick={() => removeFilter(index)}
-          >
-            <Icon name="close" size={14} />
-          </a>
-        )}
       </div>
     );
   }

--- a/frontend/src/metabase/query_builder/components/filters/FilterWidgetList.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/FilterWidgetList.jsx
@@ -34,7 +34,7 @@ export default class FilterWidgetList extends React.Component {
   render() {
     const { query, filters } = this.props;
     return (
-      <div className="Query-filterList scroll-x scroll-show">
+      <div className="Query-filterList ml2 scroll-x scroll-show">
         {filters.map((filter, index) => (
           <FilterWidget
             key={index}

--- a/frontend/test/metabase/scenarios/admin/datamodel/metrics.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/metrics.cy.spec.js
@@ -85,21 +85,6 @@ describe("scenarios > admin > datamodel > metrics", () => {
       );
     });
 
-    it("should have 'Custom expression' in a filter list (metabase#13069)", () => {
-      cy.visit("/admin/datamodel/metrics");
-      cy.findByText("New metric").click();
-      cy.findByText("Select a table").click();
-      popover().within(() => {
-        cy.findByText("Orders").click();
-      });
-      cy.findByText("Add filters to narrow your answer").click();
-
-      cy.log("Fails in v0.36.0 and v0.36.3. It exists in v0.35.4");
-      popover().within(() => {
-        cy.findByText("Custom Expression");
-      });
-    });
-
     it("should show how to create metrics", () => {
       cy.visit("/reference/metrics");
       cy.findByText(
@@ -264,7 +249,7 @@ describe("scenarios > admin > datamodel > metrics", () => {
       cy.findByText("Orders, CE"); // Definition
     });
 
-    it("should show CE that uses 'AND/OR' (metabase#13070)", () => {
+    it("should show CE that uses 'AND/OR' (metabase#13069, metabase#13070)", () => {
       cy.visit("/admin/datamodel/metrics");
       cy.findByText("New metric").click();
       cy.findByText("Select a table").click();
@@ -272,10 +257,9 @@ describe("scenarios > admin > datamodel > metrics", () => {
       cy.findByText("Add filters to narrow your answer").click();
       cy.findByText("Custom Expression").click();
       cy.get(".ace_text-input")
-        .click()
         .clear()
-        .type("[ID] > 0 OR [ID] < 9876543210", { delay: 100 });
-      cy.findByText("Done").click();
+        .type("[ID] > 0 OR [ID] < 9876543210");
+      cy.button("Done").click();
 
       cy.log("**Assert that there is a filter text visible**");
       cy.findByText("ID > 0 OR ID < 9876543210");

--- a/frontend/test/metabase/scenarios/admin/datamodel/metrics.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/metrics.cy.spec.js
@@ -85,7 +85,7 @@ describe("scenarios > admin > datamodel > metrics", () => {
       );
     });
 
-    it.skip("should have 'Custom expression' in a filter list (metabase#13069)", () => {
+    it("should have 'Custom expression' in a filter list (metabase#13069)", () => {
       cy.visit("/admin/datamodel/metrics");
       cy.findByText("New metric").click();
       cy.findByText("Select a table").click();
@@ -262,6 +262,23 @@ describe("scenarios > admin > datamodel > metrics", () => {
 
       cy.findByText("13022_Metric"); // Name
       cy.findByText("Orders, CE"); // Definition
+    });
+
+    it("should show CE that uses 'AND/OR' (metabase#13070)", () => {
+      cy.visit("/admin/datamodel/metrics");
+      cy.findByText("New metric").click();
+      cy.findByText("Select a table").click();
+      cy.findByText("Orders").click();
+      cy.findByText("Add filters to narrow your answer").click();
+      cy.findByText("Custom Expression").click();
+      cy.get(".ace_text-input")
+        .click()
+        .clear()
+        .type("[ID] > 0 OR [ID] < 9876543210", { delay: 100 });
+      cy.findByText("Done").click();
+
+      cy.log("**Assert that there is a filter text visible**");
+      cy.findByText("ID > 0 OR ID < 9876543210");
     });
   });
 });

--- a/frontend/test/metabase/scenarios/admin/datamodel/segments.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/segments.cy.spec.js
@@ -21,7 +21,7 @@ describe("scenarios > admin > datamodel > segments", () => {
       );
     });
 
-    it.skip("should have 'Custom expression' in a filter list (metabase#13069)", () => {
+    it("should have 'Custom expression' in a filter list (metabase#13069)", () => {
       cy.visit("/admin/datamodel/segments");
       cy.findByText("New segment").click();
       cy.findByText("Select a table").click();


### PR DESCRIPTION
How to verify:
1. Settings, Admin settings
2. Data Model, Segments, New segment 
3. select Products table, press the `+` button

### Before

Only simple filtering is possible, not with custom expression.

![image](https://user-images.githubusercontent.com/7288/164252646-1a87a2ce-6688-4b62-a2be-4e7f49e3c7d8.png)

### After

Custom expression can be used:

![Screenshot_20220420_071741](https://user-images.githubusercontent.com/7288/164252699-9f98221c-413e-499f-8d65-d22a568368bf.png)

![Screenshot_20220420_071813](https://user-images.githubusercontent.com/7288/164252847-a3d0b6aa-92b6-4045-a952-31fc65a5aaef.png)

and then it appears properly:

![Screenshot_20220420_071837](https://user-images.githubusercontent.com/7288/164252752-4d362479-214a-4dab-bf74-172e4c61ace5.png)

Also in metrics:

![Screenshot_20220420_071936](https://user-images.githubusercontent.com/7288/164252799-b2ecd391-b610-49a9-8932-b944330f5daa.png)
