### PR TITLE
Remove unused arg in EntityType

### DIFF
--- a/frontend/src/metabase/entities/containers/EntityType.jsx
+++ b/frontend/src/metabase/entities/containers/EntityType.jsx
@@ -3,15 +3,14 @@ import React from "react";
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
 
-export default entityType => ComposedComponent => {
+export default () => ComposedComponent => {
   const mapStateToProps = (state, props) => ({
     entityDef:
       // dynamic require due to dependency load order issues
       require("metabase/entities")[
-        entityType ||
-          (typeof props.entityType === "function"
-            ? props.entityType(state, props)
-            : props.entityType)
+        typeof props.entityType === "function"
+          ? props.entityType(state, props)
+          : props.entityType
       ],
   });
   return connect(mapStateToProps)(


### PR DESCRIPTION
While I was working on https://github.com/metabase/metabase/issues/22714, I came across this higher-order function that doesn't seem to use the first argument anymore.

There are 3 places that use this higher-order function, and you could see that there's no argument passed to the function.
1. https://github.com/metabase/metabase/blob/029f862b798baed620bc0886608944015b6dfa14/frontend/src/metabase/entities/containers/EntityObjectLoader.jsx#L143
2. https://github.com/metabase/metabase/blob/029f862b798baed620bc0886608944015b6dfa14/frontend/src/metabase/entities/containers/EntityListLoader.jsx#L231
3. https://github.com/metabase/metabase/blob/029f862b798baed620bc0886608944015b6dfa14/frontend/src/metabase/entities/containers/EntityForm.jsx#L70