### PR TITLE
Add delete button to object detail modal

### DIFF
--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -343,6 +343,10 @@ export const MetabaseApi = {
     // this prevents the `endpoint` parameter from being URL encoded
     raw: { endpoint: true },
   }),
+
+  actions: {
+    deleteRow: POST("/api/actions/row/delete"),
+  },
 };
 
 export const ModerationReviewApi = {

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
@@ -56,12 +56,11 @@ import {
   ErrorWrapper,
   EditingFormContainer,
 } from "./ObjectDetail.styled";
-import ModalWithTrigger from "metabase/components/ModalWithTrigger";
-import ConfirmContent from "metabase/components/ConfirmContent";
 import {
   deleteRowFromObjectDetail,
   DeleteRowPayload,
 } from "metabase/writeback/actions";
+import ActionHeader from "metabase/writeback/components/ObjectDetails/ActionHeader";
 
 const mapStateToProps = (state: State, { data }: ObjectDetailProps) => {
   let zoomedRowID = getZoomedObjectId(state);
@@ -222,6 +221,17 @@ export function ObjectDetailFn({
     [zoomedRowID, followForeignKey],
   );
 
+  const canEdit = !!(isWritebackEnabled && table);
+  const deleteRow = React.useMemo(() => {
+    if (canEdit) {
+      return () =>
+        deleteRowFromObjectDetail({
+          id: zoomedRowID,
+          table,
+        });
+    }
+  }, [canEdit, zoomedRowID, table, deleteRowFromObjectDetail]);
+
   const onKeyDown = (event: KeyboardEvent) => {
     const capturedKeys: { [key: string]: () => void } = {
       ArrowUp: viewPreviousObjectDetail,
@@ -256,16 +266,6 @@ export function ObjectDetailFn({
     !!tableForeignKeys.length &&
     hasPk
   );
-  const canEdit = !!(isWritebackEnabled && table);
-
-  let deleteRow;
-  if (canEdit) {
-    deleteRow = () =>
-      deleteRowFromObjectDetail({
-        id: zoomedRowID,
-        table,
-      });
-  }
 
   return (
     <Modal
@@ -350,7 +350,6 @@ export function ObjectDetailHeader({
   closeObjectDetail,
   onToggleEditingModeClick,
 }: ObjectDetailHeaderProps): JSX.Element {
-  const deleteRowModal = React.useRef() as any;
   return (
     <div className="Grid border-bottom relative">
       <div className="Grid-cell">
@@ -361,38 +360,11 @@ export function ObjectDetailHeader({
       </div>
       <div className="flex align-center">
         {canEdit && (
-          <>
-            {deleteRow ? (
-              <ModalWithTrigger
-                ref={deleteRowModal}
-                triggerElement={
-                  <Button
-                    className="mr1"
-                    icon={"trash"}
-                    iconSize={20}
-                    onlyIcon
-                    borderless
-                  />
-                }
-              >
-                <ConfirmContent
-                  title={t`Delete row`}
-                  content={""}
-                  onClose={() => deleteRowModal.current.toggle()}
-                  onAction={() => deleteRow()}
-                />
-              </ModalWithTrigger>
-            ) : null}
-
-            <Button
-              className="mr1"
-              icon={isEditing ? "eye" : "pencil"}
-              onClick={onToggleEditingModeClick}
-              iconSize={20}
-              onlyIcon
-              borderless
-            />
-          </>
+          <ActionHeader
+            isEditing={isEditing}
+            deleteRow={deleteRow}
+            onToggleEditingModeClick={onToggleEditingModeClick}
+          />
         )}
         <div className="flex p2">
           {!!canZoom && (

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.unit.spec.tsx
@@ -19,6 +19,7 @@ describe("Object Detail", () => {
         canZoomPreviousRow={false}
         isEditing={false}
         canEdit={false}
+        deleteRow={() => null}
         viewPreviousObjectDetail={() => null}
         viewNextObjectDetail={() => null}
         closeObjectDetail={() => null}
@@ -39,6 +40,7 @@ describe("Object Detail", () => {
         canZoomPreviousRow={false}
         isEditing={false}
         canEdit={false}
+        deleteRow={() => null}
         viewPreviousObjectDetail={() => null}
         viewNextObjectDetail={() => null}
         closeObjectDetail={() => null}
@@ -109,6 +111,7 @@ describe("Object Detail", () => {
         visualizationIsClickable={() => false}
         fetchTableFks={() => null}
         loadObjectDetailFKReferences={() => null}
+        deleteRowFromObjectDetail={() => null}
         viewPreviousObjectDetail={() => null}
         viewNextObjectDetail={() => null}
         closeObjectDetail={() => null}

--- a/frontend/src/metabase/writeback/actions.ts
+++ b/frontend/src/metabase/writeback/actions.ts
@@ -1,7 +1,7 @@
-import * as api from "metabase/writeback/api";
+import { MetabaseApi } from "metabase/services";
+import Table from "metabase-lib/lib/metadata/Table";
 import { runQuestionQuery } from "metabase/query_builder/actions/querying";
 import { closeObjectDetail } from "metabase/query_builder/actions/object-detail";
-import Table from "metabase-lib/lib/metadata/Table";
 
 export type DeleteRowPayload = {
   table: Table;
@@ -19,12 +19,12 @@ export const deleteRowFromObjectDetail = (payload: DeleteRowPayload) => {
     }
 
     const pk = field.isNumeric() && typeof id === "string" ? parseInt(id) : id;
-    const result = await api.deleteRow({
+    const result = await MetabaseApi.actions.deleteRow({
       type: "query",
       database: table.db_id,
       query: {
         "source-table": table.id,
-        filter: ["=", ["field", field.id, null], pk],
+        filter: ["=", field.reference(), pk],
       },
     });
 

--- a/frontend/src/metabase/writeback/actions.ts
+++ b/frontend/src/metabase/writeback/actions.ts
@@ -1,0 +1,37 @@
+import * as api from "metabase/writeback/api";
+import { runQuestionQuery } from "metabase/query_builder/actions/querying";
+import { closeObjectDetail } from "metabase/query_builder/actions/object-detail";
+import Table from "metabase-lib/lib/metadata/Table";
+
+export type DeleteRowPayload = {
+  table: Table;
+  id: number | string;
+};
+
+export const DELETE_ROW_FROM_OBJECT_DETAIL =
+  "metabase/qb/DELETE_ROW_FROM_OBJECT_DETAIL";
+export const deleteRowFromObjectDetail = (payload: DeleteRowPayload) => {
+  return async (dispatch: any) => {
+    const { table, id } = payload;
+    const field = table.fields.find(field => field.isPK());
+    if (!field) {
+      throw new Error("Cannot delete row from table without a primary key");
+    }
+
+    const pk = field.isNumeric() && typeof id === "string" ? parseInt(id) : id;
+    const result = await api.deleteRow({
+      type: "query",
+      database: table.db_id,
+      query: {
+        "source-table": table.id,
+        filter: ["=", ["field", field.id, null], pk],
+      },
+    });
+
+    dispatch.action(DELETE_ROW_FROM_OBJECT_DETAIL, payload);
+    if (result?.["rows-deleted"]?.length > 0) {
+      dispatch(closeObjectDetail());
+      dispatch(runQuestionQuery());
+    }
+  };
+};

--- a/frontend/src/metabase/writeback/api.ts
+++ b/frontend/src/metabase/writeback/api.ts
@@ -1,0 +1,3 @@
+import { POST } from "metabase/lib/api";
+
+export const deleteRow = POST("/api/actions/row/delete");

--- a/frontend/src/metabase/writeback/api.ts
+++ b/frontend/src/metabase/writeback/api.ts
@@ -1,3 +1,0 @@
-import { POST } from "metabase/lib/api";
-
-export const deleteRow = POST("/api/actions/row/delete");

--- a/frontend/src/metabase/writeback/components/ObjectDetails/ActionHeader.tsx
+++ b/frontend/src/metabase/writeback/components/ObjectDetails/ActionHeader.tsx
@@ -1,0 +1,53 @@
+import ConfirmContent from "metabase/components/ConfirmContent";
+import ModalWithTrigger from "metabase/components/ModalWithTrigger";
+import Button from "metabase/core/components/Button";
+import React from "react";
+import { connect } from "react-redux";
+import { t } from "ttag";
+
+export interface ObjectDetailHeaderProps {
+  isEditing: boolean;
+  deleteRow?: () => void;
+  onToggleEditingModeClick: () => void;
+}
+
+export default function ActionHeader({
+  isEditing,
+  deleteRow,
+  onToggleEditingModeClick,
+}: ObjectDetailHeaderProps): JSX.Element {
+  const deleteRowModal = React.useRef() as any;
+  return (
+    <>
+      {deleteRow ? (
+        <ModalWithTrigger
+          ref={deleteRowModal}
+          triggerElement={
+            <Button
+              className="mr1"
+              icon={"trash"}
+              iconSize={20}
+              onlyIcon
+              borderless
+            />
+          }
+        >
+          <ConfirmContent
+            title={t`Delete row`}
+            content={""}
+            onClose={() => deleteRowModal.current.toggle()}
+            onAction={() => deleteRow()}
+          />
+        </ModalWithTrigger>
+      ) : null}
+      <Button
+        className="mr1"
+        icon={isEditing ? "eye" : "pencil"}
+        onClick={onToggleEditingModeClick}
+        iconSize={20}
+        onlyIcon
+        borderless
+      />
+    </>
+  );
+}


### PR DESCRIPTION
Attempt at #22547 (the table grid view is complicated and adding the on-hover button will take more time)

### To Verify

1. Run Metabase with `experimental-enable-actions` flag or patch [this selector](https://github.com/metabase/metabase/blob/84bd09ffc2bc5069ff7482fb6c6b9ae70b737dd3/frontend/src/metabase/writeback/selectors.ts#L5) to return `true`
2. Click `Enable actions` in Database settings (Danger Zone!) for an H2 or Postgres database
3. Open an object detail for any row (click the PK or hover the row and click the "expand" icon on the left)
4. Click the "trash" icon next to the previous/next/edit buttons in the header
5. You should see a confirmation dialog
6. When you confirm, it should fire off an api request to `/api/actions/row/delete` 

![image](https://user-images.githubusercontent.com/653604/168308959-975fea28-734f-4158-aaaf-70df628adf0f.png)

![image](https://user-images.githubusercontent.com/653604/168309807-4155749f-0643-4e3a-a2c1-34f01609218f.png)
