### PR TITLE
Use nil value in parameters to by pass default value for FieldFilter

### DIFF
--- a/shared/src/metabase/mbql/normalize.cljc
+++ b/shared/src/metabase/mbql/normalize.cljc
@@ -792,6 +792,7 @@
   {:native identity
    :query  {:source-query remove-empty-clauses-in-source-query
             :joins        {::sequence remove-empty-clauses-in-join}}
+   :parameters identity
    :viz-settings identity})
 
 (defn- remove-empty-clauses

--- a/shared/test/metabase/mbql/normalize_test.cljc
+++ b/shared/test/metabase/mbql/normalize_test.cljc
@@ -1171,7 +1171,8 @@
                                                :widget-type :string/=      ;; widget-type normalize
                                                :default ["Hudson Borer"]}} ;; default values not keyworded
                        :query "select * from PEOPLE where {{name}}"}
-              :type :native}
+              :type :native
+              :parameters []}
              (mbql.normalize/normalize
               {:database 1
                :native {:template-tags {"name" {:id "1f56330b-3dcb-75a3-8f3d-5c2c2792b749"

--- a/src/metabase/driver/common/parameters/values.clj
+++ b/src/metabase/driver/common/parameters/values.clj
@@ -91,6 +91,18 @@
      (when (and (seq matching-params)
                 (every? :value matching-params))
        (normalize-params matching-params))
+
+     ;; If a FieldFilter has value=nil on *purpose*, return a [[params/no-value]]
+     ;; so that this filter can be substituted with "1 = 1" regardless of whether or not this tag has default value
+     (when (and
+            (seq matching-params)
+            (every? (fn [param]
+                      (and
+                       (contains? param :value)
+                       (nil? (:value param))))
+                    matching-params))
+       params/no-value)
+
      ;; otherwise, attempt to fall back to the default value specified as part of the template tag.
      (when-let [tag-default (:default tag)]
        {:type  (:widget-type tag :dimension) ; widget-type is the actual type of the default value if set


### PR DESCRIPTION
Fix #13961