### PR TITLE
Tweak native query to inject parameters and parameter mappings

### DIFF
--- a/frontend/src/metabase-lib/lib/queries/AtomicQuery.ts
+++ b/frontend/src/metabase-lib/lib/queries/AtomicQuery.ts
@@ -4,6 +4,8 @@ import Query from "metabase-lib/lib/queries/Query";
 import Table from "metabase-lib/lib/metadata/Table";
 import { DatabaseEngine, DatabaseId } from "metabase-types/types/Database";
 import Database from "metabase-lib/lib/metadata/Database";
+import { ParameterMappings } from "metabase-types/types/Parameter";
+
 /**
  * A query type for queries that are attached to a specific database table
  * and form a single MBQL / native query clause
@@ -27,5 +29,9 @@ export default class AtomicQuery extends Query {
 
   engine(): DatabaseEngine | null | undefined {
     return null;
+  }
+
+  parameterMappings(): ParameterMappings {
+    return [];
   }
 }

--- a/frontend/src/metabase-lib/lib/queries/NativeQuery.ts
+++ b/frontend/src/metabase-lib/lib/queries/NativeQuery.ts
@@ -22,6 +22,7 @@ import {
   TemplateTag,
 } from "metabase-types/types/Query";
 import { DatabaseEngine, DatabaseId } from "metabase-types/types/Database";
+import { ParameterMappings } from "metabase-types/types/Parameter";
 import AtomicQuery from "metabase-lib/lib/queries/AtomicQuery";
 import Dimension, { TemplateTagDimension, FieldDimension } from "../Dimension";
 import Variable, { TemplateTagVariable } from "../Variable";
@@ -287,6 +288,10 @@ export default class NativeQuery extends AtomicQuery {
 
   templateTagsMap(): TemplateTags {
     return getIn(this.datasetQuery(), ["native", "template-tags"]) || {};
+  }
+
+  parameterMappings(): ParameterMappings {
+    return getIn(this.datasetQuery(), ["native", "parameter_mappings"]) || [];
   }
 
   validate() {

--- a/frontend/src/metabase-types/types/Parameter.ts
+++ b/frontend/src/metabase-types/types/Parameter.ts
@@ -22,6 +22,8 @@ export type ParameterMapping = {
   target: ParameterTarget;
 };
 
+export type ParameterMappings = ParameterMapping[];
+
 export type ParameterMappingOptions = {
   name: string;
   sectionId: string;

--- a/frontend/src/metabase-types/types/Query.ts
+++ b/frontend/src/metabase-types/types/Query.ts
@@ -62,6 +62,12 @@ export type TemplateTag = {
 
 export type TemplateTags = { [key: TemplateTagName]: TemplateTag };
 
+export type ParameterMapping = {
+  id: string;
+  name: string;
+  "display-name": string;
+};
+
 export type NativeQuery = {
   query: string;
   "template-tags": TemplateTags;

--- a/frontend/src/metabase/parameters/utils/dashboards.js
+++ b/frontend/src/metabase/parameters/utils/dashboards.js
@@ -2,6 +2,7 @@ import _ from "underscore";
 import { setIn } from "icepick";
 
 import Question from "metabase-lib/lib/Question";
+import { generateParameterId } from "metabase/parameters/utils/parameter-id";
 import { getParameterTargetField } from "metabase/parameters/utils/targets";
 import { slugify } from "metabase/lib/formatting";
 
@@ -16,7 +17,7 @@ export function createParameter(option, parameters = []) {
   const parameter = {
     name: "",
     slug: "",
-    id: Math.floor(Math.random() * Math.pow(2, 32)).toString(16),
+    id: generateParameterId(),
     type: option.type,
     sectionId: option.sectionId,
   };

--- a/frontend/src/metabase/parameters/utils/parameter-id.js
+++ b/frontend/src/metabase/parameters/utils/parameter-id.js
@@ -1,0 +1,4 @@
+export function generateParameterId() {
+  const num = Math.floor(Math.random() * Math.pow(2, 32));
+  return num.toString(16);
+}

--- a/frontend/src/metabase/parameters/utils/parameter-id.unit.spec.js
+++ b/frontend/src/metabase/parameters/utils/parameter-id.unit.spec.js
@@ -1,0 +1,7 @@
+import { generateParameterId } from "./parameter-id";
+
+describe("parameters/utils/parameter-id", () => {
+  it("should generate a random parameter id", () => {
+    expect(generateParameterId().length).toBeGreaterThan(1);
+  });
+});

--- a/frontend/src/metabase/query_builder/actions/native.js
+++ b/frontend/src/metabase/query_builder/actions/native.js
@@ -1,5 +1,5 @@
 import _ from "underscore";
-import { getIn, updateIn, assocIn } from "icepick";
+import { getIn, updateIn, merge } from "icepick";
 
 import { createAction } from "redux-actions";
 
@@ -155,15 +155,17 @@ export const setTemplateTag = createThunkAction(
             : templateTag;
         return { ...tags, [name]: newTag };
       };
-      const updatedTagsCard = updateIn(
-        updatedCard,
-        ["dataset_query", "native", "template-tags"],
-        updateTags,
-      );
-      return assocIn(
-        assocIn(updatedTagsCard, ["dataset_query", "parameters"], parameters),
-        ["dataset_query", "parameter-mappings"],
-        parameterMappings,
+
+      return merge(
+        {
+          parameters,
+          "parameter-mappings": parameterMappings,
+        },
+        updateIn(
+          updatedCard,
+          ["dataset_query", "native", "template-tags"],
+          updateTags,
+        ),
       );
     };
   },

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx
@@ -52,6 +52,7 @@ export default class TagEditorSidebar extends React.Component {
     } = this.props;
     // The tag editor sidebar excludes snippets since they have a separate sidebar.
     const tags = query.templateTagsWithoutSnippets();
+    const parameterMappings = query.parameterMappings();
     const database = query.database();
     const parameters = query.question().parameters();
     const parametersById = _.indexBy(parameters, "id");
@@ -84,6 +85,7 @@ export default class TagEditorSidebar extends React.Component {
           {section === "settings" ? (
             <SettingsPane
               tags={tags}
+              parameterMappings={parameterMappings}
               parametersById={parametersById}
               databaseFields={databaseFields}
               database={database}
@@ -109,6 +111,7 @@ export default class TagEditorSidebar extends React.Component {
 
 const SettingsPane = ({
   tags,
+  parameterMappings,
   parametersById,
   databaseFields,
   database,


### PR DESCRIPTION
To try this:
1. New, SQL Query, Sample Database
2. Enter `select * from PRODUCTS where CATEGORY={{cat}}`
3. Tweak the `cat` tag as necessary (e.g. marking as Required, adding a default value, etc)
4. Save the question.

![image](https://user-images.githubusercontent.com/7288/170529771-233cf49f-99a0-44da-b160-b6c6214988dd.png)

Now open the app DB, go to `report_card`  table and find the record for the query. In the `dataset_query` column, you'll find the following (formatted for clarity). Note the presence of both `parameters` and `parameter-mappings`, both did not exist before this PR.

```json
{
  "parameter-mappings": [
    {
      "parameter-id": "76c0405",
      "target": [
        "template-tag",
        [
          "variable",
          "cat"
        ]
      ]
    }
  ],
  "type": "native",
  "native": {
    "query": "select * from PRODUCTS where CATEGORY={{cat}}",
    "template-tags": {
      "cat": {
        "id": "c16cb69c-03dd-90ad-c84c-fc99c6569db7",
        "name": "cat",
        "display-name": "Cat",
        "type": "text",
        "required": true,
        "default": "Gizmo"
      }
    }
  },
  "database": 1,
  "parameters": [
    {
      "id": "76c0405",
      "name": "cat",
      "type": "text",
      "required": true,
      "default": "Gizm"
    }
  ]
}
```