### PR TITLE
Update Question name inline

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/caching/components/QuestionCacheSection/QuestionCacheSection.styled.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/QuestionCacheSection/QuestionCacheSection.styled.tsx
@@ -1,8 +1,8 @@
-import styled from '@emotion/styled';
-import Button from 'metabase/core/components/Button'
-import Input from 'metabase/core/components/Input';
+import styled from "@emotion/styled";
+import Button from "metabase/core/components/Button";
+import Input from "metabase/core/components/Input";
 
-import { color } from 'metabase/lib/colors';
+import { color } from "metabase/lib/colors";
 
 export const QuestionCacheSectionRoot = styled.div`
   display: flex;
@@ -15,14 +15,14 @@ export const QuestionCacheSectionRoot = styled.div`
   ${Button.Content} {
     justify-content: start;
   }
-`
+`;
 
 export const Text = styled.span`
   font-weight: 700;
   font-size: 0.875rem;
   line-height: 1rem;
   margin: 0.5rem 0rem;
-`
+`;
 
 export const CachePopover = styled.div`
   padding: 1.5rem;
@@ -43,10 +43,10 @@ export const CachePopover = styled.div`
     padding: 0.625rem;
     margin: 0 0.5rem;
 
-    border: 1px solid ${color('border')}
+    border: 1px solid ${color("border")};
   }
 
   ${Button.Root} {
     width: 120px;
   }
-`
+`;

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/QuestionCacheSection/QuestionCacheSection.styled.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/QuestionCacheSection/QuestionCacheSection.styled.tsx
@@ -1,0 +1,52 @@
+import styled from '@emotion/styled';
+import Button from 'metabase/core/components/Button'
+import Input from 'metabase/core/components/Input';
+
+import { color } from 'metabase/lib/colors';
+
+export const QuestionCacheSectionRoot = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  ${Button.Root} {
+    padding: 0;
+  }
+
+  ${Button.Content} {
+    justify-content: start;
+  }
+`
+
+export const Text = styled.span`
+  font-weight: 700;
+  font-size: 0.875rem;
+  line-height: 1rem;
+  margin: 0.5rem 0rem;
+`
+
+export const CachePopover = styled.div`
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: end;
+
+  ${Text} {
+    margin-top: 0;
+    margin-bottom: 1.5rem;
+  }
+
+  ${Input.Field} {
+    width: 40px;
+    height: 32px;
+    font-size: 0.875rem;
+    line-height: 1rem;
+    padding: 0.625rem;
+    margin: 0 0.5rem;
+
+    border: 1px solid ${color('border')}
+  }
+
+  ${Button.Root} {
+    width: 120px;
+  }
+`

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/QuestionCacheSection/QuestionCacheSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/QuestionCacheSection/QuestionCacheSection.tsx
@@ -1,0 +1,80 @@
+import React, { useCallback, useState } from "react";
+import { t } from "ttag";
+
+import TippyPopoverWithTrigger from "metabase/components/PopoverWithTrigger/TippyPopoverWithTrigger";
+import Button from "metabase/core/components/Button";
+import ActionButton from "metabase/components/ActionButton";
+import Input from "metabase/core/components/Input";
+
+import Question from "metabase-lib/lib/Question";
+import { color } from "metabase/lib/colors";
+
+import { normalizeCacheTTL } from "../../utils";
+
+import {
+  Text,
+  QuestionCacheSectionRoot,
+  CachePopover,
+} from "./QuestionCacheSection.styled";
+
+interface QuestionCacheSectionProps {
+  question: Question;
+  onSave: (cache_ttl: number | null) => Promise<Question>;
+}
+
+export const QuestionCacheSection = ({
+  question,
+  onSave,
+}: QuestionCacheSectionProps) => {
+  const [cacheTTL, setCacheTTL] = useState<number | null>(question.cache_ttl());
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const {
+        target: { value },
+      } = e;
+      setCacheTTL(normalizeCacheTTL(parseInt(value)));
+    },
+    [setCacheTTL],
+  );
+
+  const handleSave = useCallback(async () => {
+    return await onSave(cacheTTL);
+  }, [onSave, cacheTTL]);
+
+  return (
+    <QuestionCacheSectionRoot>
+      <TippyPopoverWithTrigger
+        key="extra-actions-menu"
+        placement="bottom-start"
+        renderTrigger={({ onClick, visible }) => (
+          <Button
+            borderless
+            color={color("brand")}
+            onClick={onClick}
+            iconRight={visible ? "chevronup" : "chevrondown"}
+          >
+            {t`Cache Configuration`}
+          </Button>
+        )}
+        popoverContent={
+          <CachePopover>
+            <Text>
+              {t`Cache results for `}{" "}
+              <Input
+                placeholder="24"
+                value={cacheTTL || ""}
+                onChange={handleChange}
+              />{" "}
+              {t` hours`}
+            </Text>
+            <ActionButton
+              primary
+              actionFn={handleSave}
+            >{t`Save changes`}</ActionButton>
+          </CachePopover>
+        }
+      />
+    </QuestionCacheSectionRoot>
+  );
+};

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/QuestionCacheSection/QuestionCacheSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/QuestionCacheSection/QuestionCacheSection.tsx
@@ -4,7 +4,7 @@ import { t } from "ttag";
 import TippyPopoverWithTrigger from "metabase/components/PopoverWithTrigger/TippyPopoverWithTrigger";
 import Button from "metabase/core/components/Button";
 import ActionButton from "metabase/components/ActionButton";
-import Input from "metabase/core/components/Input";
+import NumericInput from "metabase/core/components/NumericInput";
 
 import Question from "metabase-lib/lib/Question";
 import { color } from "metabase/lib/colors";
@@ -29,11 +29,8 @@ export const QuestionCacheSection = ({
   const [cacheTTL, setCacheTTL] = useState<number | null>(question.cache_ttl());
 
   const handleChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      const {
-        target: { value },
-      } = e;
-      setCacheTTL(normalizeCacheTTL(parseInt(value)));
+    number => {
+      setCacheTTL(normalizeCacheTTL(number));
     },
     [setCacheTTL],
   );
@@ -60,13 +57,13 @@ export const QuestionCacheSection = ({
         popoverContent={
           <CachePopover>
             <Text>
-              {t`Cache results for `}{" "}
-              <Input
+              {t`Cache results for`}
+              <NumericInput
                 placeholder="24"
                 value={cacheTTL || ""}
                 onChange={handleChange}
-              />{" "}
-              {t` hours`}
+              />
+              {t`hours`}
             </Text>
             <ActionButton
               primary

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/QuestionCacheSection/QuestionCacheSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/QuestionCacheSection/QuestionCacheSection.tsx
@@ -26,7 +26,7 @@ export const QuestionCacheSection = ({
   question,
   onSave,
 }: QuestionCacheSectionProps) => {
-  const [cacheTTL, setCacheTTL] = useState<number | null>(question.cache_ttl());
+  const [cacheTTL, setCacheTTL] = useState<number | null>(question.cacheTTL());
 
   const handleChange = useCallback(
     number => {

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/QuestionCacheSection/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/QuestionCacheSection/index.js
@@ -1,0 +1,1 @@
+export * from './QuestionCacheSection';

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/QuestionCacheSection/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/QuestionCacheSection/index.js
@@ -1,1 +1,1 @@
-export * from './QuestionCacheSection';
+export * from "./QuestionCacheSection";

--- a/enterprise/frontend/src/metabase-enterprise/caching/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/caching/index.js
@@ -52,5 +52,5 @@ if (hasPremiumFeature("advanced_config")) {
 
   PLUGIN_CACHING.getQuestionsImplicitCacheTTL = getQuestionsImplicitCacheTTL;
   PLUGIN_CACHING.QuestionCacheSection = QuestionCacheSection;
-  PLUGIN_CACHING.showQuestionCacheSection = true;
+  PLUGIN_CACHING.isEnabled = () => true;
 }

--- a/enterprise/frontend/src/metabase-enterprise/caching/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/caching/index.js
@@ -6,6 +6,8 @@ import Link from "metabase/core/components/Link";
 import { CacheTTLField } from "./components/CacheTTLField";
 import { DatabaseCacheTTLField } from "./components/DatabaseCacheTTLField";
 import { QuestionCacheTTLField } from "./components/QuestionCacheTTLField";
+import { QuestionCacheSection } from "./components/QuestionCacheSection";
+
 import {
   getQuestionsImplicitCacheTTL,
   validateCacheTTL,
@@ -49,4 +51,6 @@ if (hasPremiumFeature("advanced_config")) {
   PLUGIN_FORM_WIDGETS.questionCacheTTL = QuestionCacheTTLField;
 
   PLUGIN_CACHING.getQuestionsImplicitCacheTTL = getQuestionsImplicitCacheTTL;
+  PLUGIN_CACHING.QuestionCacheSection = QuestionCacheSection;
+  PLUGIN_CACHING.showQuestionCacheSection = true;
 }

--- a/enterprise/frontend/src/metabase-enterprise/caching/utils.js
+++ b/enterprise/frontend/src/metabase-enterprise/caching/utils.js
@@ -52,5 +52,5 @@ export function validateCacheTTL(value) {
 }
 
 export function normalizeCacheTTL(value) {
-  return value === 0 ? null : value;
+  return value === 0 || value === undefined ? null : value;
 }

--- a/frontend/src/metabase-lib/lib/Question.ts
+++ b/frontend/src/metabase-lib/lib/Question.ts
@@ -283,6 +283,13 @@ class QuestionInner {
   }
 
   /**
+   * The cache_ttl of a question if it exists
+   */
+  cache_ttl(): number | null {
+    return this._card?.cache_ttl;
+  }
+
+  /**
    * returns whether this question is a model
    * @returns boolean
    */

--- a/frontend/src/metabase-lib/lib/Question.ts
+++ b/frontend/src/metabase-lib/lib/Question.ts
@@ -289,6 +289,10 @@ class QuestionInner {
     return this._card?.cache_ttl;
   }
 
+  setCacheTTL(cache) {
+    return this.setCard(assoc(this.card(), "cache_ttl", cache));
+  }
+
   /**
    * returns whether this question is a model
    * @returns boolean
@@ -866,8 +870,12 @@ class QuestionInner {
     return this.setCard(card);
   }
 
-  description(): string | null | undefined {
+  description(): string | null {
     return this._card && this._card.description;
+  }
+
+  setDescription(description) {
+    return this.setCard(assoc(this.card(), "description", description));
   }
 
   lastEditInfo() {

--- a/frontend/src/metabase-lib/lib/Question.ts
+++ b/frontend/src/metabase-lib/lib/Question.ts
@@ -282,10 +282,7 @@ class QuestionInner {
     return this.setCard(assoc(this.card(), "display", display));
   }
 
-  /**
-   * The cache_ttl of a question if it exists
-   */
-  cache_ttl(): number | null {
+  cacheTTL(): number | null {
     return this._card?.cache_ttl;
   }
 

--- a/frontend/src/metabase-types/types/Card.ts
+++ b/frontend/src/metabase-types/types/Card.ts
@@ -27,7 +27,7 @@ export type SavedCard<Query = DatasetQuery> = UnsavedCard<Query> & {
   can_write: boolean;
   public_uuid: string;
   archived?: boolean;
-  cache_ttl?: number;
+  cache_ttl?: number | null;
 };
 
 export type Card<Query = DatasetQuery> = SavedCard<Query> | UnsavedCard<Query>;

--- a/frontend/src/metabase-types/types/Card.ts
+++ b/frontend/src/metabase-types/types/Card.ts
@@ -22,7 +22,7 @@ export type UnsavedCard<Query = DatasetQuery> = {
 export type SavedCard<Query = DatasetQuery> = UnsavedCard<Query> & {
   id: CardId;
   name?: string;
-  description?: string;
+  description?: string | null;
   dataset?: boolean;
   can_write: boolean;
   public_uuid: string;

--- a/frontend/src/metabase-types/types/Card.ts
+++ b/frontend/src/metabase-types/types/Card.ts
@@ -27,6 +27,7 @@ export type SavedCard<Query = DatasetQuery> = UnsavedCard<Query> & {
   can_write: boolean;
   public_uuid: string;
   archived?: boolean;
+  cache_ttl?: number;
 };
 
 export type Card<Query = DatasetQuery> = SavedCard<Query> | UnsavedCard<Query>;

--- a/frontend/src/metabase/lib/keyboard.js
+++ b/frontend/src/metabase/lib/keyboard.js
@@ -13,3 +13,4 @@ export const KEY_COMMA = ",";
 export const KEYCODE_FORWARD_SLASH = 191;
 
 export const KEY_ESCAPE = "Escape";
+export const KEY_ENTER = "Enter";

--- a/frontend/src/metabase/lib/settings.ts
+++ b/frontend/src/metabase/lib/settings.ts
@@ -96,7 +96,8 @@ export type SettingName =
   | "premium-embedding-token"
   | "metabase-store-managed"
   | "application-font"
-  | "available-fonts";
+  | "available-fonts"
+  | "enable-query-caching";
 
 type SettingsMap = Record<SettingName, any>; // provides access to Metabase application settings
 

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -126,7 +126,9 @@ export const PLUGIN_CACHING = {
   dashboardCacheTTLFormField: null,
   databaseCacheTTLFormField: null,
   questionCacheTTLFormField: null,
-  getQuestionsImplicitCacheTTL: () => null,
+  getQuestionsImplicitCacheTTL: (question?: any) => null,
+  QuestionCacheSection: PluginPlaceholder,
+  showQuestionCacheSection: false,
 };
 
 export const PLUGIN_REDUCERS: { applicationPermissionsPlugin: any } = {

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -128,7 +128,7 @@ export const PLUGIN_CACHING = {
   questionCacheTTLFormField: null,
   getQuestionsImplicitCacheTTL: (question?: any) => null,
   QuestionCacheSection: PluginPlaceholder,
-  showQuestionCacheSection: false,
+  isEnabled: () => false,
 };
 
 export const PLUGIN_REDUCERS: { applicationPermissionsPlugin: any } = {

--- a/frontend/src/metabase/query_builder/components/EditableText/EditableText.stories.tsx
+++ b/frontend/src/metabase/query_builder/components/EditableText/EditableText.stories.tsx
@@ -10,7 +10,8 @@ export default {
 
 const Template: ComponentStory<typeof EditableText> = args => {
   const [{ initialValue }, updateArgs] = useArgs();
-  const handleChange = (value: string) => updateArgs({ initialValue: value });
+  const handleChange = (value: string | null | undefined) =>
+    updateArgs({ initialValue: value });
 
   console.log(initialValue);
 

--- a/frontend/src/metabase/query_builder/components/EditableText/EditableText.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/EditableText/EditableText.styled.tsx
@@ -24,7 +24,8 @@ export const EditableTextRoot = styled.div<EditableTextRootProps>`
   max-width: 500px;
 
   &:after {
-    content: "${props => props.value} ";
+    content: "${props =>
+      props.value?.replace(/"/g, '\\"').replace(/\n/g, "\\00000a")} ";
     white-space: pre-wrap;
     visibility: hidden;
     ${SharedStyles}

--- a/frontend/src/metabase/query_builder/components/EditableText/EditableText.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/EditableText/EditableText.styled.tsx
@@ -13,10 +13,8 @@ export const SharedStyles = css`
   color: ${color("text-dark")};
 `;
 
-export type TEXT = string | null;
-
 interface EditableTextRootProps {
-  value: TEXT;
+  value: string | null;
 }
 
 export const EditableTextRoot = styled.div<EditableTextRootProps>`

--- a/frontend/src/metabase/query_builder/components/EditableText/EditableText.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/EditableText/EditableText.styled.tsx
@@ -2,7 +2,7 @@ import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
 import { css } from "@emotion/react";
 
-const sharedStyle = css`
+export const SharedStyles = css`
   border: 1px solid transparent;
   border-radius: 0.25rem;
   padding: 0.5rem;
@@ -15,13 +15,13 @@ const sharedStyle = css`
 
 export const EditableTextRoot = styled.div`
   display: grid;
-  max-width: 300px;
+  max-width: 500px;
 
   &::after {
     content: attr(data-replicated-value) " ";
     white-space: pre-wrap;
     visibility: hidden;
-    ${sharedStyle}
+    ${SharedStyles}
   }
 `;
 
@@ -39,5 +39,5 @@ export const EditableTextArea = styled.textarea`
     cursor: text;
   }
 
-  ${sharedStyle}
+  ${SharedStyles}
 `;

--- a/frontend/src/metabase/query_builder/components/EditableText/EditableText.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/EditableText/EditableText.styled.tsx
@@ -24,8 +24,7 @@ export const EditableTextRoot = styled.div<EditableTextRootProps>`
   max-width: 500px;
 
   &:after {
-    content: "${props =>
-      props.value?.replace(/"/g, '\\"').replace(/\n/g, "\\00000a")} ";
+    content: "${props => props.value?.replace(/\n/g, "\\00000a")} ";
     white-space: pre-wrap;
     visibility: hidden;
     ${SharedStyles}

--- a/frontend/src/metabase/query_builder/components/EditableText/EditableText.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/EditableText/EditableText.styled.tsx
@@ -13,12 +13,18 @@ export const SharedStyles = css`
   color: ${color("text-dark")};
 `;
 
-export const EditableTextRoot = styled.div`
+export type TEXT = string | null | undefined;
+
+interface EditableTextRootProps {
+  value: TEXT;
+}
+
+export const EditableTextRoot = styled.div<EditableTextRootProps>`
   display: grid;
   max-width: 500px;
 
-  &::after {
-    content: attr(data-replicated-value) " ";
+  &:after {
+    content: "${props => props.value} ";
     white-space: pre-wrap;
     visibility: hidden;
     ${SharedStyles}

--- a/frontend/src/metabase/query_builder/components/EditableText/EditableText.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/EditableText/EditableText.styled.tsx
@@ -13,7 +13,7 @@ export const SharedStyles = css`
   color: ${color("text-dark")};
 `;
 
-export type TEXT = string | null | undefined;
+export type TEXT = string | null;
 
 interface EditableTextRootProps {
   value: TEXT;

--- a/frontend/src/metabase/query_builder/components/EditableText/EditableText.tsx
+++ b/frontend/src/metabase/query_builder/components/EditableText/EditableText.tsx
@@ -55,7 +55,7 @@ const EditableText = ({
     <EditableTextRoot value={value}>
       <EditableTextArea
         placeholder={placeholder}
-        value={value || undefined}
+        value={value || ""}
         onChange={handleChange}
         onBlur={handleBlur}
         onKeyDown={handleKeyDown}

--- a/frontend/src/metabase/query_builder/components/EditableText/EditableText.tsx
+++ b/frontend/src/metabase/query_builder/components/EditableText/EditableText.tsx
@@ -1,17 +1,15 @@
 import React, { useState, useRef } from "react";
+import { KEY_ESCAPE, KEY_ENTER } from "metabase/lib/keyboard";
 
 import {
   EditableTextRoot,
   EditableTextArea,
   SharedStyles,
-  TEXT,
 } from "./EditableText.styled";
 
-import { KEY_ESCAPE, KEY_ENTER } from "metabase/lib/keyboard";
-
 interface EditableTextProps {
-  initialValue: TEXT;
-  onChange?: (val: TEXT) => void;
+  initialValue: string | null;
+  onChange?: (val: string | null) => void;
   submitOnEnter?: boolean;
   "data-testid"?: string;
   placeholder?: string;
@@ -24,7 +22,7 @@ const EditableText = ({
   "data-testid": dataTestid,
   placeholder,
 }: EditableTextProps) => {
-  const [value, setValue] = useState<TEXT>(initialValue);
+  const [value, setValue] = useState<string | null>(initialValue);
   const textArea = useRef<HTMLTextAreaElement>(null);
 
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
@@ -37,7 +35,7 @@ const EditableText = ({
     } = e;
 
     if (onChange && value !== initialValue) {
-      onChange(e.target.value);
+      onChange(value);
     }
   };
 

--- a/frontend/src/metabase/query_builder/components/EditableText/EditableText.tsx
+++ b/frontend/src/metabase/query_builder/components/EditableText/EditableText.tsx
@@ -13,12 +13,16 @@ interface EditableTextProps {
   initialValue: TEXT;
   onChange?: (val: TEXT) => void;
   submitOnEnter?: boolean;
+  "data-testid"?: string;
+  placeholder?: string;
 }
 
 const EditableText = ({
   initialValue,
   onChange,
   submitOnEnter,
+  "data-testid": dataTestid,
+  placeholder,
 }: EditableTextProps) => {
   const [value, setValue] = useState<TEXT>(initialValue);
   const textArea = useRef<HTMLTextAreaElement>(null);
@@ -50,7 +54,7 @@ const EditableText = ({
   return (
     <EditableTextRoot value={value}>
       <EditableTextArea
-        placeholder="Description"
+        placeholder={placeholder}
         value={value || undefined}
         onChange={handleChange}
         onBlur={handleBlur}
@@ -58,6 +62,7 @@ const EditableText = ({
         rows={1}
         cols={1}
         ref={textArea}
+        data-testid={dataTestid}
       />
     </EditableTextRoot>
   );

--- a/frontend/src/metabase/query_builder/components/EditableText/EditableText.tsx
+++ b/frontend/src/metabase/query_builder/components/EditableText/EditableText.tsx
@@ -1,18 +1,28 @@
-import React, { useState } from "react";
+import React, { useState, useRef } from "react";
 
-import { EditableTextRoot, EditableTextArea } from "./EditableText.styled";
+import {
+  EditableTextRoot,
+  EditableTextArea,
+  SharedStyles,
+} from "./EditableText.styled";
 
-import { KEY_ESCAPE } from "metabase/lib/keyboard";
+import { KEY_ESCAPE, KEY_ENTER } from "metabase/lib/keyboard";
 
 type TEXT = string | null | undefined;
 
 interface EditableTextProps {
   initialValue: TEXT;
-  onChange?: (val: string) => void;
+  onChange?: (val: TEXT) => void;
+  submitOnEnter?: boolean;
 }
 
-const EditableText = ({ initialValue, onChange }: EditableTextProps) => {
+const EditableText = ({
+  initialValue,
+  onChange,
+  submitOnEnter,
+}: EditableTextProps) => {
   const [value, setValue] = useState<TEXT>(initialValue);
+  const textArea = useRef<HTMLTextAreaElement>(null);
 
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setValue(e.target.value);
@@ -28,6 +38,10 @@ const EditableText = ({ initialValue, onChange }: EditableTextProps) => {
     if (e.key === KEY_ESCAPE) {
       setValue(initialValue);
     }
+    if (e.key === KEY_ENTER && submitOnEnter) {
+      textArea.current?.blur();
+      e.preventDefault();
+    }
   };
 
   return (
@@ -38,9 +52,16 @@ const EditableText = ({ initialValue, onChange }: EditableTextProps) => {
         onChange={handleChange}
         onBlur={handleBlur}
         onKeyDown={handleKeyDown}
+        rows={1}
+        cols={1}
+        ref={textArea}
       />
     </EditableTextRoot>
   );
 };
 
-export default EditableText;
+export default Object.assign(EditableText, {
+  SharedStyles,
+  Root: EditableTextRoot,
+  TextArea: EditableTextArea,
+});

--- a/frontend/src/metabase/query_builder/components/EditableText/EditableText.tsx
+++ b/frontend/src/metabase/query_builder/components/EditableText/EditableText.tsx
@@ -4,11 +4,10 @@ import {
   EditableTextRoot,
   EditableTextArea,
   SharedStyles,
+  TEXT,
 } from "./EditableText.styled";
 
 import { KEY_ESCAPE, KEY_ENTER } from "metabase/lib/keyboard";
-
-type TEXT = string | null | undefined;
 
 interface EditableTextProps {
   initialValue: TEXT;
@@ -29,7 +28,11 @@ const EditableText = ({
   };
 
   const handleBlur = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    if (onChange) {
+    const {
+      target: { value },
+    } = e;
+
+    if (onChange && value !== initialValue) {
       onChange(e.target.value);
     }
   };
@@ -45,7 +48,7 @@ const EditableText = ({
   };
 
   return (
-    <EditableTextRoot data-replicated-value={value}>
+    <EditableTextRoot value={value}>
       <EditableTextArea
         placeholder="Description"
         value={value || undefined}

--- a/frontend/src/metabase/query_builder/components/SavedQuestionHeaderButton/SavedQuestionHeaderButton.jsx
+++ b/frontend/src/metabase/query_builder/components/SavedQuestionHeaderButton/SavedQuestionHeaderButton.jsx
@@ -2,34 +2,44 @@ import React from "react";
 import PropTypes from "prop-types";
 
 import { PLUGIN_MODERATION } from "metabase/plugins";
-import { HeaderButton } from "./SavedQuestionHeaderButton.styled";
+import EditableText from "../EditableText/EditableText";
 
-export default SavedQuestionHeaderButton;
+import { Root, StyledIcon } from "./SavedQuestionHeaderButton.styled";
+
+import { color } from "metabase/lib/colors";
 
 SavedQuestionHeaderButton.propTypes = {
   className: PropTypes.string,
   question: PropTypes.object.isRequired,
-  onClick: PropTypes.func.isRequired,
-  isActive: PropTypes.bool.isRequired,
+  onSave: PropTypes.func,
 };
 
-function SavedQuestionHeaderButton({ className, question, onClick, isActive }) {
+const ICON_SIZE = 16;
+
+function SavedQuestionHeaderButton({ className, question, onSave }) {
   const {
     name: reviewIconName,
     color: reviewIconColor,
   } = PLUGIN_MODERATION.getStatusIconForQuestion(question);
 
   return (
-    <HeaderButton
-      className={className}
-      onClick={onClick}
-      icon={reviewIconName}
-      leftIconColor={reviewIconColor}
-      isActive={isActive}
-      iconSize={20}
-      data-testid="saved-question-header-button"
-    >
-      {question.displayName()}
-    </HeaderButton>
+    <Root>
+      <EditableText
+        initialValue={question.displayName()}
+        onChange={onSave}
+        submitOnEnter
+      />
+      {reviewIconName && (
+        <StyledIcon
+          name={reviewIconName}
+          color={color(reviewIconColor)}
+          size={ICON_SIZE}
+        />
+      )}
+    </Root>
   );
 }
+
+export default Object.assign(SavedQuestionHeaderButton, {
+  Root,
+});

--- a/frontend/src/metabase/query_builder/components/SavedQuestionHeaderButton/SavedQuestionHeaderButton.jsx
+++ b/frontend/src/metabase/query_builder/components/SavedQuestionHeaderButton/SavedQuestionHeaderButton.jsx
@@ -31,6 +31,7 @@ function SavedQuestionHeaderButton({ className, question, onSave }) {
         initialValue={question.displayName()}
         onChange={onSave}
         submitOnEnter
+        placeholder="A nice title"
         data-testid="saved-question-header-title"
       />
       {reviewIconName && (

--- a/frontend/src/metabase/query_builder/components/SavedQuestionHeaderButton/SavedQuestionHeaderButton.jsx
+++ b/frontend/src/metabase/query_builder/components/SavedQuestionHeaderButton/SavedQuestionHeaderButton.jsx
@@ -1,15 +1,16 @@
 import React from "react";
+import { t } from "ttag";
 import PropTypes from "prop-types";
 
 import { PLUGIN_MODERATION } from "metabase/plugins";
-import EditableText from "../EditableText/EditableText";
 
+import { color } from "metabase/lib/colors";
+
+import EditableText from "../EditableText";
 import {
   HeaderRoot,
   HeaderReviewIcon,
 } from "./SavedQuestionHeaderButton.styled";
-
-import { color } from "metabase/lib/colors";
 
 SavedQuestionHeaderButton.propTypes = {
   className: PropTypes.string,
@@ -31,7 +32,7 @@ function SavedQuestionHeaderButton({ className, question, onSave }) {
         initialValue={question.displayName()}
         onChange={onSave}
         submitOnEnter
-        placeholder="A nice title"
+        placeholder={t`A nice title`}
         data-testid="saved-question-header-title"
       />
       {reviewIconName && (

--- a/frontend/src/metabase/query_builder/components/SavedQuestionHeaderButton/SavedQuestionHeaderButton.jsx
+++ b/frontend/src/metabase/query_builder/components/SavedQuestionHeaderButton/SavedQuestionHeaderButton.jsx
@@ -4,7 +4,10 @@ import PropTypes from "prop-types";
 import { PLUGIN_MODERATION } from "metabase/plugins";
 import EditableText from "../EditableText/EditableText";
 
-import { Root, StyledIcon } from "./SavedQuestionHeaderButton.styled";
+import {
+  HeaderRoot,
+  HeaderReviewIcon,
+} from "./SavedQuestionHeaderButton.styled";
 
 import { color } from "metabase/lib/colors";
 
@@ -23,23 +26,24 @@ function SavedQuestionHeaderButton({ className, question, onSave }) {
   } = PLUGIN_MODERATION.getStatusIconForQuestion(question);
 
   return (
-    <Root>
+    <HeaderRoot>
       <EditableText
         initialValue={question.displayName()}
         onChange={onSave}
         submitOnEnter
+        data-testid="saved-question-header-title"
       />
       {reviewIconName && (
-        <StyledIcon
+        <HeaderReviewIcon
           name={reviewIconName}
           color={color(reviewIconColor)}
           size={ICON_SIZE}
         />
       )}
-    </Root>
+    </HeaderRoot>
   );
 }
 
 export default Object.assign(SavedQuestionHeaderButton, {
-  Root,
+  Root: HeaderRoot,
 });

--- a/frontend/src/metabase/query_builder/components/SavedQuestionHeaderButton/SavedQuestionHeaderButton.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/SavedQuestionHeaderButton/SavedQuestionHeaderButton.styled.jsx
@@ -3,21 +3,18 @@ import styled from "@emotion/styled";
 import EditableText from "../EditableText/EditableText";
 import Icon from "metabase/components/Icon";
 
-export const Root = styled.div`
-  ${EditableText.Root}::after, ${EditableText.TextArea} {
+export const HeaderRoot = styled.div`
+  ${EditableText.Root}:after, ${EditableText.TextArea} {
     font-size: 1.25rem;
     font-weight: 700;
     line-height: 1.5rem;
     padding: 0.25rem;
   }
 
-  ${EditableText.Root}::after {
-    content: attr(data-replicated-value);
-  }
   display: flex;
   align-items: center;
 `;
 
-export const StyledIcon = styled(Icon)`
+export const HeaderReviewIcon = styled(Icon)`
   padding-left: 0.25rem;
 `;

--- a/frontend/src/metabase/query_builder/components/SavedQuestionHeaderButton/SavedQuestionHeaderButton.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/SavedQuestionHeaderButton/SavedQuestionHeaderButton.styled.jsx
@@ -1,17 +1,23 @@
 import styled from "@emotion/styled";
-import { color } from "metabase/lib/colors";
 
-import Button from "metabase/core/components/Button";
+import EditableText from "../EditableText/EditableText";
+import Icon from "metabase/components/Icon";
 
-export const HeaderButton = styled(Button)`
-  font-size: 1.25rem;
-  border: none;
-  padding: 0.25rem 0.25rem;
-  color: ${props => (props.isActive ? color("brand") : "unset")};
-  background-color: ${props => (props.isActive ? color("bg-light") : "unset")};
-  text-align: left;
-
-  .Icon:not(.Icon-chevrondown) {
-    color: ${props => color(props.leftIconColor)};
+export const Root = styled.div`
+  ${EditableText.Root}::after, ${EditableText.TextArea} {
+    font-size: 1.25rem;
+    font-weight: 700;
+    line-height: 1.5rem;
+    padding: 0.25rem;
   }
+
+  ${EditableText.Root}::after {
+    content: attr(data-replicated-value);
+  }
+  display: flex;
+  align-items: center;
+`;
+
+export const StyledIcon = styled(Icon)`
+  padding-left: 0.25rem;
 `;

--- a/frontend/src/metabase/query_builder/components/SavedQuestionHeaderButton/SavedQuestionHeaderButton.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/SavedQuestionHeaderButton/SavedQuestionHeaderButton.unit.spec.js
@@ -1,26 +1,23 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import SavedQuestionHeaderButton from "./SavedQuestionHeaderButton";
 
 describe("SavedQuestionHeaderButton", () => {
-  let onClick;
+  let onSave;
   let question;
   let componentContainer;
 
   beforeEach(() => {
-    onClick = jest.fn();
+    onSave = jest.fn();
     question = {
       displayName: () => "foo",
       getModerationReviews: () => [],
     };
 
     const { container } = render(
-      <SavedQuestionHeaderButton
-        question={question}
-        onClick={onClick}
-        isActive={false}
-      />,
+      <SavedQuestionHeaderButton question={question} onSave={onSave} />,
     );
 
     componentContainer = container;
@@ -30,16 +27,17 @@ describe("SavedQuestionHeaderButton", () => {
     expect(screen.getByText("foo")).toBeInTheDocument();
   });
 
-  it("is clickable", () => {
-    screen.getByText("foo").click();
-    expect(onClick).toHaveBeenCalled();
+  it("is updateable", () => {
+    const title = screen.getByTestId("saved-question-header-title");
+    userEvent.type(title, "1");
+    title.blur();
+
+    expect(onSave).toHaveBeenCalled();
   });
 
   describe("when the question does not have a latest moderation review", () => {
     it("should contain no additional icons", () => {
-      expect(
-        componentContainer.querySelector(".Icon:not(.Icon-chevrondown)"),
-      ).toEqual(null);
+      expect(componentContainer.querySelector(".Icon")).toEqual(null);
     });
   });
 
@@ -54,20 +52,14 @@ describe("SavedQuestionHeaderButton", () => {
       };
 
       const { container } = render(
-        <SavedQuestionHeaderButton
-          question={question}
-          onClick={onClick}
-          isActive={false}
-        />,
+        <SavedQuestionHeaderButton question={question} onSave={onSave} />,
       );
 
       componentContainer = container;
     });
 
     it("should have an additional icon to signify the question's moderation status", () => {
-      expect(
-        componentContainer.querySelector(".Icon:not(.Icon-chevrondown)"),
-      ).toBeDefined();
+      expect(componentContainer.querySelector(".Icon")).toBeDefined();
     });
   });
 });

--- a/frontend/src/metabase/query_builder/components/SavedQuestionHeaderButton/SavedQuestionHeaderButton.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/SavedQuestionHeaderButton/SavedQuestionHeaderButton.unit.spec.js
@@ -59,7 +59,7 @@ describe("SavedQuestionHeaderButton", () => {
     });
 
     it("should have an additional icon to signify the question's moderation status", () => {
-      expect(componentContainer.querySelector(".Icon")).toBeDefined();
+      expect(componentContainer.querySelector(".Icon")).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/metabase/query_builder/components/SavedQuestionHeaderButton/SavedQuestionHeaderButton.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/SavedQuestionHeaderButton/SavedQuestionHeaderButton.unit.spec.js
@@ -59,7 +59,7 @@ describe("SavedQuestionHeaderButton", () => {
     });
 
     it("should have an additional icon to signify the question's moderation status", () => {
-      expect(componentContainer.querySelector(".Icon")).toBeInTheDocument();
+      expect(componentContainer.querySelector(".Icon")).toBeDefined();
     });
   });
 });

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -45,6 +45,7 @@ import {
   ViewSubHeaderRoot,
   StyledLastEditInfoLabel,
   StyledQuestionDataSource,
+  SavedQuestionLeftSideRoot,
 } from "./ViewHeader.styled";
 
 const viewTitleHeaderPropTypes = {
@@ -129,9 +130,7 @@ export function ViewTitleHeader(props) {
         style={style}
         data-testid="qb-header"
       >
-        {isDataset ? (
-          <DatasetLeftSide {...props} />
-        ) : isSaved ? (
+        {isSaved ? (
           <SavedQuestionLeftSide {...props} />
         ) : (
           <AhHocQuestionLeftSide
@@ -168,7 +167,7 @@ SavedQuestionLeftSide.propTypes = {
   isAdditionalInfoVisible: PropTypes.bool,
   isShowingQuestionDetailsSidebar: PropTypes.bool,
   onOpenQuestionInfo: PropTypes.func.isRequired,
-  onOpenModal: PropTypes.func.isRequired,
+  onSave: PropTypes.func,
 };
 
 function SavedQuestionLeftSide(props) {
@@ -178,31 +177,33 @@ function SavedQuestionLeftSide(props) {
     isAdditionalInfoVisible,
     isShowingQuestionDetailsSidebar,
     onOpenQuestionInfo,
-    onOpenModal,
+    onSave,
   } = props;
 
   const hasLastEditInfo = question.lastEditInfo() != null;
 
-  const onHeaderClick = useCallback(() => {
-    onOpenModal(MODAL_TYPES.EDIT);
-  }, [onOpenModal]);
+  const onHeaderChange = useCallback(
+    name => {
+      if (name !== question.displayName()) {
+        onSave({
+          ...question.card(),
+          name,
+        });
+      }
+    },
+    [question, onSave],
+  );
 
   return (
-    <div>
+    <SavedQuestionLeftSideRoot>
       <ViewHeaderMainLeftContentContainer>
         <SavedQuestionHeaderButtonContainer>
           <SavedQuestionHeaderButton
             question={question}
             isActive={isShowingQuestionDetailsSidebar}
-            onClick={onHeaderClick}
+            onSave={onHeaderChange}
           />
         </SavedQuestionHeaderButtonContainer>
-        {hasLastEditInfo && isAdditionalInfoVisible && (
-          <StyledLastEditInfoLabel
-            item={question.card()}
-            onClick={onOpenQuestionInfo}
-          />
-        )}
       </ViewHeaderMainLeftContentContainer>
       {isAdditionalInfoVisible && (
         <ViewHeaderLeftSubHeading>
@@ -213,9 +214,15 @@ function SavedQuestionLeftSide(props) {
               subHead
             />
           )}
+          {hasLastEditInfo && isAdditionalInfoVisible && (
+            <StyledLastEditInfoLabel
+              item={question.card()}
+              onClick={onOpenQuestionInfo}
+            />
+          )}
         </ViewHeaderLeftSubHeading>
       )}
-    </div>
+    </SavedQuestionLeftSideRoot>
   );
 }
 
@@ -279,12 +286,7 @@ DatasetLeftSide.propTypes = {
 };
 
 function DatasetLeftSide(props) {
-  const {
-    question,
-    isAdditionalInfoVisible,
-    isShowingQuestionDetailsSidebar,
-    onOpenModal,
-  } = props;
+  const { question, isShowingQuestionDetailsSidebar, onOpenModal } = props;
 
   const onHeaderClick = useCallback(() => {
     onOpenModal(MODAL_TYPES.EDIT);
@@ -294,26 +296,13 @@ function DatasetLeftSide(props) {
     <div>
       <ViewHeaderMainLeftContentContainer>
         <AdHocViewHeading>
-          <HeadBreadcrumbs
-            divider="/"
-            parts={[
-              ...(isAdditionalInfoVisible
-                ? [
-                    <DatasetCollectionBadge
-                      key="collection"
-                      dataset={question}
-                    />,
-                  ]
-                : []),
-              <DatasetHeaderButtonContainer key="dataset-header-button">
-                <SavedQuestionHeaderButton
-                  question={question}
-                  isActive={isShowingQuestionDetailsSidebar}
-                  onClick={onHeaderClick}
-                />
-              </DatasetHeaderButtonContainer>,
-            ]}
-          />
+          <DatasetHeaderButtonContainer key="dataset-header-button">
+            <SavedQuestionHeaderButton
+              question={question}
+              isActive={isShowingQuestionDetailsSidebar}
+              onClick={onHeaderClick}
+            />
+          </DatasetHeaderButtonContainer>
         </AdHocViewHeading>
       </ViewHeaderMainLeftContentContainer>
     </div>

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -36,7 +36,6 @@ import QuestionActions from "../QuestionActions";
 import NativeQueryButton from "./NativeQueryButton";
 import {
   AdHocViewHeading,
-  DatasetHeaderButtonContainer,
   SaveButton,
   SavedQuestionHeaderButtonContainer,
   ViewHeaderMainLeftContentContainer,
@@ -175,7 +174,6 @@ function SavedQuestionLeftSide(props) {
     question,
     isObjectDetail,
     isAdditionalInfoVisible,
-    isShowingQuestionDetailsSidebar,
     onOpenQuestionInfo,
     onSave,
   } = props;
@@ -200,7 +198,6 @@ function SavedQuestionLeftSide(props) {
         <SavedQuestionHeaderButtonContainer>
           <SavedQuestionHeaderButton
             question={question}
-            isActive={isShowingQuestionDetailsSidebar}
             onSave={onHeaderChange}
           />
         </SavedQuestionHeaderButtonContainer>
@@ -274,37 +271,6 @@ function AhHocQuestionLeftSide(props) {
           />
         )}
       </ViewHeaderLeftSubHeading>
-    </div>
-  );
-}
-
-DatasetLeftSide.propTypes = {
-  question: PropTypes.object.isRequired,
-  isAdditionalInfoVisible: PropTypes.bool,
-  isShowingQuestionDetailsSidebar: PropTypes.bool,
-  onOpenModal: PropTypes.func.isRequired,
-};
-
-function DatasetLeftSide(props) {
-  const { question, isShowingQuestionDetailsSidebar, onOpenModal } = props;
-
-  const onHeaderClick = useCallback(() => {
-    onOpenModal(MODAL_TYPES.EDIT);
-  }, [onOpenModal]);
-
-  return (
-    <div>
-      <ViewHeaderMainLeftContentContainer>
-        <AdHocViewHeading>
-          <DatasetHeaderButtonContainer key="dataset-header-button">
-            <SavedQuestionHeaderButton
-              question={question}
-              isActive={isShowingQuestionDetailsSidebar}
-              onClick={onHeaderClick}
-            />
-          </DatasetHeaderButtonContainer>
-        </AdHocViewHeading>
-      </ViewHeaderMainLeftContentContainer>
     </div>
   );
 }

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -193,7 +193,7 @@ function SavedQuestionLeftSide(props) {
   );
 
   return (
-    <SavedQuestionLeftSideRoot>
+    <SavedQuestionLeftSideRoot data-testid="qb-header-left-side">
       <ViewHeaderMainLeftContentContainer>
         <SavedQuestionHeaderButtonContainer>
           <SavedQuestionHeaderButton

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useCallback } from "react";
+import React, { useEffect, useCallback, useState } from "react";
 import PropTypes from "prop-types";
 import { t } from "ttag";
 import cx from "classnames";
@@ -14,6 +14,7 @@ import ViewButton from "metabase/query_builder/components/view/ViewButton";
 
 import { usePrevious } from "metabase/hooks/use-previous";
 import { useToggle } from "metabase/hooks/use-toggle";
+import { useOnMount } from "metabase/hooks/use-on-mount";
 
 import { MODAL_TYPES } from "metabase/query_builder/constants";
 import SavedQuestionHeaderButton from "metabase/query_builder/components/SavedQuestionHeaderButton/SavedQuestionHeaderButton";
@@ -178,6 +179,15 @@ function SavedQuestionLeftSide(props) {
     onSave,
   } = props;
 
+  const [showSubHeader, setShowSubHeader] = useState(true);
+
+  useOnMount(() => {
+    const timerId = setTimeout(() => {
+      setShowSubHeader(false);
+    }, 4000);
+    return () => clearTimeout(timerId);
+  });
+
   const hasLastEditInfo = question.lastEditInfo() != null;
 
   const onHeaderChange = useCallback(
@@ -193,7 +203,10 @@ function SavedQuestionLeftSide(props) {
   );
 
   return (
-    <SavedQuestionLeftSideRoot data-testid="qb-header-left-side">
+    <SavedQuestionLeftSideRoot
+      data-testid="qb-header-left-side"
+      showSubHeader={showSubHeader}
+    >
       <ViewHeaderMainLeftContentContainer>
         <SavedQuestionHeaderButtonContainer>
           <SavedQuestionHeaderButton

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.styled.jsx
@@ -131,11 +131,11 @@ export const SavedQuestionLeftSideRoot = styled.div`
   ${SavedQuestionHeaderButton.Root} {
     transition: all 400ms ease;
     position: relative;
-    top: 10px;
+    top: ${props => (props.showSubHeader ? "0" : "10px")};
   }
 
   ${ViewHeaderLeftSubHeading} {
-    opacity: 0;
+    opacity: ${props => (props.showSubHeader ? "1" : "0")};
     transition: all 400ms ease;
   }
 

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.styled.jsx
@@ -8,6 +8,7 @@ import { color, alpha } from "metabase/lib/colors";
 import { breakpointMaxSmall, space } from "metabase/styled-components/theme";
 import ViewSection, { ViewSubHeading, ViewHeading } from "./ViewSection";
 import QuestionDataSource from "./QuestionDataSource";
+import SavedQuestionHeaderButton from "../SavedQuestionHeaderButton/SavedQuestionHeaderButton";
 
 export const ViewHeaderContainer = styled(ViewSection)`
   border-bottom: 1px solid ${color("border")};
@@ -123,11 +124,36 @@ export const StyledLastEditInfoLabel = styled(LastEditInfoLabel)`
 `;
 
 export const StyledQuestionDataSource = styled(QuestionDataSource)`
-  margin-bottom: 0.5rem;
   padding-right: 1rem;
 
   ${breakpointMaxSmall} {
     margin-left: 0;
     padding-right: 0;
+  }
+`;
+
+export const SavedQuestionLeftSideRoot = styled.div`
+  ${SavedQuestionHeaderButton.Root} {
+    transition: all 400ms ease 4s;
+    position: relative;
+    top: 10px;
+  }
+
+  ${ViewHeaderLeftSubHeading} {
+    opacity: 0;
+    transition: all 400ms ease 4s;
+  }
+
+  &:hover,
+  &:focus-within {
+    ${SavedQuestionHeaderButton.Root} {
+      top: 0px;
+      transition: all 400ms ease 0s;
+    }
+
+    ${ViewHeaderLeftSubHeading} {
+      opacity: 1;
+      transition: all 400ms ease 0s;
+    }
   }
 `;

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.styled.jsx
@@ -129,26 +129,24 @@ export const StyledQuestionDataSource = styled(QuestionDataSource)`
 
 export const SavedQuestionLeftSideRoot = styled.div`
   ${SavedQuestionHeaderButton.Root} {
-    transition: all 400ms ease 4s;
+    transition: all 400ms ease;
     position: relative;
     top: 10px;
   }
 
   ${ViewHeaderLeftSubHeading} {
     opacity: 0;
-    transition: all 400ms ease 4s;
+    transition: all 400ms ease;
   }
 
   &:hover,
   &:focus-within {
     ${SavedQuestionHeaderButton.Root} {
       top: 0px;
-      transition: all 400ms ease 0s;
     }
 
     ${ViewHeaderLeftSubHeading} {
       opacity: 1;
-      transition: all 400ms ease 0s;
     }
   }
 `;

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.styled.jsx
@@ -55,11 +55,6 @@ export const SavedQuestionHeaderButtonContainer = styled.div`
   right: 0.38rem;
 `;
 
-export const DatasetHeaderButtonContainer = styled.div`
-  position: relative;
-  right: 0.3rem;
-`;
-
 export const HeaderButton = styled(Button)`
   font-size: 0.875rem;
   background-color: ${({ active, color = getDefaultColor() }) =>

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.unit.spec.js
@@ -1,5 +1,6 @@
 import React from "react";
 import xhrMock from "xhr-mock";
+import userEvent from "@testing-library/user-event";
 import { fireEvent, renderWithProviders, screen } from "__support__/ui";
 import {
   SAMPLE_DATABASE,
@@ -107,6 +108,7 @@ function setup({
     onCloseFilter: jest.fn(),
     onEditSummary: jest.fn(),
     onCloseSummary: jest.fn(),
+    onSave: jest.fn(),
   };
 
   renderWithProviders(
@@ -356,9 +358,11 @@ describe("ViewHeader", () => {
         });
 
         it("opens details sidebar on question name click", () => {
-          const { onOpenModal } = setup({ question });
-          fireEvent.click(screen.getByText(question.displayName()));
-          expect(onOpenModal).toHaveBeenCalled();
+          const { onSave } = setup({ question });
+          const title = screen.getByTestId("saved-question-header-title");
+          userEvent.type(title, "New Title");
+          fireEvent.blur(title);
+          expect(onSave).toHaveBeenCalled();
         });
 
         it("shows bookmark and action buttons", () => {

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.tsx
@@ -1,6 +1,10 @@
 import React from "react";
 
-import { PLUGIN_MODERATION, PLUGIN_MODEL_PERSISTENCE } from "metabase/plugins";
+import {
+  PLUGIN_MODERATION,
+  PLUGIN_MODEL_PERSISTENCE,
+  PLUGIN_CACHING,
+} from "metabase/plugins";
 
 import EditableText from "../../EditableText";
 import QuestionActivityTimeline from "metabase/query_builder/components/QuestionActivityTimeline";
@@ -9,12 +13,15 @@ import { Card } from "metabase-types/types/Card";
 
 import { Root, ContentSection } from "./QuestionInfoSidebar.styled";
 
-interface Props {
+interface QuestionInfoSidebarProps {
   question: Question;
-  onSave: (card: Card) => void;
+  onSave: (card: Card) => Promise<Question>;
 }
 
-export const QuestionInfoSidebar = ({ question, onSave }: Props) => {
+export const QuestionInfoSidebar = ({
+  question,
+  onSave,
+}: QuestionInfoSidebarProps) => {
   const description = question.description();
   const isDataset = question.isDataset();
   const isPersisted = isDataset && question.isPersisted();
@@ -24,6 +31,15 @@ export const QuestionInfoSidebar = ({ question, onSave }: Props) => {
       onSave({
         ...question.card(),
         description,
+      });
+    }
+  };
+
+  const handleUpdateCacheTTL = (cache_ttl: number | undefined) => {
+    if (question.cache_ttl() !== cache_ttl) {
+      return onSave({
+        ...question.card(),
+        cache_ttl,
       });
     }
   };
@@ -43,6 +59,15 @@ export const QuestionInfoSidebar = ({ question, onSave }: Props) => {
         <ContentSection extraPadding>
           <PLUGIN_MODEL_PERSISTENCE.ModelCacheManagementSection
             model={question}
+          />
+        </ContentSection>
+      )}
+
+      {PLUGIN_CACHING.showQuestionCacheSection && (
+        <ContentSection extraPadding>
+          <PLUGIN_CACHING.QuestionCacheSection
+            question={question}
+            onSave={handleUpdateCacheTTL}
           />
         </ContentSection>
       )}

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.tsx
@@ -19,7 +19,7 @@ export const QuestionInfoSidebar = ({ question, onSave }: Props) => {
   const isDataset = question.isDataset();
   const isPersisted = isDataset && question.isPersisted();
 
-  const handleSave = (description: string) => {
+  const handleSave = (description: string | null | undefined) => {
     if (question.description() !== description) {
       onSave({
         ...question.card(),
@@ -31,7 +31,11 @@ export const QuestionInfoSidebar = ({ question, onSave }: Props) => {
   return (
     <Root>
       <ContentSection>
-        <EditableText initialValue={description} onChange={handleSave} />
+        <EditableText
+          initialValue={description}
+          onChange={handleSave}
+          placeholder="Description"
+        />
         <PLUGIN_MODERATION.QuestionModerationSection question={question} />
       </ContentSection>
 

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.tsx
@@ -26,21 +26,15 @@ export const QuestionInfoSidebar = ({
   const isDataset = question.isDataset();
   const isPersisted = isDataset && question.isPersisted();
 
-  const handleSave = (description: string | null | undefined) => {
+  const handleSave = (description: string | null) => {
     if (question.description() !== description) {
-      onSave({
-        ...question.card(),
-        description,
-      });
+      onSave(question.setDescription(description).card());
     }
   };
 
   const handleUpdateCacheTTL = (cache_ttl: number | undefined) => {
     if (question.cache_ttl() !== cache_ttl) {
-      return onSave({
-        ...question.card(),
-        cache_ttl,
-      });
+      return onSave(question.setCacheTTL(cache_ttl).card());
     }
   };
 

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.tsx
@@ -6,11 +6,14 @@ import {
   PLUGIN_CACHING,
 } from "metabase/plugins";
 
-import EditableText from "../../EditableText";
+import MetabaseSettings from "metabase/lib/settings";
+
 import QuestionActivityTimeline from "metabase/query_builder/components/QuestionActivityTimeline";
+
 import Question from "metabase-lib/lib/Question";
 import { Card } from "metabase-types/types/Card";
 
+import EditableText from "../../EditableText";
 import { Root, ContentSection } from "./QuestionInfoSidebar.styled";
 
 interface QuestionInfoSidebarProps {
@@ -26,6 +29,9 @@ export const QuestionInfoSidebar = ({
   const isDataset = question.isDataset();
   const isPersisted = isDataset && question.isPersisted();
 
+  const showCaching =
+    PLUGIN_CACHING.isEnabled() && MetabaseSettings.get("enable-query-caching");
+
   const handleSave = (description: string | null) => {
     if (question.description() !== description) {
       onSave(question.setDescription(description).card());
@@ -33,7 +39,7 @@ export const QuestionInfoSidebar = ({
   };
 
   const handleUpdateCacheTTL = (cache_ttl: number | undefined) => {
-    if (question.cache_ttl() !== cache_ttl) {
+    if (question.cacheTTL() !== cache_ttl) {
       return onSave(question.setCacheTTL(cache_ttl).card());
     }
   };
@@ -57,7 +63,7 @@ export const QuestionInfoSidebar = ({
         </ContentSection>
       )}
 
-      {PLUGIN_CACHING.showQuestionCacheSection && (
+      {showCaching && (
         <ContentSection extraPadding>
           <PLUGIN_CACHING.QuestionCacheSection
             question={question}

--- a/frontend/test/metabase/scenarios/embedding/embedding-full-app.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/embedding-full-app.cy.spec.js
@@ -55,6 +55,7 @@ describe("scenarios > embedding > full app", () => {
       visitQuestionUrl({ url: "/question/1" });
 
       cy.findByTestId("qb-header").should("be.visible");
+      cy.findByTestId("qb-header-left-side").realHover();
       cy.findByText(/Edited/).should("be.visible");
 
       cy.icon("refresh").should("be.visible");

--- a/frontend/test/metabase/scenarios/models/models.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models.cy.spec.js
@@ -28,7 +28,6 @@ import {
   selectDimensionOptionFromSidebar,
   saveQuestionBasedOnModel,
   assertIsQuestion,
-  openDetailsSidebar,
 } from "./helpers/e2e-models-helpers";
 
 const { PRODUCTS } = SAMPLE_DATABASE;
@@ -376,22 +375,21 @@ describe("scenarios > models", () => {
       cy.visit("/model/1");
       cy.wait("@dataset");
 
-      openDetailsSidebar();
-      modal().within(() => {
-        cy.findByLabelText("Name")
-          .clear()
-          .type("M1");
-        cy.findByLabelText("Description")
-          .clear()
-          .type("foo");
-        cy.button("Save").click();
-      });
+      cy.findByTestId("saved-question-header-title")
+        .clear()
+        .type("M1")
+        .blur();
       cy.wait("@updateCard");
 
       questionInfoButton().click();
 
-      cy.findByText("M1");
-      cy.findByText("foo");
+      cy.findByPlaceholderText("Description")
+        .type("foo")
+        .blur();
+      cy.wait("@updateCard");
+
+      cy.findByDisplayValue("M1");
+      cy.findByDisplayValue("foo");
     });
   });
 

--- a/frontend/test/metabase/scenarios/organization/moderation-question.cy.spec.js
+++ b/frontend/test/metabase/scenarios/organization/moderation-question.cy.spec.js
@@ -42,7 +42,7 @@ describeEE("scenarios > saved question moderation", () => {
 
       cy.findByText("Verify this question").should("be.visible");
 
-      cy.findByTestId("saved-question-header-button").within(() => {
+      cy.findByTestId("qb-header-left-side").within(() => {
         cy.icon("verified").should("not.exist");
       });
 

--- a/frontend/test/metabase/scenarios/question/caching.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/caching.cy.spec.js
@@ -2,9 +2,11 @@ import {
   restore,
   describeEE,
   mockSessionProperty,
-  modal,
   visitQuestion,
+  questionInfoButton,
+  rightSidebar,
 } from "__support__/e2e/cypress";
+import { popover } from "../../../__support__/e2e/helpers/e2e-ui-elements-helpers";
 
 describeEE("scenarios > question > caching", () => {
   beforeEach(() => {
@@ -17,40 +19,50 @@ describeEE("scenarios > question > caching", () => {
     cy.intercept("PUT", "/api/card/1").as("updateQuestion");
     visitQuestion(1);
 
-    openEditingModalForm();
-    modal().within(() => {
-      cy.findByText("More options").click();
+    questionInfoButton().click();
+
+    rightSidebar().within(() => {
+      cy.findByText("Cache Configuration").click();
+    });
+
+    popover().within(() => {
       cy.findByPlaceholderText("24")
         .clear()
         .type("48")
         .blur();
-      cy.button("Save").click();
+      cy.button("Save changes").click();
     });
 
     cy.wait("@updateQuestion");
+    cy.button(/Saved/);
     cy.reload();
 
-    openEditingModalForm();
-    modal().within(() => {
-      cy.findByText("More options").click();
+    questionInfoButton().click();
+
+    rightSidebar().within(() => {
+      cy.findByText("Cache Configuration").click();
+    });
+
+    popover().within(() => {
       cy.findByDisplayValue("48")
         .clear()
         .type("0")
         .blur();
-      cy.button("Save").click();
+      cy.button("Save changes").click();
     });
 
     cy.wait("@updateQuestion");
+    cy.button(/Saved/);
     cy.reload();
 
-    openEditingModalForm();
-    modal().within(() => {
-      cy.findByText("More options").click();
+    questionInfoButton().click();
+
+    rightSidebar().within(() => {
+      cy.findByText("Cache Configuration").click();
+    });
+
+    popover().within(() => {
       cy.findByPlaceholderText("24");
     });
   });
 });
-
-function openEditingModalForm() {
-  cy.findByTestId("saved-question-header-button").click();
-}

--- a/frontend/test/metabase/scenarios/question/caching.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/caching.cy.spec.js
@@ -5,8 +5,8 @@ import {
   visitQuestion,
   questionInfoButton,
   rightSidebar,
+  popover,
 } from "__support__/e2e/cypress";
-import { popover } from "../../../__support__/e2e/helpers/e2e-ui-elements-helpers";
 
 describeEE("scenarios > question > caching", () => {
   beforeEach(() => {

--- a/frontend/test/metabase/scenarios/question/question-management.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/question-management.cy.spec.js
@@ -36,11 +36,10 @@ describe("managing question from the question's details sidebar", () => {
 
             it("should be able to edit question details (metabase#11719-1)", () => {
               // cy.skipOn(user === "nodata");
-              cy.findByTestId("saved-question-header-button").click();
-              cy.findByLabelText("Name")
+              cy.findByTestId("saved-question-header-title")
                 .click()
-                .type("1");
-              clickButton("Save");
+                .type("1")
+                .blur();
               assertOnRequest("updateQuestion");
               cy.findByText("Orders1");
             });
@@ -50,9 +49,10 @@ describe("managing question from the question's details sidebar", () => {
 
               questionInfoButton().click();
 
-              cy.findByPlaceholderText("Description").type("foo", { delay: 0 });
+              cy.findByPlaceholderText("Description")
+                .type("foo", { delay: 0 })
+                .blur();
 
-              cy.findByPlaceholderText("Description").blur();
               assertOnRequest("updateQuestion");
 
               cy.findByText("foo");
@@ -174,5 +174,4 @@ function assertOnRequest(xhr_alias) {
   cy.findByText("Sorry, you don’t have permission to see that.").should(
     "not.exist",
   );
-  cy.get(".Modal").should("not.exist");
 }

--- a/frontend/test/metabase/scenarios/smoketest/admin_setup.cy.spec.js
+++ b/frontend/test/metabase/scenarios/smoketest/admin_setup.cy.spec.js
@@ -2,7 +2,6 @@ import {
   browse,
   popover,
   restore,
-  modal,
   openPeopleTable,
   visualize,
   navigationSidebar,
@@ -10,6 +9,7 @@ import {
   visitQuestion,
 } from "__support__/e2e/cypress";
 import { USERS } from "__support__/e2e/cypress_data";
+import { questionInfoButton } from "../../../__support__/e2e/helpers/e2e-ui-elements-helpers";
 
 const { admin, normal, nocollection, nodata } = USERS;
 const new_user = {
@@ -277,6 +277,7 @@ describe("smoketest > admin_setup", () => {
     });
 
     it("should rename a question and description as admin", () => {
+      cy.intercept("PUT", "/api/card/3").as("updateCard");
       cy.visit("/");
 
       cy.findByText("Our analytics").click();
@@ -290,12 +291,18 @@ describe("smoketest > admin_setup", () => {
 
       cy.findByText("Settings");
 
-      cy.findByTestId("saved-question-header-button").click();
-      cy.findByLabelText("Name")
+      cy.findByTestId("saved-question-header-title")
         .clear()
-        .type("Test Question");
-      cy.findByLabelText("Description").type("Testing question description");
-      cy.findByText("Save").click();
+        .type("Test Question")
+        .blur();
+      cy.wait("@updateCard");
+
+      questionInfoButton().click();
+      cy.findByPlaceholderText("Description")
+        .clear()
+        .type("Testing question description")
+        .blur();
+      cy.wait("@updateCard");
     });
 
     it("should rename a table and add a description as admin", () => {
@@ -537,14 +544,11 @@ describe("smoketest > admin_setup", () => {
       );
 
       cy.findByText("Test Question").click();
-      cy.findByTestId("saved-question-header-button").click();
 
-      cy.findByText("Edit question");
-      modal().within(() => {
-        cy.findByText("Testing question description");
-      });
-
-      cy.findByText("Cancel").click();
+      questionInfoButton().click();
+      cy.findByDisplayValue("Test Question");
+      cy.findByDisplayValue("Testing question description");
+      questionInfoButton().click();
 
       // Check column names and visiblity
 


### PR DESCRIPTION
Epic #22826 

Updating so that Question titles can be edited inline. Sub header information appears on hover, and while the title is being edited.
![chrome_gDAcyqG0fW](https://user-images.githubusercontent.com/1328979/173603539-d84d3cdd-bf16-488f-a1b8-13907131e2a0.gif)