### PR TITLE
Remove unneeded URIs from content security policy header

### DIFF
--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -53,7 +53,6 @@
                                    "https://maps.google.com"
                                    "https://accounts.google.com"
                                    "https://*.googleapis.com"
-                                   "*.gstatic.com"
                                    (when (public-settings/anon-tracking-enabled)
                                      "https://www.google-analytics.com")
                                    ;; for webpack hot reloading

--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -63,6 +63,9 @@
                                      "'unsafe-inline'")]
                                   (when-not config/is-dev?
                                     (map (partial format "'sha256-%s'") inline-js-hashes)))
+                  :child-src    ["'self'"
+                                 ;; TODO - double check that we actually need this for Google Auth
+                                 "https://accounts.google.com"]
                   :style-src    ["'self'"
                                  "'unsafe-inline'"
                                  "https://accounts.google.com"]
@@ -72,6 +75,8 @@
                   :img-src      ["*"
                                  "'self' data:"]
                   :connect-src  ["'self'"
+                                 ;; Google Identity Services
+                                 "https://accounts.google.com"
                                  ;; MailChimp. So people can sign up for the Metabase mailing list in the sign up process
                                  "metabase.us10.list-manage.com"
                                  ;; Google analytics

--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -63,9 +63,6 @@
                                      "'unsafe-inline'")]
                                   (when-not config/is-dev?
                                     (map (partial format "'sha256-%s'") inline-js-hashes)))
-                  :child-src    ["'self'"
-                                 ;; TODO - double check that we actually need this for Google Auth
-                                 "https://accounts.google.com"]
                   :style-src    ["'self'"
                                  "'unsafe-inline'"
                                  "https://accounts.google.com"]

--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -51,6 +51,7 @@
                                   ["'self'"
                                    "'unsafe-eval'" ; TODO - we keep working towards removing this entirely
                                    "https://maps.google.com"
+                                   "https://accounts.google.com"
                                    (when (public-settings/anon-tracking-enabled)
                                      "https://www.google-analytics.com")
                                    ;; for webpack hot reloading

--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -51,8 +51,6 @@
                                   ["'self'"
                                    "'unsafe-eval'" ; TODO - we keep working towards removing this entirely
                                    "https://maps.google.com"
-                                   "https://accounts.google.com"
-                                   "https://*.googleapis.com"
                                    (when (public-settings/anon-tracking-enabled)
                                      "https://www.google-analytics.com")
                                    ;; for webpack hot reloading

--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -72,8 +72,6 @@
                   :img-src      ["*"
                                  "'self' data:"]
                   :connect-src  ["'self'"
-                                 ;; Google Identity Services
-                                 "https://accounts.google.com"
                                  ;; MailChimp. So people can sign up for the Metabase mailing list in the sign up process
                                  "metabase.us10.list-manage.com"
                                  ;; Google analytics


### PR DESCRIPTION
Here we remove URIs that we no longer use to load resources.