### PR TITLE
Enable :unsorted-required-namespaces and lint cleanups

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -29,6 +29,12 @@
            :unused-referred-var {:exclude {compojure.core [GET DELETE POST PUT]}}
            :deprecated-var {:exclude {metabase.query-processor.util/normalize-token
                                       {:namespaces ["metabase.*"]}
+                                      metabase.db.data-migrations/data-migrations
+                                      {:namespaces ["metabase.db.data-migrations"]}
+                                      metabase.db.data-migrations/defmigration
+                                      {:namespaces ["metabase.db.data-migrations"]}
+                                      metabase.db.data-migrations/run-migration-if-needed!
+                                      {:namespaces ["metabase.db.data-migrations"]}
                                       metabase.driver/supports?
                                       {:namespaces ["metabase.*"]}
                                       metabase.driver/current-db-time
@@ -78,6 +84,7 @@
                                       schema.core/both
                                       {:namespaces ["metabase.*"]}}}
            :unresolved-var {:exclude [colorize.core]}
+           :unsorted-required-namespaces {:level :warning}
            :consistent-alias {:aliases {buddy.core.hash                                                 buddy-hash
                                         cheshire.generate                                               json.generate
                                         clj-http.client                                                 http

--- a/src/metabase/api/common/validation.clj
+++ b/src/metabase/api/common/validation.clj
@@ -1,5 +1,5 @@
 (ns metabase.api.common.validation
-  (:require [clojure.string :as string]
+  (:require [clojure.string :as str]
             [metabase.api.common :as api]
             [metabase.plugins.classloader :as classloader]
             [metabase.public-settings :as public-settings]
@@ -39,7 +39,7 @@
   [perm-type]
   (api/check (premium-features/enable-advanced-permissions?)
              [402 (tru "The {0} permissions functionality is only enabled if you have a premium token with the advanced-permissions feature."
-                       (string/replace (name perm-type) "-" " "))]))
+                       (str/replace (name perm-type) "-" " "))]))
 
 (defn check-group-manager
   "If `advanced-permissions` is enabled, check is `*current-user*` a manager of at least one group.

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -654,63 +654,63 @@
    refingerprint      (s/maybe s/Bool)
    details            (s/maybe su/Map)
    schedules          (s/maybe sync.schedules/ExpandedSchedulesMap)
-   description        (s/maybe s/Str)                ; s/Str instead of su/NonBlankString because we don't care
-   caveats            (s/maybe s/Str)                ; whether someone sets these to blank strings
+   description        (s/maybe s/Str)   ; s/Str instead of su/NonBlankString because we don't care
+   caveats            (s/maybe s/Str)   ; whether someone sets these to blank strings
    points_of_interest (s/maybe s/Str)
    auto_run_queries   (s/maybe s/Bool)
    cache_ttl          (s/maybe su/IntGreaterThanZero)}
   ;; TODO - ensure that custom schedules and let-user-control-scheduling go in lockstep
-  (let [existing-database (api/write-check (Database id))]
-    (let [details    (driver.u/db-details-client->server engine details)
-          details    (upsert-sensitive-fields existing-database details)
-          conn-error (when (some? details)
-                       (assert (some? engine))
-                       (test-database-connection engine details))
-          full-sync? (when-not (nil? is_full_sync)
-                       (boolean is_full_sync))]
-      (if conn-error
-        ;; failed to connect, return error
-        {:status 400
-         :body   conn-error}
-        ;; no error, proceed with update
-        (do
-          ;; TODO - is there really a reason to let someone change the engine on an existing database?
-          ;;       that seems like the kind of thing that will almost never work in any practical way
-          ;; TODO - this means one cannot unset the description. Does that matter?
-          (api/check-500 (db/update-non-nil-keys! Database id
-                                                  (merge
-                                                     {:name               name
-                                                      :engine             engine
-                                                      :details            details
-                                                      :refingerprint      refingerprint
-                                                      :is_full_sync       full-sync?
-                                                      :is_on_demand       (boolean is_on_demand)
-                                                      :description        description
-                                                      :caveats            caveats
-                                                      :points_of_interest points_of_interest
-                                                      :auto_run_queries   auto_run_queries}
-                                                     (cond
-                                                       ;; transition back to metabase managed schedules. the schedule
-                                                       ;; details, even if provided, are ignored. database is the
-                                                       ;; current stored value and check against the incoming details
-                                                       (and (get-in existing-database [:details :let-user-control-scheduling])
-                                                            (not (:let-user-control-scheduling details)))
+  (let [existing-database (api/write-check (Database id))
+        details           (driver.u/db-details-client->server engine details)
+        details           (upsert-sensitive-fields existing-database details)
+        conn-error        (when (some? details)
+                            (assert (some? engine))
+                            (test-database-connection engine details))
+        full-sync?        (when-not (nil? is_full_sync)
+                            (boolean is_full_sync))]
+    (if conn-error
+      ;; failed to connect, return error
+      {:status 400
+       :body   conn-error}
+      ;; no error, proceed with update
+      (do
+        ;; TODO - is there really a reason to let someone change the engine on an existing database?
+        ;;       that seems like the kind of thing that will almost never work in any practical way
+        ;; TODO - this means one cannot unset the description. Does that matter?
+        (api/check-500 (db/update-non-nil-keys! Database id
+                                                (merge
+                                                 {:name               name
+                                                  :engine             engine
+                                                  :details            details
+                                                  :refingerprint      refingerprint
+                                                  :is_full_sync       full-sync?
+                                                  :is_on_demand       (boolean is_on_demand)
+                                                  :description        description
+                                                  :caveats            caveats
+                                                  :points_of_interest points_of_interest
+                                                  :auto_run_queries   auto_run_queries}
+                                                 (cond
+                                                   ;; transition back to metabase managed schedules. the schedule
+                                                   ;; details, even if provided, are ignored. database is the
+                                                   ;; current stored value and check against the incoming details
+                                                   (and (get-in existing-database [:details :let-user-control-scheduling])
+                                                        (not (:let-user-control-scheduling details)))
 
-                                                       (sync.schedules/schedule-map->cron-strings (sync.schedules/default-schedule))
+                                                   (sync.schedules/schedule-map->cron-strings (sync.schedules/default-schedule))
 
-                                                       ;; if user is controlling schedules
-                                                       (:let-user-control-scheduling details)
-                                                       (sync.schedules/schedule-map->cron-strings (sync.schedules/scheduling schedules))))))
-                                                       ;; do nothing in the case that user is not in control of
-                                                       ;; scheduling. leave them as they are in the db
+                                                   ;; if user is controlling schedules
+                                                   (:let-user-control-scheduling details)
+                                                   (sync.schedules/schedule-map->cron-strings (sync.schedules/scheduling schedules))))))
+        ;; do nothing in the case that user is not in control of
+        ;; scheduling. leave them as they are in the db
 
-          ;; unlike the other fields, folks might want to nil out cache_ttl
-          (api/check-500 (db/update! Database id {:cache_ttl cache_ttl}))
+        ;; unlike the other fields, folks might want to nil out cache_ttl
+        (api/check-500 (db/update! Database id {:cache_ttl cache_ttl}))
 
-          (let [db (Database id)]
-            (events/publish-event! :database-update db)
-            ;; return the DB with the expanded schedules back in place
-            (add-expanded-schedules db)))))))
+        (let [db (Database id)]
+          (events/publish-event! :database-update db)
+          ;; return the DB with the expanded schedules back in place
+          (add-expanded-schedules db))))))
 
 
 ;;; -------------------------------------------- DELETE /api/database/:id --------------------------------------------

--- a/src/metabase/api/table.clj
+++ b/src/metabase/api/table.clj
@@ -15,6 +15,7 @@
             [metabase.related :as related]
             [metabase.sync :as sync]
             [metabase.sync.concurrent :as sync.concurrent]
+            #_:clj-kondo/ignore
             [metabase.sync.field-values :as sync.field-values]
             [metabase.types :as types]
             [metabase.util :as u]

--- a/src/metabase/cmd.clj
+++ b/src/metabase/cmd.clj
@@ -120,7 +120,7 @@
   ([]
    (classloader/require 'metabase.cmd.driver-methods)
    ((resolve 'metabase.cmd.driver-methods/print-available-multimethods) false))
-  ([docs]
+  ([_docs]
    (classloader/require 'metabase.cmd.driver-methods)
    ((resolve 'metabase.cmd.driver-methods/print-available-multimethods) true)))
 

--- a/src/metabase/db/data_migrations.clj
+++ b/src/metabase/db/data_migrations.clj
@@ -12,7 +12,7 @@
             [clojure.walk :as walk]
             [medley.core :as m]
             [metabase.models.dashboard-card :refer [DashboardCard]]
-            [metabase.models.permissions-group :as group]
+            [metabase.models.permissions-group :as perms-group]
             [metabase.models.setting :as setting :refer [Setting]]
             [metabase.util :as u]
             [toucan.db :as db]
@@ -185,7 +185,7 @@
 
 (defn- remove-admin-group-from-mappings-by-setting-key!
   [mapping-setting-key]
-  (let [admin-group-id (:id (group/admin))
+  (let [admin-group-id (:id (perms-group/admin))
         mapping        (try
                         (json/parse-string (raw-setting mapping-setting-key))
                         (catch Exception _e

--- a/src/metabase/db/setup.clj
+++ b/src/metabase/db/setup.clj
@@ -54,39 +54,37 @@
    data-source :- javax.sql.DataSource
    direction   :- s/Keyword]
   (with-open [conn (.getConnection data-source)]
-    ;; TODO: this try has no catch. We need to make sure the catches are at the right level and possibly remove this
-    ;; outer try?
-    (try
-      (.setAutoCommit conn false)
+    (.setAutoCommit conn false)
       ;; Set up liquibase and let it do its thing
-      (log/info (trs "Setting up Liquibase..."))
-      (liquibase/with-liquibase [liquibase conn]
-        (try
-          (liquibase/consolidate-liquibase-changesets! db-type conn)
-          (log/info (trs "Liquibase is ready."))
-          (case direction
-            :up            (liquibase/migrate-up-if-needed! liquibase)
-            :force         (liquibase/force-migrate-up-if-needed! conn liquibase)
-            :down-one      (liquibase/rollback-one liquibase)
-            :print         (print-migrations-and-quit-if-needed! liquibase)
-            :release-locks (liquibase/force-release-locks! liquibase))
-          ;; Migrations were successful; commit everything and re-enable auto-commit
-          (.commit conn)
-          (.setAutoCommit conn true)
-          :done
-          ;; In the Throwable block, we're releasing the lock assuming we have the lock and we failed while in the
-          ;; middle of a migration. It's possible that we failed because we couldn't get the lock. We don't want to
-          ;; clear the lock in that case, so handle that case separately
-          (catch LockException e
-            (.rollback conn)
-            (throw e))
-          ;; If for any reason any part of the migrations fail then rollback all changes
-          (catch Throwable e
-            (.rollback conn)
-            ;; With some failures, it's possible that the lock won't be released. To make this worse, if we retry the
-            ;; operation without releasing the lock first, the real error will get hidden behind a lock error
-            (liquibase/release-lock-if-needed! liquibase)
-            (throw e)))))))
+
+    (log/info (trs "Setting up Liquibase..."))
+    (liquibase/with-liquibase [liquibase conn]
+      (try
+        (liquibase/consolidate-liquibase-changesets! db-type conn)
+        (log/info (trs "Liquibase is ready."))
+        (case direction
+          :up            (liquibase/migrate-up-if-needed! liquibase)
+          :force         (liquibase/force-migrate-up-if-needed! conn liquibase)
+          :down-one      (liquibase/rollback-one liquibase)
+          :print         (print-migrations-and-quit-if-needed! liquibase)
+          :release-locks (liquibase/force-release-locks! liquibase))
+        ;; Migrations were successful; commit everything and re-enable auto-commit
+        (.commit conn)
+        (.setAutoCommit conn true)
+        :done
+        ;; In the Throwable block, we're releasing the lock assuming we have the lock and we failed while in the
+        ;; middle of a migration. It's possible that we failed because we couldn't get the lock. We don't want to
+        ;; clear the lock in that case, so handle that case separately
+        (catch LockException e
+          (.rollback conn)
+          (throw e))
+        ;; If for any reason any part of the migrations fail then rollback all changes
+        (catch Throwable e
+          (.rollback conn)
+          ;; With some failures, it's possible that the lock won't be released. To make this worse, if we retry the
+          ;; operation without releasing the lock first, the real error will get hidden behind a lock error
+          (liquibase/release-lock-if-needed! liquibase)
+          (throw e))))))
 
 (s/defn ^:private verify-db-connection
   "Test connection to application database with `data-source` and throw an exception if we have any troubles

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -15,7 +15,7 @@
             [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
             [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
             [metabase.driver.sql-jdbc.sync :as sql-jdbc.sync]
-            [metabase.driver.sql-jdbc.sync.describe-table :as sql-jdbc.sync.describe-table]
+            [metabase.driver.sql-jdbc.sync.describe-table :as sql-jdbc.describe-table]
             [metabase.driver.sql.query-processor :as sql.qp]
             [metabase.driver.sql.util.unprepare :as unprepare]
             [metabase.models.field :as field]
@@ -188,7 +188,7 @@
 (defmethod sql-jdbc.sync/describe-nested-field-columns :postgres
   [driver database table]
   (let [spec   (sql-jdbc.conn/db->pooled-connection-spec database)
-        fields (sql-jdbc.sync.describe-table/describe-nested-field-columns driver spec table)]
+        fields (sql-jdbc.describe-table/describe-nested-field-columns driver spec table)]
     (if (> (count fields) max-nested-field-columns)
       #{}
       fields)))
@@ -301,7 +301,7 @@
                        (qp.store/field id-or-name))
         parent-method (get-method sql.qp/->honeysql [:sql :field])
         identifier    (parent-method driver clause)
-        nfc-path      (:nfc_path stored-field)]
+        _nfc-path     (:nfc_path stored-field)]
     (cond
       (= (:database_type stored-field) "money")
       (pg-conversion identifier :numeric)
@@ -320,7 +320,7 @@
 ;; The alias names in JSON fields are unique wrt nfc path"
 (defmethod sql.qp/apply-top-level-clause
   [:postgres :breakout]
-  [driver clause honeysql-form {breakout-fields :breakout, fields-fields :fields :as query}]
+  [driver clause honeysql-form {breakout-fields :breakout, _fields-fields :fields :as query}]
   (let [stored-field-ids (map second breakout-fields)
         stored-fields    (map #(when (integer? %) (qp.store/field %)) stored-field-ids)
         parent-method    (partial (get-method sql.qp/apply-top-level-clause [:sql :breakout])

--- a/src/metabase/driver/sql_jdbc/sync/describe_table.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_table.clj
@@ -250,8 +250,8 @@
   ([acc-field-type-map] acc-field-type-map)
   ([acc-field-type-map second-field-type-map]
    (into {}
-         (for [json-column (set/union (keys second-field-type-map)
-                                      (keys acc-field-type-map))]
+         (for [json-column (set/union (set (keys second-field-type-map))
+                                      (set (keys acc-field-type-map)))]
            (cond
              (or (nil? acc-field-type-map)
                  (nil? (acc-field-type-map json-column))
@@ -330,7 +330,7 @@
   "Default implementation of `describe-nested-field-columns` for SQL JDBC drivers. Goes and queries the table if there are JSON columns for the nested contents."
   [driver spec table]
   (with-open [conn (jdbc/get-connection spec)]
-    (let [map-inner        (fn [f xs] (map #(into {}
+    (let [_map-inner       (fn [f xs] (map #(into {}
                                                   (for [[k v] %]
                                                     [k (f v)])) xs))
           table-fields     (describe-table-fields driver conn table)

--- a/src/metabase/models/secret.clj
+++ b/src/metabase/models/secret.clj
@@ -245,7 +245,7 @@
                       (instance? (class Secret) secret-or-id)
                       secret-or-id
 
-                      true ; default; app DB look up from the ID in db-details
+                      :else ; default; app DB look up from the ID in db-details
                       (latest-for-id (get db-details (subprop "-id"))))
         src     (:source secret*)]
     ;; always populate the -source, -creator-id, and -created-at sub properties

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -213,7 +213,7 @@
   (fn [chart-type _ _ _ _ _] chart-type))
 
 (s/defmethod render :table :- common/RenderedPulseCard
-  [_ render-type timezone-id :- (s/maybe s/Str) card _ {:keys [cols rows] :as data}]
+  [_ render-type timezone-id :- (s/maybe s/Str) card _ {:keys [rows] :as data}]
   (let [table-body [:div
                     (table/render-table
                      (color/make-color-selector data (:visualization_settings card))


### PR DESCRIPTION
### Before

```
❯ clj-kondo --lint src:shared/src
src/metabase/api/common/validation.clj:2:33: warning: Inconsistent alias. Expected str instead of string.
src/metabase/api/database.clj:664:5: warning: Redundant let expression.
src/metabase/api/table.clj:18:45: warning: Inconsistent alias. Expected field-values instead of sync.field-values.
src/metabase/cmd.clj:123:5: warning: unused binding docs
src/metabase/db/data_migrations.clj:15:52: warning: Inconsistent alias. Expected perms-group instead of group.
src/metabase/db/data_migrations.clj:55:15: warning: #'metabase.db.data-migrations/data-migrations is deprecated
src/metabase/db/data_migrations.clj:62:24: warning: #'metabase.db.data-migrations/data-migrations is deprecated
src/metabase/db/data_migrations.clj:63:7: warning: #'metabase.db.data-migrations/run-migration-if-needed! is deprecated
src/metabase/db/data_migrations.clj:154:1: warning: #'metabase.db.data-migrations/defmigration is deprecated
src/metabase/db/data_migrations.clj:201:1: warning: #'metabase.db.data-migrations/defmigration is deprecated
src/metabase/db/setup.clj:59:5: warning: Missing catch or finally in try
src/metabase/driver/postgres.clj:18:63: warning: Inconsistent alias. Expected sql-jdbc.describe-table instead of sql-jdbc.sync.describe-table.
src/metabase/driver/postgres.clj:304:9: warning: unused binding nfc-path
src/metabase/driver/postgres.clj:323:60: warning: unused binding fields-fields
src/metabase/driver/sql_jdbc/sync/describe_table.clj:253:39: error: Expected: set or nil, received: seq.
src/metabase/driver/sql_jdbc/sync/describe_table.clj:254:39: error: Expected: set or nil, received: seq.
src/metabase/driver/sql_jdbc/sync/describe_table.clj:333:11: warning: unused binding map-inner
src/metabase/models/secret.clj:248:23: warning: use :else as the catch-all test expression in cond
src/metabase/pulse/render/body.clj:216:64: warning: unused binding cols
src/metabase/task/refresh_slack_channel_user_cache.clj:52:25: error: clojurewerkz.quartzite.schedule.simple/with-interval-in-seconds is called with 1 arg but expects 2
linting took 5988ms, errors: 3, warnings: 17
```

### After

```
❯ clj-kondo --lint src:shared/src
src/metabase/task/refresh_slack_channel_user_cache.clj:52:25: error: clojurewerkz.quartzite.schedule.simple/with-interval-in-seconds is called with 1 arg but expects 2
linting took 5270ms, errors: 1, warnings: 0
```

Want to call out a few things:

The following all related to the new paths into json feature. Wanted
howon to verify that nothing got dropped with these unused bindings. @howonlee 

```
src/metabase/driver/postgres.clj:304:9: warning: unused binding nfc-path
src/metabase/driver/postgres.clj:323:60: warning: unused binding fields-fields
src/metabase/driver/sql_jdbc/sync/describe_table.clj:253:39: error: Expected: set or nil, received: seq.
src/metabase/driver/sql_jdbc/sync/describe_table.clj:254:39: error: Expected: set or nil, received: seq.
src/metabase/driver/sql_jdbc/sync/describe_table.clj:333:11: warning: unused binding map-inner
```

### One last change
I think we need to fix up the macro expansion with quartz in the slack channel caching and then we are clean.

See `metabase.task.refresh-slack-channel-user-cache` in the `task/init!` and `.clj-kondo/macros/quartz`.

One that is fixed up we have 0 errors in clj-kondo and that can be set to fail builds on errors and remove `.lint-config.edn`. @bshepherdson 