### PR TITLE
[E2E] Experiment running `custom-column` test group as PR check

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -63,6 +63,7 @@ jobs:
           - "dashboard-filters"
           - "downloads"
           - "joins"
+          - "custom-column"
     services:
       maildev:
         image: maildev/maildev:1.1.0


### PR DESCRIPTION
Adding `custom-column` test group as PR check

Data:
[custom-column OSS](https://github.com/metabase/metabase/runs/6174593642?check_suite_focus=true) vs [custom-column EE](https://github.com/metabase/metabase/runs/6174595443?check_suite_focus=true)
| e2e-tests-custom-column                       | total | passing | pending  |
|---------------------------|--------|-------|-------|
| OSS                  | 50   | 41  | 9  |
| EE                 | 50   | 41  | 9  |