### PR TITLE
do not offer expore results when a query db does not support nested queries

### DIFF
--- a/frontend/src/metabase-lib/lib/queries/AtomicQuery.ts
+++ b/frontend/src/metabase-lib/lib/queries/AtomicQuery.ts
@@ -28,4 +28,8 @@ export default class AtomicQuery extends Query {
   engine(): DatabaseEngine | null | undefined {
     return null;
   }
+
+  canNest() {
+    return this.database()?.hasFeature("nested-queries");
+  }
 }

--- a/frontend/src/metabase-lib/lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/lib/queries/StructuredQuery.ts
@@ -1470,11 +1470,6 @@ class StructuredQueryInner extends AtomicQuery {
     }));
   }
 
-  canNest() {
-    const db = this.database();
-    return db && db.hasFeature("nested-queries");
-  }
-
   /**
    * The (wrapped) source query, if any
    */

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -425,8 +425,10 @@ function ViewTitleHeaderRightSide(props) {
   const isReadOnlyQuery = query.readOnly();
   const canEditQuery = !isReadOnlyQuery;
   const canRunAdhocQueries = !isReadOnlyQuery;
+  const canNest = query.canNest();
   const hasExploreResultsLink =
     isNative &&
+    canNest &&
     isSaved &&
     canRunAdhocQueries &&
     MetabaseSettings.get("enable-nested-queries");

--- a/frontend/test/metabase/scenarios/native/reproductions/22822-explore-results-unsupported-databases.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/reproductions/22822-explore-results-unsupported-databases.cy.spec.js
@@ -11,7 +11,7 @@ const questionDetails = {
   },
 };
 
-describe.skip("issue 22822", () => {
+describe("issue 22822", () => {
   beforeEach(() => {
     restore("mongo-4");
     cy.signInAsAdmin();


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/22822

## Changes

Hide "Explore results" button on questions created from databases that do not support `nested-queries` feature.

## How to verify

Check the issue repro steps