### PR TITLE
Add starburst (Trino) in the partner driver list

### DIFF
--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -416,7 +416,7 @@
 
 (def partner-drivers
   "The set of other drivers in the partnership program"
-  #{"firebolt"})
+  #{"firebolt" "starburst"})
 
 (defn driver-source
   "Return the source type of the driver: official, partner, or community"


### PR DESCRIPTION
Adding the starburst driver to the partner list.

We expect to have this driver soon on Cloud offerings.