### PR TITLE
Limit linked filter to field filter parameters

### DIFF
--- a/frontend/src/metabase/parameters/components/ParameterSidebar.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterSidebar.jsx
@@ -6,6 +6,7 @@ import cx from "classnames";
 import { DashboardApi } from "metabase/services";
 import Fields from "metabase/entities/fields";
 import Tables from "metabase/entities/tables";
+import { canUseLinkedFilters } from "metabase/parameters/utils/linked-filters";
 
 import Radio from "metabase/core/components/Radio";
 import Toggle from "metabase/core/components/Toggle";
@@ -15,9 +16,10 @@ import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 import ParameterValueWidget from "metabase/parameters/components/ParameterValueWidget";
 import Sidebar from "metabase/dashboard/components/Sidebar";
 
-const tabs = [
+const LINKED_FILTER = "linked-filters";
+const TABS = [
   { value: "settings", name: t`Settings`, icon: "gear" },
-  { value: "linked-filters", name: t`Linked filters`, icon: "link" },
+  { value: LINKED_FILTER, name: t`Linked filters`, icon: "link" },
 ];
 class ParameterSidebar extends React.Component {
   state = { currentTab: "settings", originalParameter: null };
@@ -51,6 +53,11 @@ class ParameterSidebar extends React.Component {
       setFilteringParameters,
     } = this.props;
     const { currentTab } = this.state;
+
+    const tabs = canUseLinkedFilters(parameter)
+      ? TABS
+      : TABS.filter(tab => tab.value !== LINKED_FILTER);
+
     return (
       <Sidebar onClose={done} onCancel={this.handleCancel}>
         <div className="flex justify-evenly border-bottom">

--- a/frontend/src/metabase/parameters/components/ParameterSidebar.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterSidebar.jsx
@@ -6,7 +6,10 @@ import cx from "classnames";
 import { DashboardApi } from "metabase/services";
 import Fields from "metabase/entities/fields";
 import Tables from "metabase/entities/tables";
-import { canUseLinkedFilters } from "metabase/parameters/utils/linked-filters";
+import {
+  canUseLinkedFilters,
+  usableAsLinkedFilter,
+} from "metabase/parameters/utils/linked-filters";
 
 import Radio from "metabase/core/components/Radio";
 import Toggle from "metabase/core/components/Toggle";
@@ -170,10 +173,12 @@ class OtherParameterList extends React.Component {
       showAddParameterPopover,
     } = this.props;
     const { expandedParameterId, columnPairs } = this.state;
+    const usableParameters = otherParameters.filter(usableAsLinkedFilter);
+
     return (
       <div className="py3 px2">
         <h3>{t`Limit this filter's choices`}</h3>
-        {otherParameters.length === 0 ? (
+        {usableParameters.length === 0 ? (
           <div>
             <p className="text-medium">{t`If you have another dashboard filter, you can limit the choices that are listed for this filter based on the selection of the other one.`}</p>
             <p className="text-medium">{jt`So first, ${(
@@ -188,7 +193,7 @@ class OtherParameterList extends React.Component {
             <p className="text-medium">{jt`If you toggle on one of these dashboard filters, selecting a value for that filter will limit the available choices for ${(
               <span className="text-italic">this</span>
             )} filter.`}</p>
-            {otherParameters.map(({ id, name }) => (
+            {usableParameters.map(({ id, name }) => (
               <div className={"bg-light rounded mb2"} key={name}>
                 <div className="flex justify-between align-center p2">
                   <span

--- a/frontend/src/metabase/parameters/components/ParameterSidebar.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterSidebar.jsx
@@ -59,7 +59,7 @@ class ParameterSidebar extends React.Component {
 
     const tabs = canUseLinkedFilters(parameter)
       ? TABS
-      : TABS.filter(tab => tab.value !== LINKED_FILTER);
+      : TABS.filter(({ value }) => value !== LINKED_FILTER);
 
     return (
       <Sidebar onClose={done} onCancel={this.handleCancel}>

--- a/frontend/src/metabase/parameters/constants.js
+++ b/frontend/src/metabase/parameters/constants.js
@@ -147,3 +147,19 @@ export const LOCATION_OPTIONS = [
     name: t`Country`,
   },
 ];
+
+export const TYPE_SUPPORTS_LINKED_FILTERS = [
+  "string",
+  "category",
+  "id",
+  "location",
+];
+
+export const TYPE_USABLE_AS_LINKED_FILTER = [
+  "date",
+  "string",
+  "number",
+  "id",
+  "category",
+  "location",
+];

--- a/frontend/src/metabase/parameters/utils/linked-filters.js
+++ b/frontend/src/metabase/parameters/utils/linked-filters.js
@@ -1,6 +1,15 @@
-import { getParameterType } from "./parameter-type";
+import {
+  TYPE_SUPPORTS_LINKED_FILTERS,
+  TYPE_USABLE_AS_LINKED_FILTER,
+} from "metabase/parameters/constants";
+import { getParameterType } from "metabase/parameters/utils/parameter-type";
 
 export function canUseLinkedFilters(parameter) {
   const type = getParameterType(parameter);
-  return ["string", "category", "id", "location"].includes(type);
+  return TYPE_SUPPORTS_LINKED_FILTERS.includes(type);
+}
+
+export function usableAsLinkedFilter(parameter) {
+  const type = getParameterType(parameter);
+  return TYPE_USABLE_AS_LINKED_FILTER.includes(type);
 }

--- a/frontend/src/metabase/parameters/utils/linked-filters.js
+++ b/frontend/src/metabase/parameters/utils/linked-filters.js
@@ -1,0 +1,6 @@
+import { getParameterType } from "./parameter-type";
+
+export function canUseLinkedFilters(parameter) {
+  const type = getParameterType(parameter);
+  return ["string", "category", "id", "location"].includes(type);
+}


### PR DESCRIPTION
Related to #22554

1. I'm limiting linked filters to filters that can have lists of values. It doesn't make sense for a `date/single` or a `number/between` etc. to show this UI because it doesn't do anything.
2. I added code to limit the list of linkable filters to field filter parameters -- this doesn't do anything right now because all parameters _are_ field filter parameters.