### PR TITLE
Adding fullscreen check to hasNavBar

### DIFF
--- a/frontend/src/metabase/App.tsx
+++ b/frontend/src/metabase/App.tsx
@@ -85,7 +85,7 @@ class ErrorBoundary extends React.Component<{
 function App({
   currentUser,
   errorPage,
-  location: { pathname },
+  location: { pathname, hash },
   isEditingDashboard,
   children,
 }: AppProps) {
@@ -110,11 +110,18 @@ function App({
   }, [currentUser, pathname, isEditingDashboard]);
 
   const hasAppBar = useMemo(() => {
-    if (!currentUser || IFRAMED || isAdminApp || isEditingDashboard) {
+    const isFullscreen = hash.includes("fullscreen");
+    if (
+      !currentUser ||
+      IFRAMED ||
+      isAdminApp ||
+      isEditingDashboard ||
+      isFullscreen
+    ) {
       return false;
     }
     return !PATHS_WITHOUT_NAVBAR.some(pattern => pattern.test(pathname));
-  }, [currentUser, pathname, isEditingDashboard, isAdminApp]);
+  }, [currentUser, pathname, isEditingDashboard, isAdminApp, hash]);
 
   return (
     <ErrorBoundary onError={setErrorInfo}>


### PR DESCRIPTION
Fixes #21992

Quick check in `App.tsx` to determine if we are fullscreen or not. Ideally we would have a selector we could map to, but we keep this state in the `DashboardControls.jsx` component, so it's not super accessible to parent components. Another alternative would be to just read the state from screenful, but because it's outside the react ecosystem it's not reliable as a memo dependency. Ultimately I decided to drive it from the url hash (which is also set in `DashboardControls.jsx`), largely because it's the location change that is causing the re-render in the first place.

![chrome_kJobqn8xtN](https://user-images.githubusercontent.com/1328979/165213413-cac5d626-36ed-433d-9889-e9c3a14cbc17.gif)

