### PR TITLE
Fix permission bugs

### DIFF
--- a/frontend/src/metabase/collections/components/NewCollectionItemMenu.jsx
+++ b/frontend/src/metabase/collections/components/NewCollectionItemMenu.jsx
@@ -10,11 +10,12 @@ import { ANALYTICS_CONTEXT } from "metabase/collections/constants";
 const propTypes = {
   collection: PropTypes.object,
   list: PropTypes.arrayOf(PropTypes.object),
+  canCreateQuestions: PropTypes.bool,
 };
 
-function NewCollectionItemMenu({ collection }) {
+function NewCollectionItemMenu({ collection, canCreateQuestions }) {
   const items = [
-    {
+    canCreateQuestions && {
       icon: "insight",
       title: t`Question`,
       link: newQuestion({ mode: "notebook", collectionId: collection.id }),
@@ -32,7 +33,7 @@ function NewCollectionItemMenu({ collection }) {
       link: newCollection(collection.id),
       event: `${ANALYTICS_CONTEXT};New Item Menu;Collection Click`,
     },
-  ];
+  ].filter(Boolean);
 
   return <EntityMenu items={items} triggerIcon="add" tooltip={t`New…`} />;
 }

--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -14,7 +14,7 @@ import { getIsNavbarOpen, openNavbar } from "metabase/redux/app";
 
 import BulkActions from "metabase/collections/components/BulkActions";
 import CollectionEmptyState from "metabase/components/CollectionEmptyState";
-import Header from "metabase/collections/components/CollectionHeader/CollectionHeader";
+import Header from "metabase/collections/containers/CollectionHeader";
 import ItemsTable from "metabase/collections/components/ItemsTable";
 import PinnedItemOverview from "metabase/collections/components/PinnedItemOverview";
 import { isPersonalCollectionChild } from "metabase/collections/utils";

--- a/frontend/src/metabase/collections/containers/CollectionHeader.tsx
+++ b/frontend/src/metabase/collections/containers/CollectionHeader.tsx
@@ -1,0 +1,18 @@
+import _ from "underscore";
+import { connect } from "react-redux";
+
+import { State } from "metabase-types/store";
+import Databases from "metabase/entities/databases";
+import { getHasDataAccess } from "metabase/new_query/selectors";
+import CollectionHeader from "../components/CollectionHeader/CollectionHeader";
+
+const mapStateToProps = (state: State) => ({
+  canCreateQuestions: getHasDataAccess(state),
+});
+
+export default _.compose(
+  Databases.loadList({
+    loadingAndErrorWrapper: false,
+  }),
+  connect(mapStateToProps),
+)(CollectionHeader);

--- a/frontend/src/metabase/components/Tooltip/Tooltip.tsx
+++ b/frontend/src/metabase/components/Tooltip/Tooltip.tsx
@@ -19,7 +19,7 @@ Tooltip.propTypes = {
   maxWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
 };
 
-interface TooltipProps
+export interface TooltipProps
   extends Partial<
     Pick<
       Tippy.TippyProps,

--- a/frontend/src/metabase/core/components/Link/Link.tsx
+++ b/frontend/src/metabase/core/components/Link/Link.tsx
@@ -12,7 +12,7 @@ export interface LinkProps extends HTMLAttributes<HTMLAnchorElement> {
   activeClassName?: string;
   activeStyle?: CSSProperties;
   onlyActiveOnIndex?: boolean;
-  TooltipProps: Omit<TooltipProps, "tooltip">;
+  TooltipProps?: Omit<TooltipProps, "tooltip">;
 }
 
 const Link = ({
@@ -20,7 +20,7 @@ const Link = ({
   children,
   disabled,
   tooltip,
-  TooltipProps,
+  TooltipProps = {},
   ...props
 }: LinkProps): JSX.Element => {
   const link = (

--- a/frontend/src/metabase/core/components/Link/Link.tsx
+++ b/frontend/src/metabase/core/components/Link/Link.tsx
@@ -8,11 +8,10 @@ export interface LinkProps extends HTMLAttributes<HTMLAnchorElement> {
   disabled?: boolean;
   className?: string;
   children?: ReactNode;
-  tooltip?: string;
+  tooltip?: string | TooltipProps;
   activeClassName?: string;
   activeStyle?: CSSProperties;
   onlyActiveOnIndex?: boolean;
-  TooltipProps?: Omit<TooltipProps, "tooltip">;
 }
 
 const Link = ({
@@ -20,7 +19,6 @@ const Link = ({
   children,
   disabled,
   tooltip,
-  TooltipProps = {},
   ...props
 }: LinkProps): JSX.Element => {
   const link = (
@@ -35,8 +33,15 @@ const Link = ({
     </LinkRoot>
   );
 
+  const tooltipProps =
+    typeof tooltip === "string"
+      ? {
+          tooltip,
+        }
+      : tooltip;
+
   return tooltip ? (
-    <Tooltip tooltip={tooltip} {...TooltipProps}>
+    <Tooltip {...tooltipProps}>
       <span>{link}</span>
     </Tooltip>
   ) : (

--- a/frontend/src/metabase/core/components/Link/Link.tsx
+++ b/frontend/src/metabase/core/components/Link/Link.tsx
@@ -1,6 +1,7 @@
 import React, { CSSProperties, HTMLAttributes, ReactNode } from "react";
 import Tooltip from "metabase/components/Tooltip";
 import { LinkRoot } from "./Link.styled";
+import { TooltipProps } from "metabase/components/Tooltip/Tooltip";
 
 export interface LinkProps extends HTMLAttributes<HTMLAnchorElement> {
   to: string;
@@ -11,6 +12,7 @@ export interface LinkProps extends HTMLAttributes<HTMLAnchorElement> {
   activeClassName?: string;
   activeStyle?: CSSProperties;
   onlyActiveOnIndex?: boolean;
+  TooltipProps: Omit<TooltipProps, "tooltip">;
 }
 
 const Link = ({
@@ -18,6 +20,7 @@ const Link = ({
   children,
   disabled,
   tooltip,
+  TooltipProps,
   ...props
 }: LinkProps): JSX.Element => {
   const link = (
@@ -32,7 +35,13 @@ const Link = ({
     </LinkRoot>
   );
 
-  return tooltip ? <Tooltip tooltip={tooltip}>{link}</Tooltip> : link;
+  return tooltip ? (
+    <Tooltip tooltip={tooltip} {...TooltipProps}>
+      <span>{link}</span>
+    </Tooltip>
+  ) : (
+    link
+  );
 };
 
 export default Object.assign(Link, {

--- a/frontend/src/metabase/lib/errors.ts
+++ b/frontend/src/metabase/lib/errors.ts
@@ -1,0 +1,3 @@
+export const SERVER_ERROR_TYPES = {
+  missingPermissions: "missing-required-permissions",
+};

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -411,7 +411,7 @@ function ViewTitleHeaderRightSide(props) {
   const hasSaveButton = !isDataset && !!isDirty && (isNewQuery || canEditQuery);
   const isMissingPermissions =
     result?.error_type === SERVER_ERROR_TYPES.missingPermissions;
-  const showRunButton =
+  const hasRunButton =
     isRunnable && !isNativeEditorOpen && !isMissingPermissions;
 
   return (
@@ -421,9 +421,9 @@ function ViewTitleHeaderRightSide(props) {
     >
       {hasSaveButton && (
         <SaveButton
-          tooltip={t`You don't have permission to save this question.`}
           disabled={!question.canRun() || !canEditQuery}
-          TooltipProps={{
+          tooltip={{
+            tooltip: t`You don't have permission to save this question.`,
             isEnabled: !canEditQuery,
             placement: "left",
           }}
@@ -488,7 +488,7 @@ function ViewTitleHeaderRightSide(props) {
         />
       )}
       {hasExploreResultsLink && <ExploreResultsLink question={question} />}
-      {showRunButton && (
+      {hasRunButton && (
         <RunButtonWithTooltip
           className={cx("text-brand-hover text-dark hide", {
             "sm-show": !isShowingNotebook || isNative,

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -4,6 +4,7 @@ import { t } from "ttag";
 import cx from "classnames";
 
 import * as Urls from "metabase/lib/urls";
+import { SERVER_ERROR_TYPES } from "metabase/lib/errors";
 import MetabaseSettings from "metabase/lib/settings";
 
 import ButtonBar from "metabase/components/ButtonBar";
@@ -408,6 +409,10 @@ function ViewTitleHeaderRightSide(props) {
 
   const isNewQuery = !query.hasData();
   const hasSaveButton = !isDataset && !!isDirty && (isNewQuery || canEditQuery);
+  const isMissingPermissions =
+    result?.error_type === SERVER_ERROR_TYPES.missingPermissions;
+  const showRunButton =
+    isRunnable && !isNativeEditorOpen && !isMissingPermissions;
 
   return (
     <div
@@ -483,7 +488,7 @@ function ViewTitleHeaderRightSide(props) {
         />
       )}
       {hasExploreResultsLink && <ExploreResultsLink question={question} />}
-      {isRunnable && !isNativeEditorOpen && (
+      {showRunButton && (
         <RunButtonWithTooltip
           className={cx("text-brand-hover text-dark hide", {
             "sm-show": !isShowingNotebook || isNative,

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -416,7 +416,12 @@ function ViewTitleHeaderRightSide(props) {
     >
       {hasSaveButton && (
         <SaveButton
-          disabled={!question.canRun()}
+          tooltip={t`You don't have permission to save this question.`}
+          disabled={!question.canRun() || !canEditQuery}
+          TooltipProps={{
+            isEnabled: !canEditQuery,
+            placement: "left",
+          }}
           data-metabase-event={
             isShowingNotebook
               ? `Notebook Mode; Click Save`

--- a/frontend/test/metabase/scenarios/permissions/reproductions/22447-illogical-UI-elements-for-nodata.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/reproductions/22447-illogical-UI-elements-for-nodata.cy.spec.js
@@ -1,9 +1,9 @@
-import { restore, visitQuestion, isEE } from "__support__/e2e/cypress";
+import { restore, visitQuestion, isEE, popover } from "__support__/e2e/cypress";
 import { USER_GROUPS, SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 
 const { ALL_USERS_GROUP, COLLECTION_GROUP } = USER_GROUPS;
 
-describe.skip("UI elements that make no sense for users without data permissions (metabase#22447, metabase##22449, metabase#22450)", () => {
+describe("UI elements that make no sense for users without data permissions (metabase#22447, metabase##22449, metabase#22450)", () => {
   beforeEach(() => {
     restore();
   });
@@ -20,23 +20,28 @@ describe.skip("UI elements that make no sense for users without data permissions
     cy.icon("line").click();
 
     cy.findByTextEnsureVisible("Line options");
-    cy.findByText("Save").should("not.exist");
+    cy.findByText("Save")
+      .as("saveButton")
+      .invoke("css", "pointer-events")
+      .should("equal", "none");
 
-    // TODO: Please uncoment this part when metabase#22449 gets fixed
-    // cy.icon("refresh").should("not.exist");
+    cy.get("@saveButton").realHover();
+    cy.findByText("You don't have permission to save this question.");
 
-    // TODO: Please uncoment this part when metabase#22450 gets fixed
-    // cy.visit("/collection/root");
+    cy.findByTestId("qb-header-action-panel").within(() => {
+      cy.icon("refresh").should("not.exist");
+    });
 
-    // cy.get("main")
-    //   .find(".Icon-add")
-    //   .click();
+    cy.visit("/collection/root");
 
-    // Do not forget to import popover
-    // popover()
-    //   .should("contain", "Dashboard")
-    //   .and("contain", "Collection")
-    //   .and("not.contain", "Question");
+    cy.get("main")
+      .find(".Icon-add")
+      .click();
+
+    popover()
+      .should("contain", "Dashboard")
+      .and("contain", "Collection")
+      .and("not.contain", "Question");
   });
 
   it("should not show visualization or question settings to users with block data permissions", () => {
@@ -61,20 +66,18 @@ describe.skip("UI elements that make no sense for users without data permissions
     cy.findByText("Settings").should("not.exist");
     cy.findByText("Visualization").should("not.exist");
 
-    // TODO: Please uncoment this part when metabase#22449 gets fixed
-    // cy.icon("refresh").should("not.exist");
+    cy.findByTestId("qb-header-action-panel").within(() => {
+      cy.icon("refresh").should("not.exist");
+    });
+    cy.visit("/collection/root");
 
-    // TODO: Please uncoment this part when metabase#22450 gets fixed
-    // cy.visit("/collection/root");
+    cy.get("main")
+      .find(".Icon-add")
+      .click();
 
-    // cy.get("main")
-    //   .find(".Icon-add")
-    //   .click();
-
-    // Do not forget to import popover
-    // popover()
-    //   .should("contain", "Dashboard")
-    //   .and("contain", "Collection")
-    //   .and("not.contain", "Question");
+    popover()
+      .should("contain", "Dashboard")
+      .and("contain", "Collection")
+      .and("not.contain", "Question");
   });
 });


### PR DESCRIPTION
## Changes

Fixes showing query builder actions that does not make sense or unclear when users have limited permissions.

1) When users view a question based on a data source with "No self-service" permission, they can change visualization type but they are not allowed to save the question. I tried to address @flamber concerns from here https://github.com/metabase/metabase/pull/21823#pullrequestreview-950964705 — hiding "Save" button is unclear so I disabled it and added a tooltip that clarifies why a user cannot save a question.

Closes https://github.com/metabase/metabase/issues/22447

2) Hide new question button from the collections view when users don't have access to any data sources.

Closes https://github.com/metabase/metabase/issues/22450

3) Hide refresh button for questions that use blocked data sources.

Closes https://github.com/metabase/metabase/issues/22449

## How to verify

Check issues to find repro steps

