### PR TITLE
Fix accessing model cache error modal from URL

### DIFF
--- a/frontend/src/metabase/admin/tasks/containers/ModelCacheRefreshJobs/ModelCacheRefreshJobModal.tsx
+++ b/frontend/src/metabase/admin/tasks/containers/ModelCacheRefreshJobs/ModelCacheRefreshJobModal.tsx
@@ -8,6 +8,7 @@ import Link from "metabase/core/components/Link";
 import ModalContent from "metabase/components/ModalContent";
 
 import PersistedModels from "metabase/entities/persisted-models";
+import { usePrevious } from "metabase/hooks/use-previous";
 
 import { ModelCacheRefreshStatus } from "metabase-types/api";
 
@@ -26,7 +27,6 @@ type ModelCacheRefreshJobModalStateProps = {
 
 type PersistedModelsLoaderProps = {
   persistedModel: ModelCacheRefreshStatus;
-  loading: boolean;
 };
 
 type ModelCacheRefreshJobModalProps = ModelCacheRefreshJobModalOwnProps &
@@ -40,15 +40,21 @@ const mapDispatchToProps = {
 
 function ModelCacheRefreshJobModal({
   persistedModel,
-  loading,
   onClose,
   onRefresh,
 }: ModelCacheRefreshJobModalProps) {
+  const prevModelInfo = usePrevious(persistedModel);
+
   useEffect(() => {
-    if (loading === false && persistedModel?.state !== "error" && onClose) {
+    if (
+      !prevModelInfo &&
+      persistedModel &&
+      persistedModel.state !== "error" &&
+      onClose
+    ) {
       onClose();
     }
-  }, [loading, persistedModel, onClose]);
+  }, [prevModelInfo, persistedModel, onClose]);
 
   const footer = useMemo(() => {
     if (!persistedModel) {


### PR DESCRIPTION
Related to #22538

Fixes accessing `/admin/tools/model-caching/:id` by URL directly wasn't showing up the modal properly. The "model caching" page has a list of all model cache refresh statuses: both successful and failed and we only want to show the modal for failed refreshes. The modal component fetches the info object and checks if loading was done (`!loading` prop) and checked if the job was actually successful; in this case, the modal will just autoclose. The problem was that there is a moment when `loading` is already `true`, but the entity object returned by the loader is still `undefined`.

### To Verify

1. Sign in as an admin
2. Go to `/admin/settings/caching` and enable model persistence
3. Spin up a sample PostgreSQL DB from [metabase/metabase-qa](https://github.com/metabase/metabase-qa) in Docker
4. Go to `/admin/databases`, connect the new PSQL DB and enable model persistence for the DB (click the "Enable model persistence" button on the DB page's sidebar)
5. Create a few questions using PSQL data, turn them into models, and enable persistence for them (click the "database" icon in the model details sidebar)
5. Shutdown your Docker container running the sample Postgres DB and start a new blank container
6. Go to `/admin/tools/model-caching` and click "refresh" button on the latest cache refresh
7. Refresh the page in sec, you should see the refresh failed
8. Click the error message to open up the modal
9. Refresh the page
10. Ensure you can still see the modal

### Demo

https://user-images.githubusercontent.com/17258145/168908137-2c7ffa84-2704-4ba6-82b7-f4b444dc1d6b.mp4
