### PR TITLE
fix infinite-loading dashboard on 403

### DIFF
--- a/frontend/src/metabase/dashboard/actions.js
+++ b/frontend/src/metabase/dashboard/actions.js
@@ -5,7 +5,7 @@ import _ from "underscore";
 import { t } from "ttag";
 
 import { createAction, createThunkAction } from "metabase/lib/redux";
-import { defer, delay } from "metabase/lib/promise";
+import { defer } from "metabase/lib/promise";
 import { normalize, schema } from "normalizr";
 
 import Question from "metabase-lib/lib/Question";
@@ -544,8 +544,6 @@ export const fetchCardData = createThunkAction(FETCH_CARD_DATA, function(
     // If the dataset_query was filtered then we don't have permisison to view this card, so
     // shortcircuit and return a fake 403
     if (!card.dataset_query) {
-      // introduce delay to avoid setting this request complete before it was set to pending
-      await delay(1);
       return {
         dashcard_id: dashcard.id,
         card_id: card.id,

--- a/frontend/src/metabase/dashboard/actions.js
+++ b/frontend/src/metabase/dashboard/actions.js
@@ -5,7 +5,7 @@ import _ from "underscore";
 import { t } from "ttag";
 
 import { createAction, createThunkAction } from "metabase/lib/redux";
-import { defer } from "metabase/lib/promise";
+import { defer, delay } from "metabase/lib/promise";
 import { normalize, schema } from "normalizr";
 
 import Question from "metabase-lib/lib/Question";
@@ -544,6 +544,8 @@ export const fetchCardData = createThunkAction(FETCH_CARD_DATA, function(
     // If the dataset_query was filtered then we don't have permisison to view this card, so
     // shortcircuit and return a fake 403
     if (!card.dataset_query) {
+      // introduce delay to avoid setting this request complete before it was set to pending
+      await delay(1);
       return {
         dashcard_id: dashcard.id,
         card_id: card.id,

--- a/frontend/src/metabase/dashboard/reducers.js
+++ b/frontend/src/metabase/dashboard/reducers.js
@@ -302,18 +302,21 @@ const loadingDashCards = handleActions(
       }),
     },
     [FETCH_DASHBOARD]: {
-      next: (state, { payload }) => ({
-        ...state,
-        dashcardIds: Object.values(payload.entities.dashcard || {})
+      next: (state, { payload }) => {
+        const cardIds = Object.values(payload.entities.dashcard || {})
           .filter(dc => !isVirtualDashCard(dc))
-          .map(dc => dc.id),
-        loadingStatus: "idle",
-      }),
+          .map(dc => dc.id);
+        return {
+          ...state,
+          dashcardIds: cardIds,
+          loadingIds: cardIds,
+          loadingStatus: "idle",
+        };
+      },
     },
     [FETCH_DASHBOARD_CARD_DATA]: {
       next: state => ({
         ...state,
-        loadingIds: state.dashcardIds,
         loadingStatus: state.dashcardIds.length > 0 ? "running" : "idle",
         startTime:
           state.dashcardIds.length > 0 &&

--- a/frontend/src/metabase/dashboard/reducers.unit.spec.js
+++ b/frontend/src/metabase/dashboard/reducers.unit.spec.js
@@ -237,6 +237,7 @@ describe("dashboard reducers", () => {
             ...initState,
             loadingDashCards: {
               dashcardIds: dashcardIds,
+              loadingIds: dashcardIds,
             },
           },
           {


### PR DESCRIPTION
## Before

If a user views a dashboard that includes one or more cards on which they do not have permissions, the browser title/time would continue counting up infinitely, and the unauthorized question would never be counted as completed.

![Screenshot from 2022-04-20 13-53-31](https://user-images.githubusercontent.com/30528226/164312620-7083011d-8e40-411d-b463-30e80e3da7ef.png)


## Fix

When we fetch data for a dashboard, we create an array of promises to fetch the data for each card, and fire a redux action `FETCH_DASHBOARD_CARD_DATA` which sets all the cards to loading state.

When each card completes, it fires a `FETCH_CARD_DATA` action which marks that card as loaded. when all cards are loaded, the timer stops.

There is some logic which early-returns a 403 if there is a card to which a user does not have access. Because we never make a network request, that early return would often/usually fire the `FETCH_CARD_DATA` event BEFORE the `FETCH_DASHBOARD_CARD_DATA` action which marked the card as loading.

![withoutDelay](https://user-images.githubusercontent.com/30528226/164310718-721cb73f-7c8b-478d-bb91-a3ea4ceae53d.png)

By simply setting the array of loading card ids in the `FETCH_DASHBOARD` reducer, we can guarantee they get populated before any return as completed in a `FETCH_CARD_DATA` reducer.

![Screenshot from 2022-04-22 10-42-39](https://user-images.githubusercontent.com/30528226/164758190-4febcca4-f960-4fc4-9819-c3353d5a12c8.png)

## After

Dashboards that include unauthorized questions get properly marked as finished loading when all authorized questions are finished loading

Resolves #12583 

![Screenshot from 2022-04-20 13-54-00](https://user-images.githubusercontent.com/30528226/164312726-916b44ca-de7e-4281-8d7e-ad2a36fe1ff0.png)

