### PR TITLE
Force slack channel cache refresh when new token is saved

### DIFF
--- a/src/metabase/api/slack.clj
+++ b/src/metabase/api/slack.clj
@@ -35,7 +35,7 @@
           ;; refresh user/conversation cache when token is newly valid
           (slack/refresh-channels-and-usernames-when-needed!))
       ;; clear user/conversation cache when token is newly empty
-      (slack/slack-cached-channels-and-usernames! []))
+      (slack/clear-channel-cache!))
     (let [processed-files-channel (slack/process-files-channel-name slack-files-channel)]
       (when (and processed-files-channel (not (slack/channel-exists? processed-files-channel)))
         (throw (ex-info (tru "Slack channel not found.")

--- a/src/metabase/api/slack.clj
+++ b/src/metabase/api/slack.clj
@@ -24,7 +24,7 @@
     (when (and slack-app-token
                (not config/is-test?)
                (not (slack/valid-token? slack-app-token)))
-      (slack/slack-cached-channels-and-usernames! [])
+      (slack/clear-channel-cache!)
       (throw (ex-info (tru "Invalid Slack token.")
                       {:errors {:slack-app-token (tru "invalid token")}})))
     (slack/slack-app-token! slack-app-token)

--- a/src/metabase/integrations/slack.clj
+++ b/src/metabase/integrations/slack.clj
@@ -219,6 +219,12 @@
    (slack-channels-and-usernames-last-updated)
    (t/minutes 10)))
 
+(defn clear-channel-cache!
+  "Clear the Slack channels cache, and reset its last-updated timestamp to its default value (the Unix epoch)."
+  []
+  (slack-channels-and-usernames-last-updated! zoned-time-epoch)
+  (slack-cached-channels-and-usernames! []))
+
 (defn refresh-channels-and-usernames!
   "Refreshes users and conversations in slack-cache. finds both in parallel, sets
   [[slack-cached-channels-and-usernames]], and resets the [[slack-channels-and-usernames-last-updated]] time."

--- a/test/metabase/integrations/slack_test.clj
+++ b/test/metabase/integrations/slack_test.clj
@@ -137,8 +137,8 @@
     (testing "should be able to fetch list of users and page"
       (http-fake/with-fake-routes {users-endpoint (comp mock-200-response mock-users-response-body)}
         (let [expected-result (map
-                              (comp #(str \@ %) :name)
-                              (concat (mock-users) (mock-users)))]
+                               (comp #(str \@ %) :name)
+                               (concat (mock-users) (mock-users)))]
           (tu/with-temporary-setting-values [slack-token     nil
                                              slack-app-token "test-token"]
             (is (= expected-result


### PR DESCRIPTION
If you've recently deleted a Slack token, the Slack channels cache is cleared. If you then try to save a new token within 10 minutes of adding the previous one, it will try to populate the cache, but will fail the `needs-refresh?` check and thus not work.

This PR fixes this by resetting the `slack-channels-and-usernames-last-updated!` when the Slack cache is cleared in addition to the cache itself.

Resolves #23251