### PR TITLE
Fix automagic dashboards for queries with source queries

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard/x-rays.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/x-rays.cy.spec.js
@@ -108,7 +108,7 @@ describe("scenarios > x-rays", () => {
 
       cy.findByTextEnsureVisible("A look at the number of 15655");
 
-      cy.findByRole("heading", { name: /^A closer look at the number of/ });
+      cy.findByRole("heading", { name: /^A look at the number of/ });
       cy.get(".DashCard");
     });
 

--- a/frontend/test/metabase/scenarios/dashboard/x-rays.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/x-rays.cy.spec.js
@@ -76,9 +76,6 @@ describe("scenarios > x-rays", () => {
 
   ["X-ray", "Compare to the rest"].forEach(action => {
     it(`"${action.toUpperCase()}" should work on a nested question made from base native question (metabase#15655)`, () => {
-      // TODO: Remove this when #15655 gets fixed
-      cy.skipOn(action === "Compare to the rest");
-
       cy.intercept("GET", "/api/automagic-dashboards/**").as("xray");
 
       cy.createNativeQuestion({

--- a/src/metabase/api/automagic_dashboards.clj
+++ b/src/metabase/api/automagic_dashboards.clj
@@ -1,7 +1,6 @@
 (ns metabase.api.automagic-dashboards
   (:require [buddy.core.codecs :as codecs]
             [cheshire.core :as json]
-            [clojure.string :as str]
             [compojure.core :refer [GET]]
             [metabase.api.common :as api]
             [metabase.automagic-dashboards.comparison :refer [comparison-dashboard]]

--- a/src/metabase/api/automagic_dashboards.clj
+++ b/src/metabase/api/automagic_dashboards.clj
@@ -1,6 +1,7 @@
 (ns metabase.api.automagic-dashboards
   (:require [buddy.core.codecs :as codecs]
             [cheshire.core :as json]
+            [clojure.string :as str]
             [compojure.core :refer [GET]]
             [metabase.api.common :as api]
             [metabase.automagic-dashboards.comparison :refer [comparison-dashboard]]
@@ -105,8 +106,9 @@
   {show   Show
    entity Entity}
   (if (= entity "transform")
-    (transform.dashboard/dashboard ((->entity entity) entity-id-or-query))
-    (-> entity-id-or-query ((->entity entity)) (automagic-analysis {:show (keyword show)}))))
+    (transform.dashboard/dashboard (->entity entity entity-id-or-query))
+    (-> (->entity entity entity-id-or-query)
+        (automagic-analysis {:show (keyword show)}))))
 
 (api/defendpoint GET "/:entity/:entity-id-or-query/rule/:prefix/:rule"
   "Return an automagic dashboard for entity `entity` with id `id` using rule `rule`."
@@ -115,8 +117,9 @@
    show   Show
    prefix Prefix
    rule   Rule}
-  (-> entity-id-or-query ((->entity entity)) (automagic-analysis {:show (keyword show)
-                                                                  :rule ["table" prefix rule]})))
+  (-> (->entity entity entity-id-or-query)
+      (automagic-analysis {:show (keyword show)
+                           :rule ["table" prefix rule]})))
 
 (api/defendpoint GET "/:entity/:entity-id-or-query/cell/:cell-query"
   "Return an automagic dashboard analyzing cell in  automagic dashboard for entity `entity`
@@ -126,8 +129,7 @@
   {entity     Entity
    show       Show
    cell-query Base64EncodedJSON}
-  (-> entity-id-or-query
-      ((->entity entity))
+  (-> (->entity entity entity-id-or-query)
       (automagic-analysis {:show       (keyword show)
                            :cell-query (decode-base64-json cell-query)})))
 
@@ -140,8 +142,7 @@
    prefix     Prefix
    rule       Rule
    cell-query Base64EncodedJSON}
-  (-> entity-id-or-query
-      ((->entity entity))
+  (-> (->entity entity entity-id-or-query)
       (automagic-analysis {:show       (keyword show)
                            :rule       ["table" prefix rule]
                            :cell-query (decode-base64-json cell-query)})))
@@ -153,8 +154,8 @@
   {show              Show
    entity            Entity
    comparison-entity ComparisonEntity}
-  (let [left      ((->entity entity) entity-id-or-query)
-        right     ((->entity comparison-entity) comparison-entity-id-or-query)
+  (let [left      (->entity entity entity-id-or-query)
+        right     (->entity comparison-entity comparison-entity-id-or-query)
         dashboard (automagic-analysis left {:show         (keyword show)
                                             :query-filter nil
                                             :comparison?  true})]
@@ -169,8 +170,8 @@
    prefix            Prefix
    rule              Rule
    comparison-entity ComparisonEntity}
-  (let [left      ((->entity entity) entity-id-or-query)
-        right     ((->entity comparison-entity) comparison-entity-id-or-query)
+  (let [left      (->entity entity entity-id-or-query)
+        right     (->entity comparison-entity comparison-entity-id-or-query)
         dashboard (automagic-analysis left {:show         (keyword show)
                                             :rule         ["table" prefix rule]
                                             :query-filter nil
@@ -186,8 +187,8 @@
    show              Show
    cell-query        Base64EncodedJSON
    comparison-entity ComparisonEntity}
-  (let [left      ((->entity entity) entity-id-or-query)
-        right     ((->entity comparison-entity) comparison-entity-id-or-query)
+  (let [left      (->entity entity entity-id-or-query)
+        right     (->entity comparison-entity comparison-entity-id-or-query)
         dashboard (automagic-analysis left {:show         (keyword show)
                                             :query-filter nil
                                             :comparison?  true})]
@@ -204,8 +205,8 @@
    rule              Rule
    cell-query        Base64EncodedJSON
    comparison-entity ComparisonEntity}
-  (let [left      ((->entity entity) entity-id-or-query)
-        right     ((->entity comparison-entity) comparison-entity-id-or-query)
+  (let [left      (->entity entity entity-id-or-query)
+        right     (->entity comparison-entity comparison-entity-id-or-query)
         dashboard (automagic-analysis left {:show         (keyword show)
                                             :rule         ["table" prefix rule]
                                             :query-filter nil})]

--- a/src/metabase/automagic_dashboards/core.clj
+++ b/src/metabase/automagic_dashboards/core.clj
@@ -44,23 +44,32 @@
 (def ^:private ^{:arglists '([field])} id-or-name
   (some-fn :id :name))
 
-(s/defn ->field
+(s/defn ->field :- (s/maybe (type Field))
   "Return `Field` instance for a given ID or name in the context of root."
-  [root id-or-name :- (s/cond-pre su/IntGreaterThanZero su/NonBlankString mbql.s/Field)]
-  (let [id-or-name (if (sequential? id-or-name)
-                     (filters/field-reference->id id-or-name)
-                     id-or-name)]
-    (if (->> root :source (instance? (type Table)))
-      (Field id-or-name)
-      (when-let [field (->> root
-                            :source
-                            :result_metadata
-                            (m/find-first (comp #{id-or-name} :name)))]
-        (-> field
-            (update :base_type keyword)
-            (update :semantic_type keyword)
-            field/map->FieldInstance
-            (classify/run-classifiers {}))))))
+  [{{result-metadata :result_metadata} :source, :as root}
+   field-id-or-name-or-clause :- (s/cond-pre su/IntGreaterThanZero su/NonBlankString mbql.s/Field)]
+  (let [id-or-name (if (sequential? field-id-or-name-or-clause)
+                     (filters/field-reference->id field-id-or-name-or-clause)
+                     field-id-or-name-or-clause)]
+    (or
+     ;; Handle integer Field IDs.
+     (when (integer? id-or-name)
+       (Field id-or-name))
+     ;; handle field string names. Only if we have result metadata. (Not sure why)
+     (when (string? id-or-name)
+       (when-not result-metadata
+         (log/warn (trs "Warning: Automagic analysis context is missing result metadata. Unable to resolve Fields by name.")))
+       (when-let [field (m/find-first #(= (:name %) id-or-name)
+                                      result-metadata)]
+         (-> field
+             (update :base_type keyword)
+             (update :semantic_type keyword)
+             field/map->FieldInstance
+             (classify/run-classifiers {}))))
+     ;; otherwise this isn't returning something, and that's probably an error. Log it.
+     (log/warn (str (trs "Cannot resolve Field {0} in automagic analysis context" field-id-or-name-or-clause)
+                    \newline
+                    (u/pprint-to-str root))))))
 
 (def ^{:arglists '([root])} source-name
   "Return the (display) name of the soruce of a given root object."
@@ -1014,11 +1023,12 @@
                :transient_filters (:query-filter context)
                :param_fields      (->> context :query-filter (filter-referenced-fields root))))))
 
-(defmulti
-  ^{:doc "Create a transient dashboard analyzing given entity."
-    :arglists '([entity opts])}
-  automagic-analysis (fn [entity _]
-                       (type entity)))
+
+(defmulti automagic-analysis
+  "Create a transient dashboard analyzing given entity."
+  {:arglists '([entity opts])}
+  (fn [entity _]
+    (type entity)))
 
 (defmethod automagic-analysis (type Table)
   [table opts]
@@ -1032,7 +1042,7 @@
   [metric opts]
   (automagic-dashboard (merge (->root metric) opts)))
 
-(defn- collect-metrics
+(s/defn ^:private collect-metrics :- (s/maybe [(type Metric)])
   [root question]
   (map (fn [aggregation-clause]
          (if (-> aggregation-clause
@@ -1047,21 +1057,30 @@
                                           :table_id   table-id}))))
        (get-in question [:dataset_query :query :aggregation])))
 
-(defn- collect-breakout-fields
+(s/defn ^:private collect-breakout-fields :- (s/maybe [(type Field)])
   [root question]
-  (map (comp (partial ->field root)
-             first
-             filters/collect-field-references)
-       (get-in question [:dataset_query :query :breakout])))
+  (for [breakout     (get-in question [:dataset_query :query :breakout])
+        field-clause (take 1 (filters/collect-field-references breakout))
+        :let         [field (->field root field-clause)]
+        :when        field]
+    field))
 
 (defn- decompose-question
   [root question opts]
-  (map #(automagic-analysis % (assoc opts
-                                :source       (:source root)
-                                :query-filter (:query-filter root)
-                                :database     (:database root)))
-       (concat (collect-metrics root question)
-               (collect-breakout-fields root question))))
+  (letfn [(analyze [x]
+            (try
+              (automagic-analysis x (assoc opts
+                                           :source       (:source root)
+                                           :query-filter (:query-filter root)
+                                           :database     (:database root)))
+              (catch Throwable e
+                (throw (ex-info (tru "Error decomposing question: {0}" (ex-message e))
+                                {:root root, :question question, :object x}
+                                e)))))]
+    (into []
+          (comp cat (map analyze))
+          [(collect-metrics root question)
+           (collect-breakout-fields root question)])))
 
 (defn- pluralize
   [x]

--- a/src/metabase/automagic_dashboards/filters.clj
+++ b/src/metabase/automagic_dashboards/filters.clj
@@ -137,10 +137,11 @@
                                        (into {})))
         (add-filters dashboard max-filters)))
   ([dashboard dimensions max-filters]
-   (let [fks (->> (db/select Field
-                    :fk_target_field_id [:not= nil]
-                    :table_id [:in (keep (comp :table_id :card) (:ordered_cards dashboard))])
-                  field/with-targets)]
+   (let [fks (when-let [table-ids (not-empty (set (keep (comp :table_id :card)
+                                                        (:ordered_cards dashboard))))]
+               (->> (db/select Field :fk_target_field_id [:not= nil]
+                               :table_id [:in table-ids])
+                    field/with-targets))]
      (->> dimensions
           remove-unqualified
           sort-by-interestingness
@@ -161,7 +162,6 @@
                                                :slug (:name candidate)}))
                  dashboard)))
            dashboard)))))
-
 
 (defn- flatten-filter-clause
   "Returns a sequence of filter subclauses making up `filter-clause` by flattening `:and` compound filters.

--- a/src/metabase/sync/analyze/classifiers/name.clj
+++ b/src/metabase/sync/analyze/classifiers/name.clj
@@ -143,9 +143,10 @@
                 (str/blank? (:name field-or-column)))
     (semantic-type-for-name-and-base-type (:name field-or-column) (:base_type field-or-column))))
 
-(s/defn infer-and-assoc-semantic-type  :- (s/maybe FieldOrColumn)
+(s/defn infer-and-assoc-semantic-type :- (s/maybe FieldOrColumn)
   "Returns `field-or-column` with a computed semantic type based on the name and base type of the `field-or-column`"
-  [field-or-column :- FieldOrColumn, _ :- (s/maybe i/Fingerprint)]
+  [field-or-column :- FieldOrColumn
+   _fingerprint    :- (s/maybe i/Fingerprint)]
   (when-let [inferred-semantic-type (infer-semantic-type field-or-column)]
     (log/debug (format "Based on the name of %s, we're giving it a semantic type of %s."
                        (sync-util/name-for-logging field-or-column)

--- a/test/metabase/api/automagic_dashboards_test.clj
+++ b/test/metabase/api/automagic_dashboards_test.clj
@@ -117,6 +117,7 @@
     (testing "GET /api/automagic-dashboards/adhoc/:query/cell/:cell-query/rule/example/indepth"
       (is (some? (api-call "adhoc/%s/cell/%s/rule/example/indepth" [query cell-query]))))))
 
+
 ;;; ------------------- Comparisons -------------------
 
 (def ^:private segment

--- a/test/metabase/api/automagic_dashboards_test.clj
+++ b/test/metabase/api/automagic_dashboards_test.clj
@@ -117,13 +117,12 @@
     (testing "GET /api/automagic-dashboards/adhoc/:query/cell/:cell-query/rule/example/indepth"
       (is (some? (api-call "adhoc/%s/cell/%s/rule/example/indepth" [query cell-query]))))))
 
-
 ;;; ------------------- Comparisons -------------------
 
 (def ^:private segment
   (delay
-   {:table_id   (mt/id :venues)
-    :definition {:filter [:> [:field-id (mt/id :venues :price)] 10]}}))
+    {:table_id   (mt/id :venues)
+     :definition {:filter [:> [:field-id (mt/id :venues :price)] 10]}}))
 
 (deftest comparisons-test
   (tt/with-temp Segment [{segment-id :id} @segment]
@@ -146,6 +145,33 @@
                       (->> [:= [:field-id (mt/id :venues :price)] 15]
                            (#'magic/encode-base64-json))
                       segment-id]))))))
+
+(deftest compare-nested-query-test
+  (testing "Ad-hoc X-Rays should work for queries have Card source queries (#15655)"
+    (mt/dataset sample-dataset
+      (let [card-query      (mt/native-query {:query "select * from people"})
+            result-metadata (get-in (qp/process-query card-query) [:data :results_metadata :columns]) ]
+        (mt/with-temp* [Collection [{collection-id :id}]
+                        Card       [{card-id :id} {:name            "15655_Q1"
+                                                   :collection_id   collection-id
+                                                   :dataset_query   card-query
+                                                   :result_metadata result-metadata}]]
+          (let [query      {:database (mt/id)
+                            :type     :query
+                            :query    {:source-table (format "card__%d" card-id)
+                                       :breakout     [[:field "SOURCE" {:base-type :type/Text}]]
+                                       :aggregation  [[:count]]}}
+                cell-query [:= [:field "SOURCE" {:base-type :type/Text}] "Affiliate"]]
+            (testing "X-Ray"
+              (is (some? (api-call "adhoc/%s/cell/%s"
+                                   (map #'magic/encode-base64-json [query cell-query])
+                                   #(revoke-collection-permissions! collection-id)))))
+            (perms/grant-collection-read-permissions! (perms-group/all-users) collection-id)
+            (testing "Compare"
+              (is (some? (api-call "adhoc/%s/cell/%s/compare/table/%s"
+                                   (concat (map #'magic/encode-base64-json [query cell-query])
+                                           [(format "card__%d" card-id)])
+                                   #(revoke-collection-permissions! collection-id)))))))))))
 
 
 ;;; ------------------- Transforms -------------------


### PR DESCRIPTION
Fixes #15655

Automagic dashboards did not work if you tried to hit the endpoint like

```
/api/automagic-dashboards/adhoc/<query>/cell/<cell-query>/compare/table/card__10
```

Now It does seem like you should probably have just called 

```
/api/automagic-dashboards/adhoc/<query>/cell/<cell-query>/compare/question/10
```

instead but it was easy enough for me to detect this case and fix it on our end.

Once I fixed that I ran into a bunch of other bugs that had to be fixed (I will explain in the comments)