### PR TITLE
Skipping test for analysis on H2 lock

### DIFF
--- a/frontend/test/metabase/scenarios/admin/databases/list.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/list.cy.spec.js
@@ -64,7 +64,8 @@ describe("scenarios > admin > databases > list", () => {
     cy.url().should("match", /\/admin\/databases\/\d+$/);
   });
 
-  it("should display a deprecated database warning", () => {
+  // Adding test on Quarantine to understand a bit better some H2 Lock issue.
+  it.skip("should display a deprecated database warning", () => {
     cy.intercept("/api/database*", req => {
       req.reply(res => {
         res.body.data = res.body.data.map(database => ({


### PR DESCRIPTION
All admin test fails are happening after the `list.cy.spec.js` finishes its run. So, to understand a bit better, I'm skipping the latest test to see if the fails still happening.

Doing a PR to that since I'm unable to reproduce locally and analyze better.

Some errors for reference:
- https://github.com/metabase/metabase/runs/6177105123?check_suite_focus=true
- https://github.com/metabase/metabase/runs/6181319352?check_suite_focus=true
