### PR TITLE
Handle locationlization errors from java.util.Locale

### DIFF
--- a/src/metabase/server/routes/index.clj
+++ b/src/metabase/server/routes/index.clj
@@ -36,7 +36,7 @@
                      "msgstr" ["Metabase"]}}}}))
 
 (defn- localization-json-file-name [locale-string]
-  (format "frontend_client/app/locales/%s.json" locale-string))
+  (format "frontend_client/app/locales/%s.json" (str/replace locale-string \- \_)))
 
 (defn- load-localization* [locale-string]
   (or

--- a/src/metabase/server/routes/index.clj
+++ b/src/metabase/server/routes/index.clj
@@ -35,26 +35,26 @@
     {"" {"Metabase" {"msgid"  "Metabase"
                      "msgstr" ["Metabase"]}}}}))
 
-(defn- localization-json-file-name [locale-or-name]
-  (format "frontend_client/app/locales/%s.json" (str (i18n/locale locale-or-name))))
+(defn- localization-json-file-name [locale-string]
+  (format "frontend_client/app/locales/%s.json" locale-string))
 
-(defn- load-localization* [locale-or-name]
+(defn- load-localization* [locale-string]
   (or
-   (when-let [locale-name (some-> locale-or-name str)]
-     (when-not (= locale-name "en")
+   (when locale-string
+     (when-not (= locale-string "en")
        (try
-         (slurp (or (io/resource (localization-json-file-name locale-name))
-                    (when-let [fallback-locale (i18n/fallback-locale locale-name)]
+         (slurp (or (io/resource (localization-json-file-name locale-string))
+                    (when-let [fallback-locale (i18n/fallback-locale locale-string)]
                       (io/resource (localization-json-file-name (str fallback-locale))))
                     ;; don't try to i18n the Exception message below, we have no locale to translate it to!
-                    (throw (FileNotFoundException. (format "Locale '%s' not found." locale-name)))))
+                    (throw (FileNotFoundException. (format "Locale '%s' not found." locale-string)))))
          (catch Throwable e
            (log/warn (.getMessage e))))))
-   (fallback-localization locale-or-name)))
+   (fallback-localization locale-string)))
 
 (def ^:private ^{:arglists '([])} load-localization
   "Load a JSON-encoded map of localized strings for the current user's Locale."
-  (comp (memoize load-localization*) #(some-> (i18n/user-locale) str)))
+  (comp (memoize load-localization*) #(i18n/user-locale-string)))
 
 (defn- load-inline-js* [resource-name]
   (slurp (io/resource (format "frontend_client/inline_js/%s.js" resource-name))))

--- a/src/metabase/util/i18n.clj
+++ b/src/metabase/util/i18n.clj
@@ -30,6 +30,7 @@
   nil)
 
 (defn site-locale-string
+  "Site Locale string from the settings."
   []
   (or *site-locale-override*
       (i18n.impl/site-locale-from-setting)

--- a/src/metabase/util/i18n.clj
+++ b/src/metabase/util/i18n.clj
@@ -25,25 +25,32 @@
   nil)
 
 (def ^:dynamic *site-locale-override*
-  "Bind this to a string, keyword, or `Locale` to override the value returned by `site-locale`. For testing purposes,
+  "Bind this to a string, keyword to override the value returned by `site-locale`. For testing purposes,
   such as when swapping out an application database temporarily, when the setting table may not even exist."
   nil)
+
+(defn site-locale-string
+  []
+  (or *site-locale-override*
+      (i18n.impl/site-locale-from-setting)
+      "en"))
+
+(defn user-locale-string
+  "Locale string ed we should *use* from the current User"
+  []
+  (or *user-locale*
+      (site-locale-string)))
 
 (defn site-locale
   "The default locale for this Metabase installation. Normally this is the value of the `site-locale` Setting."
   ^Locale []
-  (locale (or *site-locale-override*
-              (i18n.impl/site-locale-from-setting)
-              ;; if DB is not initialized yet fall back to English
-              "en")))
+  (locale (site-locale-string)))
 
 (defn user-locale
   "Locale we should *use* for the current User (e.g. `tru` messages) -- `*user-locale*` if bound, otherwise the system
   locale."
   ^Locale []
-  (locale
-   (or *user-locale*
-       (site-locale))))
+  (locale (user-locale-string)))
 
 (defn available-locales-with-names
   "Returns all locale abbreviations and their full names"
@@ -57,7 +64,8 @@
   "Translate a string with the System locale."
   [format-string & args]
   (let [translated (apply translate (site-locale) format-string args)]
-    (log/tracef "Translated %s for site locale %s -> %s" (pr-str format-string) (pr-str (site-locale)) (pr-str translated))
+    (log/tracef "Translated %s for site locale %s -> %s"
+                (pr-str format-string) (pr-str (site-locale-string)) (pr-str translated))
     translated))
 
 (defn translate-user-locale
@@ -65,7 +73,8 @@
   [format-string & args]
   (let [translated (apply translate (user-locale) format-string args)]
     (log/tracef "Translating %s for user locale %s (site locale %s) -> %s"
-                (pr-str format-string) (pr-str (user-locale)) (pr-str (site-locale)) (pr-str translated))
+                (pr-str format-string) (pr-str (user-locale-string))
+                (pr-str (site-locale-string)) (pr-str translated))
     translated))
 
 (p.types/defrecord+ UserLocalizedString [format-string args]

--- a/src/metabase/util/i18n.clj
+++ b/src/metabase/util/i18n.clj
@@ -30,14 +30,16 @@
   nil)
 
 (defn site-locale-string
-  "Site Locale string from the settings."
+  "The default locale string for this Metabase installation. Normally this is the value of the `site-locale` Setting,
+  which is also a string."
   []
   (or *site-locale-override*
       (i18n.impl/site-locale-from-setting)
       "en"))
 
 (defn user-locale-string
-  "Locale string ed we should *use* from the current User"
+  "Locale string we should *use* for the current User (e.g. `tru` messages) -- `*user-locale*` if bound, otherwise the
+  system locale as a string."
   []
   (or *user-locale*
       (site-locale-string)))

--- a/test/metabase/server/routes/index_test.clj
+++ b/test/metabase/server/routes/index_test.clj
@@ -11,44 +11,6 @@
   (is (= "frontend_client/app/locales/es_MX.json"
          (#'index/localization-json-file-name "es-MX"))))
 
-(comment
-  (into {}
-        (comp (remove (comp #{"en"} first))
-              (map (fn [[l _human]]
-                     [l (-> (slurp (clojure.java.io/resource (#'index/localization-json-file-name l)))
-                            json/parse-string
-                            (get-in ["headers" "language"]))])))
-        (i18n/available-locales-with-names))
-  )
-
-(def ^:private po-header-langues
-  "Map from our locale string to the locale declared in the headers of our po editor json
-  files (resources/frontend_client/app/locales/<locale>.json)."
-  {"nl"    "nl"
-   "zh"    "zh-Hans"
-   "sr"    "sr"
-   "tr"    "tr"
-   "it"    "it"
-   "fa"    "fa"
-   "zh_HK" "zh-hk"
-   "vi"    "vi"
-   "id"    "id"
-   "uk"    "uk"
-   "pl"    "pl"
-   "zh_TW" "zh-TW"
-   "ca"    "ca"
-   "sv"    "sv"
-   "fr"    "fr"
-   "de"    "de"
-   "nb"    "nb"
-   "ru"    "ru"
-   "sk"    "sk"
-   "es"    "es"
-   "ja"    "ja"
-   "cs"    "cs"
-   "bg"    "bg"
-   "pt_BR" "pt-br"})
-
 (deftest load-localization-test
   (testing "make sure `load-localization` is correctly loading i18n files (#9938)"
     (is (= {"charset"      "utf-8"
@@ -65,30 +27,7 @@
               (#'index/load-localization))
             json/parse-string
             (update "translations" select-keys [""])
-            (update-in ["translations" ""] select-keys ["Your database has been added!"])))))
-  (testing "Localization files exist for all available locales"
-    (letfn [(locale-json [] (-> (#'index/load-localization)
-                                json/parse-string
-                                (get "headers")
-                                (select-keys ["language" "x-generator"])))]
-      (testing "Setting site-locale finds localization json files for the frontend."
-        (doseq [[localization human-readable] (i18n/available-locales-with-names)]
-          (mt/with-temporary-setting-values [site-locale localization]
-            (when-not (= "en" localization)
-              ;; asserting that it found a json file created from the POEditor and the language is what we expect (ie,
-              ;; not "id" -> "in" and the frontend blows up.)
-              (is (= {"language" (po-header-langues localization)
-                      "x-generator" "POEditor.com"}
-                     (locale-json))
-                  (format "Localization json file does not say exact same localization: %s (%s)" localization human-readable))))))
-      (testing "Setting user-locale finds localization json files for the frontend"
-        (doseq [[localization human-readable] (i18n/available-locales-with-names)]
-          (binding [i18n/*user-locale* localization]
-            (when-not (= "en" localization)
-              (is (= {"language" (po-header-langues localization)
-                      "x-generator" "POEditor.com"}
-                     (locale-json))
-                  (format "Localization json file does not say exact same localization: %s (%s)" localization human-readable)))))))))
+            (update-in ["translations" ""] select-keys ["Your database has been added!"]))))))
 
 (deftest fallback-localization-test
   (testing "if locale does not exist it should log a message and return the 'fallback' localalization (english)"

--- a/test/metabase/server/routes/index_test.clj
+++ b/test/metabase/server/routes/index_test.clj
@@ -11,6 +11,44 @@
   (is (= "frontend_client/app/locales/es_MX.json"
          (#'index/localization-json-file-name "es-MX"))))
 
+(comment
+  (into {}
+        (comp (remove (comp #{"en"} first))
+              (map (fn [[l _human]]
+                     [l (-> (slurp (clojure.java.io/resource (#'index/localization-json-file-name l)))
+                            json/parse-string
+                            (get-in ["headers" "language"]))])))
+        (i18n/available-locales-with-names))
+  )
+
+(def ^:private po-header-langues
+  "Map from our locale string to the locale declared in the headers of our po editor json
+  files (resources/frontend_client/app/locales/<locale>.json)."
+  {"nl"    "nl"
+   "zh"    "zh-Hans"
+   "sr"    "sr"
+   "tr"    "tr"
+   "it"    "it"
+   "fa"    "fa"
+   "zh_HK" "zh-hk"
+   "vi"    "vi"
+   "id"    "id"
+   "uk"    "uk"
+   "pl"    "pl"
+   "zh_TW" "zh-TW"
+   "ca"    "ca"
+   "sv"    "sv"
+   "fr"    "fr"
+   "de"    "de"
+   "nb"    "nb"
+   "ru"    "ru"
+   "sk"    "sk"
+   "es"    "es"
+   "ja"    "ja"
+   "cs"    "cs"
+   "bg"    "bg"
+   "pt_BR" "pt-br"})
+
 (deftest load-localization-test
   (testing "make sure `load-localization` is correctly loading i18n files (#9938)"
     (is (= {"charset"      "utf-8"
@@ -27,7 +65,30 @@
               (#'index/load-localization))
             json/parse-string
             (update "translations" select-keys [""])
-            (update-in ["translations" ""] select-keys ["Your database has been added!"]))))))
+            (update-in ["translations" ""] select-keys ["Your database has been added!"])))))
+  (testing "Localization files exist for all available locales"
+    (letfn [(locale-json [] (-> (#'index/load-localization)
+                                json/parse-string
+                                (get "headers")
+                                (select-keys ["language" "x-generator"])))]
+      (testing "Setting site-locale finds localization json files for the frontend."
+        (doseq [[localization human-readable] (i18n/available-locales-with-names)]
+          (mt/with-temporary-setting-values [site-locale localization]
+            (when-not (= "en" localization)
+              ;; asserting that it found a json file created from the POEditor and the language is what we expect (ie,
+              ;; not "id" -> "in" and the frontend blows up.)
+              (is (= {"language" (po-header-langues localization)
+                      "x-generator" "POEditor.com"}
+                     (locale-json))
+                  (format "Localization json file does not say exact same localization: %s (%s)" localization human-readable))))))
+      (testing "Setting user-locale finds localization json files for the frontend"
+        (doseq [[localization human-readable] (i18n/available-locales-with-names)]
+          (binding [i18n/*user-locale* localization]
+            (when-not (= "en" localization)
+              (is (= {"language" (po-header-langues localization)
+                      "x-generator" "POEditor.com"}
+                     (locale-json))
+                  (format "Localization json file does not say exact same localization: %s (%s)" localization human-readable)))))))))
 
 (deftest fallback-localization-test
   (testing "if locale does not exist it should log a message and return the 'fallback' localalization (english)"


### PR DESCRIPTION
Indonesian has code "id". But
```
;; java 11
(str (java.util.Locale/forLanguageTag "id")) => "in"

;; java 17
(str (java.util.Locale/forLanguageTag "id")) => "id"
```

And this was bad. Because the frontend sends us the language to use:
"id" for indonesian. We write that down. And then when we need to
construct the index.html page with the correct translations, instead of
using "id"-- the value we were given-- we construct a Locale from "id"
and then get the str value of that which is "in". We don't have a in.edn
file, there's no frontend in.json file, and moment.js has no in
localization. And this all happened because we kept this value we all
agreed upon in a java util class and then asked it for that value back.
\