### PR TITLE
bugfix: handle field values lists with no values

### DIFF
--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterItem/BulkFilterItem.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterItem/BulkFilterItem.unit.spec.tsx
@@ -61,12 +61,12 @@ const categoryField = new Field({
   table_id: 8,
   name: "category_string",
   has_field_values: "list",
-  values: ["Michaelangelo", "Donatello", "Raphael", "Leonardo"],
+  values: [["Michaelangelo"], ["Donatello"], ["Raphael"], ["Leonardo"]],
   dimensions: {},
   dimension_options: [],
-  effective_type: "type/Float",
+  effective_type: "type/Text",
   id: 137,
-  base_type: "type/Float",
+  base_type: "type/Text",
   metadata,
 });
 

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineCategoryPicker/InlineCategoryPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineCategoryPicker/InlineCategoryPicker.tsx
@@ -21,6 +21,11 @@ import { BulkFilterSelect } from "../BulkFilterSelect";
 
 const mapStateToProps = (state: any, props: any) => {
   const fieldId = props.dimension?.field?.()?.id;
+
+  if (props.dimension?.field?.()?.values?.length) {
+    return { fieldValues: props.dimension?.field?.()?.values };
+  }
+
   const fieldValues =
     fieldId != null
       ? Fields.selectors.getFieldValues(state, {

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineCategoryPicker/InlineCategoryPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineCategoryPicker/InlineCategoryPicker.tsx
@@ -76,6 +76,7 @@ export function InlineCategoryPickerComponent({
   }, [dimension, safeFetchFieldValues, shouldFetchFieldValues]);
 
   const showInlinePicker =
+    fieldValues.length > 0 &&
     fieldValues.length <= MAX_INLINE_CATEGORIES &&
     (!filter || filter?.operatorName() === "=");
 


### PR DESCRIPTION
## Before

Category fields in the bulk filter modal with zero field values from the API would render as blank. 😢 

![Screen Shot 2022-07-01 at 3 44 27 PM](https://user-images.githubusercontent.com/30528226/176971508-152b30c1-4b7f-4f08-a8f1-1eef713cd096.png)

![Screen Shot 2022-07-01 at 3 45 47 PM](https://user-images.githubusercontent.com/30528226/176971491-9bd66651-d63b-42e3-bd68-e13e5597ca3e.png)

## Changes

Don't show the inline category picker if there are no field options 👍 


