### PR TITLE
Disable bulk actions on view-only collections

### DIFF
--- a/frontend/src/metabase/collections/components/BaseTableItem.jsx
+++ b/frontend/src/metabase/collections/components/BaseTableItem.jsx
@@ -63,7 +63,8 @@ export function BaseTableItem({
   }, [item, onToggleSelected]);
 
   const renderRow = useCallback(() => {
-    const canSelect = typeof onToggleSelected === "function";
+    const canSelect =
+      collection.can_write && typeof onToggleSelected === "function";
 
     const lastEditInfo = item["last-edit-info"];
 

--- a/frontend/src/metabase/collections/components/BaseTableItem.jsx
+++ b/frontend/src/metabase/collections/components/BaseTableItem.jsx
@@ -111,6 +111,7 @@ export function BaseTableItem({
             pinned={isPinned}
             selectable={canSelect}
             selected={isSelected}
+            disabled={!canSelect}
             onToggleSelected={handleSelectionToggled}
             showCheckbox={isHoveringOverRow}
           />

--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -362,6 +362,24 @@ describe("collection permissions", () => {
               );
             });
 
+            it("should not be able to use bulk actions on collection items (metabase#16490)", () => {
+              cy.visit("/collection/root");
+
+              cy.findByText("Orders")
+                .closest("tr")
+                .within(() => {
+                  cy.icon("table").trigger("mouseover");
+                  cy.findByRole("checkbox").should("not.exist");
+                });
+
+              cy.findByText("Orders in a dashboard")
+                .closest("tr")
+                .within(() => {
+                  cy.icon("dashboard").trigger("mouseover");
+                  cy.findByRole("checkbox").should("not.exist");
+                });
+            });
+
             ["/", "/collection/root"].forEach(route => {
               it("should not be offered to save dashboard in collections they have `read` access to (metabase#15281)", () => {
                 const { first_name, last_name } = USERS[user];


### PR DESCRIPTION
Reproduces #16490, fixes #16490

While being on a collection page, people can select a few collection items for bulk archive/move action. They need to hover over a collection item icon, a checkbox will show up and once you click it, you'll see a bulk actions bar at the bottom of the page. The issue was that users without a "write" permission to a collection could also do that and it was leading to errors.

### To Verify

1. As an admin, go to Admin > Permissions > Collections
2. Pick a collection with some content inside and set the permission to "View" for the "All users" group
3. Sign in as a non-admin user and open that collection page
4. Hover a few collection items, you should see no checkboxes appearing
5. Sign in as an admin an open the same collection
6. Hover a few collection items, you should see a checkbox appearing, click it, select a few more items and try to archive/move them using the bulk actions bar

### Demo

**Before**

https://user-images.githubusercontent.com/17258145/164723029-04b5b936-df67-46ee-865e-de11dabf4dc4.mp4

**After**

https://user-images.githubusercontent.com/17258145/164723040-fc287f9c-c22a-4e94-b429-0388b9a8049c.mp4

