### PR TITLE
Fix double-committing filters in FilterPopover

### DIFF
--- a/frontend/src/metabase/query_builder/components/filters/FilterPopover.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/FilterPopover.tsx
@@ -2,6 +2,7 @@
 import React, { Component } from "react";
 
 import { t } from "ttag";
+import _ from "underscore";
 
 import { color } from "metabase/lib/colors";
 
@@ -114,17 +115,19 @@ export default class FilterPopover extends Component<Props, State> {
     );
   };
 
-  handleCommitFilter = (filter: Filter | null, query: StructuredQuery) => {
-    if (filter && !(filter instanceof Filter)) {
-      filter = new Filter(filter, null, query);
-    }
-    if (filter && filter.isValid() && this.props.onChangeFilter) {
-      this.props.onChangeFilter(filter);
-      if (this.props.onClose) {
-        this.props.onClose();
+  handleCommitFilter = _.once(
+    (filter: Filter | null, query: StructuredQuery) => {
+      if (filter && !(filter instanceof Filter)) {
+        filter = new Filter(filter, null, query);
       }
-    }
-  };
+      if (filter && filter.isValid() && this.props.onChangeFilter) {
+        this.props.onChangeFilter(filter);
+        if (this.props.onClose) {
+          this.props.onClose();
+        }
+      }
+    },
+  );
 
   handleDimensionChange = (dimension: FieldDimension) => {
     let filter = this.state.filter;

--- a/frontend/src/metabase/query_builder/components/filters/FilterPopover.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/FilterPopover.tsx
@@ -115,6 +115,8 @@ export default class FilterPopover extends Component<Props, State> {
     );
   };
 
+  // we should only commit the filter once to prevent
+  // inconsistent filters from being committed
   handleCommitFilter = _.once(
     (filter: Filter | null, query: StructuredQuery) => {
       if (filter && !(filter instanceof Filter)) {

--- a/frontend/src/metabase/query_builder/components/filters/FilterPopoverPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/FilterPopoverPicker.tsx
@@ -28,7 +28,7 @@ export default class FilterPopoverPicker extends React.Component<Props> {
 
   handleKeyDown = (event: KeyboardEvent) => {
     if (event.key === "Enter") {
-      this.props.onCommit(this.props.filter);
+      this.props.filter.isValid() && this.props.onCommit(this.props.filter);
     }
   };
 

--- a/frontend/test/metabase/scenarios/filters/filter-bulk.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/filter-bulk.cy.spec.js
@@ -347,6 +347,60 @@ describe("scenarios > filters > bulk filtering", () => {
       cy.findByText("Showing 4 rows").should("be.visible");
     });
   });
+
+  describe("date filters", () => {
+    beforeEach(() => {
+      visitQuestionAdhoc(rawQuestionDetails);
+      openFilterModal();
+    });
+
+    it("can add a date shortcut filter", () => {
+      modal().within(() => {
+        cy.findByLabelText("Created At").click();
+      });
+      cy.findByText("Today").click();
+
+      cy.findByLabelText("Created At").within(() => {
+        cy.findByText("Today").should("be.visible");
+      });
+      // make sure select popover is closed
+      cy.findByText("Yesterday").should("not.exist");
+    });
+
+    it("can add a date range filter", () => {
+      modal().within(() => {
+        cy.findByLabelText("Created At").click();
+      });
+      cy.findByText("Specific dates...").click();
+      cy.findByText("Before").click();
+
+      popover().within(() => {
+        cy.get("input")
+          .eq(0)
+          .clear()
+          .type("01/01/2018");
+
+        cy.findByText("Add filter").click();
+      });
+
+      cy.findByLabelText("Created At").within(() => {
+        cy.findByText("is before January 1, 2018").should("be.visible");
+      });
+    });
+
+    it.skip("Bug repro: can cancel adding date filter", () => {
+      modal().within(() => {
+        cy.findByLabelText("Created At").click();
+      });
+      // click outside the popover
+      cy.findByText("Discount").click();
+
+      cy.findByLabelText("Created At").within(() => {
+        // there should be no filter so the X should not populate
+        cy.get(".Icon-close").should("not.exist");
+      });
+    });
+  });
 });
 
 const modal = () => {


### PR DESCRIPTION
## Before

This fixes a bug in the Bulk Filter Modal introduced by https://github.com/metabase/metabase/pull/22903

With the `saveOnBlur` option activated, the filterPopover was double-committing filters in certain instances. This was unperformant whenever a filter was manually saved, but didn't create any bugs. However, when a date filter is applied from a shortcut, it gets immediately committed before the component's state updates, which caused the `componentWillUnmount` function to be called with an empty filter, overwriting the date filter 😢 

To reproduce on master
- open the orders table
- open the bulk filter modal
- add a 'today' filter to the created at field
- see that it's empty


https://user-images.githubusercontent.com/30528226/173376633-a042cd21-7685-4ca3-95bf-e6920dffb893.mp4


## Changes

Use underscore's `once` function to ensure that `onCommit` only ever gets called once, preventing unwanted state updates, or unnecessary function calls. Because this function call triggers the popover closing, we should never want to call it multiple times. 😄 

To test:
- open the orders table
- open the bulk filter modal
- add a 'today' filter to the created at field
- see that it adds a today filter

![Screen Shot 2022-06-10 at 3 25 36 PM](https://user-images.githubusercontent.com/30528226/173153394-32221564-8729-4f51-af49-b03bf7a72146.png)


