### PR TITLE
Custom expression: avoid circular reference

### DIFF
--- a/frontend/src/metabase/lib/expressions/diagnostics.js
+++ b/frontend/src/metabase/lib/expressions/diagnostics.js
@@ -34,7 +34,7 @@ export function countMatchingParentheses(tokens) {
   return tokens.reduce(count, 0);
 }
 
-export function diagnose(source, startRule, query) {
+export function diagnose(source, startRule, query, name = null) {
   if (!source || source.length === 0) {
     return null;
   }
@@ -77,15 +77,15 @@ export function diagnose(source, startRule, query) {
   }
 
   try {
-    return prattCompiler(source, startRule, query);
+    return prattCompiler(source, startRule, query, name);
   } catch (err) {
     return err;
   }
 }
 
-function prattCompiler(source, startRule, query) {
+function prattCompiler(source, startRule, query, name) {
   const tokens = lexify(source);
-  const options = { source, startRule, query };
+  const options = { source, startRule, query, name };
 
   // PARSE
   const { root, errors } = parse(tokens, {
@@ -113,8 +113,10 @@ function prattCompiler(source, startRule, query) {
       }
       return Array.isArray(segment.id) ? segment.id : ["segment", segment.id];
     } else {
+      const reference = options.name; // avoid circular reference
+
       // fallback
-      const dimension = parseDimension(name, options);
+      const dimension = parseDimension(name, { reference, ...options });
       if (!dimension) {
         throw new ResolverError(t`Unknown Field: ${name}`, node);
       }

--- a/frontend/src/metabase/lib/expressions/index.js
+++ b/frontend/src/metabase/lib/expressions/index.js
@@ -1,6 +1,6 @@
 export * from "./config";
 
-import Dimension from "metabase-lib/lib/Dimension";
+import Dimension, { ExpressionDimension } from "metabase-lib/lib/Dimension";
 import { FK_SYMBOL } from "metabase/lib/formatting";
 import {
   OPERATORS,
@@ -102,11 +102,16 @@ export function formatSegmentName(segment, options) {
 /**
  * Find dimension with matching `name` in query. TODO - How is this "parsing" a dimension? Not sure about this name.
  */
-export function parseDimension(name, { query }) {
+export function parseDimension(name, { reference, query }) {
   // FIXME: this is pretty inefficient, create a lookup table?
   return query
     .dimensionOptions()
     .all()
+    .filter(
+      d =>
+        !(d instanceof ExpressionDimension) ||
+        getDimensionName(d) !== reference,
+    )
     .find(d =>
       EDITOR_FK_SYMBOLS.symbols.some(
         separator => getDimensionName(d, separator) === name,

--- a/frontend/src/metabase/lib/expressions/process.js
+++ b/frontend/src/metabase/lib/expressions/process.js
@@ -27,8 +27,10 @@ export function processSource(options) {
       }
       return Array.isArray(segment.id) ? segment.id : ["segment", segment.id];
     } else {
+      const reference = options.name; // avoid circular reference
+
       // fallback
-      const dimension = parseDimension(name, options);
+      const dimension = parseDimension(name, { reference, ...options });
       if (!dimension) {
         throw new Error(t`Unknown Field: ${name}`);
       }

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -57,6 +57,7 @@ export default class ExpressionEditorTextfield extends React.Component {
       PropTypes.number,
       PropTypes.array,
     ]),
+    name: PropTypes.string,
     onChange: PropTypes.func.isRequired,
     onError: PropTypes.func.isRequired,
     startRule: PropTypes.string.isRequired,
@@ -279,22 +280,22 @@ export default class ExpressionEditorTextfield extends React.Component {
 
   compileExpression() {
     const { source } = this.state;
+    const { query, startRule, name } = this.props;
     if (!source || source.length === 0) {
       return null;
     }
-    const { query, startRule } = this.props;
-    const { expression } = processSource({ source, query, startRule });
+    const { expression } = processSource({ name, source, query, startRule });
 
     return expression;
   }
 
   diagnoseExpression() {
     const { source } = this.state;
+    const { query, startRule, name } = this.props;
     if (!source || source.length === 0) {
       return { message: "Empty expression" };
     }
-    const { query, startRule } = this.props;
-    return diagnose(source, startRule, query);
+    return diagnose(source, startRule, query, name);
   }
 
   commitExpression() {

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx
@@ -57,7 +57,7 @@ export default class ExpressionWidget extends Component {
 
   render() {
     const { query } = this.props;
-    const { expression } = this.state;
+    const { expression, name } = this.state;
 
     return (
       <div style={{ maxWidth: "600px" }}>
@@ -67,6 +67,7 @@ export default class ExpressionWidget extends Component {
             <ExpressionEditorTextfield
               helpTextTarget={this.helpTextTarget.current}
               expression={expression}
+              name={name}
               query={query}
               onChange={parsedExpression =>
                 this.setState({ expression: parsedExpression, error: null })

--- a/frontend/test/metabase/scenarios/custom-column/reproductions/21135-cc-same-name-as-existing-column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/custom-column/reproductions/21135-cc-same-name-as-existing-column.cy.spec.js
@@ -12,7 +12,7 @@ const questionDetails = {
   },
 };
 
-describe.skip("issue 21135", () => {
+describe("issue 21135", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
@@ -32,7 +32,7 @@ describe.skip("issue 21135", () => {
 
     // We should probably use data-testid or some better selector but it is crucial
     // to narrow the results to the preview area to avoid false positive result.
-    cy.get("[class*=PreviewRoot]").within(() => {
+    cy.get("[class*=TableInteractive]").within(() => {
       cy.findByText("Rustic Paper Wallet");
 
       cy.findAllByText("Price").should("have.length", 2);


### PR DESCRIPTION
Fixed #21135.

To verify:
1. New, Question, Sample Database, Products
2. Custom column, type `[Price] + 2` and name it as `Price`, press Done
3. Click on that custom column again, don't change anything, press Update
4. Preview

### Before this PR

The front-end tries to resolve `[Price]` dimension to itself (instead of the field in the Products table), leading to an expression with a circular reference. This confuses the back-end (rightfully).

![image](https://user-images.githubusercontent.com/7288/165184328-87c91972-5da6-49f7-9ade-23b30481a30b.png)

### After this PR

Now the front-end will avoid resolving any dimension with the same name to itself. The query/preview works as expected.

![image](https://user-images.githubusercontent.com/7288/165184398-ebb78584-fca3-4094-aab9-90768a0cc4cd.png)



