### PR TITLE
Change hour-of-day exclude units to integers, not time with time zones

### DIFF
--- a/frontend/src/metabase/lib/query_time.js
+++ b/frontend/src/metabase/lib/query_time.js
@@ -185,7 +185,11 @@ export function generateTimeIntervalDescription(n, unit) {
 }
 
 export function generateTimeValueDescription(value, bucketing, isExclude) {
-  if (typeof value === "string") {
+  if (typeof value === "number" && bucketing === "hour-of-day") {
+    return moment()
+      .hour(value)
+      .format("h A");
+  } else if (typeof value === "string") {
     const m = parseTimestamp(value, bucketing);
     if (bucketing) {
       return formatDateTimeWithUnit(value, bucketing, { isExclude });
@@ -684,13 +688,19 @@ export const EXCLUDE_OPTIONS = {
     ];
   },
   [EXCLUDE_UNITS["hours"]]: () => {
+    const now = moment()
+      .utc()
+      .minutes(0)
+      .seconds(0)
+      .milliseconds(0);
     const func = hour => {
-      const displayName = hour.toString();
+      const date = now.hour(hour);
+      const displayName = date.format("h A");
       return {
         displayName,
         value: hour,
         serialized: hour.toString(),
-        test: value => value.toString() === displayName,
+        test: value => value === hour,
       };
     };
     return [_.range(0, 12).map(func), _.range(12, 24).map(func)];

--- a/frontend/src/metabase/lib/query_time.js
+++ b/frontend/src/metabase/lib/query_time.js
@@ -684,22 +684,13 @@ export const EXCLUDE_OPTIONS = {
     ];
   },
   [EXCLUDE_UNITS["hours"]]: () => {
-    const now = moment()
-      .utc()
-      .minutes(0)
-      .seconds(0)
-      .milliseconds(0);
     const func = hour => {
-      const date = now.hour(hour);
-      const displayName = date.format("h A");
+      const displayName = hour.toString();
       return {
         displayName,
-        value: date.toISOString(),
-        serialized: date.format("H"),
-        test: value =>
-          moment(value)
-            .utc()
-            .format("h A") === displayName,
+        value: hour,
+        serialized: hour.toString(),
+        test: value => value.toString() === displayName,
       };
     };
     return [_.range(0, 12).map(func), _.range(12, 24).map(func)];


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/23461

I found the root cause on the frontend. I've got a solution, but it needs tidying up.

Specifically, I would check whether (1) `generateTimeValueDescription` is the best place to put the `6` -> `"6 AM"` transformation to create the filter `displayName`, and (2) if there are any other downstream consequences of having these arguments be integers, instead of timestamp strings.

What changed:

The idea is to replace the hour-of-day exclude units defined [here](https://github.com/metabase/metabase/blob/master/frontend/src/metabase/lib/query_time.js#L686) to be integers instead of timestamps with time zones, so the hour of the day matches the values in the filter, regardless of the reporting timezone.

For example, if you have this exclude hour of day filter:
<img width="325" alt="image" src="https://user-images.githubusercontent.com/39073188/175268837-d6c9b09e-aafa-4bab-9961-19d3d63f1388.png">

This is the current filter (seen in redux devtools):
<img width="467" alt="image" src="https://user-images.githubusercontent.com/39073188/175268773-5b256d54-da49-4fe4-85e0-dbf7f54c0dd9.png">

After this change, the filter will have integer values:
<img width="455" alt="image" src="https://user-images.githubusercontent.com/39073188/175269648-fb67c51d-6561-4bdd-9e3c-3e6f1a600255.png">