### PR TITLE
Handle null categories in InlineCategoryPicker

### DIFF
--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineCategoryPicker/InlineCategoryPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineCategoryPicker/InlineCategoryPicker.tsx
@@ -136,11 +136,11 @@ export function SimpleCategoryFilterPicker({
       <PickerGrid>
         {options.map((option: string | number) => (
           <Checkbox
-            key={option.toString()}
+            key={option?.toString() ?? "empty"}
             checked={filterValues.includes(option)}
             onChange={e => handleChange(option, e.target.checked)}
             checkedColor="accent2"
-            label={option.toString()}
+            label={option?.toString() ?? t`empty`}
           />
         ))}
       </PickerGrid>


### PR DESCRIPTION
## Before

Modal would crash with a `null` category option 😞 

## After

- Modal doesn't crash 😁 
- Null options are displayed as "empty"

![Screen Shot 2022-06-27 at 1 51 52 PM](https://user-images.githubusercontent.com/30528226/176024274-9a452e59-88bc-4e5f-8677-b8ba32d9d42b.png)

