### PR TITLE
[E2E] Fix dashboard flake

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
@@ -29,9 +29,8 @@ describe("scenarios > dashboard", () => {
   });
 
   it("should create new dashboard and navigate to it from the nav bar and from the root collection (metabase#20638)", () => {
-    // Create dashboard
     cy.visit("/");
-    cy.icon("add").click();
+    cy.findByText("New").click();
     cy.findByText("Dashboard").click();
 
     createDashboardUsingUI("Dash A", "Desc A");


### PR DESCRIPTION
I've ran into this flake just recently.
![image](https://user-images.githubusercontent.com/31325167/172253034-f868fafb-6917-462a-9973-aa474c55a208.png)

The test was written long ago - way before we added new sidebar. The sidebar also contains the `plus` icon so Cypress fails to click the correct one (in the top nav bar). By using the explicit word "New" instead of the icon, this problem is solved.
