### PR TITLE
Ensure the correct type on revision.timestamp (for release-x.43.x)

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -11480,6 +11480,16 @@ databaseChangeLog:
               SET object = REPLACE(object, '/general/', '/application/')
               WHERE object LIKE '/general/%';
 
+  - changeSet:
+      id: v43.00-062
+      author: snoe
+      comment: Added 0.43.0 - Unify datatype with revision.timestamp for timezone info (see 17829).
+      changes:
+        - modifyDataType:
+            tableName: revision
+            columnName: timestamp
+            newDataType: ${timestamp_type}
+
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################


### PR DESCRIPTION
Cherry picked from https://github.com/metabase/metabase/pull/21959
