### PR TITLE
Add test for embedding Metabase with locale parameter

### DIFF
--- a/frontend/test/metabase/scenarios/embedding/embedding-questions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/embedding-questions.cy.spec.js
@@ -168,6 +168,29 @@ describe("scenarios > embedding > questions ", () => {
 
     cy.contains("October 7, 2017, 1:34 AM");
   });
+
+  it("should display according to `locale` parameter metabase#22561", () => {
+    const CARD_ID = 1;
+    cy.request("PUT", `/api/card/${CARD_ID}`, { enable_embedding: true });
+
+    visitQuestion(CARD_ID);
+
+    cy.icon("share").click();
+    cy.findByText("Embed this question in an application").click();
+
+    visitIframe();
+
+    cy.url().then(url => {
+      cy.visit({
+        url,
+        qs: {
+          locale: "de",
+        },
+      });
+    });
+
+    cy.findByText("Februar 11, 2019, 9:40 PM");
+  });
 });
 
 function testPairedTooltipValues(val1, val2) {


### PR DESCRIPTION
This is a test for #22561

## Note to reviewers
As there's no translation built on CircleCI, this locale test relies on the date format changes via `moment`.
https://github.com/metabase/metabase/blob/491dbdc0e9e2293f041553a284265d95794ae067/frontend/test/metabase/scenarios/dashboard/dashboard_local-only.cy.spec.js#L12-L21