### PR TITLE
Limit of length of row for json parsing (fixes #22636 for most cases)

### DIFF
--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -190,21 +190,14 @@
   (binding [*enum-types* (enum-types driver database)]
     (sql-jdbc.sync/describe-table driver database table)))
 
-(def ^:const max-nested-field-columns
-  "Maximum number of nested field columns."
-  100)
-
 ;; Describe the nested fields present in a table (currently and maybe forever just JSON),
 ;; including if they have proper keyword and type stability.
 ;; Not to be confused with existing nested field functionality for mongo,
 ;; since this one only applies to JSON fields, whereas mongo only has BSON (JSON basically) fields.
 (defmethod sql-jdbc.sync/describe-nested-field-columns :postgres
   [driver database table]
-  (let [spec   (sql-jdbc.conn/db->pooled-connection-spec database)
-        fields (sql-jdbc.describe-table/describe-nested-field-columns driver spec table)]
-    (if (> (count fields) max-nested-field-columns)
-      #{}
-      fields)))
+  (let [spec   (sql-jdbc.conn/db->pooled-connection-spec database)]
+    (sql-jdbc.describe-table/describe-nested-field-columns driver spec table)))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                           metabase.driver.sql impls                                            |

--- a/src/metabase/driver/sql_jdbc/sync/describe_table.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_table.clj
@@ -238,7 +238,8 @@
                (into {} (map (fn [[k v]] [k (type-by-parsing-string v)]) flat-row))))))
 
 (defn- describe-json-xform [member]
-  ((comp (map #(for [[k v] %] [k (json/parsed-seq (io/reader (char-array v)))]))
+  ((comp (map #(for [[k v] %]
+                 [k (first (json/parsed-seq (io/reader (char-array v))))]))
          (map #(into {} %))
          (map row->types)) member))
 

--- a/src/metabase/driver/sql_jdbc/sync/describe_table.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_table.clj
@@ -323,6 +323,9 @@
         field-hash   (apply hash-set (filter some? valid-fields))]
     field-hash))
 
+(def ^:const max-nested-field-columns
+  "Maximum number of nested field columns."
+  100)
 
 ;; The name's nested field columns but what the people wanted (issue #708)
 ;; was JSON so what they're getting is JSON.

--- a/src/metabase/driver/sql_jdbc/sync/describe_table.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_table.clj
@@ -209,8 +209,9 @@
   "Number of rows to sample for describe-nested-field-columns"
   500)
 
-(def ^:const nested-field-column-max-row-length
-  "Max string length for a row for nested field column before we just give up on parsing it"
+(def ^:dynamic *nested-field-column-max-row-length*
+  "Max string length for a row for nested field column before we just give up on parsing it.
+  Marked as mutable because we mutate it for tests."
   50000)
 
 (defn- flattened-row [field-name row]
@@ -243,7 +244,7 @@
 
 (defn- describe-json-xform [member]
   ((comp (map #(for [[k v] %
-                     :when (< (count v) nested-field-column-max-row-length)]
+                     :when (< (count v) *nested-field-column-max-row-length*)]
                  [k (json/parse-string v)]))
          (map #(into {} %))
          (map row->types)) member))

--- a/src/metabase/driver/sql_jdbc/sync/describe_table.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_table.clj
@@ -1,7 +1,6 @@
 (ns metabase.driver.sql-jdbc.sync.describe-table
   "SQL JDBC impl for `describe-table`, `describe-table-fks`, and `describe-nested-field-columns`."
   (:require [cheshire.core :as json]
-            [clojure.java.io :as io]
             [clojure.java.jdbc :as jdbc]
             [clojure.set :as set]
             [clojure.string :as str]

--- a/src/metabase/driver/sql_jdbc/sync/describe_table.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_table.clj
@@ -209,6 +209,10 @@
   "Number of rows to sample for describe-nested-field-columns"
   500)
 
+(def ^:const nested-field-column-max-row-length
+  "Max string length for a row for nested field column before we just give up on parsing it"
+  50000)
+
 (defn- flattened-row [field-name row]
   (letfn [(flatten-row [row path]
             (lazy-seq
@@ -238,8 +242,9 @@
                (into {} (map (fn [[k v]] [k (type-by-parsing-string v)]) flat-row))))))
 
 (defn- describe-json-xform [member]
-  ((comp (map #(for [[k v] %]
-                 [k (first (json/parsed-seq (io/reader (char-array v))))]))
+  ((comp (map #(for [[k v] %
+                     :when (< (count v) nested-field-column-max-row-length)]
+                 [k (json/parse-string v)]))
          (map #(into {} %))
          (map row->types)) member))
 

--- a/src/metabase/driver/sql_jdbc/sync/describe_table.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_table.clj
@@ -348,6 +348,6 @@
               query            (jdbc/reducible-query spec sql-args)
               field-types      (transduce describe-json-xform describe-json-rf query)
               fields           (field-types->fields field-types)]
-          ;; throw away fields because currently testing
-          #{}
-          )))))
+          (if (> (count fields) max-nested-field-columns)
+            #{}
+            fields))))))

--- a/test/metabase/driver/sql_jdbc/sync/describe_table_test.clj
+++ b/test/metabase/driver/sql_jdbc/sync/describe_table_test.clj
@@ -83,7 +83,7 @@
       (is (= {[:zlob "blob"] java.lang.Long} (#'sql-jdbc.describe-table/row->types obj-row))))))
 
 (deftest dont-parse-long-json-xform-test
-  (testing "obnoxiously long json should not even get parsed"
+  (testing "obnoxiously long json should not even get parsed (#22636)"
     ;; Generating an actually obnoxiously long json took too long,
     ;; and actually copy-pasting an obnoxiously long string in there looks absolutely terrible,
     ;; so this rebinding is what you get

--- a/test/metabase/driver/sql_jdbc/sync/describe_table_test.clj
+++ b/test/metabase/driver/sql_jdbc/sync/describe_table_test.clj
@@ -82,6 +82,23 @@
       (is (= {} (#'sql-jdbc.describe-table/row->types arr-row)))
       (is (= {[:zlob "blob"] java.lang.Long} (#'sql-jdbc.describe-table/row->types obj-row))))))
 
+(deftest dont-parse-long-json-xform-test
+  (testing "obnoxiously long json should not even get parsed"
+    ;; Generating an actually obnoxiously long json took too long,
+    ;; and actually copy-pasting an obnoxiously long string in there looks absolutely terrible,
+    ;; so this rebinding is what you get
+    (let [obnoxiously-long-json "{\"bob\": \"dobbs\"}"
+          json-map              {:somekey obnoxiously-long-json}]
+      (with-redefs [sql-jdbc.describe-table/*nested-field-column-max-row-length* 3]
+        (is (= {}
+               (transduce
+                 #'sql-jdbc.describe-table/describe-json-xform
+                 #'sql-jdbc.describe-table/describe-json-rf [json-map]))))
+      (is (= {[:somekey "bob"] java.lang.String}
+             (transduce
+               #'sql-jdbc.describe-table/describe-json-xform
+               #'sql-jdbc.describe-table/describe-json-rf [json-map]))))))
+
 (deftest describe-nested-field-columns-test
   (testing "flattened-row"
     (let [row       {:bob {:dobbs 123 :cobbs "boop"}}


### PR DESCRIPTION
Root cause of #22636 is big individual JSON rows. Just gigantic rows. Huuge rows. This limits the length of rows to a certain amount, above which is already insanity with the adduced rows anyways