### PR TITLE
Change default "Relative dates..." datetime filter from "Current" to "Past" 

### DIFF
--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePickerShortcuts.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePickerShortcuts.tsx
@@ -125,7 +125,7 @@ const MISC_OPTIONS: Option[] = [
   },
   {
     displayName: t`Relative dates...`,
-    init: filter => ["time-interval", getDateTimeField(filter[1]), null],
+    init: filter => ["time-interval", getDateTimeField(filter[1]), -7, "day"],
   },
 ];
 

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePickerShortcuts.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePickerShortcuts.tsx
@@ -125,7 +125,7 @@ const MISC_OPTIONS: Option[] = [
   },
   {
     displayName: t`Relative dates...`,
-    init: filter => ["time-interval", getDateTimeField(filter[1]), -7, "day"],
+    init: filter => ["time-interval", getDateTimeField(filter[1]), -30, "day"],
   },
 ];
 

--- a/frontend/test/metabase/scenarios/question/relative-datetime.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/relative-datetime.cy.spec.js
@@ -133,6 +133,7 @@ describe("scenarios > question > relative-datetime", () => {
       popover().within(() => {
         cy.findByText("Filter by this column").click();
         cy.findByText("Relative dates...").click();
+        cy.findByText("Current").click();
         cy.findByText("Year").click();
       });
       cy.wait("@dataset");
@@ -141,6 +142,21 @@ describe("scenarios > question > relative-datetime", () => {
         "not.exist",
       );
       cy.findByText("No results!").should("exist");
+    });
+
+    it("Relative dates should default to past filter (metabase#22027)", () => {
+      openOrdersTable();
+
+      cy.findByTextEnsureVisible("Created At").click();
+      popover().within(() => {
+        cy.findByText("Filter by this column").click();
+        cy.findByText("Relative dates...").click();
+        cy.findByText("Day").should("not.exist");
+        cy.findByText("Quarter").should("not.exist");
+        cy.findByText("Month").should("not.exist");
+        cy.findByText("Year").should("not.exist");
+        cy.findByText("days").should("exist");
+      });
     });
   });
 });


### PR DESCRIPTION
Fixes #22027
Reproduces #22027

### Reproduction
1. Open `Orders` table
2. Click `Created At` column in the table
3. `Filter by this column`
4. `Relative dates...`

You should see the `Past` filter tab by default instead of the `Current` tab