### PR TITLE
Small fixes for custom query actions FE

### DIFF
--- a/frontend/src/metabase/dashboard/actions.js
+++ b/frontend/src/metabase/dashboard/actions.js
@@ -409,29 +409,17 @@ export const saveDashboardAndCards = createThunkAction(
         dashboard.ordered_cards
           .filter(dc => !dc.isRemoved)
           .map(async dc => {
-            const existingEmitterIDs = Array.isArray(dashboard.emitters)
-              ? dashboard.emitters.map(emitter => emitter.id)
-              : [];
-
             if (dc.isAdded) {
               if (isActionButtonDashCard(dc) && !!getActionButtonActionId(dc)) {
                 const actionId = getActionButtonActionId(dc);
                 const action = Actions.selectors.getObject(getState(), {
                   entityId: actionId,
                 });
-                await EmittersApi.create({
+                const emitter = await EmittersApi.create({
                   dashboard_id: dashboard.id,
                   action_id: actionId,
                   parameter_mappings: getActionEmitterParameterMappings(action),
                 });
-                const newDash = await DashboardApi.get({
-                  dashId: dashboard.id,
-                });
-                const emitter = newDash.emitters.find(
-                  emitter =>
-                    !existingEmitterIDs.includes(emitter.id) &&
-                    emitter.action.card_id === action.card.id,
-                );
                 dc.visualization_settings.click_behavior.emitter_id =
                   emitter.id;
               }

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx
@@ -610,6 +610,7 @@ function ActionOptions({ dashcard, clickBehavior, updateSettings }) {
                     updateSettings({
                       type: clickBehavior.type,
                       action: action.id,
+                      emitter_id: clickBehavior.emitter_id,
                     })
                   }
                 />

--- a/frontend/src/metabase/modes/components/drill/DashboardClickDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/DashboardClickDrill.jsx
@@ -182,7 +182,7 @@ export default ({ question, clicked }) => {
 };
 
 function getParametersForNativeAction(
-  parameterMapping,
+  parameterMapping = {},
   { data, extraData, clickBehavior },
 ) {
   const action = extraData.actions[clickBehavior.action];


### PR DESCRIPTION
1. Removes a hack figuring out a newly created emitter ID with a BE change making it return a new emitter object in the `POST /api/emitter` response
2. Fixes an error when clicking on an action button without mapped parameters
3. Extra safety net to ensure the FE won't lose emitter ID on an action button