### PR TITLE
Fix `homepage` flakes

### DIFF
--- a/frontend/test/metabase/scenarios/onboarding/home/homepage.cy.spec.js
+++ b/frontend/test/metabase/scenarios/onboarding/home/homepage.cy.spec.js
@@ -35,7 +35,7 @@ describe("scenarios > home > homepage", () => {
       cy.visit("/");
       cy.wait("@getXrayCandidates");
       cy.findByText("Here are some explorations of");
-      cy.findByText("H2");
+      cy.findAllByRole("link").contains("H2");
       cy.findByText("Orders").click();
 
       cy.wait("@getXrayDashboard");
@@ -50,7 +50,7 @@ describe("scenarios > home > homepage", () => {
       cy.visit("/");
       cy.findByText(/Here are some explorations of the/);
       cy.findByText("public");
-      cy.findByText("H2");
+      cy.findAllByRole("link").contains("H2");
       cy.findByText("Orders");
       cy.findByText("People").should("not.exist");
 


### PR DESCRIPTION
### Before
These tests had a rate of failure over 50%!
![image](https://user-images.githubusercontent.com/31325167/164301719-900d2fb0-9af5-47db-9596-810bcb744418.png)

They were too fragile because we were searching for a single "H2" string **anywhere** in the DOM. There is another "H2" string showing up in a small popup window in the lower right corner. Cypress was failing because it's seeing both strings, and we explicitly told it to search for one.

Whenever possible, try to use semantic selectors or at least narrow down the search result.

### After
String search is now scoped within a link and it shouldn't fail anymore.