### PR TITLE
Add useMostRecentCall hook

### DIFF
--- a/frontend/src/metabase-types/types/index.ts
+++ b/frontend/src/metabase-types/types/index.ts
@@ -34,3 +34,5 @@ export type Moment = {
   locale: () => Moment;
   format: (format: string) => string;
 };
+
+export type AsyncFn = (...args: any[]) => Promise<any>;

--- a/frontend/src/metabase-types/types/index.ts
+++ b/frontend/src/metabase-types/types/index.ts
@@ -36,3 +36,7 @@ export type Moment = {
 };
 
 export type AsyncFn = (...args: any[]) => Promise<any>;
+
+export type AsyncReturnType<
+  T extends (...args: any) => Promise<any>
+> = T extends (...args: any) => Promise<infer R> ? R : any;

--- a/frontend/src/metabase/hooks/use-most-recent-call/index.ts
+++ b/frontend/src/metabase/hooks/use-most-recent-call/index.ts
@@ -1,0 +1,1 @@
+export { useMostRecentCall } from "./use-most-recent-call";

--- a/frontend/src/metabase/hooks/use-most-recent-call/use-most-recent-call.ts
+++ b/frontend/src/metabase/hooks/use-most-recent-call/use-most-recent-call.ts
@@ -1,0 +1,29 @@
+import { useRef, useCallback } from "react";
+
+import { AsyncFn } from "metabase-types/types";
+
+export function useMostRecentCall(asyncFn: AsyncFn): AsyncFn {
+  const promiseRef = useRef<Promise<any>>();
+
+  return useCallback(
+    async (...args: any[]) => {
+      const promise = asyncFn(...args);
+      promiseRef.current = promise;
+
+      return new Promise((resolve, reject) => {
+        return promise
+          .then((res: any) => {
+            if (promiseRef.current === promise) {
+              resolve(res);
+            }
+          })
+          .catch((err: Error) => {
+            if (promiseRef.current === promise) {
+              reject(err);
+            }
+          });
+      });
+    },
+    [asyncFn],
+  );
+}

--- a/frontend/src/metabase/hooks/use-most-recent-call/use-most-recent-call.ts
+++ b/frontend/src/metabase/hooks/use-most-recent-call/use-most-recent-call.ts
@@ -1,18 +1,18 @@
 import { useRef, useCallback } from "react";
 
-import { AsyncFn } from "metabase-types/types";
+import { AsyncFn, AsyncReturnType } from "metabase-types/types";
 
-export function useMostRecentCall(asyncFn: AsyncFn): AsyncFn {
+export function useMostRecentCall<T extends AsyncFn>(asyncFn: T) {
   const promiseRef = useRef<Promise<any>>();
 
-  return useCallback(
-    async (...args: any[]) => {
+  return useCallback<(...args: Parameters<T>) => Promise<AsyncReturnType<T>>>(
+    (...args) => {
       const promise = asyncFn(...args);
       promiseRef.current = promise;
 
       return new Promise((resolve, reject) => {
         return promise
-          .then((res: any) => {
+          .then((res: AsyncReturnType<T>) => {
             if (promiseRef.current === promise) {
               resolve(res);
             }

--- a/frontend/src/metabase/hooks/use-most-recent-call/use-most-recent-call.unit.spec.tsx
+++ b/frontend/src/metabase/hooks/use-most-recent-call/use-most-recent-call.unit.spec.tsx
@@ -1,0 +1,92 @@
+import React, { useEffect, useState } from "react";
+import { render } from "@testing-library/react";
+
+import { AsyncFn } from "metabase-types/types";
+
+import { useMostRecentCall } from "./use-most-recent-call";
+
+function TestComponent({
+  trigger,
+  asyncFn,
+}: {
+  trigger: number;
+  asyncFn: AsyncFn;
+}) {
+  const [num, setNum] = useState(0);
+  const fn = useMostRecentCall(asyncFn);
+
+  useEffect(() => {
+    fn(trigger)
+      .then(res => {
+        setNum(res);
+      })
+      .catch(err => {
+        setNum(err);
+      });
+  }, [fn, trigger]);
+
+  return <div>{num}</div>;
+}
+
+describe("useMostRecentCall", () => {
+  it("should resolve with data once triggered", () => {
+    const asyncFn = jest.fn(() => Promise.resolve(1));
+    const { findByText } = render(
+      <TestComponent asyncFn={asyncFn} trigger={1} />,
+    );
+
+    return findByText("1");
+  });
+
+  it("should only ever resolve last call's promise", async () => {
+    const resolveFnMap: Record<number, () => void> = {};
+    const asyncFn = (num: number) =>
+      new Promise(resolve => {
+        resolveFnMap[num] = resolve.bind(null, num);
+      });
+
+    const { rerender, findByText } = render(
+      <TestComponent asyncFn={asyncFn} trigger={1} />,
+    );
+
+    rerender(<TestComponent asyncFn={asyncFn} trigger={2} />);
+    rerender(<TestComponent asyncFn={asyncFn} trigger={3} />);
+
+    await findByText("0");
+
+    // before most recent call resolves
+    resolveFnMap[1]();
+    // most recent call
+    resolveFnMap[3]();
+    // after most recent call resolves
+    resolveFnMap[2]();
+
+    await findByText("3");
+  });
+
+  it("should only reject last call's promise", async () => {
+    const rejectFnMap: Record<number, () => void> = {};
+    const asyncFn = (num: number) =>
+      new Promise((resolve, reject) => {
+        rejectFnMap[num] = reject.bind(null, num);
+      });
+
+    const { rerender, findByText } = render(
+      <TestComponent asyncFn={asyncFn} trigger={1} />,
+    );
+
+    rerender(<TestComponent asyncFn={asyncFn} trigger={2} />);
+    rerender(<TestComponent asyncFn={asyncFn} trigger={3} />);
+
+    await findByText("0");
+
+    // before most recent call resolves
+    rejectFnMap[1]();
+    // most recent call
+    rejectFnMap[3]();
+    // after most recent call resolves
+    rejectFnMap[2]();
+
+    await findByText("3");
+  });
+});

--- a/frontend/src/metabase/hooks/use-most-recent-call/use-most-recent-call.unit.spec.tsx
+++ b/frontend/src/metabase/hooks/use-most-recent-call/use-most-recent-call.unit.spec.tsx
@@ -5,12 +5,14 @@ import { AsyncFn } from "metabase-types/types";
 
 import { useMostRecentCall } from "./use-most-recent-call";
 
+type TestAsyncFn = (num: number) => Promise<number>;
+
 function TestComponent({
   trigger,
   asyncFn,
 }: {
   trigger: number;
-  asyncFn: AsyncFn;
+  asyncFn: TestAsyncFn;
 }) {
   const [num, setNum] = useState(0);
   const fn = useMostRecentCall(asyncFn);
@@ -40,7 +42,7 @@ describe("useMostRecentCall", () => {
 
   it("should only ever resolve last call's promise", async () => {
     const resolveFnMap: Record<number, () => void> = {};
-    const asyncFn = (num: number) =>
+    const asyncFn: TestAsyncFn = (num: number) =>
       new Promise(resolve => {
         resolveFnMap[num] = resolve.bind(null, num);
       });
@@ -66,7 +68,7 @@ describe("useMostRecentCall", () => {
 
   it("should only reject last call's promise", async () => {
     const rejectFnMap: Record<number, () => void> = {};
-    const asyncFn = (num: number) =>
+    const asyncFn: TestAsyncFn = (num: number) =>
       new Promise((resolve, reject) => {
         rejectFnMap[num] = reject.bind(null, num);
       });


### PR DESCRIPTION
Related to #22554 

This PR adds a React hook for use in scenarios where we have an asynchronous function that can be called multiple times in a row and we don't care about or need to react to the values/errors from anything but the latest call.

Pass the hook a function that returns a `Promise<any>`. The hook will handle the logic of ignoring old Promises and resolving/rejecting the most recent Promise.

**Testing**
Not in use yet, but check out the unit tests.