### PR TITLE
[CI] Use `actions/checkout@v3` in all workflows

### DIFF
--- a/.github/workflows/auto-backport.yml
+++ b/.github/workflows/auto-backport.yml
@@ -8,7 +8,7 @@ jobs:
     if: github.event.pull_request.merged == true && (contains(github.event.pull_request.labels.*.name, 'backport') && github.event.action == 'closed' || github.event.label.name == 'backport')
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -51,7 +51,7 @@ jobs:
         edition: [oss, ee]
         java-version: [11, 17]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Prepare front-end environment
       uses: ./.github/actions/prepare-frontend
     - name: Prepare back-end environment

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -128,7 +128,7 @@ jobs:
     needs: create_pull_request
     if: ${{ failure() }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/notify-pull-request
         with:
           include-log: true


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Bumps the version of the `actions/checkout` action used in all workflows to `v3`

These workflows were the only ones that were still using `v2`. Every other has been on v3 already.

@ariya do you remember if there is a good reason we should NOT update this action?