### PR TITLE
Expand native query's text with the embedded snippet

### DIFF
--- a/frontend/src/metabase-lib/lib/queries/NativeQuery.ts
+++ b/frontend/src/metabase-lib/lib/queries/NativeQuery.ts
@@ -301,6 +301,7 @@ export default class NativeQuery extends AtomicQuery {
 
   validateTemplateTags() {
     return this.templateTags()
+      .filter(tag => tag.type !== "card")
       .map(tag => {
         const dimension = new TemplateTagDimension(
           tag.name,
@@ -532,4 +533,13 @@ export function recognizeTemplateTags(queryText: string): string[] {
 
   // eliminate any duplicates since it's allowed for a user to reference the same variable multiple times
   return _.uniq(tagNames);
+}
+
+export function parseTemplateTags(queryText: string): TemplateTags {
+  const tags = recognizeTemplateTags(queryText);
+  const templateTags = tags.reduce((map, tagName) => {
+    map[tagName] = createTemplateTag(tagName);
+    return map;
+  }, {});
+  return templateTags;
 }

--- a/frontend/src/metabase/entities/snippets.js
+++ b/frontend/src/metabase/entities/snippets.js
@@ -3,6 +3,7 @@ import { t } from "ttag";
 import { createEntity } from "metabase/lib/entities";
 import validate from "metabase/lib/validate";
 import { canonicalCollectionId } from "metabase/collections/utils";
+import { parseTemplateTags } from "metabase-lib/lib/queries/NativeQuery";
 
 const formFields = [
   {
@@ -47,6 +48,7 @@ const Snippets = createEntity({
           hidden: true,
         },
       ],
+      normalize: normalizeForm,
     },
     withVisibleCollectionPicker: {
       fields: [
@@ -58,8 +60,16 @@ const Snippets = createEntity({
           normalize: canonicalCollectionId,
         },
       ],
+      normalize: normalizeForm,
     },
   },
 });
+
+function normalizeForm(snippet) {
+  return {
+    ...snippet,
+    template_tags: parseTemplateTags(snippet.content),
+  };
+}
 
 export default Snippets;

--- a/frontend/src/metabase/entities/snippets.js
+++ b/frontend/src/metabase/entities/snippets.js
@@ -39,6 +39,17 @@ const Snippets = createEntity({
     getFetched: (state, props) =>
       getFetched(state, props) || getObject(state, props),
   }),
+  actions: {
+    save: snippet => async dispatch => {
+      if (snippet.id) {
+        return dispatch(Snippets.actions.update(snippet));
+      } else {
+        const result = await dispatch(Snippets.actions.create(snippet));
+        await dispatch(Snippets.actions.fetchList({ reload: true }));
+        return result;
+      }
+    },
+  },
   forms: {
     withoutVisibleCollectionPicker: {
       fields: [

--- a/frontend/src/metabase/parameters/utils/cards.ts
+++ b/frontend/src/metabase/parameters/utils/cards.ts
@@ -16,6 +16,9 @@ import { Card } from "metabase-types/types/Card";
 import { TemplateTag } from "metabase-types/types/Query";
 import Metadata from "metabase-lib/lib/metadata/Metadata";
 
+import { recognizeTemplateTags } from "metabase-lib/lib/queries/NativeQuery";
+import { createTemplateTag } from "metabase-lib/lib/queries/TemplateTag";
+
 function getTemplateTagType(tag: TemplateTag) {
   const { type } = tag;
   if (type === "date") {
@@ -80,6 +83,7 @@ export function getSnippetsTemplateTags(card: Card, snippets: any[]) {
       }
       return interpolated;
     }, queryText);
+    return recognizeTemplateTags(expandedQueryText).map(createTemplateTag);
   }
 
   return [];
@@ -94,14 +98,14 @@ export function getTemplateTagsForParameters(card: Card, snippets = null) {
       ? Object.values(card.dataset_query.native["template-tags"])
       : [];
 
-  if (snippets) {
-    getSnippetsTemplateTags(card, snippets);
-  }
-
-  return templateTags.filter(
+  const filteredTags = templateTags.filter(
     // this should only return template tags that define a parameter of the card
     tag => tag.type !== "card" && tag.type !== "snippet",
   );
+
+  const snippetTags = snippets ? getSnippetsTemplateTags(card, snippets) : [];
+
+  return filteredTags.concat(snippetTags);
 }
 
 export function getParametersFromCard(

--- a/frontend/src/metabase/parameters/utils/cards.ts
+++ b/frontend/src/metabase/parameters/utils/cards.ts
@@ -59,7 +59,33 @@ export function getTemplateTagParameters(
     .map(getTemplateTagParameter);
 }
 
-export function getTemplateTagsForParameters(card: Card) {
+export function getSnippetsTemplateTags(card: Card, snippets: any[]) {
+  if (
+    Array.isArray(snippets) &&
+    card &&
+    card.dataset_query &&
+    card.dataset_query.type === "native"
+  ) {
+    const queryText = card.dataset_query.native.query;
+    const expandedQueryText = snippets.reduce((text, snippet) => {
+      const { name, content } = snippet;
+      let interpolated = text;
+      const marker = "{{snippet: " + name + "}}";
+      for (;;) {
+        const previous = interpolated;
+        interpolated = interpolated.replace(marker, content);
+        if (previous === interpolated) {
+          break;
+        }
+      }
+      return interpolated;
+    }, queryText);
+  }
+
+  return [];
+}
+
+export function getTemplateTagsForParameters(card: Card, snippets = null) {
   const templateTags: TemplateTag[] =
     card &&
     card.dataset_query &&
@@ -67,6 +93,10 @@ export function getTemplateTagsForParameters(card: Card) {
     card.dataset_query.native["template-tags"]
       ? Object.values(card.dataset_query.native["template-tags"])
       : [];
+
+  if (snippets) {
+    getSnippetsTemplateTags(card, snippets);
+  }
 
   return templateTags.filter(
     // this should only return template tags that define a parameter of the card

--- a/frontend/src/metabase/parameters/utils/cards.ts
+++ b/frontend/src/metabase/parameters/utils/cards.ts
@@ -105,7 +105,11 @@ export function getTemplateTagsForParameters(card: Card, snippets = null) {
 
   const snippetTags = snippets ? getSnippetsTemplateTags(card, snippets) : [];
 
-  return filteredTags.concat(snippetTags);
+  return filteredTags.concat(
+    snippetTags.filter(snippetTag => {
+      return !filteredTags.find(tag => tag.name === snippetTag.name);
+    }),
+  );
 }
 
 export function getParametersFromCard(

--- a/frontend/src/metabase/query_builder/actions/core/core.js
+++ b/frontend/src/metabase/query_builder/actions/core/core.js
@@ -21,6 +21,7 @@ import { loadMetadataForQueries } from "metabase/redux/metadata";
 import { getMetadata } from "metabase/selectors/metadata";
 
 import Questions from "metabase/entities/questions";
+import Snippets from "metabase/entities/snippets";
 import { fetchAlertsForQuestion } from "metabase/alert/alert";
 
 import Question from "metabase-lib/lib/Question";
@@ -315,7 +316,12 @@ export const updateQuestion = (
     const newDatasetQuery = newQuestion.query().datasetQuery();
     // Sync card's parameters with the template tags;
     if (newDatasetQuery.type === "native") {
-      const templateTags = getTemplateTagsForParameters(newQuestion.card());
+      await dispatch(Snippets.actions.fetchList());
+      const snippets = Snippets.selectors.getList(getState());
+      const templateTags = getTemplateTagsForParameters(
+        newQuestion.card(),
+        snippets,
+      );
       const parameters = getTemplateTagParameters(templateTags);
       newQuestion = newQuestion.setParameters(parameters);
     }

--- a/frontend/src/metabase/query_builder/actions/native.js
+++ b/frontend/src/metabase/query_builder/actions/native.js
@@ -6,6 +6,7 @@ import { createAction } from "redux-actions";
 import * as MetabaseAnalytics from "metabase/lib/analytics";
 import { createThunkAction } from "metabase/lib/redux";
 import Utils from "metabase/lib/utils";
+import Snippets from "metabase/entities/snippets";
 
 import {
   getNativeEditorCursorOffset,
@@ -143,10 +144,13 @@ export const setTemplateTag = createThunkAction(
         },
       );
 
+      const snippets = Snippets.selectors.getList(getState());
       return assoc(
         updatedTagsCard,
         "parameters",
-        getTemplateTagParameters(getTemplateTagsForParameters(updatedTagsCard)),
+        getTemplateTagParameters(
+          getTemplateTagsForParameters(updatedTagsCard, snippets),
+        ),
       );
     };
   },

--- a/frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx
@@ -1,7 +1,8 @@
 /* eslint-disable react/prop-types */
 import React from "react";
-
+import { connect } from "react-redux";
 import { t } from "ttag";
+import _ from "underscore";
 
 import Icon from "metabase/components/Icon";
 import Modal from "metabase/components/Modal";
@@ -17,12 +18,14 @@ class SnippetModal extends React.Component {
       closeModal,
       snippet,
       snippetCollections,
+      saveSnippet,
     } = this.props;
 
     return (
       <Modal onClose={closeModal}>
         <Snippets.ModalForm
           snippet={snippet}
+          onSubmit={saveSnippet}
           form={
             snippetCollections.length <= 1
               ? Snippets.forms.withoutVisibleCollectionPicker
@@ -65,4 +68,7 @@ class SnippetModal extends React.Component {
   }
 }
 
-export default SnippetCollections.loadList()(SnippetModal);
+export default _.compose(
+  SnippetCollections.loadList(),
+  connect(null, { saveSnippet: Snippets.actions.save }),
+)(SnippetModal);


### PR DESCRIPTION
To try this:

1. New, SQL query
2. Type  `select * from products where RATING >= {{stars}}` in the editor, and then press Snippets follow by `+`.
3. In the Create your new snippet dialog, name the snippet as e.g. _Good Products_.
The query text should be now changed into: `select * from {{snippet: Good Products}}`

Try to modify the query (to provoke `onChange` event), e.g. capitalize it to `SELECT * FROM {{snippet: Good Products}}`. As it happens, the new parameter named Stars (which exists in the snippet and not in the query itself) appears in the UI.

![image](https://user-images.githubusercontent.com/7288/176046078-d0d36f3b-6a95-4725-8de5-9a45536f61e9.png)




#### Behind the scene

This is to demonstrate the trick to expand the query text of a native query (in the front-end), when there are snippets in the query. This is part of the investigation of snippets parametrization.

Assuming there is a snippet named `Good Products` which has the content:

```sql
PRODUCTS where RATING >= {{stars}}
```
and it's being used in the following query:

```sql
SELECT * from {{snippet: Good Products}}
```

then the expansion, i.e. `expandedQueryText` will be:

```sql
SELECT * from PRODUCTS where RATING >= {{stars}}
```
