### PR TITLE
Validate common passwords in user account settings

### DIFF
--- a/frontend/src/metabase/account/password/actions.js
+++ b/frontend/src/metabase/account/password/actions.js
@@ -5,15 +5,13 @@ import { createThunkAction } from "metabase/lib/redux";
 export const UPDATE_PASSWORD = "UPDATE_PASSWORD";
 export const VALIDATE_PASSWORD = "VALIDATE_PASSWORD";
 
-export const validatePassword = createThunkAction(VALIDATE_PASSWORD, function(
-  password,
-) {
-  return async function() {
-    return await UtilApi.password_check({
-      password: password,
-    });
-  };
-});
+export const validatePassword = createThunkAction(
+  VALIDATE_PASSWORD,
+  password => async () =>
+    UtilApi.password_check({
+      password,
+    }),
+);
 
 export const updatePassword = createThunkAction(UPDATE_PASSWORD, function(
   user_id,

--- a/frontend/src/metabase/account/password/components/UserPasswordForm/UserPasswordForm.jsx
+++ b/frontend/src/metabase/account/password/components/UserPasswordForm/UserPasswordForm.jsx
@@ -13,7 +13,8 @@ const UserPasswordForm = ({ user, validatePassword, updatePassword }) => {
   const handleAsyncValidate = useCallback(
     async ({ password }) => {
       try {
-        validatePassword(password);
+        await validatePassword(password);
+
         return {};
       } catch (error) {
         return error.data.errors;

--- a/frontend/test/metabase/scenarios/onboarding/setup/user_settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/onboarding/setup/user_settings.cy.spec.js
@@ -93,6 +93,20 @@ describe("user > settings", () => {
     cy.findByText("Sign in to Metabase");
   });
 
+  it("should validate common passwords (metabase#23259)", () => {
+    cy.visit("/account/password");
+    cy.findByLabelText("Create a password")
+      .as("passwordInput")
+      .type("qwerty123")
+      .blur();
+
+    cy.contains("password is too common");
+
+    cy.get("@passwordInput").clear();
+
+    cy.contains("password is too common").should("not.exist");
+  });
+
   it("should be able to change a language (metabase#22192)", () => {
     cy.intercept("PUT", "/api/user/*").as("updateUserSettings");
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/23259

## How to verify

- Open Account settings -> [Password](http://localhost:3000/account/password)
- Try changing the password to any common password like `qwerty123`
- Ensure it does not allow to save such password and shows an error message