### PR TITLE
Repro #22519: Model fails query when columns are using casting in data model

### DIFF
--- a/frontend/test/metabase/scenarios/models/reproductions/22519-casting-fails-query.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/reproductions/22519-casting-fails-query.cy.spec.js
@@ -1,0 +1,42 @@
+import { restore } from "__support__/e2e/cypress";
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+
+import { turnIntoModel } from "../helpers/e2e-models-helpers";
+
+const { REVIEWS, REVIEWS_ID } = SAMPLE_DATABASE;
+
+const ratingDataModelUrl = `/admin/datamodel/database/${SAMPLE_DB_ID}/table/${REVIEWS_ID}/${REVIEWS.RATING}/general`;
+
+const questionDetails = {
+  query: {
+    "source-table": REVIEWS_ID,
+  },
+};
+
+describe.skip("issue 22519", () => {
+  beforeEach(() => {
+    cy.intercept("PUT", "/api/field/*").as("updateField");
+    cy.intercept("POST", "/api/dataset").as("dataset");
+
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("model query should not fail when data model is using casting (metabase#22519)", () => {
+    cy.visit(ratingDataModelUrl);
+
+    cy.findByText("Don't cast").click();
+    cy.findByText("UNIX seconds → Datetime").click();
+    cy.wait("@updateField");
+
+    cy.createQuestion(questionDetails, { visitQuestion: true });
+
+    cy.findByText("xavier");
+
+    turnIntoModel();
+
+    cy.wait("@dataset");
+    cy.findByText("xavier");
+  });
+});

--- a/frontend/test/metabase/scenarios/models/reproductions/22519-casting-fails-query.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/reproductions/22519-casting-fails-query.cy.spec.js
@@ -21,15 +21,15 @@ describe.skip("issue 22519", () => {
 
     restore();
     cy.signInAsAdmin();
-  });
 
-  it("model query should not fail when data model is using casting (metabase#22519)", () => {
     cy.visit(ratingDataModelUrl);
 
     cy.findByText("Don't cast").click();
     cy.findByText("UNIX seconds → Datetime").click();
     cy.wait("@updateField");
+  });
 
+  it("model query should not fail when data model is using casting (metabase#22519)", () => {
     cy.createQuestion(questionDetails, { visitQuestion: true });
 
     cy.findByText("xavier");


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #22519 

### How to test this manually?
- `yarn test-cypress-open`
- `metabase/scenarios/models/reproductions/22519-casting-fails-query.cy.spec.js`
- Unskip repro
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/171053518-b462571f-60ea-44b1-800c-5555de342897.png)

