### PR TITLE
[E2E] Remove `organization` and `permissions` checks from CCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1303,8 +1303,6 @@ workflows:
                   "native",
                   "native-filters",
                   "onboarding",
-                  "organization",
-                  "permissions",
                   "smoketest",
                   "visualizations",
                 ]


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- In the same manner we did for #23164, this PR removes `organization` and `permissions` E2E groups from CircleCI because we've been running them successfully using GitHub actions (since #22924)