### PR TITLE
Async card metadata

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/card_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/card_test.clj
@@ -21,7 +21,7 @@
             (perms/revoke-data-perms! (perms-group/all-users) db)
             (perms/grant-permissions! group (perms/table-segmented-query-path table))
             (perms/grant-collection-readwrite-permissions! group collection)
-            (is (some? ((mt/user->client :rasta) :post 202 "card"
+            (is (some? ((mt/user->client :rasta) :post 200 "card"
                         (assoc (api.card-test/card-with-name-and-query card-name (api.card-test/mbql-count-query db table))
                                :collection_id (u/the-id collection)))))))))
 

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/card_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/card_test.clj
@@ -40,6 +40,6 @@
             (perms/grant-permissions! group (perms/table-segmented-query-path table))
             (perms/grant-collection-readwrite-permissions! group collection)
             (is (= "Another Name"
-                   (:name ((mt/user->client :rasta) :put 202 (str "card/" (u/the-id card))
+                   (:name ((mt/user->client :rasta) :put 200 (str "card/" (u/the-id card))
                            {:name          "Another Name"
                             :dataset_query (api.card-test/mbql-count-query db table)}))))))))))

--- a/frontend/src/metabase/components/form/CustomForm/CustomFormFooter/CustomFormFooter.tsx
+++ b/frontend/src/metabase/components/form/CustomForm/CustomFormFooter/CustomFormFooter.tsx
@@ -32,7 +32,7 @@ function CustomFormFooter({
           {cancelTitle}
         </Button>
       )}
-      <CustomFormMessage className="mt1 flex-full" />
+      <CustomFormMessage className="mt1" />
       {footerExtraButtons}
     </CustomFormFooterStyled>
   );

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -337,7 +337,6 @@ saved later when it is ready."
   (check-data-permissions-for-query dataset_query)
   ;; check that we have permissions for the collection we're trying to save this card to, if applicable
   (collection/check-write-perms-for-collection collection_id)
-  ;; Return a channel that can be used to fetch the results asynchronously
   (create-card! body))
 
 (api/defendpoint POST "/:id/copy"

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -209,7 +209,9 @@
                                  (format "%d %s.%s" field-id (pr-str table-name) (pr-str field-name))
                                  (describe-database field-db-id)
                                  (describe-database query-db-id)))
-                          {:status-code 400})))))))
+                          {:status-code           400
+                           :query-database        query-db-id
+                           :field-filter-database field-db-id})))))))
 
 ;; TODO -- consider whether we should validate the Card query when you save/update it??
 (defn- pre-insert [card]

--- a/test/metabase/query_processor_test/nested_queries_test.clj
+++ b/test/metabase/query_processor_test/nested_queries_test.clj
@@ -619,7 +619,7 @@
                         Collection [dest-card-collection]]
           (perms/grant-collection-read-permissions!      (perms-group/all-users) source-card-collection)
           (perms/grant-collection-readwrite-permissions! (perms-group/all-users) dest-card-collection)
-          (is (some? (save-card-via-API-with-native-source-query! 202 (mt/db) source-card-collection dest-card-collection)))))
+          (is (some? (save-card-via-API-with-native-source-query! 200 (mt/db) source-card-collection dest-card-collection)))))
 
       (testing (str "however, if we do *not* have read permissions for the source Card's collection we shouldn't be "
                     "allowed to save the query. This API call should fail")


### PR DESCRIPTION
Resolves #14957

#### Background:
We need query metadata on cards. This is how the FE knows how to display the results, but it is also how the query processor can use nested queries. Without this information we cannot select from another query (we don't know what to select). This makes metadata _extremely_ important to have.

This also causes some problems. When we are saving questions we have to get this metadata. We have several strategies to make this less painful:
- if the query hasn't changed and we have metadata, don't do anything
- for mbql queries, we can just construct the metadata ourselves. We have field information, types, etc. So no need to hit a database and we just reason about the types
- for native queries, we have no such reasoning. We _must_ query the db. We attempt to make this nicer by running the query and abandoning it after the first row comes back. But we are still at the mercy of long-running queries even if we only take the first row.

#### The idea:
We proceed as before, starting an asynchronous fetching of the metadata. If, after some timeout period (randomly chosen as 1.5 seconds at first) we do not have metadata yet, allow the request to succeed and have the metadata populate the question whenever it is ready, provided that the query is still the same.

annotated Log output:
```
<--- send request
<--- wait 1.5 seconds
INFO api.card :: Metadata not available soon enough. Saving card 5,470 and asynchronously updating metadata
DEBUG middleware.log :: PUT /api/card/5470 200 1.5 s (18 DB calls) <----- request succeeds and unblocks UI
DEBUG middleware.log :: GET /api/alert/question/5470 200 1.0 ms
INFO api.card :: Metadata updated asynchronously for card 5,470     <----- later metadata is ready and saved in background
```

#### Hesitations

I'm a bit worried about this. There are lots of subtleties to metadata. And we have to untangle how the `Card` model has some safeguards already in place.

```clojure
(defn- populate-result-metadata
  "When inserting/updating a Card, populate the result metadata column if not already populated by inferring the
  metadata from the query."
  [{query :dataset_query, metadata :result_metadata, existing-card-id :id, :as card}]
  (cond
    ;; not updating the query => no-op
    (not query)
    (do
      (log/debug "Not inferring result metadata for Card: query was not updated")
      card)

    ;; passing in metadata => no-op
    metadata
    (do
      (log/debug "Not inferring result metadata for Card: metadata was passed in to insert!/update!")
      card)

    ;; this is an update, and dataset_query hasn't changed => no-op
    (and existing-card-id
         (= query (db/select-one-field :dataset_query Card :id existing-card-id)))
    (do
      (log/debugf "Not inferring result metadata for Card %s: query has not changed" existing-card-id)
      card)

    ;; query has changed (or new Card) and this is a native query => set metadata to nil
    ;;
    ;; we can't infer the metadata for a native query without running it, so it's better to have no metadata than
    ;; possibly incorrect metadata.
    (= (:type query) :native)
    (do
      (log/debug "Can't infer result metadata for Card: query is a native query. Setting result metadata to nil")
      (assoc card :result_metadata nil))

    ;; otherwise, attempt to infer the metadata. If the query can't be run for one reason or another, set metadata to
    ;; nil.
    :else
    (do
      (log/debug "Attempting to infer result metadata for Card")
      (let [inferred-metadata (not-empty (mw.session/with-current-user nil
                                           (classloader/require 'metabase.query-processor)
                                           (u/ignore-exceptions
                                             ((resolve 'metabase.query-processor/query->expected-cols) query))))]
        (assoc card :result_metadata inferred-metadata)))))
```

This is in the `pre-insert` and `pre-update` chain for `Card`s. This is a bit heavy handed (note for all native queries it just throws away the metadata _regardless_. My thinking is that this all needs to go away. But I need to research how all of this stuff fits together. It is quite sensitive and quite subtle.

So right now it blanks out the metadata when saving this for native queries. Perhaps we could thread through the previous metadata (if it exists) and we'd hit the case above.

##### Other considerations
this is inherently a bit racy. Especially if there are queries that can take longer than 15 minutes to complete. That's a lot of changes that can be done while we have a pending write of the metadata. Some occurrences:
- someone changes the query. Then the metadata that is pending is no longer even relevant. I check against this at the moment
- someone edits model metadata. Those edits will be tossed away at this time. At this point the metadata is actually empty so there's not much to edit. Not sure what the UI would do if you tried to edit in this case.
- there's an error when getting the metadata: connections can go down, etc. Before this change that would prevent saving and give us a chance to inform the user. Now it happens silently in a java process that no one will notice
- there's an error with the query. `select id, total, quantity, sleep(1) from orders limit 3 limit 3` is an invalid query but nothing really prevents that from saving right now. You can happily save it and just be frustrated later downstream from the actual issue.