### PR TITLE
Docs: avoid redirection, go straight to /start

### DIFF
--- a/docs/developers-guide-drivers.md
+++ b/docs/developers-guide-drivers.md
@@ -70,7 +70,7 @@ If you don't see a driver for your database, then try looking in the comments of
 
 If you are having problems installing or using a community driver, your best bet is to contact the author of the driver.
 
-[Metabase Cloud](https://www.metabase.com/start/hosted/) doesn't support community drivers, meaning that (for now) you can only use Metabase Cloud with the [officially supported drivers](./administration-guide/01-managing-databases.md#officially-supported-databases), and the partner drivers listed above.
+[Metabase Cloud](https://www.metabase.com/start/) doesn't support community drivers, meaning that (for now) you can only use Metabase Cloud with the [officially supported drivers](./administration-guide/01-managing-databases.md#officially-supported-databases), and the partner drivers listed above.
 
 ## Write your own driver
 

--- a/docs/operations-guide/installing-metabase.md
+++ b/docs/operations-guide/installing-metabase.md
@@ -12,9 +12,9 @@ The simplest and most basic way of running Metabase.
 
 If you prefer to use a Docker container, we've got you covered.
 
-## [Metabase Cloud](/start/hosted/)
+## [Metabase Cloud](/start/)
 
-Our official hosted version, [Metabase Cloud](/start/hosted/). All you need to do is sign up for a free trial, and you're off to the races.
+Our official hosted version, [Metabase Cloud](/start/). All you need to do is sign up for a free trial, and you're off to the races.
 
 ## [Building Metabase from source](../developers-guide/start.md)
 

--- a/docs/operations-guide/running-metabase-on-elastic-beanstalk.md
+++ b/docs/operations-guide/running-metabase-on-elastic-beanstalk.md
@@ -29,7 +29,7 @@ This quick launch setup is intended for testing purposes only, and is not intend
 - a load balancer (to make this deployment future proof and also provide features like HTTPS or Web Application Firewall security features)
 If you want to see a high-level architectural diagram of what you will achieve once you follow this guide, [click here](images/Metabase-AWS-H2.png).
 
-If you would like a reliable, scalable and fully managed Metabase, please consider [Metabase Cloud](https://www.metabase.com/start/hosted/).
+If you would like a reliable, scalable and fully managed Metabase, please consider [Metabase Cloud](https://www.metabase.com/start/).
 
 ## Quick Launch
 


### PR DESCRIPTION
`metabase.com/start/hosted` is already permanently moved (HTTP 301) to `metabase.com/start`
