### PR TITLE
Do not run percy tests on release branches

### DIFF
--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - master
-      - "release-**"
     paths-ignore:
       - "docs/**"
       - "**.md"


### PR DESCRIPTION
We develop and run specs agains `master` so let's save Percy credits and stop running Percy tests on every commit in release branches.