### PR TITLE
Prototype data app CRUD actions

### DIFF
--- a/frontend/src/metabase-types/types/Card.ts
+++ b/frontend/src/metabase-types/types/Card.ts
@@ -20,7 +20,7 @@ export type UnsavedCard<Query = DatasetQuery> = {
 
 export type SavedCard<Query = DatasetQuery> = UnsavedCard<Query> & {
   id: CardId;
-  name?: string;
+  name: string;
   description?: string;
   dataset?: boolean;
   can_write: boolean;

--- a/frontend/src/metabase-types/types/Card.ts
+++ b/frontend/src/metabase-types/types/Card.ts
@@ -8,8 +8,8 @@ export type VisualizationSettings = {
   [key: string]: any;
 };
 
-export type UnsavedCard = {
-  dataset_query: DatasetQuery;
+export type UnsavedCard<Query = DatasetQuery> = {
+  dataset_query: Query;
   display: string;
   visualization_settings: VisualizationSettings;
   parameters?: Array<Parameter>;
@@ -18,7 +18,7 @@ export type UnsavedCard = {
   original_card_id?: CardId;
 };
 
-export type SavedCard = UnsavedCard & {
+export type SavedCard<Query = DatasetQuery> = UnsavedCard<Query> & {
   id: CardId;
   name?: string;
   description?: string;
@@ -27,7 +27,7 @@ export type SavedCard = UnsavedCard & {
   public_uuid: string;
 };
 
-export type Card = SavedCard | UnsavedCard;
+export type Card<Query = DatasetQuery> = SavedCard<Query> | UnsavedCard<Query>;
 
 export type StructuredDatasetQuery = {
   type: "query";

--- a/frontend/src/metabase-types/types/Dashboard.ts
+++ b/frontend/src/metabase-types/types/Dashboard.ts
@@ -1,4 +1,4 @@
-import { Card, CardId, VisualizationSettings } from "./Card";
+import { Card, CardId, VisualizationSettings, DatasetQuery } from "./Card";
 import { Parameter, ParameterMapping } from "./Parameter";
 
 export type DashboardId = number;
@@ -33,14 +33,14 @@ export type DashboardWithCards = {
 
 export type DashCardId = number;
 
-export type DashCard = {
+export type DashCard<Query = DatasetQuery> = {
   id: DashCardId;
 
   card_id: CardId;
   dashboard_id: DashboardId;
 
-  card: Card;
-  series: Array<Card>;
+  card: Card<Query>;
+  series: Array<Card<Query>>;
 
   // incomplete
   parameter_mappings: Array<ParameterMapping>;

--- a/frontend/src/metabase-types/types/Dashboard.ts
+++ b/frontend/src/metabase-types/types/Dashboard.ts
@@ -33,14 +33,14 @@ export type DashboardWithCards = {
 
 export type DashCardId = number;
 
-export type DashCard<Query = DatasetQuery> = {
+export type DashCard<CardType = Card> = {
   id: DashCardId;
 
   card_id: CardId;
   dashboard_id: DashboardId;
 
-  card: Card<Query>;
-  series: Array<Card<Query>>;
+  card: CardType;
+  series: Array<CardType>;
 
   // incomplete
   parameter_mappings: Array<ParameterMapping>;

--- a/frontend/src/metabase/dashboard/actions.js
+++ b/frontend/src/metabase/dashboard/actions.js
@@ -310,6 +310,8 @@ export const addActionsDashCardToDashboard = ({ dashId }) => {
   };
   const dashcardOverrides = {
     card: virtualActionsCard,
+    sizeX: 4,
+    sizeY: 1,
     visualization_settings: {
       virtual_card: virtualActionsCard,
     },

--- a/frontend/src/metabase/dashboard/actions.js
+++ b/frontend/src/metabase/dashboard/actions.js
@@ -302,6 +302,24 @@ export const addTextDashCardToDashboard = function({ dashId }) {
   });
 };
 
+export const addActionsDashCardToDashboard = ({ dashId }) => {
+  const virtualActionsCard = {
+    ...createCard(),
+    display: "actions",
+    archived: false,
+  };
+  const dashcardOverrides = {
+    card: virtualActionsCard,
+    visualization_settings: {
+      virtual_card: virtualActionsCard,
+    },
+  };
+  return addDashCardToDashboard({
+    dashId: dashId,
+    dashcardOverrides: dashcardOverrides,
+  });
+};
+
 export const saveDashboardAndCards = createThunkAction(
   SAVE_DASHBOARD_AND_CARDS,
   function() {

--- a/frontend/src/metabase/dashboard/components/DashCard.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard.jsx
@@ -176,7 +176,8 @@ export default class DashCard extends Component {
     const hideBackground =
       !isEditing &&
       (mainCard.visualization_settings["dashcard.background"] === false ||
-        mainCard.display === "list");
+        mainCard.display === "list" ||
+        mainCard.display === "actions");
 
     const isEditingDashboardLayout =
       isEditing && clickBehaviorSidebarDashcard == null && !isEditingParameter;

--- a/frontend/src/metabase/dashboard/components/DashCard.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard.jsx
@@ -15,19 +15,19 @@ import QueryDownloadWidget from "metabase/query_builder/components/QueryDownload
 import { SERVER_ERROR_TYPES } from "metabase/lib/errors";
 
 import ModalWithTrigger from "metabase/components/ModalWithTrigger";
-import PopoverWithTrigger from "metabase/components/PopoverWithTrigger";
 import { ChartSettingsWithState } from "metabase/visualizations/components/ChartSettings";
 import WithVizSettingsData from "metabase/visualizations/hoc/WithVizSettingsData";
 
 import Icon, { iconPropTypes } from "metabase/components/Icon";
 import Tooltip from "metabase/components/Tooltip";
-import { SelectList } from "metabase/components/select-list";
 
 import { isVirtualDashCard } from "metabase/dashboard/utils";
 import DashCardParameterMapper from "./DashCardParameterMapper";
 
 import { IS_EMBED_PREVIEW } from "metabase/lib/embed";
 import { getClickBehaviorDescription } from "metabase/lib/click-behavior";
+
+import ActionsLinkingControl from "metabase/writeback/components/ActionsLinkingControl";
 
 import cx from "classnames";
 import _ from "underscore";
@@ -401,7 +401,7 @@ const DashCardActionButtons = ({
 
   if (card.display === "actions") {
     buttons.push(
-      <ConnectActionsButton
+      <ActionsLinkingControl
         key="connect-actions"
         card={card}
         dashboard={dashboard}
@@ -418,55 +418,6 @@ const DashCardActionButtons = ({
         <RemoveButton className="ml1" onRemove={onRemove} />
       </Tooltip>
     </span>
-  );
-};
-
-const ConnectActionsButton = ({
-  card,
-  dashboard,
-  metadata,
-  onUpdateVisualizationSettings,
-}) => {
-  const connectedTableId = card.visualization_settings["actions.linked_table"];
-
-  const tables = dashboard.ordered_cards
-    .map(dashCard => dashCard.card)
-    .filter(
-      card =>
-        !!card.dataset_query.database && card.dataset_query.type === "query",
-    )
-    .map(card => card.dataset_query.query["source-table"])
-    .map(tableId => metadata.table(tableId))
-    .filter(Boolean);
-
-  return (
-    <PopoverWithTrigger
-      triggerElement={
-        <Tooltip tooltip={t`Connect table`}>
-          <Icon
-            name="bolt"
-            size={HEADER_ICON_SIZE}
-            style={HEADER_ACTION_STYLE}
-          />
-        </Tooltip>
-      }
-    >
-      <SelectList>
-        {tables.map(table => (
-          <SelectList.Item
-            key={table.id}
-            name={table.displayName()}
-            icon="table"
-            isSelected={table.id === connectedTableId}
-            onSelect={() =>
-              onUpdateVisualizationSettings({
-                "actions.linked_table": table.id,
-              })
-            }
-          />
-        ))}
-      </SelectList>
-    </PopoverWithTrigger>
   );
 };
 

--- a/frontend/src/metabase/dashboard/containers/DashboardHeader.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardHeader.jsx
@@ -166,6 +166,8 @@ class DashboardHeader extends Component {
       dashboard,
       parametersWidget,
       isBookmarked,
+      isAdmin,
+      isDataApp,
       isEditing,
       isFullscreen,
       isEditable,
@@ -215,20 +217,22 @@ class DashboardHeader extends Component {
         </Tooltip>,
       );
 
-      buttons.push(
-        <Tooltip key="add-actions-row" tooltip={t`Add actions`}>
-          <a
-            data-metabase-event="Dashboard;Add Actions Row"
-            key="add-actions"
-            className="text-brand-hover cursor-pointer"
-            onClick={() => this.onAddActionsBox()}
-          >
-            <DashboardHeaderButton>
-              <Icon name="bolt" size={18} />
-            </DashboardHeaderButton>
-          </a>
-        </Tooltip>,
-      );
+      if (isAdmin && isDataApp) {
+        buttons.push(
+          <Tooltip key="add-actions-row" tooltip={t`Add actions`}>
+            <a
+              data-metabase-event="Dashboard;Add Actions Row"
+              key="add-actions"
+              className="text-brand-hover cursor-pointer"
+              onClick={() => this.onAddActionsBox()}
+            >
+              <DashboardHeaderButton>
+                <Icon name="bolt" size={18} />
+              </DashboardHeaderButton>
+            </a>
+          </Tooltip>,
+        );
+      }
 
       const {
         isAddParameterPopoverOpen,

--- a/frontend/src/metabase/dashboard/containers/DashboardHeader.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardHeader.jsx
@@ -63,6 +63,7 @@ class DashboardHeader extends Component {
 
     addCardToDashboard: PropTypes.func.isRequired,
     addTextDashCardToDashboard: PropTypes.func.isRequired,
+    addActionsDashCardToDashboard: PropTypes.func.isRequired,
     fetchDashboard: PropTypes.func.isRequired,
     saveDashboardAndCards: PropTypes.func.isRequired,
     setDashboardAttribute: PropTypes.func.isRequired,
@@ -91,6 +92,12 @@ class DashboardHeader extends Component {
 
   onAddTextBox() {
     this.props.addTextDashCardToDashboard({ dashId: this.props.dashboard.id });
+  }
+
+  onAddActionsBox() {
+    this.props.addActionsDashCardToDashboard({
+      dashId: this.props.dashboard.id,
+    });
   }
 
   onDoneEditing() {
@@ -203,6 +210,21 @@ class DashboardHeader extends Component {
           >
             <DashboardHeaderButton>
               <Icon name="string" size={18} />
+            </DashboardHeaderButton>
+          </a>
+        </Tooltip>,
+      );
+
+      buttons.push(
+        <Tooltip key="add-actions-row" tooltip={t`Add actions`}>
+          <a
+            data-metabase-event="Dashboard;Add Actions Row"
+            key="add-actions"
+            className="text-brand-hover cursor-pointer"
+            onClick={() => this.onAddActionsBox()}
+          >
+            <DashboardHeaderButton>
+              <Icon name="bolt" size={18} />
             </DashboardHeaderButton>
           </a>
         </Tooltip>,

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
@@ -231,7 +231,7 @@ export function ObjectDetailFn({
     [zoomedRowID, followForeignKey],
   );
 
-  const database = question.database()?.getPlainObject?.();
+  const database = question?.database()?.getPlainObject?.();
   const canEdit = !!(
     table &&
     isWritebackEnabled &&

--- a/frontend/src/metabase/visualizations/register.js
+++ b/frontend/src/metabase/visualizations/register.js
@@ -3,6 +3,8 @@ import {
   setDefaultVisualization,
 } from "metabase/visualizations";
 
+import ActionsViz from "metabase/writeback/components/ActionsViz";
+
 import Scalar from "./visualizations/Scalar";
 import SmartScalar from "./visualizations/SmartScalar";
 import Progress from "./visualizations/Progress";
@@ -43,5 +45,6 @@ export default function() {
   registerVisualization(ObjectDetail);
   registerVisualization(PivotTable);
   registerVisualization(ListViz);
+  registerVisualization(ActionsViz);
   setDefaultVisualization(Table);
 }

--- a/frontend/src/metabase/writeback/actions.ts
+++ b/frontend/src/metabase/writeback/actions.ts
@@ -75,25 +75,29 @@ export type DeleteRowPayload = {
   id: number | string;
 };
 
+export const deleteRow = (payload: DeleteRowPayload) => {
+  const { table, id } = payload;
+  const field = table.fields.find(field => field.isPK());
+  if (!field) {
+    throw new Error("Cannot delete row from table without a primary key");
+  }
+
+  const pk = field.isNumeric() && typeof id === "string" ? parseInt(id) : id;
+  return ActionsApi.delete({
+    type: "query",
+    database: table.db_id,
+    query: {
+      "source-table": table.id,
+      filter: ["=", field.reference(), pk],
+    },
+  });
+};
+
 export const DELETE_ROW_FROM_OBJECT_DETAIL =
   "metabase/qb/DELETE_ROW_FROM_OBJECT_DETAIL";
 export const deleteRowFromObjectDetail = (payload: DeleteRowPayload) => {
   return async (dispatch: any) => {
-    const { table, id } = payload;
-    const field = table.fields.find(field => field.isPK());
-    if (!field) {
-      throw new Error("Cannot delete row from table without a primary key");
-    }
-
-    const pk = field.isNumeric() && typeof id === "string" ? parseInt(id) : id;
-    const result = await ActionsApi.delete({
-      type: "query",
-      database: table.db_id,
-      query: {
-        "source-table": table.id,
-        filter: ["=", field.reference(), pk],
-      },
-    });
+    const result = await deleteRow(payload);
 
     dispatch.action(DELETE_ROW_FROM_OBJECT_DETAIL, payload);
     if (result?.["rows-deleted"]?.length > 0) {

--- a/frontend/src/metabase/writeback/actions.ts
+++ b/frontend/src/metabase/writeback/actions.ts
@@ -4,16 +4,13 @@ import Table from "metabase-lib/lib/metadata/Table";
 import { fetchCardData } from "metabase/dashboard/actions";
 import { runQuestionQuery } from "metabase/query_builder/actions/querying";
 import { setUIControls } from "metabase/query_builder/actions/ui";
-import {
-  closeObjectDetail,
-  zoomInRow,
-} from "metabase/query_builder/actions/object-detail";
+import { closeObjectDetail } from "metabase/query_builder/actions/object-detail";
 
 import { DashCard } from "metabase-types/types/Dashboard";
 
 export type InsertRowPayload = {
   table: Table;
-  values: { [key: string]: number | string };
+  values: Record<string, unknown>;
 };
 
 export const createRow = (payload: InsertRowPayload) => {

--- a/frontend/src/metabase/writeback/actions.ts
+++ b/frontend/src/metabase/writeback/actions.ts
@@ -1,11 +1,15 @@
 import { ActionsApi } from "metabase/services";
 import Table from "metabase-lib/lib/metadata/Table";
-import { setUIControls } from "metabase/query_builder/actions/ui";
+
+import { fetchCardData } from "metabase/dashboard/actions";
 import { runQuestionQuery } from "metabase/query_builder/actions/querying";
+import { setUIControls } from "metabase/query_builder/actions/ui";
 import {
   closeObjectDetail,
   zoomInRow,
 } from "metabase/query_builder/actions/object-detail";
+
+import { DashCard } from "metabase-types/types/Dashboard";
 
 export type InsertRowPayload = {
   table: Table;
@@ -103,6 +107,25 @@ export const deleteRowFromObjectDetail = (payload: DeleteRowPayload) => {
     if (result?.["rows-deleted"]?.length > 0) {
       dispatch(closeObjectDetail());
       dispatch(runQuestionQuery());
+    }
+  };
+};
+
+export type DeleteRowFromDataAppPayload = DeleteRowPayload & {
+  dashCard: DashCard;
+};
+
+export const deleteRowFromDataApp = (payload: DeleteRowFromDataAppPayload) => {
+  return async (dispatch: any) => {
+    const result = await deleteRow(payload);
+    if (result?.["rows-deleted"]?.length > 0) {
+      const { dashCard } = payload;
+      dispatch(
+        fetchCardData(dashCard.card, dashCard, {
+          reload: true,
+          ignoreCache: true,
+        }),
+      );
     }
   };
 };

--- a/frontend/src/metabase/writeback/components/ActionsLinkingControl.tsx
+++ b/frontend/src/metabase/writeback/components/ActionsLinkingControl.tsx
@@ -8,36 +8,29 @@ import { SelectList } from "metabase/components/select-list";
 
 import * as Q_DEPRECATED from "metabase/lib/query";
 
-import { Card, StructuredDatasetQuery } from "metabase-types/types/Card";
+import { SavedCard, StructuredDatasetQuery } from "metabase-types/types/Card";
 import { DashboardWithCards, DashCard } from "metabase-types/types/Dashboard";
-import Metadata from "metabase-lib/lib/metadata/Metadata";
 
-type StructuredQueryDashCard = DashCard<StructuredDatasetQuery>;
+type StructuredQuerySavedCard = SavedCard<StructuredDatasetQuery>;
+type StructuredQueryDashCard = DashCard<StructuredQuerySavedCard>;
 
 interface Props {
   card: DashCard;
   dashboard: DashboardWithCards;
-  metadata: Metadata;
   onUpdateVisualizationSettings: (settings: Record<string, unknown>) => void;
 }
 
 function ActionsLinkingControl({
   card,
   dashboard,
-  metadata,
   onUpdateVisualizationSettings,
 }: Props) {
-  const connectedTableId = card.visualization_settings["actions.linked_table"];
+  const connectedDashCardId =
+    card.visualization_settings["actions.linked_card"];
 
   const suitableDashCards = dashboard.ordered_cards.filter(dashCard =>
     Q_DEPRECATED.isStructured(dashCard.card.dataset_query),
-  );
-
-  const suitableTables = suitableDashCards
-    .map(dashCard => (dashCard as StructuredQueryDashCard).card)
-    .map(card => card.dataset_query.query["source-query"])
-    .map(tableId => metadata.table(tableId))
-    .filter(Boolean);
+  ) as StructuredQueryDashCard[];
 
   return (
     <PopoverWithTrigger
@@ -48,17 +41,17 @@ function ActionsLinkingControl({
       }
     >
       <SelectList>
-        {suitableTables.map(table => (
+        {suitableDashCards.map(dashCard => (
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-ignore
           <SelectList.Item
-            key={table.id}
-            name={table.displayName()}
+            key={dashCard.id}
+            name={dashCard.card.name}
             icon="table"
-            isSelected={table.id === connectedTableId}
+            isSelected={dashCard.id === connectedDashCardId}
             onSelect={() =>
               onUpdateVisualizationSettings({
-                "actions.linked_table": table.id,
+                "actions.linked_card": dashCard.id,
               })
             }
           />

--- a/frontend/src/metabase/writeback/components/ActionsLinkingControl.tsx
+++ b/frontend/src/metabase/writeback/components/ActionsLinkingControl.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { t } from "ttag";
+
+import Icon from "metabase/components/Icon";
+import PopoverWithTrigger from "metabase/components/PopoverWithTrigger";
+import Tooltip from "metabase/components/Tooltip";
+import { SelectList } from "metabase/components/select-list";
+
+import { Card, StructuredDatasetQuery } from "metabase-types/types/Card";
+import { DashboardWithCards, DashCard } from "metabase-types/types/Dashboard";
+import Metadata from "metabase-lib/lib/metadata/Metadata";
+
+type StructuredQueryCard = Card<StructuredDatasetQuery>;
+
+interface Props {
+  card: DashCard;
+  dashboard: DashboardWithCards;
+  metadata: Metadata;
+  onUpdateVisualizationSettings: (settings: Record<string, unknown>) => void;
+}
+
+function ActionsLinkingControl({
+  card,
+  dashboard,
+  metadata,
+  onUpdateVisualizationSettings,
+}: Props) {
+  const connectedTableId = card.visualization_settings["actions.linked_table"];
+
+  const tables = dashboard.ordered_cards
+    .map(dashCard => dashCard.card)
+    .filter(
+      card =>
+        !!card.dataset_query.database && card.dataset_query.type === "query",
+    )
+    .map(
+      card => (card as StructuredQueryCard).dataset_query.query["source-table"],
+    )
+    .map(tableId => metadata.table(tableId))
+    .filter(Boolean);
+
+  return (
+    <PopoverWithTrigger
+      triggerElement={
+        <Tooltip tooltip={t`Connect table`}>
+          <Icon name="bolt" size={16} />
+        </Tooltip>
+      }
+    >
+      <SelectList>
+        {tables.map(table => (
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          <SelectList.Item
+            key={table.id}
+            name={table.displayName()}
+            icon="table"
+            isSelected={table.id === connectedTableId}
+            onSelect={() =>
+              onUpdateVisualizationSettings({
+                "actions.linked_table": table.id,
+              })
+            }
+          />
+        ))}
+      </SelectList>
+    </PopoverWithTrigger>
+  );
+}
+
+export default ActionsLinkingControl;

--- a/frontend/src/metabase/writeback/components/ActionsViz/ActionsViz.styled.tsx
+++ b/frontend/src/metabase/writeback/components/ActionsViz/ActionsViz.styled.tsx
@@ -1,0 +1,25 @@
+import styled from "@emotion/styled";
+import { HorizontalAlignmentValue } from "./types";
+
+function getJustifyContentValue(horizontalAlignment: HorizontalAlignmentValue) {
+  return (
+    {
+      left: "flex-start",
+      center: "center",
+      right: "flex-end",
+    }[horizontalAlignment] || "flex-end"
+  );
+}
+
+export const Root = styled.div<{
+  horizontalAlignment: HorizontalAlignmentValue;
+}>`
+  display: flex;
+  align-items: center;
+  justify-content: ${props =>
+    getJustifyContentValue(props.horizontalAlignment)};
+
+  gap: 0.5rem;
+
+  height: 100%;
+`;

--- a/frontend/src/metabase/writeback/components/ActionsViz/ActionsViz.tsx
+++ b/frontend/src/metabase/writeback/components/ActionsViz/ActionsViz.tsx
@@ -27,8 +27,10 @@ import { VisualizationProps } from "metabase-types/types/Visualization";
 import {
   DeleteRowFromDataAppPayload,
   InsertRowFromDataAppPayload,
+  UpdateRowFromDataAppPayload,
   deleteRowFromDataApp,
   createRowFromDataApp,
+  updateRowFromDataApp,
 } from "../../actions";
 import { HorizontalAlignmentValue } from "./types";
 import { Root } from "./ActionsViz.styled";
@@ -109,6 +111,7 @@ interface ActionWizStateProps {
 interface ActionWizDispatchProps {
   deleteRow: (payload: DeleteRowFromDataAppPayload) => void;
   insertRow: (payload: InsertRowFromDataAppPayload) => void;
+  updateRow: (payload: UpdateRowFromDataAppPayload) => void;
 }
 
 type ActionsVizProps = ActionVizOwnProps &
@@ -124,6 +127,7 @@ function mapStateToProps(state: State) {
 const mapDispatchToProps = {
   deleteRow: deleteRowFromDataApp,
   insertRow: createRowFromDataApp,
+  updateRow: updateRowFromDataApp,
 };
 
 function getObjectDetailViewData(
@@ -141,6 +145,7 @@ function ActionsViz({
   settings,
   deleteRow,
   insertRow,
+  updateRow,
 }: ActionsVizProps) {
   const [isModalOpen, { turnOn: showModal, turnOff: hideModal }] = useToggle(
     false,
@@ -192,7 +197,16 @@ function ActionsViz({
   }
 
   function handleUpdate(values: Record<string, unknown>) {
-    // pass
+    if (table && connectedDashCard && connectedCardData && row) {
+      const pkColumnIndex = connectedCardData.cols.findIndex(
+        col => col.semantic_type === "type/PK",
+      );
+      const pkValue = row[pkColumnIndex];
+      if (typeof pkValue !== "string" && typeof pkValue !== "number") {
+        return;
+      }
+      updateRow({ id: pkValue, table, values, dashCard: connectedDashCard });
+    }
   }
 
   function onDeleteClick() {

--- a/frontend/src/metabase/writeback/components/ActionsViz/ActionsViz.tsx
+++ b/frontend/src/metabase/writeback/components/ActionsViz/ActionsViz.tsx
@@ -75,7 +75,7 @@ const ACTIONS_VIZ_DEFINITION = {
 };
 
 interface ActionsVizProps extends VisualizationProps {
-  metadata: Metadata;
+  metadata?: Metadata;
 }
 
 function ActionsViz({ metadata, settings }: ActionsVizProps) {
@@ -84,7 +84,7 @@ function ActionsViz({ metadata, settings }: ActionsVizProps) {
   );
 
   const connectedTableId = settings["actions.linked_table"];
-  const connectedTable = metadata.table(connectedTableId);
+  const connectedTable = metadata?.table(connectedTableId);
   const hasConnectedTable = !!connectedTable;
 
   const hasCreateButton = settings["actions.create_enabled"];

--- a/frontend/src/metabase/writeback/components/ActionsViz/ActionsViz.tsx
+++ b/frontend/src/metabase/writeback/components/ActionsViz/ActionsViz.tsx
@@ -2,6 +2,11 @@ import React from "react";
 import { t } from "ttag";
 
 import Button from "metabase/core/components/Button";
+import Modal from "metabase/components/Modal";
+
+import { useToggle } from "metabase/hooks/use-toggle";
+
+import WritebackModalForm from "metabase/writeback/containers/WritebackModalForm";
 
 import Metadata from "metabase-lib/lib/metadata/Metadata";
 import { VisualizationProps } from "metabase-types/types/Visualization";
@@ -74,6 +79,10 @@ interface ActionsVizProps extends VisualizationProps {
 }
 
 function ActionsViz({ metadata, settings }: ActionsVizProps) {
+  const [isModalOpen, { turnOn: showModal, turnOff: hideModal }] = useToggle(
+    false,
+  );
+
   const connectedTableId = settings["actions.linked_table"];
   const connectedTable = metadata.table(connectedTableId);
   const hasConnectedTable = !!connectedTable;
@@ -87,20 +96,27 @@ function ActionsViz({ metadata, settings }: ActionsVizProps) {
   ] as HorizontalAlignmentValue;
 
   return (
-    <Root horizontalAlignment={horizontalAlignment}>
-      {hasCreateButton && (
-        <Button
-          disabled={!hasConnectedTable}
-          onClick={showModal}
-        >{t`New`}</Button>
+    <>
+      <Root horizontalAlignment={horizontalAlignment}>
+        {hasCreateButton && (
+          <Button
+            disabled={!hasConnectedTable}
+            onClick={showModal}
+          >{t`New`}</Button>
+        )}
+        {hasUpdateButton && (
+          <Button disabled={!hasConnectedTable}>{t`Edit`}</Button>
+        )}
+        {hasDeleteButton && (
+          <Button disabled={!hasConnectedTable} danger>{t`Delete`}</Button>
+        )}
+      </Root>
+      {connectedTable && (
+        <Modal isOpen={isModalOpen} onClose={hideModal}>
+          <WritebackModalForm table={connectedTable} onClose={hideModal} />
+        </Modal>
       )}
-      {hasUpdateButton && (
-        <Button disabled={!hasConnectedTable}>{t`Edit`}</Button>
-      )}
-      {hasDeleteButton && (
-        <Button disabled={!hasConnectedTable} danger>{t`Delete`}</Button>
-      )}
-    </Root>
+    </>
   );
 }
 

--- a/frontend/src/metabase/writeback/components/ActionsViz/ActionsViz.tsx
+++ b/frontend/src/metabase/writeback/components/ActionsViz/ActionsViz.tsx
@@ -176,16 +176,15 @@ function ActionsViz({
       : undefined;
   const row = connectedCardData?.rows[0];
 
-  const isEditingNotConnected = isEditing && !connectedDashCardId;
   const hasCreateButton =
     settings["actions.create_enabled"] &&
-    (!isObjectDetailView || isEditingNotConnected);
+    (!isObjectDetailView || !connectedDashCardId);
   const hasUpdateButton =
     settings["actions.update_enabled"] &&
-    (isObjectDetailView || isEditingNotConnected);
+    (isObjectDetailView || !connectedDashCardId);
   const hasDeleteButton =
     settings["actions.delete_enabled"] &&
-    (isObjectDetailView || isEditingNotConnected);
+    (isObjectDetailView || !connectedDashCardId);
 
   const horizontalAlignment = settings[
     "actions.align_horizontal"

--- a/frontend/src/metabase/writeback/components/ActionsViz/ActionsViz.tsx
+++ b/frontend/src/metabase/writeback/components/ActionsViz/ActionsViz.tsx
@@ -209,7 +209,7 @@ function ActionsViz({
     }
   }
 
-  function onDeleteClick() {
+  function handleDelete() {
     if (
       !question ||
       !table ||
@@ -261,7 +261,7 @@ function ActionsViz({
         {hasDeleteButton && (
           <Button
             disabled={!question}
-            onClick={onDeleteClick}
+            onClick={handleDelete}
             danger
           >{t`Delete`}</Button>
         )}

--- a/frontend/src/metabase/writeback/components/ActionsViz/ActionsViz.tsx
+++ b/frontend/src/metabase/writeback/components/ActionsViz/ActionsViz.tsx
@@ -1,0 +1,85 @@
+import React from "react";
+import { t } from "ttag";
+
+import Button from "metabase/core/components/Button";
+
+import { VisualizationProps } from "metabase-types/types/Visualization";
+
+import { HorizontalAlignmentValue } from "./types";
+import { Root } from "./ActionsViz.styled";
+
+const ACTIONS_VIZ_DEFINITION = {
+  uiName: t`Actions`,
+  identifier: "actions",
+  iconName: "bolt",
+
+  noHeader: true,
+  supportsSeries: false,
+  hidden: true,
+  supportPreviewing: false,
+
+  minSize: { width: 4, height: 1 },
+
+  checkRenderable: () => true,
+  isSensible: () => false,
+
+  settings: {
+    "card.title": {
+      dashboard: false,
+    },
+    "card.description": {
+      dashboard: false,
+    },
+    "actions.create_enabled": {
+      section: t`Default actions`,
+      title: t`Create enabled`,
+      widget: "toggle",
+      default: true,
+    },
+    "actions.update_enabled": {
+      section: t`Default actions`,
+      title: t`Update enabled`,
+      widget: "toggle",
+      default: true,
+    },
+    "actions.delete_enabled": {
+      section: t`Default actions`,
+      title: t`Delete enabled`,
+      widget: "toggle",
+      default: true,
+    },
+    "actions.align_horizontal": {
+      section: t`Display`,
+      title: t`Horizontal Alignment`,
+      widget: "select",
+      props: {
+        options: [
+          { name: t`Left`, value: "left" },
+          { name: t`Center`, value: "center" },
+          { name: t`Right`, value: "right" },
+        ],
+      },
+      default: "right",
+    },
+  },
+};
+
+function ActionsViz({ settings }: VisualizationProps) {
+  const hasCreateButton = settings["actions.create_enabled"];
+  const hasUpdateButton = settings["actions.update_enabled"];
+  const hasDeleteButton = settings["actions.delete_enabled"];
+
+  const horizontalAlignment = settings[
+    "actions.align_horizontal"
+  ] as HorizontalAlignmentValue;
+
+  return (
+    <Root horizontalAlignment={horizontalAlignment}>
+      {hasCreateButton && <Button>{t`New`}</Button>}
+      {hasUpdateButton && <Button>{t`Edit`}</Button>}
+      {hasDeleteButton && <Button danger>{t`Delete`}</Button>}
+    </Root>
+  );
+}
+
+export default Object.assign(ActionsViz, ACTIONS_VIZ_DEFINITION);

--- a/frontend/src/metabase/writeback/components/ActionsViz/ActionsViz.tsx
+++ b/frontend/src/metabase/writeback/components/ActionsViz/ActionsViz.tsx
@@ -1,16 +1,22 @@
 import React from "react";
 import { t } from "ttag";
+import { connect } from "react-redux";
 
 import Button from "metabase/core/components/Button";
 import Modal from "metabase/components/Modal";
 
 import { useToggle } from "metabase/hooks/use-toggle";
 
+import { getCardData } from "metabase/dashboard/selectors";
 import WritebackModalForm from "metabase/writeback/containers/WritebackModalForm";
 
 import Metadata from "metabase-lib/lib/metadata/Metadata";
 import Question from "metabase-lib/lib/Question";
-import { DashboardWithCards } from "metabase-types/types/Dashboard";
+
+import { State } from "metabase-types/store";
+import { SavedCard } from "metabase-types/types/Card";
+import { DashboardWithCards, DashCard } from "metabase-types/types/Dashboard";
+import { Dataset } from "metabase-types/types/Dataset";
 import { VisualizationProps } from "metabase-types/types/Visualization";
 
 import { HorizontalAlignmentValue } from "./types";
@@ -76,12 +82,41 @@ const ACTIONS_VIZ_DEFINITION = {
   },
 };
 
-interface ActionsVizProps extends VisualizationProps {
+// { [dashCardId]: { [cardId]: <dataset> } }
+type DashCardData = Record<number, Record<number, Dataset | undefined>>;
+
+interface ActionVizOwnProps extends VisualizationProps {
   dashboard: DashboardWithCards;
+  dashCardData?: DashCardData;
   metadata?: Metadata;
 }
 
-function ActionsViz({ dashboard, metadata, settings }: ActionsVizProps) {
+interface ActionWizStateProps {
+  dashCardData?: DashCardData;
+}
+
+type ActionsVizProps = ActionVizOwnProps & ActionWizStateProps;
+
+function mapStateToProps(state: State) {
+  return {
+    dashCardData: getCardData(state),
+  };
+}
+
+function getObjectDetailViewData(
+  dashCardData: DashCardData,
+  dashCard: DashCard<SavedCard>,
+): unknown[] | undefined {
+  const cardQueryResult = dashCardData[dashCard.id][dashCard.card_id];
+  return cardQueryResult?.data.rows[0];
+}
+
+function ActionsViz({
+  dashboard,
+  dashCardData,
+  metadata,
+  settings,
+}: ActionsVizProps) {
   const [isModalOpen, { turnOn: showModal, turnOff: hideModal }] = useToggle(
     false,
   );
@@ -97,6 +132,13 @@ function ActionsViz({ dashboard, metadata, settings }: ActionsVizProps) {
 
   const isObjectDetailView = question?.display() === "object";
   const table = question?.table();
+  const row =
+    connectedDashCard && isObjectDetailView && dashCardData
+      ? getObjectDetailViewData(
+          dashCardData,
+          connectedDashCard as DashCard<SavedCard>,
+        )
+      : undefined;
 
   const hasCreateButton =
     settings["actions.create_enabled"] && !isObjectDetailView;
@@ -115,18 +157,27 @@ function ActionsViz({ dashboard, metadata, settings }: ActionsVizProps) {
         {hasCreateButton && (
           <Button disabled={!question} onClick={showModal}>{t`New`}</Button>
         )}
-        {hasUpdateButton && <Button disabled={!question}>{t`Edit`}</Button>}
+        {hasUpdateButton && (
+          <Button disabled={!question} onClick={showModal}>{t`Edit`}</Button>
+        )}
         {hasDeleteButton && (
           <Button disabled={!question} danger>{t`Delete`}</Button>
         )}
       </Root>
       {!!table && (
         <Modal isOpen={isModalOpen} onClose={hideModal}>
-          <WritebackModalForm table={table} onClose={hideModal} />
+          <WritebackModalForm table={table} row={row} onClose={hideModal} />
         </Modal>
       )}
     </>
   );
 }
 
-export default Object.assign(ActionsViz, ACTIONS_VIZ_DEFINITION);
+const ConnectedActionsViz = connect<
+  ActionWizStateProps,
+  unknown,
+  ActionVizOwnProps,
+  State
+>(mapStateToProps)(ActionsViz);
+
+export default Object.assign(ConnectedActionsViz, ACTIONS_VIZ_DEFINITION);

--- a/frontend/src/metabase/writeback/components/ActionsViz/ActionsViz.tsx
+++ b/frontend/src/metabase/writeback/components/ActionsViz/ActionsViz.tsx
@@ -26,7 +26,9 @@ import { VisualizationProps } from "metabase-types/types/Visualization";
 
 import {
   DeleteRowFromDataAppPayload,
+  InsertRowFromDataAppPayload,
   deleteRowFromDataApp,
+  createRowFromDataApp,
 } from "../../actions";
 import { HorizontalAlignmentValue } from "./types";
 import { Root } from "./ActionsViz.styled";
@@ -106,6 +108,7 @@ interface ActionWizStateProps {
 
 interface ActionWizDispatchProps {
   deleteRow: (payload: DeleteRowFromDataAppPayload) => void;
+  insertRow: (payload: InsertRowFromDataAppPayload) => void;
 }
 
 type ActionsVizProps = ActionVizOwnProps &
@@ -120,6 +123,7 @@ function mapStateToProps(state: State) {
 
 const mapDispatchToProps = {
   deleteRow: deleteRowFromDataApp,
+  insertRow: createRowFromDataApp,
 };
 
 function getObjectDetailViewData(
@@ -136,6 +140,7 @@ function ActionsViz({
   metadata,
   settings,
   deleteRow,
+  insertRow,
 }: ActionsVizProps) {
   const [isModalOpen, { turnOn: showModal, turnOff: hideModal }] = useToggle(
     false,
@@ -175,6 +180,20 @@ function ActionsViz({
   const horizontalAlignment = settings[
     "actions.align_horizontal"
   ] as HorizontalAlignmentValue;
+
+  function handleInsert(values: Record<string, unknown>) {
+    if (table && connectedDashCard) {
+      insertRow({
+        table,
+        values,
+        dashCard: connectedDashCard,
+      });
+    }
+  }
+
+  function handleUpdate(values: Record<string, unknown>) {
+    // pass
+  }
 
   function onDeleteClick() {
     if (
@@ -235,7 +254,12 @@ function ActionsViz({
       </Root>
       {!!table && (
         <Modal isOpen={isModalOpen} onClose={hideModal}>
-          <WritebackModalForm table={table} row={row} onClose={hideModal} />
+          <WritebackModalForm
+            table={table}
+            row={row}
+            onSubmit={row ? handleUpdate : handleInsert}
+            onClose={hideModal}
+          />
         </Modal>
       )}
       {confirmationModalContent}

--- a/frontend/src/metabase/writeback/components/ActionsViz/ActionsViz.tsx
+++ b/frontend/src/metabase/writeback/components/ActionsViz/ActionsViz.tsx
@@ -141,6 +141,7 @@ function getObjectDetailViewData(
 function ActionsViz({
   dashboard,
   dashCardData,
+  isEditing,
   metadata,
   settings,
   deleteRow,
@@ -175,12 +176,16 @@ function ActionsViz({
       : undefined;
   const row = connectedCardData?.rows[0];
 
+  const isEditingNotConnected = isEditing && !connectedDashCardId;
   const hasCreateButton =
-    settings["actions.create_enabled"] && !isObjectDetailView;
+    settings["actions.create_enabled"] &&
+    (!isObjectDetailView || isEditingNotConnected);
   const hasUpdateButton =
-    settings["actions.update_enabled"] && isObjectDetailView;
+    settings["actions.update_enabled"] &&
+    (isObjectDetailView || isEditingNotConnected);
   const hasDeleteButton =
-    settings["actions.delete_enabled"] && isObjectDetailView;
+    settings["actions.delete_enabled"] &&
+    (isObjectDetailView || isEditingNotConnected);
 
   const horizontalAlignment = settings[
     "actions.align_horizontal"

--- a/frontend/src/metabase/writeback/components/ActionsViz/ActionsViz.tsx
+++ b/frontend/src/metabase/writeback/components/ActionsViz/ActionsViz.tsx
@@ -197,14 +197,14 @@ function ActionsViz({
   }
 
   function handleUpdate(values: Record<string, unknown>) {
-    if (table && connectedDashCard && connectedCardData && row) {
-      const pkColumnIndex = connectedCardData.cols.findIndex(
-        col => col.semantic_type === "type/PK",
-      );
-      const pkValue = row[pkColumnIndex];
-      if (typeof pkValue !== "string" && typeof pkValue !== "number") {
-        return;
-      }
+    if (!table || !connectedDashCard || !connectedCardData || !row) {
+      return;
+    }
+    const pkColumnIndex = connectedCardData.cols.findIndex(
+      col => col.semantic_type === "type/PK",
+    );
+    const pkValue = row[pkColumnIndex];
+    if (typeof pkValue === "string" || typeof pkValue === "number") {
       updateRow({ id: pkValue, table, values, dashCard: connectedDashCard });
     }
   }

--- a/frontend/src/metabase/writeback/components/ActionsViz/ActionsViz.tsx
+++ b/frontend/src/metabase/writeback/components/ActionsViz/ActionsViz.tsx
@@ -3,6 +3,7 @@ import { t } from "ttag";
 
 import Button from "metabase/core/components/Button";
 
+import Metadata from "metabase-lib/lib/metadata/Metadata";
 import { VisualizationProps } from "metabase-types/types/Visualization";
 
 import { HorizontalAlignmentValue } from "./types";
@@ -48,6 +49,10 @@ const ACTIONS_VIZ_DEFINITION = {
       widget: "toggle",
       default: true,
     },
+    "actions.linked_table": {
+      section: t`Default actions`,
+      title: t`Linked table`,
+    },
     "actions.align_horizontal": {
       section: t`Display`,
       title: t`Horizontal Alignment`,
@@ -64,7 +69,15 @@ const ACTIONS_VIZ_DEFINITION = {
   },
 };
 
-function ActionsViz({ settings }: VisualizationProps) {
+interface ActionsVizProps extends VisualizationProps {
+  metadata: Metadata;
+}
+
+function ActionsViz({ metadata, settings }: ActionsVizProps) {
+  const connectedTableId = settings["actions.linked_table"];
+  const connectedTable = metadata.table(connectedTableId);
+  const hasConnectedTable = !!connectedTable;
+
   const hasCreateButton = settings["actions.create_enabled"];
   const hasUpdateButton = settings["actions.update_enabled"];
   const hasDeleteButton = settings["actions.delete_enabled"];
@@ -75,9 +88,18 @@ function ActionsViz({ settings }: VisualizationProps) {
 
   return (
     <Root horizontalAlignment={horizontalAlignment}>
-      {hasCreateButton && <Button>{t`New`}</Button>}
-      {hasUpdateButton && <Button>{t`Edit`}</Button>}
-      {hasDeleteButton && <Button danger>{t`Delete`}</Button>}
+      {hasCreateButton && (
+        <Button
+          disabled={!hasConnectedTable}
+          onClick={showModal}
+        >{t`New`}</Button>
+      )}
+      {hasUpdateButton && (
+        <Button disabled={!hasConnectedTable}>{t`Edit`}</Button>
+      )}
+      {hasDeleteButton && (
+        <Button disabled={!hasConnectedTable} danger>{t`Delete`}</Button>
+      )}
     </Root>
   );
 }

--- a/frontend/src/metabase/writeback/components/ActionsViz/index.ts
+++ b/frontend/src/metabase/writeback/components/ActionsViz/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ActionsViz";

--- a/frontend/src/metabase/writeback/components/ActionsViz/types.ts
+++ b/frontend/src/metabase/writeback/components/ActionsViz/types.ts
@@ -1,0 +1,1 @@
+export type HorizontalAlignmentValue = "left" | "center" | "right";

--- a/frontend/src/metabase/writeback/containers/WritebackForm.tsx
+++ b/frontend/src/metabase/writeback/containers/WritebackForm.tsx
@@ -14,7 +14,7 @@ import CategoryFieldPicker from "./CategoryFieldPicker";
 export interface WritebackFormProps {
   table: Table;
   row?: unknown[];
-  onSubmit?: (values: { [key: string]: Value }) => void;
+  onSubmit?: (values: Record<string, unknown>) => void;
 
   // Form props
   isModal?: boolean;

--- a/frontend/src/metabase/writeback/containers/WritebackForm.tsx
+++ b/frontend/src/metabase/writeback/containers/WritebackForm.tsx
@@ -80,9 +80,25 @@ function WritebackForm({ table, row, onSubmit, ...props }: WritebackFormProps) {
 
   const handleSubmit = useCallback(
     values => {
-      onSubmit?.(values);
+      const isUpdate = !!row;
+      const changes = isUpdate ? {} : values;
+
+      if (isUpdate) {
+        const fields = form.fields;
+
+        // makes sure we only pass fields that were actually changed
+        Object.keys(values).forEach(fieldName => {
+          const field = fields.find(field => field.name === fieldName);
+          const hasChanged = !field || field.initial !== values[fieldName];
+          if (hasChanged) {
+            changes[fieldName] = values[fieldName];
+          }
+        });
+      }
+
+      onSubmit?.(changes);
     },
-    [onSubmit],
+    [form, row, onSubmit],
   );
 
   const submitTitle = row ? t`Update` : t`Create`;


### PR DESCRIPTION
Adds a new type of card for "data app dashboards" (at this point it's just a dashboard with a name ending with "App"). The card will contain "New", "Update" and "Delete" buttons. You can connect the actions card to another card and the buttons will use the connected card's data and metadata to allow inserts, updates, and deletes.