### PR TITLE
add :updated-at-timestamped? property and use it on some models

### DIFF
--- a/src/metabase/models/application_permissions_revision.clj
+++ b/src/metabase/models/application_permissions_revision.clj
@@ -6,15 +6,12 @@
 
 (models/defmodel ApplicationPermissionsRevision :application_permissions_revision)
 
-(defn- pre-insert [revision]
-  (assoc revision :created_at :%now))
-
 (u/strict-extend (class ApplicationPermissionsRevision)
   models/IModel
   (merge models/IModelDefaults
          {:types      (constantly {:before :json
                                    :after  :json})
-          :pre-insert pre-insert
+          :properties (constantly {:created-at-timestamped? true})
           :pre-update (fn [& _] (throw (Exception. (tru "You cannot update a ApplicationPermissionsRevision!"))))}))
 
 (defn latest-id

--- a/src/metabase/models/collection_permission_graph_revision.clj
+++ b/src/metabase/models/collection_permission_graph_revision.clj
@@ -6,17 +6,13 @@
 
 (models/defmodel CollectionPermissionGraphRevision :collection_permission_graph_revision)
 
-(defn- pre-insert [revision]
-  (assoc revision :created_at :%now))
-
 (u/strict-extend (class CollectionPermissionGraphRevision)
   models/IModel
   (merge models/IModelDefaults
          {:types      (constantly {:before :json
                                    :after  :json})
-          :pre-insert pre-insert
+          :properties (constantly {:created-at-timestamped? true})
           :pre-update (fn [& _] (throw (Exception. (tru "You cannot update a CollectionPermissionGraphRevision!"))))}))
-
 
 (defn latest-id
   "Return the ID of the newest `CollectionPermissionGraphRevision`, or zero if none have been made yet.

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -227,6 +227,10 @@
   :insert (comp add-created-at-timestamp add-updated-at-timestamp)
   :update add-updated-at-timestamp)
 
+;; like `timestamped?`, but for models that only have an `:created_at` column
+(models/add-property! :created-at-timestamped?
+  :insert add-created-at-timestamp)
+
 ;; like `timestamped?`, but for models that only have an `:updated_at` column
 (models/add-property! :updated-at-timestamped?
   :insert add-updated-at-timestamp

--- a/src/metabase/models/permissions_revision.clj
+++ b/src/metabase/models/permissions_revision.clj
@@ -6,15 +6,12 @@
 
 (models/defmodel PermissionsRevision :permissions_revision)
 
-(defn- pre-insert [revision]
-  (assoc revision :created_at :%now))
-
 (u/strict-extend (class PermissionsRevision)
   models/IModel
   (merge models/IModelDefaults
          {:types      (constantly {:before :json
                                    :after  :json})
-          :pre-insert pre-insert
+          :properties (constantly {:created-at-timestamped? true})
           :pre-update (fn [& _] (throw (Exception. (tru "You cannot update a PermissionsRevision!"))))}))
 
 (defn latest-id

--- a/src/metabase/models/session.clj
+++ b/src/metabase/models/session.clj
@@ -32,4 +32,3 @@
     :post-insert post-insert
     :pre-update  pre-update
     :properties  (constantly {:created-at-timestamped? true})}))
-

--- a/src/metabase/models/session.clj
+++ b/src/metabase/models/session.clj
@@ -17,7 +17,7 @@
   (throw (RuntimeException. "You cannot update a Session.")))
 
 (defn- pre-insert [session]
-  (cond-> (assoc session :created_at :%now)
+  (cond-> session
     (some-> mw.misc/*request* request.u/embedded?) (assoc :anti_csrf_token (random-anti-csrf-token))))
 
 (defn- post-insert [{anti-csrf-token :anti_csrf_token, :as session}]
@@ -30,4 +30,6 @@
    models/IModelDefaults
    {:pre-insert  pre-insert
     :post-insert post-insert
-    :pre-update  pre-update}))
+    :pre-update  pre-update
+    :properties  (constantly {:created-at-timestamped? true})}))
+


### PR DESCRIPTION
Some models are using `pre-insert` to automatically add `created_at` column. This is fine but we should use toucan properties instead.

This PR updates 4 models:
- ApplicationPermissionsRevision
- PermissionsRevision
- CollectionPermissionGraphRevision
- Session
