### PR TITLE
Refactor `initializeQB` action

### DIFF
--- a/frontend/src/metabase-lib/lib/queries/NativeQuery.ts
+++ b/frontend/src/metabase-lib/lib/queries/NativeQuery.ts
@@ -281,6 +281,10 @@ export default class NativeQuery extends AtomicQuery {
     return Object.values(this.templateTagsMap());
   }
 
+  hasSnippets() {
+    return this.templateTags().some(t => t.type === "snippet");
+  }
+
   templateTagsWithoutSnippets(): TemplateTag[] {
     return this.templateTags().filter(t => t.type !== "snippet");
   }

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.js
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.js
@@ -195,6 +195,29 @@ async function getCard({ cardId, serializedCard, dispatch, getState }) {
   return { card, originalCard };
 }
 
+function getInitialUIControls(location) {
+  const { mode, ...uiControls } = getQueryBuilderModeFromLocation(location);
+  uiControls.queryBuilderMode = mode;
+  return uiControls;
+}
+
+function parseHash(hash) {
+  let options = {};
+  let serializedCard;
+
+  // hash can contain either query params starting with ? or a base64 serialized card
+  if (hash) {
+    const cleanHash = hash.replace(/^#/, "");
+    if (cleanHash.charAt(0) === "?") {
+      options = querystring.parse(cleanHash.substring(1));
+    } else {
+      serializedCard = cleanHash;
+    }
+  }
+
+  return { options, serializedCard };
+}
+
 export const INITIALIZE_QB = "metabase/qb/INITIALIZE_QB";
 export const initializeQB = (location, params) => {
   return async (dispatch, getState) => {
@@ -202,31 +225,10 @@ export const initializeQB = (location, params) => {
     dispatch(cancelQuery());
 
     const cardId = Urls.extractEntityId(params.slug);
+    const uiControls = getInitialUIControls(location);
+    const { options, serializedCard } = parseHash(location.hash);
+
     let card, originalCard;
-
-    const {
-      mode: queryBuilderMode,
-      ...otherUiControls
-    } = getQueryBuilderModeFromLocation(location);
-    const uiControls = {
-      isEditing: false,
-      isShowingTemplateTagsEditor: false,
-      queryBuilderMode,
-      ...otherUiControls,
-    };
-
-    let options = {};
-    let serializedCard;
-
-    // hash can contain either query params starting with ? or a base64 serialized card
-    if (location.hash) {
-      const hash = location.hash.replace(/^#/, "");
-      if (hash.charAt(0) === "?") {
-        options = querystring.parse(hash.substring(1));
-      } else {
-        serializedCard = hash;
-      }
-    }
 
     let preserveParameters = false;
     let snippetFetch;

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.js
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.js
@@ -122,19 +122,18 @@ function getCardForBlankQuestion({ db, table, segment, metric }) {
   return question.card();
 }
 
-async function getCard({ cardId, serializedCard, dispatch, getState }) {
-  let card = {};
-  let originalCard;
-
-  if (serializedCard) {
-    card = deserializeCardFromUrl(serializedCard);
-    if (card.dataset_query.database != null) {
-      // Ensure older MBQL is supported
-      card.dataset_query = normalize(card.dataset_query);
-    }
+function deserializeCard(serializedCard) {
+  const card = deserializeCardFromUrl(serializedCard);
+  if (card.dataset_query.database != null) {
+    // Ensure older MBQL is supported
+    card.dataset_query = normalize(card.dataset_query);
   }
+  return card;
+}
 
-  const deserializedCard = card;
+async function getCard({ cardId, deserializedCard, dispatch, getState }) {
+  let card = deserializedCard || {};
+  let originalCard;
 
   if (cardId) {
     card = await loadCard(cardId);
@@ -240,15 +239,18 @@ async function handleQBInit(dispatch, getState, { location, params }) {
     return;
   }
 
-  let card, originalCard;
+  let card;
+  let originalCard;
+  let deserializedCard;
 
   let preserveParameters = false;
   let snippetFetch;
 
   if (hasCard) {
+    deserializedCard = serializedCard ? deserializeCard(serializedCard) : null;
     const loadedCards = await getCard({
       cardId,
-      serializedCard,
+      deserializedCard,
       dispatch,
       getState,
     });

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.js
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.js
@@ -14,6 +14,7 @@ import { DashboardApi } from "metabase/services";
 
 import { setErrorPage } from "metabase/redux/app";
 import { getMetadata } from "metabase/selectors/metadata";
+import { getUser } from "metabase/selectors/user";
 
 import Databases from "metabase/entities/databases";
 import Snippets from "metabase/entities/snippets";
@@ -200,8 +201,6 @@ export const initializeQB = (location, params) => {
     dispatch(resetQB());
     dispatch(cancelQuery());
 
-    const { currentUser } = getState();
-
     const cardId = Urls.extractEntityId(params.slug);
     let card, originalCard;
 
@@ -307,6 +306,7 @@ export const initializeQB = (location, params) => {
       // Don't set viz automatically for saved questions
       question = question.lockDisplay();
 
+      const currentUser = getUser(getState());
       if (currentUser.is_qbnewb) {
         uiControls.isShowingNewbModal = true;
         MetabaseAnalytics.trackStructEvent("QueryBuilder", "Show Newb Modal");

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.js
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.js
@@ -242,7 +242,11 @@ async function handleQBInit(dispatch, getState, { location, params }) {
     });
     card = loadedCards.card;
     originalCard = loadedCards.originalCard;
+  } else {
+    card = getCardForBlankQuestion(options);
+  }
 
+  if (hasCard) {
     const shouldPropagateParameters = checkShouldPropagateDashboardParameters({
       cardId,
       deserializedCard,
@@ -289,8 +293,6 @@ async function handleQBInit(dispatch, getState, { location, params }) {
 
     preserveParameters = true;
   } else {
-    card = getCardForBlankQuestion(options);
-
     if (options.metric) {
       uiControls.isShowingSummarySidebar = true;
     }

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.js
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.js
@@ -227,12 +227,25 @@ export const initializeQB = (location, params) => {
     const cardId = Urls.extractEntityId(params.slug);
     const uiControls = getInitialUIControls(location);
     const { options, serializedCard } = parseHash(location.hash);
+    const hasCard = cardId || serializedCard;
+
+    if (
+      !hasCard &&
+      !options.db &&
+      !options.table &&
+      !options.segment &&
+      !options.metric
+    ) {
+      dispatch(redirectToNewQuestionFlow());
+      return;
+    }
 
     let card, originalCard;
 
     let preserveParameters = false;
     let snippetFetch;
-    if (cardId || serializedCard) {
+
+    if (hasCard) {
       try {
         const loadedCards = await getCard({
           cardId,
@@ -272,16 +285,6 @@ export const initializeQB = (location, params) => {
         dispatch(setErrorPage(error));
       }
     } else {
-      if (
-        !options.db &&
-        !options.table &&
-        !options.segment &&
-        !options.metric
-      ) {
-        await dispatch(redirectToNewQuestionFlow());
-        return;
-      }
-
       card = getCardForBlankQuestion(options);
 
       if (options.metric) {

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.js
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.js
@@ -197,8 +197,6 @@ async function getCard({ cardId, serializedCard, dispatch, getState }) {
 export const INITIALIZE_QB = "metabase/qb/INITIALIZE_QB";
 export const initializeQB = (location, params) => {
   return async (dispatch, getState) => {
-    const queryParams = location.query;
-
     dispatch(resetQB());
     dispatch(cancelQuery());
 
@@ -323,7 +321,9 @@ export const initializeQB = (location, params) => {
       );
     }
 
+    const queryParams = location.query;
     card = question && question.card();
+
     const metadata = getMetadata(getState());
     const parameters = getValueAndFieldIdPopulatedParametersFromCard(
       card,

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.js
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.js
@@ -94,6 +94,18 @@ async function verifyMatchingDashcardAndParameters({
   }
 }
 
+function getParameterValuesForQuestion({ card, queryParams, metadata }) {
+  const parameters = getValueAndFieldIdPopulatedParametersFromCard(
+    card,
+    metadata,
+  );
+  return getParameterValuesByIdFromQueryParams(
+    parameters,
+    queryParams,
+    metadata,
+  );
+}
+
 async function handleDashboardParameters(
   card,
   { cardId, deserializedCard, originalCard, dispatch, getState },
@@ -321,15 +333,11 @@ async function handleQBInit(dispatch, getState, { location, params }) {
   const freshCard = question && question.card();
 
   const metadata = getMetadata(getState());
-  const parameters = getValueAndFieldIdPopulatedParametersFromCard(
-    freshCard,
-    metadata,
-  );
-  const parameterValues = getParameterValuesByIdFromQueryParams(
-    parameters,
+  const parameterValues = getParameterValuesForQuestion({
+    card,
     queryParams,
     metadata,
-  );
+  });
 
   const objectId = params?.objectId || queryParams?.objectId;
 

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.js
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.js
@@ -286,12 +286,6 @@ async function handleQBInit(dispatch, getState, { location, params }) {
       });
     }
 
-    MetabaseAnalytics.trackStructEvent(
-      "QueryBuilder",
-      "Query Loaded",
-      card.dataset_query.type,
-    );
-
     uiControls.isEditing = !!options.edit;
 
     if (card.archived) {
@@ -305,13 +299,13 @@ async function handleQBInit(dispatch, getState, { location, params }) {
     if (options.metric) {
       uiControls.isShowingSummarySidebar = true;
     }
-
-    MetabaseAnalytics.trackStructEvent(
-      "QueryBuilder",
-      "Query Started",
-      card.dataset_query.type,
-    );
   }
+
+  MetabaseAnalytics.trackStructEvent(
+    "QueryBuilder",
+    hasCard ? "Query Loaded" : "Query Started",
+    card.dataset_query.type,
+  );
 
   if (card && card.id != null) {
     dispatch(fetchAlertsForQuestion(card.id));

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.js
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.js
@@ -245,7 +245,6 @@ async function handleQBInit(dispatch, getState, { location, params }) {
     return;
   }
 
-  let preserveParameters = false;
   let snippetFetch;
 
   const deserializedCard = serializedCard
@@ -300,8 +299,6 @@ async function handleQBInit(dispatch, getState, { location, params }) {
     if (!card?.dataset && location.pathname.startsWith("/model")) {
       dispatch(setErrorPage(NOT_FOUND_ERROR));
     }
-
-    preserveParameters = true;
   } else {
     if (options.metric) {
       uiControls.isShowingSummarySidebar = true;
@@ -380,7 +377,7 @@ async function handleQBInit(dispatch, getState, { location, params }) {
     dispatch(
       updateUrl(freshCard, {
         replaceState: true,
-        preserveParameters,
+        preserveParameters: hasCard,
         objectId,
       }),
     );

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.js
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.js
@@ -96,7 +96,7 @@ const ARCHIVED_ERROR = {
 
 const NOT_FOUND_ERROR = {
   data: {
-    error_code: "archived",
+    error_code: "not-found",
   },
   context: "query-builder",
 };

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.js
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.js
@@ -32,6 +32,20 @@ import { cancelQuery, runQuestionQuery } from "../querying";
 
 import { loadMetadataForCard, resetQB } from "./core";
 
+const ARCHIVED_ERROR = {
+  data: {
+    error_code: "archived",
+  },
+  context: "query-builder",
+};
+
+const NOT_FOUND_ERROR = {
+  data: {
+    error_code: "not-found",
+  },
+  context: "query-builder",
+};
+
 async function verifyMatchingDashcardAndParameters({
   dispatch,
   dashboardId,
@@ -83,20 +97,6 @@ async function getSnippetsLoader({ card, dispatch, getState }) {
     return dispatch(Snippets.actions.fetchList());
   }
 }
-
-const ARCHIVED_ERROR = {
-  data: {
-    error_code: "archived",
-  },
-  context: "query-builder",
-};
-
-const NOT_FOUND_ERROR = {
-  data: {
-    error_code: "not-found",
-  },
-  context: "query-builder",
-};
 
 function getCardForBlankQuestion({ db, table, segment, metric }) {
   const databaseId = db ? parseInt(db) : undefined;

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.js
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.js
@@ -256,11 +256,6 @@ export const initializeQB = (location, params) => {
 
         uiControls.isEditing = !!options.edit;
 
-        if (cardId && currentUser.is_qbnewb) {
-          uiControls.isShowingNewbModal = true;
-          MetabaseAnalytics.trackStructEvent("QueryBuilder", "Show Newb Modal");
-        }
-
         if (card.archived) {
           dispatch(setErrorPage(ARCHIVED_ERROR));
           card = null;
@@ -313,6 +308,11 @@ export const initializeQB = (location, params) => {
     if (question && question.isSaved()) {
       // Don't set viz automatically for saved questions
       question = question.lockDisplay();
+
+      if (currentUser.is_qbnewb) {
+        uiControls.isShowingNewbModal = true;
+        MetabaseAnalytics.trackStructEvent("QueryBuilder", "Show Newb Modal");
+      }
     }
 
     if (question && question.isNative() && snippetFetch) {

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.js
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.js
@@ -105,7 +105,7 @@ export const INITIALIZE_QB = "metabase/qb/INITIALIZE_QB";
 export const initializeQB = (location, params) => {
   return async (dispatch, getState) => {
     const queryParams = location.query;
-    // do this immediately to ensure old state is cleared before the user sees it
+
     dispatch(resetQB());
     dispatch(cancelQuery());
 
@@ -125,9 +125,9 @@ export const initializeQB = (location, params) => {
       ...otherUiControls,
     };
 
-    // load up or initialize the card we'll be working on
     let options = {};
     let serializedCard;
+
     // hash can contain either query params starting with ? or a base64 serialized card
     if (location.hash) {
       const hash = location.hash.replace(/^#/, "");
@@ -141,13 +141,11 @@ export const initializeQB = (location, params) => {
     let preserveParameters = false;
     let snippetFetch;
     if (cardId || serializedCard) {
-      // existing card being loaded
       try {
-        // if we have a serialized card then unpack and use it
         if (serializedCard) {
           card = deserializeCardFromUrl(serializedCard);
-          // if serialized query has database we normalize syntax to support older mbql
           if (card.dataset_query.database != null) {
+            // Ensure older MBQL is supported
             card.dataset_query = normalize(card.dataset_query);
           }
         } else {
@@ -156,11 +154,11 @@ export const initializeQB = (location, params) => {
 
         const deserializedCard = card;
 
-        // load the card either from `cardId` parameter or the serialized card
         if (cardId) {
           card = await loadCard(cardId);
           // when we are loading from a card id we want an explicit clone of the card we loaded which is unmodified
           originalCard = Utils.copy(card);
+
           // for showing the "started from" lineage correctly when adding filters/breakouts and when going back and forth
           // in browser history, the original_card_id has to be set for the current card (simply the id of card itself for now)
           card.original_card_id = card.id;
@@ -184,7 +182,6 @@ export const initializeQB = (location, params) => {
           }
         } else if (card.original_card_id) {
           const deserializedCard = card;
-          // deserialized card contains the card id, so just populate originalCard
           originalCard = await loadCard(card.original_card_id);
 
           if (cardIsEquivalent(deserializedCard, originalCard)) {
@@ -223,17 +220,14 @@ export const initializeQB = (location, params) => {
           card.dataset_query.type,
         );
 
-        // if we have deserialized card from the url AND loaded a card by id then the user should be dropped into edit mode
         uiControls.isEditing = !!options.edit;
 
-        // if this is the users first time loading a saved card on the QB then show them the newb modal
         if (cardId && currentUser.is_qbnewb) {
           uiControls.isShowingNewbModal = true;
           MetabaseAnalytics.trackStructEvent("QueryBuilder", "Show Newb Modal");
         }
 
         if (card.archived) {
-          // use the error handler in App.jsx for showing "This question has been archived" message
           dispatch(setErrorPage(ARCHIVED_ERROR));
           card = null;
         }
@@ -250,8 +244,6 @@ export const initializeQB = (location, params) => {
         dispatch(setErrorPage(error));
       }
     } else {
-      // we are starting a new/empty card
-      // if no options provided in the hash, redirect to the new question flow
       if (
         !options.db &&
         !options.table &&
@@ -265,7 +257,6 @@ export const initializeQB = (location, params) => {
       const databaseId = options.db ? parseInt(options.db) : undefined;
       card = startNewCard("query", databaseId);
 
-      // initialize parts of the query based on optional parameters supplied
       if (card.dataset_query.query) {
         if (options.table != null) {
           card.dataset_query.query["source-table"] = parseInt(options.table);
@@ -277,7 +268,6 @@ export const initializeQB = (location, params) => {
           ];
         }
         if (options.metric != null) {
-          // show the summarize sidebar for metrics
           uiControls.isShowingSummarySidebar = true;
           card.dataset_query.query.aggregation = [
             "metric",
@@ -293,20 +283,17 @@ export const initializeQB = (location, params) => {
       );
     }
 
-    /**** All actions are dispatched here ****/
-
-    // Fetch alerts for the current question if the question is saved
     if (card && card.id != null) {
       dispatch(fetchAlertsForQuestion(card.id));
     }
-    // Fetch the question metadata (blocking)
+
     if (card) {
       await dispatch(loadMetadataForCard(card));
     }
 
     let question = card && new Question(card, getMetadata(getState()));
     if (question && question.isSaved()) {
-      // loading a saved question prevents auto-viz selection
+      // Don't set viz automatically for saved questions
       question = question.lockDisplay();
     }
 
@@ -332,7 +319,6 @@ export const initializeQB = (location, params) => {
 
     const objectId = params?.objectId || queryParams?.objectId;
 
-    // Update the question to Redux state together with the initial state of UI controls
     dispatch({
       type: INITIALIZE_QB,
       payload: {
@@ -344,20 +330,14 @@ export const initializeQB = (location, params) => {
       },
     });
 
-    // if we have loaded up a card that we can run then lets kick that off as well
-    // but don't bother for "notebook" mode
     if (question && uiControls.queryBuilderMode !== "notebook") {
       if (question.canRun()) {
-        // NOTE: timeout to allow Parameters widget to set parameterValues
+        // Timeout to allow Parameters widget to set parameterValues
         setTimeout(
-          () =>
-            // TODO Atte Keinänen 5/31/17: Check if it is dangerous to create a question object without metadata
-            dispatch(runQuestionQuery({ shouldUpdateUrl: false })),
+          () => dispatch(runQuestionQuery({ shouldUpdateUrl: false })),
           0,
         );
       }
-
-      // clean up the url and make sure it reflects our card state
       dispatch(
         updateUrl(card, {
           replaceState: true,

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.js
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.js
@@ -87,6 +87,20 @@ async function getSnippetsLoader({ card, dispatch, getState }) {
   }
 }
 
+const ARCHIVED_ERROR = {
+  data: {
+    error_code: "archived",
+  },
+  context: "query-builder",
+};
+
+const NOT_FOUND_ERROR = {
+  data: {
+    error_code: "archived",
+  },
+  context: "query-builder",
+};
+
 export const INITIALIZE_QB = "metabase/qb/INITIALIZE_QB";
 export const initializeQB = (location, params) => {
   return async (dispatch, getState) => {
@@ -220,26 +234,12 @@ export const initializeQB = (location, params) => {
 
         if (card.archived) {
           // use the error handler in App.jsx for showing "This question has been archived" message
-          dispatch(
-            setErrorPage({
-              data: {
-                error_code: "archived",
-              },
-              context: "query-builder",
-            }),
-          );
+          dispatch(setErrorPage(ARCHIVED_ERROR));
           card = null;
         }
 
         if (!card?.dataset && location.pathname.startsWith("/model")) {
-          dispatch(
-            setErrorPage({
-              data: {
-                error_code: "not-found",
-              },
-              context: "query-builder",
-            }),
-          );
+          dispatch(setErrorPage(NOT_FOUND_ERROR));
           card = null;
         }
 

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.unit.spec.ts
@@ -716,10 +716,9 @@ describe("QB Actions > initializeQB", () => {
     });
 
     it("constructs a card based on provided 'db' param", async () => {
-      const card = Question.create({
+      const expectedCard = Question.create({
         databaseId: SAMPLE_DATABASE?.id,
       }).card();
-      const expectedCard = { ...card, name: null, collection_id: undefined };
 
       const { result } = await setupBlank({ db: SAMPLE_DATABASE?.id });
       const question = new Question(result.card, metadata);
@@ -731,11 +730,7 @@ describe("QB Actions > initializeQB", () => {
     });
 
     it("constructs a card based on provided 'db' and 'table' params", async () => {
-      const expectedCard = {
-        ...ORDERS.question().card(),
-        name: null,
-        collection_id: undefined,
-      };
+      const expectedCard = ORDERS.question().card();
 
       const { result } = await setupOrdersTable();
 
@@ -765,6 +760,12 @@ describe("QB Actions > initializeQB", () => {
       const [aggregation] = query.aggregations();
 
       expect(aggregation.raw()).toEqual(["metric", METRIC_ID]);
+    });
+
+    it("opens summarization sidebar if metric is applied", async () => {
+      const METRIC_ID = 777;
+      const { result } = await setupOrdersTable({ metric: METRIC_ID });
+      expect(result.uiControls.isShowingSummarySidebar).toBe(true);
     });
 
     it("applies both 'metric' and 'segment' params", async () => {


### PR DESCRIPTION
Extracted from #22587 that ended up too big

Refactors `initializeQB` action that's run every time a user opens the query builder. Extensive coverage added in #23262 and the whole QB E2E test suite should hopefully guarantee there are no issues.

**Background**
The whole function ended up very messy and deeply nested because there are pretty many different ways how the query builder can be initialized. For instance:

* the card object should be either fetched from the server or deserialized from the URL hash
* there can be no card at all when you're opening a link like `/question/?db=1&table=5` and `initializeQB` needs to construct a new query based on these URL query params

There is also a bunch of things Metabase should do for all and specific types of questions, for instance:

* saved questions: show an error page if you're opening an archived question
* models: show 404 if you're opening a question via `/model` URL
* all: handle dashboard parameters mapping to question filters
* saved questions: fetch alerts
* all: load metadata
* saved questions: handle "qbnewb" modal
* native questions: fetch snippets

These variations led to a few huge nested `if/else` blocks that made the whole function pretty difficult to read. Everything is also wrapped in a giant `try/catch` so nesting is especially noticeable and inconvenient.

**Highlighted changes**

1. Broke down the `initializeQB` action into two functions. One contains the whole logic and the second one is basically `try/catch` wrapper
2. Applied the "return early" pattern to reduce nesting. Trying to do most of the checks should let us exit `initializeQB` as early as possible (e.g. check if opening an archived question)
3. Extracted the logic for getting the card object (either by fetching the card object from the server or deserializing a card hash). There are a few edge-cases we need to handle that make this logic a bit complex so it seemed to be worth it, please check out the `resolveCards` function implementation to learn more.