### PR TITLE
Hide "Our analytics" from navbar when don't have permission for it

### DIFF
--- a/frontend/src/metabase/collections/components/Layout.jsx
+++ b/frontend/src/metabase/collections/components/Layout.jsx
@@ -1,5 +1,0 @@
-import styled from "@emotion/styled";
-
-export const PageWrapper = styled.div`
-  overflow: hidden;
-`;

--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -19,6 +19,7 @@ import ItemsTable from "metabase/collections/components/ItemsTable";
 import PinnedItemOverview from "metabase/collections/components/PinnedItemOverview";
 import { isPersonalCollectionChild } from "metabase/collections/utils";
 
+import { Unauthorized } from "metabase/containers/ErrorPages";
 import ItemsDragLayer from "metabase/containers/dnd/ItemsDragLayer";
 import PaginationControls from "metabase/components/PaginationControls";
 
@@ -176,6 +177,10 @@ function CollectionContent({
     sort_column: "name",
     sort_direction: "asc",
   };
+
+  if (isRoot && !collection.can_write) {
+    return <Unauthorized />;
+  }
 
   return (
     <Search.ListLoader

--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -29,6 +29,7 @@ import { usePrevious } from "metabase/hooks/use-previous";
 import { useListSelect } from "metabase/hooks/use-list-select";
 import { isSmallScreen } from "metabase/lib/dom";
 import {
+  CenteredLayout,
   CollectionEmptyContent,
   CollectionMain,
   CollectionRoot,
@@ -179,7 +180,11 @@ function CollectionContent({
   };
 
   if (isRoot && !collection.can_write) {
-    return <Unauthorized />;
+    return (
+      <CenteredLayout>
+        <Unauthorized />
+      </CenteredLayout>
+    );
   }
 
   return (

--- a/frontend/src/metabase/collections/containers/CollectionContent.styled.tsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.styled.tsx
@@ -1,6 +1,14 @@
 import styled from "@emotion/styled";
 
+export const CenteredLayout = styled.div`
+  display: flex;
+  flex: 1;
+  justify-content: center;
+  align-items: center;
+`;
+
 export const CollectionRoot = styled.div`
+  width: 100%;
   padding-top: 1rem;
 `;
 

--- a/frontend/src/metabase/components/CollectionLanding/CollectionLanding.jsx
+++ b/frontend/src/metabase/components/CollectionLanding/CollectionLanding.jsx
@@ -3,7 +3,6 @@ import React from "react";
 
 import { extractCollectionId } from "metabase/lib/urls";
 
-import { PageWrapper } from "metabase/collections/components/Layout";
 import CollectionContent from "metabase/collections/containers/CollectionContent";
 import { ContentBox } from "./CollectionLanding.styled";
 
@@ -12,7 +11,7 @@ const CollectionLanding = ({ params: { slug }, children }) => {
   const isRoot = collectionId === "root";
 
   return (
-    <PageWrapper>
+    <>
       <ContentBox>
         <CollectionContent isRoot={isRoot} collectionId={collectionId} />
       </ContentBox>
@@ -20,7 +19,7 @@ const CollectionLanding = ({ params: { slug }, children }) => {
         // Need to have this here so the child modals will show up
         children
       }
-    </PageWrapper>
+    </>
   );
 };
 

--- a/frontend/src/metabase/components/CollectionLanding/CollectionLanding.styled.jsx
+++ b/frontend/src/metabase/components/CollectionLanding/CollectionLanding.styled.jsx
@@ -1,11 +1,7 @@
 import styled from "@emotion/styled";
 
-import { breakpointMinSmall } from "metabase/styled-components/theme/media-queries";
-
 export const ContentBox = styled.div`
-  overflow-y: auto;
-
-  ${breakpointMinSmall} {
-    display: block;
-  }
+  display: flex;
+  width: 100%;
+  min-height: 100%;
 `;

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer.tsx
@@ -163,13 +163,17 @@ function MainNavbarContainer({
     preparedCollections.push(...userPersonalCollections);
     preparedCollections.push(...nonPersonalOrArchivedCollections);
 
-    const root: CollectionTreeItem = {
-      ...rootCollection,
-      icon: getCollectionIcon(rootCollection),
-      children: [],
-    };
+    const tree = buildCollectionTree(preparedCollections);
 
-    return [root, ...buildCollectionTree(preparedCollections)];
+    if (rootCollection.can_write) {
+      tree.unshift({
+        ...rootCollection,
+        icon: getCollectionIcon(rootCollection),
+        children: [],
+      });
+    }
+
+    return tree;
   }, [rootCollection, collections, currentUser]);
 
   const reorderBookmarks = useCallback(

--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -400,6 +400,17 @@ describe("collection permissions", () => {
 
     cy.findByTestId("select-button").findByText("Our analytics");
   });
+
+  it("shouldn't list 'Our analytics' if a user has no access to it (metabase#20716)", () => {
+    cy.signIn("none");
+    cy.visit("/collection/root");
+
+    cy.get("main").findByText(/Sorry, you don’t have permission to see that/i);
+    navigationSidebar().within(() => {
+      cy.findByText("Our analytics").should("not.exist");
+      cy.findByText("Your personal collection");
+    });
+  });
 });
 
 function openEllipsisMenuFor(item, index = 0) {


### PR DESCRIPTION
Reproduces #20716, resolves #20716

Hides "Our analytics" from the navbar if a user doesn't have permission to it. Also makes Metabase show the "You don't have permission to see this" error message when trying to open the root collection from a URL.

### To Verify

1. Admin > Permissions > Collections - set "Our analytics" to No access for All Users
2. Sign in as a non-admin user
3. Ensure you can't see "Our analytics" in the navbar
4. Ensure you see a permission error message when opening `/collection/root` URL
5. Ensure the collection layout is not busted (have to change a few things to 🥁 🥁 🥁 center a div) 

### Demo

https://user-images.githubusercontent.com/17258145/164717481-d6c909e9-bad8-4a63-b780-448d9048318a.mp4


