### PR TITLE
Update and persist document title when cancelling query run

### DIFF
--- a/frontend/src/metabase/query_builder/actions/querying.js
+++ b/frontend/src/metabase/query_builder/actions/querying.js
@@ -162,7 +162,9 @@ const loadStartUIControls = createThunkAction(
   () => (dispatch, getState) => {
     dispatch(setDocumentTitle(t`Doing Science...`));
     const timeoutId = setTimeout(() => {
-      dispatch(setDocumentTitle(t`Still Here...`));
+      if (document.title.includes(t`Doing Science...`)) {
+        dispatch(setDocumentTitle(t`Still Here...`));
+      }
     }, 10000);
     dispatch(setDocumentTitleTimeoutId(timeoutId));
   },
@@ -234,6 +236,8 @@ export const cancelQuery = () => (dispatch, getState) => {
     if (cancelQueryDeferred) {
       cancelQueryDeferred.resolve();
     }
+    dispatch(setDocumentTitle(""));
+
     return { type: CANCEL_QUERY };
   }
 };

--- a/frontend/src/metabase/query_builder/actions/querying.js
+++ b/frontend/src/metabase/query_builder/actions/querying.js
@@ -160,12 +160,19 @@ export const runQuestionQuery = ({
 const loadStartUIControls = createThunkAction(
   LOAD_START_UI_CONTROLS,
   () => (dispatch, getState) => {
-    dispatch(setDocumentTitle(t`Doing Science...`));
+    const title = {
+      onceQueryIsRun: t`Doing Science...`,
+      ifQueryTakesLong: t`Still Here...`,
+    };
+
+    dispatch(setDocumentTitle(title.onceQueryIsRun));
+
     const timeoutId = setTimeout(() => {
-      if (document.title.includes(t`Doing Science...`)) {
-        dispatch(setDocumentTitle(t`Still Here...`));
+      if (document.title.includes(title.onceQueryIsRun)) {
+        dispatch(setDocumentTitle(title.ifQueryTakesLong));
       }
     }, 10000);
+
     dispatch(setDocumentTitleTimeoutId(timeoutId));
   },
 );


### PR DESCRIPTION
Fixes #22413 

### How to Test

#### a. Cancelling the query 10 or fewer seconds before it started

1. &plus; New
2. SQL Query
3. Add `SELECT pg_sleep(60), 1;` as the query
4. Run query

You should see `Doing science… · Metabase` as the browser tab title.

5. Before 10 seconds pass, cancel the query.

You should see `Question · Metabase` as the browser tab title.

#### b. Cancelling the query 10 or more seconds before it started

1. &plus; New
2. SQL Query
3. Add `SELECT pg_sleep(60), 1;` as the query
4. Run query
5. Wait for more than 10 seconds.

You should see `Still here… · Metabase` as the browser tab title.

5. Cancel the query.

You should see `Question · Metabase` as the browser tab title.
