### PR TITLE
[E2E] Robustify some tests which involve X-ray

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard/x-rays.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/x-rays.cy.spec.js
@@ -101,6 +101,9 @@ describe("scenarios > x-rays", () => {
         expect(xhr.response.statusCode).not.to.eq(500);
       });
 
+      cy.wait("@dataset");
+      cy.findByTextEnsureVisible("A look at the number of 15655");
+
       cy.findByRole("heading", { name: /^A closer look at the number of/ });
       cy.get(".DashCard");
     });

--- a/frontend/test/metabase/scenarios/joins/joins-2.cy.spec.js
+++ b/frontend/test/metabase/scenarios/joins/joins-2.cy.spec.js
@@ -406,6 +406,7 @@ describe("scenarios > question > joined questions", () => {
 
     it("x-rays should work on explicit joins when metric is for the joined table (metabase#14793)", () => {
       cy.intercept("GET", "/api/automagic-dashboards/adhoc/**").as("xray");
+      cy.intercept("POST", "/api/dataset").as("dataset");
 
       visitQuestionAdhoc({
         dataset_query: {
@@ -445,10 +446,15 @@ describe("scenarios > question > joined questions", () => {
         expect(xhr.response.body.cause).not.to.exist;
         expect(xhr.status).not.to.eq(500);
       });
+
+      cy.wait("@dataset");
+
+      // Metric title
+      cy.findByTextEnsureVisible(
+        "How this metric is distributed across different numbers",
+      );
       // Main title
       cy.contains(/^A closer look at/);
-      // Metric title
-      cy.findByText("How this metric is distributed across different numbers");
       // Make sure at least one card is rendered
       cy.get(".DashCard");
     });


### PR DESCRIPTION
Found this out while working on some PRs.

### Before this PR

There are failures such as:

![scenarios  question  joined questions -- joins -- x-rays should work on explicit joins when metric is for the joined table (metabase#14793) (failed) (attempt 3)](https://user-images.githubusercontent.com/7288/164360359-4e76943c-07f0-4ddb-b28d-42bf0a72b865.png)

### After this PR

The failures won't happen anymore, because this time there is an explicit wait for `/api/dataset` first.