### PR TITLE
Prototype of object view for data apps

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard.jsx
@@ -226,6 +226,7 @@ export default class DashCard extends Component {
           headerIcon={headerIcon}
           errorIcon={errorIcon}
           isSlow={isSlow}
+          isDataApp={this.props.isDataApp}
           expectedDuration={expectedDuration}
           rawSeries={series}
           showTitle

--- a/frontend/src/metabase/dashboard/components/DashCard.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard.jsx
@@ -229,7 +229,7 @@ export default class DashCard extends Component {
           isDataApp={this.props.isDataApp}
           expectedDuration={expectedDuration}
           rawSeries={series}
-          showTitle
+          showTitle={!this.props.isDataApp}
           isFullscreen={isFullscreen}
           isDashboard
           dispatch={this.props.dispatch}

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
@@ -38,6 +38,7 @@ class Dashboard extends Component {
     loadDashboardParams: PropTypes.func,
     location: PropTypes.object,
 
+    isDataApp: PropTypes.bool,
     isFullscreen: PropTypes.bool,
     isNightMode: PropTypes.bool,
     isSharing: PropTypes.bool,
@@ -314,6 +315,7 @@ class Dashboard extends Component {
                     <DashboardGrid
                       {...this.props}
                       onEditingChange={this.setEditing}
+                      isDataApp={this.props.isDataApp}
                     />
                   ) : (
                     <DashboardEmptyState

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
@@ -280,6 +280,7 @@ class DashboardGrid extends Component {
         isEditingParameter={this.props.isEditingParameter}
         isFullscreen={this.props.isFullscreen}
         isMobile={isMobile}
+        isDataApp={this.props.isDataApp}
         onRemove={this.onDashCardRemove.bind(this, dc)}
         onAddSeries={this.onDashCardAddSeries.bind(this, dc)}
         onUpdateVisualizationSettings={this.props.onUpdateDashCardVisualizationSettings.bind(

--- a/frontend/src/metabase/dashboard/containers/DashboardApp.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp.jsx
@@ -149,12 +149,15 @@ const DashboardApp = props => {
     setIsShowingToaster(false);
   }, []);
 
+  const isDataApp = dashboard?.name.endsWith(" App");
+
   return (
     <div className="shrink-below-content-size full-height">
       <Dashboard
         editingOnLoad={editingOnLoad}
         addCardOnLoad={addCardOnLoad}
         {...props}
+        isDataApp={isDataApp}
       />
       {/* For rendering modal urls */}
       {props.children}

--- a/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx
@@ -17,7 +17,7 @@ import {
 const FIXED_LAYOUT = [
   ["line", "bar", "combo", "area", "row", "waterfall"],
   ["scatter", "pie", "funnel", "smartscalar", "progress", "gauge"],
-  ["scalar", "table", "pivot", "map"],
+  ["scalar", "table", "pivot", "map", "object"],
 ];
 const FIXED_TYPES = new Set(_.flatten(FIXED_LAYOUT));
 

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.styled.tsx
@@ -8,9 +8,8 @@ interface ObjectDetailModalProps {
 }
 
 export const ObjectDetailModal = styled.div<ObjectDetailModalProps>`
-  border: 1px solid ${color("border")};
-  border-radius: 0.5rem;
   overflow-y: scroll;
+  height: 100%;
 `;
 
 export const ObjectDetailBodyWrapper = styled.div`
@@ -80,6 +79,9 @@ export const RootModal = styled(Modal)`
     }
     max-height: 95vh;
     width: 95vw;
+
+    border: 1px solid ${color("border")};
+    border-radius: 0.5rem;
   }
 
   ${ObjectDetailBodyWrapper} {

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.styled.tsx
@@ -1,4 +1,5 @@
 import styled from "@emotion/styled";
+import Modal from "metabase/components/Modal";
 import { breakpointMinMedium } from "metabase/styled-components/theme/media-queries";
 import { color } from "metabase/lib/colors";
 
@@ -9,23 +10,12 @@ interface ObjectDetailModalProps {
 export const ObjectDetailModal = styled.div<ObjectDetailModalProps>`
   border: 1px solid ${color("border")};
   border-radius: 0.5rem;
-  overflow: hidden;
-  ${breakpointMinMedium} {
-    width: ${({ wide }) => (wide ? "64rem" : "48rem")};
-    max-width: 95vw;
-  }
-  max-height: 95vh;
-  width: 95vw;
+  overflow-y: scroll;
 `;
 
 export const ObjectDetailBodyWrapper = styled.div`
   font-size: 1rem;
   overflow-y: auto;
-  ${breakpointMinMedium} {
-    display: flex;
-    height: calc(80vh - 4rem);
-  }
-  height: calc(100vh - 8rem);
 `;
 
 export const ObjectIdLabel = styled.span`
@@ -37,9 +27,6 @@ export const ObjectDetailsTable = styled.div`
   overflow-y: auto;
   flex: 1;
   padding: 2rem;
-  ${breakpointMinMedium} {
-    max-height: calc(80vh - 4rem);
-  }
 `;
 
 export const ObjectRelationships = styled.div`
@@ -47,10 +34,6 @@ export const ObjectRelationships = styled.div`
   flex: 0 0 100%;
   padding: 2rem;
   background-color: ${color("bg-light")};
-  ${breakpointMinMedium} {
-    flex: 0 0 33.3333%;
-    max-height: calc(80vh - 4rem);
-  }
 `;
 
 export const CloseButton = styled.div`
@@ -86,7 +69,43 @@ export const EditingFormContainer = styled.div`
   overflow-y: auto;
   flex: 1;
   padding: 2rem;
-  ${breakpointMinMedium} {
-    max-height: calc(80vh - 4rem);
+`;
+
+export const RootModal = styled(Modal)`
+  ${ObjectDetailModal} {
+    overflow: hidden;
+    ${breakpointMinMedium} {
+      width: ${({ wide }) => (wide ? "64rem" : "48rem")};
+      max-width: 95vw;
+    }
+    max-height: 95vh;
+    width: 95vw;
+  }
+
+  ${ObjectDetailBodyWrapper} {
+    ${breakpointMinMedium} {
+      display: flex;
+      height: calc(80vh - 4rem);
+    }
+    height: calc(100vh - 8rem);
+  }
+
+  ${ObjectDetailsTable} {
+    ${breakpointMinMedium} {
+      max-height: calc(80vh - 4rem);
+    }
+  }
+
+  ${ObjectRelationships} {
+    ${breakpointMinMedium} {
+      flex: 0 0 33.3333%;
+      max-height: calc(80vh - 4rem);
+    }
+  }
+
+  ${EditingFormContainer} {
+    ${breakpointMinMedium} {
+      max-height: calc(80vh - 4rem);
+    }
   }
 `;

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
@@ -466,6 +466,7 @@ export const ObjectDetailProperties = {
     // @ts-ignore
     ...columnSettings({ hidden: true }),
   },
+  isSensible: (data: DatasetData) => data.rows.length === 1,
 };
 
 const ObjectDetail = Object.assign(

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
@@ -118,6 +118,8 @@ export interface ObjectDetailProps {
   canZoomPreviousRow: boolean;
   canZoomNextRow: boolean;
   isWritebackEnabled: boolean;
+  showActions?: boolean;
+  showRelations?: boolean;
   onVisualizationClick: OnVisualizationClickType;
   visualizationIsClickable: (clicked: any) => boolean;
   deleteRowFromObjectDetail: (opts: DeleteRowPayload) => void;
@@ -143,6 +145,8 @@ export function ObjectDetailFn({
   canZoomPreviousRow,
   canZoomNextRow,
   isWritebackEnabled,
+  showActions = true,
+  showRelations = true,
   onVisualizationClick,
   visualizationIsClickable,
   fetchTableFks,
@@ -261,11 +265,8 @@ export function ObjectDetailFn({
 
   const displayId = getDisplayId({ cols: data.cols, zoomedRow });
   const hasPk = !!data.cols.find(isPK);
-  const hasRelationships = !!(
-    tableForeignKeys &&
-    !!tableForeignKeys.length &&
-    hasPk
-  );
+  const hasRelationships =
+    showRelations && !!(tableForeignKeys && !!tableForeignKeys.length && hasPk);
 
   return (
     <ObjectDetailModal wide={hasRelationships}>
@@ -283,6 +284,7 @@ export function ObjectDetailFn({
             canZoomNextRow={canZoomNextRow}
             isEditing={isEditing}
             canEdit={canEdit}
+            showActions={showActions}
             deleteRow={deleteRow}
             viewPreviousObjectDetail={viewPreviousObjectDetail}
             viewNextObjectDetail={viewNextObjectDetail}
@@ -316,9 +318,22 @@ export function ObjectDetailFn({
 }
 
 function ObjectDetailWrapper({
+  question,
+  isDataApp,
   closeObjectDetail,
   ...props
-}: ObjectDetailProps) {
+}: ObjectDetailProps & { isDataApp?: boolean }) {
+  if (isDataApp || question.display() === "object") {
+    return (
+      <ObjectDetailFn
+        {...props}
+        question={question}
+        showActions={false}
+        showRelations={false}
+        closeObjectDetail={closeObjectDetail}
+      />
+    );
+  }
   return (
     <RootModal
       isOpen
@@ -326,7 +341,11 @@ function ObjectDetailWrapper({
       onClose={closeObjectDetail}
       className={""} // need an empty className to override the Modal default width
     >
-      <ObjectDetailFn {...props} closeObjectDetail={closeObjectDetail} />
+      <ObjectDetailFn
+        {...props}
+        question={question}
+        closeObjectDetail={closeObjectDetail}
+      />
     </RootModal>
   );
 }
@@ -339,6 +358,7 @@ export interface ObjectDetailHeaderProps {
   canZoomNextRow: boolean;
   isEditing: boolean;
   canEdit: boolean;
+  showActions?: boolean;
   deleteRow?: () => void;
   viewPreviousObjectDetail: () => void;
   viewNextObjectDetail: () => void;
@@ -354,6 +374,7 @@ export function ObjectDetailHeader({
   canZoomNextRow,
   isEditing,
   canEdit,
+  showActions = true,
   deleteRow,
   viewPreviousObjectDetail,
   viewNextObjectDetail,
@@ -368,50 +389,52 @@ export function ObjectDetailHeader({
           {objectId !== null && <ObjectIdLabel> {objectId}</ObjectIdLabel>}
         </h2>
       </div>
-      <div className="flex align-center">
-        {canEdit && (
-          <ActionHeader
-            isEditing={isEditing}
-            deleteRow={deleteRow}
-            onToggleEditingModeClick={onToggleEditingModeClick}
-          />
-        )}
-        <div className="flex p2">
-          {!!canZoom && (
-            <>
-              <Button
-                data-testid="view-previous-object-detail"
-                onlyIcon
-                borderless
-                className="mr1"
-                disabled={!canZoomPreviousRow}
-                onClick={viewPreviousObjectDetail}
-                icon="chevronup"
-                iconSize={20}
-              />
-              <Button
-                data-testid="view-next-object-detail"
-                onlyIcon
-                borderless
-                disabled={!canZoomNextRow}
-                onClick={viewNextObjectDetail}
-                icon="chevrondown"
-                iconSize={20}
-              />
-            </>
-          )}
-          <CloseButton>
-            <Button
-              data-testId="object-detail-close-button"
-              onlyIcon
-              borderless
-              onClick={closeObjectDetail}
-              icon="close"
-              iconSize={20}
+      {showActions && (
+        <div className="flex align-center">
+          {canEdit && (
+            <ActionHeader
+              isEditing={isEditing}
+              deleteRow={deleteRow}
+              onToggleEditingModeClick={onToggleEditingModeClick}
             />
-          </CloseButton>
+          )}
+          <div className="flex p2">
+            {!!canZoom && (
+              <>
+                <Button
+                  data-testid="view-previous-object-detail"
+                  onlyIcon
+                  borderless
+                  className="mr1"
+                  disabled={!canZoomPreviousRow}
+                  onClick={viewPreviousObjectDetail}
+                  icon="chevronup"
+                  iconSize={20}
+                />
+                <Button
+                  data-testid="view-next-object-detail"
+                  onlyIcon
+                  borderless
+                  disabled={!canZoomNextRow}
+                  onClick={viewNextObjectDetail}
+                  icon="chevrondown"
+                  iconSize={20}
+                />
+              </>
+            )}
+            <CloseButton>
+              <Button
+                data-testId="object-detail-close-button"
+                onlyIcon
+                borderless
+                onClick={closeObjectDetail}
+                icon="close"
+                iconSize={20}
+              />
+            </CloseButton>
+          </div>
         </div>
-      </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
This PR implements a very rough prototype of object detail view for data apps. It uses the same object detail view as the query builder, but it's not wrapped in a modal and doesn't show relations or header action buttons.

### To Verify

1. Create a question that has only one row in the results (e.g. filter by PK or create a native question like `select * from table where ID = {{ id }}`
2. Click "Visualization" and pick "Object detail" (a new thing!)
3. Add the card to a dashboard
4. Ensure you can see the object detail view 
5. Also, if you put "App" at the end of your dashboard name, it's going to be treated as a data app and card titles will be hidden

### Demo

<img width="1512" alt="CleanShot 2022-05-26 at 18 20 00@2x" src="https://user-images.githubusercontent.com/17258145/170541263-bcf49f13-8255-4b1c-a27e-3f18aefaa30e.png">

