### PR TITLE
Add border-radius to editable text areas

### DIFF
--- a/frontend/src/metabase/core/components/EditableText/EditableText.styled.tsx
+++ b/frontend/src/metabase/core/components/EditableText/EditableText.styled.tsx
@@ -10,6 +10,7 @@ export const EditableTextRoot = styled.div<EditableTextRootProps>`
   color: ${color("text-dark")};
   padding: 0.25rem;
   border: 1px solid transparent;
+  border-radius: 4px;
 
   &:hover,
   &:focus-within {


### PR DESCRIPTION
Makes the corners of these editable text areas rounded:

<img width="335" alt="image" src="https://user-images.githubusercontent.com/2223916/176796174-41151046-70ff-4ab1-a0d6-f9d30c11ad92.png">

<img width="330" alt="image" src="https://user-images.githubusercontent.com/2223916/176796192-00d6b18d-5652-4ded-b71b-76143f5033a4.png">
