### PR TITLE
Properly tag strings in dashboard subscription sidebar

### DIFF
--- a/frontend/src/metabase/sharing/components/NewPulseSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/NewPulseSidebar.jsx
@@ -55,7 +55,7 @@ function NewPulseSidebar({
               {!emailConfigured &&
                 jt`You'll need to ${(
                   <Link key="link" to="/admin/settings/email" className="link">
-                    set up email
+                    {t`set up email`}
                   </Link>
                 )} first.`}
               {emailConfigured &&
@@ -93,7 +93,7 @@ function NewPulseSidebar({
               {!slackConfigured &&
                 jt`First, you'll have to ${(
                   <Link key="link" to="/admin/settings/slack" className="link">
-                    configure Slack
+                    {t`configure Slack`}
                   </Link>
                 )}.`}
               {slackConfigured &&


### PR DESCRIPTION
Fixes #22835 

With string debug mode on to show the strings are tagged:

<img width="392" alt="image" src="https://user-images.githubusercontent.com/2223916/171757921-658bc232-ffe1-4b4a-a33e-f46a30c319a4.png">
