### PR TITLE
Repro #22527: Negative Y axis points not rendered on scatter plot

### DIFF
--- a/frontend/test/metabase/scenarios/visualizations/reproductions/22527-scatter-negative-values-not-rendered.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/reproductions/22527-scatter-negative-values-not-rendered.cy.spec.js
@@ -1,0 +1,62 @@
+import { restore, popover } from "__support__/e2e/cypress";
+
+const questionDetails = {
+  native: {
+    query:
+      "select 1 x, 1 y, 20 size\nunion all  select 2 x, 10 y, 10 size\nunion all  select 3 x, -9 y, 6 size\nunion all  select 4 x, 100 y, 30 size\nunion all  select 5 x, -20 y, 70 size",
+  },
+  display: "scatter",
+  visualization_settings: {
+    "graph.dimensions": ["X"],
+    "graph.metrics": ["Y"],
+  },
+};
+
+describe.skip("issue 22527", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    cy.createNativeQuestion(questionDetails, { visitQuestion: true });
+  });
+
+  it("should render negative values in a scatter visualziation (metabase#22527)", () => {
+    assertion();
+
+    cy.findByText("Settings").click();
+    cy.findByTestId("sidebar-left").within(() => {
+      cy.findByTextEnsureVisible("Data").click();
+    });
+
+    cy.findByText("Bubble size")
+      .parent()
+      .contains("Select a field")
+      .click();
+
+    popover()
+      .contains(/size/i)
+      .click();
+
+    assertion();
+  });
+});
+
+function assertion() {
+  cy.get("circle")
+    .should("have.length", 5)
+    .last()
+    .realHover();
+
+  popover().within(() => {
+    testPairedTooltipValues("X", "5");
+    testPairedTooltipValues("Y", "-20");
+    testPairedTooltipValues("SIZE", "70");
+  });
+}
+
+function testPairedTooltipValues(val1, val2) {
+  cy.contains(val1)
+    .closest("td")
+    .siblings("td")
+    .findByText(val2);
+}


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #22527 

### How to test this manually?
- `yarn test-cypress-open`
- `metabase/scenarios/visualizations/reproductions/22527-scatter-negative-values-not-rendered.cy.spec.js`
- Unskip the repro
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/168385587-2f5d5f16-d8aa-4b45-8c7c-7f025281a304.png)

