### PR TITLE
🧊 Slider Number Filters

### DIFF
--- a/frontend/src/metabase/core/components/Slider/Slider.stories.tsx
+++ b/frontend/src/metabase/core/components/Slider/Slider.stories.tsx
@@ -8,8 +8,12 @@ export default {
 };
 
 const Template: ComponentStory<typeof Slider> = args => {
-  const [value, setValue] = useState([10, 40]);
-  return <Slider {...args} value={value} onChange={setValue} />;
+  const [value, setValue] = useState<(number | undefined)[]>([10, 40]);
+  return (
+    <div className="pt4">
+      <Slider {...args} value={value} onChange={setValue} />
+    </div>
+  );
 };
 
 export const Default = Template.bind({});

--- a/frontend/src/metabase/core/components/Slider/Slider.styled.tsx
+++ b/frontend/src/metabase/core/components/Slider/Slider.styled.tsx
@@ -1,9 +1,12 @@
 import styled from "@emotion/styled";
 import { color, alpha } from "metabase/lib/colors";
+import { space } from "metabase/styled-components/theme";
 
 export const SliderContainer = styled.div`
   position: relative;
   display: flex;
+  width: 100%;
+  margin: 0 ${space(1)};
 `;
 
 const thumbStyles = `
@@ -45,15 +48,38 @@ export const SliderTrack = styled.span`
   border-radius: 0.2rem;
 `;
 
-interface ActiveTrackProps {
-  left: number;
-  width: number;
-}
-
-export const ActiveTrack = styled.span<ActiveTrackProps>`
+export const ActiveTrack = styled.span`
   position: absolute;
-  left: ${props => props.left}%;
-  width: ${props => props.width}%;
   background-color: ${color("brand")};
   height: 0.2rem;
+`;
+
+export const SliderTooltip = styled.div`
+  position: absolute;
+  top: -3rem;
+  transform: translateX(-50%);
+  font-size: 0.7rem;
+  font-weight: bold;
+  text-align: center;
+  padding: ${space(0.5)} ${space(1)};
+  background: ${color("black")};
+  color: ${color("white")};
+  display: block;
+  border-radius: ${space(1)};
+  opacity: 0;
+  transition: opacity 0.2s ease-in-out;
+
+  &:before {
+    content: "";
+    position: absolute;
+    width: 0;
+    height: 0;
+    border-top: 10px solid ${color("black")};
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+    top: 100%;
+    left: 50%;
+    margin-left: -5px;
+    margin-top: -1px;
+  }
 `;

--- a/frontend/src/metabase/core/components/Slider/Slider.tsx
+++ b/frontend/src/metabase/core/components/Slider/Slider.tsx
@@ -27,6 +27,7 @@ export interface SliderProps extends NumericInputAttributes {
   min?: number;
   max?: number;
   step?: number;
+  showMinMaxTooltips?: boolean;
 }
 
 const Slider = ({
@@ -35,6 +36,7 @@ const Slider = ({
   min: parentMin = 0,
   max: parentMax = 100,
   step = 1,
+  showMinMaxTooltips = true,
 }: SliderProps) => {
   const [isHovering, setIsHovering] = useState(false);
   const [value, setValue] = useState([
@@ -46,6 +48,14 @@ const Slider = ({
   const [min, max] = useMemo(() => {
     return [_.min([...value, parentMin]), _.max([...value, parentMax])];
   }, [value, parentMin, parentMax]);
+
+  const [showMinTooltip, showMaxTooltip] = useMemo(() => {
+    if (showMinMaxTooltips) {
+      return [true, true];
+    }
+
+    return [value[0] !== min, value[1] !== max];
+  }, [showMinMaxTooltips, value, min, max]);
 
   useEffect(() => {
     setValue([parentValue[0] ?? min, parentValue[1] ?? max]);
@@ -94,7 +104,7 @@ const Slider = ({
         data-testid="min-slider-tooltip"
         style={{
           left: getTooltipPosition(beforeRange),
-          opacity: isHovering ? 1 : 0,
+          opacity: showMinTooltip && isHovering ? 1 : 0,
         }}
       >
         {hasDecimal(step) ? minValue.toFixed(2) : minValue}
@@ -114,7 +124,7 @@ const Slider = ({
         data-testid="max-slider-tooltip"
         style={{
           left: getTooltipPosition(beforeRange + rangeWidth),
-          opacity: isHovering ? 1 : 0,
+          opacity: showMaxTooltip && isHovering ? 1 : 0,
         }}
       >
         {hasDecimal(step) ? maxValue.toFixed(2) : maxValue}

--- a/frontend/src/metabase/core/components/Slider/Slider.tsx
+++ b/frontend/src/metabase/core/components/Slider/Slider.tsx
@@ -3,11 +3,15 @@ import React, {
   InputHTMLAttributes,
   useCallback,
   useMemo,
+  useState,
+  useEffect,
 } from "react";
+import _ from "underscore";
 
 import {
   SliderContainer,
   SliderInput,
+  SliderTooltip,
   SliderTrack,
   ActiveTrack,
 } from "./Slider.styled";
@@ -18,76 +22,121 @@ export type NumericInputAttributes = Omit<
 >;
 
 export interface SliderProps extends NumericInputAttributes {
-  value: number[];
-  onChange: (value: number[]) => void;
+  value: (number | undefined)[];
+  onChange: (value: (number | undefined)[]) => void;
   min?: number;
   max?: number;
   step?: number;
 }
 
 const Slider = ({
-  value,
+  value: parentValue,
   onChange,
-  min = 0,
-  max = 100,
+  min: parentMin = 0,
+  max: parentMax = 100,
   step = 1,
 }: SliderProps) => {
-  const [rangeMin, rangeMax] = useMemo(
-    () => [Math.min(...value, min, max), Math.max(...value, min, max)],
-    [value, min, max],
-  );
+  const [isHovering, setIsHovering] = useState(false);
+  const [value, setValue] = useState([
+    parentValue[0] ?? parentMin,
+    parentValue[1] ?? parentMax,
+  ]);
+
+  // potentially expand the input range to include out-of-range values
+  const [min, max] = useMemo(() => {
+    return [_.min([...value, parentMin]), _.max([...value, parentMax])];
+  }, [value, parentMin, parentMax]);
+
+  useEffect(() => {
+    setValue([parentValue[0] ?? min, parentValue[1] ?? max]);
+  }, [parentValue, min, max]);
 
   const [beforeRange, rangeWidth] = useMemo(() => {
-    const totalRange = rangeMax - rangeMin;
-
+    const totalRange = max - min;
     return [
-      ((Math.min(...value) - rangeMin) / totalRange) * 100,
+      ((Math.min(...value) - min) / totalRange) * 100,
       (Math.abs(value[1] - value[0]) / totalRange) * 100,
     ];
-  }, [value, rangeMin, rangeMax]);
+  }, [value, min, max]);
 
-  const handleChange = useCallback(
+  const handleInput = useCallback(
     (event: ChangeEvent<HTMLInputElement>, valueIndex: number) => {
       const changedValue = [...value];
       changedValue[valueIndex] = Number(event.target.value);
-      onChange(changedValue);
+      setValue(changedValue);
     },
-    [value, onChange],
+    [value, setValue],
   );
 
-  const sortValues = useCallback(() => {
-    if (value[0] > value[1]) {
-      const sortedValues = [...value].sort();
-      onChange(sortedValues);
-    }
+  const handleChange = useCallback(() => {
+    const sortedValues = value[1] < value[0] ? [...value].sort() : value;
+    onChange(sortedValues);
   }, [value, onChange]);
 
+  const [minValue, maxValue] = useMemo(
+    () =>
+      value.every(n => !isNaN(n))
+        ? [Math.min(...value), Math.max(...value)]
+        : value,
+    [value],
+  );
+
   return (
-    <SliderContainer>
+    <SliderContainer
+      onMouseEnter={() => setIsHovering(true)}
+      onMouseLeave={() => setIsHovering(false)}
+    >
       <SliderTrack />
-      <ActiveTrack left={beforeRange} width={rangeWidth} />
+      <ActiveTrack
+        style={{ left: `${beforeRange}%`, width: `${rangeWidth}%` }}
+      />
+      <SliderTooltip
+        data-testid="min-slider-tooltip"
+        style={{
+          left: getTooltipPosition(beforeRange),
+          opacity: isHovering ? 1 : 0,
+        }}
+      >
+        {hasDecimal(step) ? minValue.toFixed(2) : minValue}
+      </SliderTooltip>
       <SliderInput
         type="range"
         aria-label="min"
         value={value[0]}
-        onChange={e => handleChange(e, 0)}
-        onMouseUp={sortValues}
-        min={rangeMin}
-        max={rangeMax}
+        onChange={e => handleInput(e, 0)}
+        onMouseUp={handleChange}
+        onKeyUp={handleChange}
+        min={min}
+        max={max}
         step={step}
       />
+      <SliderTooltip
+        data-testid="max-slider-tooltip"
+        style={{
+          left: getTooltipPosition(beforeRange + rangeWidth),
+          opacity: isHovering ? 1 : 0,
+        }}
+      >
+        {hasDecimal(step) ? maxValue.toFixed(2) : maxValue}
+      </SliderTooltip>
       <SliderInput
         type="range"
         aria-label="max"
         value={value[1]}
-        onChange={e => handleChange(e, 1)}
-        onMouseUp={sortValues}
-        min={rangeMin}
-        max={rangeMax}
+        onChange={e => handleInput(e, 1)}
+        onMouseUp={handleChange}
+        onKeyUp={handleChange}
+        min={min}
+        max={max}
         step={step}
       />
     </SliderContainer>
   );
 };
+
+const getTooltipPosition = (basePosition: number) =>
+  `calc(${basePosition}% + ${11 - basePosition * 0.18}px)`;
+
+const hasDecimal = (value: number) => !isNaN(value) && value % 1 !== 0;
 
 export default Slider;

--- a/frontend/src/metabase/core/components/Slider/Slider.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/Slider/Slider.unit.spec.tsx
@@ -23,21 +23,42 @@ describe("Slider", () => {
     expect(minInput).toHaveAttribute("max", "412");
   });
 
-  it("should call onChange with the new value on input change", () => {
+  it("should call onChange with the new value on mouseUp", () => {
     const spy = jest.fn();
     render(<Slider value={[10, 20]} onChange={spy} min={0} max={100} />);
 
     const minInput = screen.getByLabelText("min");
     const maxInput = screen.getByLabelText("max");
 
-    // would be nice to use userEvent when we upgrade to v14 so we mock drage events
+    // would be nice to use userEvent when we upgrade to v14 so we can mock drag events
     fireEvent.change(minInput, { target: { value: "5" } });
+    fireEvent.mouseUp(minInput);
     fireEvent.change(maxInput, { target: { value: "15" } });
+    fireEvent.mouseUp(maxInput);
 
     const [firstCall, secondCall] = spy.mock.calls;
 
     expect(firstCall[0]).toEqual([5, 20]);
-    expect(secondCall[0]).toEqual([10, 15]);
+    expect(secondCall[0]).toEqual([5, 15]);
+  });
+
+  // handling input via arrow keys
+  it("should call onChange with the new value on keyup", () => {
+    const spy = jest.fn();
+    render(<Slider value={[10, 20]} onChange={spy} min={0} max={100} />);
+
+    const minInput = screen.getByLabelText("min");
+    const maxInput = screen.getByLabelText("max");
+
+    fireEvent.change(minInput, { target: { value: "5" } });
+    fireEvent.keyUp(minInput);
+    fireEvent.change(maxInput, { target: { value: "15" } });
+    fireEvent.keyUp(maxInput);
+
+    const [firstCall, secondCall] = spy.mock.calls;
+
+    expect(firstCall[0]).toEqual([5, 20]);
+    expect(secondCall[0]).toEqual([5, 15]);
   });
 
   it("should sort input values on mouse up", () => {
@@ -48,5 +69,34 @@ describe("Slider", () => {
 
     fireEvent.mouseUp(minInput);
     expect(spy.mock.calls[0][0]).toEqual([1, 2]);
+  });
+
+  it("should show tooltips on mouseOver", () => {
+    render(<Slider value={[10, 40]} onChange={() => null} min={0} max={100} />);
+
+    const minInput = screen.getByLabelText("min");
+    const minTooltip = screen.getByTestId("min-slider-tooltip");
+    const maxTooltip = screen.getByTestId("max-slider-tooltip");
+
+    expect(minTooltip).toHaveStyle("opacity: 0");
+    expect(maxTooltip).toHaveStyle("opacity: 0");
+    fireEvent.mouseOver(minInput);
+    expect(minTooltip).toHaveStyle("opacity: 1");
+    expect(maxTooltip).toHaveStyle("opacity: 1");
+  });
+
+  it("should hide tooltips on mouseLeave", () => {
+    render(<Slider value={[10, 40]} onChange={() => null} min={0} max={100} />);
+
+    const minInput = screen.getByLabelText("min");
+    const minTooltip = screen.getByTestId("min-slider-tooltip");
+    const maxTooltip = screen.getByTestId("max-slider-tooltip");
+
+    fireEvent.mouseEnter(minInput);
+    expect(minTooltip).toHaveStyle("opacity: 1");
+    expect(maxTooltip).toHaveStyle("opacity: 1");
+    fireEvent.mouseLeave(minInput);
+    expect(minTooltip).toHaveStyle("opacity: 0");
+    expect(maxTooltip).toHaveStyle("opacity: 0");
   });
 });

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterItem/BulkFilterItem.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterItem/BulkFilterItem.tsx
@@ -6,7 +6,10 @@ import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
 import { isBoolean } from "metabase/lib/schema_metadata";
 
 import { BooleanPickerCheckbox } from "metabase/query_builder/components/filters/pickers/BooleanPicker";
+import RangePicker from "metabase/query_builder/components/filters/pickers/RangePicker";
 import { BulkFilterSelect } from "../BulkFilterSelect";
+
+import { BASE_FIELD_FILTERS, SEMANTIC_FIELD_FILTERS } from "./constants";
 
 export interface BulkFilterItemProps {
   query: StructuredQuery;
@@ -25,9 +28,18 @@ export const BulkFilterItem = ({
   onChangeFilter,
   onRemoveFilter,
 }: BulkFilterItemProps): JSX.Element => {
-  const fieldType = useMemo(() => dimension.field().base_type ?? "", [
-    dimension,
-  ]);
+  const fieldType = useMemo(() => {
+    const semanticType = dimension.field().semantic_type ?? "";
+    const baseType = dimension.field().base_type ?? "";
+
+    if (SEMANTIC_FIELD_FILTERS.includes(semanticType)) {
+      return semanticType;
+    }
+
+    if (BASE_FIELD_FILTERS.includes(baseType)) {
+      return baseType;
+    }
+  }, [dimension]);
 
   const newFilter = useMemo(() => getNewFilter(query, dimension), [
     query,
@@ -52,6 +64,15 @@ export const BulkFilterItem = ({
       return (
         <BooleanPickerCheckbox
           filter={filter ?? newFilter}
+          onFilterChange={handleChange}
+        />
+      );
+    case "type/Float":
+    case "type/Integer":
+      return (
+        <RangePicker
+          filter={filter ?? newFilter}
+          field={dimension.field()}
           onFilterChange={handleChange}
         />
       );

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterItem/BulkFilterItem.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterItem/BulkFilterItem.unit.spec.tsx
@@ -53,9 +53,24 @@ const floatField = new Field({
   metadata,
 });
 
+const fkField = new Field({
+  database_type: "test",
+  semantic_type: "type/FK",
+  table_id: 8,
+  name: "fk_num",
+  has_field_values: "list",
+  dimensions: {},
+  dimension_options: [],
+  effective_type: "type/Integer",
+  id: 137,
+  base_type: "type/Integer",
+  metadata,
+});
+
 metadata.fields[booleanField.id] = booleanField;
 metadata.fields[intField.id] = intField;
 metadata.fields[floatField.id] = floatField;
+metadata.fields[fkField.id] = fkField;
 
 const card = {
   dataset_query: {
@@ -74,6 +89,7 @@ const query = question.query();
 const booleanDimension = booleanField.dimension();
 const floatDimension = floatField.dimension();
 const intDimension = intField.dimension();
+const fkDimension = fkField.dimension();
 
 describe("BulkFilterItem", () => {
   it("renders a boolean picker for a boolean filter", () => {
@@ -99,7 +115,7 @@ describe("BulkFilterItem", () => {
     expect(screen.getByLabelText("false")).not.toBeChecked();
   });
 
-  it("renders a bulk filter select for integer field type", () => {
+  it("renders a range picker for integer field type", () => {
     const testFilter = new Filter(
       ["=", ["field", intField.id, null], 99],
       null,
@@ -119,13 +135,11 @@ describe("BulkFilterItem", () => {
     );
 
     expect(screen.queryByText("true")).toBeNull();
-    expect(screen.getByTestId("select-button")).toHaveAttribute(
-      "aria-label",
-      "int_num",
-    );
+    const rangeInput = screen.getByLabelText("int_num");
+    expect(isNumberRangeFilter(rangeInput)).toBe(true);
   });
 
-  it("renders a bulk filter select for float field type", () => {
+  it("renders a range picker for float field type", () => {
     const testFilter = new Filter(
       ["=", ["field", floatField.id, null], 99],
       null,
@@ -144,9 +158,37 @@ describe("BulkFilterItem", () => {
       />,
     );
     expect(screen.queryByText("true")).toBeNull();
+    const rangeInput = screen.getByLabelText("float_num");
+    expect(isNumberRangeFilter(rangeInput)).toBe(true);
+  });
+
+  it("renders a generic filter select for foreign key field types", () => {
+    const testFilter = new Filter(
+      ["=", ["field", floatField.id, null], 99],
+      null,
+      query,
+    );
+    const changeSpy = jest.fn();
+
+    render(
+      <BulkFilterItem
+        query={query}
+        filter={testFilter}
+        dimension={fkDimension}
+        onAddFilter={changeSpy}
+        onChangeFilter={changeSpy}
+        onRemoveFilter={changeSpy}
+      />,
+    );
     expect(screen.getByTestId("select-button")).toHaveAttribute(
       "aria-label",
-      "float_num",
+      "fk_num",
     );
   });
 });
+
+const isNumberRangeFilter = el => {
+  const inputs = el.querySelectorAll("input");
+  const rangeInputs = el.querySelectorAll("input[type=range]");
+  return inputs.length === 4 && rangeInputs.length === 2;
+};

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterItem/constants.ts
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterItem/constants.ts
@@ -1,1 +1,7 @@
-export const INLINE_FIELD_TYPES = ["type/Boolean"];
+export const BASE_FIELD_FILTERS = [
+  "type/Boolean",
+  "type/Float",
+  "type/Integer",
+];
+
+export const SEMANTIC_FIELD_FILTERS = ["type/FK", "type/PK"];

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterList/BulkFilterList.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterList/BulkFilterList.styled.tsx
@@ -9,17 +9,18 @@ export const ListRoot = styled.div`
 
 export const ListRow = styled.div`
   display: flex;
+  flex-wrap: wrap;
   padding: 0.375rem 0;
 `;
 
 export const ListRowLabel = styled(Ellipsified)`
-  flex: 1 1 0;
-  margin: 0.625rem 1rem 0.625rem 0;
+  width: 50%;
+  padding: 0.625rem 1rem 0.625rem 0;
   color: ${color("black")};
   line-height: 1rem;
   font-weight: bold;
 `;
 
 export const ListRowContent = styled.div`
-  flex: 1 1 0;
+  flex: 1 1 50%;
 `;

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterList/BulkFilterList.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterList/BulkFilterList.tsx
@@ -91,7 +91,12 @@ const BulkFilterListItem = ({
   onRemoveFilter,
 }: BulkFilterListItemProps): JSX.Element => {
   const options = useMemo(() => {
-    return filters.filter(f => f.dimension()?.isSameBaseDimension(dimension));
+    const filtersForThisDimension = filters.filter(f =>
+      f.dimension()?.isSameBaseDimension(dimension),
+    );
+    return filtersForThisDimension.length
+      ? filtersForThisDimension
+      : [undefined];
   }, [filters, dimension]);
 
   return (
@@ -111,15 +116,6 @@ const BulkFilterListItem = ({
             onRemoveFilter={onRemoveFilter}
           />
         ))}
-        {!options.length && (
-          <BulkFilterItem
-            query={query}
-            dimension={dimension}
-            onAddFilter={onAddFilter}
-            onChangeFilter={onChangeFilter}
-            onRemoveFilter={onRemoveFilter}
-          />
-        )}
       </ListRowContent>
     </ListRow>
   );

--- a/frontend/src/metabase/query_builder/components/filters/pickers/RangePicker/RangePicker.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/RangePicker/RangePicker.styled.tsx
@@ -1,0 +1,15 @@
+import styled from "@emotion/styled";
+import { space } from "metabase/styled-components/theme";
+
+import Input from "metabase/core/components/Input";
+
+export const RangeContainer = styled.div`
+  display: flex;
+  align-items: center;
+  width: 100%;
+  margin: ${space(1)} 0;
+`;
+
+export const RangeNumberInput = styled(Input)`
+  width: 10rem;
+`;

--- a/frontend/src/metabase/query_builder/components/filters/pickers/RangePicker/RangePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/RangePicker/RangePicker.tsx
@@ -1,0 +1,187 @@
+import React, {
+  useCallback,
+  useMemo,
+  ChangeEvent,
+  useState,
+  useEffect,
+} from "react";
+import _ from "underscore";
+import { t } from "ttag";
+
+import Filter from "metabase-lib/lib/queries/structured/Filter";
+import Field from "metabase-lib/lib/metadata/Field";
+import Slider from "metabase/core/components/Slider";
+import { NumberFilterOperator } from "./types";
+
+import { RangeContainer, RangeNumberInput } from "./RangePicker.styled";
+import { getStep, roundToStep } from "./utils";
+
+const DEFAULT_MIN = 0;
+const DEFAULT_MAX = 100;
+const DEFAULT_STEP = 1;
+interface RangePickerProps {
+  filter: Filter;
+  field: Field;
+  onFilterChange: (filter: Filter) => void;
+  className?: string;
+}
+
+function RangePicker({
+  filter,
+  field,
+  onFilterChange,
+  className,
+}: RangePickerProps) {
+  const [fieldMin, fieldMax, step] = useMemo(() => {
+    const fingerprint = field.fingerprint?.type?.["type/Number"];
+    if (!fingerprint) {
+      return [DEFAULT_MIN, DEFAULT_MAX, DEFAULT_STEP];
+    }
+    const stepCalc = getStep(fingerprint.min, fingerprint.max);
+    return [
+      roundToStep(fingerprint.min, stepCalc),
+      roundToStep(fingerprint.max, stepCalc),
+      stepCalc,
+    ];
+  }, [field]);
+
+  // cache the range of values the user has entered
+  const [range, setRange] = useState([
+    fieldMin ?? DEFAULT_MIN,
+    fieldMax || DEFAULT_MAX,
+  ]);
+
+  const values = useMemo(() => getValues(filter), [filter]);
+
+  const updateFilter = useCallback(
+    (newValue: (number | undefined)[], manualInput = false) => {
+      const [minValue, maxValue] = newValue;
+      const [rangeMin, rangeMax] = range;
+
+      // we want to ignore min and max values unless they were manually input
+      const emptyMin =
+        minValue === undefined || (!manualInput && minValue === rangeMin);
+      const emptyMax =
+        maxValue === undefined || (!manualInput && maxValue === rangeMax);
+
+      if (emptyMin && emptyMax) {
+        onFilterChange(filter.setOperator("=").setArguments([]));
+      } else if (emptyMin) {
+        onFilterChange(filter.setOperator("<=").setArguments([maxValue]));
+      } else if (emptyMax) {
+        onFilterChange(filter.setOperator(">=").setArguments([minValue]));
+      } else if (minValue === maxValue) {
+        onFilterChange(filter.setOperator("=").setArguments([minValue]));
+      } else {
+        onFilterChange(filter.setOperator("between").setArguments(newValue));
+      }
+    },
+    [filter, onFilterChange, range],
+  );
+
+  useEffect(() => {
+    const [rangeMin, rangeMax] = range;
+    const minValue = _.min(values) ?? DEFAULT_MIN;
+    const maxValue = _.max(values) ?? DEFAULT_MAX;
+
+    if (minValue < rangeMin) {
+      setRange([minValue, rangeMax]);
+    } else if (maxValue > rangeMax) {
+      setRange([rangeMin, maxValue]);
+    }
+  }, [field, values, range]);
+
+  return (
+    <>
+      <RangeContainer className={className} aria-label={field.displayName()}>
+        <RangeInput
+          placeholder={t`min`}
+          value={values[0] ?? ""}
+          onClear={() => updateFilter([undefined, values[1]])}
+          onChange={value => updateFilter([value, values[1]], true)}
+        />
+        <Slider
+          min={range[0]}
+          max={range[1]}
+          step={step}
+          value={values}
+          onChange={updateFilter}
+        />
+        <RangeInput
+          placeholder={t`max`}
+          value={values[1] ?? ""}
+          onClear={() => updateFilter([values[0], undefined])}
+          onChange={value => updateFilter([values[0], value], true)}
+        />
+      </RangeContainer>
+    </>
+  );
+}
+
+function getValues(filter: Filter): (number | undefined)[] {
+  const operatorName = filter.operatorName() as NumberFilterOperator;
+  const args = filter.arguments();
+
+  const valueMap = {
+    between: () => args,
+    "=": () => [args[0], args[0]],
+    "<": () => [undefined, args[0]],
+    "<=": () => [undefined, args[0]],
+    ">": () => [args[0], undefined],
+    ">=": () => [args[0], undefined],
+    "!=": () => [undefined, undefined],
+  };
+
+  return valueMap[operatorName]?.() || [undefined, undefined];
+}
+
+interface RangeInputProps {
+  value: number | "";
+  onChange: (value: number | undefined) => void;
+  onClear: () => void;
+  placeholder: string;
+}
+
+const RangeInput = ({
+  value,
+  onChange,
+  onClear,
+  placeholder,
+}: RangeInputProps) => {
+  const [inputValue, setInputValue] = useState<string | number>(value);
+  useEffect(() => {
+    // only update from parent if the new value is not equal to the old
+    if (value !== Number(inputValue)) {
+      setInputValue(value);
+    }
+  }, [value, setInputValue]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // only update the value if the user has entered a valid number
+  const handleChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      setInputValue(e.target.value);
+
+      if (e.target.value === "") {
+        onChange(undefined);
+      } else if (!isNaN(Number(e.target.value))) {
+        onChange(Number(e.target.value));
+      }
+    },
+    [onChange],
+  );
+
+  return (
+    <RangeNumberInput
+      size="small"
+      rightIcon={value !== "" ? "close" : undefined}
+      placeholder={placeholder}
+      value={inputValue}
+      onChange={handleChange}
+      onRightIconClick={onClear}
+      rightIconTooltip={t`Clear`}
+      fullWidth
+    />
+  );
+};
+
+export default RangePicker;

--- a/frontend/src/metabase/query_builder/components/filters/pickers/RangePicker/RangePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/RangePicker/RangePicker.tsx
@@ -106,6 +106,7 @@ function RangePicker({
           step={step}
           value={values}
           onChange={updateFilter}
+          showMinMaxTooltips={false}
         />
         <RangeInput
           placeholder={t`max`}

--- a/frontend/src/metabase/query_builder/components/filters/pickers/RangePicker/RangePicker.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/RangePicker/RangePicker.unit.spec.tsx
@@ -1,0 +1,312 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import { metadata } from "__support__/sample_database_fixture";
+
+import Question from "metabase-lib/lib/Question";
+import Field from "metabase-lib/lib/metadata/Field";
+import Filter from "metabase-lib/lib/queries/structured/Filter";
+
+import RangePicker from "./index";
+
+const intField = new Field({
+  database_type: "type/Integer",
+  semantic_type: "",
+  table_id: 8,
+  name: "int_num",
+  has_field_values: "list",
+  dimensions: {},
+  dimension_options: [],
+  effective_type: "type/Integer",
+  id: 134,
+  base_type: "type/Integer",
+  metadata,
+});
+
+const floatField = new Field({
+  database_type: "type/Float",
+  semantic_type: "",
+  table_id: 8,
+  name: "float_num",
+  has_field_values: "list",
+  dimensions: {},
+  dimension_options: [],
+  effective_type: "type/Float",
+  id: 135,
+  base_type: "type/Float",
+  metadata,
+});
+
+metadata.fields[intField.id] = intField;
+metadata.fields[floatField.id] = floatField;
+
+const intFieldRef = ["field", 134, null];
+const floatFieldRef = ["field", 135, null];
+
+const intCard = {
+  dataset_query: {
+    database: 5,
+    query: {
+      "source-table": 8,
+      filter: ["=", intFieldRef, true],
+    },
+    type: "query",
+  },
+  display: "table",
+  visualization_settings: {},
+};
+
+const floatCard = {
+  dataset_query: {
+    database: 5,
+    query: {
+      "source-table": 8,
+      filter: ["=", floatFieldRef, true],
+    },
+    type: "query",
+  },
+  display: "table",
+  visualization_settings: {},
+};
+
+const intQuestion = new Question(intCard, metadata);
+const floatQuestion = new Question(floatCard, metadata);
+
+const createFilters = (fieldRef, question) => ({
+  gte: new Filter([">=", fieldRef, 16], null, question.query()),
+  lte: new Filter(["<=", fieldRef, 17], null, question.query()),
+  eq: new Filter(["=", fieldRef, 18], null, question.query()),
+  noteq: new Filter(["!=", fieldRef, 18], null, question.query()),
+  between: new Filter(["between", fieldRef, 19, 20], null, question.query()),
+  empty: new Filter(["=", fieldRef], null, question.query()),
+});
+
+const filters = createFilters(intFieldRef, intQuestion);
+const floatFilters = createFilters(floatFieldRef, floatQuestion);
+
+describe("RangePicker", () => {
+  Object.keys(filters).forEach(filterName => {
+    it(`renders a range slider and two text inputs for an integer ${filterName} filter`, () => {
+      const changeSpy = jest.fn();
+      render(
+        <RangePicker
+          filter={filters[filterName]}
+          onFilterChange={changeSpy}
+          field={intField}
+        />,
+      );
+      screen.getByLabelText("min");
+      screen.getByLabelText("max");
+      screen.getByPlaceholderText("min");
+      screen.getByPlaceholderText("max");
+    });
+  });
+
+  Object.keys(floatFilters).forEach(filterName => {
+    it(`renders a range slider and two text inputs for an integer ${filterName} filter`, () => {
+      const changeSpy = jest.fn();
+      render(
+        <RangePicker
+          filter={floatFilters[filterName]}
+          onFilterChange={changeSpy}
+          field={floatField}
+        />,
+      );
+      screen.getByLabelText("min");
+      screen.getByLabelText("max");
+      screen.getByPlaceholderText("min");
+      screen.getByPlaceholderText("max");
+    });
+  });
+
+  it("renders an empty filter with empty text fields and range sliders at the ends of the input", () => {
+    const changeSpy = jest.fn();
+    render(
+      <RangePicker
+        filter={filters.empty}
+        onFilterChange={changeSpy}
+        field={intField}
+      />,
+    );
+    const inputs = getInputs();
+
+    expect(inputs.minRangeInput).toHaveValue("0");
+    expect(inputs.maxRangeInput).toHaveValue("100");
+
+    expect(inputs.minTextInput).toHaveValue("");
+    expect(inputs.maxTextInput).toHaveValue("");
+  });
+
+  it("correctly renders an existing number filter", () => {
+    const changeSpy = jest.fn();
+    render(
+      <RangePicker
+        filter={filters.gte}
+        onFilterChange={changeSpy}
+        field={intField}
+      />,
+    );
+
+    const inputs = getInputs();
+
+    expect(inputs.minRangeInput).toHaveValue("16");
+    expect(inputs.maxRangeInput).toHaveValue("100");
+
+    expect(inputs.minTextInput).toHaveValue("16");
+    expect(inputs.maxTextInput).toHaveValue("");
+  });
+
+  it("updates the filter when the slider is moved", () => {
+    const changeSpy = jest.fn();
+    render(
+      <RangePicker
+        filter={filters.gte}
+        onFilterChange={changeSpy}
+        field={intField}
+      />,
+    );
+
+    const inputs = getInputs();
+
+    fireEvent.change(inputs.minRangeInput, { target: { value: "64" } });
+    fireEvent.mouseUp(inputs.minRangeInput);
+
+    const newFilter = changeSpy.mock.calls[0][0];
+    expect(newFilter.arguments()).toEqual([64]);
+  });
+
+  it("updates the filter when the text input is modified", () => {
+    const changeSpy = jest.fn();
+
+    render(
+      <RangePicker
+        filter={filters.gte}
+        onFilterChange={changeSpy}
+        field={intField}
+      />,
+    );
+
+    const inputs = getInputs();
+
+    fireEvent.change(inputs.minTextInput, { target: { value: "64" } });
+
+    const newFilter = changeSpy.mock.calls[0][0];
+    expect(newFilter.arguments()).toEqual([64]);
+  });
+
+  it("clears filter arguments when inputs are at max and min values", () => {
+    const changeSpy = jest.fn();
+
+    render(
+      <RangePicker
+        filter={filters.gte}
+        onFilterChange={changeSpy}
+        field={intField}
+      />,
+    );
+    const inputs = getInputs();
+
+    fireEvent.change(inputs.minRangeInput, { target: { value: "0" } });
+    fireEvent.mouseUp(inputs.minRangeInput);
+
+    const newFilter = changeSpy.mock.calls[0][0];
+
+    expect(newFilter.isValid()).toBe(false);
+  });
+
+  it("creates a >= filter when only the min input has a value", () => {
+    const changeSpy = jest.fn();
+    render(
+      <RangePicker
+        filter={filters.empty}
+        onFilterChange={changeSpy}
+        field={intField}
+      />,
+    );
+    const inputs = getInputs();
+
+    fireEvent.change(inputs.minTextInput, { target: { value: "64" } });
+
+    const newFilter = changeSpy.mock.calls[0][0];
+    expect(newFilter.operator().name).toEqual(">=");
+  });
+
+  it("creates a <= filter when only the max input has a value", () => {
+    const changeSpy = jest.fn();
+    render(
+      <RangePicker
+        filter={filters.empty}
+        onFilterChange={changeSpy}
+        field={intField}
+      />,
+    );
+    const inputs = getInputs();
+
+    fireEvent.change(inputs.maxTextInput, { target: { value: "64" } });
+
+    const newFilter = changeSpy.mock.calls[0][0];
+    expect(newFilter.operator().name).toEqual("<=");
+  });
+
+  it("creates a between filter when both inputs have values", () => {
+    const changeSpy = jest.fn();
+    render(
+      <RangePicker
+        filter={filters.gte}
+        onFilterChange={changeSpy}
+        field={intField}
+      />,
+    );
+    const inputs = getInputs();
+
+    fireEvent.change(inputs.maxTextInput, { target: { value: "64" } });
+
+    const newFilter = changeSpy.mock.calls[0][0];
+    expect(newFilter.operator().name).toEqual("between");
+  });
+
+  it("creates an invalid filter when neither input has a value", () => {
+    const changeSpy = jest.fn();
+
+    render(
+      <RangePicker
+        filter={filters.lte}
+        onFilterChange={changeSpy}
+        field={intField}
+      />,
+    );
+    const clearInput = screen.getByLabelText("close icon");
+    fireEvent.click(clearInput);
+
+    const newFilter = changeSpy.mock.calls[0][0];
+
+    expect(newFilter.isValid()).toBe(false);
+  });
+
+  it("creates an = filter when the min and max inputs have the same value", () => {
+    const changeSpy = jest.fn();
+    render(
+      <RangePicker
+        filter={filters.between}
+        onFilterChange={changeSpy}
+        field={intField}
+      />,
+    );
+    const inputs = getInputs();
+    fireEvent.change(inputs.minTextInput, { target: { value: "20" } });
+
+    const newFilter = changeSpy.mock.calls[0][0];
+    expect(newFilter.operator().name).toEqual("=");
+  });
+});
+
+function getInputs() {
+  return {
+    minRangeInput: screen.getByLabelText("min"),
+    maxRangeInput: screen.getByLabelText("max"),
+    minTextInput: screen.getByPlaceholderText("min"),
+    maxTextInput: screen.getByPlaceholderText("max"),
+  };
+}

--- a/frontend/src/metabase/query_builder/components/filters/pickers/RangePicker/index.ts
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/RangePicker/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./RangePicker";

--- a/frontend/src/metabase/query_builder/components/filters/pickers/RangePicker/types.ts
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/RangePicker/types.ts
@@ -1,0 +1,1 @@
+export type NumberFilterOperator = "=" | "<=" | ">=" | "<" | ">" | "between";

--- a/frontend/src/metabase/query_builder/components/filters/pickers/RangePicker/utils.ts
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/RangePicker/utils.ts
@@ -1,0 +1,28 @@
+const stepIntervals = [
+  [100, 1],
+  [250, 5],
+  [1000, 25],
+  [10000, 100],
+  [50000, 250],
+  [250000, 1000],
+  [1000000, 10000],
+];
+
+const MAX_STEP = 250000;
+const DECIMAL_STEP = 0.25;
+
+export const hasDecimal = (value: number) => value % 1 !== 0;
+
+export const getStep = (min: number, max: number): number => {
+  if (hasDecimal(min) || hasDecimal(max)) {
+    return DECIMAL_STEP;
+  }
+
+  const range = max - min;
+  return stepIntervals.find(([maxRange]) => range <= maxRange)?.[1] ?? MAX_STEP;
+};
+
+export const roundToStep = (value: number, step: number): number => {
+  const rounded = Math.round(value / step) * step;
+  return rounded;
+};

--- a/frontend/src/metabase/query_builder/components/filters/pickers/RangePicker/utils.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/RangePicker/utils.unit.spec.ts
@@ -1,0 +1,50 @@
+import { getStep, roundToStep } from "./utils";
+
+describe("rangePicker utils", () => {
+  describe("getStep()", () => {
+    it("should return the correct step for low values", () => {
+      const [min, max] = [0, 100];
+      expect(getStep(min, max)).toBe(1);
+    });
+
+    it("should return the correct step for medium values", () => {
+      const [min, max] = [0, 50000];
+      expect(getStep(min, max)).toBe(250);
+    });
+
+    it("should return the correct step for high values", () => {
+      const [min, max] = [-999999999, 9999999];
+      expect(getStep(min, max)).toBe(250000);
+    });
+
+    it("should return the correct step for negative numbers", () => {
+      const [min, max] = [-1000, 0];
+      expect(getStep(min, max)).toBe(25);
+    });
+
+    it("should get the correct step for decimals", () => {
+      const [min, max] = [-1000, 10000000.78];
+      expect(getStep(min, max)).toBe(0.25);
+    });
+  });
+
+  describe("roundToStep()", () => {
+    it("should round whole numbers to the nearest step", () => {
+      const rounded = roundToStep(33, 25);
+
+      expect(rounded).toBe(25);
+    });
+
+    it("should round decimal numbers to the nearest step", () => {
+      const rounded = roundToStep(33.7, 0.25);
+
+      expect(rounded).toBe(33.75);
+    });
+
+    it("should round negative numbers to the nearest step", () => {
+      const rounded = roundToStep(-840, 250);
+
+      expect(rounded).toBe(-750);
+    });
+  });
+});

--- a/frontend/test/metabase/scenarios/filters/filter-bulk.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/filter-bulk.cy.spec.js
@@ -76,57 +76,21 @@ describe("scenarios > filters > bulk filtering", () => {
     });
   });
 
-  it("should add a filter for a raw query", () => {
-    visitQuestionAdhoc(rawQuestionDetails);
-    openFilterModal();
-
-    modal().within(() => {
-      cy.findByLabelText("Quantity").click();
-    });
-
-    popover().within(() => {
-      cy.findByPlaceholderText("Search the list").type("21");
-      cy.findByText("20").click();
-      cy.button("Add filter").click();
-    });
-
-    modal().within(() => {
-      cy.button("Apply").click();
-      cy.wait("@dataset");
-    });
-
-    cy.findByText("Quantity is equal to 20").should("be.visible");
-    cy.findByText("Showing 4 rows").should("be.visible");
-  });
-
   it("should add a filter for an aggregated query", () => {
     visitQuestionAdhoc(aggregatedQuestionDetails);
     openFilterModal();
 
     modal().within(() => {
       cy.findByText("Summaries").click();
-      cy.findByLabelText("Count").click();
-    });
+      cy.findByLabelText("Count")
+        .findByPlaceholderText("min")
+        .type("500");
 
-    popover().within(() => {
-      cy.findByText("Equal to").click();
-    });
-
-    popover()
-      .eq(1)
-      .within(() => cy.findByText("Greater than").click());
-
-    popover().within(() => {
-      cy.findByPlaceholderText("Enter a number").type("500");
-      cy.button("Add filter").click();
-    });
-
-    modal().within(() => {
       cy.button("Apply").click();
       cy.wait("@dataset");
     });
 
-    cy.findByText("Count is greater than 500").should("be.visible");
+    cy.findByText("Count is greater than or equal to 500").should("be.visible");
     cy.findByText("Showing 21 rows").should("be.visible");
   });
 
@@ -158,27 +122,18 @@ describe("scenarios > filters > bulk filtering", () => {
     openFilterModal();
 
     modal().within(() => {
-      cy.findByText("is less than 30").click();
-    });
-
-    popover().within(() => {
-      cy.findByRole("textbox")
-        .click()
-        .type("30")
+      cy.findAllByDisplayValue("30")
+        .eq(1) // get the text input, not the range input
         .clear()
         .type("25");
 
-      cy.button("Update filter").click();
-    });
-
-    modal().within(() => {
       cy.button("Apply").click();
       cy.wait("@dataset");
     });
 
     cy.findByText("Quantity is greater than 20").should("be.visible");
-    cy.findByText("Quantity is less than 25").should("be.visible");
-    cy.findByText("Showing 17 rows").should("be.visible");
+    cy.findByText("Quantity is less than or equal to 25").should("be.visible");
+    cy.findByText("Showing 19 rows").should("be.visible");
   });
 
   it("should remove an existing filter", () => {
@@ -186,7 +141,8 @@ describe("scenarios > filters > bulk filtering", () => {
     openFilterModal();
 
     modal().within(() => {
-      cy.findByText("is less than 30")
+      cy.findAllByDisplayValue("30")
+        .eq(1) // get the text input, not the range input
         .parent()
         .within(() => cy.icon("close").click());
 
@@ -345,6 +301,86 @@ describe("scenarios > filters > bulk filtering", () => {
       });
 
       cy.findByText("Showing 4 rows").should("be.visible");
+    });
+  });
+
+  describe("number filters", () => {
+    it("should add an = filter", () => {
+      visitQuestionAdhoc(rawQuestionDetails);
+      openFilterModal();
+
+      modal().within(() => {
+        cy.findByLabelText("Quantity")
+          .findByPlaceholderText("min")
+          .type("20");
+
+        cy.findByLabelText("Quantity")
+          .findByPlaceholderText("max")
+          .type("20");
+
+        cy.button("Apply").click();
+        cy.wait("@dataset");
+      });
+
+      cy.findByText("Quantity is equal to 20").should("be.visible");
+      cy.findByText("Showing 4 rows").should("be.visible");
+    });
+
+    it("should add a >= filter", () => {
+      visitQuestionAdhoc(rawQuestionDetails);
+      openFilterModal();
+
+      modal().within(() => {
+        cy.findByLabelText("Total")
+          .findByPlaceholderText("min")
+          .type("150");
+
+        cy.button("Apply").click();
+        cy.wait("@dataset");
+      });
+
+      cy.findByText("Total is greater than or equal to 150").should(
+        "be.visible",
+      );
+      cy.findByText("Showing 256 rows").should("be.visible");
+    });
+
+    it("should add a <= filter", () => {
+      visitQuestionAdhoc(rawQuestionDetails);
+      openFilterModal();
+
+      modal().within(() => {
+        cy.findByLabelText("Total")
+          .findByPlaceholderText("max")
+          .type("20");
+
+        cy.button("Apply").click();
+        cy.wait("@dataset");
+      });
+
+      cy.findByText("Total is less than or equal to 20").should("be.visible");
+      cy.findByText("Showing 52 rows").should("be.visible");
+    });
+
+    it("should add a between filter with decimals", () => {
+      visitQuestionAdhoc(rawQuestionDetails);
+      openFilterModal();
+
+      modal().within(() => {
+        cy.findByLabelText("Total")
+          .findByPlaceholderText("min")
+          .type("20.50");
+
+        cy.findByLabelText("Total")
+          .findByPlaceholderText("max")
+          .type("30.09");
+
+        cy.button("Apply").click();
+        cy.wait("@dataset");
+      });
+
+      cy.findByText("Total between 20.5 30.09").should("be.visible");
+      cy.findByText("Showing 611 rows").should("be.visible");
     });
   });
 });


### PR DESCRIPTION
## Description

Allow number filters to be applied from the bulk filter modal using a combination of range sliders and free text inputs. Should Allow `=`, `>=`, `<=`, and `between` filters.

![Screen Shot 2022-06-08 at 1 05 13 PM](https://user-images.githubusercontent.com/30528226/172711012-dd688d2f-4788-41ee-8d3f-60c2eaa76316.png)


Some specific notes:

### min/max
- should set sliders, by default, to the min and max number ranges from field fingerprints, if available, otherwise, they default to 0-100
- min/max cache: the rangepicker will remember the min/max values entered manually and preserve those. E.g. if the max slider value is initially 100, but the user enters 200, even if they move the slider, the range picker bar will continue to show a max of 200 (until the modal is closed)

### Backwards min/max values
- if a user swaps the slider handles (e.g. drags the right slider to the left of the left slider), we should still get a correct "Between" filter, because the picker will sort the values internally
- if a user enters backwards min/max values in text inputs, we will not get a valid `between` filter because the UX for swapping values between text inputs is jarring

