### PR TITLE
fix member input width

### DIFF
--- a/frontend/src/metabase/admin/people/components/AddMemberRow.jsx
+++ b/frontend/src/metabase/admin/people/components/AddMemberRow.jsx
@@ -48,7 +48,7 @@ export default function AddMemberRow({ users, excludeIds, onCancel, onDone }) {
 
   return (
     <tr>
-      <td colSpan="3" style={{ padding: 0 }}>
+      <td colSpan="4" style={{ padding: 0 }}>
         <AddRow
           ref={rowRef}
           value={text}

--- a/frontend/src/metabase/admin/people/components/MembershipSelect/MembershipSelect.tsx
+++ b/frontend/src/metabase/admin/people/components/MembershipSelect/MembershipSelect.tsx
@@ -100,8 +100,8 @@ export const MembershipSelect = ({
   return (
     <PopoverWithTrigger triggerElement={triggerElement}>
       <MembershipSelectContainer>
-        {groupSections.map(section => (
-          <>
+        {groupSections.map((section, index) => (
+          <React.Fragment key={index}>
             {section.header && (
               <MembershipSelectHeader>{section.header}</MembershipSelectHeader>
             )}
@@ -140,7 +140,7 @@ export const MembershipSelect = ({
                 </MembershipSelectItem>
               );
             })}
-          </>
+          </React.Fragment>
         ))}
       </MembershipSelectContainer>
     </PopoverWithTrigger>


### PR DESCRIPTION
## Changes

Fix add member input width

**Before**
<img width="786" alt="Screenshot 2022-04-25 at 13 17 47" src="https://user-images.githubusercontent.com/14301985/165059514-3114ad45-d2bc-4eb2-8035-ef5023376414.png">

**After**
<img width="827" alt="Screenshot 2022-04-25 at 13 17 30" src="https://user-images.githubusercontent.com/14301985/165059582-7eadfa8a-d535-4721-9c0c-fe74b5d5cabd.png">

## How to verify

- Go to Admin -> People -> Groups
- Select any group and click "Add member"
- Ensure the input looks good on both OSS and EE