### PR TITLE
Stamp clj-kondo version for be-linter-clj-kondo

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Run clj-kondo
-      run: docker run -v $PWD:/work --rm cljkondo/clj-kondo clj-kondo --config /work/.clj-kondo/config.edn --config-dir /work/.clj-kondo --lint /work/src:/work/enterprise/backend/src:/work/shared/src
+      run: docker run -v $PWD:/work --rm cljkondo/clj-kondo:2022.04.25 clj-kondo --config /work/.clj-kondo/config.edn --config-dir /work/.clj-kondo --lint /work/src:/work/enterprise/backend/src:/work/shared/src
 
   be-linter-eastwood:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
For some reasons be-linter-clj-kondo is failing after their latest update: [v2022.05.27](https://github.com/clj-kondo/clj-kondo/releases/tag/v2022.05.27)

Temporarily switched to use [v2022.04.25](https://github.com/clj-kondo/clj-kondo/releases/tag/v2022.04.25) until we figure out why

example of a failed build: [link](https://github.com/metabase/metabase/runs/6625543320?check_suite_focus=true)