### PR TITLE
Hide password + user form fields when logged in via JWT and SAML

### DIFF
--- a/frontend/src/metabase/plugins/builtin.js
+++ b/frontend/src/metabase/plugins/builtin.js
@@ -1,4 +1,6 @@
 import "metabase/plugins/builtin/auth/password";
 import "metabase/plugins/builtin/auth/google";
 import "metabase/plugins/builtin/auth/ldap";
+import "metabase/plugins/builtin/auth/jwt";
+import "metabase/plugins/builtin/auth/saml";
 import "metabase/plugins/builtin/settings/hosted";

--- a/frontend/src/metabase/plugins/builtin/auth/jwt.js
+++ b/frontend/src/metabase/plugins/builtin/auth/jwt.js
@@ -1,0 +1,3 @@
+import { PLUGIN_IS_PASSWORD_USER } from "metabase/plugins";
+
+PLUGIN_IS_PASSWORD_USER.push(user => user.sso_source !== "jwt");

--- a/frontend/src/metabase/plugins/builtin/auth/saml.js
+++ b/frontend/src/metabase/plugins/builtin/auth/saml.js
@@ -1,0 +1,3 @@
+import { PLUGIN_IS_PASSWORD_USER } from "metabase/plugins";
+
+PLUGIN_IS_PASSWORD_USER.push(user => user.sso_source !== "saml");

--- a/frontend/test/metabase/scenarios/onboarding/setup/user_settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/onboarding/setup/user_settings.cy.spec.js
@@ -214,4 +214,56 @@ describe("user > settings", () => {
       cy.findByLabelText("Email").should("not.exist");
     });
   });
+
+  describe("when user is authenticated via JWT", () => {
+    beforeEach(() => {
+      cy.server();
+      cy.route(
+        "GET",
+        "/api/user/current",
+        Object.assign({}, CURRENT_USER, {
+          sso_source: "jwt",
+        }),
+      ).as("getUser");
+
+      cy.visit("/account/profile");
+      cy.wait("@getUser");
+    });
+
+    it("should hide change password tab", () => {
+      cy.findByText("Password").should("not.exist");
+    });
+
+    it("should hide first name, last name, and email input (metabase#23298)", () => {
+      cy.findByLabelText("First name").should("not.exist");
+      cy.findByLabelText("Last name").should("not.exist");
+      cy.findByLabelText("Email").should("not.exist");
+    });
+  });
+
+  describe("when user is authenticated via SAML", () => {
+    beforeEach(() => {
+      cy.server();
+      cy.route(
+        "GET",
+        "/api/user/current",
+        Object.assign({}, CURRENT_USER, {
+          sso_source: "saml",
+        }),
+      ).as("getUser");
+
+      cy.visit("/account/profile");
+      cy.wait("@getUser");
+    });
+
+    it("should hide change password tab", () => {
+      cy.findByText("Password").should("not.exist");
+    });
+
+    it("should hide first name, last name, and email input (metabase#23298)", () => {
+      cy.findByLabelText("First name").should("not.exist");
+      cy.findByLabelText("Last name").should("not.exist");
+      cy.findByLabelText("Email").should("not.exist");
+    });
+  });
 });

--- a/frontend/test/metabase/scenarios/onboarding/setup/user_settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/onboarding/setup/user_settings.cy.spec.js
@@ -64,8 +64,7 @@ describe("user > settings", () => {
   });
 
   it("should update the user without fetching memberships", () => {
-    cy.server();
-    cy.route("GET", "/api/permissions/membership").as("membership");
+    cy.intercept("GET", "/api/permissions/membership").as("membership");
     cy.visit("/account/profile");
     cy.findByDisplayValue(first_name)
       .click()
@@ -82,8 +81,7 @@ describe("user > settings", () => {
   });
 
   it("should have a change password tab", () => {
-    cy.server();
-    cy.route("GET", "/api/user/current").as("getUser");
+    cy.intercept("GET", "/api/user/current").as("getUser");
 
     cy.visit("/account/profile");
     cy.wait("@getUser");
@@ -171,8 +169,7 @@ describe("user > settings", () => {
 
   describe("when user is authenticated via ldap", () => {
     beforeEach(() => {
-      cy.server();
-      cy.route(
+      cy.intercept(
         "GET",
         "/api/user/current",
         Object.assign({}, CURRENT_USER, {
@@ -191,8 +188,7 @@ describe("user > settings", () => {
 
   describe("when user is authenticated via google", () => {
     beforeEach(() => {
-      cy.server();
-      cy.route(
+      cy.intercept(
         "GET",
         "/api/user/current",
         Object.assign({}, CURRENT_USER, {
@@ -217,8 +213,7 @@ describe("user > settings", () => {
 
   describe("when user is authenticated via JWT", () => {
     beforeEach(() => {
-      cy.server();
-      cy.route(
+      cy.intercept(
         "GET",
         "/api/user/current",
         Object.assign({}, CURRENT_USER, {
@@ -243,8 +238,7 @@ describe("user > settings", () => {
 
   describe("when user is authenticated via SAML", () => {
     beforeEach(() => {
-      cy.server();
-      cy.route(
+      cy.intercept(
         "GET",
         "/api/user/current",
         Object.assign({}, CURRENT_USER, {

--- a/src/metabase/api/user.clj
+++ b/src/metabase/api/user.clj
@@ -205,6 +205,15 @@
             (t/offset-date-time))]
     (assoc user :first_login ts)))
 
+(defn- maybe-add-sso-source
+  "Adds `sso_source` key to the `User`, so FE could determine if the user is logged in via SSO."
+  [{:keys [id] :as user}]
+  (if (premium-features/enable-advanced-permissions?)
+    (let [{:keys [sso_source]}
+          (db/select-one [User :sso_source] :id id)]
+      (assoc user :sso_source sso_source))
+    user))
+
 (api/defendpoint GET "/current"
   "Fetch the current `User`."
   []
@@ -212,7 +221,8 @@
       (hydrate :personal_collection_id :group_ids :is_installer :has_invited_second_user)
       add-has-question-and-dashboard
       add-first-login
-      maybe-add-advanced-permissions))
+      maybe-add-advanced-permissions
+      maybe-add-sso-source))
 
 (api/defendpoint GET "/:id"
   "Fetch a `User`. You must be fetching yourself *or* be a superuser *or* a Group Manager."

--- a/src/metabase/api/user.clj
+++ b/src/metabase/api/user.clj
@@ -184,6 +184,13 @@
     (with-advanced-permissions user)
     user))
 
+(defn- maybe-add-sso-source
+  "Adds `sso_source` key to the `User`, so FE could determine if the user is logged in via SSO."
+  [{:keys [id] :as user}]
+  (if (premium-features/enable-sso?)
+    (assoc user :sso_source (db/select-one-field :sso_source User :id id))
+    user))
+
 (defn- add-has-question-and-dashboard
   "True when the user has permissions for at least one un-archived question and one un-archived dashboard."
   [user]
@@ -204,15 +211,6 @@
                                        {:order-by [[:timestamp :asc]]}))
             (t/offset-date-time))]
     (assoc user :first_login ts)))
-
-(defn- maybe-add-sso-source
-  "Adds `sso_source` key to the `User`, so FE could determine if the user is logged in via SSO."
-  [{:keys [id] :as user}]
-  (if (premium-features/enable-advanced-permissions?)
-    (let [{:keys [sso_source]}
-          (db/select-one [User :sso_source] :id id)]
-      (assoc user :sso_source sso_source))
-    user))
 
 (api/defendpoint GET "/current"
   "Fetch the current `User`."


### PR DESCRIPTION
Closes #23298

This PR alters the logic that checks if users are password/SSO by including `JWT` and `SAML` checks as well. See [this discussion on Slack](https://metaboat.slack.com/archives/C03E8MQJZBM/p1655843194210369) for more info

## Before this fix (JWT user)
![image](https://user-images.githubusercontent.com/1937582/175007353-40ace326-0b42-4c04-9c39-d936e6d6d81f.png)

## With this PR (JWT user)
![image](https://user-images.githubusercontent.com/1937582/175007259-4aa0f9f6-04d6-404d-b8e8-e54fe6122e08.png)
