### PR TITLE
Fail if Node.js version is not 14 or 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/metabase/metabase",
   "license": "private",
   "engines": {
-    "node": ">=14.2 <=16.99",
+    "node": ">=14.2 <17",
     "yarn": ">=1.12.3"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/metabase/metabase",
   "license": "private",
   "engines": {
-    "node": ">=8.11.4",
+    "node": ">=14.2 <=16.99",
     "yarn": ">=1.12.3"
   },
   "dependencies": {


### PR DESCRIPTION
Our frontend can't be worked with Node.js v18 yet. If someone insists using it, the failure happens when starting the front-end, e.g.

```bash
$ yarn dev
....
[frontend] ERROR in ./app-main.js
[frontend] Module build failed (from ../../../node_modules/babel-loader/lib/index.js):
[frontend] Error: error:0308010C:digital envelope routines::unsupported
[frontend]     at new Hash (node:internal/crypto/hash:67:19)
[frontend]     at Object.createHash (node:crypto:133:10)
```

After this PR, the error will be more evident at the earlier stage:

```bash
$ yarn install  # or yarn dev or build-hot or any other scripts
yarn install v1.22.17
[1/5] Validating package.json...
error metabase@0.0.0: The engine "node" is incompatible with this module.
Expected version ">=14.2 <17". Got "18.4.0"
error Found incompatible module.
```