### PR TITLE
Fix the search input being too narrow

### DIFF
--- a/frontend/src/metabase/nav/components/SearchBar.styled.tsx
+++ b/frontend/src/metabase/nav/components/SearchBar.styled.tsx
@@ -67,6 +67,8 @@ export const SearchInput = styled.input<{ isActive: boolean }>`
   color: ${color("text-dark")};
   font-weight: 700;
 
+  width: 100%;
+
   &:focus {
     outline: none;
   }


### PR DESCRIPTION
### Before this PR

Note how the entered text in the search input is cut off.

![image](https://user-images.githubusercontent.com/7288/165356260-e5f59a2b-351b-45bd-90b3-43ffbe0cbe81.png)

### After this PR

As wide as it can be:

![image](https://user-images.githubusercontent.com/7288/165356470-88cea28f-9d85-40d6-a2fa-11b3e24407c7.png)
