### PR TITLE
Hide filter sidebar button

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx
@@ -14,7 +14,6 @@ import {
   HeaderButton,
   FilterHeaderContainer,
   FilterHeaderButton,
-  IconHeaderButton,
 } from "./ViewHeader.styled";
 
 import { color } from "metabase/lib/colors";
@@ -164,20 +163,12 @@ export function QuestionFilterWidget({
         large
         labelBreakpoint="sm"
         color={color("filter")}
-        active={isShowingFilterSidebar}
-        onClick={isShowingFilterSidebar ? onCloseFilter : onAddFilter}
-        data-metabase-event="View Mode; Open Filter Widget"
+        onClick={() => onOpenModal(MODAL_TYPES.FILTERS)}
+        aria-label={t`Show more filters`}
+        data-metabase-event="View Mode; Open Filter Modal"
       >
         {t`Filter`}
       </HeaderButton>
-      <IconHeaderButton
-        large
-        labelBreakpoint="sm"
-        color={color("filter")}
-        icon="ellipsis"
-        aria-label={t`Show more filters`}
-        onClick={() => onOpenModal(MODAL_TYPES.FILTERS)}
-      />
     </ButtonGroup>
   );
 }

--- a/frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx
@@ -17,7 +17,6 @@ import {
 } from "./ViewHeader.styled";
 
 import { color } from "metabase/lib/colors";
-import ButtonGroup from "metabase/core/components/ButtonGroup";
 
 const FilterPill = props => <ViewPill color={color("filter")} {...props} />;
 
@@ -150,26 +149,18 @@ export function FilterHeader({ className, question, expanded }) {
   );
 }
 
-export function QuestionFilterWidget({
-  className,
-  isShowingFilterSidebar,
-  onAddFilter,
-  onOpenModal,
-  onCloseFilter,
-}) {
+export function QuestionFilterWidget({ onOpenModal }) {
   return (
-    <ButtonGroup className={className}>
-      <HeaderButton
-        large
-        labelBreakpoint="sm"
-        color={color("filter")}
-        onClick={() => onOpenModal(MODAL_TYPES.FILTERS)}
-        aria-label={t`Show more filters`}
-        data-metabase-event="View Mode; Open Filter Modal"
-      >
-        {t`Filter`}
-      </HeaderButton>
-    </ButtonGroup>
+    <HeaderButton
+      large
+      labelBreakpoint="sm"
+      color={color("filter")}
+      onClick={() => onOpenModal(MODAL_TYPES.FILTERS)}
+      aria-label={t`Show more filters`}
+      data-metabase-event="View Mode; Open Filter Modal"
+    >
+      {t`Filter`}
+    </HeaderButton>
   );
 }
 

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.unit.spec.js
@@ -254,13 +254,12 @@ describe("ViewHeader", () => {
         });
 
         it("offers to filter query results", () => {
-          const { onAddFilter } = setup({
+          const { onOpenModal } = setup({
             question,
             queryBuilderMode: "view",
           });
           fireEvent.click(screen.getByText("Filter"));
-          fireEvent.click(screen.getByLabelText("Show more filters"));
-          expect(onAddFilter).toHaveBeenCalled();
+          expect(onOpenModal).toHaveBeenCalled();
         });
 
         it("offers to summarize query results", () => {

--- a/frontend/test/metabase-visual/admin/colors.cy.spec.js
+++ b/frontend/test/metabase-visual/admin/colors.cy.spec.js
@@ -47,8 +47,9 @@ describeEE("visual tests > admin > colors", () => {
     visitQuestionAdhoc(questionDetails);
     cy.percySnapshot("chart");
 
-    cy.findByText("Filter").click();
+    cy.icon("notebook").click();
     cy.percySnapshot("filters");
+    cy.icon("notebook").click();
 
     cy.findByText("Summarize").click();
     cy.percySnapshot("summarize");
@@ -66,8 +67,9 @@ describeEE("visual tests > admin > colors", () => {
     visitQuestionAdhoc(questionDetails);
     cy.percySnapshot("chart");
 
-    cy.findByText("Filter").click();
+    cy.icon("notebook").click();
     cy.percySnapshot("filters");
+    cy.icon("notebook").click();
 
     cy.findByText("Summarize").click();
     cy.percySnapshot("summarize");

--- a/frontend/test/metabase-visual/dashboard/filter-sidebar.cy.spec.js
+++ b/frontend/test/metabase-visual/dashboard/filter-sidebar.cy.spec.js
@@ -7,7 +7,7 @@ const questionDetails = {
   query: { "source-table": ORDERS_ID },
 };
 
-describe("visual tests > dashboard > filter sidebar", () => {
+describe.skip("visual tests > dashboard > filter sidebar", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();

--- a/frontend/test/metabase/scenarios/admin/datamodel/metrics.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/metrics.cy.spec.js
@@ -5,6 +5,7 @@ import {
   openOrdersTable,
   visualize,
   summarize,
+  filter,
 } from "__support__/e2e/helpers";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
@@ -162,12 +163,15 @@ describe("scenarios > admin > datamodel > metrics", () => {
       cy.get(".full")
         .find(".Button")
         .click();
-      cy.findByText("Filter").click();
-      cy.findByText("Total").click();
+
+      filter();
+
+      cy.findByLabelText("Total").click();
       cy.findByText("Equal to").click();
       cy.findByText("Greater than").click();
       cy.findByPlaceholderText("Enter a number").type("50");
       cy.findByText("Add filter").click();
+      cy.button("Apply").click();
       cy.findByText("Save").click();
       cy.findAllByText("Save")
         .last()

--- a/frontend/test/metabase/scenarios/admin/datamodel/segments.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/segments.cy.spec.js
@@ -1,5 +1,5 @@
 // Ported from `segments.e2e.spec.js`
-import { restore, popover, modal } from "__support__/e2e/helpers";
+import { restore, popover, modal, filter } from "__support__/e2e/helpers";
 
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
@@ -102,17 +102,13 @@ describe("scenarios > admin > datamodel > segments", () => {
       cy.visit("/reference/segments/1/questions");
       cy.get(".full .Button").click();
       cy.findAllByText("37.65");
-      cy.findAllByText("Filter")
-        .first()
-        .click();
-      cy.findByTestId("sidebar-right").within(() => {
-        cy.contains("Product ID").click();
-      });
-      cy.findByText("Cancel");
-      cy.findByPlaceholderText("Enter an ID")
+
+      filter();
+      cy.findByLabelText("Product ID")
+        .findByPlaceholderText("Enter an ID")
         .click()
         .type("14", { delay: 100 });
-      cy.findByText("Add filter").click();
+      cy.findByText("Apply").click();
       cy.findByText("Product ID is 14");
       cy.findByText("Save").click();
       cy.findAllByText("Save")

--- a/frontend/test/metabase/scenarios/embedding/embedding-full-app.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/embedding-full-app.cy.spec.js
@@ -61,7 +61,7 @@ describe("scenarios > embedding > full app", () => {
       cy.icon("refresh").should("be.visible");
       cy.icon("notebook").should("be.visible");
       cy.button("Summarize").should("be.visible");
-      cy.button("Filter").should("be.visible");
+      cy.findByText("Filter").should("be.visible");
     });
 
     it("should hide the question header by a param", () => {

--- a/frontend/test/metabase/scenarios/filters/filter-bulk.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/filter-bulk.cy.spec.js
@@ -2,7 +2,6 @@ import {
   popover,
   restore,
   visitQuestionAdhoc,
-  filter,
   setupBooleanQuery,
 } from "__support__/e2e/helpers";
 import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
@@ -284,12 +283,18 @@ describe("scenarios > filters > bulk filtering", () => {
     });
 
     it("should load already applied segments", () => {
-      visitQuestionAdhoc(rawQuestionDetails);
-      filter();
-      cy.findByText(SEGMENT_1_NAME).click();
+      const segmentFilterQuestion = {
+        dataset_query: {
+          database: SAMPLE_DB_ID,
+          type: "query",
+          query: {
+            "source-table": ORDERS_ID,
+            filter: ["segment", 1],
+          },
+        },
+      };
 
-      cy.findByTestId("qb-filters-panel").findByText(SEGMENT_1_NAME);
-
+      visitQuestionAdhoc(segmentFilterQuestion);
       openFilterModal();
 
       modal().within(() => {

--- a/frontend/test/metabase/scenarios/filters/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/filter.cy.spec.js
@@ -123,13 +123,13 @@ describe("scenarios > question > filter", () => {
     // Add filter as remapped Product ID (Product name)
     openOrdersTable();
     filter();
-    cy.get(".List-item-title")
-      .contains("Product ID")
-      .click();
-    cy.findByTestId("sidebar-content")
+    cy.findByLabelText("Product ID").click();
+    popover()
       .contains("Aerodynamic Linen Coat")
       .click();
     cy.findByText("Add filter").click();
+
+    cy.button("Apply").click();
 
     cy.log("Reported failing on v0.36.4 and v0.36.5.1");
     cy.findByTestId("loading-spinner").should("not.exist");
@@ -210,7 +210,7 @@ describe("scenarios > question > filter", () => {
     cy.findByText(AGGREGATED_FILTER);
   });
 
-  it("in a simple question should display popup for custom expression options (metabase#14341) (metabase#15244)", () => {
+  it.skip("in a simple question should display popup for custom expression options (metabase#14341) (metabase#15244)", () => {
     openProductsTable();
     filter();
     cy.findByText("Custom Expression").click();
@@ -594,8 +594,8 @@ describe("scenarios > question > filter", () => {
   });
 
   it("should reject a number literal", () => {
-    openProductsTable();
-    filter();
+    openProductsTable({ mode: "notebook" });
+    filter({ mode: "notebook" });
     cy.findByText("Custom Expression").click();
 
     enterCustomColumnDetails({ formula: "3.14159" });
@@ -606,8 +606,8 @@ describe("scenarios > question > filter", () => {
   });
 
   it("should reject a string literal", () => {
-    openProductsTable();
-    filter();
+    openProductsTable({ mode: "notebook" });
+    filter({ mode: "notebook" });
     cy.findByText("Custom Expression").click();
 
     enterCustomColumnDetails({ formula: '"TheAnswer"' });
@@ -955,7 +955,7 @@ describe("scenarios > question > filter", () => {
         assertOnTheResult();
       });
 
-      it("from the simple question (metabase#16386-2)", () => {
+      it.skip("from the simple question (metabase#16386-2)", () => {
         filter();
 
         cy.findByTestId("sidebar-right").within(() => {

--- a/frontend/test/metabase/scenarios/filters/relative-datetime.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/relative-datetime.cy.spec.js
@@ -25,7 +25,7 @@ describe("scenarios > question > relative-datetime", () => {
     cy.signInAsNormalUser();
   });
 
-  describe("sidebar", () => {
+  describe.skip("sidebar", () => {
     it("should go to field selection with one click", () => {
       openOrdersTable();
 

--- a/frontend/test/metabase/scenarios/filters/view.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/view.cy.spec.js
@@ -16,7 +16,7 @@ describe("scenarios > question > view", () => {
     cy.signInAsAdmin();
   });
 
-  describe("filter sidebar", () => {
+  describe.skip("filter sidebar", () => {
     it("should filter a table", () => {
       openOrdersTable();
       filter();

--- a/frontend/test/metabase/scenarios/joins/joins-2.cy.spec.js
+++ b/frontend/test/metabase/scenarios/joins/joins-2.cy.spec.js
@@ -98,8 +98,8 @@ describe("scenarios > question > joined questions", () => {
 
       cy.log("Attempt to filter on the joined table");
       filter();
-      cy.contains("Email").click();
-      cy.contains("People – Email");
+
+      cy.findByText("People - User").click();
       cy.findByPlaceholderText("Search by Email")
         .type("wo")
         .then($el => {
@@ -112,7 +112,7 @@ describe("scenarios > question > joined questions", () => {
           }
         });
       cy.findByText("wolf.dina@yahoo.com").click();
-      cy.button("Add filter").click();
+      cy.button("Apply").click();
       cy.contains("Showing 1 row");
     });
 

--- a/frontend/test/metabase/scenarios/models/models-revision-history.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models-revision-history.cy.spec.js
@@ -12,7 +12,6 @@ import {
   assertIsModel,
   assertQuestionIsBasedOnModel,
   selectFromDropdown,
-  selectDimensionOptionFromSidebar,
   saveQuestionBasedOnModel,
   assertIsQuestion,
 } from "./helpers/e2e-models-helpers";
@@ -49,10 +48,11 @@ describe("scenarios > models > revision history", () => {
     cy.get(".LineAreaBarChart");
 
     filter();
-    selectDimensionOptionFromSidebar("Discount");
+    cy.findByLabelText("Discount").click();
     cy.findByText("Equal to").click();
     selectFromDropdown("Not empty");
     cy.button("Add filter").click();
+    cy.button("Apply").click();
 
     cy.findByText("Save").click();
     modal().within(() => {
@@ -86,11 +86,12 @@ describe("scenarios > models > revision history", () => {
     cy.get(".LineAreaBarChart").should("not.exist");
 
     filter();
-    selectDimensionOptionFromSidebar("Count");
+    cy.findByLabelText("Count").click();
     cy.findByText("Equal to").click();
     selectFromDropdown("Greater than");
     cy.findByPlaceholderText("Enter a number").type("2000");
     cy.button("Add filter").click();
+    cy.button("Apply").click();
 
     assertQuestionIsBasedOnModel({
       model: "Orders Model",

--- a/frontend/test/metabase/scenarios/models/models.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models.cy.spec.js
@@ -46,10 +46,11 @@ describe("scenarios > models", () => {
     assertIsModel();
 
     filter();
-    selectDimensionOptionFromSidebar("Discount");
+    cy.findByLabelText("Discount").click();
     cy.findByText("Equal to").click();
     selectFromDropdown("Not empty");
     cy.button("Add filter").click();
+    cy.button("Apply").click();
 
     assertQuestionIsBasedOnModel({
       model: "Orders Model",
@@ -96,10 +97,11 @@ describe("scenarios > models", () => {
     assertIsModel();
 
     filter();
-    selectDimensionOptionFromSidebar("DISCOUNT");
+    cy.findByLabelText("DISCOUNT").click();
     cy.findByText("Equal to").click();
     selectFromDropdown("Not empty");
     cy.button("Add filter").click();
+    cy.button("Apply").click();
 
     assertQuestionIsBasedOnModel({
       model: "Orders Model",
@@ -307,10 +309,11 @@ describe("scenarios > models", () => {
       cy.wait("@dataset");
 
       filter();
-      selectDimensionOptionFromSidebar("Discount");
+      cy.findByLabelText("Discount").click();
       cy.findByText("Equal to").click();
       selectFromDropdown("Not empty");
       cy.button("Add filter").click();
+      cy.button("Apply").click();
 
       assertQuestionIsBasedOnModel({
         model: "Orders Model",

--- a/frontend/test/metabase/scenarios/native/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/native.cy.spec.js
@@ -6,6 +6,7 @@ import {
   visitQuestionAdhoc,
   summarize,
   sidebar,
+  filter,
 } from "__support__/e2e/helpers";
 
 import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
@@ -160,25 +161,20 @@ describe("scenarios > question > native", () => {
 
     cy.findByText("This has a value");
 
-    FILTERS.forEach(filter => {
+    FILTERS.forEach(operator => {
       cy.log("Apply a filter");
-      cy.findAllByText("Filter")
-        .first()
-        .click();
-      cy.get(".List-item-title")
-        .contains("V")
-        .click();
-      cy.findByText("Is").click();
+      filter();
+      cy.findByText("Contains").click();
       popover().within(() => {
-        cy.findByText(filter).click();
+        cy.findByText(operator).click();
       });
       cy.findByPlaceholderText("Enter some text").type("This has a value");
-      cy.findByText("Add filter").click();
+      cy.findByText("Apply").click();
 
       cy.log(
-        `**Mid-point assertion for "${filter}" filter| FAILING in v0.36.6**`,
+        `**Mid-point assertion for "${operator}" filter| FAILING in v0.36.6**`,
       );
-      cy.findByText(`V ${filter.toLowerCase()} This has a value`);
+      cy.findByText(`V ${operator.toLowerCase()} This has a value`);
       cy.findByText("No results!").should("not.exist");
 
       cy.log(

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -414,13 +414,11 @@ describe("scenarios > question > notebook", () => {
 
     cy.createQuestion(questionDetails, { visitQuestion: true });
 
-    cy.findByText("Filter").click();
-    cy.findByTestId("sidebar-right").within(() => {
-      cy.findByText("Max of Name").click();
+    filter();
+    cy.findByText("Summaries").click();
 
-      cy.findByText("Is").click();
-    });
-
+    cy.findByLabelText("Max of Name").click();
+    cy.findByText("Is").click();
     cy.findByText("Starts with").click();
 
     cy.findByText("Case sensitive").click();
@@ -439,13 +437,10 @@ describe("scenarios > question > notebook", () => {
 
     cy.createQuestion(questionDetails, { visitQuestion: true });
 
-    cy.findByText("Filter").click();
-    cy.findByTestId("sidebar-right").within(() => {
-      cy.findByText("Min of Vendor").click();
-
-      cy.findByText("Is").click();
-    });
-
+    filter();
+    cy.findByText("Summaries").click();
+    cy.findByLabelText("Min of Vendor").click();
+    cy.findByText("Is").click();
     cy.findByText("Ends with").click();
 
     cy.findByText("Case sensitive").click();

--- a/frontend/test/metabase/scenarios/question/saved.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/saved.cy.spec.js
@@ -8,6 +8,7 @@ import {
   startNewQuestion,
   visualize,
   openQuestionActions,
+  filter,
 } from "__support__/e2e/helpers";
 import {
   questionInfoButton,
@@ -154,17 +155,13 @@ describe("scenarios > question > saved", () => {
     cy.findByText("Saved Questions").click();
     cy.findByText("15808").click();
     visualize();
-    cy.findAllByText("Filter")
-      .first()
-      .click();
-    cy.findByTestId("sidebar-right")
-      .findByText(/Rating/i)
-      .click();
-    cy.findByTestId("select-button").findByText("Equal to");
+    filter();
+    cy.findByLabelText("RATING").click();
     cy.findByPlaceholderText("Enter a number").type("4");
     cy.button("Add filter")
       .should("not.be.disabled")
       .click();
+    cy.button("Apply").click();
     cy.findByText("Synergistic Granite Chair");
     cy.findByText("Rustic Paper Wallet").should("not.exist");
   });

--- a/frontend/test/metabase/scenarios/visualizations/reproductions/17524.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/reproductions/17524.cy.spec.js
@@ -77,7 +77,7 @@ describe("issue 17524", () => {
       cy.findByText("Greater than").click();
 
       cy.findByPlaceholderText("Enter an ID").type("1");
-      cy.button("Add filter").click();
+      cy.button("Apply").click();
 
       cy.get("polygon");
     });


### PR DESCRIPTION
We want to try going off the filter sidebar cold turkey before 0.44 releases. This removes the UI trigger to get into the filter sidebar and moves to using only the bulk filter modal. This updates the filter button to simply open the modal.

Before | After
--- | ---
![Screen Shot 2022-06-28 at 1 50 31 PM](https://user-images.githubusercontent.com/30528226/176272545-915442af-bdff-4c58-9eb6-50521ef21d3f.png) | ![Screen Shot 2022-06-24 at 1 15 23 PM](https://user-images.githubusercontent.com/30528226/175650490-f0908d11-65d2-4d7b-8e19-c52db423ed1a.png)

99% of the code changes here are tests. They come in two flavors:
1. some tested actual sidebar functionality, these have just been skipped, and can be removed when we actually remove the sidebar code
2. other tests were using the sidebar to test other functionality (e.g. being able to filter a model), these have been updated to use the filter modal

We'll wait to delete the actual sidebar and tests until we're 100% sure we want to go exclusively with the modal.
