### PR TITLE
Show question and model names in filters

### DIFF
--- a/frontend/src/metabase-lib/lib/DimensionOptions/DimensionOptions.ts
+++ b/frontend/src/metabase-lib/lib/DimensionOptions/DimensionOptions.ts
@@ -38,8 +38,7 @@ export default class DimensionOptions {
   sections({ extraItems = [] } = {}): DimensionOptionsSection[] {
     const [dimension] = this.dimensions;
     const table = dimension && dimension.field().table;
-    const tableName =
-      table && !table.isSavedQuestion() ? table.objectName() : null;
+    const tableName = table ? table.objectName() : null;
     const mainSection: DimensionOptionsSection = {
       name: this.name || tableName,
       icon: this.icon || "table2",


### PR DESCRIPTION
## Before

In the bulk filter modal tabs, saved question and model names would not appear

![171431659-8f754b51-2fb6-4af9-9b54-269d7577f002](https://user-images.githubusercontent.com/30528226/172488254-b1080465-9d41-4b6e-b218-70cd46a9464d.png)

## After

Question and model names appear in the bulk filter modal

![Screen Shot 2022-06-07 at 3 43 00 PM](https://user-images.githubusercontent.com/30528226/172488417-df075d95-1053-4920-8211-095cb2a45901.png)

This also affects the sidebar (positively, I think)

![Screen Shot 2022-06-07 at 3 38 21 PM](https://user-images.githubusercontent.com/30528226/172488416-df88d3cf-295f-41f5-a757-d51858533b1a.png)

Resolves https://github.com/metabase/metabase/issues/23079 and resolves https://github.com/metabase/metabase/issues/22992

## Testing Steps

- Open a saved question or model. 
- add some sort of summary (to force another tab)
- open the bulk filter modal and see your question or model name as one of the tabs


