### PR TITLE
Disallow`is_write` cards in dashboards alerts etc

### DIFF
--- a/src/metabase/api/alert.clj
+++ b/src/metabase/api/alert.clj
@@ -139,6 +139,11 @@
   (validation/check-has-application-permission :subscription false)
   ;; To create an Alert you need read perms for its Card
   (api/read-check Card (u/the-id card))
+  ;; don't allow creation of Alerts for `is_write` writeback QueryAction cards. Those are intended only for Actions
+  ;; and aren't ran for results so they don't make sense as Alerts.
+  (when (db/select-one-field :is_write Card :id (u/the-id card))
+    (throw (ex-info (tru "You cannot create an Alert for an is_write Card.")
+                    {:status-code 400})))
   ;; ok, now create the Alert
   (let [alert-card (-> card (maybe-include-csv alert_condition) pulse/card->ref)
         new-alert  (api/check-500

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -251,8 +251,8 @@
 
 
 (defn- update-field-values-for-on-demand-dbs!
-  "If the parameters have changed since last time this Dashboard was saved, we need to update the FieldValues for any
-  Fields that belong to an 'On-Demand' synced DB."
+  "If the parameters have changed since last time this Dashboard was saved, we need to update the FieldValues
+   for any Fields that belong to an 'On-Demand' synced DB."
   [old-param-field-ids new-param-field-ids]
   (when (and (seq new-param-field-ids)
              (not= old-param-field-ids new-param-field-ids))
@@ -264,8 +264,11 @@
 
 
 (defn add-dashcard!
-  "Add a Card to a Dashboard. This function is provided for convenience and also makes sure various cleanup steps are
-  performed when finished, for example updating FieldValues for On-Demand DBs. Returns newly created DashboardCard."
+  "Add a Card to a Dashboard.
+   This function is provided for convenience and also makes sure various cleanup steps are performed when finished,
+   for example updating FieldValues for On-Demand DBs.
+   Returns newly created DashboardCard."
+  {:style/indent 2}
   [dashboard-or-id card-or-id-or-nil & [dashcard-options]]
   (let [old-param-field-ids (dashboard-id->param-field-ids dashboard-or-id)
         dashboard-card      (-> (assoc dashcard-options
@@ -278,9 +281,11 @@
         (update-field-values-for-on-demand-dbs! old-param-field-ids new-param-field-ids)))))
 
 (defn update-dashcards!
-  "Update the `dashcards` belonging to `dashboard-or-id`. This function is provided as a convenience instead of doing
-  this yourself; it also makes sure various cleanup steps are performed when finished, for example updating
-  FieldValues for On-Demand DBs. Returns `nil`."
+  "Update the `dashcards` belonging to `dashboard-or-id`.
+   This function is provided as a convenience instead of doing this yourself; it also makes sure various cleanup steps
+   are performed when finished, for example updating FieldValues for On-Demand DBs.
+   Returns `nil`."
+  {:style/indent 1}
   [dashboard-or-id dashcards]
   (let [old-param-field-ids (dashboard-id->param-field-ids dashboard-or-id)
         dashcard-ids        (db/select-ids DashboardCard, :dashboard_id (u/the-id dashboard-or-id))]

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -251,8 +251,8 @@
 
 
 (defn- update-field-values-for-on-demand-dbs!
-  "If the parameters have changed since last time this Dashboard was saved, we need to update the FieldValues
-   for any Fields that belong to an 'On-Demand' synced DB."
+  "If the parameters have changed since last time this Dashboard was saved, we need to update the FieldValues for any
+  Fields that belong to an 'On-Demand' synced DB."
   [old-param-field-ids new-param-field-ids]
   (when (and (seq new-param-field-ids)
              (not= old-param-field-ids new-param-field-ids))
@@ -264,11 +264,8 @@
 
 
 (defn add-dashcard!
-  "Add a Card to a Dashboard.
-   This function is provided for convenience and also makes sure various cleanup steps are performed when finished,
-   for example updating FieldValues for On-Demand DBs.
-   Returns newly created DashboardCard."
-  {:style/indent 2}
+  "Add a Card to a Dashboard. This function is provided for convenience and also makes sure various cleanup steps are
+  performed when finished, for example updating FieldValues for On-Demand DBs. Returns newly created DashboardCard."
   [dashboard-or-id card-or-id-or-nil & [dashcard-options]]
   (let [old-param-field-ids (dashboard-id->param-field-ids dashboard-or-id)
         dashboard-card      (-> (assoc dashcard-options
@@ -281,11 +278,9 @@
         (update-field-values-for-on-demand-dbs! old-param-field-ids new-param-field-ids)))))
 
 (defn update-dashcards!
-  "Update the `dashcards` belonging to `dashboard-or-id`.
-   This function is provided as a convenience instead of doing this yourself; it also makes sure various cleanup steps
-   are performed when finished, for example updating FieldValues for On-Demand DBs.
-   Returns `nil`."
-  {:style/indent 1}
+  "Update the `dashcards` belonging to `dashboard-or-id`. This function is provided as a convenience instead of doing
+  this yourself; it also makes sure various cleanup steps are performed when finished, for example updating
+  FieldValues for On-Demand DBs. Returns `nil`."
   [dashboard-or-id dashcards]
   (let [old-param-field-ids (dashboard-id->param-field-ids dashboard-or-id)
         dashcard-ids        (db/select-ids DashboardCard, :dashboard_id (u/the-id dashboard-or-id))]

--- a/src/metabase/models/dashboard_card.clj
+++ b/src/metabase/models/dashboard_card.clj
@@ -8,6 +8,7 @@
             [metabase.models.pulse-card :refer [PulseCard]]
             [metabase.models.serialization.hash :as serdes.hash]
             [metabase.util :as u]
+            [metabase.util.i18n :refer [tru]]
             [metabase.util.schema :as su]
             [schema.core :as s]
             [toucan.db :as db]
@@ -178,20 +179,25 @@
   [dashboard-card :- NewDashboardCard]
   (let [{:keys [dashboard_id card_id parameter_mappings visualization_settings sizeX sizeY row col series]
          :or   {sizeX 2, sizeY 2, series []}} dashboard-card]
+    ;; make sure the Card isn't a writeback QueryAction. It doesn't make sense to add these to a Dashboard since we're
+    ;; not supposed to be executing them for results
+    (when (db/select-one-field :is_write Card :id card_id)
+      (throw (ex-info (tru "You cannot add an is_write Card to a Dashboard.")
+                      {:status-code 400})))
     (db/transaction
-     (let [dashboard-card (db/insert! DashboardCard
-                                      :dashboard_id           dashboard_id
-                                      :card_id                card_id
-                                      :sizeX                  sizeX
-                                      :sizeY                  sizeY
-                                      :row                    (or row 0)
-                                      :col                    (or col 0)
-                                      :parameter_mappings     (or parameter_mappings [])
-                                      :visualization_settings (or visualization_settings {}))]
-       ;; add series to the DashboardCard
-       (update-dashboard-card-series! dashboard-card series)
-       ;; return the full DashboardCard
-       (retrieve-dashboard-card (:id dashboard-card))))))
+      (let [dashboard-card (db/insert! DashboardCard
+                             :dashboard_id           dashboard_id
+                             :card_id                card_id
+                             :sizeX                  sizeX
+                             :sizeY                  sizeY
+                             :row                    (or row 0)
+                             :col                    (or col 0)
+                             :parameter_mappings     (or parameter_mappings [])
+                             :visualization_settings (or visualization_settings {}))]
+        ;; add series to the DashboardCard
+        (update-dashboard-card-series! dashboard-card series)
+        ;; return the full DashboardCard
+        (retrieve-dashboard-card (:id dashboard-card))))))
 
 (defn delete-dashboard-card!
   "Delete a DashboardCard."

--- a/src/metabase/models/dashboard_card.clj
+++ b/src/metabase/models/dashboard_card.clj
@@ -185,19 +185,19 @@
       (throw (ex-info (tru "You cannot add an is_write Card to a Dashboard.")
                       {:status-code 400})))
     (db/transaction
-      (let [dashboard-card (db/insert! DashboardCard
-                             :dashboard_id           dashboard_id
-                             :card_id                card_id
-                             :sizeX                  sizeX
-                             :sizeY                  sizeY
-                             :row                    (or row 0)
-                             :col                    (or col 0)
-                             :parameter_mappings     (or parameter_mappings [])
-                             :visualization_settings (or visualization_settings {}))]
-        ;; add series to the DashboardCard
-        (update-dashboard-card-series! dashboard-card series)
-        ;; return the full DashboardCard
-        (retrieve-dashboard-card (:id dashboard-card))))))
+     (let [dashboard-card (db/insert! DashboardCard
+                                      :dashboard_id           dashboard_id
+                                      :card_id                card_id
+                                      :sizeX                  sizeX
+                                      :sizeY                  sizeY
+                                      :row                    (or row 0)
+                                      :col                    (or col 0)
+                                      :parameter_mappings     (or parameter_mappings [])
+                                      :visualization_settings (or visualization_settings {}))]
+       ;; add series to the DashboardCard
+       (update-dashboard-card-series! dashboard-card series)
+       ;; return the full DashboardCard
+       (retrieve-dashboard-card (:id dashboard-card))))))
 
 (defn delete-dashboard-card!
   "Delete a DashboardCard."

--- a/test/metabase/actions/test_util.clj
+++ b/test/metabase/actions/test_util.clj
@@ -2,8 +2,10 @@
   (:require
    [clojure.java.jdbc :as jdbc]
    [clojure.test :refer :all]
+   [metabase.actions.test-util :as actions.test-util]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
-   [metabase.models.database :refer [Database]]
+   [metabase.models
+    :refer [Card CardEmitter Database Emitter EmitterAction QueryAction]]
    [metabase.test :as mt]
    [metabase.test.data.dataset-definitions :as defs]
    [metabase.test.data.impl :as data.impl]
@@ -64,3 +66,79 @@
             (testing "after"
               (is (= [[74]]
                      (row-count))))))))))
+
+(defn do-with-query-action
+  "Impl for [[with-query-action]]."
+  [f]
+  (mt/with-temp* [Card [{card-id :id} {:database_id   (mt/id)
+                                       :dataset_query {:database (mt/id)
+                                                       :type     :native
+                                                       :native   {:query         (str "UPDATE categories\n"
+                                                                                      "SET name = 'Bird Shop'\n"
+                                                                                      "WHERE id = {{id}}")
+                                                                  :template-tags {"id" {:name         "id"
+                                                                                        :display-name "ID"
+                                                                                        :type         :number
+                                                                                        :required     true}}}}
+                                       :is_write      true}]]
+    (let [action-id (db/select-one-field :action_id QueryAction :card_id card-id)]
+      (f {:query-action-card-id card-id
+          :action-id            action-id}))))
+
+(defmacro with-query-action
+  "Execute `body` with a newly created QueryAction. `bindings` is a map with keys `:action-id` and
+  `:query-action-card-id`.
+
+    (with-query-action [{:keys [action-id query-action-card-id], :as context}]
+      (do-something))"
+  {:style/indent 1}
+  [[bindings] & body]
+  `(do-with-query-action (fn [~bindings] ~@body)))
+
+(defn do-with-card-emitter
+  "Impl for [[with-card-emitter]]."
+  [{:keys [action-id], :as context} f]
+  (mt/with-temp* [Card    [{emitter-card-id :id}]
+                  Emitter [{emitter-id :id} {:parameter_mappings {"my_id" [:variable [:template-tag "id"]]}}]]
+    (testing "Sanity check: emitter-id should be non-nil"
+      (is (integer? emitter-id)))
+    (testing "Sanity check: make sure parameter mappings were defined the way we'd expect"
+      (is (= {:my_id [:variable [:template-tag "id"]]}
+             (db/select-one-field :parameter_mappings Emitter :id emitter-id))))
+    ;; these are tied to the Card and Emitter above and will get cascade deleted. We can't use `with-temp*` for them
+    ;; because it doesn't seem to work with tables with compound PKs
+    (db/insert! EmitterAction {:emitter_id emitter-id
+                               :action_id action-id})
+    (db/insert! CardEmitter {:card_id   emitter-card-id
+                             :action_id action-id})
+    (f (assoc context
+              :emitter-id      emitter-id
+              :emitter-card-id emitter-card-id))))
+
+(defmacro with-card-emitter
+  "Execute `body` with a newly created CardEmitter created for an Action with `:action-id`. Intended for use with the
+  `context` returned by with [[with-query-action]]. `bindings` is bound to a map with the keys `:emitter-id` and
+  `:emitter-card-id`.
+
+    (with-query-action [{:keys [action-id query-action-card-id], :as context}]
+      (with-card-emitter [{:keys [emitter-id emitter-card-id]} context]
+        (do-something)))"
+  {:style/indent 1, :arglists '([bindings {:keys [action-id], :as _action}] & body)}
+  [[bindings action] & body]
+  `(do-with-card-emitter ~action (fn [~bindings] ~@body)))
+
+
+(defn do-with-actions-setup
+  "Impl for [[with-actions-setup]]."
+  [thunk]
+  (with-actions-test-data
+    (mt/with-temporary-setting-values [experimental-enable-actions true]
+      (mt/with-temp-vals-in-db Database (mt/id) {:settings {:database-enable-actions true}}
+        (thunk)))))
+
+(defmacro with-actions-setup
+  "Execute `body` with the actions test dataset via [[with-actions-test-data]], which can be freely modified, as it is
+  recreated on each use. Enables actions at the global level and for the current test Database."
+  {:style/indent 0}
+  [& body]
+  `(do-with-actions-setup (fn [] ~@body)))

--- a/test/metabase/actions/test_util.clj
+++ b/test/metabase/actions/test_util.clj
@@ -2,7 +2,6 @@
   (:require
    [clojure.java.jdbc :as jdbc]
    [clojure.test :refer :all]
-   [metabase.actions.test-util :as actions.test-util]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.models
     :refer [Card CardEmitter Database Emitter EmitterAction QueryAction]]

--- a/test/metabase/actions/test_util.clj
+++ b/test/metabase/actions/test_util.clj
@@ -127,18 +127,23 @@
   [[bindings action] & body]
   `(do-with-card-emitter ~action (fn [~bindings] ~@body)))
 
-
-(defn do-with-actions-setup
-  "Impl for [[with-actions-setup]]."
+(defn do-with-actions-enabled
+  "Impl for [[with-actions-enabled]]."
   [thunk]
-  (with-actions-test-data
-    (mt/with-temporary-setting-values [experimental-enable-actions true]
-      (mt/with-temp-vals-in-db Database (mt/id) {:settings {:database-enable-actions true}}
-        (thunk)))))
+  (mt/with-temporary-setting-values [experimental-enable-actions true]
+    (mt/with-temp-vals-in-db Database (mt/id) {:settings {:database-enable-actions true}}
+      (thunk))))
 
-(defmacro with-actions-setup
-  "Execute `body` with the actions test dataset via [[with-actions-test-data]], which can be freely modified, as it is
-  recreated on each use. Enables actions at the global level and for the current test Database."
+(defmacro with-actions-enabled
+  "Execute `body` with Actions enabled at the global level and for the current test Database."
   {:style/indent 0}
   [& body]
-  `(do-with-actions-setup (fn [] ~@body)))
+  `(do-with-actions-enabled (fn [] ~@body)))
+
+(defmacro with-actions-test-data-and-actions-enabled
+  "Combines [[with-actions-test-data]] and [[with-actions-enabled]]."
+  {:style/indent 0}
+  [& body]
+  `(with-actions-test-data
+     (with-actions-enabled
+       (fn [] ~@body))))

--- a/test/metabase/api/action_test.clj
+++ b/test/metabase/api/action_test.clj
@@ -19,7 +19,7 @@
   "Expected schema for a CardAction as it should appear in the response for an API request to one of the GET endpoints."
   {:id       su/IntGreaterThanOrEqualToZero
    :card     {:id            su/IntGreaterThanOrEqualToZero
-              :dataset_query {:database (s/eq (mt/id))
+              :dataset_query {:database su/IntGreaterThanOrEqualToZero
                               :type     (s/eq "native")
                               :native   {:query    s/Str
                                          s/Keyword s/Any}

--- a/test/metabase/api/action_test.clj
+++ b/test/metabase/api/action_test.clj
@@ -9,9 +9,49 @@
    [metabase.models.table :refer [Table]]
    [metabase.query-processor :as qp]
    [metabase.test :as mt]
-   [metabase.util :as u]))
+   [metabase.util :as u]
+   [metabase.util.schema :as su]
+   [schema.core :as s]))
 
 (comment api.action/keep-me)
+
+(def ^:private ExpectedGetCardActionAPIResponse
+  "Expected schema for a CardAction as it should appear in the response for an API request to one of the GET endpoints."
+  {:id       su/IntGreaterThanOrEqualToZero
+   :card     {:id            su/IntGreaterThanOrEqualToZero
+              :dataset_query {:database (s/eq (mt/id))
+                              :type     (s/eq "native")
+                              :native   {:query    s/Str
+                                         s/Keyword s/Any}
+                              s/Keyword s/Any}
+              s/Keyword      s/Any}
+   s/Keyword s/Any})
+
+(deftest list-actions-test
+  (testing "GET /api/action"
+    (actions.test-util/with-actions-enabled
+      (actions.test-util/with-query-action [{:keys [action-id]}]
+        (let [response (mt/user-http-request :crowberto :get 200 "action")]
+          (is (schema= [{:id       su/IntGreaterThanZero
+                         s/Keyword s/Any}]
+                       response))
+          (let [action (some (fn [action]
+                               (when (= (:id action) action-id)
+                                 action))
+                             response)]
+            (testing "Should return Card dataset_query deserialized (#23201)"
+              (is (schema= ExpectedGetCardActionAPIResponse
+                           action)))))))))
+
+(deftest get-action-test
+  (testing "GET /api/action/:id"
+    (testing "Should return Card dataset_query deserialized (#23201)"
+      (actions.test-util/with-actions-enabled
+        (actions.test-util/with-query-action [{:keys [action-id]}]
+          (let [action (mt/user-http-request :crowberto :get 200 (format "action/%d" action-id))]
+            (testing "Should return Card dataset_query deserialized (#23201)"
+              (is (schema= ExpectedGetCardActionAPIResponse
+                           action)))))))))
 
 (defn- mock-requests []
   [{:action       "action/row/create"
@@ -38,40 +78,36 @@
 
 (deftest happy-path-test
   (testing "Make sure it's possible to use known actions end-to-end if preconditions are satisfied"
-    (actions.test-util/with-actions-test-data
-      (mt/with-temporary-setting-values [experimental-enable-actions true]
-        (mt/with-temp-vals-in-db Database (mt/id) {:settings {:database-enable-actions true}}
-          (doseq [{:keys [action request-body expected expect-fn]} (mock-requests)]
-            (testing action
-              (let [result (mt/user-http-request :crowberto :post 200 action request-body)]
-                (when expected (is (= expected result)))
-                (when expect-fn (expect-fn result))))))))))
+    (actions.test-util/with-actions-test-data-and-actions-enabled
+      (doseq [{:keys [action request-body expected expect-fn]} (mock-requests)]
+        (testing action
+          (let [result (mt/user-http-request :crowberto :post 200 action request-body)]
+            (when expected (is (= expected result)))
+            (when expect-fn (expect-fn result))))))))
 
 (deftest create-update-delete-test
   (testing "Make sure actions are acting on rows."
-    (actions.test-util/with-actions-test-data
-      (mt/with-temporary-setting-values [experimental-enable-actions true]
-        (mt/with-temp-vals-in-db Database (mt/id) {:settings {:database-enable-actions true}}
-          (let [[create update delete] (mock-requests)
-                {created-id :id :as created-row}
-                (:created-row (mt/user-http-request :crowberto :post 200 (:action create) (:request-body create)))]
-            (is (= [:id :name] (keys created-row))
-                "Create should return the entire row")
-            (is (= "created_row" (:name created-row))
-                "Create should return the correct value for name")
-            (is (= "created_row" (-> (mt/rows (mt/run-mbql-query categories {:filter [:= $id created-id]})) last last))
-                "The record at created-id should now have its name set to \"created_row\"")
-            (is (= (:expected update) (mt/user-http-request :crowberto :post 200 (:action update)
-                                                            (assoc (mt/mbql-query categories {:filter [:= $id created-id]})
-                                                                   :update_row {:name "updated_row"})))
-                "Update should return the right shape")
-            (is (= "updated_row" (-> (mt/rows (mt/run-mbql-query categories {:filter [:= $id created-id]})) last last))
-                "The row should actually be updated")
-            (is (= (:expected delete)
-                   (mt/user-http-request :crowberto :post 200 (:action delete) (mt/mbql-query categories {:filter [:= $id created-id]})))
-                "Delete should return the right shape")
-            (is (= [] (mt/rows (mt/run-mbql-query categories {:filter [:= $id created-id]})))
-                "Selecting for deleted rows should return an empty result")))))))
+    (actions.test-util/with-actions-test-data-and-actions-enabled
+      (let [[create update delete] (mock-requests)
+            {created-id :id :as created-row}
+            (:created-row (mt/user-http-request :crowberto :post 200 (:action create) (:request-body create)))]
+        (is (= [:id :name] (keys created-row))
+            "Create should return the entire row")
+        (is (= "created_row" (:name created-row))
+            "Create should return the correct value for name")
+        (is (= "created_row" (-> (mt/rows (mt/run-mbql-query categories {:filter [:= $id created-id]})) last last))
+            "The record at created-id should now have its name set to \"created_row\"")
+        (is (= (:expected update) (mt/user-http-request :crowberto :post 200 (:action update)
+                                                        (assoc (mt/mbql-query categories {:filter [:= $id created-id]})
+                                                               :update_row {:name "updated_row"})))
+            "Update should return the right shape")
+        (is (= "updated_row" (-> (mt/rows (mt/run-mbql-query categories {:filter [:= $id created-id]})) last last))
+            "The row should actually be updated")
+        (is (= (:expected delete)
+               (mt/user-http-request :crowberto :post 200 (:action delete) (mt/mbql-query categories {:filter [:= $id created-id]})))
+            "Delete should return the right shape")
+        (is (= [] (mt/rows (mt/run-mbql-query categories {:filter [:= $id created-id]})))
+            "Selecting for deleted rows should return an empty result")))))
 
 ;; TODO: update test for this when we get something other than categories
 #_(deftest row-delete-row-with-constraint-fails-test
@@ -124,54 +160,49 @@
                                              :values   {:name "Toucannery"}})))))))
 
 (deftest validation-test
-  (mt/with-temporary-setting-values [experimental-enable-actions true]
-    (mt/with-temp-vals-in-db Database (mt/id) {:settings {:database-enable-actions true}}
-      (doseq [{:keys [action request-body]} (mock-requests)
-              k [:query :type]]
-        (testing (str action " without " k)
-          (when (row-action? action)
-            (is (re= #"Value does not match schema:.*"
-                     (:message (mt/user-http-request :crowberto :post 400 action (dissoc request-body k)))))))))))
+  (actions.test-util/with-actions-enabled
+    (doseq [{:keys [action request-body]} (mock-requests)
+            k [:query :type]]
+      (testing (str action " without " k)
+        (when (row-action? action)
+          (is (re= #"Value does not match schema:.*"
+                   (:message (mt/user-http-request :crowberto :post 400 action (dissoc request-body k))))))))))
 
 (deftest row-update-action-gives-400-when-matching-more-than-one
-  (mt/with-temporary-setting-values [experimental-enable-actions true]
-    (mt/with-temp-vals-in-db Database (mt/id) {:settings {:database-enable-actions true}}
-      (let [query-that-returns-more-than-one (assoc (mt/mbql-query users {:filter [:>= $id 1]}) :update_row {:name "new-name"})
-            result-count (count (mt/rows (qp/process-query query-that-returns-more-than-one)))]
-        (is (< 1 result-count))
-        (doseq [{:keys [action]} (filter #(= "action/row/update" (:action %)) (mock-requests))
-                :when (not= action "action/row/create")] ;; the query in create is not used to select values to act upopn.
-          (is (re= #"Sorry, this would update [\d|,]+ rows, but you can only act on 1"
-                   (:message (mt/user-http-request :crowberto :post 400 action query-that-returns-more-than-one))))
-          (is (= result-count (count (mt/rows (qp/process-query query-that-returns-more-than-one))))
-              "The result-count after a rollback must remain the same!"))))))
+  (actions.test-util/with-actions-enabled
+    (let [query-that-returns-more-than-one (assoc (mt/mbql-query users {:filter [:>= $id 1]}) :update_row {:name "new-name"})
+          result-count (count (mt/rows (qp/process-query query-that-returns-more-than-one)))]
+      (is (< 1 result-count))
+      (doseq [{:keys [action]} (filter #(= "action/row/update" (:action %)) (mock-requests))
+              :when (not= action "action/row/create")] ;; the query in create is not used to select values to act upopn.
+        (is (re= #"Sorry, this would update [\d|,]+ rows, but you can only act on 1"
+                 (:message (mt/user-http-request :crowberto :post 400 action query-that-returns-more-than-one))))
+        (is (= result-count (count (mt/rows (qp/process-query query-that-returns-more-than-one))))
+            "The result-count after a rollback must remain the same!")))))
 
 (deftest row-delete-action-gives-400-when-matching-more-than-one
-  (mt/with-temporary-setting-values [experimental-enable-actions true]
-    (mt/with-temp-vals-in-db Database (mt/id) {:settings {:database-enable-actions true}}
-      (let [query-that-returns-more-than-one (assoc (mt/mbql-query checkins {:filter [:>= $id 1]}) :update_row {:name "new-name"})
-            result-count (count (mt/rows (qp/process-query query-that-returns-more-than-one)))]
-        (is (< 1 result-count))
-        (doseq [{:keys [action]} (filter #(= "action/row/delete" (:action %)) (mock-requests))
-                :when (not= action "action/row/create")] ;; the query in create is not used to select values to act upopn.
-          (is (re= #"Sorry, this would delete [\d|,]+ rows, but you can only act on 1"
-                   (:message (mt/user-http-request :crowberto :post 400 action query-that-returns-more-than-one))))
-          (is (= result-count (count (mt/rows (qp/process-query query-that-returns-more-than-one))))
-              "The result-count after a rollback must remain the same!"))))))
+  (actions.test-util/with-actions-enabled
+    (let [query-that-returns-more-than-one (assoc (mt/mbql-query checkins {:filter [:>= $id 1]}) :update_row {:name "new-name"})
+          result-count (count (mt/rows (qp/process-query query-that-returns-more-than-one)))]
+      (is (< 1 result-count))
+      (doseq [{:keys [action]} (filter #(= "action/row/delete" (:action %)) (mock-requests))
+              :when (not= action "action/row/create")] ;; the query in create is not used to select values to act upopn.
+        (is (re= #"Sorry, this would delete [\d|,]+ rows, but you can only act on 1"
+                 (:message (mt/user-http-request :crowberto :post 400 action query-that-returns-more-than-one))))
+        (is (= result-count (count (mt/rows (qp/process-query query-that-returns-more-than-one))))
+            "The result-count after a rollback must remain the same!")))))
 
 (deftest unknown-row-action-gives-404
-  (mt/with-temporary-setting-values [experimental-enable-actions true]
-    (mt/with-temp-vals-in-db Database (mt/id) {:settings {:database-enable-actions true}}
-      (testing "404 for unknown Row action"
-        (is (= "Unknown row action \"fake\"."
-               (:message (mt/user-http-request :crowberto :post 404 "action/row/fake" (mt/mbql-query categories {:filter [:= $id 1]})))))))))
+  (actions.test-util/with-actions-enabled
+    (testing "404 for unknown Row action"
+      (is (= "Unknown row action \"fake\"."
+             (:message (mt/user-http-request :crowberto :post 404 "action/row/fake" (mt/mbql-query categories {:filter [:= $id 1]}))))))))
 
 (deftest four-oh-four-test
-  (mt/with-temporary-setting-values [experimental-enable-actions true]
-    (mt/with-temp-vals-in-db Database (mt/id) {:settings {:database-enable-actions true}}
-      (doseq [{:keys [action request-body]} (mock-requests)]
-        (testing action
-          (testing "404 for unknown Table"
-            (is (= "Failed to fetch Table 2,147,483,647: Table does not exist, or belongs to a different Database."
-                   (:message (mt/user-http-request :crowberto :post 404 action
-                                                   (assoc-in request-body [:query :source-table] Integer/MAX_VALUE)))))))))))
+  (actions.test-util/with-actions-enabled
+    (doseq [{:keys [action request-body]} (mock-requests)]
+      (testing action
+        (testing "404 for unknown Table"
+          (is (= "Failed to fetch Table 2,147,483,647: Table does not exist, or belongs to a different Database."
+                 (:message (mt/user-http-request :crowberto :post 404 action
+                                                 (assoc-in request-body [:query :source-table] Integer/MAX_VALUE))))))))))

--- a/test/metabase/api/alert_test.clj
+++ b/test/metabase/api/alert_test.clj
@@ -11,9 +11,7 @@
             [metabase.models.pulse-test :as pulse-test]
             [metabase.server.middleware.util :as mw.util]
             [metabase.test :as mt]
-            [metabase.test.data.users :refer :all]
             [metabase.test.mock.util :refer [pulse-channel-defaults]]
-            [metabase.test.util :as tu]
             [metabase.util :as u]
             [toucan.db :as db]))
 
@@ -295,7 +293,7 @@
                 (assoc-in [:card :collection_id] true)
                 (update-in [:channels 0] merge {:schedule_hour 12, :schedule_type "daily", :recipients []}))
             (new-alert-email :rasta {"has any results" true})]
-           (tu/with-non-admin-groups-no-root-collection-perms
+           (mt/with-non-admin-groups-no-root-collection-perms
              (mt/with-temp Collection [collection]
                (db/update! Card (u/the-id card) :collection_id (u/the-id collection))
                (with-alert-setup
@@ -343,7 +341,7 @@
                                 :alert_first_only false
                                 :channels         [(assoc daily-email-channel
                                                           :details       {:emails nil}
-                                                          :recipients    (mapv fetch-user [:crowberto :rasta]))]})
+                                                          :recipients    (mapv mt/fetch-user [:crowberto :rasta]))]})
                               setify-recipient-emails
                               alert-response))
               :emails (et/regex-email-bodies #"https://metabase.com/testmb"
@@ -354,7 +352,7 @@
 ;; Check creation of a below goal alert
 (deftest below-goal-alert-test
   (is (= (new-alert-email :rasta {"goes below its goal" true})
-         (tu/with-non-admin-groups-no-root-collection-perms
+         (mt/with-non-admin-groups-no-root-collection-perms
            (mt/with-temp* [Collection [collection]
                            Card       [card {:name          "My question"
                                              :display       "line"
@@ -376,7 +374,7 @@
 ;; Check creation of a above goal alert
 (deftest above-goal-alert-test
   (is (= (new-alert-email :rasta {"meets its goal" true})
-         (tu/with-non-admin-groups-no-root-collection-perms
+         (mt/with-non-admin-groups-no-root-collection-perms
            (mt/with-temp* [Collection [collection]
                            Card       [card {:name          "My question"
                                              :display       "bar"
@@ -395,6 +393,21 @@
                (et/regex-email-bodies #"https://metabase.com/testmb"
                                       #"meets its goal"
                                       #"My question")))))))
+
+(deftest disallow-creating-alert-with-is-write-card-test
+  (testing "POST /api/alert"
+    (testing "Disallow creating an Alert with a QueryAction is_write Card (#22846)"
+      (mt/with-temp Card [{card-id :id} {:is_write true}]
+        (is (= "You cannot create an Alert for an is_write Card."
+               (mt/user-http-request :crowberto :post 400 "alert"
+                                     {:card             {:id                card-id
+                                                         :include_csv       false
+                                                         :include_xls       false
+                                                         :dashboard_card_id nil}
+                                      :alert_condition  "goal"
+                                      :alert_first_only false
+                                      :channels         [daily-email-channel]})))))))
+
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                               PUT /api/alert/:id                                               |
@@ -476,7 +489,7 @@
                     PulseChannel          [pc    (pulse-channel alert)]
                     PulseChannelRecipient [_     (recipient pc :rasta)]]
       (is (= (default-alert card)
-             (tu/with-model-cleanup [Pulse]
+             (mt/with-model-cleanup [Pulse]
                (alert-response
                 ((alert-client :crowberto) :put 200 (alert-url alert)
                  (default-alert-req card pc))))))))
@@ -491,11 +504,11 @@
                     :alert_first_only true
                     :alert_above_goal true
                     :alert_condition  "goal")
-             (tu/with-model-cleanup [Pulse]
+             (mt/with-model-cleanup [Pulse]
                (alert-response
                 ((alert-client :crowberto) :put 200 (alert-url alert)
                  (default-alert-req card (u/the-id pc) {:alert_first_only true, :alert_above_goal true, :alert_condition "goal"}
-                                    [(fetch-user :rasta)]))))))))
+                                    [(mt/fetch-user :rasta)]))))))))
 
   (testing "Admin users can add a recipient, that recipient should be notified"
     (mt/with-temp* [Pulse                 [alert (basic-alert)]
@@ -512,8 +525,8 @@
                   (alert-response
                    (setify-recipient-emails
                     ((alert-client :crowberto) :put 200 (alert-url alert)
-                     (default-alert-req card pc {} [(fetch-user :crowberto)
-                                                    (fetch-user :rasta)])))))
+                     (default-alert-req card pc {} [(mt/fetch-user :crowberto)
+                                                    (mt/fetch-user :rasta)])))))
                 (et/regex-email-bodies #"https://metabase.com/testmb"
                                        #"now getting alerts")]))))))
 
@@ -527,7 +540,7 @@
       (is (= (-> (default-alert card)
                  (assoc-in [:card :collection_id] true))
              (with-alerts-in-writeable-collection [alert]
-               (tu/with-model-cleanup [Pulse]
+               (mt/with-model-cleanup [Pulse]
                  (alert-response
                   ((alert-client :rasta) :put 200 (alert-url alert)
                    (default-alert-req card pc)))))))))
@@ -541,9 +554,9 @@
       (is (= (str "Non-admin users without monitoring or subscription permissions "
                   "are not allowed to modify the channels for an alert")
              (with-alerts-in-writeable-collection [alert]
-               (tu/with-model-cleanup [Pulse]
+               (mt/with-model-cleanup [Pulse]
                  ((alert-client :rasta) :put 403 (alert-url alert)
-                  (default-alert-req card pc {} [(fetch-user :crowberto)])))))))))
+                  (default-alert-req card pc {} [(mt/fetch-user :crowberto)])))))))))
 
 (deftest admin-users-remove-recipient-test
   (testing "admin users can remove a recipieint, that recipient should be notified"
@@ -571,20 +584,20 @@
 (deftest update-alert-permissions-test
   (testing "Non-admin users cannot update alerts for cards in a collection they don't have access to"
     (is (= "You don't have permissions to do that."
-         (tu/with-non-admin-groups-no-root-collection-perms
-           (mt/with-temp* [Pulse                 [alert (assoc (basic-alert) :creator_id (user->id :crowberto))]
+         (mt/with-non-admin-groups-no-root-collection-perms
+           (mt/with-temp* [Pulse                 [alert (assoc (basic-alert) :creator_id (mt/user->id :crowberto))]
                            Card                  [card]
                            PulseCard             [_     (pulse-card alert card)]
                            PulseChannel          [pc    (pulse-channel alert)]
                            PulseChannelRecipient [_     (recipient pc :rasta)]]
-             (tu/with-non-admin-groups-no-root-collection-perms
+             (mt/with-non-admin-groups-no-root-collection-perms
                (with-alert-setup
                  ((alert-client :rasta) :put 403 (alert-url alert)
                   (default-alert-req card pc)))))))))
 
   (testing "Non-admin users can't edit alerts if they're not in the recipient list"
     (is (= "You don't have permissions to do that."
-           (tu/with-non-admin-groups-no-root-collection-perms
+           (mt/with-non-admin-groups-no-root-collection-perms
              (mt/with-temp* [Pulse                 [alert (basic-alert)]
                              Card                  [card]
                              PulseCard             [_     (pulse-card alert card)]
@@ -595,7 +608,7 @@
                   (default-alert-req card pc))))))))
 
   (testing "Non-admin users can update alerts in collection they have view permisisons"
-    (tu/with-non-admin-groups-no-root-collection-perms
+    (mt/with-non-admin-groups-no-root-collection-perms
       (with-alert-in-collection [_ collection alert card]
         (mt/with-temp* [PulseCard [pc (pulse-card alert card)]]
           (perms/grant-collection-read-permissions! (perms-group/all-users) collection)
@@ -641,7 +654,7 @@
                 (assoc :can_write false)
                 (update-in [:channels 0] merge {:schedule_hour 15, :schedule_type "daily"})
                 (assoc-in [:card :collection_id] true))]
-           (tu/with-non-admin-groups-no-root-collection-perms
+           (mt/with-non-admin-groups-no-root-collection-perms
              (with-alert-setup
                (map alert-response
                     (with-alerts-in-readable-collection [alert]
@@ -676,7 +689,7 @@
                            ;; A separate admin created alert
                            Pulse                 [alert-2 (assoc (basic-alert)
                                                                  :alert_above_goal false
-                                                                 :creator_id       (user->id :crowberto))]
+                                                                 :creator_id       (mt/user->id :crowberto))]
                            PulseCard             [_       (pulse-card alert-2 card)]
                            PulseChannel          [pc-2    (pulse-channel alert-2)]
                            PulseChannelRecipient [_       (recipient pc-2 :crowberto)]
@@ -699,7 +712,7 @@
                     Pulse                 [alert-2 (assoc (basic-alert)
                                                           :alert_above_goal false
                                                           :archived         true
-                                                          :creator_id       (user->id :crowberto))]
+                                                          :creator_id       (mt/user->id :crowberto))]
                     PulseCard             [_       (pulse-card alert-2 card)]
                     PulseChannel          [pc-2    (pulse-channel alert-2)]
                     PulseChannelRecipient [_       (recipient pc-2 :crowberto)]
@@ -773,11 +786,11 @@
              (with-alerts-in-readable-collection [alert]
                (with-alert-setup
                  (array-map
-                  :recipients-1 (recipient-emails ((user->client :rasta) :get 200 (alert-question-url card)))
+                  :recipients-1 (recipient-emails (mt/user-http-request :rasta :get 200 (alert-question-url card)))
                   :recipients-2 (do
                                   (et/with-expected-messages 1
                                     (api:unsubscribe! :crowberto 204 alert))
-                                  (recipient-emails ((user->client :crowberto) :get 200 (alert-question-url card))))
+                                  (recipient-emails (mt/user-http-request :crowberto :get 200 (alert-question-url card))))
                   :emails       (et/regex-email-bodies #"https://metabase.com/testmb"
                                                        #"Foo"))))))))
 

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -908,6 +908,18 @@
            (is (= new-mappings
                   (db/select-one-field :parameter_mappings DashboardCard :dashboard_id dashboard-id, :card_id card-id)))))))))
 
+(deftest disallow-adding-is-write-card-to-dashboard-test
+  (testing "PUT /api/dashboard/:id/cards"
+    (testing "Disallow adding a QueryAction is_write Card to a Dashboard (#22846)"
+      (mt/with-temp* [Dashboard [{dashboard-id :id}]
+                      Card      [{card-id :id} {:is_write true}]]
+        (is (= "You cannot add an is_write Card to a Dashboard."
+               (mt/user-http-request :crowberto :post 400
+                                     (format "dashboard/%d/cards" dashboard-id)
+                                     {:cardId card-id
+                                      :row    0
+                                      :col    0})))))))
+
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                        DELETE /api/dashboard/:id/cards                                         |

--- a/test/metabase/api/emitter_test.clj
+++ b/test/metabase/api/emitter_test.clj
@@ -2,99 +2,45 @@
   (:require
    [clojure.test :refer :all]
    [metabase.actions.test-util :as actions.test-util]
-   [metabase.models
-    :refer [Card
-            CardEmitter
-            Dashboard
-            Database
-            Emitter
-            EmitterAction
-            QueryAction]]
+   [metabase.models :refer [Card Dashboard]]
    [metabase.test :as mt]
    [metabase.util.schema :as su]
-   [schema.core :as s]
-   [toucan.db :as db]))
-
-(defn- do-with-query-action [f]
-  (mt/with-temp* [Card [{card-id :id} {:database_id   (mt/id)
-                                       :dataset_query {:database (mt/id)
-                                                       :type     :native
-                                                       :native   {:query         (str "UPDATE categories\n"
-                                                                                      "SET name = 'Bird Shop'\n"
-                                                                                      "WHERE id = {{id}}")
-                                                                  :template-tags {"id" {:name         "id"
-                                                                                        :display-name "ID"
-                                                                                        :type         :number
-                                                                                        :required     true}}}}
-                                       :is_write      true}]]
-    (let [action-id (db/select-one-field :action_id QueryAction :card_id card-id)]
-      (f {:query-action-card-id card-id
-          :action-id            action-id}))))
-
-(defn- do-with-card-emitter [{:keys [action-id], :as context} f]
-  (mt/with-temp* [Card    [{emitter-card-id :id}]
-                  Emitter [{emitter-id :id} {:parameter_mappings {"my_id" [:variable [:template-tag "id"]]}}]]
-    (testing "Sanity check: emitter-id should be non-nil"
-      (is (integer? emitter-id)))
-    (testing "Sanity check: make sure parameter mappings were defined the way we'd expect"
-      (is (= {:my_id [:variable [:template-tag "id"]]}
-             (db/select-one-field :parameter_mappings Emitter :id emitter-id))))
-    ;; these are tied to the Card and Emitter above and will get cascade deleted. We can't use `with-temp*` for them
-    ;; because it doesn't seem to work with tables with compound PKs
-    (db/insert! EmitterAction {:emitter_id emitter-id
-                               :action_id action-id})
-    (db/insert! CardEmitter {:card_id   emitter-card-id
-                             :action_id action-id})
-    (f (assoc context
-              :emitter-id      emitter-id
-              :emitter-card-id emitter-card-id))))
-
-(defn- do-with-actions-setup [thunk]
-  (actions.test-util/with-actions-test-data
-    (mt/with-temporary-setting-values [experimental-enable-actions true]
-      (mt/with-temp-vals-in-db Database (mt/id) {:settings {:database-enable-actions true}}
-        (thunk)))))
+   [schema.core :as s]))
 
 (deftest create-emitter-test
   (testing "POST /api/emitter"
     (testing "Creating an emitter with the POST endpoint should return the newly created Emitter"
-      (do-with-actions-setup
-       (fn []
-         (do-with-query-action
-          (fn [{:keys [action-id query-action-card-id]}]
-            (let [expected-response {:id                 su/IntGreaterThanZero
-                                     :parameter_mappings (s/eq nil)
-                                     :action_id          (s/eq action-id)
-                                     :action             {:type     (s/eq      "query")
-                                                          :card     {:id       (s/eq query-action-card-id)
-                                                                     s/Keyword s/Any}
-                                                          s/Keyword s/Any}
-                                     s/Keyword           s/Any}]
-              (testing "CardEmitter"
-                (mt/with-temp Card [{card-id :id}]
-                  (is (schema= expected-response
-                               (mt/user-http-request :crowberto :post 200 "emitter" {:card_id   card-id
-                                                                                     :action_id action-id})))))
-              (testing "DashboardEmitter"
-                (mt/with-temp Dashboard [{dashboard-id :id}]
-                  (is (schema= expected-response
-                               (mt/user-http-request :crowberto :post 200 "emitter" {:dashboard_id dashboard-id
-                                                                                     :action_id    action-id})))))))))))))
+      (actions.test-util/with-actions-setup
+        (actions.test-util/with-query-action [{:keys [action-id query-action-card-id]}]
+          (let [expected-response {:id                 su/IntGreaterThanZero
+                                   :parameter_mappings (s/eq nil)
+                                   :action_id          (s/eq action-id)
+                                   :action             {:type     (s/eq      "query")
+                                                        :card     {:id       (s/eq query-action-card-id)
+                                                                   s/Keyword s/Any}
+                                                        s/Keyword s/Any}
+                                   s/Keyword           s/Any}]
+            (testing "CardEmitter"
+              (mt/with-temp Card [{card-id :id}]
+                (is (schema= expected-response
+                             (mt/user-http-request :crowberto :post 200 "emitter" {:card_id   card-id
+                                                                                   :action_id action-id})))))
+            (testing "DashboardEmitter"
+              (mt/with-temp Dashboard [{dashboard-id :id}]
+                (is (schema= expected-response
+                             (mt/user-http-request :crowberto :post 200 "emitter" {:dashboard_id dashboard-id
+                                                                                   :action_id    action-id})))))))))))
 
 (deftest execute-custom-action-test
   (mt/test-drivers (mt/normal-drivers-with-feature :actions/custom)
-    (do-with-actions-setup
-     (fn []
-       (do-with-query-action
-        (fn [context]
-          (do-with-card-emitter
-           context
-           (fn [{:keys [emitter-id], :as _context}]
-             (testing "Should be able to execute an emitter"
-               (is (= {:rows-affected 1}
-                      (mt/user-http-request :crowberto :post 200 (format "emitter/%d/execute" emitter-id)
-                                            {:parameters {"my_id" {:type  :number/=
-                                                                   :value 1}}}))))
-             (is (= [1 "Bird Shop"]
-                    (mt/first-row
-                     (mt/run-mbql-query categories {:filter [:= $id 1]}))))))))))))
+    (actions.test-util/with-actions-setup
+      (actions.test-util/with-query-action [context]
+        (actions.test-util/with-card-emitter [{:keys [emitter-id]} context]
+          (testing "Should be able to execute an emitter"
+            (is (= {:rows-affected 1}
+                   (mt/user-http-request :crowberto :post 200 (format "emitter/%d/execute" emitter-id)
+                                         {:parameters {"my_id" {:type  :number/=
+                                                                :value 1}}}))))
+          (is (= [1 "Bird Shop"]
+                 (mt/first-row
+                  (mt/run-mbql-query categories {:filter [:= $id 1]})))))))))

--- a/test/metabase/api/emitter_test.clj
+++ b/test/metabase/api/emitter_test.clj
@@ -10,7 +10,7 @@
 (deftest create-emitter-test
   (testing "POST /api/emitter"
     (testing "Creating an emitter with the POST endpoint should return the newly created Emitter"
-      (actions.test-util/with-actions-setup
+      (actions.test-util/with-actions-test-data-and-actions-enabled
         (actions.test-util/with-query-action [{:keys [action-id query-action-card-id]}]
           (let [expected-response {:id                 su/IntGreaterThanZero
                                    :parameter_mappings (s/eq nil)
@@ -33,7 +33,7 @@
 
 (deftest execute-custom-action-test
   (mt/test-drivers (mt/normal-drivers-with-feature :actions/custom)
-    (actions.test-util/with-actions-setup
+    (actions.test-util/with-actions-test-data-and-actions-enabled
       (actions.test-util/with-query-action [context]
         (actions.test-util/with-card-emitter [{:keys [emitter-id]} context]
           (testing "Should be able to execute an emitter"


### PR DESCRIPTION
Implements #22846

This PR throws a 400 if you attempt to add an `is_write` (QueryAction) Card to a Dashboard, make an Alert for it, share it publicly, or embed it.