### PR TITLE
Adding can_write check to save question modal

### DIFF
--- a/frontend/src/metabase/containers/SaveQuestionModal.jsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal.jsx
@@ -94,14 +94,21 @@ export default class SaveQuestionModal extends Component {
         card.collection_id === undefined
           ? initialCollectionId
           : card.collection_id,
-      saveType: originalCard && !originalCard.dataset ? "overwrite" : "create",
+      saveType:
+        originalCard && !originalCard.dataset && originalCard.can_write
+          ? "overwrite"
+          : "create",
     };
 
     const title = this.props.multiStep
       ? t`First, save your question`
       : t`Save question`;
 
-    const showSaveType = !card.id && !!originalCard && !originalCard.dataset;
+    const showSaveType =
+      !card.id &&
+      !!originalCard &&
+      !originalCard.dataset &&
+      originalCard.can_write;
 
     return (
       <ModalContent

--- a/frontend/test/metabase/containers/SaveQuestionModal.unit.spec.js
+++ b/frontend/test/metabase/containers/SaveQuestionModal.unit.spec.js
@@ -350,7 +350,6 @@ describe("SaveQuestionModal", () => {
 
     it("shouldn't allow to save a question if form is invalid", () => {
       const originalQuestion = getQuestion({ isSaved: true });
-      console.log(originalQuestion);
       renderSaveQuestionModal(
         getDirtyQuestion(originalQuestion),
         originalQuestion,

--- a/frontend/test/metabase/containers/SaveQuestionModal.unit.spec.js
+++ b/frontend/test/metabase/containers/SaveQuestionModal.unit.spec.js
@@ -61,6 +61,7 @@ function getQuestion({
   name = "Q1",
   description = "Example",
   collection_id = 12,
+  can_write = true,
 } = {}) {
   const extraCardParams = {};
 
@@ -69,6 +70,7 @@ function getQuestion({
     extraCardParams.name = name;
     extraCardParams.description = description;
     extraCardParams.collection_id = collection_id;
+    extraCardParams.can_write = can_write;
   }
 
   return new Question(
@@ -348,6 +350,7 @@ describe("SaveQuestionModal", () => {
 
     it("shouldn't allow to save a question if form is invalid", () => {
       const originalQuestion = getQuestion({ isSaved: true });
+      console.log(originalQuestion);
       renderSaveQuestionModal(
         getDirtyQuestion(originalQuestion),
         originalQuestion,
@@ -485,6 +488,23 @@ describe("SaveQuestionModal", () => {
       userEvent.click(screen.getByText(/Replace original question, ".*"/));
 
       expect(screen.getByRole("button", { name: "Save" })).toBeEnabled();
+    });
+
+    it("should not allow overwriting when user does not have curate permission on collection (metabase#20717)", () => {
+      const originalQuestion = getQuestion({
+        isSaved: true,
+        name: "Beautiful Orders",
+        can_write: false,
+      });
+      const dirtyQuestion = getDirtyQuestion(originalQuestion);
+      renderSaveQuestionModal(dirtyQuestion, originalQuestion);
+
+      expect(
+        screen.queryByText("Save as new question"),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByText(/Replace original question, ".*"/),
+      ).not.toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
Fixes #20717 

Adding a quick check in `SaveQuestionModal.jsx` to ensure we have can_write permissions on the original card.
![chrome_KKqXVTz56f](https://user-images.githubusercontent.com/1328979/165536231-61609846-b48f-4bf6-8ae1-9d282f27ad3a.gif)

