### PR TITLE
Modal tab styling updates

### DIFF
--- a/frontend/src/metabase/core/components/Tab/Tab.styled.tsx
+++ b/frontend/src/metabase/core/components/Tab/Tab.styled.tsx
@@ -1,6 +1,7 @@
 import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
 import Icon from "metabase/components/Icon";
+import Ellipsified from "../Ellipsified";
 
 export interface TabProps {
   isSelected?: boolean;
@@ -35,8 +36,8 @@ export const TabIcon = styled(Icon)`
   margin-right: 0.25rem;
 `;
 
-export const TabLabel = styled.span`
+export const TabLabel = styled(Ellipsified)`
   font-size: 1rem;
-  line-height: 1rem;
   font-weight: bold;
+  max-width: 16rem;
 `;

--- a/frontend/src/metabase/core/components/TabList/TabList.stories.tsx
+++ b/frontend/src/metabase/core/components/TabList/TabList.stories.tsx
@@ -9,15 +9,37 @@ export default {
   title: "Core/TabList",
   component: TabList,
 };
+
+const sampleStyle = {
+  maxWidth: "400px",
+  padding: "10px",
+  border: "1px solid #ccc",
+};
+
 const Template: ComponentStory<typeof TabList> = args => {
   const [{ value }, updateArgs] = useArgs();
   const handleChange = (value: unknown) => updateArgs({ value });
 
   return (
-    <TabList {...args} value={value} onChange={handleChange}>
-      <Tab value={1}>Tab 1</Tab>
-      <Tab value={2}>Tab 2</Tab>
-    </TabList>
+    <div style={sampleStyle}>
+      <TabList {...args} value={value} onChange={handleChange}>
+        <Tab value={1}>Tab 1</Tab>
+        <Tab value={2}>Tab 2</Tab>
+        <Tab value={3}>Tab3supercalifragilisticexpialidocious</Tab>
+        <Tab value={4}>
+          Tab 4 With a Very Long Name that may cause this component to wrap
+        </Tab>
+        <Tab value={5}>
+          Tab 5 With a Very Long Name that may cause this component to wrap
+        </Tab>
+        <Tab value={6}>
+          Tab 6 With a Very Long Name that may cause this component to wrap
+        </Tab>
+        <Tab value={7}>
+          Tab 7 With a Very Long Name that may cause this component to wrap
+        </Tab>
+      </TabList>
+    </div>
   );
 };
 

--- a/frontend/src/metabase/core/components/TabList/TabList.styled.tsx
+++ b/frontend/src/metabase/core/components/TabList/TabList.styled.tsx
@@ -17,7 +17,7 @@ export const TabListContent = styled.div`
 `;
 
 interface ScrollButtonProps {
-  direction: "left" | "right";
+  directionIcon: "left" | "right";
 }
 
 export const ScrollButton = styled.button<ScrollButtonProps>`
@@ -26,14 +26,14 @@ export const ScrollButton = styled.button<ScrollButtonProps>`
   height: 100%;
   width: 3rem;
   padding-bottom: ${space(2)};
-  text-align: ${props => props.direction};
+  text-align: ${props => props.directionIcon};
   color: ${color("text-light")};
   &:hover {
     color: ${color("brand")};
   }
-  ${props => props.direction}: 0;
+  ${props => props.directionIcon}: 0;
   background: linear-gradient(
-    to ${props => props.direction},
+    to ${props => props.directionIcon},
     ${alpha("white", 0.1)},
     ${alpha("white", 0.5)},
     30%,

--- a/frontend/src/metabase/core/components/TabList/TabList.styled.tsx
+++ b/frontend/src/metabase/core/components/TabList/TabList.styled.tsx
@@ -1,10 +1,42 @@
 import styled from "@emotion/styled";
+import { alpha, color } from "metabase/lib/colors";
+import { space } from "metabase/styled-components/theme";
 
 export const TabListRoot = styled.div`
-  overflow-x: auto;
+  position: relative;
+  display: flex;
+  align-items: center;
 `;
 
 export const TabListContent = styled.div`
+  overflow-x: hidden;
   display: flex;
-  gap: 1rem;
+  align-items: flex-start;
+  gap: 2.5rem;
+  scroll-behavior: smooth;
+`;
+
+interface ScrollButtonProps {
+  direction: "left" | "right";
+}
+
+export const ScrollButton = styled.button<ScrollButtonProps>`
+  position: absolute;
+  cursor: pointer;
+  height: 100%;
+  width: 3rem;
+  padding-bottom: ${space(2)};
+  text-align: ${props => props.direction};
+  color: ${color("text-light")};
+  &:hover {
+    color: ${color("brand")};
+  }
+  ${props => props.direction}: 0;
+  background: linear-gradient(
+    to ${props => props.direction},
+    ${alpha("white", 0.1)},
+    ${alpha("white", 0.5)},
+    30%,
+    ${color("white")}
+  );
 `;

--- a/frontend/src/metabase/core/components/TabList/TabList.tsx
+++ b/frontend/src/metabase/core/components/TabList/TabList.tsx
@@ -14,6 +14,8 @@ import { useUniqueId } from "metabase/hooks/use-unique-id";
 import { TabContext, TabContextType } from "../Tab";
 import { TabListContent, TabListRoot, ScrollButton } from "./TabList.styled";
 
+const UNDERSCROLL_PIXELS = 32;
+
 export interface TabListProps<T>
   extends Omit<HTMLAttributes<HTMLDivElement>, "onChange"> {
   value?: T;
@@ -29,7 +31,6 @@ const TabList = forwardRef(function TabGroup<T>(
   const outerContext = useContext(TabContext);
 
   const [scrollPosition, setScrollPosition] = useState(0);
-  const [showScrollLeft, setShowScrollLeft] = useState(false);
   const [showScrollRight, setShowScrollRight] = useState(false);
 
   const tabListContentRef = useRef(null);
@@ -45,11 +46,14 @@ const TabList = forwardRef(function TabGroup<T>(
       const container = tabListContentRef.current as HTMLDivElement;
 
       const scrollDistance =
-        (container.offsetWidth - 32) * (direction === "left" ? -1 : 1);
-      container.scroll(container.scrollLeft + scrollDistance, 0);
+        (container.offsetWidth - UNDERSCROLL_PIXELS) *
+        (direction === "left" ? -1 : 1);
+      container.scrollBy(scrollDistance, 0);
       setScrollPosition(container.scrollLeft + scrollDistance);
     }
   };
+
+  const showScrollLeft = scrollPosition > 0;
 
   useEffect(() => {
     if (!tabListContentRef.current) {
@@ -60,8 +64,7 @@ const TabList = forwardRef(function TabGroup<T>(
     setShowScrollRight(
       scrollPosition + container.offsetWidth < container.scrollWidth,
     );
-    setShowScrollLeft(scrollPosition > 0);
-  }, [setShowScrollLeft, setShowScrollRight, scrollPosition]);
+  }, [scrollPosition]);
 
   return (
     <TabListRoot {...props} ref={ref} role="tablist">
@@ -88,7 +91,7 @@ interface ScrollArrowProps {
 const ScrollArrow = ({ direction, onClick }: ScrollArrowProps) => (
   <ScrollButton
     onClick={onClick}
-    direction={direction}
+    directionIcon={direction}
     aria-label={`scroll-${direction}-button`}
   >
     <Icon name={`chevron${direction}`} color="brand" />

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterModal/BulkFilterModal.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterModal/BulkFilterModal.styled.tsx
@@ -38,7 +38,7 @@ export const ModalTitle = styled(Ellipsified)`
 `;
 
 export const ModalTabList = styled(TabList)`
-  padding: 0 2rem;
+  margin: 0 2rem;
   flex-shrink: 0;
 `;
 

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterModal/BulkFilterModal.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterModal/BulkFilterModal.tsx
@@ -174,7 +174,7 @@ const BulkFilterModalSectionList = ({
     <TabContent value={tab} onChange={setTab}>
       <ModalTabList>
         {sections.map((section, index) => (
-          <Tab key={index} value={index} icon={section.icon}>
+          <Tab key={index} value={index}>
             {section.name}
           </Tab>
         ))}


### PR DESCRIPTION
## Before

![Screen Shot 2022-06-29 at 2 40 41 PM](https://user-images.githubusercontent.com/30528226/176540625-a0f9d6f7-c693-4cfe-9b8c-5850a587502d.png)
![badscroll](https://user-images.githubusercontent.com/30528226/176541012-d4ccc0ce-92e0-41fa-922a-26ce733222fa.gif)


## Changes

Two parts to this
1. Hide Icons and add spacing in the modal tab list
2. More elegant scrolling support for long table names, and scrolling table lists

[figma design](https://www.figma.com/file/jXbZjiG8q7XGd5De62ut1Q/Make-filters-more-aware-of-what-they're-filtering?node-id=226%3A6860)

## After
. | . 
--- | ---
Without Scroll | ![Screen Shot 2022-06-29 at 2 19 46 PM](https://user-images.githubusercontent.com/30528226/176540748-203bd92b-dfdc-499f-8135-b28d4a3b9e4d.png)
With Scroll | ![scrollmodal](https://user-images.githubusercontent.com/30528226/176540727-bb89a430-df7b-4122-8d60-c68d1838d6b5.gif)