### PR TITLE
Allow multi-line strings using `str` in translation macros

### DIFF
--- a/bin/i18n/src/i18n/enumerate.clj
+++ b/bin/i18n/src/i18n/enumerate.clj
@@ -59,11 +59,16 @@
                             :args (s/+ any?))))
 
 (defn- form->string-for-translation
-  "Function that turns a form into the translation string. At the moment
-  it is just the second arg of the form. Afterwards it will need to
-  concat string literals in a `(str \"foo\" \"bar\")` situation. "
+  "Function that turns a form into the translation string. Handles string literals and calls to `str` on string
+  literals.
+
+  (form->string-for-translation (tru \"Foo {0}\")) -> \"Foo {0}\"
+  (form->string-for-translation (tru (str \"Foo {0} \" \"Bar\")) -> \"Foo {0} Bar\""
   [form]
-  (second form))
+  (let [i18n-spot (second form)]
+    (if (string? i18n-spot)
+      i18n-spot
+      (apply str (rest i18n-spot)))))
 
 (defn- analyze-translations
   [roots]

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -264,9 +264,10 @@
   :default 60.0)
 
 (defsetting query-caching-ttl-ratio
-  (str (deferred-tru "To determine how long each saved question''s cached result should stick around, we take the query''s average execution time and multiply that by whatever you input here.")
-       " "
-       (deferred-tru "So if a query takes on average 2 minutes to run, and you input 10 for your multiplier, its cache entry will persist for 20 minutes."))
+  (deferred-tru
+   (str "To determine how long each saved question''s cached result should stick around, we take the query''s average "
+        "execution time and multiply that by whatever you input here. So if a query takes on average 2 minutes to run, "
+        "and you input 10 for your multiplier, its cache entry will persist for 20 minutes."))
   :type    :integer
   :default 10)
 
@@ -281,13 +282,17 @@
   :default    "Metabase")
 
 (defsetting application-colors
-  (deferred-tru "These are the primary colors used in charts and throughout Metabase. You might need to refresh your browser to see your changes take effect.")
+  (deferred-tru
+   (str "These are the primary colors used in charts and throughout Metabase. "
+        "You might need to refresh your browser to see your changes take effect."))
   :visibility :public
   :type       :json
   :default    {})
 
 (defsetting application-font
-  (deferred-tru "This is the primary font used in charts and throughout Metabase. You might need to refresh your browser to see your changes take effect.")
+  (deferred-tru
+   (str "This is the primary font used in charts and throughout Metabase. "
+        "You might need to refresh your browser to see your changes take effect."))
   :visibility :public
   :type       :string
   :default    "Lato"
@@ -334,12 +339,16 @@
                     true))))
 
 (defsetting breakout-bins-num
-  (deferred-tru "When using the default binning strategy and a number of bins is not provided, this number will be used as the default.")
+  (deferred-tru
+    (str "When using the default binning strategy and a number of bins is not provided, "
+         "this number will be used as the default."))
   :type :integer
   :default 8)
 
 (defsetting breakout-bin-width
-  (deferred-tru "When using the default binning strategy for a field of type Coordinate (such as Latitude and Longitude), this number will be used as the default bin width (in degrees).")
+  (deferred-tru
+   (str "When using the default binning strategy for a field of type Coordinate (such as Latitude and Longitude), "
+        "this number will be used as the default bin width (in degrees)."))
   :type :double
   :default 10.0)
 
@@ -356,19 +365,25 @@
   :visibility :authenticated)
 
 (defsetting show-homepage-data
-  (deferred-tru "Whether or not to display data on the homepage. Admins might turn this off in order to direct users to better content than raw data")
+  (deferred-tru
+   (str "Whether or not to display data on the homepage. "
+        "Admins might turn this off in order to direct users to better content than raw data"))
   :type       :boolean
   :default    true
   :visibility :authenticated)
 
 (defsetting show-homepage-xrays
-  (deferred-tru "Whether or not to display x-ray suggestions on the homepage. They will also be hidden if any dashboards are pinned. Admins might hide this to direct users to better content than raw data")
+  (deferred-tru
+    (str "Whether or not to display x-ray suggestions on the homepage. They will also be hidden if any dashboards are "
+         "pinned. Admins might hide this to direct users to better content than raw data"))
   :type       :boolean
   :default    true
   :visibility :authenticated)
 
 (defsetting show-homepage-pin-message
-  (deferred-tru "Whether or not to display a message about pinning dashboards. It will also be hidden if any dashboards are pinned. Admins might hide this to direct users to better content than raw data")
+  (deferred-tru
+   (str "Whether or not to display a message about pinning dashboards. It will also be hidden if any dashboards are "
+        "pinned. Admins might hide this to direct users to better content than raw data"))
   :type       :boolean
   :default    true
   :visibility :authenticated)
@@ -503,9 +518,9 @@
                   (fetch-cloud-gateway-ips-fn))))
 
 (defsetting show-database-syncing-modal
-  (str (deferred-tru "Whether an introductory modal should be shown after the next database connection is added.")
-       " "
-       (deferred-tru "Defaults to false if any non-default database has already finished syncing for this instance."))
+  (deferred-tru
+    (str "Whether an introductory modal should be shown after the next database connection is added. "
+         "Defaults to false if any non-default database has already finished syncing for this instance."))
   :visibility :admin
   :type       :boolean
   :getter     (fn []

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -118,9 +118,9 @@
 ;; This value is *guaranteed* to never have a trailing slash :D
 ;; It will also prepend `http://` to the URL if there's no protocol when it comes in
 (defsetting site-url
-  (str (deferred-tru "This URL is used for things like creating links in emails, auth redirects,")
-       " "
-       (deferred-tru "and in some embedding scenarios, so changing it could break functionality or get you locked out of this instance."))
+  (deferred-tru
+   (str "This URL is used for things like creating links in emails, auth redirects, and in some embedding scenarios, "
+        "so changing it could break functionality or get you locked out of this instance."))
   :visibility :public
   :getter (fn []
             (try
@@ -136,9 +136,9 @@
               (setting/set-value-of-type! :string :site-url new-value))))
 
 (defsetting site-locale
-  (str (deferred-tru "The default language for all users across the Metabase UI, system emails, pulses, and alerts.")
-       " "
-       (deferred-tru "Users can individually override this default language from their own account settings."))
+  (deferred-tru
+    (str "The default language for all users across the Metabase UI, system emails, pulses, and alerts. "
+         "Users can individually override this default language from their own account settings."))
   :default    "en"
   :visibility :public
   :setter     (fn [new-value]
@@ -292,10 +292,10 @@
   :type       :string
   :default    "Lato"
   :setter (fn [new-value]
-                (when new-value
-                  (when-not (u.fonts/available-font? new-value)
-                    (throw (ex-info (tru "Invalid font {0}" (pr-str new-value)) {:status-code 400}))))
-                (setting/set-value-of-type! :string :application-font new-value)))
+              (when new-value
+                (when-not (u.fonts/available-font? new-value)
+                  (throw (ex-info (tru "Invalid font {0}" (pr-str new-value)) {:status-code 400}))))
+              (setting/set-value-of-type! :string :application-font new-value)))
 
 (defn application-color
   "The primary color, a.k.a. brand color"

--- a/src/metabase/util/i18n.clj
+++ b/src/metabase/util/i18n.clj
@@ -122,7 +122,7 @@
   (let [format-string              (cond
                                      (string? format-string-or-str) format-string-or-str
                                      (valid-str-form? format-string-or-str) (apply str (rest format-string-or-str))
-                                     :else (assert false "The first arg to (deferred-)trs/tru must be a String or a valid `str` form!"))
+                                     :else (assert false "The first arg to (deferred-)trs/tru must be a String or a valid `str` form with String arguments!"))
         message-format             (MessageFormat. format-string)
         ;; number of {n} placeholders in format string including any you may have skipped. e.g. "{0} {2}" -> 3
         expected-num-args-by-index (count (.getFormatsByArgumentIndex message-format))
@@ -141,8 +141,12 @@
 (defmacro deferred-tru
   "Similar to `tru` but creates a `UserLocalizedString` instance so that conversion to the correct locale can be delayed
   until it is needed. The user locale comes from the browser, so conversion to the localized string needs to be 'late
-  bound' and only occur when the user's locale is in scope. Calling `str` on the results of this invocation will
-  lookup the translated version of the string."
+  bound' and only occur when the user's locale is in scope.
+
+  The first argument can be a format string, or a valid `str` form with all string arguments. The latter can be used to
+  split a long string over multiple lines.
+
+  Calling `str` on the results of this invocation will lookup the translated version of the string."
   [format-string-or-str & args]
   (validate-number-of-args format-string-or-str args)
   `(UserLocalizedString. ~format-string-or-str ~(vec args)))
@@ -150,6 +154,10 @@
 (defmacro deferred-trs
   "Similar to `trs` but creates a `SiteLocalizedString` instance so that conversion to the correct locale can be
   delayed until it is needed. This is needed as the system locale from the JVM can be overridden/changed by a setting.
+
+  The first argument can be a format string, or a valid `str` form with all string arguments. The latter can be used to
+  split a long string over multiple lines.
+
   Calling `str` on the results of this invocation will lookup the translated version of the string."
   [format-string & args]
   (validate-number-of-args format-string args)
@@ -164,17 +172,25 @@
 
 (defmacro tru
   "Applies `str` to `deferred-tru`'s expansion.
+
+  The first argument can be a format string, or a valid `str` form with all string arguments. The latter can be used to
+  split a long string over multiple lines.
+
   Prefer this over `deferred-tru`. Use `deferred-tru` only in code executed at compile time, or where `str` is manually
   applied to the result."
-  [format-string & args]
-  `(str* (deferred-tru ~format-string ~@args)))
+  [format-string-or-str & args]
+  `(str* (deferred-tru ~format-string-or-str ~@args)))
 
 (defmacro trs
   "Applies `str` to `deferred-trs`'s expansion.
+
+  The first argument can be a format string, or a valid `str` form with all string arguments. The latter can be used to
+  split a long string over multiple lines.
+
   Prefer this over `deferred-trs`. Use `deferred-trs` only in code executed at compile time, or where `str` is manually
   applied to the result."
-  [format-string & args]
-  `(str* (deferred-trs ~format-string ~@args)))
+  [format-string-or-str & args]
+  `(str* (deferred-trs ~format-string-or-str ~@args)))
 
 ;; TODO - I seriously doubt whether these are still actually needed now that `tru` and `trs` generate forms wrapped in
 ;; `str` by default

--- a/test/metabase/util/i18n_test.clj
+++ b/test/metabase/util/i18n_test.clj
@@ -11,8 +11,14 @@
 
 (deftest tru-test
   (mt/with-mock-i18n-bundles {"es" {"must be {0} characters or less" "deben tener {0} caracteres o menos"}}
-    (doseq [[message f] {"tru"          (fn [] (i18n/tru "must be {0} characters or less" 140))
-                         "deferred-tru" (fn [] (str (i18n/deferred-tru "must be {0} characters or less" 140)))}]
+    (doseq [[message f] {"tru"
+                         (fn [] (i18n/tru "must be {0} characters or less" 140))
+                         "tru with str"
+                         (fn [] (i18n/tru (str "must be " "{0} characters or less") 140))
+                         "deferred-tru"
+                         (fn [] (str (i18n/deferred-tru "must be {0} characters or less" 140)))
+                         "deferred-tru with str"
+                         (fn [] (str (i18n/deferred-tru (str "must be " "{0} characters or less") 140)))}]
       (testing message
         (testing "Should fall back to English if user locale & system locale are unset"
           (mt/with-temporary-setting-values [site-locale nil]
@@ -36,8 +42,14 @@
 
 (deftest trs-test
   (mt/with-mock-i18n-bundles {"es" {"must be {0} characters or less" "deben tener {0} caracteres o menos"}}
-    (doseq [[message f] {"trs"          (fn [] (i18n/trs "must be {0} characters or less" 140))
-                         "deferred-trs" (fn [] (str (i18n/deferred-trs "must be {0} characters or less" 140)))}]
+    (doseq [[message f] {"trs"
+                         (fn [] (i18n/trs "must be {0} characters or less" 140))
+                         "trs with str"
+                         (fn [] (i18n/trs (str "must be " "{0} characters or less") 140))
+                         "deferred-trs"
+                         (fn [] (str (i18n/deferred-trs "must be {0} characters or less" 140)))
+                         "deferred-trs with str"
+                         (fn [] (str (i18n/deferred-trs (str "must be " "{0} characters or less") 140)))}]
       (testing message
         (testing "Should fall back to English if user locale & system locale are unset"
           (mt/with-temporary-setting-values [site-locale nil]
@@ -97,4 +109,13 @@
         (is (thrown-with-msg?
              AssertionError
              #"missing some \{\} placeholders\. Expected \{0\}, \{1\}"
-             (#'i18n/validate-number-of-args "{1}" [0 1])))))))
+             (#'i18n/validate-number-of-args "{1}" [0 1]))))))
+
+  (testing "The number of args is still validated if the first argument is a `str` form"
+      (is (thrown?
+           clojure.lang.Compiler$CompilerException
+           (walk/macroexpand-all `(i18n/trs (~'str "{0}" "{1}") 0))))
+      (is (thrown-with-msg?
+           AssertionError
+           #"expects 2 args, got 1"
+           (#'i18n/validate-number-of-args '(str "{0}" "{1}") [0])))))


### PR DESCRIPTION
This is a proposal for a potential way to solve #10770, which is an issue that I've seen come up a couple times now for me and others.

Basically, this change means that the `tru`, `trs`, `deferred-tru` and `deferred-trs` macros can take as a first argument _either_ a string, or a `str` form that has all strings as arguments. If the latter is used, the strings are concatenated (using `str`) before the `UserLocalizedString`/`SiteLocalizedString` is created. The `str` is basically just syntactic sugar; it could equally be a vector of strings that are implicitly joined or something similar, but this syntax seemed intuitive.

This allows us to break up long strings over multiple lines but have them translated as a single unit. It also fixes some bugs where `str` was being used to join multiple `deferred-tru` macros in code that was executed at compile-time, thus losing the advantage of a deferred translation lookup. This happened in a couple setting descriptions, so I've converted those to use the new syntax as examples (as well as a few others that were exceeding 120 chars).