### PR TITLE
[E2E] Experiment running `embedding` test group as PR check

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -64,6 +64,7 @@ jobs:
           - "dashboard"
           - "dashboard-filters"
           - "downloads"
+          - "embedding"
           - "joins"
     services:
       maildev:


### PR DESCRIPTION
Adding `embedding` test group as PR check

Data:
[embedding OSS](https://github.com/metabase/metabase/runs/6296960753?check_suite_focus=true) vs [embedding EE](https://github.com/metabase/metabase/runs/6296963186?check_suite_focus=true)
| e2e-tests-embedding                       | total | passing | pending  |
|---------------------------|--------|-------|-------|
| OSS                  | 33   | 32  | 1  |
| EE                 | 33   | 30  | 3  |