### PR TITLE
Bulk Filter Modal: Show autocomplete options in popover

### DIFF
--- a/frontend/src/metabase/components/FieldValuesWidget.jsx
+++ b/frontend/src/metabase/components/FieldValuesWidget.jsx
@@ -91,6 +91,7 @@ class FieldValuesWidgetInner extends Component {
     formatOptions: {},
     maxWidth: 500,
     disableSearch: false,
+    showOptionsInPopover: false,
   };
 
   componentDidMount() {
@@ -245,6 +246,7 @@ class FieldValuesWidgetInner extends Component {
       disablePKRemappingForSearch,
       formatOptions,
       placeholder,
+      showOptionsInPopover,
     } = this.props;
     const { loadingState, options = [] } = this.state;
 
@@ -302,7 +304,9 @@ class FieldValuesWidgetInner extends Component {
             color={color}
             style={{ ...style, minWidth: "inherit" }}
             className={className}
-            optionsStyle={!parameter ? { maxHeight: "none" } : {}}
+            optionsStyle={
+              !parameter && !showOptionsInPopover ? { maxHeight: "none" } : {}
+            }
             // end forwarded props
             options={options}
             valueKey="0"
@@ -317,12 +321,16 @@ class FieldValuesWidgetInner extends Component {
                 autoLoad: false,
               });
             }}
-            layoutRenderer={layoutProps => (
-              <div>
-                {layoutProps.valuesList}
-                {renderOptions(this.state, this.props, layoutProps)}
-              </div>
-            )}
+            layoutRenderer={
+              showOptionsInPopover
+                ? undefined
+                : layoutProps => (
+                    <div>
+                      {layoutProps.valuesList}
+                      {renderOptions(this.state, this.props, layoutProps)}
+                    </div>
+                  )
+            }
             filterOption={(option, filterString) => {
               const lowerCaseFilterString = filterString.toLowerCase();
               return option.some(

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineValuePicker/InlineValuePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineValuePicker/InlineValuePicker.tsx
@@ -52,7 +52,7 @@ export function InlineValuePicker({
         onChange={changeArguments}
         className="input"
         fields={[field]}
-        disableSearch
+        showOptionsInPopover
         multi
       />
     </ValuesPickerContainer>

--- a/frontend/test/metabase/scenarios/filters/filter-bulk.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/filter-bulk.cy.spec.js
@@ -491,7 +491,7 @@ describe("scenarios > filters > bulk filtering", () => {
     it("adds a contains text filter", () => {
       modal().within(() => {
         cy.findByLabelText("Title").within(() => {
-          cy.findByPlaceholderText("Enter some text").type("Marble");
+          cy.findByPlaceholderText("Search by Title").type("Marble");
         });
         cy.button("Apply").click();
       });
@@ -511,7 +511,7 @@ describe("scenarios > filters > bulk filtering", () => {
 
       modal().within(() => {
         cy.findByLabelText("Title").within(() => {
-          cy.findByPlaceholderText("Enter some text").type("Hat");
+          cy.findByPlaceholderText("Search by Title").type("Hat");
         });
         cy.button("Apply").click();
       });


### PR DESCRIPTION
## Description

By default, the field values widget shows suggestions inline, which really messes up the vibe of the bulk filter modal. This adds a `showOptionsInPopover` option to show the suggestions in a popover. (the popover functionality is actually the default for the TokenValue component, but it's overridden by the FieldValuesWidget. This adds a flag that allows a field values widget to accept the default behavior of the TokenField component.

![Screen Shot 2022-06-23 at 12 38 34 PM](https://user-images.githubusercontent.com/30528226/175374009-9676a7f7-344c-4249-ab2e-f296180e4afd.png)


## Testing Steps
- open any table with a text field (like people) 
- start typing a filter value for any text field (like city)
- see autocomplete suggestions in a popover
- you can click the suggestions to add them to the values box


*Known, unrelated 🐛 : adding multiple values for a contains/starts with/ends with filter will error* fixed in https://github.com/metabase/metabase/pull/23520