### PR TITLE
Ensure Groups element is Visible on Admin 

### DIFF
--- a/frontend/test/metabase/scenarios/admin/people/group-managers.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/people/group-managers.cy.spec.js
@@ -21,7 +21,7 @@ describeEE("scenarios > admin > people", () => {
 
   describe("group managers", () => {
     it("can manage groups from the group page", () => {
-      cy.findByText("Groups").click();
+      cy.findByTextEnsureVisible("Groups").click();
 
       // Edit group name
       cy.icon("ellipsis")
@@ -147,7 +147,7 @@ describeEE("scenarios > admin > people", () => {
   });
 
   it("after removing the last group redirects to the home page", () => {
-    cy.findByText("Groups").click();
+    cy.findByTextEnsureVisible("Groups").click();
 
     removeFirstGroup();
     cy.url().should("match", /\/admin\/people\/groups$/);


### PR DESCRIPTION
We are having [some failures](https://app.circleci.com/pipelines/github/metabase/metabase/36520/workflows/1b6c8b37-beaa-440e-8150-de735783f2c4/jobs/1912299/artifacts) when trying to find the element (looks like race condition), so just changing the cypress command to ensure the text is visible before clicking.

