### PR TITLE
Widen Object Detail Modal

### DIFF
--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.styled.tsx
@@ -8,10 +8,11 @@ interface ObjectDetailModalProps {
 
 export const ObjectDetailModal = styled.div<ObjectDetailModalProps>`
   border: 1px solid ${colors.border};
-  border-radius: 8px;
+  border-radius: 0.5rem;
   overflow: hidden;
   ${breakpointMinMedium} {
-    width: ${({ wide }) => (wide ? "880px" : "568px")};
+    width: ${({ wide }) => (wide ? "64rem" : "48rem")};
+    max-width: 95vw;
   }
   max-height: 95vh;
   width: 95vw;
@@ -59,4 +60,19 @@ export const CloseButton = styled.div`
 
 export const ErrorWrapper = styled.div`
   height: 480px;
+`;
+
+type GridContainerProps = { cols?: number };
+
+export const GridContainer = styled.div<GridContainerProps>`
+  display: grid;
+  grid-template-columns: repeat(${props => props.cols || 2}, minmax(0, 1fr));
+  gap: 1rem;
+`;
+
+type GridItemProps = { colSpan?: number };
+
+export const GridCell = styled.div<GridItemProps>`
+  grid-column: span ${props => props.colSpan || 1} / span
+    ${props => props.colSpan || 1};
 `;

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
@@ -258,9 +258,9 @@ export function ObjectDetailHeader({
   return (
     <div className="Grid border-bottom relative">
       <div className="Grid-cell">
-        <h1 className="p3">
+        <h2 className="p3">
           {objectName} {objectId}
-        </h1>
+        </h2>
       </div>
       <div className="flex align-center">
         <div className="flex p2">

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailsTable.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailsTable.tsx
@@ -21,6 +21,7 @@ export interface DetailsTableCellProps {
   value: any;
   isColumnName: boolean;
   settings: any;
+  className?: string;
   onVisualizationClick: OnVisualizationClickType;
   visualizationIsClickable: (clicked: unknown) => boolean;
 }
@@ -30,6 +31,7 @@ export function DetailsTableCell({
   value,
   isColumnName,
   settings,
+  className = "",
   onVisualizationClick,
   visualizationIsClickable,
 }: DetailsTableCellProps): JSX.Element {
@@ -75,10 +77,13 @@ export function DetailsTableCell({
   return (
     <div>
       <span
-        className={cx({
-          "cursor-pointer": isClickable,
-          link: isClickable && isLink,
-        })}
+        className={cx(
+          {
+            "cursor-pointer": isClickable,
+            link: isClickable && isLink,
+          },
+          className,
+        )}
         onClick={
           isClickable
             ? e => {
@@ -122,24 +127,21 @@ export function DetailsTable({
                 value={row[columnIndex]}
                 isColumnName
                 settings={settings}
+                className="text-bold text-medium"
                 onVisualizationClick={onVisualizationClick}
                 visualizationIsClickable={visualizationIsClickable}
               />
             </GridCell>
             <GridCell colSpan={2}>
-              <div
-                style={{ wordWrap: "break-word" }}
-                className="text-bold text-dark"
-              >
-                <DetailsTableCell
-                  column={column}
-                  value={row[columnIndex]}
-                  isColumnName={false}
-                  settings={settings}
-                  onVisualizationClick={onVisualizationClick}
-                  visualizationIsClickable={visualizationIsClickable}
-                />
-              </div>
+              <DetailsTableCell
+                column={column}
+                value={row[columnIndex]}
+                isColumnName={false}
+                settings={settings}
+                className="text-bold text-dark text-spaced text-wrap"
+                onVisualizationClick={onVisualizationClick}
+                visualizationIsClickable={visualizationIsClickable}
+              />
             </GridCell>
           </>
         ))}

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailsTable.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailsTable.tsx
@@ -10,7 +10,11 @@ import { TYPE, isa } from "metabase/lib/types";
 import { formatValue, formatColumn } from "metabase/lib/formatting";
 
 import { OnVisualizationClickType } from "./types";
-import { ObjectDetailsTable } from "./ObjectDetail.styled";
+import {
+  ObjectDetailsTable,
+  GridContainer,
+  GridCell,
+} from "./ObjectDetail.styled";
 
 export interface DetailsTableCellProps {
   column: any;
@@ -109,33 +113,37 @@ export function DetailsTable({
 
   return (
     <ObjectDetailsTable>
-      {cols.map((column, columnIndex) => (
-        <div className="Grid Grid--1of2 mb2" key={columnIndex}>
-          <div className="Grid-cell">
-            <DetailsTableCell
-              column={column}
-              value={row[columnIndex]}
-              isColumnName
-              settings={settings}
-              onVisualizationClick={onVisualizationClick}
-              visualizationIsClickable={visualizationIsClickable}
-            />
-          </div>
-          <div
-            style={{ wordWrap: "break-word" }}
-            className="Grid-cell text-bold text-dark"
-          >
-            <DetailsTableCell
-              column={column}
-              value={row[columnIndex]}
-              isColumnName={false}
-              settings={settings}
-              onVisualizationClick={onVisualizationClick}
-              visualizationIsClickable={visualizationIsClickable}
-            />
-          </div>
-        </div>
-      ))}
+      <GridContainer cols={3}>
+        {cols.map((column, columnIndex) => (
+          <>
+            <GridCell>
+              <DetailsTableCell
+                column={column}
+                value={row[columnIndex]}
+                isColumnName
+                settings={settings}
+                onVisualizationClick={onVisualizationClick}
+                visualizationIsClickable={visualizationIsClickable}
+              />
+            </GridCell>
+            <GridCell colSpan={2}>
+              <div
+                style={{ wordWrap: "break-word" }}
+                className="text-bold text-dark"
+              >
+                <DetailsTableCell
+                  column={column}
+                  value={row[columnIndex]}
+                  isColumnName={false}
+                  settings={settings}
+                  onVisualizationClick={onVisualizationClick}
+                  visualizationIsClickable={visualizationIsClickable}
+                />
+              </div>
+            </GridCell>
+          </>
+        ))}
+      </GridContainer>
     </ObjectDetailsTable>
   );
 }

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailsTable.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailsTable.tsx
@@ -120,7 +120,7 @@ export function DetailsTable({
     <ObjectDetailsTable>
       <GridContainer cols={3}>
         {cols.map((column, columnIndex) => (
-          <>
+          <React.Fragment key={columnIndex}>
             <GridCell>
               <DetailsTableCell
                 column={column}
@@ -143,7 +143,7 @@ export function DetailsTable({
                 visualizationIsClickable={visualizationIsClickable}
               />
             </GridCell>
-          </>
+          </React.Fragment>
         ))}
       </GridContainer>
     </ObjectDetailsTable>

--- a/frontend/test/metabase/scenarios/visualizations/object_detail.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/object_detail.cy.spec.js
@@ -144,7 +144,6 @@ function getFirstTableColumn() {
 
 function assertDetailView({ id, entityName, byFK = false }) {
   cy.get("h2")
-    .parent()
     .should("contain", entityName)
     .should("contain", id);
 

--- a/frontend/test/metabase/scenarios/visualizations/object_detail.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/object_detail.cy.spec.js
@@ -143,7 +143,7 @@ function getFirstTableColumn() {
 }
 
 function assertDetailView({ id, entityName, byFK = false }) {
-  cy.get("h1")
+  cy.get("h2")
     .parent()
     .should("contain", entityName)
     .should("contain", id);


### PR DESCRIPTION
## Before

Longer text content was kind of hard to read in the new object detail modal, because only a few words could fit on each line. e.g: 

![Screenshot from 2022-04-27 11-01-16](https://user-images.githubusercontent.com/30528226/165580557-0cf24b66-c898-436a-bb9c-9151730e455e.png)

## Changes

- widened the object detail modal
- changed column content in the modal from 1/2 width to 2/3 width (using CSS Grid now)
- (unrelated: made the modal header text smaller, and tweaked text styling)

## After

Instead of 5-6 words per line, we see 10-12.

![Screenshot from 2022-04-27 13-24-50](https://user-images.githubusercontent.com/30528226/165604345-126e9046-d613-4a88-8cce-1be00210374d.png)






