### PR TITLE
Rename useAsyncFunction to useSafeAsyncFunction

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -27,7 +27,7 @@
     "react/forbid-component-props": [2, { "forbid": ["w", "h"] }],
     "react-hooks/exhaustive-deps": [
       "warn",
-      { "additionalHooks": "(useSyncedQueryString|useAsyncFunction)" }
+      { "additionalHooks": "(useSyncedQueryString|useSafeAsyncFunction)" }
     ],
     "prefer-const": [1, { "destructuring": "all" }],
     "no-useless-escape": 0,

--- a/frontend/src/metabase/components/MetadataInfo/FieldFingerprintInfo/CategoryFingerprint.jsx
+++ b/frontend/src/metabase/components/MetadataInfo/FieldFingerprintInfo/CategoryFingerprint.jsx
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { t, ngettext, msgid } from "ttag";
 
-import { useAsyncFunction } from "metabase/hooks/use-async-function";
+import { useSafeAsyncFunction } from "metabase/hooks/use-safe-async-function";
 import Field from "metabase-lib/lib/metadata/Field";
 import Fields from "metabase/entities/fields";
 import { formatNumber } from "metabase/lib/formatting";
@@ -61,7 +61,7 @@ export function CategoryFingerprint({
   const formattedDistinctCount = formatNumber(distinctCount);
 
   const [isLoading, setIsLoading] = useState(shouldFetchFieldValues);
-  const safeFetchFieldValues = useAsyncFunction(fetchFieldValues);
+  const safeFetchFieldValues = useSafeAsyncFunction(fetchFieldValues);
   useEffect(() => {
     if (shouldFetchFieldValues) {
       setIsLoading(true);

--- a/frontend/src/metabase/components/MetadataInfo/TableInfo/TableInfo.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/TableInfo/TableInfo.tsx
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import { t } from "ttag";
 import { connect } from "react-redux";
 
-import { useAsyncFunction } from "metabase/hooks/use-async-function";
+import { useSafeAsyncFunction } from "metabase/hooks/use-safe-async-function";
 import Tables from "metabase/entities/tables";
 import Table from "metabase-lib/lib/metadata/Table";
 
@@ -64,7 +64,7 @@ function useDependentTableMetadata({
   const [hasFetchedMetadata, setHasFetchedMetadata] = useState(
     !shouldFetchMetadata,
   );
-  const fetchDependentData = useAsyncFunction(() => {
+  const fetchDependentData = useSafeAsyncFunction(() => {
     return Promise.all([
       isMissingFields && fetchMetadata({ id: tableId }),
       isMissingFks && fetchForeignKeys({ id: tableId }),

--- a/frontend/src/metabase/hooks/use-safe-async-function.ts
+++ b/frontend/src/metabase/hooks/use-safe-async-function.ts
@@ -5,7 +5,7 @@ type AsyncFn = (...args: any[]) => Promise<any>;
 
 // wraps the given async function in a promise that does not resolve
 // after the component has unmounted
-export function useAsyncFunction(fn: AsyncFn, deps?: any[]): AsyncFn {
+export function useSafeAsyncFunction(fn: AsyncFn, deps?: any[]): AsyncFn {
   const isMounted = useIsMounted();
 
   const safeFn: AsyncFn = useCallback(


### PR DESCRIPTION
Related to https://github.com/metabase/metabase/issues/22554

Original intention of this hook was to wrap asynchronous functions in code that prevents them from being resolved/rejected in order to avoid react throwing errors if a component has been unmounted, so I'm tweaking the name of this hook slightly to make it clearer what it does. We can remove this code eventually, since newer version of react get rid of the errors we are trying to avoid here.