### PR TITLE
Run Percy on `master` using the default GH runners

### DIFF
--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - run-percy-on-gh-runners
     paths-ignore:
       - "docs/**"
       - "**.md"

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - master
-      - run-percy-on-gh-runners
     paths-ignore:
       - "docs/**"
       - "**.md"

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -14,8 +14,8 @@ on:
 
 jobs:
   percy:
-    timeout-minutes: 30
-    runs-on: buildjet-4vcpu-ubuntu-2004
+    timeout-minutes: 45
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - name: Prepare front-end environment


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Updates the runners for Percy workflow on `master` to the default GitHub ones
- There's no reason we should keep the custom (beefier) runners for jobs that are going to be running once something is already merged to `master`.

@diogormendes mentioned that the job timed out initially so I'm increasing the timeout as well.