### PR TITLE
fix custom url click behavior with the same dashboard url

### DIFF
--- a/frontend/src/metabase/lib/dom.js
+++ b/frontend/src/metabase/lib/dom.js
@@ -246,6 +246,11 @@ export function constrainToScreen(element, direction, padding) {
   return false;
 }
 
+function getWithSiteUrl(url) {
+  const siteUrl = MetabaseSettings.get("site-url");
+  return url.startsWith("/") ? siteUrl + url : url;
+}
+
 // Used for tackling Safari rendering issues
 // http://stackoverflow.com/a/3485654
 export function forceRedraw(domNode) {
@@ -290,9 +295,12 @@ export function open(
     openInSameWindow = url => clickLink(url, false),
     // custom function for opening in new window
     openInBlankWindow = url => clickLink(url, true),
+    ignoreSiteUrl = false,
     ...options
   } = {},
 ) {
+  url = ignoreSiteUrl ? url : getWithSiteUrl(url);
+
   if (shouldOpenInBlankWindow(url, options)) {
     openInBlankWindow(url);
   } else {
@@ -301,8 +309,7 @@ export function open(
 }
 
 export function openInBlankWindow(url) {
-  const siteUrl = MetabaseSettings.get("site-url");
-  clickLink(url.startsWith("/") ? siteUrl + url : url, true);
+  clickLink(getWithSiteUrl(url), true);
 }
 
 function clickLink(url, blank = false) {

--- a/frontend/src/metabase/lib/urls/questions.ts
+++ b/frontend/src/metabase/lib/urls/questions.ts
@@ -111,9 +111,18 @@ export function dataset(...args: Parameters<typeof question>) {
   return question(...args);
 }
 
-export function publicQuestion(uuid: string, type: string | null = null) {
+export function publicQuestion(
+  uuid: string,
+  type: string | null = null,
+  query?: string,
+) {
   const siteUrl = MetabaseSettings.get("site-url");
-  return `${siteUrl}/public/question/${uuid}` + (type ? `.${type}` : ``);
+  const searchQuery = query ? `?${query}` : "";
+  return (
+    `${siteUrl}/public/question/${uuid}` +
+    (type ? `.${type}` : "") +
+    searchQuery
+  );
 }
 
 export function embedCard(token: string, type: string | null = null) {

--- a/frontend/src/metabase/modes/components/drill/DashboardClickDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/DashboardClickDrill.jsx
@@ -14,6 +14,7 @@ import {
   formatSourceForTarget,
 } from "metabase/lib/click-behavior";
 import { renderLinkURLForClick } from "metabase/lib/formatting/link";
+import * as Urls from "metabase/lib/urls";
 
 export default ({ question, clicked }) => {
   const settings = (clicked && clicked.settings) || {};
@@ -53,6 +54,7 @@ export default ({ question, clicked }) => {
   } else if (type === "link") {
     if (linkType === "url") {
       behavior = {
+        ignoreSiteUrl: true,
         url: () =>
           renderLinkURLForClick(clickBehavior.linkTemplate || "", data),
       };
@@ -81,8 +83,8 @@ export default ({ question, clicked }) => {
 
         const path =
           clickBehavior.use_public_link && targetDashboard.public_uuid
-            ? `/public/dashboard/${targetDashboard.public_uuid}`
-            : `/dashboard/${targetId}`;
+            ? Urls.publicDashboard(targetDashboard.public_uuid)
+            : Urls.dashboard({ id: targetId });
         const url = `${path}?${querystring.stringify(queryParams)}`;
 
         behavior = { url: () => url };
@@ -111,9 +113,11 @@ export default ({ question, clicked }) => {
 
       let url = null;
       if (clickBehavior.use_public_link && targetQuestion.publicUUID()) {
-        url = `/public/question/${targetQuestion.publicUUID()}?${querystring.stringify(
-          queryParams,
-        )}`;
+        url = Urls.publicQuestion(
+          targetQuestion.publicUUID(),
+          null,
+          querystring.stringify(queryParams),
+        );
       } else {
         url = targetQuestion.isStructured()
           ? targetQuestion.getUrlWithParameters(parameters, queryParams)

--- a/frontend/src/metabase/visualizations/lib/action.js
+++ b/frontend/src/metabase/visualizations/lib/action.js
@@ -1,7 +1,6 @@
-/* eslint-disable react/prop-types */
 import _ from "underscore";
 
-import { openUrl } from "metabase/redux/app";
+import { open } from "metabase/lib/dom";
 
 export function performAction(action, { dispatch, onChangeCardAndRun }) {
   let didPerform = false;
@@ -14,8 +13,9 @@ export function performAction(action, { dispatch, onChangeCardAndRun }) {
   }
   if (action.url) {
     const url = action.url();
+    const ignoreSiteUrl = action.ignoreSiteUrl;
     if (url) {
-      dispatch(openUrl(url));
+      open(url, { ignoreSiteUrl });
       didPerform = true;
     }
   }

--- a/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
@@ -242,6 +242,37 @@ describe("scenarios > dashboard > dashboard drill", () => {
       });
   });
 
+  it("should open the same dashboard when a custom URL click behavior points to the same dashboard (metabase#22702)", () => {
+    createDashboardWithQuestion({}, dashboardId => visitDashboard(dashboardId));
+    cy.icon("pencil").click();
+    showDashboardCardActions();
+    cy.icon("click").click();
+
+    cy.findByText("On-click behavior for each column")
+      .parent()
+      .parent()
+      .within(() => cy.findByText("MY_NUMBER").click());
+    cy.findByText("Go to a custom destination").click();
+    cy.findByText("URL").click();
+
+    modal().within(() => {
+      cy.get("input")
+        .first()
+        .type("/dashboard/2?my_param=Aaron Hand");
+      cy.get("input")
+        .last()
+        .type("Click behavior");
+      cy.findByText("Done").click();
+    });
+
+    cy.findByText("Save").click();
+
+    cy.findByText("Click behavior").click();
+
+    cy.location("pathname").should("eq", "/dashboard/2");
+    cy.location("search").should("eq", "?my_param=Aaron%20Hand");
+  });
+
   // This was flaking. Example: https://dashboard.cypress.io/projects/a394u1/runs/2109/test-results/91a15b66-4b80-40bf-b569-de28abe21f42
   it.skip("should handle cross-filter on a table", () => {
     createDashboardWithQuestion({}, dashboardId => visitDashboard(dashboardId));


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/22702

## Changes
Fixes when a click behavior custom url points to the same dashboard but adds some parameter values, clicking on a visualization did not change the url.

## How to verify

#### Custom URL click behavior to the same dashboard
- Create a new dashboard (D1) or open an existing one.
- Add a question to it (Q1).
- Add a filter (F1) and connect it to Q1.
- Set a custom URL click behavior for Q1 which links to D1 and alter the some filters like F1.
- Ensure click behavior correctly reloads the dashboard with the filter changes
