### PR TITLE
Hydrate :persisted on Card PUT

### DIFF
--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -520,6 +520,7 @@
                    :average_query_time
                    :last_query_start
                    :collection [:moderation_reviews :moderator_details])
+          (cond-> (:dataset card) (hydrate :persisted))
           (assoc :last-edit-info (last-edit/edit-information-for-user @api/*current-user*))))))
 
 (api/defendpoint ^:returns-chan PUT "/:id"


### PR DESCRIPTION
We want to make sure that the :persisted hydration is returned when
updating a card's description.
