### PR TITLE
fix login form mobile layout

### DIFF
--- a/frontend/src/metabase/auth/components/AuthLayout/AuthLayout.styled.tsx
+++ b/frontend/src/metabase/auth/components/AuthLayout/AuthLayout.styled.tsx
@@ -27,7 +27,7 @@ export const LayoutBody = styled.div`
   justify-content: center;
   align-items: center;
   position: relative;
-  padding: 0 1rem 2rem;
+  padding: 1.5rem 1rem 3rem;
   min-height: 100vh;
 `;
 

--- a/frontend/src/metabase/auth/components/AuthLayout/AuthLayout.styled.tsx
+++ b/frontend/src/metabase/auth/components/AuthLayout/AuthLayout.styled.tsx
@@ -1,6 +1,7 @@
 import styled from "@emotion/styled";
 import { css } from "@emotion/react";
 import { color } from "metabase/lib/colors";
+import { breakpointMinSmall } from "metabase/styled-components/theme";
 
 export interface LayoutProps {
   showScene?: boolean;
@@ -31,10 +32,15 @@ export const LayoutBody = styled.div`
 `;
 
 export const LayoutCard = styled.div`
-  width: 30.875rem;
+  width: 100%;
   margin-top: 1.5rem;
-  padding: 2.5rem 3.5rem;
+  padding: 2.5rem 1.5rem;
   background-color: ${color("white")};
   box-shadow: 0 1px 15px ${color("shadow")};
   border-radius: 6px;
+
+  ${breakpointMinSmall} {
+    width: 30.875rem;
+    padding: 2.5rem 3.5rem;
+  }
 `;


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/23028
Closes https://github.com/metabase/metabase/issues/23056

### Before
<img width="482" alt="Screenshot 2022-05-30 at 23 25 39" src="https://user-images.githubusercontent.com/14301985/171050504-971bbbc0-3235-47fe-9425-cc3888ca20e7.png">

### After
<img width="481" alt="Screenshot 2022-05-30 at 23 24 37" src="https://user-images.githubusercontent.com/14301985/171050527-2b97bbb1-a3c9-4f22-a51f-60529ffae801.png">

## How to verify

- Open the login form and ensure it looks good on all screen widths

