### PR TITLE
Use the brand color for the first generated chart color when there are no custom colors

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/ChartColorSettings/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/ChartColorSettings/utils.ts
@@ -50,12 +50,12 @@ const getAutoColors = (
 
   const autoColors: Color[] = [];
   oldColors.forEach((_, index) => {
-    if (index > 0) {
-      autoColors.push(getNextColor(autoColors[index - 1]));
-    } else if (oldColor) {
+    if (index === 0 && !oldColor) {
+      autoColors.push(fallbackColor);
+    } else if (index === 0 && oldColor) {
       autoColors.push(getNextColor(oldColor));
     } else {
-      autoColors.push(fallbackColor);
+      autoColors.push(getNextColor(autoColors[index - 1]));
     }
   });
 

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/ChartColorSettings/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/ChartColorSettings/utils.ts
@@ -46,12 +46,18 @@ const getAutoColors = (
   oldColors: (Color | undefined)[],
   fallbackColor: Color,
 ) => {
-  const baseColor = oldColors.find(color => color != null) ?? fallbackColor;
+  const oldColor = oldColors.find(color => color != null);
 
   const autoColors: Color[] = [];
-  oldColors.forEach((_, index) =>
-    autoColors.push(getNextColor(index ? autoColors[index - 1] : baseColor)),
-  );
+  oldColors.forEach((_, index) => {
+    if (index > 0) {
+      autoColors.push(getNextColor(autoColors[index - 1]));
+    } else if (oldColor) {
+      autoColors.push(getNextColor(oldColor));
+    } else {
+      autoColors.push(fallbackColor);
+    }
+  });
 
   const availableColors = autoColors.filter(
     newColor => !isSimilarToColors(newColor, oldColors),

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/ChartColorSettings/utils.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/ChartColorSettings/utils.unit.spec.ts
@@ -23,7 +23,22 @@ describe("getAutoChartColors", () => {
   const groups = [["accent1"], ["accent2"], ["accent3"]];
   const palette = { brand: "blue" };
 
-  it("should fill missing chart colors", () => {
+  it("should use the brand color for the first chart color when there are no custom colors", () => {
+    const values = {
+      brand: "blue",
+    };
+
+    const newValues = getAutoChartColors(values, groups, palette);
+
+    expect(newValues).toEqual({
+      brand: "blue",
+      accent1: Color.rgb(0, 0, 255).hex(), // blue, brand
+      accent2: Color.rgb(207, 138, 230).hex(), // generated
+      accent3: Color.rgb(230, 138, 184).hex(), // generated
+    });
+  });
+
+  it("should fill missing chart colors without overwriting existing values", () => {
     const values = {
       brand: "blue",
       accent2: "green",
@@ -33,9 +48,9 @@ describe("getAutoChartColors", () => {
 
     expect(newValues).toEqual({
       brand: "blue",
-      accent1: Color.rgb(138, 230, 230).hex(), // cyan
+      accent1: Color.rgb(138, 230, 230).hex(), // generated
       accent2: Color.rgb(0, 128, 0).hex(), // green, unchanged
-      accent3: Color.rgb(138, 161, 230).hex(), // purple
+      accent3: Color.rgb(138, 161, 230).hex(), // generated
     });
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/ColorResetModal/ColorResetModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/ColorResetModal/ColorResetModal.tsx
@@ -30,7 +30,7 @@ const ColorResetModal = ({
       ]}
       onClose={onClose}
     >
-      {t`If you do this, your colors will change to our default colors. This action can’t be undone`}
+      {t`If you do this, your colors will change to our default colors. This action can’t be undone.`}
     </ModalContent>
   );
 };

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/index.js
@@ -94,8 +94,9 @@ if (hasPremiumFeature("whitelabel")) {
     ...sections,
   }));
 
-  PLUGIN_APP_INIT_FUCTIONS.push(({ root }) => {
+  PLUGIN_APP_INIT_FUCTIONS.push(() => {
     updateColors();
+    MetabaseSettings.on("application-colors", updateColors);
   });
 
   enabledApplicationNameReplacement();

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/lib/whitelabel.js
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/lib/whitelabel.js
@@ -20,20 +20,11 @@ const JS_COLOR_UPDATORS_BY_COLOR_NAME = {};
 const RANDOM_COLOR = Color({ r: 0xab, g: 0xcd, b: 0xed });
 
 function colorScheme() {
-  // FIXME: Ugh? initially load public setting as "application_color" but if the admin updates it
-  // we need to use "application-colors"
-  return (
-    MetabaseSettings.get("application-colors") ||
-    MetabaseSettings.get("application_colors")
-  );
+  return { ...MetabaseSettings.get("application-colors"), ...originalColors };
 }
 
 function applicationName() {
-  // FIXME: Ugh? see comment in colorScheme()
-  return (
-    MetabaseSettings.get("application-name") ||
-    MetabaseSettings.get("application_name")
-  );
+  return MetabaseSettings.get("application-name");
 }
 
 function walkStyleSheets(sheets, fn) {

--- a/frontend/src/metabase/lib/settings.ts
+++ b/frontend/src/metabase/lib/settings.ts
@@ -98,6 +98,7 @@ export type SettingName =
   | "show-database-syncing-modal"
   | "premium-embedding-token"
   | "metabase-store-managed"
+  | "application-colors"
   | "application-font"
   | "available-fonts"
   | "enable-query-caching";


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/22816
Demo https://www.loom.com/share/4fc5a46a5cbd4da6bea800a68afcb4d4

How to test:
- Run Metabase EE
- Go to Admin -> Settings -> Appearance
- Reset charts colors to default values if you have custom values defined
- Click `Generate chart colors`
- The first chart color should be the same as `brand`

<img width="609" alt="Screenshot 2022-07-06 at 10 41 55" src="https://user-images.githubusercontent.com/8542534/177496978-d6d8b1e7-3f79-457a-be1f-8d869685d09e.png">


