### PR TITLE
Prevent Filter Modal Tab Scroll

### DIFF
--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterModal/BulkFilterModal.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterModal/BulkFilterModal.styled.tsx
@@ -39,6 +39,7 @@ export const ModalTitle = styled(Ellipsified)`
 
 export const ModalTabList = styled(TabList)`
   padding: 0 2rem;
+  flex-shrink: 0;
 `;
 
 export const ModalTabPanel = styled(TabPanel)`


### PR DESCRIPTION
## Before

The filter modal tabs would scroll if the modal body had scroll on it as well :cry: 

![Screenshot from 2022-05-19 13-56-22](https://user-images.githubusercontent.com/30528226/169394074-0b52a38e-bd40-47d2-b187-cf379cbc79a8.png)

## After

The modal body scrolls without scrolling the tab bar :smile: 

![Screenshot from 2022-05-19 13-56-35](https://user-images.githubusercontent.com/30528226/169394251-cb191e46-1d0e-4b8f-8d7c-d3ec4b144d6c.png)
