### PR TITLE
Upgrade build-drivers to Clojure 1.11.1

### DIFF
--- a/bin/build-drivers/deps.edn
+++ b/bin/build-drivers/deps.edn
@@ -1,7 +1,8 @@
 {:paths ["src"]
 
  :deps
- {common/common                   {:local/root "../common"}
+ {org.clojure/clojure             {:mvn/version "1.11.1"} ; explicit otherwise version is picked up from cli
+  common/common                   {:local/root "../common"}
   com.github.seancorfield/depstar {:mvn/version "2.1.278"}
   cheshire/cheshire               {:mvn/version "5.8.1"}
   commons-codec/commons-codec     {:mvn/version "1.14"}


### PR DESCRIPTION
Addressing a build failure with new clojure 1.11 functions in build-drivers.

Running clj -X:deps tree in bin/build-drivers the cli version is getting picked up
as I switched clojure-cli versions between 1.11 and 1.10.

I think this is because including metabase/metabase-core as a local/root no longer
places the clojure dep within it at the top level.

Now, the docs say
> It is a top dep (top dep versions always win) or it is a new lib or a newer version of a known lib (Maven keeps only the first found version regardless of new/old)

And so I would expect to see org.clojure/clojure in the deps tree under
metabase/metabase-core but it's missing, which to me means clojure maybe treated
specially if the root deps don't specify it.

Explicitly adding the dependency here gets 1.11 picked up.