### PR TITLE
Fix `yarn docs`/`yarn dev`/`yarn dev-ee` issues

### DIFF
--- a/frontend/src/metabase-lib/lib/Dimension.ts
+++ b/frontend/src/metabase-lib/lib/Dimension.ts
@@ -5,26 +5,29 @@ import _ from "underscore";
 import { merge } from "icepick";
 import { stripId, FK_SYMBOL } from "metabase/lib/formatting";
 import { TYPE } from "metabase/lib/types";
-import { TemplateTagVariable } from "./Variable";
-import Field from "./metadata/Field";
+import { TemplateTagVariable } from "metabase-lib/lib/Variable";
+import Field from "metabase-lib/lib/metadata/Field";
 import {
   AggregationOperator,
   FilterOperator,
   Metadata,
   Query,
-} from "./metadata/Metadata";
+} from "metabase-lib/lib/metadata/Metadata";
 import {
   ConcreteField,
   LocalFieldReference,
   ExpressionReference,
   DatetimeUnit,
 } from "metabase-types/types/Query";
-import { ValidationError, VALIDATION_ERROR_TYPES } from "./ValidationError";
+import {
+  ValidationError,
+  VALIDATION_ERROR_TYPES,
+} from "metabase-lib/lib/ValidationError";
 import { IconName } from "metabase-types/types";
 import { getFieldValues, getRemappings } from "metabase/lib/query/field";
 import { DATETIME_UNITS, formatBucketing } from "metabase/lib/query_time";
-import Aggregation from "./queries/structured/Aggregation";
-import StructuredQuery from "./queries/StructuredQuery";
+import Aggregation from "metabase-lib/lib/queries/structured/Aggregation";
+import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
 import { infer, MONOTYPE } from "metabase/lib/expressions/typeinferencer";
 import { isa } from "cljs/metabase.types";
 

--- a/frontend/src/metabase-lib/lib/Question.ts
+++ b/frontend/src/metabase-lib/lib/Question.ts
@@ -10,7 +10,7 @@ import NativeQuery, {
   NATIVE_QUERY_TEMPLATE,
 } from "metabase-lib/lib/queries/NativeQuery";
 import AtomicQuery from "metabase-lib/lib/queries/AtomicQuery";
-import InternalQuery from "./queries/InternalQuery";
+import InternalQuery from "metabase-lib/lib/queries/InternalQuery";
 import Query from "metabase-lib/lib/queries/Query";
 import Metadata from "metabase-lib/lib/metadata/Metadata";
 import Database from "metabase-lib/lib/metadata/Database";

--- a/frontend/src/metabase-lib/lib/Variable.ts
+++ b/frontend/src/metabase-lib/lib/Variable.ts
@@ -1,9 +1,9 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
-import Metadata from "./metadata/Metadata";
-import Query from "./queries/Query";
+import Metadata from "metabase-lib/lib/metadata/Metadata";
+import Query from "metabase-lib/lib/queries/Query";
 import { TemplateTag } from "metabase-types/types/Query";
-import NativeQuery from "./queries/NativeQuery";
+import NativeQuery from "metabase-lib/lib/queries/NativeQuery";
 export default class Variable {
   _args: any;
   _metadata: Metadata | null | undefined;

--- a/frontend/src/metabase-lib/lib/queries/NativeQuery.ts
+++ b/frontend/src/metabase-lib/lib/queries/NativeQuery.ts
@@ -26,7 +26,7 @@ import AtomicQuery from "metabase-lib/lib/queries/AtomicQuery";
 import Dimension, { TemplateTagDimension, FieldDimension } from "../Dimension";
 import Variable, { TemplateTagVariable } from "../Variable";
 import DimensionOptions from "../DimensionOptions";
-import { ValidationError } from "../ValidationError";
+import { ValidationError } from "metabase-lib/lib/ValidationError";
 
 type DimensionFilter = (dimension: Dimension) => boolean;
 type VariableFilter = (variable: Variable) => boolean;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -231,12 +231,7 @@ if (WEBPACK_BUNDLE === "hot") {
         loader: "babel-loader",
         options: {
           ...BABEL_CONFIG,
-          plugins: [
-            "@emotion",
-            "@babel/plugin-proposal-export-default-from",
-            ["@babel/plugin-proposal-decorators", { legacy: true }],
-            "react-refresh/babel",
-          ],
+          plugins: ["@emotion", "react-refresh/babel"],
         },
       },
     ],


### PR DESCRIPTION
Updates all of the imports in `metabase-lib/lib` to use absolute `metabase-lib/lib/*` imports

Fixes errors in `yarn docs` command that breaks `yarn dev`/`yarn dev-ee`