### PR TITLE
Complete the support for "All Time" in the time-series filter

### DIFF
--- a/frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx
+++ b/frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx
@@ -18,6 +18,7 @@ import _ from "underscore";
 
 export default class TimeseriesFilterWidget extends Component {
   state = {
+    dimension: null,
     filter: null,
     filterIndex: -1,
     currentFilter: null,
@@ -34,34 +35,34 @@ export default class TimeseriesFilterWidget extends Component {
       const filters = query.filters();
 
       const dimensions = breakouts.map(b => b.dimension());
-      const dimension = dimensions[0];
+      const firstDimension = dimensions[0];
 
-      const timeseriesDimension =
-        dimension instanceof FieldDimension
-          ? dimension.withoutTemporalBucketing()
-          : dimension;
+      const dimension =
+        firstDimension instanceof FieldDimension
+          ? firstDimension.withoutTemporalBucketing()
+          : firstDimension;
 
       const filterIndex = _.findIndex(
         filters,
         filter =>
           Filter.isFieldFilter(filter) &&
-          _.isEqual(filter[1], timeseriesDimension.mbql()),
+          _.isEqual(filter[1], dimension.mbql()),
       );
 
       let filter, currentFilter;
       if (filterIndex >= 0) {
         filter = currentFilter = filters[filterIndex];
       } else {
-        filter = ["time-interval", timeseriesDimension.mbql(), -30, "day"];
+        filter = null; // All time
       }
 
-      this.setState({ filter, filterIndex, currentFilter });
+      this.setState({ dimension, filter, filterIndex, currentFilter });
     }
   }
 
   render() {
     const { className, card, setDatasetQuery } = this.props;
-    const { filter, filterIndex, currentFilter } = this.state;
+    const { dimension, filter, filterIndex, currentFilter } = this.state;
     let currentDescription;
 
     if (currentFilter) {
@@ -94,7 +95,8 @@ export default class TimeseriesFilterWidget extends Component {
       >
         <DatePicker
           className="m2"
-          filter={this.state.filter}
+          dimension={dimension}
+          filter={filter}
           onFilterChange={newFilter => {
             this.setState({ filter: newFilter });
           }}

--- a/frontend/test/metabase/scenarios/question/reproductions/22247-timeseries-filter-all-time.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/22247-timeseries-filter-all-time.cy.spec.js
@@ -1,0 +1,106 @@
+import { restore, popover, openProductsTable } from "__support__/e2e/cypress";
+
+describe("time-series filter widget", () => {
+  beforeEach(() => {
+    cy.intercept("POST", "/api/dataset").as("dataset");
+
+    restore();
+    cy.signInAsAdmin();
+    openProductsTable();
+  });
+
+  it("should properly display All Time as the initial filtering (metabase#22247)", () => {
+    cy.findAllByText("Summarize")
+      .first()
+      .click();
+    cy.findAllByText("Created At")
+      .last()
+      .click();
+    cy.wait("@dataset");
+    cy.findByText("Done").click();
+
+    cy.findByText("All Time").click();
+    popover().within(() => {
+      cy.findByText("Previous").should("not.exist");
+      cy.findByText("Next").should("not.exist");
+
+      cy.findByTextEnsureVisible("All Time");
+      cy.findByTextEnsureVisible("Apply");
+    });
+  });
+
+  it("should allow switching from All Time filter", () => {
+    cy.findAllByText("Summarize")
+      .first()
+      .click();
+    cy.findAllByText("Created At")
+      .last()
+      .click();
+    cy.wait("@dataset");
+    cy.findByText("Done").click();
+
+    // switch to previous 30 quarters
+    cy.findByText("All Time").click();
+    popover().within(() => {
+      cy.findByText("All Time").click();
+    });
+    cy.get(".List-item")
+      .contains("Previous")
+      .click();
+    cy.findByTextEnsureVisible("days").click();
+    cy.get(".List-item")
+      .contains("quarters")
+      .click();
+    cy.button("Apply").click();
+    cy.wait("@dataset");
+
+    cy.findByTextEnsureVisible("Created At Previous 30 Quarters");
+    cy.findByTextEnsureVisible("Previous 30 Quarters");
+  });
+
+  it("should stay in-sync with the actual filter", () => {
+    cy.findAllByText("Filter")
+      .first()
+      .click();
+    cy.findAllByText("Created At")
+      .last()
+      .click();
+    cy.findByText("Last 3 Months").click();
+    cy.wait("@dataset");
+
+    cy.findByText("Created At Previous 3 Months").click();
+    cy.findByText("months").click();
+    cy.findByText("years").click();
+    cy.button("Add filter").click();
+    cy.wait("@dataset");
+
+    cy.findAllByText("Summarize")
+      .first()
+      .click();
+    cy.findAllByText("Created At")
+      .last()
+      .click();
+    cy.wait("@dataset");
+    cy.findByText("Done").click();
+
+    cy.findByTextEnsureVisible("Created At Previous 3 Years");
+
+    cy.findByText("Previous 3 Years").click();
+    popover().within(() => {
+      cy.findByText("Previous").should("be.visible");
+      cy.findByText("All Time").should("not.exist");
+      cy.findByText("Next").should("not.exist");
+    });
+
+    // switch to All Time filter
+    popover().within(() => {
+      cy.findByText("Previous").click();
+    });
+    cy.findByText("All Time").click();
+    cy.button("Apply").click();
+    cy.wait("@dataset");
+
+    cy.findByText("Created At Previous 3 Years").should("not.exist");
+    cy.findByTextEnsureVisible("All Time");
+  });
+});


### PR DESCRIPTION
Its corresponding date picker needs to understand the idea that a null filter is really "All Time" (i.e. apply no filter). Because the need to convert from null filter and that null filter does not carry any dimension information, we pass the dimension explicitly as another prop.

Fixes #22247.


To verify:
1. Browse Data, Sample Database, Products
2. Summarize, Created At
3. From the time-series on the footer, click on All Time

### Before

The popover incorrectly shows Previous even if the filter says All Time (and indeed there is no filtering at all).

![image](https://user-images.githubusercontent.com/7288/166134107-b0739135-caeb-4a15-aba3-1a3c619a4f33.png)

### After

The popover correctly shows All Time.

![image](https://user-images.githubusercontent.com/7288/166134093-07294cf8-9166-4cc7-ba7b-e038d4e01505.png)

and it's possible to apply time filtering by choosing a different filter:

![image](https://user-images.githubusercontent.com/7288/166134134-2ada0992-07ba-4fcc-9dcb-6bac37cf2cb9.png)

![image](https://user-images.githubusercontent.com/7288/166134141-1d23f294-57a7-407a-8783-c1e08964d922.png)
