### PR TITLE
Fix incorrect row count translations for ru

### DIFF
--- a/locales/ru.po
+++ b/locales/ru.po
@@ -13261,10 +13261,8 @@ msgstr "Начать с"
 #: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:23
 msgid "{0} row"
 msgid_plural "{0} rows"
-msgstr[0] "строка"
-msgstr[1] "строк"
-msgstr[2] "строк"
-msgstr[3] "строки"
+msgstr[0] "{0} строка"
+msgstr[1] "{0} строки"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:29
 msgid "Show all rows"


### PR DESCRIPTION
To verify:

1. New, Question, Sample Database, Products
2. Filter by Category, e.g. `Gadget` only
3. Visualize and then save as a question. Pay attention to the row count (bottom right corner)
![image](https://user-images.githubusercontent.com/7288/165183086-d8f7c281-b0f8-4175-b4ad-5d3551458177.png)

4. Switch language to German (gear Settings, Account settings, Profile, Language). Open the previous question and look at the row count again.
![image](https://user-images.githubusercontent.com/7288/165183105-89172cd0-474e-4dd7-bd1a-894f8c46bdcf.png)


6. Switch language to Russian, open the question, and check the row count


### Before this PR

The display row count is mistaken, compared to the English and German version.

![image](https://user-images.githubusercontent.com/7288/165183071-a7d15490-0319-4b28-97df-c250a1cb7788.png)


### After this PR

Exactly as we all expect it to be.

![image](https://user-images.githubusercontent.com/7288/165183136-ca7ab460-4bdd-4bba-badd-64b242f24259.png)
