### PR TITLE
Clear browser caches when logging out

### DIFF
--- a/frontend/src/metabase/auth/actions.ts
+++ b/frontend/src/metabase/auth/actions.ts
@@ -78,7 +78,7 @@ export const logout = createThunkAction(LOGOUT, () => {
     trackLogout();
 
     dispatch(push("/auth/login"));
-    window.location.reload();
+    window.location.reload(); // clears redux state and browser caches
   };
 });
 

--- a/frontend/src/metabase/auth/actions.ts
+++ b/frontend/src/metabase/auth/actions.ts
@@ -78,6 +78,7 @@ export const logout = createThunkAction(LOGOUT, () => {
     trackLogout();
 
     dispatch(push("/auth/login"));
+    window.location.reload();
   };
 });
 


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/21974

How to test:
- Follow the steps from the issue

Please note that this PR simply reverts removing of `window.location.reload()` that was present before. Just to be on the safe side, I don't want to try something more complex right now.