### PR TITLE
Repro #22408: Block permissions obstructing download permissions set to "No"

### DIFF
--- a/frontend/test/metabase/scenarios/permissions/download-permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/download-permissions.cy.spec.js
@@ -61,14 +61,10 @@ describeEE("scenarios > admin > permissions > data > downloads", () => {
       DOWNLOAD_PERMISSION_INDEX,
       "1 million rows",
     );
+  });
 
-    cy.log(
-      "Make sure the download permissions are set to `No` when data access is revoked",
-    );
-
-    cy.get("a")
-      .contains("Sample Database")
-      .click();
+  it("respects 'no download' permissions when 'All users' group data permissions are set to `Block` (metabase#22408)", () => {
+    cy.visit(`/admin/permissions/data/database/${SAMPLE_DB_ID}`);
 
     modifyPermission("All Users", DATA_ACCESS_PERMISSION_INDEX, "Block");
 
@@ -80,7 +76,17 @@ describeEE("scenarios > admin > permissions > data > downloads", () => {
       cy.button("Yes").click();
     });
 
+    // When data permissions are set to `Block`, download permissions are automatically revoked
     assertPermissionForItem("All Users", DOWNLOAD_PERMISSION_INDEX, "No");
+
+    // Normal user belongs to both "data" and "collections" groups.
+    // They both have restricted downloads so this user shouldn't have the right to download anything.
+    cy.signIn("normal");
+
+    visitQuestion("1");
+
+    cy.findByText("Showing first 2,000 rows");
+    cy.icon("download").should("not.exist");
   });
 
   it("restricts users from downloading questions", () => {


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Reproduces #22408

### How to test this manually?
- `yarn test-cypress-open`
- `metabase/scenarios/permissions/download-permissions.cy.spec.js`
- All tests should pass

### Additional notes:
- The bug was fixed in #22426

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/166803842-4fa4b876-0a98-4684-802f-e4892b97a51c.png)
