### PR TITLE
Fix flakes in repro for 22227

### DIFF
--- a/frontend/test/metabase/scenarios/filters/relative-datetime.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/relative-datetime.cy.spec.js
@@ -220,7 +220,7 @@ describe("scenarios > question > relative-datetime", () => {
       setRelativeDatetimeUnit("months");
       setRelativeDatetimeValue(1);
       popover().within(() => {
-        cy.findByText("Add filter").click();
+        cy.button("Add filter").click();
       });
       cy.wait("@dataset");
 
@@ -229,7 +229,7 @@ describe("scenarios > question > relative-datetime", () => {
       ).click();
       setRelativeDatetimeValue(3);
       popover().within(() => {
-        cy.findByText("Update filter").click();
+        cy.button("Update filter").click();
       });
       cy.wait("@dataset");
 
@@ -238,9 +238,10 @@ describe("scenarios > question > relative-datetime", () => {
       ).click();
       setStartingFromValue(30);
       popover().within(() => {
-        cy.findByText("Update filter").click();
+        cy.button("Update filter").click();
       });
       cy.wait("@dataset");
+
       cy.findByTextEnsureVisible(
         "Created At Previous 3 Months, starting 30 months ago",
       );

--- a/frontend/test/metabase/scenarios/filters/relative-datetime.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/relative-datetime.cy.spec.js
@@ -215,7 +215,6 @@ describe("scenarios > question > relative-datetime", () => {
     it("should allow changing values with starting from (metabase#22227)", () => {
       openOrdersTable();
 
-      // cy.intercept("POST", "/api/dataset").as("dataset");
       openCreatedAt("Past");
       addStartingFrom();
       setRelativeDatetimeUnit("months");
@@ -225,7 +224,6 @@ describe("scenarios > question > relative-datetime", () => {
       });
       cy.wait("@dataset");
 
-      cy.intercept("POST", "/api/dataset").as("dataset");
       cy.findByTextEnsureVisible(
         "Created At Previous Month, starting 7 months ago",
       ).click();

--- a/frontend/test/metabase/scenarios/filters/relative-datetime.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/relative-datetime.cy.spec.js
@@ -215,7 +215,7 @@ describe("scenarios > question > relative-datetime", () => {
     it("should allow changing values with starting from (metabase#22227)", () => {
       openOrdersTable();
 
-      cy.intercept("POST", "/api/dataset").as("dataset");
+      // cy.intercept("POST", "/api/dataset").as("dataset");
       openCreatedAt("Past");
       addStartingFrom();
       setRelativeDatetimeUnit("months");
@@ -318,9 +318,9 @@ const setRelativeDatetimeUnit = unit => {
 };
 
 const setRelativeDatetimeValue = value => {
-  cy.findAllByTestId("relative-datetime-value")
+  cy.findByTestId("relative-datetime-value")
+    .click()
     .clear()
-    .clear() // Included twice because it's buggy sometimes
     .type(value)
     .blur();
 };
@@ -333,9 +333,9 @@ const setStartingFromUnit = unit => {
 };
 
 const setStartingFromValue = value => {
-  cy.findAllByTestId("starting-from-value")
+  cy.findByTestId("starting-from-value")
+    .click()
     .clear()
-    .clear() // Included twice because it's buggy sometimes
     .type(value)
     .blur();
 };

--- a/frontend/test/metabase/scenarios/filters/relative-datetime.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/relative-datetime.cy.spec.js
@@ -79,8 +79,6 @@ describe("scenarios > question > relative-datetime", () => {
 
       cy.findByTextEnsureVisible("Created At").click();
 
-      cy.intercept("POST", "/api/dataset").as("dataset");
-
       popover().within(() => {
         cy.findByText("Filter by this column").click();
         cy.icon("chevronleft").should("not.exist");
@@ -150,7 +148,6 @@ describe("scenarios > question > relative-datetime", () => {
     it("current filters should work (metabase#21977)", () => {
       openOrdersTable();
 
-      cy.intercept("POST", "/api/dataset").as("dataset");
       cy.findByTextEnsureVisible("Created At").click();
       popover().within(() => {
         cy.findByText("Filter by this column").click();
@@ -249,8 +246,6 @@ describe("scenarios > question > relative-datetime", () => {
 
     it("starting from option should set correct sign (metabase#22228)", () => {
       openOrdersTable();
-
-      cy.intercept("POST", "/api/dataset").as("dataset");
 
       openCreatedAt("Next");
       addStartingFrom();


### PR DESCRIPTION
According to the statistics, this repro was failing close to 20% of the time in the last 14 days.

I could reproduce the failure locally and it failed in the similar range: 3/10

Before
![image](https://user-images.githubusercontent.com/31325167/174374498-c27488ce-824f-446c-bb02-1eee166ff61d.png)

After this fix, I ran it first ten times and then twenty times. No failures in both instances.
![image](https://user-images.githubusercontent.com/31325167/174378369-52b8ca6b-32c2-423a-abdf-5e5cdcdf2af0.png)

![image](https://user-images.githubusercontent.com/31325167/174377157-efbd4c62-95c3-405c-bda3-930b705f631b.png)

--- 
EDIT:
This should also fix the flake and the [failure](https://app.currents.dev/instance/885343af-a9f8-447c-96b3-b981010219e7/test/r20) in "should not clobber filter when value is set to 1" test:

As you can see from the screenshot of a failed attempt, the root cause was the same. Cypress failed to clear the field and to change it from `30` to `1`, so the list of the values in the popover was in plural. The test failed trying to find a singular version of the word `year`.
![image](https://user-images.githubusercontent.com/31325167/174388248-80f66900-e30a-4428-a31b-ccbdead79026.png)
