### PR TITLE
Render empty string for null boolean column results

### DIFF
--- a/frontend/src/metabase/lib/formatting.js
+++ b/frontend/src/metabase/lib/formatting.js
@@ -746,7 +746,7 @@ export function formatValueRaw(value, options = {}) {
     return NULL_DISPLAY_VALUE;
   } else if (value === null && isBoolean(column)) {
     // Custom expressions returning the False literal return null
-    return JSON.stringify(false);
+    return "";
   } else if (value == null) {
     return null;
   } else if (


### PR DESCRIPTION
Fixes #22621 

### How to Test

1. \+ New
2. SQL Query
3. Use query below

```
select 'TRUE' "Text", true::boolean "Boolean", 1::bit(1) "Bit"
union all select 'FALSE', false::boolean, 0::bit(1)
union all select 'NULL', null::boolean, null::bit(1)
```

### After
![image](https://user-images.githubusercontent.com/1447303/167840532-912f504e-d6e8-4a5f-9e12-3d3686db82ab.png)

### Before 
![image](https://user-images.githubusercontent.com/1447303/167840614-03b43620-a0a6-47ed-9962-9b483319d32d.png)

