### PR TITLE
Fix ID column & null value sorting in SimpleTable

### DIFF
--- a/frontend/src/metabase/lib/number.ts
+++ b/frontend/src/metabase/lib/number.ts
@@ -1,0 +1,3 @@
+export function isPositiveInteger(value: any) {
+  return /^\d+$/.test(String(value));
+}

--- a/frontend/src/metabase/lib/number.unit.spec.ts
+++ b/frontend/src/metabase/lib/number.unit.spec.ts
@@ -1,0 +1,32 @@
+import { isPositiveInteger } from "./number";
+
+describe("metabase/lib/number", () => {
+  describe("isPositiveInteger", () => {
+    it("should be be true for a positive integer", () => {
+      expect(isPositiveInteger(123)).toBe(true);
+    });
+
+    it("should be false for a negative integer", () => {
+      expect(isPositiveInteger(-123)).toBe(false);
+    });
+
+    it("should be false for a non-integer number", () => {
+      expect(isPositiveInteger(123.45)).toBe(false);
+      expect(isPositiveInteger(Infinity)).toBe(false);
+      expect(isPositiveInteger(NaN)).toBe(false);
+    });
+
+    it("should be true for a string that is a positive integer", () => {
+      expect(isPositiveInteger("123")).toBe(true);
+      expect(isPositiveInteger("0123")).toBe(true);
+    });
+
+    it("should be false for a string that contains non-number characters", () => {
+      expect(isPositiveInteger("-123")).toBe(false);
+      expect(isPositiveInteger("123.45")).toBe(false);
+      expect(isPositiveInteger("123abc")).toBe(false);
+      expect(isPositiveInteger("abc123")).toBe(false);
+      expect(isPositiveInteger("abc")).toBe(false);
+    });
+  });
+});

--- a/frontend/src/metabase/visualizations/components/TableSimple.jsx
+++ b/frontend/src/metabase/visualizations/components/TableSimple.jsx
@@ -19,6 +19,7 @@ import {
 } from "metabase/visualizations/lib/table";
 import { getColumnExtent } from "metabase/visualizations/lib/utils";
 import { HARD_ROW_LIMIT } from "metabase/lib/query";
+import { isPositiveInteger } from "metabase/lib/number";
 
 import { t } from "ttag";
 import cx from "classnames";
@@ -111,7 +112,7 @@ export default class TableSimple extends Component {
         const col = cols[sortColumn];
         // for strings we should be case insensitive
         if (typeof value === "string") {
-          if (isID(col)) {
+          if (isID(col) && isPositiveInteger(value)) {
             value = parseInt(value, 10);
           } else {
             value = value.toLowerCase();

--- a/frontend/src/metabase/visualizations/components/TableSimple.jsx
+++ b/frontend/src/metabase/visualizations/components/TableSimple.jsx
@@ -108,9 +108,17 @@ export default class TableSimple extends Component {
     if (sortColumn != null) {
       rowIndexes = _.sortBy(rowIndexes, rowIndex => {
         let value = rows[rowIndex][sortColumn];
+        const col = cols[sortColumn];
         // for strings we should be case insensitive
         if (typeof value === "string") {
-          value = value.toLowerCase();
+          if (isID(col)) {
+            value = parseInt(value, 10);
+          } else {
+            value = value.toLowerCase();
+          }
+        }
+        if (value === null) {
+          value = undefined;
         }
         return value;
       });


### PR DESCRIPTION
Fixes #20781 
Fixes #13135

ID columns return as strings now, so before sorting, we need to parse them as integers.

`null` values are getting coerced into strings. Looks like underscore makes an exception for `void 0` so converting the `null` into an `undefined` in the sortBy callback fixes the issue: https://github.com/jashkenas/underscore/blob/master/modules/sortBy.js#L19

**Testing**
Follow steps in #20781 and #13135

---

ID sorting:
![Screen Shot 2022-04-20 at 4 47 45 PM](https://user-images.githubusercontent.com/13057258/164342615-ca7b362f-b358-4460-8cc8-e0c4331a3ef9.png)

null sorting:
![Screen Shot 2022-04-20 at 4 47 30 PM](https://user-images.githubusercontent.com/13057258/164342613-f87815d7-7e56-4d43-a8cc-f30d27352ea8.png)
