### PR TITLE
Fix question details sidebar border

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/moderation/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/index.js
@@ -12,6 +12,7 @@ import {
 
 if (hasPremiumFeature("content_management")) {
   Object.assign(PLUGIN_MODERATION, {
+    isEnabled: () => true,
     QuestionModerationSection,
     ModerationStatusIcon,
     getStatusIconForQuestion,

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -103,6 +103,7 @@ export const PLUGIN_COLLECTION_COMPONENTS = {
 };
 
 export const PLUGIN_MODERATION = {
+  isEnabled: () => false,
   QuestionModerationSection: PluginPlaceholder,
   ModerationStatusIcon: PluginPlaceholder,
   getStatusIconForQuestion: object,

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebarPanel.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebarPanel.jsx
@@ -38,6 +38,9 @@ function QuestionDetailsSidebarPanel({
       }
     : undefined;
 
+  const hasSecondarySection =
+    (isDataset && canWrite) || (!isDataset && PLUGIN_MODERATION.isEnabled());
+
   return (
     <Container>
       <SidebarPaddedContent>
@@ -53,18 +56,20 @@ function QuestionDetailsSidebarPanel({
           description={description}
           onEdit={onDescriptionEdit}
         />
-        <BorderedSectionContainer>
-          {isDataset && canWrite && (
-            <DatasetManagementSection dataset={question} />
-          )}
-          {!isDataset && (
-            <ModerationSectionContainer>
-              <PLUGIN_MODERATION.QuestionModerationSection
-                question={question}
-              />
-            </ModerationSectionContainer>
-          )}
-        </BorderedSectionContainer>
+        {hasSecondarySection && (
+          <BorderedSectionContainer>
+            {isDataset && canWrite && (
+              <DatasetManagementSection dataset={question} />
+            )}
+            {!isDataset && (
+              <ModerationSectionContainer>
+                <PLUGIN_MODERATION.QuestionModerationSection
+                  question={question}
+                />
+              </ModerationSectionContainer>
+            )}
+          </BorderedSectionContainer>
+        )}
       </SidebarPaddedContent>
       <QuestionActivityTimeline question={question} />
     </Container>


### PR DESCRIPTION
This is a cosmetic fix for the question details sidebar. The details sidebar for questions and models has an action bar + a clickable description. But for models and questions with BUCM enabled we also display another set of actions that's separated by a horizontal divider. It only makes sense to show the divider if there's content below it, but at the moment it's displayed all the time. This PR makes it show the divider only if there's some content below it.

### To Verify

1. Spin up Metabase OSS
2. Open a question, click its title to open the sidebar, ensure there's no divider
3. Open a model, click its title to open the sidebar, ensure there's a divider under the "model management" section
4. Spin up Metabase EE
5. Open a question, click its title to open the sidebar, ensure there's a divider under the "verify" action/status
6. Open a model, click its title to open the sidebar, ensure there's a divider under the "model management" section

### Demo

**Before**

![CleanShot 2022-04-25 at 13 29 30@2x](https://user-images.githubusercontent.com/17258145/165089169-b24dcb71-ea79-4304-b805-aa407902e24d.png)

**After**

<details>
<summary>Question OSS</summary>
<img width="362" alt="after-question" src="https://user-images.githubusercontent.com/17258145/165089295-12251294-f471-4d73-a589-0371a16b4c76.png">

</details>

<details>
<summary>Question BUCM</summary>
<img width="358" alt="CleanShot 2022-04-25 at 13 23 44@2x" src="https://user-images.githubusercontent.com/17258145/165089321-438feb79-4f87-4b0c-9ad9-aa4fc0422902.png">

</details>

<details>
<summary>Model</summary>
<img width="357" alt="after-model" src="https://user-images.githubusercontent.com/17258145/165089308-565b3774-9afd-46b2-b7ec-52c0118ed7e6.png">

</details>