### PR TITLE
[E2E] Experiment running `sharing` test group as PR check

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -67,6 +67,7 @@ jobs:
           - "embedding"
           - "joins"
           - "models"
+          - "sharing"
         include:
           - edition: oss
             java-version: 11


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Following the steps of https://github.com/metabase/metabase/pull/21492 and the tasks that @ariya started, we're now adding `sharing` test group to PR checks using GitHub actions.

Analyzing the flakes report, I couldn't find any flakes from this group in the last days.

There are some OSS-specific tests in this group, but thanks to https://github.com/metabase/metabase/pull/23009, we don't have to worry about that any more!

### The next steps
After we make sure this group runs without major hiccups on GitHub (for at least a week?), remove it from CircleCI.