### PR TITLE
Field filter: treat :type/Name as STRING instead of NUMBER

### DIFF
--- a/frontend/src/metabase/components/FieldValuesWidget.jsx
+++ b/frontend/src/metabase/components/FieldValuesWidget.jsx
@@ -144,11 +144,14 @@ export class FieldValuesWidget extends Component {
   getNonSearchableTokenFieldPlaceholder(firstField) {
     if (firstField.isID()) {
       return t`Enter an ID`;
+    } else if (firstField.isString()) {
+      return t`Enter some text`;
     } else if (firstField.isNumeric()) {
       return t`Enter a number`;
-    } else {
-      return t`Enter some text`;
     }
+
+    // fallback
+    return t`Enter some text`;
   }
 
   getTokenFieldPlaceholder() {

--- a/frontend/src/metabase/lib/schema_metadata.js
+++ b/frontend/src/metabase/lib/schema_metadata.js
@@ -137,9 +137,9 @@ export function getFieldType(field) {
     COORDINATE,
     FOREIGN_KEY,
     PRIMARY_KEY,
-    NUMBER,
     STRING,
     STRING_LIKE,
+    NUMBER,
     BOOLEAN,
   ]) {
     if (isFieldType(type, field)) {

--- a/frontend/test/metabase/lib/schema_metadata.unit.spec.js
+++ b/frontend/test/metabase/lib/schema_metadata.unit.spec.js
@@ -84,6 +84,12 @@ describe("schema_metadata", () => {
         );
       });
     });
+    it("should still recognize a name as a string regardless of its base type", () => {
+      // TYPE.Float can occur in a field filter
+      expect(
+        getFieldType({ base_type: TYPE.Float, semantic_type: TYPE.Name }),
+      ).toEqual(STRING);
+    });
     it("should know what it doesn't know", () => {
       expect(getFieldType({ base_type: "DERP DERP DERP" })).toEqual(undefined);
     });

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -394,6 +394,31 @@ describe("scenarios > question > notebook", () => {
     cy.findByText("ID").should("not.exist");
   });
 
+  it("should treat max/min on a name as a string filter (metabase#21973)", () => {
+    startNewQuestion();
+    cy.contains("Sample Database").click();
+    cy.contains("People").click();
+    cy.contains("Pick the metric").click();
+    popover().within(() => {
+      cy.findByText("Maximum of ...").click();
+      cy.findByText("Name").click();
+    });
+    cy.findByText("Pick a column to group by").click();
+    popover().within(() => {
+      cy.findByText("Source").click();
+    });
+
+    cy.get(".Icon-filter").click();
+    popover().within(() => {
+      cy.findByText("Max of Name").click();
+    });
+
+    cy.findByText("Is").click();
+    cy.findByText("Starts with").click();
+
+    cy.findByText("Case sensitive").click();
+  });
+
   // flaky test
   it.skip("should show an info popover when hovering over a field picker option for a table", () => {
     startNewQuestion();

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -16,7 +16,7 @@ import {
 import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
-const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
+const { ORDERS, ORDERS_ID, PEOPLE, PEOPLE_ID } = SAMPLE_DATABASE;
 
 describe("scenarios > question > notebook", () => {
   beforeEach(() => {
@@ -395,25 +395,25 @@ describe("scenarios > question > notebook", () => {
   });
 
   it("should treat max/min on a name as a string filter (metabase#21973)", () => {
-    startNewQuestion();
-    cy.contains("Sample Database").click();
-    cy.contains("People").click();
-    cy.contains("Pick the metric").click();
-    popover().within(() => {
-      cy.findByText("Maximum of ...").click();
-      cy.findByText("Name").click();
-    });
-    cy.findByText("Pick a column to group by").click();
-    popover().within(() => {
-      cy.findByText("Source").click();
-    });
+    const questionDetails = {
+      name: "21973",
+      query: {
+        "source-table": PEOPLE_ID,
+        aggregation: [["max", ["field", PEOPLE.NAME, null]]],
+        breakout: [["field", PEOPLE.SOURCE, null]],
+      },
+      display: "table",
+    };
 
-    cy.get(".Icon-filter").click();
-    popover().within(() => {
+    cy.createQuestion(questionDetails, { visitQuestion: true });
+
+    cy.findByText("Filter").click();
+    cy.findByTestId("sidebar-right").within(() => {
       cy.findByText("Max of Name").click();
+
+      cy.findByText("Is").click();
     });
 
-    cy.findByText("Is").click();
     cy.findByText("Starts with").click();
 
     cy.findByText("Case sensitive").click();


### PR DESCRIPTION
To verify:
1. New, Question, Sample Database, People
2. Summarize, Maximum of Name, group by Source
3. Filter, choose Max of Name


### Before this PR

The field to filter is incorrectly treated as a number:

![image](https://user-images.githubusercontent.com/7288/165387375-098ee748-4b22-4a51-9e71-4db10c8dfa9a.png)


### After this PR

The field to filter is correctly treated as a string:

![image](https://user-images.githubusercontent.com/7288/165387434-42965197-a780-4078-adaa-01eae565c52f.png)

