### PR TITLE
Fix removing the field type in data reference

### DIFF
--- a/frontend/src/metabase/reference/components/Field.jsx
+++ b/frontend/src/metabase/reference/components/Field.jsx
@@ -44,7 +44,11 @@ const Field = ({ field, foreignKeys, url, icon, isEditing, formField }) => (
           {isEditing ? (
             <Select
               placeholder={t`Select a field type`}
-              value={formField.semantic_type.value || field.semantic_type}
+              value={
+                formField.semantic_type.value !== ""
+                  ? formField.semantic_type.value
+                  : field.semantic_type
+              }
               onChange={({ target: { value } }) =>
                 formField.semantic_type.onChange(value)
               }

--- a/frontend/test/metabase/scenarios/onboarding/reference/reproductions/5276-remove-field-type.cy.spec.js
+++ b/frontend/test/metabase/scenarios/onboarding/reference/reproductions/5276-remove-field-type.cy.spec.js
@@ -1,0 +1,25 @@
+import { popover, restore } from "__support__/e2e/cypress";
+
+describe("issue 5276", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+    cy.intercept("PUT", "/api/field/*").as("updateField");
+  });
+
+  it("should allow removing the field type (metabase#5276)", () => {
+    cy.visit("/reference/databases");
+
+    cy.findByText("Sample Database").click();
+    cy.findByText("Tables in Sample Database").click();
+    cy.findByText("Products").click();
+    cy.findByText("Fields in this table").click();
+    cy.findByText("Edit").click();
+
+    cy.findByText("Score").click();
+    popover().within(() => cy.findByText("No field type").click());
+    cy.button("Save").click();
+    cy.wait("@updateField");
+    cy.findByText("Score").should("not.exist");
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/5276
Reproduces https://github.com/metabase/metabase/issues/5276

How to test:
- Open http://localhost:3000/reference/databases/1/tables/1/fields
- Remove the field type on `Score` field