### PR TITLE
XLSX formatting for temporal breakout fields

### DIFF
--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -246,8 +246,8 @@
 (defn- default-format-strings
   "Default strings to use for datetime and number fields if custom format settings are not set."
   []
-  {:datetime "mmmm d, yyyy" (datetime-format-string (merge-global-settings {} :type/Temporal))
-   :date     "mmmm d, yyyy" (datetime-format-string (merge-global-settings {::mb.viz/time-enabled nil} :type/Temporal))
+  {:datetime (datetime-format-string (merge-global-settings {} :type/Temporal))
+   :date     (datetime-format-string (merge-global-settings {::mb.viz/time-enabled nil} :type/Temporal))
    ;; Use a fixed format for time fields since time formatting isn't currently supported (#17357)
    :time     "h:mm am/pm"
    :integer  "#,##0"
@@ -304,8 +304,8 @@
   to format strings."
   (memoize
    (fn [^Workbook workbook cols col-settings]
-     (let [data-format   (. workbook createDataFormat)
-           col-styles    (column-style-delays workbook data-format col-settings cols)]
+     (let [data-format (. workbook createDataFormat)
+           col-styles  (column-style-delays workbook data-format col-settings cols)]
        (into col-styles
              (for [[name-keyword format-string] (seq (default-format-strings))]
                {name-keyword (format-string-delay workbook data-format format-string)}))))))

--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -3,6 +3,7 @@
             [clojure.string :as str]
             [dk.ative.docjure.spreadsheet :as spreadsheet]
             [java-time :as t]
+            [metabase.mbql.schema :as mbql.s]
             [metabase.public-settings :as public-settings]
             [metabase.query-processor.streaming.common :as common]
             [metabase.query-processor.streaming.interface :as qp.si]
@@ -156,55 +157,78 @@
   (let [separator (::mb.viz/date-separator format-settings "/")]
     (str/replace format-string "/" separator)))
 
-(defn- add-time-format
-  [format-settings format-string]
+(defn- time-format
+  [format-settings]
   (let [base-time-format (condp = (::mb.viz/time-enabled format-settings "minutes")
-                           "minutes"
-                           "h:mm"
+                               "minutes"
+                               "h:mm"
 
-                           "seconds"
-                           "h:mm:ss"
+                               "seconds"
+                               "h:mm:ss"
 
-                           "milliseconds"
-                           "h:mm:ss.000"
+                               "milliseconds"
+                               "h:mm:ss.000"
 
-                           ;; {::mb.viz/time-enabled nil} indicates that time is explicitly disabled, rather than
-                           ;; defaulting to "minutes"
-                           nil
-                           nil)
-        time-format      (when base-time-format
-                           (condp = (::mb.viz/time-style format-settings "h:mm A")
-                             "HH:mm"
-                             (str "h" base-time-format)
+                               ;; {::mb.viz/time-enabled nil} indicates that time is explicitly disabled, rather than
+                               ;; defaulting to "minutes"
+                               nil
+                               nil)]
+    (when base-time-format
+      (condp = (::mb.viz/time-style format-settings "h:mm A")
+        "HH:mm"
+        (str "h" base-time-format)
 
-                             ;; Deprecated time style which should be already converted to HH:mm when viz settings are
-                             ;; normalized, but we'll handle it here too just in case. (#18112)
-                             "k:mm"
-                             (str "h" base-time-format)
+        ;; Deprecated time style which should be already converted to HH:mm when viz settings are
+        ;; normalized, but we'll handle it here too just in case. (#18112)
+        "k:mm"
+        (str "h" base-time-format)
 
-                             "h:mm A"
-                             (str base-time-format " am/pm")
+        "h:mm A"
+        (str base-time-format " am/pm")
 
-                             "h A"
-                             "h am/pm"))]
-    (if time-format
+        "h A"
+        "h am/pm"))))
+
+(defn- add-time-format
+  "Adds the appropriate time setting to a date format string if necessary, producing a datetime format string."
+  [format-settings unit format-string]
+  (if (or (not unit) (mbql.s/time-bucketing-units unit))
+    (if-let [time-format (time-format format-settings)]
       (str format-string ", " time-format)
-      format-string)))
+      format-string)
+    format-string))
+
+(def ^:private month-style-overrides
+  "Overrides for the date-style in a column's viz settings if :unit is :month."
+  {"M/D/YYYY"     "m/yyyy"
+   "YYYY/M/D"     "yyyy/m"
+   "MMMM D, YYYY" "mmmm, yyyy"})
+
+(defn- date-format
+  [format-settings unit]
+  (let [base-style (::mb.viz/date-style format-settings "mmmm d, yyyy")
+        unit-style (case unit
+                     :month (get month-style-overrides base-style)
+                     :year "yyyy"
+                     base-style)]
+    (->> unit-style
+         str/lower-case
+         (abbreviate-date-names format-settings)
+         (replace-date-separators format-settings))))
 
 (defn- datetime-format-string
-  [format-settings]
-  (let [merged-settings (merge-global-settings format-settings :type/Temporal)
-        date-style      (::mb.viz/date-style merged-settings "mmmm d, yyyy")]
-    (->> date-style
-         str/lower-case
-         (abbreviate-date-names merged-settings)
-         (replace-date-separators merged-settings)
-         (add-time-format merged-settings))))
+  ([format-settings]
+   (datetime-format-string format-settings nil))
+
+  ([format-settings unit]
+   (let [merged-settings (merge-global-settings format-settings :type/Temporal)]
+     (->> (date-format merged-settings unit)
+          (add-time-format merged-settings unit)))))
 
 (defn- format-settings->format-strings
   "Returns a vector of format strings for a datetime column or number column, corresponding
   to the provided format settings."
-  [format-settings {semantic-type :semantic_type, effective-type :effective_type, :as _col}]
+  [format-settings {semantic-type :semantic_type, effective-type :effective_type, unit :unit}]
   (u/one-or-many
    (cond
      ;; Primary key or foreign key
@@ -214,7 +238,7 @@
      (and (or (some #(contains? datetime-setting-keys %) (keys format-settings))
               (isa? semantic-type :type/Temporal))
           (isa? effective-type :type/Temporal))
-     (datetime-format-string format-settings)
+     (datetime-format-string format-settings unit)
 
      (or (some #(contains? number-setting-keys %) (keys format-settings))
          (isa? semantic-type :type/Currency))
@@ -223,8 +247,8 @@
 (defn- default-format-strings
   "Default strings to use for datetime and number fields if custom format settings are not set."
   []
-  {:datetime (datetime-format-string (merge-global-settings {} :type/Temporal))
-   :date     (datetime-format-string (merge-global-settings {::mb.viz/time-enabled nil} :type/Temporal))
+  {:datetime "mmmm d, yyyy" (datetime-format-string (merge-global-settings {} :type/Temporal))
+   :date     "mmmm d, yyyy" (datetime-format-string (merge-global-settings {::mb.viz/time-enabled nil} :type/Temporal))
    ;; Use a fixed format for time fields since time formatting isn't currently supported (#17357)
    :time     "h:mm am/pm"
    :integer  "#,##0"

--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -200,19 +200,18 @@
 
 (def ^:private month-style-overrides
   "Overrides for the date-style in a column's viz settings if :unit is :month."
-  {"M/D/YYYY"     "m/yyyy"
-   "YYYY/M/D"     "yyyy/m"
-   "MMMM D, YYYY" "mmmm, yyyy"})
+  {"m/d/yyyy"     "m/yyyy"
+   "yyyy/m/d"     "yyyy/m"
+   "mmmm d, yyyy" "mmmm, yyyy"})
 
 (defn- date-format
   [format-settings unit]
-  (let [base-style (::mb.viz/date-style format-settings "mmmm d, yyyy")
+  (let [base-style (str/lower-case (::mb.viz/date-style format-settings "mmmm d, yyyy"))
         unit-style (case unit
                      :month (get month-style-overrides base-style)
                      :year "yyyy"
                      base-style)]
     (->> unit-style
-         str/lower-case
          (abbreviate-date-names format-settings)
          (replace-date-separators format-settings))))
 

--- a/test/metabase/query_processor/streaming/xlsx_test.clj
+++ b/test/metabase/query_processor/streaming/xlsx_test.clj
@@ -19,9 +19,8 @@
   ([format-settings]
    (format-string format-settings nil))
 
-  ([format-settings semantic-type]
-   (let [format-strings (@#'qp.xlsx/format-settings->format-strings format-settings {:semantic_type  semantic-type
-                                                                                     :effective_type :type/Temporal})]
+  ([format-settings col]
+   (let [format-strings (@#'qp.xlsx/format-settings->format-strings format-settings col)]
      ;; If only one format string is returned (for datetimes) or both format strings
      ;; are equal, just return a single value to make tests more readable.
      (cond
@@ -110,126 +109,137 @@
                                                                   ::mb.viz/suffix "suffix"})))))
 
     (testing "Currency formatting"
-      (testing "Default currency formatting is dollar sign"
-        (is (= "[$$]#,##0.00" (format-string {::mb.viz/currency-in-header false} :type/Price))))
+      (let [price-col {:semantic_type :type/Price, :effective_type :type/Float}]
+        (testing "Default currency formatting is dollar sign"
+          (is (= "[$$]#,##0.00" (format-string {::mb.viz/currency-in-header false} price-col))))
 
-      (testing "Uses native currency symbol if supported"
-        (is (= "[$$]#,##0.00"   (format-string {::mb.viz/currency-in-header false, ::mb.viz/currency "USD"} :type/Price)))
-        (is (= "[$CA$]#,##0.00" (format-string {::mb.viz/currency-in-header false, ::mb.viz/currency "CAD"} :type/Price)))
-        (is (= "[$€]#,##0.00"   (format-string {::mb.viz/currency-in-header false, ::mb.viz/currency "EUR"} :type/Price)))
-        (is (= "[$¥]#,##0.00"   (format-string {::mb.viz/currency-in-header false, ::mb.viz/currency "JPY"} :type/Price))))
+        (testing "Uses native currency symbol if supported"
+          (is (= "[$$]#,##0.00"   (format-string {::mb.viz/currency-in-header false, ::mb.viz/currency "USD"} price-col)))
+          (is (= "[$CA$]#,##0.00" (format-string {::mb.viz/currency-in-header false, ::mb.viz/currency "CAD"} price-col)))
+          (is (= "[$€]#,##0.00"   (format-string {::mb.viz/currency-in-header false, ::mb.viz/currency "EUR"} price-col)))
+          (is (= "[$¥]#,##0.00"   (format-string {::mb.viz/currency-in-header false, ::mb.viz/currency "JPY"} price-col))))
 
-      (testing "Falls back to code if native symbol not supported"
-        (is (= "[$KGS] #,##0.00" (format-string {::mb.viz/currency-in-header false, ::mb.viz/currency "KGS"} :type/Price)))
-        (is (= "[$KGS] #,##0.00" (format-string {::mb.viz/currency-in-header false,
-                                                 ::mb.viz/currency "KGS",
-                                                 ::mb.viz/currency-style "symbol"}
-                                                :type/Price))))
+        (testing "Falls back to code if native symbol not supported"
+          (is (= "[$KGS] #,##0.00" (format-string {::mb.viz/currency-in-header false, ::mb.viz/currency "KGS"} price-col)))
+          (is (= "[$KGS] #,##0.00" (format-string {::mb.viz/currency-in-header false,
+                                                   ::mb.viz/currency "KGS",
+                                                   ::mb.viz/currency-style "symbol"}
+                                                  price-col))))
 
-      (testing "Respects currency-style option"
-        (is (= "[$$]#,##0.00"            (format-string {::mb.viz/currency-in-header false,
-                                                         ::mb.viz/currency-style "symbol"}
-                                                        :type/Price)))
-        (is (= "[$USD] #,##0.00"         (format-string {::mb.viz/currency-in-header false,
-                                                         ::mb.viz/currency-style "code"}
-                                                        :type/Price)))
-        (is (= "#,##0.00\" US dollars\"" (format-string {::mb.viz/currency-in-header false,
-                                                         ::mb.viz/currency-style "name"}
-                                                        :type/Price)))
-        (is (= "[$€]#,##0.00"            (format-string {::mb.viz/currency-in-header false,
-                                                         ::mb.viz/currency "EUR",
-                                                         ::mb.viz/currency-style "symbol"}
-                                                        :type/Price)))
-        (is (= "[$EUR] #,##0.00"         (format-string {::mb.viz/currency-in-header false,
-                                                         ::mb.viz/currency "EUR",
-                                                         ::mb.viz/currency-style "code"}
-                                                        :type/Price)))
-        (is (= "#,##0.00\" euros\""      (format-string {::mb.viz/currency-in-header false,
-                                                         ::mb.viz/currency "EUR",
-                                                         ::mb.viz/currency-style "name"}
-                                                        :type/Price))))
+        (testing "Respects currency-style option"
+          (is (= "[$$]#,##0.00"            (format-string {::mb.viz/currency-in-header false,
+                                                           ::mb.viz/currency-style "symbol"}
+                                                          price-col)))
+          (is (= "[$USD] #,##0.00"         (format-string {::mb.viz/currency-in-header false,
+                                                           ::mb.viz/currency-style "code"}
+                                                          price-col)))
+          (is (= "#,##0.00\" US dollars\"" (format-string {::mb.viz/currency-in-header false,
+                                                           ::mb.viz/currency-style "name"}
+                                                          price-col)))
+          (is (= "[$€]#,##0.00"            (format-string {::mb.viz/currency-in-header false,
+                                                           ::mb.viz/currency "EUR",
+                                                           ::mb.viz/currency-style "symbol"}
+                                                          price-col)))
+          (is (= "[$EUR] #,##0.00"         (format-string {::mb.viz/currency-in-header false,
+                                                           ::mb.viz/currency "EUR",
+                                                           ::mb.viz/currency-style "code"}
+                                                          price-col)))
+          (is (= "#,##0.00\" euros\""      (format-string {::mb.viz/currency-in-header false,
+                                                           ::mb.viz/currency "EUR",
+                                                           ::mb.viz/currency-style "name"}
+                                                          price-col))))
 
-      (testing "Currency not included for non-currency semantic types"
-        (is (= "#,##0.00" (format-string {::mb.viz/currency-in-header false} :type/Quantity))))
+        (testing "Currency not included for non-currency semantic types"
+          (is (= "#,##0.00" (format-string {::mb.viz/currency-in-header false} {:semantic_type :type/Quantity}))))
 
-      (testing "Formatting options are ignored if currency-in-header is true or absent (defaults to true)"
-        (is (= "#,##0.00" (format-string {::mb.viz/currency-style "symbol"} :type/Price)))
-        (is (= "#,##0.00" (format-string {::mb.viz/currency-style "name"} :type/Price)))
-        (is (= "#,##0.00" (format-string {::mb.viz/currency-style "code"} :type/Price)))
-        (is (= "#,##0.00" (format-string {::mb.viz/currency "USD"} :type/Price)))
-        (is (= "#,##0.00" (format-string {::mb.viz/currency "EUR"} :type/Price)))
-        (is (= "#,##0.00" (format-string {::currency-in-header true, ::mb.viz/currency-style "symbol"} :type/Price)))
-        (is (= "#,##0.00" (format-string {::currency-in-header true, ::mb.viz/currency-style "name"} :type/Price)))
-        (is (= "#,##0.00" (format-string {::currency-in-header true, ::mb.viz/currency-style "code"} :type/Price)))
-        (is (= "#,##0.00" (format-string {::currency-in-header true, ::mb.viz/currency "USD"} :type/Price)))
-        (is (= "#,##0.00" (format-string {::currency-in-header true, ::mb.viz/currency "EUR"} :type/Price))))
+        (testing "Formatting options are ignored if currency-in-header is true or absent (defaults to true)"
+          (is (= "#,##0.00" (format-string {::mb.viz/currency-style "symbol"} price-col)))
+          (is (= "#,##0.00" (format-string {::mb.viz/currency-style "name"} price-col)))
+          (is (= "#,##0.00" (format-string {::mb.viz/currency-style "code"} price-col)))
+          (is (= "#,##0.00" (format-string {::mb.viz/currency "USD"} price-col)))
+          (is (= "#,##0.00" (format-string {::mb.viz/currency "EUR"} price-col)))
+          (is (= "#,##0.00" (format-string {::currency-in-header true, ::mb.viz/currency-style "symbol"} price-col)))
+          (is (= "#,##0.00" (format-string {::currency-in-header true, ::mb.viz/currency-style "name"} price-col)))
+          (is (= "#,##0.00" (format-string {::currency-in-header true, ::mb.viz/currency-style "code"} price-col)))
+          (is (= "#,##0.00" (format-string {::currency-in-header true, ::mb.viz/currency "USD"} price-col)))
+          (is (= "#,##0.00" (format-string {::currency-in-header true, ::mb.viz/currency "EUR"} price-col))))
 
-      (testing "Global localization settings are incorporated with lower precedence than column format settings"
-        (mt/with-temporary-setting-values [custom-formatting {:type/Currency {:currency "EUR",
-                                                                              :currency_in_header false,
-                                                                              :currency_style "code"}}]
-          (is (= "[$EUR] #,##0.00" (format-string {} :type/Price)))
-          (is (= "[$CAD] #,##0.00" (format-string {::mb.viz/currency "CAD"} :type/Price)))
-          (is (= "[$€]#,##0.00"    (format-string {::mb.viz/currency-style "symbol"} :type/Price)))
-          (is (= "#,##0.00"        (format-string {::mb.viz/currency-in-header true} :type/Price))))))
+        (testing "Global localization settings are incorporated with lower precedence than column format settings"
+          (mt/with-temporary-setting-values [custom-formatting {:type/Currency {:currency "EUR",
+                                                                                :currency_in_header false,
+                                                                                :currency_style "code"}}]
+            (is (= "[$EUR] #,##0.00" (format-string {} price-col)))
+            (is (= "[$CAD] #,##0.00" (format-string {::mb.viz/currency "CAD"} price-col)))
+            (is (= "[$€]#,##0.00"    (format-string {::mb.viz/currency-style "symbol"} price-col)))
+            (is (= "#,##0.00"        (format-string {::mb.viz/currency-in-header true} price-col)))))))
 
     (testing "Datetime formatting"
-      (testing "date-style"
-        (is (= "m/d/yyyy, h:mm am/pm"           (format-string {::mb.viz/date-style "M/D/YYYY"})))
-        (is (= "d/m/yyyy, h:mm am/pm"           (format-string {::mb.viz/date-style "D/M/YYYY"})))
-        (is (= "yyyy/m/d, h:mm am/pm"           (format-string {::mb.viz/date-style "YYYY/M/D"})))
-        (is (= "mmmm d, yyyy, h:mm am/pm"       (format-string {::mb.viz/date-style "MMMM D, YYYY"})))
-        (is (= "dmmmm, yyyy, h:mm am/pm"        (format-string {::mb.viz/date-style "DMMMM, YYYY"})))
-        (is (= "dddd, mmmm d, yyyy, h:mm am/pm" (format-string {::mb.viz/date-style "dddd, MMMM D, YYYY"}))))
+      (let [date-col {:semantic_type :type/CreationTimestamp, :effective_type :type/Temporal}]
+        (testing "date-style"
+          (is (= "m/d/yyyy, h:mm am/pm"           (format-string {::mb.viz/date-style "M/D/YYYY"} date-col)))
+          (is (= "d/m/yyyy, h:mm am/pm"           (format-string {::mb.viz/date-style "D/M/YYYY"} date-col)))
+          (is (= "yyyy/m/d, h:mm am/pm"           (format-string {::mb.viz/date-style "YYYY/M/D"} date-col)))
+          (is (= "mmmm d, yyyy, h:mm am/pm"       (format-string {::mb.viz/date-style "MMMM D, YYYY"} date-col)))
+          (is (= "dmmmm, yyyy, h:mm am/pm"        (format-string {::mb.viz/date-style "DMMMM, YYYY"} date-col)))
+          (is (= "dddd, mmmm d, yyyy, h:mm am/pm" (format-string {::mb.viz/date-style "dddd, MMMM D, YYYY"} date-col))))
 
-      (testing "date-separator"
-        (is (= "m/d/yyyy, h:mm am/pm" (format-string {::mb.viz/date-style "M/D/YYYY", ::mb.viz/date-separator "/"})))
-        (is (= "m.d.yyyy, h:mm am/pm" (format-string {::mb.viz/date-style "M/D/YYYY", ::mb.viz/date-separator "."})))
-        (is (= "m-d-yyyy, h:mm am/pm" (format-string {::mb.viz/date-style "M/D/YYYY", ::mb.viz/date-separator "-"}))))
+        (testing "date-separator"
+          (is (= "m/d/yyyy, h:mm am/pm" (format-string {::mb.viz/date-style "M/D/YYYY", ::mb.viz/date-separator "/"} date-col)))
+          (is (= "m.d.yyyy, h:mm am/pm" (format-string {::mb.viz/date-style "M/D/YYYY", ::mb.viz/date-separator "."} date-col)))
+          (is (= "m-d-yyyy, h:mm am/pm" (format-string {::mb.viz/date-style "M/D/YYYY", ::mb.viz/date-separator "-"} date-col))))
 
-      (testing "date-abbreviate"
-        (is (= "mmm d, yyyy, h:mm am/pm"        (format-string {::mb.viz/date-abbreviate true})))
-        (is (= "mmmm d, yyyy, h:mm am/pm"       (format-string {::mb.viz/date-abbreviate false})))
-        (is (= "ddd, mmm d, yyyy, h:mm am/pm"   (format-string {::mb.viz/date-abbreviate true
-                                                                ::mb.viz/date-style, "dddd, MMMM D, YYYY"})))
-        (is (= "dddd, mmmm d, yyyy, h:mm am/pm" (format-string {::mb.viz/date-abbreviate false
-                                                                ::mb.viz/date-style, "dddd, MMMM D, YYYY"}))))
+        (testing "date-abbreviate"
+          (is (= "mmm d, yyyy, h:mm am/pm"        (format-string {::mb.viz/date-abbreviate true} date-col)))
+          (is (= "mmmm d, yyyy, h:mm am/pm"       (format-string {::mb.viz/date-abbreviate false} date-col)))
+          (is (= "ddd, mmm d, yyyy, h:mm am/pm"   (format-string {::mb.viz/date-abbreviate true
+                                                                  ::mb.viz/date-style, "dddd, MMMM D, YYYY"} date-col)))
+          (is (= "dddd, mmmm d, yyyy, h:mm am/pm" (format-string {::mb.viz/date-abbreviate false
+                                                                  ::mb.viz/date-style, "dddd, MMMM D, YYYY"} date-col))))
 
-      (testing "time-style"
-        (is (= "mmmm d, yyyy, hh:mm"      (format-string {::mb.viz/time-style "HH:mm"})))
-        (is (= "mmmm d, yyyy, hh:mm"      (format-string {::mb.viz/time-style "k:mm"})))
-        (is (= "mmmm d, yyyy, h:mm am/pm" (format-string {::mb.viz/time-style "h:mm A"})))
-        (is (= "mmmm d, yyyy, h am/pm"    (format-string {::mb.viz/time-style "h A"}))))
+        (testing "time-style"
+          (is (= "mmmm d, yyyy, hh:mm"      (format-string {::mb.viz/time-style "HH:mm"} date-col)))
+          (is (= "mmmm d, yyyy, hh:mm"      (format-string {::mb.viz/time-style "k:mm"} date-col)))
+          (is (= "mmmm d, yyyy, h:mm am/pm" (format-string {::mb.viz/time-style "h:mm A"} date-col)))
+          (is (= "mmmm d, yyyy, h am/pm"    (format-string {::mb.viz/time-style "h A"} date-col))))
 
-      (testing "time-enabled"
-        (is (= "mmmm d, yyyy"                    (format-string {::mb.viz/time-enabled nil})))
-        (is (= "mmmm d, yyyy, h:mm am/pm"        (format-string {::mb.viz/time-enabled "minutes"})))
-        (is (= "mmmm d, yyyy, h:mm:ss am/pm"     (format-string {::mb.viz/time-enabled "seconds"})))
-        (is (= "mmmm d, yyyy, h:mm:ss.000 am/pm" (format-string {::mb.viz/time-enabled "milliseconds"})))
-        ;; time-enabled overrides time-styled
-        (is (= "mmmm d, yyyy"                    (format-string {::mb.viz/time-style "h:mm A", ::mb.viz/time-enabled nil}))))
+        (testing "time-enabled"
+          (is (= "mmmm d, yyyy"                    (format-string {::mb.viz/time-enabled nil} date-col)))
+          (is (= "mmmm d, yyyy, h:mm am/pm"        (format-string {::mb.viz/time-enabled "minutes"} date-col)))
+          (is (= "mmmm d, yyyy, h:mm:ss am/pm"     (format-string {::mb.viz/time-enabled "seconds"} date-col)))
+          (is (= "mmmm d, yyyy, h:mm:ss.000 am/pm" (format-string {::mb.viz/time-enabled "milliseconds"} date-col)))
+          ;; time-enabled overrides time-styled
+          (is (= "mmmm d, yyyy"                    (format-string {::mb.viz/time-style "h:mm A", ::mb.viz/time-enabled nil} date-col))))
 
-      (testing "misc combinations"
-        (is (= "yyyy.m.d, h:mm:ss am/pm"          (format-string {::mb.viz/date-style "YYYY/M/D",
-                                                                  ::mb.viz/date-separator ".",
-                                                                  ::mb.viz/time-style "h:mm A",
-                                                                  ::mb.viz/time-enabled "seconds"})))
-        (is (= "dddd, mmmm d, yyyy, hh:mm:ss.000" (format-string {::mb.viz/date-style "dddd, MMMM D, YYYY",
-                                                                  ::mb.viz/time-style "HH:mm",
-                                                                  ::mb.viz/time-enabled "milliseconds"}))))
+        (testing ":unit values on temporal breakout fields"
+          (let [month-col (assoc date-col :unit :month)
+                year-col  (assoc date-col :unit :year)]
+            (is (= "mmmm, yyyy" (format-string {} month-col)))
+            (is (= "m/yyyy"     (format-string {::mb.viz/date-style "M/D/YYYY"} month-col)))
+            (is (= "yyyy/m"     (format-string {::mb.viz/date-style "YYYY/M/D"} month-col)))
+            (is (= "yyyy"       (format-string {} year-col)))
+            (is (= "yyyy"       (format-string {::mb.viz/date-style "M/D/YYYY"} year-col)))))
 
-      (testing "Global localization settings are incorporated with lower precedence than column format settings"
-        (mt/with-temporary-setting-values [custom-formatting {:type/Temporal {:date_style "YYYY/M/D",
-                                                                              :date_separator ".",
-                                                                              :time_style "HH:mm"}}]
-          (is (= "yyyy.m.d, hh:mm"      (format-string {} :type/DateTime)))
-          (is (= "d.m.yyyy, hh:mm"      (format-string {::mb.viz/date-style "D/M/YYYY"} :type/DateTime)))
-          (is (= "yyyy-m-d, hh:mm"      (format-string {::mb.viz/date-separator "-"} :type/DateTime)))
-          (is (= "yyyy.m.d, h:mm am/pm" (format-string {::mb.viz/time-style "h:mm A"} :type/DateTime))))))
+        (testing "misc combinations"
+          (is (= "yyyy.m.d, h:mm:ss am/pm"          (format-string {::mb.viz/date-style "YYYY/M/D",
+                                                                    ::mb.viz/date-separator ".",
+                                                                    ::mb.viz/time-style "h:mm A",
+                                                                    ::mb.viz/time-enabled "seconds"} date-col)))
+          (is (= "dddd, mmmm d, yyyy, hh:mm:ss.000" (format-string {::mb.viz/date-style "dddd, MMMM D, YYYY",
+                                                                    ::mb.viz/time-style "HH:mm",
+                                                                    ::mb.viz/time-enabled "milliseconds"} date-col))))
+
+        (testing "Global localization settings are incorporated with lower precedence than column format settings"
+          (mt/with-temporary-setting-values [custom-formatting {:type/Temporal {:date_style "YYYY/M/D",
+                                                                                :date_separator ".",
+                                                                                :time_style "HH:mm"}}]
+            (is (= "yyyy.m.d, hh:mm"      (format-string {} date-col)))
+            (is (= "d.m.yyyy, hh:mm"      (format-string {::mb.viz/date-style "D/M/YYYY"} date-col)))
+            (is (= "yyyy-m-d, hh:mm"      (format-string {::mb.viz/date-separator "-"} date-col)))
+            (is (= "yyyy.m.d, h:mm am/pm" (format-string {::mb.viz/time-style "h:mm A"} date-col)))))))
 
     (testing "primary key and foreign key formatting"
-      (is (= "0" (format-string {} :type/PK)))
-      (is (= "0" (format-string {} :type/FK))))))
+      (is (= "0" (format-string {} {:semantic_type :type/PK})))
+      (is (= "0" (format-string {} {:semantic_type :type/FK}))))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                               XLSX export tests                                                |


### PR DESCRIPTION
* Only add time format to the format string if `unit` is in the set of `time-bucketing-units`, or is `nil`.
* Use specific format string overrides for the `:month` unit
* Always use `yyyy` format string for the `:year` unit
* A bit of code & test refactor

Resolves #18219