### PR TITLE
Remove Duplicate Date Shortcut Options

### DIFF
--- a/frontend/src/metabase/query_builder/components/filters/FilterPopover.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/FilterPopover.tsx
@@ -23,6 +23,7 @@ import { isStartingFrom } from "metabase/lib/query_time";
 import { Button } from "./FilterPopover.styled";
 import DatePicker from "./pickers/DatePicker/DatePicker";
 import TimePicker from "./pickers/TimePicker";
+import { DateShortcutOptions } from "./pickers/DatePicker/DatePickerShortcutOptions";
 
 const MIN_WIDTH = 300;
 const MAX_WIDTH = 410;
@@ -43,6 +44,7 @@ type Props = {
 
   noCommitButton?: boolean;
   showFieldPicker?: boolean;
+  dateShortcutOptions?: DateShortcutOptions;
   showCustom?: boolean;
   isNew?: boolean;
   isSidebar?: boolean;
@@ -164,6 +166,7 @@ export default class FilterPopover extends Component<Props, State> {
       isSidebar,
       isTopLevel,
       showCustom,
+      dateShortcutOptions,
     } = this.props;
     const { filter, editingFilter, choosingField } = this.state;
 
@@ -254,6 +257,7 @@ export default class FilterPopover extends Component<Props, State> {
               className={className}
               isSidebar={isSidebar}
               filter={filter}
+              dateShortcutOptions={dateShortcutOptions}
               primaryColor={primaryColor}
               minWidth={isSidebar ? null : MIN_WIDTH}
               maxWidth={isSidebar ? null : MAX_WIDTH}

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterSelect/BulkFilterSelect.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterSelect/BulkFilterSelect.tsx
@@ -9,6 +9,7 @@ import Dimension from "metabase-lib/lib/Dimension";
 import { isBoolean } from "metabase/lib/schema_metadata";
 
 import TippyPopoverWithTrigger from "metabase/components/PopoverWithTrigger/TippyPopoverWithTrigger";
+import { DateShortcutOptions } from "metabase/query_builder/components/filters/pickers/DatePicker/DatePickerShortcutOptions";
 
 import {
   SelectFilterButton,
@@ -20,6 +21,7 @@ export interface BulkFilterSelectProps {
   query: StructuredQuery;
   filter?: Filter;
   dimension: Dimension;
+  dateShortcutOptions?: DateShortcutOptions;
   customTrigger?: ({ onClick }: { onClick: () => void }) => JSX.Element;
   handleChange: (newFilter: Filter) => void;
   handleClear: () => void;
@@ -29,6 +31,7 @@ export const BulkFilterSelect = ({
   query,
   filter,
   dimension,
+  dateShortcutOptions,
   customTrigger,
   handleChange,
   handleClear,
@@ -66,6 +69,7 @@ export const BulkFilterSelect = ({
           isNew={filter == null}
           showCustom={false}
           showFieldPicker={false}
+          dateShortcutOptions={dateShortcutOptions}
           onChangeFilter={handleChange}
           onClose={closePopover}
           commitOnBlur

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineDatePicker/InlineDatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineDatePicker/InlineDatePicker.tsx
@@ -107,7 +107,11 @@ export function InlineDatePicker({
         dimension={dimension}
         handleChange={onChange}
         handleClear={onClear}
-        dateShortcutOptions={POPOVER_SHORTCUT_OPTIONS}
+        dateShortcutOptions={
+          shouldShowShortcutOptions
+            ? POPOVER_SHORTCUT_OPTIONS
+            : ALL_DATE_OPTIONS
+        }
         customTrigger={({ onClick }) =>
           filter && selectedFilterIndex === null ? (
             <OptionButton active onClick={onClick}>

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineDatePicker/InlineDatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineDatePicker/InlineDatePicker.tsx
@@ -10,7 +10,7 @@ import Icon from "metabase/components/Icon";
 import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
 import Dimension from "metabase-lib/lib/Dimension";
 
-import { OPTIONS } from "metabase/query_builder/components/filters/pickers/DatePicker/DatePickerShortcuts";
+import { DATE_SHORTCUT_OPTIONS as ALL_DATE_OPTIONS } from "metabase/query_builder/components/filters/pickers/DatePicker/DatePickerShortcutOptions";
 
 import { BulkFilterSelect } from "../BulkFilterSelect";
 import {
@@ -19,12 +19,24 @@ import {
   ClearButton,
 } from "./InlineDatePicker.styled";
 
-const DATE_SHORTCUT_OPTIONS = [
-  OPTIONS.DAY_OPTIONS[0], // Today
-  OPTIONS.DAY_OPTIONS[1], // Yesterday
-  OPTIONS.DAY_OPTIONS[2], // Last Week
-  OPTIONS.MONTH_OPTIONS[0], // Last Month
+const INLINE_SHORTCUT_OPTIONS = [
+  ALL_DATE_OPTIONS.DAY_OPTIONS[0], // Today
+  ALL_DATE_OPTIONS.DAY_OPTIONS[1], // Yesterday
+  ALL_DATE_OPTIONS.DAY_OPTIONS[2], // Last Week
+  ALL_DATE_OPTIONS.MONTH_OPTIONS[0], // Last Month
 ];
+
+const POPOVER_SHORTCUT_OPTIONS = {
+  DAY_OPTIONS: _.difference(
+    ALL_DATE_OPTIONS.DAY_OPTIONS,
+    INLINE_SHORTCUT_OPTIONS,
+  ),
+  MONTH_OPTIONS: _.difference(
+    ALL_DATE_OPTIONS.MONTH_OPTIONS,
+    INLINE_SHORTCUT_OPTIONS,
+  ),
+  MISC_OPTIONS: ALL_DATE_OPTIONS.MISC_OPTIONS,
+};
 
 interface InlineDatePickerProps {
   query: StructuredQuery;
@@ -47,7 +59,7 @@ export function InlineDatePicker({
     if (!filter) {
       return null;
     }
-    const optionIndex = DATE_SHORTCUT_OPTIONS.findIndex(({ init }) =>
+    const optionIndex = INLINE_SHORTCUT_OPTIONS.findIndex(({ init }) =>
       _.isEqual(filter, init(filter)),
     );
     return optionIndex !== -1 ? optionIndex : null;
@@ -73,7 +85,7 @@ export function InlineDatePicker({
       aria-label={dimension?.field()?.displayName()}
     >
       {shouldShowShortcutOptions &&
-        DATE_SHORTCUT_OPTIONS.map(({ displayName, init }, index) => (
+        INLINE_SHORTCUT_OPTIONS.map(({ displayName, init }, index) => (
           <OptionButton
             key={displayName}
             active={index === selectedFilterIndex}
@@ -95,6 +107,7 @@ export function InlineDatePicker({
         dimension={dimension}
         handleChange={onChange}
         handleClear={onClear}
+        dateShortcutOptions={POPOVER_SHORTCUT_OPTIONS}
         customTrigger={({ onClick }) =>
           filter && selectedFilterIndex === null ? (
             <OptionButton active onClick={onClick}>

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePicker.tsx
@@ -21,6 +21,7 @@ import DatePickerFooter from "./DatePickerFooter";
 import DatePickerHeader from "./DatePickerHeader";
 import ExcludeDatePicker from "./ExcludeDatePicker";
 import DatePickerShortcuts from "./DatePickerShortcuts";
+import { DateShortcutOptions } from "./DatePickerShortcutOptions";
 import { CurrentPicker, NextPicker, PastPicker } from "./RelativeDatePicker";
 import { AfterPicker, BeforePicker, BetweenPicker } from "./RangeDatePicker";
 import SingleDatePicker from "./SingleDatePicker";
@@ -229,6 +230,7 @@ type Props = {
   className?: string;
 
   filter: Filter;
+  dateShortcutOptions?: DateShortcutOptions;
   operators?: DateOperator[];
 
   hideTimeSelectors?: boolean;
@@ -249,6 +251,7 @@ const DatePicker: React.FC<Props> = props => {
   const {
     className,
     filter,
+    dateShortcutOptions,
     onFilterChange,
     isSidebar,
     disableOperatorSelection,
@@ -284,6 +287,7 @@ const DatePicker: React.FC<Props> = props => {
         <DatePickerShortcuts
           className="p2"
           primaryColor={primaryColor}
+          dateShortcutOptions={dateShortcutOptions}
           onFilterChange={filter => {
             setShowShortcuts(false);
             onFilterChange(filter);

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePickerShortcutOptions.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePickerShortcutOptions.tsx
@@ -1,0 +1,140 @@
+import { t } from "ttag";
+import moment from "moment";
+
+import { Field } from "metabase-types/types/Field";
+import { FieldDimension } from "metabase-lib/lib/Dimension";
+import Filter from "metabase-lib/lib/queries/structured/Filter";
+
+function getDateTimeField(field: Field, bucketing?: string) {
+  const dimension = FieldDimension.parseMBQLOrWarn(field);
+  if (dimension) {
+    if (bucketing) {
+      return dimension.withTemporalUnit(bucketing).mbql();
+    } else {
+      return dimension.withoutTemporalBucketing().mbql();
+    }
+  }
+  return field;
+}
+
+type Option = {
+  displayName: string;
+  init: (filter: Filter) => any;
+};
+
+const DAY_OPTIONS: Option[] = [
+  {
+    displayName: t`Today`,
+    init: filter => [
+      "time-interval",
+      getDateTimeField(filter[1]),
+      "current",
+      "day",
+      { include_current: true },
+    ],
+  },
+  {
+    displayName: t`Yesterday`,
+    init: filter => [
+      "time-interval",
+      getDateTimeField(filter[1]),
+      -1,
+      "day",
+      { include_current: false },
+    ],
+  },
+  {
+    displayName: t`Last Week`,
+    init: filter => [
+      "time-interval",
+      getDateTimeField(filter[1]),
+      -1,
+      "week",
+      { include_current: false },
+    ],
+  },
+  {
+    displayName: t`Last 7 Days`,
+    init: filter => [
+      "time-interval",
+      getDateTimeField(filter[1]),
+      -7,
+      "day",
+      { include_current: false },
+    ],
+  },
+  {
+    displayName: t`Last 30 Days`,
+    init: filter => [
+      "time-interval",
+      getDateTimeField(filter[1]),
+      -30,
+      "day",
+      { include_current: false },
+    ],
+  },
+];
+
+const MONTH_OPTIONS: Option[] = [
+  {
+    displayName: t`Last Month`,
+    init: filter => [
+      "time-interval",
+      getDateTimeField(filter[1]),
+      -1,
+      "month",
+      { include_current: false },
+    ],
+  },
+  {
+    displayName: t`Last 3 Months`,
+    init: filter => [
+      "time-interval",
+      getDateTimeField(filter[1]),
+      -3,
+      "month",
+      { include_current: false },
+    ],
+  },
+  {
+    displayName: t`Last 12 Months`,
+    init: filter => [
+      "time-interval",
+      getDateTimeField(filter[1]),
+      -12,
+      "month",
+      { include_current: false },
+    ],
+  },
+];
+
+const MISC_OPTIONS: Option[] = [
+  {
+    displayName: t`Specific dates...`,
+    init: filter => [
+      "=",
+      getDateTimeField(filter[1]),
+      moment().format("YYYY-MM-DD"),
+    ],
+  },
+  {
+    displayName: t`Relative dates...`,
+    init: filter => ["time-interval", getDateTimeField(filter[1]), -30, "day"],
+  },
+  {
+    displayName: t`Exclude...`,
+    init: filter => ["!=", getDateTimeField(filter[1])],
+  },
+];
+
+export interface DateShortcutOptions {
+  DAY_OPTIONS: Option[];
+  MONTH_OPTIONS: Option[];
+  MISC_OPTIONS: Option[];
+}
+
+export const DATE_SHORTCUT_OPTIONS: DateShortcutOptions = {
+  DAY_OPTIONS,
+  MONTH_OPTIONS,
+  MISC_OPTIONS,
+};

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePickerShortcuts.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePickerShortcuts.tsx
@@ -1,147 +1,20 @@
-import React from "react";
-import { t } from "ttag";
-import moment from "moment";
+import React, { useMemo } from "react";
 import _ from "underscore";
 
-import { Field } from "metabase-types/types/Field";
-import { FieldDimension } from "metabase-lib/lib/Dimension";
 import Filter from "metabase-lib/lib/queries/structured/Filter";
 import SidebarHeader from "metabase/query_builder/components/SidebarHeader";
 import { Filter as FilterExpression } from "metabase-types/types/Query";
 
 import { ShortcutButton, Separator } from "./DatePickerShortcuts.styled";
-
-function getDateTimeField(field: Field, bucketing?: string) {
-  const dimension = FieldDimension.parseMBQLOrWarn(field);
-  if (dimension) {
-    if (bucketing) {
-      return dimension.withTemporalUnit(bucketing).mbql();
-    } else {
-      return dimension.withoutTemporalBucketing().mbql();
-    }
-  }
-  return field;
-}
-
-type Option = {
-  displayName: string;
-  init: (filter: Filter) => any;
-};
-
-const DAY_OPTIONS: Option[] = [
-  {
-    displayName: t`Today`,
-    init: filter => [
-      "time-interval",
-      getDateTimeField(filter[1]),
-      "current",
-      "day",
-      { include_current: true },
-    ],
-  },
-  {
-    displayName: t`Yesterday`,
-    init: filter => [
-      "time-interval",
-      getDateTimeField(filter[1]),
-      -1,
-      "day",
-      { include_current: false },
-    ],
-  },
-  {
-    displayName: t`Last Week`,
-    init: filter => [
-      "time-interval",
-      getDateTimeField(filter[1]),
-      -1,
-      "week",
-      { include_current: false },
-    ],
-  },
-  {
-    displayName: t`Last 7 Days`,
-    init: filter => [
-      "time-interval",
-      getDateTimeField(filter[1]),
-      -7,
-      "day",
-      { include_current: false },
-    ],
-  },
-  {
-    displayName: t`Last 30 Days`,
-    init: filter => [
-      "time-interval",
-      getDateTimeField(filter[1]),
-      -30,
-      "day",
-      { include_current: false },
-    ],
-  },
-];
-
-const MONTH_OPTIONS: Option[] = [
-  {
-    displayName: t`Last Month`,
-    init: filter => [
-      "time-interval",
-      getDateTimeField(filter[1]),
-      -1,
-      "month",
-      { include_current: false },
-    ],
-  },
-  {
-    displayName: t`Last 3 Months`,
-    init: filter => [
-      "time-interval",
-      getDateTimeField(filter[1]),
-      -3,
-      "month",
-      { include_current: false },
-    ],
-  },
-  {
-    displayName: t`Last 12 Months`,
-    init: filter => [
-      "time-interval",
-      getDateTimeField(filter[1]),
-      -12,
-      "month",
-      { include_current: false },
-    ],
-  },
-];
-
-const MISC_OPTIONS: Option[] = [
-  {
-    displayName: t`Specific dates...`,
-    init: filter => [
-      "=",
-      getDateTimeField(filter[1]),
-      moment().format("YYYY-MM-DD"),
-    ],
-  },
-  {
-    displayName: t`Relative dates...`,
-    init: filter => ["time-interval", getDateTimeField(filter[1]), -30, "day"],
-  },
-  {
-    displayName: t`Exclude...`,
-    init: filter => ["!=", getDateTimeField(filter[1])],
-  },
-];
-
-export const OPTIONS = {
-  DAY_OPTIONS,
-  MONTH_OPTIONS,
-  MISC_OPTIONS,
-};
+import {
+  DATE_SHORTCUT_OPTIONS,
+  DateShortcutOptions,
+} from "./DatePickerShortcutOptions";
 
 type Props = {
   className?: string;
   primaryColor?: string;
+  dateShortcutOptions?: DateShortcutOptions;
 
   filter: Filter;
   onCommit: (value: FilterExpression[]) => void;
@@ -153,6 +26,7 @@ export default function DatePickerShortcuts({
   className,
   onFilterChange,
   filter,
+  dateShortcutOptions,
   onCommit,
   onBack,
   primaryColor,
@@ -165,6 +39,11 @@ export default function DatePickerShortcuts({
       (field.table ? field.table.displayName() + " – " : "") +
       field.displayName();
   }
+
+  const { DAY_OPTIONS, MONTH_OPTIONS, MISC_OPTIONS } = useMemo(
+    () => dateShortcutOptions ?? DATE_SHORTCUT_OPTIONS,
+    [dateShortcutOptions],
+  );
 
   return (
     <div className={className}>


### PR DESCRIPTION
## Before

It's a little silly to show some inline date options and show them again the filter popover
![Screen Shot 2022-06-30 at 2 13 14 PM](https://user-images.githubusercontent.com/30528226/176769696-b0f932ae-62a6-434a-aaab-8b8eee24316e.png)

## Changes
First, I simply moved the date picker options data structure and types to its own file. I feel pretty good about that.

Second, From `InlineDatePicker`, we need to let `DatePickerShortcuts` know that it shouldn't show certain shortcuts, this is a little tricker.

This is the current component hierarchy:

```jsx
InlineDatePicker
 └─ BulkFilterSelect
     └─ FilterPopover
          └─ DatePicker
              └─ DatePickerShortcuts
```

We have a handful of options for how to accomplish this, none of which I really like:

1. Just drill a prop with an options override data structure all the way down
> kind of a crude solution that touches a lot of intermediate general purpose components for a very specific use case
2. Pass a flag down that shows a limited set of options
> just as bad as option 1, but less versatile since we can't use the prop for anything else
3. Use Context to provide an options override
> we can't do this because our popover component adds data to the end of the DOM, so our provider would need to encompass the entire `<body>`
4. Make InlineDatePicker a parent of DatePicker, cutting out 2 levels of prop drilling
> this would require use to duplicate certain styling and display code from `BulkFilterSelect` and filter-changing logic from `FilterPopover` that is less than ideal

Given these options, I chose option 1 as the least of all evils, but would very much welcome suggestions for a better strategy for changing the available date filter shortcuts.

## After

No Duplicated Options

![Screen Shot 2022-06-30 at 2 08 21 PM](https://user-images.githubusercontent.com/30528226/176769757-90c020f4-a93f-45ef-8672-09d4201019aa.png)
