### PR TITLE
Manual backport for `No open redirects for enterprise SSO's (#22622)`

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
@@ -111,24 +111,25 @@
   ;; and redirect them back to us
   [req]
   (check-saml-enabled)
-  (try
-    (let [redirect-url (or (get-in req [:params :redirect])
-                           (log/warn (trs "Warning: expected `redirect` param, but none is present"))
-                           (public-settings/site-url))
-          idp-url      (sso-settings/saml-identity-provider-uri)
-          saml-request (saml/request
-                        {:request-id (str "id-" (java.util.UUID/randomUUID))
-                         :sp-name    (sso-settings/saml-application-name)
-                         :issuer     (sso-settings/saml-application-name)
-                         :acs-url    (acs-url)
-                         :idp-url    idp-url
-                         :credential (sp-cert-keystore-details)})
-          relay-state  (saml/str->base64 redirect-url)]
-      (saml/idp-redirect-response saml-request idp-url relay-state))
+  (let [redirect-url (or (get-in req [:params :redirect])
+                         (log/warn (trs "Warning: expected `redirect` param, but none is present"))
+                         (public-settings/site-url))]
+    (sso-utils/check-sso-redirect redirect-url)
+    (try
+      (let [idp-url      (sso-settings/saml-identity-provider-uri)
+            saml-request (saml/request
+                           {:request-id (str "id-" (java.util.UUID/randomUUID))
+                            :sp-name    (sso-settings/saml-application-name)
+                            :issuer     (sso-settings/saml-application-name)
+                            :acs-url    (acs-url)
+                            :idp-url    idp-url
+                            :credential (sp-cert-keystore-details)})
+            relay-state  (saml/str->base64 redirect-url)]
+        (saml/idp-redirect-response saml-request idp-url relay-state))
     (catch Throwable e
       (let [msg (trs "Error generating SAML request")]
         (log/error e msg)
-        (throw (ex-info msg {:status-code 500} e))))))
+        (throw (ex-info msg {:status-code 500} e)))))))
 
 (defn- validate-response [response]
   (let [idp-cert (or (sso-settings/saml-identity-provider-certificate)
@@ -177,20 +178,21 @@
   (let [continue-url  (u/ignore-exceptions
                         (when-let [s (some-> (:RelayState params) base64-decode)]
                           (when-not (str/blank? s)
-                            s)))
-        xml-string    (base64-decode (:SAMLResponse params))
-        saml-response (xml-string->saml-response xml-string)
-        attrs         (saml-response->attributes saml-response)
-        email         (get attrs (sso-settings/saml-attribute-email))
-        first-name    (get attrs (sso-settings/saml-attribute-firstname) "Unknown")
-        last-name     (get attrs (sso-settings/saml-attribute-lastname) "Unknown")
-        groups        (get attrs (sso-settings/saml-attribute-group))
-        session       (fetch-or-create-user!
-                       {:first-name      first-name
-                        :last-name       last-name
-                        :email           email
-                        :group-names     groups
-                        :user-attributes attrs
-                        :device-info     (request.u/device-info request)})
-        response      (resp/redirect (or continue-url (public-settings/site-url)))]
-    (mw.session/set-session-cookie request response session)))
+                            s)))]
+    (sso-utils/check-sso-redirect continue-url)
+    (let [xml-string    (base64-decode (:SAMLResponse params))
+          saml-response (xml-string->saml-response xml-string)
+          attrs         (saml-response->attributes saml-response)
+          email         (get attrs (sso-settings/saml-attribute-email))
+          first-name    (get attrs (sso-settings/saml-attribute-firstname) "Unknown")
+          last-name     (get attrs (sso-settings/saml-attribute-lastname) "Unknown")
+          groups        (get attrs (sso-settings/saml-attribute-group))
+          session       (fetch-or-create-user!
+                          {:first-name      first-name
+                           :last-name       last-name
+                           :email           email
+                           :group-names     groups
+                           :user-attributes attrs
+                           :device-info     (request.u/device-info request)})
+          response      (resp/redirect (or continue-url (public-settings/site-url)))]
+      (mw.session/set-session-cookie request response session))))

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_utils.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_utils.clj
@@ -3,13 +3,16 @@
   (:require [clojure.tools.logging :as log]
             [metabase-enterprise.sso.integrations.sso-settings :as sso-settings]
             [metabase.email.messages :as email]
+            [metabase.api.common :as api]
             [metabase.models.user :refer [User]]
+            [metabase.public-settings :as public-settings]
             [metabase.util :as u]
-            [metabase.util.i18n :refer [trs]]
+            [metabase.util.i18n :refer [trs tru]]
             [metabase.util.schema :as su]
             [schema.core :as s]
             [toucan.db :as db])
-  (:import java.util.UUID))
+  (:import [java.net MalformedURLException URL URLDecoder]
+           java.util.UUID))
 
 (def ^:private UserAttributes
   {:first_name       su/NonBlankString
@@ -40,3 +43,17 @@
       (do
         (db/update! User id :login_attributes new-user-attributes)
         (User id)))))
+
+(defn check-sso-redirect
+  "Check if open redirect is being exploited in SSO, blurts out a 400 if so"
+  [redirect-url]
+  (let [decoded-url (some-> redirect-url (URLDecoder/decode))
+                    ;; In this case, this just means that we don't have a specified host in redirect,
+                    ;; meaning it can't be an open redirect
+        no-host     (or (nil? decoded-url) (= (first decoded-url) \/))
+        host        (try
+                      (.getHost (new URL decoded-url))
+                      (catch MalformedURLException _ ""))
+        our-host    (some-> (public-settings/site-url) (URL.) (.getHost))]
+  (api/check (or no-host (= host our-host))
+    [400 (tru "SSO is trying to do an open redirect to an untrusted site")])))

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_utils.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_utils.clj
@@ -2,8 +2,8 @@
   "Functions shared by the various SSO implementations"
   (:require [clojure.tools.logging :as log]
             [metabase-enterprise.sso.integrations.sso-settings :as sso-settings]
-            [metabase.email.messages :as email]
             [metabase.api.common :as api]
+            [metabase.email.messages :as email]
             [metabase.models.user :refer [User]]
             [metabase.public-settings :as public-settings]
             [metabase.util :as u]

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
@@ -358,7 +358,8 @@
     (doseq [relay-state ["something-random_#!@__^^"
                          ""
                          "   "
-                         "/"]]
+                         "/"
+                         "https://badsite.com"]]
       (testing (format "\nRelayState = %s" (pr-str relay-state))
         (with-saml-default-setup
           (do-with-some-validators-disabled
@@ -369,7 +370,17 @@
                 (is (= (public-settings/site-url)
                        (get-in response [:headers "Location"])))
                 (is (= (some-saml-attributes "rasta")
-                       (saml-login-attributes "rasta@metabase.com")))))))))))
+                       (saml-login-attributes "rasta@metabase.com"))))))))))
+  (testing "if the RelayState leads us to the wrong host, avoid the open redirect (boat#160)"
+    (let [redirect-url "https://badsite.com"]
+      (with-saml-default-setup
+        (mt/with-temporary-setting-values [site-url "http://localhost:3000"]
+          (do-with-some-validators-disabled
+            (fn []
+              (let [get-response (client :get 400 "/auth/sso"
+                                   {:request-options {:redirect-strategy :none}}
+                                   :redirect redirect-url)]
+                (is (= "SSO is trying to do an open redirect to an untrusted site" get-response))))))))))
 
 (deftest login-create-account-test
   (testing "A new account will be created for a SAML user we haven't seen before"


### PR DESCRIPTION
Manual Backport for boat-160-sso

Open redirects means doing some sso with a built-in redirect, and redirecting into an unhappy place (aka, a non-MB place) afterwards so that someone gets phished or other bad things happen. This is already prevented for OSS sso's but not EE - prevents this for EE sso's by forcing redirects to be in MB `site-url` set domain.
