### PR TITLE
Allow SCOPE (for max/min) to work also on STRING

### DIFF
--- a/frontend/src/metabase/lib/schema_metadata.js
+++ b/frontend/src/metabase/lib/schema_metadata.js
@@ -74,7 +74,7 @@ const TYPES = {
     exclude: [ENTITY, LOCATION, TEMPORAL],
   },
   [SCOPE]: {
-    include: [NUMBER, TEMPORAL, CATEGORY, ENTITY],
+    include: [NUMBER, TEMPORAL, CATEGORY, ENTITY, STRING],
     exclude: [LOCATION],
   },
   [CATEGORY]: {

--- a/frontend/test/metabase/scenarios/question/reproductions/18207-string-min-max.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/18207-string-min-max.cy.spec.js
@@ -18,10 +18,11 @@ describe("issue 18207", () => {
     summarize({ mode: "notebook" });
   });
 
-  it("should be possible to use MIN on a string column (metabase#18207)", () => {
+  it("should be possible to use MIN on a string column (metabase#18207, metabase#22155)", () => {
     cy.contains("Minimum of").click();
     cy.findByText("Price");
     cy.findByText("Rating");
+    cy.findByText("Ean").should("be.visible");
     cy.contains("Category").click();
 
     visualize();
@@ -29,10 +30,11 @@ describe("issue 18207", () => {
     cy.findByText("Doohickey");
   });
 
-  it("should be possible to use MAX on a string column (metabase#18207)", () => {
+  it("should be possible to use MAX on a string column (metabase#18207, metabase#22155)", () => {
     cy.contains("Maximum of").click();
     cy.findByText("Price");
     cy.findByText("Rating");
+    cy.findByText("Ean").should("be.visible");
     cy.contains("Category").click();
 
     visualize();
@@ -40,10 +42,11 @@ describe("issue 18207", () => {
     cy.findByText("Widget");
   });
 
-  it("should be not possible to use AVERAGE on a string column (metabase#18207)", () => {
+  it("should be not possible to use AVERAGE on a string column (metabase#18207, metabase#22155)", () => {
     cy.contains("Average of").click();
     cy.findByText("Price");
     cy.findByText("Rating");
+    cy.findByText("Ean").should("not.exist");
     cy.findByText("Category").should("not.exist");
   });
 


### PR DESCRIPTION
Fixes #22155.

To reproduce:
1. New, SQL Query
2. Type `select * from PRODUCTS`, Run, Save it as "SQL Products"
3. Explore results, Show editor
4. Summarize, Maximum of ...

### Before this PR

Only ID, TITLE, VENDOR, PRICE, RATING, and CREATED_AT are selectable. Missing: EAN and CATEGORY.

![image](https://user-images.githubusercontent.com/7288/165614443-e0b8ca33-0434-432c-96ca-a9be3c4958de.png)

### After this PR

Maximum (and minimum) should also work for EAN and CATEGORY.

![image](https://user-images.githubusercontent.com/7288/166073369-1e0fc14b-df14-4116-b11f-b26449fd6f74.png)
