### PR TITLE
Button to get rid of spinners (#20863)

### DIFF
--- a/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.jsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.jsx
@@ -65,7 +65,7 @@ const DatabaseEditAppSidebar = ({
                 className="Button Button--dismissSyncSpinner"
                 normalText={t`Dismiss sync spinner manually`}
                 activeText={t`Dismissing…`}
-                failedText={t`Failed to dismissed`}
+                failedText={t`Failed to dismiss sync spinner`}
                 successText={t`Sync spinners dismissed!`}
               />
             </li>

--- a/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.jsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.jsx
@@ -59,16 +59,6 @@ const DatabaseEditAppSidebar = ({
                 successText={t`Sync triggered!`}
               />
             </li>
-            <li>
-              <ActionButton
-                actionFn={() => dismissSyncSpinner(database.id)}
-                className="Button Button--dismissSyncSpinner"
-                normalText={t`Dismiss sync spinner manually`}
-                activeText={t`Dismissing…`}
-                failedText={t`Failed to dismiss sync spinner`}
-                successText={t`Sync spinners dismissed!`}
-              />
-            </li>
             <li className="mt2">
               <ActionButton
                 actionFn={() => rescanDatabaseFields(database.id)}
@@ -79,6 +69,18 @@ const DatabaseEditAppSidebar = ({
                 successText={t`Scan triggered!`}
               />
             </li>
+            {database["initial_sync_status"] !== "complete" && (
+              <li className="mt2">
+                <ActionButton
+                  actionFn={() => dismissSyncSpinner(database.id)}
+                  className="Button Button--dismissSyncSpinner"
+                  normalText={t`Dismiss sync spinner manually`}
+                  activeText={t`Dismissing…`}
+                  failedText={t`Failed to dismiss sync spinner`}
+                  successText={t`Sync spinners dismissed!`}
+                />
+              </li>
+            )}
             {isModelPersistenceEnabled && database.supportsPersistence() && (
               <li className="mt2">
                 {database.isPersisted() ? (

--- a/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.jsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.jsx
@@ -14,6 +14,7 @@ const propTypes = {
   database: PropTypes.object.isRequired,
   deleteDatabase: PropTypes.func.isRequired,
   syncDatabaseSchema: PropTypes.func.isRequired,
+  dismissSyncSpinner: PropTypes.func.isRequired,
   rescanDatabaseFields: PropTypes.func.isRequired,
   discardSavedFieldValues: PropTypes.func.isRequired,
   persistDatabase: PropTypes.func.isRequired,
@@ -26,6 +27,7 @@ const DatabaseEditAppSidebar = ({
   database,
   deleteDatabase,
   syncDatabaseSchema,
+  dismissSyncSpinner,
   rescanDatabaseFields,
   discardSavedFieldValues,
   persistDatabase,
@@ -55,6 +57,16 @@ const DatabaseEditAppSidebar = ({
                 activeText={t`Starting…`}
                 failedText={t`Failed to sync`}
                 successText={t`Sync triggered!`}
+              />
+            </li>
+            <li>
+              <ActionButton
+                actionFn={() => dismissSyncSpinner(database.id)}
+                className="Button Button--dismissSyncSpinner"
+                normalText={t`Dismiss sync spinner manually`}
+                activeText={t`Dismissing…`}
+                failedText={t`Failed to dismissed`}
+                successText={t`Sync spinners dismissed!`}
               />
             </li>
             <li className="mt2">

--- a/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.unit.spec.js
+++ b/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.unit.spec.js
@@ -46,6 +46,25 @@ it("rescans database field values", () => {
   expect(rescanDatabaseFields).toHaveBeenCalledWith(databaseId);
 });
 
+it("can cancel sync and just forgets about initial sync (#20863)", () => {
+  const databaseId = 1;
+  const database = {
+    id: databaseId,
+    initial_sync_status: "incomplete",
+    supportsPersistence: () => true,
+    isPersisted: () => false,
+  };
+  const dismissSyncSpinner = jest.fn();
+
+  render(
+    <Sidebar database={database} dismissSyncSpinner={dismissSyncSpinner} />,
+  );
+
+  const dismissButton = screen.getByText("Dismiss sync spinner manually");
+  fireEvent.click(dismissButton);
+  expect(dismissSyncSpinner).toHaveBeenCalledWith(databaseId);
+});
+
 it("discards saved field values", () => {
   const databaseId = 1;
   const database = {

--- a/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx
@@ -27,6 +27,7 @@ import {
   initializeDatabase,
   saveDatabase,
   syncDatabaseSchema,
+  dismissSyncSpinner,
   rescanDatabaseFields,
   discardSavedFieldValues,
   deleteDatabase,
@@ -61,6 +62,7 @@ const mapDispatchToProps = {
   initializeDatabase,
   saveDatabase,
   syncDatabaseSchema,
+  dismissSyncSpinner,
   rescanDatabaseFields,
   discardSavedFieldValues,
   persistDatabase,
@@ -81,6 +83,7 @@ class DatabaseEditApp extends Component {
     reset: PropTypes.func.isRequired,
     initializeDatabase: PropTypes.func.isRequired,
     syncDatabaseSchema: PropTypes.func.isRequired,
+    dismissSyncSpinner: PropTypes.func.isRequired,
     rescanDatabaseFields: PropTypes.func.isRequired,
     discardSavedFieldValues: PropTypes.func.isRequired,
     persistDatabase: PropTypes.func.isRequired,
@@ -106,6 +109,7 @@ class DatabaseEditApp extends Component {
       initializeError,
       rescanDatabaseFields,
       syncDatabaseSchema,
+      dismissSyncSpinner,
       persistDatabase,
       unpersistDatabase,
       isAdmin,
@@ -203,6 +207,7 @@ class DatabaseEditApp extends Component {
               discardSavedFieldValues={discardSavedFieldValues}
               rescanDatabaseFields={rescanDatabaseFields}
               syncDatabaseSchema={syncDatabaseSchema}
+              dismissSyncSpinner={dismissSyncSpinner}
               persistDatabase={persistDatabase}
               unpersistDatabase={unpersistDatabase}
             />

--- a/frontend/src/metabase/admin/databases/database.js
+++ b/frontend/src/metabase/admin/databases/database.js
@@ -34,6 +34,8 @@ export const PERSIST_DATABASE = "metabase/admin/databases/PERSIST_DATABASE";
 export const UNPERSIST_DATABASE = "metabase/admin/databases/UNPERSIST_DATABASE";
 export const SYNC_DATABASE_SCHEMA =
   "metabase/admin/databases/SYNC_DATABASE_SCHEMA";
+export const DISMISS_SYNC_SPINNER =
+  "metabase/admin/databases/DISMISS_SYNC_SPINNER";
 export const RESCAN_DATABASE_FIELDS =
   "metabase/admin/databases/RESCAN_DATABASE_FIELDS";
 export const DISCARD_SAVED_FIELD_VALUES =
@@ -247,6 +249,19 @@ export const syncDatabaseSchema = createThunkAction(
         return call;
       } catch (error) {
         console.log("error syncing database", error);
+      }
+    };
+  },
+);
+
+export const dismissSyncSpinner = createThunkAction(
+  DISMISS_SYNC_SPINNER,
+  function(databaseId) {
+    return async function(dispatch, getState) {
+      try {
+        console.log("spinning away...");
+      } catch (error) {
+        console.log("error dismissing sync spinner for database", error);
       }
     };
   },

--- a/frontend/src/metabase/admin/databases/database.js
+++ b/frontend/src/metabase/admin/databases/database.js
@@ -259,7 +259,7 @@ export const dismissSyncSpinner = createThunkAction(
   function(databaseId) {
     return async function(dispatch, getState) {
       try {
-        console.log("spinning away...");
+        await MetabaseApi.db_dismiss_sync_spinner({ dbId: databaseId });
       } catch (error) {
         console.log("error dismissing sync spinner for database", error);
       }

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -264,6 +264,7 @@ export const MetabaseApi = {
     "/api/database/:dbId/autocomplete_suggestions?search=:prefix",
   ),
   db_sync_schema: POST("/api/database/:dbId/sync_schema"),
+  db_dismiss_sync_spinner: POST("/api/database/:dbId/dismiss_spinner"),
   db_rescan_values: POST("/api/database/:dbId/rescan_values"),
   db_discard_values: POST("/api/database/:dbId/discard_values"),
   db_persist: POST("/api/database/:dbId/persist"),

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -814,13 +814,12 @@
   "Manually set the initial sync status of the `Database` and corresponding
   tables to be `complete` (see #20863)"
   [id]
-  ;; just wrap this in a future so it happens async
+  ;; manual full sync needs to be async, but this is a simple update of `Database`
   (let [db     (add-tables (api/write-check (Database id)))
         tables (:tables db)]
-    (future
-      (sync-util/set-initial-database-sync-complete! db)
-      (for [table tables]
-        (sync-util/set-initial-table-sync-complete!))))
+    (sync-util/set-initial-database-sync-complete! db)
+    (for [table tables]
+      (sync-util/set-initial-table-sync-complete!)))
   {:status :ok})
 
 ;; TODO - do we also want an endpoint to manually trigger analysis. Or separate ones for classification/fingerprinting?

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -734,11 +734,15 @@
 
 (deftest dismiss-spinner-test
   (testing "Can we dismiss the spinner? (#20863)"
-    (mt/with-temp* [Database [db    {:engine "h2", :details (:details (mt/db) :initial_sync_status "incomplete")}]
+    (mt/with-temp* [Database [db    {:engine "h2", :details (:details (mt/db)) :initial_sync_status "incomplete"}]
                     Table    [table {:db_id (u/the-id db) :initial_sync_status "incomplete"}]]
       (mt/user-http-request :crowberto :post 200 (format "database/%d/dismiss_spinner" (u/the-id db)))
-      (is (= "complete" (db :initial_sync_status)))
-      (is (= "complete" (table :initial_sync_status))))))
+      (testing "dismissed db spinner"
+        (is (= "complete" (:initial_sync_status
+                            (mt/user-http-request :crowberto :get 200 (format "database/%d" (u/the-id db)))))))
+      (testing "dismissed table spinner"
+        (is (= "complete" (:initial_sync_status
+                            (mt/user-http-request :crowberto :get 200 (format "table/%d" (u/the-id table))))))))))
 
 (deftest non-admins-cant-trigger-sync
   (testing "Non-admins should not be allowed to trigger sync"

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -732,6 +732,14 @@
             (is (= true
                    (deref analyze-called? long-timeout :analyze-never-called)))))))))
 
+(deftest dismiss-spinner-test
+  (testing "Can we dismiss the spinner? (#20863)"
+    (mt/with-temp* [Database [db    {:engine "h2", :details (:details (mt/db) :initial_sync_status "incomplete")}]
+                    Table    [table {:db_id (u/the-id db) :initial_sync_status "incomplete"}]]
+      (mt/user-http-request :crowberto :post 200 (format "database/%d/dismiss_spinner" (u/the-id db)))
+      (is (= "complete" (db :initial_sync_status)))
+      (is (= "complete" (table :initial_sync_status))))))
+
 (deftest non-admins-cant-trigger-sync
   (testing "Non-admins should not be allowed to trigger sync"
     (is (= "You don't have permissions to do that."


### PR DESCRIPTION
Pursuant to #20863.

Some syncs (viz., the ones in mongo, in the #20863 ticket, but there seem to be others) don't mutate the `initial_sync_status` in metabase database object properly. I looked into directly fixing in mongodb and then found that this was also the case in some others of the DB's so we can't really 100% trust that initial_sync_status to be set automatically generally.

This creates a pretty unhappy UX where, if you have mongo, that sync spinner just stays there forever. Flamber details a workaround to it in #20863 which is... reaching into metabase app DB and mutating stuff. Not ideal.

This adds a button to the admin panel for a DB that appears if (and only if) the sync status isn't `complete` to just coerce the sync status of DB and tables under DB to be `complete`. Screenshot of button existing attached.

<img width="612" alt="Screen Shot 2022-06-22 at 10 28 21 AM" src="https://user-images.githubusercontent.com/1364952/175100638-a9a9b7d7-ce39-4d43-8969-7d8345b5fcbc.png">

I think there needs to be a separate PR to get rid of the per-second sync thing with something exponential backoffy. That's pretty logically separate tho, so that's going to be in a separate PR