### PR TITLE
[E2E] Experiment running `dashboard-filters` test group as PR check

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -60,6 +60,7 @@ jobs:
         edition: [ee]
         folder:
           - "binning"
+          - "dashboard-filters"
           - "downloads"
           - "moderation"
     services:


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Following the steps of https://github.com/metabase/metabase/pull/21492 and the tasks that @ariya started, we're now adding `dashboard-filters` test group to PR checks using GitHub actions.

Analyzing the flakes report, the only flaking tests I saw were related to https://github.com/metabase/metabase/issues/21830. Those should now be fixed by #21801

There's one more important check we need to make. Let's see if the number of passing tests is the same for both OSS and EE versions.

tl;dr It is. Because dashboard-filters tests are version agnostic.

But here's the data:
[dashboard-filters OSS](https://github.com/metabase/metabase/runs/6112755351?check_suite_focus=true) vs [dashboard-filters EE](https://github.com/metabase/metabase/runs/6112757083?check_suite_focus=true)
| e2e-tests-binning                       | total | passing | pending  |
|---------------------------|--------|-------|-------|
| OSS                  | 85   | 79  | 6  |
| EE                 | 85   | 79  | 6  |


### The next steps
After we make sure this group runs without major hiccups on GitHub (for at least a week?), remove it from CircleCI.