### PR TITLE
Hide settings button when navbar is closed

### DIFF
--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.styled.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.styled.tsx
@@ -142,6 +142,7 @@ export const ProfileLinkContainer = styled.div<{ isOpen: boolean }>`
   border-top: 1px solid ${color("border")};
   background-color: ${color("white")};
   display: flex;
+  overflow: hidden;
   align-items: center;
   margin-right: ${space(2)};
   color: ${color("text-light")};


### PR DESCRIPTION
## Before

the settings button was clickable even when the sidebar was closed

https://user-images.githubusercontent.com/30528226/166060580-31988665-cd73-4461-bdf7-dd87e7e8e475.mp4


## After

The settings button is no longer clickable with the sidebar closed.
Resolves https://github.com/metabase/metabase/issues/22211

https://user-images.githubusercontent.com/30528226/166060522-ad796f54-4512-4526-8d7e-59de6b08bb63.mp4

