### PR TITLE
Removing `sharing` test to analyse H2 lock

### DIFF
--- a/frontend/test/metabase/scenarios/sharing/approved-domains.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/approved-domains.cy.spec.js
@@ -35,7 +35,8 @@ describeEE("scenarios > sharing > approved domains (EE)", () => {
     cy.findByText(alertError);
   });
 
-  it("should validate approved email domains for a dashboard subscription (metabase#17977)", () => {
+  // Adding test on Quarantine to understand a bit better some H2 Lock issue.
+  it.skip("should validate approved email domains for a dashboard subscription (metabase#17977)", () => {
     visitDashboard(1);
     cy.icon("subscription").click();
     cy.findByText("Email it").click();


### PR DESCRIPTION
All `sharing` test fails are happening after the `approved-domains.cy.spec.js` finishes its run. So, to understand a bit better, I'm skipping the latest test to see if the fails still happening.

Doing a PR to that since I'm unable to reproduce locally and analyze better.

Some errors for reference:
- https://github.com/metabase/metabase/runs/6168937037?check_suite_focus=true
- https://github.com/metabase/metabase/runs/6168937037?check_suite_focus=true