### PR TITLE
Add a test to check that all exported models have a portable unique name

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/models/entity_id_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/models/entity_id_test.clj
@@ -1,4 +1,4 @@
-(ns metabase.models.entity-id-test
+(ns metabase_enterprise.models.entity-id-test
   "To support serialization, all exported entities should have either an external name (eg. a database path) or a
   generated NanoID in a column called entity_id. There's a property :entity_id to automatically populate that field.
 

--- a/enterprise/backend/test/metabase_enterprise/models/entity_id_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/models/entity_id_test.clj
@@ -5,7 +5,7 @@
   This file makes it impossible to forget to add entity_id to new entities. It tests that every entity is either
   explicitly excluded, or has the :entity_id property."
   (:require
-    [clojure.test :refer [deftest is]]
+    [clojure.test :refer :all]
     [metabase.db.data-migrations]
     [metabase.models]
     [metabase.models.dependency-test]
@@ -66,9 +66,11 @@
     metabase_enterprise.sandbox.models.group_table_access_policy.GroupTableAccessPolicyInstance})
 
 (deftest comprehensive-entity-id-test
-  (is (empty? (->> (extenders IModel)
-                   (remove entities-not-exported)
-                   (remove entities-external-name)
-                   (remove (comp :entity_id toucan.models/properties #(.newInstance %)))))
-      "Every Toucan model should either: have an entity_id column and declare the :entity_id property, or be explicitly
-      listed as having an external name, or explicitly listed as excluded from serialization."))
+  (doseq [model (->> (extenders IModel)
+                     (remove entities-not-exported)
+                     (remove entities-external-name))]
+    (testing (format "Model %s should either: have the :entity_id property, or be explicitly listed as having an external name, or explicitly listed as excluded from serialization"
+                     (.getSimpleName model))
+      (is (= true (-> (.newInstance model)
+                      toucan.models/properties
+                      :entity_id))))))

--- a/enterprise/backend/test/metabase_enterprise/models/entity_id_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/models/entity_id_test.clj
@@ -6,7 +6,10 @@
   explicitly excluded, or has the :entity_id property."
   (:require
     [clojure.test :refer [deftest is]]
+    [metabase.db.data-migrations]
     [metabase.models]
+    [metabase.models.dependency-test]
+    [metabase.models.revision-test]
     [toucan.models :as models :refer [IModel]]))
 
 (def entities-external-name
@@ -26,7 +29,8 @@
   - not exported in serialization; or
   - exported as a child of something else (eg. timeline_event under timeline)
   so they don't need a generated entity_id."
-  #{metabase.models.activity.ActivityInstance
+  #{metabase.db.data_migrations.DataMigrationsInstance
+    metabase.models.activity.ActivityInstance
     metabase.models.application_permissions_revision.ApplicationPermissionsRevisionInstance
     metabase.models.bookmark.BookmarkOrderingInstance
     metabase.models.bookmark.CardBookmarkInstance
@@ -35,6 +39,7 @@
     metabase.models.collection.root.RootCollection
     metabase.models.collection_permission_graph_revision.CollectionPermissionGraphRevisionInstance
     metabase.models.dashboard_card_series.DashboardCardSeriesInstance
+    metabase.models.dependency_test.MockInstance
     metabase.models.field_values.FieldValuesInstance
     metabase.models.login_history.LoginHistoryInstance
     metabase.models.metric_important_field.MetricImportantFieldInstance
@@ -51,6 +56,7 @@
     metabase.models.query_cache.QueryCacheInstance
     metabase.models.query_execution.QueryExecutionInstance
     metabase.models.revision.RevisionInstance
+    metabase.models.revision_test.FakedCardInstance
     metabase.models.secret.SecretInstance
     metabase.models.session.SessionInstance
     metabase.models.task_history.TaskHistoryInstance

--- a/enterprise/backend/test/metabase_enterprise/models/entity_id_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/models/entity_id_test.clj
@@ -6,11 +6,16 @@
   explicitly excluded, or has the :entity_id property."
   (:require
     [clojure.test :refer :all]
-    [metabase.db.data-migrations]
-    [metabase.models]
-    [metabase.models.dependency-test]
-    [metabase.models.revision-test]
-    [toucan.models :as models :refer [IModel]]))
+    metabase.db.data-migrations
+    metabase.models
+    metabase.models.dependency-test
+    metabase.models.revision-test
+    [toucan.models :refer [IModel properties]]))
+
+(comment metabase.models/keep-me
+         metabase.db.data-migrations/keep-me
+         metabase.models.dependency-test/keep-me
+         metabase.models.revision-test/keep-me)
 
 (def entities-external-name
   "Entities with external names, so they don't need a generated entity_id."

--- a/test/metabase/models/entity_id_test.clj
+++ b/test/metabase/models/entity_id_test.clj
@@ -5,7 +5,7 @@
   This file makes it impossible to forget to add entity_id to new entities. It tests that every entity is either
   explicitly excluded, or has the :entity_id property."
   (:require
-    [clojure.test :refer [deftest is testing]]
+    [clojure.test :refer [deftest is]]
     [metabase.models]
     [toucan.models :as models :refer [IModel]]))
 
@@ -66,4 +66,3 @@
                    (remove (comp :entity_id toucan.models/properties #(.newInstance %)))))
       "Every Toucan model should either: have an entity_id column and declare the :entity_id property, or be explicitly
       listed as having an external name, or explicitly listed as excluded from serialization."))
-

--- a/test/metabase/models/entity_id_test.clj
+++ b/test/metabase/models/entity_id_test.clj
@@ -1,0 +1,69 @@
+(ns metabase.models.entity-id-test
+  "To support serialization, all exported entities should have either an external name (eg. a database path) or a
+  generated NanoID in a column called entity_id. There's a property :entity_id to automatically populate that field.
+
+  This file makes it impossible to forget to add entity_id to new entities. It tests that every entity is either
+  explicitly excluded, or has the :entity_id property."
+  (:require
+    [clojure.test :refer [deftest is testing]]
+    [metabase.models]
+    [toucan.models :as models :refer [IModel]]))
+
+(def entities-external-name
+  "Entities with external names, so they don't need a generated entity_id."
+  #{;; Databases have external names based on their URLs; tables are nested under databases; fields under tables.
+    metabase.models.database.DatabaseInstance
+    metabase.models.table.TableInstance
+    metabase.models.field.FieldInstance
+    ;; Settings have human-selected unique names.
+    metabase.models.setting.SettingInstance
+    ;; Dependencies are serialized but no extra ID is necessary since they're just many-to-many links between entities
+    ;; with unique IDs, and don't need unique IDs of their own.
+    metabase.models.dependency.DependencyInstance})
+
+(def entities-not-exported
+  "Entities that are either:
+  - not exported in serialization; or
+  - exported as a child of something else (eg. timeline_event under timeline)
+  so they don't need a generated entity_id."
+  #{metabase.models.activity.ActivityInstance
+    metabase.models.application_permissions_revision.ApplicationPermissionsRevisionInstance
+    metabase.models.bookmark.BookmarkOrderingInstance
+    metabase.models.bookmark.CardBookmarkInstance
+    metabase.models.bookmark.CollectionBookmarkInstance
+    metabase.models.bookmark.DashboardBookmarkInstance
+    metabase.models.collection.root.RootCollection
+    metabase.models.collection_permission_graph_revision.CollectionPermissionGraphRevisionInstance
+    metabase.models.dashboard_card_series.DashboardCardSeriesInstance
+    metabase.models.field_values.FieldValuesInstance
+    metabase.models.login_history.LoginHistoryInstance
+    metabase.models.metric_important_field.MetricImportantFieldInstance
+    metabase.models.moderation_review.ModerationReviewInstance
+    metabase.models.permissions.PermissionsInstance
+    metabase.models.permissions_group.PermissionsGroupInstance
+    metabase.models.permissions_group_membership.PermissionsGroupMembershipInstance
+    metabase.models.permissions_revision.PermissionsRevisionInstance
+    metabase.models.persisted_info.PersistedInfoInstance
+    metabase.models.pulse_card.PulseCardInstance
+    metabase.models.pulse_channel.PulseChannelInstance
+    metabase.models.pulse_channel_recipient.PulseChannelRecipientInstance
+    metabase.models.query.QueryInstance
+    metabase.models.query_cache.QueryCacheInstance
+    metabase.models.query_execution.QueryExecutionInstance
+    metabase.models.revision.RevisionInstance
+    metabase.models.secret.SecretInstance
+    metabase.models.session.SessionInstance
+    metabase.models.task_history.TaskHistoryInstance
+    metabase.models.timeline_event.TimelineEventInstance
+    metabase.models.user.UserInstance
+    metabase.models.view_log.ViewLogInstance
+    metabase_enterprise.sandbox.models.group_table_access_policy.GroupTableAccessPolicyInstance})
+
+(deftest comprehensive-entity-id-test
+  (is (empty? (->> (extenders IModel)
+                   (remove entities-not-exported)
+                   (remove entities-external-name)
+                   (remove (comp :entity_id toucan.models/properties #(.newInstance %)))))
+      "Every Toucan model should either: have an entity_id column and declare the :entity_id property, or be explicitly
+      listed as having an external name, or explicitly listed as excluded from serialization."))
+


### PR DESCRIPTION
Either an external name (eg. a database path) or an entity_id column.
Unexported models are explicitly listed as such here.

This makes it impossible to forget to address a unique ID for any new
model.

Related to epic #22641

