### PR TITLE
Repro #21984: Viewing tables in Data Model is registered in "Recently viewed"

### DIFF
--- a/frontend/test/metabase/scenarios/admin/datamodel/reproductions/21984-data-model-registered-as-view.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/reproductions/21984-data-model-registered-as-view.cy.spec.js
@@ -1,0 +1,36 @@
+import { restore } from "__support__/e2e/helpers";
+
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+
+const { REVIEWS_ID } = SAMPLE_DATABASE;
+
+const reviewsDataModelPage = `/admin/datamodel/database/${SAMPLE_DB_ID}/table/${REVIEWS_ID}`;
+
+describe.skip("issue 21984", () => {
+  beforeEach(() => {
+    cy.intercept("GET", "/api/table/*/query_metadata?**").as("tableMetadata");
+
+    restore();
+    cy.signInAsAdmin();
+
+    cy.visit(reviewsDataModelPage);
+    cy.wait(["@tableMetadata", "@tableMetadata"]);
+
+    cy.findByDisplayValue("ID");
+  });
+
+  it('should not show data model visited tables in search or in "Pick up where you left off" items on homepage (metabase#21984)', () => {
+    cy.visit("/");
+
+    cy.findByText("Pick up where you left off")
+      .parent()
+      .within(() => {
+        cy.findByText("Reviews").should("not.exist");
+      });
+
+    cy.findByPlaceholderText("Search…").click();
+    cy.findByText("Recently viewed");
+    cy.findAllByTestId("recently-viewed-item").should("not.contain", "Reviews");
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #21984

### How to test this manually?
- `yarn test-cypress-open`
- `metabase/scenarios/admin/datamodel/reproductions/21984-data-model-registered-as-view.cy.spec.js`
- Unskip repro
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
The repro will first fail for the homepage check and "Pick up where you left off"
![image](https://user-images.githubusercontent.com/31325167/176491130-ef65a31f-c2e4-4605-91ef-4317e3cd3c56.png)

Even if that's fixed, it will have additional check in the search results - "Recently viewed"
> **Note**
> Not possible to create a proper and realistic screenshot until #23609 gets fixed, but Cypress will still traverse the DOM and fail even if the element is not visible to the human eye
![image](https://user-images.githubusercontent.com/31325167/176491598-8ddf8654-0b87-4976-9caa-2e80802e26fd.png)
