### PR TITLE
Adding the Starburst driver repo to docs

### DIFF
--- a/docs/developers-guide-drivers.md
+++ b/docs/developers-guide-drivers.md
@@ -37,6 +37,7 @@ To qualify as a partner driver, the driver must:
 Current partner drivers:
 
 - [Firebolt](https://github.com/firebolt-db/metabase-firebolt-driver)
+- [Starburst (compatible with Trino)](https://github.com/starburstdata/metabase-driver)
 
 Partner drivers are available to Cloud customers out-of-the-box.
 


### PR DESCRIPTION
We are releasing a new partner driver: Starburst (compatible with Trino)

Added the link to the repo

ps.: maybe we could use Logos or a table here, it would be more beautiful
