### PR TITLE
Enable using site locale for translations on FE

### DIFF
--- a/frontend/src/metabase/lib/i18n.js
+++ b/frontend/src/metabase/lib/i18n.js
@@ -64,16 +64,19 @@ function updateMomentStartOfWeek() {
 // if the start of week Setting is updated, update the moment start of week
 MetabaseSettings.on("start-of-week", updateMomentStartOfWeek);
 
-export function setLocalization(translationsObject) {
+function setLanguage(translationsObject) {
   const locale = translationsObject.headers.language;
-
   addMsgIds(translationsObject);
 
-  // add and set locale with C-3PO
+  // add and set locale for ttag
   addLocale(locale, translationsObject);
   // eslint-disable-next-line react-hooks/rules-of-hooks
   useLocale(locale);
+}
 
+export function setLocalization(translationsObject) {
+  const locale = translationsObject.headers.language;
+  setLanguage(translationsObject);
   updateMomentLocale(locale);
   updateMomentStartOfWeek(locale);
 }
@@ -119,7 +122,23 @@ function addMsgIds(translationsObject) {
   }
 }
 
+// Runs `f` with the current language for ttag set to the instance (site) locale rather than the user locale, then
+// restores the user locale. This can be used for translating specific strings into the instance language; e.g. for
+// parameter values in dashboard text cards that should be translated the same for all users viewing the dashboard.
+export function withInstanceLanguage(f) {
+  if (window.MetabaseSiteLocalization) {
+    setLanguage(window.MetabaseSiteLocalization);
+  }
+  try {
+    f();
+  } finally {
+    if (window.MetabaseUserLocalization) {
+      setLanguage(window.MetabaseUserLocalization);
+    }
+  }
+}
+
 // set the initial localization
-if (window.MetabaseLocalization) {
-  setLocalization(window.MetabaseLocalization);
+if (window.MetabaseUserLocalization) {
+  setLocalization(window.MetabaseUserLocalization);
 }

--- a/frontend/src/metabase/lib/i18n.js
+++ b/frontend/src/metabase/lib/i18n.js
@@ -130,7 +130,7 @@ export function withInstanceLanguage(f) {
     setLanguage(window.MetabaseSiteLocalization);
   }
   try {
-    f();
+    return f();
   } finally {
     if (window.MetabaseUserLocalization) {
       setLanguage(window.MetabaseUserLocalization);

--- a/resources/frontend_client/index_template.html
+++ b/resources/frontend_client/index_template.html
@@ -27,8 +27,12 @@
       {{{bootstrapJSON}}}
     </script>
 
-    <script type="application/json" id="_metabaseLocalization">
-      {{{localizationJSON}}}
+    <script type="application/json" id="_metabaseUserLocalization">
+      {{{userLocalizationJSON}}}
+    </script>
+
+    <script type="application/json" id="_metabaseSiteLocalization">
+      {{{siteLocalizationJSON}}}
     </script>
 
     <!-- If you modify this script, make sure you update the whitelisted Content-Security-Policy hash in metabase.server.middleware.security -->

--- a/resources/frontend_client/inline_js/index_bootstrap.js
+++ b/resources/frontend_client/inline_js/index_bootstrap.js
@@ -1,6 +1,7 @@
 (function() {
-  window.MetabaseBootstrap    = JSON.parse(document.getElementById("_metabaseBootstrap").textContent);
-  window.MetabaseLocalization = JSON.parse(document.getElementById("_metabaseLocalization").textContent);
+  window.MetabaseBootstrap        = JSON.parse(document.getElementById("_metabaseBootstrap").textContent);
+  window.MetabaseUserLocalization = JSON.parse(document.getElementById("_metabaseUserLocalization").textContent);
+  window.MetabaseSiteLocalization = JSON.parse(document.getElementById("_metabaseSiteLocalization").textContent);
 
   var configuredRoot = document.head.querySelector("meta[name='base-href']").content;
   var actualRoot = "/";

--- a/shared/src/metabase/shared/util/i18n.clj
+++ b/shared/src/metabase/shared/util/i18n.clj
@@ -14,4 +14,19 @@
       `(metabase.util.i18n/tru ~format-string ~@args))
 
     :cljs
-    `(js-i18n ~format-string ~@args)))
+    `(js-tru ~format-string ~@args)))
+
+(defmacro trs
+  "i18n a string with the site's locale. Format string will be translated to the site's locale when the form is eval'ed.
+  Placeholders should use `gettext` format e.g. `{0}`, `{1}`, and so forth.
+
+    (trs \"Number of cans: {0}\" 2)"
+  [format-string & args]
+  (macros/case
+    :clj
+    (do
+      (require 'metabase.util.i18n)
+      `(metabase.util.i18n/trs ~format-string ~@args))
+
+    :cljs
+    `(js-trs ~format-string ~@args)))

--- a/shared/src/metabase/shared/util/i18n.cljs
+++ b/shared/src/metabase/shared/util/i18n.cljs
@@ -1,6 +1,6 @@
 (ns metabase.shared.util.i18n
-  (:require ["ttag" :as ttag])
-  (:require ["metabase/lib/i18n" :as i18n])
+  (:require ["metabase/lib/i18n" :as i18n]
+            ["ttag" :as ttag])
   (:require-macros metabase.shared.util.i18n))
 
 (comment metabase.shared.util.i18n/keep-me

--- a/shared/src/metabase/shared/util/i18n.cljs
+++ b/shared/src/metabase/shared/util/i18n.cljs
@@ -1,5 +1,6 @@
 (ns metabase.shared.util.i18n
   (:require ["ttag" :as ttag])
+  (:require ["metabase/lib/i18n" :as i18n])
   (:require-macros metabase.shared.util.i18n))
 
 (comment metabase.shared.util.i18n/keep-me
@@ -8,4 +9,5 @@
 (defn js-i18n
   "Format an i18n `format-string` with `args` with a translated string in the user locale."
   [format-string & args]
+  (i18n/withInstanceLanguage (fn [] (js/console.log "asdf")))
   (apply ttag/gettext format-string args))

--- a/shared/src/metabase/shared/util/i18n.cljs
+++ b/shared/src/metabase/shared/util/i18n.cljs
@@ -6,8 +6,13 @@
 (comment metabase.shared.util.i18n/keep-me
          ttag/keep-me)
 
-(defn js-i18n
+(defn js-tru
   "Format an i18n `format-string` with `args` with a translated string in the user locale."
   [format-string & args]
-  (i18n/withInstanceLanguage (fn [] (js/console.log "asdf")))
   (apply ttag/gettext format-string args))
+
+(defn js-trs
+  "Format an i18n `format-string` with `args` with a translated string in the site locale."
+  [format-string & args]
+  (i18n/withInstanceLanguage
+   (fn [] (apply ttag/gettext format-string args))))

--- a/src/metabase/server/routes/index.clj
+++ b/src/metabase/server/routes/index.clj
@@ -75,18 +75,19 @@
   (load-template
    (str "frontend_client/" entrypoint-name ".html")
    (let [{:keys [anon-tracking-enabled google-auth-client-id], :as public-settings} (setting/user-readable-values-map :public)]
-     {:bootstrapJS        (load-inline-js "index_bootstrap")
-      :googleAnalyticsJS  (load-inline-js "index_ganalytics")
-      :bootstrapJSON      (escape-script (json/generate-string public-settings))
-      :localizationJSON   (escape-script (load-localization (:locale params)))
-      :language           (hiccup.util/escape-html (public-settings/site-locale))
-      :favicon            (hiccup.util/escape-html (public-settings/application-favicon-url))
-      :applicationName    (hiccup.util/escape-html (public-settings/application-name))
-      :uri                (hiccup.util/escape-html uri)
-      :baseHref           (hiccup.util/escape-html (base-href))
-      :embedCode          (when embeddable? (embed/head uri))
-      :enableGoogleAuth   (boolean google-auth-client-id)
-      :enableAnonTracking (boolean anon-tracking-enabled)})))
+     {:bootstrapJS          (load-inline-js "index_bootstrap")
+      :googleAnalyticsJS    (load-inline-js "index_ganalytics")
+      :bootstrapJSON        (escape-script (json/generate-string public-settings))
+      :userLocalizationJSON (escape-script (load-localization (:locale params)))
+      :siteLocalizationJSON (escape-script (load-localization (public-settings/site-locale)))
+      :language             (hiccup.util/escape-html (public-settings/site-locale))
+      :favicon              (hiccup.util/escape-html (public-settings/application-favicon-url))
+      :applicationName      (hiccup.util/escape-html (public-settings/application-name))
+      :uri                  (hiccup.util/escape-html uri)
+      :baseHref             (hiccup.util/escape-html (base-href))
+      :embedCode            (when embeddable? (embed/head uri))
+      :enableGoogleAuth     (boolean google-auth-client-id)
+      :enableAnonTracking   (boolean anon-tracking-enabled)})))
 
 (defn- load-init-template []
   (load-template


### PR DESCRIPTION
This PR enables using site locale for translations on the FE, by including the site locale JSON in the `index.html` template alongside the user locale JSON. The language can then be temporarily overridden using the `withInstanceLanguage` helper function. I've also updated the clojurescript i18n utilities to include a `trs` macro that uses this helper function.

These changes are mostly based on @ranquild's suggestions [in this thread](https://metaboat.slack.com/archives/C505ZNNH4/p1656604380044879).

Context: I am working on including parameters in markdown cards, and certain parameter values (like relative datetimes) include translatable text. Since these values are interpolated into a text card that might be written in any language, we need to ensure that we translate the value consistently for all users. In the future we may want to make this configurable, but for this first pass we are sticking with using the site language.