### PR TITLE
Cleanup collection breadcrumbs

### DIFF
--- a/frontend/src/metabase/nav/components/CollectionBreadcrumbs/CollectionBreadcrumbs.styled.tsx
+++ b/frontend/src/metabase/nav/components/CollectionBreadcrumbs/CollectionBreadcrumbs.styled.tsx
@@ -12,14 +12,17 @@ export const PathSeparator = styled.div`
   display: flex;
   align-items: center;
   color: ${color("text-light")};
+  font-size: 0.8em;
+  font-weight: bold;
   margin-left: 0.5rem;
   margin-right: 0.5rem;
+  user-select: none;
 `;
 
 export const ExpandButton = styled(Button)`
   border: none;
-  padding: 0 5px;
   margin: 0;
+  padding: 0.25rem;
   background-color: ${color("bg-light")};
   border-radius: 2px;
   color: ${color("text-medium")};

--- a/frontend/src/metabase/nav/components/CollectionBreadcrumbs/CollectionBreadcrumbs.tsx
+++ b/frontend/src/metabase/nav/components/CollectionBreadcrumbs/CollectionBreadcrumbs.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { useToggle } from "metabase/hooks/use-toggle";
 import { isRootCollection } from "metabase/collections/utils";
-import Icon from "metabase/components/Icon";
 import CollectionBadge from "metabase/questions/components/CollectionBadge";
 import { Collection } from "metabase-types/api";
 import {
@@ -35,7 +34,7 @@ export const CollectionBreadcrumbs = ({
           inactiveColor="text-medium"
           isSingleLine
         />
-        <CollectionSeparator onClick={toggle} />
+        <PathSeparator>/</PathSeparator>
         <ExpandButton
           small
           borderless
@@ -44,7 +43,7 @@ export const CollectionBreadcrumbs = ({
           onlyIcon
           onClick={toggle}
         />
-        <CollectionSeparator onClick={toggle} />
+        <PathSeparator>/</PathSeparator>
       </>
     ) : (
       parts.map(collection => (
@@ -54,7 +53,7 @@ export const CollectionBreadcrumbs = ({
             inactiveColor="text-medium"
             isSingleLine
           />
-          <CollectionSeparator onClick={toggle} />
+          <PathSeparator>/</PathSeparator>
         </>
       ))
     );
@@ -70,15 +69,5 @@ export const CollectionBreadcrumbs = ({
     </PathContainer>
   );
 };
-
-interface CollectionSeparatorProps {
-  onClick: () => void;
-}
-
-const CollectionSeparator = ({ onClick }: CollectionSeparatorProps) => (
-  <PathSeparator onClick={onClick}>
-    <Icon name="chevronright" size={8} />
-  </PathSeparator>
-);
 
 export default CollectionBreadcrumbs;


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/22826

Some styles tweaking for collection breadcrumbs in the app bar.

How to test:
- Open a saved question in a nested collection
- Close the sidebar
- Make sure that `/` is used for dividers in collection breadcrumbs

<img width="1077" alt="Screenshot 2022-07-06 at 13 14 04" src="https://user-images.githubusercontent.com/8542534/177527939-6013d126-63ed-4ba2-8b70-6514afec51cc.png">
<img width="1053" alt="Screenshot 2022-07-06 at 13 14 20" src="https://user-images.githubusercontent.com/8542534/177527952-fb9611bc-db29-4d83-a979-073ca5ed05e9.png">
