### PR TITLE
fix issue with missing parameter options in cloned, targeted dashboard

### DIFF
--- a/frontend/src/metabase/dashboard/components/ClickMappings.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickMappings.jsx
@@ -33,11 +33,13 @@ import { getParameters } from "metabase/dashboard/selectors";
     )
       .filter(mapping => getIn(mapping, ["source", "type"]) === "parameter")
       .map(mapping => mapping.source.id);
-    parameters = parameters.filter(p => parametersUsedAsSources.includes(p.id));
+    parameters = parameters.filter(p => {
+      return parametersUsedAsSources.includes(p.id);
+    });
   }
 
   const [setTargets, unsetTargets] = _.partition(
-    getTargetsWithSourceFilters({ isDash, object, metadata }),
+    getTargetsWithSourceFilters({ isDash, dashcard, object, metadata }),
     ({ id }) =>
       getIn(clickBehavior, ["parameterMapping", id, "source"]) != null,
   );

--- a/frontend/test/metabase/lib/click-behavior.unit.spec.js
+++ b/frontend/test/metabase/lib/click-behavior.unit.spec.js
@@ -66,6 +66,9 @@ describe("metabase/lib/click-behavior", () => {
       const [{ id, name, target }] = getTargetsWithSourceFilters({
         isDash: true,
         object: { parameters: [parameter] },
+        dashcard: {
+          dashboard_id: 111,
+        },
       });
       expect(id).toEqual("foo123");
       expect(name).toEqual("My Param");
@@ -219,6 +222,9 @@ describe("metabase/lib/click-behavior", () => {
           const [{ sourceFilters }] = getTargetsWithSourceFilters({
             isDash: true,
             object: { parameters: [parameter] },
+            dashcard: {
+              dashboard_id: 111,
+            },
           });
 
           const filteredSources = _.mapObject(sources, (sources, sourceType) =>


### PR DESCRIPTION
Fixes #19122 

In this specific scenario we need to check both dashboard ID and parameter ID; parameter IDs are not technically unique, and when cloning a dashboard we do not change the id value, so adding a click behavior to a dashcard that sends parameters to a copy of the dashboard you are on will otherwise have some options filtered out.

**Testing**
Follow steps in #19122 