### PR TITLE
Fix XLSX column names for remapped cols

### DIFF
--- a/frontend/test/metabase/scenarios/downloads/reproductions/18573-remapped-fields-not-renamed.cy.spec.js
+++ b/frontend/test/metabase/scenarios/downloads/reproductions/18573-remapped-fields-not-renamed.cy.spec.js
@@ -43,7 +43,7 @@ describe("issue 18573", () => {
     cy.findByText("Foo");
     cy.findByText("Awesome Concrete Shoes");
 
-    downloadAndAssert("xlsx", assertion);
+    downloadAndAssert({ fileType: "xlsx" }, assertion);
   });
 });
 

--- a/frontend/test/metabase/scenarios/downloads/reproductions/18573-remapped-fields-not-renamed.cy.spec.js
+++ b/frontend/test/metabase/scenarios/downloads/reproductions/18573-remapped-fields-not-renamed.cy.spec.js
@@ -24,7 +24,7 @@ const questionDetails = {
   },
 };
 
-describe.skip("issue 18573", () => {
+describe("issue 18573", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();

--- a/frontend/test/metabase/scenarios/downloads/reproductions/18573-remapped-fields-not-renamed.cy.spec.js
+++ b/frontend/test/metabase/scenarios/downloads/reproductions/18573-remapped-fields-not-renamed.cy.spec.js
@@ -37,15 +37,13 @@ describe("issue 18573", () => {
     });
   });
 
-  ["csv", "xlsx"].forEach(fileType => {
-    it(`for the remapped columns, it should preserve renamed column name in exports for ${fileType} (metabase#18573)`, () => {
-      visitQuestionAdhoc(questionDetails);
+  it(`for the remapped columns, it should preserve renamed column name in exports for xlsx (metabase#18573)`, () => {
+    visitQuestionAdhoc(questionDetails);
 
-      cy.findByText("Foo");
-      cy.findByText("Awesome Concrete Shoes");
+    cy.findByText("Foo");
+    cy.findByText("Awesome Concrete Shoes");
 
-      downloadAndAssert({ fileType }, assertion);
-    });
+    downloadAndAssert("xlsx", assertion);
   });
 });
 

--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -11,11 +11,11 @@
             [metabase.util :as u]
             [metabase.util.date-2 :as u.date]
             [metabase.util.i18n :refer [tru]])
-  (:import java.io.OutputStream
-           [java.time LocalDate LocalDateTime LocalTime OffsetDateTime OffsetTime ZonedDateTime]
-           [org.apache.poi.ss.usermodel Cell DataFormat DateUtil Workbook]
-           org.apache.poi.ss.util.CellRangeAddress
-           [org.apache.poi.xssf.streaming SXSSFRow SXSSFSheet SXSSFWorkbook]))
+  (:import (java.io OutputStream)
+           (java.time LocalDate LocalDateTime LocalTime OffsetDateTime OffsetTime ZonedDateTime)
+           (org.apache.poi.ss.usermodel Cell DataFormat DateUtil Workbook)
+           (org.apache.poi.ss.util CellRangeAddress)
+           (org.apache.poi.xssf.streaming SXSSFRow SXSSFSheet SXSSFWorkbook)))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                         Format string generation                                               |
@@ -412,7 +412,7 @@
   "Generates the column titles that should be used in the export, taking into account viz settings."
   [ordered-cols col-settings]
   (for [col ordered-cols]
-    (let [id-or-name       (or (:fk_field_id col)
+    (let [id-or-name       (or (and (:remapped_from col) (:fk_field_id col))
                                (:id col)
                                (:name col))
           format-settings  (or (get col-settings {::mb.viz/field-id id-or-name})

--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -11,11 +11,11 @@
             [metabase.util :as u]
             [metabase.util.date-2 :as u.date]
             [metabase.util.i18n :refer [tru]])
-  (:import (java.io OutputStream)
-           (java.time LocalDate LocalDateTime LocalTime OffsetDateTime OffsetTime ZonedDateTime)
-           (org.apache.poi.ss.usermodel Cell DataFormat DateUtil Workbook)
-           (org.apache.poi.ss.util CellRangeAddress)
-           (org.apache.poi.xssf.streaming SXSSFRow SXSSFSheet SXSSFWorkbook)))
+  (:import java.io.OutputStream
+           [java.time LocalDate LocalDateTime LocalTime OffsetDateTime OffsetTime ZonedDateTime]
+           [org.apache.poi.ss.usermodel Cell DataFormat DateUtil Workbook]
+           org.apache.poi.ss.util.CellRangeAddress
+           [org.apache.poi.xssf.streaming SXSSFRow SXSSFSheet SXSSFWorkbook]))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                         Format string generation                                               |

--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -412,7 +412,9 @@
   "Generates the column titles that should be used in the export, taking into account viz settings."
   [ordered-cols col-settings]
   (for [col ordered-cols]
-    (let [id-or-name       (or (:id col) (:name col))
+    (let [id-or-name       (or (:fk_field_id col)
+                               (:id col)
+                               (:name col))
           format-settings  (or (get col-settings {::mb.viz/field-id id-or-name})
                                (get col-settings {::mb.viz/column-name id-or-name}))
           is-currency?     (or (isa? (:semantic_type col) :type/Currency)

--- a/test/metabase/query_processor/streaming/xlsx_test.clj
+++ b/test/metabase/query_processor/streaming/xlsx_test.clj
@@ -380,6 +380,13 @@
                                                           {::mb.viz/currency "USD",
                                                            ::mb.viz/currency-style "code",
                                                            ::mb.viz/currency-in-header false}}}
+                               [])))))
+
+  (testing "If a col is remapped to a foreign key field, the title is taken from the viz settings for its fk_field_id (#18573)"
+    (is (= ["Correct title"]
+           (first (xlsx-export [{:id 0, :fk_field_id 1}]
+                               {::mb.viz/column-settings {{::mb.viz/field-id 0} {::mb.viz/column-title "Incorrect title"}
+                                                          {::mb.viz/field-id 1} {::mb.viz/column-title "Correct title"}}}
                                []))))))
 
 (deftest scale-test

--- a/test/metabase/query_processor/streaming/xlsx_test.clj
+++ b/test/metabase/query_processor/streaming/xlsx_test.clj
@@ -21,7 +21,7 @@
 
   ([format-settings semantic-type]
    (let [format-strings (@#'qp.xlsx/format-settings->format-strings format-settings {:semantic_type  semantic-type
-                                                                                  :effective_type :type/Temporal})]
+                                                                                     :effective_type :type/Temporal})]
      ;; If only one format string is returned (for datetimes) or both format strings
      ;; are equal, just return a single value to make tests more readable.
      (cond
@@ -384,7 +384,7 @@
 
   (testing "If a col is remapped to a foreign key field, the title is taken from the viz settings for its fk_field_id (#18573)"
     (is (= ["Correct title"]
-           (first (xlsx-export [{:id 0, :fk_field_id 1}]
+           (first (xlsx-export [{:id 0, :fk_field_id 1, :remapped_from "FIELD_1"}]
                                {::mb.viz/column-settings {{::mb.viz/field-id 0} {::mb.viz/column-title "Incorrect title"}
                                                           {::mb.viz/field-id 1} {::mb.viz/column-title "Correct title"}}}
                                []))))))


### PR DESCRIPTION
If a column is remapped to a FK field, its `:id` in the col metadata will be the FK id. But the display title in the viz settings will still be associated with the original field id. So we need to pull out the original field ID from the `:fk_field_id` field, if it exists, and use it to look up the correct column in the viz settings.

Fixes #18573