### PR TITLE
Use grab/grabbing cursor style when sorting bookmarks

### DIFF
--- a/frontend/src/metabase/nav/containers/MainNavbar/BookmarkList/BookmarkList.styled.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/BookmarkList/BookmarkList.styled.tsx
@@ -16,6 +16,7 @@ export const DragIcon = styled(Icon)`
   position: absolute;
   top: 50%;
   transform: translateY(-50%);
+  cursor: grab;
 `;
 
 export const SidebarBookmarkItem = styled(SidebarLink)<SidebarBookmarkItem>`

--- a/frontend/src/metabase/nav/containers/MainNavbar/BookmarkList/BookmarkList.styled.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/BookmarkList/BookmarkList.styled.tsx
@@ -2,7 +2,6 @@ import styled from "@emotion/styled";
 import { css } from "@emotion/react";
 
 import { color } from "metabase/lib/colors";
-import { space } from "metabase/styled-components/theme";
 
 import Icon from "metabase/components/Icon";
 import { SidebarLink } from "../SidebarItems";

--- a/frontend/src/metabase/nav/containers/MainNavbar/BookmarkList/BookmarkList.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/BookmarkList/BookmarkList.tsx
@@ -136,7 +136,7 @@ const BookmarkList = ({
       headerClass="mb1"
       onToggle={onToggleBookmarks}
     >
-      <SortableListOfBookmarks
+      <SortableBookmarkList
         distance={9}
         onSortStart={handleSortStart}
         onSortEnd={handleSortEnd}
@@ -154,14 +154,15 @@ const BookmarkList = ({
             onDeleteBookmark={onDeleteBookmark}
           />
         ))}
-      </SortableListOfBookmarks>
+      </SortableBookmarkList>
     </CollapseSection>
   );
 };
 
 const List = ({ children }: { children: JSX.Element[] }) => <ul>{children}</ul>;
 const Item = ({ children }: { children: JSX.Element }) => <>{children}</>;
+
 const SortableBookmarkItem = SortableElement(Item);
-const SortableListOfBookmarks = SortableContainer(List);
+const SortableBookmarkList = SortableContainer(List);
 
 export default connect(null, mapDispatchToProps)(BookmarkList);

--- a/frontend/src/metabase/nav/containers/MainNavbar/BookmarkList/BookmarkList.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/BookmarkList/BookmarkList.tsx
@@ -116,11 +116,13 @@ const BookmarkList = ({
   }, []);
 
   const handleSortStart = useCallback(() => {
+    document.body.classList.add("grabbing");
     setIsSorting(true);
   }, []);
 
   const handleSortEnd = useCallback(
     ({ newIndex, oldIndex }) => {
+      document.body.classList.remove("grabbing");
       setIsSorting(false);
       reorderBookmarks({ newIndex, oldIndex });
     },

--- a/frontend/src/metabase/nav/containers/MainNavbar/BookmarkList/BookmarkList.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/BookmarkList/BookmarkList.tsx
@@ -115,20 +115,17 @@ const BookmarkList = ({
     localStorage.setItem("shouldDisplayBookmarks", String(isVisible));
   }, []);
 
-  const handleSortStart = () => {
+  const handleSortStart = useCallback(() => {
     setIsSorting(true);
-  };
+  }, []);
 
-  const handleSortEnd = ({
-    newIndex,
-    oldIndex,
-  }: {
-    newIndex: number;
-    oldIndex: number;
-  }) => {
-    setIsSorting(false);
-    reorderBookmarks({ newIndex, oldIndex });
-  };
+  const handleSortEnd = useCallback(
+    ({ newIndex, oldIndex }) => {
+      setIsSorting(false);
+      reorderBookmarks({ newIndex, oldIndex });
+    },
+    [reorderBookmarks],
+  );
 
   return (
     <CollapseSection

--- a/frontend/src/metabase/nav/containers/MainNavbar/BookmarkList/BookmarkList.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/BookmarkList/BookmarkList.tsx
@@ -8,7 +8,6 @@ import "./sortable.css";
 import {
   SortableContainer,
   SortableElement,
-  SortableHandle,
 } from "metabase/components/sortable";
 import CollapseSection from "metabase/components/CollapseSection";
 import Icon from "metabase/components/Icon";


### PR DESCRIPTION
Adds `cursor: grab/grabbing` CSS for sidebar bookmark elements instead of just pointers. Also does a small clean up of surrounding components.

### To Verify

1. Bookmark a few items
2. Hover one of the bookmarks, you should see a "handle" appearing on the left
3. Hover the handle, the cursor should become "grab"
4. Grab the bookmark and start dragging it here and there, the cursor should change to "grabbing"
5. Release the bookmark wherever you want, the cursor should reset to a default one

### Demo

![CleanShot 2022-04-25 at 15 03 04](https://user-images.githubusercontent.com/17258145/165105666-669e07c2-7852-4652-ba78-9f42ad3f7e45.gif)

