### PR TITLE
hide back button on the relative date time picker when open from a table column header

### DIFF
--- a/frontend/src/metabase/query_builder/components/filters/FilterPopover.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/FilterPopover.tsx
@@ -258,6 +258,7 @@ export default class FilterPopover extends Component<Props, State> {
               onBack={onBack}
               onCommit={this.handleCommit}
               onFilterChange={this.handleFilterChange}
+              disableChangingDimension={!showFieldPicker}
             >
               {!isSidebar ? (
                 <Button

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePicker.tsx
@@ -234,6 +234,7 @@ type Props = {
   hideTimeSelectors?: boolean;
   hideEmptinessOperators?: boolean;
   disableOperatorSelection?: boolean;
+  disableChangingDimension?: boolean;
 
   primaryColor?: string;
   minWidth?: number | null;
@@ -251,6 +252,7 @@ const DatePicker: React.FC<Props> = props => {
     onFilterChange,
     isSidebar,
     disableOperatorSelection,
+    disableChangingDimension,
     primaryColor,
     onCommit,
     children,
@@ -265,8 +267,9 @@ const DatePicker: React.FC<Props> = props => {
   const Widget = operator && operator.widget;
 
   const enableBackButton =
-    (!showShortcuts && !disableOperatorSelection) ||
-    (showShortcuts && props.onBack);
+    !disableChangingDimension &&
+    ((!showShortcuts && !disableOperatorSelection) ||
+      (showShortcuts && props.onBack));
   const onBack = () => {
     if (!operator || showShortcuts) {
       props.onBack?.();

--- a/frontend/test/metabase/scenarios/filters/relative-datetime.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/relative-datetime.cy.spec.js
@@ -78,9 +78,15 @@ describe("scenarios > question > relative-datetime", () => {
       openOrdersTable();
 
       cy.findByTextEnsureVisible("Created At").click();
-      cy.findByText("Filter by this column").click();
+
       cy.intercept("POST", "/api/dataset").as("dataset");
-      cy.findByText("Last 30 Days").click();
+
+      popover().within(() => {
+        cy.findByText("Filter by this column").click();
+        cy.icon("chevronleft").should("not.exist");
+        cy.findByText("Last 30 Days").click();
+      });
+
       cy.wait("@dataset");
 
       cy.findByText("Created At Previous 30 Days").click();
@@ -103,10 +109,6 @@ describe("scenarios > question > relative-datetime", () => {
         cy.icon("chevronleft")
           .first()
           .click();
-        cy.findByText("Specific dates...").should("exist");
-        cy.icon("chevronleft").click();
-        cy.findByText("Specific dates...").should("not.exist");
-        cy.findByText("Created At").click();
         cy.findByText("Specific dates...").should("exist");
         cy.findByText("Between").should("not.exist");
       });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/22332

## Changes

Removes the ability to change column when open the relative date time filter from a table column

Before
<img width="343" alt="Screenshot 2022-05-20 at 19 47 36" src="https://user-images.githubusercontent.com/14301985/169564880-d420d357-b88d-4a8f-8fa1-638686e53dd6.png">

After
<img width="339" alt="Screenshot 2022-05-20 at 19 47 18" src="https://user-images.githubusercontent.com/14301985/169564827-495cf1bc-0fc7-4569-93c2-ebfa7c74f2b9.png">

## How to verify

- New -> Question -> Sample database -> Orders
- Click on the Created At header cell
- Ensure there is no ability to change the column from the popup
