### PR TITLE
remove an errant tap> (whoops)

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -356,7 +356,7 @@
             (let [synced-tables (db/select Table :db_id (mt/id))]
               (is (partial= {true [{:name "messages"} {:name "users"}]
                              false [{:name "messages"} {:name "users"}]}
-                            (-> (group-by :active (doto synced-tables tap>))
+                            (-> (group-by :active synced-tables)
                                 (update-vals #(sort-by :name %)))))))
           (finally (db/delete! Table :db_id (mt/id) :active false)))))))
 


### PR DESCRIPTION
accidentally left in before our new githooks checked for it.