### PR TITLE
Put `default-query-constraints` behind a function for setting (#22792)

### DIFF
--- a/modules/drivers/sqlserver/test/metabase/driver/sqlserver_test.clj
+++ b/modules/drivers/sqlserver/test/metabase/driver/sqlserver_test.clj
@@ -338,7 +338,7 @@
                          mt/native-query
                          ;; add default query constraints to ensure the default limit of 2000 is overridden by the
                          ;; `:rowcount-override` connection property we defined in the details above
-                         (assoc :constraints constraints/default-query-constraints)
+                         (assoc :constraints (constraints/default-query-constraints))
                          qp/process-query
                          mt/rows
                          ffirst))))))))

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -147,8 +147,7 @@
   [{:keys [dataset_query]}]
   (u/ignore-exceptions
     [(qp-util/query-hash dataset_query)
-     (qp-util/query-hash (assoc dataset_query :constraints constraints/default-query-constraints))]))
-
+     (qp-util/query-hash (assoc dataset_query :constraints (constraints/default-query-constraints)))]))
 (defn- dashcard->query-hashes
   "Return a sequence of all the query hashes for this `dashcard`, including the top-level Card and any Series."
   [{:keys [card series]}]

--- a/src/metabase/api/dataset.clj
+++ b/src/metabase/api/dataset.clj
@@ -143,7 +143,7 @@
   {:average (or
              (some (comp query/average-execution-time-ms qputil/query-hash)
                    [query
-                    (assoc query :constraints qp.constraints/default-query-constraints)])
+                    (assoc query :constraints (qp.constraints/default-query-constraints))])
              0)})
 
 (api/defendpoint POST "/native"

--- a/src/metabase/api/embed.clj
+++ b/src/metabase/api/embed.clj
@@ -259,7 +259,7 @@
   {:style/indent 0}
   [& {:keys [dashboard-id dashcard-id card-id export-format embedding-params token-params
              query-params constraints qp-runner]
-      :or   {constraints constraints/default-query-constraints
+      :or   {constraints (constraints/default-query-constraints)
              qp-runner   qp/process-query-and-save-execution!}}]
   {:pre [(integer? dashboard-id) (integer? dashcard-id) (integer? card-id) (u/maybe? map? embedding-params)
          (map? token-params) (map? query-params)]}
@@ -316,7 +316,7 @@
   "Run the query belonging to Card identified by `unsigned-token`. Checks that embedding is enabled both globally and
   for this Card. Returns core.async channel to fetch the results."
   [unsigned-token export-format query-params & {:keys [constraints qp-runner]
-                                                :or   {constraints constraints/default-query-constraints
+                                                :or   {constraints (constraints/default-query-constraints)
                                                        qp-runner   qp/process-query-and-save-execution!}
                                                 :as   options}]
   (let [card-id (eu/get-in-unsigned-token-or-throw unsigned-token [:resource :question])]
@@ -383,7 +383,7 @@
   {:style/indent 1}
   [token dashcard-id card-id export-format query-params
    & {:keys [constraints qp-runner]
-      :or   {constraints constraints/default-query-constraints
+      :or   {constraints (constraints/default-query-constraints)
              qp-runner   qp/process-query-and-save-execution!}}]
   (let [unsigned-token (eu/unsign token)
         dashboard-id   (eu/get-in-unsigned-token-or-throw unsigned-token [:resource :dashboard])]

--- a/src/metabase/api/public.clj
+++ b/src/metabase/api/public.clj
@@ -204,8 +204,8 @@
       :as   options}]
   (let [options (merge
                  {:context     :public-dashboard
-                  :constraints constraints/default-query-constraints}
-                 options
+                  :constraints (constraints/default-query-constraints)}
+        options
                  {:parameters    (cond-> parameters
                                    (string? parameters) (json/parse-string keyword))
                   :export-format export-format

--- a/src/metabase/query_processor/card.clj
+++ b/src/metabase/query_processor/card.clj
@@ -177,7 +177,7 @@
   options."
   [card-id export-format
    & {:keys [parameters constraints context dashboard-id middleware qp-runner run ignore_cache]
-      :or   {constraints constraints/default-query-constraints
+      :or   {constraints (constraints/default-query-constraints)
              context     :question
              qp-runner   qp/process-query-and-save-execution!}}]
   {:pre [(int? card-id) (u/maybe? sequential? parameters)]}

--- a/src/metabase/query_processor/dashboard.clj
+++ b/src/metabase/query_processor/dashboard.clj
@@ -160,7 +160,7 @@
   (let [resolved-params (resolve-params-for-query dashboard-id card-id dashcard-id parameters)
         options         (merge
                          {:ignore_cache false
-                          :constraints  constraints/default-query-constraints
+                          :constraints  (constraints/default-query-constraints)
                           :context      :dashboard}
                          options
                          {:parameters   resolved-params

--- a/src/metabase/query_processor/middleware/constraints.clj
+++ b/src/metabase/query_processor/middleware/constraints.clj
@@ -19,8 +19,9 @@
   "General maximum number of rows to return from an API query."
   10000)
 
-(def default-query-constraints
+(defn default-query-constraints
   "Default map of constraints that we apply on dataset queries executed by the api."
+  []
   {:max-results           max-results
    :max-results-bare-rows (or (max-results-bare-rows) default-max-results-bare-rows)})
 
@@ -35,7 +36,7 @@
     (assoc constraints :max-results-bare-rows max-results)))
 
 (defn- merge-default-constraints [constraints]
-  (merge default-query-constraints constraints))
+  (merge (default-query-constraints) constraints))
 
 (defn- add-default-userland-constraints*
   "Add default values of `:max-results` and `:max-results-bare-rows` to `:constraints` map `m`."

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -1425,7 +1425,7 @@
           (testing "Sanity check: this CSV download should not be subject to C O N S T R A I N T S"
             (is (= {:constraints nil}
                    (mt/user-http-request :rasta :post 200 (format "card/%d/query/csv" (u/the-id card))))))
-          (with-redefs [constraints/default-query-constraints {:max-results 10, :max-results-bare-rows 10}]
+          (with-redefs [constraints/default-query-constraints (constantly {:max-results 10, :max-results-bare-rows 10})]
             (testing (str "Downloading CSV/JSON/XLSX results shouldn't be subject to the default query constraints -- even "
                           "if the query comes in with `add-default-userland-constraints` (as will be the case if the query "
                           "gets saved from one that had it -- see #9831)")

--- a/test/metabase/api/dataset_test.clj
+++ b/test/metabase/api/dataset_test.clj
@@ -215,7 +215,7 @@
   (testing "POST /api/dataset/:format"
     (testing "Downloading CSV/JSON/XLSX results shouldn't be subject to the default query constraints (#9831)"
       ;; even if the query comes in with `add-default-userland-constraints` (as will be the case if the query gets saved
-      (with-redefs [constraints/default-query-constraints {:max-results 10, :max-results-bare-rows 10}]
+      (with-redefs [constraints/default-query-constraints (constantly {:max-results 10, :max-results-bare-rows 10})]
         (let [result (mt/user-http-request :rasta :post 200 "dataset/csv"
                                            :query (json/generate-string
                                                    {:database (mt/id)
@@ -251,7 +251,7 @@
 (deftest non--download--queries-should-still-get-the-default-constraints
   (testing (str "non-\"download\" queries should still get the default constraints "
                 "(this also is a sanitiy check to make sure the `with-redefs` in the test above actually works)")
-    (with-redefs [constraints/default-query-constraints {:max-results 10, :max-results-bare-rows 10}]
+    (with-redefs [constraints/default-query-constraints (constantly {:max-results 10, :max-results-bare-rows 10})]
       (let [{row-count :row_count, :as result}
             (mt/user-http-request :rasta :post 202 "dataset"
                                   {:database (mt/id)

--- a/test/metabase/api/embed_test.clj
+++ b/test/metabase/api/embed_test.clj
@@ -273,7 +273,7 @@
   (testing (str "Downloading CSV/JSON/XLSX results shouldn't be subject to the default query constraints -- even if "
                 "the query comes in with `add-default-userland-constraints` (as will be the case if the query gets "
                 "saved from one that had it -- see #9831 and #10399)")
-    (with-redefs [constraints/default-query-constraints {:max-results 10, :max-results-bare-rows 10}]
+    (with-redefs [constraints/default-query-constraints (constantly {:max-results 10, :max-results-bare-rows 10})]
       (with-embedding-enabled-and-new-secret-key
         (with-temp-card [card {:enable_embedding true
                                :dataset_query    (assoc (mt/mbql-query venues)
@@ -437,7 +437,7 @@
 (deftest downloading-csv-json-xlsx-results-from-the-dashcard-endpoint-shouldn-t-be-subject-to-the-default-query-constraints
   (testing (str "Downloading CSV/JSON/XLSX results from the dashcard endpoint shouldn't be subject to the default "
                 "query constraints (#10399)")
-    (with-redefs [constraints/default-query-constraints {:max-results 10, :max-results-bare-rows 10}]
+    (with-redefs [constraints/default-query-constraints (constantly {:max-results 10, :max-results-bare-rows 10})]
       (with-embedding-enabled-and-new-secret-key
         (with-temp-dashcard [dashcard {:dash {:enable_embedding true}
                                        :card {:dataset_query (assoc (mt/mbql-query venues)

--- a/test/metabase/pulse_test.clj
+++ b/test/metabase/pulse_test.clj
@@ -328,8 +328,8 @@
 
       :fixture
       (fn [_ thunk]
-        (with-redefs [constraints/default-query-constraints {:max-results           10000
-                                                             :max-results-bare-rows 30}]
+        (with-redefs [constraints/default-query-constraints (constantly {:max-results           10000
+                                                                            :max-results-bare-rows 30})]
           (thunk)))
 
       :assert


### PR DESCRIPTION
manual backport of https://github.com/metabase/metabase/pull/22792. Manual because of ns rename of `[metabase.query-processor.middleware.constraints :as constraints]` to `qp.constraints`.