### PR TITLE
Add parameter_mappings to report_card

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/serialization/cmd_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/cmd_test.clj
@@ -70,6 +70,7 @@
           :creator_id             (u/the-id user)
           :visualization_settings "{}"
           :parameters             "[]"
+          :parameter_mappings     "[]"
           :created_at             :%now
           :updated_at             :%now)
         ;; serialize "everything" (which should just be the card and user), which should succeed if #16931 is fixed

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -11648,7 +11648,7 @@ databaseChangeLog:
               - column:
                   name: parameters
                   type: ${text.type}
-                  remarks: List of parameter associated to to a card
+                  remarks: List of parameter associated to a card
                   constraints:
                     nullable: true
                     deferrable: false
@@ -11675,7 +11675,7 @@ databaseChangeLog:
               - column:
                   name: parameter_mappings
                   type: ${text.type}
-                  remarks: List of parameter associated to to a card
+                  remarks: List of parameter associated to a card
                   constraints:
                     nullable: true
                     deferrable: false

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -11664,6 +11664,34 @@ databaseChangeLog:
             defaultNullValue: '[]'
             tableName: report_card
 
+  - changeSet:
+      id: v44.00-025
+      author: qnkhuat
+      comment: Added 0.44.0 - Add parameter_mappings to report_card
+      changes:
+        - addColumn:
+            tableName: report_card
+            columns:
+              - column:
+                  name: parameter_mappings
+                  type: ${text.type}
+                  remarks: List of parameter associated to to a card
+                  constraints:
+                    nullable: true
+                    deferrable: false
+                    initiallyDeferred: false
+  - changeSet:
+      id: v44.00-026
+      author: qnkhuat
+      comment: Added 0.44.0 - Add parameter_mappings to report_card
+      changes:
+        - addNotNullConstraint:
+            columnDataType: ${text.type}
+            columnName: parameter_mappings
+            defaultNullValue: '[]'
+            tableName: report_card
+
+
 
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -270,15 +270,16 @@
 (defn- create-card-async!
   "Create a new Card asynchronously. Returns a channel for fetching the newly created Card, or an Exception if one was
   thrown. Closing this channel before it finishes will cancel the Card creation."
-  [{:keys [dataset_query result_metadata dataset parameters], :as card-data}]
+  [{:keys [dataset_query result_metadata dataset parameters parameter_mappings], :as card-data}]
   ;; `zipmap` instead of `select-keys` because we want to get `nil` values for keys that aren't present. Required by
   ;; `api/maybe-reconcile-collection-position!`
   (let [data-keys            [:dataset_query :description :display :name :visualization_settings
-                              :parameters :collection_id :collection_position :cache_ttl]
+                              :parameters :parameter_mappings :collection_id :collection_position :cache_ttl]
         card-data            (assoc (zipmap data-keys (map card-data data-keys))
                                     :creator_id api/*current-user-id*
                                     :dataset (boolean (:dataset card-data))
-                                    :parameters (or parameters []))
+                                    :parameters (or parameters [])
+                                    :parameter_mappings (or parameter_mappings []))
         result-metadata-chan (result-metadata-async {:query dataset_query
                                                      :metadata result_metadata
                                                      :dataset? dataset})
@@ -299,9 +300,10 @@
 (api/defendpoint ^:returns-chan POST "/"
   "Create a new `Card`."
   [:as {{:keys [collection_id collection_position dataset_query description display name
-                parameters result_metadata visualization_settings cache_ttl], :as body} :body}]
+                parameters parameter_mappings result_metadata visualization_settings cache_ttl], :as body} :body}]
   {name                   su/NonBlankString
    parameters             (s/maybe [su/Parameter])
+   parameter_mappings     (s/maybe [su/ParameterMapping])
    description            (s/maybe su/NonBlankString)
    display                su/NonBlankString
    visualization_settings su/Map
@@ -504,7 +506,7 @@
         (u/select-keys-when card-updates
           :present #{:collection_id :collection_position :description :cache_ttl :dataset}
           :non-nil #{:dataset_query :display :name :visualization_settings :archived :enable_embedding
-                     :parameters :embedding_params :result_metadata})))
+                     :parameters :parameter_mappings :embedding_params :result_metadata})))
     ;; Fetch the updated Card from the DB
     (let [card (Card id)]
       (delete-alerts-if-needed! card-before-update card)

--- a/src/metabase/models/params.clj
+++ b/src/metabase/models/params.clj
@@ -25,6 +25,13 @@
     (throw (ex-info (tru ":parameters must be a sequence of maps with String :id key")
                     {:parameters parameters}))))
 
+(defn assert-valid-parameter-mappings
+  "Receive a Paremeterized Object and check if its parameters is valid."
+  [{:keys [parameter_mappings]}]
+  (when (s/check (s/maybe [su/ParameterMapping]) parameter_mappings)
+    (throw (ex-info (tru ":parameter_mappings must be a sequence of maps with String :parameter_id key")
+                    {:parameter_mappings parameter_mappings}))))
+
 (s/defn unwrap-field-clause :- mbql.s/field
   "Unwrap something that contains a `:field` clause, such as a template tag, Also handles unwrapped integers for
   legacy compatibility.

--- a/src/metabase/util/schema.clj
+++ b/src/metabase/util/schema.clj
@@ -333,6 +333,12 @@
                            s/Keyword s/Any}
     (deferred-tru "parameter must be a map with String :id key")))
 
+(def ParameterMapping
+  "Schema for a valid Parameter Mapping"
+  (with-api-error-message {:parameter_id       NonBlankString
+                           s/Keyword s/Any}
+    (deferred-tru "parameter mapping must be a String :parameter_id key")))
+
 (def EmbeddingParams
   "Schema for a valid map of embedding params."
   (with-api-error-message (s/maybe {s/Keyword (s/enum "disabled" "enabled" "locked")})

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -812,7 +812,7 @@
                                              :target ["dimension" ["template-tags" "category"]]}]}
                       (mt/user-http-request :rasta :put 202 (str "card/" (u/the-id card))
                                             {:parameters nil}))))
-      (testing "a non empty list will remove parameter_mappings"
+      (testing "an empty list will remove parameter_mappings"
         (is (partial= {:parameter_mappings []}
                       (mt/user-http-request :rasta :put 202 (str "card/" (u/the-id card))
                                             {:parameter_mappings []})))))))

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -598,3 +598,28 @@
                                              :collection_id          nil})]
        (migrate!)
        (is (= [] (:parameters (first (db/simple-select Card {:where [:= :id card-id]})))))))))
+
+(deftest add-parameter-mappings-to-cards-test
+  (testing "Migration v44.00-024: Add parameter_mappings to cards"
+    (impl/test-migrations ["v44.00-024" "v44.00-026"] [migrate!]
+      (let [user-id
+            (db/simple-insert! User {:first_name  "Howard"
+                                     :last_name   "Hughes"
+                                     :email       "howard@aircraft.com"
+                                     :password    "superstrong"
+                                     :date_joined :%now})
+            database-id
+            (db/simple-insert! Database {:name "DB", :engine "h2", :created_at :%now, :updated_at :%now})
+            card-id
+            (db/simple-insert! Card {:name                   "My Saved Question"
+                                     :created_at             :%now
+                                     :updated_at             :%now
+                                     :creator_id             user-id
+                                     :display                "table"
+                                     :dataset_query          "{}"
+                                     :visualization_settings "{}"
+                                     :database_id            database-id
+                                     :collection_id          nil})]
+        (migrate!)
+        (is (= []
+               (:parameter_mappings (first (db/simple-select Card {:where [:= :id card-id]})))))))))

--- a/test/metabase/events/revision_test.clj
+++ b/test/metabase/events/revision_test.clj
@@ -32,6 +32,7 @@
    :made_public_by_id      nil
    :name                   (:name card)
    :parameters             []
+   :parameter_mappings     []
    :public_uuid            nil
    :cache_ttl              nil
    :query_type             :query

--- a/test/metabase/models/card_test.clj
+++ b/test/metabase/models/card_test.clj
@@ -314,7 +314,6 @@
              (db/update! Card id :parameters [{:id 100}])))
         (is (some? (db/update! Card id :parameters [{:id "new-valid-id"}])))))))
 
-
 (deftest normalize-parameters-test
   (testing ":parameters should get normalized when coming out of the DB"
     (doseq [[target expected] {[:dimension [:field-id 1000]] [:dimension [:field 1000 nil]]

--- a/test/metabase/models/card_test.clj
+++ b/test/metabase/models/card_test.clj
@@ -312,8 +312,8 @@
              clojure.lang.ExceptionInfo
              #":parameters must be a sequence of maps with String :id key"
              (db/update! Card id :parameters [{:id 100}])))
-
         (is (some? (db/update! Card id :parameters [{:id "new-valid-id"}])))))))
+
 
 (deftest normalize-parameters-test
   (testing ":parameters should get normalized when coming out of the DB"
@@ -331,3 +331,33 @@
                    :type   :category
                    :target expected}]
                  (db/select-one-field :parameters Card :id card-id))))))))
+
+(deftest validate-parameter-mappings-test
+  (testing "Should validate Card :parameter_mappings when"
+    (testing "creating"
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #":parameter_mappings must be a sequence of maps with String :parameter_id key"
+           (mt/with-temp Card [_ {:parameter_mappings {:a :b}}])))
+
+     (mt/with-temp Card [card {:parameter_mappings [{:parameter_id "valid-id"}]}]
+       (is (some? card))))
+
+    (testing "updating"
+      (mt/with-temp Card [{:keys [id]} {:parameter_mappings []}]
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #":parameter_mappings must be a sequence of maps with String :parameter_id key"
+             (db/update! Card id :parameter_mappings [{:parameter_id 100}])))
+
+        (is (some? (db/update! Card id :parameter_mappings [{:parameter_id "new-valid-id"}])))))))
+
+(deftest normalize-parameter-mappings-test
+  (testing ":parameter_mappings should get normalized when coming out of the DB"
+    (mt/with-temp Card [{card-id :id} {:parameter_mappings [{:parameter_id "22486e00"
+                                                             :card_id      1
+                                                             :target       [:dimension [:field-id 1]]}]}]
+      (is (= [{:parameter_id "22486e00",
+               :card_id      1,
+               :target       [:dimension [:field 1 nil]]}]
+             (db/select-one-field :parameter_mappings Card :id card-id))))))


### PR DESCRIPTION
Pursuant of #22976, This PR adds `parameter_mappings` to report_card
With this:
- POST /api/card and PUT /api/card/:id will accept a new parameter_mappings param
- Any APIs that return a card now will have a new parameter_mappings keys

Closes #23000