### PR TITLE
Repro #22872: Pivot Table cannot sort by metric

### DIFF
--- a/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
@@ -857,6 +857,56 @@ describe("scenarios > visualizations > pivot tables", () => {
 
     cy.findAllByText(/Totals for .*/i).should("have.length", 0);
   });
+
+  it.skip("should sort by metric (metabase#22872)", () => {
+    const questionDetails = {
+      dataset_query: {
+        database: SAMPLE_DB_ID,
+        query: {
+          "source-table": REVIEWS_ID,
+          aggregation: [["count"]],
+          breakout: [
+            ["field", REVIEWS.RATING, null],
+            ["field", REVIEWS.CREATED_AT, { "temporal-unit": "year" }],
+          ],
+        },
+        type: "query",
+      },
+      display: "pivot",
+    };
+
+    visitQuestionAdhoc(questionDetails);
+
+    cy.findByTextEnsureVisible("Created At: Year");
+    cy.findByTextEnsureVisible("Row totals");
+
+    assertTopMostRowTotalValue("149");
+
+    cy.icon("notebook").click();
+
+    cy.findByTextEnsureVisible("Sort").click();
+
+    popover()
+      .contains("Count")
+      .click();
+    cy.wait("@pivotDataset");
+
+    cy.button("Visualize").click();
+
+    assertTopMostRowTotalValue("23");
+
+    /**
+     * @param { string } value
+     */
+    function assertTopMostRowTotalValue(value) {
+      // Warning: Fragile selector!
+      // TODO: refactor once we have a better HTML structure for tables.
+      cy.get("[role=rowgroup] > div")
+        .eq(5)
+        .invoke("text")
+        .should("eq", value);
+    }
+  });
 });
 
 const testQuery = {


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #22872 

### How to test this manually?
- `yarn test-cypress-open`
- `metabase/scenarios/visualizations/pivot_tables.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/169899553-c7c44b73-0d43-4d48-9262-2884aaa2da47.png)
