### PR TITLE
[E2E] Experiment running `question` test group as PR check

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -67,6 +67,7 @@ jobs:
           - "embedding"
           - "joins"
           - "models"
+          - "question"
           - "sharing"
         include:
           - edition: oss


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Following the steps of https://github.com/metabase/metabase/pull/21492 and the tasks that @ariya started, we're now adding `question` test group to PR checks using GitHub actions.

Analyzing the flakes report, there were only two flakes from this group and they should be fixed by #22975

### The next steps
After we make sure this group runs without major hiccups on GitHub (for at least a week?), remove it from CircleCI.

---

### Note:
This is by far the longest running e2e ci group, so we might need to adjust the timeout accordingly.