### PR TITLE
Clear download perms when setting block perms

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions.clj
@@ -44,8 +44,7 @@
                [group-id db-id schema-name]
                [group-id db-id schema-name table-or-id])}
   [group-id & path-components]
-  (apply (partial revoke-permissions! :download :full group-id) path-components)
-  (apply (partial revoke-permissions! :download :limited group-id) path-components))
+  (apply (perms/revoke-download-perms! group-id) path-components))
 
 (defn- update-table-download-permissions!
   [group-id db-id schema table-id new-table-perms]

--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions.clj
@@ -44,7 +44,7 @@
                [group-id db-id schema-name]
                [group-id db-id schema-name table-or-id])}
   [group-id & path-components]
-  (apply (perms/revoke-download-perms! group-id) path-components))
+  (apply (partial perms/revoke-download-perms! group-id) path-components))
 
 (defn- update-table-download-permissions!
   [group-id db-id schema table-id new-table-perms]

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions_test.clj
@@ -83,7 +83,13 @@
                                                                                             id-4 :full}}})
             (is (= {:schemas {"PUBLIC" {id-1 :full id-2 :full id-3 :full id-4 :full}}
                     :native :full}
-                   (download-perms-by-group-id group-id))))))
+                   (download-perms-by-group-id group-id)))))
+
+        (testing "Download perms are revoked when block perms are set"
+          (ee-perms/update-db-download-permissions! group-id (mt/id) {:schemas :full :native :full})
+          (is (= {:schemas :full :native :full} (download-perms-by-group-id group-id)))
+          (@#'perms/update-db-data-access-permissions! group-id (mt/id) {:schemas :block})
+          (is (= nil (download-perms-by-group-id group-id)))))
 
       (premium-features-test/with-premium-features #{}
         (testing "Download permissions cannot be modified without the :advanced-permissions feature flag"
@@ -237,7 +243,7 @@
       (testing (pr-str perm-type)
         (testing "slash"
           (mt/with-temp PermissionsGroup [group]
-            (#'ee-perms/grant-permissions! perm-type perm-value (:id group) (mt/id) "schema/with_slash" )
+            (#'ee-perms/grant-permissions! perm-type perm-value (:id group) (mt/id) "schema/with_slash")
             (is (= "schema/with_slash"
                    (-> (get-in (perms/data-perms-graph) [:groups (u/the-id group) (mt/id) perm-type :schemas])
                        keys

--- a/frontend/test/metabase/scenarios/permissions/download-permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/download-permissions.cy.spec.js
@@ -61,14 +61,10 @@ describeEE("scenarios > admin > permissions > data > downloads", () => {
       DOWNLOAD_PERMISSION_INDEX,
       "1 million rows",
     );
+  });
 
-    cy.log(
-      "Make sure the download permissions are set to `No` when data access is revoked",
-    );
-
-    cy.get("a")
-      .contains("Sample Database")
-      .click();
+  it("respects 'no download' permissions when 'All users' group data permissions are set to `Block` (metabase#22408)", () => {
+    cy.visit(`/admin/permissions/data/database/${SAMPLE_DB_ID}`);
 
     modifyPermission("All Users", DATA_ACCESS_PERMISSION_INDEX, "Block");
 
@@ -80,7 +76,17 @@ describeEE("scenarios > admin > permissions > data > downloads", () => {
       cy.button("Yes").click();
     });
 
+    // When data permissions are set to `Block`, download permissions are automatically revoked
     assertPermissionForItem("All Users", DOWNLOAD_PERMISSION_INDEX, "No");
+
+    // Normal user belongs to both "data" and "collections" groups.
+    // They both have restricted downloads so this user shouldn't have the right to download anything.
+    cy.signIn("normal");
+
+    visitQuestion("1");
+
+    cy.findByText("Showing first 2,000 rows");
+    cy.icon("download").should("not.exist");
   });
 
   it("restricts users from downloading questions", () => {

--- a/src/metabase/models/permissions.clj
+++ b/src/metabase/models/permissions.clj
@@ -842,6 +842,15 @@
   [group-or-id & path-components]
   (delete-related-permissions! group-or-id (apply data-perms-path path-components)))
 
+(defn revoke-download-perms!
+  "Revoke all full and limited download permissions for `group-or-id` to object with `path-components`."
+  {:arglists '([group-id db-id]
+               [group-id db-id schema-name]
+               [group-id db-id schema-name table-or-id])}
+  [group-or-id & path-components]
+  (delete-related-permissions! group-or-id (apply (partial feature-perms-path :download :full) path-components))
+  (delete-related-permissions! group-or-id (apply (partial feature-perms-path :download :limited) path-components)))
+
 (defn grant-permissions!
   "Grant permissions for `group-or-id`. Two-arity grants any arbitrary Permissions `path`. With > 2 args, grants the
   data permissions from calling [[data-perms-path]]."
@@ -1117,6 +1126,7 @@
                  (when-not (premium-features/has-feature? :advanced-permissions)
                    (throw (ee-permissions-exception :block)))
                  (revoke-data-perms! group-id db-id)
+                 (revoke-download-perms! group-id db-id)
                  (grant-permissions! group-id (database-block-perms-path db-id)))
         (when (map? schemas)
           (delete-block-perms-for-this-db!)


### PR DESCRIPTION
I had a slightly mistaken understand of how block perms worked -- I thought that block perms for the All Users group would override data perms for other groups. So I thought we were fine to skip clearing download perms when setting block perms, since users with block perms can't download data _de facto_, because they can't run the query. 

Since this isn't the case, we just need to make sure to clear download perms when setting block perms, like we do with data access perms.

Resolves #22408