### PR TITLE
Improve LDAP setup workflow

### DIFF
--- a/frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx
@@ -109,34 +109,34 @@ export default class SettingsBatchForm extends Component {
   }
 
   validateForm() {
-    const { elements, enabledKey } = this.props;
+    const { elements } = this.props;
     const { formData } = this.state;
 
     let valid = true;
     const validationErrors = {};
 
     // Validate form only if LDAP is enabled
-    if (!enabledKey || formData[enabledKey]) {
-      elements.forEach(function(element) {
-        // test for required elements
-        if (element.required && MetabaseUtils.isEmpty(formData[element.key])) {
-          valid = false;
-        }
+    //if (!enabledKey || formData[enabledKey]) {
+    elements.forEach(function(element) {
+      // test for required elements
+      if (element.required && MetabaseUtils.isEmpty(formData[element.key])) {
+        valid = false;
+      }
 
-        if (element.validations) {
-          element.validations.forEach(function(validation) {
-            validationErrors[element.key] = this.validateElement(
-              validation,
-              formData[element.key],
-              element,
-            );
-            if (validationErrors[element.key]) {
-              valid = false;
-            }
-          }, this);
-        }
-      }, this);
-    }
+      if (element.validations) {
+        element.validations.forEach(function(validation) {
+          validationErrors[element.key] = this.validateElement(
+            validation,
+            formData[element.key],
+            element,
+          );
+          if (validationErrors[element.key]) {
+            valid = false;
+          }
+        }, this);
+      }
+    }, this);
+    //}
 
     if (
       this.state.valid !== valid ||

--- a/frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx
@@ -22,7 +22,7 @@ export default class SettingsLdapForm extends React.Component {
           {
             title: t`Server Settings`,
             settings: [
-              "ldap-enabled",
+              //"ldap-enabled",
               "ldap-host",
               "ldap-port",
               "ldap-security",

--- a/src/metabase/api/ldap.clj
+++ b/src/metabase/api/ldap.clj
@@ -102,14 +102,11 @@
   (let [ldap-settings (-> settings
                           (select-keys (keys mb-settings->ldap-details))
                           (assoc :ldap-port (when-let [^String ldap-port (not-empty (str (:ldap-port settings)))]
-                                              (Long/parseLong ldap-port)))
+                                              (Long/parseLong ldap-port))
+                                 :ldap-enabled true)
                           (update :ldap-password update-password-if-needed))
         ldap-details  (set/rename-keys ldap-settings mb-settings->ldap-details)
-        results       (if-not (:ldap-enabled settings)
-                        ;; when disabled just respond with a success message
-                        {:status :SUCCESS}
-                        ;; otherwise validate settings
-                        (ldap/test-ldap-connection ldap-details))]
+        results       (ldap/test-ldap-connection ldap-details)]
     (if (= :SUCCESS (:status results))
       ;; test succeeded, save our settings
       (setting/set-many! ldap-settings)

--- a/src/metabase/api/ldap.clj
+++ b/src/metabase/api/ldap.clj
@@ -101,8 +101,10 @@
   (validation/check-has-application-permission :setting)
   (let [ldap-settings (-> settings
                           (select-keys (keys mb-settings->ldap-details))
-                          (assoc :ldap-port (when-let [^String ldap-port (not-empty (str (:ldap-port settings)))]
-                                              (Long/parseLong ldap-port))
+                          (assoc :ldap-port (let [port (:ldap-port settings)]
+                                              (if (and (string? port) (not-empty port))
+                                                (Long/parseLong port)
+                                                port))
                                  :ldap-enabled true)
                           (update :ldap-password update-password-if-needed))
         ldap-details  (set/rename-keys ldap-settings mb-settings->ldap-details)

--- a/src/metabase/integrations/ldap.clj
+++ b/src/metabase/integrations/ldap.clj
@@ -96,8 +96,8 @@
   :type       :boolean
   :visibility :public
   :setter     :none
-  :getter     (fn [] (boolean (and (ldap-enabled)
-                                   (ldap-host)
+  :getter     (fn [] (boolean (and (ldap-host)
+                                   (ldap-password)
                                    (ldap-user-base)))))
 
 (defn- details->ldap-options [{:keys [host port bind-dn password security]}]

--- a/src/metabase/integrations/ldap.clj
+++ b/src/metabase/integrations/ldap.clj
@@ -21,10 +21,12 @@
 (defsetting ldap-host
   (deferred-tru "Server hostname."))
 
+(def ^:private ldap-default-port 389)
+
 (defsetting ldap-port
   (deferred-tru "Server port, usually 389 or 636 if SSL is used.")
   :type :integer
-  :default 389)
+  :default ldap-default-port)
 
 (defsetting ldap-security
   (deferred-tru "Use SSL, TLS or plain text.")
@@ -102,9 +104,10 @@
 
 (defn- details->ldap-options [{:keys [host port bind-dn password security]}]
   (let [security (keyword security)
-        port     (if (string? port)
-                   (Integer/parseInt port)
-                   port)]
+        port     (cond
+                   (string? port) (Integer/parseInt port)
+                   (nil? port)    ldap-default-port
+                   :else          port)]
     ;; Connecting via IPv6 requires us to use this form for :host, otherwise
     ;; clj-ldap will find the first : and treat it as an IPv4 and port number
     {:host      {:address host


### PR DESCRIPTION
Goal is to separate configuration from enabling.
If a new configuration validates successfully, LDAP is enabled. After
that it can be turned off without damaging the configuration.

The frontend changes are a hack to test this somewhat and can't be
checked in.

Backend changes for #19428, umbrella bug is #16225.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/21888)
<!-- Reviewable:end -->
