### PR TITLE
Fix a race condition in loading questions for pinned items

### DIFF
--- a/frontend/src/metabase/collections/components/PinnedQuestionCard/PinnedQuestionLoader.tsx
+++ b/frontend/src/metabase/collections/components/PinnedQuestionCard/PinnedQuestionLoader.tsx
@@ -45,7 +45,7 @@ const PinnedQuestionLoader = ({
   return (
     <Questions.Loader id={id} loadingAndErrorWrapper={false}>
       {({ loading, question: card }: QuestionLoaderProps) => {
-        if (loading) {
+        if (loading || !card.dataset_query) {
           return children({ loading: true });
         }
 


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/23222

How to test:
- Open a collection with a scatter chart and a pivot table
- Pin these questions
- Hard refresh multiple times
- Make sure that each time the visualization is displayed correctly

Before:
<img width="1728" alt="Screenshot 2022-06-21 at 18 16 49" src="https://user-images.githubusercontent.com/8542534/174835950-e2373074-3ed9-4c9f-90b6-738f23d49683.png">

After:
<img width="1728" alt="Screenshot 2022-06-21 at 18 14 31" src="https://user-images.githubusercontent.com/8542534/174835506-48f3302a-4802-4791-b834-390be8c734b1.png">
