### PR TITLE
Do not run E2E tests on release branch in CCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1227,7 +1227,9 @@ workflows:
             - be-deps
           filters:
             branches:
-              ignore: master
+              ignore:
+                - master
+                - release-**
           <<: *Matrix
 
       - build-uberjar-frontend:
@@ -1248,7 +1250,9 @@ workflows:
             - checkout
           filters:
             branches:
-              ignore: master
+              ignore:
+                - master
+                - release-**
 
       - fe-tests-cypress:
           matrix:
@@ -1308,4 +1312,6 @@ workflows:
             - checkout
           filters:
             branches:
-              ignore: master
+              ignore:
+                - master
+                - release-**


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- The same thing as #22986, but now we're excluding Cypress E2E checks for the release branch in CircleCI


This should further reduce our CircleCI usage and it moves us one step forward to the total migration towards GitHub Actions.

### Notes
This will not affect checks on PR.

This is now possible thanks to:
- https://github.com/metabase/metabase/pull/23166
- https://github.com/metabase/metabase/pull/21299
- https://github.com/metabase/metabase/pull/23193