### PR TITLE
dashboard click behavior: fix passing multiple value parameters

### DIFF
--- a/frontend/src/metabase/modes/components/drill/DashboardClickDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/DashboardClickDrill.jsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/prop-types */
 import { getIn } from "icepick";
 import _ from "underscore";
+import querystring from "querystring";
 
 import Question from "metabase-lib/lib/Question";
 import {
@@ -77,8 +78,8 @@ export default ({ question, clicked }) => {
           clickBehavior,
         });
 
-        const urlSearchParams = new URLSearchParams(queryParams);
-        const url = `/dashboard/${targetId}?${urlSearchParams.toString()}`;
+        const urlSearchParams = querystring.stringify(queryParams);
+        const url = `/dashboard/${targetId}?${urlSearchParams}`;
         behavior = { url: () => url };
       }
     } else if (linkType === "question" && extraData && extraData.questions) {
@@ -105,9 +106,7 @@ export default ({ question, clicked }) => {
 
       const url = targetQuestion.isStructured()
         ? targetQuestion.getUrlWithParameters(parameters, queryParams)
-        : `${targetQuestion.getUrl()}?${new URLSearchParams(
-            queryParams,
-          ).toString()}`;
+        : `${targetQuestion.getUrl()}?${querystring.stringify(queryParams)}`;
 
       behavior = { url: () => url };
     }

--- a/frontend/test/metabase/scenarios/dashboard/reproductions/17160-click-behavior-multiple-options.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/reproductions/17160-click-behavior-multiple-options.cy.spec.js
@@ -2,7 +2,10 @@ import { restore, popover, visitDashboard } from "__support__/e2e/cypress";
 
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
-const { PRODUCTS } = SAMPLE_DATABASE;
+const { PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
+
+const TARGET_DASHBOARD_NAME = "Target dashboard";
+const CATEGORY_FILTER_PARAMETER_ID = "7c9ege62";
 
 describe("issue 17160", () => {
   beforeEach(() => {
@@ -10,7 +13,7 @@ describe("issue 17160", () => {
     cy.signInAsAdmin();
 
     cy.createNativeQuestion({
-      name: `17160`,
+      name: `17160Q`,
       native: {
         query: "SELECT * FROM products WHERE {{CATEGORY}}",
         "template-tags": {
@@ -26,50 +29,56 @@ describe("issue 17160", () => {
         },
       },
     }).then(({ body: { id: questionId } }) => {
-      cy.createDashboard().then(({ body: { id: dashboardId } }) => {
-        // Add the question to the dashboard
-        cy.request("POST", `/api/dashboard/${dashboardId}/cards`, {
-          cardId: questionId,
-        }).then(({ body: { id: dashCardId } }) => {
-          // Add dashboard filter
-          cy.request("PUT", `/api/dashboard/${dashboardId}`, {
-            parameters: [
-              {
-                id: "7c9ege62",
-                name: "Category",
-                slug: "category",
-                type: "category",
-              },
-            ],
-          });
+      cy.createDashboard({ name: "17160D" }).then(
+        ({ body: { id: dashboardId } }) => {
+          // Add the question to the dashboard
+          cy.request("POST", `/api/dashboard/${dashboardId}/cards`, {
+            cardId: questionId,
+          }).then(({ body: { id: dashCardId } }) => {
+            // Add dashboard filter
+            cy.request("PUT", `/api/dashboard/${dashboardId}`, {
+              parameters: [
+                {
+                  id: CATEGORY_FILTER_PARAMETER_ID,
+                  name: "Category",
+                  slug: "category",
+                  sectionId: "string",
+                  type: "string/=",
+                },
+              ],
+            });
 
-          // Create a click behavior and resize the question card
-          cy.request("PUT", `/api/dashboard/${dashboardId}/cards`, {
-            cards: [
-              {
-                id: dashCardId,
-                card_id: questionId,
-                row: 0,
-                col: 0,
-                sizeX: 12,
-                sizeY: 10,
-                parameter_mappings: [
+            createTargetDashboardForClickBehavior().then(targetDashboardId => {
+              // Create a click behavior and resize the question card
+              cy.request("PUT", `/api/dashboard/${dashboardId}/cards`, {
+                cards: [
                   {
-                    parameter_id: "7c9ege62",
-                    card_id: 4,
-                    target: ["dimension", ["template-tag", "CATEGORY"]],
+                    id: dashCardId,
+                    card_id: questionId,
+                    row: 0,
+                    col: 0,
+                    sizeX: 12,
+                    sizeY: 10,
+                    parameter_mappings: [
+                      {
+                        parameter_id: CATEGORY_FILTER_PARAMETER_ID,
+                        card_id: 4,
+                        target: ["dimension", ["template-tag", "CATEGORY"]],
+                      },
+                    ],
+                    visualization_settings: getVisualSettingsWithClickBehavior(
+                      questionId,
+                      targetDashboardId,
+                    ),
                   },
                 ],
-                visualization_settings: getVisualSettingsWithClickBehavior(
-                  questionId,
-                ),
-              },
-            ],
-          });
+              });
 
-          visitDashboard(dashboardId);
-        });
-      });
+              visitDashboard(dashboardId);
+            });
+          });
+        },
+      );
     });
   });
 
@@ -83,34 +92,52 @@ describe("issue 17160", () => {
       cy.button("Add filter").click();
     });
 
-    cy.findAllByText("click-behavior-label")
+    // Check click behavior connected to a question
+    cy.findAllByText("click-behavior-question-label")
       .eq(0)
       .click();
 
     cy.url().should("include", "/question");
 
-    cy.findByText("2 selections").click();
+    assertMultipleValuesFilterState();
 
-    cy.findByTestId("Doohickey-filter-value").within(() =>
-      cy.get("input").should("be.checked"),
-    );
-    cy.findByTestId("Gadget-filter-value").within(() =>
-      cy.get("input").should("be.checked"),
-    );
+    // Go back to the dashboard
+    cy.go("back");
+
+    // Check click behavior connected to a dashboard
+    cy.findAllByText("click-behavior-dashboard-label")
+      .eq(0)
+      .click();
+
+    cy.url().should("include", "/dashboard");
+    cy.findByText(TARGET_DASHBOARD_NAME);
+
+    assertMultipleValuesFilterState();
   });
 });
 
-function getVisualSettingsWithClickBehavior(targetId) {
+function assertMultipleValuesFilterState() {
+  cy.findByText("2 selections").click();
+
+  cy.findByTestId("Doohickey-filter-value").within(() =>
+    cy.get("input").should("be.checked"),
+  );
+  cy.findByTestId("Gadget-filter-value").within(() =>
+    cy.get("input").should("be.checked"),
+  );
+}
+
+function getVisualSettingsWithClickBehavior(questionTarget, dashboardTarget) {
   return {
     column_settings: {
       '["name","ID"]': {
         click_behavior: {
-          targetId,
+          targetId: questionTarget,
           parameterMapping: {
             "6b8b10ef-0104-1047-1e1b-2492d5954322": {
               source: {
                 type: "parameter",
-                id: "7c9ege62",
+                id: CATEGORY_FILTER_PARAMETER_ID,
                 name: "Category",
               },
               target: {
@@ -122,9 +149,84 @@ function getVisualSettingsWithClickBehavior(targetId) {
           },
           linkType: "question",
           type: "link",
-          linkTextTemplate: "click-behavior-label",
+          linkTextTemplate: "click-behavior-question-label",
+        },
+      },
+
+      '["name","EAN"]': {
+        click_behavior: {
+          targetId: dashboardTarget,
+          parameterMapping: {
+            dd19ec03: {
+              source: {
+                type: "parameter",
+                id: CATEGORY_FILTER_PARAMETER_ID,
+                name: "Category",
+              },
+              target: {
+                type: "parameter",
+                id: "dd19ec03",
+              },
+              id: "dd19ec03",
+            },
+          },
+          linkType: "dashboard",
+          type: "link",
+          linkTextTemplate: "click-behavior-dashboard-label",
         },
       },
     },
   };
+}
+
+function createTargetDashboardForClickBehavior() {
+  return cy
+    .createQuestionAndDashboard({
+      dashboardDetails: {
+        name: TARGET_DASHBOARD_NAME,
+      },
+      questionDetails: {
+        query: {
+          "source-table": PRODUCTS_ID,
+        },
+      },
+    })
+    .then(({ body: { id, card_id, dashboard_id } }) => {
+      cy.request("PUT", `/api/dashboard/${dashboard_id}`, {
+        parameters: [
+          {
+            name: "Category",
+            slug: "category",
+            id: "dd19ec03",
+            type: "string/=",
+            sectionId: "string",
+          },
+        ],
+      });
+
+      // Create a click behavior and resize the question card
+      return cy
+        .request("PUT", `/api/dashboard/${dashboard_id}/cards`, {
+          cards: [
+            {
+              id,
+              card_id,
+              row: 0,
+              col: 0,
+              sizeX: 12,
+              sizeY: 10,
+              parameter_mappings: [
+                {
+                  parameter_id: "dd19ec03",
+                  card_id,
+                  target: ["dimension", ["field", PRODUCTS.CATEGORY, null]],
+                },
+              ],
+            },
+          ],
+        })
+        .then(() => {
+          return dashboard_id;
+        });
+    });
 }

--- a/frontend/test/metabase/scenarios/dashboard/reproductions/17160-click-behavior-multiple-options.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/reproductions/17160-click-behavior-multiple-options.cy.spec.js
@@ -1,0 +1,130 @@
+import { restore, popover, visitDashboard } from "__support__/e2e/cypress";
+
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+
+const { PRODUCTS } = SAMPLE_DATABASE;
+
+describe("issue 17160", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    cy.createNativeQuestion({
+      name: `17160`,
+      native: {
+        query: "SELECT * FROM products WHERE {{CATEGORY}}",
+        "template-tags": {
+          CATEGORY: {
+            id: "6b8b10ef-0104-1047-1e1b-2492d5954322",
+            name: "CATEGORY",
+            display_name: "CATEGORY",
+            type: "dimension",
+            dimension: ["field", PRODUCTS.CATEGORY, null],
+            "widget-type": "category",
+            default: null,
+          },
+        },
+      },
+    }).then(({ body: { id: questionId } }) => {
+      cy.createDashboard().then(({ body: { id: dashboardId } }) => {
+        // Add the question to the dashboard
+        cy.request("POST", `/api/dashboard/${dashboardId}/cards`, {
+          cardId: questionId,
+        }).then(({ body: { id: dashCardId } }) => {
+          // Add dashboard filter
+          cy.request("PUT", `/api/dashboard/${dashboardId}`, {
+            parameters: [
+              {
+                id: "7c9ege62",
+                name: "Category",
+                slug: "category",
+                type: "category",
+              },
+            ],
+          });
+
+          // Create a click behavior and resize the question card
+          cy.request("PUT", `/api/dashboard/${dashboardId}/cards`, {
+            cards: [
+              {
+                id: dashCardId,
+                card_id: questionId,
+                row: 0,
+                col: 0,
+                sizeX: 12,
+                sizeY: 10,
+                parameter_mappings: [
+                  {
+                    parameter_id: "7c9ege62",
+                    card_id: 4,
+                    target: ["dimension", ["template-tag", "CATEGORY"]],
+                  },
+                ],
+                visualization_settings: getVisualSettingsWithClickBehavior(
+                  questionId,
+                ),
+              },
+            ],
+          });
+
+          visitDashboard(dashboardId);
+        });
+      });
+    });
+  });
+
+  it("should pass multiple filter values to a SQL question parameter (metabase#17160)", () => {
+    cy.findByText("Category").click();
+
+    popover().within(() => {
+      cy.findByText("Doohickey").click();
+      cy.findByText("Gadget").click();
+
+      cy.button("Add filter").click();
+    });
+
+    cy.findAllByText("click-behavior-label")
+      .eq(0)
+      .click();
+
+    cy.url().should("include", "/question");
+
+    cy.findByText("2 selections").click();
+
+    cy.findByTestId("Doohickey-filter-value").within(() =>
+      cy.get("input").should("be.checked"),
+    );
+    cy.findByTestId("Gadget-filter-value").within(() =>
+      cy.get("input").should("be.checked"),
+    );
+  });
+});
+
+function getVisualSettingsWithClickBehavior(targetId) {
+  return {
+    column_settings: {
+      '["name","ID"]': {
+        click_behavior: {
+          targetId,
+          parameterMapping: {
+            "6b8b10ef-0104-1047-1e1b-2492d5954322": {
+              source: {
+                type: "parameter",
+                id: "7c9ege62",
+                name: "Category",
+              },
+              target: {
+                type: "variable",
+                id: "CATEGORY",
+              },
+              id: "6b8b10ef-0104-1047-1e1b-2492d5954322",
+            },
+          },
+          linkType: "question",
+          type: "link",
+          linkTextTemplate: "click-behavior-label",
+        },
+      },
+    },
+  };
+}


### PR DESCRIPTION
Fixes internal links from https://github.com/metabase/metabase/issues/17160
Reproduces https://github.com/metabase/metabase/issues/17160

## Changes

Links composed by click behavior incorrectly serialized arrays for query strings like `filter=foo,bar`, however our application expects `filter=foo&filter=bar`.

## How to verify 

**Reproduce 1: dashboard**
1. Question > Sample > Products - save as "Q1"
2. Create two dashboards "D1" and "D2" - add "Q1" to both and add a Dropdown filter to both connected to the Q1's "Category"
3. On "D1" - create a Click Behavior to dashboard "D2" connecting both filters
4. On "D1" - set filter value to Gizmo and Widget, click the Click Behavior column
5. You're taken to "D2" and the filter is `Gizmo` and `Widget`

**Reproduce 2: SQL**
1. Question > Sample > Products - save as "Q1"
2. Native > Sample > `select count(*) from products where {{filter}}` set as Field Filter of Products.Category - save as "Q2"
3. Create a dashboard and add "Q1" and add a Dropdown connected to Q1's "Category"
4. On the dashboard card, add Click Behavior to question "Q2" connecting dashboard filter to question filter
5. Set filter value to Gizmo and Widget, click the Click Behavior column
5. You're taken to "Q2" and the filter is `Gizmo` and `Widget`