### PR TITLE
Add Warnings component unit tests

### DIFF
--- a/frontend/test/metabase/components/Warnings.unit.spec.js
+++ b/frontend/test/metabase/components/Warnings.unit.spec.js
@@ -1,0 +1,28 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import Warnings from "metabase/query_builder/components/Warnings";
+
+describe("Warnings", () => {
+  it("should render a warning icon", () => {
+    render(<Warnings warnings={["foo"]} />);
+    expect(screen.getByLabelText("warning icon"));
+  });
+
+  it("should render a warning message tooltip on hover", () => {
+    render(<Warnings warnings={["test warning message"]} />);
+    userEvent.hover(screen.getByLabelText("warning icon"));
+    screen.getByText("test warning message");
+  });
+
+  it("should render multiple warnings", () => {
+    const warningMessages = ["foo", "bar", "baz"];
+    render(<Warnings warnings={warningMessages} />);
+    userEvent.hover(screen.getByLabelText("warning icon"));
+
+    warningMessages.forEach(message => {
+      screen.getByText(message);
+    });
+  });
+});


### PR DESCRIPTION
Adds some unit tests to replace coverage lost by https://github.com/metabase/metabase/pull/23199
