### PR TITLE
Fix unescaped apostrophes in translated strings during .edn creation

### DIFF
--- a/bin/i18n/src/i18n/create_artifacts.clj
+++ b/bin/i18n/src/i18n/create_artifacts.clj
@@ -5,17 +5,16 @@
             [i18n.create-artifacts.frontend :as frontend]
             [metabuild-common.core :as u]))
 
-;; TODO -- shouldn't this be `locales.edn`?
-(defn- locales-dot-clj []
+(defn- locales-dot-edn []
   {:locales  (conj (i18n/locales) "en")
    :packages ["metabase"]
    :bundle   "metabase.Messages"})
 
-(defn- generate-locales-dot-clj! []
+(defn- generate-locales-dot-edn! []
   (u/step "Create resources/locales.clj"
     (let [file (u/filename u/project-root-directory "resources" "locales.clj")]
       (u/delete-file-if-exists! file)
-      (spit file (with-out-str (pprint/pprint (locales-dot-clj))))
+      (spit file (with-out-str (pprint/pprint (locales-dot-edn))))
       (u/assert-file-exists file))))
 
 (defn- create-artifacts-for-locale! [locale]
@@ -33,7 +32,7 @@
 
 (defn create-all-artifacts! []
   (u/step "Create i18n artifacts"
-    (generate-locales-dot-clj!)
+    (generate-locales-dot-edn!)
     (create-artifacts-for-all-locales!)
     (u/announce "Translation resources built successfully.")))
 

--- a/bin/i18n/src/i18n/create_artifacts/backend.clj
+++ b/bin/i18n/src/i18n/create_artifacts/backend.clj
@@ -23,10 +23,19 @@
                            :str-plural nil
                            :plural? false})))
 
+(def ^:private apostrophe-regex
+  "Regex that matches incorrectly escaped apostrophe characters.
+  Matches on a single apostrophe surrounded by any letter, number, space, or diacritical character (chars with accents like é) and is case-insensitive"
+  #"(?<![^a-zA-Z0-9\s\u00C0-\u017F])'(?![^a-zA-Z0-9\s\u00C0-\u017F])")
+
+(defn- fix-unescaped-apostrophes [message]
+  (update message :str str/replace apostrophe-regex "''"))
+
 (defn- ->edn [{:keys [messages]}]
   (eduction
    (filter backend-message?)
    (map plural->singular)
+   (map fix-unescaped-apostrophes)
    i18n/print-message-count-xform
    messages))
 


### PR DESCRIPTION
Fixes #15531
Fixes #8468

A diff of `fr.edn` before/after the script change.
[fr.txt](https://github.com/metabase/metabase/files/8606500/fr.txt)

This fixes many minor translation errors where apostrohpes are missing in the rendered message. This is common in French translations. In some cases it even causes `{0}` parameters to be left un-rendered in the final message since they end up accidentally escaped:

> "L'exécution de la requête a pris {0} ; le minimum pour l'éligibilité du cache est {1}."

Which would end up rendered as follows, if `{0} = 100ms` and `{1} = 2000ms`:
> "L'exécution de la requête a pris {0} ; le minimum pour l'éligibilité du cache est 100ms."
Which is clearly incorrect. 

You can run the following in a REPL to see how apostrophes should be escaped. There are a few example strings that have apostrophes _intentionally_ escaping parameters, so that intent should be presereved.

```clojure
i18n.create-artifacts.backend> (defn- check-escaping [{s :str good :good :as msg}]
                                 (let [fix (fix-unescaped-apostrophes msg)]
                                   (if (= (:str fix) good)
                                     true
                                     (do (println (str "Expected: " good "\n"
                                                       "  Actual: " (:str fix) "\n"))))))
#'i18n.create-artifacts.backend/check-escaping
i18n.create-artifacts.backend> 
(def test-strs
  [{:str ""
    :good ""}
   {:str "Some normal string."
    :good "Some normal string."}
   {:str "already ''escaped'' string"
    :good "already ''escaped'' string"}
   {:str "this has an escaped '{0}' param"
    :good "this has an escaped '{0}' param"}
   {:str "Fonction d'interrogation interne invalide : {0} n'est pas marqué comme ^:internal-query-fn"
    :good "Fonction d''interrogation interne invalide : {0} n''est pas marqué comme ^:internal-query-fn"}
   {:str "L'utilisateur \"{0}\" a tenté d'accéder à un champ inaccessible. Champs accessibles {1}, champs de la requête {2}"
    :good "L''utilisateur \"{0}\" a tenté d''accéder à un champ inaccessible. Champs accessibles {1}, champs de la requête {2}"}
   {:str "J'ai trouvé plus d'une politique d'accès aux tables de groupe pour l'utilisateur ''{0}''."
    :good "J''ai trouvé plus d''une politique d''accès aux tables de groupe pour l''utilisateur ''{0}''."}
   {:str "La requête nécessite l'attribut utilisateur `{0}`"
    :good "La requête nécessite l''attribut utilisateur `{0}`"}
   {:str "L'exécution de la requête a pris {0} ; le minimum pour l'éligibilité du cache est {1}."
    :good "L''exécution de la requête a pris {0} ; le minimum pour l''éligibilité du cache est {1}."}
   {:str "Je ne sais pas comment traiter l'événement avec le modèle {0}."
    :good "Je ne sais pas comment traiter l''événement avec le modèle {0}."}
   {:str "Le type sémantique de {0} est passé de ''{1}'' à ''{2}''."
    :good "Le type sémantique de {0} est passé de ''{1}'' à ''{2}''."}
   {:str "Filtre de recherche d'appartenance à un groupe. Les caractères de remplacement '{dn}' et '{uid}' seront remplacés par le nom distinctif et l'UID de l'utilisateur, respectivement."
    :good "Filtre de recherche d''appartenance à un groupe. Les caractères de remplacement '{dn}' et '{uid}' seront remplacés par le nom distinctif et l''UID de l''utilisateur, respectivement."}])
#'i18n.create-artifacts.backend/test-strs
i18n.create-artifacts.backend> (map check-escaping test-strs)
(true true true true true true true true true true true true)
i18n.create-artifacts.backend> 
```

## After this PR
Running `./bin/i18n/build-translation-resources` from top level directory of the Metabase project will build all translation resources, running the apostrophe fix on every string.

To verify, run the script then open `/metabase/resources/i18n/fr.edn` and search for something like `L''Url`. If you compare the .edn file to the `fr.po` file (`/metabase/locales/fr.po`), you will notice that strings with single apostrophes have been fixed.

You should also see correct translations in the UI (note that it's possible some strings have not yet been translated).
<img width="679" alt="image" src="https://user-images.githubusercontent.com/21064735/166333694-746f09c0-c5bb-4f79-9755-9bb424e7d0ec.png">
<img width="679" alt="image" src="https://user-images.githubusercontent.com/21064735/166333724-60e434f0-bae9-4329-a7b0-96308de85511.png">

