### PR TITLE
Gh 21549 snippet permissions

### DIFF
--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
@@ -427,9 +427,9 @@ export default class NativeQueryEditor extends Component {
       </div>
     );
 
-    const canSaveSnippets = !!snippetCollections
-      .map(sc => sc.can_write)
-      .find(x => x);
+    const canSaveSnippets = snippetCollections.some(
+      collection => collection.can_write,
+    );
 
     return (
       <div className="NativeQueryEditor bg-light full">

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
@@ -416,6 +416,7 @@ export default class NativeQueryEditor extends Component {
       hasTopBar = true,
       hasEditingSidebar = true,
       resizableBoxProps = {},
+      snippetCollections = [],
     } = this.props;
 
     const parameters = query.question().parameters();
@@ -425,6 +426,10 @@ export default class NativeQueryEditor extends Component {
         <div className="NativeQueryEditorDragHandle" />
       </div>
     );
+
+    const canSaveSnippets = !!snippetCollections
+      .map(sc => sc.can_write)
+      .find(x => x);
 
     return (
       <div className="NativeQueryEditor bg-light full">
@@ -483,6 +488,7 @@ export default class NativeQueryEditor extends Component {
             openSnippetModalWithSelectedText={openSnippetModalWithSelectedText}
             runQuery={this.runQuery}
             target={() => this.editor.current.querySelector(".ace_selection")}
+            canSaveSnippets={canSaveSnippets}
           />
 
           {this.props.modalSnippet && (

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/RightClickPopover/RightClickPopover.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/RightClickPopover/RightClickPopover.jsx
@@ -14,6 +14,7 @@ const propTypes = {
   target: PropTypes.func,
   runQuery: PropTypes.func,
   openSnippetModalWithSelectedText: PropTypes.func,
+  canSaveSnippets: PropTypes.bool,
 };
 
 const NativeQueryEditorRightClickPopover = ({
@@ -21,6 +22,7 @@ const NativeQueryEditorRightClickPopover = ({
   target,
   runQuery,
   openSnippetModalWithSelectedText,
+  canSaveSnippets,
 }) => (
   <Popover isOpen={isOpen} target={target}>
     <Container>
@@ -28,10 +30,12 @@ const NativeQueryEditorRightClickPopover = ({
         <Icon name={"play"} size={16} />
         <h4>{t`Run selection`}</h4>
       </Anchor>
-      <Anchor onClick={openSnippetModalWithSelectedText}>
-        <Icon name={"snippet"} size={16} />
-        <h4>{t`Save as snippet`}</h4>
-      </Anchor>
+      {canSaveSnippets && (
+        <Anchor onClick={openSnippetModalWithSelectedText}>
+          <Icon name={"snippet"} size={16} />
+          <h4>{t`Save as snippet`}</h4>
+        </Anchor>
+      )}
     </Container>
   </Popover>
 );

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -8,7 +8,9 @@
             [clojure.string :as str]
             [clojure.tools.logging :as log]
             [honeysql.core :as hsql]
-            [metabase.api.common :as api :refer [*current-user-id* *current-user-permissions-set*]]
+            [medley.core :as m]
+            [metabase.api.common :as api :refer [*current-user-id*
+                                                 *current-user-permissions-set*]]
             [metabase.models.collection.root :as collection.root]
             [metabase.models.interface :as mi]
             [metabase.models.permissions :as perms :refer [Permissions]]
@@ -179,11 +181,12 @@
 (defn root-collection-with-ui-details
   "The special Root Collection placeholder object with some extra details to facilitate displaying it on the FE."
   [collection-namespace]
-  (assoc root-collection
-         :name (case (keyword collection-namespace)
-                 :snippets (tru "Top folder")
-                 (tru "Our analytics"))
-         :id   "root"))
+  (m/assoc-some root-collection
+                :name (case (keyword collection-namespace)
+                        :snippets (tru "Top folder")
+                        (tru "Our analytics"))
+                :namespace collection-namespace
+                :id   "root"))
 
 (def ^:private CollectionWithLocationOrRoot
   (s/cond-pre


### PR DESCRIPTION
Fixes #21549 

Main issue was around improper permissions being returned for the root snippet collection. I also added a check to show/hide the right click "save as snippet" option when right clicking on highlighted text. Showing the ability to edit or create from the sidebar was already working after being passed proper permissions.

No Snippets access:
<img width="959" alt="chrome_yySnpHFTBR" src="https://user-images.githubusercontent.com/1328979/164717625-3f6d142b-91b0-4db5-b3cd-50845a693bb7.png">
Write access to folder:
<img width="284" alt="chrome_lIQ8kYNkji" src="https://user-images.githubusercontent.com/1328979/164717651-14d13c10-7b89-4088-ab96-0412b8f945a6.png">
View access to folder (note the lack of create and edit buttons):
<img width="273" alt="chrome_RoTHWZ9bO1" src="https://user-images.githubusercontent.com/1328979/164717704-32a70f23-5aa7-439a-a349-4f12b64e046e.png">

