### PR TITLE
[E2E] Fix `filters` flakes

### DIFF
--- a/frontend/test/metabase/scenarios/filters/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/filter.cy.spec.js
@@ -932,8 +932,9 @@ describe("scenarios > question > filter", () => {
       beforeEach(setupBooleanQuery);
 
       it("from the column popover (metabase#16386-1)", () => {
-        cy.get(".cellData")
+        cy.findAllByTestId("header-cell")
           .contains("boolean")
+          .should("be.visible")
           .click();
 
         popover()

--- a/frontend/test/metabase/scenarios/filters/reproductions/22730-table-column-time-filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/reproductions/22730-table-column-time-filter.cy.spec.js
@@ -14,22 +14,31 @@ describe("issue 22730", () => {
       },
       { visitQuestion: true },
     );
+
     cy.intercept("POST", "/api/dataset").as("dataset");
   });
 
   it("allows filtering by time column (metabase#22730)", () => {
     cy.findByText("Explore results").click();
-    cy.findByText("time").click();
+    cy.wait("@dataset");
+
+    cy.findAllByTestId("header-cell")
+      .contains("time")
+      .should("be.visible")
+      .click();
 
     popover().within(() => {
       cy.findByText("Filter by this column").click();
 
       cy.findByTestId("hours-input")
         .clear()
-        .type("14");
+        .type("14")
+        .blur();
+
       cy.findByTestId("minutes-input")
         .clear()
-        .type("03");
+        .type("03")
+        .blur();
 
       cy.button("Add filter").click();
     });


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Fixes flakes in `filters` E2E group

1. flake in repro for 22730 (top most flake in the last 14 days)
![image](https://user-images.githubusercontent.com/31325167/174655253-67110b53-2932-4bdc-868a-f937a0d9dae0.png)

2. flake in repro for 16386 (had flakiness rate of around 3% but seemed like an easy fix)
![image](https://user-images.githubusercontent.com/31325167/174655415-c4f7623c-0f6d-4039-ac88-cf580200211c.png)

### Next step
After this PR (and after https://github.com/metabase/metabase/pull/23416), it should be safe to start running `filters` test group in GHA on PRs.