### PR TITLE
visual permissions fixes

### DIFF
--- a/frontend/src/metabase/admin/datamodel/components/database/MetadataSchema/MetadataSchema.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/MetadataSchema/MetadataSchema.tsx
@@ -48,14 +48,6 @@ const MetadataSchema = ({ table }: MetadataSchemaProps) => {
 
   return (
     <div className="mt3 full">
-      <div className="flex flex-column px1">
-        <div
-          data-testid="table-name-input"
-          className="TableEditor-table-name text-bold"
-        >
-          {table.name}
-        </div>
-      </div>
       <table className="mt2 full">
         <thead className="text-uppercase text-medium py1">
           <tr>

--- a/frontend/src/metabase/admin/people/components/GroupsListing.jsx
+++ b/frontend/src/metabase/admin/people/components/GroupsListing.jsx
@@ -176,9 +176,9 @@ function GroupRow({
       <td>
         <Link
           to={"/admin/people/groups/" + group.id}
-          className="link no-decoration"
+          className="link no-decoration flex align-center"
         >
-          <span className="text-white inline-block">
+          <span className="text-white">
             <UserAvatar
               background={color}
               user={{ first_name: getGroupNameLocalized(group) }}

--- a/frontend/src/metabase/admin/permissions/components/PermissionsTable/PermissionsTable.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsTable/PermissionsTable.jsx
@@ -98,23 +98,25 @@ export function PermissionsTable({
         </thead>
         <tbody>
           {entities.map(entity => {
+            const entityName = (
+              <span className="flex align-center">
+                <Ellipsified>{entity.name}</Ellipsified>
+                {entity.hint && (
+                  <Tooltip tooltip={entity.hint}>
+                    <HintIcon />
+                  </Tooltip>
+                )}
+              </span>
+            );
             return (
               <PermissionsTableRow key={entity.id}>
                 <PermissionsTableCell>
                   {entity.canSelect ? (
                     <EntityNameLink onClick={() => onSelect(entity)}>
-                      <Ellipsified>{entity.name}</Ellipsified>
+                      {entityName}
                     </EntityNameLink>
                   ) : (
-                    <EntityName>
-                      <Ellipsified>{entity.name}</Ellipsified>
-                    </EntityName>
-                  )}
-
-                  {entity.hint && (
-                    <Tooltip tooltip={entity.hint}>
-                      <HintIcon />
-                    </Tooltip>
+                    <EntityName>{entityName}</EntityName>
                   )}
                 </PermissionsTableCell>
 

--- a/frontend/src/metabase/admin/permissions/components/PermissionsTable/PermissionsTable.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsTable/PermissionsTable.jsx
@@ -4,6 +4,7 @@ import PropTypes from "prop-types";
 import Tooltip from "metabase/components/Tooltip";
 import Modal from "metabase/components/Modal";
 import ConfirmContent from "metabase/components/ConfirmContent";
+import Ellipsified from "metabase/components/Ellipsified";
 
 import { PermissionsSelect } from "../PermissionsSelect";
 import {
@@ -102,10 +103,12 @@ export function PermissionsTable({
                 <PermissionsTableCell>
                   {entity.canSelect ? (
                     <EntityNameLink onClick={() => onSelect(entity)}>
-                      {entity.name}
+                      <Ellipsified>{entity.name}</Ellipsified>
                     </EntityNameLink>
                   ) : (
-                    <EntityName>{entity.name}</EntityName>
+                    <EntityName>
+                      <Ellipsified>{entity.name}</Ellipsified>
+                    </EntityName>
                   )}
 
                   {entity.hint && (

--- a/frontend/src/metabase/admin/permissions/components/PermissionsTable/PermissionsTable.styled.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsTable/PermissionsTable.styled.jsx
@@ -11,17 +11,21 @@ export const PermissionsTableRoot = styled.table`
 
 export const PermissionsTableCell = styled.td`
   vertical-align: center;
-  padding: 0.625rem 2rem;
+  padding: 0.625rem 1rem;
   box-sizing: border-box;
   min-height: 40px;
+  overflow: hidden;
 
   &:first-of-type {
-    min-width: 300px;
+    width: 1%;
+    white-space: nowrap;
+    max-width: 300px;
     background: white;
     left: 0;
     top: 0;
     position: sticky;
     padding-left: 0;
+    padding-right: 1.5rem;
 
     &:after {
       position: absolute;


### PR DESCRIPTION
1) Closes https://github.com/metabase/metabase/issues/21765

Open the [data permissions page](http://localhost:3000/admin/permissions/data/group) and ensure it handles short and long names correctly.
**Short name**
<img width="591" alt="Screenshot 2022-04-20 at 17 27 38" src="https://user-images.githubusercontent.com/14301985/164241322-120b2fce-bef8-45dc-a5fe-7776820fe0e8.png">

**Long name**
<img width="553" alt="Screenshot 2022-04-20 at 17 27 21" src="https://user-images.githubusercontent.com/14301985/164241387-57bfb763-26c4-4f9f-af8d-1c182debeacf.png">


2) Closes https://github.com/metabase/metabase/issues/21763
Open the [data model page](http://localhost:3000/admin/datamodel/database/5/table/25) and click on the original schema. Ensure the table name is not duplocated.

<img width="572" alt="Screenshot 2022-04-20 at 17 32 05" src="https://user-images.githubusercontent.com/14301985/164241886-664265eb-f1a0-4193-8535-035edc68f770.png">
