### PR TITLE
Close info panel when question is unsaved

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/View.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View.jsx
@@ -165,6 +165,8 @@ class View extends React.Component {
       onSave,
     } = this.props;
 
+    const isSaved = question.isSaved();
+
     if (isShowingSummarySidebar) {
       return (
         <SummarizeSidebar
@@ -198,7 +200,7 @@ class View extends React.Component {
       );
     }
 
-    if (isShowingQuestionInfoSidebar) {
+    if (isSaved && isShowingQuestionInfoSidebar) {
       return <QuestionInfoSidebar question={question} onSave={onSave} />;
     }
 


### PR DESCRIPTION
Small fix to hide the info panel when changed are made to a question and we haven't saved.

![chrome_lIxd4XtI5Z](https://user-images.githubusercontent.com/1328979/176734169-b8186421-e58b-46ad-b232-e2e73b932f29.gif)

