### PR TITLE
Fixing Model Metadata and a dashboard test

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard/reproductions/17160-click-behavior-multiple-options.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/reproductions/17160-click-behavior-multiple-options.cy.spec.js
@@ -25,7 +25,9 @@ describe("issue 17160", () => {
     });
 
     // Check click behavior connected to a question
-    cy.findAllByText("click-behavior-question-label").eq(0).click();
+    cy.findAllByText("click-behavior-question-label")
+      .eq(0)
+      .click();
 
     cy.url().should("include", "/question");
 
@@ -35,10 +37,12 @@ describe("issue 17160", () => {
     cy.go("back");
 
     // Check click behavior connected to a dashboard
-    cy.findAllByText("click-behavior-dashboard-label").eq(0).click();
+    cy.findAllByText("click-behavior-dashboard-label")
+      .eq(0)
+      .click();
 
     cy.url().should("include", "/dashboard");
-    cy.findByText(TARGET_DASHBOARD_NAME);
+    cy.findByDisplayValue(TARGET_DASHBOARD_NAME);
 
     assertMultipleValuesFilterState();
   });
@@ -67,7 +71,9 @@ describe("issue 17160", () => {
     });
 
     // Check click behavior connected to a question
-    cy.findAllByText("click-behavior-question-label").eq(0).click();
+    cy.findAllByText("click-behavior-question-label")
+      .eq(0)
+      .click();
 
     cy.url().should("include", "/public/question");
 
@@ -77,7 +83,9 @@ describe("issue 17160", () => {
     cy.go("back");
 
     // Check click behavior connected to a dashboard
-    cy.findAllByText("click-behavior-dashboard-label").eq(0).click();
+    cy.findAllByText("click-behavior-dashboard-label")
+      .eq(0)
+      .click();
 
     cy.url().should("include", "/public/dashboard");
     cy.findByText(TARGET_DASHBOARD_NAME);

--- a/frontend/test/metabase/scenarios/dashboard/reproductions/17160-click-behavior-multiple-options.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/reproductions/17160-click-behavior-multiple-options.cy.spec.js
@@ -38,7 +38,8 @@ describe("issue 17160", () => {
     cy.findAllByText("click-behavior-dashboard-label").eq(0).click();
 
     cy.url().should("include", "/dashboard");
-    cy.findByDisplayValue(TARGET_DASHBOARD_NAME);
+    cy.location("search").should("eq", "?category=Doohickey&category=Gadget");
+    cy.findByText(TARGET_DASHBOARD_NAME);
 
     assertMultipleValuesFilterState();
   });
@@ -80,6 +81,7 @@ describe("issue 17160", () => {
     cy.findAllByText("click-behavior-dashboard-label").eq(0).click();
 
     cy.url().should("include", "/public/dashboard");
+    cy.location("search").should("eq", "?category=Doohickey&category=Gadget");
     cy.findByText(TARGET_DASHBOARD_NAME);
 
     assertMultipleValuesFilterState();
@@ -166,7 +168,6 @@ function setup(shouldUsePublicLinks) {
                 },
               ],
             });
-
             visitDashboard(dashboardId);
           });
         });

--- a/frontend/test/metabase/scenarios/dashboard/reproductions/17160-click-behavior-multiple-options.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/reproductions/17160-click-behavior-multiple-options.cy.spec.js
@@ -25,9 +25,7 @@ describe("issue 17160", () => {
     });
 
     // Check click behavior connected to a question
-    cy.findAllByText("click-behavior-question-label")
-      .eq(0)
-      .click();
+    cy.findAllByText("click-behavior-question-label").eq(0).click();
 
     cy.url().should("include", "/question");
 
@@ -37,9 +35,7 @@ describe("issue 17160", () => {
     cy.go("back");
 
     // Check click behavior connected to a dashboard
-    cy.findAllByText("click-behavior-dashboard-label")
-      .eq(0)
-      .click();
+    cy.findAllByText("click-behavior-dashboard-label").eq(0).click();
 
     cy.url().should("include", "/dashboard");
     cy.findByDisplayValue(TARGET_DASHBOARD_NAME);
@@ -71,9 +67,7 @@ describe("issue 17160", () => {
     });
 
     // Check click behavior connected to a question
-    cy.findAllByText("click-behavior-question-label")
-      .eq(0)
-      .click();
+    cy.findAllByText("click-behavior-question-label").eq(0).click();
 
     cy.url().should("include", "/public/question");
 
@@ -83,9 +77,7 @@ describe("issue 17160", () => {
     cy.go("back");
 
     // Check click behavior connected to a dashboard
-    cy.findAllByText("click-behavior-dashboard-label")
-      .eq(0)
-      .click();
+    cy.findAllByText("click-behavior-dashboard-label").eq(0).click();
 
     cy.url().should("include", "/public/dashboard");
     cy.findByText(TARGET_DASHBOARD_NAME);

--- a/frontend/test/metabase/scenarios/models/models-metadata.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models-metadata.cy.spec.js
@@ -37,16 +37,21 @@ describe("scenarios > models metadata", () => {
     openQuestionActions();
 
     popover().within(() => {
-      cy.findByTestId("tooltip-component-wrapper").parent().realHover();
-      cy.findByText("89%");
+      //Need to wait for action menu to be fully visible before hovering
+      cy.wait(500);
+      cy.findByTestId("tooltip-component-wrapper").realHover();
     });
 
+    //Tooltip has 700ms delay
+    cy.wait(700);
     cy.findByText(
       "Some columns are missing a column type, description, or friendly name.",
     );
     cy.findByText(
       "Adding metadata makes it easier for your team to explore this data.",
     );
+
+    cy.findByText("89%");
 
     cy.findByText("Edit metadata").click();
 
@@ -81,16 +86,21 @@ describe("scenarios > models metadata", () => {
     openQuestionActions();
 
     popover().within(() => {
-      cy.findByTestId("tooltip-component-wrapper").parent().realHover();
-      cy.findByText("37%");
+      //Need to wait for action menu to be fully visible before hovering
+      cy.wait(500);
+      cy.findByTestId("tooltip-component-wrapper").realHover();
     });
 
+    //Tooltip has 700ms delay
+    cy.wait(700);
     cy.findByText(
       "Most columns are missing a column type, description, or friendly name.",
     );
     cy.findByText(
       "Adding metadata makes it easier for your team to explore this data.",
     );
+
+    cy.findByText("37%");
 
     cy.findByText("Edit metadata").click();
 
@@ -158,7 +168,9 @@ describe("scenarios > models metadata", () => {
 
     rightSidebar().within(() => {
       cy.findByText("History");
-      cy.findAllByTestId("question-revert-button").first().click();
+      cy.findAllByTestId("question-revert-button")
+        .first()
+        .click();
     });
 
     cy.wait("@revert");
@@ -275,10 +287,18 @@ describe("scenarios > models metadata", () => {
 });
 
 function drillFK({ id }) {
-  cy.get(".Table-FK").contains(id).first().click();
-  popover().findByText("View details").click();
+  cy.get(".Table-FK")
+    .contains(id)
+    .first()
+    .click();
+  popover()
+    .findByText("View details")
+    .click();
 }
 
 function drillDashboardFK({ id }) {
-  cy.get(".Table-FK").contains(id).first().click();
+  cy.get(".Table-FK")
+    .contains(id)
+    .first()
+    .click();
 }

--- a/frontend/test/metabase/scenarios/models/models-metadata.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models-metadata.cy.spec.js
@@ -37,9 +37,7 @@ describe("scenarios > models metadata", () => {
     openQuestionActions();
 
     popover().within(() => {
-      //Need to wait for action menu to be fully visible before hovering
-      cy.findByTestId("tooltip-component-wrapper").should("be.visible");
-      cy.findByTestId("tooltip-component-wrapper").realHover();
+      cy.findByTextEnsureVisible("89%").trigger("mouseenter");
     });
 
     cy.findByText(
@@ -48,8 +46,6 @@ describe("scenarios > models metadata", () => {
     cy.findByText(
       "Adding metadata makes it easier for your team to explore this data.",
     );
-
-    cy.findByText("89%");
 
     cy.findByText("Edit metadata").click();
 
@@ -84,9 +80,7 @@ describe("scenarios > models metadata", () => {
     openQuestionActions();
 
     popover().within(() => {
-      //Need to wait for action menu to be fully visible before hovering
-      cy.findByTestId("tooltip-component-wrapper").should("be.visible");
-      cy.findByTestId("tooltip-component-wrapper").realHover();
+      cy.findByTextEnsureVisible("37%").trigger("mouseenter");
     });
 
     cy.findByText(
@@ -95,8 +89,6 @@ describe("scenarios > models metadata", () => {
     cy.findByText(
       "Adding metadata makes it easier for your team to explore this data.",
     );
-
-    cy.findByText("37%");
 
     cy.findByText("Edit metadata").click();
 

--- a/frontend/test/metabase/scenarios/models/models-metadata.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models-metadata.cy.spec.js
@@ -38,12 +38,10 @@ describe("scenarios > models metadata", () => {
 
     popover().within(() => {
       //Need to wait for action menu to be fully visible before hovering
-      cy.wait(500);
+      cy.findByTestId("tooltip-component-wrapper").should("be.visible");
       cy.findByTestId("tooltip-component-wrapper").realHover();
     });
 
-    //Tooltip has 700ms delay
-    cy.wait(700);
     cy.findByText(
       "Some columns are missing a column type, description, or friendly name.",
     );
@@ -87,12 +85,10 @@ describe("scenarios > models metadata", () => {
 
     popover().within(() => {
       //Need to wait for action menu to be fully visible before hovering
-      cy.wait(500);
+      cy.findByTestId("tooltip-component-wrapper").should("be.visible");
       cy.findByTestId("tooltip-component-wrapper").realHover();
     });
 
-    //Tooltip has 700ms delay
-    cy.wait(700);
     cy.findByText(
       "Most columns are missing a column type, description, or friendly name.",
     );
@@ -168,9 +164,7 @@ describe("scenarios > models metadata", () => {
 
     rightSidebar().within(() => {
       cy.findByText("History");
-      cy.findAllByTestId("question-revert-button")
-        .first()
-        .click();
+      cy.findAllByTestId("question-revert-button").first().click();
     });
 
     cy.wait("@revert");
@@ -287,18 +281,10 @@ describe("scenarios > models metadata", () => {
 });
 
 function drillFK({ id }) {
-  cy.get(".Table-FK")
-    .contains(id)
-    .first()
-    .click();
-  popover()
-    .findByText("View details")
-    .click();
+  cy.get(".Table-FK").contains(id).first().click();
+  popover().findByText("View details").click();
 }
 
 function drillDashboardFK({ id }) {
-  cy.get(".Table-FK")
-    .contains(id)
-    .first()
-    .click();
+  cy.get(".Table-FK").contains(id).first().click();
 }


### PR DESCRIPTION
Small adjustments to a couple of test cases.
- click-behavior-multiple-options was passing locally, but there were other places where I needed to look for display value rather than text with regards to text areas
- models-metadata adjusted the hover logic to make it much more reliable. It was failing locally and I suspect it only passed in CI when things were bogged down. Now passes reliably locally
