### PR TITLE
Fix opening details sidebar from notebook mode

### DIFF
--- a/frontend/src/metabase/query_builder/reducers.js
+++ b/frontend/src/metabase/query_builder/reducers.js
@@ -114,22 +114,34 @@ const CLOSED_NATIVE_EDITOR_SIDEBARS = {
   isShowingTimelineSidebar: false,
 };
 
-// various ui state options
+function setUIControls(state, changes) {
+  const { queryBuilderMode: currentQBMode, ...currentState } = state;
+  const { queryBuilderMode: nextQBMode, ...nextStateChanges } = changes;
+
+  const isChangingQBMode = nextQBMode && currentQBMode !== nextQBMode;
+  const isOpeningEditingQBMode = isChangingQBMode && nextQBMode !== "view";
+
+  const queryBuilderMode = nextQBMode || currentQBMode;
+  const previousQueryBuilderMode = isChangingQBMode
+    ? currentQBMode
+    : state.previousQueryBuilderMode;
+
+  // Close all the sidebars when entering notebook/dataset QB modes
+  const extraState = isOpeningEditingQBMode ? UI_CONTROLS_SIDEBAR_DEFAULTS : {};
+
+  return {
+    ...currentState,
+    ...extraState,
+    ...nextStateChanges,
+    queryBuilderMode,
+    previousQueryBuilderMode,
+  };
+}
+
 export const uiControls = handleActions(
   {
     [SET_UI_CONTROLS]: {
-      next: (
-        { queryBuilderMode: currentQBMode, ...state },
-        { payload: { queryBuilderMode: nextQBMode, ...payload } },
-      ) => ({
-        ...state,
-        ...payload,
-        queryBuilderMode: nextQBMode || currentQBMode,
-        previousQueryBuilderMode:
-          nextQBMode && currentQBMode !== nextQBMode
-            ? currentQBMode
-            : state.previousQueryBuilderMode,
-      }),
+      next: (state, { payload }) => setUIControls(state, payload),
     },
 
     [RESET_UI_CONTROLS]: {
@@ -262,12 +274,13 @@ export const uiControls = handleActions(
       ...state,
       ...UI_CONTROLS_SIDEBAR_DEFAULTS,
     }),
-    [onOpenQuestionDetails]: state => ({
-      ...state,
-      ...UI_CONTROLS_SIDEBAR_DEFAULTS,
-      isShowingQuestionDetailsSidebar: true,
-      questionDetailsTimelineDrawerState: undefined,
-    }),
+    [onOpenQuestionDetails]: state =>
+      setUIControls(state, {
+        ...UI_CONTROLS_SIDEBAR_DEFAULTS,
+        isShowingQuestionDetailsSidebar: true,
+        questionDetailsTimelineDrawerState: undefined,
+        queryBuilderMode: "view",
+      }),
     [onCloseQuestionDetails]: (
       state,
       { payload: { closeOtherSidebars } = {} } = {},
@@ -285,12 +298,13 @@ export const uiControls = handleActions(
         questionDetailsTimelineDrawerState: undefined,
       };
     },
-    [onOpenQuestionHistory]: state => ({
-      ...state,
-      ...UI_CONTROLS_SIDEBAR_DEFAULTS,
-      isShowingQuestionDetailsSidebar: true,
-      questionDetailsTimelineDrawerState: "open",
-    }),
+    [onOpenQuestionHistory]: state =>
+      setUIControls(state, {
+        ...UI_CONTROLS_SIDEBAR_DEFAULTS,
+        isShowingQuestionDetailsSidebar: true,
+        questionDetailsTimelineDrawerState: "open",
+        queryBuilderMode: "view",
+      }),
     [onCloseQuestionHistory]: state => ({
       ...state,
       ...UI_CONTROLS_SIDEBAR_DEFAULTS,


### PR DESCRIPTION
This PR makes it close the notebook view when clicking the saved question title which usually opens the details sidebar.

### To Verify

1. New > Question > Sample Dataset > Orders
2. Save the question without leaving the notebook editor
3. Click the question name at the top left
4. Ensure the notebook is closed and you can see the details sidebar open
5. Open the notebook editor again (click the icon at the top right)
6. Click the question name again
7. Ensure the notebook is closed and you can see the details sidebar open

### Demo

**Before**

https://user-images.githubusercontent.com/17258145/165094080-88c0529b-1ea8-4085-bfec-db58e6227a99.mp4

**After**

https://user-images.githubusercontent.com/17258145/165094098-4ba32030-a981-48bc-9913-cf1ee70d5b65.mp4


