### PR TITLE
silence diemsionOptions warnings 🤫

### DIFF
--- a/frontend/src/metabase-lib/lib/DimensionOptions/index.ts
+++ b/frontend/src/metabase-lib/lib/DimensionOptions/index.ts
@@ -1,1 +1,3 @@
-export { default } from "./DimensionOptions";
+import DimensionOptions from "./DimensionOptions";
+
+export default DimensionOptions;


### PR DESCRIPTION
Webpack was constantly throwing warnings for no default export.

![Screen Shot 2022-05-26 at 10 49 22 AM](https://user-images.githubusercontent.com/30528226/170535710-bb9a389d-156a-4543-8603-b3f8c2dbbf48.png)


Not 100% sure this is the pattern we want, but would be nice to get rid of that noise.