### PR TITLE
Fix deadlock in pivot table connection management

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -52,6 +52,7 @@
   (eval . (put-clojure-indent 'mt/test-driver 1))
   (eval . (put-clojure-indent 'prop/for-all 1))
   (eval . (put-clojure-indent 'qp.streaming/streaming-response 1))
+  (eval . (put-clojure-indent 'u/prog1 1))
   (eval . (put-clojure-indent 'u/select-keys-when 1))
   (eval . (put-clojure-indent 'u/strict-extend 1))
   ;; these ones have to be done with `define-clojure-indent' for now because of upstream bug

--- a/src/metabase/query_processor/context/default.clj
+++ b/src/metabase/query_processor/context/default.clj
@@ -62,10 +62,10 @@
                                                    context)))]
       (qp.context/reducedf reduced-rows context))))
 
-(defn- default-runf [query rf context]
+(defn- default-runf [query rff context]
   (try
     (qp.context/executef driver/*driver* query context (fn respond* [metadata reducible-rows]
-                                                         (qp.context/reducef rf context metadata reducible-rows)))
+                                                         (qp.context/reducef rff context metadata reducible-rows)))
     (catch Throwable e
       (qp.context/raisef e context))))
 


### PR DESCRIPTION
Addresses part of https://github.com/metabase/metabase/issues/8679

Pivot tables can have subqueries that run to create tallies. We do not
hold the entirety of resultsets in memory so we have a bit of an
inversion of control flow: connections are opened, queries run, and
result sets are transduced and then the connection closed.

The error here was that subsequent queries for the pivot were run while
the first connection is still held open. But the connection is no longer
needed. But enough pivots running at the same time in a dashboard can
create a deadlock where the subqueries need a new connection, but the
main queries cannot be released until the subqueries have completed.

Also, rf management is critical. It's completion arity must be called
once and only once. We also have middleware that need to be
composed (format, etc) and others that can only be composed
once (limit). We have to save the original reducing function before
composition (this is the one that can write to the download writer, etc)
but compose it each time we use it with `(rff metadata)` so we have the
format and other middleware. Keeping this distinction in mind will save
you lots of time. (The limit query will ignore all subsequent rows if
you just grab the output of `(rff metadata)` and not the rf returned
from the `:rff` key on the context.

But this takes the following connection management:

```
tap> "OPENING CONNECTION 0"
tap> "already open: "
  tap> "OPENING CONNECTION 1"
  tap> "already open: 0"
  tap> "CLOSING CONNECTION 1"
  tap> "OPENING CONNECTION 2"
  tap> "already open: 0"
  tap> "CLOSING CONNECTION 2"
  tap> "OPENING CONNECTION 3"
  tap> "already open: 0"
  tap> "CLOSING CONNECTION 3"
tap> "CLOSING CONNECTION 0"
```

and properly sequences it so that connection 0 is closed before opening
connection 1.

It hijacks the executef to just pass that function into the reducef part
so we can reduce multiple times and therefore control the
connections. Otherwise the reducef happens "inside" of the executef at
which point the connection is closed.

Care is taken to ensure that:
- the init is only called once (subsequent queries have the init of the
rf overridden to just return `init` (the acc passed in) rather than
`(rf)`
- the completion arity is only called once (use of `(completing rf)` and
the reducing function in the subsequent queries is just `([acc] acc)`
and does not call `(rf acc)`. Remember this is just on the lower
reducing function and all of the takes, formats, etc _above_ it will
have the completion arity called because we are using transduce. The
completion arity is what takes the volatile rows and row counts and
actually nests them in the `{:data {:rows []}` structure. Without
calling that once (and ONLY once) you end up with no actual
results. they are just in memory.


### How identified:
pivot kept coming up as a possible place to look. Luiggi had the great idea to set the connection pool size to 2 for source dbs. Then lock it up and get a stack dump ( `control-\`). Analyzing the stack dump on https://fastthread.io/ft-thread-report.jsp?dumpId=1#flameGraphMenu showed four threads in pivot and where they were blocked. Invaluable.

<img width="792" alt="image" src="https://user-images.githubusercontent.com/6377293/170572275-70246d69-528b-4a1f-ad7b-2f9a8cba3941.png">

<img width="1008" alt="image" src="https://user-images.githubusercontent.com/6377293/170572848-cee4b9d9-7d30-430a-a78d-f1daeadcc868.png">


### How to test/verify

#### An easy pivot question
Sample db on Orders, Summarize by Count and Sum of Total, grouped by Product Id. Add a limit 3 if you want to keep repl results small. This also brings in the limit middleware that is so important.
<img width="1063" alt="image" src="https://user-images.githubusercontent.com/6377293/170724534-ca3317ab-f921-418a-bf46-4e2c8f826e3a.png">

#### See connection openings and closings

Update `metabase.driver.sql-jdbc.execute/execute-reducible-query` to print on opening/closing of the connection here.

Suggested change:
```clojure
(let [i (atom -1)]
  (defn- id! [] (swap! i inc)))
```

Not the full form but change `conn` to reify close and get connection. Substitute your `log`, `println`, etc of choice over `tap>` if you like.
```clojure
(with-open [conn          (let [id (id!)
                                c (connection-with-timezone driver (qp.store/database) (qp.timezone/report-timezone-id-if-supported))]
                            (reify
                              javax.sql.DataSource
                              (getConnection [_]
                                (tap> (str "opening connection: " id))
                                c)
                              java.lang.AutoCloseable
                              (close [_]
                                (tap> (str "closing connection: " id))
                                (.close c))))
            stmt          (statement-or-prepared-statement
                           driver (.getConnection conn) sql params     ;; note we call (.getConnection conn) now to unwrap it since we want to reify javax.sql.DataSource (one method really) vs java.sql.Connection (lots and lots of methods)
                           (qp.context/canceled-chan context))
            ])
```

Then from `metabase.query-processor.pivot`, just run 
```clojure
(comment
  (def query (:dataset_query (metabase.models/Card 32))) ;; substitute your query's id here
  (do (run! tap> (repeat 10 "*****")) ;; set a barrier so its easy to find the beginning of the output
      (require 'metabase.driver.sql-jdbc.execute :reload) ;; this resets the counter for `id!`, not necessary otherwise
      (-> (run-pivot-query query) :data :rows))

  )
```

#### Output

On master you should see what's at the top of this PR. Basically, opening connection 0, opening connection 1, closing connection 1, closing connection 0.

On this branch, you should see
```
tap> "opening connection0"
tap> "closing connection0"
tap> "opening connection1"
tap> "closing connection1"
```

#### How to deadlock

1. Make a dashboard that has 15 copies of your pivot question. This will easily exhaust the 15 connections available.
2. Change `metabase.driver.sql-jdbc.connection/connection-pool-spec` to assoc `(assoc pool-properties "maxPoolSize" 2)` and then
```clojure
(comment
  (let [db (metabase.models/Database 1)]
    (set-pool! 1 (create-pool! db) db))

  (-> (db->pooled-connection-spec 1) :datasource (.getConnectionPoolDataSource) (.getMaxPoolSize))
  )
```
will set and then verify this change. A dashboard with two questions on it will deadlock now.
