### PR TITLE
Native query: construct `parameters[]` when necessary

### DIFF
--- a/frontend/src/metabase-lib/lib/Question.ts
+++ b/frontend/src/metabase-lib/lib/Question.ts
@@ -1341,6 +1341,10 @@ export default class Question extends memoizeClass<QuestionInner>(
       dataset_query,
     };
 
+    if (type === "native") {
+      card = assocIn(card, ["parameters"], []);
+    }
+
     if (tableId != null) {
       card = assocIn(card, ["dataset_query", "query", "source-table"], tableId);
     }

--- a/frontend/src/metabase/query_builder/actions/core/core.js
+++ b/frontend/src/metabase/query_builder/actions/core/core.js
@@ -26,6 +26,11 @@ import { fetchAlertsForQuestion } from "metabase/alert/alert";
 import Question from "metabase-lib/lib/Question";
 import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
 
+import {
+  getTemplateTagsForParameters,
+  getTemplateTagParameters,
+} from "metabase/parameters/utils/cards";
+
 import { trackNewQuestionSaved } from "../../analytics";
 import {
   getCard,
@@ -305,6 +310,14 @@ export const updateQuestion = (
           shouldUpdateUrl: false,
         }),
       );
+    }
+
+    const newDatasetQuery = newQuestion.query().datasetQuery();
+    // Sync card's parameters with the template tags;
+    if (newDatasetQuery.type === "native") {
+      const templateTags = getTemplateTagsForParameters(newQuestion.card());
+      const parameters = getTemplateTagParameters(templateTags);
+      newQuestion = newQuestion.setParameters(parameters);
     }
 
     // Replace the current question with a new one

--- a/frontend/src/metabase/query_builder/actions/native.js
+++ b/frontend/src/metabase/query_builder/actions/native.js
@@ -20,7 +20,6 @@ import { SET_UI_CONTROLS } from "./ui";
 import {
   getTemplateTagsForParameters,
   getTemplateTagParameters,
-  getTemplateTagParameter,
 } from "metabase/parameters/utils/cards";
 
 export const TOGGLE_DATA_REFERENCE = "metabase/qb/TOGGLE_DATA_REFERENCE";
@@ -144,29 +143,11 @@ export const setTemplateTag = createThunkAction(
         },
       );
 
-      const { parameters } = updatedTagsCard;
-      if (parameters && Array.isArray(parameters)) {
-        if (parameters.length === 0) {
-          // reconstruct from the existing template tags
-          const tags = getTemplateTagsForParameters(updatedTagsCard);
-          const newParameters = getTemplateTagParameters(tags);
-          return assoc(updatedTagsCard, "parameters", newParameters);
-        } else {
-          // update an existing parameter
-          const index = parameters.findIndex(p => p.id === templateTag.id);
-          if (index < 0) {
-            console.warn(`Can't find parameter with id=${templateTag.id}!`);
-          } else {
-            parameters[index] = getTemplateTagParameter(templateTag);
-          }
-        }
-      } else {
-        const tags = getTemplateTagsForParameters(updatedTagsCard);
-        const newParameters = getTemplateTagParameters(tags);
-        return assoc(updatedTagsCard, "parameters", newParameters);
-      }
-
-      return updatedTagsCard;
+      return assoc(
+        updatedTagsCard,
+        "parameters",
+        getTemplateTagParameters(getTemplateTagsForParameters(updatedTagsCard)),
+      );
     };
   },
 );

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx
@@ -14,10 +14,6 @@ import SidebarContent from "metabase/query_builder/components/SidebarContent";
 import * as MetabaseAnalytics from "metabase/lib/analytics";
 
 import NativeQuery from "metabase-lib/lib/queries/NativeQuery";
-import {
-  getTemplateTagsForParameters,
-  getTemplateTagParameters,
-} from "metabase/parameters/utils/cards";
 
 export default class TagEditorSidebar extends React.Component {
   state = {
@@ -45,7 +41,6 @@ export default class TagEditorSidebar extends React.Component {
 
   render() {
     const {
-      card,
       databases,
       databaseFields,
       sampleDatabaseId,
@@ -55,11 +50,6 @@ export default class TagEditorSidebar extends React.Component {
       setParameterValue,
       onClose,
     } = this.props;
-
-    // Sync card's parameters with the template tags;
-    card.parameters = getTemplateTagParameters(
-      getTemplateTagsForParameters(card),
-    );
 
     // The tag editor sidebar excludes snippets since they have a separate sidebar.
     const tags = query.templateTagsWithoutSnippets();

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx
@@ -14,6 +14,10 @@ import SidebarContent from "metabase/query_builder/components/SidebarContent";
 import * as MetabaseAnalytics from "metabase/lib/analytics";
 
 import NativeQuery from "metabase-lib/lib/queries/NativeQuery";
+import {
+  getTemplateTagsForParameters,
+  getTemplateTagParameters,
+} from "metabase/parameters/utils/cards";
 
 export default class TagEditorSidebar extends React.Component {
   state = {
@@ -41,6 +45,7 @@ export default class TagEditorSidebar extends React.Component {
 
   render() {
     const {
+      card,
       databases,
       databaseFields,
       sampleDatabaseId,
@@ -50,6 +55,12 @@ export default class TagEditorSidebar extends React.Component {
       setParameterValue,
       onClose,
     } = this.props;
+
+    // Sync card's parameters with the template tags;
+    card.parameters = getTemplateTagParameters(
+      getTemplateTagsForParameters(card),
+    );
+
     // The tag editor sidebar excludes snippets since they have a separate sidebar.
     const tags = query.templateTagsWithoutSnippets();
     const database = query.database();

--- a/frontend/test/metabase/scenarios/native/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/native.cy.spec.js
@@ -216,6 +216,42 @@ describe("scenarios > question > native", () => {
     cy.get("@sidebar").contains(/added/i);
   });
 
+  it("should recognize template tags and save them as parameters", () => {
+    openNativeEditor().type(
+      "select * from PRODUCTS where CATEGORY={{cat}} and RATING >= {{stars}}",
+      {
+        parseSpecialCharSequences: false,
+      },
+    );
+    cy.get("input[placeholder*='Cat']").type("Gizmo");
+    cy.get("input[placeholder*='Stars']").type("3");
+
+    cy.get(".NativeQueryEditor .Icon-play").click();
+    cy.wait("@dataset");
+
+    cy.contains("Save").click();
+
+    modal().within(() => {
+      cy.findByLabelText("Name").type("SQL Products");
+      cy.findByText("Save").click();
+
+      // parameters[] should reflect the template tags
+      cy.wait("@card").should(xhr => {
+        const requestBody = xhr.request?.body;
+        expect(requestBody?.parameters?.length).to.equal(2);
+      });
+    });
+    cy.findByText("Not now").click();
+
+    // Now load the question again and parameters[] should still be there
+    cy.intercept("GET", "/api/card/4").as("cardQuestion");
+    cy.visit("/question/4?cat=Gizmo&stars=3");
+    cy.wait("@cardQuestion").should(xhr => {
+      const responseBody = xhr.response?.body;
+      expect(responseBody?.parameters?.length).to.equal(2);
+    });
+  });
+
   it("should link correctly from the variables sidebar (metabase#16212)", () => {
     cy.createNativeQuestion({
       name: "test-question",


### PR DESCRIPTION
To verify:
1. New, SQL Query
2. Type `select * from PRODUCTS where CATEGORY={{cat}}`
3. Save, and give it a name

There is a new E2E test added in `frontend/test/metabase/scenarios/native/native.cy.spec.js`, run it as well.

### Before this PR

During Step 3, if we open browser console/DevTools, the `POST` to `/api/card` does not include `parameters` array.

![image](https://user-images.githubusercontent.com/7288/172465323-c84ec6a8-00a4-4d81-8304-80aa232d754b.png)

### After this PR

`parameters[]` is constructed properly.

![image](https://user-images.githubusercontent.com/7288/172465067-10c0a15b-d709-4dca-b252-3f2aacdb259e.png)
