### PR TITLE
fix permissions layout

### DIFF
--- a/frontend/src/metabase/admin/permissions/components/PermissionsSelect/PermissionsSelect.styled.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsSelect/PermissionsSelect.styled.jsx
@@ -9,7 +9,7 @@ import { PermissionsSelectOption } from "./PermissionsSelectOption";
 export const PermissionsSelectRoot = styled.div`
   display: flex;
   align-items: center;
-  width: 180px;
+  min-width: 180px;
   cursor: ${props => (props.isDisabled ? "default" : "pointer")};
 `;
 

--- a/frontend/src/metabase/admin/permissions/components/PermissionsTable/PermissionsTable.styled.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsTable/PermissionsTable.styled.jsx
@@ -17,8 +17,6 @@ export const PermissionsTableCell = styled.td`
   overflow: hidden;
 
   &:first-of-type {
-    width: 1%;
-    white-space: nowrap;
     max-width: 300px;
     background: white;
     left: 0;


### PR DESCRIPTION
## Changes

Fix permissions are too spread when there are a few of them on a wide screen

Before
<img width="1361" alt="Screenshot 2022-04-26 at 00 51 30" src="https://user-images.githubusercontent.com/14301985/165173028-94fd8843-a8f8-49c8-9d00-b3705cb57bb2.png">

After
<img width="1012" alt="Screenshot 2022-04-26 at 00 50 20" src="https://user-images.githubusercontent.com/14301985/165173048-4bd14748-9db8-44ca-a1cb-7be902c51adc.png">

## How to verify

- Open all [permissions pages](http://localhost:3000/admin/permissions)
- Ensure it the permissions table looks good