### PR TITLE
Fix click behavior passes multiple options selected to a linked question

### DIFF
--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx
@@ -20,6 +20,7 @@ import DashboardPicker from "metabase/containers/DashboardPicker";
 import Questions from "metabase/entities/questions";
 import QuestionPicker from "metabase/containers/QuestionPicker";
 import Sidebar from "metabase/dashboard/components/Sidebar";
+import CheckBox from "metabase/core/components/CheckBox";
 import ClickMappings, {
   withUserAttributes,
   clickTargetObjectType,
@@ -789,6 +790,18 @@ function QuestionDashboardPicker({ dashcard, clickBehavior, updateSettings }) {
         <Entity.Loader id={clickBehavior.targetId}>
           {({ object }) => (
             <div className="pt1">
+              {object.public_uuid && (
+                <CheckBox
+                  label={t`Use public link`}
+                  checked={clickBehavior.use_public_link}
+                  onChange={e =>
+                    updateSettings({
+                      ...clickBehavior,
+                      use_public_link: e.target.checked,
+                    })
+                  }
+                />
+              )}
               <Heading>
                 {
                   {

--- a/frontend/src/metabase/modes/components/drill/DashboardClickDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/DashboardClickDrill.jsx
@@ -72,14 +72,19 @@ export default ({ question, clicked }) => {
           },
         };
       } else {
+        const targetDashboard = extraData.dashboards[targetId];
         const queryParams = getParameterValuesBySlug(parameterMapping, {
           data,
           extraData,
           clickBehavior,
         });
 
-        const urlSearchParams = querystring.stringify(queryParams);
-        const url = `/dashboard/${targetId}?${urlSearchParams}`;
+        const path =
+          clickBehavior.use_public_link && targetDashboard.public_uuid
+            ? `/public/dashboard/${targetDashboard.public_uuid}`
+            : `/dashboard/${targetId}`;
+        const url = `${path}?${querystring.stringify(queryParams)}`;
+
         behavior = { url: () => url };
       }
     } else if (linkType === "question" && extraData && extraData.questions) {
@@ -104,9 +109,16 @@ export default ({ question, clicked }) => {
         }))
         .value();
 
-      const url = targetQuestion.isStructured()
-        ? targetQuestion.getUrlWithParameters(parameters, queryParams)
-        : `${targetQuestion.getUrl()}?${querystring.stringify(queryParams)}`;
+      let url = null;
+      if (clickBehavior.use_public_link && targetQuestion.publicUUID()) {
+        url = `/public/question/${targetQuestion.publicUUID()}?${querystring.stringify(
+          queryParams,
+        )}`;
+      } else {
+        url = targetQuestion.isStructured()
+          ? targetQuestion.getUrlWithParameters(parameters, queryParams)
+          : `${targetQuestion.getUrl()}?${querystring.stringify(queryParams)}`;
+      }
 
       behavior = { url: () => url };
     }

--- a/frontend/src/metabase/public/containers/PublicDashboard.jsx
+++ b/frontend/src/metabase/public/containers/PublicDashboard.jsx
@@ -58,7 +58,7 @@ const mapDispatchToProps = {
 
 // NOTE: this should use DashboardData HoC
 class PublicDashboard extends Component {
-  async UNSAFE_componentWillMount() {
+  _initialize = async () => {
     const {
       initialize,
       fetchDashboard,
@@ -82,14 +82,22 @@ class PublicDashboard extends Component {
       console.error(error);
       setErrorPage(error);
     }
+  };
+
+  async componentDidMount() {
+    this._initialize();
   }
 
   componentWillUnmount() {
     this.props.cancelFetchDashboardCardData();
   }
 
-  UNSAFE_componentWillReceiveProps(nextProps) {
-    if (!_.isEqual(this.props.parameterValues, nextProps.parameterValues)) {
+  async componentDidUpdate(prevProps) {
+    if (this.props.dashboardId !== prevProps.dashboardId) {
+      return this._initialize();
+    }
+
+    if (!_.isEqual(this.props.parameterValues, prevProps.parameterValues)) {
       this.props.fetchDashboardCardData({ reload: false, clear: true });
     }
   }

--- a/frontend/test/metabase/scenarios/dashboard/reproductions/17160-click-behavior-multiple-options.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/reproductions/17160-click-behavior-multiple-options.cy.spec.js
@@ -11,78 +11,10 @@ describe("issue 17160", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
-
-    cy.createNativeQuestion({
-      name: `17160Q`,
-      native: {
-        query: "SELECT * FROM products WHERE {{CATEGORY}}",
-        "template-tags": {
-          CATEGORY: {
-            id: "6b8b10ef-0104-1047-1e1b-2492d5954322",
-            name: "CATEGORY",
-            display_name: "CATEGORY",
-            type: "dimension",
-            dimension: ["field", PRODUCTS.CATEGORY, null],
-            "widget-type": "category",
-            default: null,
-          },
-        },
-      },
-    }).then(({ body: { id: questionId } }) => {
-      cy.createDashboard({ name: "17160D" }).then(
-        ({ body: { id: dashboardId } }) => {
-          // Add the question to the dashboard
-          cy.request("POST", `/api/dashboard/${dashboardId}/cards`, {
-            cardId: questionId,
-          }).then(({ body: { id: dashCardId } }) => {
-            // Add dashboard filter
-            cy.request("PUT", `/api/dashboard/${dashboardId}`, {
-              parameters: [
-                {
-                  id: CATEGORY_FILTER_PARAMETER_ID,
-                  name: "Category",
-                  slug: "category",
-                  sectionId: "string",
-                  type: "string/=",
-                },
-              ],
-            });
-
-            createTargetDashboardForClickBehavior().then(targetDashboardId => {
-              // Create a click behavior and resize the question card
-              cy.request("PUT", `/api/dashboard/${dashboardId}/cards`, {
-                cards: [
-                  {
-                    id: dashCardId,
-                    card_id: questionId,
-                    row: 0,
-                    col: 0,
-                    sizeX: 12,
-                    sizeY: 10,
-                    parameter_mappings: [
-                      {
-                        parameter_id: CATEGORY_FILTER_PARAMETER_ID,
-                        card_id: 4,
-                        target: ["dimension", ["template-tag", "CATEGORY"]],
-                      },
-                    ],
-                    visualization_settings: getVisualSettingsWithClickBehavior(
-                      questionId,
-                      targetDashboardId,
-                    ),
-                  },
-                ],
-              });
-
-              visitDashboard(dashboardId);
-            });
-          });
-        },
-      );
-    });
   });
 
-  it("should pass multiple filter values to a SQL question parameter (metabase#17160)", () => {
+  it("should pass multiple filter values to questions and dashboards (metabase#17160-1)", () => {
+    setup(false);
     cy.findByText("Category").click();
 
     popover().within(() => {
@@ -114,6 +46,52 @@ describe("issue 17160", () => {
 
     assertMultipleValuesFilterState();
   });
+
+  it("should pass multiple filter values to public questions and dashboards (metabase#17160-2)", () => {
+    setup(true);
+
+    cy.icon("share").click();
+
+    // Open the dashboard public link
+    cy.findByText("Public link")
+      .parent()
+      .within(() => {
+        cy.get("input").then(input => {
+          cy.visit(input.val());
+        });
+      });
+
+    cy.findByText("Category").click();
+
+    popover().within(() => {
+      cy.findByText("Doohickey").click();
+      cy.findByText("Gadget").click();
+
+      cy.button("Add filter").click();
+    });
+
+    // Check click behavior connected to a question
+    cy.findAllByText("click-behavior-question-label")
+      .eq(0)
+      .click();
+
+    cy.url().should("include", "/public/question");
+
+    assertMultipleValuesFilterState();
+
+    // Go back to the dashboard
+    cy.go("back");
+
+    // Check click behavior connected to a dashboard
+    cy.findAllByText("click-behavior-dashboard-label")
+      .eq(0)
+      .click();
+
+    cy.url().should("include", "/public/dashboard");
+    cy.findByText(TARGET_DASHBOARD_NAME);
+
+    assertMultipleValuesFilterState();
+  });
 });
 
 function assertMultipleValuesFilterState() {
@@ -127,11 +105,94 @@ function assertMultipleValuesFilterState() {
   );
 }
 
-function getVisualSettingsWithClickBehavior(questionTarget, dashboardTarget) {
+function setup(shouldUsePublicLinks) {
+  cy.createNativeQuestion({
+    name: `17160Q`,
+    native: {
+      query: "SELECT * FROM products WHERE {{CATEGORY}}",
+      "template-tags": {
+        CATEGORY: {
+          id: "6b8b10ef-0104-1047-1e1b-2492d5954322",
+          name: "CATEGORY",
+          display_name: "CATEGORY",
+          type: "dimension",
+          dimension: ["field", PRODUCTS.CATEGORY, null],
+          "widget-type": "category",
+          default: null,
+        },
+      },
+    },
+  }).then(({ body: { id: questionId } }) => {
+    // Share the question
+    cy.request("POST", `/api/card/${questionId}/public_link`);
+
+    cy.createDashboard({ name: "17160D" }).then(
+      ({ body: { id: dashboardId } }) => {
+        // Share the dashboard
+        cy.request("POST", `/api/dashboard/${dashboardId}/public_link`);
+
+        // Add the question to the dashboard
+        cy.request("POST", `/api/dashboard/${dashboardId}/cards`, {
+          cardId: questionId,
+        }).then(({ body: { id: dashCardId } }) => {
+          // Add dashboard filter
+          cy.request("PUT", `/api/dashboard/${dashboardId}`, {
+            parameters: [
+              {
+                id: CATEGORY_FILTER_PARAMETER_ID,
+                name: "Category",
+                slug: "category",
+                sectionId: "string",
+                type: "string/=",
+              },
+            ],
+          });
+
+          createTargetDashboardForClickBehavior().then(targetDashboardId => {
+            // Create a click behavior and resize the question card
+            cy.request("PUT", `/api/dashboard/${dashboardId}/cards`, {
+              cards: [
+                {
+                  id: dashCardId,
+                  card_id: questionId,
+                  row: 0,
+                  col: 0,
+                  sizeX: 12,
+                  sizeY: 10,
+                  parameter_mappings: [
+                    {
+                      parameter_id: CATEGORY_FILTER_PARAMETER_ID,
+                      card_id: 4,
+                      target: ["dimension", ["template-tag", "CATEGORY"]],
+                    },
+                  ],
+                  visualization_settings: getVisualSettingsWithClickBehavior(
+                    questionId,
+                    targetDashboardId,
+                    shouldUsePublicLinks,
+                  ),
+                },
+              ],
+            });
+
+            visitDashboard(dashboardId);
+          });
+        });
+      },
+    );
+  });
+}
+
+function getVisualSettingsWithClickBehavior(
+  questionTarget,
+  dashboardTarget,
+  shouldUsePublicLinks = false,
+) {
   return {
     column_settings: {
       '["name","ID"]': {
         click_behavior: {
+          use_public_link: shouldUsePublicLinks,
           targetId: questionTarget,
           parameterMapping: {
             "6b8b10ef-0104-1047-1e1b-2492d5954322": {
@@ -155,6 +216,7 @@ function getVisualSettingsWithClickBehavior(questionTarget, dashboardTarget) {
 
       '["name","EAN"]': {
         click_behavior: {
+          use_public_link: shouldUsePublicLinks,
           targetId: dashboardTarget,
           parameterMapping: {
             dd19ec03: {
@@ -192,6 +254,10 @@ function createTargetDashboardForClickBehavior() {
       },
     })
     .then(({ body: { id, card_id, dashboard_id } }) => {
+      // Share the dashboard
+      cy.request("POST", `/api/dashboard/${dashboard_id}/public_link`);
+
+      // Add a filter
       cy.request("PUT", `/api/dashboard/${dashboard_id}`, {
         parameters: [
           {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/17160
Closes https://github.com/metabase/metabase/issues/14009

## Problem

We did not provide a way to connect dashboard click behavior to a **public** question. The existing workaround of using "Custom URL" option for a public question has one downside — it cannot handle multiple selected parameters properly.

Custom URL is just a template string that we extrapolate with mapped values. Parameters containing multiple options `["a", "b"]` become a comma-separated list `a,b` which is completely reasonable for a simple string extrapolation. However, to specify multiple parameter values for a public question page we need to use a bit different format of the query string `?param=a&param=b` which removes ambiguity between a single value `a,b` and two values `a` and `b` concatenated with a comma.

## Changes

As a solution, we can allow users to specify which version of a question they want to connect and then we can compose the correct url to the question.

<img width="388" alt="Screenshot 2022-05-18 at 18 06 15" src="https://user-images.githubusercontent.com/14301985/169061068-5c98682d-1d3d-4f24-ac51-62846e6b0312.png">

## How to verify

**Reproduce 1: dashboard**
1. Question > Sample > Products - save as "Q1"
2. Create two dashboards "D1" and "D2" - add "Q1" to both and add a Dropdown filter to both connected to the Q1's "Category"
3. Enable public sharing for both dashboards
4. On "D1" - create a Click Behavior to dashboard "D2" connecting both filters and tick "Use public link" checkbox and save the dashboard
5. Open the public link of "D1" - set filter value to Gizmo and Widget, click the Click Behavior column
6. Ensure you're taken to public "D2" link with filter that contains two values `Gizmo` and `Widget`

**Reproduce 2: SQL**
1. Question > Sample > Products - save as "Q1"
2. Native > Sample > `select count(*) from products where {{filter}}` set as Field Filter of Products.Category - save as "Q2"
3. Enable public sharing for "Q2" question
4. Create a dashboard and add "Q1" and add a Dropdown connected to Q1's "Category"
5. Enable public sharing for the dashboard
6. On the dashboard card, add Click Behavior to question "Q2" connecting dashboard filter to question filter and tick "Use public link" checkbox
7. Open the public link of the dashboard and set filter value to Gizmo and Widget, click the Click Behavior column
8. Ensure you're taken to public "Q2" link with filter that contains two values `Gizmo` and `Widget`
