### PR TITLE
Fix mysql humanize error

### DIFF
--- a/modules/drivers/mongo/src/metabase/driver/mongo.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo.clj
@@ -55,7 +55,8 @@
                   :ok))
        1.0)))
 
-(defmethod driver/humanize-connection-error-message :mongo
+(defmethod driver/humanize-connection-error-message
+  :mongo
   [_ message]
   (condp re-matches message
     #"^Timed out after \d+ ms while waiting for a server .*$"
@@ -85,7 +86,6 @@
     #"java.security.InvalidKeyException: invalid key format"
     :invalid-key-format
 
-    #".*"                               ; default
     message))
 
 

--- a/modules/drivers/presto/src/metabase/driver/presto.clj
+++ b/modules/drivers/presto/src/metabase/driver/presto.clj
@@ -256,5 +256,4 @@
     #"^java.net.UnknownHostException.*$"
     :invalid-hostname
 
-    #".*"                               ; default
     message))

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -37,7 +37,7 @@
     #"(?s).*Object does not exist.*$"
     :database-name-incorrect
 
-    #"(?s).*" ; default - the Snowflake errors have a \n in them
+    ; default - the Snowflake errors have a \n in them
     message))
 
 (defmethod driver/db-start-of-week :snowflake

--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -116,7 +116,6 @@
     #"^Wrong user name or password .*$"
     :username-or-password-incorrect
 
-    #".*"                               ; default
     message))
 
 (def ^:private date-format-str "yyyy-MM-dd HH:mm:ss.SSS zzz")

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -134,7 +134,7 @@
     #"Must specify port after ':' in connection string"
     :invalid-hostname
 
-    #".*"                               ; default
+    ;; else
     message))
 
 (defmethod sql-jdbc.sync/db-default-timezone :mysql

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -93,7 +93,6 @@
     (let [[_ message] (re-matches #"^FATAL: (.*$)" message)]
       (str (str/capitalize message) \.))
 
-    #".*" ; default
     message))
 
 (defmethod driver.common/current-db-time-date-formatters :postgres


### PR DESCRIPTION
Fix an error in parsing exception messages in sql errors:

Condp is exhaustive and throws if nothing matches

```clojure
mysql=> (condp = 2
          1 :nope
          3 :nope)
Execution error (IllegalArgumentException) at metabase.driver.mysql/eval169387 (REPL:870).
No matching clause: 2
mysql=>
```

and can take a single default clause at the end with no predicate

```clojure
mysql=> (condp = 2
          1 :nope
          :default-catch-all)
:default-catch-all
```

This was attempted with a regex `#".*"` but this regex does not match
everything!

```clojure
mysql=> (driver/humanize-connection-error-message :mysql
                                                  "hello\nthere")
Execution error (IllegalArgumentException) at metabase.driver.mysql/eval167431$fn (mysql.clj:124).
No matching clause: hello
there
mysql=> (re-matches #".*" "hi\nthere")
nil
```

So just use use the message as the default to be returned which was the
original intention.

### Motivation:

Was trying to connect by ssh to a mysql instance and was getting errors parsing the error message:

```clojure
mysql=> (driver/humanize-connection-error-message :mysql
                                                  "Could not connect to address=(host=localhost)(port=59380)(type=master) : (conn=9) Access denied for user 'metabase'@'172.20.0.3' (using password: YES)\nCurrent charset is UTF-8. If password has been set using other charset, consider using option 'passwordCharacterEncoding'")
Execution error (IllegalArgumentException) at metabase.driver.mysql/eval167431$fn (mysql.clj:124).
No matching clause: Could not connect to address=(host=localhost)(port=59380)(type=master) : (conn=9) Access denied for user 'metabase'@'172.20.0.3' (using password: YES)
Current charset is UTF-8. If password has been set using other charset, consider using option 'passwordCharacterEncoding'
```
