### PR TITLE
[E2E] Remove `collections` group from checks on CCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1298,7 +1298,6 @@ workflows:
               folder:
                 [
                   "admin",
-                  "collections",
                   "filters",
                   "native",
                   "native-filters",


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- In the same manner we did for #23164, this PR removes `collections` E2E group from CircleCI because we've been running it successfully using GitHub actions (since #23169)