### PR TITLE
preserve filter options on change

### DIFF
--- a/frontend/src/metabase-lib/lib/queries/structured/Filter.ts
+++ b/frontend/src/metabase-lib/lib/queries/structured/Filter.ts
@@ -20,6 +20,8 @@ import {
   isCustom,
   isFieldFilter,
   hasFilterOptions,
+  getFilterOptions,
+  setFilterOptions,
 } from "metabase/lib/query/filter";
 import { isExpression } from "metabase/lib/expressions";
 import { getFilterArgumentFormatOptions } from "metabase/lib/schema_metadata";
@@ -301,6 +303,14 @@ export default class Filter extends MBQLClause {
 
   arguments() {
     return hasFilterOptions(this) ? this.slice(2, -1) : this.slice(2);
+  }
+
+  options() {
+    return getFilterOptions(this);
+  }
+
+  setOptions(options: any) {
+    return this.set(setFilterOptions(this, options));
   }
 
   formattedArguments(maxDisplayValues?: number = 1) {

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineValuePicker/InlineValuePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineValuePicker/InlineValuePicker.tsx
@@ -32,7 +32,9 @@ export function InlineValuePicker({
 
   const changeArguments = useCallback(
     (newArguments: (string | number)[]) => {
-      handleChange(filter.setArguments(newArguments));
+      handleChange(
+        filter.setArguments(newArguments).setOptions(filter.options()),
+      );
     },
     [filter, handleChange],
   );


### PR DESCRIPTION
The default behaveior for "contains" text filters is to be case-insensitive. The way we had been overrididing filter arguments in the modal had been overwriting those options. 

This change preserves case-sensitivity when changing text filters from the filter modal.
