### PR TITLE
Add `experimental-enable-actions` feature flag

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -124,7 +124,9 @@
                                         java-time                                                       t
                                         metabase-enterprise.audit-app.pages.common                      common
                                         metabase-enterprise.sandbox.api.table                           table
+                                        metabase.actions                                                actions
                                         metabase.analytics.stats                                        stats
+                                        metabase.api.actions                                            api.actions
                                         metabase.api.activity                                           api.activity
                                         metabase.api.alert                                              api.alert
                                         metabase.api.automagic-dashboards                               api.magic

--- a/src/metabase/actions.clj
+++ b/src/metabase/actions.clj
@@ -1,5 +1,5 @@
 (ns metabase.actions
-  "Code related to the new write Actions "
+  "Code related to the new writeback Actions."
   (:require [metabase.models.setting :as setting]
             [metabase.util.i18n :as i18n]))
 

--- a/src/metabase/actions.clj
+++ b/src/metabase/actions.clj
@@ -1,0 +1,10 @@
+(ns metabase.actions
+  "Code related to the new write Actions "
+  (:require [metabase.models.setting :as setting]
+            [metabase.util.i18n :as i18n]))
+
+(setting/defsetting experimental-enable-actions
+  (i18n/deferred-tru "Whether to enable using the new experimental Actions features globally. (Actions must also be enabled for each Database.)")
+  :default false
+  :type :boolean
+  :visibility :public)

--- a/src/metabase/api/actions.clj
+++ b/src/metabase/api/actions.clj
@@ -15,17 +15,10 @@
   "Ring middleware that checks that the [[metabase.actions/experimental-enable-actions]] feature flag is enabled, and
   returns a 403 Unauthorized response "
   [handler]
-  (letfn [(actions-exception []
-            (ex-info (i18n/tru "Actions are not enabled.")
-                     {:status-code 400}))]
-    (fn
-      ([request]
-       (when-not (actions/experimental-enable-actions)
-         (throw (actions-exception)))
-       (handler request))
-      ([request respond raise]
-       (if (actions/experimental-enable-actions)
-         (handler request respond raise)
-         (raise (actions-exception)))))))
+  (fn [request respond raise]
+    (if (actions/experimental-enable-actions)
+      (handler request respond raise)
+      (raise (ex-info (i18n/tru "Actions are not enabled.")
+                      {:status-code 400})))))
 
 (api/define-routes +check-actions-enabled)

--- a/src/metabase/api/actions.clj
+++ b/src/metabase/api/actions.clj
@@ -1,8 +1,8 @@
 (ns metabase.api.actions
   "`/api/actions/` endpoints."
   (:require [compojure.core :refer [GET]]
-            [metabase.api.common :as api]
             [metabase.actions :as actions]
+            [metabase.api.common :as api]
             [metabase.util.i18n :as i18n]))
 
 (api/defendpoint GET "/dummy"

--- a/src/metabase/api/routes.clj
+++ b/src/metabase/api/routes.clj
@@ -1,6 +1,7 @@
 (ns metabase.api.routes
   (:require [compojure.core :refer [context defroutes]]
             [compojure.route :as route]
+            [metabase.api.actions :as api.actions]
             [metabase.api.activity :as api.activity]
             [metabase.api.alert :as api.alert]
             [metabase.api.automagic-dashboards :as api.magic]
@@ -61,6 +62,7 @@
 
 (defroutes ^{:doc "Ring routes for API endpoints."} routes
   ee-routes
+  (context "/actions"              [] (+auth api.actions/routes))
   (context "/activity"             [] (+auth api.activity/routes))
   (context "/alert"                [] (+auth api.alert/routes))
   (context "/automagic-dashboards" [] (+auth api.magic/routes))

--- a/test/metabase/api/actions_test.clj
+++ b/test/metabase/api/actions_test.clj
@@ -1,0 +1,15 @@
+(ns metabase.api.actions-test
+  (:require [clojure.test :refer :all]
+            [metabase.test :as mt]))
+
+;; TODO -- once we add a new endpoint rework these tests to test those and remove the dummy endpoint.
+(deftest global-feature-flag-test
+  (testing "Enable or disable endpoints based on the `experimental-enable-actions` feature flag"
+    (testing "Should return a 400 if feature flag is disabled"
+      (mt/with-temporary-setting-values [experimental-enable-actions false]
+        (is (= "Actions are not enabled."
+               (mt/user-http-request :crowberto :get 400 "actions/dummy")))))
+    (testing "Should work if feature flag is enabled"
+      (mt/with-temporary-setting-values [experimental-enable-actions true]
+        (is (= {:dummy true}
+               (mt/user-http-request :crowberto :get 200 "actions/dummy")))))))

--- a/test/metabase/api/actions_test.clj
+++ b/test/metabase/api/actions_test.clj
@@ -1,6 +1,9 @@
 (ns metabase.api.actions-test
   (:require [clojure.test :refer :all]
+            [metabase.api.actions :as api.actions]
             [metabase.test :as mt]))
+
+(comment api.actions/keep-me)
 
 ;; TODO -- once we add a new endpoint rework these tests to test those and remove the dummy endpoint.
 (deftest global-feature-flag-test


### PR DESCRIPTION
Resolves #22551
Resolves #22555

Adds a new `experimental-enable-actions` Setting that will be used as a feature flag for #22542. For the time being this Setting can be set with the usual API endpoints but we do not intend to add UI for it to the admin panel.

Added a placeholder `GET /api/actions/dummy` endpoint for testing its functionality and ` metabase.api.actions` namespace with middleware that returns a 400 error response for any `/api/actions` route if the feature flag is disabled. We can remove this endpoint once we have some other endpoints to test against.