### PR TITLE
Repro #23677: `Exclude` datefilter provides wrong results with `is empty`

### DIFF
--- a/frontend/test/metabase/scenarios/filters/reproductions/23677-exclude-is-empty.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/reproductions/23677-exclude-is-empty.cy.spec.js
@@ -1,0 +1,24 @@
+import { restore, openProductsTable } from "__support__/e2e/helpers";
+
+describe.skip("issue 23677", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("`exclude` fitler should work properly with `is empty` and `is not empty` (metabase#23677)", () => {
+    openProductsTable();
+    cy.findByText("Showing 200 rows");
+
+    cy.findByTextEnsureVisible("Created At").click();
+    cy.findByText("Filter by this column").click();
+    cy.findByText("Exclude...").click();
+    cy.findByText("Is empty").click();
+    cy.wait("@dataset");
+
+    // We don't have empty rows in this column so the result should stay the same
+    cy.findByText("Showing 200 rows");
+    // NOTE: Not sure how are we going to resolve this filter name. Update accordingly.
+    cy.findByText("Created At excludes is empty");
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #23677

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/filters/reproductions/23677-exclude-is-empty.cy.spec.js`
- Unskip repro
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/177206962-62c93a7f-29b1-4e0e-a4d3-f9e073951672.png)

