### PR TITLE
[E2E] Add download permission tests for native questions

### DIFF
--- a/frontend/test/metabase/scenarios/permissions/download-permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/download-permissions.cy.spec.js
@@ -10,9 +10,13 @@ import {
   visitQuestion,
 } from "__support__/e2e/cypress";
 
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+
 import { SAMPLE_DB_ID, USER_GROUPS } from "__support__/e2e/cypress_data";
 
 const { ALL_USERS_GROUP } = USER_GROUPS;
+
+const { PRODUCTS_ID, ORDERS_ID, PEOPLE_ID, REVIEWS_ID } = SAMPLE_DATABASE;
 
 const DATA_ACCESS_PERMISSION_INDEX = 0;
 const DOWNLOAD_PERMISSION_INDEX = 2;
@@ -122,4 +126,104 @@ describeEE("scenarios > admin > permissions > data > downloads", () => {
       assertSheetRowsCount(10000),
     );
   });
+
+  describe("native questions", () => {
+    beforeEach(() => {
+      cy.intercept("POST", "/api/dataset").as("dataset");
+
+      cy.createNativeQuestion(
+        {
+          name: "Native Orders",
+          native: {
+            query: "select * from orders",
+          },
+        },
+        { wrapId: true, idAlias: "nativeQuestionId" },
+      );
+    });
+
+    it("prevents user from downloading a native question even if only one table doesn't have download permissions", () => {
+      setDownloadPermissionsForProductsTable("none");
+
+      cy.signInAsNormalUser();
+
+      cy.get("@nativeQuestionId").then(id => {
+        visitQuestion(id);
+
+        cy.findByText("Showing first 2,000 rows");
+        cy.icon("download").should("not.exist");
+
+        // Ad-hoc nested query also shouldn't be downloadable
+        cy.findByText("Explore results").click();
+        cy.wait("@dataset");
+
+        cy.findByText("Showing first 2,000 rows");
+        cy.icon("download").should("not.exist");
+
+        // Convert question to a model, which also shouldn't be downloadable
+        cy.request("PUT", `/api/card/${id}`, { name: "Native Model" });
+
+        visitQuestion(id);
+
+        cy.findByText("Showing first 2,000 rows");
+        cy.icon("download").should("not.exist");
+      });
+    });
+
+    it("limits download results for a native question even if even one table has `limited` download permissions", () => {
+      setDownloadPermissionsForProductsTable("limited");
+
+      cy.signInAsNormalUser();
+
+      cy.get("@nativeQuestionId").then(id => {
+        visitQuestion(id);
+
+        cy.icon("download").click();
+
+        downloadAndAssert(
+          { fileType: "xlsx", questionId: id },
+          assertSheetRowsCount(10000),
+        );
+
+        // Ad-hoc nested query based on a native question should also have a download row limit
+        cy.findByText("Explore results").click();
+        cy.wait("@dataset");
+
+        cy.icon("download").click();
+
+        downloadAndAssert({ fileType: "xlsx" }, assertSheetRowsCount(10000));
+
+        // Convert question to a model, which should also have a download row limit
+        cy.request("PUT", `/api/card/${id}`, { name: "Native Model" });
+
+        visitQuestion(id);
+
+        cy.icon("download").click();
+
+        downloadAndAssert(
+          { fileType: "xlsx", questionId: id },
+          assertSheetRowsCount(10000),
+        );
+      });
+    });
+  });
 });
+
+function setDownloadPermissionsForProductsTable(permission) {
+  cy.updatePermissionsGraph({
+    [ALL_USERS_GROUP]: {
+      [SAMPLE_DB_ID]: {
+        download: {
+          schemas: {
+            PUBLIC: {
+              [PRODUCTS_ID]: permission,
+              [ORDERS_ID]: "full",
+              [PEOPLE_ID]: "full",
+              [REVIEWS_ID]: "full",
+            },
+          },
+        },
+      },
+    },
+  });
+}

--- a/frontend/test/metabase/scenarios/permissions/download-permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/download-permissions.cy.spec.js
@@ -142,6 +142,41 @@ describeEE("scenarios > admin > permissions > data > downloads", () => {
       );
     });
 
+    it("lets user download results from native queries", () => {
+      cy.signInAsNormalUser();
+
+      cy.get("@nativeQuestionId").then(id => {
+        visitQuestion(id);
+
+        cy.icon("download").click();
+
+        downloadAndAssert(
+          { fileType: "xlsx", questionId: id },
+          assertSheetRowsCount(18760),
+        );
+
+        cy.icon("download").click();
+
+        // Make sure we can download results from an ad-hoc nested query based on a native question
+        cy.findByText("Explore results").click();
+        cy.wait("@dataset");
+
+        downloadAndAssert({ fileType: "xlsx" }, assertSheetRowsCount(18760));
+
+        // Make sure we can download results from a native model
+        cy.request("PUT", `/api/card/${id}`, { name: "Native Model" });
+
+        visitQuestion(id);
+
+        cy.icon("download").click();
+
+        downloadAndAssert(
+          { fileType: "xlsx", questionId: id },
+          assertSheetRowsCount(18760),
+        );
+      });
+    });
+
     it("prevents user from downloading a native question even if only one table doesn't have download permissions", () => {
       setDownloadPermissionsForProductsTable("none");
 

--- a/frontend/test/metabase/scenarios/permissions/download-permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/download-permissions.cy.spec.js
@@ -170,7 +170,7 @@ describeEE("scenarios > admin > permissions > data > downloads", () => {
       });
     });
 
-    it("limits download results for a native question even if even one table has `limited` download permissions", () => {
+    it("limits download results for a native question even if only one table has `limited` download permissions", () => {
       setDownloadPermissionsForProductsTable("limited");
 
       cy.signInAsNormalUser();


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Adds more E2E tests that cover scenarios related to native queries and (saved) native questions

Namely, we cover:
- saved native questions
- ad-hoc nested queries based on a native question
- models based on a native question

For each scenario we are testing for:
- happy path (user group doesn't have limits and can download full results)
- `limited` results (user group can download up to 10k results)
- revoked permissions (user group cannot download results at all)

### Questions
- Is there any point in expanding download tests for other file types we support? cc @noahmoss @alxnddr 
- Do you see any other scenario I might have missed?

### Screenshots
![image](https://user-images.githubusercontent.com/31325167/167002949-ec4c7503-079d-4f0d-970a-318c9b58f46f.png)

