### PR TITLE
Repro #21830: Clicking on visualization options on slow loading dashboard cards leads to a page reload or error

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard/reproductions/21830-slow-loading-card-viz-options-error.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/reproductions/21830-slow-loading-card-viz-options-error.cy.spec.js
@@ -1,0 +1,40 @@
+import {
+  restore,
+  editDashboard,
+  showDashboardCardActions,
+} from "__support__/e2e/cypress";
+
+describe.skip("issue 21830", () => {
+  beforeEach(() => {
+    restore("postgres-12");
+    cy.signInAsAdmin();
+  });
+
+  it("slow loading card visualization options click shouldn't lead to error (metabase#21830)", () => {
+    cy.intercept(
+      {
+        method: "POST",
+        url: "/api/dashboard/*/dashcard/*/card/*/query",
+        middleware: true,
+      },
+      req => {
+        req.on("response", res => {
+          // Throttle the response to 500 Kbps to simulate a mobile 3G connection
+          res.setThrottle(500);
+        });
+      },
+    ).as("dashcardQuery");
+
+    cy.visit("/dashboard/1");
+
+    // It's crucial that we try to click on this icon BEFORE we wait for the `dashcardQuery` response!
+    editDashboard();
+    showDashboardCardActions();
+
+    cy.icon("palette").click({ force: true });
+
+    cy.wait("@dashcardQuery");
+
+    cy.get(".Modal");
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #21830 

### How to test this manually?
- `yarn test-cypress-open`
- `metabase/scenarios/dashboard/reproductions/21830-slow-loading-card-viz-options-error.cy.spec.js`
- Unskip repro
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/164514757-ce95994b-cec6-4900-8806-e66b27bb8215.png)

