### PR TITLE
Add test for user endpoint when user is a sandboxed group manager

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/user_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/user_test.clj
@@ -14,7 +14,7 @@
 ;; are an example usage of this. Segmented users should not have that ability. Instead they should only see
 ;; themselves. This test checks that GET /api/user for a segmented user only returns themselves
 (deftest segmented-user-list-test
-  (testing "GET /api/user"
+  (testing "GET /api/user for a segmented user should return themselves"
     (mt/with-gtaps {:gtaps {:venues {}}}
       ;; Now do the request
       (is (= [{:common_name "Rasta Toucan"
@@ -23,7 +23,7 @@
                :email       "rasta@metabase.com"
                :id          true}]
              (tu/boolean-ids-and-timestamps ((mt/user-http-request :rasta :get 200 "user") :data))))
-      (testing "When a group manager"
+      (testing "Should return themselves when the user is a segmented group manager"
         (mt/with-group [group {:name "a group"}]
           (let [membership (db/select-one PermissionsGroupMembership
                                           :group_id (u/the-id group)


### PR DESCRIPTION
Just adding a test for [this PR](https://github.com/metabase/metabase/pull/23525), which fixes this issue ["column reference "id" is ambiguous" when group managers want to see the group members](https://github.com/metabase/metabase/issues/23246).

No additional changes, I just missed adding a test in the original PR.