### PR TITLE
[E2E] A quick sanity check on template tags handling

### DIFF
--- a/frontend/test/metabase/scenarios/native/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/native.cy.spec.js
@@ -12,6 +12,7 @@ import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 
 describe("scenarios > question > native", () => {
   beforeEach(() => {
+    cy.intercept("POST", "api/dataset").as("dataset");
     restore();
     cy.signInAsNormalUser();
   });
@@ -75,6 +76,16 @@ describe("scenarios > question > native", () => {
     // run query again and see new result
     cy.get(".NativeQueryEditor .Icon-play").click();
     cy.contains("18,760");
+  });
+
+  it("should handle template tags", () => {
+    openNativeEditor().type("select * from PRODUCTS where RATING > {{Stars}}", {
+      parseSpecialCharSequences: false,
+    });
+    cy.get("input[placeholder*='Stars']").type("3");
+    cy.get(".NativeQueryEditor .Icon-play").click();
+    cy.wait("@dataset");
+    cy.contains("Showing 168 rows");
   });
 
   it("can save a question with no rows", () => {


### PR DESCRIPTION
To facilitate confident refactoring, let's add a simple check around template tags support in the native query editor.

To run this manually: `yarn test-visual-open` and pick `frontend/test/metabase/scenarios/native/native.cy.spec.js`.

![image](https://user-images.githubusercontent.com/7288/172734149-58f36384-dc96-45ca-bd9f-5d80b60b1b93.png)
