### PR TITLE
Revert "Do not run backend tests on unrelated changes (#23425)"

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -6,11 +6,6 @@ on:
       - 'master'
       - 'release-**'
   pull_request:
-    paths-ignore:
-      - "docs/**"
-      - "**.md"
-      - "frontend/test/**"
-      - "enterprise/frontend/test/**"
 
 jobs:
 


### PR DESCRIPTION
This PR reverts the changes because `backend.yml` workflow is marked as `required`. If we skip running these tests on a PR, it will be blocked, like it happened here for example: #23430.

To make things worse, I spoke to @ariya about this very problem not so long ago but am obviously either tired or distracted because I completely forgot about it when I created the original PR.


Edit:
There is [a recipe](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks) for how to handle required but skipped checks, but we agreed that [it's not worth going down that route](https://www.notion.so/metabase/Testing-Group-Meetings-e0162f54b97342d6bd5d67ef6af68cd5#2c1fe4ec50314d219052aed56c692fb5).