### PR TITLE
docs - note on postgres json sync

### DIFF
--- a/docs/administration-guide/databases/mongodb.md
+++ b/docs/administration-guide/databases/mongodb.md
@@ -8,9 +8,9 @@ This article covers:
 - [General connectivity concerns](#general-connectivity-concerns).
 - [I added fields to my database but don't see them in Metabase](#i-added-fields-to-my-database-but-dont-see-them-in-metabase).
 
-## How does MongoDB work in Metabase
+## How Metabase syncs data in MongoDB
 
-Because MongoDB contains unstructured data, Metabase takes a different approach to syncing your database's metadata. To get a sense of the schema, Metabase will scan the first 200 documents of each collection in your MongoDB. This sampling helps Metabase do things like differentiate datetime fields from string fields, and provide people with pre-populated filters. The reason Metabase only scans a sample of the documents is because scanning every document in every collection on every sync would be put too much strain on your database. And while the sampling does a pretty good job keeping Metabase up to date, it can also mean that new fields can sometimes fall through the cracks, leading to visualization issues, or even fields failing to appear in your results. For more info, check out our [troubleshooting guide](../../troubleshooting-guide/datawarehouse.html).
+Because MongoDB contains unstructured data, Metabase takes a different approach to syncing your database's metadata. To get a sense of the schema, Metabase will scan the first ten thousand documents of each collection in your MongoDB. This sampling helps Metabase do things like differentiate datetime fields from string fields, and provide people with pre-populated filters. The reason Metabase only scans a sample of the documents is because scanning every document in every collection on every sync would be put too much strain on your database. And while the sampling does a pretty good job keeping Metabase up to date, it can also mean that new fields can sometimes fall through the cracks, leading to visualization issues, or even fields failing to appear in your results. For more info, check out our [troubleshooting guide](../../troubleshooting-guide/datawarehouse.md).
 
 ## Connecting to MongoDB
 

--- a/docs/administration-guide/databases/postgresql.md
+++ b/docs/administration-guide/databases/postgresql.md
@@ -82,5 +82,12 @@ This is a lightweight process that checks for updates to this database’s schem
 
 This enables Metabase to scan for additional field values during syncs allowing smarter behavior, like improved auto-binning on your bar charts.
 
+## Note on syncing records that include JSON 
+
+Postgres JSON fields don’t have schema, so Metabase can’t rely on table metadata to define which keys a JSON field has. To work around the lack of schema, Metabase will get the first ten thousand records and parse the JSON in those records to infer the JSON's "schema". The reason Metabase limits itself to ten thousand records is so that syncing metadata doesn't put unnecessary strain on your database.
+
+The problem is that if the keys in the JSON vary record to record, the first ten thousand rows may not capture all the keys used by JSON objects in that JSON field. To get Metabase to infer all the JSON keys, you'll need to add the additional keys to the JSON objects in the first ten thousand row.
+
 [ssl-modes]: https://jdbc.postgresql.org/documentation/head/ssl-client.html
 [ssh-tunnel]: ../ssh-tunnel-for-database-connections.html
+


### PR DESCRIPTION
- Adds note to postgres connection docs regarding JSON sync.
- In Mongo docs, updates the number of records synced from 200 to 10K.
