### PR TITLE
Open dashboard history on last edit info click

### DIFF
--- a/frontend/src/metabase/components/Header.jsx
+++ b/frontend/src/metabase/components/Header.jsx
@@ -38,6 +38,7 @@ const propTypes = {
   setItemAttributeFn: PropTypes.func,
   onHeaderModalDone: PropTypes.func,
   onHeaderModalCancel: PropTypes.func,
+  onLastEditInfoClick: PropTypes.func,
 };
 
 const defaultProps = {
@@ -116,7 +117,7 @@ class Header extends Component {
   }
 
   render() {
-    const { item, hasBadge } = this.props;
+    const { item, hasBadge, onLastEditInfoClick } = this.props;
     const hasLastEditInfo = !!item["last-edit-info"];
 
     let titleAndDescription;
@@ -185,7 +186,12 @@ class Header extends Component {
               {hasBadge && hasLastEditInfo && (
                 <HeaderBadgesDivider>•</HeaderBadgesDivider>
               )}
-              {hasLastEditInfo && <StyledLastEditInfoLabel item={item} />}
+              {hasLastEditInfo && (
+                <StyledLastEditInfoLabel
+                  item={item}
+                  onClick={onLastEditInfoClick}
+                />
+              )}
             </HeaderBadges>
           </HeaderContent>
 

--- a/frontend/src/metabase/dashboard/containers/DashboardHeader.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardHeader.jsx
@@ -1,8 +1,10 @@
 /* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import { connect } from "react-redux";
+import { push } from "react-router-redux";
 import PropTypes from "prop-types";
 import { t } from "ttag";
+
 import ActionButton from "metabase/components/ActionButton";
 import Button from "metabase/core/components/Button";
 import Header from "metabase/components/Header";
@@ -31,6 +33,7 @@ const mapStateToProps = (state, props) => {
 const mapDispatchToProps = {
   createBookmark: id => Bookmark.actions.create({ id, type: "dashboard" }),
   deleteBookmark: id => Bookmark.actions.delete({ id, type: "dashboard" }),
+  onChangeLocation: push,
 };
 
 @Bookmark.loadList()
@@ -70,6 +73,8 @@ export default class DashboardHeader extends Component {
     onFullscreenChange: PropTypes.func.isRequired,
 
     onSharingClick: PropTypes.func.isRequired,
+
+    onChangeLocation: PropTypes.func.isRequired,
   };
 
   handleEdit(dashboard) {
@@ -369,7 +374,7 @@ export default class DashboardHeader extends Component {
   }
 
   render() {
-    const { dashboard } = this.props;
+    const { dashboard, location, onChangeLocation } = this.props;
 
     return (
       <Header
@@ -385,6 +390,9 @@ export default class DashboardHeader extends Component {
         editingTitle={t`You're editing this dashboard.`}
         editingButtons={this.getEditingButtons()}
         setItemAttributeFn={this.props.setDashboardAttribute}
+        onLastEditInfoClick={() =>
+          onChangeLocation(`${location.pathname}/history`)
+        }
       />
     );
   }


### PR DESCRIPTION
Makes it open a dashboard revision history modal when you click the last edit info label on the dashboard page

### To Verify

1. Open any dashboard
2. Click "Edited {{ time }} ago by {{ user }}" label in the dashboard header
3. Ensure the revision history model is open

### Demo

https://user-images.githubusercontent.com/17258145/165118887-3a1b801c-dd2c-4fdc-bbf7-276d350114ac.mp4


