### PR TITLE
Don't need to cast DATE columns with date()

### DIFF
--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -273,7 +273,7 @@
 (defmethod sql.qp/date [:mysql :minute-of-hour]  [_ _ expr] (hx/minute expr))
 (defmethod sql.qp/date [:mysql :hour]            [_ _ expr] (trunc-with-format "%Y-%m-%d %H" expr))
 (defmethod sql.qp/date [:mysql :hour-of-day]     [_ _ expr] (hx/hour expr))
-(defmethod sql.qp/date [:mysql :day]             [_ _ expr] (->date expr))
+(defmethod sql.qp/date [:mysql :day]             [_ _ expr] expr)
 (defmethod sql.qp/date [:mysql :day-of-month]    [_ _ expr] (hsql/call :dayofmonth expr))
 (defmethod sql.qp/date [:mysql :day-of-year]     [_ _ expr] (hsql/call :dayofyear expr))
 (defmethod sql.qp/date [:mysql :month-of-year]   [_ _ expr] (hx/month expr))


### PR DESCRIPTION
Related to https://github.com/metabase/metabase/issues/11502

I found that the date() will still be wrapped in the DATE column when using notebook, and the query will be slower. 

This PR:
1. When using MySQL, DATE Column(by day) will use the default expression.

Test:
1. Query builder should still work.

Before: 

<img width="750" alt="image" src="https://user-images.githubusercontent.com/17266004/174266376-5ecba8d6-095e-475a-ad74-c6684e18980a.png">

After:

<img width="750" alt="image" src="https://user-images.githubusercontent.com/17266004/174266582-b2bc333c-577a-43ea-8f5b-b1df92612382.png">