### PR TITLE
Inline Category Picker

### DIFF
--- a/frontend/src/metabase-lib/lib/metadata/Field.ts
+++ b/frontend/src/metabase-lib/lib/metadata/Field.ts
@@ -50,6 +50,7 @@ class FieldInner extends Base {
   base_type: string | null;
   table?: Table;
   target?: Field;
+  has_field_values?: "list" | "search" | "none";
 
   getId() {
     if (Array.isArray(this.id)) {

--- a/frontend/src/metabase-lib/lib/metadata/Field.ts
+++ b/frontend/src/metabase-lib/lib/metadata/Field.ts
@@ -51,6 +51,7 @@ class FieldInner extends Base {
   table?: Table;
   target?: Field;
   has_field_values?: "list" | "search" | "none";
+  values: any[];
 
   getId() {
     if (Array.isArray(this.id)) {

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterItem/BulkFilterItem.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterItem/BulkFilterItem.tsx
@@ -2,7 +2,6 @@ import React, { useMemo, useCallback } from "react";
 
 import Filter from "metabase-lib/lib/queries/structured/Filter";
 import Dimension from "metabase-lib/lib/Dimension";
-
 import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
 import { isBoolean } from "metabase/lib/schema_metadata";
 
@@ -51,7 +50,6 @@ export const BulkFilterItem = ({
 
   const handleChange = useCallback(
     (newFilter: Filter) => {
-      console.log("new", newFilter);
       filter ? onChangeFilter(filter, newFilter) : onAddFilter(newFilter);
     },
     [filter, onAddFilter, onChangeFilter],

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterItem/BulkFilterItem.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterItem/BulkFilterItem.tsx
@@ -76,8 +76,8 @@ export const BulkFilterItem = ({
           filter={filter}
           newFilter={newFilter}
           dimension={dimension}
-          handleChange={handleChange}
-          handleClear={handleClear}
+          onChange={handleChange}
+          onClear={handleClear}
         />
       );
     default:

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterItem/BulkFilterItem.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterItem/BulkFilterItem.tsx
@@ -31,15 +31,18 @@ export const BulkFilterItem = ({
   onRemoveFilter,
 }: BulkFilterItemProps): JSX.Element => {
   const fieldType = useMemo(() => {
-    const semanticType = dimension.field().semantic_type ?? "";
-    const baseType = dimension.field().base_type ?? "";
+    const field = dimension.field();
 
-    if (BASE_FIELD_FILTERS.includes(baseType)) {
-      return baseType;
+    if (field.has_field_values === "list") {
+      return "type/Category";
     }
 
-    if (SEMANTIC_FIELD_FILTERS.includes(semanticType)) {
-      return semanticType;
+    if (BASE_FIELD_FILTERS.includes(field.base_type ?? "")) {
+      return field.base_type;
+    }
+
+    if (SEMANTIC_FIELD_FILTERS.includes(field.semantic_type ?? "")) {
+      return field.semantic_type;
     }
   }, [dimension]);
 

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterItem/BulkFilterItem.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterItem/BulkFilterItem.tsx
@@ -2,11 +2,9 @@ import React, { useMemo, useCallback } from "react";
 
 import Filter from "metabase-lib/lib/queries/structured/Filter";
 import Dimension from "metabase-lib/lib/Dimension";
-import Field from "metabase-lib/lib/metadata/Field";
 
 import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
 import { isBoolean } from "metabase/lib/schema_metadata";
-import Fields from "metabase/entities/fields";
 
 import { BooleanPickerCheckbox } from "metabase/query_builder/components/filters/pickers/BooleanPicker";
 import { BulkFilterSelect } from "../BulkFilterSelect";

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterItem/BulkFilterItem.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterItem/BulkFilterItem.tsx
@@ -2,11 +2,16 @@ import React, { useMemo, useCallback } from "react";
 
 import Filter from "metabase-lib/lib/queries/structured/Filter";
 import Dimension from "metabase-lib/lib/Dimension";
+import Field from "metabase-lib/lib/metadata/Field";
+
 import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
 import { isBoolean } from "metabase/lib/schema_metadata";
+import Fields from "metabase/entities/fields";
 
 import { BooleanPickerCheckbox } from "metabase/query_builder/components/filters/pickers/BooleanPicker";
 import { BulkFilterSelect } from "../BulkFilterSelect";
+import { InlineCategoryPicker } from "../InlineCategoryPicker";
+import { SEMANTIC_FIELD_FILTERS, BASE_FIELD_FILTERS } from "./constants";
 
 export interface BulkFilterItemProps {
   query: StructuredQuery;
@@ -25,9 +30,18 @@ export const BulkFilterItem = ({
   onChangeFilter,
   onRemoveFilter,
 }: BulkFilterItemProps): JSX.Element => {
-  const fieldType = useMemo(() => dimension.field().base_type ?? "", [
-    dimension,
-  ]);
+  const fieldType = useMemo(() => {
+    const semanticType = dimension.field().semantic_type ?? "";
+    const baseType = dimension.field().base_type ?? "";
+
+    if (BASE_FIELD_FILTERS.includes(baseType)) {
+      return baseType;
+    }
+
+    if (SEMANTIC_FIELD_FILTERS.includes(semanticType)) {
+      return semanticType;
+    }
+  }, [dimension]);
 
   const newFilter = useMemo(() => getNewFilter(query, dimension), [
     query,
@@ -36,6 +50,7 @@ export const BulkFilterItem = ({
 
   const handleChange = useCallback(
     (newFilter: Filter) => {
+      console.log("new", newFilter);
       filter ? onChangeFilter(filter, newFilter) : onAddFilter(newFilter);
     },
     [filter, onAddFilter, onChangeFilter],
@@ -53,6 +68,17 @@ export const BulkFilterItem = ({
         <BooleanPickerCheckbox
           filter={filter ?? newFilter}
           onFilterChange={handleChange}
+        />
+      );
+    case "type/Category":
+      return (
+        <InlineCategoryPicker
+          query={query}
+          filter={filter}
+          newFilter={newFilter}
+          dimension={dimension}
+          handleChange={handleChange}
+          handleClear={handleClear}
         />
       );
     default:

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterItem/BulkFilterItem.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterItem/BulkFilterItem.tsx
@@ -31,12 +31,12 @@ export const BulkFilterItem = ({
   const fieldType = useMemo(() => {
     const field = dimension.field();
 
-    if (field.has_field_values === "list") {
-      return "type/Category";
-    }
-
     if (BASE_FIELD_FILTERS.includes(field.base_type ?? "")) {
       return field.base_type;
+    }
+
+    if (field.has_field_values === "list") {
+      return "type/Category";
     }
 
     if (SEMANTIC_FIELD_FILTERS.includes(field.semantic_type ?? "")) {

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterItem/BulkFilterItem.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterItem/BulkFilterItem.unit.spec.tsx
@@ -4,6 +4,8 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import { metadata } from "__support__/sample_database_fixture";
+import { getStore } from "__support__/entities-store";
+import { Provider } from "react-redux";
 
 import Field from "metabase-lib/lib/metadata/Field";
 import Filter from "metabase-lib/lib/queries/structured/Filter";
@@ -16,7 +18,7 @@ const booleanField = new Field({
   semantic_type: "",
   table_id: 8,
   name: "bool",
-  has_field_values: "list",
+  has_field_values: "none",
   dimensions: {},
   dimension_options: [],
   effective_type: "type/Boolean",
@@ -30,7 +32,7 @@ const intField = new Field({
   semantic_type: "",
   table_id: 8,
   name: "int_num",
-  has_field_values: "list",
+  has_field_values: "none",
   dimensions: {},
   dimension_options: [],
   effective_type: "type/Integer",
@@ -44,7 +46,7 @@ const floatField = new Field({
   semantic_type: "",
   table_id: 8,
   name: "float_num",
-  has_field_values: "list",
+  has_field_values: "none",
   dimensions: {},
   dimension_options: [],
   effective_type: "type/Float",
@@ -53,9 +55,25 @@ const floatField = new Field({
   metadata,
 });
 
+const categoryField = new Field({
+  database_type: "test",
+  semantic_type: "",
+  table_id: 8,
+  name: "category_string",
+  has_field_values: "list",
+  values: ["Michaelangelo", "Donatello", "Raphael", "Leonardo"],
+  dimensions: {},
+  dimension_options: [],
+  effective_type: "type/Float",
+  id: 137,
+  base_type: "type/Float",
+  metadata,
+});
+
 metadata.fields[booleanField.id] = booleanField;
 metadata.fields[intField.id] = intField;
 metadata.fields[floatField.id] = floatField;
+metadata.fields[categoryField.id] = categoryField;
 
 const card = {
   dataset_query: {
@@ -74,6 +92,7 @@ const query = question.query();
 const booleanDimension = booleanField.dimension();
 const floatDimension = floatField.dimension();
 const intDimension = intField.dimension();
+const categoryDimension = categoryField.dimension();
 
 describe("BulkFilterItem", () => {
   it("renders a boolean picker for a boolean filter", () => {
@@ -148,5 +167,29 @@ describe("BulkFilterItem", () => {
       "aria-label",
       "float_num",
     );
+  });
+
+  it("renders a category picker for category type", () => {
+    const testFilter = new Filter(
+      ["=", ["field", categoryField.id, null], "Donatello"],
+      null,
+      query,
+    );
+    const changeSpy = jest.fn();
+    const store = getStore();
+
+    render(
+      <Provider store={store}>
+        <BulkFilterItem
+          query={query}
+          filter={testFilter}
+          dimension={categoryDimension}
+          onAddFilter={changeSpy}
+          onChangeFilter={changeSpy}
+          onRemoveFilter={changeSpy}
+        />
+      </Provider>,
+    );
+    screen.getByTestId("category-picker");
   });
 });

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterItem/constants.ts
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterItem/constants.ts
@@ -1,1 +1,3 @@
-export const INLINE_FIELD_TYPES = ["type/Boolean"];
+export const BASE_FIELD_FILTERS = ["type/Boolean"];
+
+export const SEMANTIC_FIELD_FILTERS = ["type/FK", "type/PK", "type/Category"];

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterList/BulkFilterList.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterList/BulkFilterList.styled.tsx
@@ -9,17 +9,18 @@ export const ListRoot = styled.div`
 
 export const ListRow = styled.div`
   display: flex;
+  flex-wrap: wrap;
   padding: 0.375rem 0;
 `;
 
 export const ListRowLabel = styled(Ellipsified)`
-  flex: 1 1 0;
-  margin: 0.625rem 1rem 0.625rem 0;
+  width: 50%;
+  padding: 0.625rem 1rem 0.625rem 0;
   color: ${color("black")};
   line-height: 1rem;
   font-weight: bold;
 `;
 
 export const ListRowContent = styled.div`
-  flex: 1 1 0;
+  flex: 1 1 50%;
 `;

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterList/BulkFilterList.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterList/BulkFilterList.styled.tsx
@@ -8,19 +8,14 @@ export const ListRoot = styled.div`
 `;
 
 export const ListRow = styled.div`
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   padding: 0.375rem 0;
 `;
 
 export const ListRowLabel = styled(Ellipsified)`
-  width: 50%;
   padding: 0.625rem 1rem 0.625rem 0;
   color: ${color("black")};
   line-height: 1rem;
   font-weight: bold;
-`;
-
-export const ListRowContent = styled.div`
-  flex: 1 1 50%;
 `;

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterList/BulkFilterList.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterList/BulkFilterList.tsx
@@ -12,12 +12,7 @@ import { ModalDivider } from "../BulkFilterModal/BulkFilterModal.styled";
 import Filter from "metabase-lib/lib/queries/structured/Filter";
 import { BulkFilterItem } from "../BulkFilterItem";
 import { SegmentFilterSelect } from "../BulkFilterSelect";
-import {
-  ListRoot,
-  ListRow,
-  ListRowContent,
-  ListRowLabel,
-} from "./BulkFilterList.styled";
+import { ListRoot, ListRow, ListRowLabel } from "./BulkFilterList.styled";
 import { sortDimensions } from "./utils";
 
 export interface BulkFilterListProps {
@@ -99,7 +94,7 @@ const BulkFilterListItem = ({
       <ListRowLabel data-testid="dimension-filter-label">
         {dimension.displayName()}
       </ListRowLabel>
-      <ListRowContent>
+      <>
         {options.map((filter, index) => (
           <BulkFilterItem
             key={index}
@@ -120,7 +115,7 @@ const BulkFilterListItem = ({
             onRemoveFilter={onRemoveFilter}
           />
         )}
-      </ListRowContent>
+      </>
     </ListRow>
   );
 };
@@ -143,7 +138,7 @@ const SegmentListItem = ({
   <>
     <ListRow>
       <ListRowLabel>{t`Segments`}</ListRowLabel>
-      <ListRowContent>
+      <>
         <SegmentFilterSelect
           query={query}
           segments={segments}
@@ -151,7 +146,7 @@ const SegmentListItem = ({
           onRemoveFilter={onRemoveFilter}
           onClearSegments={onClearSegments}
         />
-      </ListRowContent>
+      </>
     </ListRow>
     <ModalDivider marginY="0.5rem" />
   </>

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterList/BulkFilterList.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterList/BulkFilterList.tsx
@@ -86,7 +86,12 @@ const BulkFilterListItem = ({
   onRemoveFilter,
 }: BulkFilterListItemProps): JSX.Element => {
   const options = useMemo(() => {
-    return filters.filter(f => f.dimension()?.isSameBaseDimension(dimension));
+    const filtersForThisDimension = filters.filter(f =>
+      f.dimension()?.isSameBaseDimension(dimension),
+    );
+    return filtersForThisDimension.length
+      ? filtersForThisDimension
+      : [undefined];
   }, [filters, dimension]);
 
   return (
@@ -94,28 +99,17 @@ const BulkFilterListItem = ({
       <ListRowLabel data-testid="dimension-filter-label">
         {dimension.displayName()}
       </ListRowLabel>
-      <>
-        {options.map((filter, index) => (
-          <BulkFilterItem
-            key={index}
-            query={query}
-            filter={filter}
-            dimension={dimension}
-            onAddFilter={onAddFilter}
-            onChangeFilter={onChangeFilter}
-            onRemoveFilter={onRemoveFilter}
-          />
-        ))}
-        {!options.length && (
-          <BulkFilterItem
-            query={query}
-            dimension={dimension}
-            onAddFilter={onAddFilter}
-            onChangeFilter={onChangeFilter}
-            onRemoveFilter={onRemoveFilter}
-          />
-        )}
-      </>
+      {options.map((filter, index) => (
+        <BulkFilterItem
+          key={index}
+          query={query}
+          filter={filter}
+          dimension={dimension}
+          onAddFilter={onAddFilter}
+          onChangeFilter={onChangeFilter}
+          onRemoveFilter={onRemoveFilter}
+        />
+      ))}
     </ListRow>
   );
 };

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterSelect/BulkFilterSelect.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterSelect/BulkFilterSelect.styled.tsx
@@ -4,6 +4,7 @@ import FilterPopover from "../../FilterPopover";
 import Select from "metabase/core/components/Select";
 
 export const SelectFilterButton = styled(SelectButton)`
+  grid-column: 2;
   min-height: 2.25rem;
 
   &:not(:first-of-type) {

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineCategoryPicker/InlineCategoryPicker.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineCategoryPicker/InlineCategoryPicker.styled.tsx
@@ -10,7 +10,7 @@ export const Loading = styled(LoadingSpinner)`
 `;
 
 export const PickerContainer = styled.div`
-  grid-column: span 2 / span 2;
+  grid-column: span 2;
   margin: ${space(2)} 0;
   padding-bottom: ${space(2)};
   font-weight: bold;

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineCategoryPicker/InlineCategoryPicker.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineCategoryPicker/InlineCategoryPicker.styled.tsx
@@ -1,0 +1,15 @@
+import styled from "@emotion/styled";
+
+export const PickerContainer = styled.div`
+  display: flex;
+  width: 100%;
+  margin: 1rem 0;
+  font-weight: bold;
+`;
+
+export const PickerGrid = styled.div`
+  width: 100%;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.5rem;
+`;

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineCategoryPicker/InlineCategoryPicker.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineCategoryPicker/InlineCategoryPicker.styled.tsx
@@ -1,15 +1,27 @@
 import styled from "@emotion/styled";
+import { color } from "metabase/lib/colors";
+import { space } from "metabase/styled-components/theme";
+
+import LoadingSpinner from "metabase/components/LoadingSpinner";
+
+export const Loading = styled(LoadingSpinner)`
+  margin: ${space(1)} 0;
+  color: ${color("brand")};
+`;
 
 export const PickerContainer = styled.div`
-  display: flex;
-  width: 100%;
-  margin: 1rem 0;
+  grid-column: span 2 / span 2;
+  margin: ${space(2)} 0;
+  padding-bottom: ${space(2)};
   font-weight: bold;
+  border-bottom: 1px solid ${color("border")};
 `;
 
 export const PickerGrid = styled.div`
   width: 100%;
   display: grid;
+  columns: 2;
+  align-items: center;
   grid-template-columns: repeat(3, 1fr);
-  gap: 0.5rem;
+  gap: ${space(2)};
 `;

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineCategoryPicker/InlineCategoryPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineCategoryPicker/InlineCategoryPicker.tsx
@@ -47,7 +47,7 @@ interface InlineCategoryPickerProps {
   handleClear: () => void;
 }
 
-function InlineCategoryPickerComponent({
+export function InlineCategoryPickerComponent({
   query,
   filter,
   newFilter,
@@ -134,15 +134,13 @@ export function SimpleCategoryFilterPicker({
         ? [...filterValues, option]
         : filterValues.filter(o => o !== option);
 
-      console.log("newArgs", newArgs);
-
       handleChange(filter.setArguments(newArgs));
     },
     [filterValues, handleChange, filter],
   );
 
   return (
-    <PickerContainer>
+    <PickerContainer data-testid="category-picker">
       <PickerGrid>
         {options.map((option: string | number) => (
           <Checkbox

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineCategoryPicker/InlineCategoryPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineCategoryPicker/InlineCategoryPicker.tsx
@@ -1,0 +1,121 @@
+import React, { useState, useEffect, useMemo, useCallback } from "react";
+
+import Filter from "metabase-lib/lib/queries/structured/Filter";
+import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
+import Dimension from "metabase-lib/lib/Dimension";
+import Field from "metabase-lib/lib/metadata/Field";
+import Checkbox from "metabase/core/components/CheckBox";
+import { MetabaseApi } from "metabase/services";
+
+import { MAX_INLINE_CATEGORIES } from "./constants";
+import { PickerContainer, PickerGrid } from "./InlineCategoryPicker.styled";
+import { BulkFilterSelect } from "../BulkFilterSelect";
+import { P } from "cljs/goog.dom.tagname";
+
+interface InlineCategoryPickerProps {
+  query: StructuredQuery;
+  filter?: Filter;
+  newFilter: Filter;
+  dimension: Dimension;
+  handleChange: (newFilter: Filter) => void;
+  handleClear: () => void;
+}
+
+export function InlineCategoryPicker({
+  query,
+  filter,
+  newFilter,
+  handleChange,
+  dimension,
+  handleClear,
+}: InlineCategoryPickerProps) {
+  const [fieldValues, setFieldValues] = useState<null | (string | number)[]>(
+    null,
+  );
+
+  useEffect(() => {
+    const field = dimension.field();
+    if (field.hasFieldValues()) {
+      setFieldValues(field.fieldValues());
+      return;
+    }
+    MetabaseApi.field_values({
+      fieldId: field.id,
+      limit: MAX_INLINE_CATEGORIES + 1,
+    })
+      .then(response => {
+        setFieldValues(response.values.flat());
+      })
+      .catch(() => {
+        throw new Error("Failed to load field values");
+      });
+  }, [dimension]);
+
+  if (!fieldValues) {
+    return <div>loading</div>;
+  }
+
+  if (fieldValues.length <= MAX_INLINE_CATEGORIES) {
+    return (
+      <SimpleCategoryFilterPicker
+        filter={filter ?? newFilter}
+        handleChange={handleChange}
+        options={fieldValues}
+      />
+    );
+  }
+  return (
+    <BulkFilterSelect
+      query={query}
+      filter={filter}
+      dimension={dimension}
+      handleChange={handleChange}
+      handleClear={handleClear}
+    />
+  );
+}
+
+interface SimpleCategoryFilterPickerProps {
+  filter: Filter;
+  options: (string | number)[];
+  handleChange: (newFilter: Filter) => void;
+}
+
+export function SimpleCategoryFilterPicker({
+  filter,
+  options,
+  handleChange,
+}: SimpleCategoryFilterPickerProps) {
+  const filterValues = useMemo(() => filter.arguments().filter(Boolean), [
+    filter,
+  ]);
+
+  const onChange = useCallback(
+    (option, checked) => {
+      const newArgs = checked
+        ? [...filterValues, option]
+        : filterValues.filter(o => o !== option);
+
+      console.log("newArgs", newArgs);
+
+      handleChange(filter.setArguments(newArgs));
+    },
+    [filterValues, handleChange, filter],
+  );
+
+  return (
+    <PickerContainer>
+      <PickerGrid>
+        {options.map((option: string | number) => (
+          <Checkbox
+            key={option.toString()}
+            checked={filterValues.includes(option)}
+            onChange={e => onChange(option, e.target.checked)}
+            checkedColor="accent2"
+            label={option.toString()}
+          />
+        ))}
+      </PickerGrid>
+    </PickerContainer>
+  );
+}

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineCategoryPicker/InlineCategoryPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineCategoryPicker/InlineCategoryPicker.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo, useCallback } from "react";
+import React, { useState, useEffect } from "react";
 import { connect } from "react-redux";
 import { t } from "ttag";
 
@@ -27,9 +27,7 @@ const mapStateToProps = (state: any, props: any) => {
           entityId: fieldId,
         })
       : [];
-  return {
-    fieldValues: fieldValues || [],
-  };
+  return { fieldValues };
 };
 
 const mapDispatchToProps = {
@@ -43,22 +41,21 @@ interface InlineCategoryPickerProps {
   dimension: Dimension;
   fieldValues: any[];
   fetchFieldValues: ({ id }: { id: number }) => Promise<any>;
-  handleChange: (newFilter: Filter) => void;
-  handleClear: () => void;
+  onChange: (newFilter: Filter) => void;
+  onClear: () => void;
 }
 
 export function InlineCategoryPickerComponent({
   query,
   filter,
   newFilter,
-  handleChange,
+  dimension,
   fieldValues,
   fetchFieldValues,
-  dimension,
-  handleClear,
+  onChange,
+  onClear,
 }: InlineCategoryPickerProps) {
   const safeFetchFieldValues = useSafeAsyncFunction(fetchFieldValues);
-
   const shouldFetchFieldValues = !dimension?.field()?.hasFieldValues();
   const [isLoading, setIsLoading] = useState(shouldFetchFieldValues);
   const [hasError, setHasError] = useState(false);
@@ -96,7 +93,7 @@ export function InlineCategoryPickerComponent({
     return (
       <SimpleCategoryFilterPicker
         filter={filter ?? newFilter}
-        handleChange={handleChange}
+        onChange={onChange}
         options={fieldValues.flat()}
       />
     );
@@ -107,8 +104,8 @@ export function InlineCategoryPickerComponent({
       query={query}
       filter={filter}
       dimension={dimension}
-      handleChange={handleChange}
-      handleClear={handleClear}
+      handleChange={onChange}
+      handleClear={onClear}
     />
   );
 }
@@ -116,28 +113,23 @@ export function InlineCategoryPickerComponent({
 interface SimpleCategoryFilterPickerProps {
   filter: Filter;
   options: (string | number)[];
-  handleChange: (newFilter: Filter) => void;
+  onChange: (newFilter: Filter) => void;
 }
 
 export function SimpleCategoryFilterPicker({
   filter,
   options,
-  handleChange,
+  onChange,
 }: SimpleCategoryFilterPickerProps) {
-  const filterValues = useMemo(() => filter.arguments().filter(Boolean), [
-    filter,
-  ]);
+  const filterValues = filter.arguments().filter(Boolean);
 
-  const onChange = useCallback(
-    (option, checked) => {
-      const newArgs = checked
-        ? [...filterValues, option]
-        : filterValues.filter(o => o !== option);
+  const handleChange = (option: string | number, checked: boolean) => {
+    const newArgs = checked
+      ? [...filterValues, option]
+      : filterValues.filter(filterValue => filterValue !== option);
 
-      handleChange(filter.setArguments(newArgs));
-    },
-    [filterValues, handleChange, filter],
-  );
+    onChange(filter.setArguments(newArgs));
+  };
 
   return (
     <PickerContainer data-testid="category-picker">
@@ -146,7 +138,7 @@ export function SimpleCategoryFilterPicker({
           <Checkbox
             key={option.toString()}
             checked={filterValues.includes(option)}
-            onChange={e => onChange(option, e.target.checked)}
+            onChange={e => handleChange(option, e.target.checked)}
             checkedColor="accent2"
             label={option.toString()}
           />

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineCategoryPicker/InlineCategoryPicker.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineCategoryPicker/InlineCategoryPicker.unit.spec.tsx
@@ -1,5 +1,5 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-nocheck
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+
 import React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -9,6 +9,7 @@ import { metadata } from "__support__/sample_database_fixture";
 import Field from "metabase-lib/lib/metadata/Field";
 import Filter from "metabase-lib/lib/queries/structured/Filter";
 import Question from "metabase-lib/lib/Question";
+import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
 
 import { InlineCategoryPickerComponent } from "./InlineCategoryPicker";
 import { MAX_INLINE_CATEGORIES } from "./constants";
@@ -16,15 +17,15 @@ import { MAX_INLINE_CATEGORIES } from "./constants";
 const smallCategoryField = new Field({
   database_type: "test",
   semantic_type: "type/Category",
+  effective_type: "type/Text",
+  base_type: "type/Text",
   table_id: 8,
   name: "small_category_field",
   has_field_values: "list",
-  values: ["Michaelangelo", "Donatello", "Raphael", "Leonardo"],
+  values: [["Michaelangelo"], ["Donatello"], ["Raphael"], ["Leonardo"]],
   dimensions: {},
   dimension_options: [],
-  effective_type: "type/Text",
   id: 137,
-  effective_type: "type/Text",
   metadata,
 });
 
@@ -34,41 +35,44 @@ const turtleFactory = () => {
   const name = ["Michaelangelo", "Donatello", "Raphael", "Leonardo"][
     Math.floor(Math.random() * 4)
   ];
-  return `${name}_${Math.round(Math.random() * 100000)}`;
+  return [`${name}_${Math.round(Math.random() * 100000)}`];
 };
 
 const largeCategoryField = new Field({
   database_type: "test",
   semantic_type: "type/Category",
+  effective_type: "type/Text",
+  base_type: "type/Text",
   table_id: 8,
   name: "large_category_field",
   has_field_values: "list",
   values: new Array(MAX_INLINE_CATEGORIES + 1).fill(null).map(turtleFactory),
   dimensions: {},
   dimension_options: [],
-  effective_type: "type/Text",
   id: 138,
-  effective_type: "type/Text",
   metadata,
 });
 
 const emptyCategoryField = new Field({
   database_type: "test",
   semantic_type: "type/Category",
+  effective_type: "type/Text",
+  base_type: "type/Text",
   table_id: 8,
   name: "empty_category_field",
   has_field_values: "list",
   values: [],
   dimensions: {},
   dimension_options: [],
-  effective_type: "type/Text",
   id: 139,
-  effective_type: "type/Text",
   metadata,
 });
 
+// @ts-ignore
 metadata.fields[smallCategoryField.id] = smallCategoryField;
+// @ts-ignore
 metadata.fields[largeCategoryField.id] = largeCategoryField;
+// @ts-ignore
 metadata.fields[emptyCategoryField.id] = emptyCategoryField;
 
 const card = {
@@ -84,7 +88,7 @@ const card = {
 };
 
 const question = new Question(card, metadata);
-const query = question.query();
+const query = question.query() as StructuredQuery;
 const smallDimension = smallCategoryField.dimension();
 const largeDimension = largeCategoryField.dimension();
 const emptyDimension = emptyCategoryField.dimension();
@@ -103,17 +107,17 @@ describe("InlineCategoryPicker", () => {
       <InlineCategoryPickerComponent
         query={query}
         filter={testFilter}
-        newfilter={testFilter}
-        handleChange={changeSpy}
+        newFilter={testFilter}
+        onChange={changeSpy}
         fieldValues={smallCategoryField.values}
         fetchFieldValues={fetchSpy}
         dimension={smallDimension}
-        handleClear={changeSpy}
+        onClear={changeSpy}
       />,
     );
 
     screen.getByTestId("category-picker");
-    smallCategoryField.values.forEach(value => {
+    smallCategoryField.values.forEach(([value]) => {
       screen.getByText(value);
     });
   });
@@ -131,12 +135,12 @@ describe("InlineCategoryPicker", () => {
       <InlineCategoryPickerComponent
         query={query}
         filter={testFilter}
-        newfilter={testFilter}
-        handleChange={changeSpy}
+        newFilter={testFilter}
+        onChange={changeSpy}
         fieldValues={emptyCategoryField.values}
         fetchFieldValues={fetchSpy}
         dimension={emptyDimension}
-        handleClear={changeSpy}
+        onClear={changeSpy}
       />,
     );
     screen.getByTestId("loading-spinner");
@@ -156,12 +160,12 @@ describe("InlineCategoryPicker", () => {
       <InlineCategoryPickerComponent
         query={query}
         filter={testFilter}
-        newfilter={testFilter}
-        handleChange={changeSpy}
+        newFilter={testFilter}
+        onChange={changeSpy}
         fieldValues={emptyCategoryField.values}
         fetchFieldValues={fetchSpy}
         dimension={emptyDimension}
-        handleClear={changeSpy}
+        onClear={changeSpy}
       />,
     );
     await waitFor(() => expect(fetchSpy).toHaveBeenCalled());
@@ -181,17 +185,17 @@ describe("InlineCategoryPicker", () => {
       <InlineCategoryPickerComponent
         query={query}
         filter={testFilter}
-        newfilter={testFilter}
-        handleChange={changeSpy}
+        newFilter={testFilter}
+        onChange={changeSpy}
         fieldValues={smallCategoryField.values}
         fetchFieldValues={fetchSpy}
         dimension={smallDimension}
-        handleClear={changeSpy}
+        onClear={changeSpy}
       />,
     );
 
     screen.getByTestId("category-picker");
-    smallCategoryField.values.forEach(value => {
+    smallCategoryField.values.forEach(([value]) => {
       screen.getByText(value);
     });
   });
@@ -209,12 +213,12 @@ describe("InlineCategoryPicker", () => {
       <InlineCategoryPickerComponent
         query={query}
         filter={testFilter}
-        newfilter={testFilter}
-        handleChange={changeSpy}
+        newFilter={testFilter}
+        onChange={changeSpy}
         fieldValues={largeCategoryField.values}
         fetchFieldValues={fetchSpy}
         dimension={largeDimension}
-        handleClear={changeSpy}
+        onClear={changeSpy}
       />,
     );
 
@@ -236,12 +240,12 @@ describe("InlineCategoryPicker", () => {
       <InlineCategoryPickerComponent
         query={query}
         filter={testFilter}
-        newfilter={testFilter}
-        handleChange={changeSpy}
+        newFilter={testFilter}
+        onChange={changeSpy}
         fieldValues={smallCategoryField.values}
         fetchFieldValues={fetchSpy}
         dimension={smallDimension}
-        handleClear={changeSpy}
+        onClear={changeSpy}
       />,
     );
 
@@ -265,12 +269,12 @@ describe("InlineCategoryPicker", () => {
       <InlineCategoryPickerComponent
         query={query}
         filter={testFilter}
-        newfilter={testFilter}
-        handleChange={changeSpy}
+        newFilter={testFilter}
+        onChange={changeSpy}
         fieldValues={smallCategoryField.values}
         fetchFieldValues={fetchSpy}
         dimension={smallDimension}
-        handleClear={changeSpy}
+        onClear={changeSpy}
       />,
     );
 
@@ -297,12 +301,12 @@ describe("InlineCategoryPicker", () => {
       <InlineCategoryPickerComponent
         query={query}
         filter={testFilter}
-        newfilter={testFilter}
-        handleChange={changeSpy}
+        newFilter={testFilter}
+        onChange={changeSpy}
         fieldValues={emptyCategoryField.values}
         fetchFieldValues={fetchSpy}
         dimension={emptyDimension}
-        handleClear={changeSpy}
+        onClear={changeSpy}
       />,
     );
     await waitFor(() => expect(fetchSpy).toHaveBeenCalled());
@@ -323,12 +327,12 @@ describe("InlineCategoryPicker", () => {
       <InlineCategoryPickerComponent
         query={query}
         filter={testFilter}
-        newfilter={testFilter}
-        handleChange={changeSpy}
+        newFilter={testFilter}
+        onChange={changeSpy}
         fieldValues={largeCategoryField.values}
         fetchFieldValues={fetchSpy}
         dimension={largeDimension}
-        handleClear={changeSpy}
+        onClear={changeSpy}
       />,
     );
 

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineCategoryPicker/InlineCategoryPicker.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineCategoryPicker/InlineCategoryPicker.unit.spec.tsx
@@ -1,0 +1,337 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { metadata } from "__support__/sample_database_fixture";
+
+import Field from "metabase-lib/lib/metadata/Field";
+import Filter from "metabase-lib/lib/queries/structured/Filter";
+import Question from "metabase-lib/lib/Question";
+
+import { InlineCategoryPickerComponent } from "./InlineCategoryPicker";
+import { MAX_INLINE_CATEGORIES } from "./constants";
+
+const smallCategoryField = new Field({
+  database_type: "test",
+  semantic_type: "type/Category",
+  table_id: 8,
+  name: "small_category_field",
+  has_field_values: "list",
+  values: ["Michaelangelo", "Donatello", "Raphael", "Leonardo"],
+  dimensions: {},
+  dimension_options: [],
+  effective_type: "type/Text",
+  id: 137,
+  effective_type: "type/Text",
+  metadata,
+});
+
+// we want to make sure we always get enough unique field values
+// even if we change MAX_INLINE_CATEGORIES
+const turtleFactory = () => {
+  const name = ["Michaelangelo", "Donatello", "Raphael", "Leonardo"][
+    Math.floor(Math.random() * 4)
+  ];
+  return `${name}_${Math.round(Math.random() * 100000)}`;
+};
+
+const largeCategoryField = new Field({
+  database_type: "test",
+  semantic_type: "type/Category",
+  table_id: 8,
+  name: "large_category_field",
+  has_field_values: "list",
+  values: new Array(MAX_INLINE_CATEGORIES + 1).fill(null).map(turtleFactory),
+  dimensions: {},
+  dimension_options: [],
+  effective_type: "type/Text",
+  id: 138,
+  effective_type: "type/Text",
+  metadata,
+});
+
+const emptyCategoryField = new Field({
+  database_type: "test",
+  semantic_type: "type/Category",
+  table_id: 8,
+  name: "empty_category_field",
+  has_field_values: "list",
+  values: [],
+  dimensions: {},
+  dimension_options: [],
+  effective_type: "type/Text",
+  id: 139,
+  effective_type: "type/Text",
+  metadata,
+});
+
+metadata.fields[smallCategoryField.id] = smallCategoryField;
+metadata.fields[largeCategoryField.id] = largeCategoryField;
+metadata.fields[emptyCategoryField.id] = emptyCategoryField;
+
+const card = {
+  dataset_query: {
+    database: 5,
+    query: {
+      "source-table": 8,
+    },
+    type: "query",
+  },
+  display: "table",
+  visualization_settings: {},
+};
+
+const question = new Question(card, metadata);
+const query = question.query();
+const smallDimension = smallCategoryField.dimension();
+const largeDimension = largeCategoryField.dimension();
+const emptyDimension = emptyCategoryField.dimension();
+
+describe("InlineCategoryPicker", () => {
+  it("should render an inline category picker", () => {
+    const testFilter = new Filter(
+      ["=", ["field", smallCategoryField.id, null], undefined],
+      null,
+      query,
+    );
+    const changeSpy = jest.fn();
+    const fetchSpy = jest.fn();
+
+    render(
+      <InlineCategoryPickerComponent
+        query={query}
+        filter={testFilter}
+        newfilter={testFilter}
+        handleChange={changeSpy}
+        fieldValues={smallCategoryField.values}
+        fetchFieldValues={fetchSpy}
+        dimension={smallDimension}
+        handleClear={changeSpy}
+      />,
+    );
+
+    screen.getByTestId("category-picker");
+    smallCategoryField.values.forEach(value => {
+      screen.getByText(value);
+    });
+  });
+
+  it("should render a loading spinner while loading", async () => {
+    const testFilter = new Filter(
+      ["=", ["field", emptyCategoryField.id, null], undefined],
+      null,
+      query,
+    );
+    const changeSpy = jest.fn();
+    const fetchSpy = jest.fn();
+
+    render(
+      <InlineCategoryPickerComponent
+        query={query}
+        filter={testFilter}
+        newfilter={testFilter}
+        handleChange={changeSpy}
+        fieldValues={emptyCategoryField.values}
+        fetchFieldValues={fetchSpy}
+        dimension={emptyDimension}
+        handleClear={changeSpy}
+      />,
+    );
+    screen.getByTestId("loading-spinner");
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalled());
+  });
+
+  it("should render a warning message on api failure", async () => {
+    const testFilter = new Filter(
+      ["=", ["field", emptyCategoryField.id, null], undefined],
+      null,
+      query,
+    );
+    const changeSpy = jest.fn();
+    const fetchSpy = jest.fn();
+
+    render(
+      <InlineCategoryPickerComponent
+        query={query}
+        filter={testFilter}
+        newfilter={testFilter}
+        handleChange={changeSpy}
+        fieldValues={emptyCategoryField.values}
+        fetchFieldValues={fetchSpy}
+        dimension={emptyDimension}
+        handleClear={changeSpy}
+      />,
+    );
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalled());
+    screen.getByLabelText("warning icon");
+  });
+
+  it(`should render up to ${MAX_INLINE_CATEGORIES} checkboxes`, () => {
+    const testFilter = new Filter(
+      ["=", ["field", smallCategoryField.id, null], undefined],
+      null,
+      query,
+    );
+    const changeSpy = jest.fn();
+    const fetchSpy = jest.fn();
+
+    render(
+      <InlineCategoryPickerComponent
+        query={query}
+        filter={testFilter}
+        newfilter={testFilter}
+        handleChange={changeSpy}
+        fieldValues={smallCategoryField.values}
+        fetchFieldValues={fetchSpy}
+        dimension={smallDimension}
+        handleClear={changeSpy}
+      />,
+    );
+
+    screen.getByTestId("category-picker");
+    smallCategoryField.values.forEach(value => {
+      screen.getByText(value);
+    });
+  });
+
+  it(`should not render more than ${MAX_INLINE_CATEGORIES} checkboxes`, () => {
+    const testFilter = new Filter(
+      ["=", ["field", largeCategoryField.id, null], undefined],
+      null,
+      query,
+    );
+    const changeSpy = jest.fn();
+    const fetchSpy = jest.fn();
+
+    render(
+      <InlineCategoryPickerComponent
+        query={query}
+        filter={testFilter}
+        newfilter={testFilter}
+        handleChange={changeSpy}
+        fieldValues={largeCategoryField.values}
+        fetchFieldValues={fetchSpy}
+        dimension={largeDimension}
+        handleClear={changeSpy}
+      />,
+    );
+
+    expect(screen.queryByTestId("category-picker")).not.toBeInTheDocument();
+    // should render general purpose picker instead
+    screen.getByTestId("select-button");
+  });
+
+  it("should load existing filter selections", () => {
+    const testFilter = new Filter(
+      ["=", ["field", smallCategoryField.id, null], "Donatello", "Leonardo"],
+      null,
+      query,
+    );
+    const changeSpy = jest.fn();
+    const fetchSpy = jest.fn();
+
+    render(
+      <InlineCategoryPickerComponent
+        query={query}
+        filter={testFilter}
+        newfilter={testFilter}
+        handleChange={changeSpy}
+        fieldValues={smallCategoryField.values}
+        fetchFieldValues={fetchSpy}
+        dimension={smallDimension}
+        handleClear={changeSpy}
+      />,
+    );
+
+    screen.getByTestId("category-picker");
+    expect(screen.getByLabelText("Donatello")).toBeChecked();
+    expect(screen.getByLabelText("Leonardo")).toBeChecked();
+    expect(screen.getByLabelText("Raphael")).not.toBeChecked();
+    expect(screen.getByLabelText("Michaelangelo")).not.toBeChecked();
+  });
+
+  it("should save a filter based on selection", () => {
+    const testFilter = new Filter(
+      ["=", ["field", smallCategoryField.id, null], undefined],
+      null,
+      query,
+    );
+    const changeSpy = jest.fn();
+    const fetchSpy = jest.fn();
+
+    render(
+      <InlineCategoryPickerComponent
+        query={query}
+        filter={testFilter}
+        newfilter={testFilter}
+        handleChange={changeSpy}
+        fieldValues={smallCategoryField.values}
+        fetchFieldValues={fetchSpy}
+        dimension={smallDimension}
+        handleClear={changeSpy}
+      />,
+    );
+
+    screen.getByTestId("category-picker");
+    userEvent.click(screen.getByLabelText("Raphael"));
+    expect(changeSpy.mock.calls.length).toBe(1);
+    expect(changeSpy.mock.calls[0][0]).toEqual([
+      "=",
+      ["field", 137, null],
+      "Raphael",
+    ]);
+  });
+
+  it("should fetch field values data if its not already loaded", async () => {
+    const testFilter = new Filter(
+      ["=", ["field", emptyCategoryField.id, null], undefined],
+      null,
+      query,
+    );
+    const changeSpy = jest.fn();
+    const fetchSpy = jest.fn();
+
+    render(
+      <InlineCategoryPickerComponent
+        query={query}
+        filter={testFilter}
+        newfilter={testFilter}
+        handleChange={changeSpy}
+        fieldValues={emptyCategoryField.values}
+        fetchFieldValues={fetchSpy}
+        dimension={emptyDimension}
+        handleClear={changeSpy}
+      />,
+    );
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalled());
+
+    expect(fetchSpy.mock.calls[0][0]).toEqual({ id: emptyCategoryField.id });
+  });
+
+  it("should not fetch field values data if it is already present", async () => {
+    const testFilter = new Filter(
+      ["=", ["field", largeCategoryField.id, null], undefined],
+      null,
+      query,
+    );
+    const changeSpy = jest.fn();
+    const fetchSpy = jest.fn();
+
+    render(
+      <InlineCategoryPickerComponent
+        query={query}
+        filter={testFilter}
+        newfilter={testFilter}
+        handleChange={changeSpy}
+        fieldValues={largeCategoryField.values}
+        fetchFieldValues={fetchSpy}
+        dimension={largeDimension}
+        handleClear={changeSpy}
+      />,
+    );
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineCategoryPicker/constants.ts
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineCategoryPicker/constants.ts
@@ -1,1 +1,1 @@
-export const MAX_INLINE_CATEGORIES = 9;
+export const MAX_INLINE_CATEGORIES = 12;

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineCategoryPicker/constants.ts
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineCategoryPicker/constants.ts
@@ -1,1 +1,1 @@
-export const MAX_INLINE_CATEGORIES = 16;
+export const MAX_INLINE_CATEGORIES = 9;

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineCategoryPicker/constants.ts
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineCategoryPicker/constants.ts
@@ -1,0 +1,1 @@
+export const MAX_INLINE_CATEGORIES = 16;

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineCategoryPicker/index.ts
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineCategoryPicker/index.ts
@@ -1,0 +1,1 @@
+export * from "./InlineCategoryPicker";

--- a/frontend/test/metabase/scenarios/filters/filter-bulk.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/filter-bulk.cy.spec.js
@@ -146,15 +146,7 @@ describe("scenarios > filters > bulk filtering", () => {
 
     modal().within(() => {
       cy.findByText("Product").click();
-      cy.findByLabelText("Category").click();
-    });
-
-    popover().within(() => {
-      cy.findByText("Gadget").click();
-      cy.button("Add filter").click();
-    });
-
-    modal().within(() => {
+      cy.findByLabelText("Gadget").click();
       cy.button("Apply").click();
       cy.wait("@dataset");
     });

--- a/frontend/test/metabase/scenarios/filters/filter-bulk.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/filter-bulk.cy.spec.js
@@ -8,7 +8,7 @@ import {
 import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
-const { ORDERS_ID, ORDERS } = SAMPLE_DATABASE;
+const { ORDERS_ID, ORDERS, PEOPLE_ID } = SAMPLE_DATABASE;
 
 const rawQuestionDetails = {
   dataset_query: {
@@ -16,6 +16,16 @@ const rawQuestionDetails = {
     type: "query",
     query: {
       "source-table": ORDERS_ID,
+    },
+  },
+};
+
+const peopleQuestion = {
+  dataset_query: {
+    database: SAMPLE_DB_ID,
+    type: "query",
+    query: {
+      "source-table": PEOPLE_ID,
     },
   },
 };
@@ -399,6 +409,42 @@ describe("scenarios > filters > bulk filtering", () => {
         // there should be no filter so the X should not populate
         cy.get(".Icon-close").should("not.exist");
       });
+    });
+  });
+  describe("category filters", () => {
+    beforeEach(() => {
+      visitQuestionAdhoc(peopleQuestion);
+      openFilterModal();
+    });
+
+    it("should show inline category picker for referral source", () => {
+      modal().within(() => {
+        cy.findByText("Affiliate").click();
+        cy.button("Apply").click();
+        cy.wait("@dataset");
+      });
+
+      cy.findByText("Source is Affiliate").should("be.visible");
+      cy.findByText("Showing 506 rows").should("be.visible");
+    });
+
+    it("should not show inline category picker for state", () => {
+      modal().within(() => {
+        cy.findByLabelText("State").click();
+      });
+
+      popover().within(() => {
+        cy.findByText("AZ").click();
+        cy.button("Add filter").click();
+      });
+
+      modal().within(() => {
+        cy.button("Apply").click();
+        cy.wait("@dataset");
+      });
+
+      cy.findByText("State is AZ").should("be.visible");
+      cy.findByText("Showing 20 rows").should("be.visible");
     });
   });
 });


### PR DESCRIPTION
## Background

We want to make it super easy to filter by categories when there are less than 13 unique category values. when opening the bulk filter modal, we will show inline checkboxes for category filters when there are 12 or fewer (like product category), and use the standard popover filter for larger sets of values (like state).

![Screen Shot 2022-06-14 at 1 54 01 PM](https://user-images.githubusercontent.com/30528226/173676890-8c21df90-d26f-4dcc-90c3-8d8e5dc9bc5b.png)


## To Test

- Open the bulk filter modal on the People table: see that the source field shows its filter options inline
- Also in the people table, see that the state field does not show its options inline, because there are too many
- See that adding and removing category filters for both fields works as expected.
