### PR TITLE
Fallback to Card's description when sending Pulse

### DIFF
--- a/src/metabase/pulse/render.clj
+++ b/src/metabase/pulse/render.clj
@@ -51,7 +51,7 @@
   [dashcard card]
   (when *include-description*
     (when-let [description (or (get-in dashcard [:visualization_settings :card.description])
-                               ( :description card))]
+                               (:description card))]
       {:attachments {}
        :content [:div {:style (style/style {:color style/color-text-medium
                                             :font-size :12px

--- a/src/metabase/pulse/render.clj
+++ b/src/metabase/pulse/render.clj
@@ -1,7 +1,6 @@
 (ns metabase.pulse.render
   (:require [clojure.tools.logging :as log]
             [hiccup.core :refer [h]]
-            [metabase.models.card :refer [Card]]
             [metabase.models.dashboard-card :as dashboard-card]
             [metabase.pulse.render.body :as body]
             [metabase.pulse.render.common :as common]
@@ -10,8 +9,7 @@
             [metabase.pulse.render.style :as style]
             [metabase.util.i18n :refer [trs tru]]
             [metabase.util.urls :as urls]
-            [schema.core :as s]
-            [toucan.db :as db]))
+            [schema.core :as s]))
 
 (def ^:dynamic *include-buttons*
   "Should the rendered pulse include buttons? (default: `false`)"
@@ -50,10 +48,10 @@
                                  :src   (:image-src image-bundle)}])]]]]})))
 
 (s/defn ^:private make-description-if-needed :- (s/maybe common/RenderedPulseCard)
-  [dashcard]
+  [dashcard card]
   (when *include-description*
     (when-let [description (or (get-in dashcard [:visualization_settings :card.description])
-                               (db/select-one-field :description Card :id (:card_id dashcard)))]
+                               ( :description card))]
       {:attachments {}
        :content [:div {:style (style/style {:color style/color-text-medium
                                             :font-size :12px
@@ -165,7 +163,7 @@
   scalar results where text is preferable to an image of a div of a single result."
   [render-type timezone-id :- (s/maybe s/Str) card dashcard results]
   (let [{title :content, title-attachments :attachments} (make-title-if-needed render-type card dashcard)
-        {description :content}                           (make-description-if-needed dashcard)
+        {description :content}                           (make-description-if-needed dashcard card)
         {pulse-body       :content
          body-attachments :attachments
          text             :render/text}                  (render-pulse-card-body render-type timezone-id card dashcard results)]

--- a/src/metabase/pulse/render.clj
+++ b/src/metabase/pulse/render.clj
@@ -1,7 +1,7 @@
 (ns metabase.pulse.render
   (:require [clojure.tools.logging :as log]
             [hiccup.core :refer [h]]
-            [metabase.models :refer [Card]]
+            [metabase.models.card :refer [Card]]
             [metabase.models.dashboard-card :as dashboard-card]
             [metabase.pulse.render.body :as body]
             [metabase.pulse.render.common :as common]
@@ -10,8 +10,8 @@
             [metabase.pulse.render.style :as style]
             [metabase.util.i18n :refer [trs tru]]
             [metabase.util.urls :as urls]
-            [toucan.db :as db]
-            [schema.core :as s]))
+            [schema.core :as s]
+            [toucan.db :as db]))
 
 (def ^:dynamic *include-buttons*
   "Should the rendered pulse include buttons? (default: `false`)"

--- a/src/metabase/pulse/render.clj
+++ b/src/metabase/pulse/render.clj
@@ -1,6 +1,7 @@
 (ns metabase.pulse.render
   (:require [clojure.tools.logging :as log]
             [hiccup.core :refer [h]]
+            [metabase.models :refer [Card]]
             [metabase.models.dashboard-card :as dashboard-card]
             [metabase.pulse.render.body :as body]
             [metabase.pulse.render.common :as common]
@@ -9,6 +10,7 @@
             [metabase.pulse.render.style :as style]
             [metabase.util.i18n :refer [trs tru]]
             [metabase.util.urls :as urls]
+            [toucan.db :as db]
             [schema.core :as s]))
 
 (def ^:dynamic *include-buttons*
@@ -50,7 +52,8 @@
 (s/defn ^:private make-description-if-needed :- (s/maybe common/RenderedPulseCard)
   [dashcard]
   (when *include-description*
-    (when-let [description (-> dashcard :visualization_settings :card.description)]
+    (when-let [description (or (get-in dashcard [:visualization_settings :card.description])
+                               (db/select-one-field :description Card :id (:card_id dashcard)))]
       {:attachments {}
        :content [:div {:style (style/style {:color style/color-text-medium
                                             :font-size :12px

--- a/test/metabase/pulse/render_test.clj
+++ b/test/metabase/pulse/render_test.clj
@@ -113,3 +113,19 @@
                                                  {:base_type :type/Number}]
                                           :rows [["apple" 3]
                                                  ["banana" 4]]}))))
+
+(deftest make-description-if-needed-test
+  (testing "Use Visualization Settings's description if it exists"
+    (mt/with-temp* [Card          [card {:description "Card description"}]
+                    Dashboard     [dashboard]
+                    DashboardCard [dc1 {:dashboard_id (:id dashboard) :card_id (:id card)
+                                        :visualization_settings {:card.description "Visualization description"}}]]
+      (binding [render/*include-description* true]
+        (is (= "Visualization description" (last (:content (#'render/make-description-if-needed dc1))))))))
+
+  (testing "Fallback to Card's description if Visualization Settings's description not exists"
+    (mt/with-temp* [Card          [card {:description "Card description"}]
+                    Dashboard     [dashboard]
+                    DashboardCard [dc1 {:dashboard_id (:id dashboard) :card_id (:id card)}]]
+      (binding [render/*include-description* true]
+        (is (= "Card description" (last (:content (#'render/make-description-if-needed dc1)))))))))

--- a/test/metabase/pulse/render_test.clj
+++ b/test/metabase/pulse/render_test.clj
@@ -121,11 +121,11 @@
                     DashboardCard [dc1 {:dashboard_id (:id dashboard) :card_id (:id card)
                                         :visualization_settings {:card.description "Visualization description"}}]]
       (binding [render/*include-description* true]
-        (is (= "Visualization description" (last (:content (#'render/make-description-if-needed dc1))))))))
+        (is (= "Visualization description" (last (:content (#'render/make-description-if-needed dc1 card))))))))
 
   (testing "Fallback to Card's description if Visualization Settings's description not exists"
     (mt/with-temp* [Card          [card {:description "Card description"}]
                     Dashboard     [dashboard]
                     DashboardCard [dc1 {:dashboard_id (:id dashboard) :card_id (:id card)}]]
       (binding [render/*include-description* true]
-        (is (= "Card description" (last (:content (#'render/make-description-if-needed dc1)))))))))
+        (is (= "Card description" (last (:content (#'render/make-description-if-needed dc1 card)))))))))


### PR DESCRIPTION
Fix #20948 by fallback to Card's description if Dashcard's visualization settings does not have description.

Thanks @escherize for paring with me 💪.