### PR TITLE
[E2E] Remove `native-filters` group from checks on CCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1299,7 +1299,6 @@ workflows:
                 [
                   "admin",
                   "filters",
-                  "native-filters",
                   "onboarding",
                   "smoketest",
                   "visualizations",


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- In the same manner we did for #23405, this PR removes `native-filters` E2E group from CircleCI because we've been running it successfully using GitHub actions