### PR TITLE
Fix timeseries drill

### DIFF
--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePicker.tsx
@@ -2,19 +2,14 @@
 import React from "react";
 import { t } from "ttag";
 import cx from "classnames";
-import moment from "moment";
 import _ from "underscore";
 
-import { FieldDimension } from "metabase-lib/lib/Dimension";
 import Filter from "metabase-lib/lib/queries/structured/Filter";
 import {
   updateRelativeDatetimeFilter,
   isRelativeDatetime,
   isStartingFrom,
   getRelativeDatetimeInterval,
-  getRelativeDatetimeField,
-  getTimeComponent,
-  setTimeComponent,
 } from "metabase/lib/query_time";
 
 import DatePickerFooter from "./DatePickerFooter";
@@ -24,83 +19,14 @@ import DatePickerShortcuts from "./DatePickerShortcuts";
 import { CurrentPicker, NextPicker, PastPicker } from "./RelativeDatePicker";
 import { AfterPicker, BeforePicker, BetweenPicker } from "./RangeDatePicker";
 import SingleDatePicker from "./SingleDatePicker";
-
-const getIntervals = ([op, _field, value, _unit]: Filter) =>
-  op === "time-interval" && typeof value === "number" ? Math.abs(value) : 30;
-const getUnit = ([op, _field, _value, unit]: Filter) => {
-  const result = op === "time-interval" && unit ? unit : "day";
-  return result;
-};
-const getOptions = ([op, _field, _value, _unit, options]: Filter) =>
-  (op === "time-interval" && options) || {};
-
-const getDate = (value: string): string => {
-  if (typeof value !== "string" || !moment(value).isValid()) {
-    value = moment().format("YYYY-MM-DD");
-  }
-  // Relative date shortcut sets unit to "none" to avoid preselecting
-  if (value === "none") {
-    return "day";
-  }
-  return value;
-};
-
-const hasTime = (value: unknown) =>
-  typeof value === "string" && /T\d{2}:\d{2}:\d{2}$/.test(value);
-
-/**
- * Returns MBQL :field clause with temporal bucketing applied.
- * @deprecated -- just use FieldDimension to do this stuff.
- */
-function getDateTimeField(filter: any, bucketing?: string | null) {
-  let dimension = filter?.dimension?.();
-  if (!dimension) {
-    dimension = FieldDimension.parseMBQLOrWarn(
-      getRelativeDatetimeField(filter),
-    );
-  }
-  if (dimension) {
-    if (bucketing) {
-      return dimension.withTemporalUnit(bucketing).mbql();
-    } else {
-      return dimension.withoutTemporalBucketing().mbql();
-    }
-  }
-  return null;
-}
-
-export function getDateTimeFieldTarget(field: any[]) {
-  const dimension = FieldDimension.parseMBQLOrWarn(field);
-  if (dimension && dimension.temporalUnit()) {
-    return dimension.withoutTemporalBucketing().mbql() as any;
-  } else {
-    return field;
-  }
-}
-
-// add temporal-unit to fields if any of them have a time component
-function getDateTimeFieldAndValues(filter: Filter, count: number) {
-  let values = filter.slice(2, 2 + count).map(value => value && getDate(value));
-  const bucketing = _.any(values, hasTime) ? "minute" : null;
-  const field = getDateTimeField(filter, bucketing);
-  const { hours, minutes } = getTimeComponent(values[0]);
-  if (
-    typeof hours === "number" &&
-    typeof minutes === "number" &&
-    values.length === 2
-  ) {
-    const { hours: otherHours, minutes: otherMinutes } = getTimeComponent(
-      values[1],
-    );
-    if (typeof otherHours !== "number" || typeof otherMinutes !== "number") {
-      values = [
-        values[0],
-        setTimeComponent(values[1], hours, minutes) || values[0],
-      ];
-    }
-  }
-  return [field, ...values.filter(value => value !== undefined)];
-}
+import {
+  getDateTimeField,
+  getDateTimeFieldAndValues,
+  getIntervals,
+  getOptions,
+  getTemporalUnit,
+  getUnit,
+} from "./utils";
 
 export type DatePickerGroup = "relative" | "specific";
 
@@ -178,10 +104,18 @@ export const DATE_OPERATORS: DateOperator[] = [
       const [field, ...values] = getDateTimeFieldAndValues(filter, 2);
       return ["between", field, ...values];
     },
-    test: ([op, _field, left, right]) =>
-      op === "between" &&
-      !isRelativeDatetime(left) &&
-      !isRelativeDatetime(right),
+    test: ([op, field, left, right]) => {
+      const isExplicitBetween =
+        op === "between" &&
+        !isRelativeDatetime(left) &&
+        !isRelativeDatetime(right);
+
+      const temporalUnit = getTemporalUnit(field);
+
+      const isImplicitBetween =
+        op === "=" && temporalUnit != null && temporalUnit !== "day";
+      return isExplicitBetween || isImplicitBetween;
+    },
     group: "specific",
     widget: BetweenPicker,
   },

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePickerHeader.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePickerHeader.tsx
@@ -28,6 +28,7 @@ export default function DatePickerHeader({
   const dimension = filter.dimension?.();
   const operator = _.find(operators, o => o.test(filter));
   const tabs = operators.filter(o => o.group === operator?.group);
+  const selectedTab = operators.find(o => o.test(filter));
 
   if (operator?.name === "exclude") {
     const hasTemporalUnit = dimension?.temporalUnit();
@@ -62,16 +63,18 @@ export default function DatePickerHeader({
           icon="chevronleft"
         />
       ) : null}
-      {tabs.map(({ test, displayName, init }) => (
+      {tabs.map(tab => (
         <TabButton
-          selected={!!test(filter)}
+          selected={tab === selectedTab}
           primaryColor={primaryColor}
-          key={displayName}
+          key={tab.displayName}
           onClick={() => {
-            onFilterChange(init(filter));
+            onFilterChange(
+              tab.init(dimension?.withoutTemporalBucketing().mbql() as any),
+            );
           }}
         >
-          {displayName}
+          {tab.displayName}
         </TabButton>
       ))}
     </Container>

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RangeDatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RangeDatePicker.tsx
@@ -6,14 +6,11 @@ import Calendar from "metabase/components/Calendar";
 import moment from "moment";
 import Filter from "metabase-lib/lib/queries/structured/Filter";
 import { TimeContainer } from "./RangeDatePicker.styled";
-import {
-  hasTimeComponent,
-  setTimeComponent,
-  TIME_SELECTOR_DEFAULT_HOUR,
-  TIME_SELECTOR_DEFAULT_MINUTE,
-} from "metabase/lib/query_time";
+import { setTimeComponent } from "metabase/lib/query_time";
 import SingleDatePicker, { SingleDatePickerProps } from "./SingleDatePicker";
 import SpecificDatePicker from "./SpecificDatePicker";
+import { getTemporalUnit } from "./utils";
+import { formatFilterDate } from "metabase/modes/lib/actions";
 
 type BetweenPickerProps = {
   isSidebar?: boolean;
@@ -25,6 +22,19 @@ type BetweenPickerProps = {
   hideTimeSelectors?: boolean;
 };
 
+const getEndValue = (field: Filter, endValue: string) => {
+  const temporalUnit = getTemporalUnit(field);
+  if (!temporalUnit || temporalUnit === "day") {
+    return endValue;
+  }
+
+  const end = formatFilterDate(
+    moment(endValue).endOf(temporalUnit),
+    temporalUnit,
+  );
+  return end;
+};
+
 export const BetweenPicker = ({
   className,
   isSidebar,
@@ -33,14 +43,10 @@ export const BetweenPicker = ({
   hideTimeSelectors,
   primaryColor,
 }: BetweenPickerProps) => {
-  let endDatetime = endValue;
-  if (hasTimeComponent(startValue) && !hasTimeComponent(endValue)) {
-    endDatetime = setTimeComponent(
-      endValue,
-      TIME_SELECTOR_DEFAULT_HOUR,
-      TIME_SELECTOR_DEFAULT_MINUTE,
-    );
+  if (op === "=") {
+    endValue = startValue;
   }
+  const normalizedEndValue = getEndValue(field, endValue);
   return (
     <div className={className}>
       <TimeContainer isSidebar={isSidebar}>
@@ -54,7 +60,7 @@ export const BetweenPicker = ({
         </div>
         <div>
           <SpecificDatePicker
-            value={endValue}
+            value={normalizedEndValue}
             primaryColor={primaryColor}
             hideTimeSelectors={hideTimeSelectors}
             onClear={() =>
@@ -75,7 +81,7 @@ export const BetweenPicker = ({
           primaryColor={primaryColor}
           initial={startValue}
           selected={startValue && moment(startValue)}
-          selectedEnd={endValue && moment(endValue)}
+          selectedEnd={endValue && moment(normalizedEndValue)}
           onChange={(startValue, endValue) =>
             onFilterChange([op, field, startValue, endValue])
           }

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/SpecificDatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/SpecificDatePicker.tsx
@@ -57,6 +57,7 @@ const SpecificDatePicker: React.FC<Props> = props => {
     <div className={className}>
       <div className="mb2 full bordered rounded flex align-center">
         <InputBlurChange
+          data-testid="date-picker-input"
           placeholder={moment().format(dateFormat)}
           className="borderless full p1 h3"
           style={{

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/utils.ts
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/utils.ts
@@ -1,0 +1,90 @@
+import moment from "moment";
+import _ from "underscore";
+
+import { FieldDimension } from "metabase-lib/lib/Dimension";
+import Filter from "metabase-lib/lib/queries/structured/Filter";
+import {
+  getRelativeDatetimeField,
+  getTimeComponent,
+  setTimeComponent,
+} from "metabase/lib/query_time";
+
+export const getIntervals = ([op, _field, value, _unit]: Filter) =>
+  op === "time-interval" && typeof value === "number" ? Math.abs(value) : 30;
+export const getUnit = ([op, _field, _value, unit]: Filter) => {
+  const result = op === "time-interval" && unit ? unit : "day";
+  return result;
+};
+export const getOptions = ([op, _field, _value, _unit, options]: Filter) =>
+  (op === "time-interval" && options) || {};
+
+export const getDate = (value: string): string => {
+  if (typeof value !== "string" || !moment(value).isValid()) {
+    value = moment().format("YYYY-MM-DD");
+  }
+  // Relative date shortcut sets unit to "none" to avoid preselecting
+  if (value === "none") {
+    return "day";
+  }
+  return value;
+};
+
+export const hasTime = (value: unknown) =>
+  typeof value === "string" && /T\d{2}:\d{2}:\d{2}$/.test(value);
+
+/**
+ * Returns MBQL :field clause with temporal bucketing applied.
+ * @deprecated -- just use FieldDimension to do this stuff.
+ */
+export function getDateTimeField(filter: any, bucketing?: string | null) {
+  let dimension = filter?.dimension?.();
+  if (!dimension) {
+    dimension = FieldDimension.parseMBQLOrWarn(
+      getRelativeDatetimeField(filter),
+    );
+  }
+  if (dimension) {
+    if (bucketing) {
+      return dimension.withTemporalUnit(bucketing).mbql();
+    } else {
+      return dimension.withoutTemporalBucketing().mbql();
+    }
+  }
+  return null;
+}
+
+export function getDateTimeFieldTarget(field: any[]) {
+  const dimension = FieldDimension.parseMBQLOrWarn(field);
+  if (dimension && dimension.temporalUnit()) {
+    return dimension.withoutTemporalBucketing().mbql() as any;
+  } else {
+    return field;
+  }
+}
+
+// add temporal-unit to fields if any of them have a time component
+export function getDateTimeFieldAndValues(filter: Filter, count: number) {
+  let values = filter.slice(2, 2 + count).map(value => value && getDate(value));
+  const bucketing = _.any(values, hasTime) ? "minute" : null;
+  const field = getDateTimeField(filter, bucketing);
+  const { hours, minutes } = getTimeComponent(values[0]);
+  if (
+    typeof hours === "number" &&
+    typeof minutes === "number" &&
+    values.length === 2
+  ) {
+    const { hours: otherHours, minutes: otherMinutes } = getTimeComponent(
+      values[1],
+    );
+    if (typeof otherHours !== "number" || typeof otherMinutes !== "number") {
+      values = [
+        values[0],
+        setTimeComponent(values[1], hours, minutes) || values[0],
+      ];
+    }
+  }
+  return [field, ...values.filter(value => value !== undefined)];
+}
+
+export const getTemporalUnit = (field: Filter) =>
+  (Array.isArray(field) && field[2]?.["temporal-unit"]) || null;

--- a/frontend/test/metabase/modes/lib/actions.unit.spec.js
+++ b/frontend/test/metabase/modes/lib/actions.unit.spec.js
@@ -3,20 +3,42 @@ import { ORDERS } from "__support__/sample_database_fixture";
 
 describe("actions", () => {
   describe("drillFilter", () => {
-    it("should add the filter with the same timezone", () => {
+    it("should include time temporal units smaller than a day", () => {
+      ["minute", "hour"].map(temporalUnit => {
+        const newQuery = drillFilter(
+          ORDERS.query(),
+          "2018-04-27T00:00:00",
+          ORDERS.CREATED_AT.column({
+            unit: temporalUnit,
+          }),
+        );
+        expect(newQuery.query()).toEqual({
+          "source-table": ORDERS.id,
+          filter: [
+            "=",
+            ["field", ORDERS.CREATED_AT.id, { "temporal-unit": temporalUnit }],
+            "2018-04-27T00:00:00",
+          ],
+        });
+      });
+    });
+  });
+
+  it("should not include time temporal units greater than a hour", () => {
+    ["day", "week", "month", "quarter", "year"].map(temporalUnit => {
       const newQuery = drillFilter(
         ORDERS.query(),
-        "2018-04-27T00:00:00.000+02:00",
+        "2018-04-27T00:00:00",
         ORDERS.CREATED_AT.column({
-          unit: "day",
+          unit: temporalUnit,
         }),
       );
       expect(newQuery.query()).toEqual({
         "source-table": ORDERS.id,
         filter: [
           "=",
-          ["field", ORDERS.CREATED_AT.id, { "temporal-unit": "day" }],
-          "2018-04-27T00:00:00+02:00",
+          ["field", ORDERS.CREATED_AT.id, { "temporal-unit": temporalUnit }],
+          "2018-04-27",
         ],
       });
     });

--- a/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
@@ -65,7 +65,8 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
     // new filter applied
     // Note: Test was flaking because apparently mouseup doesn't always happen at the same position.
     //       It is enough that we assert that the filter exists and that it starts with May, 2016
-    cy.contains(/^Created At between May, 2016/);
+    cy.contains(/^Created At between May, 2016/).click();
+    cy.findByDisplayValue("05/01/2016");
     // more granular axis labels
     cy.contains("June, 2016");
     // confirm that product category is still broken out
@@ -315,7 +316,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
     cy.contains("Dominique Leffler");
   });
 
-  it.skip("should drill through a with date filter (metabase#12496)", () => {
+  it("should drill through a with date filter (metabase#12496)", () => {
     cy.createQuestion({
       name: "Orders by Created At: Week",
       query: {
@@ -645,6 +646,40 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
       cy.findByText("Category is Widget");
       cy.findByText("Gizmo").should("not.exist");
       cy.findByText("Doohickey").should("not.exist");
+    });
+  });
+
+  it("should show 'between' filter when drill through ", () => {
+    cy.createQuestion(
+      {
+        name: "Orders by month",
+        query: {
+          "source-table": ORDERS_ID,
+          aggregation: [["count"]],
+          breakout: [
+            ["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }],
+          ],
+        },
+        display: "line",
+      },
+      { visitQuestion: true },
+    );
+
+    cy.get(".dot")
+      .eq(1)
+      .click({ force: true });
+    cy.contains("View these Orders").click();
+
+    cy.findByText("Created At is May, 2016").click();
+
+    popover().within(() => {
+      cy.findAllByTestId("date-picker-input")
+        .eq(0)
+        .should("have.value", "05/01/2016");
+
+      cy.findAllByTestId("date-picker-input")
+        .eq(1)
+        .should("have.value", "05/31/2016");
     });
   });
 });


### PR DESCRIPTION
Related to https://github.com/metabase/metabase/issues/12496

## Changes

Following changes apply to cases when users drill into time series charts by clicking on a single point -> "View these ...." or by brushing charts to select a range. 

1) **Removes applying current timezone**. If you try to create the same filter as from drilling a chart, it does not include user's timezone. For some reason, we added curent timezone when drilling which caused invalid state of filter widgets (tested on x.42.x to the latest master).

2) Shows Range date picker for filters with operator `=` but with temporal units others than a day. The reason is that when users drill into charts summarized units like a month, they actually selecting a range of days and showing a single date picker is incorrect.

## How to verify

- New -> Question -> Orders table of the Sample Database
- Summarize by all type of units from minute to year
- Try drilling into the chart by clicking on a single point or by brushing
- Click on the applied filter pill
- Ensure it shows the correct range

## Screenshots
This is the state of the filter widget right after drilling into a chart

Before
<img width="382" alt="Screenshot 2022-05-14 at 02 13 35" src="https://user-images.githubusercontent.com/14301985/168396024-dabd49ad-129f-44d0-933b-753eb4691662.png">

After
<img width="488" alt="Screenshot 2022-05-14 at 02 13 45" src="https://user-images.githubusercontent.com/14301985/168396034-6ffdb59e-7ab5-415b-b44b-7245dbd3d7e1.png">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/22722)
<!-- Reviewable:end -->
