### PR TITLE
Clean up `initializeQB` action

### DIFF
--- a/frontend/src/metabase-lib/lib/queries/NativeQuery.ts
+++ b/frontend/src/metabase-lib/lib/queries/NativeQuery.ts
@@ -281,6 +281,10 @@ export default class NativeQuery extends AtomicQuery {
     return Object.values(this.templateTagsMap());
   }
 
+  hasSnippets() {
+    return this.templateTags().some(t => t.type === "snippet");
+  }
+
   templateTagsWithoutSnippets(): TemplateTag[] {
     return this.templateTags().filter(t => t.type !== "snippet");
   }

--- a/frontend/src/metabase-lib/mocks.ts
+++ b/frontend/src/metabase-lib/mocks.ts
@@ -1,0 +1,130 @@
+import {
+  Card,
+  SavedCard,
+  UnsavedCard,
+  StructuredDatasetQuery,
+  NativeDatasetQuery,
+} from "metabase-types/types/Card";
+
+import {
+  SAMPLE_DATABASE,
+  ORDERS,
+  metadata,
+} from "__support__/sample_database_fixture";
+
+import Question from "./lib/Question";
+import NativeQuery from "./lib/queries/NativeQuery";
+import StructuredQuery from "./lib/queries/StructuredQuery";
+
+type NativeSavedCard = SavedCard<NativeDatasetQuery>;
+type NativeUnsavedCard = UnsavedCard<NativeDatasetQuery>;
+type StructuredSavedCard = SavedCard<StructuredDatasetQuery>;
+type StructuredUnsavedCard = UnsavedCard<StructuredDatasetQuery>;
+
+const BASE_GUI_QUESTION: StructuredUnsavedCard = {
+  display: "table",
+  visualization_settings: {},
+  dataset_query: {
+    type: "query",
+    database: SAMPLE_DATABASE?.id,
+    query: {
+      "source-table": ORDERS.id,
+    },
+  },
+};
+
+const BASE_NATIVE_QUESTION: NativeUnsavedCard = {
+  display: "table",
+  visualization_settings: {},
+  dataset_query: {
+    type: "native",
+    database: SAMPLE_DATABASE?.id,
+    native: {
+      query: "select * from orders",
+      "template-tags": {},
+    },
+  },
+};
+
+const SAVED_QUESTION = {
+  id: 1,
+  name: "Q1",
+  description: "",
+  collection_id: null,
+};
+
+export function getQuestion(card: Partial<Card>) {
+  return new Question(
+    {
+      ...BASE_GUI_QUESTION,
+      display: "table",
+      visualization_settings: {},
+      ...card,
+    },
+    metadata,
+  );
+}
+
+export function getAdHocQuestion(card?: Partial<StructuredUnsavedCard>) {
+  return getQuestion({ ...BASE_GUI_QUESTION, ...card });
+}
+
+export function getCleanStructuredQuestion(
+  card?: Partial<StructuredUnsavedCard>,
+) {
+  const question = getAdHocQuestion(card);
+
+  const query = (question.query() as StructuredQuery).setSourceTableId(
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    undefined,
+  );
+
+  return question.setQuery(query);
+}
+
+export function getUnsavedNativeQuestion(card?: Partial<NativeUnsavedCard>) {
+  return getQuestion({ ...BASE_NATIVE_QUESTION, ...card });
+}
+
+export function getCleanNativeQuestion(card?: Partial<NativeUnsavedCard>) {
+  const question = getUnsavedNativeQuestion(card);
+  const query = (question.query() as NativeQuery).setQueryText("");
+  return question.setQuery(query);
+}
+
+export function getSavedStructuredQuestion(
+  card?: Partial<StructuredSavedCard>,
+) {
+  return getQuestion({ ...BASE_GUI_QUESTION, ...SAVED_QUESTION, ...card });
+}
+
+export function getSavedNativeQuestion(card?: Partial<NativeSavedCard>) {
+  return getQuestion({
+    ...BASE_NATIVE_QUESTION,
+    ...SAVED_QUESTION,
+    ...card,
+  });
+}
+
+export function getStructuredModel(
+  card?: Omit<Partial<StructuredSavedCard>, "dataset">,
+) {
+  return getQuestion({
+    ...BASE_GUI_QUESTION,
+    ...SAVED_QUESTION,
+    ...card,
+    dataset: true,
+  });
+}
+
+export function getNativeModel(
+  card?: Omit<Partial<NativeSavedCard>, "dataset">,
+) {
+  return getQuestion({
+    ...BASE_NATIVE_QUESTION,
+    ...SAVED_QUESTION,
+    ...card,
+    dataset: true,
+  });
+}

--- a/frontend/src/metabase-types/store/state.ts
+++ b/frontend/src/metabase-types/store/state.ts
@@ -17,3 +17,7 @@ export interface State {
   settings: SettingsState;
   setup: SetupState;
 }
+
+export type Dispatch<T = unknown> = (action: T) => void;
+
+export type GetState = () => State;

--- a/frontend/src/metabase-types/types/Card.ts
+++ b/frontend/src/metabase-types/types/Card.ts
@@ -14,6 +14,10 @@ export type UnsavedCard<Q = DatasetQuery> = {
   visualization_settings: VisualizationSettings;
   parameters?: Array<Parameter>;
 
+  // If coming from dashboard
+  dashboardId?: number;
+  dashcardId?: number;
+
   // Not part of the card API contract, a field used by query builder for showing lineage
   original_card_id?: CardId;
 };
@@ -26,6 +30,7 @@ export type SavedCard<Q = DatasetQuery> = UnsavedCard<Q> & {
   collection_id: number | null;
   can_write: boolean;
   public_uuid: string;
+  archived?: boolean;
 };
 
 export type Card<Q = DatasetQuery> = SavedCard<Q> | UnsavedCard<Q>;

--- a/frontend/src/metabase-types/types/Card.ts
+++ b/frontend/src/metabase-types/types/Card.ts
@@ -8,8 +8,8 @@ export type VisualizationSettings = {
   [key: string]: any;
 };
 
-export type UnsavedCard = {
-  dataset_query: DatasetQuery;
+export type UnsavedCard<Q = DatasetQuery> = {
+  dataset_query: Q;
   display: string;
   visualization_settings: VisualizationSettings;
   parameters?: Array<Parameter>;
@@ -18,16 +18,17 @@ export type UnsavedCard = {
   original_card_id?: CardId;
 };
 
-export type SavedCard = UnsavedCard & {
+export type SavedCard<Q = DatasetQuery> = UnsavedCard<Q> & {
   id: CardId;
   name?: string;
   description?: string;
   dataset?: boolean;
+  collection_id: number | null;
   can_write: boolean;
   public_uuid: string;
 };
 
-export type Card = SavedCard | UnsavedCard;
+export type Card<Q = DatasetQuery> = SavedCard<Q> | UnsavedCard<Q>;
 
 export type StructuredDatasetQuery = {
   type: "query";

--- a/frontend/src/metabase-types/types/Query.ts
+++ b/frontend/src/metabase-types/types/Query.ts
@@ -47,7 +47,13 @@ export type DatetimeUnit =
 
 export type TemplateTagId = string;
 export type TemplateTagName = string;
-export type TemplateTagType = "card" | "text" | "number" | "date" | "dimension";
+export type TemplateTagType =
+  | "card"
+  | "text"
+  | "number"
+  | "date"
+  | "dimension"
+  | "snippet";
 
 export type TemplateTag = {
   id: TemplateTagId;
@@ -58,6 +64,10 @@ export type TemplateTag = {
   "widget-type"?: ParameterType;
   required?: boolean;
   default?: string;
+
+  // Snippet specific
+  "snippet-id"?: number;
+  "snippet-name"?: string;
 };
 
 export type TemplateTags = { [key: TemplateTagName]: TemplateTag };

--- a/frontend/src/metabase/lib/query/normalize.js
+++ b/frontend/src/metabase/lib/query/normalize.js
@@ -1,0 +1,1 @@
+export { normalize } from "cljs/metabase.mbql.js";

--- a/frontend/src/metabase/query_builder/actions/core/core.js
+++ b/frontend/src/metabase/query_builder/actions/core/core.js
@@ -1,15 +1,9 @@
 import _ from "underscore";
-import { assocIn, getIn } from "icepick";
-import querystring from "querystring";
+import { assocIn } from "icepick";
 import { createAction } from "redux-actions";
-import { normalize } from "cljs/metabase.mbql.js";
 
 import * as MetabaseAnalytics from "metabase/lib/analytics";
-import {
-  deserializeCardFromUrl,
-  loadCard,
-  startNewCard,
-} from "metabase/lib/card";
+import { loadCard } from "metabase/lib/card";
 import { isAdHocModelQuestion } from "metabase/lib/data-modeling/utils";
 import { shouldOpenInBlankWindow } from "metabase/lib/dom";
 import * as Urls from "metabase/lib/urls";
@@ -18,29 +12,21 @@ import { createThunkAction } from "metabase/lib/redux";
 
 import { cardIsEquivalent, cardQueryIsEquivalent } from "metabase/meta/Card";
 
-import { DashboardApi } from "metabase/services";
-
 import { getCardAfterVisualizationClick } from "metabase/visualizations/lib/utils";
 import { getPersistableDefaultSettingsForSeries } from "metabase/visualizations/lib/settings/visualization";
 
-import { openUrl, setErrorPage } from "metabase/redux/app";
+import { openUrl } from "metabase/redux/app";
 import { setRequestUnloaded } from "metabase/redux/requests";
 import { loadMetadataForQueries } from "metabase/redux/metadata";
 import { getMetadata } from "metabase/selectors/metadata";
 
-import Databases from "metabase/entities/databases";
 import Questions from "metabase/entities/questions";
-import Snippets from "metabase/entities/snippets";
 import { fetchAlertsForQuestion } from "metabase/alert/alert";
-
-import { getValueAndFieldIdPopulatedParametersFromCard } from "metabase/parameters/utils/cards";
-import { hasMatchingParameters } from "metabase/parameters/utils/dashboards";
-import { getParameterValuesByIdFromQueryParams } from "metabase/parameters/utils/parameter-values";
 
 import Question from "metabase-lib/lib/Question";
 import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
 
-import { trackNewQuestionSaved } from "../analytics";
+import { trackNewQuestionSaved } from "../../analytics";
 import {
   getCard,
   getFirstQueryResult,
@@ -53,50 +39,21 @@ import {
   getResultsMetadata,
   getTransformedSeries,
   isBasedOnExistingQuestion,
-} from "../selectors";
-import {
-  getNextTemplateTagVisibilityState,
-  getQueryBuilderModeFromLocation,
-} from "../utils";
+} from "../../selectors";
+import { getNextTemplateTagVisibilityState } from "../../utils";
 
-import { redirectToNewQuestionFlow, updateUrl } from "./navigation";
-import { setIsShowingTemplateTagsEditor } from "./native";
-import { zoomInRow } from "./object-detail";
-import { cancelQuery, clearQueryResult, runQuestionQuery } from "./querying";
+import { updateUrl } from "../navigation";
+import { setIsShowingTemplateTagsEditor } from "../native";
+import { zoomInRow } from "../object-detail";
+import { clearQueryResult, runQuestionQuery } from "../querying";
 import {
   onCloseSidebars,
   onCloseQuestionDetails,
   setQueryBuilderMode,
-} from "./ui";
+} from "../ui";
 
 export const RESET_QB = "metabase/qb/RESET_QB";
 export const resetQB = createAction(RESET_QB);
-
-async function verifyMatchingDashcardAndParameters({
-  dispatch,
-  dashboardId,
-  dashcardId,
-  cardId,
-  parameters,
-  metadata,
-}) {
-  try {
-    const dashboard = await DashboardApi.get({ dashId: dashboardId });
-    if (
-      !hasMatchingParameters({
-        dashboard,
-        dashcardId,
-        cardId,
-        parameters,
-        metadata,
-      })
-    ) {
-      dispatch(setErrorPage({ status: 403 }));
-    }
-  } catch (error) {
-    dispatch(setErrorPage(error));
-  }
-}
 
 /**
  * Saves to `visualization_settings` property of a question those visualization settings that
@@ -130,305 +87,6 @@ function hasNewColumns(question, queryResult) {
     query instanceof StructuredQuery ? query.columnNames() : [];
   return _.difference(nextColumns, previousColumns).length > 0;
 }
-
-export const INITIALIZE_QB = "metabase/qb/INITIALIZE_QB";
-export const initializeQB = (location, params) => {
-  return async (dispatch, getState) => {
-    const queryParams = location.query;
-    // do this immediately to ensure old state is cleared before the user sees it
-    dispatch(resetQB());
-    dispatch(cancelQuery());
-
-    const { currentUser } = getState();
-
-    const cardId = Urls.extractEntityId(params.slug);
-    let card, originalCard;
-
-    const {
-      mode: queryBuilderMode,
-      ...otherUiControls
-    } = getQueryBuilderModeFromLocation(location);
-    const uiControls = {
-      isEditing: false,
-      isShowingTemplateTagsEditor: false,
-      queryBuilderMode,
-      ...otherUiControls,
-    };
-
-    // load up or initialize the card we'll be working on
-    let options = {};
-    let serializedCard;
-    // hash can contain either query params starting with ? or a base64 serialized card
-    if (location.hash) {
-      const hash = location.hash.replace(/^#/, "");
-      if (hash.charAt(0) === "?") {
-        options = querystring.parse(hash.substring(1));
-      } else {
-        serializedCard = hash;
-      }
-    }
-
-    let preserveParameters = false;
-    let snippetFetch;
-    if (cardId || serializedCard) {
-      // existing card being loaded
-      try {
-        // if we have a serialized card then unpack and use it
-        if (serializedCard) {
-          card = deserializeCardFromUrl(serializedCard);
-          // if serialized query has database we normalize syntax to support older mbql
-          if (card.dataset_query.database != null) {
-            card.dataset_query = normalize(card.dataset_query);
-          }
-        } else {
-          card = {};
-        }
-
-        const deserializedCard = card;
-
-        // load the card either from `cardId` parameter or the serialized card
-        if (cardId) {
-          card = await loadCard(cardId);
-          // when we are loading from a card id we want an explicit clone of the card we loaded which is unmodified
-          originalCard = Utils.copy(card);
-          // for showing the "started from" lineage correctly when adding filters/breakouts and when going back and forth
-          // in browser history, the original_card_id has to be set for the current card (simply the id of card itself for now)
-          card.original_card_id = card.id;
-
-          // if there's a card in the url, it may have parameters from a dashboard
-          if (deserializedCard && deserializedCard.parameters) {
-            const metadata = getMetadata(getState());
-            const { dashboardId, dashcardId, parameters } = deserializedCard;
-            verifyMatchingDashcardAndParameters({
-              dispatch,
-              dashboardId,
-              dashcardId,
-              cardId,
-              parameters,
-              metadata,
-            });
-
-            card.parameters = parameters;
-            card.dashboardId = dashboardId;
-            card.dashcardId = dashcardId;
-          }
-        } else if (card.original_card_id) {
-          const deserializedCard = card;
-          // deserialized card contains the card id, so just populate originalCard
-          originalCard = await loadCard(card.original_card_id);
-
-          if (cardIsEquivalent(deserializedCard, originalCard)) {
-            card = Utils.copy(originalCard);
-
-            if (
-              !cardIsEquivalent(deserializedCard, originalCard, {
-                checkParameters: true,
-              })
-            ) {
-              const metadata = getMetadata(getState());
-              const { dashboardId, dashcardId, parameters } = deserializedCard;
-              verifyMatchingDashcardAndParameters({
-                dispatch,
-                dashboardId,
-                dashcardId,
-                cardId: card.id,
-                parameters,
-                metadata,
-              });
-
-              card.parameters = parameters;
-              card.dashboardId = dashboardId;
-              card.dashcardId = dashcardId;
-            }
-          }
-        }
-        // if this card has any snippet tags we might need to fetch snippets pending permissions
-        if (
-          Object.values(
-            getIn(card, ["dataset_query", "native", "template-tags"]) || {},
-          ).filter(t => t.type === "snippet").length > 0
-        ) {
-          const dbId = card.database_id;
-          let database = Databases.selectors.getObject(getState(), {
-            entityId: dbId,
-          });
-          // if we haven't already loaded this database, block on loading dbs now so we can check write permissions
-          if (!database) {
-            await dispatch(Databases.actions.fetchList());
-            database = Databases.selectors.getObject(getState(), {
-              entityId: dbId,
-            });
-          }
-
-          // database could still be missing if the user doesn't have any permissions
-          // if the user has native permissions against this db, fetch snippets
-          if (database && database.native_permissions === "write") {
-            snippetFetch = dispatch(Snippets.actions.fetchList());
-          }
-        }
-
-        MetabaseAnalytics.trackStructEvent(
-          "QueryBuilder",
-          "Query Loaded",
-          card.dataset_query.type,
-        );
-
-        // if we have deserialized card from the url AND loaded a card by id then the user should be dropped into edit mode
-        uiControls.isEditing = !!options.edit;
-
-        // if this is the users first time loading a saved card on the QB then show them the newb modal
-        if (cardId && currentUser.is_qbnewb) {
-          uiControls.isShowingNewbModal = true;
-          MetabaseAnalytics.trackStructEvent("QueryBuilder", "Show Newb Modal");
-        }
-
-        if (card.archived) {
-          // use the error handler in App.jsx for showing "This question has been archived" message
-          dispatch(
-            setErrorPage({
-              data: {
-                error_code: "archived",
-              },
-              context: "query-builder",
-            }),
-          );
-          card = null;
-        }
-
-        if (!card.dataset && location.pathname.startsWith("/model")) {
-          dispatch(
-            setErrorPage({
-              data: {
-                error_code: "not-found",
-              },
-              context: "query-builder",
-            }),
-          );
-          card = null;
-        }
-
-        preserveParameters = true;
-      } catch (error) {
-        console.warn("initializeQb failed because of an error:", error);
-        card = null;
-        dispatch(setErrorPage(error));
-      }
-    } else {
-      // we are starting a new/empty card
-      // if no options provided in the hash, redirect to the new question flow
-      if (
-        !options.db &&
-        !options.table &&
-        !options.segment &&
-        !options.metric
-      ) {
-        await dispatch(redirectToNewQuestionFlow());
-        return;
-      }
-
-      const databaseId = options.db ? parseInt(options.db) : undefined;
-      card = startNewCard("query", databaseId);
-
-      // initialize parts of the query based on optional parameters supplied
-      if (card.dataset_query.query) {
-        if (options.table != null) {
-          card.dataset_query.query["source-table"] = parseInt(options.table);
-        }
-        if (options.segment != null) {
-          card.dataset_query.query.filter = [
-            "segment",
-            parseInt(options.segment),
-          ];
-        }
-        if (options.metric != null) {
-          // show the summarize sidebar for metrics
-          uiControls.isShowingSummarySidebar = true;
-          card.dataset_query.query.aggregation = [
-            "metric",
-            parseInt(options.metric),
-          ];
-        }
-      }
-
-      MetabaseAnalytics.trackStructEvent(
-        "QueryBuilder",
-        "Query Started",
-        card.dataset_query.type,
-      );
-    }
-
-    /**** All actions are dispatched here ****/
-
-    // Fetch alerts for the current question if the question is saved
-    if (card && card.id != null) {
-      dispatch(fetchAlertsForQuestion(card.id));
-    }
-    // Fetch the question metadata (blocking)
-    if (card) {
-      await dispatch(loadMetadataForCard(card));
-    }
-
-    let question = card && new Question(card, getMetadata(getState()));
-    if (question && question.isSaved()) {
-      // loading a saved question prevents auto-viz selection
-      question = question.lockDisplay();
-    }
-
-    if (question && question.isNative() && snippetFetch) {
-      await snippetFetch;
-      const snippets = Snippets.selectors.getList(getState());
-      question = question.setQuery(
-        question.query().updateQueryTextWithNewSnippetNames(snippets),
-      );
-    }
-
-    card = question && question.card();
-    const metadata = getMetadata(getState());
-    const parameters = getValueAndFieldIdPopulatedParametersFromCard(
-      card,
-      metadata,
-    );
-    const parameterValues = getParameterValuesByIdFromQueryParams(
-      parameters,
-      queryParams,
-      metadata,
-    );
-
-    const objectId = params?.objectId || queryParams?.objectId;
-
-    // Update the question to Redux state together with the initial state of UI controls
-    dispatch.action(INITIALIZE_QB, {
-      card,
-      originalCard,
-      uiControls,
-      parameterValues,
-      objectId,
-    });
-
-    // if we have loaded up a card that we can run then lets kick that off as well
-    // but don't bother for "notebook" mode
-    if (question && uiControls.queryBuilderMode !== "notebook") {
-      if (question.canRun()) {
-        // NOTE: timeout to allow Parameters widget to set parameterValues
-        setTimeout(
-          () =>
-            // TODO Atte Keinänen 5/31/17: Check if it is dangerous to create a question object without metadata
-            dispatch(runQuestionQuery({ shouldUpdateUrl: false })),
-          0,
-        );
-      }
-
-      // clean up the url and make sure it reflects our card state
-      dispatch(
-        updateUrl(card, {
-          replaceState: true,
-          preserveParameters,
-          objectId,
-        }),
-      );
-    }
-  };
-};
 
 export const loadMetadataForCard = card => (dispatch, getState) => {
   const metadata = getMetadata(getState());

--- a/frontend/src/metabase/query_builder/actions/core/index.ts
+++ b/frontend/src/metabase/query_builder/actions/core/index.ts
@@ -1,0 +1,2 @@
+export * from "./core";
+export * from "./initializeQB";

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.js
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.js
@@ -195,6 +195,29 @@ async function getCard({ cardId, serializedCard, dispatch, getState }) {
   return { card, originalCard };
 }
 
+function getInitialUIControls(location) {
+  const { mode, ...uiControls } = getQueryBuilderModeFromLocation(location);
+  uiControls.queryBuilderMode = mode;
+  return uiControls;
+}
+
+function parseHash(hash) {
+  let options = {};
+  let serializedCard;
+
+  // hash can contain either query params starting with ? or a base64 serialized card
+  if (hash) {
+    const cleanHash = hash.replace(/^#/, "");
+    if (cleanHash.charAt(0) === "?") {
+      options = querystring.parse(cleanHash.substring(1));
+    } else {
+      serializedCard = cleanHash;
+    }
+  }
+
+  return { options, serializedCard };
+}
+
 export const INITIALIZE_QB = "metabase/qb/INITIALIZE_QB";
 export const initializeQB = (location, params) => {
   return async (dispatch, getState) => {
@@ -202,31 +225,10 @@ export const initializeQB = (location, params) => {
     dispatch(cancelQuery());
 
     const cardId = Urls.extractEntityId(params.slug);
+    const uiControls = getInitialUIControls(location);
+    const { options, serializedCard } = parseHash(location.hash);
+
     let card, originalCard;
-
-    const {
-      mode: queryBuilderMode,
-      ...otherUiControls
-    } = getQueryBuilderModeFromLocation(location);
-    const uiControls = {
-      isEditing: false,
-      isShowingTemplateTagsEditor: false,
-      queryBuilderMode,
-      ...otherUiControls,
-    };
-
-    let options = {};
-    let serializedCard;
-
-    // hash can contain either query params starting with ? or a base64 serialized card
-    if (location.hash) {
-      const hash = location.hash.replace(/^#/, "");
-      if (hash.charAt(0) === "?") {
-        options = querystring.parse(hash.substring(1));
-      } else {
-        serializedCard = hash;
-      }
-    }
 
     let preserveParameters = false;
     let snippetFetch;

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.js
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.js
@@ -122,19 +122,18 @@ function getCardForBlankQuestion({ db, table, segment, metric }) {
   return question.card();
 }
 
-async function getCard({ cardId, serializedCard, dispatch, getState }) {
-  let card = {};
-  let originalCard;
-
-  if (serializedCard) {
-    card = deserializeCardFromUrl(serializedCard);
-    if (card.dataset_query.database != null) {
-      // Ensure older MBQL is supported
-      card.dataset_query = normalize(card.dataset_query);
-    }
+function deserializeCard(serializedCard) {
+  const card = deserializeCardFromUrl(serializedCard);
+  if (card.dataset_query.database != null) {
+    // Ensure older MBQL is supported
+    card.dataset_query = normalize(card.dataset_query);
   }
+  return card;
+}
 
-  const deserializedCard = card;
+async function getCard({ cardId, deserializedCard, dispatch, getState }) {
+  let card = deserializedCard || {};
+  let originalCard;
 
   if (cardId) {
     card = await loadCard(cardId);
@@ -240,15 +239,18 @@ async function handleQBInit(dispatch, getState, { location, params }) {
     return;
   }
 
-  let card, originalCard;
+  let card;
+  let originalCard;
+  let deserializedCard;
 
   let preserveParameters = false;
   let snippetFetch;
 
   if (hasCard) {
+    deserializedCard = serializedCard ? deserializeCard(serializedCard) : null;
     const loadedCards = await getCard({
       cardId,
-      serializedCard,
+      deserializedCard,
       dispatch,
       getState,
     });

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.js
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.js
@@ -14,6 +14,7 @@ import { DashboardApi } from "metabase/services";
 
 import { setErrorPage } from "metabase/redux/app";
 import { getMetadata } from "metabase/selectors/metadata";
+import { getUser } from "metabase/selectors/user";
 
 import Databases from "metabase/entities/databases";
 import Snippets from "metabase/entities/snippets";
@@ -200,8 +201,6 @@ export const initializeQB = (location, params) => {
     dispatch(resetQB());
     dispatch(cancelQuery());
 
-    const { currentUser } = getState();
-
     const cardId = Urls.extractEntityId(params.slug);
     let card, originalCard;
 
@@ -307,6 +306,7 @@ export const initializeQB = (location, params) => {
       // Don't set viz automatically for saved questions
       question = question.lockDisplay();
 
+      const currentUser = getUser(getState());
       if (currentUser.is_qbnewb) {
         uiControls.isShowingNewbModal = true;
         MetabaseAnalytics.trackStructEvent("QueryBuilder", "Show Newb Modal");

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.js
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.js
@@ -242,7 +242,11 @@ async function handleQBInit(dispatch, getState, { location, params }) {
     });
     card = loadedCards.card;
     originalCard = loadedCards.originalCard;
+  } else {
+    card = getCardForBlankQuestion(options);
+  }
 
+  if (hasCard) {
     const shouldPropagateParameters = checkShouldPropagateDashboardParameters({
       cardId,
       deserializedCard,
@@ -289,8 +293,6 @@ async function handleQBInit(dispatch, getState, { location, params }) {
 
     preserveParameters = true;
   } else {
-    card = getCardForBlankQuestion(options);
-
     if (options.metric) {
       uiControls.isShowingSummarySidebar = true;
     }

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.js
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.js
@@ -178,7 +178,7 @@ export const initializeQB = (location, params) => {
             getIn(card, ["dataset_query", "native", "template-tags"]) || {},
           ).filter(t => t.type === "snippet").length > 0
         ) {
-          const dbId = card.database_id;
+          const dbId = getIn(card, ["dataset_query", "database"]);
           let database = Databases.selectors.getObject(getState(), {
             entityId: dbId,
           });
@@ -225,7 +225,7 @@ export const initializeQB = (location, params) => {
           card = null;
         }
 
-        if (!card.dataset && location.pathname.startsWith("/model")) {
+        if (!card?.dataset && location.pathname.startsWith("/model")) {
           dispatch(
             setErrorPage({
               data: {
@@ -327,12 +327,15 @@ export const initializeQB = (location, params) => {
     const objectId = params?.objectId || queryParams?.objectId;
 
     // Update the question to Redux state together with the initial state of UI controls
-    dispatch.action(INITIALIZE_QB, {
-      card,
-      originalCard,
-      uiControls,
-      parameterValues,
-      objectId,
+    dispatch({
+      type: INITIALIZE_QB,
+      payload: {
+        card,
+        originalCard,
+        uiControls,
+        parameterValues,
+        objectId,
+      },
     });
 
     // if we have loaded up a card that we can run then lets kick that off as well

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.js
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.js
@@ -227,12 +227,25 @@ export const initializeQB = (location, params) => {
     const cardId = Urls.extractEntityId(params.slug);
     const uiControls = getInitialUIControls(location);
     const { options, serializedCard } = parseHash(location.hash);
+    const hasCard = cardId || serializedCard;
+
+    if (
+      !hasCard &&
+      !options.db &&
+      !options.table &&
+      !options.segment &&
+      !options.metric
+    ) {
+      dispatch(redirectToNewQuestionFlow());
+      return;
+    }
 
     let card, originalCard;
 
     let preserveParameters = false;
     let snippetFetch;
-    if (cardId || serializedCard) {
+
+    if (hasCard) {
       try {
         const loadedCards = await getCard({
           cardId,
@@ -272,16 +285,6 @@ export const initializeQB = (location, params) => {
         dispatch(setErrorPage(error));
       }
     } else {
-      if (
-        !options.db &&
-        !options.table &&
-        !options.segment &&
-        !options.metric
-      ) {
-        await dispatch(redirectToNewQuestionFlow());
-        return;
-      }
-
       card = getCardForBlankQuestion(options);
 
       if (options.metric) {

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.js
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.js
@@ -1,0 +1,361 @@
+import _ from "underscore";
+import { getIn } from "icepick";
+import querystring from "querystring";
+import { normalize } from "cljs/metabase.mbql.js";
+
+import * as MetabaseAnalytics from "metabase/lib/analytics";
+import {
+  deserializeCardFromUrl,
+  loadCard,
+  startNewCard,
+} from "metabase/lib/card";
+import * as Urls from "metabase/lib/urls";
+import Utils from "metabase/lib/utils";
+
+import { cardIsEquivalent } from "metabase/meta/Card";
+
+import { DashboardApi } from "metabase/services";
+
+import { setErrorPage } from "metabase/redux/app";
+import { getMetadata } from "metabase/selectors/metadata";
+
+import Databases from "metabase/entities/databases";
+import Snippets from "metabase/entities/snippets";
+import { fetchAlertsForQuestion } from "metabase/alert/alert";
+
+import { getValueAndFieldIdPopulatedParametersFromCard } from "metabase/parameters/utils/cards";
+import { hasMatchingParameters } from "metabase/parameters/utils/dashboards";
+import { getParameterValuesByIdFromQueryParams } from "metabase/parameters/utils/parameter-values";
+
+import Question from "metabase-lib/lib/Question";
+import { getQueryBuilderModeFromLocation } from "../../utils";
+
+import { redirectToNewQuestionFlow, updateUrl } from "../navigation";
+import { cancelQuery, runQuestionQuery } from "../querying";
+
+import { loadMetadataForCard, resetQB } from "./core";
+
+async function verifyMatchingDashcardAndParameters({
+  dispatch,
+  dashboardId,
+  dashcardId,
+  cardId,
+  parameters,
+  metadata,
+}) {
+  try {
+    const dashboard = await DashboardApi.get({ dashId: dashboardId });
+    if (
+      !hasMatchingParameters({
+        dashboard,
+        dashcardId,
+        cardId,
+        parameters,
+        metadata,
+      })
+    ) {
+      dispatch(setErrorPage({ status: 403 }));
+    }
+  } catch (error) {
+    dispatch(setErrorPage(error));
+  }
+}
+
+export const INITIALIZE_QB = "metabase/qb/INITIALIZE_QB";
+export const initializeQB = (location, params) => {
+  return async (dispatch, getState) => {
+    const queryParams = location.query;
+    // do this immediately to ensure old state is cleared before the user sees it
+    dispatch(resetQB());
+    dispatch(cancelQuery());
+
+    const { currentUser } = getState();
+
+    const cardId = Urls.extractEntityId(params.slug);
+    let card, originalCard;
+
+    const {
+      mode: queryBuilderMode,
+      ...otherUiControls
+    } = getQueryBuilderModeFromLocation(location);
+    const uiControls = {
+      isEditing: false,
+      isShowingTemplateTagsEditor: false,
+      queryBuilderMode,
+      ...otherUiControls,
+    };
+
+    // load up or initialize the card we'll be working on
+    let options = {};
+    let serializedCard;
+    // hash can contain either query params starting with ? or a base64 serialized card
+    if (location.hash) {
+      const hash = location.hash.replace(/^#/, "");
+      if (hash.charAt(0) === "?") {
+        options = querystring.parse(hash.substring(1));
+      } else {
+        serializedCard = hash;
+      }
+    }
+
+    let preserveParameters = false;
+    let snippetFetch;
+    if (cardId || serializedCard) {
+      // existing card being loaded
+      try {
+        // if we have a serialized card then unpack and use it
+        if (serializedCard) {
+          card = deserializeCardFromUrl(serializedCard);
+          // if serialized query has database we normalize syntax to support older mbql
+          if (card.dataset_query.database != null) {
+            card.dataset_query = normalize(card.dataset_query);
+          }
+        } else {
+          card = {};
+        }
+
+        const deserializedCard = card;
+
+        // load the card either from `cardId` parameter or the serialized card
+        if (cardId) {
+          card = await loadCard(cardId);
+          // when we are loading from a card id we want an explicit clone of the card we loaded which is unmodified
+          originalCard = Utils.copy(card);
+          // for showing the "started from" lineage correctly when adding filters/breakouts and when going back and forth
+          // in browser history, the original_card_id has to be set for the current card (simply the id of card itself for now)
+          card.original_card_id = card.id;
+
+          // if there's a card in the url, it may have parameters from a dashboard
+          if (deserializedCard && deserializedCard.parameters) {
+            const metadata = getMetadata(getState());
+            const { dashboardId, dashcardId, parameters } = deserializedCard;
+            verifyMatchingDashcardAndParameters({
+              dispatch,
+              dashboardId,
+              dashcardId,
+              cardId,
+              parameters,
+              metadata,
+            });
+
+            card.parameters = parameters;
+            card.dashboardId = dashboardId;
+            card.dashcardId = dashcardId;
+          }
+        } else if (card.original_card_id) {
+          const deserializedCard = card;
+          // deserialized card contains the card id, so just populate originalCard
+          originalCard = await loadCard(card.original_card_id);
+
+          if (cardIsEquivalent(deserializedCard, originalCard)) {
+            card = Utils.copy(originalCard);
+
+            if (
+              !cardIsEquivalent(deserializedCard, originalCard, {
+                checkParameters: true,
+              })
+            ) {
+              const metadata = getMetadata(getState());
+              const { dashboardId, dashcardId, parameters } = deserializedCard;
+              verifyMatchingDashcardAndParameters({
+                dispatch,
+                dashboardId,
+                dashcardId,
+                cardId: card.id,
+                parameters,
+                metadata,
+              });
+
+              card.parameters = parameters;
+              card.dashboardId = dashboardId;
+              card.dashcardId = dashcardId;
+            }
+          }
+        }
+        // if this card has any snippet tags we might need to fetch snippets pending permissions
+        if (
+          Object.values(
+            getIn(card, ["dataset_query", "native", "template-tags"]) || {},
+          ).filter(t => t.type === "snippet").length > 0
+        ) {
+          const dbId = card.database_id;
+          let database = Databases.selectors.getObject(getState(), {
+            entityId: dbId,
+          });
+          // if we haven't already loaded this database, block on loading dbs now so we can check write permissions
+          if (!database) {
+            await dispatch(Databases.actions.fetchList());
+            database = Databases.selectors.getObject(getState(), {
+              entityId: dbId,
+            });
+          }
+
+          // database could still be missing if the user doesn't have any permissions
+          // if the user has native permissions against this db, fetch snippets
+          if (database && database.native_permissions === "write") {
+            snippetFetch = dispatch(Snippets.actions.fetchList());
+          }
+        }
+
+        MetabaseAnalytics.trackStructEvent(
+          "QueryBuilder",
+          "Query Loaded",
+          card.dataset_query.type,
+        );
+
+        // if we have deserialized card from the url AND loaded a card by id then the user should be dropped into edit mode
+        uiControls.isEditing = !!options.edit;
+
+        // if this is the users first time loading a saved card on the QB then show them the newb modal
+        if (cardId && currentUser.is_qbnewb) {
+          uiControls.isShowingNewbModal = true;
+          MetabaseAnalytics.trackStructEvent("QueryBuilder", "Show Newb Modal");
+        }
+
+        if (card.archived) {
+          // use the error handler in App.jsx for showing "This question has been archived" message
+          dispatch(
+            setErrorPage({
+              data: {
+                error_code: "archived",
+              },
+              context: "query-builder",
+            }),
+          );
+          card = null;
+        }
+
+        if (!card.dataset && location.pathname.startsWith("/model")) {
+          dispatch(
+            setErrorPage({
+              data: {
+                error_code: "not-found",
+              },
+              context: "query-builder",
+            }),
+          );
+          card = null;
+        }
+
+        preserveParameters = true;
+      } catch (error) {
+        console.warn("initializeQb failed because of an error:", error);
+        card = null;
+        dispatch(setErrorPage(error));
+      }
+    } else {
+      // we are starting a new/empty card
+      // if no options provided in the hash, redirect to the new question flow
+      if (
+        !options.db &&
+        !options.table &&
+        !options.segment &&
+        !options.metric
+      ) {
+        await dispatch(redirectToNewQuestionFlow());
+        return;
+      }
+
+      const databaseId = options.db ? parseInt(options.db) : undefined;
+      card = startNewCard("query", databaseId);
+
+      // initialize parts of the query based on optional parameters supplied
+      if (card.dataset_query.query) {
+        if (options.table != null) {
+          card.dataset_query.query["source-table"] = parseInt(options.table);
+        }
+        if (options.segment != null) {
+          card.dataset_query.query.filter = [
+            "segment",
+            parseInt(options.segment),
+          ];
+        }
+        if (options.metric != null) {
+          // show the summarize sidebar for metrics
+          uiControls.isShowingSummarySidebar = true;
+          card.dataset_query.query.aggregation = [
+            "metric",
+            parseInt(options.metric),
+          ];
+        }
+      }
+
+      MetabaseAnalytics.trackStructEvent(
+        "QueryBuilder",
+        "Query Started",
+        card.dataset_query.type,
+      );
+    }
+
+    /**** All actions are dispatched here ****/
+
+    // Fetch alerts for the current question if the question is saved
+    if (card && card.id != null) {
+      dispatch(fetchAlertsForQuestion(card.id));
+    }
+    // Fetch the question metadata (blocking)
+    if (card) {
+      await dispatch(loadMetadataForCard(card));
+    }
+
+    let question = card && new Question(card, getMetadata(getState()));
+    if (question && question.isSaved()) {
+      // loading a saved question prevents auto-viz selection
+      question = question.lockDisplay();
+    }
+
+    if (question && question.isNative() && snippetFetch) {
+      await snippetFetch;
+      const snippets = Snippets.selectors.getList(getState());
+      question = question.setQuery(
+        question.query().updateQueryTextWithNewSnippetNames(snippets),
+      );
+    }
+
+    card = question && question.card();
+    const metadata = getMetadata(getState());
+    const parameters = getValueAndFieldIdPopulatedParametersFromCard(
+      card,
+      metadata,
+    );
+    const parameterValues = getParameterValuesByIdFromQueryParams(
+      parameters,
+      queryParams,
+      metadata,
+    );
+
+    const objectId = params?.objectId || queryParams?.objectId;
+
+    // Update the question to Redux state together with the initial state of UI controls
+    dispatch.action(INITIALIZE_QB, {
+      card,
+      originalCard,
+      uiControls,
+      parameterValues,
+      objectId,
+    });
+
+    // if we have loaded up a card that we can run then lets kick that off as well
+    // but don't bother for "notebook" mode
+    if (question && uiControls.queryBuilderMode !== "notebook") {
+      if (question.canRun()) {
+        // NOTE: timeout to allow Parameters widget to set parameterValues
+        setTimeout(
+          () =>
+            // TODO Atte Keinänen 5/31/17: Check if it is dangerous to create a question object without metadata
+            dispatch(runQuestionQuery({ shouldUpdateUrl: false })),
+          0,
+        );
+      }
+
+      // clean up the url and make sure it reflects our card state
+      dispatch(
+        updateUrl(card, {
+          replaceState: true,
+          preserveParameters,
+          objectId,
+        }),
+      );
+    }
+  };
+};

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.js
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.js
@@ -197,8 +197,6 @@ async function getCard({ cardId, serializedCard, dispatch, getState }) {
 export const INITIALIZE_QB = "metabase/qb/INITIALIZE_QB";
 export const initializeQB = (location, params) => {
   return async (dispatch, getState) => {
-    const queryParams = location.query;
-
     dispatch(resetQB());
     dispatch(cancelQuery());
 
@@ -323,7 +321,9 @@ export const initializeQB = (location, params) => {
       );
     }
 
+    const queryParams = location.query;
     card = question && question.card();
+
     const metadata = getMetadata(getState());
     const parameters = getValueAndFieldIdPopulatedParametersFromCard(
       card,

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.js
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.js
@@ -94,6 +94,18 @@ async function verifyMatchingDashcardAndParameters({
   }
 }
 
+function getParameterValuesForQuestion({ card, queryParams, metadata }) {
+  const parameters = getValueAndFieldIdPopulatedParametersFromCard(
+    card,
+    metadata,
+  );
+  return getParameterValuesByIdFromQueryParams(
+    parameters,
+    queryParams,
+    metadata,
+  );
+}
+
 async function handleDashboardParameters(
   card,
   { cardId, deserializedCard, originalCard, dispatch, getState },
@@ -321,15 +333,11 @@ async function handleQBInit(dispatch, getState, { location, params }) {
   const freshCard = question && question.card();
 
   const metadata = getMetadata(getState());
-  const parameters = getValueAndFieldIdPopulatedParametersFromCard(
-    freshCard,
-    metadata,
-  );
-  const parameterValues = getParameterValuesByIdFromQueryParams(
-    parameters,
+  const parameterValues = getParameterValuesForQuestion({
+    card,
     queryParams,
     metadata,
-  );
+  });
 
   const objectId = params?.objectId || queryParams?.objectId;
 

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.js
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.js
@@ -286,12 +286,6 @@ async function handleQBInit(dispatch, getState, { location, params }) {
       });
     }
 
-    MetabaseAnalytics.trackStructEvent(
-      "QueryBuilder",
-      "Query Loaded",
-      card.dataset_query.type,
-    );
-
     uiControls.isEditing = !!options.edit;
 
     if (card.archived) {
@@ -305,13 +299,13 @@ async function handleQBInit(dispatch, getState, { location, params }) {
     if (options.metric) {
       uiControls.isShowingSummarySidebar = true;
     }
-
-    MetabaseAnalytics.trackStructEvent(
-      "QueryBuilder",
-      "Query Started",
-      card.dataset_query.type,
-    );
   }
+
+  MetabaseAnalytics.trackStructEvent(
+    "QueryBuilder",
+    hasCard ? "Query Loaded" : "Query Started",
+    card.dataset_query.type,
+  );
 
   if (card && card.id != null) {
     dispatch(fetchAlertsForQuestion(card.id));

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.js
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.js
@@ -245,7 +245,6 @@ async function handleQBInit(dispatch, getState, { location, params }) {
     return;
   }
 
-  let preserveParameters = false;
   let snippetFetch;
 
   const deserializedCard = serializedCard
@@ -300,8 +299,6 @@ async function handleQBInit(dispatch, getState, { location, params }) {
     if (!card?.dataset && location.pathname.startsWith("/model")) {
       dispatch(setErrorPage(NOT_FOUND_ERROR));
     }
-
-    preserveParameters = true;
   } else {
     if (options.metric) {
       uiControls.isShowingSummarySidebar = true;
@@ -380,7 +377,7 @@ async function handleQBInit(dispatch, getState, { location, params }) {
     dispatch(
       updateUrl(freshCard, {
         replaceState: true,
-        preserveParameters,
+        preserveParameters: hasCard,
         objectId,
       }),
     );

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.js
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.js
@@ -96,7 +96,7 @@ const ARCHIVED_ERROR = {
 
 const NOT_FOUND_ERROR = {
   data: {
-    error_code: "archived",
+    error_code: "not-found",
   },
   context: "query-builder",
 };

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.js
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.js
@@ -32,6 +32,20 @@ import { cancelQuery, runQuestionQuery } from "../querying";
 
 import { loadMetadataForCard, resetQB } from "./core";
 
+const ARCHIVED_ERROR = {
+  data: {
+    error_code: "archived",
+  },
+  context: "query-builder",
+};
+
+const NOT_FOUND_ERROR = {
+  data: {
+    error_code: "not-found",
+  },
+  context: "query-builder",
+};
+
 async function verifyMatchingDashcardAndParameters({
   dispatch,
   dashboardId,
@@ -83,20 +97,6 @@ async function getSnippetsLoader({ card, dispatch, getState }) {
     return dispatch(Snippets.actions.fetchList());
   }
 }
-
-const ARCHIVED_ERROR = {
-  data: {
-    error_code: "archived",
-  },
-  context: "query-builder",
-};
-
-const NOT_FOUND_ERROR = {
-  data: {
-    error_code: "not-found",
-  },
-  context: "query-builder",
-};
 
 function getCardForBlankQuestion({ db, table, segment, metric }) {
   const databaseId = db ? parseInt(db) : undefined;

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.js
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.js
@@ -256,11 +256,6 @@ export const initializeQB = (location, params) => {
 
         uiControls.isEditing = !!options.edit;
 
-        if (cardId && currentUser.is_qbnewb) {
-          uiControls.isShowingNewbModal = true;
-          MetabaseAnalytics.trackStructEvent("QueryBuilder", "Show Newb Modal");
-        }
-
         if (card.archived) {
           dispatch(setErrorPage(ARCHIVED_ERROR));
           card = null;
@@ -313,6 +308,11 @@ export const initializeQB = (location, params) => {
     if (question && question.isSaved()) {
       // Don't set viz automatically for saved questions
       question = question.lockDisplay();
+
+      if (currentUser.is_qbnewb) {
+        uiControls.isShowingNewbModal = true;
+        MetabaseAnalytics.trackStructEvent("QueryBuilder", "Show Newb Modal");
+      }
     }
 
     if (question && question.isNative() && snippetFetch) {

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.js
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.js
@@ -105,7 +105,7 @@ export const INITIALIZE_QB = "metabase/qb/INITIALIZE_QB";
 export const initializeQB = (location, params) => {
   return async (dispatch, getState) => {
     const queryParams = location.query;
-    // do this immediately to ensure old state is cleared before the user sees it
+
     dispatch(resetQB());
     dispatch(cancelQuery());
 
@@ -125,9 +125,9 @@ export const initializeQB = (location, params) => {
       ...otherUiControls,
     };
 
-    // load up or initialize the card we'll be working on
     let options = {};
     let serializedCard;
+
     // hash can contain either query params starting with ? or a base64 serialized card
     if (location.hash) {
       const hash = location.hash.replace(/^#/, "");
@@ -141,13 +141,11 @@ export const initializeQB = (location, params) => {
     let preserveParameters = false;
     let snippetFetch;
     if (cardId || serializedCard) {
-      // existing card being loaded
       try {
-        // if we have a serialized card then unpack and use it
         if (serializedCard) {
           card = deserializeCardFromUrl(serializedCard);
-          // if serialized query has database we normalize syntax to support older mbql
           if (card.dataset_query.database != null) {
+            // Ensure older MBQL is supported
             card.dataset_query = normalize(card.dataset_query);
           }
         } else {
@@ -156,11 +154,11 @@ export const initializeQB = (location, params) => {
 
         const deserializedCard = card;
 
-        // load the card either from `cardId` parameter or the serialized card
         if (cardId) {
           card = await loadCard(cardId);
           // when we are loading from a card id we want an explicit clone of the card we loaded which is unmodified
           originalCard = Utils.copy(card);
+
           // for showing the "started from" lineage correctly when adding filters/breakouts and when going back and forth
           // in browser history, the original_card_id has to be set for the current card (simply the id of card itself for now)
           card.original_card_id = card.id;
@@ -184,7 +182,6 @@ export const initializeQB = (location, params) => {
           }
         } else if (card.original_card_id) {
           const deserializedCard = card;
-          // deserialized card contains the card id, so just populate originalCard
           originalCard = await loadCard(card.original_card_id);
 
           if (cardIsEquivalent(deserializedCard, originalCard)) {
@@ -223,17 +220,14 @@ export const initializeQB = (location, params) => {
           card.dataset_query.type,
         );
 
-        // if we have deserialized card from the url AND loaded a card by id then the user should be dropped into edit mode
         uiControls.isEditing = !!options.edit;
 
-        // if this is the users first time loading a saved card on the QB then show them the newb modal
         if (cardId && currentUser.is_qbnewb) {
           uiControls.isShowingNewbModal = true;
           MetabaseAnalytics.trackStructEvent("QueryBuilder", "Show Newb Modal");
         }
 
         if (card.archived) {
-          // use the error handler in App.jsx for showing "This question has been archived" message
           dispatch(setErrorPage(ARCHIVED_ERROR));
           card = null;
         }
@@ -250,8 +244,6 @@ export const initializeQB = (location, params) => {
         dispatch(setErrorPage(error));
       }
     } else {
-      // we are starting a new/empty card
-      // if no options provided in the hash, redirect to the new question flow
       if (
         !options.db &&
         !options.table &&
@@ -265,7 +257,6 @@ export const initializeQB = (location, params) => {
       const databaseId = options.db ? parseInt(options.db) : undefined;
       card = startNewCard("query", databaseId);
 
-      // initialize parts of the query based on optional parameters supplied
       if (card.dataset_query.query) {
         if (options.table != null) {
           card.dataset_query.query["source-table"] = parseInt(options.table);
@@ -277,7 +268,6 @@ export const initializeQB = (location, params) => {
           ];
         }
         if (options.metric != null) {
-          // show the summarize sidebar for metrics
           uiControls.isShowingSummarySidebar = true;
           card.dataset_query.query.aggregation = [
             "metric",
@@ -293,20 +283,17 @@ export const initializeQB = (location, params) => {
       );
     }
 
-    /**** All actions are dispatched here ****/
-
-    // Fetch alerts for the current question if the question is saved
     if (card && card.id != null) {
       dispatch(fetchAlertsForQuestion(card.id));
     }
-    // Fetch the question metadata (blocking)
+
     if (card) {
       await dispatch(loadMetadataForCard(card));
     }
 
     let question = card && new Question(card, getMetadata(getState()));
     if (question && question.isSaved()) {
-      // loading a saved question prevents auto-viz selection
+      // Don't set viz automatically for saved questions
       question = question.lockDisplay();
     }
 
@@ -332,7 +319,6 @@ export const initializeQB = (location, params) => {
 
     const objectId = params?.objectId || queryParams?.objectId;
 
-    // Update the question to Redux state together with the initial state of UI controls
     dispatch({
       type: INITIALIZE_QB,
       payload: {
@@ -344,20 +330,14 @@ export const initializeQB = (location, params) => {
       },
     });
 
-    // if we have loaded up a card that we can run then lets kick that off as well
-    // but don't bother for "notebook" mode
     if (question && uiControls.queryBuilderMode !== "notebook") {
       if (question.canRun()) {
-        // NOTE: timeout to allow Parameters widget to set parameterValues
+        // Timeout to allow Parameters widget to set parameterValues
         setTimeout(
-          () =>
-            // TODO Atte Keinänen 5/31/17: Check if it is dangerous to create a question object without metadata
-            dispatch(runQuestionQuery({ shouldUpdateUrl: false })),
+          () => dispatch(runQuestionQuery({ shouldUpdateUrl: false })),
           0,
         );
       }
-
-      // clean up the url and make sure it reflects our card state
       dispatch(
         updateUrl(card, {
           replaceState: true,

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.js
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.js
@@ -87,6 +87,20 @@ async function getSnippetsLoader({ card, dispatch, getState }) {
   }
 }
 
+const ARCHIVED_ERROR = {
+  data: {
+    error_code: "archived",
+  },
+  context: "query-builder",
+};
+
+const NOT_FOUND_ERROR = {
+  data: {
+    error_code: "archived",
+  },
+  context: "query-builder",
+};
+
 export const INITIALIZE_QB = "metabase/qb/INITIALIZE_QB";
 export const initializeQB = (location, params) => {
   return async (dispatch, getState) => {
@@ -220,26 +234,12 @@ export const initializeQB = (location, params) => {
 
         if (card.archived) {
           // use the error handler in App.jsx for showing "This question has been archived" message
-          dispatch(
-            setErrorPage({
-              data: {
-                error_code: "archived",
-              },
-              context: "query-builder",
-            }),
-          );
+          dispatch(setErrorPage(ARCHIVED_ERROR));
           card = null;
         }
 
         if (!card?.dataset && location.pathname.startsWith("/model")) {
-          dispatch(
-            setErrorPage({
-              data: {
-                error_code: "not-found",
-              },
-              context: "query-builder",
-            }),
-          );
+          dispatch(setErrorPage(NOT_FOUND_ERROR));
           card = null;
         }
 

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
@@ -2,10 +2,9 @@ import _ from "underscore";
 import querystring from "querystring";
 import { LocationDescriptorObject } from "history";
 
-import { normalize } from "cljs/metabase.mbql.js";
-
 import * as MetabaseAnalytics from "metabase/lib/analytics";
 import { deserializeCardFromUrl, loadCard } from "metabase/lib/card";
+import { normalize } from "metabase/lib/query/normalize";
 import * as Urls from "metabase/lib/urls";
 
 import { cardIsEquivalent } from "metabase/meta/Card";

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
@@ -187,11 +187,11 @@ function parseHash(hash?: string) {
   return { options, serializedCard };
 }
 
-export const INITIALIZE_QB = "metabase/qb/INITIALIZE_QB";
-
 function isSavedCard(card: Card): card is SavedCard {
   return !!(card as SavedCard).id;
 }
+
+export const INITIALIZE_QB = "metabase/qb/INITIALIZE_QB";
 
 async function handleQBInit(
   dispatch: Dispatch,

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
@@ -10,8 +10,6 @@ import * as Urls from "metabase/lib/urls";
 
 import { cardIsEquivalent } from "metabase/meta/Card";
 
-import { DashboardApi } from "metabase/services";
-
 import { setErrorPage } from "metabase/redux/app";
 import { getMetadata } from "metabase/selectors/metadata";
 import { getUser } from "metabase/selectors/user";
@@ -19,25 +17,23 @@ import { getUser } from "metabase/selectors/user";
 import Snippets from "metabase/entities/snippets";
 import { fetchAlertsForQuestion } from "metabase/alert/alert";
 
-import { getValueAndFieldIdPopulatedParametersFromCard } from "metabase/parameters/utils/cards";
-import { hasMatchingParameters } from "metabase/parameters/utils/dashboards";
-import { getParameterValuesByIdFromQueryParams } from "metabase/parameters/utils/parameter-values";
-
 import Question from "metabase-lib/lib/Question";
 import NativeQuery from "metabase-lib/lib/queries/NativeQuery";
 import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
-import Metadata from "metabase-lib/lib/metadata/Metadata";
 
 import { Dispatch, GetState } from "metabase-types/store";
 
 import { Card, SavedCard } from "metabase-types/types/Card";
-import { Parameter } from "metabase-types/types/Parameter";
 
 import { getQueryBuilderModeFromLocation } from "../../utils";
 import { redirectToNewQuestionFlow, updateUrl } from "../navigation";
 import { cancelQuery, runQuestionQuery } from "../querying";
 
 import { loadMetadataForCard, resetQB } from "./core";
+import {
+  handleDashboardParameters,
+  getParameterValuesForQuestion,
+} from "./parameterUtils";
 
 type BlankQueryOptions = {
   db?: string;
@@ -73,127 +69,6 @@ const NOT_FOUND_ERROR = {
   },
   context: "query-builder",
 };
-
-function checkShouldPropagateDashboardParameters({
-  cardId,
-  deserializedCard,
-  originalCard,
-}: {
-  cardId?: number;
-  deserializedCard?: Card;
-  originalCard?: Card;
-}) {
-  if (!deserializedCard) {
-    return false;
-  }
-  if (cardId && deserializedCard.parameters) {
-    return true;
-  }
-  if (!originalCard) {
-    return false;
-  }
-  const equalCards = cardIsEquivalent(deserializedCard, originalCard, {
-    checkParameters: false,
-  });
-  const differentParameters = !cardIsEquivalent(
-    deserializedCard,
-    originalCard,
-    { checkParameters: true },
-  );
-  return equalCards && differentParameters;
-}
-
-async function verifyMatchingDashcardAndParameters({
-  dispatch,
-  dashboardId,
-  dashcardId,
-  cardId,
-  parameters,
-  metadata,
-}: {
-  dispatch: Dispatch;
-  dashboardId: number;
-  dashcardId: number;
-  cardId: number;
-  parameters: Parameter[];
-  metadata: Metadata;
-}) {
-  try {
-    const dashboard = await DashboardApi.get({ dashId: dashboardId });
-    if (
-      !hasMatchingParameters({
-        dashboard,
-        dashcardId,
-        cardId,
-        parameters,
-        metadata,
-      })
-    ) {
-      dispatch(setErrorPage({ status: 403 }));
-    }
-  } catch (error) {
-    dispatch(setErrorPage(error));
-  }
-}
-
-function getParameterValuesForQuestion({
-  card,
-  queryParams,
-  metadata,
-}: {
-  card: Card;
-  queryParams?: QueryParams;
-  metadata: Metadata;
-}) {
-  const parameters = getValueAndFieldIdPopulatedParametersFromCard(
-    card,
-    metadata,
-  );
-  return getParameterValuesByIdFromQueryParams(
-    parameters,
-    queryParams,
-    metadata,
-  );
-}
-
-async function handleDashboardParameters(
-  card: Card,
-  {
-    deserializedCard,
-    originalCard,
-    dispatch,
-    getState,
-  }: {
-    cardId?: number;
-    deserializedCard?: Card;
-    originalCard?: Card;
-    dispatch: Dispatch;
-    getState: GetState;
-  },
-) {
-  const cardId = (card as SavedCard).id;
-  const shouldPropagateParameters = checkShouldPropagateDashboardParameters({
-    cardId,
-    deserializedCard,
-    originalCard,
-  });
-  if (shouldPropagateParameters && deserializedCard) {
-    const { dashboardId, dashcardId, parameters } = deserializedCard;
-    const metadata = getMetadata(getState());
-    await verifyMatchingDashcardAndParameters({
-      dispatch,
-      cardId,
-      metadata,
-      dashboardId: dashboardId as number,
-      dashcardId: dashcardId as number,
-      parameters: parameters as Parameter[],
-    });
-
-    card.parameters = parameters;
-    card.dashboardId = dashboardId;
-    card.dashcardId = dashcardId;
-  }
-}
 
 function getCardForBlankQuestion({
   db,

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
@@ -21,11 +21,15 @@ import Question from "metabase-lib/lib/Question";
 import NativeQuery from "metabase-lib/lib/queries/NativeQuery";
 import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
 
-import { Dispatch, GetState } from "metabase-types/store";
+import {
+  Dispatch,
+  GetState,
+  QueryBuilderUIControls,
+} from "metabase-types/store";
 
 import { Card, SavedCard } from "metabase-types/types/Card";
 
-import { getQueryBuilderModeFromLocation } from "../../utils";
+import { getQueryBuilderModeFromLocation } from "../../typed-utils";
 import { redirectToNewQuestionFlow, updateUrl } from "../navigation";
 import { cancelQuery, runQuestionQuery } from "../querying";
 
@@ -47,14 +51,7 @@ type QueryParams = BlankQueryOptions & {
   objectId?: string;
 };
 
-type QueryBuilderMode = "view" | "notebook" | "dataset";
-
-type UIControls = {
-  isShowingNewbModal?: boolean;
-  isShowingSummarySidebar?: boolean;
-  datasetEditorTab?: string;
-  queryBuilderMode?: QueryBuilderMode;
-};
+type UIControls = Partial<QueryBuilderUIControls>;
 
 const ARCHIVED_ERROR = {
   data: {
@@ -164,12 +161,6 @@ async function resolveCards({
     : fetchAndPrepareAdHocQuestionCards(deserializedCard as Card);
 }
 
-function getInitialUIControls(location: LocationDescriptorObject) {
-  const { mode, ...uiControls } = getQueryBuilderModeFromLocation(location);
-  (uiControls as UIControls).queryBuilderMode = mode as QueryBuilderMode;
-  return uiControls;
-}
-
 function parseHash(hash?: string) {
   let options: BlankQueryOptions = {};
   let serializedCard;
@@ -206,7 +197,7 @@ async function handleQBInit(
 
   const queryParams = location.query;
   const cardId = Urls.extractEntityId(params.slug);
-  const uiControls: UIControls = getInitialUIControls(location);
+  const uiControls: UIControls = getQueryBuilderModeFromLocation(location);
   const { options, serializedCard } = parseHash(location.hash);
   const hasCard = cardId || serializedCard;
 

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.unit.spec.ts
@@ -1,0 +1,506 @@
+import { LocationDescriptorObject } from "history";
+import _ from "underscore";
+import xhrMock from "xhr-mock";
+
+import * as CardLib from "metabase/lib/card";
+import * as Urls from "metabase/lib/urls";
+
+import * as alert from "metabase/alert/alert";
+import { setErrorPage } from "metabase/redux/app";
+
+import Question from "metabase-lib/lib/Question";
+import {
+  getAdHocQuestion,
+  getSavedStructuredQuestion,
+  getSavedNativeQuestion,
+  getUnsavedNativeQuestion,
+  getStructuredModel,
+  getNativeModel,
+} from "metabase-lib/mocks";
+
+import { User } from "metabase-types/api";
+import { createMockUser } from "metabase-types/api/mocks";
+import { Card } from "metabase-types/types/Card";
+import { createMockState } from "metabase-types/store/mocks";
+
+import { state as entitiesState } from "__support__/sample_database_fixture";
+
+import * as querying from "../querying";
+
+import * as core from "./core";
+import { initializeQB } from "./initializeQB";
+
+function getLocationForQuestion(
+  question: Question,
+  extra: LocationDescriptorObject = {},
+): LocationDescriptorObject {
+  const card = question.card();
+  const isSaved = question.isSaved();
+  return {
+    pathname: isSaved ? Urls.question(card) : Urls.serializedQuestion(card),
+    hash: !isSaved ? CardLib.serializeCardForUrl(card) : "",
+    query: {},
+    ...extra,
+  };
+}
+
+function getQueryParamsForQuestion(
+  question: Question,
+  extra: Record<string, unknown> = {},
+): Record<string, unknown> {
+  if (!question.isSaved()) {
+    return extra;
+  }
+  const id = question.id();
+  const name = question.displayName();
+  return {
+    slug: `${id}-${name}`,
+    ...extra,
+  };
+}
+
+type SetupOpts = {
+  question: Question;
+  user?: User;
+  location?: LocationDescriptorObject;
+  params?: Record<string, unknown>;
+};
+
+async function setup({
+  question,
+  user,
+  location = getLocationForQuestion(question),
+  params = getQueryParamsForQuestion(question),
+}: SetupOpts) {
+  jest.useFakeTimers();
+
+  const card = question.card();
+
+  if ("id" in card) {
+    xhrMock.get(`/api/card/${card.id}`, {
+      body: JSON.stringify(card),
+    });
+  }
+
+  const dispatch = jest.fn().mockReturnValue({ mock: "mock" });
+
+  const state = {
+    ...createMockState(),
+    ...entitiesState,
+  };
+  if (user) {
+    state.currentUser = user;
+  }
+  const getState = () => state;
+
+  await initializeQB(location, params)(dispatch, getState);
+  jest.runAllTimers();
+
+  const [initQBAction] = dispatch.mock.calls.find(
+    call => call[0]?.type === "metabase/qb/INITIALIZE_QB",
+  );
+
+  return { dispatch, state, result: initQBAction.payload };
+}
+
+describe("QB Actions > initializeQB", () => {
+  beforeAll(() => {
+    console.warn = jest.fn();
+  });
+
+  beforeEach(() => {
+    xhrMock.setup();
+  });
+
+  afterEach(() => {
+    xhrMock.teardown();
+    jest.restoreAllMocks();
+  });
+
+  const TEST_CASE = {
+    SAVED_STRUCTURED_QUESTION: {
+      question: getSavedStructuredQuestion(),
+      questionType: "saved structured question",
+    },
+    UNSAVED_STRUCTURED_QUESTION: {
+      question: getAdHocQuestion(),
+      questionType: "ad-hoc structured question",
+    },
+
+    SAVED_NATIVE_QUESTION: {
+      question: getSavedNativeQuestion(),
+      questionType: "saved native question",
+    },
+    UNSAVED_NATIVE_QUESTION: {
+      question: getUnsavedNativeQuestion(),
+      questionType: "unsaved native question",
+    },
+
+    STRUCTURED_MODEL: {
+      question: getStructuredModel(),
+      questionType: "structured model",
+    },
+    NATIVE_MODEL: {
+      question: getNativeModel(),
+      questionType: "native model",
+    },
+  };
+
+  const ALL_TEST_CASES = Object.values(TEST_CASE);
+
+  const SAVED_QUESTION_TEST_CASES = [
+    TEST_CASE.SAVED_STRUCTURED_QUESTION,
+    TEST_CASE.SAVED_NATIVE_QUESTION,
+  ];
+
+  const UNSAVED_QUESTION_TEST_CASES = [
+    TEST_CASE.UNSAVED_STRUCTURED_QUESTION,
+    TEST_CASE.UNSAVED_NATIVE_QUESTION,
+  ];
+
+  const MODEL_TEST_CASES = [TEST_CASE.STRUCTURED_MODEL, TEST_CASE.NATIVE_MODEL];
+
+  describe("common", () => {
+    ALL_TEST_CASES.forEach(testCase => {
+      const { question, questionType } = testCase;
+
+      describe(questionType, () => {
+        it("resets QB state before doing anything", async () => {
+          const resetQBSpy = jest.spyOn(core, "resetQB");
+          await setup({ question });
+          expect(resetQBSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it("cancels running query before doing anything", async () => {
+          const cancelQuerySpy = jest.spyOn(querying, "cancelQuery");
+          await setup({ question });
+          expect(cancelQuerySpy).toHaveBeenCalledTimes(1);
+        });
+
+        it("fetches question metadata", async () => {
+          const loadMetadataForCardSpy = jest.spyOn(
+            core,
+            "loadMetadataForCard",
+          );
+
+          await setup({ question });
+
+          expect(loadMetadataForCardSpy).toHaveBeenCalledTimes(1);
+          expect(loadMetadataForCardSpy).toHaveBeenCalledWith(
+            expect.objectContaining(question.card()),
+          );
+        });
+
+        it("runs question query in view mode", async () => {
+          const runQuestionQuerySpy = jest.spyOn(querying, "runQuestionQuery");
+          await setup({ question });
+          expect(runQuestionQuerySpy).toHaveBeenCalledTimes(1);
+        });
+
+        it("does not run non-runnable question queries", async () => {
+          const runQuestionQuerySpy = jest.spyOn(querying, "runQuestionQuery");
+          jest.spyOn(Question.prototype, "canRun").mockReturnValue(false);
+
+          await setup({ question });
+
+          expect(runQuestionQuerySpy).not.toHaveBeenCalled();
+        });
+
+        it("does not run question query in notebook mode", async () => {
+          const runQuestionQuerySpy = jest.spyOn(querying, "runQuestionQuery");
+          const baseUrl = Urls.question(question.card());
+          const location = getLocationForQuestion(question, {
+            pathname: `${baseUrl}/notebook`,
+          });
+
+          await setup({ question, location });
+
+          expect(runQuestionQuerySpy).not.toHaveBeenCalled();
+        });
+
+        it("passes object ID from params correctly", async () => {
+          const params = getQueryParamsForQuestion(question, { objectId: 123 });
+          const { result } = await setup({ question, params });
+          expect(result.objectId).toBe(123);
+        });
+
+        it("passes object ID from location query params correctly", async () => {
+          const location = getLocationForQuestion(question, {
+            query: { objectId: 123 },
+          });
+          const { result } = await setup({ question, location });
+          expect(result.objectId).toBe(123);
+        });
+
+        it("sets original card id on the card", async () => {
+          const { result } = await setup({ question });
+          expect(result.card.original_card_id).toBe(question.id());
+        });
+
+        it("sets QB mode correctly", async () => {
+          const { result } = await setup({ question });
+          expect(result.uiControls.queryBuilderMode).toBe("view");
+        });
+
+        it("sets QB mode to notebook if opening /notebook route", async () => {
+          const baseUrl = Urls.question(question.card());
+          const location = getLocationForQuestion(question, {
+            pathname: `${baseUrl}/notebook`,
+          });
+
+          const { result } = await setup({ question, location });
+
+          expect(result.uiControls.queryBuilderMode).toBe("notebook");
+        });
+      });
+    });
+  });
+
+  describe("saved questions and models", () => {
+    [...SAVED_QUESTION_TEST_CASES, ...MODEL_TEST_CASES].forEach(testCase => {
+      const { question, questionType } = testCase;
+
+      describe(questionType, () => {
+        it("locks question display", async () => {
+          const { result } = await setup({
+            question: question.setDisplayIsLocked(false),
+          });
+          expect(result.card.displayIsLocked).toBe(true);
+        });
+
+        it("fetches alerts", async () => {
+          const fetchAlertsForQuestionSpy = jest.spyOn(
+            alert,
+            "fetchAlertsForQuestion",
+          );
+
+          await setup({ question });
+
+          expect(fetchAlertsForQuestionSpy).toHaveBeenCalledWith(question.id());
+        });
+
+        it("passes object ID from params correctly", async () => {
+          const params = getQueryParamsForQuestion(question, { objectId: 123 });
+          const { result } = await setup({ question, params });
+          expect(result.objectId).toBe(123);
+        });
+
+        it("passes object ID from location query params correctly", async () => {
+          const location = getLocationForQuestion(question, {
+            query: { objectId: 123 },
+          });
+          const { result } = await setup({ question, location });
+          expect(result.objectId).toBe(123);
+        });
+
+        describe("newb modal", () => {
+          it("shows modal if user has not yet seen it", async () => {
+            const { result } = await setup({
+              question,
+              user: createMockUser({ is_qbnewb: true }),
+            });
+            expect(result.uiControls.isShowingNewbModal).toBe(true);
+          });
+
+          it("does not show modal if user has seen it", async () => {
+            const { result } = await setup({
+              question,
+              user: createMockUser({ is_qbnewb: false }),
+            });
+            expect(result.uiControls.isShowingNewbModal).toBeFalsy();
+          });
+        });
+
+        it("throws error for archived card", async () => {
+          const { dispatch } = await setup({
+            question: question.setCard({
+              ...question.card(),
+              // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+              // @ts-ignore
+              archived: true,
+            }),
+          });
+
+          expect(dispatch).toHaveBeenCalledWith(
+            setErrorPage(
+              expect.objectContaining({ data: { error_code: "archived" } }),
+            ),
+          );
+        });
+      });
+    });
+  });
+
+  describe("saved questions", () => {
+    SAVED_QUESTION_TEST_CASES.forEach(testCase => {
+      const { question, questionType } = testCase;
+
+      describe(questionType, () => {
+        it("throws not found error when opening question with /model URL", async () => {
+          const { dispatch } = await setup({
+            question,
+            location: { pathname: `/model/${question.id()}` },
+          });
+
+          expect(dispatch).toHaveBeenCalledWith(
+            setErrorPage(
+              expect.objectContaining({ data: { error_code: "not-found" } }),
+            ),
+          );
+        });
+      });
+    });
+  });
+
+  describe("unsaved questions", () => {
+    UNSAVED_QUESTION_TEST_CASES.forEach(testCase => {
+      const { question, questionType } = testCase;
+
+      const ORIGINAL_CARD_ID = 321;
+
+      function getOriginalQuestion(card?: Partial<Card>) {
+        return question.setCard({
+          ...question.card(),
+          ...card,
+          id: ORIGINAL_CARD_ID,
+        });
+      }
+
+      function setupWithOriginalQuestion({
+        originalQuestion,
+        question,
+        ...opts
+      }: SetupOpts & { originalQuestion: Question }) {
+        const q = question.setCard({
+          ...question.card(),
+          original_card_id: ORIGINAL_CARD_ID,
+        });
+
+        xhrMock.get(`/api/card/${originalQuestion.id()}`, {
+          body: JSON.stringify(originalQuestion.card()),
+        });
+
+        return setup({ question: q, ...opts });
+      }
+
+      describe(questionType, () => {
+        it("loads original card", async () => {
+          const originalQuestion = getOriginalQuestion({ display: "line" });
+
+          const { result } = await setupWithOriginalQuestion({
+            question,
+            originalQuestion,
+          });
+
+          expect(result.card.original_card_id).toBe(ORIGINAL_CARD_ID);
+          expect(result.originalCard).toEqual(originalQuestion.card());
+        });
+
+        it("replaces card with original card if they're equal", async () => {
+          const originalQuestion = getOriginalQuestion();
+
+          const { result } = await setupWithOriginalQuestion({
+            question,
+            originalQuestion,
+          });
+
+          expect(result.card.original_card_id).toBeUndefined();
+          expect(result.originalCard).toEqual(originalQuestion.card());
+          expect(result.card).toEqual(originalQuestion.lockDisplay().card());
+        });
+
+        it("does not lock question display", async () => {
+          const { result } = await setup({ question });
+          expect(result.card.displayIsLocked).toBeFalsy();
+        });
+
+        it("does not try to fetch alerts", async () => {
+          const fetchAlertsForQuestionSpy = jest.spyOn(
+            alert,
+            "fetchAlertsForQuestion",
+          );
+
+          await setup({ question });
+
+          expect(fetchAlertsForQuestionSpy).not.toHaveBeenCalled();
+        });
+
+        it("does not show qbnewb modal", async () => {
+          const { result } = await setup({
+            question,
+            user: createMockUser({ is_qbnewb: true }),
+          });
+          expect(result.uiControls.isShowingNewbModal).toBeFalsy();
+        });
+
+        it("handles error if couldn't deserialize card hash", async () => {
+          const error = new Error("failed to deserialize card");
+          jest
+            .spyOn(CardLib, "deserializeCardFromUrl")
+            .mockImplementation(() => {
+              throw error;
+            });
+
+          const { dispatch } = await setup({ question });
+
+          expect(dispatch).toHaveBeenCalledWith(setErrorPage(error));
+        });
+      });
+    });
+  });
+
+  describe("models", () => {
+    MODEL_TEST_CASES.forEach(testCase => {
+      const { question, questionType } = testCase;
+
+      describe(questionType, () => {
+        it("runs question query on /query route", async () => {
+          const runQuestionQuerySpy = jest.spyOn(querying, "runQuestionQuery");
+          const baseUrl = Urls.question(question.card());
+          const location = getLocationForQuestion(question, {
+            pathname: `${baseUrl}/query`,
+          });
+
+          await setup({ question, location });
+
+          expect(runQuestionQuerySpy).toHaveBeenCalledTimes(1);
+        });
+        it("runs question query on /metadata route", async () => {
+          const runQuestionQuerySpy = jest.spyOn(querying, "runQuestionQuery");
+          const baseUrl = Urls.question(question.card());
+          const location = getLocationForQuestion(question, {
+            pathname: `${baseUrl}/metadata`,
+          });
+
+          await setup({ question, location });
+
+          expect(runQuestionQuerySpy).toHaveBeenCalledTimes(1);
+        });
+
+        it("sets UI state correctly for /query route", async () => {
+          const baseUrl = Urls.question(question.card());
+          const location = getLocationForQuestion(question, {
+            pathname: `${baseUrl}/query`,
+          });
+
+          const { result } = await setup({ question, location });
+
+          expect(result.uiControls.queryBuilderMode).toBe("dataset");
+          expect(result.uiControls.datasetEditorTab).toBe("query");
+        });
+
+        it("sets UI state correctly for /metadata route", async () => {
+          const baseUrl = Urls.question(question.card());
+          const location = getLocationForQuestion(question, {
+            pathname: `${baseUrl}/metadata`,
+          });
+
+          const { result } = await setup({ question, location });
+
+          expect(result.uiControls.queryBuilderMode).toBe("dataset");
+          expect(result.uiControls.datasetEditorTab).toBe("metadata");
+        });
+      });
+    });
+  });
+});

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.unit.spec.ts
@@ -715,12 +715,22 @@ describe("QB Actions > initializeQB", () => {
       expect(redirectSpy).toHaveBeenCalledTimes(1);
     });
 
+    it("constructs a card based on provided 'db' param", async () => {
+      const expectedCard = Question.create({
+        databaseId: SAMPLE_DATABASE?.id,
+      }).card();
+
+      const { result } = await setupBlank({ db: SAMPLE_DATABASE?.id });
+      const question = new Question(result.card, metadata);
+      const query = question.query() as StructuredQuery;
+
+      expect(result.card).toEqual(expectedCard);
+      expect(query.sourceTableId()).toBe(null);
+      expect(result.originalCard).toBeUndefined();
+    });
+
     it("constructs a card based on provided 'db' and 'table' params", async () => {
-      const expectedCard = {
-        ...ORDERS.question().card(),
-        name: null,
-        collection_id: undefined,
-      };
+      const expectedCard = ORDERS.question().card();
 
       const { result } = await setupOrdersTable();
 
@@ -744,6 +754,12 @@ describe("QB Actions > initializeQB", () => {
       const [aggregation] = query.aggregations();
 
       expect(aggregation.raw()).toEqual(["metric", METRIC_ID]);
+    });
+
+    it("opens summarization sidebar if metric is applied", async () => {
+      const METRIC_ID = 777;
+      const { result } = await setupOrdersTable({ metric: METRIC_ID });
+      expect(result.uiControls.isShowingSummarySidebar).toBe(true);
     });
 
     it("applies both 'metric' and 'segment' params", async () => {

--- a/frontend/src/metabase/query_builder/actions/core/parameterUtils.ts
+++ b/frontend/src/metabase/query_builder/actions/core/parameterUtils.ts
@@ -1,0 +1,152 @@
+import _ from "underscore";
+
+import { cardIsEquivalent } from "metabase/meta/Card";
+
+import { DashboardApi } from "metabase/services";
+
+import { setErrorPage } from "metabase/redux/app";
+import { getMetadata } from "metabase/selectors/metadata";
+
+import { getValueAndFieldIdPopulatedParametersFromCard } from "metabase/parameters/utils/cards";
+import { hasMatchingParameters } from "metabase/parameters/utils/dashboards";
+import { getParameterValuesByIdFromQueryParams } from "metabase/parameters/utils/parameter-values";
+
+import Metadata from "metabase-lib/lib/metadata/Metadata";
+
+import { Dispatch, GetState } from "metabase-types/store";
+
+import { Card, SavedCard } from "metabase-types/types/Card";
+import { Parameter } from "metabase-types/types/Parameter";
+
+type BlankQueryOptions = {
+  db?: string;
+  table?: string;
+  segment?: string;
+  metric?: string;
+};
+
+type QueryParams = BlankQueryOptions & {
+  slug?: string;
+  objectId?: string;
+};
+
+function checkShouldPropagateDashboardParameters({
+  cardId,
+  deserializedCard,
+  originalCard,
+}: {
+  cardId?: number;
+  deserializedCard?: Card;
+  originalCard?: Card;
+}) {
+  if (!deserializedCard) {
+    return false;
+  }
+  if (cardId && deserializedCard.parameters) {
+    return true;
+  }
+  if (!originalCard) {
+    return false;
+  }
+  const equalCards = cardIsEquivalent(deserializedCard, originalCard, {
+    checkParameters: false,
+  });
+  const differentParameters = !cardIsEquivalent(
+    deserializedCard,
+    originalCard,
+    { checkParameters: true },
+  );
+  return equalCards && differentParameters;
+}
+
+async function verifyMatchingDashcardAndParameters({
+  dispatch,
+  dashboardId,
+  dashcardId,
+  cardId,
+  parameters,
+  metadata,
+}: {
+  dispatch: Dispatch;
+  dashboardId: number;
+  dashcardId: number;
+  cardId: number;
+  parameters: Parameter[];
+  metadata: Metadata;
+}) {
+  try {
+    const dashboard = await DashboardApi.get({ dashId: dashboardId });
+    if (
+      !hasMatchingParameters({
+        dashboard,
+        dashcardId,
+        cardId,
+        parameters,
+        metadata,
+      })
+    ) {
+      dispatch(setErrorPage({ status: 403 }));
+    }
+  } catch (error) {
+    dispatch(setErrorPage(error));
+  }
+}
+
+export function getParameterValuesForQuestion({
+  card,
+  queryParams,
+  metadata,
+}: {
+  card: Card;
+  queryParams?: QueryParams;
+  metadata: Metadata;
+}) {
+  const parameters = getValueAndFieldIdPopulatedParametersFromCard(
+    card,
+    metadata,
+  );
+  return getParameterValuesByIdFromQueryParams(
+    parameters,
+    queryParams,
+    metadata,
+  );
+}
+
+export async function handleDashboardParameters(
+  card: Card,
+  {
+    deserializedCard,
+    originalCard,
+    dispatch,
+    getState,
+  }: {
+    cardId?: number;
+    deserializedCard?: Card;
+    originalCard?: Card;
+    dispatch: Dispatch;
+    getState: GetState;
+  },
+) {
+  const cardId = (card as SavedCard).id;
+  const shouldPropagateParameters = checkShouldPropagateDashboardParameters({
+    cardId,
+    deserializedCard,
+    originalCard,
+  });
+  if (shouldPropagateParameters && deserializedCard) {
+    const { dashboardId, dashcardId, parameters } = deserializedCard;
+    const metadata = getMetadata(getState());
+    await verifyMatchingDashcardAndParameters({
+      dispatch,
+      cardId,
+      metadata,
+      dashboardId: dashboardId as number,
+      dashcardId: dashcardId as number,
+      parameters: parameters as Parameter[],
+    });
+
+    card.parameters = parameters;
+    card.dashboardId = dashboardId;
+    card.dashcardId = dashcardId;
+  }
+}

--- a/frontend/src/metabase/query_builder/actions/navigation.js
+++ b/frontend/src/metabase/query_builder/actions/navigation.js
@@ -20,10 +20,10 @@ import {
   getQueryBuilderMode,
   getQuestion,
 } from "../selectors";
+import { getQueryBuilderModeFromLocation } from "../typed-utils";
 import {
   getCurrentQueryParams,
   getPathNameFromQueryBuilderMode,
-  getQueryBuilderModeFromLocation,
   getURLForCardState,
 } from "../utils";
 
@@ -68,7 +68,7 @@ export const popState = createThunkAction(
     }
 
     const {
-      mode: queryBuilderModeFromURL,
+      queryBuilderMode: queryBuilderModeFromURL,
       ...uiControls
     } = getQueryBuilderModeFromLocation(location);
 

--- a/frontend/src/metabase/query_builder/actions/querying.js
+++ b/frontend/src/metabase/query_builder/actions/querying.js
@@ -84,7 +84,7 @@ export const RUN_QUERY = "metabase/qb/RUN_QUERY";
 export const runQuestionQuery = ({
   shouldUpdateUrl = true,
   ignoreCache = false,
-  overrideWithCard,
+  overrideWithCard = null,
 } = {}) => {
   return async (dispatch, getState) => {
     dispatch(loadStartUIControls());

--- a/frontend/src/metabase/query_builder/typed-utils.ts
+++ b/frontend/src/metabase/query_builder/typed-utils.ts
@@ -1,0 +1,27 @@
+import { LocationDescriptorObject } from "history";
+import { QueryBuilderMode, DatasetEditorTab } from "metabase-types/store";
+
+type LocationQBModeResult = {
+  queryBuilderMode: QueryBuilderMode;
+  datasetEditorTab?: DatasetEditorTab;
+};
+
+export function getQueryBuilderModeFromLocation(
+  location: LocationDescriptorObject,
+): LocationQBModeResult {
+  const { pathname } = location;
+  if (pathname?.endsWith("/notebook")) {
+    return {
+      queryBuilderMode: "notebook",
+    };
+  }
+  if (pathname?.endsWith("/query") || pathname?.endsWith("/metadata")) {
+    return {
+      queryBuilderMode: "dataset",
+      datasetEditorTab: pathname.endsWith("/query") ? "query" : "metadata",
+    };
+  }
+  return {
+    queryBuilderMode: "view",
+  };
+}

--- a/frontend/src/metabase/query_builder/utils.js
+++ b/frontend/src/metabase/query_builder/utils.js
@@ -3,26 +3,6 @@ import { isSupportedTemplateTagForModel } from "metabase/lib/data-modeling/utils
 import * as Urls from "metabase/lib/urls";
 import NativeQuery from "metabase-lib/lib/queries/NativeQuery";
 
-// Query Builder Mode
-
-export function getQueryBuilderModeFromLocation(location) {
-  const { pathname } = location;
-  if (pathname.endsWith("/notebook")) {
-    return {
-      mode: "notebook",
-    };
-  }
-  if (pathname.endsWith("/query") || pathname.endsWith("/metadata")) {
-    return {
-      mode: "dataset",
-      datasetEditorTab: pathname.endsWith("/query") ? "query" : "metadata",
-    };
-  }
-  return {
-    mode: "view",
-  };
-}
-
 export function getPathNameFromQueryBuilderMode({
   pathname,
   queryBuilderMode,


### PR DESCRIPTION
Adds extensive coverage, refactors, and cleans up query builder's `initializeQB` action. Also converts the action's code to TypeScript, so it's moved to a separate `.ts` file. Also, adds `metabase-lib/mocks` file with question instances factories for unit tests.