### PR TITLE
Allow navbar on embedded homepage

### DIFF
--- a/frontend/src/metabase/App.tsx
+++ b/frontend/src/metabase/App.tsx
@@ -102,8 +102,10 @@ function App({
       return false;
     }
     if (IFRAMED) {
-      return EMBEDDED_ROUTES_WITH_NAVBAR.some(path =>
-        pathname.startsWith(path),
+      const isHomepage = pathname === "/";
+      return (
+        isHomepage ||
+        EMBEDDED_ROUTES_WITH_NAVBAR.some(path => pathname.startsWith(path))
       );
     }
     return !PATHS_WITHOUT_NAVBAR.some(pattern => pattern.test(pathname));

--- a/frontend/src/metabase/App.tsx
+++ b/frontend/src/metabase/App.tsx
@@ -47,7 +47,12 @@ const getErrorComponent = ({ status, data, context }: AppErrorDescriptor) => {
 
 const PATHS_WITHOUT_NAVBAR = [/\/model\/.*\/query/, /\/model\/.*\/metadata/];
 
-const EMBEDDED_ROUTES_WITH_NAVBAR = ["/collection", "/archive"];
+const HOMEPAGE_PATTERN = /^\/$/;
+const EMBEDDED_ROUTES_WITH_NAVBAR = [
+  HOMEPAGE_PATTERN,
+  /^\/collection\/.*/,
+  /^\/archive/,
+];
 
 interface AppStateProps {
   currentUser?: User;
@@ -102,10 +107,8 @@ function App({
       return false;
     }
     if (IFRAMED) {
-      const isHomepage = pathname === "/";
-      return (
-        isHomepage ||
-        EMBEDDED_ROUTES_WITH_NAVBAR.some(path => pathname.startsWith(path))
+      return EMBEDDED_ROUTES_WITH_NAVBAR.some(pattern =>
+        pattern.test(pathname),
       );
     }
     return !PATHS_WITHOUT_NAVBAR.some(pattern => pattern.test(pathname));


### PR DESCRIPTION
Fixes #21954: makes it show the new navbar on the homepage in a full-app embedding environment. Same spirit as #21352

<img width="1512" alt="CleanShot 2022-04-28 at 11 18 59@2x" src="https://user-images.githubusercontent.com/17258145/165733887-0cd7065a-07cb-4728-aad4-6e47dcf2cf7f.png">

