### PR TITLE
show permission error for cards with blocked data sources

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard.jsx
@@ -12,6 +12,7 @@ import Visualization, {
   ERROR_MESSAGE_PERMISSION,
 } from "metabase/visualizations/components/Visualization";
 import QueryDownloadWidget from "metabase/query_builder/components/QueryDownloadWidget";
+import { SERVER_ERROR_TYPES } from "metabase/lib/errors";
 
 import ModalWithTrigger from "metabase/components/ModalWithTrigger";
 import { ChartSettingsWithState } from "metabase/visualizations/components/ChartSettings";
@@ -145,10 +146,17 @@ export default class DashCard extends Component {
       loading &&
       _.some(series, s => s.isSlow) &&
       (usuallyFast ? "usually-fast" : "usually-slow");
+
+    const isAccessRestricted = series.some(
+      s =>
+        s.error_type === SERVER_ERROR_TYPES.missingPermissions ||
+        s.error?.status === 403,
+    );
+
     const errors = series.map(s => s.error).filter(e => e);
 
     let errorMessage, errorIcon;
-    if (_.any(errors, e => e && e.status === 403)) {
+    if (isAccessRestricted) {
       errorMessage = ERROR_MESSAGE_PERMISSION;
       errorIcon = "key";
     } else if (errors.length > 0) {

--- a/frontend/test/metabase/scenarios/permissions/admin-permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/admin-permissions.cy.spec.js
@@ -10,6 +10,7 @@ import {
   assertSidebarItems,
   isPermissionDisabled,
   visitQuestion,
+  visitDashboard,
 } from "__support__/e2e/cypress";
 
 import { SAMPLE_DB_ID, USER_GROUPS } from "__support__/e2e/cypress_data";
@@ -615,5 +616,20 @@ describeEE("scenarios > admin > permissions", () => {
     cy.findByText("There was a problem with your question");
     cy.findByText("Settings").should("not.exist");
     cy.findByText("Visualization").should("not.exist");
+  });
+
+  it("shows permission error for cards that use blocked data sources", () => {
+    cy.updatePermissionsGraph({
+      [ALL_USERS_GROUP]: {
+        [SAMPLE_DB_ID]: {
+          data: { schemas: "block" },
+        },
+      },
+    });
+
+    cy.signIn("nodata");
+    visitDashboard(1);
+
+    cy.findByText("Sorry, you don't have permission to see this card.");
   });
 });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/22395

## Changes

Show explaining error message when dashboard cards cannot be viewed because they use blocked data sources.

<img width="354" alt="Screenshot 2022-05-25 at 00 27 35" src="https://user-images.githubusercontent.com/14301985/170126075-5feab174-3ad0-456f-99a0-6b871cc3a531.png">

## How to verify

- Run Metabase EE
- Create a dashboard with a card that uses Sample Database
- Create a Test User
- Set "Block" permission level to All Users for the Sample Dataset
- As a Test User open the dashboard
- Ensure the errored card says you don't have permissions