### PR TITLE
Running Mochawesome Reports only if JSON file exists

### DIFF
--- a/.github/workflows/e2e-main.yml
+++ b/.github/workflows/e2e-main.yml
@@ -148,8 +148,14 @@ jobs:
       env:
         TERM: xterm
 
+    - name: "Check JSON report existence"
+      id: check_files
+      uses: andstor/file-existence-action@v1
+      with:
+        files: "cypress/reports/mochareports/*.json"
+
     - name: Generate Mochawesome Reports
-      if: failure()
+      if: steps.check_files.outputs.files_exists == 'true'
       run: yarn generate-cypress-html-report
 
     - name: Upload Cypress Artifacts upon failure

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -151,8 +151,14 @@ jobs:
       env:
         TERM: xterm
 
+    - name: "Check JSON report existence"
+      id: check_files
+      uses: andstor/file-existence-action@v1
+      with:
+        files: "cypress/reports/mochareports/*.json"
+
     - name: Generate Mochawesome Reports
-      if: failure()
+      if: steps.check_files.outputs.files_exists == 'true'
       run: yarn generate-cypress-html-report
 
     - name: Upload Cypress Artifacts upon failure


### PR DESCRIPTION
To avoid errors such as this one: https://github.com/metabase/metabase/runs/7185881675?check_suite_focus=true, now before running the yarn command we assert that the file exists. If it does not, it skips the report generation.