### PR TITLE
Fix parameter input loses value

### DIFF
--- a/frontend/src/metabase/components/TextWidget/TextWidget.tsx
+++ b/frontend/src/metabase/components/TextWidget/TextWidget.tsx
@@ -21,11 +21,6 @@ type State = {
 };
 
 class TextWidget extends React.Component<Props, State> {
-  state: State = {
-    value: null,
-    isFocused: false,
-  };
-
   static defaultProps = {
     isEditing: false,
     commitImmediately: false,
@@ -34,6 +29,11 @@ class TextWidget extends React.Component<Props, State> {
 
   constructor(props: Props) {
     super(props);
+
+    this.state = {
+      value: props.value,
+      isFocused: false,
+    };
   }
 
   static noPopover = true;
@@ -43,7 +43,7 @@ class TextWidget extends React.Component<Props, State> {
   }
 
   UNSAFE_componentWillReceiveProps(nextProps: Props) {
-    if (nextProps.value !== this.state.value) {
+    if (nextProps.value !== this.props.value) {
       this.setState({ value: nextProps.value }, () => {
         // HACK: Address Safari rendering bug which causes https://github.com/metabase/metabase/issues/5335
         forceRedraw(ReactDOM.findDOMNode(this));


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/23640
Caused by https://github.com/metabase/metabase/pull/22819

## Changes

Every state rerender of a dashboard previously reset a parameter text input value. So did the state change when favicon changes. Caused by a recent refactoring.

## How to verify

Check the original issue repro steps

Reproduction video for easier understanding:

<video src="https://user-images.githubusercontent.com/14301985/177646468-725595f5-2611-41a3-8869-94c9357f15e7.mov" />



