### PR TITLE
Clean collection items bulk selection when opening another collection

### DIFF
--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -24,6 +24,7 @@ import PaginationControls from "metabase/components/PaginationControls";
 
 import { useOnMount } from "metabase/hooks/use-on-mount";
 import { usePagination } from "metabase/hooks/use-pagination";
+import { usePrevious } from "metabase/hooks/use-previous";
 import { useListSelect } from "metabase/hooks/use-list-select";
 import { isSmallScreen } from "metabase/lib/dom";
 import {
@@ -82,12 +83,19 @@ function CollectionContent({
     getIsSelected,
     clear,
   } = useListSelect(itemKeyFn);
+  const previousCollection = usePrevious(collection);
 
   useOnMount(() => {
     if (!isSmallScreen()) {
       openNavbar();
     }
   });
+
+  useEffect(() => {
+    if (previousCollection && previousCollection.id !== collection.id) {
+      clear();
+    }
+  }, [previousCollection, collection, clear]);
 
   useEffect(() => {
     const shouldBeBookmarked = bookmarks.some(

--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -317,6 +317,20 @@ describe("scenarios > collection defaults", () => {
           bulkSelectDeselectWorkflow();
         });
 
+        it("should clean up selection when opening another collection (metabase#16491)", () => {
+          cy.request("PUT", "/api/card/1", {
+            collection_id: 1,
+          });
+          cy.visit("/collection/root");
+          cy.findByText("Your personal collection").click();
+
+          selectItemUsingCheckbox("Orders");
+          cy.findByText("1 item selected").should("be.visible");
+
+          cy.findByText("Our analytics").click();
+          cy.findByTestId("bulk-action-bar").should("not.be.visible");
+        });
+
         function bulkSelectDeselectWorkflow() {
           cy.visit("/collection/root");
           selectItemUsingCheckbox("Orders");


### PR DESCRIPTION
Reproduces #16491, fixes #16491

On a collection page, it's possible to select a few items for a bulk archive/move action. This PR fixes a bug when the selection would not be reset when a user selects an item and then opens another collection. This could lead to unexpected item moves/archives.

It doesn't happen all the time and the root cause is, most likely, our entity loader mechanism. If you select a few items and open a collection you haven't yet opened in the current session, the selection will be reset. This happens because the whole collection page component gets rendered, so the `useListSelect` hook gets initialized from scratch too and the selection gets cleared. On the other hand, if you switch between collections you've already opened before, the entity loader will just change the `collection` prop (as it's cached in redux), and the FE will actually need to manually clean up the selection. This is exactly what's done in this PR

### To Verify

1. Open root collection and save an item to it
2. Open your personal collection and save an item to it (let's saved it's a question called "Orders")
3. While being on the personal collection page, hover over the "Orders" question icon and click the appeared checkbox
4. Ensure you can see a bulk actions bar appearing at the bottom of the collection page
5. Click "Our analytics" in the sidebar to open it
6. Ensure the bulk actions bar is gone
7. Ensure bulk operations work normally

### Demo

**Before**

https://user-images.githubusercontent.com/17258145/164264611-1b9333f1-81d3-48ad-bdae-0f960256f05c.mp4

**After**

https://user-images.githubusercontent.com/17258145/164264625-4657a069-5cbb-4f48-ad0b-b42d1ab6747b.mp4
