### PR TITLE
[E2E] Simplify CircleCI Cypress workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -908,6 +908,9 @@ jobs:
       test-files:
         type: string
         default: ""
+      grep:
+        type: string
+        default: ""
       qa-db:
         type: boolean
         default: false
@@ -946,6 +949,7 @@ jobs:
                   run test-cypress-run \
                   <<# parameters.test-files >> --spec << parameters.test-files >> <</ parameters.test-files >> \
                   <<# parameters.source-folder >> --folder << parameters.source-folder >> <</ parameters.source-folder >>
+                  <<# parameters.grep >> --env << parameters.grep >> <</ parameters.grep >>
                 after-steps:
                   - store_artifacts:
                       path: /home/circleci/metabase/metabase/cypress
@@ -1249,7 +1253,7 @@ workflows:
       - fe-tests-cypress:
           matrix:
             parameters:
-              edition: ["ee", "oss"]
+              edition: ["ee"]
               folder:
                 [
                   "admin",
@@ -1270,6 +1274,23 @@ workflows:
             - snowplow-deps
           cypress-group: "<< matrix.folder >>-<< matrix.edition >>"
           source-folder: << matrix.folder >>
+          qa-db: true
+          snowplow: true
+          before-steps:
+            - run-snowplow-micro
+            - wait-for-databases
+
+      - fe-tests-cypress:
+          matrix:
+            parameters:
+              edition: ["oss"]
+          name: e2e-tests-<< matrix.edition >>
+          requires:
+            - build-uberjar-<< matrix.edition >>
+            - snowplow-deps
+          cypress-group: e2e-tests-<< matrix.edition >>
+          test-files: "./frontend/test/metabase/scenarios/**/*.cy.spec.js"
+          grep: "grepTags=@OSS,grepFilterSpecs=true"
           qa-db: true
           snowplow: true
           before-steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1289,7 +1289,6 @@ workflows:
             - build-uberjar-<< matrix.edition >>
             - snowplow-deps
           cypress-group: e2e-tests-<< matrix.edition >>
-          test-files: "./frontend/test/metabase/scenarios/**/*.cy.spec.js"
           grep: "grepTags=@OSS,grepFilterSpecs=true"
           qa-db: true
           snowplow: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -947,9 +947,9 @@ jobs:
                   # Make both `test-files`,  `source-folder` and `currents-record` parameters optional. Translates to: if `parameter` => run associated flag (`--spec`, `--folder` and `--key $CURRENTS_KEY --record` respectively)
                 command: |
                   run test-cypress-run \
+                  <<# parameters.grep >> --env << parameters.grep >> <</ parameters.grep >>
                   <<# parameters.test-files >> --spec << parameters.test-files >> <</ parameters.test-files >> \
                   <<# parameters.source-folder >> --folder << parameters.source-folder >> <</ parameters.source-folder >>
-                  <<# parameters.grep >> --env << parameters.grep >> <</ parameters.grep >>
                 after-steps:
                   - store_artifacts:
                       path: /home/circleci/metabase/metabase/cypress

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -947,7 +947,7 @@ jobs:
                   # Make both `test-files`,  `source-folder` and `currents-record` parameters optional. Translates to: if `parameter` => run associated flag (`--spec`, `--folder` and `--key $CURRENTS_KEY --record` respectively)
                 command: |
                   run test-cypress-run \
-                  <<# parameters.grep >> --env << parameters.grep >> <</ parameters.grep >>
+                  <<# parameters.grep >> --env << parameters.grep >> <</ parameters.grep >> \
                   <<# parameters.test-files >> --spec << parameters.test-files >> <</ parameters.test-files >> \
                   <<# parameters.source-folder >> --folder << parameters.source-folder >> <</ parameters.source-folder >>
                 after-steps:


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Simplifies E2E CircleCI workflow in such a way that:
1. We run all (remaining) Cypress tests only against EE version (in the same manner as #21676)
2. We run OSS specific tests using `cypress-grep` (in the same manner as #23009)

As of #22986, we basically run E2E tests in CircleCI only on PRs.

With the changes proposed in this PR, the logic on CircleCi will now match the one in [E2E runs on PR](https://github.com/metabase/metabase/blob/master/.github/workflows/e2e-tests.yml) in GitHub Actions.

This moves us one more step closer to completely removing E2E tests from CircleCI. It should also further reduce our CCI usage and free up some resources for other tasks.