### PR TITLE
Add a tooltip for the question's last edit date

### DIFF
--- a/frontend/src/metabase/components/LastEditInfoLabel.js
+++ b/frontend/src/metabase/components/LastEditInfoLabel.js
@@ -5,8 +5,9 @@ import { t } from "ttag";
 import moment from "moment";
 
 import { getUser } from "metabase/selectors/user";
-
 import { TextButton } from "metabase/components/Button.styled";
+import Tooltip from "metabase/components/Tooltip";
+import DateTime from "metabase/components/DateTime";
 
 function mapStateToProps(state) {
   return {
@@ -46,12 +47,14 @@ function LastEditInfoLabel({ item, user, onClick, className }) {
     editorId === user.id ? t`you` : formatEditorName(first_name, last_name);
 
   return (
-    <TextButton
-      size="small"
-      className={className}
-      onClick={onClick}
-      data-testid="revision-history-button"
-    >{t`Edited ${time} by ${editor}`}</TextButton>
+    <Tooltip tooltip={<DateTime value={timestamp} />}>
+      <TextButton
+        size="small"
+        className={className}
+        onClick={onClick}
+        data-testid="revision-history-button"
+      >{t`Edited ${time} by ${editor}`}</TextButton>
+    </Tooltip>
   );
 }
 


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/20973

How to test:
- Save a question
- However over `Edited ... ago by you` label
- Make sure there is a tooltip with the date and time the question was modified

<img width="891" alt="Screenshot 2022-04-21 at 17 06 44" src="https://user-images.githubusercontent.com/8542534/164476300-115d8256-6524-4825-b0b4-c55935e414b0.png">
