### PR TITLE
Fix following an FK from object detail view

### DIFF
--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectRelationships.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectRelationships.tsx
@@ -85,8 +85,9 @@ function Relationship({
   const fkCountValue = fkCountInfo?.value || 0;
   const isLoaded = fkCountInfo?.status === 1;
   const fkClickable = isLoaded && fkCountInfo.value;
+  const originTableName = fk.origin.table.display_name;
 
-  const relationName = inflect(fk.origin.table.display_name, fkCountValue);
+  const relationName = inflect(originTableName, fkCountValue);
 
   const via =
     fkCount > 1 ? (
@@ -102,7 +103,7 @@ function Relationship({
   });
 
   return (
-    <li>
+    <li data-testid={`fk-relation-${originTableName.toLowerCase()}`}>
       <div
         className={classes}
         onClick={fkClickable ? () => foreignKeyClicked(fk) : undefined}

--- a/frontend/test/metabase/scenarios/visualizations/object_detail.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/object_detail.cy.spec.js
@@ -1,4 +1,9 @@
-import { restore, popover, openPeopleTable } from "__support__/e2e/cypress";
+import {
+  restore,
+  popover,
+  openPeopleTable,
+  openProductsTable,
+} from "__support__/e2e/cypress";
 
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
@@ -78,18 +83,33 @@ describe("scenarios > question > object details", () => {
     });
   });
 
-  it("should show orders/reviews connected to a product", () => {
-    cy.visit("/browse/1");
-    cy.contains("Products").click();
-    // click on product #1's id
-    cy.contains(/^1$/).click();
-    // check that the correct counts of related tables appear
-    cy.contains("Orders")
-      .parent()
-      .contains("93");
-    cy.contains("Reviews")
-      .parent()
-      .contains("8");
+  it("should allow to browse linked entities by FKs (metabase#21757)", () => {
+    const PRODUCT_ID = 7;
+    const EXPECTED_LINKED_ORDERS_COUNT = 92;
+    const EXPECTED_LINKED_REVIEWS_COUNT = 8;
+    openProductsTable();
+
+    getFirstTableColumn()
+      .eq(7)
+      .should("contain", PRODUCT_ID)
+      .click();
+
+    cy.findByTestId("object-detail").within(() => {
+      cy.findByTestId("fk-relation-reviews").findByText(
+        EXPECTED_LINKED_REVIEWS_COUNT,
+      );
+
+      cy.findByTestId("fk-relation-orders")
+        .findByText(EXPECTED_LINKED_ORDERS_COUNT)
+        .click();
+    });
+
+    cy.wait("@dataset");
+
+    cy.findByTestId("qb-filters-panel").findByText(
+      `Product ID is ${PRODUCT_ID}`,
+    );
+    cy.findByText(`Showing ${EXPECTED_LINKED_ORDERS_COUNT} rows`);
   });
 
   it("should not offer drill-through on the object detail records (metabase#20560)", () => {


### PR DESCRIPTION
Reproduces #21757, fixes #21757

When browsing object details, clicking an FK link would always result in an incorrect query to the linked table.

### To Verify

1. New > Question > Sample Database > Products
2. Click any product's ID to open the object detail modal
3. Ensure you can see a number of linked orders and reviews on the right side of the modal
4. Let's assume the product you opened is connected to 42 orders
5. Click the "42 orders" link
6. Ensure it opened an ad-hoc question to the Orders table with a `Product ID is {{ YOUR_PRODUCT_ID }}`
7. Ensure the number of orders in query results matches the number shown in the product's object detail view (42 in this example). You can apply a "Count" summarization or check the "Showing {{ NUMBER }} rows" text in the QB view footer

### Demo

**Before**

https://user-images.githubusercontent.com/17258145/165112790-1bb2e57f-f20e-4521-8a5a-d23b61b7b6a2.mp4

**After**

https://user-images.githubusercontent.com/17258145/165112809-4406b47f-aea9-499e-95db-e6a280c41f2d.mp4


