### PR TITLE
[CI] Increase `be-tests-java` timeout

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -44,7 +44,7 @@ jobs:
   be-tests:
     runs-on: ubuntu-20.04
     name: be-tests-java-${{ matrix.java-version }}-${{ matrix.edition }}
-    timeout-minutes: 15
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
AS @flamber noted, these jobs are timing out quite often now. Increasing the timeout to 20 minutes should take care of that.

![image](https://user-images.githubusercontent.com/31325167/175892054-27c62c67-bd7e-4c5c-98c4-cfb5ebcd9a36.png)
