### PR TITLE
Fix broken relative datetime filter "Current"

### DIFF
--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RelativeDatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RelativeDatePicker.tsx
@@ -80,7 +80,7 @@ export function CurrentPicker(props: CurrentPickerProps) {
     className,
     primaryColor,
     onCommit,
-    filter: [operator, field, intervals, unit],
+    filter: [operator, field, _intervals, unit],
   } = props;
   return (
     <div className={className}>
@@ -99,7 +99,7 @@ export function CurrentPicker(props: CurrentPickerProps) {
                 primaryColor={primaryColor}
                 selected={operator && unit === period.toLowerCase()}
                 onClick={() => {
-                  onCommit([operator, field, intervals, period]);
+                  onCommit([operator, field, "current", period]);
                 }}
               >
                 {formatBucketing(period, 1)}

--- a/frontend/test/metabase/scenarios/question/relative-datetime.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/relative-datetime.cy.spec.js
@@ -125,7 +125,7 @@ describe("scenarios > question > relative-datetime", () => {
       });
     });
 
-    it("current filters should work", () => {
+    it("current filters should work (metabase#21977)", () => {
       openOrdersTable();
 
       cy.intercept("POST", "/api/dataset").as("dataset");


### PR DESCRIPTION
Fixes #21977
Reproduces #21977

### Optimizations

Moved the `relative-datetime.cy.spec` setup code so it's executed per group instead of per test