### PR TITLE
Better FE feedback for CRUD actions

### DIFF
--- a/frontend/src/metabase/containers/UndoListing.jsx
+++ b/frontend/src/metabase/containers/UndoListing.jsx
@@ -4,6 +4,7 @@ import { connect } from "react-redux";
 import { t } from "ttag";
 import _ from "underscore";
 
+import { color } from "metabase/lib/colors";
 import { capitalize, inflect } from "metabase/lib/formatting";
 import { dismissUndo, performUndo } from "metabase/redux/undo";
 import { getUndos } from "metabase/selectors/undo";
@@ -61,8 +62,11 @@ UndoToast.propTypes = {
 };
 
 function UndoToast({ undo, onUndo, onDismiss }) {
+  const style = undo.toastColor
+    ? { backgroundColor: color(undo.toastColor) }
+    : undefined;
   return (
-    <ToastCard dark data-testid="toast-undo">
+    <ToastCard dark data-testid="toast-undo" style={style}>
       <CardContent>
         <CardContentSide>
           <CardIcon name={undo.icon || "check"} color="white" />

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
@@ -250,7 +250,7 @@ export function ObjectDetailFn({
   const onSubmit = React.useMemo(
     () =>
       canEdit && table
-        ? (values: any) => {
+        ? (values: Record<string, unknown>) => {
             updateRowFromObjectDetail({
               table,
               id: zoomedRowID,
@@ -261,6 +261,7 @@ export function ObjectDetailFn({
         : undefined,
     [updateRowFromObjectDetail, canEdit, table, zoomedRowID],
   );
+  const canUpdate = isEditing && typeof onSubmit === "function" && table;
 
   const onKeyDown = (event: KeyboardEvent) => {
     const capturedKeys: { [key: string]: () => void } = {
@@ -318,7 +319,7 @@ export function ObjectDetailFn({
             onToggleEditingModeClick={() => setIsEditing(editing => !editing)}
           />
           <ObjectDetailBodyWrapper>
-            {isEditing && table ? (
+            {canUpdate ? (
               <EditingFormContainer>
                 <WritebackForm
                   table={table}

--- a/frontend/src/metabase/writeback/actions.ts
+++ b/frontend/src/metabase/writeback/actions.ts
@@ -168,13 +168,24 @@ export type DeleteRowFromDataAppPayload = DeleteRowPayload & {
 
 export const deleteRowFromDataApp = (payload: DeleteRowFromDataAppPayload) => {
   return async (dispatch: any) => {
-    const result = await deleteRow(payload);
-    if (result?.["rows-deleted"]?.length > 0) {
-      const { dashCard } = payload;
+    try {
+      const result = await deleteRow(payload);
+      if (result?.["rows-deleted"]?.length > 0) {
+        const { dashCard } = payload;
+        dispatch(
+          fetchCardData(dashCard.card, dashCard, {
+            reload: true,
+            ignoreCache: true,
+          }),
+        );
+      }
+    } catch (err) {
+      console.error(err);
       dispatch(
-        fetchCardData(dashCard.card, dashCard, {
-          reload: true,
-          ignoreCache: true,
+        addUndo({
+          icon: "warning",
+          toastColor: "error",
+          message: t`Something went wrong while deleting the row`,
         }),
       );
     }

--- a/frontend/src/metabase/writeback/actions.ts
+++ b/frontend/src/metabase/writeback/actions.ts
@@ -1,5 +1,9 @@
+import { t } from "ttag";
+
 import { ActionsApi } from "metabase/services";
 import Table from "metabase-lib/lib/metadata/Table";
+
+import { addUndo } from "metabase/redux/undo";
 
 import { fetchCardData } from "metabase/dashboard/actions";
 import { runQuestionQuery } from "metabase/query_builder/actions/querying";
@@ -45,12 +49,19 @@ export type InsertRowFromDataAppPayload = InsertRowPayload & {
 export const createRowFromDataApp = (payload: InsertRowFromDataAppPayload) => {
   return async (dispatch: any) => {
     const result = await createRow(payload);
+    const { table } = payload;
     if (result?.["created-row"]?.id) {
       const { dashCard } = payload;
       dispatch(
         fetchCardData(dashCard.card, dashCard, {
           reload: true,
           ignoreCache: true,
+        }),
+      );
+      dispatch(
+        addUndo({
+          message: t`Successfully inserted a row into the ${table.displayName()} table`,
+          toastColor: "success",
         }),
       );
     }

--- a/frontend/src/metabase/writeback/components/ActionsViz/ActionsViz.tsx
+++ b/frontend/src/metabase/writeback/components/ActionsViz/ActionsViz.tsx
@@ -192,7 +192,7 @@ function ActionsViz({
 
   function handleInsert(values: Record<string, unknown>) {
     if (table && connectedDashCard) {
-      insertRow({
+      return insertRow({
         table,
         values,
         dashCard: connectedDashCard,
@@ -209,7 +209,12 @@ function ActionsViz({
     );
     const pkValue = row[pkColumnIndex];
     if (typeof pkValue === "string" || typeof pkValue === "number") {
-      updateRow({ id: pkValue, table, values, dashCard: connectedDashCard });
+      return updateRow({
+        id: pkValue,
+        table,
+        values,
+        dashCard: connectedDashCard,
+      });
     }
   }
 

--- a/frontend/src/metabase/writeback/containers/WritebackForm.tsx
+++ b/frontend/src/metabase/writeback/containers/WritebackForm.tsx
@@ -13,7 +13,7 @@ import CategoryFieldPicker from "./CategoryFieldPicker";
 export interface WritebackFormProps {
   table: Table;
   row?: unknown[];
-  onSubmit?: (values: Record<string, unknown>) => void;
+  onSubmit: (values: Record<string, unknown>) => void;
 
   // Form props
   isModal?: boolean;

--- a/frontend/src/metabase/writeback/containers/WritebackForm.tsx
+++ b/frontend/src/metabase/writeback/containers/WritebackForm.tsx
@@ -7,7 +7,6 @@ import { TYPE } from "metabase/lib/types";
 
 import Field from "metabase-lib/lib/metadata/Field";
 import Table from "metabase-lib/lib/metadata/Table";
-import { Value } from "metabase-types/types/Dataset";
 
 import CategoryFieldPicker from "./CategoryFieldPicker";
 
@@ -96,7 +95,7 @@ function WritebackForm({ table, row, onSubmit, ...props }: WritebackFormProps) {
         });
       }
 
-      onSubmit?.(changes);
+      return onSubmit?.(changes);
     },
     [form, row, onSubmit],
   );

--- a/frontend/src/metabase/writeback/containers/WritebackModalForm.tsx
+++ b/frontend/src/metabase/writeback/containers/WritebackModalForm.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback } from "react";
 import { t } from "ttag";
 
 import ModalContent from "metabase/components/ModalContent";
@@ -12,12 +12,22 @@ interface WritebackModalFormProps extends WritebackFormProps {
 function WritebackModalForm({
   table,
   onClose,
+  onSubmit,
   ...props
 }: WritebackModalFormProps) {
   const title = t`New ${table.objectName()}`;
+
+  const handleSubmit = useCallback(
+    async (values: Record<string, unknown>) => {
+      await onSubmit(values);
+      onClose();
+    },
+    [onSubmit, onClose],
+  );
+
   return (
     <ModalContent title={title} onClose={onClose}>
-      <WritebackForm table={table} {...props} />
+      <WritebackForm table={table} onSubmit={handleSubmit} {...props} />
     </ModalContent>
   );
 }


### PR DESCRIPTION
Related to #22542

Makes the frontend handle successful/failing insertions/updates/deletes a bit nicer:

* fixes server error response propagation to the `Form` container. Now if insert/update fails, the form should display an error message next to the submit button
* shows a toast message if row delete failed
* shows a toast on successful row insertion
* automatically closes the insert/update form if the action was successful