### PR TITLE
Manual backport `Hide parsed JSON columns when they get parsed` (#21934)

### DIFF
--- a/src/metabase/driver/sql_jdbc/sync/describe_table.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_table.clj
@@ -13,6 +13,7 @@
             [metabase.driver.sql-jdbc.sync.interface :as i]
             [metabase.driver.sql.query-processor :as sql.qp]
             [metabase.mbql.schema :as mbql.s]
+            [metabase.models.table :as table]
             [metabase.util :as u]
             [metabase.util.honeysql-extensions :as hx])
   (:import [java.sql Connection DatabaseMetaData ResultSet]))
@@ -137,12 +138,20 @@
   (into
    #{}
    (map-indexed (fn [i {:keys [database-type], column-name :name, :as col}]
-                  (merge
-                   (u/select-non-nil-keys col [:name :database-type :field-comment])
-                   {:base-type         (database-type->base-type-or-warn driver database-type)
-                    :database-position i}
-                   (when-let [semantic-type (calculated-semantic-type driver column-name database-type)]
-                     {:semantic-type semantic-type}))))
+                  (let [semantic-type (calculated-semantic-type driver column-name database-type)]
+                    (merge
+                      (u/select-non-nil-keys col [:name :database-type :field-comment])
+                      {:base-type         (database-type->base-type-or-warn driver database-type)
+                       :database-position i}
+                      (when semantic-type
+                        {:semantic-type semantic-type})
+                      (when (and
+                              (isa? semantic-type :type/SerializedJSON)
+                              (driver/database-supports?
+                                driver
+                                :nested-field-columns
+                                (table/database table)))
+                        {:visibility-type :details-only})))))
    (fields-metadata driver conn table db-name-or-nil)))
 
 (defn add-table-pks

--- a/src/metabase/sync/sync_metadata/fields/sync_instances.clj
+++ b/src/metabase/sync/sync_metadata/fields/sync_instances.clj
@@ -39,7 +39,8 @@
   [table :- i/TableInstance, new-field-metadatas :- [i/TableMetadataField], parent-id :- common/ParentID]
   (when (seq new-field-metadatas)
     (db/insert-many! Field
-      (for [{:keys [database-type base-type effective-type coercion-strategy field-comment database-position nfc-path], field-name :name :as field} new-field-metadatas]
+      (for [{:keys [database-type base-type effective-type coercion-strategy
+                    field-comment database-position nfc-path visibility-type], field-name :name :as field} new-field-metadatas]
         (do
          (when (and effective-type
                     base-type
@@ -65,7 +66,8 @@
           :nfc_path          nfc-path
           :description       field-comment
           :position          database-position
-          :database_position database-position})))))
+          :database_position database-position
+          :visibility_type   (or visibility-type :normal)})))))
 
 (s/defn ^:private create-or-reactivate-fields! :- (s/maybe [i/FieldInstance])
   "Create (or reactivate) Metabase Field object(s) for any Fields in `new-field-metadatas`. Does *NOT* recursively


### PR DESCRIPTION
Automated backport landed on `release-x.43.x-translation` because of the autobackporter bug Sasha fixed. Dealing with consequences in this PR