### PR TITLE
Allow firing an event (e.g. clicking) on the checkbox's label

### DIFF
--- a/frontend/src/metabase/core/components/CheckBox/CheckBox.tsx
+++ b/frontend/src/metabase/core/components/CheckBox/CheckBox.tsx
@@ -37,6 +37,7 @@ function CheckboxTooltip({
 
 const CheckBox = forwardRef<HTMLLabelElement, CheckBoxProps>(function Checkbox(
   {
+    name,
     label,
     labelEllipsis = false,
     checked,
@@ -74,6 +75,7 @@ const CheckBox = forwardRef<HTMLLabelElement, CheckBoxProps>(function Checkbox(
           onChange={isControlledCheckBoxInput ? onChange : undefined}
           onFocus={onFocus}
           onBlur={onBlur}
+          id={name}
         />
         <CheckBoxContainer disabled={disabled}>
           <CheckBoxIconContainer

--- a/frontend/src/metabase/core/components/CheckBox/types.ts
+++ b/frontend/src/metabase/core/components/CheckBox/types.ts
@@ -26,6 +26,7 @@ export interface CheckBoxLabelProps {
 
 export interface CheckBoxProps
   extends Omit<HTMLAttributes<HTMLElement>, "onChange" | "onFocus" | "onBlur"> {
+  name?: string;
   label?: ReactNode;
   labelEllipsis?: boolean;
   checked?: boolean;

--- a/frontend/test/metabase/scenarios/onboarding/auth/signin.cy.spec.js
+++ b/frontend/test/metabase/scenarios/onboarding/auth/signin.cy.spec.js
@@ -53,6 +53,16 @@ describe("scenarios > auth > signin", () => {
     cy.contains(/[a-z ]+, Bob/i);
   });
 
+  it("should allow toggling of Remember Me", () => {
+    cy.visit("/auth/login");
+
+    // default initial state
+    cy.findByRole("checkbox").should("be.checked");
+
+    cy.findByLabelText("Remember me").click();
+    cy.findByRole("checkbox").should("not.be.checked");
+  });
+
   it("should redirect to a unsaved question after login", () => {
     cy.signInAsAdmin();
     cy.visit("/");


### PR DESCRIPTION
To verify manually:
1. Go to the sign-in form, e.g. `/auth/login`
2. Click on the "Remember me" label (**not** on the checkbox)

![image](https://user-images.githubusercontent.com/7288/167148172-aa6b5169-ffc9-4ae0-a5c8-0f81eaf18d61.png)

To run the E2E test: `yarn test-cypress-open`, choose and run `frontend/test/metabase/scenarios/onboarding/auth/signin.cy.spec.js`.

### Before

The checkbox stays checked.

### After

The checkbox switches state, i.e. now it becomes unchecked.
