### PR TITLE
Remove all decorators 

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditCustomView.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditCustomView.jsx
@@ -19,8 +19,7 @@ const mapDispatchToProps = {
   onChangeLocation: push,
 };
 
-@connect(mapStateToProps, mapDispatchToProps)
-export default class AuditTable extends React.Component {
+class AuditTable extends React.Component {
   render() {
     const { metadata, card } = this.props;
     const question = new Question(card.card, metadata);
@@ -32,3 +31,5 @@ export default class AuditTable extends React.Component {
     );
   }
 }
+
+export default connect(mapStateToProps, mapDispatchToProps)(AuditTable);

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/pages/AuditQueryDetail.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/pages/AuditQueryDetail.jsx
@@ -1,5 +1,6 @@
 /* eslint-disable react/prop-types */
 import React from "react";
+import _ from "underscore";
 
 import AuditContent from "../components/AuditContent";
 import AuditCustomView from "../containers/AuditCustomView";
@@ -66,9 +67,7 @@ import { loadMetadataForCard } from "metabase/query_builder/actions";
 const mapStateToProps = state => ({ metadata: getMetadata(state) });
 const mapDispatchToProps = { loadMetadataForCard };
 
-@connect(mapStateToProps, mapDispatchToProps)
-@ExplicitSize()
-class QueryBuilderReadOnly extends React.Component {
+class QueryBuilderReadOnlyInner extends React.Component {
   state = {
     isNativeEditorOpen: false,
   };
@@ -114,5 +113,10 @@ class QueryBuilderReadOnly extends React.Component {
     }
   }
 }
+
+const QueryBuilderReadOnly = _.compose(
+  connect(mapStateToProps, mapDispatchToProps),
+  ExplicitSize(),
+)(QueryBuilderReadOnlyInner);
 
 export default AuditQueryDetail;

--- a/enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx
@@ -22,8 +22,7 @@ import GroupMappingsWidget from "metabase/admin/settings/components/widgets/Grou
 import MetabaseSettings from "metabase/lib/settings";
 import { SAMLFormSection } from "./SettingsSAMLForm.styled";
 
-@connect(null, { updateSettings })
-export default class SettingsSAMLForm extends Component {
+class SettingsSAMLForm extends Component {
   render() {
     const { elements, settingValues, updateSettings } = this.props;
     // TODO: move these to an outer component so we don't have to do it in every form page
@@ -185,3 +184,5 @@ export default class SettingsSAMLForm extends Component {
     );
   }
 }
+
+export default connect(null, { updateSettings })(SettingsSAMLForm);

--- a/enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx
@@ -33,9 +33,7 @@ const mapDispatchToProps = {
   updateTableSandboxingPermission,
 };
 
-@withRouter
-@connect(mapStateToProps, mapDispatchToProps)
-export default class GTAPModal extends React.Component {
+class GTAPModal extends React.Component {
   state = {
     gtap: null,
     attributesOptions: null,
@@ -249,6 +247,11 @@ export default class GTAPModal extends React.Component {
     );
   }
 }
+
+export default _.compose(
+  withRouter,
+  connect(mapStateToProps, mapDispatchToProps),
+)(GTAPModal);
 
 const AttributePicker = ({ value, onChange, attributesOptions }) => (
   <div style={{ minWidth: 200 }}>

--- a/enterprise/frontend/src/metabase-enterprise/sandboxes/containers/QuestionParameterTargetWidget.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/sandboxes/containers/QuestionParameterTargetWidget.jsx
@@ -6,8 +6,7 @@ import { QuestionLoaderHOC } from "metabase/containers/QuestionLoader";
 
 import { getParameterMappingOptions } from "metabase/parameters/utils/mapping-options";
 
-@QuestionLoaderHOC
-export default class QuestionParameterTargetWidget extends React.Component {
+class QuestionParameterTargetWidget extends React.Component {
   render() {
     const { question, ...props } = this.props;
     const mappingOptions = question
@@ -16,3 +15,5 @@ export default class QuestionParameterTargetWidget extends React.Component {
     return <ParameterTargetWidget {...props} mappingOptions={mappingOptions} />;
   }
 }
+
+export default QuestionLoaderHOC(QuestionParameterTargetWidget);

--- a/enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionRow.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionRow.jsx
@@ -9,8 +9,7 @@ import CollectionOptionsButton from "./CollectionOptionsButton";
 
 const ICON_SIZE = 16;
 
-@SnippetCollections.load({ id: (state, props) => props.item.id, wrapped: true })
-export default class CollectionRow extends React.Component {
+class CollectionRow extends React.Component {
   render() {
     const {
       snippetCollection: collection,
@@ -33,3 +32,8 @@ export default class CollectionRow extends React.Component {
     );
   }
 }
+
+export default SnippetCollections.load({
+  id: (state, props) => props.item.id,
+  wrapped: true,
+})(CollectionRow);

--- a/enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionModal.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionModal.jsx
@@ -6,8 +6,7 @@ import Modal from "metabase/components/Modal";
 
 import SnippetCollections from "metabase/entities/snippet-collections";
 
-@SnippetCollections.load({ id: (state, props) => props.collection.id })
-export default class SnippetCollectionModal extends React.Component {
+class SnippetCollectionModal extends React.Component {
   render() {
     const {
       snippetCollection,
@@ -32,3 +31,7 @@ export default class SnippetCollectionModal extends React.Component {
     );
   }
 }
+
+export default SnippetCollections.load({
+  id: (state, props) => props.collection.id,
+})(SnippetCollectionModal);

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/LogoIcon.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/LogoIcon.jsx
@@ -12,8 +12,7 @@ const mapStateToProps = state => ({
   url: getLogoUrl(state),
 });
 
-@connect(mapStateToProps)
-export default class LogoIcon extends Component {
+class LogoIcon extends Component {
   state = {
     svg: null,
   };
@@ -133,3 +132,5 @@ export default class LogoIcon extends Component {
     );
   }
 }
+
+export default connect(mapStateToProps)(LogoIcon);

--- a/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx
@@ -76,9 +76,7 @@ const mapDispatchToProps = {
   selectEngine,
 };
 
-@connect(mapStateToProps, mapDispatchToProps)
-@title(({ database }) => database && database.name)
-export default class DatabaseEditApp extends Component {
+class DatabaseEditApp extends Component {
   constructor(props, context) {
     super(props, context);
   }
@@ -219,3 +217,8 @@ export default class DatabaseEditApp extends Component {
     );
   }
 }
+
+export default _.compose(
+  connect(mapStateToProps, mapDispatchToProps),
+  title(({ database }) => database && database.name),
+)(DatabaseEditApp);

--- a/frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx
@@ -4,6 +4,7 @@ import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { Link } from "react-router";
 import { t } from "ttag";
+import _ from "underscore";
 
 import cx from "classnames";
 import MetabaseSettings from "metabase/lib/settings";
@@ -64,13 +65,8 @@ const mapDispatchToProps = {
   addSampleDatabase: addSampleDatabase,
   closeSyncingModal,
 };
-@Database.loadList({
-  reloadInterval: getReloadInterval,
-  query,
-  LoadingAndErrorWrapper: LoadingAndGenericErrorWrapper,
-})
-@connect(mapStateToProps, mapDispatchToProps)
-export default class DatabaseList extends Component {
+
+class DatabaseList extends Component {
   constructor(props) {
     super(props);
 
@@ -219,3 +215,12 @@ export default class DatabaseList extends Component {
     );
   }
 }
+
+export default _.compose(
+  Database.loadList({
+    reloadInterval: getReloadInterval,
+    query,
+    LoadingAndErrorWrapper: LoadingAndGenericErrorWrapper,
+  }),
+  connect(mapStateToProps, mapDispatchToProps),
+)(DatabaseList);

--- a/frontend/src/metabase/admin/datamodel/components/MetricForm.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/MetricForm.jsx
@@ -14,42 +14,7 @@ import { formatValue } from "metabase/lib/formatting";
 
 import * as Q from "metabase/lib/query/query";
 
-@reduxForm(
-  {
-    form: "metric",
-    fields: [
-      "id",
-      "name",
-      "description",
-      "table_id",
-      "definition",
-      "revision_message",
-      "show_in_getting_started",
-    ],
-    validate: values => {
-      const errors = {};
-      if (!values.name) {
-        errors.name = t`Name is required`;
-      }
-      if (!values.description) {
-        errors.description = t`Description is required`;
-      }
-      if (values.id != null) {
-        if (!values.revision_message) {
-          errors.revision_message = t`Revision message is required`;
-        }
-      }
-      const aggregations =
-        values.definition && Q.getAggregations(values.definition);
-      if (!aggregations || aggregations.length === 0) {
-        errors.definition = t`Aggregation is required`;
-      }
-      return errors;
-    },
-  },
-  (state, { metric }) => ({ initialValues: metric }),
-)
-export default class MetricForm extends Component {
+class MetricForm extends Component {
   renderActionButtons() {
     const { invalid, handleSubmit } = this.props;
     return (
@@ -151,3 +116,39 @@ export default class MetricForm extends Component {
     );
   }
 }
+
+export default reduxForm(
+  {
+    form: "metric",
+    fields: [
+      "id",
+      "name",
+      "description",
+      "table_id",
+      "definition",
+      "revision_message",
+      "show_in_getting_started",
+    ],
+    validate: values => {
+      const errors = {};
+      if (!values.name) {
+        errors.name = t`Name is required`;
+      }
+      if (!values.description) {
+        errors.description = t`Description is required`;
+      }
+      if (values.id != null) {
+        if (!values.revision_message) {
+          errors.revision_message = t`Revision message is required`;
+        }
+      }
+      const aggregations =
+        values.definition && Q.getAggregations(values.definition);
+      if (!aggregations || aggregations.length === 0) {
+        errors.definition = t`Aggregation is required`;
+      }
+      return errors;
+    },
+  },
+  (state, { metric }) => ({ initialValues: metric }),
+)(MetricForm);

--- a/frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx
@@ -15,13 +15,7 @@ import * as Urls from "metabase/lib/urls";
 
 import withTableMetadataLoaded from "../hoc/withTableMetadataLoaded";
 
-@Tables.load({
-  id: (state, props) => props.value && props.value["source-table"],
-  wrapped: true,
-})
-@withTableMetadataLoaded
-@connect((state, props) => ({ metadata: getMetadata(state) }))
-export default class PartialQueryBuilder extends Component {
+class PartialQueryBuilder extends Component {
   static propTypes = {
     onChange: PropTypes.func.isRequired,
     table: PropTypes.object.isRequired,
@@ -135,3 +129,12 @@ export default class PartialQueryBuilder extends Component {
     );
   }
 }
+
+export default _.compose(
+  Tables.load({
+    id: (state, props) => props.value && props.value["source-table"],
+    wrapped: true,
+  }),
+  withTableMetadataLoaded,
+  connect((state, props) => ({ metadata: getMetadata(state) })),
+)(PartialQueryBuilder);

--- a/frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx
@@ -14,50 +14,7 @@ import { reduxForm } from "redux-form";
 
 import cx from "classnames";
 
-@reduxForm(
-  {
-    form: "segment",
-    fields: [
-      "id",
-      "name",
-      "description",
-      "table_id",
-      "definition",
-      "revision_message",
-    ],
-    validate: values => {
-      const errors = {};
-      if (!values.name) {
-        errors.name = t`Name is required`;
-      }
-      if (!values.description) {
-        errors.description = t`Description is required`;
-      }
-      if (values.id != null) {
-        if (!values.revision_message) {
-          errors.revision_message = t`Revision message is required`;
-        }
-      }
-      if (
-        !values.definition ||
-        !values.definition.filter ||
-        values.definition.filter.length < 1
-      ) {
-        errors.definition = t`At least one filter is required`;
-      }
-      return errors;
-    },
-    initialValues: {
-      name: "",
-      description: "",
-      table_id: null,
-      definition: { filter: [] },
-      revision_message: null,
-    },
-  },
-  (state, { segment }) => ({ initialValues: segment }),
-)
-export default class SegmentForm extends Component {
+class SegmentForm extends Component {
   updatePreviewSummary(datasetQuery) {
     this.props.updatePreviewSummary({
       ...datasetQuery,
@@ -167,3 +124,47 @@ export default class SegmentForm extends Component {
     );
   }
 }
+
+export default reduxForm(
+  {
+    form: "segment",
+    fields: [
+      "id",
+      "name",
+      "description",
+      "table_id",
+      "definition",
+      "revision_message",
+    ],
+    validate: values => {
+      const errors = {};
+      if (!values.name) {
+        errors.name = t`Name is required`;
+      }
+      if (!values.description) {
+        errors.description = t`Description is required`;
+      }
+      if (values.id != null) {
+        if (!values.revision_message) {
+          errors.revision_message = t`Revision message is required`;
+        }
+      }
+      if (
+        !values.definition ||
+        !values.definition.filter ||
+        values.definition.filter.length < 1
+      ) {
+        errors.definition = t`At least one filter is required`;
+      }
+      return errors;
+    },
+    initialValues: {
+      name: "",
+      description: "",
+      table_id: null,
+      definition: { filter: [] },
+      revision_message: null,
+    },
+  },
+  (state, { segment }) => ({ initialValues: segment }),
+)(SegmentForm);

--- a/frontend/src/metabase/admin/datamodel/components/database/ColumnItem/ColumnItem.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/ColumnItem/ColumnItem.jsx
@@ -20,8 +20,7 @@ import * as MetabaseAnalytics from "metabase/lib/analytics";
 import { ColumnItemInput } from "./ColumnItem.styled";
 import { getFieldRawName } from "../../../utils";
 
-@withRouter
-export default class Column extends Component {
+class Column extends Component {
   static propTypes = {
     field: PropTypes.object,
     idfields: PropTypes.array.isRequired,
@@ -110,6 +109,8 @@ export default class Column extends Component {
     );
   }
 }
+
+export default withRouter(Column);
 
 const getFkFieldPlaceholder = (field, idfields) => {
   const hasIdFields = idfields?.length > 0;

--- a/frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx
@@ -2,6 +2,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { Link, withRouter } from "react-router";
+import _ from "underscore";
 
 import Databases from "metabase/entities/databases";
 
@@ -10,13 +11,7 @@ import SaveStatus from "metabase/components/SaveStatus";
 import Icon from "metabase/components/Icon";
 import { PLUGIN_FEATURE_LEVEL_PERMISSIONS } from "metabase/plugins";
 
-@withRouter
-@Databases.loadList({
-  query: {
-    ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.dataModelQueryProps,
-  },
-})
-export default class MetadataHeader extends Component {
+class MetadataHeader extends Component {
   static propTypes = {
     databaseId: PropTypes.number,
     databases: PropTypes.array.isRequired,
@@ -80,3 +75,12 @@ export default class MetadataHeader extends Component {
     );
   }
 }
+
+export default _.compose(
+  withRouter,
+  Databases.loadList({
+    query: {
+      ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.dataModelQueryProps,
+    },
+  }),
+)(MetadataHeader);

--- a/frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx
@@ -16,14 +16,7 @@ import { regexpEscape } from "metabase/lib/string";
 import { color } from "metabase/lib/colors";
 import { isSyncCompleted } from "metabase/lib/syncing";
 
-@connect(null, {
-  setVisibilityForTables: (tables, visibility_type) =>
-    Tables.actions.bulkUpdate({
-      ids: tables.map(t => t.id),
-      visibility_type,
-    }),
-})
-export default class MetadataTableList extends Component {
+class MetadataTableList extends Component {
   constructor(props, context) {
     super(props, context);
 
@@ -160,6 +153,14 @@ export default class MetadataTableList extends Component {
     );
   }
 }
+
+export default connect(null, {
+  setVisibilityForTables: (tables, visibility_type) =>
+    Tables.actions.bulkUpdate({
+      ids: tables.map(t => t.id),
+      visibility_type,
+    }),
+})(MetadataTableList);
 
 function TableRow({
   table,

--- a/frontend/src/metabase/admin/datamodel/components/database/MetadataTablePicker.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/MetadataTablePicker.jsx
@@ -9,18 +9,8 @@ import MetadataTableList from "./MetadataTableList";
 import MetadataSchemaList from "./MetadataSchemaList";
 
 const RELOAD_INTERVAL = 2000;
-@Tables.loadList({
-  query: (state, { databaseId }) => ({
-    dbId: databaseId,
-    include_hidden: true,
-    ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.dataModelQueryProps,
-  }),
-  reloadInterval: (state, props, tables = []) => {
-    return tables.some(t => isSyncInProgress(t)) ? RELOAD_INTERVAL : 0;
-  },
-  selectorName: "getListUnfiltered",
-})
-export default class MetadataTablePicker extends Component {
+
+class MetadataTablePicker extends Component {
   constructor(props, context) {
     super(props, context);
 
@@ -72,3 +62,15 @@ export default class MetadataTablePicker extends Component {
     );
   }
 }
+
+export default Tables.loadList({
+  query: (state, { databaseId }) => ({
+    dbId: databaseId,
+    include_hidden: true,
+    ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.dataModelQueryProps,
+  }),
+  reloadInterval: (state, props, tables = []) => {
+    return tables.some(t => isSyncInProgress(t)) ? RELOAD_INTERVAL : 0;
+  },
+  selectorName: "getListUnfiltered",
+})(MetadataTablePicker);

--- a/frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx
@@ -10,8 +10,7 @@ import Tables from "metabase/entities/tables";
 
 import { assignUserColors } from "metabase/lib/formatting";
 
-@Tables.load({ id: (state, { object: { table_id } }) => table_id })
-export default class RevisionHistory extends Component {
+class RevisionHistory extends Component {
   static propTypes = {
     object: PropTypes.object,
     revisions: PropTypes.array,
@@ -65,3 +64,7 @@ export default class RevisionHistory extends Component {
     );
   }
 }
+
+export default Tables.load({
+  id: (state, { object: { table_id } }) => table_id,
+})(RevisionHistory);

--- a/frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx
@@ -81,8 +81,7 @@ const mapDispatchToProps = {
   discardFieldValues,
 };
 
-@connect(mapStateToProps, mapDispatchToProps)
-export default class FieldApp extends React.Component {
+class FieldApp extends React.Component {
   state = {
     tab: "general",
   };
@@ -247,6 +246,8 @@ export default class FieldApp extends React.Component {
     );
   }
 }
+
+export default connect(mapStateToProps, mapDispatchToProps)(FieldApp);
 
 const FieldGeneralPane = ({
   field,

--- a/frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx
@@ -1,7 +1,9 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { push, replace } from "react-router-redux";
+import _ from "underscore";
 
 import { t } from "ttag";
 import * as MetabaseAnalytics from "metabase/lib/analytics";
@@ -54,15 +56,7 @@ const mapDispatchToProps = {
     Metrics.actions.setArchived({ id }, true, rest),
 };
 
-@connect(mapStateToProps, mapDispatchToProps)
-@Databases.load({
-  id: (state, props) => props.databaseId,
-  query: {
-    ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.dataModelQueryProps,
-  },
-  loadingAndErrorWrapper: false,
-})
-class MetadataEditor extends Component {
+class MetadataEditorInner extends Component {
   constructor(props, context) {
     super(props, context);
     this.toggleShowSchema = this.toggleShowSchema.bind(this);
@@ -133,6 +127,17 @@ class MetadataEditor extends Component {
     );
   }
 }
+
+const MetadataEditor = _.compose(
+  connect(mapStateToProps, mapDispatchToProps),
+  Databases.load({
+    id: (state, props) => props.databaseId,
+    query: {
+      ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.dataModelQueryProps,
+    },
+    loadingAndErrorWrapper: false,
+  }),
+)(MetadataEditorInner);
 
 MetadataEditor.propTypes = propTypes;
 

--- a/frontend/src/metabase/admin/datamodel/containers/MetricApp.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/MetricApp.jsx
@@ -21,8 +21,7 @@ const mapStateToProps = (state, props) => ({
   previewSummary: getPreviewSummary(state),
 });
 
-@Metrics.load({ id: (state, props) => parseInt(props.params.id) })
-class UpdateMetricForm extends Component {
+class UpdateMetricFormInner extends Component {
   onSubmit = async metric => {
     await this.props.updateMetric(metric);
     MetabaseAnalytics.trackStructEvent("Data Model", "Metric Updated");
@@ -40,6 +39,10 @@ class UpdateMetricForm extends Component {
     );
   }
 }
+
+const UpdateMetricForm = Metrics.load({
+  id: (state, props) => parseInt(props.params.id),
+})(UpdateMetricFormInner);
 
 class CreateMetricForm extends Component {
   onSubmit = async metric => {

--- a/frontend/src/metabase/admin/datamodel/containers/MetricApp.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/MetricApp.jsx
@@ -56,8 +56,7 @@ class CreateMetricForm extends Component {
   }
 }
 
-@connect(mapStateToProps, mapDispatchToProps)
-export default class MetricApp extends Component {
+class MetricApp extends Component {
   render() {
     return this.props.params.id ? (
       <UpdateMetricForm {...this.props} />
@@ -66,3 +65,5 @@ export default class MetricApp extends Component {
     );
   }
 }
+
+export default connect(mapStateToProps, mapDispatchToProps)(MetricApp);

--- a/frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/prop-types */
 import React from "react";
 import { t } from "ttag";
+import _ from "underscore";
 
 import Metrics from "metabase/entities/metrics";
 import MetricItem from "metabase/admin/datamodel/components/MetricItem";
@@ -9,9 +10,7 @@ import FilteredToUrlTable from "metabase/admin/datamodel/hoc/FilteredToUrlTable"
 import Button from "metabase/core/components/Button";
 import Link from "metabase/core/components/Link";
 
-@Metrics.loadList({ wrapped: true })
-@FilteredToUrlTable("metrics")
-class MetricListApp extends React.Component {
+class MetricListAppInner extends React.Component {
   render() {
     const { metrics, tableSelector } = this.props;
 
@@ -50,5 +49,10 @@ class MetricListApp extends React.Component {
     );
   }
 }
+
+const MetricListApp = _.compose(
+  Metrics.loadList({ wrapped: true }),
+  FilteredToUrlTable("metrics"),
+)(MetricListAppInner);
 
 export default MetricListApp;

--- a/frontend/src/metabase/admin/datamodel/containers/RevisionHistoryApp.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/RevisionHistoryApp.jsx
@@ -18,8 +18,7 @@ const mapStateToProps = (state, props) => ({
 
 const mapDispatchToProps = { fetchRevisions };
 
-@connect(mapStateToProps, mapDispatchToProps)
-export default class RevisionHistoryApp extends Component {
+class RevisionHistoryApp extends Component {
   componentDidMount() {
     const { id, objectType } = this.props;
     this.props.fetchRevisions({ entity: objectType, id });
@@ -33,6 +32,8 @@ export default class RevisionHistoryApp extends Component {
     );
   }
 }
+
+export default connect(mapStateToProps, mapDispatchToProps)(RevisionHistoryApp);
 
 @Metrics.load({ id: (state, { id }) => id })
 class MetricRevisionHistory extends Component {

--- a/frontend/src/metabase/admin/datamodel/containers/RevisionHistoryApp.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/RevisionHistoryApp.jsx
@@ -35,18 +35,24 @@ class RevisionHistoryApp extends Component {
 
 export default connect(mapStateToProps, mapDispatchToProps)(RevisionHistoryApp);
 
-@Metrics.load({ id: (state, { id }) => id })
-class MetricRevisionHistory extends Component {
+class MetricRevisionHistoryInner extends Component {
   render() {
     const { metric, ...props } = this.props;
     return <RevisionHistory object={metric} {...props} />;
   }
 }
 
-@Segments.load({ id: (state, { id }) => id })
-class SegmentRevisionHistory extends Component {
+const MetricRevisionHistory = Metrics.load({ id: (state, { id }) => id })(
+  MetricRevisionHistoryInner,
+);
+
+class SegmentRevisionHistoryInner extends Component {
   render() {
     const { segment, ...props } = this.props;
     return <RevisionHistory object={segment} {...props} />;
   }
 }
+
+const SegmentRevisionHistory = Segments.load({ id: (state, { id }) => id })(
+  SegmentRevisionHistoryInner,
+);

--- a/frontend/src/metabase/admin/datamodel/containers/SegmentApp.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/SegmentApp.jsx
@@ -21,8 +21,7 @@ const mapStateToProps = (state, props) => ({
   previewSummary: getPreviewSummary(state),
 });
 
-@Segments.load({ id: (state, props) => parseInt(props.params.id) })
-class UpdateSegmentForm extends Component {
+class UpdateSegmentFormInner extends Component {
   onSubmit = async segment => {
     await this.props.updateSegment(segment);
     MetabaseAnalytics.trackStructEvent("Data Model", "Segment Updated");
@@ -40,6 +39,10 @@ class UpdateSegmentForm extends Component {
     );
   }
 }
+
+const UpdateSegmentForm = Segments.load({
+  id: (state, props) => parseInt(props.params.id),
+})(UpdateSegmentFormInner);
 
 class CreateSegmentForm extends Component {
   onSubmit = async segment => {

--- a/frontend/src/metabase/admin/datamodel/containers/SegmentApp.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/SegmentApp.jsx
@@ -56,8 +56,7 @@ class CreateSegmentForm extends Component {
   }
 }
 
-@connect(mapStateToProps, mapDispatchToProps)
-export default class SegmentApp extends Component {
+class SegmentApp extends Component {
   render() {
     return this.props.params.id ? (
       <UpdateSegmentForm {...this.props} />
@@ -66,3 +65,5 @@ export default class SegmentApp extends Component {
     );
   }
 }
+
+export default connect(mapStateToProps, mapDispatchToProps)(SegmentApp);

--- a/frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/prop-types */
 import React from "react";
 import { t } from "ttag";
+import _ from "underscore";
 
 import Segment from "metabase/entities/segments";
 import SegmentItem from "metabase/admin/datamodel/components/SegmentItem";
@@ -9,9 +10,7 @@ import FilteredToUrlTable from "metabase/admin/datamodel/hoc/FilteredToUrlTable"
 import Button from "metabase/core/components/Button";
 import Link from "metabase/core/components/Link";
 
-@Segment.loadList({ wrapped: true })
-@FilteredToUrlTable("segments")
-class SegmentListApp extends React.Component {
+class SegmentListAppInner extends React.Component {
   render() {
     const { segments, tableSelector } = this.props;
 
@@ -50,5 +49,10 @@ class SegmentListApp extends React.Component {
     );
   }
 }
+
+const SegmentListApp = _.compose(
+  Segment.loadList({ wrapped: true }),
+  FilteredToUrlTable("segments"),
+)(SegmentListAppInner);
 
 export default SegmentListApp;

--- a/frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx
@@ -24,8 +24,7 @@ const mapDispatchToProps = {
   discardTableFieldValues,
 };
 
-@connect(mapStateToProps, mapDispatchToProps)
-export default class TableSettingsApp extends Component {
+class TableSettingsApp extends Component {
   render() {
     const { tableId } = this.props;
     return (
@@ -45,6 +44,8 @@ export default class TableSettingsApp extends Component {
     );
   }
 }
+
+export default connect(mapStateToProps, mapDispatchToProps)(TableSettingsApp);
 
 @Databases.load({
   id: (state, { databaseId }) => databaseId,

--- a/frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import { connect } from "react-redux";
+import _ from "underscore";
 
 import { t } from "ttag";
 import Breadcrumbs from "metabase/components/Breadcrumbs";
@@ -47,20 +48,7 @@ class TableSettingsApp extends Component {
 
 export default connect(mapStateToProps, mapDispatchToProps)(TableSettingsApp);
 
-@Databases.load({
-  id: (state, { databaseId }) => databaseId,
-  query: {
-    ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.dataModelQueryProps,
-  },
-})
-@Tables.load({
-  id: (state, { tableId }) => tableId,
-  query: {
-    ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.dataModelQueryProps,
-  },
-  selectorName: "getObjectUnfiltered",
-})
-class Nav extends Component {
+class NavInner extends Component {
   render() {
     const { database: db, table } = this.props;
     return (
@@ -82,6 +70,22 @@ class Nav extends Component {
     );
   }
 }
+
+const Nav = _.compose(
+  Databases.load({
+    id: (state, { databaseId }) => databaseId,
+    query: {
+      ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.dataModelQueryProps,
+    },
+  }),
+  Tables.load({
+    id: (state, { tableId }) => tableId,
+    query: {
+      ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.dataModelQueryProps,
+    },
+    selectorName: "getObjectUnfiltered",
+  }),
+)(NavInner);
 
 class UpdateFieldValues extends Component {
   render() {

--- a/frontend/src/metabase/admin/datamodel/hoc/FilteredToUrlTable.jsx
+++ b/frontend/src/metabase/admin/datamodel/hoc/FilteredToUrlTable.jsx
@@ -47,11 +47,7 @@ const FilteredToUrlTable = propName => ComposedComponent =>
 
 export default FilteredToUrlTable;
 
-@Tables.load({
-  id: (state, props) => props.tableId,
-  loadingAndErrorWrapper: false,
-})
-class TableSelector extends React.Component {
+class TableSelectorInner extends React.Component {
   render() {
     const { table, tableId, setTableId } = this.props;
     return (
@@ -89,3 +85,8 @@ class TableSelector extends React.Component {
     );
   }
 }
+
+const TableSelector = Tables.load({
+  id: (state, props) => props.tableId,
+  loadingAndErrorWrapper: false,
+})(TableSelectorInner);

--- a/frontend/src/metabase/admin/people/containers/GroupDetailApp.jsx
+++ b/frontend/src/metabase/admin/people/containers/GroupDetailApp.jsx
@@ -1,14 +1,18 @@
 import React, { Component } from "react";
+import _ from "underscore";
 
 import User from "metabase/entities/users";
 import Group from "metabase/entities/groups";
 
 import GroupDetail from "../components/GroupDetail";
 
-@User.loadList()
-@Group.load({ id: (_state, props) => props.params.groupId })
-export default class GroupDetailApp extends Component {
+class GroupDetailApp extends Component {
   render() {
     return <GroupDetail {...this.props} />;
   }
 }
+
+export default _.compose(
+  User.loadList(),
+  Group.load({ id: (_state, props) => props.params.groupId }),
+)(GroupDetailApp);

--- a/frontend/src/metabase/admin/people/containers/GroupsListingApp.jsx
+++ b/frontend/src/metabase/admin/people/containers/GroupsListingApp.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import _ from "underscore";
 import { connect } from "react-redux";
 
 import { PLUGIN_GROUP_MANAGERS } from "metabase/plugins";
@@ -16,10 +17,13 @@ const mapDispatchToProps = {
   delete: PLUGIN_GROUP_MANAGERS.deleteGroup ?? Group.actions.delete,
 };
 
-@Group.loadList({ reload: true })
-@connect(mapStateToProps, mapDispatchToProps)
-export default class GroupsListingApp extends React.Component {
+class GroupsListingApp extends React.Component {
   render() {
     return <GroupsListing {...this.props} />;
   }
 }
+
+export default _.compose(
+  Group.loadList({ reload: true }),
+  connect(mapStateToProps, mapDispatchToProps),
+)(GroupsListingApp);

--- a/frontend/src/metabase/admin/people/containers/UserActivationModal.jsx
+++ b/frontend/src/metabase/admin/people/containers/UserActivationModal.jsx
@@ -12,14 +12,7 @@ import Text from "metabase/components/type/Text";
 
 // NOTE: we have to load the list of users because /api/user/:id doesn't return deactivated users
 // but that's ok because it's probably already loaded through the people PeopleListingApp
-@User.loadList({
-  query: { include_deactivated: true },
-  wrapped: true,
-})
-@connect((state, { users, params: { userId } }) => ({
-  user: _.findWhere(users, { id: parseInt(userId) }),
-}))
-class UserActivationModal extends React.Component {
+class UserActivationModalInner extends React.Component {
   render() {
     const { user, onClose } = this.props;
     if (!user) {
@@ -63,5 +56,15 @@ class UserActivationModal extends React.Component {
     }
   }
 }
+
+const UserActivationModal = _.compose(
+  User.loadList({
+    query: { include_deactivated: true },
+    wrapped: true,
+  }),
+  connect((state, { users, params: { userId } }) => ({
+    user: _.findWhere(users, { id: parseInt(userId) }),
+  })),
+)(UserActivationModalInner);
 
 export default UserActivationModal;

--- a/frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx
+++ b/frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx
@@ -3,6 +3,7 @@ import React from "react";
 import { connect } from "react-redux";
 import { goBack } from "react-router-redux";
 import { t } from "ttag";
+import _ from "underscore";
 
 import User from "metabase/entities/users";
 import { clearTemporaryPassword } from "../people";
@@ -15,23 +16,7 @@ import ModalContent from "metabase/components/ModalContent";
 import PasswordReveal from "metabase/components/PasswordReveal";
 import { ButtonContainer } from "./UserPasswordResetModal.styled";
 
-@User.load({
-  id: (state, props) => props.params.userId,
-  wrapped: true,
-})
-@connect(
-  (state, props) => ({
-    emailConfigured: MetabaseSettings.isEmailConfigured(),
-    temporaryPassword: getUserTemporaryPassword(state, {
-      userId: props.params.userId,
-    }),
-  }),
-  {
-    onClose: goBack,
-    clearTemporaryPassword,
-  },
-)
-export default class UserPasswordResetModal extends React.Component {
+class UserPasswordResetModal extends React.Component {
   componentWillUnmount() {
     this.props.clearTemporaryPassword(this.props.params.userId);
   }
@@ -74,3 +59,22 @@ export default class UserPasswordResetModal extends React.Component {
     );
   }
 }
+
+export default _.compose(
+  User.load({
+    id: (state, props) => props.params.userId,
+    wrapped: true,
+  }),
+  connect(
+    (state, props) => ({
+      emailConfigured: MetabaseSettings.isEmailConfigured(),
+      temporaryPassword: getUserTemporaryPassword(state, {
+        userId: props.params.userId,
+      }),
+    }),
+    {
+      onClose: goBack,
+      clearTemporaryPassword,
+    },
+  ),
+)(UserPasswordResetModal);

--- a/frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx
+++ b/frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/prop-types */
 import React from "react";
 import { t, jt } from "ttag";
+import _ from "underscore";
 
 import { connect } from "react-redux";
 import { push } from "react-router-redux";
@@ -15,22 +16,7 @@ import ModalContent from "metabase/components/ModalContent";
 import PasswordReveal from "metabase/components/PasswordReveal";
 import { PasswordSuccessMessage } from "./UserSuccessModal.styled";
 
-@User.load({
-  id: (state, props) => props.params.userId,
-  wrapped: true,
-})
-@connect(
-  (state, props) => ({
-    temporaryPassword: getUserTemporaryPassword(state, {
-      userId: props.params.userId,
-    }),
-  }),
-  {
-    onClose: () => push("/admin/people"),
-    clearTemporaryPassword,
-  },
-)
-export default class UserSuccessModal extends React.Component {
+class UserSuccessModal extends React.Component {
   componentWillUnmount() {
     this.props.clearTemporaryPassword(this.props.params.userId);
   }
@@ -51,6 +37,24 @@ export default class UserSuccessModal extends React.Component {
     );
   }
 }
+
+export default _.compose(
+  User.load({
+    id: (state, props) => props.params.userId,
+    wrapped: true,
+  }),
+  connect(
+    (state, props) => ({
+      temporaryPassword: getUserTemporaryPassword(state, {
+        userId: props.params.userId,
+      }),
+    }),
+    {
+      onClose: () => push("/admin/people"),
+      clearTemporaryPassword,
+    },
+  ),
+)(UserSuccessModal);
 
 const EmailSuccess = ({ user }) => (
   <div>{jt`We’ve sent an invite to ${(

--- a/frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx
@@ -31,16 +31,7 @@ const SAVE_SETTINGS_BUTTONS_STATES = {
   success: t`Changes saved!`,
 };
 
-@connect(
-  null,
-  (dispatch, { updateSettings }) => ({
-    updateSettings:
-      updateSettings || (settings => dispatch(defaultUpdateSettings(settings))),
-  }),
-  null,
-  { withRef: true }, // HACK: needed so consuming components can call methods on the component :-/
-)
-export default class SettingsBatchForm extends Component {
+class SettingsBatchForm extends Component {
   constructor(props, context) {
     super(props, context);
     this.state = {
@@ -310,6 +301,16 @@ export default class SettingsBatchForm extends Component {
     );
   }
 }
+
+export default connect(
+  null,
+  (dispatch, { updateSettings }) => ({
+    updateSettings:
+      updateSettings || (settings => dispatch(defaultUpdateSettings(settings))),
+  }),
+  null,
+  { withRef: true }, // HACK: needed so consuming components can call methods on the component :-/
+)(SettingsBatchForm);
 
 const StandardSection = ({ title, children }) => (
   <div>

--- a/frontend/src/metabase/admin/settings/components/SettingsEmailForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsEmailForm.jsx
@@ -24,8 +24,7 @@ const SEND_TEST_BUTTON_STATES = {
   success: t`Sent!`,
 };
 
-@connect(null, { sendTestEmail, updateEmailSettings, clearEmailSettings })
-export default class SettingsEmailForm extends Component {
+class SettingsEmailForm extends Component {
   state = {
     sendingEmail: "default",
   };
@@ -112,3 +111,9 @@ export default class SettingsEmailForm extends Component {
     );
   }
 }
+
+export default connect(null, {
+  sendTestEmail,
+  updateEmailSettings,
+  clearEmailSettings,
+})(SettingsEmailForm);

--- a/frontend/src/metabase/admin/settings/components/SettingsGoogleForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsGoogleForm.jsx
@@ -22,8 +22,7 @@ const settingsGoogleFormPropTypes = {
   updateSettings: PropTypes.func,
 };
 
-@connect(null, { updateSettings })
-export default class SettingsGoogleForm extends Component {
+class SettingsGoogleForm extends Component {
   render() {
     const { elements, settingValues, updateSettings } = this.props;
 
@@ -86,5 +85,7 @@ export default class SettingsGoogleForm extends Component {
     );
   }
 }
+
+export default connect(null, { updateSettings })(SettingsGoogleForm);
 
 SettingsGoogleForm.propTypes = settingsGoogleFormPropTypes;

--- a/frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx
@@ -7,8 +7,7 @@ import { updateLdapSettings } from "metabase/admin/settings/settings";
 
 import SettingsBatchForm from "./SettingsBatchForm";
 
-@connect(null, { updateSettings: updateLdapSettings })
-export default class SettingsLdapForm extends React.Component {
+class SettingsLdapForm extends React.Component {
   render() {
     return (
       <SettingsBatchForm
@@ -61,3 +60,7 @@ export default class SettingsLdapForm extends React.Component {
     );
   }
 }
+
+export default connect(null, { updateSettings: updateLdapSettings })(
+  SettingsLdapForm,
+);

--- a/frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx
@@ -14,8 +14,7 @@ import ExternalLink from "metabase/core/components/ExternalLink";
 import _ from "underscore";
 import { t, jt } from "ttag";
 
-@connect(null, { updateSettings: updateSlackSettings })
-export default class SettingsSlackForm extends Component {
+class SettingsSlackForm extends Component {
   constructor(props, context) {
     super(props, context);
 
@@ -287,3 +286,7 @@ export default class SettingsSlackForm extends Component {
     );
   }
 }
+
+export default connect(null, { updateSettings: updateSlackSettings })(
+  SettingsSlackForm,
+);

--- a/frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx
+++ b/frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx
@@ -47,9 +47,7 @@ const mapDispatchToProps = {
   reloadSettings,
 };
 
-@connect(mapStateToProps, mapDispatchToProps)
-@title(({ activeSection }) => activeSection && activeSection.name)
-export default class SettingsEditorApp extends Component {
+class SettingsEditorApp extends Component {
   layout = null; // the reference to AdminLayout
 
   static propTypes = {
@@ -257,3 +255,8 @@ export default class SettingsEditorApp extends Component {
     );
   }
 }
+
+export default _.compose(
+  connect(mapStateToProps, mapDispatchToProps),
+  title(({ activeSection }) => activeSection && activeSection.name),
+)(SettingsEditorApp);

--- a/frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx
+++ b/frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx
@@ -60,8 +60,7 @@ const renderJobsTable = jobs => {
   );
 };
 
-@connect(null, { fetchJobInfo })
-export default class JobInfoApp extends React.Component {
+class JobInfoApp extends React.Component {
   async componentDidMount() {
     try {
       const info = (await this.props.fetchJobInfo()).payload;
@@ -96,3 +95,5 @@ export default class JobInfoApp extends React.Component {
     );
   }
 }
+
+export default connect(null, { fetchJobInfo })(JobInfoApp);

--- a/frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx
+++ b/frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx
@@ -50,8 +50,7 @@ const renderTriggersTable = triggers => {
   );
 };
 
-@connect(null, { fetchJobInfo, goBack })
-export default class JobTriggersModal extends React.Component {
+class JobTriggersModal extends React.Component {
   state = {
     triggers: null,
     error: null,
@@ -86,3 +85,5 @@ export default class JobTriggersModal extends React.Component {
     );
   }
 }
+
+export default connect(null, { fetchJobInfo, goBack })(JobTriggersModal);

--- a/frontend/src/metabase/admin/tasks/containers/TaskModal.jsx
+++ b/frontend/src/metabase/admin/tasks/containers/TaskModal.jsx
@@ -3,17 +3,14 @@ import React from "react";
 import { t } from "ttag";
 import { connect } from "react-redux";
 import { goBack } from "react-router-redux";
+import _ from "underscore";
 
 import Task from "metabase/entities/tasks";
 
 import Code from "metabase/components/Code";
 import ModalContent from "metabase/components/ModalContent";
 
-@Task.load({
-  id: (state, props) => props.params.taskId,
-})
-@connect(null, { goBack })
-class TaskModal extends React.Component {
+class TaskModalInner extends React.Component {
   render() {
     const { object } = this.props;
     return (
@@ -23,5 +20,12 @@ class TaskModal extends React.Component {
     );
   }
 }
+
+const TaskModal = _.compose(
+  Task.load({
+    id: (state, props) => props.params.taskId,
+  }),
+  connect(null, { goBack }),
+)(TaskModalInner);
 
 export default TaskModal;

--- a/frontend/src/metabase/admin/tasks/containers/TasksApp.jsx
+++ b/frontend/src/metabase/admin/tasks/containers/TasksApp.jsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/prop-types */
 import React from "react";
 import { t } from "ttag";
+import _ from "underscore";
 
 import Database from "metabase/entities/databases";
 import Task from "metabase/entities/tasks";
@@ -20,11 +21,8 @@ import {
 // Please preserve the following 2 @ calls in this order.
 // Otherwise @Database.loadList overrides pagination props
 // that come from @Task.LoadList
-@Database.loadList()
-@Task.loadList({
-  pageSize: 50,
-})
-class TasksApp extends React.Component {
+
+class TasksAppInner extends React.Component {
   render() {
     const {
       tasks,
@@ -112,5 +110,12 @@ class TasksApp extends React.Component {
     );
   }
 }
+
+const TasksApp = _.compose(
+  Database.loadList(),
+  Task.loadList({
+    pageSize: 50,
+  }),
+)(TasksAppInner);
 
 export default TasksApp;

--- a/frontend/src/metabase/components/AdminAwareEmptyState.jsx
+++ b/frontend/src/metabase/components/AdminAwareEmptyState.jsx
@@ -13,8 +13,7 @@ const mapStateToProps = (state, props) => ({
   user: getUser(state, props),
 });
 
-@connect(mapStateToProps, null)
-class AdminAwareEmptyState extends Component {
+class AdminAwareEmptyStateInner extends Component {
   render() {
     const {
       user,
@@ -48,5 +47,10 @@ class AdminAwareEmptyState extends Component {
     );
   }
 }
+
+const AdminAwareEmptyState = connect(
+  mapStateToProps,
+  null,
+)(AdminAwareEmptyStateInner);
 
 export default AdminAwareEmptyState;

--- a/frontend/src/metabase/components/ArchiveCollectionModal.jsx
+++ b/frontend/src/metabase/components/ArchiveCollectionModal.jsx
@@ -1,5 +1,6 @@
 /* eslint-disable react/prop-types */
 import React from "react";
+import _ from "underscore";
 
 import { connect } from "react-redux";
 import { withRouter } from "react-router";
@@ -17,12 +18,7 @@ const mapDispatchToProps = {
   push,
 };
 
-@connect(null, mapDispatchToProps)
-@Collection.load({
-  id: (state, props) => Urls.extractCollectionId(props.params.slug),
-})
-@withRouter
-class ArchiveCollectionModal extends React.Component {
+class ArchiveCollectionModalInner extends React.Component {
   archive = async () => {
     const { setCollectionArchived, params } = this.props;
     const id = Urls.extractCollectionId(params.slug);
@@ -53,5 +49,13 @@ class ArchiveCollectionModal extends React.Component {
     );
   }
 }
+
+const ArchiveCollectionModal = _.compose(
+  connect(null, mapDispatchToProps),
+  Collection.load({
+    id: (state, props) => Urls.extractCollectionId(props.params.slug),
+  }),
+  withRouter,
+)(ArchiveCollectionModalInner);
 
 export default ArchiveCollectionModal;

--- a/frontend/src/metabase/components/CreateDashboardModal.jsx
+++ b/frontend/src/metabase/components/CreateDashboardModal.jsx
@@ -4,6 +4,7 @@ import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { withRouter } from "react-router";
 import { push } from "react-router-redux";
+import _ from "underscore";
 
 import * as Urls from "metabase/lib/urls";
 
@@ -21,9 +22,7 @@ const mapDispatchToProps = {
   onChangeLocation: push,
 };
 
-@withRouter
-@connect(mapStateToProps, mapDispatchToProps)
-export default class CreateDashboardModal extends Component {
+class CreateDashboardModal extends Component {
   static propTypes = {
     onSaved: PropTypes.func,
     onClose: PropTypes.func,
@@ -52,3 +51,8 @@ export default class CreateDashboardModal extends Component {
     );
   }
 }
+
+export default _.compose(
+  withRouter,
+  connect(mapStateToProps, mapDispatchToProps),
+)(CreateDashboardModal);

--- a/frontend/src/metabase/components/DebouncedFrame.jsx
+++ b/frontend/src/metabase/components/DebouncedFrame.jsx
@@ -13,8 +13,8 @@ const DEBOUNCE_PERIOD = 300;
  * Useful for rendering components that maybe take a long time to render but you still wnat to allow their container to be resized fluidly
  * We also fade the component out and block mouse events while it's transitioning
  */
-@ExplicitSize()
-export default class DebouncedFrame extends React.Component {
+
+class DebouncedFrame extends React.Component {
   // NOTE: don't keep `_transition` in component state because we don't want to trigger a rerender when we update it
   // Instead manually modify the style in _updateTransitionStyle
   // There's probably a better way to block renders of children though
@@ -104,3 +104,5 @@ export default class DebouncedFrame extends React.Component {
     );
   }
 }
+
+export default ExplicitSize()(DebouncedFrame);

--- a/frontend/src/metabase/components/FieldValuesWidget.jsx
+++ b/frontend/src/metabase/components/FieldValuesWidget.jsx
@@ -49,8 +49,7 @@ function mapStateToProps(state, { fields = [] }) {
   };
 }
 
-@AutoExpanding
-export class FieldValuesWidget extends Component {
+class FieldValuesWidgetInner extends Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -496,6 +495,8 @@ export class FieldValuesWidget extends Component {
     );
   }
 }
+
+export const FieldValuesWidget = AutoExpanding(FieldValuesWidgetInner);
 
 FieldValuesWidget.propTypes = fieldValuesWidgetPropTypes;
 

--- a/frontend/src/metabase/components/HeaderModal.jsx
+++ b/frontend/src/metabase/components/HeaderModal.jsx
@@ -5,8 +5,7 @@ import BodyComponent from "metabase/components/BodyComponent";
 import cx from "classnames";
 import { t } from "ttag";
 
-@BodyComponent
-export default class HeaderModal extends Component {
+class HeaderModal extends Component {
   constructor(props, context) {
     super(props, context);
     this.state = {
@@ -54,3 +53,5 @@ export default class HeaderModal extends Component {
     );
   }
 }
+
+export default BodyComponent(HeaderModal);

--- a/frontend/src/metabase/containers/AddToDashSelectDashModal.jsx
+++ b/frontend/src/metabase/containers/AddToDashSelectDashModal.jsx
@@ -18,8 +18,7 @@ function mapStateToProps(state) {
   };
 }
 
-@connect(mapStateToProps)
-export default class AddToDashSelectDashModal extends Component {
+class AddToDashSelectDashModal extends Component {
   state = {
     shouldCreateDashboard: false,
   };
@@ -75,3 +74,5 @@ export default class AddToDashSelectDashModal extends Component {
     }
   }
 }
+
+export default connect(mapStateToProps)(AddToDashSelectDashModal);

--- a/frontend/src/metabase/containers/Form.jsx
+++ b/frontend/src/metabase/containers/Form.jsx
@@ -54,8 +54,7 @@ const ReduxFormComponent = reduxForm()(
   },
 );
 
-@connect(makeMapStateToProps)
-export default class Form extends React.Component {
+class Form extends React.Component {
   _state = {
     submitting: false,
     failed: false,
@@ -282,6 +281,8 @@ export default class Form extends React.Component {
     );
   }
 }
+
+export default connect(makeMapStateToProps)(Form);
 
 // returns a function that takes an object
 // apply the top level method (if any) to the whole object

--- a/frontend/src/metabase/containers/HistoryModal.jsx
+++ b/frontend/src/metabase/containers/HistoryModal.jsx
@@ -5,14 +5,7 @@ import PropTypes from "prop-types";
 import HistoryModal from "metabase/components/HistoryModal";
 import Revision from "metabase/entities/revisions";
 
-@Revision.loadList({
-  query: (state, props) => ({
-    model_type: props.modelType,
-    model_id: props.modelId,
-  }),
-  wrapped: true,
-})
-export default class HistoryModalContainer extends React.Component {
+class HistoryModalContainer extends React.Component {
   static propTypes = {
     canRevert: PropTypes.bool.isRequired,
   };
@@ -37,3 +30,11 @@ export default class HistoryModalContainer extends React.Component {
     );
   }
 }
+
+export default Revision.loadList({
+  query: (state, props) => ({
+    model_type: props.modelType,
+    model_id: props.modelId,
+  }),
+  wrapped: true,
+})(HistoryModalContainer);

--- a/frontend/src/metabase/containers/ItemPicker.jsx
+++ b/frontend/src/metabase/containers/ItemPicker.jsx
@@ -30,19 +30,7 @@ const getCollectionIconColor = () => color("text-light");
 
 const isRoot = collection => collection.id === "root" || collection.id == null;
 
-@entityListLoader({
-  entityType: (state, props) => {
-    return props.entity ? props.entity.name : "collections";
-  },
-  loadingAndErrorWrapper: false,
-})
-@connect((state, props) => ({
-  collectionsById: (
-    props.entity || Collections
-  ).selectors.getExpandedCollectionsById(state),
-  getCollectionIcon: (props.entity || Collections).objectSelectors.getIcon,
-}))
-export default class ItemPicker extends React.Component {
+class ItemPicker extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -292,6 +280,21 @@ export default class ItemPicker extends React.Component {
     );
   }
 }
+
+export default _.compose(
+  entityListLoader({
+    entityType: (state, props) => {
+      return props.entity ? props.entity.name : "collections";
+    },
+    loadingAndErrorWrapper: false,
+  }),
+  connect((state, props) => ({
+    collectionsById: (
+      props.entity || Collections
+    ).selectors.getExpandedCollectionsById(state),
+    getCollectionIcon: (props.entity || Collections).objectSelectors.getIcon,
+  })),
+)(ItemPicker);
 
 const Item = ({
   item,

--- a/frontend/src/metabase/containers/dnd/ItemDragSource.jsx
+++ b/frontend/src/metabase/containers/dnd/ItemDragSource.jsx
@@ -6,7 +6,30 @@ import { getEmptyImage } from "react-dnd-html5-backend";
 
 import { dragTypeForItem } from ".";
 
-@DragSource(
+class ItemDragSource extends React.Component {
+  componentDidMount() {
+    // Use empty image as a drag preview so browsers don't draw it
+    // and we can draw whatever we want on the custom drag layer instead.
+    if (this.props.connectDragPreview) {
+      this.props.connectDragPreview(getEmptyImage(), {
+        // IE fallback: specify that we'd rather screenshot the node
+        // when it already knows it's being dragged so we can hide it with CSS.
+        captureDraggingState: true,
+      });
+    }
+  }
+  render() {
+    const { connectDragSource, children, ...props } = this.props;
+    return connectDragSource(
+      // must be a native DOM element or use innerRef which appears to be broken
+      // https://github.com/react-dnd/react-dnd/issues/1021
+      // https://github.com/jxnblk/styled-system/pull/188
+      typeof children === "function" ? children(props) : children,
+    );
+  }
+}
+
+export default DragSource(
   props => dragTypeForItem(props.item),
   {
     canDrag({ isSelected, selected, collection, item }, monitor) {
@@ -53,26 +76,4 @@ import { dragTypeForItem } from ".";
     connectDragPreview: connect.dragPreview(),
     isDragging: monitor.isDragging(),
   }),
-)
-export default class ItemDragSource extends React.Component {
-  componentDidMount() {
-    // Use empty image as a drag preview so browsers don't draw it
-    // and we can draw whatever we want on the custom drag layer instead.
-    if (this.props.connectDragPreview) {
-      this.props.connectDragPreview(getEmptyImage(), {
-        // IE fallback: specify that we'd rather screenshot the node
-        // when it already knows it's being dragged so we can hide it with CSS.
-        captureDraggingState: true,
-      });
-    }
-  }
-  render() {
-    const { connectDragSource, children, ...props } = this.props;
-    return connectDragSource(
-      // must be a native DOM element or use innerRef which appears to be broken
-      // https://github.com/react-dnd/react-dnd/issues/1021
-      // https://github.com/jxnblk/styled-system/pull/188
-      typeof children === "function" ? children(props) : children,
-    );
-  }
-}
+)(ItemDragSource);

--- a/frontend/src/metabase/containers/dnd/ItemsDragLayer.jsx
+++ b/frontend/src/metabase/containers/dnd/ItemsDragLayer.jsx
@@ -10,14 +10,7 @@ import PinnedItemCard from "metabase/collections/components/PinnedItemCard";
 // NOTE: our version of react-hot-loader doesn't play nice with react-dnd's DragLayer,
 // so we exclude files named `*DragLayer.jsx` in webpack.config.js
 
-@DragLayer((monitor, props) => ({
-  item: monitor.getItem(),
-  // itemType: monitor.getItemType(),
-  initialOffset: monitor.getInitialSourceClientOffset(),
-  currentOffset: monitor.getSourceClientOffset(),
-  isDragging: monitor.isDragging(),
-}))
-class ItemsDragLayer extends React.Component {
+class ItemsDragLayerInner extends React.Component {
   render() {
     const {
       isDragging,
@@ -55,6 +48,14 @@ class ItemsDragLayer extends React.Component {
     );
   }
 }
+
+const ItemsDragLayer = DragLayer((monitor, props) => ({
+  item: monitor.getItem(),
+  // itemType: monitor.getItemType(),
+  initialOffset: monitor.getInitialSourceClientOffset(),
+  currentOffset: monitor.getSourceClientOffset(),
+  isDragging: monitor.isDragging(),
+}))(ItemsDragLayerInner);
 
 export default BodyComponent(ItemsDragLayer);
 

--- a/frontend/src/metabase/containers/dnd/ItemsDragLayer.jsx
+++ b/frontend/src/metabase/containers/dnd/ItemsDragLayer.jsx
@@ -17,8 +17,7 @@ import PinnedItemCard from "metabase/collections/components/PinnedItemCard";
   currentOffset: monitor.getSourceClientOffset(),
   isDragging: monitor.isDragging(),
 }))
-@BodyComponent
-export default class ItemsDragLayer extends React.Component {
+class ItemsDragLayer extends React.Component {
   render() {
     const {
       isDragging,
@@ -56,6 +55,8 @@ export default class ItemsDragLayer extends React.Component {
     );
   }
 }
+
+export default BodyComponent(ItemsDragLayer);
 
 class DraggedItems extends React.Component {
   shouldComponentUpdate(nextProps) {

--- a/frontend/src/metabase/core/components/Select/Select.jsx
+++ b/frontend/src/metabase/core/components/Select/Select.jsx
@@ -18,8 +18,7 @@ import { composeEventHandlers } from "metabase/lib/compose-event-handlers";
 
 const MIN_ICON_WIDTH = 20;
 
-@Uncontrollable()
-export default class Select extends Component {
+class Select extends Component {
   static propTypes = {
     className: PropTypes.string,
 
@@ -260,6 +259,8 @@ export default class Select extends Component {
     );
   }
 }
+
+export default Uncontrollable()(Select);
 export class OptionSection extends Component {
   static propTypes = {
     name: PropTypes.any,

--- a/frontend/src/metabase/dashboard/components/AddSeriesModal/AddSeriesModal.jsx
+++ b/frontend/src/metabase/dashboard/components/AddSeriesModal/AddSeriesModal.jsx
@@ -5,6 +5,7 @@ import { t } from "ttag";
 import { getIn } from "icepick";
 import { connect } from "react-redux";
 import { createSelector } from "reselect";
+import _ from "underscore";
 
 import Visualization from "metabase/visualizations/components/Visualization";
 
@@ -28,14 +29,8 @@ const getQuestions = createSelector(
 );
 
 // TODO: rework this so we don't have to load all cards up front
-@Questions.loadList({ query: { f: "all" } })
-@connect(
-  (state, ownProps) => ({
-    questions: getQuestions(state, ownProps),
-  }),
-  { loadMetadataForQueries },
-)
-export default class AddSeriesModal extends Component {
+
+class AddSeriesModal extends Component {
   constructor(props, context) {
     super(props, context);
 
@@ -243,3 +238,13 @@ export default class AddSeriesModal extends Component {
     );
   }
 }
+
+export default _.compose(
+  Questions.loadList({ query: { f: "all" } }),
+  connect(
+    (state, ownProps) => ({
+      questions: getQuestions(state, ownProps),
+    }),
+    { loadMetadataForQueries },
+  ),
+)(AddSeriesModal);

--- a/frontend/src/metabase/dashboard/components/ClickMappings.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickMappings.jsx
@@ -18,38 +18,7 @@ import { loadMetadataForQuery } from "metabase/redux/metadata";
 import { getMetadata } from "metabase/selectors/metadata";
 import { getParameters } from "metabase/dashboard/selectors";
 
-@loadQuestionMetadata((state, props) => (props.isDash ? null : props.object))
-@withUserAttributes
-@connect((state, props) => {
-  const { object, isDash, dashcard, clickBehavior } = props;
-  const metadata = getMetadata(state, props);
-  let parameters = getParameters(state, props);
-
-  if (props.excludeParametersSources) {
-    // Remove parameters as possible sources.
-    // We still include any that were already in use prior to this code change.
-    const parametersUsedAsSources = Object.values(
-      clickBehavior.parameterMapping || {},
-    )
-      .filter(mapping => getIn(mapping, ["source", "type"]) === "parameter")
-      .map(mapping => mapping.source.id);
-    parameters = parameters.filter(p => {
-      return parametersUsedAsSources.includes(p.id);
-    });
-  }
-
-  const [setTargets, unsetTargets] = _.partition(
-    getTargetsWithSourceFilters({ isDash, dashcard, object, metadata }),
-    ({ id }) =>
-      getIn(clickBehavior, ["parameterMapping", id, "source"]) != null,
-  );
-  const sourceOptions = {
-    column: dashcard.card.result_metadata.filter(isMappableColumn),
-    parameter: parameters,
-  };
-  return { setTargets, unsetTargets, sourceOptions };
-})
-class ClickMappings extends React.Component {
+class ClickMappingsInner extends React.Component {
   render() {
     const { setTargets, unsetTargets } = this.props;
     const sourceOptions = {
@@ -143,6 +112,40 @@ class ClickMappings extends React.Component {
     return "Unknown";
   }
 }
+
+const ClickMappings = _.compose(
+  loadQuestionMetadata((state, props) => (props.isDash ? null : props.object)),
+  withUserAttributes,
+  connect((state, props) => {
+    const { object, isDash, dashcard, clickBehavior } = props;
+    const metadata = getMetadata(state, props);
+    let parameters = getParameters(state, props);
+
+    if (props.excludeParametersSources) {
+      // Remove parameters as possible sources.
+      // We still include any that were already in use prior to this code change.
+      const parametersUsedAsSources = Object.values(
+        clickBehavior.parameterMapping || {},
+      )
+        .filter(mapping => getIn(mapping, ["source", "type"]) === "parameter")
+        .map(mapping => mapping.source.id);
+      parameters = parameters.filter(p => {
+        return parametersUsedAsSources.includes(p.id);
+      });
+    }
+
+    const [setTargets, unsetTargets] = _.partition(
+      getTargetsWithSourceFilters({ isDash, dashcard, object, metadata }),
+      ({ id }) =>
+        getIn(clickBehavior, ["parameterMapping", id, "source"]) != null,
+    );
+    const sourceOptions = {
+      column: dashcard.card.result_metadata.filter(isMappableColumn),
+      parameter: parameters,
+    };
+    return { setTargets, unsetTargets, sourceOptions };
+  }),
+)(ClickMappingsInner);
 
 const getKeyForSource = o => (o.type == null ? null : `${o.type}-${o.id}`);
 const getSourceOption = {
@@ -260,13 +263,6 @@ function TargetWithSource({
 // TODO: Extract this to a more general HOC. It can probably also take care of withTableMetadataLoaded.
 function loadQuestionMetadata(getQuestion) {
   return ComposedComponent => {
-    @connect(
-      (state, props) => ({
-        metadata: getMetadata(state),
-        question: getQuestion && getQuestion(state, props),
-      }),
-      { loadMetadataForQuery },
-    )
     class MetadataLoader extends React.Component {
       componentDidMount() {
         if (this.props.question) {
@@ -295,7 +291,13 @@ function loadQuestionMetadata(getQuestion) {
       }
     }
 
-    return MetadataLoader;
+    return connect(
+      (state, props) => ({
+        metadata: getMetadata(state),
+        question: getQuestion && getQuestion(state, props),
+      }),
+      { loadMetadataForQuery },
+    )(MetadataLoader);
   };
 }
 

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
@@ -26,8 +26,8 @@ import { getValuePopulatedParameters } from "metabase/parameters/utils/parameter
 const SCROLL_THROTTLE_INTERVAL = 1000 / 24;
 
 // NOTE: move DashboardControls HoC to container
-@DashboardControls
-export default class Dashboard extends Component {
+
+class Dashboard extends Component {
   state = {
     error: null,
     isParametersWidgetSticky: false,
@@ -330,3 +330,5 @@ export default class Dashboard extends Component {
     );
   }
 }
+
+export default DashboardControls(Dashboard);

--- a/frontend/src/metabase/dashboard/components/DashboardCopyModal.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardCopyModal.jsx
@@ -3,6 +3,7 @@ import React from "react";
 import { withRouter } from "react-router";
 import { connect } from "react-redux";
 import { dissoc } from "icepick";
+import _ from "underscore";
 
 import { replace } from "react-router-redux";
 import * as Urls from "metabase/lib/urls";
@@ -30,9 +31,7 @@ const mapDispatchToProps = {
   onReplaceLocation: replace,
 };
 
-@withRouter
-@connect(mapStateToProps, mapDispatchToProps)
-class DashboardCopyModal extends React.Component {
+class DashboardCopyModalInner extends React.Component {
   render() {
     const {
       onClose,
@@ -62,5 +61,10 @@ class DashboardCopyModal extends React.Component {
     );
   }
 }
+
+const DashboardCopyModal = _.compose(
+  withRouter,
+  connect(mapStateToProps, mapDispatchToProps),
+)(DashboardCopyModalInner);
 
 export default DashboardCopyModal;

--- a/frontend/src/metabase/dashboard/components/DashboardDetailsModal.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardDetailsModal.jsx
@@ -21,9 +21,7 @@ const mapDispatchToProps = { setDashboardAttributes };
 
 const COLLAPSED_FIELDS = ["cache_ttl"];
 
-@withRouter
-@connect(mapStateToProps, mapDispatchToProps)
-class DashboardDetailsModal extends React.Component {
+class DashboardDetailsModalInner extends React.Component {
   render() {
     const {
       onClose,
@@ -79,5 +77,10 @@ class DashboardDetailsModal extends React.Component {
     );
   }
 }
+
+const DashboardDetailsModal = _.compose(
+  withRouter,
+  connect(mapStateToProps, mapDispatchToProps),
+)(DashboardDetailsModalInner);
 
 export default DashboardDetailsModal;

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
@@ -30,8 +30,7 @@ import AddSeriesModal from "./AddSeriesModal/AddSeriesModal";
 import RemoveFromDashboardModal from "./RemoveFromDashboardModal";
 import DashCard from "./DashCard";
 
-@ExplicitSize()
-export default class DashboardGrid extends Component {
+class DashboardGrid extends Component {
   constructor(props, context) {
     super(props, context);
 
@@ -369,3 +368,5 @@ export default class DashboardGrid extends Component {
     );
   }
 }
+
+export default ExplicitSize()(DashboardGrid);

--- a/frontend/src/metabase/dashboard/components/DashboardHistoryModal.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHistoryModal.jsx
@@ -2,6 +2,7 @@
 import React from "react";
 import { connect } from "react-redux";
 import { withRouter } from "react-router";
+import _ from "underscore";
 
 import HistoryModal from "metabase/containers/HistoryModal";
 import * as Urls from "metabase/lib/urls";
@@ -11,13 +12,7 @@ import {
 } from "metabase/dashboard/actions";
 import Dashboards from "metabase/entities/dashboards";
 
-@withRouter
-@Dashboards.load({
-  id: (state, props) => Urls.extractEntityId(props.params.slug),
-  wrapped: false,
-})
-@connect(null, { fetchDashboard, fetchDashboardCardData })
-export default class DashboardHistoryModal extends React.Component {
+class DashboardHistoryModal extends React.Component {
   render() {
     const {
       dashboard,
@@ -41,3 +36,12 @@ export default class DashboardHistoryModal extends React.Component {
     );
   }
 }
+
+export default _.compose(
+  withRouter,
+  Dashboards.load({
+    id: (state, props) => Urls.extractEntityId(props.params.slug),
+    wrapped: false,
+  }),
+  connect(null, { fetchDashboard, fetchDashboardCardData }),
+)(DashboardHistoryModal);

--- a/frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx
@@ -3,6 +3,7 @@ import React from "react";
 import { withRouter } from "react-router";
 import { connect } from "react-redux";
 import { t, jt } from "ttag";
+import _ from "underscore";
 
 import Icon from "metabase/components/Icon";
 import CollectionMoveModal from "metabase/containers/CollectionMoveModal";
@@ -18,9 +19,7 @@ const mapDispatchToProps = {
   setDashboardCollection: Dashboards.actions.setCollection,
 };
 
-@withRouter
-@connect(null, mapDispatchToProps)
-class DashboardMoveModal extends React.Component {
+class DashboardMoveModalInner extends React.Component {
   render() {
     const { params, onClose, setDashboardCollection } = this.props;
     const dashboardId = Urls.extractEntityId(params.slug);
@@ -44,6 +43,11 @@ class DashboardMoveModal extends React.Component {
     );
   }
 }
+
+const DashboardMoveModal = _.compose(
+  withRouter,
+  connect(null, mapDispatchToProps),
+)(DashboardMoveModalInner);
 
 export default DashboardMoveModal;
 

--- a/frontend/src/metabase/dashboard/containers/ArchiveDashboardModal.jsx
+++ b/frontend/src/metabase/dashboard/containers/ArchiveDashboardModal.jsx
@@ -2,6 +2,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { t } from "ttag";
+import _ from "underscore";
 
 import { connect } from "react-redux";
 import { withRouter } from "react-router";
@@ -19,15 +20,7 @@ const mapDispatchToProps = {
   push,
 };
 
-@connect(null, mapDispatchToProps)
-@Dashboard.load({
-  id: (state, props) => Urls.extractCollectionId(props.params.slug),
-})
-@Collection.load({
-  id: (state, props) => props.dashboard && props.dashboard.collection_id,
-})
-@withRouter
-export default class ArchiveDashboardModal extends Component {
+class ArchiveDashboardModal extends Component {
   static propTypes = {
     onClose: PropTypes.func,
   };
@@ -58,3 +51,14 @@ export default class ArchiveDashboardModal extends Component {
     );
   }
 }
+
+export default _.compose(
+  connect(null, mapDispatchToProps),
+  Dashboard.load({
+    id: (state, props) => Urls.extractCollectionId(props.params.slug),
+  }),
+  Collection.load({
+    id: (state, props) => props.dashboard && props.dashboard.collection_id,
+  }),
+  withRouter,
+)(ArchiveDashboardModal);

--- a/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx
+++ b/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx
@@ -3,6 +3,7 @@ import React from "react";
 import { t } from "ttag";
 import { connect } from "react-redux";
 import cx from "classnames";
+import _ from "underscore";
 
 import title from "metabase/hoc/Title";
 import withToast from "metabase/hoc/Toast";
@@ -52,11 +53,7 @@ const mapDispatchToProps = {
   invalidateCollections: Collections.actions.invalidateLists,
 };
 
-@connect(mapStateToProps, mapDispatchToProps)
-@DashboardData
-@withToast
-@title(({ dashboard }) => dashboard && dashboard.name)
-class AutomaticDashboardApp extends React.Component {
+class AutomaticDashboardAppInner extends React.Component {
   state = {
     savedDashboardId: null,
   };
@@ -192,6 +189,13 @@ class AutomaticDashboardApp extends React.Component {
     );
   }
 }
+
+const AutomaticDashboardApp = _.compose(
+  connect(mapStateToProps, mapDispatchToProps),
+  DashboardData,
+  withToast,
+  title(({ dashboard }) => dashboard && dashboard.name),
+)(AutomaticDashboardAppInner);
 
 const TransientTitle = ({ dashboard }) =>
   dashboard.transient_name ? (

--- a/frontend/src/metabase/dashboard/containers/DashboardHeader.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardHeader.jsx
@@ -4,6 +4,7 @@ import { connect } from "react-redux";
 import { push } from "react-router-redux";
 import PropTypes from "prop-types";
 import { t } from "ttag";
+import _ from "underscore";
 
 import ActionButton from "metabase/components/ActionButton";
 import Button from "metabase/core/components/Button";
@@ -36,9 +37,7 @@ const mapDispatchToProps = {
   onChangeLocation: push,
 };
 
-@Bookmark.loadList()
-@connect(mapStateToProps, mapDispatchToProps)
-export default class DashboardHeader extends Component {
+class DashboardHeader extends Component {
   constructor(props) {
     super(props);
 
@@ -397,3 +396,8 @@ export default class DashboardHeader extends Component {
     );
   }
 }
+
+export default _.compose(
+  Bookmark.loadList(),
+  connect(mapStateToProps, mapDispatchToProps),
+)(DashboardHeader);

--- a/frontend/src/metabase/entities/containers/EntityForm.jsx
+++ b/frontend/src/metabase/entities/containers/EntityForm.jsx
@@ -53,8 +53,7 @@ const Modal = ({
   );
 };
 
-@entityType()
-export default class EntityForm extends React.Component {
+class EntityForm extends React.Component {
   render() {
     const { modal, ...props } = this.props;
 
@@ -67,3 +66,5 @@ export default class EntityForm extends React.Component {
     }
   }
 }
+
+export default entityType()(EntityForm);

--- a/frontend/src/metabase/entities/containers/EntityListLoader.jsx
+++ b/frontend/src/metabase/entities/containers/EntityListLoader.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
@@ -77,57 +78,7 @@ const getMemoizedEntityQuery = createMemoizedSelector(
   entityQuery => entityQuery,
 );
 
-@entityType()
-@paginationState()
-@connect((state, props) => {
-  let {
-    entityDef,
-    entityQuery,
-    reloadInterval,
-    page,
-    pageSize,
-    allLoading,
-    allLoaded,
-    allFetched,
-    allError,
-    selectorName = "getList",
-  } = props;
-  if (typeof entityQuery === "function") {
-    entityQuery = entityQuery(state, props);
-  }
-  if (typeof pageSize === "number" && typeof page === "number") {
-    entityQuery = { limit: pageSize, offset: pageSize * page, ...entityQuery };
-  }
-  entityQuery = getMemoizedEntityQuery(state, { entityQuery });
-
-  const list = entityDef.selectors[selectorName](state, { entityQuery });
-  if (typeof reloadInterval === "function") {
-    reloadInterval = reloadInterval(state, props, list);
-  }
-
-  const loading = entityDef.selectors.getLoading(state, { entityQuery });
-  const loaded = entityDef.selectors.getLoaded(state, { entityQuery });
-  const fetched = entityDef.selectors.getFetched(state, { entityQuery });
-  const error = entityDef.selectors.getError(state, { entityQuery });
-  const metadata = entityDef.selectors.getListMetadata(state, { entityQuery });
-
-  return {
-    list,
-    entityQuery,
-    reloadInterval,
-    metadata,
-    loading,
-    loaded,
-    fetched,
-    error,
-    // merge props passed in from stacked Entity*Loaders:
-    allLoading: loading || (allLoading == null ? false : allLoading),
-    allLoaded: loaded && (allLoaded == null ? true : allLoaded),
-    allFetched: fetched && (allFetched == null ? true : allFetched),
-    allError: error || (allError == null ? null : allError),
-  };
-})
-class EntityListLoader extends React.Component {
+class EntityListLoaderInner extends React.Component {
   state = {
     previousList: [],
     isReloading: this.props.reload,
@@ -275,6 +226,65 @@ class EntityListLoader extends React.Component {
     this.fetchList(this.props, { reload: true });
   };
 }
+
+const EntityListLoader = _.compose(
+  entityType(),
+  paginationState(),
+  connect((state, props) => {
+    let {
+      entityDef,
+      entityQuery,
+      reloadInterval,
+      page,
+      pageSize,
+      allLoading,
+      allLoaded,
+      allFetched,
+      allError,
+      selectorName = "getList",
+    } = props;
+    if (typeof entityQuery === "function") {
+      entityQuery = entityQuery(state, props);
+    }
+    if (typeof pageSize === "number" && typeof page === "number") {
+      entityQuery = {
+        limit: pageSize,
+        offset: pageSize * page,
+        ...entityQuery,
+      };
+    }
+    entityQuery = getMemoizedEntityQuery(state, { entityQuery });
+
+    const list = entityDef.selectors[selectorName](state, { entityQuery });
+    if (typeof reloadInterval === "function") {
+      reloadInterval = reloadInterval(state, props, list);
+    }
+
+    const loading = entityDef.selectors.getLoading(state, { entityQuery });
+    const loaded = entityDef.selectors.getLoaded(state, { entityQuery });
+    const fetched = entityDef.selectors.getFetched(state, { entityQuery });
+    const error = entityDef.selectors.getError(state, { entityQuery });
+    const metadata = entityDef.selectors.getListMetadata(state, {
+      entityQuery,
+    });
+
+    return {
+      list,
+      entityQuery,
+      reloadInterval,
+      metadata,
+      loading,
+      loaded,
+      fetched,
+      error,
+      // merge props passed in from stacked Entity*Loaders:
+      allLoading: loading || (allLoading == null ? false : allLoading),
+      allLoaded: loaded && (allLoaded == null ? true : allLoaded),
+      allFetched: fetched && (allFetched == null ? true : allFetched),
+      allError: error || (allError == null ? null : allError),
+    };
+  }),
+)(EntityListLoaderInner);
 
 EntityListLoader.propTypes = propTypes;
 EntityListLoader.defaultProps = defaultProps;

--- a/frontend/src/metabase/entities/containers/EntityObjectLoader.jsx
+++ b/frontend/src/metabase/entities/containers/EntityObjectLoader.jsx
@@ -29,7 +29,7 @@ const getMemoizedEntityQuery = createMemoizedSelector(
   entityQuery => entityQuery,
 );
 
-class EntityObjectLoader extends React.Component {
+class EntityObjectLoaderInner extends React.Component {
   static defaultProps = {
     loadingAndErrorWrapper: true,
     LoadingAndErrorWrapper: LoadingAndErrorWrapper,
@@ -139,7 +139,7 @@ class EntityObjectLoader extends React.Component {
   };
 }
 
-export default _.compose(
+const EntityObjectLoader = _.compose(
   entityType(),
   connect(
     (
@@ -169,7 +169,9 @@ export default _.compose(
       };
     },
   ),
-)(EntityObjectLoader);
+)(EntityObjectLoaderInner);
+
+export default EntityObjectLoader;
 
 export const entityObjectLoader = eolProps =>
   // eslint-disable-line react/display-name

--- a/frontend/src/metabase/entities/containers/EntityObjectLoader.jsx
+++ b/frontend/src/metabase/entities/containers/EntityObjectLoader.jsx
@@ -29,30 +29,7 @@ const getMemoizedEntityQuery = createMemoizedSelector(
   entityQuery => entityQuery,
 );
 
-@entityType()
-@connect(
-  (
-    state,
-    { entityDef, entityId, entityQuery, selectorName = "getObject", ...props },
-  ) => {
-    if (typeof entityId === "function") {
-      entityId = entityId(state, props);
-    }
-    if (typeof entityQuery === "function") {
-      entityQuery = entityQuery(state, props);
-    }
-
-    return {
-      entityId,
-      entityQuery: getMemoizedEntityQuery(state, entityQuery),
-      object: entityDef.selectors[selectorName](state, { entityId }),
-      fetched: entityDef.selectors.getFetched(state, { entityId }),
-      loading: entityDef.selectors.getLoading(state, { entityId }),
-      error: entityDef.selectors.getError(state, { entityId }),
-    };
-  },
-)
-export default class EntityObjectLoader extends React.Component {
+class EntityObjectLoader extends React.Component {
   static defaultProps = {
     loadingAndErrorWrapper: true,
     LoadingAndErrorWrapper: LoadingAndErrorWrapper,
@@ -161,6 +138,38 @@ export default class EntityObjectLoader extends React.Component {
     return this.props.delete(this.props.object);
   };
 }
+
+export default _.compose(
+  entityType(),
+  connect(
+    (
+      state,
+      {
+        entityDef,
+        entityId,
+        entityQuery,
+        selectorName = "getObject",
+        ...props
+      },
+    ) => {
+      if (typeof entityId === "function") {
+        entityId = entityId(state, props);
+      }
+      if (typeof entityQuery === "function") {
+        entityQuery = entityQuery(state, props);
+      }
+
+      return {
+        entityId,
+        entityQuery: getMemoizedEntityQuery(state, entityQuery),
+        object: entityDef.selectors[selectorName](state, { entityId }),
+        fetched: entityDef.selectors.getFetched(state, { entityId }),
+        loading: entityDef.selectors.getLoading(state, { entityId }),
+        error: entityDef.selectors.getError(state, { entityId }),
+      };
+    },
+  ),
+)(EntityObjectLoader);
 
 export const entityObjectLoader = eolProps =>
   // eslint-disable-line react/display-name

--- a/frontend/src/metabase/hoc/ScrollToTop.js
+++ b/frontend/src/metabase/hoc/ScrollToTop.js
@@ -2,8 +2,7 @@
 import React from "react";
 import { withRouter } from "react-router";
 
-@withRouter
-class ScrollToTop extends React.Component {
+class ScrollToTopInner extends React.Component {
   componentDidUpdate(prevProps) {
     // Compare location.pathame to see if we're on a different URL. Do this to ensure
     // that query strings don't cause a scroll to the top
@@ -15,5 +14,7 @@ class ScrollToTop extends React.Component {
     return this.props.children;
   }
 }
+
+const ScrollToTop = withRouter(ScrollToTopInner);
 
 export default ScrollToTop;

--- a/frontend/src/metabase/hoc/Toast.jsx
+++ b/frontend/src/metabase/hoc/Toast.jsx
@@ -9,7 +9,6 @@ const mapDispatchToProps = {
 };
 
 const withToaster = ComposedComponent => {
-  @connect(null, mapDispatchToProps)
   class ToastedComponent extends React.Component {
     _triggerToast = (message, options = {}) => {
       const { addUndo } = this.props;
@@ -25,7 +24,7 @@ const withToaster = ComposedComponent => {
       );
     }
   }
-  return ToastedComponent;
+  return connect(null, mapDispatchToProps)(ToastedComponent);
 };
 
 export default withToaster;

--- a/frontend/src/metabase/home/containers/ActivityApp.jsx
+++ b/frontend/src/metabase/home/containers/ActivityApp.jsx
@@ -32,8 +32,7 @@ const mapDispatchToProps = {
   onChangeLocation: push,
 };
 
-@connect(mapStateToProps, mapDispatchToProps)
-export default class ActivityApp extends Component {
+class ActivityApp extends Component {
   static propTypes = {
     onChangeLocation: PropTypes.func.isRequired,
     user: PropTypes.object.isRequired,
@@ -70,3 +69,5 @@ export default class ActivityApp extends Component {
     );
   }
 }
+
+export default connect(mapStateToProps, mapDispatchToProps)(ActivityApp);

--- a/frontend/src/metabase/home/containers/ArchiveApp.jsx
+++ b/frontend/src/metabase/home/containers/ArchiveApp.jsx
@@ -2,6 +2,7 @@
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import { t } from "ttag";
+import _ from "underscore";
 
 import ArchivedItem from "../../components/ArchivedItem";
 import Button from "metabase/core/components/Button";
@@ -38,14 +39,7 @@ const mapDispatchToProps = {
 
 const ROW_HEIGHT = 68;
 
-@Search.loadList({
-  query: { archived: true },
-  reload: true,
-  wrapped: true,
-})
-@listSelect({ keyForItem: item => `${item.model}:${item.id}` })
-@connect(mapStateToProps, mapDispatchToProps)
-export default class ArchiveApp extends Component {
+class ArchiveApp extends Component {
   componentDidMount() {
     if (!isSmallScreen()) {
       this.props.openNavbar();
@@ -128,6 +122,16 @@ export default class ArchiveApp extends Component {
     );
   }
 }
+
+export default _.compose(
+  Search.loadList({
+    query: { archived: true },
+    reload: true,
+    wrapped: true,
+  }),
+  listSelect({ keyForItem: item => `${item.model}:${item.id}` }),
+  connect(mapStateToProps, mapDispatchToProps),
+)(ArchiveApp);
 
 const BulkActionControls = ({ selected, reload }) => (
   <span>

--- a/frontend/src/metabase/new_query/containers/NewQueryOptions.jsx
+++ b/frontend/src/metabase/new_query/containers/NewQueryOptions.jsx
@@ -34,8 +34,7 @@ const mapDispatchToProps = {
   push,
 };
 
-@connect(mapStateToProps, mapDispatchToProps)
-export default class NewQueryOptions extends Component {
+class NewQueryOptions extends Component {
   componentDidMount() {
     // We need to check if any databases exist otherwise show an empty state.
     // Be aware that the embedded version does not have the Navbar, which also
@@ -121,3 +120,5 @@ export default class NewQueryOptions extends Component {
     );
   }
 }
+
+export default connect(mapStateToProps, mapDispatchToProps)(NewQueryOptions);

--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
@@ -48,8 +48,7 @@ const mapDispatchToProps = {
   fetchField,
 };
 
-@connect(makeMapStateToProps, mapDispatchToProps)
-export default class ParameterValueWidget extends Component {
+class ParameterValueWidget extends Component {
   static propTypes = {
     parameter: PropTypes.object.isRequired,
     name: PropTypes.string,
@@ -239,6 +238,11 @@ export default class ParameterValueWidget extends Component {
     }
   }
 }
+
+export default connect(
+  makeMapStateToProps,
+  mapDispatchToProps,
+)(ParameterValueWidget);
 
 function getFields(metadata, parameter) {
   if (!metadata) {

--- a/frontend/src/metabase/public/components/EmbedFrame.jsx
+++ b/frontend/src/metabase/public/components/EmbedFrame.jsx
@@ -21,8 +21,7 @@ const DEFAULT_OPTIONS = {
   titled: true,
 };
 
-@withRouter
-export default class EmbedFrame extends Component {
+class EmbedFrame extends Component {
   state = {
     innerScroll: true,
   };
@@ -107,3 +106,5 @@ export default class EmbedFrame extends Component {
     );
   }
 }
+
+export default withRouter(EmbedFrame);

--- a/frontend/src/metabase/public/components/widgets/EmbedModalContent.jsx
+++ b/frontend/src/metabase/public/components/widgets/EmbedModalContent.jsx
@@ -34,8 +34,7 @@ const mapStateToProps = (state, props) => ({
   isApplicationEmbeddingEnabled: getIsApplicationEmbeddingEnabled(state, props),
 });
 
-@connect(mapStateToProps)
-export default class EmbedModalContent extends Component {
+class EmbedModalContent extends Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -240,6 +239,8 @@ export default class EmbedModalContent extends Component {
     );
   }
 }
+
+export default connect(mapStateToProps)(EmbedModalContent);
 
 export const EmbedTitle = ({ type, onClick }) => (
   <a className="flex align-center" onClick={onClick}>

--- a/frontend/src/metabase/public/containers/PublicApp.jsx
+++ b/frontend/src/metabase/public/containers/PublicApp.jsx
@@ -9,8 +9,7 @@ const mapStateToProps = (state, props) => ({
   errorPage: state.app.errorPage,
 });
 
-@connect(mapStateToProps)
-export default class PublicApp extends Component {
+class PublicApp extends Component {
   render() {
     const { children, errorPage } = this.props;
     if (errorPage) {
@@ -24,3 +23,5 @@ export default class PublicApp extends Component {
     }
   }
 }
+
+export default connect(mapStateToProps)(PublicApp);

--- a/frontend/src/metabase/public/containers/PublicDashboard.jsx
+++ b/frontend/src/metabase/public/containers/PublicDashboard.jsx
@@ -56,11 +56,8 @@ const mapDispatchToProps = {
   onChangeLocation: push,
 };
 
-@connect(mapStateToProps, mapDispatchToProps)
-@title(({ dashboard }) => dashboard && dashboard.name)
-@DashboardControls
 // NOTE: this should use DashboardData HoC
-export default class PublicDashboard extends Component {
+class PublicDashboard extends Component {
   async UNSAFE_componentWillMount() {
     const {
       initialize,
@@ -142,3 +139,9 @@ export default class PublicDashboard extends Component {
     );
   }
 }
+
+export default _.compose(
+  connect(mapStateToProps, mapDispatchToProps),
+  title(({ dashboard }) => dashboard && dashboard.name),
+  DashboardControls,
+)(PublicDashboard);

--- a/frontend/src/metabase/public/containers/PublicQuestion.jsx
+++ b/frontend/src/metabase/public/containers/PublicQuestion.jsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import { connect } from "react-redux";
+import _ from "underscore";
 
 import Visualization from "metabase/visualizations/components/Visualization";
 import QueryDownloadWidget from "metabase/query_builder/components/QueryDownloadWidget";
@@ -45,10 +46,7 @@ const mapDispatchToProps = {
   addFields,
 };
 
-@connect(mapStateToProps, mapDispatchToProps)
-@title(({ card }) => card && card.name)
-@ExplicitSize({ refreshMode: "debounceLeading" })
-export default class PublicQuestion extends Component {
+class PublicQuestion extends Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -233,3 +231,9 @@ export default class PublicQuestion extends Component {
     );
   }
 }
+
+export default _.compose(
+  connect(mapStateToProps, mapDispatchToProps),
+  title(({ card }) => card && card.name),
+  ExplicitSize({ refreshMode: "debounceLeading" }),
+)(PublicQuestion);

--- a/frontend/src/metabase/pulse/components/PulseEdit.jsx
+++ b/frontend/src/metabase/pulse/components/PulseEdit.jsx
@@ -30,12 +30,7 @@ import Collections from "metabase/entities/collections";
 import cx from "classnames";
 import { PulseHeader, PulseHeaderContent } from "./PulseEdit.styled";
 
-@Collections.load({
-  id: (state, { pulse, initialCollectionId }) =>
-    pulse.collection_id || initialCollectionId,
-  loadingAndErrorWrapper: false,
-})
-export default class PulseEdit extends Component {
+class PulseEdit extends Component {
   static propTypes = {
     pulse: PropTypes.object.isRequired,
     pulseId: PropTypes.number,
@@ -249,3 +244,9 @@ export default class PulseEdit extends Component {
     );
   }
 }
+
+export default Collections.load({
+  id: (state, { pulse, initialCollectionId }) =>
+    pulse.collection_id || initialCollectionId,
+  loadingAndErrorWrapper: false,
+})(PulseEdit);

--- a/frontend/src/metabase/pulse/containers/PulseEditApp.jsx
+++ b/frontend/src/metabase/pulse/containers/PulseEditApp.jsx
@@ -1,6 +1,7 @@
 /* eslint "react/prop-types": "warn" */
 import React, { Component } from "react";
 import { connect } from "react-redux";
+import _ from "underscore";
 
 import title from "metabase/hoc/Title";
 
@@ -53,11 +54,14 @@ const mapDispatchToProps = {
   goBack,
 };
 
-@User.loadList()
-@connect(mapStateToProps, mapDispatchToProps)
-@title(({ pulse }) => pulse && pulse.name)
-export default class PulseEditApp extends Component {
+class PulseEditApp extends Component {
   render() {
     return <PulseEdit {...this.props} />;
   }
 }
+
+export default _.compose(
+  User.loadList(),
+  connect(mapStateToProps, mapDispatchToProps),
+  title(({ pulse }) => pulse && pulse.name),
+)(PulseEditApp);

--- a/frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx
+++ b/frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx
@@ -111,11 +111,7 @@ export default connect(
   null,
 )(AlertListPopoverContent);
 
-@connect(state => ({ user: getUser(state) }), {
-  unsubscribeFromAlert,
-  deleteAlert,
-})
-export class AlertListItem extends Component {
+class AlertListItemInner extends Component {
   state = {
     unsubscribingProgress: null,
     hasJustUnsubscribed: false,
@@ -238,6 +234,11 @@ export class AlertListItem extends Component {
     );
   }
 }
+
+export const AlertListItem = connect(state => ({ user: getUser(state) }), {
+  unsubscribeFromAlert,
+  deleteAlert,
+})(AlertListItemInner);
 
 export const UnsubscribedListItem = () => (
   <li className="border-bottom flex align-center py4 text-bold">

--- a/frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx
+++ b/frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx
@@ -20,11 +20,7 @@ import {
   UpdateAlertModalContent,
 } from "metabase/query_builder/components/AlertModals";
 
-@connect(
-  state => ({ questionAlerts: getQuestionAlerts(state), user: getUser(state) }),
-  null,
-)
-export default class AlertListPopoverContent extends Component {
+class AlertListPopoverContent extends Component {
   state = {
     adding: false,
     hasJustUnsubscribedFromOwnAlert: false,
@@ -109,6 +105,11 @@ export default class AlertListPopoverContent extends Component {
     );
   }
 }
+
+export default connect(
+  state => ({ questionAlerts: getQuestionAlerts(state), user: getUser(state) }),
+  null,
+)(AlertListPopoverContent);
 
 @connect(state => ({ user: getUser(state) }), {
   unsubscribeFromAlert,

--- a/frontend/src/metabase/query_builder/components/AlertModals.jsx
+++ b/frontend/src/metabase/query_builder/components/AlertModals.jsx
@@ -62,19 +62,7 @@ const textStyle = {
   width: "162px",
 };
 
-@connect(
-  state => ({
-    question: getQuestion(state),
-    visualizationSettings: getVisualizationSettings(state),
-    isAdmin: getUserIsAdmin(state),
-    user: getUser(state),
-    hasLoadedChannelInfo: hasLoadedChannelInfoSelector(state),
-    hasConfiguredAnyChannel: hasConfiguredAnyChannelSelector(state),
-    hasConfiguredEmailChannel: hasConfiguredEmailChannelSelector(state),
-  }),
-  { createAlert, fetchPulseFormInput, apiUpdateQuestion, updateUrl },
-)
-export class CreateAlertModalContent extends Component {
+class CreateAlertModalContentInner extends Component {
   constructor(props) {
     super();
 
@@ -194,6 +182,19 @@ export class CreateAlertModalContent extends Component {
   }
 }
 
+export const CreateAlertModalContent = connect(
+  state => ({
+    question: getQuestion(state),
+    visualizationSettings: getVisualizationSettings(state),
+    isAdmin: getUserIsAdmin(state),
+    user: getUser(state),
+    hasLoadedChannelInfo: hasLoadedChannelInfoSelector(state),
+    hasConfiguredAnyChannel: hasConfiguredAnyChannelSelector(state),
+    hasConfiguredEmailChannel: hasConfiguredEmailChannelSelector(state),
+  }),
+  { createAlert, fetchPulseFormInput, apiUpdateQuestion, updateUrl },
+)(CreateAlertModalContentInner);
+
 export class AlertEducationalScreen extends Component {
   render() {
     const { onProceed } = this.props;
@@ -273,16 +274,7 @@ export class AlertEducationalScreen extends Component {
   }
 }
 
-@connect(
-  state => ({
-    user: getUser(state),
-    isAdmin: getUserIsAdmin(state),
-    question: getQuestion(state),
-    visualizationSettings: getVisualizationSettings(state),
-  }),
-  { apiUpdateQuestion, updateAlert, deleteAlert, updateUrl },
-)
-export class UpdateAlertModalContent extends Component {
+class UpdateAlertModalContentInner extends Component {
   constructor(props) {
     super();
     this.state = {
@@ -369,6 +361,16 @@ export class UpdateAlertModalContent extends Component {
   }
 }
 
+export const UpdateAlertModalContent = connect(
+  state => ({
+    user: getUser(state),
+    isAdmin: getUserIsAdmin(state),
+    question: getQuestion(state),
+    visualizationSettings: getVisualizationSettings(state),
+  }),
+  { apiUpdateQuestion, updateAlert, deleteAlert, updateUrl },
+)(UpdateAlertModalContentInner);
+
 export class DeleteAlertSection extends Component {
   getConfirmItems() {
     // same as in PulseEdit but with some changes to copy
@@ -440,8 +442,7 @@ const AlertModalTitle = ({ text }) => (
   </div>
 );
 
-@connect(state => ({ isAdmin: getUserIsAdmin(state) }), null)
-export class AlertEditForm extends Component {
+class AlertEditFormInner extends Component {
   onScheduleChange = schedule => {
     const { alert, onAlertChange } = this.props;
 
@@ -477,6 +478,11 @@ export class AlertEditForm extends Component {
     );
   }
 }
+
+export const AlertEditForm = connect(
+  state => ({ isAdmin: getUserIsAdmin(state) }),
+  null,
+)(AlertEditFormInner);
 
 export const AlertGoalToggles = ({ alertType, alert, onAlertChange }) => {
   const isTimeseries = alertType === ALERT_TYPE_TIMESERIES_GOAL;

--- a/frontend/src/metabase/query_builder/components/AlertModals.jsx
+++ b/frontend/src/metabase/query_builder/components/AlertModals.jsx
@@ -572,17 +572,7 @@ export class AlertEditSchedule extends Component {
   }
 }
 
-@User.loadList()
-@connect(
-  (state, props) => ({
-    user: getUser(state),
-    formInput: getPulseFormInput(state),
-  }),
-  {
-    fetchPulseFormInput,
-  },
-)
-export class AlertEditChannels extends Component {
+class AlertEditChannelsInner extends Component {
   componentDidMount() {
     this.props.fetchPulseFormInput();
   }
@@ -626,6 +616,19 @@ export class AlertEditChannels extends Component {
     );
   }
 }
+
+export const AlertEditChannels = _.compose(
+  User.loadList(),
+  connect(
+    (state, props) => ({
+      user: getUser(state),
+      formInput: getPulseFormInput(state),
+    }),
+    {
+      fetchPulseFormInput,
+    },
+  ),
+)(AlertEditChannelsInner);
 
 // TODO: Not sure how to translate text with formatting properly
 @connect(state => ({

--- a/frontend/src/metabase/query_builder/components/AlertModals.jsx
+++ b/frontend/src/metabase/query_builder/components/AlertModals.jsx
@@ -637,11 +637,7 @@ export const AlertEditChannels = _.compose(
 )(AlertEditChannelsInner);
 
 // TODO: Not sure how to translate text with formatting properly
-@connect(state => ({
-  question: getQuestion(state),
-  visualizationSettings: getVisualizationSettings(state),
-}))
-export class RawDataAlertTip extends Component {
+class RawDataAlertTipInner extends Component {
   render() {
     const display = this.props.question.display();
     const vizSettings = this.props.visualizationSettings;
@@ -668,6 +664,11 @@ export class RawDataAlertTip extends Component {
     );
   }
 }
+
+export const RawDataAlertTip = connect(state => ({
+  question: getQuestion(state),
+  visualizationSettings: getVisualizationSettings(state),
+}))(RawDataAlertTipInner);
 
 export const MultiSeriesAlertTip = () => (
   <div>{jt`${(

--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -182,48 +182,53 @@ const FieldTriggerContent = ({ selectedDatabase, selectedField }) => {
   }
 };
 
-@Search.loadList({
-  // If there is at least one dataset,
-  // we want to display a slightly different data picker view
-  // (see DATA_BUCKET step)
-  query: {
-    models: "dataset",
-    limit: 1,
-  },
-  loadingAndErrorWrapper: false,
-})
-@connect(
-  (state, ownProps) => ({
-    metadata: getMetadata(state),
-    databases:
-      ownProps.databases ||
-      Databases.selectors.getList(state, {
-        entityQuery: ownProps.databaseQuery,
-      }) ||
-      [],
-    hasFetchedDatabasesWithTablesSaved: !!Databases.selectors.getList(state, {
-      entityQuery: { include: "tables", saved: true },
-    }),
-    hasFetchedDatabasesWithSaved: !!Databases.selectors.getList(state, {
-      entityQuery: { saved: true },
-    }),
-    hasFetchedDatabasesWithTables: !!Databases.selectors.getList(state, {
-      entityQuery: { include: "tables" },
-    }),
-    hasDataAccess: getHasDataAccess(state),
-  }),
-  {
-    fetchDatabases: databaseQuery => Databases.actions.fetchList(databaseQuery),
-    fetchSchemas: databaseId => Schemas.actions.fetchList({ dbId: databaseId }),
-    fetchSchemaTables: schemaId => Schemas.actions.fetch({ id: schemaId }),
-    fetchFields: tableId => Tables.actions.fetchMetadata({ id: tableId }),
-  },
-)
-class DataSelector extends Component {
+class DataSelectorInner extends Component {
   render() {
     return <UnconnectedDataSelector {...this.props} />;
   }
 }
+
+const DataSelector = _.compose(
+  Search.loadList({
+    // If there is at least one dataset,
+    // we want to display a slightly different data picker view
+    // (see DATA_BUCKET step)
+    query: {
+      models: "dataset",
+      limit: 1,
+    },
+    loadingAndErrorWrapper: false,
+  }),
+  connect(
+    (state, ownProps) => ({
+      metadata: getMetadata(state),
+      databases:
+        ownProps.databases ||
+        Databases.selectors.getList(state, {
+          entityQuery: ownProps.databaseQuery,
+        }) ||
+        [],
+      hasFetchedDatabasesWithTablesSaved: !!Databases.selectors.getList(state, {
+        entityQuery: { include: "tables", saved: true },
+      }),
+      hasFetchedDatabasesWithSaved: !!Databases.selectors.getList(state, {
+        entityQuery: { saved: true },
+      }),
+      hasFetchedDatabasesWithTables: !!Databases.selectors.getList(state, {
+        entityQuery: { include: "tables" },
+      }),
+      hasDataAccess: getHasDataAccess(state),
+    }),
+    {
+      fetchDatabases: databaseQuery =>
+        Databases.actions.fetchList(databaseQuery),
+      fetchSchemas: databaseId =>
+        Schemas.actions.fetchList({ dbId: databaseId }),
+      fetchSchemaTables: schemaId => Schemas.actions.fetch({ id: schemaId }),
+      fetchFields: tableId => Tables.actions.fetchMetadata({ id: tableId }),
+    },
+  ),
+)(DataSelectorInner);
 
 export class UnconnectedDataSelector extends Component {
   constructor(props) {

--- a/frontend/src/metabase/query_builder/components/FilterList.jsx
+++ b/frontend/src/metabase/query_builder/components/FilterList.jsx
@@ -11,8 +11,7 @@ const mapStateToProps = state => ({
   metadata: getMetadata(state),
 });
 
-@connect(mapStateToProps)
-export default class FilterList extends Component {
+class FilterList extends Component {
   static defaultProps = {
     filterRenderer: filterWidgetFilterRenderer,
   };
@@ -35,3 +34,5 @@ export default class FilterList extends Component {
     );
   }
 }
+
+export default connect(mapStateToProps)(FilterList);

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
@@ -42,10 +42,7 @@ import "./NativeQueryEditor.css";
 const AUTOCOMPLETE_DEBOUNCE_DURATION = 700;
 const AUTOCOMPLETE_CACHE_DURATION = AUTOCOMPLETE_DEBOUNCE_DURATION * 1.2; // tolerate 20%
 
-@ExplicitSize()
-@Snippets.loadList({ loadingAndErrorWrapper: false })
-@SnippetCollections.loadList({ loadingAndErrorWrapper: false })
-export default class NativeQueryEditor extends Component {
+class NativeQueryEditor extends Component {
   _localUpdate = false;
 
   constructor(props) {
@@ -506,3 +503,9 @@ export default class NativeQueryEditor extends Component {
     );
   }
 }
+
+export default _.compose(
+  ExplicitSize(),
+  Snippets.loadList({ loadingAndErrorWrapper: false }),
+  SnippetCollections.loadList({ loadingAndErrorWrapper: false }),
+)(NativeQueryEditor);

--- a/frontend/src/metabase/query_builder/components/dataref/DatabasePane.jsx
+++ b/frontend/src/metabase/query_builder/components/dataref/DatabasePane.jsx
@@ -1,4 +1,4 @@
-/* eslint "react/prop-types": "warn" */
+/* eslint-disable react/prop-types */
 import React from "react";
 import PropTypes from "prop-types";
 import DatabaseSchemasPane from "./DatabaseSchemasPane";
@@ -6,11 +6,7 @@ import DatabaseTablesPane from "./DatabaseTablesPane";
 import LoadingSpinner from "metabase/components/LoadingSpinner";
 import Databases from "metabase/entities/databases";
 
-@Databases.load({
-  id: (state, { database }) => database && database.id,
-  wrapped: true,
-})
-class DatabasePane extends React.Component {
+class DatabasePaneInner extends React.Component {
   componentDidMount() {
     const { database } = this.props;
     if (database.schemas.length === 0) {
@@ -35,6 +31,11 @@ class DatabasePane extends React.Component {
     return <Component {...this.props} />;
   }
 }
+
+const DatabasePane = Databases.load({
+  id: (state, { database }) => database && database.id,
+  wrapped: true,
+})(DatabasePaneInner);
 
 DatabasePane.propTypes = {
   show: PropTypes.func.isRequired,

--- a/frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx
+++ b/frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx
@@ -23,8 +23,7 @@ const mapStateToProps = (state, props) => ({
   metadata: getMetadata(state, props),
 });
 
-@connect(mapStateToProps, mapDispatchToProps)
-export default class MetricPane extends Component {
+class MetricPane extends Component {
   constructor(props, context) {
     super(props, context);
 
@@ -102,3 +101,5 @@ export default class MetricPane extends Component {
     );
   }
 }
+
+export default connect(mapStateToProps, mapDispatchToProps)(MetricPane);

--- a/frontend/src/metabase/query_builder/components/dataref/SchemaPane.jsx
+++ b/frontend/src/metabase/query_builder/components/dataref/SchemaPane.jsx
@@ -1,11 +1,10 @@
-/* eslint "react/prop-types": "warn" */
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import Icon from "metabase/components/Icon";
 import Schemas from "metabase/entities/schemas";
 
-@Schemas.load({ id: (state, { schema }) => schema.id })
-class SchemaPane extends Component {
+class SchemaPaneInner extends Component {
   render() {
     const { schema, show } = this.props;
     const tables = schema.tables.sort((a, b) => a.name.localeCompare(b.name));
@@ -38,6 +37,10 @@ class SchemaPane extends Component {
     );
   }
 }
+
+const SchemaPane = Schemas.load({ id: (state, { schema }) => schema.id })(
+  SchemaPaneInner,
+);
 SchemaPane.propTypes = {
   show: PropTypes.func.isRequired,
   schema: PropTypes.object.isRequired,

--- a/frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx
+++ b/frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx
@@ -25,8 +25,7 @@ const mapStateToProps = (state, props) => ({
   metadata: getMetadata(state, props),
 });
 
-@connect(mapStateToProps, mapDispatchToProps)
-export default class SegmentPane extends Component {
+class SegmentPane extends Component {
   constructor(props, context) {
     super(props, context);
 
@@ -156,3 +155,5 @@ export default class SegmentPane extends Component {
     );
   }
 }
+
+export default connect(mapStateToProps, mapDispatchToProps)(SegmentPane);

--- a/frontend/src/metabase/query_builder/components/dataref/TablePane.jsx
+++ b/frontend/src/metabase/query_builder/components/dataref/TablePane.jsx
@@ -18,8 +18,7 @@ const mapDispatchToProps = {
   fetchMetadata: Table.actions.fetchMetadata,
 };
 
-@connect(mapStateToProps, mapDispatchToProps)
-export default class TablePane extends React.Component {
+class TablePane extends React.Component {
   state = {
     error: null,
   };
@@ -87,6 +86,8 @@ export default class TablePane extends React.Component {
     }
   }
 }
+
+export default connect(mapStateToProps, mapDispatchToProps)(TablePane);
 
 const ExpandableItemList = Expandable(
   ({ name, type, show, items, isExpanded, onExpand }) => (

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -43,8 +43,7 @@ const ErrorMessage = ({ error }) => {
   );
 };
 
-@ExplicitSize()
-export default class ExpressionEditorTextfield extends React.Component {
+class ExpressionEditorTextfield extends React.Component {
   constructor() {
     super();
     this.input = React.createRef();
@@ -462,3 +461,5 @@ export default class ExpressionEditorTextfield extends React.Component {
     );
   }
 }
+
+export default ExplicitSize()(ExpressionEditorTextfield);

--- a/frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx
@@ -15,11 +15,7 @@ import * as Urls from "metabase/lib/urls";
 import { formatDateTimeWithUnit } from "metabase/lib/formatting";
 import MetabaseSettings from "metabase/lib/settings";
 
-@Questions.load({
-  id: (state, { tag }) => tag["card-id"],
-  loadingAndErrorWrapper: false,
-})
-export default class CardTagEditor extends Component {
+class CardTagEditor extends Component {
   handleQuestionSelection = id => {
     const { question, query, setDatasetQuery } = this.props;
     setDatasetQuery(
@@ -130,6 +126,11 @@ export default class CardTagEditor extends Component {
     );
   }
 }
+
+export default Questions.load({
+  id: (state, { tag }) => tag["card-id"],
+  loadingAndErrorWrapper: false,
+})(CardTagEditor);
 
 // This formats a timestamp as a date using any custom formatting options.
 function formatDate(value) {

--- a/frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx
@@ -9,8 +9,7 @@ import Link from "metabase/core/components/Link";
 import Snippets from "metabase/entities/snippets";
 import SnippetCollections from "metabase/entities/snippet-collections";
 
-@SnippetCollections.loadList()
-export default class SnippetModal extends React.Component {
+class SnippetModal extends React.Component {
   render() {
     const {
       insertSnippet,
@@ -65,3 +64,5 @@ export default class SnippetModal extends React.Component {
     );
   }
 }
+
+export default SnippetCollections.loadList()(SnippetModal);

--- a/frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx
@@ -283,11 +283,7 @@ export default _.compose(
   }),
 )(SnippetSidebar);
 
-@SnippetCollections.loadList({ query: { archived: true }, wrapped: true })
-@connect((state, { list }) => ({ archivedSnippetCollections: list }))
-@SnippetCollections.loadList()
-@Snippets.loadList({ query: { archived: true }, wrapped: true })
-class ArchivedSnippets extends React.Component {
+class ArchivedSnippetsInner extends React.Component {
   render() {
     const {
       onBack,
@@ -332,6 +328,13 @@ class ArchivedSnippets extends React.Component {
     );
   }
 }
+
+const ArchivedSnippets = _.compose(
+  SnippetCollections.loadList({ query: { archived: true }, wrapped: true }),
+  connect((state, { list }) => ({ archivedSnippetCollections: list })),
+  SnippetCollections.loadList(),
+  Snippets.loadList({ query: { archived: true }, wrapped: true }),
+)(ArchivedSnippetsInner);
 
 function Row(props) {
   const Component = {

--- a/frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx
@@ -29,21 +29,7 @@ const ICON_SIZE = 16;
 const HEADER_ICON_SIZE = 18;
 const MIN_SNIPPETS_FOR_SEARCH = 15;
 
-@Snippets.loadList()
-@SnippetCollections.loadList()
-@SnippetCollections.load({
-  id: (state, props) =>
-    props.snippetCollectionId === null ? "root" : props.snippetCollectionId,
-  wrapped: true,
-})
-@Search.loadList({
-  query: (state, props) => ({
-    collection:
-      props.snippetCollectionId === null ? "root" : props.snippetCollectionId,
-    namespace: "snippets",
-  }),
-})
-export default class SnippetSidebar extends React.Component {
+class SnippetSidebar extends React.Component {
   state = {
     showSearch: false,
     searchString: "",
@@ -279,6 +265,23 @@ export default class SnippetSidebar extends React.Component {
     );
   }
 }
+
+export default _.compose(
+  Snippets.loadList(),
+  SnippetCollections.loadList(),
+  SnippetCollections.load({
+    id: (state, props) =>
+      props.snippetCollectionId === null ? "root" : props.snippetCollectionId,
+    wrapped: true,
+  }),
+  Search.loadList({
+    query: (state, props) => ({
+      collection:
+        props.snippetCollectionId === null ? "root" : props.snippetCollectionId,
+      namespace: "snippets",
+    }),
+  }),
+)(SnippetSidebar);
 
 @SnippetCollections.loadList({ query: { archived: true }, wrapped: true })
 @connect((state, { list }) => ({ archivedSnippetCollections: list }))

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx
@@ -18,8 +18,7 @@ import { getMetadata } from "metabase/selectors/metadata";
 import { SchemaTableAndFieldDataSelector } from "metabase/query_builder/components/DataSelector";
 import MetabaseSettings from "metabase/lib/settings";
 
-@connect(state => ({ metadata: getMetadata(state) }), { fetchField })
-export default class TagEditorParam extends Component {
+class TagEditorParam extends Component {
   UNSAFE_componentWillMount() {
     const { tag, fetchField } = this.props;
 
@@ -291,3 +290,7 @@ export default class TagEditorParam extends Component {
     );
   }
 }
+
+export default connect(state => ({ metadata: getMetadata(state) }), {
+  fetchField,
+})(TagEditorParam);

--- a/frontend/src/metabase/query_builder/components/template_tags/snippet-sidebar/SnippetRow.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/snippet-sidebar/SnippetRow.jsx
@@ -9,11 +9,7 @@ import Snippets from "metabase/entities/snippets";
 
 const ICON_SIZE = 16;
 
-@Snippets.load({
-  id: (state, props) => props.item.id,
-  wrapped: true,
-})
-class SnippetRow extends React.Component {
+class SnippetRowInner extends React.Component {
   constructor(props) {
     super(props);
     this.state = { isOpen: false };
@@ -94,5 +90,10 @@ class SnippetRow extends React.Component {
     );
   }
 }
+
+const SnippetRow = Snippets.load({
+  id: (state, props) => props.item.id,
+  wrapped: true,
+})(SnippetRowInner);
 
 export default SnippetRow;

--- a/frontend/src/metabase/query_builder/components/view/View.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View.jsx
@@ -57,8 +57,7 @@ const DEFAULT_POPOVER_STATE = {
   breakoutPopoverTarget: null,
 };
 
-@ExplicitSize({ refreshMode: "debounceLeading" })
-export default class View extends React.Component {
+class View extends React.Component {
   state = {
     ...DEFAULT_POPOVER_STATE,
   };
@@ -531,3 +530,5 @@ export default class View extends React.Component {
     );
   }
 }
+
+export default ExplicitSize({ refreshMode: "debounceLeading" })(View);

--- a/frontend/src/metabase/query_builder/containers/QuestionEmbedWidget.jsx
+++ b/frontend/src/metabase/query_builder/containers/QuestionEmbedWidget.jsx
@@ -46,8 +46,7 @@ const mapDispatchToProps = {
   updateEmbeddingParams,
 };
 
-@connect(mapStateToProps, mapDispatchToProps)
-export default class QuestionEmbedWidget extends Component {
+class QuestionEmbedWidget extends Component {
   render() {
     const {
       className,
@@ -102,6 +101,11 @@ export default class QuestionEmbedWidget extends Component {
     );
   }
 }
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(QuestionEmbedWidget);
 
 export function QuestionEmbedWidgetTrigger({ onClick }) {
   return (

--- a/frontend/src/metabase/query_builder/containers/QuestionHistoryModal.jsx
+++ b/frontend/src/metabase/query_builder/containers/QuestionHistoryModal.jsx
@@ -4,10 +4,7 @@ import PropTypes from "prop-types";
 import Questions from "metabase/entities/questions";
 import HistoryModal from "metabase/containers/HistoryModal";
 
-@Questions.load({
-  id: (state, props) => props.questionId,
-})
-class QuestionHistoryModal extends React.Component {
+class QuestionHistoryModalInner extends React.Component {
   static propTypes = {
     question: PropTypes.object.isRequired,
     questionId: PropTypes.number.isRequired,
@@ -28,5 +25,9 @@ class QuestionHistoryModal extends React.Component {
     );
   }
 }
+
+const QuestionHistoryModal = Questions.load({
+  id: (state, props) => props.questionId,
+})(QuestionHistoryModalInner);
 
 export default QuestionHistoryModal;

--- a/frontend/src/metabase/reference/components/FieldsToGroupBy.jsx
+++ b/frontend/src/metabase/reference/components/FieldsToGroupBy.jsx
@@ -21,8 +21,7 @@ const mapStateToProps = (state, props) => ({
   metadata: getMetadata(state, props),
 });
 
-@connect(mapStateToProps, mapDispatchToProps)
-export default class FieldsToGroupBy extends Component {
+class FieldsToGroupBy extends Component {
   render() {
     const {
       fields,
@@ -73,3 +72,5 @@ export default class FieldsToGroupBy extends Component {
     );
   }
 }
+
+export default connect(mapStateToProps, mapDispatchToProps)(FieldsToGroupBy);

--- a/frontend/src/metabase/reference/components/Formula.jsx
+++ b/frontend/src/metabase/reference/components/Formula.jsx
@@ -16,8 +16,7 @@ const mapDispatchToProps = {
   fetchTableMetadata,
 };
 
-@connect(null, mapDispatchToProps)
-export default class Formula extends Component {
+class Formula extends Component {
   render() {
     const {
       type,
@@ -55,3 +54,5 @@ export default class Formula extends Component {
     );
   }
 }
+
+export default connect(null, mapDispatchToProps)(Formula);

--- a/frontend/src/metabase/reference/databases/DatabaseDetail.jsx
+++ b/frontend/src/metabase/reference/databases/DatabaseDetail.jsx
@@ -7,6 +7,7 @@ import { push } from "react-router-redux";
 import { t } from "ttag";
 import List from "metabase/components/List";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
+import _ from "underscore";
 
 import EditHeader from "metabase/reference/components/EditHeader";
 import EditableReferenceHeader from "metabase/reference/components/EditableReferenceHeader";
@@ -55,20 +56,7 @@ const validate = (values, props) => {
   return {};
 };
 
-@connect(mapStateToProps, mapDispatchToProps)
-@reduxForm({
-  form: "details",
-  fields: [
-    "name",
-    "display_name",
-    "description",
-    "revision_message",
-    "points_of_interest",
-    "caveats",
-  ],
-  validate,
-})
-export default class DatabaseDetail extends Component {
+class DatabaseDetail extends Component {
   static propTypes = {
     style: PropTypes.object.isRequired,
     entity: PropTypes.object.isRequired,
@@ -190,3 +178,19 @@ export default class DatabaseDetail extends Component {
     );
   }
 }
+
+export default _.compose(
+  connect(mapStateToProps, mapDispatchToProps),
+  reduxForm({
+    form: "details",
+    fields: [
+      "name",
+      "display_name",
+      "description",
+      "revision_message",
+      "points_of_interest",
+      "caveats",
+    ],
+    validate,
+  }),
+)(DatabaseDetail);

--- a/frontend/src/metabase/reference/databases/DatabaseDetailContainer.jsx
+++ b/frontend/src/metabase/reference/databases/DatabaseDetailContainer.jsx
@@ -23,8 +23,7 @@ const mapDispatchToProps = {
   ...actions,
 };
 
-@connect(mapStateToProps, mapDispatchToProps)
-export default class DatabaseDetailContainer extends Component {
+class DatabaseDetailContainer extends Component {
   static propTypes = {
     params: PropTypes.object.isRequired,
     location: PropTypes.object.isRequired,
@@ -66,3 +65,8 @@ export default class DatabaseDetailContainer extends Component {
     );
   }
 }
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(DatabaseDetailContainer);

--- a/frontend/src/metabase/reference/databases/DatabaseList.jsx
+++ b/frontend/src/metabase/reference/databases/DatabaseList.jsx
@@ -28,8 +28,7 @@ const mapDispatchToProps = {
   ...metadataActions,
 };
 
-@connect(mapStateToProps, mapDispatchToProps)
-export default class DatabaseList extends Component {
+class DatabaseList extends Component {
   static propTypes = {
     style: PropTypes.object.isRequired,
     entities: PropTypes.object.isRequired,
@@ -86,3 +85,5 @@ export default class DatabaseList extends Component {
     );
   }
 }
+
+export default connect(mapStateToProps, mapDispatchToProps)(DatabaseList);

--- a/frontend/src/metabase/reference/databases/DatabaseListContainer.jsx
+++ b/frontend/src/metabase/reference/databases/DatabaseListContainer.jsx
@@ -22,8 +22,7 @@ const mapDispatchToProps = {
   ...actions,
 };
 
-@connect(mapStateToProps, mapDispatchToProps)
-export default class DatabaseListContainer extends Component {
+class DatabaseListContainer extends Component {
   static propTypes = {
     params: PropTypes.object.isRequired,
     databaseId: PropTypes.number.isRequired,
@@ -61,3 +60,8 @@ export default class DatabaseListContainer extends Component {
     );
   }
 }
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(DatabaseListContainer);

--- a/frontend/src/metabase/reference/databases/FieldDetail.jsx
+++ b/frontend/src/metabase/reference/databases/FieldDetail.jsx
@@ -6,6 +6,7 @@ import { reduxForm } from "redux-form";
 import { push } from "react-router-redux";
 import { t } from "ttag";
 import S from "metabase/reference/Reference.css";
+import _ from "underscore";
 
 import List from "metabase/components/List";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
@@ -100,22 +101,7 @@ const validate = (values, props) => {
   return {};
 };
 
-@connect(mapStateToProps, mapDispatchToProps)
-@reduxForm({
-  form: "details",
-  fields: [
-    "name",
-    "display_name",
-    "description",
-    "revision_message",
-    "points_of_interest",
-    "caveats",
-    "semantic_type",
-    "fk_target_field_id",
-  ],
-  validate,
-})
-export default class FieldDetail extends Component {
+class FieldDetail extends Component {
   static propTypes = {
     style: PropTypes.object.isRequired,
     entity: PropTypes.object.isRequired,
@@ -286,3 +272,21 @@ export default class FieldDetail extends Component {
     );
   }
 }
+
+export default _.compose(
+  connect(mapStateToProps, mapDispatchToProps),
+  reduxForm({
+    form: "details",
+    fields: [
+      "name",
+      "display_name",
+      "description",
+      "revision_message",
+      "points_of_interest",
+      "caveats",
+      "semantic_type",
+      "fk_target_field_id",
+    ],
+    validate,
+  }),
+)(FieldDetail);

--- a/frontend/src/metabase/reference/databases/FieldDetailContainer.jsx
+++ b/frontend/src/metabase/reference/databases/FieldDetailContainer.jsx
@@ -33,8 +33,7 @@ const mapDispatchToProps = {
   ...actions,
 };
 
-@connect(mapStateToProps, mapDispatchToProps)
-export default class FieldDetailContainer extends Component {
+class FieldDetailContainer extends Component {
   static propTypes = {
     params: PropTypes.object.isRequired,
     location: PropTypes.object.isRequired,
@@ -81,3 +80,8 @@ export default class FieldDetailContainer extends Component {
     );
   }
 }
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(FieldDetailContainer);

--- a/frontend/src/metabase/reference/databases/FieldList.jsx
+++ b/frontend/src/metabase/reference/databases/FieldList.jsx
@@ -7,6 +7,7 @@ import { t } from "ttag";
 import S from "metabase/components/List.css";
 import R from "metabase/reference/Reference.css";
 import F from "metabase/reference/components/Field.css";
+import _ from "underscore";
 
 import Field from "metabase/reference/components/Field";
 import List from "metabase/components/List";
@@ -63,12 +64,7 @@ const validate = (values, props) => {
   return {};
 };
 
-@connect(mapStateToProps, mapDispatchToProps)
-@reduxForm({
-  form: "fields",
-  validate,
-})
-export default class FieldList extends Component {
+class FieldList extends Component {
   static propTypes = {
     style: PropTypes.object.isRequired,
     entities: PropTypes.object.isRequired,
@@ -194,3 +190,11 @@ export default class FieldList extends Component {
     );
   }
 }
+
+export default _.compose(
+  connect(mapStateToProps, mapDispatchToProps),
+  reduxForm({
+    form: "fields",
+    validate,
+  }),
+)(FieldList);

--- a/frontend/src/metabase/reference/databases/FieldListContainer.jsx
+++ b/frontend/src/metabase/reference/databases/FieldListContainer.jsx
@@ -29,8 +29,7 @@ const mapDispatchToProps = {
   ...actions,
 };
 
-@connect(mapStateToProps, mapDispatchToProps)
-export default class FieldListContainer extends Component {
+class FieldListContainer extends Component {
   static propTypes = {
     params: PropTypes.object.isRequired,
     location: PropTypes.object.isRequired,
@@ -73,3 +72,5 @@ export default class FieldListContainer extends Component {
     );
   }
 }
+
+export default connect(mapStateToProps, mapDispatchToProps)(FieldListContainer);

--- a/frontend/src/metabase/reference/databases/TableDetail.jsx
+++ b/frontend/src/metabase/reference/databases/TableDetail.jsx
@@ -6,6 +6,7 @@ import { reduxForm } from "redux-form";
 import { push } from "react-router-redux";
 import { t } from "ttag";
 import S from "metabase/reference/Reference.css";
+import _ from "underscore";
 
 import List from "metabase/components/List";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
@@ -82,20 +83,7 @@ const validate = (values, props) => {
   return {};
 };
 
-@connect(mapStateToProps, mapDispatchToProps)
-@reduxForm({
-  form: "details",
-  fields: [
-    "name",
-    "display_name",
-    "description",
-    "revision_message",
-    "points_of_interest",
-    "caveats",
-  ],
-  validate,
-})
-export default class TableDetail extends Component {
+class TableDetail extends Component {
   static propTypes = {
     style: PropTypes.object.isRequired,
     entity: PropTypes.object.isRequired,
@@ -240,3 +228,19 @@ export default class TableDetail extends Component {
     );
   }
 }
+
+export default _.compose(
+  connect(mapStateToProps, mapDispatchToProps),
+  reduxForm({
+    form: "details",
+    fields: [
+      "name",
+      "display_name",
+      "description",
+      "revision_message",
+      "points_of_interest",
+      "caveats",
+    ],
+    validate,
+  }),
+)(TableDetail);

--- a/frontend/src/metabase/reference/databases/TableDetailContainer.jsx
+++ b/frontend/src/metabase/reference/databases/TableDetailContainer.jsx
@@ -29,8 +29,7 @@ const mapDispatchToProps = {
   ...actions,
 };
 
-@connect(mapStateToProps, mapDispatchToProps)
-export default class TableDetailContainer extends Component {
+class TableDetailContainer extends Component {
   static propTypes = {
     params: PropTypes.object.isRequired,
     location: PropTypes.object.isRequired,
@@ -73,3 +72,8 @@ export default class TableDetailContainer extends Component {
     );
   }
 }
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(TableDetailContainer);

--- a/frontend/src/metabase/reference/databases/TableList.jsx
+++ b/frontend/src/metabase/reference/databases/TableList.jsx
@@ -84,8 +84,7 @@ export const separateTablesBySchema = (
         : createListItem(table, index);
     });
 
-@connect(mapStateToProps, mapDispatchToProps)
-export default class TableList extends Component {
+class TableList extends Component {
   static propTypes = {
     style: PropTypes.object.isRequired,
     entities: PropTypes.object.isRequired,
@@ -146,3 +145,5 @@ export default class TableList extends Component {
     );
   }
 }
+
+export default connect(mapStateToProps, mapDispatchToProps)(TableList);

--- a/frontend/src/metabase/reference/databases/TableListContainer.jsx
+++ b/frontend/src/metabase/reference/databases/TableListContainer.jsx
@@ -23,8 +23,7 @@ const mapDispatchToProps = {
   ...actions,
 };
 
-@connect(mapStateToProps, mapDispatchToProps)
-export default class TableListContainer extends Component {
+class TableListContainer extends Component {
   static propTypes = {
     params: PropTypes.object.isRequired,
     location: PropTypes.object.isRequired,
@@ -66,3 +65,5 @@ export default class TableListContainer extends Component {
     );
   }
 }
+
+export default connect(mapStateToProps, mapDispatchToProps)(TableListContainer);

--- a/frontend/src/metabase/reference/databases/TableQuestions.jsx
+++ b/frontend/src/metabase/reference/databases/TableQuestions.jsx
@@ -51,8 +51,7 @@ const mapDispatchToProps = {
   ...metadataActions,
 };
 
-@connect(mapStateToProps, mapDispatchToProps)
-export default class TableQuestions extends Component {
+class TableQuestions extends Component {
   static propTypes = {
     table: PropTypes.object.isRequired,
     style: PropTypes.object.isRequired,
@@ -111,3 +110,5 @@ export default class TableQuestions extends Component {
     );
   }
 }
+
+export default connect(mapStateToProps, mapDispatchToProps)(TableQuestions);

--- a/frontend/src/metabase/reference/databases/TableQuestionsContainer.jsx
+++ b/frontend/src/metabase/reference/databases/TableQuestionsContainer.jsx
@@ -32,8 +32,7 @@ const mapDispatchToProps = {
   ...actions,
 };
 
-@connect(mapStateToProps, mapDispatchToProps)
-export default class TableQuestionsContainer extends Component {
+class TableQuestionsContainer extends Component {
   static propTypes = {
     params: PropTypes.object.isRequired,
     location: PropTypes.object.isRequired,
@@ -76,3 +75,8 @@ export default class TableQuestionsContainer extends Component {
     );
   }
 }
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(TableQuestionsContainer);

--- a/frontend/src/metabase/reference/metrics/MetricDetail.jsx
+++ b/frontend/src/metabase/reference/metrics/MetricDetail.jsx
@@ -64,21 +64,7 @@ const validate = (values, props) =>
     ? { revision_message: t`Please enter a revision message` }
     : {};
 
-@connect(mapStateToProps, mapDispatchToProps)
-@reduxForm({
-  form: "details",
-  fields: [
-    "name",
-    "display_name",
-    "description",
-    "revision_message",
-    "points_of_interest",
-    "caveats",
-    "how_is_this_calculated",
-  ],
-  validate,
-})
-export default class MetricDetail extends Component {
+class MetricDetail extends Component {
   static propTypes = {
     style: PropTypes.object.isRequired,
     entity: PropTypes.object.isRequired,
@@ -258,3 +244,20 @@ export default class MetricDetail extends Component {
     );
   }
 }
+
+export default _.compose(
+  connect(mapStateToProps, mapDispatchToProps),
+  reduxForm({
+    form: "details",
+    fields: [
+      "name",
+      "display_name",
+      "description",
+      "revision_message",
+      "points_of_interest",
+      "caveats",
+      "how_is_this_calculated",
+    ],
+    validate,
+  }),
+)(MetricDetail);

--- a/frontend/src/metabase/reference/metrics/MetricDetailContainer.jsx
+++ b/frontend/src/metabase/reference/metrics/MetricDetailContainer.jsx
@@ -26,8 +26,7 @@ const mapDispatchToProps = {
   ...actions,
 };
 
-@connect(mapStateToProps, mapDispatchToProps)
-export default class MetricDetailContainer extends Component {
+class MetricDetailContainer extends Component {
   static propTypes = {
     router: PropTypes.shape({
       replace: PropTypes.func.isRequired,
@@ -94,3 +93,8 @@ export default class MetricDetailContainer extends Component {
     );
   }
 }
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(MetricDetailContainer);

--- a/frontend/src/metabase/reference/metrics/MetricList.jsx
+++ b/frontend/src/metabase/reference/metrics/MetricList.jsx
@@ -42,8 +42,7 @@ const mapDispatchToProps = {
   ...metadataActions,
 };
 
-@connect(mapStateToProps, mapDispatchToProps)
-export default class MetricList extends Component {
+class MetricList extends Component {
   static propTypes = {
     style: PropTypes.object.isRequired,
     entities: PropTypes.object.isRequired,
@@ -95,3 +94,5 @@ export default class MetricList extends Component {
     );
   }
 }
+
+export default connect(mapStateToProps, mapDispatchToProps)(MetricList);

--- a/frontend/src/metabase/reference/metrics/MetricListContainer.jsx
+++ b/frontend/src/metabase/reference/metrics/MetricListContainer.jsx
@@ -22,8 +22,7 @@ const mapDispatchToProps = {
   ...actions,
 };
 
-@connect(mapStateToProps, mapDispatchToProps)
-export default class MetricListContainer extends Component {
+class MetricListContainer extends Component {
   static propTypes = {
     params: PropTypes.object.isRequired,
     location: PropTypes.object.isRequired,
@@ -61,3 +60,8 @@ export default class MetricListContainer extends Component {
     );
   }
 }
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(MetricListContainer);

--- a/frontend/src/metabase/reference/metrics/MetricQuestions.jsx
+++ b/frontend/src/metabase/reference/metrics/MetricQuestions.jsx
@@ -54,8 +54,7 @@ const mapDispatchToProps = {
   ...metadataActions,
 };
 
-@connect(mapStateToProps, mapDispatchToProps)
-export default class MetricQuestions extends Component {
+class MetricQuestions extends Component {
   static propTypes = {
     style: PropTypes.object.isRequired,
     entities: PropTypes.object.isRequired,
@@ -117,3 +116,5 @@ export default class MetricQuestions extends Component {
     );
   }
 }
+
+export default connect(mapStateToProps, mapDispatchToProps)(MetricQuestions);

--- a/frontend/src/metabase/reference/metrics/MetricQuestionsContainer.jsx
+++ b/frontend/src/metabase/reference/metrics/MetricQuestionsContainer.jsx
@@ -34,8 +34,7 @@ const mapDispatchToProps = {
   ...actions,
 };
 
-@connect(mapStateToProps, mapDispatchToProps)
-export default class MetricQuestionsContainer extends Component {
+class MetricQuestionsContainer extends Component {
   static propTypes = {
     params: PropTypes.object.isRequired,
     location: PropTypes.object.isRequired,
@@ -76,3 +75,8 @@ export default class MetricQuestionsContainer extends Component {
     );
   }
 }
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(MetricQuestionsContainer);

--- a/frontend/src/metabase/reference/metrics/MetricRevisions.jsx
+++ b/frontend/src/metabase/reference/metrics/MetricRevisions.jsx
@@ -45,8 +45,7 @@ const mapDispatchToProps = {
   ...metadataActions,
 };
 
-@connect(mapStateToProps, mapDispatchToProps)
-export default class MetricRevisions extends Component {
+class MetricRevisions extends Component {
   static propTypes = {
     style: PropTypes.object.isRequired,
     revisions: PropTypes.object.isRequired,
@@ -127,3 +126,5 @@ export default class MetricRevisions extends Component {
     );
   }
 }
+
+export default connect(mapStateToProps, mapDispatchToProps)(MetricRevisions);

--- a/frontend/src/metabase/reference/metrics/MetricRevisionsContainer.jsx
+++ b/frontend/src/metabase/reference/metrics/MetricRevisionsContainer.jsx
@@ -31,8 +31,7 @@ const mapDispatchToProps = {
   ...actions,
 };
 
-@connect(mapStateToProps, mapDispatchToProps)
-export default class MetricRevisionsContainer extends Component {
+class MetricRevisionsContainer extends Component {
   static propTypes = {
     params: PropTypes.object.isRequired,
     location: PropTypes.object.isRequired,
@@ -73,3 +72,8 @@ export default class MetricRevisionsContainer extends Component {
     );
   }
 }
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(MetricRevisionsContainer);

--- a/frontend/src/metabase/reference/segments/SegmentDetail.jsx
+++ b/frontend/src/metabase/reference/segments/SegmentDetail.jsx
@@ -7,6 +7,7 @@ import { t } from "ttag";
 import S from "../components/Detail.css";
 import List from "metabase/components/List";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
+import _ from "underscore";
 
 import EditHeader from "metabase/reference/components/EditHeader";
 import EditableReferenceHeader from "metabase/reference/components/EditableReferenceHeader";
@@ -82,20 +83,7 @@ const validate = (values, props) =>
     ? { revision_message: t`Please enter a revision message` }
     : {};
 
-@connect(mapStateToProps, mapDispatchToProps)
-@reduxForm({
-  form: "details",
-  fields: [
-    "name",
-    "display_name",
-    "description",
-    "revision_message",
-    "points_of_interest",
-    "caveats",
-  ],
-  validate,
-})
-export default class SegmentDetail extends Component {
+class SegmentDetail extends Component {
   static propTypes = {
     style: PropTypes.object.isRequired,
     entity: PropTypes.object.isRequired,
@@ -273,3 +261,19 @@ export default class SegmentDetail extends Component {
     );
   }
 }
+
+export default _.compose(
+  connect(mapStateToProps, mapDispatchToProps),
+  reduxForm({
+    form: "details",
+    fields: [
+      "name",
+      "display_name",
+      "description",
+      "revision_message",
+      "points_of_interest",
+      "caveats",
+    ],
+    validate,
+  }),
+)(SegmentDetail);

--- a/frontend/src/metabase/reference/segments/SegmentDetailContainer.jsx
+++ b/frontend/src/metabase/reference/segments/SegmentDetailContainer.jsx
@@ -31,8 +31,7 @@ const mapDispatchToProps = {
   ...actions,
 };
 
-@connect(mapStateToProps, mapDispatchToProps)
-export default class SegmentDetailContainer extends Component {
+class SegmentDetailContainer extends Component {
   static propTypes = {
     params: PropTypes.object.isRequired,
     location: PropTypes.object.isRequired,
@@ -73,3 +72,8 @@ export default class SegmentDetailContainer extends Component {
     );
   }
 }
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(SegmentDetailContainer);

--- a/frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx
+++ b/frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx
@@ -5,6 +5,7 @@ import { connect } from "react-redux";
 import { reduxForm } from "redux-form";
 import { t } from "ttag";
 import S from "metabase/reference/Reference.css";
+import _ from "underscore";
 
 import List from "metabase/components/List";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
@@ -82,22 +83,7 @@ const validate = (values, props) => {
   return {};
 };
 
-@connect(mapStateToProps, mapDispatchToProps)
-@reduxForm({
-  form: "details",
-  fields: [
-    "name",
-    "display_name",
-    "description",
-    "revision_message",
-    "points_of_interest",
-    "caveats",
-    "semantic_type",
-    "fk_target_field_id",
-  ],
-  validate,
-})
-export default class SegmentFieldDetail extends Component {
+class SegmentFieldDetail extends Component {
   static propTypes = {
     style: PropTypes.object.isRequired,
     entity: PropTypes.object.isRequired,
@@ -263,3 +249,21 @@ export default class SegmentFieldDetail extends Component {
     );
   }
 }
+
+export default _.compose(
+  connect(mapStateToProps, mapDispatchToProps),
+  reduxForm({
+    form: "details",
+    fields: [
+      "name",
+      "display_name",
+      "description",
+      "revision_message",
+      "points_of_interest",
+      "caveats",
+      "semantic_type",
+      "fk_target_field_id",
+    ],
+    validate,
+  }),
+)(SegmentFieldDetail);

--- a/frontend/src/metabase/reference/segments/SegmentFieldDetailContainer.jsx
+++ b/frontend/src/metabase/reference/segments/SegmentFieldDetailContainer.jsx
@@ -31,8 +31,7 @@ const mapDispatchToProps = {
   ...actions,
 };
 
-@connect(mapStateToProps, mapDispatchToProps)
-export default class SegmentFieldDetailContainer extends Component {
+class SegmentFieldDetailContainer extends Component {
   static propTypes = {
     params: PropTypes.object.isRequired,
     location: PropTypes.object.isRequired,
@@ -73,3 +72,8 @@ export default class SegmentFieldDetailContainer extends Component {
     );
   }
 }
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(SegmentFieldDetailContainer);

--- a/frontend/src/metabase/reference/segments/SegmentFieldList.jsx
+++ b/frontend/src/metabase/reference/segments/SegmentFieldList.jsx
@@ -7,6 +7,7 @@ import { t } from "ttag";
 import S from "metabase/components/List.css";
 import R from "metabase/reference/Reference.css";
 import F from "metabase/reference/components/Field.css";
+import _ from "underscore";
 
 import Field from "metabase/reference/components/Field";
 import List from "metabase/components/List";
@@ -63,12 +64,7 @@ const validate = (values, props) => {
   return {};
 };
 
-@connect(mapStateToProps, mapDispatchToProps)
-@reduxForm({
-  form: "fields",
-  validate,
-})
-export default class SegmentFieldList extends Component {
+class SegmentFieldList extends Component {
   static propTypes = {
     segment: PropTypes.object.isRequired,
     style: PropTypes.object.isRequired,
@@ -190,3 +186,11 @@ export default class SegmentFieldList extends Component {
     );
   }
 }
+
+export default _.compose(
+  connect(mapStateToProps, mapDispatchToProps),
+  reduxForm({
+    form: "fields",
+    validate,
+  }),
+)(SegmentFieldList);

--- a/frontend/src/metabase/reference/segments/SegmentFieldListContainer.jsx
+++ b/frontend/src/metabase/reference/segments/SegmentFieldListContainer.jsx
@@ -31,8 +31,7 @@ const mapDispatchToProps = {
   ...actions,
 };
 
-@connect(mapStateToProps, mapDispatchToProps)
-export default class SegmentFieldListContainer extends Component {
+class SegmentFieldListContainer extends Component {
   static propTypes = {
     params: PropTypes.object.isRequired,
     location: PropTypes.object.isRequired,
@@ -73,3 +72,8 @@ export default class SegmentFieldListContainer extends Component {
     );
   }
 }
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(SegmentFieldListContainer);

--- a/frontend/src/metabase/reference/segments/SegmentList.jsx
+++ b/frontend/src/metabase/reference/segments/SegmentList.jsx
@@ -41,8 +41,7 @@ const mapDispatchToProps = {
   ...metadataActions,
 };
 
-@connect(mapStateToProps, mapDispatchToProps)
-export default class SegmentList extends Component {
+class SegmentList extends Component {
   static propTypes = {
     style: PropTypes.object.isRequired,
     entities: PropTypes.object.isRequired,
@@ -94,3 +93,5 @@ export default class SegmentList extends Component {
     );
   }
 }
+
+export default connect(mapStateToProps, mapDispatchToProps)(SegmentList);

--- a/frontend/src/metabase/reference/segments/SegmentListContainer.jsx
+++ b/frontend/src/metabase/reference/segments/SegmentListContainer.jsx
@@ -22,8 +22,7 @@ const mapDispatchToProps = {
   ...actions,
 };
 
-@connect(mapStateToProps, mapDispatchToProps)
-export default class SegmentListContainer extends Component {
+class SegmentListContainer extends Component {
   static propTypes = {
     params: PropTypes.object.isRequired,
     location: PropTypes.object.isRequired,
@@ -61,3 +60,8 @@ export default class SegmentListContainer extends Component {
     );
   }
 }
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(SegmentListContainer);

--- a/frontend/src/metabase/reference/segments/SegmentQuestions.jsx
+++ b/frontend/src/metabase/reference/segments/SegmentQuestions.jsx
@@ -53,8 +53,7 @@ const mapDispatchToProps = {
   ...metadataActions,
 };
 
-@connect(mapStateToProps, mapDispatchToProps)
-export default class SegmentQuestions extends Component {
+class SegmentQuestions extends Component {
   static propTypes = {
     table: PropTypes.object.isRequired,
     segment: PropTypes.object.isRequired,
@@ -116,3 +115,5 @@ export default class SegmentQuestions extends Component {
     );
   }
 }
+
+export default connect(mapStateToProps, mapDispatchToProps)(SegmentQuestions);

--- a/frontend/src/metabase/reference/segments/SegmentQuestionsContainer.jsx
+++ b/frontend/src/metabase/reference/segments/SegmentQuestionsContainer.jsx
@@ -34,8 +34,7 @@ const mapDispatchToProps = {
   ...actions,
 };
 
-@connect(mapStateToProps, mapDispatchToProps)
-export default class SegmentQuestionsContainer extends Component {
+class SegmentQuestionsContainer extends Component {
   static propTypes = {
     params: PropTypes.object.isRequired,
     location: PropTypes.object.isRequired,
@@ -79,3 +78,8 @@ export default class SegmentQuestionsContainer extends Component {
     );
   }
 }
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(SegmentQuestionsContainer);

--- a/frontend/src/metabase/reference/segments/SegmentRevisions.jsx
+++ b/frontend/src/metabase/reference/segments/SegmentRevisions.jsx
@@ -44,8 +44,7 @@ const mapDispatchToProps = {
   ...metadataActions,
 };
 
-@connect(mapStateToProps, mapDispatchToProps)
-export default class SegmentRevisions extends Component {
+class SegmentRevisions extends Component {
   static propTypes = {
     style: PropTypes.object.isRequired,
     revisions: PropTypes.object.isRequired,
@@ -128,3 +127,5 @@ export default class SegmentRevisions extends Component {
     );
   }
 }
+
+export default connect(mapStateToProps, mapDispatchToProps)(SegmentRevisions);

--- a/frontend/src/metabase/reference/segments/SegmentRevisionsContainer.jsx
+++ b/frontend/src/metabase/reference/segments/SegmentRevisionsContainer.jsx
@@ -31,8 +31,7 @@ const mapDispatchToProps = {
   ...actions,
 };
 
-@connect(mapStateToProps, mapDispatchToProps)
-export default class SegmentRevisionsContainer extends Component {
+class SegmentRevisionsContainer extends Component {
   static propTypes = {
     params: PropTypes.object.isRequired,
     location: PropTypes.object.isRequired,
@@ -76,3 +75,8 @@ export default class SegmentRevisionsContainer extends Component {
     );
   }
 }
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(SegmentRevisionsContainer);

--- a/frontend/src/metabase/sharing/components/SharingSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/SharingSidebar.jsx
@@ -105,13 +105,7 @@ const mapDispatchToProps = {
   testPulse,
 };
 
-@Pulses.loadList({
-  query: (state, { dashboard }) => ({ dashboard_id: dashboard.id }),
-  loadingAndErrorWrapper: false,
-})
-@User.loadList({ loadingAndErrorWrapper: false })
-@connect(mapStateToProps, mapDispatchToProps)
-class SharingSidebar extends React.Component {
+class SharingSidebarInner extends React.Component {
   state = {
     editingMode: "list-pulses",
     // use this to know where to go "back" to
@@ -412,5 +406,14 @@ class SharingSidebar extends React.Component {
     return <Sidebar />;
   }
 }
+
+const SharingSidebar = _.compose(
+  Pulses.loadList({
+    query: (state, { dashboard }) => ({ dashboard_id: dashboard.id }),
+    loadingAndErrorWrapper: false,
+  }),
+  User.loadList({ loadingAndErrorWrapper: false }),
+  connect(mapStateToProps, mapDispatchToProps),
+)(SharingSidebarInner);
 
 export default SharingSidebar;

--- a/frontend/src/metabase/visualizations/components/CardRenderer.jsx
+++ b/frontend/src/metabase/visualizations/components/CardRenderer.jsx
@@ -17,11 +17,7 @@ const trackEventThrottled = _.throttle(
   10000,
 );
 
-@ExplicitSize({
-  wrapped: true,
-  refreshMode: props => (props.isDashboard ? "debounce" : "throttle"),
-})
-export default class CardRenderer extends Component {
+class CardRenderer extends Component {
   static propTypes = {
     className: PropTypes.string,
     series: PropTypes.array.isRequired,
@@ -107,3 +103,8 @@ export default class CardRenderer extends Component {
     return <div className={this.props.className} style={this.props.style} />;
   }
 }
+
+export default ExplicitSize({
+  wrapped: true,
+  refreshMode: props => (props.isDashboard ? "debounce" : "throttle"),
+})(CardRenderer);

--- a/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
@@ -71,8 +71,7 @@ Object.values(SECTIONS).map((section, index) => {
 const getGALabelForAction = action =>
   action ? `${action.section || ""}:${action.name || ""}` : null;
 
-@connect()
-export default class ChartClickActions extends Component {
+class ChartClickActions extends Component {
   state = {
     popoverAction: null,
   };
@@ -260,6 +259,8 @@ export default class ChartClickActions extends Component {
     );
   }
 }
+
+export default connect()(ChartClickActions);
 
 export const ChartClickAction = ({ action, isLastItem, handleClickAction }) => {
   // This is where all the different action button styles get applied.

--- a/frontend/src/metabase/visualizations/components/ChartWithLegend.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartWithLegend.jsx
@@ -14,11 +14,7 @@ const PADDING = 14;
 
 const DEFAULT_GRID_SIZE = 100;
 
-@ExplicitSize({
-  wrapped: true,
-  refreshMode: props => (props.isDashboard ? "debounce" : "throttle"),
-})
-export default class ChartWithLegend extends Component {
+class ChartWithLegend extends Component {
   static defaultProps = {
     aspectRatio: 1,
     style: {},
@@ -147,3 +143,8 @@ export default class ChartWithLegend extends Component {
     );
   }
 }
+
+export default ExplicitSize({
+  wrapped: true,
+  refreshMode: props => (props.isDashboard ? "debounce" : "throttle"),
+})(ChartWithLegend);

--- a/frontend/src/metabase/visualizations/components/LegendHeader.jsx
+++ b/frontend/src/metabase/visualizations/components/LegendHeader.jsx
@@ -13,8 +13,7 @@ import { normal } from "metabase/lib/colors";
 const DEFAULT_COLORS = Object.values(normal);
 const MIN_WIDTH_PER_SERIES = 100;
 
-@ExplicitSize({ refreshMode: "debounce" })
-export default class LegendHeader extends Component {
+class LegendHeader extends Component {
   static propTypes = {
     series: PropTypes.array.isRequired,
     hovered: PropTypes.object,
@@ -147,3 +146,5 @@ export default class LegendHeader extends Component {
     );
   }
 }
+
+export default ExplicitSize({ refreshMode: "debounce" })(LegendHeader);

--- a/frontend/src/metabase/visualizations/components/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive.jsx
@@ -64,10 +64,7 @@ function pickRowsToMeasure(rows, columnIndex, count = 10) {
   return rowIndexes;
 }
 
-@ExplicitSize({
-  refreshMode: props => (props.isDashboard ? "debounce" : "throttle"),
-})
-export default class TableInteractive extends Component {
+class TableInteractive extends Component {
   constructor(props) {
     super(props);
 
@@ -1047,6 +1044,10 @@ export default class TableInteractive extends Component {
     next();
   }
 }
+
+export default ExplicitSize({
+  refreshMode: props => (props.isDashboard ? "debounce" : "throttle"),
+})(TableInteractive);
 
 const DetailShortcut = React.forwardRef((_props, ref) => (
   <div

--- a/frontend/src/metabase/visualizations/components/TableSimple.jsx
+++ b/frontend/src/metabase/visualizations/components/TableSimple.jsx
@@ -28,11 +28,7 @@ import { getIn } from "icepick";
 
 import { isID, isFK } from "metabase/lib/schema_metadata";
 
-@ExplicitSize({
-  refreshMode: props =>
-    props.isDashboard && !props.isEditing ? "debounce" : "throttle",
-})
-export default class TableSimple extends Component {
+class TableSimple extends Component {
   constructor(props) {
     super(props);
 
@@ -316,3 +312,8 @@ export default class TableSimple extends Component {
     );
   }
 }
+
+export default ExplicitSize({
+  refreshMode: props =>
+    props.isDashboard && !props.isEditing ? "debounce" : "throttle",
+})(TableSimple);

--- a/frontend/src/metabase/visualizations/components/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization.jsx
@@ -43,12 +43,8 @@ import Mode from "metabase-lib/lib/Mode";
 import { memoize } from "metabase-lib/lib/utils";
 
 // NOTE: pass `CardVisualization` so that we don't include header when providing size to child element
-@ExplicitSize({
-  selector: ".CardVisualization",
-  refreshMode: props => (props.isDashboard ? "debounce" : "throttle"),
-})
-@connect()
-export default class Visualization extends React.PureComponent {
+
+class Visualization extends React.PureComponent {
   constructor(props) {
     super(props);
 
@@ -556,3 +552,11 @@ export default class Visualization extends React.PureComponent {
     );
   }
 }
+
+export default _.compose(
+  ExplicitSize({
+    selector: ".CardVisualization",
+    refreshMode: props => (props.isDashboard ? "debounce" : "throttle"),
+  }),
+  connect(),
+)(Visualization);

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPartition.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPartition.jsx
@@ -292,67 +292,7 @@ class EmptyPartition extends React.Component {
   }
 }
 
-@DropTarget(
-  "columns",
-  {
-    hover: (props, monitor, component) => {
-      const item = monitor.getItem();
-      if (props.columnFilter && props.columnFilter(item.column) === false) {
-        return;
-      }
-      const { index: dragIndex, partitionName: itemPartition } = item;
-      const hoverIndex = props.index;
-      const { value, partitionName, updateDisplayedValue } = props;
-      if (partitionName === itemPartition && dragIndex !== hoverIndex) {
-        const columns = value[itemPartition];
-        const columnsDup = [...columns];
-        columnsDup[dragIndex] = columns[hoverIndex];
-        columnsDup[hoverIndex] = columns[dragIndex];
-        updateDisplayedValue({ ...value, [itemPartition]: columnsDup });
-        item.index = hoverIndex;
-      } else if (partitionName !== itemPartition) {
-        updateDisplayedValue({
-          ...value,
-          [itemPartition]: [
-            ...value[itemPartition].slice(0, dragIndex),
-            ...value[itemPartition].slice(dragIndex + 1),
-          ],
-          [partitionName]: [
-            ...value[partitionName].slice(0, hoverIndex),
-            value[itemPartition][dragIndex],
-            ...value[partitionName].slice(hoverIndex),
-          ],
-        });
-        item.index = hoverIndex;
-        item.partitionName = partitionName;
-      }
-    },
-    drop: ({ index, column, partitionName }, monitor, component) => ({
-      index,
-      column,
-      partitionName,
-    }),
-  },
-  (connect, monitor) => ({ connectDropTarget: connect.dropTarget() }),
-)
-@DragSource(
-  "columns",
-  {
-    beginDrag: ({ column, partitionName, index }) => ({
-      column,
-      partitionName,
-      index,
-    }),
-    endDrag: (props, monitor, component) => {
-      // props.commitDisplayedValue();
-    },
-  },
-  (connect, monitor) => ({
-    connectDragSource: connect.dragSource(),
-    isDragging: monitor.isDragging(),
-  }),
-)
-class Column extends React.Component {
+class ColumnInner extends React.Component {
   constructor(props) {
     super(props);
     this.state = { expanded: false };
@@ -419,5 +359,68 @@ class Column extends React.Component {
     );
   }
 }
+
+const Column = _.compose(
+  DropTarget(
+    "columns",
+    {
+      hover: (props, monitor, component) => {
+        const item = monitor.getItem();
+        if (props.columnFilter && props.columnFilter(item.column) === false) {
+          return;
+        }
+        const { index: dragIndex, partitionName: itemPartition } = item;
+        const hoverIndex = props.index;
+        const { value, partitionName, updateDisplayedValue } = props;
+        if (partitionName === itemPartition && dragIndex !== hoverIndex) {
+          const columns = value[itemPartition];
+          const columnsDup = [...columns];
+          columnsDup[dragIndex] = columns[hoverIndex];
+          columnsDup[hoverIndex] = columns[dragIndex];
+          updateDisplayedValue({ ...value, [itemPartition]: columnsDup });
+          item.index = hoverIndex;
+        } else if (partitionName !== itemPartition) {
+          updateDisplayedValue({
+            ...value,
+            [itemPartition]: [
+              ...value[itemPartition].slice(0, dragIndex),
+              ...value[itemPartition].slice(dragIndex + 1),
+            ],
+            [partitionName]: [
+              ...value[partitionName].slice(0, hoverIndex),
+              value[itemPartition][dragIndex],
+              ...value[partitionName].slice(hoverIndex),
+            ],
+          });
+          item.index = hoverIndex;
+          item.partitionName = partitionName;
+        }
+      },
+      drop: ({ index, column, partitionName }, monitor, component) => ({
+        index,
+        column,
+        partitionName,
+      }),
+    },
+    (connect, monitor) => ({ connectDropTarget: connect.dropTarget() }),
+  ),
+  DragSource(
+    "columns",
+    {
+      beginDrag: ({ column, partitionName, index }) => ({
+        column,
+        partitionName,
+        index,
+      }),
+      endDrag: (props, monitor, component) => {
+        // props.commitDisplayedValue();
+      },
+    },
+    (connect, monitor) => ({
+      connectDragSource: connect.dragSource(),
+      isDragging: monitor.isDragging(),
+    }),
+  ),
+)(ColumnInner);
 
 export default ChartSettingFieldsPartition;

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPartition.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPartition.jsx
@@ -200,19 +200,7 @@ class ChartSettingFieldsPartition extends React.Component {
   }
 }
 
-@DropTarget(
-  "columns",
-  {
-    // Using a drop target here is a hack to work around another issue.
-    // The version of react-dnd we're on has a bug where endDrag isn't called.
-    // Drop is still called here, so we trigger commit here.
-    drop: (props, monitor, component) => {
-      props.commitDisplayedValue();
-    },
-  },
-  (connect, monitor) => ({ connectDropTarget: connect.dropTarget() }),
-)
-class Partition extends React.Component {
+class PartitionInner extends React.Component {
   render() {
     const {
       columns = [],
@@ -260,7 +248,28 @@ class Partition extends React.Component {
   }
 }
 
-@DropTarget(
+const Partition = DropTarget(
+  "columns",
+  {
+    // Using a drop target here is a hack to work around another issue.
+    // The version of react-dnd we're on has a bug where endDrag isn't called.
+    // Drop is still called here, so we trigger commit here.
+    drop: (props, monitor, component) => {
+      props.commitDisplayedValue();
+    },
+  },
+  (connect, monitor) => ({ connectDropTarget: connect.dropTarget() }),
+)(PartitionInner);
+
+class EmptyPartitionInner extends React.Component {
+  render() {
+    return this.props.connectDropTarget(
+      <div className="p2 text-centered bg-light rounded text-medium">{t`Drag fields here`}</div>,
+    );
+  }
+}
+
+const EmptyPartition = DropTarget(
   "columns",
   {
     hover: (props, monitor, component) => {
@@ -283,14 +292,7 @@ class Partition extends React.Component {
     },
   },
   (connect, monitor) => ({ connectDropTarget: connect.dropTarget() }),
-)
-class EmptyPartition extends React.Component {
-  render() {
-    return this.props.connectDropTarget(
-      <div className="p2 text-centered bg-light rounded text-medium">{t`Drag fields here`}</div>,
-    );
-  }
-}
+)(EmptyPartitionInner);
 
 class ColumnInner extends React.Component {
   constructor(props) {

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -68,8 +68,7 @@ const mapStateToProps = state => ({
   hasCustomColors: PLUGIN_SELECTORS.getHasCustomColors(state),
 });
 
-@connect(mapStateToProps)
-export default class PivotTable extends Component {
+class PivotTable extends Component {
   static uiName = t`Pivot Table`;
   static identifier = "pivot";
   static iconName = "pivot_table";
@@ -523,6 +522,8 @@ export default class PivotTable extends Component {
       });
   }
 }
+
+export default connect(mapStateToProps)(PivotTable);
 
 function RowToggleIcon({
   value,


### PR DESCRIPTION
# Why?

[The ECMAScript decorators proposal](https://github.com/tc39/proposal-decorators) has moved onto stage 3 in the standardization process with an API surface that is incompatible with [stage 1](https://github.com/wycats/javascript-decorators/blob/e1bf8d41bfa2591d949dd3bbf013514c8904b913/README.md) and [stage 2](https://github.com/tc39/proposal-decorators/tree/7fa580b40f2c19c561511ea2c978e307ae689a1b) decorators. This is a problem because many build tools like [`esbuild`](https://github.com/evanw/esbuild) that can improve our developer experience will not support the feature until it makes it into the standard, forcing us to use `@babel/plugin-proposal-decorators` for stage 1 decorators and Typescript's `experimentalDecorators` feature for stage 2 decorators like `memoize` in `metabase-lib/lib/utils`.

This PR should improve build performance by removing several `babel` plugins and open the door to more modern tooling.


## Notes

* I removed `memoize` from `AccordionList.getRowsCached` because repeated calls would always return the first result even with different arguments - performance seemed to improve