### PR TITLE
Fix missing 'meta' variable

### DIFF
--- a/frontend/src/metabase-lib/lib/Dimension.ts
+++ b/frontend/src/metabase-lib/lib/Dimension.ts
@@ -798,7 +798,7 @@ export class FieldDimension extends Dimension {
       }
 
       if (field.name_field != null) {
-        field.field_name = meta.field(field.name_field);
+        field.field_name = this._metadata.field(field.name_field);
       } else if (field.table && field.isPK()) {
         field.field_name = _.find(field.table.fields, f => f.isEntityName());
       }


### PR DESCRIPTION
`meta` isn't defined, and it seems to me the intent here was to use `this._metadata`. This doesn't error because of the `// @ts-nocheck` at the top of the file.