### PR TITLE
Remove unused nav color constant

### DIFF
--- a/frontend/src/metabase/nav/constants.js
+++ b/frontend/src/metabase/nav/constants.js
@@ -1,7 +1,3 @@
-import { color, lighten } from "metabase/lib/colors";
-
-export const getDefaultSearchColor = () => lighten(color("nav"), 0.07);
-
 export const APP_BAR_HEIGHT = "52px";
 export const ADMIN_NAVBAR_HEIGHT = "65px";
 export const NAV_SIDEBAR_WIDTH = "324px";


### PR DESCRIPTION
This constant was not called anywhere in our codebase as far as I could tell.

We have removed the customizability of `color("nav")`.

Part of fix #22221