### PR TITLE
Moving E2E from BuildJet to GHA

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -16,7 +16,7 @@ jobs:
 
   build:
     if: github.event.pull_request.draft == false
-    runs-on: buildjet-2vcpu-ubuntu-2004
+    runs-on: ubuntu-20.04
     timeout-minutes: 25
     strategy:
       matrix:
@@ -42,7 +42,7 @@ jobs:
       uses: ./.github/actions/prepare-uberjar-artifact
 
   e2e-tests:
-    runs-on: buildjet-4vcpu-ubuntu-2004
+    runs-on: ubuntu-20.04
     timeout-minutes: 30
     needs: build
     name: e2e-tests-${{ matrix.folder }}-${{ matrix.edition }}


### PR DESCRIPTION
Now that we have an Enterprise (180 runners) account we can move the E2E Tests to GH Runners and have the same machines as the ones running on Master