### PR TITLE
fix missing visual options on text cards

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard.jsx
@@ -133,7 +133,10 @@ export default class DashCard extends Component {
         card.query_average_duration < DATASET_USUALLY_FAST_THRESHOLD,
     }));
 
-    const loading = !(series.length > 0 && _.every(series, s => s.data));
+    const loading =
+      !(series.length > 0 && _.every(series, s => s.data)) &&
+      !isVirtualDashCard(dashcard);
+
     const expectedDuration = Math.max(
       ...series.map(s => s.card.query_average_duration || 0),
     );

--- a/frontend/test/metabase/scenarios/dashboard/text-box.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/text-box.cy.spec.js
@@ -36,6 +36,18 @@ describe("scenarios > dashboard > text-box", () => {
       cy.icon("edit_document");
     });
 
+    it("should render visualization options (metabase#22061)", () => {
+      showDashboardCardActions(1);
+
+      // edit mode
+      cy.icon("palette")
+        .eq(1)
+        .click();
+
+      cy.findByText("Vertical Alignment");
+      cy.findByText("Horizontal Alignment");
+    });
+
     it("should not render edit and preview actions when not editing", () => {
       // Exit edit mode and check for edit options
       cy.findByText("Save").click();


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/22061

Visualization options button on text cards was missing because of incorrectly calculating `loading` based on series data which simply does not exist for text cards.

<img width="318" alt="Screenshot 2022-04-27 at 12 22 50" src="https://user-images.githubusercontent.com/14301985/165474736-f537bccf-2241-436c-bbc2-9207b7007629.png">

## How to verify
- Add a text card on a dashboard
- Ensure "Visualization options" action is renderd and it works