### PR TITLE
fix tooltip overflow

### DIFF
--- a/frontend/src/metabase/components/Tooltip/Tooltip.tsx
+++ b/frontend/src/metabase/components/Tooltip/Tooltip.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import PropTypes from "prop-types";
 import * as Tippy from "@tippyjs/react";
 import * as ReactIs from "react-is";
@@ -26,6 +26,7 @@ export interface TooltipProps
       "delay" | "reference" | "placement" | "maxWidth" | "offset"
     >
   > {
+  preventOverflow?: boolean;
   tooltip?: React.ReactNode;
   children?: React.ReactNode;
   isEnabled?: boolean;
@@ -69,12 +70,28 @@ function Tooltip({
   offset,
   isEnabled,
   isOpen,
+  preventOverflow,
   maxWidth = 200,
 }: TooltipProps) {
   const visible = isOpen != null ? isOpen : undefined;
   const animationDuration = isReducedMotionPreferred() ? 0 : undefined;
   const disabled = isEnabled === false;
   const targetProps = getTargetProps(reference, children);
+
+  const popperOptions = useMemo(
+    () => ({
+      modifiers: [
+        {
+          name: "preventOverflow",
+          enabled: preventOverflow,
+          options: {
+            altAxis: true,
+          },
+        },
+      ],
+    }),
+    [preventOverflow],
+  );
 
   if (tooltip && targetProps) {
     return (
@@ -92,6 +109,7 @@ function Tooltip({
         placement={placement}
         offset={offset}
         zIndex={DEFAULT_Z_INDEX}
+        popperOptions={popperOptions}
         {...targetProps}
       />
     );

--- a/frontend/src/metabase/components/Tooltip/Tooltip.tsx
+++ b/frontend/src/metabase/components/Tooltip/Tooltip.tsx
@@ -79,17 +79,19 @@ function Tooltip({
   const targetProps = getTargetProps(reference, children);
 
   const popperOptions = useMemo(
-    () => ({
-      modifiers: [
-        {
-          name: "preventOverflow",
-          enabled: preventOverflow,
-          options: {
-            altAxis: true,
-          },
-        },
-      ],
-    }),
+    () =>
+      preventOverflow
+        ? {
+            modifiers: [
+              {
+                name: "preventOverflow",
+                options: {
+                  altAxis: true,
+                },
+              },
+            ],
+          }
+        : undefined,
     [preventOverflow],
   );
 

--- a/frontend/src/metabase/components/Tooltip/Tooltip.tsx
+++ b/frontend/src/metabase/components/Tooltip/Tooltip.tsx
@@ -70,7 +70,7 @@ function Tooltip({
   offset,
   isEnabled,
   isOpen,
-  preventOverflow,
+  preventOverflow = false,
   maxWidth = 200,
 }: TooltipProps) {
   const visible = isOpen != null ? isOpen : undefined;

--- a/frontend/src/metabase/visualizations/components/ChartTooltip/ChartTooltip.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartTooltip/ChartTooltip.tsx
@@ -51,6 +51,7 @@ const ChartTooltip = ({ hovered, settings }: ChartTooltipProps) => {
 
   return target ? (
     <Tooltip
+      preventOverflow
       reference={target}
       isOpen={isOpen}
       tooltip={tooltip}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/22970

## Changes

Fixes tooltip gets clip when there is no space for it to render. To fix case mentioned in the original issue, adding the flipping behavior would not look great, so I made tooltips overlap the original element more when they don't have enough space.

## Screenshots

**Embedding**
<img width="871" alt="Screenshot 2022-06-22 at 02 40 01" src="https://user-images.githubusercontent.com/14301985/174908945-30590326-0faa-41e2-871d-81f25609c50b.png">

**Public link**
<img width="1026" alt="Screenshot 2022-06-22 at 02 40 23" src="https://user-images.githubusercontent.com/14301985/174908959-56876bc6-ad0f-4983-add0-cc080adf6a39.png">

## How to verify

1. Question > Sample > Products - summarize Count, Sum of Price and Avg of Rating, grouped by Category
![image](https://user-images.githubusercontent.com/1447303/170490946-95c48888-0a32-4128-bbe9-dff914e1ae2e.png)
2. Save question - enable Public sharing
3. Open the public link in another tab `http://localhost:3000/public/question/:uuid` and append `#titled=false` to it
4. Ensure when you hover bars the tooltip does not go off-screen

