### PR TITLE
Add docstrings to persistence `jobs/defjob` macros

### DIFF
--- a/src/metabase/task/persist_refresh.clj
+++ b/src/metabase/task/persist_refresh.clj
@@ -164,12 +164,14 @@
   [_job-context]
   (prune-all-deletable! dispatching-refresher))
 
-(jobs/defjob ^{org.quartz.DisallowConcurrentExecution true} PersistenceRefresh
-  [job-context]
+(jobs/defjob ^{org.quartz.DisallowConcurrentExecution true
+               :doc "Refresh persisted tables job"}
+  PersistenceRefresh [job-context]
   (refresh-job-fn! job-context))
 
-(jobs/defjob ^{org.quartz.DisallowConcurrentExecution true} PersistencePrune
-  [job-context]
+(jobs/defjob ^{org.quartz.DisallowConcurrentExecution true
+               :doc "Remove deletable persisted tables"}
+  PersistencePrune [job-context]
   (prune-job-fn! job-context))
 
 (def ^:private refresh-job-key


### PR DESCRIPTION
fixup docstrings against new clj-kondo linter.