### PR TITLE
fix permissions diff shows saved questions

### DIFF
--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/diff.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/diff.ts
@@ -3,6 +3,7 @@ import _ from "underscore";
 import { State } from "metabase-types/store";
 import Groups from "metabase/entities/groups";
 import { diffDataPermissions } from "metabase/admin/permissions/utils/graph";
+import { isVirtualCardId } from "metabase/lib/saved-questions/saved-questions";
 import { Group } from "metabase-types/api";
 
 const getDatabasesWithTables = createSelector(
@@ -17,7 +18,7 @@ const getDatabasesWithTables = createSelector(
 
     return databasesList.map(database => {
       const databaseTables = tablesList.filter(
-        table => table.db_id === database.id,
+        table => table.db_id === database.id && !isVirtualCardId(table.id),
       );
 
       return {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/22984

## Changes

In our state we store saved questions with tables because they can be used as base tables for other questions. We need to filter out them when we need only real tables like on the permissions pages.

## How to verify

Check the original issue repro steps.