### PR TITLE
Ignore all unit tests in E2E workflows

### DIFF
--- a/.github/workflows/e2e-main.yml
+++ b/.github/workflows/e2e-main.yml
@@ -9,7 +9,7 @@ on:
       - "docs/**"
       - "**.md"
       - ".circleci/**"
-      - "**unit.spec.js"
+      - "**.unit.spec.*"
 
 jobs:
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -7,6 +7,7 @@ on:
       - "docs/**"
       - "**.md"
       - ".circleci/**"
+      - "**.unit.spec.*"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Ignores all unit tests in E2E workflows, as they can come in many flavors (.js, .jsx, .ts, .tsx)

### Resources:
- https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet

### Notes
- Testing in my fork, it turned out that `"**/*.unit.spec.{js,jsx,ts,tsx}"` will not work. Looking at the cheat sheet above, it's clear why. I've adapted and simplified the pattern, tested it in my fork and can confirm it works for all four variations of unit tests.