### PR TITLE
fix permissions url with a schema name

### DIFF
--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/tables.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/tables.ts
@@ -21,6 +21,7 @@ import {
 } from "../confirmations";
 import { Group, GroupsPermissions } from "metabase-types/api";
 import { SchemaEntityId } from "../../types";
+import { getGroupFocusPermissionsUrl } from "../../utils/urls";
 
 const buildAccessPermission = (
   entityId: SchemaEntityId,
@@ -66,10 +67,7 @@ const buildAccessPermission = (
     warning,
     confirmations,
     postActions: {
-      controlled: () =>
-        push(
-          `/admin/permissions/data/group/${groupId}/database/${entityId.databaseId}/schema/${entityId.schemaName}`,
-        ),
+      controlled: () => push(getGroupFocusPermissionsUrl(groupId, entityId)),
     },
     options: PLUGIN_ADVANCED_PERMISSIONS.addSchemaPermissionOptions(
       [


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/22047

## How to verify
- Connect a db with a schema called `special_/_#_%_'__._&_>_:_ _end`
- Open Permissions -> Groups -> select "All Users" in the sidebar
- Select the database that contains the schema in the permission editor
- For the schema try to change Data Access permission to "Granular"
- Ensure it opens permisions for tables of the schema