### PR TITLE
Filter out the is_saved_questions db in the db reference view

### DIFF
--- a/frontend/src/metabase/reference/databases/DatabaseList.jsx
+++ b/frontend/src/metabase/reference/databases/DatabaseList.jsx
@@ -40,6 +40,16 @@ export default class DatabaseList extends Component {
   render() {
     const { entities, style, loadingError, loading } = this.props;
 
+    const databases = Object.values(entities)
+      .filter(database => {
+        const exists = Boolean(database?.id && database?.name);
+        return exists && !database.is_saved_questions;
+      })
+      .sort((a, b) => {
+        const compared = a.name.localeCompare(b.name);
+        return compared !== 0 ? compared : a.engine.localeCompare(b.engine);
+      });
+
     return (
       <div style={style} className="full">
         <ReferenceHeader name={t`Our data`} />
@@ -51,30 +61,18 @@ export default class DatabaseList extends Component {
             Object.keys(entities).length > 0 ? (
               <div className="wrapper">
                 <List>
-                  {Object.values(entities)
-                    .sort((a, b) => {
-                      const compared = a.name.localeCompare(b.name);
-                      return compared !== 0
-                        ? compared
-                        : a.engine.localeCompare(b.engine);
-                    })
-                    .map(
-                      (entity, index) =>
-                        entity &&
-                        entity.id &&
-                        entity.name && (
-                          <li className="relative" key={entity.id}>
-                            <ListItem
-                              id={entity.id}
-                              index={index}
-                              name={entity.display_name || entity.name}
-                              description={entity.description}
-                              url={`/reference/databases/${entity.id}`}
-                              icon="database"
-                            />
-                          </li>
-                        ),
-                    )}
+                  {databases.map((database, index) => (
+                    <li className="relative" key={database.id}>
+                      <ListItem
+                        id={database.id}
+                        index={index}
+                        name={database.display_name || database.name}
+                        description={database.description}
+                        url={`/reference/databases/${database.id}`}
+                        icon="database"
+                      />
+                    </li>
+                  ))}
                 </List>
               </div>
             ) : (


### PR DESCRIPTION
Fixes #18331 

**Testing**
- Follow steps in #18331 
- Sometimes the "Saved Questions" option doesn't appear; you may want to navigate to the "New question" page before navigating to the DB reference page to guarantee all data is hydrated in the client.

Before
![Screen Shot 2022-04-20 at 5 01 56 PM](https://user-images.githubusercontent.com/13057258/164343782-7b1a176b-0803-4ea5-8b5d-f8ad3dd26f31.png)

After
![Screen Shot 2022-04-20 at 5 01 38 PM](https://user-images.githubusercontent.com/13057258/164343789-7c46bacf-4f8a-43f4-b79d-36aae477a36a.png)

