### PR TITLE
Repro #23689: Sandboxed group managers can't see other users in the People tab #23689

### DIFF
--- a/frontend/test/metabase/scenarios/admin/people/reproductions/23689-sandboxed-group-manager.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/people/reproductions/23689-sandboxed-group-manager.cy.spec.js
@@ -1,0 +1,66 @@
+import { restore, describeEE } from "__support__/e2e/helpers";
+import { USERS, USER_GROUPS } from "__support__/e2e/cypress_data";
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+
+const { COLLECTION_GROUP } = USER_GROUPS;
+const { sandboxed, normal, nodata } = USERS;
+
+const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
+
+describeEE("issue 23689", () => {
+  beforeEach(() => {
+    // TODO: remove the next line when this issue gets fixed
+    cy.skipOn(true);
+
+    cy.intercept("GET", "/api/permissions/membership").as("membership");
+
+    restore();
+    cy.signInAsAdmin();
+
+    visitGroupPermissionsPage(COLLECTION_GROUP);
+
+    cy.findByText("3 members");
+
+    findUserByFullName(normal);
+    findUserByFullName(nodata);
+
+    // Make sandboxed user a group manager
+    findUserByFullName(sandboxed)
+      .closest("tr")
+      .findByTestId("user-type-toggle")
+      .click({ force: true });
+
+    // Sanity check instead of waiting for the PUT request
+    cy.findByText("Manager");
+
+    cy.sandboxTable({
+      table_id: ORDERS_ID,
+      attribute_remappings: {
+        attr_uid: ["dimension", ["field", ORDERS.USER_ID, null]],
+      },
+    });
+
+    cy.signOut();
+    cy.signInAsSandboxedUser();
+  });
+
+  it("sandboxed group manager should see all group members (metabase#23689)", () => {
+    visitGroupPermissionsPage(COLLECTION_GROUP);
+
+    cy.findByText("3 members");
+
+    findUserByFullName(sandboxed);
+    findUserByFullName(normal);
+    findUserByFullName(nodata);
+  });
+});
+
+function findUserByFullName(user) {
+  const { first_name, last_name } = user;
+  return cy.findByText(`${first_name} ${last_name}`);
+}
+
+function visitGroupPermissionsPage(groupId) {
+  cy.visit(`/admin/people/groups/${COLLECTION_GROUP}`);
+  cy.wait("@membership");
+}

--- a/frontend/test/metabase/scenarios/admin/people/reproductions/23689-sandboxed-group-manager.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/people/reproductions/23689-sandboxed-group-manager.cy.spec.js
@@ -3,9 +3,11 @@ import { USERS, USER_GROUPS } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { COLLECTION_GROUP } = USER_GROUPS;
-const { sandboxed, normal, nodata } = USERS;
+const { sandboxed, normal, nodata, nocollection } = USERS;
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
+
+const totalUsers = Object.keys(USERS).length;
 
 describeEE("issue 23689", () => {
   beforeEach(() => {
@@ -44,7 +46,7 @@ describeEE("issue 23689", () => {
     cy.signInAsSandboxedUser();
   });
 
-  it("sandboxed group manager should see all group members (metabase#23689)", () => {
+  it("sandboxed group manager should see all other members (metabase#23689)", () => {
     visitGroupPermissionsPage(COLLECTION_GROUP);
 
     cy.findByText("3 members");
@@ -52,6 +54,15 @@ describeEE("issue 23689", () => {
     findUserByFullName(sandboxed);
     findUserByFullName(normal);
     findUserByFullName(nodata);
+
+    cy.visit("/admin/people");
+    cy.wait("@membership");
+
+    cy.findByText(`${totalUsers} people found`);
+    findUserByFullName(sandboxed);
+    findUserByFullName(normal);
+    findUserByFullName(nodata);
+    findUserByFullName(nocollection);
   });
 });
 

--- a/frontend/test/metabase/scenarios/admin/people/reproductions/23689-sandboxed-group-manager.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/people/reproductions/23689-sandboxed-group-manager.cy.spec.js
@@ -61,6 +61,6 @@ function findUserByFullName(user) {
 }
 
 function visitGroupPermissionsPage(groupId) {
-  cy.visit(`/admin/people/groups/${COLLECTION_GROUP}`);
+  cy.visit(`/admin/people/groups/${groupId}`);
   cy.wait("@membership");
 }


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #23689 

### How to test this manually?
- `yarn test-cypress-open`
- `metabase/scenarios/admin/people/reproductions/23689-sandboxed-group-manager.cy.spec.js`
- Unskip repro (remove `cy.skipOn(true)`)
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
Group page
![image](https://user-images.githubusercontent.com/31325167/177402682-984d0655-9849-4730-9d37-48a9c8fb65cc.png)

