### PR TITLE
Prototype custom row actions (Frontend)

### DIFF
--- a/frontend/src/metabase-lib/lib/Mode/constants.ts
+++ b/frontend/src/metabase-lib/lib/Mode/constants.ts
@@ -1,3 +1,4 @@
+export const MODE_TYPE_ACTION = "actions";
 export const MODE_TYPE_DEFAULT = "default";
 export const MODE_TYPE_NATIVE = "native";
 export const MODE_TYPE_SEGMENT = "segment";
@@ -7,6 +8,7 @@ export const MODE_TYPE_GEO = "geo";
 export const MODE_TYPE_PIVOT = "pivot";
 
 export const MODES_TYPES = [
+  MODE_TYPE_ACTION,
   MODE_TYPE_NATIVE,
   MODE_TYPE_SEGMENT,
   MODE_TYPE_METRIC,

--- a/frontend/src/metabase-lib/lib/Mode/utils.ts
+++ b/frontend/src/metabase-lib/lib/Mode/utils.ts
@@ -3,6 +3,7 @@ import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
 import NativeQuery from "metabase-lib/lib/queries/NativeQuery";
 import { ModeType } from "./types";
 import {
+  MODE_TYPE_ACTION,
   MODE_TYPE_NATIVE,
   MODE_TYPE_SEGMENT,
   MODE_TYPE_METRIC,
@@ -15,6 +16,10 @@ import {
 export function getMode(question: Question): ModeType | null {
   if (!question) {
     return null;
+  }
+
+  if (question.card().display === "action-button") {
+    return MODE_TYPE_ACTION;
   }
 
   const query = question.query();

--- a/frontend/src/metabase-types/types/Card.ts
+++ b/frontend/src/metabase-types/types/Card.ts
@@ -27,6 +27,9 @@ export type SavedCard<Query = DatasetQuery> = UnsavedCard<Query> & {
   can_write: boolean;
   public_uuid: string;
   archived?: boolean;
+
+  // Only for native queries
+  is_write?: boolean;
 };
 
 export type Card<Query = DatasetQuery> = SavedCard<Query> | UnsavedCard<Query>;

--- a/frontend/src/metabase-types/types/Dashboard.ts
+++ b/frontend/src/metabase-types/types/Dashboard.ts
@@ -51,4 +51,8 @@ export type DashCard<CardType = Card> = {
   row: number;
   sizeY: number;
   sizeX: number;
+
+  isAdded?: boolean;
+  isDirty?: boolean;
+  justAdded?: boolean;
 };

--- a/frontend/src/metabase-types/types/Visualization.ts
+++ b/frontend/src/metabase-types/types/Visualization.ts
@@ -116,7 +116,7 @@ export type VisualizationProps = {
   onHoverChange: (hoverObject?: HoverObject) => void;
   onVisualizationClick: (clickObject?: ClickObject) => void;
   visualizationIsClickable: (clickObject?: ClickObject) => boolean;
-  getExtraDataForClick: (clickObject?: ClickObject) => unknown;
+  getExtraDataForClick?: (clickObject?: ClickObject) => Record<string, unknown>;
   onChangeCardAndRun: OnChangeCardAndRun;
 
   onUpdateVisualizationSettings: (settings: Record<string, any>) => void;

--- a/frontend/src/metabase/dashboard/actions.js
+++ b/frontend/src/metabase/dashboard/actions.js
@@ -311,7 +311,7 @@ export const addActionsDashCardToDashboard = ({ dashId }) => {
   };
   const dashcardOverrides = {
     card: virtualActionsCard,
-    sizeX: 4,
+    sizeX: 3,
     sizeY: 1,
     visualization_settings: {
       virtual_card: virtualActionsCard,

--- a/frontend/src/metabase/dashboard/actions.js
+++ b/frontend/src/metabase/dashboard/actions.js
@@ -323,6 +323,26 @@ export const addActionsDashCardToDashboard = ({ dashId }) => {
   });
 };
 
+export const addActionButtonDashCardToDashboard = ({ dashId }) => {
+  const virtualActionsCard = {
+    ...createCard(),
+    display: "action-button",
+    archived: false,
+  };
+  const dashcardOverrides = {
+    card: virtualActionsCard,
+    sizeX: 1,
+    sizeY: 1,
+    visualization_settings: {
+      virtual_card: virtualActionsCard,
+    },
+  };
+  return addDashCardToDashboard({
+    dashId: dashId,
+    dashcardOverrides: dashcardOverrides,
+  });
+};
+
 export const saveDashboardAndCards = createThunkAction(
   SAVE_DASHBOARD_AND_CARDS,
   function() {

--- a/frontend/src/metabase/dashboard/actions.js
+++ b/frontend/src/metabase/dashboard/actions.js
@@ -311,7 +311,7 @@ export const addActionsDashCardToDashboard = ({ dashId }) => {
   };
   const dashcardOverrides = {
     card: virtualActionsCard,
-    sizeX: 3,
+    sizeX: 5,
     sizeY: 1,
     visualization_settings: {
       virtual_card: virtualActionsCard,

--- a/frontend/src/metabase/dashboard/actions.js
+++ b/frontend/src/metabase/dashboard/actions.js
@@ -331,7 +331,7 @@ export const addActionButtonDashCardToDashboard = ({ dashId }) => {
   };
   const dashcardOverrides = {
     card: virtualActionsCard,
-    sizeX: 1,
+    sizeX: 2,
     sizeY: 1,
     visualization_settings: {
       virtual_card: virtualActionsCard,

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx
@@ -589,29 +589,47 @@ const ActionOption = ({ name, description, isSelected, onClick }) => {
   );
 };
 
-function ActionOptions({ clickBehavior, updateSettings }) {
+function ActionOptions({ dashcard, clickBehavior, updateSettings }) {
   return (
     <SidebarContent>
       <Heading className="text-medium">{t`Pick an action`}</Heading>
       <Actions.ListLoader>
-        {({ actions }) => (
-          <>
-            {actions.map(action => (
-              <ActionOption
-                key={action.id}
-                name={action.card.name}
-                description={action.card.description}
-                isSelected={clickBehavior.action === action.id}
-                onClick={() =>
-                  updateSettings({
-                    type: clickBehavior.type,
-                    action: action.id,
-                  })
-                }
-              />
-            ))}
-          </>
-        )}
+        {({ actions }) => {
+          const selectedAction = actions.find(
+            action => action.id === clickBehavior.action,
+          );
+          return (
+            <>
+              {actions.map(action => (
+                <ActionOption
+                  key={action.id}
+                  name={action.card.name}
+                  description={action.card.description}
+                  isSelected={clickBehavior.action === action.id}
+                  onClick={() =>
+                    updateSettings({
+                      type: clickBehavior.type,
+                      action: action.id,
+                    })
+                  }
+                />
+              ))}
+              {selectedAction && (
+                <ClickMappings
+                  object={{
+                    ...selectedAction.card,
+                    dataset_query: JSON.parse(
+                      selectedAction.card.dataset_query,
+                    ),
+                  }}
+                  dashcard={dashcard}
+                  clickBehavior={clickBehavior}
+                  updateSettings={updateSettings}
+                />
+              )}
+            </>
+          );
+        }}
       </Actions.ListLoader>
     </SidebarContent>
   );

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx
@@ -616,12 +616,7 @@ function ActionOptions({ dashcard, clickBehavior, updateSettings }) {
               ))}
               {selectedAction && (
                 <ClickMappings
-                  object={{
-                    ...selectedAction.card,
-                    dataset_query: JSON.parse(
-                      selectedAction.card.dataset_query,
-                    ),
-                  }}
+                  object={selectedAction.card}
                   dashcard={dashcard}
                   clickBehavior={clickBehavior}
                   updateSettings={updateSettings}

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx
@@ -15,6 +15,7 @@ import ModalContent from "metabase/components/ModalContent";
 import InputBlurChange from "metabase/components/InputBlurChange";
 import PopoverWithTrigger from "metabase/components/PopoverWithTrigger";
 
+import Actions from "metabase/entities/actions";
 import Dashboards from "metabase/entities/dashboards";
 import DashboardPicker from "metabase/containers/DashboardPicker";
 import Questions from "metabase/entities/questions";
@@ -39,6 +40,7 @@ const clickBehaviorOptions = [
   { value: "menu", icon: "popover" },
   { value: "link", icon: "link" },
   { value: "crossfilter", icon: "filter" },
+  { value: "action", icon: "play" },
 ];
 
 function getClickBehaviorOptionName(value, dashcard) {
@@ -47,11 +49,16 @@ function getClickBehaviorOptionName(value, dashcard) {
       ? t`Open the Metabase actions menu`
       : t`Do nothing`;
   }
-  return value === "link"
-    ? t`Go to a custom destination`
-    : value === "crossfilter"
-    ? t`Update a dashboard filter`
-    : "Unknown";
+  if (value === "link") {
+    return t`Go to a custom destination`;
+  }
+  if (value === "crossfilter") {
+    return t`Update a dashboard filter`;
+  }
+  if (value === "action") {
+    return t`Perform action`;
+  }
+  return t`Unknown`;
 }
 
 const Heading = ({ children }) => (
@@ -502,6 +509,13 @@ class ClickBehaviorSidebar extends React.Component {
                   dashcard={dashcard}
                   updateSettings={this.updateSettings}
                 />
+              ) : clickBehavior.type === "action" ? (
+                <ActionOptions
+                  clickBehavior={clickBehavior}
+                  dashcard={dashcard}
+                  parameters={parameters}
+                  updateSettings={this.updateSettings}
+                />
               ) : null}
             </div>
           )}
@@ -539,6 +553,67 @@ function TypeSelector({
         </div>
       ))}
     </div>
+  );
+}
+
+const ActionOption = ({ name, description, isSelected, onClick }) => {
+  return (
+    <SidebarItemWrapper
+      onClick={onClick}
+      style={{
+        ...SidebarItemStyle,
+        backgroundColor: isSelected ? color("brand") : "transparent",
+        color: isSelected ? color("white") : "inherit",
+        alignItems: description ? "flex-start" : "center",
+        marginTop: "2px",
+      }}
+    >
+      <SidebarIconWrapper>
+        <Icon
+          name="bolt"
+          color={isSelected ? color("text-white") : color("brand")}
+        />
+      </SidebarIconWrapper>
+      <div>
+        <h4>{name}</h4>
+        {description && (
+          <span
+            className={isSelected ? "text-white" : "text-medium"}
+            style={{ width: "95%", marginTop: "2px" }}
+          >
+            {description}
+          </span>
+        )}
+      </div>
+    </SidebarItemWrapper>
+  );
+};
+
+function ActionOptions({ clickBehavior, updateSettings }) {
+  return (
+    <SidebarContent>
+      <Heading className="text-medium">{t`Pick an action`}</Heading>
+      <Actions.ListLoader>
+        {({ actions }) => (
+          <>
+            {actions.map(action => (
+              <ActionOption
+                key={action.id}
+                name={action.card.name}
+                description={action.card.description}
+                isSelected={clickBehavior.action === action.id}
+                onClick={() =>
+                  updateSettings({
+                    type: clickBehavior.type,
+                    action: action.id,
+                  })
+                }
+              />
+            ))}
+          </>
+        )}
+      </Actions.ListLoader>
+    </SidebarContent>
   );
 }
 

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx
@@ -927,9 +927,8 @@ const CustomLinkText = ({
 
 const ValuesYouCanReference = withUserAttributes(
   ({ dashcard, parameters, userAttributes }) => {
-    const columns = dashcard.card.result_metadata
-      .filter(isMappableColumn)
-      .map(c => c.name);
+    const columnMetadata = dashcard.card.result_metadata || [];
+    const columns = columnMetadata?.filter(isMappableColumn).map(c => c.name);
     const parameterNames = parameters.map(p => p.name);
     const sections = [
       {

--- a/frontend/src/metabase/dashboard/components/ClickMappings.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickMappings.jsx
@@ -140,7 +140,7 @@ const ClickMappings = _.compose(
         getIn(clickBehavior, ["parameterMapping", id, "source"]) != null,
     );
     const sourceOptions = {
-      column: dashcard.card.result_metadata.filter(isMappableColumn),
+      column: dashcard.card.result_metadata?.filter(isMappableColumn) || [],
       parameter: parameters,
     };
     return { setTargets, unsetTargets, sourceOptions };

--- a/frontend/src/metabase/dashboard/components/DashCard.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard.jsx
@@ -175,12 +175,15 @@ export default class DashCard extends Component {
       parameterValues,
     );
 
+    const isStandardCRUDActionsRow = mainCard.display === "actions";
+    const isActionButton = mainCard.display === "action-button";
+
     const hideBackground =
       !isEditing &&
       (mainCard.visualization_settings["dashcard.background"] === false ||
         mainCard.display === "list" ||
-        mainCard.display === "actions" ||
-        mainCard.display === "action-button");
+        isStandardCRUDActionsRow ||
+        isActionButton);
 
     const isEditingDashboardLayout =
       isEditing && clickBehaviorSidebarDashcard == null && !isEditingParameter;
@@ -268,8 +271,7 @@ export default class DashCard extends Component {
           replacementContent={
             (clickBehaviorSidebarDashcard != null || isEditingParameter) &&
             isVirtualDashCard(dashcard) &&
-            dashcard.visualization_settings.virtual_card.display !==
-              "action-button" ? (
+            isActionButton ? (
               <div className="flex full-height align-center justify-center">
                 <h4 className="text-medium">
                   {dashcard.visualization_settings.virtual_card.display ===
@@ -278,7 +280,7 @@ export default class DashCard extends Component {
                     : t`Standard actions`}
                 </h4>
               </div>
-            ) : isEditingParameter ? (
+            ) : isEditingParameter && !isActionButton ? (
               <DashCardParameterMapper dashcard={dashcard} />
             ) : clickBehaviorSidebarDashcard != null ? (
               <ClickBehaviorSidebarOverlay

--- a/frontend/src/metabase/dashboard/components/DashCard.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard.jsx
@@ -179,7 +179,8 @@ export default class DashCard extends Component {
       !isEditing &&
       (mainCard.visualization_settings["dashcard.background"] === false ||
         mainCard.display === "list" ||
-        mainCard.display === "actions");
+        mainCard.display === "actions" ||
+        mainCard.display === "action-button");
 
     const isEditingDashboardLayout =
       isEditing && clickBehaviorSidebarDashcard == null && !isEditingParameter;

--- a/frontend/src/metabase/dashboard/components/DashCard.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard.jsx
@@ -270,8 +270,7 @@ export default class DashCard extends Component {
           }
           replacementContent={
             (clickBehaviorSidebarDashcard != null || isEditingParameter) &&
-            isVirtualDashCard(dashcard) &&
-            isActionButton ? (
+            isVirtualDashCard(dashcard) ? (
               <div className="flex full-height align-center justify-center">
                 <h4 className="text-medium">
                   {dashcard.visualization_settings.virtual_card.display ===

--- a/frontend/src/metabase/dashboard/components/DashCard.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard.jsx
@@ -266,9 +266,16 @@ export default class DashCard extends Component {
           }
           replacementContent={
             (clickBehaviorSidebarDashcard != null || isEditingParameter) &&
-            isVirtualDashCard(dashcard) ? (
+            isVirtualDashCard(dashcard) &&
+            dashcard.visualization_settings.virtual_card.display !==
+              "action-button" ? (
               <div className="flex full-height align-center justify-center">
-                <h4 className="text-medium">{t`Text card`}</h4>
+                <h4 className="text-medium">
+                  {dashcard.visualization_settings.virtual_card.display ===
+                  "text"
+                    ? t`Text card`
+                    : t`Standard actions`}
+                </h4>
               </div>
             ) : isEditingParameter ? (
               <DashCardParameterMapper dashcard={dashcard} />
@@ -373,7 +380,7 @@ const DashCardActionButtons = ({
         />,
       );
     }
-    if (!isVirtualDashCard) {
+    if (!isVirtualDashCard || card.display === "action-button") {
       buttons.push(
         <Tooltip key="click-behavior-tooltip" tooltip={t`Click behavior`}>
           <a

--- a/frontend/src/metabase/dashboard/components/DashCardCardParameterMapper.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCardCardParameterMapper.jsx
@@ -67,7 +67,6 @@ function DashCardCardParameterMapper({
   dashcard,
   editingParameter,
   target,
-  mappingsByParameter,
   mappingOptions,
   metadata,
   setParameterMapping,

--- a/frontend/src/metabase/dashboard/containers/DashboardApp.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp.jsx
@@ -183,6 +183,7 @@ export default _.compose(
       titleIndex: 1,
     })),
     titleWithLoadingTime("loadingStartTime"),
-    MetabaseSettings.get("experimental-enable-actions") && Actions.loadList(),
+    MetabaseSettings.get("experimental-enable-actions") &&
+      Actions.loadList({ metadataPropName: "actionListMetadata" }),
   ].filter(Boolean),
 )(DashboardApp);

--- a/frontend/src/metabase/dashboard/containers/DashboardApp.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp.jsx
@@ -17,6 +17,7 @@ import { useLoadingTimer } from "metabase/hooks/use-loading-timer";
 import { useWebNotification } from "metabase/hooks/use-web-notification";
 import { useOnUnmount } from "metabase/hooks/use-on-unmount";
 
+import Actions from "metabase/entities/actions";
 import { fetchDatabaseMetadata } from "metabase/redux/metadata";
 import { getIsNavbarOpen, setErrorPage } from "metabase/redux/app";
 
@@ -180,4 +181,5 @@ export default _.compose(
     titleIndex: 1,
   })),
   titleWithLoadingTime("loadingStartTime"),
+  Actions.loadList(),
 )(DashboardApp);

--- a/frontend/src/metabase/dashboard/containers/DashboardApp.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp.jsx
@@ -20,6 +20,7 @@ import { useOnUnmount } from "metabase/hooks/use-on-unmount";
 import Actions from "metabase/entities/actions";
 import { fetchDatabaseMetadata } from "metabase/redux/metadata";
 import { getIsNavbarOpen, setErrorPage } from "metabase/redux/app";
+import MetabaseSettings from "metabase/lib/settings";
 
 import {
   getIsEditing,
@@ -174,12 +175,14 @@ const DashboardApp = props => {
 };
 
 export default _.compose(
-  connect(mapStateToProps, mapDispatchToProps),
-  favicon(({ pageFavicon }) => pageFavicon),
-  title(({ dashboard, documentTitle }) => ({
-    title: documentTitle || dashboard?.name,
-    titleIndex: 1,
-  })),
-  titleWithLoadingTime("loadingStartTime"),
-  Actions.loadList(),
+  ...[
+    connect(mapStateToProps, mapDispatchToProps),
+    favicon(({ pageFavicon }) => pageFavicon),
+    title(({ dashboard, documentTitle }) => ({
+      title: documentTitle || dashboard?.name,
+      titleIndex: 1,
+    })),
+    titleWithLoadingTime("loadingStartTime"),
+    MetabaseSettings.get("experimental-enable-actions") && Actions.loadList(),
+  ].filter(Boolean),
 )(DashboardApp);

--- a/frontend/src/metabase/dashboard/containers/DashboardHeader.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardHeader.jsx
@@ -104,6 +104,12 @@ class DashboardHeader extends Component {
     });
   }
 
+  onAddActionButton() {
+    this.props.addActionButtonDashCardToDashboard({
+      dashId: this.props.dashboard.id,
+    });
+  }
+
   onDoneEditing() {
     this.props.onEditingChange(false);
   }
@@ -232,6 +238,18 @@ class DashboardHeader extends Component {
             >
               <DashboardHeaderButton>
                 <Icon name="bolt" size={18} />
+              </DashboardHeaderButton>
+            </a>
+          </Tooltip>,
+          <Tooltip key="add-action-button" tooltip={t`Add action button`}>
+            <a
+              data-metabase-event="Dashboard;Add Action Button"
+              key="add-action-button"
+              className="text-brand-hover cursor-pointer"
+              onClick={() => this.onAddActionButton()}
+            >
+              <DashboardHeaderButton>
+                <Icon name="play" size={18} />
               </DashboardHeaderButton>
             </a>
           </Tooltip>,

--- a/frontend/src/metabase/entities/actions.js
+++ b/frontend/src/metabase/entities/actions.js
@@ -1,0 +1,9 @@
+import { createEntity } from "metabase/lib/entities";
+
+const Actions = createEntity({
+  name: "actions",
+  nameOne: "action",
+  path: "/api/actions",
+});
+
+export default Actions;

--- a/frontend/src/metabase/entities/containers/EntityListLoader.jsx
+++ b/frontend/src/metabase/entities/containers/EntityListLoader.jsx
@@ -242,6 +242,7 @@ const EntityListLoader = _.compose(
       allFetched,
       allError,
       selectorName = "getList",
+      metadataPropName = "metadata",
     } = props;
     if (typeof entityQuery === "function") {
       entityQuery = entityQuery(state, props);
@@ -272,7 +273,7 @@ const EntityListLoader = _.compose(
       list,
       entityQuery,
       reloadInterval,
-      metadata,
+      [metadataPropName]: metadata,
       loading,
       loaded,
       fetched,

--- a/frontend/src/metabase/entities/index.js
+++ b/frontend/src/metabase/entities/index.js
@@ -1,3 +1,4 @@
+export { default as actions } from "./actions";
 export { default as alerts } from "./alerts";
 export { default as collections } from "./collections";
 export { default as snippetCollections } from "./snippet-collections";

--- a/frontend/src/metabase/lib/click-behavior.js
+++ b/frontend/src/metabase/lib/click-behavior.js
@@ -219,11 +219,15 @@ export function clickBehaviorIsValid(clickBehavior) {
     linkType,
     targetId,
     linkTemplate,
+    action,
   } = clickBehavior;
   if (type === "crossfilter") {
     return Object.keys(parameterMapping).length > 0;
   }
-  // if it's not a crossfilter, it's a link
+  if (type === "action") {
+    return typeof action === "number";
+  }
+  // if it's not a crossfilter/action, it's a link
   if (linkType === "url") {
     return (linkTemplate || "").length > 0;
   }

--- a/frontend/src/metabase/modes/components/drill/DashboardClickDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/DashboardClickDrill.jsx
@@ -159,7 +159,7 @@ function getParametersForNativeAction(
 ) {
   const action = extraData.actions[clickBehavior.action];
   const templateTags = Object.values(
-    JSON.parse(action.card.dataset_query).native["template-tags"],
+    action.card.dataset_query.native["template-tags"],
   );
 
   const parameters = {};

--- a/frontend/src/metabase/modes/components/drill/DashboardClickDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/DashboardClickDrill.jsx
@@ -8,6 +8,7 @@ import {
   setOrUnsetParameterValues,
   setParameterValue,
 } from "metabase/dashboard/actions";
+import { executeRowAction } from "metabase/writeback/actions";
 import {
   getDataFromClicked,
   getTargetForQueryParams,
@@ -33,7 +34,7 @@ export default ({ question, clicked }) => {
   }
   const { extraData } = clicked || {};
   const data = getDataFromClicked(clicked);
-  const { type, linkType, parameterMapping, targetId } = clickBehavior;
+  const { action, type, linkType, parameterMapping, targetId } = clickBehavior;
 
   let behavior;
 
@@ -41,7 +42,20 @@ export default ({ question, clicked }) => {
     return [];
   }
 
-  if (type === "crossfilter") {
+  if (type === "action") {
+    const parameters = getParameterValuesBySlug(parameterMapping, {
+      data,
+      extraData,
+      clickBehavior,
+    });
+    behavior = {
+      action: () =>
+        executeRowAction({
+          action: extraData.actions[action],
+          parameters,
+        }),
+    };
+  } else if (type === "crossfilter") {
     const parameterIdValuePairs = getParameterIdValuePairs(parameterMapping, {
       data,
       extraData,

--- a/frontend/src/metabase/modes/components/drill/DashboardClickDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/DashboardClickDrill.jsx
@@ -52,7 +52,7 @@ export default ({ question, clicked }) => {
     behavior = {
       action: () =>
         executeRowAction({
-          dashboardId: extraData.dashboard.id,
+          dashboard: extraData.dashboard,
           emitterId: clickBehavior.emitter_id,
           parameters,
         }),
@@ -167,11 +167,13 @@ function getParametersForNativeAction(
   Object.values(parameterMapping).forEach(({ id, source, target }) => {
     const targetTemplateTag = templateTags.find(tag => tag.id === id);
 
-    const [value] = formatSourceForTarget(source, target, {
+    const result = formatSourceForTarget(source, target, {
       data,
       extraData,
       clickBehavior,
     });
+    // For some reason it's sometimes [1] and sometimes just 1
+    const value = Array.isArray(result) ? result[0] : result;
 
     parameters[id] = {
       value,

--- a/frontend/src/metabase/modes/components/modes/ActionMode.jsx
+++ b/frontend/src/metabase/modes/components/modes/ActionMode.jsx
@@ -1,0 +1,8 @@
+import DashboardClickDrill from "../drill/DashboardClickDrill";
+
+const ActionMode = {
+  name: "actions",
+  drills: () => [DashboardClickDrill],
+};
+
+export default ActionMode;

--- a/frontend/src/metabase/modes/lib/modes.ts
+++ b/frontend/src/metabase/modes/lib/modes.ts
@@ -1,3 +1,4 @@
+import ActionMode from "../components/modes/ActionMode";
 import SegmentMode from "../components/modes/SegmentMode";
 import MetricMode from "../components/modes/MetricMode";
 import TimeseriesMode from "../components/modes/TimeseriesMode";
@@ -10,6 +11,7 @@ import { QueryMode } from "metabase-types/types/Visualization";
 import Question from "metabase-lib/lib/Question";
 import { getMode as getModeFromLib } from "metabase-lib/lib/Mode";
 import {
+  MODE_TYPE_ACTION,
   MODE_TYPE_NATIVE,
   MODE_TYPE_SEGMENT,
   MODE_TYPE_METRIC,
@@ -25,6 +27,9 @@ export function getMode(question: Question): QueryMode | any | null {
   }
 
   switch (mode) {
+    case MODE_TYPE_ACTION:
+      return ActionMode;
+
     case MODE_TYPE_NATIVE:
       return NativeMode;
 

--- a/frontend/src/metabase/parameters/utils/cards.ts
+++ b/frontend/src/metabase/parameters/utils/cards.ts
@@ -16,7 +16,7 @@ import { Card } from "metabase-types/types/Card";
 import { TemplateTag } from "metabase-types/types/Query";
 import Metadata from "metabase-lib/lib/metadata/Metadata";
 
-function getTemplateTagType(tag: TemplateTag) {
+export function getTemplateTagType(tag: TemplateTag) {
   const { type } = tag;
   if (type === "date") {
     return "date/single";

--- a/frontend/src/metabase/parameters/utils/cards.ts
+++ b/frontend/src/metabase/parameters/utils/cards.ts
@@ -30,16 +30,19 @@ function getTemplateTagType(tag: TemplateTag) {
   }
 }
 
-export function getTemplateTagParameter(tag: TemplateTag): ParameterWithTarget {
-  const target: ParameterTarget =
-    tag.type === "dimension"
-      ? ["dimension", ["template-tag", tag.name]]
-      : ["variable", ["template-tag", tag.name]];
+export function getTemplateTagParameterTarget(
+  tag: TemplateTag,
+): ParameterTarget {
+  return tag.type === "dimension"
+    ? ["dimension", ["template-tag", tag.name]]
+    : ["variable", ["template-tag", tag.name]];
+}
 
+export function getTemplateTagParameter(tag: TemplateTag): ParameterWithTarget {
   return {
     id: tag.id,
     type: tag["widget-type"] || getTemplateTagType(tag),
-    target,
+    target: getTemplateTagParameterTarget(tag),
     name: tag["display-name"],
     slug: tag.name,
     default: tag.default,

--- a/frontend/src/metabase/parameters/utils/mapping-options.js
+++ b/frontend/src/metabase/parameters/utils/mapping-options.js
@@ -41,8 +41,12 @@ function buildVariableOption(variable) {
 
 export function getParameterMappingOptions(metadata, parameter = null, card) {
   const options = [];
-  if (card.display === "text") {
-    // text cards don't have parameters
+  if (
+    card.display === "text" ||
+    card.display === "actions" ||
+    card.display === "action-button"
+  ) {
+    // text and action cards don't have parameters
     return [];
   }
 

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -528,3 +528,10 @@ export const ActionsApi = {
   update: POST("/api/actions/row/update"),
   delete: POST("/api/actions/row/delete"),
 };
+
+export const EmittersApi = {
+  create: POST("/api/emitter"),
+  update: PUT("/api/emitter/:id"),
+  delete: DELETE("/api/emitter/:id"),
+  execute: POST("/api/emitter/:id/execute"),
+};

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.styled.tsx
@@ -7,6 +7,13 @@ interface ObjectDetailModalProps {
   wide: boolean;
 }
 
+export const CenteredLayout = styled.div`
+  display: flex;
+  flex: 1;
+  justify-content: center;
+  align-items: center;
+`;
+
 export const ObjectDetailModal = styled.div<ObjectDetailModalProps>`
   overflow-y: scroll;
   height: 100%;

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
@@ -49,6 +49,7 @@ import {
 import { DetailsTable } from "./ObjectDetailsTable";
 import { Relationships } from "./ObjectRelationships";
 import {
+  CenteredLayout,
   RootModal,
   ObjectDetailModal,
   ObjectDetailBodyWrapper,
@@ -352,13 +353,23 @@ export function ObjectDetailFn({
 function ObjectDetailWrapper({
   question,
   isDataApp,
+  data,
   closeObjectDetail,
   ...props
 }: ObjectDetailProps & { isDataApp?: boolean }) {
   if (isDataApp || question.display() === "object") {
+    if (data.rows.length > 1) {
+      return (
+        <CenteredLayout>
+          <h3>{t`Too many rows for a detail view`}</h3>
+        </CenteredLayout>
+      );
+    }
+
     return (
       <ObjectDetailFn
         {...props}
+        data={data}
         question={question}
         showActions={false}
         showRelations={false}
@@ -375,6 +386,7 @@ function ObjectDetailWrapper({
     >
       <ObjectDetailFn
         {...props}
+        data={data}
         question={question}
         closeObjectDetail={closeObjectDetail}
       />
@@ -531,7 +543,7 @@ export const ObjectDetailProperties = {
     // @ts-ignore
     ...columnSettings({ hidden: true }),
   },
-  isSensible: (data: DatasetData) => data.rows.length === 1,
+  isSensible: () => true,
 };
 
 const ObjectDetail = Object.assign(

--- a/frontend/src/metabase/visualizations/hoc/WithVizSettingsData.js
+++ b/frontend/src/metabase/visualizations/hoc/WithVizSettingsData.js
@@ -4,8 +4,33 @@ import { connect } from "react-redux";
 import _ from "underscore";
 
 import { getUserAttributes } from "metabase/selectors/user";
+
+import Actions from "metabase/entities/actions";
 import Questions from "metabase/entities/questions";
 import Dashboards from "metabase/entities/dashboards";
+
+function hasLinkedQuestionOrDashboard({ type, linkType, action } = {}) {
+  if (type === "action") {
+    return typeof action === "number";
+  }
+  if (type === "link") {
+    return linkType === "question" || linkType === "dashboard";
+  }
+  return false;
+}
+
+function mapLinkedEntityToEntityQuery({ type, linkType, action, targetId }) {
+  if (type === "action") {
+    return {
+      entity: Actions,
+      entityId: action,
+    };
+  }
+  return {
+    entity: linkType === "question" ? Questions : Dashboards,
+    entityId: targetId,
+  };
+}
 
 // This HOC give access to data referenced in viz settings.
 // We use it to fetch and select entities needed for dashboard drill actions (e.g. clicking through to a question)
@@ -18,15 +43,8 @@ const WithVizSettingsData = ComposedComponent => {
         settings => settings.click_behavior,
       ),
     ]
-      .filter(
-        ({ type, linkType } = {}) =>
-          type === "link" &&
-          (linkType === "question" || linkType === "dashboard"),
-      )
-      .map(({ linkType, targetId }) => ({
-        entity: linkType === "question" ? Questions : Dashboards,
-        entityId: targetId,
-      }));
+      .filter(hasLinkedQuestionOrDashboard)
+      .map(mapLinkedEntityToEntityQuery);
   }
   return connect(
     (state, props) => ({

--- a/frontend/src/metabase/visualizations/register.js
+++ b/frontend/src/metabase/visualizations/register.js
@@ -4,6 +4,7 @@ import {
 } from "metabase/visualizations";
 
 import ActionsViz from "metabase/writeback/components/ActionsViz";
+import ActionButtonViz from "metabase/writeback/components/ActionButtonViz";
 
 import Scalar from "./visualizations/Scalar";
 import SmartScalar from "./visualizations/SmartScalar";
@@ -46,5 +47,6 @@ export default function() {
   registerVisualization(PivotTable);
   registerVisualization(ListViz);
   registerVisualization(ActionsViz);
+  registerVisualization(ActionButtonViz);
   setDefaultVisualization(Table);
 }

--- a/frontend/src/metabase/writeback/actions.ts
+++ b/frontend/src/metabase/writeback/actions.ts
@@ -3,6 +3,7 @@ import { t } from "ttag";
 import { ActionsApi } from "metabase/services";
 import Table from "metabase-lib/lib/metadata/Table";
 
+import { getMetadata } from "metabase/selectors/metadata";
 import { addUndo } from "metabase/redux/undo";
 
 import { fetchCardData } from "metabase/dashboard/actions";
@@ -10,7 +11,12 @@ import { runQuestionQuery } from "metabase/query_builder/actions/querying";
 import { setUIControls } from "metabase/query_builder/actions/ui";
 import { closeObjectDetail } from "metabase/query_builder/actions/object-detail";
 
+import Question from "metabase-lib/lib/Question";
+
 import { DashCard } from "metabase-types/types/Dashboard";
+import { State } from "metabase-types/store";
+
+import { WritebackAction } from "./types";
 
 export type InsertRowPayload = {
   table: Table;
@@ -189,5 +195,31 @@ export const deleteRowFromDataApp = (payload: DeleteRowFromDataAppPayload) => {
         }),
       );
     }
+  };
+};
+
+export type ExecuteRowActionPayload = {
+  action: WritebackAction;
+  parameters: Record<string, unknown>;
+};
+
+export const executeRowAction = ({
+  action,
+  parameters,
+}: ExecuteRowActionPayload) => {
+  return async function(dispatch: any, getState: () => State) {
+    const metadata = getMetadata(getState());
+    const actionCard = {
+      ...action.card,
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      dataset_query: JSON.parse(action.card.dataset_query as string),
+    };
+    const actionQuestion = new Question(actionCard, metadata);
+    alert(
+      `Call ${actionQuestion.displayName()}, parameters: ${JSON.stringify(
+        parameters,
+      )}`,
+    );
   };
 };

--- a/frontend/src/metabase/writeback/actions.ts
+++ b/frontend/src/metabase/writeback/actions.ts
@@ -1,22 +1,16 @@
 import { t } from "ttag";
 
-import { ActionsApi } from "metabase/services";
+import { ActionsApi, EmittersApi } from "metabase/services";
 import Table from "metabase-lib/lib/metadata/Table";
 
-import { getMetadata } from "metabase/selectors/metadata";
 import { addUndo } from "metabase/redux/undo";
 
-import { fetchCardData } from "metabase/dashboard/actions";
+import { fetchCardData, fetchDashboard } from "metabase/dashboard/actions";
 import { runQuestionQuery } from "metabase/query_builder/actions/querying";
 import { setUIControls } from "metabase/query_builder/actions/ui";
 import { closeObjectDetail } from "metabase/query_builder/actions/object-detail";
 
-import Question from "metabase-lib/lib/Question";
-
 import { DashCard } from "metabase-types/types/Dashboard";
-import { State } from "metabase-types/store";
-
-import { WritebackAction } from "./types";
 
 export type InsertRowPayload = {
   table: Table;
@@ -199,27 +193,40 @@ export const deleteRowFromDataApp = (payload: DeleteRowFromDataAppPayload) => {
 };
 
 export type ExecuteRowActionPayload = {
-  action: WritebackAction;
+  dashboardId: number;
+  emitterId: number;
   parameters: Record<string, unknown>;
 };
 
 export const executeRowAction = ({
-  action,
+  dashboardId,
+  emitterId,
   parameters,
 }: ExecuteRowActionPayload) => {
-  return async function(dispatch: any, getState: () => State) {
-    const metadata = getMetadata(getState());
-    const actionCard = {
-      ...action.card,
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      dataset_query: JSON.parse(action.card.dataset_query as string),
-    };
-    const actionQuestion = new Question(actionCard, metadata);
-    alert(
-      `Call ${actionQuestion.displayName()}, parameters: ${JSON.stringify(
+  return async function(dispatch: any) {
+    try {
+      const result = await EmittersApi.execute({
+        id: emitterId,
         parameters,
-      )}`,
-    );
+      });
+      if (result["rows-affected"] > 0) {
+        dispatch(fetchDashboard(dashboardId));
+        dispatch(
+          addUndo({
+            toastColor: "success",
+            message: t`Successfully executed the action`,
+          }),
+        );
+      }
+    } catch (err) {
+      console.error(err);
+      dispatch(
+        addUndo({
+          icon: "warning",
+          toastColor: "error",
+          message: t`Something went wrong while executing the action`,
+        }),
+      );
+    }
   };
 };

--- a/frontend/src/metabase/writeback/components/ActionButtonViz.tsx
+++ b/frontend/src/metabase/writeback/components/ActionButtonViz.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import { t } from "ttag";
+
+import Button from "metabase/core/components/Button";
+
+import { DashboardWithCards } from "metabase-types/types/Dashboard";
+import { VisualizationProps } from "metabase-types/types/Visualization";
+
+const ACTIONS_VIZ_DEFINITION = {
+  uiName: t`Action button`,
+  identifier: "action-button",
+  iconName: "play",
+
+  noHeader: true,
+  supportsSeries: false,
+  hidden: true,
+  supportPreviewing: false,
+
+  minSize: { width: 1, height: 1 },
+  maxSize: { width: 1, height: 1 },
+
+  checkRenderable: () => true,
+  isSensible: () => false,
+
+  settings: {
+    "card.title": {
+      dashboard: false,
+    },
+    "card.description": {
+      dashboard: false,
+    },
+    "button.label": {
+      section: t`Display`,
+      title: t`Label`,
+      widget: "input",
+      default: "Click Me",
+    },
+    "button.variant": {
+      section: t`Display`,
+      title: t`Variant`,
+      widget: "select",
+      default: "default",
+      props: {
+        options: [
+          { name: t`Default`, value: "default" },
+          { name: t`Primary`, value: "primary" },
+          { name: t`Danger`, value: "danger" },
+          { name: t`Success`, value: "success" },
+          { name: t`Borderless`, value: "borderless" },
+        ],
+      },
+    },
+  },
+};
+
+interface ActionButtonVizProps extends VisualizationProps {
+  dashboard: DashboardWithCards;
+}
+
+function ActionButtonViz({ settings }: ActionButtonVizProps) {
+  const label = settings["button.label"];
+  const variant = settings["button.variant"];
+
+  const variantProps: any = {};
+  if (variant !== "default") {
+    variantProps[variant] = true;
+  }
+
+  return <Button {...variantProps}>{label}</Button>;
+}
+
+export default Object.assign(ActionButtonViz, ACTIONS_VIZ_DEFINITION);

--- a/frontend/src/metabase/writeback/components/ActionButtonViz.tsx
+++ b/frontend/src/metabase/writeback/components/ActionButtonViz.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback, useMemo } from "react";
 import { t } from "ttag";
 import cx from "classnames";
 
@@ -58,7 +58,12 @@ interface ActionButtonVizProps extends VisualizationProps {
   dashboard: DashboardWithCards;
 }
 
-function ActionButtonViz({ isSettings, settings }: ActionButtonVizProps) {
+function ActionButtonViz({
+  isSettings,
+  settings,
+  getExtraDataForClick,
+  onVisualizationClick,
+}: ActionButtonVizProps) {
   const label = settings["button.label"];
   const variant = settings["button.variant"];
 
@@ -67,11 +72,35 @@ function ActionButtonViz({ isSettings, settings }: ActionButtonVizProps) {
     variantProps[variant] = true;
   }
 
+  const clicked = useMemo(
+    () => ({
+      settings,
+    }),
+    [settings],
+  );
+
+  const extraData = useMemo(() => getExtraDataForClick?.(clicked), [
+    clicked,
+    getExtraDataForClick,
+  ]);
+
+  const onClick = useCallback(
+    (e: React.MouseEvent) => {
+      onVisualizationClick({
+        ...clicked,
+        extraData,
+        element: e.currentTarget as HTMLElement,
+      });
+    },
+    [clicked, extraData, onVisualizationClick],
+  );
+
   return (
     <Button
       className={cx({
         "full-height": !isSettings,
       })}
+      onClick={onClick}
       {...variantProps}
     >
       {label}

--- a/frontend/src/metabase/writeback/components/ActionButtonViz.tsx
+++ b/frontend/src/metabase/writeback/components/ActionButtonViz.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { t } from "ttag";
+import cx from "classnames";
 
 import Button from "metabase/core/components/Button";
 
@@ -57,7 +58,7 @@ interface ActionButtonVizProps extends VisualizationProps {
   dashboard: DashboardWithCards;
 }
 
-function ActionButtonViz({ settings }: ActionButtonVizProps) {
+function ActionButtonViz({ isSettings, settings }: ActionButtonVizProps) {
   const label = settings["button.label"];
   const variant = settings["button.variant"];
 
@@ -66,7 +67,16 @@ function ActionButtonViz({ settings }: ActionButtonVizProps) {
     variantProps[variant] = true;
   }
 
-  return <Button {...variantProps}>{label}</Button>;
+  return (
+    <Button
+      className={cx({
+        "full-height": !isSettings,
+      })}
+      {...variantProps}
+    >
+      {label}
+    </Button>
+  );
 }
 
 export default Object.assign(ActionButtonViz, ACTIONS_VIZ_DEFINITION);

--- a/frontend/src/metabase/writeback/components/ActionButtonViz.tsx
+++ b/frontend/src/metabase/writeback/components/ActionButtonViz.tsx
@@ -17,8 +17,7 @@ const ACTIONS_VIZ_DEFINITION = {
   hidden: true,
   supportPreviewing: false,
 
-  minSize: { width: 1, height: 1 },
-  maxSize: { width: 1, height: 1 },
+  minSize: { width: 2, height: 1 },
 
   checkRenderable: () => true,
   isSensible: () => false,

--- a/frontend/src/metabase/writeback/components/ActionsLinkingControl.tsx
+++ b/frontend/src/metabase/writeback/components/ActionsLinkingControl.tsx
@@ -28,8 +28,10 @@ function ActionsLinkingControl({
   const connectedDashCardId =
     card.visualization_settings["actions.linked_card"];
 
-  const suitableDashCards = dashboard.ordered_cards.filter(dashCard =>
-    Q_DEPRECATED.isStructured(dashCard.card.dataset_query),
+  const suitableDashCards = dashboard.ordered_cards.filter(
+    dashCard =>
+      Q_DEPRECATED.isStructured(dashCard.card.dataset_query) &&
+      !dashCard.isAdded, // only show dash cards that have a stable ID already
   ) as StructuredQueryDashCard[];
 
   return (

--- a/frontend/src/metabase/writeback/components/ActionsViz/ActionsViz.tsx
+++ b/frontend/src/metabase/writeback/components/ActionsViz/ActionsViz.tsx
@@ -15,6 +15,8 @@ import WritebackModalForm from "metabase/writeback/containers/WritebackModalForm
 // TODO This should better be extracted to metabase/lib/somewhere
 import { getObjectName } from "metabase/visualizations/components/ObjectDetail/utils";
 
+import { getMetadata } from "metabase/selectors/metadata";
+
 import Metadata from "metabase-lib/lib/metadata/Metadata";
 import Question from "metabase-lib/lib/Question";
 
@@ -121,6 +123,7 @@ type ActionsVizProps = ActionVizOwnProps &
 function mapStateToProps(state: State) {
   return {
     dashCardData: getCardData(state),
+    metadata: getMetadata(state),
   };
 }
 
@@ -164,6 +167,7 @@ function ActionsViz({
     ? new Question(connectedDashCard?.card, metadata)
     : null;
 
+  console.log("### QUESTIOn", { question, metadata, connectedDashCard });
   const isObjectDetailView = question?.display() === "object";
   const table = question?.table();
   const connectedCardData =

--- a/frontend/src/metabase/writeback/components/ActionsViz/ActionsViz.tsx
+++ b/frontend/src/metabase/writeback/components/ActionsViz/ActionsViz.tsx
@@ -167,7 +167,6 @@ function ActionsViz({
     ? new Question(connectedDashCard?.card, metadata)
     : null;
 
-  console.log("### QUESTIOn", { question, metadata, connectedDashCard });
   const isObjectDetailView = question?.display() === "object";
   const table = question?.table();
   const connectedCardData =

--- a/frontend/src/metabase/writeback/components/ActionsViz/ActionsViz.tsx
+++ b/frontend/src/metabase/writeback/components/ActionsViz/ActionsViz.tsx
@@ -45,7 +45,7 @@ const ACTIONS_VIZ_DEFINITION = {
   hidden: true,
   supportPreviewing: false,
 
-  minSize: { width: 4, height: 1 },
+  minSize: { width: 3, height: 1 },
 
   checkRenderable: () => true,
   isSensible: () => false,

--- a/frontend/src/metabase/writeback/components/ActionsViz/ActionsViz.tsx
+++ b/frontend/src/metabase/writeback/components/ActionsViz/ActionsViz.tsx
@@ -141,7 +141,6 @@ function getObjectDetailViewData(
 function ActionsViz({
   dashboard,
   dashCardData,
-  isEditing,
   metadata,
   settings,
   deleteRow,

--- a/frontend/src/metabase/writeback/types.ts
+++ b/frontend/src/metabase/writeback/types.ts
@@ -1,4 +1,5 @@
 import Field from "metabase-lib/lib/metadata/Field";
+import { SavedCard, NativeDatasetQuery } from "metabase-types/types/Card";
 
 export interface CategoryWidgetProps {
   field: {
@@ -8,4 +9,16 @@ export interface CategoryWidgetProps {
   formField: {
     fieldInstance: Field;
   };
+}
+
+export type WritebackActionCard = SavedCard<NativeDatasetQuery> & {
+  is_write: true;
+};
+
+export interface WritebackAction {
+  id: number;
+  type: "row";
+  card: WritebackActionCard;
+  "updated-at": string;
+  "created-at": string;
 }

--- a/frontend/src/metabase/writeback/utils.ts
+++ b/frontend/src/metabase/writeback/utils.ts
@@ -1,5 +1,6 @@
 import Database from "metabase-lib/lib/metadata/Database";
 import { Database as IDatabase } from "metabase-types/types/Database";
+import { DashCard } from "metabase-types/types/Dashboard";
 
 const DB_WRITEBACK_FEATURE = "actions";
 const DB_WRITEBACK_SETTING = "database-enable-actions";
@@ -9,3 +10,12 @@ export const isDatabaseWritebackEnabled = (database?: IDatabase | null) =>
 
 export const isWritebackSupported = (database?: Database | null) =>
   !!database?.hasFeature(DB_WRITEBACK_FEATURE);
+
+export const isActionButtonDashCard = (dashCard: DashCard) =>
+  dashCard.visualization_settings?.virtual_card?.display === "action-button";
+
+export const getActionButtonEmitterId = (dashCard: DashCard) =>
+  dashCard.visualization_settings?.click_behavior?.emitter_id;
+
+export const getActionButtonActionId = (dashCard: DashCard) =>
+  dashCard.visualization_settings?.click_behavior?.action;

--- a/frontend/src/metabase/writeback/utils.ts
+++ b/frontend/src/metabase/writeback/utils.ts
@@ -2,7 +2,6 @@ import { getTemplateTagParameterTarget } from "metabase/parameters/utils/cards";
 
 import Database from "metabase-lib/lib/metadata/Database";
 
-import { NativeDatasetQuery } from "metabase-types/types/Card";
 import { Database as IDatabase } from "metabase-types/types/Database";
 import { DashCard } from "metabase-types/types/Dashboard";
 import { ParameterTarget } from "metabase-types/types/Parameter";
@@ -33,10 +32,9 @@ export const getActionEmitterParameterMappings = (
 ) => {
   const { click_behavior } = dashCard.visualization_settings;
 
-  const query = JSON.parse(
-    (action.card.dataset_query as unknown) as string,
-  ) as NativeDatasetQuery;
-  const templateTags = Object.values(query.native["template-tags"]);
+  const templateTags = Object.values(
+    action.card.dataset_query.native["template-tags"],
+  );
 
   const parameterMappings: Record<string, ParameterTarget> = {};
 


### PR DESCRIPTION
Resolves (partially) #22857 and #22858

This PR makes it possible to add custom action buttons to a dashboard and hooked them up with custom query actions via dashboard emitters. For now, it's only possible to create/delete emitters (no updates), no support for emitters on saved questions too.

The first implementation is pretty harsh and will most likely evolve. Emitters have everything needed to store button dimensions, positions on a dashboard, and various attributes like a label, color, etc. The problem is that dashboards are too bound to an idea of everything there being a card with visualization settings and parameters passed via click behavior. At the moment an action button is still going to be a "virtual dashboard card" (like a markdown-only card). Once a user saves a new action button, the FE will also create an emitter and put its ID in the action button's card object, so they're "linked". Eventually, we'll probably want "data apps" to treat buttons in a different way. Not necessarily though, so I'm leaning towards the fastest implementation for now