### PR TITLE
Use native `Array.isArray` to check for array type

### DIFF
--- a/frontend/interfaces/underscore.js
+++ b/frontend/interfaces/underscore.js
@@ -71,7 +71,6 @@ declare module "underscore" {
   declare function isEmpty(o: any): boolean;
   declare function isString(o: any): boolean;
   declare function isObject(o: any): boolean;
-  declare function isArray(o: any): boolean;
 
   declare function groupBy<T>(
     a: Array<T>,

--- a/frontend/src/metabase/lib/request.js
+++ b/frontend/src/metabase/lib/request.js
@@ -52,7 +52,7 @@ export class RestfulRequest {
 
   mergeToDictionary = (dict, result) => {
     dict = dict || {};
-    result = _.isArray(result)
+    result = Array.isArray(result)
       ? _.indexBy(result, "id")
       : { [result.id]: result };
 

--- a/frontend/test/metabase/scenarios/onboarding/auth/signin.cy.spec.js
+++ b/frontend/test/metabase/scenarios/onboarding/auth/signin.cy.spec.js
@@ -89,7 +89,7 @@ describe("scenarios > auth > signin", () => {
 
   sizes.forEach(size => {
     it(`should redirect from /auth/forgot_password back to /auth/login (viewport: ${size}) (metabase#12658)`, () => {
-      if (Cypress._.isArray(size)) {
+      if (Array.isArray(size)) {
         cy.viewport(size[0], size[1]);
       } else {
         cy.viewport(size);


### PR DESCRIPTION
**Without** the need to support non ES6 browsers (IE 11), we ought to use native method [Array.isArray](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray).