### PR TITLE
Allow Google Platform Library authentication

### DIFF
--- a/frontend/src/metabase/lib/auth.js
+++ b/frontend/src/metabase/lib/auth.js
@@ -28,6 +28,7 @@ export const attachGoogleAuth = (element, onLogin, onError) => {
     const auth2 = window.gapi.auth2.init({
       client_id: Settings.get("google-auth-client-id"),
       cookiepolicy: "single_host_origin",
+      plugin_name: "metabase-legacy-google-auth",
     });
 
     auth2.attachClickHandler(


### PR DESCRIPTION
Temporary fix for https://github.com/metabase/metabase/issues/17429

## Changes

Google is deprecating the Google Platform Library so newly created Client IDs are now blocked from using the old library unless we specify a "[plugin_name](https://developers.google.com/identity/sign-in/web/reference)" string while we implementing the new google auth flow.

## How to verify

- Login as an admin and configure Google authentication using this [new client id](https://metaboat.slack.com/archives/C03E3Q5T4P4/p1653085210635789)
- Try to sign in with Google and ensure it works

It should not work on `master` because the library we use is deprecated. A login attempt will end up like this:
<img width="1013" alt="Screenshot 2022-05-23 at 23 10 54" src="https://user-images.githubusercontent.com/14301985/169889993-53f4b217-c34e-4521-8d4e-c303ba60205b.png">
