### PR TITLE
Expose more QB actions to no-data users

### DIFF
--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -1393,11 +1393,11 @@ export const queryCompleted = (question, queryResults) => {
     const [{ data }] = queryResults;
     const [{ data: prevData }] = getQueryResults(getState()) || [{}];
     const originalQuestion = getOriginalQuestion(getState());
-    const dirty =
-      !originalQuestion ||
-      (originalQuestion && question.isDirtyComparedTo(originalQuestion));
+    const isDirty =
+      question.query().isEditable() &&
+      question.isDirtyComparedTo(originalQuestion);
 
-    if (dirty) {
+    if (isDirty) {
       if (question.isNative()) {
         question = question.syncColumnsAndSettings(
           originalQuestion,

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -1049,16 +1049,18 @@ export const navigateToNewCardInsideQB = createThunkAction(
 export const UPDATE_QUESTION = "metabase/qb/UPDATE_QUESTION";
 export const updateQuestion = (
   newQuestion,
-  { doNotClearNameAndId = false, run = false, shouldUpdateUrl = false } = {},
+  { run = false, shouldUpdateUrl = false } = {},
 ) => {
   return async (dispatch, getState) => {
     const oldQuestion = getQuestion(getState());
     const mode = getQueryBuilderMode(getState());
 
+    const shouldConvertIntoAdHoc = newQuestion.query().isEditable();
+
     // TODO Atte Keinänen 6/2/2017 Ways to have this happen automatically when modifying a question?
     // Maybe the Question class or a QB-specific question wrapper class should know whether it's being edited or not?
     if (
-      !doNotClearNameAndId &&
+      shouldConvertIntoAdHoc &&
       !getIsEditing(getState()) &&
       newQuestion.isSaved() &&
       mode !== "dataset"

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -858,10 +858,12 @@ export const updateCardVisualizationSettings = settings => async (
     return;
   }
 
+  // The check allows users without data permission to resize/rearrange columns
+  const hasWritePermissions = question.query().isEditable();
   await dispatch(
     updateQuestion(question.updateSettings(settings), {
-      run: "auto",
-      shouldUpdateUrl: true,
+      run: hasWritePermissions ? "auto" : false,
+      shouldUpdateUrl: hasWritePermissions,
     }),
   );
 };
@@ -871,10 +873,13 @@ export const replaceAllCardVisualizationSettings = settings => async (
   getState,
 ) => {
   const question = getQuestion(getState());
+
+  // The check allows users without data permission to resize/rearrange columns
+  const hasWritePermissions = question.query().isEditable();
   await dispatch(
     updateQuestion(question.setSettings(settings), {
-      run: "auto",
-      shouldUpdateUrl: true,
+      run: hasWritePermissions ? "auto" : false,
+      shouldUpdateUrl: hasWritePermissions,
     }),
   );
 };

--- a/frontend/src/metabase/query_builder/components/view/ViewFooter.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewFooter.jsx
@@ -74,8 +74,6 @@ const ViewFooter = ({
     return null;
   }
 
-  const hasDataPermission = question.query().isEditable();
-
   return (
     <ViewFooterRoot
       className={cx(className, "text-medium border-top")}
@@ -107,30 +105,26 @@ const ViewFooter = ({
               onCloseSummary={onCloseSummary}
             />
           ),
-          hasDataPermission && (
-            <VizTypeButton
-              key="viz-type"
-              question={question}
-              result={result}
-              active={isShowingChartTypeSidebar}
-              onClick={
-                isShowingChartTypeSidebar ? onCloseChartType : onOpenChartType
-              }
-            />
-          ),
-          hasDataPermission && (
-            <VizSettingsButton
-              key="viz-settings"
-              ml={1}
-              mr={[3, 0]}
-              active={isShowingChartSettingsSidebar}
-              onClick={
-                isShowingChartSettingsSidebar
-                  ? onCloseChartSettings
-                  : onOpenChartSettings
-              }
-            />
-          ),
+          <VizTypeButton
+            key="viz-type"
+            question={question}
+            result={result}
+            active={isShowingChartTypeSidebar}
+            onClick={
+              isShowingChartTypeSidebar ? onCloseChartType : onOpenChartType
+            }
+          />,
+          <VizSettingsButton
+            key="viz-settings"
+            ml={1}
+            mr={[3, 0]}
+            active={isShowingChartSettingsSidebar}
+            onClick={
+              isShowingChartSettingsSidebar
+                ? onCloseChartSettings
+                : onOpenChartSettings
+            }
+          />,
         ]}
         center={
           isVisualized && (

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -398,7 +398,9 @@ function ViewTitleHeaderRightSide(props) {
     onCollapseFilters,
   } = props;
   const isShowingNotebook = queryBuilderMode === "notebook";
-  const isReadOnlyQuery = question.query().readOnly();
+  const query = question.query();
+  const isReadOnlyQuery = query.readOnly();
+  const canEditQuery = !isReadOnlyQuery;
   const canRunAdhocQueries = !isReadOnlyQuery;
   const hasExploreResultsLink =
     isNative &&
@@ -406,12 +408,15 @@ function ViewTitleHeaderRightSide(props) {
     canRunAdhocQueries &&
     MetabaseSettings.get("enable-nested-queries");
 
+  const isNewQuery = !query.hasData();
+  const hasSaveButton = !isDataset && !!isDirty && (isNewQuery || canEditQuery);
+
   return (
     <div
       className="ml-auto flex align-center"
       data-testid="qb-header-action-panel"
     >
-      {!!isDirty && !isDataset && !isReadOnlyQuery && (
+      {hasSaveButton && (
         <SaveButton
           disabled={!question.canRun()}
           data-metabase-event={

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -398,7 +398,8 @@ function ViewTitleHeaderRightSide(props) {
     onCollapseFilters,
   } = props;
   const isShowingNotebook = queryBuilderMode === "notebook";
-  const canRunAdhocQueries = !question.query().readOnly();
+  const isReadOnlyQuery = question.query().readOnly();
+  const canRunAdhocQueries = !isReadOnlyQuery;
   const hasExploreResultsLink =
     isNative &&
     isSaved &&
@@ -410,7 +411,7 @@ function ViewTitleHeaderRightSide(props) {
       className="ml-auto flex align-center"
       data-testid="qb-header-action-panel"
     >
-      {!!isDirty && !isDataset && (
+      {!!isDirty && !isDataset && !isReadOnlyQuery && (
         <SaveButton
           disabled={!question.canRun()}
           data-metabase-event={

--- a/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx
@@ -68,7 +68,10 @@ const ChartTypeSidebar = ({
                     question
                       .setDisplay(type)
                       .lockDisplay(true) // prevent viz auto-selection
-                      .update(null, { reload: false, shouldUpdateUrl: true });
+                      .update(null, {
+                        reload: false,
+                        shouldUpdateUrl: question.query().isEditable(),
+                      });
                     onOpenChartSettings({ section: t`Data` });
                     setUIControls({ isShowingRawTable: false });
                   }}

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -527,8 +527,16 @@ export const getQuery = createSelector(
 );
 
 export const getIsRunnable = createSelector(
-  [getQuestion],
-  question => question && question.canRun(),
+  [getQuestion, getIsDirty],
+  (question, isDirty) => {
+    if (!question) {
+      return false;
+    }
+    if (!question.isSaved() || isDirty) {
+      return question.canRun() && !question.query().readOnly();
+    }
+    return question.canRun();
+  },
 );
 
 export const getQuestionAlerts = createSelector(

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -395,6 +395,10 @@ export const getIsResultDirty = createSelector(
     nextParameters,
     tableMetadata,
   ) => {
+    if (question && question.query().readOnly()) {
+      return false;
+    }
+
     // When viewing a model, its dataset_query is swapped with a clean query using the dataset as a source table
     // (it's necessary for datasets to behave like tables opened in simple mode)
     // We need to escape the isDirty check as it will always be true in this case,

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -395,10 +395,6 @@ export const getIsResultDirty = createSelector(
     nextParameters,
     tableMetadata,
   ) => {
-    if (question && question.query().readOnly()) {
-      return false;
-    }
-
     // When viewing a model, its dataset_query is swapped with a clean query using the dataset as a source table
     // (it's necessary for datasets to behave like tables opened in simple mode)
     // We need to escape the isDirty check as it will always be true in this case,
@@ -408,12 +404,18 @@ export const getIsResultDirty = createSelector(
       return false;
     }
 
+    const hasParametersChange = !Utils.equals(lastParameters, nextParameters);
+    if (hasParametersChange) {
+      return true;
+    }
+
+    if (question && question.query().readOnly()) {
+      return false;
+    }
+
     lastDatasetQuery = normalizeQuery(lastDatasetQuery, tableMetadata);
     nextDatasetQuery = normalizeQuery(nextDatasetQuery, tableMetadata);
-    return (
-      !Utils.equals(lastDatasetQuery, nextDatasetQuery) ||
-      !Utils.equals(lastParameters, nextParameters)
-    );
+    return !Utils.equals(lastDatasetQuery, nextDatasetQuery);
   },
 );
 

--- a/frontend/src/metabase/visualizations/components/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive.jsx
@@ -625,7 +625,6 @@ export default class TableInteractive extends Component {
   // We should maybe rethink the approach to measurements or render a very basic table header, without react-draggable
   tableHeaderRenderer = ({ key, style, columnIndex, isVirtual = false }) => {
     const {
-      query,
       data,
       sort,
       isPivoted,
@@ -641,7 +640,7 @@ export default class TableInteractive extends Component {
 
     const clicked = this.getHeaderClickedObject(columnIndex);
 
-    const isDraggable = !isPivoted && query && query.isEditable();
+    const isDraggable = !isPivoted;
     const isDragging = dragColIndex === columnIndex;
     const isClickable = this.visualizationIsClickable(clicked);
     const isSortable = isClickable && column.source && !isPivoted;

--- a/frontend/test/metabase/scenarios/question/new.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/new.cy.spec.js
@@ -367,31 +367,6 @@ describe("scenarios > question > new", () => {
       // this should be among the granular selection choices
       cy.findByText("Hour of Day").click();
     });
-
-    it("'read-only' user should be able to resize column width (metabase#9772)", () => {
-      cy.signIn("readonly");
-      visitQuestion(1);
-      cy.findByText("Tax")
-        .closest(".TableInteractive-headerCellData")
-        .as("headerCell")
-        .then($cell => {
-          const originalWidth = $cell[0].getBoundingClientRect().width;
-
-          cy.wrap($cell)
-            .find(".react-draggable")
-            .trigger("mousedown", 0, 0, { force: true })
-            .trigger("mousemove", 100, 0, { force: true })
-            .trigger("mouseup", 100, 0, { force: true });
-
-          cy.findByText("Started from").click(); // Give DOM some time to update
-
-          cy.get("@headerCell").then($newCell => {
-            const newWidth = $newCell[0].getBoundingClientRect().width;
-
-            expect(newWidth).to.be.gt(originalWidth);
-          });
-        });
-    });
   });
 });
 

--- a/frontend/test/metabase/scenarios/question/new.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/new.cy.spec.js
@@ -368,6 +368,40 @@ describe("scenarios > question > new", () => {
       cy.findByText("Hour of Day").click();
     });
   });
+
+  it("'read-only' user should be able to resize column width (metabase#9772)", () => {
+    cy.signIn("readonly");
+    visitQuestion(1);
+
+    cy.findByText("Tax")
+      .closest(".TableInteractive-headerCellData")
+      .as("headerCell")
+      .then($cell => {
+        const originalWidth = $cell[0].getBoundingClientRect().width;
+
+        // Retries the assertion a few times to ensure it waits for DOM changes
+        // More context: https://github.com/metabase/metabase/pull/21823#discussion_r855302036
+        function assertColumnResized(attempt = 0) {
+          cy.get("@headerCell").then($newCell => {
+            const newWidth = $newCell[0].getBoundingClientRect().width;
+            if (newWidth === originalWidth && attempt < 3) {
+              cy.wait(100);
+              assertColumnResized(++attempt);
+            } else {
+              expect(newWidth).to.be.gt(originalWidth);
+            }
+          });
+        }
+
+        cy.wrap($cell)
+          .find(".react-draggable")
+          .trigger("mousedown", 0, 0, { force: true })
+          .trigger("mousemove", 100, 0, { force: true })
+          .trigger("mouseup", 100, 0, { force: true });
+
+        assertColumnResized();
+      });
+  });
 });
 
 function removeMetricFromSidebar(metricName) {


### PR DESCRIPTION
Fixes #16836, fixes #18433

Continuation of #20317 and #20320. This PR would allow no-data users to:

* resize columns and change their order for table visualization
* change a question's visualization type and visualization settings

Both things would only work "locally", i.e. there will be no "Save" button to keep the changes.

### To Verifty

1. Create a question visualized as a table
2. Sign in as a no-data user
3. Try to resize/rearrange columns
4. Ensure it worked, ensure the URL is not changed to `/question#longHashValue`, ensure you don't see the "Save" button
5. Try to change visualization type and viz settings
6. Ensure it worked, ensure the URL is not changed to `/question#longHashValue`, ensure you don't see the "Save" button
7. Refresh the page, ensure the question looks the same as originally (without the changes you've made)

### Demo

https://user-images.githubusercontent.com/17258145/164306279-a0180327-96da-4e22-8547-f5ae88326555.mp4


