### PR TITLE
Remove diff logic from Percy job on `master`

### DIFF
--- a/.github/workflows/e2e-main.yml
+++ b/.github/workflows/e2e-main.yml
@@ -201,17 +201,6 @@ jobs:
         jar xf target/uberjar/metabase.jar version.properties
         mv version.properties resources/
     - name: Percy Test
-      run: |
-        CHANGED_SPECS=$(git diff --name-only origin/${{ github.base_ref }} origin/${{ github.head_ref }})
-        CYPRESS_SPECS=$(echo "$CHANGED_SPECS" | grep "metabase/scenarios")
-
-        if [ "$CHANGED_SPECS" == "" ]; then
-          echo "No files have been changed";
-        elif [ "$CHANGED_SPECS" == "$CYPRESS_SPECS" ]; then
-          echo "Not running Percy because the only changed files are Cypress E2E specs";
-        else
-          echo "Run Percy visual tests";
-          yarn run test-visual-run
-        fi
+      run: yarn run test-visual-run
       env:
         PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Fixes the flawed logic introduced in https://github.com/metabase/metabase/pull/23480 and removes the `diff` check all together

Example of the failure:
https://github.com/metabase/metabase/runs/7061902055?check_suite_focus=true

### Explanation:
tl;dr
The diff logic was suited for the `pull request` workflow, and we're trying to determine the diff on `push` in `master`.

Once a commit is already merged into `master`, GitHub environment variables `GITHUB.HEAD_REF` and `GITHUB.BASE_REF` don't work any more. The official GH docs have been updated on Jan 7, 2022 to explicitly reflect/explain this behavior.

I was trying different tricks like `git diff HEAD^^`, but every single attempt failed in my fork. My blind guess is that GitHub is missing the full context from the `.git` folder. Maybe we can copy it over and then do the diff, but that seems like a heavy hack.
Let's first run Percy on `master` for every new commit and see how much our usage will increase.