### PR TITLE
Change permission on GET /api/persist

### DIFF
--- a/src/metabase/api/persist.clj
+++ b/src/metabase/api/persist.clj
@@ -54,7 +54,7 @@
 (api/defendpoint GET "/"
   "List the entries of [[PersistedInfo]] in order to show a status page."
   []
-  (validation/check-has-application-permission :setting)
+  (validation/check-has-application-permission :monitoring)
   (let [db-ids (db/select-field :database_id PersistedInfo)
         writable-db-ids (when (seq db-ids)
                           (->> (db/select Database :id [:in db-ids])


### PR DESCRIPTION
Since this information is used in the model cache logging screen
accessible by monitoring users, :monitoring rather than :setting
permission is the correct one.
