### PR TITLE
Simple Admin Mobile Nav

### DIFF
--- a/frontend/src/metabase/nav/components/AdminNavbar/AdminNavbar.styled.tsx
+++ b/frontend/src/metabase/nav/components/AdminNavbar/AdminNavbar.styled.tsx
@@ -1,17 +1,21 @@
 import styled from "@emotion/styled";
 import Link from "metabase/core/components/Link";
 import { alpha, color, darken } from "metabase/lib/colors";
-import { breakpointMaxLarge } from "metabase/styled-components/theme";
+import {
+  breakpointMaxLarge,
+  breakpointMaxMedium,
+} from "metabase/styled-components/theme";
 import { ADMIN_NAVBAR_HEIGHT } from "../../constants";
 
 export const AdminNavbarRoot = styled.nav`
-  padding: 0.5rem;
+  padding: 0.5rem 1rem;
   background: ${color("admin-navbar")};
   color: ${color("white")};
   font-size: 0.85rem;
   height: ${ADMIN_NAVBAR_HEIGHT};
   display: flex;
   align-items: center;
+  justify-content: space-between;
 `;
 
 export const AdminNavbarItems = styled.ul`
@@ -21,8 +25,36 @@ export const AdminNavbarItems = styled.ul`
   margin-left: 2rem;
 `;
 
+export const MobileHide = styled.div`
+  display: flex;
+  flex: 1 0 auto;
+  align-items: center;
+  ${breakpointMaxMedium} {
+    display: none;
+  }
+`;
+
+export const AdminMobileNavbar = styled.div`
+  ${breakpointMaxMedium} {
+    display: block;
+  }
+  display: none;
+`;
+
+export const AdminMobileNavBarItems = styled.ul`
+  position: fixed;
+  display: flex;
+  flex-direction: column;
+  text-align: right;
+  padding: 1rem;
+  gap: 2rem;
+  border-radius: 0 0 0 0.5rem;
+  top: ${ADMIN_NAVBAR_HEIGHT};
+  right: 0;
+  background: ${color("admin-navbar")};
+`;
+
 export const AdminExitLink = styled(Link)`
-  margin-right: 16px;
   border: 1px solid ${alpha("white", 0.2)};
   padding: 12px 18px;
   border-radius: 5px;
@@ -31,6 +63,7 @@ export const AdminExitLink = styled(Link)`
   transition: all 200ms;
   color: ${color("white")};
   white-space: nowrap;
+  text-align: center;
 
   &:hover {
     color: ${color("white")};
@@ -60,5 +93,4 @@ export const AdminLogoLink = styled(Link)`
   cursor: pointer;
   display: flex;
   justify-content: center;
-  margin-left: 1rem;
 `;

--- a/frontend/src/metabase/nav/components/AdminNavbar/AdminNavbar.tsx
+++ b/frontend/src/metabase/nav/components/AdminNavbar/AdminNavbar.tsx
@@ -1,9 +1,10 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import { t } from "ttag";
 import MetabaseSettings from "metabase/lib/settings";
 import { AdminNavItem } from "./AdminNavItem";
 import StoreLink from "../StoreLink";
 import LogoIcon from "metabase/components/LogoIcon";
+import Icon from "metabase/components/Icon";
 import {
   AdminExitLink,
   AdminLogoContainer,
@@ -11,6 +12,9 @@ import {
   AdminLogoText,
   AdminNavbarItems,
   AdminNavbarRoot,
+  AdminMobileNavbar,
+  AdminMobileNavBarItems,
+  MobileHide,
 } from "./AdminNavbar.styled";
 import { User } from "metabase-types/api";
 import { AdminPath } from "metabase-types/store";
@@ -34,22 +38,68 @@ export const AdminNavbar = ({
         </AdminLogoContainer>
       </AdminLogoLink>
 
-      <AdminNavbarItems>
-        {adminPaths.map(({ name, key, path }) => (
-          <AdminNavItem
-            name={name}
-            path={path}
-            key={key}
-            currentPath={currentPath}
-          />
-        ))}
-      </AdminNavbarItems>
+      <MobileNavbar adminPaths={adminPaths} currentPath={currentPath} />
 
-      {!MetabaseSettings.isPaidPlan() && <StoreLink />}
-      <AdminExitLink
-        to="/"
-        data-metabase-event="Navbar;Exit Admin"
-      >{t`Exit admin`}</AdminExitLink>
+      <MobileHide>
+        <AdminNavbarItems>
+          {adminPaths.map(({ name, key, path }) => (
+            <AdminNavItem
+              name={name}
+              path={path}
+              key={key}
+              currentPath={currentPath}
+            />
+          ))}
+        </AdminNavbarItems>
+
+        {!MetabaseSettings.isPaidPlan() && <StoreLink />}
+        <AdminExitLink
+          to="/"
+          data-metabase-event="Navbar;Exit Admin"
+        >{t`Exit admin`}</AdminExitLink>
+      </MobileHide>
     </AdminNavbarRoot>
+  );
+};
+
+interface AdminMobileNavbarProps {
+  adminPaths: AdminPath[];
+  currentPath: string;
+}
+
+const MobileNavbar = ({ adminPaths, currentPath }: AdminMobileNavbarProps) => {
+  const [mobileNavOpen, setMobileNavOpen] = useState(false);
+
+  useEffect(() => {
+    if (mobileNavOpen) {
+      const listener = () => setMobileNavOpen(false);
+      document.addEventListener("click", listener, { once: true });
+      return () => document.removeEventListener("click", listener);
+    }
+  }, [mobileNavOpen]);
+
+  return (
+    <AdminMobileNavbar>
+      <Icon
+        name="burger"
+        size={20}
+        onClick={() => setMobileNavOpen(prev => !prev)}
+      />
+      {mobileNavOpen && (
+        <AdminMobileNavBarItems>
+          {adminPaths.map(({ name, key, path }) => (
+            <AdminNavItem
+              name={name}
+              path={path}
+              key={key}
+              currentPath={currentPath}
+            />
+          ))}
+          <AdminExitLink to="/" data-metabase-event="Navbar;Exit Admin">
+            {t`Exit admin`}
+          </AdminExitLink>
+        </AdminMobileNavBarItems>
+      )}
+    </AdminMobileNavbar>
   );
 };


### PR DESCRIPTION
## Before

Currently, our admin settings page is completely un-responsive: admins cannot even see all nav items, and can't even access the exit button, leaving no way to exit admin settings except the browser back button. While we probably don't need to support full administration from mobile devices, we should at least let users exit these settings from mobile devices.

![Screenshot from 2022-04-20 15-41-41](https://user-images.githubusercontent.com/30528226/164328194-8cac5482-a232-4216-9143-b4b771bb8954.png)

https://user-images.githubusercontent.com/30528226/164328205-4c53f7f7-a6ec-4e4a-b794-5d7165a36fc8.mp4

## Changes

- Add a very simple mobile burger nav menu for admin settings
- no changes to desktop admin settings nav
- Resolves #18430 

## After

- Admins can navigate to all settings pages
- admins can navigate away from admin settings

![Screenshot from 2022-04-20 15-47-30](https://user-images.githubusercontent.com/30528226/164328568-6140c4a5-1e0f-4bf4-a5cb-bca99ad7055e.png)

https://user-images.githubusercontent.com/30528226/164328474-c58855cd-c6bb-4e87-8e1f-18a37d2f7b02.mp4
