### PR TITLE
Fix errors when downgrading then upgrading to bigquery driver

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -48,6 +48,7 @@
   (eval . (put-clojure-indent 'mt/format-rows-by 1))
   (eval . (put-clojure-indent 'mt/query 1))
   (eval . (put-clojure-indent 'mt/test-drivers 1))
+  (eval . (put-clojure-indent 'mt/test-driver 1))
   (eval . (put-clojure-indent 'prop/for-all 1))
   (eval . (put-clojure-indent 'qp.streaming/streaming-response 1))
   (eval . (put-clojure-indent 'u/select-keys-when 1))

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -335,8 +335,24 @@
                 :name   tbl-nm
                 :fields #{{:name "int_col", :database-type "INTEGER", :base-type :type/Integer, :database-position 0}
                           {:name "array_col", :database-type "INTEGER", :base-type :type/Array, :database-position 1}}}
-              (driver/describe-table :bigquery-cloud-sdk (mt/db) {:name tbl-nm, :schema "v3_test_data"}))
-          "`describe-table` should detect the correct base-type for array type columns")))))
+               (driver/describe-table :bigquery-cloud-sdk (mt/db) {:name tbl-nm, :schema "v3_test_data"}))
+               "`describe-table` should detect the correct base-type for array type columns")))))
+
+(deftest sync-inactivates-old-duplicate-tables
+  (testing "If on the new driver, then downgrade, then upgrade again (#21981)"
+    (mt/test-driver :bigquery-cloud-sdk
+      (mt/dataset avian-singles
+        (try
+          (let [synced-tables (db/select Table :db_id (mt/id))]
+            (is (= 2 (count synced-tables)))
+            (db/insert-many! Table (map #(dissoc % :id :schema) synced-tables))
+            (sync/sync-database! (mt/db) {:scan :schema})
+            (let [synced-tables (db/select Table :db_id (mt/id))]
+              (is (partial= {true [{:name "messages"} {:name "users"}]
+                             false [{:name "messages"} {:name "users"}]}
+                            (-> (group-by :active (doto synced-tables tap>))
+                                (update-vals #(sort-by :name %)))))))
+          (finally (db/delete! Table :db_id (mt/id) :active false)))))))
 
 (deftest retry-certain-exceptions-test
   (mt/test-driver :bigquery-cloud-sdk


### PR DESCRIPTION
Fixes #21981 

This issue has a simple fix but a convoluted story. The new bigquery
driver handles multiple schemas and puts that schema (dataset-id) in the
normal spot on a table in our database. The old driver handled only a
single schema by having that dataset-id hardcoded in the database
details and leaving the schema slot nil on the table row.

```clojure
;; new driver describe database:
[{:name "table-1" :schema "a"}
 {:name "table-2" :schema "b"}]

;; old driver describe database (with dataset-id "a" on the db):
[{:name "table-1" :schema nil}]
```

So if you started on the new driver and then downgraded for some reason,
the table sync would see you had tables with schemas, but when it
enumerated the tables in the database on the next sync, would see tables
without schemas. It did not unify these two together, nor did it archive
the tables with a schema. You ended up with both copies in the
database, all active.

```clojure
[{:name "table-1" :schema "a"}
 {:name "table-2" :schema "b"}
 {:name "table-1" :schema nil}]
```

If you then tried to migrate back to the newer driver, we migrated them
as normal: since the old driver only dealt with one schema but left it
nil, put that dataset-id on all of the tables connected to this
connection.

But since the new driver and then the old driver created copies of the
same tables, you would end up with a constraint violation: tables with
the same name and, now after the migration, the same schema. Ignore this
error and the sync in more recent versions will correctly inactivate the
old tables with no schema.

```clojure
[{:name "table-1" :schema "a"}  <-|
 {:name "table-2" :schema "b"}    | constraint violation
 {:name "table-1" :schema "a"}] <-|

;; preferrable:
[{:name "table-1" :schema "a"}
 {:name "table-2" :schema "b"}
 {:name "table-1" :schema nil :active false}]
```

Concretely: the following is what the fix ends up looking like. All of the tables are duplicated but the ones without schema information are marked inactive.

```sql
bq_bug=# select id, name, schema, active from metabase_table where db_id = 3;
 id |   name    |  schema   | active
----+-----------+-----------+--------
 32 | names2017 | babynames | t
 33 | names2009 | babynames | t
 34 | names2001 | babynames | t
 35 | names2011 | babynames | t
 36 | names2006 | babynames | t
 37 | names2008 | babynames | t
 27 | names2004 | babynames | t
 28 | names2002 | babynames | t
 29 | names2007 | babynames | t
 30 | names2016 | babynames | t
 47 | names2015 | babynames | t
 48 | names2001 | [null]    | f
 63 | names2016 | [null]    | f
 61 | names2014 | [null]    | f
 64 | names2018 | [null]    | f
 66 | names2004 | [null]    | f
 38 | names2013 | babynames | t
 39 | names2005 | babynames | t
 40 | names2003 | babynames | t
 41 | names2000 | babynames | t
 42 | names2019 | babynames | t
 43 | names2012 | babynames | t
 44 | names2010 | babynames | t
 45 | names2018 | babynames | t
 46 | names2014 | babynames | t
 67 | names2003 | [null]    | f
 68 | names2006 | [null]    | f
 49 | names2010 | [null]    | f
```
