### PR TITLE
Support parameter value parsing without a field

### DIFF
--- a/frontend/src/metabase/parameters/components/widgets/TextWidget.jsx
+++ b/frontend/src/metabase/parameters/components/widgets/TextWidget.jsx
@@ -62,11 +62,15 @@ export default class TextWidget extends Component {
       this.setState({ isFocused });
     };
 
+    const value = Array.isArray(this.state.value)
+      ? this.state.value[0]
+      : this.state.value;
+
     return (
       <input
         className={className}
         type="text"
-        value={this.state.value || ""}
+        value={value || ""}
         onChange={e => {
           this.setState({ value: e.target.value });
           if (this.props.commitImmediately) {

--- a/frontend/src/metabase/parameters/utils/parameter-values.js
+++ b/frontend/src/metabase/parameters/utils/parameter-values.js
@@ -42,8 +42,9 @@ export function getParameterValueFromQueryParams(
 }
 
 export function parseParameterValue(value, parameter) {
-  if (Array.isArray(parameter.fields) && parameter.fields.length > 0) {
-    return parseParameterValueForFields(value, parameter.fields);
+  const { fields } = parameter;
+  if (Array.isArray(fields) && fields.length > 0) {
+    return parseParameterValueForFields(value, fields);
   }
 
   const type = getParameterType(parameter);

--- a/frontend/src/metabase/parameters/utils/parameter-values.js
+++ b/frontend/src/metabase/parameters/utils/parameter-values.js
@@ -1,5 +1,4 @@
 import { getParameterType } from "./parameter-type";
-import Dimension from "metabase-lib/lib/Dimension";
 
 export function getValuePopulatedParameters(parameters, parameterValues) {
   return parameterValues
@@ -29,18 +28,30 @@ export function getParameterValueFromQueryParams(
 ) {
   queryParams = queryParams || {};
 
-  const fields = getFields(parameter, metadata);
   const maybeParameterValue = queryParams[parameter.slug || parameter.id];
 
-  if (hasParameterValue(maybeParameterValue)) {
-    const parsedValue = parseParameterValueForFields(
-      maybeParameterValue,
-      fields,
-    );
+  // skip parsing "" because it indicates a forcefully unset parameter
+  if (maybeParameterValue === "") {
+    return "";
+  } else if (hasParameterValue(maybeParameterValue)) {
+    const parsedValue = parseParameterValue(maybeParameterValue, parameter);
     return normalizeParameterValueForWidget(parsedValue, parameter);
   } else {
     return parameter.default;
   }
+}
+
+export function parseParameterValue(value, parameter) {
+  if (Array.isArray(parameter.fields) && parameter.fields.length > 0) {
+    return parseParameterValueForFields(value, parameter.fields);
+  }
+
+  const type = getParameterType(parameter);
+  if (type === "number") {
+    return parseFloat(value);
+  }
+
+  return value;
 }
 
 function parseParameterValueForFields(value, fields) {
@@ -48,16 +59,13 @@ function parseParameterValueForFields(value, fields) {
     return value.map(v => parseParameterValueForFields(v, fields));
   }
 
-  // [].every is always true, so only check if there are some fields
-  if (fields.length > 0) {
-    // unix dates fields are numeric but query params shouldn't be parsed as numbers
-    if (fields.every(f => f.isNumeric() && !f.isDate())) {
-      return value === "" ? value : parseFloat(value);
-    }
+  // unix dates fields are numeric but query params shouldn't be parsed as numbers
+  if (fields.every(f => f.isNumeric() && !f.isDate())) {
+    return parseFloat(value);
+  }
 
-    if (fields.every(f => f.isBoolean())) {
-      return value === "true" ? true : value === "false" ? false : value;
-    }
+  if (fields.every(f => f.isBoolean())) {
+    return value === "true" ? true : value === "false" ? false : value;
   }
 
   return value;
@@ -70,37 +78,11 @@ function normalizeParameterValueForWidget(value, parameter) {
     parameter.hasOnlyFieldTargets && !/^date\//.test(parameter.type);
 
   // If we'll use FieldValuesWidget, we should start with an array to match.
-  if (willUseFieldValuesWidget && !Array.isArray(value) && value !== "") {
+  if (willUseFieldValuesWidget && !Array.isArray(value)) {
     value = [value];
   }
 
   return value;
-}
-
-// field IDs can be either
-// ["field", <integer-id>, <options>] or
-// ["field", <string-name>, <options>]
-function getFields(parameter, metadata) {
-  if (parameter.fields) {
-    return parameter.fields;
-  }
-
-  const fieldIds =
-    parameter.field_ids || [parameter.field_id].filter(f => f != null);
-
-  return fieldIds
-    .map(id => {
-      const field = metadata.field(id);
-      if (field != null) {
-        return field;
-      }
-
-      const dimension = Dimension.parseMBQL(id, metadata);
-      if (dimension != null) {
-        return dimension.field();
-      }
-    })
-    .filter(field => field != null);
 }
 
 // on dashboards we treat a default parameter with a set value of "" (from a query parameter)

--- a/frontend/src/metabase/parameters/utils/parameter-values.js
+++ b/frontend/src/metabase/parameters/utils/parameter-values.js
@@ -73,15 +73,8 @@ function parseParameterValueForFields(value, fields) {
 
 function normalizeParameterValueForWidget(value, parameter) {
   const fieldType = getParameterType(parameter);
-
-  // ParameterValueWidget uses FieldValuesWidget if there's no available
-  // date widget and all targets are fields.
-  const willUseFieldValuesWidget =
-    parameter.hasOnlyFieldTargets && fieldType !== "date";
-
-  // If we'll use FieldValuesWidget, we should start with an array to match.
-  if (willUseFieldValuesWidget && !Array.isArray(value)) {
-    value = [value];
+  if (fieldType !== "date" && !Array.isArray(value)) {
+    return [value];
   }
 
   return value;

--- a/frontend/src/metabase/parameters/utils/parameter-values.js
+++ b/frontend/src/metabase/parameters/utils/parameter-values.js
@@ -72,10 +72,12 @@ function parseParameterValueForFields(value, fields) {
 }
 
 function normalizeParameterValueForWidget(value, parameter) {
+  const fieldType = getParameterType(parameter);
+
   // ParameterValueWidget uses FieldValuesWidget if there's no available
   // date widget and all targets are fields.
   const willUseFieldValuesWidget =
-    parameter.hasOnlyFieldTargets && !/^date\//.test(parameter.type);
+    parameter.hasOnlyFieldTargets && fieldType !== "date";
 
   // If we'll use FieldValuesWidget, we should start with an array to match.
   if (willUseFieldValuesWidget && !Array.isArray(value)) {

--- a/frontend/src/metabase/parameters/utils/parameter-values.unit.spec.js
+++ b/frontend/src/metabase/parameters/utils/parameter-values.unit.spec.js
@@ -160,13 +160,13 @@ describe("parameters/utils/parameter-values", () => {
     it("should return the parameter value found in the queryParams object", () => {
       expect(
         getParameterValueFromQueryParams(parameter1, queryParams, metadata),
-      ).toBe("parameter1 queryParam value");
+      ).toEqual(["parameter1 queryParam value"]);
     });
 
     it("should ignore the parameter's default value when the parameter value is found in queryParams", () => {
       expect(
         getParameterValueFromQueryParams(parameter2, queryParams, metadata),
-      ).toBe("parameter2 queryParam value");
+      ).toEqual(["parameter2 queryParam value"]);
     });
 
     it("should return an empty string as the value for a defaulted parameter because we handle that special case elsewhere", () => {
@@ -196,7 +196,7 @@ describe("parameters/utils/parameter-values", () => {
           },
           metadata,
         ),
-      ).toBe(123.456);
+      ).toEqual([123.456]);
 
       expect(
         getParameterValueFromQueryParams(
@@ -223,7 +223,7 @@ describe("parameters/utils/parameter-values", () => {
           },
           metadata,
         ),
-      ).toBe(123.456);
+      ).toEqual([123.456]);
     });
 
     it("should not parse numeric values that are dates as floats", () => {
@@ -241,7 +241,7 @@ describe("parameters/utils/parameter-values", () => {
           },
           metadata,
         ),
-      ).toBe("123.456");
+      ).toEqual(["123.456"]);
     });
 
     it("should parse a value of 'true' or 'false' as a boolean if all associated fields are booleans", () => {
@@ -256,7 +256,7 @@ describe("parameters/utils/parameter-values", () => {
           },
           metadata,
         ),
-      ).toBe(true);
+      ).toEqual([true]);
 
       expect(
         getParameterValueFromQueryParams(
@@ -266,7 +266,7 @@ describe("parameters/utils/parameter-values", () => {
           },
           metadata,
         ),
-      ).toBe(false);
+      ).toEqual([false]);
 
       expect(
         getParameterValueFromQueryParams(
@@ -286,7 +286,7 @@ describe("parameters/utils/parameter-values", () => {
           },
           metadata,
         ),
-      ).toBe("foo");
+      ).toEqual(["foo"]);
     });
 
     it("should not normalize date parameters", () => {
@@ -316,7 +316,7 @@ describe("parameters/utils/parameter-values", () => {
           },
           metadata,
         ),
-      ).toEqual("foo");
+      ).toEqual(["foo"]);
     });
 
     it("should not normalize empty string parameter values", () => {
@@ -370,7 +370,7 @@ describe("parameters/utils/parameter-values", () => {
           },
           metadata,
         ),
-      ).toBe(true);
+      ).toEqual([true]);
     });
 
     it("should not try to parse parameters without fields", () => {
@@ -382,7 +382,7 @@ describe("parameters/utils/parameter-values", () => {
           },
           metadata,
         ),
-      ).toBe("true");
+      ).toEqual(["true"]);
     });
 
     it("should not try to parse default values", () => {
@@ -397,7 +397,7 @@ describe("parameters/utils/parameter-values", () => {
           },
           metadata,
         ),
-      ).toBe(NaN);
+      ).toEqual([NaN]);
 
       expect(getParameterValueFromQueryParams(parameter2, {}, metadata)).toBe(
         "parameter2 default value",
@@ -415,8 +415,8 @@ describe("parameters/utils/parameter-values", () => {
             metadata,
           ),
         ).toEqual({
-          [parameter1.id]: "parameter1 queryParam value",
-          [parameter2.id]: "parameter2 queryParam value",
+          [parameter1.id]: ["parameter1 queryParam value"],
+          [parameter2.id]: ["parameter2 queryParam value"],
           [parameter3.id]: "parameter3 default value",
         });
       });
@@ -480,16 +480,16 @@ describe("parameters/utils/parameter-values", () => {
             parameters,
             {
               [parameter1.slug]: "0",
-              [parameter2.slug]: "parameter2 default value",
+              [parameter2.slug]: "parameter2 foo value",
               [parameter3.slug]: "false",
             },
             metadata,
             { forcefullyUnsetDefaultedParametersWithEmptyStringValue: false },
           ),
         ).toEqual({
-          [parameter1.id]: 0,
-          [parameter2.id]: "parameter2 default value",
-          [parameter3.id]: false,
+          [parameter1.id]: [0],
+          [parameter2.id]: ["parameter2 foo value"],
+          [parameter3.id]: [false],
         });
       });
     });
@@ -533,8 +533,8 @@ describe("parameters/utils/parameter-values", () => {
           { forcefullyUnsetDefaultedParametersWithEmptyStringValue: true },
         ),
       ).toEqual({
-        [parameter1.id]: 0,
-        [parameter3.id]: false,
+        [parameter1.id]: [0],
+        [parameter3.id]: [false],
       });
     });
   });

--- a/frontend/src/metabase/parameters/utils/parameter-values.unit.spec.js
+++ b/frontend/src/metabase/parameters/utils/parameter-values.unit.spec.js
@@ -73,21 +73,21 @@ describe("parameters/utils/parameter-values", () => {
     parameter1 = {
       id: 111,
       slug: "foo",
-      field_ids: [1, 4],
+      fields: [field1, field4],
     };
     // found in queryParams and defaulted
     parameter2 = {
       id: 222,
       slug: "bar",
       default: "parameter2 default value",
-      field_id: 2,
+      fields: [field2],
     };
     // not found in queryParams and defaulted
     parameter3 = {
       id: 333,
       slug: "baz",
       default: "parameter3 default value",
-      field_ids: [["field", 3, null]],
+      fields: [field3],
     };
     // not found in queryParams and not defaulted
     parameter4 = {
@@ -207,6 +207,23 @@ describe("parameters/utils/parameter-values", () => {
           metadata,
         ),
       ).toBe("");
+    });
+
+    it("should parse the parameter value as a float when it is a number parameter without fields", () => {
+      const numberParameter = {
+        id: 111,
+        slug: "numberParameter",
+        type: "number/=",
+      };
+      expect(
+        getParameterValueFromQueryParams(
+          numberParameter,
+          {
+            [numberParameter.slug]: "123.456",
+          },
+          metadata,
+        ),
+      ).toBe(123.456);
     });
 
     it("should not parse numeric values that are dates as floats", () => {


### PR DESCRIPTION
Related to https://github.com/metabase/metabase/issues/22554

Here I'm adding code to parse URL parameter values as numbers when the associated parameter is of type `number/*`.

I've also done a small amount of refactoring here to remove some field references:
1. Removed a redundant `getFields` function -- the `parameter.fields` array is sufficient here.
2. Removed a reference to `FieldValuesWidget`. In order to make this work, I've also added some code to `TextWidget` to handle array values.

Behavior in-app should remain the same.