### PR TITLE
skip flaky date test

### DIFF
--- a/frontend/test/metabase/scenarios/filters/filter-bulk.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/filter-bulk.cy.spec.js
@@ -388,7 +388,7 @@ describe("scenarios > filters > bulk filtering", () => {
     });
 
     // if this gets flaky, disable, it's an issue with internal state in the datepicker component
-    it("can add a date range filter", () => {
+    it.skip("can add a date range filter", () => {
       modal().within(() => {
         cy.findByLabelText("Created At").within(() => {
           cy.findByLabelText("more options").click();


### PR DESCRIPTION

Skips flaky date test. At some point we probably want to look at whatever internal race-condition in the date picker component causes this.