### PR TITLE
Backport: Don't hard-code timeout in Druid driver

### DIFF
--- a/modules/drivers/druid/src/metabase/driver/druid/query_processor.clj
+++ b/modules/drivers/druid/src/metabase/driver/druid/query_processor.clj
@@ -136,8 +136,7 @@
   (merge
    {:intervals   ["1900-01-01/2100-01-01"]
     :granularity :all
-    :context     {:timeout 60000
-                  :queryId (random-query-id)}}
+    :context     {:queryId (random-query-id)}}
    (case query-type
      ::scan               {:queryType :scan
                            :limit     i/absolute-max-results}

--- a/modules/drivers/druid/test/metabase/driver/druid/query_processor_test.clj
+++ b/modules/drivers/druid/test/metabase/driver/druid/query_processor_test.clj
@@ -106,7 +106,7 @@
                             :granularity      :all
                             :dataSource       "checkins"
                             :dimension        "venue_price"
-                            :context          {:timeout 60000, :queryId "<Query ID>"}
+                            :context          {:queryId "<Query ID>"}
                             :postAggregations [{:type   :arithmetic
                                                 :name   "expression"
                                                 :fn     :*
@@ -135,7 +135,7 @@
                             :granularity  :all
                             :dataSource   "checkins"
                             :dimension    "venue_category_name"
-                            :context      {:timeout 60000, :queryId "<Query ID>"}
+                            :context      {:queryId "<Query ID>"}
                             :intervals    ["1900-01-01/2100-01-01"]
                             :metric       "__count_0"
                             :aggregations [{:type       :cardinality
@@ -159,7 +159,7 @@
                             :granularity  :all
                             :dataSource   "checkins"
                             :dimensions   ["venue_category_name", "user_name"]
-                            :context      {:timeout 60000, :queryId "<Query ID>"}
+                            :context      {:queryId "<Query ID>"}
                             :intervals    ["1900-01-01/2100-01-01"]
                             :aggregations [{:type       :cardinality
                                             :name       "__count_0"
@@ -186,7 +186,7 @@
                             :granularity  :all
                             :dataSource   "checkins"
                             :dimensions   ["venue_category_name", "user_name"]
-                            :context      {:timeout 60000, :queryId "<Query ID>"}
+                            :context      {:queryId "<Query ID>"}
                             :intervals    ["1900-01-01/2100-01-01"]
                             :aggregations [{:type       :cardinality
                                             :name       "__count_0"
@@ -214,7 +214,7 @@
                 :query       {:queryType        :timeseries
                               :granularity      :all
                               :dataSource       "checkins"
-                              :context          {:timeout 60000, :queryId "<Query ID>"}
+                              :context          {:queryId "<Query ID>"}
                               :intervals        ["1900-01-01/2100-01-01"]
                               :aggregations     [{:type       :cardinality
                                                   :name       "__distinct_0"


### PR DESCRIPTION
It should come from the context, like all the other drivers.

Manual backport of #22161 in 43. Issue #18078

