### PR TITLE
Improve clj-kondo linting of with-temp*

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -16,8 +16,6 @@
                       (clojure.core.logic/matcha)
                       (clojure.core.logic/run)
                       (clojure.test/is [query= sql= partial=])
-                      (toucan.util.test/with-temp*)
-                      (metabase.test/with-temp*)
                       (taoensso.nippy/extend-freeze)
                       (taoensso.nippy/extend-thaw)
                       (metabase.driver.druid.query-processor-test/druid-query-returning-rows)
@@ -396,6 +394,8 @@
    metabase.test/query                                        hooks.metabase.test.data/$ids
    metabase.test/run-mbql-query                               hooks.metabase.test.data/$ids
    metabase.test/with-temp                                    hooks.toucan.util.test/with-temp
+   metabase.test/with-temp*                                   hooks.toucan.util.test/with-temp*
+   metabase-enterprise.serialization.test-util/with-temp-dpc  hooks.toucan.util.test/with-temp*
    metabase.test/with-temporary-setting-values                hooks.metabase.test.util/with-temporary-setting-values
    metabase.test.data/$ids                                    hooks.metabase.test.data/$ids
    metabase.test.data/dataset                                 hooks.metabase.test.data/dataset

--- a/.clj-kondo/hooks/toucan/util/test.clj
+++ b/.clj-kondo/hooks/toucan/util/test.clj
@@ -1,11 +1,21 @@
 (ns hooks.toucan.util.test
   (:require [clj-kondo.hooks-api :as api]))
 
+(defn- with-temp-inner [body bindings]
+  (let [pairs       (partition 2 bindings)
+        db-refs     (map first pairs)
+        let-stream  (for [[_ binding+opts] pairs
+                          part             (:children binding+opts)]
+                      part)]
+    (api/vector-node [(api/vector-node db-refs)
+                      (api/list-node (list* (api/token-node `let)
+                                            (api/vector-node let-stream)
+                                            body))])))
+
 (defn with-temp [{:keys [node]}]
-  (let [[_ db-ref binding+opts & body] (:children node)
-        [args opts] (:children binding+opts)]
-    {:node (api/vector-node [db-ref
-                             opts
-                             (api/list-node (list* (api/token-node 'fn)
-                                                   (api/vector-node [args])
-                                                   body))])}))
+  (let [[_ db-ref binding+opts & body] (:children node)]
+    {:node (with-temp-inner body [db-ref binding+opts])}))
+
+(defn with-temp* [{:keys [node]}]
+  (let [[_ bindings & body]  (:children node)]
+    {:node (with-temp-inner body (:children bindings))}))


### PR DESCRIPTION
I noticed some clumsy linting in `with-temp*` and looked into it.

Our lint configuration was simply ignoring undeclared vars inside `with-temp*`.
We had a nice config for basic `with-temp`, so I expanded it to support
`with-temp*`.
