### PR TITLE
Remove delete button from archive app

### DIFF
--- a/frontend/src/metabase/home/containers/ArchiveApp.jsx
+++ b/frontend/src/metabase/home/containers/ArchiveApp.jsx
@@ -93,14 +93,6 @@ export default class ArchiveApp extends Component {
                           }
                         : null
                     }
-                    onDelete={
-                      item.delete
-                        ? async () => {
-                            await item.delete();
-                            reload();
-                          }
-                        : null
-                    }
                     selected={selection.has(item)}
                     onToggleSelected={() => onToggleSelected(item)}
                     showSelect={selected.length > 0}
@@ -144,17 +136,6 @@ const BulkActionControls = ({ selected, reload }) => (
         }
       }}
     >{t`Unarchive`}</Button>
-    <Button
-      ml={1}
-      medium
-      onClick={async () => {
-        try {
-          await Promise.all(selected.map(item => item.delete && item.delete()));
-        } finally {
-          reload();
-        }
-      }}
-    >{t`Delete`}</Button>
   </span>
 );
 


### PR DESCRIPTION
Closes #18372 

⚠️ This is conceptually wrong - for now. 
See discussions below.

### How to test

1. Create a collection
2. Archive it
3. Go to http://localhost:3000/archive
4. Select a collection by clicking on the checkbox to the left of the collection name

You should see a bar at the bottom of the window.
It should include an `Unarchive` button.
It should no longer include a `Delete` button.