### PR TITLE
[E2E] Sync pagination tests with the UI changes to prevent failures

### DIFF
--- a/frontend/test/metabase/scenarios/admin/people/people.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/people/people.cy.spec.js
@@ -251,15 +251,17 @@ describe("scenarios > admin > people", () => {
         cy.findByTestId("previous-page-btn").should("be.disabled");
 
         cy.findByTestId("next-page-btn").click();
-
         waitForUserRequests();
+        cy.findByText("Loading...").should("not.exist");
 
         // Page 2
-        cy.findByText(`${PAGE_SIZE + 1} - ${NEW_TOTAL_USERS}`);
+        cy.findByTextEnsureVisible(`${PAGE_SIZE + 1} - ${NEW_TOTAL_USERS}`);
         assertTableRowsCount(NEW_TOTAL_USERS % PAGE_SIZE);
         cy.findByTestId("next-page-btn").should("be.disabled");
 
         cy.findByTestId("previous-page-btn").click();
+        cy.wait("@users");
+        cy.findByText("Loading...").should("not.exist");
 
         // Page 1
         cy.findByText(`1 - ${PAGE_SIZE}`);
@@ -279,13 +281,17 @@ describe("scenarios > admin > people", () => {
         cy.findByTestId("previous-page-btn").should("be.disabled");
 
         cy.findByTestId("next-page-btn").click();
+        waitForUserRequests();
+        cy.findByText("Loading...").should("not.exist");
 
         // Page 2
-        cy.findByText(`${PAGE_SIZE + 1} - ${NEW_TOTAL_USERS}`);
+        cy.findByTextEnsureVisible(`${PAGE_SIZE + 1} - ${NEW_TOTAL_USERS}`);
         assertTableRowsCount(NEW_TOTAL_USERS % PAGE_SIZE);
         cy.findByTestId("next-page-btn").should("be.disabled");
 
         cy.findByTestId("previous-page-btn").click();
+        cy.wait("@users");
+        cy.findByText("Loading...").should("not.exist");
 
         // Page 1
         cy.findByText(`1 - ${PAGE_SIZE}`);


### PR DESCRIPTION
### Before

The pagination tests in `frontend/test/metabase/scenarios/admin/people/people.cy.spec.js` sometimes failed miserably, like this:

![image](https://user-images.githubusercontent.com/7288/169356877-5d308eda-0f69-4366-860e-c18750596a3c.png)

### After

It unlikely happen anymore, due to a better sync between the requests and UI changes.