### PR TITLE
Add description icons to collection items

### DIFF
--- a/frontend/src/metabase/collections/components/BaseItemsTable.styled.jsx
+++ b/frontend/src/metabase/collections/components/BaseItemsTable.styled.jsx
@@ -68,6 +68,10 @@ export const SortingIcon = styled(Icon)`
   margin-left: 4px;
 `;
 
+export const DescriptionIcon = styled(Icon)`
+  color: ${color("text-medium")};
+`;
+
 SortingIcon.defaultProps = {
   size: 8,
 };

--- a/frontend/src/metabase/collections/components/BaseTableItem.jsx
+++ b/frontend/src/metabase/collections/components/BaseTableItem.jsx
@@ -19,6 +19,7 @@ import {
   EntityIconCheckBox,
   ItemLink,
   TableItemSecondaryField,
+  DescriptionIcon,
 } from "./BaseItemsTable.styled";
 
 BaseTableItem.propTypes = {
@@ -116,8 +117,16 @@ export function BaseTableItem({
           <ItemLink {...linkProps} to={item.getUrl()}>
             <EntityItem.Name name={item.name} variant="list" />
             <PLUGIN_MODERATION.ModerationStatusIcon
+              size={16}
               status={item.moderated_status}
             />
+            {item.description && (
+              <DescriptionIcon
+                name="info"
+                size={16}
+                tooltip={item.description}
+              />
+            )}
           </ItemLink>
         </ItemCell>
         <ItemCell data-testid={`${testId}-last-edited-by`}>


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/22826

How to test:
- Run Metabase EE
- Open the collection list with some unpinned questions
- Verify and add descriptions to some questions
- Make sure they have verified and description icons
- It should be possible to hover the description icon and see the text in a tooltip

<img width="901" alt="Screenshot 2022-06-20 at 21 51 02" src="https://user-images.githubusercontent.com/8542534/174664053-95d0d398-5185-450e-8cea-c4d6edf3dce5.png">
<img width="700" alt="Screenshot 2022-06-20 at 22 01 04" src="https://user-images.githubusercontent.com/8542534/174664063-5c1d270f-ad7e-491c-b588-795b9d8778c5.png">
