### PR TITLE
Adds nanoseconds support

### DIFF
--- a/frontend/src/metabase/admin/datamodel/containers/humanizeCoercionStrategy.js
+++ b/frontend/src/metabase/admin/datamodel/containers/humanizeCoercionStrategy.js
@@ -3,6 +3,7 @@ const LEFT_TERM_CONVERSIONS = {
   UNIXSeconds: "UNIX seconds",
   UNIXMilliSeconds: "UNIX milliseconds",
   UNIXMicroSeconds: "UNIX microseconds",
+  UNIXNanoSeconds: "UNIX nanoseconds",
   YYYYMMDDHHMMSSString: "YYYYMMDDHHMMSS string",
   YYYYMMDDHHMMSSBytes: "YYYYMMDDHHMMSS bytes",
 };

--- a/frontend/src/metabase/admin/datamodel/containers/humanizeCoercionStrategy.unit.spec.js
+++ b/frontend/src/metabase/admin/datamodel/containers/humanizeCoercionStrategy.unit.spec.js
@@ -123,6 +123,35 @@ describe("UNIX microseconds", () => {
   });
 });
 
+describe("UNIX nanoseconds", () => {
+  it("converts to UNIX nanoseconds → Time", () => {
+    const original = "UNIXNanoSeconds->Time";
+    const expected = "UNIX nanoseconds → Time";
+
+    const humanized = humanizeCoercionStrategy(original);
+
+    expect(humanized).toBe(expected);
+  });
+
+  it("converts to UNIX nanoseconds → Date", () => {
+    const original = "UNIXNanoSeconds->Date";
+    const expected = "UNIX nanoseconds → Date";
+
+    const humanized = humanizeCoercionStrategy(original);
+
+    expect(humanized).toBe(expected);
+  });
+
+  it("converts to UNIX nanoseconds → Datetime", () => {
+    const original = "UNIXNanoSeconds->DateTime";
+    const expected = "UNIX nanoseconds → Datetime";
+
+    const humanized = humanizeCoercionStrategy(original);
+
+    expect(humanized).toBe(expected);
+  });
+});
+
 describe("YYYYMMDDHHMMSS", () => {
   it("converts YYYYMMDDHHMMSSString->Temporal to YYYYMMDDHHMMSS → Time", () => {
     const original = "YYYYMMDDHHMMSSString->Temporal";

--- a/shared/src/metabase/types.cljc
+++ b/shared/src/metabase/types.cljc
@@ -319,6 +319,7 @@
 (derive :Coercion/UNIXSeconds->DateTime :Coercion/UNIXTime->Temporal)
 (derive :Coercion/UNIXMilliSeconds->DateTime :Coercion/UNIXTime->Temporal)
 (derive :Coercion/UNIXMicroSeconds->DateTime :Coercion/UNIXTime->Temporal)
+(derive :Coercion/UNIXNanoSeconds->DateTime :Coercion/UNIXTime->Temporal)
 
 ;;; ---------------------------------------------------- Util Fns ----------------------------------------------------
 
@@ -348,6 +349,7 @@
      (clj->js (into {} (for [tyype (distinct (mapcat descendants [:type/* :Semantic/* :Relation/*]))]
                          [(name tyype) (shared.u/qualified-name tyype)])))))
 
+(coercion-hierarchies/define-types! :Coercion/UNIXNanoSeconds->DateTime #{:type/Integer :type/Decimal} :type/Instant)
 (coercion-hierarchies/define-types! :Coercion/UNIXMicroSeconds->DateTime #{:type/Integer :type/Decimal} :type/Instant)
 (coercion-hierarchies/define-types! :Coercion/UNIXMilliSeconds->DateTime #{:type/Integer :type/Decimal} :type/Instant)
 (coercion-hierarchies/define-types! :Coercion/UNIXSeconds->DateTime      #{:type/Integer :type/Decimal} :type/Instant)

--- a/shared/test/metabase/types_test.cljc
+++ b/shared/test/metabase/types_test.cljc
@@ -34,18 +34,21 @@
 
 (t/deftest coercion-possibilities-test
   (t/is (= {:type/Text    #{::Coerce-Int-To-Str}
-            :type/Instant #{:Coercion/UNIXMicroSeconds->DateTime
+            :type/Instant #{:Coercion/UNIXNanoSeconds->DateTime
+                            :Coercion/UNIXMicroSeconds->DateTime
                             :Coercion/UNIXMilliSeconds->DateTime
                             :Coercion/UNIXSeconds->DateTime}}
            (types/coercion-possibilities :type/Integer)))
-  (t/is (= {:type/Instant #{:Coercion/UNIXMicroSeconds->DateTime
+  (t/is (= {:type/Instant #{:Coercion/UNIXNanoSeconds->DateTime
+                            :Coercion/UNIXMicroSeconds->DateTime
                             :Coercion/UNIXMilliSeconds->DateTime
                             :Coercion/UNIXSeconds->DateTime}}
            (types/coercion-possibilities :type/Decimal)))
 
   (t/testing "Should work for for subtypes of a the coercion base type(s)"
     (t/is (= {:type/Text    #{::Coerce-Int-To-Str}
-              :type/Instant #{:Coercion/UNIXMicroSeconds->DateTime
+              :type/Instant #{:Coercion/UNIXNanoSeconds->DateTime
+                              :Coercion/UNIXMicroSeconds->DateTime
                               :Coercion/UNIXMilliSeconds->DateTime
                               :Coercion/UNIXSeconds->DateTime
                               ::Coerce-BigInteger-To-Instant}}

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -207,6 +207,10 @@
   [driver _ expr]
   (unix-timestamp->honeysql driver :seconds (hx// expr 1000000)))
 
+(defmethod unix-timestamp->honeysql [:sql :nanoseconds]
+  [driver _ expr]
+  (unix-timestamp->honeysql driver :seconds (hx// expr 1000000000)))
+
 (defmulti cast-temporal-byte
   "Cast a byte field"
   {:arglists '([driver coercion-strategy expr]), :added "0.38.0"}
@@ -259,7 +263,8 @@
     (throw (ex-info "Semantic type must be a UNIXTimestamp"
                     {:type          qp.error-type/invalid-query
                      :coercion-type coercion-type})))
-  (or (get {:Coercion/UNIXMicroSeconds->DateTime :microseconds
+  (or (get {:Coercion/UNIXNanoSeconds->DateTime :nanoseconds
+            :Coercion/UNIXMicroSeconds->DateTime :microseconds
             :Coercion/UNIXMilliSeconds->DateTime :milliseconds
             :Coercion/UNIXSeconds->DateTime      :seconds}
            coercion-type)


### PR DESCRIPTION

This fix adds nanoseconds support to Timestamp data. Pandas stores the timestamp in parquet in nanoseconds, so data imported directly from  those parquets will contain timestamp in nanoseconds.

With this fix we add support to transform the column timestamp in nanoseconds to a date time format in Metabase.