### PR TITLE
Don't reschedule syncs on startup (#22680)

### DIFF
--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -594,7 +594,7 @@
                                   (sync.schedules/schedule-map->cron-strings
                                     (if (:let-user-control-scheduling details)
                                       (sync.schedules/scheduling schedules)
-                                      (sync.schedules/default-schedule)))
+                                      (sync.schedules/default-randomized-schedule)))
                                   (when (some? auto_run_queries)
                                     {:auto_run_queries auto_run_queries}))))
         (events/publish-event! :database-create <>)
@@ -660,57 +660,57 @@
    auto_run_queries   (s/maybe s/Bool)
    cache_ttl          (s/maybe su/IntGreaterThanZero)}
   ;; TODO - ensure that custom schedules and let-user-control-scheduling go in lockstep
-  (let [existing-database (api/write-check (Database id))]
-    (let [details    (driver.u/db-details-client->server engine details)
-          details    (upsert-sensitive-fields existing-database details)
-          conn-error (when (some? details)
-                       (assert (some? engine))
-                       (test-database-connection engine details))
-          full-sync? (when-not (nil? is_full_sync)
-                       (boolean is_full_sync))]
-      (if conn-error
-        ;; failed to connect, return error
-        {:status 400
-         :body   conn-error}
-        ;; no error, proceed with update
-        (do
-          ;; TODO - is there really a reason to let someone change the engine on an existing database?
-          ;;       that seems like the kind of thing that will almost never work in any practical way
-          ;; TODO - this means one cannot unset the description. Does that matter?
-          (api/check-500 (db/update-non-nil-keys! Database id
-                                                  (merge
-                                                     {:name               name
-                                                      :engine             engine
-                                                      :details            details
-                                                      :refingerprint      refingerprint
-                                                      :is_full_sync       full-sync?
-                                                      :is_on_demand       (boolean is_on_demand)
-                                                      :description        description
-                                                      :caveats            caveats
-                                                      :points_of_interest points_of_interest
-                                                      :auto_run_queries   auto_run_queries}
-                                                     (cond
-                                                       ;; transition back to metabase managed schedules. the schedule
-                                                       ;; details, even if provided, are ignored. database is the
-                                                       ;; current stored value and check against the incoming details
-                                                       (and (get-in existing-database [:details :let-user-control-scheduling])
-                                                            (not (:let-user-control-scheduling details)))
+  (let [existing-database (api/write-check (Database id))
+        details           (driver.u/db-details-client->server engine details)
+        details           (upsert-sensitive-fields existing-database details)
+        conn-error        (when (some? details)
+                            (assert (some? engine))
+                            (test-database-connection engine details))
+        full-sync?        (when-not (nil? is_full_sync)
+                            (boolean is_full_sync))]
+    (if conn-error
+      ;; failed to connect, return error
+      {:status 400
+       :body   conn-error}
+      ;; no error, proceed with update
+      (do
+        ;; TODO - is there really a reason to let someone change the engine on an existing database?
+        ;;       that seems like the kind of thing that will almost never work in any practical way
+        ;; TODO - this means one cannot unset the description. Does that matter?
+        (api/check-500 (db/update-non-nil-keys! Database id
+                                                (merge
+                                                 {:name               name
+                                                  :engine             engine
+                                                  :details            details
+                                                  :refingerprint      refingerprint
+                                                  :is_full_sync       full-sync?
+                                                  :is_on_demand       (boolean is_on_demand)
+                                                  :description        description
+                                                  :caveats            caveats
+                                                  :points_of_interest points_of_interest
+                                                  :auto_run_queries   auto_run_queries}
+                                                 (cond
+                                                   ;; transition back to metabase managed schedules. the schedule
+                                                   ;; details, even if provided, are ignored. database is the
+                                                   ;; current stored value and check against the incoming details
+                                                   (and (get-in existing-database [:details :let-user-control-scheduling])
+                                                        (not (:let-user-control-scheduling details)))
 
-                                                       (sync.schedules/schedule-map->cron-strings (sync.schedules/default-schedule))
+                                                   (sync.schedules/schedule-map->cron-strings (sync.schedules/default-randomized-schedule))
 
-                                                       ;; if user is controlling schedules
-                                                       (:let-user-control-scheduling details)
-                                                       (sync.schedules/schedule-map->cron-strings (sync.schedules/scheduling schedules))))))
-                                                       ;; do nothing in the case that user is not in control of
-                                                       ;; scheduling. leave them as they are in the db
+                                                   ;; if user is controlling schedules
+                                                   (:let-user-control-scheduling details)
+                                                   (sync.schedules/schedule-map->cron-strings (sync.schedules/scheduling schedules))))))
+        ;; do nothing in the case that user is not in control of
+        ;; scheduling. leave them as they are in the db
 
-          ;; unlike the other fields, folks might want to nil out cache_ttl
-          (api/check-500 (db/update! Database id {:cache_ttl cache_ttl}))
+        ;; unlike the other fields, folks might want to nil out cache_ttl
+        (api/check-500 (db/update! Database id {:cache_ttl cache_ttl}))
 
-          (let [db (Database id)]
-            (events/publish-event! :database-update db)
-            ;; return the DB with the expanded schedules back in place
-            (add-expanded-schedules db)))))))
+        (let [db (Database id)]
+          (events/publish-event! :database-update db)
+          ;; return the DB with the expanded schedules back in place
+          (add-expanded-schedules db))))))
 
 
 ;;; -------------------------------------------- DELETE /api/database/:id --------------------------------------------

--- a/src/metabase/sync/schedules.clj
+++ b/src/metabase/sync/schedules.clj
@@ -33,17 +33,20 @@
 (defn randomly-once-an-hour
   "Schedule map for once an hour at a random minute of the hour."
   []
-  {:schedule_minute (rand-int 59)
+  ;; prevent zeros which would appear as non-random
+  {:schedule_minute (inc (rand-int 59))
    :schedule_type   "hourly"})
 
 (defn randomly-once-a-day
   "Schedule map for once a day at a random hour of the day."
   []
-  {:schedule_hour  (rand-int 24)
+  ;; prevent zeros which would appear as non-random
+  {:schedule_hour  (inc (rand-int 23))
    :schedule_type  "daily"})
 
-(defn default-schedule
-  "Default schedule maps for caching field values and sync."
+(defn default-randomized-schedule
+  "Default schedule maps for caching field values and sync. Defaults to `:cache_field_values` randomly once a day and
+  `:metadata_sync` randomly once an hour. "
   []
   {:cache_field_values (randomly-once-a-day)
    :metadata_sync      (randomly-once-an-hour)})

--- a/test/metabase/models/database_test.clj
+++ b/test/metabase/models/database_test.clj
@@ -45,10 +45,7 @@
 (deftest tasks-test
   (testing "Sync tasks should get scheduled for a newly created Database"
     (mt/with-temp-scheduler
-      ;; temporarily disable the `maybe-update-db-schedules` behavior that normally happens when the sync databases
-      ;; task gets initialized so we don't end up getting all of our database sync schedules randomized.
-      (with-redefs [task.sync-databases/maybe-update-db-schedules identity]
-        (task/init! ::task.sync-databases/SyncDatabases))
+      (task/init! ::task.sync-databases/SyncDatabases)
       (mt/with-temp Database [{db-id :id}]
         (is (schema= {:description         (s/eq (format "sync-and-analyze Database %d" db-id))
                       :key                 (s/eq (format "metabase.task.sync-and-analyze.trigger.%d" db-id))
@@ -176,7 +173,7 @@
     (mt/with-driver :secret-test-driver
       (binding [api/*current-user-id* (mt/user->id :crowberto)]
         (let [secret-ids  (atom #{}) ; keep track of all secret IDs created with the temp database
-              check-db-fn (fn [{:keys [details] :as database} exp-secret]
+              check-db-fn (fn [{:keys [details] :as _database} exp-secret]
                             (when (not= :file-path (:source exp-secret))
                               (is (not (contains? details :password-value))
                                   "password-value was removed from details when not a file-path"))
@@ -225,7 +222,7 @@
                       (format "Secret ID %d was not removed from the app DB" secret-id)))))))))))
 
 (deftest user-may-not-update-sample-database-test
-  (mt/with-temp Database [{:keys [id details] :as sample-database} {:engine    :h2
+  (mt/with-temp Database [{:keys [id details] :as _sample-database} {:engine    :h2
                                                                     :is_sample true
                                                                     :name      "Sample Database"
                                                                     :details   {:db "./resources/sample-database.db;USER=GUEST;PASSWORD=guest"}}]

--- a/test/metabase/task/sync_databases_test.clj
+++ b/test/metabase/task/sync_databases_test.clj
@@ -7,7 +7,7 @@
             [java-time :as t]
             [metabase.models.database :refer [Database]]
             [metabase.sync.schedules :as sync.schedules]
-            [metabase.task.sync-databases :as sync-db]
+            [metabase.task.sync-databases :as task.sync-databases]
             [metabase.test :as mt]
             [metabase.test.util :as tu]
             [metabase.util :as u]
@@ -43,7 +43,7 @@
 
 (defmacro with-scheduler-setup [& body]
   `(tu/with-temp-scheduler
-     (#'sync-db/job-init)
+     (#'task.sync-databases/job-init)
      ~@body))
 
 (def ^:private sync-job
@@ -149,7 +149,7 @@
 (deftest check-orphaned-jobs-removed-test
   (testing "jobs for orphaned databases are removed during sync run"
     (with-scheduler-setup
-      (doseq [sync-fn [#'sync-db/update-field-values! #'sync-db/sync-and-analyze-database!]]
+      (doseq [sync-fn [#'task.sync-databases/update-field-values! #'task.sync-databases/sync-and-analyze-database!]]
         (testing (str sync-fn)
           (mt/with-temp Database [database {:engine :postgres}]
             (let [db-id (:id database)]
@@ -226,8 +226,8 @@
                :metadata_sync_schedule      (cron-schedule-for-next-year)
                :cache_field_values_schedule "* * * * * ? *"})))))
 
-(def should-refingerprint #'sync-db/should-refingerprint-fields?)
-(def threshold @#'sync-db/analyze-duration-threshold-for-refingerprinting)
+(def should-refingerprint #'task.sync-databases/should-refingerprint-fields?)
+(def threshold @#'task.sync-databases/analyze-duration-threshold-for-refingerprinting)
 
 (defn results [minutes-duration fingerprints-attempted]
   (let [now (t/instant)

--- a/test/metabase/task/sync_databases_test.clj
+++ b/test/metabase/task/sync_databases_test.clj
@@ -11,10 +11,6 @@
             [metabase.test :as mt]
             [metabase.test.util :as tu]
             [metabase.util :as u]
-<<<<<<< HEAD
-            [metabase.util.cron :as cron-util]
-=======
->>>>>>> a6c1b33c09 (Don't reschedule syncs on startup (#22680))
             [toucan.db :as db])
   (:import [metabase.task.sync_databases SyncAndAnalyzeDatabase UpdateFieldValues]))
 


### PR DESCRIPTION
manual backport of https://github.com/metabase/metabase/pull/22680

conflicts were from a duplicate `let` in api/database.clj that was removed in master for lint cleanup. and another namespace had a conflict on ns alias changes. Otherwise the same.