### PR TITLE
Repro #21979: Filtering "Exclude" shows wrong weekday

### DIFF
--- a/frontend/test/metabase/scenarios/question/question-reproductions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/question-reproductions.cy.spec.js
@@ -18,6 +18,7 @@ import { issue19742 } from "./reproductions/19742-data-picker-closes-after-hidin
 import { issue20551 } from "./reproductions/20551-filter-starts-with";
 import { issue20627 } from "./reproductions/20627-nested-long-names-wrong-aliases";
 import { issue20683 } from "./reproductions/20683-postgres-current-quarter";
+import { issue21979 } from "./reproductions/21979-exclude-day-of-the-week";
 
 issue4482();
 issue6239();
@@ -39,3 +40,4 @@ issue19742();
 issue20551();
 issue20627();
 issue20683();
+issue21979();

--- a/frontend/test/metabase/scenarios/question/reproductions/21979-exclude-day-of-the-week.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/21979-exclude-day-of-the-week.js
@@ -1,0 +1,54 @@
+import {
+  restore,
+  openProductsTable,
+  visualize,
+  popover,
+} from "__support__/e2e/cypress";
+
+export function issue21979() {
+  describe.skip("issue 21979", () => {
+    beforeEach(() => {
+      restore();
+      cy.signInAsAdmin();
+      openProductsTable({ mode: "notebook" });
+    });
+
+    it("exclude 'day of the week' should show the correct day reference in the UI (metabase#21979)", () => {
+      cy.findByText("Filter").click();
+      cy.findByText("Created At").click();
+
+      cy.findByText("Exclude...").click();
+      cy.findByText("Days of the week...").click();
+
+      popover().within(() => {
+        cy.findByText("Monday").click();
+
+        cy.button("Add filter").click();
+      });
+
+      cy.log("Make sure the filter references correct day in the UI");
+      cy.findByText("Created At excludes Monday");
+
+      visualize();
+
+      cy.log("Make sure the query is correct");
+
+      // One of the products created on Monday
+      cy.findByText("Enormous Marble Wallet").should("not.exist");
+
+      cy.log("Make sure we can re-enable the exluded filter");
+
+      cy.findByText("Created At excludes Monday").click();
+
+      popover().within(() => {
+        cy.findByText("Monday").click();
+
+        cy.button("Add filter").click();
+      });
+
+      visualize();
+
+      cy.findByText("Enormous Marble Wallet");
+    });
+  });
+}


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #21979 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/question/reproductions/21979-exclude-day-of-the-week.js`
- Replace `describe.skip()` with `describe.only()` to run the test in isolation
- Open and run `metabase/scenarios/question/question-reproductions.cy.spec.js`
- The test should fail until the related issue gets fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/165088270-b3cd189c-055d-4061-be4a-8993f5ba0257.png)

