### PR TITLE
fix **User filter** field

### DIFF
--- a/docs/administration-guide/10-single-sign-on.md
+++ b/docs/administration-guide/10-single-sign-on.md
@@ -59,7 +59,7 @@ For example, let's say you're configuring LDAP for your company, WidgetCo, where
 You'll see the following grayed-out default value in the **User filter** field:
 
 ```
-(&(objectClass=inetOrgPerson)(|uid={login})(mail={login})
+(&(objectClass=inetOrgPerson)(|(uid={login})(mail={login})))
 ```
 
 When a person logs into Metabase, this command confirms that the login they supplied matches either a UID _or_ email field in your LDAP server, _and_ that the matching entry has an objectClass of `inetOrgPerson`.


### PR DESCRIPTION
Fixing the default value in the **User filter** field for ldap Auth according to the up-to-date version

###### Before submitting the PR, please make sure you do the following

- [ ] If you're attempting to fix a translation issue, please submit your changes to our [POEditor project](https://poeditor.com/join/project/ynjQmwSsGh) instead of opening a PR.

### Tests

- [ ] Run the frontend and Cypress end-to-end tests with `yarn lint && yarn test`)
- [ ] If there are changes to the backend codebase, run the backend tests with `clojure -X:dev:test`
- [ ] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
      (unless it's a tiny documentation change).
