### PR TITLE
Handle undefined parameter `field` property in ParameterValueWidget

### DIFF
--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
@@ -20,11 +20,7 @@ import { getMetadata } from "metabase/selectors/metadata";
 
 import { getParameterIconName } from "metabase/parameters/utils/ui";
 import { isDashboardParameterWithoutMapping } from "metabase/parameters/utils/dashboards";
-import {
-  hasFieldValues,
-  getFields,
-  getFieldIds,
-} from "metabase/parameters/utils/fields";
+import { hasFieldValues, getFieldIds } from "metabase/parameters/utils/fields";
 
 import S from "./ParameterWidget.css";
 
@@ -265,7 +261,7 @@ function Widget({
   target,
 }) {
   const DateWidget = DATE_WIDGETS[parameter.type];
-  const fields = getFields(metadata, parameter);
+  const fields = parameter.fields || [];
 
   if (disabled) {
     return (
@@ -319,12 +315,10 @@ Widget.propTypes = {
 };
 
 function getWidgetDefinition(metadata, parameter) {
+  const fields = parameter.fields || [];
   if (DATE_WIDGETS[parameter.type]) {
     return DATE_WIDGETS[parameter.type];
-  } else if (
-    getFields(metadata, parameter).length > 0 &&
-    parameter.hasOnlyFieldTargets
-  ) {
+  } else if (fields.length > 0 && parameter.hasOnlyFieldTargets) {
     return ParameterFieldWidget;
   } else {
     return TextWidget;

--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
@@ -20,7 +20,11 @@ import { getMetadata } from "metabase/selectors/metadata";
 
 import { getParameterIconName } from "metabase/parameters/utils/ui";
 import { isDashboardParameterWithoutMapping } from "metabase/parameters/utils/dashboards";
-import { hasFieldValues } from "metabase/parameters/utils/fields";
+import {
+  hasFieldValues,
+  getFields,
+  getFieldIds,
+} from "metabase/parameters/utils/fields";
 
 import S from "./ParameterWidget.css";
 
@@ -243,24 +247,6 @@ export default connect(
   makeMapStateToProps,
   mapDispatchToProps,
 )(ParameterValueWidget);
-
-function getFields(metadata, parameter) {
-  if (!metadata) {
-    return [];
-  }
-  return (
-    parameter.fields ??
-    getFieldIds(parameter)
-      .map(id => metadata.field(id))
-      .filter(f => f != null)
-  );
-}
-
-function getFieldIds(parameter) {
-  const { field_ids = [], field_id } = parameter;
-  const fieldIds = field_id ? [field_id] : field_ids;
-  return fieldIds.filter(id => typeof id === "number");
-}
 
 function Widget({
   parameter,

--- a/frontend/src/metabase/parameters/utils/fields.js
+++ b/frontend/src/metabase/parameters/utils/fields.js
@@ -1,17 +1,9 @@
 export function hasFieldValues(parameter) {
-  return parameter.fields.some(field => field.hasFieldValues());
-}
-
-export function getFields(metadata, parameter) {
-  if (!metadata) {
-    return [];
+  if (!Array.isArray(parameter.fields)) {
+    return false;
   }
-  return (
-    parameter.fields ??
-    getFieldIds(parameter)
-      .map(id => metadata.field(id))
-      .filter(f => f != null)
-  );
+
+  return parameter.fields.some(field => field.hasFieldValues());
 }
 
 export function getFieldIds(parameter) {

--- a/frontend/src/metabase/parameters/utils/fields.js
+++ b/frontend/src/metabase/parameters/utils/fields.js
@@ -1,3 +1,21 @@
 export function hasFieldValues(parameter) {
   return parameter.fields.some(field => field.hasFieldValues());
 }
+
+export function getFields(metadata, parameter) {
+  if (!metadata) {
+    return [];
+  }
+  return (
+    parameter.fields ??
+    getFieldIds(parameter)
+      .map(id => metadata.field(id))
+      .filter(f => f != null)
+  );
+}
+
+export function getFieldIds(parameter) {
+  const { field_ids = [], field_id } = parameter;
+  const fieldIds = field_id ? [field_id] : field_ids;
+  return fieldIds.filter(id => typeof id === "number");
+}

--- a/frontend/src/metabase/parameters/utils/fields.unit.spec.js
+++ b/frontend/src/metabase/parameters/utils/fields.unit.spec.js
@@ -1,5 +1,5 @@
 import Field from "metabase-lib/lib/metadata/Field";
-import { hasFieldValues } from "./fields";
+import { hasFieldValues, getFieldIds } from "./fields";
 
 describe("parameters/utils/fields", () => {
   describe("hasFieldValues", () => {
@@ -20,6 +20,33 @@ describe("parameters/utils/fields", () => {
       expect(
         hasFieldValues({ fields: [fieldWithoutValues, fieldWithValues] }),
       ).toBe(true);
+    });
+
+    it("should handle a parameter with no fields", () => {
+      expect(hasFieldValues({})).toBe(false);
+    });
+  });
+
+  describe("getFieldIds", () => {
+    it("should handle a parameter with no fields", () => {
+      expect(getFieldIds({})).toEqual([]);
+    });
+
+    it("should return number field ids", () => {
+      expect(getFieldIds({ field_ids: [1, 2, 3] })).toEqual([1, 2, 3]);
+    });
+
+    it("should filter out virtual field ids", () => {
+      expect(getFieldIds({ field_ids: [1, "two", 3] })).toEqual([1, 3]);
+    });
+
+    it("should favor the field_id prop for whatever reason", () => {
+      expect(
+        getFieldIds({
+          field_id: 1,
+          field_ids: [2, 3],
+        }),
+      ).toEqual([1]);
     });
   });
 });


### PR DESCRIPTION
Related to #22554

This scenario is currently an impossibility, but it won't be for much longer. In preparation for that, I'm working backwards to a point where we can remove the field-related properties that currently exist on all parameters.

- I've removed the `getFields` function because its logic is redundant; if there is a fields array, the objects within are `Field` instances
- I've moved `getFieldIds` to the `metabase/parameters/utils/fields` utility fn file and I've added tests
