### PR TITLE
Fix native model view for no-data user

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/View.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View.jsx
@@ -297,17 +297,33 @@ export default class View extends React.Component {
     );
   };
 
+  renderNativeQueryEditor = () => {
+    const { question, query, card, height, isDirty } = this.props;
+
+    if (question.isDataset() && !query.isEditable()) {
+      return null;
+    }
+
+    return (
+      <NativeQueryEditorContainer>
+        <NativeQueryEditor
+          {...this.props}
+          viewHeight={height}
+          isOpen={!card.dataset_query.native.query || isDirty}
+          datasetQuery={card && card.dataset_query}
+        />
+      </NativeQueryEditorContainer>
+    );
+  };
+
   renderMain = ({ leftSidebar, rightSidebar }) => {
     const {
       query,
-      card,
       mode,
       parameters,
-      isDirty,
       isLiveResizable,
       isPreviewable,
       isPreviewing,
-      height,
       setParameterValue,
       setIsPreviewing,
     } = this.props;
@@ -334,14 +350,7 @@ export default class View extends React.Component {
     return (
       <QueryBuilderMain isSidebarOpen={isSidebarOpen}>
         {isNative ? (
-          <NativeQueryEditorContainer>
-            <NativeQueryEditor
-              {...this.props}
-              viewHeight={height}
-              isOpen={!card.dataset_query.native.query || isDirty}
-              datasetQuery={card && card.dataset_query}
-            />
-          </NativeQueryEditorContainer>
+          this.renderNativeQueryEditor()
         ) : (
           <StyledSyncedParametersList
             parameters={parameters}

--- a/frontend/src/metabase/query_builder/components/view/View.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View.jsx
@@ -300,6 +300,13 @@ export default class View extends React.Component {
   renderNativeQueryEditor = () => {
     const { question, query, card, height, isDirty } = this.props;
 
+    // Normally, when users open native models,
+    // they open an ad-hoc GUI question using the model as a data source
+    // (using the `/dataset` endpoint instead of the `/card/:id/query`)
+    // However, users without data permission open a real model as they can't use the `/dataset` endpoint
+    // So the model is opened as an underlying native question and the query editor becomes visible
+    // This check makes it hide the editor in this particular case
+    // More details: https://github.com/metabase/metabase/pull/20161
     if (question.isDataset() && !query.isEditable()) {
       return null;
     }

--- a/frontend/test/metabase/scenarios/models/models.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models.cy.spec.js
@@ -532,6 +532,22 @@ describe("scenarios > models", () => {
     });
   });
 
+  it("should correctly show native models for no-data users", () => {
+    cy.intercept("POST", "/api/card/*/query").as("cardQuery");
+    cy.createNativeQuestion({
+      name: "TEST MODEL",
+      dataset: true,
+      native: {
+        query: "select * from orders",
+      },
+    });
+    cy.signIn("nodata");
+    cy.visit("/collection/root");
+    cy.findByText("TEST MODEL").click();
+    cy.wait("@cardQuery");
+    cy.findByText(/This question is written in SQL/i).should("not.exist");
+  });
+
   describe("listing", () => {
     beforeEach(() => {
       cy.request("PUT", "/api/card/1", { name: "Orders Model", dataset: true });


### PR DESCRIPTION
This PR makes it completely hide the native query editor for no-data users when they open a native model. It doesn't show up for users with data permissions, and the reason no-data users can see it is a "simple mode" mechanism behind models (for more details, please read #20161 and the code comment in the file diff)

### To Verify

1. Create a native model
2. Sign in as a no-data user
3. Open the model, ensure you don't see the "This question is written in SQL" message

### Demo

**Before**
![before](https://user-images.githubusercontent.com/17258145/164300384-4b294d71-2131-4827-a503-c2ce0d5308db.png)

**After**
<img width="1500" alt="after" src="https://user-images.githubusercontent.com/17258145/164300370-acb1b6b9-7ffe-4d6d-ab68-f59d53fc714f.png">

