### PR TITLE
docs - mysql json note

### DIFF
--- a/docs/administration-guide/databases/mysql.md
+++ b/docs/administration-guide/databases/mysql.md
@@ -64,3 +64,12 @@ mysql:
       - $PWD/mysql:/var/lib/mysql
     command: ['--default-authentication-plugin=mysql_native_password']
 ```
+
+## Note on syncing records that include JSON
+
+1. **Metabase will infer the JSON "schema" based on the keys in the first five hundred rows of a table.** MySQL JSON fields lack schema, so Metabase can't rely on table metadata to define which keys a JSON field has. To work around the lack of schema, Metabase will get the first five hundred records and parse the JSON in those records to infer the JSON's "schema". The reason Metabase limits itself to five hundred records is so that syncing metadata doesn't put unnecessary strain on your database.
+
+The problem is that if the keys in the JSON vary record to record, the first five hundred rows may not capture all the keys used by JSON objects in that JSON field. To get Metabase to infer all the JSON keys, you'll need to add the additional keys to the JSON objects in the first five hundred rows.
+
+2. **This JSON support doesn't work with MariaDB**, due to implementation differences between MySQL and MariaDB.
+

--- a/docs/administration-guide/databases/postgresql.md
+++ b/docs/administration-guide/databases/postgresql.md
@@ -101,9 +101,9 @@ This enables Metabase to scan for additional field values during syncs allowing 
 
 ## Note on syncing records that include JSON
 
-Postgres JSON fields don’t have schema, so Metabase can’t rely on table metadata to define which keys a JSON field has. To work around the lack of schema, Metabase will get the first ten thousand records and parse the JSON in those records to infer the JSON's "schema". The reason Metabase limits itself to ten thousand records is so that syncing metadata doesn't put unnecessary strain on your database.
+**Metabase will infer the JSON "schema" based on the keys in the first five hundred rows of a table.** PostgreSQL JSON fields lack schema, so Metabase can’t rely on table metadata to define which keys a JSON field has. To work around the lack of schema, Metabase will get the first five hundred records and parse the JSON in those records to infer the JSON's "schema". The reason Metabase limits itself to five hundred records is so that syncing metadata doesn't put unnecessary strain on your database.
 
-The problem is that if the keys in the JSON vary record to record, the first ten thousand rows may not capture all the keys used by JSON objects in that JSON field. To get Metabase to infer all the JSON keys, you'll need to add the additional keys to the JSON objects in the first ten thousand row.
+The problem is that if the keys in the JSON vary record to record, the first five hundred rows may not capture all the keys used by JSON objects in that JSON field. To get Metabase to infer all the JSON keys for that table, you'll need to add the additional keys to the JSON objects in the first five hundred rows.
 
 [ssl-modes]: https://jdbc.postgresql.org/documentation/head/ssl-client.html
 [ssh-tunnel]: ../ssh-tunnel-for-database-connections.html


### PR DESCRIPTION
- Adds note to MySQL page regarding JSON sync.
- Updates postgres page to specify 500 records (see https://github.com/metabase/metabase/pull/22662).

There is some repeated text here, but the duplication is probably okay for now. If we support JSON in more databases, we can consider creating a dedicated JSON page.