### PR TITLE
Fix ordering in the dev guide documentation on how to build Metabase

### DIFF
--- a/docs/developers-guide/build.md
+++ b/docs/developers-guide/build.md
@@ -123,6 +123,7 @@ The “official” branch of Metabase is called `master`, and other feature deve
 
 ## Run Metabase
 
+{:start="9"}
 9. Now we’ll start up the backend server of Metabase with:
 
    ```

--- a/docs/developers-guide/build.md
+++ b/docs/developers-guide/build.md
@@ -72,6 +72,7 @@ Once you've installed all the build tools, you'll need to clone the [Metabase re
 cd ~/workspace
 ```
 
+{:start="3"}
 3. Run the following command to “clone” Metabase into this folder, using the URL of the Metabase repository on GitHub:
 
 ```
@@ -84,6 +85,7 @@ This is the part that you’ll use over and over.
 
 The “official” branch of Metabase is called `master`, and other feature development branches get merged into it when they’re approved. So if you want to try out a feature before then, you’ll need to know the name of that branch so you can switch over to it. Here’s what to do:
 
+{:start="4"}
 4. Open up your terminal app
 
 5. Navigate to where you're storing the Metabase code. If you followed this guide exactly, you'd get there by entering this command: 
@@ -138,6 +140,7 @@ The “official” branch of Metabase is called `master`, and other feature deve
    yarn build-hot
    ```
 
+{:start="11"}
 11. In your web browser of choice, navigate to [localhost:3000](http://localhost:3000), where you should see Metabase!
      
    This is the local “server” on your computer, and 3000 is the “port” that Metabase is running on. You can have multiple different apps running on different ports on your own computer. Note that if you share any URLs with others that begin with `localhost`, they won’t be able to access them because your computer by default isn’t open up to the whole world, for security.    


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Fixes the ordering in the `https://www.metabase.com/docs/latest/developers-guide/build.html` page
- Thank you @howonlee for pointing us to [the solution](https://stackoverflow.com/questions/48612358/how-to-start-ordered-list-from-number-other-then-1-in-jekyll)

The current situation

### 1, 2, 3
<details>
    <summary>Before</summary>

![image](https://user-images.githubusercontent.com/31325167/170120273-4d6bed86-573d-4c35-a201-1899964ea521.png)

</details>

<details>
    <summary>After</summary>

![image](https://user-images.githubusercontent.com/31325167/170120899-73866b04-fe4e-44a0-8076-8aa93b974926.png)

</details>

### 4, 5, 6, 7, 8
<details>
    <summary>Before</summary>

![image](https://user-images.githubusercontent.com/31325167/170120403-2483725c-6b72-41dd-a686-3ad273a3a04b.png)

</details>

<details>
    <summary>After</summary>

![image](https://user-images.githubusercontent.com/31325167/170121042-e280fc1a-6c82-4313-997c-ece77081bf97.png)

</details>


### 9, 10, 11
<details>
    <summary>Before</summary>

![image](https://user-images.githubusercontent.com/31325167/170120455-c74b1e64-0c35-48ea-b8bd-ca3bf8603f0a.png)

</details>

<details>
    <summary>After</summary>

![image](https://user-images.githubusercontent.com/31325167/170121197-627515d2-7645-4794-95c7-a3f993062b55.png)

</details>