### PR TITLE
Missing Oracle and Vertica in the official drivers list

### DIFF
--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -330,7 +330,7 @@
 
 (def official-drivers
   "The set of all official drivers"
-  #{"bigquery-cloud-sdk" "druid" "googleanalytics" "h2" "mongo" "mysql" "postgres" "presto" "presto-jdbc" "redshift" "snowflake" "sparksql" "sqlite" "sqlserver"})
+  #{"bigquery-cloud-sdk" "druid" "googleanalytics" "h2" "mongo" "mysql" "oracle" "postgres" "presto" "presto-jdbc" "redshift" "snowflake" "sparksql" "sqlite" "sqlserver" "vertica"})
 
 (def partner-drivers
   "The set of other drivers in the partnership program"


### PR DESCRIPTION
These two were mistakenly skipped in PR #21409.

Long term solution: don't hard-code the list, follow the suggestion from @camsaul to enumerate `modules/drivers` at compile time. 