### PR TITLE
Persisted batched-hyrdation is checking wrong id

### DIFF
--- a/src/metabase/models/persisted_info.clj
+++ b/src/metabase/models/persisted_info.clj
@@ -73,7 +73,7 @@
   {:batched-hydrate :persisted}
   [cards]
   (when (seq cards)
-    (let [existing-ids (db/select-ids PersistedInfo :card_id [:in (map :id cards)])]
+    (let [existing-ids (db/select-field :card_id PersistedInfo :card_id [:in (map :id cards)])]
       (map (fn [{id :id :as card}]
              (assoc card :persisted (contains? existing-ids id)))
            cards))))


### PR DESCRIPTION
- The check needs to be done against card_id, but `select-ids` returns `persisted-info.id`.
