### PR TITLE
Remove auditing related test from `sharing` again

### DIFF
--- a/frontend/test/metabase/scenarios/sharing/approved-domains.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/approved-domains.cy.spec.js
@@ -5,12 +5,10 @@ import {
   sidebar,
   visitQuestion,
   visitDashboard,
-  modal,
 } from "__support__/e2e/cypress";
 
 const allowedDomain = "metabase.test";
 const deniedDomain = "metabase.example";
-const allowedEmail = `mailer@${allowedDomain}`;
 const deniedEmail = `mailer@${deniedDomain}`;
 const subscriptionError = `You're only allowed to email subscriptions to addresses ending in ${allowedDomain}`;
 const alertError = `You're only allowed to email alerts to addresses ending in ${allowedDomain}`;
@@ -48,27 +46,6 @@ describeEE("scenarios > sharing > approved domains (EE)", () => {
       // Reproduces metabase#17977
       cy.button("Send email now").should("be.disabled");
       cy.button("Done").should("be.disabled");
-      cy.findByText(subscriptionError);
-    });
-  });
-
-  it("should validate approved email domains for a dashboard subscription in the audit app", () => {
-    visitDashboard(1);
-    cy.icon("subscription").click();
-    cy.findByText("Email it").click();
-
-    sidebar().within(() => {
-      addEmailRecipient(allowedEmail);
-      cy.button("Done").click();
-    });
-
-    cy.visit("/admin/audit/subscriptions/subscriptions");
-    cy.findByText("1").click();
-
-    modal().within(() => {
-      addEmailRecipient(deniedEmail);
-
-      cy.button("Update").should("be.disabled");
       cy.findByText(subscriptionError);
     });
   });


### PR DESCRIPTION
Originally removed in https://github.com/metabase/metabase/pull/21324/files, but added by accident back in in https://github.com/metabase/metabase/pull/21307.

We removed it because it's contributing to the H2 locking issue.