### PR TITLE
Fix pivot queries that specify `:order-by`

### DIFF
--- a/test/metabase/query_processor/pivot_test.clj
+++ b/test/metabase/query_processor/pivot_test.clj
@@ -303,3 +303,18 @@
                                result))
                   (is (= (mt/rows (qp.pivot/run-pivot-query query))
                          (mt/rows result))))))))))))
+
+(deftest pivot-with-order-by-test
+  (testing "Pivot queries should work if there is an `:order-by` clause (#17198)"
+    (mt/dataset sample-dataset
+      (let [query (mt/mbql-query products
+                    {:breakout    [$category]
+                     :aggregation [[:count]]
+                     :order-by    [[:asc $category]]})]
+        (is (= [["Doohickey" 0 42]
+                ["Gadget" 0 53]
+                ["Gizmo" 0 51]
+                ["Widget" 0 54]
+                [nil 1 200]]
+               (mt/rows
+                (qp.pivot/run-pivot-query query))))))))


### PR DESCRIPTION
Fixes #17198

If you create a query that specifies `:order-by` it will probably fail if you try to use the Pivot visualization. That's because the Pivot visualization is magic and it rewrites the query and adds in a bunch of custom `:breakout`s (`:breakout` in MBQL translates to both `GROUP BY` and `ORDER BY` in SQL). 

In #17198 the initial query was basically

```sql
SELECT count(*)
FROM products
GROUP BY category
ORDER BY category ASC
```

which for pivot mode gets rewritten to something like

```sql
SELECT source."pivot-grouping", count(*)
FROM (
  SELECT products.*, 1 AS "pivot-grouping"
  FROM products
) source
GROUP BY source."pivot-grouping"
ORDER BY source.category ASC, source."pivot-grouping" ASC
```

which doesn't work. You can't order by `source.category` since it doesn't appear in the `GROUP BY`.

The correct fix here is just to strip out that `ORDER BY source.category` entirely in the rewritten query so we get

```sql
SELECT source."pivot-grouping", count(*)
FROM (
  SELECT products.*, 1 AS "pivot-grouping"
  FROM products
) source
GROUP BY source."pivot-grouping"
ORDER BY source."pivot-grouping" ASC
```

which is actually what we wanted anyway in order for the pivot results to display the way we expect. Now things work. Nice