### PR TITLE
Dashboard Info Panel

### DIFF
--- a/frontend/src/metabase-types/api/dashboard.ts
+++ b/frontend/src/metabase-types/api/dashboard.ts
@@ -8,7 +8,7 @@ import { CardId, SavedCard } from "metabase-types/types/Card";
 export interface Dashboard {
   id: number;
   name: string;
-  description: string;
+  description: string | null;
   model?: string;
   ordered_cards: DashboardOrderedCard[];
   parameters?: Parameter[] | null;

--- a/frontend/src/metabase-types/api/dashboard.ts
+++ b/frontend/src/metabase-types/api/dashboard.ts
@@ -8,6 +8,7 @@ import { CardId, SavedCard } from "metabase-types/types/Card";
 export interface Dashboard {
   id: number;
   name: string;
+  description: string;
   model?: string;
   ordered_cards: DashboardOrderedCard[];
   parameters?: Parameter[] | null;

--- a/frontend/src/metabase-types/api/index.ts
+++ b/frontend/src/metabase-types/api/index.ts
@@ -16,3 +16,4 @@ export * from "./question";
 export * from "./dataset";
 export * from "./models";
 export * from "./notifications";
+export * from "./revision";

--- a/frontend/src/metabase-types/api/mocks/dashboard.ts
+++ b/frontend/src/metabase-types/api/mocks/dashboard.ts
@@ -5,5 +5,6 @@ export const createMockDashboard = (opts?: Partial<Dashboard>): Dashboard => ({
   name: "Dashboard",
   ordered_cards: [],
   can_write: true,
+  description: "",
   ...opts,
 });

--- a/frontend/src/metabase-types/api/revision.ts
+++ b/frontend/src/metabase-types/api/revision.ts
@@ -1,0 +1,12 @@
+import { BaseUser } from "./user";
+
+export interface Revision {
+  description: string;
+  id: number;
+  is_creation: boolean;
+  is_reversion: boolean;
+  message?: string | null;
+  user: BaseUser;
+  diff: { before: object; after: object };
+  timestamp: string;
+}

--- a/frontend/src/metabase/core/components/EditableText/EditableText.tsx
+++ b/frontend/src/metabase/core/components/EditableText/EditableText.tsx
@@ -6,7 +6,6 @@ import React, {
   Ref,
   useCallback,
   useState,
-  useEffect,
 } from "react";
 import { EditableTextArea, EditableTextRoot } from "./EditableText.styled";
 
@@ -41,11 +40,6 @@ const EditableText = forwardRef(function EditableText(
   const [inputValue, setInputValue] = useState(initialValue ?? "");
   const [submitValue, setSubmitValue] = useState(initialValue ?? "");
   const displayValue = inputValue ? inputValue : placeholder;
-
-  useEffect(() => {
-    setInputValue(initialValue ?? "");
-    setSubmitValue(initialValue ?? "");
-  }, [initialValue, setInputValue, setSubmitValue]);
 
   const handleBlur = useCallback(() => {
     if (!isOptional && !inputValue) {

--- a/frontend/src/metabase/core/components/EditableText/EditableText.tsx
+++ b/frontend/src/metabase/core/components/EditableText/EditableText.tsx
@@ -6,6 +6,7 @@ import React, {
   Ref,
   useCallback,
   useState,
+  useEffect,
 } from "react";
 import { EditableTextArea, EditableTextRoot } from "./EditableText.styled";
 
@@ -40,6 +41,11 @@ const EditableText = forwardRef(function EditableText(
   const [inputValue, setInputValue] = useState(initialValue ?? "");
   const [submitValue, setSubmitValue] = useState(initialValue ?? "");
   const displayValue = inputValue ? inputValue : placeholder;
+
+  useEffect(() => {
+    setInputValue(initialValue ?? "");
+    setSubmitValue(initialValue ?? "");
+  }, [initialValue, setInputValue, setSubmitValue]);
 
   const handleBlur = useCallback(() => {
     if (!isOptional && !inputValue) {

--- a/frontend/src/metabase/dashboard/actions.js
+++ b/frontend/src/metabase/dashboard/actions.js
@@ -1143,3 +1143,15 @@ export const fetchDashboardParameterValues = args => async (
   );
   return dashboardParameterValuesCache.get(args) || [];
 };
+
+export const REVERT_TO_REVISION = "metabase/dashboard/REVERT_TO_REVISION";
+export const revertToRevision = createThunkAction(
+  REVERT_TO_REVISION,
+  revision => {
+    return async dispatch => {
+      await revision.revert();
+      await dispatch(fetchDashboard(revision.model_id, null));
+      await dispatch(fetchDashboardCardData({ reload: false, clear: true }));
+    };
+  },
+);

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
@@ -327,6 +327,7 @@ class Dashboard extends Component {
                 {...this.props}
                 onCancel={this.onCancel}
                 showAddQuestionSidebar={showAddQuestionSidebar}
+                setDashboardAttribute={this.setDashboardAttribute}
               />
             </DashboardBody>
           </DashboardStyled>

--- a/frontend/src/metabase/dashboard/components/DashboardInfoSidebar.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardInfoSidebar.styled.tsx
@@ -1,0 +1,21 @@
+import styled from "@emotion/styled";
+import EditableText from "metabase/core/components/EditableText";
+
+import { color } from "metabase/lib/colors";
+
+export const DashboardInfoSidebarRoot = styled.div`
+  width: 360px;
+  padding: 1.5rem 2rem;
+  background: ${color("white")};
+  border-left: 1px solid ${color("border")};
+  height: 100%;
+  overflow-y: auto;
+`;
+
+export const HistoryHeader = styled.h3`
+  margin-bottom: 1rem;
+`;
+
+export const DashboardDescriptionEditbaleText = styled(EditableText)`
+  margin-bottom: 2rem;
+`;

--- a/frontend/src/metabase/dashboard/components/DashboardInfoSidebar.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardInfoSidebar.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback, useMemo } from "react";
 import _ from "underscore";
 import { t } from "ttag";
 import { connect } from "react-redux";
@@ -37,17 +37,22 @@ const DashboardInfoSidebar = ({
 }: DashboardInfoSidebarProps) => {
   const canWrite = dashboard.can_write;
 
-  const handleDescriptionChange = async (description: string) => {
-    console.log(description);
-    await setDashboardAttribute("description", description);
-    console.log("now save");
-    saveDashboardAndCards(dashboard.id);
-  };
+  const handleDescriptionChange = useCallback(
+    async (description: string) => {
+      await setDashboardAttribute("description", description);
+      saveDashboardAndCards(dashboard.id);
+    },
+    [setDashboardAttribute, saveDashboardAndCards, dashboard],
+  );
 
-  const events = getRevisionEventsForTimeline(revisions, {
-    currentUser,
-    canWrite,
-  });
+  const events = useMemo(
+    () =>
+      getRevisionEventsForTimeline(revisions, {
+        currentUser,
+        canWrite,
+      }),
+    [revisions, currentUser, canWrite],
+  );
 
   return (
     <DashboardInfoSidebarRoot>

--- a/frontend/src/metabase/dashboard/components/DashboardInfoSidebar.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardInfoSidebar.tsx
@@ -61,7 +61,8 @@ const DashboardInfoSidebar = ({
         isDisabled={!dashboard.can_write}
         onChange={handleDescriptionChange}
         isMultiline
-        placeholder="Add a helpful description. You'll thank me later"
+        placeholder={t`Add a helpful description. You'll thank me later`}
+        key={`dashboard-description-${dashboard.description}`}
       />
 
       <HistoryHeader>{t`History`}</HistoryHeader>

--- a/frontend/src/metabase/dashboard/components/DashboardInfoSidebar.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardInfoSidebar.tsx
@@ -1,0 +1,90 @@
+import React from "react";
+import _ from "underscore";
+import { t } from "ttag";
+import { connect } from "react-redux";
+import DefaultTimeline from "metabase/components/Timeline";
+
+import { Dashboard, Revision as RevisionType, User } from "metabase-types/api";
+import { State } from "metabase-types/store";
+import Revision from "metabase/entities/revisions";
+import { getRevisionEventsForTimeline } from "metabase/lib/revisions";
+import { getUser } from "metabase/selectors/user";
+
+import { revertToRevision } from "metabase/dashboard/actions";
+
+import {
+  DashboardInfoSidebarRoot,
+  HistoryHeader,
+  DashboardDescriptionEditbaleText,
+} from "./DashboardInfoSidebar.styled";
+
+interface DashboardInfoSidebarProps {
+  dashboard: Dashboard;
+  setDashboardAttribute: (name: string, value: string) => void;
+  saveDashboardAndCards: (id: number) => void;
+  revisions: RevisionType[];
+  currentUser: User;
+  revertToRevision: (revision: RevisionType) => void;
+}
+
+const DashboardInfoSidebar = ({
+  dashboard,
+  setDashboardAttribute,
+  saveDashboardAndCards,
+  revisions,
+  currentUser,
+  revertToRevision,
+}: DashboardInfoSidebarProps) => {
+  const canWrite = dashboard.can_write;
+
+  const handleDescriptionChange = async (description: string) => {
+    console.log(description);
+    await setDashboardAttribute("description", description);
+    console.log("now save");
+    saveDashboardAndCards(dashboard.id);
+  };
+
+  const events = getRevisionEventsForTimeline(revisions, {
+    currentUser,
+    canWrite,
+  });
+
+  return (
+    <DashboardInfoSidebarRoot>
+      <DashboardDescriptionEditbaleText
+        initialValue={dashboard.description}
+        isDisabled={!dashboard.can_write}
+        onChange={handleDescriptionChange}
+        isMultiline
+        placeholder="Add a helpful description. You'll thank me later"
+      />
+
+      <HistoryHeader>{t`History`}</HistoryHeader>
+      <DefaultTimeline
+        items={events}
+        data-testid="dashboard-history-list"
+        revertFn={revertToRevision}
+      />
+    </DashboardInfoSidebarRoot>
+  );
+};
+
+const mapStateToProps = (state: State) => ({
+  currentUser: getUser(state),
+});
+
+const mapDispatchToProps = {
+  revertToRevision,
+};
+
+export default _.compose(
+  Revision.loadList({
+    query: (state: State, props: DashboardInfoSidebarProps) => ({
+      model_type: "dashboard",
+      model_id: props.dashboard.id,
+    }),
+    wrapped: true,
+    loadingAndErrorWrapper: false,
+  }),
+  connect(mapStateToProps, mapDispatchToProps),
+)(DashboardInfoSidebar);

--- a/frontend/src/metabase/dashboard/components/DashboardSidebars.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardSidebars.jsx
@@ -5,6 +5,7 @@ import _ from "underscore";
 import { SIDEBAR_NAME } from "metabase/dashboard/constants";
 
 import ClickBehaviorSidebar from "./ClickBehaviorSidebar";
+import DashboardInfoSidebar from "./DashboardInfoSidebar";
 import ParameterSidebar from "metabase/parameters/components/ParameterSidebar";
 import SharingSidebar from "metabase/sharing/components/SharingSidebar";
 import { AddCardSidebar } from "./add-card-sidebar/AddCardSidebar";
@@ -40,6 +41,8 @@ DashboardSidebars.propTypes = {
     props: PropTypes.object,
   }).isRequired,
   closeSidebar: PropTypes.func.isRequired,
+  setDashboardAttribute: PropTypes.func,
+  saveDashboardAndCards: PropTypes.func,
 };
 
 export function DashboardSidebars({
@@ -68,6 +71,8 @@ export function DashboardSidebars({
   params,
   sidebar,
   closeSidebar,
+  setDashboardAttribute,
+  saveDashboardAndCards,
 }) {
   const handleAddCard = useCallback(
     cardId => {
@@ -142,6 +147,14 @@ export function DashboardSidebars({
           dashboard={dashboard}
           params={params}
           onCancel={onCancel}
+        />
+      );
+    case SIDEBAR_NAME.info:
+      return (
+        <DashboardInfoSidebar
+          dashboard={dashboard}
+          saveDashboardAndCards={saveDashboardAndCards}
+          setDashboardAttribute={setDashboardAttribute}
         />
       );
     default:

--- a/frontend/src/metabase/dashboard/constants.js
+++ b/frontend/src/metabase/dashboard/constants.js
@@ -3,4 +3,5 @@ export const SIDEBAR_NAME = {
   clickBehavior: "clickBehavior",
   editParameter: "editParameter",
   sharing: "sharing",
+  info: "info",
 };

--- a/frontend/src/metabase/dashboard/containers/DashboardHeader.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardHeader.jsx
@@ -28,7 +28,7 @@ import DashboardBookmark from "metabase/dashboard/components/DashboardBookmark";
 import TippyPopover from "metabase/components/Popover/TippyPopover";
 import {
   getIsBookmarked,
-  getShowDashboardInfoSidebar,
+  getIsShowDashboardInfoSidebar,
 } from "metabase/dashboard/selectors";
 
 import Header from "../components/DashboardHeader";
@@ -39,7 +39,7 @@ const mapStateToProps = (state, props) => {
   return {
     isBookmarked: getIsBookmarked(state, props),
     isNavBarOpen: getIsNavbarOpen(state),
-    isShowingDashboardIngoSidebar: getShowDashboardInfoSidebar(state),
+    isShowingDashboardInfoSidebar: getIsShowDashboardInfoSidebar(state),
   };
 };
 
@@ -187,7 +187,7 @@ class DashboardHeader extends Component {
       createBookmark,
       deleteBookmark,
       setSidebar,
-      isShowingDashboardIngoSidebar,
+      isShowingDashboardInfoSidebar,
       closeSidebar,
     } = this.props;
 
@@ -362,9 +362,9 @@ class DashboardHeader extends Component {
             iconSize={18}
             onlyIcon
             borderless
-            isShowingDashboardIngoSidebar={isShowingDashboardIngoSidebar}
+            isShowingDashboardInfoSidebar={isShowingDashboardInfoSidebar}
             onClick={() =>
-              isShowingDashboardIngoSidebar
+              isShowingDashboardInfoSidebar
                 ? closeSidebar()
                 : setSidebar({ name: "info" })
             }

--- a/frontend/src/metabase/dashboard/containers/DashboardHeader.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardHeader.jsx
@@ -20,12 +20,16 @@ import { getDashboardActions } from "metabase/dashboard/components/DashboardActi
 import {
   DashboardHeaderButton,
   DashboardHeaderActionContainer,
+  DashboardHeaderInfoButton,
 } from "./DashboardHeader.styled";
 
 import ParametersPopover from "metabase/dashboard/components/ParametersPopover";
 import DashboardBookmark from "metabase/dashboard/components/DashboardBookmark";
 import TippyPopover from "metabase/components/Popover/TippyPopover";
-import { getIsBookmarked } from "metabase/dashboard/selectors";
+import {
+  getIsBookmarked,
+  getShowDashboardInfoSidebar,
+} from "metabase/dashboard/selectors";
 
 import Header from "../components/DashboardHeader";
 
@@ -35,6 +39,7 @@ const mapStateToProps = (state, props) => {
   return {
     isBookmarked: getIsBookmarked(state, props),
     isNavBarOpen: getIsNavbarOpen(state),
+    isShowingDashboardIngoSidebar: getShowDashboardInfoSidebar(state),
   };
 };
 
@@ -85,6 +90,9 @@ class DashboardHeader extends Component {
     onSharingClick: PropTypes.func.isRequired,
 
     onChangeLocation: PropTypes.func.isRequired,
+
+    setSidebar: PropTypes.func.isRequired,
+    closeSidebar: PropTypes.func.isRequired,
   };
 
   handleEdit(dashboard) {
@@ -178,7 +186,11 @@ class DashboardHeader extends Component {
       onFullscreenChange,
       createBookmark,
       deleteBookmark,
+      setSidebar,
+      isShowingDashboardIngoSidebar,
+      closeSidebar,
     } = this.props;
+
     const canEdit = dashboard.can_write && isEditable && !!dashboard;
 
     const buttons = [];
@@ -344,6 +356,18 @@ class DashboardHeader extends Component {
             onCreateBookmark={createBookmark}
             onDeleteBookmark={deleteBookmark}
             isBookmarked={isBookmarked}
+          />
+          <DashboardHeaderInfoButton
+            icon="info"
+            iconSize={18}
+            onlyIcon
+            borderless
+            isShowingDashboardIngoSidebar={isShowingDashboardIngoSidebar}
+            onClick={() =>
+              isShowingDashboardIngoSidebar
+                ? closeSidebar()
+                : setSidebar({ name: "info" })
+            }
           />
           <EntityMenu items={extraButtons} triggerIcon="ellipsis" />
         </DashboardHeaderActionContainer>,

--- a/frontend/src/metabase/dashboard/containers/DashboardHeader.styled.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardHeader.styled.jsx
@@ -34,5 +34,5 @@ export const DashboardHeaderActionContainer = styled.div`
 
 export const DashboardHeaderInfoButton = styled(Button)`
   color: ${props =>
-    props.isShowingDashboardIngoSidebar ? color("brand") : color("text-dark")};
+    props.isShowingDashboardInfoSidebar ? color("brand") : color("text-dark")};
 `;

--- a/frontend/src/metabase/dashboard/containers/DashboardHeader.styled.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardHeader.styled.jsx
@@ -1,6 +1,8 @@
 import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
 
+import Button from "metabase/core/components/Button";
+
 export const DashboardHeaderButton = styled.button`
   display: flex;
   align-items: center;
@@ -28,4 +30,9 @@ export const DashboardHeaderActionContainer = styled.div`
   display: flex;
   padding-left: 0.5rem;
   border-left: 1px solid ${color("border")};
+`;
+
+export const DashboardHeaderInfoButton = styled(Button)`
+  color: ${props =>
+    props.isShowingDashboardIngoSidebar ? color("brand") : color("text-dark")};
 `;

--- a/frontend/src/metabase/dashboard/selectors.js
+++ b/frontend/src/metabase/dashboard/selectors.js
@@ -54,7 +54,7 @@ export const getShowAddQuestionSidebar = createSelector(
   sidebar => sidebar.name === SIDEBAR_NAME.addQuestion,
 );
 
-export const getShowDashboardInfoSidebar = createSelector(
+export const getIsShowDashboardInfoSidebar = createSelector(
   [getSidebar],
   sidebar => sidebar.name === SIDEBAR_NAME.info,
 );

--- a/frontend/src/metabase/dashboard/selectors.js
+++ b/frontend/src/metabase/dashboard/selectors.js
@@ -54,6 +54,11 @@ export const getShowAddQuestionSidebar = createSelector(
   sidebar => sidebar.name === SIDEBAR_NAME.addQuestion,
 );
 
+export const getShowDashboardInfoSidebar = createSelector(
+  [getSidebar],
+  sidebar => sidebar.name === SIDEBAR_NAME.info,
+);
+
 export const getDashboard = createSelector(
   [getDashboardId, getDashboards],
   (dashboardId, dashboards) => dashboards[dashboardId],

--- a/frontend/test/metabase/scenarios/dashboard/reproductions/18454-card-description.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/reproductions/18454-card-description.cy.spec.js
@@ -31,8 +31,9 @@ describe("issue 18454", () => {
 
   it("should show card descriptions (metabase#18454)", () => {
     cy.get(".DashCard").realHover();
-    cy.icon("info").trigger("mouseenter", { force: true });
-
+    cy.get(".DashCard").within(() => {
+      cy.icon("info").trigger("mouseenter", { force: true });
+    });
     cy.findByText(CARD_DESCRIPTION);
   });
 });


### PR DESCRIPTION
Epic #22826 

Dashboard Info Panel with history and editable description. Removing `DashboardHistoryModal`, `DashboardDetailsModel` and related tests will follow this PR. A few notes:
- Sizing of the side panel feels a little strange to me. if you have a "short" dashboard, but lots of revisions to show, it's a full screen scroll.
- The revisions aren't quite as nice as they are with questions. Might be something to look into.
![chrome_fkDez2zluI](https://user-images.githubusercontent.com/1328979/176250404-679aea11-da28-41fb-8940-7276e7b69740.gif)
