### PR TITLE
Fix dashboard PK drill on filtered data

### DIFF
--- a/frontend/src/metabase-lib/lib/Question.ts
+++ b/frontend/src/metabase-lib/lib/Question.ts
@@ -1266,7 +1266,7 @@ export default class Question {
     return isAltered ? question.markDirty() : question;
   }
 
-  getUrlWithParameters(parameters, parameterValues) {
+  getUrlWithParameters(parameters, parameterValues, { objectId } = {}) {
     const includeDisplayIsLocked = true;
 
     if (this.isStructured()) {
@@ -1279,6 +1279,7 @@ export default class Question {
           .getUrl({
             originalQuestion: this,
             includeDisplayIsLocked,
+            query: { objectId },
           });
       } else {
         const query = getParameterValuesBySlug(parameters, parameterValues);

--- a/frontend/src/metabase/dashboard/actions.js
+++ b/frontend/src/metabase/dashboard/actions.js
@@ -1032,7 +1032,7 @@ export const deletePublicLink = createAction(
 const NAVIGATE_TO_NEW_CARD = "metabase/dashboard/NAVIGATE_TO_NEW_CARD";
 export const navigateToNewCardFromDashboard = createThunkAction(
   NAVIGATE_TO_NEW_CARD,
-  ({ nextCard, previousCard, dashcard }) => (dispatch, getState) => {
+  ({ nextCard, previousCard, dashcard, objectId }) => (dispatch, getState) => {
     const metadata = getMetadata(getState());
     const { dashboardId, dashboards, parameterValues } = getState().dashboard;
     const dashboard = dashboards[dashboardId];
@@ -1059,11 +1059,14 @@ export const navigateToNewCardFromDashboard = createThunkAction(
       dashcard,
     );
 
-    // when the query is for a specific object it does not make sense to apply parameter filters
+    // when the query is for a specific object (ie `=` filter on PK column)
+    // it does not make sense to apply parameter filters
     // because we'll be navigating to the details view of a specific row on a table
     const url = question.isObjectDetail()
       ? Urls.serializedQuestion(question.card())
-      : question.getUrlWithParameters(parametersMappedToCard, parameterValues);
+      : question.getUrlWithParameters(parametersMappedToCard, parameterValues, {
+          objectId,
+        });
 
     dispatch(openUrl(url));
   },

--- a/frontend/src/metabase/dashboard/components/DashCard.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard.jsx
@@ -270,12 +270,13 @@ export default class DashCard extends Component {
           mode={mode}
           onChangeCardAndRun={
             navigateToNewCardFromDashboard
-              ? ({ nextCard, previousCard }) => {
+              ? ({ nextCard, previousCard, objectId }) => {
                   // navigateToNewCardFromDashboard needs `dashcard` for applying active filters to the query
                   navigateToNewCardFromDashboard({
                     nextCard,
                     previousCard,
                     dashcard,
+                    objectId,
                   });
                 }
               : null

--- a/frontend/src/metabase/lib/urls/questions.ts
+++ b/frontend/src/metabase/lib/urls/questions.ts
@@ -34,6 +34,7 @@ export function question(
 
   if (query && typeof query === "object") {
     query = extractQueryParams(query)
+      .filter(([key, value]) => value !== undefined)
       .map(kv => kv.map(encodeURIComponent).join("="))
       .join("&");
   }

--- a/frontend/src/metabase/modes/components/drill/ObjectDetailDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/ObjectDetailDrill.jsx
@@ -1,6 +1,5 @@
 import { t } from "ttag";
 import { isFK, isPK } from "metabase/lib/schema_metadata";
-import * as Urls from "metabase/lib/urls";
 import { zoomInRow } from "metabase/query_builder/actions";
 
 function hasManyPKColumns(question) {
@@ -19,7 +18,9 @@ function getActionForPKColumn({ question, column, objectId, isDashboard }) {
     return ["question", () => question.filter("=", column, objectId)];
   }
   if (isDashboard) {
-    return ["url", () => Urls.question(question.card(), { objectId })];
+    const getNextQuestion = () => question;
+    const getExtraData = () => ({ objectId });
+    return ["question", getNextQuestion, getExtraData];
   }
   return ["action", () => zoomInRow({ objectId })];
 }
@@ -37,13 +38,16 @@ function getBaseActionObject() {
 
 function getPKAction({ question, column, objectId, isDashboard }) {
   const actionObject = getBaseActionObject();
-  const [actionKey, action] = getActionForPKColumn({
+  const [actionKey, action, extra] = getActionForPKColumn({
     question,
     column,
     objectId,
     isDashboard,
   });
   actionObject[actionKey] = action;
+  if (extra) {
+    actionObject.extra = extra;
+  }
   return actionObject;
 }
 

--- a/frontend/src/metabase/visualizations/components/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization.jsx
@@ -277,13 +277,13 @@ export default class Visualization extends React.PureComponent {
   };
 
   // Add the underlying card of current series to onChangeCardAndRun if available
-  handleOnChangeCardAndRun = ({ nextCard, seriesIndex }) => {
+  handleOnChangeCardAndRun = ({ nextCard, seriesIndex, objectId }) => {
     const { series, clicked } = this.state;
 
     const index = seriesIndex || (clicked && clicked.seriesIndex) || 0;
     const previousCard = series && series[index] && series[index].card;
 
-    this.props.onChangeCardAndRun({ nextCard, previousCard });
+    this.props.onChangeCardAndRun({ nextCard, previousCard, objectId });
   };
 
   onRender = ({ yAxisSplit, warnings = [] } = {}) => {

--- a/frontend/src/metabase/visualizations/lib/action.js
+++ b/frontend/src/metabase/visualizations/lib/action.js
@@ -21,8 +21,9 @@ export function performAction(action, { dispatch, onChangeCardAndRun }) {
   }
   if (action.question) {
     const question = action.question();
+    const extra = action?.extra?.() ?? {};
     if (question) {
-      onChangeCardAndRun({ nextCard: question.card() });
+      onChangeCardAndRun({ nextCard: question.card(), ...extra });
       didPerform = true;
     }
   }

--- a/frontend/test/metabase-lib/lib/Question.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/Question.unit.spec.js
@@ -1247,6 +1247,21 @@ describe("Question", () => {
           },
         });
       });
+
+      it("should include objectId in a URL", () => {
+        const OBJECT_ID = "5";
+        const url = question.getUrlWithParameters(
+          parameters,
+          { "1": "bar" },
+          { objectId: OBJECT_ID },
+        );
+
+        expect(parseUrl(url)).toEqual({
+          pathname: "/question",
+          query: { objectId: OBJECT_ID },
+          card: expect.any(Object),
+        });
+      });
     });
 
     describe("with structured question & no permissions", () => {
@@ -1272,6 +1287,16 @@ describe("Question", () => {
           },
           card: deserializedCard,
         });
+      });
+
+      it("should not include objectId in a URL", () => {
+        const url = question.getUrlWithParameters(
+          parameters,
+          { "1": "bar" },
+          { objectId: 5 },
+        );
+
+        expect(parseUrl(url).query.objectId).toBeUndefined();
       });
     });
 
@@ -1348,6 +1373,13 @@ describe("Question", () => {
           query: { bar: "111" },
           card: null,
         });
+      });
+
+      it("should not include objectId in a URL", () => {
+        const url = question.getUrlWithParameters(parametersForNativeQ, {
+          "1": "bar",
+        });
+        expect(parseUrl(url).query.objectId).toBeUndefined();
       });
     });
   });

--- a/frontend/test/metabase/lib/urls.unit.spec.js
+++ b/frontend/test/metabase/lib/urls.unit.spec.js
@@ -38,6 +38,21 @@ describe("urls", () => {
           "/question?foo=bar&foo=baz%26bay",
         );
       });
+
+      it("does not include undefined params", () => {
+        expect(question(null, { query: { foo: undefined } })).toEqual(
+          "/question",
+        );
+        expect(
+          question(null, { query: { foo: undefined, bar: "bar" } }),
+        ).toEqual("/question?bar=bar");
+      });
+
+      it("includes null params", () => {
+        expect(question(null, { query: { foo: null } })).toEqual(
+          "/question?foo=null",
+        );
+      });
     });
 
     describe("question ids", () => {

--- a/frontend/test/metabase/modes/components/drill/ObjectDetailDrill.unit.spec.js
+++ b/frontend/test/metabase/modes/components/drill/ObjectDetailDrill.unit.spec.js
@@ -126,11 +126,42 @@ describe("ObjectDetailDrill", () => {
     });
 
     describe("from dashboard", () => {
+      describe("without parameters", () => {
+        const { actions, cellValue } = setup({
+          question: SAVED_QUESTION,
+          column: ORDERS.ID.column(),
+          extraData: {
+            dashboard: { id: 5 },
+          },
+        });
+
+        it("should return object detail filter", () => {
+          expect(actions).toMatchObject([
+            {
+              name: "object-detail",
+              url: expect.any(Function),
+            },
+          ]);
+        });
+
+        it("should return correct URL to object detail", () => {
+          const [action] = actions;
+          expect(action.url()).toBe(
+            `/question/${SAVED_QUESTION.id()}-${SAVED_QUESTION.displayName()}/${cellValue}`,
+          );
+        });
+      });
+    });
+
+    describe("with parameters", () => {
       const { actions, cellValue } = setup({
         question: SAVED_QUESTION,
         column: ORDERS.ID.column(),
         extraData: {
           dashboard: { id: 5 },
+          parameterValuesBySlug: {
+            foo: "bar",
+          },
         },
       });
 

--- a/frontend/test/metabase/modes/components/drill/ObjectDetailDrill.unit.spec.js
+++ b/frontend/test/metabase/modes/components/drill/ObjectDetailDrill.unit.spec.js
@@ -144,7 +144,7 @@ describe("ObjectDetailDrill", () => {
         ]);
       });
 
-      it("should return correct URL to object detail", () => {
+      it("should return correct action", () => {
         const [action] = actions;
         expect(action.question()).toBe(SAVED_QUESTION);
         expect(action.extra()).toEqual({ objectId: cellValue });

--- a/frontend/test/metabase/modes/components/drill/ObjectDetailDrill.unit.spec.js
+++ b/frontend/test/metabase/modes/components/drill/ObjectDetailDrill.unit.spec.js
@@ -136,15 +136,18 @@ describe("ObjectDetailDrill", () => {
 
       it("should return object detail filter", () => {
         expect(actions).toMatchObject([
-          { name: "object-detail", url: expect.any(Function) },
+          {
+            name: "object-detail",
+            question: expect.any(Function),
+            extra: expect.any(Function),
+          },
         ]);
       });
 
       it("should return correct URL to object detail", () => {
         const [action] = actions;
-        expect(action.url()).toBe(
-          `/question/${SAVED_QUESTION.id()}-${SAVED_QUESTION.displayName()}/${cellValue}`,
-        );
+        expect(action.question()).toBe(SAVED_QUESTION);
+        expect(action.extra()).toEqual({ objectId: cellValue });
       });
     });
   });

--- a/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
@@ -661,8 +661,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
   });
 
   it('should drill-through on PK/FK to the "object detail" when filtered by explicit joined column (metabase#15331)', () => {
-    cy.server();
-    cy.route("POST", "/api/card/*/query").as("cardQuery");
+    cy.intercept("POST", "/api/dataset").as("dataset");
 
     cy.createQuestion({
       name: "15331",
@@ -739,7 +738,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
       .contains("1")
       .click();
 
-    cy.wait("@cardQuery").then(xhr => {
+    cy.wait("@dataset").then(xhr => {
       expect(xhr.response.body.error).to.not.exist;
     });
     cy.findByTestId("object-detail");


### PR DESCRIPTION
Followup to [this issue](https://github.com/metabase/metabase/pull/22140#pullrequestreview-956252620) from #22140 that @flamber has mentioned

A similar problem to #21756 (seeing not found when drilling to FK outside of the first 2000 rows). This PR fixes an issue happening with PK drills on a dashboard. If you apply a few dashboard parameters that filter table data, you could drill down to an object detail, but Metabase won't convert dashboard parameters to question filters, so a clicked row won't end up in the first 2000 result rows.

Fixed by changing `ObjectDetailDrill` to actually use the [`navigateToNewCardFromDashboard` action](https://github.com/metabase/metabase/blob/1d849d9ca00121fdccad3866d2d17d528966fe0c/frontend/src/metabase/dashboard/actions.js#L1033) instead of a link when there are dashboard parameters with values. `navigateToNewCardFromDashboard` will make sure dashboard parameters are converted into question filters and this should guarantee clicked row will be present in new query results. When there are no dashboard parameters, it will still use the URL approach for a PK drill.

### To Verify

1. New > Question > Sample Database > Orders > Save
2. Add the question to a dashboard
3. Add a "Category" filter and connect it to Order's "Product > Category" field
4. Set filter to "Doohikey"
5. Click the Orders card's "ID" column header twice, so IDs are sorted desc
6. Click any Order ID
7. Ensure you're navigated to an object detail view and you see an expected order record info

### Demo

**Before**

https://user-images.githubusercontent.com/17258145/165773050-f46dd9af-ab87-44a0-95a7-5227c9e63381.mp4

**After**

https://user-images.githubusercontent.com/17258145/165773071-7fe23860-c0bc-40d6-ba57-c4e79ab4746f.mp4


