### PR TITLE
Render empty string for null boolean column results

### DIFF
--- a/frontend/src/metabase/lib/formatting.js
+++ b/frontend/src/metabase/lib/formatting.js
@@ -744,9 +744,6 @@ export function formatValueRaw(value, options = {}) {
 
   if (value === NULL_NUMERIC_VALUE) {
     return NULL_DISPLAY_VALUE;
-  } else if (value === null && isBoolean(column)) {
-    // Custom expressions returning the False literal return null
-    return JSON.stringify(false);
   } else if (value == null) {
     return null;
   } else if (


### PR DESCRIPTION
Fixes #22621

### How to Test

1. \+ New
2. SQL Query
3. Add following query:

```
select 'TRUE' "Text", true::boolean "Boolean", 1::bit(1) "Bit"
union all select 'FALSE', false::boolean, 0::bit(1)
union all select 'NULL', null::boolean, null::bit(1)
```

You should see the following:

![image](https://user-images.githubusercontent.com/1447303/167840532-912f504e-d6e8-4a5f-9e12-3d3686db82ab.png)