### PR TITLE
Ensure current code does not confuse with the new added FieldValues type

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/field_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/field_test.clj
@@ -127,7 +127,7 @@
                   :attributes {:cat 50}}
     (let [field (Field (mt/id :venues :name))]
       ;; Make sure FieldValues are populated
-      (field-values/get-or-create-field-values! field)
+      (field-values/get-or-create-full-field-values! field)
       ;; Warm up the cache
       (mt/user-http-request :rasta :get 200 (str "field/" (:id field) "/values"))
       (testing "Do we use cached values when available?"
@@ -165,7 +165,7 @@
                      (:values (mt/user-http-request :rasta :get 200 (str "field/" (:id field) "/values")))))))
           (finally
             ;; Put everything back as it was
-            (field-values/get-or-create-field-values! field))))
+            (field-values/get-or-create-full-field-values! field))))
 
       (testing "When a sandbox fieldvalues expired, do we delete it then create a new one?"
         (#'field-values/clear-advanced-field-values-for-field! field)

--- a/src/metabase/api/field.clj
+++ b/src/metabase/api/field.clj
@@ -258,6 +258,7 @@
   [field-or-id value-pairs]
   (let [human-readable-values? (validate-human-readable-pairs value-pairs)]
     (db/insert! FieldValues
+      :type :full
       :field_id (u/the-id field-or-id)
       :values (map first value-pairs)
       :human_readable_values (when human-readable-values?
@@ -272,7 +273,7 @@
     (api/check (field-values/field-should-have-field-values? field)
       [400 (str "You can only update the human readable values of a mapped values of a Field whose value of "
                 "`has_field_values` is `list` or whose 'base_type' is 'type/Boolean'.")])
-    (if-let [field-value-id (db/select-one-id FieldValues, :field_id id)]
+    (if-let [field-value-id (db/select-one-id FieldValues, :field_id id :type :full)]
       (update-field-values! field-value-id value-pairs)
       (create-field-values! field value-pairs)))
   {:status :success})
@@ -286,7 +287,7 @@
     ;; but no data perms, they should stll be able to trigger a sync of field values. This is fine because we don't
     ;; return any actual field values from this API. (#21764)
     (binding [api/*current-user-permissions-set* (atom #{"/"})]
-      (field-values/create-or-update-field-values! field)))
+      (field-values/create-or-update-full-field-values! field)))
   {:status :success})
 
 (api/defendpoint POST "/:id/discard_values"

--- a/src/metabase/models/params/field_values.clj
+++ b/src/metabase/models/params/field_values.clj
@@ -12,7 +12,7 @@
   "OSS implementation; used as a fallback for the EE implementation if the field isn't sandboxed."
   [field]
   (when (field-values/field-should-have-field-values? field)
-    (field-values/get-or-create-field-values! field)))
+    (field-values/get-or-create-full-field-values! field)))
 
 (defenterprise get-or-create-field-values-for-current-user!*
   "Fetch cached FieldValues for a `field`, creating them if needed if the Field should have FieldValues."
@@ -26,7 +26,8 @@
   (when (seq field-ids)
     (not-empty
      (let [field-values       (db/select [FieldValues :values :human_readable_values :field_id]
-                                :field_id [:in (set field-ids)])
+                                :field_id [:in (set field-ids)]
+                                :type :full)
            readable-fields    (when (seq field-values)
                                 (field/readable-fields-only (db/select [Field :id :table_id]
                                                               :id [:in (set (map :field_id field-values))])))

--- a/src/metabase/sync/field_values.clj
+++ b/src/metabase/sync/field_values.clj
@@ -20,7 +20,7 @@
 
 (s/defn ^:private update-field-values-for-field! [field :- i/FieldInstance]
   (log/debug (u/format-color 'green "Looking into updating FieldValues for %s" (sync-util/name-for-logging field)))
-  (field-values/create-or-update-field-values! field))
+  (field-values/create-or-update-full-field-values! field))
 
 (defn- update-field-value-stats-count [counts-map result]
   (if (instance? Exception result)

--- a/test/metabase/models/field_values_test.clj
+++ b/test/metabase/models/field_values_test.clj
@@ -126,7 +126,9 @@
 (deftest get-or-create-full-field-values!-test
   (testing "create a full Fieldvalues if it does not exist"
     (db/delete! FieldValues :field_id (mt/id :categories :name) :type :full)
-    (is (= :full (:type (field-values/get-or-create-full-field-values! (Field (mt/id :categories :name)))))
+    (is (= :full (-> (Field (mt/id :categories :name))
+                     field-values/get-or-create-full-field-values!
+                     :type))
      (is (= 1 (db/count FieldValues :field_id (mt/id :categories :name) :type :full))))
 
    (testing "if an Advanced FeildValues Exists, make sure we still returns the full FieldValues"

--- a/test/metabase/models/field_values_test.clj
+++ b/test/metabase/models/field_values_test.clj
@@ -131,7 +131,7 @@
 
    (testing "if an Advanced FeildValues Exists, make sure we still returns the full FieldValues"
      (mt/with-temp FieldValues [_ {:field_id (mt/id :categories :name)
-                                   :type     "sandbox"
+                                   :type     :sandbox
                                    :hash_key "random-hash"}])
      (is (= :full (:type (field-values/get-or-create-full-field-values! (Field (mt/id :categories :name)))))))))
 

--- a/test/metabase/models/on_demand_test.clj
+++ b/test/metabase/models/on_demand_test.clj
@@ -18,7 +18,7 @@
   {:style/indent 0}
   [f]
   (let [updated-field-names (atom #{})]
-    (with-redefs [field-values/create-or-update-field-values! (fn [field]
+    (with-redefs [field-values/create-or-update-full-field-values! (fn [field]
                                                                 (swap! updated-field-names conj (:name field)))]
       (f updated-field-names)
       @updated-field-names)))


### PR DESCRIPTION
In #23435, we've introduced new types of FieldValues by adding a `type` column.
Prior to that change, we had an implicit assumption that FieldValues and Field have a one-to-one relationship. But with the new FieldValues types, it's no longer true, one Field could have many FieldValues.

For example: when calling the `GET /api/field/:id/values` API, it'll select by 
```(db/select FieldValues :field_id field-id)```, 
this will returns the wrong FieldValues if there are more than one FieldValues of the same field. 
Instead we should do
```(db/select FieldValues :field_id field-id :type :full)```
to returns the correct FieldValues.

Above is the one example of what could go wrong, in this PR I attempt to make sure our old code recognizes the new type and behave correctly.