### PR TITLE
Add a way to use a custom font in signed embedding widgets

### DIFF
--- a/frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx
+++ b/frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx
@@ -84,7 +84,7 @@ const DisplayOptionsPane = ({
               value={displayOptions.font}
               options={[
                 {
-                  name: t`Use instance font`,
+                  name: t`Use global font`,
                   value: null,
                 },
                 ...MetabaseSettings.get("available-fonts").map(font => ({

--- a/frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx
+++ b/frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx
@@ -82,10 +82,16 @@ const DisplayOptionsPane = ({
           <DisplayOptionSection title={t`Font`}>
             <Select
               value={displayOptions.font}
-              options={MetabaseSettings.get("available-fonts").map(font => ({
-                name: font,
-                value: font,
-              }))}
+              options={[
+                {
+                  name: t`Default`,
+                  value: null,
+                },
+                ...MetabaseSettings.get("available-fonts").map(font => ({
+                  name: font,
+                  value: font,
+                })),
+              ]}
               onChange={e => {
                 onChangeDisplayOptions({
                   ...displayOptions,

--- a/frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx
+++ b/frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx
@@ -84,7 +84,7 @@ const DisplayOptionsPane = ({
               value={displayOptions.font}
               options={[
                 {
-                  name: t`Default`,
+                  name: t`Use instance font`,
                   value: null,
                 },
                 ...MetabaseSettings.get("available-fonts").map(font => ({

--- a/frontend/src/metabase/public/components/widgets/EmbedModalContent.jsx
+++ b/frontend/src/metabase/public/components/widgets/EmbedModalContent.jsx
@@ -22,12 +22,7 @@ import {
   getIsPublicSharingEnabled,
   getIsApplicationEmbeddingEnabled,
 } from "metabase/selectors/settings";
-
-import { PLUGIN_SELECTORS } from "metabase/plugins";
-
 import { getUserIsAdmin } from "metabase/selectors/user";
-
-import MetabaseSettings from "metabase/lib/settings";
 
 import * as MetabaseAnalytics from "metabase/lib/analytics";
 
@@ -37,20 +32,17 @@ const mapStateToProps = (state, props) => ({
   secretKey: getEmbeddingSecretKey(state, props),
   isPublicSharingEnabled: getIsPublicSharingEnabled(state, props),
   isApplicationEmbeddingEnabled: getIsApplicationEmbeddingEnabled(state, props),
-  canWhitelabel: PLUGIN_SELECTORS.canWhitelabel(state),
 });
 
 class EmbedModalContent extends Component {
   constructor(props) {
     super(props);
     const displayOptions = {
+      font: null,
       theme: null,
       bordered: true,
       titled: true,
     };
-    if (props.canWhitelabel) {
-      displayOptions.font = MetabaseSettings.get("application-font");
-    }
     this.state = {
       pane: "preview",
       embedType: null,

--- a/frontend/test/metabase/scenarios/embedding/embedding-snippets.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/embedding-snippets.cy.spec.js
@@ -28,17 +28,14 @@ describe("scenarios > embedding > code snippets", () => {
     cy.get(".ace_content")
       .first()
       .invoke("text")
-      .should("match", JS_CODE({ type: "dashboard", isEE }));
+      .should("match", JS_CODE({ type: "dashboard" }));
 
     // set transparent background metabase#23477
     cy.findByText("Transparent").click();
     cy.get(".ace_content")
       .first()
       .invoke("text")
-      .should(
-        "match",
-        JS_CODE({ type: "dashboard", isEE, theme: "transparent" }),
-      );
+      .should("match", JS_CODE({ type: "dashboard", theme: "transparent" }));
 
     // No download button for dashboards even for pro/enterprise users metabase#23477
     cy.findByLabelText("Enable users to download data from this embed?").should(
@@ -84,17 +81,14 @@ describe("scenarios > embedding > code snippets", () => {
     cy.get(".ace_content")
       .first()
       .invoke("text")
-      .should("match", JS_CODE({ type: "question", isEE }));
+      .should("match", JS_CODE({ type: "question" }));
 
     // set transparent background metabase#23477
     cy.findByText("Transparent").click();
     cy.get(".ace_content")
       .first()
       .invoke("text")
-      .should(
-        "match",
-        JS_CODE({ type: "question", isEE, theme: "transparent" }),
-      );
+      .should("match", JS_CODE({ type: "question", theme: "transparent" }));
 
     // hide download button for pro/enterprise users metabase#23477
     if (isEE) {
@@ -109,7 +103,6 @@ describe("scenarios > embedding > code snippets", () => {
           "match",
           JS_CODE({
             type: "question",
-            isEE,
             theme: "transparent",
             hideDownloadButton: true,
           }),

--- a/frontend/test/metabase/scenarios/embedding/embedding-snippets.js
+++ b/frontend/test/metabase/scenarios/embedding/embedding-snippets.js
@@ -1,4 +1,4 @@
-export const JS_CODE = ({ type, isEE, hideDownloadButton, theme }) => {
+export const JS_CODE = ({ type, hideDownloadButton, theme }) => {
   return new RegExp(
     `// you will need to install via 'npm install jsonwebtoken' or in your package.json
 
@@ -15,7 +15,7 @@ var token = jwt.sign(payload, METABASE_SECRET_KEY);
 
 var iframeUrl = METABASE_SITE_URL + "/embed/${type}/" + token + "#${getThemeParameter(
       theme,
-    )}bordered=true&titled=true${getParameter({ isEE, hideDownloadButton })}";`
+    )}bordered=true&titled=true${getParameter({ hideDownloadButton })}";`
       .split("\n")
       .join("")
       .replace(/[-\/\\^$*+?.()|[\]{}]/g, "\\$&")
@@ -34,12 +34,8 @@ export const IFRAME_CODE = `<iframe
   .split("\n")
   .join("");
 
-function getParameter({ isEE, hideDownloadButton }) {
+function getParameter({ hideDownloadButton }) {
   let parameter = "";
-
-  if (isEE) {
-    parameter += "&font=Lato";
-  }
 
   if (hideDownloadButton) {
     parameter += "&hide_download_button=true";


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/22582

Currently there is no way to use the custom font defined in Admin settings in signed embedding widgets. To fix that we'll add `Use global font` option, selected by default. If the instance font is set to `Custom`, it will use that in signed embedding.

How to test:
- Run Metabase EE
- Go to Admin -> Settings -> Appearance
- Set `Font` to `Custom` with `https://fonts.gstatic.com/s/lora/v24/0QIvMX1D_JOuMwr7I_FMl_E.woff2` for `Regular`
- Make sure the font is applied
- Go to Admin -> Settings -> Embedding
- Enable embedding in other applications
- Create a question, open it, and click on Share -> Embed into another application
- Make sure `Use global font` is selected by default and the widget is rendered with the custom font
- Change the font to `Lato`
- Make sure the widget is rendered with `Lato`

<img width="1728" alt="Screenshot 2022-07-05 at 15 49 47" src="https://user-images.githubusercontent.com/8542534/177332495-affbe29b-b62d-4e95-8029-3d5e4f160a65.png">
<img width="1432" alt="Screenshot 2022-07-05 at 15 49 58" src="https://user-images.githubusercontent.com/8542534/177332522-87017bf1-1cf1-43eb-8b45-a4f00a763329.png">
