### PR TITLE
Enable Tooltips to have multiline text if they are line broken by \n

### DIFF
--- a/frontend/src/metabase/css/components/tippy.css
+++ b/frontend/src/metabase/css/components/tippy.css
@@ -1,0 +1,3 @@
+.tippy-content {
+  white-space: pre-wrap;
+}

--- a/frontend/src/metabase/css/index.css
+++ b/frontend/src/metabase/css/index.css
@@ -10,6 +10,7 @@
 @import "./components/modal.css";
 @import "./components/select.css";
 @import "./components/table.css";
+@import "./components/tippy.css";
 @import "./components/token.css";
 @import "./components/grabber.css";
 


### PR DESCRIPTION
Fixes #11091

### How to Test

#### Dashboard description

1. Add a multi-line description to a Dashboard
2. To the right of the Dashboard title, hover on the icon with a `i`
3. Tooltip should respect description lines.

#### Question description

1. Add a multi-line description to a Question
2. Add Question as card to Dashboard
2. To the right of the Question title in card, hover on the icon with a `i`
3. Tooltip should respect description lines.

<img width="399" alt="image" src="https://user-images.githubusercontent.com/380816/172936916-127d249e-8ff4-468d-b99b-793aa96e72ca.png">
