### PR TITLE
return download results button to publicly shared questions

### DIFF
--- a/frontend/src/metabase/public/containers/PublicQuestion.jsx
+++ b/frontend/src/metabase/public/containers/PublicQuestion.jsx
@@ -3,6 +3,7 @@ import React, { Component } from "react";
 import { connect } from "react-redux";
 
 import Visualization from "metabase/visualizations/components/Visualization";
+import QueryDownloadWidget from "metabase/query_builder/components/QueryDownloadWidget";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 import ExplicitSize from "metabase/components/ExplicitSize";
 import EmbedFrame from "../components/EmbedFrame";
@@ -172,8 +173,20 @@ export default class PublicQuestion extends Component {
   };
 
   render() {
-    const { metadata } = this.props;
+    const {
+      params: { uuid, token },
+      metadata,
+    } = this.props;
     const { card, result, initialized, parameterValues } = this.state;
+
+    const actionButtons = result && (
+      <QueryDownloadWidget
+        className="m1 text-medium-hover"
+        uuid={uuid}
+        token={token}
+        result={result}
+      />
+    );
 
     const parameters =
       card && getValueAndFieldIdPopulatedParametersFromCard(card, metadata);
@@ -182,6 +195,7 @@ export default class PublicQuestion extends Component {
       <EmbedFrame
         name={card && card.name}
         description={card && card.description}
+        actionButtons={actionButtons}
         parameters={initialized ? parameters : []}
         parameterValues={parameterValues}
         setParameterValue={this.setParameterValue}

--- a/frontend/test/metabase/scenarios/permissions/download-permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/download-permissions.cy.spec.js
@@ -5,8 +5,8 @@ import {
   assertPermissionForItem,
   modifyPermission,
   downloadAndAssert,
+  assertSheetRowsCount,
 } from "__support__/e2e/cypress";
-const xlsx = require("xlsx");
 
 const DATA_ACCESS_PERMISSION_INDEX = 0;
 const DOWNLOAD_PERMISSION_INDEX = 2;
@@ -138,14 +138,7 @@ describeEE("scenarios > admin > permissions", () => {
 
     downloadAndAssert(
       { fileType: "xlsx", questionId },
-      getRowsCountAssertion(10000),
+      assertSheetRowsCount(10000),
     );
   });
 });
-
-function getRowsCountAssertion(expectedCount) {
-  return sheet => {
-    const range = xlsx.utils.decode_range(sheet["!ref"]);
-    expect(range.e.r).to.eq(expectedCount);
-  };
-}

--- a/frontend/test/metabase/scenarios/sharing/public-question.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/public-question.cy.spec.js
@@ -84,15 +84,10 @@ describe("scenarios > question > public", () => {
 
     cy.createNativeQuestion(questionData).then(({ body: { id } }) => {
       enableSharingQuestion(id);
-
       visitQuestion(id);
-      // Make sure metadata fully loaded before we continue
-      cy.wait("@cardQuery");
 
       cy.icon("share").click();
-
       visitPublicURL();
-
       cy.icon("download").click();
 
       cy.url().then(url => {

--- a/frontend/test/metabase/scenarios/sharing/public-question.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/public-question.cy.spec.js
@@ -1,4 +1,10 @@
-import { restore, filterWidget, visitQuestion } from "__support__/e2e/cypress";
+import {
+  restore,
+  filterWidget,
+  visitQuestion,
+  downloadAndAssert,
+  assertSheetRowsCount,
+} from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { PEOPLE } = SAMPLE_DATABASE;
@@ -66,6 +72,38 @@ describe("scenarios > question > public", () => {
     cy.wait("@publicQuery");
     // Name of a city from the expected results
     cy.findByText("Winner");
+  });
+
+  it("allows downloading publicly shared questions (metabase#21993)", () => {
+    const questionData = {
+      name: "21993",
+      native: {
+        query: "select * from orders",
+      },
+    };
+
+    cy.createNativeQuestion(questionData).then(({ body: { id } }) => {
+      enableSharingQuestion(id);
+
+      visitQuestion(id);
+      // Make sure metadata fully loaded before we continue
+      cy.wait("@cardQuery");
+
+      cy.icon("share").click();
+
+      visitPublicURL();
+
+      cy.icon("download").click();
+
+      cy.url().then(url => {
+        const publicUid = url.split("/").pop();
+
+        downloadAndAssert(
+          { fileType: "xlsx", questionId: id, publicUid },
+          assertSheetRowsCount(18760),
+        );
+      });
+    });
   });
 });
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/21993
Reproduces https://github.com/metabase/metabase/issues/21993

We intentionally removed the download results button from publicly shared questions but then agreed to revert that.

### How to verify
- Check the linked issue steps