### PR TITLE
remove misleading permissions tooltip

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/download-permission.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/download-permission.ts
@@ -21,7 +21,7 @@ import {
 import { getGroupFocusPermissionsUrl } from "metabase/admin/permissions/utils/urls";
 import { PLUGIN_ADVANCED_PERMISSIONS } from "metabase/plugins";
 
-export const UNABLE_TO_DOWNLOAD_RESULTS = t`Users with Block data access can't download results`;
+export const UNABLE_TO_DOWNLOAD_RESULTS = t`Groups with Block data access can't download results`;
 
 const getTooltipMessage = (isAdmin: boolean, isBlockedAccess: boolean) => {
   if (isAdmin) {

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/download-permission.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/download-permission.ts
@@ -21,7 +21,19 @@ import {
 import { getGroupFocusPermissionsUrl } from "metabase/admin/permissions/utils/urls";
 import { PLUGIN_ADVANCED_PERMISSIONS } from "metabase/plugins";
 
-export const DOWNLOAD_PERMISSION_REQUIRES_DATA_ACCESS = t`Download results access requires full data access.`;
+export const UNABLE_TO_DOWNLOAD_RESULTS = t`Users with Block data access can't download results`;
+
+const getTooltipMessage = (isAdmin: boolean, isBlockedAccess: boolean) => {
+  if (isAdmin) {
+    return UNABLE_TO_CHANGE_ADMIN_PERMISSIONS;
+  }
+
+  if (isBlockedAccess) {
+    return UNABLE_TO_DOWNLOAD_RESULTS;
+  }
+
+  return null;
+};
 
 export const DOWNLOAD_PERMISSION_OPTIONS = {
   none: {
@@ -111,6 +123,11 @@ export const buildDownloadPermission = (
     isAdmin ||
     PLUGIN_ADVANCED_PERMISSIONS.isBlockPermission(dataAccessPermissionValue);
 
+  const disabledTooltip = getTooltipMessage(
+    isAdmin,
+    PLUGIN_ADVANCED_PERMISSIONS.isBlockPermission(dataAccessPermissionValue),
+  );
+
   const warning = getPermissionWarning(
     value,
     defaultGroupValue,
@@ -135,15 +152,11 @@ export const buildDownloadPermission = (
     permission: "download",
     type: "download",
     isDisabled,
+    disabledTooltip,
     value,
     warning,
     confirmations,
     isHighlighted: isAdmin,
-    disabledTooltip: isAdmin
-      ? UNABLE_TO_CHANGE_ADMIN_PERMISSIONS
-      : isDisabled
-      ? DOWNLOAD_PERMISSION_REQUIRES_DATA_ACCESS
-      : null,
     options: [
       DOWNLOAD_PERMISSION_OPTIONS.none,
       ...(hasChildEntities ? [DOWNLOAD_PERMISSION_OPTIONS.controlled] : []),


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/22356

## Changes

Update hint tooltip copy for the download permission when it is disabled due to `block` data access permission.

<img width="799" alt="Screenshot 2022-05-04 at 23 16 27" src="https://user-images.githubusercontent.com/14301985/166809436-2a6cd0d8-091f-4675-bca0-87fe2bf07e8e.png">

## How to verify

Check the original issue for repro steps