### PR TITLE
[E2E] Reduce the chance of failing tests due to slow UI change

### DIFF
--- a/frontend/test/metabase/scenarios/question/reproductions/22247-timeseries-filter-all-time.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/22247-timeseries-filter-all-time.cy.spec.js
@@ -44,13 +44,9 @@ describe("time-series filter widget", () => {
     popover().within(() => {
       cy.findByText("All Time").click();
     });
-    cy.get(".List-item")
-      .contains("Previous")
-      .click();
+    cy.findByTextEnsureVisible("Previous").click();
     cy.findByTextEnsureVisible("days").click();
-    cy.get(".List-item")
-      .contains("quarters")
-      .click();
+    cy.findByTextEnsureVisible("quarters").click();
     cy.button("Apply").click();
     cy.wait("@dataset");
 


### PR DESCRIPTION
### Before

Somehow the test `frontend/test/metabase/scenarios/question/reproductions/22247-timeseries-filter-all-time.cy.spec.js` occasionally still failed (mainly on CI, always pass for me locally) like this:

![image](https://user-images.githubusercontent.com/7288/169353683-a63e1acf-3619-4e70-951a-2a6f2d16d0e2.png)

### After

This should not happen anymore due to better sync between UI change vs assertions.