### PR TITLE
Add a delay for showing tooltips for relative date filters

### DIFF
--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RelativeDatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RelativeDatePicker.tsx
@@ -89,6 +89,7 @@ export function CurrentPicker(props: CurrentPickerProps) {
             <TippyPopover
               key={period}
               placement="bottom"
+              delay={[500, null]}
               content={
                 <CurrentPopover>{periodPopoverText(period)}</CurrentPopover>
               }


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/22283

How to test:
- Open a products table
- Click on `Created at` -> `Filter by this column` -> `Relative dates` -> `Current`
- Hover over options and make sure there is a delay for showing the tooltip

<img width="463" alt="Screenshot 2022-05-04 at 17 14 47" src="https://user-images.githubusercontent.com/8542534/166700473-48d208f5-2385-4c1b-93d7-7d618705d50d.png">
