### PR TITLE
Fix redirects of group managers when they remove the last group they manage

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/group_managers/actions.js
+++ b/enterprise/frontend/src/metabase-enterprise/group_managers/actions.js
@@ -6,9 +6,11 @@ import {
 } from "metabase/admin/people/people";
 import { getAdminPaths } from "metabase/admin/app/selectors";
 import { refreshCurrentUser } from "metabase/redux/user";
+import Groups from "metabase/entities/groups";
 import {
   getRevokeManagerGroupsRedirect,
   getRevokeManagerPeopleRedirect,
+  getRevokedAllGroupManagersPath,
 } from "./utils";
 
 export const CONFIRM_DELETE_MEMBERSHIP =
@@ -20,6 +22,7 @@ export const confirmDeleteMembership = createThunkAction(
     getState,
   ) => {
     await dispatch(deleteMembership(membershipId));
+    await dispatch(refreshCurrentUser());
 
     const adminPaths = getAdminPaths(getState());
 
@@ -30,7 +33,6 @@ export const confirmDeleteMembership = createThunkAction(
 
     if (redirectUrl) {
       await dispatch(push(redirectUrl));
-      await dispatch(refreshCurrentUser());
     }
   },
 );
@@ -41,6 +43,7 @@ export const confirmUpdateMembership = createThunkAction(
   CONFIRM_UPDATE_MEMBERSHIP,
   (membership, currentUserMemberships, view) => async (dispatch, getState) => {
     await dispatch(updateMembership(membership));
+    await dispatch(refreshCurrentUser());
 
     const adminPaths = getAdminPaths(getState());
 
@@ -51,7 +54,24 @@ export const confirmUpdateMembership = createThunkAction(
 
     if (redirectUrl) {
       await dispatch(push(redirectUrl));
-      await dispatch(refreshCurrentUser());
+    }
+  },
+);
+
+export const DELETE_GROUP = "metabase-enterprise/group_managers/DELETE_GROUP";
+export const deleteGroup = createThunkAction(
+  DELETE_GROUP,
+  group => async (dispatch, getState) => {
+    const groups = Groups.selectors.getList(getState());
+    const isLastGroup = groups.length === 1;
+
+    await dispatch(Groups.actions.delete({ id: group.id }));
+    await dispatch(refreshCurrentUser());
+
+    if (isLastGroup) {
+      const adminPaths = getAdminPaths(getState());
+      const redirectUrl = getRevokedAllGroupManagersPath(adminPaths);
+      await dispatch(push(redirectUrl));
     }
   },
 );

--- a/enterprise/frontend/src/metabase-enterprise/group_managers/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/group_managers/index.ts
@@ -5,7 +5,11 @@ import {
 } from "metabase/plugins";
 import { UserTypeCell } from "./components/UserTypeCell";
 import { UserTypeToggle } from "./components/UserTypeToggle";
-import { confirmDeleteMembership, confirmUpdateMembership } from "./actions";
+import {
+  confirmDeleteMembership,
+  confirmUpdateMembership,
+  deleteGroup,
+} from "./actions";
 import {
   getChangeMembershipConfirmation,
   getRemoveMembershipConfirmation,
@@ -21,6 +25,7 @@ if (hasPremiumFeature("advanced_permissions")) {
   PLUGIN_GROUP_MANAGERS.getRemoveMembershipConfirmation = getRemoveMembershipConfirmation;
   PLUGIN_GROUP_MANAGERS.getChangeMembershipConfirmation = getChangeMembershipConfirmation;
 
+  PLUGIN_GROUP_MANAGERS.deleteGroup = deleteGroup;
   PLUGIN_GROUP_MANAGERS.confirmDeleteMembershipAction = confirmDeleteMembership;
   PLUGIN_GROUP_MANAGERS.confirmUpdateMembershipAction = confirmUpdateMembership;
 }

--- a/enterprise/frontend/src/metabase-enterprise/group_managers/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/group_managers/utils.ts
@@ -19,7 +19,7 @@ export const groupManagerAllowedPathGetter = (
   return canAccessPeople(user) ? ["people"] : [];
 };
 
-const getRevokedAllGroupManagersPath = (adminPaths: AdminPath[]) => {
+export const getRevokedAllGroupManagersPath = (adminPaths: AdminPath[]) => {
   const allowedItems = adminPaths.filter(item => item.key !== "people");
 
   return allowedItems.length > 0 ? allowedItems[0].path : "/";

--- a/frontend/src/metabase/admin/people/containers/GroupsListingApp.jsx
+++ b/frontend/src/metabase/admin/people/containers/GroupsListingApp.jsx
@@ -1,16 +1,23 @@
 import React from "react";
 import { connect } from "react-redux";
 
+import { PLUGIN_GROUP_MANAGERS } from "metabase/plugins";
 import Group from "metabase/entities/groups";
+import { getUserIsAdmin } from "metabase/selectors/user";
 import GroupsListing from "../components/GroupsListing";
 import { getGroupsWithoutMetabot } from "../selectors";
-import { getUserIsAdmin } from "metabase/selectors/user";
 
-@Group.loadList({ reload: true })
-@connect((state, props) => ({
+const mapStateToProps = (state, props) => ({
   groups: getGroupsWithoutMetabot(state, props),
   isAdmin: getUserIsAdmin(state),
-}))
+});
+
+const mapDispatchToProps = {
+  delete: PLUGIN_GROUP_MANAGERS.deleteGroup ?? Group.actions.delete,
+};
+
+@Group.loadList({ reload: true })
+@connect(mapStateToProps, mapDispatchToProps)
 export default class GroupsListingApp extends React.Component {
   render() {
     return <GroupsListing {...this.props} />;

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -172,6 +172,7 @@ export const PLUGIN_GROUP_MANAGERS: PluginGroupManagersType = {
   getChangeMembershipConfirmation: () => null,
   getRemoveMembershipConfirmation: () => null,
 
+  deleteGroup: null,
   confirmDeleteMembershipAction: null,
   confirmUpdateMembershipAction: null,
 };

--- a/frontend/src/metabase/plugins/types.ts
+++ b/frontend/src/metabase/plugins/types.ts
@@ -29,6 +29,7 @@ export type PluginGroupManagersType = {
   getChangeMembershipConfirmation: GetChangeMembershipConfirmation;
   getRemoveMembershipConfirmation: GetRemoveMembershipConfirmation;
 
+  deleteGroup: any;
   confirmDeleteMembershipAction: any;
   confirmUpdateMembershipAction: any;
 };

--- a/frontend/test/metabase/scenarios/admin/people/group-managers.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/people/group-managers.cy.spec.js
@@ -12,16 +12,15 @@ describeEE("scenarios > admin > people", () => {
       .click();
 
     cy.findAllByTestId("user-type-toggle").click({ multiple: true });
+
+    cy.signInAsNormalUser();
+    cy.visit("/");
+    cy.icon("gear").click();
+    cy.findByText("Admin settings").click();
   });
 
   describe("group managers", () => {
     it("can manage groups from the group page", () => {
-      cy.signInAsNormalUser();
-      cy.visit("/");
-
-      cy.icon("gear").click();
-      cy.findByText("Admin settings").click();
-
       cy.findByText("Groups").click();
 
       // Edit group name
@@ -91,11 +90,6 @@ describeEE("scenarios > admin > people", () => {
     });
 
     it("can manage members from the people page", () => {
-      cy.signInAsNormalUser();
-      cy.visit("/");
-      cy.icon("gear").click();
-      cy.findByText("Admin settings").click();
-
       // Open membership select for a user
       cy.findByText("No Collection Tableton")
         .closest("tr")
@@ -151,6 +145,16 @@ describeEE("scenarios > admin > people", () => {
       cy.url().should("match", /\/$/);
     });
   });
+
+  it("after removing the last group redirects to the home page", () => {
+    cy.findByText("Groups").click();
+
+    removeFirstGroup();
+    cy.url().should("match", /\/admin\/people\/groups$/);
+
+    removeFirstGroup();
+    cy.url().should("match", /\/$/);
+  });
 });
 
 function confirmLosingAbilityToManageGroup() {
@@ -160,4 +164,12 @@ function confirmLosingAbilityToManageGroup() {
     );
     cy.button("Confirm").click();
   });
+}
+
+function removeFirstGroup() {
+  cy.icon("ellipsis")
+    .eq(0)
+    .click();
+  cy.findByText("Remove Group").click();
+  cy.button("Yes").click();
 }


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/22217
Reproduces https://github.com/metabase/metabase/issues/22217

## Changes
- Fixes the case when group managers remove the last group they manage. Now they are being redirected to other settings they have access to or to the home page.
- Fixes another case when group managers remove their memberships in groups which gave them access to other admin settings.

## How to verify

### Setup
- run Metabase EE
- create a Test User and login under it in a separate browser window
- create a Test Group and grant the settings permission to it using [the application permissions editor](http://localhost:3000/admin/permissions/application)
- promote the Test User to a group admin of the Test Group

### Removing membership
- login as the Test User
- go to the [Admin Settings -> People](http://localhost:3000/admin/people)
- remove yourself from the Test Group
- ensure you are being redirected to the home page

### Removing group
- login as the Test User
- go to the [Admin Settings -> People -> Groups](http://localhost:3000/admin/people/groups)
- remove the Test Group
- ensure you are being redirected to the home page