### PR TITLE
[E2E] Experiment running `dashboard-filters-sql` test group as PR check

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -61,6 +61,7 @@ jobs:
         folder:
           - "binning"
           - "dashboard-filters"
+          - "dashboard-filters-sql"
           - "downloads"
           - "moderation"
     services:


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Following the steps of https://github.com/metabase/metabase/pull/21492 and the tasks that @ariya started, we're now adding `dashboard-filters-sql` test group to PR checks using GitHub actions.

Analyzing the flakes report, I haven't found any test from this group failing in the last 90 days.

There's one more important check we need to make. Let's see if the number of passing tests is the same for both OSS and EE versions.

tl;dr It is. Because `dashboard-filters-sql` tests are version agnostic.

But here's the data:
[dashboard-filters-sql OSS](https://github.com/metabase/metabase/runs/6119362135?check_suite_focus=true) vs [dashboard-filters-sql EE](https://github.com/metabase/metabase/runs/6119363525?check_suite_focus=true)
| e2e-tests-dashboard-filters-sql                       | total | passing | pending  |
|---------------------------|--------|-------|-------|
| OSS                  | 52   | 52  | -  |
| EE                 | 52   | 52  | -  |


### The next steps
After we make sure this group runs without major hiccups on GitHub (for at least a week?), remove it from CircleCI.