### PR TITLE
Bump transitive com.google.code.gson/gson

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/deps.edn
+++ b/modules/drivers/bigquery-cloud-sdk/deps.edn
@@ -3,4 +3,6 @@
 
  :deps
  ;; TODO: figure out how to be able to leave off this version string and use the version from the BOM
- {com.google.cloud/google-cloud-bigquery {:mvn/version "1.135.4"}}}
+ {com.google.cloud/google-cloud-bigquery {:mvn/version "1.135.4"}
+  ;; CVE on 2.8.7 from bigquery (NB: also in googleanalytics)
+  com.google.code.gson/gson {:mvn/version "2.8.9"}}}

--- a/modules/drivers/googleanalytics/deps.edn
+++ b/modules/drivers/googleanalytics/deps.edn
@@ -2,6 +2,8 @@
 
  :deps
  {com.google.apis/google-api-services-analytics      {:mvn/version "v3-rev20190807-1.32.1"}
+  ;; CVE on 2.8.7 from google api services (NB: also in bigquery-cloud-sdk)
+  com.google.code.gson/gson                          {:mvn/version "2.8.9"}
   ;; for some reason, Google stopped depending on google-http-client-jackson2 from google-api-client somewhere between
   ;; 1.30.7 and 1.32.1, so we must explicitly bring it in because the google driver uses it directly
   com.google.http-client/google-http-client-jackson2 {:mvn/version "1.39.2-sp.1"}}}


### PR DESCRIPTION
An alert from trivy:

```
Package: com.google.code.gson:gson
Installed Version: 2.8.7
Vulnerability CVE-2022-25647
Severity: HIGH
Fixed Version: 2.8.9
Link: CVE-2022-25647
Trivy
```

running `clj -Sdeps` will not show this dep because it is in two
drivers. Instead running

```
clj A:ee:drivers
```

will find it.

```
. metabase/bigquery-cloud-sdk /Users/dan/projects/work/metabase/modules/drivers/bigquery-cloud-sdk
    . com.google.cloud/google-cloud-bigquery 1.135.4
      . com.google.code.gson/gson 2.8.7
```

and

```
  . metabase/googleanalytics /Users/dan/projects/work/metabase/modules/drivers/googleanalytics
    . com.google.apis/google-api-services-analytics v3-rev20190807-1.32.1
      . com.google.api-client/google-api-client 1.32.1
        . com.google.http-client/google-http-client-gson 1.39.2
          X com.google.code.gson/gson 2.8.6 :older-version
```

This shows: google analytics depends on 2.8.6 but it is not actually
used and bigquery-cloud-sdk depends on 2.8.7 which is the version that
we are ending up with. (The `X` means excluded from the jar with reason
being `:older-version`).

More info:

https://clojure.org/reference/dep_expansion#_tree_printing

```
Trees are built from the trace log and include all considered nodes. Included nodes are prefixed with .. 
Excluded nodes are prefixed with X. The end of the line will contain the reason code (some codes are suppressed). 
The current set of reason codes (subject to change) are:

    :new-top-dep - included as top dep (suppressed)

    :new-dep - included as new dep (suppressed)

    :same-version - excluded, same as currently selected dep (suppressed)

    :newer-version - included, newer version than previously selected

    :use-top - excluded, same as top lib but not at top

    :older-version - excluded, older version than previously selected

    :excluded - excluded, node in parent path excluded this lib

    :parent-omitted - excluded, parent node deselected

    :superseded - excluded, this version was deselected

```

THE FIX:

Just put a top level dependency on the version we care about. No need to
exclude the version. Technically only need it in one project as our
build would always use the specified version. But in case anyone builds
with just one or the other included in both for completeness with a
comment indicating the other location.

```clojure
com.google.code.gson/gson {:mvn/version "2.8.9"}
```

PROOF OF FIX:

clj -A:ee:drivers and look for gson

```
  . metabase/bigquery-cloud-sdk /Users/dan/projects/work/metabase/modules/drivers/bigquery-cloud-sdk
    . com.google.cloud/google-cloud-bigquery 1.135.4
      X com.google.code.gson/gson 2.8.7 :older-version
```

```
. metabase/googleanalytics /Users/dan/projects/work/metabase/modules/drivers/googleanalytics
    . com.google.apis/google-api-services-analytics v3-rev20190807-1.32.1
      . com.google.api-client/google-api-client 1.32.1
        . com.google.http-client/google-http-client-gson 1.39.2
          X com.google.code.gson/gson 2.8.6 :older-version
    . com.google.code.gson/gson 2.8.9
```

- 2.8.7 in bigquery-cloud-sdk now has an `X` and `:older-version`
- 2.8.6 in google analytics still has `X` and `:older-version`
- metabase/googleanalytics now has a top level (and included `.`) gson on 2.8.9
