### PR TITLE
Better Handle Filter Operators in FieldValuesPicker

### DIFF
--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterList/BulkFilterList.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterList/BulkFilterList.styled.tsx
@@ -9,7 +9,7 @@ export const ListRoot = styled.div`
 
 export const ListRow = styled.div`
   display: grid;
-  grid-template-columns: 1fr 2fr;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 2fr);
   padding: 0.375rem 0;
 `;
 

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineValuePicker/InlineValuePicker.styled.ts
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineValuePicker/InlineValuePicker.styled.ts
@@ -1,8 +1,10 @@
 import styled from "@emotion/styled";
 import { space } from "metabase/styled-components/theme";
+import { color } from "metabase/lib/colors";
 
 import OperatorSelectorComponent from "metabase/query_builder/components/filters/OperatorSelector";
 import FieldValuesWidget from "metabase/components/FieldValuesWidget";
+import Input from "metabase/core/components/Input";
 
 export const OperatorSelector = styled(OperatorSelectorComponent)`
   margin-bottom: ${space(1)};
@@ -14,4 +16,22 @@ export const ArgumentSelector = styled(FieldValuesWidget)`
 
 export const ValuesPickerContainer = styled.div`
   grid-column: 2;
+`;
+
+export const BetweenContainer = styled.div`
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+export const NumberSeparator = styled.span`
+  color: ${color("text-light")};
+  font-weight: bold;
+  padding: 0 ${space(1)};
+`;
+
+export const NumberInput = styled(Input)`
+  border-color: ${color("border")};
+  width: 10rem;
 `;

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineValuePicker/InlineValuePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineValuePicker/InlineValuePicker.tsx
@@ -34,6 +34,9 @@ export function InlineValuePicker({
   );
 
   const filterOperators = field.filterOperators(filter.operatorName());
+  const hideArgumentSelector = ["is-null", "not-null", "empty", "not-empty"].includes(
+    filter.operatorName(),
+  );
 
   return (
     <ValuesPickerContainer
@@ -45,16 +48,18 @@ export function InlineValuePicker({
         operators={filterOperators}
         onOperatorChange={changeOperator}
       />
-      <ArgumentSelector
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore: this component doesn't have types or propTypes
-        value={filter.arguments()}
-        onChange={changeArguments}
-        className="input"
-        fields={[field]}
-        multi={!!filter?.operator()?.multi}
-        showOptionsInPopover
-      />
+      {!hideArgumentSelector && (
+        <ArgumentSelector
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore: this component doesn't have types or propTypes
+          value={filter.arguments()}
+          onChange={changeArguments}
+          className="input"
+          fields={[field]}
+          disableSearch
+          multi={!!filter?.operator()?.multi}
+        />
+      )}
     </ValuesPickerContainer>
   );
 }

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineValuePicker/InlineValuePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineValuePicker/InlineValuePicker.tsx
@@ -31,24 +31,20 @@ export function InlineValuePicker({
   );
 
   const changeArguments = useCallback(
-    (newArguments: number[]) => {
+    (newArguments: (string | number)[]) => {
       handleChange(filter.setArguments(newArguments));
     },
     [filter, handleChange],
   );
 
   const filterOperators = field.filterOperators(filter.operatorName());
+
   const hideArgumentSelector = [
     "is-null",
     "not-null",
-    "empty",
+    "is-empty",
     "not-empty",
   ].includes(filter.operatorName());
-
-  const isBetween =
-    filter.operatorName() === "between" &&
-    filter?.operator()?.fields.length === 2;
-  const filterArguments = filter.arguments() ?? [];
 
   return (
     <ValuesPickerContainer
@@ -60,39 +56,60 @@ export function InlineValuePicker({
         operators={filterOperators}
         onOperatorChange={changeOperator}
       />
-      {!hideArgumentSelector && !isBetween && (
-        <ArgumentSelector
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore: this component doesn't have types or propTypes
-          value={filterArguments}
-          onChange={changeArguments}
-          className="input"
-          fields={[field]}
-          multi={!!filter?.operator()?.multi}
-          showOptionsInPopover
-        />
-      )}
-      {isBetween && (
-        <BetweenContainer>
-          <NumberInput
-            placeholder={t`min`}
-            value={filterArguments[0] ?? ""}
-            onChange={e =>
-              changeArguments([e.target.value, filterArguments[1]])
-            }
-            fullWidth
-          />
-          <NumberSeparator>{t`and`}</NumberSeparator>
-          <NumberInput
-            placeholder={t`max`}
-            value={filterArguments[1] ?? ""}
-            onChange={e =>
-              changeArguments([filterArguments[0], e.target.value])
-            }
-            fullWidth
-          />
-        </BetweenContainer>
+      {!hideArgumentSelector && (
+        <ValuesInput filter={filter} field={field} onChange={changeArguments} />
       )}
     </ValuesPickerContainer>
+  );
+}
+
+interface ValuesInputTypes {
+  onChange: (newArguments: (string | number)[]) => void;
+  filter: Filter;
+  field: Field;
+}
+
+function ValuesInput({
+  onChange,
+  field,
+  filter,
+}: ValuesInputTypes): JSX.Element {
+  const isBetween =
+    filter.operatorName() === "between" &&
+    filter?.operator()?.fields.length === 2;
+
+  const filterArguments = filter.arguments() ?? [];
+
+  if (!isBetween) {
+    return (
+      <ArgumentSelector
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore: this component doesn't have types or propTypes
+        value={filterArguments}
+        onChange={onChange}
+        className="input"
+        fields={[field]}
+        multi={!!filter?.operator()?.multi}
+        showOptionsInPopover
+      />
+    );
+  }
+
+  return (
+    <BetweenContainer>
+      <NumberInput
+        placeholder={t`min`}
+        value={filterArguments[0] ?? ""}
+        onChange={e => onChange([e.target.value, filterArguments[1]])}
+        fullWidth
+      />
+      <NumberSeparator>{t`and`}</NumberSeparator>
+      <NumberInput
+        placeholder={t`max`}
+        value={filterArguments[1] ?? ""}
+        onChange={e => onChange([filterArguments[0], e.target.value])}
+        fullWidth
+      />
+    </BetweenContainer>
   );
 }

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineValuePicker/InlineValuePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineValuePicker/InlineValuePicker.tsx
@@ -52,8 +52,8 @@ export function InlineValuePicker({
         onChange={changeArguments}
         className="input"
         fields={[field]}
+        multi={!!filter?.operator()?.multi}
         showOptionsInPopover
-        multi
       />
     </ValuesPickerContainer>
   );

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineValuePicker/InlineValuePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineValuePicker/InlineValuePicker.tsx
@@ -48,7 +48,7 @@ export function InlineValuePicker({
   const isBetween =
     filter.operatorName() === "between" &&
     filter?.operator()?.fields.length === 2;
-  const filterArguments = filter.arguments();
+  const filterArguments = filter.arguments() ?? [];
 
   return (
     <ValuesPickerContainer
@@ -75,6 +75,7 @@ export function InlineValuePicker({
       {isBetween && (
         <BetweenContainer>
           <NumberInput
+            placeholder={t`min`}
             value={filterArguments[0] ?? ""}
             onChange={e =>
               changeArguments([e.target.value, filterArguments[1]])
@@ -83,7 +84,8 @@ export function InlineValuePicker({
           />
           <NumberSeparator>{t`and`}</NumberSeparator>
           <NumberInput
-            value={filter.arguments()[1] ?? ""}
+            placeholder={t`max`}
+            value={filterArguments[1] ?? ""}
             onChange={e =>
               changeArguments([filterArguments[0], e.target.value])
             }

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineValuePicker/InlineValuePicker.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineValuePicker/InlineValuePicker.unit.spec.tsx
@@ -275,4 +275,27 @@ describe("InlineValuePicker", () => {
     // reads commas as part of the input instead of token separators
     expect(lastCall[2]).toEqual("foo,bar,");
   });
+
+  it("shows multiple inputs for between filters", async () => {
+    const testFilter = new Filter(
+      ["between", ["field", pkField.id, null], 14, 74],
+      null,
+      query,
+    );
+    const changeSpy = jest.fn();
+
+    render(
+      <Provider store={store}>
+        <InlineValuePicker
+          filter={testFilter}
+          field={pkField}
+          handleChange={changeSpy}
+        />
+      </Provider>,
+    );
+
+    screen.getByText("Between");
+    screen.getByPlaceholderText("min");
+    screen.getByPlaceholderText("max");
+  });
 });

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineValuePicker/InlineValuePicker.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineValuePicker/InlineValuePicker.unit.spec.tsx
@@ -298,4 +298,31 @@ describe("InlineValuePicker", () => {
     screen.getByPlaceholderText("min");
     screen.getByPlaceholderText("max");
   });
+
+  const noValueOperators = ["is-null", "not-null", "is-empty", "not-empty"];
+
+  noValueOperators.forEach(op => {
+    it(`hides value input for ${op} empty operator`, () => {
+      const testFilter = new Filter(
+        [op, ["field", textField.id, null]],
+        null,
+        query,
+      );
+      const changeSpy = jest.fn();
+
+      render(
+        <Provider store={store}>
+          <InlineValuePicker
+            filter={testFilter}
+            field={textField}
+            handleChange={changeSpy}
+          />
+        </Provider>,
+      );
+
+      expect(
+        screen.queryByPlaceholderText("Enter some text"),
+      ).not.toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/test/metabase/scenarios/filters/filter-bulk.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/filter-bulk.cy.spec.js
@@ -547,6 +547,29 @@ describe("scenarios > filters > bulk filtering", () => {
       });
       cy.findByText("Showing 12 rows").should("be.visible");
     });
+
+    it("adds multiple is text filters", () => {
+      modal().within(() => {
+        cy.findByLabelText("Title").within(() => {
+          cy.findByText("Is").click();
+        });
+      });
+
+      popover().within(() => {
+        cy.findByText("Ends with").click();
+      });
+
+      modal().within(() => {
+        cy.findByLabelText("Title").within(() => {
+          cy.findByPlaceholderText("Enter some text").type(
+            "Small Marble Shoes,Rustic Paper Wallet",
+          );
+        });
+        cy.button("Apply").click();
+      });
+      cy.findByText("Title is 2 selections").should("be.visible");
+      cy.findByText("Showing 2 rows").should("be.visible");
+    });
   });
 });
 

--- a/frontend/test/metabase/scenarios/filters/filter-bulk.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/filter-bulk.cy.spec.js
@@ -551,17 +551,17 @@ describe("scenarios > filters > bulk filtering", () => {
     it("adds multiple is text filters", () => {
       modal().within(() => {
         cy.findByLabelText("Title").within(() => {
-          cy.findByText("Is").click();
+          cy.findByText("Contains").click();
         });
       });
 
       popover().within(() => {
-        cy.findByText("Ends with").click();
+        cy.findByText("Is").click();
       });
 
       modal().within(() => {
         cy.findByLabelText("Title").within(() => {
-          cy.findByPlaceholderText("Enter some text").type(
+          cy.findByPlaceholderText("Search by Title").type(
             "Small Marble Shoes,Rustic Paper Wallet",
           );
         });


### PR DESCRIPTION
## Description

Certain field value operators have effects on the value picker, and this makes the InlineValuePicker sensitive to these cases:
- `empty`/`not empty` operators don't take value parameters
- `is`/`is not` operators can have multiple arguments, other operators can only have a single argument
- `between` operator shows 2 inputs

![Screen Shot 2022-06-23 at 1 28 47 PM](https://user-images.githubusercontent.com/30528226/175381683-21ce246e-45f3-49e3-8bd2-0c1686af4906.png)

## Testing Steps

- open a table, like people, that has text or key fields
- see that single-value operators for text fields only take a single input value (pressing comma does not tokenize multiple values): `contains`, `starts with`, `ends with`
- see that multi-value operators take multiple values: `is`, `is-not`
- see that null/empty operators, if selected, hide the field value input field
- see that `between` operator on a key field shows 2 inputs
