### PR TITLE
Put model refers on their own line in cmd.copy

### DIFF
--- a/src/metabase/cmd/copy.clj
+++ b/src/metabase/cmd/copy.clj
@@ -9,14 +9,47 @@
             [metabase.db.connection :as mdb.connection]
             [metabase.db.data-migrations :refer [DataMigrations]]
             [metabase.db.setup :as mdb.setup]
-            [metabase.models :refer [Activity ApplicationPermissionsRevision BookmarkOrdering Card CardBookmark
-                                     Collection CollectionBookmark CollectionPermissionGraphRevision
-                                     Dashboard DashboardBookmark DashboardCard DashboardCardSeries
-                                     Database Dependency Dimension Field FieldValues
-                                     LoginHistory Metric MetricImportantField ModerationReview NativeQuerySnippet
-                                     Permissions PermissionsGroup PermissionsGroupMembership PermissionsRevision PersistedInfo Pulse PulseCard
-                                     PulseChannel PulseChannelRecipient Revision Secret Segment Session Setting Table
-                                     Timeline TimelineEvent User ViewLog]]
+            [metabase.models :refer [Activity
+                                     ApplicationPermissionsRevision
+                                     BookmarkOrdering
+                                     Card
+                                     CardBookmark
+                                     Collection
+                                     CollectionBookmark
+                                     CollectionPermissionGraphRevision
+                                     Dashboard
+                                     DashboardBookmark
+                                     DashboardCard
+                                     DashboardCardSeries
+                                     Database
+                                     Dependency
+                                     Dimension
+                                     Field
+                                     FieldValues
+                                     LoginHistory
+                                     Metric
+                                     MetricImportantField
+                                     ModerationReview
+                                     NativeQuerySnippet
+                                     Permissions
+                                     PermissionsGroup
+                                     PermissionsGroupMembership
+                                     PermissionsRevision
+                                     PersistedInfo
+                                     Pulse
+                                     PulseCard
+                                     PulseChannel
+                                     PulseChannelRecipient
+                                     Revision
+                                     Secret
+                                     Segment
+                                     Session
+                                     Setting
+                                     Table
+                                     Timeline
+                                     TimelineEvent
+                                     User
+                                     ViewLog]]
             [metabase.util :as u]
             [metabase.util.i18n :refer [trs]]
             [schema.core :as s])


### PR DESCRIPTION
Since we have linters that force the refers to be both sorted and max
lined, adding new models in the middled forced people to realign the whole refer vector.

Having run into this twice, if we keep refers each on their own line the
initial add, as well as merges will both be much less painful.
