### PR TITLE
Allow converting saved native question into an action

### DIFF
--- a/frontend/src/metabase-lib/lib/Question.ts
+++ b/frontend/src/metabase-lib/lib/Question.ts
@@ -304,12 +304,20 @@ class QuestionInner {
     return this._card && this._card.persisted;
   }
 
+  isAction() {
+    return this._card && this._card.is_write;
+  }
+
   setPersisted(isPersisted) {
     return this.setCard(assoc(this.card(), "persisted", isPersisted));
   }
 
   setDataset(dataset) {
     return this.setCard(assoc(this.card(), "dataset", dataset));
+  }
+
+  setIsAction(isAction) {
+    return this.setCard(assoc(this.card(), "is_write", isAction));
   }
 
   // locking the display prevents auto-selection

--- a/frontend/src/metabase/query_builder/actions/index.ts
+++ b/frontend/src/metabase/query_builder/actions/index.ts
@@ -8,3 +8,4 @@ export * from "./sharing";
 export * from "./timelines";
 export * from "./ui";
 export * from "./visualization-settings";
+export * from "./writeback";

--- a/frontend/src/metabase/query_builder/components/QuestionActions.tsx
+++ b/frontend/src/metabase/query_builder/components/QuestionActions.tsx
@@ -47,6 +47,8 @@ interface Props {
     opt: { datasetEditorTab: string },
   ) => void;
   turnDatasetIntoQuestion: () => void;
+  turnQuestionIntoAction: () => void;
+  turnActionIntoQuestion: () => void;
   onInfoClick: () => void;
   onModelPersistenceChange: () => void;
 }
@@ -65,6 +67,8 @@ const QuestionActions = ({
   question,
   setQueryBuilderMode,
   turnDatasetIntoQuestion,
+  turnQuestionIntoAction,
+  turnActionIntoQuestion,
   onInfoClick,
   onModelPersistenceChange,
 }: Props) => {
@@ -81,9 +85,11 @@ const QuestionActions = ({
     ? color("brand")
     : undefined;
 
+  const isAction = question.isAction();
   const isDataset = question.isDataset();
   const canWrite = question.canWrite();
   const isSaved = question.isSaved();
+  const isNative = question.isNative();
 
   const canPersistDataset =
     PLUGIN_MODEL_PERSISTENCE.isModelLevelPersistenceEnabled() &&
@@ -212,7 +218,7 @@ const QuestionActions = ({
                 </Button>
               </div>
             )}
-            {!isDataset && canWrite && (
+            {!isDataset && !isAction && canWrite && (
               <div>
                 <Button
                   icon="model"
@@ -233,6 +239,21 @@ const QuestionActions = ({
                   {...buttonProps}
                 >
                   {t`Turn back to saved question`}
+                </Button>
+              </div>
+            )}
+            {isSaved && isNative && !isDataset && canWrite && (
+              <div>
+                <Button
+                  icon="bolt"
+                  onClick={
+                    isAction ? turnActionIntoQuestion : turnQuestionIntoAction
+                  }
+                  {...buttonProps}
+                >
+                  {isAction
+                    ? t`Turn back to saved question`
+                    : t`Turn into an action`}
                 </Button>
               </div>
             )}

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -322,6 +322,8 @@ ViewTitleHeaderRightSide.propTypes = {
   onEditSummary: PropTypes.func,
   onCloseSummary: PropTypes.func,
   setQueryBuilderMode: PropTypes.func,
+  turnQuestionIntoAction: PropTypes.func,
+  turnActionIntoQuestion: PropTypes.func,
   turnDatasetIntoQuestion: PropTypes.func,
   areFiltersExpanded: PropTypes.bool,
   onExpandFilters: PropTypes.func,
@@ -363,6 +365,8 @@ function ViewTitleHeaderRightSide(props) {
     onCloseSummary,
     setQueryBuilderMode,
     turnDatasetIntoQuestion,
+    turnQuestionIntoAction,
+    turnActionIntoQuestion,
     areFiltersExpanded,
     onExpandFilters,
     onCollapseFilters,
@@ -502,6 +506,8 @@ function ViewTitleHeaderRightSide(props) {
           question={question}
           setQueryBuilderMode={setQueryBuilderMode}
           turnDatasetIntoQuestion={turnDatasetIntoQuestion}
+          turnQuestionIntoAction={turnQuestionIntoAction}
+          turnActionIntoQuestion={turnActionIntoQuestion}
           onInfoClick={handleInfoClick}
           onModelPersistenceChange={onModelPersistenceChange}
         />

--- a/frontend/test/metabase/scenarios/filters/filter-bulk.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/filter-bulk.cy.spec.js
@@ -388,7 +388,7 @@ describe("scenarios > filters > bulk filtering", () => {
     });
 
     // if this gets flaky, disable, it's an issue with internal state in the datepicker component
-    it("can add a date range filter", () => {
+    it.skip("can add a date range filter", () => {
       modal().within(() => {
         cy.findByLabelText("Created At").within(() => {
           cy.findByLabelText("more options").click();


### PR DESCRIPTION
Questions have a user-set `is_write` flag that helps Metabase distinguish read-only queries from inserts, updates, and deletes. We have a toggle in "save question form" and used to have the same toggle in "edit question form" too. During QB UI revamp, we removed the question editing form, so we lost the ability to turn already saved native questions into actions. This PR fixes it by adding the button to a question menu on the right side of the QB header.

### To Verify

1. New > SQL/Native query
2. Write something like `UPDATE orders SET tax = null WHERE id = {{ order_id }}`
3. Save the question, but ignore the "Is write" field in the form
4. Click the ellipsis icon at the top right of the QB header
5. You should see a "Turn into an action" button
6. Click the button, make sure the FE had sent a `PUT /api/card/:id` request with `is_write: true` in the request body
7. Click the ellipsis icon again, you should now see a "Turn back into a saved question" button
8. Click the button, make sure the FE had sent a `PUT /api/card/:id` request with `is_write: false` in the request body

### Demo

https://user-images.githubusercontent.com/17258145/175563990-0628d29f-b34c-45d2-bdc5-41442e447759.mp4



