### PR TITLE
Fix compilation of temporal arithmetic in between filters

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
@@ -607,7 +607,7 @@
     (reconcile-temporal-types
      ((get-method sql.qp/->honeysql [:sql filter-type])
       driver
-      clause))))
+      (reconcile-temporal-types clause)))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -616,14 +616,6 @@
 
 (defn- interval [amount unit]
   (hsql/raw (format "INTERVAL %d %s" (int amount) (name unit))))
-
-(defn- assert-addable-unit [t-type unit]
-  (when-not (contains? (temporal-type->supported-units t-type) unit)
-    ;; trying to add an `hour` to a `date` or a `year` to a `time` is something we shouldn't be allowing in the UI in
-    ;; the first place
-    (throw (ex-info (tru "Invalid query: you cannot add a {0} to a {1} column."
-                         (name unit) (name t-type))
-             {:type qp.error-type/invalid-query}))))
 
 ;; We can coerce the HoneySQL form this wraps to whatever we want and generate the appropriate SQL.
 ;; Thus for something like filtering against a relative datetime

--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -407,7 +407,7 @@
   ;; Addition is commutative and any but not all elements of `args` can be intervals.
   ;; We pick the first arg that is not an interval and add the rest of args to it.
   ;; (It's the callers responsibility to make sure that the first non-interval argument
-  ;; represents a date and not offset like an integer would.)
+  ;; represents a date and not an offset like an integer would.)
   ;; If none of the args is an interval, we shortcut with a simple addition.
   (if (some interval? args)
     (if-let [[arg others] (u/pick-first (complement interval?) args)]

--- a/shared/src/metabase/mbql/schema.cljc
+++ b/shared/src/metabase/mbql/schema.cljc
@@ -548,7 +548,7 @@
   s StringExpressionArg, pattern s/Str)
 
 (defclause ^{:requires-features #{:expressions}} +
-  x NumericExpressionArg, y NumericExpressionArgOrInterval, more (rest NumericExpressionArgOrInterval))
+  x NumericExpressionArgOrInterval, y NumericExpressionArgOrInterval, more (rest NumericExpressionArgOrInterval))
 
 (defclause ^{:requires-features #{:expressions}} -
   x NumericExpressionArg, y NumericExpressionArgOrInterval, more (rest NumericExpressionArgOrInterval))

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -983,3 +983,14 @@
   "Generates a random NanoID string. Usually these are used for the entity_id field of various models."
   []
   (nano-id))
+
+(defn pick-first
+  "Returns a pair [match others] where match is the first element of `coll` for which `pred` returns
+  a truthy value and others is a sequence of the other elements of `coll` with the order preserved.
+  Returns nil if no element satisfies `pred`."
+  [pred coll]
+  (loop [xs (seq coll), prefix []]
+    (when-let [[x & xs] xs]
+      (if (pred x)
+        [x (concat prefix xs)]
+        (recur xs (conj prefix x))))))

--- a/test/metabase/query_processor_test/filter_test.clj
+++ b/test/metabase/query_processor_test/filter_test.clj
@@ -166,7 +166,7 @@
           (doseq [offset-unit [:year :day]
                   interval-unit [:year :day]
                   compare-op [:between := :< :<= :> :>=]
-                  add-op [:+ #_:-] ; TODO add support for for subtraction like sql.qp/add-interval-honeysql-form
+                  add-op [:+ #_:-] ; TODO support subtraction like sql.qp/add-interval-honeysql-form (#23423)
                   compare-order (cond-> [:field-first]
                                   (not= compare-op :between) (conj :value-first))]
             (let [add-fn (fn [field interval]

--- a/test/metabase/query_processor_test/filter_test.clj
+++ b/test/metabase/query_processor_test/filter_test.clj
@@ -124,7 +124,10 @@
                            :filter      [:between [:+ !default.datetime_tz [:interval 3 offset-unit]]
                                          [:relative-datetime -7 interval-unit]
                                          [:relative-datetime 0 interval-unit]]})
-                  expected-count (get {[:day :year] 20} [offset-unit interval-unit] 0)]
+                  expected-count (get {[:day :year] 20}
+                                      [offset-unit interval-unit]
+                                      (when (not= :mongo driver/*driver*)
+                                        0))]
               (mt/with-native-query-testing-context query
                 (let [[[result]] (mt/formatted-rows [int]
                                    (qp/process-query query))]

--- a/test/metabase/query_processor_test/filter_test.clj
+++ b/test/metabase/query_processor_test/filter_test.clj
@@ -121,7 +121,7 @@
   (set/intersection
    ;; we also want to test this against MongoDB but [[mt/normal-drivers-with-feature]] would normally not include that
    ;; since MongoDB only supports expressions if version is 4.0 or above and [[mt/normal-drivers-with-feature]]
-   ;; currently uses [[driver/supports?]] rather than [[driver/database-supports?]] (TODO FIXME)
+   ;; currently uses [[driver/supports?]] rather than [[driver/database-supports?]] (TODO FIXME, see #23422)
    (conj (mt/normal-drivers-with-feature :expressions) :mongo)
    (timezones-test/timezone-aware-column-drivers)))
 
@@ -159,9 +159,6 @@
 
 (deftest nonstandard-temporal-arithmetic-test
   (testing "Nonstandard temporal arithmetic should also be supported"
-    ;; we also want to test this against MongoDB but [[mt/normal-drivers-with-feature]] would normally not include that
-    ;; since MongoDB only supports expressions if version is 4.0 or above and [[mt/normal-drivers-with-feature]]
-    ;; currently uses [[driver/supports?]] rather than [[driver/database-supports?]] (TODO FIXME)
     (mt/test-drivers (timezone-arithmetic-drivers)
       (mt/dataset attempted-murders
         (when-not (some-> (mongo-major-version (mt/db))

--- a/test/metabase/query_processor_test/timezones_test.clj
+++ b/test/metabase/query_processor_test/timezones_test.clj
@@ -31,7 +31,7 @@
    (set (mt/normal-drivers-with-feature :set-timezone))
    broken-drivers))
 
-(defn- timezone-aware-column-drivers
+(defn timezone-aware-column-drivers
   "Drivers that support the equivalent of `TIMESTAMP WITH TIME ZONE` columns."
   []
   (conj (set-timezone-drivers) :h2 :bigquery-cloud-sdk :sqlserver :mongo))

--- a/test/metabase/util_test.clj
+++ b/test/metabase/util_test.clj
@@ -368,3 +368,16 @@
        1.3     2 1.251
        12300.0 3 12345.67
        0.00321 3 0.003209817))
+
+(defspec pick-first-test 100
+  (prop/for-all [coll (gen/list gen/int)]
+    (let [result (u/pick-first pos? coll)]
+      (or (and (nil? result)
+               (every? (complement pos?) coll))
+          (let [[x ys] result
+                [non-pos [m & rest]] (split-with (complement pos?) coll)]
+            (and (vector? result)
+                 (= (count result) 2)
+                 (pos? x)
+                 (= x m)
+                 (= ys (concat non-pos rest))))))))


### PR DESCRIPTION
Fixes #22531 for BigQuery and Mongo 5+.


