### PR TITLE
Upgrade Underscore.js to v1.13.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "tether": "^1.2.0",
     "tippy.js": "^6.3.5",
     "ttag": "1.7.15",
-    "underscore": "^1.8.3",
+    "underscore": "~1.13.3",
     "yarn.lock": "^0.0.1-security",
     "z-index": "0.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -20673,10 +20673,10 @@ unc-path-regex@^0.1.0, unc-path-regex@^0.1.2:
   resolved "https://registry.yarnpkg.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
   integrity sha1-5z3T17DXxe2G+6xrCufYxqadUPo=
 
-underscore@^1.8.3:
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.11.0.tgz#dd7c23a195db34267186044649870ff1bab5929e"
-  integrity sha512-xY96SsN3NA461qIRKZ/+qox37YXPtSBswMGfiNptr+wrt6ds4HaMw23TP612fEyGekRE6LNRiLYr/aqbHXNedw==
+underscore@~1.13.3:
+  version "1.13.3"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.3.tgz#54bc95f7648c5557897e5e968d0f76bc062c34ee"
+  integrity sha512-QvjkYpiD+dJJraRA8+dGAU4i7aBbb2s0S3jA45TFOvg2VgqvdCDd/3N6CqA8gluk1W91GLoXg5enMUx560QzuA==
 
 unfetch@^4.2.0:
   version "4.2.0"


### PR DESCRIPTION
Our current Underscore.js is v1.8.3 (April 2, 2015), though technically resolved to 1.11.0 (August 28, 2020) in `yarn.lock`, and there have been numerous improvements since then (and so far, with no breaking changes). See its [Change Log](https://underscorejs.org/#changelog) for more details.