### PR TITLE
Add minHeight option to sizeToFit modifier

### DIFF
--- a/frontend/src/metabase/components/Popover/SizeToFitModifier.ts
+++ b/frontend/src/metabase/components/Popover/SizeToFitModifier.ts
@@ -1,0 +1,65 @@
+import * as popper from "@popperjs/core";
+
+const PAGE_PADDING = 10;
+const SIZE_TO_FIT_MIN_HEIGHT = 200;
+
+export type SizeToFitOptions = {
+  minHeight: number;
+};
+
+export function sizeToFitModifierFn({
+  state,
+  options,
+}: popper.ModifierArguments<SizeToFitOptions>) {
+  const {
+    placement,
+    rects: {
+      popper: { height },
+      reference: { height: targetHeight },
+    },
+  } = state;
+  const { minHeight = SIZE_TO_FIT_MIN_HEIGHT } = options;
+
+  const topPlacement = placement.startsWith("top");
+  const bottomPlacement = placement.startsWith("bottom");
+
+  if (topPlacement || bottomPlacement) {
+    const overflow = popper.detectOverflow(state);
+    const distanceFromEdge = placement.startsWith("top")
+      ? overflow.top
+      : overflow.bottom;
+
+    const maxHeight = height - distanceFromEdge - PAGE_PADDING;
+    const minnedMaxHeight = Math.max(maxHeight, minHeight);
+
+    const oppositeSpace = window.innerHeight - targetHeight - maxHeight;
+
+    if (
+      maxHeight < minHeight &&
+      oppositeSpace > minHeight &&
+      !state.modifiersData.sizeToFit.flipped
+    ) {
+      state.placement = getAltPlacement(placement);
+      state.modifiersData.sizeToFit.flipped = true;
+      state.reset = true;
+    } else {
+      state.styles.popper.maxHeight = `${minnedMaxHeight}px`;
+    }
+  }
+}
+
+export function getAltPlacement(
+  placementStr: popper.Placement,
+): popper.Placement {
+  const [targetPlacement, horizontalPlacement] = placementStr.split("-") as
+    | [string]
+    | [string, string];
+  const newPlacement = [
+    targetPlacement === "top" ? "bottom" : "top",
+    horizontalPlacement,
+  ]
+    .filter((str): str is string => Boolean(str))
+    .join("-");
+
+  return newPlacement as popper.Placement;
+}

--- a/frontend/src/metabase/components/Popover/TippyPopover.info.js
+++ b/frontend/src/metabase/components/Popover/TippyPopover.info.js
@@ -119,5 +119,5 @@ export const examples = {
       {target}
     </TippyPopover>
   ),
-  extra_space: <div style={{ height: 250 }} />,
+  extra_space: <div style={{ height: 400 }} />,
 };

--- a/frontend/src/metabase/components/Popover/TippyPopover.tsx
+++ b/frontend/src/metabase/components/Popover/TippyPopover.tsx
@@ -2,7 +2,6 @@ import React, { useState, useMemo, useCallback, useRef } from "react";
 import PropTypes from "prop-types";
 import * as TippyReact from "@tippyjs/react";
 import * as tippy from "tippy.js";
-import * as popper from "@popperjs/core";
 import cx from "classnames";
 import { merge } from "icepick";
 
@@ -26,9 +25,7 @@ export interface ITippyPopoverProps extends TippyProps {
   onClose?: () => void;
 }
 
-const PAGE_PADDING = 10;
 const OFFSET: [number, number] = [0, 5];
-const SIZE_TO_FIT_MIN_HEIGHT = 200;
 
 const propTypes = {
   disablContentSandbox: PropTypes.bool,


### PR DESCRIPTION
This lets us set a reasonable minHeight value on a `TippyPopover` that uses the `sizeToFit` modifier so that the popover doesn't become too small. Pass the option object as the value of the prop `sizeToFit={{ minHeight: 500 }}`. Right now, can only be a number value because we use it for comparisons.

This is one option. It favors trying to preserve the original placement. Beyond the min-height, it flips the placement, but will fall back to the original if the space meets the minimum requirement (the minHeight value). If there's not enough height above or below, it defaults back to the original `placement` and overflows.

Another option I could implement is a sort of "aggressive" flip which will flip to whichever area has more space, regardless of the original placement.

https://user-images.githubusercontent.com/13057258/166988160-692256e3-2c1c-4986-bebc-18083cfaaa00.mov


