### PR TITLE
try/catch around moment.locale

### DIFF
--- a/frontend/src/metabase/lib/i18n.js
+++ b/frontend/src/metabase/lib/i18n.js
@@ -80,11 +80,15 @@ export function setLocalization(translationsObject) {
 
 function updateMomentLocale(locale) {
   const momentLocale = mapToMomentLocale(locale);
-  if (momentLocale !== "en") {
-    require("moment/locale/" + momentLocale);
+  try {
+    if (momentLocale !== "en") {
+      require("moment/locale/" + momentLocale);
+    }
+    moment.locale(momentLocale);
+  } catch (e) {
+    console.warn(`Could not set moment locale to ${momentLocale}`);
+    moment.locale("en");
   }
-
-  moment.locale(momentLocale);
 }
 
 function mapToMomentLocale(locale = "") {


### PR DESCRIPTION
Wrapping moment.locale around try/catch so that if we attempt to require a locale that doesn't exist you are still able to use the site.
