### PR TITLE
[E2E] Fix flaky on Join

### DIFF
--- a/frontend/test/metabase/scenarios/joins/joins-2.cy.spec.js
+++ b/frontend/test/metabase/scenarios/joins/joins-2.cy.spec.js
@@ -117,8 +117,6 @@ describe("scenarios > question > joined questions", () => {
     });
 
     it("should join on field literals", () => {
-      cy.intercept("/api/database/1/schema/PUBLIC").as("schema");
-
       // create two native questions
       cy.createNativeQuestion({
         name: "question a",
@@ -137,10 +135,9 @@ describe("scenarios > question > joined questions", () => {
 
       // join to question b
       cy.icon("join_left_outer").click();
-      cy.wait("@schema");
 
       popover().within(() => {
-        cy.findByTextEnsureVisible("Sample Database").click();
+        cy.findByTextEnsureVisible("Sample Database").click({ force: true });
         cy.findByTextEnsureVisible("Saved Questions").click();
         cy.findByText("question b").click();
       });


### PR DESCRIPTION
We were waiting for the endpoint `api/database/1/schema/PUBLIC` to be called before moving forward with the popover, but it looks like when the internet connection is bad the `wait()` is being called before the `intercept()`.

Fail examples: https://github.com/metabase/metabase/runs/6210254441?check_suite_focus=true

Some videos on the analysis:

API being called AFTER the popover is clicked:
https://user-images.githubusercontent.com/17742979/165833233-6afbd84b-4b20-4e4b-9d0e-24033ead2093.mov

Test failing with 3G and after passing without slow internet
https://user-images.githubusercontent.com/17742979/165833337-4a8f3811-491e-4146-ae3d-90dc8941b59e.mov


