### PR TITLE
Reload FKs when browsing object details

### DIFF
--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
@@ -110,6 +110,7 @@ export function ObjectDetailFn({
   closeObjectDetail,
 }: ObjectDetailProps): JSX.Element | null {
   const [hasNotFoundError, setHasNotFoundError] = useState(false);
+  const prevZoomedRowId = usePrevious(zoomedRowID);
   const prevData = usePrevious(data);
   const prevTableForeignKeys = usePrevious(tableForeignKeys);
 
@@ -133,6 +134,17 @@ export function ObjectDetailFn({
       window.removeEventListener("keydown", onKeyDown, true);
     };
   });
+
+  useEffect(() => {
+    if (tableForeignKeys && prevZoomedRowId !== zoomedRowID) {
+      loadObjectDetailFKReferences();
+    }
+  }, [
+    tableForeignKeys,
+    prevZoomedRowId,
+    zoomedRowID,
+    loadObjectDetailFKReferences,
+  ]);
 
   useEffect(() => {
     const queryCompleted = !prevData && data;

--- a/frontend/test/metabase/scenarios/visualizations/object_detail.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/object_detail.cy.spec.js
@@ -90,15 +90,22 @@ describe("scenarios > question > object details", () => {
     openProductsTable();
 
     getFirstTableColumn()
-      .eq(7)
-      .should("contain", PRODUCT_ID)
+      .eq(5)
+      .should("contain", 5)
       .click();
 
     cy.findByTestId("object-detail").within(() => {
+      cy.findByTestId("fk-relation-orders").findByText(97);
+      cy.findByTestId("fk-relation-reviews").findByText(4);
+      cy.findByTestId("view-next-object-detail").click();
+
+      cy.findByTestId("fk-relation-orders").findByText(88);
+      cy.findByTestId("fk-relation-reviews").findByText(5);
+      cy.findByTestId("view-next-object-detail").click();
+
       cy.findByTestId("fk-relation-reviews").findByText(
         EXPECTED_LINKED_REVIEWS_COUNT,
       );
-
       cy.findByTestId("fk-relation-orders")
         .findByText(EXPECTED_LINKED_ORDERS_COUNT)
         .click();


### PR DESCRIPTION
Fixes an issue with FKs not reloading when browsing object details via previous/next buttons. Just missed a small hook.
Please note that this requires a fix from #22013 to be merged first

### To Verify

1. New > Question > Sample Database > Products
2. Click any product ID to open the details view
3. Use previous/next buttons in the object details modal to go through the records
4. Ensure related records info gets reloaded and you see different numbers on the right side of the modal

### Demo

**Before**

https://user-images.githubusercontent.com/17258145/165116712-e1b3b0d7-baf6-450e-b65f-cec321158807.mp4

**After**

https://user-images.githubusercontent.com/17258145/165116732-f15f4a2c-a3e9-4fd5-920a-e458a5adb4c9.mp4



