### PR TITLE
[E2E] Smoketest user: wait for the dataset before assertion

### DIFF
--- a/frontend/test/metabase/scenarios/smoketest/user.cy.spec.js
+++ b/frontend/test/metabase/scenarios/smoketest/user.cy.spec.js
@@ -38,6 +38,7 @@ describe("smoketest > user", () => {
   });
 
   it("should sort via both the header and notebook editor", () => {
+    cy.intercept("POST", "/api/dataset").as("dataset");
     // Sorting by header
     cy.wait(1000)
       .get(".Icon-table2")
@@ -53,6 +54,7 @@ describe("smoketest > user", () => {
       .click();
 
     cy.icon("arrow_down").click();
+    cy.wait("@dataset");
 
     cy.get("@firstTableCell").contains("Ergonomic Wool Bag");
 


### PR DESCRIPTION
### Before

A failure [like this](https://app.circleci.com/pipelines/github/metabase/metabase/35129/workflows/d51f41ee-4e12-4de1-a730-d462ee267949/jobs/1827969/artifacts) happened on `frontend/test/metabase/scenarios/smoketest/user.cy.spec.js`. Seems like a race condition between the UI and the XHR to `/api/dataset`.

![image](https://user-images.githubusercontent.com/7288/165980717-c2408463-5435-4714-8212-6f9ee9f6e11f.png)

### After

It should happen anyway, as the test waits properly for `/api/dataset`, before checking the result in the table.