### PR TITLE
Improve DateRelativeWidget

### DIFF
--- a/frontend/src/metabase/components/DateRelativeWidget/DateRelativeWidget.stories.tsx
+++ b/frontend/src/metabase/components/DateRelativeWidget/DateRelativeWidget.stories.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { ComponentStory } from "@storybook/react";
+import { useArgs } from "@storybook/client-api";
+import DateRelativeWidget from "./DateRelativeWidget";
+
+export default {
+  title: "Parameters/DateRelativeWidget",
+  component: DateRelativeWidget,
+};
+
+const Template: ComponentStory<typeof DateRelativeWidget> = args => {
+  const [{ value }, updateArgs] = useArgs();
+
+  const handleSetValue = (v?: string) => {
+    updateArgs({ value: v });
+  };
+
+  const handleClose = () => {
+    // do nothing
+  };
+
+  return (
+    <DateRelativeWidget
+      {...args}
+      value={value}
+      setValue={handleSetValue}
+      onClose={handleClose}
+    />
+  );
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  value: "",
+};
+
+export const Yesterday = Template.bind({});
+Yesterday.args = {
+  value: "yesterday",
+};
+
+export const LastMonth = Template.bind({});
+LastMonth.args = {
+  value: "lastmonth",
+};
+
+export const ThisWeek = Template.bind({});
+ThisWeek.args = {
+  value: "thisweek",
+};

--- a/frontend/src/metabase/components/DateRelativeWidget/DateRelativeWidget.tsx
+++ b/frontend/src/metabase/components/DateRelativeWidget/DateRelativeWidget.tsx
@@ -1,11 +1,19 @@
-/* eslint-disable react/prop-types */
-import React, { Component } from "react";
-import PropTypes from "prop-types";
+import React from "react";
 import { t } from "ttag";
 import cx from "classnames";
 import _ from "underscore";
 
-const SHORTCUTS = [
+type Shortcut = {
+  name: string;
+  operator: string | string[];
+  values: any[];
+};
+
+type ShortcutMap = {
+  [name: string]: Shortcut[];
+};
+
+const SHORTCUTS: Shortcut[] = [
   {
     name: t`Today`,
     operator: ["=", "<", ">"],
@@ -20,7 +28,7 @@ const SHORTCUTS = [
   { name: t`Past 30 days`, operator: "time-interval", values: [-30, "day"] },
 ];
 
-const RELATIVE_SHORTCUTS = {
+const RELATIVE_SHORTCUTS: ShortcutMap = {
   [t`Last`]: [
     { name: t`Week`, operator: "time-interval", values: ["last", "week"] },
     { name: t`Month`, operator: "time-interval", values: ["last", "month"] },
@@ -33,19 +41,21 @@ const RELATIVE_SHORTCUTS = {
   ],
 };
 
-export class PredefinedRelativeDatePicker extends Component {
-  constructor(props, context) {
-    super(props, context);
+type PredefinedRelativeDatePickerProps = {
+  filter: any[];
+  onFilterChange: (filter: any[]) => void;
+};
+
+export class PredefinedRelativeDatePicker extends React.Component<
+  PredefinedRelativeDatePickerProps
+> {
+  constructor(props: PredefinedRelativeDatePickerProps) {
+    super(props);
 
     _.bindAll(this, "isSelectedShortcut", "onSetShortcut");
   }
 
-  static propTypes = {
-    filter: PropTypes.array.isRequired,
-    onFilterChange: PropTypes.func.isRequired,
-  };
-
-  isSelectedShortcut(shortcut) {
+  isSelectedShortcut(shortcut: Shortcut) {
     const { filter } = this.props;
     return (
       (Array.isArray(shortcut.operator)
@@ -55,7 +65,7 @@ export class PredefinedRelativeDatePicker extends Component {
     );
   }
 
-  onSetShortcut(shortcut) {
+  onSetShortcut(shortcut: Shortcut) {
     const { filter } = this.props;
     let operator;
     if (Array.isArray(shortcut.operator)) {
@@ -81,6 +91,7 @@ export class PredefinedRelativeDatePicker extends Component {
             >
               <button
                 key={index}
+                aria-selected={this.isSelectedShortcut(s)}
                 className={cx(
                   "Button Button-normal Button--medium text-normal text-centered full",
                   { "Button--purple": this.isSelectedShortcut(s) },
@@ -113,6 +124,7 @@ export class PredefinedRelativeDatePicker extends Component {
               {RELATIVE_SHORTCUTS[sectionName].map((s, index) => (
                 <button
                   key={index}
+                  aria-selected={this.isSelectedShortcut(s)}
                   data-ui-tag={
                     "relative-date-shortcut-" +
                     sectionName.toLowerCase() +
@@ -139,8 +151,15 @@ export class PredefinedRelativeDatePicker extends Component {
   }
 }
 
+type FilterMap = {
+  [name: string]: {
+    name: string;
+    mapping: any[];
+  };
+};
+
 // HACK: easiest way to get working with RelativeDatePicker
-const FILTERS = {
+const FILTERS: FilterMap = {
   today: {
     name: t`Today`,
     mapping: ["=", null, ["relative-datetime", "current"]],
@@ -183,16 +202,19 @@ const FILTERS = {
   },
 };
 
-export default class DateRelativeWidget extends Component {
-  constructor(props, context) {
-    super(props, context);
-    this.state = {};
+type DateRelativeWidgetProps = {
+  value: string;
+  setValue: (v?: string) => void;
+  onClose: () => void;
+};
+
+class DateRelativeWidget extends React.Component<DateRelativeWidgetProps> {
+  constructor(props: DateRelativeWidgetProps) {
+    super(props);
   }
 
-  static propTypes = {};
-  static defaultProps = {};
-
-  static format = value => (FILTERS[value] ? FILTERS[value].name : "");
+  static format = (value: string) =>
+    FILTERS[value] ? FILTERS[value].name : "";
 
   render() {
     const { value, setValue, onClose } = this.props;
@@ -209,3 +231,5 @@ export default class DateRelativeWidget extends Component {
     );
   }
 }
+
+export default DateRelativeWidget;

--- a/frontend/src/metabase/components/DateRelativeWidget/DateRelativeWidget.unit.spec.tsx
+++ b/frontend/src/metabase/components/DateRelativeWidget/DateRelativeWidget.unit.spec.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import DateRelativeWidget from "./DateRelativeWidget";
+
+describe("DateRelativeWidget", () => {
+  it("should render correctly", () => {
+    const { container } = render(
+      <DateRelativeWidget
+        value={"yesterday"}
+        setValue={jest.fn()}
+        onClose={jest.fn()}
+      ></DateRelativeWidget>,
+    );
+
+    expect(
+      container.querySelector("button[aria-selected='true']"),
+    ).toHaveTextContent("Yesterday");
+
+    expect(screen.getByText("Today")).toBeVisible();
+    expect(screen.getByText("Past 7 days")).toBeVisible();
+    expect(screen.getByText("Past 30 days")).toBeVisible();
+  });
+});

--- a/frontend/src/metabase/components/DateRelativeWidget/index.ts
+++ b/frontend/src/metabase/components/DateRelativeWidget/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DateRelativeWidget";

--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
@@ -7,7 +7,7 @@ import PopoverWithTrigger from "metabase/components/PopoverWithTrigger";
 import Icon from "metabase/components/Icon";
 import DateSingleWidget from "./widgets/DateSingleWidget";
 import DateRangeWidget from "./widgets/DateRangeWidget";
-import DateRelativeWidget from "./widgets/DateRelativeWidget";
+import DateRelativeWidget from "metabase/components/DateRelativeWidget";
 import DateMonthYearWidget from "metabase/components/DateMonthYearWidget";
 import DateQuarterYearWidget from "./widgets/DateQuarterYearWidget";
 import DateAllOptionsWidget from "./widgets/DateAllOptionsWidget";


### PR DESCRIPTION
* migrate to TypeScript, add type annotations
* include props definition
* ensure a11y
* support Storybook
* add a basic unit test

Verify manually by creating a dashboard with a parameter:
1. Browse data, Sample Database, Products
2. Save as a question, add to a dashboard
3. Edit dashboard, Add a filter, choose `Time` and `Relative Date`
4. Column to filter on `Created At`, Done

Ensure that everything works exactly the same **before** and **after** this PR.

![image](https://user-images.githubusercontent.com/7288/168388125-1b68b049-9bbb-4c52-a52c-7b6372c2d936.png)

To view this component in Storybook: `yarn storybook` and search for `DateRelativeWidget`:

![image](https://user-images.githubusercontent.com/7288/168388285-d82bae4c-dba0-464e-9d02-26a663c35baa.png)
