### PR TITLE
Simplify FieldValuesWidget fetching/option-handling logic

### DIFF
--- a/frontend/src/metabase/components/FieldValuesWidget.jsx
+++ b/frontend/src/metabase/components/FieldValuesWidget.jsx
@@ -20,7 +20,6 @@ import { addRemappings, fetchFieldValues } from "metabase/redux/metadata";
 import { defer } from "metabase/lib/promise";
 import { stripId } from "metabase/lib/formatting";
 import { fetchDashboardParameterValues } from "metabase/dashboard/actions";
-import { getDashboardParameterValuesCache } from "metabase/dashboard/selectors";
 
 import Fields from "metabase/entities/fields";
 
@@ -44,7 +43,6 @@ const mapDispatchToProps = {
 function mapStateToProps(state, { fields = [] }) {
   // try and use the selected fields, but fall back to the ones passed
   return {
-    dashboardParameterValuesCache: getDashboardParameterValuesCache(state),
     fields: fields.map(
       field =>
         Fields.selectors.getObject(state, { entityId: field.id }) || field,
@@ -97,8 +95,7 @@ class FieldValuesWidgetInner extends Component {
         parameter,
         parameters,
       };
-      await this.props.fetchDashboardParameterValues(args);
-      options = this.props.dashboardParameterValuesCache.get(args);
+      options = await this.props.fetchDashboardParameterValues(args);
     } finally {
       this.setState({
         loadingState: "LOADED",
@@ -142,8 +139,7 @@ class FieldValuesWidgetInner extends Component {
         parameters,
         query: value,
       };
-      await this.props.fetchDashboardParameterValues(args);
-      results = this.props.dashboardParameterValuesCache.get(args);
+      results = await this.props.fetchDashboardParameterValues(args);
     } else {
       results = dedupeValues(
         await Promise.all(

--- a/frontend/src/metabase/components/FieldValuesWidget.jsx
+++ b/frontend/src/metabase/components/FieldValuesWidget.jsx
@@ -113,6 +113,7 @@ class FieldValuesWidgetInner extends Component {
         options = await this.fetchFieldValues(query);
       }
     } finally {
+      this.updateRemappings(options);
       this.setState({
         loadingState: "LOADED",
         options,
@@ -144,16 +145,6 @@ class FieldValuesWidgetInner extends Component {
         cancelled,
       );
 
-      if (showRemapping(fields)) {
-        const [field] = fields;
-        if (
-          field.remappedField() ===
-          searchField(field, this.props.disablePKRemappingForSearch)
-        ) {
-          this.props.addRemappings(field.id, options);
-        }
-      }
-
       this._cancel = null;
       return options;
     }
@@ -169,6 +160,19 @@ class FieldValuesWidgetInner extends Component {
     };
     return this.props.fetchDashboardParameterValues(args);
   };
+
+  updateRemappings(options) {
+    const { fields } = this.props;
+    if (showRemapping(fields)) {
+      const [field] = fields;
+      if (
+        field.remappedField() ===
+        searchField(field, this.props.disablePKRemappingForSearch)
+      ) {
+        this.props.addRemappings(field.id, options);
+      }
+    }
+  }
 
   componentWillUnmount() {
     if (this._cancel) {
@@ -308,9 +312,11 @@ class FieldValuesWidgetInner extends Component {
                 compact: false,
               })
             }
-            optionRenderer={option =>
-              renderValue(fields, formatOptions, option[0], { autoLoad: false })
-            }
+            optionRenderer={option => {
+              return renderValue(fields, formatOptions, option[0], {
+                autoLoad: false,
+              });
+            }}
             layoutRenderer={layoutProps => (
               <div>
                 {layoutProps.valuesList}

--- a/frontend/src/metabase/components/FieldValuesWidget.jsx
+++ b/frontend/src/metabase/components/FieldValuesWidget.jsx
@@ -124,7 +124,7 @@ class FieldValuesWidgetInner extends Component {
     if (query == null) {
       const { fields, fetchFieldValues } = this.props;
       await Promise.all(fields.map(field => fetchFieldValues(field.id)));
-      return dedupeValues(fields.map(field => field.values));
+      return dedupeValues(this.props.fields.map(field => field.values));
     } else {
       const { fields } = this.props;
       const cancelDeferred = defer();

--- a/frontend/src/metabase/components/FieldValuesWidget.jsx
+++ b/frontend/src/metabase/components/FieldValuesWidget.jsx
@@ -243,7 +243,7 @@ class FieldValuesWidgetInner extends Component {
       formatOptions,
       placeholder,
     } = this.props;
-    const { loadingState, options: stateOptions } = this.state;
+    const { loadingState, options = [] } = this.state;
 
     const tokenFieldPlaceholder = getTokenFieldPlaceholder({
       fields,
@@ -252,30 +252,8 @@ class FieldValuesWidgetInner extends Component {
       placeholder,
       disablePKRemappingForSearch,
       loadingState,
-      options: stateOptions,
+      options,
     });
-
-    let options = [];
-    if (
-      hasList({
-        fields,
-        disableSearch,
-        dashboard,
-        loadingState,
-        options: stateOptions,
-      }) &&
-      !usesChainFilterEndpoints(this.props.dashboard)
-    ) {
-      options = dedupeValues(fields.map(field => field.values));
-    } else if (
-      loadingState === "LOADED" &&
-      (isSearchable(fields, disableSearch, disablePKRemappingForSearch) ||
-        usesChainFilterEndpoints(this.props.dashboard))
-    ) {
-      options = this.state.options;
-    } else {
-      options = [];
-    }
 
     const isLoading = loadingState === "LOADING";
     const isFetchingList =
@@ -285,7 +263,7 @@ class FieldValuesWidgetInner extends Component {
       disableSearch,
       dashboard,
       loadingState,
-      options: stateOptions,
+      options,
     });
 
     return (

--- a/frontend/src/metabase/components/FieldValuesWidget.jsx
+++ b/frontend/src/metabase/components/FieldValuesWidget.jsx
@@ -238,7 +238,6 @@ class FieldValuesWidgetInner extends Component {
       parameter,
       prefix,
       disableSearch,
-      dashboard,
       disablePKRemappingForSearch,
       formatOptions,
       placeholder,
@@ -248,7 +247,6 @@ class FieldValuesWidgetInner extends Component {
     const tokenFieldPlaceholder = getTokenFieldPlaceholder({
       fields,
       disableSearch,
-      dashboard,
       placeholder,
       disablePKRemappingForSearch,
       loadingState,
@@ -261,8 +259,6 @@ class FieldValuesWidgetInner extends Component {
     const hasListData = hasList({
       fields,
       disableSearch,
-      dashboard,
-      loadingState,
       options,
     });
 
@@ -467,14 +463,8 @@ function getSearchableTokenFieldPlaceholder(
   return placeholder;
 }
 
-function hasList({ fields, disableSearch, dashboard, loadingState, options }) {
-  const nonEmptyArray = a => a && a.length > 0;
-  return (
-    shouldList(fields, disableSearch) &&
-    (usesChainFilterEndpoints(dashboard)
-      ? loadingState === "LOADED" && nonEmptyArray(options)
-      : fields.every(field => nonEmptyArray(field.values)))
-  );
+function hasList({ fields, disableSearch, options }) {
+  return shouldList(fields, disableSearch) && !_.isEmpty(options);
 }
 
 function isSearchable(fields, disableSearch, disablePKRemappingForSearch) {
@@ -495,7 +485,6 @@ function isSearchable(fields, disableSearch, disablePKRemappingForSearch) {
 function getTokenFieldPlaceholder({
   fields,
   disableSearch,
-  dashboard,
   placeholder,
   disablePKRemappingForSearch,
   loadingState,
@@ -511,9 +500,6 @@ function getTokenFieldPlaceholder({
     hasList({
       fields,
       disableSearch,
-      disablePKRemappingForSearch,
-      dashboard,
-      loadingState,
       options,
     })
   ) {
@@ -538,7 +524,6 @@ function renderOptions(
     alwaysShowOptions,
     fields,
     disableSearch,
-    dashboard,
     disablePKRemappingForSearch,
   } = props;
   const { loadingState, options } = state;
@@ -550,8 +535,6 @@ function renderOptions(
       hasList({
         fields,
         disableSearch,
-        dashboard,
-        loadingState,
         options,
       })
     ) {

--- a/frontend/src/metabase/dashboard/actions.js
+++ b/frontend/src/metabase/dashboard/actions.js
@@ -59,6 +59,7 @@ import {
   getParameterValues,
   getDashboardParameterValuesSearchCache,
   getLoadingDashCards,
+  getDashboardParameterValuesCache,
 } from "./selectors";
 import { getMetadata } from "metabase/selectors/metadata";
 import { getCardAfterVisualizationClick } from "metabase/visualizations/lib/utils";
@@ -136,8 +137,8 @@ export const SHOW_ADD_PARAMETER_POPOVER =
 export const HIDE_ADD_PARAMETER_POPOVER =
   "metabase/dashboard/HIDE_ADD_PARAMETER_POPOVER";
 
-export const FETCH_DASHBOARD_PARAMETER_FIELD_VALUES =
-  "metabase/dashboard/FETCH_DASHBOARD_PARAMETER_FIELD_VALUES";
+export const FETCH_DASHBOARD_PARAMETER_FIELD_VALUES_WITH_CACHE =
+  "metabase/dashboard/FETCH_DASHBOARD_PARAMETER_FIELD_VALUES_WITH_CACHE";
 
 export const SET_SIDEBAR = "metabase/dashboard/SET_SIDEBAR";
 export const CLOSE_SIDEBAR = "metabase/dashboard/CLOSE_SIDEBAR";
@@ -1098,8 +1099,8 @@ const loadMetadataForDashboard = dashCards => (dispatch, getState) => {
   );
 };
 
-export const fetchDashboardParameterValues = createThunkAction(
-  FETCH_DASHBOARD_PARAMETER_FIELD_VALUES,
+const fetchDashboardParameterValuesWithCache = createThunkAction(
+  FETCH_DASHBOARD_PARAMETER_FIELD_VALUES_WITH_CACHE,
   ({ dashboardId, parameter, parameters, query }) => async (
     dispatch,
     getState,
@@ -1138,3 +1139,14 @@ export const fetchDashboardParameterValues = createThunkAction(
     };
   },
 );
+
+export const fetchDashboardParameterValues = args => async (
+  dispatch,
+  getState,
+) => {
+  await dispatch(fetchDashboardParameterValuesWithCache(args));
+  const dashboardParameterValuesCache = getDashboardParameterValuesCache(
+    getState(),
+  );
+  return dashboardParameterValuesCache.get(args) || [];
+};

--- a/frontend/src/metabase/dashboard/actions.js
+++ b/frontend/src/metabase/dashboard/actions.js
@@ -1099,7 +1099,7 @@ const loadMetadataForDashboard = dashCards => (dispatch, getState) => {
   );
 };
 
-const fetchDashboardParameterValuesWithCache = createThunkAction(
+export const fetchDashboardParameterValuesWithCache = createThunkAction(
   FETCH_DASHBOARD_PARAMETER_FIELD_VALUES_WITH_CACHE,
   ({ dashboardId, parameter, parameters, query }) => async (
     dispatch,

--- a/frontend/src/metabase/dashboard/actions.unit.spec.js
+++ b/frontend/src/metabase/dashboard/actions.unit.spec.js
@@ -12,7 +12,7 @@ import {
   removeParameter,
   SET_DASHBOARD_ATTRIBUTES,
   fetchDashboardParameterValues,
-  FETCH_DASHBOARD_PARAMETER_FIELD_VALUES,
+  FETCH_DASHBOARD_PARAMETER_FIELD_VALUES_WITH_CACHE,
 } from "./actions";
 import { SIDEBAR_NAME } from "./constants";
 
@@ -201,7 +201,7 @@ describe("dashboard actions", () => {
             "dashboardId: 1, parameterId: a, query: foo, filteringParameterValues: []",
           results: [[1], [2], [3]],
         },
-        type: FETCH_DASHBOARD_PARAMETER_FIELD_VALUES,
+        type: FETCH_DASHBOARD_PARAMETER_FIELD_VALUES_WITH_CACHE,
       });
     });
 
@@ -223,7 +223,7 @@ describe("dashboard actions", () => {
             "dashboardId: 1, parameterId: a, query: null, filteringParameterValues: []",
           results: [[4], [5], [6]],
         },
-        type: FETCH_DASHBOARD_PARAMETER_FIELD_VALUES,
+        type: FETCH_DASHBOARD_PARAMETER_FIELD_VALUES_WITH_CACHE,
       });
     });
 
@@ -247,7 +247,7 @@ describe("dashboard actions", () => {
             'dashboardId: 1, parameterId: a, query: bar, filteringParameterValues: [["b","bbb"]]',
           results: [[1], [2], [3]],
         },
-        type: FETCH_DASHBOARD_PARAMETER_FIELD_VALUES,
+        type: FETCH_DASHBOARD_PARAMETER_FIELD_VALUES_WITH_CACHE,
       });
     });
 
@@ -270,7 +270,7 @@ describe("dashboard actions", () => {
             'dashboardId: 1, parameterId: a, query: null, filteringParameterValues: [["b","bbb"]]',
           results: [[4], [5], [6]],
         },
-        type: FETCH_DASHBOARD_PARAMETER_FIELD_VALUES,
+        type: FETCH_DASHBOARD_PARAMETER_FIELD_VALUES_WITH_CACHE,
       });
     });
 
@@ -293,7 +293,7 @@ describe("dashboard actions", () => {
 
       expect(action).toEqual({
         payload: undefined,
-        type: FETCH_DASHBOARD_PARAMETER_FIELD_VALUES,
+        type: FETCH_DASHBOARD_PARAMETER_FIELD_VALUES_WITH_CACHE,
       });
     });
   });

--- a/frontend/src/metabase/dashboard/actions.unit.spec.js
+++ b/frontend/src/metabase/dashboard/actions.unit.spec.js
@@ -11,7 +11,7 @@ import {
   openAddQuestionSidebar,
   removeParameter,
   SET_DASHBOARD_ATTRIBUTES,
-  fetchDashboardParameterValues,
+  fetchDashboardParameterValuesWithCache,
   FETCH_DASHBOARD_PARAMETER_FIELD_VALUES_WITH_CACHE,
 } from "./actions";
 import { SIDEBAR_NAME } from "./constants";
@@ -154,7 +154,7 @@ describe("dashboard actions", () => {
     });
   });
 
-  describe("fetchDashboardParameterValues", () => {
+  describe("fetchDashboardParameterValuesWithCache", () => {
     const dashboardId = 1;
     const parameter = { id: "a" };
     const parameterWithFilteringParameters = {
@@ -183,7 +183,7 @@ describe("dashboard actions", () => {
     });
 
     it("should fetch parameter values using the given query string", async () => {
-      const action = await fetchDashboardParameterValues({
+      const action = await fetchDashboardParameterValuesWithCache({
         dashboardId,
         parameter,
         parameters,
@@ -206,7 +206,7 @@ describe("dashboard actions", () => {
     });
 
     it("should fetch parameter values without a query string", async () => {
-      const action = await fetchDashboardParameterValues({
+      const action = await fetchDashboardParameterValuesWithCache({
         dashboardId,
         parameter,
         parameters,
@@ -228,7 +228,7 @@ describe("dashboard actions", () => {
     });
 
     it("should fetch parameter values using a query string and filtering parameters", async () => {
-      const action = await fetchDashboardParameterValues({
+      const action = await fetchDashboardParameterValuesWithCache({
         dashboardId,
         parameter: parameterWithFilteringParameters,
         parameters,
@@ -252,7 +252,7 @@ describe("dashboard actions", () => {
     });
 
     it("should fetch parameter values without a query string but with filtering parameters", async () => {
-      const action = await fetchDashboardParameterValues({
+      const action = await fetchDashboardParameterValuesWithCache({
         dashboardId,
         parameter: parameterWithFilteringParameters,
         parameters,
@@ -281,7 +281,7 @@ describe("dashboard actions", () => {
         [cacheKey]: [[1], [2], [3]],
       };
 
-      const action = await fetchDashboardParameterValues({
+      const action = await fetchDashboardParameterValuesWithCache({
         dashboardId,
         parameter: parameterWithFilteringParameters,
         parameters,

--- a/frontend/src/metabase/dashboard/reducers.js
+++ b/frontend/src/metabase/dashboard/reducers.js
@@ -30,7 +30,7 @@ import {
   HIDE_ADD_PARAMETER_POPOVER,
   SET_SIDEBAR,
   CLOSE_SIDEBAR,
-  FETCH_DASHBOARD_PARAMETER_FIELD_VALUES,
+  FETCH_DASHBOARD_PARAMETER_FIELD_VALUES_WITH_CACHE,
   SAVE_DASHBOARD_AND_CARDS,
   SET_DOCUMENT_TITLE,
   SET_SHOW_LOADING_COMPLETE_FAVICON,
@@ -284,7 +284,7 @@ const parameterValuesSearchCache = handleActions(
     [SAVE_DASHBOARD_AND_CARDS]: {
       next: () => ({}),
     },
-    [FETCH_DASHBOARD_PARAMETER_FIELD_VALUES]: {
+    [FETCH_DASHBOARD_PARAMETER_FIELD_VALUES_WITH_CACHE]: {
       next: (state, { payload }) =>
         payload ? assoc(state, payload.cacheKey, payload.results) : state,
     },

--- a/frontend/test/metabase/components/FieldValuesWidget.unit.spec.js
+++ b/frontend/test/metabase/components/FieldValuesWidget.unit.spec.js
@@ -31,9 +31,9 @@ describe("FieldValuesWidget", () => {
         expect(fetchFieldValues).not.toHaveBeenCalled();
       });
 
-      it("should have 'Enter some text' as the placeholder text", () => {
+      it("should have 'Enter some text' as the placeholder text", async () => {
         renderFieldValuesWidget({ ...props });
-        screen.getByPlaceholderText("Enter some text");
+        await screen.findByPlaceholderText("Enter some text");
       });
     });
     describe("has_field_values = list", () => {
@@ -55,11 +55,11 @@ describe("FieldValuesWidget", () => {
         ).toBeNull();
       });
 
-      it("should have 'Enter some text' as the placeholder text for fields with more than 10 values", () => {
+      it("should have 'Enter some text' as the placeholder text for fields with more than 10 values", async () => {
         renderFieldValuesWidget({
           fields: [mock(PRODUCTS.TITLE, { has_field_values: "list" })],
         });
-        screen.getByPlaceholderText("Enter some text");
+        await screen.findByPlaceholderText("Enter some text");
       });
     });
 
@@ -74,25 +74,25 @@ describe("FieldValuesWidget", () => {
         expect(fetchFieldValues).not.toHaveBeenCalled();
       });
 
-      it("should have 'Search by Category' as the placeholder text", () => {
+      it("should have 'Search by Category' as the placeholder text", async () => {
         renderFieldValuesWidget({ ...props });
-        screen.getByPlaceholderText("Search by Category");
+        await screen.findByPlaceholderText("Search by Category");
       });
     });
   });
 
   describe("id field", () => {
     describe("has_field_values = none", () => {
-      it("should have 'Enter an ID' as the placeholder text", () => {
+      it("should have 'Enter an ID' as the placeholder text", async () => {
         renderFieldValuesWidget({
           fields: [mock(ORDERS.PRODUCT_ID, { has_field_values: "none" })],
         });
-        screen.getByPlaceholderText("Enter an ID");
+        await screen.findByPlaceholderText("Enter an ID");
       });
     });
 
     describe("has_field_values = list", () => {
-      it("should have 'Search the list' as the placeholder text", () => {
+      it("should have 'Search the list' as the placeholder text", async () => {
         renderFieldValuesWidget({
           fields: [
             mock(ORDERS.PRODUCT_ID, {
@@ -101,12 +101,12 @@ describe("FieldValuesWidget", () => {
             }),
           ],
         });
-        screen.getByPlaceholderText("Search the list");
+        await screen.findByPlaceholderText("Search the list");
       });
     });
 
     describe("has_field_values = search", () => {
-      it("should have 'Search by Category or enter an ID' as the placeholder text", () => {
+      it("should have 'Search by Category or enter an ID' as the placeholder text", async () => {
         renderFieldValuesWidget({
           fields: [
             mock(ORDERS.PRODUCT_ID, {
@@ -115,7 +115,7 @@ describe("FieldValuesWidget", () => {
             }),
           ],
         });
-        screen.getByPlaceholderText("Search by Category or enter an ID");
+        await screen.findByPlaceholderText("Search by Category or enter an ID");
       });
 
       it("should not duplicate 'ID' in placeholder when ID itself is searchable", async () => {
@@ -126,7 +126,7 @@ describe("FieldValuesWidget", () => {
           }),
         ];
         renderFieldValuesWidget({ fields });
-        screen.getByPlaceholderText("Search by Product");
+        await screen.findByPlaceholderText("Search by Product");
       });
     });
   });
@@ -138,31 +138,31 @@ describe("FieldValuesWidget", () => {
         mock(PEOPLE.STATE, { has_field_values: "list" }),
       ];
       renderFieldValuesWidget({ fields });
-      screen.getByPlaceholderText("Search the list");
+      await screen.findByPlaceholderText("Search the list");
 
-      screen.getByText("AZ");
-      screen.getByText("Facebook");
+      await screen.findByText("AZ");
+      await screen.findByText("Facebook");
     });
 
-    it("search if any field is a search", () => {
+    it("search if any field is a search", async () => {
       const fields = [
         mock(PEOPLE.SOURCE, { has_field_values: "search" }),
         mock(PEOPLE.STATE, { has_field_values: "list" }),
       ];
       renderFieldValuesWidget({ fields });
-      screen.getByPlaceholderText("Search");
+      await screen.findByPlaceholderText("Search");
 
       expect(screen.queryByText("AZ")).toBeNull();
       expect(screen.queryByText("Facebook")).toBeNull();
     });
 
-    it("don't list any values if any is set to 'plain input box'", () => {
+    it("don't list any values if any is set to 'plain input box'", async () => {
       const fields = [
         mock(PEOPLE.SOURCE, { has_field_values: "none" }),
         mock(PEOPLE.STATE, { has_field_values: "list" }),
       ];
       renderFieldValuesWidget({ fields });
-      screen.getByPlaceholderText("Enter some text");
+      await screen.findByPlaceholderText("Enter some text");
 
       expect(screen.queryByText("AZ")).toBeNull();
       expect(screen.queryByText("Facebook")).toBeNull();

--- a/frontend/test/metabase/components/FieldValuesWidget.unit.spec.js
+++ b/frontend/test/metabase/components/FieldValuesWidget.unit.spec.js
@@ -14,6 +14,7 @@ const renderFieldValuesWidget = props =>
       value={[]}
       onChange={() => {}}
       fetchFieldValues={() => {}}
+      addRemappings={() => {}}
       {...props}
     />,
   );


### PR DESCRIPTION
Related to #22554 

In this PR I try to simplify how we fetch and handle options in the `FieldValuesWidget` component.

1. I've moved all field value fetching logic to the `fetchFieldValues` so that it behaves similarly to `fetchDashboardParamValues`.
2. I've combined `searchDebounced` with the `search` method. `onInputChange` --> `searchDebounced` --> `search` --> `_search` was a chain of functions that melted my brain too many times. Still needs some work, but this is a little better.
3. I've made `fetchFieldValues` set field values options in `this.state`, similar to how the dashboard endpoint does it, so that we can remove some unnecessarily complicated this-or-that logic when dealing with options for the widget.

There's still more to do here, but I hope you agree that this is an OK chunk of work to stop at.

The end-goal here is to make the UI code in `FieldValuesWidget` be more independent of where/how we retrieve values. This component shouldn't know anything about dashboards or parameters, but it has access to both right now. There will likely still need to be a field-coupled "values widget," but perhaps it will have an overridable "fetch" function. We'll see.

**Testing**
Do the following for dashboards and native questions:
1. Create a parameter mapped to a field that has the `has_field_values` property set to `"list"` (eg the Category field of the Products table). When you click to open the widget, the values of the field should be shown immediately.
2. Create a parameter mapped to a field that has the `has_field_values` property set to `"search"` (eg the Title field of the Products table). When you click to open the widget, the values of the field should NOT show immediately. Typing in the input should make the widget search for field values.
3. Create a parameter mapped to a field that has the `has_field_values` property set to `"none"`. The widget should not fetch or search for field values.

**Dashboard**

https://user-images.githubusercontent.com/13057258/170783695-925baeaf-baf2-4ca5-b30b-56df22970e75.mov

**Native Query Editor**

https://user-images.githubusercontent.com/13057258/170784401-fd01797a-019f-4641-bf74-aaeaa89a5e76.mov


