### PR TITLE
Don't pass query parameters when compiling Saved Question references

### DIFF
--- a/frontend/test/metabase/scenarios/native-filters/reproductions/21246.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native-filters/reproductions/21246.cy.spec.js
@@ -7,7 +7,7 @@ const questionDetails = {
   query: { "source-table": PRODUCTS_ID },
 };
 
-describe.skip("issue 21246", () => {
+describe("issue 21246", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();


### PR DESCRIPTION
Fixes #21246

The problem was we were passing along parameters meant for the top-level native query along to the referenced Saved Questions (e.g. the `{{#1234}}` parameters) which caused things to fail since native query parameters don't work when compiling MBQL questions. I thought we must have been doing this for some sort of good reason but it looks like all tests are passing when we remove it and it fixes the problem