### PR TITLE
[E2E] Experiment running `joins` test group as PR check

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -62,6 +62,7 @@ jobs:
           - "binning"
           - "dashboard-filters"
           - "downloads"
+          - "joins"
           - "moderation"
     services:
       maildev:


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Following the steps of https://github.com/metabase/metabase/pull/21492 and the tasks that @ariya started, we're now adding `joins` test group to PR checks using GitHub actions.

Analyzing the flakes report, I there are some flakes related to `joins`, but I couldn't reproduce them locally. Let's deal with them if they start obstructing devs' workflow.

There's one more important check we need to make. Let's see if the number of passing tests is the same for both OSS and EE versions.

tl;dr It is. Because `joins` tests are version agnostic.

But here's the data:
[joins OSS](https://github.com/metabase/metabase/runs/6174594213?check_suite_focus=true) vs [joins EE](https://github.com/metabase/metabase/runs/6174595879?check_suite_focus=true)
| e2e-tests-joins                       | total | passing | pending  |
|---------------------------|--------|-------|-------|
| OSS                  | 29   | 28  | 1  |
| EE                 | 29   | 28  | 1  |


### The next steps
After we make sure this group runs without major hiccups on GitHub (for at least a week?), remove it from CircleCI.