### PR TITLE
Set consistent height for object detail modal

### DIFF
--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.styled.tsx
@@ -13,7 +13,6 @@ export const ObjectDetailModal = styled.div<ObjectDetailModalProps>`
   ${breakpointMinMedium} {
     width: ${({ wide }) => (wide ? "880px" : "568px")};
   }
-  min-height: 480px;
   max-height: 95vh;
   width: 95vw;
 `;
@@ -33,7 +32,7 @@ export const ObjectDetailsTable = styled.div`
   flex: 1;
   padding: 2rem;
   ${breakpointMinMedium} {
-    max-height: calc(100vh - 12rem);
+    max-height: calc(80vh - 4rem);
   }
 `;
 
@@ -44,7 +43,7 @@ export const ObjectRelationships = styled.div`
   background-color: ${colors["bg-light"]};
   ${breakpointMinMedium} {
     flex: 0 0 33.3333%;
-    max-height: calc(100vh - 12rem);
+    max-height: calc(80vh - 4rem);
   }
 `;
 

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.styled.tsx
@@ -23,10 +23,9 @@ export const ObjectDetailBodyWrapper = styled.div`
   overflow-y: auto;
   ${breakpointMinMedium} {
     display: flex;
-    max-height: auto;
-    min-height: calc(480px - 4rem);
+    height: calc(80vh - 4rem);
   }
-  max-height: calc(100vh - 8rem);
+  height: calc(100vh - 8rem);
 `;
 
 export const ObjectDetailsTable = styled.div`


### PR DESCRIPTION
## Before

Having a variable height for the object detail modal made it difficult to rapidly click through many different detail records because the forward/back buttons could move vertically on the screen.


https://user-images.githubusercontent.com/30528226/164558681-48cbb7ac-bc78-4de3-b489-4174437565cf.mp4

## After

Setting consistent height based on screen size guarantees the modal won't jump around and the forward/back buttons will stay in the same spot.

Resolves https://github.com/metabase/metabase/issues/21897

https://user-images.githubusercontent.com/30528226/164558727-025571b5-8560-4918-a254-930ab021a79b.mp4

