### PR TITLE
docs - frontmatter

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,7 @@
+---
+title: Getting started
+---
+
 ## Getting started
 
 - [Getting started](/learn/getting-started/getting-started)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,5 @@
 ---
-title: Getting started
+title: Metabase documentation
 ---
 
 ## Getting started

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -1,3 +1,7 @@
+---
+title: Accessibility in Metabase
+---
+
 # Accessibility in Metabase 
 
 Metabase is not yet fully compliant with [the US federal government's Section 508 standard][508-accessibility]. Some specific areas where Metabase we still have work to do include:

--- a/docs/administration-guide/01-managing-databases.md
+++ b/docs/administration-guide/01-managing-databases.md
@@ -1,3 +1,7 @@
+---
+title: Adding and managing databases
+---
+
 # Adding and managing databases
 
 - [Adding a database connection](#adding-a-database-connection)

--- a/docs/administration-guide/02-setting-up-email.md
+++ b/docs/administration-guide/02-setting-up-email.md
@@ -1,3 +1,6 @@
+---
+title: Setting up Email
+---
 
 ## Setting up Email
 

--- a/docs/administration-guide/03-metadata-editing.md
+++ b/docs/administration-guide/03-metadata-editing.md
@@ -1,8 +1,8 @@
 ---
-title: The Data Model page: editing metadata
+title: The Data Model page
 ---
 
-# The Data Model page: editing metadata
+# The Data Model page
 
 Metabase allows you to annotate the data in your database. Annotations can give Metabase a better understanding of what the data actually means, which allows Metabase to make more intelligent decisions when processing and displaying that data.
 

--- a/docs/administration-guide/03-metadata-editing.md
+++ b/docs/administration-guide/03-metadata-editing.md
@@ -1,3 +1,7 @@
+---
+title: The Data Model page: editing metadata
+---
+
 # The Data Model page: editing metadata
 
 Metabase allows you to annotate the data in your database. Annotations can give Metabase a better understanding of what the data actually means, which allows Metabase to make more intelligent decisions when processing and displaying that data.

--- a/docs/administration-guide/04-managing-users.md
+++ b/docs/administration-guide/04-managing-users.md
@@ -1,3 +1,7 @@
+---
+title: Managing people and groups
+---
+
 # Managing people and groups
 
 To start managing people, first go to the **Admin panel** by clicking on the **gear** icon in the bottom of the navigation sidebar and selecting **Admin settings**.

--- a/docs/administration-guide/05-setting-permissions.md
+++ b/docs/administration-guide/05-setting-permissions.md
@@ -1,3 +1,7 @@
+---
+title: Permissions overview
+---
+
 # Permissions overview
 
 There are always going to be sensitive bits of information in your data, and thankfully Metabase provides a rich set of tools to ensure that people on your team only see the data they’re supposed to.

--- a/docs/administration-guide/06-collections.md
+++ b/docs/administration-guide/06-collections.md
@@ -1,3 +1,7 @@
+---
+title: Collection permissions
+---
+
 # Collection permissions
 
 ![Collection detail](images/collections/collection-detail.png)

--- a/docs/administration-guide/07-segments-and-metrics.md
+++ b/docs/administration-guide/07-segments-and-metrics.md
@@ -1,3 +1,7 @@
+---
+title: Creating Custom Segments and Metrics
+---
+
 # Creating Custom Segments and Metrics
 
 Metabase allows you to create your own segments and metrics so you can quickly and easily reference them in the query builder. Just head over to the **Admin Panel** and select **Data Model** from the top menu.

--- a/docs/administration-guide/08-configuration-settings.md
+++ b/docs/administration-guide/08-configuration-settings.md
@@ -1,3 +1,7 @@
+---
+title: General settings
+---
+
 ## General settings
 
 This section contains settings for your whole instance, like its URL, the reporting timezone, and toggles for disabling or enabling some of Metabase's optional features.

--- a/docs/administration-guide/09-setting-up-slack.md
+++ b/docs/administration-guide/09-setting-up-slack.md
@@ -1,3 +1,7 @@
+---
+title: Setting up Slack
+---
+
 # Setting up Slack
 
 If you want to have your [Dashboard subscriptions][dashboard-subscriptions] sent to Slack channels (or people on Slack), an admin must first integrate your Metabase with Slack.

--- a/docs/administration-guide/10-single-sign-on.md
+++ b/docs/administration-guide/10-single-sign-on.md
@@ -1,3 +1,7 @@
+---
+title: Authenticating with Google Sign-In or LDAP
+---
+
 # Authenticating with Google Sign-In or LDAP
 
 Enabling [Google Sign-In](#enabling-google-sign-in) or [LDAP](#enabling-ldap-authentication) for [single sign-on (SSO)][sso-docs] lets your team log in with a click instead of using email and password. It can also be used to let people sign up for Metabase accounts without an admin having to create them first. You can find these options in the **Settings** section of the **Admin Panel**, under **Authentication**.

--- a/docs/administration-guide/11-getting-started-guide.md
+++ b/docs/administration-guide/11-getting-started-guide.md
@@ -1,3 +1,7 @@
+---
+title: Getting Started Guide
+---
+
 ## Getting Started Guide
 
 The Getting Started Guide was removed from Metabase in version 0.30. Instead, a great way of helping your teammates find their way around Metabase is by pinning the most important dashboards or questions in each of your collections to make it clear what's most important.

--- a/docs/administration-guide/12-public-links.md
+++ b/docs/administration-guide/12-public-links.md
@@ -1,3 +1,7 @@
+---
+title: Sharing and embedding dashboards or questions
+---
+
 ## Sharing and embedding dashboards or questions
 
 Sometimes you'll want to share a dashboard or question you've saved with someone that isn't a part of your organization or company, or someone who doesn't need access to your full Metabase instance. Metabase lets administrators create public links and simple embeds to let you do just that.

--- a/docs/administration-guide/13-embedding.md
+++ b/docs/administration-guide/13-embedding.md
@@ -1,3 +1,7 @@
+---
+title: Embedding Metabase in other applications
+---
+
 # Embedding Metabase in other applications
 
 Metabase includes a powerful application embedding feature that allows you to embed your saved questions or dashboards in your own web applications. You can even pass parameters to these embeds to customize them for different users.

--- a/docs/administration-guide/14-caching.md
+++ b/docs/administration-guide/14-caching.md
@@ -1,3 +1,7 @@
+---
+title: Caching query results
+---
+
 # Caching query results
 
 Metabase now gives you the ability to automatically cache the results of queries that take a long time to run.

--- a/docs/administration-guide/15-whitelabeling.md
+++ b/docs/administration-guide/15-whitelabeling.md
@@ -1,3 +1,7 @@
+---
+title: White labeling Metabase
+---
+
 ## White labeling Metabase
 
 This page has been moved [here](../enterprise-guide/whitelabeling.md).

--- a/docs/administration-guide/16-authenticating-with-saml.md
+++ b/docs/administration-guide/16-authenticating-with-saml.md
@@ -1,3 +1,7 @@
+---
+title: Authenticating with SAML
+---
+
 ## Authenticating with SAML
 
 This page has been moved [here](../enterprise-guide/authenticating-with-saml.md).

--- a/docs/administration-guide/17-data-sandboxes.md
+++ b/docs/administration-guide/17-data-sandboxes.md
@@ -1,3 +1,7 @@
+---
+title: Sandboxing your data
+---
+
 ## Sandboxing your data
 
 This page has been moved [here](../enterprise-guide/data-sandboxes.md).

--- a/docs/administration-guide/18-authenticating-with-jwt.md
+++ b/docs/administration-guide/18-authenticating-with-jwt.md
@@ -1,3 +1,7 @@
+---
+title: JWT-based Authentication
+---
+
 ## JWT-based Authentication
 
 This page has been moved [here](../enterprise-guide/authenticating-with-jwt.md).

--- a/docs/administration-guide/19-formatting-settings.md
+++ b/docs/administration-guide/19-formatting-settings.md
@@ -1,3 +1,7 @@
+---
+title: Setting default formatting for your data
+---
+
 ## Setting default formatting for your data
 
 There are Metabase users around the world, each with different preferences for how dates, times, numbers, and currencies should be formatted and displayed. Metabase allows you to customize these formatting options at three different levels:

--- a/docs/administration-guide/20-custom-maps.md
+++ b/docs/administration-guide/20-custom-maps.md
@@ -1,3 +1,7 @@
+---
+title: Custom Maps
+---
+
 ## Custom Maps
 
 By default, Metabase uses OpenStreetMaps for map visualizations, but there are a few customization options.

--- a/docs/administration-guide/application-permissions.md
+++ b/docs/administration-guide/application-permissions.md
@@ -1,3 +1,7 @@
+---
+title: Application permissions
+---
+
 # Application permissions
 
 {% include plans-blockquote.html feature="Application permissions" %}

--- a/docs/administration-guide/data-permissions.md
+++ b/docs/administration-guide/data-permissions.md
@@ -1,3 +1,7 @@
+---
+title: Data permissions
+---
+
 # Data permissions
 
 This page covers permissions for databases and tables. If you haven't already, check out our [Permissions overview][permissions-overview].

--- a/docs/administration-guide/databases/aws-rds.md
+++ b/docs/administration-guide/databases/aws-rds.md
@@ -1,3 +1,7 @@
+---
+title: Connecting to AWS's Relational Database Service (RDS)
+---
+
 ## Connecting to AWS's Relational Database Service (RDS)
 
 RDS offers several databases that Metabase officially supports, including PostgreSQL, MySQL, MariaDB, Oracle, and SQL server.
@@ -15,4 +19,3 @@ Here's how to get connection information for databases on Amazon's RDS:
    - **Username**. Find this under Configuration Details.
    - **Database Name**. Find this under Configuration Details
    - **Password**. Ask your database administrator for the password.
-

--- a/docs/administration-guide/databases/bigquery.md
+++ b/docs/administration-guide/databases/bigquery.md
@@ -1,3 +1,7 @@
+---
+title: Working with Google BigQuery in Metabase
+---
+
 # Working with Google BigQuery in Metabase
 
 This page provides information on how to create and manage a connection to a Google [BigQuery](https://cloud.google.com/bigquery) dataset, including one that uses [files stored in Google Drive](https://cloud.google.com/bigquery/external-data-drive) as a data source, like Google Sheets (GSheets).

--- a/docs/administration-guide/databases/google-analytics.md
+++ b/docs/administration-guide/databases/google-analytics.md
@@ -108,4 +108,4 @@ If you're having trouble, see the guides under [Troubleshooting data sources][tr
 [google-oauth-scopes]: https://developers.google.com/identity/protocols/oauth2/scopes
 [google-service-accounts]: https://cloud.google.com/iam/docs/service-accounts
 [sync-docs]: ../../administration-guide/01-managing-databases.html#choose-when-metabase-syncs-and-scans
-[troubleshooting-data-sources]: .../troubleshooting-guide/index.html#data-sources
+[troubleshooting-data-sources]: ../troubleshooting-guide/index.html#data-sources

--- a/docs/administration-guide/databases/google-analytics.md
+++ b/docs/administration-guide/databases/google-analytics.md
@@ -2,7 +2,7 @@
 title: Working with Google Analytics in Metabase
 ---
 
-## Working with Google Analytics in Metabase
+# Working with Google Analytics in Metabase
 
 This page provides information on how to create and manage a connection to a [Google Analytics][google-analytics] dataset.
 

--- a/docs/administration-guide/databases/google-analytics.md
+++ b/docs/administration-guide/databases/google-analytics.md
@@ -108,4 +108,4 @@ If you're having trouble, see the guides under [Troubleshooting data sources][tr
 [google-oauth-scopes]: https://developers.google.com/identity/protocols/oauth2/scopes
 [google-service-accounts]: https://cloud.google.com/iam/docs/service-accounts
 [sync-docs]: ../../administration-guide/01-managing-databases.html#choose-when-metabase-syncs-and-scans
-[troubleshooting-data-sources]: ../troubleshooting-guide/index.html#data-sources
+[troubleshooting-data-sources]: ../../troubleshooting-guide/index.html#data-sources

--- a/docs/administration-guide/databases/google-analytics.md
+++ b/docs/administration-guide/databases/google-analytics.md
@@ -1,3 +1,7 @@
+---
+title: Working with Google Analytics in Metabase
+---
+
 ## Working with Google Analytics in Metabase
 
 This page provides information on how to create and manage a connection to a [Google Analytics][google-analytics] dataset.

--- a/docs/administration-guide/databases/h2.md
+++ b/docs/administration-guide/databases/h2.md
@@ -1,3 +1,7 @@
+---
+title: H2
+---
+
 ## H2
 
 H2 is a lightweight, in-memory database; it’s perfect for getting spun up quickly, but not so good for long-term usage. By default, Metabase uses H2 to store its internal data. The Sample Database included with Metabase is also an H2 database.

--- a/docs/administration-guide/databases/mongodb.md
+++ b/docs/administration-guide/databases/mongodb.md
@@ -1,3 +1,7 @@
+---
+title: Working with MongoDB in Metabase
+---
+
 # Working with MongoDB in Metabase
 
 This article covers:

--- a/docs/administration-guide/databases/mysql.md
+++ b/docs/administration-guide/databases/mysql.md
@@ -1,3 +1,7 @@
+---
+title: Working with MySQL in Metabase
+---
+
 # Working with MySQL in Metabase
 
 This page includes some helpful info for connecting Metabase to your MySQL database.
@@ -60,4 +64,3 @@ mysql:
       - $PWD/mysql:/var/lib/mysql
     command: ['--default-authentication-plugin=mysql_native_password']
 ```
-

--- a/docs/administration-guide/databases/oracle.md
+++ b/docs/administration-guide/databases/oracle.md
@@ -1,3 +1,7 @@
+---
+title: Working with Oracle in Metabase
+---
+
 # Working with Oracle in Metabase
 
 ## Downloading the Oracle JDBC Driver JAR

--- a/docs/administration-guide/databases/postgresql.md
+++ b/docs/administration-guide/databases/postgresql.md
@@ -1,3 +1,7 @@
+---
+title: Connecting to a PostgreSQL database
+---
+
 # Connecting to a PostgreSQL database
 
 In addition to specifying the host, port, database name and user credentials for the database connection, you have the option of securing that connection.
@@ -90,4 +94,3 @@ The problem is that if the keys in the JSON vary record to record, the first ten
 
 [ssl-modes]: https://jdbc.postgresql.org/documentation/head/ssl-client.html
 [ssh-tunnel]: ../ssh-tunnel-for-database-connections.html
-

--- a/docs/administration-guide/databases/redshift.md
+++ b/docs/administration-guide/databases/redshift.md
@@ -1,3 +1,7 @@
+---
+title: Redshift
+---
+
 # Redshift
 
 ## Connection information
@@ -32,4 +36,3 @@ Let's say you have three schemas: foo, bar, and baz.
 - If you have **All except...** set, and enter the string `b*`, you'll just sync foo.
 
 Note that only the `*` wildcard is supported; you can't use other special characters or regexes.
-

--- a/docs/administration-guide/databases/snowflake.md
+++ b/docs/administration-guide/databases/snowflake.md
@@ -1,3 +1,7 @@
+---
+title: Snowflake
+---
+
 # Snowflake
 
 ## Schemas

--- a/docs/administration-guide/databases/vertica.md
+++ b/docs/administration-guide/databases/vertica.md
@@ -1,3 +1,7 @@
+---
+title: Working with Vertica in Metabase
+---
+
 # Working with Vertica in Metabase
 
 Starting in v0.20.0, Metabase provides a driver for connecting to Vertica databases. Under the hood, Metabase uses Vertica's JDBC driver;

--- a/docs/administration-guide/localization.md
+++ b/docs/administration-guide/localization.md
@@ -1,3 +1,7 @@
+---
+title: Languages and localization
+---
+
 # Languages and localization
 
 ## Supported languages
@@ -80,5 +84,3 @@ If you need to, you can change the first day of the week for your instance (the 
 - `Unit of currency:` if you do most of your business in a particular currency, you can specify that here.
 - `Currency label style:` whether you want to have your currencies labeled with a symbol, a code (like `USD`), or its full name.
 - `Where to display the unit of currency:` this pertains specifically to tables, and lets you choose if you want the currency labels to appear only in the column heading, or next to each value in the column.
-
-

--- a/docs/administration-guide/secure-database-connections-with-ssl-certificates.md
+++ b/docs/administration-guide/secure-database-connections-with-ssl-certificates.md
@@ -1,3 +1,7 @@
+---
+title: Securing database connections using an SSL certificate
+---
+
 ## Securing database connections using an SSL certificate
 
 If you'd like to connect your Metabase Cloud or self-hosted instance to a database, you can secure the connection using Secure Socket Layer (SSL) encryption with a certificate.

--- a/docs/administration-guide/ssh-tunnel-for-database-connections.md
+++ b/docs/administration-guide/ssh-tunnel-for-database-connections.md
@@ -1,3 +1,7 @@
+---
+title: SSH tunneling in Metabase
+---
+
 ## SSH tunneling in Metabase
 
 Metabase can connect to some databases by first establishing a connection to a server in between Metabase and a data warehouse, then connecting to the data warehouse using that connection as a bridge. This makes connecting to some data warehouses possible in situations that would otherwise prevent the use of Metabase.

--- a/docs/administration-guide/sso.md
+++ b/docs/administration-guide/sso.md
@@ -1,3 +1,7 @@
+---
+title: Setting up Single Sign-on (SSO)
+---
+
 ## Setting up Single Sign-on (SSO)
 
 We recommend that you set up [Single Sign-on][sso-def] for your Metabase installation.

--- a/docs/administration-guide/start.md
+++ b/docs/administration-guide/start.md
@@ -1,3 +1,7 @@
+---
+title: Administration Guide
+---
+
 # Administration Guide
 
 Are you in charge of managing Metabase for your organization? Then you're in the right spot. You are the chosen one.

--- a/docs/administration-guide/supported-browsers.md
+++ b/docs/administration-guide/supported-browsers.md
@@ -1,3 +1,7 @@
+---
+title: Supported browsers
+---
+
 # Supported browsers
 
 We try our best to make sure Metabase works in as many browsers as possible, but as this is the Internet, there may be little quirks from time to time in different settings. We believe Metabase works on these versions of these browsers and will attempt to fix specific bugs if any are found:

--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -1,7 +1,3 @@
----
-title: Metabase API documentation
----
-
 # Metabase API documentation
 
 _These reference files were generated from source comments by running `clojure -M:ee:run api-documentation`_.

--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -1,3 +1,7 @@
+---
+title: Metabase API documentation
+---
+
 # Metabase API documentation
 
 _These reference files were generated from source comments by running `clojure -M:ee:run api-documentation`_.

--- a/docs/api/activity.md
+++ b/docs/api/activity.md
@@ -1,8 +1,11 @@
 ---
 title: "Activity"
+summary: "API endpoints for Activity."
 ---
 
 # Activity
+
+API endpoints for Activity.
 
   - [GET /api/activity/](#get-apiactivity)
   - [GET /api/activity/popular_items](#get-apiactivitypopular_items)

--- a/docs/api/activity.md
+++ b/docs/api/activity.md
@@ -1,3 +1,7 @@
+---
+title: Activity
+---
+
 # Activity
 
   - [GET /api/activity/](#get-apiactivity)

--- a/docs/api/activity.md
+++ b/docs/api/activity.md
@@ -1,5 +1,5 @@
 ---
-title: Activity
+title: "Activity"
 ---
 
 # Activity

--- a/docs/api/alert.md
+++ b/docs/api/alert.md
@@ -1,5 +1,6 @@
 ---
-title: Alert
+title: "Alert"
+summary: "/api/alert endpoints."
 ---
 
 # Alert

--- a/docs/api/alert.md
+++ b/docs/api/alert.md
@@ -1,3 +1,7 @@
+---
+title: Alert
+---
+
 # Alert
 
 /api/alert endpoints.

--- a/docs/api/automagic-dashboards.md
+++ b/docs/api/automagic-dashboards.md
@@ -1,3 +1,7 @@
+---
+title: Automagic dashboards
+---
+
 # Automagic dashboards
 
   - [GET /api/automagic-dashboards/:entity/:entity-id-or-query](#get-apiautomagic-dashboardsentityentity-id-or-query)

--- a/docs/api/automagic-dashboards.md
+++ b/docs/api/automagic-dashboards.md
@@ -1,5 +1,5 @@
 ---
-title: Automagic dashboards
+title: "Automagic dashboards"
 ---
 
 # Automagic dashboards

--- a/docs/api/automagic-dashboards.md
+++ b/docs/api/automagic-dashboards.md
@@ -1,8 +1,11 @@
 ---
 title: "Automagic dashboards"
+summary: "API endpoints for Automagic dashboards."
 ---
 
 # Automagic dashboards
+
+API endpoints for Automagic dashboards.
 
   - [GET /api/automagic-dashboards/:entity/:entity-id-or-query](#get-apiautomagic-dashboardsentityentity-id-or-query)
   - [GET /api/automagic-dashboards/:entity/:entity-id-or-query/cell/:cell-query](#get-apiautomagic-dashboardsentityentity-id-or-querycellcell-query)

--- a/docs/api/bookmark.md
+++ b/docs/api/bookmark.md
@@ -1,3 +1,7 @@
+---
+title: Bookmark
+---
+
 # Bookmark
 
 Handle creating bookmarks for the user. Bookmarks are in three tables and should be thought of as a tuple of (model,

--- a/docs/api/bookmark.md
+++ b/docs/api/bookmark.md
@@ -3,7 +3,7 @@ title: "Bookmark"
 summary: "Handle creating bookmarks for the user. Bookmarks are in three tables and should be thought of as a tuple of (model,
   model-id) rather than a row in a table with an id. The DELETE takes the model and id because DELETE's do not
   necessarily support request bodies. The POST is therefore shaped in this same manner. Since there are three
-  underlying tables the id on the actual bookmark itself is not unique among "bookmarks" and is not a good
+  underlying tables the id on the actual bookmark itself is not unique among 'bookmarks' and is not a good
   identifier for using in the API."
 ---
 
@@ -12,7 +12,7 @@ summary: "Handle creating bookmarks for the user. Bookmarks are in three tables 
 Handle creating bookmarks for the user. Bookmarks are in three tables and should be thought of as a tuple of (model,
   model-id) rather than a row in a table with an id. The DELETE takes the model and id because DELETE's do not
   necessarily support request bodies. The POST is therefore shaped in this same manner. Since there are three
-  underlying tables the id on the actual bookmark itself is not unique among "bookmarks" and is not a good
+  underlying tables the id on the actual bookmark itself is not unique among 'bookmarks' and is not a good
   identifier for using in the API.
 
   - [DELETE /api/bookmark/:model/:id](#delete-apibookmarkmodelid)

--- a/docs/api/bookmark.md
+++ b/docs/api/bookmark.md
@@ -1,5 +1,10 @@
 ---
-title: Bookmark
+title: "Bookmark"
+summary: "Handle creating bookmarks for the user. Bookmarks are in three tables and should be thought of as a tuple of (model,
+  model-id) rather than a row in a table with an id. The DELETE takes the model and id because DELETE's do not
+  necessarily support request bodies. The POST is therefore shaped in this same manner. Since there are three
+  underlying tables the id on the actual bookmark itself is not unique among "bookmarks" and is not a good
+  identifier for using in the API."
 ---
 
 # Bookmark

--- a/docs/api/card.md
+++ b/docs/api/card.md
@@ -1,5 +1,6 @@
 ---
-title: Card
+title: "Card"
+summary: "/api/card endpoints."
 ---
 
 # Card
@@ -102,6 +103,8 @@ Create a new `Card`.
 
 *  **`visualization_settings`** value must be a map.
 
+*  **`parameters`** value may be nil, or if non-nil, value must be an array. Each parameter must be a map with String :id key
+
 *  **`description`** value may be nil, or if non-nil, value must be a non-blank string.
 
 *  **`collection_position`** value may be nil, or if non-nil, value must be an integer greater than zero.
@@ -115,6 +118,8 @@ Create a new `Card`.
 *  **`cache_ttl`** value may be nil, or if non-nil, value must be an integer greater than zero.
 
 *  **`dataset_query`** 
+
+*  **`parameter_mappings`** value may be nil, or if non-nil, value must be an array. Each parameter mapping must be a String :parameter_id key
 
 *  **`display`** value must be a non-blank string.
 
@@ -231,6 +236,8 @@ Update a `Card`.
 ### PARAMS:
 
 *  **`visualization_settings`** value may be nil, or if non-nil, value must be a map.
+
+*  **`parameters`** value may be nil, or if non-nil, value must be an array. Each parameter must be a map with String :id key
 
 *  **`dataset`** value may be nil, or if non-nil, value must be a boolean.
 

--- a/docs/api/card.md
+++ b/docs/api/card.md
@@ -1,3 +1,7 @@
+---
+title: Card
+---
+
 # Card
 
 /api/card endpoints.

--- a/docs/api/collection.md
+++ b/docs/api/collection.md
@@ -1,3 +1,7 @@
+---
+title: Collection
+---
+
 # Collection
 
 `/api/collection` endpoints. By default, these endpoints operate on Collections in the 'default' namespace, which is

--- a/docs/api/collection.md
+++ b/docs/api/collection.md
@@ -1,5 +1,10 @@
 ---
-title: Collection
+title: "Collection"
+summary: "`/api/collection` endpoints. By default, these endpoints operate on Collections in the 'default' namespace, which is
+  the one that has things like Dashboards and Cards. Other namespaces of Collections exist as well, such as the
+  `:snippet` namespace, (called 'Snippet folders' in the UI). These namespaces are completely independent hierarchies.
+  To use these endpoints for other Collections namespaces, you can pass the `?namespace=` parameter (e.g.
+  `?namespace=snippet`)."
 ---
 
 # Collection

--- a/docs/api/dashboard.md
+++ b/docs/api/dashboard.md
@@ -1,3 +1,7 @@
+---
+title: Dashboard
+---
+
 # Dashboard
 
 /api/dashboard endpoints.

--- a/docs/api/dashboard.md
+++ b/docs/api/dashboard.md
@@ -1,5 +1,6 @@
 ---
-title: Dashboard
+title: "Dashboard"
+summary: "/api/dashboard endpoints."
 ---
 
 # Dashboard
@@ -179,7 +180,7 @@ Create a new Dashboard.
 
 *  **`description`** value may be nil, or if non-nil, value must be a string.
 
-*  **`parameters`** value must be an array. Each value must be a map.
+*  **`parameters`** value may be nil, or if non-nil, value must be an array. Each parameter must be a map with String :id key
 
 *  **`cache_ttl`** value may be nil, or if non-nil, value must be an integer greater than zero.
 
@@ -321,7 +322,7 @@ Update a Dashboard.
 
 ### PARAMS:
 
-*  **`parameters`** value may be nil, or if non-nil, value must be an array. Each value must be a map.
+*  **`parameters`** value may be nil, or if non-nil, value must be an array. Each parameter must be a map with String :id key
 
 *  **`points_of_interest`** value may be nil, or if non-nil, value must be a string.
 

--- a/docs/api/database.md
+++ b/docs/api/database.md
@@ -1,5 +1,6 @@
 ---
-title: Database
+title: "Database"
+summary: "/api/database endpoints."
 ---
 
 # Database
@@ -324,6 +325,8 @@ Update a `Database`.
 *  **`auto_run_queries`** value may be nil, or if non-nil, value must be a boolean.
 
 *  **`name`** value may be nil, or if non-nil, value must be a non-blank string.
+
+*  **`settings`** value may be nil, or if non-nil, value must be a map.
 
 *  **`caveats`** value may be nil, or if non-nil, value must be a string.
 

--- a/docs/api/database.md
+++ b/docs/api/database.md
@@ -1,3 +1,7 @@
+---
+title: Database
+---
+
 # Database
 
 /api/database endpoints.

--- a/docs/api/dataset.md
+++ b/docs/api/dataset.md
@@ -1,5 +1,6 @@
 ---
-title: Dataset
+title: "Dataset"
+summary: "/api/dataset endpoints."
 ---
 
 # Dataset

--- a/docs/api/dataset.md
+++ b/docs/api/dataset.md
@@ -1,3 +1,7 @@
+---
+title: Dataset
+---
+
 # Dataset
 
 /api/dataset endpoints.

--- a/docs/api/ee/advanced-permissions-application.md
+++ b/docs/api/ee/advanced-permissions-application.md
@@ -1,3 +1,7 @@
+---
+title: Advanced permissions application
+---
+
 # Advanced permissions application
 
 `/advanced-permisisons/application` Routes.

--- a/docs/api/ee/advanced-permissions-application.md
+++ b/docs/api/ee/advanced-permissions-application.md
@@ -1,5 +1,8 @@
 ---
-title: Advanced permissions application
+title: "Advanced permissions application"
+summary: "`/advanced-permisisons/application` Routes.
+  Implements the Permissions routes needed for application permission - a class of permissions that control access to features
+  like access Setting pages, access monitoring tools ... etc."
 ---
 
 # Advanced permissions application

--- a/docs/api/ee/audit-app-user.md
+++ b/docs/api/ee/audit-app-user.md
@@ -1,5 +1,6 @@
 ---
-title: Audit app user
+title: "Audit app user"
+summary: "`/api/ee/audit-app/user` endpoints. These only work if you have a premium token with the `:audit-app` feature."
 ---
 
 # Audit app user

--- a/docs/api/ee/audit-app-user.md
+++ b/docs/api/ee/audit-app-user.md
@@ -1,3 +1,7 @@
+---
+title: Audit app user
+---
+
 # Audit app user
 
 `/api/ee/audit-app/user` endpoints. These only work if you have a premium token with the `:audit-app` feature.

--- a/docs/api/ee/content-management-review.md
+++ b/docs/api/ee/content-management-review.md
@@ -1,5 +1,5 @@
 ---
-title: Content management review
+title: "Content management review"
 ---
 
 # Content management review

--- a/docs/api/ee/content-management-review.md
+++ b/docs/api/ee/content-management-review.md
@@ -1,8 +1,11 @@
 ---
 title: "Content management review"
+summary: "API endpoints for Content management review."
 ---
 
 # Content management review
+
+API endpoints for Content management review.
 
   - [POST /api/ee/content-management/review/](#post-apieecontent-managementreview)
 

--- a/docs/api/ee/content-management-review.md
+++ b/docs/api/ee/content-management-review.md
@@ -1,3 +1,7 @@
+---
+title: Content management review
+---
+
 # Content management review
 
   - [POST /api/ee/content-management/review/](#post-apieecontent-managementreview)

--- a/docs/api/ee/sandbox-gtap.md
+++ b/docs/api/ee/sandbox-gtap.md
@@ -1,5 +1,6 @@
 ---
-title: Sandbox GTAP
+title: "Sandbox GTAP"
+summary: "`/api/mt/gtap` endpoints, for CRUD operations and the like on GTAPs (Group Table Access Policies)."
 ---
 
 # Sandbox GTAP

--- a/docs/api/ee/sandbox-gtap.md
+++ b/docs/api/ee/sandbox-gtap.md
@@ -1,3 +1,7 @@
+---
+title: Sandbox GTAP
+---
+
 # Sandbox GTAP
 
 `/api/mt/gtap` endpoints, for CRUD operations and the like on GTAPs (Group Table Access Policies).

--- a/docs/api/ee/sandbox-table.md
+++ b/docs/api/ee/sandbox-table.md
@@ -1,3 +1,7 @@
+---
+title: Sandbox table
+---
+
 # Sandbox table
 
   - [GET /api/ee/sandbox/table/:id/query_metadata](#get-apieesandboxtableidquery_metadata)

--- a/docs/api/ee/sandbox-table.md
+++ b/docs/api/ee/sandbox-table.md
@@ -1,5 +1,5 @@
 ---
-title: Sandbox table
+title: "Sandbox table"
 ---
 
 # Sandbox table

--- a/docs/api/ee/sandbox-table.md
+++ b/docs/api/ee/sandbox-table.md
@@ -1,8 +1,11 @@
 ---
 title: "Sandbox table"
+summary: "API endpoints for Sandbox table."
 ---
 
 # Sandbox table
+
+API endpoints for Sandbox table.
 
   - [GET /api/ee/sandbox/table/:id/query_metadata](#get-apieesandboxtableidquery_metadata)
 

--- a/docs/api/ee/sandbox-user.md
+++ b/docs/api/ee/sandbox-user.md
@@ -1,5 +1,6 @@
 ---
-title: Sandbox user
+title: "Sandbox user"
+summary: "Endpoint(s)for setting user attributes."
 ---
 
 # Sandbox user

--- a/docs/api/ee/sandbox-user.md
+++ b/docs/api/ee/sandbox-user.md
@@ -1,3 +1,7 @@
+---
+title: Sandbox user
+---
+
 # Sandbox user
 
 Endpoint(s)for setting user attributes.

--- a/docs/api/ee/sso.md
+++ b/docs/api/ee/sso.md
@@ -1,5 +1,9 @@
 ---
-title: SSO
+title: "SSO"
+summary: "`/auth/sso` Routes.
+
+  Implements the SSO routes needed for SAML and JWT. This namespace primarily provides hooks for those two backends so
+  we can have a uniform interface both via the API and code."
 ---
 
 # SSO

--- a/docs/api/ee/sso.md
+++ b/docs/api/ee/sso.md
@@ -1,3 +1,7 @@
+---
+title: SSO
+---
+
 # SSO
 
 `/auth/sso` Routes.

--- a/docs/api/email.md
+++ b/docs/api/email.md
@@ -1,3 +1,7 @@
+---
+title: Email
+---
+
 # Email
 
 /api/email endpoints.

--- a/docs/api/email.md
+++ b/docs/api/email.md
@@ -1,5 +1,6 @@
 ---
-title: Email
+title: "Email"
+summary: "/api/email endpoints."
 ---
 
 # Email

--- a/docs/api/embed.md
+++ b/docs/api/embed.md
@@ -1,3 +1,7 @@
+---
+title: Embed
+---
+
 # Embed
 
 Various endpoints that use [JSON web tokens](https://jwt.io/introduction/) to fetch Cards and Dashboards.

--- a/docs/api/embed.md
+++ b/docs/api/embed.md
@@ -1,5 +1,20 @@
 ---
-title: Embed
+title: "Embed"
+summary: "Various endpoints that use [JSON web tokens](https://jwt.io/introduction/) to fetch Cards and Dashboards.
+   The endpoints are the same as the ones in `api/public/`, and differ only in the way they are authorized.
+
+   To use these endpoints:
+
+    1.  Set the `embedding-secret-key` Setting to a hexadecimal-encoded 32-byte sequence (i.e., a 64-character string).
+        You can use `/api/util/random_token` to get a cryptographically-secure value for this.
+    2.  Sign/base-64 encode a JSON Web Token using the secret key and pass it as the relevant part of the URL path
+        to the various endpoints here.
+
+   Tokens can have the following fields:
+
+      {:resource {:question  <card-id>
+                  :dashboard <dashboard-id>}
+       :params   <params>}."
 ---
 
 # Embed

--- a/docs/api/field.md
+++ b/docs/api/field.md
@@ -1,8 +1,11 @@
 ---
 title: "Field"
+summary: "API endpoints for Field."
 ---
 
 # Field
+
+API endpoints for Field.
 
   - [DELETE /api/field/:id/dimension](#delete-apifieldiddimension)
   - [GET /api/field/:id](#get-apifieldid)

--- a/docs/api/field.md
+++ b/docs/api/field.md
@@ -1,3 +1,7 @@
+---
+title: Field
+---
+
 # Field
 
   - [DELETE /api/field/:id/dimension](#delete-apifieldiddimension)

--- a/docs/api/field.md
+++ b/docs/api/field.md
@@ -1,5 +1,5 @@
 ---
-title: Field
+title: "Field"
 ---
 
 # Field

--- a/docs/api/geojson.md
+++ b/docs/api/geojson.md
@@ -1,8 +1,11 @@
 ---
 title: "GeoJSON"
+summary: "API endpoints for GeoJSON."
 ---
 
 # GeoJSON
+
+API endpoints for GeoJSON.
 
   - [GET /api/geojson/](#get-apigeojson)
   - [GET /api/geojson/:key](#get-apigeojsonkey)

--- a/docs/api/geojson.md
+++ b/docs/api/geojson.md
@@ -1,3 +1,7 @@
+---
+title: GeoJSON
+---
+
 # GeoJSON
 
   - [GET /api/geojson/](#get-apigeojson)

--- a/docs/api/geojson.md
+++ b/docs/api/geojson.md
@@ -1,5 +1,5 @@
 ---
-title: GeoJSON
+title: "GeoJSON"
 ---
 
 # GeoJSON

--- a/docs/api/ldap.md
+++ b/docs/api/ldap.md
@@ -1,3 +1,7 @@
+---
+title: LDAP
+---
+
 # LDAP
 
 /api/ldap endpoints.

--- a/docs/api/ldap.md
+++ b/docs/api/ldap.md
@@ -1,5 +1,6 @@
 ---
-title: LDAP
+title: "LDAP"
+summary: "/api/ldap endpoints."
 ---
 
 # LDAP

--- a/docs/api/login-history.md
+++ b/docs/api/login-history.md
@@ -1,8 +1,11 @@
 ---
 title: "Login history"
+summary: "API endpoints for Login history."
 ---
 
 # Login history
+
+API endpoints for Login history.
 
   - [GET /api/login-history/current](#get-apilogin-historycurrent)
 

--- a/docs/api/login-history.md
+++ b/docs/api/login-history.md
@@ -1,3 +1,7 @@
+---
+title: Login history
+---
+
 # Login history
 
   - [GET /api/login-history/current](#get-apilogin-historycurrent)

--- a/docs/api/login-history.md
+++ b/docs/api/login-history.md
@@ -1,5 +1,5 @@
 ---
-title: Login history
+title: "Login history"
 ---
 
 # Login history

--- a/docs/api/metric.md
+++ b/docs/api/metric.md
@@ -1,5 +1,6 @@
 ---
-title: Metric
+title: "Metric"
+summary: "/api/metric endpoints."
 ---
 
 # Metric

--- a/docs/api/metric.md
+++ b/docs/api/metric.md
@@ -1,3 +1,7 @@
+---
+title: Metric
+---
+
 # Metric
 
 /api/metric endpoints.

--- a/docs/api/native-query-snippet.md
+++ b/docs/api/native-query-snippet.md
@@ -1,3 +1,7 @@
+---
+title: Native query snippet
+---
+
 # Native query snippet
 
 Native query snippet (/api/native-query-snippet) endpoints.

--- a/docs/api/native-query-snippet.md
+++ b/docs/api/native-query-snippet.md
@@ -1,5 +1,6 @@
 ---
-title: Native query snippet
+title: "Native query snippet"
+summary: "Native query snippet (/api/native-query-snippet) endpoints."
 ---
 
 # Native query snippet

--- a/docs/api/notify.md
+++ b/docs/api/notify.md
@@ -1,5 +1,6 @@
 ---
-title: Notify
+title: "Notify"
+summary: "/api/notify/* endpoints which receive inbound etl server notifications."
 ---
 
 # Notify

--- a/docs/api/notify.md
+++ b/docs/api/notify.md
@@ -1,3 +1,7 @@
+---
+title: Notify
+---
+
 # Notify
 
 /api/notify/* endpoints which receive inbound etl server notifications.

--- a/docs/api/permissions.md
+++ b/docs/api/permissions.md
@@ -1,3 +1,7 @@
+---
+title: Permissions
+---
+
 # Permissions
 
 /api/permissions endpoints.

--- a/docs/api/permissions.md
+++ b/docs/api/permissions.md
@@ -1,5 +1,6 @@
 ---
-title: Permissions
+title: "Permissions"
+summary: "/api/permissions endpoints."
 ---
 
 # Permissions

--- a/docs/api/persist.md
+++ b/docs/api/persist.md
@@ -1,8 +1,11 @@
 ---
 title: "Persist"
+summary: "API endpoints for Persist."
 ---
 
 # Persist
+
+API endpoints for Persist.
 
   - [GET /api/persist/](#get-apipersist)
   - [GET /api/persist/:persisted-info-id](#get-apipersistpersisted-info-id)

--- a/docs/api/persist.md
+++ b/docs/api/persist.md
@@ -1,3 +1,7 @@
+---
+title: Persist
+---
+
 # Persist
 
   - [GET /api/persist/](#get-apipersist)

--- a/docs/api/persist.md
+++ b/docs/api/persist.md
@@ -1,5 +1,5 @@
 ---
-title: Persist
+title: "Persist"
 ---
 
 # Persist
@@ -42,11 +42,15 @@ Enable global setting to allow databases to persist models.
 
 ## `POST /api/persist/set-interval`
 
-Set the interval (in hours) to refresh persisted models. Shape should be JSON like {hours: 4}.
+Set the interval (in hours) to refresh persisted models.
+   Anchor can be provided to set the time to begin the interval (local to reporting-timezone or system).
+   Shape should be JSON like {hours: 4, anchor: 16:45}.
 
 ### PARAMS:
 
-*  **`hours`** Value must be an integer representing hours greater than or equal to one and less than or equal to twenty-four
+*  **`hours`** value may be nil, or if non-nil, Value must be an integer representing hours greater than or equal to one and less than or equal to twenty-four
+
+*  **`anchor`** value may be nil, or if non-nil, Value must be a string representing a time in format HH:mm
 
 *  **`_body`**
 

--- a/docs/api/premium-features.md
+++ b/docs/api/premium-features.md
@@ -1,5 +1,5 @@
 ---
-title: Premium features
+title: "Premium features"
 ---
 
 # Premium features

--- a/docs/api/premium-features.md
+++ b/docs/api/premium-features.md
@@ -1,8 +1,11 @@
 ---
 title: "Premium features"
+summary: "API endpoints for Premium features."
 ---
 
 # Premium features
+
+API endpoints for Premium features.
 
   - [GET /api/premium-features/token/status](#get-apipremium-featurestokenstatus)
 

--- a/docs/api/premium-features.md
+++ b/docs/api/premium-features.md
@@ -1,3 +1,7 @@
+---
+title: Premium features
+---
+
 # Premium features
 
   - [GET /api/premium-features/token/status](#get-apipremium-featurestokenstatus)

--- a/docs/api/preview-embed.md
+++ b/docs/api/preview-embed.md
@@ -1,3 +1,7 @@
+---
+title: Preview embed
+---
+
 # Preview embed
 
 Endpoints for previewing how Cards and Dashboards will look when embedding them.

--- a/docs/api/preview-embed.md
+++ b/docs/api/preview-embed.md
@@ -1,5 +1,14 @@
 ---
-title: Preview embed
+title: "Preview embed"
+summary: "Endpoints for previewing how Cards and Dashboards will look when embedding them.
+   These endpoints are basically identical in functionality to the ones in `/api/embed`, but:
+
+   1.  Require admin access
+   2.  Ignore the values of `:enabled_embedding` for Cards/Dashboards
+   3.  Ignore the `:embed_params` whitelist for Card/Dashboards, instead using a field called `:_embedding_params` in
+       the JWT token itself.
+
+   Refer to the documentation for those endpoints for further details."
 ---
 
 # Preview embed

--- a/docs/api/public.md
+++ b/docs/api/public.md
@@ -1,3 +1,7 @@
+---
+title: Public
+---
+
 # Public
 
 Metabase API endpoints for viewing publicly-accessible Cards and Dashboards.

--- a/docs/api/public.md
+++ b/docs/api/public.md
@@ -1,5 +1,6 @@
 ---
-title: Public
+title: "Public"
+summary: "Metabase API endpoints for viewing publicly-accessible Cards and Dashboards."
 ---
 
 # Public

--- a/docs/api/pulse.md
+++ b/docs/api/pulse.md
@@ -1,3 +1,7 @@
+---
+title: Pulse
+---
+
 # Pulse
 
 /api/pulse endpoints.

--- a/docs/api/pulse.md
+++ b/docs/api/pulse.md
@@ -1,5 +1,6 @@
 ---
-title: Pulse
+title: "Pulse"
+summary: "/api/pulse endpoints."
 ---
 
 # Pulse

--- a/docs/api/revision.md
+++ b/docs/api/revision.md
@@ -1,8 +1,11 @@
 ---
 title: "Revision"
+summary: "API endpoints for Revision."
 ---
 
 # Revision
+
+API endpoints for Revision.
 
   - [GET /api/revision/](#get-apirevision)
   - [POST /api/revision/revert](#post-apirevisionrevert)

--- a/docs/api/revision.md
+++ b/docs/api/revision.md
@@ -1,3 +1,7 @@
+---
+title: Revision
+---
+
 # Revision
 
   - [GET /api/revision/](#get-apirevision)

--- a/docs/api/revision.md
+++ b/docs/api/revision.md
@@ -1,5 +1,5 @@
 ---
-title: Revision
+title: "Revision"
 ---
 
 # Revision

--- a/docs/api/search.md
+++ b/docs/api/search.md
@@ -1,5 +1,5 @@
 ---
-title: Search
+title: "Search"
 ---
 
 # Search

--- a/docs/api/search.md
+++ b/docs/api/search.md
@@ -1,3 +1,7 @@
+---
+title: Search
+---
+
 # Search
 
   - [GET /api/search/](#get-apisearch)

--- a/docs/api/search.md
+++ b/docs/api/search.md
@@ -1,8 +1,11 @@
 ---
 title: "Search"
+summary: "API endpoints for Search."
 ---
 
 # Search
+
+API endpoints for Search.
 
   - [GET /api/search/](#get-apisearch)
   - [GET /api/search/models](#get-apisearchmodels)

--- a/docs/api/segment.md
+++ b/docs/api/segment.md
@@ -1,3 +1,7 @@
+---
+title: Segment
+---
+
 # Segment
 
 /api/segment endpoints.

--- a/docs/api/segment.md
+++ b/docs/api/segment.md
@@ -1,5 +1,6 @@
 ---
-title: Segment
+title: "Segment"
+summary: "/api/segment endpoints."
 ---
 
 # Segment

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -1,5 +1,6 @@
 ---
-title: Session
+title: "Session"
+summary: "/api/session endpoints."
 ---
 
 # Session

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -1,3 +1,7 @@
+---
+title: Session
+---
+
 # Session
 
 /api/session endpoints.

--- a/docs/api/setting.md
+++ b/docs/api/setting.md
@@ -1,3 +1,7 @@
+---
+title: Setting
+---
+
 # Setting
 
 /api/setting endpoints.

--- a/docs/api/setting.md
+++ b/docs/api/setting.md
@@ -1,5 +1,6 @@
 ---
-title: Setting
+title: "Setting"
+summary: "/api/setting endpoints."
 ---
 
 # Setting

--- a/docs/api/setup.md
+++ b/docs/api/setup.md
@@ -1,3 +1,7 @@
+---
+title: Setup
+---
+
 # Setup
 
   - [GET /api/setup/admin_checklist](#get-apisetupadmin_checklist)

--- a/docs/api/setup.md
+++ b/docs/api/setup.md
@@ -1,8 +1,11 @@
 ---
 title: "Setup"
+summary: "API endpoints for Setup."
 ---
 
 # Setup
+
+API endpoints for Setup.
 
   - [GET /api/setup/admin_checklist](#get-apisetupadmin_checklist)
   - [GET /api/setup/user_defaults](#get-apisetupuser_defaults)

--- a/docs/api/setup.md
+++ b/docs/api/setup.md
@@ -1,5 +1,5 @@
 ---
-title: Setup
+title: "Setup"
 ---
 
 # Setup

--- a/docs/api/slack.md
+++ b/docs/api/slack.md
@@ -1,3 +1,7 @@
+---
+title: Slack
+---
+
 # Slack
 
 /api/slack endpoints.

--- a/docs/api/slack.md
+++ b/docs/api/slack.md
@@ -1,5 +1,6 @@
 ---
-title: Slack
+title: "Slack"
+summary: "/api/slack endpoints."
 ---
 
 # Slack

--- a/docs/api/table.md
+++ b/docs/api/table.md
@@ -1,5 +1,6 @@
 ---
-title: Table
+title: "Table"
+summary: "/api/table endpoints."
 ---
 
 # Table

--- a/docs/api/table.md
+++ b/docs/api/table.md
@@ -1,3 +1,7 @@
+---
+title: Table
+---
+
 # Table
 
 /api/table endpoints.

--- a/docs/api/task.md
+++ b/docs/api/task.md
@@ -1,5 +1,6 @@
 ---
-title: Task
+title: "Task"
+summary: "/api/task endpoints."
 ---
 
 # Task

--- a/docs/api/task.md
+++ b/docs/api/task.md
@@ -1,3 +1,7 @@
+---
+title: Task
+---
+
 # Task
 
 /api/task endpoints.

--- a/docs/api/tiles.md
+++ b/docs/api/tiles.md
@@ -1,5 +1,6 @@
 ---
-title: Tiles
+title: "Tiles"
+summary: "`/api/tiles` endpoints."
 ---
 
 # Tiles

--- a/docs/api/tiles.md
+++ b/docs/api/tiles.md
@@ -1,3 +1,7 @@
+---
+title: Tiles
+---
+
 # Tiles
 
 `/api/tiles` endpoints.

--- a/docs/api/timeline-event.md
+++ b/docs/api/timeline-event.md
@@ -1,3 +1,7 @@
+---
+title: Timeline event
+---
+
 # Timeline event
 
 /api/timeline-event endpoints.

--- a/docs/api/timeline-event.md
+++ b/docs/api/timeline-event.md
@@ -1,5 +1,6 @@
 ---
-title: Timeline event
+title: "Timeline event"
+summary: "/api/timeline-event endpoints."
 ---
 
 # Timeline event

--- a/docs/api/timeline.md
+++ b/docs/api/timeline.md
@@ -1,5 +1,6 @@
 ---
-title: Timeline
+title: "Timeline"
+summary: "/api/timeline endpoints."
 ---
 
 # Timeline

--- a/docs/api/timeline.md
+++ b/docs/api/timeline.md
@@ -1,3 +1,7 @@
+---
+title: Timeline
+---
+
 # Timeline
 
 /api/timeline endpoints.

--- a/docs/api/transform.md
+++ b/docs/api/transform.md
@@ -1,5 +1,5 @@
 ---
-title: Transform
+title: "Transform"
 ---
 
 # Transform

--- a/docs/api/transform.md
+++ b/docs/api/transform.md
@@ -1,3 +1,7 @@
+---
+title: Transform
+---
+
 # Transform
 
   - [GET /api/transform/:db-id/:schema/:transform-name](#get-apitransformdb-idschematransform-name)

--- a/docs/api/transform.md
+++ b/docs/api/transform.md
@@ -1,8 +1,11 @@
 ---
 title: "Transform"
+summary: "API endpoints for Transform."
 ---
 
 # Transform
+
+API endpoints for Transform.
 
   - [GET /api/transform/:db-id/:schema/:transform-name](#get-apitransformdb-idschematransform-name)
 

--- a/docs/api/user.md
+++ b/docs/api/user.md
@@ -1,5 +1,6 @@
 ---
-title: User
+title: "User"
+summary: "/api/user endpoints."
 ---
 
 # User

--- a/docs/api/user.md
+++ b/docs/api/user.md
@@ -1,3 +1,7 @@
+---
+title: User
+---
+
 # User
 
 /api/user endpoints.

--- a/docs/api/util.md
+++ b/docs/api/util.md
@@ -1,5 +1,7 @@
 ---
-title: Util
+title: "Util"
+summary: "Random utilty endpoints for things that don't belong anywhere else in particular, e.g. endpoints for certain admin
+  page tasks."
 ---
 
 # Util

--- a/docs/api/util.md
+++ b/docs/api/util.md
@@ -1,3 +1,7 @@
+---
+title: Util
+---
+
 # Util
 
 Random utilty endpoints for things that don't belong anywhere else in particular, e.g. endpoints for certain admin

--- a/docs/code-reviews.md
+++ b/docs/code-reviews.md
@@ -1,3 +1,7 @@
+---
+title: **The overall goal of a code review is to serve as a safety net for other people on our team and help them write better code, not to judge them or their code. When in doubt, assume that they have good intentions and BE NICE.**
+---
+
 **The overall goal of a code review is to serve as a safety net for other people on our team and help them write better code, not to judge them or their code. When in doubt, assume that they have good intentions and BE NICE.**
 
 ## Goals:

--- a/docs/code-reviews.md
+++ b/docs/code-reviews.md
@@ -1,8 +1,10 @@
 ---
-title: **The overall goal of a code review is to serve as a safety net for other people on our team and help them write better code, not to judge them or their code. When in doubt, assume that they have good intentions and BE NICE.**
+title: Code reviews
 ---
 
-**The overall goal of a code review is to serve as a safety net for other people on our team and help them write better code, not to judge them or their code. When in doubt, assume that they have good intentions and BE NICE.**
+# Code reviews
+
+The overall goal of a code review is to serve as a safety net for other people on our team and help them write better code, not to judge them or their code. When in doubt, assume that they have good intentions and BE NICE.
 
 ## Goals:
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,3 +1,7 @@
+---
+title: Thank you
+---
+
 ## Thank you
 
 First off, thanks for your interest in Metabase and for wanting to contribute!

--- a/docs/developers-guide-drivers.md
+++ b/docs/developers-guide-drivers.md
@@ -1,3 +1,7 @@
+---
+title: Partner and community drivers
+---
+
 # Partner and community drivers
 
 In addition to our [Officially supported drivers](./administration-guide/01-managing-databases.md#officially-supported-databases), many people build and maintain drivers for database integrations.

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1,3 +1,7 @@
+---
+title: <!-- Do not remove this file since the published HTML in the public doc
+---
+
 <!-- Do not remove this file since the published HTML in the public doc
 (https://www.metabase.com/docs/latest/developers-guide.html)
 is often referred to in various issues, discussions, etc -->

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1,7 +1,6 @@
 ---
-title: <!-- Do not remove this file since the published HTML in the public doc
+title: "Deprecated Developer's guide"
 ---
-
 <!-- Do not remove this file since the published HTML in the public doc
 (https://www.metabase.com/docs/latest/developers-guide.html)
 is often referred to in various issues, discussions, etc -->

--- a/docs/developers-guide/build.md
+++ b/docs/developers-guide/build.md
@@ -1,3 +1,7 @@
+---
+title: Building Metabase
+---
+
 # Building Metabase
 
 This doc will show you how you can build and run Metabase on your own computer so you can play around with it or test features in development. You can also run development branches of Metabase [using a pre-built Docker image](dev-branch-docker.md).
@@ -158,4 +162,3 @@ The entire Metabase application is compiled and assembled into a single .jar fil
     ./bin/build
 
 After running the build script simply look in `target/uberjar` for the output .jar file and you are ready to go.
-

--- a/docs/developers-guide/clojure.md
+++ b/docs/developers-guide/clojure.md
@@ -1,7 +1,9 @@
+---
+title: Working with Clojure
+---
+
 # Working with Clojure
 
 Check out [Clojure for the Brave and True](https://www.braveclojure.com/clojure-for-the-brave-and-true/). It's free online. 
 
-If you don't feel like reading a whole book, [Mark Volkmann's Clojure tutorial](https://objectcomputing.com/resources/publications/sett/march-2009-clojure-functional-programming-for-the-jvm) is another good starting point. 
-
-
+If you don't feel like reading a whole book, [Mark Volkmann's Clojure tutorial](https://objectcomputing.com/resources/publications/sett/march-2009-clojure-functional-programming-for-the-jvm) is another good starting point.

--- a/docs/developers-guide/contributing.md
+++ b/docs/developers-guide/contributing.md
@@ -1,3 +1,7 @@
+---
+title: Contributing
+---
+
 # Contributing
 
 In general, we like to have an open issue for every pull request as a place to discuss the nature of any bug or proposed improvement. Each pull request should address a single issue, and contain both the fix as well as a description of the pull request and tests that validate that the PR fixes the issue in question.

--- a/docs/developers-guide/dev-branch-docker.md
+++ b/docs/developers-guide/dev-branch-docker.md
@@ -1,3 +1,7 @@
+---
+title: How to run a development branch of Metabase using Docker
+---
+
 # How to run a development branch of Metabase using Docker
 
 If you want to run a branch of Metabase that's currently in development, the easiest way to get started is to use a pre-built Docker image. You can also [compile Metabase yourself](build.md).

--- a/docs/developers-guide/devenv.md
+++ b/docs/developers-guide/devenv.md
@@ -1,3 +1,7 @@
+---
+title: Development environment
+---
+
 # Development environment
 
 The Metabase application has two basic components:

--- a/docs/developers-guide/driver-changelog.md
+++ b/docs/developers-guide/driver-changelog.md
@@ -1,3 +1,7 @@
+---
+title: Driver Interface Changelog
+---
+
 # Driver Interface Changelog
 
 ## Metabase 0.43.0

--- a/docs/developers-guide/drivers/basics.md
+++ b/docs/developers-guide/drivers/basics.md
@@ -1,3 +1,7 @@
+---
+title: Database driver basics
+---
+
 # Database driver basics
 
 A Metabase driver:

--- a/docs/developers-guide/drivers/driver-tests.md
+++ b/docs/developers-guide/drivers/driver-tests.md
@@ -1,3 +1,7 @@
+---
+title: Submitting a PR for a new driver
+---
+
 # Submitting a PR for a new driver
 
 If you want to submit a PR to add a driver plugin to the [Metabase repo](https://github.com/metabase/metabase) (as opposed to keeping it in a separate repo), you'll need to:
@@ -240,4 +244,3 @@ and the steps:
 ```
 
 For more on what it is you're doing here and how all this works, see [CircleCI 2.0 Workflows](https://circleci.com/docs/2.0/workflows/).
-

--- a/docs/developers-guide/drivers/multimethods.md
+++ b/docs/developers-guide/drivers/multimethods.md
@@ -1,3 +1,7 @@
+---
+title: Implementing multimethods for your driver
+---
+
 # Implementing multimethods for your driver
 
 Implementing multimethods lets you take advantage of Metabase's existing driver code by extending those methods to work for your particular database.

--- a/docs/developers-guide/drivers/plugins.md
+++ b/docs/developers-guide/drivers/plugins.md
@@ -1,3 +1,7 @@
+---
+title: Plugin manifests
+---
+
 # Plugin manifests
 
 Metabase plugin JARs contain a _plugin manifest_ -- a top-level file named `metabase-plugin.yaml`. When Metabase launches, it iterates over every JAR in the plugins directory, and looks for the manifest in each. This manifest tells Metabase what the plugin provides and how to initialize it.

--- a/docs/developers-guide/drivers/start.md
+++ b/docs/developers-guide/drivers/start.md
@@ -1,3 +1,7 @@
+---
+title: Guide to writing a Metabase driver
+---
+
 # Guide to writing a Metabase driver
 
 So here's the scenario: you love Metabase. It's changed your life. But you have some data in a Visual Fox Pro '98 database and you need to make charts with it, and it might be a while before the core Metabase team writes a driver for Visual Fox Pro '98. No problem! Writing a driver can be fun.
@@ -32,4 +36,4 @@ Try to avoid skipping right to whichever page you think will give you the code y
 
 ## Driver development announcements
 
-Occasionally, we may make changes to Metabase that impact database drivers. We'll try to give everyone as much of a heads up as possible. For notifications regarding potential driver changes, subscribe to the [Metabase Community Authors mailing list](http://eepurl.com/gQcIO9). 
+Occasionally, we may make changes to Metabase that impact database drivers. We'll try to give everyone as much of a heads up as possible. For notifications regarding potential driver changes, subscribe to the [Metabase Community Authors mailing list](http://eepurl.com/gQcIO9).

--- a/docs/developers-guide/e2e-tests.md
+++ b/docs/developers-guide/e2e-tests.md
@@ -1,3 +1,7 @@
+---
+title: End-to-end Tests with Cypress
+---
+
 # End-to-end Tests with Cypress
 
 Metabase uses Cypress for “end-to-end testing”, that is, tests that are executed against the application as a whole, including the frontend, backend, and application database. These tests are essentially scripts written in JavaScript that run in the web browser: visit different URLs, click various UI elements, type text, and assert that things happen as expected (for example, an element appearing on screen, or a network request occuring).

--- a/docs/developers-guide/emacs.md
+++ b/docs/developers-guide/emacs.md
@@ -1,3 +1,7 @@
+---
+title: Developing Metabase with Emacs
+---
+
 # Developing Metabase with Emacs
 
 `.dir-locals.el` contains some Emacs Lisp that tells `clojure-mode` how to indent Metabase macros and which arguments are docstrings. Whenever this file is updated,
@@ -11,4 +15,3 @@ You'll probably want to tell Emacs to store customizations in a different file. 
 (ignore-errors                                                ; load customizations from ~/.emacs.d/.custom.el
   (load-file custom-file))
 ```
-

--- a/docs/developers-guide/frontend.md
+++ b/docs/developers-guide/frontend.md
@@ -1,3 +1,7 @@
+---
+title: Frontend
+---
+
 # Frontend
 
 ## Entity Loaders

--- a/docs/developers-guide/internationalization.md
+++ b/docs/developers-guide/internationalization.md
@@ -1,3 +1,7 @@
+---
+title: Internationalization
+---
+
 # Internationalization
 
 We are an application with lots of users all over the world. To help them use Metabase in their own language, we mark all of our strings as i18n.

--- a/docs/developers-guide/start.md
+++ b/docs/developers-guide/start.md
@@ -1,3 +1,7 @@
+---
+title: Developer's Guide
+---
+
 # Developer's Guide
 
 This guide contains detailed information on how to work on Metabase codebase.

--- a/docs/developers-guide/visual-studio-code.md
+++ b/docs/developers-guide/visual-studio-code.md
@@ -1,3 +1,7 @@
+---
+title: Developing with Visual Studio Code
+---
+
 ## Developing with Visual Studio Code
 
 ### Debugging
@@ -56,4 +60,3 @@ Steps:
 5. After a while (after all JavaScript and Clojure dependencies are completely downloaded), open localhost:3000 with your web browser.
 
 See [here](dev-branch-docker.md) for more on running development branches of Metabase using Docker.
-

--- a/docs/developers-guide/visual-tests.md
+++ b/docs/developers-guide/visual-tests.md
@@ -1,3 +1,7 @@
+---
+title: Visual Tests
+---
+
 # Visual Tests
 
 We use [Percy](https://percy.io/) via Github actions to run visual regression tests. Percy provides pull-request-based workflow, handles diff review and approval flow conveniently. In addition to that, It integrates with Cypress, which allows us to use all power of our custom helpers and commands. We run

--- a/docs/enterprise-guide/activating-the-enterprise-edition.md
+++ b/docs/enterprise-guide/activating-the-enterprise-edition.md
@@ -1,3 +1,7 @@
+---
+title: Activating your Metabase commercial license
+---
+
 ## Activating your Metabase commercial license
 
 The paid Pro and Enterprise editions of Metabase are distinct from the free Open Source edition, so to use your paid features you’ll need to first get a license. And if you want to self-host, you'll need a different JAR or Docker image that you can use to activate the advanced features with your license token.

--- a/docs/enterprise-guide/audit.md
+++ b/docs/enterprise-guide/audit.md
@@ -1,3 +1,7 @@
+---
+title: Audit logs
+---
+
 # Audit logs
 
 {% include plans-blockquote.html feature="Audit logs" %}

--- a/docs/enterprise-guide/authenticating-with-jwt.md
+++ b/docs/enterprise-guide/authenticating-with-jwt.md
@@ -1,3 +1,7 @@
+---
+title: JWT-based authentication
+---
+
 # JWT-based authentication
 
 {% include plans-blockquote.html feature="JWT-based authentication" %}

--- a/docs/enterprise-guide/authenticating-with-saml-azure-ad.md
+++ b/docs/enterprise-guide/authenticating-with-saml-azure-ad.md
@@ -1,3 +1,7 @@
+---
+title: Using Azure AD as the Identity Provider with Metabase and SAML
+---
+
 ## Using Azure AD as the Identity Provider with Metabase and SAML
 
 {% include plans-blockquote.html feature="SAML authentication" %}

--- a/docs/enterprise-guide/authenticating-with-saml.md
+++ b/docs/enterprise-guide/authenticating-with-saml.md
@@ -1,3 +1,7 @@
+---
+title: Authenticating with SAML
+---
+
 ## Authenticating with SAML
 
 {% include plans-blockquote.html feature="SAML authentication" %}

--- a/docs/enterprise-guide/cache.md
+++ b/docs/enterprise-guide/cache.md
@@ -1,3 +1,7 @@
+---
+title: Advanced caching controls
+---
+
 # Advanced caching controls
 
 {% include plans-blockquote.html feature="Question-specific caching" %}

--- a/docs/enterprise-guide/customizing-drill-through.md
+++ b/docs/enterprise-guide/customizing-drill-through.md
@@ -1,1 +1,5 @@
+---
+title: For customizing what happens when users click on a dashboard card, see [interactive dashboards](../users-guide/interactive-dashboards.md).
+---
+
 For customizing what happens when users click on a dashboard card, see [interactive dashboards](../users-guide/interactive-dashboards.md).

--- a/docs/enterprise-guide/customizing-drill-through.md
+++ b/docs/enterprise-guide/customizing-drill-through.md
@@ -1,5 +1,5 @@
 ---
-title: For customizing what happens when users click on a dashboard card, see [interactive dashboards](../users-guide/interactive-dashboards.md).
+title: Deprecated page
 ---
 
 For customizing what happens when users click on a dashboard card, see [interactive dashboards](../users-guide/interactive-dashboards.md).

--- a/docs/enterprise-guide/dashboard-subscriptions.md
+++ b/docs/enterprise-guide/dashboard-subscriptions.md
@@ -1,3 +1,6 @@
+---
+title: Customize filter values for each dashboard subscription
+---
 
 ## Customize filter values for each dashboard subscription
 
@@ -14,4 +17,3 @@ Here's the sidebar where you can set the filter values:
 ![Setting a filter value](./images/dashboard-subscriptions/set-filter-values.png)
 
 The section to call out here is the **Set filter values for when this gets sent**. Here we've set "VT" as the value for the dashboard's State filter to scope results to records from Vermont. We didn't set a value for the Created_At filter, so the subscription will send the results without a filter applied. If you've set a default value for the filter, the subscription will list the value here.
-

--- a/docs/enterprise-guide/data-sandboxes.md
+++ b/docs/enterprise-guide/data-sandboxes.md
@@ -1,3 +1,7 @@
+---
+title: Data sandboxes
+---
+
 # Data sandboxes
 
 {% include plans-blockquote.html feature="Data sandboxes" %}

--- a/docs/enterprise-guide/full-app-embedding.md
+++ b/docs/enterprise-guide/full-app-embedding.md
@@ -1,3 +1,7 @@
+---
+title: Embedding all of Metabase in your web app
+---
+
 ## Embedding all of Metabase in your web app
 
 {% include plans-blockquote.html feature="Full-app embedding" %}

--- a/docs/enterprise-guide/saml-auth0.md
+++ b/docs/enterprise-guide/saml-auth0.md
@@ -1,3 +1,7 @@
+---
+title: Setting up SAML with Auth0
+---
+
 # Setting up SAML with Auth0
 
 {% include plans-blockquote.html feature="SAML authentication" %}

--- a/docs/enterprise-guide/saml-google.md
+++ b/docs/enterprise-guide/saml-google.md
@@ -1,3 +1,7 @@
+---
+title: Setting up SAML with Google
+---
+
 # Setting up SAML with Google
 
 {% include plans-blockquote.html feature="Google SAML authentication" %}

--- a/docs/enterprise-guide/saml-keycloak.md
+++ b/docs/enterprise-guide/saml-keycloak.md
@@ -1,3 +1,7 @@
+---
+title: Setting up SAML with Keycloak
+---
+
 # Setting up SAML with Keycloak
 
 Keycloak is an open source platform that can be used as a user directory to save user data while acting as the IdP for single sign-on.

--- a/docs/enterprise-guide/serialization.md
+++ b/docs/enterprise-guide/serialization.md
@@ -1,5 +1,5 @@
 ---
-title: Serialization: copying contents of one Metabase instance to another
+title: "Serialization: copying contents of one Metabase instance to another"
 ---
 
 ## Serialization: copying contents of one Metabase instance to another

--- a/docs/enterprise-guide/serialization.md
+++ b/docs/enterprise-guide/serialization.md
@@ -1,3 +1,7 @@
+---
+title: Serialization: copying contents of one Metabase instance to another
+---
+
 ## Serialization: copying contents of one Metabase instance to another
 
 {% include plans-blockquote.html feature="Serialization" %}

--- a/docs/enterprise-guide/sql-snippets.md
+++ b/docs/enterprise-guide/sql-snippets.md
@@ -1,3 +1,7 @@
+---
+title: SQL snippet folders and permissions
+---
+
 # SQL snippet folders and permissions
 
 {% include plans-blockquote.html feature="SQL snippet controls" %}

--- a/docs/enterprise-guide/start.md
+++ b/docs/enterprise-guide/start.md
@@ -1,3 +1,7 @@
+---
+title: Enterprise and Pro editions
+---
+
 # Enterprise and Pro editions
 
 The [Enterprise and Pro][pricing] editions of Metabase provide additional features that help organizations scale Metabase and deliver self-service, embedded analytics.

--- a/docs/enterprise-guide/tools.md
+++ b/docs/enterprise-guide/tools.md
@@ -1,3 +1,7 @@
+---
+title: Admin tools
+---
+
 # Admin tools
 
 {% include plans-blockquote.html features="Admin tools" %}

--- a/docs/enterprise-guide/whitelabeling.md
+++ b/docs/enterprise-guide/whitelabeling.md
@@ -1,3 +1,7 @@
+---
+title: White labeling Metabase
+---
+
 ## White labeling Metabase
 
 {% include plans-blockquote.html feature="White labeling" %}

--- a/docs/information-collection.md
+++ b/docs/information-collection.md
@@ -1,3 +1,7 @@
+---
+title: About the Information we collect:
+---
+
 # About the Information we collect:
 
 Metabase uses Google Analytics and Snowplow to collect anonymous usage information from the installed servers that enable this feature. Below is a representative list of the events we have instrumented, as well as the information we collect about the user performing the action and the instance being used.

--- a/docs/information-collection.md
+++ b/docs/information-collection.md
@@ -1,8 +1,8 @@
 ---
-title: About the Information we collect:
+title: About the Information we collect
 ---
 
-# About the Information we collect:
+# About the Information we collect
 
 Metabase uses Google Analytics and Snowplow to collect anonymous usage information from the installed servers that enable this feature. Below is a representative list of the events we have instrumented, as well as the information we collect about the user performing the action and the instance being used.
 

--- a/docs/operations-guide/advanced-topics-for-running-Metabase-in-AWS-ElasticBeanstalk.md
+++ b/docs/operations-guide/advanced-topics-for-running-Metabase-in-AWS-ElasticBeanstalk.md
@@ -1,6 +1,8 @@
 ---
-title: - [Logging](logging)
+title: Advanced topics for running Metabase on Elastic Beanstalk
 ---
+
+# Advanced topics for running Metabase on Elastic Beanstalk
 
 - [Logging](#logging)
   - [Network Access log](#network-access-log)
@@ -11,7 +13,6 @@ title: - [Logging](logging)
   - [Setup DNS CNAME (using AWS)](#setup-dns-cname-using-aws)
   - [Modify Metabase to enforce HTTPS](#modify-metabase-to-enforce-https)
 
-# Logging
 ## Network Access log
 
 If you need a log of all the IP addresses and URLs that were accessed during a specific period, you can configure the Load Balancer to send those logs to S3. This is useful for analyzing the traffic to your Metabase instance.

--- a/docs/operations-guide/advanced-topics-for-running-Metabase-in-AWS-ElasticBeanstalk.md
+++ b/docs/operations-guide/advanced-topics-for-running-Metabase-in-AWS-ElasticBeanstalk.md
@@ -12,14 +12,19 @@ title: Advanced topics for running Metabase on Elastic Beanstalk
   - [Upload a Server Certificate](#upload-a-server-certificate)
   - [Setup DNS CNAME (using AWS)](#setup-dns-cname-using-aws)
   - [Modify Metabase to enforce HTTPS](#modify-metabase-to-enforce-https)
+- [RAM usage monitoring](#ram-usage-monitoring)
+- [Automated security assessment](#automated-security-assessment)
+- [About NGINX configs inside Elastic Beanstalk deployments](#about-nginx-configs-inside-elastic-beanstalk-deployments)
 
-## Network Access log
+## Logging
+
+### Network Access log
 
 If you need a log of all the IP addresses and URLs that were accessed during a specific period, you can configure the Load Balancer to send those logs to S3. This is useful for analyzing the traffic to your Metabase instance.
 
 To enable this logging, you have to go to the settings of the Load Balancer and enable **Store Logs** in the **Access Log Files** section. You will need to choose an S3 bucket to dump the logs in, and a prefix that will identify the logs coming from this load balancer.
 
-## Application Logs
+### Application Logs
 
 If you want to retain the Metabase application logs, you can publish them to an S3 bucket:
 
@@ -29,7 +34,7 @@ If you want to retain the Metabase application logs, you can publish them to an 
 
 You'll need to wait a minute for the logging to kick in, but then you should be good to go. Elastic Beanstalk will now periodically publish the application log files to S3, which you can download whenever you need to analyze them.
 
-## Using Papertrail for logging on AWS
+### Using Papertrail for logging on AWS
 
 You can also use the [Papertrail logging service](https://www.papertrail.com/) for collecting your application logs.
 
@@ -43,11 +48,11 @@ You can also use the [Papertrail logging service](https://www.papertrail.com/) f
 
 _NOTE: Sometimes these settings will not apply until you restart your application server, which you can do by either choosing `Restart App Server(s)` from the Actions dropdown or by deploying the same version again._
 
-# Running Metabase over HTTPS
+## Running Metabase over HTTPS
 
 There is no requirement to run Metabase over HTTPS, but we are sticklers for security and believe you should always be careful with your data. Here's how to set up HTTPS on AWS.
 
-## Upload a Server Certificate
+### Upload a Server Certificate
 
 First, you need to open a new tab in your browser and search for AWS certificate manager in your AWS Dashboard. Once inside, you have the options for provisioning certificates or become a private certificate authority. We will choose `Provision certificates` and we will click on `Get Started`.
 
@@ -55,27 +60,27 @@ A blue button will appear on the top of the page with the feature to import cert
 
 Follow the steps to input your certificates details. Once you submit your certificate details, you'll see the certificate in other tools of AWS (like HTTPS on your load balancer).
 
-## Setup DNS CNAME (using AWS)
+### Setup DNS CNAME (using AWS)
 
 - Open up AWS **Route 53** by navigating to **Services > Networking > Route 53** in the AWS Console header.
 - Click on **Hosted Zones**, then click on the domain name you want to use for Metabase.
 - Click on the blue button **Create Record** (a new panel will open up).
   - Enter in a **Record name**: for your application. This record name should be the exact URL you plan to access Metabase with (e.g. `metabase.mycompany.com`).
   - Under the dropdown for **Record type**: select _A – Routes traffic to an IPv4 address and some AWS resources_.
-  - Enable the **Alias** switch. For the **Route traffic to** option, select __Alias to Application and Classic Load Balancer__, region __US East (Ohio) [us-east-2]__, or the one that you deployed your instance to (e.g. `mycompany-metabase.elasticbeanstalk.com`).
+  - Enable the **Alias** switch. For the **Route traffic to** option, select **Alias to Application and Classic Load Balancer**, region **US East (Ohio) [us-east-2]**, or the one that you deployed your instance to (e.g. `mycompany-metabase.elasticbeanstalk.com`).
   - Choose the load balancer that corresponds to your instance.
   - Leave all other settings in their default values.
   - At the bottom of the page, click **Create Record** .
- 
+
 After creating the record, the record can take ten minutes (sometimes longer) to propagate on the Internet.
 
-## Modify Metabase to enforce HTTPS
+### Modify Metabase to enforce HTTPS
 
 Before trying to enable HTTPS support, you must upload a server certificate to your AWS account.
 
 - Go to Elastic Beanstalk and select your **Metabase** application.
 - Click on Environment that you would like to update.
-- One the left sidebar, click **Configuration**. 
+- One the left sidebar, click **Configuration**.
 - Scroll down to **Load Balancer** and click the Edit button on the right of the screen.
 - On Listeners section, click on **Add Listener** and change the Protocol to HTTPS on the modal window that opens.
 - Set the value for **Port** to 443.
@@ -85,8 +90,8 @@ Before trying to enable HTTPS support, you must upload a server certificate to y
 - Scroll to the bottom of the page and click **Save**.
 
 Your Environment will begin updating with your new change. You will have to wait for this to complete before making additional updates.
- 
- Once this change is made you will no longer be able to access your Metabase instance at the *.elasticbeanstalk.com URL provided by Amazon because it will result in a certificate mismatch. To continue accessing your secure Metabase instance you must [Set up a DNS CNAME](#setup-dns-cname-using-aws).
+
+Once this change is made you will no longer be able to access your Metabase instance at the \*.elasticbeanstalk.com URL provided by Amazon because it will result in a certificate mismatch. To continue accessing your secure Metabase instance you must [Set up a DNS CNAME](#setup-dns-cname-using-aws).
 
 Once your application is working properly over HTTPS, we recommend setting an additional property to force non-HTTPS clients to use the HTTPS endpoint.
 
@@ -95,7 +100,7 @@ Once your application is working properly over HTTPS, we recommend setting an ad
 - Under **Environment Properties** add an entry for `NGINX_FORCE_SSL` with a value of `1`.
 - Scroll to the bottom of the page and click **Apply** in the lower right, then wait for your application to update.
 - Click on `Configuration` on the left hand sidebar.
-- One the left sidebar, click **Configuration**. 
+- One the left sidebar, click **Configuration**.
 - Scroll down to `Load Balancer` and click the Edit button on the right of the screen.
 - On Listeners section, click on "Add Listener" and change the Protocol to HTTPS on the modal window that opens.
 - Set the value for `Port` to _443_.
@@ -113,16 +118,16 @@ Once your application is working properly over HTTPS, we recommend setting an ad
 - Under `Environment Properties` add an entry for `NGINX_FORCE_SSL` with a value of `1`.
 - Scroll to the bottom of the page and click `Apply` in the lower right, then wait for your application to update.
 
-# RAM usage monitoring
+## RAM usage monitoring
 
 Metabase installs the CloudWatch agent into the Elastic Beanstalk deployment, which sends data about your deployment to CloudWatch, allowing you to track your Metabase's RAM usage and other metrics.
 
 To set up CloudWatch for your Elastic Beanstalk environment, follow the steps in the AWS documentation to [grant permissions to publish CloudWatch metrics](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/customize-containers-cw.html#customize-containers-cw-policy).
 
-# Automated security assessment
+## Automated security assessment
 
 Metabase installs the AWS Inspector into the Elastic Beanstalk deployment, so you can have real-time assessments about your instance's security that you can integrate into other AWS products. To start the automated checks on your instance, you only need to enable the Inspector in AWS's console.
 
-# About NGINX configs inside Elastic Beanstalk deployments
+## About NGINX configs inside Elastic Beanstalk deployments
 
 In the near future we will be removing the custom NGINX configuration that was being bundled with Metabase in the previous configurations, so in the case that you were using configurations like NGINX_FORCE_SSL or custom certificates, you will need to move these configurations to AWS Application Load Balancers. To do this, check out the [enabling VPC](https://www.metabase.com/docs/latest/operations-guide/running-metabase-on-elastic-beanstalk.html#22-enabling-vpc) part of the Elastic Beanstalk guide where it's specified how to use an Application Load Balancer with your Elastic Beanstalk configuration, or otherwise start over the creation of your Elastic Beanstalk deployment [having made a backup first](backing-up-metabase-application-data.html) of your application database so you don't lose your Metabase configuration.

--- a/docs/operations-guide/advanced-topics-for-running-Metabase-in-AWS-ElasticBeanstalk.md
+++ b/docs/operations-guide/advanced-topics-for-running-Metabase-in-AWS-ElasticBeanstalk.md
@@ -1,3 +1,7 @@
+---
+title: - [Logging](logging)
+---
+
 - [Logging](#logging)
   - [Network Access log](#network-access-log)
   - [Application Logs](#application-logs)

--- a/docs/operations-guide/backing-up-metabase-application-data.md
+++ b/docs/operations-guide/backing-up-metabase-application-data.md
@@ -1,3 +1,7 @@
+---
+title: Backing up Metabase application data
+---
+
 # Backing up Metabase application data
 
 Avoid losing your application data (all of your questions, dashboards, collections and so on) by backing up your data.

--- a/docs/operations-guide/changing-password-complexity.md
+++ b/docs/operations-guide/changing-password-complexity.md
@@ -1,3 +1,7 @@
+---
+title: Changing Metabase password complexity
+---
+
 # Changing Metabase password complexity
 
 Metabase offers a couple controls for administrators who prefer to increase the password requirements on their user accounts.

--- a/docs/operations-guide/changing-session-expiration.md
+++ b/docs/operations-guide/changing-session-expiration.md
@@ -1,3 +1,7 @@
+---
+title: Changing session expiration
+---
+
 # Changing session expiration
 
 By default, Metabase sessions are valid for two weeks after a user last authenticated (e.g. by entering their email

--- a/docs/operations-guide/configuring-application-database.md
+++ b/docs/operations-guide/configuring-application-database.md
@@ -1,3 +1,7 @@
+---
+title: Configuring the Metabase Application Database
+---
+
 # Configuring the Metabase Application Database
 
 The application database is where Metabase stores information about users, saved questions, dashboards, and any other

--- a/docs/operations-guide/creating-RDS-database-on-AWS.md
+++ b/docs/operations-guide/creating-RDS-database-on-AWS.md
@@ -1,3 +1,7 @@
+---
+title: - [Configuring RDS for Metabase (the recommended guide)](configuring-rds-for-metabase-the-recommended-guide)
+---
+
 - [Configuring RDS for Metabase (the recommended guide)](#configuring-rds-for-metabase-the-recommended-guide)
   - [Step 1](#step-1)
   - [Step 2](#step-2)

--- a/docs/operations-guide/creating-RDS-database-on-AWS.md
+++ b/docs/operations-guide/creating-RDS-database-on-AWS.md
@@ -1,10 +1,10 @@
 ---
-title: "Configuring RDS for Metabase"
+title: "Creating RDS database on AWS"
 ---
 
-# Configuring RDS for Metabase
+# Creating RDS database on AWS
 
-- [Configuring RDS for Metabase (the recommended guide)](#configuring-rds-for-metabase-the-recommended-guide)
+- [Configuring RDS for Metabase](#configuring-rds-for-metabase)
   - [Step 1](#step-1)
   - [Step 2](#step-2)
   - [Step 3](#step-3)
@@ -14,38 +14,44 @@ title: "Configuring RDS for Metabase"
   - [Step 2](#step-2-1)
   - [Step 3](#step-3-1)
 
+## Configuring RDS for Metabase
+
 If you want to move from using Metabase just for testing to something that is ready for the big time, you need to use a production-grade database like PostgreSQL or MySQL/MariaDB. Here's a [high level architecture diagram](images/Metabase-AWS-SI.png) of Metabase deployed with a dedicated application database.
 
 ## Step 1
+
 In AWS, enter RDS in the search box or select RDS from the dropdown button on the top left of the page. Once inside RDS, click on the **Create database** button.
 
 ## Step 2
+
 - Create Database: select MySQL or PostgreSQL as engine types, as these two are the ones that Metabase support as the Application Database (where Metabase will save all of its configurations). For this example we will choose PostgreSQL on its latest version available in AWS at the time of writing (12.4-R1).
 
 - Templates: you can leave "Production" selected, or choose any other option that better suits your needs.
 
 - Settings: type a unique **DB instance identifier** for your database. You'll need the username and master password to configure the environment variables in Metabase.
-![RDS Templates Section](images/RDSPostgresSettings.png)
+  ![RDS Templates Section](images/RDSPostgresSettings.png)
 
 - Instance size: the sizing of the RDS instance depends on the number of Metabase instances that will be connected to this database, the number of simultaneous users who are using Metabase, and the number of questions, dashboards, and configurations that are saved. To start, a `t3.small` is a good choice.
-![RDS Instance size](images/RDSInstanceSize.png)
+  ![RDS Instance size](images/RDSInstanceSize.png)
 
-- Availability & Durability: on production deployments, you __should__ be using a Multi-AZ (Availability Zone) cluster, as this will ensure that the database does not goes down in case there is an issue on a single availability zone.
-![RDS MultiAZ](images/RDSMultiAZ.png)
+- Availability & Durability: on production deployments, you **should** be using a Multi-AZ (Availability Zone) cluster, as this will ensure that the database does not goes down in case there is an issue on a single availability zone.
+  ![RDS MultiAZ](images/RDSMultiAZ.png)
 
-- Connectivity: 
-  - Ensure that you are deploying the database in the same VPC as the one you deployed the Metabase instance/s, otherwise they won't be able to see each other. 
+- Connectivity:
+
+  - Ensure that you are deploying the database in the same VPC as the one you deployed the Metabase instance/s, otherwise they won't be able to see each other.
   - Create a **VPC security group**, as you will need to grant access from the Metabase instance/s to the database on the port that listens for connections.
-![RDS VPC Security Groups](images/RDSVPCSecurityGroup.png)
+    ![RDS VPC Security Groups](images/RDSVPCSecurityGroup.png)
 
 - Additional configuration
-  - Enter `metabase` as the **Initial database name**. Metabase will use this database for all of its configurations. 
+  - Enter `metabase` as the **Initial database name**. Metabase will use this database for all of its configurations.
   - You can also configure the backup window in case you need to restore the backups at some point in time.
-![RDS Initial Database](images/RDSInitialDatabase.png)
+    ![RDS Initial Database](images/RDSInitialDatabase.png)
 
 When you've completed all these configurations, click on the **Create database** button on the lower right part of the page and wait for the database to be created (which can take several minutes).
 
 ## Step 3
+
 Once the database status is `Available`, you need to click on the DB identifier:
 ![RDS DB Identifier](images/RDSDBIdentifier.png)
 
@@ -64,40 +70,44 @@ When you click on Inbound Rules, you need to click on **Edit Inbound Rules** but
 
 ![RDS Edit Inbound Rule](images/RDSEditInboundRule.png)
 
-On the edit page, you need to delete the IP address that appears as default, then add the security group that the Elastic Beanstalk has (the Security group name will have the keyword AWSEBSecurityGroup  in its name). Once you add this security group, click the **Save rules** button.
+On the edit page, you need to delete the IP address that appears as default, then add the security group that the Elastic Beanstalk has (the Security group name will have the keyword AWSEBSecurityGroup in its name). Once you add this security group, click the **Save rules** button.
 
 ![RDS Edit Inbound Rule](images/RDSEditInboundRuleSG.png)
 
-# Step 4 
+# Step 4
 
 After having finished all the previous steps, go to the your Elastic Beanstalk deployment and add the RDS instance as the Application Database with [Environment variables](environment-variables.html) under the [Software configuration](running-metabase-on-elastic-beanstalk.html#set-or-change-environment-variables).
 
 ---
+
 # Decouple your RDS database from the Elastic Beanstalk deployment
 
 In the previous versions of this guide, we recommended the creation of an Elastic Beanstalk deployment (AWS's service for deploying applications easily) that had a RDS (AWS's Relational Database Service) database included in the creation by default thanks to the magic of CloudFormation (AWS's Infrastructure as a Code service). While this was an easier approach to simplify the deployments, we found out that this approach was not the optimal for building a future-proof architecture, since leaving the creation of the database to Elastic Beanstalk lead to limitations in the configuration of the database that would limit the choice for users. That's the reason why we now recommend creating the database separately from the Metabase deployment and glue them together manually, or even separate both components with this guide:
-
 
 - This procedure will generate downtime, so make sure to communicate to your users that Metabase will be down while you recreate the environment with the new database.
 - You'll need the master username and password for the database you used when you created the Elastic Beanstalk instance.
 
 ## Step 1
+
 Identify the RDS endpoint that your Elastic Beanstalk is using by going to the configuration of the Environment and finding the endpoint value on the Database section.
 ![RDS endpooint](images/EBDatabaseEndpoint.png)
+
 - If the Retention option is "Create snapshot", you're good to go. You can delete the whole Elastic Beanstalk environment, because AWS will take a snapshot (backup) of the database before deleting the environment.
 - In case the Retention option has a different value, visit your RDS instance and take a snapshot of the database used by the Elastic Beanstalk application.
-![RDS snapshot](images/RDSTakeSnapshot.png)
+  ![RDS snapshot](images/RDSTakeSnapshot.png)
 
 ## Step 2
-Go to the Elastic Beanstalk Metabase Application, select the running environment, and terminate it. Confirm that the database will be terminated __with snapshot__)
+
+Go to the Elastic Beanstalk Metabase Application, select the running environment, and terminate it. Confirm that the database will be terminated **with snapshot**)
 ![Terminate environment](images/EBTerminateEnvironment.png)
 
 This step can take around 20 minutes. If the deletion fails, you'll have to identify through CloudFormation which resources failed to be deleted and delete them yourself.
 
 ## Step 3
+
 Return to RDS and select the **Snapshots** option on the left of the page. You should see a Manual Snapshot listed.
 ![RDS Snapshots](images/RDSSnapshotsMenu.png)
 
 Select that snapshot and click on **Actions** → Restore Snapshot.
 
-From this step on, you can follow the same steps as the [Configuring RDS for Metabase (the recommended guide)](#configuring-rds-for-metabase-the-recommended-guide) from [step 2](#step-2).
+From this step on, you can follow the same steps as the [Configuring RDS for Metabase](#configuring-rds-for-metabase) from [step 2](#step-2).

--- a/docs/operations-guide/creating-RDS-database-on-AWS.md
+++ b/docs/operations-guide/creating-RDS-database-on-AWS.md
@@ -1,6 +1,8 @@
 ---
-title: - [Configuring RDS for Metabase (the recommended guide)](configuring-rds-for-metabase-the-recommended-guide)
+title: "Configuring RDS for Metabase"
 ---
+
+# Configuring RDS for Metabase
 
 - [Configuring RDS for Metabase (the recommended guide)](#configuring-rds-for-metabase-the-recommended-guide)
   - [Step 1](#step-1)
@@ -11,8 +13,6 @@ title: - [Configuring RDS for Metabase (the recommended guide)](configuring-rds-
   - [Step 1](#step-1-1)
   - [Step 2](#step-2-1)
   - [Step 3](#step-3-1)
-
-# Configuring RDS for Metabase (the recommended guide)
 
 If you want to move from using Metabase just for testing to something that is ready for the big time, you need to use a production-grade database like PostgreSQL or MySQL/MariaDB. Here's a [high level architecture diagram](images/Metabase-AWS-SI.png) of Metabase deployed with a dedicated application database.
 

--- a/docs/operations-guide/customizing-jetty-webserver.md
+++ b/docs/operations-guide/customizing-jetty-webserver.md
@@ -1,3 +1,7 @@
+---
+title: Customizing the Metabase Jetty webserver
+---
+
 # Customizing the Metabase Jetty webserver
 
 In most cases there will be no reason to modify any of the settings around how Metabase runs its embedded Jetty webserver to host the application, but if you wish to run HTTPS directly with your Metabase server or if you need to run on another port, that's all configurable.

--- a/docs/operations-guide/enable-jmx.md
+++ b/docs/operations-guide/enable-jmx.md
@@ -1,3 +1,6 @@
+---
+title: Monitoring Your Metabase Instance
+---
 
 ## Monitoring Your Metabase Instance
 

--- a/docs/operations-guide/encrypting-database-details-at-rest.md
+++ b/docs/operations-guide/encrypting-database-details-at-rest.md
@@ -1,3 +1,7 @@
+---
+title: Encrypting your database connection details at rest
+---
+
 # Encrypting your database connection details at rest
 
 Metabase stores connection information for the various databases you add in the Metabase application database. To prevent bad actors from being able to access these details if they were to gain access to

--- a/docs/operations-guide/environment-variables.md
+++ b/docs/operations-guide/environment-variables.md
@@ -1,3 +1,7 @@
+---
+title: Environment variables
+---
+
 # Environment variables
 
 Many settings in Metabase can be viewed and modified in the Admin Panel, or set via environment variables. The environment variables always take precedence. Note that the environment variables won't get written into the application database.

--- a/docs/operations-guide/handling-timezones.md
+++ b/docs/operations-guide/handling-timezones.md
@@ -1,3 +1,7 @@
+---
+title: Handling timezones in Metabase
+---
+
 # Handling timezones in Metabase
 
 Metabase does its best to ensure proper and accurate reporting in whatever timezone you desire, but timezones are a complicated beast so it's important to abide by some recommendations listed below to ensure your reports come out as intended.

--- a/docs/operations-guide/installing-metabase.md
+++ b/docs/operations-guide/installing-metabase.md
@@ -1,3 +1,7 @@
+---
+title: Installing Metabase
+---
+
 # Installing Metabase
 
 Metabase is built and packaged as a Java JAR file and can be run anywhere that Java is available.

--- a/docs/operations-guide/java-versions.md
+++ b/docs/operations-guide/java-versions.md
@@ -1,3 +1,7 @@
+---
+title: Java Versions
+---
+
 # Java Versions
 
 Metabase requires a Java Runtime Environment (JRE), with a Java version of 11 or higher.

--- a/docs/operations-guide/jmx-monitoring.md
+++ b/docs/operations-guide/jmx-monitoring.md
@@ -1,3 +1,7 @@
+---
+title: [Monitoring via JMX](enable-jmx.md)
+---
+
 # [Monitoring via JMX](enable-jmx.md)
 
 Diagnosing performance related issues can be a challenge. Luckily the JVM ships with tools that can help diagnose many common issues. Enabling JMX and using a tool like VisualVM can help diagnose issues related to running out of memory, a hung Metabase instance and slow response times. See [Monitoring via JMX](enable-jmx.md) for more information on setting this up.

--- a/docs/operations-guide/jmx-monitoring.md
+++ b/docs/operations-guide/jmx-monitoring.md
@@ -1,7 +1,9 @@
 ---
-title: [Monitoring via JMX](enable-jmx.md)
+title: Monitoring via JMX
 ---
 
-# [Monitoring via JMX](enable-jmx.md)
+# Monitoring via JMX
 
-Diagnosing performance related issues can be a challenge. Luckily the JVM ships with tools that can help diagnose many common issues. Enabling JMX and using a tool like VisualVM can help diagnose issues related to running out of memory, a hung Metabase instance and slow response times. See [Monitoring via JMX](enable-jmx.md) for more information on setting this up.
+Diagnosing performance related issues can be a challenge. Luckily the JVM ships with tools that can help diagnose many common issues. Enabling JMX and using a tool like VisualVM can help diagnose issues related to running out of memory, a hung Metabase instance and slow response times.
+
+See [Monitoring via JMX](enable-jmx.md).

--- a/docs/operations-guide/log-configuration.md
+++ b/docs/operations-guide/log-configuration.md
@@ -1,3 +1,7 @@
+---
+title: Metabase logs
+---
+
 # Metabase logs
 
 Metabase logs quite a bit of information by default. It uses [Log4j 2][log4j] under the hood, so you can configure how much information Metabase logs.
@@ -66,4 +70,4 @@ java -jar metabase.jar
 [default-log-config]: https://github.com/metabase/metabase/blob/master/resources/log4j2.xml
 [levels]: https://logging.apache.org/log4j/2.x/manual/customloglevels.html
 [log4j]: https://logging.apache.org/log4j/2.x/
-[read-logs]: ../troubleshooting-guide/server-logs.html 
+[read-logs]: ../troubleshooting-guide/server-logs.html

--- a/docs/operations-guide/migrating-from-h2.md
+++ b/docs/operations-guide/migrating-from-h2.md
@@ -1,3 +1,7 @@
+---
+title: Migrating from the default H2 database to a production database
+---
+
 # Migrating from the default H2 database to a production database
 
 - [Metabase's application database](#metabases-application-database)

--- a/docs/operations-guide/running-metabase-on-azure.md
+++ b/docs/operations-guide/running-metabase-on-azure.md
@@ -1,3 +1,7 @@
+---
+title: Running Metabase on Microsoft Azure
+---
+
 # Running Metabase on Microsoft Azure
 
 This guide covers the basics for running your Metabase instance in Microsoft Azure using Docker.

--- a/docs/operations-guide/running-metabase-on-debian.md
+++ b/docs/operations-guide/running-metabase-on-debian.md
@@ -1,3 +1,7 @@
+---
+title: Running Metabase on Debian as a service with nginx
+---
+
 # Running Metabase on Debian as a service with nginx
 
 For those people who don't (or can't) use Docker in their infrastructure, there's still a need to easily setup and deploy Metabase in production. On Debian-based systems, this means registering Metabase as a service that can be started/stopped/uninstalled.
@@ -161,4 +165,3 @@ sudo systemctl start metabase.service
 sudo systemctl stop metabase.service
 sudo systemctl restart metabase.service
 ```
-

--- a/docs/operations-guide/running-metabase-on-docker.md
+++ b/docs/operations-guide/running-metabase-on-docker.md
@@ -1,3 +1,7 @@
+---
+title: Running Metabase on Docker
+---
+
 # Running Metabase on Docker
 
 Metabase provides an official Docker image via Dockerhub that can be used for deployments on any system that is running Docker.

--- a/docs/operations-guide/running-metabase-on-elastic-beanstalk.md
+++ b/docs/operations-guide/running-metabase-on-elastic-beanstalk.md
@@ -1,3 +1,7 @@
+---
+title: **Covered in this guide:**
+---
+
 **Covered in this guide:**
 
 - [Running Metabase on AWS Elastic Beanstalk](#running-metabase-on-aws-elastic-beanstalk)

--- a/docs/operations-guide/running-metabase-on-elastic-beanstalk.md
+++ b/docs/operations-guide/running-metabase-on-elastic-beanstalk.md
@@ -1,8 +1,8 @@
 ---
-title: **Covered in this guide:**
+title: Running Metabase on AWS Elastic Beanstalk
 ---
 
-**Covered in this guide:**
+# Running Metabase on AWS Elastic Beanstalk
 
 - [Running Metabase on AWS Elastic Beanstalk](#running-metabase-on-aws-elastic-beanstalk)
   - [Quick Launch](#quick-launch)
@@ -22,9 +22,6 @@ title: **Covered in this guide:**
   - [Set or change environment variables](#set-or-change-environment-variables)
   - [Notifications](#notifications)
 - [Deploying New Versions of Metabase on Elastic Beanstalk](#deploying-new-versions-of-metabase-on-elastic-beanstalk)
-
-# Running Metabase on AWS Elastic Beanstalk
-
 
 This quick launch setup is intended for testing purposes only, and is not intended for production use. We'll focus on deploying Metabase with a single instance and the embedded H2 database with the following components:
 - a region (where your Metabase application will exist)

--- a/docs/operations-guide/running-metabase-on-heroku.md
+++ b/docs/operations-guide/running-metabase-on-heroku.md
@@ -1,3 +1,7 @@
+---
+title: Running Metabase on Heroku
+---
+
 # Running Metabase on Heroku
 
 Currently in beta. We've run Metabase on Heroku and it works just fine, but it's not hardened for production use just yet. If you're up for it then give it a shot and let us know how we can make it better!

--- a/docs/operations-guide/running-migrations-manually.md
+++ b/docs/operations-guide/running-migrations-manually.md
@@ -1,3 +1,7 @@
+---
+title: Running Metabase database migrations manually
+---
+
 # Running Metabase database migrations manually
 
 When Metabase is starting up, it will typically attempt to determine if any changes are required to the application database, and, if so, will execute those changes automatically. If for some reason you wanted to see what these changes are and run them manually on your database then we let you do that.

--- a/docs/operations-guide/running-the-metabase-jar-file.md
+++ b/docs/operations-guide/running-the-metabase-jar-file.md
@@ -1,3 +1,7 @@
+---
+title: Running the Metabase JAR file
+---
+
 # Running the Metabase JAR file
 
 To run Metabase via a JAR file, you will need to have a Java Runtime Environment (JRE) installed on your system.

--- a/docs/operations-guide/start.md
+++ b/docs/operations-guide/start.md
@@ -1,3 +1,7 @@
+---
+title: Operations Guide
+---
+
 # Operations Guide
 
 This guide contains detailed information about how to install and configure Metabase for production use. If you'd prefer we take care of the details of running Metabase for you, check out our [paid plans](https://www.metabase.com/pricing/).

--- a/docs/operations-guide/upgrading-metabase.md
+++ b/docs/operations-guide/upgrading-metabase.md
@@ -1,3 +1,7 @@
+---
+title: Upgrading Metabase
+---
+
 # Upgrading Metabase
 
 ## Step 1: Back up your application database

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -1,3 +1,7 @@
+---
+title: Privacy
+---
+
 # Privacy 
 
 ## Do you need a Data Processing Agreement with Metabase to comply with GDPR?

--- a/docs/setting-up-metabase.md
+++ b/docs/setting-up-metabase.md
@@ -1,3 +1,7 @@
+---
+title: Setting up Metabase
+---
+
 # Setting up Metabase
 
 This guide will help you set up Metabase once you’ve gotten it installed. If you haven’t installed Metabase yet, you can [get Metabase here](https://metabase.com/start/).

--- a/docs/troubleshooting-guide/bigquery-drive.md
+++ b/docs/troubleshooting-guide/bigquery-drive.md
@@ -1,3 +1,7 @@
+---
+title: Troubleshooting BigQuery and Google Drive connections in Metabase
+---
+
 # Troubleshooting BigQuery and Google Drive connections in Metabase
 
 [This page](../administration-guide/databases/bigquery) explains how to connect a BigQuery data source, including one that uses a file stored in Google Drive, like a Google Sheet (GSheets). 

--- a/docs/troubleshooting-guide/bugs.md
+++ b/docs/troubleshooting-guide/bugs.md
@@ -1,3 +1,7 @@
+---
+title: Reporting a bug
+---
+
 # Reporting a bug
 
 If you come across something that looks like a bug, please start by searching our [Github issues][metabase-issues] to see if it has already been reported. If it has, please let us know you're experiencing the same issue by reacting with a thumbs up emoji or adding a comment providing additional information.

--- a/docs/troubleshooting-guide/cant-log-in.md
+++ b/docs/troubleshooting-guide/cant-log-in.md
@@ -1,3 +1,7 @@
+---
+title: People can't log in to Metabase
+---
+
 # People can't log in to Metabase
 
 ## Do you know how your logins are managed?

--- a/docs/troubleshooting-guide/cant-see-tables.md
+++ b/docs/troubleshooting-guide/cant-see-tables.md
@@ -1,3 +1,7 @@
+---
+title: I can't see my tables
+---
+
 # I can't see my tables
 
 You have connected Metabase to a database, but:

--- a/docs/troubleshooting-guide/cant-send-email.md
+++ b/docs/troubleshooting-guide/cant-send-email.md
@@ -1,3 +1,7 @@
+---
+title: Metabase isn't sending email
+---
+
 # Metabase isn't sending email
 
 You have told Metabase to send email notifications, but:

--- a/docs/troubleshooting-guide/datawarehouse.md
+++ b/docs/troubleshooting-guide/datawarehouse.md
@@ -1,3 +1,7 @@
+---
+title: Connecting to databases
+---
+
 # Connecting to databases
 
 <div class='doc-toc' markdown=1>

--- a/docs/troubleshooting-guide/docker.md
+++ b/docs/troubleshooting-guide/docker.md
@@ -1,3 +1,7 @@
+---
+title: Running Metabase on Docker
+---
+
 # Running Metabase on Docker
 
 <div class='doc-toc' markdown=1>

--- a/docs/troubleshooting-guide/error-message.md
+++ b/docs/troubleshooting-guide/error-message.md
@@ -1,3 +1,7 @@
+---
+title: Different types of error messages
+---
+
 # Different types of error messages
 
 - [API error messages][api-error-message]
@@ -26,4 +30,3 @@
 [discourse-search-metabase-error]: https://discourse.metabase.com/search?q=metabase%20error%20message
 [metabase-error-message]: #metabase-error-messages
 [sql-editor]: /glossary/native_query_editor.html
-

--- a/docs/troubleshooting-guide/filters.md
+++ b/docs/troubleshooting-guide/filters.md
@@ -1,3 +1,7 @@
+---
+title: My dashboard filters don't work
+---
+
 # My dashboard filters don't work
 
 You've tried to add a [filter widget][filter-widget-gloss] to your dashboard, but:

--- a/docs/troubleshooting-guide/index.md
+++ b/docs/troubleshooting-guide/index.md
@@ -1,3 +1,7 @@
+---
+title: What are you having trouble with?
+---
+
 # What are you having trouble with?
 
 This page collects resources for getting you unstuck.

--- a/docs/troubleshooting-guide/ldap.md
+++ b/docs/troubleshooting-guide/ldap.md
@@ -1,3 +1,7 @@
+---
+title: LDAP
+---
+
 # LDAP
 
 <div class='doc-toc' markdown=1>

--- a/docs/troubleshooting-guide/linked-filters.md
+++ b/docs/troubleshooting-guide/linked-filters.md
@@ -1,3 +1,7 @@
+---
+title: My linked filters don't work
+---
+
 # My linked filters don't work
 
 You have created a [linked filter][linked-filter-gloss] so that (for example) if a dashboard contains both a "State" and a "City" filter, the "City" filter only shows cities in the state selected by the "State" filter. However:

--- a/docs/troubleshooting-guide/loading-from-h2.md
+++ b/docs/troubleshooting-guide/loading-from-h2.md
@@ -1,3 +1,7 @@
+---
+title: Using or migrating from an H2 application database
+---
+
 # Using or migrating from an H2 application database
 
 You have installed Metabase, but:

--- a/docs/troubleshooting-guide/my-dashboard-is-slow.md
+++ b/docs/troubleshooting-guide/my-dashboard-is-slow.md
@@ -1,3 +1,7 @@
+---
+title: My dashboard is slow
+---
+
 # My dashboard is slow
 
 You have created a dashboard that shows the right things but:

--- a/docs/troubleshooting-guide/permissions.md
+++ b/docs/troubleshooting-guide/permissions.md
@@ -1,3 +1,7 @@
+---
+title: Fixing permissions issues
+---
+
 # Fixing permissions issues
 
 This troubleshooting guide has you covered if you've [connected your database][connecting-database] to Metabase, set up [groups][groups] for new people, and granted [data permissions][data-permissions] and [collection permissions][setting-collection-permissions] to those groups, but:

--- a/docs/troubleshooting-guide/proxies.md
+++ b/docs/troubleshooting-guide/proxies.md
@@ -1,3 +1,7 @@
+---
+title: Can't save questions or dashboards, or getting a blank page
+---
+
 # Can't save questions or dashboards, or getting a blank page
 
 <div class='doc-toc' markdown=1>

--- a/docs/troubleshooting-guide/requesting-new-features.md
+++ b/docs/troubleshooting-guide/requesting-new-features.md
@@ -1,3 +1,7 @@
+---
+title: How to request new features
+---
+
 # How to request new features
 
 1. Check out the [issues in the github repo][github-issues] to make sure someone hasn't already requested the feature.

--- a/docs/troubleshooting-guide/running.md
+++ b/docs/troubleshooting-guide/running.md
@@ -1,3 +1,7 @@
+---
+title: Running Metabase
+---
+
 # Running Metabase
 
 <div class='doc-toc' markdown=1>

--- a/docs/troubleshooting-guide/saml.md
+++ b/docs/troubleshooting-guide/saml.md
@@ -1,3 +1,7 @@
+---
+title: Troubleshooting SAML authentication setup
+---
+
 # Troubleshooting SAML authentication setup
 
 {% include plans-blockquote.html feature="SAML authentication" %}

--- a/docs/troubleshooting-guide/sandboxing.md
+++ b/docs/troubleshooting-guide/sandboxing.md
@@ -1,3 +1,7 @@
+---
+title: Troubleshooting sandbox access to rows and columns
+---
+
 # Troubleshooting sandbox access to rows and columns
 
 [Sandboxing data][sandboxing-your-data] gives some people access to only a subset of the data. (The term comes from the practice of putting children in a sandbox to play safely.) To implement sandboxing, Metabase runs a query that filters rows and/or selects a subset of columns from a table based on [the person's permissions][permissions]; the person's query then runs on the initial query's result (i.e., it runs on the sandboxed data).

--- a/docs/troubleshooting-guide/server-logs.md
+++ b/docs/troubleshooting-guide/server-logs.md
@@ -1,3 +1,6 @@
+---
+title: How to read the server logs
+---
 
 # How to read the server logs
 

--- a/docs/troubleshooting-guide/sql.md
+++ b/docs/troubleshooting-guide/sql.md
@@ -1,3 +1,7 @@
+---
+title: Troubleshooting SQL questions
+---
+
 # Troubleshooting SQL questions
 
 ## [I'm getting a SQL syntax error][debugging-sql-syntax]

--- a/docs/troubleshooting-guide/sync-fingerprint-scan.md
+++ b/docs/troubleshooting-guide/sync-fingerprint-scan.md
@@ -1,3 +1,7 @@
+---
+title: Synchronizing with the database
+---
+
 # Synchronizing with the database
 
 <div class='doc-toc' markdown=1>

--- a/docs/troubleshooting-guide/timezones.md
+++ b/docs/troubleshooting-guide/timezones.md
@@ -1,3 +1,7 @@
+---
+title: The dates and times in my questions and charts are wrong
+---
+
 # The dates and times in my questions and charts are wrong
 
 You are doing calculations with dates and times, or displaying them in charts, but:

--- a/docs/users-guide/01-what-is-metabase.md
+++ b/docs/users-guide/01-what-is-metabase.md
@@ -1,3 +1,7 @@
+---
+title: What is Metabase?
+---
+
 ## What is Metabase?
 
 Metabase is an open source business intelligence tool. It lets you ask questions about your data, and displays answers in formats that make sense, whether that's a bar chart or a detailed table.

--- a/docs/users-guide/03-basic-exploration.md
+++ b/docs/users-guide/03-basic-exploration.md
@@ -1,3 +1,7 @@
+---
+title: Exploring in Metabase
+---
+
 # Exploring in Metabase
 
 ## See what your teammates have made

--- a/docs/users-guide/04-asking-questions.md
+++ b/docs/users-guide/04-asking-questions.md
@@ -1,3 +1,7 @@
+---
+title: Asking questions
+---
+
 # Asking questions
 
 Metabase's two core concepts are questions and their corresponding answers. Everything else is based around questions and answers. To ask a question in Metabase, click the **+ New** button in the upper right of the main navigation bar, and select either:

--- a/docs/users-guide/05-visualizing-results.md
+++ b/docs/users-guide/05-visualizing-results.md
@@ -1,3 +1,7 @@
+---
+title: Visualizing results
+---
+
 # Visualizing results
 
 While tables are useful for looking up information or finding specific numbers, it's usually easier to see trends and make sense of data using charts.

--- a/docs/users-guide/06-sharing-answers.md
+++ b/docs/users-guide/06-sharing-answers.md
@@ -1,3 +1,7 @@
+---
+title: Saving and editing your questions
+---
+
 # Saving and editing your questions
 
 ## How to save a question

--- a/docs/users-guide/07-dashboards.md
+++ b/docs/users-guide/07-dashboards.md
@@ -1,3 +1,7 @@
+---
+title: Dashboards
+---
+
 # Dashboards
 
 ![Interactive dashboard](images/dashboards/interactive-dashboard.png)

--- a/docs/users-guide/08-dashboard-filters.md
+++ b/docs/users-guide/08-dashboard-filters.md
@@ -1,3 +1,7 @@
+---
+title: Dashboard Filters
+---
+
 ## Dashboard Filters
 
 ![Dashboard Filters](images/dashboard-filters/dashboard-filters.png)

--- a/docs/users-guide/09-multi-series-charting.md
+++ b/docs/users-guide/09-multi-series-charting.md
@@ -1,3 +1,7 @@
+---
+title: Charts with multiple series
+---
+
 # Charts with multiple series
 
 Data in isolation is rarely all that useful. One of the best ways to add context and clarity when communicating with data is to show data side-by-side with other data. Here are just a few examples of data that is better together than apart.

--- a/docs/users-guide/12-data-model-reference.md
+++ b/docs/users-guide/12-data-model-reference.md
@@ -1,3 +1,7 @@
+---
+title: Data reference
+---
+
 ## Data reference
 
 Sometimes when you're writing a SQL query, you might forget the exact names of different tables or columns, or which table contains what. That’s where the _data reference_ comes in handy. You can open the data reference panel from the SQL editor by clicking on the book icon in the top right corner of the editor when it's open.

--- a/docs/users-guide/13-sql-parameters.md
+++ b/docs/users-guide/13-sql-parameters.md
@@ -1,3 +1,7 @@
+---
+title: Creating SQL templates
+---
+
 # Creating SQL templates
 
 You can create SQL templates by adding variables to your SQL queries in the [Native/SQL editor][sql-editor]. These variables will create filter widgets that you can use to change the variable's value in the query. You can also add parameters to your question's URL to set the filters' values, so that when the question loads, those values are inserted into the variables.

--- a/docs/users-guide/14-x-rays.md
+++ b/docs/users-guide/14-x-rays.md
@@ -1,3 +1,7 @@
+---
+title: X-rays
+---
+
 ## X-rays
 
 X-rays are a fast and easy way to get automatic insights and explorations of your data.
@@ -65,4 +69,3 @@ The X-ray suggestions that appear on the homepage of Metabase will be hidden if 
 ### Need help?
 
 If you still have questions about X-rays or comparisons, you can head over to our [discussion forum](https://discourse.metabase.com/). See you there!
-

--- a/docs/users-guide/15-alerts.md
+++ b/docs/users-guide/15-alerts.md
@@ -1,3 +1,7 @@
+---
+title: Getting alerts about questions
+---
+
 # Getting alerts about questions
 
 Whether you're keeping track of revenue, users, or negative reviews, there are often times when you want to be alerted about something. Metabase has a few different kinds of alerts you can set up, and you can choose to be notified via email or Slack.
@@ -72,4 +76,3 @@ There are a few ways alerts can be stopped:
 - Admins can edit any alert and delete it entirely. This can't be undone, so be careful!
 - If a saved question that has an alert on it gets edited in such a way that the alert doesn't make sense anymore, the alert will get deleted. For example, if a saved question with a goal line alert on it gets edited, and the goal line is removed entirely, that alert will get deleted.
 - If a question gets archived, any alerts on it will be deleted.
-

--- a/docs/users-guide/account-settings.md
+++ b/docs/users-guide/account-settings.md
@@ -1,3 +1,7 @@
+---
+title: Account settings
+---
+
 # Account settings
 
 You can view your account settings by clicking on the **gears** icon in the upper right of the main navigation bar, then selecting **Account settings**. Here you'll find three tabs:

--- a/docs/users-guide/collections.md
+++ b/docs/users-guide/collections.md
@@ -1,3 +1,7 @@
+---
+title: Collections
+---
+
 # Collections
 
  After your team has been using Metabase for a while, you’ll probably end up with lots of saved questions.

--- a/docs/users-guide/dashboard-subscriptions.md
+++ b/docs/users-guide/dashboard-subscriptions.md
@@ -1,3 +1,7 @@
+---
+title: Dashboard subscriptions
+---
+
 ## Dashboard subscriptions
 
 Dashboard subscriptions are a great way to keep you and your team up to date on the data that matters most. They allow you to send all of the questions on a dashboard via email or Slack. If your Metabase has email or Slack set up, all you need to do is create a dashboard, add subscribers to it, and tell Metabase how often you'd like the send out an update. You can set up as many subscriptions to a dashboard as you like, and if you make any changes to the dashboard, Metabase will update the subscriptions the next time they're delivered.
@@ -68,4 +72,3 @@ Some plans allow you to [customize filter values for each subscription](../enter
 ## Next: data model reference
 
 Sometimes you’ll need help understanding what data is available to you and what it means. Metabase provides a way for your administrators and data experts to build a [data model reference](12-data-model-reference.md) to help you make sense of your data.
-

--- a/docs/users-guide/events-and-timelines.md
+++ b/docs/users-guide/events-and-timelines.md
@@ -1,3 +1,7 @@
+---
+title: Events and timelines
+---
+
 # Events and timelines
 
 A lot of discussions around data have a moment when someone asks a question related to a specific point in time: "Wait, what's the spike in March again?", or "When did the new widget launch?"

--- a/docs/users-guide/expressions-list.md
+++ b/docs/users-guide/expressions-list.md
@@ -1,3 +1,7 @@
+---
+title: List of expressions
+---
+
 # List of expressions
 
 For an introduction to expressions, check out [Writing expressions in the notebook editor][expressions].

--- a/docs/users-guide/expressions.md
+++ b/docs/users-guide/expressions.md
@@ -1,3 +1,7 @@
+---
+title: Custom expressions in the query builder
+---
+
 # Custom expressions in the query builder
 
 [Custom expressions][expression-list] are like formulas in spreadsheet software like Excel, Google Sheets, and LibreOffice Calc. They are the power tools in the notebook editor of the query builder that allow you to ask more complicated questions.

--- a/docs/users-guide/field-types.md
+++ b/docs/users-guide/field-types.md
@@ -1,3 +1,7 @@
+---
+title: Field types in Metabase
+---
+
 # Field types in Metabase
 
 
@@ -94,4 +98,3 @@ While data types themselves can't be edited in Metabase, admins can manually [ca
 - [Exploring data with Metabase's data browser](/learn/getting-started/data-browser.html).
 - [The Data Model page: editing metadata](../administration-guide/03-metadata-editing.md).
 - [Field Filters: create smart filter widgets for SQL questions](/learn/sql-questions/field-filters.html).
-

--- a/docs/users-guide/interactive-dashboards.md
+++ b/docs/users-guide/interactive-dashboards.md
@@ -1,3 +1,7 @@
+---
+title: Interactive dashboards
+---
+
 ## Interactive dashboards
 
 You can customize what happens when people click on questions in your dashboard.

--- a/docs/users-guide/join.md
+++ b/docs/users-guide/join.md
@@ -1,3 +1,7 @@
+---
+title: Joining data
+---
+
 # Joining data
 
 ![Joining](./images/notebook/join-step.png)

--- a/docs/users-guide/models.md
+++ b/docs/users-guide/models.md
@@ -1,3 +1,7 @@
+---
+title: Models
+---
+
 # Models
 
 Models are a fundamental building block in Metabase. Models curate data from another table or tables from the same database to anticipate the kinds of questions people will ask of the data. You can think of them as derived tables, or a special kind of saved question meant to be used as the starting point for new questions. You can base a model on a SQL or query builder question, which means you can include custom, calculated columns in your model.

--- a/docs/users-guide/referencing-saved-questions-in-queries.md
+++ b/docs/users-guide/referencing-saved-questions-in-queries.md
@@ -1,3 +1,7 @@
+---
+title: Referencing models and saved questions in SQL queries
+---
+
 ## Referencing models and saved questions in SQL queries
 
 With SQL databases, we can use a [model][model] or an existing question as the basis for a new query, or as a common table expression [CTE][CTE].

--- a/docs/users-guide/sql-snippets.md
+++ b/docs/users-guide/sql-snippets.md
@@ -1,3 +1,7 @@
+---
+title: SQL snippets
+---
+
 ## SQL snippets
 
 ![Highlight and save as snippet](./images/sql-snippets/highlight_and_save_as_snippet.gif)

--- a/docs/users-guide/start.md
+++ b/docs/users-guide/start.md
@@ -1,3 +1,7 @@
+---
+title: User Guide
+---
+
 # User Guide
 
 ## Some basics

--- a/docs/users-guide/writing-sql.md
+++ b/docs/users-guide/writing-sql.md
@@ -1,3 +1,7 @@
+---
+title: The SQL editor
+---
+
 # The SQL editor
 
 If you ever need to ask questions that can't be expressed using the query builder, you can use [SQL][sql-gloss] instead.

--- a/src/metabase/cmd/endpoint_dox.clj
+++ b/src/metabase/cmd/endpoint_dox.clj
@@ -51,7 +51,20 @@
       (capitalize-initialisms initialisms)
       (str/replace "SSO SSO" "SSO")))
 
-(defn- format-description
+(defn- handle-quotes
+  "Used for formatting YAML string punctuation for frontmatter descriptions."
+  [s]
+  (-> s
+      (str/replace #"\"" "'")
+      str/split-lines
+      (#(str/join "\n  " %))))
+
+(defn- format-frontmatter-description
+  "Formats description for YAML frontmatter."
+  [desc]
+  (str "|\n  " (handle-quotes desc)))
+
+(defn- get-description
   "Used to grab namespace description, if it exists."
   [ep ep-data]
   (let [desc (-> ep-data
@@ -62,17 +75,14 @@
                  u/add-period)]
     (if (str/blank? desc)
       (u/add-period (str "API endpoints for " ep))
-      (str (str/replace desc "\"" "'")))))
+      desc)))
 
 (defn- endpoint-page-frontmatter
   "Formats frontmatter, which includes title and summary, if any."
   [ep ep-data]
-  (let [desc (format-description ep ep-data)]
-    (str "---\ntitle: \""
-         ep "\""
-         "\nsummary: \""
-         desc
-         "\"\n---\n\n")))
+  (let [desc (format-frontmatter-description (get-description ep ep-data))]
+    (str "---\ntitle: \"" ep "\""
+         "\nsummary: " desc "\n---\n\n")))
 
 (defn- endpoint-page-title
   "Creates a page title for a set of endpoints, e.g., `# Card`."
@@ -84,7 +94,7 @@
 (defn- endpoint-page-description
   "If there is a namespace docstring, include the docstring with a paragraph break."
   [ep ep-data]
-  (let [desc (format-description ep ep-data)]
+  (let [desc (get-description ep ep-data)]
     (if (str/blank? desc)
       desc
       (str desc "\n\n"))))

--- a/src/metabase/cmd/endpoint_dox.clj
+++ b/src/metabase/cmd/endpoint_dox.clj
@@ -37,15 +37,6 @@
       (reduce (fn [n m] (str/replace n m (str/upper-case m))) name matches)
       name)))
 
-(defn ^:private capitalize-first-char
-  "Like string/capitalize, only it ignores the rest of the string
-  to retain case-sensitive capitalization, e.g., initialisms."
-  [s]
-  (if (< (count s) 2)
-    (str/upper-case s)
-    (str (str/upper-case (subs s 0 1))
-         (subs s 1))))
-
 (defn- endpoint-ns-name
   "Creates a name for endpoints in a namespace, like all the endpoints for Alerts.
   Handles some edge cases for enterprise endpoints."
@@ -55,24 +46,33 @@
       name
       handle-enterprise-ns
       last
-      capitalize-first-char
+      u/capitalize-first-char
       (str/replace #"(.api.|-)" " ")
       (capitalize-initialisms initialisms)
       (str/replace "SSO SSO" "SSO")))
 
 (defn- format-description
   "Used to grab namespace description, if it exists."
-  [ep-data]
-  (u/add-period (:doc (meta (:ns (first ep-data))))))
+  [ep ep-data]
+  (let [desc (-> ep-data
+                 first
+                 :ns
+                 meta
+                 :doc
+                 u/add-period)]
+    (if (str/blank? desc)
+      (u/add-period (str "API endpoints for " ep))
+      (str (str/replace desc "\"" "'")))))
 
 (defn- endpoint-page-frontmatter
   "Formats frontmatter, which includes title and summary, if any."
   [ep ep-data]
-  (let [desc (format-description ep-data)]
+  (let [desc (format-description ep ep-data)]
     (str "---\ntitle: \""
          ep "\""
-         (if-not (str/blank? desc) (str "\nsummary: \"" desc "\""))
-         "\n---\n\n")))
+         "\nsummary: \""
+         desc
+         "\"\n---\n\n")))
 
 (defn- endpoint-page-title
   "Creates a page title for a set of endpoints, e.g., `# Card`."
@@ -83,8 +83,8 @@
 
 (defn- endpoint-page-description
   "If there is a namespace docstring, include the docstring with a paragraph break."
-  [ep-data]
-  (let [desc (format-description ep-data)]
+  [ep ep-data]
+  (let [desc (format-description ep ep-data)]
     (if (str/blank? desc)
       desc
       (str desc "\n\n"))))
@@ -174,7 +174,7 @@
   (apply str
          (endpoint-page-frontmatter ep ep-data)
          (endpoint-page-title ep)
-         (endpoint-page-description ep-data)
+         (endpoint-page-description ep ep-data)
          (route-toc ep-data)
          (endpoint-docs ep-data)
          (endpoint-footer ep-data)))

--- a/src/metabase/cmd/endpoint_dox.clj
+++ b/src/metabase/cmd/endpoint_dox.clj
@@ -60,6 +60,20 @@
       (capitalize-initialisms initialisms)
       (str/replace "SSO SSO" "SSO")))
 
+(defn- format-description
+  "Used to grab namespace description, if it exists."
+  [ep-data]
+  (u/add-period (:doc (meta (:ns (first ep-data))))))
+
+(defn- endpoint-page-frontmatter
+  "Formats frontmatter, which includes title and summary, if any."
+  [ep ep-data]
+  (let [desc (format-description ep-data)]
+    (str "---\ntitle: \""
+         ep "\""
+         (if-not (str/blank? desc) (str "\nsummary: \"" desc "\""))
+         "\n---\n\n")))
+
 (defn- endpoint-page-title
   "Creates a page title for a set of endpoints, e.g., `# Card`."
   [ep-title]
@@ -70,7 +84,7 @@
 (defn- endpoint-page-description
   "If there is a namespace docstring, include the docstring with a paragraph break."
   [ep-data]
-  (let [desc (u/add-period (:doc (meta (:ns (first ep-data)))))]
+  (let [desc (format-description ep-data)]
     (if (str/blank? desc)
       desc
       (str desc "\n\n"))))
@@ -158,6 +172,7 @@
   followed by the endpoint and their parameter descriptions."
   [ep ep-data]
   (apply str
+         (endpoint-page-frontmatter ep ep-data)
          (endpoint-page-title ep)
          (endpoint-page-description ep-data)
          (route-toc ep-data)

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -40,6 +40,15 @@
     s
     (str s ".")))
 
+(defn capitalize-first-char
+  "Like string/capitalize, only it ignores the rest of the string
+  to retain case-sensitive capitalization, e.g., PostgreSQL."
+  [s]
+  (if (< (count s) 2)
+    (str/upper-case s)
+    (str (str/upper-case (subs s 0 1))
+         (subs s 1))))
+
 (defn lower-case-en
   "Locale-agnostic version of `clojure.string/lower-case`.
   `clojure.string/lower-case` uses the default locale in conversions, turning

--- a/test/metabase/cmd/endpoint_dox_test.clj
+++ b/test/metabase/cmd/endpoint_dox_test.clj
@@ -29,7 +29,7 @@
                   :doc
                   "## `GET /api/activity/recent_views`\n\nGet the list of 10 things the current user has been viewing most recently."}]})
 
-(def page-markdown (str "---\ntitle: \"Activity\"\nsummary: \"API endpoints for Activity.\"\n---\n\n# Activity\n\nAPI endpoints for Activity.\n\n  - [GET /api/activity/](#get-apiactivity)\n  - [GET /api/activity/recent_views](#get-apiactivityrecent_views)\n\n## `GET /api/activity/`\n\nGet recent activity.\n\n## `GET /api/activity/recent_views`\n\nGet the list of 10 things the current user has been viewing most recently." (endpoint-dox/endpoint-footer (val (first endpoints)))))
+(def page-markdown (str "---\ntitle: \"Activity\"\nsummary: |\n  API endpoints for Activity.\n---\n\n# Activity\n\nAPI endpoints for Activity.\n\n  - [GET /api/activity/](#get-apiactivity)\n  - [GET /api/activity/recent_views](#get-apiactivityrecent_views)\n\n## `GET /api/activity/`\n\nGet recent activity.\n\n## `GET /api/activity/recent_views`\n\nGet the list of 10 things the current user has been viewing most recently." (endpoint-dox/endpoint-footer (val (first endpoints)))))
 
 (deftest build-endpoint-link-test
   (testing "Links to endpoint pages are generated correctly."

--- a/test/metabase/cmd/endpoint_dox_test.clj
+++ b/test/metabase/cmd/endpoint_dox_test.clj
@@ -3,7 +3,7 @@
             [metabase.cmd.endpoint-dox :as endpoint-dox]
             [metabase.config :as config]))
 
-(deftest capitalize-iniitialisms-test
+(deftest capitalize-initialisms-test
   (testing "Select initialisms and acronyms are in all caps."
     (is (= "The GeoJSON has too many semicolons."
            (endpoint-dox/capitalize-initialisms "The Geojson has too many semicolons." endpoint-dox/initialisms)))))
@@ -29,7 +29,7 @@
                   :doc
                   "## `GET /api/activity/recent_views`\n\nGet the list of 10 things the current user has been viewing most recently."}]})
 
-(def page-markdown (str "# Activity\n\n  - [GET /api/activity/](#get-apiactivity)\n  - [GET /api/activity/recent_views](#get-apiactivityrecent_views)\n\n## `GET /api/activity/`\n\nGet recent activity.\n\n## `GET /api/activity/recent_views`\n\nGet the list of 10 things the current user has been viewing most recently." (endpoint-dox/endpoint-footer (val (first endpoints)))))
+(def page-markdown (str "---\ntitle: \"Activity\"\nsummary: \"API endpoints for Activity.\"\n---\n\n# Activity\n\nAPI endpoints for Activity.\n\n  - [GET /api/activity/](#get-apiactivity)\n  - [GET /api/activity/recent_views](#get-apiactivityrecent_views)\n\n## `GET /api/activity/`\n\nGet recent activity.\n\n## `GET /api/activity/recent_views`\n\nGet the list of 10 things the current user has been viewing most recently." (endpoint-dox/endpoint-footer (val (first endpoints)))))
 
 (deftest build-endpoint-link-test
   (testing "Links to endpoint pages are generated correctly."


### PR DESCRIPTION
Adds frontmatter with title key to doc pages.

Additionally, it updates `src/metabase/cmd/endpoint-dox.clj` script to generate frontmatter for API doc pages.

This is step one in improving our doc search results' title formatting, as well as other places where we use the de-slugged URL in place of an actual page title on our website.