### PR TITLE
Fix flaky test in randomized schedules

### DIFF
--- a/src/metabase/sync/schedules.clj
+++ b/src/metabase/sync/schedules.clj
@@ -33,9 +33,10 @@
 (defn randomly-once-an-hour
   "Schedule map for once an hour at a random minute of the hour."
   []
-  ;; prevent zeros which would appear as non-random
-  {:schedule_minute (inc (rand-int 59))
-   :schedule_type   "hourly"})
+  ;; prevent zeros and 50s which would appear as non-random choices
+  (let [choices (into [] (remove #{0 50}) (range 60))]
+    {:schedule_minute (rand-nth choices)
+     :schedule_type   "hourly"}))
 
 (defn randomly-once-a-day
   "Schedule map for once a day at a random hour of the day."

--- a/test/metabase/sync/schedules_test.clj
+++ b/test/metabase/sync/schedules_test.clj
@@ -1,6 +1,7 @@
 (ns metabase.sync.schedules-test
   (:require [clojure.test :refer :all]
-            [metabase.sync.schedules :as sync.schedules]))
+            [metabase.sync.schedules :as sync.schedules]
+            [metabase.util.cron :as u.cron]))
 
 (deftest schedule-map->cron-strings-test
   (is (= {} (sync.schedules/schedule-map->cron-strings {})))
@@ -12,3 +13,17 @@
          (sync.schedules/schedule-map->cron-strings {:cache_field_values {:schedule_type "daily"
                                                                           :schedule_hour 4}
                                                      :metadata_sync      {:schedule_type "hourly"}}))))
+
+(deftest default-randomized-schedule
+  (testing "randomized schedule never matches \"default\" values"
+    ;; this really checks to prevent flaky tests which assert a non-default value, and to prevent "randomizing" the
+    ;; same db schedules multiple times
+    (doseq [[defaults k] [[sync.schedules/default-cache-field-values-schedule-cron-strings
+                           :cache_field_values]
+                          [sync.schedules/default-metadata-sync-schedule-cron-strings
+                           :metadata_sync]]]
+     (let [generator  (comp u.cron/schedule-map->cron-string
+                            k
+                            sync.schedules/default-randomized-schedule)]
+       (is (empty? (filter defaults (repeatedly 500 generator)))
+           (format "Found default values for %s randomized schedule" (name k)))))))


### PR DESCRIPTION
we assert that the schedule gets randomized and it is no longer one of
the default schedules. We need to make sure that it cannot return one of
the default schedules in that case :). Low probability (1 in 58) but
with 28 test suites run for each commit it starts to add up and becomes
Flaky™


case in point on another PR of mine:
<img width="1250" alt="image" src="https://user-images.githubusercontent.com/6377293/169398887-489a4218-6361-4a61-a99d-7173453a6723.png">
