### PR TITLE
Make parameter mbql conversion code a little more generic

### DIFF
--- a/frontend/src/metabase-lib/lib/Question.ts
+++ b/frontend/src/metabase-lib/lib/Question.ts
@@ -1244,18 +1244,17 @@ class QuestionInner {
       return this;
     }
 
-    const [query, hasQueryBeenAltered] = this.parameters().reduce(
-      ([query, hasQueryBeenAltered], parameter) => {
-        const filter = fieldFilterParameterToMBQLFilter(
-          parameter,
-          this.metadata(),
-        );
-        return filter
-          ? [query.filter(filter), true]
-          : [query, hasQueryBeenAltered];
-      },
-      [this.query(), false],
-    );
+    const mbqlFilters = this.parameters()
+      .map(parameter => {
+        return fieldFilterParameterToMBQLFilter(parameter, this.metadata());
+      })
+      .filter(mbqlFilter => mbqlFilter != null);
+
+    const query = mbqlFilters.reduce((query, mbqlFilter) => {
+      return query.filter(mbqlFilter);
+    }, this.query());
+
+    const hasQueryBeenAltered = mbqlFilters.length > 0;
 
     const question = query
       .question()

--- a/frontend/src/metabase-lib/lib/Question.ts
+++ b/frontend/src/metabase-lib/lib/Question.ts
@@ -36,7 +36,7 @@ import {
   getValueAndFieldIdPopulatedParametersFromCard,
   remapParameterValuesToTemplateTags,
 } from "metabase/parameters/utils/cards";
-import { parameterToMBQLFilter } from "metabase/parameters/utils/mbql";
+import { fieldFilterParameterToMBQLFilter } from "metabase/parameters/utils/mbql";
 import {
   normalizeParameterValue,
   getParameterValuesBySlug,
@@ -1244,10 +1244,15 @@ class QuestionInner {
       return this;
     }
 
-    const [query, isAltered] = this.parameters().reduce(
-      ([query, isAltered], parameter) => {
-        const filter = parameterToMBQLFilter(parameter, this.metadata());
-        return filter ? [query.filter(filter), true] : [query, isAltered];
+    const [query, hasQueryBeenAltered] = this.parameters().reduce(
+      ([query, hasQueryBeenAltered], parameter) => {
+        const filter = fieldFilterParameterToMBQLFilter(
+          parameter,
+          this.metadata(),
+        );
+        return filter
+          ? [query.filter(filter), true]
+          : [query, hasQueryBeenAltered];
       },
       [this.query(), false],
     );
@@ -1257,7 +1262,7 @@ class QuestionInner {
       .setParameters(undefined)
       .setParameterValues(undefined);
 
-    return isAltered ? question.markDirty() : question;
+    return hasQueryBeenAltered ? question.markDirty() : question;
   }
 
   getUrlWithParameters(parameters, parameterValues, { objectId, clean } = {}) {

--- a/frontend/src/metabase-lib/lib/Question.ts
+++ b/frontend/src/metabase-lib/lib/Question.ts
@@ -1239,7 +1239,7 @@ class QuestionInner {
     return utf8_to_b64url(JSON.stringify(sortObject(cardCopy)));
   }
 
-  convertParametersToFilters() {
+  convertParametersToMbql() {
     if (!this.isStructured()) {
       return this;
     }
@@ -1273,7 +1273,7 @@ class QuestionInner {
       if (this.query().isEditable()) {
         return questionWithParameters
           .setParameterValues(parameterValues)
-          .convertParametersToFilters()
+          .convertParametersToMbql()
           .getUrl({
             clean,
             originalQuestion: this,

--- a/frontend/src/metabase/parameters/utils/mbql.js
+++ b/frontend/src/metabase/parameters/utils/mbql.js
@@ -160,15 +160,20 @@ export function numberParameterValueToMBQL(parameter, fieldRef) {
   );
 }
 
+export function isFieldFilterParameterConveratableToMBQL(parameter) {
+  const { value, target } = parameter;
+  const hasValue = hasParameterValue(value);
+  const hasWellFormedTarget = Array.isArray(target[1]);
+  const hasFieldDimensionTarget =
+    isDimensionTarget(target) &&
+    !TemplateTagDimension.isTemplateTagClause(target[1]);
+
+  return hasValue && hasWellFormedTarget && hasFieldDimensionTarget;
+}
+
 /** compiles a parameter with value to an MBQL clause */
 export function parameterToMBQLFilter(parameter, metadata) {
-  if (
-    !parameter.target ||
-    !isDimensionTarget(parameter.target) ||
-    !Array.isArray(parameter.target[1]) ||
-    TemplateTagDimension.isTemplateTagClause(parameter.target[1]) ||
-    !hasParameterValue(parameter.value)
-  ) {
+  if (!isFieldFilterParameterConveratableToMBQL(parameter)) {
     return null;
   }
 

--- a/frontend/src/metabase/parameters/utils/mbql.js
+++ b/frontend/src/metabase/parameters/utils/mbql.js
@@ -163,7 +163,7 @@ export function numberParameterValueToMBQL(parameter, fieldRef) {
 export function isFieldFilterParameterConveratableToMBQL(parameter) {
   const { value, target } = parameter;
   const hasValue = hasParameterValue(value);
-  const hasWellFormedTarget = Array.isArray(target[1]);
+  const hasWellFormedTarget = Array.isArray(target?.[1]);
   const hasFieldDimensionTarget =
     isDimensionTarget(target) &&
     !TemplateTagDimension.isTemplateTagClause(target[1]);
@@ -172,7 +172,7 @@ export function isFieldFilterParameterConveratableToMBQL(parameter) {
 }
 
 /** compiles a parameter with value to an MBQL clause */
-export function parameterToMBQLFilter(parameter, metadata) {
+export function fieldFilterParameterToMBQLFilter(parameter, metadata) {
   if (!isFieldFilterParameterConveratableToMBQL(parameter)) {
     return null;
   }

--- a/frontend/src/metabase/parameters/utils/mbql.unit.spec.js
+++ b/frontend/src/metabase/parameters/utils/mbql.unit.spec.js
@@ -4,7 +4,7 @@ import {
   dateParameterValueToMBQL,
   stringParameterValueToMBQL,
   numberParameterValueToMBQL,
-  parameterToMBQLFilter,
+  fieldFilterParameterToMBQLFilter,
 } from "./mbql";
 import { metadata, PRODUCTS } from "__support__/sample_database_fixture";
 
@@ -252,10 +252,10 @@ describe("parameters/utils/mbql", () => {
     });
   });
 
-  describe("parameterToMBQLFilter", () => {
+  describe("fieldFilterParameterToMBQLFilter", () => {
     it("should return null for parameter targets that are not field dimension targets", () => {
       expect(
-        parameterToMBQLFilter({
+        fieldFilterParameterToMBQLFilter({
           target: null,
           type: "category",
           value: ["foo"],
@@ -263,11 +263,15 @@ describe("parameters/utils/mbql", () => {
       ).toBe(null);
 
       expect(
-        parameterToMBQLFilter({ target: [], type: "category", value: ["foo"] }),
+        fieldFilterParameterToMBQLFilter({
+          target: [],
+          type: "category",
+          value: ["foo"],
+        }),
       ).toBe(null);
 
       expect(
-        parameterToMBQLFilter({
+        fieldFilterParameterToMBQLFilter({
           target: ["dimension"],
           type: "category",
           value: ["foo"],
@@ -275,7 +279,7 @@ describe("parameters/utils/mbql", () => {
       ).toBe(null);
 
       expect(
-        parameterToMBQLFilter({
+        fieldFilterParameterToMBQLFilter({
           target: ["dimension", ["template-tag", "foo"]],
           type: "category",
           value: ["foo"],
@@ -285,7 +289,7 @@ describe("parameters/utils/mbql", () => {
 
     it("should return mbql filter for date parameter", () => {
       expect(
-        parameterToMBQLFilter(
+        fieldFilterParameterToMBQLFilter(
           {
             target: ["dimension", ["field", PRODUCTS.CREATED_AT.id, null]],
             type: "date/single",
@@ -298,7 +302,7 @@ describe("parameters/utils/mbql", () => {
 
     it("should return mbql filter for string parameter", () => {
       expect(
-        parameterToMBQLFilter(
+        fieldFilterParameterToMBQLFilter(
           {
             target: ["dimension", ["field", PRODUCTS.CATEGORY.id, null]],
             type: "string/starts-with",
@@ -309,7 +313,7 @@ describe("parameters/utils/mbql", () => {
       ).toEqual(["starts-with", ["field", PRODUCTS.CATEGORY.id, null], "foo"]);
 
       expect(
-        parameterToMBQLFilter(
+        fieldFilterParameterToMBQLFilter(
           {
             target: ["dimension", ["field", PRODUCTS.CATEGORY.id, null]],
             type: "string/starts-with",
@@ -322,7 +326,7 @@ describe("parameters/utils/mbql", () => {
 
     it("should return mbql filter for category parameter", () => {
       expect(
-        parameterToMBQLFilter(
+        fieldFilterParameterToMBQLFilter(
           {
             target: ["dimension", ["field", PRODUCTS.CATEGORY.id, null]],
             type: "category",
@@ -335,7 +339,7 @@ describe("parameters/utils/mbql", () => {
 
     it("should return mbql filter for number parameter", () => {
       expect(
-        parameterToMBQLFilter(
+        fieldFilterParameterToMBQLFilter(
           {
             target: ["dimension", ["field", PRODUCTS.RATING.id, null]],
             type: "number/=",
@@ -346,7 +350,7 @@ describe("parameters/utils/mbql", () => {
       ).toEqual(["=", ["field", PRODUCTS.RATING.id, null], 111]);
 
       expect(
-        parameterToMBQLFilter(
+        fieldFilterParameterToMBQLFilter(
           {
             target: ["dimension", ["field", PRODUCTS.RATING.id, null]],
             type: "number/=",
@@ -357,7 +361,7 @@ describe("parameters/utils/mbql", () => {
       ).toEqual(["=", ["field", PRODUCTS.RATING.id, null], 111]);
 
       expect(
-        parameterToMBQLFilter(
+        fieldFilterParameterToMBQLFilter(
           {
             target: ["dimension", ["field", PRODUCTS.RATING.id, null]],
             type: "number/between",

--- a/frontend/test/metabase-lib/lib/Question.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/Question.unit.spec.js
@@ -1137,10 +1137,10 @@ describe("Question", () => {
     });
   });
 
-  describe("Question.prototype.convertParametersToFilters", () => {
+  describe("Question.prototype.convertParametersToMbql", () => {
     it("should do nothing to a native question", () => {
       const question = new Question(native_orders_count_card, metadata);
-      expect(question.convertParametersToFilters()).toBe(question);
+      expect(question.convertParametersToMbql()).toBe(question);
     });
 
     it("should convert a question with parameters into a new question with filters", () => {
@@ -1165,7 +1165,7 @@ describe("Question", () => {
           foo_id: "abc",
         });
 
-      const questionWithFilters = question.convertParametersToFilters();
+      const questionWithFilters = question.convertParametersToMbql();
 
       expect(questionWithFilters.card().dataset_query.query.filter).toEqual([
         "starts-with",


### PR DESCRIPTION
Related to #22554

This is mostly a noop, but I'm updating the language we use in the parameter --> mbql code to be more generic so that future changes are a little easier.

1. Renamed parameterToMBQLFilter to fieldFilterParameterToMBQLFilter
2. Simplified the giant safety check in fieldFilterParameterToMBQLFilter and pulled it out as a separate function
3. Renamed convertParametersToFilter to convertParametersToMbql
4. Simplified logic in convertParametersToMbql so that it'll be easier to extend