### PR TITLE
Update Filter Input Colors

### DIFF
--- a/frontend/src/metabase/admin/datamodel/components/database/ColumnItem/ColumnItem.styled.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/ColumnItem/ColumnItem.styled.tsx
@@ -7,7 +7,7 @@ interface ColumnItemInputProps {
 }
 
 export const ColumnItemInput = styled(InputBlurChange)<ColumnItemInputProps>`
-  border-color: ${color("border")};
+  border-color: ${color("border-dark")};
 
   background-color: ${props =>
     color(props.variant === "primary" ? "white" : "bg-light")};

--- a/frontend/src/metabase/components/Icon.tsx
+++ b/frontend/src/metabase/components/Icon.tsx
@@ -61,6 +61,7 @@ export const iconPropTypes = {
   tooltip: PropTypes.string,
   className: PropTypes.string,
   onClick: PropTypes.func,
+  style: PropTypes.object,
 };
 
 export type IconProps = PropTypes.InferProps<typeof iconPropTypes> & {

--- a/frontend/src/metabase/components/InputBlurChange.styled.tsx
+++ b/frontend/src/metabase/components/InputBlurChange.styled.tsx
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
-import { darken } from "metabase/lib/colors";
+import { color } from "metabase/lib/colors";
 
 export const Input = styled.input`
-  border: 1px solid ${darken("border", 0.1)};
+  border: 1px solid ${color("border-dark")};
 `;

--- a/frontend/src/metabase/components/TextInput/TextInput.styled.tsx
+++ b/frontend/src/metabase/components/TextInput/TextInput.styled.tsx
@@ -33,7 +33,7 @@ const getBorderColor = (colorScheme: ColorScheme, invalid?: boolean) => {
     return color("error");
   }
 
-  return colorScheme === "transparent" ? "transparent" : color("border");
+  return colorScheme === "transparent" ? "transparent" : color("border-dark");
 };
 
 export const Input = styled.input<InputProps>`

--- a/frontend/src/metabase/components/TokenField/TokenField.styled.tsx
+++ b/frontend/src/metabase/components/TokenField/TokenField.styled.tsx
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { color } from "metabase/lib/colors";
+import { color, alpha } from "metabase/lib/colors";
 
 export const TokenFieldItem = styled.li<{
   isValid: boolean;
@@ -9,8 +9,8 @@ export const TokenFieldItem = styled.li<{
   margin: 0 0.25rem 0.25rem 0;
   padding: 0.75rem 0.5rem;
   border-radius: 0.5rem;
-  color: ${({ isValid }) => (isValid ? "" : color("error"))};
-  background-color: ${color("bg-medium")};
+  color: ${({ isValid }) => (isValid ? color("brand") : color("error"))};
+  background-color: ${alpha("brand", 0.2)};
 `;
 
 export const TokenFieldAddon = styled.a<{

--- a/frontend/src/metabase/core/components/Input/Input.styled.tsx
+++ b/frontend/src/metabase/core/components/Input/Input.styled.tsx
@@ -25,7 +25,7 @@ export const InputField = styled.input<InputProps>`
   font-size: 1rem;
   color: ${color("text-dark")};
   padding: 0.75rem;
-  border: 1px solid ${darken("border", 0.1)};
+  border: 1px solid ${color("border")};
   border-radius: 4px;
   background-color: ${props => color(props.readOnly ? "bg-light" : "bg-white")};
   outline: none;

--- a/frontend/src/metabase/core/components/Input/Input.styled.tsx
+++ b/frontend/src/metabase/core/components/Input/Input.styled.tsx
@@ -25,7 +25,7 @@ export const InputField = styled.input<InputProps>`
   font-size: 1rem;
   color: ${color("text-dark")};
   padding: 0.75rem;
-  border: 1px solid ${color("border")};
+  border: 1px solid ${color("border-dark")};
   border-radius: 4px;
   background-color: ${props => color(props.readOnly ? "bg-light" : "bg-white")};
   outline: none;

--- a/frontend/src/metabase/core/components/SelectButton/SelectButton.styled.tsx
+++ b/frontend/src/metabase/core/components/SelectButton/SelectButton.styled.tsx
@@ -24,7 +24,7 @@ export const SelectButtonRoot = styled.button<SelectButtonRootProps>`
   padding: 0.6em;
   border: 1px solid
     ${({ hasValue, highlighted }) =>
-      hasValue && highlighted ? color("brand") : color("border")};
+      hasValue && highlighted ? color("brand") : color("border-dark")};
   background-color: ${({ hasValue, highlighted }) =>
     hasValue && highlighted ? color("brand") : color("white")};
   border-radius: 8px;

--- a/frontend/src/metabase/css/components/form.css
+++ b/frontend/src/metabase/css/components/form.css
@@ -1,5 +1,5 @@
 :root {
-  --form-field-border-color: color-mod(var(--color-border) blackness(10%));
+  --form-field-border-color: var(--color-border-dark);
 }
 ::-webkit-input-placeholder {
   color: var(--color-text-light);
@@ -55,7 +55,7 @@
 }
 .Form-file-input::before {
   background: transparent;
-  border: 1px solid color-mod(var(--color-border) blackness(5%));
+  border: 1px solid color-mod(var(--color-border-dark) blackness(5%));
   border-radius: 6px;
   box-sizing: border-box;
   color: var(--color-text-dark);

--- a/frontend/src/metabase/css/core/colors.css
+++ b/frontend/src/metabase/css/core/colors.css
@@ -31,6 +31,7 @@
   --color-focus: #cbe2f7;
   --color-shadow: rgba(0, 0, 0, 0.13);
   --color-border: #eeecec;
+  --color-border-dark: #b5bbbf;
 
   /* Saturated colors for the SQL editor. Shouldn't be used elsewhere since they're not white-labelable. */
   --color-saturated-blue: #2d86d4;

--- a/frontend/src/metabase/css/core/colors.css
+++ b/frontend/src/metabase/css/core/colors.css
@@ -31,7 +31,7 @@
   --color-focus: #cbe2f7;
   --color-shadow: rgba(0, 0, 0, 0.13);
   --color-border: #eeecec;
-  --color-border-dark: #b5bbbf;
+  --color-border-dark: #c9ced3;
 
   /* Saturated colors for the SQL editor. Shouldn't be used elsewhere since they're not white-labelable. */
   --color-saturated-blue: #2d86d4;

--- a/frontend/src/metabase/css/core/inputs.css
+++ b/frontend/src/metabase/css/core/inputs.css
@@ -1,5 +1,5 @@
 :root {
-  --input-border-color: var(--color-border);
+  --input-border-color: var(--color-border-dark);
   --input-border-active-color: var(--color-brand);
   --input-border-radius: 4px;
 }

--- a/frontend/src/metabase/lib/colors/palette.ts
+++ b/frontend/src/metabase/lib/colors/palette.ts
@@ -37,6 +37,7 @@ export const colors: ColorPalette = {
   "bg-yellow": "#FFFCF2",
   shadow: "rgba(0,0,0,0.08)",
   border: "#EEECEC",
+  "border-dark": "#B5BBBF",
 
   /* Saturated colors for the SQL editor. Shouldn't be used elsewhere since they're not white-labelable. */
   "saturated-blue": "#2D86D4",

--- a/frontend/src/metabase/lib/colors/palette.ts
+++ b/frontend/src/metabase/lib/colors/palette.ts
@@ -37,7 +37,7 @@ export const colors: ColorPalette = {
   "bg-yellow": "#FFFCF2",
   shadow: "rgba(0,0,0,0.08)",
   border: "#EEECEC",
-  "border-dark": "#B5BBBF",
+  "border-dark": "#C9CED3",
 
   /* Saturated colors for the SQL editor. Shouldn't be used elsewhere since they're not white-labelable. */
   "saturated-blue": "#2D86D4",

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineDatePicker/InlineDatePicker.styled.ts
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineDatePicker/InlineDatePicker.styled.ts
@@ -1,15 +1,11 @@
 import styled from "@emotion/styled";
 import { space } from "metabase/styled-components/theme";
-import { color, alpha, darken, lighten } from "metabase/lib/colors";
+import { color, alpha, darken } from "metabase/lib/colors";
 
 import Button from "metabase/core/components/Button";
 
 export const OptionContainer = styled.div`
-  grid-column: span 2;
-  margin: ${space(2)} 0;
-  padding-bottom: ${space(2)};
   font-weight: bold;
-  border-bottom: 1px solid ${color("border")};
 `;
 
 type OptionButtonProps = {
@@ -18,32 +14,30 @@ type OptionButtonProps = {
 };
 
 export const OptionButton = styled(Button)<OptionButtonProps>`
+  border: none;
+
   border-radius: ${space(1)};
+  padding: 13px ${space(2)};
   margin-right: ${space(1)};
   margin-bottom: ${space(1)};
-  padding-top: ${space(1)};
-  padding-bottom: ${space(1)};
 
   background-color: ${({ active }) =>
-    active ? color("brand") : color("white")};
-  color: ${({ active }) => (active ? color("white") : color("text-dark"))};
-  border-color: ${({ active }) => (active ? "transparent" : color("border"))};
+    active ? alpha("brand", 0.2) : "transparent"};
+  color: ${({ active }) => (active ? color("brand") : color("text-dark"))};
 
   &:hover {
     background-color: ${({ active }) =>
-      active ? alpha("brand", 0.8) : alpha("brand", 0.2)};
-    color: ${({ active }) => (active ? color("white") : color("text-dark"))};
-    border-color: ${({ active }) =>
-      active ? alpha("brand", 0.8) : color("transparent")};
+      active ? alpha("brand", 0.35) : "transparent"};
+    color: ${color("brand")};
   }
 `;
 
 export const ClearButton = styled.span`
-  color: ${lighten("brand", 0.5)};
+  color: ${color("brand")};
   margin-left: ${space(1)};
   cursor: pointer;
 
   &:hover {
-    color: ${color("white")};
+    color: ${darken("brand", 0.2)};
   }
 `;

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineDatePicker/InlineDatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineDatePicker/InlineDatePicker.tsx
@@ -13,6 +13,7 @@ import Dimension from "metabase-lib/lib/Dimension";
 import { DATE_SHORTCUT_OPTIONS as ALL_DATE_OPTIONS } from "metabase/query_builder/components/filters/pickers/DatePicker/DatePickerShortcutOptions";
 
 import { BulkFilterSelect } from "../BulkFilterSelect";
+
 import {
   OptionButton,
   OptionContainer,
@@ -122,7 +123,7 @@ export function InlineDatePicker({
             </OptionButton>
           ) : (
             <OptionButton onClick={onClick} aria-label={t`more options`}>
-              <Icon name="ellipsis" size={14} />
+              <Icon name="ellipsis" size={14} style={{ marginBottom: -5 }} />
             </OptionButton>
           )
         }

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineValuePicker/InlineValuePicker.styled.ts
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineValuePicker/InlineValuePicker.styled.ts
@@ -16,6 +16,12 @@ export const ArgumentSelector = styled(FieldValuesWidget)`
 
 export const ValuesPickerContainer = styled.div`
   grid-column: 2;
+  ul.input {
+    margin-bottom: 0;
+  }
+  input {
+    color: ${color("brand")};
+  }
 `;
 
 export const BetweenContainer = styled.div`
@@ -32,6 +38,5 @@ export const NumberSeparator = styled.span`
 `;
 
 export const NumberInput = styled(NumericInput)`
-  border-color: ${color("border")};
   width: 10rem;
 `;


### PR DESCRIPTION
## Description
This is a small collection of changes aimed at making it clearer which filters are "active" at a glance. It also improves consistency in a few places

## Overview

image | change description
--- | ---
![Screen Shot 2022-07-06 at 11 13 26 AM](https://user-images.githubusercontent.com/30528226/177606675-736d85f3-c6cf-4fe8-85ce-4d4b13be19f2.png) | set numbers to blue in this modal only to highlight that they're active
![Screen Shot 2022-07-06 at 11 12 15 AM](https://user-images.githubusercontent.com/30528226/177606677-e2cc66bb-a38c-4fb4-b1ec-9ce4fdb3b613.png) | global change: use muted brand colors on token fields
![Screen Shot 2022-07-06 at 11 11 16 AM](https://user-images.githubusercontent.com/30528226/177606680-41938cd3-323c-4f36-a22e-d43b05d5a2ae.png) | update date picker to use more muted colors and fewer borders. Also moves the `...` icon down a bit since it looks funny centered next to text
![Screen Shot 2022-07-06 at 12 16 11 PM](https://user-images.githubusercontent.com/30528226/177616437-22fb4daa-e2b0-4182-b3ec-b3854aa3095c.png) | global change: make all inputs have the same border color: `border-dark`
