### PR TITLE
Remove value-label-outline text to fix blurry night mode value labels

### DIFF
--- a/frontend/src/metabase/css/dashboard.css
+++ b/frontend/src/metabase/css/dashboard.css
@@ -337,12 +337,7 @@
   background-color: color-mod(var(--color-bg-white) alpha(-86%));
 }
 
-.Dashboard--night text.value-label-outline {
-  stroke: var(--night-mode-card);
-}
-
 .Dashboard text.value-label,
-.Dashboard text.value-label-outline,
 .Dashboard text.value-label-white,
 .Dashboard .LineAreaBarChart .dc-chart .axis text {
   font-size: 12px;

--- a/frontend/src/metabase/visualizations/components/LineAreaBarChart.css
+++ b/frontend/src/metabase/visualizations/components/LineAreaBarChart.css
@@ -228,17 +228,8 @@
   stroke-dasharray: 5, 5;
 }
 
-text.value-label-outline,
 text.value-label {
   pointer-events: none;
-}
-
-text.value-label-outline {
-  font-weight: 800;
-  font-size: 12px;
-  letter-spacing: 0.5px;
-  stroke-width: 3px;
-  stroke: var(--color-text-white);
 }
 
 text.value-label {

--- a/frontend/src/metabase/visualizations/lib/chart_values.js
+++ b/frontend/src/metabase/visualizations/lib/chart_values.js
@@ -283,11 +283,7 @@ export function onRenderValueLabels(
         return transforms.join(" ");
       });
 
-    // Labels are either white inside the bar or black with white outline.
-    // For outlined labels, Safari had an issue with rendering paint-order: stroke.
-    // To work around that, we create two text labels: one for the the black text
-    // and another for the white outline behind it.
-    ["value-label-outline", "value-label", "value-label-white"].forEach(klass =>
+    ["value-label", "value-label-white"].forEach(klass =>
       labelGroups
         .append("text")
         // only create labels for the correct class(es) given the type of label
@@ -320,7 +316,7 @@ export function onRenderValueLabels(
     addLabels(sample, compactForSeries[index]);
     const totalWidth = chart
       .svg()
-      .selectAll(".value-label-outline")
+      .selectAll(".value-label, .value-label-white")
       .flat()
       .reduce((sum, label) => sum + label.getBoundingClientRect().width, 0);
     const labelWidth = totalWidth / sample.length + LABEL_PADDING;


### PR DESCRIPTION
Fixes #13125 

**Before**
![Screen Shot 2022-04-28 at 11 50 44 AM](https://user-images.githubusercontent.com/13057258/165825367-ba9943d1-db48-4452-8582-aa25a1f36f3f.png)


**After**
![Screen Shot 2022-04-28 at 11 50 57 AM](https://user-images.githubusercontent.com/13057258/165825401-3ee8ce89-c03c-47ca-accc-0911a4cc0eab.png)



**Testing**
1. Create a new question, Products table, Count rows, Group by Created At (month)
2. Click the "Settings" button in the footer and toggle the "Show values on data points" toggle
3. Save the question
4. Click on the sharing link in the footer, enable sharing, open up the public question link
5. Data points on the chart should look the same
6. Add `#theme=night` to the end of the public question link to view it in nightmode
7. Data points on the chart should no longer be blurry
8. Test in various browsers
