### PR TITLE
Removing delay/blur/focus after running query

### DIFF
--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
@@ -19,7 +19,6 @@ import _ from "underscore";
 import { ResizableBox } from "react-resizable";
 
 import { isEventOverElement } from "metabase/lib/dom";
-import { delay } from "metabase/lib/promise";
 import { SQLBehaviour } from "metabase/lib/ace/sql_behaviour";
 import ExplicitSize from "metabase/components/ExplicitSize";
 
@@ -202,21 +201,7 @@ export default class NativeQueryEditor extends Component {
         shouldUpdateUrl: false,
       });
     } else if (query.canRun()) {
-      runQuestionQuery()
-        // <hack>
-        // This is an attempt to fix a conflict between Ace and react-draggable.
-        // TableInteractive uses react-draggable for the column headers. When
-        // that's first added (as a result of runninga query), Ace freezes until
-        // the arrow keys are hit or text is deleted.
-        // Bluring and refocusing gets it out of that state. Here we try and
-        // wait until just after a table is added. That's super error prone, but
-        // we're just doing a best effort to eliminate the freezing.
-        .then(() => delay(1500))
-        .then(() => {
-          this._editor.blur();
-          this._editor.focus();
-        });
-      // </hack>
+      runQuestionQuery();
     }
   };
 


### PR DESCRIPTION
Fixes #18150 

Returning focus to the editor was a deliberate decision made back in 2019 when updating the ace text editor (#11515). I removed the delay/focus/blur and did the steps that @mazameli outlined in the comments of the original pr and I'm not experiencing any lock up. I know we are now pulling a new version of Ace, and presumably a new version of the drag and drop library for tables, so something must have resolved this issue

Showing that focus isn't being pulled:
![6LXG7M8Sn9](https://user-images.githubusercontent.com/1328979/164726273-401e7ab9-309f-4a93-b3bd-bdc0025fdac0.gif)

Showing original issue from 2019 is no longer present (mouse wasn't clicked after I ran the query):
![chrome_LxtcNaDZ3r](https://user-images.githubusercontent.com/1328979/164726437-dd109b56-28e4-4abf-807f-d5dbb3bb8345.gif)

