### PR TITLE
Repro #22382: Duplicate breakout fields can appear in a table under certain circumstances

### DIFF
--- a/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
@@ -192,6 +192,54 @@ describe("binning related reproductions", () => {
     cy.findByText("Hour of Day");
   });
 
+  it.skip("shouldn't duplicate the breakout field (metabase#22382)", () => {
+    const questionDetails = {
+      name: "22382",
+      query: {
+        "source-table": ORDERS_ID,
+        aggregation: [["count"]],
+        breakout: [["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }]],
+      },
+    };
+
+    cy.intercept("POST", "/api/dataset").as("dataset");
+
+    cy.createQuestion(questionDetails, { visitQuestion: true });
+
+    cy.findByText("Settings").click();
+
+    cy.findByTestId("sidebar-left").within(() => {
+      cy.findByTextEnsureVisible("Table options");
+      cy.findByText("Count")
+        .siblings(".Icon-close")
+        .click();
+      cy.button("Done").click();
+    });
+
+    summarize();
+
+    cy.findByTestId("pinned-dimensions")
+      .should("contain", "Created At")
+      .find(".Icon-close")
+      .click();
+    cy.wait("@dataset");
+
+    cy.get(".Visualization").findByText("Count");
+
+    cy.findByTestId("sidebar-right")
+      .findAllByText("Created At")
+      .first()
+      .click();
+    cy.wait("@dataset");
+
+    cy.get(".Visualization").within(() => {
+      // ALl of these are implicit assertions and will fail if there's more than one string
+      cy.findByText("Count");
+      cy.findByText("Created At: Month");
+      cy.findByText("June, 2016");
+    });
+  });
+
   describe("binning should work on nested question based on question that has aggregation (metabase#16379)", () => {
     beforeEach(() => {
       cy.createQuestion(


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #22382 

### How to test this manually?
- `yarn test-cypress-open`
- `metabase/scenarios/binning/binning-reproductions.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/166961957-04a57fe6-a9a3-4ad4-a480-38ae07526d07.png)

