### PR TITLE
Fix whitelabeled logo proportions

### DIFF
--- a/frontend/src/metabase/nav/containers/AppBar.tsx
+++ b/frontend/src/metabase/nav/containers/AppBar.tsx
@@ -53,7 +53,7 @@ const mapDispatchToProps = {
 function HomepageLink({ handleClick }: { handleClick: () => void }) {
   return (
     <LogoLink to="/" onClick={handleClick} data-metabase-event="Navbar;Logo">
-      <LogoIcon size={24} />
+      <LogoIcon height={32} />
     </LogoLink>
   );
 }


### PR DESCRIPTION
### How to test

1. Run Metabase in Enterprise mode
2. Go to http://localhost:3000/admin/settings/whitelabel
3. Add a logo, try once in portrait and another time in landscape orientation
4. Go to http://localhost

Customized header logo should not be squashed.