### PR TITLE
.gitignore: ignore Calva

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,5 @@ dev/src/dev/nocommit/
 !.lsp/config.edn
 .clj-kondo/.cache
 *.code-workspace
+
+.calva/


### PR DESCRIPTION
useful for some of us, beginning Clojurians not using Emacs.