### PR TITLE
Run E2E tests on the release branch (on push)

### DIFF
--- a/.github/workflows/e2e-main.yml
+++ b/.github/workflows/e2e-main.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "master"
+      - 'release-**'
     paths-ignore:
       - "docs/**"
       - "**.md"


### PR DESCRIPTION
As of https://github.com/metabase/metabase/pull/23123, we are not running the full E2E suite on the release branch. This PR fixes that.

Example of the build/run for one of the latest commits to the `release-x.43.x` branch:
https://app.circleci.com/pipelines/github/metabase/metabase/37573/workflows/50e4fd6d-52b0-452a-a465-8352342be2c4

After this change:
The full E2E suite will run for any release branch commit using the GitHub Actions, in the same manner we're already doing for `master` branch.