### PR TITLE
Validate Slack files channel before saving new token

### DIFF
--- a/src/metabase/api/slack.clj
+++ b/src/metabase/api/slack.clj
@@ -27,6 +27,11 @@
       (slack/clear-channel-cache!)
       (throw (ex-info (tru "Invalid Slack token.")
                       {:errors {:slack-app-token (tru "invalid token")}})))
+    (let [processed-files-channel (slack/process-files-channel-name slack-files-channel)]
+      (when (and processed-files-channel (not (slack/channel-exists? processed-files-channel)))
+        (throw (ex-info (tru "Slack channel not found.")
+                        {:errors {:slack-files-channel (tru "channel not found")}})))
+      (slack/slack-files-channel! processed-files-channel))
     (slack/slack-app-token! slack-app-token)
     (if slack-app-token
       (do (slack/slack-token-valid?! true)
@@ -36,11 +41,6 @@
           (slack/refresh-channels-and-usernames-when-needed!))
       ;; clear user/conversation cache when token is newly empty
       (slack/clear-channel-cache!))
-    (let [processed-files-channel (slack/process-files-channel-name slack-files-channel)]
-      (when (and processed-files-channel (not (slack/channel-exists? processed-files-channel)))
-        (throw (ex-info (tru "Slack channel not found.")
-                        {:errors {:slack-files-channel (tru "channel not found")}})))
-      (slack/slack-files-channel! processed-files-channel))
     {:ok true}
     (catch clojure.lang.ExceptionInfo info
       {:status 400, :body (ex-data info)})))

--- a/test/metabase/api/slack_test.clj
+++ b/test/metabase/api/slack_test.clj
@@ -43,11 +43,14 @@
           (mt/user-http-request :crowberto :put 200 "slack/settings" {:slack-files-channel "#fake-channel"})
           (is (= "fake-channel" (slack/slack-files-channel))))))
 
-    (testing "An error is returned if the Slack files channel cannot be found"
-      (with-redefs [slack/channel-exists? (constantly nil)]
+    (testing "An error is returned if the Slack files channel cannot be found, and the token is not saved"
+      (with-redefs [slack/valid-token?    (constantly true)
+                    slack/channel-exists? (constantly nil)]
         (let [response (mt/user-http-request :crowberto :put 400 "slack/settings"
-                                             {:slack-files-channel "fake-channel"})]
-          (is (= {:slack-files-channel "channel not found"} (:errors response))))))
+                                             {:slack-app-token     "fake-token"
+                                              :slack-files-channel "fake-channel"})]
+          (is (= {:slack-files-channel "channel not found"} (:errors response)))
+          (is (= nil (slack/slack-app-token))))))
 
     (testing "The Slack app token or files channel settings are cleared if no value is sent in the request"
       (mt/with-temporary-setting-values [slack-app-token "fake-token"


### PR DESCRIPTION
The issue in #23254 is simply that we store the new token before we check for the existence of the files channel. So if the files channel check fails, the Slack integration is still "enabled" successfully (even though it's broken).

Moving the files channel check up before saving the new token fixes the issue.

resolves #23254