### PR TITLE
Use a locale's language tag to find the appropriate translations

### DIFF
--- a/src/metabase/server/routes/index.clj
+++ b/src/metabase/server/routes/index.clj
@@ -25,10 +25,10 @@
   ;; https://stackoverflow.com/questions/14780858/escape-in-script-tag-contents/23983448#23983448
   (str/replace s #"(?i)</script" "</scr\\\\ipt"))
 
-(defn- fallback-localization [locale-or-name]
+(def ^:private fallback-localization
   (json/generate-string
    {"headers"
-    {"language"     (str locale-or-name)
+    {"language"     "en"
      "plural-forms" "nplurals=2; plural=(n != 1);"}
 
     "translations"
@@ -51,7 +51,7 @@
                     (throw (FileNotFoundException. (format "Locale '%s' not found." locale-name)))))
          (catch Throwable e
            (log/warn (.getMessage e))))))
-   (fallback-localization locale-or-name)))
+   fallback-localization))
 
 (def ^:private ^{:arglists '([])} load-localization
   "Load a JSON-encoded map of localized strings for the current user's Locale."

--- a/src/metabase/server/routes/index.clj
+++ b/src/metabase/server/routes/index.clj
@@ -36,7 +36,8 @@
                      "msgstr" ["Metabase"]}}}}))
 
 (defn- localization-json-file-name [locale-or-name]
-  (format "frontend_client/app/locales/%s.json" (str (i18n/locale locale-or-name))))
+  (format "frontend_client/app/locales/%s.json"
+          (str/replace (.toLanguageTag (i18n/locale locale-or-name)) \- \_)))
 
 (defn- load-localization* [locale-or-name]
   (or

--- a/test/metabase/server/routes/index_test.clj
+++ b/test/metabase/server/routes/index_test.clj
@@ -31,7 +31,7 @@
 
 (deftest fallback-localization-test
   (testing "if locale does not exist it should log a message and return the 'fallback' localalization (english)"
-    (is (= {"headers"      {"language" "xx", "plural-forms" "nplurals=2; plural=(n != 1);"}
+    (is (= {"headers"      {"language" "en", "plural-forms" "nplurals=2; plural=(n != 1);"}
             "translations" {"" {"Metabase" {"msgid" "Metabase", "msgstr" ["Metabase"]}}}}
            (mt/suppress-output
              (some->


### PR DESCRIPTION
Fixes #22192

In many cases, the Locale code and Language code are equivalent. But not always. This cropped up when we wanted to set Indonesian as the language: The Locale/Language codes are different. Language code is "id" but the locale is
different depending on the Java version (either "id" or "in"). When the backend coerces the string into a Locale, we sometimes get "in" which causes the page to fail its render as there are no translation resources with "in" (eg. no "in.edn" exists).

So, we can use the language tag to keep things consistent.

Thanks @noahmoss for the fix here