### PR TITLE
Removing Uberjar workflow cancel on concurrency

### DIFF
--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -9,10 +9,6 @@ on:
     - ".**"
     - "test*"
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   build:
     name: Build MB ${{ matrix.edition }}


### PR DESCRIPTION
When we had more than one job merged to master in a short period of time, the Uberjar.yaml was canceling the older one. This led to failed jobs.

This only removes the concurrency and will fully run for each merge on master.