### PR TITLE
[E2E] Remove `dashboard` group from checks on CCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1248,7 +1248,6 @@ workflows:
                 [
                   "admin",
                   "collections",
-                  "dashboard",
                   "embedding",
                   "filters",
                   "models",


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- In the same manner we did for #21991, this PR removes `dashboard` E2E group from CircleCI because we've been running it successfully using GitHub actions.