### PR TITLE
Prevent triggering backport when adding other labels after merge

### DIFF
--- a/.github/workflows/auto-backport.yml
+++ b/.github/workflows/auto-backport.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   create-backport:
-    if: github.event.pull_request.merged == true && (contains(github.event.pull_request.labels.*.name, 'backport') || github.event.label.name == 'backport')
+    if: github.event.pull_request.merged == true && (contains(github.event.pull_request.labels.*.name, 'backport') && github.event.action == 'closed' || github.event.label.name == 'backport')
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
## Changes

Fixes triggering automatic backport when:
- PR already merged with the backport label
- Any other label has been added

## How to verify
- Try this scenario on your fork of Metabase