### PR TITLE
When creating a model, use any viz settings titles for display name

### DIFF
--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -9,7 +9,6 @@
             [medley.core :as m]
             [metabase.api.card :as api.card]
             [metabase.api.pivots :as api.pivots]
-            [metabase.driver :as driver]
             [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
             [metabase.http-client :as client]
             [metabase.models :refer [Card CardBookmark Collection Dashboard Database ModerationReview Pulse PulseCard


### PR DESCRIPTION
Fixes #20624 


## DRAFT
This is in draft. We seem to have some bug in the metadata that it is getting dropped when switching from a card to a model. This impacts two things:
- here for saving viz settings into metadata: we are dropping the metadata with the changes so it all goes away :(
- for persisting, we are losing the raw database types, preventing those types from being kept around for creating cache tables

I'm not sure why. But it seems that:
- PUT model with dataset true
- that correctly uses existing metadata blends it and saves it
- the POST to get the model query after saving nukes it all. I don't know why :(

## Body
Editing column titles in the UI stores those renames in the viz
settings, which are ignored by models. But we can copy those titles over
to the display_name on the metadata of the model.

We only do this on the "model edge", when a card is turned into a model
so that the future editing remains in the metadat editor where it
belongs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/21946)
<!-- Reviewable:end -->
