### PR TITLE
Repro #23421: `visualization_settings` can break UI

### DIFF
--- a/frontend/test/metabase/scenarios/models/reproductions/23421-visualization-settins-breaks-ui.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/reproductions/23421-visualization-settins-breaks-ui.cy.spec.js
@@ -1,0 +1,35 @@
+import { restore, openQuestionActions } from "__support__/e2e/helpers";
+
+const query = 'SELECT 1 AS "id", current_timestamp::timestamp AS "created_at"';
+
+const questionDetails = {
+  native: {
+    query,
+  },
+  displayIsLocked: true,
+  visualization_settings: {
+    "table.columns": [],
+    "table.pivot_column": "orphaned1",
+    "table.cell_column": "orphaned2",
+  },
+  dataset: true,
+};
+
+describe.skip("issue 23421", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    cy.createNativeQuestion(questionDetails, { visitQuestion: true });
+  });
+
+  it("`visualization_settings` should not break UI (metabase#23421)", () => {
+    openQuestionActions();
+    cy.findByText("Edit query definition").click();
+
+    cy.get(".ace_content").should("contain", query);
+    cy.get(".cellData").should("have.length", 4);
+
+    cy.button("Save changes").should("be.disabled");
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #23421 

### How to test this manually?
- `yarn test-cypress-open`
- `metabase/scenarios/models/reproductions/23421-visualization-settings-breaks-ui.cy.spec.js`
- Unskip repro
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/175922569-100c64c0-bb12-41cf-9bea-fe77b2fc13bd.png)

Sanity check
If we omit `"table.columns": []` from the `visualization_settings` everything works
![image](https://user-images.githubusercontent.com/31325167/175922869-592766f4-7982-4eed-aa1c-4623090ff155.png)

