### PR TITLE
Handle field values endpoint has_more_values state

### DIFF
--- a/frontend/src/metabase/components/FieldValuesWidget.jsx
+++ b/frontend/src/metabase/components/FieldValuesWidget.jsx
@@ -76,11 +76,16 @@ async function searchFieldValues(
 class FieldValuesWidgetInner extends Component {
   constructor(props) {
     super(props);
+    const { fields, disableSearch, disablePKRemappingForSearch } = props;
     this.state = {
       options: [],
       loadingState: "INIT",
       lastValue: "",
-      valuesMode: getValuesMode(props),
+      valuesMode: getValuesMode(
+        fields,
+        disableSearch,
+        disablePKRemappingForSearch,
+      ),
     };
   }
 
@@ -114,7 +119,13 @@ class FieldValuesWidgetInner extends Component {
         options = await this.fetchDashboardParamValues(query);
       } else {
         options = await this.fetchFieldValues(query);
-        valuesMode = getValuesMode(this.props);
+        const { fields, disableSearch, disablePKRemappingForSearch } =
+          this.props;
+        valuesMode = getValuesMode(
+          fields,
+          disableSearch,
+          disablePKRemappingForSearch,
+        );
       }
     } finally {
       this.updateRemappings(options);
@@ -596,7 +607,7 @@ function renderValue(fields, formatOptions, value, options) {
   );
 }
 
-function getValuesMode({ fields, disableSearch, disablePKRemappingForSearch }) {
+function getValuesMode(fields, disableSearch, disablePKRemappingForSearch) {
   if (fields.length === 0) {
     return "none";
   }

--- a/frontend/src/metabase/components/FieldValuesWidget.jsx
+++ b/frontend/src/metabase/components/FieldValuesWidget.jsx
@@ -209,7 +209,7 @@ class FieldValuesWidgetInner extends Component {
       maxResults,
     )
       ? "list"
-      : "search";
+      : valuesMode;
 
     if (valuesMode === "search") {
       this._search(value);

--- a/frontend/src/metabase/components/FieldValuesWidget.jsx
+++ b/frontend/src/metabase/components/FieldValuesWidget.jsx
@@ -189,12 +189,8 @@ class FieldValuesWidgetInner extends Component {
   }
 
   onInputChange = value => {
-    const {
-      fields,
-      disableSearch,
-      disablePKRemappingForSearch,
-      maxResults,
-    } = this.props;
+    const { fields, disableSearch, disablePKRemappingForSearch, maxResults } =
+      this.props;
     const { lastValue, options, hasIncompleteValueSet } = this.state;
 
     const canSearch = isSearchable(

--- a/frontend/src/metabase/components/FieldValuesWidget.jsx
+++ b/frontend/src/metabase/components/FieldValuesWidget.jsx
@@ -80,6 +80,7 @@ class FieldValuesWidgetInner extends Component {
       options: [],
       loadingState: "INIT",
       lastValue: "",
+      valuesMode: getValuesMode(props),
     };
   }
 
@@ -107,24 +108,20 @@ class FieldValuesWidgetInner extends Component {
     });
 
     let options = [];
-    let hasIncompleteValueSet;
+    let valuesMode = this.state.valuesMode;
     try {
       if (usesChainFilterEndpoints(this.props.dashboard)) {
         options = await this.fetchDashboardParamValues(query);
-        // not yet implemented for dashboard parameter values endpoint
-        hasIncompleteValueSet = false;
       } else {
         options = await this.fetchFieldValues(query);
-        hasIncompleteValueSet = this.props.fields.some(
-          field => field.has_more_values,
-        );
+        valuesMode = getValuesMode(this.props);
       }
     } finally {
       this.updateRemappings(options);
       this.setState({
         loadingState: "LOADED",
         options,
-        hasIncompleteValueSet,
+        valuesMode,
       });
     }
   }
@@ -189,22 +186,21 @@ class FieldValuesWidgetInner extends Component {
   }
 
   onInputChange = value => {
-    const { fields, disableSearch, disablePKRemappingForSearch, maxResults } =
-      this.props;
-    const { lastValue, options, hasIncompleteValueSet } = this.state;
+    const { maxResults } = this.props;
+    const { lastValue, options } = this.state;
+    let { valuesMode } = this.state;
 
-    const canSearch = isSearchable(
-      fields,
-      disableSearch,
-      disablePKRemappingForSearch,
-      hasIncompleteValueSet,
-    );
+    // override "search" mode when searching is unnecessary
+    valuesMode = isExtensionOfPreviousSearch(
+      value,
+      lastValue,
+      options,
+      maxResults,
+    )
+      ? "list"
+      : "search";
 
-    const shouldSearch = () =>
-      !isExtensionOfPreviousSearch(value, lastValue, options, maxResults) ||
-      hasIncompleteValueSet;
-
-    if (value && canSearch && shouldSearch()) {
+    if (valuesMode === "search") {
       this._search(value);
     }
 
@@ -252,7 +248,7 @@ class FieldValuesWidgetInner extends Component {
       placeholder,
       showOptionsInPopover,
     } = this.props;
-    const { loadingState, options = [], hasIncompleteValueSet } = this.state;
+    const { loadingState, options = [] } = this.state;
 
     const tokenFieldPlaceholder = getTokenFieldPlaceholder({
       fields,
@@ -261,18 +257,14 @@ class FieldValuesWidgetInner extends Component {
       disablePKRemappingForSearch,
       loadingState,
       options,
-      hasIncompleteValueSet,
     });
 
     const isLoading = loadingState === "LOADING";
-    const isFetchingList =
-      shouldList(this.props.fields, this.props.disableSearch) && isLoading;
-    const hasExhaustedListData =
-      hasList({
-        fields,
-        disableSearch,
-        options,
-      }) && !hasIncompleteValueSet;
+    const usesListField = hasList({
+      fields,
+      disableSearch,
+      options,
+    });
 
     return (
       <div
@@ -282,22 +274,24 @@ class FieldValuesWidgetInner extends Component {
           maxWidth: this.props.maxWidth,
         }}
       >
-        {hasExhaustedListData && isFetchingList && <LoadingState />}
-        {hasExhaustedListData && (
-          <ListField
-            isDashboardFilter={parameter}
-            placeholder={tokenFieldPlaceholder}
-            value={value.filter(v => v != null)}
-            onChange={onChange}
-            options={options}
-            optionRenderer={option =>
-              renderValue(fields, formatOptions, option[0], {
-                autoLoad: false,
-              })
-            }
-          />
-        )}
-        {!hasExhaustedListData && (
+        {usesListField &&
+          (isLoading ? (
+            <LoadingState />
+          ) : (
+            <ListField
+              isDashboardFilter={parameter}
+              placeholder={tokenFieldPlaceholder}
+              value={value.filter(v => v != null)}
+              onChange={onChange}
+              options={options}
+              optionRenderer={option =>
+                renderValue(fields, formatOptions, option[0], {
+                  autoLoad: false,
+                })
+              }
+            />
+          ))}
+        {!usesListField && (
           <TokenField
             prefix={prefix}
             value={value.filter(v => v != null)}
@@ -493,12 +487,7 @@ function isExtensionOfPreviousSearch(value, lastValue, options, maxResults) {
   );
 }
 
-function isSearchable(
-  fields,
-  disableSearch,
-  disablePKRemappingForSearch,
-  hasIncompleteValueSet,
-) {
+function isSearchable(fields, disableSearch, disablePKRemappingForSearch) {
   return (
     !disableSearch &&
     // search is available if:
@@ -508,7 +497,7 @@ function isSearchable(
     fields.some(
       f =>
         f.has_field_values === "search" ||
-        (f.has_field_values === "list" && hasIncompleteValueSet),
+        (f.has_field_values === "list" && f.has_more_values === true),
     ) &&
     // and all fields are either "search" or "list"
     fields.every(
@@ -524,7 +513,6 @@ function getTokenFieldPlaceholder({
   disablePKRemappingForSearch,
   loadingState,
   options,
-  hasIncompleteValueSet,
 }) {
   if (placeholder) {
     return placeholder;
@@ -540,14 +528,7 @@ function getTokenFieldPlaceholder({
     })
   ) {
     return t`Search the list`;
-  } else if (
-    isSearchable(
-      fields,
-      disableSearch,
-      disablePKRemappingForSearch,
-      hasIncompleteValueSet,
-    )
-  ) {
+  } else if (isSearchable(fields, disableSearch, disablePKRemappingForSearch)) {
     return getSearchableTokenFieldPlaceholder(
       fields,
       firstField,
@@ -569,7 +550,7 @@ function renderOptions(
     disableSearch,
     disablePKRemappingForSearch,
   } = props;
-  const { loadingState, options, hasIncompleteValueSet } = state;
+  const { loadingState, options } = state;
 
   if (alwaysShowOptions || isFocused) {
     if (optionsList) {
@@ -585,12 +566,7 @@ function renderOptions(
         return <EveryOptionState />;
       }
     } else if (
-      isSearchable(
-        fields,
-        disableSearch,
-        disablePKRemappingForSearch,
-        hasIncompleteValueSet,
-      )
+      isSearchable(fields, disableSearch, disablePKRemappingForSearch)
     ) {
       if (loadingState === "LOADING") {
         return <LoadingState />;
@@ -618,4 +594,20 @@ function renderValue(fields, formatOptions, value, options) {
       {...options}
     />
   );
+}
+
+function getValuesMode({ fields, disableSearch, disablePKRemappingForSearch }) {
+  if (fields.length === 0) {
+    return "none";
+  }
+
+  if (isSearchable(fields, disableSearch, disablePKRemappingForSearch)) {
+    return "search";
+  }
+
+  if (shouldList(fields, disableSearch)) {
+    return "list";
+  }
+
+  return "none";
 }

--- a/frontend/src/metabase/components/FieldValuesWidget.jsx
+++ b/frontend/src/metabase/components/FieldValuesWidget.jsx
@@ -203,11 +203,12 @@ class FieldValuesWidgetInner extends Component {
       disablePKRemappingForSearch,
       hasIncompleteValueSet,
     );
-    const shouldSearch =
+
+    const shouldSearch = () =>
       !isExtensionOfPreviousSearch(value, lastValue, options, maxResults) ||
       hasIncompleteValueSet;
 
-    if (value && canSearch && shouldSearch) {
+    if (value && canSearch && shouldSearch()) {
       this._search(value);
     }
 

--- a/frontend/src/metabase/components/FieldValuesWidget.jsx
+++ b/frontend/src/metabase/components/FieldValuesWidget.jsx
@@ -201,6 +201,7 @@ class FieldValuesWidgetInner extends Component {
       fields,
       disableSearch,
       disablePKRemappingForSearch,
+      hasIncompleteValueSet,
     );
     const shouldSearch =
       !isExtensionOfPreviousSearch(value, lastValue, options, maxResults) ||
@@ -263,6 +264,7 @@ class FieldValuesWidgetInner extends Component {
       disablePKRemappingForSearch,
       loadingState,
       options,
+      hasIncompleteValueSet,
     });
 
     const isLoading = loadingState === "LOADING";
@@ -494,12 +496,23 @@ function isExtensionOfPreviousSearch(value, lastValue, options, maxResults) {
   );
 }
 
-function isSearchable(fields, disableSearch, disablePKRemappingForSearch) {
+function isSearchable(
+  fields,
+  disableSearch,
+  disablePKRemappingForSearch,
+  hasIncompleteValueSet,
+) {
   return (
     !disableSearch &&
     // search is available if:
     // all fields have a valid search field
     fields.every(field => searchField(field, disablePKRemappingForSearch)) &&
+    // at least one field is set to display as "search" or is a list field that has an incomplete value set
+    fields.some(
+      f =>
+        f.has_field_values === "search" ||
+        (f.has_field_values === "list" && hasIncompleteValueSet),
+    ) &&
     // and all fields are either "search" or "list"
     fields.every(
       f => f.has_field_values === "search" || f.has_field_values === "list",
@@ -514,6 +527,7 @@ function getTokenFieldPlaceholder({
   disablePKRemappingForSearch,
   loadingState,
   options,
+  hasIncompleteValueSet,
 }) {
   if (placeholder) {
     return placeholder;
@@ -529,7 +543,14 @@ function getTokenFieldPlaceholder({
     })
   ) {
     return t`Search the list`;
-  } else if (isSearchable(fields, disableSearch, disablePKRemappingForSearch)) {
+  } else if (
+    isSearchable(
+      fields,
+      disableSearch,
+      disablePKRemappingForSearch,
+      hasIncompleteValueSet,
+    )
+  ) {
     return getSearchableTokenFieldPlaceholder(
       fields,
       firstField,
@@ -551,7 +572,7 @@ function renderOptions(
     disableSearch,
     disablePKRemappingForSearch,
   } = props;
-  const { loadingState, options } = state;
+  const { loadingState, options, hasIncompleteValueSet } = state;
 
   if (alwaysShowOptions || isFocused) {
     if (optionsList) {
@@ -567,7 +588,12 @@ function renderOptions(
         return <EveryOptionState />;
       }
     } else if (
-      isSearchable(fields, disableSearch, disablePKRemappingForSearch)
+      isSearchable(
+        fields,
+        disableSearch,
+        disablePKRemappingForSearch,
+        hasIncompleteValueSet,
+      )
     ) {
       if (loadingState === "LOADING") {
         return <LoadingState />;

--- a/frontend/src/metabase/entities/fields.js
+++ b/frontend/src/metabase/entities/fields.js
@@ -84,7 +84,7 @@ const Fields = createEntity({
       const {
         field_id: id,
         values,
-        has_more_values = false,
+        has_more_values,
       } = await MetabaseApi.field_values({
         fieldId,
       });

--- a/frontend/src/metabase/entities/fields.js
+++ b/frontend/src/metabase/entities/fields.js
@@ -81,10 +81,14 @@ const Fields = createEntity({
       ),
       withNormalize(FieldSchema),
     )(({ id: fieldId }) => async (dispatch, getState) => {
-      const { field_id: id, values } = await MetabaseApi.field_values({
+      const {
+        field_id: id,
+        values,
+        has_more_values = false,
+      } = await MetabaseApi.field_values({
         fieldId,
       });
-      return { id, values };
+      return { id, values, has_more_values };
     }),
 
     updateField(field, opts) {


### PR DESCRIPTION
Related to #23162 

BE added a boolean to what the field values endpoint returns, `has_more_values`, to indicate a state where the list returned by said endpoint is not a complete list of values. Currently, we do not handle this scenario on the FE.

This PR adds logic to `FieldValuesWidget` to enable search when a field has the property `has_more_values`. When this boolean is set to `true`, I am reverting to usage of `TokenField` because `ListField` does not contain any logic for handling search.

It does this by introducing the concept of `valuesMode`, which can either be none, list, or search. This `valuesMode` value may be overridden in the case where we are in search mode but there are fewer than 100 available values and the user has extended the search.

Testing
1. create a dashboard, add the People table (as a saved question) to it, and add a `string/=` parameter to the dashboard and map it to the State column.
1. manually set the property `has_more_values` on the State field
1. open the State parameter widget and make sure it searches for values