### PR TITLE
Skip flaky FE unit test

### DIFF
--- a/frontend/src/metabase/parameters/utils/mbql.unit.spec.js
+++ b/frontend/src/metabase/parameters/utils/mbql.unit.spec.js
@@ -143,7 +143,7 @@ describe("parameters/utils/mbql", () => {
           .format("YYYY-MM-DD"),
       ]);
     });
-    it("should parse exclude-quarters-1-2", () => {
+    it.skip("should parse exclude-quarters-1-2", () => {
       expect(dateParameterValueToMBQL("exclude-quarters-1-2", null)).toEqual([
         "!=",
         ["field", null, { "temporal-unit": "quarter-of-year" }],


### PR DESCRIPTION
FE unit test seems to be failing consistently, and it's blocking new PRs to `master`.
We have to skip it to unblock others, while @akiselev (the author) takes a look and eventually fixes it.

Example of the failure
```
FAIL frontend/src/metabase/parameters/utils/mbql.unit.spec.js
  ● parameters/utils/mbql › dateParameterValueToMBQL › should parse exclude-quarters-1-2

    expect(received).toEqual(expected) // deep equality

    - Expected  - 1
    + Received  + 1

    @@ -6,7 +6,7 @@
          Object {
            "temporal-unit": "quarter-of-year",
          },
        ],
        "2022-02-28",
    -   "2022-05-30",
    +   "2022-05-28",
      ]

      145 |     });
      146 |     it("should parse exclude-quarters-1-2", () => {
    > 147 |       expect(dateParameterValueToMBQL("exclude-quarters-1-2", null)).toEqual([
          |                                                                      ^
      148 |         "!=",
      149 |         ["field", null, { "temporal-unit": "quarter-of-year" }],
      150 |         date()

      at Object.<anonymous> (frontend/src/metabase/parameters/utils/mbql.unit.spec.js:147:70)
```
on `master`
https://github.com/metabase/metabase/runs/6653123479?check_suite_focus=true

in PR against master
https://github.com/metabase/metabase/runs/6657067561?check_suite_focus=true
