### PR TITLE
Tweak bulk action bar height

### DIFF
--- a/frontend/src/metabase/home/containers/ArchiveApp.styled.tsx
+++ b/frontend/src/metabase/home/containers/ArchiveApp.styled.tsx
@@ -17,7 +17,7 @@ export const ArchiveBody = styled.div`
 export const ArchiveBarContent = styled.div`
   display: flex;
   align-items: center;
-  padding: 1rem 4rem;
+  padding: 0.46rem 4rem;
 `;
 
 export const ArchiveBarText = styled.div`

--- a/frontend/src/metabase/home/containers/ArchiveApp.styled.tsx
+++ b/frontend/src/metabase/home/containers/ArchiveApp.styled.tsx
@@ -15,8 +15,12 @@ export const ArchiveBody = styled.div`
 `;
 
 export const ArchiveBarContent = styled.div`
-  display: flex;
   align-items: center;
+  display: flex;
+  // Height is hard-set so it remains
+  // the same as the ProfileLinkContainer
+  // in MainNavbar
+  height: 48px;
   padding: 8px 4rem 7px;
 `;
 

--- a/frontend/src/metabase/home/containers/ArchiveApp.styled.tsx
+++ b/frontend/src/metabase/home/containers/ArchiveApp.styled.tsx
@@ -17,7 +17,7 @@ export const ArchiveBody = styled.div`
 export const ArchiveBarContent = styled.div`
   display: flex;
   align-items: center;
-  padding: 0.46rem 4rem;
+  padding: 8px 4rem 7px;
 `;
 
 export const ArchiveBarText = styled.div`

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.styled.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.styled.tsx
@@ -135,6 +135,10 @@ export const LoadingTitle = styled.h2`
 export const ProfileLinkContainer = styled.div<{ isOpen: boolean }>`
   position: fixed;
   bottom: 0;
+  // Height is hard-set so it remains
+  // the same as the ArchiveBarContent
+  // in ArchiveApp
+  height: 49px;
   left: 0;
   padding: ${space(0)};
   width: ${props => (props.isOpen ? NAV_SIDEBAR_WIDTH : 0)};


### PR DESCRIPTION
Makes it same height as admin section on the main sidebar.

🎗️
This is a proposal.
We can easily think of increasing the height of the admin section of the main sidebar instead. 
I'd guess 99% or more of use cases are not about the archive page, hence tweaking the archive page to conform.

### After

<img src=https://user-images.githubusercontent.com/380816/167809866-fa0bfd3e-f4da-418a-8376-50ba46449e03.png width=500 />

### Before

<img src=https://user-images.githubusercontent.com/380816/167810094-fe88c9b3-da46-40ec-8ca1-57262c24c15c.png width=500 />
