### PR TITLE
Fix several bugs in relative datetime filters

### DIFF
--- a/frontend/src/metabase/lib/query_time.js
+++ b/frontend/src/metabase/lib/query_time.js
@@ -40,7 +40,18 @@ export function computeFilterTimeRange(filter) {
   const bucketing = parseFieldBucketing(field, "day");
 
   let start, end;
-  if (operator === "=" && values[0]) {
+  if (isStartingFrom(filter)) {
+    const [startingFrom, startingFromUnit] = getStartingFrom(filter);
+    const [value, unit] = getRelativeDatetimeInterval(filter);
+    const now = moment()
+      .startOf(unit)
+      .add(-startingFrom, startingFromUnit);
+    start = now.clone().add(value < 0 ? value : 0, unit);
+    end = now.clone().add(value < 0 ? 0 : value, unit);
+    if (["day", "week", "month", "quarter", "year"].indexOf(unit) > -1) {
+      end = end.add(-1, "day");
+    }
+  } else if (operator === "=" && values[0]) {
     const point = absolute(values[0]);
     start = point.clone().startOf(bucketing);
     end = point.clone().endOf(bucketing);
@@ -53,11 +64,6 @@ export function computeFilterTimeRange(filter) {
   } else if (operator === "between" && values[0] && values[1]) {
     start = absolute(values[0]).startOf(bucketing);
     end = absolute(values[1]).endOf(bucketing);
-  }
-  if (isStartingFrom(filter)) {
-    const [value, unit] = getStartingFrom(filter);
-    start = start.add(-value, unit);
-    end = end.add(-value, unit);
   }
 
   return [start, end];
@@ -273,6 +279,8 @@ export function parseFieldBucketing(field, defaultUnit = null) {
   const dimension = FieldDimension.parseMBQLOrWarn(field);
   if (dimension) {
     return dimension.temporalUnit() || defaultUnit;
+  } else if (field?.[0] === "+" && field?.[1]?.[0] === "field") {
+    return parseFieldBucketing(field[1], defaultUnit);
   }
   return defaultUnit;
 }
@@ -403,20 +411,16 @@ export function setStartingFrom(mbql, num, unit) {
   if (interval) {
     const [field, intervalNum, intervalUnit] = interval;
     const newUnit = unit || intervalUnit;
-    const expr = [
-      "+",
-      field,
-      ["interval", num ?? getDefaultDatetimeValue(newUnit), newUnit],
-    ];
-    const newInterval = ["relative-datetime", intervalNum, intervalUnit];
-    if (intervalNum === -1 || intervalNum === 1) {
-      return ["=", expr, newInterval];
-    } else {
-      const zeroed = ["relative-datetime", 0, intervalUnit];
-      const left = intervalNum < 0 ? newInterval : zeroed;
-      const right = intervalNum < 0 ? zeroed : newInterval;
-      return ["between", expr, left, right];
+    let newValue = num;
+    if (typeof newValue !== "number") {
+      newValue = (intervalNum < 0 ? 1 : -1) * getDefaultDatetimeValue(newUnit);
     }
+    const expr = ["+", field, ["interval", newValue, newUnit]];
+    const newInterval = ["relative-datetime", intervalNum, intervalUnit];
+    const zeroed = ["relative-datetime", 0, intervalUnit];
+    const left = intervalNum < 0 ? newInterval : zeroed;
+    const right = intervalNum < 0 ? zeroed : newInterval;
+    return ["between", expr, left, right];
   }
 
   return mbql;
@@ -502,10 +506,9 @@ export function updateRelativeDatetimeFilter(filter, positive) {
     const [value, unit] = getRelativeDatetimeInterval(filter);
     const absValue = Math.abs(value);
     const newValue = positive ? absValue : -absValue;
-    const newField = [fieldOp, field, [intervalOp, -intervalNum, intervalUnit]];
-    if (absValue === 1) {
-      return ["=", newField, ["relative-datetime", newValue, unit]];
-    }
+    const absInterval = Math.abs(intervalNum);
+    const newInterval = positive ? -absInterval : absInterval;
+    const newField = [fieldOp, field, [intervalOp, newInterval, intervalUnit]];
     const zeroed = ["relative-datetime", 0, unit];
     const interval = ["relative-datetime", newValue, unit];
     const left = newValue < 0 ? interval : zeroed;
@@ -519,9 +522,14 @@ export function setRelativeDatetimeUnit(filter, unit) {
   if (filter[0] === "time-interval") {
     return assoc(filter, 3, unit);
   }
-  if (isStartingFrom(filter)) {
+  const startingFrom = getStartingFrom(filter);
+  if (startingFrom) {
     const [op, field, start, end] = filter;
-    return [op, field, assoc(start, 2, unit), end ? assoc(end, 2, unit) : end];
+    return setStartingFrom(
+      [op, field, assoc(start, 2, unit), end ? assoc(end, 2, unit) : end],
+      startingFrom[0],
+      unit,
+    );
   }
   return filter;
 }
@@ -531,15 +539,13 @@ export function setRelativeDatetimeValue(filter, value) {
     return assoc(filter, 2, value);
   }
   if (isStartingFrom(filter)) {
-    const [_op, field, start, end] = filter;
-    if (value === 1 || value === -1) {
-      return ["=", field, assoc(start, 1, value)];
-    }
+    const [_op, field] = filter;
+    const [_num, unit] = getRelativeDatetimeInterval(filter);
     return [
       "between",
       field,
-      assoc(start, 1, value < 0 ? value : 0),
-      assoc(end, 1, value < 0 ? 0 : value),
+      ["relative-datetime", value < 0 ? value : 0, unit],
+      ["relative-datetime", value < 0 ? 0 : value, unit],
     ];
   }
   return filter;

--- a/frontend/src/metabase/lib/query_time.js
+++ b/frontend/src/metabase/lib/query_time.js
@@ -277,9 +277,10 @@ export function absolute(date) {
  */
 export function parseFieldBucketing(field, defaultUnit = null) {
   const dimension = FieldDimension.parseMBQLOrWarn(field);
+  const isStartingFromExpr = field?.[0] === "+" && field?.[1]?.[0] === "field";
   if (dimension) {
     return dimension.temporalUnit() || defaultUnit;
-  } else if (field?.[0] === "+" && field?.[1]?.[0] === "field") {
+  } else if (isStartingFromExpr) {
     return parseFieldBucketing(field[1], defaultUnit);
   }
   return defaultUnit;

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DateUnitSelector.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DateUnitSelector.tsx
@@ -14,6 +14,7 @@ type Props = {
   formatter: (value: any) => any;
   formatDisplayName?: (period: string, intervals: number) => string;
   periods: string[];
+  testId?: string;
 };
 
 const DateUnitSelector = ({
@@ -24,6 +25,7 @@ const DateUnitSelector = ({
   formatter,
   formatDisplayName = defaultDisplayName,
   periods,
+  testId,
 }: Props) => (
   <Select
     className={className}
@@ -31,6 +33,7 @@ const DateUnitSelector = ({
     onChange={(e: any) => onChange(e.target.value)}
     width={150}
     compact
+    buttonProps={testId ? { "data-testid": testId } : undefined}
   >
     {periods.map(period => (
       <Option value={period} key={period}>

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RelativeDatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RelativeDatePicker.tsx
@@ -206,7 +206,11 @@ const RelativeDatePicker: React.FC<Props> = props => {
     </OptionsContainer>
   );
   return (
-    <GridContainer className={className} numColumns={numColumns}>
+    <GridContainer
+      className={className}
+      numColumns={numColumns}
+      data-testid="relative-datetime-filter"
+    >
       {startingFrom ? (
         <GridText>{intervals < 0 ? t`Past` : t`Next`}</GridText>
       ) : null}
@@ -214,6 +218,7 @@ const RelativeDatePicker: React.FC<Props> = props => {
         className="input border-purple text-right"
         style={SELECT_STYLE}
         data-ui-tag="relative-date-input"
+        data-testid="relative-datetime-value"
         value={typeof intervals === "number" ? Math.abs(intervals) : intervals}
         onChange={(value: number) => {
           onFilterChange(setRelativeDatetimeValue(filter, formatter(value)));
@@ -225,6 +230,7 @@ const RelativeDatePicker: React.FC<Props> = props => {
         onChange={value => {
           onFilterChange(setRelativeDatetimeUnit(filter, value));
         }}
+        testId="relative-datetime-unit"
         intervals={intervals}
         formatter={formatter}
         periods={ALL_PERIODS}
@@ -251,6 +257,7 @@ const RelativeDatePicker: React.FC<Props> = props => {
             className="input border-purple text-right"
             style={SELECT_STYLE}
             data-ui-tag="relative-date-input"
+            data-testid="starting-from-value"
             value={
               typeof startingFrom[0] === "number"
                 ? Math.abs(startingFrom[0])
@@ -278,6 +285,7 @@ const RelativeDatePicker: React.FC<Props> = props => {
             intervals={Math.abs(startingFrom[0])}
             formatter={formatter}
             periods={ALL_PERIODS}
+            testId={"starting-from-unit"}
           />
           <MoreButton
             icon="close"

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RelativeDatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RelativeDatePicker.tsx
@@ -130,6 +130,7 @@ const CURRENT_INTERVAL_NAME = {
   week: t`this week`,
   month: t`this month`,
   year: t`this year`,
+  quarter: t`this quarter`,
   minute: t`this minute`,
   hour: t`this hour`,
 };

--- a/frontend/test/metabase/scenarios/filters/relative-datetime.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/relative-datetime.cy.spec.js
@@ -284,7 +284,8 @@ const setRelativeDatetimeValue = value => {
   cy.findAllByTestId("relative-datetime-value")
     .clear()
     .clear() // Included twice because it's buggy sometimes
-    .type(value);
+    .type(value)
+    .blur();
 };
 
 const setStartingFromUnit = unit => {
@@ -298,7 +299,8 @@ const setStartingFromValue = value => {
   cy.findAllByTestId("starting-from-value")
     .clear()
     .clear() // Included twice because it's buggy sometimes
-    .type(value);
+    .type(value)
+    .blur();
 };
 
 const withStartingFrom = (dir, [num, unit], [startNum, startUnit]) => {

--- a/frontend/test/metabase/scenarios/native-filters/helpers/e2e-date-filter-helpers.js
+++ b/frontend/test/metabase/scenarios/native-filters/helpers/e2e-date-filter-helpers.js
@@ -49,7 +49,7 @@ export function setAdHocFilter({
   }
 
   if (timeBucket) {
-    cy.findAllByTestId("select-button")
+    cy.findAllByTestId("relative-datetime-unit")
       .contains("days")
       .click();
 


### PR DESCRIPTION
**Changing the granularity of the `Past`/`Next` range picker now changes the granularity of the `Starting from` option**
  - Fixes #22222
  - Reproduces #22222 

---

**`Include this quarter` now displays correctly**
  - Fixes #22224 

---

**Now shows the correct date preview in `Past`/`Next` range picker**
  - Fixes #22225 
  - Reproduces #22225 

---

**Can now change `Past`/`Next` granularity when the value is set to `1`**
  - Fixes #22227
  - Reproduces #22227

---

**`Next` relative filter pill text now reads `from now` instead of `ago`**
  - Fixes #22228
  - Reproduces #22228