### PR TITLE
Add extended color pickers

### DIFF
--- a/frontend/src/metabase/core/components/ColorInput/ColorInput.stories.tsx
+++ b/frontend/src/metabase/core/components/ColorInput/ColorInput.stories.tsx
@@ -1,0 +1,21 @@
+import React, { useState } from "react";
+import { ComponentStory } from "@storybook/react";
+import ColorInput from "./ColorInput";
+import { useArgs } from "@storybook/client-api";
+
+export default {
+  title: "Core/ColorInput",
+  component: ColorInput,
+};
+
+const Template: ComponentStory<typeof ColorInput> = args => {
+  const [{ color }, updateArgs] = useArgs();
+
+  const handleChange = (color?: string) => {
+    updateArgs({ color });
+  };
+
+  return <ColorInput {...args} color={color} onChange={handleChange} />;
+};
+
+export const Default = Template.bind({});

--- a/frontend/src/metabase/core/components/ColorInput/ColorInput.stories.tsx
+++ b/frontend/src/metabase/core/components/ColorInput/ColorInput.stories.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { ComponentStory } from "@storybook/react";
-import ColorInput from "./ColorInput";
 import { useArgs } from "@storybook/client-api";
+import ColorInput from "./ColorInput";
 
 export default {
   title: "Core/ColorInput",

--- a/frontend/src/metabase/core/components/ColorInput/ColorInput.tsx
+++ b/frontend/src/metabase/core/components/ColorInput/ColorInput.tsx
@@ -1,0 +1,55 @@
+import React, {
+  InputHTMLAttributes,
+  FocusEvent,
+  useCallback,
+  useMemo,
+  useState,
+} from "react";
+import Color from "color";
+import Input from "metabase/core/components/Input";
+
+export type ColorInputAttributes = Omit<
+  InputHTMLAttributes<HTMLDivElement>,
+  "value" | "onChange"
+>;
+
+export interface ColorInputProps extends ColorInputAttributes {
+  value?: string;
+  onChange?: (value?: string) => void;
+}
+
+const ColorInput = ({
+  value,
+  onFocus,
+  onBlur,
+  onChange,
+}: ColorInputProps): JSX.Element => {
+  const [inputText, setInputText] = useState("");
+  const [isFocused, setIsFocused] = useState(false);
+
+  const valueText = useMemo(() => {
+    const color = Color(value);
+    return color.hex();
+  }, [value]);
+
+  const handleFocus = useCallback(
+    (event: FocusEvent<HTMLInputElement>) => {
+      setIsFocused(true);
+      setInputText(valueText);
+      onFocus?.(event);
+    },
+    [valueText, onFocus],
+  );
+
+  const handleBlur = useCallback(
+    (event: FocusEvent<HTMLInputElement>) => {
+      setIsFocused(false);
+      onBlur?.(event);
+    },
+    [onBlur],
+  );
+
+  return <Input onFocus={handleFocus} onBlur={handleBlur} />;
+};
+
+export default ColorInput;

--- a/frontend/src/metabase/core/components/ColorInput/ColorInput.tsx
+++ b/frontend/src/metabase/core/components/ColorInput/ColorInput.tsx
@@ -4,6 +4,7 @@ import React, {
   useCallback,
   useMemo,
   useState,
+  ChangeEvent,
 } from "react";
 import Color from "color";
 import Input from "metabase/core/components/Input";
@@ -28,8 +29,7 @@ const ColorInput = ({
   const [isFocused, setIsFocused] = useState(false);
 
   const valueText = useMemo(() => {
-    const color = Color(value);
-    return color.hex();
+    return value ? Color(value).hex() : "";
   }, [value]);
 
   const handleFocus = useCallback(
@@ -49,7 +49,29 @@ const ColorInput = ({
     [onBlur],
   );
 
-  return <Input onFocus={handleFocus} onBlur={handleBlur} />;
+  const handleChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const newText = event.target.value;
+      setInputText(newText);
+
+      try {
+        const color = Color(newText);
+        onChange?.(color.hex());
+      } catch (e) {
+        onChange?.(undefined);
+      }
+    },
+    [onChange],
+  );
+
+  return (
+    <Input
+      value={isFocused ? inputText : valueText}
+      onFocus={handleFocus}
+      onBlur={handleBlur}
+      onChange={handleChange}
+    />
+  );
 };
 
 export default ColorInput;

--- a/frontend/src/metabase/core/components/ColorInput/ColorInput.tsx
+++ b/frontend/src/metabase/core/components/ColorInput/ColorInput.tsx
@@ -1,10 +1,10 @@
 import React, {
-  InputHTMLAttributes,
+  ChangeEvent,
   FocusEvent,
+  InputHTMLAttributes,
   useCallback,
   useMemo,
   useState,
-  ChangeEvent,
 } from "react";
 import Color from "color";
 import Input from "metabase/core/components/Input";
@@ -15,12 +15,12 @@ export type ColorInputAttributes = Omit<
 >;
 
 export interface ColorInputProps extends ColorInputAttributes {
-  value?: string;
+  color?: string;
   onChange?: (value?: string) => void;
 }
 
 const ColorInput = ({
-  value,
+  color,
   onFocus,
   onBlur,
   onChange,
@@ -28,17 +28,17 @@ const ColorInput = ({
   const [inputText, setInputText] = useState("");
   const [isFocused, setIsFocused] = useState(false);
 
-  const valueText = useMemo(() => {
-    return value ? Color(value).hex() : "";
-  }, [value]);
+  const colorText = useMemo(() => {
+    return color ? Color(color).hex() : "";
+  }, [color]);
 
   const handleFocus = useCallback(
     (event: FocusEvent<HTMLInputElement>) => {
       setIsFocused(true);
-      setInputText(valueText);
+      setInputText(colorText);
       onFocus?.(event);
     },
-    [valueText, onFocus],
+    [colorText, onFocus],
   );
 
   const handleBlur = useCallback(
@@ -55,8 +55,7 @@ const ColorInput = ({
       setInputText(newText);
 
       try {
-        const color = Color(newText);
-        onChange?.(color.hex());
+        onChange?.(Color(newText).hex());
       } catch (e) {
         onChange?.(undefined);
       }
@@ -66,7 +65,7 @@ const ColorInput = ({
 
   return (
     <Input
-      value={isFocused ? inputText : valueText}
+      value={isFocused ? inputText : colorText}
       onFocus={handleFocus}
       onBlur={handleBlur}
       onChange={handleChange}

--- a/frontend/src/metabase/core/components/ColorInput/ColorInput.tsx
+++ b/frontend/src/metabase/core/components/ColorInput/ColorInput.tsx
@@ -1,7 +1,9 @@
 import React, {
   ChangeEvent,
   FocusEvent,
+  forwardRef,
   InputHTMLAttributes,
+  Ref,
   useCallback,
   useMemo,
   useState,
@@ -20,13 +22,10 @@ export interface ColorInputProps extends ColorInputAttributes {
   onChange?: (value?: string) => void;
 }
 
-const ColorInput = ({
-  color,
-  onFocus,
-  onBlur,
-  onChange,
-  ...props
-}: ColorInputProps): JSX.Element => {
+const ColorInput = forwardRef(function ColorInput(
+  { color, onFocus, onBlur, onChange, ...props }: ColorInputProps,
+  ref: Ref<HTMLDivElement>,
+) {
   const [inputText, setInputText] = useState("");
   const [isFocused, setIsFocused] = useState(false);
 
@@ -68,6 +67,7 @@ const ColorInput = ({
   return (
     <Input
       {...props}
+      ref={ref}
       value={isFocused ? inputText : colorText}
       size="small"
       onFocus={handleFocus}
@@ -75,6 +75,6 @@ const ColorInput = ({
       onChange={handleChange}
     />
   );
-};
+});
 
 export default ColorInput;

--- a/frontend/src/metabase/core/components/ColorInput/ColorInput.tsx
+++ b/frontend/src/metabase/core/components/ColorInput/ColorInput.tsx
@@ -66,6 +66,7 @@ const ColorInput = ({
   return (
     <Input
       value={isFocused ? inputText : colorText}
+      size="small"
       onFocus={handleFocus}
       onBlur={handleBlur}
       onChange={handleChange}

--- a/frontend/src/metabase/core/components/ColorInput/ColorInput.tsx
+++ b/frontend/src/metabase/core/components/ColorInput/ColorInput.tsx
@@ -26,12 +26,9 @@ const ColorInput = forwardRef(function ColorInput(
   { color, onFocus, onBlur, onChange, ...props }: ColorInputProps,
   ref: Ref<HTMLDivElement>,
 ) {
-  const [inputText, setInputText] = useState("");
+  const colorText = useMemo(() => getColorHex(color) ?? "", [color]);
+  const [inputText, setInputText] = useState(colorText);
   const [isFocused, setIsFocused] = useState(false);
-
-  const colorText = useMemo(() => {
-    return color ? Color(color).hex() : "";
-  }, [color]);
 
   const handleFocus = useCallback(
     (event: FocusEvent<HTMLInputElement>) => {
@@ -54,12 +51,7 @@ const ColorInput = forwardRef(function ColorInput(
     (event: ChangeEvent<HTMLInputElement>) => {
       const newText = event.target.value;
       setInputText(newText);
-
-      try {
-        onChange?.(Color(newText).hex());
-      } catch (e) {
-        onChange?.(undefined);
-      }
+      onChange?.(getColorHex(newText));
     },
     [onChange],
   );
@@ -76,5 +68,13 @@ const ColorInput = forwardRef(function ColorInput(
     />
   );
 });
+
+const getColorHex = (color?: string) => {
+  try {
+    return color ? Color(color).hex() : undefined;
+  } catch (e) {
+    return undefined;
+  }
+};
 
 export default ColorInput;

--- a/frontend/src/metabase/core/components/ColorInput/ColorInput.tsx
+++ b/frontend/src/metabase/core/components/ColorInput/ColorInput.tsx
@@ -16,6 +16,7 @@ export type ColorInputAttributes = Omit<
 
 export interface ColorInputProps extends ColorInputAttributes {
   color?: string;
+  fullWidth?: boolean;
   onChange?: (value?: string) => void;
 }
 
@@ -24,6 +25,7 @@ const ColorInput = ({
   onFocus,
   onBlur,
   onChange,
+  ...props
 }: ColorInputProps): JSX.Element => {
   const [inputText, setInputText] = useState("");
   const [isFocused, setIsFocused] = useState(false);
@@ -65,6 +67,7 @@ const ColorInput = ({
 
   return (
     <Input
+      {...props}
       value={isFocused ? inputText : colorText}
       size="small"
       onFocus={handleFocus}

--- a/frontend/src/metabase/core/components/ColorInput/index.ts
+++ b/frontend/src/metabase/core/components/ColorInput/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ColorInput";

--- a/frontend/src/metabase/core/components/ColorPicker/ColorPicker.stories.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPicker.stories.tsx
@@ -22,4 +22,5 @@ const Template: ComponentStory<typeof ColorPicker> = args => {
 export const Default = Template.bind({});
 Default.args = {
   color: color("brand"),
+  placeholder: color("brand"),
 };

--- a/frontend/src/metabase/core/components/ColorPicker/ColorPicker.stories.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPicker.stories.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { ComponentStory } from "@storybook/react";
 import { useArgs } from "@storybook/client-api";
-import ColorPicker from "./ColorPicker";
+import ColorPicker, { ColorValue } from "./ColorPicker";
 
 export default {
   title: "Core/ColorPicker",
@@ -11,8 +11,8 @@ export default {
 const Template: ComponentStory<typeof ColorPicker> = args => {
   const [{ color }, updateArgs] = useArgs();
 
-  const handleChange = (color: string) => {
-    updateArgs({ color });
+  const handleChange = (color: ColorValue) => {
+    updateArgs({ color: color.hex });
   };
 
   return <ColorPicker {...args} color={color} onChange={handleChange} />;

--- a/frontend/src/metabase/core/components/ColorPicker/ColorPicker.stories.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPicker.stories.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { ComponentStory } from "@storybook/react";
 import { useArgs } from "@storybook/client-api";
-import ColorPicker, { ColorValue } from "./ColorPicker";
+import ColorPicker, { ColorChangeEvent } from "./ColorPicker";
 
 export default {
   title: "Core/ColorPicker",
@@ -11,8 +11,8 @@ export default {
 const Template: ComponentStory<typeof ColorPicker> = args => {
   const [{ color }, updateArgs] = useArgs();
 
-  const handleChange = (color: ColorValue) => {
-    updateArgs({ color: color.hex });
+  const handleChange = (event: ColorChangeEvent) => {
+    updateArgs({ color: event.hex });
   };
 
   return <ColorPicker {...args} color={color} onChange={handleChange} />;

--- a/frontend/src/metabase/core/components/ColorPicker/ColorPicker.stories.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPicker.stories.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { ComponentStory } from "@storybook/react";
+import { useArgs } from "@storybook/client-api";
+import ColorPicker from "./ColorPicker";
+
+export default {
+  title: "Core/ColorPicker",
+  component: ColorPicker,
+};
+
+const Template: ComponentStory<typeof ColorPicker> = args => {
+  const [{ color }, updateArgs] = useArgs();
+
+  const handleChange = (color: string) => {
+    updateArgs({ color });
+  };
+
+  return <ColorPicker {...args} color={color} onChange={handleChange} />;
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  color: "white",
+};

--- a/frontend/src/metabase/core/components/ColorPicker/ColorPicker.stories.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPicker.stories.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { ComponentStory } from "@storybook/react";
 import { useArgs } from "@storybook/client-api";
-import ColorPicker, { ColorChangeEvent } from "./ColorPicker";
+import ColorPicker from "./ColorPicker";
 
 export default {
   title: "Core/ColorPicker",
@@ -11,8 +11,8 @@ export default {
 const Template: ComponentStory<typeof ColorPicker> = args => {
   const [{ color }, updateArgs] = useArgs();
 
-  const handleChange = (event: ColorChangeEvent) => {
-    updateArgs({ color: event.hex });
+  const handleChange = (color: string) => {
+    updateArgs({ color });
   };
 
   return <ColorPicker {...args} color={color} onChange={handleChange} />;

--- a/frontend/src/metabase/core/components/ColorPicker/ColorPicker.styled.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPicker.styled.tsx
@@ -1,13 +1,19 @@
-import styled from "@emotion/styled";
-
-export const SaturationContainer = styled.div`
-  position: relative;
-  height: 10rem;
-  margin-bottom: 1rem;
-`;
-
-export const HueContainer = styled.div`
-  position: relative;
-  height: 0.5rem;
-  border-radius: 0.25rem;
-`;
+export const getStyles = () => ({
+  default: {
+    picker: {
+      boxShadow: "none",
+      background: "none",
+      fontFamily: "inherit",
+    },
+    body: {
+      marginTop: "16px",
+      padding: "0",
+    },
+    color: {
+      display: "none",
+    },
+    saturation: {
+      borderRadius: "4px",
+    },
+  },
+});

--- a/frontend/src/metabase/core/components/ColorPicker/ColorPicker.styled.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPicker.styled.tsx
@@ -18,18 +18,31 @@ export const SaturationContainer = styled.div`
   position: relative;
   height: 10rem;
   margin-bottom: 1rem;
+  border-radius: 0.25rem;
+  overflow: hidden;
 `;
 
 export const HueContainer = styled.div`
   position: relative;
-  height: 0.625rem;
+  height: 0.5rem;
+  border-radius: 0.25rem;
+  overflow: hidden;
 `;
 
-export const SaturationPointer = styled.div`
-  width: 0.875rem;
-  height: 0.875rem;
+export const ControlsPointer = styled.div`
   border: 2px solid ${color("white")};
   border-radius: 50%;
   pointer-events: none;
+`;
+
+export const SaturationPointer = styled(ControlsPointer)`
+  width: 0.875rem;
+  height: 0.875rem;
   transform: translate(-50%, -50%);
+`;
+
+export const HuePointer = styled(ControlsPointer)`
+  width: 0.625rem;
+  height: 0.625rem;
+  transform: translate(-50%, -0.0625rem);
 `;

--- a/frontend/src/metabase/core/components/ColorPicker/ColorPicker.styled.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPicker.styled.tsx
@@ -5,7 +5,7 @@ export const TriggerContainer = styled.div`
   gap: 1rem;
 `;
 
-export const PickerContainer = styled.div`
+export const ContentContainer = styled.div`
   width: 16.5rem;
   padding: 1rem;
 `;

--- a/frontend/src/metabase/core/components/ColorPicker/ColorPicker.styled.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPicker.styled.tsx
@@ -1,5 +1,10 @@
 import styled from "@emotion/styled";
 
+export const ControlsContainer = styled.div`
+  width: 16.5rem;
+  padding: 1rem;
+`;
+
 export const SaturationContainer = styled.div`
   position: relative;
   height: 10rem;

--- a/frontend/src/metabase/core/components/ColorPicker/ColorPicker.styled.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPicker.styled.tsx
@@ -1,6 +1,11 @@
 import styled from "@emotion/styled";
 
-export const ControlsContainer = styled.div`
+export const TriggerContainer = styled.div`
+  display: flex;
+  gap: 1rem;
+`;
+
+export const PickerContainer = styled.div`
   width: 16.5rem;
   padding: 1rem;
 `;

--- a/frontend/src/metabase/core/components/ColorPicker/ColorPicker.styled.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPicker.styled.tsx
@@ -1,4 +1,5 @@
 import styled from "@emotion/styled";
+import { color } from "metabase/lib/colors";
 
 export const TriggerContainer = styled.div`
   display: flex;
@@ -22,4 +23,13 @@ export const SaturationContainer = styled.div`
 export const HueContainer = styled.div`
   position: relative;
   height: 0.625rem;
+`;
+
+export const SaturationPointer = styled.div`
+  width: 0.875rem;
+  height: 0.875rem;
+  border: 2px solid ${color("white")};
+  border-radius: 50%;
+  pointer-events: none;
+  transform: translate(-50%, -50%);
 `;

--- a/frontend/src/metabase/core/components/ColorPicker/ColorPicker.styled.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPicker.styled.tsx
@@ -1,0 +1,13 @@
+import styled from "@emotion/styled";
+
+export const SaturationContainer = styled.div`
+  position: relative;
+  height: 10rem;
+  margin-bottom: 1rem;
+`;
+
+export const HueContainer = styled.div`
+  position: relative;
+  height: 0.5rem;
+  border-radius: 0.25rem;
+`;

--- a/frontend/src/metabase/core/components/ColorPicker/ColorPicker.styled.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPicker.styled.tsx
@@ -18,5 +18,5 @@ export const SaturationContainer = styled.div`
 
 export const HueContainer = styled.div`
   position: relative;
-  height: 0.5rem;
+  height: 0.625rem;
 `;

--- a/frontend/src/metabase/core/components/ColorPicker/ColorPicker.styled.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPicker.styled.tsx
@@ -5,7 +5,7 @@ export const TriggerContainer = styled.div`
   gap: 1rem;
 `;
 
-export const ControlsContainer = styled.div`
+export const ContentContainer = styled.div`
   width: 16.5rem;
   padding: 1rem;
 `;

--- a/frontend/src/metabase/core/components/ColorPicker/ColorPicker.styled.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPicker.styled.tsx
@@ -1,19 +1,13 @@
-export const getStyles = () => ({
-  default: {
-    picker: {
-      boxShadow: "none",
-      background: "none",
-      fontFamily: "inherit",
-    },
-    body: {
-      marginTop: "16px",
-      padding: "0",
-    },
-    color: {
-      display: "none",
-    },
-    saturation: {
-      borderRadius: "4px",
-    },
-  },
-});
+import styled from "@emotion/styled";
+
+export const SaturationContainer = styled.div`
+  position: relative;
+  height: 10rem;
+  margin-bottom: 1rem;
+`;
+
+export const HueContainer = styled.div`
+  position: relative;
+  height: 0.5rem;
+  border-radius: 0.25rem;
+`;

--- a/frontend/src/metabase/core/components/ColorPicker/ColorPicker.styled.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPicker.styled.tsx
@@ -5,7 +5,7 @@ export const TriggerContainer = styled.div`
   gap: 1rem;
 `;
 
-export const ContentContainer = styled.div`
+export const ControlsContainer = styled.div`
   width: 16.5rem;
   padding: 1rem;
 `;

--- a/frontend/src/metabase/core/components/ColorPicker/ColorPicker.styled.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPicker.styled.tsx
@@ -6,6 +6,9 @@ export const TriggerContainer = styled.div`
 `;
 
 export const ContentContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
   width: 16.5rem;
   padding: 1rem;
 `;

--- a/frontend/src/metabase/core/components/ColorPicker/ColorPicker.styled.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPicker.styled.tsx
@@ -9,5 +9,4 @@ export const SaturationContainer = styled.div`
 export const HueContainer = styled.div`
   position: relative;
   height: 0.5rem;
-  border-radius: 0.25rem;
 `;

--- a/frontend/src/metabase/core/components/ColorPicker/ColorPicker.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPicker.tsx
@@ -1,24 +1,19 @@
-import React, { useCallback } from "react";
-import { ColorState, HuePicker } from "react-color";
+import React from "react";
+import {
+  ColorState,
+  CustomPicker,
+  CustomPickerInjectedProps,
+} from "react-color";
+import { Hue } from "react-color/lib/components/common";
 
-export interface ColorPickerProps {
-  color?: string;
-  onChange?: (color: string) => void;
-}
+export type ColorValue = ColorState;
 
-const ColorPicker = ({ color, onChange }: ColorPickerProps): JSX.Element => {
-  const handleChange = useCallback(
-    (state: ColorState) => {
-      onChange?.(state.hex);
-    },
-    [onChange],
-  );
-
+const ColorPicker = (props: CustomPickerInjectedProps): JSX.Element => {
   return (
     <div>
-      <HuePicker color={color} onChange={handleChange} />
+      <Hue {...props} />
     </div>
   );
 };
 
-export default ColorPicker;
+export default CustomPicker(ColorPicker);

--- a/frontend/src/metabase/core/components/ColorPicker/ColorPicker.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPicker.tsx
@@ -1,0 +1,24 @@
+import React, { useCallback } from "react";
+import { ColorState, HuePicker } from "react-color";
+
+export interface ColorPickerProps {
+  color?: string;
+  onChange?: (color: string) => void;
+}
+
+const ColorPicker = ({ color, onChange }: ColorPickerProps): JSX.Element => {
+  const handleChange = useCallback(
+    (state: ColorState) => {
+      onChange?.(state.hex);
+    },
+    [onChange],
+  );
+
+  return (
+    <div>
+      <HuePicker color={color} onChange={handleChange} />
+    </div>
+  );
+};
+
+export default ColorPicker;

--- a/frontend/src/metabase/core/components/ColorPicker/ColorPicker.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPicker.tsx
@@ -3,11 +3,16 @@ import { ChromePicker, ColorState } from "react-color";
 import { getStyles } from "./ColorPicker.styled";
 
 export interface ColorPickerProps {
+  className?: string;
   color?: string;
   onChange?: (color: string) => void;
 }
 
-const ColorPicker = ({ color, onChange }: ColorPickerProps): JSX.Element => {
+const ColorPicker = ({
+  className,
+  color,
+  onChange,
+}: ColorPickerProps): JSX.Element => {
   const handleChange = useCallback(
     (state: ColorState) => {
       onChange?.(state.hex);
@@ -17,6 +22,7 @@ const ColorPicker = ({ color, onChange }: ColorPickerProps): JSX.Element => {
 
   return (
     <ChromePicker
+      className={className}
       color={color}
       styles={getStyles()}
       disableAlpha

--- a/frontend/src/metabase/core/components/ColorPicker/ColorPicker.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPicker.tsx
@@ -1,25 +1,20 @@
-import React from "react";
-import {
-  ColorState,
-  CustomPicker,
-  CustomPickerInjectedProps,
-} from "react-color";
-import { Hue, Saturation } from "react-color/lib/components/common";
-import { HueContainer, SaturationContainer } from "./ColorPicker.styled";
+import React, { useCallback } from "react";
+import { ChromePicker, ColorState } from "react-color";
 
-export type ColorChangeEvent = ColorState;
+export interface ColorPickerProps {
+  color?: string;
+  onChange?: (color: string) => void;
+}
 
-const ColorPicker = (props: CustomPickerInjectedProps): JSX.Element => {
-  return (
-    <div>
-      <SaturationContainer>
-        <Saturation {...props} />
-      </SaturationContainer>
-      <HueContainer>
-        <Hue {...props} />
-      </HueContainer>
-    </div>
+const ColorPicker = ({ color, onChange }: ColorPickerProps): JSX.Element => {
+  const handleChange = useCallback(
+    (state: ColorState) => {
+      onChange?.(state.hex);
+    },
+    [onChange],
   );
+
+  return <ChromePicker color={color} onChange={handleChange} />;
 };
 
-export default CustomPicker(ColorPicker);
+export default ColorPicker;

--- a/frontend/src/metabase/core/components/ColorPicker/ColorPicker.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPicker.tsx
@@ -8,7 +8,7 @@ import { Hue, Saturation } from "react-color/lib/components/common";
 import ColorPill from "metabase/core/components/ColorPill";
 import TippyPopoverWithTrigger from "metabase/components/PopoverWithTrigger/TippyPopoverWithTrigger";
 import {
-  PickerContainer,
+  ContentContainer,
   HueContainer,
   SaturationContainer,
   TriggerContainer,
@@ -28,7 +28,14 @@ const ColorPicker = ({
   isSelected,
   onChange,
 }: ColorPickerProps): JSX.Element => {
-  const handleChange = useCallback(
+  const handleTriggerChange = useCallback(
+    (color?: string) => {
+      color && onChange?.(color);
+    },
+    [onChange],
+  );
+
+  const handleContentChange = useCallback(
     (state: ColorState) => {
       onChange?.(state.hex);
     },
@@ -43,11 +50,11 @@ const ColorPicker = ({
           isBordered={isBordered}
           isSelected={isSelected}
           onClick={onClick}
-          onChange={onChange}
+          onChange={handleTriggerChange}
         />
       )}
       popoverContent={
-        <ColorPickerContent color={color} onChange={handleChange} />
+        <ColorPickerContent color={color} onChange={handleContentChange} />
       }
     />
   );
@@ -58,7 +65,7 @@ interface ColorPickerTriggerProps
   color: string;
   isBordered?: boolean;
   isSelected?: boolean;
-  onChange?: (color: string) => void;
+  onChange?: (color?: string) => void;
 }
 
 const ColorPickerTrigger = forwardRef(function ColorPickerTrigger(
@@ -72,13 +79,6 @@ const ColorPickerTrigger = forwardRef(function ColorPickerTrigger(
   }: ColorPickerTriggerProps,
   ref: Ref<HTMLDivElement>,
 ) {
-  const handleChange = useCallback(
-    (color?: string) => {
-      color && onChange?.(color);
-    },
-    [onChange],
-  );
-
   return (
     <TriggerContainer {...props} ref={ref}>
       <ColorPill
@@ -87,7 +87,7 @@ const ColorPickerTrigger = forwardRef(function ColorPickerTrigger(
         isSelected={isSelected}
         onClick={onClick}
       />
-      <ColorInput color={color} onChange={handleChange} />
+      <ColorInput color={color} onChange={onChange} />
     </TriggerContainer>
   );
 });
@@ -96,14 +96,14 @@ const ColorPickerContent = CustomPicker(function ColorControls(
   props: CustomPickerInjectedProps,
 ) {
   return (
-    <PickerContainer>
+    <ContentContainer>
       <SaturationContainer>
         <Saturation {...props} />
       </SaturationContainer>
       <HueContainer>
         <Hue {...props} />
       </HueContainer>
-    </PickerContainer>
+    </ContentContainer>
   );
 });
 

--- a/frontend/src/metabase/core/components/ColorPicker/ColorPicker.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPicker.tsx
@@ -14,7 +14,23 @@ const ColorPicker = ({ color, onChange }: ColorPickerProps): JSX.Element => {
     [onChange],
   );
 
-  return <ChromePicker color={color} onChange={handleChange} />;
+  return (
+    <ChromePicker
+      color={color}
+      styles={styles}
+      disableAlpha
+      onChange={handleChange}
+    />
+  );
+};
+
+const styles = {
+  default: {
+    picker: {
+      boxShadow: "none",
+      background: "none",
+    },
+  },
 };
 
 export default ColorPicker;

--- a/frontend/src/metabase/core/components/ColorPicker/ColorPicker.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPicker.tsx
@@ -1,9 +1,14 @@
-import React from "react";
+import React, { forwardRef, HTMLAttributes, Ref } from "react";
 import TippyPopoverWithTrigger from "metabase/components/PopoverWithTrigger/TippyPopoverWithTrigger";
 import ColorPickerTrigger from "./ColorPickerTrigger";
 import ColorPickerContent from "./ColorPickerContent";
 
-export interface ColorPickerProps {
+export type ColorPickerAttributes = Omit<
+  HTMLAttributes<HTMLDivElement>,
+  "onChange"
+>;
+
+export interface ColorPickerProps extends ColorPickerAttributes {
   color: string;
   placeholder?: string;
   isBordered?: boolean;
@@ -12,19 +17,25 @@ export interface ColorPickerProps {
   onChange?: (color: string) => void;
 }
 
-const ColorPicker = ({
-  color,
-  placeholder,
-  isBordered,
-  isSelected,
-  isGenerated,
-  onChange,
-}: ColorPickerProps): JSX.Element => {
+const ColorPicker = forwardRef(function ColorPicker(
+  {
+    color,
+    placeholder,
+    isBordered,
+    isSelected,
+    isGenerated,
+    onChange,
+    ...props
+  }: ColorPickerProps,
+  ref: Ref<HTMLDivElement>,
+) {
   return (
     <TippyPopoverWithTrigger
       disableContentSandbox
       renderTrigger={({ onClick }) => (
         <ColorPickerTrigger
+          {...props}
+          ref={ref}
           color={color}
           placeholder={placeholder}
           isBordered={isBordered}
@@ -37,6 +48,6 @@ const ColorPicker = ({
       popoverContent={<ColorPickerContent color={color} onChange={onChange} />}
     />
   );
-};
+});
 
 export default ColorPicker;

--- a/frontend/src/metabase/core/components/ColorPicker/ColorPicker.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPicker.tsx
@@ -5,6 +5,7 @@ import ColorPickerContent from "./ColorPickerContent";
 
 export interface ColorPickerProps {
   color: string;
+  placeholder?: string;
   isBordered?: boolean;
   isSelected?: boolean;
   isGenerated?: boolean;
@@ -13,6 +14,7 @@ export interface ColorPickerProps {
 
 const ColorPicker = ({
   color,
+  placeholder,
   isBordered,
   isSelected,
   isGenerated,
@@ -24,6 +26,7 @@ const ColorPicker = ({
       renderTrigger={({ onClick }) => (
         <ColorPickerTrigger
           color={color}
+          placeholder={placeholder}
           isBordered={isBordered}
           isSelected={isSelected}
           isGenerated={isGenerated}

--- a/frontend/src/metabase/core/components/ColorPicker/ColorPicker.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPicker.tsx
@@ -1,18 +1,7 @@
-import React, { forwardRef, HTMLAttributes, Ref, useCallback } from "react";
-import {
-  ColorState,
-  CustomPicker,
-  CustomPickerInjectedProps,
-} from "react-color";
-import { Hue, Saturation } from "react-color/lib/components/common";
-import ColorPill from "metabase/core/components/ColorPill";
+import React from "react";
 import TippyPopoverWithTrigger from "metabase/components/PopoverWithTrigger/TippyPopoverWithTrigger";
-import {
-  HueContainer,
-  SaturationContainer,
-  TriggerContainer,
-} from "./ColorPicker.styled";
-import ColorInput from "metabase/core/components/ColorInput";
+import ColorPickerTrigger from "./ColorPickerTrigger";
+import ColorPickerContent from "./ColorPickerContent";
 
 export interface ColorPickerProps {
   color: string;
@@ -29,20 +18,6 @@ const ColorPicker = ({
   isGenerated,
   onChange,
 }: ColorPickerProps): JSX.Element => {
-  const handleTriggerChange = useCallback(
-    (color?: string) => {
-      color && onChange?.(color);
-    },
-    [onChange],
-  );
-
-  const handleContentChange = useCallback(
-    (state: ColorState) => {
-      onChange?.(state.hex);
-    },
-    [onChange],
-  );
-
   return (
     <TippyPopoverWithTrigger
       disableContentSandbox
@@ -53,64 +28,12 @@ const ColorPicker = ({
           isSelected={isSelected}
           isGenerated={isGenerated}
           onClick={onClick}
-          onChange={handleTriggerChange}
+          onChange={onChange}
         />
       )}
-      popoverContent={
-        <ColorPickerContent color={color} onChange={handleContentChange} />
-      }
+      popoverContent={<ColorPickerContent color={color} onChange={onChange} />}
     />
   );
 };
-
-interface ColorPickerTriggerProps
-  extends Omit<HTMLAttributes<HTMLDivElement>, "onChange"> {
-  color: string;
-  isBordered?: boolean;
-  isSelected?: boolean;
-  isGenerated?: boolean;
-  onChange?: (color?: string) => void;
-}
-
-const ColorPickerTrigger = forwardRef(function ColorPickerTrigger(
-  {
-    color,
-    isBordered,
-    isSelected,
-    isGenerated,
-    onClick,
-    onChange,
-    ...props
-  }: ColorPickerTriggerProps,
-  ref: Ref<HTMLDivElement>,
-) {
-  return (
-    <TriggerContainer {...props} ref={ref}>
-      <ColorPill
-        color={color}
-        isBordered={isBordered}
-        isSelected={isSelected}
-        isGenerated={isGenerated}
-        onClick={onClick}
-      />
-      <ColorInput color={color} onChange={onChange} />
-    </TriggerContainer>
-  );
-});
-
-const ColorPickerContent = CustomPicker(function ColorControls(
-  props: CustomPickerInjectedProps,
-) {
-  return (
-    <div>
-      <SaturationContainer>
-        <Saturation {...props} />
-      </SaturationContainer>
-      <HueContainer>
-        <Hue {...props} />
-      </HueContainer>
-    </div>
-  );
-});
 
 export default ColorPicker;

--- a/frontend/src/metabase/core/components/ColorPicker/ColorPicker.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPicker.tsx
@@ -4,14 +4,20 @@ import {
   CustomPicker,
   CustomPickerInjectedProps,
 } from "react-color";
-import { Hue } from "react-color/lib/components/common";
+import { Hue, Saturation } from "react-color/lib/components/common";
+import { HueContainer, SaturationContainer } from "./ColorPicker.styled";
 
 export type ColorChangeEvent = ColorState;
 
 const ColorPicker = (props: CustomPickerInjectedProps): JSX.Element => {
   return (
     <div>
-      <Hue {...props} />
+      <SaturationContainer>
+        <Saturation {...props} />
+      </SaturationContainer>
+      <HueContainer>
+        <Hue {...props} />
+      </HueContainer>
     </div>
   );
 };

--- a/frontend/src/metabase/core/components/ColorPicker/ColorPicker.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPicker.tsx
@@ -6,7 +6,7 @@ import {
 } from "react-color";
 import { Hue } from "react-color/lib/components/common";
 
-export type ColorValue = ColorState;
+export type ColorChangeEvent = ColorState;
 
 const ColorPicker = (props: CustomPickerInjectedProps): JSX.Element => {
   return (

--- a/frontend/src/metabase/core/components/ColorPicker/ColorPicker.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPicker.tsx
@@ -1,18 +1,18 @@
 import React, { useCallback } from "react";
-import { ChromePicker, ColorState } from "react-color";
-import { getStyles } from "./ColorPicker.styled";
+import {
+  ColorState,
+  CustomPicker,
+  CustomPickerInjectedProps,
+} from "react-color";
+import { Hue, Saturation } from "react-color/lib/components/common";
+import { HueContainer, SaturationContainer } from "./ColorPicker.styled";
 
 export interface ColorPickerProps {
-  className?: string;
   color?: string;
   onChange?: (color: string) => void;
 }
 
-const ColorPicker = ({
-  className,
-  color,
-  onChange,
-}: ColorPickerProps): JSX.Element => {
+const ColorPicker = ({ color, onChange }: ColorPickerProps): JSX.Element => {
   const handleChange = useCallback(
     (state: ColorState) => {
       onChange?.(state.hex);
@@ -20,15 +20,22 @@ const ColorPicker = ({
     [onChange],
   );
 
-  return (
-    <ChromePicker
-      className={className}
-      color={color}
-      styles={getStyles()}
-      disableAlpha
-      onChange={handleChange}
-    />
-  );
+  return <ColorControls color={color} onChange={handleChange} />;
 };
+
+const ColorControls = CustomPicker(function ColorControls(
+  props: CustomPickerInjectedProps,
+) {
+  return (
+    <div>
+      <SaturationContainer>
+        <Saturation {...props} />
+      </SaturationContainer>
+      <HueContainer>
+        <Hue {...props} />
+      </HueContainer>
+    </div>
+  );
+});
 
 export default ColorPicker;

--- a/frontend/src/metabase/core/components/ColorPicker/ColorPicker.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPicker.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React, { forwardRef, HTMLAttributes, Ref, useCallback } from "react";
 import {
   ColorState,
   CustomPicker,
@@ -8,10 +8,12 @@ import { Hue, Saturation } from "react-color/lib/components/common";
 import ColorPill from "metabase/core/components/ColorPill";
 import TippyPopoverWithTrigger from "metabase/components/PopoverWithTrigger/TippyPopoverWithTrigger";
 import {
-  ControlsContainer,
+  PickerContainer,
   HueContainer,
   SaturationContainer,
+  TriggerContainer,
 } from "./ColorPicker.styled";
+import ColorInput from "metabase/core/components/ColorInput";
 
 export interface ColorPickerProps {
   color: string;
@@ -36,30 +38,72 @@ const ColorPicker = ({
   return (
     <TippyPopoverWithTrigger
       renderTrigger={({ onClick }) => (
-        <ColorPill
+        <ColorPickerTrigger
           color={color}
           isBordered={isBordered}
           isSelected={isSelected}
           onClick={onClick}
+          onChange={onChange}
         />
       )}
-      popoverContent={<ColorControls color={color} onChange={handleChange} />}
+      popoverContent={
+        <ColorPickerContent color={color} onChange={handleChange} />
+      }
     />
   );
 };
 
-const ColorControls = CustomPicker(function ColorControls(
+interface ColorPickerTriggerProps
+  extends Omit<HTMLAttributes<HTMLDivElement>, "onChange"> {
+  color: string;
+  isBordered?: boolean;
+  isSelected?: boolean;
+  onChange?: (color: string) => void;
+}
+
+const ColorPickerTrigger = forwardRef(function ColorPickerTrigger(
+  {
+    color,
+    isBordered,
+    isSelected,
+    onClick,
+    onChange,
+    ...props
+  }: ColorPickerTriggerProps,
+  ref: Ref<HTMLDivElement>,
+) {
+  const handleChange = useCallback(
+    (color?: string) => {
+      color && onChange?.(color);
+    },
+    [onChange],
+  );
+
+  return (
+    <TriggerContainer {...props} ref={ref}>
+      <ColorPill
+        color={color}
+        isBordered={isBordered}
+        isSelected={isSelected}
+        onClick={onClick}
+      />
+      <ColorInput color={color} onChange={handleChange} />
+    </TriggerContainer>
+  );
+});
+
+const ColorPickerContent = CustomPicker(function ColorControls(
   props: CustomPickerInjectedProps,
 ) {
   return (
-    <ControlsContainer>
+    <PickerContainer>
       <SaturationContainer>
         <Saturation {...props} />
       </SaturationContainer>
       <HueContainer>
         <Hue {...props} />
       </HueContainer>
-    </ControlsContainer>
+    </PickerContainer>
   );
 });
 

--- a/frontend/src/metabase/core/components/ColorPicker/ColorPicker.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPicker.tsx
@@ -19,6 +19,7 @@ export interface ColorPickerProps {
   color: string;
   isBordered?: boolean;
   isSelected?: boolean;
+  isGenerated?: boolean;
   onChange?: (color: string) => void;
 }
 
@@ -26,6 +27,7 @@ const ColorPicker = ({
   color,
   isBordered,
   isSelected,
+  isGenerated,
   onChange,
 }: ColorPickerProps): JSX.Element => {
   const handleTriggerChange = useCallback(
@@ -50,6 +52,7 @@ const ColorPicker = ({
           color={color}
           isBordered={isBordered}
           isSelected={isSelected}
+          isGenerated={isGenerated}
           onClick={onClick}
           onChange={handleTriggerChange}
         />
@@ -66,6 +69,7 @@ interface ColorPickerTriggerProps
   color: string;
   isBordered?: boolean;
   isSelected?: boolean;
+  isGenerated?: boolean;
   onChange?: (color?: string) => void;
 }
 
@@ -74,6 +78,7 @@ const ColorPickerTrigger = forwardRef(function ColorPickerTrigger(
     color,
     isBordered,
     isSelected,
+    isGenerated,
     onClick,
     onChange,
     ...props
@@ -86,6 +91,7 @@ const ColorPickerTrigger = forwardRef(function ColorPickerTrigger(
         color={color}
         isBordered={isBordered}
         isSelected={isSelected}
+        isGenerated={isGenerated}
         onClick={onClick}
       />
       <ColorInput color={color} onChange={onChange} />

--- a/frontend/src/metabase/core/components/ColorPicker/ColorPicker.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPicker.tsx
@@ -8,7 +8,6 @@ import { Hue, Saturation } from "react-color/lib/components/common";
 import ColorPill from "metabase/core/components/ColorPill";
 import TippyPopoverWithTrigger from "metabase/components/PopoverWithTrigger/TippyPopoverWithTrigger";
 import {
-  ControlsContainer,
   HueContainer,
   SaturationContainer,
   TriggerContainer,
@@ -103,14 +102,14 @@ const ColorPickerContent = CustomPicker(function ColorControls(
   props: CustomPickerInjectedProps,
 ) {
   return (
-    <ControlsContainer>
+    <div>
       <SaturationContainer>
         <Saturation {...props} />
       </SaturationContainer>
       <HueContainer>
         <Hue {...props} />
       </HueContainer>
-    </ControlsContainer>
+    </div>
   );
 });
 

--- a/frontend/src/metabase/core/components/ColorPicker/ColorPicker.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPicker.tsx
@@ -44,6 +44,7 @@ const ColorPicker = ({
 
   return (
     <TippyPopoverWithTrigger
+      disableContentSandbox
       renderTrigger={({ onClick }) => (
         <ColorPickerTrigger
           color={color}

--- a/frontend/src/metabase/core/components/ColorPicker/ColorPicker.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPicker.tsx
@@ -8,7 +8,7 @@ import { Hue, Saturation } from "react-color/lib/components/common";
 import ColorPill from "metabase/core/components/ColorPill";
 import TippyPopoverWithTrigger from "metabase/components/PopoverWithTrigger/TippyPopoverWithTrigger";
 import {
-  ContentContainer,
+  ControlsContainer,
   HueContainer,
   SaturationContainer,
   TriggerContainer,
@@ -103,14 +103,14 @@ const ColorPickerContent = CustomPicker(function ColorControls(
   props: CustomPickerInjectedProps,
 ) {
   return (
-    <ContentContainer>
+    <ControlsContainer>
       <SaturationContainer>
         <Saturation {...props} />
       </SaturationContainer>
       <HueContainer>
         <Hue {...props} />
       </HueContainer>
-    </ContentContainer>
+    </ControlsContainer>
   );
 });
 

--- a/frontend/src/metabase/core/components/ColorPicker/ColorPicker.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPicker.tsx
@@ -5,10 +5,16 @@ import {
   CustomPickerInjectedProps,
 } from "react-color";
 import { Hue, Saturation } from "react-color/lib/components/common";
-import { HueContainer, SaturationContainer } from "./ColorPicker.styled";
+import ColorPill from "metabase/core/components/ColorPill";
+import TippyPopoverWithTrigger from "metabase/components/PopoverWithTrigger/TippyPopoverWithTrigger";
+import {
+  ControlsContainer,
+  HueContainer,
+  SaturationContainer,
+} from "./ColorPicker.styled";
 
 export interface ColorPickerProps {
-  color?: string;
+  color: string;
   onChange?: (color: string) => void;
 }
 
@@ -20,21 +26,28 @@ const ColorPicker = ({ color, onChange }: ColorPickerProps): JSX.Element => {
     [onChange],
   );
 
-  return <ColorControls color={color} onChange={handleChange} />;
+  return (
+    <TippyPopoverWithTrigger
+      renderTrigger={({ onClick }) => (
+        <ColorPill color={color} onClick={onClick} />
+      )}
+      popoverContent={<ColorControls color={color} onChange={handleChange} />}
+    />
+  );
 };
 
 const ColorControls = CustomPicker(function ColorControls(
   props: CustomPickerInjectedProps,
 ) {
   return (
-    <div>
+    <ControlsContainer>
       <SaturationContainer>
         <Saturation {...props} />
       </SaturationContainer>
       <HueContainer>
         <Hue {...props} />
       </HueContainer>
-    </div>
+    </ControlsContainer>
   );
 });
 

--- a/frontend/src/metabase/core/components/ColorPicker/ColorPicker.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPicker.tsx
@@ -15,10 +15,17 @@ import {
 
 export interface ColorPickerProps {
   color: string;
+  isBordered?: boolean;
+  isSelected?: boolean;
   onChange?: (color: string) => void;
 }
 
-const ColorPicker = ({ color, onChange }: ColorPickerProps): JSX.Element => {
+const ColorPicker = ({
+  color,
+  isBordered,
+  isSelected,
+  onChange,
+}: ColorPickerProps): JSX.Element => {
   const handleChange = useCallback(
     (state: ColorState) => {
       onChange?.(state.hex);
@@ -29,7 +36,12 @@ const ColorPicker = ({ color, onChange }: ColorPickerProps): JSX.Element => {
   return (
     <TippyPopoverWithTrigger
       renderTrigger={({ onClick }) => (
-        <ColorPill color={color} onClick={onClick} />
+        <ColorPill
+          color={color}
+          isBordered={isBordered}
+          isSelected={isSelected}
+          onClick={onClick}
+        />
       )}
       popoverContent={<ColorControls color={color} onChange={handleChange} />}
     />

--- a/frontend/src/metabase/core/components/ColorPicker/ColorPicker.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPicker.tsx
@@ -29,6 +29,17 @@ const styles = {
     picker: {
       boxShadow: "none",
       background: "none",
+      fontFamily: "inherit",
+    },
+    body: {
+      marginTop: "16px",
+      padding: "0",
+    },
+    color: {
+      display: "none",
+    },
+    saturation: {
+      borderRadius: "4px",
     },
   },
 };

--- a/frontend/src/metabase/core/components/ColorPicker/ColorPicker.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPicker.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback } from "react";
 import { ChromePicker, ColorState } from "react-color";
+import { getStyles } from "./ColorPicker.styled";
 
 export interface ColorPickerProps {
   color?: string;
@@ -17,31 +18,11 @@ const ColorPicker = ({ color, onChange }: ColorPickerProps): JSX.Element => {
   return (
     <ChromePicker
       color={color}
-      styles={styles}
+      styles={getStyles()}
       disableAlpha
       onChange={handleChange}
     />
   );
-};
-
-const styles = {
-  default: {
-    picker: {
-      boxShadow: "none",
-      background: "none",
-      fontFamily: "inherit",
-    },
-    body: {
-      marginTop: "16px",
-      padding: "0",
-    },
-    color: {
-      display: "none",
-    },
-    saturation: {
-      borderRadius: "4px",
-    },
-  },
 };
 
 export default ColorPicker;

--- a/frontend/src/metabase/core/components/ColorPicker/ColorPicker.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPicker.unit.spec.tsx
@@ -1,0 +1,36 @@
+import React, { useState } from "react";
+import Color from "color";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ColorPicker from "./ColorPicker";
+
+const TestColorPicker = () => {
+  const [color, setColor] = useState("white");
+  return <ColorPicker color={color} onChange={setColor} />;
+};
+
+describe("ColorPicker", () => {
+  it("should input a color inline", () => {
+    render(<TestColorPicker />);
+
+    const color = Color.rgb(0, 0, 0);
+    const input = screen.getByRole("textbox");
+    userEvent.clear(input);
+    userEvent.type(input, color.hex());
+
+    expect(screen.getByLabelText(color.hex())).toBeInTheDocument();
+  });
+
+  it("should input a color in a popover", async () => {
+    render(<TestColorPicker />);
+    userEvent.click(screen.getByLabelText("white"));
+
+    const color = Color.rgb(0, 0, 0);
+    const tooltip = await screen.findByRole("tooltip");
+    const input = within(tooltip).getByRole("textbox");
+    userEvent.clear(input);
+    userEvent.type(input, color.hex());
+
+    expect(screen.getByLabelText(color.hex())).toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/core/components/ColorPicker/ColorPickerContent.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPickerContent.tsx
@@ -1,0 +1,1 @@
+import React from "react";

--- a/frontend/src/metabase/core/components/ColorPicker/ColorPickerContent.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPickerContent.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback } from "react";
 import { ColorState } from "react-color";
+import ColorInput from "metabase/core/components/ColorInput";
 import ColorPickerControls from "./ColorPickerControls";
 import { ContentContainer } from "./ColorPicker.styled";
 
@@ -12,14 +13,20 @@ const ColorPickerContent = ({
   color,
   onChange,
 }: ColorPickerContentProps): JSX.Element => {
-  const handleChange = useCallback(
+  const handleInputChange = useCallback(
+    (color?: string) => color && onChange?.(color),
+    [onChange],
+  );
+
+  const handleControlsChange = useCallback(
     (state: ColorState) => onChange?.(state.hex),
     [onChange],
   );
 
   return (
     <ContentContainer>
-      <ColorPickerControls color={color} onChange={handleChange} />
+      <ColorPickerControls color={color} onChange={handleControlsChange} />
+      <ColorInput color={color} fullWidth onChange={handleInputChange} />
     </ContentContainer>
   );
 };

--- a/frontend/src/metabase/core/components/ColorPicker/ColorPickerContent.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPickerContent.tsx
@@ -1,18 +1,23 @@
-import React, { useCallback } from "react";
+import React, { forwardRef, HTMLAttributes, Ref, useCallback } from "react";
 import { ColorState } from "react-color";
 import ColorInput from "metabase/core/components/ColorInput";
 import ColorPickerControls from "./ColorPickerControls";
 import { ContentContainer } from "./ColorPicker.styled";
 
-export interface ColorPickerContentProps {
+export type ColorPickerContentAttributes = Omit<
+  HTMLAttributes<HTMLDivElement>,
+  "onChange"
+>;
+
+export interface ColorPickerContentProps extends ColorPickerContentAttributes {
   color?: string;
   onChange?: (color: string) => void;
 }
 
-const ColorPickerContent = ({
-  color,
-  onChange,
-}: ColorPickerContentProps): JSX.Element => {
+const ColorPickerContent = forwardRef(function ColorPickerContent(
+  { color, onChange, ...props }: ColorPickerContentProps,
+  ref: Ref<HTMLDivElement>,
+) {
   const handleInputChange = useCallback(
     (color?: string) => color && onChange?.(color),
     [onChange],
@@ -24,11 +29,11 @@ const ColorPickerContent = ({
   );
 
   return (
-    <ContentContainer>
+    <ContentContainer {...props} ref={ref}>
       <ColorPickerControls color={color} onChange={handleControlsChange} />
       <ColorInput color={color} fullWidth onChange={handleInputChange} />
     </ContentContainer>
   );
-};
+});
 
 export default ColorPickerContent;

--- a/frontend/src/metabase/core/components/ColorPicker/ColorPickerContent.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPickerContent.tsx
@@ -18,20 +18,20 @@ const ColorPickerContent = forwardRef(function ColorPickerContent(
   { color, onChange, ...props }: ColorPickerContentProps,
   ref: Ref<HTMLDivElement>,
 ) {
-  const handleInputChange = useCallback(
+  const handleColorChange = useCallback(
     (color?: string) => color && onChange?.(color),
     [onChange],
   );
 
-  const handleControlsChange = useCallback(
+  const handleColorStateChange = useCallback(
     (state: ColorState) => onChange?.(state.hex),
     [onChange],
   );
 
   return (
     <ContentContainer {...props} ref={ref}>
-      <ColorPickerControls color={color} onChange={handleControlsChange} />
-      <ColorInput color={color} fullWidth onChange={handleInputChange} />
+      <ColorPickerControls color={color} onChange={handleColorStateChange} />
+      <ColorInput color={color} fullWidth onChange={handleColorChange} />
     </ContentContainer>
   );
 });

--- a/frontend/src/metabase/core/components/ColorPicker/ColorPickerContent.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPickerContent.tsx
@@ -1,1 +1,27 @@
-import React from "react";
+import React, { useCallback } from "react";
+import { ColorState } from "react-color";
+import ColorPickerControls from "./ColorPickerControls";
+import { ContentContainer } from "./ColorPicker.styled";
+
+export interface ColorPickerContentProps {
+  color?: string;
+  onChange?: (color: string) => void;
+}
+
+const ColorPickerContent = ({
+  color,
+  onChange,
+}: ColorPickerContentProps): JSX.Element => {
+  const handleChange = useCallback(
+    (state: ColorState) => onChange?.(state.hex),
+    [onChange],
+  );
+
+  return (
+    <ContentContainer>
+      <ColorPickerControls color={color} onChange={handleChange} />
+    </ContentContainer>
+  );
+};
+
+export default ColorPickerContent;

--- a/frontend/src/metabase/core/components/ColorPicker/ColorPickerControls.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPickerControls.tsx
@@ -1,24 +1,20 @@
 import React from "react";
 import { CustomPicker, CustomPickerInjectedProps } from "react-color";
 import { Hue, Saturation } from "react-color/lib/components/common";
-import {
-  ControlsContainer,
-  HueContainer,
-  SaturationContainer,
-} from "./ColorPicker.styled";
+import { HueContainer, SaturationContainer } from "./ColorPicker.styled";
 
 const ColorPickerControls = CustomPicker(function ColorControls(
   props: CustomPickerInjectedProps,
 ) {
   return (
-    <ControlsContainer>
+    <div>
       <SaturationContainer>
         <Saturation {...props} />
       </SaturationContainer>
       <HueContainer>
         <Hue {...props} />
       </HueContainer>
-    </ControlsContainer>
+    </div>
   );
 });
 

--- a/frontend/src/metabase/core/components/ColorPicker/ColorPickerControls.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPickerControls.tsx
@@ -1,7 +1,11 @@
 import React from "react";
 import { CustomPicker, CustomPickerInjectedProps } from "react-color";
 import { Hue, Saturation } from "react-color/lib/components/common";
-import { HueContainer, SaturationContainer } from "./ColorPicker.styled";
+import {
+  HueContainer,
+  SaturationContainer,
+  SaturationPointer,
+} from "./ColorPicker.styled";
 
 const ColorPickerControls = CustomPicker(function ColorControls(
   props: CustomPickerInjectedProps,
@@ -9,7 +13,7 @@ const ColorPickerControls = CustomPicker(function ColorControls(
   return (
     <div>
       <SaturationContainer>
-        <Saturation {...props} />
+        <Saturation {...props} pointer={SaturationPointer} />
       </SaturationContainer>
       <HueContainer>
         <Hue {...props} />

--- a/frontend/src/metabase/core/components/ColorPicker/ColorPickerControls.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPickerControls.tsx
@@ -3,9 +3,17 @@ import { CustomPicker, CustomPickerInjectedProps } from "react-color";
 import { Hue, Saturation } from "react-color/lib/components/common";
 import {
   HueContainer,
+  HuePointer,
   SaturationContainer,
   SaturationPointer,
 } from "./ColorPicker.styled";
+
+const saturationStyles = {
+  color: {
+    borderTopLeftRadius: "5px",
+    borderBottomRightRadius: "5px",
+  },
+};
 
 const ColorPickerControls = CustomPicker(function ColorControls(
   props: CustomPickerInjectedProps,
@@ -13,10 +21,14 @@ const ColorPickerControls = CustomPicker(function ColorControls(
   return (
     <div>
       <SaturationContainer>
-        <Saturation {...props} pointer={SaturationPointer} />
+        <Saturation
+          {...props}
+          pointer={SaturationPointer}
+          style={saturationStyles}
+        />
       </SaturationContainer>
       <HueContainer>
-        <Hue {...props} />
+        <Hue {...props} pointer={HuePointer} />
       </HueContainer>
     </div>
   );

--- a/frontend/src/metabase/core/components/ColorPicker/ColorPickerControls.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPickerControls.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { CustomPicker, CustomPickerInjectedProps } from "react-color";
+import { Hue, Saturation } from "react-color/lib/components/common";
+import {
+  ControlsContainer,
+  HueContainer,
+  SaturationContainer,
+} from "./ColorPicker.styled";
+
+const ColorPickerControls = CustomPicker(function ColorControls(
+  props: CustomPickerInjectedProps,
+) {
+  return (
+    <ControlsContainer>
+      <SaturationContainer>
+        <Saturation {...props} />
+      </SaturationContainer>
+      <HueContainer>
+        <Hue {...props} />
+      </HueContainer>
+    </ControlsContainer>
+  );
+});
+
+export default ColorPickerControls;

--- a/frontend/src/metabase/core/components/ColorPicker/ColorPickerTrigger.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPickerTrigger.tsx
@@ -6,6 +6,7 @@ import { TriggerContainer } from "./ColorPicker.styled";
 export interface ColorPickerTriggerProps
   extends Omit<HTMLAttributes<HTMLDivElement>, "onChange"> {
   color: string;
+  placeholder?: string;
   isBordered?: boolean;
   isSelected?: boolean;
   isGenerated?: boolean;
@@ -15,6 +16,7 @@ export interface ColorPickerTriggerProps
 const ColorPickerTrigger = forwardRef(function ColorPickerTrigger(
   {
     color,
+    placeholder,
     isBordered,
     isSelected,
     isGenerated,
@@ -38,7 +40,11 @@ const ColorPickerTrigger = forwardRef(function ColorPickerTrigger(
         isGenerated={isGenerated}
         onClick={onClick}
       />
-      <ColorInput color={color} onChange={handleChange} />
+      <ColorInput
+        color={color}
+        placeholder={placeholder}
+        onChange={handleChange}
+      />
     </TriggerContainer>
   );
 });

--- a/frontend/src/metabase/core/components/ColorPicker/ColorPickerTrigger.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPickerTrigger.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, HTMLAttributes, Ref } from "react";
+import React, { forwardRef, HTMLAttributes, Ref, useCallback } from "react";
 import ColorPill from "metabase/core/components/ColorPill";
 import ColorInput from "metabase/core/components/ColorInput";
 import { TriggerContainer } from "./ColorPicker.styled";
@@ -9,7 +9,7 @@ export interface ColorPickerTriggerProps
   isBordered?: boolean;
   isSelected?: boolean;
   isGenerated?: boolean;
-  onChange?: (color?: string) => void;
+  onChange?: (color: string) => void;
 }
 
 const ColorPickerTrigger = forwardRef(function ColorPickerTrigger(
@@ -24,6 +24,13 @@ const ColorPickerTrigger = forwardRef(function ColorPickerTrigger(
   }: ColorPickerTriggerProps,
   ref: Ref<HTMLDivElement>,
 ) {
+  const handleChange = useCallback(
+    (color?: string) => {
+      color && onChange?.(color);
+    },
+    [onChange],
+  );
+
   return (
     <TriggerContainer {...props} ref={ref}>
       <ColorPill
@@ -33,7 +40,7 @@ const ColorPickerTrigger = forwardRef(function ColorPickerTrigger(
         isGenerated={isGenerated}
         onClick={onClick}
       />
-      <ColorInput color={color} onChange={onChange} />
+      <ColorInput color={color} onChange={handleChange} />
     </TriggerContainer>
   );
 });

--- a/frontend/src/metabase/core/components/ColorPicker/ColorPickerTrigger.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPickerTrigger.tsx
@@ -1,0 +1,41 @@
+import React, { forwardRef, HTMLAttributes, Ref } from "react";
+import ColorPill from "metabase/core/components/ColorPill";
+import ColorInput from "metabase/core/components/ColorInput";
+import { TriggerContainer } from "./ColorPicker.styled";
+
+export interface ColorPickerTriggerProps
+  extends Omit<HTMLAttributes<HTMLDivElement>, "onChange"> {
+  color: string;
+  isBordered?: boolean;
+  isSelected?: boolean;
+  isGenerated?: boolean;
+  onChange?: (color?: string) => void;
+}
+
+const ColorPickerTrigger = forwardRef(function ColorPickerTrigger(
+  {
+    color,
+    isBordered,
+    isSelected,
+    isGenerated,
+    onClick,
+    onChange,
+    ...props
+  }: ColorPickerTriggerProps,
+  ref: Ref<HTMLDivElement>,
+) {
+  return (
+    <TriggerContainer {...props} ref={ref}>
+      <ColorPill
+        color={color}
+        isBordered={isBordered}
+        isSelected={isSelected}
+        isGenerated={isGenerated}
+        onClick={onClick}
+      />
+      <ColorInput color={color} onChange={onChange} />
+    </TriggerContainer>
+  );
+});
+
+export default ColorPickerTrigger;

--- a/frontend/src/metabase/core/components/ColorPicker/ColorPickerTrigger.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPickerTrigger.tsx
@@ -25,9 +25,7 @@ const ColorPickerTrigger = forwardRef(function ColorPickerTrigger(
   ref: Ref<HTMLDivElement>,
 ) {
   const handleChange = useCallback(
-    (color?: string) => {
-      color && onChange?.(color);
-    },
+    (color?: string) => color && onChange?.(color),
     [onChange],
   );
 

--- a/frontend/src/metabase/core/components/ColorPicker/index.ts
+++ b/frontend/src/metabase/core/components/ColorPicker/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ColorPicker";

--- a/frontend/src/metabase/core/components/ColorPicker/index.ts
+++ b/frontend/src/metabase/core/components/ColorPicker/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./ColorPicker";
+export * from "./ColorPicker";

--- a/frontend/src/metabase/core/components/ColorPicker/index.ts
+++ b/frontend/src/metabase/core/components/ColorPicker/index.ts
@@ -1,1 +1,1 @@
-export * from "./ColorPicker";
+export { default } from "./ColorPicker";

--- a/frontend/src/metabase/core/components/ColorPill/ColorPill.stories.tsx
+++ b/frontend/src/metabase/core/components/ColorPill/ColorPill.stories.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { ComponentStory } from "@storybook/react";
+import ColorPill from "./ColorPill";
+
+export default {
+  title: "Core/ColorPill",
+  component: ColorPill,
+};
+
+const Template: ComponentStory<typeof ColorPill> = args => {
+  return <ColorPill {...args} />;
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  color: "white",
+};

--- a/frontend/src/metabase/core/components/ColorPill/ColorPill.stories.tsx
+++ b/frontend/src/metabase/core/components/ColorPill/ColorPill.stories.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { ComponentStory } from "@storybook/react";
+import { color } from "metabase/lib/colors";
 import ColorPill from "./ColorPill";
 
 export default {
@@ -13,5 +14,5 @@ const Template: ComponentStory<typeof ColorPill> = args => {
 
 export const Default = Template.bind({});
 Default.args = {
-  color: "white",
+  color: color("brand"),
 };

--- a/frontend/src/metabase/core/components/ColorPill/ColorPill.styled.tsx
+++ b/frontend/src/metabase/core/components/ColorPill/ColorPill.styled.tsx
@@ -1,0 +1,31 @@
+import styled from "@emotion/styled";
+import { color } from "metabase/lib/colors";
+
+export interface ColorPillRootProps {
+  isBordered?: boolean;
+  isSelected?: boolean;
+  isGenerated?: boolean;
+}
+
+export const ColorPillRoot = styled.div<ColorPillRootProps>`
+  display: inline-block;
+  width: 2rem;
+  height: 2rem;
+  padding: ${props => props.isBordered && "0.1875rem"};
+  border-width: ${props => (props.isBordered ? "0.0625rem" : "0")};
+  border-color: ${props =>
+    props.isSelected ? color("border") : "transparent"};
+  border-style: ${props => (props.isGenerated ? "dashed" : "solid")};
+  border-radius: 50%;
+  cursor: pointer;
+`;
+
+export interface ColorPillContentProps {
+  isBordered?: boolean;
+}
+
+export const ColorPillContent = styled.div<ColorPillContentProps>`
+  width: ${props => (props.isBordered ? "1.5rem" : "2rem")};
+  height: ${props => (props.isBordered ? "1.5rem" : "2rem")};
+  border-radius: 50%;
+`;

--- a/frontend/src/metabase/core/components/ColorPill/ColorPill.tsx
+++ b/frontend/src/metabase/core/components/ColorPill/ColorPill.tsx
@@ -1,21 +1,21 @@
-import React from "react";
+import React, { forwardRef, HTMLAttributes, Ref } from "react";
 import { ColorPillContent, ColorPillRoot } from "./ColorPill.styled";
 
-export interface ColorPillProps {
+export interface ColorPillProps extends HTMLAttributes<HTMLDivElement> {
   color?: string;
   isBordered?: boolean;
   isSelected?: boolean;
   isGenerated?: boolean;
 }
 
-const ColorPill = ({
-  color,
-  isBordered,
-  isSelected,
-  isGenerated,
-}: ColorPillProps): JSX.Element => {
+const ColorPill = forwardRef(function ColorPill(
+  { color, isBordered, isSelected, isGenerated, ...props }: ColorPillProps,
+  ref: Ref<HTMLDivElement>,
+) {
   return (
     <ColorPillRoot
+      {...props}
+      ref={ref}
       isBordered={isBordered}
       isSelected={isSelected}
       isGenerated={isGenerated}
@@ -26,6 +26,6 @@ const ColorPill = ({
       />
     </ColorPillRoot>
   );
-};
+});
 
 export default ColorPill;

--- a/frontend/src/metabase/core/components/ColorPill/ColorPill.tsx
+++ b/frontend/src/metabase/core/components/ColorPill/ColorPill.tsx
@@ -2,7 +2,7 @@ import React, { forwardRef, HTMLAttributes, Ref } from "react";
 import { ColorPillContent, ColorPillRoot } from "./ColorPill.styled";
 
 export interface ColorPillProps extends HTMLAttributes<HTMLDivElement> {
-  color?: string;
+  color: string;
   isBordered?: boolean;
   isSelected?: boolean;
   isGenerated?: boolean;

--- a/frontend/src/metabase/core/components/ColorPill/ColorPill.tsx
+++ b/frontend/src/metabase/core/components/ColorPill/ColorPill.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { ColorPillContent, ColorPillRoot } from "./ColorPill.styled";
+
+export interface ColorPillProps {
+  color?: string;
+  isBordered?: boolean;
+  isSelected?: boolean;
+  isGenerated?: boolean;
+}
+
+const ColorPill = ({
+  color,
+  isBordered,
+  isSelected,
+  isGenerated,
+}: ColorPillProps): JSX.Element => {
+  return (
+    <ColorPillRoot
+      isBordered={isBordered}
+      isSelected={isSelected}
+      isGenerated={isGenerated}
+    >
+      <ColorPillContent
+        isBordered={isBordered}
+        style={{ backgroundColor: color }}
+      />
+    </ColorPillRoot>
+  );
+};
+
+export default ColorPill;

--- a/frontend/src/metabase/core/components/ColorPill/ColorPill.tsx
+++ b/frontend/src/metabase/core/components/ColorPill/ColorPill.tsx
@@ -9,7 +9,14 @@ export interface ColorPillProps extends HTMLAttributes<HTMLDivElement> {
 }
 
 const ColorPill = forwardRef(function ColorPill(
-  { color, isBordered, isSelected, isGenerated, ...props }: ColorPillProps,
+  {
+    color,
+    isBordered,
+    isSelected,
+    isGenerated,
+    "aria-label": ariaLabel = color,
+    ...props
+  }: ColorPillProps,
   ref: Ref<HTMLDivElement>,
 ) {
   return (
@@ -19,6 +26,7 @@ const ColorPill = forwardRef(function ColorPill(
       isBordered={isBordered}
       isSelected={isSelected}
       isGenerated={isGenerated}
+      aria-label={ariaLabel}
     >
       <ColorPillContent
         isBordered={isBordered}

--- a/frontend/src/metabase/core/components/ColorPill/index.ts
+++ b/frontend/src/metabase/core/components/ColorPill/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ColorPill";

--- a/frontend/src/metabase/core/components/ColorSelector/ColorSelector.stories.tsx
+++ b/frontend/src/metabase/core/components/ColorSelector/ColorSelector.stories.tsx
@@ -2,24 +2,25 @@ import React from "react";
 import { ComponentStory } from "@storybook/react";
 import { useArgs } from "@storybook/client-api";
 import { color } from "metabase/lib/colors";
-import ColorPicker from "./ColorPicker";
+import ColorSelector from "./ColorSelector";
 
 export default {
-  title: "Core/ColorPicker",
-  component: ColorPicker,
+  title: "Core/ColorSelector",
+  component: ColorSelector,
 };
 
-const Template: ComponentStory<typeof ColorPicker> = args => {
+const Template: ComponentStory<typeof ColorSelector> = args => {
   const [{ color }, updateArgs] = useArgs();
 
   const handleChange = (color: string) => {
     updateArgs({ color });
   };
 
-  return <ColorPicker {...args} color={color} onChange={handleChange} />;
+  return <ColorSelector {...args} color={color} onChange={handleChange} />;
 };
 
 export const Default = Template.bind({});
 Default.args = {
   color: color("brand"),
+  colors: [color("brand"), color("summarize"), color("filter")],
 };

--- a/frontend/src/metabase/core/components/ColorSelector/ColorSelector.stories.tsx
+++ b/frontend/src/metabase/core/components/ColorSelector/ColorSelector.stories.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { ComponentStory } from "@storybook/react";
 import { useArgs } from "@storybook/client-api";
 import { color } from "metabase/lib/colors";
-import ColorSelector from "./ColorSelector";
+import ColorSelector from "./ColorSelectorContent";
 
 export default {
   title: "Core/ColorSelector",

--- a/frontend/src/metabase/core/components/ColorSelector/ColorSelector.stories.tsx
+++ b/frontend/src/metabase/core/components/ColorSelector/ColorSelector.stories.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { ComponentStory } from "@storybook/react";
 import { useArgs } from "@storybook/client-api";
 import { color } from "metabase/lib/colors";
-import ColorSelector from "./ColorSelectorContent";
+import ColorSelector from "./ColorSelector";
 
 export default {
   title: "Core/ColorSelector",

--- a/frontend/src/metabase/core/components/ColorSelector/ColorSelector.styled.tsx
+++ b/frontend/src/metabase/core/components/ColorSelector/ColorSelector.styled.tsx
@@ -1,10 +1,10 @@
 import styled from "@emotion/styled";
 
-export interface ColorListProps {
+export interface ColorSelectorProps {
   colors: string[];
 }
 
-export const ColorList = styled.div<ColorListProps>`
+export const ColorSelectorRoot = styled.div<ColorSelectorProps>`
   display: flex;
   flex-wrap: wrap;
   gap: 0.25rem;

--- a/frontend/src/metabase/core/components/ColorSelector/ColorSelector.styled.tsx
+++ b/frontend/src/metabase/core/components/ColorSelector/ColorSelector.styled.tsx
@@ -1,0 +1,7 @@
+import styled from "@emotion/styled";
+
+export const ColorSelectorRoot = styled.div`
+  display: grid;
+  grid-template-columns: repeat(9, min-content);
+  gap: 0.25rem;
+`;

--- a/frontend/src/metabase/core/components/ColorSelector/ColorSelector.styled.tsx
+++ b/frontend/src/metabase/core/components/ColorSelector/ColorSelector.styled.tsx
@@ -1,8 +1,12 @@
 import styled from "@emotion/styled";
 
-export const ColorGrid = styled.div`
-  display: grid;
-  grid-template-columns: repeat(9, min-content);
+export interface ColorGridProps {
+  colors: string[];
+}
+
+export const ColorGrid = styled.div<ColorGridProps>`
+  display: flex;
+  flex-wrap: wrap;
   gap: 0.25rem;
-  padding: 0.25rem;
+  padding: 0.75rem;
 `;

--- a/frontend/src/metabase/core/components/ColorSelector/ColorSelector.styled.tsx
+++ b/frontend/src/metabase/core/components/ColorSelector/ColorSelector.styled.tsx
@@ -1,7 +1,8 @@
 import styled from "@emotion/styled";
 
-export const ColorSelectorRoot = styled.div`
+export const ColorGrid = styled.div`
   display: grid;
   grid-template-columns: repeat(9, min-content);
   gap: 0.25rem;
+  padding: 0.25rem;
 `;

--- a/frontend/src/metabase/core/components/ColorSelector/ColorSelector.styled.tsx
+++ b/frontend/src/metabase/core/components/ColorSelector/ColorSelector.styled.tsx
@@ -4,9 +4,10 @@ export interface ColorGridProps {
   colors: string[];
 }
 
-export const ColorGrid = styled.div<ColorGridProps>`
+export const ColorSelectorContent = styled.div<ColorGridProps>`
   display: flex;
   flex-wrap: wrap;
   gap: 0.25rem;
   padding: 0.75rem;
+  max-width: 21.5rem;
 `;

--- a/frontend/src/metabase/core/components/ColorSelector/ColorSelector.styled.tsx
+++ b/frontend/src/metabase/core/components/ColorSelector/ColorSelector.styled.tsx
@@ -1,10 +1,10 @@
 import styled from "@emotion/styled";
 
-export interface ColorGridProps {
+export interface ColorListProps {
   colors: string[];
 }
 
-export const ColorSelectorContent = styled.div<ColorGridProps>`
+export const ColorList = styled.div<ColorListProps>`
   display: flex;
   flex-wrap: wrap;
   gap: 0.25rem;

--- a/frontend/src/metabase/core/components/ColorSelector/ColorSelector.tsx
+++ b/frontend/src/metabase/core/components/ColorSelector/ColorSelector.tsx
@@ -6,18 +6,27 @@ import { ColorList } from "./ColorSelector.styled";
 export interface ColorSelectorProps {
   color: string;
   colors: string[];
+  isBordered?: boolean;
+  isSelected?: boolean;
   onChange: (color: string) => void;
 }
 
 const ColorSelector = ({
   color,
   colors,
+  isBordered,
+  isSelected,
   onChange,
 }: ColorSelectorProps): JSX.Element => {
   return (
     <TippyPopoverWithTrigger
       renderTrigger={({ onClick }) => (
-        <ColorPill color={color} isBordered isSelected onClick={onClick} />
+        <ColorPill
+          color={color}
+          isBordered={isBordered}
+          isSelected={isSelected}
+          onClick={onClick}
+        />
       )}
       popoverContent={
         <ColorList colors={colors}>

--- a/frontend/src/metabase/core/components/ColorSelector/ColorSelector.tsx
+++ b/frontend/src/metabase/core/components/ColorSelector/ColorSelector.tsx
@@ -1,9 +1,14 @@
-import React from "react";
+import React, { forwardRef, HTMLAttributes, Ref } from "react";
 import ColorPill from "metabase/core/components/ColorPill";
 import TippyPopoverWithTrigger from "metabase/components/PopoverWithTrigger/TippyPopoverWithTrigger";
 import ColorSelectorContent from "./ColorSelectorContent";
 
-export interface ColorSelectorProps {
+export type ColorSelectorAttributes = Omit<
+  HTMLAttributes<HTMLDivElement>,
+  "onChange"
+>;
+
+export interface ColorSelectorProps extends ColorSelectorAttributes {
   color: string;
   colors: string[];
   isBordered?: boolean;
@@ -11,17 +16,23 @@ export interface ColorSelectorProps {
   onChange?: (color: string) => void;
 }
 
-const ColorSelector = ({
-  color,
-  colors,
-  isBordered,
-  isSelected,
-  onChange,
-}: ColorSelectorProps): JSX.Element => {
+const ColorSelector = forwardRef(function ColorSelector(
+  {
+    color,
+    colors,
+    isBordered,
+    isSelected,
+    onChange,
+    ...props
+  }: ColorSelectorProps,
+  ref: Ref<HTMLDivElement>,
+) {
   return (
     <TippyPopoverWithTrigger
       renderTrigger={({ onClick }) => (
         <ColorPill
+          {...props}
+          ref={ref}
           color={color}
           isBordered={isBordered}
           isSelected={isSelected}
@@ -37,6 +48,6 @@ const ColorSelector = ({
       }
     />
   );
-};
+});
 
 export default ColorSelector;

--- a/frontend/src/metabase/core/components/ColorSelector/ColorSelector.tsx
+++ b/frontend/src/metabase/core/components/ColorSelector/ColorSelector.tsx
@@ -1,31 +1,42 @@
-import React, { forwardRef, HTMLAttributes, Ref } from "react";
+import React from "react";
 import ColorPill from "metabase/core/components/ColorPill";
-import { ColorSelectorRoot } from "./ColorSelector.styled";
+import TippyPopoverWithTrigger from "metabase/components/PopoverWithTrigger/TippyPopoverWithTrigger";
+import ColorSelectorContent from "./ColorSelectorContent";
 
-export interface ColorSelectorProps
-  extends Omit<HTMLAttributes<HTMLDivElement>, "onChange"> {
+export interface ColorSelectorProps {
   color: string;
   colors: string[];
-  onChange: (color: string) => void;
+  isBordered?: boolean;
+  isSelected?: boolean;
+  onChange?: (color: string) => void;
 }
 
-const ColorSelector = forwardRef(function ColorSelector(
-  { color, colors, onChange, ...props }: ColorSelectorProps,
-  ref: Ref<HTMLDivElement>,
-) {
+const ColorSelector = ({
+  color,
+  colors,
+  isBordered,
+  isSelected,
+  onChange,
+}: ColorSelectorProps): JSX.Element => {
   return (
-    <ColorSelectorRoot {...props} ref={ref} colors={colors}>
-      {colors.map((option, index) => (
+    <TippyPopoverWithTrigger
+      renderTrigger={({ onClick }) => (
         <ColorPill
-          key={index}
-          color={option}
-          isBordered
-          isSelected={color === option}
-          onClick={() => onChange(option)}
+          color={color}
+          isBordered={isBordered}
+          isSelected={isSelected}
+          onClick={onClick}
         />
-      ))}
-    </ColorSelectorRoot>
+      )}
+      popoverContent={
+        <ColorSelectorContent
+          color={color}
+          colors={colors}
+          onChange={onChange}
+        />
+      }
+    />
   );
-});
+};
 
 export default ColorSelector;

--- a/frontend/src/metabase/core/components/ColorSelector/ColorSelector.tsx
+++ b/frontend/src/metabase/core/components/ColorSelector/ColorSelector.tsx
@@ -1,4 +1,6 @@
 import React from "react";
+import ColorPill from "../ColorPill";
+import { ColorSelectorRoot } from "./ColorSelector.styled";
 
 export interface ColorSelectorProps {
   color?: string;
@@ -6,8 +8,24 @@ export interface ColorSelectorProps {
   onChange: (color: string) => void;
 }
 
-const ColorSelector = (): JSX.Element => {
-  return <div />;
+const ColorSelector = ({
+  color,
+  colors,
+  onChange,
+}: ColorSelectorProps): JSX.Element => {
+  return (
+    <ColorSelectorRoot>
+      {colors.map((option, index) => (
+        <ColorPill
+          key={index}
+          color={option}
+          isBordered
+          isSelected={color === option}
+          onClick={() => onChange(option)}
+        />
+      ))}
+    </ColorSelectorRoot>
+  );
 };
 
 export default ColorSelector;

--- a/frontend/src/metabase/core/components/ColorSelector/ColorSelector.tsx
+++ b/frontend/src/metabase/core/components/ColorSelector/ColorSelector.tsx
@@ -1,48 +1,31 @@
-import React from "react";
+import React, { forwardRef, HTMLAttributes, Ref } from "react";
 import ColorPill from "metabase/core/components/ColorPill";
-import TippyPopoverWithTrigger from "metabase/components/PopoverWithTrigger/TippyPopoverWithTrigger";
-import { ColorList } from "./ColorSelector.styled";
+import { ColorSelectorRoot } from "./ColorSelector.styled";
 
-export interface ColorSelectorProps {
+export interface ColorSelectorProps
+  extends Omit<HTMLAttributes<HTMLDivElement>, "onChange"> {
   color: string;
   colors: string[];
-  isBordered?: boolean;
-  isSelected?: boolean;
   onChange: (color: string) => void;
 }
 
-const ColorSelector = ({
-  color,
-  colors,
-  isBordered,
-  isSelected,
-  onChange,
-}: ColorSelectorProps): JSX.Element => {
+const ColorSelector = forwardRef(function ColorSelector(
+  { color, colors, onChange, ...props }: ColorSelectorProps,
+  ref: Ref<HTMLDivElement>,
+) {
   return (
-    <TippyPopoverWithTrigger
-      renderTrigger={({ onClick }) => (
+    <ColorSelectorRoot {...props} ref={ref} colors={colors}>
+      {colors.map((option, index) => (
         <ColorPill
-          color={color}
-          isBordered={isBordered}
-          isSelected={isSelected}
-          onClick={onClick}
+          key={index}
+          color={option}
+          isBordered
+          isSelected={color === option}
+          onClick={() => onChange(option)}
         />
-      )}
-      popoverContent={
-        <ColorList colors={colors}>
-          {colors.map((option, index) => (
-            <ColorPill
-              key={index}
-              color={option}
-              isBordered
-              isSelected={color === option}
-              onClick={() => onChange(option)}
-            />
-          ))}
-        </ColorList>
-      }
-    />
+      ))}
+    </ColorSelectorRoot>
   );
-};
+});
 
 export default ColorSelector;

--- a/frontend/src/metabase/core/components/ColorSelector/ColorSelector.tsx
+++ b/frontend/src/metabase/core/components/ColorSelector/ColorSelector.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+
+export interface ColorSelectorProps {
+  color?: string;
+  colors: string[];
+  onChange: (color: string) => void;
+}
+
+const ColorSelector = (): JSX.Element => {
+  return <div />;
+};
+
+export default ColorSelector;

--- a/frontend/src/metabase/core/components/ColorSelector/ColorSelector.tsx
+++ b/frontend/src/metabase/core/components/ColorSelector/ColorSelector.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import ColorPill from "../ColorPill";
 import TippyPopoverWithTrigger from "metabase/components/PopoverWithTrigger/TippyPopoverWithTrigger";
-import { ColorGrid } from "./ColorSelector.styled";
+import { ColorSelectorContent } from "./ColorSelector.styled";
 
 export interface ColorSelectorProps {
   color: string;
@@ -20,7 +20,7 @@ const ColorSelector = ({
         <ColorPill color={color} isBordered isSelected onClick={onClick} />
       )}
       popoverContent={
-        <ColorGrid colors={colors}>
+        <ColorSelectorContent colors={colors}>
           {colors.map((option, index) => (
             <ColorPill
               key={index}
@@ -30,7 +30,7 @@ const ColorSelector = ({
               onClick={() => onChange(option)}
             />
           ))}
-        </ColorGrid>
+        </ColorSelectorContent>
       }
     />
   );

--- a/frontend/src/metabase/core/components/ColorSelector/ColorSelector.tsx
+++ b/frontend/src/metabase/core/components/ColorSelector/ColorSelector.tsx
@@ -1,9 +1,10 @@
 import React from "react";
 import ColorPill from "../ColorPill";
-import { ColorSelectorRoot } from "./ColorSelector.styled";
+import TippyPopoverWithTrigger from "metabase/components/PopoverWithTrigger/TippyPopoverWithTrigger";
+import { ColorGrid } from "./ColorSelector.styled";
 
 export interface ColorSelectorProps {
-  color?: string;
+  color: string;
   colors: string[];
   onChange: (color: string) => void;
 }
@@ -14,17 +15,24 @@ const ColorSelector = ({
   onChange,
 }: ColorSelectorProps): JSX.Element => {
   return (
-    <ColorSelectorRoot>
-      {colors.map((option, index) => (
-        <ColorPill
-          key={index}
-          color={option}
-          isBordered
-          isSelected={color === option}
-          onClick={() => onChange(option)}
-        />
-      ))}
-    </ColorSelectorRoot>
+    <TippyPopoverWithTrigger
+      renderTrigger={({ onClick }) => (
+        <ColorPill color={color} isBordered isSelected onClick={onClick} />
+      )}
+      popoverContent={
+        <ColorGrid>
+          {colors.map((option, index) => (
+            <ColorPill
+              key={index}
+              color={option}
+              isBordered
+              isSelected={color === option}
+              onClick={() => onChange(option)}
+            />
+          ))}
+        </ColorGrid>
+      }
+    />
   );
 };
 

--- a/frontend/src/metabase/core/components/ColorSelector/ColorSelector.tsx
+++ b/frontend/src/metabase/core/components/ColorSelector/ColorSelector.tsx
@@ -20,7 +20,7 @@ const ColorSelector = ({
         <ColorPill color={color} isBordered isSelected onClick={onClick} />
       )}
       popoverContent={
-        <ColorGrid>
+        <ColorGrid colors={colors}>
           {colors.map((option, index) => (
             <ColorPill
               key={index}

--- a/frontend/src/metabase/core/components/ColorSelector/ColorSelector.tsx
+++ b/frontend/src/metabase/core/components/ColorSelector/ColorSelector.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-import ColorPill from "../ColorPill";
+import ColorPill from "metabase/core/components/ColorPill";
 import TippyPopoverWithTrigger from "metabase/components/PopoverWithTrigger/TippyPopoverWithTrigger";
-import { ColorSelectorContent } from "./ColorSelector.styled";
+import { ColorList } from "./ColorSelector.styled";
 
 export interface ColorSelectorProps {
   color: string;
@@ -20,7 +20,7 @@ const ColorSelector = ({
         <ColorPill color={color} isBordered isSelected onClick={onClick} />
       )}
       popoverContent={
-        <ColorSelectorContent colors={colors}>
+        <ColorList colors={colors}>
           {colors.map((option, index) => (
             <ColorPill
               key={index}
@@ -30,7 +30,7 @@ const ColorSelector = ({
               onClick={() => onChange(option)}
             />
           ))}
-        </ColorSelectorContent>
+        </ColorList>
       }
     />
   );

--- a/frontend/src/metabase/core/components/ColorSelector/ColorSelector.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/ColorSelector/ColorSelector.unit.spec.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import ColorSelector from "./ColorSelector";
 
@@ -16,7 +16,8 @@ describe("ColorSelector", () => {
     );
 
     userEvent.click(screen.getByLabelText("white"));
-    userEvent.click(await screen.findByLabelText("blue"));
+    const tooltip = await screen.findByRole("tooltip");
+    userEvent.click(within(tooltip).getByLabelText("blue"));
 
     expect(onChange).toHaveBeenCalledWith("blue");
   });

--- a/frontend/src/metabase/core/components/ColorSelector/ColorSelector.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/ColorSelector/ColorSelector.unit.spec.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ColorSelector from "./ColorSelector";
+
+describe("ColorSelector", () => {
+  it("should select a color in a popover", async () => {
+    const onChange = jest.fn();
+
+    render(
+      <ColorSelector
+        color="white"
+        colors={["blue", "green"]}
+        onChange={onChange}
+      />,
+    );
+
+    userEvent.click(screen.getByLabelText("white"));
+    userEvent.click(await screen.findByLabelText("blue"));
+
+    expect(onChange).toHaveBeenCalledWith("blue");
+  });
+});

--- a/frontend/src/metabase/core/components/ColorSelector/ColorSelectorContent.tsx
+++ b/frontend/src/metabase/core/components/ColorSelector/ColorSelectorContent.tsx
@@ -1,0 +1,31 @@
+import React, { forwardRef, HTMLAttributes, Ref } from "react";
+import ColorPill from "metabase/core/components/ColorPill";
+import { ColorSelectorRoot } from "./ColorSelector.styled";
+
+export interface ColorSelectorContentProps
+  extends Omit<HTMLAttributes<HTMLDivElement>, "onChange"> {
+  color?: string;
+  colors: string[];
+  onChange?: (color: string) => void;
+}
+
+const ColorSelectorContent = forwardRef(function ColorSelector(
+  { color, colors, onChange, ...props }: ColorSelectorContentProps,
+  ref: Ref<HTMLDivElement>,
+) {
+  return (
+    <ColorSelectorRoot {...props} ref={ref} colors={colors}>
+      {colors.map((option, index) => (
+        <ColorPill
+          key={index}
+          color={option}
+          isBordered
+          isSelected={color === option}
+          onClick={() => onChange?.(option)}
+        />
+      ))}
+    </ColorSelectorRoot>
+  );
+});
+
+export default ColorSelectorContent;

--- a/frontend/src/metabase/core/components/ColorSelector/index.ts
+++ b/frontend/src/metabase/core/components/ColorSelector/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ColorSelector";

--- a/frontend/src/metabase/core/components/ColorSelector/index.ts
+++ b/frontend/src/metabase/core/components/ColorSelector/index.ts
@@ -1,2 +1,1 @@
 export { default } from "./ColorSelector";
-export { default as ColorSelectorContent } from "./ColorSelectorContent";

--- a/frontend/src/metabase/core/components/ColorSelector/index.ts
+++ b/frontend/src/metabase/core/components/ColorSelector/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./ColorSelector";
+export { default as ColorSelectorContent } from "./ColorSelectorContent";

--- a/frontend/src/metabase/core/components/DateInput/DateInput.tsx
+++ b/frontend/src/metabase/core/components/DateInput/DateInput.tsx
@@ -19,7 +19,7 @@ const TIME_FORMAT_24 = "HH:mm";
 
 export type DateInputAttributes = Omit<
   InputHTMLAttributes<HTMLDivElement>,
-  "value" | "onChange"
+  "size" | "value" | "onChange"
 >;
 
 export interface DateInputProps extends DateInputAttributes {

--- a/frontend/src/metabase/core/components/Input/Input.styled.tsx
+++ b/frontend/src/metabase/core/components/Input/Input.styled.tsx
@@ -5,7 +5,7 @@ import IconButtonWrapper from "metabase/components/IconButtonWrapper";
 import { InputSize } from "./types";
 
 export interface InputProps {
-  size?: InputSize;
+  fieldSize?: InputSize;
   hasError?: boolean;
   fullWidth?: boolean;
   hasLeftIcon?: boolean;
@@ -61,7 +61,7 @@ export const InputField = styled.input<InputProps>`
     `};
 
   ${props =>
-    props.size === "small" &&
+    props.fieldSize === "small" &&
     css`
       font-size: 0.875rem;
       padding: 0.4375rem 0.625rem;

--- a/frontend/src/metabase/core/components/Input/Input.styled.tsx
+++ b/frontend/src/metabase/core/components/Input/Input.styled.tsx
@@ -2,8 +2,10 @@ import styled from "@emotion/styled";
 import { css } from "@emotion/react";
 import { color, darken } from "metabase/lib/colors";
 import IconButtonWrapper from "metabase/components/IconButtonWrapper";
+import { InputSize } from "./types";
 
 export interface InputProps {
+  size?: InputSize;
   hasError?: boolean;
   fullWidth?: boolean;
   hasLeftIcon?: boolean;
@@ -56,6 +58,13 @@ export const InputField = styled.input<InputProps>`
     props.hasRightIcon &&
     css`
       padding-right: 2.25rem;
+    `};
+
+  ${props =>
+    props.size === "small" &&
+    css`
+      font-size: 0.875rem;
+      padding: 0.4375rem 0.625rem;
     `};
 `;
 

--- a/frontend/src/metabase/core/components/Input/Input.tsx
+++ b/frontend/src/metabase/core/components/Input/Input.tsx
@@ -13,9 +13,16 @@ import {
   InputRightButton,
   InputRoot,
 } from "./Input.styled";
+import { InputSize } from "./types";
 
-export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+export type InputAttributes = Omit<
+  InputHTMLAttributes<HTMLInputElement>,
+  "size"
+>;
+
+export interface InputProps extends InputAttributes {
   inputRef?: Ref<HTMLInputElement>;
+  size?: InputSize;
   error?: boolean;
   fullWidth?: boolean;
   leftIcon?: string;
@@ -31,6 +38,7 @@ const Input = forwardRef(function Input(
     className,
     style,
     inputRef,
+    size = "medium",
     error,
     fullWidth,
     leftIcon,
@@ -53,6 +61,7 @@ const Input = forwardRef(function Input(
       <InputField
         {...props}
         ref={inputRef}
+        size={size}
         hasError={error}
         fullWidth={fullWidth}
         hasRightIcon={Boolean(rightIcon)}

--- a/frontend/src/metabase/core/components/Input/Input.tsx
+++ b/frontend/src/metabase/core/components/Input/Input.tsx
@@ -61,7 +61,7 @@ const Input = forwardRef(function Input(
       <InputField
         {...props}
         ref={inputRef}
-        size={size}
+        fieldSize={size}
         hasError={error}
         fullWidth={fullWidth}
         hasRightIcon={Boolean(rightIcon)}

--- a/frontend/src/metabase/core/components/Input/types.ts
+++ b/frontend/src/metabase/core/components/Input/types.ts
@@ -1,0 +1,1 @@
+export type InputSize = "small" | "medium";

--- a/frontend/src/metabase/core/components/NumericInput/NumericInput.tsx
+++ b/frontend/src/metabase/core/components/NumericInput/NumericInput.tsx
@@ -12,7 +12,7 @@ import Input from "metabase/core/components/Input";
 
 export type NumericInputAttributes = Omit<
   InputHTMLAttributes<HTMLDivElement>,
-  "value" | "onChange"
+  "value" | "size" | "onChange"
 >;
 
 export interface NumericInputProps extends NumericInputAttributes {


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/22816

Adds new `ColorPicker` and `ColorSelector`. To be used to pick a color from the new color palette (in a follow-up PRs).

How to test:
- Open storybook `yarn storybook`
- Make sure it's possible to select a color with both `ColorPicker` and `ColorSelector`.

Please note that fonts are broken in storybook atm.

<img width="817" alt="Screenshot 2022-05-23 at 22 09 44" src="https://user-images.githubusercontent.com/8542534/169889678-4628f09b-c52f-4688-8632-27df23bd3857.png">
<img width="871" alt="Screenshot 2022-05-23 at 22 09 58" src="https://user-images.githubusercontent.com/8542534/169889687-0a43b948-169c-474f-b24e-ee2bcd1479ed.png">
