### PR TITLE
Native query: allow dots in the variable names

### DIFF
--- a/frontend/src/metabase-lib/lib/queries/NativeQuery.ts
+++ b/frontend/src/metabase-lib/lib/queries/NativeQuery.ts
@@ -425,7 +425,7 @@ export default class NativeQuery extends AtomicQuery {
       // anything that doesn't match our rule is ignored, so {{&foo!}} would simply be ignored
       // variables referencing other questions, by their card ID, are also supported: {{#123}} references question with ID 123
       let match;
-      const re = /\{\{\s*((snippet:\s*[^}]+)|[A-Za-z0-9_]+?|#[0-9]*)\s*\}\}/g;
+      const re = /\{\{\s*((snippet:\s*[^}]+)|[A-Za-z0-9_\.]+?|#[0-9]*)\s*\}\}/g;
 
       while ((match = re.exec(queryText)) != null) {
         tags.push(match[1]);

--- a/frontend/test/metabase/scenarios/native/reproductions/15029-sql-variable-dot.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/reproductions/15029-sql-variable-dot.cy.spec.js
@@ -16,10 +16,6 @@ describe("issue 15029", () => {
 
     cy.findAllByText("Variable name")
       .parent()
-      .as("variableField");
-
-    cy.get("@variableField")
-      .first()
       .findByText("number.of.stars");
   });
 });

--- a/frontend/test/metabase/scenarios/native/reproductions/15029-sql-variable-dot.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/reproductions/15029-sql-variable-dot.cy.spec.js
@@ -1,0 +1,25 @@
+import { restore, openNativeEditor } from "__support__/e2e/cypress";
+
+describe("issue 15029", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsNormalUser();
+  });
+
+  it("should allow dots in the variable reference (metabase#15029)", () => {
+    openNativeEditor().type(
+      "select * from products where RATING = {{number.of.stars}}",
+      {
+        parseSpecialCharSequences: false,
+      },
+    );
+
+    cy.findAllByText("Variable name")
+      .parent()
+      .as("variableField");
+
+    cy.get("@variableField")
+      .first()
+      .findByText("number.of.stars");
+  });
+});


### PR DESCRIPTION
To verify:
1. New, SQL Query, Sample Database
2. Type `select * from products where RATING = {{stars}}`
Note that the sidebar _correctly_ recognizes the `stars` variable template.

![image](https://user-images.githubusercontent.com/7288/164503394-38b037f6-1363-4142-a4e7-2a294138aebb.png)

3. Change to `select * from products where RATING = {{number.of.stars}}`


### Before

`number.of.stars` is **not** recognized, the sidebar is now empty

![image](https://user-images.githubusercontent.com/7288/164503475-e835ada8-62fa-40a1-a0fa-df94cdf3c4df.png)


### After

`number.of.stars` is recognized, as shown in the sidebar.

![image](https://user-images.githubusercontent.com/7288/164503529-d3896e00-2fc0-4701-883c-24ab6de12dd3.png)


Moreover, it's working as the intended variable.

![image](https://user-images.githubusercontent.com/7288/164503511-47ecba33-8268-43ce-95f5-8541966b425d.png)
