### PR TITLE
Repros #22859: Multi-level nested questions with joins incorrect column aliasing

### DIFF
--- a/frontend/test/metabase/scenarios/joins/reproductions/22859-multi-nested-joins-wrong-aliasing.cy.spec.js
+++ b/frontend/test/metabase/scenarios/joins/reproductions/22859-multi-nested-joins-wrong-aliasing.cy.spec.js
@@ -1,0 +1,108 @@
+import {
+  restore,
+  popover,
+  visualize,
+  startNewQuestion,
+  openOrdersTable,
+} from "__support__/e2e/cypress";
+
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+
+const { REVIEWS, REVIEWS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
+
+const questionDetails = {
+  name: "22859-Q1",
+  query: {
+    "source-table": REVIEWS_ID,
+    joins: [
+      {
+        fields: "all",
+        "source-table": PRODUCTS_ID,
+        condition: [
+          "=",
+          ["field", REVIEWS.PRODUCT_ID, null],
+          ["field", PRODUCTS.ID, { "join-alias": "Products" }],
+        ],
+        alias: "Products",
+      },
+    ],
+  },
+};
+
+describe.skip("issue 22859 - multiple levels of nesting", () => {
+  beforeEach(() => {
+    cy.intercept("POST", "/api/card").as("saveQuestion");
+
+    restore();
+    cy.signInAsAdmin();
+
+    cy.createQuestion(questionDetails, { wrapId: true, idAlias: "q1Id" });
+
+    // Join Orders table with the previously saved question and save it again
+    openOrdersTable({ mode: "notebook" });
+    cy.findByText("Join data").click();
+
+    popover().within(() => {
+      cy.findByText("Sample Database").click();
+      cy.findByText("Saved Questions").click();
+      cy.findByText(questionDetails.name).click();
+    });
+
+    popover()
+      .contains("Product ID")
+      .click();
+
+    popover()
+      .contains("Product ID")
+      .click();
+
+    visualize();
+
+    saveQuestion("22859-Q2");
+
+    cy.wait("@saveQuestion").then(({ response: { body } }) =>
+      cy.wrap(body.id).as("q2Id"),
+    );
+
+    getJoinedTableColumnHeader();
+  });
+
+  it("model based on multi-level nested saved question should work (metabase#22859-1)", () => {
+    cy.get("@q2Id").then(id => {
+      // Convert the second question to a model
+      cy.request("PUT", `/api/card/${id}`, { dataset: true });
+
+      cy.visit(`/model/${id}`);
+      cy.wait("@dataset");
+    });
+
+    getJoinedTableColumnHeader();
+  });
+
+  it("third level of nesting with joins should result in proper column aliasing (metabase#22859-2)", () => {
+    startNewQuestion();
+    cy.findByText("Saved Questions").click();
+    cy.findByText("22859-Q2").click();
+
+    visualize();
+
+    getJoinedTableColumnHeader();
+  });
+});
+
+function saveQuestion(name) {
+  cy.findByText("Save").click();
+  cy.findByDisplayValue("Orders")
+    .clear()
+    .type(name)
+    .blur();
+
+  cy.button("Save").click();
+  cy.button("Not now").click();
+}
+
+function getJoinedTableColumnHeader() {
+  cy.get("@q1Id").then(id => {
+    cy.findByText(`Question ${id} → ID`);
+  });
+}


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #22859 

### How to test this manually?
- `yarn test-cypress-open`
- `metabase/scenarios/joins/reproductions/22859-multi-nested-joins-wrong-aliasing.cy.spec.js`
- Unskip the repro
- Both tests should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure all tests are passing and
- Merge it together with the fix

### Screenshots:

Model based on a saved nested question
![image](https://user-images.githubusercontent.com/31325167/170106882-e7272fd8-ffd8-4957-860a-f216b2ac487e.png)

Third-level nesting
![image](https://user-images.githubusercontent.com/31325167/170107035-8f20b553-af79-4fcc-a22a-4b7f878a874d.png)


