### PR TITLE
Fix incomplete list of aggregation operators

### DIFF
--- a/frontend/src/metabase-lib/lib/metadata/Table.ts
+++ b/frontend/src/metabase-lib/lib/metadata/Table.ts
@@ -136,6 +136,9 @@ export default class Table extends Base {
     if (Array.isArray(this.fks)) {
       return this.fks.map(fk => new Table(fk.origin.table));
     }
+    if (!Array.isArray(this.fields)) {
+      return [];
+    }
     return this.fields
       .filter(field => field.isFK() && field.fk_target_field_id)
       .map(field => this.metadata.field(field.fk_target_field_id).table)

--- a/frontend/src/metabase-lib/lib/metadata/Table.ts
+++ b/frontend/src/metabase-lib/lib/metadata/Table.ts
@@ -95,7 +95,7 @@ export default class Table extends Base {
   // AGGREGATIONS
   @memoize
   aggregationOperators() {
-    return getAggregationOperators(this);
+    return getAggregationOperators([this, ...this.connectedTables()]);
   }
 
   @memoize

--- a/frontend/src/metabase-lib/lib/metadata/Table.unit.spec.ts
+++ b/frontend/src/metabase-lib/lib/metadata/Table.unit.spec.ts
@@ -36,5 +36,9 @@ describe("Table", () => {
         peopleTable,
       ]);
     });
+
+    it("should return an empty list if has no data to find foreign tables", () => {
+      expect(new Table().connectedTables()).toEqual([]);
+    });
   });
 });

--- a/frontend/src/metabase-lib/lib/metadata/Table.unit.spec.ts
+++ b/frontend/src/metabase-lib/lib/metadata/Table.unit.spec.ts
@@ -1,8 +1,10 @@
-import { PRODUCTS } from "__support__/sample_database_fixture";
+import { ORDERS, PRODUCTS, PEOPLE } from "__support__/sample_database_fixture";
 import Table from "./Table";
 
 describe("Table", () => {
+  const ordersTable = new Table(ORDERS);
   const productsTable = new Table(PRODUCTS);
+  const peopleTable = new Table(PEOPLE);
 
   describe("numFields", () => {
     it("should return the number of fields", () => {
@@ -26,6 +28,13 @@ describe("Table", () => {
       });
 
       expect(table.connectedTables()).toEqual([productsTable]);
+    });
+
+    it("should return a list of table instances connected to it via FK fields", () => {
+      expect(ordersTable.connectedTables()).toEqual([
+        productsTable,
+        peopleTable,
+      ]);
     });
   });
 });

--- a/frontend/src/metabase/components/MetadataInfo/TableInfo/TableInfo.unit.spec.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/TableInfo/TableInfo.unit.spec.tsx
@@ -68,9 +68,12 @@ describe("TableInfo", () => {
   });
 
   it("should fetch fks if fks are undefined on table", () => {
+    const table = new Table({ ...PRODUCTS, fields: [1, 2, 3], fks: undefined });
+    table.connectedTables = () => [];
+
     setup({
       id: PRODUCTS.id,
-      table: new Table({ ...PRODUCTS, fields: [1, 2, 3], fks: undefined }),
+      table,
     });
 
     expect(fetchMetadata).not.toHaveBeenCalled();

--- a/frontend/src/metabase/lib/schema_metadata.js
+++ b/frontend/src/metabase/lib/schema_metadata.js
@@ -706,9 +706,19 @@ export function getSupportedAggregationOperators(table) {
   });
 }
 
-export function getAggregationOperators(table) {
-  return getSupportedAggregationOperators(table)
-    .map(operator => populateFields(operator, table.fields))
+export function getAggregationOperators(tableOrTableList) {
+  const tables = Array.isArray(tableOrTableList)
+    ? tableOrTableList
+    : [tableOrTableList];
+
+  const fields = tables.reduce(
+    (fields, table) => [...fields, ...table.fields],
+    [],
+  );
+
+  // taking the first table as tables should come from the same DB
+  return getSupportedAggregationOperators(tables[0])
+    .map(operator => populateFields(operator, fields))
     .filter(
       aggregation =>
         !aggregation.requiresField ||

--- a/frontend/test/metabase/lib/schema_metadata.unit.spec.js
+++ b/frontend/test/metabase/lib/schema_metadata.unit.spec.js
@@ -329,13 +329,17 @@ describe("schema_metadata", () => {
   });
 
   describe("getAggregationOperators", () => {
-    function setup({ fields = [] } = {}) {
-      const table = {
+    function getTable(fields = []) {
+      return {
         fields,
         db: {
           features: ["basic-aggregations", "standard-deviation-aggregations"],
         },
       };
+    }
+
+    function setup({ fields = [] } = {}) {
+      const table = getTable(fields);
       const fullOperators = getAggregationOperators(table);
       return {
         fullOperators,
@@ -360,6 +364,21 @@ describe("schema_metadata", () => {
     const NUMBERS = getTypedFields(TYPE.Number);
     const STRINGS = getTypedFields(TYPE.Text);
     const TEMPORALS = getTypedFields(TYPE.Temporal);
+
+    it("should handle multiple tables", () => {
+      const field1 = { id: 1, semantic_type: TYPE.Number };
+      const field2 = { id: 2, semantic_type: TYPE.Category };
+      const table1 = getTable([field1]);
+      const table2 = getTable([field2]);
+
+      const operators = getAggregationOperators([table1, table2]);
+      const distinct = _.findWhere(operators, { short: "distinct" });
+      const sum = _.findWhere(operators, { short: "sum" });
+
+      expect(operators).toHaveLength(10);
+      expect(distinct.fields[0]).toEqual([field1, field2]);
+      expect(sum.fields[0]).toEqual([field1]);
+    });
 
     describe("count", () => {
       it("offers without fields", () => {

--- a/frontend/test/metabase/scenarios/question/reproductions/12248-missing-foreign-table-aggregation-opts.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/12248-missing-foreign-table-aggregation-opts.cy.spec.js
@@ -1,0 +1,44 @@
+import {
+  restore,
+  openReviewsTable,
+  popover,
+  visualize,
+} from "__support__/e2e/cypress";
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+
+const { PRODUCTS, REVIEWS } = SAMPLE_DATABASE;
+
+describe("issue 12248", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    cy.request("PUT", `/api/field/${REVIEWS.RATING}`, {
+      visibility_type: "sensitive",
+    });
+    cy.request("PUT", `/api/field/${REVIEWS.PRODUCT_ID}`, {
+      semantic_type: "type/FK",
+      fk_target_field_id: PRODUCTS.ID,
+    });
+  });
+
+  it("should use foreign tables when offering aggregation operators in notebook (metabase#12248)", () => {
+    openReviewsTable({ mode: "notebook" });
+    cy.findByText("Summarize").click();
+    popover().within(() => {
+      cy.findAllByText(/Count of rows/i);
+      cy.findAllByText(/Sum/i);
+      cy.findByText(/Distinct/i);
+      cy.findByText(/Minimum/i);
+      cy.findByText(/Maximum/i);
+      cy.findByText(/Average/i).click();
+    });
+    popover().within(() => {
+      cy.findByText("Product");
+      cy.findByText("Review").should("not.exist");
+      cy.findByText("Price").click();
+    });
+    visualize();
+    cy.findByText("56.41");
+  });
+});


### PR DESCRIPTION
Reproduces #12248, fixes #12248, based on #22469

The query builder offers possible aggregation operators (like sum/min/max/avg) based on DB features and table fields. For instance, it doesn't make sense to offer the "sum" aggregation if a table only has no numeric columns. Suitable aggregation operators can be retrieved with `table's` `getAggregationOperators` method which uses `getAggregationOperators` from `metabase/lib/schema_metadata` under the hood.

The root cause of the issue is that Metabase retrieves aggregation options only for the source table. So if a source table doesn't have way much aggregatable columns, but has a foreign key to another table with richer data, the foreign table will be ignored and the final list of aggregations will be pretty limited.

This PR fixes that by making it take foreign tables in mind when building a list of suitable aggregation operators.

### To Verify

Repeat the steps from #12248