### PR TITLE
Handle not available Notifications API

### DIFF
--- a/frontend/src/metabase/dashboard/containers/DashboardApp.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp.jsx
@@ -106,7 +106,7 @@ const DashboardApp = props => {
   const [isShowingToaster, setIsShowingToaster] = useState(false);
 
   const onTimeout = useCallback(() => {
-    if (Notification.permission === "default") {
+    if ("Notification" in window && Notification.permission === "default") {
       setIsShowingToaster(true);
     }
   }, []);
@@ -123,7 +123,11 @@ const DashboardApp = props => {
   useEffect(() => {
     if (isLoadingComplete) {
       setIsShowingToaster(false);
-      if (Notification.permission === "granted" && document.hidden) {
+      if (
+        "Notification" in window &&
+        Notification.permission === "granted" &&
+        document.hidden
+      ) {
         showNotification(
           t`All Set! ${dashboard?.name} is ready.`,
           t`All questions loaded`,

--- a/frontend/src/metabase/hooks/use-web-notification.ts
+++ b/frontend/src/metabase/hooks/use-web-notification.ts
@@ -1,12 +1,21 @@
-import React, { useCallback } from "react";
+import { useCallback } from "react";
+
+const hasNotificationAPI = "Notification" in window;
 
 export function useWebNotification() {
   const requestPermission = useCallback(async () => {
+    if (!hasNotificationAPI) {
+      return "denied";
+    }
     const permission = await Notification.requestPermission();
     return permission;
   }, []);
 
   const showNotification = useCallback((title: string, body: string) => {
+    if (!hasNotificationAPI) {
+      return;
+    }
+
     const notification = new Notification(title, {
       body,
       icon: "app/assets/img/favicon-32x32.png",

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
@@ -373,7 +373,7 @@ function QueryBuilder(props) {
   const { isRunning } = uiControls;
 
   const onTimeout = useCallback(() => {
-    if (Notification.permission === "default") {
+    if ("Notification" in window && Notification.permission === "default") {
       setIsShowingToaster(true);
     }
   }, []);
@@ -389,7 +389,11 @@ function QueryBuilder(props) {
     if (isLoadingComplete) {
       setIsShowingToaster(false);
 
-      if (Notification.permission === "granted" && document.hidden) {
+      if (
+        "Notification" in window &&
+        Notification.permission === "granted" &&
+        document.hidden
+      ) {
         showNotification(
           t`All Set! Your question is ready.`,
           t`${card.name} is loaded.`,


### PR DESCRIPTION
Fixes #22172

Dashboard and question pages were constantly erroring and reloading on mobile because they were trying to use unavailable web notifications API. Fixed by adding checks if the `Notification` class is available in `window`. It'd be better to encapsulate all of these inside the `useWebNotification` hook, but we should better do that in another PR and keep the fix simple.

### To Verify

_I'm not sure if there is a go-to approach on how to spin up Metabase locally so you can open it on mobile, but here's what I did:_

1. Get your local IP address (`192.168.x.x`)
2. Replace `localhost` in [here](https://github.com/metabase/metabase/blob/6602f0f57138a20737b6ceb233900b868673365e/webpack.config.js#L221) with your local IP (keep the 8080 port though)
3. Remove [this line](https://github.com/metabase/metabase/blob/6602f0f57138a20737b6ceb233900b868673365e/src/metabase/server/middleware/security.clj#L126) to get remove the `Content-Security-Policy` HTTP header
4. Run Metabase with `MB_JETTY_HOST` var set to your local IP, example: `MB_JETTY_PORT=192.168.x.x yarn dev`
5. On your mobile phone, go to `{{ YOUR_LOCAL_IP }}:8000`
6. Open any question/dashboard
7. Ensure the page opens and can be normally used
8. On the desktop: ensure changes from #21414 work

### Demo

**Before**

https://user-images.githubusercontent.com/17258145/166446384-a37d0b91-e567-4777-b713-a5f9c2d894d9.MP4

**After**

https://user-images.githubusercontent.com/17258145/166446381-9de2cb55-d762-4d8e-b859-02d5c4d015e6.mov