### PR TITLE
Adjust JWT and SAML fetch-and-update user to save new attributes

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/enhancements/integrations/ldap.clj
+++ b/enterprise/backend/src/metabase_enterprise/enhancements/integrations/ldap.clj
@@ -9,7 +9,7 @@
             [metabase.models.user :as user :refer [User]]
             [metabase.public-settings.premium-features :as premium-features :refer [defenterprise-schema]]
             [metabase.util :as u]
-            [metabase.util.i18n :refer [deferred-tru tru trs]]
+            [metabase.util.i18n :refer [deferred-tru trs tru]]
             [metabase.util.schema :as su]
             [schema.core :as s])
   (:import com.unboundid.ldap.sdk.LDAPConnectionPool))

--- a/enterprise/backend/src/metabase_enterprise/enhancements/integrations/ldap.clj
+++ b/enterprise/backend/src/metabase_enterprise/enhancements/integrations/ldap.clj
@@ -1,16 +1,17 @@
 (ns metabase-enterprise.enhancements.integrations.ldap
   "The Enterprise version of the LDAP integration is basically the same but also supports syncing user attributes."
-  (:require [metabase.integrations.common :as integrations.common]
+  (:require [metabase-enterprise.sso.integrations.sso-utils :as sso-utils]
+            [metabase.integrations.common :as integrations.common]
+            [metabase.integrations.ldap :as ldap]
             [metabase.integrations.ldap.default-implementation :as default-impl]
             [metabase.integrations.ldap.interface :as i]
             [metabase.models.setting :as setting :refer [defsetting]]
             [metabase.models.user :as user :refer [User]]
             [metabase.public-settings.premium-features :as premium-features :refer [defenterprise-schema]]
             [metabase.util :as u]
-            [metabase.util.i18n :refer [deferred-tru trs]]
+            [metabase.util.i18n :refer [deferred-tru tru trs]]
             [metabase.util.schema :as su]
-            [schema.core :as s]
-            [toucan.db :as db])
+            [schema.core :as s])
   (:import com.unboundid.ldap.sdk.LDAPConnectionPool))
 
 (def ^:private EEUserInfo
@@ -35,27 +36,19 @@
   (when (ldap-sync-user-attributes)
     (apply dissoc m :objectclass (map (comp keyword u/lower-case-en) (ldap-sync-user-attributes-blacklist)))))
 
-(defn- attribute-synced-user
-  [{:keys [attributes first-name last-name email]}]
-  (when-let [user (db/select-one [User :id :last_login :first_name :last_name :login_attributes :is_active]
-                                 :%lower.email (u/lower-case-en email))]
-            (let [syncable-attributes (syncable-user-attributes attributes)
-                  old-first-name (:first_name user)
-                  old-last-name (:last_name user)
-                  new-first-name (default-impl/updated-name-part first-name old-first-name)
-                  new-last-name (default-impl/updated-name-part last-name old-last-name)
-                  user-changes (merge
-                                (when-not (= syncable-attributes (:login_attributes user))
-                                          {:login_attributes syncable-attributes})
-                                (when-not (= new-first-name old-first-name)
-                                          {:first_name new-first-name})
-                                (when-not (= new-last-name old-last-name)
-                                          {:last_name new-last-name}))]
-              (if (seq user-changes)
-                (do
-                  (db/update! User (:id user) user-changes)
-                  (db/select-one [User :id :last_login :is_active] :id (:id user))) ; Reload updated user
-                user))))
+(defn fetch-or-create-user*!
+  "Returns a session map for the given `email`. Will create the user if needed."
+  [first-name last-name email user-attributes]
+  (when-not (ldap/ldap-configured?)
+    (throw (IllegalArgumentException. (str (tru "Can't create new LDAP user when LDAP is not configured")))))
+  (let [user {:first_name       first-name
+              :last_name        last-name
+              :email            email
+              :login_attributes (syncable-user-attributes user-attributes)}]
+    (or (sso-utils/fetch-and-update-login-attributes! user) ; this fn is also used by JWT/SAML
+        (user/create-new-ldap-auth-user! (merge user
+                                                (when-not first-name {:first_name (trs "Unknown")})
+                                                (when-not last-name {:last_name (trs "Unknown")}))))))
 
 (defenterprise-schema find-user :- (s/maybe EEUserInfo)
   "Get user information for the supplied username."
@@ -76,12 +69,7 @@
   :feature :any
   [{:keys [first-name last-name email groups attributes], :as user-info} :- EEUserInfo
    {:keys [sync-groups?], :as settings}                                  :- i/LDAPSettings]
-  (let [user (or (attribute-synced-user user-info)
-                 (-> (user/create-new-ldap-auth-user! {:first_name       (or first-name (trs "Unknown"))
-                                                       :last_name        (or last-name (trs "Unknown"))
-                                                       :email            email
-                                                       :login_attributes attributes})
-                     (assoc :is_active true)))]
+  (let [user (fetch-or-create-user*! first-name last-name email attributes)]
     (u/prog1 user
       (when sync-groups?
         (let [group-ids            (default-impl/ldap-groups->mb-group-ids groups settings)

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
@@ -19,12 +19,13 @@
   [first-name last-name email user-attributes]
   (when-not (sso-settings/jwt-configured?)
     (throw (IllegalArgumentException. (str (tru "Can't create new JWT user when JWT is not configured")))))
-  (or (sso-utils/fetch-and-update-login-attributes! email user-attributes)
-      (sso-utils/create-new-sso-user! {:first_name       first-name
-                                       :last_name        last-name
-                                       :email            email
-                                       :sso_source       "jwt"
-                                       :login_attributes user-attributes})))
+  (let [user {:first_name       first-name
+              :last_name        last-name
+              :email            email
+              :sso_source       "jwt"
+              :login_attributes user-attributes}]
+    (or (sso-utils/fetch-and-update-login-attributes! user)
+        (sso-utils/create-new-sso-user! user))))
 
 (def ^:private ^{:arglists '([])} jwt-attribute-email     (comp keyword sso-settings/jwt-attribute-email))
 (def ^:private ^{:arglists '([])} jwt-attribute-firstname (comp keyword sso-settings/jwt-attribute-firstname))

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
@@ -26,8 +26,8 @@
               :login_attributes user-attributes}]
     (or (sso-utils/fetch-and-update-login-attributes! user)
         (sso-utils/create-new-sso-user! (merge user
-                                               (when-not first-name {first-name (trs "Unknown")})
-                                               (when-not last-name {last-name (trs "Unknown")}))))))
+                                               (when-not first-name {:first_name (trs "Unknown")})
+                                               (when-not last-name {:last_name (trs "Unknown")}))))))
 
 (def ^:private ^{:arglists '([])} jwt-attribute-email     (comp keyword sso-settings/jwt-attribute-email))
 (def ^:private ^{:arglists '([])} jwt-attribute-firstname (comp keyword sso-settings/jwt-attribute-firstname))

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
@@ -25,7 +25,9 @@
               :sso_source       "jwt"
               :login_attributes user-attributes}]
     (or (sso-utils/fetch-and-update-login-attributes! user)
-        (sso-utils/create-new-sso-user! user))))
+        (sso-utils/create-new-sso-user! (merge user
+                                               (when-not first-name {first-name (trs "Unknown")})
+                                               (when-not last-name {last-name (trs "Unknown")}))))))
 
 (def ^:private ^{:arglists '([])} jwt-attribute-email     (comp keyword sso-settings/jwt-attribute-email))
 (def ^:private ^{:arglists '([])} jwt-attribute-firstname (comp keyword sso-settings/jwt-attribute-firstname))
@@ -81,8 +83,8 @@
                                            e))))
           login-attrs  (jwt-data->login-attributes jwt-data)
           email        (get jwt-data (jwt-attribute-email))
-          first-name   (get jwt-data (jwt-attribute-firstname) (trs "Unknown"))
-          last-name    (get jwt-data (jwt-attribute-lastname) (trs "Unknown"))
+          first-name   (get jwt-data (jwt-attribute-firstname))
+          last-name    (get jwt-data (jwt-attribute-lastname))
           user         (fetch-or-create-user! first-name last-name email login-attrs)
           session      (api.session/create-session! :sso user (request.u/device-info request))]
       (sync-groups! user jwt-data)

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
@@ -81,7 +81,9 @@
                   :sso_source       "saml"
                   :login_attributes user-attributes}]
     (when-let [user (or (sso-utils/fetch-and-update-login-attributes! new-user)
-                        (sso-utils/create-new-sso-user! new-user))]
+                        (sso-utils/create-new-sso-user! (merge new-user
+                                                               (when-not first-name {first-name (trs "Unknown")})
+                                                               (when-not last-name {last-name (trs "Unknown")}))))]
       (sync-groups! user group-names)
       (api.session/create-session! :sso user device-info))))
 

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
@@ -74,16 +74,16 @@
                               (sso-settings/saml-attribute-email))
                          " "
                          (tru "Please make sure your SAML IdP is properly configured."))
-             {:status-code 400, :user-attributes (keys user-attributes)})))
-  (when-let [user (or (sso-utils/fetch-and-update-login-attributes! email user-attributes)
-                      (sso-utils/create-new-sso-user! {:first_name       first-name
-                                                       :last_name        last-name
-                                                       :email            email
-                                                       :sso_source       "saml"
-                                                       :login_attributes user-attributes}))]
-    (sync-groups! user group-names)
-    (api.session/create-session! :sso user device-info)))
-
+                    {:status-code 400, :user-attributes (keys user-attributes)})))
+  (let [new-user {:first_name       first-name
+                  :last_name        last-name
+                  :email            email
+                  :sso_source       "saml"
+                  :login_attributes user-attributes}]
+    (when-let [user (or (sso-utils/fetch-and-update-login-attributes! new-user)
+                        (sso-utils/create-new-sso-user! new-user))]
+      (sync-groups! user group-names)
+      (api.session/create-session! :sso user device-info))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
@@ -82,8 +82,8 @@
                   :login_attributes user-attributes}]
     (when-let [user (or (sso-utils/fetch-and-update-login-attributes! new-user)
                         (sso-utils/create-new-sso-user! (merge new-user
-                                                               (when-not first-name {first-name (trs "Unknown")})
-                                                               (when-not last-name {last-name (trs "Unknown")}))))]
+                                                               (when-not first-name {:first_name (trs "Unknown")})
+                                                               (when-not last-name {:last_name (trs "Unknown")}))))]
       (sync-groups! user group-names)
       (api.session/create-session! :sso user device-info))))
 

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_utils.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_utils.clj
@@ -36,12 +36,12 @@
 
 (defn fetch-and-update-login-attributes!
   "Update the login attributes for the user at `email`. This call is a no-op if the login attributes are the same"
-  [email new-user-attributes]
-  (when-let [{:keys [id login_attributes] :as user} (db/select-one User :%lower.email (u/lower-case-en email))]
-    (if (= login_attributes new-user-attributes)
+  [{:keys [email] :as new-user-attributes}]
+  (when-let [{:keys [id] :as user} (db/select-one User :%lower.email (u/lower-case-en email))]
+    (if (= (select-keys user (keys new-user-attributes)) new-user-attributes)
       user
       (do
-        (db/update! User id :login_attributes new-user-attributes)
+        (apply db/update! (concat [User id] (apply concat new-user-attributes)))
         (User id)))))
 
 (defn check-sso-redirect

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
@@ -30,7 +30,7 @@
 (def ^:private default-jwt-secret   (crypto-random/hex 32))
 
 (deftest sso-prereqs-test
-  (testing "SSO requests fail if SAML hasn't been enabled"
+  (testing "SSO requests fail if JWT hasn't been enabled"
     (mt/with-temporary-setting-values [jwt-enabled false]
       (saml-test/with-valid-premium-features-token
         (is (= "SSO has not been enabled and/or configured"
@@ -41,16 +41,18 @@
           (is (= "SSO requires a valid token"
                  (saml-test/client :get 403 "/auth/sso")))))))
 
-  (testing "SSO requests fail if SAML is enabled but hasn't been configured"
+  (testing "SSO requests fail if JWT is enabled but hasn't been configured"
     (saml-test/with-valid-premium-features-token
-      (mt/with-temporary-setting-values [jwt-enabled true]
+      (mt/with-temporary-setting-values [jwt-enabled true
+                                         jwt-identity-provider-uri nil]
         (is (= "JWT SSO has not been enabled and/or configured"
                (saml-test/client :get 400 "/auth/sso"))))))
 
-  (testing "The IdP provider certificate must also be included for SSO to be configured"
+  (testing "The JWT Shared Secret must also be included for SSO to be configured"
     (saml-test/with-valid-premium-features-token
       (mt/with-temporary-setting-values [jwt-enabled               true
-                                         jwt-identity-provider-uri default-idp-uri]
+                                         jwt-identity-provider-uri default-idp-uri
+                                         jwt-shared-secret         nil]
         (is (= "JWT SSO has not been enabled and/or configured"
                (saml-test/client :get 400 "/auth/sso")))))))
 

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
@@ -127,8 +127,8 @@
   (try
     (f)
     (finally
-      (u/ignore-exceptions (db/update-where! User {} :login_attributes nil)
-                           (db/delete! User :first_name "Unknown")))))
+      (u/ignore-exceptions (do (db/update-where! User {} :login_attributes nil)
+                               (db/update-where! User {:email "rasta@metabase.com"} :first_name "Rasta" :last_name "Toucan"))))))
 
 (defmacro ^:private with-saml-default-setup [& body]
   `(with-valid-premium-features-token

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
@@ -5,6 +5,7 @@
             [metabase-enterprise.sso.integrations.sso-settings :as sso-settings]
             [metabase.config :as config]
             [metabase.http-client :as client]
+            [metabase.integrations.ldap :refer [ldap-enabled]]
             [metabase.models.permissions-group :refer [PermissionsGroup]]
             [metabase.models.permissions-group-membership :refer [PermissionsGroupMembership]]
             [metabase.models.user :refer [User]]

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
@@ -127,7 +127,8 @@
   (try
     (f)
     (finally
-      (u/ignore-exceptions (db/update-where! User {} :login_attributes nil)))))
+      (u/ignore-exceptions (db/update-where! User {} :login_attributes nil)
+                           (db/delete! User :first_name "Unknown")))))
 
 (defmacro ^:private with-saml-default-setup [& body]
   `(with-valid-premium-features-token
@@ -255,7 +256,7 @@
         (select-keys attribute-keys))))
 
 (deftest validate-request-id-test
-  (testing "Sample response shoudl fail because _1 isn't a request ID that we issued."
+  (testing "Sample response should fail because _1 isn't a request ID that we issued."
     (with-saml-default-setup
       (do-with-some-validators-disabled
         (fn []

--- a/test_resources/saml-test-response-new-user-no-names.xml
+++ b/test_resources/saml-test-response-new-user-no-names.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0"?>
+<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" ID="_6643ab567200fd4a5c73" InResponseTo="_1" Version="2.0" IssueInstant="2018-07-05T18:02:53Z" Destination="http://localhost:3000/auth/sso">
+  <saml:Issuer xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">urn:saml-metabase-test.auth0.com</saml:Issuer>
+  <samlp:Status>
+    <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+  </samlp:Status>
+  <saml:Assertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Version="2.0" ID="_vUq3VKutPOwCGartAC4Cbdmql23G3PE2" IssueInstant="2018-07-05T18:02:53.262Z">
+    <saml:Issuer>urn:saml-metabase-test.auth0.com</saml:Issuer>
+    <Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
+      <SignedInfo>
+        <CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+        <SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>
+        <Reference URI="#_vUq3VKutPOwCGartAC4Cbdmql23G3PE2">
+          <Transforms>
+            <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+            <Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+          </Transforms>
+          <DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
+          <DigestValue>4SH+6iSi9cU3PCPqmJDnP6iK+BY=</DigestValue>
+        </Reference>
+      </SignedInfo>
+      <SignatureValue>Dvfajt2ZBDHmHGl0yLETE1trkR99Bv+kVbgVtqNTRBeeb2oUShBY9EQJKmFtdReuamqr1Tn3kjaxZefxpd1XzB4dzsWNKF0duThKP5YTg5njM3PBsN/yXFAIrIHTjedHEOdwuDgPm+endqEtaFm8yQkn0VhYGK86udpPsMvxwPbYdy2eCAWuHXpNFynfWSRJz7rckubIGvXm7Lar/bMbMYiJa5u+wVqmeH53IddjIEQOeZLsQfPyNeZolWGqBv0TzpM/yEejDjQnnj55fMFXpGS3lKJ02vArYLdgtjW2isgB8/m5dY0gjFob0k9ioy+nghdH/rDKFIvqS/Jb8A50zg==</SignatureValue>
+      <KeyInfo>
+        <X509Data>
+          <X509Certificate>MIIDEzCCAfugAwIBAgIJYpjQiNMYxf1GMA0GCSqGSIb3DQEBCwUAMCcxJTAjBgNVBAMTHHNhbWwtbWV0YWJhc2UtdGVzdC5hdXRoMC5jb20wHhcNMTgwNTI5MjEwMDIzWhcNMzIwMjA1MjEwMDIzWjAnMSUwIwYDVQQDExxzYW1sLW1ldGFiYXNlLXRlc3QuYXV0aDAuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzNcrpju4sILZQNe1adwg3beXtAMFGB+Buuc414+FDv2OG7X7b9OSYar/nsYfWwiazZRxEGriagd0Sj5mJ4Qqx+zmB/r4UgX3q/KgocRLlShvvz5gTD99hR7LonDPSWET1E9PD4XE1fRaq+BwftFBl45pKTcCR9QrUAFZJ2R/3g06NPZdhe4bg/lTssY5emCxaZpQEku/v+zzpV2nLF4by0vSj7AHsubrsLgsCfV3JvJyTxCyo1aIOlv4Vrx7h9rOgl9eEmoU5XJAl3D7DuvSTEOy7MyDnKF17m7l5nOPZCVOSzmCWvxSCyysijgsM5DSgAE8DPJyoYezV3gTX2OO2QIDAQABo0IwQDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBSpB3lvrtbSDuXkB6fhbjeUpFmL2DAOBgNVHQ8BAf8EBAMCAoQwDQYJKoZIhvcNAQELBQADggEBAAEHGIAhR5GPD2JxgLtpNtZMCYiAM4Gr7hoTQMaKiXgVtdQu4iMFfbpEwIr6UVaDU2HKhvSRFIilOjRGmCGrIzvJgR2l+RL1Z3KrZypI1AXKJT5pF5g5FitBsZq+kiUpdRILl2hICzw9Q1M2Le+JSUcHcbHTVgF24xuzOZonxeE56Oc26Ju4CorLpM3Nb5iYaGOlQ+48/GP82cLxlVyi02va8tp7KP03ePSaZeBEKGpFtBtEN/dC3NKO1mmrT9284H0tvete6KLUH+dsS6bDEYGHZM5KGoSLWRr3qYlCB3AmAw+KvuiuSczLg9oYBkdxlhK9zZvkjCgaLCen+0aY67A=</X509Certificate>
+        </X509Data>
+      </KeyInfo>
+    </Signature>
+    <saml:Subject>
+      <saml:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">auth0|5b0dd0185d7d1617fd8065b5</saml:NameID>
+      <saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+        <saml:SubjectConfirmationData NotOnOrAfter="2018-07-05T19:02:53.262Z" Recipient="http://localhost:3000/auth/sso" InResponseTo="_1"/>
+      </saml:SubjectConfirmation>
+    </saml:Subject>
+    <saml:Conditions NotBefore="2018-07-05T18:02:53.262Z" NotOnOrAfter="2018-07-05T19:02:53.262Z">
+      <saml:AudienceRestriction>
+        <saml:Audience>Metabase</saml:Audience>
+      </saml:AudienceRestriction>
+    </saml:Conditions>
+    <saml:AuthnStatement AuthnInstant="2018-07-05T18:02:53.262Z" SessionIndex="_8vKjURdHz4jghbYbj48khvBkLaEeyEqc">
+      <saml:AuthnContext>
+        <saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:unspecified</saml:AuthnContextClassRef>
+      </saml:AuthnContext>
+    </saml:AuthnStatement>
+    <saml:AttributeStatement xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <saml:Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+        <saml:AttributeValue xsi:type="xs:string">auth0|5b0dd0185d7d1617fd8065b5</saml:AttributeValue>
+      </saml:Attribute>
+      <saml:Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+        <saml:AttributeValue xsi:type="xs:string">newuser@metabase.com</saml:AttributeValue>
+      </saml:Attribute>
+      <saml:Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+        <saml:AttributeValue xsi:type="xs:string">newuser@metabase.com</saml:AttributeValue>
+      </saml:Attribute>
+      <saml:Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+        <saml:AttributeValue xsi:type="xs:string">newuser@metabase.com</saml:AttributeValue>
+      </saml:Attribute>
+      <saml:Attribute Name="http://schemas.auth0.com/identities/default/provider" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+        <saml:AttributeValue xsi:type="xs:string">auth0</saml:AttributeValue>
+      </saml:Attribute>
+      <saml:Attribute Name="http://schemas.auth0.com/identities/default/connection" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+        <saml:AttributeValue xsi:type="xs:string">Username-Password-Authentication</saml:AttributeValue>
+      </saml:Attribute>
+      <saml:Attribute Name="http://schemas.auth0.com/identities/default/isSocial" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+        <saml:AttributeValue xsi:type="xs:boolean">false</saml:AttributeValue>
+      </saml:Attribute>
+      <saml:Attribute Name="http://schemas.auth0.com/email_verified" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+        <saml:AttributeValue xsi:type="xs:boolean">true</saml:AttributeValue>
+      </saml:Attribute>
+      <saml:Attribute Name="http://schemas.auth0.com/clientID" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+        <saml:AttributeValue xsi:type="xs:string">W1R5HozFA9cnbFVbmIT8KPdVmH0pU85k</saml:AttributeValue>
+      </saml:Attribute>
+      <saml:Attribute Name="http://schemas.auth0.com/picture" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+        <saml:AttributeValue xsi:type="xs:string">https://s.gravatar.com/avatar/9e18d6fcddec348d9131522c3c535646?s=480&amp;r=pg&amp;d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fry.png</saml:AttributeValue>
+      </saml:Attribute>
+      <saml:Attribute Name="http://schemas.auth0.com/nickname" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+        <saml:AttributeValue xsi:type="xs:string">newuser</saml:AttributeValue>
+      </saml:Attribute>
+      <saml:Attribute Name="http://schemas.auth0.com/updated_at" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+        <saml:AttributeValue xsi:type="xs:anyType">Thu Jul 05 2018 18:02:53 GMT+0000 (UTC)</saml:AttributeValue>
+      </saml:Attribute>
+      <saml:Attribute Name="http://schemas.auth0.com/created_at" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+        <saml:AttributeValue xsi:type="xs:anyType">Tue May 29 2018 22:11:36 GMT+0000 (UTC)</saml:AttributeValue>
+      </saml:Attribute>
+    </saml:AttributeStatement>
+  </saml:Assertion>
+</samlp:Response>


### PR DESCRIPTION
Related: #22754
Fixes: #15484

Before this change, JWT/SAML logins would attempt to update attributes, but never considered the first-name or last-name attributes, so they would never be updated, even if the identity provider sends the correct keys.

Now, `:first_name` and `:last_name` attributes are properly considered when calling `sso-utils/fetch-and-update-login-attributes!` which will:

- return the User unchanged if the IdP keys/vals are equal to those in the app-db
- return the User unchanged if the IdP is missing first/last name attributes (first/last name are required by the app-db, so will already exist either as "Unknown" or some previously established value)
- update the User attributes (including `:first_name` and `:last_name`) in the app-db if the IdP attributes do NOT match.

In other words, the IdP values will take precedence over Metabase's app-db values, which was already true before this PR except, of course, for first/last name attributes.