### PR TITLE
Stopgap to fix #22636 until full implementation

### DIFF
--- a/src/metabase/driver/sql_jdbc/sync/describe_table.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_table.clj
@@ -206,7 +206,7 @@
 
 (def ^:const nested-field-sample-limit
   "Number of rows to sample for describe-nested-field-columns"
-  10000)
+  500)
 
 (defn- flattened-row [field-name row]
   (letfn [(flatten-row [row path]


### PR DESCRIPTION
Pursuant to #22636. This is all linear WRT cardinality of rows looked at (holding row size constant) - 10k was a guess, but apparently a bad one with respect to the necessarily-statistical balance between completeness and speed, if it's pegging people's CPU's.