### PR TITLE
Add/fix/improve parameter types

### DIFF
--- a/frontend/src/metabase-types/api/dashboard.ts
+++ b/frontend/src/metabase-types/api/dashboard.ts
@@ -1,5 +1,28 @@
+import {
+  ParameterTarget,
+  ParameterId,
+  Parameter,
+} from "metabase-types/types/Parameter";
+import { CardId, SavedCard } from "metabase-types/types/Card";
+
 export interface Dashboard {
   id: number;
   name: string;
   model?: string;
+  ordered_cards: DashboardOrderedCard[];
+  parameters?: Parameter[] | null;
 }
+
+export type DashboardOrderedCard = {
+  id: number;
+  card: SavedCard;
+  card_id: CardId;
+  parameter_mappings?: DashboardParameterMapping[] | null;
+  series?: SavedCard[];
+};
+
+export type DashboardParameterMapping = {
+  card_id: CardId;
+  parameter_id: ParameterId;
+  target: ParameterTarget;
+};

--- a/frontend/src/metabase-types/api/mocks/dashboard.ts
+++ b/frontend/src/metabase-types/api/mocks/dashboard.ts
@@ -3,5 +3,6 @@ import { Dashboard } from "metabase-types/api";
 export const createMockDashboard = (opts?: Partial<Dashboard>): Dashboard => ({
   id: 1,
   name: "Dashboard",
+  ordered_cards: [],
   ...opts,
 });

--- a/frontend/src/metabase-types/types/Card.ts
+++ b/frontend/src/metabase-types/types/Card.ts
@@ -1,6 +1,6 @@
 import { DatabaseId } from "./Database";
 import { StructuredQuery, NativeQuery } from "./Query";
-import { Parameter, ParameterInstance } from "./Parameter";
+import { Parameter, ParameterQueryObject } from "./Parameter";
 
 export type CardId = number;
 
@@ -33,14 +33,14 @@ export type StructuredDatasetQuery = {
   type: "query";
   database?: DatabaseId;
   query: StructuredQuery;
-  parameters?: Array<ParameterInstance>;
+  parameters?: Array<ParameterQueryObject>;
 };
 
 export type NativeDatasetQuery = {
   type: "native";
   database?: DatabaseId;
   native: NativeQuery;
-  parameters?: Array<ParameterInstance>;
+  parameters?: Array<ParameterQueryObject>;
 };
 
 /**

--- a/frontend/src/metabase-types/types/Parameter.ts
+++ b/frontend/src/metabase-types/types/Parameter.ts
@@ -1,45 +1,20 @@
 import { CardId } from "./Card";
-import { Field, FieldId } from "./Field";
 import { LocalFieldReference, ForeignFieldReference } from "./Query";
 
 export type ParameterId = string;
 
-// date/*, category, id, etc
 export type ParameterType = string;
 
-// a URL-safe encoding of a parameter value
-export type ParameterValue = string;
-export type ParameterValueOrArray = string | Array<string>;
-
-export type Parameter = {
-  id: ParameterId;
-  name: string;
-  sectionId: string;
-  type: ParameterType;
-  slug: string;
-  default?: string;
-  field_id: FieldId | null;
-  field_ids?: FieldId[];
-  fields: Field[];
-  hasOnlyFieldTargets?: boolean; // true if the parameter is only connected to fields/dimensions rather than variables
-  target?: ParameterTarget;
-  filteringParameters?: ParameterId[];
-};
-
 export type VariableTarget = ["template-tag", string];
-export type DimensionTarget =
-  | ["template-tag", string]
-  | LocalFieldReference
-  | ForeignFieldReference;
+export type ParameterVariableTarget = ["variable", VariableTarget];
+export type DimensionTarget = LocalFieldReference | ForeignFieldReference;
+export type ParameterDimensionTarget = ["dimension", DimensionTarget];
+
+export type ParameterValueOrArray = string | Array<any>;
 
 export type ParameterTarget =
-  | ["variable", VariableTarget]
-  | ["dimension", DimensionTarget];
-
-export type ParameterMappingOption = {
-  name: string;
-  target: ParameterTarget;
-};
+  | ParameterVariableTarget
+  | ParameterDimensionTarget;
 
 export type ParameterMapping = {
   card_id: CardId;
@@ -47,31 +22,25 @@ export type ParameterMapping = {
   target: ParameterTarget;
 };
 
-export type ParameterOption = {
+export type ParameterMappingOptions = {
   name: string;
-  description?: string;
+  sectionId: string;
+  combinedName?: string;
   type: ParameterType;
 };
 
-export type ParameterSection = {
-  id: string;
+export interface Parameter {
+  id: ParameterId;
   name: string;
-  description: string;
-  options: ParameterOption[];
-};
+  type: ParameterType;
+  slug: string;
+  sectionId?: string;
+  default?: any;
+  filteringParameters?: ParameterId[];
+}
 
-export type ParameterInstance = {
+export type ParameterQueryObject = {
   type: ParameterType;
   target: ParameterTarget;
-  value: ParameterValue;
-};
-
-export type ParameterMappingUIOption = ParameterMappingOption & {
-  icon?: string;
-  sectionName: string;
-  isForeign?: boolean;
-};
-
-export type ParameterValues = {
-  [id: ParameterId]: ParameterValue;
+  value: ParameterValueOrArray;
 };

--- a/frontend/src/metabase/parameters/types.ts
+++ b/frontend/src/metabase/parameters/types.ts
@@ -1,0 +1,17 @@
+import Field from "metabase-lib/lib/metadata/Field";
+import { Parameter, ParameterTarget } from "metabase-types/types/Parameter";
+
+export interface ValuePopulatedParameter extends Parameter {
+  value?: any;
+}
+
+export interface FieldFilterUiParameter extends ValuePopulatedParameter {
+  fields: Field[];
+  hasOnlyFieldTargets?: boolean;
+}
+
+export type UiParameter = FieldFilterUiParameter | ValuePopulatedParameter;
+
+export type ParameterWithTarget = Parameter & {
+  target: ParameterTarget;
+};


### PR DESCRIPTION
Related to #22554 

Pulling out the types I added in https://github.com/metabase/metabase/pull/22803 because that hasn't merged yet and I am blocked on other parameter code changes where I want to use `UiParameter` and so on.

1. Keeping `metabase-types/types/Parameter.ts` around for parameter objects that come directly from endpoints (`Parameter, `ParameterTarget`) or are used directly in endpoints (`ParameterQueryObject`). A few UI-related stragglers I'll deal with later.
2. Separate `metabase/parameters/types.ts` file for `UiParameter` and friends, since these types pull in `metabase-lib`.