### PR TITLE
Fix freezing when opening a timeseries chart with sparse data and without the X-axis

### DIFF
--- a/frontend/src/metabase/visualizations/lib/apply_axis.js
+++ b/frontend/src/metabase/visualizations/lib/apply_axis.js
@@ -101,6 +101,8 @@ export function applyChartTimeseriesXAxis(
   // compute the data interval
   const dataInterval = xInterval;
   let tickInterval = dataInterval;
+  let tickFormat = () => "";
+  const { timezone } = tickInterval;
 
   if (chart.settings["graph.x_axis.labels_enabled"]) {
     chart.xAxisLabel(
@@ -123,13 +125,10 @@ export function applyChartTimeseriesXAxis(
         ? xValues[xValues.length - 1]
         : null;
 
-    // extract xInterval timezone for updating tickInterval
-    const { timezone } = tickInterval;
-
     // special handling for weeks
     // TODO: are there any other cases where we should do this?
     let tickFormatUnit = dimensionColumn.unit;
-    const tickFormat = timestamp => {
+    tickFormat = timestamp => {
       const { column, ...columnSettings } = chart.settings.column(
         dimensionColumn,
       );
@@ -170,19 +169,19 @@ export function applyChartTimeseriesXAxis(
     } else {
       chart.xAxis().tickPadding(X_AXIS_PADDING);
     }
-
-    // Compute a sane interval to display based on the data granularity, domain, and chart width
-    tickInterval = {
-      ...tickInterval,
-      ...computeTimeseriesTicksInterval(
-        xDomain,
-        tickInterval,
-        chart.width(),
-        tickFormat,
-      ),
-      timezone,
-    };
   }
+
+  // Compute a sane interval to display based on the data granularity, domain, and chart width
+  tickInterval = {
+    ...tickInterval,
+    ...computeTimeseriesTicksInterval(
+      xDomain,
+      tickInterval,
+      chart.width(),
+      tickFormat,
+    ),
+    timezone,
+  };
 
   // pad the domain slightly to prevent clipping
   xDomain = stretchTimeseriesDomain(xDomain, dataInterval);

--- a/frontend/src/metabase/visualizations/lib/timeseriesScale.js
+++ b/frontend/src/metabase/visualizations/lib/timeseriesScale.js
@@ -97,7 +97,7 @@ function ticksForRange([start, end], { count, timezone, interval, shiftDays }) {
   const intervalMod = tick.get(interval);
   tick.set(interval, intervalMod - (intervalMod % count));
 
-  while (!tick.isAfter(end) && ticks.length < count) {
+  while (!tick.isAfter(end)) {
     if (!tick.isBefore(start)) {
       ticks.push(tick);
     }

--- a/frontend/src/metabase/visualizations/lib/timeseriesScale.js
+++ b/frontend/src/metabase/visualizations/lib/timeseriesScale.js
@@ -97,7 +97,7 @@ function ticksForRange([start, end], { count, timezone, interval, shiftDays }) {
   const intervalMod = tick.get(interval);
   tick.set(interval, intervalMod - (intervalMod % count));
 
-  while (!tick.isAfter(end)) {
+  while (!tick.isAfter(end) && ticks.length < count) {
     if (!tick.isBefore(start)) {
       ticks.push(tick);
     }

--- a/frontend/test/metabase/scenarios/visualizations/reproductions/18776-timeseries-hidden-axis-freeze.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/reproductions/18776-timeseries-hidden-axis-freeze.cy.spec.js
@@ -26,7 +26,7 @@ describe("issue 18776", () => {
     cy.signInAsAdmin();
   });
 
-  it("should not freeze when opening a timeseries chart without X-axis", () => {
+  it("should not freeze when opening a timeseries chart with sparse data and without the X-axis", () => {
     visitQuestionAdhoc(questionDetails);
     cy.findByText("Visualization").should("be.visible");
   });

--- a/frontend/test/metabase/scenarios/visualizations/reproductions/18776-timeseries-hidden-axis-freeze.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/reproductions/18776-timeseries-hidden-axis-freeze.cy.spec.js
@@ -1,0 +1,33 @@
+import { restore, visitQuestionAdhoc } from "__support__/e2e/cypress";
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
+
+const questionDetails = {
+  dataset_query: {
+    type: "native",
+    native: {
+      query: `
+select 101002 as "id", 1 as "rate"
+union all select 103017, 2
+union all select 210002, 3`,
+    },
+    database: SAMPLE_DB_ID,
+  },
+  display: "bar",
+  visualization_settings: {
+    "graph.dimensions": ["id"],
+    "graph.metrics": ["rate"],
+    "graph.x_axis.axis_enabled": false,
+  },
+};
+
+describe("issue 18776", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should not freeze when opening a timeseries chart without X-axis", () => {
+    visitQuestionAdhoc(questionDetails);
+    cy.findByText("Visualization").should("be.visible");
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/18776

The problem is that `computeTimeseriesTicksInterval` wasn't called for charts without X-axis. `computeTimeseriesTicksInterval` adjusts `xInterval` to decrease the number of ticks. Without it, the query from the issue caused 100,000 ticks to be generated internally by `dc.js `.

The underlying issue is that `dc.js` doesn't support charts without the X axis, so it always generates ticks. We hide them after the initial render. As we can't change how `dc.js` works, this fix seems to be a valid solution.

Please also note that this PR simply moves code within a function.

How to test:
- Follow the steps from the issue
- There is also a new cypress test with the exact same steps