### PR TITLE
fix links with slashes

### DIFF
--- a/frontend/src/metabase/lib/urls/browse.ts
+++ b/frontend/src/metabase/lib/urls/browse.ts
@@ -16,7 +16,9 @@ export function browseDatabase(database: Database) {
 
 export function browseSchema(table: Table) {
   const databaseId = table.db?.id || table.db_id;
-  return `/browse/${databaseId}/schema/${table.schema_name}`;
+  return `/browse/${databaseId}/schema/${encodeURIComponent(
+    table.schema_name ?? "",
+  )}`;
 }
 
 export function browseTable(table: Table) {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/15454

## Changes

Fixes two more places where we have links leading to the schema browse page.

## How to verify

- Connect a db that contains schemas with slashes 
- Check schema links work in search and question location
<img src="https://user-images.githubusercontent.com/1447303/164510923-3b47127d-6e46-4476-806f-19fd974e170c.png" />
