### PR TITLE
Validate required fields in writeback forms

### DIFF
--- a/frontend/src/metabase-lib/lib/metadata/Field.ts
+++ b/frontend/src/metabase-lib/lib/metadata/Field.ts
@@ -48,6 +48,7 @@ class FieldInner extends Base {
   name: string;
   description: string | null;
   semantic_type: string | null;
+  database_required: boolean;
   fingerprint?: FieldFingerprint;
   base_type: string | null;
   table?: Table;

--- a/frontend/src/metabase/writeback/containers/WritebackForm.tsx
+++ b/frontend/src/metabase/writeback/containers/WritebackForm.tsx
@@ -8,6 +8,7 @@ import { TYPE } from "metabase/lib/types";
 import Field from "metabase-lib/lib/metadata/Field";
 import Table from "metabase-lib/lib/metadata/Table";
 
+import { isEditableField } from "../utils";
 import CategoryFieldPicker from "./CategoryFieldPicker";
 
 export interface WritebackFormProps {
@@ -56,10 +57,9 @@ function getFieldTypeProps(field: Field) {
 }
 
 function WritebackForm({ table, row, onSubmit, ...props }: WritebackFormProps) {
-  const editableFields = useMemo(
-    () => table.fields.filter(field => field.id && !field.isPK()),
-    [table],
-  );
+  const editableFields = useMemo(() => table.fields.filter(isEditableField), [
+    table,
+  ]);
 
   const form = useMemo(() => {
     return {

--- a/frontend/src/metabase/writeback/containers/WritebackForm.tsx
+++ b/frontend/src/metabase/writeback/containers/WritebackForm.tsx
@@ -66,9 +66,15 @@ function WritebackForm({ table, row, onSubmit, ...props }: WritebackFormProps) {
       fields: editableFields.map(field => {
         const fieldIndex = table.fields.findIndex(f => f.id === field.id);
         const initialValue = row ? row[fieldIndex] : undefined;
+
+        let title = field.displayName();
+        if (field.database_required) {
+          title += " (" + t`required` + ")";
+        }
+
         return {
           name: field.name,
-          title: field.displayName(),
+          title,
           description: field.description,
           initial: initialValue,
           ...getFieldTypeProps(field),

--- a/frontend/src/metabase/writeback/containers/WritebackForm.tsx
+++ b/frontend/src/metabase/writeback/containers/WritebackForm.tsx
@@ -3,6 +3,7 @@ import { t } from "ttag";
 
 import Form from "metabase/containers/Form";
 
+import validate from "metabase/lib/validate";
 import { TYPE } from "metabase/lib/types";
 
 import Field from "metabase-lib/lib/metadata/Field";
@@ -56,6 +57,18 @@ function getFieldTypeProps(field: Field) {
   return { type: "input" };
 }
 
+function getFieldValidationProp(field: Field) {
+  let validator = validate as any;
+
+  if (field.database_required) {
+    validator = validator.required();
+  }
+
+  return {
+    validate: validator,
+  };
+}
+
 function WritebackForm({ table, row, onSubmit, ...props }: WritebackFormProps) {
   const editableFields = useMemo(() => table.fields.filter(isEditableField), [
     table,
@@ -78,6 +91,7 @@ function WritebackForm({ table, row, onSubmit, ...props }: WritebackFormProps) {
           description: field.description,
           initial: initialValue,
           ...getFieldTypeProps(field),
+          ...getFieldValidationProp(field),
         };
       }),
     };

--- a/frontend/src/metabase/writeback/utils.ts
+++ b/frontend/src/metabase/writeback/utils.ts
@@ -1,6 +1,7 @@
 import { getTemplateTagParameterTarget } from "metabase/parameters/utils/cards";
 
 import Database from "metabase-lib/lib/metadata/Database";
+import Field from "metabase-lib/lib/metadata/Field";
 
 import { Database as IDatabase } from "metabase-types/types/Database";
 import { DashCard } from "metabase-types/types/Dashboard";
@@ -16,6 +17,23 @@ export const isDatabaseWritebackEnabled = (database?: IDatabase | null) =>
 
 export const isWritebackSupported = (database?: Database | null) =>
   !!database?.hasFeature(DB_WRITEBACK_FEATURE);
+
+export const isEditableField = (field: Field) => {
+  const isRealField = typeof field.id === "number";
+  if (!isRealField) {
+    // Filters out custom, aggregated columns, etc.
+    return false;
+  }
+
+  if (field.isPK()) {
+    // Most of the time PKs are auto-generated,
+    // but there are rare cases when they're not
+    // In this case they're marked as `database_required`
+    return field.database_required;
+  }
+
+  return true;
+};
 
 export const isActionButtonDashCard = (dashCard: DashCard) =>
   dashCard.visualization_settings?.virtual_card?.display === "action-button";


### PR DESCRIPTION
Based on BE work from #23213

Makes FE take the new `database_required` field metadata flag in mind when building insert/update forms. Required fields are going to have a "(required)" label next to their display names and the form submission will be disabled until all the required fields are filled in.