### PR TITLE
Fix cancelling the native query via shortcut

### DIFF
--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
@@ -177,9 +177,14 @@ export default class NativeQueryEditor extends Component {
   }, 100);
 
   handleKeyDown = e => {
-    const ENTER_KEY = 13;
-    if (e.keyCode === ENTER_KEY && (e.metaKey || e.ctrlKey)) {
-      this.runQuery();
+    const { isRunning, cancelQuery } = this.props;
+
+    if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+      if (isRunning) {
+        cancelQuery();
+      } else {
+        this.runQuery();
+      }
     }
   };
 

--- a/frontend/test/metabase/scenarios/visualizations/reproductions/11727-cancel-native-query-shortcut.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/reproductions/11727-cancel-native-query-shortcut.cy.spec.js
@@ -20,7 +20,7 @@ describe("issue 11727", () => {
   beforeEach(() => {
     restore("postgres-12");
     cy.signInAsAdmin();
-    cy.intercept("GET", "/api/dataset").as("getDataset");
+    cy.intercept("GET", "/api/database").as("getDatabases");
   });
 
   it("should cancel the native query via the keyboard shortcut (metabase#11727)", () => {

--- a/frontend/test/metabase/scenarios/visualizations/reproductions/11727-cancel-native-query-shortcut.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/reproductions/11727-cancel-native-query-shortcut.cy.spec.js
@@ -1,0 +1,38 @@
+import {
+  restore,
+  withDatabase,
+  adhocQuestionHash,
+} from "__support__/e2e/cypress";
+
+const PG_DB_ID = 2;
+
+const questionDetails = {
+  dataset_query: {
+    type: "native",
+    database: PG_DB_ID,
+    native: {
+      query: "SELECT pg_sleep(10)",
+    },
+  },
+};
+
+describe("issue 11727", () => {
+  beforeEach(() => {
+    restore("postgres-12");
+    cy.signInAsAdmin();
+    cy.intercept("GET", "/api/dataset").as("getDataset");
+  });
+
+  it("should cancel the native query via the keyboard shortcut (metabase#11727)", () => {
+    withDatabase(PG_DB_ID, () => {
+      cy.visit(`/question#` + adhocQuestionHash(questionDetails));
+      cy.wait("@getDatabases");
+
+      cy.findByText("Doing science...").should("be.visible");
+      cy.get("body").type("{cmd}{enter}");
+      cy.findByText("Here's where your results will appear").should(
+        "be.visible",
+      );
+    });
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/11727
Reproduces https://github.com/metabase/metabase/issues/11727

Currently there is a mismatch in behavior between running the query via the Run button and the keyboard shortcut. When clicking on the button it will cancel the query if it's still running. On other hand, the shortcut will cancel the query and execute it again. This PR fixes this behavior in a way that the shortcut behaves in the same way as the button.

The title of the original issue is misleading. I initially thought that the query is not cancelled and it's possible to execute multiple queries in parallel. That's not exactly true - the call to the backend was cancelled before each subsequent call. But the underlying query wasn't cancelled by the backend, and that's a different story.

How to test:
- Add a postgres database
- Run `SELECT pg_sleep(10);` query
- Hit `Cmd+Enter` to cancel the query
- The query should be cancelled and its results should no appear after 10 seconds