### PR TITLE
Handle non `=` category filters

### DIFF
--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineCategoryPicker/InlineCategoryPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineCategoryPicker/InlineCategoryPicker.tsx
@@ -75,6 +75,10 @@ export function InlineCategoryPickerComponent({
       });
   }, [dimension, safeFetchFieldValues, shouldFetchFieldValues]);
 
+  const showInlinePicker =
+    fieldValues.length <= MAX_INLINE_CATEGORIES &&
+    (!filter || filter?.operatorName() === "=");
+
   if (hasError) {
     return (
       <Warnings
@@ -89,7 +93,7 @@ export function InlineCategoryPickerComponent({
     return <Loading size={20} />;
   }
 
-  if (fieldValues.length <= MAX_INLINE_CATEGORIES) {
+  if (showInlinePicker) {
     return (
       <SimpleCategoryFilterPicker
         filter={filter ?? newFilter}

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineCategoryPicker/InlineCategoryPicker.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineCategoryPicker/InlineCategoryPicker.unit.spec.tsx
@@ -338,4 +338,30 @@ describe("InlineCategoryPicker", () => {
 
     expect(fetchSpy).not.toHaveBeenCalled();
   });
+
+  it("should fall back to bulk filter if the filter operator is not =", async () => {
+    const testFilter = new Filter(
+      ["!=", ["field", smallCategoryField.id, null], undefined],
+      null,
+      query,
+    );
+    const changeSpy = jest.fn();
+    const fetchSpy = jest.fn();
+
+    render(
+      <InlineCategoryPickerComponent
+        query={query}
+        filter={testFilter}
+        newFilter={testFilter}
+        onChange={changeSpy}
+        fieldValues={smallCategoryField.values}
+        fetchFieldValues={fetchSpy}
+        dimension={smallDimension}
+        onClear={changeSpy}
+      />,
+    );
+
+    expect(screen.queryByTestId("category-picker")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("select-button")).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Background

The new inline category picker only support `=` filter operators, and this will likely encompass most of our users' filtering needs, but other operators are available in notebook mode, and we should display those filters sensibly in the bulk filter modal. 

![Screen Shot 2022-06-28 at 3 20 35 PM](https://user-images.githubusercontent.com/30528226/176293867-7518893c-31fa-4d77-b3af-384bc8fb5ab2.png)

## Changes

If a category filter has an operator other than `=`, we simply fall back to the BulkFilterSelect component, and it all just works!

![Screen Shot 2022-06-28 at 3 18 28 PM](https://user-images.githubusercontent.com/30528226/176293485-a05a7a4b-d59d-4323-897f-25fb55e29fa2.png)

![Screen Shot 2022-06-28 at 3 21 48 PM](https://user-images.githubusercontent.com/30528226/176296172-45e4eb41-cc7f-486c-aa2d-008a2b41f234.png)


## Testing Steps
- open the orders table
- from notebook mode, add a filter to the `Category` field like `starts with G`, or anything else that's not an `=` filter
- exit notebook mode and open the bulk filter modal and see that it displays the filter properly
- see that the filter can be edited, and if you edit it back to an = filter, you get the inline checkbox interface back


