### PR TITLE
Relative datetime filters: Dashboards fixes

### DIFF
--- a/frontend/src/metabase/lib/query_time.js
+++ b/frontend/src/metabase/lib/query_time.js
@@ -1,3 +1,4 @@
+import _ from "underscore";
 import moment from "moment";
 import { assoc } from "icepick";
 import inflection from "inflection";
@@ -591,3 +592,97 @@ export const setTimeComponent = (value, hours, minutes) => {
 
 export const TIME_SELECTOR_DEFAULT_HOUR = 12;
 export const TIME_SELECTOR_DEFAULT_MINUTE = 30;
+
+export const EXCLUDE_UNITS = {
+  days: "day-of-week",
+  months: "month-of-year",
+  quarters: "quarter-of-year",
+  hours: "hour-of-day",
+};
+
+export const EXCLUDE_OPTIONS = {
+  [EXCLUDE_UNITS["days"]]: () => {
+    const now = moment()
+      .utc()
+      .hours(0)
+      .minutes(0)
+      .seconds(0)
+      .milliseconds(0);
+    return [
+      _.range(0, 7).map(day => {
+        const date = now.day(day + 1);
+        const displayName = date.format("dddd");
+        const value = date.format("YYYY-MM-DD");
+        return {
+          displayName,
+          value,
+          serialized: date.format("ddd"),
+          test: val => value === val,
+        };
+      }),
+    ];
+  },
+  [EXCLUDE_UNITS["months"]]: () => {
+    const now = moment()
+      .utc()
+      .hours(0)
+      .minutes(0)
+      .seconds(0)
+      .milliseconds(0);
+    const func = month => {
+      const date = now.month(month);
+      const displayName = date.format("MMMM");
+      const value = date.format("YYYY-MM-DD");
+      return {
+        displayName,
+        value,
+        serialized: date.format("MMM"),
+        test: value => moment(value).format("MMMM") === displayName,
+      };
+    };
+    return [_.range(0, 6).map(func), _.range(6, 12).map(func)];
+  },
+  [EXCLUDE_UNITS["quarters"]]: () => {
+    const now = moment()
+      .utc()
+      .hours(0)
+      .minutes(0)
+      .seconds(0)
+      .milliseconds(0);
+    const suffix = " " + t`quarter`;
+    return [
+      _.range(1, 5).map(quarter => {
+        const date = now.quarter(quarter);
+        const displayName = date.format("Qo");
+        const value = date.format("YYYY-MM-DD");
+        return {
+          displayName: displayName + suffix,
+          value,
+          serialized: date.format("Q"),
+          test: value => moment(value).format("Qo") === displayName,
+        };
+      }),
+    ];
+  },
+  [EXCLUDE_UNITS["hours"]]: () => {
+    const now = moment()
+      .utc()
+      .minutes(0)
+      .seconds(0)
+      .milliseconds(0);
+    const func = hour => {
+      const date = now.hour(hour);
+      const displayName = date.format("h A");
+      return {
+        displayName,
+        value: date.toISOString(),
+        serialized: date.format("H"),
+        test: value =>
+          moment(value)
+            .utc()
+            .format("h A") === displayName,
+      };
+    };
+    return [_.range(0, 12).map(func), _.range(12, 24).map(func)];
+  },
+};

--- a/frontend/src/metabase/parameters/components/widgets/DateAllOptionsWidget.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/DateAllOptionsWidget.tsx
@@ -35,14 +35,14 @@ const serializersByOperatorName: Record<string, (...args: any[]) => string> = {
   previous: getFilterValueSerializer((value, unit, options = {}) => {
     if (options.startingFrom) {
       const [fromValue, fromUnit] = options.startingFrom;
-      return `past${-value}${unit}s~${fromValue}${fromUnit}s`;
+      return `past${-value}${unit}s-from-${fromValue}${fromUnit}s`;
     }
     return `past${-value}${unit}s${options["include-current"] ? "~" : ""}`;
   }),
   next: getFilterValueSerializer((value, unit, options = {}) => {
     if (options.startingFrom) {
       const [fromValue, fromUnit] = options.startingFrom;
-      return `next${value}${unit}s~${-fromValue}${fromUnit}s`;
+      return `next${value}${unit}s-from-${-fromValue}${fromUnit}s`;
     }
     return `next${value}${unit}s${options["include-current"] ? "~" : ""}`;
   }),
@@ -61,7 +61,7 @@ const serializersByOperatorName: Record<string, (...args: any[]) => string> = {
       .getOptions()
       .flat()
       .filter(({ test }) => !!_.find(values, (value: string) => test(value)));
-    return `${operator.name}~${options
+    return `exclude-${operator.name}-${options
       .map(({ serialized }) => serialized)
       .join("-")}`;
   },

--- a/frontend/src/metabase/parameters/components/widgets/DateAllOptionsWidget.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/DateAllOptionsWidget.tsx
@@ -140,8 +140,6 @@ const DateAllOptionsWidget = ({
         onFilterChange={setFilter}
         onCommit={commitAndClose}
         hideTimeSelectors
-        disableStartingFrom
-        hideExcludeOperators
         hideEmptinessOperators
         disableOperatorSelection={disableOperatorSelection}
       >

--- a/frontend/src/metabase/parameters/components/widgets/DateAllOptionsWidget.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/DateAllOptionsWidget.tsx
@@ -1,42 +1,82 @@
 import React, { useState } from "react";
-import cx from "classnames";
 import { t } from "ttag";
+import _ from "underscore";
+import cx from "classnames";
+
+import { dateParameterValueToMBQL } from "metabase/parameters/utils/mbql";
 import DatePicker, {
   DATE_OPERATORS,
 } from "metabase/query_builder/components/filters/pickers/DatePicker/DatePicker";
-import { generateTimeFilterValuesDescriptions } from "metabase/lib/query_time";
-import { dateParameterValueToMBQL } from "metabase/parameters/utils/mbql";
-import { Container, Footer, UpdateButton } from "./DateWidget.styled";
+import {
+  generateTimeFilterValuesDescriptions,
+  getRelativeDatetimeInterval,
+  getStartingFrom,
+} from "metabase/lib/query_time";
+import { EXCLUDE_OPERATORS } from "metabase/query_builder/components/filters/pickers/DatePicker/ExcludeDatePicker";
+
+import { Container, UpdateButton } from "./DateWidget.styled";
 
 // Use a placeholder value as field references are not used in dashboard filters
 const noopRef = null;
 
 function getFilterValueSerializer(func: (...args: any[]) => string) {
-  return (filter: any[]) => func(filter[2], filter[3], filter[4] || {});
+  return (filter: any[]) => {
+    const startingFrom = getStartingFrom(filter);
+    if (startingFrom) {
+      const [value, unit] = getRelativeDatetimeInterval(filter);
+      return func(value, unit, { startingFrom });
+    } else {
+      return func(filter[2], filter[3], filter[4] || {});
+    }
+  };
 }
 
 const serializersByOperatorName: Record<string, (...args: any[]) => string> = {
-  previous: getFilterValueSerializer(
-    (value, unit, options = {}) =>
-      `past${-value}${unit}s${options["include-current"] ? "~" : ""}`,
-  ),
-  next: getFilterValueSerializer(
-    (value, unit, options = {}) =>
-      `next${value}${unit}s${options["include-current"] ? "~" : ""}`,
-  ),
+  previous: getFilterValueSerializer((value, unit, options = {}) => {
+    if (options.startingFrom) {
+      const [fromValue, fromUnit] = options.startingFrom;
+      return `past${-value}${unit}s~${fromValue}${fromUnit}s`;
+    }
+    return `past${-value}${unit}s${options["include-current"] ? "~" : ""}`;
+  }),
+  next: getFilterValueSerializer((value, unit, options = {}) => {
+    if (options.startingFrom) {
+      const [fromValue, fromUnit] = options.startingFrom;
+      return `next${value}${unit}s~${-fromValue}${fromUnit}s`;
+    }
+    return `next${value}${unit}s${options["include-current"] ? "~" : ""}`;
+  }),
   current: getFilterValueSerializer((_, unit) => `this${unit}`),
   before: getFilterValueSerializer(value => `~${value}`),
   after: getFilterValueSerializer(value => `${value}~`),
   on: getFilterValueSerializer(value => `${value}`),
   between: getFilterValueSerializer((from, to) => `${from}~${to}`),
+  exclude: (filter: any[]) => {
+    const [_op, _field, ...values] = filter;
+    const operator = getExcludeOperator(filter);
+    if (!operator) {
+      return "";
+    }
+    const options = operator
+      .getOptions()
+      .flat()
+      .filter(({ test }) => !!_.find(values, (value: string) => test(value)));
+    return `${operator.name}~${options
+      .map(({ serialized }) => serialized)
+      .join("-")}`;
+  },
 };
 
 function getFilterOperator(filter: any[] = []) {
   return DATE_OPERATORS.find(op => op.test(filter as any));
 }
+
+function getExcludeOperator(filter: any[] = []) {
+  return EXCLUDE_OPERATORS.find(op => op.test(filter as any));
+}
+
 function filterToUrlEncoded(filter: any[]) {
   const operator = getFilterOperator(filter);
-
   if (operator) {
     return serializersByOperatorName[operator.name](filter);
   } else {
@@ -45,6 +85,7 @@ function filterToUrlEncoded(filter: any[]) {
 }
 
 const prefixedOperators = new Set([
+  "exclude",
   "before",
   "after",
   "on",
@@ -53,10 +94,16 @@ const prefixedOperators = new Set([
 ]);
 
 function getFilterTitle(filter: any[]) {
-  const desc = generateTimeFilterValuesDescriptions(filter).join(" - ");
+  const values = generateTimeFilterValuesDescriptions(filter);
+  const desc =
+    values.length > 2
+      ? t`${values.length} selections`
+      : values.join(filter[0] === "!=" ? ", " : " - ");
   const op = getFilterOperator(filter);
   const prefix =
-    op && prefixedOperators.has(op.name) ? `${op.displayName} ` : "";
+    op && prefixedOperators.has(op.name)
+      ? `${op.displayPrefix ?? op.displayName} `
+      : "";
   return prefix + desc;
 }
 
@@ -84,9 +131,8 @@ const DateAllOptionsWidget = ({
 
   const isValid = () => {
     const filterValues = filter.slice(2);
-    return filterValues.every(value => value != null);
+    return filterValues.every((value: any) => value != null);
   };
-
   return (
     <Container>
       <DatePicker

--- a/frontend/src/metabase/parameters/utils/mbql.js
+++ b/frontend/src/metabase/parameters/utils/mbql.js
@@ -1,4 +1,5 @@
 import moment from "moment";
+import _ from "underscore";
 
 import Dimension, {
   FieldDimension,
@@ -8,6 +9,11 @@ import { getParameterSubType, isDateParameter } from "./parameter-type";
 import { getParameterOperatorName } from "./operators";
 import { isDimensionTarget } from "./targets";
 import { hasParameterValue } from "./parameter-values";
+import {
+  setStartingFrom,
+  EXCLUDE_OPTIONS,
+  EXCLUDE_UNITS,
+} from "metabase/lib/query_time";
 
 const withTemporalUnit = (fieldRef, unit) => {
   const dimension =
@@ -19,11 +25,52 @@ const withTemporalUnit = (fieldRef, unit) => {
 
 const timeParameterValueDeserializers = [
   {
+    testRegex: /^(days|months|quarters|hours)~([a-zA-Z0-9\-]+)$/,
+    deserialize: (matches, fieldRef) => {
+      const unit = EXCLUDE_UNITS[matches[0]];
+      const options = EXCLUDE_OPTIONS[unit]().flat();
+      const values = matches[1].split("-");
+      return [
+        "!=",
+        withTemporalUnit(fieldRef, unit),
+        ...options
+          .filter(
+            ({ serialized }) => !!_.find(values, value => value === serialized),
+          )
+          .map(({ value }) => value),
+      ];
+    },
+  },
+  {
+    testRegex: /^past([0-9]+)([a-z]+)s~([0-9]+)([a-z]+)s$/,
+    deserialize: (matches, fieldRef) => {
+      const base = [
+        "time-interval",
+        fieldRef,
+        -parseInt(matches[0]),
+        matches[1],
+      ];
+      return setStartingFrom(base, parseInt(matches[2]), matches[3]);
+    },
+  },
+  {
     testRegex: /^past([0-9]+)([a-z]+)s(~)?$/,
     deserialize: (matches, fieldRef) =>
       ["time-interval", fieldRef, -parseInt(matches[0]), matches[1]].concat(
         matches[2] ? [{ "include-current": true }] : [],
       ),
+  },
+  {
+    testRegex: /^next([0-9]+)([a-z]+)s~([0-9]+)([a-z]+)s$/,
+    deserialize: (matches, fieldRef) => {
+      const base = [
+        "time-interval",
+        fieldRef,
+        parseInt(matches[0]),
+        matches[1],
+      ];
+      return setStartingFrom(base, -parseInt(matches[2]), matches[3]);
+    },
   },
   {
     testRegex: /^next([0-9]+)([a-z]+)s(~)?$/,

--- a/frontend/src/metabase/parameters/utils/mbql.js
+++ b/frontend/src/metabase/parameters/utils/mbql.js
@@ -25,7 +25,7 @@ const withTemporalUnit = (fieldRef, unit) => {
 
 const timeParameterValueDeserializers = [
   {
-    testRegex: /^(days|months|quarters|hours)~([a-zA-Z0-9\-]+)$/,
+    testRegex: /^exclude-(days|months|quarters|hours)-([a-zA-Z0-9\-]+)$/,
     deserialize: (matches, fieldRef) => {
       const unit = EXCLUDE_UNITS[matches[0]];
       const options = EXCLUDE_OPTIONS[unit]().flat();
@@ -42,7 +42,7 @@ const timeParameterValueDeserializers = [
     },
   },
   {
-    testRegex: /^past([0-9]+)([a-z]+)s~([0-9]+)([a-z]+)s$/,
+    testRegex: /^past([0-9]+)([a-z]+)s-from-([0-9]+)([a-z]+)s$/,
     deserialize: (matches, fieldRef) => {
       const base = [
         "time-interval",
@@ -61,7 +61,7 @@ const timeParameterValueDeserializers = [
       ),
   },
   {
-    testRegex: /^next([0-9]+)([a-z]+)s~([0-9]+)([a-z]+)s$/,
+    testRegex: /^next([0-9]+)([a-z]+)s-from-([0-9]+)([a-z]+)s$/,
     deserialize: (matches, fieldRef) => {
       const base = [
         "time-interval",

--- a/frontend/src/metabase/parameters/utils/mbql.unit.spec.js
+++ b/frontend/src/metabase/parameters/utils/mbql.unit.spec.js
@@ -1,3 +1,5 @@
+import moment from "moment";
+
 import {
   dateParameterValueToMBQL,
   stringParameterValueToMBQL,
@@ -25,6 +27,14 @@ describe("parameters/utils/mbql", () => {
         { "include-current": true },
       ]);
     });
+    it("should parse past30days~3years", () => {
+      expect(dateParameterValueToMBQL("past30days~3years", null)).toEqual([
+        "between",
+        ["+", null, ["interval", 3, "year"]],
+        ["relative-datetime", -30, "day"],
+        ["relative-datetime", 0, "day"],
+      ]);
+    });
     it("should parse next2years", () => {
       expect(dateParameterValueToMBQL("next2years", null)).toEqual([
         "time-interval",
@@ -40,6 +50,14 @@ describe("parameters/utils/mbql", () => {
         2,
         "year",
         { "include-current": true },
+      ]);
+    });
+    it("should parse next2years~3months", () => {
+      expect(dateParameterValueToMBQL("next2years~3months", null)).toEqual([
+        "between",
+        ["+", null, ["interval", -3, "month"]],
+        ["relative-datetime", 0, "year"],
+        ["relative-datetime", 2, "year"],
       ]);
     });
     it("should parse thisday", () => {
@@ -93,6 +111,80 @@ describe("parameters/utils/mbql", () => {
         "2017-05-02",
       ]);
     });
+    it("should parse hours~0", () => {
+      expect(dateParameterValueToMBQL("hours~0", null)).toEqual([
+        "!=",
+        ["field", null, { "temporal-unit": "hour-of-day" }],
+        date()
+          .hour(0)
+          .toISOString(),
+      ]);
+    });
+    it("should parse hours~0-23", () => {
+      expect(dateParameterValueToMBQL("hours~0-23", null)).toEqual([
+        "!=",
+        ["field", null, { "temporal-unit": "hour-of-day" }],
+        date()
+          .hour(0)
+          .toISOString(),
+        date()
+          .hour(23)
+          .toISOString(),
+      ]);
+    });
+    it("should parse quarters~1", () => {
+      expect(dateParameterValueToMBQL("quarters~1", null)).toEqual([
+        "!=",
+        ["field", null, { "temporal-unit": "quarter-of-year" }],
+        date()
+          .quarter(1)
+          .format("YYYY-MM-DD"),
+      ]);
+    });
+    it("should parse quarters~1-2", () => {
+      expect(dateParameterValueToMBQL("quarters~1-2", null)).toEqual([
+        "!=",
+        ["field", null, { "temporal-unit": "quarter-of-year" }],
+        date()
+          .quarter(1)
+          .format("YYYY-MM-DD"),
+        date()
+          .quarter(2)
+          .format("YYYY-MM-DD"),
+      ]);
+    });
+    it("should parse months~Feb-Mar", () => {
+      expect(dateParameterValueToMBQL("months~Feb-Mar", null)).toEqual([
+        "!=",
+        ["field", null, { "temporal-unit": "month-of-year" }],
+        date()
+          .month(1)
+          .format("YYYY-MM-DD"),
+        date()
+          .month(2)
+          .format("YYYY-MM-DD"),
+      ]);
+    });
+    it("should parse days~Mon-Fri", () => {
+      expect(dateParameterValueToMBQL("days~Mon-Fri", null)).toEqual([
+        "!=",
+        ["field", null, { "temporal-unit": "day-of-week" }],
+        date()
+          .day(1)
+          .format("YYYY-MM-DD"),
+        date()
+          .day(5)
+          .format("YYYY-MM-DD"),
+      ]);
+    });
+
+    const date = () =>
+      moment()
+        .utc()
+        .hours(0)
+        .minutes(0)
+        .seconds(0)
+        .milliseconds(0);
   });
 
   describe("stringParameterValueToMBQL", () => {

--- a/frontend/src/metabase/parameters/utils/mbql.unit.spec.js
+++ b/frontend/src/metabase/parameters/utils/mbql.unit.spec.js
@@ -28,7 +28,7 @@ describe("parameters/utils/mbql", () => {
       ]);
     });
     it("should parse past30days-from-3years", () => {
-      expect(dateParameterValueToMBQL("past30days~3years", null)).toEqual([
+      expect(dateParameterValueToMBQL("past30days-from-3years", null)).toEqual([
         "between",
         ["+", null, ["interval", 3, "year"]],
         ["relative-datetime", -30, "day"],
@@ -53,7 +53,9 @@ describe("parameters/utils/mbql", () => {
       ]);
     });
     it("should parse next2years-from-3months", () => {
-      expect(dateParameterValueToMBQL("next2years~3months", null)).toEqual([
+      expect(
+        dateParameterValueToMBQL("next2years-from-3months", null),
+      ).toEqual([
         "between",
         ["+", null, ["interval", -3, "month"]],
         ["relative-datetime", 0, "year"],

--- a/frontend/src/metabase/parameters/utils/mbql.unit.spec.js
+++ b/frontend/src/metabase/parameters/utils/mbql.unit.spec.js
@@ -27,7 +27,7 @@ describe("parameters/utils/mbql", () => {
         { "include-current": true },
       ]);
     });
-    it("should parse past30days~3years", () => {
+    it("should parse past30days-from-3years", () => {
       expect(dateParameterValueToMBQL("past30days~3years", null)).toEqual([
         "between",
         ["+", null, ["interval", 3, "year"]],
@@ -52,7 +52,7 @@ describe("parameters/utils/mbql", () => {
         { "include-current": true },
       ]);
     });
-    it("should parse next2years~3months", () => {
+    it("should parse next2years-from-3months", () => {
       expect(dateParameterValueToMBQL("next2years~3months", null)).toEqual([
         "between",
         ["+", null, ["interval", -3, "month"]],
@@ -111,8 +111,8 @@ describe("parameters/utils/mbql", () => {
         "2017-05-02",
       ]);
     });
-    it("should parse hours~0", () => {
-      expect(dateParameterValueToMBQL("hours~0", null)).toEqual([
+    it("should parse exclude-hours-0", () => {
+      expect(dateParameterValueToMBQL("exclude-hours-0", null)).toEqual([
         "!=",
         ["field", null, { "temporal-unit": "hour-of-day" }],
         date()
@@ -120,8 +120,8 @@ describe("parameters/utils/mbql", () => {
           .toISOString(),
       ]);
     });
-    it("should parse hours~0-23", () => {
-      expect(dateParameterValueToMBQL("hours~0-23", null)).toEqual([
+    it("should parse exclude-hours-0-23", () => {
+      expect(dateParameterValueToMBQL("exclude-hours-0-23", null)).toEqual([
         "!=",
         ["field", null, { "temporal-unit": "hour-of-day" }],
         date()
@@ -132,8 +132,8 @@ describe("parameters/utils/mbql", () => {
           .toISOString(),
       ]);
     });
-    it("should parse quarters~1", () => {
-      expect(dateParameterValueToMBQL("quarters~1", null)).toEqual([
+    it("should parse exclude-quarters-1", () => {
+      expect(dateParameterValueToMBQL("exclude-quarters-1", null)).toEqual([
         "!=",
         ["field", null, { "temporal-unit": "quarter-of-year" }],
         date()
@@ -141,8 +141,8 @@ describe("parameters/utils/mbql", () => {
           .format("YYYY-MM-DD"),
       ]);
     });
-    it("should parse quarters~1-2", () => {
-      expect(dateParameterValueToMBQL("quarters~1-2", null)).toEqual([
+    it("should parse exclude-quarters-1-2", () => {
+      expect(dateParameterValueToMBQL("exclude-quarters-1-2", null)).toEqual([
         "!=",
         ["field", null, { "temporal-unit": "quarter-of-year" }],
         date()
@@ -153,8 +153,8 @@ describe("parameters/utils/mbql", () => {
           .format("YYYY-MM-DD"),
       ]);
     });
-    it("should parse months~Feb-Mar", () => {
-      expect(dateParameterValueToMBQL("months~Feb-Mar", null)).toEqual([
+    it("should parse exclude-months-Feb-Mar", () => {
+      expect(dateParameterValueToMBQL("exclude-months-Feb-Mar", null)).toEqual([
         "!=",
         ["field", null, { "temporal-unit": "month-of-year" }],
         date()
@@ -165,8 +165,8 @@ describe("parameters/utils/mbql", () => {
           .format("YYYY-MM-DD"),
       ]);
     });
-    it("should parse days~Mon-Fri", () => {
-      expect(dateParameterValueToMBQL("days~Mon-Fri", null)).toEqual([
+    it("should parse exclude-days-Mon-Fri", () => {
+      expect(dateParameterValueToMBQL("exclude-days-Mon-Fri", null)).toEqual([
         "!=",
         ["field", null, { "temporal-unit": "day-of-week" }],
         date()

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePicker.tsx
@@ -107,6 +107,7 @@ export type DatePickerGroup = "relative" | "specific";
 export type DateOperator = {
   name: string;
   displayName: string;
+  displayPrefix?: string;
   init: (filter: Filter) => any[];
   test: (filter: Filter) => boolean;
   widget: any;
@@ -211,6 +212,7 @@ export const DATE_OPERATORS: DateOperator[] = [
   {
     name: "exclude",
     displayName: t`Exclude...`,
+    displayPrefix: t`Exclude`,
     init: ([op, field, ...values]) =>
       op === "!=" ? [op, field, ...values] : [op, field],
     test: ([op]) => ["!=", "is-null", "not-null"].indexOf(op) > -1,
@@ -257,10 +259,6 @@ const DatePicker: React.FC<Props> = props => {
     hideTimeSelectors,
     hideExcludeOperators,
   } = props;
-
-  const [showShortcuts, setShowShortcuts] = React.useState(
-    !filter?.isValid?.() && !disableOperatorSelection,
-  );
   const operators = React.useMemo(() => {
     let ops = props.operators || DATE_OPERATORS;
     if (props.hideExcludeOperators) {
@@ -270,6 +268,9 @@ const DatePicker: React.FC<Props> = props => {
   }, [props.operators, props.hideExcludeOperators]);
 
   const operator = getOperator(props.filter, operators);
+  const [showShortcuts, setShowShortcuts] = React.useState(
+    !operator && !disableOperatorSelection,
+  );
   const Widget = operator && operator.widget;
 
   const onBack = () => {

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePicker.tsx
@@ -273,6 +273,9 @@ const DatePicker: React.FC<Props> = props => {
   );
   const Widget = operator && operator.widget;
 
+  const enableBackButton =
+    (!showShortcuts && !disableOperatorSelection) ||
+    (showShortcuts && props.onBack);
   const onBack = () => {
     if (!operator || showShortcuts) {
       props.onBack?.();
@@ -294,7 +297,7 @@ const DatePicker: React.FC<Props> = props => {
           hideExcludeOperators={hideExcludeOperators}
           onCommit={onCommit}
           filter={filter}
-          onBack={onBack}
+          onBack={enableBackButton ? onBack : undefined}
         />
       ) : (
         <>

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePicker.tsx
@@ -232,8 +232,6 @@ type Props = {
   operators?: DateOperator[];
 
   hideTimeSelectors?: boolean;
-  disableStartingFrom?: boolean;
-  hideExcludeOperators?: boolean;
   hideEmptinessOperators?: boolean;
   disableOperatorSelection?: boolean;
 
@@ -257,15 +255,8 @@ const DatePicker: React.FC<Props> = props => {
     onCommit,
     children,
     hideTimeSelectors,
-    hideExcludeOperators,
+    operators = DATE_OPERATORS,
   } = props;
-  const operators = React.useMemo(() => {
-    let ops = props.operators || DATE_OPERATORS;
-    if (props.hideExcludeOperators) {
-      ops = ops.filter(op => op.name !== "exclude");
-    }
-    return ops;
-  }, [props.operators, props.hideExcludeOperators]);
 
   const operator = getOperator(props.filter, operators);
   const [showShortcuts, setShowShortcuts] = React.useState(
@@ -294,7 +285,6 @@ const DatePicker: React.FC<Props> = props => {
             setShowShortcuts(false);
             onFilterChange(filter);
           }}
-          hideExcludeOperators={hideExcludeOperators}
           onCommit={onCommit}
           filter={filter}
           onBack={enableBackButton ? onBack : undefined}

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePickerShortcuts.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePickerShortcuts.tsx
@@ -127,19 +127,17 @@ const MISC_OPTIONS: Option[] = [
     displayName: t`Relative dates...`,
     init: filter => ["time-interval", getDateTimeField(filter[1]), -30, "day"],
   },
+  {
+    displayName: t`Exclude...`,
+    init: filter => ["!=", getDateTimeField(filter[1])],
+  },
 ];
-
-const EXCLUDE_OPTION: Option = {
-  displayName: t`Exclude...`,
-  init: filter => ["!=", getDateTimeField(filter[1])],
-};
 
 type Props = {
   className?: string;
   primaryColor?: string;
 
   filter: Filter;
-  hideExcludeOperators?: boolean;
   onCommit: (value: FilterExpression[]) => void;
   onFilterChange: (filter: FilterExpression[]) => void;
   onBack?: () => void;
@@ -150,13 +148,8 @@ export default function DatePickerShortcuts({
   onFilterChange,
   filter,
   onCommit,
-  hideExcludeOperators,
   onBack,
 }: Props) {
-  const options = hideExcludeOperators
-    ? MISC_OPTIONS
-    : [...MISC_OPTIONS, EXCLUDE_OPTION];
-
   const dimension = filter.dimension?.();
   let title = "";
   if (dimension) {
@@ -197,7 +190,7 @@ export default function DatePickerShortcuts({
         </ShortcutButton>
       ))}
       <Separator />
-      {options.map(({ displayName, init }) => (
+      {MISC_OPTIONS.map(({ displayName, init }) => (
         <ShortcutButton
           key={displayName}
           onClick={() => {

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/ExcludeDatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/ExcludeDatePicker.tsx
@@ -16,31 +16,31 @@ import { FieldDimension } from "metabase-lib/lib/Dimension";
 import { Field } from "metabase-types/types/Field";
 import Filter from "metabase-lib/lib/queries/structured/Filter";
 import { color } from "metabase/lib/colors";
+import { EXCLUDE_OPTIONS } from "metabase/lib/query_time";
 
 function getDateTimeField(field: Field, bucketing?: string) {
-  const dimension = FieldDimension.parseMBQLOrWarn(field);
-  if (dimension) {
-    if (bucketing) {
-      return dimension.withTemporalUnit(bucketing).mbql();
-    } else {
-      return dimension.withoutTemporalBucketing().mbql();
-    }
+  const dimension =
+    FieldDimension.parseMBQLOrWarn(field) ?? new FieldDimension(null);
+  if (bucketing) {
+    return dimension.withTemporalUnit(bucketing).mbql();
+  } else {
+    return dimension.withoutTemporalBucketing().mbql();
   }
-  return field;
 }
 
 type Option = {
   displayName: string;
   value: string;
+  serialized: string;
   test: (value: string) => boolean;
 };
 
 type Group = {
+  name: string;
   displayName: string;
   init: (filter: Filter) => any[];
   test: (filter: Filter) => boolean;
   getOptions: () => Option[][];
-  twoColumns?: boolean;
 };
 
 const testTemporalUnit = (unit: string) => (filter: Filter) => {
@@ -48,107 +48,37 @@ const testTemporalUnit = (unit: string) => (filter: Filter) => {
   if (dimension) {
     return dimension.temporalUnit() === unit;
   }
-  return false;
+  return filter[1]?.[2]?.["temporal-unit"] === unit;
 };
 
-const EXCLUDE: Group[] = [
+export const EXCLUDE_OPERATORS: Group[] = [
   {
+    name: "days",
     displayName: t`Days of the week...`,
     test: testTemporalUnit("day-of-week"),
     init: filter => ["!=", getDateTimeField(filter[1], "day-of-week")],
-    getOptions: () => {
-      const now = moment()
-        .utc()
-        .hours(0)
-        .minutes(0)
-        .seconds(0);
-      return [
-        _.range(0, 7).map(day => {
-          const date = now.day(day + 1);
-          const displayName = date.format("dddd");
-          const value = date.format("YYYY-MM-DD");
-          return {
-            displayName,
-            value,
-            test: val => value === val,
-          };
-        }),
-      ];
-    },
+    getOptions: EXCLUDE_OPTIONS["day-of-week"],
   },
   {
+    name: "months",
     displayName: t`Months of the year...`,
     test: testTemporalUnit("month-of-year"),
     init: filter => ["!=", getDateTimeField(filter[1], "month-of-year")],
-    getOptions: () => {
-      const now = moment()
-        .utc()
-        .hours(0)
-        .minutes(0)
-        .seconds(0);
-      const func = (month: number) => {
-        const date = now.month(month);
-        const displayName = date.format("MMMM");
-        const value = date.format("YYYY-MM-DD");
-        return {
-          displayName,
-          value,
-          test: (value: string) => moment(value).format("MMMM") === displayName,
-        };
-      };
-      return [_.range(0, 6).map(func), _.range(6, 12).map(func)];
-    },
-    twoColumns: true,
+    getOptions: EXCLUDE_OPTIONS["month-of-year"],
   },
   {
+    name: "quarters",
     displayName: t`Quarters of the year...`,
     test: testTemporalUnit("quarter-of-year"),
     init: filter => ["!=", getDateTimeField(filter[1], "quarter-of-year")],
-    getOptions: () => {
-      const now = moment()
-        .utc()
-        .hours(0)
-        .minutes(0)
-        .seconds(0);
-      const suffix = " " + t`quarter`;
-      return [
-        _.range(1, 5).map(quarter => {
-          const date = now.quarter(quarter);
-          const displayName = date.format("Qo");
-          const value = date.format("YYYY-MM-DD");
-          return {
-            displayName: displayName + suffix,
-            value,
-            test: (value: string) => moment(value).format("Qo") === displayName,
-          };
-        }),
-      ];
-    },
+    getOptions: EXCLUDE_OPTIONS["quarter-of-year"],
   },
   {
+    name: "hours",
     displayName: t`Hours of the day...`,
     test: testTemporalUnit("hour-of-day"),
     init: filter => ["!=", getDateTimeField(filter[1], "hour-of-day")],
-    getOptions: () => {
-      const now = moment()
-        .utc()
-        .minutes(0)
-        .seconds(0);
-      const func = (hour: number) => {
-        const date = now.hour(hour);
-        const displayName = date.format("h A");
-        return {
-          displayName,
-          value: date.toISOString(),
-          test: (value: string) =>
-            moment(value)
-              .utc()
-              .format("h A") === displayName,
-        };
-      };
-      return [_.range(0, 12).map(func), _.range(12, 24).map(func)];
-    },
-    twoColumns: true,
+    getOptions: EXCLUDE_OPTIONS["hour-of-day"],
   },
 ];
 
@@ -157,7 +87,7 @@ export function getHeaderText(filter: Filter) {
 }
 
 export function getExcludeOperator(filter: Filter) {
-  return _.find(EXCLUDE, ({ test }) => test(filter));
+  return _.find(EXCLUDE_OPERATORS, ({ test }) => test(filter));
 }
 
 type Props = {
@@ -178,12 +108,12 @@ export default function ExcludeDatePicker({
   hideEmptinessOperators,
 }: Props) {
   const [operator, field, ...values] = filter;
-  const temporalUnit = _.find(EXCLUDE, ({ test }) => test(filter));
+  const temporalUnit = _.find(EXCLUDE_OPERATORS, ({ test }) => test(filter));
 
   if (!temporalUnit || operator === "is-null" || operator === "not-null") {
     return (
       <div className={className}>
-        {EXCLUDE.map(({ displayName, init }) => (
+        {EXCLUDE_OPERATORS.map(({ displayName, init }) => (
           <OptionButton
             key={displayName}
             onClick={() => {

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RelativeDatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RelativeDatePicker.tsx
@@ -151,7 +151,6 @@ type Props = {
   offsetFormatter: (value: number) => number;
   primaryColor?: string;
   reverseIconDirection?: boolean;
-  disableStartingFrom?: boolean;
 };
 
 const RelativeDatePicker: React.FC<Props> = props => {
@@ -163,7 +162,6 @@ const RelativeDatePicker: React.FC<Props> = props => {
     className,
     primaryColor,
     reverseIconDirection,
-    disableStartingFrom,
   } = props;
 
   const startingFrom = getStartingFrom(filter);
@@ -178,18 +176,16 @@ const RelativeDatePicker: React.FC<Props> = props => {
 
   const optionsContent = (
     <OptionsContainer>
-      {!disableStartingFrom ? (
-        <OptionButton
-          icon="arrow_left_to_line"
-          reverseIconDirection={reverseIconDirection}
-          onClick={() => {
-            setOptionsVisible(false);
-            onFilterChange(setStartingFrom(filter));
-          }}
-        >
-          {t`Starting from...`}
-        </OptionButton>
-      ) : null}
+      <OptionButton
+        icon="arrow_left_to_line"
+        reverseIconDirection={reverseIconDirection}
+        onClick={() => {
+          setOptionsVisible(false);
+          onFilterChange(setStartingFrom(filter));
+        }}
+      >
+        {t`Starting from...`}
+      </OptionButton>
       <OptionButton
         selected={includeCurrent}
         primaryColor={primaryColor}


### PR DESCRIPTION
Fixes #21807

* Correctly sets `onBack={undefined}` for `DatePickerHeader` in dashboards
* Fix dashboard filter validation logic  (allow the field to be `null`)
* Add `Exclude` and `Starting from` serialization/deserialization