### PR TITLE
docs - update sso

### DIFF
--- a/docs/administration-guide/10-single-sign-on.md
+++ b/docs/administration-guide/10-single-sign-on.md
@@ -134,7 +134,7 @@ Once a person creates an account, you cannot change the authentication method fo
 
 Note that you must have at least one account with email and password login. This account safeguards you from getting locked out of your Metabase if there are any problems with your SSO provider.
 
-## Troubleshooting
+## Troubleshooting login issues
 
 For common issues, go to [Troubleshooting logins](../troubleshooting-guide/cant-log-in.html).
 

--- a/docs/administration-guide/10-single-sign-on.md
+++ b/docs/administration-guide/10-single-sign-on.md
@@ -33,7 +33,7 @@ Next, you'll have to create authorization credentials for your application by fo
 
 Once you have your `Client ID` (ending in `.apps.googleusercontent.com`), click `Configure` on the "Sign in with Google" section of the Authentication page in the Metabase Admin Panel. Paste your `client_id` into the first box.
 
-[Check if your SSO setup is working correctly](#checking-if-sso-is-working-correctly). Now existing Metabase users signed into a Google account that matches their Metabase account email can sign in with just a click.
+Now existing Metabase users signed into a Google account that matches their Metabase account email can sign in with just a click.
 
 ### Creating Metabase accounts with Google Sign-in
 
@@ -134,17 +134,14 @@ Once a person creates an account, you cannot change the authentication method fo
 
 Note that you must have at least one account with email and password login. This account safeguards you from getting locked out of your Metabase if there are any problems with your SSO provider.
 
-## Checking if SSO is working correctly
+## Troubleshooting
 
-Go to your Metabase login page. If SSO is working correctly, you should see [a single button to sign in][sso-def] with your identity provider (IdP). Once you're authenticated, you should be automatically redirected to the Metabase home page.
-
-If you're having trouble, go to [Troubleshooting logins](../troubleshooting-guide/cant-log-in.html).
+For common issues, go to [Troubleshooting logins](../troubleshooting-guide/cant-log-in.html).
 
 [data-sandboxing-docs]: ../enterprise-guide/data-sandboxes.html
 [google-saml-docs]: ../enterprise-guide/saml-google.html
 [jwt-docs]: ../enterprise-guide/authenticating-with-jwt.html
 [saml-docs]: ../enterprise-guide/authenticating-with-saml.html
-[sso-def]: /glossary/sso
 [sso-docs]: ../administration-guide/sso.html
 [user-attributes-docs]: ../enterprise-guide/data-sandboxes.html#getting-user-attributes
 [user-attributes-def]: /glossary/attribute#user-attributes-in-metabase

--- a/docs/enterprise-guide/authenticating-with-saml.md
+++ b/docs/enterprise-guide/authenticating-with-saml.md
@@ -24,13 +24,17 @@ Setting up SAML will require you to configure settings in two places:
 
 ## Turning on SAML-based SSO
 
-To get started, head over to the Settings section of the Admin Panel, then click on the Authentication tab. Click the `Configure` button in the SAML section of the Authentication page, and you'll see this form:
+To get started, head over to the Settings section of the Admin Panel, then click on the **Authentication** tab. Click the **Configure** button in the SAML section of the Authentication page, and you'll see this form:
 
 ![SAML form](images/saml-form.png)
 
 At the top, **make sure to click the toggle to enable SAML authentication**, otherwise things won't work even if all of your settings are right.
 
-The form itself is broken up into three parts: information about Metabase that you'll have to input into your identity provider (IdP); information about your IdP that you'll need to tell Metabase about; and some optional settings at the bottom.
+The form itself is broken up into three parts: 
+
+1. Information about Metabase that you'll have to input into your identity provider (IdP).
+2. Information about your IdP that you'll need to tell Metabase about.
+3. Optional settings at the bottom.
 
 ## Setting up SAML with your IdP
 

--- a/docs/enterprise-guide/authenticating-with-saml.md
+++ b/docs/enterprise-guide/authenticating-with-saml.md
@@ -219,7 +219,7 @@ You can find example code that uses SAML authentication in the [SSO examples rep
 
 ## Troubleshooting SAML issues
 
-For common issues, go to [Troubleshooting SAML](../troubleshooting-guide/cant-log-in.html).
+For common issues, go to [Troubleshooting SAML](../troubleshooting-guide/saml.html).
 
 ---
 

--- a/docs/enterprise-guide/authenticating-with-saml.md
+++ b/docs/enterprise-guide/authenticating-with-saml.md
@@ -213,7 +213,7 @@ When users log in to Metabase for the first time via SSO, this will automaticall
 
 You can find example code that uses SAML authentication in the [SSO examples repository](https://github.com/metabase/sso-examples).
 
-## Troubleshooting
+## Troubleshooting SAML issues
 
 For common issues, go to [Troubleshooting SAML](../troubleshooting-guide/cant-log-in.html).
 

--- a/docs/enterprise-guide/authenticating-with-saml.md
+++ b/docs/enterprise-guide/authenticating-with-saml.md
@@ -20,8 +20,6 @@ Setting up SAML will require you to configure settings in two places:
 1. Your [Metabase admin settings](#turning-on-saml-based-sso).
 2. The [identity provider (IdP) console](#setting-up-saml-with-your-idp).
 
-Once you've configured SAML in both places, you can [check if your SSO setup is working correctly](../administration-guide/10-single-sign-on.html#checking-if-sso-is-working-correctly).
-
 > **Tip:** Before beginning your SAML set-up, make sure you know the password for your Metabase admin account. If anything becomes misconfigured during the set-up process, an "Admin backup login" option on the sign-in screen is available.
 
 ## Turning on SAML-based SSO
@@ -201,16 +199,6 @@ After that, type in the name of the user attribute you added in your SAML provid
 
 ![Group schema](images/saml-group-schema.png)
 
-## Troubleshooting Tips
-
-[Check if your SSO setup is working correctly](../administration-guide/10-single-sign-on.html#checking-if-sso-is-working-correctly). If you're experiencing issues setting up your SAML connection:
-
-- Verify that the application you created in your IdP supports SAML. Sometimes other options are presented during the app creation process.
-- Read all field labels and tooltips carefully. Since SAML providers each use different labeling for their fields, it's important to make sure the correct information is being placed into the correct fields.
-- Set your attributes and check your assertions! Many SAML providers make this pretty easy to do - just look for a button marked "Preview the SAML assertion."
-- Verify that the Single Sign On URL (or equivalent) that you enter on your SAML provider's website has `/auth/sso` appended to it. For instance, if you want your users to end up at `https://metabase.mycompany.com`, the full URL should be `https://metabase.mycompany.com/auth/sso`.
-- If you're still stuck, try [Troubleshooting logins](../troubleshooting-guide/cant-log-in.html).
-
 ## Disabling password log-in
 
 Once you have configured SAML authentication, you can choose to disable the option for users to log in via email and password. To do this, return to the main Authentication settings page and scroll to the bottom. A toggle will now be visible allowing you to disable password authentication.
@@ -224,6 +212,10 @@ When users log in to Metabase for the first time via SSO, this will automaticall
 ## Example code using SAML
 
 You can find example code that uses SAML authentication in the [SSO examples repository](https://github.com/metabase/sso-examples).
+
+## Troubleshooting
+
+For common issues, go to [Troubleshooting SAML](../troubleshooting-guide/cant-log-in.html).
 
 ---
 

--- a/docs/enterprise-guide/saml-auth0.md
+++ b/docs/enterprise-guide/saml-auth0.md
@@ -8,9 +8,8 @@ title: Setting up SAML with Auth0
 
 1. [Configure SAML in Auth0](#working-in-the-auth0-console) (the identity provider).
 2. [Configure SAML in Metabase](../enterprise-guide/authenticating-with-saml.html) (the service provider).
-3. Once you've configured SAML in both the Auth0 console and your Metabase Admin settings, you can [check if your SSO setup is working correctly](../administration-guide/10-single-sign-on.html#checking-if-sso-is-working-correctly).
 
-For more information, check out our guide for [authenticating with SAML](authenticating-with-saml.html).
+For more information, check out our guide for [authenticating with SAML](authenticating-with-saml.html#turning-on-saml-based-sso).
 
 ## Working in the Auth0 console
 

--- a/docs/enterprise-guide/saml-auth0.md
+++ b/docs/enterprise-guide/saml-auth0.md
@@ -7,9 +7,9 @@ title: Setting up SAML with Auth0
 {% include plans-blockquote.html feature="SAML authentication" %}
 
 1. [Configure SAML in Auth0](#working-in-the-auth0-console) (the identity provider).
-2. [Configure SAML in Metabase](../enterprise-guide/authenticating-with-saml.html) (the service provider).
+2. [Configure SAML in Metabase](../enterprise-guide/authenticating-with-saml.html#enabling-saml-authentication-in-metabase) (the service provider).
 
-For more information, check out our guide for [authenticating with SAML](authenticating-with-saml.html#turning-on-saml-based-sso).
+For more information, check out our guide for [authenticating with SAML](../enterprise-guide/authenticating-with-saml.html).
 
 ## Working in the Auth0 console
 

--- a/docs/enterprise-guide/saml-auth0.md
+++ b/docs/enterprise-guide/saml-auth0.md
@@ -75,6 +75,6 @@ The "SAML Application Name" value can be left as the default (Metabase).
 
 Save your settings, then [enable SAML](authenticating-with-saml.html) in Metabase, and you should be good to go!
 
-## Troubleshooting
+## Troubleshooting SAML issues
 
 For common issues, see our [SAML troubleshooting page](../troubleshooting-guide/saml.html).

--- a/docs/enterprise-guide/saml-google.md
+++ b/docs/enterprise-guide/saml-google.md
@@ -26,4 +26,4 @@ For more information, check out our guide for [authenticating with SAML](authent
 
 ## Troubleshooting
 
-For common issues, go to [Troubleshooting SAML](../troubleshooting-guide/cant-log-in.html).
+For common issues, go to [Troubleshooting SAML](../troubleshooting-guide/saml.html).

--- a/docs/enterprise-guide/saml-google.md
+++ b/docs/enterprise-guide/saml-google.md
@@ -8,9 +8,8 @@ title: Setting up SAML with Google
 
 1. Set up a [custom SAML application](https://support.google.com/a/answer/6087519?hl=en) with Google (the identity provider).
 2. [Configure SAML in Metabase](../enterprise-guide/authenticating-with-saml.html) (the service provider).
-3. Once you've configured SAML in both the Google developer console and your Metabase Admin settings, you can [check if your SSO setup is working correctly](../administration-guide/10-single-sign-on.html#checking-if-sso-is-working-correctly).
 
-For more information, check out our guide for [authenticating with SAML](authenticating-with-saml.html).
+For more information, check out our guide for [authenticating with SAML](authenticating-with-saml.html#turning-on-saml-based-sso).
 
 ## How to fill out SAML settings in Google and Metabase
 
@@ -24,3 +23,7 @@ For more information, check out our guide for [authenticating with SAML](authent
 | SAML Identity Provider Certificate  | Google Admin console > Google Identity Provider details > Download certificate                                                                                |
 | SAML Application Name               | Google Admin console > Google Identity Provider details > Copy the **Entity ID**                                                                              |
 | SAML Identity Provider Issuer       | Google Admin console > Google Identity Provider details > Download metadata                                                                                   |
+
+## Troubleshooting
+
+For common issues, go to [Troubleshooting SAML](../troubleshooting-guide/cant-log-in.html).

--- a/docs/enterprise-guide/saml-google.md
+++ b/docs/enterprise-guide/saml-google.md
@@ -7,9 +7,9 @@ title: Setting up SAML with Google
 {% include plans-blockquote.html feature="Google SAML authentication" %}
 
 1. Set up a [custom SAML application](https://support.google.com/a/answer/6087519) with Google (the identity provider).
-2. [Configure SAML in Metabase](../enterprise-guide/authenticating-with-saml.html) (the service provider).
+2. [Configure SAML in Metabase](../enterprise-guide/authenticating-with-saml.html#enabling-saml-authentication-in-metabase) (the service provider).
 
-For more information, check out our guide for [authenticating with SAML](authenticating-with-saml.html#turning-on-saml-based-sso).
+For more information, check out our guide for [authenticating with SAML](../enterprise-guide/authenticating-with-saml.html).
 
 ## How to fill out SAML settings in Google and Metabase
 

--- a/docs/enterprise-guide/saml-google.md
+++ b/docs/enterprise-guide/saml-google.md
@@ -6,7 +6,7 @@ title: Setting up SAML with Google
 
 {% include plans-blockquote.html feature="Google SAML authentication" %}
 
-1. Set up a [custom SAML application](https://support.google.com/a/answer/6087519?hl=en) with Google (the identity provider).
+1. Set up a [custom SAML application](https://support.google.com/a/answer/6087519) with Google (the identity provider).
 2. [Configure SAML in Metabase](../enterprise-guide/authenticating-with-saml.html) (the service provider).
 
 For more information, check out our guide for [authenticating with SAML](authenticating-with-saml.html#turning-on-saml-based-sso).
@@ -24,6 +24,6 @@ For more information, check out our guide for [authenticating with SAML](authent
 | SAML Application Name               | Google Admin console > Google Identity Provider details > Copy the **Entity ID**                                                                              |
 | SAML Identity Provider Issuer       | Google Admin console > Google Identity Provider details > Download metadata                                                                                   |
 
-## Troubleshooting
+## Troubleshooting SAML issues
 
 For common issues, go to [Troubleshooting SAML](../troubleshooting-guide/saml.html).

--- a/docs/enterprise-guide/saml-keycloak.md
+++ b/docs/enterprise-guide/saml-keycloak.md
@@ -68,4 +68,4 @@ You can find the attribute values from your Metabase **Admin settings** > **Auth
 
 ## Troubleshooting
 
-For common issues, go to [Troubleshooting SAML](../troubleshooting-guide/cant-log-in.html).
+For common issues, go to [Troubleshooting SAML](../troubleshooting-guide/saml.html).

--- a/docs/enterprise-guide/saml-keycloak.md
+++ b/docs/enterprise-guide/saml-keycloak.md
@@ -8,9 +8,8 @@ Keycloak is an open source platform that can be used as a user directory to save
 
 1. [Set up SAML in Keycloak](#working-in-the-keycloak-console) (the identity provider).
 2. [Set up SAML in Metabase](../enterprise-guide/authenticating-with-saml.html) (the service provider).
-3. Once you've configured SAML in both the Keycloak console and your Metabase Admin settings, you can [check if your SSO setup is working correctly](../administration-guide/10-single-sign-on.html#checking-if-sso-is-working-correctly).
 
-For more information, check out our guide for [authenticating with SAML](authenticating-with-saml.html).
+For more information, check out our guide for [authenticating with SAML](authenticating-with-saml.html#turning-on-saml-based-sso).
 
 ## Working in the Keycloak console
 
@@ -66,3 +65,7 @@ Let's say we want email, name, and surname to be passed between the client (Meta
     - **SAML Attribute NameFormat**: select “Basic” from the dropdown menu.
 
 You can find the attribute values from your Metabase **Admin settings** > **Authentication** > **SAML** > **Attributes**.
+
+## Troubleshooting
+
+For common issues, go to [Troubleshooting SAML](../troubleshooting-guide/cant-log-in.html).

--- a/docs/enterprise-guide/saml-keycloak.md
+++ b/docs/enterprise-guide/saml-keycloak.md
@@ -7,9 +7,9 @@ title: Setting up SAML with Keycloak
 Keycloak is an open source platform that can be used as a user directory to save user data while acting as the IdP for single sign-on.
 
 1. [Set up SAML in Keycloak](#working-in-the-keycloak-console) (the identity provider).
-2. [Set up SAML in Metabase](../enterprise-guide/authenticating-with-saml.html) (the service provider).
+2. [Set up SAML in Metabase](../enterprise-guide/authenticating-with-saml.html#enabling-saml-authentication-in-metabase) (the service provider).
 
-For more information, check out our guide for [authenticating with SAML](authenticating-with-saml.html#turning-on-saml-based-sso).
+For more information, check out our guide for [authenticating with SAML](../enterprise-guide/authenticating-with-saml.html).
 
 ## Working in the Keycloak console
 

--- a/docs/enterprise-guide/saml-keycloak.md
+++ b/docs/enterprise-guide/saml-keycloak.md
@@ -66,6 +66,6 @@ Let's say we want email, name, and surname to be passed between the client (Meta
 
 You can find the attribute values from your Metabase **Admin settings** > **Authentication** > **SAML** > **Attributes**.
 
-## Troubleshooting
+## Troubleshooting SAML issues
 
 For common issues, go to [Troubleshooting SAML](../troubleshooting-guide/saml.html).

--- a/docs/enterprise-guide/start.md
+++ b/docs/enterprise-guide/start.md
@@ -17,7 +17,7 @@ Metabase Pro is hosted, so you should already be setup with all the paid feature
 Paid plans include more ways to authenticate people and manage groups.
 
 - [Authenticating with SAML](authenticating-with-saml.html)
-  - [Setting up SAML with Auth0](authenticating-with-saml.html)
+  - [Setting up SAML with Auth0](saml-auth0.html)
   - [Setting up SAML with Google](saml-google.html)
   - [Setting up SAML with Keycloak](saml-keycloak.html)
   - [Documentation for other common IdPs](../enterprise-guide/authenticating-with-saml.html#documentation-for-other-common-idps)

--- a/docs/troubleshooting-guide/cant-log-in.md
+++ b/docs/troubleshooting-guide/cant-log-in.md
@@ -6,36 +6,30 @@ title: People can't log in to Metabase
 
 ## Do you know how your logins are managed?
 
-- [Metabase][metabase-idp]
-- [SSO][troubleshooting-sso]
+- [Metabase](#common-metabase-login-problems)
+- [SAML][troubleshooting-saml]
 - [LDAP][troubleshooting-ldap]
 - [I don't know how my logins are managed][how-to-find-idp].
 
-## Troubleshooting Metabase logins
+## Common Metabase login problems
 
-- [I can't access the Metabase login page][no-login-page].
-- [I can't log in to my Metabase Cloud account][metabase-cloud-login].
+- [I can't access the Metabase login page](#cant-access-the-metabase-login-page).
+- [I can't log in to my Metabase Cloud account](#cant-log-in-to-a-metabase-cloud-account).
 - [I forgot my password][how-to-reset-password].
 - [I forgot the admin password][how-to-reset-admin-password].
 - [I want to delete an account that was set up incorrectly][how-to-delete-an-account].
 
-### I can't access the Metabase login page.
-
-- [Are you using the right URL for your Metabase?][incorrect-metabase-url]
-- [Ask your Metabase admin if your account has been deactivated][how-to-reactivate-account].
-
-#### Are you using the right URL for your Metabase?
+### Can't access the Metabase login page
 
 1. Check whether you need to include a port number as well as a hostname in the connection URL. For example, Metabase might be at `https://example.com:3000/` instead of `https://example.com/`.
    - If you're an administrator, you'll have configured this.
    - If you're not, please ask your admin.
 2. Check whether your Metabase instance has moved. For example, if you were using a trial instance of Metabase, but you're now in production, the URL might have changed.
+3. [Ask your Metabase admin if your account has been deactivated][how-to-reactivate-account].
 
-### Further reading
+For more information, see the [Configuration settings documentation][config-settings]
 
-- [Configuration settings documentation][config-settings]
-
-## Troubleshooting Metabase Cloud logins
+## Can't log in to a Metabase Cloud account
 
 If you're using [Metabase Cloud][pricing], note that your Metabase store password is different from your Metabase Cloud admin password.
 
@@ -43,22 +37,7 @@ If you're using [Metabase Cloud][pricing], note that your Metabase store passwor
 - [I forgot my Metabase Cloud password][how-to-reset-admin-password].
 - If you're a Metabase Cloud customer, you can [contact support][help-premium].
 
-### Further reading
-
-- [Metabase Cloud documentation][cloud-docs]
-
-## Troubleshooting SSO logins
-
-- [Troubleshooting SAML][troubleshooting-saml].
-
-### Checking if SSO is working correctly
-
-Go to your Metabase login page. If SSO is working correctly, you should see [a single button to sign in][sso-gloss] with your identity provider (IdP). Once you're authenticated, you should be automatically redirected to the Metabase home page.
-
-### Further reading
-
-- [SSO documentation][sso-docs]
-- [Checking a person's auth method][how-to-find-auth-method-for-an-account]
+For more information, see the [Metabase Cloud documentation][cloud-docs].
 
 ## I don't know how my logins are managed
 
@@ -87,6 +66,7 @@ What do you use to log in?
 - [SSO documentation][sso-docs]
 - [SAML documentation][saml-docs]
 - [LDAP documentation][ldap-docs]
+- [Checking a person's auth method][how-to-find-auth-method-for-an-account]
 
 ## Are you still stuck?
 
@@ -110,7 +90,6 @@ If you can’t solve your problem using the troubleshooting guides:
 [known-issues]: ./known-issues.html
 [ldap-docs]: ../administration-guide/10-single-sign-on.html#enabling-ldap-authentication
 [metabase-cloud-login]: #troubleshooting-metabase-cloud-logins
-[metabase-idp]: #troubleshooting-metabase-logins
 [no-login-page]: #i-cant-access-the-metabase-login-page
 [pricing]: https://www.metabase.com/pricing/
 [reset-store-password]: https://store.metabase.com/forgot-password
@@ -120,4 +99,3 @@ If you can’t solve your problem using the troubleshooting guides:
 [sso-gloss]: /glossary/sso.html
 [troubleshooting-ldap]: ./ldap.html
 [troubleshooting-saml]: ./saml.html
-[troubleshooting-sso]: #troubleshooting-sso-logins

--- a/docs/troubleshooting-guide/cant-log-in.md
+++ b/docs/troubleshooting-guide/cant-log-in.md
@@ -9,7 +9,7 @@ title: People can't log in to Metabase
 - [Metabase](#common-metabase-login-problems)
 - [SAML][troubleshooting-saml]
 - [LDAP][troubleshooting-ldap]
-- [I don't know how my logins are managed][how-to-find-idp].
+- [I don't know how my logins are managed](#i-dont-know-how-my-logins-are-managed).
 
 ## Common Metabase login problems
 
@@ -27,7 +27,7 @@ title: People can't log in to Metabase
 2. Check whether your Metabase instance has moved. For example, if you were using a trial instance of Metabase, but you're now in production, the URL might have changed.
 3. [Ask your Metabase admin if your account has been deactivated][how-to-reactivate-account].
 
-For more information, see the [Configuration settings documentation][config-settings]
+For more information, see the [Configuration settings documentation][config-settings].
 
 ## Can't log in to a Metabase Cloud account
 
@@ -45,11 +45,11 @@ What do you use to log in?
 
 - **An email address and password.**
 
-  You're using [Metabase][metabase-idp] or [LDAP][troubleshooting-ldap].
+  You're using [Metabase](#common-metabase-login-problems) or [LDAP][troubleshooting-ldap].
 
 - **A button that launches a [pop-up dialog][sso-gloss].**
 
-  You're using [SSO][troubleshooting-sso].
+  You're using SSO. If you're using SAML, go to [Troubleshooting SAML][troubleshooting-saml]. If you're using JWT, search or ask the [Metabase community][discourse].
 
 - **I'm signing in at a site that doesn't have `.metabase.com` in the URL.**
 
@@ -59,9 +59,9 @@ What do you use to log in?
 
   If you're using [Metabase Cloud][pricing], the password for the Metabase store (where you pay for things) is not automatically the same as the password for your Metabase instance (where you log in to look at data).
 
-  If your password and URL are correct, go to [Troubleshooting Metabase Cloud logins][metabase-cloud-login].
+  If your password and URL are correct, go to [Can't log in to a Metabase Cloud account](#cant-log-in-to-a-metabase-cloud-account).
 
-### Further reading
+## Further reading
 
 - [SSO documentation][sso-docs]
 - [SAML documentation][saml-docs]
@@ -77,20 +77,15 @@ If you can’t solve your problem using the troubleshooting guides:
 
 [cloud-docs]: /cloud/docs/
 [config-settings]: ../administration-guide/08-configuration-settings.html
-[deactivated-metabase-account]: #has-your-metabase-account-been-deactivated
 [discourse]: https://discourse.metabase.com/
 [help-premium]: https://www.metabase.com/help-premium/
 [how-to-delete-an-account]: ../administration-guide/04-managing-users.html#deleting-an-account
-[how-to-find-idp]: #i-dont-know-how-my-logins-are-managed
 [how-to-find-auth-method-for-an-account]: ../administration-guide/04-managing-users.html#checking-someones-auth-method
 [how-to-reactivate-account]: ../administration-guide/04-managing-users.html#reactivating-an-account
 [how-to-reset-admin-password]: ../administration-guide/04-managing-users.html#resetting-the-admin-password
 [how-to-reset-password]: ../administration-guide/04-managing-users.html#resetting-someones-password
-[incorrect-metabase-url]: #are-you-using-the-right-url-for-your-metabase
 [known-issues]: ./known-issues.html
 [ldap-docs]: ../administration-guide/10-single-sign-on.html#enabling-ldap-authentication
-[metabase-cloud-login]: #troubleshooting-metabase-cloud-logins
-[no-login-page]: #i-cant-access-the-metabase-login-page
 [pricing]: https://www.metabase.com/pricing/
 [reset-store-password]: https://store.metabase.com/forgot-password
 [saml-docs]: ../enterprise-guide/authenticating-with-saml.html

--- a/docs/troubleshooting-guide/cant-log-in.md
+++ b/docs/troubleshooting-guide/cant-log-in.md
@@ -50,7 +50,10 @@ If you're using [Metabase Cloud][pricing], note that your Metabase store passwor
 ## Troubleshooting SSO logins
 
 - [Troubleshooting SAML][troubleshooting-saml].
-- [SSO logins are creating "unknown" users](https://github.com/metabase/metabase/issues/15484).
+
+### Checking if SSO is working correctly
+
+Go to your Metabase login page. If SSO is working correctly, you should see [a single button to sign in][sso-gloss] with your identity provider (IdP). Once you're authenticated, you should be automatically redirected to the Metabase home page.
 
 ### Further reading
 

--- a/docs/troubleshooting-guide/saml.md
+++ b/docs/troubleshooting-guide/saml.md
@@ -8,6 +8,10 @@ title: Troubleshooting SAML authentication setup
 
 Some common problems when setting up SAML.
 
+## Does your app support SAML?
+
+Verify that the application you created in your IdP supports SAML. Sometimes other options are presented during the app creation process.
+
 ## Is the entity or issuer ID correct?
 
 After filling out the authentication form with your identity provider, you're taken back to Metabase but it throws an error. To see the error, go to **Admin settings** > **Troubleshooting** > **Logs**. You'll see an error that says something like **Incorrect response <issuer>**.
@@ -31,6 +35,10 @@ After filling out the authentication form with your identity provider, you go ba
 1. You should have received an XML file from your identity provider. Open that metadata file, and check to make sure the certificate you inputted is correct.
 2. Go to **Admin settings** > **Settings** > **Authentication** > **SAML**. Check that the certificate that you entered into the **SAML Identity Provider Certificate** field matches the certificate in the XML file you got from your identity provider. Depending on your provider, you might need to download this, open it in a text editor, then copy and paste the certificate's contents into the field.
 
+## Is the SSO URL correct?
+
+Verify that the Single Sign On URL (or equivalent) that you enter on your SAML provider’s website has /auth/sso appended to it. For instance, if you want your users to end up at https://metabase.mycompany.com, the full URL should be https://metabase.mycompany.com/auth/sso.
+
 ## Searching for private key and found a null
 
 This error will only occur if you're using **Signed SSO requests**. That is, in Metabase, you've filled out the fields in the configuration section in **Admin settings** > **Settings** > **Authentication** > **SAML** > **Signed SSO requests**. Those fields are:
@@ -44,3 +52,10 @@ This error will only occur if you're using **Signed SSO requests**. That is, in 
 **Steps to take**:
 
 1. Add a certificate with a private key to your keystore.
+
+## Are you still stuck?
+
+If you can’t solve your problem using the troubleshooting guides:
+
+- Search or ask the [Metabase community](https://discourse.metabase.com/).
+- Search for [known bugs or limitations](./known-issues.html).

--- a/docs/troubleshooting-guide/saml.md
+++ b/docs/troubleshooting-guide/saml.md
@@ -53,6 +53,10 @@ This error will only occur if you're using **Signed SSO requests**. That is, in 
 
 1. Add a certificate with a private key to your keystore.
 
+### Checking if SAML is working correctly
+
+Go to your Metabase login page. If SAML is working correctly, you should see [a single button to sign in](/glossary/sso) with your identity provider (IdP). Once you're authenticated, you should be automatically redirected to the Metabase home page.
+
 ## Are you still stuck?
 
 If you can’t solve your problem using the troubleshooting guides:

--- a/docs/troubleshooting-guide/saml.md
+++ b/docs/troubleshooting-guide/saml.md
@@ -12,28 +12,34 @@ Some common problems when setting up SAML.
 
 Verify that the application you created in your IdP supports SAML. Sometimes other options are presented during the app creation process.
 
-## Is the entity or issuer ID correct?
+## Is the issuer or entity ID correct?
 
-After filling out the authentication form with your identity provider, you're taken back to Metabase but it throws an error. To see the error, go to **Admin settings** > **Troubleshooting** > **Logs**. You'll see an error that says something like **Incorrect response <issuer>**.
+After filling out the authentication form with your identity provider, you're taken back to Metabase but it throws an error. To see the error, go to **Admin settings** > **Troubleshooting** > **Logs**. You'll see an error that says something like **Incorrect response <issuer\>**.
 
-**Root cause**: Your entity or issuer ID is incorrect.
+**Root cause**: Your issuer or entity ID is incorrect.
 
 **Steps to take**:
 
-1. You should have received an XML file of metadata from your identity provider. Open that metadata file, and look for the correct issuer or entity ID. This ID is a unique identifier for the identity provider. Depending on your provider, this usually looks something like http://www.example.com/141xkex604w0Q5PN724v.
-2. Copy that ID.
-3. Go to **Admin settings** > **Settings** > **Authentication** > **SAML** and enter the issuer or entity ID into the **SAML Identity Provider Issuer** field in Metabase. 
+1. You should have received an XML file of metadata from your identity provider. Open that metadata file, and look for the correct issuer or entity ID. This ID is a unique identifier for the identity provider. Depending on your provider, the issuer or entity ID usually looks something like this:
+    ```
+    http://www.example.com/141xkex604w0Q5PN724v
+    ```
+2. Copy the issuer or entity ID from the XML file.
+3. Go to Metabase and select **Admin settings** > **Settings** > **Authentication** > **SAML**. Enter the issuer or entity ID into the **SAML Identity Provider Issuer** field. 
 
 ## Is the SAML identity provider certificate value correct?
 
-After filling out the authentication form with your identity provider, you go back to Metabase but it throws an error. Go to **Admin settings** > **Troubleshooting** > **Logs**. You'll see an error that says something like **Invalid assertion error <issuer>**. 
+After filling out the authentication form with your identity provider, you go back to Metabase but it throws an error. Go to **Admin settings** > **Troubleshooting** > **Logs**. You'll see an error that says something like **Invalid assertion error <issuer\>**. 
 
 **Root cause**: The certificate value you entered is incorrect.
 
 **Steps to take**:
 
-1. You should have received an XML file from your identity provider. Open that metadata file, and check to make sure the certificate you inputted is correct.
-2. Go to **Admin settings** > **Settings** > **Authentication** > **SAML**. Check that the certificate that you entered into the **SAML Identity Provider Certificate** field matches the certificate in the XML file you got from your identity provider. Depending on your provider, you might need to download this, open it in a text editor, then copy and paste the certificate's contents into the field.
+1. Go to Metabase and select **Admin settings** > **Settings** > **Authentication** > **SAML**. Check that the certificate that you entered into the **SAML Identity Provider Certificate** field matches the certificate in the XML file you got from your identity provider. 
+
+    - Depending on your provider, you might need to download the XML file, open it in a text editor, then copy and paste the certificate's contents into the **SAML Identity Provider Certificate** field in Metabase.
+
+    - Note that your certificate text may include header and footer comments that look like `-----BEGIN CERTIFICATE-----` and `-----END CERTIFICATE-----`. These comments should be included when pasting your certificate text into Metabase.
 
 ## Is the SSO URL correct?
 

--- a/docs/troubleshooting-guide/saml.md
+++ b/docs/troubleshooting-guide/saml.md
@@ -37,7 +37,7 @@ After filling out the authentication form with your identity provider, you go ba
 
 ## Is the SSO URL correct?
 
-Verify that the Single Sign On URL (or equivalent) that you enter on your SAML provider’s website has /auth/sso appended to it. For instance, if you want your users to end up at https://metabase.mycompany.com, the full URL should be https://metabase.mycompany.com/auth/sso.
+Verify that the Single Sign On URL (or equivalent) that you enter on your SAML provider’s website has `/auth/sso` appended to it. For instance, if you want your users to end up at `https://metabase.mycompany.com`, the full URL should be `https://metabase.mycompany.com/auth/sso`.
 
 ## Searching for private key and found a null
 
@@ -53,7 +53,7 @@ This error will only occur if you're using **Signed SSO requests**. That is, in 
 
 1. Add a certificate with a private key to your keystore.
 
-### Checking if SAML is working correctly
+## Checking if SAML is working correctly
 
 Go to your Metabase login page. If SAML is working correctly, you should see [a single button to sign in](/glossary/sso) with your identity provider (IdP). Once you're authenticated, you should be automatically redirected to the Metabase home page.
 


### PR DESCRIPTION
Bit of clean up across SSO & SAML docs -- rather pleased that deletions > additions in this PR :)

Changes:
- Moved stuff from Docs to Troubleshooting
  - Moved "Checking if SSO is working correctly" from SSO doc to "Can't log in" page.
  - Moved "Troubleshooting tips" from SAML doc to "Troubleshooting SAML" page.
- Simplified the "Can't log in" page (I'd added an excess of headers last time).