### PR TITLE
invalidate revisions on question revert

### DIFF
--- a/frontend/src/metabase/entities/revisions.js
+++ b/frontend/src/metabase/entities/revisions.js
@@ -23,16 +23,14 @@ const Revision = createEntity({
 
   objectActions: {
     // use thunk since we don't actually want to dispatch an action
-    revert: revision => (dispatch, getState) => {
-      return Revision.api
-        .revert({
-          entity: revision.model_type,
-          id: revision.model_id,
-          revision_id: revision.id,
-        })
-        .then(() => {
-          return dispatch(Revision.actions.invalidateLists());
-        });
+    revert: revision => async (dispatch, getState) => {
+      await Revision.api.revert({
+        entity: revision.model_type,
+        id: revision.model_id,
+        revision_id: revision.id,
+      });
+
+      return dispatch(Revision.actions.invalidateLists());
     },
   },
 

--- a/frontend/src/metabase/entities/revisions.js
+++ b/frontend/src/metabase/entities/revisions.js
@@ -23,12 +23,17 @@ const Revision = createEntity({
 
   objectActions: {
     // use thunk since we don't actually want to dispatch an action
-    revert: revision => (dispatch, getState) =>
-      Revision.api.revert({
-        entity: revision.model_type,
-        id: revision.model_id,
-        revision_id: revision.id,
-      }),
+    revert: revision => (dispatch, getState) => {
+      return Revision.api
+        .revert({
+          entity: revision.model_type,
+          id: revision.model_id,
+          revision_id: revision.id,
+        })
+        .then(() => {
+          return dispatch(Revision.actions.invalidateLists());
+        });
+    },
   },
 
   actionShouldInvalidateLists(action) {

--- a/frontend/test/metabase/scenarios/question/saved.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/saved.cy.spec.js
@@ -133,6 +133,7 @@ describe("scenarios > question > saved", () => {
 
     cy.findByRole("button", { name: "Revert" }).click();
 
+    cy.findByText(/Reverted to an earlier revision/i);
     cy.findByText(/This is a question/i).should("not.exist");
   });
 


### PR DESCRIPTION
Revision lists were not updating after reverting to a previous version. Dispatching a quick invalidation action after the revert call remedies the issue. Also updated a relevant test that had been adjusted in https://github.com/metabase/metabase/pull/19466

Before PR:
![chrome_uq37elhry9](https://user-images.githubusercontent.com/1328979/165601465-c7d78e0e-f656-4da1-aebc-b4032dbdc3cf.gif)

After PR:
![chrome_DpbkcU4u8q](https://user-images.githubusercontent.com/1328979/165601045-4f84736b-4014-4462-aa95-4ff2c37f6e7b.gif)

