### PR TITLE
Manual backport for #23278

### DIFF
--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -18,6 +18,7 @@
             [metabase.models.secret :as secret]
             [metabase.models.table :refer [Table]]
             [metabase.query-processor :as qp]
+            [metabase.query-processor.store :as qp.store]
             [metabase.sync :as sync]
             [metabase.sync.sync-metadata :as sync-metadata]
             [metabase.test :as mt]
@@ -286,7 +287,7 @@
       (is (= false (driver/database-supports? :postgres :nested-field-columns no-json-unfold-db))))))
 
 (deftest ^:parallel json-query-test
-  (let [boop-identifier (hx/with-type-info (hx/identifier :field "boop" "bleh -> meh") {})]
+  (let [boop-identifier (:form (hx/with-type-info (hx/identifier :field "boop" "bleh -> meh") {}))]
     (testing "Transforming MBQL query with JSON in it to postgres query works"
       (let [boop-field {:nfc_path [:bleh :meh] :database_type "integer"}]
         (is (= ["(boop.bleh#>> ?::text[])::integer " "{meh}"]
@@ -303,6 +304,30 @@
       (let [boolean-boop-field {:database_type "bigint" :nfc_path [:bleh "boop" :foobar 1234]}]
         (is (= ["(boop.bleh#>> ?::text[])::bigint " "{boop,foobar,1234}"]
                (hsql/format (#'postgres/json-query boop-identifier boolean-boop-field))))))))
+
+(deftest json-field-test
+  (mt/test-driver :postgres
+    (testing "Deal with complicated identifier (#22967)"
+      (let [details   (mt/dbdef->connection-details :postgres :db {:database-name "complicated_identifiers"
+                                                                   :json-unfolding true})]
+        (mt/with-temp* [Database [database  {:engine :postgres, :details details}]
+                        Table    [table     {:db_id (u/the-id database)
+                                             :name "complicated_identifiers"}]
+                        Field    [val-field {:table_id      (u/the-id table)
+                                             :nfc_path      [:jsons "values" "qty"]
+                                             :database_type "integer"}]]
+        (qp.store/with-store
+          (qp.store/fetch-and-store-database! (u/the-id database))
+          (qp.store/fetch-and-store-tables! [(u/the-id table)])
+          (qp.store/fetch-and-store-fields! [(u/the-id val-field)])
+          (let [field-clause [:field (u/the-id val-field) {:binning
+                                                           {:strategy :num-bins,
+                                                            :num-bins 100,
+                                                            :min-value 0.75,
+                                                            :max-value 54.0,
+                                                            :bin-width 0.75}}]]
+            (is (= ["((floor((((complicated_identifiers.jsons#>> ?::text[])::integer  - 0.75) / 0.75)) * 0.75) + 0.75)" "{values,qty}"]
+                   (hsql/format (sql.qp/->honeysql :postgres field-clause)))))))))))
 
 (deftest json-alias-test
   (mt/test-driver :postgres


### PR DESCRIPTION
#23278 should fix #22967, which is why the branch is named #22967-backport. This is manual backport of #23278 onto release, though.