### PR TITLE
[E2E] Remove `embedding` group from checks on CCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1254,7 +1254,6 @@ workflows:
                 [
                   "admin",
                   "collections",
-                  "embedding",
                   "filters",
                   "models",
                   "native",


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- In the same manner we did for #22907, this PR removes `embedding` E2E group from CircleCI because we've been running it successfully using GitHub actions.