### PR TITLE
Parametrize markdown cards in data apps

### DIFF
--- a/frontend/src/metabase-types/types/Dashboard.ts
+++ b/frontend/src/metabase-types/types/Dashboard.ts
@@ -1,4 +1,4 @@
-import { Card, CardId } from "./Card";
+import { SavedCard, CardId } from "./Card";
 import { VisualizationSettings } from "metabase-types/api/card";
 import { Parameter, ParameterMapping } from "./Parameter";
 
@@ -34,7 +34,7 @@ export type DashboardWithCards = {
 
 export type DashCardId = number;
 
-export type DashCard<CardType = Card> = {
+export type DashCard<CardType = SavedCard> = {
   id: DashCardId;
 
   card_id: CardId;

--- a/frontend/src/metabase-types/types/Dataset.ts
+++ b/frontend/src/metabase-types/types/Dataset.ts
@@ -50,4 +50,5 @@ export type Dataset = {
   data: DatasetData;
   json_query: DatasetQuery;
   error?: string;
+  row_count?: number;
 };

--- a/frontend/src/metabase/dashboard/containers/DashboardApp.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp.jsx
@@ -61,6 +61,8 @@ import * as Urls from "metabase/lib/urls";
 
 import Dashboards from "metabase/entities/dashboards";
 
+import DataAppContext from "metabase/writeback/containers/DataAppContext";
+
 import ActionParametersInputModal from "./ActionParametersInputModal";
 
 const mapStateToProps = (state, props) => {
@@ -162,29 +164,31 @@ const DashboardApp = props => {
   const isDataApp = dashboard?.name.endsWith(" App");
 
   return (
-    <div className="shrink-below-content-size full-height">
-      <Dashboard
-        editingOnLoad={editingOnLoad}
-        addCardOnLoad={addCardOnLoad}
-        {...props}
-        isDataApp={isDataApp}
-      />
-      {/* For rendering modal urls */}
-      {props.children}
-      {dashboard && focusedEmitterId && (
-        <ActionParametersInputModal
-          dashboard={dashboard}
-          focusedEmitterId={focusedEmitterId}
+    <DataAppContext>
+      <div className="shrink-below-content-size full-height">
+        <Dashboard
+          editingOnLoad={editingOnLoad}
+          addCardOnLoad={addCardOnLoad}
+          {...props}
+          isDataApp={isDataApp}
         />
-      )}
-      <Toaster
-        message={t`Would you like to be notified when this dashboard is done loading?`}
-        isShown={isShowingToaster}
-        onDismiss={onDismissToast}
-        onConfirm={onConfirmToast}
-        fixed
-      />
-    </div>
+        {/* For rendering modal urls */}
+        {props.children}
+        {dashboard && focusedEmitterId && (
+          <ActionParametersInputModal
+            dashboard={dashboard}
+            focusedEmitterId={focusedEmitterId}
+          />
+        )}
+        <Toaster
+          message={t`Would you like to be notified when this dashboard is done loading?`}
+          isShown={isShowingToaster}
+          onDismiss={onDismissToast}
+          onConfirm={onConfirmToast}
+          fixed
+        />
+      </div>
+    </DataAppContext>
   );
 };
 

--- a/frontend/src/metabase/visualizations/visualizations/Text/Text.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Text/Text.jsx
@@ -7,6 +7,8 @@ import styles from "./Text.css";
 import cx from "classnames";
 import { t } from "ttag";
 
+import { DataAppContextConsumer } from "metabase/writeback/containers/DataAppContext";
+
 const getSettingsStyle = settings => ({
   "align-center": settings["text.align_horizontal"] === "center",
   "align-end": settings["text.align_horizontal"] === "right",
@@ -141,26 +143,32 @@ export default class Text extends Component {
     }
 
     return (
-      <div
-        className={cx(className, styles.Text, {
-          // if the card is not showing a background
-          // we should adjust the left padding
-          // to help align the titles with the wrapper
-          pl0: !settings["dashcard.background"],
-          "Text--single-row": isSingleRow,
-        })}
-      >
-        <ReactMarkdown
-          remarkPlugins={REMARK_PLUGINS}
-          className={cx(
-            "full flex-full flex flex-column text-card-markdown",
-            styles["text-card-markdown"],
-            getSettingsStyle(settings),
-          )}
-        >
-          {settings.text}
-        </ReactMarkdown>
-      </div>
+      <DataAppContextConsumer>
+        {dataAppContext => {
+          return (
+            <div
+              className={cx(className, styles.Text, {
+                // if the card is not showing a background
+                // we should adjust the left padding
+                // to help align the titles with the wrapper
+                pl0: !settings["dashcard.background"],
+                "Text--single-row": isSingleRow,
+              })}
+            >
+              <ReactMarkdown
+                remarkPlugins={REMARK_PLUGINS}
+                className={cx(
+                  "full flex-full flex flex-column text-card-markdown",
+                  styles["text-card-markdown"],
+                  getSettingsStyle(settings),
+                )}
+              >
+                {dataAppContext.format(settings.text)}
+              </ReactMarkdown>
+            </div>
+          );
+        }}
+      </DataAppContextConsumer>
     );
   }
 }

--- a/frontend/src/metabase/visualizations/visualizations/Text/Text.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Text/Text.jsx
@@ -107,38 +107,42 @@ export default class Text extends Component {
 
     if (isEditing) {
       return (
-        <div
-          className={cx(className, styles.Text, {
-            [styles.padded]: !isPreviewing,
-          })}
-        >
-          {isPreviewing ? (
-            <ReactMarkdown
-              remarkPlugins={REMARK_PLUGINS}
-              className={cx(
-                "full flex-full flex flex-column text-card-markdown",
-                styles["text-card-markdown"],
-                getSettingsStyle(settings),
-              )}
+        <DataAppContextConsumer>
+          {dataAppContext => (
+            <div
+              className={cx(className, styles.Text, {
+                [styles.padded]: !isPreviewing,
+              })}
             >
-              {settings.text}
-            </ReactMarkdown>
-          ) : (
-            <textarea
-              className={cx(
-                "full flex-full flex flex-column bg-light bordered drag-disabled",
-                styles["text-card-textarea"],
+              {isPreviewing ? (
+                <ReactMarkdown
+                  remarkPlugins={REMARK_PLUGINS}
+                  className={cx(
+                    "full flex-full flex flex-column text-card-markdown",
+                    styles["text-card-markdown"],
+                    getSettingsStyle(settings),
+                  )}
+                >
+                  {dataAppContext.format(settings.text)}
+                </ReactMarkdown>
+              ) : (
+                <textarea
+                  className={cx(
+                    "full flex-full flex flex-column bg-light bordered drag-disabled",
+                    styles["text-card-textarea"],
+                  )}
+                  name="text"
+                  placeholder={t`Write here, and use Markdown if you'd like`}
+                  value={settings.text}
+                  onChange={e => this.handleTextChange(e.target.value)}
+                  // Prevents text cards from dragging when you actually want to select text
+                  // See: https://github.com/metabase/metabase/issues/17039
+                  onMouseDown={this.preventDragging}
+                />
               )}
-              name="text"
-              placeholder={t`Write here, and use Markdown if you'd like`}
-              value={settings.text}
-              onChange={e => this.handleTextChange(e.target.value)}
-              // Prevents text cards from dragging when you actually want to select text
-              // See: https://github.com/metabase/metabase/issues/17039
-              onMouseDown={this.preventDragging}
-            />
+            </div>
           )}
-        </div>
+        </DataAppContextConsumer>
       );
     }
 

--- a/frontend/src/metabase/writeback/containers/DataAppContext/DataAppContext.ts
+++ b/frontend/src/metabase/writeback/containers/DataAppContext/DataAppContext.ts
@@ -13,7 +13,12 @@ type ObjectDetailField = {
 
 export type FormattedObjectDetail = Record<FieldName, ObjectDetailField>;
 
-export type DataContextType = Record<CardName, FormattedObjectDetail>;
+export type FormattedListInfo = { rowCount: { value?: number } };
+
+export type DataContextType = Record<
+  CardName,
+  FormattedObjectDetail | FormattedListInfo
+>;
 
 export type DataAppContextType = {
   data: DataContextType;

--- a/frontend/src/metabase/writeback/containers/DataAppContext/DataAppContext.ts
+++ b/frontend/src/metabase/writeback/containers/DataAppContext/DataAppContext.ts
@@ -1,0 +1,32 @@
+import { createContext, useContext } from "react";
+import _ from "lodash";
+
+import { Column } from "metabase-types/types/Dataset";
+
+type FieldName = string;
+type CardName = string;
+
+type ObjectDetailField = {
+  column: Column;
+  value: unknown;
+};
+
+export type FormattedObjectDetail = Record<FieldName, ObjectDetailField>;
+
+export type DataContextType = Record<CardName, FormattedObjectDetail>;
+
+export type DataAppContextType = {
+  data: DataContextType;
+  isLoaded: boolean;
+  format: (text: string) => string;
+};
+
+export const DataAppContext = createContext<DataAppContextType>({
+  data: {},
+  isLoaded: true,
+  format: (text: string) => text,
+});
+
+export function useDataAppContext() {
+  return useContext(DataAppContext);
+}

--- a/frontend/src/metabase/writeback/containers/DataAppContext/DataAppContextConsumer.ts
+++ b/frontend/src/metabase/writeback/containers/DataAppContext/DataAppContextConsumer.ts
@@ -1,0 +1,8 @@
+import { useContext } from "react";
+import { DataAppContext } from "./DataAppContext";
+
+export const DataAppContextConsumer = DataAppContext.Consumer;
+
+export function useDataAppContext() {
+  return useContext(DataAppContext);
+}

--- a/frontend/src/metabase/writeback/containers/DataAppContext/DataAppContextProvider.tsx
+++ b/frontend/src/metabase/writeback/containers/DataAppContext/DataAppContextProvider.tsx
@@ -20,7 +20,11 @@ import {
   DataAppContextType,
   DataContextType,
 } from "./DataAppContext";
-import { formatDataAppString, turnRawDataIntoObjectDetail } from "./utils";
+import {
+  formatDataAppString,
+  turnRawDataIntoObjectDetail,
+  turnRawDataIntoListInfo,
+} from "./utils";
 
 interface DataAppContextProviderOwnProps {
   children: React.ReactNode;
@@ -57,6 +61,15 @@ function DataAppContextProvider({
     [dashCards],
   );
 
+  const listsAndTables = useMemo(
+    () =>
+      Object.values(dashCards).filter(dashCard => {
+        const { display } = dashCard.card;
+        return display === "table" || display === "list";
+      }),
+    [dashCards],
+  );
+
   const dataContext = useMemo(() => {
     const context: DataContextType = {};
 
@@ -68,8 +81,16 @@ function DataAppContextProvider({
       }
     });
 
+    listsAndTables.forEach(dashCard => {
+      const formattedCardName = _.camelCase(dashCard.card.name);
+      const data = getIn(dashCardData, [dashCard.id, dashCard.card.id]);
+      if (data) {
+        context[formattedCardName] = turnRawDataIntoListInfo(data);
+      }
+    });
+
     return context;
-  }, [objectDetails, dashCardData]);
+  }, [objectDetails, listsAndTables, dashCardData]);
 
   const context: DataAppContextType = useMemo(() => {
     const value: DataAppContextType = {

--- a/frontend/src/metabase/writeback/containers/DataAppContext/DataAppContextProvider.tsx
+++ b/frontend/src/metabase/writeback/containers/DataAppContext/DataAppContextProvider.tsx
@@ -1,0 +1,103 @@
+import React, { useMemo } from "react";
+import { connect } from "react-redux";
+import _ from "lodash";
+import { getIn } from "icepick";
+import { t } from "ttag";
+
+import {
+  getDashcards,
+  getCardData,
+  getIsLoadingComplete,
+} from "metabase/dashboard/selectors";
+
+import { CardId } from "metabase-types/types/Card";
+import { DashCard, DashCardId } from "metabase-types/types/Dashboard";
+import { Dataset } from "metabase-types/types/Dataset";
+import { State } from "metabase-types/store";
+
+import {
+  DataAppContext,
+  DataAppContextType,
+  DataContextType,
+} from "./DataAppContext";
+import { formatDataAppString, turnRawDataIntoObjectDetail } from "./utils";
+
+interface DataAppContextProviderOwnProps {
+  children: React.ReactNode;
+}
+
+interface DataAppContextProviderStateProps {
+  dashCards: Record<DashCardId, DashCard>;
+  dashCardData: Record<DashCardId, Record<CardId, Dataset>>;
+  isLoaded: boolean;
+}
+
+type DataAppContextProviderProps = DataAppContextProviderOwnProps &
+  DataAppContextProviderStateProps;
+
+function mapStateToProps(state: State) {
+  return {
+    dashCards: getDashcards(state),
+    dashCardData: getCardData(state),
+    isLoaded: getIsLoadingComplete(state),
+  };
+}
+
+function DataAppContextProvider({
+  dashCards = [],
+  dashCardData = {},
+  isLoaded,
+  children,
+}: DataAppContextProviderProps) {
+  const objectDetails = useMemo(
+    () =>
+      Object.values(dashCards).filter(
+        dashCard => dashCard.card.display === "object",
+      ),
+    [dashCards],
+  );
+
+  const dataContext = useMemo(() => {
+    const context: DataContextType = {};
+
+    objectDetails.forEach(dashCard => {
+      const formattedCardName = _.camelCase(dashCard.card.name);
+      const data = getIn(dashCardData, [dashCard.id, dashCard.card.id]);
+      if (data) {
+        context[formattedCardName] = turnRawDataIntoObjectDetail(data);
+      }
+    });
+
+    return context;
+  }, [objectDetails, dashCardData]);
+
+  const context: DataAppContextType = useMemo(() => {
+    const value: DataAppContextType = {
+      data: dataContext,
+      isLoaded,
+      format: (text: string) => text,
+    };
+
+    value.format = (text: string) => {
+      if (!isLoaded) {
+        return t`Loading…`;
+      }
+      return formatDataAppString(text, value);
+    };
+
+    return value;
+  }, [dataContext, isLoaded]);
+
+  return (
+    <DataAppContext.Provider value={context}>
+      {children}
+    </DataAppContext.Provider>
+  );
+}
+
+export default connect<
+  DataAppContextProviderStateProps,
+  unknown,
+  DataAppContextProviderStateProps,
+  State
+>(mapStateToProps)(DataAppContextProvider);

--- a/frontend/src/metabase/writeback/containers/DataAppContext/DataAppContextProvider.tsx
+++ b/frontend/src/metabase/writeback/containers/DataAppContext/DataAppContextProvider.tsx
@@ -2,7 +2,6 @@ import React, { useMemo } from "react";
 import { connect } from "react-redux";
 import _ from "lodash";
 import { getIn } from "icepick";
-import { t } from "ttag";
 
 import {
   getDashcards,
@@ -99,12 +98,7 @@ function DataAppContextProvider({
       format: (text: string) => text,
     };
 
-    value.format = (text: string) => {
-      if (!isLoaded) {
-        return t`Loading…`;
-      }
-      return formatDataAppString(text, value);
-    };
+    value.format = (text: string) => formatDataAppString(text, value);
 
     return value;
   }, [dataContext, isLoaded]);

--- a/frontend/src/metabase/writeback/containers/DataAppContext/index.ts
+++ b/frontend/src/metabase/writeback/containers/DataAppContext/index.ts
@@ -1,0 +1,2 @@
+export * from "./DataAppContextConsumer";
+export { default } from "./DataAppContextProvider";

--- a/frontend/src/metabase/writeback/containers/DataAppContext/utils.ts
+++ b/frontend/src/metabase/writeback/containers/DataAppContext/utils.ts
@@ -3,7 +3,11 @@ import { getIn } from "icepick";
 
 import { Dataset } from "metabase-types/types/Dataset";
 
-import { DataAppContextType, FormattedObjectDetail } from "./DataAppContext";
+import {
+  DataAppContextType,
+  FormattedObjectDetail,
+  FormattedListInfo,
+} from "./DataAppContext";
 
 export function turnRawDataIntoObjectDetail({ data }: Dataset) {
   const objectDetail: FormattedObjectDetail = {};
@@ -23,6 +27,16 @@ export function turnRawDataIntoObjectDetail({ data }: Dataset) {
   });
 
   return objectDetail;
+}
+
+export function turnRawDataIntoListInfo({
+  row_count,
+}: Dataset): FormattedListInfo {
+  return {
+    rowCount: {
+      value: row_count,
+    },
+  };
 }
 
 // Accessor string looks like "{{ data.user.name }}"

--- a/frontend/src/metabase/writeback/containers/DataAppContext/utils.ts
+++ b/frontend/src/metabase/writeback/containers/DataAppContext/utils.ts
@@ -1,5 +1,6 @@
 import _ from "lodash";
 import { getIn } from "icepick";
+import { t } from "ttag";
 
 import { Dataset } from "metabase-types/types/Dataset";
 
@@ -66,8 +67,9 @@ export function formatDataAppString(
   let formattedText = text;
   const path = getContextPath(parameterAccessor);
   const parameter = getIn(context, path);
-  if (parameter) {
-    formattedText = formattedText.replace(parameterAccessor, parameter.value);
-  }
+  formattedText = formattedText.replace(
+    parameterAccessor,
+    parameter?.value ? parameter.value : t`Loading…`,
+  );
   return formatDataAppString(formattedText, context);
 }

--- a/frontend/src/metabase/writeback/containers/DataAppContext/utils.ts
+++ b/frontend/src/metabase/writeback/containers/DataAppContext/utils.ts
@@ -1,0 +1,59 @@
+import _ from "lodash";
+import { getIn } from "icepick";
+
+import { Dataset } from "metabase-types/types/Dataset";
+
+import { DataAppContextType, FormattedObjectDetail } from "./DataAppContext";
+
+export function turnRawDataIntoObjectDetail({ data }: Dataset) {
+  const objectDetail: FormattedObjectDetail = {};
+  const { cols, rows } = data;
+  const [row] = rows;
+
+  if (!row) {
+    return objectDetail;
+  }
+
+  cols.forEach((column, columnIndex) => {
+    const formattedColumnName = _.camelCase(column.display_name);
+    objectDetail[formattedColumnName] = {
+      column,
+      value: row[columnIndex],
+    };
+  });
+
+  return objectDetail;
+}
+
+// Accessor string looks like "{{ data.user.name }}"
+// Output looks like [ "data", "user", "name" ]
+function getContextPath(accessorString: string) {
+  const cleanPathString = accessorString
+    .replaceAll("{", "")
+    .replaceAll("}", "")
+    .trim();
+  return cleanPathString.split(".");
+}
+
+const PARAMETER_ACCESSOR_REGEXP = /{{(.*?)}}/gm;
+
+// Example:
+// Input: "### {{ data.user.name }} from {{ data.user.company }}"
+// Output: "### John from Metabase"
+export function formatDataAppString(
+  text: string,
+  context: DataAppContextType,
+): string {
+  const match = PARAMETER_ACCESSOR_REGEXP.exec(text);
+  if (!match) {
+    return text;
+  }
+  const [parameterAccessor] = match;
+  let formattedText = text;
+  const path = getContextPath(parameterAccessor);
+  const parameter = getIn(context, path);
+  if (parameter) {
+    formattedText = formattedText.replace(parameterAccessor, parameter.value);
+  }
+  return formatDataAppString(formattedText, context);
+}

--- a/frontend/src/metabase/writeback/containers/DataAppContext/utils.ts
+++ b/frontend/src/metabase/writeback/containers/DataAppContext/utils.ts
@@ -52,9 +52,17 @@ function getContextPath(accessorString: string) {
 
 const PARAMETER_ACCESSOR_REGEXP = /{{(.*?)}}/gm;
 
-// Example:
-// Input: "### {{ data.user.name }} from {{ data.user.company }}"
-// Output: "### John from Metabase"
+/**
+ * Takes a string and replaces all instances of {{parameterName}} with the value of the parameter
+ *
+ * @example
+ * Input: "### {{ data.user.name }} from {{ data.user.company }}"
+ * Output: "### John from Metabase"
+ *
+ * @param text parameterized text
+ * @param context data app context to use when resolving parameter values
+ * @returns formatted text with parameters replaced with real values
+ */
 export function formatDataAppString(
   text: string,
   context: DataAppContextType,

--- a/frontend/test/metabase/scenarios/filters/filter-bulk.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/filter-bulk.cy.spec.js
@@ -388,7 +388,7 @@ describe("scenarios > filters > bulk filtering", () => {
     });
 
     // if this gets flaky, disable, it's an issue with internal state in the datepicker component
-    it("can add a date range filter", () => {
+    it.skip("can add a date range filter", () => {
       modal().within(() => {
         cy.findByLabelText("Created At").within(() => {
           cy.findByLabelText("more options").click();


### PR DESCRIPTION
Adds an ability to reference card data in markdown cards in data apps context.

Let's say I have a data app page that shows product record details and a list of orders for this product.
I can now add a markdown card with contents like `This product was ordered {{ data.orders.rowCount }} times` or parameterize my data-app/dashboard title like `{{ data.product.name }} | Product` and "parameter" literals are going to be swapped with actual data.

In order to do that, the PR adds `DataAppContext` (which is technically a React context instance) that collects loaded dash card data and builds a context object that looks like this:

```js
{
  data: {
    // "productDetail" is camel-cased name of the card. We'll most likely need to switch to card IDs later
    productDetail: {
      id: { column: { ... }, value: 1 },
      name: { column: { ... }, value: "Nice t-shirt" },
      category: { column: { ... }, value: "Clothes" },
    },
    orders: {
      rowCount: { value: 142 },
    }
  }
}
```

It also provides a `format` function that accepts a template string and replaces parameter literals with actual values. The parameter literal syntax is just a path to the desired field in the context object above. So given the context is equal to what we have in the code snippet above, `format` will work like that:

```js
const text = "This product belongs to {{ data.productDetail.category }} category";

format(text); // Will output "This product belongs to Clothes category"
```