### PR TITLE
Go back to field selection with a single click from datetime shortcuts

### DIFF
--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePicker.tsx
@@ -273,7 +273,7 @@ const DatePicker: React.FC<Props> = props => {
   const Widget = operator && operator.widget;
 
   const onBack = () => {
-    if (showShortcuts) {
+    if (!operator || showShortcuts) {
       props.onBack?.();
     } else {
       setShowShortcuts(true);

--- a/frontend/test/metabase/scenarios/question/relative-datetime.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/relative-datetime.cy.spec.js
@@ -1,6 +1,11 @@
 import moment from "moment";
 import _ from "underscore";
-import { restore, popover, openOrdersTable } from "__support__/e2e/cypress";
+import {
+  restore,
+  sidebar,
+  popover,
+  openOrdersTable,
+} from "__support__/e2e/cypress";
 
 const STARTING_FROM_UNITS = [
   "minutes",
@@ -14,6 +19,24 @@ const STARTING_FROM_UNITS = [
 
 describe("scenarios > question > relative-datetime", () => {
   const now = moment().utc();
+
+  describe("sidebar", () => {
+    it("should go to field selection with one click", () => {
+      cy.signInAsNormalUser();
+      openOrdersTable();
+
+      cy.findByTextEnsureVisible("Filter").click();
+      sidebar().within(() => {
+        cy.contains("Created At")
+          .first()
+          .click();
+        cy.contains("Specific dates...").should("exist");
+        cy.icon("chevronleft").click();
+        cy.contains("Created At").should("exist");
+        cy.contains("Specific dates...").should("not.exist");
+      });
+    });
+  });
 
   describe("starting from", () => {
     const date = values =>


### PR DESCRIPTION
Fixes #21778

### Repro

- Sample Database > Orders > Filter sidebar
- Filter by `Created At`
- Click back button

It should go back to field selection with only a single click of the back button