### PR TITLE
docs - Add troubleshooting for node version

### DIFF
--- a/docs/developers-guide/build.md
+++ b/docs/developers-guide/build.md
@@ -143,6 +143,8 @@ The “official” branch of Metabase is called `master`, and other feature deve
    ```
    yarn build-hot
    ```
+   
+If you're having trouble with this step, make sure you are using the LTS version of [Node.js (http://nodejs.org/)](http://nodejs.org/).
 
 {:start="11"}
 11. In your web browser of choice, navigate to [localhost:3000](http://localhost:3000), where you should see Metabase!


### PR DESCRIPTION
Ran into an error on `yarn build-hot` using the wrong node version. Since this is the first impression for a dev, we should make sure the user doesn't get stuck at this step.

Context in slack: https://metaboat.slack.com/archives/C505ZNNH4/p1655373726561399