### PR TITLE
Skiping flake Permission test

### DIFF
--- a/.github/workflows/e2e-master.yml
+++ b/.github/workflows/e2e-master.yml
@@ -39,7 +39,7 @@ jobs:
 
   e2e-tests:
     runs-on: ubuntu-20.04
-    timeout-minutes: 30
+    timeout-minutes: 60
     needs: build
     name: e2e-tests-${{ matrix.folder }}-${{ matrix.edition }}
     env:

--- a/.github/workflows/e2e-master.yml
+++ b/.github/workflows/e2e-master.yml
@@ -3,7 +3,7 @@ name: E2E Tests
 on:
   push:
     branches:
-      - "permission-skip"
+      - "master"
     paths-ignore:
       - "docs/**"
       - "**.md"
@@ -39,7 +39,7 @@ jobs:
 
   e2e-tests:
     runs-on: ubuntu-20.04
-    timeout-minutes: 60
+    timeout-minutes: 30
     needs: build
     name: e2e-tests-${{ matrix.folder }}-${{ matrix.edition }}
     env:
@@ -55,25 +55,25 @@ jobs:
         java-version: [11]
         edition: [oss, ee]
         folder:
-          # - "admin"
-          # - "binning"
-          # - "collections"
-          # - "custom-column"
-          # - "dashboard"
-          # - "dashboard-filters"
-          # - "dashboard-filters-sql"
-          # - "downloads"
-          # - "embedding"
-          # - "joins"
-          # - "models"
-          # - "moderation"
-          # - "native"
-          # - "native-filters"
-          # - "onboarding"
+          - "admin"
+          - "binning"
+          - "collections"
+          - "custom-column"
+          - "dashboard"
+          - "dashboard-filters"
+          - "dashboard-filters-sql"
+          - "downloads"
+          - "embedding"
+          - "joins"
+          - "models"
+          - "moderation"
+          - "native"
+          - "native-filters"
+          - "onboarding"
           - "permissions"
-          # - "question"
-          # - "sharing"
-          # - "visualizations"
+          - "question"
+          - "sharing"
+          - "visualizations"
     services:
       maildev:
         image: maildev/maildev:1.1.0
@@ -129,7 +129,11 @@ jobs:
 
     - name: Run Cypress tests on ${{ matrix.folder }}
       run: |
-        yarn run test-cypress-run --spec "frontend/test/metabase/scenarios/permissions/*.spec.js" --env burn=20
+        yarn run test-cypress-run \
+          --folder ${{ matrix.folder }} \
+          --record --key ${{ secrets.CURRENTS_KEY }} \
+          --group ${{ matrix.folder }}-${{ matrix.edition }} \
+          --ci-build-id "${{ github.run_id }}-${{ github.run_attempt }}"
       env:
         TERM: xterm
 

--- a/.github/workflows/e2e-master.yml
+++ b/.github/workflows/e2e-master.yml
@@ -3,7 +3,7 @@ name: E2E Tests
 on:
   push:
     branches:
-      - "master"
+      - "permission-skip"
     paths-ignore:
       - "docs/**"
       - "**.md"
@@ -55,25 +55,25 @@ jobs:
         java-version: [11]
         edition: [oss, ee]
         folder:
-          - "admin"
-          - "binning"
-          - "collections"
-          - "custom-column"
-          - "dashboard"
-          - "dashboard-filters"
-          - "dashboard-filters-sql"
-          - "downloads"
-          - "embedding"
-          - "joins"
-          - "models"
-          - "moderation"
-          - "native"
-          - "native-filters"
-          - "onboarding"
+          # - "admin"
+          # - "binning"
+          # - "collections"
+          # - "custom-column"
+          # - "dashboard"
+          # - "dashboard-filters"
+          # - "dashboard-filters-sql"
+          # - "downloads"
+          # - "embedding"
+          # - "joins"
+          # - "models"
+          # - "moderation"
+          # - "native"
+          # - "native-filters"
+          # - "onboarding"
           - "permissions"
-          - "question"
-          - "sharing"
-          - "visualizations"
+          # - "question"
+          # - "sharing"
+          # - "visualizations"
     services:
       maildev:
         image: maildev/maildev:1.1.0
@@ -129,11 +129,7 @@ jobs:
 
     - name: Run Cypress tests on ${{ matrix.folder }}
       run: |
-        yarn run test-cypress-run \
-          --folder ${{ matrix.folder }} \
-          --record --key ${{ secrets.CURRENTS_KEY }} \
-          --group ${{ matrix.folder }}-${{ matrix.edition }} \
-          --ci-build-id "${{ github.run_id }}-${{ github.run_attempt }}"
+        yarn run test-cypress-run --spec "frontend/test/metabase/scenarios/permissions/*.spec.js" --env burn=20
       env:
         TERM: xterm
 

--- a/frontend/test/metabase/scenarios/permissions/application-permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/application-permissions.cy.spec.js
@@ -100,6 +100,8 @@ describeEE("scenarios > admin > permissions > application", () => {
         cy.signInAsNormalUser();
       });
 
+      // Adding this test to quarantine. When it was failing was making all the subsequents to fail.
+      // More details can be found on the Thread https://metaboat.slack.com/archives/CKZEMT1MJ/p1649272824618149
       it.skip("allows accessing tools, audit, and troubleshooting for non-admins", () => {
         cy.visit("/");
         cy.icon("gear").click();

--- a/frontend/test/metabase/scenarios/permissions/application-permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/application-permissions.cy.spec.js
@@ -100,7 +100,7 @@ describeEE("scenarios > admin > permissions > application", () => {
         cy.signInAsNormalUser();
       });
 
-      it("allows accessing tools, audit, and troubleshooting for non-admins", () => {
+      it.skip("allows accessing tools, audit, and troubleshooting for non-admins", () => {
         cy.visit("/");
         cy.icon("gear").click();
 


### PR DESCRIPTION
For some still unknown reason when we get a failure on the test `allows accessing tools, audit, and troubleshooting for non-admins`, this leads to a deadlock on the H2 DB, making all the subsequent tests fail.

Putting this in quarantine in the meantime to not generate noise while is being analyzed properly.

Failing example: https://github.com/metabase/metabase/runs/6133211224?check_suite_focus=true