### PR TITLE
Fix `process-query-debug` to work with pre- and post-processing middleware

### DIFF
--- a/src/metabase/query_processor.clj
+++ b/src/metabase/query_processor.clj
@@ -200,7 +200,9 @@
 ;; query -> results      = around + pre-process + compile + execute + post-process = default-middleware
 
 (def default-middleware
-  "The default set of middleware applied to queries ran via [[process-query]]."
+  "The default set of middleware applied to queries ran via [[process-query]].
+  NOTE: if you add any new middleware groups, you may need to modify [[dev.debug-qp/default-debug-middleware]] as well,
+  so that [[dev.debug-qp/process-query-debug]] still works as expected."
   (letfn [(combined-pre-process [qp]
             (fn combined-pre-process* [query rff context]
               (qp (preprocess* query) rff context)))


### PR DESCRIPTION
The QP refactor earlier this year (e.g. in #19938) changed the form of pre-processing and post-processing middleware, so that they no longer follow the normal signature for transducing middleware. Instead they are composed into `combined-pre-process` and `combined-post-process` middleware functions before query execution.

This broke the `process-query-debug` dev helper function, because it now only displays changes before and after `combined-pre-process` and `combined-post-process`, rather than after each individual component middleware.

This is my attempt to fix this. Basically in `process-query-debug`, we
* Use `alter-var-root` to replace each pre- and post-processing middleware var with an equivalent transducing middleware
* Use a `default-debug-middleware` list for debug queries which includes all pre- and post-processing middleware individually, rather than `combined-pre-process` and `combined-post-process`
* Restore the original middleware functions after the debug query is finished

**Example**
Here's an example output of `default-debug-middleware` before and after this PR for a simple nested query:
```
{:database 1
 :type     :query 
 :query    {:source-query
            {:source-table 1
             :fields       [[:field 25 nil]]
             :limit        1}}}
```

<details>
<summary>Before</summary>

```
[pre] metabase.query_processor$fn__145589$combined_pre_process__145590@2e53fa84 transformed query:
{:database 1,
 :type :query,
 :query
 {:source-query
  {:source-table (do #_"PRODUCTS" 1),
   :fields [[:field 25 #_"PRODUCTS.VENDOR" nil]],
   :limit 1},
  :source-metadata ...,
  :fields [[:field 25 #_"PRODUCTS.VENDOR" nil]],
  :limit 1048575,
  :metabase.query-processor.middleware.limit/original-limit nil}}

+
{:query
 {:source-metadata ...,
  :fields [[:field 25 #_"PRODUCTS.VENDOR" nil]],
  :limit 1048575,
  :metabase.query-processor.middleware.limit/original-limit nil}}

[pre] #'metabase.query-processor.middleware.mbql-to-native/mbql->native transformed query:
{:database 1,
 :type :query,
 :query
 {:source-query
  {:source-table (do #_"PRODUCTS" 1),
   :fields [[:field 25 #_"PRODUCTS.VENDOR" nil]],
   :limit 1},
  :source-metadata ...,
  :fields [[:field 25 #_"PRODUCTS.VENDOR" nil]],
  :limit 1048575,
  :metabase.query-processor.middleware.limit/original-limit nil},
 :native
 {:query
  "SELECT \"source\".\"VENDOR\" AS \"VENDOR\" FROM (SELECT \"PUBLIC\".\"PRODUCTS\".\"VENDOR\" AS \"VENDOR\" FROM \"PUBLIC\".\"PRODUCTS\" LIMIT 1) \"source\" LIMIT 1048575",
  :params nil}}

+
{:native
 {:query
  "SELECT \"source\".\"VENDOR\" AS \"VENDOR\" FROM (SELECT \"PUBLIC\".\"PRODUCTS\".\"VENDOR\" AS \"VENDOR\" FROM \"PUBLIC\".\"PRODUCTS\" LIMIT 1) \"source\" LIMIT 1048575",
  :params nil}}

[post] #'metabase-enterprise.advanced-permissions.query-processor.middleware.permissions/check-download-permissions transformed metadata:
{:cols ..., :download_perms :none}

+
{:download_perms :none}

[post] #'metabase.query-processor.middleware.mbql-to-native/mbql->native transformed metadata:
{:cols ...,
 :download_perms :none,
 :native_form
 {:query
  "SELECT \"source\".\"VENDOR\" AS \"VENDOR\" FROM (SELECT \"PUBLIC\".\"PRODUCTS\".\"VENDOR\" AS \"VENDOR\" FROM \"PUBLIC\".\"PRODUCTS\" LIMIT 1) \"source\" LIMIT 1048575",
  :params nil}}

+
{:native_form
 {:query
  "SELECT \"source\".\"VENDOR\" AS \"VENDOR\" FROM (SELECT \"PUBLIC\".\"PRODUCTS\".\"VENDOR\" AS \"VENDOR\" FROM \"PUBLIC\".\"PRODUCTS\" LIMIT 1) \"source\" LIMIT 1048575",
  :params nil}}

[post] metabase.query_processor$fn__145589$combined_post_process__145594@5e035125 transformed metadata:
{:cols ...,
 :download_perms :none,
 :native_form
 {:query
  "SELECT \"source\".\"VENDOR\" AS \"VENDOR\" FROM (SELECT \"PUBLIC\".\"PRODUCTS\".\"VENDOR\" AS \"VENDOR\" FROM \"PUBLIC\".\"PRODUCTS\" LIMIT 1) \"source\" LIMIT 1048575",
  :params nil},
 :results_timezone "UTC"}

+
{:cols ..., :results_timezone "UTC"}

[post] metabase.query_processor$fn__145589$combined_post_process__145594@5e035125 transformed result:
{:data
 {:cols ...,
  :download_perms :none,
  :insights nil,
  :native_form
  {:query
   "SELECT \"source\".\"VENDOR\" AS \"VENDOR\" FROM (SELECT \"PUBLIC\".\"PRODUCTS\".\"VENDOR\" AS \"VENDOR\" FROM \"PUBLIC\".\"PRODUCTS\" LIMIT 1) \"source\" LIMIT 1048575",
   :params nil},
  :results_metadata ...,
  :results_timezone "UTC"}}

+
{:data {:insights nil, :results_metadata ...}}
```

</details>

<details>
<summary>After</summary>

```

[pre] #'metabase.query-processor.middleware.add-source-metadata/add-source-metadata-for-source-queries transformed query:
{:database 1,
 :type :query,
 :query
 {:source-query
  {:source-table (do #_"PRODUCTS" 1),
   :fields [[:field 25 #_"PRODUCTS.VENDOR" nil]],
   :limit 1},
  :source-metadata ...}}

+
{:query {:source-metadata ...}}

[pre] #'metabase.query-processor.middleware.add-implicit-clauses/add-implicit-clauses transformed query:
{:database 1,
 :type :query,
 :query
 {:source-query
  {:source-table (do #_"PRODUCTS" 1),
   :fields [[:field 25 #_"PRODUCTS.VENDOR" nil]],
   :limit 1},
  :source-metadata ...,
  :fields [[:field 25 #_"PRODUCTS.VENDOR" nil]]}}

+
{:query {:fields [[:field 25 #_"PRODUCTS.VENDOR" nil]]}}

[pre] #'metabase.query-processor.middleware.limit/add-default-limit transformed query:
{:database 1,
 :type :query,
 :query
 {:source-query
  {:source-table (do #_"PRODUCTS" 1),
   :fields [[:field 25 #_"PRODUCTS.VENDOR" nil]],
   :limit 1},
  :source-metadata ...,
  :fields [[:field 25 #_"PRODUCTS.VENDOR" nil]],
  :limit 1048575,
  :metabase.query-processor.middleware.limit/original-limit nil}}

+
{:query
 {:limit 1048575,
  :metabase.query-processor.middleware.limit/original-limit nil}}

[pre] #'metabase.query-processor.middleware.mbql-to-native/mbql->native transformed query:
{:database 1,
 :type :query,
 :query
 {:source-query
  {:source-table (do #_"PRODUCTS" 1),
   :fields [[:field 25 #_"PRODUCTS.VENDOR" nil]],
   :limit 1},
  :source-metadata ...,
  :fields [[:field 25 #_"PRODUCTS.VENDOR" nil]],
  :limit 1048575,
  :metabase.query-processor.middleware.limit/original-limit nil},
 :native
 {:query
  "SELECT \"source\".\"VENDOR\" AS \"VENDOR\" FROM (SELECT \"PUBLIC\".\"PRODUCTS\".\"VENDOR\" AS \"VENDOR\" FROM \"PUBLIC\".\"PRODUCTS\" LIMIT 1) \"source\" LIMIT 1048575",
  :params nil}}

+
{:native
 {:query
  "SELECT \"source\".\"VENDOR\" AS \"VENDOR\" FROM (SELECT \"PUBLIC\".\"PRODUCTS\".\"VENDOR\" AS \"VENDOR\" FROM \"PUBLIC\".\"PRODUCTS\" LIMIT 1) \"source\" LIMIT 1048575",
  :params nil}}

[post] #'metabase-enterprise.advanced-permissions.query-processor.middleware.permissions/check-download-permissions transformed metadata:
{:cols ..., :download_perms :none}

+
{:download_perms :none}

[post] #'metabase.query-processor.middleware.mbql-to-native/mbql->native transformed metadata:
{:cols ...,
 :download_perms :none,
 :native_form
 {:query
  "SELECT \"source\".\"VENDOR\" AS \"VENDOR\" FROM (SELECT \"PUBLIC\".\"PRODUCTS\".\"VENDOR\" AS \"VENDOR\" FROM \"PUBLIC\".\"PRODUCTS\" LIMIT 1) \"source\" LIMIT 1048575",
  :params nil}}

+
{:native_form
 {:query
  "SELECT \"source\".\"VENDOR\" AS \"VENDOR\" FROM (SELECT \"PUBLIC\".\"PRODUCTS\".\"VENDOR\" AS \"VENDOR\" FROM \"PUBLIC\".\"PRODUCTS\" LIMIT 1) \"source\" LIMIT 1048575",
  :params nil}}

[post] #'metabase.query-processor.middleware.add-timezone-info/add-timezone-info transformed metadata:
{:cols ...,
 :download_perms :none,
 :native_form
 {:query
  "SELECT \"source\".\"VENDOR\" AS \"VENDOR\" FROM (SELECT \"PUBLIC\".\"PRODUCTS\".\"VENDOR\" AS \"VENDOR\" FROM \"PUBLIC\".\"PRODUCTS\" LIMIT 1) \"source\" LIMIT 1048575",
  :params nil},
 :results_timezone "UTC"}

+
{:results_timezone "UTC"}

[post] #'metabase.query-processor.middleware.annotate/add-column-info transformed metadata:
{:cols ...,
 :download_perms :none,
 :native_form
 {:query
  "SELECT \"source\".\"VENDOR\" AS \"VENDOR\" FROM (SELECT \"PUBLIC\".\"PRODUCTS\".\"VENDOR\" AS \"VENDOR\" FROM \"PUBLIC\".\"PRODUCTS\" LIMIT 1) \"source\" LIMIT 1048575",
  :params nil},
 :results_timezone "UTC"}

+
{:cols ...}

[post] #'metabase.query-processor.middleware.results-metadata/record-and-return-metadata! transformed result:
{:data
 {:cols ...,
  :download_perms :none,
  :insights nil,
  :native_form
  {:query
   "SELECT \"source\".\"VENDOR\" AS \"VENDOR\" FROM (SELECT \"PUBLIC\".\"PRODUCTS\".\"VENDOR\" AS \"VENDOR\" FROM \"PUBLIC\".\"PRODUCTS\" LIMIT 1) \"source\" LIMIT 1048575",
   :params nil},
  :results_metadata ...,
  :results_timezone "UTC"}}

+
{:data {:insights nil, :results_metadata ...}}
```

</details>