### PR TITLE
User with view collection perms can create Alerts

### DIFF
--- a/frontend/src/metabase/query_builder/components/AlertModals.jsx
+++ b/frontend/src/metabase/query_builder/components/AlertModals.jsx
@@ -109,16 +109,9 @@ export class CreateAlertModalContent extends Component {
   onAlertChange = alert => this.setState({ alert });
 
   onCreateAlert = async () => {
-    const {
-      question,
-      createAlert,
-      apiUpdateQuestion,
-      updateUrl,
-      onAlertCreated,
-    } = this.props;
+    const { question, createAlert, updateUrl, onAlertCreated } = this.props;
     const { alert } = this.state;
 
-    await apiUpdateQuestion(question);
     await createAlert(alert);
     await updateUrl(question.card(), { dirty: false });
 

--- a/src/metabase/api/alert.clj
+++ b/src/metabase/api/alert.clj
@@ -137,9 +137,8 @@
    card             pulse/CardRef
    channels         (su/non-empty [su/Map])}
   (validation/check-has-application-permission :subscription false)
-  ;; do various perms checks as needed. Perms for an Alert == perms for its Card. So to create an Alert you need write
-  ;; perms for its Card
-  (api/write-check Card (u/the-id card))
+  ;; To create an Alert you need read perms for its Card
+  (api/read-check Card (u/the-id card))
   ;; ok, now create the Alert
   (let [alert-card (-> card (maybe-include-csv alert_condition) pulse/card->ref)
         new-alert  (api/check-500
@@ -184,7 +183,7 @@
             (tru "Invalid Alert: Alert does not have a Card associated with it"))
     ;; check permissions as needed.
     ;; Check permissions to update existing Card
-    (api/write-check Card (u/the-id (:card alert-before-update)))
+    (api/read-check Card (u/the-id (:card alert-before-update)))
     ;; if trying to change the card, check perms for that as well
     (when card
       (api/write-check Card (u/the-id card)))


### PR DESCRIPTION
Fix #13908 by changing permission to allow users with permissions to view collection to call:
- `POST /api/alert`
- `PUT /api/alert/:id` can update the alert but will 403 if attempts to update card

I also make a change in FE in which I remove the call to `PUT /api/card/:id` when creating an alert.
This seems to be a no-op call and should not be a problem to remove (details in [here](https://github.com/metabase/metabase/pull/22364#discussion_r863862561))
FWIW when creating a Pulse, we don't update the dashboard.