### PR TITLE
Add basic insert/update row form UI

### DIFF
--- a/frontend/src/metabase-lib/lib/metadata/Field.ts
+++ b/frontend/src/metabase-lib/lib/metadata/Field.ts
@@ -43,6 +43,7 @@ import Base from "./Base";
 
 class FieldInner extends Base {
   name: string;
+  description: string | null;
   semantic_type: string | null;
   table?: Table;
 

--- a/frontend/src/metabase-lib/lib/metadata/Field.ts
+++ b/frontend/src/metabase-lib/lib/metadata/Field.ts
@@ -30,6 +30,7 @@ import {
   getIconForField,
   getFilterOperators,
 } from "metabase/lib/schema_metadata";
+import { FieldFingerprint } from "metabase-types/api/field";
 import { FieldDimension } from "../Dimension";
 import Table from "./Table";
 import Base from "./Base";
@@ -42,9 +43,11 @@ import Base from "./Base";
  */
 
 class FieldInner extends Base {
+  id?: number;
   name: string;
   description: string | null;
   semantic_type: string | null;
+  fingerprint?: FieldFingerprint;
   table?: Table;
 
   parent() {

--- a/frontend/src/metabase-lib/lib/metadata/Table.ts
+++ b/frontend/src/metabase-lib/lib/metadata/Table.ts
@@ -7,6 +7,7 @@ import Base from "./Base";
 import { singularize } from "metabase/lib/formatting";
 import { getAggregationOperators } from "metabase/lib/schema_metadata";
 import { createLookupByProperty, memoizeClass } from "metabase-lib/lib/utils";
+import Field from "./Field";
 
 /**
  * @typedef { import("./metadata").SchemaName } SchemaName
@@ -24,6 +25,7 @@ class TableInner extends Base {
   display_name: string;
   schema_name: string;
   db_id: number;
+  fields: Field[];
 
   hasSchema() {
     return (this.schema_name && this.db && this.db.schemas.length > 1) || false;

--- a/frontend/src/metabase-types/api/field.ts
+++ b/frontend/src/metabase-types/api/field.ts
@@ -1,3 +1,42 @@
+export type TextFieldFingerprint = {
+  "type/Text": {
+    "average-length": 13;
+    "percent-email": 0;
+    "percent-json": 0;
+    "percent-state": 0;
+    "percent-url": 0;
+  };
+};
+
+export type NumberFieldFingerprint = {
+  "type/Number": {
+    avg: number;
+    max: number;
+    min: number;
+    q1: number;
+    q3: number;
+    sd: number;
+  };
+};
+
+export type DateTimeFieldFingerprint = {
+  "type/DateTime": {
+    earliest: "2016-04-26T19:29:55.147Z";
+    latest: "2019-04-15T13:34:19.931Z";
+  };
+};
+
+export interface FieldFingerprint {
+  global: {
+    "distinct-count"?: number;
+    "nil%": 0;
+  };
+  type?:
+    | TextFieldFingerprint
+    | NumberFieldFingerprint
+    | DateTimeFieldFingerprint;
+}
+
 export interface Field {
   id: number;
   table_id: number;
@@ -5,4 +44,6 @@ export interface Field {
   base_type: string;
   description: string | null;
   nfc_path: string[] | null;
+
+  fingerprint: FieldFingerprint;
 }

--- a/frontend/src/metabase/components/FieldValuesWidget.jsx
+++ b/frontend/src/metabase/components/FieldValuesWidget.jsx
@@ -255,10 +255,11 @@ class FieldValuesWidgetInner extends Component {
       formatOptions,
       placeholder,
       forceTokenField = false,
-      valueRenderer = renderValue(fields, formatOptions, value, {
-        autoLoad: true,
-        compact: false,
-      }),
+      valueRenderer = value =>
+        renderValue(fields, formatOptions, value, {
+          autoLoad: true,
+          compact: false,
+        }),
       optionRenderer = option =>
         renderValue(fields, formatOptions, option[0], { autoLoad: false }),
       layoutRenderer = layoutProps => (

--- a/frontend/src/metabase/components/FieldValuesWidget.jsx
+++ b/frontend/src/metabase/components/FieldValuesWidget.jsx
@@ -254,6 +254,18 @@ class FieldValuesWidgetInner extends Component {
       disablePKRemappingForSearch,
       formatOptions,
       placeholder,
+      valueRenderer = renderValue(fields, formatOptions, value, {
+        autoLoad: true,
+        compact: false,
+      }),
+      optionRenderer = option =>
+        renderValue(fields, formatOptions, option[0], { autoLoad: false }),
+      layoutRenderer = layoutProps => (
+        <div>
+          {layoutProps.valuesList}
+          {renderOptions(this.state, this.props, layoutProps)}
+        </div>
+      ),
     } = this.props;
     const { loadingState, options: stateOptions } = this.state;
 
@@ -340,21 +352,9 @@ class FieldValuesWidgetInner extends Component {
             // end forwarded props
             options={options}
             valueKey={0}
-            valueRenderer={value =>
-              renderValue(fields, formatOptions, value, {
-                autoLoad: true,
-                compact: false,
-              })
-            }
-            optionRenderer={option =>
-              renderValue(fields, formatOptions, option[0], { autoLoad: false })
-            }
-            layoutRenderer={layoutProps => (
-              <div>
-                {layoutProps.valuesList}
-                {renderOptions(this.state, this.props, layoutProps)}
-              </div>
-            )}
+            valueRenderer={valueRenderer}
+            optionRenderer={optionRenderer}
+            layoutRenderer={layoutRenderer}
             filterOption={(option, filterString) => {
               const lowerCaseFilterString = filterString.toLowerCase();
               return option.some(

--- a/frontend/src/metabase/components/FieldValuesWidget.jsx
+++ b/frontend/src/metabase/components/FieldValuesWidget.jsx
@@ -254,6 +254,7 @@ class FieldValuesWidgetInner extends Component {
       disablePKRemappingForSearch,
       formatOptions,
       placeholder,
+      forceTokenField = false,
       valueRenderer = renderValue(fields, formatOptions, value, {
         autoLoad: true,
         compact: false,
@@ -321,7 +322,7 @@ class FieldValuesWidgetInner extends Component {
         }}
       >
         {isFetchingList && <LoadingState />}
-        {hasListData && (
+        {hasListData && !forceTokenField && (
           <ListField
             isDashboardFilter={parameter}
             placeholder={tokenFieldPlaceholder}
@@ -335,7 +336,7 @@ class FieldValuesWidgetInner extends Component {
             }
           />
         )}
-        {!hasListData && !isFetchingList && (
+        {(!hasListData || forceTokenField) && !isFetchingList && (
           <TokenField
             prefix={prefix}
             value={value.filter(v => v != null)}

--- a/frontend/src/metabase/components/TokenField.jsx
+++ b/frontend/src/metabase/components/TokenField.jsx
@@ -530,6 +530,9 @@ export default class TokenField extends Component {
         className={cx(
           className,
           "pl1 pt1 pb0 pr0 flex align-center flex-wrap bg-white scroll-x scroll-y",
+          {
+            "TokenField--focused": isFocused,
+          },
         )}
         style={{ maxHeight: 130, ...style }}
         onMouseDownCapture={this.onMouseDownCapture}
@@ -540,7 +543,11 @@ export default class TokenField extends Component {
           </span>
         )}
         {value.map((v, index) => (
-          <TokenFieldItem key={index} isValid={validateValue(v)}>
+          <TokenFieldItem
+            key={index}
+            className="TokenField-ItemWrapper"
+            isValid={validateValue(v)}
+          >
             <span
               style={{ ...defaultStyleValue, ...valueStyle }}
               className={multi ? "pl1 pr0" : "px1"}
@@ -562,7 +569,7 @@ export default class TokenField extends Component {
           </TokenFieldItem>
         ))}
         {canAddItems && (
-          <li className={cx("flex-full flex align-center mr1 mb1 p1")}>
+          <li className="TokenField-NewItemInputContainer flex-full flex align-center mr1 mb1 p1">
             <input
               ref={this.inputRef}
               style={{ ...defaultStyleValue, ...valueStyle }}

--- a/frontend/src/metabase/core/components/Input/Input.styled.tsx
+++ b/frontend/src/metabase/core/components/Input/Input.styled.tsx
@@ -29,7 +29,8 @@ export const InputField = styled.input<InputProps>`
   outline: none;
   text-align: inherit;
 
-  &:focus {
+  &:focus,
+  &:hover {
     border-color: ${color("brand")};
     transition: border 300ms ease-in-out;
   }

--- a/frontend/src/metabase/query_builder/components/QueryModals.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryModals.jsx
@@ -24,7 +24,7 @@ import NewDatasetModal from "metabase/query_builder/components/NewDatasetModal";
 
 import EntityCopyModal from "metabase/entities/containers/EntityCopyModal";
 
-import WritebackForm from "metabase/writeback/containers/WritebackForm";
+import WritebackModalForm from "metabase/writeback/containers/WritebackModalForm";
 
 import NewEventModal from "metabase/timelines/questions/containers/NewEventModal";
 import EditEventModal from "metabase/timelines/questions/containers/EditEventModal";
@@ -249,7 +249,11 @@ export default class QueryModals extends React.Component {
       </Modal>
     ) : modal === MODAL_TYPES.INSERT_ROW ? (
       <Modal onClose={onCloseModal}>
-        <WritebackForm table={question.table()} />
+        <WritebackModalForm
+          table={question.table()}
+          onSubmit={onCloseModal}
+          onClose={onCloseModal}
+        />
       </Modal>
     ) : null;
   }

--- a/frontend/src/metabase/query_builder/components/QueryModals.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryModals.jsx
@@ -21,7 +21,11 @@ import QuestionHistoryModal from "metabase/query_builder/containers/QuestionHist
 import { CreateAlertModalContent } from "metabase/query_builder/components/AlertModals";
 import { ImpossibleToCreateModelModal } from "metabase/query_builder/components/ImpossibleToCreateModelModal";
 import NewDatasetModal from "metabase/query_builder/components/NewDatasetModal";
+
 import EntityCopyModal from "metabase/entities/containers/EntityCopyModal";
+
+import WritebackForm from "metabase/writeback/containers/WritebackForm";
+
 import NewEventModal from "metabase/timelines/questions/containers/NewEventModal";
 import EditEventModal from "metabase/timelines/questions/containers/EditEventModal";
 import MoveEventModal from "metabase/timelines/questions/containers/MoveEventModal";
@@ -242,6 +246,10 @@ export default class QueryModals extends React.Component {
           collectionId={question.collectionId()}
           onClose={onCloseModal}
         />
+      </Modal>
+    ) : modal === MODAL_TYPES.INSERT_ROW ? (
+      <Modal onClose={onCloseModal}>
+        <WritebackForm table={question.table()} />
       </Modal>
     ) : null;
   }

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -437,7 +437,7 @@ function ViewTitleHeaderRightSide(props) {
   const hasRunButton =
     isRunnable && !isNativeEditorOpen && !isMissingPermissions;
 
-  const hasNewRowButton = isWritebackEnabled && isSaved && !isNative;
+  const hasNewRowButton = isWritebackEnabled && !isNative && query.isRaw();
 
   return (
     <div

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -7,6 +7,7 @@ import * as Urls from "metabase/lib/urls";
 import { SERVER_ERROR_TYPES } from "metabase/lib/errors";
 import MetabaseSettings from "metabase/lib/settings";
 
+import Button from "metabase/core/components/Button";
 import ButtonBar from "metabase/components/ButtonBar";
 import Link from "metabase/core/components/Link";
 import ViewButton from "metabase/query_builder/components/view/ViewButton";
@@ -14,6 +15,7 @@ import ViewButton from "metabase/query_builder/components/view/ViewButton";
 import { usePrevious } from "metabase/hooks/use-previous";
 import { useToggle } from "metabase/hooks/use-toggle";
 
+import { MODAL_TYPES } from "metabase/query_builder/constants";
 import SavedQuestionHeaderButton from "metabase/query_builder/components/SavedQuestionHeaderButton/SavedQuestionHeaderButton";
 
 import RunButtonWithTooltip from "../RunButtonWithTooltip";
@@ -64,6 +66,7 @@ const viewTitleHeaderPropTypes = {
   isShowingQuestionDetailsSidebar: PropTypes.bool,
   isObjectDetail: PropTypes.bool,
   isAdditionalInfoVisible: PropTypes.bool,
+  isWritebackEnabled: PropTypes.bool,
 
   runQuestionQuery: PropTypes.func,
   cancelQuery: PropTypes.func,
@@ -365,6 +368,7 @@ ViewTitleHeaderRightSide.propTypes = {
   isNativeEditorOpen: PropTypes.bool,
   isShowingFilterSidebar: PropTypes.bool,
   isShowingSummarySidebar: PropTypes.bool,
+  isWritebackEnabled: PropTypes.bool,
   isDirty: PropTypes.bool,
   isResultDirty: PropTypes.bool,
   isActionListVisible: PropTypes.bool,
@@ -395,6 +399,7 @@ function ViewTitleHeaderRightSide(props) {
     isNativeEditorOpen,
     isShowingFilterSidebar,
     isShowingSummarySidebar,
+    isWritebackEnabled,
     isDirty,
     isResultDirty,
     isActionListVisible,
@@ -432,6 +437,8 @@ function ViewTitleHeaderRightSide(props) {
   const hasRunButton =
     isRunnable && !isNativeEditorOpen && !isMissingPermissions;
 
+  const hasNewRowButton = isWritebackEnabled && isSaved && !isNative;
+
   return (
     <div
       className="ml-auto flex align-center"
@@ -463,6 +470,16 @@ function ViewTitleHeaderRightSide(props) {
           onExpand={onExpandFilters}
           onCollapse={onCollapseFilters}
         />
+      )}
+      {hasNewRowButton && (
+        <Button
+          primary
+          icon="add"
+          onClick={() => onOpenModal(MODAL_TYPES.INSERT_ROW)}
+          ml={1}
+        >
+          {t`New row`}
+        </Button>
       )}
       {QuestionFilterWidget.shouldRender(props) && (
         <QuestionFilterWidget

--- a/frontend/src/metabase/query_builder/constants.js
+++ b/frontend/src/metabase/query_builder/constants.js
@@ -17,6 +17,8 @@ export const MODAL_TYPES = {
   NEW_EVENT: "new-event",
   EDIT_EVENT: "edit-event",
   MOVE_EVENT: "move-event",
+
+  INSERT_ROW: "insert-row",
 };
 
 export const SIDEBAR_SIZES = {

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
@@ -11,9 +11,12 @@ import { push } from "react-router-redux";
 import { t } from "ttag";
 import _ from "underscore";
 
+import { getWritebackEnabled } from "metabase/writeback/selectors";
+
 import Bookmark from "metabase/entities/bookmarks";
 import Collections from "metabase/entities/collections";
 import Timelines from "metabase/entities/timelines";
+
 import { closeNavbar } from "metabase/redux/app";
 import { MetabaseApi } from "metabase/services";
 import { getMetadata } from "metabase/selectors/metadata";
@@ -168,6 +171,8 @@ const mapStateToProps = (state, props) => {
     isHeaderVisible: getIsHeaderVisible(state),
     isActionListVisible: getIsActionListVisible(state),
     isAdditionalInfoVisible: getIsAdditionalInfoVisible(state),
+
+    isWritebackEnabled: getWritebackEnabled(state),
 
     parameters: getParameters(state),
     databaseFields: getDatabaseFields(state),

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.styled.tsx
@@ -81,3 +81,12 @@ export const GridCell = styled.div<GridItemProps>`
   grid-column: span ${props => props.colSpan || 1} / span
     ${props => props.colSpan || 1};
 `;
+
+export const EditingFormContainer = styled.div`
+  overflow-y: auto;
+  flex: 1;
+  padding: 2rem;
+  ${breakpointMinMedium} {
+    max-height: calc(80vh - 4rem);
+  }
+`;

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
@@ -4,8 +4,10 @@ import { t } from "ttag";
 
 import Question from "metabase-lib/lib/Question";
 import { isPK } from "metabase/lib/schema_metadata";
-import { Table } from "metabase-types/types/Table";
+import Table from "metabase-lib/lib/metadata/Table";
+
 import { ForeignKey } from "metabase-types/api/foreignKey";
+import { State } from "metabase-types/store";
 import { DatasetData } from "metabase-types/types/Dataset";
 import { ObjectId, OnVisualizationClickType } from "./types";
 
@@ -35,6 +37,9 @@ import {
 } from "metabase/query_builder/selectors";
 import { columnSettings } from "metabase/visualizations/lib/settings/column";
 
+import WritebackForm from "metabase/writeback/containers/WritebackForm";
+import { getWritebackEnabled } from "metabase/writeback/selectors";
+
 import {
   getObjectName,
   getDisplayId,
@@ -49,9 +54,10 @@ import {
   ObjectIdLabel,
   CloseButton,
   ErrorWrapper,
+  EditingFormContainer,
 } from "./ObjectDetail.styled";
 
-const mapStateToProps = (state: unknown, { data }: ObjectDetailProps) => {
+const mapStateToProps = (state: State, { data }: ObjectDetailProps) => {
   let zoomedRowID = getZoomedObjectId(state);
   const isZooming = zoomedRowID != null;
 
@@ -73,6 +79,7 @@ const mapStateToProps = (state: unknown, { data }: ObjectDetailProps) => {
     canZoom: isZooming && !!zoomedRow,
     canZoomPreviousRow,
     canZoomNextRow,
+    isWritebackEnabled: getWritebackEnabled(state),
   };
 };
 
@@ -103,6 +110,7 @@ export interface ObjectDetailProps {
   canZoom: boolean;
   canZoomPreviousRow: boolean;
   canZoomNextRow: boolean;
+  isWritebackEnabled: boolean;
   onVisualizationClick: OnVisualizationClickType;
   visualizationIsClickable: (clicked: any) => boolean;
   fetchTableFks: (id: number) => void;
@@ -125,6 +133,7 @@ export function ObjectDetailFn({
   canZoom,
   canZoomPreviousRow,
   canZoomNextRow,
+  isWritebackEnabled,
   onVisualizationClick,
   visualizationIsClickable,
   fetchTableFks,
@@ -133,8 +142,10 @@ export function ObjectDetailFn({
   viewPreviousObjectDetail,
   viewNextObjectDetail,
   closeObjectDetail,
+  ...rest
 }: ObjectDetailProps): JSX.Element | null {
   const [hasNotFoundError, setHasNotFoundError] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
   const prevZoomedRowId = usePrevious(zoomedRowID);
   const prevData = usePrevious(data);
   const prevTableForeignKeys = usePrevious(tableForeignKeys);
@@ -235,6 +246,7 @@ export function ObjectDetailFn({
     !!tableForeignKeys.length &&
     hasPk
   );
+  const canEdit = !!(isWritebackEnabled && table);
 
   return (
     <Modal
@@ -256,22 +268,33 @@ export function ObjectDetailFn({
               objectId={displayId}
               canZoomPreviousRow={canZoomPreviousRow}
               canZoomNextRow={canZoomNextRow}
+              isEditing={isEditing}
+              canEdit={canEdit}
               viewPreviousObjectDetail={viewPreviousObjectDetail}
               viewNextObjectDetail={viewNextObjectDetail}
               closeObjectDetail={closeObjectDetail}
+              onToggleEditingModeClick={() => setIsEditing(editing => !editing)}
             />
-            <ObjectDetailBody
-              data={data}
-              objectName={objectName}
-              zoomedRow={zoomedRow ?? []}
-              settings={settings}
-              hasRelationships={hasRelationships}
-              onVisualizationClick={onVisualizationClick}
-              visualizationIsClickable={visualizationIsClickable}
-              tableForeignKeys={tableForeignKeys}
-              tableForeignKeyReferences={tableForeignKeyReferences}
-              followForeignKey={onFollowForeignKey}
-            />
+            <ObjectDetailBodyWrapper>
+              {isEditing && table ? (
+                <EditingFormContainer>
+                  <WritebackForm table={table} row={zoomedRow} isModal />
+                </EditingFormContainer>
+              ) : (
+                <ObjectDetailBody
+                  data={data}
+                  objectName={objectName}
+                  zoomedRow={zoomedRow ?? []}
+                  settings={settings}
+                  hasRelationships={hasRelationships}
+                  onVisualizationClick={onVisualizationClick}
+                  visualizationIsClickable={visualizationIsClickable}
+                  tableForeignKeys={tableForeignKeys}
+                  tableForeignKeyReferences={tableForeignKeyReferences}
+                  followForeignKey={onFollowForeignKey}
+                />
+              )}
+            </ObjectDetailBodyWrapper>
           </div>
         )}
       </ObjectDetailModal>
@@ -284,9 +307,12 @@ export interface ObjectDetailHeaderProps {
   objectId: ObjectId | null | unknown;
   canZoomPreviousRow: boolean;
   canZoomNextRow: boolean;
+  isEditing: boolean;
+  canEdit: boolean;
   viewPreviousObjectDetail: () => void;
   viewNextObjectDetail: () => void;
   closeObjectDetail: () => void;
+  onToggleEditingModeClick: () => void;
 }
 
 export function ObjectDetailHeader({
@@ -295,9 +321,12 @@ export function ObjectDetailHeader({
   objectId,
   canZoomPreviousRow,
   canZoomNextRow,
+  isEditing,
+  canEdit,
   viewPreviousObjectDetail,
   viewNextObjectDetail,
   closeObjectDetail,
+  onToggleEditingModeClick,
 }: ObjectDetailHeaderProps): JSX.Element {
   return (
     <div className="Grid border-bottom relative">
@@ -308,6 +337,16 @@ export function ObjectDetailHeader({
         </h2>
       </div>
       <div className="flex align-center">
+        {canEdit && (
+          <Button
+            className="mr1"
+            icon={isEditing ? "eye" : "pencil"}
+            onClick={onToggleEditingModeClick}
+            iconSize={20}
+            onlyIcon
+            borderless
+          />
+        )}
         <div className="flex p2">
           {!!canZoom && (
             <>
@@ -376,7 +415,7 @@ export function ObjectDetailBody({
   followForeignKey,
 }: ObjectDetailBodyProps): JSX.Element {
   return (
-    <ObjectDetailBodyWrapper>
+    <>
       <DetailsTable
         data={data}
         zoomedRow={zoomedRow}
@@ -392,7 +431,7 @@ export function ObjectDetailBody({
           foreignKeyClicked={followForeignKey}
         />
       )}
-    </ObjectDetailBodyWrapper>
+    </>
   );
 }
 

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.unit.spec.tsx
@@ -17,9 +17,12 @@ describe("Object Detail", () => {
         objectId={778}
         canZoomNextRow={false}
         canZoomPreviousRow={false}
+        isEditing={false}
+        canEdit={false}
         viewPreviousObjectDetail={() => null}
         viewNextObjectDetail={() => null}
         closeObjectDetail={() => null}
+        onToggleEditingModeClick={() => null}
       />,
     );
     screen.getAllByText(/Large Sandstone Socks/i);
@@ -34,9 +37,12 @@ describe("Object Detail", () => {
         objectId={778}
         canZoomNextRow={true}
         canZoomPreviousRow={false}
+        isEditing={false}
+        canEdit={false}
         viewPreviousObjectDetail={() => null}
         viewNextObjectDetail={() => null}
         closeObjectDetail={() => null}
+        onToggleEditingModeClick={() => null}
       />,
     );
     const nextDisabled = screen
@@ -97,6 +103,7 @@ describe("Object Detail", () => {
         canZoom={true}
         canZoomPreviousRow={false}
         canZoomNextRow={false}
+        isWritebackEnabled={false}
         followForeignKey={() => null}
         onVisualizationClick={() => null}
         visualizationIsClickable={() => false}

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/utils.ts
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/utils.ts
@@ -3,8 +3,9 @@ import _ from "underscore";
 
 import { singularize } from "metabase/lib/formatting";
 import { isPK, isEntityName } from "metabase/lib/schema_metadata";
-import { Table } from "metabase-types/types/Table";
+
 import Question from "metabase-lib/lib/Question";
+import Table from "metabase-lib/lib/metadata/Table";
 import { DatasetData, Column } from "metabase-types/types/Dataset";
 
 import { ObjectId } from "./types";

--- a/frontend/src/metabase/writeback/components/CategoryFieldInput/CategoryFieldInput.jsx
+++ b/frontend/src/metabase/writeback/components/CategoryFieldInput/CategoryFieldInput.jsx
@@ -33,7 +33,7 @@ function CategoryFieldInput({ value, field, onChange }) {
       <StyledFieldValuesWidget
         value={value ? [String(value)] : []}
         fields={[field]}
-        onChange={onChange}
+        onChange={values => onChange(values[0])}
         multi={false}
         autoFocus={false}
         alwaysShowOptions={false}

--- a/frontend/src/metabase/writeback/components/CategoryFieldInput/CategoryFieldInput.jsx
+++ b/frontend/src/metabase/writeback/components/CategoryFieldInput/CategoryFieldInput.jsx
@@ -1,0 +1,57 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+import TippyPopover from "metabase/components/Popover/TippyPopover";
+
+import Field from "metabase-lib/lib/metadata/Field";
+
+import {
+  OptionListContainer,
+  StyledFieldValuesWidget,
+  FieldValuesWidgetContainer,
+} from "./CategoryFieldInput.styled";
+
+const DefaultTokenFieldLayout = ({ valuesList, optionsList, isFocused }) => (
+  <TippyPopover
+    visible={isFocused && !!optionsList}
+    content={<OptionListContainer>{optionsList}</OptionListContainer>}
+    placement="bottom-start"
+  >
+    <div>{valuesList}</div>
+  </TippyPopover>
+);
+
+DefaultTokenFieldLayout.propTypes = {
+  valuesList: PropTypes.arrayOf(PropTypes.string),
+  optionsList: PropTypes.arrayOf(PropTypes.string),
+  isFocused: PropTypes.bool,
+};
+
+function CategoryFieldInput({ value, field, onChange }) {
+  return (
+    <FieldValuesWidgetContainer>
+      <StyledFieldValuesWidget
+        value={value ? [String(value)] : []}
+        fields={[field]}
+        onChange={onChange}
+        multi={false}
+        autoFocus={false}
+        alwaysShowOptions={false}
+        disableSearch={false}
+        forceTokenField
+        layoutRenderer={DefaultTokenFieldLayout}
+        valueRenderer={value => <span>{value}</span>}
+        color="brand"
+        maxWidth={null}
+      />
+    </FieldValuesWidgetContainer>
+  );
+}
+
+CategoryFieldInput.propTypes = {
+  value: PropTypes.string,
+  field: PropTypes.instanceOf(Field).isRequired,
+  onChange: PropTypes.func.isRequired,
+};
+
+export default CategoryFieldInput;

--- a/frontend/src/metabase/writeback/components/CategoryFieldInput/CategoryFieldInput.styled.tsx
+++ b/frontend/src/metabase/writeback/components/CategoryFieldInput/CategoryFieldInput.styled.tsx
@@ -1,0 +1,59 @@
+import styled from "@emotion/styled";
+
+import FieldValuesWidget from "metabase/components/FieldValuesWidget";
+
+import { color, darken } from "metabase/lib/colors";
+
+export const OptionListContainer = styled.div`
+  max-height: 200px;
+`;
+
+export const StyledFieldValuesWidget = styled(FieldValuesWidget)`
+  border: 1px solid ${darken("border", 0.1)};
+  border-radius: 4px;
+  padding: 0;
+  font-weight: 700;
+  font-size: 1rem;
+  height: 45.5px;
+
+  .TokenField--focused {
+    border-color: ${color("brand")};
+  }
+
+  .TokenField-ItemWrapper {
+    background-color: transparent;
+    color: ${color("text-dark")};
+
+    padding-left: 12px;
+    padding-top: 0;
+    padding-right: 0;
+    padding-bottom: 0;
+    margin: 0;
+
+    span {
+      padding: 0;
+    }
+  }
+
+  .TokenField-NewItemInputContainer {
+    padding: 12px;
+    margin: 0;
+
+    input {
+      color: ${color("text-dark")};
+      padding: 0;
+      margin: 0;
+    }
+  }
+
+  &:hover {
+    border-color: ${color("brand")};
+    transition: border 300ms ease-in-out;
+  }
+`;
+
+export const FieldValuesWidgetContainer = styled.div`
+  .TokenField--focused {
+    border-color: ${color("brand")};
+  }
+`;

--- a/frontend/src/metabase/writeback/components/CategoryFieldInput/index.ts
+++ b/frontend/src/metabase/writeback/components/CategoryFieldInput/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./CategoryFieldInput";

--- a/frontend/src/metabase/writeback/containers/CategoryFieldPicker.tsx
+++ b/frontend/src/metabase/writeback/containers/CategoryFieldPicker.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+
+import { CategoryWidgetProps } from "../types";
+import CategoryRadioPicker from "./CategoryRadioPicker";
+
+import CategoryFieldInput from "../components/CategoryFieldInput";
+
+const MAX_DISTINCT_OPTIONS_FOR_RADIO_INPUT = 7;
+
+function CategoryFieldPicker({ field, formField }: CategoryWidgetProps) {
+  const { value } = field;
+  const { fieldInstance } = formField;
+
+  const distinctCount = fieldInstance.fingerprint?.global?.["distinct-count"];
+
+  if (
+    distinctCount != null &&
+    distinctCount <= MAX_DISTINCT_OPTIONS_FOR_RADIO_INPUT
+  ) {
+    return <CategoryRadioPicker field={field} formField={formField} />;
+  }
+
+  return (
+    <CategoryFieldInput
+      value={value}
+      field={fieldInstance}
+      onChange={field.onChange}
+    />
+  );
+}
+
+export default CategoryFieldPicker;

--- a/frontend/src/metabase/writeback/containers/CategoryRadioPicker.tsx
+++ b/frontend/src/metabase/writeback/containers/CategoryRadioPicker.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import { connect } from "react-redux";
+
+import Radio from "metabase/core/components/Radio";
+
+import Fields from "metabase/entities/fields";
+import { useOnMount } from "metabase/hooks/use-on-mount";
+
+import { State } from "metabase-types/store";
+
+import { CategoryWidgetProps as CategoryWidgetOwnProps } from "../types";
+
+interface CategoryWidgetStateProps {
+  fieldValues: unknown[][];
+}
+
+interface CategoryWidgetDispatchProps {
+  fetchFieldValues: (opts: { id: number }) => void;
+}
+
+interface CategoryWidgetProps
+  extends CategoryWidgetOwnProps,
+    CategoryWidgetStateProps,
+    CategoryWidgetDispatchProps {}
+
+function mapStateToProps(
+  state: State,
+  { formField: { fieldInstance } }: CategoryWidgetOwnProps,
+) {
+  const fieldValues = Fields.selectors.getFieldValues(state, {
+    entityId: fieldInstance.id,
+  });
+  return {
+    fieldValues,
+  };
+}
+
+const mapDispatchToProps = {
+  fetchFieldValues: Fields.actions.fetchFieldValues,
+};
+
+function CategoryRadioPicker({
+  field,
+  formField,
+  fieldValues = [],
+  fetchFieldValues,
+}: CategoryWidgetProps) {
+  const { fieldInstance } = formField;
+
+  useOnMount(() => {
+    if (fieldInstance.id) {
+      fetchFieldValues({ id: fieldInstance.id });
+    }
+  });
+
+  const options = fieldValues.flat().map(value => ({
+    name: String(value),
+    value: String(value),
+  }));
+
+  return <Radio {...field} options={options} variant="bubble" />;
+}
+
+export default connect<
+  CategoryWidgetStateProps,
+  CategoryWidgetDispatchProps,
+  CategoryWidgetOwnProps,
+  State
+>(
+  mapStateToProps,
+  mapDispatchToProps,
+)(CategoryRadioPicker);

--- a/frontend/src/metabase/writeback/containers/WritebackForm.tsx
+++ b/frontend/src/metabase/writeback/containers/WritebackForm.tsx
@@ -7,6 +7,8 @@ import { TYPE } from "metabase/lib/types";
 import Field from "metabase-lib/lib/metadata/Field";
 import Table from "metabase-lib/lib/metadata/Table";
 
+import CategoryFieldPicker from "./CategoryFieldPicker";
+
 export interface WritebackFormProps {
   table: Table;
   onSubmit?: () => void;
@@ -35,6 +37,15 @@ function getFieldTypeProps(field: Field) {
     field.semantic_type === TYPE.Comment
   ) {
     return { type: "text" };
+  }
+  if (field.semantic_type === TYPE.Title) {
+    return { type: "input" };
+  }
+  if (field.isCategory()) {
+    return {
+      fieldInstance: field,
+      widget: CategoryFieldPicker,
+    };
   }
   return { type: "input" };
 }

--- a/frontend/src/metabase/writeback/containers/WritebackForm.tsx
+++ b/frontend/src/metabase/writeback/containers/WritebackForm.tsx
@@ -14,6 +14,9 @@ export interface WritebackFormProps {
   table: Table;
   row?: unknown[];
   onSubmit?: () => void;
+
+  // Form props
+  isModal?: boolean;
 }
 
 function getFieldTypeProps(field: Field) {

--- a/frontend/src/metabase/writeback/containers/WritebackForm.tsx
+++ b/frontend/src/metabase/writeback/containers/WritebackForm.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+
+import Table from "metabase-lib/lib/metadata/Table";
+
+export interface WritebackFormProps {
+  table: Table;
+}
+
+function WritebackForm({ table }: WritebackFormProps) {
+  return null;
+}
+
+export default WritebackForm;

--- a/frontend/src/metabase/writeback/containers/WritebackForm.tsx
+++ b/frontend/src/metabase/writeback/containers/WritebackForm.tsx
@@ -1,13 +1,67 @@
-import React from "react";
+import React, { useCallback, useMemo } from "react";
 
+import Form from "metabase/containers/Form";
+
+import { TYPE } from "metabase/lib/types";
+
+import Field from "metabase-lib/lib/metadata/Field";
 import Table from "metabase-lib/lib/metadata/Table";
 
 export interface WritebackFormProps {
   table: Table;
+  onSubmit?: () => void;
 }
 
-function WritebackForm({ table }: WritebackFormProps) {
-  return null;
+function getFieldTypeProps(field: Field) {
+  if (field.isFK()) {
+    return {
+      type: field.isNumeric() ? "integer" : "input",
+    };
+  }
+  if (field.isNumeric()) {
+    return { type: "integer" };
+  }
+  if (field.isBoolean()) {
+    return { type: "boolean" };
+  }
+  if (field.isDate()) {
+    return { type: "date" };
+  }
+  if (field.semantic_type === TYPE.Email) {
+    return { type: "email" };
+  }
+  if (
+    field.semantic_type === TYPE.Description ||
+    field.semantic_type === TYPE.Comment
+  ) {
+    return { type: "text" };
+  }
+  return { type: "input" };
+}
+
+function WritebackForm({ table, onSubmit }: WritebackFormProps) {
+  const editableFields = useMemo(
+    () => table.fields.filter(field => !field.isPK()),
+    [table],
+  );
+
+  const form = useMemo(
+    () => ({
+      fields: editableFields.map(field => ({
+        name: field.name,
+        title: field.displayName(),
+        description: field.description,
+        ...getFieldTypeProps(field),
+      })),
+    }),
+    [editableFields],
+  );
+
+  const handleSubmit = useCallback(() => {
+    onSubmit?.();
+  }, [onSubmit]);
+
+  return <Form form={form} onSubmit={handleSubmit} />;
 }
 
 export default WritebackForm;

--- a/frontend/src/metabase/writeback/containers/WritebackModalForm.tsx
+++ b/frontend/src/metabase/writeback/containers/WritebackModalForm.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { t } from "ttag";
+
+import ModalContent from "metabase/components/ModalContent";
+
+import WritebackForm, { WritebackFormProps } from "./WritebackForm";
+
+interface WritebackModalFormProps extends WritebackFormProps {
+  onClose: () => void;
+}
+
+function WritebackModalForm({
+  table,
+  onClose,
+  ...props
+}: WritebackModalFormProps) {
+  const title = t`New ${table.objectName()}`;
+  return (
+    <ModalContent title={title} onClose={onClose}>
+      <WritebackForm table={table} {...props} />
+    </ModalContent>
+  );
+}
+
+export default WritebackModalForm;

--- a/frontend/src/metabase/writeback/types.ts
+++ b/frontend/src/metabase/writeback/types.ts
@@ -1,0 +1,11 @@
+import Field from "metabase-lib/lib/metadata/Field";
+
+export interface CategoryWidgetProps {
+  field: {
+    value: string;
+    onChange: (value: string) => void;
+  };
+  formField: {
+    fieldInstance: Field;
+  };
+}


### PR DESCRIPTION
Part of #22549

This PR adds forms for inserting/updating table rows. Note: it only contains the UI and it's not hooked up with the backend yet. The form is generated out of table fields metadata and is only supported for raw tables (ie no aggregations and breakouts).

Note: it's a prototype and the final look and feel of it is going to change, so please don't be hard on the UI/UX issues 🙂 

### To Verify

1. Run Metabase with `experimental-enable-actions` flag or patch [this selector](https://github.com/metabase/metabase/blob/84bd09ffc2bc5069ff7482fb6c6b9ae70b737dd3/frontend/src/metabase/writeback/selectors.ts#L5) to return `true`
2. Open any table
3. You should see a "+ New row" button near the "Filter" and "Summarize" buttons. Click it
4. You should see a modal form with fields matching real table fields. Ensure that:
   * you don't see fields for PKs (FKs should be present though)
   * other fields make inputs make sense
5. Open an object detail for any row (click the PK or hover the row and click the "expand" icon on the left)
6. Click the "pencil" icon next to the previous/next buttons
7. You should see the very same form, but with field values populated with row data

### Demo

https://user-images.githubusercontent.com/17258145/167939234-d4fb6e80-e91e-4a67-84d9-824cfde4497a.mp4


