### PR TITLE
Ensure the correct type on revision.timestamp

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -11501,6 +11501,16 @@ databaseChangeLog:
             columnName: icon
             defaultNullValue: "star"
 
+  - changeSet:
+      id: v43.00-062
+      author: snoe
+      comment: Added 0.43.0 - Unify datatype with revision.timestamp for timezone info (see 17829).
+      changes:
+        - modifyDataType:
+            tableName: revision
+            columnName: timestamp
+            newDataType: ${timestamp_type}
+
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################


### PR DESCRIPTION
Fixes #17829 

In H2 the column type for `revision.timestamp` was
`["TIMESTAMP" "TIMESTAMP NOT NULL"]`

This change will ensure it is correctly
`["TIMESTAMP" "TIMESTAMP WITH TIME ZONE NOT NULL"]`

Postgres remains as `timestamp with time zone`
