### PR TITLE
Stop caching /api/geojson/:key requests

### DIFF
--- a/src/metabase/server/request/util.clj
+++ b/src/metabase/server/request/util.clj
@@ -37,9 +37,7 @@
         (and query-string
              (re-matches #"^/app/dist/.*\.(js|css)$" uri))
         ;; any resource that is named as a cache-busting hex string (e.g. fonts, images)
-        (re-matches #"^/app/dist/[a-f0-9]{20}+.*$" uri)
-        ;; GeoJSON proxy requests should also be cached
-        (re-matches #"^/api/geojson/.*" uri))))
+        (re-matches #"^/app/dist/[a-f0-9]{20}+.*$" uri))))
 
 (defn https?
   "True if the original request made by the frontend client (i.e., browser) was made over HTTPS.

--- a/test/metabase/api/geojson_test.clj
+++ b/test/metabase/api/geojson_test.clj
@@ -156,10 +156,6 @@
         (is (= {:type        "Point"
                 :coordinates [37.77986 -122.429]}
                (mt/user-http-request :rasta :get 200 "geojson/middle-earth"))))
-      (testing "response should not include the usual cache-busting headers"
-        (is (= (#'mw.security/cache-far-future-headers)
-               (select-keys (:headers (client/client-full-response :get 200 "geojson/middle-earth"))
-                            (keys (#'mw.security/cache-prevention-headers))))))
       (testing "should be able to fetch the GeoJSON even if you aren't logged in"
         (is (= {:type        "Point"
                 :coordinates [37.77986 -122.429]}

--- a/test/metabase/api/geojson_test.clj
+++ b/test/metabase/api/geojson_test.clj
@@ -4,7 +4,6 @@
             [metabase.api.geojson :as api.geojson]
             [metabase.http-client :as client]
             [metabase.models.setting :as setting]
-            [metabase.server.middleware.security :as mw.security]
             [metabase.test :as mt]
             [metabase.util :as u]
             [metabase.util.schema :as su]


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/22534.

The caching of geojson maps by key doesn't take into account that the custom map's URL might change, or that the geojson data at the URL might change. So we need to reinstate cache busting headers for this.

The app still uses an in-memory cache for the users session, but it will be refreshed on page refresh.