### PR TITLE
Handle archived and models reverted to regular questions

### DIFF
--- a/frontend/src/metabase-types/api/models.ts
+++ b/frontend/src/metabase-types/api/models.ts
@@ -21,6 +21,8 @@ export interface ModelCacheRefreshStatus {
   error: string | null;
   active: boolean;
 
+  card_archived?: boolean;
+  card_dataset?: boolean;
   card_id: CardId;
   card_name: string;
 

--- a/frontend/src/metabase/lib/data-modeling/utils.ts
+++ b/frontend/src/metabase/lib/data-modeling/utils.ts
@@ -74,6 +74,14 @@ export function isAdHocModelQuestion(
 export function checkCanRefreshModelCache(
   refreshInfo: ModelCacheRefreshStatus,
 ) {
+  if (refreshInfo.card_archived === true) {
+    return false;
+  }
+
+  if (refreshInfo.card_dataset === false) {
+    return false;
+  }
+
   return refreshInfo.state === "persisted" || refreshInfo.state === "error";
 }
 

--- a/src/metabase/api/persist.clj
+++ b/src/metabase/api/persist.clj
@@ -31,6 +31,8 @@
                              :p.refresh_begin :p.refresh_end
                              :p.table_name :p.creator_id
                              :p.card_id [:c.name :card_name]
+                             [:c.archived :card_archived]
+                             [:c.dataset :card_dataset]
                              [:db.name :database_name]
                              [:col.id :collection_id] [:col.name :collection_name]
                              [:col.authority_level :collection_authority_level]]

--- a/src/metabase/task/persist_refresh.clj
+++ b/src/metabase/task/persist_refresh.clj
@@ -374,6 +374,17 @@
            :triggers
            (u/key-by (comp #(get % "db-id") qc/from-job-data :data))))
 
+(defn job-info-for-individual-refresh
+  "Return a set of PersistedInfo ids of all jobs scheduled for individual refreshes."
+  []
+  (some->> refresh-job-key
+           task/job-info
+           :triggers
+           (map (comp qc/from-job-data :data))
+           (filter (comp #{"individual"} #(get % "type")))
+           (map #(get % "persisted-id"))
+           set))
+
 (defn unschedule-persistence-for-database!
   "Stop refreshing tables for a given database. Should only be called when marking the database as not
   persisting. Tables will be left over and up to the caller to clean up."

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -12,7 +12,7 @@
             [metabase.api.pivots :as api.pivots]
             [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
             [metabase.http-client :as client]
-            [metabase.models :refer [Card CardBookmark Collection Dashboard Database ModerationReview Pulse PersistedInfo
+            [metabase.models :refer [Card CardBookmark Collection Dashboard Database ModerationReview PersistedInfo Pulse
                                      PulseCard PulseChannel PulseChannelRecipient Table Timeline TimelineEvent ViewLog]]
             [metabase.models.moderation-review :as moderation-review]
             [metabase.models.params.chain-filter-test :as chain-filter-test]

--- a/test/metabase/task/persist_refresh_test.clj
+++ b/test/metabase/task/persist_refresh_test.clj
@@ -1,6 +1,7 @@
 (ns metabase.task.persist-refresh-test
   (:require [clojure.test :refer :all]
             [clojurewerkz.quartzite.conversion :as qc]
+            [java-time :as t]
             [medley.core :as m]
             [metabase.models :refer [Card Database PersistedInfo TaskHistory]]
             [metabase.query-processor.timezone :as qp.timezone]
@@ -119,17 +120,22 @@
     (mt/with-temp* [Database [db {:options {:persist-models-enabled true}}]
                     Card     [model1 {:dataset true :database_id (u/the-id db)}]
                     Card     [model2 {:dataset true :database_id (u/the-id db)}]
-                    PersistedInfo [p1 {:card_id (u/the-id model1) :database_id (u/the-id db)}]
-                    PersistedInfo [p2 {:card_id (u/the-id model2) :database_id (u/the-id db)}]]
+                    Card     [archived {:archived true :dataset true :database_id (u/the-id db)}]
+                    Card     [unmodeled {:dataset false :database_id (u/the-id db)}]
+                    PersistedInfo [_p1 {:card_id (u/the-id model1) :database_id (u/the-id db)}]
+                    PersistedInfo [_p2 {:card_id (u/the-id model2) :database_id (u/the-id db)}]
+                    PersistedInfo [_parchived {:card_id (u/the-id archived) :database_id (u/the-id db)}]
+                    PersistedInfo [_punmodeled {:card_id (u/the-id unmodeled) :database_id (u/the-id db)}]]
       (testing "Calls refresh on each persisted-info row"
-        (let [call-count (atom 0)
+        (let [card-ids (atom #{})
               test-refresher (reify pr/Refresher
-                               (refresh! [_ _database _definition _dataset-query]
-                                 (swap! call-count inc)
+                               (refresh! [_ _database _definition card]
+                                 (swap! card-ids conj (:id card))
                                  {:state :success})
                                (unpersist! [_ _database _persisted-info]))]
           (#'pr/refresh-tables! (u/the-id db) test-refresher)
-          (is (= 2 @call-count))
+          (testing "Does not refresh archived cards or cards no longer models."
+            (is (= #{(u/the-id model1) (u/the-id model2)} @card-ids)))
           (is (partial= {:task "persist-refresh"
                          :task_details {:success 2 :error 0}}
                         (db/select-one TaskHistory
@@ -139,7 +145,7 @@
       (testing "Handles errors and continues"
         (let [call-count (atom 0)
               test-refresher (reify pr/Refresher
-                               (refresh! [_ _database _definition _dataset-query]
+                               (refresh! [_ _database _definition _card]
                                  (swap! call-count inc)
                                  ;; throw on first persist
                                  (when (= @call-count 1)
@@ -157,18 +163,31 @@
     (testing "Deletes any in a deletable state"
       (mt/with-temp* [Database [db {:options {:persist-models-enabled true}}]
                       Card     [model3 {:dataset true :database_id (u/the-id db)}]
+                      Card     [archived {:archived true :dataset true :database_id (u/the-id db)}]
+                      Card     [unmodeled {:dataset false :database_id (u/the-id db)}]
+                      PersistedInfo [parchived {:card_id (u/the-id archived) :database_id (u/the-id db)}]
+                      PersistedInfo [punmodeled {:card_id (u/the-id unmodeled) :database_id (u/the-id db)}]
                       PersistedInfo [deletable {:card_id (u/the-id model3) :database_id (u/the-id db)
-                                                :state "deletable"}]]
+                                                :state "deletable"
+                                                ;; need an "old enough" state change
+                                                :state_change_at (t/minus (t/local-date-time) (t/hours 2))}]]
         (let [called-on (atom #{})
               test-refresher (reify pr/Refresher
-                               (refresh! [_ _ _ _])
+                               (refresh! [_ _ _ _]
+                                 (is false "refresh! called on a model that should not be refreshed"))
                                (unpersist! [_ _database persisted-info]
                                  (swap! called-on conj (u/the-id persisted-info))))]
-          (#'pr/prune-deletables! test-refresher [deletable])
+          (testing "Query finds deletabable, archived, and unmodeled persisted infos"
+            (let [queued-for-deletion (into #{} (map :id) (#'pr/deletable-models))]
+              (doseq [deletable-persisted [deletable punmodeled parchived]]
+                (is (contains? queued-for-deletion (u/the-id deletable-persisted))))))
+          ;; we manually pass in the deleteable ones to not catch others in a running instance
+          (#'pr/prune-deletables! test-refresher [deletable parchived punmodeled])
           ;; don't assert equality if there are any deletable in the app db
-          (is (contains? @called-on (u/the-id deletable)))
+          (doseq [deletable-persisted [deletable punmodeled parchived]]
+            (is (contains? @called-on (u/the-id deletable-persisted))))
           (is (partial= {:task "unpersist-tables"
-                         :task_details {:success 1 :error 0}}
+                         :task_details {:success 3 :error 0, :skipped 0}}
                         (db/select-one TaskHistory
                                        :task "unpersist-tables"
                                        {:order-by [[:id :desc]]}))))))))


### PR DESCRIPTION
We are attempting to refresh archived cards and cards that are no longer models.

#### TODO:
- [x] don't refresh archived cards in scheduled task refreshing
- [x] don't refresh un-modeled cards in scheduled task refreshing
- [x] include card's `dataset` and `archived` status on `GET api/persist`. (currently as `"card_archived"` and `"card_dataset"` at the moment.
- [x] have manual refresh endpoint reject refreshing of archived cards or cards that are no longer models
- [x] prevent UI from offering to manually refresh these 

For the third part, I'm going to send along the card with the persisted-info on the screen
<img width="1398" alt="image" src="https://user-images.githubusercontent.com/6377293/177594299-e1d9ba4a-5ba5-49e8-b36d-47be41163fcf.png">

The UI should suppress the ability to refresh the persisted data for "no longer model" and "gonna archive". When someone picks up the FE work for this, I'm happy to do whatever you like to indicate which persisted-infos are eligible for refreshing. Options:
- just include card and FE can reimplement logic to not offer refreshing on these types
- annotate which are not eligible for refreshing (optionally include a reason? up to you to decide how that should look. I can put an opaque translated string, some "reason" snippet like "archived" (verbiage around "not-model" or "no longer model" gets weird) and you can present a translated screen on a popover on a greyed out refresh button)

Should not refresh these and should unpersist them

Updated the signature of `refresh!` in the `Refresher` protocol to take
a card instead of a dataset query so that the tests could use the card's
id for checks. The `dispatching-refresher` then calls the
`ddl.i/refresh!` multimethod with the dataset_query from the card so its
a very surface level refactoring.

Updated the stats from refreshing to be a bit smarter. It used to have a
`when` block for its check against the model's state. this meant on a
state change that prevented refreshing it would throw away accumulated
stats. Whoops. Now it records that as a skip. The check itself has grown
to check archived and dataset status of the underlying card.


#### UI Changes
Now the admin screen does not show a refresh button for archived cards or cards reverted back to regular questions:
<img width="1408" alt="image" src="https://user-images.githubusercontent.com/6377293/178019033-bb9ce687-c700-4a00-9f5e-c4f13b49aa2d.png">
