### PR TITLE
Add validCheckSum:ANY to some migrations I change in #23723

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -11796,6 +11796,7 @@ databaseChangeLog:
       id: v44.00-023
       author: qnkhuat
       comment: Added 0.44.0 - Add parameters to report_card
+      validCheckSum: ANY
       changes:
         - addColumn:
             tableName: report_card
@@ -11810,6 +11811,7 @@ databaseChangeLog:
       id: v44.00-025
       author: qnkhuat
       comment: Added 0.44.0 - Add parameter_mappings to report_card
+      validCheckSum: ANY
       changes:
         - addColumn:
             tableName: report_card
@@ -11887,6 +11889,7 @@ databaseChangeLog:
       id: v44.00-035
       author: qnkhuat
       comment: Added 0.44.0. Add type to fieldvalues
+      validCheckSum: ANY
       changes:
         - addColumn:
             tableName: metabase_fieldvalues


### PR DESCRIPTION
I made some updates to existing migrations in #23723 and it broke the existing DBs.

Add validCheckSum:ANY to fix those errors.

Error message
```
2022-07-06 09:53:24,077 INFO db.liquibase :: Checking if Database has unrun migrations...
2022-07-06 09:53:25,757 ERROR metabase.core :: Metabase Initialization FAILED
liquibase.exception.ValidationFailedException: Validation Failed:
     3 change sets check sum
          migrations/000_migrations.yaml::v44.00-023::qnkhuat was: 8:ade53f1b54cf6ffd8ad1bdb7b0034ca1 but is now: 8:493153694fde9482c906922a6c63bf88
          migrations/000_migrations.yaml::v44.00-025::qnkhuat was: 8:1533aeb62bd0ee4ff761c4e7c280e046 but is now: 8:653792e7485e6c6d9063cdd085d8584c
          migrations/000_migrations.yaml::v44.00-035::qnkhuat was: 8:17a45faefa9345e908906fbc9a664ae0 but is now: 8:38dcbf6c407d7a19591ea6c7baa287e3
```