### PR TITLE
Get JSON sync to not explode if top-level array entity in JSON encountered

### DIFF
--- a/src/metabase/driver/sql_jdbc/sync/describe_table.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_table.clj
@@ -221,7 +221,9 @@
       member-type)))
 
 (defn- row->types [row]
-  (into {} (for [[field-name field-val] row]
+  (into {} (for [[field-name field-val] row
+                 ;; That is, don't look at the row at all if the top-level JSON entity is an array
+                 :when (map? field-val)]
              (let [flat-row (flattened-row field-name field-val)]
                (into {} (map (fn [[k v]] [k (type-by-parsing-string v)]) flat-row))))))
 

--- a/src/metabase/driver/sql_jdbc/sync/describe_table.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_table.clj
@@ -222,7 +222,7 @@
 
 (defn- row->types [row]
   (into {} (for [[field-name field-val] row
-                 ;; That is, don't look at the row at all if the top-level JSON entity is an array
+                 ;; We put top-level array row type semantics on JSON roadmap but skip for now
                  :when (map? field-val)]
              (let [flat-row (flattened-row field-name field-val)]
                (into {} (map (fn [[k v]] [k (type-by-parsing-string v)]) flat-row))))))

--- a/test/metabase/driver/sql_jdbc/sync/describe_table_test.clj
+++ b/test/metabase/driver/sql_jdbc/sync/describe_table_test.clj
@@ -75,6 +75,13 @@
     (is (= java.time.LocalDateTime (#'sql-jdbc.describe-table/type-by-parsing-string "2017-01-13T17:09:42.411")))
     (is (= java.lang.Long (#'sql-jdbc.describe-table/type-by-parsing-string 11111)))))
 
+(deftest row->types-test
+  (testing "array rows ignored properly in JSON row->types (#21752)"
+    (let [arr-row   {:bob [:bob :cob :dob 123 "blob"]}
+          obj-row   {:zlob {"blob" 1323}}]
+      (is (= {} (#'sql-jdbc.describe-table/row->types arr-row)))
+      (is (= {[:zlob "blob"] java.lang.Long} (#'sql-jdbc.describe-table/row->types obj-row))))))
+
 (deftest describe-nested-field-columns-test
   (testing "flattened-row"
     (let [row       {:bob {:dobbs 123 :cobbs "boop"}}


### PR DESCRIPTION
Pursuant to #21752, I think this is the root cause. Previously, if there was a top-level array row in a JSON column sync would explode because it still treats it as an object. Now we just ignore and punt down the roadmap.