### PR TITLE
docs - update login troubleshooting

### DIFF
--- a/docs/administration-guide/04-managing-users.md
+++ b/docs/administration-guide/04-managing-users.md
@@ -22,6 +22,18 @@ To deactivate someone's account, click on the three dots icon on the right of a 
 
 To reactivate a deactivated account, click the **Deactivated** radio button at the top of the people list to see the list of deactivated accounts. Click on the icon on the far right to reactivate that account, allowing them to log in to Metabase again.
 
+### Deleting an account
+
+Metabase does not explicitly support account deletion. 
+
+The deactivation process protects the user’s activity (questions, dashboards, and collections) from disappearing when you want to revoke an account's access.
+
+If you want to delete an account because the account information was set up incorrectly, you will need to deactivate the old account and create a new one.
+
+1. Change the user name and email of the account you want to delete.
+2. Deactivate the account you want to delete.
+3. Create a new account with the correct user information.
+
 ### Editing an account
 
 You can edit someone's name and email address by clicking the three dots icon and choosing **Edit Details**. Note: be careful when changing someone's email address, because _this will change the address they’ll use to log in to Metabase_.
@@ -31,6 +43,33 @@ You can edit someone's name and email address by clicking the three dots icon an
 If you've already [configured your email settings](02-setting-up-email.md), people can reset their passwords using the "forgot password" link on the login screen. If you haven't yet configured your email settings, they will see a message telling them to ask an admin to reset their password for them.
 
 To reset a password for someone, just click the three dots icon next to their account and choose **Reset Password**. If you haven’t [configured your email settings](02-setting-up-email.md) yet, you’ll be given a temporary password that you’ll have to share with that person. Otherwise, they’ll receive a password reset email.
+
+### Resetting the admin password
+
+If you are using Metabase Cloud, contact support to have your admin password reset.
+
+If you're the administrator of a Metabase instance and have access to the server console, but have forgotten the password for the admin account, you can get Metabase to send you a password reset token:
+
+1.  Stop the running Metabase application.
+2.  Restart Metabase with `reset-password email@example.com`, where "email@example.com" is the email associated with the admin account:
+    ```
+    java -jar metabase.jar reset-password email@example.com
+    ```
+3.  This will print out a random token like this:
+
+    ```
+    ...
+    Resetting password for email@example.com...
+
+    OK [[[1_7db2b600-d538-4aeb-b4f7-0cf5b1970d89]]]
+    ```
+
+4.  Start Metabase normally again (_without_ the `reset-password` option).
+5.  Navigate to it in your browser using the path `/auth/reset_password/:token`, where ":token" is the token that was generated from the step above. The full URL should look something like this:
+    ```
+    https://metabase.example.com/auth/reset_password/1_7db2b600-d538-4aeb-b4f7-0cf5b1970d89
+    ```
+6.  You should now see a page where you can input a new password for the admin account.
 
 ### Unsubscribe from all subscriptions / alerts
 

--- a/docs/administration-guide/04-managing-users.md
+++ b/docs/administration-guide/04-managing-users.md
@@ -20,23 +20,33 @@ To deactivate someone's account, click on the three dots icon on the right of a 
 
 ![Remove a user](images/RemoveUser.png)
 
+### Reactivating an account
+
 To reactivate a deactivated account, click the **Deactivated** radio button at the top of the people list to see the list of deactivated accounts. Click on the icon on the far right to reactivate that account, allowing them to log in to Metabase again.
 
 ### Deleting an account
 
-Metabase does not explicitly support account deletion. 
+Metabase does not support account deletion. 
 
 The deactivation process protects the user’s activity (questions, dashboards, and collections) from disappearing when you want to revoke an account's access.
 
-If you want to delete an account because the account information was set up incorrectly, you will need to deactivate the old account and create a new one.
+If you want to delete an account because the account information was set up incorrectly, you can [deactivate](#deactivating-an-account) the old account and create a new one instead.
 
-1. Change the user name and email of the account you want to delete.
-2. Deactivate the account you want to delete.
+1. Change the user name and email of the old account.
+2. Deactivate the old account.
 3. Create a new account with the correct user information.
 
 ### Editing an account
 
 You can edit someone's name and email address by clicking the three dots icon and choosing **Edit Details**. Note: be careful when changing someone's email address, because _this will change the address they’ll use to log in to Metabase_.
+
+### Checking an account's auth method
+
+- Search for a user and look for an icon beside their name. 
+- If they log in using Google credentials, Metabase displays a Google icon. 
+- If they log in using an email address and password stored in Metabase, no icon is shown. 
+
+Note that the type of user is set when the account is first created: if you create a user in Metabase, but that person then logs in via Google or some other form of SSO, the latter's icon will _not_ show up next to their name.
 
 ### Resetting someone’s password
 

--- a/docs/administration-guide/04-managing-users.md
+++ b/docs/administration-guide/04-managing-users.md
@@ -26,15 +26,13 @@ To reactivate a deactivated account, click the **Deactivated** radio button at t
 
 ### Deleting an account
 
-Metabase does not support account deletion. 
-
-The deactivation process protects the user’s activity (questions, dashboards, and collections) from disappearing when you want to revoke an account's access.
+Metabase doesn't explicitly support account deletion. Instead, Metabase deactivates accounts so people can't log in to them, while it preserves any questions, models, dashboards, and other items created by those accounts.
 
 If you want to delete an account because the account information was set up incorrectly, you can [deactivate](#deactivating-an-account) the old account and create a new one instead.
 
-1. Change the user name and email of the old account.
+1. Change the name and email associated with the old account.
 2. Deactivate the old account.
-3. Create a new account with the correct user information.
+3. Create a new account with the person's correct information.
 
 ### Editing an account
 
@@ -56,16 +54,16 @@ To reset a password for someone, just click the three dots icon next to their ac
 
 ### Resetting the admin password
 
-If you are using Metabase Cloud, contact support to have your admin password reset.
+If you're using Metabase Cloud, contact support to reset your Admin password.
 
-If you're the administrator of a Metabase instance and have access to the server console, but have forgotten the password for the admin account, you can get Metabase to send you a password reset token:
+If you're a Metabase admin and have access to the server console, you can get Metabase to send you a password reset token:
 
 1.  Stop the running Metabase application.
 2.  Restart Metabase with `reset-password email@example.com`, where "email@example.com" is the email associated with the admin account:
     ```
     java -jar metabase.jar reset-password email@example.com
     ```
-3.  This will print out a random token like this:
+3.  Metabase will print out a random token like this:
 
     ```
     ...

--- a/docs/administration-guide/04-managing-users.md
+++ b/docs/administration-guide/04-managing-users.md
@@ -28,23 +28,24 @@ To reactivate a deactivated account, click the **Deactivated** radio button at t
 
 Metabase doesn't explicitly support account deletion. Instead, Metabase deactivates accounts so people can't log in to them, while it preserves any questions, models, dashboards, and other items created by those accounts.
 
-If you want to delete an account because the account information was set up incorrectly, you can [deactivate](#deactivating-an-account) the old account and create a new one instead.
+If you want to delete an account because the account information was set up incorrectly, you can deactivate the old account and create a new one instead.
 
 1. Change the name and email associated with the old account.
-2. Deactivate the old account.
-3. Create a new account with the person's correct information.
+2. [Deactivate](#deactivating-an-account) the old account.
+3. [Create a new account](#creating-accounts-for-your-team) with the person's correct information.
 
 ### Editing an account
 
 You can edit someone's name and email address by clicking the three dots icon and choosing **Edit Details**. Note: be careful when changing someone's email address, because _this will change the address they’ll use to log in to Metabase_.
 
-### Checking an account's auth method
+### Checking someone's auth method
 
-- Search for a user and look for an icon beside their name. 
+Search for a person and look for an icon beside their name.
+
 - If they log in using Google credentials, Metabase displays a Google icon. 
 - If they log in using an email address and password stored in Metabase, no icon is shown. 
 
-Note that the type of user is set when the account is first created: if you create a user in Metabase, but that person then logs in via Google or some other form of SSO, the latter's icon will _not_ show up next to their name.
+Note that the type of user is set when the account is first created: if you create a user in Metabase, but that person then logs in via Google or some other form of [SSO](sso.md), the latter's icon will _not_ show up next to their name.
 
 ### Resetting someone’s password
 
@@ -54,7 +55,7 @@ To reset a password for someone, just click the three dots icon next to their ac
 
 ### Resetting the admin password
 
-If you're using Metabase Cloud, contact support to reset your Admin password.
+If you're using Metabase Cloud, [contact support](https://www.metabase.com/help-premium/) to reset your admin password.
 
 If you're a Metabase admin and have access to the server console, you can get Metabase to send you a password reset token:
 

--- a/docs/troubleshooting-guide/cant-log-in.md
+++ b/docs/troubleshooting-guide/cant-log-in.md
@@ -16,7 +16,7 @@
 ### I can't access the Metabase login page.
 
 - [Are you using the right URL for your Metabase?][incorrect-metabase-url]
-- [Has your Metabase account been deactivated?][deactivated-metabase-account]
+- [Ask your Metabase admin if your account has been deactivated][how-to-reactivate-account].
 
 #### Are you using the right URL for your Metabase?
 
@@ -24,15 +24,6 @@
    - If you're an administrator, you'll have configured this.
    - If you're not, please ask your admin.
 2. Check whether your Metabase instance has moved. For example, if you were using a trial instance of Metabase, but you're now in production, the URL might have changed.
-
-#### Has your Metabase account been deactivated?
-
-For obvious reasons, regular users can't reactivate deactivated accounts. If you're an administrator and you want to do this for someone else:
-
-1. Go to **Admin Panel** and select **People**.
-2. If no **Deactivated** tab is available, there are no deactivated accounts, so this isn't the problem.
-3. If there _is_ a **Deactivated** tab, look for the user who isn't able to log in.
-4. Click on the recycle loop arrow to reactivate the account.
 
 ## I can't log in to my Metabase Cloud account
 
@@ -46,55 +37,59 @@ Your Metabase store password is different from your Metabase Cloud admin passwor
 - [Troubleshooting SAML][troubleshooting-saml]
 - [SSO creates "unknown" users](https://github.com/metabase/metabase/issues/15484).
 
-If you are an administrator, you can go to **Admin Panel** and select **People**, then search for a user and look for an icon beside their name. If they log in using Google credentials, Metabase displays a Google icon. If they log in using an email address and password stored in Metababse, no icon is shown. Note that the type of user is set when the account is first created: if you create a user in Metabase, but that person then logs in via Google or some other form of SSO, the latter's icon will _not_ show up next to their name.
+### Further reading
 
-If you are an administrator and want to check SSO settings, go to **Admin Panel**, choose **Settings**, then select the **Authentication** tab. [This FAQ][auth] explains how to configure SSO for various providers.
+- [SSO documentation][sso-docs]
+- [How to look up a user's authentication method in Metabase][how-to-find-auth-method-for-an-account].
 
 ## I don't know how my logins are managed
 
 What do you use to log in?
 
-- An email address and password
+- **An email address and password.**
+
   You're using [Metabase][metabase-idp] or [LDAP][troubleshooting-ldap].
 
-- A button that launches a [pop-up dialog][sso-gloss].
+- **A button that launches a [pop-up dialog][sso-gloss].**
+
   You're using [SSO][troubleshooting-sso].
 
-- A site that doesn't have `.metabase.com` in the URL.
+- **A site that doesn't have `.metabase.com` in the URL.**
+
   You're using an embedded application. If a Metabase question or dashboard is embedded in another website or web application, that site or application determines who you are. It may pass on your identity to Metabase to control what data you are allowed to view---please see [our troubleshooting guide for sandboxing][sandboxing] if you are having trouble with this.
 
-- I'm signing in at `store.metabase.com` instead of `metabase.com`.
-  If you are using Metabase Cloud, the password for the Metabase store (where you pay for things) is not automatically the same as the password for your Metabase instance (where you log in to look at data).
+- **I'm signing in at `store.metabase.com` instead of `metabase.com`.**
 
-Metabase can manage accounts itself, or administrators can configure it to let people log in using credentials managed by some other service.
+  If you're using Metabase Cloud, the password for the Metabase store (where you pay for things) is not automatically the same as the password for your Metabase instance (where you log in to look at data).
 
 ### Further reading
 
-- [SSO][sso-docs]
-- [SAML-based authentication][saml-docs]
-- [LDAP][ldap-docs]
+- [SSO documentation][sso-docs]
+- [SAML documentation][saml-docs]
+- [LDAP documentation][ldap-docs]
 
 ## Are you still stuck?
 
 If you can’t solve your problem using the troubleshooting guides, search or ask the [Metabase community][discourse].
 
 
-[auth]: ../administration-guide/sso.html
 [deactivated-metabase-account]: #has-your-metabase-account-been-deactivated
 [how-to-delete-an-account]: ../administration-guide/04-managing-users.md#deleting-an-account
 [discourse]: https://discourse.metabase.com/
 [how-to-find-idp]: #i-dont-know-how-my-logins-are-managed
+[how-to-find-auth-method-for-an-account]: ../administration-guide/04-managing-users.html#checking-an-accounts-auth-method
+[how-to-reactivate-account]: ../administration-guide/04-managing-users.html#reactivating-an-account
 [how-to-reset-admin-password]: ../administration-guide/04-managing-users.html#resetting-the-admin-password
 [how-to-reset-password]: ../administration-guide/04-managing-users.html#resetting-someones-password
 [incorrect-metabase-url]: #are-you-using-the-right-url-for-your-metabase
-[ldap-docs]: /administration-guide/10-single-sign-on.html#enabling-ldap-authentication
+[ldap-docs]: ../administration-guide/10-single-sign-on.html#enabling-ldap-authentication
 [metabase-cloud-login]: #i-cant-log-in-to-my-metabase-cloud-account
 [metabase-idp]: #metabase
 [no-login-page]: #i-cant-access-the-metabase-login-page
 [reset-store-password]: https://store.metabase.com/forgot-password
 [saml-docs]: ../enterprise-guide/authenticating-with-saml.html
 [sandboxing]: ./sandboxing.html
-[sso-docs]: /administration-guide/sso.html
+[sso-docs]: ../administration-guide/sso.html
 [sso-gloss]: /glossary/sso.html
 [troubleshooting-ldap]: ./ldap.html
 [troubleshooting-saml]: ./saml.html

--- a/docs/troubleshooting-guide/cant-log-in.md
+++ b/docs/troubleshooting-guide/cant-log-in.md
@@ -1,13 +1,15 @@
 # People can't log in to Metabase
 
 ## Do you know how your logins are managed?
+
 - [Metabase][metabase-idp]
 - [SSO][troubleshooting-sso]
 - [LDAP][troubleshooting-ldap]
 - [I don't know how my logins are managed][how-to-find-idp].
 
-## Metabase
-- [I can't access the login page][no-login-page].
+## Troubleshooting Metabase logins
+
+- [I can't access the Metabase login page][no-login-page].
 - [I can't log in to my Metabase Cloud account][metabase-cloud-login].
 - [I forgot my password][how-to-reset-password].
 - [I forgot the admin password][how-to-reset-admin-password].
@@ -25,22 +27,31 @@
    - If you're not, please ask your admin.
 2. Check whether your Metabase instance has moved. For example, if you were using a trial instance of Metabase, but you're now in production, the URL might have changed.
 
-## I can't log in to my Metabase Cloud account
+### Further reading
 
-Your Metabase store password is different from your Metabase Cloud admin password.
+- [Configuration settings documentation][config-settings]
+
+## Troubleshooting Metabase Cloud logins
+
+If you're using [Metabase Cloud][pricing], note that your Metabase store password is different from your Metabase Cloud admin password.
 
 - [I forgot my Metabase store password][reset-store-password].
 - [I forgot my Metabase Cloud password][how-to-reset-admin-password].
+- If you're a Metabase Cloud customer, you can [contact support][help-premium].
 
-## SSO
+### Further reading
 
-- [Troubleshooting SAML][troubleshooting-saml]
-- [SSO creates "unknown" users](https://github.com/metabase/metabase/issues/15484).
+- [Metabase Cloud documentation][cloud-docs]
+
+## Troubleshooting SSO logins
+
+- [Troubleshooting SAML][troubleshooting-saml].
+- [SSO logins are creating "unknown" users](https://github.com/metabase/metabase/issues/15484).
 
 ### Further reading
 
 - [SSO documentation][sso-docs]
-- [How to look up a user's authentication method in Metabase][how-to-find-auth-method-for-an-account].
+- [Checking a person's auth method][how-to-find-auth-method-for-an-account]
 
 ## I don't know how my logins are managed
 
@@ -54,13 +65,15 @@ What do you use to log in?
 
   You're using [SSO][troubleshooting-sso].
 
-- **A site that doesn't have `.metabase.com` in the URL.**
+- **I'm signing in at a site that doesn't have `.metabase.com` in the URL.**
 
   You're using an embedded application. If a Metabase question or dashboard is embedded in another website or web application, that site or application determines who you are. It may pass on your identity to Metabase to control what data you are allowed to view---please see [our troubleshooting guide for sandboxing][sandboxing] if you are having trouble with this.
 
-- **I'm signing in at `store.metabase.com` instead of `metabase.com`.**
+- **I'm signing in at `store.metabase.com`.**
 
-  If you're using Metabase Cloud, the password for the Metabase store (where you pay for things) is not automatically the same as the password for your Metabase instance (where you log in to look at data).
+  If you're using [Metabase Cloud][pricing], the password for the Metabase store (where you pay for things) is not automatically the same as the password for your Metabase instance (where you log in to look at data).
+
+  If your password and URL are correct, go to [Troubleshooting Metabase Cloud logins][metabase-cloud-login].
 
 ### Further reading
 
@@ -72,20 +85,23 @@ What do you use to log in?
 
 If you can’t solve your problem using the troubleshooting guides, search or ask the [Metabase community][discourse].
 
-
+[cloud-docs]: /cloud/docs/
+[config-settings]: ../administration-guide/08-configuration-settings.html
 [deactivated-metabase-account]: #has-your-metabase-account-been-deactivated
-[how-to-delete-an-account]: ../administration-guide/04-managing-users.md#deleting-an-account
 [discourse]: https://discourse.metabase.com/
+[help-premium]: https://www.metabase.com/help-premium/
+[how-to-delete-an-account]: ../administration-guide/04-managing-users.html#deleting-an-account
 [how-to-find-idp]: #i-dont-know-how-my-logins-are-managed
-[how-to-find-auth-method-for-an-account]: ../administration-guide/04-managing-users.html#checking-an-accounts-auth-method
+[how-to-find-auth-method-for-an-account]: ../administration-guide/04-managing-users.html#checking-someones-auth-method
 [how-to-reactivate-account]: ../administration-guide/04-managing-users.html#reactivating-an-account
 [how-to-reset-admin-password]: ../administration-guide/04-managing-users.html#resetting-the-admin-password
 [how-to-reset-password]: ../administration-guide/04-managing-users.html#resetting-someones-password
 [incorrect-metabase-url]: #are-you-using-the-right-url-for-your-metabase
 [ldap-docs]: ../administration-guide/10-single-sign-on.html#enabling-ldap-authentication
-[metabase-cloud-login]: #i-cant-log-in-to-my-metabase-cloud-account
-[metabase-idp]: #metabase
+[metabase-cloud-login]: #troubleshooting-metabase-cloud-logins
+[metabase-idp]: #troubleshooting-metabase-logins
 [no-login-page]: #i-cant-access-the-metabase-login-page
+[pricing]: https://www.metabase.com/pricing/
 [reset-store-password]: https://store.metabase.com/forgot-password
 [saml-docs]: ../enterprise-guide/authenticating-with-saml.html
 [sandboxing]: ./sandboxing.html
@@ -93,4 +109,4 @@ If you can’t solve your problem using the troubleshooting guides, search or as
 [sso-gloss]: /glossary/sso.html
 [troubleshooting-ldap]: ./ldap.html
 [troubleshooting-saml]: ./saml.html
-[troubleshooting-sso]: #sso
+[troubleshooting-sso]: #troubleshooting-sso-logins

--- a/docs/troubleshooting-guide/cant-log-in.md
+++ b/docs/troubleshooting-guide/cant-log-in.md
@@ -11,7 +11,7 @@
 - [I can't log in to my Metabase Cloud account][metabase-cloud-login].
 - [I forgot my password][how-to-reset-password].
 - [I forgot the admin password][how-to-reset-admin-password].
-- [I want to delete an account that was set up with incorrect user information][how-to-delete-an-account].
+- [I want to delete an account that was set up incorrectly][how-to-delete-an-account].
 
 ### I can't access the Metabase login page.
 
@@ -20,16 +20,12 @@
 
 #### Are you using the right URL for your Metabase?
 
-**Steps**
-
 1. Check whether you need to include a port number as well as a hostname in the connection URL. For example, Metabase might be at `https://example.com:3000/` instead of `https://example.com/`.
    - If you're an administrator, you'll have configured this.
    - If you're not, please ask your admin.
 2. Check whether your Metabase instance has moved. For example, if you were using a trial instance of Metabase, but you're now in production, the URL might have changed.
 
 #### Has your Metabase account been deactivated?
-
-**Steps**
 
 For obvious reasons, regular users can't reactivate deactivated accounts. If you're an administrator and you want to do this for someone else:
 
@@ -48,36 +44,58 @@ Your Metabase store password is different from your Metabase Cloud admin passwor
 ## SSO
 
 - [Troubleshooting SAML][troubleshooting-saml]
-- [SSO creates "unknown" users][https://github.com/metabase/metabase/issues/15484].
-
-## I don't know how my logins are managed
-
-**Background** Metabase can manage accounts itself, or administrators can configure it to let people log in using credentials managed by some other service, such as Google, [SAML-based authentication][saml-docs], or [LDAP][ldap-docs]. Metabase questions and dashboards can also be embedded in other websites.
-
-**Scenarios**
-
-1. If Metabase is managing your account, or if your instance is using LDAP, you will typically log in directly using an email address and password.
-2. If some other service (like Google) is managing your credentials, you will typically see a single button that launches a pop-up dialog when you log in.
-3. If a Metabase question or dashboard is embedded in another website or web application, that site or application determines who you are. It may pass on your identity to Metabase to control what data you are allowed to view---please see [our troubleshooting guide for sandboxing][sandboxing] if you are having trouble with this.
-4. If you are using Metabase Cloud, the password for the Metabase store (where you pay for things) is not automatically the same as the password for your Metabase instance (where you log in to look at data).
+- [SSO creates "unknown" users](https://github.com/metabase/metabase/issues/15484).
 
 If you are an administrator, you can go to **Admin Panel** and select **People**, then search for a user and look for an icon beside their name. If they log in using Google credentials, Metabase displays a Google icon. If they log in using an email address and password stored in Metababse, no icon is shown. Note that the type of user is set when the account is first created: if you create a user in Metabase, but that person then logs in via Google or some other form of SSO, the latter's icon will _not_ show up next to their name.
 
 If you are an administrator and want to check SSO settings, go to **Admin Panel**, choose **Settings**, then select the **Authentication** tab. [This FAQ][auth] explains how to configure SSO for various providers.
 
+## I don't know how my logins are managed
+
+What do you use to log in?
+
+- An email address and password
+  You're using [Metabase][metabase-idp] or [LDAP][troubleshooting-ldap].
+
+- A button that launches a [pop-up dialog][sso-gloss].
+  You're using [SSO][troubleshooting-sso].
+
+- A site that doesn't have `.metabase.com` in the URL.
+  You're using an embedded application. If a Metabase question or dashboard is embedded in another website or web application, that site or application determines who you are. It may pass on your identity to Metabase to control what data you are allowed to view---please see [our troubleshooting guide for sandboxing][sandboxing] if you are having trouble with this.
+
+- I'm signing in at `store.metabase.com` instead of `metabase.com`.
+  If you are using Metabase Cloud, the password for the Metabase store (where you pay for things) is not automatically the same as the password for your Metabase instance (where you log in to look at data).
+
+Metabase can manage accounts itself, or administrators can configure it to let people log in using credentials managed by some other service.
+
+### Further reading
+
+- [SSO][sso-docs]
+- [SAML-based authentication][saml-docs]
+- [LDAP][ldap-docs]
+
+## Are you still stuck?
+
+If you can’t solve your problem using the troubleshooting guides, search or ask the [Metabase community][discourse].
+
 
 [auth]: ../administration-guide/sso.html
 [deactivated-metabase-account]: #has-your-metabase-account-been-deactivated
 [how-to-delete-an-account]: ../administration-guide/04-managing-users.md#deleting-an-account
+[discourse]: https://discourse.metabase.com/
 [how-to-find-idp]: #i-dont-know-how-my-logins-are-managed
 [how-to-reset-admin-password]: ../administration-guide/04-managing-users.html#resetting-the-admin-password
 [how-to-reset-password]: ../administration-guide/04-managing-users.html#resetting-someones-password
 [incorrect-metabase-url]: #are-you-using-the-right-url-for-your-metabase
 [ldap-docs]: /administration-guide/10-single-sign-on.html#enabling-ldap-authentication
+[metabase-cloud-login]: #i-cant-log-in-to-my-metabase-cloud-account
 [metabase-idp]: #metabase
+[no-login-page]: #i-cant-access-the-metabase-login-page
 [reset-store-password]: https://store.metabase.com/forgot-password
 [saml-docs]: ../enterprise-guide/authenticating-with-saml.html
 [sandboxing]: ./sandboxing.html
+[sso-docs]: /administration-guide/sso.html
+[sso-gloss]: /glossary/sso.html
 [troubleshooting-ldap]: ./ldap.html
 [troubleshooting-saml]: ./saml.html
 [troubleshooting-sso]: #sso

--- a/docs/troubleshooting-guide/cant-log-in.md
+++ b/docs/troubleshooting-guide/cant-log-in.md
@@ -1,15 +1,60 @@
 # People can't log in to Metabase
 
-You should be able to log in to Metabase, but:
+## Do you know how your logins are managed?
+- [Metabase][metabase-idp]
+- [SSO][troubleshooting-sso]
+- [LDAP][troubleshooting-ldap]
+- [I don't know how my logins are managed][how-to-find-idp].
 
-- you can't see the login page, or
-- your credentials aren't accepted.
+## Metabase
+- [I can't access the login page][no-login-page].
+- [I can't log in to my Metabase Cloud account][metabase-cloud-login].
+- [I forgot my password][how-to-reset-password].
+- [I forgot the admin password][how-to-reset-admin-password].
+- [I want to delete an account that was set up with incorrect user information][how-to-delete-an-account].
 
-## Do you know who is managing your login?
+### I can't access the Metabase login page.
 
-**Background:** Metabase can manage accounts itself, or administrators can configure it to let people log in using credentials managed by some other service, such as Google, [SAML-based authentication][saml], or [LDAP][troubleshooting-ldap]. Metabase questions and dashboards can also be embedded in other websites.
+- [Are you using the right URL for your Metabase?][incorrect-metabase-url]
+- [Has your Metabase account been deactivated?][deactivated-metabase-account]
 
-**Scenarios:**
+#### Are you using the right URL for your Metabase?
+
+**Steps**
+
+1. Check whether you need to include a port number as well as a hostname in the connection URL. For example, Metabase might be at `https://example.com:3000/` instead of `https://example.com/`.
+   - If you're an administrator, you'll have configured this.
+   - If you're not, please ask your admin.
+2. Check whether your Metabase instance has moved. For example, if you were using a trial instance of Metabase, but you're now in production, the URL might have changed.
+
+#### Has your Metabase account been deactivated?
+
+**Steps**
+
+For obvious reasons, regular users can't reactivate deactivated accounts. If you're an administrator and you want to do this for someone else:
+
+1. Go to **Admin Panel** and select **People**.
+2. If no **Deactivated** tab is available, there are no deactivated accounts, so this isn't the problem.
+3. If there _is_ a **Deactivated** tab, look for the user who isn't able to log in.
+4. Click on the recycle loop arrow to reactivate the account.
+
+## I can't log in to my Metabase Cloud account
+
+Your Metabase store password is different from your Metabase Cloud admin password.
+
+- [I forgot my Metabase store password][reset-store-password].
+- [I forgot my Metabase Cloud password][how-to-reset-admin-password].
+
+## SSO
+
+- [Troubleshooting SAML][troubleshooting-saml]
+- [SSO creates "unknown" users][https://github.com/metabase/metabase/issues/15484].
+
+## I don't know how my logins are managed
+
+**Background** Metabase can manage accounts itself, or administrators can configure it to let people log in using credentials managed by some other service, such as Google, [SAML-based authentication][saml-docs], or [LDAP][ldap-docs]. Metabase questions and dashboards can also be embedded in other websites.
+
+**Scenarios**
 
 1. If Metabase is managing your account, or if your instance is using LDAP, you will typically log in directly using an email address and password.
 2. If some other service (like Google) is managing your credentials, you will typically see a single button that launches a pop-up dialog when you log in.
@@ -20,97 +65,19 @@ If you are an administrator, you can go to **Admin Panel** and select **People**
 
 If you are an administrator and want to check SSO settings, go to **Admin Panel**, choose **Settings**, then select the **Authentication** tab. [This FAQ][auth] explains how to configure SSO for various providers.
 
-## Do you need to reset your password?
 
-**Root cause:** You have forgotten your password.
-
-**Steps to take:**
-
-1. As noted above, if you are logging in via Single Sign-On, your password is managed by that service, not by Metabase, so you need to reset your password there.
-2. If you are an administrator and want to reset someone's passsword, go to **Admin Panel**, select **People**, click on the ellipsis "..." next to the person's account, and select `Reset Password`.
-3. If you are using the web app as a normal user:
-   1. Click the link in the lower-right of the login screen that reads, "I seem to have forgotten my password".
-   2. If your Metabase administrator has [set up email][setting-up-email] you will receive a password reset email.
-   3. If email has not been configured, you will need to contact a Metabase admin to perform a password reset.
-
-## If you are using Metabase Cloud, are you trying to use the correct password?
-
-**Root cause:** You are trying to log in to Metabase Cloud using the password you set for the Metabase store.
-
-**Steps to take:**
-
-1. Check which password you are using.
-2. If you cannot remember the Metababse Cloud admin password, please see the next entry.
-
-## Do you need to reset the admin password?
-
-**Root cause:** You have forgotten the overall admin password for a Metabase instance.
-
-**Steps to take:**
-
-If you are using Metabase Cloud, contact support to have your admin password reset.
-
-If you're the administrator of a Metabase instance and have access to the server console, but have forgotten the password for the admin account, you can get Metabase to send you a password reset token:
-
-1.  Stop the running Metabase application.
-2.  Restart Metabase with `reset-password email@example.com`, where "email@example.com" is the email associated with the admin account:
-    ```
-    java -jar metabase.jar reset-password email@example.com
-    ```
-3.  This will print out a random token like this:
-
-    ```
-    ...
-    Resetting password for email@example.com...
-
-    OK [[[1_7db2b600-d538-4aeb-b4f7-0cf5b1970d89]]]
-    ```
-
-4.  Start Metabase normally again (_without_ the `reset-password` option).
-5.  Navigate to it in your browser using the path `/auth/reset_password/:token`, where ":token" is the token that was generated from the step above. The full URL should look something like this:
-    ```
-    https://metabase.example.com/auth/reset_password/1_7db2b600-d538-4aeb-b4f7-0cf5b1970d89
-    ```
-6.  You should now see a page where you can input a new password for the admin account.
-
-## Are you using the right URL for your Metabase?
-
-**Root cause:** the Metabase instance you are trying to log in to isn't where you think it is or isn't accessible.
-
-**Steps to take:**
-
-1. Check whether you need to include a port number as well as a hostname in the connection URL. For example, Metabase might be at `https://example.com:3000/` instead of `https://example.com/`.
-   - If you're an administrator, you'll have configured this.
-   - If you're not, please ask your admin.
-2. Check whether your Metabase instance has moved. For example, if you were using a trial instance of Metabase, but you're now in production, the URL might have changed.
-
-## If Metabase is managing your password, has your account been deactivated?
-
-**Root cause:** Metabase doesn't delete accounts, but admins can deactivate them, and if your account is deactivated, you can't log in with it.
-
-**Steps to take:**
-
-For obvious reasons, regular users can't reactivate deactivated accounts. If you're an administrator and you want to do this for someone else:
-
-1. Go to **Admin Panel** and select **People**.
-2. If no **Deactivated** tab is available, there are no deactivated accounts, so this isn't the problem.
-3. If there _is_ a **Deactivated** tab, look for the user who isn't able to log in.
-4. Click on the recycle loop arrow to reactivate the account.
-
-## If you're logging in via LDAP, is LDAP configured correctly?
-
-**Root cause**: The LDAP connection is not configured correctly.
-
-**Steps to take:**
-
-1.  Go to the **Admin Panel** and choose **Authentication**.
-2.  Make sure that LDAP is enabled
-3.  Make sure Metabase has the correct host, port, and login credentials for your LDAP server. You can test this by logging into LDAP directly using some other application, such as [Apache Directory Studio][ads].
-
-[ads]: https://directory.apache.org/studio/
 [auth]: ../administration-guide/sso.html
-[reset-password]: ../faq/using-metabase/how-do-i-reset-my-password.html
-[saml]: ../enterprise-guide/authenticating-with-saml.html
+[deactivated-metabase-account]: #has-your-metabase-account-been-deactivated
+[how-to-delete-an-account]: ../administration-guide/04-managing-users.md#deleting-an-account
+[how-to-find-idp]: #i-dont-know-how-my-logins-are-managed
+[how-to-reset-admin-password]: ../administration-guide/04-managing-users.html#resetting-the-admin-password
+[how-to-reset-password]: ../administration-guide/04-managing-users.html#resetting-someones-password
+[incorrect-metabase-url]: #are-you-using-the-right-url-for-your-metabase
+[ldap-docs]: /administration-guide/10-single-sign-on.html#enabling-ldap-authentication
+[metabase-idp]: #metabase
+[reset-store-password]: https://store.metabase.com/forgot-password
+[saml-docs]: ../enterprise-guide/authenticating-with-saml.html
 [sandboxing]: ./sandboxing.html
-[setting-up-email]: ../administration-guide/02-setting-up-email.html
 [troubleshooting-ldap]: ./ldap.html
+[troubleshooting-saml]: ./saml.html
+[troubleshooting-sso]: #sso

--- a/docs/troubleshooting-guide/ldap.md
+++ b/docs/troubleshooting-guide/ldap.md
@@ -7,7 +7,7 @@
 - [Current limitations](#current-limitations)
 </div>
 
-Metabase can use LDAP for authentication. [This article][ldap-learn] explains how to set it up, and the guide below will help you troubleshoot if anything goes wrong. You may also want to check [our troubleshooting guide for logging in](./cant-log-in.md).
+Metabase can use LDAP for authentication. [This article][ldap-learn] explains how to set it up, and the guide below will help you troubleshoot if anything goes wrong. If your problem isn't specific to LDAP, go to [our troubleshooting guide for logging in](./cant-log-in.md).
 
 <h2 id="ldap-sample-configuration">LDAP sample configuration</h2>
 

--- a/docs/troubleshooting-guide/ldap.md
+++ b/docs/troubleshooting-guide/ldap.md
@@ -81,3 +81,7 @@ If you run into an issue, check that you can login to your LDAP directory and is
 [apache-directory-studio]: https://directory.apache.org/studio/
 [ldap-learn]: /learn/permissions/ldap-auth-access-control.html
 [ldap-docs]: ../administration-guide/10-single-sign-on.html#enabling-ldap-authentication
+
+## Are you still stuck?
+
+If you can’t solve your problem using the troubleshooting guides, search or ask the [Metabase community][discourse].

--- a/docs/troubleshooting-guide/ldap.md
+++ b/docs/troubleshooting-guide/ldap.md
@@ -1,6 +1,7 @@
 # LDAP
 
 <div class='doc-toc' markdown=1>
+- [LDAP documentation][ldap-docs]
 - [LDAP sample configuration](#ldap-sample-configuration)
 - [Related software for troubleshooting](#related-software-for-troubleshooting)
 - [Current limitations](#current-limitations)
@@ -79,3 +80,4 @@ If you run into an issue, check that you can login to your LDAP directory and is
 
 [apache-directory-studio]: https://directory.apache.org/studio/
 [ldap-learn]: /learn/permissions/ldap-auth-access-control.html
+[ldap-docs]: ../administration-guide/10-single-sign-on.html#enabling-ldap-authentication


### PR DESCRIPTION
Updates to "Managing users":
- Added "Deleting an account" section with a short how-to. 
- Deals with the case where someone needs to "delete" an account and replace it with updated / corrected user info.
- Ticket: https://metabase.zendesk.com/agent/tickets/9829
- Discussion: https://discourse.metabase.com/t/delete-user-from-metabase-db/13661/12

Updates to "Can't log in" troubleshooting guide:
- Moved sections around and added some structure to make it more "troubleshooty" (I have no better way to describe the goal here... 🥲)
- Removed sections:
  - Reset password (point to docs)
  - Reset Cloud password (point to docs)
  - Has your account been deactivated (point to docs)
  - LDAP (point to LDAP troubleshooting)
- Relocated to "Managing users" docs
  - How to reset admin password
  - How to look up an account's auth method
  
Update to LDAP troubleshooting:
- Added a link to LDAP documentation.