### PR TITLE
Align events with the X interval of the chart

### DIFF
--- a/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
@@ -393,6 +393,7 @@ function onRenderAddTimelineEvents(
   {
     timelineEvents,
     selectedTimelineEventIds,
+    xInterval,
     isTimeseries,
     onHoverChange,
     onOpenTimelines,
@@ -403,6 +404,7 @@ function onRenderAddTimelineEvents(
   renderEvents(chart, {
     events: timelineEvents,
     selectedEventIds: selectedTimelineEventIds,
+    xInterval,
     isTimeseries,
     onHoverChange,
     onOpenTimelines,
@@ -452,6 +454,7 @@ function onRender(
   onRenderAddTimelineEvents(chart, {
     timelineEvents,
     selectedTimelineEventIds,
+    xInterval,
     isTimeseries,
     onHoverChange,
     onOpenTimelines,

--- a/frontend/src/metabase/visualizations/lib/timelines.js
+++ b/frontend/src/metabase/visualizations/lib/timelines.js
@@ -18,13 +18,14 @@ function getScale(chart) {
   return chart.x();
 }
 
-function getEventMapping(events, scale) {
+function getEventMapping({ events, scale, xInterval }) {
   const mapping = new Map();
   let group = [];
   let groupPoint = 0;
 
   events.forEach(event => {
-    const eventPoint = scale(event.timestamp);
+    const eventDate = event.timestamp.clone().startOf(xInterval.interval);
+    const eventPoint = scale(eventDate);
     const groupDistance = eventPoint - groupPoint;
 
     if (!group.length || groupDistance < ICON_SIZE) {
@@ -220,6 +221,7 @@ export function renderEvents(
   {
     events = [],
     selectedEventIds = [],
+    xInterval,
     isTimeseries,
     onHoverChange,
     onOpenTimelines,
@@ -234,7 +236,7 @@ export function renderEvents(
   }
 
   const scale = getScale(chart);
-  const eventMapping = getEventMapping(events, scale);
+  const eventMapping = getEventMapping({ events, scale, xInterval });
   const eventPoints = getEventPoints(eventMapping);
   const eventGroups = getEventGroups(eventMapping);
 


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/20289

There are issues with rendering of events with bar charts and some X intervals (weeks, years). This PR solves the issue by aligning events with X interval of the chart.

**Before**
<img width="1728" alt="Screenshot 2022-04-21 at 15 37 48" src="https://user-images.githubusercontent.com/8542534/164459811-bb18ed5f-236e-4df4-a095-5f6c68fec4d2.png">
<img width="1728" alt="Screenshot 2022-04-21 at 15 37 54" src="https://user-images.githubusercontent.com/8542534/164459829-75cf1515-09ef-4ee6-ba13-d45e2ec9d0b5.png">
<img width="1373" alt="Screenshot 2022-04-21 at 15 38 11" src="https://user-images.githubusercontent.com/8542534/164459835-a571a08a-c757-4fc6-a294-a0017b2aee2f.png">

**After**
<img width="794" alt="Screenshot 2022-04-21 at 15 37 23" src="https://user-images.githubusercontent.com/8542534/164459902-66d2ea0d-f4ea-47dc-af8b-cf24189bd847.png">
<img width="797" alt="Screenshot 2022-04-21 at 15 37 27" src="https://user-images.githubusercontent.com/8542534/164459916-17a594cb-e6cf-42bb-93a7-325e3610d325.png">
<img width="1579" alt="Screenshot 2022-04-21 at 15 38 30" src="https://user-images.githubusercontent.com/8542534/164459921-684e6763-6fc3-43e6-ab94-1ca25ec5b16e.png">

