### PR TITLE
Better filter validity check

### DIFF
--- a/frontend/src/metabase-lib/lib/queries/structured/Filter.ts
+++ b/frontend/src/metabase-lib/lib/queries/structured/Filter.ts
@@ -101,6 +101,9 @@ export default class Filter extends MBQLClause {
         return false;
       }
 
+      if (!this.operatorName()) {
+        return false;
+      }
       const operator = this.operator();
 
       if (operator) {

--- a/frontend/test/metabase-lib/lib/queries/structured/Filter.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/structured/Filter.unit.spec.js
@@ -31,6 +31,11 @@ describe("Filter", () => {
           false,
         );
       });
+      it("should return false with a null operator", () => {
+        expect(
+          filter([null, ["field", ORDERS.TOTAL.id, null], 42]).isValid(),
+        ).toBe(false);
+      });
       it("should return true for a filter with an expression for the field", () => {
         expect(
           filter(["=", ["/", ["field", 12341234, null], 43], 42]).isValid(),


### PR DESCRIPTION
## Before

There was a bug in our filter validity checking logic that allowed invalid filters to be detected as valid.

This was most obviously manifest when adding date filters with no content

![badDateFilter](https://user-images.githubusercontent.com/30528226/175120027-cf2565e7-4f65-47ce-a95a-a42f52af5219.gif)

It was also present in the bulk filter which could add invalid filters on blur:

![badblur](https://user-images.githubusercontent.com/30528226/175120412-c5adcaa9-1564-4aff-a7d0-cf436fe06d79.gif)

## Changes

`Filter.isValid()` would return `true` for filters that have a `null` operatorName. This adds a simple check for a truthy filter operatorName.

## After

With the validity check working properly, we get the intended behavior in the filter sidebar: a cancel button when there's no valid filter
![correct](https://user-images.githubusercontent.com/30528226/175120575-a0b20358-713e-4673-ba66-01cbc0b4cb49.gif)

And in the popover, the blur action doesn't add an invalid filter anymore:

![goodBlur](https://user-images.githubusercontent.com/30528226/175120634-b2a22e72-3dd6-43f6-919c-a488507e48e8.gif)




