### PR TITLE
[E2E] Fix permissions pin flake

### DIFF
--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -73,8 +73,11 @@ describe("collection permissions", () => {
                   // Assert that we're starting from a scenario with no pins
                   cy.findByTestId("pinned-items").should("not.exist");
 
-                  pinItem("Orders in a dashboard"); // dashboard
-                  pinItem("Orders, Count"); // question
+                  pinItem("Orders in a dashboard");
+                  unpinnedItemsLeft(3);
+
+                  pinItem("Orders, Count");
+                  unpinnedItemsLeft(2);
 
                   // Should see "pinned items" and items should be in that section
                   cy.findByTestId("pinned-items").within(() => {
@@ -82,6 +85,13 @@ describe("collection permissions", () => {
                     cy.findByText("Orders, Count");
                   });
                 });
+
+                function unpinnedItemsLeft(count) {
+                  cy.findAllByTestId("collection-entry").should(
+                    "have.length",
+                    count,
+                  );
+                }
               });
 
               describe("move", () => {


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Fixes the flake in collections permissions re: pinning items
This was one of the flakiest tests in the last 14 days
![image](https://user-images.githubusercontent.com/31325167/171902990-44fae9be-c6b1-4bf8-b8d5-66f1f30554b6.png)

### What caused the flake and how it was fixed?
Cause
Cypress was sometimes trying to find "Orders, Count" string during re-render. When we click on the pin, it takes some time until we re-render the item as pinned. Cypress was much faster than that so it most probably originally finds the string and then when it wants to click on it, that DOM element was in the detached state.

Solution
I've added an explicit assertion that the unpinned items left is less than before we pinned the item. That means that the page already re-rendered and it's now safe for Cypress to continue.

Notice the DOM/screen in the moment when Cypress finds "Orders, Count"
Before
![image](https://user-images.githubusercontent.com/31325167/171904371-ba74fc1f-9e44-41ec-b0f7-875777c434df.png)

After the fix
![image](https://user-images.githubusercontent.com/31325167/171904268-174cf41d-3cb9-4796-b8e3-81e1b301b472.png)
