### PR TITLE
Fix images in markdown for events

### DIFF
--- a/frontend/src/metabase/core/components/Markdown/Markdown.styled.tsx
+++ b/frontend/src/metabase/core/components/Markdown/Markdown.styled.tsx
@@ -22,6 +22,11 @@ export const MarkdownRoot = styled(getComponent(ReactMarkdown))`
   a:hover {
     text-decoration: underline;
   }
+
+  img {
+    max-width: 100%;
+    height: auto;
+  }
 `;
 
 function getComponent<P>(component: (props: P) => ReactElement): FC<P> {


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/20289

How to test:
- Create a timeseries question in the query builder
- Open the events sidebar
- Add an event with the following description `![Image](https://upload.wikimedia.org/wikipedia/commons/2/28/JPG_Test.jpg)`
- Check that the image is resized to fix the sidebar

<img width="305" alt="Screenshot 2022-04-28 at 15 49 41" src="https://user-images.githubusercontent.com/8542534/165755964-c5a4b66c-fbcf-4197-a236-dbdc626793b4.png">
<img width="650" alt="Screenshot 2022-04-28 at 15 49 48" src="https://user-images.githubusercontent.com/8542534/165755990-4a7cd48a-9cf4-4a2c-936a-2c5bf387327e.png">
