### PR TITLE
fix click behavior permission error

### DIFF
--- a/frontend/src/metabase-lib/lib/Question.ts
+++ b/frontend/src/metabase-lib/lib/Question.ts
@@ -1274,7 +1274,7 @@ class QuestionInner {
     if (this.isStructured()) {
       const questionWithParameters = this.setParameters(parameters);
 
-      if (this.query().isEditable()) {
+      if (!this.query().readOnly()) {
         return questionWithParameters
           .setParameterValues(parameterValues)
           .convertParametersToMbql()

--- a/frontend/test/metabase/scenarios/dashboard/click-behavior.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/click-behavior.cy.spec.js
@@ -16,7 +16,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
     cy.signInAsAdmin();
   });
 
-  it.skip("should show filters defined on a question with filter pass-thru (metabase#15993)", () => {
+  it("should show filters defined on a question with filter pass-thru (metabase#15993)", () => {
     cy.createQuestion({
       name: "15993",
       query: {
@@ -48,15 +48,6 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
               });
 
               visitDashboard(dashboardId);
-
-              cy.intercept(
-                "POST",
-                `/api/dashboard/${dashboardId}/dashcard/*/card/${question1Id}/query`,
-              ).as("cardQuery");
-
-              cy.intercept("POST", `/api/card/${nativeId}/query`).as(
-                "nativeQuery",
-              );
             });
           });
         },
@@ -64,12 +55,10 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
     });
 
     // Drill-through
-    cy.wait("@nativeQuery");
     cy.get(".cellData .link")
       .contains("0")
       .realClick();
 
-    cy.wait("@cardQuery");
     cy.contains("117.03").should("not.exist"); // Total for the order in which quantity wasn't 0
     cy.findByText("Quantity is equal to 0");
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/15993

## Changes
Allow creating drilling to dashboard questions through click behavior when there is no question metadata loaded.

## How to verify
- New -> Question -> Sample Dataset -> Orders - save as "Q1"
- New -> SQL query -> Sample Dataset -> `select 0` - save as "Q2"
- Add "Q2" to dashboard and add Click Behavior to question "Q1" and set it to pass filter to Quantity
- Save the dashboard and reload the page
- Click on `0` from Q2 and ensure it leads to Q1 with a correct filter state
