### PR TITLE
fix y-axis scatter extend calculation

### DIFF
--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -126,13 +126,11 @@ function getXAxisProps(props, datas, warn) {
 ///------------------------------------------------------------ DIMENSIONS & GROUPS ------------------------------------------------------------///
 
 function getDimensionsAndGroupsForScatterChart(datas) {
-  const dataset = crossfilter();
-  datas.map(data => dataset.add(data));
-
+  const dataset = crossfilter(datas);
   const dimension = dataset.dimension(row => row);
   const groups = datas.map(data => {
     const dim = crossfilter(data).dimension(row => row);
-    return [dim.group().reduceSum(d => d[2] || 1)];
+    return [dim.group().reduceSum(d => d[1] ?? 1)];
   });
 
   return { dimension, groups };

--- a/frontend/test/metabase-visual/visualizations/scatter.cy.spec.js
+++ b/frontend/test/metabase-visual/visualizations/scatter.cy.spec.js
@@ -39,4 +39,31 @@ describe("visual tests > visualizations > scatter", () => {
 
     cy.percySnapshot();
   });
+
+  it("with log axes", () => {
+    visitQuestionAdhoc({
+      dataset_query: {
+        type: "native",
+        native: {
+          query: `select 1 x, 1 y
+                  union all select 10 x, 10 y
+                  union all select 100 x, 100 y
+                  union all select 200 x, 200 y
+                  union all select 10000 x, 10000 y`,
+        },
+        database: SAMPLE_DB_ID,
+      },
+      display: "scatter",
+
+      displayIsLocked: true,
+      visualization_settings: {
+        "graph.dimensions": ["X"],
+        "graph.metrics": ["Y"],
+        "graph.x_axis.scale": "log",
+        "graph.y_axis.scale": "log",
+      },
+    });
+
+    cy.percySnapshot();
+  });
 });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/20822

## Changes

While grouping data for scatter chart it used wrong index for y-axis values. This led to invalid y-axis extent calculation [1, 1] which somehow worked with a linear scale correctly.

## How to verify

- Create a native query
```
select 1 x, 1 y
union all  select 10 x, 10 y
union all  select 100 x, 100 y
union all  select 200 x, 200 y
union all  select 10000 x, 10000 y
```
- Change y-axis type to log and ensure it looks correct

**Before**
<img width="1155" alt="Screenshot 2022-04-28 at 03 09 53" src="https://user-images.githubusercontent.com/14301985/165646002-9ea91ada-a920-42c0-964e-799d0050210d.png">

**After**
<img width="1157" alt="Screenshot 2022-04-28 at 03 09 25" src="https://user-images.githubusercontent.com/14301985/165646026-29b1a89b-c0d4-4630-bd7a-2c8a0247ee30.png">