### PR TITLE
Adjust date filter styling

### DIFF
--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineDatePicker/InlineDatePicker.styled.ts
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineDatePicker/InlineDatePicker.styled.ts
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 import { space } from "metabase/styled-components/theme";
-import { color, alpha } from "metabase/lib/colors";
+import { color, alpha, darken, lighten } from "metabase/lib/colors";
 
 import Button from "metabase/core/components/Button";
 
@@ -14,37 +14,36 @@ export const OptionContainer = styled.div`
 
 type OptionButtonProps = {
   primaryColor?: string;
-  selected?: boolean;
+  active?: boolean;
 };
 
 export const OptionButton = styled(Button)<OptionButtonProps>`
-  border-color: ${({ selected }) =>
-    selected ? color("brand") : color("border")};
   border-radius: ${space(1)};
   margin-right: ${space(1)};
   margin-bottom: ${space(1)};
-
-  background-color: ${({ selected }) =>
-    selected ? alpha("brand", 0.3) : color("white")};
-  color: ${({ selected, primaryColor = color("brand") }) =>
-    selected ? primaryColor : color("text-dark")};
-
   padding-top: ${space(1)};
   padding-bottom: ${space(1)};
 
+  background-color: ${({ active }) =>
+    active ? color("brand") : color("white")};
+  color: ${({ active }) => (active ? color("white") : color("text-dark"))};
+  border-color: ${({ active }) => (active ? "transparent" : color("border"))};
+
   &:hover {
-    background-color: ${({ selected }) =>
-      selected ? alpha("brand", 0.3) : color("white")};
-    border-color: ${color("brand")};
+    background-color: ${({ active }) =>
+      active ? alpha("brand", 0.8) : alpha("brand", 0.2)};
+    color: ${({ active }) => (active ? color("white") : color("text-dark"))};
+    border-color: ${({ active }) =>
+      active ? alpha("brand", 0.8) : color("transparent")};
   }
 `;
 
 export const ClearButton = styled.span`
-  color: ${alpha("brand", 0.5)};
+  color: ${lighten("brand", 0.5)};
   margin-left: ${space(1)};
   cursor: pointer;
 
   &:hover {
-    color: ${color("brand")};
+    color: ${color("white")};
   }
 `;

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineDatePicker/InlineDatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineDatePicker/InlineDatePicker.tsx
@@ -76,7 +76,7 @@ export function InlineDatePicker({
         DATE_SHORTCUT_OPTIONS.map(({ displayName, init }, index) => (
           <OptionButton
             key={displayName}
-            selected={index === selectedFilterIndex}
+            active={index === selectedFilterIndex}
             onClick={
               index === selectedFilterIndex
                 ? onClear
@@ -97,7 +97,7 @@ export function InlineDatePicker({
         handleClear={onClear}
         customTrigger={({ onClick }) =>
           filter && selectedFilterIndex === null ? (
-            <OptionButton selected onClick={onClick}>
+            <OptionButton active onClick={onClick}>
               <span>{filter.displayName({ includeDimension: false })}</span>
               <ClearButton onClick={handleClear}>
                 <Icon name="close" size={12} />


### PR DESCRIPTION
## Description 

some small adjustments to date filter color design:
- selected state has an opaque background
- hover state for unselected items is darker
- hover state for selected items is lighter
- changed the `selected` prop to be named `active` to be more consistent with similar components

--- Inactive ----- Hovered ------ Active
![Screen Shot 2022-06-24 at 3 34 03 PM](https://user-images.githubusercontent.com/30528226/175696629-aa6db239-3f8e-4e67-8a0d-e5c13457fcdb.png)

![Screen Shot 2022-06-24 at 3 39 18 PM](https://user-images.githubusercontent.com/30528226/175696601-ae1d55eb-03c6-479a-8ce7-6ba990d1b509.png)
