### PR TITLE
Native query: update parameters upon tags/variables modification

### DIFF
--- a/frontend/src/metabase/query_builder/actions/native.js
+++ b/frontend/src/metabase/query_builder/actions/native.js
@@ -160,6 +160,10 @@ export const setTemplateTag = createThunkAction(
             parameters[index] = getTemplateTagParameter(templateTag);
           }
         }
+      } else {
+        const tags = getTemplateTagsForParameters(updatedTagsCard);
+        const newParameters = getTemplateTagParameters(tags);
+        return assoc(updatedTagsCard, "parameters", newParameters);
       }
 
       return updatedTagsCard;

--- a/frontend/test/metabase/scenarios/native/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/native.cy.spec.js
@@ -13,6 +13,7 @@ import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 describe("scenarios > question > native", () => {
   beforeEach(() => {
     cy.intercept("POST", "api/dataset").as("dataset");
+    cy.intercept("POST", "api/card").as("card");
     restore();
     cy.signInAsNormalUser();
   });
@@ -86,6 +87,36 @@ describe("scenarios > question > native", () => {
     cy.get(".NativeQueryEditor .Icon-play").click();
     cy.wait("@dataset");
     cy.contains("Showing 168 rows");
+  });
+
+  it("should modify parameters accordingly when tags are modified", () => {
+    openNativeEditor().type("select * from PRODUCTS where CATEGORY = {{cat}}", {
+      parseSpecialCharSequences: false,
+    });
+    cy.findByTestId("sidebar-right")
+      .findByText("Required?")
+      .parent()
+      .find("input")
+      .click();
+    cy.get("input[placeholder*='Enter a default value']").type("Gizmo");
+    cy.get(".NativeQueryEditor .Icon-play").click();
+    cy.wait("@dataset");
+
+    cy.contains("Save").click();
+
+    modal().within(() => {
+      cy.findByLabelText("Name").type("Products on Category");
+      cy.findByText("Save").click();
+
+      cy.wait("@card").should(xhr => {
+        const requestBody = xhr.request?.body;
+        expect(requestBody?.parameters?.length).to.equal(1);
+        const parameter = requestBody.parameters[0];
+        expect(parameter.default).to.equal("Gizmo");
+      });
+    });
+
+    cy.findByText("Not now").click();
   });
 
   it("can save a question with no rows", () => {


### PR DESCRIPTION
To verify manually:
1. New, SQL Query
2. Type `select * from PRODUCTS where CATEGORY={{cat}}`
3. From the sidebar, change Cat to Required and supply `Gizmo` as the default value
3. Save, and give it a name

Also, run the added E2E test in `frontend/test/metabase/scenarios/native/native.cy.spec.js`.

### Before this PR

During Step 3, if we open browser console/DevTools, the `POST` to `/api/card` does not even include `parameters` array.

### After this PR

`parameters[]` is updated accordingly, i.e. see the value of `default`:

![image](https://user-images.githubusercontent.com/7288/172935508-f57e65a7-0abf-4260-8d1a-432c71d88bd1.png)
