### PR TITLE
Increase E2E job timeout on PRs

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -43,7 +43,7 @@ jobs:
 
   e2e-tests:
     runs-on: ubuntu-20.04
-    timeout-minutes: 30
+    timeout-minutes: 35
     needs: build
     name: e2e-tests-${{ matrix.folder }}-${{ matrix.edition }}
     env:


### PR DESCRIPTION
`e2e-tests-dashboard-filters-ee` in [`e2e-tests`](https://github.com/metabase/metabase/blob/master/.github/workflows/e2e-tests.yml) is timing out and getting cancelled quite often.

I believe that bumping the timeout by just 5 minutes should either completely solve this or greatly reduce it.