### PR TITLE
Add `Actions` feature toggle to the database settings page

### DIFF
--- a/frontend/src/metabase-types/types/Database.ts
+++ b/frontend/src/metabase-types/types/Database.ts
@@ -20,6 +20,10 @@ export type DatabaseDetails = {
   [key: string]: any;
 };
 
+export type DatabaseSettings = {
+  [key: string]: any;
+};
+
 export type DatabaseEngine = string;
 
 export type DatabaseNativePermission = "write" | "read";
@@ -32,6 +36,7 @@ export type Database = {
   tables: Table[];
 
   details: DatabaseDetails;
+  settings?: DatabaseSettings | null;
   engine: DatabaseType;
   features: DatabaseFeature[];
   is_full_sync: boolean;

--- a/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.jsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.jsx
@@ -8,7 +8,10 @@ import ActionButton from "metabase/components/ActionButton";
 import ModalWithTrigger from "metabase/components/ModalWithTrigger";
 import ConfirmContent from "metabase/components/ConfirmContent";
 import Button from "metabase/core/components/Button";
-import { isDatabaseWritebackEnabled } from "metabase/writeback/utils";
+import {
+  isDatabaseWritebackEnabled,
+  isWritebackSupported,
+} from "metabase/writeback/utils";
 import { SidebarRoot } from "./Sidebar.styled";
 
 const propTypes = {
@@ -43,7 +46,10 @@ const DatabaseEditAppSidebar = ({
   const deleteDatabaseModal = useRef();
 
   const hasWriteback = isDatabaseWritebackEnabled(database);
-  const enableWriteback = isWritebackEnabled && typeof database.id === "number";
+  const showWriteback =
+    isWritebackEnabled &&
+    typeof database.id === "number" &&
+    isWritebackSupported(database);
 
   return (
     <SidebarRoot>
@@ -141,7 +147,7 @@ const DatabaseEditAppSidebar = ({
               </li>
             )}
 
-            {enableWriteback && (
+            {showWriteback && (
               <li className="mt2">
                 <ModalWithTrigger
                   ref={enableWritebackModal}

--- a/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx
@@ -13,6 +13,7 @@ import Breadcrumbs from "metabase/components/Breadcrumbs";
 import Sidebar from "metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar";
 import DriverWarning from "metabase/containers/DriverWarning";
 import { getUserIsAdmin } from "metabase/selectors/user";
+import { getWritebackEnabled } from "metabase/writeback/selectors";
 
 import Databases from "metabase/entities/databases";
 import { getSetting } from "metabase/selectors/settings";
@@ -29,6 +30,7 @@ import {
   reset,
   initializeDatabase,
   saveDatabase,
+  updateDatabase,
   syncDatabaseSchema,
   rescanDatabaseFields,
   discardSavedFieldValues,
@@ -56,6 +58,7 @@ const mapStateToProps = state => {
     databaseCreationStep: getDatabaseCreationStep(state),
     initializeError: getInitializeError(state),
     isAdmin: getUserIsAdmin(state),
+    isWritebackEnabled: getWritebackEnabled(state),
     isModelPersistenceEnabled: getSetting(state, "persisted-models-enabled"),
   };
 };
@@ -64,6 +67,7 @@ const mapDispatchToProps = {
   reset,
   initializeDatabase,
   saveDatabase,
+  updateDatabase,
   syncDatabaseSchema,
   rescanDatabaseFields,
   discardSavedFieldValues,
@@ -92,9 +96,11 @@ class DatabaseEditApp extends Component {
     unpersistDatabase: PropTypes.func.isRequired,
     deleteDatabase: PropTypes.func.isRequired,
     saveDatabase: PropTypes.func.isRequired,
+    updateDatabase: PropTypes.func.isRequired,
     selectEngine: PropTypes.func.isRequired,
     location: PropTypes.object,
     isAdmin: PropTypes.bool,
+    isWritebackEnabled: PropTypes.bool,
     isModelPersistenceEnabled: PropTypes.bool,
   };
 
@@ -107,6 +113,7 @@ class DatabaseEditApp extends Component {
     const {
       database,
       deleteDatabase,
+      updateDatabase,
       discardSavedFieldValues,
       initializeError,
       rescanDatabaseFields,
@@ -114,6 +121,7 @@ class DatabaseEditApp extends Component {
       persistDatabase,
       unpersistDatabase,
       isAdmin,
+      isWritebackEnabled,
       isModelPersistenceEnabled,
     } = this.props;
     const editingExistingDatabase = database?.id != null;
@@ -195,7 +203,9 @@ class DatabaseEditApp extends Component {
             <Sidebar
               database={database}
               isAdmin={isAdmin}
+              isWritebackEnabled={isWritebackEnabled}
               isModelPersistenceEnabled={isModelPersistenceEnabled}
+              updateDatabase={updateDatabase}
               deleteDatabase={deleteDatabase}
               discardSavedFieldValues={discardSavedFieldValues}
               rescanDatabaseFields={rescanDatabaseFields}

--- a/frontend/src/metabase/writeback/utils.ts
+++ b/frontend/src/metabase/writeback/utils.ts
@@ -1,0 +1,6 @@
+import { Database } from "metabase-types/types/Database";
+
+const DB_WRITEBACK_SETTING = "database-enable-actions";
+
+export const isDatabaseWritebackEnabled = (database: Database) =>
+  !!database?.settings?.[DB_WRITEBACK_SETTING];

--- a/frontend/src/metabase/writeback/utils.ts
+++ b/frontend/src/metabase/writeback/utils.ts
@@ -1,6 +1,11 @@
-import { Database } from "metabase-types/types/Database";
+import Database from "metabase-lib/lib/metadata/Database";
+import { Database as IDatabase } from "metabase-types/types/Database";
 
+const DB_WRITEBACK_FEATURE = "actions";
 const DB_WRITEBACK_SETTING = "database-enable-actions";
 
-export const isDatabaseWritebackEnabled = (database: Database) =>
+export const isDatabaseWritebackEnabled = (database: IDatabase) =>
   !!database?.settings?.[DB_WRITEBACK_SETTING];
+
+export const isWritebackSupported = (database: Database) =>
+  !!database?.hasFeature(DB_WRITEBACK_FEATURE);


### PR DESCRIPTION
Resolves #22545 
Part of #22542

Adds an option to enable experimental actions

![image](https://user-images.githubusercontent.com/653604/168274360-15f58251-a079-4888-a4d1-a1699f83a06d.png)

**NOTE** This depends on #22691 and #22689 to work