### PR TITLE
Handle obligatory parameters without default value

### DIFF
--- a/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.tsx
+++ b/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.tsx
@@ -3,7 +3,7 @@ import React, { useCallback } from "react";
 import { Collection } from "metabase-types/api";
 import { ANALYTICS_CONTEXT } from "metabase/collections/constants";
 import {
-  hasRequiredParameters,
+  isFullyParametrized,
   isItemPinned,
   isPreviewShown,
   isPreviewEnabled,
@@ -88,7 +88,7 @@ function ActionMenu({
         item={item}
         isBookmarked={isBookmarked}
         isPreviewShown={isPreviewShown(item)}
-        isPreviewAvailable={hasRequiredParameters(item)}
+        isPreviewAvailable={isFullyParametrized(item)}
         onPin={collection.can_write ? handlePin : null}
         onMove={collection.can_write && item.setCollection ? handleMove : null}
         onCopy={item.copy ? handleCopy : null}

--- a/frontend/src/metabase/collections/components/PinnedQuestionCard/PinnedQuestionCard.tsx
+++ b/frontend/src/metabase/collections/components/PinnedQuestionCard/PinnedQuestionCard.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { t } from "ttag";
 import {
-  hasRequiredParameters,
+  isFullyParametrized,
   isPreviewShown,
   Item,
 } from "metabase/collections/utils";
@@ -83,7 +83,7 @@ const PinnedQuestionCard = ({
 };
 
 const getSkeletonTooltip = (item: Item) => {
-  if (!hasRequiredParameters(item)) {
+  if (!isFullyParametrized(item)) {
     return t`Open this question and fill in its variables to see it.`;
   } else {
     return undefined;

--- a/frontend/src/metabase/collections/utils.ts
+++ b/frontend/src/metabase/collections/utils.ts
@@ -9,7 +9,7 @@ export type Item = {
   copy?: boolean;
   collection_position?: number | null;
   collection_preview?: boolean | null;
-  has_required_parameters?: boolean | null;
+  fully_parametrized?: boolean | null;
   getIcon: () => { name: string };
   getUrl: () => string;
   setArchived: (isArchived: boolean) => void;
@@ -81,15 +81,15 @@ export function isItemPinned(item: Item) {
 }
 
 export function isPreviewShown(item: Item) {
-  return isPreviewEnabled(item) && hasRequiredParameters(item);
+  return isPreviewEnabled(item) && isFullyParametrized(item);
 }
 
 export function isPreviewEnabled(item: Item) {
   return item.collection_preview ?? true;
 }
 
-export function hasRequiredParameters(item: Item) {
-  return item.has_required_parameters ?? true;
+export function isFullyParametrized(item: Item) {
+  return item.fully_parametrized ?? true;
 }
 
 // API requires items in "root" collection be persisted with a "null" collection ID

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -298,7 +298,23 @@
     (not (zero? v))
     v))
 
-(defn- has-required-parameters? [row]
+(defn- fully-parametrized?
+  "Decide if the query in the card represented by the result row `row` is fully parametrized.
+
+  The rules to consider a query fully parametrized is as follows:
+
+  1. All parameters not in an optional block are field-filters or have a default value.
+  2. All required parameters have a default value.
+
+  The first rule is absolutely necessary, as queries violating it cannot be executed without
+  externally supplied parameter values. The second rule is more controversial, as field-filters
+  outside of optional blocks ([[ ... ]]) don't prevent the query from being executed without
+  external parameter values (neither do parameters in optional blocks). The rule has been added
+  nonetheless, because marking a parameter as required is something the user does intentionally
+  and queries that are technically executable without parameters can be unacceptably slow
+  without the necessary constraints. (Marking parameters in optional blocks as required doesn't
+  seem to be useful any way, but if the user said it is required, we honor this flag.)"
+  [row]
   (let [native-query (-> row :dataset_query (json/parse-string keyword) :native)]
     (if-let [template-tags (:template-tags native-query)]
       (let [obligatory-params (into #{}
@@ -313,7 +329,7 @@
   (-> row
       (dissoc :authority_level :icon :personal_owner_id :dataset_query)
       (update :collection_preview bit->boolean)
-      (assoc :has_required_parameters (has-required-parameters? row))))
+      (assoc :fully_parametrized (fully-parametrized? row))))
 
 (defmethod post-process-collection-children :card
   [_ rows]

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -1062,9 +1062,10 @@
     (testing "has_required_parameters of a card"
       (testing "can be false"
         (mt/with-temp Card [card {:name "Business Card"
-                                  :dataset_query {:native {:template-tags {:param0 {:required true, :default 0}
-                                                                           :param1 {:required true}
-                                                                           :param2 {:required false}}}}}]
+                                  :dataset_query {:native {:template-tags {:param0 {:default 0}
+                                                                           :param1 {:required false}
+                                                                           :param2 {:required false}}
+                                                           :query "select {{param0}}, {{param1}} [[ , {{param2}} ]]"}}}]
           (is (= (let [collection (collection/user->personal-collection (mt/user->id :crowberto))]
                    [{:name                    "Business Card"
                      :description             nil
@@ -1084,11 +1085,61 @@
                  (for [item (:data (mt/user-http-request :crowberto :get 200 "collection/root/items"))]
                    (dissoc item :id))))))
 
-      (testing "is true if all required parameters have defaults"
+      (testing "is false even if a required field-filter parameter has no default"
         (mt/with-temp Card [card {:name "Business Card"
-                                  :dataset_query {:native {:template-tags {:param0 {:required true, :default 0}
+                                  :dataset_query {:native {:template-tags {:param0 {:default 0}
+                                                                           :param1 {:type "dimension", :required true}}
+                                                           :query "select {{param0}}, {{param1}}"}}}]
+          (is (= (let [collection (collection/user->personal-collection (mt/user->id :crowberto))]
+                   [{:name                    "Business Card"
+                     :description             nil
+                     :collection_position     nil
+                     :collection_preview      true
+                     :display                 "table"
+                     :moderated_status        nil
+                     :entity_id               (:entity_id card)
+                     :model                   "card"
+                     :has_required_parameters false}
+                    {:name            "Crowberto Corv's Personal Collection"
+                     :description     nil
+                     :model           "collection"
+                     :authority_level nil
+                     :entity_id       (:entity_id collection)
+                     :can_write       true}])
+                 (for [item (:data (mt/user-http-request :crowberto :get 200 "collection/root/items"))]
+                   (dissoc item :id))))))
+
+      (testing "is false even if an optional required parameter has no default"
+        (mt/with-temp Card [card {:name "Business Card"
+                                  :dataset_query {:native {:template-tags {:param0 {:default 0}
+                                                                           :param1 {:required true}}
+                                                           :query "select {{param0}}, [[ , {{param1}} ]]"}}}]
+          (is (= (let [collection (collection/user->personal-collection (mt/user->id :crowberto))]
+                   [{:name                    "Business Card"
+                     :description             nil
+                     :collection_position     nil
+                     :collection_preview      true
+                     :display                 "table"
+                     :moderated_status        nil
+                     :entity_id               (:entity_id card)
+                     :model                   "card"
+                     :has_required_parameters false}
+                    {:name            "Crowberto Corv's Personal Collection"
+                     :description     nil
+                     :model           "collection"
+                     :authority_level nil
+                     :entity_id       (:entity_id collection)
+                     :can_write       true}])
+                 (for [item (:data (mt/user-http-request :crowberto :get 200 "collection/root/items"))]
+                   (dissoc item :id))))))
+
+      (testing "is true if all obligatory parameters have defaults"
+        (mt/with-temp Card [card {:name "Business Card"
+                                  :dataset_query {:native {:template-tags {:param0 {:required false, :default 0}
                                                                            :param1 {:required true, :default 1}
-                                                                           :param2 {:required false}}}}}]
+                                                                           :param2 {}
+                                                                           :param3 {:type "dimension"}}
+                                                           :query "select {{param0}}, {{param1}} [[ , {{param2}} ]] from t {{param3}}"}}}]
           (is (= (let [collection (collection/user->personal-collection (mt/user->id :crowberto))]
                    [{:name                    "Business Card"
                      :description             nil

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -418,16 +418,16 @@
                                            :moderator_id        user-id
                                            :most_recent         true}]]
         (is (= (mt/obj->json->obj
-                [{:id                      card-id
-                  :name                    (:name card)
-                  :collection_position     nil
-                  :collection_preview      true
-                  :display                 "table"
-                  :description             nil
-                  :entity_id               (:entity_id card)
-                  :moderated_status        "verified"
-                  :model                   "card"
-                  :has_required_parameters true}])
+                [{:id                  card-id
+                  :name                (:name card)
+                  :collection_position nil
+                  :collection_preview  true
+                  :display             "table"
+                  :description         nil
+                  :entity_id           (:entity_id card)
+                  :moderated_status    "verified"
+                  :model               "card"
+                  :fully_parametrized  true}])
                (mt/obj->json->obj
                 (:data (mt/user-http-request :crowberto :get 200
                                              (str "collection/" (u/the-id collection) "/items"))))))))
@@ -472,7 +472,7 @@
                                           :collection_preview false, :display "table", :entity_id true}
                                          {:name "Dine & Dashboard", :description nil, :model "dashboard", :entity_id true}
                                          {:name "Electro-Magnetic Pulse", :model "pulse", :entity_id true}])
-                     (assoc-in [1 :has_required_parameters] true))
+                     (assoc-in [1 :fully_parametrized] true))
                  (mt/boolean-ids-and-timestamps
                   (:data (mt/user-http-request :rasta :get 200 (str "collection/" (u/the-id collection) "/items"))))))))
 
@@ -489,7 +489,7 @@
             (is (= [(-> {:name "Birthday Card", :description nil, :model "card",
                          :collection_preview false, :display "table", :entity_id true}
                         default-item
-                        (assoc :has_required_parameters true))
+                        (assoc :fully_parametrized true))
                     (default-item {:name "Dine & Dashboard", :description nil, :model "dashboard", :entity_id true})]
                    (mt/boolean-ids-and-timestamps
                     (:data (mt/user-http-request :rasta :get 200 (str "collection/" (u/the-id collection) "/items?models=dashboard&models=card"))))))))))
@@ -940,7 +940,7 @@
       (is (= [(-> {:name "Birthday Card", :description nil, :model "card",
                    :collection_preview false, :display "table"}
                   default-item
-                  (assoc :has_required_parameters true))
+                  (assoc :fully_parametrized true))
               (collection-item "Crowberto Corv's Personal Collection")
               (default-item {:name "Dine & Dashboard", :description nil, :model "dashboard"})
               (default-item {:name "Electro-Magnetic Pulse", :model "pulse"})]
@@ -986,7 +986,7 @@
               (is (= [(-> {:name "Birthday Card", :description nil, :model "card",
                            :collection_preview false, :display "table"}
                           default-item
-                          (assoc :has_required_parameters true))
+                          (assoc :fully_parametrized true))
                       (default-item {:name "Dine & Dashboard", :description nil, :model "dashboard"})
                       (default-item {:name "Electro-Magnetic Pulse", :model "pulse"})
                       (collection-item "Rasta Toucan's Personal Collection")]
@@ -1047,35 +1047,35 @@
 
       (testing "Can we look for `archived` stuff with this endpoint?"
         (mt/with-temp Card [card {:name "Business Card", :archived true}]
-          (is (= [{:name                    "Business Card"
-                   :description             nil
-                   :collection_position     nil
-                   :collection_preview      true
-                   :display                 "table"
-                   :moderated_status        nil
-                   :entity_id               (:entity_id card)
-                   :model                   "card"
-                   :has_required_parameters true}]
+          (is (= [{:name                "Business Card"
+                   :description         nil
+                   :collection_position nil
+                   :collection_preview  true
+                   :display             "table"
+                   :moderated_status    nil
+                   :entity_id           (:entity_id card)
+                   :model               "card"
+                   :fully_parametrized  true}]
                  (for [item (:data (mt/user-http-request :crowberto :get 200 "collection/root/items?archived=true"))]
                    (dissoc item :id)))))))
 
-    (testing "has_required_parameters of a card"
+    (testing "fully_parametrized of a card"
       (testing "can be false"
-        (mt/with-temp Card [card {:name "Business Card"
+        (mt/with-temp Card [card {:name          "Business Card"
                                   :dataset_query {:native {:template-tags {:param0 {:default 0}
                                                                            :param1 {:required false}
                                                                            :param2 {:required false}}
-                                                           :query "select {{param0}}, {{param1}} [[ , {{param2}} ]]"}}}]
+                                                           :query         "select {{param0}}, {{param1}} [[ , {{param2}} ]]"}}}]
           (is (= (let [collection (collection/user->personal-collection (mt/user->id :crowberto))]
-                   [{:name                    "Business Card"
-                     :description             nil
-                     :collection_position     nil
-                     :collection_preview      true
-                     :display                 "table"
-                     :moderated_status        nil
-                     :entity_id               (:entity_id card)
-                     :model                   "card"
-                     :has_required_parameters false}
+                   [{:name                "Business Card"
+                     :description         nil
+                     :collection_position nil
+                     :collection_preview  true
+                     :display             "table"
+                     :moderated_status    nil
+                     :entity_id           (:entity_id card)
+                     :model               "card"
+                     :fully_parametrized  false}
                     {:name            "Crowberto Corv's Personal Collection"
                      :description     nil
                      :model           "collection"
@@ -1086,20 +1086,20 @@
                    (dissoc item :id))))))
 
       (testing "is false even if a required field-filter parameter has no default"
-        (mt/with-temp Card [card {:name "Business Card"
+        (mt/with-temp Card [card {:name          "Business Card"
                                   :dataset_query {:native {:template-tags {:param0 {:default 0}
                                                                            :param1 {:type "dimension", :required true}}
-                                                           :query "select {{param0}}, {{param1}}"}}}]
+                                                           :query         "select {{param0}}, {{param1}}"}}}]
           (is (= (let [collection (collection/user->personal-collection (mt/user->id :crowberto))]
-                   [{:name                    "Business Card"
-                     :description             nil
-                     :collection_position     nil
-                     :collection_preview      true
-                     :display                 "table"
-                     :moderated_status        nil
-                     :entity_id               (:entity_id card)
-                     :model                   "card"
-                     :has_required_parameters false}
+                   [{:name                "Business Card"
+                     :description         nil
+                     :collection_position nil
+                     :collection_preview  true
+                     :display             "table"
+                     :moderated_status    nil
+                     :entity_id           (:entity_id card)
+                     :model               "card"
+                     :fully_parametrized  false}
                     {:name            "Crowberto Corv's Personal Collection"
                      :description     nil
                      :model           "collection"
@@ -1110,20 +1110,20 @@
                    (dissoc item :id))))))
 
       (testing "is false even if an optional required parameter has no default"
-        (mt/with-temp Card [card {:name "Business Card"
+        (mt/with-temp Card [card {:name          "Business Card"
                                   :dataset_query {:native {:template-tags {:param0 {:default 0}
                                                                            :param1 {:required true}}
-                                                           :query "select {{param0}}, [[ , {{param1}} ]]"}}}]
+                                                           :query         "select {{param0}}, [[ , {{param1}} ]]"}}}]
           (is (= (let [collection (collection/user->personal-collection (mt/user->id :crowberto))]
-                   [{:name                    "Business Card"
-                     :description             nil
-                     :collection_position     nil
-                     :collection_preview      true
-                     :display                 "table"
-                     :moderated_status        nil
-                     :entity_id               (:entity_id card)
-                     :model                   "card"
-                     :has_required_parameters false}
+                   [{:name                "Business Card"
+                     :description         nil
+                     :collection_position nil
+                     :collection_preview  true
+                     :display             "table"
+                     :moderated_status    nil
+                     :entity_id           (:entity_id card)
+                     :model               "card"
+                     :fully_parametrized  false}
                     {:name            "Crowberto Corv's Personal Collection"
                      :description     nil
                      :model           "collection"
@@ -1134,22 +1134,22 @@
                    (dissoc item :id))))))
 
       (testing "is true if all obligatory parameters have defaults"
-        (mt/with-temp Card [card {:name "Business Card"
+        (mt/with-temp Card [card {:name          "Business Card"
                                   :dataset_query {:native {:template-tags {:param0 {:required false, :default 0}
                                                                            :param1 {:required true, :default 1}
                                                                            :param2 {}
                                                                            :param3 {:type "dimension"}}
                                                            :query "select {{param0}}, {{param1}} [[ , {{param2}} ]] from t {{param3}}"}}}]
           (is (= (let [collection (collection/user->personal-collection (mt/user->id :crowberto))]
-                   [{:name                    "Business Card"
-                     :description             nil
-                     :collection_position     nil
-                     :collection_preview      true
-                     :display                 "table"
-                     :moderated_status        nil
-                     :entity_id               (:entity_id card)
-                     :model                   "card"
-                     :has_required_parameters true}
+                   [{:name                "Business Card"
+                     :description         nil
+                     :collection_position nil
+                     :collection_preview  true
+                     :display             "table"
+                     :moderated_status    nil
+                     :entity_id           (:entity_id card)
+                     :model               "card"
+                     :fully_parametrized  true}
                     {:name            "Crowberto Corv's Personal Collection"
                      :description     nil
                      :model           "collection"


### PR DESCRIPTION
If obligatory parameters (i.e., parameters not inside an optional block) have no default value, `fully_parametrized` has to be false even if the `required` flag of the parameter is false or missing.

The `fully_parametrized` flag is intended to tell if the query can be executed without any parameters. It is introduced now to let the frontend know if a given card should be executed in the collection preview. (This is a followup on #23222, see [Notion](https://www.notion.so/metabase/Behavior-for-pinned-SQL-template-questions-is-a-bit-off-4f3f952aeccc495491480346033fbd68) for context.)

The rules implemented in this PR are: 
1. Parameters not in an optional block have to be field-filters or have a default value.
1. Required parameters have to have a default value.

The first rule is absolutely necessary, as queries violating it cannot be executed without externally supplied parameter values. The second rule is more controversial, as field-filters outside of optional blocks (`[[ ... ]]`) don't prevent the query from being executed without external parameter values (neither do parameters in optional blocks). I've added it nonetheless, because marking a parameter as required is something the user does intentionally and queries that are technically executable without parameters can be unacceptably slow without the necessary constraints. (Marking parameters in optional blocks as required doesn't seem to be useful any way, I have no idea why anybody would do that.)

With this change the backend parses each query in the collection to find the obligatory parameters. It has to be seen if this is fast enough in practice.