### PR TITLE
Remove abillity for users with DB detail perms to delete DBs

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -327,18 +327,9 @@
 
 (deftest delete-database-test
   (mt/with-temp Database [{db-id :id}]
-    (testing "A non-admin cannot delete a database if the advanced-permissions feature flag is not present"
+    (testing "A non-admin cannot delete a database even if they have DB details permissions"
       (with-all-users-data-perms {db-id {:details :yes}}
-        (premium-features-test/with-premium-features #{}
-          (mt/user-http-request :rasta :delete 403 (format "database/%d" db-id)))))
-
-    (testing "A non-admin cannot update database metadata if they do not have DB details permissions"
-      (with-all-users-data-perms {db-id {:details :no}}
-        (mt/user-http-request :rasta :delete 403 (format "database/%d" db-id))))
-
-    (testing "A non-admin can update database metadata if they have DB details permissions"
-      (with-all-users-data-perms {db-id {:details :yes}}
-        (mt/user-http-request :rasta :put 200 (format "database/%d" db-id) {:name "Database Test"})))))
+        (mt/user-http-request :rasta :delete 403 (format "database/%d" db-id))))))
 
 (deftest db-operations-test
   (mt/with-temp* [Database    [{db-id :id}     {:engine "h2", :details (:details (mt/db))}]

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -718,8 +718,8 @@
 (api/defendpoint DELETE "/:id"
   "Delete a `Database`."
   [id]
-  (let [db (api/write-check (Database id))]
-    (api/write-check db)
+  (api/check-superuser)
+  (let [db (Database id)]
     (db/delete! Database :id id)
     (events/publish-event! :database-delete db))
   api/generic-204-no-content)

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -719,7 +719,7 @@
   "Delete a `Database`."
   [id]
   (api/check-superuser)
-  (let [db (Database id)]
+  (api/let-404 [db (Database id)]
     (db/delete! Database :id id)
     (events/publish-event! :database-delete db))
   api/generic-204-no-content)

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -178,10 +178,14 @@
 
 (deftest delete-database-test
   (testing "DELETE /api/database/:id"
-    (testing "Check that we can delete a Database"
+    (testing "Check that a superuser can delete a Database"
       (mt/with-temp Database [db]
         (mt/user-http-request :crowberto :delete 204 (format "database/%d" (:id db)))
-        (is (false? (db/exists? Database :id (u/the-id db))))))))
+        (is (false? (db/exists? Database :id (u/the-id db))))))
+
+    (testing "Check that a non-superuser cannot delete a Database"
+      (mt/with-temp Database [db]
+        (mt/user-http-request :rasta :delete 403 (format "database/%d" (:id db)))))))
 
 (deftest update-database-test
   (testing "PUT /api/database/:id"


### PR DESCRIPTION
See https://metaboat.slack.com/archives/C010L1Z4F9S/p1651262695941719 for context.

The original product spec allowed users to delete DBs that they have write perms for. We've decided to revert this decision, so I'm changing the `DELETE /api/database/:id` endpoint to be restricted only to admins. No FE changes are necessary since the delete button is already hidden for these users.

Closes #22293