### PR TITLE
Expect `advanced_config` feature flag for model cache controls

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/model_persistence/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/model_persistence/index.ts
@@ -1,9 +1,12 @@
 import { PLUGIN_MODEL_PERSISTENCE } from "metabase/plugins";
+import { hasPremiumFeature } from "metabase-enterprise/settings";
 
 import ModelCacheControl from "./components/ModelCacheControl";
 import ModelCacheManagementSection from "./components/ModelCacheManagementSection";
 
-PLUGIN_MODEL_PERSISTENCE.isModelLevelPersistenceEnabled = () => true;
+if (hasPremiumFeature("advanced_config")) {
+  PLUGIN_MODEL_PERSISTENCE.isModelLevelPersistenceEnabled = () => true;
 
-PLUGIN_MODEL_PERSISTENCE.ModelCacheControl = ModelCacheControl;
-PLUGIN_MODEL_PERSISTENCE.ModelCacheManagementSection = ModelCacheManagementSection;
+  PLUGIN_MODEL_PERSISTENCE.ModelCacheControl = ModelCacheControl;
+  PLUGIN_MODEL_PERSISTENCE.ModelCacheManagementSection = ModelCacheManagementSection;
+}


### PR DESCRIPTION
This PR makes sure we're only going to show highlighted controls on paid plans with `advanced_config` flag enabled

![CleanShot 2022-05-23 at 19 09 56@2x](https://user-images.githubusercontent.com/17258145/169881004-78212d26-1161-4463-bd86-e7ae824ac1e7.png)
