### PR TITLE
Backport: Render empty string for null boolean column results

### DIFF
--- a/frontend/src/metabase/lib/formatting.js
+++ b/frontend/src/metabase/lib/formatting.js
@@ -744,9 +744,6 @@ export function formatValueRaw(value, options = {}) {
 
   if (value === NULL_NUMERIC_VALUE) {
     return NULL_DISPLAY_VALUE;
-  } else if (value === null && isBoolean(column)) {
-    // Custom expressions returning the False literal return null
-    return JSON.stringify(false);
   } else if (value == null) {
     return null;
   } else if (


### PR DESCRIPTION
Manual backport of: #23314

Fixes issue #22621