### PR TITLE
Disable parameter popover

### DIFF
--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
@@ -157,6 +157,7 @@ class ParameterValueWidget extends Component {
         >
           <PopoverWithTrigger
             ref={this.valuePopover}
+            disabled={isDashParamWithoutMapping}
             triggerElement={
               <div
                 ref={this.trigger}


### PR DESCRIPTION
1. Create a date parameter and save it without mapping it to any fields
2. Click on the parameter widget and a little nub appears
3. Disabling the popover fixes it

Before
<img width="294" alt="Screen Shot 2022-06-17 at 10 54 21 AM" src="https://user-images.githubusercontent.com/13057258/174352316-68ae9462-ecb2-439a-8c18-8592afea0479.png">

After
<img width="272" alt="Screen Shot 2022-06-17 at 10 54 35 AM" src="https://user-images.githubusercontent.com/13057258/174352331-69f16e8e-1372-4d1b-b548-bf834971ad5e.png">

