### PR TITLE
[E2E] Remove `question` group from checks on CCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1264,7 +1264,6 @@ workflows:
                   "onboarding",
                   "organization",
                   "permissions",
-                  "question",
                   "smoketest",
                   "visualizations",
                 ]


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- In the same manner we did for #23117, this PR removes `question` E2E group from CircleCI because we've been running it successfully using GitHub actions.

### Note
All known flakes have been fixed previously.