### PR TITLE
Ignore unrelated file changes for backend workflow

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -6,6 +6,11 @@ on:
       - 'master'
       - 'release-**'
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**.md"
+      - "frontend/test/**"
+      - "**unit.spec.{js,jsx,ts,tsx}"
 
 jobs:
 


### PR DESCRIPTION
I've seen backend workflow running (and flaking) for completely unrelated file changes so many times that I decided to exclude some paths.