### PR TITLE
Allow drivers to `skip-compilation?` if desired

### DIFF
--- a/bin/build-drivers/src/build_drivers/build_driver.clj
+++ b/bin/build-drivers/src/build_drivers/build_driver.clj
@@ -19,7 +19,7 @@
   ([driver edition]
    (build-driver! driver edition nil))
 
-  ([driver edition {:keys [project-dir target-dir], :as options}]
+  ([driver edition {:keys [project-dir target-dir skip-compilation?], :as options}]
    (let [edition       (or edition :oss)
          start-time-ms (System/currentTimeMillis)]
      (binding [c/*driver-project-dir* (or project-dir
@@ -29,7 +29,9 @@
        (u/step (format "Build driver %s (edition = %s, options = %s)" driver edition (pr-str options))
          (clean! driver)
          (copy-source-files/copy-source-files! driver edition)
-         (compile-source-files/compile-clojure-source-files! driver edition)
+         (when-not skip-compilation?
+             (compile-source-files/compile-clojure-source-files! driver edition))
+         (u/announce "Skipping compiling")
          (create-uberjar/create-uberjar! driver edition)
          (u/announce "Built %s driver in %d ms." driver (- (System/currentTimeMillis) start-time-ms))
-         (verify/verify-driver driver))))))
+         (verify/verify-driver driver skip-compilation?))))))


### PR DESCRIPTION
I suspect we are having some issues due to AOT'ing third party
libraries. So allow them to opt out of this if they desire.

For some background check out [discourse conversation](https://discourse.metabase.com/t/running-integration-tests-with-deps-edn-build-without-symlink/20157)
