### PR TITLE
Do not render "Add your own data" button if user does not have permissions to create database

### DIFF
--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer.tsx
@@ -20,12 +20,12 @@ import Collections, {
 } from "metabase/entities/collections";
 import { openNavbar, closeNavbar } from "metabase/redux/app";
 import { logout } from "metabase/auth/actions";
-import { canAccessAdmin } from "metabase/admin/app/selectors";
+import { getUserIsAdmin, getUser } from "metabase/selectors/user";
 import {
   getHasOwnDatabase,
   getHasDataAccess,
 } from "metabase/new_query/selectors";
-import { getUser } from "metabase/selectors/user";
+
 import {
   nonPersonalOrArchivedCollection,
   currentUserPersonalCollections,
@@ -48,7 +48,7 @@ type NavbarModal = "MODAL_NEW_COLLECTION" | null;
 function mapStateToProps(state: State) {
   return {
     currentUser: getUser(state),
-    canAccessAdmin: canAccessAdmin(state),
+    isAdmin: getUserIsAdmin(state),
     hasDataAccess: getHasDataAccess(state),
     hasOwnDatabase: getHasOwnDatabase(state),
     bookmarks: getOrderedBookmarks(state),
@@ -70,7 +70,7 @@ interface CollectionTreeItem extends Collection {
 
 type Props = {
   isOpen: boolean;
-  canAccessAdmin: boolean;
+  isAdmin: boolean;
   currentUser: User;
   bookmarks: BookmarksType;
   collections: Collection[];
@@ -93,7 +93,7 @@ type Props = {
 
 function MainNavbarContainer({
   bookmarks,
-  canAccessAdmin,
+  isAdmin,
   isOpen,
   currentUser,
   hasOwnDatabase,
@@ -215,7 +215,7 @@ function MainNavbarContainer({
             <MainNavbarView
               {...props}
               bookmarks={bookmarks}
-              canAccessAdmin={canAccessAdmin}
+              isAdmin={isAdmin}
               isOpen={isOpen}
               currentUser={currentUser}
               collections={collectionTree}

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer.tsx
@@ -20,6 +20,7 @@ import Collections, {
 } from "metabase/entities/collections";
 import { openNavbar, closeNavbar } from "metabase/redux/app";
 import { logout } from "metabase/auth/actions";
+import { canAccessAdmin } from "metabase/admin/app/selectors";
 import {
   getHasOwnDatabase,
   getHasDataAccess,
@@ -47,6 +48,7 @@ type NavbarModal = "MODAL_NEW_COLLECTION" | null;
 function mapStateToProps(state: State) {
   return {
     currentUser: getUser(state),
+    canAccessAdmin: canAccessAdmin(state),
     hasDataAccess: getHasDataAccess(state),
     hasOwnDatabase: getHasOwnDatabase(state),
     bookmarks: getOrderedBookmarks(state),
@@ -68,6 +70,7 @@ interface CollectionTreeItem extends Collection {
 
 type Props = {
   isOpen: boolean;
+  canAccessAdmin: boolean;
   currentUser: User;
   bookmarks: BookmarksType;
   collections: Collection[];
@@ -90,6 +93,7 @@ type Props = {
 
 function MainNavbarContainer({
   bookmarks,
+  canAccessAdmin,
   isOpen,
   currentUser,
   hasOwnDatabase,
@@ -211,6 +215,7 @@ function MainNavbarContainer({
             <MainNavbarView
               {...props}
               bookmarks={bookmarks}
+              canAccessAdmin={canAccessAdmin}
               isOpen={isOpen}
               currentUser={currentUser}
               collections={collectionTree}

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarView.tsx
@@ -40,7 +40,7 @@ interface CollectionTreeItem extends Collection {
 }
 
 type Props = {
-  canAccessAdmin: boolean;
+  isAdmin: boolean;
   isOpen: boolean;
   currentUser: User;
   bookmarks: BookmarksType;
@@ -66,7 +66,7 @@ const ARCHIVE_URL = "/archive";
 const ADD_YOUR_OWN_DATA_URL = "/admin/databases/create";
 
 function MainNavbarView({
-  canAccessAdmin,
+  isAdmin,
   isOpen,
   currentUser,
   bookmarks,
@@ -149,7 +149,7 @@ function MainNavbarView({
               >
                 {t`Browse data`}
               </BrowseLink>
-              {!hasOwnDatabase && canAccessAdmin && (
+              {!hasOwnDatabase && isAdmin && (
                 <AddYourOwnDataLink
                   icon="add"
                   url={ADD_YOUR_OWN_DATA_URL}

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarView.tsx
@@ -40,6 +40,7 @@ interface CollectionTreeItem extends Collection {
 }
 
 type Props = {
+  canAccessAdmin: boolean;
   isOpen: boolean;
   currentUser: User;
   bookmarks: BookmarksType;
@@ -65,6 +66,7 @@ const ARCHIVE_URL = "/archive";
 const ADD_YOUR_OWN_DATA_URL = "/admin/databases/create";
 
 function MainNavbarView({
+  canAccessAdmin,
   isOpen,
   currentUser,
   bookmarks,
@@ -147,7 +149,7 @@ function MainNavbarView({
               >
                 {t`Browse data`}
               </BrowseLink>
-              {!hasOwnDatabase && (
+              {!hasOwnDatabase && canAccessAdmin && (
                 <AddYourOwnDataLink
                   icon="add"
                   url={ADD_YOUR_OWN_DATA_URL}


### PR DESCRIPTION
Fixes #21766

### How to test

#### For users with permissions

1. With an admin user, you should continue to see the button at the bottom of the sidebar

<img width="500" alt="image" src="https://user-images.githubusercontent.com/380816/166292273-a4700bd0-7ed8-4426-a4e9-ac97445571b9.png">

#### For users without permissions

1. Add a user without admin permissions
2. Log in with newly created user

You should not see the button.

<img width="500" alt="image" src="https://user-images.githubusercontent.com/380816/166292458-dbd95514-5d34-4ff4-a7c0-333c21893ff8.png">
