### PR TITLE
Do not run backend tests on unrelated changes

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -6,6 +6,10 @@ on:
       - 'master'
       - 'release-**'
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**.md"
+      - "**/frontend/test/**"
 
 jobs:
 

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -9,7 +9,8 @@ on:
     paths-ignore:
       - "docs/**"
       - "**.md"
-      - "**/frontend/test/**"
+      - "frontend/test/**"
+      - "enterprise/frontend/test/**"
 
 jobs:
 


### PR DESCRIPTION
I've noticed some of the completely unrelated PRs being blocked by failing backend tests. It doesn't make sense to run the full backend suite for docs changes or for frontend test changes, especially when so many backend tests are flaky.