### PR TITLE
Custom expression: allow equality comparison of boolean expressions

### DIFF
--- a/frontend/src/metabase/lib/expressions/resolver.js
+++ b/frontend/src/metabase/lib/expressions/resolver.js
@@ -42,7 +42,13 @@ const isCompatible = (a, b) => {
   if (a === b) {
     return true;
   }
-  if (a === "expression" && (b === "number" || b === "string")) {
+  if (
+    a === "expression" &&
+    (b === "number" || b === "string" || b === "boolean")
+  ) {
+    return true;
+  }
+  if (a === "value" && (b === "number" || b === "string")) {
     return true;
   }
   if (a === "aggregation" && b === "number") {
@@ -85,7 +91,8 @@ export function resolve(expression, type = "expression", fn = undefined) {
     } else if (op === "true" || op === "false") {
       operandType = "expression";
     } else if (COMPARISON_OPS.includes(op)) {
-      operandType = "expression";
+      const isEquality = op === OP.Equal || op === OP.NotEqual;
+      operandType = isEquality ? "expression" : "value";
       const [firstOperand] = operands;
       if (typeof firstOperand === "number" && !Array.isArray(firstOperand)) {
         throw new ResolverError(

--- a/frontend/test/metabase/lib/expressions/resolver.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/resolver.unit.spec.js
@@ -96,6 +96,11 @@ describe("metabase/lib/expressions/resolve", () => {
       expect(() => filter(["<=", ["lower", A], "P"])).not.toThrow();
     });
 
+    it("should allow an equality comparison on boolean values", () => {
+      // X = IsNull(Y)
+      expect(() => filter(["=", X, ["is-null", Y]])).not.toThrow();
+    });
+
     it("should reject a less/greater comparison on functions returning boolean", () => {
       // IsEmpty([A]) < 0
       expect(() => filter(["<", ["is-empty", A], 0])).toThrow();


### PR DESCRIPTION
To verify:
1. New Question, Sample Database, Products table
2. Filter, Custom Expression, enter `([Rating] > 2) = startsWith([Vendor], "S")`. Note the **equality** comparison.

### Before

![image](https://user-images.githubusercontent.com/7288/167232207-e8a64e87-72b8-4722-acf9-1c393a66ff93.png)

### After

![image](https://user-images.githubusercontent.com/7288/167232241-0692ca1a-a02d-40ed-8f68-13e64f4a6222.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/22510)
<!-- Reviewable:end -->
