### PR TITLE
[E2E] Remove `filters` and `onboarding` checks from CCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1298,8 +1298,6 @@ workflows:
               folder:
                 [
                   "admin",
-                  "filters",
-                  "onboarding",
                   "visualizations",
                 ]
           name: e2e-tests-<< matrix.folder >>-<< matrix.edition >>


### PR DESCRIPTION
Removing `filters` and `onboarding` from CCI since they were recently moved to GHA

https://github.com/metabase/metabase/pull/23442
https://github.com/metabase/metabase/pull/23438