### PR TITLE
[E2E] Remove `native` group from checks on CCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1299,7 +1299,6 @@ workflows:
                 [
                   "admin",
                   "filters",
-                  "native",
                   "native-filters",
                   "onboarding",
                   "smoketest",


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- In the same manner we did for #23308, this PR removes `native` E2E group from CircleCI because we've been running it successfully using GitHub actions