### PR TITLE
Fix for query preprocessing happening 3x

### DIFF
--- a/src/metabase/driver/common/parameters/values.clj
+++ b/src/metabase/driver/common/parameters/values.clj
@@ -291,7 +291,7 @@
 
    (sequential? value)
    (params/map->MultipleValues {:values (for [v value]
-                                     (parse-value-for-type param-type v))})
+                                         (parse-value-for-type param-type v))})
 
    ;; Field Filters with "special" base types
    (and (= param-type :dimension)

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -271,7 +271,7 @@
   [col-settings col]
   (-> (m/map-keys (fn [k] (-> k name (str/replace #"-" "_") keyword)) col-settings)
       (backfill-currency)
-      (u/update-when :date_style update-date-style (:unit col))))
+      (u/update-if-exists :date_style update-date-style (:unit col))))
 
 (defn- ->js-viz
   "Include viz settings for js.
@@ -319,7 +319,7 @@
      :x        {:type (or (:graph.x_axis.scale viz-settings) default-x-type)
                 :format x-format}
      :y        {:type (or (:graph.y_axis.scale viz-settings) "linear")
-                :format y-format }
+                :format y-format}
      :labels   labels}))
 
 (defn- set-default-stacked
@@ -504,15 +504,15 @@
         image-bundle  (image-bundle/make-image-bundle
                         render-type
                         (js-svg/combo-chart series settings))]
-  {:attachments
-   (when image-bundle
-     (image-bundle/image-bundle->attachment image-bundle))
+   {:attachments
+    (when image-bundle
+      (image-bundle/image-bundle->attachment image-bundle))
 
-   :content
-   [:div
-    [:img {:style (style/style {:display :block
-                                :width   :100%})
-           :src   (:image-src image-bundle)}]]}))
+    :content
+    [:div
+     [:img {:style (style/style {:display :block
+                                 :width   :100%})
+            :src   (:image-src image-bundle)}]]}))
 
 (defn- series-setting [viz-settings inner-key outer-key]
   (get-in viz-settings [:series_settings (keyword outer-key) inner-key]))
@@ -533,11 +533,11 @@
           selected-rows (sort-by first (map #(vector (ffirst %) (nth (second %) idx)) joined-rows))
           y-axis-pos    (or (series-setting viz-settings y-col-key :axis)
                             (nth (default-y-pos viz-settings) idx))]
-    {:name          card-name
-     :color         card-color
-     :type          card-type
-     :data          selected-rows
-     :yAxisPosition y-axis-pos})))
+     {:name          card-name
+      :color         card-color
+      :type          card-type
+      :data          selected-rows
+      :yAxisPosition y-axis-pos})))
 
 (defn- double-x-axis-combo-series
   "This munges rows and columns into series in the format that we want for combo staticviz for literal combo displaytype,
@@ -797,13 +797,13 @@
                                 :measure {:format (:y jsviz-settings)}))
         svg            (js-svg/funnel rows settings)
         image-bundle   (image-bundle/make-image-bundle render-type svg)]
-  {:attachments
-   (image-bundle/image-bundle->attachment image-bundle)
+   {:attachments
+    (image-bundle/image-bundle->attachment image-bundle)
 
-   :content
-   [:div
-    [:img {:style (style/style {:display :block :width :100%})
-           :src   (:image-src image-bundle)}]]}))
+    :content
+    [:div
+     [:img {:style (style/style {:display :block :width :100%})
+            :src   (:image-src image-bundle)}]]}))
 
 
 (s/defmethod render :empty :- common/RenderedPulseCard

--- a/src/metabase/query_processor/card.clj
+++ b/src/metabase/query_processor/card.clj
@@ -94,7 +94,7 @@
     (into
      {}
      (comp
-      (map (fn [[param-name {widget-type :widget-type, tag-type :type}] ]
+      (map (fn [[param-name {widget-type :widget-type, tag-type :type}]]
              ;; Field Filter parameters have a `:type` of `:dimension` and the widget type that should be used is
              ;; specified by `:widget-type`. Non-Field-filter parameters just have `:type`. So prefer
              ;; `:widget-type` if available but fall back to `:type` if not.

--- a/src/metabase/query_processor/dashboard.clj
+++ b/src/metabase/query_processor/dashboard.clj
@@ -97,7 +97,7 @@
                            :target (some (fn [{mapping-card-id :card_id, :keys [target]}]
                                             (when (= mapping-card-id card-id)
                                               target))
-                                          mappings)}]))
+                                         mappings)}]))
          (filter (fn [[_ {:keys [target]}]]
                    target)))
    dashboard-param-id->param))

--- a/src/metabase/query_processor/middleware/catch_exceptions.clj
+++ b/src/metabase/query_processor/middleware/catch_exceptions.clj
@@ -147,11 +147,11 @@
   exceptions to the `result-chan`."
   [qp]
   (fn [query rff context]
-    (let [extra-info (atom
+    (let [extra-info (delay
                       {:native       (u/ignore-exceptions
                                        ((resolve 'metabase.query-processor/compile) query))
                        :preprocessed (u/ignore-exceptions
-                                       ((resolve 'metabase.query-processor/preprocess) query))})]
+                                      ((resolve 'metabase.query-processor/preprocess) query))})]
       (letfn [(raisef* [e context]
                 ;; format the Exception and return it
                 (let [formatted-exception (format-exception* query e @extra-info)]

--- a/src/metabase/query_processor/middleware/catch_exceptions.clj
+++ b/src/metabase/query_processor/middleware/catch_exceptions.clj
@@ -112,7 +112,6 @@
      (when (seq more)
        {:via (vec more)}))))
 
-
 (defn- query-info
   "Map of about `query` to add to the exception response."
   [{query-type :type, :as query} {:keys [preprocessed native]}]
@@ -149,7 +148,7 @@
   (fn [query rff context]
     (let [extra-info (delay
                       {:native       (u/ignore-exceptions
-                                       ((resolve 'metabase.query-processor/compile) query))
+                                      ((resolve 'metabase.query-processor/compile) query))
                        :preprocessed (u/ignore-exceptions
                                       ((resolve 'metabase.query-processor/preprocess) query))})]
       (letfn [(raisef* [e context]

--- a/src/metabase/query_processor/middleware/parameters.clj
+++ b/src/metabase/query_processor/middleware/parameters.clj
@@ -62,7 +62,7 @@
        (expand-all outer-query expanded)))))
 
 (defn- move-top-level-params-to-inner-query
-  "Move any top-level parameters to the same level (i.e., 'inner query') as the query the affect."
+  "Move any top-level parameters to the same level (i.e., 'inner query') as the query they affect."
   [{:keys [parameters], query-type :type, :as outer-query}]
   {:pre [(#{:query :native} query-type)]}
   (cond-> (set/rename-keys outer-query {:parameters :user-parameters})
@@ -95,7 +95,7 @@
 (defn- hoist-database-for-snippet-tags
   "Assocs the `:database` ID from `query` in all snippet template tags."
   [query]
-  (u/update-in-when query [:native :template-tags] (partial assoc-db-in-snippet-tag (:database query))))
+  (u/update-in-if-exists query [:native :template-tags] (partial assoc-db-in-snippet-tag (:database query))))
 
 (defn substitute-parameters
   "Substitute Dashboard or Card-supplied parameters in a query, replacing the param placeholers with appropriate values

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -625,7 +625,7 @@
     (long (math/floor (/ (Math/log (math/abs x))
                          (Math/log 10))))))
 
-(defn update-when
+(defn update-if-exists
   "Like `clojure.core/update` but does not create a new key if it does not exist. Useful when you don't want to create
   cruft."
   [m k f & args]
@@ -633,7 +633,7 @@
     (apply update m k f args)
     m))
 
-(defn update-in-when
+(defn update-in-if-exists
   "Like `clojure.core/update-in` but does not create new keys if they do not exist. Useful when you don't want to create
   cruft."
   [m ks f & args]

--- a/test/metabase/query_processor/middleware/catch_exceptions_test.clj
+++ b/test/metabase/query_processor/middleware/catch_exceptions_test.clj
@@ -61,7 +61,18 @@
   (testing "No Exception -- should return response as-is"
     (is (= {:data {}, :row_count 0, :status :completed}
            (catch-exceptions
-            (fn []))))))
+            (fn [])))))
+
+  (testing "compile and preprocess should not be called if no exception occurs"
+    (let [compile-call-count (atom 0)
+          preprocess-call-count (atom 0)]
+     (with-redefs [qp/compile    (fn [_] (swap! compile-call-count inc))
+                   qp/preprocess (fn [_] (swap! preprocess-call-count inc))]
+      (is (= {:data {}, :row_count 0, :status :completed}
+             (catch-exceptions
+              (fn []))))
+      (is (= 0 @compile-call-count))
+      (is (= 0 @preprocess-call-count))))))
 
 (deftest sync-exception-test
   (testing "if the QP throws an Exception (synchronously), should format the response appropriately"


### PR DESCRIPTION
I was playing with the parameters QP middleware and noticed that it was being invoked three times per card whenever I loaded a dashboard. I tracked this down to [these lines](https://github.com/metabase/metabase/blob/b085e4214674cb531a0b2d9944f4e40b8fdcf9f7/src/metabase/query_processor/middleware/catch_exceptions.clj#L150-L154) in the `catch-exceptions` middleware. Basically, the middleware always calls both `qp/compile` and `qp/preprocess` on the query, so other preprocessing middleware ends up running 3x per query, and compilation middleware gets invoked 2x.

This code is run when creating an atom, which is odd, since the atom isn't ever updated. I think a delay was meant to be used here instead, so that the re-processing only happens if an exception is caught. I've changed it to a delay and added a test to verify the expected behavior.

I've also bundled in a couple of other minor changes that I had already had in a local branch:
* A decent number of whitespace & alignment fixes
* Renamed the `update-when` and `update-in-when` util functions to `update-if-exists` and `update-in-if-exists`. I got a bit confused by the old names (they seemed to imply behavior similar to `some->`) and I think the new names are more precise. They're also each only used in one place so it's not a big change.