### PR TITLE
Run Percy (visual regression) sanity check on PRs using GHA

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -144,6 +144,10 @@ jobs:
       env:
         TERM: xterm
 
+    - name: Percy Test Sanity Check
+      if: matrix.edition == 'ee'
+      run: yarn run test-visual-run
+
     - name: Upload Cypress recording upon failure
       uses: actions/upload-artifact@v2
       if: failure()

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -158,7 +158,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 30
     needs: build
-    name: Percy Test Sanity Check
+    name: percy-tests-sanity-check-${{ matrix.edition }}
     env:
       MB_EDITION: ${{ matrix.edition }}
       ENTERPRISE_TOKEN: ${{ secrets.ENTERPRISE_TOKEN }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -145,7 +145,8 @@ jobs:
         TERM: xterm
 
     - name: Percy Test Sanity Check
-      if: matrix.edition == 'ee'
+      # The name of the folder does not matter. This "hack" makes sure that we only run visual tests once.
+      if: matrix.edition == 'ee' && matrix.folder == 'binning'
       run: yarn run test-visual-run
 
     - name: Upload Cypress recording upon failure

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -115,7 +115,7 @@ jobs:
       with:
         java-version: ${{ matrix.java-version }}
         distribution: 'temurin'
-    - name: Prepare cypress environment
+    - name: Prepare Cypress environment
       uses: ./.github/actions/prepare-cypress
     - name: Run Snowplow micro
       uses: ./.github/actions/run-snowplow-micro
@@ -144,11 +144,6 @@ jobs:
       env:
         TERM: xterm
 
-    - name: Percy Test Sanity Check
-      # The name of the folder does not matter. This "hack" makes sure that we only run visual tests once.
-      if: matrix.edition == 'ee' && matrix.folder == 'binning'
-      run: yarn run test-visual-run
-
     - name: Upload Cypress recording upon failure
       uses: actions/upload-artifact@v2
       if: failure()
@@ -158,3 +153,48 @@ jobs:
           ./cypress
           ./logs/test.log
         if-no-files-found: ignore
+
+  visual-regression-tests:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 30
+    needs: build
+    name: Percy Test Sanity Check
+    env:
+      MB_EDITION: ${{ matrix.edition }}
+      ENTERPRISE_TOKEN: ${{ secrets.ENTERPRISE_TOKEN }}
+    strategy:
+      matrix:
+        java-version: [11]
+        edition: [ee]
+    services:
+      maildev:
+        image: maildev/maildev:1.1.0
+        ports:
+          - "80:80"
+          - "25:25"
+        credentials:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+    steps:
+    - uses: actions/checkout@v3
+    - name: Prepare front-end environment
+      uses: ./.github/actions/prepare-frontend
+    - name: Prepare JDK ${{ matrix.java-version }}
+      uses: actions/setup-java@v3
+      with:
+        java-version: ${{ matrix.java-version }}
+        distribution: 'temurin'
+    - name: Prepare Cypress environment
+      uses: ./.github/actions/prepare-cypress
+
+    - uses: actions/download-artifact@v2
+      name: Retrieve uberjar artifact for ${{ matrix.edition }}
+      with:
+        name: metabase-${{ matrix.edition }}-uberjar
+    - name: Get the version info
+      run: |
+        jar xf target/uberjar/metabase.jar version.properties
+        mv version.properties resources/
+    - name: Percy Test
+      run: yarn run test-visual-run
+    

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -197,4 +197,3 @@ jobs:
         mv version.properties resources/
     - name: Percy Test
       run: yarn run test-visual-run
-    


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Adds the visual regression sanity check to the existing E2E workflow that runs on PRs
- This will not record and/or send screenshots to Percy servers. It literary makes sure we don't break anything before we merge commit to the `master` branch

### Why?
- The goal is to remove Percy from CircleCI and to run it using GitHub Actions

before
![image](https://user-images.githubusercontent.com/31325167/173667050-4f73ba62-f1a6-4657-8b9c-a163cb4dc14d.png)

after
![image](https://user-images.githubusercontent.com/31325167/173666940-05d10397-c3e0-4faa-9908-1c13f8ce02a7.png)