### PR TITLE
Clean up semantics of data model & DB detail editing permission checks

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/common.clj
@@ -32,13 +32,13 @@
                        :user_id api/*current-user-id* :group_id (u/the-id group-or-id)))
 
 (defn filter-tables-by-data-model-perms
-  "Given a list of tables, removes the ones for which `*current-user*` does not have data model editing permissions.
-  Returns the list unmodified if the :advanced-permissions feature flag is not enabled."
+  "Given a list of tables, removes the ones for which `*current-user*` does not have data model editing permissions."
   [tables]
   (cond
     api/*is-superuser?*
     tables
 
+    ;; If advanced-permissions is not enabled, no non-admins have any data-model editing perms, so return an empty list
     (not (premium-features/enable-advanced-permissions?))
     (empty tables)
 
@@ -58,7 +58,7 @@
     api/*is-superuser?*
     dbs
 
-    ;; If advanced-permissions is not enabled, no non-admins have any data-model editing perms.
+    ;; If advanced-permissions is not enabled, no non-admins have any data-model editing perms, so return an empty list
     (not (premium-features/enable-advanced-permissions?))
     (empty dbs)
 

--- a/enterprise/backend/src/metabase_enterprise/sandbox/api/table.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/api/table.clj
@@ -22,7 +22,7 @@
   [table-or-table-id user-or-user-id]
   (some->> (db/query {:select [:c.id :c.dataset_query]
                       :from [[GroupTableAccessPolicy :gtap]]
-                      :join [[PermissionsGroupMembership :pgm] [:= :gtap.group_id :pgm.group_id ]
+                      :join [[PermissionsGroupMembership :pgm] [:= :gtap.group_id :pgm.group_id]
                              [Card :c] [:= :c.id :gtap.card_id]]
                       :where [:and
                               [:= :gtap.table_id (u/the-id table-or-table-id)]
@@ -58,9 +58,10 @@
   excluded from what is show in the query builder. When the user has full permissions (or no permissions) this route
   doesn't add/change anything from the OSS version. See the docs on the OSS version of the endpoint for more
   information."
-  [id include_sensitive_fields include_hidden_fields]
-  {include_sensitive_fields (s/maybe su/BooleanString)
-   include_hidden_fields    (s/maybe su/BooleanString)}
+  [id include_sensitive_fields include_hidden_fields include_editable_data_model]
+  {include_sensitive_fields    (s/maybe su/BooleanString)
+   include_hidden_fields       (s/maybe su/BooleanString)
+   include_editable_data_model (s/maybe su/BooleanString)}
   (let [table            (api/check-404 (Table id))
         segmented-perms? (only-segmented-perms? table)
         thunk            (fn []
@@ -69,7 +70,8 @@
                             (api.table/fetch-query-metadata
                              table
                              include_sensitive_fields
-                             include_hidden_fields)))]
+                             include_hidden_fields
+                             include_editable_data_model)))]
     ;; if the user has segmented perms, temporarily upgrade their perms to read perms for the Table so they can see
     ;; the metadata
     (if segmented-perms?

--- a/enterprise/backend/src/metabase_enterprise/sandbox/api/table.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/api/table.clj
@@ -69,9 +69,9 @@
                             table
                             (api.table/fetch-query-metadata
                              table
-                             include_sensitive_fields
-                             include_hidden_fields
-                             include_editable_data_model)))]
+                             {:include-sensitive-fields?    include_sensitive_fields
+                              :include-hidden-fields?       include_hidden_fields
+                              :include-editable-data-model? include_editable_data_model})))]
     ;; if the user has segmented perms, temporarily upgrade their perms to read perms for the Table so they can see
     ;; the metadata
     (if segmented-perms?

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -285,25 +285,25 @@
     (mt/with-temp Table [{table-id :id} {:db_id (mt/id) :schema "PUBLIC"}]
       (testing "A non-admin without self-service perms for a table cannot fetch the table normally"
         (with-all-users-data-perms {(mt/id) {:data {:native :none :schemas :none}}}
-          (mt/user-http-request :rasta :get 403 (format "table/%d" table-id))))
+          (mt/user-http-request :rasta :get 403 (format "table/%d?include_editable_data_model=true" table-id))))
 
       (testing "A non-admin without self-service perms for a table can fetch the table if they have data model perms for
                the DB"
         (with-all-users-data-perms {(mt/id) {:data       {:native :none :schemas :none}
                                              :data-model {:schemas :all}}}
-          (mt/user-http-request :rasta :get 200 (format "table/%d" table-id))))
+          (mt/user-http-request :rasta :get 200 (format "table/%d?include_editable_data_model=true" table-id))))
 
       (testing "A non-admin without self-service perms for a table can fetch the table if they have data model perms for
                the schema"
         (with-all-users-data-perms {(mt/id) {:data       {:native :none :schemas :none}
                                              :data-model {:schemas {"PUBLIC" :all}}}}
-          (mt/user-http-request :rasta :get 200 (format "table/%d" table-id))))
+          (mt/user-http-request :rasta :get 200 (format "table/%d?include_editable_data_model=true" table-id))))
 
       (testing "A non-admin without self-service perms for a table can fetch the table if they have data model perms for
                the table"
         (with-all-users-data-perms {(mt/id) {:data       {:native :none :schemas :none}
                                              :data-model {:schemas {"PUBLIC" {table-id :all}}}}}
-          (mt/user-http-request :rasta :get 200 (format "table/%d" table-id)))))))
+          (mt/user-http-request :rasta :get 200 (format "table/%d?include_editable_data_model=true" table-id)))))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                  Database details permission enforcement                                       |
@@ -370,20 +370,20 @@
   (mt/with-temp Database [{db-id :id}]
     (testing "A non-admin without self-service perms for a DB cannot fetch the DB normally"
       (with-all-users-data-perms {db-id {:data {:native :none :schemas :none}}}
-        (mt/user-http-request :rasta :get 403 (format "database/%d" db-id))))
+        (mt/user-http-request :rasta :get 403 (format "database/%d?exclude_uneditable_details=true" db-id))))
 
     (testing "A non-admin without self-service perms for a DB can fetch the DB if they have DB details permissions"
       (with-all-users-data-perms {db-id {:data    {:native :none :schemas :none}
                                          :details :yes}}
-        (mt/user-http-request :rasta :get 200 (format "database/%d" db-id))))
+        (mt/user-http-request :rasta :get 200 (format "database/%d?exclude_uneditable_details=true" db-id))))
 
     (testing "A non-admin with block perms for a DB can fetch the DB if they have DB details permissions"
       (with-all-users-data-perms {db-id {:data    {:native :none :schemas :block}
                                          :details :yes}}
-        (mt/user-http-request :rasta :get 200 (format "database/%d" db-id))))
+        (mt/user-http-request :rasta :get 200 (format "database/%d?exclude_uneditable_details=true" db-id))))
 
     (testing "The returned database contains a :details field for a user with DB details permissions"
       (with-all-users-data-perms {db-id {:data    {:native :none :schemas :block}
                                          :details :yes}}
         (is (partial= {:details {}}
-             (mt/user-http-request :rasta :get 200 (format "database/%d" db-id))))))))
+             (mt/user-http-request :rasta :get 200 (format "database/%d?exclude_uneditable_details=true" db-id))))))))

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -305,6 +305,24 @@
                                              :data-model {:schemas {"PUBLIC" {table-id :all}}}}}
           (mt/user-http-request :rasta :get 200 (format "table/%d?include_editable_data_model=true" table-id)))))))
 
+(deftest fetch-query-metadata-test
+  (testing "GET /api/table/:id/query_metadata?include_editable_data_model=true"
+    (mt/with-temp Table [{table-id :id} {:db_id (mt/id) :schema "PUBLIC"}]
+      (testing "A non-admin without data model perms for a table cannot fetch the query metadata when
+               include_editable_data_model=true"
+        (with-all-users-data-perms {(mt/id) {:data       {:native :write :schemas :all}
+                                             :data-model {:schemas :none}}}
+          (mt/user-http-request :rasta :get 403
+                                (format "table/%d/query_metadata?include_editable_data_model=true" table-id))))
+
+      (testing "A non-admin with only data model perms for a table can fetch the query metadata when
+               include_editable_data_model=true"
+        (with-all-users-data-perms {(mt/id) {:data       {:native :none :schemas :none}
+                                             :data-model {:schemas :all}}}
+          (mt/user-http-request :rasta :get 200
+                                (format "table/%d/query_metadata?include_editable_data_model=true" table-id)))))))
+
+
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                  Database details permission enforcement                                       |
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -87,11 +87,13 @@
                           :data
                           (filter (fn [db] (= (mt/id) (:id db))))
                           first)))]
-      (with-all-users-data-perms {(mt/id) {:data       {:schemas :all :native :write}
-                                           :data-model {:schemas :all}}}
-        (is (partial= {:id (mt/id)} (get-test-db))))
+      (testing "Sanity check: a non-admin can fetch a DB when they have full data access and data model perms"
+        (with-all-users-data-perms {(mt/id) {:data       {:schemas :all :native :write}
+                                             :data-model {:schemas :all}}}
+          (is (partial= {:id (mt/id)} (get-test-db)))))
 
-      (testing "DB with no data model perms is excluded"
+      (testing "A non-admin cannot fetch a DB for which they do not have data model perms if
+               include_editable_data_model=true"
         (with-all-users-data-perms {(mt/id) {:data       {:schemas :all :native :write}
                                              :data-model {:schemas :none}}}
             (is (= nil (get-test-db)))))
@@ -102,7 +104,8 @@
                                                                               id-2 :none
                                                                               id-3 :none
                                                                               id-4 :none}}}}}
-          (testing "DB with data model perms for a single table is included"
+          (testing "If a non-admin has data model perms for a single table in a DB, the DB is returned when listing
+                   all DBs"
             (is (partial= {:id (mt/id)} (get-test-db))))
 
           (testing "if include=tables, only tables with data model perms are included"

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -330,7 +330,7 @@
   {include (s/maybe (s/enum "tables" "tables.fields"))}
   (let [include-editable-data-model? (Boolean/parseBoolean include_editable_data_model)
         exclude-uneditable-details?  (Boolean/parseBoolean exclude_uneditable_details)
-        filter-by-data-access? (not (or include-editable-data-model? exclude-uneditable-details?))]
+        filter-by-data-access?       (not (or include-editable-data-model? exclude-uneditable-details?))]
     (cond-> (api/check-404 (Database id))
       filter-by-data-access?       api/read-check
       exclude-uneditable-details?  api/write-check

--- a/src/metabase/api/table.clj
+++ b/src/metabase/api/table.clj
@@ -299,7 +299,7 @@
   Passing `include_sensitive_fields=true` will include any sensitive `Fields` in the response. Defaults to `false`.
 
   Passing `include_editable_data_model=true` will check that the current user has write permissions for the table's
-  data model, rather than checking that they have data access perms for the table.
+  data model, while `false` checks that they have data access perms for the table. Defaults to `false`.
 
   These options are provided for use in the Admin Edit Metadata page."
   [id include_sensitive_fields include_hidden_fields include_editable_data_model]

--- a/src/metabase/api/table.clj
+++ b/src/metabase/api/table.clj
@@ -273,7 +273,7 @@
 (defn fetch-query-metadata
   "Returns the query metadata used to power the Query Builder for the given `table`. `include-sensitive-fields?`,
   `include-hidden-fields?` and `include-editable-data-model?` can be either booleans or boolean strings."
-  [table include-sensitive-fields? include-hidden-fields? include-editable-data-model?]
+  [table {:keys [include-sensitive-fields? include-hidden-fields? include-editable-data-model?]}]
   (if (Boolean/parseBoolean include-editable-data-model?)
     (api/write-check table)
     (api/read-check table))
@@ -306,7 +306,9 @@
   {include_sensitive_fields (s/maybe su/BooleanString)
    include_hidden_fields (s/maybe su/BooleanString)
    include_editable_data_model (s/maybe su/BooleanString)}
-  (fetch-query-metadata (Table id) include_sensitive_fields include_hidden_fields include_editable_data_model))
+  (fetch-query-metadata (Table id) {:include-sensitive-fields?    include_sensitive_fields
+                                    :include-hidden-fields?       include_hidden_fields
+                                    :include-editable-data-model? include_editable_data_model}))
 
 (defn- card-result-metadata->virtual-fields
   "Return a sequence of 'virtual' fields metadata for the 'virtual' table for a Card in the Saved Questions 'virtual'

--- a/src/metabase/api/table.clj
+++ b/src/metabase/api/table.clj
@@ -42,10 +42,13 @@
 
 (api/defendpoint GET "/:id"
   "Get `Table` with ID."
-  [id]
-  (u/prog1 (-> (api/read-check Table id)
-               (hydrate :db :pk_field))
-           (events/publish-event! :table-read (assoc <> :actor_id api/*current-user-id*))))
+  [id include_editable_data_model]
+  (let [api-perm-check-fn (if (Boolean/parseBoolean include_editable_data_model)
+                            api/write-check
+                            api/read-check)]
+    (u/prog1 (-> (api-perm-check-fn Table id)
+                 (hydrate :db :pk_field))
+             (events/publish-event! :table-read (assoc <> :actor_id api/*current-user-id*)))))
 
 (defn- update-table!*
   "Takes an existing table and the changes, updates in the database and optionally calls `table/update-field-positions!`
@@ -268,10 +271,12 @@
                 field)))))
 
 (defn fetch-query-metadata
-  "Returns the query metadata used to power the Query Builder for the given `table`. `include-sensitive-fields?` and
-  `include-hidden-fields?` can be either booleans or boolean strings."
-  [table include-sensitive-fields? include-hidden-fields?]
-  (api/read-check table)
+  "Returns the query metadata used to power the Query Builder for the given `table`. `include-sensitive-fields?`,
+  `include-hidden-fields?` and `include-editable-data-model?` can be either booleans or boolean strings."
+  [table include-sensitive-fields? include-hidden-fields? include-editable-data-model?]
+  (if (Boolean/parseBoolean include-editable-data-model?)
+    (api/write-check table)
+    (api/read-check table))
   (let [driver                    (driver.u/database->driver (:db_id table))
         include-sensitive-fields? (cond-> include-sensitive-fields? (string? include-sensitive-fields?) Boolean/parseBoolean)
         include-hidden-fields?    (cond-> include-hidden-fields? (string? include-hidden-fields?) Boolean/parseBoolean)]
@@ -293,11 +298,15 @@
   Passing `include_hidden_fields=true` will include any hidden `Fields` in the response. Defaults to `false`
   Passing `include_sensitive_fields=true` will include any sensitive `Fields` in the response. Defaults to `false`.
 
+  Passing `include_editable_data_model=true` will check that the current user has write permissions for the table's
+  data model, rather than checking that they have data access perms for the table.
+
   These options are provided for use in the Admin Edit Metadata page."
-  [id include_sensitive_fields include_hidden_fields]
+  [id include_sensitive_fields include_hidden_fields include_editable_data_model]
   {include_sensitive_fields (s/maybe su/BooleanString)
-   include_hidden_fields (s/maybe su/BooleanString)}
-  (fetch-query-metadata (Table id) include_sensitive_fields include_hidden_fields))
+   include_hidden_fields (s/maybe su/BooleanString)
+   include_editable_data_model (s/maybe su/BooleanString)}
+  (fetch-query-metadata (Table id) include_sensitive_fields include_hidden_fields include_editable_data_model))
 
 (defn- card-result-metadata->virtual-fields
   "Return a sequence of 'virtual' fields metadata for the 'virtual' table for a Card in the Saved Questions 'virtual'

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -184,10 +184,7 @@
 
 (defn- perms-objects-set [{db-id :id} read-or-write]
   #{(case read-or-write
-      ;; We should let a user read a DB if they have write perms for the DB details *or* self-service data access.
-      ;; Since a user can have one or the other, we use `mi/has-any-permissions?` to check both read and write permission
-      ;; sets in the `can-read?` implementation.
-      :read (perms/data-perms-path db-id)
+      :read  (perms/data-perms-path db-id)
       :write (perms/db-details-write-perms-path db-id))})
 
 (u/strict-extend (class Database)
@@ -210,9 +207,7 @@
   mi/IObjectPermissions
   (merge mi/IObjectPermissionsDefaults
          {:perms-objects-set perms-objects-set
-          :can-read?         (mi/has-any-permissions?
-                              (partial mi/current-user-has-partial-permissions? :read)
-                              (partial mi/current-user-has-full-permissions? :write))
+          :can-read?         (partial mi/current-user-has-partial-permissions? :read)
           :can-write?        (partial mi/current-user-has-full-permissions? :write)}))
 
 

--- a/src/metabase/models/field.clj
+++ b/src/metabase/models/field.clj
@@ -147,7 +147,7 @@
 
 (defn- perms-objects-set
   "Calculate set of permissions required to access a Field. For the time being permissions to access a Field are the
-   same as permissions to access its parent Table, and there are not separate permissions for reading/writing."
+   same as permissions to access its parent Table."
   [{table-id :table_id, {db-id :db_id, schema :schema} :table} read-or-write]
   {:arglists '([field read-or-write])}
   (if db-id

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -344,13 +344,3 @@
   permissions for the paths returned by its implementation of `perms-objects-set`. (`read-or-write` is either `:read` or
   `:write` and passed to `perms-objects-set`; you'll usually want to partially bind it in the implementation map)."
   (partial check-perms-with-fn 'metabase.models.permissions/set-has-partial-permissions-for-set?))
-
-(defn has-any-permissions?
-  "Accepts multiple permission-checking functions, such as the ones returned by `current-user-has-full-permissions?`
-  and `current-user-has-partial-permissions?`, and returns a function which returns true if any permission functions
-  return true."
-  [& permission-check-fns]
-  (fn [object]
-    (->> ((apply juxt permission-check-fns) object)
-         (some true?)
-         boolean)))

--- a/src/metabase/models/secret.clj
+++ b/src/metabase/models/secret.clj
@@ -265,13 +265,10 @@
   details->secret association itself. Refer to the docstring for [[expand-inferred-secret-values]] for full details."
   {:added "0.42.0"}
   [database]
-  (when database
-   (update database
-           :details
-           (fn [details]
-             (reduce-over-details-secret-values (driver.u/database->driver database)
-                                                details
-                                                expand-inferred-secret-values)))))
+  (update database :details (fn [details]
+                              (reduce-over-details-secret-values (driver.u/database->driver database)
+                                                                 details
+                                                                 expand-inferred-secret-values))))
 
 ;;; -------------------------------------------------- JSON Encoder --------------------------------------------------
 

--- a/src/metabase/models/secret.clj
+++ b/src/metabase/models/secret.clj
@@ -265,10 +265,13 @@
   details->secret association itself. Refer to the docstring for [[expand-inferred-secret-values]] for full details."
   {:added "0.42.0"}
   [database]
-  (update database :details (fn [details]
-                              (reduce-over-details-secret-values (driver.u/database->driver database)
-                                                                 details
-                                                                 expand-inferred-secret-values))))
+  (when database
+   (update database
+           :details
+           (fn [details]
+             (reduce-over-details-secret-values (driver.u/database->driver database)
+                                                details
+                                                expand-inferred-secret-values)))))
 
 ;;; -------------------------------------------------- JSON Encoder --------------------------------------------------
 

--- a/src/metabase/models/table.clj
+++ b/src/metabase/models/table.clj
@@ -71,9 +71,7 @@
           :pre-delete     pre-delete})
   mi/IObjectPermissions
   (merge mi/IObjectPermissionsDefaults
-         {:can-read?         (mi/has-any-permissions?
-                              (partial mi/current-user-has-full-permissions? :read)
-                              (partial mi/current-user-has-full-permissions? :write))
+         {:can-read?         (partial mi/current-user-has-full-permissions? :read)
           :can-write?        (partial mi/current-user-has-full-permissions? :write)
           :perms-objects-set perms-objects-set}))
 

--- a/src/metabase/models/table.clj
+++ b/src/metabase/models/table.clj
@@ -48,8 +48,10 @@
 
 (defn- perms-objects-set [{db-id :db_id, schema :schema, table-id :id, :as table} read-or-write]
   ;; To read (e.g., fetch metadata) a Table you must have either self-service data permissions for the Table, or write
-  ;; permissions for the Table (detailed below). Since a user can have one or the other, we use `i/has-any-permissions?`
-  ;; to check both read and write permission sets in the `can-read?` implementation.
+  ;; permissions for the Table (detailed below). `can-read?` checks the former, while `can-write?` checks the latter;
+  ;; the permission-checking function to call when reading a Table depends on the context of the request. When reading
+  ;; Tables to power the admin data model page; `can-write?` should be called; in other contexts, `can-read?` should
+  ;; be called. (TODO: is there a way to clear up the semantics here?)
   ;;
   ;; To write a Table (e.g. update its metadata):
   ;;   * If Enterprise Edition code is available and the :advanced-permissions feature is enabled, you must have


### PR DESCRIPTION
The way data model and/or DB editing permission checks are currently done when calling DB, table and field APIs aren't _wrong_ per se (i.e. we're not exposing more data to users than they have access to), but they are a bit muddled. And there are some cases, like the examples in #22381, where we show DBs/tables to users in the main app because they have data model perms, even though they _don't_ have data access perms. This PR is my attempt to fix these issues and make the semantics consistent across all relevant APIs.

Main changes:
* `can-read?` on Databases, Tables and Fields check data access perms _only_, rather then also checking data model or DB detail editing perms. `can-write?` should be used for explicitly checking detail editing perms (for Databases) or data model perms (for Tables and Fields) even when just reading the object.
  * I acknowledge that this is still a bit confusing, but it's an artifact of these new permissions not cleanly fitting into the read/write binary. I'll keep thinking about ways to make this clearer.
* Updates Database, Table, and Field `GET` APIs to take a consistent `include_editable_data_model` query param. When `true`, we should only check data model perms when fetching the relevant objects; when `false`, we should only check data access perms. This is passed as `true` when loading data for the data model admin page for EE instances, but we weren't consistently accepting it for all relevant APIs.
* Similarly, Database `GET` APIs accept an `exclude_uneditable_details` parameter which has similar behavior, but checks detail editing permissions.
  * I don't like the names of these parameters (particularly the double negative of `exclude_uneditable_details`), but I'm keeping them in this PR to avoid having to touch the frontend. In a follow-up PR I am planning on exploring changing these to a single `permission_check` (or similar) parameter that accepts `data`, `data-model` or `details`, since these should all be mutually exclusive anyway.
* Added some new tests and refactored some others.

Resolves #22381