### PR TITLE
use a cached version of site locale, to translate shutdown messages

### DIFF
--- a/src/metabase/util/i18n/impl.clj
+++ b/src/metabase/util/i18n/impl.clj
@@ -190,9 +190,16 @@
                (f)))))))))
 
 (defn site-locale-from-setting
-  "Fetch the value of the `site-locale` Setting."
+  "Fetch the value of the `site-locale` Setting.
+  When metabase is shutting down, we need to log some messages after the db connection is closed, so we keep around a
+  cached-site-locale for that purpose."
   []
-  (@site-locale-from-setting-fn))
+  (let [cached-site-locale (atom "en")]
+    (try
+      (let [site-locale (@site-locale-from-setting-fn)]
+        (reset! cached-site-locale site-locale)
+        site-locale)
+      (catch Exception e @cached-site-locale))))
 
 (defmethod print-method Locale
   [locale ^java.io.Writer writer]


### PR DESCRIPTION
fixes #12986

Pressing Ctrl-C to shutdown the jar can throw a stacktrance

- This happened because the db is closed before the call to `destroy!`

- it occurs when translating the two shutdown messages. So caching the
  site locale and using it to translate those messages makes it work.

- testing this requires starting and `sigint`-ing it, so to test, build a
  jar with this, let it's initialization complete, and hit Ctrl-C. You
  should see: two messages about shutdown (translated into whatever
  locale you have set) and NO stacktrace.

```shell
clj -T:build uberjar
cp target/uberjar/metabase.jar <your-temp-location>
```

AFTER:
```shell
MB_SITE_LOCALE=fr MB_JETTY_PORT=3005 java -jar metabase.jar
...snip ...
^C2022-04-20 16:12:45,481 INFO metabase.core :: Metabase en cours darrêt...
2022-04-20 16:12:45,483 INFO metabase.server :: Arrêt du serveur web Jetty intégré
2022-04-20 16:12:45,512 INFO metabase.core :: Arrêt de Metabase EFFECTIF
```

BEFORE:
```shell
... snip ...
07-23 15:34:23 DEBUG middleware.log :: GET /api/dashboard/6 200 4.5 ms (4 DB calls) App DB connections: 0/10 Jetty threads: 4/50 (5 idle, 0 queued) (104 total active threads) Queries in flight: 0 (0 queued)
^CException in thread "Thread-10" org.h2.jdbc.JdbcSQLException: Database is already closed (to disable automatic closing at VM shutdown, add ";DB_CLOSE_ON_EXIT=FALSE" to the db URL) [90121-197]
	at org.h2.message.DbException.getJdbcSQLException(DbException.java:357)
	at org.h2.message.DbException.get(DbException.java:179)
	at org.h2.message.DbException.get(DbException.java:155)
	at org.h2.message.DbException.get(DbException.java:144)
	at org.h2.jdbc.JdbcConnection.checkClosed(JdbcConnection.java:1526)
	at org.h2.jdbc.JdbcConnection.checkClosed(JdbcConnection.java:1502)
	at org.h2.jdbc.JdbcConnection.prepareStatement(JdbcConnection.java:302)
	at com.mchange.v2.c3p0.impl.NewProxyConnection.prepareStatement(NewProxyConnection.java:387)
	at clojure.java.jdbc$prepare_statement.invokeStatic(jdbc.clj:679)
	at clojure.java.jdbc$prepare_statement.invoke(jdbc.clj:626)
	at clojure.java.jdbc$db_query_with_resultset_STAR_.invokeStatic(jdbc.clj:1112)
	at clojure.java.jdbc$db_query_with_resultset_STAR_.invoke(jdbc.clj:1093)
	at clojure.java.jdbc$query.invokeStatic(jdbc.clj:1182)
	at clojure.java.jdbc$query.invoke(jdbc.clj:1144)
	at toucan.db$query.invokeStatic(db.clj:288)
	at toucan.db$query.doInvoke(db.clj:284)
	at clojure.lang.RestFn.invoke(RestFn.java:410)
	at toucan.db$simple_select.invokeStatic(db.clj:394)
	at toucan.db$simple_select.invoke(db.clj:383)
	at toucan.db$simple_select_one.invokeStatic(db.clj:420)
	at toucan.db$simple_select_one.invoke(db.clj:409)
	at toucan.db$select_one.invokeStatic(db.clj:627)
	at toucan.db$select_one.doInvoke(db.clj:620)
	at clojure.lang.RestFn.applyTo(RestFn.java:139)
	at clojure.core$apply.invokeStatic(core.clj:667)
	at clojure.core$apply.invoke(core.clj:660)
	at toucan.db$select_one_field.invokeStatic(db.clj:636)
	at toucan.db$select_one_field.doInvoke(db.clj:629)
	at clojure.lang.RestFn.invoke(RestFn.java:442)
	at metabase.models.setting.cache$cache_out_of_date_QMARK_.invokeStatic(cache.clj:98)
	at metabase.models.setting.cache$cache_out_of_date_QMARK_.invoke(cache.clj:79)
	at metabase.models.setting.cache$restore_cache_if_needed_BANG_.invokeStatic(cache.clj:151)
	at metabase.models.setting.cache$restore_cache_if_needed_BANG_.invoke(cache.clj:128)
	at metabase.models.setting$db_or_cache_value.invokeStatic(setting.clj:175)
	at metabase.models.setting$db_or_cache_value.invoke(setting.clj:169)
	at metabase.models.setting$get_string.invokeStatic(setting.clj:188)
	at metabase.models.setting$get_string.invoke(setting.clj:178)
	at clojure.lang.Var.invoke(Var.java:384)
	at metabase.util.i18n.impl$fn__7770$f__7771.invoke(impl.clj:156)
	at metabase.util.i18n.impl$site_locale_from_setting.invokeStatic(impl.clj:163)
	at metabase.util.i18n.impl$site_locale_from_setting.invoke(impl.clj:160)
	at metabase.util.i18n$site_locale.invokeStatic(i18n.clj:31)
	at metabase.util.i18n$site_locale.invoke(i18n.clj:28)
	at metabase.util.i18n$translate_site_locale.invokeStatic(i18n.clj:52)
	at metabase.util.i18n$translate_site_locale.doInvoke(i18n.clj:49)
	at clojure.lang.RestFn.invoke(RestFn.java:410)
	at clojure.lang.AFn.applyToHelper(AFn.java:154)
	at clojure.lang.RestFn.applyTo(RestFn.java:132)
	at clojure.core$apply.invokeStatic(core.clj:667)
	at clojure.core$apply.invoke(core.clj:660)
	at metabase.util.i18n.SiteLocalizedString.toString(i18n.clj:75)
	at clojure.core$str.invokeStatic(core.clj:553)
	at clojure.core$str.invoke(core.clj:544)
	at metabase.core$destroy_BANG_.invokeStatic(core.clj:47)
	at metabase.core$destroy_BANG_.invoke(core.clj:44)
	at clojure.lang.AFn.run(AFn.java:22)
	at java.base/java.lang.Thread.run(Thread.java:834)
```
