### PR TITLE
Add basic Question mock objects for unit-tests

### DIFF
--- a/frontend/src/metabase-lib/mocks.ts
+++ b/frontend/src/metabase-lib/mocks.ts
@@ -1,0 +1,130 @@
+import {
+  Card,
+  SavedCard,
+  UnsavedCard,
+  StructuredDatasetQuery,
+  NativeDatasetQuery,
+} from "metabase-types/types/Card";
+
+import {
+  SAMPLE_DATABASE,
+  ORDERS,
+  metadata,
+} from "__support__/sample_database_fixture";
+
+import Question from "./lib/Question";
+import NativeQuery from "./lib/queries/NativeQuery";
+import StructuredQuery from "./lib/queries/StructuredQuery";
+
+type NativeSavedCard = SavedCard<NativeDatasetQuery>;
+type NativeUnsavedCard = UnsavedCard<NativeDatasetQuery>;
+type StructuredSavedCard = SavedCard<StructuredDatasetQuery>;
+type StructuredUnsavedCard = UnsavedCard<StructuredDatasetQuery>;
+
+const BASE_GUI_QUESTION: StructuredUnsavedCard = {
+  display: "table",
+  visualization_settings: {},
+  dataset_query: {
+    type: "query",
+    database: SAMPLE_DATABASE?.id,
+    query: {
+      "source-table": ORDERS.id,
+    },
+  },
+};
+
+const BASE_NATIVE_QUESTION: NativeUnsavedCard = {
+  display: "table",
+  visualization_settings: {},
+  dataset_query: {
+    type: "native",
+    database: SAMPLE_DATABASE?.id,
+    native: {
+      query: "select * from orders",
+      "template-tags": {},
+    },
+  },
+};
+
+const SAVED_QUESTION = {
+  id: 1,
+  name: "Q1",
+  description: "",
+  collection_id: null,
+};
+
+export function getQuestion(card: Partial<Card>) {
+  return new Question(
+    {
+      ...BASE_GUI_QUESTION,
+      display: "table",
+      visualization_settings: {},
+      ...card,
+    },
+    metadata,
+  );
+}
+
+export function getAdHocQuestion(card?: Partial<StructuredUnsavedCard>) {
+  return getQuestion({ ...BASE_GUI_QUESTION, ...card });
+}
+
+export function getCleanStructuredQuestion(
+  card?: Partial<StructuredUnsavedCard>,
+) {
+  const question = getAdHocQuestion(card);
+
+  const query = (question.query() as StructuredQuery).setSourceTableId(
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    undefined,
+  );
+
+  return question.setQuery(query);
+}
+
+export function getUnsavedNativeQuestion(card?: Partial<NativeUnsavedCard>) {
+  return getQuestion({ ...BASE_NATIVE_QUESTION, ...card });
+}
+
+export function getCleanNativeQuestion(card?: Partial<NativeUnsavedCard>) {
+  const question = getUnsavedNativeQuestion(card);
+  const query = (question.query() as NativeQuery).setQueryText("");
+  return question.setQuery(query);
+}
+
+export function getSavedStructuredQuestion(
+  card?: Partial<StructuredSavedCard>,
+) {
+  return getQuestion({ ...BASE_GUI_QUESTION, ...SAVED_QUESTION, ...card });
+}
+
+export function getSavedNativeQuestion(card?: Partial<NativeSavedCard>) {
+  return getQuestion({
+    ...BASE_NATIVE_QUESTION,
+    ...SAVED_QUESTION,
+    ...card,
+  });
+}
+
+export function getStructuredModel(
+  card?: Omit<Partial<StructuredSavedCard>, "dataset">,
+) {
+  return getQuestion({
+    ...BASE_GUI_QUESTION,
+    ...SAVED_QUESTION,
+    ...card,
+    dataset: true,
+  });
+}
+
+export function getNativeModel(
+  card?: Omit<Partial<NativeSavedCard>, "dataset">,
+) {
+  return getQuestion({
+    ...BASE_NATIVE_QUESTION,
+    ...SAVED_QUESTION,
+    ...card,
+    dataset: true,
+  });
+}

--- a/frontend/src/metabase-lib/mocks.ts
+++ b/frontend/src/metabase-lib/mocks.ts
@@ -72,15 +72,11 @@ export function getAdHocQuestion(card?: Partial<StructuredUnsavedCard>) {
 export function getCleanStructuredQuestion(
   card?: Partial<StructuredUnsavedCard>,
 ) {
-  const question = getAdHocQuestion(card);
-
-  const query = (question.query() as StructuredQuery).setSourceTableId(
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    undefined,
-  );
-
-  return question.setQuery(query);
+  let question = getAdHocQuestion(card);
+  if (question.query() instanceof StructuredQuery) {
+    question = question.setQuery({});
+  }
+  return question;
 }
 
 export function getUnsavedNativeQuestion(card?: Partial<NativeUnsavedCard>) {

--- a/frontend/src/metabase-types/types/Card.ts
+++ b/frontend/src/metabase-types/types/Card.ts
@@ -5,8 +5,8 @@ import { VisualizationSettings } from "metabase-types/api/card";
 
 export type CardId = number;
 
-export type UnsavedCard = {
-  dataset_query: DatasetQuery;
+export type UnsavedCard<Query = DatasetQuery> = {
+  dataset_query: Query;
   display: string;
   visualization_settings: VisualizationSettings;
   parameters?: Array<Parameter>;
@@ -15,7 +15,7 @@ export type UnsavedCard = {
   original_card_id?: CardId;
 };
 
-export type SavedCard = UnsavedCard & {
+export type SavedCard<Query = DatasetQuery> = UnsavedCard<Query> & {
   id: CardId;
   name?: string;
   description?: string;
@@ -24,7 +24,7 @@ export type SavedCard = UnsavedCard & {
   public_uuid: string;
 };
 
-export type Card = SavedCard | UnsavedCard;
+export type Card<Query = DatasetQuery> = SavedCard<Query> | UnsavedCard<Query>;
 
 export type StructuredDatasetQuery = {
   type: "query";


### PR DESCRIPTION
Extracted from #22587 which ended up too big.

Some pieces of code that work with `metabase-lib's` `Question` instance can behave differently depending on a question type (ad-hoc vs. saved, structured vs. native, question vs. model, and all the combos of these variants). It can be beneficial to parameterize unit tests and run them for different types of questions to make us more confident. We already have tests doing that for QB's `ViewHeader` component [here](https://github.com/metabase/metabase/blob/6895130733db308ac148cb1d1a47ed8ecb3bb0cd/frontend/src/metabase/query_builder/components/view/ViewHeader.unit.spec.js#L158).

This PR adds a set of helpers to create the most basic types of questions. In the future, we can iterate on these helpers and extend the list and coverage. E.g. we can add nested, aggregated, public questions, etc.

