### PR TITLE
Storybook issue when using some metabase library code

### DIFF
--- a/frontend/src/metabase/components/HelloWorld.stories.tsx
+++ b/frontend/src/metabase/components/HelloWorld.stories.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { ComponentStory } from "@storybook/react";
+import HelloWorld from "./HelloWorld";
+
+export default {
+  title: "HelloWorld",
+  component: HelloWorld,
+};
+
+const Template: ComponentStory<typeof HelloWorld> = args => {
+  return <HelloWorld />;
+};
+
+export const Default = Template.bind({});
+Default.args = {};

--- a/frontend/src/metabase/components/HelloWorld.tsx
+++ b/frontend/src/metabase/components/HelloWorld.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+import { getStartingFrom } from "metabase/lib/query_time";
+
+console.log({ getStartingFrom });
+
+const HelloWorld = () => {
+  return <h2>Hola</h2>;
+};
+
+export default HelloWorld;


### PR DESCRIPTION
To reproduce:
1. Check out this branch
2. Run `yarn storybook`

Although the example `HelloWorld` component is dead simple, it won't appear in Storybook at all.

Upon opening the browser console, there is this mysterious error:

![image](https://user-images.githubusercontent.com/7288/169665408-8582a4c0-f71d-42c8-9256-fbbed26dd4e9.png)

Try to comment out line 5 (i.e. `console.log({ getStartingFrom })`) and wait until Storybook reloads. Now the component appears perfectly.

![image](https://user-images.githubusercontent.com/7288/169665461-6cb40eec-7623-456d-92e9-0214f9312f01.png)

What could go wrong here?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/22877)
<!-- Reviewable:end -->
