### PR TITLE
🍒  Manual backport of #23562

### DIFF
--- a/frontend/test/__support__/e2e/helpers/e2e-ui-elements-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-ui-elements-helpers.js
@@ -61,3 +61,7 @@ export function browse() {
 export function filterWidget() {
   return cy.get("fieldset");
 }
+
+export function openQuestionActions() {
+  cy.findByTestId("saved-question-header-button").click();
+}

--- a/frontend/test/metabase/scenarios/models/reproductions/23421-visualization-settins-breaks-ui.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/reproductions/23421-visualization-settins-breaks-ui.cy.spec.js
@@ -1,0 +1,35 @@
+import { restore, openQuestionActions } from "__support__/e2e/helpers";
+
+const query = 'SELECT 1 AS "id", current_timestamp::timestamp AS "created_at"';
+
+const questionDetails = {
+  native: {
+    query,
+  },
+  displayIsLocked: true,
+  visualization_settings: {
+    "table.columns": [],
+    "table.pivot_column": "orphaned1",
+    "table.cell_column": "orphaned2",
+  },
+  dataset: true,
+};
+
+describe.skip("issue 23421", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    cy.createNativeQuestion(questionDetails, { visitQuestion: true });
+  });
+
+  it("`visualization_settings` should not break UI (metabase#23421)", () => {
+    openQuestionActions();
+    cy.findByText("Edit query definition").click();
+
+    cy.get(".ace_content").should("contain", query);
+    cy.get(".cellData").should("have.length", 4);
+
+    cy.button("Save changes").should("be.disabled");
+  });
+});


### PR DESCRIPTION
Manual backport of #23562

I had to add `openQuestionActions` helper and to adapt it to the release branch because the UI changed in `master`. 

Adding this (adapted) helper should help with the next backports as well. In other words, tests written in `master` should "just work" in the release branch.