### PR TITLE
Convert `initializeQB` to TypeScript

### DIFF
--- a/frontend/src/metabase-types/store/state.ts
+++ b/frontend/src/metabase-types/store/state.ts
@@ -19,3 +19,7 @@ export interface State {
   settings: SettingsState;
   setup: SetupState;
 }
+
+export type Dispatch<T = unknown> = (action: T) => void;
+
+export type GetState = () => State;

--- a/frontend/src/metabase-types/types/Card.ts
+++ b/frontend/src/metabase-types/types/Card.ts
@@ -11,6 +11,10 @@ export type UnsavedCard<Query = DatasetQuery> = {
   visualization_settings: VisualizationSettings;
   parameters?: Array<Parameter>;
 
+  // If coming from dashboard
+  dashboardId?: number;
+  dashcardId?: number;
+
   // Not part of the card API contract, a field used by query builder for showing lineage
   original_card_id?: CardId;
 };
@@ -22,6 +26,7 @@ export type SavedCard<Query = DatasetQuery> = UnsavedCard<Query> & {
   dataset?: boolean;
   can_write: boolean;
   public_uuid: string;
+  archived?: boolean;
 };
 
 export type Card<Query = DatasetQuery> = SavedCard<Query> | UnsavedCard<Query>;

--- a/frontend/src/metabase/lib/query/normalize.js
+++ b/frontend/src/metabase/lib/query/normalize.js
@@ -1,0 +1,1 @@
+export { normalize } from "cljs/metabase.mbql.js";

--- a/frontend/src/metabase/parameters/utils/cards.ts
+++ b/frontend/src/metabase/parameters/utils/cards.ts
@@ -92,7 +92,7 @@ export function getParametersFromCard(
 export function getValueAndFieldIdPopulatedParametersFromCard(
   card: Card,
   metadata: Metadata,
-  parameterValues: { [key: string]: any },
+  parameterValues: { [key: string]: any } = {},
   parameters = getParametersFromCard(card),
 ) {
   if (!card) {

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
@@ -2,10 +2,9 @@ import _ from "underscore";
 import querystring from "querystring";
 import { LocationDescriptorObject } from "history";
 
-import { normalize } from "cljs/metabase.mbql.js";
-
 import * as MetabaseAnalytics from "metabase/lib/analytics";
 import { deserializeCardFromUrl, loadCard } from "metabase/lib/card";
+import { normalize } from "metabase/lib/query/normalize";
 import * as Urls from "metabase/lib/urls";
 
 import { cardIsEquivalent } from "metabase/meta/Card";

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
@@ -187,11 +187,11 @@ function parseHash(hash?: string) {
   return { options, serializedCard };
 }
 
-export const INITIALIZE_QB = "metabase/qb/INITIALIZE_QB";
-
 function isSavedCard(card: Card): card is SavedCard {
   return !!(card as SavedCard).id;
 }
+
+export const INITIALIZE_QB = "metabase/qb/INITIALIZE_QB";
 
 async function handleQBInit(
   dispatch: Dispatch,

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
@@ -10,8 +10,6 @@ import * as Urls from "metabase/lib/urls";
 
 import { cardIsEquivalent } from "metabase/meta/Card";
 
-import { DashboardApi } from "metabase/services";
-
 import { setErrorPage } from "metabase/redux/app";
 import { getMetadata } from "metabase/selectors/metadata";
 import { getUser } from "metabase/selectors/user";
@@ -19,25 +17,23 @@ import { getUser } from "metabase/selectors/user";
 import Snippets from "metabase/entities/snippets";
 import { fetchAlertsForQuestion } from "metabase/alert/alert";
 
-import { getValueAndFieldIdPopulatedParametersFromCard } from "metabase/parameters/utils/cards";
-import { hasMatchingParameters } from "metabase/parameters/utils/dashboards";
-import { getParameterValuesByIdFromQueryParams } from "metabase/parameters/utils/parameter-values";
-
 import Question from "metabase-lib/lib/Question";
 import NativeQuery from "metabase-lib/lib/queries/NativeQuery";
 import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
-import Metadata from "metabase-lib/lib/metadata/Metadata";
 
 import { Dispatch, GetState } from "metabase-types/store";
 
 import { Card, SavedCard } from "metabase-types/types/Card";
-import { Parameter } from "metabase-types/types/Parameter";
 
 import { getQueryBuilderModeFromLocation } from "../../utils";
 import { redirectToNewQuestionFlow, updateUrl } from "../navigation";
 import { cancelQuery, runQuestionQuery } from "../querying";
 
 import { loadMetadataForCard, resetQB } from "./core";
+import {
+  handleDashboardParameters,
+  getParameterValuesForQuestion,
+} from "./parameterUtils";
 
 type BlankQueryOptions = {
   db?: string;
@@ -73,127 +69,6 @@ const NOT_FOUND_ERROR = {
   },
   context: "query-builder",
 };
-
-function checkShouldPropagateDashboardParameters({
-  cardId,
-  deserializedCard,
-  originalCard,
-}: {
-  cardId?: number;
-  deserializedCard?: Card;
-  originalCard?: Card;
-}) {
-  if (!deserializedCard) {
-    return false;
-  }
-  if (cardId && deserializedCard.parameters) {
-    return true;
-  }
-  if (!originalCard) {
-    return false;
-  }
-  const equalCards = cardIsEquivalent(deserializedCard, originalCard, {
-    checkParameters: false,
-  });
-  const differentParameters = !cardIsEquivalent(
-    deserializedCard,
-    originalCard,
-    { checkParameters: true },
-  );
-  return equalCards && differentParameters;
-}
-
-async function verifyMatchingDashcardAndParameters({
-  dispatch,
-  dashboardId,
-  dashcardId,
-  cardId,
-  parameters,
-  metadata,
-}: {
-  dispatch: Dispatch;
-  dashboardId: number;
-  dashcardId: number;
-  cardId: number;
-  parameters: Parameter[];
-  metadata: Metadata;
-}) {
-  try {
-    const dashboard = await DashboardApi.get({ dashId: dashboardId });
-    if (
-      !hasMatchingParameters({
-        dashboard,
-        dashcardId,
-        cardId,
-        parameters,
-        metadata,
-      })
-    ) {
-      dispatch(setErrorPage({ status: 403 }));
-    }
-  } catch (error) {
-    dispatch(setErrorPage(error));
-  }
-}
-
-function getParameterValuesForQuestion({
-  card,
-  queryParams,
-  metadata,
-}: {
-  card: Card;
-  queryParams?: QueryParams;
-  metadata: Metadata;
-}) {
-  const parameters = getValueAndFieldIdPopulatedParametersFromCard(
-    card,
-    metadata,
-  );
-  return getParameterValuesByIdFromQueryParams(
-    parameters,
-    queryParams,
-    metadata,
-  );
-}
-
-async function handleDashboardParameters(
-  card: Card,
-  {
-    deserializedCard,
-    originalCard,
-    dispatch,
-    getState,
-  }: {
-    cardId?: number;
-    deserializedCard?: Card;
-    originalCard?: Card;
-    dispatch: Dispatch;
-    getState: GetState;
-  },
-) {
-  const cardId = (card as SavedCard).id;
-  const shouldPropagateParameters = checkShouldPropagateDashboardParameters({
-    cardId,
-    deserializedCard,
-    originalCard,
-  });
-  if (shouldPropagateParameters && deserializedCard) {
-    const { dashboardId, dashcardId, parameters } = deserializedCard;
-    const metadata = getMetadata(getState());
-    await verifyMatchingDashcardAndParameters({
-      dispatch,
-      cardId,
-      metadata,
-      dashboardId: dashboardId as number,
-      dashcardId: dashcardId as number,
-      parameters: parameters as Parameter[],
-    });
-
-    card.parameters = parameters;
-    card.dashboardId = dashboardId;
-    card.dashcardId = dashcardId;
-  }
-}
 
 function getCardForBlankQuestion({
   db,

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
@@ -21,11 +21,15 @@ import Question from "metabase-lib/lib/Question";
 import NativeQuery from "metabase-lib/lib/queries/NativeQuery";
 import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
 
-import { Dispatch, GetState } from "metabase-types/store";
+import {
+  Dispatch,
+  GetState,
+  QueryBuilderUIControls,
+} from "metabase-types/store";
 
 import { Card, SavedCard } from "metabase-types/types/Card";
 
-import { getQueryBuilderModeFromLocation } from "../../utils";
+import { getQueryBuilderModeFromLocation } from "../../typed-utils";
 import { redirectToNewQuestionFlow, updateUrl } from "../navigation";
 import { cancelQuery, runQuestionQuery } from "../querying";
 
@@ -47,14 +51,7 @@ type QueryParams = BlankQueryOptions & {
   objectId?: string;
 };
 
-type QueryBuilderMode = "view" | "notebook" | "dataset";
-
-type UIControls = {
-  isShowingNewbModal?: boolean;
-  isShowingSummarySidebar?: boolean;
-  datasetEditorTab?: string;
-  queryBuilderMode?: QueryBuilderMode;
-};
+type UIControls = Partial<QueryBuilderUIControls>;
 
 const ARCHIVED_ERROR = {
   data: {
@@ -164,12 +161,6 @@ async function resolveCards({
     : fetchAndPrepareAdHocQuestionCards(deserializedCard as Card);
 }
 
-function getInitialUIControls(location: LocationDescriptorObject) {
-  const { mode, ...uiControls } = getQueryBuilderModeFromLocation(location);
-  (uiControls as UIControls).queryBuilderMode = mode as QueryBuilderMode;
-  return uiControls;
-}
-
 function parseHash(hash?: string) {
   let options: BlankQueryOptions = {};
   let serializedCard;
@@ -206,7 +197,7 @@ async function handleQBInit(
 
   const queryParams = location.query;
   const cardId = Urls.extractEntityId(params.slug);
-  const uiControls: UIControls = getInitialUIControls(location);
+  const uiControls: UIControls = getQueryBuilderModeFromLocation(location);
   const { options, serializedCard } = parseHash(location.hash);
   const hasCard = cardId || serializedCard;
 

--- a/frontend/src/metabase/query_builder/actions/core/parameterUtils.ts
+++ b/frontend/src/metabase/query_builder/actions/core/parameterUtils.ts
@@ -1,0 +1,152 @@
+import _ from "underscore";
+
+import { cardIsEquivalent } from "metabase/meta/Card";
+
+import { DashboardApi } from "metabase/services";
+
+import { setErrorPage } from "metabase/redux/app";
+import { getMetadata } from "metabase/selectors/metadata";
+
+import { getValueAndFieldIdPopulatedParametersFromCard } from "metabase/parameters/utils/cards";
+import { hasMatchingParameters } from "metabase/parameters/utils/dashboards";
+import { getParameterValuesByIdFromQueryParams } from "metabase/parameters/utils/parameter-values";
+
+import Metadata from "metabase-lib/lib/metadata/Metadata";
+
+import { Dispatch, GetState } from "metabase-types/store";
+
+import { Card, SavedCard } from "metabase-types/types/Card";
+import { Parameter } from "metabase-types/types/Parameter";
+
+type BlankQueryOptions = {
+  db?: string;
+  table?: string;
+  segment?: string;
+  metric?: string;
+};
+
+type QueryParams = BlankQueryOptions & {
+  slug?: string;
+  objectId?: string;
+};
+
+function checkShouldPropagateDashboardParameters({
+  cardId,
+  deserializedCard,
+  originalCard,
+}: {
+  cardId?: number;
+  deserializedCard?: Card;
+  originalCard?: Card;
+}) {
+  if (!deserializedCard) {
+    return false;
+  }
+  if (cardId && deserializedCard.parameters) {
+    return true;
+  }
+  if (!originalCard) {
+    return false;
+  }
+  const equalCards = cardIsEquivalent(deserializedCard, originalCard, {
+    checkParameters: false,
+  });
+  const differentParameters = !cardIsEquivalent(
+    deserializedCard,
+    originalCard,
+    { checkParameters: true },
+  );
+  return equalCards && differentParameters;
+}
+
+async function verifyMatchingDashcardAndParameters({
+  dispatch,
+  dashboardId,
+  dashcardId,
+  cardId,
+  parameters,
+  metadata,
+}: {
+  dispatch: Dispatch;
+  dashboardId: number;
+  dashcardId: number;
+  cardId: number;
+  parameters: Parameter[];
+  metadata: Metadata;
+}) {
+  try {
+    const dashboard = await DashboardApi.get({ dashId: dashboardId });
+    if (
+      !hasMatchingParameters({
+        dashboard,
+        dashcardId,
+        cardId,
+        parameters,
+        metadata,
+      })
+    ) {
+      dispatch(setErrorPage({ status: 403 }));
+    }
+  } catch (error) {
+    dispatch(setErrorPage(error));
+  }
+}
+
+export function getParameterValuesForQuestion({
+  card,
+  queryParams,
+  metadata,
+}: {
+  card: Card;
+  queryParams?: QueryParams;
+  metadata: Metadata;
+}) {
+  const parameters = getValueAndFieldIdPopulatedParametersFromCard(
+    card,
+    metadata,
+  );
+  return getParameterValuesByIdFromQueryParams(
+    parameters,
+    queryParams,
+    metadata,
+  );
+}
+
+export async function handleDashboardParameters(
+  card: Card,
+  {
+    deserializedCard,
+    originalCard,
+    dispatch,
+    getState,
+  }: {
+    cardId?: number;
+    deserializedCard?: Card;
+    originalCard?: Card;
+    dispatch: Dispatch;
+    getState: GetState;
+  },
+) {
+  const cardId = (card as SavedCard).id;
+  const shouldPropagateParameters = checkShouldPropagateDashboardParameters({
+    cardId,
+    deserializedCard,
+    originalCard,
+  });
+  if (shouldPropagateParameters && deserializedCard) {
+    const { dashboardId, dashcardId, parameters } = deserializedCard;
+    const metadata = getMetadata(getState());
+    await verifyMatchingDashcardAndParameters({
+      dispatch,
+      cardId,
+      metadata,
+      dashboardId: dashboardId as number,
+      dashcardId: dashcardId as number,
+      parameters: parameters as Parameter[],
+    });
+
+    card.parameters = parameters;
+    card.dashboardId = dashboardId;
+    card.dashcardId = dashcardId;
+  }
+}

--- a/frontend/src/metabase/query_builder/actions/navigation.js
+++ b/frontend/src/metabase/query_builder/actions/navigation.js
@@ -20,10 +20,10 @@ import {
   getQueryBuilderMode,
   getQuestion,
 } from "../selectors";
+import { getQueryBuilderModeFromLocation } from "../typed-utils";
 import {
   getCurrentQueryParams,
   getPathNameFromQueryBuilderMode,
-  getQueryBuilderModeFromLocation,
   getURLForCardState,
 } from "../utils";
 
@@ -68,7 +68,7 @@ export const popState = createThunkAction(
     }
 
     const {
-      mode: queryBuilderModeFromURL,
+      queryBuilderMode: queryBuilderModeFromURL,
       ...uiControls
     } = getQueryBuilderModeFromLocation(location);
 

--- a/frontend/src/metabase/query_builder/actions/querying.js
+++ b/frontend/src/metabase/query_builder/actions/querying.js
@@ -84,7 +84,7 @@ export const RUN_QUERY = "metabase/qb/RUN_QUERY";
 export const runQuestionQuery = ({
   shouldUpdateUrl = true,
   ignoreCache = false,
-  overrideWithCard,
+  overrideWithCard = null,
 } = {}) => {
   return async (dispatch, getState) => {
     dispatch(loadStartUIControls());

--- a/frontend/src/metabase/query_builder/typed-utils.ts
+++ b/frontend/src/metabase/query_builder/typed-utils.ts
@@ -1,0 +1,27 @@
+import { LocationDescriptorObject } from "history";
+import { QueryBuilderMode, DatasetEditorTab } from "metabase-types/store";
+
+type LocationQBModeResult = {
+  queryBuilderMode: QueryBuilderMode;
+  datasetEditorTab?: DatasetEditorTab;
+};
+
+export function getQueryBuilderModeFromLocation(
+  location: LocationDescriptorObject,
+): LocationQBModeResult {
+  const { pathname } = location;
+  if (pathname?.endsWith("/notebook")) {
+    return {
+      queryBuilderMode: "notebook",
+    };
+  }
+  if (pathname?.endsWith("/query") || pathname?.endsWith("/metadata")) {
+    return {
+      queryBuilderMode: "dataset",
+      datasetEditorTab: pathname.endsWith("/query") ? "query" : "metadata",
+    };
+  }
+  return {
+    queryBuilderMode: "view",
+  };
+}

--- a/frontend/src/metabase/query_builder/utils.js
+++ b/frontend/src/metabase/query_builder/utils.js
@@ -3,26 +3,6 @@ import { isSupportedTemplateTagForModel } from "metabase/lib/data-modeling/utils
 import * as Urls from "metabase/lib/urls";
 import NativeQuery from "metabase-lib/lib/queries/NativeQuery";
 
-// Query Builder Mode
-
-export function getQueryBuilderModeFromLocation(location) {
-  const { pathname } = location;
-  if (pathname.endsWith("/notebook")) {
-    return {
-      mode: "notebook",
-    };
-  }
-  if (pathname.endsWith("/query") || pathname.endsWith("/metadata")) {
-    return {
-      mode: "dataset",
-      datasetEditorTab: pathname.endsWith("/query") ? "query" : "metadata",
-    };
-  }
-  return {
-    mode: "view",
-  };
-}
-
 export function getPathNameFromQueryBuilderMode({
   pathname,
   queryBuilderMode,


### PR DESCRIPTION
Extracted from #22587 that ended up too big, based on #23264 work

Converts refactored `initializeQB` action to TypeScript and extracts a few helpers/utils. Type checking, extensive coverage added in #23262, and the whole QB E2E test suite should hopefully guarantee there are no issues.