### PR TITLE
Fix incorrect choropleth map panning

### DIFF
--- a/frontend/src/metabase/visualizations/components/LeafletChoropleth.jsx
+++ b/frontend/src/metabase/visualizations/components/LeafletChoropleth.jsx
@@ -100,7 +100,6 @@ const LeafletChoropleth = ({
       // ]).addTo(map);
 
       map.fitBounds(minimalBounds);
-      map.panTo([0, 0], { animate: false });
 
       return () => {
         map.remove();


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/23450

On initial rendering of a CloroplethMap component, the map pans to an origin around [0, 0]. This causes the map to disappear off the preview window in some instances, as in the issue linked above.

I've removed the line that pans the map to the origin, which fixes the issue.