### PR TITLE
Fix embedded dashboard is not being updated after changing params

### DIFF
--- a/frontend/src/metabase/dashboard/utils.js
+++ b/frontend/src/metabase/dashboard/utils.js
@@ -85,7 +85,7 @@ export async function fetchDataOrError(dataPromise) {
   }
 }
 
-export function getDatasetQueryParams(datasetQuery) {
+export function getDatasetQueryParams(datasetQuery = {}) {
   const { type, query, native, parameters = [] } = datasetQuery;
   return { type, query, native, parameters };
 }

--- a/frontend/test/metabase/scenarios/sharing/reproductions/22524-public-dashboard-updates-after-changing-parameters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/reproductions/22524-public-dashboard-updates-after-changing-parameters.cy.spec.js
@@ -1,0 +1,68 @@
+import {
+  restore,
+  popover,
+  visitDashboard,
+  saveDashboard,
+  editDashboard,
+  setFilter,
+} from "__support__/e2e/cypress";
+
+const questionDetails = {
+  name: "22524 question",
+  native: {
+    query: "select * from people where city = {{city}}",
+    "template-tags": {
+      city: {
+        id: "6d077d39-a420-fd14-0b0b-a5eb611ce1e0",
+        name: "city",
+        "display-name": "City",
+        type: "text",
+      },
+    },
+  },
+};
+
+describe("issue 22524", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("update dashboard cards when changing parameters on publicly shared dashboards (metabase#22524)", () => {
+    cy.createNativeQuestionAndDashboard({ questionDetails }).then(
+      ({ body: { dashboard_id } }) => {
+        visitDashboard(dashboard_id);
+      },
+    );
+
+    editDashboard();
+    setFilter("Text or Category", "Dropdown");
+
+    cy.findByText("Select…").click();
+    popover()
+      .contains("City")
+      .click();
+
+    saveDashboard();
+
+    // Share dashboard
+    cy.icon("share").click();
+    cy.findByRole("switch").click();
+
+    cy.findByText("Public link")
+      .parent()
+      .within(() => {
+        cy.get("input").then(input => {
+          cy.visit(input.val());
+        });
+      });
+
+    // Set parameter value
+    cy.findByPlaceholderText("Text")
+      .clear()
+      .type("Rye{enter}");
+
+    // Check results
+    cy.findByText("2-7900 Cuerno Verde Road");
+  });
+});


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/22524
Reproduces https://github.com/metabase/metabase/issues/22524
Caused by https://github.com/metabase/metabase/pull/22197

## How to verify

- Create a native query `select * from people where city = {{city}}` and add it to a dashboard
- Add a filter Category -> Dropdown and connect to the query parameter
- Share dashboard and open public link
- Try enter any value like `Rye` and press Enter
- Ensure the dashboard card is being updated without reloading the page
