### PR TITLE
Fix visualization and settings buttons are visible for questions that use blocked db

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/ViewFooter.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewFooter.jsx
@@ -74,6 +74,9 @@ const ViewFooter = ({
     return null;
   }
 
+  const hasDataPermission = question.query().isEditable();
+  const hideChartSettings = result.error && !hasDataPermission;
+
   return (
     <ViewFooterRoot
       className={cx(className, "text-medium border-top")}
@@ -82,7 +85,10 @@ const ViewFooter = ({
       <ButtonBar
         className="flex-full"
         left={[
-          QuestionFilterWidget.shouldRender({ question, queryBuilderMode }) && (
+          QuestionFilterWidget.shouldRender({
+            question,
+            queryBuilderMode,
+          }) && (
             <MobileQuestionFilterWidget
               className="sm-hide"
               mr={1}
@@ -105,26 +111,30 @@ const ViewFooter = ({
               onCloseSummary={onCloseSummary}
             />
           ),
-          <VizTypeButton
-            key="viz-type"
-            question={question}
-            result={result}
-            active={isShowingChartTypeSidebar}
-            onClick={
-              isShowingChartTypeSidebar ? onCloseChartType : onOpenChartType
-            }
-          />,
-          <VizSettingsButton
-            key="viz-settings"
-            ml={1}
-            mr={[3, 0]}
-            active={isShowingChartSettingsSidebar}
-            onClick={
-              isShowingChartSettingsSidebar
-                ? onCloseChartSettings
-                : onOpenChartSettings
-            }
-          />,
+          !hideChartSettings && (
+            <VizTypeButton
+              key="viz-type"
+              question={question}
+              result={result}
+              active={isShowingChartTypeSidebar}
+              onClick={
+                isShowingChartTypeSidebar ? onCloseChartType : onOpenChartType
+              }
+            />
+          ),
+          !hideChartSettings && (
+            <VizSettingsButton
+              key="viz-settings"
+              ml={1}
+              mr={[3, 0]}
+              active={isShowingChartSettingsSidebar}
+              onClick={
+                isShowingChartSettingsSidebar
+                  ? onCloseChartSettings
+                  : onOpenChartSettings
+              }
+            />
+          ),
         ]}
         center={
           isVisualized && (
@@ -140,7 +150,11 @@ const ViewFooter = ({
           )
         }
         right={[
-          QuestionRowCount.shouldRender({ question, result, isObjectDetail }) &&
+          QuestionRowCount.shouldRender({
+            question,
+            result,
+            isObjectDetail,
+          }) &&
             !isPreviewing && (
               <QuestionRowCount
                 key="row_count"

--- a/frontend/test/metabase/scenarios/permissions/admin-permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/admin-permissions.cy.spec.js
@@ -12,6 +12,10 @@ import {
   visitQuestion,
 } from "__support__/e2e/cypress";
 
+import { SAMPLE_DB_ID, USER_GROUPS } from "__support__/e2e/cypress_data";
+
+const { ALL_USERS_GROUP } = USER_GROUPS;
+
 const COLLECTION_ACCESS_PERMISSION_INDEX = 0;
 
 const DATA_ACCESS_PERMISSION_INDEX = 0;
@@ -503,34 +507,6 @@ describeOSS("scenarios > admin > permissions", () => {
       });
     });
   });
-
-  // TODO: uncomment when starts returning an error
-  it.skip("block permission block access to questions that use blocked sources", () => {
-    cy.signInAsNormalUser();
-
-    visitQuestion(1);
-    cy.findAllByText("Orders");
-
-    cy.signInAsAdmin();
-
-    cy.visit("/admin/permissions/data/database/1");
-
-    ["All Users", "collection", "data", "nosql", "readonly"].forEach(group =>
-      modifyPermission(group, DATA_ACCESS_PERMISSION_INDEX, "Block"),
-    );
-
-    cy.findByText("Save changes").click();
-
-    modal().within(() => {
-      cy.button("Yes").click();
-    });
-
-    cy.signInAsNormalUser();
-
-    visitQuestion(1);
-
-    cy.findAllByText("Orders").should("not.exist");
-  });
 });
 
 describeEE("scenarios > admin > permissions", () => {
@@ -622,5 +598,22 @@ describeEE("scenarios > admin > permissions", () => {
       isPermissionDisabled(DATA_ACCESS_PERMISSION_INDEX, "Block", false);
       isPermissionDisabled(NATIVE_QUERIES_PERMISSION_INDEX, "No", true);
     });
+  });
+
+  it("Visualization and Settings query builder buttons are not visible for questions that use blocked data sources", () => {
+    cy.updatePermissionsGraph({
+      [ALL_USERS_GROUP]: {
+        [SAMPLE_DB_ID]: {
+          data: { schemas: "block" },
+        },
+      },
+    });
+
+    cy.signIn("nodata");
+    visitQuestion(1);
+
+    cy.findByText("There was a problem with your question");
+    cy.findByText("Settings").should("not.exist");
+    cy.findByText("Visualization").should("not.exist");
   });
 });


### PR DESCRIPTION
Cosmetic change for https://github.com/metabase/metabase-private/issues/56

## Changes
When users view questions that use blocked for them data sources they are still able to see Settings and Visualization buttons:
<img width="280" alt="Screenshot 2022-05-04 at 22 38 08" src="https://user-images.githubusercontent.com/14301985/166803291-9e031baa-4730-49c4-bfac-d67faa05935d.png">

## How to verify
- Run Metabase EE
- Create a Test User and login under it in a separate browser window
- As an admin 
    - Create Orders saved question from Orders table
    - Set Sample Database permission to "Block" for "All Users"
- As a Test User
    - Open the Orders question
    - Ensure it does not show Visualization and Settings buttons

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/22433)
<!-- Reviewable:end -->
