### PR TITLE
Support Segments in Bulk Filter Modal

### DIFF
--- a/frontend/src/metabase-lib/lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/lib/queries/StructuredQuery.ts
@@ -999,6 +999,13 @@ class StructuredQueryInner extends AtomicQuery {
     return this._updateQuery(Q.clearFilters, arguments);
   }
 
+  /**
+   * @returns {StructuredQuery} new query with all segment filters removed
+   */
+  clearSegments() {
+    return this._updateQuery(Q.clearSegments, arguments);
+  }
+
   // SORTS
   // TODO: standardize SORT vs ORDER_BY terminology
   sorts(): OrderByWrapper[] {

--- a/frontend/src/metabase/core/components/Select/Select.jsx
+++ b/frontend/src/metabase/core/components/Select/Select.jsx
@@ -41,6 +41,7 @@ class Select extends Component {
 
     // SelectButton props
     buttonProps: PropTypes.object,
+    buttonText: PropTypes.string, // will override selected options text
 
     // AccordianList props
     searchProp: PropTypes.string,
@@ -217,14 +218,17 @@ class Select extends Component {
               disabled={disabled}
               {...buttonProps}
             >
-              {selectedNames.length > 0
-                ? selectedNames.map((name, index) => (
-                    <span key={index}>
-                      {name}
-                      {index < selectedNames.length - 1 ? ", " : ""}
-                    </span>
-                  ))
-                : placeholder}
+              {this.props.buttonText ?? null}
+              {!this.props.buttonText
+                ? selectedNames.length > 0
+                  ? selectedNames.map((name, index) => (
+                      <span key={index}>
+                        {name}
+                        {index < selectedNames.length - 1 ? ", " : ""}
+                      </span>
+                    ))
+                  : placeholder
+                : null}
             </SelectButton>
           )
         }

--- a/frontend/src/metabase/core/components/Select/Select.jsx
+++ b/frontend/src/metabase/core/components/Select/Select.jsx
@@ -218,17 +218,16 @@ class Select extends Component {
               disabled={disabled}
               {...buttonProps}
             >
-              {this.props.buttonText ?? null}
-              {!this.props.buttonText
-                ? selectedNames.length > 0
-                  ? selectedNames.map((name, index) => (
-                      <span key={index}>
-                        {name}
-                        {index < selectedNames.length - 1 ? ", " : ""}
-                      </span>
-                    ))
-                  : placeholder
-                : null}
+              {this.props.buttonText
+                ? this.props.buttonText
+                : selectedNames.length > 0
+                ? selectedNames.map((name, index) => (
+                    <span key={index}>
+                      {name}
+                      {index < selectedNames.length - 1 ? ", " : ""}
+                    </span>
+                  ))
+                : placeholder}
             </SelectButton>
           )
         }

--- a/frontend/src/metabase/core/components/Select/Select.jsx
+++ b/frontend/src/metabase/core/components/Select/Select.jsx
@@ -136,6 +136,7 @@ class Select extends Component {
       value = this.itemIsSelected(option)
         ? values.filter(value => value !== optionValue)
         : [...values, optionValue];
+      value.changedItem = optionValue;
     } else {
       value = optionValue;
     }

--- a/frontend/src/metabase/lib/query/filter.js
+++ b/frontend/src/metabase/lib/query/filter.js
@@ -45,6 +45,10 @@ export function removeFilter(filter, index) {
 export function clearFilters(filter) {
   return getFilterClause(clear());
 }
+export function clearSegments(filters) {
+  const newFilters = filters.filter(f => !isSegment(f));
+  return getFilterClause(newFilters);
+}
 
 // MISC
 

--- a/frontend/src/metabase/lib/query/query.js
+++ b/frontend/src/metabase/lib/query/query.js
@@ -52,6 +52,8 @@ export const removeFilter = (query, index) =>
   setFilterClause(query, F.removeFilter(query.filter, index));
 export const clearFilters = query =>
   setFilterClause(query, F.clearFilters(query.filter));
+export const clearSegments = query =>
+  setFilterClause(query, F.clearSegments(getFilters(query)));
 
 export const canAddFilter = query => F.canAddFilter(query.filter);
 

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterList/BulkFilterList.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterList/BulkFilterList.tsx
@@ -149,7 +149,7 @@ const SegmentListItem = ({
         />
       </ListRowContent>
     </ListRow>
-    <ModalDivider />
+    <ModalDivider marginY="0.5rem" />
   </>
 );
 

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterList/BulkFilterList.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterList/BulkFilterList.tsx
@@ -1,10 +1,17 @@
 import React, { useMemo } from "react";
+import { t } from "ttag";
+
 import StructuredQuery, {
   DimensionOption,
+  SegmentOption,
+  isDimensionOption,
+  isSegmentOption,
 } from "metabase-lib/lib/queries/StructuredQuery";
 import Dimension from "metabase-lib/lib/Dimension";
+import { isSegment } from "metabase/lib/query/filter";
+import { ModalDivider } from "../BulkFilterModal/BulkFilterModal.styled";
 import Filter from "metabase-lib/lib/queries/structured/Filter";
-import BulkFilterSelect from "../BulkFilterSelect";
+import { BulkFilterSelect, SegmentFilterSelect } from "../BulkFilterSelect";
 import {
   ListRoot,
   ListRow,
@@ -15,7 +22,7 @@ import {
 export interface BulkFilterListProps {
   query: StructuredQuery;
   filters: Filter[];
-  options: DimensionOption[];
+  options: (DimensionOption | SegmentOption)[];
   onAddFilter: (filter: Filter) => void;
   onChangeFilter: (filter: Filter, newFilter: Filter) => void;
   onRemoveFilter: (filter: Filter) => void;
@@ -29,9 +36,27 @@ const BulkFilterList = ({
   onChangeFilter,
   onRemoveFilter,
 }: BulkFilterListProps): JSX.Element => {
+  const [dimensions, segments, segmentFilters] = useMemo(
+    () => [
+      options.filter(isDimensionOption),
+      options.filter(isSegmentOption),
+      filters.filter(isSegment),
+    ],
+    [options, filters],
+  );
+
   return (
     <ListRoot>
-      {options.map(({ dimension }, index) => (
+      {!!segments.length && (
+        <SegmentListItem
+          query={query}
+          filters={segmentFilters}
+          segments={segments}
+          onAddFilter={onAddFilter}
+          onRemoveFilter={onRemoveFilter}
+        />
+      )}
+      {dimensions.map(({ dimension }, index) => (
         <BulkFilterListItem
           key={index}
           query={query}
@@ -95,5 +120,37 @@ const BulkFilterListItem = ({
     </ListRow>
   );
 };
+
+interface SegmentListItemProps {
+  query: StructuredQuery;
+  filters: Filter[];
+  segments: SegmentOption[];
+  onAddFilter: (filter: Filter) => void;
+  onRemoveFilter: (filter: Filter) => void;
+}
+
+const SegmentListItem = ({
+  query,
+  filters,
+  segments,
+  onAddFilter,
+  onRemoveFilter,
+}: SegmentListItemProps): JSX.Element => (
+  <>
+    <ListRow>
+      <ListRowLabel>{t`Segments`}</ListRowLabel>
+      <ListRowContent>
+        <SegmentFilterSelect
+          query={query}
+          filters={filters}
+          segments={segments}
+          onAddFilter={onAddFilter}
+          onRemoveFilter={onRemoveFilter}
+        />
+      </ListRowContent>
+    </ListRow>
+    <ModalDivider />
+  </>
+);
 
 export default BulkFilterList;

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterList/BulkFilterList.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterList/BulkFilterList.tsx
@@ -26,6 +26,7 @@ export interface BulkFilterListProps {
   onAddFilter: (filter: Filter) => void;
   onChangeFilter: (filter: Filter, newFilter: Filter) => void;
   onRemoveFilter: (filter: Filter) => void;
+  onClearSegments: () => void;
 }
 
 const BulkFilterList = ({
@@ -35,14 +36,11 @@ const BulkFilterList = ({
   onAddFilter,
   onChangeFilter,
   onRemoveFilter,
+  onClearSegments,
 }: BulkFilterListProps): JSX.Element => {
-  const [dimensions, segments, segmentFilters] = useMemo(
-    () => [
-      options.filter(isDimensionOption),
-      options.filter(isSegmentOption),
-      filters.filter(isSegment),
-    ],
-    [options, filters],
+  const [dimensions, segments] = useMemo(
+    () => [options.filter(isDimensionOption), options.filter(isSegmentOption)],
+    [options],
   );
 
   return (
@@ -50,10 +48,10 @@ const BulkFilterList = ({
       {!!segments.length && (
         <SegmentListItem
           query={query}
-          filters={segmentFilters}
           segments={segments}
           onAddFilter={onAddFilter}
           onRemoveFilter={onRemoveFilter}
+          onClearSegments={onClearSegments}
         />
       )}
       {dimensions.map(({ dimension }, index) => (
@@ -123,18 +121,18 @@ const BulkFilterListItem = ({
 
 interface SegmentListItemProps {
   query: StructuredQuery;
-  filters: Filter[];
   segments: SegmentOption[];
   onAddFilter: (filter: Filter) => void;
   onRemoveFilter: (filter: Filter) => void;
+  onClearSegments: () => void;
 }
 
 const SegmentListItem = ({
   query,
-  filters,
   segments,
   onAddFilter,
   onRemoveFilter,
+  onClearSegments,
 }: SegmentListItemProps): JSX.Element => (
   <>
     <ListRow>
@@ -145,6 +143,7 @@ const SegmentListItem = ({
           segments={segments}
           onAddFilter={onAddFilter}
           onRemoveFilter={onRemoveFilter}
+          onClearSegments={onClearSegments}
         />
       </ListRowContent>
     </ListRow>

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterList/BulkFilterList.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterList/BulkFilterList.tsx
@@ -142,7 +142,6 @@ const SegmentListItem = ({
       <ListRowContent>
         <SegmentFilterSelect
           query={query}
-          filters={filters}
           segments={segments}
           onAddFilter={onAddFilter}
           onRemoveFilter={onRemoveFilter}

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterModal/BulkFilterModal.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterModal/BulkFilterModal.styled.tsx
@@ -47,8 +47,13 @@ export const ModalTabPanel = styled(TabPanel)`
   padding: 0 2rem;
 `;
 
-export const ModalDivider = styled.div`
+interface ModalDividerProps {
+  marginY?: string;
+}
+
+export const ModalDivider = styled.div<ModalDividerProps>`
   border-top: 1px solid ${color("border")};
+  margin: ${props => (props.marginY ? props.marginY : "0")} 0;
 `;
 
 export const ModalCloseButton = styled(IconButtonWrapper)`

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterModal/BulkFilterModal.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterModal/BulkFilterModal.tsx
@@ -60,6 +60,11 @@ const BulkFilterModal = ({
     setIsChanged(true);
   }, []);
 
+  const handleClearSegments = useCallback(() => {
+    setQuery(query.clearSegments());
+    setIsChanged(true);
+  }, [query]);
+
   const handleApplyQuery = useCallback(() => {
     query.update(undefined, { run: true });
     onClose?.();
@@ -81,6 +86,7 @@ const BulkFilterModal = ({
           onAddFilter={handleAddFilter}
           onChangeFilter={handleChangeFilter}
           onRemoveFilter={handleRemoveFilter}
+          onClearSegments={handleClearSegments}
         />
       ) : (
         <BulkFilterModalSectionList
@@ -90,6 +96,7 @@ const BulkFilterModal = ({
           onAddFilter={handleAddFilter}
           onChangeFilter={handleChangeFilter}
           onRemoveFilter={handleRemoveFilter}
+          onClearSegments={handleClearSegments}
         />
       )}
       <ModalDivider />
@@ -112,6 +119,7 @@ interface BulkFilterModalSectionProps {
   onAddFilter: (filter: Filter) => void;
   onChangeFilter: (filter: Filter, newFilter: Filter) => void;
   onRemoveFilter: (filter: Filter) => void;
+  onClearSegments: () => void;
 }
 
 const BulkFilterModalSection = ({
@@ -121,6 +129,7 @@ const BulkFilterModalSection = ({
   onAddFilter,
   onChangeFilter,
   onRemoveFilter,
+  onClearSegments,
 }: BulkFilterModalSectionProps): JSX.Element => {
   return (
     <ModalBody>
@@ -131,6 +140,7 @@ const BulkFilterModalSection = ({
         onAddFilter={onAddFilter}
         onChangeFilter={onChangeFilter}
         onRemoveFilter={onRemoveFilter}
+        onClearSegments={onClearSegments}
       />
     </ModalBody>
   );
@@ -143,6 +153,7 @@ interface BulkFilterModalSectionListProps {
   onAddFilter: (filter: Filter) => void;
   onChangeFilter: (filter: Filter, newFilter: Filter) => void;
   onRemoveFilter: (filter: Filter) => void;
+  onClearSegments: () => void;
 }
 
 const BulkFilterModalSectionList = ({
@@ -152,6 +163,7 @@ const BulkFilterModalSectionList = ({
   onAddFilter,
   onChangeFilter,
   onRemoveFilter,
+  onClearSegments,
 }: BulkFilterModalSectionListProps): JSX.Element => {
   const [tab, setTab] = useState(0);
 
@@ -178,6 +190,7 @@ const BulkFilterModalSectionList = ({
             onAddFilter={onAddFilter}
             onChangeFilter={onChangeFilter}
             onRemoveFilter={onRemoveFilter}
+            onClearSegments={onClearSegments}
           />
         </ModalTabPanel>
       ))}

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterModal/BulkFilterModal.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterModal/BulkFilterModal.tsx
@@ -39,7 +39,7 @@ const BulkFilterModal = ({
   }, [query]);
 
   const sections = useMemo(() => {
-    return query.topLevelFilterFieldOptionSections();
+    return query.topLevelFilterFieldOptionSections(null, 2, true);
   }, [query]);
 
   const handleAddFilter = useCallback((filter: Filter) => {

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterSelect/BulkFilterSelect.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterSelect/BulkFilterSelect.styled.tsx
@@ -1,6 +1,7 @@
 import styled from "@emotion/styled";
 import SelectButton from "metabase/core/components/SelectButton";
 import FilterPopover from "../../FilterPopover";
+import Select from "metabase/core/components/Select";
 
 export const SelectFilterButton = styled(SelectButton)`
   min-height: 2.25rem;
@@ -8,6 +9,10 @@ export const SelectFilterButton = styled(SelectButton)`
   &:not(:first-of-type) {
     margin-top: 0.75rem;
   }
+`;
+
+export const SegmentSelect = styled(Select)`
+  min-height: 2.25rem;
 `;
 
 export const SelectFilterPopover = styled(FilterPopover)`

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterSelect/BulkFilterSelect.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterSelect/BulkFilterSelect.tsx
@@ -4,7 +4,6 @@ import { xor } from "lodash";
 import StructuredQuery, {
   SegmentOption,
 } from "metabase-lib/lib/queries/StructuredQuery";
-import Select from "metabase/core/components/Select";
 
 import Filter from "metabase-lib/lib/queries/structured/Filter";
 import Dimension from "metabase-lib/lib/Dimension";
@@ -12,6 +11,7 @@ import TippyPopoverWithTrigger from "metabase/components/PopoverWithTrigger/Tipp
 import {
   SelectFilterButton,
   SelectFilterPopover,
+  SegmentSelect,
 } from "./BulkFilterSelect.styled";
 
 export interface BulkFilterSelectProps {
@@ -128,19 +128,15 @@ export const SegmentFilterSelect = ({
   );
 
   return (
-    <div>
-      <Select
-        options={segments.map(segment => ({
-          name: segment.name,
-          value: segment,
-          icon: segment.icon,
-        }))}
-        value={activeSegments}
-        multiple={true}
-        optionNameFn={(o: any) => o?.name}
-        optionValueFn={(o: any) => o?.value ?? o}
-        onChange={(e: any) => toggleSegment(e.target.value)}
-      />
-    </div>
+    <SegmentSelect
+      options={segments.map(segment => ({
+        name: segment.name,
+        value: segment,
+        icon: segment.icon,
+      }))}
+      value={activeSegments}
+      multiple={true}
+      onChange={(e: any) => toggleSegment(e.target.value)}
+    />
   );
 };

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterSelect/BulkFilterSelect.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterSelect/BulkFilterSelect.tsx
@@ -113,7 +113,14 @@ export const SegmentFilterSelect = ({
   const toggleSegment = useCallback(
     (changedSegment: SegmentOption) => {
       const segmentIsActive = activeSegmentOptions.includes(changedSegment);
-      const segmentFilter = new Filter(changedSegment.filter, null, query);
+
+      const segmentFilter = segmentIsActive
+        ? (query
+            .filters()
+            .find(
+              f => f[0] === "segment" && f[1] === changedSegment.filter[1],
+            ) as Filter)
+        : new Filter(changedSegment.filter, null, query);
 
       segmentIsActive
         ? onRemoveFilter(segmentFilter)

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterSelect/BulkFilterSelect.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterSelect/BulkFilterSelect.tsx
@@ -92,7 +92,6 @@ const getNewFilter = (query: StructuredQuery, dimension: Dimension): Filter => {
 
 export interface SegmentFilterSelectProps {
   query: StructuredQuery;
-  filters?: Filter[];
   segments: SegmentOption[];
   onAddFilter: (filter: Filter) => void;
   onRemoveFilter: (filter: Filter) => void;
@@ -100,31 +99,27 @@ export interface SegmentFilterSelectProps {
 
 export const SegmentFilterSelect = ({
   query,
-  filters,
   segments,
   onAddFilter,
   onRemoveFilter,
 }: SegmentFilterSelectProps): JSX.Element => {
-  const activeSegments = useMemo(() => {
-    return segments.filter(segment => {
-      return !!filters?.find(
-        filter => filter[0] === "segment" && filter[1] === segment.filter[1],
-      );
-    });
-  }, [filters, segments]);
+  const activeSegmentOptions = useMemo(() => {
+    const activeSegmentIds = query.segments().map(s => s.id);
+    return segments.filter(segment =>
+      activeSegmentIds.includes(segment.filter[1]),
+    );
+  }, [query, segments]);
 
   const toggleSegment = useCallback(
-    (newActiveSegments: SegmentOption[]) => {
-      const [changedSegment] = xor(newActiveSegments, activeSegments);
-      const segmentIsActive = activeSegments.includes(changedSegment);
-
+    (changedSegment: SegmentOption) => {
+      const segmentIsActive = activeSegmentOptions.includes(changedSegment);
       const segmentFilter = new Filter(changedSegment.filter, null, query);
 
       segmentIsActive
         ? onRemoveFilter(segmentFilter)
         : onAddFilter(segmentFilter);
     },
-    [query, activeSegments, onRemoveFilter, onAddFilter],
+    [query, activeSegmentOptions, onRemoveFilter, onAddFilter],
   );
 
   return (
@@ -134,9 +129,9 @@ export const SegmentFilterSelect = ({
         value: segment,
         icon: segment.icon,
       }))}
-      value={activeSegments}
-      multiple={true}
-      onChange={(e: any) => toggleSegment(e.target.value)}
+      value={activeSegmentOptions}
+      onChange={(e: any) => toggleSegment(e.target.value.changedItem)}
+      multiple
     />
   );
 };

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterSelect/BulkFilterSelect.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterSelect/BulkFilterSelect.tsx
@@ -95,6 +95,7 @@ export interface SegmentFilterSelectProps {
   segments: SegmentOption[];
   onAddFilter: (filter: Filter) => void;
   onRemoveFilter: (filter: Filter) => void;
+  onClearSegments: () => void;
 }
 
 export const SegmentFilterSelect = ({
@@ -102,6 +103,7 @@ export const SegmentFilterSelect = ({
   segments,
   onAddFilter,
   onRemoveFilter,
+  onClearSegments,
 }: SegmentFilterSelectProps): JSX.Element => {
   const activeSegmentOptions = useMemo(() => {
     const activeSegmentIds = query.segments().map(s => s.id);
@@ -139,6 +141,16 @@ export const SegmentFilterSelect = ({
       value={activeSegmentOptions}
       onChange={(e: any) => toggleSegment(e.target.value.changedItem)}
       multiple
+      buttonProps={{
+        hasValue: activeSegmentOptions.length > 0,
+        highlighted: true,
+        onClear: onClearSegments,
+      }}
+      buttonText={
+        activeSegmentOptions.length > 1
+          ? `${activeSegmentOptions.length} segments`
+          : null
+      }
     />
   );
 };

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterSelect/index.ts
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterSelect/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./BulkFilterSelect";
+export * from "./BulkFilterSelect";


### PR DESCRIPTION
## Description

- Add support for filtering by segments in bulk filter modal
- (fixes bug where bulk filter modal would crash on a table with segments)

![Screenshot from 2022-05-23 13-28-55](https://user-images.githubusercontent.com/30528226/169902005-6b633498-0117-4689-9f62-0e3b51d91418.png)

## Testing Steps

1. Create one or more segments on a table (the orders table works well) `/admin/datamodel/segments`
> suggested filters: orders with total over $100, orders with discount over $0
2. Browse to the orders table
3. In the filter modal, see that both of your newly-created segments appear, and that you can apply one or both of them
4. See that you can remove segment filters by re-entering the filter modal.