### PR TITLE
fix isDirty prop on DashboardApp.jsx

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
@@ -92,9 +92,10 @@ export default class DashboardGrid extends Component {
         card => String(card.id) === layoutItem.i,
       );
 
+      const keys = ["h", "w", "x", "y"];
       const changed = !_.isEqual(
-        layoutItem,
-        this.getLayoutForDashCard(dashboardCard),
+        _.pick(layoutItem, keys),
+        _.pick(this.getLayoutForDashCard(dashboardCard), keys),
       );
 
       if (changed) {


### PR DESCRIPTION
Fixes #19605 

This was caused by Dashboard Grid comparing 2 objects that were structured differently. I changed the comparison to only look at the things that we actually send with the `setMultipleDashCardAttributes` action
![chrome_vh8lNqbAhY](https://user-images.githubusercontent.com/1328979/165383666-acca1cf9-3e47-4acd-b484-35e7371be666.gif)
.