### PR TITLE
Remove `memoize` decorator

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,9 +1,5 @@
 {
-  "plugins": [
-    "@emotion",
-    "@babel/plugin-proposal-export-default-from",
-    ["@babel/plugin-proposal-decorators", { "legacy": true }]
-  ],
+  "plugins": ["@emotion"],
   "presets": [
     "@babel/preset-env",
     "@babel/preset-react",

--- a/frontend/src/metabase-lib/lib/Question.ts
+++ b/frontend/src/metabase-lib/lib/Question.ts
@@ -23,7 +23,7 @@ import {
 import Mode from "metabase-lib/lib/Mode";
 import { isStandard } from "metabase/lib/query/filter";
 import { isFK } from "metabase/lib/schema_metadata";
-import { memoize, sortObject } from "metabase-lib/lib/utils";
+import { memoizeClass, sortObject } from "metabase-lib/lib/utils";
 // TODO: remove these dependencies
 import * as Urls from "metabase/lib/urls";
 import {
@@ -96,7 +96,7 @@ export type QuestionCreatorOpts = {
  * This is a wrapper around a question/card object, which may contain one or more Query objects
  */
 
-export default class Question {
+class Question {
   /**
    * The plain object presentation of this question, equal to the format that Metabase REST API understands.
    * It is called `card` for both historical reasons and to make a clear distinction to this class.
@@ -256,7 +256,6 @@ export default class Question {
    *
    * This is just a wrapper object, the data is stored in `this._card.dataset_query` in a format specific to the query type.
    */
-  @memoize
   query(): AtomicQuery {
     const datasetQuery = this._card.dataset_query;
 
@@ -823,7 +822,6 @@ export default class Question {
     }
   }
 
-  @memoize
   mode(): Mode | null | undefined {
     return Mode.forQuestion(this);
   }
@@ -1340,3 +1338,5 @@ export default class Question {
     return getIn(this, ["_card", "moderation_reviews"]) || [];
   }
 }
+
+export default memoizeClass("query", "mode")(Question);

--- a/frontend/src/metabase-lib/lib/Question.ts
+++ b/frontend/src/metabase-lib/lib/Question.ts
@@ -152,43 +152,6 @@ class QuestionInner {
     );
   }
 
-  /**
-   * TODO Atte Keinänen 6/13/17: Discussed with Tom that we could use the default Question constructor instead,
-   * but it would require changing the constructor signature so that `card` is an optional parameter and has a default value
-   */
-  static create({
-    databaseId,
-    tableId,
-    collectionId,
-    metadata,
-    parameterValues,
-    type = "query",
-    name,
-    display = "table",
-    visualization_settings = {},
-    dataset_query = type === "native"
-      ? NATIVE_QUERY_TEMPLATE
-      : STRUCTURED_QUERY_TEMPLATE,
-  }: QuestionCreatorOpts = {}) {
-    let card: CardObject = {
-      name,
-      collection_id: collectionId,
-      display,
-      visualization_settings,
-      dataset_query,
-    };
-
-    if (tableId != null) {
-      card = assocIn(card, ["dataset_query", "query", "source-table"], tableId);
-    }
-
-    if (databaseId != null) {
-      card = assocIn(card, ["dataset_query", "database"], databaseId);
-    }
-
-    return new Question(card, metadata, parameterValues);
-  }
-
   metadata(): Metadata {
     return this._metadata;
   }
@@ -1339,7 +1302,44 @@ class QuestionInner {
   }
 }
 
-export default class Question extends memoizeClass(
+export default class Question extends memoizeClass<QuestionInner>(
   "query",
   "mode",
-)(QuestionInner) {}
+)(QuestionInner) {
+  /**
+   * TODO Atte Keinänen 6/13/17: Discussed with Tom that we could use the default Question constructor instead,
+   * but it would require changing the constructor signature so that `card` is an optional parameter and has a default value
+   */
+  static create({
+    databaseId,
+    tableId,
+    collectionId,
+    metadata,
+    parameterValues,
+    type = "query",
+    name,
+    display = "table",
+    visualization_settings = {},
+    dataset_query = type === "native"
+      ? NATIVE_QUERY_TEMPLATE
+      : STRUCTURED_QUERY_TEMPLATE,
+  }: QuestionCreatorOpts = {}) {
+    let card: CardObject = {
+      name,
+      collection_id: collectionId,
+      display,
+      visualization_settings,
+      dataset_query,
+    };
+
+    if (tableId != null) {
+      card = assocIn(card, ["dataset_query", "query", "source-table"], tableId);
+    }
+
+    if (databaseId != null) {
+      card = assocIn(card, ["dataset_query", "database"], databaseId);
+    }
+
+    return new Question(card, metadata, parameterValues);
+  }
+}

--- a/frontend/src/metabase-lib/lib/Question.ts
+++ b/frontend/src/metabase-lib/lib/Question.ts
@@ -96,7 +96,7 @@ export type QuestionCreatorOpts = {
  * This is a wrapper around a question/card object, which may contain one or more Query objects
  */
 
-class Question {
+class QuestionInner {
   /**
    * The plain object presentation of this question, equal to the format that Metabase REST API understands.
    * It is called `card` for both historical reasons and to make a clear distinction to this class.
@@ -1339,4 +1339,7 @@ class Question {
   }
 }
 
-export default memoizeClass("query", "mode")(Question);
+export default class Question extends memoizeClass(
+  "query",
+  "mode",
+)(QuestionInner) {}

--- a/frontend/src/metabase-lib/lib/metadata/Database.ts
+++ b/frontend/src/metabase-lib/lib/metadata/Database.ts
@@ -3,7 +3,7 @@
 import Question from "../Question";
 import Base from "./Base";
 import { generateSchemaId } from "metabase/lib/schema";
-import { memoize, createLookupByProperty } from "metabase-lib/lib/utils";
+import { createLookupByProperty, memoizeClass } from "metabase-lib/lib/utils";
 import Table from "./Table";
 import Schema from "./Schema";
 import Metadata from "./Metadata";
@@ -17,7 +17,7 @@ import Metadata from "./Metadata";
  * Backed by types/Database data structure which matches the backend API contract
  */
 
-export default class Database extends Base {
+class Database extends Base {
   id: number;
   name: string;
   description: string;
@@ -56,7 +56,6 @@ export default class Database extends Base {
   }
 
   // TABLES
-  @memoize
   tablesLookup() {
     return createLookupByProperty(this.tables, "id");
   }
@@ -184,3 +183,5 @@ export default class Database extends Base {
     this.auto_run_queries = auto_run_queries;
   }
 }
+
+export default memoizeClass("tablesLookup")(Database);

--- a/frontend/src/metabase-lib/lib/metadata/Database.ts
+++ b/frontend/src/metabase-lib/lib/metadata/Database.ts
@@ -17,7 +17,7 @@ import Metadata from "./Metadata";
  * Backed by types/Database data structure which matches the backend API contract
  */
 
-class Database extends Base {
+class DatabaseInner extends Base {
   id: number;
   name: string;
   description: string;
@@ -184,4 +184,6 @@ class Database extends Base {
   }
 }
 
-export default memoizeClass("tablesLookup")(Database);
+export default class Database extends memoizeClass("tablesLookup")(
+  DatabaseInner,
+) {}

--- a/frontend/src/metabase-lib/lib/metadata/Database.ts
+++ b/frontend/src/metabase-lib/lib/metadata/Database.ts
@@ -184,6 +184,6 @@ class DatabaseInner extends Base {
   }
 }
 
-export default class Database extends memoizeClass("tablesLookup")(
-  DatabaseInner,
-) {}
+export default class Database extends memoizeClass<DatabaseInner>(
+  "tablesLookup",
+)(DatabaseInner) {}

--- a/frontend/src/metabase-lib/lib/metadata/Field.ts
+++ b/frontend/src/metabase-lib/lib/metadata/Field.ts
@@ -2,7 +2,7 @@
 // @ts-nocheck
 import _ from "underscore";
 import moment from "moment";
-import { memoize, createLookupByProperty } from "metabase-lib/lib/utils";
+import { createLookupByProperty, memoizeClass } from "metabase-lib/lib/utils";
 import { formatField, stripId } from "metabase/lib/formatting";
 import { getFieldValues } from "metabase/lib/query/field";
 import {
@@ -41,7 +41,7 @@ import Base from "./Base";
  * Wrapper class for field metadata objects. Belongs to a Table.
  */
 
-export default class Field extends Base {
+class Field extends Base {
   name: string;
   semantic_type: string | null;
   table?: Table;
@@ -243,12 +243,10 @@ export default class Field extends Base {
   }
 
   // FILTERS
-  @memoize
   filterOperators(selected) {
     return getFilterOperators(this, this.table, selected);
   }
 
-  @memoize
   filterOperatorsLookup() {
     return createLookupByProperty(this.filterOperators(), "name");
   }
@@ -268,7 +266,6 @@ export default class Field extends Base {
   }
 
   // AGGREGATIONS
-  @memoize
   aggregationOperators() {
     return this.table
       ? this.table
@@ -281,7 +278,6 @@ export default class Field extends Base {
       : null;
   }
 
-  @memoize
   aggregationOperatorsLookup() {
     return createLookupByProperty(this.aggregationOperators(), "short");
   }
@@ -442,3 +438,10 @@ export default class Field extends Base {
     this.metadata = metadata;
   }
 }
+
+export default memoizeClass(
+  "filterOperators",
+  "filterOperatorsLookup",
+  "aggregationOperators",
+  "aggregationOperatorsLookup",
+)(Field);

--- a/frontend/src/metabase-lib/lib/metadata/Field.ts
+++ b/frontend/src/metabase-lib/lib/metadata/Field.ts
@@ -439,7 +439,7 @@ class FieldInner extends Base {
   }
 }
 
-export default class Field extends memoizeClass(
+export default class Field extends memoizeClass<FieldInner>(
   "filterOperators",
   "filterOperatorsLookup",
   "aggregationOperators",

--- a/frontend/src/metabase-lib/lib/metadata/Field.ts
+++ b/frontend/src/metabase-lib/lib/metadata/Field.ts
@@ -41,7 +41,7 @@ import Base from "./Base";
  * Wrapper class for field metadata objects. Belongs to a Table.
  */
 
-class Field extends Base {
+class FieldInner extends Base {
   name: string;
   semantic_type: string | null;
   table?: Table;
@@ -439,9 +439,9 @@ class Field extends Base {
   }
 }
 
-export default memoizeClass(
+export default class Field extends memoizeClass(
   "filterOperators",
   "filterOperatorsLookup",
   "aggregationOperators",
   "aggregationOperatorsLookup",
-)(Field);
+)(FieldInner) {}

--- a/frontend/src/metabase-lib/lib/metadata/Table.ts
+++ b/frontend/src/metabase-lib/lib/metadata/Table.ts
@@ -153,7 +153,7 @@ class TableInner extends Base {
   }
 }
 
-export default class Table extends memoizeClass(
+export default class Table extends memoizeClass<TableInner>(
   "aggregationOperators",
   "aggregationOperatorsLookup",
   "fieldsLookup",

--- a/frontend/src/metabase-lib/lib/metadata/Table.ts
+++ b/frontend/src/metabase-lib/lib/metadata/Table.ts
@@ -16,7 +16,7 @@ import { createLookupByProperty, memoizeClass } from "metabase-lib/lib/utils";
 
 /** This is the primary way people interact with tables */
 
-class Table extends Base {
+class TableInner extends Base {
   id: number;
   description?: string;
   fks?: any[];
@@ -153,8 +153,8 @@ class Table extends Base {
   }
 }
 
-export default memoizeClass(
+export default class Table extends memoizeClass(
   "aggregationOperators",
   "aggregationOperatorsLookup",
   "fieldsLookup",
-)(Table);
+)(TableInner) {}

--- a/frontend/src/metabase-lib/lib/metadata/Table.ts
+++ b/frontend/src/metabase-lib/lib/metadata/Table.ts
@@ -6,7 +6,7 @@ import Schema from "./Schema";
 import Base from "./Base";
 import { singularize } from "metabase/lib/formatting";
 import { getAggregationOperators } from "metabase/lib/schema_metadata";
-import { memoize, createLookupByProperty } from "metabase-lib/lib/utils";
+import { createLookupByProperty, memoizeClass } from "metabase-lib/lib/utils";
 
 /**
  * @typedef { import("./metadata").SchemaName } SchemaName
@@ -16,7 +16,7 @@ import { memoize, createLookupByProperty } from "metabase-lib/lib/utils";
 
 /** This is the primary way people interact with tables */
 
-export default class Table extends Base {
+class Table extends Base {
   id: number;
   description?: string;
   fks?: any[];
@@ -91,12 +91,10 @@ export default class Table extends Base {
   }
 
   // AGGREGATIONS
-  @memoize
   aggregationOperators() {
     return getAggregationOperators(this);
   }
 
-  @memoize
   aggregationOperatorsLookup() {
     return createLookupByProperty(this.aggregationOperators(), "short");
   }
@@ -116,7 +114,6 @@ export default class Table extends Base {
   }
 
   // FIELDS
-  @memoize
   fieldsLookup() {
     return createLookupByProperty(this.fields, "id");
   }
@@ -155,3 +152,9 @@ export default class Table extends Base {
     this.entity_type = entity_type;
   }
 }
+
+export default memoizeClass(
+  "aggregationOperators",
+  "aggregationOperatorsLookup",
+  "fieldsLookup",
+)(Table);

--- a/frontend/src/metabase-lib/lib/queries/Query.ts
+++ b/frontend/src/metabase-lib/lib/queries/Query.ts
@@ -6,7 +6,7 @@ import Metadata from "metabase-lib/lib/metadata/Metadata";
 import Question from "metabase-lib/lib/Question";
 import Dimension from "metabase-lib/lib/Dimension";
 import Variable from "metabase-lib/lib/Variable";
-import { memoize } from "metabase-lib/lib/utils";
+import { memoizeClass } from "metabase-lib/lib/utils";
 import DimensionOptions from "metabase-lib/lib/DimensionOptions";
 
 type QueryUpdateFn = (datasetQuery: DatasetQuery) => void;
@@ -14,7 +14,7 @@ type QueryUpdateFn = (datasetQuery: DatasetQuery) => void;
  * An abstract class for all query types (StructuredQuery & NativeQuery)
  */
 
-export default class Query {
+class Query {
   _metadata: Metadata;
 
   /**
@@ -34,7 +34,6 @@ export default class Query {
    * Returns a question updated with the current dataset query.
    * Can only be applied to query that is a direct child of the question.
    */
-  @memoize
   question(): Question {
     return this._originalQuestion.setQuery(this);
   }
@@ -132,3 +131,5 @@ export default class Query {
     }
   }
 }
+
+export default memoizeClass("question")(Query);

--- a/frontend/src/metabase-lib/lib/queries/Query.ts
+++ b/frontend/src/metabase-lib/lib/queries/Query.ts
@@ -14,7 +14,7 @@ type QueryUpdateFn = (datasetQuery: DatasetQuery) => void;
  * An abstract class for all query types (StructuredQuery & NativeQuery)
  */
 
-class Query {
+class QueryInner {
   _metadata: Metadata;
 
   /**
@@ -132,4 +132,4 @@ class Query {
   }
 }
 
-export default memoizeClass("question")(Query);
+export default class Query extends memoizeClass("question")(QueryInner) {}

--- a/frontend/src/metabase-lib/lib/queries/Query.ts
+++ b/frontend/src/metabase-lib/lib/queries/Query.ts
@@ -132,4 +132,6 @@ class QueryInner {
   }
 }
 
-export default class Query extends memoizeClass("question")(QueryInner) {}
+export default class Query extends memoizeClass<QueryInner>("question")(
+  QueryInner,
+) {}

--- a/frontend/src/metabase-lib/lib/queries/Query.ts
+++ b/frontend/src/metabase-lib/lib/queries/Query.ts
@@ -14,7 +14,7 @@ type QueryUpdateFn = (datasetQuery: DatasetQuery) => void;
  * An abstract class for all query types (StructuredQuery & NativeQuery)
  */
 
-class QueryInner {
+class Query {
   _metadata: Metadata;
 
   /**
@@ -132,6 +132,4 @@ class QueryInner {
   }
 }
 
-export default class Query extends memoizeClass<QueryInner>("question")(
-  QueryInner,
-) {}
+export default memoizeClass<Query>("question")(Query);

--- a/frontend/src/metabase-lib/lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/lib/queries/StructuredQuery.ts
@@ -13,7 +13,7 @@ import { isCompatibleAggregationOperatorForField } from "metabase/lib/schema_met
 import _ from "underscore";
 import { chain, updateIn } from "icepick";
 import { t } from "ttag";
-import { memoize } from "metabase-lib/lib/utils";
+import { memoizeClass } from "metabase-lib/lib/utils";
 import {
   StructuredQuery as StructuredQueryObject,
   Aggregation,
@@ -63,7 +63,7 @@ export const STRUCTURED_QUERY_TEMPLATE = {
  * A wrapper around an MBQL (`query` type @type {DatasetQuery}) object
  */
 
-export default class StructuredQuery extends AtomicQuery {
+class StructuredQueryInner extends AtomicQuery {
   static isDatasetQueryType(datasetQuery: DatasetQuery) {
     return datasetQuery && datasetQuery.type === STRUCTURED_QUERY_TEMPLATE.type;
   }
@@ -298,7 +298,6 @@ export default class StructuredQuery extends AtomicQuery {
   /**
    * @returns the table object, if a table is selected and loaded.
    */
-  @memoize
   table(): Table {
     const sourceQuery = this.sourceQuery();
 
@@ -822,7 +821,6 @@ export default class StructuredQuery extends AtomicQuery {
   /**
    * @returns An array of MBQL @type {Filter}s.
    */
-  @memoize
   filters(): FilterWrapper[] {
     return Q.getFilters(this.query()).map(
       (filter, index) => new FilterWrapper(filter, index, this),
@@ -964,7 +962,6 @@ export default class StructuredQuery extends AtomicQuery {
 
   // SORTS
   // TODO: standardize SORT vs ORDER_BY terminology
-  @memoize
   sorts(): OrderByWrapper[] {
     return Q.getOrderBys(this.query()).map(
       (sort, index) => new OrderByWrapper(sort, index, this),
@@ -1281,7 +1278,6 @@ export default class StructuredQuery extends AtomicQuery {
     return [...this.expressionDimensions(), ...this.tableDimensions()];
   }
 
-  @memoize
   tableDimensions(): Dimension[] {
     const table: Table = this.table();
     return table // HACK: ensure the dimensions are associated with this query
@@ -1291,7 +1287,6 @@ export default class StructuredQuery extends AtomicQuery {
       : [];
   }
 
-  @memoize
   expressionDimensions(): Dimension[] {
     return Object.entries(this.expressions()).map(
       ([expressionName, expression]) => {
@@ -1305,24 +1300,20 @@ export default class StructuredQuery extends AtomicQuery {
     );
   }
 
-  @memoize
   joinedDimensions(): Dimension[] {
     return [].concat(...this.joins().map(join => join.fieldsDimensions()));
   }
 
-  @memoize
   breakoutDimensions() {
     return this.breakouts().map(breakout => this.parseFieldReference(breakout));
   }
 
-  @memoize
   aggregationDimensions() {
     return this.aggregations().map(aggregation =>
       aggregation.aggregationDimension(),
     );
   }
 
-  @memoize
   fieldDimensions() {
     return this.fields().map((fieldClause, index) =>
       this.parseFieldReference(fieldClause),
@@ -1331,7 +1322,6 @@ export default class StructuredQuery extends AtomicQuery {
 
   // TODO: this replicates logic in the backend, we should have integration tests to ensure they match
   // NOTE: these will not have the correct columnName() if there are duplicates
-  @memoize
   columnDimensions() {
     if (this.hasAggregations() || this.hasBreakouts()) {
       const aggregations = this.aggregationDimensions();
@@ -1369,7 +1359,6 @@ export default class StructuredQuery extends AtomicQuery {
   }
 
   // TODO: this replicates logic in the backend, we should have integration tests to ensure they match
-  @memoize
   columnNames() {
     // NOTE: dimension.columnName() doesn't include suffixes for duplicated column names so we need to do that here
     const nameCounts = new Map();
@@ -1443,7 +1432,6 @@ export default class StructuredQuery extends AtomicQuery {
   /**
    * The (wrapped) source query, if any
    */
-  @memoize
   sourceQuery(): StructuredQuery | null | undefined {
     const sourceQuery = this.query()?.["source-query"];
 
@@ -1461,7 +1449,6 @@ export default class StructuredQuery extends AtomicQuery {
   /**
    * Returns the "first" of the nested queries, or this query it not nested
    */
-  @memoize
   rootQuery(): StructuredQuery {
     const sourceQuery = this.sourceQuery();
     return sourceQuery ? sourceQuery.rootQuery() : this;
@@ -1470,7 +1457,6 @@ export default class StructuredQuery extends AtomicQuery {
   /**
    * Returns the "last" nested query that is already summarized, or `null` if none are
    * */
-  @memoize
   lastSummarizedQuery(): StructuredQuery | null | undefined {
     if (this.hasAggregations() || !this.canNest()) {
       return this;
@@ -1484,7 +1470,6 @@ export default class StructuredQuery extends AtomicQuery {
    * Returns the "last" nested query that is already summarized, or the query itself.
    * Used in "view mode" to effectively ignore post-aggregation filter stages
    */
-  @memoize
   topLevelQuery(): StructuredQuery {
     if (!this.canNest()) {
       return this;
@@ -1661,6 +1646,26 @@ export default class StructuredQuery extends AtomicQuery {
     );
   }
 } // subclass of StructuredQuery that's returned by query.sourceQuery() to allow manipulation of source-query
+
+const StructuredQuery = memoizeClass(
+  "table",
+  "filters",
+  "sorts",
+  "tableDimensions",
+  "expressionDimensions",
+  "joinedDimensions",
+  "breakoutDimensions",
+  "aggregationDimensions",
+  "fieldDimensions",
+  "columnDimensions",
+  "columnNames",
+  "sourceQuery",
+  "rootQuery",
+  "lastSummarizedQuery",
+  "topLevelQuery",
+)(StructuredQueryInner);
+
+export default StructuredQuery;
 
 class NestedStructuredQuery extends StructuredQuery {
   _parent: StructuredQuery;

--- a/frontend/src/metabase-lib/lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/lib/queries/StructuredQuery.ts
@@ -1647,7 +1647,7 @@ class StructuredQueryInner extends AtomicQuery {
   }
 } // subclass of StructuredQuery that's returned by query.sourceQuery() to allow manipulation of source-query
 
-class StructuredQuery extends memoizeClass(
+class StructuredQuery extends memoizeClass<StructuredQueryInner>(
   "table",
   "filters",
   "sorts",

--- a/frontend/src/metabase-lib/lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/lib/queries/StructuredQuery.ts
@@ -1647,7 +1647,7 @@ class StructuredQueryInner extends AtomicQuery {
   }
 } // subclass of StructuredQuery that's returned by query.sourceQuery() to allow manipulation of source-query
 
-const StructuredQuery = memoizeClass(
+class StructuredQuery extends memoizeClass(
   "table",
   "filters",
   "sorts",
@@ -1663,7 +1663,7 @@ const StructuredQuery = memoizeClass(
   "rootQuery",
   "lastSummarizedQuery",
   "topLevelQuery",
-)(StructuredQueryInner);
+)(StructuredQueryInner) {}
 
 export default StructuredQuery;
 

--- a/frontend/src/metabase-lib/lib/utils.ts
+++ b/frontend/src/metabase-lib/lib/utils.ts
@@ -27,8 +27,8 @@ const memoized = new WeakMap();
 
 type Constructor<T> = new (...args: any[]) => T;
 
-export function memoizeClass<P, T extends Constructor<P>>(...keys: string[]) {
-  return function(Class: T) {
+export function memoizeClass<T>(...keys: string[]) {
+  return function(Class: Constructor<T>) {
     const descriptors = Object.getOwnPropertyDescriptors(Class.prototype);
 
     keys.forEach(key => {

--- a/frontend/src/metabase/core/components/AccordionList/AccordionList.jsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionList.jsx
@@ -7,12 +7,12 @@ import _ from "underscore";
 import { getIn } from "icepick";
 
 import Icon from "metabase/components/Icon";
-import { memoize } from "metabase-lib/lib/utils";
+import { memoizeClass } from "metabase-lib/lib/utils";
 import { AccordionListCell } from "./AccordionListCell";
 import { AccordionListRoot } from "./AccordionList.styled";
 import { getNextCursor, getPrevCursor } from "./utils";
 
-export default class AccordionList extends Component {
+class AccordionList extends Component {
   constructor(props, context) {
     super(props, context);
 
@@ -375,7 +375,6 @@ export default class AccordionList extends Component {
     }
   };
 
-  @memoize
   getRowsCached = (
     searchFilter,
     searchable,
@@ -667,3 +666,5 @@ export default class AccordionList extends Component {
     );
   }
 }
+
+export default memoizeClass(AccordionList, "getRowsCached");

--- a/frontend/src/metabase/core/components/AccordionList/AccordionList.jsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionList.jsx
@@ -7,12 +7,11 @@ import _ from "underscore";
 import { getIn } from "icepick";
 
 import Icon from "metabase/components/Icon";
-import { memoizeClass } from "metabase-lib/lib/utils";
 import { AccordionListCell } from "./AccordionListCell";
 import { AccordionListRoot } from "./AccordionList.styled";
 import { getNextCursor, getPrevCursor } from "./utils";
 
-class AccordionList extends Component {
+export default class AccordionList extends Component {
   constructor(props, context) {
     super(props, context);
 
@@ -375,7 +374,7 @@ class AccordionList extends Component {
     }
   };
 
-  getRowsCached(
+  getRowsCached = (
     searchFilter,
     searchable,
     sections,
@@ -385,7 +384,7 @@ class AccordionList extends Component {
     itemIsSelected,
     hideEmptySectionsInSearch,
     openSection,
-  ) {
+  ) => {
     const sectionIsExpanded = sectionIndex =>
       alwaysExpanded || openSection === sectionIndex;
     const sectionIsSearchable = sectionIndex =>
@@ -484,7 +483,7 @@ class AccordionList extends Component {
     }
 
     return rows;
-  }
+  };
 
   getRows() {
     const {
@@ -666,5 +665,3 @@ class AccordionList extends Component {
     );
   }
 }
-
-export default memoizeClass("getRowsCached")(AccordionList);

--- a/frontend/src/metabase/core/components/AccordionList/AccordionList.jsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionList.jsx
@@ -375,7 +375,7 @@ class AccordionList extends Component {
     }
   };
 
-  getRowsCached = (
+  getRowsCached(
     searchFilter,
     searchable,
     sections,
@@ -385,7 +385,7 @@ class AccordionList extends Component {
     itemIsSelected,
     hideEmptySectionsInSearch,
     openSection,
-  ) => {
+  ) {
     const sectionIsExpanded = sectionIndex =>
       alwaysExpanded || openSection === sectionIndex;
     const sectionIsSearchable = sectionIndex =>
@@ -484,7 +484,7 @@ class AccordionList extends Component {
     }
 
     return rows;
-  };
+  }
 
   getRows() {
     const {
@@ -667,4 +667,4 @@ class AccordionList extends Component {
   }
 }
 
-export default memoizeClass(AccordionList, "getRowsCached");
+export default memoizeClass("getRowsCached")(AccordionList);

--- a/frontend/src/metabase/visualizations/components/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive.jsx
@@ -13,7 +13,7 @@ import Tooltip from "metabase/components/Tooltip";
 
 import { formatValue } from "metabase/lib/formatting";
 import { isID, isPK, isFK } from "metabase/lib/schema_metadata";
-import { memoize } from "metabase-lib/lib/utils";
+import { memoizeClass } from "metabase-lib/lib/utils";
 import {
   getTableCellClickedObject,
   getTableHeaderClickedObject,
@@ -337,7 +337,6 @@ class TableInteractive extends Component {
     }
   }
   // NOTE: all arguments must be passed to the memoized method, not taken from this.props etc
-  @memoize
   _getCellClickedObjectCached(
     data,
     settings,
@@ -376,7 +375,6 @@ class TableInteractive extends Component {
     }
   }
   // NOTE: all arguments must be passed to the memoized method, not taken from this.props etc
-  @memoize
   _getHeaderClickedObjectCached(data, columnIndex, isPivoted) {
     return getTableHeaderClickedObject(data, columnIndex, isPivoted);
   }
@@ -402,13 +400,11 @@ class TableInteractive extends Component {
     }
   }
   // NOTE: all arguments must be passed to the memoized method, not taken from this.props etc
-  @memoize
   _visualizationIsClickableCached(visualizationIsClickable, clicked) {
     return visualizationIsClickable(clicked);
   }
 
   // NOTE: all arguments must be passed to the memoized method, not taken from this.props etc
-  @memoize
   getCellBackgroundColor(settings, value, rowIndex, columnName) {
     try {
       return settings["table._cell_background_getter"](
@@ -422,7 +418,6 @@ class TableInteractive extends Component {
   }
 
   // NOTE: all arguments must be passed to the memoized method, not taken from this.props etc
-  @memoize
   getCellFormattedValue(value, columnSettings, clicked) {
     try {
       return formatValue(value, {
@@ -600,7 +595,6 @@ class TableInteractive extends Component {
     return style.left;
   }
 
-  @memoize
   getDimension(column, query) {
     if (!query) {
       return undefined;
@@ -1045,9 +1039,19 @@ class TableInteractive extends Component {
   }
 }
 
-export default ExplicitSize({
-  refreshMode: props => (props.isDashboard ? "debounce" : "throttle"),
-})(TableInteractive);
+export default _.compose(
+  ExplicitSize({
+    refreshMode: props => (props.isDashboard ? "debounce" : "throttle"),
+  }),
+  memoizeClass(
+    "_getCellClickedObjectCached",
+    "_getHeaderClickedObjectCached",
+    "_visualizationIsClickableCached",
+    "getCellBackgroundColor",
+    "getCellFormattedValue",
+    "getDimension",
+  ),
+)(TableInteractive);
 
 const DetailShortcut = React.forwardRef((_props, ref) => (
   <div

--- a/frontend/src/metabase/visualizations/components/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization.jsx
@@ -40,7 +40,7 @@ export const ERROR_MESSAGE_PERMISSION = t`Sorry, you don't have permission to se
 
 import Question from "metabase-lib/lib/Question";
 import Mode from "metabase-lib/lib/Mode";
-import { memoize } from "metabase-lib/lib/utils";
+import { memoizeClass } from "metabase-lib/lib/utils";
 
 // NOTE: pass `CardVisualization` so that we don't include header when providing size to child element
 
@@ -184,7 +184,6 @@ class Visualization extends React.PureComponent {
     }
   };
 
-  @memoize
   _getQuestionForCardCached(metadata, card) {
     if (!metadata || !card) {
       return;
@@ -559,4 +558,5 @@ export default _.compose(
     refreshMode: props => (props.isDashboard ? "debounce" : "throttle"),
   }),
   connect(),
+  memoizeClass("_getQuestionForCardCached"),
 )(Visualization);

--- a/package.json
+++ b/package.json
@@ -107,8 +107,6 @@
     "@babel/cli": "^7.14.5",
     "@babel/core": "^7.14.6",
     "@babel/node": "^7.14.7",
-    "@babel/plugin-proposal-decorators": "^7.14.5",
-    "@babel/plugin-proposal-export-default-from": "^7.14.5",
     "@babel/preset-env": "^7.14.7",
     "@babel/preset-react": "^7.14.5",
     "@babel/preset-typescript": "^7.15.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -957,15 +957,6 @@
     "@babel/helper-plugin-utils" "^7.14.5"
     "@babel/plugin-syntax-decorators" "^7.16.0"
 
-"@babel/plugin-proposal-decorators@^7.14.5":
-  version "7.14.5"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.14.5.tgz#59bc4dfc1d665b5a6749cf798ff42297ed1b2c1d"
-  integrity sha512-LYz5nvQcvYeRVjui1Ykn28i+3aUiXwQ/3MGoEy0InTaz1pJo/lAzmIDXX+BQny/oufgHzJ6vnEEiXQ8KZjEVFg==
-  dependencies:
-    "@babel/helper-create-class-features-plugin" "^7.14.5"
-    "@babel/helper-plugin-utils" "^7.14.5"
-    "@babel/plugin-syntax-decorators" "^7.14.5"
-
 "@babel/plugin-proposal-dynamic-import@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.14.5.tgz#0c6617df461c0c1f8fff3b47cd59772360101d2c"
@@ -989,14 +980,6 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
     "@babel/plugin-syntax-export-default-from" "^7.16.0"
-
-"@babel/plugin-proposal-export-default-from@^7.14.5":
-  version "7.14.5"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-export-default-from/-/plugin-proposal-export-default-from-7.14.5.tgz#8931a6560632c650f92a8e5948f6e73019d6d321"
-  integrity sha512-T8KZ5abXvKMjF6JcoXjgac3ElmXf0AWzJwi2O/42Jk+HmCky3D9+i1B7NPP1FblyceqTevKeV/9szeikFoaMDg==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.14.5"
-    "@babel/plugin-syntax-export-default-from" "^7.14.5"
 
 "@babel/plugin-proposal-export-namespace-from@^7.14.5":
   version "7.14.5"
@@ -1240,13 +1223,6 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
-"@babel/plugin-syntax-decorators@^7.14.5":
-  version "7.14.5"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.14.5.tgz#eafb9c0cbe09c8afeb964ba3a7bbd63945a72f20"
-  integrity sha512-c4sZMRWL4GSvP1EXy0woIP7m4jkVcEuG8R1TOZxPBPtp4FSM/kiPZub9UIs/Jrb5ZAOzvTUSGYrWsrSu1JvoPw==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.14.5"
-
 "@babel/plugin-syntax-decorators@^7.16.0":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.16.0.tgz#eb8d811cdd1060f6ac3c00956bf3f6335505a32f"
@@ -1260,13 +1236,6 @@
   integrity sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
-
-"@babel/plugin-syntax-export-default-from@^7.14.5":
-  version "7.14.5"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-export-default-from/-/plugin-syntax-export-default-from-7.14.5.tgz#cdfa9d43d2b2c89b6f1af3e83518e8c8b9ed0dbc"
-  integrity sha512-snWDxjuaPEobRBnhpqEfZ8RMxDbHt8+87fiEioGuE+Uc0xAKgSD8QiuL3lF93hPVQfZFAcYwrrf+H5qUhike3Q==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.14.5"
 
 "@babel/plugin-syntax-export-default-from@^7.16.0":
   version "7.16.0"


### PR DESCRIPTION
This is a follow up to #22407 that removes the `memoize` decorator in a separate PR

# Why?

[The ECMAScript decorators proposal](https://github.com/tc39/proposal-decorators) has moved onto stage 3 in the standardization process with an API surface that is incompatible with [stage 1](https://github.com/wycats/javascript-decorators/blob/e1bf8d41bfa2591d949dd3bbf013514c8904b913/README.md) and [stage 2](https://github.com/tc39/proposal-decorators/tree/7fa580b40f2c19c561511ea2c978e307ae689a1b) decorators. This is a problem because many build tools like [`esbuild`](https://github.com/evanw/esbuild) that can improve our developer experience will not support the feature until it makes it into the standard, forcing us to use `@babel/plugin-proposal-decorators` for stage 1 decorators and Typescript's `experimentalDecorators` feature for stage 2 decorators like `memoize` in `metabase-lib/lib/utils`.


## Notes

* I removed `memoize` from `AccordionList.getRowsCached` because repeated calls would always return the first result even with different arguments - performance seemed to improve