### PR TITLE
Improve DateMonthYearWidget

### DIFF
--- a/frontend/src/metabase/components/DateQuarterYearWidget/DateQuarterYearWidget.stories.tsx
+++ b/frontend/src/metabase/components/DateQuarterYearWidget/DateQuarterYearWidget.stories.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { ComponentStory } from "@storybook/react";
+import { useArgs } from "@storybook/client-api";
+import DateQuarterYearWidget from "./DateQuarterYearWidget";
+
+export default {
+  title: "Parameters/DateQuarterYearWidget",
+  component: DateQuarterYearWidget,
+};
+
+const Template: ComponentStory<typeof DateQuarterYearWidget> = args => {
+  const [{ value }, updateArgs] = useArgs();
+
+  const handleSetValue = (v: string) => {
+    updateArgs({ value: v });
+  };
+
+  const handleClose = () => {
+    // do nothing
+  };
+
+  return (
+    <DateQuarterYearWidget
+      {...args}
+      value={value}
+      setValue={handleSetValue}
+      onClose={handleClose}
+    />
+  );
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  value: "",
+};
+
+export const SomeTimeLastYear = Template.bind({});
+SomeTimeLastYear.args = {
+  value: "4-2021",
+};
+
+export const SomeTimeAgo = Template.bind({});
+SomeTimeAgo.args = {
+  value: "2-1981",
+};

--- a/frontend/src/metabase/components/DateQuarterYearWidget/DateQuarterYearWidget.tsx
+++ b/frontend/src/metabase/components/DateQuarterYearWidget/DateQuarterYearWidget.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable react/prop-types */
-import React, { Component } from "react";
+import React from "react";
 import moment from "moment";
 import _ from "underscore";
 import cx from "classnames";
@@ -10,9 +9,25 @@ import YearPicker from "metabase/components/YearPicker";
 // translator: this is a "moment" format string (https://momentjs.com/docs/#/displaying/format/) It should include "Q" for the quarter number, and raw text can be escaped by brackets. For eample "[Quarter] Q" will be rendered as "Quarter 1" etc
 const QUARTER_FORMAT_STRING = t`[Q]Q`;
 
-export default class DateQuarterYearWidget extends Component {
-  constructor(props, context) {
-    super(props, context);
+type Props = {
+  value: string;
+  setValue: (v: string) => void;
+  onClose: () => void;
+};
+
+type State = {
+  quarter: number | null;
+  year: number;
+};
+
+class DateQuarterYearWidget extends React.Component<Props, State> {
+  state: State = {
+    quarter: null,
+    year: moment().year(),
+  };
+
+  constructor(props: Props) {
+    super(props);
 
     const initial = moment(this.props.value, "[Q]Q-YYYY");
     if (initial.isValid()) {
@@ -28,10 +43,7 @@ export default class DateQuarterYearWidget extends Component {
     }
   }
 
-  static propTypes = {};
-  static defaultProps = {};
-
-  static format = value => {
+  static format = (value: string) => {
     const m = moment(value, "[Q]Q-YYYY");
     return m.isValid() ? m.format("[Q]Q, YYYY") : "";
   };
@@ -78,8 +90,15 @@ export default class DateQuarterYearWidget extends Component {
   }
 }
 
-const Quarter = ({ quarter, selected, onClick }) => (
+interface QuarterProps {
+  quarter: number;
+  selected: boolean;
+  onClick: () => void;
+}
+
+const Quarter = ({ quarter, selected, onClick }: QuarterProps) => (
   <li
+    aria-selected={selected}
     className={cx(
       "cursor-pointer bg-brand-hover text-white-hover flex layout-centered",
       { "bg-brand text-white": selected },
@@ -92,3 +111,5 @@ const Quarter = ({ quarter, selected, onClick }) => (
       .format(QUARTER_FORMAT_STRING)}
   </li>
 );
+
+export default DateQuarterYearWidget;

--- a/frontend/src/metabase/components/DateQuarterYearWidget/DateQuarterYearWidget.unit.spec.tsx
+++ b/frontend/src/metabase/components/DateQuarterYearWidget/DateQuarterYearWidget.unit.spec.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import DateQuarterYearWidget from "./DateQuarterYearWidget";
+
+describe("DateQuarterYearWidget", () => {
+  it("should render correctly", () => {
+    const { container } = render(
+      <DateQuarterYearWidget
+        value={"2-2020"}
+        setValue={jest.fn()}
+        onClose={jest.fn()}
+      ></DateQuarterYearWidget>,
+    );
+
+    expect(screen.getByText("Q1")).toBeVisible();
+    expect(screen.getByText("Q4")).toBeVisible();
+
+    expect(screen.getByTestId("select-button")).toHaveTextContent("2020");
+    expect(
+      container.querySelector("li[aria-selected='true']"),
+    ).toHaveTextContent("Q2");
+  });
+});

--- a/frontend/src/metabase/components/DateQuarterYearWidget/index.ts
+++ b/frontend/src/metabase/components/DateQuarterYearWidget/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DateQuarterYearWidget";

--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
@@ -9,7 +9,7 @@ import DateSingleWidget from "./widgets/DateSingleWidget";
 import DateRangeWidget from "./widgets/DateRangeWidget";
 import DateRelativeWidget from "./widgets/DateRelativeWidget";
 import DateMonthYearWidget from "metabase/components/DateMonthYearWidget";
-import DateQuarterYearWidget from "./widgets/DateQuarterYearWidget";
+import DateQuarterYearWidget from "metabase/components/DateQuarterYearWidget";
 import DateAllOptionsWidget from "./widgets/DateAllOptionsWidget";
 import TextWidget from "./widgets/TextWidget";
 import ParameterFieldWidget from "./widgets/ParameterFieldWidget/ParameterFieldWidget";


### PR DESCRIPTION
* migrate to TypeScript, add type annotations
* include props and state definition
* support Storybook
* add a basic unit test

Verify manually by creating a dashboard with a parameter:
1. Browse data, Sample Database, Products
2. Save as a question, add to a dashboard
3. Edit dashboard, Add a filter, choose `Time` and `Quarter and Year`
4. Column to filter on `Created At`, Done

Ensure that everything works exactly the same **before** and **after** this PR.

![image](https://user-images.githubusercontent.com/7288/168193451-75a95539-c259-44ff-829d-5f3d86811827.png)

To view this component in Storybook: `yarn storybook` and search for `DateQuarterYearWidget`:

![image](https://user-images.githubusercontent.com/7288/168194280-54a2799d-1606-495c-b68e-ee5c074c1f6f.png)

