### PR TITLE
[E2E] Experiment running `native` test group as PR check

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -68,6 +68,7 @@ jobs:
           - "embedding"
           - "joins"
           - "models"
+          - "native"
           - "organization"
           - "permissions"
           - "question"


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Following the steps of https://github.com/metabase/metabase/pull/21492 and the tasks that @ariya started, we're now adding `native` test group to PR checks using GitHub actions.
- There were no flakes related to this group in the last 14 days

### The next steps
After we make sure this group runs without major hiccups on GitHub (for at least a week?), remove it from CircleCI.