### PR TITLE
[E2E] Experiment running `dashboard` test group as PR check

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -60,6 +60,7 @@ jobs:
         edition: [ee]
         folder:
           - "binning"
+          - "dashboard"
           - "dashboard-filters"
           - "downloads"
           - "joins"

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -60,11 +60,11 @@ jobs:
         edition: [ee]
         folder:
           - "binning"
+          - "custom-column"
           - "dashboard"
           - "dashboard-filters"
           - "downloads"
           - "joins"
-          - "custom-column"
     services:
       maildev:
         image: maildev/maildev:1.1.0


### PR DESCRIPTION
Adding `dashboard` test group as PR check

Data:
[dashboard OSS](https://github.com/metabase/metabase/runs/6174593804?check_suite_focus=true) vs [dashboard EE](https://github.com/metabase/metabase/runs/6174595525?check_suite_focus=true)
| e2e-tests-dashboard                       | total | passing | pending  |
|---------------------------|--------|-------|-------|
| OSS                  | 82   | 72  | 10  |
| EE                 | 83   | 73  | 9  |