### PR TITLE
Close relative datetime options when user clicks outside the popover

### DIFF
--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RelativeDatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RelativeDatePicker.tsx
@@ -237,6 +237,7 @@ const RelativeDatePicker: React.FC<Props> = props => {
           visible={optionsVisible}
           placement={"bottom-start"}
           content={optionsContent}
+          onClose={() => setOptionsVisible(false)}
         >
           <MoreButton
             icon="ellipsis"


### PR DESCRIPTION
Fixes #21780

Adds `TippyPopover` `onClose` handler

### Repro

- Sample Database > Orders > Filter
- Filter by `Created At`
- Relative dates > Past
- Click ellipsis to open options popover
- Click outside options popover

Options popover should close