### PR TITLE
Set MySQL/MariaDB query timeout to 20 minutes

### DIFF
--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -345,6 +345,7 @@
      default-connection-args
      ;; newer versions of MySQL will complain if you don't specify this when not using SSL
      {:useSSL (boolean ssl?)}
+     {:sessionVariables "max_statement_time=1200"} ; Configure a timeout of 20 minutes, our prod timeout.
      (let [details (-> (if ssl-cert? (set/rename-keys details {:ssl-cert :serverSslCert}) details)
                        (set/rename-keys {:dbname :db})
                        (dissoc :ssl))]


### PR DESCRIPTION
**Background**

`max_statement_time` is an environment variable in MySQL, which can be
set in a cascading way by config files, `mysqld` command line, the JDBC
connection or an individual query.

**Problem**

MySQL's default timeout is 0 (no timeout) but if the environment (say,
Amazon RDS) sets it at the server level, it applies to Metabase queries.

**Solution**

This sets `max_statement_time` to 1200 seconds = 20 minutes, the same as
the Metabase prod timeout. (Metabase's own shorter timeouts for dev and
testing continue to apply.)

Fixes #19383.