### PR TITLE
Allow Chevron click on select button

### DIFF
--- a/frontend/src/metabase/core/components/SelectButton/SelectButton.tsx
+++ b/frontend/src/metabase/core/components/SelectButton/SelectButton.tsx
@@ -21,7 +21,7 @@ export interface SelectButtonProps
   disabled?: boolean;
   fullWidth?: boolean;
   highlighted?: boolean;
-  onClick: () => void;
+  onClick?: () => void;
   onClear?: () => void;
   dataTestId?: string;
 }

--- a/frontend/src/metabase/core/components/SelectButton/SelectButton.tsx
+++ b/frontend/src/metabase/core/components/SelectButton/SelectButton.tsx
@@ -21,6 +21,7 @@ export interface SelectButtonProps
   disabled?: boolean;
   fullWidth?: boolean;
   highlighted?: boolean;
+  onClick: () => void;
   onClear?: () => void;
   dataTestId?: string;
 }
@@ -35,6 +36,7 @@ const SelectButton = forwardRef(function SelectButton(
     disabled = false,
     fullWidth = true,
     highlighted = false,
+    onClick,
     onClear,
     dataTestId,
     ...rest
@@ -70,6 +72,7 @@ const SelectButton = forwardRef(function SelectButton(
       disabled={disabled}
       highlighted={highlighted}
       fullWidth={fullWidth}
+      onClick={onClick}
       {...rest}
     >
       {React.isValidElement(left) && left}
@@ -81,7 +84,7 @@ const SelectButton = forwardRef(function SelectButton(
         size={12}
         hasValue={hasValue}
         highlighted={highlighted}
-        onClick={onClear ? handleClear : undefined}
+        onClick={rightIcon === "close" ? handleClear : undefined}
       />
     </SelectButtonRoot>
   );


### PR DESCRIPTION
## Description

The `SelectButton` component conditionally renders either a chevron or close icon, depending on the state of the component. However, the icon itself has a click action which was conditional only upon whether an `onClear` function was passed. This updates that logic to only use the `onClear` function when the `close` icon appears, keeping the `chevronDown` icon from triggering the `onClear` function, and allowing it to bubble up to the main `onClick` handler.

I also added in the `onClick` prop explicitly, to reduce the number of inscrutable `...rest` props.

**tl;dr: clicking on the chevron icon works as expected now**

Before | After
--- | ---
![clickfail](https://user-images.githubusercontent.com/30528226/173694678-0fa865a0-7798-476b-b3bb-b8b49fb641eb.gif) | ![clickyes](https://user-images.githubusercontent.com/30528226/173694671-893dfc20-4602-4038-a5eb-706da8b35084.gif)

### Testing steps

- open the bulk filter modal on any table
- click a chevron in a select box, and see that the popover opens!
