### PR TITLE
Exclude storybook (*.stories) from coverage collection

### DIFF
--- a/jest.unit.conf.json
+++ b/jest.unit.conf.json
@@ -26,7 +26,8 @@
   "coverageReporters": ["text", "html", "lcov"],
   "collectCoverageFrom": [
     "frontend/src/**/*.{js,jsx,ts,tsx}",
-    "enterprise/frontend/src/**/*.{js,jsx,ts,tsx}"
+    "enterprise/frontend/src/**/*.{js,jsx,ts,tsx}",
+    "**/*.stories.{js,jsx,ts,tsx}"
   ],
   "coveragePathIgnorePatterns": [
     "/node_modules/",


### PR DESCRIPTION
We are not running tests which exercise those *.stories files, hence it is not fair to include them in the coverage analysis.

### Before

Codecov still reports something like this:

![image](https://user-images.githubusercontent.com/7288/167997217-996add55-270b-4e81-8df6-71bf7f2e981a.png)

which does not portray a fair view since `*.stories.*` files are only for Storybook (and not to be unit tested).

### After

Codecov excludes stories from the coverage report.
