### PR TITLE
[E2E] Remove `custom-column` check from CCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1253,7 +1253,6 @@ workflows:
                 [
                   "admin",
                   "collections",
-                  "custom-column",
                   "dashboard",
                   "embedding",
                   "filters",


### PR DESCRIPTION
Removes `custom-column` E2E group from CircleCI because we've been running it successfully using GitHub actions.