### PR TITLE
Remove field-specific code from ParameterValueWidget

### DIFF
--- a/frontend/src/metabase/parameters/components/WidgetStatusIcon/WidgetStatusIcon.tsx
+++ b/frontend/src/metabase/parameters/components/WidgetStatusIcon/WidgetStatusIcon.tsx
@@ -1,0 +1,81 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+import Icon from "metabase/components/Icon";
+
+const propTypes = {
+  isFullscreen: PropTypes.bool.isRequired,
+  hasValue: PropTypes.bool.isRequired,
+  noReset: PropTypes.bool.isRequired,
+  noPopover: PropTypes.bool.isRequired,
+  isFocused: PropTypes.bool.isRequired,
+  setValue: PropTypes.func.isRequired,
+};
+
+type Props = {
+  isFullscreen: boolean;
+  hasValue: boolean;
+  noReset: boolean;
+  noPopover: boolean;
+  isFocused: boolean;
+  setValue: (value: any) => void;
+};
+
+function WidgetStatusIcon({
+  isFullscreen,
+  hasValue,
+  noReset,
+  noPopover,
+  isFocused,
+  setValue,
+}: Props) {
+  if (isFullscreen) {
+    return null;
+  }
+
+  if (hasValue && !noReset) {
+    return (
+      <Icon
+        name="close"
+        className="flex-align-right cursor-pointer flex-no-shrink"
+        size={12}
+        onClick={e => {
+          if (hasValue) {
+            e.stopPropagation();
+            setValue(null);
+          }
+        }}
+      />
+    );
+  } else if (noPopover && isFocused) {
+    return (
+      <Icon
+        name="enter_or_return"
+        className="flex-align-right flex-no-shrink"
+        size={12}
+      />
+    );
+  } else if (noPopover) {
+    return (
+      <Icon
+        name="empty"
+        className="flex-align-right cursor-pointer flex-no-shrink"
+        size={12}
+      />
+    );
+  } else if (!noPopover) {
+    return (
+      <Icon
+        name="chevrondown"
+        className="flex-align-right flex-no-shrink"
+        size={12}
+      />
+    );
+  }
+
+  return null;
+}
+
+export default WidgetStatusIcon;
+
+WidgetStatusIcon.propTypes = propTypes;

--- a/frontend/src/metabase/parameters/components/WidgetStatusIcon/index.ts
+++ b/frontend/src/metabase/parameters/components/WidgetStatusIcon/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./WidgetStatusIcon";

--- a/frontend/src/metabase/parameters/utils/fields.js
+++ b/frontend/src/metabase/parameters/utils/fields.js
@@ -11,3 +11,12 @@ export function getFieldIds(parameter) {
   const fieldIds = field_id ? [field_id] : field_ids;
   return fieldIds.filter(id => typeof id === "number");
 }
+
+export function hasFields(parameter) {
+  const { fields } = parameter;
+  return Array.isArray(fields) && fields.length > 0;
+}
+
+export function isOnlyMappedToFields(parameter) {
+  return hasFields(parameter) && parameter.hasOnlyFieldTargets;
+}

--- a/frontend/src/metabase/parameters/utils/fields.unit.spec.js
+++ b/frontend/src/metabase/parameters/utils/fields.unit.spec.js
@@ -1,5 +1,10 @@
 import Field from "metabase-lib/lib/metadata/Field";
-import { hasFieldValues, getFieldIds } from "./fields";
+import {
+  hasFieldValues,
+  getFieldIds,
+  hasFields,
+  isOnlyMappedToFields,
+} from "./fields";
 
 describe("parameters/utils/fields", () => {
   describe("hasFieldValues", () => {
@@ -47,6 +52,52 @@ describe("parameters/utils/fields", () => {
           field_ids: [2, 3],
         }),
       ).toEqual([1]);
+    });
+  });
+
+  describe("hasFields", () => {
+    it("should be false when the parameter has no fields", () => {
+      expect(hasFields({ fields: [] })).toBe(false);
+      expect(hasFields({})).toBe(false);
+    });
+
+    it("should be true when a field on the parameter has values", () => {
+      const mockField = new Field({ id: 1, name: "foo" });
+      expect(hasFields({ fields: [mockField] })).toBe(true);
+    });
+  });
+
+  describe("isOnlyMappedToFields", () => {
+    it("should be false when the parameter has no fields", () => {
+      expect(
+        isOnlyMappedToFields({ fields: [], hasOnlyFieldTargets: false }),
+      ).toBe(false);
+    });
+
+    it("should be false in a broken scenario where it has no fields but claims to only target fields", () => {
+      expect(
+        isOnlyMappedToFields({ fields: [], hasOnlyFieldTargets: true }),
+      ).toBe(false);
+    });
+
+    it("should be false when the parameter has fields but is mapped to more than fields", () => {
+      const mockField = new Field({ id: 1, name: "foo" });
+      expect(
+        isOnlyMappedToFields({
+          fields: [mockField],
+          hasOnlyFieldTargets: false,
+        }),
+      ).toBe(false);
+    });
+
+    it("should be true when the parameter has fields and is mapped only to fields", () => {
+      const mockField = new Field({ id: 1, name: "foo" });
+      expect(
+        isOnlyMappedToFields({
+          fields: [mockField],
+          hasOnlyFieldTargets: true,
+        }),
+      ).toBe(true);
     });
   });
 });

--- a/frontend/test/metabase/scenarios/dashboard-filters/parameters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/parameters.cy.spec.js
@@ -19,7 +19,6 @@ describe("scenarios > dashboard > parameters", () => {
     cy.intercept("POST", "/api/card/**/query").as("cardQuery");
     cy.intercept("GET", "/api/dashboard/**").as("dashboard");
     cy.intercept("GET", "/api/collection/**").as("collection");
-    cy.intercept("GET", "/api/field/**/values").as("fieldValues");
   });
 
   it("should be visible if previously added", () => {
@@ -558,7 +557,6 @@ describe("scenarios > dashboard > parameters", () => {
     it("should not see mapping options", () => {
       cy.icon("pencil").click();
       cy.findByText("Location").click({ force: true });
-      cy.wait("@fieldValues");
 
       cy.icon("key");
     });
@@ -570,7 +568,6 @@ function selectFilter(selection, filterName) {
   popover()
     .contains(filterName)
     .click({ force: true });
-  cy.wait("@fieldValues");
 }
 
 function addQuestion(name) {
@@ -590,7 +587,6 @@ function addCityFilterWithDefault() {
   cy.findByText("Select…").click();
   popover().within(() => {
     cy.findByText("City").click();
-    cy.wait("@fieldValues");
   });
 
   // Create a default value and save filter


### PR DESCRIPTION
Related to #22554 

This PR removes the field coupling on `ParameterValueWidget`. More details:

1. adds a new utility function `isOnlyMappedToField` which replaces the `parameter.fields.length > 0 && parameter.hasOnlyFieldTargets` check we do in a few places.
2. uses `isOnlyMappedToField` in `ParameterValueWidget`
3. removes logic in `ParameterValueWidget` that fetches fields and field values. I believe that NativeQuery's [dependentMetadata method](https://github.com/metabase/metabase/blob/95c4686c7a42ee174b9ab924c413d5afddc4881e/frontend/src/metabase-lib/lib/queries/NativeQuery.ts#L512) takes care of fetching fields for us (a better home for this sort of logic), and `FieldValuesWidget` fetches field values when the component [mounts](https://github.com/metabase/metabase/blob/95c4686c7a42ee174b9ab924c413d5afddc4881e/frontend/src/metabase/components/FieldValuesWidget.jsx#L78).
4. Moves `WidgetStatusIcon` component into a separate file.

There's plenty more refactoring to do in this component, but I'll save it for a separate PR.

**Testing**
The field and field value fetching logic only ran in the native query editor, so create a native query with template tags, map the template tags to fields with values that are listed (eg Product's Category field) and that are searchable (eg Product's Title field). Test that the parameters work. Save as a question, and test that the parameters still work.