### PR TITLE
[E2E] Run OSS-specific tests on PR

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 25
     strategy:
       matrix:
-        edition: [ee]
+        edition: [oss, ee]
     env:
       MB_EDITION: ${{ matrix.edition }}
       INTERACTIVE: false
@@ -67,6 +67,9 @@ jobs:
           - "embedding"
           - "joins"
           - "models"
+        include:
+          - edition: oss
+            java-version: 11
     services:
       maildev:
         image: maildev/maildev:1.1.0
@@ -120,7 +123,17 @@ jobs:
         jar xf target/uberjar/metabase.jar version.properties
         mv version.properties resources/
 
-    - name: Run Cypress tests on ${{ matrix.folder }}
+    - name: Run OSS-specific Cypress tests
+      if: matrix.edition == 'oss'
+      run: |
+        yarn run test-cypress-run \
+        --env grepTags=@OSS,grepOmitFiltered=true \
+        --spec './frontend/test/metabase/scenarios/**/*.cy.spec.js'
+      env:
+        TERM: xterm
+
+    - name: Run EE Cypress tests on ${{ matrix.folder }}
+      if: matrix.edition == 'ee'
       run: yarn run test-cypress-run --folder ${{ matrix.folder }}
       env:
         TERM: xterm

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -127,7 +127,7 @@ jobs:
       if: matrix.edition == 'oss'
       run: |
         yarn run test-cypress-run \
-        --env grepTags=@OSS,grepOmitFiltered=true \
+        --env grepTags=@OSS,grepFilterSpecs=true \
         --spec './frontend/test/metabase/scenarios/**/*.cy.spec.js'
       env:
         TERM: xterm

--- a/frontend/test/metabase/scenarios/admin/databases/list.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/list.cy.spec.js
@@ -6,7 +6,7 @@ describe("scenarios > admin > databases > list", () => {
     cy.signInAsAdmin();
   });
 
-  describeOSS("OSS", () => {
+  describeOSS("OSS", { tags: "@OSS" }, () => {
     it("should not display error messages upon a failed `GET` (metabase#20471)", () => {
       const errorMessage = "Lorem ipsum dolor sit amet, consectetur adip";
 

--- a/frontend/test/metabase/scenarios/admin/databases/list.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/list.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, describeEE, describeOSS } from "__support__/e2e/cypress";
+import { restore, describeEE, isOSS } from "__support__/e2e/cypress";
 
 describe("scenarios > admin > databases > list", () => {
   beforeEach(() => {
@@ -6,8 +6,10 @@ describe("scenarios > admin > databases > list", () => {
     cy.signInAsAdmin();
   });
 
-  describeOSS("OSS", { tags: "@OSS" }, () => {
+  describe("OSS", { tags: "@OSS" }, () => {
     it("should not display error messages upon a failed `GET` (metabase#20471)", () => {
+      cy.onlyOn(isOSS);
+
       const errorMessage = "Lorem ipsum dolor sit amet, consectetur adip";
 
       cy.intercept(

--- a/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
@@ -4,7 +4,6 @@ import {
   popover,
   describeEE,
   setupMetabaseCloud,
-  describeOSS,
   isOSS,
   isEE,
 } from "__support__/e2e/cypress";
@@ -302,8 +301,9 @@ describe("scenarios > admin > settings", () => {
   });
 });
 
-describeOSS("scenarios > admin > settings (OSS)", { tags: "@OSS" }, () => {
+describe("scenarios > admin > settings (OSS)", { tags: "@OSS" }, () => {
   beforeEach(() => {
+    cy.onlyOn(isOSS);
     restore();
     cy.signInAsAdmin();
   });

--- a/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
@@ -18,15 +18,19 @@ describe("scenarios > admin > settings", () => {
     cy.signInAsAdmin();
   });
 
-  it("should prompt admin to migrate to the hosted instance", () => {
-    cy.onlyOn(isOSS);
-    cy.visit("/admin/settings/setup");
-    cy.findByText("Have your server maintained for you.");
-    cy.findByText("Migrate to Metabase Cloud.");
-    cy.findAllByRole("link", { name: "Learn more" })
-      .should("have.attr", "href")
-      .and("include", "/migrate/");
-  });
+  it(
+    "should prompt admin to migrate to the hosted instance",
+    { tags: "@OSS" },
+    () => {
+      cy.onlyOn(isOSS);
+      cy.visit("/admin/settings/setup");
+      cy.findByText("Have your server maintained for you.");
+      cy.findByText("Migrate to Metabase Cloud.");
+      cy.findAllByRole("link", { name: "Learn more" })
+        .should("have.attr", "href")
+        .and("include", "/migrate/");
+    },
+  );
 
   it("should surface an error when validation for any field fails (metabase#4506)", () => {
     const BASE_URL = Cypress.config().baseUrl;
@@ -246,18 +250,22 @@ describe("scenarios > admin > settings", () => {
     cy.findByText(/Site URL/i);
   });
 
-  it("should display the order of the settings items consistently between OSS/EE versions (metabase#15441)", () => {
-    const lastItem = isEE ? "Appearance" : "Caching";
+  it(
+    "should display the order of the settings items consistently between OSS/EE versions (metabase#15441)",
+    { tags: "@OSS" },
+    () => {
+      const lastItem = isEE ? "Appearance" : "Caching";
 
-    cy.visit("/admin/settings/setup");
-    cy.get(".AdminList .AdminList-item")
-      .as("settingsOptions")
-      .first()
-      .contains("Setup");
-    cy.get("@settingsOptions")
-      .last()
-      .contains(lastItem);
-  });
+      cy.visit("/admin/settings/setup");
+      cy.get(".AdminList .AdminList-item")
+        .as("settingsOptions")
+        .first()
+        .contains("Setup");
+      cy.get("@settingsOptions")
+        .last()
+        .contains(lastItem);
+    },
+  );
 
   // Unskip when mocking Cloud in Cypress is fixed (#18289)
   it.skip("should hide self-hosted settings when running Metabase Cloud", () => {
@@ -294,7 +302,7 @@ describe("scenarios > admin > settings", () => {
   });
 });
 
-describeOSS("scenarios > admin > settings (OSS)", () => {
+describeOSS("scenarios > admin > settings (OSS)", { tags: "@OSS" }, () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();

--- a/frontend/test/metabase/scenarios/admin/troubleshooting/help.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/troubleshooting/help.cy.spec.js
@@ -21,25 +21,29 @@ describe("scenarios > admin > troubleshooting > help", () => {
   });
 });
 
-describeOSS("scenarios > admin > troubleshooting > help", () => {
-  beforeEach(() => {
-    restore();
-    cy.signInAsAdmin();
-  });
+describeOSS(
+  "scenarios > admin > troubleshooting > help",
+  { tags: "@OSS" },
+  () => {
+    beforeEach(() => {
+      restore();
+      cy.signInAsAdmin();
+    });
 
-  it("should link `Get Help` to help", () => {
-    cy.visit("/admin/troubleshooting/help");
+    it("should link `Get Help` to help", () => {
+      cy.visit("/admin/troubleshooting/help");
 
-    cy.findByText("Metabase Admin");
-    cy.findByText("Get Help")
-      .parents("a")
-      .should("have.prop", "href")
-      .and(
-        "match",
-        /^https:\/\/www\.metabase\.com\/help\?utm_source=in-product&utm_medium=troubleshooting&utm_campaign=help&instance_version=v(?:(?!diag=).)+$/,
-      );
-  });
-});
+      cy.findByText("Metabase Admin");
+      cy.findByText("Get Help")
+        .parents("a")
+        .should("have.prop", "href")
+        .and(
+          "match",
+          /^https:\/\/www\.metabase\.com\/help\?utm_source=in-product&utm_medium=troubleshooting&utm_campaign=help&instance_version=v(?:(?!diag=).)+$/,
+        );
+    });
+  },
+);
 
 describeEE("scenarios > admin > troubleshooting > help (EE)", () => {
   beforeEach(() => {

--- a/frontend/test/metabase/scenarios/admin/troubleshooting/help.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/troubleshooting/help.cy.spec.js
@@ -1,5 +1,5 @@
 import {
-  describeOSS,
+  isOSS,
   describeEE,
   restore,
   setupMetabaseCloud,
@@ -21,29 +21,27 @@ describe("scenarios > admin > troubleshooting > help", () => {
   });
 });
 
-describeOSS(
-  "scenarios > admin > troubleshooting > help",
-  { tags: "@OSS" },
-  () => {
-    beforeEach(() => {
-      restore();
-      cy.signInAsAdmin();
-    });
+describe("scenarios > admin > troubleshooting > help", { tags: "@OSS" }, () => {
+  beforeEach(() => {
+    cy.onlyOn(isOSS);
 
-    it("should link `Get Help` to help", () => {
-      cy.visit("/admin/troubleshooting/help");
+    restore();
+    cy.signInAsAdmin();
+  });
 
-      cy.findByText("Metabase Admin");
-      cy.findByText("Get Help")
-        .parents("a")
-        .should("have.prop", "href")
-        .and(
-          "match",
-          /^https:\/\/www\.metabase\.com\/help\?utm_source=in-product&utm_medium=troubleshooting&utm_campaign=help&instance_version=v(?:(?!diag=).)+$/,
-        );
-    });
-  },
-);
+  it("should link `Get Help` to help", () => {
+    cy.visit("/admin/troubleshooting/help");
+
+    cy.findByText("Metabase Admin");
+    cy.findByText("Get Help")
+      .parents("a")
+      .should("have.prop", "href")
+      .and(
+        "match",
+        /^https:\/\/www\.metabase\.com\/help\?utm_source=in-product&utm_medium=troubleshooting&utm_campaign=help&instance_version=v(?:(?!diag=).)+$/,
+      );
+  });
+});
 
 describeEE("scenarios > admin > troubleshooting > help (EE)", () => {
   beforeEach(() => {

--- a/frontend/test/metabase/scenarios/embedding/embedding-premium-token.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/embedding-premium-token.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, describeOSS } from "__support__/e2e/cypress";
+import { restore, isOSS } from "__support__/e2e/cypress";
 
 const embeddingPage = "/admin/settings/embedding_in_other_applications";
 const licensePage = "/admin/settings/premium-embedding-license";
@@ -13,11 +13,13 @@ const invalidTokenMessage =
 const discountedWarning =
   "Our Premium Embedding product has been discontinued, but if you already have a license you can activate it here. You’ll continue to receive support for the duration of your license.";
 
-describeOSS(
+describe(
   "scenarios > embedding > premium embedding token",
   { tags: "@OSS" },
   () => {
     beforeEach(() => {
+      cy.onlyOn(isOSS);
+
       restore();
       cy.signInAsAdmin();
     });

--- a/frontend/test/metabase/scenarios/embedding/embedding-premium-token.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/embedding-premium-token.cy.spec.js
@@ -13,92 +13,98 @@ const invalidTokenMessage =
 const discountedWarning =
   "Our Premium Embedding product has been discontinued, but if you already have a license you can activate it here. You’ll continue to receive support for the duration of your license.";
 
-describeOSS("scenarios > embedding > premium embedding token", () => {
-  beforeEach(() => {
-    restore();
-    cy.signInAsAdmin();
-  });
+describeOSS(
+  "scenarios > embedding > premium embedding token",
+  { tags: "@OSS" },
+  () => {
+    beforeEach(() => {
+      restore();
+      cy.signInAsAdmin();
+    });
 
-  it("should validate a premium embedding token", () => {
-    cy.intercept("PUT", "/api/setting/premium-embedding-token").as(
-      "saveEmbeddingToken",
-    );
+    it("should validate a premium embedding token", () => {
+      cy.intercept("PUT", "/api/setting/premium-embedding-token").as(
+        "saveEmbeddingToken",
+      );
 
-    cy.visit(embeddingPage);
+      cy.visit(embeddingPage);
 
-    cy.contains("Have a Premium Embedding license?");
-    cy.contains("Activate it here.").click();
+      cy.contains("Have a Premium Embedding license?");
+      cy.contains("Activate it here.").click();
 
-    cy.location("pathname").should("eq", licensePage);
+      cy.location("pathname").should("eq", licensePage);
 
-    cy.findByRole("heading")
-      .invoke("text")
-      .should("eq", "Premium embedding");
+      cy.findByRole("heading")
+        .invoke("text")
+        .should("eq", "Premium embedding");
 
-    cy.findByText(discountedWarning);
+      cy.findByText(discountedWarning);
 
-    cy.findByText("Enter the token you bought from the Metabase Store below.");
+      cy.findByText(
+        "Enter the token you bought from the Metabase Store below.",
+      );
 
-    cy.findByTestId("license-input")
-      .as("tokenInput")
-      .should("be.empty");
+      cy.findByTestId("license-input")
+        .as("tokenInput")
+        .should("be.empty");
 
-    // 1. Try an invalid token format
-    cy.get("@tokenInput").type("Hi");
-    cy.button("Activate").click();
+      // 1. Try an invalid token format
+      cy.get("@tokenInput").type("Hi");
+      cy.button("Activate").click();
 
-    cy.wait("@saveEmbeddingToken").then(({ response: { body } }) => {
-      expect(body.cause).to.eq("Token format is invalid.");
-      expect(body["error-details"]).to.eq(
-        "Token should be 64 hexadecimal characters.",
+      cy.wait("@saveEmbeddingToken").then(({ response: { body } }) => {
+        expect(body.cause).to.eq("Token format is invalid.");
+        expect(body["error-details"]).to.eq(
+          "Token should be 64 hexadecimal characters.",
+        );
+      });
+
+      cy.findByText(invalidTokenMessage);
+
+      // 2. Try a valid format, but an invalid token
+      cy.get("@tokenInput")
+        .clear()
+        .type(embeddingToken);
+      cy.button("Activate").click();
+
+      cy.wait("@saveEmbeddingToken").then(({ response: { body } }) => {
+        expect(body.cause).to.eq("Token does not exist.");
+        expect(body["error-details"]).to.be.null;
+      });
+
+      cy.findByText(invalidTokenMessage);
+
+      // 3. Try submitting an empty value
+      //    Although this might sound counterintuitive, the goal is to provide a mechanism to reset a token.
+      cy.get("@tokenInput").clear();
+      cy.button("Activate").click();
+
+      cy.wait("@saveEmbeddingToken").then(({ response: { body } }) => {
+        expect(body).to.eq("");
+      });
+
+      cy.findByText(invalidTokenMessage).should("not.exist");
+    });
+
+    it("should be able to set a premium embedding token", () => {
+      stubTokenResponses();
+
+      cy.visit(licensePage);
+
+      cy.findByTestId("license-input").type(embeddingToken);
+      cy.button("Activate").click();
+
+      cy.wait("@saveEmbeddingToken").then(({ response }) => {
+        expect(response.body).to.eq(embeddingToken);
+      });
+
+      cy.wait("@getSettings");
+      cy.findByText(
+        /Your Premium Embedding license is active until Dec 3(0|1), 2122\./,
       );
     });
-
-    cy.findByText(invalidTokenMessage);
-
-    // 2. Try a valid format, but an invalid token
-    cy.get("@tokenInput")
-      .clear()
-      .type(embeddingToken);
-    cy.button("Activate").click();
-
-    cy.wait("@saveEmbeddingToken").then(({ response: { body } }) => {
-      expect(body.cause).to.eq("Token does not exist.");
-      expect(body["error-details"]).to.be.null;
-    });
-
-    cy.findByText(invalidTokenMessage);
-
-    // 3. Try submitting an empty value
-    //    Although this might sound counterintuitive, the goal is to provide a mechanism to reset a token.
-    cy.get("@tokenInput").clear();
-    cy.button("Activate").click();
-
-    cy.wait("@saveEmbeddingToken").then(({ response: { body } }) => {
-      expect(body).to.eq("");
-    });
-
-    cy.findByText(invalidTokenMessage).should("not.exist");
-  });
-
-  it("should be able to set a premium embedding token", () => {
-    stubTokenResponses();
-
-    cy.visit(licensePage);
-
-    cy.findByTestId("license-input").type(embeddingToken);
-    cy.button("Activate").click();
-
-    cy.wait("@saveEmbeddingToken").then(({ response }) => {
-      expect(response.body).to.eq(embeddingToken);
-    });
-
-    cy.wait("@getSettings");
-    cy.findByText(
-      /Your Premium Embedding license is active until Dec 3(0|1), 2122\./,
-    );
-  });
-});
+  },
+);
 
 function stubTokenResponses() {
   cy.intercept("PUT", "/api/setting/premium-embedding-token", {

--- a/frontend/test/metabase/scenarios/embedding/embedding-smoketests.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/embedding-smoketests.cy.spec.js
@@ -26,7 +26,7 @@ describe("scenarios > embedding > smoke tests", () => {
       resetEmbedding();
     });
 
-    it("should display the embedding page correctly", () => {
+    it("should display the embedding page correctly", { tags: "@OSS" }, () => {
       cy.visit("/admin/settings/setup");
       cy.findByText("Embedding in other Applications").click();
 
@@ -99,7 +99,7 @@ describe("scenarios > embedding > smoke tests", () => {
     });
   });
 
-  context("embedding enabled", () => {
+  context("embedding enabled", { tags: "@OSS" }, () => {
     ["question", "dashboard"].forEach(object => {
       it(`should be able to publish/embed and then unpublish a ${object} without filters`, () => {
         const embeddableObject = object === "question" ? "card" : "dashboard";

--- a/frontend/test/metabase/scenarios/organization/moderation-collection.cy.spec.js
+++ b/frontend/test/metabase/scenarios/organization/moderation-collection.cy.spec.js
@@ -2,7 +2,7 @@ import {
   restore,
   modal,
   describeEE,
-  describeOSS,
+  isOSS,
   openNewCollectionItemFlowFor,
   appBar,
   navigationSidebar,
@@ -148,8 +148,10 @@ describeEE("collections types", () => {
   });
 });
 
-describeOSS("collection types", { tags: "@OSS" }, () => {
+describe("collection types", { tags: "@OSS" }, () => {
   beforeEach(() => {
+    cy.onlyOn(isOSS);
+
     restore();
     cy.signInAsAdmin();
   });

--- a/frontend/test/metabase/scenarios/organization/moderation-collection.cy.spec.js
+++ b/frontend/test/metabase/scenarios/organization/moderation-collection.cy.spec.js
@@ -148,7 +148,7 @@ describeEE("collections types", () => {
   });
 });
 
-describeOSS("collection types", () => {
+describeOSS("collection types", { tags: "@OSS" }, () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();

--- a/frontend/test/metabase/scenarios/permissions/admin-permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/admin-permissions.cy.spec.js
@@ -22,7 +22,7 @@ const COLLECTION_ACCESS_PERMISSION_INDEX = 0;
 const DATA_ACCESS_PERMISSION_INDEX = 0;
 const NATIVE_QUERIES_PERMISSION_INDEX = 1;
 
-describeOSS("scenarios > admin > permissions", () => {
+describeOSS("scenarios > admin > permissions", { tags: "@OSS" }, () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();

--- a/frontend/test/metabase/scenarios/permissions/admin-permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/admin-permissions.cy.spec.js
@@ -3,7 +3,7 @@ import {
   popover,
   modal,
   describeEE,
-  describeOSS,
+  isOSS,
   assertPermissionTable,
   modifyPermission,
   selectSidebarItem,
@@ -22,8 +22,10 @@ const COLLECTION_ACCESS_PERMISSION_INDEX = 0;
 const DATA_ACCESS_PERMISSION_INDEX = 0;
 const NATIVE_QUERIES_PERMISSION_INDEX = 1;
 
-describeOSS("scenarios > admin > permissions", { tags: "@OSS" }, () => {
+describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
   beforeEach(() => {
+    cy.onlyOn(isOSS);
+
     restore();
     cy.signInAsAdmin();
   });

--- a/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
@@ -273,7 +273,7 @@ describe("scenarios > dashboard > subscriptions", () => {
     });
   });
 
-  describe("OSS email subscriptions", () => {
+  describe("OSS email subscriptions", { tags: "@OSS" }, () => {
     beforeEach(() => {
       cy.onlyOn(isOSS);
       cy.visit(`/dashboard/1`);


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- It adds a small subset of OSS-specific tests to the PR check

#### Why (some background):
We decided to optimize this workflow by run E2E tests only against EE version, as it is a superset of the OSS version. However, there is a crucial subset of tests (usually negative testing) that we absolutely must run against OSS version. The challenge was how to achieve this without either duplicating the whole `e2e-tests` job or spinning up X containers for each of the E2E groups (folders).

Some conditional logic was needed in the job matrix, after which we could add `cypress-grep` plugin.

### Important
We have to tag OSS-specific tests with the `@OSS` tag. It works on `describe`, `context` and `it`.

### Caveats
Cypress-grep plugin [doesn't work with parameterized test names](https://github.com/cypress-io/cypress-grep/issues/109). That means that we cannot use `describeOSS` any more, nor we can construct such tests dynamically. For example:
```js
["A", "B"].forEach(name => {
  it(`test #{name}`, { tags: "@OSS" }, ()=> {
    // cypress-grep would not "see" this
  });
});
```
1. There is an effort to fix this
2. Even if we have to work around this, the number of OSS-specific tests is fairly small and we can always write them in such a way that the plugin works on them

### Note
After we merge this PR it should be safe to remove any group that we currently run on PR using GHA from Circle CI checks! 🎉 🍾 🥳