### PR TITLE
Respect advanced permissions for model persistence

### DIFF
--- a/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.jsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.jsx
@@ -67,31 +67,29 @@ const DatabaseEditAppSidebar = ({
                 successText={t`Scan triggered!`}
               />
             </li>
-            {isAdmin &&
-              isModelPersistenceEnabled &&
-              database.supportsPersistence() && (
-                <li className="mt2">
-                  {database.isPersisted() ? (
-                    <ActionButton
-                      actionFn={() => unpersistDatabase(database.id)}
-                      className="Button"
-                      normalText={t`Disable model persistence`}
-                      activeText={t`Disabling…`}
-                      failedText={t`Failed`}
-                      successText={t`Done`}
-                    />
-                  ) : (
-                    <ActionButton
-                      actionFn={() => persistDatabase(database.id)}
-                      className="Button"
-                      normalText={t`Enable model persistence`}
-                      activeText={t`Enabling…`}
-                      failedText={t`Failed`}
-                      successText={t`Done`}
-                    />
-                  )}
-                </li>
-              )}
+            {isModelPersistenceEnabled && database.supportsPersistence() && (
+              <li className="mt2">
+                {database.isPersisted() ? (
+                  <ActionButton
+                    actionFn={() => unpersistDatabase(database.id)}
+                    className="Button"
+                    normalText={t`Disable model persistence`}
+                    activeText={t`Disabling…`}
+                    failedText={t`Failed`}
+                    successText={t`Done`}
+                  />
+                ) : (
+                  <ActionButton
+                    actionFn={() => persistDatabase(database.id)}
+                    className="Button"
+                    normalText={t`Enable model persistence`}
+                    activeText={t`Enabling…`}
+                    failedText={t`Failed`}
+                    successText={t`Done`}
+                  />
+                )}
+              </li>
+            )}
           </ol>
         </div>
 

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -211,7 +211,7 @@
   (deferred-tru "Allow persisting models into the source database.")
   :type       :boolean
   :default    false
-  :visibility :admin)
+  :visibility :authenticated)
 
 (defsetting persisted-model-refresh-interval-hours
   (deferred-tru "Hour interval to refresh persisted models.")


### PR DESCRIPTION
Part of #22538

This PR makes FE handle advanced permissions for some parts of model persistence UI:

1. Fixes regular users (non-admins) with "Manage database" permission couldn't turn on/off model persistence for this DB
2. Ensures "Model caching log" is properly displayed depending on "Monitoring" application permission

### To Verify

**Prepare**
1. Run Metabase Enterprise (these permissions are only available in paid plans)
2. Sign in as an admin
3. Make sure you have Postgres running and connected to your Metabase instance. You can use [our sample PSQL database Docker image](https://github.com/metabase/metabase-qa#postgresql-12
4. Go to `/admin/settings/caching` and turn on model persistence

**Database management permission**
1. As an admin, go to `/admin/permissions/data/database/{{ YOUR_POSTGRES_DB_ID }}` page
2. Set "Manage database" permission to "Yes" for "All users" and save the changes
3. Sign in as a non-admin user
4. Go to `/admin/databases/{{ YOUR_POSTGRES_DB_ID }}`
5. Ensure you can see the "Enable/disable persistence" button. Click it, you shouldn't see any permission error

**Monitoring permission**
1. As an admin, go to `/admin/permissions/application`
2. Turn on "Monitoring" permission for all users
3. Sign in as a non-admin user
4. Go to `/admin/tools`
5. Ensure you can see both "Questions" and "Model Caching Log" tabs
6. Sign in as admin and go to `/admin/permissions/application` again
7. Turn off "Monitoring" permission for all users, but enable the "Settings" one
8. Sign in as a non-admin user
9. Go to the admin, ensure you can't see the "Tools" tab at all