### PR TITLE
Update some migrations added in 44 to make sure we don't break downgrade ability

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -11897,7 +11897,7 @@ databaseChangeLog:
                   defaultValue: 'full'
                   remarks: Type of FieldValues
                   constraints:
-                    nullable: true
+                    nullable: false
   - changeSet:
       id: v44.00-037
       author: qnkhuat

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -11918,20 +11918,11 @@ databaseChangeLog:
             columns:
               - column:
                   name: type
-                  type: ${text.type}
+                  type: varchar(254)
+                  defaultValue: 'full'
                   remarks: Type of FieldValues
                   constraints:
                     nullable: true
-  - changeSet:
-      id: v44.00-036
-      author: qnkhuat
-      comment: Added 0.44.0 - Add default value for metabase_fieldvalues.type
-      changes:
-        - addNotNullConstraint:
-            columnDataType: ${text.type}
-            columnName: type
-            defaultNullValue: 'full'
-            tableName: metabase_fieldvalues
   - changeSet:
       id: v44.00-037
       author: qnkhuat

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -11893,7 +11893,7 @@ databaseChangeLog:
             columns:
               - column:
                   name: type
-                  type: varchar(254)
+                  type: varchar(32)
                   defaultValue: 'full'
                   remarks: Type of FieldValues
                   constraints:

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -11806,19 +11806,6 @@ databaseChangeLog:
                   remarks: List of parameter associated to a card
                   constraints:
                     nullable: true
-                    deferrable: false
-                    initiallyDeferred: false
-  - changeSet:
-      id: v44.00-024
-      author: qnkhuat
-      comment: Added 0.44.0 - Add parameters to report_card
-      changes:
-        - addNotNullConstraint:
-            columnDataType: ${text.type}
-            columnName: parameters
-            defaultNullValue: '[]'
-            tableName: report_card
-
   - changeSet:
       id: v44.00-025
       author: qnkhuat
@@ -11833,18 +11820,6 @@ databaseChangeLog:
                   remarks: List of parameter associated to a card
                   constraints:
                     nullable: true
-                    deferrable: false
-                    initiallyDeferred: false
-  - changeSet:
-      id: v44.00-026
-      author: qnkhuat
-      comment: Added 0.44.0 - Add parameter_mappings to report_card
-      changes:
-        - addNotNullConstraint:
-            columnDataType: ${text.type}
-            columnName: parameter_mappings
-            defaultNullValue: '[]'
-            tableName: report_card
 
   - changeSet:
       id: v44.00-027

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -595,7 +595,8 @@
                                              :database_id            database-id
                                              :collection_id          nil})]
        (migrate!)
-       (is (= [] (:parameters (first (db/simple-select Card {:where [:= :id card-id]})))))))))
+       (is (= nil
+              (:parameters (first (db/simple-select Card {:where [:= :id card-id]})))))))))
 
 (deftest add-parameter-mappings-to-cards-test
   (testing "Migration v44.00-024: Add parameter_mappings to cards"
@@ -619,7 +620,7 @@
                                      :database_id            database-id
                                      :collection_id          nil})]
         (migrate!)
-        (is (= []
+        (is (= nil
                (:parameter_mappings (first (db/simple-select Card {:where [:= :id card-id]})))))))))
 
 (deftest grant-all-users-root-snippets-collection-readwrite-perms-test


### PR DESCRIPTION
I added some not-null text columns in 44, in those PRs I thought that using `defaultNullValue` will add a default value for the column it's actually not :).

And having not-null columns without default values will break downgrade ability.

### the 1st
I added `parameters` and `parameter_mappings` to report_card in #22976 and #23003.
Changing it to `nullable`, and since the `parameter-list` toucan's property already handle converting `null` to an empty seq so we should be okay.

### the 2nd
I added `type` column to `metabase_fieldvalues` in #23435.
Changing it to `varchar` so that we could specify a default value for it.

**Questions**: should I add migrations to remove the not-null constraints and change type, or removing these migrations is okay? I believe we could do this if it was not released?

---

Note that MySQL doesn't support defaultValue for `longtext` type, that's why we can't use `defaultValue` for `text` columns