### PR TITLE
Fix print layout

### DIFF
--- a/frontend/src/metabase/App.styled.tsx
+++ b/frontend/src/metabase/App.styled.tsx
@@ -15,10 +15,19 @@ export const AppContentContainer = styled.div<{
     props.isAppBarVisible ? `calc(100vh - ${APP_BAR_HEIGHT})` : "100vh"};
   background-color: ${props =>
     color(props.isAdminApp ? "bg-white" : "content")};
+
+  @media print {
+    height: 100%;
+    overflow: visible !important;
+  }
 `;
 
 export const AppContent = styled.main`
   width: 100%;
   height: 100%;
   overflow: auto;
+
+  @media print {
+    overflow: visible !important;
+  }
 `;

--- a/frontend/src/metabase/nav/containers/AppBar.styled.tsx
+++ b/frontend/src/metabase/nav/containers/AppBar.styled.tsx
@@ -21,6 +21,10 @@ export const AppBarRoot = styled.header`
   background-color: ${color("bg-white")};
   border-bottom: 1px solid ${color("border")};
   z-index: 4;
+
+  @media print {
+    display: none;
+  }
 `;
 
 export const LogoLink = styled(Link)`


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/23098

## Changes

Our dashboards has never been very printable and it will require some effort to make them so due to the way we position cards. Nevertheless, this PR makes it less horrible and allows having more than 1 page as it was in 42 release.

## How to verify

Create a dashboard with cards that can fit in one page. Press `ctrl + p` to print it. Ensure the result can contain more than one page.