### PR TITLE
Enable detail view for any row

### DIFF
--- a/frontend/src/metabase-lib/lib/Question.ts
+++ b/frontend/src/metabase-lib/lib/Question.ts
@@ -285,6 +285,10 @@ class QuestionInner {
     return this.setCard(assoc(this.card(), "display", display));
   }
 
+  /**
+   * returns whether this question is a model
+   * @returns boolean
+   */
   isDataset() {
     return this._card && this._card.dataset;
   }

--- a/frontend/src/metabase/modes/components/drill/ObjectDetailDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/ObjectDetailDrill.jsx
@@ -3,8 +3,10 @@ import { isFK, isPK } from "metabase/lib/schema_metadata";
 import { zoomInRow } from "metabase/query_builder/actions";
 
 function hasManyPKColumns(question) {
-  const table = question.query().table();
-  const fields = table?.fields ?? question.getResultMetadata();
+  const fields = question.isDataset()
+    ? question.getResultMetadata() ?? question.query().table?.()?.fields
+    : question.query().table?.()?.fields ?? question.getResultMetadata();
+
   return fields.filter(field => isPK(field)).length > 1;
 }
 

--- a/frontend/src/metabase/query_builder/actions/object-detail.js
+++ b/frontend/src/metabase/query_builder/actions/object-detail.js
@@ -24,7 +24,7 @@ export const zoomInRow = ({ objectId }) => (dispatch, getState) => {
   dispatch({ type: ZOOM_IN_ROW, payload: { objectId } });
 
   // don't show object id in url if it is a row index
-  const hasPK = getPKColumnIndex(getState()) === -1;
+  const hasPK = getPKColumnIndex(getState()) !== -1;
   !hasPK && dispatch(updateUrl(null, { objectId, replaceState: false }));
 };
 

--- a/frontend/src/metabase/query_builder/actions/object-detail.js
+++ b/frontend/src/metabase/query_builder/actions/object-detail.js
@@ -11,6 +11,7 @@ import { FieldDimension } from "metabase-lib/lib/Dimension";
 import {
   getCard,
   getFirstQueryResult,
+  getPKColumnIndex,
   getNextRowPKValue,
   getPreviousRowPKValue,
   getTableForeignKeys,
@@ -19,9 +20,12 @@ import { setCardAndRun } from "./core";
 import { updateUrl } from "./navigation";
 
 export const ZOOM_IN_ROW = "metabase/qb/ZOOM_IN_ROW";
-export const zoomInRow = ({ objectId }) => dispatch => {
+export const zoomInRow = ({ objectId }) => (dispatch, getState) => {
   dispatch({ type: ZOOM_IN_ROW, payload: { objectId } });
-  dispatch(updateUrl(null, { objectId, replaceState: false }));
+
+  // don't show object id in url if it is a row index
+  const hasPK = getPKColumnIndex(getState()) === -1;
+  !hasPK && dispatch(updateUrl(null, { objectId, replaceState: false }));
 };
 
 export const RESET_ROW_ZOOM = "metabase/qb/RESET_ROW_ZOOM";

--- a/frontend/src/metabase/query_builder/actions/object-detail.js
+++ b/frontend/src/metabase/query_builder/actions/object-detail.js
@@ -25,7 +25,7 @@ export const zoomInRow = ({ objectId }) => (dispatch, getState) => {
 
   // don't show object id in url if it is a row index
   const hasPK = getPKColumnIndex(getState()) !== -1;
-  !hasPK && dispatch(updateUrl(null, { objectId, replaceState: false }));
+  hasPK && dispatch(updateUrl(null, { objectId, replaceState: false }));
 };
 
 export const RESET_ROW_ZOOM = "metabase/qb/RESET_ROW_ZOOM";

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -151,6 +151,9 @@ export const getPKRowIndexMap = createSelector(
       return {};
     }
     const { rows } = result.data;
+    if (PKColumnIndex < 0) {
+      return rows.map((_, index) => index);
+    }
     const map = {};
     rows.forEach((row, index) => {
       const PKValue = row[PKColumnIndex];
@@ -426,6 +429,9 @@ export const getPreviousRowPKValue = createSelector(
     if (!result) {
       return;
     }
+    if (PKColumnIndex === -1) {
+      return rowIndex - 1;
+    }
     const { rows } = result.data;
     return rows[rowIndex - 1][PKColumnIndex];
   },
@@ -436,6 +442,9 @@ export const getNextRowPKValue = createSelector(
   (result, PKColumnIndex, rowIndex) => {
     if (!result) {
       return;
+    }
+    if (PKColumnIndex === -1) {
+      return rowIndex + 1;
     }
     const { rows } = result.data;
     return rows[rowIndex + 1][PKColumnIndex];

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -140,6 +140,10 @@ export const getPKColumnIndex = createSelector(
       return;
     }
     const { cols } = result.data;
+    const hasMultiplePks = cols.filter(isPK).length > 1;
+    if (hasMultiplePks) {
+      return -1;
+    }
     return cols.findIndex(isPK);
   },
 );

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.styled.tsx
@@ -1,13 +1,13 @@
 import styled from "@emotion/styled";
 import { breakpointMinMedium } from "metabase/styled-components/theme/media-queries";
-import colors from "metabase/lib/colors";
+import { color } from "metabase/lib/colors";
 
 interface ObjectDetailModalProps {
   wide: boolean;
 }
 
 export const ObjectDetailModal = styled.div<ObjectDetailModalProps>`
-  border: 1px solid ${colors.border};
+  border: 1px solid ${color("border")};
   border-radius: 0.5rem;
   overflow: hidden;
   ${breakpointMinMedium} {
@@ -41,7 +41,7 @@ export const ObjectRelationships = styled.div`
   overflow-y: auto;
   flex: 0 0 100%;
   padding: 2rem;
-  background-color: ${colors["bg-light"]};
+  background-color: ${color("bg-light")};
   ${breakpointMinMedium} {
     flex: 0 0 33.3333%;
     max-height: calc(80vh - 4rem);
@@ -52,7 +52,7 @@ export const CloseButton = styled.div`
   display: flex;
   margin-left: 1rem;
   padding-left: 1rem;
-  border-left: 1px solid ${colors.border};
+  border-left: 1px solid ${color("border")};
   ${breakpointMinMedium} {
     display: none;
   }

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.styled.tsx
@@ -28,6 +28,11 @@ export const ObjectDetailBodyWrapper = styled.div`
   height: calc(100vh - 8rem);
 `;
 
+export const ObjectIdLabel = styled.span`
+  color: ${color("text-medium")};
+  margin-left: 0.5rem;
+`;
+
 export const ObjectDetailsTable = styled.div`
   overflow-y: auto;
   flex: 1;

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
@@ -92,7 +92,7 @@ export interface ObjectDetailProps {
   data: DatasetData;
   question: Question;
   table: Table | null;
-  zoomedRow: unknown[] | undefined;
+  zoomedRow: unknown[];
   zoomedRowID: ObjectId;
   tableForeignKeys: ForeignKey[];
   tableForeignKeyReferences: {
@@ -228,7 +228,9 @@ export function ObjectDetailFn({
   });
 
   const displayId = getDisplayId({ cols: data.cols, zoomedRow });
-  const hasRelationships = tableForeignKeys && !!tableForeignKeys.length;
+  const hasPk = !!data.cols.find(isPK);
+  const hasRelationships =
+    tableForeignKeys && !!tableForeignKeys.length && hasPk;
 
   return (
     <Modal
@@ -259,6 +261,7 @@ export function ObjectDetailFn({
               objectName={objectName}
               zoomedRow={zoomedRow}
               settings={settings}
+              hasRelationships={hasRelationships}
               onVisualizationClick={onVisualizationClick}
               visualizationIsClickable={visualizationIsClickable}
               tableForeignKeys={tableForeignKeys}
@@ -348,6 +351,7 @@ export interface ObjectDetailBodyProps {
   objectName: string;
   zoomedRow: unknown[] | undefined;
   settings: unknown;
+  hasRelationships: boolean;
   onVisualizationClick: OnVisualizationClickType;
   visualizationIsClickable: (clicked: unknown) => boolean;
   tableForeignKeys: ForeignKey[];
@@ -362,6 +366,7 @@ export function ObjectDetailBody({
   objectName,
   zoomedRow,
   settings,
+  hasRelationships = false,
   onVisualizationClick,
   visualizationIsClickable,
   tableForeignKeys,
@@ -377,12 +382,14 @@ export function ObjectDetailBody({
         onVisualizationClick={onVisualizationClick}
         visualizationIsClickable={visualizationIsClickable}
       />
-      <Relationships
-        objectName={objectName}
-        tableForeignKeys={tableForeignKeys}
-        tableForeignKeyReferences={tableForeignKeyReferences}
-        foreignKeyClicked={followForeignKey}
-      />
+      {hasRelationships && (
+        <Relationships
+          objectName={objectName}
+          tableForeignKeys={tableForeignKeys}
+          tableForeignKeyReferences={tableForeignKeyReferences}
+          foreignKeyClicked={followForeignKey}
+        />
+      )}
     </ObjectDetailBodyWrapper>
   );
 }

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
@@ -3,6 +3,7 @@ import { connect } from "react-redux";
 import { t } from "ttag";
 
 import Question from "metabase-lib/lib/Question";
+import { isPK } from "metabase/lib/schema_metadata";
 import { Table } from "metabase-types/types/Table";
 import { ForeignKey } from "metabase-types/api/foreignKey";
 import { DatasetData } from "metabase-types/types/Dataset";
@@ -34,7 +35,12 @@ import {
 } from "metabase/query_builder/selectors";
 import { columnSettings } from "metabase/visualizations/lib/settings/column";
 
-import { getObjectName, getIdValue, getSingleResultsRow } from "./utils";
+import {
+  getObjectName,
+  getDisplayId,
+  getIdValue,
+  getSingleResultsRow,
+} from "./utils";
 import { DetailsTable } from "./ObjectDetailsTable";
 import { Relationships } from "./ObjectRelationships";
 import {
@@ -214,8 +220,14 @@ export function ObjectDetailFn({
     return null;
   }
 
-  const objectName = getObjectName({ table, question });
+  const objectName = getObjectName({
+    table,
+    question,
+    cols: data.cols,
+    zoomedRow,
+  });
 
+  const displayId = getDisplayId({ cols: data.cols, zoomedRow });
   const hasRelationships = tableForeignKeys && !!tableForeignKeys.length;
 
   return (
@@ -235,7 +247,7 @@ export function ObjectDetailFn({
             <ObjectDetailHeader
               canZoom={canZoom && (canZoomNextRow || canZoomPreviousRow)}
               objectName={objectName}
-              objectId={zoomedRowID}
+              objectId={displayId}
               canZoomPreviousRow={canZoomPreviousRow}
               canZoomNextRow={canZoomNextRow}
               viewPreviousObjectDetail={viewPreviousObjectDetail}
@@ -262,7 +274,7 @@ export function ObjectDetailFn({
 export interface ObjectDetailHeaderProps {
   canZoom: boolean;
   objectName: string;
-  objectId: ObjectId;
+  objectId: ObjectId | null | unknown;
   canZoomPreviousRow: boolean;
   canZoomNextRow: boolean;
   viewPreviousObjectDetail: () => void;
@@ -284,7 +296,10 @@ export function ObjectDetailHeader({
     <div className="Grid border-bottom relative">
       <div className="Grid-cell">
         <h2 className="p3">
-          {objectName} {objectId}
+          {objectName}
+          {objectId !== null && (
+            <span className="text-medium ml1"> {objectId}</span>
+          )}
         </h2>
       </div>
       <div className="flex align-center">

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
@@ -229,8 +229,11 @@ export function ObjectDetailFn({
 
   const displayId = getDisplayId({ cols: data.cols, zoomedRow });
   const hasPk = !!data.cols.find(isPK);
-  const hasRelationships =
-    tableForeignKeys && !!tableForeignKeys.length && hasPk;
+  const hasRelationships = !!(
+    tableForeignKeys &&
+    !!tableForeignKeys.length &&
+    hasPk
+  );
 
   return (
     <Modal
@@ -349,7 +352,7 @@ export function ObjectDetailHeader({
 export interface ObjectDetailBodyProps {
   data: DatasetData;
   objectName: string;
-  zoomedRow: unknown[] | undefined;
+  zoomedRow: unknown[];
   settings: unknown;
   hasRelationships: boolean;
   onVisualizationClick: OnVisualizationClickType;

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
@@ -92,7 +92,7 @@ export interface ObjectDetailProps {
   data: DatasetData;
   question: Question;
   table: Table | null;
-  zoomedRow: unknown[];
+  zoomedRow: unknown[] | undefined;
   zoomedRowID: ObjectId;
   tableForeignKeys: ForeignKey[];
   tableForeignKeyReferences: {
@@ -262,7 +262,7 @@ export function ObjectDetailFn({
             <ObjectDetailBody
               data={data}
               objectName={objectName}
-              zoomedRow={zoomedRow}
+              zoomedRow={zoomedRow ?? []}
               settings={settings}
               hasRelationships={hasRelationships}
               onVisualizationClick={onVisualizationClick}

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
@@ -46,6 +46,7 @@ import { Relationships } from "./ObjectRelationships";
 import {
   ObjectDetailModal,
   ObjectDetailBodyWrapper,
+  ObjectIdLabel,
   CloseButton,
   ErrorWrapper,
 } from "./ObjectDetail.styled";
@@ -303,9 +304,7 @@ export function ObjectDetailHeader({
       <div className="Grid-cell">
         <h2 className="p3">
           {objectName}
-          {objectId !== null && (
-            <span className="text-medium ml1"> {objectId}</span>
-          )}
+          {objectId !== null && <ObjectIdLabel> {objectId}</ObjectIdLabel>}
         </h2>
       </div>
       <div className="flex align-center">

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.unit.spec.tsx
@@ -60,6 +60,7 @@ describe("Object Detail", () => {
         settings={{
           column: () => null,
         }}
+        hasRelationships={false}
         onVisualizationClick={() => null}
         visualizationIsClickable={() => false}
         tableForeignKeys={[]}

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailsTable.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailsTable.tsx
@@ -114,7 +114,7 @@ export function DetailsTable({
   visualizationIsClickable,
 }: DetailsTableProps): JSX.Element {
   const { rows, cols } = data;
-  const row = zoomedRow || rows[0];
+  const row = zoomedRow;
 
   return (
     <ObjectDetailsTable>

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailsTable.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailsTable.tsx
@@ -5,6 +5,8 @@ import { t } from "ttag";
 import { DatasetData } from "metabase-types/types/Dataset";
 
 import ExpandableString from "metabase/query_builder/components/ExpandableString";
+import EmptyState from "metabase/components/EmptyState";
+
 import { isID } from "metabase/lib/schema_metadata";
 import { TYPE, isa } from "metabase/lib/types";
 import { formatValue, formatColumn } from "metabase/lib/formatting";
@@ -115,6 +117,10 @@ export function DetailsTable({
 }: DetailsTableProps): JSX.Element {
   const { cols } = data;
   const row = zoomedRow;
+
+  if (!row?.length) {
+    return <EmptyState message={t`No details found`} />;
+  }
 
   return (
     <ObjectDetailsTable>

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailsTable.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailsTable.tsx
@@ -100,7 +100,7 @@ export function DetailsTableCell({
 
 export interface DetailsTableProps {
   data: DatasetData;
-  zoomedRow: unknown[] | undefined;
+  zoomedRow: unknown[];
   settings: unknown;
   onVisualizationClick: OnVisualizationClickType;
   visualizationIsClickable: (clicked: any) => boolean;
@@ -113,7 +113,7 @@ export function DetailsTable({
   onVisualizationClick,
   visualizationIsClickable,
 }: DetailsTableProps): JSX.Element {
-  const { rows, cols } = data;
+  const { cols } = data;
   const row = zoomedRow;
 
   return (
@@ -124,7 +124,7 @@ export function DetailsTable({
             <GridCell>
               <DetailsTableCell
                 column={column}
-                value={row[columnIndex]}
+                value={row[columnIndex] ?? "Empty"}
                 isColumnName
                 settings={settings}
                 className="text-bold text-medium"

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailsTable.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailsTable.tsx
@@ -130,7 +130,7 @@ export function DetailsTable({
             <GridCell>
               <DetailsTableCell
                 column={column}
-                value={row[columnIndex] ?? "Empty"}
+                value={row[columnIndex] ?? t`Empty`}
                 isColumnName
                 settings={settings}
                 className="text-bold text-medium"

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailsTable.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailsTable.unit.spec.tsx
@@ -63,7 +63,7 @@ describe("ObjectDetailsTable", () => {
       render(
         <DetailsTable
           data={objectDetailCard.data}
-          zoomedRow={undefined}
+          zoomedRow={objectDetailCard.data.rows[0]}
           onVisualizationClick={() => null}
           visualizationIsClickable={() => false}
           settings={{}}
@@ -78,7 +78,7 @@ describe("ObjectDetailsTable", () => {
       render(
         <DetailsTable
           data={invalidObjectDetailCard.data}
-          zoomedRow={undefined}
+          zoomedRow={invalidObjectDetailCard.data.rows[0]}
           onVisualizationClick={() => null}
           visualizationIsClickable={() => false}
           settings={{}}

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectRelationships.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectRelationships.tsx
@@ -41,7 +41,7 @@ export function Relationships({
   return (
     <ObjectRelationships>
       <div className="text-bold text-medium">
-        {jt`This ${(
+        {jt`${(
           <span className="text-dark" key={objectName}>
             {objectName}
           </span>

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/utils.ts
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/utils.ts
@@ -13,7 +13,7 @@ export interface GetObjectNameArgs {
   table: Table | null;
   question: Question;
   cols: Column[];
-  zoomedRow: unknown[];
+  zoomedRow: unknown[] | undefined;
 }
 
 export const getObjectName = ({
@@ -41,7 +41,7 @@ export const getObjectName = ({
 
 export interface GetDisplayIdArgs {
   cols: Column[];
-  zoomedRow: unknown[];
+  zoomedRow: unknown[] | undefined;
 }
 
 export const getDisplayId = ({
@@ -53,6 +53,10 @@ export const getDisplayId = ({
       (pks: number, col: Column) => (isPK(col) ? pks + 1 : pks),
       0,
     ) === 1;
+
+  if (!zoomedRow) {
+    return null;
+  }
 
   if (hasSinglePk) {
     const pkColumn = cols.findIndex(isPK);

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/utils.ts
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/utils.ts
@@ -13,7 +13,7 @@ export interface GetObjectNameArgs {
   table: Table | null;
   question: Question;
   cols: Column[];
-  zoomedRow: unknown[] | undefined;
+  zoomedRow: unknown[];
 }
 
 export const getObjectName = ({
@@ -40,15 +40,11 @@ export const getObjectName = ({
 };
 
 export interface GetDisplayIdArgs {
-  table: Table | null;
-  question: Question;
   cols: Column[];
   zoomedRow: unknown[];
 }
 
 export const getDisplayId = ({
-  table,
-  question,
   cols,
   zoomedRow,
 }: GetDisplayIdArgs): ObjectId | null => {

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/utils.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/utils.unit.spec.ts
@@ -1,0 +1,165 @@
+import {
+  metadata,
+  SAMPLE_DATABASE,
+  ORDERS,
+} from "__support__/sample_database_fixture";
+
+import Question from "metabase-lib/lib/Question";
+import { Card } from "metabase-types/types/Card";
+
+import { getObjectName, getDisplayId, getIdValue } from "./utils";
+
+const card = {
+  id: 1,
+  name: "Special Orders",
+  display: "table",
+  visualization_settings: {},
+  can_write: true,
+  dataset_query: {
+    type: "query",
+    database: SAMPLE_DATABASE?.id,
+    query: {
+      "source-table": ORDERS.id,
+    },
+  },
+} as Card;
+
+describe("ObjectDetail utils", () => {
+  const idCol = {
+    name: "id",
+    display_name: "ID",
+    base_type: "int",
+    effective_type: "int",
+    semantic_type: "type/PK",
+  };
+  const qtyCol = {
+    name: "qty",
+    display_name: "qty",
+    base_type: "int",
+    effective_type: "int",
+    semantic_type: "type/int",
+  };
+  const nameCol = {
+    name: "id",
+    display_name: "ID",
+    base_type: "string",
+    effective_type: "string",
+    semantic_type: "type/Name",
+  };
+
+  describe("getObjectName", () => {
+    const question = new Question(card, metadata);
+    const table = question.table();
+
+    it("should get an entity name when there is an entity name column", () => {
+      const name = getObjectName({
+        table: null,
+        question: question,
+        cols: [idCol, qtyCol, nameCol],
+        zoomedRow: [22, 33, "Giant Sprocket"],
+      });
+
+      expect(name).toBe("Giant Sprocket");
+    });
+
+    it("should get a singularized table name if no entity name is present", () => {
+      const name = getObjectName({
+        table: table as any,
+        question: question,
+        cols: [idCol, qtyCol],
+        zoomedRow: [22, 33],
+      });
+
+      expect(name).toBe("Order");
+    });
+
+    it("should get a singularized question name if neither table nor entity names are present", () => {
+      const name = getObjectName({
+        table: null,
+        question: question,
+        cols: [idCol, qtyCol],
+        zoomedRow: [22, 33],
+      });
+
+      expect(name).toBe("Special Order");
+    });
+
+    it("should fall back to default text", () => {
+      const name = getObjectName({
+        table: null,
+        question: new Question(
+          {
+            ...card,
+            name: "",
+          },
+          metadata,
+        ),
+        cols: [idCol, qtyCol],
+        zoomedRow: [22, 33],
+      });
+
+      expect(name).toBe("Item Detail");
+    });
+  });
+
+  describe("getDisplayId", () => {
+    it("should get a display id when there is a single primary key column", () => {
+      const id = getDisplayId({
+        cols: [idCol, qtyCol, nameCol],
+        zoomedRow: [22, 33, "Giant Sprocket"],
+      });
+
+      expect(id).toBe(22);
+    });
+
+    it("should return null if there is no primary key and an entity name", () => {
+      const id = getDisplayId({
+        cols: [qtyCol, nameCol],
+        zoomedRow: [33, "Giant Sprocket"],
+      });
+
+      expect(id).toBe(null);
+    });
+
+    it("should return the first row's value if there is neither an entity name nor a primary key", () => {
+      const id = getDisplayId({
+        cols: [qtyCol, qtyCol],
+        zoomedRow: [33, 44],
+      });
+
+      expect(id).toBe(33);
+    });
+  });
+
+  describe("getIdValue", () => {
+    it("should return the zoomed Row id if present", () => {
+      const id = getIdValue({
+        data: {
+          cols: [idCol, qtyCol, nameCol],
+          rows: [
+            [22, 33, "Giant Sprocket"],
+            [44, 55, "Tiny Sprocket"],
+          ],
+        },
+        zoomedRowID: 1,
+      });
+
+      expect(id).toBe(1);
+    });
+
+    // this code should no longer be reachable now that we always reach object detail by zooming
+    it("should return the primary key of the first row if now zoomed row id exists", () => {
+      const id = getIdValue({
+        data: {
+          cols: [idCol, qtyCol, nameCol],
+          rows: [
+            [22, 33, "Giant Sprocket"],
+            [44, 55, "Tiny Sprocket"],
+          ],
+        },
+      });
+
+      expect(id).toBe(22);
+    });
+  });
+});

--- a/frontend/src/metabase/visualizations/components/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive.jsx
@@ -76,6 +76,7 @@ class TableInteractive extends Component {
     this.state = {
       columnWidths: [],
       contentWidths: null,
+      showDetailShortcut: true,
     };
     this.columnHasResized = {};
     this.headerRefs = [];
@@ -115,6 +116,7 @@ class TableInteractive extends Component {
 
     this._measure();
     this._findIDColumn(this.props.data, this.props.isPivoted);
+    this._showDetailShortcut(this.props.query, this.props.isPivoted);
   }
 
   componentWillUnmount() {
@@ -147,6 +149,7 @@ class TableInteractive extends Component {
 
     if (isDataChange) {
       this._findIDColumn(nextData, newProps.isPivoted);
+      this._showDetailShortcut(this.props.query, this.props.isPivoted);
     }
   }
 
@@ -161,6 +164,14 @@ class TableInteractive extends Component {
       IDColumn: pkIndex === -1 ? null : data.cols[pkIndex],
     });
     document.addEventListener("keydown", this.onKeyDown);
+  };
+
+  _showDetailShortcut = (query, isPivoted) => {
+    const hasAggregation = !!query.aggregations?.()?.length;
+    console.log({ hasAggregation });
+    this.setState({
+      showDetailShortcut: !(isPivoted || hasAggregation),
+    });
   };
 
   _getColumnSettings(props) {
@@ -455,8 +466,8 @@ class TableInteractive extends Component {
   };
 
   cellRenderer = ({ key, style, rowIndex, columnIndex }) => {
-    const { data, settings, isPivoted } = this.props;
-    const { dragColIndex } = this.state;
+    const { data, settings } = this.props;
+    const { dragColIndex, showDetailShortcut } = this.state;
     const { rows, cols } = data;
 
     const column = cols[columnIndex];
@@ -500,7 +511,7 @@ class TableInteractive extends Component {
         }}
         className={cx("TableInteractive-cellWrapper text-dark", {
           "TableInteractive-cellWrapper--firstColumn": columnIndex === 0,
-          padLeft: columnIndex === 0 && this.props.isPivoted,
+          padLeft: columnIndex === 0 && !showDetailShortcut,
           "TableInteractive-cellWrapper--lastColumn":
             columnIndex === cols.length - 1,
           "TableInteractive-emptyCell": value == null,
@@ -526,9 +537,11 @@ class TableInteractive extends Component {
             : undefined
         }
         onMouseEnter={
-          !isPivoted ? e => this.handleHoverRow(e, rowIndex) : undefined
+          showDetailShortcut ? e => this.handleHoverRow(e, rowIndex) : undefined
         }
-        onMouseLeave={!isPivoted ? e => this.handleLeaveRow() : undefined}
+        onMouseLeave={
+          showDetailShortcut ? e => this.handleLeaveRow() : undefined
+        }
         tabIndex="0"
       >
         {this.props.renderTableCellWrapper(cellData)}
@@ -557,7 +570,7 @@ class TableInteractive extends Component {
   }
 
   getColumnPositions = () => {
-    let left = !this.props.isPivoted ? SIDEBAR_WIDTH : 0;
+    let left = this.state.showDetailShortcut ? SIDEBAR_WIDTH : 0;
     return this.props.data.cols.map((col, index) => {
       const width = this.getColumnWidth({ index });
       const pos = {
@@ -576,7 +589,7 @@ class TableInteractive extends Component {
     const { cols } = this.props.data;
     const indexes = cols.map((col, index) => index);
     indexes.splice(dragColNewIndex, 0, indexes.splice(dragColIndex, 1)[0]);
-    let left = !this.props.isPivoted ? SIDEBAR_WIDTH : 0;
+    let left = this.state.showDetailShortcut ? SIDEBAR_WIDTH : 0;
     const lefts = indexes.map(index => {
       const thisLeft = left;
       left += columnPositions[index].width;
@@ -625,7 +638,7 @@ class TableInteractive extends Component {
       getColumnTitle,
       renderTableHeaderWrapper,
     } = this.props;
-    const { dragColIndex } = this.state;
+    const { dragColIndex, showDetailShortcut } = this.state;
     const { cols } = data;
     const column = cols[columnIndex];
 
@@ -710,7 +723,7 @@ class TableInteractive extends Component {
             "TableInteractive-cellWrapper TableInteractive-headerCellData text-medium text-brand-hover",
             {
               "TableInteractive-cellWrapper--firstColumn": columnIndex === 0,
-              padLeft: columnIndex === 0 && !this.props.isPivoted,
+              padLeft: columnIndex === 0 && !showDetailShortcut,
               "TableInteractive-cellWrapper--lastColumn":
                 columnIndex === cols.length - 1,
               "TableInteractive-cellWrapper--active": isDragging,
@@ -797,13 +810,15 @@ class TableInteractive extends Component {
   };
 
   getDisplayColumnWidth = ({ index: displayIndex }) => {
-    if (!this.props.isPivoted && displayIndex === 0) {
+    if (this.state.showDetailShortcut && displayIndex === 0) {
       return SIDEBAR_WIDTH;
     }
 
-    // if this is not a pivot table, we've added a column of empty cells and need to shift
+    // if the detail shortcut is visible, we've added a column of empty cells and need to shift
     // the display index to get the data index
-    const dataIndex = !this.props.isPivoted ? displayIndex - 1 : displayIndex;
+    const dataIndex = this.state.showDetailShortcut
+      ? displayIndex - 1
+      : displayIndex;
 
     return this.getColumnWidth({ index: dataIndex });
   };
@@ -872,7 +887,6 @@ class TableInteractive extends Component {
       data: { cols, rows },
       className,
       scrollToColumn,
-      isPivoted,
     } = this.props;
 
     if (!width || !height) {
@@ -880,7 +894,7 @@ class TableInteractive extends Component {
     }
 
     const headerHeight = this.props.tableHeaderHeight || HEADER_HEIGHT;
-    const gutterColumn = !isPivoted ? 1 : 0;
+    const gutterColumn = this.state.showDetailShortcut ? 1 : 0;
 
     return (
       <ScrollSync>

--- a/frontend/src/metabase/visualizations/components/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive.jsx
@@ -168,7 +168,6 @@ class TableInteractive extends Component {
 
   _showDetailShortcut = (query, isPivoted) => {
     const hasAggregation = !!query.aggregations?.()?.length;
-    console.log({ hasAggregation });
     this.setState({
       showDetailShortcut: !(isPivoted || hasAggregation),
     });

--- a/frontend/src/metabase/visualizations/components/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive.jsx
@@ -167,7 +167,7 @@ class TableInteractive extends Component {
   };
 
   _showDetailShortcut = (query, isPivoted) => {
-    const hasAggregation = !!query.aggregations?.()?.length;
+    const hasAggregation = !!query?.aggregations?.()?.length;
     this.setState({
       showDetailShortcut: !(isPivoted || hasAggregation),
     });

--- a/frontend/src/metabase/visualizations/components/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive.jsx
@@ -3,10 +3,15 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import ReactDOM from "react-dom";
 import { t } from "ttag";
+import { connect } from "react-redux";
+import _ from "underscore";
+import cx from "classnames";
+import Draggable from "react-draggable";
+import { Grid, ScrollSync } from "react-virtualized";
+
 import "./TableInteractive.css";
 
 import Icon from "metabase/components/Icon";
-
 import ExternalLink from "metabase/core/components/ExternalLink";
 import Button from "metabase/core/components/Button";
 import Tooltip from "metabase/components/Tooltip";
@@ -25,15 +30,11 @@ import { fieldRefForColumn } from "metabase/lib/dataset";
 import { isAdHocModelQuestionCard } from "metabase/lib/data-modeling/utils";
 import Dimension from "metabase-lib/lib/Dimension";
 import { getScrollBarSize } from "metabase/lib/dom";
-
-import _ from "underscore";
-import cx from "classnames";
+import { zoomInRow } from "metabase/query_builder/actions";
 
 import ExplicitSize from "metabase/components/ExplicitSize";
 import MiniBar from "./MiniBar";
 
-import { Grid, ScrollSync } from "react-virtualized";
-import Draggable from "react-draggable";
 import Ellipsified from "metabase/components/Ellipsified";
 import DimensionInfoPopover from "metabase/components/MetadataInfo/DimensionInfoPopover";
 
@@ -63,6 +64,10 @@ function pickRowsToMeasure(rows, columnIndex, count = 10) {
   }
   return rowIndexes;
 }
+
+const mapDispatchToProps = dispatch => ({
+  onZoomRow: objectId => dispatch(zoomInRow({ objectId })),
+});
 
 class TableInteractive extends Component {
   constructor(props) {
@@ -155,9 +160,7 @@ class TableInteractive extends Component {
       IDColumnIndex: pkIndex === -1 ? null : pkIndex,
       IDColumn: pkIndex === -1 ? null : data.cols[pkIndex],
     });
-    if (pkIndex !== -1) {
-      document.addEventListener("keydown", this.onKeyDown);
-    }
+    document.addEventListener("keydown", this.onKeyDown);
   };
 
   _getColumnSettings(props) {
@@ -432,18 +435,18 @@ class TableInteractive extends Component {
     }
   }
 
-  pkClick(rowIndex) {
-    const columnIndex = this.state.IDColumnIndex;
-    const clicked = this.getCellClickedObject(rowIndex, columnIndex);
-
-    return e => this.onVisualizationClick(clicked, e.currentTarget);
-  }
+  pkClick = rowIndex => {
+    const objectId = this.state.IDColumn
+      ? this.props.data.rows[rowIndex][this.state.IDColumnIndex]
+      : rowIndex;
+    return e => this.props.onZoomRow(objectId);
+  };
 
   onKeyDown = event => {
     const detailEl = this.detailShortcutRef.current;
     const visibleDetailButton =
       !!detailEl && Array.from(detailEl.classList).includes("show") && detailEl;
-    const canViewRowDetail = !!this.state.IDColumn && !!visibleDetailButton;
+    const canViewRowDetail = !this.props.isPivoted && !!visibleDetailButton;
 
     if (event.key === "Enter" && canViewRowDetail) {
       const hoveredRowIndex = Number(detailEl.dataset.showDetailRowindex);
@@ -452,7 +455,7 @@ class TableInteractive extends Component {
   };
 
   cellRenderer = ({ key, style, rowIndex, columnIndex }) => {
-    const { data, settings } = this.props;
+    const { data, settings, isPivoted } = this.props;
     const { dragColIndex } = this.state;
     const { rows, cols } = data;
 
@@ -497,7 +500,7 @@ class TableInteractive extends Component {
         }}
         className={cx("TableInteractive-cellWrapper text-dark", {
           "TableInteractive-cellWrapper--firstColumn": columnIndex === 0,
-          padLeft: columnIndex === 0 && !this.state.IDColumn,
+          padLeft: columnIndex === 0 && this.props.isPivoted,
           "TableInteractive-cellWrapper--lastColumn":
             columnIndex === cols.length - 1,
           "TableInteractive-emptyCell": value == null,
@@ -523,13 +526,9 @@ class TableInteractive extends Component {
             : undefined
         }
         onMouseEnter={
-          this.state.IDColumn
-            ? e => this.handleHoverRow(e, rowIndex)
-            : undefined
+          !isPivoted ? e => this.handleHoverRow(e, rowIndex) : undefined
         }
-        onMouseLeave={
-          this.state.IDColumn ? e => this.handleLeaveRow() : undefined
-        }
+        onMouseLeave={!isPivoted ? e => this.handleLeaveRow() : undefined}
         tabIndex="0"
       >
         {this.props.renderTableCellWrapper(cellData)}
@@ -558,7 +557,7 @@ class TableInteractive extends Component {
   }
 
   getColumnPositions = () => {
-    let left = this.state.IDColumn ? SIDEBAR_WIDTH : 0;
+    let left = !this.props.isPivoted ? SIDEBAR_WIDTH : 0;
     return this.props.data.cols.map((col, index) => {
       const width = this.getColumnWidth({ index });
       const pos = {
@@ -577,7 +576,7 @@ class TableInteractive extends Component {
     const { cols } = this.props.data;
     const indexes = cols.map((col, index) => index);
     indexes.splice(dragColNewIndex, 0, indexes.splice(dragColIndex, 1)[0]);
-    let left = this.state.IDColumn ? SIDEBAR_WIDTH : 0;
+    let left = !this.props.isPivoted ? SIDEBAR_WIDTH : 0;
     const lefts = indexes.map(index => {
       const thisLeft = left;
       left += columnPositions[index].width;
@@ -711,7 +710,7 @@ class TableInteractive extends Component {
             "TableInteractive-cellWrapper TableInteractive-headerCellData text-medium text-brand-hover",
             {
               "TableInteractive-cellWrapper--firstColumn": columnIndex === 0,
-              padLeft: columnIndex === 0 && !this.state.IDColumn,
+              padLeft: columnIndex === 0 && !this.props.isPivoted,
               "TableInteractive-cellWrapper--lastColumn":
                 columnIndex === cols.length - 1,
               "TableInteractive-cellWrapper--active": isDragging,
@@ -798,13 +797,13 @@ class TableInteractive extends Component {
   };
 
   getDisplayColumnWidth = ({ index: displayIndex }) => {
-    if (this.state.IDColumn && displayIndex === 0) {
+    if (!this.props.isPivoted && displayIndex === 0) {
       return SIDEBAR_WIDTH;
     }
 
-    // if we have an ID column, we've added a column of empty cells and need to shift
+    // if this is not a pivot table, we've added a column of empty cells and need to shift
     // the display index to get the data index
-    const dataIndex = this.state.IDColumn ? displayIndex - 1 : displayIndex;
+    const dataIndex = !this.props.isPivoted ? displayIndex - 1 : displayIndex;
 
     return this.getColumnWidth({ index: dataIndex });
   };
@@ -873,6 +872,7 @@ class TableInteractive extends Component {
       data: { cols, rows },
       className,
       scrollToColumn,
+      isPivoted,
     } = this.props;
 
     if (!width || !height) {
@@ -880,7 +880,7 @@ class TableInteractive extends Component {
     }
 
     const headerHeight = this.props.tableHeaderHeight || HEADER_HEIGHT;
-    const gutterColumn = this.state.IDColumn ? 1 : 0;
+    const gutterColumn = !isPivoted ? 1 : 0;
 
     return (
       <ScrollSync>
@@ -1043,6 +1043,7 @@ export default _.compose(
   ExplicitSize({
     refreshMode: props => (props.isDashboard ? "debounce" : "throttle"),
   }),
+  connect(null, mapDispatchToProps),
   memoizeClass(
     "_getCellClickedObjectCached",
     "_getHeaderClickedObjectCached",

--- a/frontend/test/metabase/modes/components/drill/ObjectDetailDrill.unit.spec.js
+++ b/frontend/test/metabase/modes/components/drill/ObjectDetailDrill.unit.spec.js
@@ -90,6 +90,7 @@ describe("ObjectDetailDrill", () => {
   describe("PK cells", () => {
     describe("general", () => {
       const mockDispatch = jest.fn();
+      const mockGetState = () => ({ qb: { queryResults: {}, card: {} } });
       const { actions, cellValue } = setup({
         column: ORDERS.ID.column(),
       });
@@ -102,7 +103,7 @@ describe("ObjectDetailDrill", () => {
 
       it("should return correct redux action", () => {
         const [action] = actions;
-        action.action()(mockDispatch);
+        action.action()(mockDispatch, mockGetState);
         expect(mockDispatch).toHaveBeenCalledWith({
           type: ZOOM_IN_ROW,
           payload: {

--- a/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
@@ -403,7 +403,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
     cy.wait("@dataset");
 
     cy.findByTestId("object-detail").within(() => {
-      cy.findByText(PK_VALUE);
+      cy.findAllByText(PK_VALUE);
     });
 
     const pattern = new RegExp(`/question\\?objectId=${PK_VALUE}#*`);

--- a/frontend/test/metabase/scenarios/models/models-metadata.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models-metadata.cy.spec.js
@@ -218,8 +218,8 @@ describe("scenarios > models metadata", () => {
         drillFK({ id: 1 });
         cy.wait("@dataset");
         cy.findByTestId("object-detail").within(() => {
-          cy.findByText("1");
-          cy.findByText("Hudson Borer");
+          cy.findByText("68883"); // zip
+          cy.findAllByText("Hudson Borer");
         });
 
         cy.go("back"); // close modal
@@ -232,8 +232,8 @@ describe("scenarios > models metadata", () => {
         drillFK({ id: 7 });
         cy.wait("@dataset");
         cy.findByTestId("object-detail").within(() => {
-          cy.findByText("7");
-          cy.findByText("perry.ruecker");
+          cy.findAllByText("7");
+          cy.findAllByText("perry.ruecker");
         });
       });
     });
@@ -255,8 +255,8 @@ describe("scenarios > models metadata", () => {
           drillDashboardFK({ id: 1 });
           cy.wait("@dataset");
           cy.findByTestId("object-detail").within(() => {
-            cy.findByText("1");
-            cy.findByText("Hudson Borer");
+            cy.findAllByText("1");
+            cy.findAllByText("Hudson Borer");
           });
 
           cy.go("back");
@@ -267,8 +267,8 @@ describe("scenarios > models metadata", () => {
           drillDashboardFK({ id: 7 });
           cy.wait("@dataset");
           cy.findByTestId("object-detail").within(() => {
-            cy.findByText("7");
-            cy.findByText("perry.ruecker");
+            cy.findAllByText("7");
+            cy.findAllByText("perry.ruecker");
           });
         });
       });

--- a/frontend/test/metabase/scenarios/question/reproductions/16938-nested-native-query-pk-drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/16938-nested-native-query-pk-drill.cy.spec.js
@@ -29,7 +29,7 @@ describe("issue 16938", () => {
       .click();
 
     cy.findByTestId("object-detail").within(() => {
-      cy.findByText(`Order ${ORDER_ID}`);
+      cy.findByText(`37.65`);
     });
   });
 });

--- a/frontend/test/metabase/scenarios/question/reproductions/16938-nested-native-query-pk-drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/16938-nested-native-query-pk-drill.cy.spec.js
@@ -29,7 +29,7 @@ describe("issue 16938", () => {
       .click();
 
     cy.findByTestId("object-detail").within(() => {
-      cy.findByText(`37.65`);
+      cy.findByText("37.65");
     });
   });
 });

--- a/frontend/test/metabase/scenarios/visualizations/object_detail.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/object_detail.cy.spec.js
@@ -58,7 +58,7 @@ describe("scenarios > question > object details", () => {
 
     drillFK({ id: 1 });
 
-    assertUserDetailView({ id: 1 });
+    assertUserDetailView({ id: 1, name: "Hudson Borer" });
     getPreviousObjectDetailButton().should("not.exist");
     getNextObjectDetailButton().should("not.exist");
 
@@ -69,7 +69,7 @@ describe("scenarios > question > object details", () => {
     changeSorting("User ID", "desc");
     drillFK({ id: 2500 });
 
-    assertDetailView({ id: 2500, entityName: "Person", byFK: true });
+    assertUserDetailView({ id: 2500, name: "Kenny Schmidt" });
     getPreviousObjectDetailButton().should("not.exist");
     getNextObjectDetailButton().should("not.exist");
   });
@@ -125,7 +125,8 @@ describe("scenarios > question > object details", () => {
     cy.url().should("contain", "objectId=2");
 
     cy.findByTestId("object-detail")
-      .findByText("Domenica Williamson")
+      .findAllByText("Domenica Williamson")
+      .last()
       .click();
     // Popover is blocking the city. If it renders, Cypress will not be able to click on "Searsboro" and the test will fail.
     // Unfortunately, asserting that the popover does not exist will give us a false positive result.
@@ -168,8 +169,8 @@ function assertOrderDetailView({ id }) {
   assertDetailView({ id, entityName: "Order" });
 }
 
-function assertUserDetailView({ id }) {
-  assertDetailView({ id, entityName: "Person", byFK: true });
+function assertUserDetailView({ id, name }) {
+  assertDetailView({ id, entityName: name, byFK: true });
 }
 
 function getPreviousObjectDetailButton() {


### PR DESCRIPTION
## Background

Previously, object detail view was only available if
1. the table row had a visible primary key, OR
2. the table row was the only visible row due to filtering

This made object detail view inaccessible for many tables: e.g.
1. Tables with aggregations (e.g. 10 most popular products in the past 90 days)
2. Tables with hidden primary keys
3. Tables with composite primary keys (until you filtered down to a single record)
4. Tables based on SQL queries (where we can't detect primary keys)
5. Models without primary keys designated in metadata

## Changes

### Redux 

The must-have-a-primary-key limitation is a product of the use of `zoomedRowId` in redux only reading from a map of primary keys. I have changed `zoomedRowId` from always being a primary key, to being a primary key if only one exists, but falling back to a row index if the dataset does not have exactly one primary key column.

Now, the `getPKRowIndexMap` selector will fall back to creating a simple map of row indexes instead of primary keys if there are no primary keys.

Because we can always fall back to row indices, now all tables (except pivot tables) are eligible to use object detail view.  (Except that we check if a table is an aggregation and hide object detail shortcuts for those. We can't do this for SQL queries).

### URLs

One potential pitfall of this behavior is that links for tables that do not have primary keys will be potentially unstable (e.g the 4th most popular product over the past 90 days will change based on when you view the link) - therefore we don't insert the object detail id into the URL when we're viewing a row without a usable primary key.

### Modal Titles

Part of the consequence of showing anything in a modal is we had to make our modal title logic a bit more complex.

Entity Name | Table Name | Question Name | Primary Key | First Row Data | Modal Title
-- | -- | -- | -- | -- | --
Sprocket | Widgets | Popular Widgets | 123 | 456 | Sprocket 123
  | Widgets | Popular Widgets | 123 | 456 | Widget 123
  |   | Popular Widgets | 123 | 456 | Popular Widget 123
  |   |   | 123 | 456 | Item Detail 123
  |   |   |   | 456 | Item Detail 456
Sprocket | Widgets | Popular Widgets |   | 456 | Sprocket
  | Widgets | Popular Widgets |   | 456 | Widget 456
  |   | Popular Widgets |   | 456 | Popular Widget 456

![Screenshot from 2022-05-03 14-11-03](https://user-images.githubusercontent.com/30528226/166584005-e4a15545-e269-4181-bac8-f2f25c35bde3.png)
