### PR TITLE
[E2E] Fix models tests

### DIFF
--- a/frontend/test/__support__/e2e/helpers/e2e-misc-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-misc-helpers.js
@@ -210,3 +210,13 @@ function dashboardHasQuestions(cards) {
     return false;
   }
 }
+
+export function interceptIfNotPreviouslyDefined({ method, url, alias } = {}) {
+  const aliases = Object.keys(cy.state("aliases"));
+
+  const isAlreadyDefined = aliases.find(a => a === alias);
+
+  if (!isAlreadyDefined) {
+    cy.intercept(method, url).as(alias);
+  }
+}

--- a/frontend/test/metabase/scenarios/models/helpers/e2e-models-helpers.js
+++ b/frontend/test/metabase/scenarios/models/helpers/e2e-models-helpers.js
@@ -1,4 +1,9 @@
-import { popover, modal, openQuestionActions } from "__support__/e2e/helpers";
+import {
+  popover,
+  modal,
+  openQuestionActions,
+  interceptIfNotPreviouslyDefined,
+} from "__support__/e2e/helpers";
 
 export function assertQuestionIsBasedOnModel({
   questionName,
@@ -84,6 +89,12 @@ export function assertIsQuestion() {
 }
 
 export function turnIntoModel() {
+  interceptIfNotPreviouslyDefined({
+    method: "POST",
+    url: "/api/dataset",
+    alias: "dataset",
+  });
+
   openQuestionActions();
   popover().within(() => {
     cy.icon("model").click();
@@ -91,6 +102,7 @@ export function turnIntoModel() {
   modal().within(() => {
     cy.button("Turn this into a model").click();
   });
+  cy.wait("@dataset");
 }
 
 export function selectFromDropdown(option, clickOpts) {

--- a/frontend/test/metabase/scenarios/models/models.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models.cy.spec.js
@@ -133,7 +133,7 @@ describe("scenarios > models", () => {
       cy.icon("table");
     });
 
-    cy.url().should("not.include", "/question/1");
+    cy.location("pathname").should("eq", "/collection/root");
   });
 
   it("changes model's display to table", () => {

--- a/frontend/test/metabase/scenarios/models/models.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models.cy.spec.js
@@ -50,7 +50,9 @@ describe("scenarios > models", () => {
       .findByText("Between")
       .click();
     selectFromDropdown("Not empty");
+
     cy.button("Apply").click();
+    cy.wait("@dataset");
 
     assertQuestionIsBasedOnModel({
       model: "Orders Model",
@@ -103,6 +105,7 @@ describe("scenarios > models", () => {
     selectFromDropdown("Not empty");
 
     cy.button("Apply").click();
+    cy.wait("@dataset");
 
     assertQuestionIsBasedOnModel({
       model: "Orders Model",
@@ -315,6 +318,7 @@ describe("scenarios > models", () => {
         .click();
       selectFromDropdown("Not empty");
       cy.button("Apply").click();
+      cy.wait("@dataset");
 
       assertQuestionIsBasedOnModel({
         model: "Orders Model",
@@ -325,6 +329,7 @@ describe("scenarios > models", () => {
       summarize();
 
       selectDimensionOptionFromSidebar("Created At");
+      cy.wait("@dataset");
       cy.button("Done").click();
 
       assertQuestionIsBasedOnModel({


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- It adds some additional guards against race conditions in tests affected by changes in filter bulk modal by @iethree 

Models have had a failing rate of 20%, which is insanely high.
These changes should prevent that in the future.

Example of the failed run: https://github.com/metabase/metabase/runs/7195086880?check_suite_focus=true
![image](https://user-images.githubusercontent.com/31325167/177333090-03e7f889-439b-452a-8837-3cb1834537d8.png)

While I wasn't able to trigger the failure locally, I've noticed that the `dataset` request happens way too late in this screenshot (or rather, Cypress continues with UI assertions without waiting for a question to be turned into a model).

The fix consists in waiting for that event to happen first, and only then continuing with the test.
![Screenshot 2022-07-05 at 15 00 27](https://user-images.githubusercontent.com/31325167/177333642-f741a7ef-b35f-4604-938e-5d9c8ae2b8b6.png)

Notice the difference compared to the failing screenshot.

