### PR TITLE
Add moderated_status icon to recents list

### DIFF
--- a/frontend/src/metabase/nav/components/RecentsList.jsx
+++ b/frontend/src/metabase/nav/components/RecentsList.jsx
@@ -7,10 +7,12 @@ import RecentItems from "metabase/entities/recent-items";
 import Text from "metabase/components/type/Text";
 import * as Urls from "metabase/lib/urls";
 import { isSyncCompleted } from "metabase/lib/syncing";
+import { PLUGIN_MODERATION } from "metabase/plugins";
 import {
   ResultLink,
   ResultSpinner,
   Title,
+  TitleWrapper,
 } from "metabase/search/components/SearchResult.styled";
 import { ItemIcon } from "metabase/search/components/SearchResult";
 import EmptyState from "metabase/components/EmptyState";
@@ -64,6 +66,7 @@ function RecentsList({ list, loading }) {
                 const active = isItemActive(item);
                 const loading = isItemLoading(item);
                 const url = active ? Urls.modelToUrl(item) : "";
+                const moderatedStatus = getModeratedStatus(item);
 
                 return (
                   <li key={key}>
@@ -78,12 +81,18 @@ function RecentsList({ list, loading }) {
                           active={active}
                         />
                         <div>
-                          <Title
-                            active={active}
-                            data-testid="recently-viewed-item-title"
-                          >
-                            {title}
-                          </Title>
+                          <TitleWrapper>
+                            <Title
+                              active={active}
+                              data-testid="recently-viewed-item-title"
+                            >
+                              {title}
+                            </Title>
+                            <PLUGIN_MODERATION.ModerationStatusIcon
+                              status={moderatedStatus}
+                              size={12}
+                            />
+                          </TitleWrapper>
                           <Text data-testid="recently-viewed-item-type">
                             {type}
                           </Text>
@@ -116,6 +125,10 @@ const getItemKey = ({ model, model_id }) => {
 
 const getItemName = ({ model_object }) => {
   return model_object.display_name || model_object.name;
+};
+
+const getModeratedStatus = ({ model_object }) => {
+  return model_object.moderated_status;
 };
 
 const isItemActive = ({ model, model_object }) => {


### PR DESCRIPTION
Resolves #18021 

RecentsList shares a lot in common with the SearchResult component, which already has the icon, so we mostly just need to use the same components and get the value off of the given item.

**Testing**
1. Save a question
2. Verify it via the left sidebar that opens when you click the question name in the QB header
3. Refresh
4. Click on the search input in the app header
5. The question should show the verified status icon in the "Recently viewed" list

![Screen Shot 2022-05-05 at 12 49 47 PM](https://user-images.githubusercontent.com/13057258/167014370-c9ffdec9-bcfb-4f3c-abb7-797abe0e234d.png)

