### PR TITLE
Bring back `static-viz` to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -495,6 +495,9 @@ jobs:
                echo '' > .CACHE-PREFIX
             fi
       - run:
+          name: Create static visualization js bundle
+          command: yarn build-static-viz
+      - run:
           name: 'Check for branch name to bust caches if it is a release branch'
           command: |
             if [[ $CIRCLE_BRANCH == release* || $CIRCLE_BRANCH == master  ]]; then


### PR DESCRIPTION
After merging https://github.com/metabase/metabase/pull/23553, some of the backend tests on the `master` branch started failing because they are missing the `static-viz` bundle.

This PR tries to fix that, but without the caching logic that we previously had. The imperative is to fix `master` asap, and then I will work on caching logic in the next PR.

Previously:
```
  run-yarn-command:
    parameters:
      command-name:
        type: string
      command:
        type: string
      before-steps:
        type: steps
        default: []
      after-steps:
        type: steps
        default: []
      skip-when-no-change:
        type: boolean
        default: false
    steps:
      - when:
          condition: << parameters.skip-when-no-change >>
          steps:
            - run-on-change:
                checksum: '{{ checksum ".FRONTEND-CHECKSUMS" }}'
                steps:
                  - restore-fe-deps-cache
                  - steps: << parameters.before-steps >>
                  - run:
                      name: << parameters.command-name >>
                      command: yarn << parameters.command >>
                      no_output_timeout: 15m
                  - steps: << parameters.after-steps >>
      - unless:
          condition: << parameters.skip-when-no-change >>
          steps:
            - restore-fe-deps-cache
            - steps: << parameters.before-steps >>
            - run:
                name: << parameters.command-name >>
                command: yarn << parameters.command >>
                no_output_timeout: 15m
            - steps: << parameters.after-steps >>
```