### PR TITLE
Remove `update_collection_tree_authority_level` from PUT collection/:id

### DIFF
--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -757,21 +757,19 @@
 
 (api/defendpoint PUT "/:id"
   "Modify an existing Collection, including archiving or unarchiving it, or moving it."
-  [id, :as {{:keys [name color description archived parent_id authority_level update_collection_tree_authority_level], :as collection-updates} :body}]
+  [id, :as {{:keys [name color description archived parent_id authority_level], :as collection-updates} :body}]
   {name                                   (s/maybe su/NonBlankString)
    color                                  (s/maybe collection/hex-color-regex)
    description                            (s/maybe su/NonBlankString)
    archived                               (s/maybe s/Bool)
    parent_id                              (s/maybe su/IntGreaterThanZero)
-   authority_level                        collection/AuthorityLevel
-   update_collection_tree_authority_level (s/maybe s/Bool)}
+   authority_level                        collection/AuthorityLevel}
   ;; do we have perms to edit this Collection?
   (let [collection-before-update (api/write-check Collection id)]
     ;; if we're trying to *archive* the Collection, make sure we're allowed to do that
     (check-allowed-to-archive-or-unarchive collection-before-update collection-updates)
-    (when (or (and (contains? collection-updates :authority_level)
-                   (not= authority_level (:authority_level collection-before-update)))
-              update_collection_tree_authority_level)
+    (when (and (contains? collection-updates :authority_level)
+                    (not= authority_level (:authority_level collection-before-update)))
       (api/check-403 (and api/*is-superuser?*
                           ;; pre-update of model checks if the collection is a personal collection and rejects changes
                           ;; to authority_level, but it doesn't check if it is a sub-collection of a personal one so we add that
@@ -784,19 +782,11 @@
         (db/update! Collection id updates)))
     ;; if we're trying to *move* the Collection (instead or as well) go ahead and do that
     (move-collection-if-needed! collection-before-update collection-updates)
-    ;; mark the tree after moving so the new tree is what is marked as official
-    (when update_collection_tree_authority_level
-      (db/execute! {:update Collection
-                    :set    {:authority_level authority_level}
-                    :where  [:or
-                             [:= :id id]
-                             [:like :location (hx/literal (format "%%/%d/%%" id))]]}))
     ;; if we *did* end up archiving this Collection, we most post a few notifications
     (maybe-send-archived-notificaitons! collection-before-update collection-updates))
   ;; finally, return the updated object
   (-> (Collection id)
       (hydrate :parent_id)))
-
 
 ;;; ------------------------------------------------ GRAPH ENDPOINTS -------------------------------------------------
 

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -1379,26 +1379,6 @@
                (-> (mt/user-http-request :rasta :put 200 (str "collection/" (u/the-id collection))
                                          {:name "foo"})
                    :authority_level)))))
-    (testing "Admins can mark a tree as official"
-      (mt/with-temp* [Collection [collection]
-                      Collection [sub-collection]
-                      Collection [sub-sub-collection]]
-        (collection/move-collection! sub-collection (collection/children-location collection))
-        (collection/move-collection! sub-sub-collection
-                                     ;; needs updated path so reload
-                                     (collection/children-location (Collection (:id sub-collection))))
-        (is (= "official"
-               (-> (mt/user-http-request :crowberto :put 200 (str "collection/" (u/the-id collection))
-                                         {:authority_level "official" :update_collection_tree_authority_level true})
-                   :authority_level)))
-        ;; descended and marked sub collections
-        (is (= :official (db/select-one-field :authority_level Collection :id (:id sub-collection))))
-        (is (= :official (db/select-one-field :authority_level Collection :id (:id sub-sub-collection))))
-        (testing "Non-admins cannot apply types to the whole tree"
-          (mt/user-http-request :rasta :put 403 (str "collection/" (u/the-id collection))
-                                {:name "new name" :update_collection_tree_authority_level true})
-          (mt/user-http-request :rasta :put 403 (str "collection/" (u/the-id collection))
-                                {:name "new name" :authority_level nil :update_collection_tree_authority_level true}))))
     (testing "check that users without write perms aren't allowed to update a Collection"
       (mt/with-non-admin-groups-no-root-collection-perms
         (mt/with-temp Collection [collection]


### PR DESCRIPTION
Related: #22826

Apparently the ability to update the entire collection tree's authority level at once is not used. At least, the flag on `PUT collection/:id` is not used, per the related Epic.

There was one test that I removed which tested specifically this feature. Since it's being removed, that test can safely be eliminated.