### PR TITLE
Handle `nil` cache during initial cache population (#22779)

### DIFF
--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -383,15 +383,24 @@
 (defn- db-or-cache-value
   "Get the value, if any, of `setting-definition-or-name` from the DB (using / restoring the cache as needed)."
   ^String [setting-definition-or-name]
-  (let [setting (resolve-setting setting-definition-or-name)]
-    (when (allows-site-wide-values? setting)
+  (let [setting       (resolve-setting setting-definition-or-name)
+        db-is-set-up? (or (requiring-resolve 'metabase.db/db-is-set-up?)
+                          ;; this should never be hit. it is just overly cautious against a NPE here. But no way this
+                          ;; cannot resolve
+                          (constantly false))]
+    ;; cannot use db (and cache populated from db) if db is not set up
+    (when (and (db-is-set-up?) (allows-site-wide-values? setting))
       (let [v (if *disable-cache*
                 (db/select-one-field :value Setting :key (setting-name setting-definition-or-name))
                 (do
                   (cache/restore-cache-if-needed!)
-                  (clojure.core/get (cache/cache) (setting-name setting-definition-or-name))))]
-        (when (seq v)
-          v)))))
+                  (let [cache (cache/cache)]
+                    (if (nil? cache)
+                      ;; If another thread is populating the cache for the first time, we will have a nil value for
+                      ;; the cache and must hit the db while the cache populates
+                      (db/select-one-field :value Setting :key (setting-name setting-definition-or-name))
+                      (clojure.core/get cache (setting-name setting-definition-or-name))))))]
+        (not-empty v)))))
 
 (defn default-value
   "Get the `:default` value of `setting-definition-or-name` if one was specified."

--- a/src/metabase/models/setting/cache.clj
+++ b/src/metabase/models/setting/cache.clj
@@ -157,11 +157,8 @@
       ;; attempt to acquire the lock. Returns immediately if lock is is already held.
       (when (.tryLock restore-cache-lock)
         (try
-          ;; don't try to restore the cache before the application DB is ready, it's not going to work...
-          (when-let [db-is-set-up? (resolve 'metabase.db/db-is-set-up?)]
-            (when (db-is-set-up?)
-              (reset! last-update-check (System/currentTimeMillis))
-              (when (cache-out-of-date?)
-                (restore-cache!))))
+          (reset! last-update-check (System/currentTimeMillis))
+          (when (cache-out-of-date?)
+            (restore-cache!))
           (finally
             (.unlock restore-cache-lock)))))))


### PR DESCRIPTION
manual backport of https://github.com/metabase/metabase/pull/22779 since we changed the alias of `[metabase.models.setting.cache :as cache]` to `setting.cache`