### PR TITLE
Enable object detail view on nested native queries

### DIFF
--- a/frontend/src/metabase/modes/components/drill/ObjectDetailDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/ObjectDetailDrill.jsx
@@ -43,6 +43,43 @@ function getFKTargetField(question, column) {
   return fkField?.target;
 }
 
+function getBaseActionObject() {
+  return {
+    name: "object-detail",
+    section: "details",
+    title: t`View details`,
+    buttonType: "horizontal",
+    icon: "document",
+    default: true,
+  };
+}
+
+function getPKAction({ question, column, objectId, isDashboard }) {
+  const actionObject = getBaseActionObject();
+  const [actionKey, action] = getActionForPKColumn({
+    question,
+    column,
+    objectId,
+    isDashboard,
+  });
+  actionObject[actionKey] = action;
+  return actionObject;
+}
+
+function getFKAction({ question, column, objectId }) {
+  const actionObject = getBaseActionObject();
+  const targetField = getFKTargetField(question, column);
+  if (!targetField) {
+    return;
+  }
+  const [actionKey, action] = getActionForFKColumn({
+    targetField,
+    objectId,
+  });
+  actionObject[actionKey] = action;
+  return actionObject;
+}
+
 export default ({ question, clicked }) => {
   if (
     !clicked?.column ||
@@ -55,34 +92,8 @@ export default ({ question, clicked }) => {
   const { column, value: objectId, extraData } = clicked;
   const isDashboard = !!extraData?.dashboard;
 
-  const actionObject = {
-    name: "object-detail",
-    section: "details",
-    title: t`View details`,
-    buttonType: "horizontal",
-    icon: "document",
-    default: true,
-  };
+  const params = { question, column, objectId, isDashboard };
 
-  if (isPK(column)) {
-    const [actionKey, action] = getActionForPKColumn({
-      question,
-      column,
-      objectId,
-      isDashboard,
-    });
-    actionObject[actionKey] = action;
-  } else {
-    const targetField = getFKTargetField(question, column);
-    if (!targetField) {
-      return [];
-    }
-    const [actionKey, action] = getActionForFKColumn({
-      targetField,
-      objectId,
-    });
-    actionObject[actionKey] = action;
-  }
-
-  return [actionObject];
+  const actionObject = isPK(column) ? getPKAction(params) : getFKAction(params);
+  return actionObject ? [actionObject] : [];
 };

--- a/frontend/src/metabase/modes/components/drill/ObjectDetailDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/ObjectDetailDrill.jsx
@@ -38,6 +38,11 @@ function getActionForFKColumn({ targetField, objectId }) {
   ];
 }
 
+function getFKTargetField(question, column) {
+  const fkField = question.metadata().field(column.id);
+  return fkField?.target;
+}
+
 export default ({ question, clicked }) => {
   if (
     !clicked?.column ||
@@ -49,14 +54,6 @@ export default ({ question, clicked }) => {
 
   const { column, value: objectId, extraData } = clicked;
   const isDashboard = !!extraData?.dashboard;
-
-  let field = question.metadata().field(column.id);
-  if (isFK(column)) {
-    field = field.target;
-  }
-  if (!field) {
-    return [];
-  }
 
   const actionObject = {
     name: "object-detail",
@@ -76,8 +73,12 @@ export default ({ question, clicked }) => {
     });
     actionObject[actionKey] = action;
   } else {
+    const targetField = getFKTargetField(question, column);
+    if (!targetField) {
+      return [];
+    }
     const [actionKey, action] = getActionForFKColumn({
-      targetField: field,
+      targetField,
       objectId,
     });
     actionObject[actionKey] = action;

--- a/frontend/test/metabase/scenarios/question/question-reproductions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/question-reproductions.cy.spec.js
@@ -7,6 +7,7 @@ import { issue14957 } from "./reproductions/14957-unable-to-save-question-before
 import { issue15714 } from "./reproductions/15714-cc-postgres-percentile-accepts-two-params";
 import { issue15876 } from "./reproductions/15876-postgres-cast-time";
 import { issue16621 } from "./reproductions/16621-create-multiple-filters-with-same-value";
+import { issue16938 } from "./reproductions/16938-nesed-native-query-pk-drill.cy.spec";
 import { issue17512 } from "./reproductions/17512";
 import { issue17514 } from "./reproductions/17514-ui-overlay";
 import { issue17963 } from "./reproductions/17963-mongo-filter-expression-compare-two-fields";
@@ -27,6 +28,7 @@ issue14957();
 issue15714();
 issue15876();
 issue16621();
+issue16938();
 issue17512();
 issue17514();
 issue17963();

--- a/frontend/test/metabase/scenarios/question/reproductions/16938-nesed-native-query-pk-drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/16938-nesed-native-query-pk-drill.cy.spec.js
@@ -1,0 +1,41 @@
+import { restore } from "__support__/e2e/cypress";
+
+export function issue16938() {
+  describe("issue 16938", () => {
+    beforeEach(() => {
+      restore();
+      cy.signInAsAdmin();
+      cy.intercept("POST", "/api/dataset").as("dataset");
+    });
+
+    it("should allow to browse object details when exploring native query results (metabase#16938)", () => {
+      const ORDER_ID = 1;
+
+      cy.createNativeQuestion(
+        {
+          name: "Orders",
+          native: {
+            query: "select * from orders",
+          },
+        },
+        { visitQuestion: true },
+      );
+
+      cy.button(/Explore results/i).click();
+      cy.wait("@dataset");
+
+      getFirstTableColumn()
+        .eq(1)
+        .should("contain", ORDER_ID)
+        .click();
+
+      cy.findByTestId("object-detail").within(() => {
+        cy.findByText(`Order ${ORDER_ID}`);
+      });
+    });
+  });
+}
+
+function getFirstTableColumn() {
+  return cy.get(".TableInteractive-cellWrapper--firstColumn");
+}


### PR DESCRIPTION
Resolves #16938 — allows opening object detail view when exploring native query results. [The fix itself is pretty short](https://github.com/metabase/metabase/commit/0ca1a0891cd9557d2460e2b100ed7d79054c5feb), the rest of the diff is just a small `ObjectDetailDrill` clean up.

`ObjectDetailDrill` was returning nothing for PK columns when it couldn't resolve `field` from `metadata`. We actually don't need the `field` instance for PK drills, so the fix was about just moving this check to FK

### To Verify

1. Create a native question like `select * from orders`
2. On the question page, click the "Explore results" button
3. Click one of the ID column cells (primary key)
4. Ensure object detail view as opened and you can go through the records via "next" and "previous" keys

### Demo

**Before**

https://user-images.githubusercontent.com/17258145/164521901-0b261b99-9fba-4c8f-8d97-9ce10b9d9776.mp4

**After**

https://user-images.githubusercontent.com/17258145/164521914-221d66e9-705f-4380-90cf-65d113ec4f0a.mp4


