### PR TITLE
Fix FK drills for native models overwriting metadata

### DIFF
--- a/frontend/src/metabase-lib/lib/Question.ts
+++ b/frontend/src/metabase-lib/lib/Question.ts
@@ -1286,7 +1286,7 @@ export default class Question {
     return isAltered ? question.markDirty() : question;
   }
 
-  getUrlWithParameters(parameters, parameterValues, { objectId } = {}) {
+  getUrlWithParameters(parameters, parameterValues, { objectId, clean } = {}) {
     const includeDisplayIsLocked = true;
 
     if (this.isStructured()) {
@@ -1297,6 +1297,7 @@ export default class Question {
           .setParameterValues(parameterValues)
           .convertParametersToFilters()
           .getUrl({
+            clean,
             originalQuestion: this,
             includeDisplayIsLocked,
             query: { objectId },
@@ -1304,12 +1305,14 @@ export default class Question {
       } else {
         const query = getParameterValuesBySlug(parameters, parameterValues);
         return questionWithParameters.markDirty().getUrl({
+          clean,
           query,
           includeDisplayIsLocked,
         });
       }
     } else {
       return this.getUrl({
+        clean,
         query: remapParameterValuesToTemplateTags(
           this.query().templateTags(),
           parameters,

--- a/frontend/src/metabase-lib/lib/Question.ts
+++ b/frontend/src/metabase-lib/lib/Question.ts
@@ -621,6 +621,15 @@ export default class Question {
     const query = this.query();
 
     if (!(query instanceof StructuredQuery)) {
+      if (this.isDataset()) {
+        const drillQuery = Question.create({
+          type: "query",
+          databaseId: this.databaseId(),
+          tableId: field.table_id,
+          metadata: this.metadata(),
+        }).query();
+        return drillQuery.addFilter(["=", field.reference(), value]).question();
+      }
       return;
     }
 

--- a/frontend/src/metabase-lib/lib/Question.ts
+++ b/frontend/src/metabase-lib/lib/Question.ts
@@ -22,6 +22,7 @@ import {
 } from "metabase-lib/lib/Dimension";
 import Mode from "metabase-lib/lib/Mode";
 import { isStandard } from "metabase/lib/query/filter";
+import { isFK } from "metabase/lib/schema_metadata";
 import { memoize, sortObject } from "metabase-lib/lib/utils";
 // TODO: remove these dependencies
 import * as Urls from "metabase/lib/urls";
@@ -69,6 +70,7 @@ import { Dataset, Value } from "metabase-types/types/Dataset";
 import { TableId } from "metabase-types/types/Table";
 import { DatabaseId } from "metabase-types/types/Database";
 import { ClickObject } from "metabase-types/types/Visualization";
+import { DependentMetadataItem } from "metabase-types/types/Query";
 import {
   ALERT_TYPE_PROGRESS_BAR_GOAL,
   ALERT_TYPE_ROWS,
@@ -1011,6 +1013,24 @@ export default class Question {
 
   getResultMetadata() {
     return this.card().result_metadata ?? [];
+  }
+
+  dependentMetadata(): DependentMetadataItem[] {
+    if (!this.isDataset()) {
+      return [];
+    }
+    const dependencies = [];
+
+    this.getResultMetadata().forEach(field => {
+      if (isFK(field) && field.fk_target_field_id) {
+        dependencies.push({
+          type: "field",
+          id: field.fk_target_field_id,
+        });
+      }
+    });
+
+    return dependencies;
   }
 
   /**

--- a/frontend/src/metabase/dashboard/actions.js
+++ b/frontend/src/metabase/dashboard/actions.js
@@ -1078,12 +1078,17 @@ export const navigateToNewCardFromDashboard = createThunkAction(
 const loadMetadataForDashboard = dashCards => (dispatch, getState) => {
   const metadata = getMetadata(getState());
 
-  const queries = dashCards
+  const questions = dashCards
     .filter(dc => !isVirtualDashCard(dc) && dc.card.dataset_query) // exclude text cards and queries without perms
     .flatMap(dc => [dc.card].concat(dc.series || []))
-    .map(card => new Question(card, metadata).query());
+    .map(card => new Question(card, metadata));
 
-  return dispatch(loadMetadataForQueries(queries));
+  return dispatch(
+    loadMetadataForQueries(
+      questions.map(question => question.query()),
+      questions.map(question => question.dependentMetadata()),
+    ),
+  );
 };
 
 export const fetchDashboardParameterValues = createThunkAction(

--- a/frontend/src/metabase/dashboard/actions.js
+++ b/frontend/src/metabase/dashboard/actions.js
@@ -1062,12 +1062,21 @@ export const navigateToNewCardFromDashboard = createThunkAction(
       dashcard,
     );
 
+    // When drilling from a native model, the drill can return a new question
+    // querying a table for which we don't have any metadata for
+    // When building a question URL, it'll usually clean the query and
+    // strip clauses referencing fields from tables without metadata
+    const previousQuestion = new Question(previousCard, metadata);
+    const isDrillingFromNativeModel =
+      previousQuestion.isDataset() && previousQuestion.isNative();
+
     // when the query is for a specific object (ie `=` filter on PK column)
     // it does not make sense to apply parameter filters
     // because we'll be navigating to the details view of a specific row on a table
     const url = question.isObjectDetail()
       ? Urls.serializedQuestion(question.card())
       : question.getUrlWithParameters(parametersMappedToCard, parameterValues, {
+          clean: !isDrillingFromNativeModel,
           objectId,
         });
 

--- a/frontend/src/metabase/modes/components/drill/ObjectDetailDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/ObjectDetailDrill.jsx
@@ -4,12 +4,9 @@ import * as Urls from "metabase/lib/urls";
 import { zoomInRow } from "metabase/query_builder/actions";
 
 function hasManyPKColumns(question) {
-  return (
-    question
-      .query()
-      .table()
-      .fields.filter(field => field.isPK()).length > 1
-  );
+  const table = question.query().table();
+  const fields = table?.fields ?? question.getResultMetadata();
+  return fields.filter(field => isPK(field)).length > 1;
 }
 
 function getActionForPKColumn({ question, column, objectId, extraData }) {

--- a/frontend/src/metabase/modes/components/drill/ObjectDetailDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/ObjectDetailDrill.jsx
@@ -65,13 +65,25 @@ function getPKAction({ question, column, objectId, extraData }) {
   return actionObject;
 }
 
+function getFKTargetField(column, metadata) {
+  const fkField = metadata.field(column.id);
+  if (fkField?.target) {
+    return fkField.target;
+  }
+  if (column.fk_target_field_id) {
+    const targetField = metadata.field(column.fk_target_field_id);
+    return targetField;
+  }
+  return null;
+}
+
 function getFKAction({ question, column, objectId }) {
   const actionObject = getBaseActionObject();
-  const fkField = question.metadata().field(column.id);
-  if (!fkField?.target) {
+  const targetField = getFKTargetField(column, question.metadata());
+  if (!targetField) {
     return;
   }
-  actionObject.question = () => question.drillPK(fkField.target, objectId);
+  actionObject.question = () => question.drillPK(targetField, objectId);
   return actionObject;
 }
 

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -819,7 +819,9 @@ export const loadMetadataForCard = card => (dispatch, getState) => {
   if (question.isDataset()) {
     queries.push(question.composeDataset().query());
   }
-  return dispatch(loadMetadataForQueries(queries));
+  return dispatch(
+    loadMetadataForQueries(queries, question.dependentMetadata()),
+  );
 };
 
 function hasNewColumns(question, queryResult) {

--- a/frontend/src/metabase/redux/metadata.js
+++ b/frontend/src/metabase/redux/metadata.js
@@ -308,27 +308,28 @@ export const fetchRealDatabasesWithMetadata = createThunkAction(
 
 export const loadMetadataForQuery = query => loadMetadataForQueries([query]);
 
-export const loadMetadataForQueries = queries => dispatch =>
-  Promise.all(
-    _.chain(queries)
-      .map(q => q.dependentMetadata())
-      .flatten()
-      .uniq(false, dep => dep.type + dep.id)
-      .map(({ type, id, foreignTables }) => {
-        if (type === "table") {
-          return (foreignTables
-            ? Tables.actions.fetchMetadataAndForeignTables
-            : Tables.actions.fetchMetadata)({ id });
-        } else if (type === "field") {
-          return Fields.actions.fetch({ id });
-        } else if (type === "schema") {
-          return Schemas.actions.fetchList({ dbId: id });
-        } else {
-          console.warn(`loadMetadataForQueries: type ${type} not implemented`);
-        }
-      })
-      // unrecognized types would result in undefined, so we filter that out
-      .filter(action => action !== undefined)
-      .map(dispatch)
-      .value(),
-  ).catch(e => console.error("Failed loading metadata for query", e));
+export const loadMetadataForQueries = queries => dispatch => {
+  const dependencies = _.chain(queries)
+    .map(q => q.dependentMetadata())
+    .flatten()
+    .uniq(false, dep => dep.type + dep.id)
+    .map(({ type, id, foreignTables }) => {
+      if (type === "table") {
+        return (foreignTables
+          ? Tables.actions.fetchMetadataAndForeignTables
+          : Tables.actions.fetchMetadata)({ id });
+      } else if (type === "field") {
+        return Fields.actions.fetch({ id });
+      } else if (type === "schema") {
+        return Schemas.actions.fetchList({ dbId: id });
+      } else {
+        console.warn(`loadMetadataForQueries: type ${type} not implemented`);
+      }
+    })
+    .filter(Boolean)
+    .value();
+
+  return Promise.all(dependencies.map(dispatch)).catch(e =>
+    console.error("Failed loading metadata for query", e),
+  );
+};

--- a/frontend/src/metabase/redux/metadata.js
+++ b/frontend/src/metabase/redux/metadata.js
@@ -306,11 +306,16 @@ export const fetchRealDatabasesWithMetadata = createThunkAction(
   },
 );
 
-export const loadMetadataForQuery = query => loadMetadataForQueries([query]);
+export const loadMetadataForQuery = (query, extraDependencies) =>
+  loadMetadataForQueries([query], extraDependencies);
 
-export const loadMetadataForQueries = queries => dispatch => {
+export const loadMetadataForQueries = (
+  queries,
+  extraDependencies = [],
+) => dispatch => {
   const dependencies = _.chain(queries)
     .map(q => q.dependentMetadata())
+    .push(...extraDependencies)
     .flatten()
     .uniq(false, dep => dep.type + dep.id)
     .map(({ type, id, foreignTables }) => {

--- a/frontend/src/metabase/redux/metadata.unit.spec.js
+++ b/frontend/src/metabase/redux/metadata.unit.spec.js
@@ -136,5 +136,21 @@ describe("deprecated metadata actions", () => {
 
       expect(Fields.actions.fetch).toHaveBeenCalledWith({ id: 3 });
     });
+
+    it("should load extra dependencies if provided", () => {
+      const query = {
+        dependentMetadata: () => [
+          {
+            type: "table",
+            id: 1,
+          },
+        ],
+      };
+
+      loadMetadataForQuery(query, [{ type: "field", id: 3 }])(dispatch);
+
+      expect(Tables.actions.fetchMetadata).toHaveBeenCalledWith({ id: 1 });
+      expect(Fields.actions.fetch).toHaveBeenCalledWith({ id: 3 });
+    });
   });
 });

--- a/frontend/test/__support__/e2e/commands/api/dashboard.js
+++ b/frontend/test/__support__/e2e/commands/api/dashboard.js
@@ -4,6 +4,6 @@ Cypress.Commands.add(
     cy.log(`Create a dashboard: ${name}`);
 
     // For all the possible keys, refer to `src/metabase/api/dashboard.clj`
-    cy.request("POST", "/api/dashboard", { name, ...dashboardDetails });
+    return cy.request("POST", "/api/dashboard", { name, ...dashboardDetails });
   },
 );

--- a/frontend/test/metabase-lib/lib/Question.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/Question.unit.spec.js
@@ -13,6 +13,8 @@ import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
 import NativeQuery from "metabase-lib/lib/queries/NativeQuery";
 import { deserializeCardFromUrl } from "metabase/lib/card";
 
+import { TYPE as SEMANTIC_TYPE } from "cljs/metabase.types";
+
 const card = {
   display: "table",
   visualization_settings: {},
@@ -929,6 +931,50 @@ describe("Question", () => {
         metadata,
       );
       expect(question.getResultMetadata()).toEqual([]);
+    });
+  });
+
+  describe("Question.prototype.dependentMetadata", () => {
+    it("should return model FK field targets", () => {
+      const question = new Question(
+        {
+          ...card,
+          dataset: true,
+          result_metadata: [
+            { semantic_type: SEMANTIC_TYPE.FK, fk_target_field_id: 5 },
+          ],
+        },
+        metadata,
+      );
+
+      expect(question.dependentMetadata()).toEqual([{ type: "field", id: 5 }]);
+    });
+
+    it("should return skip with with FK target field which are not FKs semantically", () => {
+      const question = new Question(
+        {
+          ...card,
+          dataset: true,
+          result_metadata: [{ fk_target_field_id: 5 }],
+        },
+        metadata,
+      );
+
+      expect(question.dependentMetadata()).toEqual([]);
+    });
+
+    it("should return nothing for regular questions", () => {
+      const question = new Question(
+        {
+          ...card,
+          result_metadata: [
+            { semantic_type: SEMANTIC_TYPE.FK, fk_target_field_id: 5 },
+          ],
+        },
+        metadata,
+      );
+
+      expect(question.dependentMetadata()).toEqual([]);
     });
   });
 

--- a/frontend/test/metabase-lib/lib/Question.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/Question.unit.spec.js
@@ -915,7 +915,7 @@ describe("Question", () => {
   });
 
   describe("Question.prototype.getResultMetadata", () => {
-    it("shoud return the `result_metadata` property off the underlying card", () => {
+    it("should return the `result_metadata` property off the underlying card", () => {
       const question = new Question(
         { ...card, result_metadata: [1, 2, 3] },
         metadata,

--- a/frontend/test/metabase/modes/components/drill/ObjectDetailDrill.unit.spec.js
+++ b/frontend/test/metabase/modes/components/drill/ObjectDetailDrill.unit.spec.js
@@ -1,6 +1,7 @@
 import Question from "metabase-lib/lib/Question";
 import ObjectDetailDrill from "metabase/modes/components/drill/ObjectDetailDrill";
 import { ZOOM_IN_ROW } from "metabase/query_builder/actions";
+import { TYPE as SEMANTIC_TYPE } from "cljs/metabase.types";
 import {
   ORDERS,
   PRODUCTS,
@@ -184,22 +185,48 @@ describe("ObjectDetailDrill", () => {
   });
 
   describe("FK cells", () => {
-    const { actions, cellValue } = setup({
-      column: ORDERS.PRODUCT_ID.column(),
+    describe("with a FK column", () => {
+      const { actions, cellValue } = setup({
+        column: ORDERS.PRODUCT_ID.column(),
+      });
+
+      it("should return object detail filter", () => {
+        expect(actions).toMatchObject([
+          { name: "object-detail", question: expect.any(Function) },
+        ]);
+      });
+
+      it("should apply object detail filter correctly", () => {
+        const [action] = actions;
+        const card = action.question().card();
+        expect(card.dataset_query.query).toEqual({
+          "source-table": PRODUCTS.id,
+          filter: ["=", PRODUCTS.ID.reference(), cellValue],
+        });
+      });
     });
 
-    it("should return object detail filter", () => {
-      expect(actions).toMatchObject([
-        { name: "object-detail", question: expect.any(Function) },
-      ]);
-    });
+    describe("with fk_target_field_id (model with customized metadata)", () => {
+      const { actions, cellValue } = setup({
+        column: {
+          semantic_type: SEMANTIC_TYPE.FK,
+          fk_target_field_id: PRODUCTS.ID.id,
+        },
+      });
 
-    it("should apply object detail filter correctly", () => {
-      const [action] = actions;
-      const card = action.question().card();
-      expect(card.dataset_query.query).toEqual({
-        "source-table": PRODUCTS.id,
-        filter: ["=", PRODUCTS.ID.reference(), cellValue],
+      it("should return object detail filter", () => {
+        expect(actions).toMatchObject([
+          { name: "object-detail", question: expect.any(Function) },
+        ]);
+      });
+
+      it("should apply object detail filter correctly", () => {
+        const [action] = actions;
+        const card = action.question().card();
+        expect(card.dataset_query.query).toEqual({
+          "source-table": PRODUCTS.id,
+          filter: ["=", PRODUCTS.ID.reference(), cellValue],
+        });
       });
     });
   });

--- a/frontend/test/metabase/modes/components/drill/ObjectDetailDrill.unit.spec.js
+++ b/frontend/test/metabase/modes/components/drill/ObjectDetailDrill.unit.spec.js
@@ -70,6 +70,23 @@ describe("ObjectDetailDrill", () => {
     expect(createdAtActions).toHaveLength(0);
   });
 
+  it("should not be available for not editable queries", () => {
+    const question = ORDERS.question();
+    question.query().isEditable = () => false;
+
+    const pk = setup({
+      question,
+      column: ORDERS.ID.column(),
+    });
+    const fk = setup({
+      question,
+      column: ORDERS.PRODUCT_ID.column(),
+    });
+
+    expect(pk.actions).toHaveLength(0);
+    expect(fk.actions).toHaveLength(0);
+  });
+
   describe("PK cells", () => {
     describe("general", () => {
       const mockDispatch = jest.fn();

--- a/frontend/test/metabase/scenarios/models/helpers/e2e-models-metadata-helpers.js
+++ b/frontend/test/metabase/scenarios/models/helpers/e2e-models-metadata-helpers.js
@@ -31,3 +31,12 @@ export function mapColumnTo({ table, column } = {}) {
     .contains(column)
     .click();
 }
+
+export function setModelMetadata(modelId, callback) {
+  return cy.request("GET", `/api/card/${modelId}`).then(response => {
+    const { result_metadata } = response.body;
+    return cy.request("PUT", `/api/card/${modelId}`, {
+      result_metadata: result_metadata.map(callback),
+    });
+  });
+}

--- a/frontend/test/metabase/scenarios/models/models-metadata.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models-metadata.cy.spec.js
@@ -1,4 +1,10 @@
-import { restore, sidebar, visualize } from "__support__/e2e/cypress";
+import {
+  restore,
+  sidebar,
+  visualize,
+  visitDashboard,
+  popover,
+} from "__support__/e2e/cypress";
 
 import {
   openDetailsSidebar,
@@ -10,6 +16,7 @@ import {
   renameColumn,
   setColumnType,
   mapColumnTo,
+  setModelMetadata,
 } from "./helpers/e2e-models-metadata-helpers";
 
 describe("scenarios > models metadata", () => {
@@ -161,4 +168,125 @@ describe("scenarios > models metadata", () => {
     cy.findByText("Tax ($)").should("not.exist");
     cy.findByText("TAX");
   });
+
+  describe("native models metadata overwrites", () => {
+    beforeEach(() => {
+      cy.createNativeQuestion(
+        {
+          name: "Native Model",
+          dataset: true,
+          native: {
+            query: "select * from orders",
+          },
+        },
+        { wrapId: true, idAlias: "modelId" },
+      );
+
+      cy.get("@modelId").then(modelId => {
+        setModelMetadata(modelId, field => {
+          if (field.display_name === "USER_ID") {
+            return {
+              ...field,
+              id: 11,
+              display_name: "User ID",
+              semantic_type: "type/FK",
+              fk_target_field_id: 30,
+            };
+          }
+          if (field.display_name !== "QUANTITY") {
+            return field;
+          }
+          return {
+            ...field,
+            display_name: "Review ID",
+            semantic_type: "type/FK",
+            fk_target_field_id: 36,
+          };
+        });
+      });
+
+      cy.intercept("POST", "/api/dataset").as("dataset");
+    });
+
+    it("should allow drills on FK columns", () => {
+      cy.get("@modelId").then(modelId => {
+        cy.visit(`/model/${modelId}`);
+        cy.wait("@dataset");
+
+        // Drill to People table
+        // FK column is mapped to real DB column
+        drillFK({ id: 1 });
+        cy.wait("@dataset");
+        cy.findByTestId("object-detail").within(() => {
+          cy.findByText("1");
+          cy.findByText("Hudson Borer");
+        });
+
+        cy.go("back");
+        cy.wait("@dataset");
+
+        // Drill to Reviews table
+        // FK column has a FK semantic type, no mapping to real DB columns
+        drillFK({ id: 7 });
+        cy.wait("@dataset");
+        cy.findByTestId("object-detail").within(() => {
+          cy.findByText("7");
+          cy.findByText("perry.ruecker");
+        });
+      });
+    });
+
+    it("should allow drills on FK columns from dashboards", () => {
+      cy.get("@modelId").then(modelId => {
+        cy.createDashboard().then(response => {
+          const dashboardId = response.body.id;
+          cy.request("POST", `/api/dashboard/${dashboardId}/cards`, {
+            cardId: modelId,
+            sizeX: 18,
+            sizeY: 9,
+          });
+
+          visitDashboard(dashboardId);
+
+          // Drill to People table
+          // FK column is mapped to real DB column
+          drillDashboardFK({ id: 1 });
+          cy.wait("@dataset");
+          cy.findByTestId("object-detail").within(() => {
+            cy.findByText("1");
+            cy.findByText("Hudson Borer");
+          });
+
+          cy.go("back");
+          cy.wait("@dataset");
+
+          // Drill to Reviews table
+          // FK column has a FK semantic type, no mapping to real DB columns
+          drillDashboardFK({ id: 7 });
+          cy.wait("@dataset");
+          cy.findByTestId("object-detail").within(() => {
+            cy.findByText("7");
+            cy.findByText("perry.ruecker");
+          });
+        });
+      });
+    });
+  });
 });
+
+function drillFK({ id }) {
+  cy.get(".Table-FK")
+    .contains(id)
+    .first()
+    .click();
+  popover()
+    .findByText("View details")
+    .click();
+}
+
+function drillDashboardFK({ id }) {
+  cy.get(".Table-FK")
+    .contains(id)
+    .first()
+    .click();
+}


### PR DESCRIPTION
Native questions usually have very limited metadata since we don't parse SQL. People can turn native questions into models and customize their columns' metadata via the metadata editor (`/model/:id/metadata`). For instance, it's possible to set the column's semantic type to `type/FK` and set its `fk_target_field_id`, so Metabase will treat the column as an FK.

This PR fixes a problem when FK drills were not working for the native model's FK columns. This happens because we were not loading the linked field's metadata, so there was no way for Metabase to build a new query to a foreign table.

Normally, we use [`loadMetadataForQueries` action](https://github.com/metabase/metabase/blob/91a87d814fa20125bacddf1d72ffd8e9dfe7a5f6/frontend/src/metabase/redux/metadata.js#L311) to load all the necessary metadata (fields, tables, foreign tables, etc.). It accepts a list of `StructuredQuery` / `NativeQuery`, retrieves a list of dependencies from their `dependentMetadata` methods, and then dispatches the necessary actions to fetch the data. This PR adds a `dependentMetadata` method for `Question` class instances that will only work for models. Model's `dependentMetadata` will return a list of foreign fields to be fetched. After this metadata is loaded, Metabase will be able to perform FK drills. There are also a few fixes around making it work in a dashboard environment + handling a lot of inconveniences because a lot of stuff is usually disabled for native queries.

### To Verify

<details>
<summary>🔨 [VIDEO] How to prepare the model for testing</summary>

https://user-images.githubusercontent.com/17258145/165991415-db197abc-9ba4-4bed-b75a-f67b110a71f3.mp4

</details>

⚠️ This PR is based on `master`, so it has some WIP changes to the object details view model. You'll notice that once you see an object detail modal with foreign record data, you won't be able to close the modal with a UI. It's an known issue that doesn't exist in the release branch and will be fixed separately.

1. New > SQL question > Sample Database > `select * from orders` > Save
2. Turn the question into a model, go to the metadata editor (click "Customize metadata" inside the details sidebar)
3. Map "USER ID" column to "Orders > User ID" column (click the column name > "Database column this maps to" > select "Orders" > "User ID"
4. Rename "Quantity" into something like "Reviews ID" and make it a FK to the Reviews table (click "semantic type" > select "Foreign Key" > select "Reviews > ID" from the dropdown that'll appear under the semantic type picker
5. Click "Save changes" in the top right
6. Click one of the "User ID" cells, you should see a modal with the user record info
7. Go back to the model, click one of the "Review ID" cells, you should see a modal with the review record info
8. Add the model to a dashboard, repeat the steps 6 and 7 

### Demo

<details>
<summary>From query builder</summary>

**Before**

https://user-images.githubusercontent.com/17258145/165992214-a00955a6-362f-42ad-bf1e-400788e9395f.mp4

**After**

https://user-images.githubusercontent.com/17258145/165992225-a639089e-8e13-48b6-bed0-39607798f92e.mp4

</details>

<details>
<summary>From dashboard</summary>

**Before**

https://user-images.githubusercontent.com/17258145/165992254-a8730f04-c859-4909-b456-13583df02601.mp4

**After**

https://user-images.githubusercontent.com/17258145/165992266-6de5bbf3-3b90-4c4f-af60-10bf96b251a2.mp4

</details>

