### PR TITLE
[E2E] Experiment running `onboarding` test group as PR check

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -70,6 +70,7 @@ jobs:
           - "models"
           - "native"
           - "native-filters"
+          - "onboarding"
           - "organization"
           - "permissions"
           - "question"


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Following the steps of https://github.com/metabase/metabase/pull/21492 and the tasks that @ariya started, we're now adding `onboarding` test group to PR checks using GitHub actions.
- There are a few flakes from this group but the percentage of flakiness is below 3%. We can deal with it as we go.

### The next steps
After we make sure this group runs without major hiccups on GitHub (for at least a week?), remove it from CircleCI.