### PR TITLE
Revert "Fix changing column order/visibility via sidebar is inconsistent"

### DIFF
--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -330,7 +330,6 @@ export function normalizeQuery(query, tableMetadata) {
     return query;
   }
   if (query.query) {
-    // sort query.fields
     if (tableMetadata) {
       query = updateIn(query, ["query", "fields"], fields => {
         fields = fields
@@ -342,23 +341,6 @@ export function normalizeQuery(query, tableMetadata) {
           JSON.stringify(b).localeCompare(JSON.stringify(a)),
         );
       });
-    }
-
-    // sort query.joins[int].fields
-    if (query.query.joins) {
-      query = updateIn(query, ["query", "joins"], joins =>
-        joins.map(joinedTable => {
-          if (!joinedTable.fields || joinedTable.fields === "all") {
-            return joinedTable;
-          }
-
-          const joinedTableFields = [...joinedTable.fields];
-          joinedTableFields.sort((a, b) =>
-            JSON.stringify(b).localeCompare(JSON.stringify(a)),
-          );
-          return { ...joinedTable, fields: joinedTableFields };
-        }),
-      );
     }
     ["aggregation", "breakout", "filter", "joins", "order-by"].forEach(
       clauseList => {

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx
@@ -59,11 +59,9 @@ export default class ChartSettingOrderedColumns extends Component {
   };
 
   handleSortEnd = ({ oldIndex, newIndex }) => {
-    const enabledColumns = [...this.props.value].filter(columnSetting =>
-      findColumnForColumnSetting(this.props.columns, columnSetting),
-    );
-    enabledColumns.splice(newIndex, 0, enabledColumns.splice(oldIndex, 1)[0]);
-    this.props.onChange(enabledColumns);
+    const fields = [...this.props.value];
+    fields.splice(newIndex, 0, fields.splice(oldIndex, 1)[0]);
+    this.props.onChange(fields);
   };
 
   handleEdit = columnSetting => {

--- a/frontend/src/metabase/visualizations/visualizations/Table.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Table.jsx
@@ -173,9 +173,7 @@ export default class Table extends Component {
         // otherwise it will be overwritten by `getDefault` below
         card.visualization_settings["table.columns"].length !== 0 &&
         _.all(
-          card.visualization_settings["table.columns"].filter(
-            columnSetting => columnSetting.enabled,
-          ),
+          card.visualization_settings["table.columns"],
           columnSetting =>
             findColumnIndexForColumnSetting(data.cols, columnSetting) >= 0,
         ),

--- a/frontend/test/metabase/scenarios/question/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/settings.cy.spec.js
@@ -72,7 +72,7 @@ describe("scenarios > question > settings", () => {
         .should("not.exist");
     });
 
-    it("should preserve correct order of columns after column removal or addition via sidebar (metabase#13455)", () => {
+    it.skip("should preserve correct order of columns after column removal via sidebar (metabase#13455)", () => {
       cy.viewport(2000, 1200);
       // Orders join Products
       visitQuestionAdhoc({
@@ -173,10 +173,6 @@ describe("scenarios > question > settings", () => {
         cy.icon("play")
           .last()
           .click();
-
-        // Prevent performing actions while the query is being executed.
-        // Which caused some race condition and failed the test.
-        cy.wait("@dataset");
       }
 
       function findColumnAtIndex(column_name, index) {


### PR DESCRIPTION
This reverts commit 605a726ad05af4865d0971f52ea066644c747801 
PR: https://github.com/metabase/metabase/pull/21338
Reopens: https://github.com/metabase/metabase/issues/13455

Reverting because it caused two P1 regressions and this area of code is fragile and produced multiple regressions in the past. It would not be reasonable to rush with fixes for both of these right before the release becasue the risk of making other regressions is high.

Closes https://github.com/metabase/metabase/issues/22201
Closes https://github.com/metabase/metabase/issues/22206


