### PR TITLE
Add `experimental-enable-actions` flag to FE

### DIFF
--- a/frontend/src/metabase/lib/settings.ts
+++ b/frontend/src/metabase/lib/settings.ts
@@ -66,6 +66,7 @@ export type SettingName =
   | "enable-enhancements?"
   | "enable-public-sharing"
   | "enable-xrays"
+  | "experimental-enable-actions"
   | "persisted-models-enabled"
   | "engines"
   | "ga-code"

--- a/frontend/src/metabase/writeback/selectors.ts
+++ b/frontend/src/metabase/writeback/selectors.ts
@@ -1,0 +1,6 @@
+import { getSetting } from "metabase/selectors/settings";
+import { State } from "metabase-types/store";
+
+export function getWritebackEnabled(state: State) {
+  return getSetting(state, "experimental-enable-actions");
+}


### PR DESCRIPTION
Part of #22542. Adds basic code to work with the `experimental-enable-actions` flag from #22551 to the frontend