### PR TITLE
fix getXValues fails on empty results

### DIFF
--- a/frontend/src/metabase/visualizations/lib/renderer_utils.js
+++ b/frontend/src/metabase/visualizations/lib/renderer_utils.js
@@ -185,6 +185,9 @@ export function getXValues({ settings, series }) {
     // In the raw series, the dimension isn't necessarily in the first element
     // of each row. This finds the correct column index.
     const columnIndex = getColumnIndex({ settings, data });
+    if (!data.cols[columnIndex]) {
+      continue;
+    }
 
     const parseOptions = getParseOptions({ settings, data });
     let lastValue;

--- a/frontend/test/metabase/visualizations/lib/renderer_utils.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/renderer_utils.unit.spec.js
@@ -74,6 +74,12 @@ describe("getXValues", () => {
     const settings = {};
     expect(getXValues({ settings, series })).toEqual(["d", "c", "b", "a"]);
   });
+  it("should return empty array when data has no rows and columns", () => {
+    const series = [{ data: { rows: [], cols: [] } }];
+    series._raw = [{ data: { rows: [], cols: [] } }];
+
+    expect(getXValues({ settings: {}, series })).toEqual([]);
+  });
   it("should use the correct column as the dimension for raw series", () => {
     const series = [
       {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/23300

## Changes

This PR fixes the case when BE returns an error and `data` has no rows and columns which led to an exception in `getXValues`.

## How to verify

Check the linked issue repro steps