### PR TITLE
Repro #22788: Filters connected to a custom column lose their settings when editing the dashboard a second time

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard-filters/reproductions/22788-flter-cc-dropped-on-second-edit.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/reproductions/22788-flter-cc-dropped-on-second-edit.cy.spec.js
@@ -1,0 +1,101 @@
+import {
+  restore,
+  visitDashboard,
+  filterWidget,
+  editDashboard,
+  saveDashboard,
+} from "__support__/e2e/cypress";
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+
+const { PRODUCTS_ID, PRODUCTS } = SAMPLE_DATABASE;
+
+const ccName = "Custom Category";
+
+const questionDetails = {
+  name: "22788",
+  query: {
+    "source-table": PRODUCTS_ID,
+    expressions: { [ccName]: ["field", PRODUCTS.CATEGORY, null] },
+    limit: 5,
+  },
+};
+
+const filter = {
+  name: "Text",
+  slug: "text",
+  id: "a7565817",
+  type: "string/=",
+  sectionId: "string",
+};
+
+const dashboardDetails = {
+  name: "22788D",
+  parameters: [filter],
+};
+
+describe.skip("issue 22788", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    cy.createQuestionAndDashboard({ questionDetails, dashboardDetails }).then(
+      ({ body: { dashboard_id, card_id, id } }) => {
+        cy.request("PUT", `/api/dashboard/${dashboard_id}/cards`, {
+          cards: [
+            {
+              id,
+              card_id,
+              row: 0,
+              col: 0,
+              sizeX: 8,
+              sizeY: 6,
+              parameter_mappings: [
+                {
+                  parameter_id: filter.id,
+                  card_id,
+                  target: ["dimension", ["expression", ccName, null]],
+                },
+              ],
+            },
+          ],
+        });
+
+        visitDashboard(dashboard_id);
+      },
+    );
+  });
+
+  it("should not drop filter connected to a custom column on a second dashboard edit (metabase#22788)", () => {
+    addFilterAndAssert();
+
+    editDashboard();
+
+    openFilterSettings();
+
+    // Make sure the filter is still connected to the custom column
+    cy.findByText("Column to filter on")
+      .parent()
+      .within(() => {
+        cy.findByText(ccName);
+      });
+
+    saveDashboard();
+
+    addFilterAndAssert();
+  });
+});
+
+function addFilterAndAssert() {
+  filterWidget().click();
+  cy.findByPlaceholderText("Enter some text").type("Gizmo{enter}");
+  cy.button("Add filter").click();
+
+  cy.findAllByText("Gizmo");
+  cy.findAllByText("Doohickey").should("not.exist");
+}
+
+function openFilterSettings() {
+  cy.findByTestId("edit-dashboard-parameters-widget-container")
+    .find(".Icon-gear")
+    .click();
+}


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #22788 

### How to test this manually?
- `yarn test-cypress-open`
- `metabase/scenarios/dashboard-filters/reproductions/22788-flter-cc-dropped-on-second-edit.cy.spec.js`
- Unskip repro
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/170339655-fd857a6d-92f0-4cc9-8038-a7f5385bf3f3.png)

