### PR TITLE
Add `:actions` driver feature flag

### DIFF
--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -433,7 +433,10 @@
     :advanced-math-expressions
 
     ;; Does the driver support percentile calculations (including median)
-    :percentile-aggregations})
+    :percentile-aggregations
+
+    ;; Does the driver support experimental "writeback" actions like "delete this row" or "insert a new row" from 44+?
+    :actions})
 
 (defmulti supports?
   "Does this driver support a certain `feature`? (A feature is a keyword, and can be any of the ones listed above in

--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -29,8 +29,11 @@
 
 (doseq [[feature supported?] {:full-join               false
                               :regex                   false
-                              :percentile-aggregations false}]
-  (defmethod driver/supports? [:h2 feature] [_ _] supported?))
+                              :percentile-aggregations false
+                              :actions                 true}]
+  (defmethod driver/database-supports? [:h2 feature]
+    [_driver _feature _database]
+    supported?))
 
 (defmethod driver/connection-properties :h2
   [_]

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -39,13 +39,15 @@
 
 (driver/register! :postgres, :parent :sql-jdbc)
 
-(defmethod driver/database-supports? [:postgres :nested-field-columns] [_ _ _] true)
-
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                             metabase.driver impls                                              |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 (defmethod driver/display-name :postgres [_] "PostgreSQL")
+
+(defmethod driver/database-supports? [:postgres :nested-field-columns]
+  [_driver _feature _db]
+  true)
 
 (defmethod driver/database-supports? [:postgres :persist-models]
   [_driver _feat _db]
@@ -54,6 +56,11 @@
 (defmethod driver/database-supports? [:postgres :persist-models-enabled]
   [_driver _feat db]
   (-> db :options :persist-models-enabled))
+
+(defmethod driver/database-supports? [:postgres :actions]
+  [driver _feat _db]
+  ;; only supported for Postgres for right now. Not supported for child drivers like Redshift or whatever.
+  (= driver :postgres))
 
 (defn- ->timestamp [honeysql-form]
   (hx/cast-unless-type-in "timestamp" #{"timestamp" "timestamptz" "date"} honeysql-form))

--- a/test/metabase/api/actions_test.clj
+++ b/test/metabase/api/actions_test.clj
@@ -88,8 +88,11 @@
         (is (partial= {:message (format "%s Database %d \"Birds\" does not support actions."
                                         (u/qualified-name ::feature-flag-test-driver)
                                         db-id)}
+                      ;; TODO -- not sure what the actual shape of this API is supposed to look like. We'll have to
+                      ;; update this test when the PR to support row insertion is in.
                       (mt/user-http-request :crowberto :post 400 "actions/table/insert"
-                                            {:table-id table-id
+                                            {:database db-id
+                                             :table-id table-id
                                              :values   {:name "Toucannery"}})))))))
 
 (deftest validation-test
@@ -114,7 +117,10 @@
         (testing action
           (testing "404 for unknown Table"
             (is (= "Failed to fetch Table 2,147,483,647: Table does not exist, or belongs to a different Database."
-                   (:message (mt/user-http-request :crowberto :post 404 action (assoc (mt/mbql-query venues {:filter [:= $id 1]}) :source-table Integer/MAX_VALUE))))))))
+                   (:message (mt/user-http-request :crowberto :post 404 action
+                                                   (mt/mbql-query venues {:source-table Integer/MAX_VALUE
+                                                                          :filter       [:= $id 1]}))))))))
       (testing "404 for unknown Row action"
         (is (= "Unknown row action \"fake\"."
-               (:message (mt/user-http-request :crowberto :post 404 "actions/row/fake" (mt/mbql-query venues {:filter [:= $id 1]})))))))))
+               (:message (mt/user-http-request :crowberto :post 404 "actions/row/fake"
+                                               (mt/mbql-query venues {:filter [:= $id 1]})))))))))


### PR DESCRIPTION
Resolves #22557

Adds a new `:actions` feature flag to see whether actions are enabled for a given driver/Database. For now I enabled it for H2 and Postgres since what we already have seems to work for either of those and disabling H2 actually makes things harder to test than leaving it enabled