### PR TITLE
Always show main sidebar with white bg

### DIFF
--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.styled.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.styled.tsx
@@ -30,7 +30,6 @@ export const Sidebar = styled.aside<{ isOpen: boolean }>`
   flex-shrink: 0;
   align-items: center;
   padding: 0.5rem 0;
-  background-color: ${color("nav")};
 
   overflow: auto;
   overflow-x: hidden;


### PR DESCRIPTION
We have just removed the option to configure a background color for the main side nav.

This PR will display the sidebar with a white background even if the configuration has been set to another color.

### How to Test

1. Go to a previous state in our repo: `git checkout 19c3700d4b`
2. Go http://localhost:3000/admin/settings/whitelabel
3. Choose some color other than white for `nav` (second option)
4. Go back to this branch: `git checkout display-side-nav-only-with-white-background`

Visit http://localhost:3000/

Left-hand sidebar should have a white background.

<img width="500" alt="image" src="https://user-images.githubusercontent.com/380816/167433668-77dbb3a7-6e08-4e90-9153-31a2f18af928.png">

Part of fix #22221