### PR TITLE
Repro #23024: Not possible to connect dashboard filters to a Model based on SQL

### DIFF
--- a/frontend/test/metabase/scenarios/models/reproductions/23024-cannot-apply-dash-filter-native-model.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/reproductions/23024-cannot-apply-dash-filter-native-model.cy.spec.js
@@ -1,0 +1,89 @@
+import {
+  restore,
+  popover,
+  visitDashboard,
+  editDashboard,
+} from "__support__/e2e/cypress";
+
+import { openDetailsSidebar } from "../helpers/e2e-models-helpers";
+
+describe.skip("issue 23024", () => {
+  beforeEach(() => {
+    cy.intercept("POST", "/api/card/*/query").as("cardQuery");
+    cy.intercept("PUT", "/api/card/*").as("updateMetadata");
+
+    restore();
+    cy.signInAsAdmin();
+
+    cy.createNativeQuestion(
+      {
+        native: {
+          query: `select * from products limit 5`,
+        },
+        dataset: true,
+      },
+      { wrapId: true, idAlias: "modelId", visitQuestion: true },
+    );
+
+    openDetailsSidebar();
+
+    cy.findByText("Customize metadata").click();
+    cy.wait(["@cardQuery", "@cardQuery"]);
+
+    cy.findByText("CATEGORY").click();
+
+    mapColumnTo({ table: "Products", column: "Category" });
+
+    cy.button("Save changes").click();
+    cy.wait("@updateMetadata");
+
+    addModelToDashboardAndVisit();
+  });
+
+  it("should be possible to apply the dashboard filter to the native model (metabase#23024)", () => {
+    editDashboard();
+
+    cy.icon("filter").click();
+
+    cy.findByText("Text or Category").click();
+    cy.findByText("Dropdown").click();
+
+    cy.findByText("Column to filter on")
+      .parent()
+      .within(() => {
+        cy.findByText("Select…").click();
+      });
+
+    popover().contains("Category");
+  });
+});
+
+function mapColumnTo({ table, column } = {}) {
+  cy.findByText("Database column this maps to")
+    .closest(".Form-field")
+    .contains("None")
+    .click();
+
+  popover()
+    .findByText(table)
+    .click();
+  popover()
+    .findByText(column)
+    .click();
+
+  cy.findByDisplayValue(column);
+}
+
+function addModelToDashboardAndVisit() {
+  cy.createDashboard().then(({ body: { id } }) => {
+    cy.get("@modelId").then(cardId => {
+      cy.request("POST", `/api/dashboard/${id}/cards`, {
+        cardId,
+        sizeX: 16,
+        sizeY: 10,
+      });
+    });
+
+    visitDashboard(id);
+  });
+}


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #23024

### How to test this manually?
- `yarn test-cypress-open`
- `metabase/scenarios/models/reproductions/23024-cannot-apply-dash-filter-native-model.cy.spec.js`
- Unskip repro
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/171490774-ba74d5d1-1df6-414e-9070-1ea65229b0eb.png)
