### PR TITLE
Sticky permissions table header

### DIFF
--- a/frontend/src/metabase/admin/permissions/components/PermissionsEditor/PermissionsEditor.styled.js
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsEditor/PermissionsEditor.styled.js
@@ -4,5 +4,5 @@ export const PermissionsEditorRoot = styled.div`
   flex-grow: 1;
   position: relative;
   overflow: auto;
-  padding: 1rem 0 2rem 0;
+  padding: 1rem 0 0 0;
 `;

--- a/frontend/src/metabase/admin/permissions/components/PermissionsEditor/PermissionsEditorContent.styled.tsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsEditor/PermissionsEditorContent.styled.tsx
@@ -1,7 +1,10 @@
 import styled from "@emotion/styled";
 
 export const PermissionEditorContentRoot = styled.div`
+  display: flex;
+  flex-direction: column;
   padding-left: 40px;
+  height: 100%;
 `;
 
 export const EditorFilterContainer = styled.div`
@@ -15,6 +18,7 @@ export const EditorEmptyStateContainer = styled.div`
 
 export const PermissionTableWrapper = styled.div`
   position: relative;
+  flex: 1;
   overflow-x: auto;
-  padding-bottom: 20px;
+  padding-bottom: 2rem;
 `;

--- a/frontend/src/metabase/admin/permissions/components/PermissionsTable/PermissionsTable.styled.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsTable/PermissionsTable.styled.jsx
@@ -5,8 +5,21 @@ import Link from "metabase/core/components/Link";
 import Icon from "metabase/components/Icon";
 import Label from "metabase/components/type/Label";
 
+const tableBorder = `1px solid ${alpha(color("border"), 0.5)}`;
+
+// background with 1px of border color at the bottom
+// to work properly with sticky positioning
+const headerBackground = `linear-gradient(to top, ${alpha(
+  color("border"),
+  0.5,
+)}, ${alpha(color("border"), 0.5)} 1px, ${color("white")} 1px, ${color(
+  "white",
+)} 100%)`;
+
 export const PermissionsTableRoot = styled.table`
   border-collapse: collapse;
+  max-height: 100%;
+  overflow-y: auto;
 `;
 
 export const PermissionsTableCell = styled.td`
@@ -32,7 +45,7 @@ export const PermissionsTableCell = styled.td`
       right: 0;
       top: 0;
       height: 100%;
-      border-right: 1px solid ${alpha(color("border"), 0.5)};
+      border-right: ${tableBorder};
       content: " ";
     }
   }
@@ -41,7 +54,15 @@ export const PermissionsTableCell = styled.td`
 export const PermissionTableHeaderCell = styled(
   PermissionsTableCell.withComponent("th"),
 )`
+  position: sticky;
+  top: 0;
+  border: none;
+  background: ${headerBackground};
+  z-index: 1;
+
   &:first-of-type {
+    background: ${headerBackground};
+    z-index: 2;
     &:after {
       display: none;
     }
@@ -49,8 +70,7 @@ export const PermissionTableHeaderCell = styled(
 `;
 
 export const PermissionsTableRow = styled.tr`
-  border-top: 1px solid ${alpha(color("border"), 0.5)};
-  border-bottom: 1px solid ${alpha(color("border"), 0.5)};
+  border-bottom: ${tableBorder};
 `;
 
 export const EntityName = styled.span`


### PR DESCRIPTION
## Problem

If you have a lot of databases or groups, the permissions table can get a little hard to use when scrolling down

## Solution

Constrain the height of the permissions table and make the headers sticky, resolves #21851 



![Screenshot from 2022-04-25 14-03-46](https://user-images.githubusercontent.com/30528226/165178275-a1369e4a-41a1-4b63-bc56-bf88ccc1b2c2.png)

https://user-images.githubusercontent.com/30528226/165178321-bd6273b1-211b-4536-930f-773732344006.mp4

