### PR TITLE
Show disabled menu item to show visualization

### DIFF
--- a/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.tsx
+++ b/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.tsx
@@ -3,9 +3,8 @@ import React, { useCallback } from "react";
 import { Collection } from "metabase-types/api";
 import { ANALYTICS_CONTEXT } from "metabase/collections/constants";
 import {
-  isItemPinned,
-  isPreviewable,
   hasRequiredParameters,
+  isItemPinned,
   isPreviewEnabled,
   Item,
 } from "metabase/collections/utils";

--- a/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.tsx
+++ b/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.tsx
@@ -3,9 +3,9 @@ import React, { useCallback } from "react";
 import { Collection } from "metabase-types/api";
 import { ANALYTICS_CONTEXT } from "metabase/collections/constants";
 import {
-  hasRequiredParameters,
   isItemPinned,
   isPreviewEnabled,
+  isPreviewShown,
   Item,
 } from "metabase/collections/utils";
 import EventSandbox from "metabase/components/EventSandbox";
@@ -50,11 +50,8 @@ function ActionMenu({
   deleteBookmark,
 }: ActionMenuProps) {
   const isBookmarked = bookmarks && getIsBookmarked(item, bookmarks);
-  const canTogglePreview =
-    isItemPinned(item) &&
-    hasRequiredParameters(item) &&
-    collection.can_write &&
-    item.setCollectionPreview;
+  const isPreviewVisible =
+    isItemPinned(item) && collection.can_write && item.setCollectionPreview;
 
   const handlePin = useCallback(() => {
     item.setPinned(!isItemPinned(item));
@@ -78,7 +75,7 @@ function ActionMenu({
   }, [createBookmark, deleteBookmark, isBookmarked, item]);
 
   const handleTogglePreview = useCallback(() => {
-    item?.setCollectionPreview?.(!isPreviewEnabled(item));
+    item?.setCollectionPreview?.(!isPreviewShown(item));
   }, [item]);
 
   return (
@@ -89,6 +86,7 @@ function ActionMenu({
         className={className}
         item={item}
         isBookmarked={isBookmarked}
+        isPreviewShown={isPreviewShown(item)}
         isPreviewEnabled={isPreviewEnabled(item)}
         onPin={collection.can_write ? handlePin : null}
         onMove={collection.can_write && item.setCollection ? handleMove : null}
@@ -97,7 +95,7 @@ function ActionMenu({
           collection.can_write && item.setArchived ? handleArchive : null
         }
         onToggleBookmark={handleToggleBookmark}
-        onTogglePreview={canTogglePreview ? handleTogglePreview : null}
+        onTogglePreview={isPreviewVisible ? handleTogglePreview : null}
         analyticsContext={ANALYTICS_CONTEXT}
       />
     </EventSandbox>

--- a/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.tsx
+++ b/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.tsx
@@ -4,8 +4,8 @@ import { Collection } from "metabase-types/api";
 import { ANALYTICS_CONTEXT } from "metabase/collections/constants";
 import {
   isItemPinned,
-  isPreviewEnabled,
-  isPreviewShown,
+  isItemPreviewEnabled,
+  isItemPreviewShown,
   Item,
 } from "metabase/collections/utils";
 import EventSandbox from "metabase/components/EventSandbox";
@@ -75,7 +75,7 @@ function ActionMenu({
   }, [createBookmark, deleteBookmark, isBookmarked, item]);
 
   const handleTogglePreview = useCallback(() => {
-    item?.setCollectionPreview?.(!isPreviewShown(item));
+    item?.setCollectionPreview?.(!isItemPreviewShown(item));
   }, [item]);
 
   return (
@@ -86,8 +86,8 @@ function ActionMenu({
         className={className}
         item={item}
         isBookmarked={isBookmarked}
-        isPreviewShown={isPreviewShown(item)}
-        isPreviewEnabled={isPreviewEnabled(item)}
+        isPreviewShown={isItemPreviewShown(item)}
+        isPreviewEnabled={isItemPreviewEnabled(item)}
         onPin={collection.can_write ? handlePin : null}
         onMove={collection.can_write && item.setCollection ? handleMove : null}
         onCopy={item.copy ? handleCopy : null}

--- a/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.tsx
+++ b/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.tsx
@@ -5,6 +5,7 @@ import { ANALYTICS_CONTEXT } from "metabase/collections/constants";
 import {
   hasRequiredParameters,
   isItemPinned,
+  isPreviewable,
   isPreviewEnabled,
   Item,
 } from "metabase/collections/utils";
@@ -86,7 +87,7 @@ function ActionMenu({
         className={className}
         item={item}
         isBookmarked={isBookmarked}
-        isPreviewEnabled={isPreviewEnabled(item)}
+        isPreviewEnabled={isPreviewable(item)}
         isPreviewAvailable={hasRequiredParameters(item)}
         onPin={collection.can_write ? handlePin : null}
         onMove={collection.can_write && item.setCollection ? handleMove : null}

--- a/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.tsx
+++ b/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.tsx
@@ -51,7 +51,7 @@ function ActionMenu({
   deleteBookmark,
 }: ActionMenuProps) {
   const isBookmarked = bookmarks && getIsBookmarked(item, bookmarks);
-  const isPreviewVisible =
+  const isPreviewOptionShown =
     isItemPinned(item) && collection.can_write && item.setCollectionPreview;
 
   const handlePin = useCallback(() => {
@@ -96,7 +96,7 @@ function ActionMenu({
           collection.can_write && item.setArchived ? handleArchive : null
         }
         onToggleBookmark={handleToggleBookmark}
-        onTogglePreview={isPreviewVisible ? handleTogglePreview : null}
+        onTogglePreview={isPreviewOptionShown ? handleTogglePreview : null}
         analyticsContext={ANALYTICS_CONTEXT}
       />
     </EventSandbox>

--- a/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.tsx
+++ b/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.tsx
@@ -87,8 +87,8 @@ function ActionMenu({
         className={className}
         item={item}
         isBookmarked={isBookmarked}
-        isPreviewShown={isPreviewable(item)}
-        isPreviewEnabled={hasRequiredParameters(item)}
+        isPreviewEnabled={isPreviewEnabled(item)}
+        isPreviewAvailable={hasRequiredParameters(item)}
         onPin={collection.can_write ? handlePin : null}
         onMove={collection.can_write && item.setCollection ? handleMove : null}
         onCopy={item.copy ? handleCopy : null}

--- a/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.tsx
+++ b/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.tsx
@@ -4,6 +4,7 @@ import { Collection } from "metabase-types/api";
 import { ANALYTICS_CONTEXT } from "metabase/collections/constants";
 import {
   isItemPinned,
+  isItemPreviewable,
   isItemPreviewEnabled,
   isItemPreviewShown,
   Item,
@@ -86,7 +87,7 @@ function ActionMenu({
         className={className}
         item={item}
         isBookmarked={isBookmarked}
-        isPreviewShown={isItemPreviewShown(item)}
+        isPreviewShown={isItemPreviewable(item)}
         isPreviewEnabled={isItemPreviewEnabled(item)}
         onPin={collection.can_write ? handlePin : null}
         onMove={collection.can_write && item.setCollection ? handleMove : null}

--- a/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.tsx
+++ b/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.tsx
@@ -5,7 +5,7 @@ import { ANALYTICS_CONTEXT } from "metabase/collections/constants";
 import {
   hasRequiredParameters,
   isItemPinned,
-  isPreviewable,
+  isPreviewShown,
   isPreviewEnabled,
   Item,
 } from "metabase/collections/utils";
@@ -87,7 +87,7 @@ function ActionMenu({
         className={className}
         item={item}
         isBookmarked={isBookmarked}
-        isPreviewEnabled={isPreviewable(item)}
+        isPreviewShown={isPreviewShown(item)}
         isPreviewAvailable={hasRequiredParameters(item)}
         onPin={collection.can_write ? handlePin : null}
         onMove={collection.can_write && item.setCollection ? handleMove : null}

--- a/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.tsx
+++ b/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.tsx
@@ -4,9 +4,9 @@ import { Collection } from "metabase-types/api";
 import { ANALYTICS_CONTEXT } from "metabase/collections/constants";
 import {
   isItemPinned,
-  isItemPreviewable,
-  isItemPreviewEnabled,
-  isItemPreviewShown,
+  isPreviewable,
+  hasRequiredParameters,
+  isPreviewEnabled,
   Item,
 } from "metabase/collections/utils";
 import EventSandbox from "metabase/components/EventSandbox";
@@ -76,7 +76,7 @@ function ActionMenu({
   }, [createBookmark, deleteBookmark, isBookmarked, item]);
 
   const handleTogglePreview = useCallback(() => {
-    item?.setCollectionPreview?.(!isItemPreviewShown(item));
+    item?.setCollectionPreview?.(!isPreviewEnabled(item));
   }, [item]);
 
   return (
@@ -87,8 +87,8 @@ function ActionMenu({
         className={className}
         item={item}
         isBookmarked={isBookmarked}
-        isPreviewShown={isItemPreviewable(item)}
-        isPreviewEnabled={isItemPreviewEnabled(item)}
+        isPreviewShown={isPreviewable(item)}
+        isPreviewEnabled={hasRequiredParameters(item)}
         onPin={collection.can_write ? handlePin : null}
         onMove={collection.can_write && item.setCollection ? handleMove : null}
         onCopy={item.copy ? handleCopy : null}

--- a/frontend/src/metabase/collections/components/PinnedItemOverview/PinnedItemOverview.tsx
+++ b/frontend/src/metabase/collections/components/PinnedItemOverview/PinnedItemOverview.tsx
@@ -11,7 +11,7 @@ import PinnedItemSortDropTarget from "metabase/collections/components/PinnedItem
 import {
   Item,
   isRootCollection,
-  isPreviewable,
+  isPreviewShown,
 } from "metabase/collections/utils";
 import PinDropZone from "metabase/collections/components/PinDropZone";
 import ItemDragSource from "metabase/containers/dnd/ItemDragSource";
@@ -50,7 +50,7 @@ function PinnedItemOverview({
     dashboard: dashboardItems = [],
     dataset: dataModelItems = [],
   } = _.groupBy(sortedItems, "model");
-  const cardGroups = _.partition(cardItems, isPreviewable);
+  const cardGroups = _.partition(cardItems, isPreviewShown);
 
   return items.length === 0 ? (
     <Container>

--- a/frontend/src/metabase/collections/components/PinnedItemOverview/PinnedItemOverview.tsx
+++ b/frontend/src/metabase/collections/components/PinnedItemOverview/PinnedItemOverview.tsx
@@ -11,7 +11,7 @@ import PinnedItemSortDropTarget from "metabase/collections/components/PinnedItem
 import {
   Item,
   isRootCollection,
-  isPreviewable,
+  isItemPreviewable,
 } from "metabase/collections/utils";
 import PinDropZone from "metabase/collections/components/PinDropZone";
 import ItemDragSource from "metabase/containers/dnd/ItemDragSource";
@@ -50,7 +50,7 @@ function PinnedItemOverview({
     dashboard: dashboardItems = [],
     dataset: dataModelItems = [],
   } = _.groupBy(sortedItems, "model");
-  const cardGroups = _.partition(cardItems, isPreviewable);
+  const cardGroups = _.partition(cardItems, isItemPreviewable);
 
   return items.length === 0 ? (
     <Container>

--- a/frontend/src/metabase/collections/components/PinnedItemOverview/PinnedItemOverview.tsx
+++ b/frontend/src/metabase/collections/components/PinnedItemOverview/PinnedItemOverview.tsx
@@ -11,7 +11,7 @@ import PinnedItemSortDropTarget from "metabase/collections/components/PinnedItem
 import {
   Item,
   isRootCollection,
-  isItemPreviewable,
+  isPreviewable,
 } from "metabase/collections/utils";
 import PinDropZone from "metabase/collections/components/PinDropZone";
 import ItemDragSource from "metabase/containers/dnd/ItemDragSource";
@@ -50,7 +50,7 @@ function PinnedItemOverview({
     dashboard: dashboardItems = [],
     dataset: dataModelItems = [],
   } = _.groupBy(sortedItems, "model");
-  const cardGroups = _.partition(cardItems, isItemPreviewable);
+  const cardGroups = _.partition(cardItems, isPreviewable);
 
   return items.length === 0 ? (
     <Container>

--- a/frontend/src/metabase/collections/components/PinnedQuestionCard/PinnedQuestionCard.tsx
+++ b/frontend/src/metabase/collections/components/PinnedQuestionCard/PinnedQuestionCard.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { t } from "ttag";
 import {
-  isPreviewable,
   hasRequiredParameters,
+  isPreviewable,
   Item,
 } from "metabase/collections/utils";
 import Visualization from "metabase/visualizations/components/Visualization";

--- a/frontend/src/metabase/collections/components/PinnedQuestionCard/PinnedQuestionCard.tsx
+++ b/frontend/src/metabase/collections/components/PinnedQuestionCard/PinnedQuestionCard.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { t } from "ttag";
 import {
   hasRequiredParameters,
-  isPreviewable,
+  isItemPreviewable,
   Item,
 } from "metabase/collections/utils";
 import Visualization from "metabase/visualizations/components/Visualization";
@@ -37,7 +37,7 @@ const PinnedQuestionCard = ({
   onCreateBookmark,
   onDeleteBookmark,
 }: PinnedQuestionCardProps): JSX.Element => {
-  const isPreview = isPreviewable(item);
+  const isPreview = isItemPreviewable(item);
 
   return (
     <CardRoot to={item.getUrl()} isPreview={isPreview}>

--- a/frontend/src/metabase/collections/components/PinnedQuestionCard/PinnedQuestionCard.tsx
+++ b/frontend/src/metabase/collections/components/PinnedQuestionCard/PinnedQuestionCard.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { t } from "ttag";
 import {
-  isItemPreviewable,
-  isItemPreviewEnabled,
+  isPreviewable,
+  hasRequiredParameters,
   Item,
 } from "metabase/collections/utils";
 import Visualization from "metabase/visualizations/components/Visualization";
@@ -37,7 +37,7 @@ const PinnedQuestionCard = ({
   onCreateBookmark,
   onDeleteBookmark,
 }: PinnedQuestionCardProps): JSX.Element => {
-  const isPreview = isItemPreviewable(item);
+  const isPreview = isPreviewable(item);
 
   return (
     <CardRoot to={item.getUrl()} isPreview={isPreview}>
@@ -83,7 +83,7 @@ const PinnedQuestionCard = ({
 };
 
 const getSkeletonTooltip = (item: Item) => {
-  if (!isItemPreviewEnabled(item)) {
+  if (!hasRequiredParameters(item)) {
     return t`Open this question and fill in its variables to see it.`;
   } else {
     return undefined;

--- a/frontend/src/metabase/collections/components/PinnedQuestionCard/PinnedQuestionCard.tsx
+++ b/frontend/src/metabase/collections/components/PinnedQuestionCard/PinnedQuestionCard.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { t } from "ttag";
 import {
-  hasRequiredParameters,
   isItemPreviewable,
+  isItemPreviewEnabled,
   Item,
 } from "metabase/collections/utils";
 import Visualization from "metabase/visualizations/components/Visualization";
@@ -83,7 +83,7 @@ const PinnedQuestionCard = ({
 };
 
 const getSkeletonTooltip = (item: Item) => {
-  if (!hasRequiredParameters(item)) {
+  if (!isItemPreviewEnabled(item)) {
     return t`Open this question and fill in its variables to see it.`;
   } else {
     return undefined;

--- a/frontend/src/metabase/collections/components/PinnedQuestionCard/PinnedQuestionCard.tsx
+++ b/frontend/src/metabase/collections/components/PinnedQuestionCard/PinnedQuestionCard.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { t } from "ttag";
 import {
   hasRequiredParameters,
-  isPreviewable,
+  isPreviewShown,
   Item,
 } from "metabase/collections/utils";
 import Visualization from "metabase/visualizations/components/Visualization";
@@ -37,7 +37,7 @@ const PinnedQuestionCard = ({
   onCreateBookmark,
   onDeleteBookmark,
 }: PinnedQuestionCardProps): JSX.Element => {
-  const isPreview = isPreviewable(item);
+  const isPreview = isPreviewShown(item);
 
   return (
     <CardRoot to={item.getUrl()} isPreview={isPreview}>

--- a/frontend/src/metabase/collections/utils.ts
+++ b/frontend/src/metabase/collections/utils.ts
@@ -82,15 +82,15 @@ export function isItemPinned(item: Item) {
   return item.collection_position != null;
 }
 
-export function isPreviewable(item: Item) {
-  return isPreviewShown(item) && isPreviewEnabled(item);
+export function isItemPreviewable(item: Item) {
+  return isItemPreviewShown(item) && isItemPreviewEnabled(item);
 }
 
-export function isPreviewShown(item: Item) {
+export function isItemPreviewShown(item: Item) {
   return item.collection_preview ?? true;
 }
 
-export function isPreviewEnabled(item: Item) {
+export function isItemPreviewEnabled(item: Item) {
   return hasRequiredParameters(item);
 }
 

--- a/frontend/src/metabase/collections/utils.ts
+++ b/frontend/src/metabase/collections/utils.ts
@@ -82,7 +82,7 @@ export function isItemPinned(item: Item) {
   return item.collection_position != null;
 }
 
-export function isPreviewable(item: Item) {
+export function isPreviewShown(item: Item) {
   return isPreviewEnabled(item) && hasRequiredParameters(item);
 }
 

--- a/frontend/src/metabase/collections/utils.ts
+++ b/frontend/src/metabase/collections/utils.ts
@@ -82,15 +82,15 @@ export function isItemPinned(item: Item) {
   return item.collection_position != null;
 }
 
-export function isItemPreviewable(item: Item) {
-  return isItemPreviewShown(item) && isItemPreviewEnabled(item);
+export function isPreviewable(item: Item) {
+  return isPreviewEnabled(item) && hasRequiredParameters(item);
 }
 
-export function isItemPreviewShown(item: Item) {
+export function isPreviewEnabled(item: Item) {
   return item.collection_preview ?? true;
 }
 
-export function isItemPreviewEnabled(item: Item) {
+export function hasRequiredParameters(item: Item) {
   return item.has_required_parameters ?? false;
 }
 

--- a/frontend/src/metabase/collections/utils.ts
+++ b/frontend/src/metabase/collections/utils.ts
@@ -83,11 +83,15 @@ export function isItemPinned(item: Item) {
 }
 
 export function isPreviewable(item: Item) {
-  return isPreviewEnabled(item) && hasRequiredParameters(item);
+  return isPreviewShown(item) && isPreviewEnabled(item);
+}
+
+export function isPreviewShown(item: Item) {
+  return item.collection_preview ?? true;
 }
 
 export function isPreviewEnabled(item: Item) {
-  return item.collection_preview ?? true;
+  return hasRequiredParameters(item);
 }
 
 export function hasRequiredParameters(item: Item) {

--- a/frontend/src/metabase/collections/utils.ts
+++ b/frontend/src/metabase/collections/utils.ts
@@ -91,11 +91,7 @@ export function isItemPreviewShown(item: Item) {
 }
 
 export function isItemPreviewEnabled(item: Item) {
-  return hasRequiredParameters(item);
-}
-
-export function hasRequiredParameters(item: Item) {
-  return item.has_required_parameters ?? true;
+  return item.has_required_parameters ?? false;
 }
 
 // API requires items in "root" collection be persisted with a "null" collection ID

--- a/frontend/src/metabase/collections/utils.ts
+++ b/frontend/src/metabase/collections/utils.ts
@@ -1,7 +1,5 @@
 import { t } from "ttag";
-import _ from "underscore";
-
-import { Collection, CollectionId } from "metabase-types/api";
+import { Collection } from "metabase-types/api";
 
 export type Item = {
   id: number;

--- a/frontend/src/metabase/collections/utils.ts
+++ b/frontend/src/metabase/collections/utils.ts
@@ -91,7 +91,7 @@ export function isPreviewEnabled(item: Item) {
 }
 
 export function hasRequiredParameters(item: Item) {
-  return item.has_required_parameters ?? false;
+  return item.has_required_parameters ?? true;
 }
 
 // API requires items in "root" collection be persisted with a "null" collection ID

--- a/frontend/src/metabase/components/EntityItem.jsx
+++ b/frontend/src/metabase/components/EntityItem.jsx
@@ -85,6 +85,7 @@ function EntityItemName({ name, variant }) {
 function EntityItemMenu({
   item,
   isBookmarked,
+  isPreviewShown,
   isPreviewEnabled,
   onPin,
   onMove,
@@ -108,12 +109,13 @@ function EntityItemMenu({
           event: `${analyticsContext};Entity Item;Pin Item;${item.model}`,
         },
         onTogglePreview && {
-          title: isPreviewEnabled
+          title: isPreviewShown
             ? t`Don’t show visualization`
             : t`Show visualization`,
-          icon: isPreviewEnabled ? "eye_crossed_out" : "eye",
+          icon: isPreviewShown ? "eye_crossed_out" : "eye",
           action: onTogglePreview,
           event: `${analyticsContext};Entity Item;Preview Item;${item.model}`,
+          disabled: !isPreviewEnabled,
         },
         onMove && {
           title: t`Move`,
@@ -144,6 +146,7 @@ function EntityItemMenu({
       item.model,
       isPinned,
       isBookmarked,
+      isPreviewShown,
       isPreviewEnabled,
       showPinnedAction,
       onPin,

--- a/frontend/src/metabase/components/EntityItem.jsx
+++ b/frontend/src/metabase/components/EntityItem.jsx
@@ -85,7 +85,7 @@ function EntityItemName({ name, variant }) {
 function EntityItemMenu({
   item,
   isBookmarked,
-  isPreviewEnabled,
+  isPreviewShown,
   isPreviewAvailable,
   onPin,
   onMove,
@@ -109,10 +109,10 @@ function EntityItemMenu({
           event: `${analyticsContext};Entity Item;Pin Item;${item.model}`,
         },
         onTogglePreview && {
-          title: isPreviewEnabled
+          title: isPreviewShown
             ? t`Don’t show visualization`
             : t`Show visualization`,
-          icon: isPreviewEnabled ? "eye_crossed_out" : "eye",
+          icon: isPreviewShown ? "eye_crossed_out" : "eye",
           action: onTogglePreview,
           event: `${analyticsContext};Entity Item;Preview Item;${item.model}`,
           disabled: !isPreviewAvailable,
@@ -146,7 +146,7 @@ function EntityItemMenu({
       item.model,
       isPinned,
       isBookmarked,
-      isPreviewEnabled,
+      isPreviewShown,
       isPreviewAvailable,
       showPinnedAction,
       onPin,

--- a/frontend/src/metabase/components/EntityItem.jsx
+++ b/frontend/src/metabase/components/EntityItem.jsx
@@ -85,8 +85,8 @@ function EntityItemName({ name, variant }) {
 function EntityItemMenu({
   item,
   isBookmarked,
-  isPreviewShown,
   isPreviewEnabled,
+  isPreviewAvailable,
   onPin,
   onMove,
   onCopy,
@@ -109,13 +109,13 @@ function EntityItemMenu({
           event: `${analyticsContext};Entity Item;Pin Item;${item.model}`,
         },
         onTogglePreview && {
-          title: isPreviewShown
+          title: isPreviewEnabled
             ? t`Don’t show visualization`
             : t`Show visualization`,
-          icon: isPreviewShown ? "eye_crossed_out" : "eye",
+          icon: isPreviewEnabled ? "eye_crossed_out" : "eye",
           action: onTogglePreview,
           event: `${analyticsContext};Entity Item;Preview Item;${item.model}`,
-          disabled: !isPreviewEnabled,
+          disabled: !isPreviewAvailable,
         },
         onMove && {
           title: t`Move`,
@@ -146,8 +146,8 @@ function EntityItemMenu({
       item.model,
       isPinned,
       isBookmarked,
-      isPreviewShown,
       isPreviewEnabled,
+      isPreviewAvailable,
       showPinnedAction,
       onPin,
       onMove,

--- a/frontend/src/metabase/components/EntityMenu.jsx
+++ b/frontend/src/metabase/components/EntityMenu.jsx
@@ -140,6 +140,7 @@ class EntityMenu extends Component {
                                   }
                                   event={item.event && item.event}
                                   link={item.link}
+                                  disabled={item.disabled}
                                   onClose={() => {
                                     this.toggleMenu();
                                     item?.onClose?.();

--- a/frontend/src/metabase/components/EntityMenuItem.jsx
+++ b/frontend/src/metabase/components/EntityMenuItem.jsx
@@ -5,11 +5,19 @@ import { Link } from "react-router";
 import Icon from "metabase/components/Icon";
 import { Item, StyledExternalLink } from "./EntityMenuItem.styled";
 
-const LinkMenuItem = ({ children, link, onClose, event, externalLink }) =>
+const LinkMenuItem = ({
+  children,
+  link,
+  onClose,
+  event,
+  externalLink,
+  disabled,
+}) =>
   externalLink ? (
     <StyledExternalLink
       href={link}
       target="_blank"
+      disabled={disabled}
       onClick={onClose}
       data-metabase-event={event}
     >
@@ -18,6 +26,7 @@ const LinkMenuItem = ({ children, link, onClose, event, externalLink }) =>
   ) : (
     <Link
       to={link}
+      disabled={disabled}
       onClick={onClose}
       data-metabase-event={event}
       className="block"
@@ -26,8 +35,8 @@ const LinkMenuItem = ({ children, link, onClose, event, externalLink }) =>
     </Link>
   );
 
-const ActionMenuItem = ({ children, action, event }) => (
-  <div onClick={action} data-metabase-event={event}>
+const ActionMenuItem = ({ children, action, event, disabled }) => (
+  <div onClick={!disabled ? action : undefined} data-metabase-event={event}>
     {children}
   </div>
 );
@@ -40,6 +49,7 @@ const EntityMenuItem = ({
   onClose,
   event,
   externalLink,
+  disabled,
 }) => {
   if (link && action) {
     console.warn(
@@ -49,7 +59,7 @@ const EntityMenuItem = ({
   }
 
   const content = (
-    <Item>
+    <Item disabled={disabled}>
       {icon && <Icon name={icon} mr={1} />}
       <span className="text-bold">{title}</span>
     </Item>
@@ -60,6 +70,7 @@ const EntityMenuItem = ({
       <LinkMenuItem
         link={link}
         externalLink={externalLink}
+        disabled={disabled}
         onClose={onClose}
         event={event}
       >
@@ -69,7 +80,7 @@ const EntityMenuItem = ({
   }
   if (action) {
     return (
-      <ActionMenuItem action={action} event={event}>
+      <ActionMenuItem action={action} event={event} disabled={disabled}>
         {content}
       </ActionMenuItem>
     );

--- a/frontend/src/metabase/components/EntityMenuItem.styled.jsx
+++ b/frontend/src/metabase/components/EntityMenuItem.styled.jsx
@@ -6,7 +6,7 @@ import { color } from "metabase/lib/colors";
 export const Item = styled.div`
   display: flex;
   align-items: center;
-  cursor: ${props => !props.disabled && "pointer"};
+  cursor: ${props => (props.disabled ? "not-allowed" : "pointer")};
   color: ${props => color(props.disabled ? "text-light" : "text-medium")};
   padding: 0.85em 1.45em;
   text-decoration: none;

--- a/frontend/src/metabase/components/EntityMenuItem.styled.jsx
+++ b/frontend/src/metabase/components/EntityMenuItem.styled.jsx
@@ -5,21 +5,21 @@ import { color } from "metabase/lib/colors";
 
 export const Item = styled.div`
   display: flex;
-align-items: center;
-  cursor: pointer;
-  color: ${color("text-medium")};
+  align-items: center;
+  cursor: ${props => !props.disabled && "pointer"};
+  color: ${props => color(props.disabled ? "text-light" : "text-medium")};
   padding: 0.85em 1.45em;
   text-decoration: none;
   transition: all 300ms linear;
   :hover {
-    color: ${color("brand")};
+    color: ${props => !props.disabled && color("brand")};
   }
   > .Icon {
     color: ${color("text-light")};
     margin-right: 0.65em;
   }
   :hover > .Icon {
-    color: ${color("brand")};
+    color: ${props => !props.disabled && color("brand")};
     transition: all 300ms linear;
   },
   /* icon specific tweaks


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/23222

How to test:
- Change https://github.com/metabase/metabase/blob/32f85c0581c8b72658e2fc7fa9dad95f45132165/frontend/src/metabase/collections/utils.ts#L92 to `return false;`
- Open a collection with pinned questions
- The preview option should be visible, but disabled

<img width="883" alt="Screenshot 2022-06-14 at 21 28 36" src="https://user-images.githubusercontent.com/8542534/173662689-b1e803a3-2440-4405-8826-d528d0af6b3e.png">
