### PR TITLE
Repro #22700: Custom expression aggregation does not work in metrics

### DIFF
--- a/frontend/test/metabase/scenarios/admin/datamodel/metrics.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/metrics.cy.spec.js
@@ -92,6 +92,44 @@ describe("scenarios > admin > datamodel > metrics", () => {
       );
       cy.findByText("Learn how to create metrics");
     });
+
+    it.skip("custom expression aggregation should work in metrics (metabase#22700)", () => {
+      cy.intercept("POST", "/api/dataset").as("dataset");
+
+      const customExpression = "Count / Distinct([Product ID])";
+
+      cy.visit("/admin/datamodel/metrics");
+
+      cy.button("New metric").click();
+      cy.findByText("Select a table").click();
+      cy.findByText("Orders").click();
+      // It sees that there is one dataset query for each of the fields:
+      // `data`, `filtered by` and `view`
+      cy.wait(["@dataset", "@dataset", "@dataset"]);
+
+      cy.findByText("Count").click();
+      popover()
+        .contains("Custom Expression")
+        .click();
+
+      cy.get(".ace_text-input")
+
+        .click()
+        .type(`{selectall}{del}${customExpression}`)
+        .blur();
+
+      cy.findByPlaceholderText("Name (required)").type("Foo");
+
+      cy.button("Done").click();
+      cy.wait("@dataset");
+
+      // The test should fail on this step first
+      cy.findByText("Result: 93.8");
+
+      // Let's make sure the custom expression is still preserved
+      cy.findByText("Foo").click();
+      cy.get(".ace_content").should("contain", customExpression);
+    });
   });
 
   describe("with metrics", () => {

--- a/frontend/test/metabase/scenarios/admin/datamodel/metrics.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/metrics.cy.spec.js
@@ -113,7 +113,6 @@ describe("scenarios > admin > datamodel > metrics", () => {
         .click();
 
       cy.get(".ace_text-input")
-
         .click()
         .type(`{selectall}{del}${customExpression}`)
         .blur();


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #22700

### How to test this manually?
- `yarn test-cypress-open`
- `metabase/scenarios/admin/datamodel/metrics.cy.spec.js
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/168376768-5f723ad9-55b4-421a-ad31-f9a4bc4e1ea3.png)

