### PR TITLE
Add TokenField parseFreeFormValue utils

### DIFF
--- a/frontend/src/metabase/components/FieldValuesWidget.jsx
+++ b/frontend/src/metabase/components/FieldValuesWidget.jsx
@@ -5,7 +5,10 @@ import { connect } from "react-redux";
 import { t, jt } from "ttag";
 import _ from "underscore";
 
-import TokenField from "metabase/components/TokenField";
+import TokenField, {
+  parseNumberValue,
+  parseStringValue,
+} from "metabase/components/TokenField";
 import ListField from "metabase/components/ListField";
 import ValueComponent from "metabase/components/Value";
 import LoadingSpinner from "metabase/components/LoadingSpinner";
@@ -366,23 +369,10 @@ class FieldValuesWidgetInner extends Component {
               );
             }}
             onInputChange={this.onInputChange}
-            parseFreeformValue={v => {
-              // trim whitespace
-              v = String(v || "").trim();
-              // empty string is not valid
-              if (!v) {
-                return null;
-              }
-              // if the field is numeric we need to parse the string into an integer
-              if (fields[0].isNumeric()) {
-                const n = Number.parseFloat(v);
-                if (Number.isFinite(n)) {
-                  return n;
-                } else {
-                  return null;
-                }
-              }
-              return v;
+            parseFreeformValue={value => {
+              return fields[0].isNumeric()
+                ? parseNumberValue(value)
+                : parseStringValue(value);
             }}
           />
         )}

--- a/frontend/src/metabase/components/TokenField/index.ts
+++ b/frontend/src/metabase/components/TokenField/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./TokenField";
+export * from "./utils";

--- a/frontend/src/metabase/components/TokenField/utils.ts
+++ b/frontend/src/metabase/components/TokenField/utils.ts
@@ -1,0 +1,22 @@
+export function parseNumberValue(value: any): number | null {
+  const number = Number.parseFloat(value);
+
+  if (Number.isFinite(number)) {
+    return number;
+  } else {
+    return null;
+  }
+}
+
+export function parseStringValue(value: any): string | null {
+  const trimmedValue = trim(value);
+  if (trimmedValue === "") {
+    return null;
+  }
+
+  return trimmedValue;
+}
+
+function trim(value: any) {
+  return String(value || "").trim();
+}

--- a/frontend/src/metabase/components/TokenField/utils.unit.spec.ts
+++ b/frontend/src/metabase/components/TokenField/utils.unit.spec.ts
@@ -1,0 +1,47 @@
+import { parseNumberValue, parseStringValue } from "./utils";
+
+describe("metabase/components/TokenField/utils", () => {
+  describe("parseNumberValue", () => {
+    it("should return null for non-number values", () => {
+      expect(parseNumberValue("")).toBeNull();
+      expect(parseNumberValue(" ")).toBeNull();
+      expect(parseNumberValue(" foo ")).toBeNull();
+      expect(parseNumberValue(null)).toBeNull();
+      expect(parseNumberValue("abc 123")).toBeNull();
+    });
+
+    it("should return null for numbers that are not finite", () => {
+      expect(parseNumberValue("Infinity")).toBeNull();
+      expect(parseNumberValue(Infinity)).toBeNull();
+      expect(parseNumberValue("-Infinity")).toBeNull();
+      expect(parseNumberValue(NaN)).toBeNull();
+      expect(parseNumberValue("NaN")).toBeNull();
+    });
+
+    it("should return a value parsed as a float", () => {
+      expect(parseNumberValue("123")).toBe(123);
+      expect(parseNumberValue("123px")).toBe(123);
+      expect(parseNumberValue("123.456")).toBe(123.456);
+      expect(parseNumberValue("0")).toBe(0);
+      expect(parseNumberValue(0)).toBe(0);
+      expect(parseNumberValue(123)).toBe(123);
+    });
+  });
+
+  describe("parseStringValue", () => {
+    it("should return null for falsy and whitespace values", () => {
+      expect(parseStringValue("")).toBeNull();
+      expect(parseStringValue(" ")).toBeNull();
+      expect(parseStringValue(" \n ")).toBeNull();
+      expect(parseStringValue(null)).toBeNull();
+      expect(parseStringValue(false)).toBeNull();
+      expect(parseStringValue(0)).toBeNull();
+    });
+
+    it("should return truthy values coerced into strings", () => {
+      expect(parseStringValue(123)).toBe("123");
+      expect(parseStringValue(true)).toBe("true");
+      expect(parseStringValue(" abc 123 \n ")).toBe("abc 123");
+    });
+  });
+});


### PR DESCRIPTION
Related to #22554 

Pulling these utils out of `FieldValuesWidget` as I will be using them in future field-free parameter widget code. Added tests, but they should basically behave the same way. In `FieldValuesWidget` the `value` arg for this function is always a string because we are dealing with lists of string values from the various field value endpoints, but technically the values can be anything.

The one change worth pointing out is a tweak to the number-parsing function so that a `value` arg of `0` isn't turned into `null`.