### PR TITLE
Polish on the Appearance page's color settings

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/BrandColorSettings/BrandColorSettings.styled.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/BrandColorSettings/BrandColorSettings.styled.tsx
@@ -27,7 +27,8 @@ export const TableHeaderRow = styled.div`
 export const TableHeaderCell = styled.div`
   ${cellStyles};
   color: ${color("text-medium")};
-  font-size: 0.5rem;
+  font-size: 0.6rem;
+  letter-spacing: 1px;
   line-height: 0.625rem;
   font-weight: bold;
   text-transform: uppercase;

--- a/frontend/src/metabase/core/components/ColorPill/ColorPill.styled.tsx
+++ b/frontend/src/metabase/core/components/ColorPill/ColorPill.styled.tsx
@@ -16,6 +16,11 @@ export const ColorPillRoot = styled.div<ColorPillRootProps>`
   border-style: ${props => (props.isAuto ? "dashed" : "solid")};
   border-radius: 50%;
   cursor: pointer;
+
+  &:hover {
+    border-color: ${props =>
+      props.isSelected ? color("text-dark") : color("text-light")};
+  }
 `;
 
 export const ColorPillContent = styled.div`


### PR DESCRIPTION
Makes the table headings a bit bigger, and adds a hover effect to the color pill borders (here and in visualization settings):

<img width="403" alt="image" src="https://user-images.githubusercontent.com/2223916/176977085-10b7e894-748a-4877-b8f5-d5ae42b64728.png">
