### PR TITLE
Spacing and sizing tweaks to question info sidebar

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationReviewBanner/ModerationReviewBanner.styled.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationReviewBanner/ModerationReviewBanner.styled.jsx
@@ -7,7 +7,7 @@ export const Container = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: start;
-  column-gap: 1rem;
+  column-gap: 0.5rem;
   border-radius: 8px;
 `;
 

--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationReviewBanner/ModerationReviewBanner.styled.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationReviewBanner/ModerationReviewBanner.styled.jsx
@@ -3,7 +3,7 @@ import { color } from "metabase/lib/colors";
 import Button from "metabase/core/components/Button";
 
 export const Container = styled.div`
-  padding: 1rem 0.5rem;
+  padding: 1rem 0;
   display: flex;
   justify-content: space-between;
   align-items: start;
@@ -26,7 +26,7 @@ export const Text = styled.span`
 
 export const Time = styled.time`
   color: ${color("text-medium")};
-  font-size: 0.875rem;
+  font-size: 0.766rem;
   line-height: 1.25rem;
 `;
 

--- a/frontend/src/metabase/core/components/EditableText/EditableText.styled.tsx
+++ b/frontend/src/metabase/core/components/EditableText/EditableText.styled.tsx
@@ -6,6 +6,8 @@ export interface EditableTextRootProps {
 }
 
 export const EditableTextRoot = styled.div<EditableTextRootProps>`
+  ${props =>
+    props.bigText ? "font-size: 1rem; line-height: 1.4rem;" : "inherit"}
   position: relative;
   color: ${color("text-dark")};
   padding: 0.25rem;

--- a/frontend/src/metabase/core/components/EditableText/EditableText.styled.tsx
+++ b/frontend/src/metabase/core/components/EditableText/EditableText.styled.tsx
@@ -6,10 +6,6 @@ export interface EditableTextRootProps {
 }
 
 export const EditableTextRoot = styled.div<EditableTextRootProps>`
-  ${props =>
-    props.bigText ? "font-size: 1rem; line-height: 1.4rem;" : "inherit"}
-  ${props =>
-    props.negativeMargin ? "margin-left: -0.3rem;" : ""}
   position: relative;
   color: ${color("text-dark")};
   padding: 0.25rem;

--- a/frontend/src/metabase/core/components/EditableText/EditableText.styled.tsx
+++ b/frontend/src/metabase/core/components/EditableText/EditableText.styled.tsx
@@ -8,6 +8,8 @@ export interface EditableTextRootProps {
 export const EditableTextRoot = styled.div<EditableTextRootProps>`
   ${props =>
     props.bigText ? "font-size: 1rem; line-height: 1.4rem;" : "inherit"}
+  ${props =>
+    props.negativeMargin ? "margin-left: -0.3rem;" : ""}
   position: relative;
   color: ${color("text-dark")};
   padding: 0.25rem;

--- a/frontend/src/metabase/core/components/EditableText/EditableText.tsx
+++ b/frontend/src/metabase/core/components/EditableText/EditableText.tsx
@@ -89,4 +89,4 @@ const EditableText = forwardRef(function EditableText(
   );
 });
 
-export default EditableText;
+export default Object.assign(EditableText, { Root: EditableTextRoot });

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.styled.tsx
@@ -28,3 +28,7 @@ export const ContentSection = styled.div<ContentSectionProps>`
     padding-top: 0;
   }
 `;
+
+export const Header = styled.h3`
+  margin-top: 0.5rem;
+`;

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.styled.tsx
@@ -1,5 +1,6 @@
 import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
+import EditableText from "metabase/core/components/EditableText";
 
 export const Root = styled.div`
   padding: 1rem 1.5rem 0;
@@ -26,6 +27,12 @@ export const ContentSection = styled.div<ContentSectionProps>`
 
   &:first-of-type {
     padding-top: 0;
+  }
+
+  ${EditableText.Root} {
+    font-size: 1rem; 
+    line-height: 1.4rem;
+    margin-left: -0.3rem;
   }
 `;
 

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.styled.tsx
@@ -16,8 +16,8 @@ interface ContentSectionProps {
 export const ContentSection = styled.div<ContentSectionProps>`
   display: flex;
   flex-direction: column;
+  row-gap: 0.5rem;
   ${props => (props.extraPadding ? "padding: 2rem 0;" : "padding: 1rem 0;")}
-  ${props => (props.bigText ? "font-size: 1rem; line-height: 1.4rem;" : "")}
   border-bottom: 1px solid ${color("border")};
 
   &:last-of-type {

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.styled.tsx
@@ -17,6 +17,7 @@ export const ContentSection = styled.div<ContentSectionProps>`
   display: flex;
   flex-direction: column;
   ${props => (props.extraPadding ? "padding: 2rem 0;" : "padding: 1rem 0;")}
+  ${props => (props.bigText ? "font-size: 1rem; line-height: 1.4rem;" : "")}
   border-bottom: 1px solid ${color("border")};
 
   &:last-of-type {

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.tsx
@@ -13,7 +13,7 @@ import { Card } from "metabase-types/types/Card";
 import EditableText from "metabase/core/components/EditableText";
 
 import ModelCacheManagementSection from "./ModelCacheManagementSection";
-import { Root, ContentSection } from "./QuestionInfoSidebar.styled";
+import { Root, ContentSection, Header } from "./QuestionInfoSidebar.styled";
 
 interface QuestionInfoSidebarProps {
   question: Question;
@@ -46,9 +46,10 @@ export const QuestionInfoSidebar = ({
   return (
     <Root>
       <ContentSection>
-        <h3>{t`About`}</h3>
+        <Header>{t`About`}</Header>
         <EditableText
           bigText
+          negativeMargin
           initialValue={description}
           placeholder={t`Add description`}
           isOptional

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.tsx
@@ -45,7 +45,7 @@ export const QuestionInfoSidebar = ({
 
   return (
     <Root>
-      <ContentSection>
+      <ContentSection bigText>
         <EditableText
           initialValue={description}
           placeholder={t`Add description`}

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.tsx
@@ -45,8 +45,10 @@ export const QuestionInfoSidebar = ({
 
   return (
     <Root>
-      <ContentSection bigText>
+      <ContentSection>
+        <h3>{t`About`}</h3>
         <EditableText
+          bigText
           initialValue={description}
           placeholder={t`Add description`}
           isOptional

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.tsx
@@ -48,8 +48,6 @@ export const QuestionInfoSidebar = ({
       <ContentSection>
         <Header>{t`About`}</Header>
         <EditableText
-          bigText
-          negativeMargin
           initialValue={description}
           placeholder={t`Add description`}
           isOptional


### PR DESCRIPTION
- Larger description text
- Add an About subheading above description
- Add a bit more spacing between description and verified banner
- Fix left alignment of items

![image](https://user-images.githubusercontent.com/2223916/176955297-36772a56-5a01-4b4f-aaa9-e7592dfc36c6.png)
