### PR TITLE
Treat type/Category as STRING for the purpose of filtering

### DIFF
--- a/frontend/src/metabase/lib/schema_metadata.js
+++ b/frontend/src/metabase/lib/schema_metadata.js
@@ -44,7 +44,7 @@ const TYPES = {
   [STRING]: {
     base: [TYPE.Text],
     effective: [TYPE.Text],
-    semantic: [TYPE.Text],
+    semantic: [TYPE.Text, TYPE.Category],
   },
   [STRING_LIKE]: {
     base: [TYPE.TextLike],

--- a/frontend/test/metabase/lib/schema_metadata.unit.spec.js
+++ b/frontend/test/metabase/lib/schema_metadata.unit.spec.js
@@ -84,10 +84,13 @@ describe("schema_metadata", () => {
         );
       });
     });
-    it("should still recognize a name as a string regardless of its base type", () => {
+    it("should still recognize some types as a string regardless of its base type", () => {
       // TYPE.Float can occur in a field filter
       expect(
         getFieldType({ base_type: TYPE.Float, semantic_type: TYPE.Name }),
+      ).toEqual(STRING);
+      expect(
+        getFieldType({ base_type: TYPE.Float, semantic_type: TYPE.Category }),
       ).toEqual(STRING);
     });
     it("should know what it doesn't know", () => {

--- a/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
@@ -332,13 +332,13 @@ describe("scenarios > dashboard > dashboard drill", () => {
       cy.findByText("=").click();
 
       cy.findByText("Reviewer is xavier");
-      cy.findByText("Rating is equal to 2 selections");
+      cy.findByText("Rating is 2 selections");
       cy.contains("Reprehenderit non error"); // xavier's review
     });
 
     it("when clicking on the card title (metabase#13062-2)", () => {
       cy.findByText(questionDetails.name).click();
-      cy.findByText("Rating is equal to 2 selections");
+      cy.findByText("Rating is 2 selections");
       cy.contains("Ad perspiciatis quis et consectetur."); // 5 star review
     });
   });

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -16,7 +16,14 @@ import {
 import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
-const { ORDERS, ORDERS_ID, PEOPLE, PEOPLE_ID } = SAMPLE_DATABASE;
+const {
+  ORDERS,
+  ORDERS_ID,
+  PEOPLE,
+  PEOPLE_ID,
+  PRODUCTS,
+  PRODUCTS_ID,
+} = SAMPLE_DATABASE;
 
 describe("scenarios > question > notebook", () => {
   beforeEach(() => {
@@ -415,6 +422,31 @@ describe("scenarios > question > notebook", () => {
     });
 
     cy.findByText("Starts with").click();
+
+    cy.findByText("Case sensitive").click();
+  });
+
+  it("should treat max/min on a category as a string filter (metabase#22154)", () => {
+    const questionDetails = {
+      name: "22154",
+      query: {
+        "source-table": PRODUCTS_ID,
+        aggregation: [["min", ["field", PRODUCTS.VENDOR, null]]],
+        breakout: [["field", PRODUCTS.CATEGORY, null]],
+      },
+      display: "table",
+    };
+
+    cy.createQuestion(questionDetails, { visitQuestion: true });
+
+    cy.findByText("Filter").click();
+    cy.findByTestId("sidebar-right").within(() => {
+      cy.findByText("Min of Vendor").click();
+
+      cy.findByText("Is").click();
+    });
+
+    cy.findByText("Ends with").click();
 
     cy.findByText("Case sensitive").click();
   });


### PR DESCRIPTION
Fixes #22154.

To reproduce:
1. New, Question, Sample Database, Products
2. Summarize, Minimum of Vendor, group by Category
3. Filter, Min of Vendor

### Before

It's a number filter (incorrect).

![image](https://user-images.githubusercontent.com/7288/165866094-1a29f64c-6325-4f5a-bb8d-df438a6eb343.png)

### After

It's a string filter.

![image](https://user-images.githubusercontent.com/7288/165866039-08eea104-3137-4687-bdff-ee6b41e51041.png)
