### PR TITLE
Support empty card title in the dashboard

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChartCaption.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartCaption.jsx
@@ -18,7 +18,8 @@ const ChartCaption = ({
   actionButtons,
   onChangeCardAndRun,
 }) => {
-  const title = settings["card.title"] || series[0].card.name;
+  const cardTitle = settings["card.title"];
+  const title = typeof cardTitle === "string" ? cardTitle : series[0].card.name;
   const description = settings["card.description"];
   const data = series._raw || series;
   const card = data[0].card;

--- a/frontend/src/metabase/visualizations/components/ChartCaption.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartCaption.jsx
@@ -18,8 +18,7 @@ const ChartCaption = ({
   actionButtons,
   onChangeCardAndRun,
 }) => {
-  const cardTitle = settings["card.title"];
-  const title = typeof cardTitle === "string" ? cardTitle : series[0].card.name;
+  const title = settings["card.title"] ?? series[0].card.name;
   const description = settings["card.description"];
   const data = series._raw || series;
   const card = data[0].card;

--- a/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
@@ -83,7 +83,6 @@ describe("scenarios > dashboard", () => {
   });
 
   it("should allow empty card title (metabase#12013)", () => {
-    cy.intercept("GET", "/api/table/**/query_metadata").as("tableMetadata");
     visitDashboard(1);
 
     cy.findByTextEnsureVisible("Orders");

--- a/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
@@ -3,6 +3,7 @@ import {
   restore,
   selectDashboardFilter,
   expectedRouteCalls,
+  editDashboard,
   showDashboardCardActions,
   filterWidget,
   sidebar,
@@ -85,24 +86,19 @@ describe("scenarios > dashboard", () => {
     cy.intercept("GET", "/api/table/**/query_metadata").as("tableMetadata");
     visitDashboard(1);
 
-    // 3 tables
-    cy.wait("@tableMetadata");
-    cy.wait("@tableMetadata");
-    cy.wait("@tableMetadata");
-
     cy.findByTextEnsureVisible("Orders");
-    cy.get("[data-testid='legend-caption']").should("exist");
+    cy.findByTestId("legend-caption").should("exist");
 
-    cy.findByTextEnsureVisible("Quantity").realHover();
-    cy.icon("pencil").click({ force: true });
+    editDashboard();
+    showDashboardCardActions();
     cy.icon("palette").click();
 
-    cy.get("[data-testid='card.title']")
+    cy.findByDisplayValue("Orders")
       .click()
       .clear();
     cy.get("[data-metabase-event='Chart Settings;Done']").click();
 
-    cy.get("[data-testid='legend-caption']").should("not.exist");
+    cy.findByTestId("legend-caption").should("not.exist");
   });
 
   it("should add a filter", () => {

--- a/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
@@ -81,6 +81,30 @@ describe("scenarios > dashboard", () => {
     cy.findByText("How many orders were placed in each year?");
   });
 
+  it("should allow empty card title (metabase#12013)", () => {
+    cy.intercept("GET", "/api/table/**/query_metadata").as("tableMetadata");
+    visitDashboard(1);
+
+    // 3 tables
+    cy.wait("@tableMetadata");
+    cy.wait("@tableMetadata");
+    cy.wait("@tableMetadata");
+
+    cy.findByTextEnsureVisible("Orders");
+    cy.get("[data-testid='legend-caption']").should("exist");
+
+    cy.findByTextEnsureVisible("Quantity").realHover();
+    cy.icon("pencil").click({ force: true });
+    cy.icon("palette").click();
+
+    cy.get("[data-testid='card.title']")
+      .click()
+      .clear();
+    cy.get("[data-metabase-event='Chart Settings;Done']").click();
+
+    cy.get("[data-testid='legend-caption']").should("not.exist");
+  });
+
   it("should add a filter", () => {
     visitDashboard(1);
     cy.icon("pencil").click();


### PR DESCRIPTION
Fixes #12013.

To verify:
1. New, Question, Sample Database, Product
2. Save as a question, add to a new Product Dashboard
3. Hover on the card, Visualization options
4. From the modal dialog, set Title from `Products` to an empty text, Done

![image](https://user-images.githubusercontent.com/7288/165804049-9de3e107-39ef-4730-b4c2-59282f9572bd.png)


### Before this PR

The card is **still** displayed with its _original_ title (from the question).

![image](https://user-images.githubusercontent.com/7288/165803948-f8de726e-e565-478d-96cf-8d93691cf518.png)

### After this PR

The card is displayed without any title.

![image](https://user-images.githubusercontent.com/7288/165803840-68cb4e64-faff-470a-afa6-778f79d1f4ca.png)
