### PR TITLE
Use a different icon for tables on the homepage

### DIFF
--- a/frontend/src/metabase/entities/popular-items.js
+++ b/frontend/src/metabase/entities/popular-items.js
@@ -13,7 +13,8 @@ export const getName = item => {
 
 export const getIcon = item => {
   const entity = getEntity(item);
-  return entity.objectSelectors.getIcon(item.model_object);
+  const options = { variant: "secondary" };
+  return entity.objectSelectors.getIcon(item.model_object, options);
 };
 
 const PopularItems = createEntity({

--- a/frontend/src/metabase/entities/recent-items.js
+++ b/frontend/src/metabase/entities/recent-items.js
@@ -13,7 +13,8 @@ export const getName = item => {
 
 export const getIcon = item => {
   const entity = getEntity(item);
-  return entity.objectSelectors.getIcon(item.model_object);
+  const options = { variant: "secondary" };
+  return entity.objectSelectors.getIcon(item.model_object, options);
 };
 
 const RecentItems = createEntity({

--- a/frontend/src/metabase/entities/tables.js
+++ b/frontend/src/metabase/entities/tables.js
@@ -228,7 +228,9 @@ const Tables = createEntity({
   objectSelectors: {
     getUrl: table =>
       Urls.tableRowsQuery(table.database_id, table.table_id, null),
-    getIcon: table => ({ name: "table" }),
+    getIcon: (table, { variant = "primary" } = {}) => ({
+      name: variant === "primary" ? "table" : "database",
+    }),
     getColor: table => color("accent2"),
   },
 


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/22260

How to test:
- You need to have at least one question and a dashboard created to view recent items
- Open a raw table and save it as a question
- Reload the page to add views count for this question
- Go to the homepage and make sure there are different icons for the raw table and the question

<img width="509" alt="Screenshot 2022-05-05 at 10 25 57" src="https://user-images.githubusercontent.com/8542534/166879327-11dc2459-9647-4e57-a6c6-6ee0e42eb0cd.png">
