### PR TITLE
Handle time types in render code

### DIFF
--- a/src/metabase/pulse/render/datetime.clj
+++ b/src/metabase/pulse/render/datetime.clj
@@ -7,7 +7,8 @@
             [metabase.util.i18n :refer [trs tru]]
             [metabase.util.schema :as su]
             [schema.core :as s])
-  (:import java.time.Period
+  (:import java.time.format.DateTimeFormatter
+           java.time.Period
            java.time.temporal.Temporal))
 
 (defn- reformat-temporal-str [timezone-id s new-format-string]
@@ -17,22 +18,26 @@
   "Reformat a temporal literal string `s` (i.e., an ISO-8601 string) with a human-friendly format based on the
   column `:unit`."
   [timezone-id s col]
-  (if (str/blank? s)
-    ""
-    (case (:unit col)
-      ;; these types have special formatting
-      :hour    (reformat-temporal-str timezone-id s "h a - MMM yyyy")
-      :week    (str "Week " (reformat-temporal-str timezone-id s "w - YYYY"))
-      :month   (reformat-temporal-str timezone-id s "MMMM yyyy")
-      :quarter (reformat-temporal-str timezone-id s "QQQ - yyyy")
+  (cond (str/blank? s) ""
 
-      ;; no special formatting here : return as ISO-8601
-      ;; TODO: probably shouldn't even be showing sparkline for x-of-y groupings?
-      (:year :hour-of-day :day-of-week :week-of-year :month-of-year)
-      s
+        (isa? (or (:effective_type col) (:base_type col)) :type/Time)
+        (t/format DateTimeFormatter/ISO_LOCAL_TIME (u.date/parse s timezone-id))
 
-      ;; for everything else return in this format
-      (reformat-temporal-str timezone-id s "MMM d, yyyy"))))
+        :else
+        (case (:unit col)
+          ;; these types have special formatting
+          :hour    (reformat-temporal-str timezone-id s "h a - MMM yyyy")
+          :week    (str "Week " (reformat-temporal-str timezone-id s "w - YYYY"))
+          :month   (reformat-temporal-str timezone-id s "MMMM yyyy")
+          :quarter (reformat-temporal-str timezone-id s "QQQ - yyyy")
+
+          ;; no special formatting here : return as ISO-8601
+          ;; TODO: probably shouldn't even be showing sparkline for x-of-y groupings?
+          (:year :hour-of-day :day-of-week :week-of-year :month-of-year)
+          s
+
+          ;; for everything else return in this format
+          (reformat-temporal-str timezone-id s "MMM d, yyyy"))))
 
 (def ^:private RenderableInterval
   {:interval-start     Temporal

--- a/test/metabase/pulse/render/datetime_test.clj
+++ b/test/metabase/pulse/render/datetime_test.clj
@@ -51,4 +51,8 @@
            (datetime/format-temporal-str "UTC" nil :now))))
   (testing "Not-null values work"
     (is (= "Jul 16, 2020"
-           (datetime/format-temporal-str "UTC" now :day)))))
+           (datetime/format-temporal-str "UTC" now :day))))
+  (testing "Can render time types (#15146)"
+    (is (= "08:05:06"
+           (datetime/format-temporal-str "UTC" "08:05:06Z"
+                                         {:effective_type :type/Time})))))


### PR DESCRIPTION
Fixes #15146

Code pathway just assumed that it was all datetimes

Proof of fix: this is the rendered png that before this changeset would error with 
```clojure
;; minimal repro
datetime=> (format-temporal-str "UTC"
                                "11:00:00Z"
                                {:display_name "T"
                                 :source :native
                                 :field_ref [:field
                                             "T"
                                             {:base-type :type/Time}]
                                 :name "T"
                                 :base_type :type/Time
                                 :effective_type :type/Time})
Execution error (UnsupportedTemporalTypeException) at java.time.LocalTime/get0 (LocalTime.java:703).
Unsupported field: MonthOfYear
datetime=> (pst *e)
UnsupportedTemporalTypeException Unsupported field: MonthOfYear
	java.time.LocalTime.get0 (LocalTime.java:703)
	java.time.LocalTime.getLong (LocalTime.java:680)
	java.time.OffsetTime.getLong (OffsetTime.java:536)
	java.time.format.DateTimePrintContext.getValue (DateTimePrintContext.java:308)
	java.time.format.DateTimeFormatterBuilder$TextPrinterParser.format (DateTimeFormatterBuilder.java:3363)
	java.time.format.DateTimeFormatterBuilder$CompositePrinterParser.format (DateTimeFormatterBuilder.java:2402)
	java.time.format.DateTimeFormatter.formatTo (DateTimeFormatter.java:1849)
	java.time.format.DateTimeFormatter.format (DateTimeFormatter.java:1823)
	java-time.format/format (format.clj:51)
	java-time.format/format (format.clj:44)
	metabase.pulse.render.datetime/reformat-temporal-str (datetime.clj:14)
	metabase.pulse.render.datetime/reformat-temporal-str (datetime.clj:13)

;; after fix:
datetime=> (format-temporal-str "UTC"
                                "11:00:00Z"
                                {:display_name "T"
                                 :source :native
                                 :field_ref [:field
                                             "T"
                                             {:base-type :type/Time}]
                                 :name "T"
                                 :base_type :type/Time
                                 :effective_type :type/Time})
"11:00:00"
```
### Screenshot of rendered png after fix

![image](https://user-images.githubusercontent.com/6377293/172422456-9639114d-7b2f-42e8-b224-5e1c0993e5ae.png)

Easy repro is the query from flamber in the issue against sample db:
```sql
select '2021-06-30 11:00:00'::timestamp ts , cast('2021-06-30 11:00:00'::timestamp as time) t
```
save to a question and then `(dev.render-png/render-card-to-png <the-card-id>)`
