### PR TITLE
Bookmarks: move reorder logic to entity

### DIFF
--- a/frontend/src/metabase/entities/bookmarks.js
+++ b/frontend/src/metabase/entities/bookmarks.js
@@ -1,4 +1,4 @@
-import { assocIn } from "icepick";
+import { assocIn, dissoc } from "icepick";
 
 import { createEntity } from "metabase/lib/entities";
 import Collections from "metabase/entities/collections";
@@ -57,12 +57,12 @@ const Bookmarks = createEntity({
   reducer: (state = {}, { type, payload, error, bookmarks }) => {
     if (type === Questions.actionTypes.UPDATE && payload?.object?.archived) {
       const key = "card-" + payload?.object?.id;
-      return assocIn(state, [key], undefined);
+      return dissoc(state, key);
     }
 
     if (type === Dashboards.actionTypes.UPDATE && payload?.object?.archived) {
       const key = "dashboard-" + payload?.object?.id;
-      return assocIn(state, [key], undefined);
+      return dissoc(state, key);
     }
 
     if (type === "metabase/qb/API_UPDATE_QUESTION") {

--- a/frontend/src/metabase/entities/bookmarks.js
+++ b/frontend/src/metabase/entities/bookmarks.js
@@ -46,6 +46,15 @@ const Bookmarks = createEntity({
       return state;
     }
 
+    if (type === "metabase/qb/API_UPDATE_QUESTION") {
+      const { id, query_type } = payload;
+      const entityType = query_type === "query" ? "card" : query_type;
+
+      state[entityType + "-" + id].name = payload.name;
+      console.log("🚀", { state });
+      return state;
+    }
+
     return state;
   },
 });

--- a/frontend/src/metabase/entities/bookmarks.js
+++ b/frontend/src/metabase/entities/bookmarks.js
@@ -32,18 +32,29 @@ const Bookmarks = createEntity({
     getIcon,
   },
   actions: {
-    reorder: bookmarks => {
-      const bookmarksForOrdering = bookmarks.map(({ type, item_id }) => ({
-        type,
-        item_id,
-      }));
+    reorder: (bookmarks, oldIndex, newIndex) => async dispatch => {
+      console.log("🚀", { bookmarks, oldIndex, newIndex });
+      // dispatch({ type: Dashboards.actionTypes.INVALIDATE_LISTS_ACTION });
+      const element = bookmarks[oldIndex];
+
+      bookmarks.splice(oldIndex, 1);
+      bookmarks.splice(newIndex, 0, element);
+
+      dispatch({ type: "bookmarks/REORDER", bookmarks });
+
+      const bookmarksWithFieldsForWebservice = bookmarks.map(
+        ({ type, item_id }) => ({
+          type,
+          item_id,
+        }),
+      );
       BookmarkApi.reorder(
-        { orderings: { orderings: bookmarksForOrdering } },
+        { orderings: { orderings: bookmarksWithFieldsForWebservice } },
         { bodyParamName: "orderings" },
       );
     },
   },
-  reducer: (state = {}, { type, payload, error }) => {
+  reducer: (state = {}, { type, payload, error, bookmarks }) => {
     if (type === Questions.actionTypes.UPDATE && payload?.object?.archived) {
       const key = "card-" + payload?.object?.id;
       return assocIn(state, [key], undefined);
@@ -60,6 +71,12 @@ const Bookmarks = createEntity({
 
       const key = entityType + "-" + id;
       return assocIn(state, [key, "name"], payload.name);
+    }
+
+    if (type === "bookmarks/REORDER") {
+      console.log("🚀", { bookmarks });
+      return bookmarks;
+      // return { ...state };
     }
 
     return state;

--- a/frontend/src/metabase/entities/bookmarks.js
+++ b/frontend/src/metabase/entities/bookmarks.js
@@ -39,13 +39,13 @@ const Bookmarks = createEntity({
   },
   reducer: (state = {}, { type, payload, error }) => {
     if (type === Questions.actionTypes.UPDATE && payload?.object?.archived) {
-      state[`card-${payload?.object?.id}`] = undefined;
-      return state;
+      const key = "card-" + payload?.object?.id;
+      return assocIn(state, [key], undefined);
     }
 
     if (type === Dashboards.actionTypes.UPDATE && payload?.object?.archived) {
-      state[`dashboard-${payload?.object?.id}`] = undefined;
-      return state;
+      const key = "dashboard-" + payload?.object?.id;
+      return assocIn(state, [key], undefined);
     }
 
     if (type === "metabase/qb/API_UPDATE_QUESTION") {

--- a/frontend/src/metabase/entities/bookmarks.js
+++ b/frontend/src/metabase/entities/bookmarks.js
@@ -22,6 +22,12 @@ const Bookmarks = createEntity({
       return BookmarkApi[type].delete({ id });
     },
   },
+  selectors: {
+    getOrderedList: ({ entities }, { entityQuery }) => {
+      const ids = entities.bookmarks_list?.null?.list || [];
+      return ids.map(id => entities.bookmarks[id]);
+    },
+  },
   objectSelectors: {
     getIcon,
   },

--- a/frontend/src/metabase/entities/bookmarks.js
+++ b/frontend/src/metabase/entities/bookmarks.js
@@ -1,3 +1,5 @@
+import { assocIn } from "icepick";
+
 import { createEntity } from "metabase/lib/entities";
 import Collections from "metabase/entities/collections";
 import Dashboards from "metabase/entities/dashboards";
@@ -50,9 +52,8 @@ const Bookmarks = createEntity({
       const { id, query_type } = payload;
       const entityType = query_type === "query" ? "card" : query_type;
 
-      state[entityType + "-" + id].name = payload.name;
-      console.log("🚀", { state });
-      return state;
+      const key = entityType + "-" + id;
+      return assocIn(state, [key, "name"], payload.name);
     }
 
     return state;

--- a/frontend/src/metabase/entities/bookmarks.js
+++ b/frontend/src/metabase/entities/bookmarks.js
@@ -1,4 +1,4 @@
-import { assocIn, dissoc } from "icepick";
+import { dissoc } from "icepick";
 
 import { createEntity } from "metabase/lib/entities";
 import Collections from "metabase/entities/collections";
@@ -65,13 +65,13 @@ const Bookmarks = createEntity({
       return dissoc(state, key);
     }
 
-    if (type === "metabase/qb/API_UPDATE_QUESTION") {
-      const { id, query_type } = payload;
-      const entityType = query_type === "query" ? "card" : query_type;
+    // if (type === "metabase/qb/API_UPDATE_QUESTION") {
+    //   const { id, query_type } = payload;
+    //   const entityType = query_type === "query" ? "card" : query_type;
 
-      const key = entityType + "-" + id;
-      return assocIn(state, [key, "name"], payload.name);
-    }
+    //   const key = entityType + "-" + id;
+    //   return assocIn(state, [key, "name"], payload.name);
+    // }
 
     if (type === "bookmarks/REORDER") {
       console.log("🚀", { bookmarks });

--- a/frontend/src/metabase/entities/bookmarks.js
+++ b/frontend/src/metabase/entities/bookmarks.js
@@ -24,8 +24,10 @@ const Bookmarks = createEntity({
   },
   selectors: {
     getOrderedList: ({ entities }, { entityQuery }) => {
-      const ids = entities.bookmarks_list?.null?.list || [];
-      return ids.map(id => entities.bookmarks[id]);
+      const ids = entities.bookmarks_list?.null?.list;
+      return entities.bookmarks_list && ids
+        ? ids.map(id => entities.bookmarks[id]).filter(Boolean)
+        : [];
     },
   },
   objectSelectors: {
@@ -33,8 +35,6 @@ const Bookmarks = createEntity({
   },
   actions: {
     reorder: (bookmarks, oldIndex, newIndex) => async dispatch => {
-      console.log("🚀", { bookmarks, oldIndex, newIndex });
-      // dispatch({ type: Dashboards.actionTypes.INVALIDATE_LISTS_ACTION });
       const element = bookmarks[oldIndex];
 
       bookmarks.splice(oldIndex, 1);

--- a/frontend/src/metabase/nav/containers/MainNavbar/BookmarkList/BookmarkList.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/BookmarkList/BookmarkList.tsx
@@ -105,12 +105,7 @@ const BookmarkList = ({
   onDeleteBookmark,
   reorderBookmarks,
 }: CollectionSidebarBookmarksProps) => {
-  const [orderedBookmarks, setOrderedBookmarks] = useState(bookmarks);
   const [isSorting, setIsSorting] = useState(false);
-
-  useEffect(() => {
-    setOrderedBookmarks(bookmarks);
-  }, [bookmarks]);
 
   const onToggleBookmarks = useCallback(isVisible => {
     localStorage.setItem("shouldDisplayBookmarks", String(isVisible));
@@ -131,6 +126,8 @@ const BookmarkList = ({
     reorderBookmarks({ newIndex, oldIndex });
   };
 
+  // console.log("🚀", "Hi hi hi hi", { bookmarks });
+
   return (
     <CollapseSection
       header={<SidebarHeading>{t`Bookmarks`}</SidebarHeading>}
@@ -147,7 +144,7 @@ const BookmarkList = ({
         lockAxis="y"
         helperClass="sorting"
       >
-        {orderedBookmarks.map((bookmark, index) => (
+        {bookmarks.map((bookmark, index) => (
           <BookmarkItem
             bookmark={bookmark}
             isSorting={isSorting}

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer.tsx
@@ -93,9 +93,12 @@ function MainNavbarContainer({
   const [orderedBookmarks, setOrderedBookmarks] = useState([]);
 
   useEffect(() => {
+    // A bookmark has been added or removed
+    // let's reorder them
     if (bookmarks?.length !== orderedBookmarks?.length) {
       setOrderedBookmarks(bookmarks as any);
     }
+    console.log("🚀", { bookmarks, orderedBookmarks });
   }, [orderedBookmarks, bookmarks]);
 
   useEffect(() => {
@@ -210,6 +213,7 @@ function MainNavbarContainer({
 export default _.compose(
   Bookmarks.loadList({
     loadingAndErrorWrapper: false,
+    reload: true,
   }),
   Collections.load({
     id: ROOT_COLLECTION.id,

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer.tsx
@@ -19,7 +19,7 @@ import {
   getHasOwnDatabase,
   getHasDataAccess,
 } from "metabase/new_query/selectors";
-import { getUser, getBookmarks } from "metabase/selectors/user";
+import { getUser } from "metabase/selectors/user";
 import {
   nonPersonalOrArchivedCollection,
   currentUserPersonalCollections,
@@ -40,7 +40,6 @@ function mapStateToProps(state: unknown) {
     currentUser: getUser(state),
     hasDataAccess: getHasDataAccess(state),
     hasOwnDatabase: getHasOwnDatabase(state),
-    // bookmarks: getBookmarks(state),
   };
 }
 

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer.tsx
@@ -98,7 +98,6 @@ function MainNavbarContainer({
     if (bookmarks?.length !== orderedBookmarks?.length) {
       setOrderedBookmarks(bookmarks as any);
     }
-    console.log("🚀", { bookmarks, orderedBookmarks });
   }, [orderedBookmarks, bookmarks]);
 
   useEffect(() => {
@@ -212,7 +211,7 @@ function MainNavbarContainer({
 
 export default _.compose(
   Bookmarks.loadList({
-    loadingAndErrorWrapper: false,
+    selectorName: "getOrderedList",
   }),
   Collections.load({
     id: ROOT_COLLECTION.id,

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer.tsx
@@ -47,6 +47,7 @@ const mapDispatchToProps = {
   openNavbar,
   closeNavbar,
   logout,
+  reorderBookmarks: Bookmarks.actions.reorder,
 };
 
 interface CollectionTreeItem extends Collection {
@@ -72,6 +73,11 @@ type Props = {
   openNavbar: () => void;
   closeNavbar: () => void;
   logout: () => void;
+  reorderBookmarks: (
+    bookmarks: BookmarksType,
+    oldIndex: number,
+    newIndex: number,
+  ) => void;
 };
 
 function MainNavbarContainer({
@@ -88,17 +94,18 @@ function MainNavbarContainer({
   openNavbar,
   closeNavbar,
   logout,
+  reorderBookmarks,
   ...props
 }: Props) {
-  const [orderedBookmarks, setOrderedBookmarks] = useState([]);
+  // const [orderedBookmarks, setOrderedBookmarks] = useState([]);
 
-  useEffect(() => {
-    // A bookmark has been added or removed
-    // let's reorder them
-    if (bookmarks?.length !== orderedBookmarks?.length) {
-      setOrderedBookmarks(bookmarks as any);
-    }
-  }, [orderedBookmarks, bookmarks]);
+  // useEffect(() => {
+  //   // A bookmark has been added or removed
+  //   // let's reorder them
+  //   if (bookmarks?.length !== orderedBookmarks?.length) {
+  //     setOrderedBookmarks(bookmarks as any);
+  //   }
+  // }, [orderedBookmarks, bookmarks]);
 
   useEffect(() => {
     function handleSidebarKeyboardShortcut(e: KeyboardEvent) {
@@ -161,22 +168,14 @@ function MainNavbarContainer({
     return [root, ...buildCollectionTree(preparedCollections)];
   }, [rootCollection, collections, currentUser]);
 
-  const reorderBookmarks = ({
-    newIndex,
+  const handleReorderBookmarks = ({
     oldIndex,
+    newIndex,
   }: {
     newIndex: number;
     oldIndex: number;
   }) => {
-    const bookmarksToBeReordered =
-      orderedBookmarks.length > 0 ? [...orderedBookmarks] : [...bookmarks];
-    const element = bookmarksToBeReordered[oldIndex];
-
-    bookmarksToBeReordered.splice(oldIndex, 1);
-    bookmarksToBeReordered.splice(newIndex, 0, element);
-
-    setOrderedBookmarks(bookmarksToBeReordered as any);
-    Bookmarks.actions.reorder(bookmarksToBeReordered);
+    reorderBookmarks(bookmarks, oldIndex, newIndex);
   };
 
   return (
@@ -185,16 +184,14 @@ function MainNavbarContainer({
         {allFetched && rootCollection ? (
           <MainNavbarView
             {...props}
-            bookmarks={
-              orderedBookmarks.length > 0 ? orderedBookmarks : bookmarks
-            }
+            bookmarks={bookmarks}
             isOpen={isOpen}
             currentUser={currentUser}
             collections={collectionTree}
             hasOwnDatabase={hasOwnDatabase}
             selectedItem={selectedItem}
             hasDataAccess={hasDataAccess}
-            reorderBookmarks={reorderBookmarks}
+            reorderBookmarks={handleReorderBookmarks}
             handleCloseNavbar={closeNavbar}
             handleLogout={logout}
           />

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer.tsx
@@ -19,7 +19,7 @@ import {
   getHasOwnDatabase,
   getHasDataAccess,
 } from "metabase/new_query/selectors";
-import { getUser } from "metabase/selectors/user";
+import { getUser, getBookmarks } from "metabase/selectors/user";
 import {
   nonPersonalOrArchivedCollection,
   currentUserPersonalCollections,
@@ -40,6 +40,7 @@ function mapStateToProps(state: unknown) {
     currentUser: getUser(state),
     hasDataAccess: getHasDataAccess(state),
     hasOwnDatabase: getHasOwnDatabase(state),
+    // bookmarks: getBookmarks(state),
   };
 }
 
@@ -213,7 +214,6 @@ function MainNavbarContainer({
 export default _.compose(
   Bookmarks.loadList({
     loadingAndErrorWrapper: false,
-    reload: true,
   }),
   Collections.load({
     id: ROOT_COLLECTION.id,

--- a/frontend/src/metabase/selectors/user.js
+++ b/frontend/src/metabase/selectors/user.js
@@ -28,3 +28,7 @@ export const getUserPersonalCollectionId = createSelector(
   [getUser],
   user => (user && user.personal_collection_id) || null,
 );
+
+export const getBookmarks = state => {
+  return state.entities.bookmarks;
+};

--- a/frontend/src/metabase/selectors/user.js
+++ b/frontend/src/metabase/selectors/user.js
@@ -28,7 +28,3 @@ export const getUserPersonalCollectionId = createSelector(
   [getUser],
   user => (user && user.personal_collection_id) || null,
 );
-
-export const getBookmarks = state => {
-  return state.entities.bookmarks;
-};


### PR DESCRIPTION
This started as a fix for updating bookmark names when their entities names have been updated.

Because we have a quirky comparison inside a useEffect in frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer.tsx (first hook around line 108), this branch became about cleaning up the component and moving logic into `entities/bookmarks.tsx`.

The last state of this branch is the attempt to tell the entity that the order has been updated.

For the custom `getOrderedList` selector in `entities/bookmarks.tsx`, we rely on `bookmarks_list`, not on `bookmarks`, to draw the order of the bookmarks.

So in the reducer conditional comparing for `(type === "bookmarks/REORDER")` (a temporary name, by the way), I believe we should update `bookmarks_list`.

Alexander Polyankin suggests we have to update the entity at the lib level to accomplish this.
It remains to be seen if this is worth the effort, or if we could handle this at a component level, as we are trying to do in https://github.com/metabase/metabase/pull/21962

