### PR TITLE
Make new color palette colors always hex

### DIFF
--- a/frontend/src/metabase/lib/colors/palette.ts
+++ b/frontend/src/metabase/lib/colors/palette.ts
@@ -108,10 +108,10 @@ export const darken = (c: string, f: number = 0.25) => {
 
 export const tint = (c: string, f: number = 0.125) => {
   const value = Color(color(c));
-  return value.lightness(value.lightness() + f * 100).string();
+  return value.lightness(value.lightness() + f * 100).hex();
 };
 
 export const shade = (c: string, f: number = 0.125) => {
   const value = Color(color(c));
-  return value.lightness(value.lightness() - f * 100).string();
+  return value.lightness(value.lightness() - f * 100).hex();
 };


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/22816

How to test
- Open a saved `Line` question
- Go to Settings -> Display and change the series color
- Make sure that every color is saved in hex