### PR TITLE
Fix OSS embedding test failing

### DIFF
--- a/frontend/test/metabase/scenarios/embedding/embedding-snippets.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/embedding-snippets.cy.spec.js
@@ -30,14 +30,16 @@ describe("scenarios > embedding > code snippets", () => {
       .should("match", JS_CODE({ isEE }));
 
     // hide download button for pro/enterprise users metabase#23477
-    cy.findByLabelText(
-      "Enable users to download data from this embed?",
-    ).click();
+    if (isEE) {
+      cy.findByLabelText(
+        "Enable users to download data from this embed?",
+      ).click();
 
-    cy.get(".ace_content")
-      .first()
-      .invoke("text")
-      .should("match", JS_CODE({ isEE, hideDownloadButton: true }));
+      cy.get(".ace_content")
+        .first()
+        .invoke("text")
+        .should("match", JS_CODE({ isEE, hideDownloadButton: true }));
+    }
 
     cy.get(".ace_content")
       .last()


### PR DESCRIPTION
Fix `e2e-tests-embedding-oss` job constantly fails on GH actions. 
