### PR TITLE
Handle multiple emails from identity provider

### DIFF
--- a/src/metabase/integrations/ldap/default_implementation.clj
+++ b/src/metabase/integrations/ldap/default_implementation.clj
@@ -76,7 +76,10 @@
     {:dn         dn
      :first-name first-name
      :last-name  last-name
-     :email      email
+     ; Some vendors can provide a list of all the emails attached to their identity (e.g. Okta)
+     :email      (if (coll? email)
+                     (first email)
+                     email)
      :groups     (when sync-groups?
                    ;; Active Directory and others (like FreeIPA) will supply a `memberOf` overlay attribute for
                    ;; groups. Otherwise we have to make the inverse query to get them.

--- a/test/metabase/integrations/ldap_test.clj
+++ b/test/metabase/integrations/ldap_test.clj
@@ -120,12 +120,12 @@
                (ldap/find-user "sbrown20"))))
 
        (testing "find user having two emails (professional & personal)"
-        (is (= {:dn         "cn=John Smith,ou=People,dc=metabase,dc=com"
+        (is (= {:dn         "cn=John Doe,ou=People,dc=metabase,dc=com"
                 :first-name "John"
-                :last-name  "Smith"
-                :email      "johnsmith2@metabase.com"
+                :last-name  "Doe"
+                :email      "johndoe@metabase.com"
                 :groups     ["cn=Accounting,ou=Groups,dc=metabase,dc=com"]}
-               (ldap/find-user "johnsmith2")))))))
+               (ldap/find-user "johndoe")))))))
 
 (deftest fetch-or-create-user-test
   ;; there are EE-specific versions of this test in `metabase-enterprise.enhancements.integrations.ldap-test`

--- a/test/metabase/integrations/ldap_test.clj
+++ b/test/metabase/integrations/ldap_test.clj
@@ -117,7 +117,15 @@
                 :email      "sally.brown@metabase.com"
                 :groups     ["cn=Accounting,ou=Groups,dc=metabase,dc=com",
                              "cn=Engineering,ou=Groups,dc=metabase,dc=com"]}
-               (ldap/find-user "sbrown20")))))))
+               (ldap/find-user "sbrown20"))))
+
+       (testing "find user having two emails (professional & personal)"
+        (is (= {:dn         "cn=John Smith,ou=People,dc=metabase,dc=com"
+                :first-name "John"
+                :last-name  "Smith"
+                :email      "johnsmith2@metabase.com"
+                :groups     ["cn=Accounting,ou=Groups,dc=metabase,dc=com"]}
+               (ldap/find-user "johnsmith2")))))))
 
 (deftest fetch-or-create-user-test
   ;; there are EE-specific versions of this test in `metabase-enterprise.enhancements.integrations.ldap-test`

--- a/test_resources/active_directory.ldif
+++ b/test_resources/active_directory.ldif
@@ -37,17 +37,17 @@ userPassword: 1234
 memberOf: cn=Accounting,ou=Groups,dc=metabase,dc=com
 memberOf: cn=Engineering,ou=Groups,dc=metabase,dc=com
 
-dn: cn=John Smith,ou=People,dc=metabase,dc=com
+dn: cn=John Doe,ou=People,dc=metabase,dc=com
 objectClass: top
 objectClass: person
 objectClass: organizationalPerson
 objectClass: inetOrgPerson
-cn: John Smith
-sn: Smith
+cn: John Doe
+sn: Doe
 givenName: John
-uid: johnsmith2
-mail: johnsmith2@metabase.com
-mail: johnsmith2personal@other.com
+uid: johndoe
+mail: johndoe@metabase.com
+mail: johndoepersonal@other.com
 userPassword: 1234
 memberOf: cn=Accounting,ou=Groups,dc=metabase,dc=com
 

--- a/test_resources/active_directory.ldif
+++ b/test_resources/active_directory.ldif
@@ -37,6 +37,20 @@ userPassword: 1234
 memberOf: cn=Accounting,ou=Groups,dc=metabase,dc=com
 memberOf: cn=Engineering,ou=Groups,dc=metabase,dc=com
 
+dn: cn=John Smith,ou=People,dc=metabase,dc=com
+objectClass: top
+objectClass: person
+objectClass: organizationalPerson
+objectClass: inetOrgPerson
+cn: John Smith
+sn: Smith
+givenName: John
+uid: johnsmith2
+mail: johnsmith2@metabase.com
+mail: johnsmith2personal@other.com
+userPassword: 1234
+memberOf: cn=Accounting,ou=Groups,dc=metabase,dc=com
+
 dn: ou=Groups,dc=metabase,dc=com
 objectClass: top
 objectClass: organizationalUnit


### PR DESCRIPTION
We've been experiencing a bug with Okta as an identity provider, getting:

```
Output of ldap-search-result->user-info does not match schema:
  {:email (not (instance? java.lang.String a-clojure.lang.PersistentVector))}
```

The reason seems to be that Okta provides multiple email addresses, which wasn't taken into account.

### Tests

- [ ] Run the frontend and Cypress end-to-end tests with `yarn lint && yarn test`)
- [x] If there are changes to the backend codebase, run the backend tests with `clojure -X:dev:test`
- [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/22782)
<!-- Reviewable:end -->
