### PR TITLE
Show datetime shortcuts when selecting a datetime field a second time

### DIFF
--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePicker.tsx
@@ -274,6 +274,7 @@ const DatePicker: React.FC<Props> = props => {
 
   const onBack = () => {
     if (!operator || showShortcuts) {
+      onFilterChange([null, getDateTimeField(filter)]);
       props.onBack?.();
     } else {
       setShowShortcuts(true);

--- a/frontend/test/metabase/scenarios/question/relative-datetime.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/relative-datetime.cy.spec.js
@@ -74,35 +74,25 @@ describe("scenarios > question > relative-datetime", () => {
         cy.findByText("Showing 2 rows").should("exist");
       }),
     );
+  });
 
-    it("should not clobber filter when value is set to 1", () => {
-      openOrdersTable();
+  it("should go back to shortcuts view", () => {
+    cy.signInAsNormalUser();
+    openOrdersTable();
 
-      cy.findByTextEnsureVisible("Created At").click();
+    cy.findByTextEnsureVisible("Created At").click();
+    popover().within(() => {
       cy.findByText("Filter by this column").click();
-      cy.intercept("POST", "/api/dataset").as("dataset");
-      cy.findByText("Last 30 Days").click();
-      cy.wait("@dataset");
-
-      cy.findByText("Created At Previous 30 Days").click();
-      cy.findByDisplayValue("30")
-        .clear()
-        .type(1)
-        .blur();
-      cy.findByText("day").click();
-      popover()
-        .last()
-        .within(() => cy.findByText("year").click());
-      popover().within(() => cy.icon("ellipsis").click());
-      popover()
-        .last()
-        .within(() => cy.findByText("Starting from...").click());
-      cy.findAllByDisplayValue("1")
-        .last()
-        .clear()
-        .type(2)
-        .blur();
-      cy.button("Add filter").should("be.enabled");
+      cy.findByText("Specific dates...").click();
+      cy.icon("chevronleft")
+        .first()
+        .click();
+      cy.findByText("Specific dates...").should("exist");
+      cy.icon("chevronleft").click();
+      cy.findByText("Specific dates...").should("not.exist");
+      cy.findByText("Created At").click();
+      cy.findByText("Specific dates...").should("exist");
+      cy.findByText("Between").should("not.exist");
     });
   });
 });

--- a/frontend/test/metabase/scenarios/question/relative-datetime.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/relative-datetime.cy.spec.js
@@ -76,6 +76,36 @@ describe("scenarios > question > relative-datetime", () => {
     );
   });
 
+  it("should not clobber filter when value is set to 1", () => {
+    openOrdersTable();
+
+    cy.findByTextEnsureVisible("Created At").click();
+    cy.findByText("Filter by this column").click();
+    cy.intercept("POST", "/api/dataset").as("dataset");
+    cy.findByText("Last 30 Days").click();
+    cy.wait("@dataset");
+
+    cy.findByText("Created At Previous 30 Days").click();
+    cy.findByDisplayValue("30")
+      .clear()
+      .type(1)
+      .blur();
+    cy.findByText("day").click();
+    popover()
+      .last()
+      .within(() => cy.findByText("year").click());
+    popover().within(() => cy.icon("ellipsis").click());
+    popover()
+      .last()
+      .within(() => cy.findByText("Starting from...").click());
+    cy.findAllByDisplayValue("1")
+      .last()
+      .clear()
+      .type(2)
+      .blur();
+    cy.button("Add filter").should("be.enabled");
+  });
+
   it("should go back to shortcuts view", () => {
     cy.signInAsNormalUser();
     openOrdersTable();

--- a/frontend/test/metabase/scenarios/question/relative-datetime.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/relative-datetime.cy.spec.js
@@ -74,36 +74,36 @@ describe("scenarios > question > relative-datetime", () => {
         cy.findByText("Showing 2 rows").should("exist");
       }),
     );
-  });
 
-  it("should not clobber filter when value is set to 1", () => {
-    openOrdersTable();
+    it("should not clobber filter when value is set to 1", () => {
+      openOrdersTable();
 
-    cy.findByTextEnsureVisible("Created At").click();
-    cy.findByText("Filter by this column").click();
-    cy.intercept("POST", "/api/dataset").as("dataset");
-    cy.findByText("Last 30 Days").click();
-    cy.wait("@dataset");
+      cy.findByTextEnsureVisible("Created At").click();
+      cy.findByText("Filter by this column").click();
+      cy.intercept("POST", "/api/dataset").as("dataset");
+      cy.findByText("Last 30 Days").click();
+      cy.wait("@dataset");
 
-    cy.findByText("Created At Previous 30 Days").click();
-    cy.findByDisplayValue("30")
-      .clear()
-      .type(1)
-      .blur();
-    cy.findByText("day").click();
-    popover()
-      .last()
-      .within(() => cy.findByText("year").click());
-    popover().within(() => cy.icon("ellipsis").click());
-    popover()
-      .last()
-      .within(() => cy.findByText("Starting from...").click());
-    cy.findAllByDisplayValue("1")
-      .last()
-      .clear()
-      .type(2)
-      .blur();
-    cy.button("Add filter").should("be.enabled");
+      cy.findByText("Created At Previous 30 Days").click();
+      cy.findByDisplayValue("30")
+        .clear()
+        .type(1)
+        .blur();
+      cy.findByText("day").click();
+      popover()
+        .last()
+        .within(() => cy.findByText("year").click());
+      popover().within(() => cy.icon("ellipsis").click());
+      popover()
+        .last()
+        .within(() => cy.findByText("Starting from...").click());
+      cy.findAllByDisplayValue("1")
+        .last()
+        .clear()
+        .type(2)
+        .blur();
+      cy.button("Add filter").should("be.enabled");
+    });
   });
 
   it("should go back to shortcuts view", () => {


### PR DESCRIPTION
Fixes #21779

Resets the filter operator to `null` when user goes back to field selection from the shortcuts view

# Repro

- Sample Database > Orders > Filter
- Filter by `Created At`
- Specific dates > After
- Click back button _twice_
- Click `Created At`

It should show datetime shortcuts
