### PR TITLE
Hide collection path for unsaved questions

### DIFF
--- a/frontend/src/metabase/selectors/app.ts
+++ b/frontend/src/metabase/selectors/app.ts
@@ -129,7 +129,7 @@ export const getCollectionId = createSelector(
 export const getIsCollectionPathVisible = createSelector(
   [getQuestion, getDashboard, getRouterPath],
   (question, dashboard, path) =>
-    (question != null || dashboard != null) &&
+    ((question != null && question.isSaved()) || dashboard != null) &&
     PATHS_WITH_COLLECTION_BREADCRUMBS.some(pattern => pattern.test(path)),
 );
 


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/22826

How to test:
- Click New -> Question
- Make sure there is no `Our analytics` collection badge in the app bar

<img width="1167" alt="Screenshot 2022-06-29 at 17 10 29" src="https://user-images.githubusercontent.com/8542534/176457894-b10be7c2-0981-407e-a1c5-84e85d3b9300.png">
