### PR TITLE
E2E] Remove `joins` check from CCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1257,7 +1257,6 @@ workflows:
                   "dashboard",
                   "embedding",
                   "filters",
-                  "joins",
                   "models",
                   "native",
                   "native-filters",


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
In the same manner we did for #21785 and #21991, this PR:
- Removes `joins` E2E group from CircleCI because we've been running it successfully using GitHub actions.