### PR TITLE
Truncate long columns

### DIFF
--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.css
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.css
@@ -43,7 +43,6 @@
 }
 
 .TableInteractive .TableInteractive-cellWrapper {
-  /* padding: 0 0.75em; */
   overflow: hidden;
   display: flex;
   align-items: center;
@@ -97,13 +96,6 @@
   background-color: color-mod(var(--color-brand));
   color: white !important;
 }
-
-/*
-.TableInteractive .TableInteractive-cellWrapper.tether-enabled {
-  background-color: var(--color-brand);
-  color: white !important;
-}
-*/
 
 .TableInteractive-cellWrapper:hover {
   background-color: color-mod(var(--color-brand) alpha(-90%));

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.styled.tsx
@@ -1,0 +1,17 @@
+import styled from "@emotion/styled";
+import Button from "metabase/core/components/Button";
+import { color, lighten } from "metabase/lib/colors";
+
+export const ExpandButton = styled(Button)`
+  border: 1px solid ${() => lighten("brand", 0.3)};
+  padding: 0.125rem 0.25rem;
+  border-radius: 0.25rem;
+  color: ${() => color("brand")};
+  margin-right: 0.5rem;
+  margin-left: auto;
+
+  &:hover {
+    color: ${() => color("text-white")};
+    background-color: ${() => color("brand")};
+  }
+`;

--- a/frontend/src/metabase/visualizations/components/TableInteractive/index.ts
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./TableInteractive";

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -7,7 +7,7 @@ import { getIn, updateIn } from "icepick";
 import { Grid, Collection, ScrollSync, AutoSizer } from "react-virtualized";
 
 import { darken, lighten } from "metabase/lib/colors";
-import "metabase/visualizations/components/TableInteractive.css";
+import "metabase/visualizations/components/TableInteractive/TableInteractive.css";
 import { getScrollBarSize } from "metabase/lib/dom";
 
 import Ellipsified from "metabase/core/components/Ellipsified";

--- a/frontend/src/metabase/visualizations/visualizations/Table.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Table.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/prop-types */
 import React, { Component } from "react";
 
-import TableInteractive from "../components/TableInteractive.jsx";
+import TableInteractive from "../components/TableInteractive/TableInteractive.jsx";
 import TableSimple from "../components/TableSimple";
 import { t } from "ttag";
 import * as DataGrid from "metabase/lib/data_grid";

--- a/frontend/test/metabase-visual/visualizations/table.cy.spec.js
+++ b/frontend/test/metabase-visual/visualizations/table.cy.spec.js
@@ -1,16 +1,25 @@
-import { restore, openOrdersTable, modal } from "__support__/e2e/cypress";
+import { restore, openReviewsTable, modal } from "__support__/e2e/cypress";
 
 describe("visual tests > visualizations > table", () => {
   beforeEach(() => {
     restore();
+    cy.viewport(1600, 860);
     cy.signInAsNormalUser();
 
-    openOrdersTable();
+    openReviewsTable();
 
     cy.findByTestId("loading-spinner").should("not.exist");
   });
 
-  it("ad-hoc", () => {
+  it("ad-hoc with long column trimmed", () => {
+    cy.percySnapshot();
+  });
+
+  it("ad-hoc with long column expanded", () => {
+    cy.findAllByTestId("expand-column")
+      .eq(0)
+      .click({ force: true });
+
     cy.percySnapshot();
   });
 


### PR DESCRIPTION
[Product doc](https://www.notion.so/metabase/Truncate-long-text-values-in-tables-8fc4858fe05b4658b63c4dfae0838583)

## Changes

If a column width is greater than `780px` (~120 chars) then its content is trimmed initially. This behavior is applied to
- Untouched long columns
- Long columns which widths were manually set by users

We reset width on column reordering and removing so the same happens with the trimmed/expanded state.

<img width="1461" alt="Screenshot 2022-06-08 at 01 36 41" src="https://user-images.githubusercontent.com/14301985/172487087-545f9394-86f6-48f8-839e-c3eaddfc6fa5.png">

## How to verify

- Open Reviews table
- Ensure "Body" column is trimmed
- Hover any cell from "Body" column and click on the expand button
- Ensure the column is expanded to full width
