### PR TITLE
Actions test util refactor. Add tests for `GET /api/action` and `GET /api/action/:id` endpoints

### DIFF
--- a/test/metabase/actions/test_util.clj
+++ b/test/metabase/actions/test_util.clj
@@ -2,8 +2,10 @@
   (:require
    [clojure.java.jdbc :as jdbc]
    [clojure.test :refer :all]
+   [metabase.actions.test-util :as actions.test-util]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
-   [metabase.models.database :refer [Database]]
+   [metabase.models
+    :refer [Card CardEmitter Database Emitter EmitterAction QueryAction]]
    [metabase.test :as mt]
    [metabase.test.data.dataset-definitions :as defs]
    [metabase.test.data.impl :as data.impl]
@@ -64,3 +66,79 @@
             (testing "after"
               (is (= [[74]]
                      (row-count))))))))))
+
+(defn do-with-query-action
+  "Impl for [[with-query-action]]."
+  [f]
+  (mt/with-temp* [Card [{card-id :id} {:database_id   (mt/id)
+                                       :dataset_query {:database (mt/id)
+                                                       :type     :native
+                                                       :native   {:query         (str "UPDATE categories\n"
+                                                                                      "SET name = 'Bird Shop'\n"
+                                                                                      "WHERE id = {{id}}")
+                                                                  :template-tags {"id" {:name         "id"
+                                                                                        :display-name "ID"
+                                                                                        :type         :number
+                                                                                        :required     true}}}}
+                                       :is_write      true}]]
+    (let [action-id (db/select-one-field :action_id QueryAction :card_id card-id)]
+      (f {:query-action-card-id card-id
+          :action-id            action-id}))))
+
+(defmacro with-query-action
+  "Execute `body` with a newly created QueryAction. `bindings` is a map with keys `:action-id` and
+  `:query-action-card-id`.
+
+    (with-query-action [{:keys [action-id query-action-card-id], :as context}]
+      (do-something))"
+  {:style/indent 1}
+  [[bindings] & body]
+  `(do-with-query-action (fn [~bindings] ~@body)))
+
+(defn do-with-card-emitter
+  "Impl for [[with-card-emitter]]."
+  [{:keys [action-id], :as context} f]
+  (mt/with-temp* [Card    [{emitter-card-id :id}]
+                  Emitter [{emitter-id :id} {:parameter_mappings {"my_id" [:variable [:template-tag "id"]]}}]]
+    (testing "Sanity check: emitter-id should be non-nil"
+      (is (integer? emitter-id)))
+    (testing "Sanity check: make sure parameter mappings were defined the way we'd expect"
+      (is (= {:my_id [:variable [:template-tag "id"]]}
+             (db/select-one-field :parameter_mappings Emitter :id emitter-id))))
+    ;; these are tied to the Card and Emitter above and will get cascade deleted. We can't use `with-temp*` for them
+    ;; because it doesn't seem to work with tables with compound PKs
+    (db/insert! EmitterAction {:emitter_id emitter-id
+                               :action_id action-id})
+    (db/insert! CardEmitter {:card_id   emitter-card-id
+                             :action_id action-id})
+    (f (assoc context
+              :emitter-id      emitter-id
+              :emitter-card-id emitter-card-id))))
+
+(defmacro with-card-emitter
+  "Execute `body` with a newly created CardEmitter created for an Action with `:action-id`. Intended for use with the
+  `context` returned by with [[with-query-action]]. `bindings` is bound to a map with the keys `:emitter-id` and
+  `:emitter-card-id`.
+
+    (with-query-action [{:keys [action-id query-action-card-id], :as context}]
+      (with-card-emitter [{:keys [emitter-id emitter-card-id]} context]
+        (do-something)))"
+  {:style/indent 1, :arglists '([bindings {:keys [action-id], :as _action}] & body)}
+  [[bindings action] & body]
+  `(do-with-card-emitter ~action (fn [~bindings] ~@body)))
+
+
+(defn do-with-actions-setup
+  "Impl for [[with-actions-setup]]."
+  [thunk]
+  (with-actions-test-data
+    (mt/with-temporary-setting-values [experimental-enable-actions true]
+      (mt/with-temp-vals-in-db Database (mt/id) {:settings {:database-enable-actions true}}
+        (thunk)))))
+
+(defmacro with-actions-setup
+  "Execute `body` with the actions test dataset via [[with-actions-test-data]], which can be freely modified, as it is
+  recreated on each use. Enables actions at the global level and for the current test Database."
+  {:style/indent 0}
+  [& body]
+  `(do-with-actions-setup (fn [] ~@body)))

--- a/test/metabase/actions/test_util.clj
+++ b/test/metabase/actions/test_util.clj
@@ -2,7 +2,6 @@
   (:require
    [clojure.java.jdbc :as jdbc]
    [clojure.test :refer :all]
-   [metabase.actions.test-util :as actions.test-util]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.models
     :refer [Card CardEmitter Database Emitter EmitterAction QueryAction]]

--- a/test/metabase/actions/test_util.clj
+++ b/test/metabase/actions/test_util.clj
@@ -127,18 +127,23 @@
   [[bindings action] & body]
   `(do-with-card-emitter ~action (fn [~bindings] ~@body)))
 
-
-(defn do-with-actions-setup
-  "Impl for [[with-actions-setup]]."
+(defn do-with-actions-enabled
+  "Impl for [[with-actions-enabled]]."
   [thunk]
-  (with-actions-test-data
-    (mt/with-temporary-setting-values [experimental-enable-actions true]
-      (mt/with-temp-vals-in-db Database (mt/id) {:settings {:database-enable-actions true}}
-        (thunk)))))
+  (mt/with-temporary-setting-values [experimental-enable-actions true]
+    (mt/with-temp-vals-in-db Database (mt/id) {:settings {:database-enable-actions true}}
+      (thunk))))
 
-(defmacro with-actions-setup
-  "Execute `body` with the actions test dataset via [[with-actions-test-data]], which can be freely modified, as it is
-  recreated on each use. Enables actions at the global level and for the current test Database."
+(defmacro with-actions-enabled
+  "Execute `body` with Actions enabled at the global level and for the current test Database."
   {:style/indent 0}
   [& body]
-  `(do-with-actions-setup (fn [] ~@body)))
+  `(do-with-actions-enabled (fn [] ~@body)))
+
+(defmacro with-actions-test-data-and-actions-enabled
+  "Combines [[with-actions-test-data]] and [[with-actions-enabled]]."
+  {:style/indent 0}
+  [& body]
+  `(with-actions-test-data
+     (with-actions-enabled
+       (fn [] ~@body))))

--- a/test/metabase/api/action_test.clj
+++ b/test/metabase/api/action_test.clj
@@ -19,7 +19,7 @@
   "Expected schema for a CardAction as it should appear in the response for an API request to one of the GET endpoints."
   {:id       su/IntGreaterThanOrEqualToZero
    :card     {:id            su/IntGreaterThanOrEqualToZero
-              :dataset_query {:database (s/eq (mt/id))
+              :dataset_query {:database su/IntGreaterThanOrEqualToZero
                               :type     (s/eq "native")
                               :native   {:query    s/Str
                                          s/Keyword s/Any}

--- a/test/metabase/api/action_test.clj
+++ b/test/metabase/api/action_test.clj
@@ -9,9 +9,49 @@
    [metabase.models.table :refer [Table]]
    [metabase.query-processor :as qp]
    [metabase.test :as mt]
-   [metabase.util :as u]))
+   [metabase.util :as u]
+   [metabase.util.schema :as su]
+   [schema.core :as s]))
 
 (comment api.action/keep-me)
+
+(def ^:private ExpectedGetCardActionAPIResponse
+  "Expected schema for a CardAction as it should appear in the response for an API request to one of the GET endpoints."
+  {:id       su/IntGreaterThanOrEqualToZero
+   :card     {:id            su/IntGreaterThanOrEqualToZero
+              :dataset_query {:database (s/eq (mt/id))
+                              :type     (s/eq "native")
+                              :native   {:query    s/Str
+                                         s/Keyword s/Any}
+                              s/Keyword s/Any}
+              s/Keyword      s/Any}
+   s/Keyword s/Any})
+
+(deftest list-actions-test
+  (testing "GET /api/action"
+    (actions.test-util/with-actions-enabled
+      (actions.test-util/with-query-action [{:keys [action-id]}]
+        (let [response (mt/user-http-request :crowberto :get 200 "action")]
+          (is (schema= [{:id       su/IntGreaterThanZero
+                         s/Keyword s/Any}]
+                       response))
+          (let [action (some (fn [action]
+                               (when (= (:id action) action-id)
+                                 action))
+                             response)]
+            (testing "Should return Card dataset_query deserialized (#23201)"
+              (is (schema= ExpectedGetCardActionAPIResponse
+                           action)))))))))
+
+(deftest get-action-test
+  (testing "GET /api/action/:id"
+    (testing "Should return Card dataset_query deserialized (#23201)"
+      (actions.test-util/with-actions-enabled
+        (actions.test-util/with-query-action [{:keys [action-id]}]
+          (let [action (mt/user-http-request :crowberto :get 200 (format "action/%d" action-id))]
+            (testing "Should return Card dataset_query deserialized (#23201)"
+              (is (schema= ExpectedGetCardActionAPIResponse
+                           action)))))))))
 
 (defn- mock-requests []
   [{:action       "action/row/create"
@@ -38,40 +78,36 @@
 
 (deftest happy-path-test
   (testing "Make sure it's possible to use known actions end-to-end if preconditions are satisfied"
-    (actions.test-util/with-actions-test-data
-      (mt/with-temporary-setting-values [experimental-enable-actions true]
-        (mt/with-temp-vals-in-db Database (mt/id) {:settings {:database-enable-actions true}}
-          (doseq [{:keys [action request-body expected expect-fn]} (mock-requests)]
-            (testing action
-              (let [result (mt/user-http-request :crowberto :post 200 action request-body)]
-                (when expected (is (= expected result)))
-                (when expect-fn (expect-fn result))))))))))
+    (actions.test-util/with-actions-test-data-and-actions-enabled
+      (doseq [{:keys [action request-body expected expect-fn]} (mock-requests)]
+        (testing action
+          (let [result (mt/user-http-request :crowberto :post 200 action request-body)]
+            (when expected (is (= expected result)))
+            (when expect-fn (expect-fn result))))))))
 
 (deftest create-update-delete-test
   (testing "Make sure actions are acting on rows."
-    (actions.test-util/with-actions-test-data
-      (mt/with-temporary-setting-values [experimental-enable-actions true]
-        (mt/with-temp-vals-in-db Database (mt/id) {:settings {:database-enable-actions true}}
-          (let [[create update delete] (mock-requests)
-                {created-id :id :as created-row}
-                (:created-row (mt/user-http-request :crowberto :post 200 (:action create) (:request-body create)))]
-            (is (= [:id :name] (keys created-row))
-                "Create should return the entire row")
-            (is (= "created_row" (:name created-row))
-                "Create should return the correct value for name")
-            (is (= "created_row" (-> (mt/rows (mt/run-mbql-query categories {:filter [:= $id created-id]})) last last))
-                "The record at created-id should now have its name set to \"created_row\"")
-            (is (= (:expected update) (mt/user-http-request :crowberto :post 200 (:action update)
-                                                            (assoc (mt/mbql-query categories {:filter [:= $id created-id]})
-                                                                   :update_row {:name "updated_row"})))
-                "Update should return the right shape")
-            (is (= "updated_row" (-> (mt/rows (mt/run-mbql-query categories {:filter [:= $id created-id]})) last last))
-                "The row should actually be updated")
-            (is (= (:expected delete)
-                   (mt/user-http-request :crowberto :post 200 (:action delete) (mt/mbql-query categories {:filter [:= $id created-id]})))
-                "Delete should return the right shape")
-            (is (= [] (mt/rows (mt/run-mbql-query categories {:filter [:= $id created-id]})))
-                "Selecting for deleted rows should return an empty result")))))))
+    (actions.test-util/with-actions-test-data-and-actions-enabled
+      (let [[create update delete] (mock-requests)
+            {created-id :id :as created-row}
+            (:created-row (mt/user-http-request :crowberto :post 200 (:action create) (:request-body create)))]
+        (is (= [:id :name] (keys created-row))
+            "Create should return the entire row")
+        (is (= "created_row" (:name created-row))
+            "Create should return the correct value for name")
+        (is (= "created_row" (-> (mt/rows (mt/run-mbql-query categories {:filter [:= $id created-id]})) last last))
+            "The record at created-id should now have its name set to \"created_row\"")
+        (is (= (:expected update) (mt/user-http-request :crowberto :post 200 (:action update)
+                                                        (assoc (mt/mbql-query categories {:filter [:= $id created-id]})
+                                                               :update_row {:name "updated_row"})))
+            "Update should return the right shape")
+        (is (= "updated_row" (-> (mt/rows (mt/run-mbql-query categories {:filter [:= $id created-id]})) last last))
+            "The row should actually be updated")
+        (is (= (:expected delete)
+               (mt/user-http-request :crowberto :post 200 (:action delete) (mt/mbql-query categories {:filter [:= $id created-id]})))
+            "Delete should return the right shape")
+        (is (= [] (mt/rows (mt/run-mbql-query categories {:filter [:= $id created-id]})))
+            "Selecting for deleted rows should return an empty result")))))
 
 ;; TODO: update test for this when we get something other than categories
 #_(deftest row-delete-row-with-constraint-fails-test
@@ -124,54 +160,49 @@
                                              :values   {:name "Toucannery"}})))))))
 
 (deftest validation-test
-  (mt/with-temporary-setting-values [experimental-enable-actions true]
-    (mt/with-temp-vals-in-db Database (mt/id) {:settings {:database-enable-actions true}}
-      (doseq [{:keys [action request-body]} (mock-requests)
-              k [:query :type]]
-        (testing (str action " without " k)
-          (when (row-action? action)
-            (is (re= #"Value does not match schema:.*"
-                     (:message (mt/user-http-request :crowberto :post 400 action (dissoc request-body k)))))))))))
+  (actions.test-util/with-actions-enabled
+    (doseq [{:keys [action request-body]} (mock-requests)
+            k [:query :type]]
+      (testing (str action " without " k)
+        (when (row-action? action)
+          (is (re= #"Value does not match schema:.*"
+                   (:message (mt/user-http-request :crowberto :post 400 action (dissoc request-body k))))))))))
 
 (deftest row-update-action-gives-400-when-matching-more-than-one
-  (mt/with-temporary-setting-values [experimental-enable-actions true]
-    (mt/with-temp-vals-in-db Database (mt/id) {:settings {:database-enable-actions true}}
-      (let [query-that-returns-more-than-one (assoc (mt/mbql-query users {:filter [:>= $id 1]}) :update_row {:name "new-name"})
-            result-count (count (mt/rows (qp/process-query query-that-returns-more-than-one)))]
-        (is (< 1 result-count))
-        (doseq [{:keys [action]} (filter #(= "action/row/update" (:action %)) (mock-requests))
-                :when (not= action "action/row/create")] ;; the query in create is not used to select values to act upopn.
-          (is (re= #"Sorry, this would update [\d|,]+ rows, but you can only act on 1"
-                   (:message (mt/user-http-request :crowberto :post 400 action query-that-returns-more-than-one))))
-          (is (= result-count (count (mt/rows (qp/process-query query-that-returns-more-than-one))))
-              "The result-count after a rollback must remain the same!"))))))
+  (actions.test-util/with-actions-enabled
+    (let [query-that-returns-more-than-one (assoc (mt/mbql-query users {:filter [:>= $id 1]}) :update_row {:name "new-name"})
+          result-count (count (mt/rows (qp/process-query query-that-returns-more-than-one)))]
+      (is (< 1 result-count))
+      (doseq [{:keys [action]} (filter #(= "action/row/update" (:action %)) (mock-requests))
+              :when (not= action "action/row/create")] ;; the query in create is not used to select values to act upopn.
+        (is (re= #"Sorry, this would update [\d|,]+ rows, but you can only act on 1"
+                 (:message (mt/user-http-request :crowberto :post 400 action query-that-returns-more-than-one))))
+        (is (= result-count (count (mt/rows (qp/process-query query-that-returns-more-than-one))))
+            "The result-count after a rollback must remain the same!")))))
 
 (deftest row-delete-action-gives-400-when-matching-more-than-one
-  (mt/with-temporary-setting-values [experimental-enable-actions true]
-    (mt/with-temp-vals-in-db Database (mt/id) {:settings {:database-enable-actions true}}
-      (let [query-that-returns-more-than-one (assoc (mt/mbql-query checkins {:filter [:>= $id 1]}) :update_row {:name "new-name"})
-            result-count (count (mt/rows (qp/process-query query-that-returns-more-than-one)))]
-        (is (< 1 result-count))
-        (doseq [{:keys [action]} (filter #(= "action/row/delete" (:action %)) (mock-requests))
-                :when (not= action "action/row/create")] ;; the query in create is not used to select values to act upopn.
-          (is (re= #"Sorry, this would delete [\d|,]+ rows, but you can only act on 1"
-                   (:message (mt/user-http-request :crowberto :post 400 action query-that-returns-more-than-one))))
-          (is (= result-count (count (mt/rows (qp/process-query query-that-returns-more-than-one))))
-              "The result-count after a rollback must remain the same!"))))))
+  (actions.test-util/with-actions-enabled
+    (let [query-that-returns-more-than-one (assoc (mt/mbql-query checkins {:filter [:>= $id 1]}) :update_row {:name "new-name"})
+          result-count (count (mt/rows (qp/process-query query-that-returns-more-than-one)))]
+      (is (< 1 result-count))
+      (doseq [{:keys [action]} (filter #(= "action/row/delete" (:action %)) (mock-requests))
+              :when (not= action "action/row/create")] ;; the query in create is not used to select values to act upopn.
+        (is (re= #"Sorry, this would delete [\d|,]+ rows, but you can only act on 1"
+                 (:message (mt/user-http-request :crowberto :post 400 action query-that-returns-more-than-one))))
+        (is (= result-count (count (mt/rows (qp/process-query query-that-returns-more-than-one))))
+            "The result-count after a rollback must remain the same!")))))
 
 (deftest unknown-row-action-gives-404
-  (mt/with-temporary-setting-values [experimental-enable-actions true]
-    (mt/with-temp-vals-in-db Database (mt/id) {:settings {:database-enable-actions true}}
-      (testing "404 for unknown Row action"
-        (is (= "Unknown row action \"fake\"."
-               (:message (mt/user-http-request :crowberto :post 404 "action/row/fake" (mt/mbql-query categories {:filter [:= $id 1]})))))))))
+  (actions.test-util/with-actions-enabled
+    (testing "404 for unknown Row action"
+      (is (= "Unknown row action \"fake\"."
+             (:message (mt/user-http-request :crowberto :post 404 "action/row/fake" (mt/mbql-query categories {:filter [:= $id 1]}))))))))
 
 (deftest four-oh-four-test
-  (mt/with-temporary-setting-values [experimental-enable-actions true]
-    (mt/with-temp-vals-in-db Database (mt/id) {:settings {:database-enable-actions true}}
-      (doseq [{:keys [action request-body]} (mock-requests)]
-        (testing action
-          (testing "404 for unknown Table"
-            (is (= "Failed to fetch Table 2,147,483,647: Table does not exist, or belongs to a different Database."
-                   (:message (mt/user-http-request :crowberto :post 404 action
-                                                   (assoc-in request-body [:query :source-table] Integer/MAX_VALUE)))))))))))
+  (actions.test-util/with-actions-enabled
+    (doseq [{:keys [action request-body]} (mock-requests)]
+      (testing action
+        (testing "404 for unknown Table"
+          (is (= "Failed to fetch Table 2,147,483,647: Table does not exist, or belongs to a different Database."
+                 (:message (mt/user-http-request :crowberto :post 404 action
+                                                 (assoc-in request-body [:query :source-table] Integer/MAX_VALUE))))))))))

--- a/test/metabase/api/emitter_test.clj
+++ b/test/metabase/api/emitter_test.clj
@@ -2,99 +2,45 @@
   (:require
    [clojure.test :refer :all]
    [metabase.actions.test-util :as actions.test-util]
-   [metabase.models
-    :refer [Card
-            CardEmitter
-            Dashboard
-            Database
-            Emitter
-            EmitterAction
-            QueryAction]]
+   [metabase.models :refer [Card Dashboard]]
    [metabase.test :as mt]
    [metabase.util.schema :as su]
-   [schema.core :as s]
-   [toucan.db :as db]))
-
-(defn- do-with-query-action [f]
-  (mt/with-temp* [Card [{card-id :id} {:database_id   (mt/id)
-                                       :dataset_query {:database (mt/id)
-                                                       :type     :native
-                                                       :native   {:query         (str "UPDATE categories\n"
-                                                                                      "SET name = 'Bird Shop'\n"
-                                                                                      "WHERE id = {{id}}")
-                                                                  :template-tags {"id" {:name         "id"
-                                                                                        :display-name "ID"
-                                                                                        :type         :number
-                                                                                        :required     true}}}}
-                                       :is_write      true}]]
-    (let [action-id (db/select-one-field :action_id QueryAction :card_id card-id)]
-      (f {:query-action-card-id card-id
-          :action-id            action-id}))))
-
-(defn- do-with-card-emitter [{:keys [action-id], :as context} f]
-  (mt/with-temp* [Card    [{emitter-card-id :id}]
-                  Emitter [{emitter-id :id} {:parameter_mappings {"my_id" [:variable [:template-tag "id"]]}}]]
-    (testing "Sanity check: emitter-id should be non-nil"
-      (is (integer? emitter-id)))
-    (testing "Sanity check: make sure parameter mappings were defined the way we'd expect"
-      (is (= {:my_id [:variable [:template-tag "id"]]}
-             (db/select-one-field :parameter_mappings Emitter :id emitter-id))))
-    ;; these are tied to the Card and Emitter above and will get cascade deleted. We can't use `with-temp*` for them
-    ;; because it doesn't seem to work with tables with compound PKs
-    (db/insert! EmitterAction {:emitter_id emitter-id
-                               :action_id action-id})
-    (db/insert! CardEmitter {:card_id   emitter-card-id
-                             :action_id action-id})
-    (f (assoc context
-              :emitter-id      emitter-id
-              :emitter-card-id emitter-card-id))))
-
-(defn- do-with-actions-setup [thunk]
-  (actions.test-util/with-actions-test-data
-    (mt/with-temporary-setting-values [experimental-enable-actions true]
-      (mt/with-temp-vals-in-db Database (mt/id) {:settings {:database-enable-actions true}}
-        (thunk)))))
+   [schema.core :as s]))
 
 (deftest create-emitter-test
   (testing "POST /api/emitter"
     (testing "Creating an emitter with the POST endpoint should return the newly created Emitter"
-      (do-with-actions-setup
-       (fn []
-         (do-with-query-action
-          (fn [{:keys [action-id query-action-card-id]}]
-            (let [expected-response {:id                 su/IntGreaterThanZero
-                                     :parameter_mappings (s/eq nil)
-                                     :action_id          (s/eq action-id)
-                                     :action             {:type     (s/eq      "query")
-                                                          :card     {:id       (s/eq query-action-card-id)
-                                                                     s/Keyword s/Any}
-                                                          s/Keyword s/Any}
-                                     s/Keyword           s/Any}]
-              (testing "CardEmitter"
-                (mt/with-temp Card [{card-id :id}]
-                  (is (schema= expected-response
-                               (mt/user-http-request :crowberto :post 200 "emitter" {:card_id   card-id
-                                                                                     :action_id action-id})))))
-              (testing "DashboardEmitter"
-                (mt/with-temp Dashboard [{dashboard-id :id}]
-                  (is (schema= expected-response
-                               (mt/user-http-request :crowberto :post 200 "emitter" {:dashboard_id dashboard-id
-                                                                                     :action_id    action-id})))))))))))))
+      (actions.test-util/with-actions-setup
+        (actions.test-util/with-query-action [{:keys [action-id query-action-card-id]}]
+          (let [expected-response {:id                 su/IntGreaterThanZero
+                                   :parameter_mappings (s/eq nil)
+                                   :action_id          (s/eq action-id)
+                                   :action             {:type     (s/eq      "query")
+                                                        :card     {:id       (s/eq query-action-card-id)
+                                                                   s/Keyword s/Any}
+                                                        s/Keyword s/Any}
+                                   s/Keyword           s/Any}]
+            (testing "CardEmitter"
+              (mt/with-temp Card [{card-id :id}]
+                (is (schema= expected-response
+                             (mt/user-http-request :crowberto :post 200 "emitter" {:card_id   card-id
+                                                                                   :action_id action-id})))))
+            (testing "DashboardEmitter"
+              (mt/with-temp Dashboard [{dashboard-id :id}]
+                (is (schema= expected-response
+                             (mt/user-http-request :crowberto :post 200 "emitter" {:dashboard_id dashboard-id
+                                                                                   :action_id    action-id})))))))))))
 
 (deftest execute-custom-action-test
   (mt/test-drivers (mt/normal-drivers-with-feature :actions/custom)
-    (do-with-actions-setup
-     (fn []
-       (do-with-query-action
-        (fn [context]
-          (do-with-card-emitter
-           context
-           (fn [{:keys [emitter-id], :as _context}]
-             (testing "Should be able to execute an emitter"
-               (is (= {:rows-affected 1}
-                      (mt/user-http-request :crowberto :post 200 (format "emitter/%d/execute" emitter-id)
-                                            {:parameters {"my_id" {:type  :number/=
-                                                                   :value 1}}}))))
-             (is (= [1 "Bird Shop"]
-                    (mt/first-row
-                     (mt/run-mbql-query categories {:filter [:= $id 1]}))))))))))))
+    (actions.test-util/with-actions-setup
+      (actions.test-util/with-query-action [context]
+        (actions.test-util/with-card-emitter [{:keys [emitter-id]} context]
+          (testing "Should be able to execute an emitter"
+            (is (= {:rows-affected 1}
+                   (mt/user-http-request :crowberto :post 200 (format "emitter/%d/execute" emitter-id)
+                                         {:parameters {"my_id" {:type  :number/=
+                                                                :value 1}}}))))
+          (is (= [1 "Bird Shop"]
+                 (mt/first-row
+                  (mt/run-mbql-query categories {:filter [:= $id 1]})))))))))

--- a/test/metabase/api/emitter_test.clj
+++ b/test/metabase/api/emitter_test.clj
@@ -10,7 +10,7 @@
 (deftest create-emitter-test
   (testing "POST /api/emitter"
     (testing "Creating an emitter with the POST endpoint should return the newly created Emitter"
-      (actions.test-util/with-actions-setup
+      (actions.test-util/with-actions-test-data-and-actions-enabled
         (actions.test-util/with-query-action [{:keys [action-id query-action-card-id]}]
           (let [expected-response {:id                 su/IntGreaterThanZero
                                    :parameter_mappings (s/eq nil)
@@ -33,7 +33,7 @@
 
 (deftest execute-custom-action-test
   (mt/test-drivers (mt/normal-drivers-with-feature :actions/custom)
-    (actions.test-util/with-actions-setup
+    (actions.test-util/with-actions-test-data-and-actions-enabled
       (actions.test-util/with-query-action [context]
         (actions.test-util/with-card-emitter [{:keys [emitter-id]} context]
           (testing "Should be able to execute an emitter"


### PR DESCRIPTION
I started this in an attempt to fix #23201 which I did not realize was already fixed by #23207... at any rate we didn't have tests around `GET /api/action` and `GET /api/action/:id` so I added them.

To facilitate writing these tests I moved `metabase.api.emitter-test/do-with-query-action`, `do-with-card-emitter` and `do-with-actions-setup` to `metabase.actions.test-util` and wrote wrapper macros for them (`with-query-action`, `with-card-emitter`, and `with-actions-test-data-and-actions-enabled` respectively), and added `with-actions-enabled`. I rewrote existing tests in `metabase.api.action-test` and `metabase.api.emitter-test` to use the new test macros and remove repeated boilerplate code.