### PR TITLE
Repro #22518: Changing model definition will not show changes until after browser refresh

### DIFF
--- a/frontend/test/metabase/scenarios/models/reproductions/22518.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/reproductions/22518.cy.spec.js
@@ -5,7 +5,7 @@ import {
   sidebar,
 } from "__support__/e2e/cypress";
 
-describe("issue 22518", () => {
+describe.skip("issue 22518", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();

--- a/frontend/test/metabase/scenarios/models/reproductions/22518.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/reproductions/22518.cy.spec.js
@@ -1,0 +1,39 @@
+import {
+  restore,
+  openQuestionActions,
+  summarize,
+  sidebar,
+} from "__support__/e2e/cypress";
+
+describe("issue 22518", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    cy.createNativeQuestion(
+      {
+        native: {
+          query: "select 1 id, 'a' foo",
+        },
+        dataset: true,
+      },
+      { visitQuestion: true },
+    );
+  });
+
+  it("UI should immediately reflect model query changes upon saving (metabase#22518)", () => {
+    openQuestionActions();
+    cy.findByText("Edit query definition").click();
+
+    cy.get(".ace_content").type(", 'b' bar");
+
+    cy.findByText("Save changes").click();
+
+    summarize();
+
+    sidebar()
+      .should("contain", "ID")
+      .and("contain", "FOO")
+      .and("contain", "BAR");
+  });
+});

--- a/frontend/test/metabase/scenarios/models/reproductions/22518.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/reproductions/22518.cy.spec.js
@@ -29,6 +29,10 @@ describe("issue 22518", () => {
 
     cy.findByText("Save changes").click();
 
+    cy.findAllByTestId("header-cell")
+      .should("have.length", 3)
+      .and("contain", "BAR");
+
     summarize();
 
     sidebar()


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #22518

### How to test this manually?
- `yarn test-cypress-open`
- `metabase/scenarios/models/reproductions/22518.cy.spec.js`
- Unskip repro
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/171930354-79c5a031-add3-406b-b6b8-c01c71d8083f.png)

