### PR TITLE
[E2E] Ensure that there is a reference for cy.wait

### DIFF
--- a/frontend/test/metabase/scenarios/visualizations/reproductions/21665-multi-series-frontend-reload.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/reproductions/21665-multi-series-frontend-reload.cy.spec.js
@@ -30,7 +30,7 @@ describe("issue 21665", () => {
         "GET",
         `/api/dashboard/${id}`,
         cy.spy().as("dashboardLoaded"),
-      );
+      ).as("getDashboard");
 
       cy.wrap(id).as("dashboardId");
 


### PR DESCRIPTION
### Before

`frontend/test/metabase/scenarios/visualizations/reproductions/21665-multi-series-frontend-reload.cy.spec.js` (once it's unskipped in PR #21825) seems to fail like this:

![issue 21665 -- multi-series cards shouldnt cause frontend to reload (metabase#21665) (failed)](https://user-images.githubusercontent.com/7288/164583097-0c75b8d2-5aeb-4c48-be45-65cff676aa36.png)

Note that `@getDashboard` was actually never constructed.

### After

It should not happen anymore, as `@getDashboard` is constructed properly.