### PR TITLE
[E2E] Experiment running `native-filters` test group as PR check

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -69,6 +69,7 @@ jobs:
           - "joins"
           - "models"
           - "native"
+          - "native-filters"
           - "organization"
           - "permissions"
           - "question"


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Following the steps of https://github.com/metabase/metabase/pull/21492 and the tasks that @ariya started, we're now adding `native-filters` test group to PR checks using GitHub actions.
- The only flake from this group in the last 30 days has been fixed in https://github.com/metabase/metabase/pull/23361

### The next steps
After we make sure this group runs without major hiccups on GitHub (for at least a week?), remove it from CircleCI.