### PR TITLE
Fix Trend card text alignment in 3-square wide cards in narrow viewports

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx
@@ -135,7 +135,9 @@ export default class Smart extends React.Component {
         {formatNumber(Math.abs(lastChange), { number_style: "percent" })}
       </span>
     );
-    const separator = <PreviousValueSeparator>•</PreviousValueSeparator>;
+    const separator = (
+      <PreviousValueSeparator gridSize={gridSize}>•</PreviousValueSeparator>
+    );
     const granularityDisplay = (
       <span style={{ marginLeft: 5 }}>{jt`last ${granularity}`}</span>
     );
@@ -201,7 +203,7 @@ export default class Smart extends React.Component {
           ) : lastChange === 0 ? (
             t`No change from last ${granularity}`
           ) : (
-            <PreviousValueContainer>
+            <PreviousValueContainer gridSize={gridSize}>
               <Variation color={changeColor}>
                 <Icon
                   size={13}

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar.styled.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar.styled.jsx
@@ -1,7 +1,12 @@
 import styled from "@emotion/styled";
+import { css } from "@emotion/react";
 
 import { color } from "metabase/lib/colors";
-import { breakpointMaxSmall, space } from "metabase/styled-components/theme";
+import {
+  breakpointMaxSmall,
+  breakpointMaxLarge,
+  space,
+} from "metabase/styled-components/theme";
 
 export const Variation = styled.div`
   color: ${props => props.color};
@@ -17,10 +22,19 @@ export const PreviousValueContainer = styled.div`
   align-items: center;
   display: flex;
   flex-wrap: wrap;
+  justify-content: center;
   margin-top: ${space(0)};
 
   ${breakpointMaxSmall} {
     flex-direction: column;
+  }
+
+  ${breakpointMaxLarge} {
+    ${props =>
+      props.gridSize?.width <= 3 &&
+      css`
+        flex-direction: column;
+      `}
   }
 `;
 
@@ -41,5 +55,13 @@ export const PreviousValueSeparator = styled.span`
 
   ${breakpointMaxSmall} {
     display: none;
+  }
+
+  ${breakpointMaxLarge} {
+    ${props =>
+      props.gridSize?.width <= 3 &&
+      css`
+        display: none;
+      `}
   }
 `;


### PR DESCRIPTION
### How to Test

Fixes #16797

1. Create a [Trend](https://www.metabase.com/docs/latest/users-guide/05-visualizing-results.html#trends) question.
2. Add it as a card to a dashboard.
3. Make this card 3 squares wide. 

#### After

<img width="500" alt="image" src="https://user-images.githubusercontent.com/380816/166302575-bada4356-79d2-496e-8ebc-58299f55d96f.png">

#### Before

<img width="500" alt="image" src="https://user-images.githubusercontent.com/380816/166302697-50a076b5-74e3-4d06-9e30-730100f49d11.png">
