### PR TITLE
Adjusting Token Field and removing updateOnInputChange when used in FieldValuesWidget

### DIFF
--- a/frontend/src/metabase/components/FieldValuesWidget.jsx
+++ b/frontend/src/metabase/components/FieldValuesWidget.jsx
@@ -437,7 +437,7 @@ export class FieldValuesWidget extends Component {
             value={value.filter(v => v != null)}
             onChange={onChange}
             placeholder={placeholder}
-            updateOnInputChange
+            updateOnInputBlur
             // forwarded props
             multi={multi}
             autoFocus={autoFocus}

--- a/frontend/src/metabase/components/TokenField.jsx
+++ b/frontend/src/metabase/components/TokenField.jsx
@@ -360,6 +360,9 @@ export default class TokenField extends Component {
         if (value != null && (multi || value !== this.props.value[0])) {
           this.addValue(value);
           this.clearInputValue();
+          if (multi) {
+            e.preventDefault();
+          }
           return true;
         }
       }


### PR DESCRIPTION
Fixes #21915 

Removing the updateOnInputChange flag prevents the behavior described in the ticket, and a small adjustment was made so that we still call preventDefault() on the event (so that when you type a comma, it doesn't show up in the text box). @flamber I couldn't figure out why we had that flag, perhaps you're aware. From what I can tell, that flag was added to specifically do the behavior that is described in this bug.

Typing:
![chrome_p7IHQaIZQC](https://user-images.githubusercontent.com/1328979/166687244-79257b89-b5e0-4c6f-9d2e-93847da2eb68.gif)

Copy/Paste multiple values:
![chrome_fNIRiVki1a](https://user-images.githubusercontent.com/1328979/166687431-f1a31732-44de-4131-a369-f2b2da000b9a.gif)

