### PR TITLE
Change boolean literal icon in custom expression autocomplete

### DIFF
--- a/frontend/src/metabase/lib/expressions/suggest.js
+++ b/frontend/src/metabase/lib/expressions/suggest.js
@@ -54,7 +54,7 @@ export function suggest({
       name: "True",
       text: "True",
       index: targetOffset,
-      icon: "compare",
+      icon: "io",
       order: 1,
     },
     {
@@ -62,7 +62,7 @@ export function suggest({
       name: "False",
       text: "False",
       index: targetOffset,
-      icon: "compare",
+      icon: "io",
       order: 1,
     },
   );


### PR DESCRIPTION
Fixes #21772

Changes the icon for `True`/`False` boolean literals in custom expression autocomplete

### Repro 

- Sample Database > Orders > Filter
- Filter by `Custom Expression`
- Start typing `true` or `false`

You should see `True` and `False` in the autocomplete window with the I/O icon
