### PR TITLE
Show nicer empty state for fresh login history

### DIFF
--- a/frontend/src/metabase/account/login-history/components/LoginHistory/LoginHistory.jsx
+++ b/frontend/src/metabase/account/login-history/components/LoginHistory/LoginHistory.jsx
@@ -58,7 +58,7 @@ const formatItems = items =>
   });
 
 const EmtpyLoginHistory = () => (
-  <div className="p5 text-centered">
+  <div className="text-centered">
     <img src={NoResults} className="mb2" />
     <Text color="medium">{t`No logins`}</Text>
   </div>

--- a/frontend/src/metabase/account/login-history/components/LoginHistory/LoginHistory.jsx
+++ b/frontend/src/metabase/account/login-history/components/LoginHistory/LoginHistory.jsx
@@ -2,9 +2,13 @@
 import React from "react";
 import _ from "underscore";
 import moment from "moment";
+import { t } from "ttag";
+
 import Card from "metabase/components/Card";
 import Label from "metabase/components/type/Label";
 import Text from "metabase/components/type/Text";
+import NoResults from "assets/img/no_results.svg";
+
 import {
   LoginGroup,
   LoginItemContent,
@@ -53,9 +57,20 @@ const formatItems = items =>
     };
   });
 
+const EmtpyLoginHistory = () => (
+  <div className="p5 text-centered">
+    <img src={NoResults} className="mb2" />
+    <Text color="medium">{t`No logins`}</Text>
+  </div>
+);
+
 function LoginHistoryList({ loginHistory }) {
   const items = formatItems(loginHistory);
   const groups = _.groupBy(items, item => item.date);
+
+  if (!items || !items.length) {
+    return <EmtpyLoginHistory />;
+  }
 
   return <div>{_.map(groups, LoginHistoryGroup)}</div>;
 }

--- a/frontend/src/metabase/account/login-history/components/LoginHistory/LoginHistory.jsx
+++ b/frontend/src/metabase/account/login-history/components/LoginHistory/LoginHistory.jsx
@@ -7,6 +7,7 @@ import { t } from "ttag";
 import Card from "metabase/components/Card";
 import Label from "metabase/components/type/Label";
 import Text from "metabase/components/type/Text";
+import EmptyState from "metabase/components/EmptyState";
 import NoResults from "assets/img/no_results.svg";
 
 import {
@@ -57,19 +58,17 @@ const formatItems = items =>
     };
   });
 
-const EmtpyLoginHistory = () => (
-  <div className="text-centered">
-    <img src={NoResults} className="mb2" />
-    <Text color="medium">{t`No logins`}</Text>
-  </div>
-);
-
 function LoginHistoryList({ loginHistory }) {
   const items = formatItems(loginHistory);
   const groups = _.groupBy(items, item => item.date);
 
   if (!items || !items.length) {
-    return <EmtpyLoginHistory />;
+    return (
+      <EmptyState
+        title={t`No logins`}
+        illustrationElement={<img src={NoResults} />}
+      />
+    );
   }
 
   return <div>{_.map(groups, LoginHistoryGroup)}</div>;


### PR DESCRIPTION
## Before

When a user first spins up a metabase instance, they have no login history, and the login history tab feels "broken" instead of "empty".



## After

To test: 

1. start up a new metabase instance
2. visit account settings
3. click the login history tab
4. see a nice message instead of blank space

Resolves https://github.com/metabase/metabase/issues/15442

![Screenshot from 2022-04-25 09-10-33](https://user-images.githubusercontent.com/30528226/165119524-ff04b2ac-0883-4398-b502-f224bf705707.png)

