### PR TITLE
Update filter modal tab metrics

### DIFF
--- a/frontend/src/metabase-lib/lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/lib/queries/StructuredQuery.ts
@@ -903,10 +903,13 @@ class StructuredQueryInner extends AtomicQuery {
 
     // special logic to only show aggregation dimensions for post-aggregation dimensions
     if (queries.length > 1) {
-      // set the section title to `Metrics`
-      sections[0].name = t`Metrics`;
+      const summarySection = {
+        name: t`Summaries`,
+        icon: "sum",
+        items: [],
+      };
       // only include aggregation dimensions
-      sections[0].items = sections[0].items.filter(item => {
+      summarySection.items = sections[0].items.filter(item => {
         if (item.dimension) {
           const sourceDimension = queries[0].dimensionForSourceQuery(
             item.dimension,
@@ -919,6 +922,8 @@ class StructuredQueryInner extends AtomicQuery {
 
         return true;
       });
+      sections.shift();
+      sections.push(summarySection);
     }
 
     return sections;

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterModal/BulkFilterModal.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterModal/BulkFilterModal.tsx
@@ -171,11 +171,7 @@ const BulkFilterModalSectionList = ({
     <TabContent value={tab} onChange={setTab}>
       <ModalTabList>
         {sections.map((section, index) => (
-          <Tab
-            key={index}
-            value={index}
-            icon={index > 0 ? section.icon : undefined}
-          >
+          <Tab key={index} value={index} icon={section.icon}>
             {section.name}
           </Tab>
         ))}

--- a/frontend/test/metabase/scenarios/filters/filter-bulk.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/filter-bulk.cy.spec.js
@@ -104,6 +104,7 @@ describe("scenarios > filters > bulk filtering", () => {
     openFilterModal();
 
     modal().within(() => {
+      cy.findByText("Summaries").click();
       cy.findByLabelText("Count").click();
     });
 


### PR DESCRIPTION
## Description

- change "metrics" tab name to "summaries" [(notion link)](https://www.notion.so/metabase/Change-Metrics-tab-name-to-Summaries-or-Summarizations-afdab449d595402b80053bf6fd049438)
- put "summaries" tab at the end of the tabs [(notion link)](https://www.notion.so/metabase/Dimensions-should-come-before-metrics-in-filter-modal-1daf9954df304e808c715f30009dd47e)
- always show tab icons

## Screenshots

![Screen Shot 2022-06-07 at 2 29 42 PM](https://user-images.githubusercontent.com/30528226/172476616-91866a33-80be-4e44-99b2-e745082e4e6d.png)

This also affects the name and order of options in the filter sidebar

![Screen Shot 2022-06-07 at 2 29 57 PM](https://user-images.githubusercontent.com/30528226/172476660-981c1c3a-4973-4bfa-95d7-3951fe0f62c2.png)

## Testing Steps

- open any table (like orders)
- apply any summary from the summary sidebar (like count by order id)
- open the bulk filter modal, and see the summaries tab appears at the end, with an icon