### PR TITLE
Hide navbar in fullscreen dashboard

### DIFF
--- a/frontend/src/metabase/dashboard/hoc/DashboardControls.jsx
+++ b/frontend/src/metabase/dashboard/hoc/DashboardControls.jsx
@@ -186,13 +186,10 @@ export default ComposedComponent =>
         // when _showNav is called for the first time
         if (window.document) {
           const nav = window.document.querySelector(".Nav");
-          const appBar = window.document.querySelector("#root > header");
-          if (show && nav && appBar) {
+          if (show && nav) {
             nav.classList.remove("hide");
-            appBar.classList.remove("hide");
-          } else if (!show && nav && appBar) {
+          } else if (!show && nav) {
             nav.classList.add("hide");
-            appBar.classList.add("hide");
           }
         }
       }


### PR DESCRIPTION
Fixes #22203 — navbar remained visible when entering full-screen mode on a dashboard

### To Verify

1. Open a dashboard
2. Open the navigation sidebar
3. Enter fullscreen mode (click the fullscreen icon at the top right panel)
4. Ensure the sidebar is not visible