### PR TITLE
Add a help link to homepage sections

### DIFF
--- a/frontend/src/metabase/home/homepage/components/HomeContent/HomeContent.tsx
+++ b/frontend/src/metabase/home/homepage/components/HomeContent/HomeContent.tsx
@@ -1,12 +1,11 @@
 import React from "react";
-import moment from "moment";
-import { parseTimestamp } from "metabase/lib/time";
 import { isSyncCompleted } from "metabase/lib/syncing";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 import { Database, PopularItem, RecentItem, User } from "metabase-types/api";
 import HomePopularSection from "../../containers/HomePopularSection";
 import HomeRecentSection from "../../containers/HomeRecentSection";
 import HomeXraySection from "../../containers/HomeXraySection";
+import { isWithinWeeks } from "../../utils";
 
 export interface HomeContentProps {
   user: User;
@@ -43,7 +42,7 @@ const isLoading = ({
 }: HomeContentProps): boolean => {
   if (!user.has_question_and_dashboard) {
     return databases == null;
-  } else if (user.is_installer || !isWithinWeek(user.first_login)) {
+  } else if (user.is_installer || !isWithinWeeks(user.first_login, 1)) {
     return databases == null || recentItems == null;
   } else {
     return databases == null || recentItems == null || popularItems == null;
@@ -59,7 +58,7 @@ const isPopularSection = ({
     !user.is_installer &&
     user.has_question_and_dashboard &&
     popularItems.length > 0 &&
-    (isWithinWeek(user.first_login) || !recentItems.length)
+    (isWithinWeeks(user.first_login, 1) || !recentItems.length)
   );
 };
 
@@ -72,12 +71,6 @@ const isRecentSection = ({
 
 const isXraySection = ({ databases = [] }: HomeContentProps): boolean => {
   return databases.some(isSyncCompleted);
-};
-
-const isWithinWeek = (timestamp: string): boolean => {
-  const date = parseTimestamp(timestamp);
-  const weekAgo = moment().subtract(1, "week");
-  return date.isAfter(weekAgo);
 };
 
 export default HomeContent;

--- a/frontend/src/metabase/home/homepage/components/HomeRecentSection/HomeRecentSection.tsx
+++ b/frontend/src/metabase/home/homepage/components/HomeRecentSection/HomeRecentSection.tsx
@@ -2,18 +2,24 @@ import React from "react";
 import { t } from "ttag";
 import * as Urls from "metabase/lib/urls";
 import { getIcon, getName } from "metabase/entities/recent-items";
-import { RecentItem } from "metabase-types/api";
+import { RecentItem, User } from "metabase-types/api";
 import HomeCaption from "../HomeCaption";
+import HomeHelpCard from "../HomeHelpCard";
 import HomeModelCard from "../HomeModelCard";
+import { isWithinWeeks } from "../../utils";
 import { SectionBody } from "./HomeRecentSection.styled";
 
 export interface HomeRecentSectionProps {
+  user: User;
   recentItems: RecentItem[];
 }
 
 const HomeRecentSection = ({
+  user,
   recentItems,
 }: HomeRecentSectionProps): JSX.Element => {
+  const hasHelpCard = user.is_installer && isWithinWeeks(user.first_login, 2);
+
   return (
     <div>
       <HomeCaption>{t`Pick up where you left off`}</HomeCaption>
@@ -26,6 +32,7 @@ const HomeRecentSection = ({
             url={Urls.modelToUrl(item) ?? ""}
           />
         ))}
+        {hasHelpCard && <HomeHelpCard />}
       </SectionBody>
     </div>
   );

--- a/frontend/src/metabase/home/homepage/components/HomeRecentSection/HomeRecentSection.unit.spec.tsx
+++ b/frontend/src/metabase/home/homepage/components/HomeRecentSection/HomeRecentSection.unit.spec.tsx
@@ -1,9 +1,18 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import HomeRecentSection, { HomeRecentSectionProps } from "./HomeRecentSection";
-import { createMockRecentItem } from "metabase-types/api/mocks";
+import { createMockRecentItem, createMockUser } from "metabase-types/api/mocks";
 
 describe("HomeRecentSection", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(2020, 0, 10));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it("should render a list of recent items", () => {
     const props = getProps({
       recentItems: [
@@ -21,11 +30,54 @@ describe("HomeRecentSection", () => {
     expect(screen.getByText("Pick up where you left off")).toBeInTheDocument();
     expect(screen.getByText("Orders")).toBeInTheDocument();
   });
+
+  it("should show a help link for new installers", () => {
+    const props = getProps({
+      user: createMockUser({
+        is_installer: true,
+        first_login: "2020-01-05T00:00:00Z",
+      }),
+      recentItems: [
+        createMockRecentItem({
+          model: "table",
+          model_object: {
+            name: "Orders",
+          },
+        }),
+      ],
+    });
+
+    render(<HomeRecentSection {...props} />);
+
+    expect(screen.getByText("Metabase tips")).toBeInTheDocument();
+  });
+
+  it("should not show a help link for regular users", () => {
+    const props = getProps({
+      user: createMockUser({
+        is_installer: false,
+        first_login: "2020-01-05T00:00:00Z",
+      }),
+      recentItems: [
+        createMockRecentItem({
+          model: "table",
+          model_object: {
+            name: "Orders",
+          },
+        }),
+      ],
+    });
+
+    render(<HomeRecentSection {...props} />);
+
+    expect(screen.queryByText("Metabase tips")).not.toBeInTheDocument();
+  });
 });
 
 const getProps = (
   opts?: Partial<HomeRecentSectionProps>,
 ): HomeRecentSectionProps => ({
+  user: createMockUser(),
   recentItems: [],
   ...opts,
 });

--- a/frontend/src/metabase/home/homepage/components/HomeXraySection/HomeXraySection.tsx
+++ b/frontend/src/metabase/home/homepage/components/HomeXraySection/HomeXraySection.tsx
@@ -5,6 +5,7 @@ import * as Urls from "metabase/lib/urls";
 import Select from "metabase/core/components/Select";
 import { Database, DatabaseCandidate } from "metabase-types/api";
 import HomeCaption from "../HomeCaption";
+import HomeHelpCard from "../HomeHelpCard";
 import HomeXrayCard from "../HomeXrayCard";
 import {
   DatabaseLinkIcon,
@@ -65,6 +66,7 @@ const HomeXraySection = ({
             message={tableMessages[index]}
           />
         ))}
+        <HomeHelpCard />
       </SectionBody>
     </div>
   );

--- a/frontend/src/metabase/home/homepage/containers/HomeRecentSection/HomeRecentSection.tsx
+++ b/frontend/src/metabase/home/homepage/containers/HomeRecentSection/HomeRecentSection.tsx
@@ -1,4 +1,15 @@
+import { connect } from "react-redux";
+import _ from "underscore";
 import RecentItems from "metabase/entities/recent-items";
+import { getUser } from "metabase/selectors/user";
+import { State } from "metabase-types/store";
 import HomeRecentSection from "../../components/HomeRecentSection";
 
-export default RecentItems.loadList()(HomeRecentSection);
+const mapStateToProps = (state: State) => ({
+  user: getUser(state),
+});
+
+export default _.compose(
+  RecentItems.loadList(),
+  connect(mapStateToProps),
+)(HomeRecentSection);

--- a/frontend/src/metabase/home/homepage/utils.ts
+++ b/frontend/src/metabase/home/homepage/utils.ts
@@ -1,0 +1,11 @@
+import moment, { MomentInput } from "moment";
+import { parseTimestamp } from "metabase/lib/time";
+
+export const isWithinWeeks = (
+  timestamp: MomentInput,
+  weekCount: number,
+): boolean => {
+  const date = parseTimestamp(timestamp);
+  const weeksAgo = moment().subtract(weekCount, "week");
+  return date.isAfter(weeksAgo);
+};


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/22220

How to test the x-ray section:
- Run a new Metabase instance
- Log in as an admin. You should see x-rays and the help link

How to test the recents section:
- Run a new Metabase instance
- Create a question and a dashboard. After creation, open them again, e.g. by refreshing the browser
- Refresh the page and navigate to the homepage
- You should see your recent items and the help link

<img width="980" alt="Screenshot 2022-04-29 at 13 28 10" src="https://user-images.githubusercontent.com/8542534/165928093-84e20344-e8f8-43d2-950e-9187e92d2b5f.png">
