### PR TITLE
[E2E] Fix native filter revision history flake

### DIFF
--- a/frontend/test/metabase/scenarios/native-filters/reproductions/12581.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native-filters/reproductions/12581.cy.spec.js
@@ -27,6 +27,8 @@ const nativeQuery = {
 
 describe("issue 12581", () => {
   beforeEach(() => {
+    cy.intercept("POST", "/api/dataset").as("dataset");
+
     restore();
     cy.signInAsAdmin();
 
@@ -54,9 +56,16 @@ describe("issue 12581", () => {
     });
 
     cy.reload();
+    cy.wait("@cardQuery");
 
     cy.findByTestId("revision-history-button").click();
+    // Make sure sidebar opened and the history loaded
+    cy.findByText("You created this");
+
     cy.findByTestId("question-revert-button").click(); // Revert to the first revision
+    cy.wait("@dataset");
+
+    cy.findByText("You reverted to an earlier revision");
     cy.findByText(/Open Editor/i).click();
 
     cy.log("Reported failing on v0.35.3");

--- a/frontend/test/metabase/scenarios/native-filters/reproductions/12581.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native-filters/reproductions/12581.cy.spec.js
@@ -72,6 +72,9 @@ describe("issue 12581", () => {
     cy.get("@editor")
       .should("be.visible")
       .and("contain", ORIGINAL_QUERY);
+
+    cy.findByText("37.65");
+
     // Filter dropdown field
     filterWidget().contains("Filter");
   });

--- a/frontend/test/metabase/scenarios/native-filters/reproductions/12581.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native-filters/reproductions/12581.cy.spec.js
@@ -48,7 +48,7 @@ describe("issue 12581", () => {
       .type("{selectall}{backspace}", { delay: 50 });
     cy.get("@editor")
       .click()
-      .type("{selectall}{backspace}SELECT * FROM ORDERS");
+      .type("{selectall}{backspace}SELECT 1");
 
     cy.findByText("Save").click();
     modal().within(() => {

--- a/frontend/test/metabase/scenarios/native-filters/reproductions/12581.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native-filters/reproductions/12581.cy.spec.js
@@ -71,7 +71,7 @@ describe("issue 12581", () => {
     cy.log("Reported failing on v0.35.3");
     cy.get("@editor")
       .should("be.visible")
-      .contains(ORIGINAL_QUERY);
+      .and("contain", ORIGINAL_QUERY);
     // Filter dropdown field
     filterWidget().contains("Filter");
   });


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Fixes the most prevalent flake, according to the stats from the last 14 days
![image](https://user-images.githubusercontent.com/31325167/173860663-ddbe34a1-f36f-48d4-83af-e711a88b172b.png)

The element "Open editor" was getting detached from the DOM at the moment when Cypress tried to click on it. I've added some additional query waiting and other UI sanity checks that should prevent this from happening in the future.