### PR TITLE
Add warnings when all users group has higher access level

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/application_permissions/selectors.ts
+++ b/enterprise/frontend/src/metabase-enterprise/application_permissions/selectors.ts
@@ -4,14 +4,31 @@ import { createSelector } from "reselect";
 import { Group } from "metabase-types/api";
 import { isAdminGroup } from "metabase/lib/groups";
 import { UNABLE_TO_CHANGE_ADMIN_PERMISSIONS } from "metabase/admin/permissions/constants/messages";
-import { getOrderedGroups } from "metabase/admin/permissions/selectors/data-permissions/groups";
+import {
+  getAdminGroup,
+  getOrderedGroups,
+} from "metabase/admin/permissions/selectors/data-permissions/groups";
 import { APPLICATION_PERMISSIONS_OPTIONS } from "./constants";
 import { getIn } from "icepick";
 import { ApplicationPermissionsState } from "./types/state";
 import {
   ApplicationPermissionKey,
   ApplicationPermissions,
+  ApplicationPermissionValue,
 } from "./types/permissions";
+import { getDefaultGroupHasHigherAccessText } from "metabase/admin/permissions/selectors/confirmations";
+
+export function getPermissionWarning(
+  value: ApplicationPermissionValue,
+  defaultGroupValue: ApplicationPermissionValue,
+  defaultGroup: Group,
+) {
+  if (defaultGroupValue === "yes" && value === "no") {
+    return getDefaultGroupHasHigherAccessText(defaultGroup);
+  }
+
+  return null;
+}
 
 export const canManageSubscriptions = (state: ApplicationPermissionsState) =>
   state.currentUser.permissions?.can_access_subscription ?? false;
@@ -35,24 +52,38 @@ const getPermission = (
   permissions: ApplicationPermissions,
   isAdmin: boolean,
   groupId: number,
+  defaultGroup: Group,
   permissionKey: ApplicationPermissionKey,
-) => ({
-  permission: permissionKey,
-  isDisabled: isAdmin,
-  disabledTooltip: isAdmin ? UNABLE_TO_CHANGE_ADMIN_PERMISSIONS : null,
-  value: getApplicationPermission(permissions, groupId, permissionKey),
-  options: [
-    APPLICATION_PERMISSIONS_OPTIONS.yes,
-    APPLICATION_PERMISSIONS_OPTIONS.no,
-  ],
-});
+) => {
+  const value = getApplicationPermission(permissions, groupId, permissionKey);
+  const defaultGroupValue = getApplicationPermission(
+    permissions,
+    defaultGroup.id,
+    permissionKey,
+  );
+
+  const warning = getPermissionWarning(value, defaultGroupValue, defaultGroup);
+
+  return {
+    permission: permissionKey,
+    isDisabled: isAdmin,
+    warning,
+    disabledTooltip: isAdmin ? UNABLE_TO_CHANGE_ADMIN_PERMISSIONS : null,
+    value: getApplicationPermission(permissions, groupId, permissionKey),
+    options: [
+      APPLICATION_PERMISSIONS_OPTIONS.yes,
+      APPLICATION_PERMISSIONS_OPTIONS.no,
+    ],
+  };
+};
 
 export const getApplicationPermissionEditor = createSelector(
   (state: ApplicationPermissionsState) =>
     state.plugins.applicationPermissionsPlugin?.applicationPermissions,
   getOrderedGroups,
-  (permissions, groups: Group[][]) => {
-    if (!permissions || groups == null) {
+  getAdminGroup,
+  (permissions, groups: Group[][], defaultGroup?: Group) => {
+    if (!permissions || groups == null || !defaultGroup) {
       return null;
     }
 
@@ -63,9 +94,27 @@ export const getApplicationPermissionEditor = createSelector(
         id: group.id,
         name: group.name,
         permissions: [
-          getPermission(permissions, isAdmin, group.id, "setting"),
-          getPermission(permissions, isAdmin, group.id, "monitoring"),
-          getPermission(permissions, isAdmin, group.id, "subscription"),
+          getPermission(
+            permissions,
+            isAdmin,
+            group.id,
+            defaultGroup,
+            "setting",
+          ),
+          getPermission(
+            permissions,
+            isAdmin,
+            group.id,
+            defaultGroup,
+            "monitoring",
+          ),
+          getPermission(
+            permissions,
+            isAdmin,
+            group.id,
+            defaultGroup,
+            "subscription",
+          ),
         ],
       };
     });

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/data-model-permission.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/data-model-permission.ts
@@ -1,5 +1,5 @@
 import { push } from "react-router-redux";
-import { GroupsPermissions } from "metabase-types/api";
+import { Group, GroupsPermissions } from "metabase-types/api";
 import { t } from "ttag";
 import { getGroupFocusPermissionsUrl } from "metabase/admin/permissions/utils/urls";
 import { UNABLE_TO_CHANGE_ADMIN_PERMISSIONS } from "metabase/admin/permissions/constants/messages";
@@ -14,8 +14,10 @@ import {
   getSchemasPermission,
   getTablesPermission,
 } from "metabase/admin/permissions/utils/graph";
-
-export const DATA_MODEL_PERMISSION_REQUIRES_DATA_ACCESS = t`Data model access requires full data access.`;
+import {
+  getPermissionWarning,
+  getPermissionWarningModal,
+} from "metabase/admin/permissions/selectors/confirmations";
 
 export const DATA_MODEL_PERMISSION_OPTIONS = {
   none: {
@@ -37,6 +39,12 @@ export const DATA_MODEL_PERMISSION_OPTIONS = {
     iconColor: "warning",
   },
 };
+
+const DATA_MODEL_PERMISSIONS_DESC = [
+  DATA_MODEL_PERMISSION_OPTIONS.edit.value,
+  DATA_MODEL_PERMISSION_OPTIONS.controlled.value,
+  DATA_MODEL_PERMISSION_OPTIONS.none.value,
+];
 
 const getPermissionValue = (
   permissions: GroupsPermissions,
@@ -69,6 +77,7 @@ export const buildDataModelPermission = (
   groupId: number,
   isAdmin: boolean,
   permissions: GroupsPermissions,
+  defaultGroup: Group,
   permissionSubject: PermissionSubject,
 ) => {
   const hasChildEntities = permissionSubject !== "fields";
@@ -80,15 +89,42 @@ export const buildDataModelPermission = (
     permissionSubject,
   );
 
+  const defaultGroupValue = getPermissionValue(
+    permissions,
+    defaultGroup.id,
+    entityId,
+    permissionSubject,
+  );
+
+  const warning = getPermissionWarning(
+    value,
+    defaultGroupValue,
+    permissionSubject,
+    defaultGroup,
+    groupId,
+    DATA_MODEL_PERMISSIONS_DESC,
+  );
+
+  const confirmations = (newValue: string) => [
+    getPermissionWarningModal(
+      newValue,
+      defaultGroupValue,
+      permissionSubject,
+      defaultGroup,
+      groupId,
+      DATA_MODEL_PERMISSIONS_DESC,
+    ),
+  ];
+
   return {
     permission: "data-model",
     type: "data-model",
     isDisabled: isAdmin,
-    disabledTooltip: isAdmin
-      ? UNABLE_TO_CHANGE_ADMIN_PERMISSIONS
-      : DATA_MODEL_PERMISSION_REQUIRES_DATA_ACCESS,
-    isHighlighted: isAdmin,
+    warning,
+    confirmations,
     value,
+    isHighlighted: isAdmin,
+    disabledTooltip: isAdmin ? UNABLE_TO_CHANGE_ADMIN_PERMISSIONS : null,
     options: [
       DATA_MODEL_PERMISSION_OPTIONS.none,
       ...(hasChildEntities ? [DATA_MODEL_PERMISSION_OPTIONS.controlled] : []),

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/data-model-permission.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/data-model-permission.unit.spec.ts
@@ -1,0 +1,173 @@
+import { Group, GroupsPermissions } from "metabase-types/api";
+import {
+  buildDataModelPermission,
+  DATA_MODEL_PERMISSION_OPTIONS,
+} from "./data-model-permission";
+
+const defaultGroupId = 1;
+const groupId = 2;
+
+const databaseId = 1;
+
+const getPermissionGraph = (value = "all"): GroupsPermissions =>
+  ({
+    [defaultGroupId]: {
+      [databaseId]: {
+        "data-model": {
+          schemas: "all",
+        },
+      },
+    },
+    [groupId]: {
+      [databaseId]: {
+        "data-model": {
+          schemas: value,
+        },
+      },
+    },
+  } as any);
+
+const isAdmin = true;
+const isNotAdmin = false;
+
+const defaultGroup: Group = {
+  id: defaultGroupId,
+  name: "All Users",
+} as Group;
+
+describe("buildDataModelPermission", () => {
+  it("sets correct permission and type fields and value", () => {
+    const permissionModel = buildDataModelPermission(
+      { databaseId },
+      groupId,
+      isNotAdmin,
+      getPermissionGraph(),
+      defaultGroup,
+      "schemas",
+    );
+
+    expect(permissionModel.value).toBe("all");
+    expect(permissionModel.type).toBe("data-model");
+    expect(permissionModel.permission).toBe("data-model");
+  });
+
+  it("disables permission editing for admins", () => {
+    const permissionModel = buildDataModelPermission(
+      { databaseId },
+      groupId,
+      isAdmin,
+      getPermissionGraph(),
+      defaultGroup,
+      "schemas",
+    );
+
+    expect(permissionModel.isDisabled).toBe(true);
+    expect(permissionModel.disabledTooltip).toBe(
+      "Administrators always have the highest level of access to everything in Metabase.",
+    );
+  });
+
+  it("does not disable permission editing for non-admins", () => {
+    const permissionModel = buildDataModelPermission(
+      { databaseId },
+      groupId,
+      isNotAdmin,
+      getPermissionGraph(),
+      defaultGroup,
+      "schemas",
+    );
+
+    expect(permissionModel.isDisabled).toBe(false);
+    expect(permissionModel.disabledTooltip).toBe(null);
+  });
+
+  describe("permission options", () => {
+    it("include controlled option when the permission is for schemas or tables", () => {
+      const schemasPermissionModel = buildDataModelPermission(
+        { databaseId },
+        groupId,
+        isNotAdmin,
+        getPermissionGraph(),
+        defaultGroup,
+        "schemas",
+      );
+
+      const tablesPermissionModel = buildDataModelPermission(
+        { databaseId, schemaName: "schema" },
+        groupId,
+        isNotAdmin,
+        getPermissionGraph(),
+        defaultGroup,
+        "tables",
+      );
+
+      const expectedOptions = [
+        DATA_MODEL_PERMISSION_OPTIONS.none,
+        DATA_MODEL_PERMISSION_OPTIONS.controlled,
+        DATA_MODEL_PERMISSION_OPTIONS.edit,
+      ];
+
+      expect(schemasPermissionModel.options).toStrictEqual(expectedOptions);
+      expect(tablesPermissionModel.options).toStrictEqual(expectedOptions);
+    });
+
+    it("does not include controlled option when the permission is for fields", () => {
+      const permissionModel = buildDataModelPermission(
+        { databaseId, schemaName: "schema", tableId: 1 },
+        groupId,
+        isNotAdmin,
+        getPermissionGraph(),
+        defaultGroup,
+        "fields",
+      );
+
+      const expectedOptions = [
+        DATA_MODEL_PERMISSION_OPTIONS.none,
+        DATA_MODEL_PERMISSION_OPTIONS.edit,
+      ];
+
+      expect(permissionModel.options).toStrictEqual(expectedOptions);
+    });
+  });
+
+  describe("confirmations", () => {
+    it("warns when group permissions is changing to more restrictive than the default group permission", () => {
+      const permissionModel = buildDataModelPermission(
+        { databaseId },
+        groupId,
+        isNotAdmin,
+        getPermissionGraph(),
+        defaultGroup,
+        "schemas",
+      );
+
+      const [downgradePermissionConfirmation] = permissionModel.confirmations(
+        "none",
+      );
+
+      expect(downgradePermissionConfirmation?.message).toBe(
+        'The "All Users" group has a higher level of access than this, which will override this setting. You should limit or revoke the "All Users" group\'s access to this item.',
+      );
+    });
+
+    it("warns when group permissions is already restrictive than the default group permission", () => {
+      const permissionModel = buildDataModelPermission(
+        { databaseId },
+        groupId,
+        isNotAdmin,
+        getPermissionGraph("none"),
+        defaultGroup,
+        "schemas",
+      );
+
+      const [downgradePermissionConfirmation] = permissionModel.confirmations(
+        "all",
+      );
+
+      expect(permissionModel.warning).toBe(
+        'The "All Users" group has a higher level of access than this, which will override this setting. You should limit or revoke the "All Users" group\'s access to this item.',
+      );
+      expect(downgradePermissionConfirmation?.message).toBeUndefined();
+    });
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/details-permission.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/details-permission.ts
@@ -1,10 +1,12 @@
 import { getIn } from "icepick";
 import { t } from "ttag";
-import { GroupsPermissions } from "metabase-types/api";
+import { Group, GroupsPermissions } from "metabase-types/api";
 import { UNABLE_TO_CHANGE_ADMIN_PERMISSIONS } from "metabase/admin/permissions/constants/messages";
 import { EntityId, PermissionSubject } from "metabase/admin/permissions/types";
-
-export const DETAILS_PERMISSION_REQUIRES_DATA_ACCESS = t`Manage database access requires full data access.`;
+import {
+  getPermissionWarning,
+  getPermissionWarningModal,
+} from "metabase/admin/permissions/selectors/confirmations";
 
 export const DETAILS_PERMISSION_OPTIONS = {
   no: {
@@ -21,6 +23,11 @@ export const DETAILS_PERMISSION_OPTIONS = {
   },
 };
 
+const DETAILS_PERMISSIONS_DESC = [
+  DETAILS_PERMISSION_OPTIONS.yes.value,
+  DETAILS_PERMISSION_OPTIONS.no.value,
+];
+
 const getDetailsPermission = (
   permissions: GroupsPermissions,
   groupId: number,
@@ -34,6 +41,7 @@ export const buildDetailsPermission = (
   groupId: number,
   isAdmin: boolean,
   permissions: GroupsPermissions,
+  defaultGroup: Group,
   permissionSubject: PermissionSubject,
 ) => {
   if (permissionSubject !== "schemas") {
@@ -41,16 +49,41 @@ export const buildDetailsPermission = (
   }
 
   const value = getDetailsPermission(permissions, groupId, entityId.databaseId);
+  const defaultGroupValue = getDetailsPermission(
+    permissions,
+    defaultGroup.id,
+    entityId.databaseId,
+  );
+
+  const warning = getPermissionWarning(
+    value,
+    defaultGroupValue,
+    permissionSubject,
+    defaultGroup,
+    groupId,
+    DETAILS_PERMISSIONS_DESC,
+  );
+
+  const confirmations = (newValue: string) => [
+    getPermissionWarningModal(
+      newValue,
+      defaultGroupValue,
+      permissionSubject,
+      defaultGroup,
+      groupId,
+      DETAILS_PERMISSIONS_DESC,
+    ),
+  ];
 
   return {
     permission: "details",
     type: "details",
-    isDisabled: isAdmin,
-    disabledTooltip: isAdmin
-      ? UNABLE_TO_CHANGE_ADMIN_PERMISSIONS
-      : DETAILS_PERMISSION_REQUIRES_DATA_ACCESS,
-    isHighlighted: isAdmin,
     value,
+    isDisabled: isAdmin,
+    isHighlighted: isAdmin,
+    warning,
+    confirmations,
+    disabledTooltip: isAdmin ? UNABLE_TO_CHANGE_ADMIN_PERMISSIONS : null,
     options: [DETAILS_PERMISSION_OPTIONS.no, DETAILS_PERMISSION_OPTIONS.yes],
   };
 };

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/details-permission.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/details-permission.unit.spec.ts
@@ -1,0 +1,142 @@
+import { Group, GroupsPermissions } from "metabase-types/api";
+import {
+  buildDetailsPermission,
+  DETAILS_PERMISSION_OPTIONS,
+} from "./details-permission";
+
+const defaultGroupId = 1;
+const groupId = 2;
+
+const databaseId = 1;
+
+const getPermissionGraph = (value = "yes"): GroupsPermissions =>
+  ({
+    [defaultGroupId]: {
+      [databaseId]: {
+        details: "yes",
+      },
+    },
+    [groupId]: {
+      [databaseId]: {
+        details: value,
+      },
+    },
+  } as any);
+
+const isAdmin = true;
+const isNotAdmin = false;
+
+const defaultGroup: Group = {
+  id: defaultGroupId,
+  name: "All Users",
+} as Group;
+
+describe("buildDetailsPermission", () => {
+  it("returns null for table and field levels", () => {
+    const fieldsPermissionModel = buildDetailsPermission(
+      { databaseId },
+      groupId,
+      isNotAdmin,
+      getPermissionGraph(),
+      defaultGroup,
+      "fields",
+    );
+
+    const tablesPermissionModel = buildDetailsPermission(
+      { databaseId },
+      groupId,
+      isNotAdmin,
+      getPermissionGraph(),
+      defaultGroup,
+      "tables",
+    );
+
+    expect(fieldsPermissionModel).toBeNull();
+    expect(tablesPermissionModel).toBeNull();
+  });
+
+  it("disables permission editing for admins", () => {
+    const permissionModel = buildDetailsPermission(
+      { databaseId },
+      groupId,
+      isAdmin,
+      getPermissionGraph(),
+      defaultGroup,
+      "schemas",
+    );
+
+    expect(permissionModel?.isDisabled).toBe(true);
+    expect(permissionModel?.disabledTooltip).toBe(
+      "Administrators always have the highest level of access to everything in Metabase.",
+    );
+  });
+
+  it("does not disable permission editing for non-admins", () => {
+    const permissionModel = buildDetailsPermission(
+      { databaseId },
+      groupId,
+      isNotAdmin,
+      getPermissionGraph(),
+      defaultGroup,
+      "schemas",
+    );
+
+    expect(permissionModel?.isDisabled).toBe(false);
+    expect(permissionModel?.disabledTooltip).toBe(null);
+  });
+
+  it("permission options include controlled option when the permission is for schemas or tables", () => {
+    const permissionModel = buildDetailsPermission(
+      { databaseId },
+      groupId,
+      isNotAdmin,
+      getPermissionGraph(),
+      defaultGroup,
+      "schemas",
+    );
+
+    expect(permissionModel?.options).toStrictEqual([
+      DETAILS_PERMISSION_OPTIONS.no,
+      DETAILS_PERMISSION_OPTIONS.yes,
+    ]);
+  });
+
+  describe("confirmations", () => {
+    it("warns when group permissions is changing to more restrictive than the default group permission", () => {
+      const permissionModel = buildDetailsPermission(
+        { databaseId },
+        groupId,
+        isNotAdmin,
+        getPermissionGraph(),
+        defaultGroup,
+        "schemas",
+      );
+
+      const [downgradePermissionConfirmation] =
+        permissionModel?.confirmations("no") || [];
+
+      expect(downgradePermissionConfirmation?.message).toBe(
+        'The "All Users" group has a higher level of access than this, which will override this setting. You should limit or revoke the "All Users" group\'s access to this item.',
+      );
+    });
+
+    it("warns when group permissions is already restrictive than the default group permission", () => {
+      const permissionModel = buildDetailsPermission(
+        { databaseId },
+        groupId,
+        isNotAdmin,
+        getPermissionGraph("no"),
+        defaultGroup,
+        "schemas",
+      );
+
+      const [downgradePermissionConfirmation] =
+        permissionModel?.confirmations("yes") ?? [];
+
+      expect(permissionModel?.warning).toBe(
+        'The "All Users" group has a higher level of access than this, which will override this setting. You should limit or revoke the "All Users" group\'s access to this item.',
+      );
+      expect(downgradePermissionConfirmation?.message).toBeUndefined();
+    });
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/download-permission.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/download-permission.ts
@@ -1,6 +1,7 @@
 import { push } from "react-router-redux";
 import { t } from "ttag";
-import { GroupsPermissions } from "metabase-types/api";
+
+import { Group, GroupsPermissions } from "metabase-types/api";
 import { UNABLE_TO_CHANGE_ADMIN_PERMISSIONS } from "metabase/admin/permissions/constants/messages";
 import {
   EntityId,
@@ -13,6 +14,10 @@ import {
   getSchemasPermission,
   getTablesPermission,
 } from "metabase/admin/permissions/utils/graph";
+import {
+  getPermissionWarning,
+  getPermissionWarningModal,
+} from "metabase/admin/permissions/selectors/confirmations";
 import { getGroupFocusPermissionsUrl } from "metabase/admin/permissions/utils/urls";
 import { PLUGIN_ADVANCED_PERMISSIONS } from "metabase/plugins";
 
@@ -44,6 +49,13 @@ export const DOWNLOAD_PERMISSION_OPTIONS = {
     iconColor: "warning",
   },
 };
+
+const DOWNLOAD_PERMISSIONS_DESC = [
+  DOWNLOAD_PERMISSION_OPTIONS.full.value,
+  DOWNLOAD_PERMISSION_OPTIONS.limited.value,
+  DOWNLOAD_PERMISSION_OPTIONS.controlled.value,
+  DOWNLOAD_PERMISSION_OPTIONS.none.value,
+];
 
 const getPermissionValue = (
   permissions: GroupsPermissions,
@@ -77,6 +89,7 @@ export const buildDownloadPermission = (
   isAdmin: boolean,
   permissions: GroupsPermissions,
   dataAccessPermissionValue: string,
+  defaultGroup: Group,
   permissionSubject: PermissionSubject,
 ) => {
   const hasChildEntities = permissionSubject !== "fields";
@@ -87,19 +100,50 @@ export const buildDownloadPermission = (
     ? DOWNLOAD_PERMISSION_OPTIONS.none.value
     : getPermissionValue(permissions, groupId, entityId, permissionSubject);
 
+  const defaultGroupValue = getPermissionValue(
+    permissions,
+    defaultGroup.id,
+    entityId,
+    permissionSubject,
+  );
+
   const isDisabled =
     isAdmin ||
     PLUGIN_ADVANCED_PERMISSIONS.isBlockPermission(dataAccessPermissionValue);
+
+  const warning = getPermissionWarning(
+    value,
+    defaultGroupValue,
+    permissionSubject,
+    defaultGroup,
+    groupId,
+    DOWNLOAD_PERMISSIONS_DESC,
+  );
+
+  const confirmations = (newValue: string) => [
+    getPermissionWarningModal(
+      newValue,
+      defaultGroupValue,
+      permissionSubject,
+      defaultGroup,
+      groupId,
+      DOWNLOAD_PERMISSIONS_DESC,
+    ),
+  ];
 
   return {
     permission: "download",
     type: "download",
     isDisabled,
+    value,
+    warning,
+    confirmations,
+    isHighlighted: isAdmin,
     disabledTooltip: isAdmin
       ? UNABLE_TO_CHANGE_ADMIN_PERMISSIONS
-      : DOWNLOAD_PERMISSION_REQUIRES_DATA_ACCESS,
-    isHighlighted: isAdmin,
-    value,
+      : isDisabled
+      ? DOWNLOAD_PERMISSION_REQUIRES_DATA_ACCESS
+      : null,
     options: [
       DOWNLOAD_PERMISSION_OPTIONS.none,
       ...(hasChildEntities ? [DOWNLOAD_PERMISSION_OPTIONS.controlled] : []),

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/download-permission.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/download-permission.unit.spec.ts
@@ -1,0 +1,184 @@
+import { Group, GroupsPermissions } from "metabase-types/api";
+import {
+  buildDownloadPermission,
+  DOWNLOAD_PERMISSION_OPTIONS,
+} from "./download-permission";
+
+const defaultGroupId = 1;
+const groupId = 2;
+
+const databaseId = 1;
+
+const getPermissionGraph = (downloadValue = "all"): GroupsPermissions =>
+  ({
+    [defaultGroupId]: {
+      [databaseId]: {
+        download: {
+          schemas: "all",
+        },
+      },
+    },
+    [groupId]: {
+      [databaseId]: {
+        download: {
+          schemas: downloadValue,
+        },
+      },
+    },
+  } as any);
+
+const isAdmin = true;
+const isNotAdmin = false;
+const dataAccessPermissionValue = "all";
+
+const defaultGroup: Group = {
+  id: defaultGroupId,
+  name: "All Users",
+} as Group;
+
+describe("buildDownloadPermission", () => {
+  it("sets correct permission and type fields and value", () => {
+    const permissionModel = buildDownloadPermission(
+      { databaseId },
+      groupId,
+      isNotAdmin,
+      getPermissionGraph(),
+      dataAccessPermissionValue,
+      defaultGroup,
+      "schemas",
+    );
+
+    expect(permissionModel.value).toBe("all");
+    expect(permissionModel.type).toBe("download");
+    expect(permissionModel.permission).toBe("download");
+  });
+
+  it("disables permission editing for admins", () => {
+    const permissionModel = buildDownloadPermission(
+      { databaseId },
+      groupId,
+      isAdmin,
+      getPermissionGraph(),
+      dataAccessPermissionValue,
+      defaultGroup,
+      "schemas",
+    );
+
+    expect(permissionModel.isDisabled).toBe(true);
+    expect(permissionModel.disabledTooltip).toBe(
+      "Administrators always have the highest level of access to everything in Metabase.",
+    );
+  });
+
+  it("does not disable permission editing for non-admins", () => {
+    const permissionModel = buildDownloadPermission(
+      { databaseId },
+      groupId,
+      isNotAdmin,
+      getPermissionGraph(),
+      dataAccessPermissionValue,
+      defaultGroup,
+      "schemas",
+    );
+
+    expect(permissionModel.isDisabled).toBe(false);
+    expect(permissionModel.disabledTooltip).toBe(null);
+  });
+
+  describe("permission options", () => {
+    it("include controlled option when the permission is for schemas or tables", () => {
+      const schemasPermissionModel = buildDownloadPermission(
+        { databaseId },
+        groupId,
+        isNotAdmin,
+        getPermissionGraph(),
+        dataAccessPermissionValue,
+        defaultGroup,
+        "schemas",
+      );
+
+      const tablesPermissionModel = buildDownloadPermission(
+        { databaseId, schemaName: "schema" },
+        groupId,
+        isNotAdmin,
+        getPermissionGraph(),
+        dataAccessPermissionValue,
+        defaultGroup,
+        "tables",
+      );
+
+      const expectedOptions = [
+        DOWNLOAD_PERMISSION_OPTIONS.none,
+        DOWNLOAD_PERMISSION_OPTIONS.controlled,
+        DOWNLOAD_PERMISSION_OPTIONS.limited,
+        DOWNLOAD_PERMISSION_OPTIONS.full,
+      ];
+
+      expect(schemasPermissionModel.options).toStrictEqual(expectedOptions);
+      expect(tablesPermissionModel.options).toStrictEqual(expectedOptions);
+    });
+
+    it("does not include controlled option when the permission is for fields", () => {
+      const permissionModel = buildDownloadPermission(
+        { databaseId, schemaName: "schema", tableId: 1 },
+        groupId,
+        isNotAdmin,
+        getPermissionGraph(),
+        dataAccessPermissionValue,
+        defaultGroup,
+        "fields",
+      );
+
+      const expectedOptions = [
+        DOWNLOAD_PERMISSION_OPTIONS.none,
+        DOWNLOAD_PERMISSION_OPTIONS.limited,
+        DOWNLOAD_PERMISSION_OPTIONS.full,
+      ];
+
+      expect(permissionModel.options).toStrictEqual(expectedOptions);
+    });
+  });
+
+  describe("confirmations", () => {
+    it("warns when group permissions is changing to more restrictive than the default group permission", () => {
+      const permissionModel = buildDownloadPermission(
+        { databaseId },
+        groupId,
+        isNotAdmin,
+        getPermissionGraph(),
+        dataAccessPermissionValue,
+        defaultGroup,
+        "schemas",
+      );
+
+      const [downgradePermissionConfirmation] = permissionModel.confirmations(
+        "none",
+      );
+
+      expect(downgradePermissionConfirmation?.message).toBe(
+        'The "All Users" group has a higher level of access than this, which will override this setting. You should limit or revoke the "All Users" group\'s access to this item.',
+      );
+    });
+
+    it("warns when group permissions is already restrictive than the default group permission", () => {
+      const permissionModel = buildDownloadPermission(
+        { databaseId },
+        groupId,
+        isNotAdmin,
+        getPermissionGraph("none"),
+        dataAccessPermissionValue,
+        defaultGroup,
+        "schemas",
+      );
+
+      const [downgradePermissionConfirmation] = permissionModel.confirmations(
+        "all",
+      );
+
+      expect(permissionModel.warning).toBe(
+        'The "All Users" group has a higher level of access than this, which will override this setting. You should limit or revoke the "All Users" group\'s access to this item.',
+      );
+      expect(downgradePermissionConfirmation?.message).toBeUndefined();
+    });
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/index.ts
@@ -1,4 +1,4 @@
-import { GroupsPermissions } from "metabase-types/api";
+import { Group, GroupsPermissions } from "metabase-types/api";
 import { EntityId, PermissionSubject } from "metabase/admin/permissions/types";
 import { buildDataModelPermission } from "./data-model-permission";
 import { buildDetailsPermission } from "./details-permission";
@@ -10,6 +10,7 @@ export const getFeatureLevelDataPermissions = (
   isAdmin: boolean,
   permissions: GroupsPermissions,
   dataAccessPermissionValue: string,
+  defaultGroup: Group,
   permissionSubject: PermissionSubject,
 ) => {
   const downloadPermission = buildDownloadPermission(
@@ -18,6 +19,7 @@ export const getFeatureLevelDataPermissions = (
     isAdmin,
     permissions,
     dataAccessPermissionValue,
+    defaultGroup,
     permissionSubject,
   );
 
@@ -26,6 +28,7 @@ export const getFeatureLevelDataPermissions = (
     groupId,
     isAdmin,
     permissions,
+    defaultGroup,
     permissionSubject,
   );
 
@@ -34,6 +37,7 @@ export const getFeatureLevelDataPermissions = (
     groupId,
     isAdmin,
     permissions,
+    defaultGroup,
     permissionSubject,
   );
 

--- a/frontend/src/metabase-types/api/permissions.ts
+++ b/frontend/src/metabase-types/api/permissions.ts
@@ -37,8 +37,13 @@ export type DownloadTablePermission =
 
 export type DatabasePermissions = {
   data: DatabaseAccessPermissions;
+  "data-model": DataModelPermissions;
   download: DownloadAccessPermission;
   details: DetailsPermissions;
+};
+
+export type DataModelPermissions = {
+  schemas: SchemasPermissions;
 };
 
 export type DatabaseAccessPermissions = {

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/fields.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/fields.ts
@@ -32,7 +32,7 @@ const buildAccessPermission = (
   isAdmin: boolean,
   permissions: GroupsPermissions,
   defaultGroup: Group,
-  database: Database | null,
+  database: Database,
 ) => {
   const value = getFieldsPermission(permissions, groupId, entityId, "data");
   const defaultGroupValue = getFieldsPermission(
@@ -115,7 +115,7 @@ export const buildFieldsPermissions = (
   isAdmin: boolean,
   permissions: GroupsPermissions,
   defaultGroup: Group,
-  database: Database | null,
+  database: Database,
 ) => {
   const accessPermission = buildAccessPermission(
     entityId,
@@ -142,6 +142,7 @@ export const buildFieldsPermissions = (
       isAdmin,
       permissions,
       accessPermission.value,
+      defaultGroup,
       "fields",
     ),
   ];

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/groups.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/groups.ts
@@ -12,3 +12,8 @@ export const getOrderedGroups = createSelector(
   Groups.selectors.getList,
   (groups: Group[]) => _.partition(groups, isPinnedGroup),
 );
+
+export const getAdminGroup = createSelector(
+  Groups.selectors.getList,
+  (groups: Group[]) => groups.find(isDefaultGroup),
+);

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/permission-editor.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/permission-editor.ts
@@ -159,10 +159,12 @@ export const getDatabasesPermissionEditor = createSelector(
 
     let entities: any = [];
 
-    if (schemaName != null || hasSingleSchema) {
+    const database = metadata?.database(databaseId);
+
+    if (database && (schemaName != null || hasSingleSchema)) {
       const schema: Schema = hasSingleSchema
-        ? metadata?.database(databaseId)?.getSchemas()[0]
-        : metadata?.database(databaseId)?.schema(schemaName);
+        ? database.getSchemas()[0]
+        : database.schema(schemaName);
 
       entities = schema
         .getTables()
@@ -179,7 +181,7 @@ export const getDatabasesPermissionEditor = createSelector(
               isAdmin,
               permissions,
               defaultGroup,
-              metadata.database(databaseId),
+              database,
             ),
           };
         });
@@ -253,8 +255,9 @@ export const getGroupsDataPermissionEditor = createSelector(
   getOrderedGroups,
   (metadata, params, permissions, groups: Group[][]) => {
     const { databaseId, schemaName, tableId } = params;
+    const database = metadata?.database(databaseId);
 
-    if (!permissions || databaseId == null) {
+    if (!permissions || databaseId == null || !database) {
       return null;
     }
 
@@ -289,7 +292,7 @@ export const getGroupsDataPermissionEditor = createSelector(
           isAdmin,
           permissions,
           defaultGroup,
-          metadata.database(databaseId),
+          database,
         );
       } else if (schemaName != null) {
         groupPermissions = buildTablesPermissions(

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/schemas.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/schemas.ts
@@ -176,6 +176,7 @@ export const buildSchemasPermissions = (
       isAdmin,
       permissions,
       accessPermission.value,
+      defaultGroup,
       "schemas",
     ),
   ];

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/tables.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/tables.ts
@@ -130,6 +130,7 @@ export const buildTablesPermissions = (
       isAdmin,
       permissions,
       accessPermission.value,
+      defaultGroup,
       "tables",
     ),
   ];

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -10,6 +10,7 @@ import {
   Bookmark,
   GroupsPermissions,
   Dataset,
+  Group,
 } from "metabase-types/api";
 import { AdminPathKey, State } from "metabase-types/store";
 import { PluginGroupManagersType } from "./types";
@@ -138,6 +139,7 @@ export const PLUGIN_FEATURE_LEVEL_PERMISSIONS = {
     _isAdmin: boolean,
     _permissions: GroupsPermissions,
     _dataAccessPermissionValue: string,
+    _defaultGroup: Group,
     _permissionSubject: PermissionSubject,
   ) => {
     return [] as any;


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/22330

## Changes

Add warnings when all users group has higher access level.

#### Scope
- Data permissions: download, data model, manage database
    - Added warning icons
    - Added confirmation modals
- All application permissions
    - Added warning icons

## Screenshots

Icons
<img width="642" alt="Screenshot 2022-05-04 at 03 01 43" src="https://user-images.githubusercontent.com/14301985/166586798-dfd48970-183a-4c2b-8c35-76c2fdf0ffb0.png">

Confirmation
<img width="680" alt="Screenshot 2022-05-04 at 03 01 58" src="https://user-images.githubusercontent.com/14301985/166586826-3c91157d-1ff2-418e-be40-e5614dd1379c.png">

## How to verify

### Setup
- Create a Test Group

### Data permissions
- Go to the Data Permissions page
- Ensure Download, Data Model, Manage database permissions are enabled for "All Users" and "Test Group"
- Try to restrict "Test Group" permissions and ensure it requires a confirmation
- Ensure after confirmation it shows a warning icon with a clarification in tooltip
- Ensure that it does not show the confirmation when changing "Test Group" permissions to stronger than "All Users" permissions

### Application permissions
- Go to the Data Permissions page
- Ensure Monitoring, Subscriptions, Settings permissions are enabled for "All Users" and "Test Group"
- Restrict "Test Group" permissions
- Ensure after confirmation it shows a warning icon with a clarification in tooltip
