### PR TITLE
fix dashboard parameters tablet layout

### DIFF
--- a/frontend/src/metabase/parameters/components/ParameterWidget.css
+++ b/frontend/src/metabase/parameters/components/ParameterWidget.css
@@ -7,13 +7,6 @@
   width: 100%;
 }
 
-@media screen and (--breakpoint-min-sm) {
-  :local(.container) {
-    margin-right: 0.85em;
-    width: auto;
-  }
-}
-
 :local(.container) legend {
   text-transform: none;
   position: relative;
@@ -70,8 +63,7 @@
 }
 
 :local(.parameter.noPopover) input {
-  /* NOTE: Fixed with to circumvent issues with flexbox with container having a min-width */
-  width: 115px;
+  width: 100%;
   font-size: 1em;
   font-weight: 600;
   border: none;
@@ -109,9 +101,6 @@
 .Dashboard--night :local(.parameter.noPopover) input:focus,
 .Theme--night :local(.parameter.noPopover) input:focus {
   color: var(--color-text-white);
-}
-
-:local(.input) {
 }
 
 :local(.nameInput:focus),
@@ -155,4 +144,16 @@
 :local(.editNameIconContainer) > svg {
   position: absolute;
   top: -6px;
+}
+
+@media screen and (min-width: 440px) {
+  :local(.container) {
+    margin-right: 0.85em;
+    width: auto;
+  }
+
+  :local(.parameter.noPopover) input {
+    /* NOTE: Fixed with to circumvent issues with flexbox with container having a min-width */
+    width: 115px;
+  }
 }


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/22996

## Changes

Input parameters should have full width only on sufficiently small screens.

### Before
<img width="663" alt="Screenshot 2022-05-30 at 21 18 20" src="https://user-images.githubusercontent.com/14301985/171037574-808d17eb-0054-4856-a81e-3a8d11062f2d.png">

### After
<img width="652" alt="Screenshot 2022-05-30 at 21 14 23" src="https://user-images.githubusercontent.com/14301985/171037615-82de26f5-0f44-4956-b812-b2b36c903079.png">

