### PR TITLE
Fix e2e test after introducing #23338

### DIFF
--- a/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
@@ -105,7 +105,8 @@ describe("scenarios > admin > databases > add", () => {
 
     cy.button("Save").click();
     cy.wait("@createDatabase");
-    cy.findByText(/Hmm, we couldn't connect to the database/);
+    cy.findByText(": check your connection string");
+    cy.findByText("Implicitly relative file paths are not allowed.");
   });
 
   it("should show scheduling settings if you enable the toggle", () => {


### PR DESCRIPTION
One particular E2E test seems to always fail after merging #23338 which enhances H2 error messages.

e.g.
- https://app.circleci.com/pipelines/github/metabase/metabase/38058/workflows/8e84f026-e0a9-4da5-8462-e29f7fef8644/jobs/1984327
- https://app.circleci.com/pipelines/github/metabase/metabase/38092/workflows/6c8257cc-c544-43dd-b8e1-306129353d27/jobs/1985658
- https://app.circleci.com/pipelines/github/metabase/metabase/38082/workflows/c1b68c26-c4cf-4562-9191-ba0f14a18c8b/jobs/1985805