### PR TITLE
Improve layout of embedded dashboard titles

### DIFF
--- a/frontend/src/metabase/public/components/EmbedFrame.jsx
+++ b/frontend/src/metabase/public/components/EmbedFrame.jsx
@@ -65,13 +65,17 @@ class EmbedFrame extends Component {
             "scroll-y": innerScroll,
           })}
         >
-          {name || (parameters && parameters.length > 0) ? (
-            <div className="EmbedFrame-header flex align-center p1 sm-p2 lg-p3">
+          {name || parameters?.length > 0 ? (
+            <div className="EmbedFrame-header flex flex-column p1 sm-p2 lg-p3">
               {name && (
-                <TitleAndDescription title={name} description={description} />
+                <TitleAndDescription
+                  title={name}
+                  description={description}
+                  className="my2"
+                />
               )}
-              {parameters && parameters.length > 0 ? (
-                <div className="flex ml-auto">
+              {parameters?.length > 0 ? (
+                <div className="flex">
                   <SyncedParametersList
                     className="mt1"
                     dashboard={this.props.dashboard}


### PR DESCRIPTION
Fixes #22685
Fixes #7778

### How to Test

1. Create a dashboard
2. Add one or more questions as cards
3. Add one or several filters
4. Share publicly and/or embed
5. See embed or public page in narrow screen widths

Title should not be wrapped and filters should now live underneath title, flush left.

### After

<img width="500" alt="image" src="https://user-images.githubusercontent.com/380816/171948218-7beba96d-1d3e-461a-9fed-70f58330d118.png">

### Before 

<img width="500" alt="image" src="https://user-images.githubusercontent.com/380816/171948502-23bca22e-2200-424a-bd27-bce8a5cf1ccc.png">
