### PR TITLE
Add M1 section to the dev guide

### DIFF
--- a/docs/developers-guide/build.md
+++ b/docs/developers-guide/build.md
@@ -38,6 +38,20 @@ sudo update-alternatives --config java
 
 Then select Java 11 in the menu.
 
+### Running on M1 Apple computers
+
+If you are developing on newer Apple M1 computers, please note that the current NodeJS LTS (v16.15.0) has native support for arm architecture. However, make sure you have Rosetta 2 installed before you attempt to build the frontend:
+
+```
+/usr/sbin/softwareupdate --install-rosetta (root permission not required)
+```
+
+or
+
+```
+/usr/sbin/softwareupdate --install-rosetta --agree-to-license (root permission required)
+```
+
 ### If you're running Windows, use WSL
 
 If you are developing on Windows, you should run Ubuntu on Windows Subsystem for Linux (WSL) and follow instructions for Ubuntu/Linux.


### PR DESCRIPTION
I ran into this issue today while setting up new M1 laptop and couldn't find the guide. Here's the related [Slack thread](https://metaboat.slack.com/archives/C505ZNNH4/p1653315593631439).

Although `node -p process.arch` returns `arm64`, and the current Node LTS supports arm architecture natively, my build was constantly failing with the following error:

```
[frontend] <e> [webpack-dev-middleware] Error: spawn Unknown system error -86
[frontend] <e>     at ChildProcess.spawn (node:internal/child_process:413:11)
[frontend] <e>     at spawn (node:child_process:700:9)
[frontend] <e>     at Object.execFile (node:child_process:327:17)
[frontend] <e>     at Object.module.exports.fileCommandJson (/Users/metabase/code/metabase/node_modules/node-notifier/lib/utils.js:83:13)
[frontend] <e>     at NotificationCenter.notify (/Users/metabase/code/metabase/node_modules/node-notifier/notifiers/notificationcenter.js:81:11)
[frontend] <e>     at module.exports.WebpackNotifierPlugin.compilationDone (/Users/metabase/code/metabase/node_modules/webpack-notifier/index.js:78:18)
[frontend] <e>     at Hook.eval [as callAsync] (eval at create (/Users/metabase/code/metabase/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:14:1)
[frontend] <e>     at Watching._done (/Users/metabase/code/metabase/node_modules/webpack/lib/Watching.js:287:28)
[frontend] <e>     at /Users/metabase/code/metabase/node_modules/webpack/lib/Watching.js:209:21
[frontend] <e>     at Compiler.emitRecords (/Users/metabase/code/metabase/node_modules/webpack/lib/Compiler.js:906:5) {
[frontend] <e>   errno: -86,
[frontend] <e>   code: 'Unknown system error -86',
[frontend] <e>   syscall: 'spawn'
[frontend] <e> }
```

The only thing that helped was installing Rosetta 2. It worked like a charm after that.