### PR TITLE
Improve parameter's TextWidget

### DIFF
--- a/frontend/src/metabase/components/TextWidget/TextWidget.stories.tsx
+++ b/frontend/src/metabase/components/TextWidget/TextWidget.stories.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { ComponentStory } from "@storybook/react";
+import { useArgs } from "@storybook/client-api";
+import TextWidget from "./TextWidget";
+
+export default {
+  title: "Parameters/TextWidget",
+  component: TextWidget,
+};
+
+const Template: ComponentStory<typeof TextWidget> = args => {
+  const [{ value }, updateArgs] = useArgs();
+
+  const setValue = (value: string | null) => {
+    updateArgs({ value });
+  };
+
+  return <TextWidget {...args} value={value} setValue={setValue} />;
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  value: "",
+};
+
+export const InitialValue = Template.bind({});
+InitialValue.args = {
+  value: "Toucan McBird",
+};
+
+export const Placeholder = Template.bind({});
+Placeholder.args = {
+  value: "",
+  placeholder: "What's your wish?",
+};

--- a/frontend/src/metabase/components/TextWidget/TextWidget.unit.spec.tsx
+++ b/frontend/src/metabase/components/TextWidget/TextWidget.unit.spec.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import TextWidget from "./TextWidget";
+
+describe("TextWidget", () => {
+  it("should render correctly", () => {
+    render(
+      <TextWidget
+        value={"Hello, world!"}
+        setValue={jest.fn()}
+        focusChanged={jest.fn()}
+      ></TextWidget>,
+    );
+    expect(screen.getByRole("textbox")).toHaveValue("Hello, world!");
+  });
+
+  it("should accept editing", () => {
+    render(
+      <TextWidget
+        value={""}
+        setValue={jest.fn()}
+        focusChanged={jest.fn()}
+      ></TextWidget>,
+    );
+
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "Toucan McBird" },
+    });
+    expect(screen.getByRole("textbox")).toHaveValue("Toucan McBird");
+  });
+});

--- a/frontend/src/metabase/components/TextWidget/index.ts
+++ b/frontend/src/metabase/components/TextWidget/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./TextWidget";

--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
@@ -11,7 +11,7 @@ import DateRelativeWidget from "metabase/components/DateRelativeWidget";
 import DateMonthYearWidget from "metabase/components/DateMonthYearWidget";
 import DateQuarterYearWidget from "metabase/components/DateQuarterYearWidget";
 import DateAllOptionsWidget from "./widgets/DateAllOptionsWidget";
-import TextWidget from "./widgets/TextWidget";
+import TextWidget from "metabase/components/TextWidget";
 import ParameterFieldWidget from "./widgets/ParameterFieldWidget/ParameterFieldWidget";
 import Tooltip from "metabase/components/Tooltip";
 


### PR DESCRIPTION
* switch to TypeScript, add type annotations
* support Storybook
* add some basic unit tests

Verify manually by creating a dashboard with a parameter:
1. New, SQL Query
2. Type `select * from PRODUCTS where CATEGORY={{Category}}`
3. Supply the text for the category, e.g. `Gizmo` (this is the `TextWidget` component in action)
4. Run and save the question as usual

Ensure that everything works exactly the same **before** and **after** this PR.

![image](https://user-images.githubusercontent.com/7288/169110314-9f0c76c0-ff9c-4a9a-8a19-8a0d87880ed2.png)

To view this component in Storybook: `yarn storybook` and search for `TextWidget`:

![image](https://user-images.githubusercontent.com/7288/169142822-76c21c3b-ce3f-4530-9340-9c1b9b5fb7f4.png)
