### PR TITLE
Have DashboardStyled use all available screen space

### DIFF
--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.jsx
@@ -26,8 +26,8 @@ export const DashboardLoadingAndErrorWrapper = styled(
     );
   },
 )`
-  flex: 1 0 auto;
-
+  min-height: 100%;
+  height: 1px;
   // prevents header from scrolling so we can have a fixed sidebar
   ${({ isFullHeight }) =>
     isFullHeight &&
@@ -39,7 +39,7 @@ export const DashboardLoadingAndErrorWrapper = styled(
 export const DashboardStyled = styled.div`
   display: flex;
   flex-direction: column;
-  height: 100%;
+  min-height: 100%;
   overflow-x: hidden;
   width: 100%;
 `;


### PR DESCRIPTION
Small changes to have the dashboard take up as much space as possible to allow the sidebar to look correct. Ideally we could just set the loading wrapper to full height, but this breaks `ParametersWidgetContainer` stickyness, as that logic relies on the `<main>` element being the one doing the scrolling.

Ideally we would adjust the above, and use the dashboard body. However, that proved to be messy due to the `LoadingAndErrorWrapper` component. It's hard to `Ref` anything inside of it on mount because you will always have some render cycles of API requests doing their thing. (There may have been other issues, but that's as far as I got with it).

Before:
![image](https://user-images.githubusercontent.com/1328979/177390043-172c6151-6ae2-4bfc-9b4d-6f69f63dc345.png)

After:
![image](https://user-images.githubusercontent.com/1328979/177390098-902f2279-23f6-4fcf-80c3-b304dbe272b5.png)
