### PR TITLE
Hide Filter Button on Mobile

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx
@@ -149,11 +149,12 @@ export function FilterHeader({ className, question, expanded }) {
   );
 }
 
-export function QuestionFilterWidget({ onOpenModal }) {
+export function QuestionFilterWidget({ onOpenModal, className }) {
   return (
     <HeaderButton
       large
       labelBreakpoint="sm"
+      className={className}
       color={color("filter")}
       onClick={() => onOpenModal(MODAL_TYPES.FILTERS)}
       aria-label={t`Show more filters`}


### PR DESCRIPTION
This reverts to the previous behavior of hiding the filter button on small screens

resolves https://github.com/metabase/metabase/issues/23674

![Screen Shot 2022-07-05 at 4 37 14 PM](https://user-images.githubusercontent.com/30528226/177428576-505e2593-c3e4-4265-8c2e-825013534829.png)
