### PR TITLE
Repro #22192: Selecting language Indonesian causes error

### DIFF
--- a/frontend/test/metabase/scenarios/onboarding/setup/user_settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/onboarding/setup/user_settings.cy.spec.js
@@ -1,5 +1,5 @@
 // Migrated from frontend/test/metabase/user/UserSettings.integ.spec.js
-import { restore } from "__support__/e2e/cypress";
+import { restore, popover } from "__support__/e2e/cypress";
 import { USERS } from "__support__/e2e/cypress_data";
 const { first_name, last_name, email, password } = USERS.normal;
 
@@ -90,6 +90,23 @@ describe("user > settings", () => {
     cy.findByLabelText("gear icon").click();
     cy.findByText("Sign out").click();
     cy.findByText("Sign in to Metabase");
+  });
+
+  it.skip("should be able to change a language (metabase#22192)", () => {
+    cy.intercept("PUT", "/api/user/*").as("updateUserSettings");
+
+    cy.visit("/account/profile");
+
+    cy.findByText("Use site default").click();
+    popover()
+      .contains("Indonesian")
+      .click();
+
+    cy.button("Update").click();
+    cy.wait("@updateUserSettings");
+
+    // We need some UI element other than a string
+    cy.icon("gear").should("exist");
   });
 
   describe("when user is authenticated via ldap", () => {


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #22192 

### How to test this manually?
- `yarn test-cypress-open`
- `metabase/scenarios/onboarding/setup/user_settings.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
<img width="1680" alt="image" src="https://user-images.githubusercontent.com/31325167/165811710-2d09de95-60ad-4780-85ff-10b43caeba90.png">

