### PR TITLE
Save query executions for cached queries (#23228)

### DIFF
--- a/test/metabase/query_processor/middleware/cache_test.clj
+++ b/test/metabase/query_processor/middleware/cache_test.clj
@@ -322,37 +322,41 @@
                         :status     :completed}
                        (dissoc cached-result :data))
                     "Results should be cached")
-                ;; remove metadata checksums because they can be different between runs when using an encryption key
-                (is (= (-> original-result
-                           (m/dissoc-in [:data :results_metadata :checksum]))
-                       (-> cached-result
-                           (dissoc :cached :updated_at)
-                           (m/dissoc-in [:data :results_metadata :checksum])))
+                (is (= original-result (dissoc cached-result :cached :updated_at))
                     "Cached result should be in the same format as the uncached result, except for added keys"))))))))
   (testing "Cached results don't impact average execution time"
-    (let [query                         (assoc (mt/mbql-query venues {:order-by [[:asc $id]] :limit 42})
-                                               :cache-ttl 5000)
-          q-hash                        (qputil/query-hash query)
-          call-count                    (atom 0)
-          called-promise                (promise)
-          save-query-execution-original (var-get #'process-userland-query/save-query-execution!*)]
-      (with-redefs [process-userland-query/save-query-execution!* (fn [& args]
-                                                                    (swap! call-count inc)
-                                                                    (apply save-query-execution-original args)
-                                                                    (deliver called-promise true))
-                    cache/min-duration-ms                         (constantly 0)]
+    (let [query                               (assoc (mt/mbql-query venues {:order-by [[:asc $id]] :limit 42})
+                                                     :cache-ttl 5000)
+          q-hash                              (qputil/query-hash query)
+          save-query-execution-count          (atom 0)
+          update-avg-execution-count          (atom 0)
+          called-promise                      (promise)
+          save-query-execution-original       (var-get #'process-userland-query/save-query-execution!*)
+          save-query-update-avg-time-original query/save-query-and-update-average-execution-time!]
+      (with-redefs [process-userland-query/save-query-execution!*       (fn [& args]
+                                                                          (swap! save-query-execution-count inc)
+                                                                          (apply save-query-execution-original args)
+                                                                          (deliver called-promise true))
+                    query/save-query-and-update-average-execution-time! (fn [& args]
+                                                                          (swap! update-avg-execution-count inc)
+                                                                          (apply save-query-update-avg-time-original args))
+                    cache/min-duration-ms                               (constantly 0)]
         (with-mock-cache [save-chan]
           (db/delete! Query :query_hash q-hash)
           (is (not (:cached (qp/process-userland-query query (context.default/default-context)))))
           (a/alts!! [save-chan (a/timeout 200)]) ;; wait-for-result closes the channel
           (u/deref-with-timeout called-promise 500)
-          (is (= 1 @call-count))
+          (is (= 1 @save-query-execution-count))
+          (is (= 1 @update-avg-execution-count))
           (let [avg-execution-time (query/average-execution-time-ms q-hash)]
             (is (number? avg-execution-time))
             ;; rerun query getting cached results
             (is (:cached (qp/process-userland-query query (context.default/default-context))))
             (mt/wait-for-result save-chan)
-            (is (= 1 @call-count) "Saving execution times of a cache lookup")
+            (is (= 2 @save-query-execution-count)
+                "Saving execution times of a cache lookup")
+            (is (= 1 @update-avg-execution-count)
+                "Cached query execution should not update average query duration")
             (is (= avg-execution-time (query/average-execution-time-ms q-hash)))))))))
 
 (deftest insights-from-cache-test


### PR DESCRIPTION
Manual backport of https://github.com/metabase/metabase/pull/23228 because of qputil -> qp.util ns alias change.

* Save query executions for cached queries

Previously had addressed
https://github.com/metabase/metabase/pull/16720/ because we were
including cache hit query executions in the running query execution
time. IE, queries take 60 seconds to run but the cache hit takes
100ms. Our average thus would be (60s + 100ms)/2 ~ 30 seconds and the
query duration falls below the cache threshold so we abandon the cache
until the average creeps up back up again. Original issue:
https://github.com/metabase/metabase/issues/15432

So the first fix was a poor one and it skipped recording the query
execution at all which was way too heavy handed.

```clojure
(when-not (:cached acc)
  (save-successful-query-execution! (:cached acc) execution-info @row-count))
```

This approach takes the more considered approach: skip updating average
execution time but record the query-execution.

```clojure
;; conditionally save average execution time
(when-not (:cache_hit query-execution)
    (query/save-query-and-update-average-execution-time! query query-hash running-time))

;; unconditionally (modulo having a context) save the query execution
(if-not context
  (log/warn (trs "Cannot save QueryExecution, missing :context"))
  (db/insert! QueryExecution (dissoc query-execution :json_query)))
```

One question
------------

I'm unsure about one change here. What are the implications of not
updating this execution time. There are two operations involved:
ensuring there is a `Query` (table query) entry for a query and updating
its average execution time. I'm assuming that since a query is cached it
has a query table entry. But this code creates the Query if it doesn't
exist and then updates its average execution time. It's not clear to me
if we do in fact want to ensure a Query entry exists. But it feels
harmless both in the case it is missing and also that it most likely
isn't missing since we have a cached query and when it was cached this
entry would have been created or updated. But adding a note just in case.

* Fix test

distinguish between the calls to save query execution and the calls to
update average execution duration. The former should be called
twice (for the uncached query and the cached query run) while the latter
should only be called on the first run (aka, uncached results affect
query duration stats, cached runs do not affect it)

* Checksums are no more

metadata became editable for models and the checksum really didn't add any value, just asserted that it had not been
changed.

###### Before submitting the PR, please make sure you do the following

- [ ] If you're attempting to fix a translation issue, please submit your changes to our [POEditor project](https://poeditor.com/join/project/ynjQmwSsGh) instead of opening a PR.

### Tests

- [ ] Run the frontend and Cypress end-to-end tests with `yarn lint && yarn test`)
- [ ] If there are changes to the backend codebase, run the backend tests with `clojure -X:dev:test`
- [ ] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
      (unless it's a tiny documentation change).
