### PR TITLE
Scientific notation obeys custom separators

### DIFF
--- a/frontend/src/metabase/lib/formatting.js
+++ b/frontend/src/metabase/lib/formatting.js
@@ -208,7 +208,10 @@ function formatNumberScientific(value, options) {
   if (options.maximumFractionDigits) {
     value = d3.round(value, options.maximumFractionDigits);
   }
-  const exp = value.toExponential(options.minimumFractionDigits);
+  const exp = replaceNumberSeparators(
+    value.toExponential(options.minimumFractionDigits),
+    options?.number_separators,
+  );
   if (options.jsx) {
     const [m, n] = exp.split("e");
     return (

--- a/frontend/test/metabase/lib/formatting.unit.spec.js
+++ b/frontend/test/metabase/lib/formatting.unit.spec.js
@@ -123,6 +123,19 @@ describe("formatting", () => {
         expect(formatNumber(123456.78, options)).toEqual("1.2e+5");
         expect(formatNumber(-123456.78, options)).toEqual("-1.2e+5");
       });
+      it("should obey custom separators in scientific notiation", () => {
+        const options = {
+          compact: true,
+          number_style: "scientific",
+          number_separators: ",.",
+        };
+        expect(formatNumber(0, options)).toEqual("0,0e+0");
+        expect(formatNumber(0.0001, options)).toEqual("1,0e-4");
+        expect(formatNumber(0.01, options)).toEqual("1,0e-2");
+        expect(formatNumber(0.5, options)).toEqual("5,0e-1");
+        expect(formatNumber(123456.78, options)).toEqual("1,2e+5");
+        expect(formatNumber(-123456.78, options)).toEqual("-1,2e+5");
+      });
       it("should format currency values", () => {
         const options = {
           compact: true,


### PR DESCRIPTION
## Before

- Regardless of visualization settings re. separators (i.e. `.` vs `,`), numbers in scientific notation would always use `.` as the decimal separator

## Changes

- apply separator settings to numbers in scientific notation
- resolves #16820 

## After

- numbers in scientific notation obey separator settings

, | .
--- | ---
![Screenshot from 2022-04-20 13-37-38](https://user-images.githubusercontent.com/30528226/164309391-a156fb11-3854-4c39-b079-d02225531b61.png) | ![Screenshot from 2022-04-20 13-37-25](https://user-images.githubusercontent.com/30528226/164309392-33ee01c4-bd32-4a9d-9110-803ab93e4b40.png)
