### PR TITLE
fix aggregation custom expression input width

### DIFF
--- a/frontend/src/metabase/query_builder/components/AggregationPopover/AggregationPopover.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/AggregationPopover/AggregationPopover.styled.tsx
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
 
 export const ExpressionPopoverRoot = styled.div`
-  width: 350px;
+  min-width: 350px;
 `;


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/23223

## How to verify

Ensure custom expression widgets do not have overflows:

Query builder -> Summarize -> Custom expression
<img width="728" alt="Screenshot 2022-06-10 at 18 14 00" src="https://user-images.githubusercontent.com/14301985/173084945-c3a07c44-864a-45dd-844a-74e48706c878.png">

[Legacy metric view](http://localhost:3000/admin/datamodel/metric/create) -> Select any table -> View -> Custom expression
<img width="1341" alt="Screenshot 2022-06-10 at 18 13 37" src="https://user-images.githubusercontent.com/14301985/173084957-3cc38f6e-eb98-4e9d-83cb-777b3441a332.png">

