### PR TITLE
Fix databases with no permission being shown with search results

### DIFF
--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -288,7 +288,7 @@
          :from   [[(merge
                     base-query
                     {:select [:id :name :description :updated_at :initial_sync_status
-                              [(hx/concat (hx/literal "/db/") :database.id (hx/literal "/"))
+                              [(hx/concat (hx/literal "/db/") :id (hx/literal "/"))
                                :path]]})
                    :database]]
          :where  (if (seq data-perms)

--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -284,17 +284,11 @@
     (if (contains? current-user-perms "/")
       base-query
       (let [data-perms (filter #(re-find #"^/db/*" %) current-user-perms)]
-        {:select (:select base-query)
-         :from   [[(merge
-                    base-query
-                    {:select [:id :name :description :updated_at :initial_sync_status
-                              [(hx/concat (hx/literal "/db/") :id (hx/literal "/"))
-                               :path]]})
-                   :database]]
-         :where  (if (seq data-perms)
-                   (into [:or] (for [path data-perms]
-                                 [:like :path (str path "%")]))
-                   [:= 0 1])}))))
+        (hh/merge-where base-query
+                        (if (seq data-perms)
+                          (into [:or] (for [path data-perms]
+                                        [:like (hx/concat (hx/literal "/db/") :id (hx/literal "/")) (str path "%")]))
+                          [:= 0 1]))))))
 
 (s/defmethod search-query-for-model "dashboard"
   [model search-ctx :- SearchContext]

--- a/test/metabase/api/search_test.clj
+++ b/test/metabase/api/search_test.clj
@@ -384,9 +384,15 @@
   (testing "Databases for which the user does not have access to should not show up in results"
     (mt/with-temp* [Database [db-1 {:name "db-1"}]
                     Database [_db-2 {:name "db-2"}]]
+      (is (= #{"db-2" "db-1"}
+             (->> (search-request-data-with sorted-results :rasta :q "db")
+                  (map :name)
+                  set)))
       (perms/revoke-data-perms! (perms-group/all-users) (:id db-1))
       (is (= #{"db-2"}
-             (set (map :name (search-request-data-with sorted-results :rasta :q "db"))))))))
+             (->> (search-request-data-with sorted-results :rasta :q "db")
+                  (map :name)
+                  set))))))
 
 (deftest bookmarks-test
   (testing "Bookmarks are per user, so other user's bookmarks don't cause search results to be altered"

--- a/test/metabase/api/search_test.clj
+++ b/test/metabase/api/search_test.clj
@@ -382,8 +382,8 @@
              (search-request-data :rasta :q "test")))))
 
   (testing "Databases for which the user does not have access to should not show up in results"
-    (mt/with-temp* [Database       [db-1 {:name "db-1"}]
-                    Database       [_db-2 {:name "db-2"}]]
+    (mt/with-temp* [Database [db-1 {:name "db-1"}]
+                    Database [_db-2 {:name "db-2"}]]
       (perms/revoke-data-perms! (perms-group/all-users) (:id db-1))
       (is (= #{"db-2"}
              (set (map :name (search-request-data-with sorted-results :rasta :q "db"))))))))

--- a/test/metabase/api/search_test.clj
+++ b/test/metabase/api/search_test.clj
@@ -388,22 +388,6 @@
       (is (= #{"db-2"}
              (set (map :name (search-request-data-with sorted-results :rasta :q "db"))))))))
 
-(mt/with-non-admin-groups-no-root-collection-perms
-  (with-search-items-in-collection {db-1 :database} "test"
-    (with-search-items-in-collection {db-2 :database} "test2"
-      (mt/with-temp* [PermissionsGroup           [group]
-                      PermissionsGroupMembership [_ {:user_id (mt/user->id :rasta), :group_id (u/the-id group)}]]
-        (perms/grant-collection-read-permissions! group (u/the-id coll-1))
-        (is (= (sorted-results
-                (reverse
-                 (into
-                  (default-results-with-collection)
-                  (map #(merge default-search-row % (table-search-results))
-                       [{:name "metric test2 metric", :description "Lookin' for a blueberry", :model "metric"}
-                        {:name "segment test2 segment", :description "Lookin' for a blueberry", :model "segment"}]))))
-               (search-request-data :rasta :q "test")))))))
-
-
 (deftest bookmarks-test
   (testing "Bookmarks are per user, so other user's bookmarks don't cause search results to be altered"
     (with-search-items-in-collection {:keys [card dashboard]} "test"

--- a/test/metabase/api/search_test.clj
+++ b/test/metabase/api/search_test.clj
@@ -379,7 +379,30 @@
                                  :name     "test segment"}]]
       (perms/revoke-data-perms! (perms-group/all-users) db-id)
       (is (= []
-             (search-request-data :rasta :q "test"))))))
+             (search-request-data :rasta :q "test")))))
+
+  (testing "Databases for which the user does not have access to should not show up in results"
+    (mt/with-temp* [Database       [db-1 {:name "db-1"}]
+                    Database       [_db-2 {:name "db-2"}]]
+      (perms/revoke-data-perms! (perms-group/all-users) (:id db-1))
+      (is (= #{"db-2"}
+             (set (map :name (search-request-data-with sorted-results :rasta :q "db"))))))))
+
+(mt/with-non-admin-groups-no-root-collection-perms
+  (with-search-items-in-collection {db-1 :database} "test"
+    (with-search-items-in-collection {db-2 :database} "test2"
+      (mt/with-temp* [PermissionsGroup           [group]
+                      PermissionsGroupMembership [_ {:user_id (mt/user->id :rasta), :group_id (u/the-id group)}]]
+        (perms/grant-collection-read-permissions! group (u/the-id coll-1))
+        (is (= (sorted-results
+                (reverse
+                 (into
+                  (default-results-with-collection)
+                  (map #(merge default-search-row % (table-search-results))
+                       [{:name "metric test2 metric", :description "Lookin' for a blueberry", :model "metric"}
+                        {:name "segment test2 segment", :description "Lookin' for a blueberry", :model "segment"}]))))
+               (search-request-data :rasta :q "test")))))))
+
 
 (deftest bookmarks-test
   (testing "Bookmarks are per user, so other user's bookmarks don't cause search results to be altered"


### PR DESCRIPTION
Fixes https://github.com/metabase/metaboat/issues/159 and https://github.com/metabase/metabase/issues/22695

The search subquery for databases just wasn't being filtered at all by a user's permissions.