### PR TITLE
Fix issues with custom brand colors on the homepage and the notebook editor

### DIFF
--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarItems.styled.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarItems.styled.tsx
@@ -45,7 +45,7 @@ export const NodeRoot = styled(TreeNode.Root)<{
   color: ${props => getTextColor(props.isSelected)};
 
   background-color: ${props =>
-    props.isSelected ? alpha("brand", 0.35) : "unset"};
+    props.isSelected ? alpha("brand", 0.2) : "unset"};
 
   padding-left: ${props => props.depth}rem;
   border-radius: 4px;
@@ -55,7 +55,7 @@ export const NodeRoot = styled(TreeNode.Root)<{
   }
 
   &:hover {
-    background-color: ${lighten(color("brand"), 0.6)};
+    background-color: ${alpha("brand", 0.35)};
     color: ${color("brand")};
 
     ${ExpandToggleButton} {

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarItems.styled.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarItems.styled.tsx
@@ -9,7 +9,7 @@ import Link from "metabase/core/components/Link";
 
 import { NAV_SIDEBAR_WIDTH } from "metabase/nav/constants";
 
-import { darken, color, lighten } from "metabase/lib/colors";
+import { darken, color, lighten, alpha } from "metabase/lib/colors";
 
 export const SidebarIcon = styled(Icon)<{
   color?: string | null;
@@ -45,7 +45,7 @@ export const NodeRoot = styled(TreeNode.Root)<{
   color: ${props => getTextColor(props.isSelected)};
 
   background-color: ${props =>
-    props.isSelected ? lighten(color("brand"), 0.6) : "unset"};
+    props.isSelected ? alpha("brand", 0.35) : "unset"};
 
   padding-left: ${props => props.depth}rem;
   border-radius: 4px;

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx
@@ -6,7 +6,7 @@ import _ from "underscore";
 
 import styled from "@emotion/styled";
 
-import { color as c, lighten, darken } from "metabase/lib/colors";
+import { color as c, lighten, darken, alpha } from "metabase/lib/colors";
 
 import Tooltip from "metabase/components/Tooltip";
 import Icon from "metabase/components/Icon";
@@ -39,6 +39,7 @@ const STEP_UI = {
     title: t`Data`,
     component: DataStep,
     getColor: () => c("brand"),
+    getBackgroundColor: () => alpha("brand", 0.2),
   },
   join: {
     title: t`Join data`,
@@ -46,6 +47,7 @@ const STEP_UI = {
     component: JoinStep,
     priority: 1,
     getColor: () => c("brand"),
+    getBackgroundColor: () => alpha("brand", 0.2),
   },
   expression: {
     title: t`Custom column`,
@@ -59,6 +61,7 @@ const STEP_UI = {
     component: FilterStep,
     priority: 10,
     getColor: () => c("filter"),
+    getBackgroundColor: () => alpha("filter", 0.2),
   },
   summarize: {
     title: t`Summarize`,
@@ -66,6 +69,7 @@ const STEP_UI = {
     component: SummarizeStep,
     priority: 5,
     getColor: () => c("summarize"),
+    getBackgroundColor: () => alpha("summarize", 0.2),
   },
   aggregate: {
     title: t`Aggregate`,
@@ -73,6 +77,7 @@ const STEP_UI = {
     component: AggregateStep,
     priority: 5,
     getColor: () => c("summarize"),
+    getBackgroundColor: () => alpha("summarize", 0.2),
   },
   breakout: {
     title: t`Breakout`,
@@ -80,6 +85,7 @@ const STEP_UI = {
     component: BreakoutStep,
     priority: 1,
     getColor: () => c("accent4"),
+    getBackgroundColor: () => alpha("accent4", 0.2),
   },
   sort: {
     title: t`Sort`,
@@ -140,6 +146,7 @@ export default class NotebookStep extends React.Component {
               mr={isLastStep ? 2 : 1}
               mt={isLastStep ? 2 : null}
               color={stepUi.getColor()}
+              backgroundColor={stepUi.getBackgroundColor?.()}
               large={largeActionButtons}
               {...stepUi}
               key={`actionButton_${stepUi.title}`}
@@ -216,22 +223,31 @@ export default class NotebookStep extends React.Component {
 
 const ColorButton = styled(Button)`
   border: none;
-  color: ${({ color }) => (color ? color : c("text-medium"))};
-  background-color: ${({ color }) => (color ? lighten(color, 0.61) : null)};
+  color: ${({ color }) => color};
+  background-color: ${({ backgroundColor }) => backgroundColor};
   &:hover {
-    color: ${({ color }) => (color ? darken(color, 0.115) : color("brand"))};
-    background-color: ${({ color }) =>
-      color ? lighten(color, 0.5) : lighten(color("brand"), 0.61)};
+    color: ${({ color }) => darken(color, 0.115)};
+    background-color: ${({ color, backgroundColor }) =>
+      !backgroundColor ? lighten(color, 0.5) : alpha(color, 0.35)};
   }
   transition: background 300ms;
 `;
 
-const ActionButton = ({ icon, title, color, large, onClick, ...props }) => {
+const ActionButton = ({
+  icon,
+  title,
+  color,
+  backgroundColor,
+  large,
+  onClick,
+  ...props
+}) => {
   const button = (
     <ColorButton
-      color={color}
       icon={icon}
       small={!large}
+      color={color}
+      backgroundColor={backgroundColor}
       iconVertical={large}
       iconSize={large ? 18 : 14}
       onClick={onClick}

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx
@@ -39,7 +39,6 @@ const STEP_UI = {
     title: t`Data`,
     component: DataStep,
     getColor: () => c("brand"),
-    getBackgroundColor: () => alpha("brand", 0.2),
   },
   join: {
     title: t`Join data`,
@@ -47,12 +46,12 @@ const STEP_UI = {
     component: JoinStep,
     priority: 1,
     getColor: () => c("brand"),
-    getBackgroundColor: () => alpha("brand", 0.2),
   },
   expression: {
     title: t`Custom column`,
     icon: "add_data",
     component: ExpressionStep,
+    transparent: true,
     getColor: () => c("bg-dark"),
   },
   filter: {
@@ -61,7 +60,6 @@ const STEP_UI = {
     component: FilterStep,
     priority: 10,
     getColor: () => c("filter"),
-    getBackgroundColor: () => alpha("filter", 0.2),
   },
   summarize: {
     title: t`Summarize`,
@@ -69,7 +67,6 @@ const STEP_UI = {
     component: SummarizeStep,
     priority: 5,
     getColor: () => c("summarize"),
-    getBackgroundColor: () => alpha("summarize", 0.2),
   },
   aggregate: {
     title: t`Aggregate`,
@@ -77,7 +74,6 @@ const STEP_UI = {
     component: AggregateStep,
     priority: 5,
     getColor: () => c("summarize"),
-    getBackgroundColor: () => alpha("summarize", 0.2),
   },
   breakout: {
     title: t`Breakout`,
@@ -85,13 +81,13 @@ const STEP_UI = {
     component: BreakoutStep,
     priority: 1,
     getColor: () => c("accent4"),
-    getBackgroundColor: () => alpha("accent4", 0.2),
   },
   sort: {
     title: t`Sort`,
     icon: "smartscalar",
     component: SortStep,
     compact: true,
+    transparent: true,
     getColor: () => c("bg-dark"),
   },
   limit: {
@@ -99,6 +95,7 @@ const STEP_UI = {
     icon: "list",
     component: LimitStep,
     compact: true,
+    transparent: true,
     getColor: () => c("bg-dark"),
   },
 };
@@ -146,7 +143,6 @@ export default class NotebookStep extends React.Component {
               mr={isLastStep ? 2 : 1}
               mt={isLastStep ? 2 : null}
               color={stepUi.getColor()}
-              backgroundColor={stepUi.getBackgroundColor?.()}
               large={largeActionButtons}
               {...stepUi}
               key={`actionButton_${stepUi.title}`}
@@ -197,6 +193,7 @@ export default class NotebookStep extends React.Component {
                   icon="play"
                   title={t`Preview`}
                   color={c("text-light")}
+                  transparent
                   onClick={() => this.setState({ showPreview: true })}
                 />
               </StepButtonContainer>
@@ -224,11 +221,12 @@ export default class NotebookStep extends React.Component {
 const ColorButton = styled(Button)`
   border: none;
   color: ${({ color }) => color};
-  background-color: ${({ backgroundColor }) => backgroundColor};
+  background-color: ${({ color, transparent }) =>
+    transparent ? null : alpha(color, 0.2)};
   &:hover {
     color: ${({ color }) => darken(color, 0.115)};
-    background-color: ${({ color, backgroundColor }) =>
-      !backgroundColor ? lighten(color, 0.5) : alpha(color, 0.35)};
+    background-color: ${({ color, transparent }) =>
+      transparent ? lighten(color, 0.5) : alpha(color, 0.35)};
   }
   transition: background 300ms;
 `;
@@ -237,7 +235,7 @@ const ActionButton = ({
   icon,
   title,
   color,
-  backgroundColor,
+  transparent,
   large,
   onClick,
   ...props
@@ -247,7 +245,7 @@ const ActionButton = ({
       icon={icon}
       small={!large}
       color={color}
-      backgroundColor={backgroundColor}
+      transparent={transparent}
       iconVertical={large}
       iconSize={large ? 18 : 14}
       onClick={onClick}


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/22816
Fixes https://www.notion.so/metabase/When-picking-a-dark-main-color-in-Appearance-some-UI-can-be-hard-to-use-and-read-2b4b9bc5f289461bb579e05dcf21af0b

The problem is that `lighten` and `darken` doesn't work well for some custom brand colors, so we need to replace it with alternatives. The query builder uses `alpha` and it seems to work fine. The idea is to fix some obvious places in the same way the query builder does.

How to test:
- Run Metabase EE
- Go to Admin > Appearance and set Brand to `#480F8E`
- Reload the page
- Go to the home page and make sure the sidebar button looks according to the screenshot below
- New -> Question
- Make sure that different notebook steps look according to the screenshot below

<img width="1320" alt="Screenshot 2022-07-05 at 17 30 40" src="https://user-images.githubusercontent.com/8542534/177352467-27386eae-df54-4f33-b20f-90c95fa04f04.png">
<img width="1300" alt="Screenshot 2022-07-05 at 17 30 59" src="https://user-images.githubusercontent.com/8542534/177352494-a6676d2f-4eb9-4b07-81fd-0d1923a9f638.png">
<img width="971" alt="Screenshot 2022-07-05 at 17 31 07" src="https://user-images.githubusercontent.com/8542534/177352502-03038614-39f3-4826-a013-fd74d306cb0c.png">
