### PR TITLE
Remove unnecessary X scrollbar on tools page

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/tools/containers/ErrorOverview.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/tools/containers/ErrorOverview.jsx
@@ -106,7 +106,7 @@ export default function ErrorOverview(props) {
             sorting.column,
             getSortOrder(sorting.isAscending),
           )}
-          className={"mt2 bounded-overflow-x-scroll"}
+          className="mt2 bounded-overflow-x-auto"
         />
       )}
     </AuditParameters>

--- a/frontend/src/metabase/css/core/overflow.css
+++ b/frontend/src/metabase/css/core/overflow.css
@@ -26,9 +26,9 @@
   overflow-x: scroll;
 }
 
-.bounded-overflow-x-scroll {
+.bounded-overflow-x-auto {
   width: 100%;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .overflow-y-scroll {


### PR DESCRIPTION
Resolves #21833 

- visit `/admin/tools/errors`
- scrollbar appears if you need it
- scrollbar disappears if you don't need it

scrollbar | no scrollbar
--- | ---
![Screenshot from 2022-04-21 13-56-16](https://user-images.githubusercontent.com/30528226/164542619-2a9668d6-a255-4ad6-b2fb-724bdc48ce19.png) | ![Screenshot from 2022-04-21 13-56-06](https://user-images.githubusercontent.com/30528226/164542623-451696d1-4972-4683-81e7-6bb159d66906.png)
