### PR TITLE
Save query executions for cached queries

### DIFF
--- a/test/metabase/query_processor/middleware/cache_test.clj
+++ b/test/metabase/query_processor/middleware/cache_test.clj
@@ -330,29 +330,38 @@
                            (m/dissoc-in [:data :results_metadata :checksum])))
                     "Cached result should be in the same format as the uncached result, except for added keys"))))))))
   (testing "Cached results don't impact average execution time"
-    (let [query                         (assoc (mt/mbql-query venues {:order-by [[:asc $id]] :limit 42})
-                                               :cache-ttl 5000)
-          q-hash                        (qp.util/query-hash query)
-          call-count                    (atom 0)
-          called-promise                (promise)
-          save-query-execution-original (var-get #'process-userland-query/save-query-execution!*)]
-      (with-redefs [process-userland-query/save-query-execution!* (fn [& args]
-                                                                    (swap! call-count inc)
-                                                                    (apply save-query-execution-original args)
-                                                                    (deliver called-promise true))
-                    cache/min-duration-ms                         (constantly 0)]
+    (let [query                               (assoc (mt/mbql-query venues {:order-by [[:asc $id]] :limit 42})
+                                                     :cache-ttl 5000)
+          q-hash                              (qp.util/query-hash query)
+          save-query-execution-count          (atom 0)
+          update-avg-execution-count          (atom 0)
+          called-promise                      (promise)
+          save-query-execution-original       (var-get #'process-userland-query/save-query-execution!*)
+          save-query-update-avg-time-original query/save-query-and-update-average-execution-time!]
+      (with-redefs [process-userland-query/save-query-execution!*       (fn [& args]
+                                                                          (swap! save-query-execution-count inc)
+                                                                          (apply save-query-execution-original args)
+                                                                          (deliver called-promise true))
+                    query/save-query-and-update-average-execution-time! (fn [& args]
+                                                                          (swap! update-avg-execution-count inc)
+                                                                          (apply save-query-update-avg-time-original args))
+                    cache/min-duration-ms                               (constantly 0)]
         (with-mock-cache [save-chan]
           (db/delete! Query :query_hash q-hash)
           (is (not (:cached (qp/process-userland-query query (context.default/default-context)))))
           (a/alts!! [save-chan (a/timeout 200)]) ;; wait-for-result closes the channel
           (u/deref-with-timeout called-promise 500)
-          (is (= 1 @call-count))
+          (is (= 1 @save-query-execution-count))
+          (is (= 1 @update-avg-execution-count))
           (let [avg-execution-time (query/average-execution-time-ms q-hash)]
             (is (number? avg-execution-time))
             ;; rerun query getting cached results
             (is (:cached (qp/process-userland-query query (context.default/default-context))))
             (mt/wait-for-result save-chan)
-            (is (= 1 @call-count) "Saving execution times of a cache lookup")
+            (is (= 2 @save-query-execution-count)
+                "Saving execution times of a cache lookup")
+            (is (= 1 @update-avg-execution-count)
+                "Cached query execution should not update average query duration")
             (is (= avg-execution-time (query/average-execution-time-ms q-hash)))))))))
 
 (deftest insights-from-cache-test

--- a/test/metabase/query_processor/middleware/cache_test.clj
+++ b/test/metabase/query_processor/middleware/cache_test.clj
@@ -322,12 +322,7 @@
                         :status     :completed}
                        (dissoc cached-result :data))
                     "Results should be cached")
-                ;; remove metadata checksums because they can be different between runs when using an encryption key
-                (is (= (-> original-result
-                           (m/dissoc-in [:data :results_metadata :checksum]))
-                       (-> cached-result
-                           (dissoc :cached :updated_at)
-                           (m/dissoc-in [:data :results_metadata :checksum])))
+                (is (= original-result (dissoc cached-result :cached :updated_at))
                     "Cached result should be in the same format as the uncached result, except for added keys"))))))))
   (testing "Cached results don't impact average execution time"
     (let [query                               (assoc (mt/mbql-query venues {:order-by [[:asc $id]] :limit 42})


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/18777

Previously had addressed
https://github.com/metabase/metabase/pull/16720/ because we were
including cache hit query executions in the running query execution
time. IE, queries take 60 seconds to run but the cache hit takes
100ms. Our average thus would be (60s + 100ms)/2 ~ 30 seconds and the
query duration falls below the cache threshold so we abandon the cache
until the average creeps up back up again. Original issue:
https://github.com/metabase/metabase/issues/15432

So the first fix was a poor one and it skipped recording the query
execution at all which was way too heavy handed.

```clojure
(when-not (:cached acc)
  (save-successful-query-execution! (:cached acc) execution-info @row-count))
```

This approach takes the more considered approach: skip updating average
execution time but record the query-execution.

```clojure
;; conditionally save average execution time
(when-not (:cache_hit query-execution)
    (query/save-query-and-update-average-execution-time! query query-hash running-time))

;; unconditionally (modulo having a context) save the query execution
(if-not context
  (log/warn (trs "Cannot save QueryExecution, missing :context"))
  (db/insert! QueryExecution (dissoc query-execution :json_query)))
```
<img width="956" alt="image" src="https://user-images.githubusercontent.com/6377293/172664664-1f330732-19b7-4d4f-8338-ddad803a5f09.png">

One question
------------

I'm unsure about one change here. What are the implications of not
updating this execution time. There are two operations involved:
ensuring there is a `Query` (table query) entry for a query and updating
its average execution time. I'm assuming that since a query is cached it
has a query table entry. But this code creates the Query if it doesn't
exist and then updates its average execution time. It's not clear to me
if we do in fact want to ensure a Query entry exists. But it feels
harmless both in the case it is missing and also that it most likely
isn't missing since we have a cached query and when it was cached this
entry would have been created or updated. But adding a note just in case.
