### PR TITLE
Fix exclude days of week filter formatting

### DIFF
--- a/frontend/src/metabase/lib/formatting.js
+++ b/frontend/src/metabase/lib/formatting.js
@@ -424,13 +424,11 @@ function formatDateTimeWithFormats(value, dateFormat, timeFormat, options) {
 
 export function formatDateTimeWithUnit(value, unit, options = {}) {
   if (options.isExclude && unit === "hour-of-day") {
-    return moment(value)
-      .utc()
-      .format("h A");
+    return moment.utc(value).format("h A");
   } else if (options.isExclude && unit === "day-of-week") {
-    const date = moment(value);
+    const date = moment.utc(value);
     if (date.isValid()) {
-      return date.utc().format("dddd");
+      return date.format("dddd");
     }
   }
 

--- a/frontend/test/metabase/lib/formatting.unit.spec.js
+++ b/frontend/test/metabase/lib/formatting.unit.spec.js
@@ -545,6 +545,20 @@ describe("formatting", () => {
         formatDateTimeWithUnit("2022-04-25", "day-of-week", options),
       ).toEqual("Monday");
     });
+
+    it("should format hours of day with exclude option", () => {
+      const options = {
+        isExclude: true,
+      };
+
+      expect(
+        formatDateTimeWithUnit(
+          "2022-04-27T06:00:00.000Z",
+          "hour-of-day",
+          options,
+        ),
+      ).toEqual("6 AM");
+    });
   });
 
   describe("formatTime", () => {

--- a/frontend/test/metabase/lib/formatting.unit.spec.js
+++ b/frontend/test/metabase/lib/formatting.unit.spec.js
@@ -535,6 +535,16 @@ describe("formatting", () => {
         "Sun",
       );
     });
+
+    it("should format days of week with exclude option", () => {
+      const options = {
+        isExclude: true,
+      };
+
+      expect(
+        formatDateTimeWithUnit("2022-04-25", "day-of-week", options),
+      ).toEqual("Monday");
+    });
   });
 
   describe("formatTime", () => {

--- a/frontend/test/metabase/scenarios/filters/reproductions/21979-exclude-day-of-the-week.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/reproductions/21979-exclude-day-of-the-week.cy.spec.js
@@ -1,0 +1,52 @@
+import {
+  restore,
+  openProductsTable,
+  visualize,
+  popover,
+} from "__support__/e2e/cypress";
+
+describe("issue 21979", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+    openProductsTable({ mode: "notebook" });
+  });
+
+  it("exclude 'day of the week' should show the correct day reference in the UI (metabase#21979)", () => {
+    cy.findByText("Filter").click();
+    cy.findByText("Created At").click();
+
+    cy.findByText("Exclude...").click();
+    cy.findByText("Days of the week...").click();
+
+    popover().within(() => {
+      cy.findByText("Monday").click();
+
+      cy.button("Add filter").click();
+    });
+
+    cy.log("Make sure the filter references correct day in the UI");
+    cy.findByText("Created At excludes Monday");
+
+    visualize();
+
+    cy.log("Make sure the query is correct");
+
+    // One of the products created on Monday
+    cy.findByText("Enormous Marble Wallet").should("not.exist");
+
+    cy.log("Make sure we can re-enable the exluded filter");
+
+    cy.findByText("Created At excludes Monday").click();
+
+    popover().within(() => {
+      cy.findByText("Monday").click();
+
+      cy.button("Add filter").click();
+    });
+
+    visualize();
+
+    cy.findByText("Enormous Marble Wallet");
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/21979
Reproduces https://github.com/metabase/metabase/issues/21979

How to test:
- Follow the steps from issue
- There is also new unit tests for this case

Please note that technically the change for `hour-of-day` is not needed because the `value` already contains timezone information and `moment.utc` would give the same result as `moment(value).utc()`. However I believe it would be great to parse the value in the same way as for `day-of-week` for consistency. 