### PR TITLE
Allow using some string filters for fields without special type

### DIFF
--- a/frontend/src/metabase/parameters/utils/filters.js
+++ b/frontend/src/metabase/parameters/utils/filters.js
@@ -4,7 +4,6 @@ import { TemplateTagVariable } from "metabase-lib/lib/Variable";
 
 export function fieldFilterForParameter(parameter) {
   const type = getParameterType(parameter);
-  const subtype = getParameterSubType(parameter);
   switch (type) {
     case "date":
       return field => field.isDate();
@@ -17,11 +16,7 @@ export function fieldFilterForParameter(parameter) {
     case "number":
       return field => field.isNumber() && !field.isCoordinate();
     case "string":
-      return field => {
-        return subtype === "=" || subtype === "!="
-          ? field.isCategory() && !field.isLocation()
-          : field.isString() && !field.isLocation();
-      };
+      return field => field.isString() && !field.isLocation();
   }
 
   return () => false;

--- a/frontend/src/metabase/parameters/utils/filters.unit.spec.js
+++ b/frontend/src/metabase/parameters/utils/filters.unit.spec.js
@@ -71,6 +71,7 @@ describe("parameters/utils/field-filters", () => {
           type: "category",
           field: () => ({
             ...field,
+            isString: () => true,
             isCategory: () => true,
           }),
         },
@@ -81,6 +82,7 @@ describe("parameters/utils/field-filters", () => {
           type: "category",
           field: () => ({
             ...field,
+            isString: () => true,
             isCategory: () => true,
           }),
         },


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/21653
Fixes https://github.com/metabase/metabase/issues/11274
Fixes https://github.com/metabase/metabase/issues/13186

Not sure why there was a special case for category fields, so this might break something.

How to test:
1. Create a new question on the sample database with select * from people [[where {{address}}]]
2. Make {{address}} a field filter and link it to people.address
3. Try to pick field filter type
4. Make sure that `String` and `String is not` options are available and working correctly

I didn't rename `String` to `String is` because translations are already done for the `release-` branch. It would also require more changes and it feels a bit risky already.