### PR TITLE
fix missing padding on text cards

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/Text/Text.css
+++ b/frontend/src/metabase/visualizations/visualizations/Text/Text.css
@@ -197,3 +197,7 @@
 :local .single-row {
   margin: 0;
 }
+
+:local .padded {
+  padding: 0.5em 0.75em;
+}

--- a/frontend/src/metabase/visualizations/visualizations/Text/Text.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Text/Text.jsx
@@ -94,13 +94,23 @@ export default class Text extends Component {
   preventDragging = e => e.stopPropagation();
 
   render() {
-    const { className, gridSize, settings, isEditing } = this.props;
+    const {
+      className,
+      gridSize,
+      settings,
+      isEditing,
+      isPreviewing,
+    } = this.props;
     const isSingleRow = gridSize && gridSize.height === 1;
 
     if (isEditing) {
       return (
-        <div className={cx(className, styles.Text)}>
-          {this.props.isPreviewing ? (
+        <div
+          className={cx(className, styles.Text, {
+            [styles.padded]: !isPreviewing,
+          })}
+        >
+          {isPreviewing ? (
             <ReactMarkdown
               remarkPlugins={REMARK_PLUGINS}
               className={cx(


### PR DESCRIPTION
Closes #22061

## Changes

Returned the padding in the editing mode:
<img width="397" alt="Screenshot 2022-04-26 at 20 47 48" src="https://user-images.githubusercontent.com/14301985/165351908-6d781802-e976-4712-b6cf-2e5b5d7ab1bb.png">

Kept full height scroll https://github.com/metabase/metabase/pull/21791
<img width="672" alt="Screenshot 2022-04-26 at 20 48 27" src="https://user-images.githubusercontent.com/14301985/165351889-dccf5deb-4869-41f3-b6bb-9783808dd363.png">

## How to verify

- Create a dashboard
- Add a text card
- Ensure it has padding in the editing mode
- Ensure it looks good in preview mode and in dashboard viewing mode as well

