### PR TITLE
Pass parameter value to disabled TextWidget

### DIFF
--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
@@ -282,6 +282,7 @@ function Widget({
     return (
       <TextWidget
         className={cx(className, "cursor-not-allowed")}
+        value={value}
         placeholder={placeholder}
         disabled={disabled}
       />


### PR DESCRIPTION
Resolves #19495

When a parameter widget isn't mapped to any field, we disable it and render a disabled version of the TextWidget. We weren't passing a `value` prop to this component, so it didn't show a value. Passing one solves this problem.

One possible future issue related to this is that the UI of a disabled, value-populated parameter widget looks slightly different from a mapped, value-populated widget. This is because we depend on the mapped field to render the specific parameter widget. I think this is resolvable in the future, but not at the moment.

Before

![Screen Shot 2022-05-05 at 12 05 11 PM](https://user-images.githubusercontent.com/13057258/167007961-562e8a6d-e6b2-4ab7-9391-91798fa0d7cc.png)

After

![Screen Shot 2022-05-05 at 12 09 44 PM](https://user-images.githubusercontent.com/13057258/167008050-e4fada01-d9f8-44f6-adb0-04d1adaa15be.png)

Testing
1. Create a dashboard with a dashcard added to it
2. Add a parameter to the dashboard
3. Map the parameter to the dashcard
4. Add a default value to the parameter
5. Unmap the parameter so that it has no mappings
6. Save the dashboard and see that it still shows the default value.
