### PR TITLE
Convert Action to TypeScript

### DIFF
--- a/frontend/src/metabase-lib/lib/Action.ts
+++ b/frontend/src/metabase-lib/lib/Action.ts
@@ -6,9 +6,3 @@ export default class Action {
     return "Action";
   }
 }
-
-export class ActionClick {
-  toString() {
-    return "ActionClick";
-  }
-}

--- a/frontend/src/metabase-lib/lib/Action.ts
+++ b/frontend/src/metabase-lib/lib/Action.ts
@@ -1,5 +1,14 @@
 export default class Action {
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  perform() {}
+  perform() {
+    console.warn("");
+  }
+  toString() {
+    return "Action";
+  }
 }
-export class ActionClick {}
+
+export class ActionClick {
+  toString() {
+    return "ActionClick";
+  }
+}

--- a/frontend/src/metabase-lib/lib/Action.ts
+++ b/frontend/src/metabase-lib/lib/Action.ts
@@ -2,6 +2,7 @@ export default class Action {
   perform() {
     console.warn("Action.perform()");
   }
+
   toString() {
     return "Action";
   }

--- a/frontend/src/metabase-lib/lib/Action.ts
+++ b/frontend/src/metabase-lib/lib/Action.ts
@@ -1,6 +1,6 @@
 export default class Action {
   perform() {
-    console.warn("");
+    console.warn("Action.perform()");
   }
   toString() {
     return "Action";

--- a/frontend/src/metabase-lib/lib/Action.ts
+++ b/frontend/src/metabase-lib/lib/Action.ts
@@ -1,9 +1,0 @@
-export default class Action {
-  perform() {
-    console.warn("Action.perform()");
-  }
-
-  toString() {
-    return "Action";
-  }
-}

--- a/frontend/test/metabase-lib/lib/Action.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/Action.unit.spec.js
@@ -1,9 +1,0 @@
-import Action from "metabase-lib/lib/Action";
-
-describe("Action", () => {
-  describe("perform", () => {
-    it("should perform the action", () => {
-      new Action().perform();
-    });
-  });
-});


### PR DESCRIPTION
Fixes #23295.

`Action` and `ActionClick` seem to be legacy classes.