### PR TITLE
Fix time filter

### DIFF
--- a/frontend/src/metabase/query_builder/components/filters/FilterPopover.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/FilterPopover.tsx
@@ -244,21 +244,12 @@ export default class FilterPopover extends Component<Props, State> {
       const onBack = () => {
         this.setState({ choosingField: true });
       };
+
+      const shouldShowDatePicker = field?.isDate() && !field?.isTime();
+
       return (
         <div className={className} style={{ minWidth: MIN_WIDTH, ...style }}>
-          {field?.isTime() ? (
-            <TimePicker
-              className={className}
-              isSidebar={isSidebar}
-              filter={filter}
-              primaryColor={primaryColor}
-              minWidth={isSidebar ? null : MIN_WIDTH}
-              maxWidth={isSidebar ? null : MAX_WIDTH}
-              onBack={onBack}
-              onCommit={this.handleCommit}
-              onFilterChange={this.handleFilterChange}
-            />
-          ) : field?.isDate() ? (
+          {shouldShowDatePicker ? (
             <DatePicker
               className={className}
               isSidebar={isSidebar}
@@ -287,23 +278,39 @@ export default class FilterPopover extends Component<Props, State> {
             </DatePicker>
           ) : (
             <div className={isSidebar ? "mx2 pt1" : ""}>
-              <FilterPopoverHeader
-                isSidebar={isSidebar}
-                filter={filter}
-                onFilterChange={this.handleFilterChange}
-                onBack={onBack}
-                showFieldPicker={showFieldPicker}
-              />
-              <FilterPopoverPicker
-                className={isSidebar ? "p1" : "px1 pt1 pb1"}
-                isSidebar={isSidebar}
-                filter={filter}
-                onFilterChange={this.handleFilterChange}
-                onCommit={this.handleCommit}
-                minWidth={isSidebar ? null : MIN_WIDTH}
-                maxWidth={isSidebar ? null : MAX_WIDTH}
-                primaryColor={primaryColor}
-              />
+              {field?.isTime() ? (
+                <TimePicker
+                  className={className}
+                  isSidebar={isSidebar}
+                  filter={filter}
+                  primaryColor={primaryColor}
+                  minWidth={isSidebar ? null : MIN_WIDTH}
+                  maxWidth={isSidebar ? null : MAX_WIDTH}
+                  onBack={onBack}
+                  onCommit={this.handleCommit}
+                  onFilterChange={this.handleFilterChange}
+                />
+              ) : (
+                <>
+                  <FilterPopoverHeader
+                    isSidebar={isSidebar}
+                    filter={filter}
+                    onFilterChange={this.handleFilterChange}
+                    onBack={onBack}
+                    showFieldPicker={showFieldPicker}
+                  />
+                  <FilterPopoverPicker
+                    className={isSidebar ? "p1" : "px1 pt1 pb1"}
+                    isSidebar={isSidebar}
+                    filter={filter}
+                    onFilterChange={this.handleFilterChange}
+                    onCommit={this.handleCommit}
+                    minWidth={isSidebar ? null : MIN_WIDTH}
+                    maxWidth={isSidebar ? null : MAX_WIDTH}
+                    primaryColor={primaryColor}
+                  />
+                </>
+              )}
               <FilterPopoverFooter
                 className={isSidebar ? "p1" : "px1 pb1"}
                 isSidebar={isSidebar}

--- a/frontend/src/metabase/query_builder/components/filters/FilterPopoverFooter.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/FilterPopoverFooter.tsx
@@ -29,9 +29,6 @@ export default function FilterPopoverFooter({
   className,
   primaryColor,
 }: Props) {
-  const dimension = filter.dimension();
-  const field = dimension?.field();
-
   const containerClassName = cx(className, "flex align-center", {
     PopoverFooter: !isSidebar,
   });

--- a/frontend/src/metabase/query_builder/components/filters/pickers/LegacyDatePicker/HoursMinutesInput.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/LegacyDatePicker/HoursMinutesInput.jsx
@@ -18,6 +18,7 @@ const HoursMinutesInput = ({
 }) => (
   <div className="flex align-center">
     <NumericInput
+      data-testid="hours-input"
       className="input"
       style={{ height: 36 }}
       size={2}
@@ -37,6 +38,7 @@ const HoursMinutesInput = ({
     />
     <span className="px1">:</span>
     <NumericInput
+      data-testid="minutes-input"
       className="input"
       style={{ height: 36 }}
       size={2}

--- a/frontend/src/metabase/query_builder/components/filters/pickers/TimePicker/TimePicker.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/TimePicker/TimePicker.jsx
@@ -2,12 +2,16 @@
 import React from "react";
 import { t } from "ttag";
 
+import { parseTime } from "metabase/lib/time";
 import DatePicker, {
   getDateTimeFieldTarget,
-} from "./LegacyDatePicker/DatePicker";
-import HoursMinutesInput from "./LegacyDatePicker/HoursMinutesInput";
-
-import { parseTime } from "metabase/lib/time";
+} from "../LegacyDatePicker/DatePicker";
+import HoursMinutesInput from "../LegacyDatePicker/HoursMinutesInput";
+import {
+  TimePickerRoot,
+  BetweenConnector,
+  MultiTimePickerRoot,
+} from "./TimePicker.styled";
 
 const TimeInput = ({ value, onChange }) => {
   const time = parseTime(value);
@@ -24,35 +28,30 @@ const TimeInput = ({ value, onChange }) => {
 };
 
 const SingleTimePicker = ({ filter, onFilterChange }) => (
-  <div className="mx2 mb2">
-    <TimeInput
-      value={getTime(filter[2])}
-      onChange={time => onFilterChange([filter[0], filter[1], time])}
-    />
-  </div>
+  <TimeInput
+    value={getTime(filter[2])}
+    onChange={time => onFilterChange([filter[0], filter[1], time])}
+  />
 );
 
 SingleTimePicker.horizontalLayout = true;
 
-const MultiTimePicker = ({ filter, onFilterChange }) => (
-  <div
-    className="flex align-center justify-between mx2 mb1"
-    style={{ minWidth: 480 }}
-  >
+const MultiTimePicker = ({ filter, onFilterChange, isSidebar }) => (
+  <MultiTimePickerRoot direction={isSidebar ? "column" : "row"}>
     <TimeInput
       value={getTime(filter[2])}
       onChange={time =>
         onFilterChange([filter[0], filter[1], ...sortTimes(time, filter[3])])
       }
     />
-    <span className="h3">{t`and`}</span>
+    <BetweenConnector>{t`and`}</BetweenConnector>
     <TimeInput
       value={getTime(filter[3])}
       onChange={time =>
         onFilterChange([filter[0], filter[1], ...sortTimes(filter[2], time)])
       }
     />
-  </div>
+  </MultiTimePickerRoot>
 );
 
 const sortTimes = (a, b) => {
@@ -108,7 +107,9 @@ export const TIME_OPERATORS = [
 ];
 
 const TimePicker = props => (
-  <DatePicker {...props} operators={TIME_OPERATORS} />
+  <TimePickerRoot>
+    <DatePicker {...props} operators={TIME_OPERATORS} />
+  </TimePickerRoot>
 );
 
 export default TimePicker;

--- a/frontend/src/metabase/query_builder/components/filters/pickers/TimePicker/TimePicker.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/TimePicker/TimePicker.styled.tsx
@@ -1,0 +1,26 @@
+import styled from "@emotion/styled";
+
+export const TimePickerRoot = styled.div`
+  padding: 1rem;
+`;
+
+export const BetweenConnector = styled.span`
+  margin-right: 1.5rem;
+  margin-left: 1rem;
+  font-weight: 700;
+`;
+
+interface MultiTimePickerRootProps {
+  direction: string;
+}
+
+export const MultiTimePickerRoot = styled.div<MultiTimePickerRootProps>`
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  flex-wrap: wrap;
+
+  & > * {
+    margin-bottom: 1rem;
+  }
+`;

--- a/frontend/src/metabase/query_builder/components/filters/pickers/TimePicker/index.ts
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/TimePicker/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./TimePicker";

--- a/frontend/test/metabase/scenarios/filters/reproductions/22730-table-column-time-filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/reproductions/22730-table-column-time-filter.cy.spec.js
@@ -1,0 +1,40 @@
+import { restore, popover } from "__support__/e2e/cypress";
+
+describe("issue 22730", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    cy.createNativeQuestion(
+      {
+        name: "22730",
+        native: {
+          query: `select '14:02:13'::time "time", 'before-row' "name" union all select '14:06:13'::time "time", 'after-row' `,
+        },
+      },
+      { visitQuestion: true },
+    );
+    cy.intercept("POST", "/api/dataset").as("dataset");
+  });
+
+  it("allows filtering by time column (metabase#22730)", () => {
+    cy.findByText("Explore results").click();
+    cy.findByText("time").click();
+
+    popover().within(() => {
+      cy.findByText("Filter by this column").click();
+
+      cy.findByTestId("hours-input")
+        .clear()
+        .type("14");
+      cy.findByTestId("minutes-input")
+        .clear()
+        .type("03");
+
+      cy.button("Add filter").click();
+    });
+
+    cy.findByText("before-row");
+    cy.findByText("after-row").should("not.exist");
+  });
+});


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/22730

## Changes

Fixes time filter when used not from the query builder sidebar. The layout was broken, the filter apply button was missing.

<img width="378" alt="Screenshot 2022-06-17 at 01 15 21" src="https://user-images.githubusercontent.com/14301985/174165318-482c1bae-81ce-4c9b-ae53-2412c471efb3.png">

## How to verify

- New -> Native query
- Save question with the following query `select '14:02:13'::time "time", 1`
- Click "Explore results"
- Click on the `time` table column and try adding a filter — ensure it works
