### PR TITLE
Repro #22521: Model becomes confusing, when Data Model column visibility is used

### DIFF
--- a/frontend/test/metabase/scenarios/models/reproductions/22521.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/reproductions/22521.cy.spec.js
@@ -1,0 +1,52 @@
+import { restore, popover, openQuestionActions } from "__support__/e2e/cypress";
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+
+const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
+
+const questionDetails = {
+  name: "22521",
+  dataset: true,
+  query: {
+    "source-table": ORDERS_ID,
+    joins: [
+      {
+        fields: "all",
+        "source-table": PRODUCTS_ID,
+        condition: [
+          "=",
+          ["field", ORDERS.PRODUCT_ID, null],
+          ["field", PRODUCTS.ID, { "join-alias": "Products" }],
+        ],
+        alias: "Products",
+      },
+    ],
+  },
+};
+
+describe.skip("issue 22521", () => {
+  beforeEach(() => {
+    cy.intercept("POST", "/api/card/*/query").as("cardQuery");
+
+    restore();
+    cy.signInAsAdmin();
+
+    cy.request("PUT", `/api/field/${PRODUCTS.VENDOR}`, {
+      visibility_type: "details-only",
+    });
+
+    cy.createQuestion(questionDetails, { visitQuestion: true });
+  });
+
+  it("models should respect data model column visibility (metabase#22521)", () => {
+    openQuestionActions();
+    cy.findByText("Edit query definition").click();
+
+    cy.wait("@cardQuery");
+
+    cy.findByTestId("step-join-0-0")
+      .find(".Icon-table")
+      .click();
+
+    popover().should("not.contain", "Products → Vendor");
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #22521

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/models/reproductions/22521.cy.spec.js`
- Unskip repro
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/171941439-a584a861-21c1-4f67-ba2a-6b70796e114c.png)

