### PR TITLE
Custom expression: fix unary parsing with boolean

### DIFF
--- a/frontend/src/metabase/lib/expressions/process.js
+++ b/frontend/src/metabase/lib/expressions/process.js
@@ -1,9 +1,6 @@
 import { t } from "ttag";
 
-import {
-  parse,
-  adjustBooleans,
-} from "metabase/lib/expressions/recursive-parser";
+import { parse } from "metabase/lib/expressions/recursive-parser";
 import { resolve } from "metabase/lib/expressions/resolver";
 
 import {
@@ -43,8 +40,7 @@ export function processSource(options) {
   let expression;
   let compileError;
   try {
-    const parsed = parse(source);
-    expression = adjustBooleans(resolve(parsed, startRule, resolveMBQLField));
+    expression = resolve(parse(source), startRule, resolveMBQLField);
   } catch (e) {
     console.warn("compile error", e);
     compileError = e;

--- a/frontend/src/metabase/lib/expressions/recursive-parser.js
+++ b/frontend/src/metabase/lib/expressions/recursive-parser.js
@@ -109,9 +109,10 @@ function recursiveParse(source) {
 
   // Unary ::= Primary |
   //           "+" Unary |
-  //           "-" Unary
+  //           "-" Unary |
+  //           "NOT" Unary
   const parseUnary = () => {
-    if (matchOps([OP.Plus, OP.Minus])) {
+    if (matchOps([OP.Plus, OP.Minus, OP.Not])) {
       const { op } = next();
       const expr = parseUnary();
       return op === OP.Minus && typeof expr === "number" ? -expr : [op, expr];
@@ -332,7 +333,11 @@ export const adjustBooleans = tree =>
         return [
           operator,
           ...operands.map((operand, index) => {
-            if (!Array.isArray(operand) || args[index] !== "boolean") {
+            if (
+              !Array.isArray(operand) ||
+              args[index] !== "boolean" ||
+              operator === "not"
+            ) {
               return operand;
             }
             const [op, _id, opts] = operand;

--- a/frontend/src/metabase/lib/expressions/recursive-parser.js
+++ b/frontend/src/metabase/lib/expressions/recursive-parser.js
@@ -306,54 +306,6 @@ export const adjustCase = tree =>
     return node;
   });
 
-export const adjustBooleans = tree =>
-  modify(tree, node => {
-    if (Array.isArray(node)) {
-      if (node?.[0] === "case") {
-        const [operator, pairs, options] = node;
-        return [
-          operator,
-          pairs.map(([operand, value]) => {
-            if (!Array.isArray(operand)) {
-              return [operand, value];
-            }
-            const [op, _id, opts] = operand;
-            const isBooleanField =
-              op === "field" && opts?.["base-type"] === "type/Boolean";
-            if (isBooleanField || op === "segment") {
-              return withAST([["=", operand, true], value], operand);
-            }
-            return [operand, value];
-          }),
-          options,
-        ];
-      } else {
-        const [operator, ...operands] = node;
-        const { args = [] } = MBQL_CLAUSES[operator] || {};
-        return [
-          operator,
-          ...operands.map((operand, index) => {
-            if (
-              !Array.isArray(operand) ||
-              args[index] !== "boolean" ||
-              operator === "not"
-            ) {
-              return operand;
-            }
-            const [op, _id, opts] = operand;
-            const isBooleanField =
-              op === "field" && opts?.["base-type"] === "type/Boolean";
-            if (isBooleanField || op === "segment") {
-              return withAST(["=", operand, true], operand);
-            }
-            return operand;
-          }),
-        ];
-      }
-    }
-    return node;
-  });
-
 const pipe = (...fns) => x => fns.reduce((v, f) => f(v), x);
 
 export const parse = pipe(

--- a/frontend/src/metabase/lib/expressions/resolver.js
+++ b/frontend/src/metabase/lib/expressions/resolver.js
@@ -166,12 +166,13 @@ export function resolve(expression, type = "expression", fn = undefined) {
       return resolve(operand, args[i], fn);
     });
     return [op, ...resolvedOperands];
-  } else if (
-    !isCompatible(
-      type,
-      typeof expression === "boolean" ? "expression" : typeof expression,
-    )
-  ) {
+  }
+
+  if (type === "expression" && typeof expression === "boolean") {
+    return expression;
+  }
+
+  if (!isCompatible(type, typeof expression)) {
     throw new Error(
       t`Expecting ${type} but found ${JSON.stringify(expression)}`,
     );

--- a/frontend/test/metabase/lib/expressions/recursive-parser.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/recursive-parser.unit.spec.js
@@ -165,6 +165,8 @@ describe("metabase/lib/expressions/recursive-parser", () => {
   it("should parse boolean unary expressions", () => {
     expect(process("NOT C > 0")).toEqual(["not", [">", C, 0]]);
     expect(process("NOT NOT X")).toEqual(["not", ["not", X]]);
+    expect(filter("Y = NOT X")).toEqual(["=", Y, ["not", X]]);
+    expect(filter("C = NOT true")).toEqual(["=", C, ["not", true]]);
   });
 
   it("should parse boolean binary expressions", () => {

--- a/frontend/test/metabase/scenarios/filters/reproductions/22216-boolean-not.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/reproductions/22216-boolean-not.cy.spec.js
@@ -1,0 +1,36 @@
+import {
+  restore,
+  filter,
+  enterCustomColumnDetails,
+} from "__support__/e2e/cypress";
+
+const questionDetails = {
+  name: "Test Boolean",
+  native: { query: "select true as Awesome, false as Terrible" },
+};
+
+describe("issue 22216", () => {
+  beforeEach(() => {
+    cy.intercept("POST", "/api/dataset").as("dataset");
+
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should allow filtering with boolean NOT (metabase#22216)", () => {
+    cy.createNativeQuestion(questionDetails, { visitQuestion: true });
+
+    cy.findByText("Explore results").click();
+    cy.wait("@dataset");
+
+    filter();
+    cy.findByText("Custom Expression").click();
+    enterCustomColumnDetails({ formula: "[AWESOME] = NOT [Terrible]" });
+
+    cy.button("Done").click();
+    cy.wait("@dataset");
+
+    cy.findByTextEnsureVisible("AWESOME = NOT TERRIBLE");
+    cy.findByText("AWESOME = NOT TERRIBLE = True").should("not.be.visible");
+  });
+});

--- a/frontend/test/metabase/scenarios/filters/reproductions/22216-boolean-not.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/reproductions/22216-boolean-not.cy.spec.js
@@ -31,6 +31,6 @@ describe("issue 22216", () => {
     cy.wait("@dataset");
 
     cy.findByTextEnsureVisible("AWESOME = NOT TERRIBLE");
-    cy.findByText("AWESOME = NOT TERRIBLE = True").should("not.be.visible");
+    cy.findByText("AWESOME = NOT TERRIBLE = True").should("not.be.exist");
   });
 });

--- a/shared/src/metabase/mbql/normalize.cljc
+++ b/shared/src/metabase/mbql/normalize.cljc
@@ -814,6 +814,15 @@
                        {:form x, :path path}
                        e))))))
 
+(defn normalize-unary-booleans [query]
+    (walk/postwalk
+     (fn [node] (if (and
+                     (coll? node)
+                     (= 2 (count node))
+                     (= (first node) "not"))
+                  ["=" (second node) "false"]
+                  node))
+     query))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                            PUTTING IT ALL TOGETHER                                             |
@@ -825,7 +834,8 @@
   (let [normalize* (comp remove-empty-clauses
                          perform-whole-query-transformations
                          canonicalize
-                         normalize-tokens)]
+                         normalize-tokens
+                         normalize-unary-booleans)]
     (fn [query]
       (try
         (normalize* query)

--- a/shared/src/metabase/mbql/schema.cljc
+++ b/shared/src/metabase/mbql/schema.cljc
@@ -598,17 +598,22 @@
 
 (declare Filter)
 
+(def FilterOrField
+  "A Filter or a Field."
+  (s/cond-pre (s/recursive #'Filter)
+              (s/recursive #'Field)))
+
 (defclause and
-  first-clause  (s/recursive #'Filter)
-  second-clause (s/recursive #'Filter)
-  other-clauses (rest (s/recursive #'Filter)))
+  first-clause  (s/recursive #'FilterOrField)
+  second-clause (s/recursive #'FilterOrField)
+  other-clauses (rest (s/recursive #'FilterOrField)))
 
 (defclause or
-  first-clause  (s/recursive #'Filter)
-  second-clause (s/recursive #'Filter)
-  other-clauses (rest (s/recursive #'Filter)))
+  first-clause  (s/recursive #'FilterOrField)
+  second-clause (s/recursive #'FilterOrField)
+  other-clauses (rest (s/recursive #'FilterOrField)))
 
-(defclause not, clause (s/recursive #'Filter))
+(defclause not clause (s/recursive #'FilterOrField))
 
 (def ^:private FieldOrRelativeDatetime
   (s/if (partial is-clause? :relative-datetime)

--- a/src/metabase/query_processor/middleware/fetch_source_query.clj
+++ b/src/metabase/query_processor/middleware/fetch_source_query.clj
@@ -68,7 +68,7 @@
   ((every-pred integer? pos?) database))
 
 (def ^:private FullyResolvedQuery
-  "Schema for a MBQL query where all `card__id` `:source-tables` have been removes and appropriate `:source-query`s have
+  "Schema for a MBQL query where all `card__id` `:source-tables` have been removed and appropriate `:source-query`s have
   been added instead, and where the top-level `:database` ID, if it was the 'source query placeholder`, is replaced by
   the actual database ID of the source query.
 


### PR DESCRIPTION
Fixes #22216

To verify:
1. New, SQL query
2. Type `select true as awesome, false as terrible`, run and save it as `TestBool`
3. Explore results
4. Filter, Custom expression and type `[AWESOME] = NOT [TERRIBLE]`

(Another example that demonstrates the issue: use more unary operators, `NOT NOT`)

### Before this PR

Can't click the `Done` button (it's disabled) since the expression is _incorrectly_ rejected.

![image](https://user-images.githubusercontent.com/7288/166728653-183a24ef-44c2-4c49-b195-a98c12b9e46c.png)

From the browser console:
```
compile error Error: Unexpected operator NOT
```

### After this PR

The expression is correctly accepted as valid.

![image](https://user-images.githubusercontent.com/7288/166728548-0188fddb-1234-4cee-a99a-23ea4da911a5.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/22429)
<!-- Reviewable:end -->
