### PR TITLE
[E2E] Experiment running `models` test group as PR check

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -66,6 +66,7 @@ jobs:
           - "downloads"
           - "embedding"
           - "joins"
+          - "models"
     services:
       maildev:
         image: maildev/maildev:1.1.0


### PR DESCRIPTION
Adding `models` test group as PR check

Data:
[models OSS](https://github.com/metabase/metabase/runs/6474845317?check_suite_focus=true) vs [models EE](https://github.com/metabase/metabase/runs/6474847230?check_suite_focus=true)
| e2e-tests-embedding                       | total | passing | pending  |
|---------------------------|--------|-------|-------|
| OSS                  | 43   | 42  | 1  |
| EE                 | 43   | 42  | 1  |