### PR TITLE
Respect DB management permission for model caching

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/model_persistence/components/ModelCacheControl/ModelCacheControl.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/model_persistence/components/ModelCacheControl/ModelCacheControl.tsx
@@ -32,7 +32,7 @@ function ModelCacheControl({
 }: ModelCacheControlProps) {
   const [isLoading, setLoading] = useState(false);
   const isPersisted = model.isPersisted();
-  const tooltip = isPersisted ? t`Unpersist model` : t`Persist model`;
+  const label = isPersisted ? t`Unpersist model` : t`Persist model`;
 
   const handleClick = useCallback(async () => {
     const id = model.id();
@@ -70,7 +70,7 @@ function ModelCacheControl({
             onClick={handleClick}
             iconSize={size}
           >
-            {tooltip}
+            {label}
           </Button>
         );
       }}

--- a/enterprise/frontend/src/metabase-enterprise/model_persistence/components/ModelCacheControl/ModelCacheControl.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/model_persistence/components/ModelCacheControl/ModelCacheControl.tsx
@@ -7,6 +7,9 @@ import LoadingSpinner from "metabase/components/LoadingSpinner";
 import { delay } from "metabase/lib/promise";
 import { CardApi } from "metabase/services";
 
+import Databases from "metabase/entities/databases";
+
+import Database from "metabase-lib/lib/metadata/Database";
 import Question from "metabase-lib/lib/Question";
 
 import { SpinnerContainer } from "./ModelCacheControl.styled";
@@ -16,6 +19,10 @@ interface ModelCacheControlProps {
   size?: number;
   onChange?: (isPersisted: boolean) => void;
 }
+
+type DatabaseEntityLoaderProps = {
+  database?: Database;
+};
 
 function ModelCacheControl({
   model,
@@ -46,14 +53,28 @@ function ModelCacheControl({
     }
   }, [model, onChange]);
 
-  return isLoading ? (
-    <SpinnerContainer>
-      <LoadingSpinner size={size} />
-    </SpinnerContainer>
-  ) : (
-    <Button {...props} icon="database" onClick={handleClick} iconSize={size}>
-      {tooltip}
-    </Button>
+  return (
+    <Databases.Loader id={model.databaseId()} loadingAndErrorWrapper={false}>
+      {({ database }: DatabaseEntityLoaderProps) => {
+        if (!database || !database["can-manage"]) {
+          return null;
+        }
+        return isLoading ? (
+          <SpinnerContainer>
+            <LoadingSpinner size={size} />
+          </SpinnerContainer>
+        ) : (
+          <Button
+            {...props}
+            icon="database"
+            onClick={handleClick}
+            iconSize={size}
+          >
+            {tooltip}
+          </Button>
+        );
+      }}
+    </Databases.Loader>
   );
 }
 

--- a/enterprise/frontend/src/metabase-enterprise/model_persistence/components/ModelCacheControl/ModelCacheControl.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/model_persistence/components/ModelCacheControl/ModelCacheControl.tsx
@@ -31,8 +31,7 @@ function ModelCacheControl({
   ...props
 }: ModelCacheControlProps) {
   const [isLoading, setLoading] = useState(false);
-  const isPersisted = model.isPersisted();
-  const label = isPersisted ? t`Unpersist model` : t`Persist model`;
+  const label = model.isPersisted() ? t`Unpersist model` : t`Persist model`;
 
   const handleClick = useCallback(async () => {
     const id = model.id();

--- a/frontend/src/metabase-lib/lib/metadata/Database.ts
+++ b/frontend/src/metabase-lib/lib/metadata/Database.ts
@@ -25,6 +25,9 @@ class DatabaseInner extends Base {
   schemas: Schema[];
   metadata: Metadata;
 
+  // Only appears in  GET /api/database/:id
+  "can-manage"?: boolean;
+
   // TODO Atte Keinänen 6/11/17: List all fields here (currently only in types/Database)
   displayName() {
     return this.name;

--- a/frontend/src/metabase-types/api/database.ts
+++ b/frontend/src/metabase-types/api/database.ts
@@ -15,4 +15,7 @@ export interface Database {
   timezone?: string;
   native_permissions: NativePermissions;
   initial_sync_status: InitialSyncStatus;
+
+  // Only appears in  GET /api/database/:id
+  "can-manage"?: boolean;
 }


### PR DESCRIPTION
Only users with DB management permission should be able to enable/disable caching per model. For paid plans, Metabase shows the "Persist model" or "Unpersist model" action and it should only be available if you have DB management permission. #22933 added the `can-manage` property to the `GET /api/database/:id` response and this PR makes the FE use the flag to control persist/unpersist button visibility

### To Verify

First of all, you need to spin up Metabase EE and sign in as admin

**Prepare a model**
1. Go to `/admin/settings/caching` and enable model persistence
2. Spin up a sample PostgreSQL DB from [metabase/metabase-qa](https://github.com/metabase/metabase-qa) in Docker
3. Go to `/admin/databases`, connect the new PSQL DB and enable model persistence for the DB (click the "Enable model persistence" button on the DB page's sidebar)
4. Create a question using PSQL data, turn it into a model

**Prepare a user**
1. Create a non-admin user at `/admin/people` (either keep it in the "All users" group or create a new one)
2. Go to `/admin/permissions/data/database/$YOUR_PSQL_DB_ID`
3. Grant "Manage database" permission to the group your new users belongs to

**Verify the change**
1. Sign in as your recently created non-admin user
2. Open the model you've created at the beginning
3. Click the "ellipsis" icon at the top right to open the actions menu
4. Ensure you can see the "Enable/disable persistence" button in the menu
5. Sign in as admin again, go to Go to `/admin/permissions/data/database/$YOUR_PSQL_DB_ID` and remove the "Manage database" permission from your user
6. Sign in as a non-admin user again, repeat steps 2 and 3, and ensure you can't see the "Enable/disable persistence" button anymore