### PR TITLE
[E2E] Robustify relative date time tests by assertions sync with the UI

### DIFF
--- a/frontend/test/metabase/scenarios/filters/relative-datetime.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/relative-datetime.cy.spec.js
@@ -191,14 +191,16 @@ describe("scenarios > question > relative-datetime", () => {
       cy.wait("@dataset");
 
       cy.intercept("POST", "/api/dataset").as("dataset");
-      cy.findByText("Created At Previous Month, starting 7 months ago").click();
+      cy.findByTextEnsureVisible(
+        "Created At Previous Month, starting 7 months ago",
+      ).click();
       setRelativeDatetimeValue(3);
       popover().within(() => {
         cy.findByText("Update filter").click();
       });
       cy.wait("@dataset");
 
-      cy.findByText(
+      cy.findByTextEnsureVisible(
         "Created At Previous 3 Months, starting 7 months ago",
       ).click();
       setStartingFromValue(30);
@@ -206,9 +208,9 @@ describe("scenarios > question > relative-datetime", () => {
         cy.findByText("Update filter").click();
       });
       cy.wait("@dataset");
-      cy.findByText(
+      cy.findByTextEnsureVisible(
         "Created At Previous 3 Months, starting 30 months ago",
-      ).should("exist");
+      );
     });
 
     it("starting from option should set correct sign (metabase#22228)", () => {
@@ -277,7 +279,7 @@ const setRelativeDatetimeUnit = unit => {
   cy.findByTestId("relative-datetime-unit").click();
   popover()
     .last()
-    .within(() => cy.findByText(unit).click());
+    .within(() => cy.findByTextEnsureVisible(unit).click());
 };
 
 const setRelativeDatetimeValue = value => {
@@ -304,9 +306,9 @@ const setStartingFromValue = value => {
 };
 
 const withStartingFrom = (dir, [num, unit], [startNum, startUnit]) => {
-  cy.findByText("testcol").click();
-  cy.findByText("Filter by this column").click();
-  cy.findByText("Relative dates...").click();
+  cy.findByTextEnsureVisible("testcol").click();
+  cy.findByTextEnsureVisible("Filter by this column").click();
+  cy.findByTextEnsureVisible("Relative dates...").click();
   popover().within(() => {
     cy.findByText(dir).click();
   });


### PR DESCRIPTION
To verify, run `yarn test-visual-open` and pick `relative-datetime.cy.spec.js` to run.

### Before

The tests in `frontend/test/metabase/scenarios/filters/relative-datetime.cy.spec.js` sometimes fail miserably in CI:

![image](https://user-images.githubusercontent.com/7288/170100461-1ba86179-fcb8-4e2c-9fdb-41f9954e880f.png)

### After

Those kinds of failure should happen less since now some important assertions are sync-ed with the element visibility.