### PR TITLE
Handle quarters in native queries

### DIFF
--- a/src/metabase/driver/common/parameters/dates.clj
+++ b/src/metabase/driver/common/parameters/dates.clj
@@ -69,7 +69,11 @@
 (defn- year-range [start end]
   (comparison-range start end :year))
 
-(defn- quarter-range
+(defn- relative-quarter-range
+  [start end]
+  (comparison-range start end :quarter))
+
+(defn- absolute-quarter-range
   [quarter year]
   (let [year-quarter (t/year-quarter year (case quarter
                                             "Q1" 1
@@ -80,20 +84,22 @@
      :end   (.atEndOfQuarter year-quarter)}))
 
 (def ^:private operations-by-date-unit
-  {"second" {:unit-range second-range
-             :to-period  t/seconds}
-   "minute" {:unit-range minute-range
-             :to-period  t/minutes}
-   "hour"   {:unit-range hour-range
-             :to-period  t/hours}
-   "day"    {:unit-range day-range
-             :to-period  t/days}
-   "week"   {:unit-range week-range
-             :to-period  t/weeks}
-   "month"  {:unit-range month-range
-             :to-period  t/months}
-   "year"   {:unit-range year-range
-             :to-period  t/years}})
+  {"second"  {:unit-range second-range
+              :to-period  t/seconds}
+   "minute"  {:unit-range minute-range
+              :to-period  t/minutes}
+   "hour"    {:unit-range hour-range
+              :to-period  t/hours}
+   "day"     {:unit-range day-range
+              :to-period  t/days}
+   "week"    {:unit-range week-range
+              :to-period  t/weeks}
+   "month"   {:unit-range month-range
+              :to-period  t/months}
+   "quarter" {:unit-range relative-quarter-range
+              :to-period  (comp t/months (partial * 3))}
+   "year"    {:unit-range year-range
+              :to-period  t/years}})
 
 (defn- maybe-reduce-resolution [unit dt]
   (if
@@ -269,9 +275,9 @@
    ;; quarter year
    {:parser (regex->parser #"(Q[1-4]{1})-([0-9]{4})" [:quarter :year])
     :range  (fn [{:keys [quarter year]} _]
-              (quarter-range quarter (Integer/parseInt year)))
+              (absolute-quarter-range quarter (Integer/parseInt year)))
     :filter (fn [{:keys [quarter year]} field-clause]
-              (range->filter (quarter-range quarter (Integer/parseInt year))
+              (range->filter (absolute-quarter-range quarter (Integer/parseInt year))
                              field-clause))}
    ;; single day
    {:parser (regex->parser #"([0-9-T:]+)" [:date])

--- a/test/metabase/driver/common/parameters/dates_test.clj
+++ b/test/metabase/driver/common/parameters/dates_test.clj
@@ -133,45 +133,51 @@
                                            "2016-04-18~2016-04-23" {:end "2016-04-23", :start "2016-04-18"}
                                            "2016-04-18~"           {:start "2016-04-18"}
                                            "~2016-04-18"           {:end "2016-04-18"}}
-             "relative (past)"            {"past30seconds" {:end "2016-06-07T12:13:54", :start "2016-06-07T12:13:25"}
-                                           "past5minutes~" {:end "2016-06-07T12:13:00", :start "2016-06-07T12:08:00"}
-                                           "past3hours"    {:end "2016-06-07T11:00:00", :start "2016-06-07T09:00:00"}
-                                           "past3days"     {:end "2016-06-06", :start "2016-06-04"}
-                                           "past3days~"    {:end "2016-06-07", :start "2016-06-04"}
-                                           "past7days"     {:end "2016-06-06", :start "2016-05-31"}
-                                           "past30days"    {:end "2016-06-06", :start "2016-05-08"}
-                                           "past2months"   {:end "2016-05-31", :start "2016-04-01"}
-                                           "past2months~"  {:end "2016-06-30", :start "2016-04-01"}
-                                           "past13months"  {:end "2016-05-31", :start "2015-05-01"}
-                                           "past1years"    {:end "2015-12-31", :start "2015-01-01"}
-                                           "past1years~"   {:end "2016-12-31", :start "2015-01-01"}
-                                           "past16years"   {:end "2015-12-31", :start "2000-01-01"}}
-             "relative (next)"            {"next45seconds" {:end "2016-06-07T12:14:40", :start "2016-06-07T12:13:56"}
-                                           "next20minutes" {:end "2016-06-07T12:33:00", :start "2016-06-07T12:14:00"}
-                                           "next6hours"    {:end "2016-06-07T18:00:00", :start "2016-06-07T13:00:00"}
-                                           "next3days"     {:end "2016-06-10", :start "2016-06-08"}
-                                           "next3days~"    {:end "2016-06-10", :start "2016-06-07"}
-                                           "next7days"     {:end "2016-06-14", :start "2016-06-08"}
-                                           "next30days"    {:end "2016-07-07", :start "2016-06-08"}
-                                           "next2months"   {:end "2016-08-31", :start "2016-07-01"}
-                                           "next2months~"  {:end "2016-08-31", :start "2016-06-01"}
-                                           "next13months"  {:end "2017-07-31", :start "2016-07-01"}
-                                           "next1years"    {:end "2017-12-31", :start "2017-01-01"}
-                                           "next1years~"   {:end "2017-12-31", :start "2016-01-01"}
-                                           "next16years"   {:end "2032-12-31", :start "2017-01-01"}}
-             "relative (this)"            {"thissecond" {:end "2016-06-07T12:13:55", :start "2016-06-07T12:13:55"}
-                                           "thisminute" {:end "2016-06-07T12:13:00", :start "2016-06-07T12:13:00"}
-                                           "thishour"   {:end "2016-06-07T12:00:00", :start "2016-06-07T12:00:00"}
-                                           "thisday"    {:end "2016-06-07", :start "2016-06-07"}
-                                           "thisweek"   {:end "2016-06-11", :start "2016-06-05"}
-                                           "thismonth"  {:end "2016-06-30", :start "2016-06-01"}
-                                           "thisyear"   {:end "2016-12-31", :start "2016-01-01"}}
-             "relative (last)"            {"lastsecond" {:end "2016-06-07T12:13:54", :start "2016-06-07T12:13:54"}
-                                           "lastminute" {:end "2016-06-07T12:12:00", :start "2016-06-07T12:12:00"}
-                                           "lasthour"   {:end "2016-06-07T11:00:00", :start "2016-06-07T11:00:00"}
-                                           "lastweek"   {:end "2016-06-04", :start "2016-05-29"}
-                                           "lastmonth"  {:end "2016-05-31", :start "2016-05-01"}
-                                           "lastyear"   {:end "2015-12-31", :start "2015-01-01"}}
+             "relative (past)"            {"past30seconds"  {:end "2016-06-07T12:13:54", :start "2016-06-07T12:13:25"}
+                                           "past5minutes~"  {:end "2016-06-07T12:13:00", :start "2016-06-07T12:08:00"}
+                                           "past3hours"     {:end "2016-06-07T11:00:00", :start "2016-06-07T09:00:00"}
+                                           "past3days"      {:end "2016-06-06", :start "2016-06-04"}
+                                           "past3days~"     {:end "2016-06-07", :start "2016-06-04"}
+                                           "past7days"      {:end "2016-06-06", :start "2016-05-31"}
+                                           "past30days"     {:end "2016-06-06", :start "2016-05-08"}
+                                           "past2months"    {:end "2016-05-31", :start "2016-04-01"}
+                                           "past2months~"   {:end "2016-06-30", :start "2016-04-01"}
+                                           "past13months"   {:end "2016-05-31", :start "2015-05-01"}
+                                           "past2quarters"  {:end "2016-03-31", :start "2015-10-01"}
+                                           "past2quarters~" {:end "2016-06-30", :start "2015-10-01"}
+                                           "past1years"     {:end "2015-12-31", :start "2015-01-01"}
+                                           "past1years~"    {:end "2016-12-31", :start "2015-01-01"}
+                                           "past16years"    {:end "2015-12-31", :start "2000-01-01"}}
+             "relative (next)"            {"next45seconds"  {:end "2016-06-07T12:14:40", :start "2016-06-07T12:13:56"}
+                                           "next20minutes"  {:end "2016-06-07T12:33:00", :start "2016-06-07T12:14:00"}
+                                           "next6hours"     {:end "2016-06-07T18:00:00", :start "2016-06-07T13:00:00"}
+                                           "next3days"      {:end "2016-06-10", :start "2016-06-08"}
+                                           "next3days~"     {:end "2016-06-10", :start "2016-06-07"}
+                                           "next7days"      {:end "2016-06-14", :start "2016-06-08"}
+                                           "next30days"     {:end "2016-07-07", :start "2016-06-08"}
+                                           "next2months"    {:end "2016-08-31", :start "2016-07-01"}
+                                           "next2months~"   {:end "2016-08-31", :start "2016-06-01"}
+                                           "next2quarters"  {:end "2016-12-31", :start "2016-07-01"}
+                                           "next2quarters~" {:end "2016-12-31", :start "2016-04-01"}
+                                           "next13months"   {:end "2017-07-31", :start "2016-07-01"}
+                                           "next1years"     {:end "2017-12-31", :start "2017-01-01"}
+                                           "next1years~"    {:end "2017-12-31", :start "2016-01-01"}
+                                           "next16years"    {:end "2032-12-31", :start "2017-01-01"}}
+             "relative (this)"            {"thissecond"  {:end "2016-06-07T12:13:55", :start "2016-06-07T12:13:55"}
+                                           "thisminute"  {:end "2016-06-07T12:13:00", :start "2016-06-07T12:13:00"}
+                                           "thishour"    {:end "2016-06-07T12:00:00", :start "2016-06-07T12:00:00"}
+                                           "thisday"     {:end "2016-06-07", :start "2016-06-07"}
+                                           "thisweek"    {:end "2016-06-11", :start "2016-06-05"}
+                                           "thismonth"   {:end "2016-06-30", :start "2016-06-01"}
+                                           "thisquarter" {:end "2016-06-30", :start "2016-04-01"}
+                                           "thisyear"    {:end "2016-12-31", :start "2016-01-01"}}
+             "relative (last)"            {"lastsecond"  {:end "2016-06-07T12:13:54", :start "2016-06-07T12:13:54"}
+                                           "lastminute"  {:end "2016-06-07T12:12:00", :start "2016-06-07T12:12:00"}
+                                           "lasthour"    {:end "2016-06-07T11:00:00", :start "2016-06-07T11:00:00"}
+                                           "lastweek"    {:end "2016-06-04", :start "2016-05-29"}
+                                           "lastmonth"   {:end "2016-05-31", :start "2016-05-01"}
+                                           "lastquarter" {:end "2016-03-31", :start "2016-01-01"}
+                                           "lastyear"    {:end "2015-12-31", :start "2015-01-01"}}
              "relative (today/yesterday)" {"yesterday" {:end "2016-06-06", :start "2016-06-06"}
                                            "today"     {:end "2016-06-07", :start "2016-06-07"}}
              "relative (past) with starting from" {"past3days-from-3years" {:end "2013-06-07", :start "2013-06-04"}}


### PR DESCRIPTION
Addresses the underlying bug of https://github.com/metabase/metabase/issues/23258 

Note that issue is a P1 because the FE would show "no results" on javas 13 and below because NPEs have no message on those jvms. Java 14+ introduced friendly error messages for NPEs. PR https://github.com/metabase/metabase/pull/23346 makes sure this is always reported as an error. This PR adds the functionality so it doesn't error. (two distinct fixes with different priorities)


#### Before fix
<img width="1310" alt="image" src="https://user-images.githubusercontent.com/6377293/173909828-e207ed15-6df8-47d8-9337-c95972549bd4.png">

#### After fix
<img width="1180" alt="image" src="https://user-images.githubusercontent.com/6377293/173909957-d327be1d-daa1-494e-bbc1-cd39ae5b5304.png">

#### Big Diff
MBQL goes through a different path. This is only for native
queries. Also the diff of the testing is huge because the keys are longer due to "quarters" being longer than "month". Ignoring whitespace shows a very modest
diff:

```diff
    "month"   {:unit-range month-range
               :to-period  t/months}
+   "quarter" {:unit-range relative-quarter-range
+              :to-period  (comp t/months (partial * 3))}
    "year"    {:unit-range year-range
               :to-period  t/years}})

...

   "past2months~"   {:end "2016-06-30", :start "2016-04-01"}
   "past13months"   {:end "2016-05-31", :start "2015-05-01"}
+  "past2quarters"  {:end "2016-03-31", :start "2015-10-01"}
+  "past2quarters~" {:end "2016-06-30", :start "2015-10-01"}
   "past1years"     {:end "2015-12-31", :start "2015-01-01"}
   "past1years~"    {:end "2016-12-31", :start "2015-01-01"}

(plus a few other cases but they all mimic those around them but are slightly longer)
```

### Helpful Testing Strategies


#### Sample DB

`select id, created_at from orders where {{created_at}}`
and set a field filter of type "Date Filter"

#### Custom Table

Create a table that has entries in the middle of each quarter.

```sql
esting=# create table quarters (id serial primary key not null, description text, t timestamptz);
CREATE TABLE
testing=# insert into quarters (description, t) values ('Q1 2022', '2022-02-01'), ('Q2 2022', '2022-05-01'), ('Q3 2022', '2022-08-01'), ('Q4 2022', '2022-11-01');
INSERT 0 4
testing=# select * from quarters;
 id | description |           t
----+-------------+------------------------
  1 | Q1 2022     | 2022-02-01 00:00:00-06
  2 | Q2 2022     | 2022-05-01 00:00:00-05
  3 | Q3 2022     | 2022-08-01 00:00:00-05
  4 | Q4 2022     | 2022-11-01 00:00:00-05
(4 rows)
```
And use the query `select description, t from quarters where {{created_at}}`


Before this change
------------------

> Cannot invoke "clojure.lang.IFn.invoke(Object)" because "to_period" is null

(note, if you cannot reproduce this its because you haven't gotten
https://github.com/metabase/metabase/pull/23346 in your local version
which ensured errors always appear as errors on the frontend. java 11
has no message for NPE so the Frontend missed it was an error and
displayed no results as if the query had succeeded)

This was the case for the following scenarios:
- "last1quarters": error
- "last1quarters~": error
- "thisquarter": error
- "next1quarters": error
- "next1quarters~": error

where the ~ means to include the current quarter.

After this change
-----------------

Running the queries against the custom table I made (current time is Jun
15, Q2)

- "last1quarters": "Q1 2022" "February 1, 2022, 6:00 AM"
- "last1quarters~": "Q1 2022" "February 1, 2022, 6:00 AM" | "Q2 2022" "May 1, 2022, 5:00 AM"
- "thisquarter": "Q2 2022" "May 1, 2022, 5:00 AM"
- "next1quarters" "Q3 2022" "August 1, 2022, 5:00 AM"
- "next1quarters~": "Q2 2022" "May 1, 2022, 5:00 AM" | "Q3 2022" "August 1, 2022, 5:00 AM"

And of course added tests into the matrix for the date parsing.

