### PR TITLE
Fix data selector drops list of database schemas

### DIFF
--- a/frontend/src/metabase/selectors/metadata.js
+++ b/frontend/src/metabase/selectors/metadata.js
@@ -131,10 +131,6 @@ export const getMetadata = createSelector(
         // use the database schemas if they exist
         return database.schemas.map(s => meta.schema(s));
       }
-      if (database.tables.length > 0) {
-        // if the database has tables, use their schemas
-        return _.uniq(database.tables.map(t => t.schema));
-      }
       // otherwise use any loaded schemas that match the database id
       return Object.values(meta.schemas).filter(
         s => s.database && s.database.id === database.id,

--- a/frontend/src/metabase/selectors/metadata.js
+++ b/frontend/src/metabase/selectors/metadata.js
@@ -123,20 +123,15 @@ export const getMetadata = createSelector(
     hydrate(meta.tables, "db", t => meta.database(t.db_id || t.db));
     hydrate(meta.tables, "schema", t => meta.schema(t.schema));
 
-    // NOTE: special handling for schemas
-    // This is pretty hacky
-    // hydrateList(meta.databases, "schemas", meta.schemas);
     hydrate(meta.databases, "schemas", database => {
       if (database.schemas) {
-        // use the database schemas if they exist
         return database.schemas.map(s => meta.schema(s));
       }
-      // otherwise use any loaded schemas that match the database id
       return Object.values(meta.schemas).filter(
         s => s.database && s.database.id === database.id,
       );
     });
-    // hydrateList(meta.schemas, "tables", meta.tables);
+
     hydrate(meta.schemas, "tables", schema =>
       schema.tables
         ? // use the schema tables if they exist

--- a/frontend/src/metabase/selectors/metadata.js
+++ b/frontend/src/metabase/selectors/metadata.js
@@ -126,18 +126,20 @@ export const getMetadata = createSelector(
     // NOTE: special handling for schemas
     // This is pretty hacky
     // hydrateList(meta.databases, "schemas", meta.schemas);
-    hydrate(meta.databases, "schemas", database =>
-      database.schemas
-        ? // use the database schemas if they exist
-          database.schemas.map(s => meta.schema(s))
-        : database.tables.length > 0
-        ? // if the database has tables, use their schemas
-          _.uniq(database.tables.map(t => t.schema))
-        : // otherwise use any loaded schemas that match the database id
-          Object.values(meta.schemas).filter(
-            s => s.database && s.database.id === database.id,
-          ),
-    );
+    hydrate(meta.databases, "schemas", database => {
+      if (database.schemas) {
+        // use the database schemas if they exist
+        return database.schemas.map(s => meta.schema(s));
+      }
+      if (database.tables.length > 0) {
+        // if the database has tables, use their schemas
+        return _.uniq(database.tables.map(t => t.schema));
+      }
+      // otherwise use any loaded schemas that match the database id
+      return Object.values(meta.schemas).filter(
+        s => s.database && s.database.id === database.id,
+      );
+    });
     // hydrateList(meta.schemas, "tables", meta.tables);
     hydrate(meta.schemas, "tables", schema =>
       schema.tables

--- a/frontend/test/metabase/scenarios/question/reproductions/22285-schema-picker.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/22285-schema-picker.cy.spec.js
@@ -1,0 +1,33 @@
+import { restore, startNewQuestion, popover } from "__support__/e2e/cypress";
+
+describe("issue 22285", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    cy.intercept("GET", "/api/database").as("fetchDatabases");
+
+    cy.intercept("GET", "/api/database/*/schemas", {
+      body: ["PUBLIC", "FAKE SCHEMA"],
+    });
+  });
+
+  it("should not (metabase#22285)", () => {
+    startNewQuestion();
+    cy.wait("@fetchDatabases");
+
+    popover().within(() => {
+      cy.findByText("Sample Database").click();
+
+      cy.findByText(/Fake Schema/i);
+      cy.findByText(/Public/i).click();
+      cy.findByText("Orders");
+
+      // go back to database picker
+      cy.icon("chevronleft").click();
+
+      cy.findByText(/Fake Schema/i);
+      cy.findByText(/Public/i);
+    });
+  });
+});

--- a/frontend/test/metabase/scenarios/question/reproductions/22285-schema-picker.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/22285-schema-picker.cy.spec.js
@@ -12,7 +12,7 @@ describe("issue 22285", () => {
     });
   });
 
-  it("should not (metabase#22285)", () => {
+  it("should not clean DB schemas list in the data selector (metabase#22285)", () => {
     startNewQuestion();
     cy.wait("@fetchDatabases");
 


### PR DESCRIPTION
Reproduces #22285, fixes #22285

The regression was caused by FE metadata hydration change in #21571. It changed how DB tables are hydrated, but it also had a side effect on DB schemas migration. Metabase used to hydrate schemas in three ways:

1. If the `database` instance already has `schemas` property, it would just ensure the list is up to date and use it as a source of truth.
2. If the `database` instance doesn't have `schemas`, but has `tables`, it would hydrate DB schemas out of table schemas
3. If both `schemas` and `tables` are missing, it would just use the global list of schemas

Before #21571 there was a case when DB's `tables` list would reset, so schemas hydration will jump to step 3 when hydrating schemas. After the PR, once a user picks a schema in the data selector, the FE loads a list of tables from that schema. As a result, FE always jumps to step 2 when hydrating schemas and it always resolves in just one schema since FE loaded tables only for it.

Fixed by completely removing step 2 (hydrating schemas from DB `tables`). I'm not sure why exactly we have these steps at all and why can't we just use step 3 all the time as it seems more robust. Not doing that though as it seems to risky at the moment.

### To Verify

1. Connect a DB with a few schemas to Metabase
5. New > Question
6. Pick your database, select one of the schemas
7. Without choosing a table, click the "back" icon at the top of the data selector
8. Click your database again
9. Ensure you can see a list of DB schemas

### Demo

**Before**

https://user-images.githubusercontent.com/17258145/166237861-e5154e70-0104-4a72-ad88-59463b8cd2c6.mp4

**After**

https://user-images.githubusercontent.com/17258145/166237871-3dcc4c97-b3c9-47ab-aa33-75c3f2e6bae8.mp4


