### PR TITLE
[E2E] Fix line-toolbar-toolips flake

### DIFF
--- a/frontend/test/metabase/scenarios/visualizations/line-bar-tooltips.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/line-bar-tooltips.cy.spec.js
@@ -484,7 +484,8 @@ function openDashCardVisualizationOptions() {
 function updateColumnTitle(originalText, updatedText) {
   cy.findByDisplayValue(originalText)
     .clear()
-    .type(updatedText);
+    .type(updatedText)
+    .blur();
 }
 
 function saveDashCardVisualizationOptions() {


### PR DESCRIPTION
This spec is the top most flaky one in the last 14 days
![image](https://user-images.githubusercontent.com/31325167/171006814-6faa2002-dfca-427c-a557-460c00ccbed2.png)

Renaming (updating column title) was the culprit.

Before
2-3 tests fail on average
![image](https://user-images.githubusercontent.com/31325167/171007971-46e76dc4-22bb-4c96-adb3-a89d6792aae0.png)

After
![image](https://user-images.githubusercontent.com/31325167/171007011-e04d72ce-f79f-4408-a3a0-2743a1e69622.png)
