### PR TITLE
Make it possible to convert relative filters to expressions

### DIFF
--- a/frontend/src/metabase/lib/expressions/config.js
+++ b/frontend/src/metabase/lib/expressions/config.js
@@ -227,7 +227,7 @@ export const MBQL_CLAUSES = {
     args: ["expression", "expression", "expression"],
   },
   interval: {
-    displayName: "timeInterval",
+    displayName: "timespan",
     type: "number",
     args: ["number", "string"],
   },

--- a/frontend/src/metabase/lib/expressions/config.js
+++ b/frontend/src/metabase/lib/expressions/config.js
@@ -226,11 +226,21 @@ export const MBQL_CLAUSES = {
     type: "boolean",
     args: ["expression", "expression", "expression"],
   },
+  interval: {
+    displayName: "timeInterval",
+    type: "expression",
+    args: ["number", "string"],
+  },
   "time-interval": {
     displayName: `interval`,
     type: "boolean",
     args: ["expression", "number", "string"],
     hasOptions: true,
+  },
+  "relative-datetime": {
+    displayName: "relativeDatetime",
+    type: "expression",
+    args: ["number", "string"],
   },
   "is-null": {
     displayName: `isnull`,

--- a/frontend/src/metabase/lib/expressions/config.js
+++ b/frontend/src/metabase/lib/expressions/config.js
@@ -227,7 +227,7 @@ export const MBQL_CLAUSES = {
     args: ["expression", "expression", "expression"],
   },
   interval: {
-    displayName: "timespan",
+    displayName: "timeSpan",
     type: "number",
     args: ["number", "string"],
   },
@@ -238,7 +238,7 @@ export const MBQL_CLAUSES = {
     hasOptions: true,
   },
   "relative-datetime": {
-    displayName: "relativeDatetime",
+    displayName: "relativeDateTime",
     type: "expression",
     args: ["number", "string"],
   },

--- a/frontend/src/metabase/lib/expressions/config.js
+++ b/frontend/src/metabase/lib/expressions/config.js
@@ -228,7 +228,7 @@ export const MBQL_CLAUSES = {
   },
   interval: {
     displayName: "timeInterval",
-    type: "expression",
+    type: "number",
     args: ["number", "string"],
   },
   "time-interval": {

--- a/frontend/src/metabase/lib/expressions/helper_text_strings.js
+++ b/frontend/src/metabase/lib/expressions/helper_text_strings.js
@@ -441,6 +441,22 @@ const helperTextStrings = [
     ],
   },
   {
+    name: "interval",
+    structure: "timeInterval(" + t`number` + ", " + t`text` + ")",
+    description: t`Gets a time interval of specified length`,
+    example: 'timeInterval(7, "day")',
+    args: [
+      {
+        name: t`number`,
+        description: t`Period of interval, where negative values are back in time.`,
+      },
+      {
+        name: t`text`,
+        description: t`Type of interval like "day", "month", "year".`,
+      },
+    ],
+  },
+  {
     name: "time-interval",
     structure:
       "interval(" + t`column` + ", " + t`number` + ", " + t`text` + ")",
@@ -451,6 +467,22 @@ const helperTextStrings = [
         name: t`column`,
         description: t`The date column to return interval of.`,
       },
+      {
+        name: t`number`,
+        description: t`Period of interval, where negative values are back in time.`,
+      },
+      {
+        name: t`text`,
+        description: t`Type of interval like "day", "month", "year".`,
+      },
+    ],
+  },
+  {
+    name: "relative-datetime",
+    structure: "relativeDatetime(" + t`number` + ", " + t`text` + ")",
+    description: t`Gets a timestamp relative to the current time`,
+    example: 'relativeDatetime(-30, "day")',
+    args: [
       {
         name: t`number`,
         description: t`Period of interval, where negative values are back in time.`,

--- a/frontend/src/metabase/lib/expressions/helper_text_strings.js
+++ b/frontend/src/metabase/lib/expressions/helper_text_strings.js
@@ -442,9 +442,9 @@ const helperTextStrings = [
   },
   {
     name: "interval",
-    structure: "timeInterval(" + t`number` + ", " + t`text` + ")",
+    structure: "timespan(" + t`number` + ", " + t`text` + ")",
     description: t`Gets a time interval of specified length`,
-    example: 'timeInterval(7, "day")',
+    example: 'timespan(7, "day")',
     args: [
       {
         name: t`number`,

--- a/frontend/src/metabase/lib/expressions/helper_text_strings.js
+++ b/frontend/src/metabase/lib/expressions/helper_text_strings.js
@@ -442,9 +442,9 @@ const helperTextStrings = [
   },
   {
     name: "interval",
-    structure: "timespan(" + t`number` + ", " + t`text` + ")",
+    structure: "timeSpan(" + t`number` + ", " + t`text` + ")",
     description: t`Gets a time interval of specified length`,
-    example: 'timespan(7, "day")',
+    example: 'timeSpan(7, "day")',
     args: [
       {
         name: t`number`,
@@ -479,9 +479,9 @@ const helperTextStrings = [
   },
   {
     name: "relative-datetime",
-    structure: "relativeDatetime(" + t`number` + ", " + t`text` + ")",
+    structure: "relativeDateTime(" + t`number` + ", " + t`text` + ")",
     description: t`Gets a timestamp relative to the current time`,
-    example: 'relativeDatetime(-30, "day")',
+    example: 'relativeDateTime(-30, "day")',
     args: [
       {
         name: t`number`,

--- a/frontend/test/metabase/lib/expressions/suggest.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/suggest.unit.spec.js
@@ -147,7 +147,7 @@ describe("metabase/lib/expression/suggest", () => {
           [
             { text: "True", type: "literal" },
             { text: "[Total] ", type: "fields" },
-            { text: "timespan(", type: "functions" },
+            { text: "timeSpan(", type: "functions" },
             { text: "trim(", type: "functions" },
           ].sort(suggestionSort),
         );

--- a/frontend/test/metabase/lib/expressions/suggest.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/suggest.unit.spec.js
@@ -147,6 +147,7 @@ describe("metabase/lib/expression/suggest", () => {
           [
             { text: "True", type: "literal" },
             { text: "[Total] ", type: "fields" },
+            { text: "timespan(", type: "functions" },
             { text: "trim(", type: "functions" },
           ].sort(suggestionSort),
         );


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/21978

TBD:
- Proofread new function names
- Proofread documentation

How to test:
- Question > Sample > Products
- Filter CreatedAt > Relative > Past > Starting from - Add filter
- Edit the filter again, click < (back button) a few times until you see Custom Expression
- Make sure the custom expression is created correctly
- Make sure it's possible to write these expressions manually

<img width="752" alt="Screenshot 2022-05-05 at 18 09 26" src="https://user-images.githubusercontent.com/8542534/166954659-79cd9730-ffb2-488e-8dca-d3d0f8945376.png">
<img width="664" alt="Screenshot 2022-05-05 at 18 09 32" src="https://user-images.githubusercontent.com/8542534/166954661-78c41155-f4d6-42b2-9476-d59979140277.png">
<img width="697" alt="Screenshot 2022-05-05 at 18 09 36" src="https://user-images.githubusercontent.com/8542534/166954666-71b13183-db2b-4552-a46f-92c22b6d2122.png">
