### PR TITLE
override product voice

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/settings/selectors.js
+++ b/enterprise/frontend/src/metabase-enterprise/settings/selectors.js
@@ -1,27 +1,41 @@
 import { createSelector } from "reselect";
+import { LOADING_MESSAGE_BY_SETTING } from "../whitelabel/lib/loading-message";
 
 const DEFAULT_LOGO_URL = "app/assets/img/logo.svg";
 
-export const getLogoUrl = state =>
-  state.settings.values["application-logo-url"] ||
-  state.settings.values.application_logo_url ||
-  DEFAULT_LOGO_URL;
+const hasCustomColors = settingValues => {
+  const applicationColors =
+    settingValues["application-colors"] || settingValues.application_colors;
+  return Object.keys(applicationColors || {}).length > 0;
+};
 
-const getApplicationColors = state =>
-  state.settings.values["application-colors"] ||
-  state.settings.values.application_colors;
+const getCustomLogoUrl = settingValues => {
+  return (
+    settingValues["application-logo-url"] ||
+    settingValues.application_logo_url ||
+    DEFAULT_LOGO_URL
+  );
+};
 
-export const getHasCustomColors = createSelector(
-  [getApplicationColors],
-  applicationColors => Object.keys(applicationColors || {}).length > 0,
+export const hasCustomBranding = settings =>
+  hasCustomColors(settings) || getCustomLogoUrl(settings) !== DEFAULT_LOGO_URL;
+
+export const getShowMetabot = state => state.settings.values["show-metabot"];
+
+export const getLogoUrl = state => getCustomLogoUrl(state.settings.values);
+
+export const getHasCustomColors = state =>
+  hasCustomColors(state.settings.values);
+
+export const getHasCustomBranding = state =>
+  hasCustomBranding(state.settings.values);
+
+export const getHideMetabot = createSelector(
+  [getHasCustomBranding, getShowMetabot],
+  (hasCustomBranding, showMetabot) => hasCustomBranding || !showMetabot,
 );
 
-export const getHasCustomLogo = createSelector(
-  [getLogoUrl],
-  logoUrl => logoUrl !== DEFAULT_LOGO_URL,
-);
-
-export const getHasCustomBranding = createSelector(
-  [getHasCustomLogo, getHasCustomColors],
-  (hasCustomLogo, hasCustomColors) => hasCustomLogo || hasCustomColors,
-);
+export const getLoadingMessage = state =>
+  LOADING_MESSAGE_BY_SETTING[
+    state.settings.values["loading-message"] ?? "doing-science"
+  ];

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/LogoUpload/LogoUpload.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/LogoUpload/LogoUpload.jsx
@@ -1,11 +1,12 @@
 /* eslint-disable react/prop-types */
 import React from "react";
 
-import Icon from "metabase/components/Icon";
+import Button from "metabase/core/components/Button";
 import LogoIcon from "metabase/components/LogoIcon";
-import SettingInput from "metabase/admin/settings/components/widgets/SettingInput.jsx";
-
+import SettingInput from "metabase/admin/settings/components/widgets/SettingInput";
 import { color } from "metabase/lib/colors";
+
+import { LogoFileInput } from "./LogoUpload.styled";
 
 const LogoUpload = ({ setting, onChange, ...props }) => (
   <div>
@@ -19,8 +20,7 @@ const LogoUpload = ({ setting, onChange, ...props }) => (
       </span>
     </div>
     {window.File && window.FileReader ? (
-      <input
-        type="file"
+      <LogoFileInput
         onChange={e => {
           if (e.target.files.length > 0) {
             const reader = new FileReader();
@@ -32,7 +32,7 @@ const LogoUpload = ({ setting, onChange, ...props }) => (
     ) : (
       <SettingInput setting={setting} onChange={onChange} {...props} />
     )}
-    <Icon name="close" onClick={() => onChange(undefined)} />
+    <Button onlyIcon icon="close" onClick={() => onChange(undefined)} />
   </div>
 );
 

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/LogoUpload/LogoUpload.styled.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/LogoUpload/LogoUpload.styled.tsx
@@ -1,0 +1,25 @@
+import styled from "@emotion/styled";
+import { color } from "metabase/lib/colors";
+
+export const LogoFileInput = styled.input`
+  &::file-selector-button {
+    padding: 0.75rem 1rem;
+    margin-right: 1rem;
+    border-radius: 4px;
+    border: 1px solid ${color("border")};
+    background-color: ${color("white")};
+    color: ${color("text-dark")};
+    transition: 200ms;
+    cursor: pointer;
+    font-family: var(--default-font-family);
+  }
+
+  &::file-selector-button:hover {
+    color: ${color("brand")};
+    background-color: ${color("bg-light")};
+  }
+`;
+
+LogoFileInput.defaultProps = {
+  type: "file",
+};

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/LogoUpload/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/LogoUpload/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./LogoUpload";

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/MetabotSettingWidget/MetabotSettingWidget.styled.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/MetabotSettingWidget/MetabotSettingWidget.styled.tsx
@@ -1,0 +1,25 @@
+import styled from "@emotion/styled";
+import { color } from "metabase/lib/colors";
+
+export const MetabotSettingWidgetRoot = styled.div`
+  max-width: 530px;
+  border: 1px solid ${color("border")};
+  display: flex;
+  align-items: stretch;
+  border-radius: 0.5rem;
+`;
+
+export const MetabotContainer = styled.div`
+  padding: 2rem;
+  border-right: 1px solid ${color("border")};
+`;
+
+export const ToggleContainer = styled.div`
+  padding: 2rem 1.5rem;
+  display: flex;
+  align-items: center;
+`;
+
+export const ToggleLabel = styled.label`
+  margin-right: 2rem;
+`;

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/MetabotSettingWidget/MetabotSettingWidget.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/MetabotSettingWidget/MetabotSettingWidget.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { t } from "ttag";
+import MetabotLogo from "metabase/components/MetabotLogo";
+import {
+  MetabotSettingWidgetRoot,
+  MetabotContainer,
+  ToggleContainer,
+  ToggleLabel,
+} from "./MetabotSettingWidget.styled";
+import Toggle from "metabase/core/components/Toggle";
+
+const MetabotSettingWidget = ({ setting, onChange }: any) => {
+  const toggleId = "show-metabot-switch";
+  return (
+    <MetabotSettingWidgetRoot>
+      <MetabotContainer>
+        <MetabotLogo />
+      </MetabotContainer>
+      <ToggleContainer>
+        <ToggleLabel
+          htmlFor={toggleId}
+        >{t`Display our little friend on the homepage`}</ToggleLabel>
+        <Toggle
+          id={toggleId}
+          aria-checked={setting.value}
+          role="switch"
+          value={setting.value ?? setting.defaultValue}
+          onChange={onChange}
+        />
+      </ToggleContainer>
+    </MetabotSettingWidgetRoot>
+  );
+};
+
+export default MetabotSettingWidget;

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/MetabotSettingWidget/MetabotSettingWidget.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/MetabotSettingWidget/MetabotSettingWidget.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { t } from "ttag";
+import { useUniqueId } from "metabase/hooks/use-unique-id";
 import MetabotLogo from "metabase/components/MetabotLogo";
 import {
   MetabotSettingWidgetRoot,
@@ -10,7 +11,7 @@ import {
 import Toggle from "metabase/core/components/Toggle";
 
 const MetabotSettingWidget = ({ setting, onChange }: any) => {
-  const toggleId = "show-metabot-switch";
+  const toggleId = useUniqueId("show-metabot-switch");
   return (
     <MetabotSettingWidgetRoot>
       <MetabotContainer>

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/MetabotSettingWidget/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/MetabotSettingWidget/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./MetabotSettingWidget";

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/index.js
@@ -12,17 +12,21 @@ import { hasPremiumFeature } from "metabase-enterprise/settings";
 import {
   getHasCustomBranding,
   getHasCustomColors,
-  getHasCustomLogo,
+  getHideMetabot,
+  hasCustomBranding,
+  getLoadingMessage,
 } from "metabase-enterprise/settings/selectors";
 import MetabaseSettings from "metabase/lib/settings";
 
 import ColorSettingsWidget from "./components/ColorSettingsWidget";
+import MetabotSettingWidget from "./components/MetabotSettingWidget";
 import LogoUpload from "./components/LogoUpload";
 import LogoIcon from "./components/LogoIcon";
 import {
   updateColors,
   enabledApplicationNameReplacement,
 } from "./lib/whitelabel";
+import { getLoadingMessageOptions } from "./lib/loading-message";
 
 if (hasPremiumFeature("whitelabel")) {
   PLUGIN_LANDING_PAGE.push(() => MetabaseSettings.get("landing-page"));
@@ -72,6 +76,22 @@ if (hasPremiumFeature("whitelabel")) {
           type: "string",
           placeholder: "/",
         },
+        {
+          key: "loading-message",
+          display_name: t`Loading message`,
+          type: "select",
+          options: getLoadingMessageOptions(),
+          defaultValue: "doing-science",
+        },
+        {
+          key: "show-metabot",
+          display_name: t`Metabot`,
+          description: null,
+          type: "boolean",
+          widget: MetabotSettingWidget,
+          defaultValue: true,
+          getHidden: settings => hasCustomBranding(settings),
+        },
       ],
     },
     ...sections,
@@ -88,6 +108,7 @@ if (hasPremiumFeature("whitelabel")) {
 }
 
 // these selectors control whitelabeling UI
-PLUGIN_SELECTORS.getHasCustomLogo = getHasCustomLogo;
 PLUGIN_SELECTORS.getHasCustomColors = getHasCustomColors;
 PLUGIN_SELECTORS.getHasCustomBranding = getHasCustomBranding;
+PLUGIN_SELECTORS.getHideMetabot = getHideMetabot;
+PLUGIN_SELECTORS.getLoadingMessage = getLoadingMessage;

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/lib/loading-message.ts
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/lib/loading-message.ts
@@ -1,0 +1,17 @@
+import { t } from "ttag";
+
+export const LOADING_MESSAGE_BY_SETTING = {
+  "doing-science": t`Doing science...`,
+  "running-query": t`Running query...`,
+  "loading-results": t`Loading results...`,
+};
+
+type LoadingMessageSettingValue = keyof typeof LOADING_MESSAGE_BY_SETTING;
+
+export const getLoadingMessageOptions = () =>
+  Object.keys(LOADING_MESSAGE_BY_SETTING).map(key => {
+    return {
+      value: key,
+      name: LOADING_MESSAGE_BY_SETTING[key as LoadingMessageSettingValue],
+    };
+  });

--- a/frontend/src/metabase/admin/settings/selectors.js
+++ b/frontend/src/metabase/admin/settings/selectors.js
@@ -176,7 +176,7 @@ const SECTIONS = updateSectionsWithPlugins({
         key: "email-smtp-username",
         display_name: t`SMTP Username`,
         description: null,
-        placeholder: "youlooknicetoday",
+        placeholder: "nicetoseeyou",
         type: "string",
       },
       {

--- a/frontend/src/metabase/entities/users/forms.js
+++ b/frontend/src/metabase/entities/users/forms.js
@@ -26,7 +26,7 @@ const getNameFields = () => [
 const getEmailField = () => ({
   name: "email",
   title: t`Email`,
-  placeholder: "youlooknicetoday@email.com",
+  placeholder: "nicetoseeyou@email.com",
   validate: validate.required().email(),
 });
 
@@ -102,7 +102,7 @@ export default {
       {
         name: "email",
         title: t`Email`,
-        placeholder: "youlooknicetoday@email.com",
+        placeholder: "nicetoseeyou@email.com",
         validate: email => {
           if (!email) {
             return t`required`;
@@ -125,7 +125,7 @@ export default {
           name: "username",
           type: ldap ? "input" : "email",
           title: ldap ? t`Username or email address` : t`Email address`,
-          placeholder: t`youlooknicetoday@email.com`,
+          placeholder: t`nicetoseeyou@email.com`,
           validate: ldap ? validate.required() : validate.required().email(),
           autoFocus: true,
         },
@@ -177,7 +177,7 @@ export default {
     fields: [
       {
         name: "email",
-        placeholder: "youlooknicetoday@email.com",
+        placeholder: "nicetoseeyou@email.com",
         autoFocus: true,
         validate: validate.required().email(),
       },

--- a/frontend/src/metabase/home/homepage/containers/HomeGreeting/HomeGreeting.tsx
+++ b/frontend/src/metabase/home/homepage/containers/HomeGreeting/HomeGreeting.tsx
@@ -6,7 +6,7 @@ import HomeGreeting from "../../components/HomeGreeting";
 
 const mapStateToProps = (state: State) => ({
   user: getUser(state),
-  showLogo: !PLUGIN_SELECTORS.getHasCustomBranding(state),
+  showLogo: !PLUGIN_SELECTORS.getHideMetabot(state),
 });
 
 export default connect(mapStateToProps)(HomeGreeting);

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -73,10 +73,11 @@ export const PLUGIN_SHOW_CHANGE_PASSWORD_CONDITIONS = [];
 
 // selectors that customize behavior between app versions
 export const PLUGIN_SELECTORS = {
-  getHasCustomLogo: (state: State) => false,
   getHasCustomColors: (state: State) => false,
   getHasCustomBranding: (state: State) => false,
   canWhitelabel: (state: State) => false,
+  getHideMetabot: (state: State) => false,
+  getLoadingMessage: (state: State) => t`Doing science...`,
 };
 
 export const PLUGIN_FORM_WIDGETS = {};

--- a/frontend/src/metabase/query_builder/actions/querying.js
+++ b/frontend/src/metabase/query_builder/actions/querying.js
@@ -4,6 +4,7 @@ import { t } from "ttag";
 
 import { createAction } from "redux-actions";
 
+import { PLUGIN_SELECTORS } from "metabase/plugins";
 import * as MetabaseAnalytics from "metabase/lib/analytics";
 import { isAdHocModelQuestion } from "metabase/lib/data-modeling/utils";
 import { startTimer } from "metabase/lib/performance";
@@ -160,8 +161,9 @@ export const runQuestionQuery = ({
 const loadStartUIControls = createThunkAction(
   LOAD_START_UI_CONTROLS,
   () => (dispatch, getState) => {
+    const loadingMessage = PLUGIN_SELECTORS.getLoadingMessage(getState());
     const title = {
-      onceQueryIsRun: t`Doing Science...`,
+      onceQueryIsRun: loadingMessage,
       ifQueryTakesLong: t`Still Here...`,
     };
 

--- a/frontend/src/metabase/query_builder/components/QueryVisualization.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryVisualization.jsx
@@ -59,11 +59,17 @@ export default class QueryVisualization extends Component {
       isResultDirty,
       isNativeEditorOpen,
       result,
+      loadingMessage,
     } = this.props;
 
     return (
       <div className={cx(className, "relative stacking-context")}>
-        {isRunning ? <VisualizationRunningState className="spread z2" /> : null}
+        {isRunning ? (
+          <VisualizationRunningState
+            className="spread z2"
+            loadingMessage={loadingMessage}
+          />
+        ) : null}
         <VisualizationDirtyState
           {...this.props}
           hidden={!isResultDirty || isRunning || isNativeEditorOpen}
@@ -112,7 +118,7 @@ export const VisualizationEmptyState = ({ className }) => (
   </div>
 );
 
-export const VisualizationRunningState = ({ className }) => (
+export const VisualizationRunningState = ({ className, loadingMessage }) => (
   <div
     className={cx(
       className,
@@ -121,7 +127,7 @@ export const VisualizationRunningState = ({ className }) => (
   >
     <LoadingSpinner />
     <h2 className="Loading-message text-brand text-uppercase my3">
-      {t`Doing science`}...
+      {loadingMessage}
     </h2>
   </div>
 );

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
@@ -11,6 +11,7 @@ import { push } from "react-router-redux";
 import { t } from "ttag";
 import _ from "underscore";
 
+import { PLUGIN_SELECTORS } from "metabase/plugins";
 import Bookmark from "metabase/entities/bookmarks";
 import Collections from "metabase/entities/collections";
 import Timelines from "metabase/entities/timelines";
@@ -199,6 +200,7 @@ const mapStateToProps = (state, props) => {
     documentTitle: getDocumentTitle(state),
     pageFavicon: getPageFavicon(state),
     isLoadingComplete: getIsLoadingComplete(state),
+    loadingMessage: PLUGIN_SELECTORS.getLoadingMessage(state),
   };
 };
 

--- a/frontend/test/metabase/scenarios/admin/settings/whitelabel.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/whitelabel.cy.spec.js
@@ -122,6 +122,36 @@ describeEE("formatting > whitelabel", () => {
     });
   });
 
+  describe("loading message", () => {
+    it("should update loading message", () => {
+      cy.visit("/question/1");
+      cy.findByText("Doing science...");
+
+      const runningQueryMessage = "Running query...";
+      changeLoadingMessage(runningQueryMessage);
+      cy.visit("/question/1");
+      cy.findByText(runningQueryMessage);
+
+      const loadingResultsMessage = "Loading results...";
+      changeLoadingMessage(loadingResultsMessage);
+      cy.visit("/question/1");
+      cy.findByText(loadingResultsMessage);
+    });
+  });
+
+  describe("metabot", () => {
+    it("should toggle metabot visibility", () => {
+      cy.visit("/");
+      cy.findByAltText("Metabot");
+
+      cy.visit("/admin/settings/whitelabel");
+      cy.get("#show-metabot-switch").click();
+
+      cy.visit("/");
+      cy.findByAltText("Metabot").should("not.exist");
+    });
+  });
+
   describe("font", () => {
     const font = "Open Sans";
     beforeEach(() => {
@@ -137,6 +167,12 @@ describeEE("formatting > whitelabel", () => {
     });
   });
 });
+
+function changeLoadingMessage(message) {
+  cy.visit("/admin/settings/whitelabel");
+  cy.findByTestId("loading-message-select-button").click();
+  cy.findByText(message).click();
+}
 
 function setApplicationFontTo(font) {
   cy.request("PUT", "/api/setting/application-font", {

--- a/frontend/test/metabase/scenarios/admin/settings/whitelabel.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/whitelabel.cy.spec.js
@@ -145,7 +145,7 @@ describeEE("formatting > whitelabel", () => {
       cy.findByAltText("Metabot");
 
       cy.visit("/admin/settings/whitelabel");
-      cy.get("#show-metabot-switch").click();
+      cy.findByText("Display our little friend on the homepage").click();
 
       cy.visit("/");
       cy.findByAltText("Metabot").should("not.exist");

--- a/frontend/test/metabase/scenarios/permissions/sandboxes.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/sandboxes.cy.spec.js
@@ -56,7 +56,7 @@ describeEE("formatting > sandboxes", () => {
       cy.findByText("Invite someone").click();
       cy.findByPlaceholderText("Johnny").type("John");
       cy.findByPlaceholderText("Appleseed").type("Smith");
-      cy.findByPlaceholderText("youlooknicetoday@email.com").type(
+      cy.findByPlaceholderText("nicetoseeyou@email.com").type(
         "john@smith.test",
       );
       cy.findByText("Add an attribute").click();

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -281,6 +281,17 @@
   :type       :string
   :default    "Metabase")
 
+(defsetting loading-message
+  (deferred-tru "Message to show while a query is running.")
+  :visibility :public
+  :type       :keyword)
+
+(defsetting show-metabot
+  (deferred-tru "Enables Metabot character on the home page")
+  :visibility :public
+  :type       :boolean
+  :default    true)
+
 (defsetting application-colors
   (deferred-tru
    (str "These are the primary colors used in charts and throughout Metabase. "


### PR DESCRIPTION
[Product doc](https://www.notion.so/metabase/Allow-EE-customers-to-override-our-fun-product-voice-7788c18b79d84bed828fde40d408e26d)

## Changes

Allows to tweak certain aspects of instance [appearance](http://localhost:3000/admin/settings/whitelabel) for Enterprise customers. The PR misses the Metabot animation from the product doc, it will be added further.

#### Adds a setting to configure the loading query message
<img width="456" alt="Screenshot 2022-06-15 at 23 17 41" src="https://user-images.githubusercontent.com/14301985/173907092-ee291114-a64b-4daa-a0b1-76545841a9f2.png">

#### Adds a setting to toggle Metabot visibility
<img width="531" alt="Screenshot 2022-06-15 at 23 18 03" src="https://user-images.githubusercontent.com/14301985/173907155-4de91be6-be94-4da6-b2b5-1feae2abb47a.png">

#### Updates the style of the logo file input
<img width="422" alt="Screenshot 2022-06-15 at 23 19 13" src="https://user-images.githubusercontent.com/14301985/173907495-2b0589ee-1bbb-4adf-b97f-fa4da68d03b1.png">

#### Replaces **youlooknicetoday**@email.com placeholders with **nicetoseeyou**@email.com

## How to verify
### Loading message
- Go to the [appearance](http://localhost:3000/admin/settings/whitelabel) page and change the loading message
- Open any question and ensure it shows the updated loading message

### Metabot
- Run an instance with untouched color and logo settings
- Go to the [appearance](http://localhost:3000/admin/settings/whitelabel) and hide Metabot
- Ensure it is not visible on the homepage anymore
- Go back to the appearance settings, enable the Metabot setting and upload a new logo
- Ensure the Metabot setting is hidden and Metabot is not visible on the home page

### Placeholders
- Ensure there are no `youlooknicetoday` placeholders in the product
