### PR TITLE
BE: parameters in snippet

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -11932,6 +11932,21 @@ databaseChangeLog:
                   constraints:
                     nullable: false
 
+  - changeSet:
+      id: v44.00-039
+      author: qnkhuat
+      comment: Added 0.44.0 - Add template_tags to native_query_snippet
+      changes:
+        - addColumn:
+            tableName: native_query_snippet
+            columns:
+              - column:
+                  name: template_tags
+                  type: ${text.type}
+                  remarks: Template tags for a snippet
+                  constraints:
+                    nullable: true
+
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/shared/src/metabase/mbql/normalize.cljc
+++ b/shared/src/metabase/mbql/normalize.cljc
@@ -244,7 +244,7 @@
            (not (:widget-type tag-def)))
       (assoc :widget-type :category))))
 
-(defn- normalize-template-tags
+(defn normalize-template-tags
   "Normalize native-query template tags. Like `expressions` we want to preserve the original name rather than normalize
   it."
   [template-tags]

--- a/shared/src/metabase/mbql/schema.cljc
+++ b/shared/src/metabase/mbql/schema.cljc
@@ -913,9 +913,13 @@
 ;;
 ;; Field filters and raw values usually have their value specified by `:parameters` (see [[Parameters]] below).
 
+(def template-tag-types
+  "List of valid template tag types."
+  [:snippet :card :dimension :number :text :date])
+
 (def TemplateTagType
   "Schema for valid values of template tag `:type`."
-  (s/enum :snippet :card :dimension :number :text :date))
+  (apply s/enum template-tag-types))
 
 (def ^:private TemplateTag:Common
   "Things required by all template tag types."

--- a/src/metabase/api/native_query_snippet.clj
+++ b/src/metabase/api/native_query_snippet.clj
@@ -38,17 +38,19 @@
 
 (api/defendpoint POST "/"
   "Create a new `NativeQuerySnippet`."
-  [:as {{:keys [content description name collection_id]} :body}]
+  [:as {{:keys [content description name collection_id template_tags]} :body}]
   {content       s/Str
    description   (s/maybe s/Str)
    name          native-query-snippet/NativeQuerySnippetName
-   collection_id (s/maybe su/IntGreaterThanZero)}
+   collection_id (s/maybe su/IntGreaterThanZero)
+   template_tags (s/maybe su/TemplateTags)}
   (check-snippet-name-is-unique name)
   (let [snippet {:content       content
                  :creator_id    api/*current-user-id*
                  :description   description
                  :name          name
-                 :collection_id collection_id}]
+                 :collection_id collection_id
+                 :template_tags (or template_tags {})}]
     (api/create-check NativeQuerySnippet snippet)
     (api/check-500 (db/insert! NativeQuerySnippet snippet))))
 
@@ -59,7 +61,7 @@
   (let [snippet     (NativeQuerySnippet id)
         body-fields (u/select-keys-when body
                       :present #{:description :collection_id}
-                      :non-nil #{:archived :content :name})
+                      :non-nil #{:archived :content :name :template_tags})
         [changes]   (data/diff body-fields snippet)]
     (when (seq changes)
       (api/update-check snippet changes)
@@ -70,12 +72,13 @@
 
 (api/defendpoint PUT "/:id"
   "Update an existing `NativeQuerySnippet`."
-  [id :as {{:keys [archived content description name collection_id] :as body} :body}]
+  [id :as {{:keys [archived content description name collection_id template_tags] :as body} :body}]
   {archived      (s/maybe s/Bool)
    content       (s/maybe s/Str)
    description   (s/maybe s/Str)
    name          (s/maybe native-query-snippet/NativeQuerySnippetName)
-   collection_id (s/maybe su/IntGreaterThanZero)}
+   collection_id (s/maybe su/IntGreaterThanZero)
+   template_tags (s/maybe su/TemplateTags)}
   (check-perms-and-update-snippet! id body))
 
 (api/define-routes)

--- a/src/metabase/driver/common/parameters.clj
+++ b/src/metabase/driver/common/parameters.clj
@@ -32,7 +32,7 @@
 ;;
 ;; `query` is the native query as stored in the Card
 ;;
-;; `parameters` are positional parameters for a parameterized native query e.g. the JDBC parameters corresponding to
+;; `params` are positional parameters for a parameterized native query e.g. the JDBC parameters corresponding to
 ;; `?` placeholders
 (p.types/defrecord+ ReferencedCardQuery [card-id query params]
   pretty/PrettyPrintable
@@ -44,13 +44,34 @@
   [x]
   (instance? ReferencedCardQuery x))
 
+;; `ParsedQuerySnippet` is a parsed representation of the content in `NativeQuerySnippet`.
+;; It is to be used as an intermediate state when subsituting parameter in a Snippet.
+;;
+;; `snippet-id` is the integer ID of the row in the application DB from where the snippet content is loaded.
+;;
+;; `parsed-query` is an array we got from parsing the raw query of the snippet
+;;
+;; `param->value` is a map with with template tags parsed from the raw query as keys
+(p.types/defrecord+ ParsedQuerySnippet [snippet-id parsed-query param->value]
+  pretty/PrettyPrintable
+  (pretty [this]
+    (list (pretty/qualify-symbol-for-*ns* `map->ParsedQuerySnippet) (into {} this))))
+
+(defn ParsedQuerySnippet?
+  "Is `x` an instance of the `ParsedQuerySnippet` record type?"
+  [x]
+  (instance? ParsedQuerySnippet x))
+
 ;; A `ReferencedQuerySnippet` expands to the partial query snippet stored in the `NativeQuerySnippet` table in the
 ;; application DB.
 ;;
 ;; `snippet-id` is the integer ID of the row in the application DB from where the snippet content is loaded.
 ;;
 ;; `content` is the raw query snippet which will be replaced, verbatim, for this template tag.
-(p.types/defrecord+ ReferencedQuerySnippet [snippet-id content]
+;;
+;; `params` are positional parameters for a parameterized native query e.g. the JDBC parameters corresponding to
+;; `?` placeholders
+(p.types/defrecord+ ReferencedQuerySnippet [snippet-id content params]
   pretty/PrettyPrintable
   (pretty [this]
     (list (pretty/qualify-symbol-for-*ns* `map->ReferencedQuerySnippet) (into {} this))))

--- a/src/metabase/driver/common/parameters/values.clj
+++ b/src/metabase/driver/common/parameters/values.clj
@@ -11,6 +11,7 @@
   (:require [clojure.string :as str]
             [clojure.tools.logging :as log]
             [metabase.driver.common.parameters :as params]
+            [metabase.driver.common.parameters.parse :as params.parse]
             [metabase.mbql.schema :as mbql.s]
             [metabase.models.card :refer [Card]]
             [metabase.models.native-query-snippet :refer [NativeQuerySnippet]]
@@ -25,7 +26,8 @@
   (:import clojure.lang.ExceptionInfo
            java.text.NumberFormat
            java.util.UUID
-           [metabase.driver.common.parameters CommaSeparatedNumbers FieldFilter MultipleValues ReferencedCardQuery ReferencedQuerySnippet]))
+           [metabase.driver.common.parameters CommaSeparatedNumbers FieldFilter
+            MultipleValues ParsedQuerySnippet ReferencedCardQuery]))
 
 (defmulti ^:private parse-tag
   "Parse a tag by its `:type`, returning an appropriate record type such as
@@ -158,8 +160,10 @@
                  :type              qp.error-type/invalid-parameter}
                 e))))))
 
-(s/defmethod parse-tag :snippet :- ReferencedQuerySnippet
-  [{:keys [snippet-name snippet-id], :as tag} :- mbql.s/TemplateTag, _]
+(declare query->params-map)
+
+(s/defmethod parse-tag :snippet :- ParsedQuerySnippet
+  [{:keys [snippet-name snippet-id], :as tag} :- mbql.s/TemplateTag, params]
   (let [snippet-id (or snippet-id
                        (throw (ex-info (tru "Unable to resolve Snippet: missing `:snippet-id`")
                                        {:tag tag, :type qp.error-type/invalid-parameter})))
@@ -169,10 +173,12 @@
                                         :snippet-name snippet-name
                                         :tag          tag
                                         :type         qp.error-type/invalid-parameter})))]
-    (params/map->ReferencedQuerySnippet
-     {:snippet-id (:id snippet)
-      :content    (:content snippet)})))
-
+    (params/map->ParsedQuerySnippet
+      {:snippet-id   (:id snippet)
+       ;; parse the content of snippet so that we could substitute template-tags inside snippet
+       :parsed-query (params.parse/parse (:content snippet))
+       :param->value (query->params-map  {:template-tags (:template_tags snippet)
+                                          :parameters    params})})))
 
 ;;; Non-FieldFilter Params (e.g. WHERE x = {{x}})
 

--- a/src/metabase/driver/sql.clj
+++ b/src/metabase/driver/sql.clj
@@ -41,9 +41,8 @@
 
 (s/defmethod driver/substitute-native-parameters :sql
   [_ {:keys [query] :as inner-query} :- {:query su/NonBlankString, s/Keyword s/Any}]
-  (let [[query params] (-> query
-                           params.parse/parse
-                           (sql.params.substitute/substitute (params.values/query->params-map inner-query)))]
+  (let [[query params]  (sql.params.substitute/substitute (params.parse/parse query)
+                                                          (params.values/query->params-map inner-query))]
     (assoc inner-query
            :query query
            :params params)))

--- a/src/metabase/driver/sql/parameters/substitution.clj
+++ b/src/metabase/driver/sql/parameters/substitution.clj
@@ -312,6 +312,6 @@
 ;;; ---------------------------------- Native Query Snippet replacement snippet info ---------------------------------
 
 (defmethod ->replacement-snippet-info [:sql ReferencedQuerySnippet]
-  [_ {:keys [content]}]
-  {:prepared-statement-args nil
+  [_ {:keys [content params]}]
+  {:prepared-statement-args (not-empty params)
    :replacement-snippet     content})

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -96,6 +96,10 @@
   :in  (comp json-in normalize-parameters-list)
   :out (comp (catch-normalization-exceptions normalize-parameters-list) json-out-with-keywordization))
 
+(models/add-type! :template-tags
+  :in  (comp json-in mbql.normalize/normalize-template-tags)
+  :out (comp (catch-normalization-exceptions mbql.normalize/normalize-template-tags) json-out-with-keywordization))
+
 (def ^:private MetricSegmentDefinition
   {(s/optional-key :filter)      (s/maybe mbql.s/Filter)
    (s/optional-key :aggregation) (s/maybe [mbql.s/Aggregation])

--- a/src/metabase/models/native_query_snippet.clj
+++ b/src/metabase/models/native_query_snippet.clj
@@ -19,7 +19,8 @@
   #{:snippets})
 
 (defn- pre-insert [snippet]
-  (u/prog1 snippet
+  (u/prog1 (merge {:template_tags {}}
+                  snippet)
     (collection/check-collection-namespace NativeQuerySnippet (:collection_id snippet))))
 
 (defn- pre-update [{:keys [creator_id id], :as updates}]
@@ -36,6 +37,7 @@
    models/IModelDefaults
    {:properties (constantly {:timestamped? true
                              :entity_id    true})
+    :types      (constantly {:template_tags :template-tags})
     :pre-insert pre-insert
     :pre-update pre-update})
 

--- a/src/metabase/util/schema.clj
+++ b/src/metabase/util/schema.clj
@@ -5,6 +5,7 @@
             [clojure.string :as str]
             [clojure.walk :as walk]
             [medley.core :as m]
+            [metabase.mbql.schema :as mbql.s]
             [metabase.types :as types]
             [metabase.util :as u]
             [metabase.util.date-2 :as u.date]
@@ -351,6 +352,27 @@
                            (s/optional-key :card_id) IntGreaterThanZero
                            s/Keyword                 s/Any}
     (deferred-tru "parameter_mapping must be a map with :parameter_id and :target keys")))
+
+(def ^:private TemplateTagSchema
+  ;; For the full schema that we use in MBQL, check [[metabase.mbql.schema/TemplateTagMap]]
+  {(s/either NonBlankString s/Keyword) {:id                            NonBlankString
+                                        :name                          NonBlankString
+                                        :type                          (apply s/enum (map name mbql.s/template-tag-types))
+                                        (s/optional-key :display-name) s/Str
+                                        (s/optional-key :default)      s/Any
+                                        s/Keyword                      s/Any}})
+
+(def TemplateTags
+  "Schema for a valid Template tags."
+  (with-api-error-message
+    (s/constrained
+      TemplateTagSchema
+      (fn [m]
+        (every? (fn [[tag-name tag-definition]]
+                  (= (name tag-name) (:name tag-definition)))
+                m))
+      "keys in template tag map must match the :name of their values")
+   (deferred-tru "template tags must be a map with key of name->TemplateTag.")))
 
 (def EmbeddingParams
   "Schema for a valid map of embedding params."

--- a/test/metabase/driver/common/parameters/values_test.clj
+++ b/test/metabase/driver/common/parameters/values_test.clj
@@ -2,6 +2,7 @@
   (:require [clojure.test :refer :all]
             [metabase.driver :as driver]
             [metabase.driver.common.parameters :as params]
+            [metabase.driver.common.parameters.parse :as params.parse]
             [metabase.driver.common.parameters.values :as params.values]
             [metabase.models :refer [Card Collection NativeQuerySnippet]]
             [metabase.models.permissions :as perms]
@@ -18,6 +19,7 @@
            metabase.driver.common.parameters.ReferencedCardQuery))
 
 (def ^:private test-uuid (str (UUID/randomUUID)))
+(def ^:private ^{:arglists '([field-name])} param (var-get #'params.parse/param))
 
 (deftest variable-value-test
   (mt/with-everything-store
@@ -392,35 +394,76 @@
              (query->params-map query)))))))
 
 (deftest snippet-test
-  (letfn [(query-with-snippet [& {:as snippet-properties}]
+  (letfn [(query-with-snippet [parameters & {:as snippet-properties}]
             (assoc (mt/native-query "SELECT * FROM {{expensive-venues}}")
                    :template-tags {"expensive-venues" (merge
                                                        {:type         :snippet
                                                         :name         "expensive-venues"
                                                         :display-name "Expensive Venues"
                                                         :snippet-name "expensive-venues"}
-                                                       snippet-properties)}))]
+                                                       snippet-properties)}
+                   :parameters   parameters))]
     (testing "`:snippet-id` should be required"
       (is (thrown?
            clojure.lang.ExceptionInfo
-           (query->params-map (query-with-snippet)))))
+           (query->params-map (query-with-snippet [])))))
 
     (testing "If no such Snippet exists, it should throw an Exception"
       (is (thrown?
            clojure.lang.ExceptionInfo
-           (query->params-map (query-with-snippet :snippet-id Integer/MAX_VALUE)))))
+           (query->params-map (query-with-snippet [] :snippet-id Integer/MAX_VALUE)))))
 
     (testing "Snippet parsing should work correctly for a valid Snippet"
-      (mt/with-temp NativeQuerySnippet [{snippet-id :id} {:name    "expensive-venues"
-                                                          :content "venues WHERE price = 4"}]
-        (let [expected {"expensive-venues" (params/map->ReferencedQuerySnippet {:snippet-id snippet-id
-                                                                                :content    "venues WHERE price = 4"})}]
-          (is (= expected
-                 (query->params-map (query-with-snippet :snippet-id snippet-id))))
-
-          (testing "`:snippet-name` property in query shouldn't have to match `:name` of Snippet in DB"
+      (testing "snippet without param"
+        (mt/with-temp NativeQuerySnippet [{snippet-id :id} {:name    "expensive-venues"
+                                                            :content "venues WHERE price = 4"}]
+          (let [expected {"expensive-venues" (params/map->ParsedQuerySnippet {:snippet-id   snippet-id
+                                                                              :parsed-query ["venues WHERE price = 4"]
+                                                                              :param->value {}})}]
             (is (= expected
-                   (query->params-map (query-with-snippet :snippet-id snippet-id, :snippet-name "Old Name"))))))))))
+                   (query->params-map (query-with-snippet [] :snippet-id snippet-id))))
+
+            (testing "`:snippet-name` property in query shouldn't have to match `:name` of Snippet in DB"
+              (is (= expected
+                     (query->params-map (query-with-snippet [] :snippet-id snippet-id, :snippet-name "Old Name"))))))))
+
+      (testing "snippet with params"
+        (mt/with-temp NativeQuerySnippet [{snippet-id :id}
+                                          {:name          "expensive-venues"
+                                           :content       "venues WHERE name = {{name}} and {{price}}"
+                                           :template_tags {"price" {:dimension    ["field" (mt/id :venues :price) nil]
+                                                                    :display-name "Price"
+                                                                    :id           "random-id-1"
+                                                                    :name         "price"
+                                                                    :type         "dimension"
+                                                                    :widget-type  "number/="}
+                                                           "name"  {:display-name "Name"
+                                                                    :id           "random-id-2"
+                                                                    :name         "name"
+                                                                    :type         "text"}}}]
+          (let [params         [{:id     "ramdom-id-1",
+                                 :target [:variable [:template-tag "name"]],
+                                 :type   :text,
+                                 :value  "The Apple Pan"}
+                                {:id     "random-id-2",
+                                 :target [:dimension [:template-tag "price"]],
+                                 :type   :string/=,
+                                 :value  [3]}]
+                result         (query->params-map (query-with-snippet params :snippet-id snippet-id))
+                parsed-snippet (get result "expensive-venues")]
+            (is (= snippet-id (:snippet-id parsed-snippet)))
+            (is (= ["venues WHERE name = " (param "name") " and " (param "price")]
+                   (:parsed-query parsed-snippet)))
+            (testing "FieldFilter parameter should have a field and value keys"
+              (is (= (mt/id :venues :price)
+                     (get-in parsed-snippet [:param->value "price" :field :id])))
+              (is (= {:id    "random-id-2"
+                      :type  :string/=
+                      :value [3]}
+                     (get-in parsed-snippet [:param->value "price" :value]))))
+            (testing "variable parameter should have value is the value of parameter"
+              (is (= "The Apple Pan"
+                     (get-in parsed-snippet [:param->value "name"]))))))))))
 
 (deftest invalid-param-test
   (testing "Should throw an Exception if we try to pass with a `:type` we don't understand"

--- a/test/metabase/models/native_query_snippet_test.clj
+++ b/test/metabase/models/native_query_snippet_test.clj
@@ -58,6 +58,32 @@
              #"A NativeQuerySnippet can only go in Collections in the :snippets namespace"
              (db/update! NativeQuerySnippet snippet-id :collection_id dest-collection-id)))))))
 
+(deftest normalize-template_tags-test
+  (testing ":template_tags should get normalized when coming out of the DB"
+    (mt/with-temp NativeQuerySnippet [{snippet-id :id} {:template_tags {"text"         {:display-name "Text-1"
+                                                                                        :id           "random-id-1"
+                                                                                        :name         "text-1"
+                                                                                        :type         "text"}
+                                                                        "field-filter" {:default      nil
+                                                                                        :dimension    ["field" 1 nil]
+                                                                                        :id           "random-id-2"
+                                                                                        :display-name "Field Filter"
+                                                                                        :name         "field-filter"
+                                                                                        :type         "dimension"
+                                                                                        :widget-type  "string/="}}}]
+      (is (= {"field-filter" {:default      nil,
+                              :dimension    [:field 1 nil],
+                              :display-name "Field Filter",
+                              :id           "random-id-2",
+                              :name         "field-filter",
+                              :type         :dimension,
+                              :widget-type  :string/=},
+              "text" {:display-name "Text-1",
+                      :id           "random-id-1",
+                      :name         "text",
+                      :type         :text}}
+            (db/select-one-field :template_tags NativeQuerySnippet :id snippet-id))))))
+
 (deftest identity-hash-test
   (testing "Native query snippet hashes are composed of the name and the collection's hash"
     (mt/with-temp* [Collection         [coll    {:name "field-db" :namespace :snippets :location "/"}]


### PR DESCRIPTION
Add `template_tags` column to snippet and make substitution middleware able to substitute parameters in snippet.

### Background

The simplified idea of our parameter substitution works as follows:
- The `substitute-parameters` middleware receives a native query and triggers a driver method `substitute-native-parameters` - which does the actual substitution
The code of this driver method
```clojure
(sql.params.substitute/substitute 
  (params.parse/parse query)
  (params.values/query->params-map inner-query))
```

1. the `params.parse/parse` function takes a raw query (e.g: select * from {{table-name}}) and try to parse it, the result will be an array where each elements is either a raw string, or a Param (e.g: `["select * from " (Param "table-name")]`)
2. The `params.values/query->params-map` function takes a query and try to infer from the template-tags to return a param->value map. In our example above it should returns `{"table-name": "products"}`
3. And then, the `sql.params.substitute/substitute` will walk through the parsed-query from (1), and try to replace it with the value from (2)

Regarding snippet: currently in `params.values/query->params-map`, whenever we find a template-tag that need to be replaced as a snippet, we fetch the snippet from AppDB. So that `sql.params.substitute/substitute` could substitute with the snippet content.

### Solution
Treat snippet content like a native query:
- create `template_tags` column in `snippet` table
- In `params.values/query->params-map`, if a template-tag has target is a snippet, instead of returning the raw content like before, we'll parse the content of this snippet again with `params.parse/parse`([ref](https://github.com/metabase/metabase/blob/f44b3e993148585fdc424f8afbf6589484e7b0b5/src/metabase/driver/common/parameters/values.clj#L176)). 
  - Call `params.values/query->params-map` on the template-tags of snippet to get the param->value map.
  - With the parsed-query and param->value for snippet, in the later phase `sql.params.substitute/substitute`, we could substitute the param in snippet with its desired value by simply calling `sql.params.substitute/substitute` again. ([ref](https://github.com/metabase/metabase/blob/f44b3e993148585fdc424f8afbf6589484e7b0b5/src/metabase/driver/sql/parameters/substitute.clj#L27))

### How to test
1. New SQL query
2. Create a new snippet with content `rating > {{rating}}`
3. manually update the `template_tags` column of the added snippet
```json
{"rating":{"type":"number","name":"rating","id":"bf8e3f1f-cf69-e83b-d378-366c865ee221","display-name":"Rating","default":null}}
```
4. Back to the SQL console, create a query `select * from products where ` then insert the created snippet in.
5. Now an input for the `rating` variable should appear, gives it a value (e.g: 3), and try to run the query

### Note
We'll probably need to have a follow up PR for [this](https://github.com/metabase/metabase/pull/23691#discussion_r914694950)

P.s: FE changes are in #23526.