### PR TITLE
Don't reschedule syncs on startup

### DIFF
--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -598,7 +598,7 @@
                                   (sync.schedules/schedule-map->cron-strings
                                     (if (:let-user-control-scheduling details)
                                       (sync.schedules/scheduling schedules)
-                                      (sync.schedules/default-schedule)))
+                                      (sync.schedules/default-randomized-schedule)))
                                   (when (some? auto_run_queries)
                                     {:auto_run_queries auto_run_queries}))))
         (events/publish-event! :database-create <>)
@@ -740,7 +740,7 @@
                                                    (and (get-in existing-database [:details :let-user-control-scheduling])
                                                         (not (:let-user-control-scheduling details)))
 
-                                                   (sync.schedules/schedule-map->cron-strings (sync.schedules/default-schedule))
+                                                   (sync.schedules/schedule-map->cron-strings (sync.schedules/default-randomized-schedule))
 
                                                    ;; if user is controlling schedules
                                                    (:let-user-control-scheduling details)

--- a/src/metabase/sync/schedules.clj
+++ b/src/metabase/sync/schedules.clj
@@ -33,13 +33,15 @@
 (defn randomly-once-an-hour
   "Schedule map for once an hour at a random minute of the hour."
   []
-  {:schedule_minute (rand-int 59)
+  ;; prevent zeros which would appear as non-random
+  {:schedule_minute (inc (rand-int 59))
    :schedule_type   "hourly"})
 
 (defn randomly-once-a-day
   "Schedule map for once a day at a random hour of the day."
   []
-  {:schedule_hour  (rand-int 24)
+  ;; prevent zeros which would appear as non-random
+  {:schedule_hour  (inc (rand-int 23))
    :schedule_type  "daily"})
 
 (defn default-randomized-schedule

--- a/src/metabase/sync/schedules.clj
+++ b/src/metabase/sync/schedules.clj
@@ -42,8 +42,9 @@
   {:schedule_hour  (rand-int 24)
    :schedule_type  "daily"})
 
-(defn default-schedule
-  "Default schedule maps for caching field values and sync."
+(defn default-randomized-schedule
+  "Default schedule maps for caching field values and sync. Defaults to `:cache_field_values` randomly once a day and
+  `:metadata_sync` randomly once an hour. "
   []
   {:cache_field_values (randomly-once-a-day)
    :metadata_sync      (randomly-once-an-hour)})

--- a/src/metabase/task/sync_databases.clj
+++ b/src/metabase/task/sync_databases.clj
@@ -207,6 +207,7 @@
       (cron/with-misfire-handling-instruction-do-nothing)))))
 
 ;; called [[from metabase.models.database/schedule-tasks!]] from the post-insert and the pre-update
+#_ {:clj-kondo/ignore [:unused-private-var]}
 (s/defn ^:private check-and-schedule-tasks-for-db!
   "Schedule a new Quartz job for `database` and `task-info` if it doesn't already exist or is incorrect."
   [database :- DatabaseInstance]

--- a/src/metabase/task/sync_databases.clj
+++ b/src/metabase/task/sync_databases.clj
@@ -282,4 +282,4 @@
       (log/info (trs "Updating databases without custom sync scheduling to random schedules.")))
     (doseq [db dbs-with-default-schedules]
       (db/update! Database (u/the-id db)
-        (sync.schedules/schedule-map->cron-strings (sync.schedules/default-schedule))))))
+        (sync.schedules/schedule-map->cron-strings (sync.schedules/default-randomized-schedule))))))

--- a/test/metabase/models/database_test.clj
+++ b/test/metabase/models/database_test.clj
@@ -45,10 +45,7 @@
 (deftest tasks-test
   (testing "Sync tasks should get scheduled for a newly created Database"
     (mt/with-temp-scheduler
-      ;; temporarily disable the `maybe-update-db-schedules` behavior that normally happens when the sync databases
-      ;; task gets initialized so we don't end up getting all of our database sync schedules randomized.
-      (with-redefs [task.sync-databases/maybe-update-db-schedules identity]
-        (task/init! ::task.sync-databases/SyncDatabases))
+      (task/init! ::task.sync-databases/SyncDatabases)
       (mt/with-temp Database [{db-id :id}]
         (is (schema= {:description         (s/eq (format "sync-and-analyze Database %d" db-id))
                       :key                 (s/eq (format "metabase.task.sync-and-analyze.trigger.%d" db-id))
@@ -176,7 +173,7 @@
     (mt/with-driver :secret-test-driver
       (binding [api/*current-user-id* (mt/user->id :crowberto)]
         (let [secret-ids  (atom #{}) ; keep track of all secret IDs created with the temp database
-              check-db-fn (fn [{:keys [details] :as database} exp-secret]
+              check-db-fn (fn [{:keys [details] :as _database} exp-secret]
                             (when (not= :file-path (:source exp-secret))
                               (is (not (contains? details :password-value))
                                   "password-value was removed from details when not a file-path"))
@@ -225,7 +222,7 @@
                       (format "Secret ID %d was not removed from the app DB" secret-id)))))))))))
 
 (deftest user-may-not-update-sample-database-test
-  (mt/with-temp Database [{:keys [id details] :as sample-database} {:engine    :h2
+  (mt/with-temp Database [{:keys [id details] :as _sample-database} {:engine    :h2
                                                                     :is_sample true
                                                                     :name      "Sample Database"
                                                                     :details   {:db "./resources/sample-database.db;USER=GUEST;PASSWORD=guest"}}]

--- a/test/metabase/task/sync_databases_test.clj
+++ b/test/metabase/task/sync_databases_test.clj
@@ -11,7 +11,6 @@
             [metabase.test :as mt]
             [metabase.test.util :as tu]
             [metabase.util :as u]
-            [metabase.util.cron :as u.cron]
             [toucan.db :as db])
   (:import [metabase.task.sync_databases SyncAndAnalyzeDatabase UpdateFieldValues]))
 


### PR DESCRIPTION
Fixes #22650 

Previously when we started up, for each database we compare its current
schedule to its schedule in Quartz, and update the triggers if they were
different. But we handle this change on db inserts and db updates so
this is completely unnecessary. We did this back when quartz was in
memory only and it remained when we persisted.

We can remove this complexity. On an app-db with 400 postgres databases,
this takes 46 seconds in the old world and appears as just another log
statement now.

Reports from the wild are even more distressing: the quartz tables got
full of dead tuples causing queries to the triggers to take a long
time. They also had 500+ databases. We query all triggers and linear
search for each database and this process exploded up to as much as 8
hours. Now we are not doing all of this extra work and startup should be
quick again.
