### PR TITLE
Manual backport for 21913 for 43

### DIFF
--- a/src/metabase/driver/sql_jdbc/sync/describe_table.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_table.clj
@@ -220,7 +220,9 @@
       member-type)))
 
 (defn- row->types [row]
-  (into {} (for [[field-name field-val] row]
+  (into {} (for [[field-name field-val] row
+                 ;; We put top-level array row type semantics on JSON roadmap but skip for now
+                 :when (map? field-val)]
              (let [flat-row (flattened-row field-name field-val)]
                (into {} (map (fn [[k v]] [k (type-by-parsing-string v)]) flat-row))))))
 

--- a/test/metabase/driver/sql_jdbc/sync/describe_table_test.clj
+++ b/test/metabase/driver/sql_jdbc/sync/describe_table_test.clj
@@ -75,6 +75,13 @@
     (is (= java.time.LocalDateTime (#'describe-table/type-by-parsing-string "2017-01-13T17:09:42.411")))
     (is (= java.lang.Long (#'describe-table/type-by-parsing-string 11111)))))
 
+(deftest row->types-test
+  (testing "array rows ignored properly in JSON row->types (#21752)"
+    (let [arr-row   {:bob [:bob :cob :dob 123 "blob"]}
+          obj-row   {:zlob {"blob" 1323}}]
+      (is (= {} (#'describe-table/row->types arr-row)))
+      (is (= {[:zlob "blob"] java.lang.Long} (#'describe-table/row->types obj-row))))))
+
 (deftest describe-nested-field-columns-test
   (testing "flattened-row"
     (let [row       {:bob {:dobbs 123 :cobbs "boop"}}


### PR DESCRIPTION
Automated backport #21913/#21845 broke because of shorter require statement. This should fix that.