### PR TITLE
[E2E] Robustify X-ray tests by waiting for all datasets

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard/x-rays.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/x-rays.cy.spec.js
@@ -26,6 +26,8 @@ describe("scenarios > x-rays", () => {
     cy.signInAsAdmin();
   });
 
+  const XRAY_DATASETS = 11; // enough to load most questions
+
   it.skip("should work on questions with explicit joins (metabase#13112)", () => {
     const PRODUCTS_ALIAS = "Products";
 
@@ -90,6 +92,9 @@ describe("scenarios > x-rays", () => {
       visualize();
       summarize();
       getDimensionByName({ name: "SOURCE" }).click();
+
+      cy.intercept("POST", "/api/dataset").as("postDataset");
+
       cy.button("Done").click();
       cy.get(".bar")
         .first()
@@ -97,11 +102,13 @@ describe("scenarios > x-rays", () => {
       cy.findByText(action).click();
 
       cy.wait("@xray").then(xhr => {
+        for (let c = 0; c < XRAY_DATASETS; ++c) {
+          cy.wait("@postDataset");
+        }
         expect(xhr.response.body.cause).not.to.exist;
         expect(xhr.response.statusCode).not.to.eq(500);
       });
 
-      cy.wait("@dataset");
       cy.findByTextEnsureVisible("A look at the number of 15655");
 
       cy.findByRole("heading", { name: /^A closer look at the number of/ });

--- a/frontend/test/metabase/scenarios/joins/joins-2.cy.spec.js
+++ b/frontend/test/metabase/scenarios/joins/joins-2.cy.spec.js
@@ -405,8 +405,10 @@ describe("scenarios > question > joined questions", () => {
     });
 
     it("x-rays should work on explicit joins when metric is for the joined table (metabase#14793)", () => {
+      const XRAY_DATASETS = 11; // enough to load most questions
+
       cy.intercept("GET", "/api/automagic-dashboards/adhoc/**").as("xray");
-      cy.intercept("POST", "/api/dataset").as("dataset");
+      cy.intercept("POST", "/api/dataset").as("postDataset");
 
       visitQuestionAdhoc({
         dataset_query: {
@@ -443,11 +445,12 @@ describe("scenarios > question > joined questions", () => {
       cy.findByText("X-ray").click();
 
       cy.wait("@xray").then(xhr => {
+        for (let c = 0; c < XRAY_DATASETS; ++c) {
+          cy.wait("@postDataset");
+        }
         expect(xhr.response.body.cause).not.to.exist;
         expect(xhr.status).not.to.eq(500);
       });
-
-      cy.wait("@dataset");
 
       // Metric title
       cy.findByTextEnsureVisible(


### PR DESCRIPTION
### Before

Unfortunately, it doesn't seem that the workaround in PR #21843 is completely fool-proof. On those ~potato~ CI machine, the loading of various questions are super slow and it led to the error:

![image](https://user-images.githubusercontent.com/7288/164620074-5f423ccb-10ee-40ef-a73f-1601d0200baa.png)

### After

The giant hack here is to wait for enough `/api/dataset`. Unfortunately, I can't come up with a better alternative so far.