### PR TITLE
fix usage of invalid value for scatter bubbles

### DIFF
--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -453,7 +453,7 @@ function doScatterChartStuff(chart, datas, index, { yExtent, yExtents }) {
     if (isBubble) {
       const BUBBLE_SCALE_FACTOR_MAX = 64;
       chart
-        .radiusValueAccessor(d => d.value)
+        .radiusValueAccessor(d => d.key[2])
         .r(
           d3.scale
             .sqrt()

--- a/frontend/test/metabase-visual/visualizations/scatter.cy.spec.js
+++ b/frontend/test/metabase-visual/visualizations/scatter.cy.spec.js
@@ -37,6 +37,7 @@ describe("visual tests > visualizations > scatter", () => {
       },
     });
 
+    cy.get(".dc-chart");
     cy.percySnapshot();
   });
 
@@ -64,6 +65,7 @@ describe("visual tests > visualizations > scatter", () => {
       },
     });
 
+    cy.get(".dc-chart");
     cy.percySnapshot();
   });
 
@@ -90,6 +92,7 @@ union all select 5, -20, 70`,
       },
     });
 
+    cy.get(".dc-chart");
     cy.percySnapshot();
   });
 });

--- a/frontend/test/metabase-visual/visualizations/scatter.cy.spec.js
+++ b/frontend/test/metabase-visual/visualizations/scatter.cy.spec.js
@@ -66,4 +66,30 @@ describe("visual tests > visualizations > scatter", () => {
 
     cy.percySnapshot();
   });
+
+  it("with negative values and various bubble sizes", () => {
+    visitQuestionAdhoc({
+      dataset_query: {
+        type: "native",
+        native: {
+          query: `select 1 X, 1 Y, 20 SIZE
+union all select 2, 10, 10
+union all select 3, -9, 6
+union all select 4, 100, 30
+union all select 5, -20, 70`,
+        },
+        database: SAMPLE_DB_ID,
+      },
+      display: "scatter",
+
+      displayIsLocked: true,
+      visualization_settings: {
+        "scatter.bubble": "SIZE",
+        "graph.dimensions": ["X"],
+        "graph.metrics": ["Y"],
+      },
+    });
+
+    cy.percySnapshot();
+  });
 });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/22527

## Changes

In https://github.com/metabase/metabase/pull/22164 I fixed usage of invalid dimension for `value` calculation which led to y-axis being `[1, 1]` which did not work for `log` y-axis. However, this invalid value was used for bubble sizes when a dimension specified. This PR uses the correct dimension value for bubble sizes.

## How to verify

Check the linked issue for repro steps