### PR TITLE
Fix datetime `Exclude Month of Year` filter date

### DIFF
--- a/frontend/src/metabase/lib/query_time.js
+++ b/frontend/src/metabase/lib/query_time.js
@@ -625,6 +625,7 @@ export const EXCLUDE_OPTIONS = {
   [EXCLUDE_UNITS["months"]]: () => {
     const now = moment()
       .utc()
+      .date(1)
       .hours(0)
       .minutes(0)
       .seconds(0)

--- a/frontend/src/metabase/parameters/utils/mbql.unit.spec.js
+++ b/frontend/src/metabase/parameters/utils/mbql.unit.spec.js
@@ -160,9 +160,11 @@ describe("parameters/utils/mbql", () => {
         "!=",
         ["field", null, { "temporal-unit": "month-of-year" }],
         date()
+          .date(1)
           .month(1)
           .format("YYYY-MM-DD"),
         date()
+          .date(1)
           .month(2)
           .format("YYYY-MM-DD"),
       ]);


### PR DESCRIPTION
Sets `date` to `1` before setting the month in `Exclude` month options, otherwise `moment.js` does something weird.