### PR TITLE
Clean up aggregation options getter

### DIFF
--- a/frontend/src/metabase-lib/lib/metadata/Table.ts
+++ b/frontend/src/metabase-lib/lib/metadata/Table.ts
@@ -5,7 +5,7 @@ import Question from "../Question";
 import Schema from "./Schema";
 import Base from "./Base";
 import { singularize } from "metabase/lib/formatting";
-import { getAggregationOperatorsWithFields } from "metabase/lib/schema_metadata";
+import { getAggregationOperators } from "metabase/lib/schema_metadata";
 import { memoize, createLookupByProperty } from "metabase-lib/lib/utils";
 
 /**
@@ -93,7 +93,7 @@ export default class Table extends Base {
   // AGGREGATIONS
   @memoize
   aggregationOperators() {
-    return getAggregationOperatorsWithFields(this);
+    return getAggregationOperators(this);
   }
 
   @memoize

--- a/frontend/src/metabase/lib/schema_metadata.js
+++ b/frontend/src/metabase/lib/schema_metadata.js
@@ -695,7 +695,6 @@ function populateFields(aggregationOperator, fields) {
   };
 }
 
-// TODO: unit test
 export function getAggregationOperators(table) {
   return AGGREGATION_OPERATORS.filter(
     aggregationOperator =>
@@ -720,7 +719,6 @@ export function getAggregationOperatorsWithFields(table) {
   );
 }
 
-// TODO: unit test
 export function getAggregationOperator(short) {
   return _.findWhere(AGGREGATION_OPERATORS, { short: short });
 }

--- a/frontend/src/metabase/lib/schema_metadata.js
+++ b/frontend/src/metabase/lib/schema_metadata.js
@@ -706,7 +706,7 @@ export function getSupportedAggregationOperators(table) {
   });
 }
 
-export function getAggregationOperatorsWithFields(table) {
+export function getAggregationOperators(table) {
   return getSupportedAggregationOperators(table)
     .map(operator => populateFields(operator, table.fields))
     .filter(
@@ -733,7 +733,7 @@ export function addValidOperatorsToFields(table) {
   for (const field of table.fields) {
     field.filter_operators = getFilterOperators(field, table);
   }
-  table.aggregation_operators = getAggregationOperatorsWithFields(table);
+  table.aggregation_operators = getAggregationOperators(table);
   return table;
 }
 

--- a/frontend/src/metabase/lib/schema_metadata.js
+++ b/frontend/src/metabase/lib/schema_metadata.js
@@ -696,27 +696,24 @@ function populateFields(aggregationOperator, fields) {
 }
 
 export function getAggregationOperators(table) {
-  return AGGREGATION_OPERATORS.filter(
-    aggregationOperator =>
-      !(
-        aggregationOperator.requiredDriverFeature &&
-        table.db &&
-        !_.contains(
-          table.db.features,
-          aggregationOperator.requiredDriverFeature,
-        )
-      ),
-  ).map(aggregationOperator =>
-    populateFields(aggregationOperator, table.fields),
-  );
+  return AGGREGATION_OPERATORS.filter(operator => {
+    if (!operator.requiredDriverFeature) {
+      return true;
+    }
+    return (
+      table.db && table.db.features.includes(operator.requiredDriverFeature)
+    );
+  });
 }
 
 export function getAggregationOperatorsWithFields(table) {
-  return getAggregationOperators(table).filter(
-    aggregation =>
-      !aggregation.requiresField ||
-      aggregation.fields.every(fields => fields.length > 0),
-  );
+  return getAggregationOperators(table)
+    .map(operator => populateFields(operator, table.fields))
+    .filter(
+      aggregation =>
+        !aggregation.requiresField ||
+        aggregation.fields.every(fields => fields.length > 0),
+    );
 }
 
 export function getAggregationOperator(short) {

--- a/frontend/src/metabase/lib/schema_metadata.js
+++ b/frontend/src/metabase/lib/schema_metadata.js
@@ -695,7 +695,7 @@ function populateFields(aggregationOperator, fields) {
   };
 }
 
-export function getAggregationOperators(table) {
+export function getSupportedAggregationOperators(table) {
   return AGGREGATION_OPERATORS.filter(operator => {
     if (!operator.requiredDriverFeature) {
       return true;
@@ -707,7 +707,7 @@ export function getAggregationOperators(table) {
 }
 
 export function getAggregationOperatorsWithFields(table) {
-  return getAggregationOperators(table)
+  return getSupportedAggregationOperators(table)
     .map(operator => populateFields(operator, table.fields))
     .filter(
       aggregation =>

--- a/frontend/test/metabase/lib/schema_metadata.unit.spec.js
+++ b/frontend/test/metabase/lib/schema_metadata.unit.spec.js
@@ -16,7 +16,7 @@ import {
   getOperatorByTypeAndName,
   getFilterOperators,
   getSupportedAggregationOperators,
-  getAggregationOperatorsWithFields,
+  getAggregationOperators,
   isFuzzyOperator,
   getSemanticTypeIcon,
   getSemanticTypeName,
@@ -328,7 +328,7 @@ describe("schema_metadata", () => {
     });
   });
 
-  describe("getAggregationOperatorsWithFields", () => {
+  describe("getAggregationOperators", () => {
     function setup({ fields = [] } = {}) {
       const table = {
         fields,
@@ -336,7 +336,7 @@ describe("schema_metadata", () => {
           features: ["basic-aggregations", "standard-deviation-aggregations"],
         },
       };
-      const fullOperators = getAggregationOperatorsWithFields(table);
+      const fullOperators = getAggregationOperators(table);
       return {
         fullOperators,
         operators: fullOperators.map(operator => operator.short),

--- a/frontend/test/metabase/lib/schema_metadata.unit.spec.js
+++ b/frontend/test/metabase/lib/schema_metadata.unit.spec.js
@@ -31,15 +31,18 @@ describe("schema_metadata", () => {
       expect(getFieldType({ effective_type: TYPE.DateTime })).toEqual(TEMPORAL);
       expect(getFieldType({ effective_type: TYPE.Time })).toEqual(TEMPORAL);
     });
+
     it("should know a number", () => {
       expect(getFieldType({ base_type: TYPE.BigInteger })).toEqual(NUMBER);
       expect(getFieldType({ base_type: TYPE.Integer })).toEqual(NUMBER);
       expect(getFieldType({ base_type: TYPE.Float })).toEqual(NUMBER);
       expect(getFieldType({ base_type: TYPE.Decimal })).toEqual(NUMBER);
     });
+
     it("should know a string", () => {
       expect(getFieldType({ base_type: TYPE.Text })).toEqual(STRING);
     });
+
     it("should know things that are types of strings", () => {
       expect(
         getFieldType({ base_type: TYPE.Text, semantic_type: TYPE.Name }),
@@ -54,18 +57,22 @@ describe("schema_metadata", () => {
         getFieldType({ base_type: TYPE.Text, semantic_type: TYPE.URL }),
       ).toEqual(STRING);
     });
+
     it("should know a pk", () => {
       expect(
         getFieldType({ base_type: TYPE.Integer, semantic_type: TYPE.PK }),
       ).toEqual(PRIMARY_KEY);
     });
+
     it("should know a bool", () => {
       expect(getFieldType({ base_type: TYPE.Boolean })).toEqual(BOOLEAN);
     });
+
     it("should know a location", () => {
       expect(getFieldType({ semantic_type: TYPE.City })).toEqual(LOCATION);
       expect(getFieldType({ semantic_type: TYPE.Country })).toEqual(LOCATION);
     });
+
     it("should know a coordinate", () => {
       expect(getFieldType({ semantic_type: TYPE.Latitude })).toEqual(
         COORDINATE,
@@ -74,16 +81,19 @@ describe("schema_metadata", () => {
         COORDINATE,
       );
     });
+
     describe("should know something that is string-like", () => {
       it("TYPE.TextLike", () => {
         expect(getFieldType({ base_type: TYPE.TextLike })).toEqual(STRING_LIKE);
       });
+
       it("TYPE.IPAddress", () => {
         expect(getFieldType({ base_type: TYPE.IPAddress })).toEqual(
           STRING_LIKE,
         );
       });
     });
+
     it("should still recognize some types as a string regardless of its base type", () => {
       // TYPE.Float can occur in a field filter
       expect(
@@ -93,6 +103,7 @@ describe("schema_metadata", () => {
         getFieldType({ base_type: TYPE.Float, semantic_type: TYPE.Category }),
       ).toEqual(STRING);
     });
+
     it("should know what it doesn't know", () => {
       expect(getFieldType({ base_type: "DERP DERP DERP" })).toEqual(undefined);
     });
@@ -102,9 +113,11 @@ describe("schema_metadata", () => {
     it("should work with null input", () => {
       expect(foreignKeyCountsByOriginTable(null)).toEqual(null);
     });
+
     it("should require an array as input", () => {
       expect(foreignKeyCountsByOriginTable({})).toEqual(null);
     });
+
     it("should count occurrences by origin.table.id", () => {
       expect(
         foreignKeyCountsByOriginTable([
@@ -196,6 +209,7 @@ describe("schema_metadata", () => {
         "not-null",
       ]);
     });
+
     it("should return proper filter operators for type/Text primary key", () => {
       expect(
         getFilterOperators({
@@ -215,6 +229,7 @@ describe("schema_metadata", () => {
         "ends-with",
       ]);
     });
+
     it("should return proper filter operators for type/TextLike foreign key", () => {
       expect(
         getFilterOperators({

--- a/frontend/test/metabase/lib/schema_metadata.unit.spec.js
+++ b/frontend/test/metabase/lib/schema_metadata.unit.spec.js
@@ -15,7 +15,7 @@ import {
   doesOperatorExist,
   getOperatorByTypeAndName,
   getFilterOperators,
-  getAggregationOperators,
+  getSupportedAggregationOperators,
   getAggregationOperatorsWithFields,
   isFuzzyOperator,
   getSemanticTypeIcon,
@@ -285,7 +285,7 @@ describe("schema_metadata", () => {
     });
   });
 
-  describe("getAggregationOperators", () => {
+  describe("getSupportedAggregationOperators", () => {
     function getTable(features) {
       return {
         db: {
@@ -296,13 +296,13 @@ describe("schema_metadata", () => {
 
     it("returns nothing without DB features", () => {
       const table = getTable([]);
-      const operators = getAggregationOperators(table);
+      const operators = getSupportedAggregationOperators(table);
       expect(operators).toHaveLength(0);
     });
 
     it("returns correct basic aggregation operators", () => {
       const table = getTable(["basic-aggregations"]);
-      const operators = getAggregationOperators(table);
+      const operators = getSupportedAggregationOperators(table);
       expect(operators.map(o => o.short)).toEqual([
         "rows",
         "count",
@@ -318,7 +318,7 @@ describe("schema_metadata", () => {
 
     it("filters out operators not supported by database", () => {
       const table = getTable(["standard-deviation-aggregations"]);
-      const operators = getAggregationOperators(table);
+      const operators = getSupportedAggregationOperators(table);
       expect(operators).toEqual([
         expect.objectContaining({
           short: "stddev",


### PR DESCRIPTION
Groundwork before fixing #12248 (#22434)

👀  The actual diff is pretty tiny, 90% of it is mostly unit tests to ensure nothing got broken

The query builder offers possible aggregation operators (like sum/min/max/avg) based on DB features and table fields. For instance, it doesn't make sense to offer the "sum" aggregation if a table only has no numeric columns. Suitable aggregation operators can be retrieved with `table's` `getAggregationOperators` method which uses `getAggregationOperators` from `metabase/lib/schema_metadata` under the hood.

The root cause of the issue is that Metabase retrieves aggregation options only for the source table. So if a source table doesn't have way much aggregatable columns, but has a foreign key to another table with richer data, the foreign table will be ignored and the final list of aggregations will be pretty limited.

The fix is about making `getAggregationOperators` take foreign tables in mind too. This PR cleans things up and adds extensive unit-test coverage around aggregations before the actual fix (#22434)