### PR TITLE
Fix reloading questions when filters are not changed

### DIFF
--- a/frontend/src/metabase/dashboard/actions.js
+++ b/frontend/src/metabase/dashboard/actions.js
@@ -70,6 +70,7 @@ import {
   getAllDashboardCards,
   getDashboardType,
   fetchDataOrError,
+  getDatasetQueryParams,
 } from "./utils";
 
 const DATASET_SLOW_TIMEOUT = 15 * 1000;
@@ -572,10 +573,12 @@ export const fetchCardData = createThunkAction(FETCH_CARD_DATA, function(
     if (!reload) {
       // if reload not set, check to see if the last result has the same query dict and return that
       const lastResult = getIn(dashcardData, [dashcard.id, card.id]);
-      // "constraints" is added by the backend, remove it when comparing
       if (
         lastResult &&
-        Utils.equals(_.omit(lastResult.json_query, "constraints"), datasetQuery)
+        Utils.equals(
+          getDatasetQueryParams(lastResult.json_query),
+          getDatasetQueryParams(datasetQuery),
+        )
       ) {
         return {
           dashcard_id: dashcard.id,

--- a/frontend/src/metabase/dashboard/utils.js
+++ b/frontend/src/metabase/dashboard/utils.js
@@ -84,3 +84,8 @@ export async function fetchDataOrError(dataPromise) {
     return { error };
   }
 }
+
+export function getDatasetQueryParams(datasetQuery) {
+  const { type, query, native, parameters = [] } = datasetQuery;
+  return { type, query, native, parameters };
+}

--- a/frontend/test/metabase/scenarios/dashboard-filters/reproductions/22197-reload-card-without-change.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/reproductions/22197-reload-card-without-change.cy.spec.js
@@ -23,78 +23,92 @@ const question2Details = {
 
 const dashboardDetails = {
   name: "Filters",
+  parameters: [filterDetails],
 };
 
 describe("issue 22197", () => {
   beforeEach(() => {
     restore();
+    cy.signInAsAdmin();
   });
 
   it("should not reload cards in a dashboard when corresponding filters are not changed (metabase#22197)", () => {
-    createDashboard().then(({ dashboard_id }) => {
-      cy.visit(`/dashboard/${dashboard_id}`);
-      cy.wait("@getDashboard");
-      cy.wait("@getCardQuery1");
-      cy.wait("@getCardQuery2");
-    });
+    createQuestionsAndDashboard().then(
+      ({ dashboard_id, card1_id, card2_id }) => {
+        setFilterMapping({ dashboard_id, card1_id, card2_id });
+        interceptRequests({ dashboard_id, card1_id, card2_id });
+
+        cy.visit(`/dashboard/${dashboard_id}`);
+        cy.wait("@getDashboard");
+        cy.wait("@getCardQuery1");
+        cy.wait("@getCardQuery2");
+
+        // the filter is connected only to the first card
+        cy.findByPlaceholderText(filterDetails.name).type("1{enter}");
+        cy.wait("@getCardQuery1");
+        cy.get("@getCardQuery1.all").should("have.length", 2);
+        cy.get("@getCardQuery2.all").should("have.length", 1);
+      },
+    );
   });
 });
 
-const createDashboard = () => {
+const createQuestionsAndDashboard = () => {
   return cy
-    .createDashboard(dashboardDetails)
-    .then(({ body: { id: dashboard_id } }) => {
-      cy.createQuestion(question1Details).then(({ body: { id: card1_id } }) => {
-        cy.createQuestion(question2Details).then(
-          ({ body: { id: card2_id } }) => {
-            cy.addFilterToDashboard({
-              filter: filterDetails,
-              dashboard_id,
+    .createQuestion(question1Details)
+    .then(({ body: { id: card1_id } }) => {
+      return cy
+        .createQuestion(question2Details)
+        .then(({ body: { id: card2_id } }) => {
+          return cy
+            .createDashboard(dashboardDetails)
+            .then(({ body: { id: dashboard_id } }) => {
+              return { dashboard_id, card1_id, card2_id };
             });
-
-            cy.request("POST", `/api/dashboard/${dashboard_id}/cards`, {
-              cardId: card1_id,
-              sizeX: 8,
-              sizeY: 6,
-              parameter_mappings: [
-                {
-                  parameter_id: filterDetails.id,
-                  card_id: card1_id,
-                  target: ["dimension", ["field", PRODUCTS.ID, null]],
-                },
-              ],
-            });
-
-            cy.request("POST", `/api/dashboard/${dashboard_id}/cards`, {
-              cardId: card2_id,
-              sizeX: 8,
-              sizeY: 6,
-              parameter_mappings: [
-                {
-                  parameter_id: filterDetails.id,
-                  card_id: card1_id,
-                  target: ["dimension", ["field", ORDERS.ID, null]],
-                },
-              ],
-            });
-
-            cy.intercept("GET", `/api/dashboard/${dashboard_id}`).as(
-              "getDashboard",
-            );
-
-            cy.intercept(
-              "POST",
-              `/api/dashboard/${dashboard_id}/dashcard/*/card/${card1_id}/query`,
-            ).as("getCardQuery1");
-
-            cy.intercept(
-              "POST",
-              `/api/dashboard/${dashboard_id}/dashcard/*/card/${card2_id}/query`,
-            ).as("getCardQuery2");
-
-            return { dashboard_id };
-          },
-        );
-      });
+        });
     });
+};
+
+const setFilterMapping = ({ dashboard_id, card1_id, card2_id }) => {
+  cy.request("POST", `/api/dashboard/${dashboard_id}/cards`, {
+    cardId: card1_id,
+    row: 0,
+    col: 0,
+    sizeX: 4,
+    sizeY: 4,
+    parameter_mappings: [
+      {
+        parameter_id: filterDetails.id,
+        card_id: card1_id,
+        target: ["dimension", ["field", PRODUCTS.ID, null]],
+      },
+    ],
+  });
+
+  cy.request("POST", `/api/dashboard/${dashboard_id}/cards`, {
+    cardId: card2_id,
+    row: 0,
+    col: 4,
+    sizeX: 4,
+    sizeY: 4,
+    parameter_mappings: [
+      {
+        parameter_id: filterDetails.id,
+        card_id: card1_id,
+        target: ["dimension", ["field", ORDERS.ID, null]],
+      },
+    ],
+  });
+};
+
+const interceptRequests = ({ dashboard_id, card1_id, card2_id }) => {
+  cy.intercept("GET", `/api/dashboard/${dashboard_id}`).as("getDashboard");
+  cy.intercept(
+    "POST",
+    `/api/dashboard/${dashboard_id}/dashcard/*/card/${card1_id}/query`,
+  ).as("getCardQuery1");
+  cy.intercept(
+    "POST",
+    `/api/dashboard/${dashboard_id}/dashcard/*/card/${card2_id}/query`,
+  ).as("getCardQuery2");
 };

--- a/frontend/test/metabase/scenarios/dashboard-filters/reproductions/22197-reload-card-without-change.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/reproductions/22197-reload-card-without-change.cy.spec.js
@@ -1,0 +1,100 @@
+import { restore } from "__support__/e2e/cypress";
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+
+const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
+
+const filterDetails = {
+  name: "ID",
+  slug: "id",
+  id: "11d79abe",
+  type: "id",
+  sectionId: "id",
+};
+
+const question1Details = {
+  name: "Q1",
+  query: { "source-table": PRODUCTS_ID, limit: 2 },
+};
+
+const question2Details = {
+  name: "Q2",
+  query: { "source-table": ORDERS_ID, limit: 2 },
+};
+
+const dashboardDetails = {
+  name: "Filters",
+};
+
+describe("issue 22197", () => {
+  beforeEach(() => {
+    restore();
+  });
+
+  it("should not reload cards in a dashboard when corresponding filters are not changed (metabase#22197)", () => {
+    createDashboard().then(({ dashboard_id }) => {
+      cy.visit(`/dashboard/${dashboard_id}`);
+      cy.wait("@getDashboard");
+      cy.wait("@getCardQuery1");
+      cy.wait("@getCardQuery2");
+    });
+  });
+});
+
+const createDashboard = () => {
+  return cy
+    .createDashboard(dashboardDetails)
+    .then(({ body: { id: dashboard_id } }) => {
+      cy.createQuestion(question1Details).then(({ body: { id: card1_id } }) => {
+        cy.createQuestion(question2Details).then(
+          ({ body: { id: card2_id } }) => {
+            cy.addFilterToDashboard({
+              filter: filterDetails,
+              dashboard_id,
+            });
+
+            cy.request("POST", `/api/dashboard/${dashboard_id}/cards`, {
+              cardId: card1_id,
+              sizeX: 8,
+              sizeY: 6,
+              parameter_mappings: [
+                {
+                  parameter_id: filterDetails.id,
+                  card_id: card1_id,
+                  target: ["dimension", ["field", PRODUCTS.ID, null]],
+                },
+              ],
+            });
+
+            cy.request("POST", `/api/dashboard/${dashboard_id}/cards`, {
+              cardId: card2_id,
+              sizeX: 8,
+              sizeY: 6,
+              parameter_mappings: [
+                {
+                  parameter_id: filterDetails.id,
+                  card_id: card1_id,
+                  target: ["dimension", ["field", ORDERS.ID, null]],
+                },
+              ],
+            });
+
+            cy.intercept("GET", `/api/dashboard/${dashboard_id}`).as(
+              "getDashboard",
+            );
+
+            cy.intercept(
+              "POST",
+              `/api/dashboard/${dashboard_id}/dashcard/*/card/${card1_id}/query`,
+            ).as("getCardQuery1");
+
+            cy.intercept(
+              "POST",
+              `/api/dashboard/${dashboard_id}/dashcard/*/card/${card2_id}/query`,
+            ).as("getCardQuery2");
+
+            return { dashboard_id };
+          },
+        );
+      });
+    });
+};


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/8030

The issue was that dataset queries were compared incorrectly:
- Some properties were set in `datasetQuery` that were not used in the actual query to the backend
- Empty parameters list isn't returned by the backend in `json_query`, so we should handle it when comparing

How to test:
- Please use the steps from the issue or run the cypress test