### PR TITLE
Minor mobile search UI fixes

### DIFF
--- a/frontend/src/metabase/nav/components/SearchBar.styled.tsx
+++ b/frontend/src/metabase/nav/components/SearchBar.styled.tsx
@@ -81,6 +81,7 @@ export const SearchInput = styled.input<{ isActive: boolean }>`
 
   ${breakpointMaxSmall} {
     width: 0;
+    padding: 0;
 
     ${props =>
       props.isActive &&
@@ -96,9 +97,14 @@ const ICON_MARGIN = "10px";
 
 export const SearchIcon = styled(Icon)<{ isActive: boolean }>`
   ${breakpointMaxSmall} {
-    margin-left: ${props => (props.isActive ? ICON_MARGIN : "3px")};
-    margin-right: ${props => (props.isActive ? ICON_MARGIN : 0)};
     transition: margin 0.3s;
+
+    ${props =>
+      props.isActive &&
+      css`
+        margin-left: ${ICON_MARGIN};
+        margin-right: ${ICON_MARGIN};
+      `}
   }
 
   ${breakpointMinSmall} {

--- a/frontend/src/metabase/nav/containers/AppBar.tsx
+++ b/frontend/src/metabase/nav/containers/AppBar.tsx
@@ -82,7 +82,7 @@ function AppBar({
       <RowLeft isSearchActive={isSearchActive}>
         <HomepageLink handleClick={onLogoClick} />
         <SidebarButtonContainer>
-          <Tooltip tooltip={sidebarButtonTooltip}>
+          <Tooltip tooltip={sidebarButtonTooltip} isEnabled={!isSmallScreen()}>
             <SidebarButton
               isSidebarOpen={isSidebarOpen}
               onClick={onToggleSidebarClick}


### PR DESCRIPTION
1. Disables sidebar control's tooltip (with a `cmd + .` shortcut`). Though it won't show up on mobile, but it actually does
2. Removes search input's padding in the collapsed state. It was occupying some space inside the icon circle container, so the icon position was a bit messed up

![CleanShot 2022-04-21 at 16 51 28@2x](https://user-images.githubusercontent.com/17258145/164500988-98ee4932-662b-40c2-8757-1b43be52e8c1.png)

