### PR TITLE
JWT shared key can now be any string. Message to suggest 64char key

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_settings.clj
@@ -108,12 +108,10 @@ on your IdP, this usually looks something like http://www.example.com/141xkex604
   (deferred-tru "URL of JWT based login page"))
 
 (defsetting jwt-shared-secret
-  (deferred-tru "String used to seed the private key used to validate JWT messages")
-  :setter (fn [new-value]
-            (when (seq new-value)
-              (assert (u/hexadecimal-string? new-value)
-                       "Invalid JWT Shared Secret key must be a hexadecimal-encoded 256-bit key (i.e., a 64-character string)."))
-            (setting/set-value-of-type! :string :jwt-shared-secret new-value)))
+  (str (deferred-tru "String used to seed the private key used to validate JWT messages.")
+       " "
+       (deferred-tru "A hexadecimal-encoded 256-bit key (i.e., a 64-character string) is strongly recommended."))
+  :type :string)
 
 (defsetting jwt-attribute-email
   (deferred-tru "Key to retrieve the JWT user's email address")

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_settings.clj
@@ -107,9 +107,9 @@ on your IdP, this usually looks something like http://www.example.com/141xkex604
   (deferred-tru "URL of JWT based login page"))
 
 (defsetting jwt-shared-secret
-  (str (deferred-tru "String used to seed the private key used to validate JWT messages.")
-       " "
-       (deferred-tru "A hexadecimal-encoded 256-bit key (i.e., a 64-character string) is strongly recommended."))
+  (deferred-tru (str "String used to seed the private key used to validate JWT messages."
+                     " "
+                     "A hexadecimal-encoded 256-bit key (i.e., a 64-character string) is strongly recommended."))
   :type :string)
 
 (defsetting jwt-attribute-email

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_settings.clj
@@ -4,7 +4,6 @@
   information. Separating out this information creates a better dependency graph and avoids circular dependencies."
   (:require [clojure.tools.logging :as log]
             [metabase.models.setting :as setting :refer [defsetting]]
-            [metabase.util :as u]
             [metabase.util.i18n :refer [deferred-tru trs tru]]
             [metabase.util.schema :as su]
             [saml20-clj.core :as saml]


### PR DESCRIPTION
Addresses: #16889

Some IdP providers might have shorter signing keys, so the restriction is loosened here for situations where a customer may not be able to change the provider or the signing key.

The 'generate key' button will still generate a 64 character key, and the text is adjusted to strongly recommend such a key be used, but someone can put a shorter one in.