### PR TITLE
Upating popover with option to ignore events on trigger element

### DIFF
--- a/frontend/src/metabase/components/EntityMenu.jsx
+++ b/frontend/src/metabase/components/EntityMenu.jsx
@@ -67,6 +67,7 @@ class EntityMenu extends Component {
           hasBackground={false}
           horizontalAttachments={["left", "right"]}
           targetOffsetY={targetOffsetY || 0}
+          ignoreTrigger
         >
           {/* Note: @kdoh 10/12/17
            * React Motion has a flow type problem with children see

--- a/frontend/src/metabase/components/OnClickOutsideWrapper.jsx
+++ b/frontend/src/metabase/components/OnClickOutsideWrapper.jsx
@@ -13,7 +13,7 @@ export default class OnClickOutsideWrapper extends Component {
     children: PropTypes.node,
     backdropElement: PropTypes.object,
     handleDismissal: PropTypes.func.isRequired,
-    ignoreElement: PropTypes.node,
+    ignoreElement: PropTypes.object,
   };
 
   componentDidMount() {

--- a/frontend/src/metabase/components/OnClickOutsideWrapper.jsx
+++ b/frontend/src/metabase/components/OnClickOutsideWrapper.jsx
@@ -13,6 +13,7 @@ export default class OnClickOutsideWrapper extends Component {
     children: PropTypes.node,
     backdropElement: PropTypes.object,
     handleDismissal: PropTypes.func.isRequired,
+    ignoreElement: PropTypes.node,
   };
 
   componentDidMount() {
@@ -24,6 +25,7 @@ export default class OnClickOutsideWrapper extends Component {
         contentEl,
         backdropEl: this.props.backdropElement,
         close: () => this.props.handleDismissal(),
+        ignoreEl: this.props.ignoreElement,
       };
 
       RENDERED_POPOVERS.push(this.popoverData);

--- a/frontend/src/metabase/components/Popover/Popover.jsx
+++ b/frontend/src/metabase/components/Popover/Popover.jsx
@@ -63,11 +63,10 @@ export default class Popover extends Component {
       PropTypes.func,
       PropTypes.array,
     ]),
-    dismissOnClickOutside: PropTypes.func,
-    dismissOnEscape: PropTypes.func,
     target: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
     targetEvent: PropTypes.object,
     role: PropTypes.string,
+    ignoreTrigger: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -84,6 +83,7 @@ export default class Popover extends Component {
     autoWidth: false,
     noOnClickOutsideWrapper: false,
     containerClassName: "",
+    ignoreTrigger: false,
   };
 
   _getPopoverElement(isOpen) {
@@ -171,8 +171,7 @@ export default class Popover extends Component {
       return (
         <OnClickOutsideWrapper
           handleDismissal={this.handleDismissal}
-          dismissOnEscape={this.props.dismissOnEscape}
-          dismissOnClickOutside={this.props.dismissOnClickOutside}
+          ignoreElement={this.props.ignoreTrigger && this._getTargetElement()}
         >
           {content}
         </OnClickOutsideWrapper>

--- a/frontend/src/metabase/hooks/use-sequenced-content-close-handler.ts
+++ b/frontend/src/metabase/hooks/use-sequenced-content-close-handler.ts
@@ -4,6 +4,7 @@ import _ from "underscore";
 type PopoverData = {
   contentEl: Element;
   backdropEl?: Element;
+  ignoreEl?: Element;
   close: (e: MouseEvent | KeyboardEvent) => void;
 };
 
@@ -36,7 +37,8 @@ export function shouldClosePopover(
       mostRecentPopover === popoverData &&
       !isEventInsideElement(e, mostRecentPopover.contentEl) &&
       (!popoverData.backdropEl ||
-        isEventInsideElement(e, popoverData.backdropEl))
+        isEventInsideElement(e, popoverData.backdropEl)) &&
+      (!popoverData.ignoreEl || !isEventInsideElement(e, popoverData.ignoreEl))
     );
   }
 


### PR DESCRIPTION
Entity Menu toggle was not behaving as expected. Added an option to ignore the trigger element in popover

Before:
![chrome_nBKemenN1z](https://user-images.githubusercontent.com/1328979/177558133-26910ca5-635b-457c-8533-cf7cf304a1f2.gif)
After:
![chrome_uqZT1unNci](https://user-images.githubusercontent.com/1328979/177558236-6219db21-f5a1-4f16-bfd1-68e0f8751e0d.gif)

