### PR TITLE
Improve job naming for E2E tests on PRs

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 35
     needs: build
-    name: e2e-tests-${{ matrix.folder }}-${{ matrix.edition }}
+    name: e2e-tests-${{ matrix.folder }}${{ matrix.context }}-${{ matrix.edition }}
     env:
       MB_EDITION: ${{ matrix.edition }}
       DISPLAY: ""
@@ -81,6 +81,7 @@ jobs:
           - "visualizations"
         include:
           - edition: oss
+            context: grep
             java-version: 11
     services:
       maildev:
@@ -154,7 +155,7 @@ jobs:
       uses: actions/upload-artifact@v2
       if: failure()
       with:
-        name: cypress-recording-${{ matrix.folder }}-${{ matrix.edition }}
+        name: cypress-recording-${{ matrix.folder }}${{ matrix.context }}-${{ matrix.edition }}
         path: |
           ./cypress
           ./logs/test.log


### PR DESCRIPTION
@WiNloSt mentioned that job name `e2e-tests--oss` is confusing him.

### Problem
Originally, when we [added Cypress grep to this workflow](https://github.com/metabase/metabase/pull/23009) in order to run OSS-specific tests, I thought that this name was self explanatory. It definitely looked a bit weird with the double dash but it didn't bother me too much.

Unfortunately, GitHub Actions don't support ternary operators (yet?), so I couldn't do something like:
```yml
name: ${{ matrix.folder }} == "" ? e2e-oss-specific-tests : e2e-tests-${{ matrix.folder }}-${{ matrix.edition }}
```

As far as I know, no conditional logic of any kind is possible for the `job.name`.

### Proposal
This solution is a bit of a hack, but it works.
1. EE tests have the `folder` in their matrix but don't have `context`
2. OSS tests are the opposite of that

So the names will be constructed like this:
1. EE => `e2e-tests` + `-folderName` + `""` + `-edition` (e.g. `e2e-tests-admin-ee`)
2. OSS => `e2e-tests` + `""` + `-context` + `-edition` (e.g. `e2e-tests-grep-oss`)

### Caveat
- This works for this specific scenario, and in case we don't decide to add another `grep` logic to this workflow (which we probably will not)
- It adds a bit of complexity and possibly even confusion to the person **reading the code**, BUT it definitely makes reading the generated job names a bit easier

Before
![image](https://user-images.githubusercontent.com/31325167/176660854-20b92690-a3b3-495d-8fdc-f09c73779a71.png)

After
![image](https://user-images.githubusercontent.com/31325167/176660722-6734353e-e410-4806-a930-ff01b673b527.png)

> **Note**
> Ignore the color of the circles next to the job name