### PR TITLE
Don't hard-code timeout in Druid driver

### DIFF
--- a/modules/drivers/druid/src/metabase/driver/druid.clj
+++ b/modules/drivers/druid/src/metabase/driver/druid.clj
@@ -37,10 +37,10 @@
     (assoc-in parsed [:context :timeout] timeout)))
 
 (defmethod driver/execute-reducible-query :druid
-  [_ query {:keys [timeout] :as context} respond]
+  [_ query context respond]
   (druid.execute/execute-reducible-query
     (partial druid.client/do-query-with-cancellation (qp.context/canceled-chan context))
-    (update-in query [:native :query] add-timeout-to-query timeout)
+    (update-in query [:native :query] add-timeout-to-query (qp.context/timeout context))
     respond))
 
 (doseq [[feature supported?] {:set-timezone            true

--- a/modules/drivers/druid/src/metabase/driver/druid.clj
+++ b/modules/drivers/druid/src/metabase/driver/druid.clj
@@ -1,6 +1,7 @@
 (ns metabase.driver.druid
   "Druid driver."
-  (:require [clj-http.client :as http]
+  (:require [cheshire.core :as json]
+            [clj-http.client :as http]
             [metabase.driver :as driver]
             [metabase.driver.druid.client :as druid.client]
             [metabase.driver.druid.execute :as druid.execute]
@@ -29,11 +30,18 @@
   [_ query]
   (druid.qp/mbql->native query))
 
+(defn- add-timeout-to-query [query timeout]
+  (let [parsed (if (string? query)
+                 (json/parse-string query keyword)
+                 query)]
+    (assoc-in parsed [:context :timeout] timeout)))
+
 (defmethod driver/execute-reducible-query :druid
-  [_ query context respond]
+  [_ query {:keys [timeout] :as context} respond]
   (druid.execute/execute-reducible-query
     (partial druid.client/do-query-with-cancellation (qp.context/canceled-chan context))
-    query respond))
+    (update-in query [:native :query] add-timeout-to-query timeout)
+    respond))
 
 (doseq [[feature supported?] {:set-timezone            true
                               :expression-aggregations true}]

--- a/modules/drivers/druid/src/metabase/driver/druid/query_processor.clj
+++ b/modules/drivers/druid/src/metabase/driver/druid/query_processor.clj
@@ -136,8 +136,7 @@
   (merge
    {:intervals   ["1900-01-01/2100-01-01"]
     :granularity :all
-    :context     {:timeout 60000
-                  :queryId (random-query-id)}}
+    :context     {:queryId (random-query-id)}}
    (case query-type
      ::scan               {:queryType :scan
                            :limit     qp.i/absolute-max-results}

--- a/modules/drivers/druid/test/metabase/driver/druid/client_test.clj
+++ b/modules/drivers/druid/test/metabase/driver/druid/client_test.clj
@@ -35,26 +35,12 @@
     (tqpt/with-flattened-dbdef
       (let [query (mt/mbql-query checkins)
             executed-query (atom nil)]
-        (mt/with-open-channels [running-chan (a/promise-chan)
-                                cancel-chan  (a/promise-chan)]
-          (with-redefs [druid.client/DELETE   (fn [& _]
-                                                (a/>!! cancel-chan ::cancel))
-                        druid.client/do-query (fn [_ query]
-                                                (a/>!! running-chan ::running)
-                                                (reset! executed-query query)
-                                                (Thread/sleep 5000)
-                                                (throw (Exception. "Don't actually run!")))]
-
-            (let [out-chan (qp/process-query-async query)]
-              ;; wait for query to start running, then close `out-chan`
-              (a/go
-                (a/<! running-chan)
-                (a/close! out-chan)))
-            (is (= ::cancel
-                   (mt/wait-for-result cancel-chan 2000)))
-            ;; Check the query as executed to see if it got the timeout applied correctly (3 minutes in tests)
-            (is (partial= {:context {:timeout default/query-timeout-ms}}
-                          @executed-query))))))))
+        (with-redefs [druid.client/do-query-with-cancellation (fn [_chan _details query]
+                                                                (reset! executed-query query)
+                                                                [])]
+          (qp/process-query-sync query)
+          (is (partial= {:context {:timeout default/query-timeout-ms}}
+                        @executed-query)))))))
 
 (deftest ssh-tunnel-test
   (mt/test-driver

--- a/modules/drivers/druid/test/metabase/driver/druid/query_processor_test.clj
+++ b/modules/drivers/druid/test/metabase/driver/druid/query_processor_test.clj
@@ -106,7 +106,7 @@
                             :granularity      :all
                             :dataSource       "checkins"
                             :dimension        "venue_price"
-                            :context          {:timeout 60000, :queryId "<Query ID>"}
+                            :context          {:queryId "<Query ID>"}
                             :postAggregations [{:type   :arithmetic
                                                 :name   "expression"
                                                 :fn     :*
@@ -135,7 +135,7 @@
                             :granularity  :all
                             :dataSource   "checkins"
                             :dimension    "venue_category_name"
-                            :context      {:timeout 60000, :queryId "<Query ID>"}
+                            :context      {:queryId "<Query ID>"}
                             :intervals    ["1900-01-01/2100-01-01"]
                             :metric       "__count_0"
                             :aggregations [{:type       :cardinality
@@ -159,7 +159,7 @@
                             :granularity  :all
                             :dataSource   "checkins"
                             :dimensions   ["venue_category_name", "user_name"]
-                            :context      {:timeout 60000, :queryId "<Query ID>"}
+                            :context      {:queryId "<Query ID>"}
                             :intervals    ["1900-01-01/2100-01-01"]
                             :aggregations [{:type       :cardinality
                                             :name       "__count_0"
@@ -186,7 +186,7 @@
                             :granularity  :all
                             :dataSource   "checkins"
                             :dimensions   ["venue_category_name", "user_name"]
-                            :context      {:timeout 60000, :queryId "<Query ID>"}
+                            :context      {:queryId "<Query ID>"}
                             :intervals    ["1900-01-01/2100-01-01"]
                             :aggregations [{:type       :cardinality
                                             :name       "__count_0"
@@ -214,7 +214,7 @@
                 :query       {:queryType        :timeseries
                               :granularity      :all
                               :dataSource       "checkins"
-                              :context          {:timeout 60000, :queryId "<Query ID>"}
+                              :context          {:queryId "<Query ID>"}
                               :intervals        ["1900-01-01/2100-01-01"]
                               :aggregations     [{:type       :cardinality
                                                   :name       "__distinct_0"


### PR DESCRIPTION
It should come from the context, like all the other drivers.

Fixes #18078
