### PR TITLE
Save Filters in Filter Modal On Popover close

### DIFF
--- a/frontend/src/metabase/query_builder/components/filters/FilterPopover.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/FilterPopover.tsx
@@ -38,6 +38,7 @@ type Props = {
   onChangeFilter: (filter: Filter) => void;
 
   onClose?: () => void;
+  commitOnBlur?: boolean;
 
   noCommitButton?: boolean;
   showFieldPicker?: boolean;
@@ -60,6 +61,7 @@ export default class FilterPopover extends Component<Props, State> {
     style: {},
     showFieldPicker: true,
     showCustom: true,
+    commitOnBlur: false,
   };
 
   constructor(props: Props) {
@@ -82,6 +84,10 @@ export default class FilterPopover extends Component<Props, State> {
         filter: filter.setQuery(nextProps.query),
       });
     }
+  }
+
+  componentWillUnmount() {
+    this.props.commitOnBlur && this.handleCommit();
   }
 
   setFilter(filter: Filter, hideShortcuts = true) {

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterSelect/BulkFilterSelect.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterSelect/BulkFilterSelect.tsx
@@ -73,6 +73,7 @@ const BulkFilterSelect = ({
           showFieldPicker={false}
           onChangeFilter={handleChange}
           onClose={closePopover}
+          commitOnBlur
         />
       )}
     />


### PR DESCRIPTION
## Description
- since we don't actually re-run our query until the modal is closed, we can reduce some friction by saving filter changes whenever the user clicks outside a popover
- adds an option to the filterPopover to allow changes to be commited on blur. defaults to false.

![Screenshot from 2022-05-23 15-57-02](https://user-images.githubusercontent.com/30528226/169912036-b14b7121-b065-44aa-9a55-fdf39bbee406.png)

## Testing steps

- open any table and open the filter modal from the `...` button up top
- change some filter options, but instead of clicking "apply", just click outside the popover
- see that the changes save
- see that this behavior does not carry over to other places the filter popover is used (like the notebook editor)