### PR TITLE
Fix error with custom column on tables sandboxed by a UUID column

### DIFF
--- a/shared/src/metabase/mbql/normalize.cljc
+++ b/shared/src/metabase/mbql/normalize.cljc
@@ -149,9 +149,14 @@
   [[_ amount unit]]
   [:interval amount (maybe-normalize-token unit)])
 
+(defmethod normalize-mbql-clause-tokens :value
+  ;; The args of a `value` clause shouldn't be normalized.
+  [[_ value info]]
+  [:value value info])
+
 (defmethod normalize-mbql-clause-tokens :default
-  ;; MBQL clauses by default get just the clause name normalized (e.g. `[\"COUNT\" ...]` becomes `[:count ...]`) and the
-  ;; args are left as-is.
+  ;; MBQL clauses by default are recursively normalized.
+  ;; This includes the clause name (e.g. `[\"COUNT\" ...]` becomes `[:count ...]`) and args.
   [[clause-name & args]]
   (into [(maybe-normalize-token clause-name)] (map #(normalize-tokens % :ignore-path)) args))
 

--- a/shared/src/metabase/mbql/normalize.cljc
+++ b/shared/src/metabase/mbql/normalize.cljc
@@ -151,6 +151,7 @@
 
 (defmethod normalize-mbql-clause-tokens :value
   ;; The args of a `value` clause shouldn't be normalized.
+  ;; See https://github.com/metabase/metabase/issues/23354 for details
   [[_ value info]]
   [:value value info])
 

--- a/shared/test/metabase/mbql/normalize_test.cljc
+++ b/shared/test/metabase/mbql/normalize_test.cljc
@@ -62,6 +62,7 @@
      [:field 2 {:binning {:strategy :default}}]}
 
     ":value clauses should keep snake_case keys in the type info arg"
+    ;; See https://github.com/metabase/metabase/issues/23354 for details
     {[:value "some value" {:some_key "some key value"}]
      [:value "some value" {:some_key "some key value"}]}))
 

--- a/shared/test/metabase/mbql/normalize_test.cljc
+++ b/shared/test/metabase/mbql/normalize_test.cljc
@@ -24,43 +24,46 @@
 
 (t/deftest ^:parallel normalize-tokens-test
   (normalize-tests
-    "Query type should get normalized"
-    {{:type "NATIVE"}
-     {:type :native}}
+   "Query type should get normalized"
+   {{:type "NATIVE"}
+    {:type :native}}
 
-    "native queries should NOT get normalized"
-    {{:type "NATIVE", :native {"QUERY" "SELECT COUNT(*) FROM CANS;"}}
-     {:type :native, :native {:query "SELECT COUNT(*) FROM CANS;"}}
+   "native queries should NOT get normalized"
+   {{:type "NATIVE", :native {"QUERY" "SELECT COUNT(*) FROM CANS;"}}
+    {:type :native, :native {:query "SELECT COUNT(*) FROM CANS;"}}
 
-     {:native {:query {:NAME        "FAKE_QUERY"
-                       :description "Theoretical fake query in a JSON-based query lang"}}}
-     {:native {:query {:NAME        "FAKE_QUERY"
-                       :description "Theoretical fake query in a JSON-based query lang"}}}}
+    {:native {:query {:NAME        "FAKE_QUERY"
+                      :description "Theoretical fake query in a JSON-based query lang"}}}
+    {:native {:query {:NAME        "FAKE_QUERY"
+                      :description "Theoretical fake query in a JSON-based query lang"}}}}
 
-    "METRICS shouldn't get normalized in some kind of wacky way"
-    {{:aggregation ["+" ["METRIC" 10] 1]}
-     {:aggregation [:+ [:metric 10] 1]}}
+   "METRICS shouldn't get normalized in some kind of wacky way"
+   {{:aggregation ["+" ["METRIC" 10] 1]}
+    {:aggregation [:+ [:metric 10] 1]}}
 
-    "Nor should SEGMENTS"
-    {{:filter ["=" ["+" ["SEGMENT" 10] 1] 10]}
-     {:filter [:= [:+ [:segment 10] 1] 10]}}
+   "Nor should SEGMENTS"
+   {{:filter ["=" ["+" ["SEGMENT" 10] 1] 10]}
+    {:filter [:= [:+ [:segment 10] 1] 10]}}
 
-    "field literals should be exempt too"
-    {{:order-by [[:desc [:field-literal "SALES_TAX" :type/Number]]]}
-     {:order-by [[:desc [:field-literal "SALES_TAX" :type/Number]]]}}
+   "field literals should be exempt too"
+   {{:order-by [[:desc [:field-literal "SALES_TAX" :type/Number]]]}
+    {:order-by [[:desc [:field-literal "SALES_TAX" :type/Number]]]}}
 
 
-    "... but they should be converted to strings if passed in as a KW for some reason"
-    {{:order-by [[:desc ["field_literal" :SALES/TAX "type/Number"]]]}
-     {:order-by [[:desc [:field-literal "SALES/TAX" :type/Number]]]}}
+   "... but they should be converted to strings if passed in as a KW for some reason"
+   {{:order-by [[:desc ["field_literal" :SALES/TAX "type/Number"]]]}
+    {:order-by [[:desc [:field-literal "SALES/TAX" :type/Number]]]}}
 
-    "modern :field clauses should get normalized"
-    {[:field 2 {"temporal-unit" "day"}]
-     [:field 2 {:temporal-unit :day}]
+   "modern :field clauses should get normalized"
+   {[:field 2 {"temporal-unit" "day"}]
+    [:field 2 {:temporal-unit :day}]
 
-     [:field 2 {"binning" {"strategy" "default"}}]
-     [:field 2 {:binning {:strategy :default}}]}))
+    [:field 2 {"binning" {"strategy" "default"}}]
+    [:field 2 {:binning {:strategy :default}}]}
 
+   ":value clauses should keep snake_case keys in the type info arg"
+   {[:value "some value" {:some_key "some key value"}]
+    [:value "some value" {:some_key "some key value"}]}))
 
 ;;; -------------------------------------------------- aggregation ---------------------------------------------------
 

--- a/shared/test/metabase/mbql/normalize_test.cljc
+++ b/shared/test/metabase/mbql/normalize_test.cljc
@@ -24,46 +24,46 @@
 
 (t/deftest ^:parallel normalize-tokens-test
   (normalize-tests
-   "Query type should get normalized"
-   {{:type "NATIVE"}
-    {:type :native}}
+    "Query type should get normalized"
+    {{:type "NATIVE"}
+     {:type :native}}
 
-   "native queries should NOT get normalized"
-   {{:type "NATIVE", :native {"QUERY" "SELECT COUNT(*) FROM CANS;"}}
-    {:type :native, :native {:query "SELECT COUNT(*) FROM CANS;"}}
+    "native queries should NOT get normalized"
+    {{:type "NATIVE", :native {"QUERY" "SELECT COUNT(*) FROM CANS;"}}
+     {:type :native, :native {:query "SELECT COUNT(*) FROM CANS;"}}
 
-    {:native {:query {:NAME        "FAKE_QUERY"
-                      :description "Theoretical fake query in a JSON-based query lang"}}}
-    {:native {:query {:NAME        "FAKE_QUERY"
-                      :description "Theoretical fake query in a JSON-based query lang"}}}}
+     {:native {:query {:NAME        "FAKE_QUERY"
+                       :description "Theoretical fake query in a JSON-based query lang"}}}
+     {:native {:query {:NAME        "FAKE_QUERY"
+                       :description "Theoretical fake query in a JSON-based query lang"}}}}
 
-   "METRICS shouldn't get normalized in some kind of wacky way"
-   {{:aggregation ["+" ["METRIC" 10] 1]}
-    {:aggregation [:+ [:metric 10] 1]}}
+    "METRICS shouldn't get normalized in some kind of wacky way"
+    {{:aggregation ["+" ["METRIC" 10] 1]}
+     {:aggregation [:+ [:metric 10] 1]}}
 
-   "Nor should SEGMENTS"
-   {{:filter ["=" ["+" ["SEGMENT" 10] 1] 10]}
-    {:filter [:= [:+ [:segment 10] 1] 10]}}
+    "Nor should SEGMENTS"
+    {{:filter ["=" ["+" ["SEGMENT" 10] 1] 10]}
+     {:filter [:= [:+ [:segment 10] 1] 10]}}
 
-   "field literals should be exempt too"
-   {{:order-by [[:desc [:field-literal "SALES_TAX" :type/Number]]]}
-    {:order-by [[:desc [:field-literal "SALES_TAX" :type/Number]]]}}
+    "field literals should be exempt too"
+    {{:order-by [[:desc [:field-literal "SALES_TAX" :type/Number]]]}
+     {:order-by [[:desc [:field-literal "SALES_TAX" :type/Number]]]}}
 
 
-   "... but they should be converted to strings if passed in as a KW for some reason"
-   {{:order-by [[:desc ["field_literal" :SALES/TAX "type/Number"]]]}
-    {:order-by [[:desc [:field-literal "SALES/TAX" :type/Number]]]}}
+    "... but they should be converted to strings if passed in as a KW for some reason"
+    {{:order-by [[:desc ["field_literal" :SALES/TAX "type/Number"]]]}
+     {:order-by [[:desc [:field-literal "SALES/TAX" :type/Number]]]}}
 
-   "modern :field clauses should get normalized"
-   {[:field 2 {"temporal-unit" "day"}]
-    [:field 2 {:temporal-unit :day}]
+    "modern :field clauses should get normalized"
+    {[:field 2 {"temporal-unit" "day"}]
+     [:field 2 {:temporal-unit :day}]
 
-    [:field 2 {"binning" {"strategy" "default"}}]
-    [:field 2 {:binning {:strategy :default}}]}
+     [:field 2 {"binning" {"strategy" "default"}}]
+     [:field 2 {:binning {:strategy :default}}]}
 
-   ":value clauses should keep snake_case keys in the type info arg"
-   {[:value "some value" {:some_key "some key value"}]
-    [:value "some value" {:some_key "some key value"}]}))
+    ":value clauses should keep snake_case keys in the type info arg"
+    {[:value "some value" {:some_key "some key value"}]
+     [:value "some value" {:some_key "some key value"}]}))
 
 ;;; -------------------------------------------------- aggregation ---------------------------------------------------
 


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/23354

### The problem

Running a question on Postgres with: 
- a custom column
- on a sandboxed table
- where the sandboxed column is a UUID

Results in this error:
`ERROR: operator does not exist: uuid = character varying Hint: No operator matches the given name and argument types. You might need to add explicit type casts.`

### Explanation

The error happens because:
1. For a query on a sandboxed table with a custom expression, the source table is replaced with a nested query on the source table, with a filter applied on the sandboxed column. See [here](https://github.com/metabase/metabase/blob/fix-normalize-value-clause/src/metabase/query_processor/util/nest_query.clj#L94).
2. The UUID value in the sandboxed column filter is represented in MBQL as a value clause. The value clause of a UUID type is in the following format in MBQL:
```clojure
[:value
 "5e2b47fb-a1e3-4789-97ad-cc10c37dded7"
 {:base_type         :type/UUID
  :effective_type    :type/Integer
  :coercion_strategy nil
  :semantic_type     :type/PK
  :database_type     "uuid"
  :name              "user_id"}]
```
   This UUID clause should be compiled to a format like `"some-value"::uuid` in a native PostgreSQL query.
3. The `around-middleware` which runs during the preprocessing of the nested query includes `normalize` middleware ([here](https://github.com/metabase/metabase/blob/fix-normalize-value-clause/src/metabase/query_processor/middleware/normalize_query.clj#L8)), which currently converts all keywords in the value clause to kebab-case. It will convert the keywords on the type info map, which are expected to have snake_case (schema [here](https://github.com/metabase/metabase/blob/fix-normalize-value-clause/shared/src/metabase/mbql/schema.cljc#L232)).
4. The preprocessed type info map, now with keys in kebab-case instead of snake_case, will not get compiled correctly to the UUID type in the native query. The UUID value will remain a string. This causes an error in Postgres because the native query will have a where clause like `uuid_column = "5e2b47fb-a1e3-4789-97ad-cc10c37dded7"` instead of `uuid_column = "5e2b47fb-a1e3-4789-97ad-cc10c37dded7"::uuid`

### Solution

We need to update the implementation of the `normalize-mbql-clause-tokens` mutlimethod, so a value clause's type info map is not converted to kebab-case.