### PR TITLE
Fix whitelabeled colors aren't respected in x-rays

### DIFF
--- a/src/metabase/automagic_dashboards/populate.clj
+++ b/src/metabase/automagic_dashboards/populate.clj
@@ -7,6 +7,7 @@
             [metabase.automagic-dashboards.filters :as filters]
             [metabase.models.card :as card]
             [metabase.models.collection :as collection]
+            [metabase.public-settings :as public-settings]
             [metabase.query-processor.util :as qp.util]
             [metabase.util.i18n :refer [trs]]
             [toucan.db :as db]))
@@ -43,9 +44,20 @@
         :location "/")
       (create-collection! "Automatically Generated Dashboards" "#509EE3" nil nil)))
 
-(def colors
-  "Colors used for coloring charts and collections."
-  ["#509EE3" "#9CC177" "#A989C5" "#EF8C8C" "#f9d45c" "#F1B556" "#A6E7F3" "#7172AD"])
+(defn colors
+  "A vector of colors used for coloring charts and collections. Uses [[public-settings/application-colors]] for user choices."
+  []
+  (let [order [:brand :accent1 :accent2 :accent3 :accent4 :accent5 :accent6 :accent7]
+        colors-map (merge {:brand   "#509EE3"
+                           :accent1 "#88BF4D"
+                           :accent2 "#A989C5"
+                           :accent3 "#EF8C8C"
+                           :accent4 "#F9D45C"
+                           :accent5 "#F2A86F"
+                           :accent6 "#98D9D9"
+                           :accent7 "#7172AD"}
+                          (public-settings/application-colors))]
+    (into [] (map colors-map) order)))
 
 (defn- ensure-distinct-colors
   [candidates]
@@ -55,14 +67,14 @@
         (fn [acc color count]
           (if (= count 1)
             (conj acc color)
-            (concat acc [color (first (drop-while (conj (set acc) color) colors))])))
+            (concat acc [color (first (drop-while (conj (set acc) color) (colors)))])))
         [])))
 
 (defn map-to-colors
   "Map given objects to distinct colors."
   [objs]
   (->> objs
-       (map (comp colors #(mod % (count colors)) hash))
+       (map (comp (colors) #(mod % (count (colors))) hash))
        ensure-distinct-colors))
 
 (defn- colorize

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -350,7 +350,7 @@
         dashcards  (:ordered_cards dashboard)
         collection (populate/create-collection!
                     (ensure-unique-collection-name (:name dashboard) parent-collection-id)
-                    (rand-nth populate/colors)
+                    (rand-nth (populate/colors))
                     "Automatically generated cards."
                     parent-collection-id)
         dashboard  (db/insert! Dashboard


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/22476

## Colors setting
![image](https://user-images.githubusercontent.com/1937582/166958698-3cb322e8-511e-4aa9-8916-07c9fe993beb.png)


## Before the fix
![localhost_3000_auto_dashboard_table_1 (2)](https://user-images.githubusercontent.com/1937582/166958589-0c026183-4fa3-4ff9-888f-289fab22c12f.png)


## After the fix
![localhost_3000_auto_dashboard_table_1 (1)](https://user-images.githubusercontent.com/1937582/166958616-213d30f7-50c3-4fc6-82d4-4b78c30579f1.png)

I tried fixing this on FE as I found `graph.colors` beling labeled legacy so I assumed it could be removed.
https://github.com/metabase/metabase/blob/bceca3b31e90e6ab5d23ed4937b439e466baefbd/frontend/src/metabase/visualizations/lib/settings/series.js#L164-L171
 Turns out that if I remove that all the x-rays color would be the same. But there's a logic in BE that will try to have each card have different colors if I'm not mistaken.
https://github.com/metabase/metabase/blob/1b33e3e226b0b26b1751f834470ea21073949dd8/src/metabase/automagic_dashboards/populate.clj#L82-L92