### PR TITLE
Fix archive icon being too small

### DIFF
--- a/frontend/src/metabase/components/EntityItem.jsx
+++ b/frontend/src/metabase/components/EntityItem.jsx
@@ -131,7 +131,7 @@ function EntityItemMenu({
         },
         onArchive && {
           title: t`Archive`,
-          icon: "archive",
+          icon: "view_archive",
           action: onArchive,
           event: `${analyticsContext};Entity Item;Archive Item;${item.model}`,
         },


### PR DESCRIPTION
### Status
DRAFT

### What does this PR accomplish?
- Resolves #23383
- Fixes an issue where the archive icon was too small (reported by @ukritw in [this thread](https://metaboat.slack.com/archives/C01LQQ2UW03/p1655378205355019)).

Before:
![image](https://user-images.githubusercontent.com/31325167/174068838-b44e879c-22a2-440d-8a19-c2776a85ea0f.png)

After:
![image](https://user-images.githubusercontent.com/31325167/174068666-034f9521-98b2-4456-8745-85f61b618a75.png)

@kulyk and @mazameli I've searched for other "archive" icons that I knew were looking correct and noticed that we use `view_archive` icon there (rather than `archive`). What's the story behind that? Do we need to fix SVG or to delete one of those two icons?

### How to test manually?
1. Go to the root collection
2. Pin something (question, for example)
3. In the pinned item, click on the ellipsis icon to open the context menu
4. Make sure that the icon size next to the word "Archive" looks correct