### PR TITLE
Create a generic parameter formatting function

### DIFF
--- a/frontend/src/metabase/components/DateAllOptionsWidget/DateAllOptionsWidget.tsx
+++ b/frontend/src/metabase/components/DateAllOptionsWidget/DateAllOptionsWidget.tsx
@@ -5,10 +5,7 @@ import cx from "classnames";
 
 import { dateParameterValueToMBQL } from "metabase/parameters/utils/mbql";
 import DatePicker from "metabase/query_builder/components/filters/pickers/DatePicker/DatePicker";
-import {
-  filterToUrlEncoded,
-  formatAllOptionsWidget,
-} from "metabase/parameters/utils/date-formatting";
+import { filterToUrlEncoded } from "metabase/parameters/utils/date-formatting";
 
 import { Container, UpdateButton } from "./DateWidget.styled";
 
@@ -63,7 +60,5 @@ const DateAllOptionsWidget = ({
     </Container>
   );
 };
-
-DateAllOptionsWidget.format = formatAllOptionsWidget;
 
 export default DateAllOptionsWidget;

--- a/frontend/src/metabase/components/DateAllOptionsWidget/DateAllOptionsWidget.tsx
+++ b/frontend/src/metabase/components/DateAllOptionsWidget/DateAllOptionsWidget.tsx
@@ -4,108 +4,16 @@ import _ from "underscore";
 import cx from "classnames";
 
 import { dateParameterValueToMBQL } from "metabase/parameters/utils/mbql";
-import DatePicker, {
-  DATE_OPERATORS,
-} from "metabase/query_builder/components/filters/pickers/DatePicker/DatePicker";
+import DatePicker from "metabase/query_builder/components/filters/pickers/DatePicker/DatePicker";
 import {
-  generateTimeFilterValuesDescriptions,
-  getRelativeDatetimeInterval,
-  getStartingFrom,
-} from "metabase/lib/query_time";
-import { EXCLUDE_OPERATORS } from "metabase/query_builder/components/filters/pickers/DatePicker/ExcludeDatePicker";
+  filterToUrlEncoded,
+  formatAllOptionsWidget,
+} from "metabase/parameters/utils/date-formatting";
 
 import { Container, UpdateButton } from "./DateWidget.styled";
 
 // Use a placeholder value as field references are not used in dashboard filters
 const noopRef = null;
-
-function getFilterValueSerializer(func: (...args: any[]) => string) {
-  return (filter: any[]) => {
-    const startingFrom = getStartingFrom(filter);
-    if (startingFrom) {
-      const [value, unit] = getRelativeDatetimeInterval(filter);
-      return func(value, unit, { startingFrom });
-    } else {
-      return func(filter[2], filter[3], filter[4] || {});
-    }
-  };
-}
-
-const serializersByOperatorName: Record<string, (...args: any[]) => string> = {
-  previous: getFilterValueSerializer((value, unit, options = {}) => {
-    if (options.startingFrom) {
-      const [fromValue, fromUnit] = options.startingFrom;
-      return `past${-value}${unit}s-from-${fromValue}${fromUnit}s`;
-    }
-    return `past${-value}${unit}s${options["include-current"] ? "~" : ""}`;
-  }),
-  next: getFilterValueSerializer((value, unit, options = {}) => {
-    if (options.startingFrom) {
-      const [fromValue, fromUnit] = options.startingFrom;
-      return `next${value}${unit}s-from-${-fromValue}${fromUnit}s`;
-    }
-    return `next${value}${unit}s${options["include-current"] ? "~" : ""}`;
-  }),
-  current: getFilterValueSerializer((_, unit) => `this${unit}`),
-  before: getFilterValueSerializer(value => `~${value}`),
-  after: getFilterValueSerializer(value => `${value}~`),
-  on: getFilterValueSerializer(value => `${value}`),
-  between: getFilterValueSerializer((from, to) => `${from}~${to}`),
-  exclude: (filter: any[]) => {
-    const [_op, _field, ...values] = filter;
-    const operator = getExcludeOperator(filter);
-    if (!operator) {
-      return "";
-    }
-    const options = operator
-      .getOptions()
-      .flat()
-      .filter(({ test }) => !!_.find(values, (value: string) => test(value)));
-    return `exclude-${operator.name}-${options
-      .map(({ serialized }) => serialized)
-      .join("-")}`;
-  },
-};
-
-function getFilterOperator(filter: any[] = []) {
-  return DATE_OPERATORS.find(op => op.test(filter as any));
-}
-
-function getExcludeOperator(filter: any[] = []) {
-  return EXCLUDE_OPERATORS.find(op => op.test(filter as any));
-}
-
-function filterToUrlEncoded(filter: any[]) {
-  const operator = getFilterOperator(filter);
-  if (operator) {
-    return serializersByOperatorName[operator.name](filter);
-  } else {
-    return null;
-  }
-}
-
-const prefixedOperators = new Set([
-  "exclude",
-  "before",
-  "after",
-  "on",
-  "empty",
-  "not-empty",
-]);
-
-function getFilterTitle(filter: any[]) {
-  const values = generateTimeFilterValuesDescriptions(filter);
-  const desc =
-    values.length > 2
-      ? t`${values.length} selections`
-      : values.join(filter[0] === "!=" ? ", " : " - ");
-  const op = getFilterOperator(filter);
-  const prefix =
-    op && prefixedOperators.has(op.name)
-      ? `${op.displayPrefix ?? op.displayName} `
-      : "";
-  return prefix + desc;
-}
 
 interface DateAllOptionsWidgetProps {
   setValue: (value: string | null) => void;
@@ -156,13 +64,6 @@ const DateAllOptionsWidget = ({
   );
 };
 
-DateAllOptionsWidget.format = (urlEncoded: string) => {
-  if (urlEncoded == null) {
-    return null;
-  }
-  const filter = dateParameterValueToMBQL(urlEncoded, noopRef);
-
-  return filter ? getFilterTitle(filter) : null;
-};
+DateAllOptionsWidget.format = formatAllOptionsWidget;
 
 export default DateAllOptionsWidget;

--- a/frontend/src/metabase/components/DateMonthYearWidget/DateMonthYearWidget.tsx
+++ b/frontend/src/metabase/components/DateMonthYearWidget/DateMonthYearWidget.tsx
@@ -4,6 +4,7 @@ import _ from "underscore";
 import cx from "classnames";
 
 import YearPicker from "metabase/components/YearPicker";
+import { formatMonthYearWidget } from "metabase/parameters/utils/date-formatting";
 
 import { MonthContainer, MonthList } from "./DateMonthYearWidget.styled";
 
@@ -41,10 +42,7 @@ class DateMonthYearWidget extends React.Component<Props, State> {
     }
   }
 
-  static format = (value: string) => {
-    const m = moment(value, "YYYY-MM");
-    return m.isValid() ? m.format("MMMM, YYYY") : "";
-  };
+  static format = formatMonthYearWidget;
 
   componentWillUnmount() {
     const { month, year } = this.state;

--- a/frontend/src/metabase/components/DateMonthYearWidget/DateMonthYearWidget.tsx
+++ b/frontend/src/metabase/components/DateMonthYearWidget/DateMonthYearWidget.tsx
@@ -4,7 +4,6 @@ import _ from "underscore";
 import cx from "classnames";
 
 import YearPicker from "metabase/components/YearPicker";
-import { formatMonthYearWidget } from "metabase/parameters/utils/date-formatting";
 
 import { MonthContainer, MonthList } from "./DateMonthYearWidget.styled";
 
@@ -41,8 +40,6 @@ class DateMonthYearWidget extends React.Component<Props, State> {
       };
     }
   }
-
-  static format = formatMonthYearWidget;
 
   componentWillUnmount() {
     const { month, year } = this.state;

--- a/frontend/src/metabase/components/DateQuarterYearWidget/DateQuarterYearWidget.tsx
+++ b/frontend/src/metabase/components/DateQuarterYearWidget/DateQuarterYearWidget.tsx
@@ -5,6 +5,7 @@ import cx from "classnames";
 import { t } from "ttag";
 
 import YearPicker from "metabase/components/YearPicker";
+import { formatQuarterYearWidget } from "metabase/parameters/utils/date-formatting";
 
 // translator: this is a "moment" format string (https://momentjs.com/docs/#/displaying/format/) It should include "Q" for the quarter number, and raw text can be escaped by brackets. For eample "[Quarter] Q" will be rendered as "Quarter 1" etc
 const QUARTER_FORMAT_STRING = t`[Q]Q`;
@@ -43,10 +44,7 @@ class DateQuarterYearWidget extends React.Component<Props, State> {
     }
   }
 
-  static format = (value: string) => {
-    const m = moment(value, "[Q]Q-YYYY");
-    return m.isValid() ? m.format("[Q]Q, YYYY") : "";
-  };
+  static format = formatQuarterYearWidget;
 
   componentWillUnmount() {
     const { quarter, year } = this.state;

--- a/frontend/src/metabase/components/DateQuarterYearWidget/DateQuarterYearWidget.tsx
+++ b/frontend/src/metabase/components/DateQuarterYearWidget/DateQuarterYearWidget.tsx
@@ -5,7 +5,6 @@ import cx from "classnames";
 import { t } from "ttag";
 
 import YearPicker from "metabase/components/YearPicker";
-import { formatQuarterYearWidget } from "metabase/parameters/utils/date-formatting";
 
 // translator: this is a "moment" format string (https://momentjs.com/docs/#/displaying/format/) It should include "Q" for the quarter number, and raw text can be escaped by brackets. For eample "[Quarter] Q" will be rendered as "Quarter 1" etc
 const QUARTER_FORMAT_STRING = t`[Q]Q`;
@@ -43,8 +42,6 @@ class DateQuarterYearWidget extends React.Component<Props, State> {
       };
     }
   }
-
-  static format = formatQuarterYearWidget;
 
   componentWillUnmount() {
     const { quarter, year } = this.state;

--- a/frontend/src/metabase/components/DateRangeWidget/DateRangeWidget.tsx
+++ b/frontend/src/metabase/components/DateRangeWidget/DateRangeWidget.tsx
@@ -2,7 +2,6 @@ import React from "react";
 
 import moment from "moment";
 import DateAllOptionsWidget from "metabase/components/DateAllOptionsWidget";
-import { formatRangeWidget } from "metabase/parameters/utils/date-formatting";
 
 interface DateRangeWidgetProps {
   setValue: (value: string | null) => void;
@@ -24,7 +23,5 @@ const DateRangeWidget = ({ value, ...props }: DateRangeWidgetProps) => {
     />
   );
 };
-
-DateRangeWidget.format = formatRangeWidget;
 
 export default DateRangeWidget;

--- a/frontend/src/metabase/components/DateRangeWidget/DateRangeWidget.tsx
+++ b/frontend/src/metabase/components/DateRangeWidget/DateRangeWidget.tsx
@@ -2,13 +2,7 @@ import React from "react";
 
 import moment from "moment";
 import DateAllOptionsWidget from "metabase/components/DateAllOptionsWidget";
-
-const SEPARATOR = "~"; // URL-safe
-
-function parseDateRangeValue(value: string) {
-  const [start, end] = (value || "").split(SEPARATOR);
-  return { start, end };
-}
+import { formatRangeWidget } from "metabase/parameters/utils/date-formatting";
 
 interface DateRangeWidgetProps {
   setValue: (value: string | null) => void;
@@ -31,13 +25,6 @@ const DateRangeWidget = ({ value, ...props }: DateRangeWidgetProps) => {
   );
 };
 
-DateRangeWidget.format = (value: string) => {
-  const { start, end } = parseDateRangeValue(value);
-  return start && end
-    ? moment(start).format("MMMM D, YYYY") +
-        " - " +
-        moment(end).format("MMMM D, YYYY")
-    : "";
-};
+DateRangeWidget.format = formatRangeWidget;
 
 export default DateRangeWidget;

--- a/frontend/src/metabase/components/DateRelativeWidget/DateRelativeWidget.tsx
+++ b/frontend/src/metabase/components/DateRelativeWidget/DateRelativeWidget.tsx
@@ -3,7 +3,6 @@ import { t } from "ttag";
 import cx from "classnames";
 import _ from "underscore";
 
-import { formatRelativeWidget } from "metabase/parameters/utils/date-formatting";
 import { DATE_MBQL_FILTER_MAPPING } from "metabase/parameters/constants";
 
 type Shortcut = {
@@ -164,8 +163,6 @@ class DateRelativeWidget extends React.Component<DateRelativeWidgetProps> {
   constructor(props: DateRelativeWidgetProps) {
     super(props);
   }
-
-  static format = formatRelativeWidget;
 
   render() {
     const { value, setValue, onClose } = this.props;

--- a/frontend/src/metabase/components/DateRelativeWidget/DateRelativeWidget.tsx
+++ b/frontend/src/metabase/components/DateRelativeWidget/DateRelativeWidget.tsx
@@ -3,6 +3,9 @@ import { t } from "ttag";
 import cx from "classnames";
 import _ from "underscore";
 
+import { formatRelativeWidget } from "metabase/parameters/utils/date-formatting";
+import { DATE_MBQL_FILTER_MAPPING } from "metabase/parameters/constants";
+
 type Shortcut = {
   name: string;
   operator: string | string[];
@@ -151,57 +154,6 @@ export class PredefinedRelativeDatePicker extends React.Component<
   }
 }
 
-type FilterMap = {
-  [name: string]: {
-    name: string;
-    mapping: any[];
-  };
-};
-
-// HACK: easiest way to get working with RelativeDatePicker
-const FILTERS: FilterMap = {
-  today: {
-    name: t`Today`,
-    mapping: ["=", null, ["relative-datetime", "current"]],
-  },
-  yesterday: {
-    name: t`Yesterday`,
-    mapping: ["=", null, ["relative-datetime", -1, "day"]],
-  },
-  past7days: {
-    name: t`Past 7 Days`,
-    mapping: ["time-interval", null, -7, "day"],
-  },
-  past30days: {
-    name: t`Past 30 Days`,
-    mapping: ["time-interval", null, -30, "day"],
-  },
-  lastweek: {
-    name: t`Last Week`,
-    mapping: ["time-interval", null, "last", "week"],
-  },
-  lastmonth: {
-    name: t`Last Month`,
-    mapping: ["time-interval", null, "last", "month"],
-  },
-  lastyear: {
-    name: t`Last Year`,
-    mapping: ["time-interval", null, "last", "year"],
-  },
-  thisweek: {
-    name: t`This Week`,
-    mapping: ["time-interval", null, "current", "week"],
-  },
-  thismonth: {
-    name: t`This Month`,
-    mapping: ["time-interval", null, "current", "month"],
-  },
-  thisyear: {
-    name: t`This Year`,
-    mapping: ["time-interval", null, "current", "year"],
-  },
-};
-
 type DateRelativeWidgetProps = {
   value: string;
   setValue: (v?: string) => void;
@@ -213,17 +165,24 @@ class DateRelativeWidget extends React.Component<DateRelativeWidgetProps> {
     super(props);
   }
 
-  static format = (value: string) =>
-    FILTERS[value] ? FILTERS[value].name : "";
+  static format = formatRelativeWidget;
 
   render() {
     const { value, setValue, onClose } = this.props;
     return (
       <div className="px1" style={{ maxWidth: 300 }}>
         <PredefinedRelativeDatePicker
-          filter={FILTERS[value] ? FILTERS[value].mapping : [null, null]}
+          filter={
+            DATE_MBQL_FILTER_MAPPING[value]
+              ? DATE_MBQL_FILTER_MAPPING[value].mapping
+              : [null, null]
+          }
           onFilterChange={filter => {
-            setValue(_.findKey(FILTERS, f => _.isEqual(f.mapping, filter)));
+            setValue(
+              _.findKey(DATE_MBQL_FILTER_MAPPING, f =>
+                _.isEqual(f.mapping, filter),
+              ),
+            );
             onClose();
           }}
         />

--- a/frontend/src/metabase/components/DateSingleWidget/DateSingleWidget.tsx
+++ b/frontend/src/metabase/components/DateSingleWidget/DateSingleWidget.tsx
@@ -2,6 +2,7 @@ import React from "react";
 
 import moment from "moment";
 import DateAllOptionsWidget from "metabase/components/DateAllOptionsWidget";
+import { formatSingleWidget } from "metabase/parameters/utils/date-formatting";
 
 interface DateSingleWidgetProps {
   setValue: (value: string | null) => void;
@@ -20,7 +21,6 @@ const DateSingleWidget = ({ value, ...props }: DateSingleWidgetProps) => {
   );
 };
 
-DateSingleWidget.format = (value: string) =>
-  value ? moment(value).format("MMMM D, YYYY") : "";
+DateSingleWidget.format = formatSingleWidget;
 
 export default DateSingleWidget;

--- a/frontend/src/metabase/components/DateSingleWidget/DateSingleWidget.tsx
+++ b/frontend/src/metabase/components/DateSingleWidget/DateSingleWidget.tsx
@@ -2,7 +2,6 @@ import React from "react";
 
 import moment from "moment";
 import DateAllOptionsWidget from "metabase/components/DateAllOptionsWidget";
-import { formatSingleWidget } from "metabase/parameters/utils/date-formatting";
 
 interface DateSingleWidgetProps {
   setValue: (value: string | null) => void;
@@ -20,7 +19,5 @@ const DateSingleWidget = ({ value, ...props }: DateSingleWidgetProps) => {
     />
   );
 };
-
-DateSingleWidget.format = formatSingleWidget;
 
 export default DateSingleWidget;

--- a/frontend/src/metabase/components/TextWidget/TextWidget.tsx
+++ b/frontend/src/metabase/components/TextWidget/TextWidget.tsx
@@ -38,8 +38,6 @@ class TextWidget extends React.Component<Props, State> {
 
   static noPopover = true;
 
-  static format = (value: string) => value;
-
   UNSAFE_componentWillMount() {
     this.UNSAFE_componentWillReceiveProps(this.props);
   }

--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
@@ -7,6 +7,7 @@ import _ from "underscore";
 import { getParameterIconName } from "metabase/parameters/utils/ui";
 import { isDashboardParameterWithoutMapping } from "metabase/parameters/utils/dashboards";
 import { isOnlyMappedToFields } from "metabase/parameters/utils/fields";
+import { formatParameterValue } from "metabase/parameters/utils/formatting";
 import PopoverWithTrigger from "metabase/components/PopoverWithTrigger";
 import Icon from "metabase/components/Icon";
 import DateSingleWidget from "metabase/components/DateSingleWidget";
@@ -94,7 +95,7 @@ class ParameterValueWidget extends Component {
       dashboard,
     );
     const isDashParamWithoutMappingText = t`This filter needs to be connected to a card.`;
-    const { noPopover, format } = getWidgetDefinition(parameter);
+    const { noPopover } = getWidgetDefinition(parameter);
     const parameterTypeIcon = getParameterIconName(parameter);
     const showTypeIcon = !isEditing && !hasValue && !isFocused;
 
@@ -164,7 +165,9 @@ class ParameterValueWidget extends Component {
                   />
                 )}
                 <div className="mr1 text-nowrap">
-                  {hasValue ? format(value) : placeholderText}
+                  {hasValue
+                    ? formatParameterValue(value, parameter)
+                    : placeholderText}
                 </div>
                 <WidgetStatusIcon
                   isFullscreen={isFullscreen}

--- a/frontend/src/metabase/parameters/constants.ts
+++ b/frontend/src/metabase/parameters/constants.ts
@@ -163,3 +163,53 @@ export const FIELD_FILTER_PARAMETER_TYPES = [
   "category",
   "location",
 ];
+
+type FilterMap = {
+  [name: string]: {
+    name: string;
+    mapping: any[];
+  };
+};
+
+export const DATE_MBQL_FILTER_MAPPING: FilterMap = {
+  today: {
+    name: t`Today`,
+    mapping: ["=", null, ["relative-datetime", "current"]],
+  },
+  yesterday: {
+    name: t`Yesterday`,
+    mapping: ["=", null, ["relative-datetime", -1, "day"]],
+  },
+  past7days: {
+    name: t`Past 7 Days`,
+    mapping: ["time-interval", null, -7, "day"],
+  },
+  past30days: {
+    name: t`Past 30 Days`,
+    mapping: ["time-interval", null, -30, "day"],
+  },
+  lastweek: {
+    name: t`Last Week`,
+    mapping: ["time-interval", null, "last", "week"],
+  },
+  lastmonth: {
+    name: t`Last Month`,
+    mapping: ["time-interval", null, "last", "month"],
+  },
+  lastyear: {
+    name: t`Last Year`,
+    mapping: ["time-interval", null, "last", "year"],
+  },
+  thisweek: {
+    name: t`This Week`,
+    mapping: ["time-interval", null, "current", "week"],
+  },
+  thismonth: {
+    name: t`This Month`,
+    mapping: ["time-interval", null, "current", "month"],
+  },
+  thisyear: {
+    name: t`This Year`,
+    mapping: ["time-interval", null, "current", "year"],
+  },
+};

--- a/frontend/src/metabase/parameters/mock.ts
+++ b/frontend/src/metabase/parameters/mock.ts
@@ -1,0 +1,11 @@
+import { UiParameter } from "metabase/parameters/types";
+
+export const createMockUiParameter = (
+  opts?: Partial<UiParameter>,
+): UiParameter => ({
+  id: "parameter-id",
+  slug: "slug",
+  name: "Name",
+  type: "string/=",
+  ...opts,
+});

--- a/frontend/src/metabase/parameters/utils/date-formatting.ts
+++ b/frontend/src/metabase/parameters/utils/date-formatting.ts
@@ -1,0 +1,148 @@
+import { t } from "ttag";
+import _ from "underscore";
+import moment from "moment";
+
+import { DATE_MBQL_FILTER_MAPPING } from "metabase/parameters/constants";
+import { dateParameterValueToMBQL } from "metabase/parameters/utils/mbql";
+import { DATE_OPERATORS } from "metabase/query_builder/components/filters/pickers/DatePicker/DatePicker";
+import {
+  generateTimeFilterValuesDescriptions,
+  getRelativeDatetimeInterval,
+  getStartingFrom,
+} from "metabase/lib/query_time";
+import { EXCLUDE_OPERATORS } from "metabase/query_builder/components/filters/pickers/DatePicker/ExcludeDatePicker";
+
+// Use a placeholder value as field references are not used in dashboard filters
+const noopRef = null;
+const RANGE_SEPARATOR = "~"; // URL-safe
+
+function getFilterValueSerializer(func: (...args: any[]) => string) {
+  return (filter: any[]) => {
+    const startingFrom = getStartingFrom(filter);
+    if (startingFrom) {
+      const [value, unit] = getRelativeDatetimeInterval(filter);
+      return func(value, unit, { startingFrom });
+    } else {
+      return func(filter[2], filter[3], filter[4] || {});
+    }
+  };
+}
+
+const serializersByOperatorName: Record<string, (...args: any[]) => string> = {
+  previous: getFilterValueSerializer((value, unit, options = {}) => {
+    if (options.startingFrom) {
+      const [fromValue, fromUnit] = options.startingFrom;
+      return `past${-value}${unit}s-from-${fromValue}${fromUnit}s`;
+    }
+    return `past${-value}${unit}s${options["include-current"] ? "~" : ""}`;
+  }),
+  next: getFilterValueSerializer((value, unit, options = {}) => {
+    if (options.startingFrom) {
+      const [fromValue, fromUnit] = options.startingFrom;
+      return `next${value}${unit}s-from-${-fromValue}${fromUnit}s`;
+    }
+    return `next${value}${unit}s${options["include-current"] ? "~" : ""}`;
+  }),
+  current: getFilterValueSerializer((_, unit) => `this${unit}`),
+  before: getFilterValueSerializer(value => `~${value}`),
+  after: getFilterValueSerializer(value => `${value}~`),
+  on: getFilterValueSerializer(value => `${value}`),
+  between: getFilterValueSerializer((from, to) => `${from}~${to}`),
+  exclude: (filter: any[]) => {
+    const [_op, _field, ...values] = filter;
+    const operator = getExcludeOperator(filter);
+    if (!operator) {
+      return "";
+    }
+    const options = operator
+      .getOptions()
+      .flat()
+      .filter(({ test }) => !!_.find(values, (value: string) => test(value)));
+    return `exclude-${operator.name}-${options
+      .map(({ serialized }) => serialized)
+      .join("-")}`;
+  },
+};
+
+function getFilterOperator(filter: any[] = []) {
+  return DATE_OPERATORS.find(op => op.test(filter as any));
+}
+
+function getExcludeOperator(filter: any[] = []) {
+  return EXCLUDE_OPERATORS.find(op => op.test(filter as any));
+}
+
+export function filterToUrlEncoded(filter: any[]) {
+  const operator = getFilterOperator(filter);
+  if (operator) {
+    return serializersByOperatorName[operator.name](filter);
+  } else {
+    return null;
+  }
+}
+
+const prefixedOperators = new Set([
+  "exclude",
+  "before",
+  "after",
+  "on",
+  "empty",
+  "not-empty",
+]);
+
+function getFilterTitle(filter: any[]) {
+  const values = generateTimeFilterValuesDescriptions(filter);
+  const desc =
+    values.length > 2
+      ? t`${values.length} selections`
+      : values.join(filter[0] === "!=" ? ", " : " - ");
+  const op = getFilterOperator(filter);
+  const prefix =
+    op && prefixedOperators.has(op.name)
+      ? `${op.displayPrefix ?? op.displayName} `
+      : "";
+  return prefix + desc;
+}
+
+export function formatAllOptionsWidget(urlEncoded: string) {
+  if (urlEncoded == null) {
+    return null;
+  }
+  const filter = dateParameterValueToMBQL(urlEncoded, noopRef);
+
+  return filter ? getFilterTitle(filter) : null;
+}
+
+function parseDateRangeValue(value: string) {
+  const [start, end] = (value || "").split(RANGE_SEPARATOR);
+  return { start, end };
+}
+
+export function formatRangeWidget(value: string) {
+  const { start, end } = parseDateRangeValue(value);
+  return start && end
+    ? moment(start).format("MMMM D, YYYY") +
+        " - " +
+        moment(end).format("MMMM D, YYYY")
+    : "";
+}
+
+export function formatSingleWidget(value: string) {
+  return value ? moment(value).format("MMMM D, YYYY") : "";
+}
+
+export function formatMonthYearWidget(value: string) {
+  const m = moment(value, "YYYY-MM");
+  return m.isValid() ? m.format("MMMM, YYYY") : "";
+}
+
+export function formatQuarterYearWidget(value: string) {
+  const m = moment(value, "[Q]Q-YYYY");
+  return m.isValid() ? m.format("[Q]Q, YYYY") : "";
+}
+
+export function formatRelativeWidget(value: string) {
+  return DATE_MBQL_FILTER_MAPPING[value]
+    ? DATE_MBQL_FILTER_MAPPING[value].name
+    : "";
+}

--- a/frontend/src/metabase/parameters/utils/date-formatting.ts
+++ b/frontend/src/metabase/parameters/utils/date-formatting.ts
@@ -12,6 +12,8 @@ import {
 } from "metabase/lib/query_time";
 import { EXCLUDE_OPERATORS } from "metabase/query_builder/components/filters/pickers/DatePicker/ExcludeDatePicker";
 
+import { UiParameter } from "../types";
+
 // Use a placeholder value as field references are not used in dashboard filters
 const noopRef = null;
 const RANGE_SEPARATOR = "~"; // URL-safe
@@ -145,4 +147,23 @@ export function formatRelativeWidget(value: string) {
   return DATE_MBQL_FILTER_MAPPING[value]
     ? DATE_MBQL_FILTER_MAPPING[value].name
     : "";
+}
+
+export function formatDateValue(value: string, parameter: UiParameter) {
+  switch (parameter.type) {
+    case "date/range":
+      return formatRangeWidget(value);
+    case "date/single":
+      return formatSingleWidget(value);
+    case "date/all-options":
+      return formatAllOptionsWidget(value);
+    case "date/month-year":
+      return formatMonthYearWidget(value);
+    case "date/quarter-year":
+      return formatQuarterYearWidget(value);
+    case "date/relative":
+      return formatRelativeWidget(value);
+    default:
+      return value;
+  }
 }

--- a/frontend/src/metabase/parameters/utils/formatting.ts
+++ b/frontend/src/metabase/parameters/utils/formatting.ts
@@ -30,15 +30,27 @@ export function formatParameterValue(value: any, parameter: UiParameter) {
     return formatDateValue(value, parameter);
   }
 
-  if (isFieldFilterParameter(parameter) && parameter.fields.length > 0) {
-    const [firstField] = parameter.fields;
-    const remap = parameter.fields.length === 1;
-    return formatValue(value, {
-      column: firstField,
-      maximumFractionDigits: 20,
-      remap,
-    });
+  if (isFieldFilterParameter(parameter)) {
+    // skip formatting field filter parameters mapped to native query variables
+    if (parameter.hasOnlyFieldTargets === false) {
+      return value;
+    }
+
+    // format using the parameter's first targeted field
+    if (parameter.fields.length > 0) {
+      const [firstField] = parameter.fields;
+      // when a parameter targets multiple fields we won't know
+      // which parameter the value is associated with, meaning we
+      // are unable to remap the value to the correct field
+      const remap = parameter.fields.length === 1;
+      return formatValue(value, {
+        column: firstField,
+        maximumFractionDigits: 20,
+        remap,
+      });
+    }
   }
 
+  // infer type information from parameter type
   return formatWithInferredType(value, parameter);
 }

--- a/frontend/src/metabase/parameters/utils/formatting.ts
+++ b/frontend/src/metabase/parameters/utils/formatting.ts
@@ -1,0 +1,44 @@
+import { formatValue } from "metabase/lib/formatting";
+
+import { getParameterType, isFieldFilterParameter } from "./parameter-type";
+import { formatDateValue } from "./date-formatting";
+import { UiParameter } from "../types";
+
+function inferValueType(parameter: UiParameter) {
+  const type = getParameterType(parameter);
+  if (type === "number") {
+    return "type/Number";
+  }
+
+  return "type/Text";
+}
+
+function formatWithInferredType(value: any, parameter: UiParameter) {
+  const inferredType = inferValueType(parameter);
+  const column = {
+    base_type: inferredType,
+  };
+  return formatValue(value, {
+    column,
+    maximumFractionDigits: 20,
+  });
+}
+
+export function formatParameterValue(value: any, parameter: UiParameter) {
+  const type = getParameterType(parameter);
+  if (type === "date") {
+    return formatDateValue(value, parameter);
+  }
+
+  if (isFieldFilterParameter(parameter) && parameter.fields.length > 0) {
+    const [firstField] = parameter.fields;
+    const remap = parameter.fields.length === 1;
+    return formatValue(value, {
+      column: firstField,
+      maximumFractionDigits: 20,
+      remap,
+    });
+  }
+
+  return formatWithInferredType(value, parameter);
+}

--- a/frontend/src/metabase/parameters/utils/formatting.unit.spec.ts
+++ b/frontend/src/metabase/parameters/utils/formatting.unit.spec.ts
@@ -1,0 +1,115 @@
+import { formatParameterValue } from "./formatting";
+import { createMockUiParameter } from "metabase/parameters/mock";
+
+import Field from "metabase-lib/lib/metadata/Field";
+import { PRODUCTS, ORDERS } from "__support__/sample_database_fixture";
+
+const numberField = ORDERS.TOTAL;
+const textField = PRODUCTS.TITLE;
+const categoryField = PRODUCTS.CATEGORY;
+
+const remappedField = new Field({
+  base_type: "type/Text",
+  human_readable_field_id: numberField.id,
+  remapping: new Map([[123456789, 0]]),
+});
+
+describe("metabase/parameters/utils/formatting", () => {
+  describe("formatParameterValue", () => {
+    const cases = [
+      {
+        type: "date/range",
+        value: "1995-01-01~1995-01-10",
+        expected: "January 1, 1995 - January 10, 1995",
+      },
+      {
+        type: "date/single",
+        value: "2018-01-01",
+        expected: "January 1, 2018",
+      },
+      {
+        type: "date/all-options",
+        value: "2018-01-01",
+        expected: "On January 1, 2018",
+      },
+      {
+        type: "date/month-year",
+        value: "2018-01",
+        expected: "January, 2018",
+      },
+      {
+        type: "date/quarter-year",
+        value: "Q1-2018",
+        expected: "Q1, 2018",
+      },
+      {
+        type: "date/relative",
+        value: "past30days",
+        expected: "Past 30 Days",
+      },
+      {
+        type: "number/=",
+        value: 123456789,
+        expected: "123,456,789",
+        fields: [numberField],
+      },
+      {
+        type: "number/>=",
+        value: 1.111111111111,
+        expected: "1.111111111111",
+        fields: [],
+      },
+      {
+        type: "string/=",
+        value: "abc",
+        expected: "abc",
+        fields: [textField],
+      },
+      {
+        type: "category",
+        value: "foo",
+        expected: "foo",
+        fields: [categoryField],
+      },
+      {
+        type: "location/city",
+        value: "foo",
+        expected: "foo",
+        fields: [],
+      },
+      {
+        type: "location/country",
+        value: "foo",
+        expected: "foo",
+        fields: [],
+      },
+    ];
+
+    test.each(cases)(
+      "should format $type parameter",
+      ({ type, value, expected, fields }) => {
+        const parameter = createMockUiParameter({
+          type,
+          fields,
+        });
+        expect(formatParameterValue(value, parameter)).toEqual(expected);
+      },
+    );
+
+    it("should not remap a field filter parameter connected to more than one field", () => {
+      const parameter = createMockUiParameter({
+        type: "number/=",
+        fields: [remappedField, numberField],
+      });
+      expect(formatParameterValue(123456789, parameter)).toEqual("123456789");
+    });
+
+    it("should remap a field filter parameter value with a target field that is remapped", () => {
+      const parameter = createMockUiParameter({
+        type: "number/=",
+        fields: [remappedField],
+      });
+      expect(formatParameterValue(123456789, parameter)).toEqual(0);
+    });
+  });
+});

--- a/frontend/src/metabase/parameters/utils/formatting.unit.spec.ts
+++ b/frontend/src/metabase/parameters/utils/formatting.unit.spec.ts
@@ -60,6 +60,13 @@ describe("metabase/parameters/utils/formatting", () => {
         fields: [],
       },
       {
+        type: "number/>=",
+        value: 1.111111111111,
+        expected: 1.111111111111,
+        fields: [],
+        hasOnlyFieldTargets: false,
+      },
+      {
         type: "string/=",
         value: "abc",
         expected: "abc",
@@ -77,21 +84,12 @@ describe("metabase/parameters/utils/formatting", () => {
         expected: "foo",
         fields: [],
       },
-      {
-        type: "location/country",
-        value: "foo",
-        expected: "foo",
-        fields: [],
-      },
     ];
 
     test.each(cases)(
       "should format $type parameter",
-      ({ type, value, expected, fields }) => {
-        const parameter = createMockUiParameter({
-          type,
-          fields,
-        });
+      ({ value, expected, ...parameterProps }) => {
+        const parameter = createMockUiParameter(parameterProps);
         expect(formatParameterValue(value, parameter)).toEqual(expected);
       },
     );


### PR DESCRIPTION
Related to #22554 

This PR:

1. moves parameter formatting code to a new utility function file, `metabase/parameters/utils/formatting.ts` and `metabase/parameter/utils/date-formatting.ts` to decouple it from the parameter's widget component.
2. adds support for formatting parameter values where there isn't an associated field.

Right now, we will only use `formatParameterValue` for date widgets and parameters that end up using the text widget (anything connected to a sql variable), but the intention is to use it whenever we need to format a parameter value not connected to a field (or, like in the case of `date/*` parameters, we require extra formatting logic). Other parameters currently in existence are formatted via the `Value` component. We can't get rid of this component (yet, at least) because it does extra things, particularly when remapping field values.

FYI: I tried to make https://github.com/metabase/metabase/pull/22937/commits/f0293c60fcb975a38d705138d605ecfb7b7cf5fb a separate PR, but on its own the build breaks: https://github.com/metabase/metabase/pull/22918

**Testing**
1. Test that Date parameter widgets are properly formatted:

https://user-images.githubusercontent.com/13057258/170387484-e234c452-6fa3-4912-9946-622117e4e424.mov

2. Test that text widget parameters are **not** formatted:

https://user-images.githubusercontent.com/13057258/170387522-adc3d497-b8aa-4043-bc89-b069d56de444.mov



