### PR TITLE
Check for errors when transforming series

### DIFF
--- a/frontend/src/metabase/visualizations/index.js
+++ b/frontend/src/metabase/visualizations/index.js
@@ -58,7 +58,7 @@ export function getVisualizationRaw(series) {
 
 export function getVisualizationTransformed(series) {
   // don't transform if we don't have the data
-  if (_.any(series, s => s.data == null)) {
+  if (_.any(series, s => s.data == null) || _.any(series, s => s.error)) {
     return getVisualizationRaw(series);
   }
 

--- a/frontend/test/metabase/scenarios/visualizations/reproductions/21665-multi-series-frontend-reload.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/reproductions/21665-multi-series-frontend-reload.cy.spec.js
@@ -17,7 +17,7 @@ const Q2 = {
   display: "scalar",
 };
 
-describe.skip("issue 21665", () => {
+describe("issue 21665", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
@@ -59,18 +59,10 @@ describe.skip("issue 21665", () => {
       visitDashboard(id);
     });
 
-    /**
-     * WARNING!
-     * Until this issue gets resolved, you will have to manually stop this test EVEN AFTER IT FAILS!
-     * It will send your browser in the infinite loop and can eventually freeze your browser or even the whole system if left unattended.
-     *
-     * TODO:
-     * Once this issue gets fixed, please remove the arbitrary wait and replace it with the positive assertion.
-     */
-
-    cy.wait(1000);
-
     cy.get("@dashboardLoaded").should("have.been.calledThrice");
+    cy.findByText("There was a problem displaying this chart.").should(
+      "be.visible",
+    );
   });
 });
 


### PR DESCRIPTION
Fixes #21665 

Adding a check for errors when transforming series data. We already to a check to ensure a data object exists, but in our case it's empty which causes errors. Now rather than getting an infinite render loop, we get the generic error message. Cypress Test has also been enabled

![image](https://user-images.githubusercontent.com/1328979/164311224-e8de49f0-a3c6-4cc4-9c30-25b9c926381d.png)


