### PR TITLE
Postgres create driver -- fix typo

### DIFF
--- a/src/metabase/driver/sql_jdbc/actions.clj
+++ b/src/metabase/driver/sql_jdbc/actions.clj
@@ -76,7 +76,7 @@
                         (assoc :values [create-row]))]
 
     {:created-row
-     (if (= :driver :postgres)
+     (if (= driver :postgres)
        ;; postgres is happy with "returning *", However:
        ;; for mysql: to return all the columns we must add them to the column list and provide default values in the VALUES clause.
        ;; for h2: I don't see an easy way to do it, so for those two, just use select *.


### PR DESCRIPTION
I noticed that this was wrong, so I am fixing it.