### PR TITLE
Derive parameter operator, not passing it as a prop

### DIFF
--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
@@ -19,7 +19,6 @@ import { fetchField, fetchFieldValues } from "metabase/redux/metadata";
 import { getMetadata } from "metabase/selectors/metadata";
 
 import { getParameterIconName } from "metabase/parameters/utils/ui";
-import { deriveFieldOperatorFromParameter } from "metabase/parameters/utils/operators";
 import { isDashboardParameterWithoutMapping } from "metabase/parameters/utils/dashboards";
 import { hasFieldValues } from "metabase/parameters/utils/fields";
 
@@ -306,7 +305,6 @@ function Widget({
         setValue={setValue}
         isEditing={isEditing}
         focusChanged={onFocusChanged}
-        operator={deriveFieldOperatorFromParameter(parameter)}
       />
     );
   } else {

--- a/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/ParameterFieldWidget.jsx
+++ b/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/ParameterFieldWidget.jsx
@@ -12,6 +12,8 @@ import Button from "metabase/core/components/Button";
 
 import { normalizeValue } from "./normalizeValue";
 
+import { deriveFieldOperatorFromParameter } from "metabase/parameters/utils/operators";
+
 import cx from "classnames";
 import {
   getFilterArgumentFormatOptions,
@@ -23,7 +25,6 @@ const propTypes = {
   dashboard: PropTypes.object,
   fields: PropTypes.array.isRequired,
   isEditing: PropTypes.bool.isRequired,
-  operator: PropTypes.object.isRequired,
   parameter: PropTypes.object.isRequired,
   parameters: PropTypes.array.isRequired,
   parentFocusChanged: PropTypes.bool,
@@ -69,11 +70,11 @@ export default class ParameterFieldWidget extends Component {
       isEditing,
       fields,
       parentFocusChanged,
-      operator,
       parameter,
       parameters,
       dashboard,
     } = this.props;
+    const operator = deriveFieldOperatorFromParameter(parameter);
     const { isFocused, widgetWidth } = this.state;
     const { numFields = 1, multi = false, verboseName } = operator || {};
     const savedValue = normalizeValue(this.props.value);


### PR DESCRIPTION
Verify manually by creating a dashboard with a parameter:
1. Browse data, Sample Database, Products
2. Save as a question, add to a dashboard
3. Edit dashboard, Add a filter, choose `Text or Category` and `Dropdown`
4. Column to filter on `Category`, Done

Ensure that everything works exactly the same **before** and **after** this PR.

In case of doubt, place a break-point in `ParameterFieldWidget.render()` and inspect the value of `operator`.

![image](https://user-images.githubusercontent.com/7288/167520485-13818cbb-95c4-490d-9e5b-42997c71d821.png)
