### PR TITLE
Move parameter date widget formatting code to utils file

### DIFF
--- a/frontend/src/metabase/components/DateAllOptionsWidget/DateAllOptionsWidget.tsx
+++ b/frontend/src/metabase/components/DateAllOptionsWidget/DateAllOptionsWidget.tsx
@@ -4,108 +4,16 @@ import _ from "underscore";
 import cx from "classnames";
 
 import { dateParameterValueToMBQL } from "metabase/parameters/utils/mbql";
-import DatePicker, {
-  DATE_OPERATORS,
-} from "metabase/query_builder/components/filters/pickers/DatePicker/DatePicker";
+import DatePicker from "metabase/query_builder/components/filters/pickers/DatePicker/DatePicker";
 import {
-  generateTimeFilterValuesDescriptions,
-  getRelativeDatetimeInterval,
-  getStartingFrom,
-} from "metabase/lib/query_time";
-import { EXCLUDE_OPERATORS } from "metabase/query_builder/components/filters/pickers/DatePicker/ExcludeDatePicker";
+  filterToUrlEncoded,
+  formatAllOptionsWidget,
+} from "metabase/parameters/utils/date-formatting";
 
 import { Container, UpdateButton } from "./DateWidget.styled";
 
 // Use a placeholder value as field references are not used in dashboard filters
 const noopRef = null;
-
-function getFilterValueSerializer(func: (...args: any[]) => string) {
-  return (filter: any[]) => {
-    const startingFrom = getStartingFrom(filter);
-    if (startingFrom) {
-      const [value, unit] = getRelativeDatetimeInterval(filter);
-      return func(value, unit, { startingFrom });
-    } else {
-      return func(filter[2], filter[3], filter[4] || {});
-    }
-  };
-}
-
-const serializersByOperatorName: Record<string, (...args: any[]) => string> = {
-  previous: getFilterValueSerializer((value, unit, options = {}) => {
-    if (options.startingFrom) {
-      const [fromValue, fromUnit] = options.startingFrom;
-      return `past${-value}${unit}s-from-${fromValue}${fromUnit}s`;
-    }
-    return `past${-value}${unit}s${options["include-current"] ? "~" : ""}`;
-  }),
-  next: getFilterValueSerializer((value, unit, options = {}) => {
-    if (options.startingFrom) {
-      const [fromValue, fromUnit] = options.startingFrom;
-      return `next${value}${unit}s-from-${-fromValue}${fromUnit}s`;
-    }
-    return `next${value}${unit}s${options["include-current"] ? "~" : ""}`;
-  }),
-  current: getFilterValueSerializer((_, unit) => `this${unit}`),
-  before: getFilterValueSerializer(value => `~${value}`),
-  after: getFilterValueSerializer(value => `${value}~`),
-  on: getFilterValueSerializer(value => `${value}`),
-  between: getFilterValueSerializer((from, to) => `${from}~${to}`),
-  exclude: (filter: any[]) => {
-    const [_op, _field, ...values] = filter;
-    const operator = getExcludeOperator(filter);
-    if (!operator) {
-      return "";
-    }
-    const options = operator
-      .getOptions()
-      .flat()
-      .filter(({ test }) => !!_.find(values, (value: string) => test(value)));
-    return `exclude-${operator.name}-${options
-      .map(({ serialized }) => serialized)
-      .join("-")}`;
-  },
-};
-
-function getFilterOperator(filter: any[] = []) {
-  return DATE_OPERATORS.find(op => op.test(filter as any));
-}
-
-function getExcludeOperator(filter: any[] = []) {
-  return EXCLUDE_OPERATORS.find(op => op.test(filter as any));
-}
-
-function filterToUrlEncoded(filter: any[]) {
-  const operator = getFilterOperator(filter);
-  if (operator) {
-    return serializersByOperatorName[operator.name](filter);
-  } else {
-    return null;
-  }
-}
-
-const prefixedOperators = new Set([
-  "exclude",
-  "before",
-  "after",
-  "on",
-  "empty",
-  "not-empty",
-]);
-
-function getFilterTitle(filter: any[]) {
-  const values = generateTimeFilterValuesDescriptions(filter);
-  const desc =
-    values.length > 2
-      ? t`${values.length} selections`
-      : values.join(filter[0] === "!=" ? ", " : " - ");
-  const op = getFilterOperator(filter);
-  const prefix =
-    op && prefixedOperators.has(op.name)
-      ? `${op.displayPrefix ?? op.displayName} `
-      : "";
-  return prefix + desc;
-}
 
 interface DateAllOptionsWidgetProps {
   setValue: (value: string | null) => void;
@@ -156,13 +64,6 @@ const DateAllOptionsWidget = ({
   );
 };
 
-DateAllOptionsWidget.format = (urlEncoded: string) => {
-  if (urlEncoded == null) {
-    return null;
-  }
-  const filter = dateParameterValueToMBQL(urlEncoded, noopRef);
-
-  return filter ? getFilterTitle(filter) : null;
-};
+DateAllOptionsWidget.format = formatAllOptionsWidget;
 
 export default DateAllOptionsWidget;

--- a/frontend/src/metabase/components/DateMonthYearWidget/DateMonthYearWidget.tsx
+++ b/frontend/src/metabase/components/DateMonthYearWidget/DateMonthYearWidget.tsx
@@ -4,6 +4,7 @@ import _ from "underscore";
 import cx from "classnames";
 
 import YearPicker from "metabase/components/YearPicker";
+import { formatMonthYearWidget } from "metabase/parameters/utils/date-formatting";
 
 import { MonthContainer, MonthList } from "./DateMonthYearWidget.styled";
 
@@ -41,10 +42,7 @@ class DateMonthYearWidget extends React.Component<Props, State> {
     }
   }
 
-  static format = (value: string) => {
-    const m = moment(value, "YYYY-MM");
-    return m.isValid() ? m.format("MMMM, YYYY") : "";
-  };
+  static format = formatMonthYearWidget;
 
   componentWillUnmount() {
     const { month, year } = this.state;

--- a/frontend/src/metabase/components/DateQuarterYearWidget/DateQuarterYearWidget.tsx
+++ b/frontend/src/metabase/components/DateQuarterYearWidget/DateQuarterYearWidget.tsx
@@ -5,6 +5,7 @@ import cx from "classnames";
 import { t } from "ttag";
 
 import YearPicker from "metabase/components/YearPicker";
+import { formatQuarterYearWidget } from "metabase/parameters/utils/date-formatting";
 
 // translator: this is a "moment" format string (https://momentjs.com/docs/#/displaying/format/) It should include "Q" for the quarter number, and raw text can be escaped by brackets. For eample "[Quarter] Q" will be rendered as "Quarter 1" etc
 const QUARTER_FORMAT_STRING = t`[Q]Q`;
@@ -43,10 +44,7 @@ class DateQuarterYearWidget extends React.Component<Props, State> {
     }
   }
 
-  static format = (value: string) => {
-    const m = moment(value, "[Q]Q-YYYY");
-    return m.isValid() ? m.format("[Q]Q, YYYY") : "";
-  };
+  static format = formatQuarterYearWidget;
 
   componentWillUnmount() {
     const { quarter, year } = this.state;

--- a/frontend/src/metabase/components/DateRangeWidget/DateRangeWidget.tsx
+++ b/frontend/src/metabase/components/DateRangeWidget/DateRangeWidget.tsx
@@ -2,13 +2,7 @@ import React from "react";
 
 import moment from "moment";
 import DateAllOptionsWidget from "metabase/components/DateAllOptionsWidget";
-
-const SEPARATOR = "~"; // URL-safe
-
-function parseDateRangeValue(value: string) {
-  const [start, end] = (value || "").split(SEPARATOR);
-  return { start, end };
-}
+import { formatRangeWidget } from "metabase/parameters/utils/date-formatting";
 
 interface DateRangeWidgetProps {
   setValue: (value: string | null) => void;
@@ -31,13 +25,6 @@ const DateRangeWidget = ({ value, ...props }: DateRangeWidgetProps) => {
   );
 };
 
-DateRangeWidget.format = (value: string) => {
-  const { start, end } = parseDateRangeValue(value);
-  return start && end
-    ? moment(start).format("MMMM D, YYYY") +
-        " - " +
-        moment(end).format("MMMM D, YYYY")
-    : "";
-};
+DateRangeWidget.format = formatRangeWidget;
 
 export default DateRangeWidget;

--- a/frontend/src/metabase/components/DateRelativeWidget/DateRelativeWidget.tsx
+++ b/frontend/src/metabase/components/DateRelativeWidget/DateRelativeWidget.tsx
@@ -3,6 +3,9 @@ import { t } from "ttag";
 import cx from "classnames";
 import _ from "underscore";
 
+import { formatRelativeWidget } from "metabase/parameters/utils/date-formatting";
+import { DATE_MBQL_FILTER_MAPPING } from "metabase/parameters/constants";
+
 type Shortcut = {
   name: string;
   operator: string | string[];
@@ -151,57 +154,6 @@ export class PredefinedRelativeDatePicker extends React.Component<
   }
 }
 
-type FilterMap = {
-  [name: string]: {
-    name: string;
-    mapping: any[];
-  };
-};
-
-// HACK: easiest way to get working with RelativeDatePicker
-const FILTERS: FilterMap = {
-  today: {
-    name: t`Today`,
-    mapping: ["=", null, ["relative-datetime", "current"]],
-  },
-  yesterday: {
-    name: t`Yesterday`,
-    mapping: ["=", null, ["relative-datetime", -1, "day"]],
-  },
-  past7days: {
-    name: t`Past 7 Days`,
-    mapping: ["time-interval", null, -7, "day"],
-  },
-  past30days: {
-    name: t`Past 30 Days`,
-    mapping: ["time-interval", null, -30, "day"],
-  },
-  lastweek: {
-    name: t`Last Week`,
-    mapping: ["time-interval", null, "last", "week"],
-  },
-  lastmonth: {
-    name: t`Last Month`,
-    mapping: ["time-interval", null, "last", "month"],
-  },
-  lastyear: {
-    name: t`Last Year`,
-    mapping: ["time-interval", null, "last", "year"],
-  },
-  thisweek: {
-    name: t`This Week`,
-    mapping: ["time-interval", null, "current", "week"],
-  },
-  thismonth: {
-    name: t`This Month`,
-    mapping: ["time-interval", null, "current", "month"],
-  },
-  thisyear: {
-    name: t`This Year`,
-    mapping: ["time-interval", null, "current", "year"],
-  },
-};
-
 type DateRelativeWidgetProps = {
   value: string;
   setValue: (v?: string) => void;
@@ -213,17 +165,24 @@ class DateRelativeWidget extends React.Component<DateRelativeWidgetProps> {
     super(props);
   }
 
-  static format = (value: string) =>
-    FILTERS[value] ? FILTERS[value].name : "";
+  static format = formatRelativeWidget;
 
   render() {
     const { value, setValue, onClose } = this.props;
     return (
       <div className="px1" style={{ maxWidth: 300 }}>
         <PredefinedRelativeDatePicker
-          filter={FILTERS[value] ? FILTERS[value].mapping : [null, null]}
+          filter={
+            DATE_MBQL_FILTER_MAPPING[value]
+              ? DATE_MBQL_FILTER_MAPPING[value].mapping
+              : [null, null]
+          }
           onFilterChange={filter => {
-            setValue(_.findKey(FILTERS, f => _.isEqual(f.mapping, filter)));
+            setValue(
+              _.findKey(DATE_MBQL_FILTER_MAPPING, f =>
+                _.isEqual(f.mapping, filter),
+              ),
+            );
             onClose();
           }}
         />

--- a/frontend/src/metabase/components/DateSingleWidget/DateSingleWidget.tsx
+++ b/frontend/src/metabase/components/DateSingleWidget/DateSingleWidget.tsx
@@ -2,6 +2,7 @@ import React from "react";
 
 import moment from "moment";
 import DateAllOptionsWidget from "metabase/components/DateAllOptionsWidget";
+import { formatSingleWidget } from "metabase/parameters/utils/date-formatting";
 
 interface DateSingleWidgetProps {
   setValue: (value: string | null) => void;
@@ -20,7 +21,6 @@ const DateSingleWidget = ({ value, ...props }: DateSingleWidgetProps) => {
   );
 };
 
-DateSingleWidget.format = (value: string) =>
-  value ? moment(value).format("MMMM D, YYYY") : "";
+DateSingleWidget.format = formatSingleWidget;
 
 export default DateSingleWidget;

--- a/frontend/src/metabase/parameters/constants.ts
+++ b/frontend/src/metabase/parameters/constants.ts
@@ -163,3 +163,53 @@ export const FIELD_FILTER_PARAMETER_TYPES = [
   "category",
   "location",
 ];
+
+type FilterMap = {
+  [name: string]: {
+    name: string;
+    mapping: any[];
+  };
+};
+
+export const DATE_MBQL_FILTER_MAPPING: FilterMap = {
+  today: {
+    name: t`Today`,
+    mapping: ["=", null, ["relative-datetime", "current"]],
+  },
+  yesterday: {
+    name: t`Yesterday`,
+    mapping: ["=", null, ["relative-datetime", -1, "day"]],
+  },
+  past7days: {
+    name: t`Past 7 Days`,
+    mapping: ["time-interval", null, -7, "day"],
+  },
+  past30days: {
+    name: t`Past 30 Days`,
+    mapping: ["time-interval", null, -30, "day"],
+  },
+  lastweek: {
+    name: t`Last Week`,
+    mapping: ["time-interval", null, "last", "week"],
+  },
+  lastmonth: {
+    name: t`Last Month`,
+    mapping: ["time-interval", null, "last", "month"],
+  },
+  lastyear: {
+    name: t`Last Year`,
+    mapping: ["time-interval", null, "last", "year"],
+  },
+  thisweek: {
+    name: t`This Week`,
+    mapping: ["time-interval", null, "current", "week"],
+  },
+  thismonth: {
+    name: t`This Month`,
+    mapping: ["time-interval", null, "current", "month"],
+  },
+  thisyear: {
+    name: t`This Year`,
+    mapping: ["time-interval", null, "current", "year"],
+  },
+};

--- a/frontend/src/metabase/parameters/utils/date-formatting.ts
+++ b/frontend/src/metabase/parameters/utils/date-formatting.ts
@@ -1,0 +1,148 @@
+import { t } from "ttag";
+import _ from "underscore";
+import moment from "moment";
+
+import { DATE_MBQL_FILTER_MAPPING } from "metabase/parameters/constants";
+import { dateParameterValueToMBQL } from "metabase/parameters/utils/mbql";
+import { DATE_OPERATORS } from "metabase/query_builder/components/filters/pickers/DatePicker/DatePicker";
+import {
+  generateTimeFilterValuesDescriptions,
+  getRelativeDatetimeInterval,
+  getStartingFrom,
+} from "metabase/lib/query_time";
+import { EXCLUDE_OPERATORS } from "metabase/query_builder/components/filters/pickers/DatePicker/ExcludeDatePicker";
+
+// Use a placeholder value as field references are not used in dashboard filters
+const noopRef = null;
+const RANGE_SEPARATOR = "~"; // URL-safe
+
+function getFilterValueSerializer(func: (...args: any[]) => string) {
+  return (filter: any[]) => {
+    const startingFrom = getStartingFrom(filter);
+    if (startingFrom) {
+      const [value, unit] = getRelativeDatetimeInterval(filter);
+      return func(value, unit, { startingFrom });
+    } else {
+      return func(filter[2], filter[3], filter[4] || {});
+    }
+  };
+}
+
+const serializersByOperatorName: Record<string, (...args: any[]) => string> = {
+  previous: getFilterValueSerializer((value, unit, options = {}) => {
+    if (options.startingFrom) {
+      const [fromValue, fromUnit] = options.startingFrom;
+      return `past${-value}${unit}s-from-${fromValue}${fromUnit}s`;
+    }
+    return `past${-value}${unit}s${options["include-current"] ? "~" : ""}`;
+  }),
+  next: getFilterValueSerializer((value, unit, options = {}) => {
+    if (options.startingFrom) {
+      const [fromValue, fromUnit] = options.startingFrom;
+      return `next${value}${unit}s-from-${-fromValue}${fromUnit}s`;
+    }
+    return `next${value}${unit}s${options["include-current"] ? "~" : ""}`;
+  }),
+  current: getFilterValueSerializer((_, unit) => `this${unit}`),
+  before: getFilterValueSerializer(value => `~${value}`),
+  after: getFilterValueSerializer(value => `${value}~`),
+  on: getFilterValueSerializer(value => `${value}`),
+  between: getFilterValueSerializer((from, to) => `${from}~${to}`),
+  exclude: (filter: any[]) => {
+    const [_op, _field, ...values] = filter;
+    const operator = getExcludeOperator(filter);
+    if (!operator) {
+      return "";
+    }
+    const options = operator
+      .getOptions()
+      .flat()
+      .filter(({ test }) => !!_.find(values, (value: string) => test(value)));
+    return `exclude-${operator.name}-${options
+      .map(({ serialized }) => serialized)
+      .join("-")}`;
+  },
+};
+
+function getFilterOperator(filter: any[] = []) {
+  return DATE_OPERATORS.find(op => op.test(filter as any));
+}
+
+function getExcludeOperator(filter: any[] = []) {
+  return EXCLUDE_OPERATORS.find(op => op.test(filter as any));
+}
+
+export function filterToUrlEncoded(filter: any[]) {
+  const operator = getFilterOperator(filter);
+  if (operator) {
+    return serializersByOperatorName[operator.name](filter);
+  } else {
+    return null;
+  }
+}
+
+const prefixedOperators = new Set([
+  "exclude",
+  "before",
+  "after",
+  "on",
+  "empty",
+  "not-empty",
+]);
+
+function getFilterTitle(filter: any[]) {
+  const values = generateTimeFilterValuesDescriptions(filter);
+  const desc =
+    values.length > 2
+      ? t`${values.length} selections`
+      : values.join(filter[0] === "!=" ? ", " : " - ");
+  const op = getFilterOperator(filter);
+  const prefix =
+    op && prefixedOperators.has(op.name)
+      ? `${op.displayPrefix ?? op.displayName} `
+      : "";
+  return prefix + desc;
+}
+
+export function formatAllOptionsWidget(urlEncoded: string) {
+  if (urlEncoded == null) {
+    return null;
+  }
+  const filter = dateParameterValueToMBQL(urlEncoded, noopRef);
+
+  return filter ? getFilterTitle(filter) : null;
+}
+
+function parseDateRangeValue(value: string) {
+  const [start, end] = (value || "").split(RANGE_SEPARATOR);
+  return { start, end };
+}
+
+export function formatRangeWidget(value: string) {
+  const { start, end } = parseDateRangeValue(value);
+  return start && end
+    ? moment(start).format("MMMM D, YYYY") +
+        " - " +
+        moment(end).format("MMMM D, YYYY")
+    : "";
+}
+
+export function formatSingleWidget(value: string) {
+  return value ? moment(value).format("MMMM D, YYYY") : "";
+}
+
+export function formatMonthYearWidget(value: string) {
+  const m = moment(value, "YYYY-MM");
+  return m.isValid() ? m.format("MMMM, YYYY") : "";
+}
+
+export function formatQuarterYearWidget(value: string) {
+  const m = moment(value, "[Q]Q-YYYY");
+  return m.isValid() ? m.format("[Q]Q, YYYY") : "";
+}
+
+export function formatRelativeWidget(value: string) {
+  return DATE_MBQL_FILTER_MAPPING[value]
+    ? DATE_MBQL_FILTER_MAPPING[value].name
+    : "";
+}


### PR DESCRIPTION
Related to https://github.com/metabase/metabase/issues/22554

Parameter widget formatting code is a bit awkward. I'm moving all the date widget code to a separate `date-formatting.ts` utility function file. Didn't do anything besides rename a few ambiguously named constants.

The intent is to stop setting `FooComponent.format = () => {...}` on widget components and instead have a utility function `formatParameterValue (value: any, parameter: UiParameter): any` that we pass parameter values through when we want to format them. Right now, the formatting code is kind of all over the place.

**Testing**
1. Create a dashboard with the Orders table added to it
2. Wire up the "all options" date parameter, the "single" date parameter, and the "range" date parameter to one of the date fields on the Orders table
3. Test that the parameter still works
4. Refresh the page with values set in the parameter so that the URL value parsing code runs