### PR TITLE
Fix sort by aggregation question name generation

### DIFF
--- a/frontend/src/metabase/lib/query/description.js
+++ b/frontend/src/metabase/lib/query/description.js
@@ -168,12 +168,15 @@ export function getOrderByDescription(tableMetadata, query, options) {
     return [
       t`Sorted by `,
       joinList(
-        orderBy.map(
-          ([direction, field]) =>
-            getFieldName(tableMetadata, field, options) +
-            " " +
-            (direction === "asc" ? "ascending" : "descending"),
-        ),
+        orderBy.map(([direction, field]) => {
+          const name = FIELD_REF.isAggregateField(field)
+            ? getAggregationDescription(tableMetadata, query, options)
+            : getFieldName(tableMetadata, field, options);
+
+          return (
+            name + " " + (direction === "asc" ? "ascending" : "descending")
+          );
+        }),
         " and ",
       ),
     ];

--- a/frontend/test/metabase/lib/query/description.unit.spec.js
+++ b/frontend/test/metabase/lib/query/description.unit.spec.js
@@ -1,33 +1,80 @@
-import { generateQueryDescription } from "metabase/lib/query/description";
+import {
+  generateQueryDescription,
+  getOrderByDescription,
+} from "metabase/lib/query/description";
 
-import { ORDERS } from "__support__/sample_database_fixture";
+import { ORDERS, PRODUCTS } from "__support__/sample_database_fixture";
 
 const mockTableMetadata = {
   display_name: "Order",
   fields: [{ id: 1, display_name: "Total" }],
 };
 
-describe("generateQueryDescription", () => {
-  it("should work with multiple aggregations", () => {
-    expect(
-      generateQueryDescription(mockTableMetadata, {
-        "source-table": ORDERS.id,
-        aggregation: [["count"], ["sum", ["field", 1, null]]],
-      }),
-    ).toEqual("Orders, Count and Sum of Total");
-  });
-  it("should work with named aggregations", () => {
-    expect(
-      generateQueryDescription(mockTableMetadata, {
-        "source-table": ORDERS.id,
-        aggregation: [
-          [
-            "aggregation-options",
-            ["sum", ["field", 1, null]],
-            { "display-name": "Revenue" },
+describe("metabase/lib/query/description", () => {
+  describe("generateQueryDescription", () => {
+    it("should work with multiple aggregations", () => {
+      expect(
+        generateQueryDescription(mockTableMetadata, {
+          "source-table": ORDERS.id,
+          aggregation: [["count"], ["sum", ["field", 1, null]]],
+        }),
+      ).toEqual("Orders, Count and Sum of Total");
+    });
+
+    it("should work with named aggregations", () => {
+      expect(
+        generateQueryDescription(mockTableMetadata, {
+          "source-table": ORDERS.id,
+          aggregation: [
+            [
+              "aggregation-options",
+              ["sum", ["field", 1, null]],
+              { "display-name": "Revenue" },
+            ],
           ],
-        ],
-      }),
-    ).toEqual("Orders, Revenue");
+        }),
+      ).toEqual("Orders, Revenue");
+    });
+  });
+
+  describe("getOrderByDescription", () => {
+    it("should work with fields", () => {
+      const query = {
+        "source-table": PRODUCTS.id,
+        "order-by": [["asc", ["field", PRODUCTS.CATEGORY.id, null]]],
+      };
+
+      expect(getOrderByDescription(PRODUCTS, query)).toEqual([
+        "Sorted by ",
+        ["Category ascending"],
+      ]);
+    });
+
+    it("should work with aggregations", () => {
+      const query = {
+        "source-table": PRODUCTS.id,
+        aggregation: [["count"]],
+        breakout: [["field", PRODUCTS.CATEGORY.id, null]],
+        "order-by": [["asc", ["aggregation", 0, null]]],
+      };
+      expect(getOrderByDescription(PRODUCTS, query)).toEqual([
+        "Sorted by ",
+        ["Count ascending"],
+      ]);
+    });
+
+    it("should work with expressions", () => {
+      const query = {
+        "source-table": PRODUCTS.id,
+        expressions: {
+          Foo: ["concat", "Foo ", ["field", 4, null]],
+        },
+        "order-by": [["asc", ["expression", "Foo", null]]],
+      };
+      expect(getOrderByDescription(PRODUCTS, query)).toEqual([
+        "Sorted by ",
+        ["Foo ascending"],
+      ]);
+    });
   });
 });


### PR DESCRIPTION
Fixes #19005 

The `getOrderByDescription` function in `metabase/lib/query/description` handled sorting by aggregation columns incorrectly (it blindly passed the `orderedBy` field ref to `getFieldName`, which shouldn't be used for aggregation field refs). Using `getAggregationDescription` fixes the problem.

**Before**
![Screen Shot 2022-04-28 at 5 21 50 PM](https://user-images.githubusercontent.com/13057258/165867817-4e5af3f3-6233-4a31-b930-48d9259b6dbb.png)

**After**
![Screen Shot 2022-04-28 at 5 22 05 PM](https://user-images.githubusercontent.com/13057258/165867833-2c331d36-cca3-4649-8cc0-1ebd4f2a305c.png)

**Testing**
Follow the steps in #19005 