### PR TITLE
[E2E] Remove `sharing` group from checks on CCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1261,7 +1261,6 @@ workflows:
                   "organization",
                   "permissions",
                   "question",
-                  "sharing",
                   "smoketest",
                   "visualizations",
                 ]


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- In the same manner we did for #22907, this PR removes `sharing` E2E group from CircleCI because we've been running it successfully using GitHub actions.

### Note
There are no flakes or failed tests from this group in the last 60 days!