### PR TITLE
Fix inconsistency in number of documents scanned

### DIFF
--- a/docs/administration-guide/databases/mongodb.md
+++ b/docs/administration-guide/databases/mongodb.md
@@ -105,7 +105,7 @@ To make sure you are using the correct connection configuration:
 
 ## I added fields to my database but don't see them in Metabase
 
-Metabase may not sync all of your fields, as it only scans the first 200 documents in a collection to get a sample of the fields the collection contains. Since any document in a MongoDB collection can contain any number of fields, the only way to get 100% coverage of all fields would be to scan every single document in every single collection, which would put too much strain on your database (so we don't do that).
+Metabase may not sync all of your fields, as it only scans the first ten thousand documents in a collection to get a sample of the fields the collection contains. Since any document in a MongoDB collection can contain any number of fields, the only way to get 100% coverage of all fields would be to scan every single document in every single collection, which would put too much strain on your database (so we don't do that).
 
 One workaround is to include all possible keys in the first document of the collection, and give those keys null values. That way, Metabase will be able to recognize the correct schema for the entire collection.
 


### PR DESCRIPTION
The docs say that Metabase scans the first X documents of a collection where X is first "ten thousand" and later "200", looking at the file with git blame the most recent value edited is "ten thousand" so I expect that to be the correct one.