### PR TITLE
Clean up revision history and add a tooltip to Revert action

### DIFF
--- a/frontend/src/metabase/components/Timeline.jsx
+++ b/frontend/src/metabase/components/Timeline.jsx
@@ -2,8 +2,10 @@ import React, { useMemo } from "react";
 import PropTypes from "prop-types";
 import _ from "underscore";
 import { getRelativeTime } from "metabase/lib/time";
+import { t } from "ttag";
 
 import Button from "metabase/core/components/Button";
+import Tooltip from "metabase/components/Tooltip";
 
 import {
   TimelineContainer,
@@ -87,13 +89,15 @@ function Timeline({
               <ItemHeader>
                 {title}
                 {isRevertable && revertFn && (
-                  <Button
-                    icon="revert"
-                    onlyIcon
-                    borderless
-                    onClick={() => revertFn(revision)}
-                    data-testid="question-revert-button"
-                  />
+                  <Tooltip tooltip={t`Revert to this version`}>
+                    <Button
+                      icon="revert"
+                      onlyIcon
+                      borderless
+                      onClick={() => revertFn(revision)}
+                      data-testid="question-revert-button"
+                    />
+                  </Tooltip>
                 )}
               </ItemHeader>
               <Timestamp datetime={timestamp}>{formattedTimestamp}</Timestamp>

--- a/frontend/src/metabase/components/Timeline.styled.jsx
+++ b/frontend/src/metabase/components/Timeline.styled.jsx
@@ -16,7 +16,7 @@ export const TimelineItem = styled.li`
   transform: translateX(-${props => props.leftShift}px);
   white-space: pre-line;
   width: 100%;
-  margin-bottom: 1rem;
+  margin-bottom: 1.5rem;
 `;
 
 export const ItemIcon = styled(Icon)`
@@ -57,5 +57,4 @@ export const Border = styled.div`
   top: ${props => props.borderShift}px;
   left: ${props => props.borderShift}px;
   bottom: calc(-1rem - ${props => props.borderShift}px);
-  border-left: 1px solid ${color("border")};
 `;


### PR DESCRIPTION
- Get rid of weird vertical "timeline" border
- Add a tooltip to the revert action
- Add more vertical spacing between event items

## Before

<img width="354" alt="image" src="https://user-images.githubusercontent.com/2223916/176797870-fd3e139f-2b4d-4793-8b4b-41f163238901.png">

## After

<img width="354" alt="image" src="https://user-images.githubusercontent.com/2223916/176797759-fa34e514-b9f5-4a87-af78-8a64c5783d0f.png">
