### PR TITLE
[E2E] Remove `dashboard-filters` check from CCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1255,7 +1255,6 @@ workflows:
                   "collections",
                   "custom-column",
                   "dashboard",
-                  "dashboard-filters",
                   "embedding",
                   "joins",
                   "models",


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
In the same manner we did for #21785, this PR:
- Removes `dashboard-filters` E2E group from CircleCI because we've been running it successfully using GitHub actions.