### PR TITLE
Bump bigquery version to first version that supports SNAPSHOT tables

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/deps.edn
+++ b/modules/drivers/bigquery-cloud-sdk/deps.edn
@@ -3,4 +3,4 @@
 
  :deps
  ;; TODO: figure out how to be able to leave off this version string and use the version from the BOM
- {com.google.cloud/google-cloud-bigquery {:mvn/version "1.131.1"}}}
+ {com.google.cloud/google-cloud-bigquery {:mvn/version "1.135.4"}}}


### PR DESCRIPTION
Fixes #19860

SNAPSHOT tables in bigquery hold diffs from an underlying table:
https://cloud.google.com/bigquery/docs/table-snapshots-intro. But the
support in the sdk only came in 1.135.0 :
https://github.com/googleapis/java-bigquery/blob/main/CHANGELOG.md#11350-2021-06-28

I picked the most recent 1.135 version.

Running

```shell
clj -A:dev:ee:ee-dev:drivers:drivers-dev -Stree
```

Shows conflicts on

```
X google-http-client-jackson2 1.39.2 :older-version
; using 1.39.2-sp.1 from google analytics

X com.fasterxml.jackson.core/jackson-core 2.12.3 :older-version
; from cheshire we have 2.12.4

X com.google.http-client/google-http-client 1.39.2 :superseded
; using 1.39.2-sp.1 from google-http-client-jackson2 (1.39.2-sp1)

X commons-codec/commons-codec 1.15 :use-top
; pinned to this version at top level

X com.google.guava/guava 30.1.1-android :use-top
; pinned to 31.0.1-jre top level
```

So I think this change is quite safe. After the release we should
investigate the breaking changes that come in the 2.0.0 release and look
into getting onto 2.10.10. This version worked locally for me but I
don't want to introduce that into the release just yet.


#### Ticket Repro
From the ticket, if you copy the dataset as indicated in the issue details, you can sync and query the dataset showing this change fixes the reported issue.

These screens are not possible before this change. The enumeration of tables in the database fails. And the way it works it doesn't fail partially but it takes down the enumeration of all tables. I tried to make this safer but this is all outside of our code so we can't even really get a handle on it. It's getting an iterator and blowing up at that point, not on any transformation we are doing. The table is not queryable and the list of tables would show zero tables.

<img width="1563" alt="image" src="https://user-images.githubusercontent.com/6377293/165182335-10cc5b21-ed6f-4ea7-a606-31247d78f849.png">

<img width="1563" alt="image" src="https://user-images.githubusercontent.com/6377293/165182351-a16295d9-dd6b-45c1-a79e-1fabb9ce5f92.png">
