### PR TITLE
Allow additional join conditions in the query editor

### DIFF
--- a/frontend/src/metabase/core/components/Select/Select.jsx
+++ b/frontend/src/metabase/core/components/Select/Select.jsx
@@ -33,6 +33,7 @@ class Select extends Component {
     multiple: PropTypes.bool,
     placeholder: PropTypes.string,
     disabled: PropTypes.bool,
+    hiddenIcons: PropTypes.bool,
 
     // PopoverWithTrigger props
     isInitiallyOpen: PropTypes.bool,
@@ -49,6 +50,7 @@ class Select extends Component {
     searchPlaceholder: PropTypes.string,
     searchFuzzy: PropTypes.bool,
     hideEmptySectionsInSearch: PropTypes.bool,
+    width: PropTypes.number,
 
     optionNameFn: PropTypes.func,
     optionValueFn: PropTypes.func,
@@ -149,6 +151,10 @@ class Select extends Component {
   };
 
   renderItemIcon = item => {
+    if (this.props.hiddenIcons) {
+      return null;
+    }
+
     const icon = this.props.optionIconFn(item);
     if (icon) {
       return (
@@ -196,6 +202,7 @@ class Select extends Component {
       isInitiallyOpen,
       onClose,
       disabled,
+      width,
     } = this.props;
 
     const sections = this._getSections();
@@ -245,6 +252,7 @@ class Select extends Component {
           sections={sections}
           className="MB-Select text-brand"
           alwaysExpanded
+          width={width}
           itemIsSelected={this.itemIsSelected}
           itemIsClickable={this.itemIsClickable}
           renderItemName={this.props.optionNameFn}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -9,6 +9,8 @@ import { DataSourceSelector } from "metabase/query_builder/components/DataSelect
 import FieldList from "metabase/query_builder/components/FieldList";
 import Join from "metabase-lib/lib/queries/structured/Join";
 import { isDateTimeField } from "metabase/lib/query/field_ref";
+import Select from "metabase/core/components/Select";
+import Button from "metabase/core/components/Button";
 
 import { NotebookCellItem, NotebookCellAdd } from "../NotebookCell";
 import {
@@ -64,6 +66,15 @@ const joinStepPropTypes = {
   isLastOpened: PropTypes.bool,
   updateQuery: PropTypes.func.isRequired,
 };
+
+const JOIN_OPERATOR_OPTIONS = [
+  { name: "=", value: "=" },
+  { name: ">", value: ">" },
+  { name: "<", value: "<" },
+  { name: "≥", value: ">=" },
+  { name: "≤", value: "<=" },
+  { name: "≠", value: "!=" },
+];
 
 export default function JoinStep({
   color,
@@ -238,6 +249,10 @@ function JoinClause({ color, join, updateQuery, showRemove }) {
             {displayConditions.map((condition, index) => {
               const isFirst = index === 0;
               const isLast = index === displayConditions.length - 1;
+              const [operator] = condition;
+              const operatorSymbol = JOIN_OPERATOR_OPTIONS.find(
+                o => o.value === operator,
+              )?.name;
 
               function removeParentDimension() {
                 join
@@ -256,6 +271,13 @@ function JoinClause({ color, join, updateQuery, showRemove }) {
               function removeDimensionPair() {
                 join
                   .removeCondition(index)
+                  .parent()
+                  .update(updateQuery);
+              }
+
+              function updateOperator({ target: { value } }) {
+                join
+                  .setOperator(index, value)
                   .parent()
                   .update(updateQuery);
               }
@@ -281,7 +303,18 @@ function JoinClause({ color, join, updateQuery, showRemove }) {
                       }
                       data-testid="parent-dimension"
                     />
-                    <JoinConditionLabel>=</JoinConditionLabel>
+                    <JoinConditionLabel>
+                      <Select
+                        hiddenIcons
+                        width={60}
+                        value={operator}
+                        onChange={updateOperator}
+                        options={JOIN_OPERATOR_OPTIONS}
+                        triggerElement={
+                          <Button primary>{operatorSymbol}</Button>
+                        }
+                      />
+                    </JoinConditionLabel>
                   </Row>
                   <Row>
                     <JoinDimensionPicker

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -10,7 +10,6 @@ import FieldList from "metabase/query_builder/components/FieldList";
 import Join from "metabase-lib/lib/queries/structured/Join";
 import { isDateTimeField } from "metabase/lib/query/field_ref";
 import Select from "metabase/core/components/Select";
-import Button from "metabase/core/components/Button";
 
 import { NotebookCellItem, NotebookCellAdd } from "../NotebookCell";
 import {
@@ -39,6 +38,7 @@ import {
   Row,
   PrimaryJoinCell,
   SecondaryJoinCell,
+  JoinOperatorButton,
 } from "./JoinStep.styled";
 
 const stepShape = {
@@ -306,12 +306,14 @@ function JoinClause({ color, join, updateQuery, showRemove }) {
                     <JoinConditionLabel>
                       <Select
                         hiddenIcons
-                        width={60}
+                        width={80}
                         value={operator}
                         onChange={updateOperator}
                         options={JOIN_OPERATOR_OPTIONS}
                         triggerElement={
-                          <Button primary>{operatorSymbol}</Button>
+                          <JoinOperatorButton primary>
+                            {operatorSymbol}
+                          </JoinOperatorButton>
                         }
                       />
                     </JoinConditionLabel>

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.styled.jsx
@@ -3,6 +3,7 @@ import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
 import { space, breakpointMaxMedium } from "metabase/styled-components/theme";
 import Icon from "metabase/components/Icon";
+import Button from "metabase/core/components/Button";
 import { NotebookCell } from "../NotebookCell";
 
 export const Row = styled.div`
@@ -148,4 +149,11 @@ export const SecondaryJoinCell = styled(NotebookCell)`
   flex: 1;
   flex-direction: column;
   align-items: start;
+`;
+
+export const JoinOperatorButton = styled(Button)`
+  width: 36px;
+  height: 36px;
+  font-size: 16px;
+  padding: 0;
 `;

--- a/frontend/test/metabase-lib/lib/queries/structured/Join.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/structured/Join.unit.spec.js
@@ -300,6 +300,28 @@ describe("Join", () => {
         "source-table": PRODUCTS.id,
       });
     });
+
+    it("preserves operator when changes a dimension", () => {
+      let join = getJoin({
+        query: getOrdersJoinQuery({
+          condition: [">=", null, PRODUCTS_ID_JOIN_FIELD_REF],
+        }),
+      });
+
+      join = join.setParentDimension({
+        dimension: ORDERS_PRODUCT_ID_FIELD_REF,
+      });
+
+      expect(join).toEqual({
+        alias: "Products",
+        condition: [
+          ">=",
+          ORDERS_PRODUCT_ID_FIELD_REF,
+          PRODUCTS_ID_JOIN_FIELD_REF,
+        ],
+        "source-table": PRODUCTS.id,
+      });
+    });
   });
 
   describe("setJoinDimension", () => {
@@ -455,6 +477,28 @@ describe("Join", () => {
         "source-table": PRODUCTS.id,
       });
     });
+
+    it("preserves operator when changes a dimension", () => {
+      let join = getJoin({
+        query: getOrdersJoinQuery({
+          condition: [">=", PRODUCTS_ID_JOIN_FIELD_REF, null],
+        }),
+      });
+
+      join = join.setJoinDimension({
+        dimension: ORDERS_PRODUCT_ID_FIELD_REF,
+      });
+
+      expect(join).toEqual({
+        alias: "Products",
+        condition: [
+          ">=",
+          PRODUCTS_ID_JOIN_FIELD_REF,
+          ORDERS_PRODUCT_ID_FIELD_REF,
+        ],
+        "source-table": PRODUCTS.id,
+      });
+    });
   });
 
   describe("getConditions", () => {
@@ -481,6 +525,45 @@ describe("Join", () => {
       expect(join.getConditions()).toEqual([
         ORDERS_PRODUCT_JOIN_CONDITION,
         ORDERS_PRODUCT_JOIN_CONDITION_BY_CREATED_AT,
+      ]);
+    });
+  });
+
+  describe("setOperator", () => {
+    it("changes the operator of a single condition join", () => {
+      let join = getJoin({
+        query: getOrdersJoinQuery({
+          condition: ORDERS_PRODUCT_JOIN_CONDITION,
+        }),
+      });
+
+      join = join.setOperator(0, "!=");
+
+      expect(join.getConditions()).toEqual([
+        [
+          "!=",
+          ORDERS_PRODUCT_JOIN_CONDITION[1],
+          ORDERS_PRODUCT_JOIN_CONDITION[2],
+        ],
+      ]);
+    });
+
+    it("changes the operator of a multiple conditions join", () => {
+      let join = getJoin({
+        query: getOrdersJoinQuery({
+          condition: ORDERS_PRODUCT_MULTI_FIELD_JOIN_CONDITION,
+        }),
+      });
+
+      join = join.setOperator(1, "!=");
+
+      expect(join.getConditions()).toEqual([
+        ORDERS_PRODUCT_JOIN_CONDITION,
+        [
+          "!=",
+          ORDERS_PRODUCT_JOIN_CONDITION_BY_CREATED_AT[1],
+          ORDERS_PRODUCT_JOIN_CONDITION_BY_CREATED_AT[2],
+        ],
       ]);
     });
   });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/19443
[Product doc](https://www.notion.so/metabase/Allow-additional-join-conditions-in-the-query-editor-56f52641437d4728aa8752a34391b31f)

## Changes

Allow `=, >, <, ≥, ≤, ≠` join operators in GUI query builder.

<img width="923" alt="Screenshot 2022-06-28 at 00 03 51" src="https://user-images.githubusercontent.com/14301985/176025947-9d66fa3e-602a-4c0e-b784-0ea593ac0eff.png">

## How to verify

- New -> Question -> Sample Database -> Orders
- Join it with Products table
- Change the join operator
- Ensure the results are updated
- Try to break it in any way by removing parent or joined dimension, by changing datetime granularity, etc.