### PR TITLE
Show "account disabled" message in readable place when user logging in has been deactivated

### DIFF
--- a/frontend/src/metabase/components/form/CustomForm/CustomFormFooter/CustomFormFooter.styled.tsx
+++ b/frontend/src/metabase/components/form/CustomForm/CustomFormFooter/CustomFormFooter.styled.tsx
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 
-export interface CustomFormFooterStyledProps {
+interface CustomFormFooterStyledProps {
   shouldReverse?: boolean;
 }
 export const CustomFormFooterStyled = styled.div<CustomFormFooterStyledProps>`

--- a/frontend/src/metabase/components/form/CustomForm/CustomFormFooter/CustomFormFooter.styled.tsx
+++ b/frontend/src/metabase/components/form/CustomForm/CustomFormFooter/CustomFormFooter.styled.tsx
@@ -5,7 +5,7 @@ interface CustomFormFooterStyledProps {
 }
 export const CustomFormFooterStyled = styled.div<CustomFormFooterStyledProps>`
   display: flex;
-  flex-align: center;
+  align-items: center;
   flex-direction: ${({ shouldReverse }) =>
     shouldReverse ? "row-reverse" : "column"};
 `;

--- a/frontend/src/metabase/components/form/CustomForm/CustomFormFooter/CustomFormFooter.styled.tsx
+++ b/frontend/src/metabase/components/form/CustomForm/CustomFormFooter/CustomFormFooter.styled.tsx
@@ -1,0 +1,11 @@
+import styled from "@emotion/styled";
+
+export interface CustomFormFooterStyledProps {
+  shouldReverse?: boolean;
+}
+export const CustomFormFooterStyled = styled.div<CustomFormFooterStyledProps>`
+  display: flex;
+  flex-align: center;
+  flex-direction: ${({ shouldReverse }) =>
+    shouldReverse ? "row-reverse" : "column"};
+`;

--- a/frontend/src/metabase/components/form/CustomForm/CustomFormFooter/CustomFormFooter.styled.tsx
+++ b/frontend/src/metabase/components/form/CustomForm/CustomFormFooter/CustomFormFooter.styled.tsx
@@ -5,7 +5,7 @@ interface CustomFormFooterStyledProps {
 }
 export const CustomFormFooterStyled = styled.div<CustomFormFooterStyledProps>`
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   flex-direction: ${({ shouldReverse }) =>
     shouldReverse ? "row-reverse" : "column"};
 `;

--- a/frontend/src/metabase/components/form/CustomForm/CustomFormFooter/CustomFormFooter.tsx
+++ b/frontend/src/metabase/components/form/CustomForm/CustomFormFooter/CustomFormFooter.tsx
@@ -39,7 +39,6 @@ function CustomFormFooter({
           {cancelTitle}
         </Button>
       )}
-      <div className="flex-full" />
       <CustomFormMessage className="mt1 flex-full" />
       {footerExtraButtons}
     </CustomFormFooterStyled>

--- a/frontend/src/metabase/components/form/CustomForm/CustomFormFooter/CustomFormFooter.tsx
+++ b/frontend/src/metabase/components/form/CustomForm/CustomFormFooter/CustomFormFooter.tsx
@@ -5,8 +5,9 @@ import { t } from "ttag";
 
 import Button from "metabase/core/components/Button";
 
-import CustomFormMessage from "./CustomFormMessage";
-import CustomFormSubmit from "./CustomFormSubmit";
+import CustomFormMessage from "../CustomFormMessage";
+import CustomFormSubmit from "../CustomFormSubmit";
+import { CustomFormFooterStyled } from "./CustomFormFooter.styled";
 
 export interface CustomFormFooterProps {
   submitTitle: string;
@@ -31,11 +32,7 @@ function CustomFormFooter({
   isContextModal,
 }: CustomFormFooterProps & { isContextModal?: boolean }) {
   return (
-    <div
-      className={cx("flex align-center", {
-        "flex-reverse": isModal || isContextModal,
-      })}
-    >
+    <CustomFormFooterStyled shouldReverse={isModal || isContextModal}>
       <CustomFormSubmit fullWidth={fullWidth}>{submitTitle}</CustomFormSubmit>
       {onCancel && (
         <Button className="mx1" type="button" onClick={onCancel}>
@@ -43,9 +40,9 @@ function CustomFormFooter({
         </Button>
       )}
       <div className="flex-full" />
-      <CustomFormMessage className="ml1" noPadding />
+      <CustomFormMessage className="mt1 flex-full" />
       {footerExtraButtons}
-    </div>
+    </CustomFormFooterStyled>
   );
 }
 

--- a/frontend/src/metabase/components/form/CustomForm/CustomFormFooter/CustomFormFooter.tsx
+++ b/frontend/src/metabase/components/form/CustomForm/CustomFormFooter/CustomFormFooter.tsx
@@ -9,14 +9,7 @@ import CustomFormMessage from "../CustomFormMessage";
 import CustomFormSubmit from "../CustomFormSubmit";
 import { CustomFormFooterStyled } from "./CustomFormFooter.styled";
 
-export interface CustomFormFooterProps {
-  submitTitle: string;
-  cancelTitle?: string;
-  fullWidth?: boolean;
-  isModal?: boolean;
-  footerExtraButtons: React.ReactElement[];
-  onCancel?: () => void;
-}
+import { CustomFormFooterProps } from "./CustomFormFooterTypes";
 
 interface LegacyContextProps {
   isModal?: boolean;

--- a/frontend/src/metabase/components/form/CustomForm/CustomFormFooter/CustomFormFooterTypes.ts
+++ b/frontend/src/metabase/components/form/CustomForm/CustomFormFooter/CustomFormFooterTypes.ts
@@ -1,0 +1,8 @@
+export interface CustomFormFooterProps {
+  submitTitle: string;
+  cancelTitle?: string;
+  fullWidth?: boolean;
+  isModal?: boolean;
+  footerExtraButtons: React.ReactElement[];
+  onCancel?: () => void;
+}

--- a/frontend/src/metabase/components/form/CustomForm/CustomFormFooter/index.ts
+++ b/frontend/src/metabase/components/form/CustomForm/CustomFormFooter/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./CustomFormFooter";

--- a/frontend/src/metabase/components/form/CustomForm/CustomFormFooter/index.ts
+++ b/frontend/src/metabase/components/form/CustomForm/CustomFormFooter/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./CustomFormFooter";
+export * from "./CustomFormFooterTypes";


### PR DESCRIPTION
Fixes #23432

### How to Test

1. As admin, deactivate a user
2. Log out
3. Try to log in as deactivated user

Message should no longer be crammed up to the right of the form.

### Before

<img src="https://user-images.githubusercontent.com/31325167/174587444-18acf1d2-bb7e-4d5d-8624-fb55bf80d83c.png" width=400 />

### After

<img width="400" alt="image" src="https://user-images.githubusercontent.com/380816/176956935-feb032a7-f704-4f5a-8257-4fe6c1eea009.png">
