### PR TITLE
[E2E] Remove `models` check from CCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1251,7 +1251,6 @@ workflows:
                   "dashboard",
                   "embedding",
                   "filters",
-                  "models",
                   "native",
                   "native-filters",
                   "onboarding",


### PR DESCRIPTION
Removes `models` E2E group from CircleCI

PR with adding it to GHA #22787