### PR TITLE
Remove background color for dropzones

### DIFF
--- a/frontend/src/metabase/containers/dnd/DropArea.jsx
+++ b/frontend/src/metabase/containers/dnd/DropArea.jsx
@@ -15,7 +15,6 @@ const DropTargetBackgroundAndBorder = ({
   <div
     className={cx("absolute rounded", {
       "pointer-events-none": !highlighted,
-      "bg-medium": highlighted,
     })}
     style={{
       top: -marginTop,


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/23222

Removes background color from drop zones

<img width="1294" alt="Screenshot 2022-06-21 at 15 59 45" src="https://user-images.githubusercontent.com/8542534/174805218-3f597ccb-e47f-4fda-a9bb-2186ca69e881.png">
