### PR TITLE
Dual Slider Component

### DIFF
--- a/frontend/src/metabase/core/components/Slider/Slider.stories.tsx
+++ b/frontend/src/metabase/core/components/Slider/Slider.stories.tsx
@@ -1,0 +1,15 @@
+import React, { useState } from "react";
+import { ComponentStory } from "@storybook/react";
+import Slider from "./Slider";
+
+export default {
+  title: "Core/Slider",
+  component: Slider,
+};
+
+const Template: ComponentStory<typeof Slider> = args => {
+  const [value, setValue] = useState([10, 40]);
+  return <Slider {...args} value={value} onChange={setValue} />;
+};
+
+export const Default = Template.bind({});

--- a/frontend/src/metabase/core/components/Slider/Slider.styled.tsx
+++ b/frontend/src/metabase/core/components/Slider/Slider.styled.tsx
@@ -1,0 +1,59 @@
+import styled from "@emotion/styled";
+import { color, alpha } from "metabase/lib/colors";
+
+export const SliderContainer = styled.div`
+  position: relative;
+  display: flex;
+`;
+
+const thumbStyles = `
+  -webkit-appearance: none;
+  width: 1.2rem;
+  height: 1.2rem;
+  border-radius: 50%;
+  border: 2px solid ${color("brand")};
+  background-color: ${color("white")};
+  cursor: pointer;
+  box-shadow: 0 0 2px 1px ${color("brand")};
+  pointer-events: all;
+  &:active {
+    box-shadow: 0 0 4px 1px ${color("brand")};
+  }
+`;
+
+export const SliderInput = styled.input`
+  -webkit-appearance: none;
+  position: absolute;
+  width: 100%;
+  height: 0;
+  border: none;
+  outline: none;
+  background: none;
+  pointer-events: none;
+  &::-webkit-slider-thumb {
+    ${thumbStyles}
+  }
+  &::-moz-range-thumb {
+    ${thumbStyles}
+  }
+`;
+
+export const SliderTrack = styled.span`
+  width: 100%;
+  background-color: ${alpha("brand", 0.5)};
+  height: 0.2rem;
+  border-radius: 0.2rem;
+`;
+
+interface ActiveTrackProps {
+  left: number;
+  width: number;
+}
+
+export const ActiveTrack = styled.span<ActiveTrackProps>`
+  position: absolute;
+  left: ${props => props.left}%;
+  width: ${props => props.width}%;
+  background-color: ${color("brand")};
+  height: 0.2rem;
+`;

--- a/frontend/src/metabase/core/components/Slider/Slider.tsx
+++ b/frontend/src/metabase/core/components/Slider/Slider.tsx
@@ -19,10 +19,10 @@ export type NumericInputAttributes = Omit<
 
 export interface SliderProps extends NumericInputAttributes {
   value: number[];
-  min: number;
-  max: number;
-  step?: number;
   onChange: (value: number[]) => void;
+  min?: number;
+  max?: number;
+  step?: number;
 }
 
 const Slider = ({
@@ -32,14 +32,19 @@ const Slider = ({
   max = 100,
   step = 1,
 }: SliderProps) => {
+  const [rangeMin, rangeMax] = useMemo(
+    () => [Math.min(...value, min, max), Math.max(...value, min, max)],
+    [value, min, max],
+  );
+
   const [beforeRange, rangeWidth] = useMemo(() => {
-    const totalRange = max - min;
+    const totalRange = rangeMax - rangeMin;
 
     return [
-      ((Math.min(...value) - min) / totalRange) * 100,
+      ((Math.min(...value) - rangeMin) / totalRange) * 100,
       (Math.abs(value[1] - value[0]) / totalRange) * 100,
     ];
-  }, [value, min, max]);
+  }, [value, rangeMin, rangeMax]);
 
   const handleChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>, valueIndex: number) => {
@@ -67,8 +72,9 @@ const Slider = ({
         value={value[0]}
         onChange={e => handleChange(e, 0)}
         onMouseUp={sortValues}
-        min={min}
-        max={max}
+        min={rangeMin}
+        max={rangeMax}
+        step={step}
       />
       <SliderInput
         type="range"
@@ -76,8 +82,9 @@ const Slider = ({
         value={value[1]}
         onChange={e => handleChange(e, 1)}
         onMouseUp={sortValues}
-        min={min}
-        max={max}
+        min={rangeMin}
+        max={rangeMax}
+        step={step}
       />
     </SliderContainer>
   );

--- a/frontend/src/metabase/core/components/Slider/Slider.tsx
+++ b/frontend/src/metabase/core/components/Slider/Slider.tsx
@@ -1,0 +1,86 @@
+import React, {
+  ChangeEvent,
+  InputHTMLAttributes,
+  useCallback,
+  useMemo,
+} from "react";
+
+import {
+  SliderContainer,
+  SliderInput,
+  SliderTrack,
+  ActiveTrack,
+} from "./Slider.styled";
+
+export type NumericInputAttributes = Omit<
+  InputHTMLAttributes<HTMLDivElement>,
+  "value" | "size" | "onChange"
+>;
+
+export interface SliderProps extends NumericInputAttributes {
+  value: number[];
+  min: number;
+  max: number;
+  step?: number;
+  onChange: (value: number[]) => void;
+}
+
+const Slider = ({
+  value,
+  onChange,
+  min = 0,
+  max = 100,
+  step = 1,
+}: SliderProps) => {
+  const [beforeRange, rangeWidth] = useMemo(() => {
+    const totalRange = max - min;
+
+    return [
+      ((Math.min(...value) - min) / totalRange) * 100,
+      (Math.abs(value[1] - value[0]) / totalRange) * 100,
+    ];
+  }, [value, min, max]);
+
+  const handleChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>, valueIndex: number) => {
+      const changedValue = [...value];
+      changedValue[valueIndex] = Number(event.target.value);
+      onChange(changedValue);
+    },
+    [value, onChange],
+  );
+
+  const sortValues = useCallback(() => {
+    if (value[0] > value[1]) {
+      const sortedValues = [...value].sort();
+      onChange(sortedValues);
+    }
+  }, [value, onChange]);
+
+  return (
+    <SliderContainer>
+      <SliderTrack />
+      <ActiveTrack left={beforeRange} width={rangeWidth} />
+      <SliderInput
+        type="range"
+        aria-label="min"
+        value={value[0]}
+        onChange={e => handleChange(e, 0)}
+        onMouseUp={sortValues}
+        min={min}
+        max={max}
+      />
+      <SliderInput
+        type="range"
+        aria-label="max"
+        value={value[1]}
+        onChange={e => handleChange(e, 1)}
+        onMouseUp={sortValues}
+        min={min}
+        max={max}
+      />
+    </SliderContainer>
+  );
+};
+
+export default Slider;

--- a/frontend/src/metabase/core/components/Slider/Slider.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/Slider/Slider.unit.spec.tsx
@@ -1,35 +1,34 @@
 import React from "react";
-import { render, fireEvent } from "@testing-library/react";
+import { render, fireEvent, screen } from "@testing-library/react";
 import Slider from "./Slider";
 
 describe("Slider", () => {
   it("should render 2 range inputs", () => {
-    const { container } = render(
-      <Slider value={[10, 40]} onChange={() => null} min={0} max={100} />,
-    );
+    render(<Slider value={[10, 40]} onChange={() => null} min={0} max={100} />);
 
-    expect(container.querySelectorAll('input[type="range"]').length).toBe(2);
+    const minInput = screen.getByLabelText("min");
+    const maxInput = screen.getByLabelText("max");
+
+    expect(minInput).toHaveAttribute("type", "range");
+    expect(maxInput).toHaveAttribute("type", "range");
   });
 
   it("should always have values in range", () => {
-    const { container } = render(
+    render(
       <Slider value={[10, 412]} onChange={() => null} min={0} max={100} />,
     );
 
-    expect(
-      container.querySelector('input[type="range"]')?.getAttribute("max"),
-    ).toBe("412");
+    const minInput = screen.getByLabelText("min");
+
+    expect(minInput).toHaveAttribute("max", "412");
   });
 
   it("should call onChange with the new value on input change", () => {
     const spy = jest.fn();
-    const { container } = render(
-      <Slider value={[10, 20]} onChange={spy} min={0} max={100} />,
-    );
+    render(<Slider value={[10, 20]} onChange={spy} min={0} max={100} />);
 
-    const [minInput, maxInput] = container.querySelectorAll(
-      'input[type="range"]',
-    );
+    const minInput = screen.getByLabelText("min");
+    const maxInput = screen.getByLabelText("max");
 
     // would be nice to use userEvent when we upgrade to v14 so we mock drage events
     fireEvent.change(minInput, { target: { value: "5" } });
@@ -43,13 +42,9 @@ describe("Slider", () => {
 
   it("should sort input values on mouse up", () => {
     const spy = jest.fn();
-    const { container } = render(
-      <Slider value={[2, 1]} onChange={spy} min={0} max={100} />,
-    );
+    render(<Slider value={[2, 1]} onChange={spy} min={0} max={100} />);
 
-    const minInput = container.querySelector(
-      'input[type="range"]',
-    ) as HTMLInputElement;
+    const minInput = screen.getByLabelText("min");
 
     fireEvent.mouseUp(minInput);
     expect(spy.mock.calls[0][0]).toEqual([1, 2]);

--- a/frontend/src/metabase/core/components/Slider/Slider.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/Slider/Slider.unit.spec.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, fireEvent } from "@testing-library/react";
 import Slider from "./Slider";
 
 describe("Slider", () => {
@@ -9,5 +9,49 @@ describe("Slider", () => {
     );
 
     expect(container.querySelectorAll('input[type="range"]').length).toBe(2);
+  });
+
+  it("should always have values in range", () => {
+    const { container } = render(
+      <Slider value={[10, 412]} onChange={() => null} min={0} max={100} />,
+    );
+
+    expect(
+      container.querySelector('input[type="range"]')?.getAttribute("max"),
+    ).toBe("412");
+  });
+
+  it("should call onChange with the new value on input change", () => {
+    const spy = jest.fn();
+    const { container } = render(
+      <Slider value={[10, 20]} onChange={spy} min={0} max={100} />,
+    );
+
+    const [minInput, maxInput] = container.querySelectorAll(
+      'input[type="range"]',
+    );
+
+    // would be nice to use userEvent when we upgrade to v14 so we mock drage events
+    fireEvent.change(minInput, { target: { value: "5" } });
+    fireEvent.change(maxInput, { target: { value: "15" } });
+
+    const [firstCall, secondCall] = spy.mock.calls;
+
+    expect(firstCall[0]).toEqual([5, 20]);
+    expect(secondCall[0]).toEqual([10, 15]);
+  });
+
+  it("should sort input values on mouse up", () => {
+    const spy = jest.fn();
+    const { container } = render(
+      <Slider value={[2, 1]} onChange={spy} min={0} max={100} />,
+    );
+
+    const minInput = container.querySelector(
+      'input[type="range"]',
+    ) as HTMLInputElement;
+
+    fireEvent.mouseUp(minInput);
+    expect(spy.mock.calls[0][0]).toEqual([1, 2]);
   });
 });

--- a/frontend/src/metabase/core/components/Slider/Slider.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/Slider/Slider.unit.spec.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import Slider from "./Slider";
+
+describe("Slider", () => {
+  it("should render 2 range inputs", () => {
+    const { container } = render(
+      <Slider value={[10, 40]} onChange={() => null} min={0} max={100} />,
+    );
+
+    expect(container.querySelectorAll('input[type="range"]').length).toBe(2);
+  });
+});

--- a/frontend/src/metabase/core/components/Slider/index.ts
+++ b/frontend/src/metabase/core/components/Slider/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Slider";


### PR DESCRIPTION
## Description

- adds a generic dual slider component for input of ranges of numeric values
- in the UI, this will be paired with two text inputs that show exact values
- currently only implemented in storybook
- uses two overlapping `input[type="range"]` inputs to maintain accessibility
- tested in chrome, firefox, and safari

## Usage
```jsx
<Slider 
  value={[10, 20]} 
  onChange={changeHandler} 
  min={0} 
  max={100} 
  step={10}
/>
```

/>
## Screenshots
![Screen Shot 2022-06-01 at 12 57 55 PM](https://user-images.githubusercontent.com/30528226/171481446-3e4f28e2-abde-4f72-b86b-a6ef1aa1ecc2.png)

https://user-images.githubusercontent.com/30528226/171481448-1218f3b6-db06-4dbd-8ab0-180aa02f4b96.mov



## Acceptance Criteria

- accepts a tuple as a `value` prop and updates via `onChange` prop
- has optional `min` and `max` props for the range of values
- will override in the min and max range values if one of the values is outside that range
- has configurable "step" prop for the allowable increments
- always shows a darker bar between the inputs
- the user can drag the upper bar below the lower one (and vice versa), but on mouseUp the values will swap so the parent component eventually gets a `[min, max]` sorted array of values

