### PR TITLE
fix auto backport branch search

### DIFF
--- a/.github/actions/get-latest-release-branch/action.yml
+++ b/.github/actions/get-latest-release-branch/action.yml
@@ -19,7 +19,7 @@ runs:
           });
 
           const getVersionFromBranch = branch => {
-            const match = branch.match(/release-x\.(.*?)\.x/);
+            const match = branch.match(/release-x\.(.*?)\.x$/);
             return match && parseInt(match[1]);
           };
           const latestReleaseBranch = releaseBranches.data


### PR DESCRIPTION
## Changes

Exclude branches like `release-x.43.x-translations` from search of the latest release branch
