### PR TITLE
Make persisted models use "create table as"

### DIFF
--- a/src/metabase/driver/ddl/postgres.clj
+++ b/src/metabase/driver/ddl/postgres.clj
@@ -68,7 +68,8 @@
                                        (create-table-sql database
                                                          {:table-name table-name
                                                           :field-definitions [{:field-name "field"
-                                                                               :base-type :type/Text}]})))]
+                                                                               :base-type :type/Text}]}
+                                                         "values (1)")))]
                      [:persist.check/read-table
                       (fn read-table [conn]
                         (jdbc/query conn [(format "select * from %s.%s"

--- a/src/metabase/driver/ddl/postgres.clj
+++ b/src/metabase/driver/ddl/postgres.clj
@@ -1,6 +1,5 @@
 (ns metabase.driver.ddl.postgres
   (:require [clojure.java.jdbc :as jdbc]
-            [clojure.string :as str]
             [clojure.tools.logging :as log]
             [metabase.driver.ddl.interface :as ddl.i]
             [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]


### PR DESCRIPTION
There are outstanding issues with database type erasure.

If we try to recreate table columns based on the saved
definition we'll get types such as `type/Structured` that
could be `json`, `xml`, etc. Perhaps worse, consider 'citext' that we
see as `type/Text`. If they have queries on the model such as
`where email = 'JOE@example.com'` that would start to return different
results if we created the table with `email text` rather than
`email citext`.

By using `create table ... as select ....`, we avoid this issue as the db types
selected will match the db types queried.
