### PR TITLE
Slider Component Performance Improvements

### DIFF
--- a/frontend/src/metabase/core/components/Slider/Slider.stories.tsx
+++ b/frontend/src/metabase/core/components/Slider/Slider.stories.tsx
@@ -8,8 +8,12 @@ export default {
 };
 
 const Template: ComponentStory<typeof Slider> = args => {
-  const [value, setValue] = useState([10, 40]);
-  return <Slider {...args} value={value} onChange={setValue} />;
+  const [value, setValue] = useState<(number | undefined)[]>([10, 40]);
+  return (
+    <div className="pt4">
+      <Slider {...args} value={value} onChange={setValue} />
+    </div>
+  );
 };
 
 export const Default = Template.bind({});

--- a/frontend/src/metabase/core/components/Slider/Slider.stories.tsx
+++ b/frontend/src/metabase/core/components/Slider/Slider.stories.tsx
@@ -5,13 +5,14 @@ import Slider from "./Slider";
 export default {
   title: "Core/Slider",
   component: Slider,
+  argTypes: { onChange: { action: "onChange" } },
 };
 
 const Template: ComponentStory<typeof Slider> = args => {
-  const [value, setValue] = useState<(number | undefined)[]>([10, 40]);
+  const [value] = useState<(number | undefined)[]>([0, 100]);
   return (
     <div className="pt4">
-      <Slider {...args} value={value} onChange={setValue} />
+      <Slider {...args} value={value} onChange={args.onChange} />
     </div>
   );
 };

--- a/frontend/src/metabase/core/components/Slider/Slider.stories.tsx
+++ b/frontend/src/metabase/core/components/Slider/Slider.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import { ComponentStory } from "@storybook/react";
 import Slider from "./Slider";
 
@@ -9,7 +9,7 @@ export default {
 };
 
 const Template: ComponentStory<typeof Slider> = args => {
-  const [value] = useState<(number | undefined)[]>([0, 100]);
+  const value = [10, 40];
   return (
     <div className="pt4">
       <Slider {...args} value={value} onChange={args.onChange} />

--- a/frontend/src/metabase/core/components/Slider/Slider.styled.tsx
+++ b/frontend/src/metabase/core/components/Slider/Slider.styled.tsx
@@ -1,9 +1,12 @@
 import styled from "@emotion/styled";
 import { color, alpha } from "metabase/lib/colors";
+import { space } from "metabase/styled-components/theme";
 
 export const SliderContainer = styled.div`
   position: relative;
   display: flex;
+  width: 100%;
+  margin: 0 ${space(1)};
 `;
 
 const thumbStyles = `
@@ -45,15 +48,38 @@ export const SliderTrack = styled.span`
   border-radius: 0.2rem;
 `;
 
-interface ActiveTrackProps {
-  left: number;
-  width: number;
-}
-
-export const ActiveTrack = styled.span<ActiveTrackProps>`
+export const ActiveTrack = styled.span`
   position: absolute;
-  left: ${props => props.left}%;
-  width: ${props => props.width}%;
   background-color: ${color("brand")};
   height: 0.2rem;
+`;
+
+export const SliderTooltip = styled.div`
+  position: absolute;
+  top: -3rem;
+  transform: translateX(-50%);
+  font-size: 0.7rem;
+  font-weight: bold;
+  text-align: center;
+  padding: ${space(0.5)} ${space(1)};
+  background: ${color("black")};
+  color: ${color("white")};
+  display: block;
+  border-radius: ${space(1)};
+  opacity: 0;
+  transition: opacity 0.2s ease-in-out;
+
+  &:before {
+    content: "";
+    position: absolute;
+    width: 0;
+    height: 0;
+    border-top: 10px solid ${color("black")};
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+    top: 100%;
+    left: 50%;
+    margin-left: -5px;
+    margin-top: -1px;
+  }
 `;

--- a/frontend/src/metabase/core/components/Slider/Slider.styled.tsx
+++ b/frontend/src/metabase/core/components/Slider/Slider.styled.tsx
@@ -2,19 +2,22 @@ import styled from "@emotion/styled";
 import { color, alpha } from "metabase/lib/colors";
 import { space } from "metabase/styled-components/theme";
 
+export const THUMB_SIZE = "1.2rem";
+
 export const SliderContainer = styled.div`
   position: relative;
   display: flex;
   width: 100%;
-  margin: 0 ${space(1)};
+  margin-right: calc(${THUMB_SIZE} / 2);
 `;
 
 const thumbStyles = `
   -webkit-appearance: none;
-  width: 1.2rem;
-  height: 1.2rem;
+  width: ${THUMB_SIZE};
+  height: ${THUMB_SIZE};
   border-radius: 50%;
   border: 2px solid ${color("brand")};
+  box-sizing: border-box;
   background-color: ${color("white")};
   cursor: pointer;
   box-shadow: 0 0 2px 1px ${color("brand")};
@@ -42,7 +45,8 @@ export const SliderInput = styled.input`
 `;
 
 export const SliderTrack = styled.span`
-  width: 100%;
+  width: calc(100% - ${THUMB_SIZE});
+  margin-left: calc(${THUMB_SIZE} / 2);
   background-color: ${alpha("brand", 0.5)};
   height: 0.2rem;
   border-radius: 0.2rem;
@@ -82,4 +86,8 @@ export const SliderTooltip = styled.div`
     margin-left: -5px;
     margin-top: -1px;
   }
+`;
+export const TooltipContainer = styled.div`
+  position: absolute;
+  width: calc(100% - ${THUMB_SIZE});
 `;

--- a/frontend/src/metabase/core/components/Slider/Slider.styled.tsx
+++ b/frontend/src/metabase/core/components/Slider/Slider.styled.tsx
@@ -4,6 +4,8 @@ import { space } from "metabase/styled-components/theme";
 
 export const THUMB_SIZE = "1.2rem";
 
+const activeThumbStyle = `box-shadow: 0 0 4px 1px ${color("brand")}`;
+
 export const SliderContainer = styled.div`
   position: relative;
   display: flex;
@@ -23,7 +25,7 @@ const thumbStyles = `
   box-shadow: 0 0 2px 1px ${color("brand")};
   pointer-events: all;
   &:active {
-    box-shadow: 0 0 4px 1px ${color("brand")};
+    ${activeThumbStyle}
   }
 `;
 
@@ -41,6 +43,14 @@ export const SliderInput = styled.input`
   }
   &::-moz-range-thumb {
     ${thumbStyles}
+  }
+  &:focus {
+    &::-webkit-slider-thumb {
+      ${activeThumbStyle}
+    }
+    &::-moz-range-thumb {
+      ${activeThumbStyle}
+    }
   }
 `;
 

--- a/frontend/src/metabase/core/components/Slider/Slider.tsx
+++ b/frontend/src/metabase/core/components/Slider/Slider.tsx
@@ -3,11 +3,15 @@ import React, {
   InputHTMLAttributes,
   useCallback,
   useMemo,
+  useState,
+  useEffect,
 } from "react";
+import _ from "underscore";
 
 import {
   SliderContainer,
   SliderInput,
+  SliderTooltip,
   SliderTrack,
   ActiveTrack,
 } from "./Slider.styled";
@@ -18,76 +22,121 @@ export type NumericInputAttributes = Omit<
 >;
 
 export interface SliderProps extends NumericInputAttributes {
-  value: number[];
-  onChange: (value: number[]) => void;
+  value: (number | undefined)[];
+  onChange: (value: (number | undefined)[]) => void;
   min?: number;
   max?: number;
   step?: number;
 }
 
 const Slider = ({
-  value,
+  value: parentValue,
   onChange,
-  min = 0,
-  max = 100,
+  min: parentMin = 0,
+  max: parentMax = 100,
   step = 1,
 }: SliderProps) => {
-  const [rangeMin, rangeMax] = useMemo(
-    () => [Math.min(...value, min, max), Math.max(...value, min, max)],
-    [value, min, max],
-  );
+  const [isHovering, setIsHovering] = useState(false);
+  const [value, setValue] = useState([
+    parentValue[0] ?? parentMin,
+    parentValue[1] ?? parentMax,
+  ]);
+
+  // potentially expand the input range to include out-of-range values
+  const [min, max] = useMemo(() => {
+    return [_.min([...value, parentMin]), _.max([...value, parentMax])];
+  }, [value, parentMin, parentMax]);
+
+  useEffect(() => {
+    setValue([parentValue[0] ?? min, parentValue[1] ?? max]);
+  }, [parentValue, min, max]);
 
   const [beforeRange, rangeWidth] = useMemo(() => {
-    const totalRange = rangeMax - rangeMin;
-
+    const totalRange = max - min;
     return [
-      ((Math.min(...value) - rangeMin) / totalRange) * 100,
+      ((Math.min(...value) - min) / totalRange) * 100,
       (Math.abs(value[1] - value[0]) / totalRange) * 100,
     ];
-  }, [value, rangeMin, rangeMax]);
+  }, [value, min, max]);
 
-  const handleChange = useCallback(
+  const handleInput = useCallback(
     (event: ChangeEvent<HTMLInputElement>, valueIndex: number) => {
       const changedValue = [...value];
       changedValue[valueIndex] = Number(event.target.value);
-      onChange(changedValue);
+      setValue(changedValue);
     },
-    [value, onChange],
+    [value, setValue],
   );
 
-  const sortValues = useCallback(() => {
-    if (value[0] > value[1]) {
-      const sortedValues = [...value].sort();
-      onChange(sortedValues);
-    }
+  const handleChange = useCallback(() => {
+    const sortedValues = value[1] < value[0] ? [...value].sort() : value;
+    onChange(sortedValues);
   }, [value, onChange]);
 
+  const [minValue, maxValue] = useMemo(
+    () =>
+      value.every(n => !isNaN(n))
+        ? [Math.min(...value), Math.max(...value)]
+        : value,
+    [value],
+  );
+
   return (
-    <SliderContainer>
+    <SliderContainer
+      onMouseEnter={() => setIsHovering(true)}
+      onMouseLeave={() => setIsHovering(false)}
+    >
       <SliderTrack />
-      <ActiveTrack left={beforeRange} width={rangeWidth} />
+      <ActiveTrack
+        style={{ left: `${beforeRange}%`, width: `${rangeWidth}%` }}
+      />
+      <SliderTooltip
+        data-testid="min-slider-tooltip"
+        style={{
+          left: getTooltipPosition(beforeRange),
+          opacity: isHovering ? 1 : 0,
+        }}
+      >
+        {hasDecimal(step) ? minValue.toFixed(2) : minValue}
+      </SliderTooltip>
       <SliderInput
         type="range"
         aria-label="min"
         value={value[0]}
-        onChange={e => handleChange(e, 0)}
-        onMouseUp={sortValues}
-        min={rangeMin}
-        max={rangeMax}
+        onChange={e => handleInput(e, 0)}
+        onMouseUp={handleChange}
+        onKeyUp={handleChange}
+        min={min}
+        max={max}
         step={step}
       />
+      <SliderTooltip
+        data-testid="max-slider-tooltip"
+        style={{
+          left: getTooltipPosition(beforeRange + rangeWidth),
+          opacity: isHovering ? 1 : 0,
+        }}
+      >
+        {hasDecimal(step) ? maxValue.toFixed(2) : maxValue}
+      </SliderTooltip>
       <SliderInput
         type="range"
         aria-label="max"
         value={value[1]}
-        onChange={e => handleChange(e, 1)}
-        onMouseUp={sortValues}
-        min={rangeMin}
-        max={rangeMax}
+        onChange={e => handleInput(e, 1)}
+        onMouseUp={handleChange}
+        onKeyUp={handleChange}
+        min={min}
+        max={max}
         step={step}
       />
     </SliderContainer>
   );
 };
+
+const getTooltipPosition = (basePosition: number) =>
+  `calc(${basePosition}% + ${11 - basePosition * 0.18}px)`;
+
+const hasDecimal = (value: number) => !isNaN(value) && value % 1 !== 0;
 
 export default Slider;

--- a/frontend/src/metabase/core/components/Slider/Slider.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/Slider/Slider.unit.spec.tsx
@@ -23,21 +23,42 @@ describe("Slider", () => {
     expect(minInput).toHaveAttribute("max", "412");
   });
 
-  it("should call onChange with the new value on input change", () => {
+  it("should call onChange with the new value on mouseUp", () => {
     const spy = jest.fn();
     render(<Slider value={[10, 20]} onChange={spy} min={0} max={100} />);
 
     const minInput = screen.getByLabelText("min");
     const maxInput = screen.getByLabelText("max");
 
-    // would be nice to use userEvent when we upgrade to v14 so we mock drage events
+    // would be nice to use userEvent when we upgrade to v14 so we can mock drag events
     fireEvent.change(minInput, { target: { value: "5" } });
+    fireEvent.mouseUp(minInput);
     fireEvent.change(maxInput, { target: { value: "15" } });
+    fireEvent.mouseUp(maxInput);
 
     const [firstCall, secondCall] = spy.mock.calls;
 
     expect(firstCall[0]).toEqual([5, 20]);
-    expect(secondCall[0]).toEqual([10, 15]);
+    expect(secondCall[0]).toEqual([5, 15]);
+  });
+
+  // handling input via arrow keys
+  it("should call onChange with the new value on keyup", () => {
+    const spy = jest.fn();
+    render(<Slider value={[10, 20]} onChange={spy} min={0} max={100} />);
+
+    const minInput = screen.getByLabelText("min");
+    const maxInput = screen.getByLabelText("max");
+
+    fireEvent.change(minInput, { target: { value: "5" } });
+    fireEvent.keyUp(minInput);
+    fireEvent.change(maxInput, { target: { value: "15" } });
+    fireEvent.keyUp(maxInput);
+
+    const [firstCall, secondCall] = spy.mock.calls;
+
+    expect(firstCall[0]).toEqual([5, 20]);
+    expect(secondCall[0]).toEqual([5, 15]);
   });
 
   it("should sort input values on mouse up", () => {
@@ -48,5 +69,34 @@ describe("Slider", () => {
 
     fireEvent.mouseUp(minInput);
     expect(spy.mock.calls[0][0]).toEqual([1, 2]);
+  });
+
+  it("should show tooltips on mouseOver", () => {
+    render(<Slider value={[10, 40]} onChange={() => null} min={0} max={100} />);
+
+    const minInput = screen.getByLabelText("min");
+    const minTooltip = screen.getByTestId("min-slider-tooltip");
+    const maxTooltip = screen.getByTestId("max-slider-tooltip");
+
+    expect(minTooltip).toHaveStyle("opacity: 0");
+    expect(maxTooltip).toHaveStyle("opacity: 0");
+    fireEvent.mouseOver(minInput);
+    expect(minTooltip).toHaveStyle("opacity: 1");
+    expect(maxTooltip).toHaveStyle("opacity: 1");
+  });
+
+  it("should hide tooltips on mouseLeave", () => {
+    render(<Slider value={[10, 40]} onChange={() => null} min={0} max={100} />);
+
+    const minInput = screen.getByLabelText("min");
+    const minTooltip = screen.getByTestId("min-slider-tooltip");
+    const maxTooltip = screen.getByTestId("max-slider-tooltip");
+
+    fireEvent.mouseEnter(minInput);
+    expect(minTooltip).toHaveStyle("opacity: 1");
+    expect(maxTooltip).toHaveStyle("opacity: 1");
+    fireEvent.mouseLeave(minInput);
+    expect(minTooltip).toHaveStyle("opacity: 0");
+    expect(maxTooltip).toHaveStyle("opacity: 0");
   });
 });


### PR DESCRIPTION
This updates the slider component to improve performance by only calling its `onChange` handler on `mouseUp` or `keyUp` events.  This prevents multiple state changes per second from bubbling out of this component.

To improve UI and give instant feedback while dragging, this also adds onHover tooltips to both sliders.


https://user-images.githubusercontent.com/30528226/172706961-845be2c6-9c5d-4edb-a7e3-964e804be4a0.mp4

You can view this "Slider" component using `yarn storybook`