### PR TITLE
Fully specify identifier in Postgres JSON describe nested field column query (#22448)

### DIFF
--- a/src/metabase/driver/sql_jdbc/sync/describe_table.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_table.clj
@@ -330,16 +330,16 @@
   "Default implementation of `describe-nested-field-columns` for SQL JDBC drivers. Goes and queries the table if there are JSON columns for the nested contents."
   [driver spec table]
   (with-open [conn (jdbc/get-connection spec)]
-    (let [_map-inner       (fn [f xs] (map #(into {}
-                                                  (for [[k v] %]
-                                                    [k (f v)])) xs))
-          table-fields     (describe-table-fields driver conn table)
-          json-fields      (filter #(= (:semantic-type %) :type/SerializedJSON) table-fields)]
+    (let [table-identifier-info [(:schema table) (:name table)]
+
+          table-fields          (describe-table-fields driver conn table)
+          json-fields           (filter #(= (:semantic-type %) :type/SerializedJSON) table-fields)]
       (if (nil? (seq json-fields))
         #{}
-        (let [json-field-names (mapv (comp keyword :name) json-fields)
+        (let [json-field-names (mapv #(apply hx/identifier :field (into table-identifier-info [(:name %)])) json-fields)
+              table-identifier (apply hx/identifier :field table-identifier-info)
               sql-args         (hsql/format {:select json-field-names
-                                             :from   [(keyword (:name table))]
+                                             :from   [table-identifier]
                                              :limit  nested-field-sample-limit} {:quoting :ansi})
               query            (jdbc/reducible-query spec sql-args)
               field-types      (transduce describe-json-xform describe-json-rf query)

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -379,6 +379,28 @@
                    database
                    {:name "describe_json_table"}))))))))
 
+(deftest describe-nested-field-columns-identifier-test
+  (mt/test-driver :postgres
+    (testing "sync goes and runs with identifier if there is a schema other than default public one"
+      (drop-if-exists-and-create-db! "describe-json-with-schema-test")
+      (let [details (mt/dbdef->connection-details :postgres :db {:database-name "describe-json-with-schema-test"})
+            spec    (sql-jdbc.conn/connection-details->spec :postgres details)]
+        (jdbc/with-db-connection [conn (sql-jdbc.conn/connection-details->spec :postgres details)]
+          (jdbc/execute! spec [(str "CREATE SCHEMA bobdobbs;"
+                                    "CREATE TABLE bobdobbs.describe_json_table (trivial_json JSONB NOT NULL);"
+                                    "INSERT INTO bobdobbs.describe_json_table (trivial_json) VALUES ('{\"a\": 1}');")]))
+        (mt/with-temp Database [database {:engine :postgres, :details details}]
+          (is (= #{{:name "trivial_json → a",
+                   :database-type "integer",
+                   :base-type :type/Integer,
+                   :database-position 0,
+                   :visibility-type :normal,
+                   :nfc-path [:trivial_json "a"]}}
+                 (sql-jdbc.sync/describe-nested-field-columns
+                   :postgres
+                   database
+                   {:schema "bobdobbs" :name "describe_json_table"}))))))))
+
 (deftest describe-big-nested-field-columns-test
   (mt/test-driver :postgres
     (testing "blank out if huge. blank out instead of silently limiting"

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -391,11 +391,11 @@
                                     "INSERT INTO bobdobbs.describe_json_table (trivial_json) VALUES ('{\"a\": 1}');")]))
         (mt/with-temp Database [database {:engine :postgres, :details details}]
           (is (= #{{:name "trivial_json → a",
-                   :database-type "integer",
-                   :base-type :type/Integer,
-                   :database-position 0,
-                   :visibility-type :normal,
-                   :nfc-path [:trivial_json "a"]}}
+                    :database-type "integer",
+                    :base-type :type/Integer,
+                    :database-position 0,
+                    :visibility-type :normal,
+                    :nfc-path [:trivial_json "a"]}}
                  (sql-jdbc.sync/describe-nested-field-columns
                    :postgres
                    database


### PR DESCRIPTION
Root cause of #22448 is that the describe-nested-field sql ad hoc query doesn't specify the whole identifier. Actual json-query does but this was an oversight. Fixed w/ regression test