### PR TITLE
Fix a few console warnings/errors in QB

### DIFF
--- a/frontend/src/metabase/components/Badge.styled.jsx
+++ b/frontend/src/metabase/components/Badge.styled.jsx
@@ -9,9 +9,11 @@ import { shouldForwardNonTransientProp } from "metabase/lib/styling/emotion";
 
 const propTypes = {
   to: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+  activeColor: PropTypes.string,
+  inactiveColor: PropTypes.string,
 };
 
-function RawMaybeLink({ to, ...props }) {
+function RawMaybeLink({ to, activeColor, inactiveColor, ...props }) {
   return to ? <Link to={to} {...props} /> : <span {...props} />;
 }
 

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -230,8 +230,6 @@ AhHocQuestionLeftSide.propTypes = {
   isNative: PropTypes.bool,
   isObjectDetail: PropTypes.bool,
   isSummarized: PropTypes.bool,
-  onExpandFilters: PropTypes.func.isRequired,
-  onCollapseFilters: PropTypes.func.isRequired,
 };
 
 function AhHocQuestionLeftSide(props) {


### PR DESCRIPTION
1. `AhHocQuestionLeftSide` had `onExpandFilters` and `onCollapseFilters` marked as required in `propTypes`, but they are not actually used by it anymore
2. `RawMaybeLink` component has `inactiveColor` and `inactiveColor` used in styled component code, but they were accidentally spread to DOM element props (`span`)