### PR TITLE
allow equal or greater starting from units only

### DIFF
--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RelativeDatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RelativeDatePicker.tsx
@@ -122,6 +122,25 @@ const TIME_PERIODS = ["minute", "hour"];
 // define ALL_PERIODS in increasing order of duration
 const ALL_PERIODS = TIME_PERIODS.concat(DATE_PERIODS.flat());
 
+const isSmallerUnit = (unit: string, unitToCompare: string) => {
+  return ALL_PERIODS.indexOf(unit) < ALL_PERIODS.indexOf(unitToCompare);
+};
+
+const getStartingFromUnits = (
+  filterUnit: string,
+  selectedStartingFromUnit: string,
+) => {
+  const largerUnits = ALL_PERIODS.filter(
+    period => !isSmallerUnit(period, filterUnit),
+  );
+
+  if (!largerUnits.includes(selectedStartingFromUnit)) {
+    largerUnits.unshift(selectedStartingFromUnit);
+  }
+
+  return largerUnits;
+};
+
 const getCurrentString = (filter: Filter) =>
   t`Include ${getCurrentIntervalName(filter)}`;
 
@@ -290,7 +309,7 @@ const RelativeDatePicker: React.FC<Props> = props => {
             }
             intervals={Math.abs(startingFrom[0])}
             formatter={formatter}
-            periods={ALL_PERIODS}
+            periods={getStartingFromUnits(unit, startingFrom[1])}
             testId="starting-from-unit"
           />
           <MoreButton

--- a/frontend/test/metabase/scenarios/filters/relative-datetime.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/relative-datetime.cy.spec.js
@@ -98,7 +98,40 @@ describe("scenarios > question > relative-datetime", () => {
     });
   });
 
+  function assertOptions(expectedOptions) {
+    cy.findAllByRole("option").each(($option, index) => {
+      cy.wrap($option).should("have.text", expectedOptions[index]);
+    });
+  }
+
   describe("basic functionality", () => {
+    it("starting from should contain units only equal or greater than the filter unit", () => {
+      openOrdersTable();
+
+      cy.findByTextEnsureVisible("Created At").click();
+      popover().within(() => {
+        cy.findByText("Filter by this column").click();
+        cy.findByText("Relative dates...").click();
+      });
+
+      addStartingFrom();
+
+      cy.findByTestId("starting-from-unit").click();
+
+      assertOptions([
+        "days ago",
+        "weeks ago",
+        "months ago",
+        "quarters ago",
+        "years ago",
+      ]);
+
+      setRelativeDatetimeUnit("quarters");
+      cy.findByTestId("starting-from-unit").click();
+
+      assertOptions(["quarters ago", "years ago"]);
+    });
+
     it("should go back to shortcuts view", () => {
       openOrdersTable();
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/23099

## Changes

<img width="500" alt="Screenshot 2022-06-02 at 21 25 49" src="https://user-images.githubusercontent.com/14301985/171688327-00c84ac3-73f3-4f8d-b9ea-71dc52bf5daa.png">

This PR removes the ability to select "Starting from" units smaller than the filter unit. On the screenshot above it lists only `months`, `quarets`, and `years` since the filter unit is `months`. 

The reason is that having smaller units for "Starting from" adds not very useful use cases like "Past 1 month, Starting from 1 day ago".

## How to verify

- New question -> Orders -> Visualize
- Go to Created At filter -> Relative dates
- Ensure when you use "Starting from" for Past or Next filters it does not show units smaller than units of the filter
