### PR TITLE
Show selected field value is restricted

### DIFF
--- a/frontend/src/metabase/admin/datamodel/components/database/ColumnItem/ColumnItem.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/ColumnItem/ColumnItem.jsx
@@ -49,7 +49,10 @@ export default class Column extends Component {
   render() {
     const { field, idfields, dragHandle } = this.props;
     return (
-      <div className="py2 pl2 pr1 mt1 mb3 flex bordered rounded">
+      <div
+        className="py2 pl2 pr1 mt1 mb3 flex bordered rounded"
+        data-testid={`column-${field.name}`}
+      >
         <div className="flex flex-column flex-auto">
           <div className="text-monospace mb1" style={{ fontSize: "12px" }}>
             {getFieldRawName(field)}
@@ -107,6 +110,20 @@ export default class Column extends Component {
     );
   }
 }
+
+const getFkFieldPlaceholder = (field, idfields) => {
+  const hasIdFields = idfields?.length > 0;
+  const isRestrictedFKTargedSelected =
+    isFK(field.semantic_type) &&
+    field.fk_target_field_id != null &&
+    !idfields?.some(idField => idField.id === field.fk_target_field_id);
+
+  if (isRestrictedFKTargedSelected) {
+    return t`Field access denied`;
+  }
+
+  return hasIdFields ? t`Select a target` : t`No key fields`;
+};
 
 // FieldVisibilityPicker and SemanticTypeSelect are also used in FieldApp
 
@@ -174,6 +191,7 @@ export class SemanticTypeAndTargetPicker extends Component {
 
   render() {
     const { field, className, selectSeparator } = this.props;
+    let { idfields } = this.props;
 
     const semanticTypes = [
       ...MetabaseCore.field_semantic_types,
@@ -184,11 +202,9 @@ export class SemanticTypeAndTargetPicker extends Component {
       },
     ];
 
+    const hasIdFields = idfields?.length > 0;
     const showFKTargetSelect = isFK(field.semantic_type);
-
     const showCurrencyTypeSelect = isCurrency(field);
-
-    let { idfields } = this.props;
 
     // If all FK target fields are in the same schema (like `PUBLIC` for sample database)
     // or if there are no schemas at all, omit the schema name
@@ -245,12 +261,13 @@ export class SemanticTypeAndTargetPicker extends Component {
         {showFKTargetSelect && selectSeparator}
         {showFKTargetSelect && (
           <Select
+            disabled={!hasIdFields}
             className={cx(
               "TableEditor-field-target text-wrap",
               selectSeparator ? "mt0" : "mt1",
               className,
             )}
-            placeholder={t`Select a target`}
+            placeholder={getFkFieldPlaceholder(field, idfields)}
             searchProp={[
               "display_name",
               "table.display_name",

--- a/frontend/src/metabase/admin/datamodel/components/database/ColumnItem/ColumnItem.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/ColumnItem/ColumnItem.jsx
@@ -122,7 +122,7 @@ const getFkFieldPlaceholder = (field, idfields) => {
     return t`Field access denied`;
   }
 
-  return hasIdFields ? t`Select a target` : t`No key fields`;
+  return hasIdFields ? t`Select a target` : t`No key available`;
 };
 
 // FieldVisibilityPicker and SemanticTypeSelect are also used in FieldApp

--- a/frontend/test/metabase/scenarios/permissions/data-model-permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/data-model-permissions.cy.spec.js
@@ -29,13 +29,7 @@ describeEE("scenarios > admin > permissions", () => {
     modifyPermission("All Users", DATA_ACCESS_PERMISSION_INDEX, "Granular");
     modifyPermission("Orders", DATA_MODEL_PERMISSION_INDEX, "Yes");
 
-    // Save permission graph
-    cy.button("Save changes").click();
-    modal().within(() => {
-      cy.findByText("Save permissions?");
-      cy.findByText("Are you sure you want to do this?");
-      cy.button("Yes").click();
-    });
+    savePermissionsGraph();
 
     // Assert the permission has changed
     assertPermissionForItem("Orders", DATA_MODEL_PERMISSION_INDEX, "Yes");
@@ -77,13 +71,7 @@ describeEE("scenarios > admin > permissions", () => {
     // Change data model permission
     modifyPermission("All Users", DATA_MODEL_PERMISSION_INDEX, "Yes");
 
-    // Save permission graph
-    cy.button("Save changes").click();
-    modal().within(() => {
-      cy.findByText("Save permissions?");
-      cy.findByText("Are you sure you want to do this?");
-      cy.button("Yes").click();
-    });
+    savePermissionsGraph();
 
     // Assert the permission has changed
     assertPermissionForItem("All Users", DATA_MODEL_PERMISSION_INDEX, "Yes");
@@ -104,4 +92,34 @@ describeEE("scenarios > admin > permissions", () => {
     cy.findByText("People");
     cy.findByText("Reviews");
   });
+
+  it("shows `Field access denied` for foreign keys from tables user does not have access to (metabase#21762)", () => {
+    cy.visit("/admin/permissions/data/database/1");
+
+    // Change data model permission
+    modifyPermission("All Users", DATA_MODEL_PERMISSION_INDEX, "Granular");
+    modifyPermission("Orders", DATA_MODEL_PERMISSION_INDEX, "Yes");
+    modifyPermission("Orders", DATA_ACCESS_PERMISSION_INDEX, "Unrestricted");
+    cy.button("Change").click();
+
+    savePermissionsGraph();
+
+    // Check limited access as a non-admin user
+    cy.signIn("none");
+    cy.visit("/admin/datamodel/database/1/table/2");
+
+    // Find foreign key from table the user does not have access to
+    cy.findByTestId("column-USER_ID").within(() => {
+      cy.findByText("Field access denied");
+    });
+  });
 });
+
+function savePermissionsGraph() {
+  cy.button("Save changes").click();
+  modal().within(() => {
+    cy.findByText("Save permissions?");
+    cy.findByText("Are you sure you want to do this?");
+    cy.button("Yes").click();
+  });
+}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/21762
Reproduces #21762

## How to verify
- Create a Test User and login under it in a separate browser window
- As an admin enable "manage data model" and "data access" permissions only for Orders table

1) As a non-admin user open [Data Model -> Orders table](http://localhost:3000/admin/datamodel/database/1/table/2)

Ensure for foreign key fields (e.g. USER_ID) it shows "Field access denied" as a placeholder. However, since there is other available PK it allows to change it.

<img width="980" alt="Screenshot 2022-04-26 at 23 53 11" src="https://user-images.githubusercontent.com/14301985/165387974-3384b124-8e4a-41a1-a454-d15224afd6f0.png">

2) Change Orders' table ID column type to anything from "Entity Key". Since there are no any ID fields anymore it shows the disabled input for foreign key fields (e.g. USER_ID).

<img width="978" alt="Screenshot 2022-04-26 at 23 48 24" src="https://user-images.githubusercontent.com/14301985/165388029-eda6facb-d033-4b6c-b0cd-741b9e7e8654.png">

3) Change `USER_ID` type from Foreign Key to anything and then change back. Since this user does not have access to any other PK fields, it shows disabled select with "No key fields" message.

<img width="976" alt="Screenshot 2022-04-26 at 23 52 26" src="https://user-images.githubusercontent.com/14301985/165387996-595d0445-9701-4590-919d-e0c4c99c54e9.png">
