### PR TITLE
[E2E] Replace hard coded field IDs in visual tests

### DIFF
--- a/frontend/test/metabase-visual/admin/colors.cy.spec.js
+++ b/frontend/test/metabase-visual/admin/colors.cy.spec.js
@@ -17,7 +17,7 @@ const questionDetails = {
       aggregation: [["count"]],
       breakout: [
         ["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }],
-        ["field", PEOPLE.STATE, { "source-field": 11 }],
+        ["field", PEOPLE.STATE, { "source-field": ORDERS.USER_ID }],
       ],
     },
   },

--- a/frontend/test/metabase-visual/visualizations/line.cy.spec.js
+++ b/frontend/test/metabase-visual/visualizations/line.cy.spec.js
@@ -66,7 +66,7 @@ describe("visual tests > visualizations > line", () => {
               "field",
               PEOPLE.STATE,
               {
-                "source-field": 11,
+                "source-field": ORDERS.USER_ID,
               },
             ],
           ],
@@ -103,7 +103,7 @@ describe("visual tests > visualizations > line", () => {
               "field",
               PEOPLE.STATE,
               {
-                "source-field": 11,
+                "source-field": ORDERS.USER_ID,
               },
             ],
           ],


### PR DESCRIPTION
@kulyk ran into some failures in one of his PRs. After some debugging, it turned out the culprit were hard coded IDs.

Let's try to never ever hard code them and use the IDs from the sample database reference instead.