### PR TITLE
Add serialization hierarchy, serialize Database, Table and Field

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -366,7 +366,7 @@
            metabase.test/with-user-in-groups clojure.core/let
            metabase.test.data.interface/defdataset clojure.core/def
            metabase.test.data.interface/defdataset-edn clojure.core/def
-           metabase-enterprise.serialization.test-util/with-random-dump-dir clojure.core/fn
+           metabase-enterprise.serialization.test-util/with-random-dump-dir clojure.core/let
            metabase.driver.mongo.util/with-mongo-connection clojure.core/let
            metabase.driver.mongo.query-processor/mongo-let clojure.core/let
            toucan.db/with-call-counting clojure.core/fn

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/ingest.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/ingest.clj
@@ -10,11 +10,13 @@
   ;; This is written as a protocol since overriding it with [[reify]] if useful for testing.
   (ingest-list
     [this]
-    "Return a reducible stream of meta-maps, one for each entity in the dump.
+    "Return a reducible stream of meta-map *hierarchies*, one for each entity in the dump.
     See the description of the `:serdes/meta` maps in [[metabase.models.serialization.base]].
+    Each hierarchy is ordered from the root to the leaf.
 
-    The order is not specified and should not be relied upon!")
+    The order of the whole list is not specified and should not be relied upon!")
 
   (ingest-one
-    [this meta-map]
-    "Given one of the meta-maps returned by [[ingest-list]], read in and return the entire corresponding entity."))
+    [this meta-maps]
+    "Given one of the meta-map hierarchies returned by [[ingest-list]], read in and return the entire corresponding
+    entity."))

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/ingest.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/ingest.clj
@@ -7,7 +7,7 @@
 
 (p/defprotocol+ Ingestable
   ;; Represents a data source for deserializing previously-exported appdb content into this Metabase instance.
-  ;; This is written as a protocol since overriding it with [[reify]] if useful for testing.
+  ;; This is written as a protocol since overriding it with [[reify]] is useful for testing.
   (ingest-list
     [this]
     "Return a reducible stream of `:serdes/meta`-style abstract paths, one for each entity in the dump.

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/ingest.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/ingest.clj
@@ -10,13 +10,13 @@
   ;; This is written as a protocol since overriding it with [[reify]] if useful for testing.
   (ingest-list
     [this]
-    "Return a reducible stream of meta-map *hierarchies*, one for each entity in the dump.
-    See the description of the `:serdes/meta` maps in [[metabase.models.serialization.base]].
-    Each hierarchy is ordered from the root to the leaf.
+    "Return a reducible stream of `:serdes/meta`-style abstract paths, one for each entity in the dump.
+    See the description of these abstract paths in [[metabase.models.serialization.base]].
+    Each path is ordered from the root to the leaf.
 
     The order of the whole list is not specified and should not be relied upon!")
 
   (ingest-one
-    [this meta-maps]
-    "Given one of the meta-map hierarchies returned by [[ingest-list]], read in and return the entire corresponding
-    entity."))
+    [this path]
+    "Given one of the `:serdes/meta` abstract paths returned by [[ingest-list]], read in and return the entire
+    corresponding entity."))

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/ingest/yaml.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/ingest/yaml.clj
@@ -48,19 +48,15 @@
                     (mapcat (partial build-metas root-dir)))
               (file-seq root-dir)))
 
-  (ingest-one [_ meta-maps]
-    (let [{:keys [model id]} (first meta-maps)]
-      (if (and (= 1 (count meta-maps))
+  (ingest-one [_ abs-path]
+    (let [{:keys [model id]} (first abs-path)]
+      (if (and (= 1 (count abs-path))
                (= "Setting" model))
-        {:serdes/meta meta-maps :key (keyword id) :value (get settings (keyword id))}
-        (ingest-entity root-dir meta-maps)))))
+        {:serdes/meta abs-path :key (keyword id) :value (get settings (keyword id))}
+        (ingest-entity root-dir abs-path)))))
 
 (defn ingest-yaml
   "Creates a new Ingestable on a directory of YAML files, as created by
   [[metabase-enterprise.serialization.v2.storage.yaml]]."
   [root-dir]
   (->YamlIngestion (io/file root-dir) (yaml/from-file (io/file root-dir "settings.yaml"))))
-
-(comment
-  (into [] (ingest/ingest-list (ingest-yaml (io/file "/tmp/serdesv2-EHDVDKJCFOTQTVXCJJMD"))))
-  )

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
@@ -3,11 +3,7 @@
   See the detailed breakdown of the (de)serialization processes in [[metabase.models.serialization.base]]."
   (:require [medley.core :as m]
             [metabase-enterprise.serialization.v2.ingest :as serdes.ingest]
-            [metabase-enterprise.serialization.v2.models :as serdes.models]
-            [metabase.models.serialization.base :as serdes.base]
-            [metabase.models.serialization.hash :as serdes.hash]
-            [toucan.db :as db]
-            [toucan.models :as models]))
+            [metabase.models.serialization.base :as serdes.base]))
 
 (declare load-one)
 
@@ -17,8 +13,6 @@
   (if (empty? deps)
     ctx
     (reduce load-one ctx deps)))
-
-(def ^:private dummy-models #{"Schema"})
 
 (defn- load-one
   "Loads a single entity, specified by its meta-map hierarchy into the appdb, doing the necessary bookkeeping.

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
@@ -5,49 +5,65 @@
             [metabase-enterprise.serialization.v2.ingest :as serdes.ingest]
             [metabase-enterprise.serialization.v2.models :as serdes.models]
             [metabase.models.serialization.base :as serdes.base]
-            [toucan.db :as db]))
+            [metabase.models.serialization.hash :as serdes.hash]
+            [toucan.db :as db]
+            [toucan.models :as models]))
 
-(defn- load-prescan-model [model]
-  (transduce (map (fn [[eid ih pk]]
-                    {:by-entity-id     [eid pk]
-                     :by-identity-hash [ih pk]}))
-             (partial merge-with conj)
-             {:by-entity-id {} :by-identity-hash {}}
-             (serdes.base/load-prescan-all model)))
+(defn- update-local [local [{:keys [model id]} & tail] eid ih new-pk]
+  (if (empty? tail)
+    ;; We've reach the bottom, update this map here.
+    (cond-> local
+      eid (assoc-in [model :by-entity-id     eid] new-pk)
+      ih  (assoc-in [model :by-identity-hash ih]  new-pk))
+
+    ;; If there's still more nesting to go, recurse in.
+    (let [pk (or (get-in local [model :by-entity-id id])
+                 (get-in local [model :by-identity-hash id]))]
+      (update-in local [model :children pk] update-local tail eid ih new-pk))))
+
+(defn- load-prescan-model [local {:keys [hierarchy entity_id identity-hash primary-key]}]
+  (update-local local hierarchy entity_id identity-hash primary-key))
+
+;; The map is shaped like this:
+;; {"Database"  {:by-primary-key   {1 {"Table" {:by-entity-id {"76543" 12}}}}
+;;               :by-entity-id     {"12345" 1}
+;;               :by-identity-hash {"df12" 1}}
+;;  "Table" {:by-primary-key {12 {"Field" {:by-entity-id {"99" 60}}}}}
+;;  "Field" {:by-primary-key '...}}
+;; This normalization helps to keep it easy to update as new entities are scanned; there's a 
 
 (defn- load-prescan
   "For all the exported models in the list, run the prescan process."
   []
-  (into {} (for [model serdes.models/exported-models]
-             [model (load-prescan-model model)])))
-
-;; These are on ice for now; they'll be dusted off as the YAML storage/ingestion code is added in a later PR.
-;; (defn- path-parts [path]
-;;   (->> (java.nio.file.Paths/get path (into-array String []))
-;;        (.iterator)
-;;        (iterator-seq)
-;;        (map str)))
-;;
-;; (defn- id-from-path [path]
-;;   (let [^String file (last (path-parts path))
-;;         base         (.substring file 0 (.lastIndexOf file "."))
-;;         ; Things with human-readable names use the form identity_hash+human_name.yaml
-;;         plus         (.indexOf base "+")]
-;;     (if (< plus 0)
-;;       base
-;;       (.substring base 0 plus))))
+  (transduce (mapcat serdes.base/load-prescan-all) (completing load-prescan-model) {} serdes.models/exported-models))
 
 (declare load-one)
 
 (defn- load-deps
-  "Given a list of `deps` (raw IDs), convert it to a list of meta-maps and `load-one` them all."
+  "Given a list of `deps` (hierarchies), `load-one` them all."
   [ctx deps]
   (if (empty? deps)
     ctx
-    (reduce load-one ctx (map (:from-ids ctx) deps))))
+    (reduce load-one ctx deps)))
+
+(def ^:private dummy-models #{"Schema"})
+
+(defn- find-local [local [{:keys [model id]} & tail]]
+  ;; The nesting of the locals table goes like this:
+  ;; {"Database" {:by-primary-key   {1 {"Field" {...}}}
+  ;;              :by-entity-id     {"my-db" 1}
+  ;;              :by-identity-hash {"123456" 1}}}
+  (let [pk (or (get-in local [model :by-entity-id id])
+               (get-in local [model :by-identity-hash id])
+               (when (dummy-models model) id))]
+    (if (empty? tail)
+      ;; We've reached the bottom: load this Toucan entity by its primary key.
+      ((db/resolve-model (symbol model)) pk)
+      ;; Still more nesting. Continue into the children map.
+      (recur (get-in local [model :by-primary-key pk]) tail))))
 
 (defn- load-one
-  "Loads a single meta-map into the appdb, doing the necessary bookkeeping.
+  "Loads a single entity, specified by its meta-map hierarchy into the appdb, doing the necessary bookkeeping.
 
   If the incoming entity has any dependencies, they are processed first (postorder) so that any foreign key references
   in this entity can be resolved properly.
@@ -56,27 +72,27 @@
   [[metabase.models.serialization.base/load-one!]] and its various overridable parts, which see.
 
   Circular dependencies are not allowed, and are detected and thrown as an error."
-  [{:keys [expanding ingestion seen] :as ctx} {id :id model-name :model :as meta-map}]
+  [{:keys [expanding ingestion seen] :as ctx} hierarchy]
   (cond
-    (expanding id) (throw (ex-info (format "Circular dependency on %s %s" model-name id) {}))
-    (seen id)      ctx ; Already been done, just skip it.
-    :else (let [ingested (serdes.ingest/ingest-one ingestion meta-map)
-                model    (db/resolve-model (symbol model-name))
+    (expanding hierarchy) (throw (ex-info (format "Circular dependency on %s" (pr-str hierarchy)) {}))
+    (seen hierarchy)      ctx ; Already been done, just skip it.
+    :else (let [ingested (serdes.ingest/ingest-one ingestion hierarchy)
+                ;model    (db/resolve-model (symbol model-name))
                 deps     (serdes.base/serdes-dependencies ingested)
                 ctx      (-> ctx
-                             (update :expanding conj id)
+                             (update :expanding conj hierarchy)
                              (load-deps deps)
-                             (update :seen conj id)
-                             (update :expanding disj id))
+                             (update :seen conj hierarchy)
+                             (update :expanding disj hierarchy))
+                local    (find-local (:local ctx) hierarchy)
                 pk       (serdes.base/load-one!
                            ingested
-                           (or (get-in ctx [:local (name model) :by-entity-id id])
-                               (get-in ctx [:local (name model) :by-identity-hash id])))]
-            (assoc-in ctx [:local
-                           (name model)
-                           (if (serdes.base/entity-id? id) :by-entity-id :by-identity-hash)
-                           id]
-                      pk))))
+                           (get local (models/primary-key local)))]
+            (update ctx :local
+                    update-local hierarchy
+                    (serdes.base/serdes-entity-id (name local) ingested)
+                    (serdes.hash/identity-hash local)
+                    pk))))
 
 (defn load-metabase
   "Loads in a database export from an ingestion source, which is any Ingestable instance."
@@ -90,3 +106,23 @@
                       :ingestion ingestion
                       :from-ids  (m/index-by :id contents)}
             contents)))
+
+(comment
+  ;; START HERE The prescan/local check piece needs a complete rebuild.
+  ;; The actual objective is, given the entity (and hierachy) of an incoming value, do we have a corresponding one in this
+  ;; appdb?
+  ;; In general, that can be answered by logic like this:
+  ;; - If the ID is NanoID shaped, look it up by that index.
+  ;; - If not (or not found), look it up by identity-hash.
+  ;; - The identity hashes could be cached in some memoized scheme, to avoid repeatedly scanning the whole table.
+  ;; Put that in a multimethod keyed by the model, which allows Table and Field to override it with their own, hierarchy
+  ;; based logic. They have to deal with hierarchies (and Schemas), but also they don't have to fret about identity
+  ;; hashes, because the databases, tables and fields already have human-selected names.
+  ;; That also gives a nice plug-in point for database-engine specific logic around table namespacing.
+  ;;
+  ;; I think that will work, and replace nearly all of this prescan code, which will move into lazily-applied
+  ;; default.
+  ;;
+  (serdes.base/load-prescan-one (db/resolve-model 'Table) (into {} (db/select-one 'Table :id 1))
+                                #_(assoc (into {} (db/select-one 'Table :id 1)) :serdes/meta {:model "Table" :id "PRODUCTS"}))
+  (load-prescan))

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
@@ -9,34 +9,6 @@
             [toucan.db :as db]
             [toucan.models :as models]))
 
-(defn- update-local [local [{:keys [model id]} & tail] eid ih new-pk]
-  (if (empty? tail)
-    ;; We've reach the bottom, update this map here.
-    (cond-> local
-      eid (assoc-in [model :by-entity-id     eid] new-pk)
-      ih  (assoc-in [model :by-identity-hash ih]  new-pk))
-
-    ;; If there's still more nesting to go, recurse in.
-    (let [pk (or (get-in local [model :by-entity-id id])
-                 (get-in local [model :by-identity-hash id]))]
-      (update-in local [model :children pk] update-local tail eid ih new-pk))))
-
-(defn- load-prescan-model [local {:keys [hierarchy entity_id identity-hash primary-key]}]
-  (update-local local hierarchy entity_id identity-hash primary-key))
-
-;; The map is shaped like this:
-;; {"Database"  {:by-primary-key   {1 {"Table" {:by-entity-id {"76543" 12}}}}
-;;               :by-entity-id     {"12345" 1}
-;;               :by-identity-hash {"df12" 1}}
-;;  "Table" {:by-primary-key {12 {"Field" {:by-entity-id {"99" 60}}}}}
-;;  "Field" {:by-primary-key '...}}
-;; This normalization helps to keep it easy to update as new entities are scanned; there's a 
-
-(defn- load-prescan
-  "For all the exported models in the list, run the prescan process."
-  []
-  (transduce (mapcat serdes.base/load-prescan-all) (completing load-prescan-model) {} serdes.models/exported-models))
-
 (declare load-one)
 
 (defn- load-deps
@@ -47,20 +19,6 @@
     (reduce load-one ctx deps)))
 
 (def ^:private dummy-models #{"Schema"})
-
-(defn- find-local [local [{:keys [model id]} & tail]]
-  ;; The nesting of the locals table goes like this:
-  ;; {"Database" {:by-primary-key   {1 {"Field" {...}}}
-  ;;              :by-entity-id     {"my-db" 1}
-  ;;              :by-identity-hash {"123456" 1}}}
-  (let [pk (or (get-in local [model :by-entity-id id])
-               (get-in local [model :by-identity-hash id])
-               (when (dummy-models model) id))]
-    (if (empty? tail)
-      ;; We've reached the bottom: load this Toucan entity by its primary key.
-      ((db/resolve-model (symbol model)) pk)
-      ;; Still more nesting. Continue into the children map.
-      (recur (get-in local [model :by-primary-key pk]) tail))))
 
 (defn- load-one
   "Loads a single entity, specified by its meta-map hierarchy into the appdb, doing the necessary bookkeeping.
@@ -84,15 +42,12 @@
                              (load-deps deps)
                              (update :seen conj hierarchy)
                              (update :expanding disj hierarchy))
-                local    (find-local (:local ctx) hierarchy)
-                pk       (serdes.base/load-one!
-                           ingested
-                           (get local (models/primary-key local)))]
-            (update ctx :local
-                    update-local hierarchy
-                    (serdes.base/serdes-entity-id (name local) ingested)
-                    (serdes.hash/identity-hash local)
-                    pk))))
+                ;; Regenerate the hierarchy, since the one from the filesystem might have eg. sanitized file names.
+                ;; Those suffice to look up the value, but it should be derived from the real value.
+                rebuilt-hierarchy (serdes.base/serdes-hierarchy ingested)
+                local-pk (serdes.base/load-find-local rebuilt-hierarchy)
+                _        (serdes.base/load-one! ingested local-pk)]
+            ctx)))
 
 (defn load-metabase
   "Loads in a database export from an ingestion source, which is any Ingestable instance."
@@ -100,29 +55,14 @@
   ;; We proceed in the arbitrary order of ingest-list, deserializing all the files. Their declared dependencies guide
   ;; the import, and make sure all containers are imported before contents, etc.
   (let [contents (serdes.ingest/ingest-list ingestion)]
-    (reduce load-one {:local     (load-prescan)
-                      :expanding #{}
+    (reduce load-one {:expanding #{}
                       :seen      #{}
                       :ingestion ingestion
                       :from-ids  (m/index-by :id contents)}
             contents)))
 
 (comment
-  ;; START HERE The prescan/local check piece needs a complete rebuild.
-  ;; The actual objective is, given the entity (and hierachy) of an incoming value, do we have a corresponding one in this
-  ;; appdb?
-  ;; In general, that can be answered by logic like this:
-  ;; - If the ID is NanoID shaped, look it up by that index.
-  ;; - If not (or not found), look it up by identity-hash.
-  ;; - The identity hashes could be cached in some memoized scheme, to avoid repeatedly scanning the whole table.
-  ;; Put that in a multimethod keyed by the model, which allows Table and Field to override it with their own, hierarchy
-  ;; based logic. They have to deal with hierarchies (and Schemas), but also they don't have to fret about identity
-  ;; hashes, because the databases, tables and fields already have human-selected names.
-  ;; That also gives a nice plug-in point for database-engine specific logic around table namespacing.
-  ;;
-  ;; I think that will work, and replace nearly all of this prescan code, which will move into lazily-applied
-  ;; default.
-  ;;
-  (serdes.base/load-prescan-one (db/resolve-model 'Table) (into {} (db/select-one 'Table :id 1))
-                                #_(assoc (into {} (db/select-one 'Table :id 1)) :serdes/meta {:model "Table" :id "PRODUCTS"}))
-  (load-prescan))
+  (serdes.base/load-find-local [{:model "Database" :id "Sample Database"}
+                                {:model "Schema"   :id "PUBLIC"}
+                                {:model "Table"    :id "ORDERS"}])
+  )

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
@@ -28,7 +28,7 @@
   [{:keys [expanding ingestion seen] :as ctx} path]
   (cond
     (expanding path) (throw (ex-info (format "Circular dependency on %s" (pr-str path)) {:path path}))
-    (seen path)      ctx ; Already been done, just skip it.
+    (seen path) ctx ; Already been done, just skip it.
     :else (let [ingested (serdes.ingest/ingest-one ingestion path)
                 deps     (serdes.base/serdes-dependencies ingested)
                 ctx      (-> ctx

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
@@ -3,4 +3,6 @@
 (def exported-models
   "The list of models which are exported by serialization. Used for production code and by tests."
   ["Collection"
-   "Setting"])
+   "Database"
+   "Setting"
+   "Table"])

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
@@ -4,5 +4,6 @@
   "The list of models which are exported by serialization. Used for production code and by tests."
   ["Collection"
    "Database"
+   "Field"
    "Setting"
    "Table"])

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/storage/yaml.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/storage/yaml.clj
@@ -13,9 +13,9 @@
     (u.date/format data)))
 
 (defn- spit-yaml
-  [path obj]
-  (apply io/make-parents path)
-  (spit (apply io/file path) (yaml/generate-string obj :dumper-options {:flow-style :block})))
+  [file obj]
+  (io/make-parents file)
+  (spit (io/file file) (yaml/generate-string obj :dumper-options {:flow-style :block})))
 
 (defn- store-entity! [{:keys [root-dir]} entity]
   (spit-yaml (u.yaml/hierarchy->file root-dir (serdes.base/serdes-hierarchy entity))
@@ -25,7 +25,7 @@
   (let [as-map (into (sorted-map)
                      (for [{:keys [key value]} settings]
                        [key value]))]
-    (spit-yaml [root-dir "settings.yaml"] as-map)))
+    (spit-yaml (io/file root-dir "settings.yaml") as-map)))
 
 (defmethod storage/store-all! :yaml [stream opts]
   (when-not (or (string? (:root-dir opts))

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/storage/yaml.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/storage/yaml.clj
@@ -18,7 +18,7 @@
   (spit (io/file file) (yaml/generate-string obj :dumper-options {:flow-style :block})))
 
 (defn- store-entity! [{:keys [root-dir]} entity]
-  (spit-yaml (u.yaml/hierarchy->file root-dir (serdes.base/serdes-hierarchy entity))
+  (spit-yaml (u.yaml/hierarchy->file root-dir (serdes.base/serdes-path entity))
              (dissoc entity :serdes/meta)))
 
 (defn- store-settings! [{:keys [root-dir]} settings]
@@ -34,7 +34,7 @@
                     {:opts opts})))
   (let [settings (atom [])]
     (doseq [entity stream]
-      (if (-> entity :serdes/meta :model (= "Setting"))
+      (if (-> entity :serdes/meta last :model (= "Setting"))
         (swap! settings conj entity)
         (store-entity! opts entity)))
     (store-settings! opts @settings)))

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/utils/yaml.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/utils/yaml.clj
@@ -9,7 +9,7 @@
       s))
 
 (defn hierarchy->file
-  "Given a :serdes/meta hierarchy, return a [[File]] corresponding to it."
+  "Given a :serdes/meta abstract path, return a [[File]] corresponding to it."
   ^File [root-dir hierarchy]
   (let [;; All earlier parts of the hierarchy form Model/id/ pairs.
         prefix     (apply concat (for [{:keys [model id]} (drop-last hierarchy)]
@@ -31,7 +31,8 @@
       (.getName (.toFile path)))))
 
 (defn path->hierarchy
-  "Given the list of path chunks as returned by [[path-split]], reconstruct the hierarchy corresponding to it."
+  "Given the list of file path chunks as returned by [[path-split]], reconstruct the `:serdes/meta` abstract path
+  corresponding to it."
   [path-parts]
   (let [parentage  (into [] (for [[model id] (partition 2 (drop-last 2 path-parts))]
                               {:model model :id id}))

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/utils/yaml.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/utils/yaml.clj
@@ -1,21 +1,29 @@
 (ns metabase-enterprise.serialization.v2.utils.yaml
-  (:require [clojure.java.io :as io])
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str])
   (:import java.io.File))
+
+#_(defn- clean-string [s]
+  (let [clean  (str/replace s #"[^a-zA-Z0-9+\-_ \.]+" "")]
+    (if (> (count clean) 100)
+      (.substring clean 0 100)
+      clean)))
+
+(def ^:private clean-string identity)
 
 (defn ^File hierarchy->file
   "Given a :serdes/meta hierarchy, return a [[File]] corresponding to it."
   [root-dir hierarchy]
   (let [;; All earlier parts of the hierarchy form Model/id/ pairs.
         prefix     (apply concat (for [{:keys [model id]} (drop-last hierarchy)]
-                                   [model id]))
+                                   [model (clean-string id)]))
         ;; The last part of the hierarchy is used for the basename; this is the only part with the label.
-        {:keys [id model label]} (:serdes/meta (last hierarchy))
+        {:keys [id model label]} (last hierarchy)
         basename   (if (nil? label)
-                     (str id ".yaml")
+                     (str id)
                      ;; + is a legal, unescaped character on all common filesystems, but not `identity-hash` or NanoID!
-                     (str id "+" label ".yaml"))]
-    (prn hierarchy prefix model basename)
-    (apply io/file root-dir (concat prefix [model basename]))))
+                     (str id "+" label))]
+    (apply io/file root-dir (concat prefix [model (str (clean-string basename) ".yaml")]))))
 
 (defn path-split
   "Given a root directory and a file underneath it, return a sequence of path parts to get there.
@@ -28,7 +36,7 @@
 (defn path->hierarchy
   "Given the list of path chunks as returned by [[path-split]], reconstruct the hierarchy corresponding to it."
   [path-parts]
-  (let [parentage  (into [] (for [[model id] (drop-last 2 path-parts)]
+  (let [parentage  (into [] (for [[model id] (partition 2 (drop-last 2 path-parts))]
                               {:model model :id id}))
         [model basename] (take-last 2 path-parts)
         [_ id label]     (or (re-matches #"^([A-Za-z0-9_-]+)(?:\+(.*))?\.yaml$" basename)

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/utils/yaml.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/utils/yaml.clj
@@ -1,0 +1,37 @@
+(ns metabase-enterprise.serialization.v2.utils.yaml
+  (:require [clojure.java.io :as io])
+  (:import java.io.File))
+
+(defn ^File hierarchy->file
+  "Given a :serdes/meta hierarchy, return a [[File]] corresponding to it."
+  [root-dir hierarchy]
+  (let [;; All earlier parts of the hierarchy form Model/id/ pairs.
+        prefix     (apply concat (for [{:keys [model id]} (drop-last hierarchy)]
+                                   [model id]))
+        ;; The last part of the hierarchy is used for the basename; this is the only part with the label.
+        {:keys [id model label]} (:serdes/meta (last hierarchy))
+        basename   (if (nil? label)
+                     (str id ".yaml")
+                     ;; + is a legal, unescaped character on all common filesystems, but not `identity-hash` or NanoID!
+                     (str id "+" label ".yaml"))]
+    (prn hierarchy prefix model basename)
+    (apply io/file root-dir (concat prefix [model basename]))))
+
+(defn path-split
+  "Given a root directory and a file underneath it, return a sequence of path parts to get there.
+  Given a root of /foo and file /foo/bar/baz/this.file, returns `[\"bar\" \"baz\" \"this.file\"]`."
+  [^File root-dir ^File file]
+  (let [relative (.relativize (.toPath root-dir) (.toPath file))]
+    (for [path  (iterator-seq (.iterator relative))]
+      (.getName (.toFile path)))))
+
+(defn path->hierarchy
+  "Given the list of path chunks as returned by [[path-split]], reconstruct the hierarchy corresponding to it."
+  [path-parts]
+  (let [parentage  (into [] (for [[model id] (drop-last 2 path-parts)]
+                              {:model model :id id}))
+        [model basename] (take-last 2 path-parts)
+        [_ id label]     (or (re-matches #"^([A-Za-z0-9_-]+)(?:\+(.*))?\.yaml$" basename)
+                             (re-matches #"^(.+)\.yaml$" basename))]
+    (conj parentage (cond-> {:model model :id id}
+                      label (assoc :label label)))))

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/utils/yaml.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/utils/yaml.clj
@@ -3,27 +3,24 @@
             [clojure.string :as str])
   (:import java.io.File))
 
-#_(defn- clean-string [s]
-  (let [clean  (str/replace s #"[^a-zA-Z0-9+\-_ \.]+" "")]
-    (if (> (count clean) 100)
-      (.substring clean 0 100)
-      clean)))
-
-(def ^:private clean-string identity)
+(defn- clean-string [s]
+  (if (> (count s) 100)
+      (.substring s 0 100)
+      s))
 
 (defn ^File hierarchy->file
   "Given a :serdes/meta hierarchy, return a [[File]] corresponding to it."
   [root-dir hierarchy]
   (let [;; All earlier parts of the hierarchy form Model/id/ pairs.
         prefix     (apply concat (for [{:keys [model id]} (drop-last hierarchy)]
-                                   [model (clean-string id)]))
+                                   [model id]))
         ;; The last part of the hierarchy is used for the basename; this is the only part with the label.
         {:keys [id model label]} (last hierarchy)
         basename   (if (nil? label)
                      (str id)
                      ;; + is a legal, unescaped character on all common filesystems, but not `identity-hash` or NanoID!
-                     (str id "+" label))]
-    (apply io/file root-dir (concat prefix [model (str (clean-string basename) ".yaml")]))))
+                     (str id "+" (clean-string label)))]
+    (apply io/file root-dir (concat prefix [model (str basename ".yaml")]))))
 
 (defn path-split
   "Given a root directory and a file underneath it, return a sequence of path parts to get there.

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/utils/yaml.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/utils/yaml.clj
@@ -3,23 +3,26 @@
   (:import java.io.File
            java.nio.file.Path))
 
-(defn- clean-string [s]
-  (if (> (count s) 100)
-      (subs s 0 100)
+(def ^:private max-label-length 100)
+
+(defn- truncate-label [s]
+  (if (> (count s) max-label-length)
+      (subs s 0 max-label-length)
       s))
 
 (defn hierarchy->file
   "Given a :serdes/meta abstract path, return a [[File]] corresponding to it."
   ^File [root-dir hierarchy]
   (let [;; All earlier parts of the hierarchy form Model/id/ pairs.
-        prefix     (apply concat (for [{:keys [model id]} (drop-last hierarchy)]
-                                   [model id]))
+        prefix                   (apply concat (for [{:keys [model id]} (drop-last hierarchy)]
+                                                 [model id]))
         ;; The last part of the hierarchy is used for the basename; this is the only part with the label.
         {:keys [id model label]} (last hierarchy)
-        basename   (if (nil? label)
-                     (str id)
-                     ;; + is a legal, unescaped character on all common filesystems, but not `identity-hash` or NanoID!
-                     (str id "+" (clean-string label)))]
+        basename                 (if (nil? label)
+                                   (str id)
+                                   ;; + is a legal, unescaped character on all common filesystems,
+                                   ;; but doesn't appear in `identity-hash` or NanoID!
+                                   (str id "+" (truncate-label label)))]
     (apply io/file root-dir (concat prefix [model (str basename ".yaml")]))))
 
 (defn path-split
@@ -27,15 +30,15 @@
   Given a root of /foo and file /foo/bar/baz/this.file, returns `[\"bar\" \"baz\" \"this.file\"]`."
   [^File root-dir ^File file]
   (let [relative (.relativize (.toPath root-dir) (.toPath file))]
-    (for [^Path path  (iterator-seq (.iterator relative))]
+    (for [^Path path (iterator-seq (.iterator relative))]
       (.getName (.toFile path)))))
 
 (defn path->hierarchy
   "Given the list of file path chunks as returned by [[path-split]], reconstruct the `:serdes/meta` abstract path
   corresponding to it."
   [path-parts]
-  (let [parentage  (into [] (for [[model id] (partition 2 (drop-last 2 path-parts))]
-                              {:model model :id id}))
+  (let [parentage        (into [] (for [[model id] (partition 2 (drop-last 2 path-parts))]
+                                    {:model model :id id}))
         [model basename] (take-last 2 path-parts)
         [_ id label]     (or (re-matches #"^([A-Za-z0-9_-]+)(?:\+(.*))?\.yaml$" basename)
                              (re-matches #"^(.+)\.yaml$" basename))]

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/utils/yaml.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/utils/yaml.clj
@@ -1,16 +1,16 @@
 (ns metabase-enterprise.serialization.v2.utils.yaml
-  (:require [clojure.java.io :as io]
-            [clojure.string :as str])
-  (:import java.io.File))
+  (:require [clojure.java.io :as io])
+  (:import java.io.File
+           java.nio.file.Path))
 
 (defn- clean-string [s]
   (if (> (count s) 100)
-      (.substring s 0 100)
+      (subs s 0 100)
       s))
 
-(defn ^File hierarchy->file
+(defn hierarchy->file
   "Given a :serdes/meta hierarchy, return a [[File]] corresponding to it."
-  [root-dir hierarchy]
+  ^File [root-dir hierarchy]
   (let [;; All earlier parts of the hierarchy form Model/id/ pairs.
         prefix     (apply concat (for [{:keys [model id]} (drop-last hierarchy)]
                                    [model id]))
@@ -27,7 +27,7 @@
   Given a root of /foo and file /foo/bar/baz/this.file, returns `[\"bar\" \"baz\" \"this.file\"]`."
   [^File root-dir ^File file]
   (let [relative (.relativize (.toPath root-dir) (.toPath file))]
-    (for [path  (iterator-seq (.iterator relative))]
+    (for [^Path path  (iterator-seq (.iterator relative))]
       (.getName (.toFile path)))))
 
 (defn path->hierarchy

--- a/enterprise/backend/test/metabase_enterprise/serialization/cmd_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/cmd_test.clj
@@ -70,7 +70,7 @@
 
 (deftest mode-update-remove-cards-test
   (testing "--mode update should remove Cards in a Dashboard if they're gone from the serialized YAML (#20786)"
-    (ts/with-random-dump-dir [dump-dir]
+    (ts/with-random-dump-dir [dump-dir "serialization"]
       (let [dashboard-yaml-filename (str dump-dir "/collections/root/dashboards/Dashboard.yaml")]
         (ts/with-source-and-dest-dbs
           (testing "create 2 questions in the source and add them to a dashboard"

--- a/enterprise/backend/test/metabase_enterprise/serialization/cmd_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/cmd_test.clj
@@ -52,11 +52,11 @@
           :created_at             :%now
           :updated_at             :%now)
         ;; serialize "everything" (which should just be the card and user), which should succeed if #16931 is fixed
-        (is (nil? (cmd/dump (ts/random-dump-dir))))))))
+        (is (nil? (cmd/dump (ts/random-dump-dir "serdes-"))))))))
 
 (deftest blank-target-db-test
   (testing "Loading a dump into an empty app DB still works (#16639)"
-    (let [dump-dir                 (ts/random-dump-dir)
+    (let [dump-dir                 (ts/random-dump-dir "serdes-")
           user-pre-insert-called?  (atom false)]
       (log/infof "Dumping to %s" dump-dir)
       (cmd/dump dump-dir "--user" "crowberto@metabase.com")

--- a/enterprise/backend/test/metabase_enterprise/serialization/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/test_util.clj
@@ -117,11 +117,11 @@
   [& body]
   `(~'&do-with-dest-db (fn [] ~@body)))
 
-(defn random-dump-dir []
-  (str (System/getProperty "java.io.tmpdir") "/" (mt/random-name)))
+(defn random-dump-dir [prefix]
+  (str (System/getProperty "java.io.tmpdir") "/" prefix (mt/random-name)))
 
-(defn do-with-random-dump-dir [f]
-  (let [dump-dir (random-dump-dir)]
+(defn do-with-random-dump-dir [prefix f]
+  (let [dump-dir (random-dump-dir (or prefix ""))]
     (testing (format "\nDump dir = %s" (pr-str dump-dir))
       (try
         (f dump-dir)
@@ -129,8 +129,8 @@
           (when (.exists (io/file dump-dir))
             (.delete (io/file dump-dir))))))))
 
-(defmacro with-random-dump-dir {:style/indent 1} [[dump-dir-binding] & body]
-  `(do-with-random-dump-dir (fn [~dump-dir-binding] ~@body)))
+(defmacro with-random-dump-dir {:style/indent 1} [[dump-dir-binding prefix] & body]
+  `(do-with-random-dump-dir ~prefix (fn [~dump-dir-binding] ~@body)))
 
 (defmacro with-world
   "Run test in the context of a minimal Metabase instance connected to our test database."

--- a/enterprise/backend/test/metabase_enterprise/serialization/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/test_util.clj
@@ -129,7 +129,7 @@
           (when (.exists (io/file dump-dir))
             (.delete (io/file dump-dir))))))))
 
-(defmacro with-random-dump-dir {:style/indent 1} [[dump-dir-binding prefix] & body]
+(defmacro with-random-dump-dir {:style/indent 2} [[dump-dir-binding prefix] & body]
   `(do-with-random-dump-dir ~prefix (fn [~dump-dir-binding] ~@body)))
 
 (defmacro with-world

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -27,7 +27,7 @@
                                                         :personal_owner_id mark-id}]]
 
       (testing "a top-level collection is extracted correctly"
-        (let [ser (serdes.base/extract-one "Collection" (select-one "Collection" [:= :id coll-id]))]
+        (let [ser (serdes.base/extract-one "Collection" {} (select-one "Collection" [:= :id coll-id]))]
           (is (= {:model "Collection" :id coll-eid :label coll-slug} (:serdes/meta ser)))
           (is (not (contains? ser :location)))
           (is (not (contains? ser :id)))
@@ -36,7 +36,7 @@
           (is (nil? (:parent_id ser)))))
 
       (testing "a nested collection is extracted with the right parent_id"
-        (let [ser (serdes.base/extract-one "Collection" (select-one "Collection" [:= :id child-id]))]
+        (let [ser (serdes.base/extract-one "Collection" {} (select-one "Collection" [:= :id child-id]))]
           (is (= {:model "Collection" :id child-eid :label child-slug} (:serdes/meta ser)))
           (is (not (contains? ser :location)))
           (is (not (contains? ser :id)))
@@ -44,7 +44,7 @@
           (is (nil? (:personal_owner_id ser)))))
 
       (testing "personal collections are extracted with email as key"
-        (let [ser (serdes.base/extract-one "Collection" (select-one "Collection" [:= :id pc-id]))]
+        (let [ser (serdes.base/extract-one "Collection" {} (select-one "Collection" [:= :id pc-id]))]
           (is (= {:model "Collection" :id pc-eid :label pc-slug} (:serdes/meta ser)))
           (is (not (contains? ser :location)))
           (is (not (contains? ser :id)))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -28,7 +28,7 @@
 
       (testing "a top-level collection is extracted correctly"
         (let [ser (serdes.base/extract-one "Collection" {} (select-one "Collection" [:= :id coll-id]))]
-          (is (= {:model "Collection" :id coll-eid :label coll-slug} (:serdes/meta ser)))
+          (is (= [{:model "Collection" :id coll-eid :label coll-slug}] (:serdes/meta ser)))
           (is (not (contains? ser :location)))
           (is (not (contains? ser :id)))
           (is (nil? (:personal_owner_id ser)))
@@ -37,7 +37,7 @@
 
       (testing "a nested collection is extracted with the right parent_id"
         (let [ser (serdes.base/extract-one "Collection" {} (select-one "Collection" [:= :id child-id]))]
-          (is (= {:model "Collection" :id child-eid :label child-slug} (:serdes/meta ser)))
+          (is (= [{:model "Collection" :id child-eid :label child-slug}] (:serdes/meta ser)))
           (is (not (contains? ser :location)))
           (is (not (contains? ser :id)))
           (is (= coll-eid (:parent_id ser)))
@@ -45,7 +45,7 @@
 
       (testing "personal collections are extracted with email as key"
         (let [ser (serdes.base/extract-one "Collection" {} (select-one "Collection" [:= :id pc-id]))]
-          (is (= {:model "Collection" :id pc-eid :label pc-slug} (:serdes/meta ser)))
+          (is (= [{:model "Collection" :id pc-eid :label pc-slug}] (:serdes/meta ser)))
           (is (not (contains? ser :location)))
           (is (not (contains? ser :id)))
           (is (nil? (:parent_id ser)))
@@ -54,7 +54,7 @@
       (testing "overall extraction returns the expected set"
         (letfn [(collections [extraction] (->> extraction
                                                (into [])
-                                               (map :serdes/meta)
+                                               (map (comp last :serdes/meta))
                                                (filter #(= "Collection" (:model %)))
                                                (map :id)
                                                set))]

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -4,21 +4,26 @@
             [metabase-enterprise.serialization.v2.extract :as serdes.extract]
             [metabase-enterprise.serialization.v2.ingest :as serdes.ingest]
             [metabase-enterprise.serialization.v2.load :as serdes.load]
-            [metabase.models :refer [Collection]]
+            [metabase.models :refer [Collection Database Table]]
+            [metabase.models.serialization.base :as serdes.base]
             [metabase.models.serialization.hash :as serdes.hash]
             [toucan.db :as db]))
 
+(defn- no-labels [hierarchy]
+  (mapv #(dissoc % :label) hierarchy))
+
 (defn- ingestion-in-memory [extractions]
-  (let [mapped (into {} (for [{{:keys [model id]} :serdes/meta :as m} (into [] extractions)]
-                          [[model id] m]))]
+  (let [mapped (into {} (for [entity (into [] extractions)]
+                          [(no-labels (serdes.base/serdes-hierarchy entity))
+                           entity]))]
     (reify
       serdes.ingest/Ingestable
       (ingest-list [_]
-        (eduction (map :serdes/meta) (vals mapped)))
-      (ingest-one [_ {:keys [model id]}]
-        (or (get mapped [model id])
-            (throw (ex-info (format "Unknown ingestion target: %s %s" model id)
-                            {:model model :id id :world mapped})))))))
+        (keys mapped))
+      (ingest-one [_ hierarchy]
+        (or (get mapped (no-labels hierarchy))
+            (throw (ex-info (format "Unknown ingestion target: %s" hierarchy)
+                            {:hierarchy hierarchy :world mapped})))))))
 
 ;;; WARNING for test authors: [[extract/extract-metabase]] returns a lazy reducible value. To make sure you don't
 ;;; confound your tests with data from your dev appdb, remember to eagerly
@@ -27,7 +32,7 @@
 (deftest load-basics-test
   (testing "a simple, fresh collection is imported"
     (let [serialized (atom nil)
-          eid1       "123456789abcdef_0123"]
+          eid1       "0123456789abcdef_0123"]
       (ts/with-source-and-dest-dbs
         (testing "extraction succeeds"
           (ts/with-source-db
@@ -131,3 +136,52 @@
                      "Collection 2 version 1"
                      "Collection 2 version 2"}
                    (set (db/select-field :name Collection))))))))))
+
+(deftest deserialization-database-table-field-test
+  (testing "databases, tables and fields are nested in namespaces"
+    (let [serialized (atom nil)
+          db1s       (atom nil)
+          db1d       (atom nil)
+          db2s       (atom nil)
+          db2d       (atom nil)
+          t1s        (atom nil)
+          t1d        (atom nil)
+          t2s        (atom nil)
+          t2d        (atom nil)]
+      (ts/with-source-and-dest-dbs
+        (testing "serializing the two collections"
+          (ts/with-source-db
+            (reset! db1s (ts/create! Database :name "db1"))
+            (reset! t1s  (ts/create! Table    :name "posts" :db_id (:id @db1s)))
+            (reset! db2s (ts/create! Database :name "db2"))
+            (reset! t2s  (ts/create! Table    :name "posts" :db_id (:id @db2s))) ; Deliberately the same name!
+            (reset! serialized (into [] (serdes.extract/extract-metabase {})))))
+
+        (testing "serialization of databases is based on the :name"
+          (is (= #{(:name @db1s) (:name @db2s) "test-data"} ; TODO I'm not sure where the `test-data` one comes from.
+                 (->> @serialized
+                      (map :serdes/meta)
+                      (filter #(= "Database" (:model %)))
+                      (map :id)
+                      set))))
+
+        (testing "tables reference their databases by name"
+          (is (= #{(:name @db1s) (:name @db2s) "test-data"}
+                 (->> @serialized
+                      (filter #(-> % :serdes/meta :model (= "Table")))
+                      (map :db_id)
+                      set))))
+
+        (testing "deserialization works properly, keeping the same-named tables apart"
+          (ts/with-dest-db
+            (serdes.load/load-metabase (ingestion-in-memory @serialized))
+            (reset! db1d (db/select-one Database :name (:name @db1s)))
+            (reset! db2d (db/select-one Database :name (:name @db2s)))
+
+            (is (= 3 (db/count Database)))
+            (is (= #{"db1" "db2" "test-data"}
+                   (db/select-field :name Database)))
+            (is (= #{(:id @db1d) (:id @db2d)}
+                   (db/select-field :db_id Table :name "posts")))
+            (is (db/exists? Table :name "posts" :db_id (:id @db1d)))
+            (is (db/exists? Table :name "posts" :db_id (:id @db2d)))))))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/yaml_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/yaml_test.clj
@@ -117,7 +117,7 @@
           (testing "for Collections"
             (is (= 100 (count (dir->file-set (io/file dump-dir "Collection")))))
             (doseq [{:keys [entity_id slug] :as coll} (get entities "Collection")
-                    :let [filename (str entity_id "+" (#'u.yaml/clean-string slug) ".yaml")]]
+                    :let [filename (str entity_id "+" (#'u.yaml/truncate-label slug) ".yaml")]]
               (is (= (dissoc coll :serdes/meta)
                      (yaml/from-file (io/file dump-dir "Collection" filename))))))
 
@@ -173,7 +173,7 @@
               (is (= (into #{} (comp cat
                                      (map (fn [entity]
                                             (mapv #(cond-> %
-                                                     (:label %) (update :label #'u.yaml/clean-string))
+                                                     (:label %) (update :label #'u.yaml/truncate-label))
                                                   (serdes.base/serdes-path entity)))))
                            (vals entities))
                      (into #{} (ingest/ingest-list ingestable)))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/yaml_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/yaml_test.clj
@@ -7,6 +7,7 @@
             [metabase-enterprise.serialization.v2.ingest.yaml :as ingest.yaml]
             [metabase-enterprise.serialization.v2.storage.yaml :as storage.yaml]
             [metabase.models.collection :refer [Collection]]
+            [metabase.models.serialization.base :as serdes.base]
             [metabase.util.date-2 :as u.date]
             [metabase.test.generate :as test-gen]
             [reifyhealth.specmonstah.core :as rs]
@@ -61,50 +62,52 @@
 
     (let [ingestable (ingest.yaml/ingest-yaml dump-dir)
           meta-maps  (into [] (ingest/ingest-list ingestable))
-          exp-files  {{:model "Collection" :id "fake-id" :label "the_label"} {:some "made up" :data "here"}
-                      {:model "Collection" :id "no-label"}                   {:some "other" :data "in this one"}
-                      {:model "Setting" :id "some-key"}                      {:key :some-key :value "with string value"}
-                      {:model "Setting" :id "another-key"}                   {:key :another-key :value 7}
-                      {:model "Setting" :id "blank-key"}                     {:key :blank-key :value nil}}]
+          exp-files  {[{:model "Collection" :id "fake-id" :label "the_label"}] {:some "made up" :data "here"}
+                      [{:model "Collection" :id "no-label"}]                   {:some "other" :data "in this one"}
+                      [{:model "Setting" :id "some-key"}]                      {:key :some-key :value "with string value"}
+                      [{:model "Setting" :id "another-key"}]                   {:key :another-key :value 7}
+                      [{:model "Setting" :id "blank-key"}]                     {:key :blank-key :value nil}}]
       (testing "the right set of file is returned by ingest-list"
         (is (= (set (keys exp-files))
                (set meta-maps))))
 
       (testing "individual reads in any order are correct"
-        (doseq [meta-map (->> exp-files
-                              keys
-                              (repeat 10)
-                              (into [] cat)
-                              shuffle)]
+        (doseq [meta-maps (->> exp-files
+                               keys
+                               (repeat 10)
+                               (into [] cat)
+                               shuffle)]
           (is (= (-> exp-files
-                     (get meta-map)
-                     (assoc :serdes/meta meta-map))
-                 (ingest/ingest-one ingestable meta-map))))))))
+                     (get meta-maps)
+                     (assoc :serdes/meta (last meta-maps)))
+                 (ingest/ingest-one ingestable meta-maps))))))))
 
 (deftest e2e-storage-ingestion-test
   (ts/with-random-dump-dir [dump-dir "serdesv2-"]
     (ts/with-empty-h2-app-db
       (test-gen/insert! {:collection [[100 {:refs {:personal_owner_id ::rs/omit}}]]
                          :database   [[10]]
-                         :table      [[100]]})
+                         :table      (into [] (for [db [:db0 :db1 :db2 :db3 :db4 :db5 :db6 :db7 :db8 :db9]]
+                                                [10 {:refs {:db_id db}}]))
+                         #_[[100]]})
       (let [extraction (into [] (extract/extract-metabase {}))
-            entities   (reduce (fn [m {{:keys [model id]} :serdes/meta :as entity}]
-                                 (assoc-in m [model id] entity))
+            entities   (reduce (fn [m {{:keys [model]} :serdes/meta :as entity}]
+                                 (update m model (fnil conj []) entity))
                                {} extraction)]
-        (is (= 100 (-> entities (get "Collection") vals count)))
+        (is (= 100 (-> entities (get "Collection") count)))
 
         (testing "storage"
           (storage.yaml/store! (seq extraction) dump-dir)
           (testing "for Collections"
             (is (= 100 (count (dir->file-set (io/file dump-dir "Collection")))))
-            (doseq [{:keys [entity_id slug] :as coll} (vals (get entities "Collection"))
+            (doseq [{:keys [entity_id slug] :as coll} (get entities "Collection")
                     :let [filename (str entity_id "+" slug ".yaml")]]
               (is (= (dissoc coll :serdes/meta)
                      (yaml/from-file (io/file dump-dir "Collection" filename))))))
 
           (testing "for Databases"
             (is (= 10 (count (dir->file-set (io/file dump-dir "Database")))))
-            (doseq [{:keys [name] :as coll} (vals (get entities "Database"))
+            (doseq [{:keys [name] :as coll} (get entities "Database")
                     :let [filename (str name ".yaml")]]
               (is (= (-> coll
                          (dissoc :serdes/meta)
@@ -113,26 +116,35 @@
                      (yaml/from-file (io/file dump-dir "Database" filename))))))
 
           (testing "for Tables"
-            (is (= 100 (count (dir->file-set (io/file dump-dir "Table")))))
-            (doseq [{:keys [name] :as coll} (vals (get entities "Table"))
-                    :let [filename (str name ".yaml")]]
+            (is (= 100 (count (get entities "Table"))
+                   #_(count (into #{} (map :name (get entities "Table"))))))
+            (doseq [{:keys [db_id name] :as coll} (get entities "Table")]
               (is (= (-> coll
                          (dissoc :serdes/meta)
                          (update :created_at u.date/format)
                          (update :updated_at u.date/format))
-                     (yaml/from-file (io/file dump-dir "Table" filename))))))
+                     (yaml/from-file (io/file dump-dir "Database" db_id "Table" (str name ".yaml")))))))
 
           (testing "for settings"
-            (is (= (into {} (for [{:keys [key value]} (vals (get entities "Setting"))]
+            (is (= (into {} (for [{:keys [key value]} (get entities "Setting")]
                               [key value]))
                    (yaml/from-file (io/file dump-dir "settings.yaml"))))))
 
         (testing "ingestion"
           (let [ingestable (ingest.yaml/ingest-yaml dump-dir)]
             (testing "ingest-list is accurate"
-              (is (= (into #{} (comp (map vals) cat (map :serdes/meta)) (vals entities))
+              (is (= (into #{} (comp cat (map serdes.base/serdes-hierarchy))
+                           (vals entities))
                      (into #{} (ingest/ingest-list ingestable)))))
 
             (testing "each entity matches its in-memory original"
               (doseq [entity extraction]
-                (is (= entity (ingest/ingest-one ingestable (:serdes/meta entity))))))))))))
+                (is (= entity (ingest/ingest-one ingestable (serdes.base/serdes-hierarchy entity))))))))))))
+
+(comment
+  (let [ing (ingest.yaml/ingest-yaml (io/file "/tmp/serdesv2-VFBQGQNZSBCZLLFXLPQP"))]
+    (ingest/ingest-list ing)
+    #_(serdes.base/serdes-hierarchy (ingest/ingest-one ing [{:model "Database" :id "Small Plastic Clock"}
+                            {:model "Table"    :id "ARR"}]))
+    )
+  )

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/yaml_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/yaml_test.clj
@@ -85,15 +85,15 @@
                (into #{} (ingest/ingest-list ingestable)))))
 
       (testing "individual reads in any order are correct"
-        (doseq [meta-maps (->> exp-files
-                               keys
-                               (repeat 10)
-                               (into [] cat)
-                               shuffle)]
+        (doseq [abs-path (->> exp-files
+                              keys
+                              (repeat 10)
+                              (into [] cat)
+                              shuffle)]
           (is (= (-> exp-files
-                     (get meta-maps)
-                     (assoc :serdes/meta (mapv #(dissoc % :label) meta-maps)))
-                 (ingest/ingest-one ingestable meta-maps))))))))
+                     (get abs-path)
+                     (assoc :serdes/meta (mapv #(dissoc % :label) abs-path)))
+                 (ingest/ingest-one ingestable abs-path))))))))
 
 (deftest e2e-storage-ingestion-test
   (ts/with-random-dump-dir [dump-dir "serdesv2-"]

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/yaml_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/yaml_test.clj
@@ -57,20 +57,24 @@
                                  :another-key 7
                                  :blank-key nil}))
     (spit (io/file dump-dir "Collection" "fake-id+the_label.yaml")
-          (yaml/generate-string {:some "made up" :data "here"}))
+          (yaml/generate-string {:some "made up" :data "here" :entity_id "fake-id" :slug "the_label"}))
     (spit (io/file dump-dir "Collection" "no-label.yaml")
-          (yaml/generate-string {:some "other" :data "in this one"}))
+          (yaml/generate-string {:some "other" :data "in this one" :entity_id "no-label"}))
 
     (let [ingestable (ingest.yaml/ingest-yaml dump-dir)
-          meta-maps  (into [] (ingest/ingest-list ingestable))
-          exp-files  {[{:model "Collection" :id "fake-id" :label "the_label"}] {:some "made up" :data "here"}
-                      [{:model "Collection" :id "no-label"}]                   {:some "other" :data "in this one"}
+          exp-files  {[{:model "Collection" :id "fake-id" :label "the_label"}] {:some "made up"
+                                                                                :data "here"
+                                                                                :entity_id "fake-id"
+                                                                                :slug "the_label"}
+                      [{:model "Collection" :id "no-label"}]                   {:some "other"
+                                                                                :data "in this one"
+                                                                                :entity_id "no-label"}
                       [{:model "Setting" :id "some-key"}]                      {:key :some-key :value "with string value"}
                       [{:model "Setting" :id "another-key"}]                   {:key :another-key :value 7}
                       [{:model "Setting" :id "blank-key"}]                     {:key :blank-key :value nil}}]
       (testing "the right set of file is returned by ingest-list"
         (is (= (set (keys exp-files))
-               (set meta-maps))))
+               (into #{} (ingest/ingest-list ingestable)))))
 
       (testing "individual reads in any order are correct"
         (doseq [meta-maps (->> exp-files

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -925,7 +925,7 @@
   ;; Transform :location (which uses database IDs) into a portable :parent_id with the parent's entity ID.
   ;; Also transform :personal_owner_id from a database ID to the email string, if it's defined.
   ;; Use the :slug as the human-readable label.
-  [_ coll]
+  [_ _ coll]
   (let [parent       (some-> coll
                              :id
                              Collection

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -959,6 +959,11 @@
     [parent_id]
     []))
 
+(defmethod serdes.base/serdes-hierarchy "Collection" [{:keys [slug] :as coll}]
+  [{:model "Collection"
+    :id    (serdes.base/serdes-entity-id "Collection" coll)
+    :label slug}])
+
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                           Perms Checking Helper Fns                                            |
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -960,9 +960,9 @@
     []))
 
 (defmethod serdes.base/serdes-hierarchy "Collection" [{:keys [slug] :as coll}]
-  [{:model "Collection"
-    :id    (serdes.base/serdes-entity-id "Collection" coll)
-    :label slug}])
+  [(cond-> {:model "Collection"
+            :id    (serdes.base/serdes-entity-id "Collection" coll)}
+     slug  (assoc :label slug))])
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                           Perms Checking Helper Fns                                            |

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -956,7 +956,7 @@
 (defmethod serdes.base/serdes-dependencies "Collection"
   [{:keys [parent_id]}]
   (if parent_id
-    [parent_id]
+    [[{:model "Collection" :id parent_id}]]
     []))
 
 (defmethod serdes.base/serdes-hierarchy "Collection" [{:keys [slug] :as coll}]

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -939,7 +939,7 @@
     (-> (serdes.base/extract-one-basics "Collection" coll)
         (dissoc :location)
         (assoc :parent_id parent-id :personal_owner_id owner-email)
-        (assoc-in [:serdes/meta :label] (:slug coll)))))
+        (assoc-in [:serdes/meta 0 :label] (:slug coll)))))
 
 (defmethod serdes.base/load-xform "Collection" [{:keys [parent_id personal_owner_id] :as contents}]
   (let [loc        (if parent_id
@@ -959,9 +959,8 @@
     [[{:model "Collection" :id parent_id}]]
     []))
 
-(defmethod serdes.base/serdes-hierarchy "Collection" [{:keys [slug] :as coll}]
-  [(cond-> {:model "Collection"
-            :id    (serdes.base/serdes-entity-id "Collection" coll)}
+(defmethod serdes.base/serdes-generate-path "Collection" [_ {:keys [slug] :as coll}]
+  [(cond-> (serdes.base/infer-self-path "Collection" coll)
      slug  (assoc :label slug))])
 
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -293,6 +293,14 @@
   [_ {:keys [name]}]
   name)
 
+(defmethod serdes.base/serdes-hierarchy "Database"
+  [{:keys [name]}]
+  [{:model "Database" :id name}])
+
+(defmethod serdes.base/load-find-local "Database"
+  [[{:keys [id]}]]
+  (db/select-one-field :id Database :name id))
+
 (defmethod serdes.base/load-xform "Database" [{:keys [creator_id] :as entity}]
   (cond-> (serdes.base/load-xform-basics entity)
     creator_id (assoc :creator_id (db/select-one-field :id 'User :email creator_id))))

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -293,8 +293,8 @@
   [_ {:keys [name]}]
   name)
 
-(defmethod serdes.base/serdes-hierarchy "Database"
-  [{:keys [name]}]
+(defmethod serdes.base/serdes-generate-path "Database"
+  [_ {:keys [name]}]
   [{:model "Database" :id name}])
 
 (defmethod serdes.base/load-find-local "Database"

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -10,6 +10,7 @@
             [metabase.models.permissions :as perms]
             [metabase.models.permissions-group :as perms-group]
             [metabase.models.secret :as secret :refer [Secret]]
+            [metabase.models.serialization.base :as serdes.base]
             [metabase.models.serialization.hash :as serdes.hash]
             [metabase.plugins.classloader :as classloader]
             [metabase.util :as u]
@@ -277,3 +278,21 @@
                              details
                              (sensitive-fields-for-db db)))))
     json-generator)))
+
+;;; ------------------------------------------------ Serialization ----------------------------------------------------
+
+(defmethod serdes.base/extract-one "Database"
+  [_ {secrets :database/secrets :or {secrets :exclude}} entity]
+  ;; TODO Support alternative encryption of secret database details.
+  ;; There's one optional foreign key: creator_id. Resolve it as an email.
+  (cond-> (serdes.base/extract-one-basics "Database" entity)
+    (:creator_id entity) (assoc :creator_id (db/select-one-field :email 'User :id (:creator_id entity)))
+    (= :exclude secrets) (dissoc :details)))
+
+(defmethod serdes.base/serdes-entity-id "Database"
+  [_ {:keys [name]}]
+  name)
+
+(defmethod serdes.base/load-xform "Database" [{:keys [creator_id] :as entity}]
+  (cond-> (serdes.base/load-xform-basics entity)
+    creator_id (assoc :creator_id (db/select-one-field :id 'User :email creator_id))))

--- a/src/metabase/models/field.clj
+++ b/src/metabase/models/field.clj
@@ -9,6 +9,7 @@
             [metabase.models.humanization :as humanization]
             [metabase.models.interface :as mi]
             [metabase.models.permissions :as perms]
+            [metabase.models.serialization.base :as serdes.base]
             [metabase.models.serialization.hash :as serdes.hash]
             [metabase.util :as u]
             [metabase.util.honeysql-extensions :as hx]
@@ -378,3 +379,8 @@
   {:arglists '([field])}
   [{:keys [table_id]}]
   (db/select-one 'Table, :id table_id))
+
+;;; ------------------------------------------------- Serialization -------------------------------------------------
+
+#_(defmethod serdes.base/serdes-dependencies "Field" [field]
+  )

--- a/src/metabase/models/serialization/base.clj
+++ b/src/metabase/models/serialization/base.clj
@@ -244,7 +244,12 @@
   (This is not strictly required - for a different medium like protobufs the hierarchy might be encoded some other way.)
 
   The hierarchy is reconstructed by ingestion and used as the key to read entities with `ingest-one`, and to match
-  against existing entities."
+  against existing entities.
+
+  Implementation notes:
+  - :label is optional
+  - Base the hierarchy on the main entity values, not the `:serdes/meta` parts. (`:serdes/meta` is sometimes
+    reconstructed imperfectly from eg. a filesystem, which might have needed to sanitize or truncate values.)"
   ingested-model)
 
 (defmethod serdes-hierarchy :default [{meta-map :serdes/meta}]

--- a/src/metabase/models/serialization/base.clj
+++ b/src/metabase/models/serialization/base.clj
@@ -15,10 +15,97 @@
             [toucan.models :as models]))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                              :serdes/meta                                                      |
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; The Clojure maps from extraction and ingestion always include a special key `:serdes/meta` giving some information
+;;; about the serialized entity. The value is always a vector of maps that give a "path" to the entity. This is not a
+;;; filesystem path; rather it defines the nesting of some entities inside others.
+;;;
+;;; Most paths are a single layer:
+;;; `[{:model "ModelName" :id "entity ID or identity hash string" :label "Human-readable name"}]`
+;;; `:model` and `:id` are required; `:label` is optional.
+;;;
+;;; But for some entities, it can be deeper. For example Fields belong to Tables, which are in Schemas (which don't
+;;; really exist in appdb, but are reflected here for namespacing of table names), which are in Databases:
+;;; `[{:model "Database" :id "my_db"}
+;;;   {:model "Schema"   :id "PUBLIC"}
+;;;   {:model "Table"    :id "Users"}
+;;;   {:model "Field"    :id "email"}]`
+;;;
+;;; Many of the multimethods are keyed on the `:model` field of the leaf entry (the last).
+
+(defmulti serdes-entity-id
+  "Given the model name and an entity, returns its entity ID (which might be nil).
+
+  This abstracts over the exact definition of the \"entity ID\" for a given entity.
+  By default this is a column, `:entity_id`.
+
+  Models that have a different portable ID should override this."
+  (fn [model-name _] model-name))
+
+(defmethod serdes-entity-id :default [_ {:keys [entity_id]}]
+  entity_id)
+
+(defmulti serdes-generate-path
+  "Given the model name and raw entity from the database, returns a vector giving its *path*.
+  `(serdes-generate-path \"ModelName\" entity)`
+
+  The path is a vector of maps, root first and this entity itself last. Each map looks like:
+  `{:model \"ModelName\" :id \"entity ID, identity hash, or custom ID\" :label \"optional human label\"}`
+
+  Some entities stand alone, while some are naturally nested inside others. For example, fields belong in tables, which
+  belong in databases. Further, since these use eg. column names as entity IDs, they can collide if all the fields get
+  poured into one namespace (like a directory of YAML files).
+
+  Finally, it's often useful to delete the databases from an export, since the receiving end has its own different, but
+  compatible, database definitions. (For example, staging and prod instances of Metabase.) It's convenient for human
+  understanding and editing to group fields under tables under databases.
+
+  Therefore we provide an abstract path on the entities, which will generally be stored in a directory tree.
+  (This is not strictly required - for a different medium like protobufs the path might be encoded some other way.)
+
+  The path is reconstructed by ingestion and used as the key to read entities with `ingest-one`, and to match
+  against existing entities.
+
+  The default implementation is a single level, using the model name provided and the ID from either
+  [[serdes-entity-id]] or [[serdes.hash/identity-hash]].
+
+  Implementation notes:
+  - `:serdes/meta` might be defined - if so it's coming from ingestion and might have truncated values in it, and should
+    be reconstructed from the rest of the data.
+  - The primary key might still be attached, during extraction.
+  - `:label` is optional
+  - The logic to guess the leaf part of the path is in [[infer-self-path]], for use in overriding."
+  (fn [model _] model))
+
+(defn infer-self-path
+  "Implements the default logic from [[serdes-generate-path]] that guesses the `:id` of this entity. Factored out
+  so it can be called by implementors of [[serdes-generate-path]].
+
+  The guesses are:
+  - [[serdes-entity-id]]
+  - [[serdes.hash/identity-hash]] after looking up the Toucan entity by primary key
+
+  Returns `{:model \"ModelName\" :id \"id-string\"}`; throws if the inference fails, since it indicates a programmer
+  error and not a runtime one."
+  [model-name entity]
+  (let [model (db/resolve-model (symbol model-name))
+        pk    (models/primary-key model)]
+    {:model model-name
+     :id    (or (serdes-entity-id model-name entity)
+                (some-> (get entity pk) model serdes.hash/identity-hash)
+                (throw (ex-info "Could not infer-self-path on this entity - maybe implement serdes-entity-id ?"
+                                {:model model-name :entity entity})))}))
+
+(defmethod serdes-generate-path :default [model-name entity]
+  ;; This default works for most models, but needs overriding for nested ones.
+  [(infer-self-path model-name entity)])
+
+;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                          Serialization Process                                                 |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; Serialization happens in two stages: extraction and storage. These are independent and deliberately decoupled.
-;;; The result of extraction is a reducible stream of Clojure maps with `:serdes/meta` keys on them (see below).
+;;; The result of extraction is a reducible stream of Clojure maps with `:serdes/meta` keys on them (see above).
 ;;; In particular, extraction does not care about file formats or other such things.
 ;;;
 ;;; Storage takes the stream from extraction and actually stores it or sends it. Traditionally we have serialized to a
@@ -48,15 +135,6 @@
 ;;; Storage:
 ;;; The storage system might transform that stream in some arbitrary way. Storage is a dead end - it should perform side
 ;;; effects like writing to the disk or network, and return nothing.
-
-(defmulti serdes-entity-id
-  "Given the model name and an entity, returns its entity ID.
-  By default this is a column, `:entity_id`.
-  Models that have a different portable ID should override this."
-  (fn [model-name _] model-name))
-
-(defmethod serdes-entity-id :default [_ {:keys [entity_id]}]
-  entity_id)
 
 (defmulti extract-all
   "Entry point for extracting all entities of a particular model:
@@ -97,8 +175,8 @@
   "Extracts a single entity retrieved from the database into a portable map with `:serdes/meta` attached.
   `(extract-one \"ModelName\" opts entity)`
 
-  The default implementation uses the model name as the `:model` and either `:entity_id` or
-  [[serdes.hash/identity-hash]] as the `:id`. It also strips off the database's numeric primary key.
+  The default implementation uses [[serdes-generate-path]] to build the `:serdes/meta`. It also strips off the
+  database's numeric primary key.
 
   That suffices for a few simple entities, but most entities will need to override this.
   They should follow the pattern of:
@@ -106,7 +184,6 @@
   - Drop the numeric database primary key
   - Replace any foreign keys with portable values (eg. entity IDs or `identity-hash`es, owning user's ID with their
     email, etc.)
-  - Consider attaching a human-friendly `:label` under `:serdes/meta`. (Eg. a Collection's `:slug`)
 
   When overriding this, [[extract-one-basics]] is probably a useful starting point.
 
@@ -119,7 +196,7 @@
 
 (defn raw-reducible-query
   "Helper for calling Toucan's raw [[db/reducible-query]]. With just the model name, fetches everything. You can filter
-  with a HoneySQL map like {:where [:= :archived true]}.
+  with a HoneySQL map like `{:where [:= :archived true]}`.
 
   Returns a reducible stream of JDBC row maps."
   ([model-name]
@@ -142,7 +219,7 @@
 (defn extract-one-basics
   "A helper for writing [[extract-one]] implementations. It takes care of the basics:
   - Convert to a vanilla Clojure map.
-  - Add `:serdes/meta`.
+  - Add `:serdes/meta` by calling [[serdes-generate-path]].
   - Drop the primary key.
 
   Returns the Clojure map."
@@ -150,9 +227,7 @@
   (let [model (db/resolve-model (symbol model-name))
         pk    (models/primary-key model)]
     (-> entity
-        (assoc :serdes/meta {:model model-name
-                             :id    (or (serdes-entity-id model-name entity)
-                                        (serdes.hash/identity-hash (model (get entity pk))))})
+        (assoc :serdes/meta (serdes-generate-path model-name entity))
         (dissoc pk))))
 
 (defmethod extract-one :default [model-name _opts entity]
@@ -170,32 +245,27 @@
 ;;; usage for testing in-memory deserialization.
 ;;;
 ;;; Factory functions consume some details (like a file path) and return an [[Ingestable]], with its two methods:
-;;; - `(ingest-list ingestable)` returns a reducible stream of `:serdes/meta` maps in any order.
-;;; - `(ingest-one ingestable meta-map)` ingests a single entity into memory, returning it as a map.
+;;; - `(ingest-list ingestable)` returns a reducible stream of `:serdes/meta` paths in any order.
+;;; - `(ingest-one ingestable meta-path)` ingests a single entity into memory, returning it as a map.
 ;;;
 ;;; This two-stage design avoids needing all the data in memory at once, where that's practical with the underlying
 ;;; storage media (eg. files).
 ;;;
 ;;; Loading:
-;;; Loading tries to find corresponding entities in the destination appdb by `entity_id` or `identity-hash`, and update
+;;; Loading tries to find corresponding entities in the destination appdb by entity ID or identity hash, and update
 ;;; those rows rather than duplicating.
 ;;; The entry point is [[metabase-enterprise.serialization.v2.load/load-metabase]]. The top-level process works like
 ;;; this:
-;;; - `(load-prescan-all "ModelName")` is called, which selects the entire collection as a reducible stream and calls
-;;;   [[load-prescan-one]] on each entry.
-;;;     - The default for that usually is the right thing.
-;;; - `(load-prescan-one entity)` turns a particular entity into an `[entity_id identity-hash primary-key]` triple.
-;;;     - The default will work for models with a literal `entity_id` field; those with alternative IDs (database,
-;;;       table, field, setting, etc.) should override this method.
-;;; - Prescanning complete, `(ingest-list ingestable)` gets the metadata for every exported entity in arbitrary order.
+;;; - `(ingest-list ingestable)` gets the `:serdes/meta` "path" for every exported entity in arbitrary order.
 ;;;     - `(ingest-one meta-map opts)` is called on each first to ingest the value into memory, then
-;;;     - `(serdes-dependencies ingested)` to get a list of other IDs (entity IDs or identity hashes).
+;;;     - `(serdes-dependencies ingested)` to get a list of other paths that need to be loaded first.
 ;;;         - The default is an empty list.
 ;;;     - The idea of dependencies is eg. a database must be loaded before its tables, a table before its fields, a
 ;;;       collection's ancestors before the collection itself.
 ;;;     - Dependencies are loaded recursively in postorder; circular dependencies cause the process to throw.
-;;; - Having found an entity it can really load, the core code will check its table of IDs found by prescanning.
-;;;     - Then it calls `(load-one! ingested maybe-local-entity)`, passing the `ingested` value and either `nil` or the
+;;; - Having found an entity it can really load, check for any existing one:
+;;;     - `(load-find-local path)` returns the corresponding primary key, or nil.
+;;; - Then it calls `(load-one! ingested maybe-local-entity)`, passing the `ingested` value and either `nil` or the
 ;;;       Toucan entity corresponding to the incoming map.
 ;;;     - `load-one!` is a side-effecting black box to the rest of the deserialization process.
 ;;;       It returns the primary key of the new or existing entity, which is necessary to resolve foreign keys between
@@ -211,67 +281,34 @@
 ;;;     - `(load-insert! ingested)` if the entity is new.
 ;;;   Both of these have the obvious defaults of [[jdbc/update!]] or [[jdbc/insert!]].
 
-;;; +----------------------------------------------------------------------------------------------------------------+
-;;; |                                            :serdes/meta maps                                                   |
-;;; +----------------------------------------------------------------------------------------------------------------+
-;;; The Clojure maps from extraction and ingestion always include a special key `:serdes/meta` giving some information
-;;; about the serialized entity. The value is always a map like:
-;;; `{:model "ModelName" :id "entity ID or identity hash string" :label "Human-readable name"}`
-;;; `:model` and `:id` are required; `:label` is optional.
-;;;
-;;; Many of the multimethods are keyed on the `:model` field.
-
 (defn- ingested-model
   "The dispatch function for several of the load multimethods: dispatching on the model of the incoming entity."
   [ingested]
-  (-> ingested :serdes/meta :model))
+  (-> ingested :serdes/meta last :model))
 
-(defmulti serdes-hierarchy
-  "Given an exported entity, returns a vector giving its *hierarchy*.
-  `(serdes-hierarchy entity)`
-
-  The hierarchy is a list of `:serdes/meta` maps, root first and this entity itself last.
-  The default hierarchy is no nesting - just this entity's own `:serdes/meta` in a list by itself.
-
-  Some entities are naturally nested inside others. For example, fields belong in tables, which belong in databases.
-  Further, since these use eg. column names as entity IDs, they can collide if all the fields get poured into one
-  namespace.
-  Finally, it's often useful to delete the databases from an export, since the receiving end has its own different, but
-  compatible, database definitions. (For example, staging and prod instances of Metabase.) It's convenient for human
-  understanding and editing to group fields under tables under databases.
-
-  Therefore we provide an abstract hierarchy on the entities, which will generally be stored in a directory hierarchy.
-  (This is not strictly required - for a different medium like protobufs the hierarchy might be encoded some other way.)
-
-  The hierarchy is reconstructed by ingestion and used as the key to read entities with `ingest-one`, and to match
-  against existing entities.
-
-  Implementation notes:
-  - :label is optional
-  - Base the hierarchy on the main entity values, not the `:serdes/meta` parts. (`:serdes/meta` is sometimes
-    reconstructed imperfectly from eg. a filesystem, which might have needed to sanitize or truncate values.)"
-  ingested-model)
-
-(defmethod serdes-hierarchy :default [{meta-map :serdes/meta}]
-  [meta-map])
+(defn serdes-path
+  "Given an exported or imported entity with a `:serdes/meta` key on it, return the abstract path (not a filesystem
+  path)."
+  [entity]
+  (:serdes/meta entity))
 
 (defmulti load-find-local
-  "Given a hierarchy, tries to look up any corresponding local entity.
+  "Given a path, tries to look up any corresponding local entity.
 
   Returns nil, or the primary key of the local entity.
-  Keyed on the model name at the leaf of the hierarchy.
+  Keyed on the model name at the leaf of the path.
 
   By default, this tries to look up the entity by its `:entity_id` column, or identity hash, depending on the shape of
   the incoming key. For the identity hash, this scans the entire table and builds a cache of
   [[serdes.hash/identity-hash]] to primary keys, since the identity hash cannot be queried directly.
   This cache is cleared at the beginning and end of the deserialization process."
-  (fn [hierarchy]
-    (-> hierarchy last :model)))
+  (fn [path]
+    (-> path last :model)))
 
 (declare lookup-by-id)
 
-(defmethod load-find-local :default [hierarchy]
-  (let [{id :id model-name :model} (last hierarchy)
+(defmethod load-find-local :default [path]
+  (let [{id :id model-name :model} (last path)
         model                      (db/resolve-model (symbol model-name))
         pk                         (models/primary-key model)]
     (some-> model
@@ -280,9 +317,9 @@
 
 (defmulti serdes-dependencies
   "Given an entity map as ingested (not a Toucan entity) returns a (possibly empty) list of its dependencies, where each
-  dependency is represented by either the entity ID or identity hash of the target entity.
+  dependency is represented by its abstract path (its `:serdes/meta` value).
 
-  Keyed on the model name.
+  Keyed on the model name for this entity.
   Default implementation returns an empty vector, so only models that have dependencies need to implement this."
   ingested-model)
 
@@ -315,8 +352,7 @@
 
 (defmulti load-update!
   "Called by the default [[load-one!]] if there is a corresponding entity already in the appdb.
-  The first argument is the model name, the second the incoming map we're deserializing, and the third is the Toucan
-  entity found in the appdb.
+  `(load-update! \"ModelName\" ingested-and-xformed local-Toucan-entity)`
 
   Defaults to a straightforward [[db/update!]], and you may not need to update it.
 
@@ -328,20 +364,17 @@
 (defmethod load-update! :default [model-name ingested local]
   (let [model (db/resolve-model (symbol model-name))
         pk    (models/primary-key model)
-        id    (get local pk)
-        ; Get a WHERE clause, but then strip off the WHERE part to include it in the JDBC call below.
-        ;where (update (db/honeysql->sql {:where [:= pk id]}) 0
-        ;              #(.substring 5))
-        ]
+        id    (get local pk)]
     (log/tracef "Upserting %s %d: old %s new %s" model-name id (pr-str local) (pr-str ingested))
     ; Using the two-argument form of [[db/update!]] that takes the model and a HoneySQL form for the actual update.
     ; It works differently from the more typical `(db/update! 'Model id updates...)` form: this form doesn't run any of
     ; the pre-update magic, it just updates the database directly.
     (db/update! (symbol model-name) {:where [:= pk id] :set ingested})
-    pk))
+    id))
 
 (defmulti load-insert!
   "Called by the default [[load-one!]] if there is no corresponding entity already in the appdb.
+  `(load-insert! \"ModelName\" ingested-and-xformed)`
 
   Defaults to a straightforward [[db/simple-insert!]], and you probably don't need to implement this.
   Note that [[db/insert!]] should be avoided - we don't want to populate the `:entity_id` field if it wasn't already
@@ -354,7 +387,8 @@
 
 (defmethod load-insert! :default [model ingested]
   (log/tracef "Inserting %s: %s" model (pr-str ingested))
-  ; Toucan's simple-insert! actually does the right thing for our purposes: it doesn't call pre-insert or post-insert.
+  ; Toucan's simple-insert! actually does the right thing for our purposes: it doesn't call pre-insert or post-insert,
+  ; and it returns the new primary key.
   (db/simple-insert! (symbol model) ingested))
 
 (defmulti load-one!

--- a/src/metabase/models/serialization/base.clj
+++ b/src/metabase/models/serialization/base.clj
@@ -386,7 +386,7 @@
 (defn entity-id?
   "Checks if the given string is a 21-character NanoID. Useful for telling entity IDs apart from identity hashes."
   [id-str]
-  (boolean (re-matches #"^[A-Za-z0-9_-]{21}$" id-str)))
+  (boolean (and id-str (re-matches #"^[A-Za-z0-9_-]{21}$" id-str))))
 
 (defn- find-by-identity-hash
   "Given a model and a target identity hash, this scans the appdb for any instance of the model corresponding to the

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -151,7 +151,7 @@
 (defmethod serdes.base/extract-all "Setting" [_model _opts]
   (for [{:keys [key value]} (admin-writable-site-wide-settings
                               :getter (partial get-value-of-type :string))]
-    {:serdes/meta {:model "Setting" :id (name key)}
+    {:serdes/meta [{:model "Setting" :id (name key)}]
      :key key
      :value value}))
 

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -155,6 +155,9 @@
      :key key
      :value value}))
 
+(defmethod serdes.base/load-find-local "Setting" [[{:keys [id]}]]
+  (get-value-of-type :string (keyword id)))
+
 (defmethod serdes.base/load-one! "Setting" [{:keys [key value]} _]
   (set-value-of-type! :string key value))
 

--- a/src/metabase/models/table.clj
+++ b/src/metabase/models/table.clj
@@ -226,7 +226,7 @@
 
 (defmethod serdes.base/serdes-dependencies "Table"
   [{:keys [db_id]}]
-  [db_id])
+  [[{:model "Database" :id db_id}]])
 
 ;;; ------------------------------------------------ Convenience Fns -------------------------------------------------
 

--- a/src/metabase/models/table.clj
+++ b/src/metabase/models/table.clj
@@ -209,6 +209,24 @@
         {:order-by       field-order-rule}))
     tables))
 
+;;; ------------------------------------------------- Serialization --------------------------------------------------
+
+(defmethod serdes.base/serdes-entity-id "Table" [_ {:keys [db_id name schema] :or {schema "default_schema"}}]
+  (str (db/select-one-field :name 'Database :id db_id) "/" schema "/" name))
+
+(defmethod serdes.base/extract-one "Table"
+  [_ _ {:keys [db_id] :as table}]
+  (-> (serdes.base/extract-one-basics "Table" table)
+      (assoc :db_id (db/select-one-field :name 'Database :id db_id))))
+
+(defmethod serdes.base/load-xform "Table"
+  [{:keys [db_id] :as table}]
+  (-> (serdes.base/load-xform-basics table)
+      (assoc :db_id (db/select-one-field :id 'Database :name db_id))))
+
+(defmethod serdes.base/serdes-dependencies "Table"
+  [{:keys [db_id]}]
+  [db_id])
 
 ;;; ------------------------------------------------ Convenience Fns -------------------------------------------------
 

--- a/test/metabase/test/generate.clj
+++ b/test/metabase/test/generate.clj
@@ -207,9 +207,7 @@
    :field                        {:prefix      :field
                                   :spec        ::field
                                   :insert!     {:model Field}
-                                  :relations   {:table_id [:table :id]}
-                                  ;:constraints {:table_id #{:uniq}}
-                                  }
+                                  :relations   {:table_id [:table :id]}}
    :metric                       {:prefix    :metric
                                   :spec      ::metric
                                   :insert!   {:model Metric}

--- a/test/metabase/test/generate.clj
+++ b/test/metabase/test/generate.clj
@@ -291,7 +291,7 @@
   - Adjust entites, in case some fields need extra tunning like incremental position, or collections.location
   - Insert entity into the db using `toucan.core/insert!` "
   [query]
-  (reset! table-names {})
+  (reset! unique-names {})
   (-> (spec-gen query)
       (rs/visit-ents :spec-gen remove-ids)
       (rs/visit-ents :spec-gen adjust)


### PR DESCRIPTION
Databases, Tables and Fields are nested under each other and identified by
human-selected `:name`, which might collide across databases/schemas/tables.

These factors required a big refactor!

Now there's a notion of **hierarchy** for each entity, which takes the form of
the `:serdes/meta` map for all its parents, ending with itself.
Simple ones like `Collection` have one-element hierarchies, with just itself.

`Schema` is an optional layer; if the `Table` defines a `:schema` it's treated
as part of the hierarchy. This preserves the namespacing of tables in schemas
in databases.

**Open Question**: Since most of the machinery now deals directly with
hierarchies, perhaps we should change `:serdes/meta` to hold the entire
hierarchy? That would need a bit more work, but might be simpler overall.

