### PR TITLE
Fix "not found" shown briefly on admin settings

### DIFF
--- a/frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx
+++ b/frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx
@@ -130,7 +130,12 @@ export default class SettingsEditorApp extends Component {
   };
 
   renderSettingsPane() {
-    const { activeSection, settingValues } = this.props;
+    const { activeSection, settings, settingValues } = this.props;
+    const isLoading = settings.length === 0;
+
+    if (isLoading) {
+      return null;
+    }
 
     if (!activeSection) {
       return <NotFound />;


### PR DESCRIPTION
Fixes #16120

When opening `/admin/settings`, there is a brief moment when you can see a "not found" message on the page. Normally it's shown if a user tries to open a settings section that doesn't exist, like `/admin/settings/bananas`. There is a really short moment caused by data loading when the FE doesn't have a "selected section" assigned, so it blinks with a "not found" message as if you open a non-existing page. Fixed by handling this edge-case

### To Verify

1. Open `/admin/settings`
2. Refresh the page a few times, you should see no "not found" message blinking

You can add some background color to [`NotFound` component](https://github.com/metabase/metabase/blob/a6482aa42fadf645a24ab8c9c0a0b3359dbaded2/frontend/src/metabase/containers/ErrorPages.jsx#L29) locally to make it more noticeable.

### Demo

I changed "Not Found" block's background color to red in order to make it more visible for the demo

**Before**

https://user-images.githubusercontent.com/17258145/164257722-11a3c97d-7681-4bb4-adf1-1c3768f29106.mp4

**After**

https://user-images.githubusercontent.com/17258145/164257744-f1327bf3-709d-44b5-a856-4e9443518a6f.mp4


