### PR TITLE
Fix summarize button color

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.styled.jsx
@@ -54,7 +54,7 @@ export const SavedQuestionHeaderButtonContainer = styled.div`
 export const HeaderButton = styled(Button)`
   font-size: 0.875rem;
   background-color: ${({ active, color = getDefaultColor() }) =>
-    active ? alpha(color, 0.8) : "transparent"};
+    active ? color : "transparent"};
   color: ${({ active }) => (active ? "white" : color("text-dark"))};
   &:hover {
     background-color: ${({ color = getDefaultColor() }) => alpha(color, 0.15)};


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/22826

Makes the button to have the same background color as items in the sidebar have.

<img width="469" alt="Screenshot 2022-07-06 at 13 18 17" src="https://user-images.githubusercontent.com/8542534/177528616-5f968d07-d876-437b-bfd4-8527c42f2791.png">
