### PR TITLE
Respect DB `actions` setting on the frontend

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -6,6 +6,7 @@ import cx from "classnames";
 import * as Urls from "metabase/lib/urls";
 import { SERVER_ERROR_TYPES } from "metabase/lib/errors";
 import MetabaseSettings from "metabase/lib/settings";
+import { isDatabaseWritebackEnabled } from "metabase/writeback/utils";
 
 import Button from "metabase/core/components/Button";
 import ButtonBar from "metabase/components/ButtonBar";
@@ -437,7 +438,12 @@ function ViewTitleHeaderRightSide(props) {
   const hasRunButton =
     isRunnable && !isNativeEditorOpen && !isMissingPermissions;
 
-  const hasNewRowButton = isWritebackEnabled && !isNative && query.isRaw();
+  const database = question.database()?.getPlainObject?.();
+  const hasNewRowButton =
+    isWritebackEnabled &&
+    isDatabaseWritebackEnabled(database) &&
+    !isNative &&
+    query.isRaw();
 
   return (
     <div

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
@@ -39,6 +39,7 @@ import { columnSettings } from "metabase/visualizations/lib/settings/column";
 
 import WritebackForm from "metabase/writeback/containers/WritebackForm";
 import { getWritebackEnabled } from "metabase/writeback/selectors";
+import { isDatabaseWritebackEnabled } from "metabase/writeback/utils";
 
 import {
   getObjectName,
@@ -151,7 +152,6 @@ export function ObjectDetailFn({
   viewPreviousObjectDetail,
   viewNextObjectDetail,
   closeObjectDetail,
-  ...rest
 }: ObjectDetailProps): JSX.Element | null {
   const [hasNotFoundError, setHasNotFoundError] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
@@ -221,7 +221,12 @@ export function ObjectDetailFn({
     [zoomedRowID, followForeignKey],
   );
 
-  const canEdit = !!(isWritebackEnabled && table);
+  const database = question.database()?.getPlainObject?.();
+  const canEdit = !!(
+    table &&
+    isWritebackEnabled &&
+    isDatabaseWritebackEnabled(database)
+  );
   const deleteRow = React.useMemo(() => {
     if (canEdit) {
       return () =>

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.unit.spec.tsx
@@ -88,6 +88,9 @@ describe("Object Detail", () => {
         question={
           {
             displayName: () => "Product",
+            database: () => ({
+              getPlainObject: () => ({}),
+            }),
           } as any
         }
         table={

--- a/frontend/src/metabase/writeback/utils.ts
+++ b/frontend/src/metabase/writeback/utils.ts
@@ -4,8 +4,8 @@ import { Database as IDatabase } from "metabase-types/types/Database";
 const DB_WRITEBACK_FEATURE = "actions";
 const DB_WRITEBACK_SETTING = "database-enable-actions";
 
-export const isDatabaseWritebackEnabled = (database: IDatabase) =>
+export const isDatabaseWritebackEnabled = (database?: IDatabase | null) =>
   !!database?.settings?.[DB_WRITEBACK_SETTING];
 
-export const isWritebackSupported = (database: Database) =>
+export const isWritebackSupported = (database?: Database | null) =>
   !!database?.hasFeature(DB_WRITEBACK_FEATURE);


### PR DESCRIPTION
Part of #22542, missing pieces for #22547 and #22549

Makes the frontend only show writeback UI or databases with enabled experimental actions flag.

### Demo

https://user-images.githubusercontent.com/17258145/170316134-1d6b7b1f-3e3a-49ea-abbd-52f2fc11fa67.mp4


