### PR TITLE
Limit to scan 1000 distinct values for field values

### DIFF
--- a/src/metabase/db/metadata_queries.clj
+++ b/src/metabase/db/metadata_queries.clj
@@ -64,7 +64,7 @@
   * Not being too low, which would definitely result in GitHub issues along the lines of 'My 500-distinct-value Field
     that I marked as List is not showing all values in the List Widget'
   * Not being too high, which would result in Metabase running out of memory dealing with too many values"
-  (int 5000))
+  (int 1000))
 
 (s/defn field-distinct-values
   "Return the distinct values of `field`.
@@ -74,7 +74,7 @@
 
   ([field max-results :- su/IntGreaterThanZero]
    (mapv first (field-query field {:breakout [[:field (u/the-id field) nil]]
-                                   :limit    max-results}))))
+                                   :limit    (min max-results absolute-max-distinct-values-limit)}))))
 
 (defn field-distinct-count
   "Return the distinct count of `field`."


### PR DESCRIPTION
Partially addresses #16104

This PR should addresses the 1st issue:
> Decide on a sane value for both scan and UI, which doesn't cause regressions - perhaps 1000 ?