### PR TITLE
Entity menu shouldn't be too far off

### DIFF
--- a/frontend/src/metabase/components/EntityMenu.jsx
+++ b/frontend/src/metabase/components/EntityMenu.jsx
@@ -47,6 +47,7 @@ class EntityMenu extends Component {
       className,
       tooltip,
       trigger,
+      targetOffsetY,
     } = this.props;
     const { open, menuItemContent } = this.state;
     return (
@@ -65,7 +66,7 @@ class EntityMenu extends Component {
           hasArrow={false}
           hasBackground={false}
           horizontalAttachments={["left", "right"]}
-          targetOffsetY={20}
+          targetOffsetY={targetOffsetY || 0}
         >
           {/* Note: @kdoh 10/12/17
            * React Motion has a flow type problem with children see

--- a/frontend/src/metabase/nav/components/ProfileLink.jsx
+++ b/frontend/src/metabase/nav/components/ProfileLink.jsx
@@ -107,6 +107,7 @@ function ProfileLink({ user, handleCloseNavbar, adminItems, handleLogout }) {
         tooltip={t`Settings`}
         items={generateOptionsForUser()}
         triggerIcon="gear"
+        targetOffsetY={20}
         triggerProps={{
           color: color("text-medium"),
           hover: {


### PR DESCRIPTION
This should fix #21982.

### Before this PR

Show any entity menu (popover), e.g. New (and other places, see #21982).

![Screenshot_20220426_053146](https://user-images.githubusercontent.com/7288/165302712-4983a824-57d1-4b95-86aa-de0320dc6c2f.png)

### After this PR

The distance from the trigger/icon to the menu is restored just like before PR #21713.

![Screenshot_20220426_053703](https://user-images.githubusercontent.com/7288/165302751-91b32b55-c41a-40f3-9d0d-0ce480e98879.png)

Meanwhile, the settings popover correctly still won't cover the gear icon:
![Screenshot_20220426_054137](https://user-images.githubusercontent.com/7288/165302790-49c48639-6875-46d1-84b2-3c2c5bdd8036.png)
