### PR TITLE
Admin > People Uses common_name and 'Name' is now 'Member' in table

### DIFF
--- a/frontend/src/metabase/admin/people/components/GroupMembersTable/GroupMembersTable.tsx
+++ b/frontend/src/metabase/admin/people/components/GroupMembersTable/GroupMembersTable.tsx
@@ -75,7 +75,7 @@ function GroupMembersTable({
   };
 
   const columnTitles = [
-    t`Name`,
+    t`Member`,
     canEditMembership(group) ? t`Type` : null,
     t`Email`,
   ].filter(Boolean);
@@ -198,7 +198,7 @@ const UserRow = ({
 };
 
 function getName(user: IUser): string {
-  const name = [user.first_name, user.last_name].join(" ").trim();
+  const name = user.common_name;
 
   if (!name) {
     return "-";

--- a/frontend/src/metabase/admin/people/components/PeopleList.jsx
+++ b/frontend/src/metabase/admin/people/components/PeopleList.jsx
@@ -180,7 +180,7 @@ const PeopleList = ({
       <table className="ContentTable border-bottom">
         <thead>
           <tr>
-            <th>{t`Name`}</th>
+            <th>{t`Member`}</th>
             <th />
             <th>{t`Email`}</th>
             {showDeactivated ? (

--- a/frontend/src/metabase/admin/people/components/PeopleListRow.jsx
+++ b/frontend/src/metabase/admin/people/components/PeopleListRow.jsx
@@ -133,7 +133,7 @@ const PeopleListRow = ({
  * @returns {string}
  */
 function getName(user) {
-  const name = [user.first_name, user.last_name].join(" ").trim();
+  const name = user.common_name;
 
   if (!name) {
     return "-";

--- a/frontend/test/metabase/scenarios/admin/people/people.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/people/people.cy.spec.js
@@ -102,7 +102,9 @@ describe("scenarios > admin > people", () => {
       cy.findByText("Show").click();
       cy.findByText("Done").click();
 
-      cy.findByText(email);
+      // user created with 'null' first/last name so common_name is used
+      // and the fallback is user's email, so the email shows up in 'Member' and 'email' columns
+      cy.findAllByText(email).should("have.length", 2);
     });
 
     it("should disallow admin to create new users with case mutation of existing user", () => {


### PR DESCRIPTION
This is a small change to match changes made in the audit pages. 

We've adjusted core_user table to allow `null` first/last names, so it's possible for the Name category to be `-` proior to this change. 

Instead, we can use the user's `common_name` attribute to get the same result with a fallback to the user's email address (which is still required for every user, and is a unique attribute per user).