### PR TITLE
Fix color init for whitelabel

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/caching/components/CacheTTLField/CacheTTLField.styled.js
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/CacheTTLField/CacheTTLField.styled.js
@@ -27,7 +27,7 @@ export const Input = styled(NumericInput)`
 
   :focus,
   :hover {
-    border-color: ${color("brand")};
+    border-color: ${() => color("brand")};
   }
 
   transition: border 300ms ease-in-out;

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/lib/whitelabel.js
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/lib/whitelabel.js
@@ -101,7 +101,7 @@ function getCSSColorMapping(colorName) {
   if (colorName in COLOR_MAPPINGS) {
     return COLOR_MAPPINGS[colorName];
   } else {
-    return [originalColors[colorName], color => color];
+    return [[originalColors[colorName], color => color]];
   }
 }
 

--- a/frontend/src/metabase/admin/databases/components/widgets/EngineWidget/EngineWidget.styled.tsx
+++ b/frontend/src/metabase/admin/databases/components/widgets/EngineWidget/EngineWidget.styled.tsx
@@ -38,8 +38,8 @@ export const EngineCardRoot = styled.li<EngineCardRootProps>`
   outline: ${props => (props.isActive ? `2px solid ${color("focus")}` : "")};
 
   &:hover {
-    border-color: ${color("brand")};
-    background-color: ${lighten("brand", 0.6)};
+    border-color: ${() => color("brand")};
+    background-color: ${() => lighten("brand", 0.6)};
   }
 `;
 

--- a/frontend/src/metabase/auth/components/AuthButton/AuthButton.styled.tsx
+++ b/frontend/src/metabase/auth/components/AuthButton/AuthButton.styled.tsx
@@ -8,7 +8,7 @@ export const TextLink = styled(Link)`
   color: ${color("text-dark")};
 
   &:hover {
-    color: ${color("brand")};
+    color: ${() => color("brand")};
   }
 `;
 

--- a/frontend/src/metabase/components/Icon.tsx
+++ b/frontend/src/metabase/components/Icon.tsx
@@ -32,7 +32,12 @@ export const IconWrapper = styled.div<IconWrapperProps>`
   & > .icon.icon-share {
     transform: translateY(-2px);
   }
-  ${hover};
+
+  &:hover {
+    color: ${props => props.hover?.color};
+    background-color: ${props => props.hover?.backgroundColor};
+  }
+
   transition: all 300ms ease-in-out;
 
   @media (prefers-reduced-motion) {

--- a/frontend/src/metabase/components/Icon.tsx
+++ b/frontend/src/metabase/components/Icon.tsx
@@ -34,8 +34,9 @@ export const IconWrapper = styled.div<IconWrapperProps>`
   }
 
   &:hover {
-    color: ${props => props.hover?.color};
-    background-color: ${props => props.hover?.backgroundColor};
+    color: ${({ hover }) => hover?.color ?? color("brand")};
+    background-color: ${({ hover }) =>
+      hover?.backgroundColor ?? color("bg-medium")};
   }
 
   transition: all 300ms ease-in-out;
@@ -44,13 +45,6 @@ export const IconWrapper = styled.div<IconWrapperProps>`
     transition: none;
   }
 `;
-
-IconWrapper.defaultProps = {
-  hover: {
-    backgroundColor: c("bg-medium"),
-    color: c("brand"),
-  },
-};
 
 const stringOrNumberPropType = PropTypes.oneOfType([
   PropTypes.number,

--- a/frontend/src/metabase/components/MetadataInfo/FieldFingerprintInfo/CategoryFingerprint.styled.jsx
+++ b/frontend/src/metabase/components/MetadataInfo/FieldFingerprintInfo/CategoryFingerprint.styled.jsx
@@ -30,7 +30,7 @@ export const LoadingSpinner = styled(_LoadingSpinner)`
   flex-grow: 1;
   align-self: center;
   justify-content: center;
-  color: ${color("brand")};
+  color: ${() => color("brand")};
 `;
 
 LoadingSpinner.defaultProps = {

--- a/frontend/src/metabase/components/MetadataInfo/MetadataInfo.styled.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/MetadataInfo.styled.tsx
@@ -61,7 +61,7 @@ export const RelativeSizeIcon = styled(Icon)`
 `;
 
 export const InvertedColorRelativeSizeIcon = styled(RelativeSizeIcon)`
-  background-color: ${color("brand")};
+  background-color: ${() => color("brand")};
   color: ${color("white")};
   border-radius: 0.3em;
   padding: 0.3em;
@@ -87,7 +87,7 @@ export const LoadingSpinner = styled(_LoadingSpinner)`
   flex-grow: 1;
   align-self: center;
   justify-content: center;
-  color: ${color("brand")};
+  color: ${() => color("brand")};
 `;
 
 export const Table = styled.table`

--- a/frontend/src/metabase/components/form/FormField/FormField.styled.tsx
+++ b/frontend/src/metabase/components/form/FormField/FormField.styled.tsx
@@ -1,8 +1,7 @@
 import styled from "@emotion/styled";
 import { css } from "@emotion/react";
-import Icon from "metabase/components/Icon";
-
 import { color } from "metabase/lib/colors";
+import Icon from "metabase/components/Icon";
 
 export const FieldRow = styled.div`
   display: flex;
@@ -34,7 +33,7 @@ export const InfoIcon = styled(Icon)`
   color: ${color("bg-dark")};
 
   &:hover {
-    color: ${color("brand")};
+    color: ${() => color("brand")};
   }
 `;
 

--- a/frontend/src/metabase/components/form/widgets/FormSectionWidget/FormSectionWidget.styled.tsx
+++ b/frontend/src/metabase/components/form/widgets/FormSectionWidget/FormSectionWidget.styled.tsx
@@ -3,7 +3,7 @@ import { color } from "metabase/lib/colors";
 import Button from "metabase/core/components/Button";
 
 export const WidgetButton = styled(Button)`
-  color: ${color("brand")};
+  color: ${() => color("brand")};
   padding: 0;
   border: none;
   border-radius: 0;

--- a/frontend/src/metabase/core/components/CheckBox/CheckBox.styled.tsx
+++ b/frontend/src/metabase/core/components/CheckBox/CheckBox.styled.tsx
@@ -37,7 +37,7 @@ export const CheckBoxContainer = styled.span<CheckBoxContainerProps>`
   opacity: ${props => (props.disabled ? "0.4" : "")};
 
   ${CheckBoxInput}:focus + & {
-    outline: 2px solid ${color("focus")};
+    outline: 2px solid ${() => color("focus")};
   }
 
   ${CheckBoxInput}:focus:not(:focus-visible) + & {

--- a/frontend/src/metabase/core/components/ExternalLink/ExternalLink.styled.tsx
+++ b/frontend/src/metabase/core/components/ExternalLink/ExternalLink.styled.tsx
@@ -3,7 +3,7 @@ import { color } from "metabase/lib/colors";
 
 export const LinkRoot = styled.a`
   &:focus {
-    outline: 2px solid ${color("focus")};
+    outline: 2px solid ${() => color("focus")};
   }
 
   &:focus:not(:focus-visible) {

--- a/frontend/src/metabase/core/components/FileInput/FileInput.styled.tsx
+++ b/frontend/src/metabase/core/components/FileInput/FileInput.styled.tsx
@@ -43,7 +43,7 @@ export const InputButton = styled.span`
   user-select: none;
 
   ${InputField}:focus + & {
-    outline: 2px solid ${color("focus")};
+    outline: 2px solid ${() => color("focus")};
   }
 
   ${InputField}:not(:focus-visible) + & {

--- a/frontend/src/metabase/core/components/Input/Input.styled.tsx
+++ b/frontend/src/metabase/core/components/Input/Input.styled.tsx
@@ -32,7 +32,7 @@ export const InputField = styled.input<InputProps>`
   text-align: inherit;
 
   &:focus {
-    border-color: ${color("brand")};
+    border-color: ${() => color("brand")};
     transition: border 300ms ease-in-out;
   }
 

--- a/frontend/src/metabase/core/components/Link/Link.styled.tsx
+++ b/frontend/src/metabase/core/components/Link/Link.styled.tsx
@@ -17,7 +17,7 @@ export const LinkRoot = styled(Link, {
   transition: opacity 0.3s linear;
 
   &:focus {
-    outline: 2px solid ${colors("focus")};
+    outline: 2px solid ${() => colors("focus")};
   }
 
   &:focus:not(:focus-visible) {

--- a/frontend/src/metabase/core/components/Radio/Radio.styled.tsx
+++ b/frontend/src/metabase/core/components/Radio/Radio.styled.tsx
@@ -71,7 +71,7 @@ export const RadioContainer = styled.div<RadioContainerProps>`
   }
 
   ${RadioInput}:focus + & {
-    outline: 2px solid ${color("focus")};
+    outline: 2px solid ${() => color("focus")};
   }
 
   ${RadioInput}:focus:not(:focus-visible) + & {

--- a/frontend/src/metabase/core/components/SelectButton/SelectButton.styled.tsx
+++ b/frontend/src/metabase/core/components/SelectButton/SelectButton.styled.tsx
@@ -34,8 +34,8 @@ export const SelectButtonRoot = styled.button<SelectButtonRootProps>`
   color: ${getColor};
 
   &:focus {
-    border-color: ${color("brand")};
-    outline: 2px solid ${color("focus")};
+    border-color: ${() => color("brand")};
+    outline: 2px solid ${() => color("focus")};
   }
 
   &:not(:focus-visible) {

--- a/frontend/src/metabase/core/components/Toggle/Toggle.styled.tsx
+++ b/frontend/src/metabase/core/components/Toggle/Toggle.styled.tsx
@@ -56,7 +56,7 @@ export const ToggleRoot = styled.input<ToggleRootProps>`
   }
 
   &:focus {
-    outline: 2px solid ${color("focus")};
+    outline: 2px solid ${() => color("focus")};
   }
 
   &:focus:not(:focus-visible) {

--- a/frontend/src/metabase/lib/colors/palette.ts
+++ b/frontend/src/metabase/lib/colors/palette.ts
@@ -77,6 +77,10 @@ const aliases: Record<string, (palette: ColorPalette) => string> = {
 };
 
 export const color = (color: string, palette = colors) => {
+  if (color === "brand" && palette[color] === "#509EE3") {
+    console.log("error");
+  }
+
   if (color in palette) {
     return palette[color];
   }

--- a/frontend/src/metabase/lib/colors/palette.ts
+++ b/frontend/src/metabase/lib/colors/palette.ts
@@ -77,10 +77,6 @@ const aliases: Record<string, (palette: ColorPalette) => string> = {
 };
 
 export const color = (color: string, palette = colors) => {
-  if (color === "brand" && palette[color] === "#509EE3") {
-    console.log("error");
-  }
-
   if (color in palette) {
     return palette[color];
   }

--- a/frontend/src/metabase/plugins/components/SettingsCloudStoreLink/SettingsCloudStoreLink.styled.jsx
+++ b/frontend/src/metabase/plugins/components/SettingsCloudStoreLink/SettingsCloudStoreLink.styled.jsx
@@ -13,7 +13,7 @@ export const Link = styled(ExternalLink)`
   align-items: center;
   color: ${color("text-white")};
   font-weight: bold;
-  background-color: ${color("brand")};
+  background-color: ${() => color("brand")};
   padding: 12px 18px;
   border-radius: 6px;
 

--- a/frontend/src/metabase/query_builder/components/SidebarHeader/SidebarHeader.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/SidebarHeader/SidebarHeader.styled.tsx
@@ -12,15 +12,15 @@ export const HeaderIcon = styled(Icon)`
   margin-right: 0.5rem;
 `;
 
-const backButtonStyle = css`
+const backButtonStyle = () => css`
   cursor: pointer;
   &:hover {
     color: ${color("brand")};
   }
 `;
 
-const defaultBackButtonStyle = css`
-  ${backButtonStyle}
+const defaultBackButtonStyle = () => css`
+  ${backButtonStyle()}
   color: ${color("text-medium")};
   font-size: 0.83em;
   text-transform: uppercase;
@@ -39,8 +39,8 @@ function getHeaderTitleContainerVariantStyle(
     return;
   }
   return variant === "default-back-button"
-    ? defaultBackButtonStyle
-    : backButtonStyle;
+    ? defaultBackButtonStyle()
+    : backButtonStyle();
 }
 
 export const HeaderTitleContainer = styled.span<{
@@ -65,6 +65,6 @@ export const CloseButton = styled.a`
   margin-left: auto;
 
   &:hover {
-    color: ${color("brand")};
+    color: ${() => color("brand")};
   }
 `;

--- a/frontend/src/metabase/query_builder/components/filters/FilterPopover.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/FilterPopover.styled.tsx
@@ -9,16 +9,14 @@ type Props = {
 
 export const Button = styled(BaseButton)<Props>`
   color: white;
-  border-color: ${({ primaryColor = defaultColor }) => primaryColor};
-  background-color: ${({ primaryColor = defaultColor }) => primaryColor};
+  border-color: ${({ primaryColor = color("brand") }) => primaryColor};
+  background-color: ${({ primaryColor = color("brand") }) => primaryColor};
 
   &:hover,
   &:focus {
     color: white;
-    border-color: ${({ primaryColor = defaultColor }) => primaryColor};
-    background-color: ${({ primaryColor = defaultColor }) =>
+    border-color: ${({ primaryColor = color("brand") }) => primaryColor};
+    background-color: ${({ primaryColor = color("brand") }) =>
       alpha(primaryColor, 0.8)};
   }
 `;
-
-const defaultColor = color("brand");

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePickerHeader.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePickerHeader.styled.tsx
@@ -23,16 +23,16 @@ export const TabButton = styled(Button)<TabButtonProps>`
   padding-right: 0;
   margin-left: ${space(2)};
   margin-right: ${space(2)};
-  border-bottom: ${({ primaryColor = defaultColor, selected }) =>
+  border-bottom: ${({ primaryColor = color("brand"), selected }) =>
     selected ? `2px solid ${primaryColor}` : "2px solid transparent"};
 
-  color: ${({ primaryColor = defaultColor, selected }) =>
+  color: ${({ primaryColor = color("brand"), selected }) =>
     selected ? primaryColor : color("text-medium")};
 
   &:hover {
     background: none;
-    color: ${({ primaryColor = defaultColor }) => primaryColor};
-    border-color: ${({ primaryColor = defaultColor }) => primaryColor};
+    color: ${({ primaryColor = color("brand") }) => primaryColor};
+    border-color: ${({ primaryColor = color("brand") }) => primaryColor};
   }
 `;
 
@@ -46,5 +46,3 @@ export const BackButton = styled(TabButton)`
     color: ${({ primaryColor }) => primaryColor};
   }
 `;
-
-const defaultColor = color("brand");

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RelativeDatePicker.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RelativeDatePicker.styled.tsx
@@ -1,4 +1,4 @@
-import { color, alpha } from "metabase/lib/colors";
+import { alpha, color } from "metabase/lib/colors";
 import styled from "@emotion/styled";
 import { space } from "metabase/styled-components/theme";
 
@@ -12,13 +12,13 @@ type BaseProps = {
 
 export const DateUnitSelector = styled(BaseDateUnitSelector)<BaseProps>`
   button:focus {
-    border-color: ${({ primaryColor = defaultColor }) => primaryColor};
+    border-color: ${({ primaryColor = color("brand") }) => primaryColor};
   }
 `;
 
 export const NumericInput = styled(BaseNumericInput)<BaseProps>`
   &:focus {
-    border-color: ${({ primaryColor = defaultColor }) => primaryColor};
+    border-color: ${({ primaryColor = color("brand") }) => primaryColor};
   }
 `;
 
@@ -27,15 +27,13 @@ type ButtonProps = {
   selected?: boolean;
 };
 
-const defaultColor = color("brand");
-
 export const CurrentButton = styled(Button)<ButtonProps>`
   border: none;
   border-radius: 99px;
 
-  background-color: ${({ selected, primaryColor = defaultColor }) =>
+  background-color: ${({ selected, primaryColor = color("brand") }) =>
     selected ? primaryColor : alpha(primaryColor, 0.1)};
-  color: ${({ selected, primaryColor = defaultColor }) =>
+  color: ${({ selected, primaryColor = color("brand") }) =>
     selected ? "white" : primaryColor};
 
   padding-top: ${space(1)};
@@ -78,11 +76,11 @@ export const OptionButton = styled(Button)<OptionButtonProps>`
       reverseIconDirection ? "rotate(180deg)" : ""};
   }
 
-  color: ${({ selected, primaryColor = defaultColor }) =>
+  color: ${({ selected, primaryColor = color("brand") }) =>
     selected ? primaryColor : color("text-dark")};
 
   &:hover {
-    color: ${({ primaryColor = defaultColor }) => primaryColor};
+    color: ${({ primaryColor = color("brand") }) => primaryColor};
     background: none;
   }
 `;
@@ -92,7 +90,7 @@ export const MoreButton = styled(Button)<ButtonProps>`
   color: ${color("text-medium")};
 
   &:hover {
-    color: ${({ primaryColor = defaultColor }) => primaryColor};
+    color: ${({ primaryColor = color("brand") }) => primaryColor};
   }
 `;
 

--- a/frontend/src/metabase/visualizations/components/ChartSettingsWidget.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettingsWidget.styled.tsx
@@ -42,7 +42,7 @@ export const Root = styled.div<{
 
     &:hover {
       transition: border 0.3s;
-      border-color: ${color("brand")};
+      border-color: ${() => color("brand")};
     }
   }
 `;

--- a/frontend/src/metabase/visualizations/components/TableSimple/TableSimple.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/TableSimple/TableSimple.styled.tsx
@@ -71,7 +71,7 @@ export const TableHeaderCellContent = styled.button<{
   cursor: pointer;
 
   &:hover {
-    color: ${color("brand")};
+    color: ${() => color("brand")};
   }
 `;
 
@@ -105,7 +105,7 @@ export const PaginationButton = styled.button<{
   cursor: pointer;
 
   &:hover {
-    color: ${color("brand")};
+    color: ${() => color("brand")};
   }
 
   ${props =>


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/22816

A hack to make the current code work with whitelabelling. The issue is that style literals are initialized before `colors` are changed. A better way to fix it would be by migrating our colors to `ThemeProvider`.