### PR TITLE
[E2E] Fix group-admin flake

### DIFF
--- a/frontend/test/metabase/scenarios/admin/people/group-managers.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/people/group-managers.cy.spec.js
@@ -21,7 +21,9 @@ describeEE("scenarios > admin > people", () => {
 
   describe("group managers", () => {
     it("can manage groups from the group page", () => {
-      cy.findByTextEnsureVisible("Groups").click();
+      cy.get(".AdminList").within(() => {
+        cy.findByTextEnsureVisible("Groups").click();
+      });
 
       // Edit group name
       cy.icon("ellipsis")


### PR DESCRIPTION
This flake is occurring relatively often:
![image](https://user-images.githubusercontent.com/31325167/172468284-9538b131-1d5a-4edc-8ba3-50f1299f2ad9.png)

It happens because `cy.findByText` expects only one element to be found, but two strings "Groups" exist on the page.
![image](https://user-images.githubusercontent.com/31325167/172468442-a2e1b1d9-750a-4c63-9231-88e3899df544.png)

Solution is to narrow it down and to explicitly tell Cypress which string are you searching for.
