### PR TITLE
Remove subscription button on Fullscreen

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashboardActions.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardActions.jsx
@@ -50,7 +50,7 @@ export const getDashboardActions = (
 
   if (!isEditing && !isEmpty && !isPublic) {
     // Getting notifications with static text-only cards doesn't make a lot of sense
-    if (canCreateSubscription) {
+    if (canCreateSubscription && !isFullscreen) {
       buttons.push(
         <Tooltip tooltip={t`Subscriptions`} key="dashboard-subscriptions">
           <span>


### PR DESCRIPTION
Fixes #21990 

Adding a quick condition to not push the subscription button if isFullScreen is true

<img width="710" alt="chrome_nnFnNygjIb" src="https://user-images.githubusercontent.com/1328979/165168304-462bb5cf-8687-4366-988a-d049d4256086.png">

(App bar and scroll bar will be resolved with #21992)