### PR TITLE
[E2E] Do not run `@quarantine` tagged tests on PRs

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -147,7 +147,10 @@ jobs:
 
     - name: Run EE Cypress tests on ${{ matrix.folder }}
       if: matrix.edition == 'ee'
-      run: yarn run test-cypress-run --folder ${{ matrix.folder }}
+      run: |
+        yarn run test-cypress-run \
+        --env grepTags="-@quarantine" \
+        --folder ${{ matrix.folder }}
       env:
         TERM: xterm
 

--- a/frontend/test/metabase/scenarios/admin/tools/erroring-questions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/tools/erroring-questions.cy.spec.js
@@ -20,86 +20,92 @@ const brokenQuestionDetails = {
   display: "scalar",
 };
 
-describeEE("admin > tools > erroring questions ", () => {
-  beforeEach(() => {
-    restore();
-    cy.signInAsAdmin();
-
-    cy.intercept("POST", "/api/dataset").as("dataset");
-  });
-
-  describe("without broken questions", () => {
-    it.skip('should render the "Tools" tab and navigate to the "Erroring Questions" by clicking on it', () => {
-      // The sidebar has been taken out, because it looks awkward when there's only one elem on it: put it back in when there's more than one
-      cy.visit("/admin");
-
-      cy.get("nav").contains("Tools").click();
-
-      cy.location("pathname").should("eq", TOOLS_ERRORS_URL);
-      cy.findByRole("link", { name: "Erroring Questions" })
-        .should("have.attr", "href")
-        .and("eq", TOOLS_ERRORS_URL);
-    });
-
-    it("should disable search input fields (metabase#18050)", () => {
-      cy.visit(TOOLS_ERRORS_URL);
-
-      cy.findByText("No results");
-      cy.button("Rerun Selected").should("be.disabled");
-      cy.findByPlaceholderText("Error contents").should("be.disabled");
-      cy.findByPlaceholderText("DB name").should("be.disabled");
-      cy.findByPlaceholderText("Collection name").should("be.disabled");
-    });
-  });
-
-  describe("with the existing broken questions", () => {
+// Quarantine the whole spec because it is most likely causing the H2 timeouts and the chained failures!
+// NOTE: it will be quarantined on PRs, but will still run on `master`!
+describeEE(
+  "admin > tools > erroring questions ",
+  { tags: "@quarantine" },
+  () => {
     beforeEach(() => {
-      cy.createNativeQuestion(brokenQuestionDetails, {
-        loadMetadata: true,
+      restore();
+      cy.signInAsAdmin();
+
+      cy.intercept("POST", "/api/dataset").as("dataset");
+    });
+
+    describe("without broken questions", () => {
+      it.skip('should render the "Tools" tab and navigate to the "Erroring Questions" by clicking on it', () => {
+        // The sidebar has been taken out, because it looks awkward when there's only one elem on it: put it back in when there's more than one
+        cy.visit("/admin");
+
+        cy.get("nav").contains("Tools").click();
+
+        cy.location("pathname").should("eq", TOOLS_ERRORS_URL);
+        cy.findByRole("link", { name: "Erroring Questions" })
+          .should("have.attr", "href")
+          .and("eq", TOOLS_ERRORS_URL);
       });
 
-      cy.visit(TOOLS_ERRORS_URL);
+      it("should disable search input fields (metabase#18050)", () => {
+        cy.visit(TOOLS_ERRORS_URL);
+
+        cy.findByText("No results");
+        cy.button("Rerun Selected").should("be.disabled");
+        cy.findByPlaceholderText("Error contents").should("be.disabled");
+        cy.findByPlaceholderText("DB name").should("be.disabled");
+        cy.findByPlaceholderText("Collection name").should("be.disabled");
+      });
     });
 
-    it("should render correctly", () => {
-      cy.wait("@dataset");
+    describe("with the existing broken questions", () => {
+      beforeEach(() => {
+        cy.createNativeQuestion(brokenQuestionDetails, {
+          loadMetadata: true,
+        });
 
-      selectQuestion(brokenQuestionDetails.name);
+        cy.visit(TOOLS_ERRORS_URL);
+      });
 
-      cy.button("Rerun Selected").should("not.be.disabled").click();
+      it("should render correctly", () => {
+        cy.wait("@dataset");
 
-      cy.wait("@dataset");
+        selectQuestion(brokenQuestionDetails.name);
 
-      // The question is still there because we didn't fix it
-      cy.findByText(brokenQuestionDetails.name);
-      cy.button("Rerun Selected").should("be.disabled");
+        cy.button("Rerun Selected").should("not.be.disabled").click();
 
-      cy.findByPlaceholderText("Error contents").should("not.be.disabled");
-      cy.findByPlaceholderText("DB name").should("not.be.disabled");
-      cy.findByPlaceholderText("Collection name")
-        .should("not.be.disabled")
-        .type("foo");
+        cy.wait("@dataset");
 
-      cy.wait("@dataset");
+        // The question is still there because we didn't fix it
+        cy.findByText(brokenQuestionDetails.name);
+        cy.button("Rerun Selected").should("be.disabled");
 
-      cy.findByText("No results");
+        cy.findByPlaceholderText("Error contents").should("not.be.disabled");
+        cy.findByPlaceholderText("DB name").should("not.be.disabled");
+        cy.findByPlaceholderText("Collection name")
+          .should("not.be.disabled")
+          .type("foo");
+
+        cy.wait("@dataset");
+
+        cy.findByText("No results");
+      });
+
+      it("should remove fixed question on a rerun", () => {
+        fixQuestion(brokenQuestionDetails.name);
+
+        cy.visit(TOOLS_ERRORS_URL);
+
+        selectQuestion(brokenQuestionDetails.name);
+
+        cy.button("Rerun Selected").should("not.be.disabled").click();
+
+        cy.wait("@dataset");
+
+        cy.findByText("No results");
+      });
     });
-
-    it("should remove fixed question on a rerun", () => {
-      fixQuestion(brokenQuestionDetails.name);
-
-      cy.visit(TOOLS_ERRORS_URL);
-
-      selectQuestion(brokenQuestionDetails.name);
-
-      cy.button("Rerun Selected").should("not.be.disabled").click();
-
-      cy.wait("@dataset");
-
-      cy.findByText("No results");
-    });
-  });
-});
+  },
+);
 
 function fixQuestion(name) {
   cy.visit("/collection/root");


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Skips the `erroring-questions` spec all together because it is the most likely culprit behind the H2 locking and the domino effect where 16 (subsequent) tests are failing
    - Example: https://github.com/metabase/metabase/runs/7220582189?check_suite_focus=true
- Serves as a PoC of how to exclude tests with certain `grepTags` on PR, but still run them in `master` (which will alert us if we break something)

### How to test?
Once the CI finishes all tests in this spec should be skipped and the log will look like:
```
  admin > tools > erroring questions
    without broken questions
      - should render the "Tools" tab and navigate to the "Erroring Questions" by clicking on it
      - should disable search input fields (metabase#18050)
    with the existing broken questions
      - should render correctly
      - should remove fixed question on a rerun


  0 passing (314ms)
  4 pending
```
And indeed, that is what happens: https://github.com/metabase/metabase/runs/7222740815?check_suite_focus=true#step:11:1511

Hopefully, H2 locking problem will go away with this change. At least we will now have the option to compare runs on PRs and on the `master` branch.