### PR TITLE
Repro #20809: Wrong aliasing in nesting based on question with filter to implicit/explicit table

### DIFF
--- a/frontend/test/metabase/scenarios/question/reproductions/20809-nesting-explicit-implicit-filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/20809-nesting-explicit-implicit-filter.cy.spec.js
@@ -1,0 +1,79 @@
+import {
+  restore,
+  visualize,
+  visitQuestionAdhoc,
+  enterCustomColumnDetails,
+} from "__support__/e2e/helpers";
+
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+
+const { REVIEWS, REVIEWS_ID, PRODUCTS, ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
+
+const questionDetails = {
+  name: "20809",
+  query: {
+    "source-table": REVIEWS_ID,
+    filter: [
+      "=",
+      ["field", PRODUCTS.CATEGORY, { "source-field": REVIEWS.PRODUCT_ID }],
+      "Doohickey",
+    ],
+    aggregation: [["count"]],
+    breakout: [["field", REVIEWS.PRODUCT_ID, null]],
+  },
+};
+
+describe.skip("issue 20809", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    cy.createQuestion(questionDetails).then(({ body: { id } }) => {
+      const nestedQuestion = {
+        dataset_query: {
+          database: SAMPLE_DB_ID,
+          query: {
+            "source-table": ORDERS_ID,
+            joins: [
+              {
+                fields: "all",
+                "source-table": `card__${id}`,
+                condition: [
+                  "=",
+                  ["field", ORDERS.PRODUCT_ID, null],
+                  [
+                    "field",
+                    REVIEWS.PRODUCT_ID,
+                    { "join-alias": `Question ${id}` },
+                  ],
+                ],
+                alias: `Question ${id}`,
+              },
+            ],
+          },
+          type: "query",
+        },
+      };
+
+      visitQuestionAdhoc(nestedQuestion, { mode: "notebook" });
+    });
+  });
+
+  it("nesting should work on a saved question with a filter to implicit/explicit table (metabase#20809)", () => {
+    cy.findByTextEnsureVisible("Custom column").click();
+
+    enterCustomColumnDetails({
+      formula: "1 + 1",
+      name: "Two",
+    });
+
+    cy.button("Done").click();
+
+    visualize(response => {
+      expect(response.body.error).to.not.exist;
+    });
+
+    cy.contains("37.65");
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #20809 

### How to test this manually?
- `yarn test-cypress-open`
- `metabase/scenarios/question/reproductions/20809-nesting-explicit-implicit-filter.cy.spec.js`
- Unskip repro
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/176257712-ea8ba0f9-0d30-48ca-ba46-a4291578278b.png)

