### PR TITLE
Add `is_write` field to question create/update forms

### DIFF
--- a/frontend/src/metabase/containers/SaveQuestionModal.jsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal.jsx
@@ -15,6 +15,7 @@ import validate from "metabase/lib/validate";
 import { canonicalCollectionId } from "metabase/collections/utils";
 
 import Databases from "metabase/entities/databases";
+import { getUserIsAdmin } from "metabase/selectors/user";
 import { getWritebackEnabled } from "metabase/writeback/selectors";
 import { isDatabaseWritebackEnabled } from "metabase/writeback/utils";
 
@@ -22,6 +23,7 @@ import "./SaveQuestionModal.css";
 
 function mapStateToProps(state) {
   return {
+    isAdmin: getUserIsAdmin(state),
     isWritebackEnabled: getWritebackEnabled(state),
   };
 }
@@ -37,6 +39,7 @@ class SaveQuestionModal extends Component {
     onClose: PropTypes.func.isRequired,
     multiStep: PropTypes.bool,
     isWritebackEnabled: PropTypes.bool.isRequired,
+    isAdmin: PropTypes.bool.isRequired,
   };
 
   validateName = (name, context) => {
@@ -48,9 +51,10 @@ class SaveQuestionModal extends Component {
   };
 
   hasIsWriteField = () => {
-    const { card, database, isWritebackEnabled } = this.props;
+    const { card, database, isAdmin, isWritebackEnabled } = this.props;
     const isNative = Q_DEPRECATED.isNative(card.dataset_query);
     return (
+      isAdmin &&
       isNative &&
       isWritebackEnabled &&
       isDatabaseWritebackEnabled(database.getPlainObject())

--- a/frontend/src/metabase/containers/SaveQuestionModal.jsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal.jsx
@@ -57,7 +57,7 @@ class SaveQuestionModal extends Component {
       isAdmin &&
       isNative &&
       isWritebackEnabled &&
-      isDatabaseWritebackEnabled(database.getPlainObject())
+      isDatabaseWritebackEnabled(database.getPlainObject?.())
     );
   };
 

--- a/frontend/src/metabase/entities/questions.js
+++ b/frontend/src/metabase/entities/questions.js
@@ -85,6 +85,7 @@ const Questions = createEntity({
     "collection_id",
     "collection_position",
     "result_metadata",
+    "is_write",
   ],
 
   getAnalyticsMetadata([object], { action }, getState) {

--- a/frontend/src/metabase/entities/questions/forms.js
+++ b/frontend/src/metabase/entities/questions/forms.js
@@ -10,6 +10,12 @@ const FORM_FIELDS = [
     type: "text",
     placeholder: t`It's optional but oh, so helpful`,
   },
+  {
+    name: "is_write",
+    title: t`Is Write`,
+    description: t`Write questions can be used for experimental actions.`,
+    type: "boolean",
+  },
 ];
 
 export default {

--- a/frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx
+++ b/frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx
@@ -11,6 +11,7 @@ import CollapseSection from "metabase/components/CollapseSection";
 import { PLUGIN_CACHING } from "metabase/plugins";
 import Questions from "metabase/entities/questions";
 
+import { getUserIsAdmin } from "metabase/selectors/user";
 import { getWritebackEnabled } from "metabase/writeback/selectors";
 import { isDatabaseWritebackEnabled } from "metabase/writeback/utils";
 
@@ -18,12 +19,14 @@ const COLLAPSED_FIELDS = ["cache_ttl"];
 
 function mapStateToProps(state) {
   return {
+    isAdmin: getUserIsAdmin(state),
     isWritebackEnabled: getWritebackEnabled(state),
   };
 }
 
 const propTypes = {
   question: PropTypes.object.isRequired, // metabase-lib Question instance
+  isAdmin: PropTypes.bool.isRequired,
   isWritebackEnabled: PropTypes.bool.isRequired,
   onSave: PropTypes.func.isRequired,
   onClose: PropTypes.func.isRequired,
@@ -31,6 +34,7 @@ const propTypes = {
 
 function EditQuestionInfoModal({
   question,
+  isAdmin,
   isWritebackEnabled,
   onClose,
   onSave,
@@ -38,6 +42,7 @@ function EditQuestionInfoModal({
   const modalTitle = question.isDataset() ? t`Edit model` : t`Edit question`;
   const database = question.database().getPlainObject();
   const hasIsWriteField =
+    isAdmin &&
     question.isNative() &&
     !question.isDataset() &&
     isWritebackEnabled &&

--- a/frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx
+++ b/frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx
@@ -2,6 +2,7 @@ import React, { useCallback } from "react";
 import PropTypes from "prop-types";
 import { t } from "ttag";
 import _ from "underscore";
+import { connect } from "react-redux";
 
 import Form from "metabase/containers/Form";
 import ModalContent from "metabase/components/ModalContent";
@@ -10,16 +11,37 @@ import CollapseSection from "metabase/components/CollapseSection";
 import { PLUGIN_CACHING } from "metabase/plugins";
 import Questions from "metabase/entities/questions";
 
+import { getWritebackEnabled } from "metabase/writeback/selectors";
+import { isDatabaseWritebackEnabled } from "metabase/writeback/utils";
+
 const COLLAPSED_FIELDS = ["cache_ttl"];
+
+function mapStateToProps(state) {
+  return {
+    isWritebackEnabled: getWritebackEnabled(state),
+  };
+}
 
 const propTypes = {
   question: PropTypes.object.isRequired, // metabase-lib Question instance
+  isWritebackEnabled: PropTypes.bool.isRequired,
   onSave: PropTypes.func.isRequired,
   onClose: PropTypes.func.isRequired,
 };
 
-function EditQuestionInfoModal({ question, onClose, onSave }) {
+function EditQuestionInfoModal({
+  question,
+  isWritebackEnabled,
+  onClose,
+  onSave,
+}) {
   const modalTitle = question.isDataset() ? t`Edit model` : t`Edit question`;
+  const database = question.database().getPlainObject();
+  const hasIsWriteField =
+    question.isNative() &&
+    !question.isDataset() &&
+    isWritebackEnabled &&
+    isDatabaseWritebackEnabled(database);
 
   const onSubmit = useCallback(
     async card => {
@@ -54,9 +76,19 @@ function EditQuestionInfoModal({ question, onClose, onSave }) {
 
           return (
             <Form>
-              {visibleFields.map(field => (
-                <FormField key={field.name} name={field.name} />
-              ))}
+              {visibleFields.map(field => {
+                const extraProps = {};
+                if (field.name === "is_write" && !hasIsWriteField) {
+                  extraProps.type = "hidden";
+                }
+                return (
+                  <FormField
+                    key={field.name}
+                    name={field.name}
+                    {...extraProps}
+                  />
+                );
+              })}
               {collapsedFields.length > 0 && (
                 <CollapseSection
                   header={t`More options`}
@@ -83,4 +115,4 @@ function EditQuestionInfoModal({ question, onClose, onSave }) {
 
 EditQuestionInfoModal.propTypes = propTypes;
 
-export default EditQuestionInfoModal;
+export default connect(mapStateToProps)(EditQuestionInfoModal);

--- a/frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx
+++ b/frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx
@@ -40,7 +40,7 @@ function EditQuestionInfoModal({
   onSave,
 }) {
   const modalTitle = question.isDataset() ? t`Edit model` : t`Edit question`;
-  const database = question.database().getPlainObject();
+  const database = question.database()?.getPlainObject?.();
   const hasIsWriteField =
     isAdmin &&
     question.isNative() &&


### PR DESCRIPTION
Part of #22542, resolves #22856

Adds `is_write` field to questions create/update forms. It's only a UI for now as the BE support for this property is WIP (see #22845). The field will only be displayed when everything below matches:

* a user is an admin
* `experimental-enable-actions` setting is enabled
* experimental actions are supported by and enabled for the question's database
* question is native
* question is not a model

### Demo

https://user-images.githubusercontent.com/17258145/170337228-bd4e5ccf-846b-4723-960d-5262ccbd3924.mp4


