### PR TITLE
Repro #22768: Cannot view Object Detail of non-numeric IDs

### DIFF
--- a/frontend/test/metabase/scenarios/visualizations/object_detail.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/object_detail.cy.spec.js
@@ -8,7 +8,7 @@ import {
 
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
-const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
+const { ORDERS, ORDERS_ID, PRODUCTS } = SAMPLE_DATABASE;
 
 describe("scenarios > question > object details", () => {
   const FIRST_ORDER_ID = 9676;
@@ -133,6 +133,23 @@ describe("scenarios > question > object details", () => {
     cy.findByTestId("object-detail")
       .findByText("Searsboro")
       .click();
+  });
+
+  it.skip("should work with non-numeric IDs (metabse#22768)", () => {
+    cy.request("PUT", `/api/field/${PRODUCTS.ID}`, {
+      semantic_type: null,
+    });
+
+    cy.request("PUT", `/api/field/${PRODUCTS.TITLE}`, {
+      semantic_type: "type/PK",
+    });
+
+    openProductsTable({ limit: 5 });
+
+    cy.findByTextEnsureVisible("Rustic Paper Wallet").click();
+
+    cy.location("search").should("eq", "?objectId=Rustic%20Paper%20Wallet");
+    cy.findByTestId("object-detail").contains("Rustic Paper Wallet");
   });
 });
 


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #22768

### How to test this manually?
- `yarn test-cypress-open`
- `metabase/scenarios/visualizations/object_detail.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/169886563-41d0ca68-47c6-4693-8b95-0e3ae3840693.png)

