### PR TITLE
Fix relative preview dates for past intervals

### DIFF
--- a/frontend/src/metabase/lib/query_time.js
+++ b/frontend/src/metabase/lib/query_time.js
@@ -96,7 +96,7 @@ export function expandTimeIntervalFilter(filter) {
     return [
       "between",
       field,
-      ["relative-datetime", n - 1, unit],
+      ["relative-datetime", n, unit],
       ["relative-datetime", includeCurrent ? 0 : -1, unit],
     ];
   } else if (n > 1) {

--- a/frontend/test/metabase/lib/query_time.unit.spec.js
+++ b/frontend/test/metabase/lib/query_time.unit.spec.js
@@ -46,7 +46,7 @@ describe("query_time", () => {
       ).toEqual([
         "between",
         ["field", 100, { "temporal-unit": "day" }],
-        ["relative-datetime", -31, "day"],
+        ["relative-datetime", -30, "day"],
         ["relative-datetime", -1, "day"],
       ]);
     });
@@ -265,7 +265,7 @@ describe("query_time", () => {
         ]);
         expect(start.format("YYYY-MM-DD HH:mm:ss")).toEqual(
           moment()
-            .subtract(8, "day")
+            .subtract(7, "day")
             .format("YYYY-MM-DD 00:00:00"),
         );
         expect(end.format("YYYY-MM-DD HH:mm:ss")).toEqual(

--- a/frontend/test/metabase/scenarios/dashboard-filters/reproductions/22482-round-relative-ranges.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/reproductions/22482-round-relative-ranges.cy.spec.js
@@ -41,7 +41,7 @@ describe("issue 22482", () => {
     const expectedRange = getFormattedRange(
       moment()
         .startOf("month")
-        .add(-16, "month"),
+        .add(-15, "month"),
       moment()
         .add(-1, "month")
         .endOf("month"),


### PR DESCRIPTION
Fixes #22731

### How to Test

- Question > Sample > Orders - filter CreatedAt > Relative dates - 2 months
(today is May 16th, should be **Mar 1 - Apr 30**)
![image](https://user-images.githubusercontent.com/1447303/168476471-c58946b8-16cb-4044-8808-141531944ae6.png)
- SQL > Sample > `{{filter}}` - set as Field Filter of Orders.CreatedAt with type Date Filter. Click widget > Relative dates - 2 days
(today is May 16th, should be **May 14 - May 15**)
![image](https://user-images.githubusercontent.com/1447303/168476728-544304b4-9f33-4301-97b8-e5f99f54b072.png)
- Dashboard - add filter Time > All Options - click Default value > Relative dates - 2 years
(today is May 16th 2022, should be **Jan 1, 2020 - Dec 31, 2021**)
![image](https://user-images.githubusercontent.com/1447303/168476910-ecdb839a-ceaf-4442-98e9-7a7735d8ba8c.png)
