### PR TITLE
Fix drilling through FKs outside of 2000 rows limit

### DIFF
--- a/frontend/src/metabase/modes/components/drill/ObjectDetailDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/ObjectDetailDrill.jsx
@@ -39,7 +39,7 @@ function getActionForFKColumn({ field, objectId }) {
         objectId,
       );
 
-      return question.getUrl();
+      return question.getUrl({ query: { objectId } });
     },
   ];
 }

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -1554,10 +1554,14 @@ export const loadObjectDetailFKReferences = createThunkAction(
       dispatch.action(CLEAR_OBJECT_DETAIL_FK_REFERENCES);
 
       const state = getState();
+      const tableForeignKeys = getTableForeignKeys(state);
+
+      if (!Array.isArray(tableForeignKeys)) {
+        return null;
+      }
 
       const card = getCard(state);
       const queryResult = getFirstQueryResult(state);
-      const tableForeignKeys = getTableForeignKeys(state);
       const zoomedObjectId = getZoomedObjectId(state);
 
       async function getFKCount(card, queryResult, fk) {

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -1523,33 +1523,35 @@ function getFilterForFK(zoomedObjectId, fk) {
 }
 
 export const FOLLOW_FOREIGN_KEY = "metabase/qb/FOLLOW_FOREIGN_KEY";
-export const followForeignKey = createThunkAction(FOLLOW_FOREIGN_KEY, fk => {
-  return async (dispatch, getState) => {
-    const state = getState();
+export const followForeignKey = createThunkAction(
+  FOLLOW_FOREIGN_KEY,
+  ({ objectId, fk }) => {
+    return async (dispatch, getState) => {
+      const state = getState();
 
-    const card = getCard(state);
-    const queryResult = getFirstQueryResult(state);
-    const zoomedObjectId = getZoomedObjectId(state);
+      const card = getCard(state);
+      const queryResult = getFirstQueryResult(state);
 
-    if (!queryResult || !fk) {
-      return false;
-    }
+      if (!queryResult || !fk) {
+        return false;
+      }
 
-    const newCard = startNewCard("query", card.dataset_query.database);
+      const newCard = startNewCard("query", card.dataset_query.database);
 
-    newCard.dataset_query.query["source-table"] = fk.origin.table.id;
-    newCard.dataset_query.query.filter = getFilterForFK(zoomedObjectId, fk);
+      newCard.dataset_query.query["source-table"] = fk.origin.table.id;
+      newCard.dataset_query.query.filter = getFilterForFK(objectId, fk);
 
-    dispatch(resetRowZoom());
-    dispatch(setCardAndRun(newCard));
-  };
-});
+      dispatch(resetRowZoom());
+      dispatch(setCardAndRun(newCard));
+    };
+  },
+);
 
 export const LOAD_OBJECT_DETAIL_FK_REFERENCES =
   "metabase/qb/LOAD_OBJECT_DETAIL_FK_REFERENCES";
 export const loadObjectDetailFKReferences = createThunkAction(
   LOAD_OBJECT_DETAIL_FK_REFERENCES,
-  () => {
+  ({ objectId }) => {
     return async (dispatch, getState) => {
       dispatch.action(CLEAR_OBJECT_DETAIL_FK_REFERENCES);
 
@@ -1562,7 +1564,6 @@ export const loadObjectDetailFKReferences = createThunkAction(
 
       const card = getCard(state);
       const queryResult = getFirstQueryResult(state);
-      const zoomedObjectId = getZoomedObjectId(state);
 
       async function getFKCount(card, queryResult, fk) {
         const fkQuery = Q_DEPRECATED.createQuery("query");
@@ -1570,7 +1571,7 @@ export const loadObjectDetailFKReferences = createThunkAction(
         fkQuery.database = card.dataset_query.database;
         fkQuery.query["source-table"] = fk.origin.table_id;
         fkQuery.query.aggregation = ["count"];
-        fkQuery.query.filter = getFilterForFK(zoomedObjectId, fk);
+        fkQuery.query.filter = getFilterForFK(objectId, fk);
 
         const info = { status: 0, value: null };
 

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
@@ -63,6 +63,7 @@ const mapStateToProps = (state: unknown, { data }: ObjectDetailProps) => {
     tableForeignKeyReferences: getTableForeignKeyReferences(state),
     zoomedRowID,
     zoomedRow,
+    canZoom: isZooming && !!zoomedRow,
     canZoomPreviousRow,
     canZoomNextRow,
   };
@@ -92,6 +93,7 @@ export interface ObjectDetailProps {
     [key: number]: { status: number; value: number };
   };
   settings: any;
+  canZoom: boolean;
   canZoomPreviousRow: boolean;
   canZoomNextRow: boolean;
   onVisualizationClick: OnVisualizationClickType;
@@ -113,6 +115,7 @@ export function ObjectDetailFn({
   tableForeignKeys,
   tableForeignKeyReferences,
   settings,
+  canZoom,
   canZoomPreviousRow,
   canZoomNextRow,
   onVisualizationClick,
@@ -211,7 +214,6 @@ export function ObjectDetailFn({
     return null;
   }
 
-  const canZoom = !!zoomedRow;
   const objectName = getObjectName({ table, question });
 
   const hasRelationships = tableForeignKeys && !!tableForeignKeys.length;

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
@@ -72,9 +72,10 @@ const mapStateToProps = (state: unknown, { data }: ObjectDetailProps) => {
 const mapDispatchToProps = (dispatch: any) => ({
   fetchTableFks: (id: number) =>
     dispatch(Tables.objectActions.fetchForeignKeys({ id })),
-  followForeignKey: (fk: ForeignKey) => dispatch(followForeignKey(fk)),
   loadObjectDetailFKReferences: (args: any) =>
     dispatch(loadObjectDetailFKReferences(args)),
+  followForeignKey: ({ objectId, fk }: { objectId: number; fk: ForeignKey }) =>
+    dispatch(followForeignKey({ objectId, fk })),
   viewPreviousObjectDetail: () => dispatch(viewPreviousObjectDetail()),
   viewNextObjectDetail: () => dispatch(viewNextObjectDetail()),
   closeObjectDetail: () => dispatch(closeObjectDetail()),
@@ -96,8 +97,8 @@ export interface ObjectDetailProps {
   onVisualizationClick: OnVisualizationClickType;
   visualizationIsClickable: (clicked: any) => boolean;
   fetchTableFks: (id: number) => void;
-  followForeignKey: (fk: ForeignKey) => void;
   loadObjectDetailFKReferences: (opts: { objectId: ObjectId }) => void;
+  followForeignKey: (opts: { objectId: ObjectId; fk: ForeignKey }) => void;
   viewPreviousObjectDetail: () => void;
   viewNextObjectDetail: () => void;
   closeObjectDetail: () => void;
@@ -183,6 +184,13 @@ export function ObjectDetailFn({
     loadFKReferences,
   ]);
 
+  const onFollowForeignKey = useCallback(
+    (fk: ForeignKey) => {
+      followForeignKey({ objectId: zoomedRowID, fk });
+    },
+    [zoomedRowID, followForeignKey],
+  );
+
   const onKeyDown = (event: KeyboardEvent) => {
     const capturedKeys: { [key: string]: () => void } = {
       ArrowUp: viewPreviousObjectDetail,
@@ -241,7 +249,7 @@ export function ObjectDetailFn({
               visualizationIsClickable={visualizationIsClickable}
               tableForeignKeys={tableForeignKeys}
               tableForeignKeyReferences={tableForeignKeyReferences}
-              followForeignKey={followForeignKey}
+              followForeignKey={onFollowForeignKey}
             />
           </div>
         )}

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
@@ -6,7 +6,7 @@ import Question from "metabase-lib/lib/Question";
 import { Table } from "metabase-types/types/Table";
 import { ForeignKey } from "metabase-types/api/foreignKey";
 import { DatasetData } from "metabase-types/types/Dataset";
-import { OnVisualizationClickType } from "./types";
+import { ObjectId, OnVisualizationClickType } from "./types";
 
 import Modal from "metabase/components/Modal";
 import Button from "metabase/core/components/Button";
@@ -71,7 +71,7 @@ export interface ObjectDetailProps {
   question: Question;
   table: Table | null;
   zoomedRow: unknown[] | undefined;
-  zoomedRowID: number;
+  zoomedRowID: ObjectId;
   tableForeignKeys: ForeignKey[];
   tableForeignKeyReferences: {
     [key: number]: { status: number; value: number };
@@ -237,7 +237,7 @@ export function ObjectDetailFn({
 export interface ObjectDetailHeaderProps {
   canZoom: boolean;
   objectName: string;
-  objectId: number | null;
+  objectId: ObjectId;
   canZoomPreviousRow: boolean;
   canZoomNextRow: boolean;
   viewPreviousObjectDetail: () => void;

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.unit.spec.tsx
@@ -93,6 +93,7 @@ describe("Object Detail", () => {
         settings={{
           column: () => null,
         }}
+        canZoom={true}
         canZoomPreviousRow={false}
         canZoomNextRow={false}
         followForeignKey={() => null}

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/types.ts
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/types.ts
@@ -1,3 +1,5 @@
+export type ObjectId = number | string;
+
 export type OnVisualizationClickType =
   | (({
       column,

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/utils.ts
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/utils.ts
@@ -7,6 +7,8 @@ import { Table } from "metabase-types/types/Table";
 import Question from "metabase-lib/lib/Question";
 import { DatasetData } from "metabase-types/types/Dataset";
 
+import { ObjectId } from "./types";
+
 export interface GetObjectNameArgs {
   table: Table | null;
   question: Question;
@@ -29,13 +31,13 @@ export const getObjectName = ({
 
 export interface GetIdValueArgs {
   data: DatasetData;
-  zoomedRowID?: number;
+  zoomedRowID?: ObjectId;
 }
 
 export const getIdValue = ({
   data,
   zoomedRowID,
-}: GetIdValueArgs): number | null => {
+}: GetIdValueArgs): ObjectId | null => {
   if (!data) {
     return null;
   }

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/utils.ts
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/utils.ts
@@ -49,3 +49,7 @@ export const getIdValue = ({
   const columnIndex = _.findIndex(cols, col => isPK(col));
   return rows[0][columnIndex] as number;
 };
+
+export function getSingleResultsRow(data: DatasetData) {
+  return data.rows.length === 1 ? data.rows[0] : null;
+}

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/utils.ts
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/utils.ts
@@ -29,7 +29,7 @@ export const getObjectName = ({
 
 export interface GetIdValueArgs {
   data: DatasetData;
-  zoomedRowID: number;
+  zoomedRowID?: number;
 }
 
 export const getIdValue = ({

--- a/frontend/test/metabase/modes/components/drill/ObjectDetailDrill.unit.spec.js
+++ b/frontend/test/metabase/modes/components/drill/ObjectDetailDrill.unit.spec.js
@@ -3,6 +3,7 @@ import ObjectDetailDrill from "metabase/modes/components/drill/ObjectDetailDrill
 import { ZOOM_IN_ROW } from "metabase/query_builder/actions";
 import {
   ORDERS,
+  PRODUCTS,
   SAMPLE_DATABASE,
   metadata,
 } from "__support__/sample_database_fixture";
@@ -155,15 +156,17 @@ describe("ObjectDetailDrill", () => {
 
     it("should return object detail filter", () => {
       expect(actions).toMatchObject([
-        { name: "object-detail", url: expect.any(Function) },
+        { name: "object-detail", question: expect.any(Function) },
       ]);
     });
 
     it("should apply object detail filter correctly", () => {
       const [action] = actions;
-      const [urlPath, urlHash] = action.url().split("#");
-      expect(urlPath).toBe(`/question?objectId=${cellValue}`);
-      expect(urlHash.length).toBeGreaterThan(0);
+      const card = action.question().card();
+      expect(card.dataset_query.query).toEqual({
+        "source-table": PRODUCTS.id,
+        filter: ["=", PRODUCTS.ID.reference(), cellValue],
+      });
     });
   });
 });

--- a/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
@@ -400,7 +400,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
     cy.wait("@dataset").then(xhr => {
       expect(xhr.response.body.error).not.to.exist;
     });
-    cy.findByText("Fantastic Wool Shirt");
+    cy.findByTestId("object-detail").findByText("Fantastic Wool Shirt");
   });
 
   it("should apply correct date range on a graph drill-through (metabase#13785)", () => {

--- a/frontend/test/metabase/scenarios/visualizations/object_detail.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/object_detail.cy.spec.js
@@ -33,10 +33,7 @@ describe("scenarios > question > object details", () => {
 
   it("handles browsing records by PKs", () => {
     cy.createQuestion(TEST_QUESTION, { visitQuestion: true });
-    getFirstTableColumn()
-      .eq(1)
-      .should("contain", FIRST_ORDER_ID)
-      .click();
+    drillPK({ id: FIRST_ORDER_ID });
 
     assertOrderDetailView({ id: FIRST_ORDER_ID });
     getPreviousObjectDetailButton().should("have.attr", "disabled", "disabled");
@@ -59,10 +56,7 @@ describe("scenarios > question > object details", () => {
     cy.createQuestion(TEST_QUESTION, { visitQuestion: true });
     const FIRST_USER_ID = 1283;
 
-    cy.findByText(String(FIRST_USER_ID)).click();
-    popover()
-      .findByText("View details")
-      .click();
+    drillFK({ id: FIRST_ORDER_ID });
 
     assertUserDetailView({ id: FIRST_USER_ID });
     getPreviousObjectDetailButton().click();
@@ -89,10 +83,7 @@ describe("scenarios > question > object details", () => {
     const EXPECTED_LINKED_REVIEWS_COUNT = 8;
     openProductsTable();
 
-    getFirstTableColumn()
-      .eq(5)
-      .should("contain", 5)
-      .click();
+    drillPK({ id: 5 });
 
     cy.findByTestId("object-detail").within(() => {
       cy.findByTestId("fk-relation-orders").findByText(97);
@@ -122,9 +113,7 @@ describe("scenarios > question > object details", () => {
   it("should not offer drill-through on the object detail records (metabase#20560)", () => {
     openPeopleTable({ limit: 2 });
 
-    cy.get(".Table-ID")
-      .contains("2")
-      .click();
+    drillPK({ id: 2 });
     cy.url().should("contain", "objectId=2");
 
     cy.findByTestId("object-detail")
@@ -138,8 +127,21 @@ describe("scenarios > question > object details", () => {
   });
 });
 
-function getFirstTableColumn() {
-  return cy.get(".TableInteractive-cellWrapper--firstColumn");
+function drillPK({ id }) {
+  cy.get(".Table-ID")
+    .contains(id)
+    .first()
+    .click();
+}
+
+function drillFK({ id }) {
+  cy.get(".Table-FK")
+    .contains(id)
+    .first()
+    .click();
+  popover()
+    .findByText("View details")
+    .click();
 }
 
 function assertDetailView({ id, entityName, byFK = false }) {

--- a/frontend/test/metabase/scenarios/visualizations/object_detail.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/object_detail.cy.spec.js
@@ -149,7 +149,7 @@ function assertDetailView({ id, entityName, byFK = false }) {
     .should("contain", id);
 
   const pattern = byFK
-    ? new RegExp(`/question\\?objectId=${id}#*`)
+    ? new RegExp("/question#*")
     : new RegExp(`/question/[1-9]d*.*/${id}`);
 
   cy.url().should("match", pattern);


### PR DESCRIPTION
Reproduces #21756, fixes #21756

#20101 introduced a new mechanism for PK and FK drills. This PR fixes a regression caused by this change: when trying to open an object detail from a foreign table that is out of the first 2000 foreign table rows, you'll see a "not found" message. The simplest way to reproduce is to open an orders table, sort the "User ID" column desc and try to open a user record with an ID > 2000.

The PR reverts the drilling behavior for FKs. So when you open an object detail in a foreign table, Metabase will create a query to another table with an ID filter. So if we're drilling to "User ID = 2500", Metabase will query `select * from people where ID = 2500`, which guarantees that we'll always have the result as long as it's present in the DB itself. The PR also removes the prev and next buttons for drilled FKs.

### To Verify

1. New > Question > Sample Database > Orders
2. Click the "User ID" column and set the sorting to desc
3. Click a "User ID" cell with ID 2500
4. Ensure you can see the user record details, ensure the data is correct
5. Ensure there are now "previous" and "next" buttons
6. Ensure PK drills work normally

### Demo

**Before**

https://user-images.githubusercontent.com/17258145/165724956-5def4478-9692-4d08-b366-3e71c354b48c.mp4

**After**

https://user-images.githubusercontent.com/17258145/165724981-5bfd4690-3d2a-4e80-bfee-d19b7193f05f.mp4


