### PR TITLE
Add `parameters` to report_card

### DIFF
--- a/.github/actions/prepare-frontend/action.yml
+++ b/.github/actions/prepare-frontend/action.yml
@@ -16,6 +16,6 @@ runs:
       uses: actions/cache@v2
       with:
         path: node_modules
-        key: v2-${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
+        key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
     - run: yarn install --frozen-lockfile --prefer-offline
       shell: bash

--- a/.github/actions/prepare-frontend/action.yml
+++ b/.github/actions/prepare-frontend/action.yml
@@ -16,6 +16,6 @@ runs:
       uses: actions/cache@v2
       with:
         path: node_modules
-        key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
+        key: v2-${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
     - run: yarn install --frozen-lockfile --prefer-offline
       shell: bash

--- a/enterprise/backend/test/metabase_enterprise/serialization/cmd_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/cmd_test.clj
@@ -70,6 +70,7 @@
           :creator_id             (u/the-id user)
           :visualization_settings "{}"
           :parameters             "[]"
+          :parameter_mappings     "[]"
           :created_at             :%now
           :updated_at             :%now)
         ;; serialize "everything" (which should just be the card and user), which should succeed if #16931 is fixed

--- a/enterprise/backend/test/metabase_enterprise/serialization/cmd_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/cmd_test.clj
@@ -69,6 +69,7 @@
           :dataset_query          "{}"
           :creator_id             (u/the-id user)
           :visualization_settings "{}"
+          :parameters             "[]"
           :created_at             :%now
           :updated_at             :%now)
         ;; serialize "everything" (which should just be the card and user), which should succeed if #16931 is fixed

--- a/frontend/src/metabase/entities/questions.js
+++ b/frontend/src/metabase/entities/questions.js
@@ -80,6 +80,7 @@ const Questions = createEntity({
     "description",
     "visualization_settings",
     "parameters",
+    "parameter_mappings",
     "archived",
     "enable_embedding",
     "embedding_params",

--- a/frontend/src/metabase/entities/questions.js
+++ b/frontend/src/metabase/entities/questions.js
@@ -79,6 +79,7 @@ const Questions = createEntity({
     "display",
     "description",
     "visualization_settings",
+    "parameters",
     "archived",
     "enable_embedding",
     "embedding_params",

--- a/frontend/src/metabase/parameters/utils/cards.ts
+++ b/frontend/src/metabase/parameters/utils/cards.ts
@@ -86,12 +86,12 @@ export function getValueAndFieldIdPopulatedParametersFromCard(
   card: Card,
   metadata: Metadata,
   parameterValues: { [key: string]: any },
+  parameters = getParametersFromCard(card),
 ) {
   if (!card) {
     return [];
   }
 
-  const parameters = getParametersFromCard(card);
   const valuePopulatedParameters: (Parameter[] | ParameterWithTarget[]) & {
     value?: any;
   } = getValuePopulatedParameters(parameters, parameterValues);

--- a/frontend/src/metabase/parameters/utils/cards.ts
+++ b/frontend/src/metabase/parameters/utils/cards.ts
@@ -30,7 +30,24 @@ function getTemplateTagType(tag: TemplateTag) {
   }
 }
 
+export function getTemplateTagParameter(tag: TemplateTag): ParameterWithTarget {
+  const target: ParameterTarget =
+    tag.type === "dimension"
+      ? ["dimension", ["template-tag", tag.name]]
+      : ["variable", ["template-tag", tag.name]];
+
+  return {
+    id: tag.id,
+    type: tag["widget-type"] || getTemplateTagType(tag),
+    target,
+    name: tag["display-name"],
+    slug: tag.name,
+    default: tag.default,
+  };
+}
+
 // NOTE: this should mirror `template-tag-parameters` in src/metabase/api/embed.clj
+
 export function getTemplateTagParameters(
   tags: TemplateTag[],
 ): ParameterWithTarget[] {
@@ -39,21 +56,7 @@ export function getTemplateTagParameters(
       tag =>
         tag.type != null && (tag["widget-type"] || tag.type !== "dimension"),
     )
-    .map(tag => {
-      const target: ParameterTarget =
-        tag.type === "dimension"
-          ? ["dimension", ["template-tag", tag.name]]
-          : ["variable", ["template-tag", tag.name]];
-
-      return {
-        id: tag.id,
-        type: tag["widget-type"] || getTemplateTagType(tag),
-        target,
-        name: tag["display-name"],
-        slug: tag.name,
-        default: tag.default,
-      };
-    });
+    .map(getTemplateTagParameter);
 }
 
 export function getTemplateTagsForParameters(card: Card) {

--- a/frontend/src/metabase/parameters/utils/cards.ts
+++ b/frontend/src/metabase/parameters/utils/cards.ts
@@ -74,7 +74,7 @@ export function getTemplateTagsForParameters(card: Card) {
 export function getParametersFromCard(
   card: Card,
 ): Parameter[] | ParameterWithTarget[] {
-  if (card && card.parameters) {
+  if (card && card.parameters && card.parameters.length > 0) {
     return card.parameters;
   }
 

--- a/frontend/src/metabase/parameters/utils/cards.ts
+++ b/frontend/src/metabase/parameters/utils/cards.ts
@@ -74,7 +74,11 @@ export function getTemplateTagsForParameters(card: Card) {
 export function getParametersFromCard(
   card: Card,
 ): Parameter[] | ParameterWithTarget[] {
-  if (card && card.parameters && card.parameters.length > 0) {
+  if (!card) {
+    return [];
+  }
+
+  if (card.parameters && !_.isEmpty(card.parameters)) {
     return card.parameters;
   }
 

--- a/frontend/src/metabase/parameters/utils/dashboards.ts
+++ b/frontend/src/metabase/parameters/utils/dashboards.ts
@@ -2,6 +2,7 @@ import _ from "underscore";
 import { setIn } from "icepick";
 
 import Question from "metabase-lib/lib/Question";
+import { generateParameterId } from "metabase/parameters/utils/parameter-id";
 import { getParameterTargetField } from "metabase/parameters/utils/targets";
 import { slugify } from "metabase/lib/formatting";
 import {
@@ -59,7 +60,7 @@ export function createParameter(
   const parameter = {
     name: "",
     slug: "",
-    id: Math.floor(Math.random() * Math.pow(2, 32)).toString(16),
+    id: generateParameterId(),
     type: option.type,
     sectionId: option.sectionId,
   };

--- a/frontend/src/metabase/parameters/utils/parameter-id.js
+++ b/frontend/src/metabase/parameters/utils/parameter-id.js
@@ -1,0 +1,4 @@
+export function generateParameterId() {
+  const num = Math.floor(Math.random() * Math.pow(2, 32));
+  return num.toString(16);
+}

--- a/frontend/src/metabase/parameters/utils/parameter-id.unit.spec.js
+++ b/frontend/src/metabase/parameters/utils/parameter-id.unit.spec.js
@@ -1,0 +1,7 @@
+import { generateParameterId } from "./parameter-id";
+
+describe("parameters/utils/parameter-id", () => {
+  it("should generate a random parameter id", () => {
+    expect(generateParameterId().length).toBeGreaterThan(1);
+  });
+});

--- a/frontend/src/metabase/public/containers/PublicQuestion.jsx
+++ b/frontend/src/metabase/public/containers/PublicQuestion.jsx
@@ -15,7 +15,10 @@ import {
   getParameterValuesByIdFromQueryParams,
 } from "metabase/parameters/utils/parameter-values";
 import { applyParameters } from "metabase/meta/Card";
-import { getValueAndFieldIdPopulatedParametersFromCard } from "metabase/parameters/utils/cards";
+import {
+  getValueAndFieldIdPopulatedParametersFromCard,
+  getParametersFromCard,
+} from "metabase/parameters/utils/cards";
 
 import {
   PublicApi,
@@ -89,7 +92,7 @@ class PublicQuestion extends Component {
         card,
         metadata,
         {},
-        card.parameters || [],
+        card.parameters || undefined,
       );
       const parameterValuesById = getParameterValuesByIdFromQueryParams(
         parameters,
@@ -133,7 +136,7 @@ class PublicQuestion extends Component {
       return;
     }
 
-    const parameters = card.parameters || [];
+    const parameters = card.parameters || getParametersFromCard(card);
 
     try {
       this.setState({ result: null });
@@ -191,7 +194,7 @@ class PublicQuestion extends Component {
         card,
         metadata,
         {},
-        card.parameters || [],
+        card.parameters || undefined,
       );
 
     return (

--- a/frontend/src/metabase/public/containers/PublicQuestion.jsx
+++ b/frontend/src/metabase/public/containers/PublicQuestion.jsx
@@ -15,10 +15,7 @@ import {
   getParameterValuesByIdFromQueryParams,
 } from "metabase/parameters/utils/parameter-values";
 import { applyParameters } from "metabase/meta/Card";
-import {
-  getParametersFromCard,
-  getValueAndFieldIdPopulatedParametersFromCard,
-} from "metabase/parameters/utils/cards";
+import { getValueAndFieldIdPopulatedParametersFromCard } from "metabase/parameters/utils/cards";
 
 import {
   PublicApi,
@@ -91,6 +88,8 @@ class PublicQuestion extends Component {
       const parameters = getValueAndFieldIdPopulatedParametersFromCard(
         card,
         metadata,
+        {},
+        card.parameters || [],
       );
       const parameterValuesById = getParameterValuesByIdFromQueryParams(
         parameters,
@@ -134,7 +133,7 @@ class PublicQuestion extends Component {
       return;
     }
 
-    const parameters = getParametersFromCard(card);
+    const parameters = card.parameters || [];
 
     try {
       this.setState({ result: null });
@@ -187,7 +186,13 @@ class PublicQuestion extends Component {
     );
 
     const parameters =
-      card && getValueAndFieldIdPopulatedParametersFromCard(card, metadata);
+      card &&
+      getValueAndFieldIdPopulatedParametersFromCard(
+        card,
+        metadata,
+        {},
+        card.parameters || [],
+      );
 
     return (
       <EmbedFrame

--- a/frontend/src/metabase/query_builder/actions/native.js
+++ b/frontend/src/metabase/query_builder/actions/native.js
@@ -148,7 +148,7 @@ export const setTemplateTag = createThunkAction(
       if (parameters && Array.isArray(parameters)) {
         if (parameters.length === 0) {
           // reconstruct from the existing template tags
-          const tags = getTemplateTagsForParameters(card);
+          const tags = getTemplateTagsForParameters(updatedTagsCard);
           const newParameters = getTemplateTagParameters(tags);
           return assoc(updatedTagsCard, "parameters", newParameters);
         } else {

--- a/frontend/src/metabase/query_builder/actions/native.js
+++ b/frontend/src/metabase/query_builder/actions/native.js
@@ -1,5 +1,5 @@
 import _ from "underscore";
-import { updateIn } from "icepick";
+import { assoc, updateIn } from "icepick";
 
 import { createAction } from "redux-actions";
 
@@ -16,6 +16,11 @@ import {
 
 import { updateQuestion } from "./core";
 import { SET_UI_CONTROLS } from "./ui";
+
+import {
+  getTemplateTagsForParameters,
+  getTemplateTagParameters,
+} from "metabase/parameters/utils/cards";
 
 export const TOGGLE_DATA_REFERENCE = "metabase/qb/TOGGLE_DATA_REFERENCE";
 export const toggleDataReference = createAction(TOGGLE_DATA_REFERENCE, () => {
@@ -124,7 +129,7 @@ export const setTemplateTag = createThunkAction(
       }
 
       // we need to preserve the order of the keys to avoid UI jumps
-      return updateIn(
+      const updatedTagsCard = updateIn(
         updatedCard,
         ["dataset_query", "native", "template-tags"],
         tags => {
@@ -137,6 +142,20 @@ export const setTemplateTag = createThunkAction(
           return { ...tags, [name]: newTag };
         },
       );
+
+      const { parameters } = updatedTagsCard;
+      if (parameters && Array.isArray(parameters)) {
+        if (parameters.length === 0) {
+          // reconstruct from the existing template tags
+          const tags = getTemplateTagsForParameters(card);
+          const newParameters = getTemplateTagParameters(tags);
+          return assoc(updatedTagsCard, "parameters", newParameters);
+        } else {
+          // TODO: update an existing parameter
+        }
+      }
+
+      return updatedTagsCard;
     };
   },
 );

--- a/frontend/src/metabase/query_builder/actions/native.js
+++ b/frontend/src/metabase/query_builder/actions/native.js
@@ -20,6 +20,7 @@ import { SET_UI_CONTROLS } from "./ui";
 import {
   getTemplateTagsForParameters,
   getTemplateTagParameters,
+  getTemplateTagParameter,
 } from "metabase/parameters/utils/cards";
 
 export const TOGGLE_DATA_REFERENCE = "metabase/qb/TOGGLE_DATA_REFERENCE";
@@ -151,7 +152,13 @@ export const setTemplateTag = createThunkAction(
           const newParameters = getTemplateTagParameters(tags);
           return assoc(updatedTagsCard, "parameters", newParameters);
         } else {
-          // TODO: update an existing parameter
+          // update an existing parameter
+          const index = parameters.findIndex(p => p.id === templateTag.id);
+          if (index < 0) {
+            console.warn(`Can't find parameter with id=${templateTag.id}!`);
+          } else {
+            parameters[index] = getTemplateTagParameter(templateTag);
+          }
         }
       }
 

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -11802,7 +11802,7 @@ databaseChangeLog:
               - column:
                   name: parameters
                   type: ${text.type}
-                  remarks: List of parameter associated to to a card
+                  remarks: List of parameter associated to a card
                   constraints:
                     nullable: true
                     deferrable: false
@@ -11817,6 +11817,34 @@ databaseChangeLog:
             columnName: parameters
             defaultNullValue: '[]'
             tableName: report_card
+
+  - changeSet:
+      id: v44.00-025
+      author: qnkhuat
+      comment: Added 0.44.0 - Add parameter_mappings to report_card
+      changes:
+        - addColumn:
+            tableName: report_card
+            columns:
+              - column:
+                  name: parameter_mappings
+                  type: ${text.type}
+                  remarks: List of parameter associated to a card
+                  constraints:
+                    nullable: true
+                    deferrable: false
+                    initiallyDeferred: false
+  - changeSet:
+      id: v44.00-026
+      author: qnkhuat
+      comment: Added 0.44.0 - Add parameter_mappings to report_card
+      changes:
+        - addNotNullConstraint:
+            columnDataType: ${text.type}
+            columnName: parameter_mappings
+            defaultNullValue: '[]'
+            tableName: report_card
+
 
 
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -11794,7 +11794,7 @@ databaseChangeLog:
   - changeSet:
       id: v44.00-023
       author: qnkhuat
-      comment: Added 0.44.0 - Add parameter to report_card
+      comment: Added 0.44.0 - Add parameters to report_card
       changes:
         - addColumn:
             tableName: report_card
@@ -11810,7 +11810,7 @@ databaseChangeLog:
   - changeSet:
       id: v44.00-024
       author: qnkhuat
-      comment: Added 0.44.0 - Add parameter to report_card
+      comment: Added 0.44.0 - Add parameters to report_card
       changes:
         - addNotNullConstraint:
             columnDataType: ${text.type}

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -11791,6 +11791,31 @@ databaseChangeLog:
                   nullable: true
                   unique: true
             tableName: report_dashboardcard
+  - changeSet:
+      id: v44.00-023
+      author: qnkhuat
+      comment: Added 0.44.0 - Add parameter to report_card
+      changes:
+        - addColumn:
+            tableName: report_card
+            columns:
+              - column:
+                  name: parameters
+                  type: ${text.type}
+                  remarks: List of parameter associated to to a card
+                  constraints:
+                    nullable: false
+  - changeSet:
+      id: v44.00-024
+      author: qnkhuat
+      comment: Added 0.44.0 - Add parameter to report_card
+      changes:
+        - addNotNullConstraint:
+            columnDataType: ${text.type}
+            columnName: parameters
+            defaultNullValue: '[]'
+            tableName: report_card
+
 
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -11807,7 +11807,6 @@ databaseChangeLog:
                     nullable: true
                     deferrable: false
                     initiallyDeferred: false
-
   - changeSet:
       id: v44.00-024
       author: qnkhuat

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -11804,7 +11804,10 @@ databaseChangeLog:
                   type: ${text.type}
                   remarks: List of parameter associated to to a card
                   constraints:
-                    nullable: false
+                    nullable: true
+                    deferrable: false
+                    initiallyDeferred: false
+
   - changeSet:
       id: v44.00-024
       author: qnkhuat

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -270,15 +270,16 @@
 (defn- create-card-async!
   "Create a new Card asynchronously. Returns a channel for fetching the newly created Card, or an Exception if one was
   thrown. Closing this channel before it finishes will cancel the Card creation."
-  [{:keys [dataset_query result_metadata dataset parameters], :as card-data}]
+  [{:keys [dataset_query result_metadata dataset parameters parameter_mappings], :as card-data}]
   ;; `zipmap` instead of `select-keys` because we want to get `nil` values for keys that aren't present. Required by
   ;; `api/maybe-reconcile-collection-position!`
   (let [data-keys            [:dataset_query :description :display :name :visualization_settings
-                              :parameters :collection_id :collection_position :cache_ttl]
+                              :parameters :parameter_mappings :collection_id :collection_position :cache_ttl]
         card-data            (assoc (zipmap data-keys (map card-data data-keys))
                                     :creator_id api/*current-user-id*
                                     :dataset (boolean (:dataset card-data))
-                                    :parameters (or parameters []))
+                                    :parameters (or parameters [])
+                                    :parameter_mappings (or parameter_mappings []))
         result-metadata-chan (result-metadata-async {:query dataset_query
                                                      :metadata result_metadata
                                                      :dataset? dataset})
@@ -299,9 +300,10 @@
 (api/defendpoint ^:returns-chan POST "/"
   "Create a new `Card`."
   [:as {{:keys [collection_id collection_position dataset_query description display name
-                parameters result_metadata visualization_settings cache_ttl], :as body} :body}]
+                parameters parameter_mappings result_metadata visualization_settings cache_ttl], :as body} :body}]
   {name                   su/NonBlankString
    parameters             (s/maybe [su/Parameter])
+   parameter_mappings     (s/maybe [su/ParameterMapping])
    description            (s/maybe su/NonBlankString)
    display                su/NonBlankString
    visualization_settings su/Map
@@ -504,7 +506,7 @@
         (u/select-keys-when card-updates
           :present #{:collection_id :collection_position :description :cache_ttl :dataset}
           :non-nil #{:dataset_query :display :name :visualization_settings :archived :enable_embedding
-                     :parameters :embedding_params :result_metadata})))
+                     :parameters :parameter_mappings :embedding_params :result_metadata})))
     ;; Fetch the updated Card from the DB
     (let [card (Card id)]
       (delete-alerts-if-needed! card-before-update card)

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -270,14 +270,15 @@
 (defn- create-card-async!
   "Create a new Card asynchronously. Returns a channel for fetching the newly created Card, or an Exception if one was
   thrown. Closing this channel before it finishes will cancel the Card creation."
-  [{:keys [dataset_query result_metadata dataset], :as card-data}]
+  [{:keys [dataset_query result_metadata dataset parameters], :as card-data}]
   ;; `zipmap` instead of `select-keys` because we want to get `nil` values for keys that aren't present. Required by
   ;; `api/maybe-reconcile-collection-position!`
-  (let [data-keys            [:dataset_query :description :display :name
-                              :visualization_settings :collection_id :collection_position :cache_ttl]
+  (let [data-keys            [:dataset_query :description :display :name :visualization_settings
+                              :parameters :collection_id :collection_position :cache_ttl]
         card-data            (assoc (zipmap data-keys (map card-data data-keys))
                                     :creator_id api/*current-user-id*
-                                    :dataset (boolean (:dataset card-data)))
+                                    :dataset (boolean (:dataset card-data))
+                                    :parameters (or parameters []))
         result-metadata-chan (result-metadata-async {:query dataset_query
                                                      :metadata result_metadata
                                                      :dataset? dataset})
@@ -298,8 +299,9 @@
 (api/defendpoint ^:returns-chan POST "/"
   "Create a new `Card`."
   [:as {{:keys [collection_id collection_position dataset_query description display name
-                result_metadata visualization_settings cache_ttl], :as body} :body}]
+                parameters result_metadata visualization_settings cache_ttl], :as body} :body}]
   {name                   su/NonBlankString
+   parameters             (s/maybe [su/Parameter])
    description            (s/maybe su/NonBlankString)
    display                su/NonBlankString
    visualization_settings su/Map
@@ -502,7 +504,7 @@
         (u/select-keys-when card-updates
           :present #{:collection_id :collection_position :description :cache_ttl :dataset}
           :non-nil #{:dataset_query :display :name :visualization_settings :archived :enable_embedding
-                     :embedding_params :result_metadata})))
+                     :parameters :embedding_params :result_metadata})))
     ;; Fetch the updated Card from the DB
     (let [card (Card id)]
       (delete-alerts-if-needed! card-before-update card)
@@ -521,10 +523,11 @@
 (api/defendpoint ^:returns-chan PUT "/:id"
   "Update a `Card`."
   [id :as {{:keys [dataset_query description display name visualization_settings archived collection_id
-                   collection_position enable_embedding embedding_params result_metadata
+                   collection_position enable_embedding embedding_params result_metadata parameters
                    cache_ttl dataset]
             :as   card-updates} :body}]
   {name                   (s/maybe su/NonBlankString)
+   parameters             (s/maybe [su/Parameter])
    dataset_query          (s/maybe su/Map)
    dataset                (s/maybe s/Bool)
    display                (s/maybe su/NonBlankString)

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -69,7 +69,7 @@
   "Create a new Dashboard."
   [:as {{:keys [name description parameters cache_ttl collection_id collection_position], :as _dashboard} :body}]
   {name                su/NonBlankString
-   parameters          [su/Map]
+   parameters          (s/maybe [su/Parameter])
    description         (s/maybe s/Str)
    cache_ttl           (s/maybe su/IntGreaterThanZero)
    collection_id       (s/maybe su/IntGreaterThanZero)
@@ -275,7 +275,7 @@
    show_in_getting_started (s/maybe s/Bool)
    enable_embedding        (s/maybe s/Bool)
    embedding_params        (s/maybe su/EmbeddingParams)
-   parameters              (s/maybe [su/Map])
+   parameters              (s/maybe [su/Parameter])
    position                (s/maybe su/IntGreaterThanZero)
    archived                (s/maybe s/Bool)
    collection_id           (s/maybe su/IntGreaterThanZero)

--- a/src/metabase/api/embed.clj
+++ b/src/metabase/api/embed.clj
@@ -151,7 +151,6 @@
 (defn- add-implicit-card-parameters
   "Add template tag parameter information to `card`'s `:parameters`."
   [card]
-  (def card card)
   (update card :parameters concat (template-tag-parameters card)))
 
 (s/defn ^:private apply-slug->value :- (s/maybe [{:slug   su/NonBlankString

--- a/src/metabase/api/embed.clj
+++ b/src/metabase/api/embed.clj
@@ -151,6 +151,7 @@
 (defn- add-implicit-card-parameters
   "Add template tag parameter information to `card`'s `:parameters`."
   [card]
+  (def card card)
   (update card :parameters concat (template-tag-parameters card)))
 
 (s/defn ^:private apply-slug->value :- (s/maybe [{:slug   su/NonBlankString

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -210,11 +210,14 @@
 
 ;; TODO -- consider whether we should validate the Card query when you save/update it??
 (defn- pre-insert [card]
-  (u/prog1 card
-    ;; make sure this Card doesn't have circular source query references
-    (check-for-circular-source-query-references card)
-    (check-field-filter-fields-are-from-correct-database card)
-    (collection/check-collection-namespace Card (:collection_id card))))
+  (let [defaults {:parameters []}
+        card     (merge defaults card)]
+   (u/prog1 card
+     ;; make sure this Card doesn't have circular source query references
+     (check-for-circular-source-query-references card)
+     (check-field-filter-fields-are-from-correct-database card)
+     (params/assert-valid-parameters card)
+     (collection/check-collection-namespace Card (:collection_id card)))))
 
 (defn- post-insert [card]
   ;; if this Card has any native template tag parameters we need to update FieldValues for any Fields that are
@@ -231,7 +234,8 @@
   For the OSS edition, there is no implementation for this function -- it is a no-op. For Metabase Enterprise Edition,
   the implementation of this function is
   [[metabase-enterprise.sandbox.models.group-table-access-policy/update-card-check-gtaps]] and is installed by that
-  namespace."} pre-update-check-sandbox-constraints
+  namespace."}
+  pre-update-check-sandbox-constraints
   (atom identity))
 
 (defn- pre-update [{archived? :archived, id :id, :as changes}]
@@ -261,6 +265,7 @@
     (check-field-filter-fields-are-from-correct-database changes)
     ;; Make sure the Collection is in the default Collection namespace (e.g. as opposed to the Snippets Collection namespace)
     (collection/check-collection-namespace Card (:collection_id changes))
+    (params/assert-valid-parameters changes)
     ;; additional checks (Enterprise Edition only)
     (@pre-update-check-sandbox-constraints changes)))
 
@@ -289,7 +294,8 @@
                                        :embedding_params       :json
                                        :query_type             :keyword
                                        :result_metadata        ::result-metadata
-                                       :visualization_settings :visualization-settings})
+                                       :visualization_settings :visualization-settings
+                                       :parameters             :parameters-list})
           :properties     (constantly {:timestamped? true
                                        :entity_id    true})
           ;; Make sure we normalize the query before calling `pre-update` or `pre-insert` because some of the

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -210,13 +210,16 @@
 
 ;; TODO -- consider whether we should validate the Card query when you save/update it??
 (defn- pre-insert [card]
-  (let [defaults {:parameters []}
+  (let [defaults {:parameters         []
+                  :parameter_mappings []}
         card     (merge defaults card)]
    (u/prog1 card
      ;; make sure this Card doesn't have circular source query references
      (check-for-circular-source-query-references card)
      (check-field-filter-fields-are-from-correct-database card)
+     ;; TODO: add a check to see if all id in :parameter_mappings are in :parameters
      (params/assert-valid-parameters card)
+     (params/assert-valid-parameter-mappings card)
      (collection/check-collection-namespace Card (:collection_id card)))))
 
 (defn- post-insert [card]
@@ -266,6 +269,7 @@
     ;; Make sure the Collection is in the default Collection namespace (e.g. as opposed to the Snippets Collection namespace)
     (collection/check-collection-namespace Card (:collection_id changes))
     (params/assert-valid-parameters changes)
+    (params/assert-valid-parameter-mappings changes)
     ;; additional checks (Enterprise Edition only)
     (@pre-update-check-sandbox-constraints changes)))
 
@@ -295,7 +299,8 @@
                                        :query_type             :keyword
                                        :result_metadata        ::result-metadata
                                        :visualization_settings :visualization-settings
-                                       :parameters             :parameters-list})
+                                       :parameters             :parameters-list
+                                       :parameter_mappings     :parameters-list})
           :properties     (constantly {:timestamped? true
                                        :entity_id    true})
           ;; Make sure we normalize the query before calling `pre-update` or `pre-insert` because some of the

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -64,11 +64,6 @@
 (models/defmodel Dashboard :report_dashboard)
 ;;; ----------------------------------------------- Entity & Lifecycle -----------------------------------------------
 
-(defn- assert-valid-parameters [{:keys [parameters]}]
-  (when (s/check (s/maybe [{:id su/NonBlankString, s/Keyword s/Any}]) parameters)
-    (throw (ex-info (tru ":parameters must be a sequence of maps with String :id keys")
-                    {:parameters parameters}))))
-
 (defn- pre-delete [dashboard]
   (db/delete! 'Revision :model "Dashboard" :model_id (u/the-id dashboard)))
 
@@ -76,12 +71,12 @@
   (let [defaults  {:parameters []}
         dashboard (merge defaults dashboard)]
     (u/prog1 dashboard
-      (assert-valid-parameters dashboard)
+      (params/assert-valid-parameters dashboard)
       (collection/check-collection-namespace Dashboard (:collection_id dashboard)))))
 
 (defn- pre-update [dashboard]
   (u/prog1 dashboard
-    (assert-valid-parameters dashboard)
+    (params/assert-valid-parameters dashboard)
     (collection/check-collection-namespace Dashboard (:collection_id dashboard))))
 
 (defn- update-dashboard-subscription-pulses!

--- a/src/metabase/models/params.clj
+++ b/src/metabase/models/params.clj
@@ -21,7 +21,7 @@
   "Receive a Paremeterized Object and check if its parameters is valid."
   [{:keys [parameters]}]
   (when (s/check (s/maybe [su/Parameter]) parameters)
-    (throw (ex-info (tru ":parameters must be a sequence of maps with String :id keys")
+    (throw (ex-info (tru ":parameters must be a sequence of maps with String :id key")
                     {:parameters parameters}))))
 
 (s/defn unwrap-field-clause :- mbql.s/field

--- a/src/metabase/models/params.clj
+++ b/src/metabase/models/params.clj
@@ -17,6 +17,13 @@
 ;;; |                                                     SHARED                                                     |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
+(defn assert-valid-parameters
+  "Receive a Paremeterized Object and check if its parameters is valid."
+  [{:keys [parameters]}]
+  (when (s/check (s/maybe [su/Parameter]) parameters)
+    (throw (ex-info (tru ":parameters must be a sequence of maps with String :id keys")
+                    {:parameters parameters}))))
+
 (s/defn unwrap-field-clause :- mbql.s/field
   "Unwrap something that contains a `:field` clause, such as a template tag, Also handles unwrapped integers for
   legacy compatibility.

--- a/src/metabase/models/params.clj
+++ b/src/metabase/models/params.clj
@@ -24,6 +24,13 @@
     (throw (ex-info (tru ":parameters must be a sequence of maps with String :id key")
                     {:parameters parameters}))))
 
+(defn assert-valid-parameter-mappings
+  "Receive a Paremeterized Object and check if its parameters is valid."
+  [{:keys [parameter_mappings]}]
+  (when (s/check (s/maybe [su/ParameterMapping]) parameter_mappings)
+    (throw (ex-info (tru ":parameter_mappings must be a sequence of maps with String :parameter_id key")
+                    {:parameter_mappings parameter_mappings}))))
+
 (s/defn unwrap-field-clause :- mbql.s/field
   "Unwrap something that contains a `:field` clause, such as a template tag, Also handles unwrapped integers for
   legacy compatibility.

--- a/src/metabase/util/schema.clj
+++ b/src/metabase/util/schema.clj
@@ -331,7 +331,7 @@
   "Schema for a valid Parameter."
   (with-api-error-message {:id       NonBlankString
                            s/Keyword s/Any}
-    (deferred-tru "parameter must be a map with String :id keys")))
+    (deferred-tru "parameter must be a map with String :id key")))
 
 (def EmbeddingParams
   "Schema for a valid map of embedding params."

--- a/src/metabase/util/schema.clj
+++ b/src/metabase/util/schema.clj
@@ -327,6 +327,12 @@
                                                     false)))
     (deferred-tru "value must be a valid JSON string.")))
 
+(def Parameter
+  "Schema for a valid Parameter."
+  (with-api-error-message {:id       NonBlankString
+                           s/Keyword s/Any}
+    (deferred-tru ":parameters must be a sequence of maps with String :id keys")))
+
 (def EmbeddingParams
   "Schema for a valid map of embedding params."
   (with-api-error-message (s/maybe {s/Keyword (s/enum "disabled" "enabled" "locked")})

--- a/src/metabase/util/schema.clj
+++ b/src/metabase/util/schema.clj
@@ -333,6 +333,12 @@
                            s/Keyword s/Any}
     (deferred-tru "parameter must be a map with String :id key")))
 
+(def ParameterMapping
+  "Schema for a valid Parameter Mapping"
+  (with-api-error-message {:parameter_id       NonBlankString
+                           s/Keyword s/Any}
+    (deferred-tru "parameter mapping must be a String :parameter_id key")))
+
 (def EmbeddingParams
   "Schema for a valid map of embedding params."
   (with-api-error-message (s/maybe {s/Keyword (s/enum "disabled" "enabled" "locked")})

--- a/src/metabase/util/schema.clj
+++ b/src/metabase/util/schema.clj
@@ -331,7 +331,7 @@
   "Schema for a valid Parameter."
   (with-api-error-message {:id       NonBlankString
                            s/Keyword s/Any}
-    (deferred-tru ":parameters must be a sequence of maps with String :id keys")))
+    (deferred-tru "parameter must be a map with String :id keys")))
 
 (def EmbeddingParams
   "Schema for a valid map of embedding params."

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -301,16 +301,6 @@
 ;;; |                                        CREATING A CARD (POST /api/card)                                        |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-(deftest create-card-validation-test
-  (testing "POST /api/card"
-   (is (= {:errors {:visualization_settings "value must be a map."}}
-          (mt/user-http-request :crowberto :post 400 "card" {:visualization_settings "ABC"})))
-
-   (is (= {:errors {:parameters (str "value may be nil, or if non-nil, value must be an array. "
-                                     "Each parameter must be a map with String :id key")}}
-          (mt/user-http-request :crowberto :post 400 "card" {:visualization_settings {:global {:title nil}}
-                                                             :parameters             "abc"})))))
-
 (deftest create-a-card
   (testing "POST /api/card"
     (testing "Test that we can create a new Card"
@@ -365,6 +355,16 @@
                                                    (-> edit-info
                                                        (update :id boolean)
                                                        (update :timestamp boolean))))))))))))))
+
+(deftest create-card-validation-test
+  (testing "POST /api/card"
+   (is (= {:errors {:visualization_settings "value must be a map."}}
+          (mt/user-http-request :crowberto :post 400 "card" {:visualization_settings "ABC"})))
+
+   (is (= {:errors {:parameters (str "value may be nil, or if non-nil, value must be an array. "
+                                     "Each parameter must be a map with String :id key")}}
+          (mt/user-http-request :crowberto :post 400 "card" {:visualization_settings {:global {:title nil}}
+                                                             :parameters             "abc"})))))
 
 (deftest save-empty-card-test
   (testing "POST /api/card"
@@ -793,7 +793,7 @@
                                      :type "number"}]}
                       (mt/user-http-request :rasta :put 202 (str "card/" (u/the-id card))
                                             {:parameters nil}))))
-      (testing "a non empty list will remove parameters"
+      (testing "an empty list will remove parameters"
         (is (partial= {:parameters []}
                       (mt/user-http-request :rasta :put 202 (str "card/" (u/the-id card))
                                             {:parameters []})))))))

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -306,7 +306,7 @@
           (mt/user-http-request :crowberto :post 400 "card" {:visualization_settings "ABC"})))
 
    (is (= {:errors {:parameters (str "value may be nil, or if non-nil, value must be an array. "
-                                     "Each :parameters must be a sequence of maps with String :id keys")}}
+                                     "Each parameter must be a map with String :id keys")}}
           (mt/user-http-request :crowberto :post 400 "card" {:visualization_settings {:global {:title nil}}
                                                              :parameters             "abc"})))))
 

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -56,6 +56,7 @@
    :embedding_params    nil
    :made_public_by_id   nil
    :parameters          []
+   :parameter_mappings  []
    :moderation_reviews  ()
    :public_uuid         nil
    :query_type          nil
@@ -319,8 +320,10 @@
           (mt/with-model-cleanup [Card]
             (let [card (assoc (card-with-name-and-query (mt/random-name)
                                                         (mbql-count-query (mt/id) (mt/id :venues)))
-                              :collection_id (u/the-id collection)
-                              :parameters    [{:id "abc123", :name "test", :type "date"}])]
+                              :collection_id      (u/the-id collection)
+                              :parameters         [{:id "abc123", :name "test", :type "date"}]
+                              :parameter_mappings [{:parameter_id "abc123", :card_id "10",
+                                                    :target [:dimension [:template-tags "category"]]}])]
               (is (= (merge
                       card-defaults
                       {:name                   (:name card)
@@ -328,6 +331,8 @@
                        :collection             true
                        :creator_id             (mt/user->id :rasta)
                        :parameters             [{:id "abc123", :name "test", :type "date"}]
+                       :parameter_mappings     [{:parameter_id "abc123", :card_id "10",
+                                                 :target ["dimension" ["template-tags" "category"]]}]
                        :dataset_query          true
                        :query_type             "query"
                        :visualization_settings {:global {:title nil}}
@@ -792,6 +797,28 @@
         (is (partial= {:parameters []}
                       (mt/user-http-request :rasta :put 202 (str "card/" (u/the-id card))
                                             {:parameters []})))))))
+
+(deftest update-card-parameter-mappings-test
+  (testing "PUT /api/card/:id"
+    (mt/with-temp Card [card]
+      (testing "successfully update with valid parameter_mappings"
+        (is (partial= {:parameter_mappings [{:parameter_id "abc123", :card_id "10",
+                                             :target ["dimension" ["template-tags" "category"]]}]}
+                      (mt/user-http-request :rasta :put 202 (str "card/" (u/the-id card))
+                                            {:parameter_mappings [{:parameter_id "abc123", :card_id "10",
+                                                                   :target ["dimension" ["template-tags" "category"]]}]})))))
+
+    (mt/with-temp Card [card {:parameter_mappings [{:parameter_id "abc123", :card_id "10",
+                                                    :target ["dimension" ["template-tags" "category"]]}]}]
+      (testing "nil parameters will no-op"
+        (is (partial= {:parameter_mappings [{:parameter_id "abc123", :card_id "10",
+                                             :target ["dimension" ["template-tags" "category"]]}]}
+                      (mt/user-http-request :rasta :put 202 (str "card/" (u/the-id card))
+                                            {:parameters nil}))))
+      (testing "an empty list will remove parameter_mappings"
+        (is (partial= {:parameter_mappings []}
+                      (mt/user-http-request :rasta :put 202 (str "card/" (u/the-id card))
+                                            {:parameter_mappings []})))))))
 
 (deftest update-embedding-params-test
   (testing "PUT /api/card/:id"

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -306,7 +306,7 @@
           (mt/user-http-request :crowberto :post 400 "card" {:visualization_settings "ABC"})))
 
    (is (= {:errors {:parameters (str "value may be nil, or if non-nil, value must be an array. "
-                                     "Each parameter must be a map with String :id keys")}}
+                                     "Each parameter must be a map with String :id key")}}
           (mt/user-http-request :crowberto :post 400 "card" {:visualization_settings {:global {:title nil}}
                                                              :parameters             "abc"})))))
 
@@ -774,7 +774,7 @@
 (deftest update-card-parameters-test
   (testing "PUT /api/card/:id"
     (mt/with-temp Card [card]
-      (testing "successfully update with valid parameter"
+      (testing "successfully update with valid parameters"
         (is (partial= {:parameters [{:id   "random-id"
                                      :type "number"}]}
                       (mt/user-http-request :rasta :put 202 (str "card/" (u/the-id card))

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -114,7 +114,7 @@
            (mt/user-http-request :rasta :post 400 "dashboard" {})))
 
     (is (= {:errors {:parameters (str "value may be nil, or if non-nil, value must be an array. "
-                                      "Each :parameters must be a sequence of maps with String :id keys")}}
+                                      "Each parameter must be a map with String :id keys")}}
            (mt/user-http-request :crowberto :post 400 "dashboard" {:name       "Test"
                                                                    :parameters "abc"})))))
 

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -114,7 +114,7 @@
            (mt/user-http-request :rasta :post 400 "dashboard" {})))
 
     (is (= {:errors {:parameters (str "value may be nil, or if non-nil, value must be an array. "
-                                      "Each parameter must be a map with String :id keys")}}
+                                      "Each parameter must be a map with String :id key")}}
            (mt/user-http-request :crowberto :post 400 "dashboard" {:name       "Test"
                                                                    :parameters "abc"})))))
 

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -113,7 +113,8 @@
     (is (= {:errors {:name "value must be a non-blank string."}}
            (mt/user-http-request :rasta :post 400 "dashboard" {})))
 
-    (is (= {:errors {:parameters "value must be an array. Each value must be a map."}}
+    (is (= {:errors {:parameters (str "value may be nil, or if non-nil, value must be an array. "
+                                      "Each :parameters must be a sequence of maps with String :id keys")}}
            (mt/user-http-request :crowberto :post 400 "dashboard" {:name       "Test"
                                                                    :parameters "abc"})))))
 

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -598,3 +598,28 @@
                                              :collection_id          nil})]
        (migrate!)
        (is (= [] (:parameters (first (db/simple-select Card {:where [:= :id card-id]})))))))))
+
+(deftest add-parameter-mappings-to-cards-test
+  (testing "Migration v44.00-024: Add parameter_mappings to cards"
+    (impl/test-migrations ["v44.00-024" "v44.00-026"] [migrate!]
+      (let [user-id
+            (db/simple-insert! User {:first_name  "Howard"
+                                     :last_name   "Hughes"
+                                     :email       "howard@aircraft.com"
+                                     :password    "superstrong"
+                                     :date_joined :%now})
+            database-id
+            (db/simple-insert! Database {:name "DB", :engine "h2", :created_at :%now, :updated_at :%now})
+            card-id
+            (db/simple-insert! Card {:name                   "My Saved Question"
+                                     :created_at             :%now
+                                     :updated_at             :%now
+                                     :creator_id             user-id
+                                     :display                "table"
+                                     :dataset_query          "{}"
+                                     :visualization_settings "{}"
+                                     :database_id            database-id
+                                     :collection_id          nil})]
+        (migrate!)
+        (is (= []
+               (:parameter_mappings (first (db/simple-select Card {:where [:= :id card-id]})))))))))

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -582,10 +582,10 @@
     (impl/test-migrations ["v44.00-022" "v44.00-024"] [migrate!]
       (let [user-id
             (db/simple-insert! User {:first_name  "Howard"
-                                            :last_name   "Hughes"
-                                            :email       "howard@aircraft.com"
-                                            :password    "superstrong"
-                                            :date_joined :%now})
+                                     :last_name   "Hughes"
+                                     :email       "howard@aircraft.com"
+                                     :password    "superstrong"
+                                     :date_joined :%now})
             database-id (db/simple-insert! Database {:name "DB", :engine "h2", :created_at :%now, :updated_at :%now})
             card-id (db/simple-insert! Card {:name                   "My Saved Question"
                                              :created_at             :%now

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -578,7 +578,7 @@
 
 
 (deftest add-parameter-to-cards-test
-  (testing "Migration v43.00-057: Rename general permissions to application permissions"
+  (testing "Migration v44.00-022: Add parameters to report_card"
     (impl/test-migrations ["v44.00-022" "v44.00-024"] [migrate!]
       (let [user-id
             (db/simple-insert! User {:first_name  "Howard"

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -576,7 +576,6 @@
         (migrate!)
         (is (= #{"All Users"} (get-perms "/application/subscription/")))))))
 
-
 (deftest add-parameter-to-cards-test
   (testing "Migration v44.00-022: Add parameters to report_card"
     (impl/test-migrations ["v44.00-022" "v44.00-024"] [migrate!]

--- a/test/metabase/events/revision_test.clj
+++ b/test/metabase/events/revision_test.clj
@@ -33,6 +33,7 @@
    :made_public_by_id      nil
    :name                   (:name card)
    :parameters             []
+   :parameter_mappings     []
    :public_uuid            nil
    :cache_ttl              nil
    :query_type             :query

--- a/test/metabase/events/revision_test.clj
+++ b/test/metabase/events/revision_test.clj
@@ -32,6 +32,7 @@
    :id                     (u/the-id card)
    :made_public_by_id      nil
    :name                   (:name card)
+   :parameters             []
    :public_uuid            nil
    :cache_ttl              nil
    :query_type             :query

--- a/test/metabase/models/card_test.clj
+++ b/test/metabase/models/card_test.clj
@@ -300,7 +300,7 @@
     (testing "creating"
       (is (thrown-with-msg?
            clojure.lang.ExceptionInfo
-           #":parameters must be a sequence of maps with String :id keys"
+           #":parameters must be a sequence of maps with String :id key"
            (mt/with-temp Card [_ {:parameters {:a :b}}])))
 
      (mt/with-temp Card [card {:parameters [{:id "valid-id"}]}]
@@ -310,7 +310,7 @@
       (mt/with-temp Card [{:keys [id]} {:parameters []}]
         (is (thrown-with-msg?
              clojure.lang.ExceptionInfo
-             #":parameters must be a sequence of maps with String :id keys"
+             #":parameters must be a sequence of maps with String :id key"
              (db/update! Card id :parameters [{:id 100}])))
 
         (is (some? (db/update! Card id :parameters [{:id "new-valid-id"}])))))))

--- a/test/metabase/models/dashboard_test.clj
+++ b/test/metabase/models/dashboard_test.clj
@@ -282,13 +282,13 @@
     (testing "creating"
       (is (thrown-with-msg?
            clojure.lang.ExceptionInfo
-           #":parameters must be a sequence of maps with String :id keys"
+           #":parameters must be a sequence of maps with String :id key"
            (mt/with-temp Dashboard [_ {:parameters {:a :b}}]))))
     (testing "updating"
       (mt/with-temp Dashboard [{:keys [id]} {:parameters []}]
         (is (thrown-with-msg?
              clojure.lang.ExceptionInfo
-             #":parameters must be a sequence of maps with String :id keys"
+             #":parameters must be a sequence of maps with String :id key"
              (db/update! Dashboard id :parameters [{:id 100}])))))))
 
 (deftest normalize-parameters-test


### PR DESCRIPTION
As part of the attempt to parameterize Cards, this PR adds `parameters` column to `report_card` and changes APIs so we could add/update/delete it.

With this:
- `POST /api/card` and `PUT /api/card/:id` will accept a new `parameters` param
- Any APIs that return a card now will have a new `parameters` keys

Closes https://github.com/metabase/metabase/issues/22969