### PR TITLE
Support user-filled parameters for custom actions

### DIFF
--- a/frontend/src/metabase/dashboard/actions.js
+++ b/frontend/src/metabase/dashboard/actions.js
@@ -1236,3 +1236,16 @@ export const fetchDashboardParameterValues = args => async (
   );
   return dashboardParameterValuesCache.get(args) || [];
 };
+
+// Writeback
+export const OPEN_ACTION_PARAMETERS_MODAL =
+  "metabase/data-app/OPEN_ACTION_PARAMETERS_MODAL";
+export const openActionParametersModal = createAction(
+  OPEN_ACTION_PARAMETERS_MODAL,
+);
+
+export const CLOSE_ACTION_PARAMETERS_MODAL =
+  "metabase/data-app/CLOSE_ACTION_PARAMETERS_MODAL";
+export const closeActionParametersModal = createAction(
+  CLOSE_ACTION_PARAMETERS_MODAL,
+);

--- a/frontend/src/metabase/dashboard/actions.js
+++ b/frontend/src/metabase/dashboard/actions.js
@@ -423,10 +423,7 @@ export const saveDashboardAndCards = createThunkAction(
                 await EmittersApi.create({
                   dashboard_id: dashboard.id,
                   action_id: actionId,
-                  parameter_mappings: getActionEmitterParameterMappings(
-                    dc,
-                    action,
-                  ),
+                  parameter_mappings: getActionEmitterParameterMappings(action),
                 });
                 const newDash = await DashboardApi.get({
                   dashId: dashboard.id,

--- a/frontend/src/metabase/dashboard/containers/ActionParametersInputModal.tsx
+++ b/frontend/src/metabase/dashboard/containers/ActionParametersInputModal.tsx
@@ -1,0 +1,76 @@
+import React, { useCallback } from "react";
+import { connect } from "react-redux";
+
+import Modal from "metabase/components/Modal";
+import ModalContent from "metabase/components/ModalContent";
+
+import { WritebackActionEmitter } from "metabase/writeback/types";
+import ActionParametersInputForm from "metabase/writeback/containers/ActionParametersInputForm";
+
+import { DashboardWithCards } from "metabase-types/types/Dashboard";
+import { State } from "metabase-types/store";
+
+import { closeActionParametersModal } from "../actions";
+import { getEmitterParametersFormProps } from "../selectors";
+
+type DataAppDashboard = DashboardWithCards & {
+  emitters?: WritebackActionEmitter[];
+};
+
+interface OwnProps {
+  dashboard: DataAppDashboard;
+  focusedEmitterId: number;
+}
+
+interface StateProps {
+  formProps: any;
+}
+
+interface DispatchProps {
+  closeActionParametersModal: () => void;
+}
+
+type Props = OwnProps & StateProps & DispatchProps;
+
+function mapStateToProps(state: State) {
+  return {
+    formProps: getEmitterParametersFormProps(state),
+  };
+}
+
+const mapDispatchToProps = {
+  closeActionParametersModal,
+};
+
+function ActionParametersInputModal({
+  formProps,
+  dashboard,
+  focusedEmitterId,
+  closeActionParametersModal,
+}: Props) {
+  const emitter = dashboard.emitters?.find(
+    emitter => emitter.id === focusedEmitterId,
+  );
+
+  if (!emitter) {
+    return null;
+  }
+
+  const title = emitter.action.card.name;
+
+  return (
+    <Modal onClose={closeActionParametersModal}>
+      <ModalContent title={title} onClose={closeActionParametersModal}>
+        <ActionParametersInputForm
+          {...formProps}
+          onSubmitSuccess={closeActionParametersModal}
+        />
+      </ModalContent>
+    </Modal>
+  );
+}
+
+export default connect<StateProps, DispatchProps, OwnProps, State>(
+  mapStateToProps,
+  mapDispatchToProps,
+)(ActionParametersInputModal);

--- a/frontend/src/metabase/dashboard/containers/DashboardApp.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp.jsx
@@ -45,6 +45,9 @@ import {
   getIsLoadingComplete,
   getIsHeaderVisible,
   getIsAdditionalInfoVisible,
+
+  // Writeback
+  getFocusedEmitterId,
 } from "../selectors";
 import { getDatabases, getMetadata } from "metabase/selectors/metadata";
 import {
@@ -57,6 +60,8 @@ import { parseHashOptions } from "metabase/lib/browser";
 import * as Urls from "metabase/lib/urls";
 
 import Dashboards from "metabase/entities/dashboards";
+
+import ActionParametersInputModal from "./ActionParametersInputModal";
 
 const mapStateToProps = (state, props) => {
   return {
@@ -89,6 +94,9 @@ const mapStateToProps = (state, props) => {
     isLoadingComplete: getIsLoadingComplete(state),
     isHeaderVisible: getIsHeaderVisible(state),
     isAdditionalInfoVisible: getIsAdditionalInfoVisible(state),
+
+    // Writeback
+    focusedEmitterId: getFocusedEmitterId(state),
   };
 };
 
@@ -104,7 +112,7 @@ const mapDispatchToProps = {
 const DashboardApp = props => {
   const options = parseHashOptions(window.location.hash);
 
-  const { isRunning, isLoadingComplete, dashboard } = props;
+  const { isRunning, isLoadingComplete, dashboard, focusedEmitterId } = props;
 
   const [editingOnLoad] = useState(options.edit);
   const [addCardOnLoad] = useState(options.add && parseInt(options.add));
@@ -163,6 +171,12 @@ const DashboardApp = props => {
       />
       {/* For rendering modal urls */}
       {props.children}
+      {dashboard && focusedEmitterId && (
+        <ActionParametersInputModal
+          dashboard={dashboard}
+          focusedEmitterId={focusedEmitterId}
+        />
+      )}
       <Toaster
         message={t`Would you like to be notified when this dashboard is done loading?`}
         isShown={isShowingToaster}

--- a/frontend/src/metabase/dashboard/reducers.js
+++ b/frontend/src/metabase/dashboard/reducers.js
@@ -35,6 +35,10 @@ import {
   SET_DOCUMENT_TITLE,
   SET_SHOW_LOADING_COMPLETE_FAVICON,
   RESET,
+
+  // Writeback
+  OPEN_ACTION_PARAMETERS_MODAL,
+  CLOSE_ACTION_PARAMETERS_MODAL,
 } from "./actions";
 
 import { isVirtualDashCard, syncParametersAndEmbeddingParams } from "./utils";
@@ -392,6 +396,28 @@ const sidebar = handleActions(
   DEFAULT_SIDEBAR,
 );
 
+// Writeback
+const missingEmitterParameters = handleActions(
+  {
+    [INITIALIZE]: {
+      next: (state, payload) => null,
+    },
+    [OPEN_ACTION_PARAMETERS_MODAL]: {
+      next: (state, { payload: { emitterId, props } }) => ({
+        emitterId,
+        props,
+      }),
+    },
+    [CLOSE_ACTION_PARAMETERS_MODAL]: {
+      next: (state, payload) => null,
+    },
+    [RESET]: {
+      next: (state, payload) => null,
+    },
+  },
+  null,
+);
+
 export default combineReducers({
   dashboardId,
   isEditing,
@@ -405,4 +431,5 @@ export default combineReducers({
   isAddParameterPopoverOpen,
   sidebar,
   parameterValuesSearchCache,
+  missingEmitterParameters,
 });

--- a/frontend/src/metabase/dashboard/reducers.unit.spec.js
+++ b/frontend/src/metabase/dashboard/reducers.unit.spec.js
@@ -35,6 +35,7 @@ describe("dashboard reducers", () => {
       sidebar: { props: {} },
       slowCards: {},
       loadingControls: {},
+      missingEmitterParameters: null,
     });
   });
 

--- a/frontend/src/metabase/dashboard/selectors.js
+++ b/frontend/src/metabase/dashboard/selectors.js
@@ -205,3 +205,9 @@ export const getIsAdditionalInfoVisible = createSelector(
   [getIsEmbedded, getEmbedOptions],
   (isEmbedded, embedOptions) => !isEmbedded || embedOptions.additional_info,
 );
+
+// Writeback
+export const getFocusedEmitterId = state =>
+  state.dashboard.missingEmitterParameters?.emitterId;
+export const getEmitterParametersFormProps = state =>
+  state.dashboard.missingEmitterParameters?.props || {};

--- a/frontend/src/metabase/writeback/containers/ActionParametersInputForm.tsx
+++ b/frontend/src/metabase/writeback/containers/ActionParametersInputForm.tsx
@@ -1,0 +1,69 @@
+import React, { useCallback, useMemo } from "react";
+import { connect } from "react-redux";
+import { t } from "ttag";
+
+import { getTemplateTagType } from "metabase/parameters/utils/cards";
+
+import Form from "metabase/containers/Form";
+import { TemplateTag } from "metabase-types/types/Query";
+
+type MappedParameters = Record<string, { type: string; value: string }>;
+
+interface Props {
+  missingParameters: TemplateTag[];
+  onSubmit: (parameters: MappedParameters) => { type: string; payload: any };
+  onSubmitSuccess: () => void;
+  dispatch: (action: any) => void;
+}
+
+function getTemplateTagFieldProps(tag: TemplateTag) {
+  if (tag.type === "date") {
+    return { type: "date" };
+  }
+  if (tag.type === "number") {
+    return { type: "integer" };
+  }
+  return { type: "input" };
+}
+
+function ActionParametersInputForm({
+  missingParameters,
+  dispatch,
+  onSubmit,
+  onSubmitSuccess,
+}: Props) {
+  const form = useMemo(
+    () => ({
+      fields: missingParameters.map(tag => ({
+        name: tag.id,
+        title: tag["display-name"],
+        ...getTemplateTagFieldProps(tag),
+      })),
+    }),
+    [missingParameters],
+  );
+
+  const handleSubmit = useCallback(
+    params => {
+      const formattedParams: MappedParameters = {};
+
+      Object.keys(params).forEach(paramId => {
+        const tag = missingParameters.find(tag => tag.id === paramId);
+        if (tag) {
+          formattedParams[paramId] = {
+            value: params[paramId],
+            type: getTemplateTagType(tag),
+          };
+        }
+      });
+
+      dispatch(onSubmit(formattedParams));
+      onSubmitSuccess();
+    },
+    [missingParameters, onSubmit, onSubmitSuccess, dispatch],
+  );
+
+  return <Form form={form} onSubmit={handleSubmit} submitTitle={t`Execute`} />;
+}
+
+export default connect()(ActionParametersInputForm);

--- a/frontend/src/metabase/writeback/types.ts
+++ b/frontend/src/metabase/writeback/types.ts
@@ -1,5 +1,6 @@
 import Field from "metabase-lib/lib/metadata/Field";
 import { SavedCard, NativeDatasetQuery } from "metabase-types/types/Card";
+import { ParameterId, ParameterTarget } from "metabase-types/types/Parameter";
 
 export interface CategoryWidgetProps {
   field: {
@@ -19,6 +20,18 @@ export interface WritebackAction {
   id: number;
   type: "row";
   card: WritebackActionCard;
+  card_id: number;
   "updated-at": string;
   "created-at": string;
+}
+
+export interface WritebackActionEmitter {
+  id: number;
+  dashboard_id: number;
+  action: WritebackAction & {
+    emitter_id: number;
+  };
+  parameter_mappings: Record<ParameterId, ParameterTarget>;
+  updated_at: string;
+  created_at: string;
 }

--- a/frontend/src/metabase/writeback/utils.ts
+++ b/frontend/src/metabase/writeback/utils.ts
@@ -4,7 +4,7 @@ import Database from "metabase-lib/lib/metadata/Database";
 
 import { Database as IDatabase } from "metabase-types/types/Database";
 import { DashCard } from "metabase-types/types/Dashboard";
-import { ParameterTarget } from "metabase-types/types/Parameter";
+import { ParameterId, ParameterTarget } from "metabase-types/types/Parameter";
 
 import { WritebackAction } from "./types";
 
@@ -26,25 +26,15 @@ export const getActionButtonEmitterId = (dashCard: DashCard) =>
 export const getActionButtonActionId = (dashCard: DashCard) =>
   dashCard.visualization_settings?.click_behavior?.action;
 
-export const getActionEmitterParameterMappings = (
-  dashCard: DashCard,
-  action: WritebackAction,
-) => {
-  const { click_behavior } = dashCard.visualization_settings;
-
+export const getActionEmitterParameterMappings = (action: WritebackAction) => {
   const templateTags = Object.values(
     action.card.dataset_query.native["template-tags"],
   );
 
-  const parameterMappings: Record<string, ParameterTarget> = {};
+  const parameterMappings: Record<ParameterId, ParameterTarget> = {};
 
-  Object.keys(click_behavior.parameterMapping).forEach(targetVariableId => {
-    const templateTag = templateTags.find(tag => tag.id === targetVariableId);
-    if (templateTag) {
-      parameterMappings[targetVariableId] = getTemplateTagParameterTarget(
-        templateTag,
-      );
-    }
+  templateTags.forEach(tag => {
+    parameterMappings[tag.id] = getTemplateTagParameterTarget(tag);
   });
 
   return parameterMappings;


### PR DESCRIPTION
This PR makes Metabase handle actions with not every parameter mapped a bit more nicely.

Let's say I have a simple data app for sample db's "Orders" table. On the order detail page, I want to have a button called "Give discount" that I can click, fill in a custom discount value, and then apply it. I'd need a query like `update orders set discount = {{discount}} where id = {{order_id}}`. `order_id` value can be passed from a dashboard filter for a detail view, but `discount` should be handled differently as there's no other source for it except the user input.

Once a user clicks an action button, we'll check if there are any parameters with not mapped values (and without default values). In this case, we'll grab all these params and show a modal with a simple form where people can fill in missing values and finally execute the action