### PR TITLE
Remove decimals 0 from default static-viz y-axis

### DIFF
--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -299,7 +299,6 @@
   For further details look at frontend/src/metabase/static-viz/XYChart/types.ts"
   [x-col y-col labels {::mb.viz/keys [column-settings] :as viz-settings}]
   (let [default-format {:number_style "decimal"
-                        :decimals 0
                         :currency "USD"
                         :currency_style "symbol"}
         x-col-settings (or (settings-from-column x-col column-settings) {})


### PR DESCRIPTION
Fixes #20552