### PR TITLE
Fix deadlock in pivot table connection management (#22981)

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -51,6 +51,7 @@
   (eval . (put-clojure-indent 'mt/test-driver 1))
   (eval . (put-clojure-indent 'prop/for-all 1))
   (eval . (put-clojure-indent 'qp.streaming/streaming-response 1))
+  (eval . (put-clojure-indent 'u/prog1 1))
   (eval . (put-clojure-indent 'u/select-keys-when 1))
   (eval . (put-clojure-indent 'u/strict-extend 1))
   ;; these ones have to be done with `define-clojure-indent' for now because of upstream bug

--- a/src/metabase/query_processor/context/default.clj
+++ b/src/metabase/query_processor/context/default.clj
@@ -62,10 +62,10 @@
                                                 context)))]
       (context/reducedf reduced-rows context))))
 
-(defn- default-runf [query rf context]
+(defn- default-runf [query rff context]
   (try
     (context/executef driver/*driver* query context (fn respond* [metadata reducible-rows]
-                                                      (context/reducef rf context metadata reducible-rows)))
+                                                      (context/reducef rff context metadata reducible-rows)))
     (catch Throwable e
       (context/raisef e context))))
 


### PR DESCRIPTION
Manual backport of https://github.com/metabase/metabase/pull/22981 addressing issue https://github.com/metabase/metabase/issues/8679

Automatic backport failed because of `rf` -> `rff` local variable change and `context` -> `qp.context` from the ns refactor.

Recreated PR because original targeted master at first and CI is cranky