### PR TITLE
Round date values when filtering relative dates

### DIFF
--- a/frontend/src/metabase/lib/query_time.js
+++ b/frontend/src/metabase/lib/query_time.js
@@ -30,14 +30,16 @@ export const DATETIME_UNITS = [
 
 export function computeFilterTimeRange(filter) {
   let expandedFilter;
+  let defaultUnit;
   if (filter[0] === "time-interval") {
+    defaultUnit = filter[3];
     expandedFilter = expandTimeIntervalFilter(filter);
   } else {
     expandedFilter = filter;
   }
 
   const [operator, field, ...values] = expandedFilter;
-  const bucketing = parseFieldBucketing(field, "day");
+  const bucketing = parseFieldBucketing(field, defaultUnit ?? "day");
 
   let start, end;
   if (isStartingFrom(filter)) {

--- a/frontend/test/metabase/scenarios/dashboard-filters/reproductions/22482-round-relative-ranges.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/reproductions/22482-round-relative-ranges.cy.spec.js
@@ -1,0 +1,56 @@
+import moment from "moment";
+import {
+  restore,
+  popover,
+  filterWidget,
+  editDashboard,
+  saveDashboard,
+  setFilter,
+  visitDashboard,
+} from "__support__/e2e/cypress";
+
+describe("issue 22482", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    visitDashboard(1);
+
+    editDashboard();
+    setFilter("Time", "All Options");
+
+    cy.findByText("Select…").click();
+    popover()
+      .contains("Created At")
+      .eq(0)
+      .click();
+
+    saveDashboard();
+
+    filterWidget().click();
+    cy.findByText("Relative dates...").click();
+  });
+
+  it("should round relative date range (metabase#22482)", () => {
+    cy.findByTestId("relative-datetime-value")
+      .clear()
+      .type(15);
+    cy.findByTestId("relative-datetime-unit").click();
+    cy.findByText("months").click();
+
+    const expectedRange = getFormattedRange(
+      moment()
+        .startOf("month")
+        .add(-16, "month"),
+      moment()
+        .add(-1, "month")
+        .endOf("month"),
+    );
+
+    cy.findByText(expectedRange);
+  });
+});
+
+function getFormattedRange(start, end) {
+  return `${start.format("MMM D, YYYY")} - ${end.format("MMM D, YYYY")}`;
+}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/22482
Reproduces https://github.com/metabase/metabase/issues/22482

## Changes
Round date values when filtering relative dates. When users select past 3 month we should always start the range from the first day of current month minus four.

## How to verify
Check the original issue for repro steps