### PR TITLE
Add nowrap to Cloud CTA link

### DIFF
--- a/frontend/src/metabase/admin/settings/components/widgets/HostingInfoLink.jsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/HostingInfoLink.jsx
@@ -4,7 +4,7 @@ import ExternalLink from "metabase/core/components/ExternalLink";
 
 const HostingInfoLink = ({ text }) => (
   <ExternalLink
-    className="bordered rounded border-brand bg-brand-hover text-white-hover px2 py1 text-bold text-center"
+    className="bordered rounded border-brand bg-brand-hover text-white-hover px2 py1 text-bold text-center text-nowrap"
     href={
       "https://www.metabase.com/migrate/from/selfhosted?utm_source=admin-panel&utm_medium=in-app"
     }


### PR DESCRIPTION
Fixes #16176 

### How to Test

1. Go to http://localhost:3000/admin/settings/email
2. Make window narrow

`Learn more` button on the right should no longer break into two lines.