### PR TITLE
Relax the version restriction for Node.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/metabase/metabase",
   "license": "private",
   "engines": {
-    "node": ">=14.2 <17",
+    "node": ">=14.2",
     "yarn": ">=1.12.3"
   },
   "dependencies": {


### PR DESCRIPTION
Currently using Node.js v18 works fine on Mac, but not on Linux, due to the following error:

```
[js] ERROR in ./app-embed.js
[js] Module build failed (from ../../../node_modules/babel-loader/lib/index.js):
[js] Error: error:0308010C:digital envelope routines::unsupported
[js]     at new Hash (node:internal/crypto/hash:67:19)
[js]     at Object.createHash (node:crypto:133:10)
```

This is likely due to some webpack and/or babel-loader issue. Thus, let's be optimistic and assume that this issue will be resolved soon (few weeks). In the mean, Linux developers can continue to stay with v16 instead of v18.