### PR TITLE
Unbounce the checkbox

### DIFF
--- a/frontend/src/metabase/core/components/CheckBox/CheckBox.styled.tsx
+++ b/frontend/src/metabase/core/components/CheckBox/CheckBox.styled.tsx
@@ -9,6 +9,8 @@ import {
   CheckBoxLabelProps,
 } from "./types";
 
+import { DEFAULT_ICON_PADDING } from "./constants";
+
 export const CheckBoxRoot = styled.label`
   display: block;
   position: relative;
@@ -47,6 +49,7 @@ export const CheckBoxContainer = styled.span<CheckBoxContainerProps>`
 
 export const CheckBoxIcon = styled(Icon)<CheckBoxIconProps>`
   display: block;
+  padding: ${DEFAULT_ICON_PADDING / 2}px;
   color: ${props => color(props.checked ? "white" : props.uncheckedColor)};
   width: ${props => `${props.size}px`};
   height: ${props => `${props.size}px`};


### PR DESCRIPTION
Our checkbox component had a bit of padding to make the icon smaller which made the size of the component change in its checked and unchecked state.  We just need to add this padding to the surrounding component in addition to reducing the icon size.

Before | After
---|---
![bouncy](https://user-images.githubusercontent.com/30528226/173443948-52249c98-9ddb-419d-8389-052fcf3e2108.gif) | ![unbouncy](https://user-images.githubusercontent.com/30528226/173443951-175d76db-9ad1-4af7-86e5-44d9da808c5f.gif)


## To reproduce:

Open any category field filter and start checking boxes, you should see the height change

## To test fix:

Open any category field filter and start checking boxes, you should see no height changes.
