### PR TITLE
Repro #22822: Do not offer "Explore results" unless the database supports it

### DIFF
--- a/frontend/test/metabase/scenarios/native/reproductions/22822-explore-results-unsupported-databases.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/reproductions/22822-explore-results-unsupported-databases.cy.spec.js
@@ -1,0 +1,26 @@
+import { restore } from "__support__/e2e/cypress";
+
+const MONGO_DB_ID = 2;
+
+const questionDetails = {
+  name: "22822",
+  database: MONGO_DB_ID,
+  native: {
+    query: '[{"$limit": 2}]',
+    collection: "products",
+  },
+};
+
+describe.skip("issue 22822", () => {
+  beforeEach(() => {
+    restore("mongo-4");
+    cy.signInAsAdmin();
+  });
+
+  it("should not show 'Explore Results' for databases that do not support nested queries (metabase#22822)", () => {
+    cy.createNativeQuestion(questionDetails, { visitQuestion: true });
+
+    cy.findByTextEnsureVisible("Rustic Paper Wallet");
+    cy.findByText("Explore results").should("not.exist");
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #22822

### How to test this manually?
- `yarn test-cypress-open`
- `metabase/scenarios/native/reproductions/22822-explore-results-unsupported-databases.cy.spec.js`
- Unskip repro
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/170319533-fa8e4b66-ed1c-403c-aa9a-1b35fe879dae.png)
