### PR TITLE
Manual backport of 20863

### DIFF
--- a/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.jsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.jsx
@@ -14,6 +14,7 @@ const propTypes = {
   database: PropTypes.object.isRequired,
   deleteDatabase: PropTypes.func.isRequired,
   syncDatabaseSchema: PropTypes.func.isRequired,
+  dismissSyncSpinner: PropTypes.func.isRequired,
   rescanDatabaseFields: PropTypes.func.isRequired,
   discardSavedFieldValues: PropTypes.func.isRequired,
   isAdmin: PropTypes.bool,
@@ -23,6 +24,7 @@ const DatabaseEditAppSidebar = ({
   database,
   deleteDatabase,
   syncDatabaseSchema,
+  dismissSyncSpinner,
   rescanDatabaseFields,
   discardSavedFieldValues,
   isAdmin,
@@ -61,6 +63,18 @@ const DatabaseEditAppSidebar = ({
                 successText={t`Scan triggered!`}
               />
             </li>
+            {database["initial_sync_status"] !== "complete" && (
+              <li className="mt2">
+                <ActionButton
+                  actionFn={() => dismissSyncSpinner(database.id)}
+                  className="Button Button--dismissSyncSpinner"
+                  normalText={t`Dismiss sync spinner manually`}
+                  activeText={t`Dismissing…`}
+                  failedText={t`Failed to dismiss sync spinner`}
+                  successText={t`Sync spinners dismissed!`}
+                />
+              </li>
+            )}
           </ol>
         </div>
 

--- a/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.unit.spec.js
+++ b/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.unit.spec.js
@@ -36,6 +36,25 @@ it("rescans database field values", () => {
   expect(rescanDatabaseFields).toHaveBeenCalledWith(databaseId);
 });
 
+it("can cancel sync and just forgets about initial sync (#20863)", () => {
+  const databaseId = 1;
+  const database = {
+    id: databaseId,
+    initial_sync_status: "incomplete",
+    supportsPersistence: () => true,
+    isPersisted: () => false,
+  };
+  const dismissSyncSpinner = jest.fn();
+
+  render(
+    <Sidebar database={database} dismissSyncSpinner={dismissSyncSpinner} />,
+  );
+
+  const dismissButton = screen.getByText("Dismiss sync spinner manually");
+  fireEvent.click(dismissButton);
+  expect(dismissSyncSpinner).toHaveBeenCalledWith(databaseId);
+});
+
 it("discards saved field values", () => {
   const databaseId = 1;
   const database = { id: databaseId, initial_sync_status: "complete" };

--- a/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx
@@ -28,6 +28,7 @@ import {
   initializeDatabase,
   saveDatabase,
   syncDatabaseSchema,
+  dismissSyncSpinner,
   rescanDatabaseFields,
   discardSavedFieldValues,
   deleteDatabase,
@@ -61,6 +62,7 @@ const mapDispatchToProps = {
   initializeDatabase,
   saveDatabase,
   syncDatabaseSchema,
+  dismissSyncSpinner,
   rescanDatabaseFields,
   discardSavedFieldValues,
   deleteDatabase,
@@ -81,6 +83,7 @@ export default class DatabaseEditApp extends Component {
     reset: PropTypes.func.isRequired,
     initializeDatabase: PropTypes.func.isRequired,
     syncDatabaseSchema: PropTypes.func.isRequired,
+    dismissSyncSpinner: PropTypes.func.isRequired,
     rescanDatabaseFields: PropTypes.func.isRequired,
     discardSavedFieldValues: PropTypes.func.isRequired,
     deleteDatabase: PropTypes.func.isRequired,
@@ -104,6 +107,7 @@ export default class DatabaseEditApp extends Component {
       initializeError,
       rescanDatabaseFields,
       syncDatabaseSchema,
+      dismissSyncSpinner,
       isAdmin,
     } = this.props;
     const editingExistingDatabase = database?.id != null;
@@ -193,6 +197,7 @@ export default class DatabaseEditApp extends Component {
               discardSavedFieldValues={discardSavedFieldValues}
               rescanDatabaseFields={rescanDatabaseFields}
               syncDatabaseSchema={syncDatabaseSchema}
+              dismissSyncSpinner={dismissSyncSpinner}
             />
           )}
         </DatabaseEditMain>

--- a/frontend/src/metabase/admin/databases/database.js
+++ b/frontend/src/metabase/admin/databases/database.js
@@ -31,6 +31,8 @@ export const ADDING_SAMPLE_DATABASE =
 export const DELETE_DATABASE = "metabase/admin/databases/DELETE_DATABASE";
 export const SYNC_DATABASE_SCHEMA =
   "metabase/admin/databases/SYNC_DATABASE_SCHEMA";
+export const DISMISS_SYNC_SPINNER =
+  "metabase/admin/databases/DISMISS_SYNC_SPINNER";
 export const RESCAN_DATABASE_FIELDS =
   "metabase/admin/databases/RESCAN_DATABASE_FIELDS";
 export const DISCARD_SAVED_FIELD_VALUES =
@@ -246,6 +248,19 @@ export const syncDatabaseSchema = createThunkAction(
         return call;
       } catch (error) {
         console.log("error syncing database", error);
+      }
+    };
+  },
+);
+
+export const dismissSyncSpinner = createThunkAction(
+  DISMISS_SYNC_SPINNER,
+  function(databaseId) {
+    return async function(dispatch, getState) {
+      try {
+        await MetabaseApi.db_dismiss_sync_spinner({ dbId: databaseId });
+      } catch (error) {
+        console.log("error dismissing sync spinner for database", error);
       }
     };
   },

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -261,6 +261,7 @@ export const MetabaseApi = {
     "/api/database/:dbId/autocomplete_suggestions?search=:prefix",
   ),
   db_sync_schema: POST("/api/database/:dbId/sync_schema"),
+  db_dismiss_sync_spinner: POST("/api/database/:dbId/dismiss_spinner"),
   db_rescan_values: POST("/api/database/:dbId/rescan_values"),
   db_discard_values: POST("/api/database/:dbId/discard_values"),
   db_get_db_ids_with_deprecated_drivers: GET("/db-ids-with-deprecated-drivers"),

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -30,7 +30,6 @@
             [metabase.sync.schedules :as sync.schedules]
             [metabase.sync.sync-metadata :as sync-metadata]
             [metabase.sync.util :as sync-util]
-            [metabase.task.persist-refresh :as task.persist-refresh]
             [metabase.util :as u]
             [metabase.util.cron :as cron-util]
             [metabase.util.i18n :refer [deferred-tru trs tru]]

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -711,6 +711,18 @@
             (is (= true
                    (deref analyze-called? long-timeout :analyze-never-called)))))))))
 
+(deftest dismiss-spinner-test
+  (testing "Can we dismiss the spinner? (#20863)"
+    (mt/with-temp* [Database [db    {:engine "h2", :details (:details (mt/db)) :initial_sync_status "incomplete"}]
+                    Table    [table {:db_id (u/the-id db) :initial_sync_status "incomplete"}]]
+      (mt/user-http-request :crowberto :post 200 (format "database/%d/dismiss_spinner" (u/the-id db)))
+      (testing "dismissed db spinner"
+        (is (= "complete" (:initial_sync_status
+                            (mt/user-http-request :crowberto :get 200 (format "database/%d" (u/the-id db)))))))
+      (testing "dismissed table spinner"
+        (is (= "complete" (:initial_sync_status
+                            (mt/user-http-request :crowberto :get 200 (format "table/%d" (u/the-id table))))))))))
+
 (deftest non-admins-cant-trigger-sync
   (testing "Non-admins should not be allowed to trigger sync"
     (is (= "You don't have permissions to do that."


### PR DESCRIPTION
Original PR message:

Pursuant to #20863.

Some syncs (viz., the ones in mongo, in the #20863 ticket, but there seem to be others) don't mutate the initial_sync_status in metabase database object properly. I looked into directly fixing in mongodb and then found that this was also the case in some others of the DB's so we can't really 100% trust that initial_sync_status to be set automatically generally.

This creates a pretty unhappy UX where, if you have mongo, that sync spinner just stays there forever. Flamber details a workaround to it in #20863 which is... reaching into metabase app DB and mutating stuff. Not ideal.

This adds a button to the admin panel for a DB that appears if (and only if) the sync status isn't complete to just coerce the sync status of DB and tables under DB to be complete. Screenshot of button existing attached.