### PR TITLE
Don’t enable Add Group button with string of white space as a group name

### DIFF
--- a/frontend/src/metabase/admin/people/components/GroupsListing.jsx
+++ b/frontend/src/metabase/admin/people/components/GroupsListing.jsx
@@ -331,7 +331,7 @@ export default class GroupsListing extends Component {
       // ok, fire off API call to change the group
       MetabaseAnalytics.trackStructEvent("People Groups", "Group Updated");
       try {
-        await this.props.update({ id: group.id, name: group.name });
+        await this.props.update({ id: group.id, name: group.name.trim() });
         this.setState({ groupBeingEdited: null });
       } catch (error) {
         console.error("Error updating group name:", error);

--- a/frontend/src/metabase/admin/people/components/GroupsListing.jsx
+++ b/frontend/src/metabase/admin/people/components/GroupsListing.jsx
@@ -30,7 +30,7 @@ import { AddRow } from "./AddRow";
 // ------------------------------------------------------------ Add Group ------------------------------------------------------------
 
 function AddGroupRow({ text, onCancelClicked, onCreateClicked, onTextChange }) {
-  const textIsValid = text && text.length;
+  const textIsValid = text?.trim().length;
   return (
     <tr>
       <td colSpan="3" style={{ padding: 0 }}>
@@ -271,7 +271,7 @@ export default class GroupsListing extends Component {
     MetabaseAnalytics.trackStructEvent("People Groups", "Group Added");
 
     try {
-      await this.props.create({ name: this.state.text });
+      await this.props.create({ name: this.state.text.trim() });
       this.setState({
         showAddGroupRow: false,
         text: "",

--- a/frontend/src/metabase/home/containers/ArchiveApp.jsx
+++ b/frontend/src/metabase/home/containers/ArchiveApp.jsx
@@ -14,7 +14,7 @@ import VirtualizedList from "metabase/components/VirtualizedList";
 import Search from "metabase/entities/search";
 import listSelect from "metabase/hoc/ListSelect";
 
-import { getIsNavbarOpen, openNavbar } from "metabase/redux/app";
+import { openNavbar } from "metabase/redux/app";
 import { getUserIsAdmin } from "metabase/selectors/user";
 import { isSmallScreen } from "metabase/lib/dom";
 
@@ -29,7 +29,6 @@ import {
 
 const mapStateToProps = (state, props) => ({
   isAdmin: getUserIsAdmin(state, props),
-  isNavbarOpen: getIsNavbarOpen(state),
 });
 
 const mapDispatchToProps = {
@@ -55,7 +54,6 @@ export default class ArchiveApp extends Component {
   render() {
     const {
       isAdmin,
-      isNavbarOpen,
       list,
       reload,
 
@@ -114,10 +112,7 @@ export default class ArchiveApp extends Component {
             )}
           </Card>
         </ArchiveBody>
-        <BulkActionBar
-          showing={selected.length > 0}
-          isNavbarOpen={isNavbarOpen}
-        >
+        <BulkActionBar showing={selected.length > 0}>
           <ArchiveBarContent>
             <SelectionControls {...this.props} />
             <BulkActionControls {...this.props} />

--- a/frontend/src/metabase/home/containers/ArchiveApp.jsx
+++ b/frontend/src/metabase/home/containers/ArchiveApp.jsx
@@ -14,7 +14,7 @@ import VirtualizedList from "metabase/components/VirtualizedList";
 import Search from "metabase/entities/search";
 import listSelect from "metabase/hoc/ListSelect";
 
-import { openNavbar } from "metabase/redux/app";
+import { getIsNavbarOpen, openNavbar } from "metabase/redux/app";
 import { getUserIsAdmin } from "metabase/selectors/user";
 import { isSmallScreen } from "metabase/lib/dom";
 
@@ -29,6 +29,7 @@ import {
 
 const mapStateToProps = (state, props) => ({
   isAdmin: getUserIsAdmin(state, props),
+  isNavbarOpen: getIsNavbarOpen(state),
 });
 
 const mapDispatchToProps = {
@@ -54,6 +55,7 @@ export default class ArchiveApp extends Component {
   render() {
     const {
       isAdmin,
+      isNavbarOpen,
       list,
       reload,
 
@@ -112,7 +114,10 @@ export default class ArchiveApp extends Component {
             )}
           </Card>
         </ArchiveBody>
-        <BulkActionBar showing={selected.length > 0}>
+        <BulkActionBar
+          showing={selected.length > 0}
+          isNavbarOpen={isNavbarOpen}
+        >
           <ArchiveBarContent>
             <SelectionControls {...this.props} />
             <BulkActionControls {...this.props} />


### PR DESCRIPTION
Fixes #22562

### How to test

1. Go to http://localhost:3000/admin/people/groups
2. Click on "Create a group"
3. For the group name, enter one or more empty spaces

"Add" button should not become enabled.

4. Add a group with a name surrounded by white spaces, such as "     mmmmm   ".

Saved group name should be trimmed, therefore be "mmmmm".

<img width="500" alt="image" src="https://user-images.githubusercontent.com/380816/167587527-5b774460-2f05-482c-b1b1-dc2611c998e9.png">
