### PR TITLE
Do not run E2E tests using CircleCI on `master`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1223,7 +1223,7 @@ workflows:
             - be-deps
           filters:
             branches:
-              ignore: e2e-skip-cci-on-master
+              ignore: master
           <<: *Matrix
 
       - build-uberjar-frontend:
@@ -1244,7 +1244,7 @@ workflows:
             - checkout
           filters:
             branches:
-              ignore: e2e-skip-cci-on-master
+              ignore: master
 
       - fe-tests-cypress:
           matrix:
@@ -1292,4 +1292,4 @@ workflows:
             - checkout
           filters:
             branches:
-              ignore: e2e-skip-cci-on-master
+              ignore: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1221,6 +1221,9 @@ workflows:
           name: build-uberjar-drivers-<< matrix.edition >>
           requires:
             - be-deps
+          filters:
+            branches:
+              ignore: e2e-skip-cci-on-master
           <<: *Matrix
 
       - build-uberjar-frontend:
@@ -1239,6 +1242,9 @@ workflows:
       - fe-deps:
           requires:
             - checkout
+          filters:
+            branches:
+              ignore: e2e-skip-cci-on-master
 
       - fe-tests-cypress:
           matrix:
@@ -1284,3 +1290,6 @@ workflows:
       - snowplow-deps:
           requires:
             - checkout
+          filters:
+            branches:
+              ignore: e2e-skip-cci-on-master


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- As the title suggests, it will completely skip running E2E tests on `master` because we already run the [full E2E suite on `master` using GitHub Actions](https://github.com/metabase/metabase/blob/master/.github/workflows/e2e-master.yml)
- It also skips `fe-deps`, `snowplow-deps` and `build-uberjar-drivers` which were needed only for E2E tests
- The graph for CCI on `master` should look like this in the future (only backend drivers tests will run)
![image](https://user-images.githubusercontent.com/31325167/170552797-c9180c41-5917-4fae-87d1-229bb9c8dea9.png)

This should **greatly** reduce our CircleCI usage and it moves us one step forward to the total migration towards GitHub Actions.

Thanks @ariya for pointing me to the [`job filters`](https://circleci.com/docs/2.0/configuration-reference/#jobfilters). My original idea how to achieve this was more complicated that this :)

### Notes
This will not affect checks on PR, or checks on release branch in any way.