### PR TITLE
fix column settings ignored

### DIFF
--- a/frontend/src/metabase-lib/lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/lib/queries/StructuredQuery.ts
@@ -1162,10 +1162,6 @@ class StructuredQueryInner extends AtomicQuery {
       }
     }
 
-    if (this.isRaw()) {
-      query = query.clearFields();
-    }
-
     return query;
   }
 

--- a/frontend/src/metabase-lib/lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/lib/queries/StructuredQuery.ts
@@ -1162,6 +1162,10 @@ class StructuredQueryInner extends AtomicQuery {
       }
     }
 
+    if (this.isRaw() && this.sourceQuery()) {
+      query = query.clearFields();
+    }
+
     return query;
   }
 

--- a/frontend/src/metabase/visualizations/components/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive.jsx
@@ -709,6 +709,7 @@ class TableInteractive extends Component {
         }}
       >
         <div
+          data-testid="header-cell"
           ref={e => (this.headerRefs[columnIndex] = e)}
           style={{
             ...style,

--- a/frontend/test/metabase/scenarios/question/reproductions/23023-preview-shows-hidden-columns.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/23023-preview-shows-hidden-columns.cy.spec.js
@@ -1,0 +1,58 @@
+import {
+  restore,
+  visitQuestionAdhoc,
+  openNotebook,
+} from "__support__/e2e/cypress";
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+
+const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
+
+const questionDetails = {
+  display: "table",
+  dataset_query: {
+    database: SAMPLE_DB_ID,
+    query: {
+      "source-table": ORDERS_ID,
+      joins: [
+        {
+          fields: [["field", PRODUCTS.CATEGORY, { "join-alias": "Products" }]],
+          "source-table": PRODUCTS_ID,
+          condition: [
+            "=",
+            ["field", ORDERS.PRODUCT_ID, null],
+            ["field", PRODUCTS.ID, { "join-alias": "Products" }],
+          ],
+          alias: "Products",
+        },
+      ],
+      fields: [
+        ["field", ORDERS.ID, null],
+        ["field", ORDERS.PRODUCT_ID, null],
+      ],
+    },
+    type: "query",
+  },
+};
+
+describe("issue 23023", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should show only selected columns in a step preview (metabase#23023)", () => {
+    visitQuestionAdhoc(questionDetails);
+
+    openNotebook();
+
+    cy.icon("play")
+      .eq(1)
+      .click();
+
+    cy.findAllByTestId("header-cell").contains("Products → Category");
+    cy.findAllByTestId("header-cell")
+      .contains("Tax")
+      .should("not.exist");
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/23023

## Changes

Caused by https://github.com/metabase/metabase/pull/22334
We should not clear fields when cleaning expressions to keep column settings.

## How to verify

1. New Question > Sample Database > Orders - join Products
2. Select only some columns from each table and open Preview
3. Ensure only selected columns are visible
