### PR TITLE
[E2E] Increase the e2e job timeout on `master`

### DIFF
--- a/.github/workflows/e2e-master.yml
+++ b/.github/workflows/e2e-master.yml
@@ -39,7 +39,7 @@ jobs:
 
   e2e-tests:
     runs-on: ubuntu-20.04
-    timeout-minutes: 30
+    timeout-minutes: 45
     needs: build
     name: e2e-tests-${{ matrix.folder }}-${{ matrix.edition }}
     env:


### PR DESCRIPTION
As we're adding more and more tests, the time it takes for a certain job to finish increases.
We're running E2E tests using the default machines on `master`, so it takes significantly more time than it does for the PR.

`dashboard-filters` started timing out after https://github.com/metabase/metabase/pull/21987
The example: https://github.com/metabase/metabase/actions/runs/2226263129

After this PR:
Shouldn't happen anymore.

Note:
This shouldn't in any way obstruct anyone's workflow because it's running on `master` only.