### PR TITLE
Github Actions CI: allow skipping the dependency cache

### DIFF
--- a/.github/actions/prepare-backend/action.yml
+++ b/.github/actions/prepare-backend/action.yml
@@ -24,8 +24,13 @@ runs:
       run: |
         curl -O https://download.clojure.org/install/linux-install-${{ inputs.clojure-version }}.sh &&
         sudo bash ./linux-install-${{ inputs.clojure-version }}.sh
+    - name: Check to see if dependencies should be cached
+      if: ${{ contains(github.event.head_commit.message, '[ci nocache]') }}
+      run: echo "Commit message includes [ci nocache]; dependencies will NOT be cached"
+      shell: bash
     - name: Get M2 cache
       uses: actions/cache@v2
+      if: ${{ !contains(github.event.head_commit.message, '[ci nocache]') }}
       with:
         path: |
           ~/.m2

--- a/.github/actions/prepare-cypress/action.yml
+++ b/.github/actions/prepare-cypress/action.yml
@@ -2,8 +2,13 @@ name: Prepare cypress environment
 runs:
   using: "composite"
   steps:
+    - name: Check to see if dependencies should be cached
+      if: ${{ contains(github.event.head_commit.message, '[ci nocache]') }}
+      run: echo "Commit message includes [ci nocache]; dependencies will NOT be cached"
+      shell: bash
     - name: Get Cypress cache
       uses: actions/cache@v2
+      if: ${{ !contains(github.event.head_commit.message, '[ci nocache]') }}
       with:
         path: ~/.cache/Cypress
         key: ${{ runner.os }}-Cypress-${{ hashFiles('**/yarn.lock') }}

--- a/.github/actions/prepare-frontend/action.yml
+++ b/.github/actions/prepare-frontend/action.yml
@@ -7,13 +7,21 @@ runs:
       with:
         node-version: 14.x
         cache: 'yarn'
+    - name: Check to see if dependencies should be cached
+      if: ${{ contains(github.event.head_commit.message, '[ci nocache]') }}
+      run: |
+        echo "Commit message includes [ci nocache]; dependencies will NOT be cached"
+        yarn cache clean
+      shell: bash
     - name: Get M2 cache
       uses: actions/cache@v2
+      if: ${{ !contains(github.event.head_commit.message, '[ci nocache]') }}
       with:
         path: ~/.m2
         key: ${{ runner.os }}-cljs-${{ hashFiles('**/shadow-cljs.edn') }}
     - name: Get node_modules cache
       uses: actions/cache@v2
+      if: ${{ !contains(github.event.head_commit.message, '[ci nocache]') }}
       with:
         path: node_modules
         key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}


### PR DESCRIPTION
If the (last) commit message contains `[ci nocache]`, then Maven and npm dependencies will be always freshly fetched from their respective sources, instead of from the existing cache.

### Before this PR

Note the log indicating the cache restoration, right before `yarn install`:

> Cache restored from key: Linux-node-modules-c296046393b45531187f807eb375b2c30e31020a8e234a505f51c438a4efebca

![image](https://user-images.githubusercontent.com/7288/171782078-68990db5-a5db-4710-b344-4ff3c4f9c98c.png)

### After this PR

Here's what happens to `prepare-frontend` step (the same applies to backend) when `[ci nocache]` is detected in the commit message. Right before `yarn install`, there is an explicit log indicating:

> Commit message includes [ci nocache]; dependencies will NOT be cached
> yarn cache clean

![image](https://user-images.githubusercontent.com/7288/171786759-d5868860-df9f-465c-8c0b-bb437d84e5c3.png)

Also note that the entire _Prepare front-end environment_ step is notoriously slower, over 3 minutes instead of just < 1 min, because all the packages must be fetched from the upstream registry.