### PR TITLE
Clean up quotes

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/audit_app/pages/AuditDatabaseDetail.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/pages/AuditDatabaseDetail.jsx
@@ -17,7 +17,7 @@ const AuditDatabaseDetail = ({ params, ...props }) => {
         <EntityName
           entityType="databases"
           entityId={databaseId}
-          property={"name"}
+          property="name"
         />
       }
       tabs={AuditDatabaseDetail.tabs}

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/pages/AuditTableDetail.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/pages/AuditTableDetail.jsx
@@ -17,7 +17,7 @@ const AuditTableDetail = ({ params, ...props }) => {
         <EntityName
           entityType="tables"
           entityId={tableId}
-          property={"display_name"}
+          property="display_name"
         />
       }
       tabs={AuditTableDetail.tabs}

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/pages/AuditUserDetail.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/pages/AuditUserDetail.jsx
@@ -18,7 +18,7 @@ const AuditUserDetail = ({ params, ...props }) => {
         <EntityName
           entityType="users"
           entityId={userId}
-          property={"common_name"}
+          property="common_name"
         />
       }
       tabs={AuditUserDetail.tabs}

--- a/enterprise/frontend/src/metabase-enterprise/tools/containers/ErrorOverview.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/tools/containers/ErrorOverview.jsx
@@ -108,7 +108,7 @@ export default function ErrorOverview(props) {
               sorting.column,
               getSortOrder(sorting.isAscending),
             )}
-            className={"mt2 bounded-overflow-x-scroll"}
+            className="mt2 bounded-overflow-x-scroll"
           />
         )}
       </AuditParameters>

--- a/frontend/src/metabase/admin/datamodel/components/MetricForm.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/MetricForm.jsx
@@ -27,7 +27,7 @@ class MetricForm extends Component {
           onClick={handleSubmit}
         >{t`Save changes`}</button>
         <Link
-          to={`/admin/datamodel/metrics`}
+          to="/admin/datamodel/metrics"
           className="Button ml2"
         >{t`Cancel`}</Link>
       </div>

--- a/frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.jsx
@@ -34,7 +34,7 @@ export default class ObjectActionsSelect extends Component {
         <PopoverWithTrigger
           triggerElement={
             <span className="text-light text-brand-hover">
-              <Icon name={"ellipsis"} />
+              <Icon name="ellipsis" />
             </span>
           }
         >

--- a/frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx
@@ -118,7 +118,7 @@ class PartialQueryBuilder extends Component {
             <span className="text-bold px3">{previewSummary}</span>
             <Link
               to={previewUrl}
-              data-metabase-event={"Data Model;Preview Click"}
+              data-metabase-event="Data Model;Preview Click"
               target={window.OSX ? null : "_blank"}
               rel="noopener noreferrer"
               className="Button Button--primary"

--- a/frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx
@@ -37,7 +37,7 @@ class SegmentForm extends Component {
           onClick={handleSubmit}
         >{t`Save changes`}</button>
         <Link
-          to={`/admin/datamodel/segments`}
+          to="/admin/datamodel/segments"
           className="Button ml2"
         >{t`Cancel`}</Link>
       </div>

--- a/frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx
@@ -18,7 +18,7 @@ class MetricListAppInner extends React.Component {
       <div className="px3 pb2">
         <div className="flex py2">
           {tableSelector}
-          <Link to={`/admin/datamodel/metric/create`} className="ml-auto">
+          <Link to="/admin/datamodel/metric/create" className="ml-auto">
             <Button primary>{t`New metric`}</Button>
           </Link>
         </div>

--- a/frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx
@@ -18,7 +18,7 @@ class SegmentListAppInner extends React.Component {
       <div className="px3 pb2">
         <div className="flex py2">
           {tableSelector}
-          <Link to={`/admin/datamodel/segment/create`} className="ml-auto">
+          <Link to="/admin/datamodel/segment/create" className="ml-auto">
             <Button primary>{t`New segment`}</Button>
           </Link>
         </div>

--- a/frontend/src/metabase/auth/components/ForgotPassword/ForgotPassword.tsx
+++ b/frontend/src/metabase/auth/components/ForgotPassword/ForgotPassword.tsx
@@ -84,7 +84,7 @@ const ForgotPasswordForm = ({
         onSubmit={handleSubmit}
       />
       <FormFooter>
-        <FormLink to={"/auth/login"}>{t`Back to sign in`}</FormLink>
+        <FormLink to="/auth/login">{t`Back to sign in`}</FormLink>
       </FormFooter>
     </div>
   );
@@ -101,7 +101,7 @@ const ForgotPasswordSuccess = (): JSX.Element => {
       </InfoMessage>
       <InfoLink
         className="Button Button--primary"
-        to={"/auth/login"}
+        to="/auth/login"
       >{t`Back to sign in`}</InfoLink>
     </InfoBody>
   );
@@ -113,7 +113,7 @@ const ForgotPasswordDisabled = (): JSX.Element => {
       <InfoMessage>
         {t`Please contact an administrator to have them reset your password.`}
       </InfoMessage>
-      <InfoLink to={"/auth/login"}>{t`Back to sign in`}</InfoLink>
+      <InfoLink to="/auth/login">{t`Back to sign in`}</InfoLink>
     </InfoBody>
   );
 };

--- a/frontend/src/metabase/auth/components/ResetPassword/ResetPassword.tsx
+++ b/frontend/src/metabase/auth/components/ResetPassword/ResetPassword.tsx
@@ -120,7 +120,7 @@ const ResetPasswordSuccess = (): JSX.Element => {
       <InfoMessage>{t`You've updated your password.`}</InfoMessage>
       <Link
         className="Button Button--primary"
-        to={"/"}
+        to="/"
       >{t`Sign in with your new password`}</Link>
     </InfoBody>
   );

--- a/frontend/src/metabase/browse/components/BrowseHeader.jsx
+++ b/frontend/src/metabase/browse/components/BrowseHeader.jsx
@@ -18,7 +18,7 @@ export default function BrowseHeader({ crumbs }) {
           <Link
             className="flex flex-align-right"
             to="reference"
-            data-metabase-event={`NavBar;Reference`}
+            data-metabase-event="NavBar;Reference"
           >
             <div className="flex align-center text-medium text-brand-hover">
               <Icon className="flex align-center" size={14} name="reference" />

--- a/frontend/src/metabase/components/ColorRangePicker.jsx
+++ b/frontend/src/metabase/components/ColorRangePicker.jsx
@@ -34,7 +34,7 @@ const ColorRangePicker = ({
         {ranges.map((range, index) => (
           <div
             key={index}
-            className={"mb1 pl1"}
+            className="mb1 pl1"
             style={{ flex: `1 1 ${Math.round(100 / columns)}%` }}
           >
             <ColorRangePreview

--- a/frontend/src/metabase/components/TitleAndDescription.jsx
+++ b/frontend/src/metabase/components/TitleAndDescription.jsx
@@ -9,7 +9,7 @@ const TitleAndDescription = ({ title, description, className }) => (
   <div className={cx("flex align-center", className)}>
     <h2 className="h2 mr1 text-wrap">{title}</h2>
     {description && (
-      <Tooltip tooltip={description} maxWidth={"22em"}>
+      <Tooltip tooltip={description} maxWidth="22em">
         <Icon name="info" className="mx1" />
       </Tooltip>
     )}

--- a/frontend/src/metabase/dashboard/components/AddSeriesModal/AddSeriesModal.jsx
+++ b/frontend/src/metabase/dashboard/components/AddSeriesModal/AddSeriesModal.jsx
@@ -205,7 +205,7 @@ class AddSeriesModal extends Component {
               {t`Done`}
             </button>
             <button
-              data-metabase-event={"Dashboard;Edit Series Modal;cancel"}
+              data-metabase-event="Dashboard;Edit Series Modal;cancel"
               className="Button ml2"
               onClick={this.props.onClose}
             >

--- a/frontend/src/metabase/dashboard/components/DashCard.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard.jsx
@@ -432,7 +432,7 @@ const RemoveButton = ({ onRemove }) => (
 const AddSeriesButton = ({ series, onAddSeries }) => (
   <a
     data-testid="add-series-button"
-    data-metabase-event={"Dashboard;Edit Series Modal;open"}
+    data-metabase-event="Dashboard;Edit Series Modal;open"
     className="text-dark-hover cursor-pointer h3 flex-no-shrink relative mr1 drag-disabled"
     onClick={onAddSeries}
     style={HEADER_ACTION_STYLE}
@@ -456,7 +456,7 @@ const AddSeriesButton = ({ series, onAddSeries }) => (
 const ToggleCardPreviewButton = ({ isPreviewing, onPreviewToggle }) => {
   return (
     <a
-      data-metabase-event={"Dashboard;Text;edit"}
+      data-metabase-event="Dashboard;Text;edit"
       className="text-dark-hover cursor-pointer h3 flex-no-shrink relative mr1 drag-disabled"
       onClick={onPreviewToggle}
       style={HEADER_ACTION_STYLE}

--- a/frontend/src/metabase/dashboard/components/DashboardActions.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardActions.jsx
@@ -57,7 +57,7 @@ export const getDashboardActions = (
             <DashboardHeaderButton
               disabled={!canManageSubscriptions}
               onClick={onSharingClick}
-              data-metabase-event={"Dashboard;Subscriptions"}
+              data-metabase-event="Dashboard;Subscriptions"
             >
               <Icon size={18} name="subscription" />
             </DashboardHeaderButton>

--- a/frontend/src/metabase/dashboard/containers/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/containers/Dashboard.jsx
@@ -20,11 +20,7 @@ export class Dashboard extends Component {
         noBackground
       >
         {() => (
-          <DashboardGrid
-            dashboard={dashboard}
-            {...props}
-            className={"spread"}
-          />
+          <DashboardGrid dashboard={dashboard} {...props} className="spread" />
         )}
       </LoadingAndErrorWrapper>
     );

--- a/frontend/src/metabase/dashboard/containers/DashboardHeader.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardHeader.jsx
@@ -252,7 +252,7 @@ class DashboardHeader extends Component {
         <Tooltip key="revision-history" tooltip={t`Revision history`}>
           <Link
             to={location.pathname + "/history"}
-            data-metabase-event={"Dashboard;Revisions"}
+            data-metabase-event="Dashboard;Revisions"
           >
             {t`Revision history`}
           </Link>
@@ -286,7 +286,7 @@ class DashboardHeader extends Component {
           <Link
             className={extraButtonClassNames}
             to={location.pathname + "/details"}
-            data-metabase-event={"Dashboard;EditDetails"}
+            data-metabase-event="Dashboard;EditDetails"
           >
             {t`Edit dashboard details`}
           </Link>,
@@ -306,7 +306,7 @@ class DashboardHeader extends Component {
         <Link
           className={extraButtonClassNames}
           to={location.pathname + "/history"}
-          data-metabase-event={"Dashboard;EditDetails"}
+          data-metabase-event="Dashboard;EditDetails"
         >
           {t`Revision history`}
         </Link>,
@@ -316,7 +316,7 @@ class DashboardHeader extends Component {
         <Link
           className={extraButtonClassNames}
           to={location.pathname + "/copy"}
-          data-metabase-event={"Dashboard;Copy"}
+          data-metabase-event="Dashboard;Copy"
         >
           {t`Duplicate`}
         </Link>,
@@ -327,7 +327,7 @@ class DashboardHeader extends Component {
           <Link
             className={extraButtonClassNames}
             to={location.pathname + "/move"}
-            data-metabase-event={"Dashboard;Move"}
+            data-metabase-event="Dashboard;Move"
           >
             {t`Move`}
           </Link>,
@@ -339,7 +339,7 @@ class DashboardHeader extends Component {
           <Link
             className={extraButtonClassNames}
             to={location.pathname + "/archive"}
-            data-metabase-event={"Dashboard;Archive"}
+            data-metabase-event="Dashboard;Archive"
           >
             {t`Archive`}
           </Link>,

--- a/frontend/src/metabase/nav/components/AdminNavbar/AdminNavbar.tsx
+++ b/frontend/src/metabase/nav/components/AdminNavbar/AdminNavbar.tsx
@@ -31,7 +31,7 @@ export const AdminNavbar = ({
 }: AdminNavbarProps) => {
   return (
     <AdminNavbarRoot className="Nav">
-      <AdminLogoLink to="/admin" data-metabase-event={"Navbar;Logo"}>
+      <AdminLogoLink to="/admin" data-metabase-event="Navbar;Logo">
         <AdminLogoContainer>
           <LogoIcon className="text-brand my2" dark />
           <AdminLogoText>{t`Metabase Admin`}</AdminLogoText>

--- a/frontend/src/metabase/new_query/components/NewQueryOption.jsx
+++ b/frontend/src/metabase/new_query/components/NewQueryOption.jsx
@@ -44,7 +44,7 @@ export default class NewQueryOption extends Component {
           <h2 className={cx("transition-all", { "text-brand": hover })}>
             {title}
           </h2>
-          <p className={"text-medium text-small"}>{description}</p>
+          <p className="text-medium text-small">{description}</p>
         </div>
       </Link>
     );

--- a/frontend/src/metabase/new_query/containers/NewQueryOptions.jsx
+++ b/frontend/src/metabase/new_query/containers/NewQueryOptions.jsx
@@ -81,7 +81,7 @@ class NewQueryOptions extends Component {
                 description={t`Pick some data, view it, and easily filter, summarize, and visualize it.`}
                 width={180}
                 to={Urls.newQuestion({ creationType: "simple_question" })}
-                data-metabase-event={`New Question; Simple Question Start`}
+                data-metabase-event="New Question; Simple Question Start"
               />
             </QueryOptionsGridItem>
           )}
@@ -96,7 +96,7 @@ class NewQueryOptions extends Component {
                   mode: "notebook",
                   creationType: "custom_question",
                 })}
-                data-metabase-event={`New Question; Custom Question Start`}
+                data-metabase-event="New Question; Custom Question Start"
               />
             </QueryOptionsGridItem>
           )}
@@ -111,7 +111,7 @@ class NewQueryOptions extends Component {
                   creationType: "native_question",
                 })}
                 width={180}
-                data-metabase-event={`New Question; Native Query Start`}
+                data-metabase-event="New Question; Native Query Start"
               />
             </QueryOptionsGridItem>
           )}

--- a/frontend/src/metabase/parameters/components/ParameterSidebar.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterSidebar.jsx
@@ -194,7 +194,7 @@ class OtherParameterList extends React.Component {
               <span className="text-italic">this</span>
             )} filter.`}</p>
             {usableParameters.map(({ id, name }) => (
-              <div className={"bg-light rounded mb2"} key={name}>
+              <div className="bg-light rounded mb2" key={name}>
                 <div className="flex justify-between align-center p2">
                   <span
                     className="border-dashed-bottom text-bold cursor-pointer"

--- a/frontend/src/metabase/public/containers/PublicDashboard.jsx
+++ b/frontend/src/metabase/public/containers/PublicDashboard.jsx
@@ -136,7 +136,7 @@ class PublicDashboard extends Component {
           {() => (
             <DashboardGrid
               {...this.props}
-              className={"spread"}
+              className="spread"
               mode={PublicMode}
               metadata={this.props.metadata}
               navigateToNewCardFromDashboard={() => {}}

--- a/frontend/src/metabase/query_builder/components/AggregationPopover.jsx
+++ b/frontend/src/metabase/query_builder/components/AggregationPopover.jsx
@@ -344,7 +344,7 @@ export default class AggregationPopover extends Component {
             </a>
           </div>
           <FieldList
-            className={"text-green"}
+            className="text-green"
             width={this.props.width}
             maxHeight={this.props.maxHeight - (this.state.headerHeight || 0)}
             query={query}

--- a/frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx
+++ b/frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx
@@ -173,7 +173,7 @@ class AlertListItemInner extends Component {
               <AlertCreatorTitle alert={alert} user={user} />
             </div>
             <div
-              className={`ml-auto text-bold text-small`}
+              className="ml-auto text-bold text-small"
               style={{
                 transform: `translateY(4px)`,
               }}
@@ -246,7 +246,7 @@ export const UnsubscribedListItem = () => (
       <Icon name="check" className="text-success" />
     </div>
     <h3
-      className={`text-dark`}
+      className="text-dark"
       style={{ marginLeft: 10 }}
     >{jt`Okay, you're unsubscribed`}</h3>
   </li>

--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -1467,7 +1467,7 @@ const TablePicker = ({
           hasInitialFocus={hasInitialFocus}
           sections={sections}
           maxHeight={Infinity}
-          width={"100%"}
+          width="100%"
           searchable={hasFiltering && tables.length >= minTablesToShowSearch}
           onChange={item => onChangeTable(item.table)}
           itemIsSelected={item =>
@@ -1565,7 +1565,7 @@ class FieldPicker extends Component {
           hasInitialFocus={hasInitialFocus}
           sections={sections}
           maxHeight={Infinity}
-          width={"100%"}
+          width="100%"
           searchable={hasFiltering}
           onChange={item => onChangeField(item.field)}
           itemIsSelected={item =>

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/RightClickPopover/RightClickPopover.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/RightClickPopover/RightClickPopover.jsx
@@ -27,12 +27,12 @@ const NativeQueryEditorRightClickPopover = ({
   <Popover isOpen={isOpen} target={target}>
     <Container>
       <Anchor onClick={runQuery}>
-        <Icon name={"play"} size={16} />
+        <Icon name="play" size={16} />
         <h4>{t`Run selection`}</h4>
       </Anchor>
       {canSaveSnippets && (
         <Anchor onClick={openSnippetModalWithSelectedText}>
-          <Icon name={"snippet"} size={16} />
+          <Icon name="snippet" size={16} />
           <h4>{t`Save as snippet`}</h4>
         </Anchor>
       )}

--- a/frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.jsx
+++ b/frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.jsx
@@ -23,7 +23,7 @@ export default class SavedQuestionIntroModal extends Component {
           <div className="px2 pb2 text-paragraph">{message}</div>
           <div className="Form-actions flex justify-center py1">
             <button
-              data-metabase-event={"QueryBuilder;IntroModal"}
+              data-metabase-event="QueryBuilder;IntroModal"
               className="Button Button--primary"
               onClick={onClose}
             >

--- a/frontend/src/metabase/query_builder/components/expressions/Expressions.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/Expressions.jsx
@@ -50,7 +50,7 @@ export default class Expressions extends Component {
           ))}
 
         <a
-          data-metabase-event={"QueryBuilder;Show Add Custom Field"}
+          data-metabase-event="QueryBuilder;Show Add Custom Field"
           className="text-light text-bold flex align-center text-medium-hover cursor-pointer no-decoration transition-color"
           onClick={() => onAddExpression()}
         >

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePicker.tsx
@@ -282,7 +282,7 @@ const DatePicker: React.FC<Props> = props => {
     <div className={cx(className)}>
       {!operator || showShortcuts ? (
         <DatePickerShortcuts
-          className={"p2"}
+          className="p2"
           primaryColor={primaryColor}
           onFilterChange={filter => {
             setShowShortcuts(false);

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePickerShortcuts.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePickerShortcuts.tsx
@@ -164,7 +164,7 @@ export default function DatePickerShortcuts({
     <div className={className}>
       {onBack ? (
         <SidebarHeader
-          className={"text-default py1 mb1"}
+          className="text-default py1 mb1"
           title={title}
           onBack={onBack}
         />

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RelativeDatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RelativeDatePicker.tsx
@@ -241,7 +241,7 @@ const RelativeDatePicker: React.FC<Props> = props => {
       {showOptions ? (
         <TippyPopover
           visible={optionsVisible}
-          placement={"bottom-start"}
+          placement="bottom-start"
           content={optionsContent}
           onClose={() => setOptionsVisible(false)}
         >
@@ -291,7 +291,7 @@ const RelativeDatePicker: React.FC<Props> = props => {
             intervals={Math.abs(startingFrom[0])}
             formatter={formatter}
             periods={ALL_PERIODS}
-            testId={"starting-from-unit"}
+            testId="starting-from-unit"
           />
           <MoreButton
             icon="close"

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx
@@ -299,7 +299,7 @@ const TagEditorHelp = ({
         <ExternalLink
           href={MetabaseSettings.docsUrl("users-guide/13-sql-parameters")}
           target="_blank"
-          data-metabase-event={"QueryBuilder;Template Tag Documentation Click"}
+          data-metabase-event="QueryBuilder;Template Tag Documentation Click"
         >{t`Read the full documentation`}</ExternalLink>
       </p>
     </div>

--- a/frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx
@@ -166,7 +166,7 @@ export function QuestionFilterWidget({
         color={color("filter")}
         active={isShowingFilterSidebar}
         onClick={isShowingFilterSidebar ? onCloseFilter : onAddFilter}
-        data-metabase-event={`View Mode; Open Filter Widget`}
+        data-metabase-event="View Mode; Open Filter Widget"
       >
         {t`Filter`}
       </HeaderButton>

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -275,7 +275,7 @@ function AhHocQuestionLeftSide(props) {
             question={question}
             isObjectDetail={isObjectDetail}
             subHead
-            data-metabase-event={`Question Data Source Click`}
+            data-metabase-event="Question Data Source Click"
           />
         )}
       </ViewHeaderLeftSubHeading>
@@ -497,7 +497,7 @@ function ViewTitleHeaderRightSide(props) {
           isShowingSummarySidebar={isShowingSummarySidebar}
           onEditSummary={onEditSummary}
           onCloseSummary={onCloseSummary}
-          data-metabase-event={`View Mode; Open Summary Widget`}
+          data-metabase-event="View Mode; Open Summary Widget"
         />
       )}
       {QuestionNotebookButton.shouldRender(props) && (
@@ -518,7 +518,7 @@ function ViewTitleHeaderRightSide(props) {
         <NativeQueryButton
           size={16}
           question={question}
-          data-metabase-event={`Notebook Mode; Convert to SQL Click`}
+          data-metabase-event="Notebook Mode; Convert to SQL Click"
         />
       )}
       {hasExploreResultsLink && <ExploreResultsLink question={question} />}

--- a/frontend/src/metabase/query_builder/containers/QuestionHistoryModal.jsx
+++ b/frontend/src/metabase/query_builder/containers/QuestionHistoryModal.jsx
@@ -16,7 +16,7 @@ class QuestionHistoryModalInner extends React.Component {
     const { question, onClose, onReverted } = this.props;
     return (
       <HistoryModal
-        modelType={"card"}
+        modelType="card"
         modelId={question.id}
         canRevert={question.can_write}
         onClose={onClose}

--- a/frontend/src/metabase/reference/databases/NoDatabasesEmptyState.jsx
+++ b/frontend/src/metabase/reference/databases/NoDatabasesEmptyState.jsx
@@ -8,9 +8,9 @@ const NoDatabasesEmptyState = user => (
     title={t`Metabase is no fun without any data`}
     adminMessage={t`Your databases will appear here once you connect one`}
     message={t`Databases will appear here once your admins have added some`}
-    image={"app/assets/img/databases-list"}
+    image="app/assets/img/databases-list"
     adminAction={t`Connect a database`}
-    adminLink={"/admin/databases/create"}
+    adminLink="/admin/databases/create"
     user={user}
   />
 );

--- a/frontend/src/metabase/static-viz/components/ProgressBar/ProgressBar.tsx
+++ b/frontend/src/metabase/static-viz/components/ProgressBar/ProgressBar.tsx
@@ -87,7 +87,7 @@ const ProgressBar = ({
           rx={layout.borderRadius}
         />
       </ClipPath>
-      <Group clipPath={`url(#rounded-bar)`} top={layout.margin.top} left={xMin}>
+      <Group clipPath="url(#rounded-bar)" top={layout.margin.top} left={xMin}>
         <rect
           width={barWidth}
           height={layout.barHeight}
@@ -123,7 +123,7 @@ const ProgressBar = ({
       <Group left={pointerX} top={pointerY}>
         <Text
           fontSize={layout.fontSize}
-          textAnchor={"middle"}
+          textAnchor="middle"
           dy="-0.4em"
           dx={valueTextShift}
         >

--- a/frontend/src/metabase/visualizations/components/ChartSettings.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings.jsx
@@ -307,7 +307,7 @@ class ChartSettings extends Component {
           <div className="Grid flex-full">
             <div
               className="Grid-cell Cell--1of3 scroll-y scroll-show border-right py4"
-              data-testid={"chartsettings-sidebar"}
+              data-testid="chartsettings-sidebar"
             >
               {widgetList}
             </div>

--- a/frontend/src/metabase/visualizations/components/LegendItem.jsx
+++ b/frontend/src/metabase/visualizations/components/LegendItem.jsx
@@ -87,7 +87,7 @@ export default class LegendItem extends Component {
             <Ellipsified showTooltip={showTooltip}>{title}</Ellipsified>
             {description && (
               <div className="hover-child ml1 flex align-center text-medium">
-                <Tooltip tooltip={description} maxWidth={"22em"}>
+                <Tooltip tooltip={description} maxWidth="22em">
                   <Icon className={infoClassName} name="info" />
                 </Tooltip>
               </div>

--- a/frontend/src/metabase/visualizations/components/ScalarValue/ScalarValue.jsx
+++ b/frontend/src/metabase/visualizations/components/ScalarValue/ScalarValue.jsx
@@ -64,7 +64,7 @@ export const ScalarTitle = ({ title, description, onClick }) => (
         className="hover-child cursor-pointer pl1 text-brand-hover"
         style={{ marginTop: 5, width: ICON_WIDTH }}
       >
-        <Tooltip tooltip={description} maxWidth={"22em"}>
+        <Tooltip tooltip={description} maxWidth="22em">
           <Icon name="info_outline" />
         </Tooltip>
       </div>

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx
@@ -209,7 +209,7 @@ const RuleListing = ({ rules, cols, onEdit, onAdd, onRemove, onMove }) => (
         borderless
         icon="add"
         onClick={onAdd}
-        data-metabase-event={`Chart Settings;Table Formatting;Add Rule`}
+        data-metabase-event="Chart Settings;Table Formatting;Add Rule"
       >
         {t`Add a rule`}
       </Button>
@@ -472,7 +472,7 @@ const RuleEditor = ({ rule, cols, isNew, onChange, onDone, onRemove }) => {
           <Button
             primary
             onClick={onRemove}
-            data-metabase-event={`Chart Settings;Table Formatting;`}
+            data-metabase-event="Chart Settings;Table Formatting;"
           >
             {isNew ? t`Cancel` : t`Delete`}
           </Button>

--- a/frontend/src/metabase/visualizations/visualizations/PieChart.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PieChart.jsx
@@ -467,7 +467,7 @@ export default class PieChart extends Component {
               viewBox="0 0 100 100"
               style={{ maxWidth: MAX_PIE_SIZE, maxHeight: MAX_PIE_SIZE }}
             >
-              <g ref={this.chartGroup} transform={`translate(50,50)`}>
+              <g ref={this.chartGroup} transform="translate(50,50)">
                 {pie(slices).map((slice, index) => (
                   <path
                     data-testid="slice"


### PR DESCRIPTION
Just some code style housekeeping:

* replaced some backticks that were used for plain strings (not translations or template literals)
* removed brackets usage for React string props. Example: `className={"text-dark"}` —> `className="text-dark"`