### PR TITLE
Destructible version of `test-data` dataset for testing writeback actions

### DIFF
--- a/test/metabase/actions/test_util.clj
+++ b/test/metabase/actions/test_util.clj
@@ -1,0 +1,66 @@
+(ns metabase.actions.test-util
+  (:require
+   [clojure.java.jdbc :as jdbc]
+   [clojure.test :refer :all]
+   [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
+   [metabase.models.database :refer [Database]]
+   [metabase.test :as mt]
+   [metabase.test.data.dataset-definitions :as defs]
+   [metabase.test.data.impl :as data.impl]
+   [metabase.test.data.interface :as tx]
+   [toucan.db :as db]))
+
+#_ {:clj-kondo/ignore [:unused-private-var]}
+(def ^:private actions-test-data
+  "This is basically the same as [[defs/test-data]] but it only includes the `categories` table for faster loading. It's
+  meant to be reloaded at the start of every test using it so tests can do destructive things against it e.g. deleting
+  rows. (With one Table it takes ~100ms/~250ms instead of ~200ms/~450ms for H2/Postgres respectively to load all the
+  data and sync it.)"
+  ;; TODO -- this is still annoyingly SLOW we need to optimize this a bit can't be waiting 200ms for every single test
+  (tx/transformed-dataset-definition
+   "actions-test-data"
+   defs/test-data
+   (fn [database-definition]
+     (update database-definition :table-definitions (fn [table-definitions]
+                                                      (filter #(= (:table-name %) "categories")
+                                                              table-definitions))))))
+
+(defn do-with-actions-test-data
+  "Impl for [[with-actions-test-data]] macro."
+  [thunk]
+  (let [db (atom nil)]
+    (try
+      (mt/dataset actions-test-data
+        (reset! db (mt/db))
+        (thunk))
+      (finally
+        (let [{driver :engine, db-id :id} @db]
+          (tx/destroy-db! driver (tx/get-dataset-definition
+                                  (data.impl/resolve-dataset-definition 'metabase.actions.test-util 'actions-test-data)))
+          (db/delete! Database :id db-id))))))
+
+(defmacro with-actions-test-data
+  "Sets the current dataset to a freshly-loaded copy of [[defs/test-data]] that only includes the `categories` table
+  that gets destroyed at the conclusion of `body`. Use this to test destructive actions that may modify the data."
+  {:style/indent 0}
+  [& body]
+  `(do-with-actions-test-data (fn [] ~@body)))
+
+(deftest with-actions-test-data-test
+  ;; TODO -- use the feature `:actions` once #22691 is merged in
+  (mt/test-drivers #{:h2 :postgres}
+    (dotimes [i 2]
+      (testing (format "Iteration %d" i)
+        (with-actions-test-data
+          (letfn [(row-count []
+                    (mt/rows (mt/run-mbql-query categories {:aggregation [[:count]]})))]
+            (testing "before"
+              (is (= [[75]]
+                     (row-count))))
+            (testing "delete row"
+              (is (= [1]
+                     (jdbc/execute! (sql-jdbc.conn/db->pooled-connection-spec (mt/id))
+                                    "DELETE FROM CATEGORIES WHERE ID = 1;"))))
+            (testing "after"
+              (is (= [[74]]
+                     (row-count))))))))))

--- a/test/metabase/test/data/h2.clj
+++ b/test/metabase/test/data/h2.clj
@@ -13,6 +13,7 @@
             [metabase.test.data.sql-jdbc.execute :as execute]
             [metabase.test.data.sql-jdbc.load-data :as load-data]
             [metabase.test.data.sql-jdbc.spec :as spec]
+            [metabase.test.data.sql.ddl :as ddl]
             [toucan.db :as db]))
 
 (sql-jdbc.tx/add-test-extensions! :h2)
@@ -50,7 +51,7 @@
   (defmethod sql.tx/field-base-type->sql-type [:h2 base-type] [_ _] database-type))
 
 (defmethod tx/dbdef->connection-details :h2
-  [_ context dbdef]
+  [_driver context dbdef]
   {:db (str "mem:" (tx/escaped-database-name dbdef) (when (= context :db)
                                                       ;; Return details with the GUEST user added so SQL queries are
                                                       ;; allowed.
@@ -89,6 +90,10 @@
 (defmethod ddl.i/format-name :h2
   [_ s]
   (str/upper-case s))
+
+(defmethod ddl/drop-db-ddl-statements :h2
+  [_driver _dbdef & _options]
+  ["SHUTDOWN;"])
 
 (defmethod tx/id-field-type :h2 [_] :type/BigInteger)
 

--- a/test/metabase/test/data/impl.clj
+++ b/test/metabase/test/data/impl.clj
@@ -321,7 +321,6 @@
   "Impl for [[metabase.test/dataset]] macro. Resolve a dataset definition (e.g. `test-data` or `sad-toucan-incidents` in
   a namespace."
   [namespace-symb symb]
-  {:pre [(nil? (namespace symb))]}
   @(or (ns-resolve namespace-symb symb)
        (do
          (classloader/require 'metabase.test.data.dataset-definitions)

--- a/test/metabase/test/data/impl.clj
+++ b/test/metabase/test/data/impl.clj
@@ -295,15 +295,15 @@
   (copy-db-fks! old-db-id new-db-id))
 
 (def ^:dynamic *db-is-temp-copy?*
-  "Whether the current test database is a temp copy created with the `with-temp-copy-of-db` macro."
+  "Whether the current test database is a temp copy created with the [[metabase.test/with-temp-copy-of-db]] macro."
   false)
 
 (defn do-with-temp-copy-of-db
-  "Internal impl of `data/with-temp-copy-of-db`. Run `f` with a temporary Database that copies the details from the
-  standard test database, and syncs it."
+  "Internal impl of [[metabase.test/with-temp-copy-of-db]]. Run `f` with a temporary Database that copies the details
+  from the standard test database, and syncs it."
   [f]
-  (let [{old-db-id :id, :as old-db}                            (*get-db*)
-        {:keys [engine], original-name :name, :as original-db} (select-keys old-db [:details :engine :name])]
+  (let [{old-db-id :id, :as old-db} (*get-db*)
+        original-db                 (select-keys old-db [:details :engine :name])]
     (let [{new-db-id :id, :as new-db} (db/insert! Database original-db)]
       (try
         (copy-db-tables-and-fields! old-db-id new-db-id)
@@ -318,9 +318,10 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 (defn resolve-dataset-definition
-  "Impl for `data/dataset` macro. Resolve a dataset definition (e.g. `test-data` or `sad-toucan-incidents` in a
-  namespace."
+  "Impl for [[metabase.test/dataset]] macro. Resolve a dataset definition (e.g. `test-data` or `sad-toucan-incidents` in
+  a namespace."
   [namespace-symb symb]
+  {:pre [(nil? (namespace symb))]}
   @(or (ns-resolve namespace-symb symb)
        (do
          (classloader/require 'metabase.test.data.dataset-definitions)
@@ -329,8 +330,7 @@
                                   namespace-symb symb symb)))))
 
 (defn do-with-dataset
-  "Impl for `data/dataset` macro."
-  {:style/indent 1}
+  "Impl for [[metabase.test/dataset]] macro."
   [dataset-definition f]
   (let [dbdef             (tx/get-dataset-definition dataset-definition)
         get-db-for-driver (mdb.conn/memoize-for-application-db

--- a/test/metabase/test/data/interface.clj
+++ b/test/metabase/test/data/interface.clj
@@ -464,7 +464,7 @@
 (p.types/deftype+ ^:private EDNDatasetDefinition [dataset-name def]
   pretty/PrettyPrintable
   (pretty [_]
-    (list 'edn-dataset-definition dataset-name)))
+    (list `edn-dataset-definition dataset-name)))
 
 (defmethod get-dataset-definition EDNDatasetDefinition
   [^EDNDatasetDefinition this]
@@ -496,13 +496,12 @@
 (p.types/deftype+ ^:private TransformedDatasetDefinition [new-name wrapped-definition def]
   pretty/PrettyPrintable
   (pretty [_]
-    (list 'transformed-dataset-definition new-name (pretty/pretty wrapped-definition))))
+    (list `transformed-dataset-definition new-name (pretty/pretty wrapped-definition))))
 
 (s/defn transformed-dataset-definition
   "Create a dataset definition that is a transformation of an some other one, seqentially applying `transform-fns` to
   it. The results of `transform-fns` are cached."
-  {:style/indent 2}
-  [new-name :- su/NonBlankString, wrapped-definition & transform-fns :- [(s/pred fn?)]]
+  [new-name :- su/NonBlankString wrapped-definition & transform-fns :- [(s/pred fn?)]]
   (let [transform-fn (apply comp (reverse transform-fns))
         get-def      (delay
                       (transform-fn

--- a/test/metabase/test/data/postgres.clj
+++ b/test/metabase/test/data/postgres.clj
@@ -72,7 +72,7 @@
   ;; add an additional statement to the front to kill open connections to the DB before dropping
   (cons
    (kill-connections-to-db-sql database-name)
-   (apply (get-method ddl/drop-db-ddl-statements :sql-jdbc/test-extensions) :postgres dbdef options)))
+   (apply (get-method ddl/drop-db-ddl-statements :sql-jdbc/test-extensions) driver dbdef options)))
 
 (defmethod load-data/load-data! :postgres [& args]
   (apply load-data/load-data-all-at-once! args))

--- a/test/metabase/test/data/sql_jdbc/load_data.clj
+++ b/test/metabase/test/data/sql_jdbc/load_data.clj
@@ -225,7 +225,7 @@
       (load-data! driver dbdef tabledef))))
 
 (defn destroy-db!
-  "Default impl of `destroy-db!` for SQL drivers."
+  "Default impl of [[metabase.test.data.interface/destroy-db!]] for SQL drivers."
   [driver dbdef]
   (try
     (doseq [statement (ddl/drop-db-ddl-statements driver dbdef)]


### PR DESCRIPTION
Resolves #22693

Adds a new `metabase.actions.test-util/with-actions-test-data` macro that binds the current dataset (e.g. `(mt/id)` and `(mt/db)`) to a copy of `test-data` that you can feel free to destroy -- it gets destroyed at the end of the macro body. 

Since reloading and syncing this data is a pretty slow (~200ms for H2 and ~450ms for Postgres on my local machine) it currently only loads up and syncs the `categories` table but not the other three (this only takes ~100ms H2/~200ms Postgres). Should be fine for testing stuff in the short-term. In the long term I can optimize this a lot (e.g. copying Table/Fields from `test-data` so we don't need to run sync again, maybe copying the entire table using `SELECT INTO` or something like that in the Database itself). Once it's cleaned up and generalized I might rename it to something like `mt/with-destructible-copy-of-dataset` (TBD). But this should be fine for us to get #22608 merged in.

# Example usage

```clj
(deftest my-test
  (actions.test-util/with-actions-test-data
    (do-something-destructive!)))
```

For #22608 @escherize you can use this in place of `mt/with-temp-copy-of-db`.