### PR TITLE
Backport ensure error on query errors

### DIFF
--- a/src/metabase/query_processor/middleware/catch_exceptions.clj
+++ b/src/metabase/query_processor/middleware/catch_exceptions.clj
@@ -155,9 +155,15 @@
       (letfn [(raisef* [e context]
                 ;; format the Exception and return it
                 (let [formatted-exception (format-exception* query e @extra-info)]
-                  (log/error (str (trs "Error processing query: {0}" (:error format-exception))
+                  (log/error (str (trs "Error processing query: {0}"
+                                       (or (:error formatted-exception)
+                                           ;; log in server locale, respond in user locale
+                                           (trs "Error running query")))
                                   "\n" (u/pprint-to-str formatted-exception)))
-                  (context/resultf formatted-exception context)))]
+                  ;; ensure always a message on the error otherwise FE thinks query was successful.  (#23258, #23281)
+                  (context/resultf (update formatted-exception
+                                           :error (fnil identity (trs "Error running query")))
+                                   context)))]
         (try
           (qp query rff (assoc context :raisef raisef*))
           (catch Throwable e


### PR DESCRIPTION
Manual backport of https://github.com/metabase/metabase/pull/23346 . Autobackport failed due to `qp.context` vs `context` alias for `[metabase.query-processor.context :as context]`