### PR TITLE
Fix custom expression being to aggresive in an aggregation

### DIFF
--- a/frontend/src/metabase/lib/expressions/resolver.js
+++ b/frontend/src/metabase/lib/expressions/resolver.js
@@ -48,6 +48,9 @@ const isCompatible = (a, b) => {
   if (a === "aggregation" && b === "number") {
     return true;
   }
+  if (a === "number" && b === "aggregation") {
+    return true;
+  }
   return false;
 };
 

--- a/frontend/test/metabase/lib/expressions/recursive-parser.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/recursive-parser.unit.spec.js
@@ -201,6 +201,20 @@ describe("metabase/lib/expressions/recursive-parser", () => {
     expect(aggregation("1+CumulativeCount")).toEqual(["+", 1, ["cum-count"]]);
   });
 
+  it("should handle aggregation with another function", () => {
+    const type = "aggregation";
+    const aggregation = expr => resolve(parse(expr), type, mockResolve);
+
+    const A = ["dimension", "A"];
+    const B = ["dimension", "B"];
+
+    expect(aggregation("floor(Sum(A))")).toEqual(["floor", ["sum", A]]);
+    expect(aggregation("round(Distinct(B)/2)")).toEqual([
+      "round",
+      ["/", ["distinct", B], 2],
+    ]);
+  });
+
   it("should prioritize existing metrics over functions", () => {
     const mockResolve = (kind, name) => {
       if (name === "Count" || "ABC".indexOf(name) >= 0) {


### PR DESCRIPTION
To verify:
1. New, Question, Sample Database, Order
2. Summarize, Pick the metric, Custom Expression
3. Type `floor(Sum([Total]))` and give it a name

## Before

The expression is incorrectly rejected.

![image](https://user-images.githubusercontent.com/7288/164334703-aa13b6e5-bf78-426a-9a1c-a78116bd366e.png)

## After

The expression is correctly accepted.

![image](https://user-images.githubusercontent.com/7288/164334602-7d481d95-1df7-4d15-a19e-4115d6337379.png)
