### PR TITLE
bump snowplow-java-tracker

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -35,9 +35,12 @@
                                                            org.slf4j/slf4j-api]}
   com.draines/postal                        {:mvn/version "2.0.5"}              ; SMTP library
   com.google.guava/guava                    {:mvn/version "31.0.1-jre"}         ; dep for BigQuery, Spark, and GA. Require here rather than letting different dep versions stomp on each other — see comments on #9697
+  com.fasterxml.jackson.core/jackson-databind
+                                            {:mvn/version "2.13.2.2"}           ; JSON processor used by snowplow-java-tracker (pinned version due to CVE-2020-36518)
   com.h2database/h2                         {:mvn/version "1.4.197"}            ; embedded SQL database
   com.snowplowanalytics/snowplow-java-tracker
-                                            {:mvn/version "0.12.0"}             ; Snowplow analytics
+                                            {:mvn/version "0.12.0"              ; Snowplow analytics
+                                             :exclusions [com.fasterxml.jackson.core/jackson-databind]}
   com.taoensso/nippy                        {:mvn/version "3.1.1"}              ; Fast serialization (i.e., GZIP) library for Clojure
   com.vladsch.flexmark/flexmark             {:mvn/version "0.62.2"}             ; Markdown parsing
   com.vladsch.flexmark/flexmark-ext-autolink

--- a/deps.edn
+++ b/deps.edn
@@ -37,7 +37,7 @@
   com.google.guava/guava                    {:mvn/version "31.0.1-jre"}         ; dep for BigQuery, Spark, and GA. Require here rather than letting different dep versions stomp on each other — see comments on #9697
   com.h2database/h2                         {:mvn/version "1.4.197"}            ; embedded SQL database
   com.snowplowanalytics/snowplow-java-tracker
-                                            {:mvn/version "0.11.0"}             ; Snowplow analytics
+                                            {:mvn/version "0.12.0"}             ; Snowplow analytics
   com.taoensso/nippy                        {:mvn/version "3.1.1"}              ; Fast serialization (i.e., GZIP) library for Clojure
   com.vladsch.flexmark/flexmark             {:mvn/version "0.62.2"}             ; Markdown parsing
   com.vladsch.flexmark/flexmark-ext-autolink

--- a/src/metabase/analytics/snowplow.clj
+++ b/src/metabase/analytics/snowplow.clj
@@ -89,7 +89,7 @@
                                      (.url (snowplow-url)))
                          adapter (.build ^ApacheHttpClientAdapter$Builder builder)
                          batch-emitter-builder (-> (BatchEmitter/builder)
-                                                   (.bufferSize 1)
+                                                   (.batchSize 1)
                                                    (.httpClientAdapter adapter))]
                      (.build ^BatchEmitter$Builder batch-emitter-builder)))]
      (fn [] @emitter*)))


### PR DESCRIPTION
Only breaking change that affects us seems to be renaming `bufferSize` to `batchSize`. Other than that everything seems to be working fine.