### PR TITLE
Ignore exceptions when updating permissions in test macro

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -26,7 +26,8 @@
            (@#'perms/update-group-permissions! all-users-group-id graph))
           (f))
         (finally
-          (@#'perms/update-group-permissions! all-users-group-id current-graph))))))
+          (u/ignore-exceptions
+           (@#'perms/update-group-permissions! all-users-group-id graph)))))))
 
 (defmacro ^:private with-all-users-data-perms
   "Runs `f` with perms for the All Users group temporarily set to the values in `graph`. Also enables the advanced

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -27,7 +27,7 @@
           (f))
         (finally
           (u/ignore-exceptions
-           (@#'perms/update-group-permissions! all-users-group-id graph)))))))
+           (@#'perms/update-group-permissions! all-users-group-id current-graph)))))))
 
 (defmacro ^:private with-all-users-data-perms
   "Runs `f` with perms for the All Users group temporarily set to the values in `graph`. Also enables the advanced

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -22,7 +22,8 @@
       (memoize/memo-clear! @#'field/cached-perms-object-set)
       (try
         (mt/with-model-cleanup [Permissions]
-          (@#'perms/update-group-permissions! all-users-group-id graph)
+          (u/ignore-exceptions
+           (@#'perms/update-group-permissions! all-users-group-id graph))
           (f))
         (finally
           (@#'perms/update-group-permissions! all-users-group-id current-graph))))))


### PR DESCRIPTION
There are some test flakes that seem to be caused by this macro trying to add permissions to the DB which already exist, thus violating the unique constraint on permission paths. (i.e. if a separate test which ran previously left some state in the `permissions` table)

I don't totally understand why these flakes only happen some of the time, but in the meantime I think it should be fine to ignore any exceptions that occur here. (The important thing is that we don't ignore exceptions in the test body itself, but if a permission path that we're trying to put in the DB already exists, that's fine.)