### PR TITLE
Updating Dashboard Action Menu, Moving bookmark action

### DIFF
--- a/frontend/src/metabase/components/EntityMenu.jsx
+++ b/frontend/src/metabase/components/EntityMenu.jsx
@@ -133,8 +133,8 @@ class EntityMenu extends Component {
                                   externalLink={item.externalLink}
                                   action={
                                     item.action &&
-                                    (() => {
-                                      item.action();
+                                    (e => {
+                                      item.action(e);
                                       this.toggleMenu();
                                     })
                                   }

--- a/frontend/src/metabase/components/Header.styled.tsx
+++ b/frontend/src/metabase/components/Header.styled.tsx
@@ -2,6 +2,7 @@ import styled from "@emotion/styled";
 import { css } from "@emotion/react";
 
 import LastEditInfoLabel from "metabase/components/LastEditInfoLabel";
+import Button from "metabase/core/components/Button";
 
 import { color } from "metabase/lib/colors";
 import {
@@ -96,6 +97,13 @@ export const HeaderButtonsContainer = styled.div<
   ${breakpointMaxSmall} {
     width: 100%;
     margin-bottom: 6px;
+  }
+
+  ${Button.Root} {
+    padding: 0.5rem 0.75rem;
+    &:hover {
+      color: ${color("brand")};
+    }
   }
 `;
 

--- a/frontend/src/metabase/dashboard/components/DashboardActions.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardActions.jsx
@@ -4,7 +4,6 @@ import { t } from "ttag";
 import cx from "classnames";
 
 import DashboardSharingEmbeddingModal from "../containers/DashboardSharingEmbeddingModal.jsx";
-import FullscreenIcon from "metabase/components/icons/FullscreenIcon";
 import Icon from "metabase/components/Icon";
 import MetabaseSettings from "metabase/lib/settings";
 import NightModeIcon from "metabase/components/icons/NightModeIcon";
@@ -25,7 +24,6 @@ export const getDashboardActions = (
     isNightMode,
     isPublic = false,
     onNightModeChange,
-    onFullscreenChange,
     refreshPeriod,
     setRefreshElapsedHook,
     onRefreshPeriodChange,
@@ -129,29 +127,6 @@ export const getDashboardActions = (
               className="text-brand-hover cursor-pointer"
               isNightMode={isNightMode}
               onClick={() => onNightModeChange(!isNightMode)}
-            />
-          </DashboardHeaderButton>
-        </span>
-      </Tooltip>,
-    );
-  }
-
-  if (!isEditing && !isEmpty) {
-    // option click to enter fullscreen without making the browser go fullscreen
-    buttons.push(
-      <Tooltip
-        key="fullscreen"
-        tooltip={isFullscreen ? t`Exit fullscreen` : t`Enter fullscreen`}
-      >
-        <span
-          data-metabase-event={"Dashboard;Fullscreen Mode;" + !isFullscreen}
-        >
-          <DashboardHeaderButton
-            onClick={e => onFullscreenChange(!isFullscreen, !e.altKey)}
-          >
-            <FullscreenIcon
-              className="text-brand-hover"
-              isFullscreen={isFullscreen}
             />
           </DashboardHeaderButton>
         </span>

--- a/frontend/src/metabase/dashboard/components/DashboardActions.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardActions.jsx
@@ -9,6 +9,7 @@ import MetabaseSettings from "metabase/lib/settings";
 import NightModeIcon from "metabase/components/icons/NightModeIcon";
 import RefreshWidget from "metabase/dashboard/components/RefreshWidget";
 import Tooltip from "metabase/components/Tooltip";
+import Button from "metabase/core/components/Button";
 
 import { DashboardHeaderButton } from "metabase/dashboard/containers/DashboardHeader.styled";
 
@@ -28,6 +29,7 @@ export const getDashboardActions = (
     setRefreshElapsedHook,
     onRefreshPeriodChange,
     onSharingClick,
+    onFullscreenChange,
   },
 ) => {
   const isPublicLinksEnabled = MetabaseSettings.get("enable-public-sharing");
@@ -129,6 +131,25 @@ export const getDashboardActions = (
               onClick={() => onNightModeChange(!isNightMode)}
             />
           </DashboardHeaderButton>
+        </span>
+      </Tooltip>,
+    );
+  }
+
+  if (!isEditing && !isEmpty && isFullscreen) {
+    // option click to enter fullscreen without making the browser go fullscreen
+    buttons.push(
+      <Tooltip key="fullscreen" tooltip={t`Exit fullscreen`}>
+        <span
+          data-metabase-event={"Dashboard;Fullscreen Mode;" + !isFullscreen}
+        >
+          <Button
+            onClick={e => onFullscreenChange(!isFullscreen, !e.altKey)}
+            borderless
+            icon="contract"
+            iconSize={16}
+            onlyIcon
+          />
         </span>
       </Tooltip>,
     );

--- a/frontend/src/metabase/dashboard/components/DashboardBookmark.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardBookmark.tsx
@@ -1,0 +1,35 @@
+import React, { useCallback } from "react";
+import BookmarkToggle from "metabase/core/components/BookmarkToggle";
+import { Dashboard } from "metabase-types/api";
+
+export interface DashboardBookmarkProps {
+  dashboard: Dashboard;
+  isBookmarked: boolean;
+  onCreateBookmark: (dashboard: Dashboard) => void;
+  onDeleteBookmark: (dashboard: Dashboard) => void;
+}
+
+const DashboardBookmark = ({
+  dashboard,
+  isBookmarked,
+  onCreateBookmark,
+  onDeleteBookmark,
+}: DashboardBookmarkProps): JSX.Element | null => {
+  const handleCreateBookmark = useCallback(() => {
+    onCreateBookmark(dashboard);
+  }, [dashboard, onCreateBookmark]);
+
+  const handleDeleteBookmark = useCallback(() => {
+    onDeleteBookmark(dashboard);
+  }, [dashboard, onDeleteBookmark]);
+
+  return (
+    <BookmarkToggle
+      isBookmarked={isBookmarked}
+      onCreateBookmark={handleCreateBookmark}
+      onDeleteBookmark={handleDeleteBookmark}
+    />
+  );
+};
+
+export default DashboardBookmark;

--- a/frontend/src/metabase/dashboard/containers/DashboardHeader.styled.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardHeader.styled.jsx
@@ -23,3 +23,9 @@ export const DashboardHeaderButton = styled.button`
     color: ${color("text-light")};
   }
 `;
+
+export const DashboardHeaderActionContainer = styled.div`
+  display: flex;
+  padding-left: 0.5rem;
+  border-left: 1px solid ${color("border")};
+`;

--- a/frontend/test/metabase-visual/dashboard/fullscreen.cy.spec.js
+++ b/frontend/test/metabase-visual/dashboard/fullscreen.cy.spec.js
@@ -51,7 +51,11 @@ describe("visual tests > dashboard > fullscreen", () => {
   });
 
   it("renders in day mode and night mode", () => {
-    cy.icon("expand").click();
+    cy.get("main header").within(() => {
+      cy.icon("ellipsis").click();
+    });
+
+    cy.findAllByText("Enter fullscreen").click();
 
     cy.icon("moon");
 
@@ -62,5 +66,7 @@ describe("visual tests > dashboard > fullscreen", () => {
     cy.icon("sun");
 
     cy.percySnapshot("night");
+
+    cy.icon("contract").click();
   });
 });

--- a/frontend/test/metabase/scenarios/collections/revision-history.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/revision-history.cy.spec.js
@@ -107,6 +107,7 @@ describe("revision history", () => {
               cy.findByText("This dashboard is looking empty.");
 
               // Should be able to revert back again
+              openRevisionHistory();
               cy.findByText("Revision history").click();
               clickRevert("rearranged the cards");
 

--- a/frontend/test/metabase/scenarios/dashboard/bookmarks.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/bookmarks.cy.spec.js
@@ -16,20 +16,16 @@ describe("scenarios > dashboard > bookmarks", () => {
     openNavigationSidebar();
 
     cy.get("main header").within(() => {
-      cy.icon("ellipsis").click();
+      cy.icon("bookmark").click();
     });
-
-    cy.findByText("Bookmark").click();
 
     navigationSidebar().within(() => {
       cy.findByText("Orders in a dashboard");
     });
 
     cy.get("main header").within(() => {
-      cy.icon("ellipsis").click();
+      cy.icon("bookmark").click();
     });
-
-    cy.findByText("Remove from bookmarks").click();
 
     navigationSidebar().within(() => {
       cy.findByText("Orders in a dashboard").should("not.exist");


### PR DESCRIPTION
EPIC #22826

First step for Updated actions in Dashboards. Updated to use `EntityMenu` component and moved bookmark action out to the header. Once the Info panel is built, History will be moved as well. Please note that  the "Edit Dashboard Details" is only temporary until the rest of the milestone is complete.

![image](https://user-images.githubusercontent.com/1328979/175454831-2035b53e-9f0e-4bd2-921e-37ea1097aa57.png)