### PR TITLE
List all field values in data reference sidebar

### DIFF
--- a/frontend/src/metabase/components/MetadataInfo/DimensionInfo/DimensionInfo.jsx
+++ b/frontend/src/metabase/components/MetadataInfo/DimensionInfo/DimensionInfo.jsx
@@ -14,9 +14,10 @@ import {
 DimensionInfo.propTypes = {
   className: PropTypes.string,
   dimension: PropTypes.instanceOf(Dimension).isRequired,
+  showAllFieldValues: PropTypes.bool,
 };
 
-export function DimensionInfo({ className, dimension }) {
+export function DimensionInfo({ className, dimension, showAllFieldValues }) {
   const field = dimension.field();
   const description = field?.description;
   return (
@@ -27,7 +28,10 @@ export function DimensionInfo({ className, dimension }) {
         <EmptyDescription>{t`No description`}</EmptyDescription>
       )}
       <DimensionSemanticTypeLabel dimension={dimension} />
-      <FieldFingerprintInfo field={field} />
+      <FieldFingerprintInfo
+        field={field}
+        showAllFieldValues={showAllFieldValues}
+      />
     </InfoContainer>
   );
 }

--- a/frontend/src/metabase/components/MetadataInfo/FieldFingerprintInfo/CategoryFingerprint.jsx
+++ b/frontend/src/metabase/components/MetadataInfo/FieldFingerprintInfo/CategoryFingerprint.jsx
@@ -15,6 +15,7 @@ import {
   Fade,
   FadeAndSlide,
   Container,
+  Li,
 } from "./CategoryFingerprint.styled";
 
 const propTypes = {
@@ -22,6 +23,7 @@ const propTypes = {
   field: PropTypes.instanceOf(Field).isRequired,
   fieldValues: PropTypes.array.isRequired,
   fetchFieldValues: PropTypes.func.isRequired,
+  showAllFieldValues: PropTypes.bool,
 };
 
 const FIELD_VALUES_SHOW_LIMIT = 35;
@@ -48,16 +50,12 @@ export function CategoryFingerprint({
   field,
   fieldValues = [],
   fetchFieldValues,
+  showAllFieldValues,
 }) {
   const fieldId = field.id;
   const listsFieldValues = field.has_field_values === "list";
   const isMissingFieldValues = fieldValues.length === 0;
   const shouldFetchFieldValues = listsFieldValues && isMissingFieldValues;
-
-  const shortenedValuesStr = fieldValues
-    .slice(0, FIELD_VALUES_SHOW_LIMIT)
-    .map(value => (Array.isArray(value) ? value[0] : value))
-    .join(", ");
 
   const distinctCount = field.fingerprint?.global?.["distinct-count"];
   const formattedDistinctCount = formatNumber(distinctCount);
@@ -74,7 +72,7 @@ export function CategoryFingerprint({
   }, [fieldId, shouldFetchFieldValues, safeFetchFieldValues]);
 
   const showDistinctCount = isLoading || distinctCount != null;
-  const showFieldValuesBlock = isLoading || shortenedValuesStr.length > 0;
+  const showFieldValuesBlock = isLoading || fieldValues.length > 0;
   const showComponent = showDistinctCount || showFieldValuesBlock;
 
   return showComponent ? (
@@ -94,18 +92,55 @@ export function CategoryFingerprint({
           >{t`Getting distinct values...`}</Fade>
         </RelativeContainer>
       )}
-      {showFieldValuesBlock && (
-        <RelativeContainer height={isLoading ? "1.8em" : "1.5em"}>
-          <Fade visible={isLoading}>
-            <LoadingSpinner />
-          </Fade>
-          <FadeAndSlide visible={!isLoading}>
-            <NoWrap>{shortenedValuesStr}</NoWrap>
-          </FadeAndSlide>
-        </RelativeContainer>
-      )}
+      {showFieldValuesBlock &&
+        (showAllFieldValues ? (
+          <ExtendedFieldValuesList fieldValues={fieldValues} />
+        ) : (
+          <ShortenedFieldValuesList
+            isLoading={isLoading}
+            fieldValues={fieldValues}
+          />
+        ))}
     </Container>
   ) : null;
+}
+
+ExtendedFieldValuesList.propTypes = {
+  fieldValues: PropTypes.array.isRequired,
+};
+
+function ExtendedFieldValuesList({ fieldValues }) {
+  return (
+    <ul>
+      {fieldValues.map((fieldValue, i) => {
+        const value = Array.isArray(fieldValue) ? fieldValue[0] : fieldValue;
+        return <Li key={i}>{value}</Li>;
+      })}
+    </ul>
+  );
+}
+
+ShortenedFieldValuesList.propTypes = {
+  isLoading: PropTypes.bool.isRequired,
+  fieldValues: PropTypes.array.isRequired,
+};
+
+function ShortenedFieldValuesList({ isLoading, fieldValues }) {
+  const shortenedValuesStr = fieldValues
+    .slice(0, FIELD_VALUES_SHOW_LIMIT)
+    .map(value => (Array.isArray(value) ? value[0] : value))
+    .join(", ");
+
+  return (
+    <RelativeContainer height={isLoading ? "1.8em" : "1.5em"}>
+      <Fade visible={isLoading}>
+        <LoadingSpinner />
+      </Fade>
+      <FadeAndSlide visible={!isLoading}>
+        <NoWrap>{shortenedValuesStr}</NoWrap>
+      </FadeAndSlide>
+    </RelativeContainer>
+  );
 }
 
 CategoryFingerprint.propTypes = propTypes;

--- a/frontend/src/metabase/components/MetadataInfo/FieldFingerprintInfo/CategoryFingerprint.styled.jsx
+++ b/frontend/src/metabase/components/MetadataInfo/FieldFingerprintInfo/CategoryFingerprint.styled.jsx
@@ -61,3 +61,14 @@ export const FadeAndSlide = styled.div`
   transform: ${({ visible }) =>
     visible ? "translateY(0)" : "translateY(100%)"};
 `;
+
+export const Li = styled.li`
+  padding: 0.3em 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  border-bottom: 1px solid ${color("border")};
+
+  &:last-child {
+    border-bottom: none;
+  }
+`;

--- a/frontend/src/metabase/components/MetadataInfo/FieldFingerprintInfo/FieldFingerprintInfo.jsx
+++ b/frontend/src/metabase/components/MetadataInfo/FieldFingerprintInfo/FieldFingerprintInfo.jsx
@@ -11,9 +11,10 @@ import CategoryFingerprint from "./CategoryFingerprint";
 const propTypes = {
   className: PropTypes.string,
   field: PropTypes.instanceOf(Field),
+  showAllFieldValues: PropTypes.bool,
 };
 
-function FieldFingerprintInfo({ className, field }) {
+function FieldFingerprintInfo({ className, field, showAllFieldValues }) {
   if (!field?.fingerprint) {
     return null;
   }
@@ -23,7 +24,13 @@ function FieldFingerprintInfo({ className, field }) {
   } else if (field.isNumber() && !field.isID()) {
     return <NumberFingerprint className={className} field={field} />;
   } else if (field.isCategory()) {
-    return <CategoryFingerprint className={className} field={field} />;
+    return (
+      <CategoryFingerprint
+        className={className}
+        field={field}
+        showAllFieldValues={showAllFieldValues}
+      />
+    );
   } else {
     return null;
   }

--- a/frontend/src/metabase/query_builder/components/dataref/FieldPane.tsx
+++ b/frontend/src/metabase/query_builder/components/dataref/FieldPane.tsx
@@ -15,7 +15,7 @@ function FieldPane({ field }: Props) {
         <Icon name="field" className="text-medium pr1" size={16} />
         <h3 className="text-wrap">{field.name}</h3>
       </div>
-      <DimensionInfo dimension={dimension} />
+      <DimensionInfo dimension={dimension} showAllFieldValues />
     </div>
   ) : null;
 }


### PR DESCRIPTION
Resolves #21277 

We're now using `DimensionInfo` in the native query sidebar. I'm adding a flag to it so that it will list out all field values for this specific scenario. Another alternative is we return to the previous UI which you can see in the `release-x.41.x` branch.

![Screen Shot 2022-04-20 at 4 07 13 PM](https://user-images.githubusercontent.com/13057258/164339134-26e3e926-691d-4087-918f-a5fd97fb54cd.png)

**Testing**
1. Navigate to the data reference sidebar by clicking the book icon in the native query editor.
2. Select a table like People and then a field like State that has the property `has_field_values === "list"`
3. See that it shows all field values in alist
4. Navigate to the People table in the simple view and hover over the column header. The popover you see should show a single-line view of the field values.

