### PR TITLE
Types for before and after updated

### DIFF
--- a/frontend/src/metabase-types/api/revision.ts
+++ b/frontend/src/metabase-types/api/revision.ts
@@ -7,6 +7,6 @@ export interface Revision {
   is_reversion: boolean;
   message?: string | null;
   user: BaseUser;
-  diff: { before: object; after: object };
+  diff: { before: Record<string, any>; after: Record<string, any> };
   timestamp: string;
 }


### PR DESCRIPTION
__Context__

`object` type has been used in the [revision.ts](https://github.com/metabase/metabase/blob/master/frontend/src/metabase-types/api/revision.ts#L10) file.

__Problem__

It might break the local `husky` precommit checks as the types might not be valid. VS Code might also complain about invalid types.
`object` type should be avoided as recommended in the TypeScript [documentation](https://github.com/microsoft/TypeScript/issues/21732).

__Proposal__

Replace the `object` type with `Record<string, any>`.