### PR TITLE
[E2E] Experiment running `filters` test group as PR check

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -66,6 +66,7 @@ jobs:
           - "dashboard-filters"
           - "downloads"
           - "embedding"
+          - "filters"
           - "joins"
           - "models"
           - "native"


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Following the steps of https://github.com/metabase/metabase/pull/21492 and the tasks that @ariya started, we're now adding `filters` test group to PR checks using GitHub actions.
- The related flakes have been fixed in https://github.com/metabase/metabase/pull/23416 and https://github.com/metabase/metabase/pull/23440

### The next steps
After we make sure this group runs without major hiccups on GitHub (for at least a week?), remove it from CircleCI.