### PR TITLE
Fix moving a default timeline between collections

### DIFF
--- a/frontend/src/metabase/entities/timelines.js
+++ b/frontend/src/metabase/entities/timelines.js
@@ -4,7 +4,7 @@ import _ from "underscore";
 import { TimelineSchema } from "metabase/schema";
 import { TimelineApi, TimelineEventApi } from "metabase/services";
 import { createEntity, undo } from "metabase/lib/entities";
-import { getDefaultTimeline } from "metabase/lib/timelines";
+import { getDefaultTimeline, getTimelineName } from "metabase/lib/timelines";
 import { canonicalCollectionId } from "metabase/collections/utils";
 import TimelineEvents from "./timeline-events";
 import forms from "./timelines/forms";
@@ -35,17 +35,21 @@ const Timelines = createEntity({
   },
 
   objectActions: {
-    setCollection: ({ id }, collection, opts) => {
+    setCollection: (timeline, collection, opts) => {
       return Timelines.actions.update(
-        { id },
-        { collection_id: canonicalCollectionId(collection && collection.id) },
+        { id: timeline.id },
+        {
+          name: getTimelineName(timeline),
+          collection_id: canonicalCollectionId(collection && collection.id),
+          default: false,
+        },
         undo(opts, t`timeline`, t`moved`),
       );
     },
 
-    setArchived: ({ id }, archived, opts) =>
+    setArchived: (timeline, archived, opts) =>
       Timelines.actions.update(
-        { id },
+        { id: timeline.id },
         { archived, default: false },
         undo(opts, t`timeline`, archived ? t`archived` : t`unarchived`),
       ),

--- a/frontend/src/metabase/entities/timelines.js
+++ b/frontend/src/metabase/entities/timelines.js
@@ -47,12 +47,13 @@ const Timelines = createEntity({
       );
     },
 
-    setArchived: (timeline, archived, opts) =>
-      Timelines.actions.update(
+    setArchived: (timeline, archived, opts) => {
+      return Timelines.actions.update(
         { id: timeline.id },
         { archived, default: false },
         undo(opts, t`timeline`, archived ? t`archived` : t`unarchived`),
-      ),
+      );
+    },
   },
 
   reducer: (state = {}, action) => {

--- a/frontend/src/metabase/timelines/collections/actions.ts
+++ b/frontend/src/metabase/timelines/collections/actions.ts
@@ -1,0 +1,19 @@
+import { push } from "react-router-redux";
+import * as Urls from "metabase/lib/urls";
+import Timelines from "metabase/entities/timelines";
+import { Timeline } from "metabase-types/api";
+import { State } from "metabase-types/store";
+
+export const setCollectionAndNavigate = (
+  timeline: Timeline,
+  collectionId: number | null,
+) => {
+  return async (dispatch: any, getState: () => State) => {
+    const collection = { id: collectionId };
+    await dispatch(Timelines.actions.setCollection(timeline, collection));
+
+    const newProps = { entityId: timeline.id };
+    const newTimeline = Timelines.selectors.getObject(getState(), newProps);
+    dispatch(push(Urls.timelineInCollection(newTimeline)));
+  };
+};

--- a/frontend/src/metabase/timelines/collections/containers/MoveTimelineModal/MoveTimelineModal.tsx
+++ b/frontend/src/metabase/timelines/collections/containers/MoveTimelineModal/MoveTimelineModal.tsx
@@ -1,5 +1,5 @@
 import { connect } from "react-redux";
-import { goBack, push } from "react-router-redux";
+import { goBack } from "react-router-redux";
 import _ from "underscore";
 import * as Urls from "metabase/lib/urls";
 import Timelines from "metabase/entities/timelines";
@@ -7,6 +7,7 @@ import MoveTimelineModal from "metabase/timelines/common/components/MoveTimeline
 import { Timeline } from "metabase-types/api";
 import { State } from "metabase-types/store";
 import LoadingAndErrorWrapper from "../../components/LoadingAndErrorWrapper";
+import { setCollectionAndNavigate } from "../../actions";
 import { ModalParams } from "../../types";
 
 interface MoveTimelineModalProps {
@@ -22,9 +23,7 @@ const timelineProps = {
 
 const mapDispatchToProps = (dispatch: any) => ({
   onSubmit: async (timeline: Timeline, collectionId: number | null) => {
-    const collection = { id: collectionId };
-    await dispatch(Timelines.actions.setCollection(timeline, collection));
-    dispatch(push(Urls.timelineInCollection(timeline)));
+    dispatch(setCollectionAndNavigate(timeline, collectionId));
   },
   onCancel: () => {
     dispatch(goBack());

--- a/frontend/test/metabase/scenarios/organization/timelines-collection.cy.spec.js
+++ b/frontend/test/metabase/scenarios/organization/timelines-collection.cy.spec.js
@@ -360,7 +360,7 @@ describe("scenarios > organization > timelines > collection", () => {
 
     it("should move a timeline", () => {
       cy.createTimelineWithEvents({
-        timeline: { name: "Our analytics events", default: true },
+        timeline: { name: "Events", default: true },
         events: [{ name: "RC1" }],
       });
 
@@ -369,11 +369,12 @@ describe("scenarios > organization > timelines > collection", () => {
       cy.findByText("Move timeline").click();
 
       getModal().within(() => {
-        cy.findByText("First collection").click();
+        cy.findByText("My personal collection").click();
         cy.button("Move").click();
         cy.wait("@updateTimeline");
       });
 
+      cy.findByText("Bobby Tables's Personal Collection").should("be.visible");
       cy.findByText("First collection events").should("be.visible");
     });
 

--- a/frontend/test/metabase/scenarios/organization/timelines-collection.cy.spec.js
+++ b/frontend/test/metabase/scenarios/organization/timelines-collection.cy.spec.js
@@ -374,8 +374,8 @@ describe("scenarios > organization > timelines > collection", () => {
         cy.wait("@updateTimeline");
       });
 
+      cy.findByText("Our analytics events").should("be.visible");
       cy.findByText("Bobby Tables's Personal Collection").should("be.visible");
-      cy.findByText("First collection events").should("be.visible");
     });
 
     it("should archive a timeline and undo", () => {


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/22204

How to test:
- Create a default timeline in a non-root collection (e.g. personal one). A default timeline is created when there are no other timelines in a collection.
- Move the timeline to the root collection via header menu in the modal.
- Check that the timeline has retained its name after moving.
- Check that you have been correctly navigated to the collection where the timeline has been moved.

<img width="653" alt="Screenshot 2022-04-29 at 14 41 22" src="https://user-images.githubusercontent.com/8542534/165937963-5f8c79d7-e4bc-47d8-928e-3b63830cd447.png">
