### PR TITLE
Keep navigation UI on errors

### DIFF
--- a/frontend/src/metabase-types/store/app.ts
+++ b/frontend/src/metabase-types/store/app.ts
@@ -2,7 +2,7 @@ export interface AppErrorDescriptor {
   status: number;
   data?: {
     error_code: string;
-    message: string;
+    message?: string;
   };
   context?: string;
 }

--- a/frontend/src/metabase/App.tsx
+++ b/frontend/src/metabase/App.tsx
@@ -30,7 +30,7 @@ import { AppErrorDescriptor, State } from "metabase-types/store";
 import { AppContentContainer, AppContent } from "./App.styled";
 
 const getErrorComponent = ({ status, data, context }: AppErrorDescriptor) => {
-  if (status === 403) {
+  if (status === 403 || data?.error_code === "unauthorized") {
     return <Unauthorized />;
   }
   if (status === 404 || data?.error_code === "not-found") {

--- a/frontend/src/metabase/App.tsx
+++ b/frontend/src/metabase/App.tsx
@@ -119,19 +119,15 @@ function App({
   return (
     <ErrorBoundary onError={setErrorInfo}>
       <ScrollToTop>
-        {errorPage ? (
-          getErrorComponent(errorPage)
-        ) : (
-          <>
-            {hasAppBar && <AppBar />}
-            <AppContentContainer hasAppBar={hasAppBar} isAdminApp={isAdminApp}>
-              {hasNavbar && <Navbar />}
-              <AppContent>{children}</AppContent>
-              <UndoListing />
-              <StatusListing />
-            </AppContentContainer>
-          </>
-        )}
+        {hasAppBar && <AppBar />}
+        <AppContentContainer hasAppBar={hasAppBar} isAdminApp={isAdminApp}>
+          {hasNavbar && <Navbar />}
+          <AppContent>
+            {errorPage ? getErrorComponent(errorPage) : children}
+          </AppContent>
+          <UndoListing />
+          <StatusListing />
+        </AppContentContainer>
         <AppErrorCard errorInfo={errorInfo} />
       </ScrollToTop>
     </ErrorBoundary>

--- a/frontend/src/metabase/containers/NotFoundFallbackPage.tsx
+++ b/frontend/src/metabase/containers/NotFoundFallbackPage.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import { connect } from "react-redux";
+import { replace } from "react-router-redux";
+import { LocationDescriptor } from "history";
+
+import { setErrorPage } from "metabase/redux/app";
+import { refreshCurrentUser } from "metabase/redux/user";
+import { useOnMount } from "metabase/hooks/use-on-mount";
+
+import { AppErrorDescriptor } from "metabase-types/store";
+
+import { NotFound } from "./ErrorPages";
+
+type DispatchProps = {
+  setErrorPage: (err: AppErrorDescriptor) => void;
+  refreshCurrentUser: () => any;
+  onChangeLocation: (location: LocationDescriptor) => void;
+};
+
+type Props = DispatchProps;
+
+const mapDispatchToProps = {
+  setErrorPage,
+  refreshCurrentUser,
+  onChangeLocation: replace,
+};
+
+const NOT_FOUND_ERROR: AppErrorDescriptor = {
+  status: 404,
+  data: {
+    error_code: "not-found",
+  },
+};
+
+const NotFoundFallbackPage = ({
+  setErrorPage,
+  refreshCurrentUser,
+  onChangeLocation,
+}: Props) => {
+  useOnMount(() => {
+    async function refresh() {
+      const result = await refreshCurrentUser();
+      const isSignedIn = !result.error;
+      if (isSignedIn) {
+        setErrorPage(NOT_FOUND_ERROR);
+      } else {
+        onChangeLocation("/auth/login");
+      }
+    }
+    refresh();
+  });
+
+  return <NotFound />;
+};
+
+export default connect(null, mapDispatchToProps)(NotFoundFallbackPage);

--- a/frontend/src/metabase/containers/NotFoundFallbackPage.tsx
+++ b/frontend/src/metabase/containers/NotFoundFallbackPage.tsx
@@ -3,16 +3,12 @@ import { connect } from "react-redux";
 import { replace } from "react-router-redux";
 import { LocationDescriptor } from "history";
 
-import { setErrorPage } from "metabase/redux/app";
 import { refreshCurrentUser } from "metabase/redux/user";
 import { useOnMount } from "metabase/hooks/use-on-mount";
-
-import { AppErrorDescriptor } from "metabase-types/store";
 
 import { NotFound } from "./ErrorPages";
 
 type DispatchProps = {
-  setErrorPage: (err: AppErrorDescriptor) => void;
   refreshCurrentUser: () => any;
   onChangeLocation: (location: LocationDescriptor) => void;
 };
@@ -20,20 +16,11 @@ type DispatchProps = {
 type Props = DispatchProps;
 
 const mapDispatchToProps = {
-  setErrorPage,
   refreshCurrentUser,
   onChangeLocation: replace,
 };
 
-const NOT_FOUND_ERROR: AppErrorDescriptor = {
-  status: 404,
-  data: {
-    error_code: "not-found",
-  },
-};
-
 const NotFoundFallbackPage = ({
-  setErrorPage,
   refreshCurrentUser,
   onChangeLocation,
 }: Props) => {
@@ -41,9 +28,7 @@ const NotFoundFallbackPage = ({
     async function refresh() {
       const result = await refreshCurrentUser();
       const isSignedIn = !result.error;
-      if (isSignedIn) {
-        setErrorPage(NOT_FOUND_ERROR);
-      } else {
+      if (!isSignedIn) {
         onChangeLocation("/auth/login");
       }
     }

--- a/frontend/src/metabase/routes.jsx
+++ b/frontend/src/metabase/routes.jsx
@@ -46,7 +46,8 @@ import NewQueryOptions from "metabase/new_query/containers/NewQueryOptions";
 
 import CreateDashboardModal from "metabase/components/CreateDashboardModal";
 
-import { NotFound, Unauthorized } from "metabase/containers/ErrorPages";
+import { Unauthorized } from "metabase/containers/ErrorPages";
+import NotFoundFallbackPage from "metabase/containers/NotFoundFallbackPage";
 
 // Reference Metrics
 import MetricListContainer from "metabase/reference/metrics/MetricListContainer";
@@ -391,6 +392,6 @@ export const getRoutes = store => (
 
     {/* MISC */}
     <Route path="/unauthorized" component={Unauthorized} />
-    <Route path="/*" component={NotFound} />
+    <Route path="/*" component={NotFoundFallbackPage} />
   </Route>
 );


### PR DESCRIPTION
Fixes that the navigation UI was hiding on "global" error pages (missing permission, not found, etc.)

### To Verify

1. Open an archived question/dashboard by URL (paste the URL in the browser's address bar)
2. Ensure you can see the error view + the whole navigation (navbar + appbar)
3. Open a completely random URL (e.g. `/bananas`)
4. Ensure you can see the error view + the whole navigation (navbar + appbar)
5. Sign out, try to access real/random URLs
6. Ensure you're redirected to `/auth/login` page

### Demo

**Before**

https://user-images.githubusercontent.com/17258145/164761536-827187c0-52aa-457b-b8a4-69ff8977fe8c.mp4

**After**

https://user-images.githubusercontent.com/17258145/164761459-1d5ffe83-21f6-4a7f-8ab2-934c96244406.mp4

