### PR TITLE
Add a check to PUT /user/:id to disallow name edits if an SSO user

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
@@ -128,7 +128,7 @@
     (f)
     (finally
       (u/ignore-exceptions (do (db/update-where! User {} :login_attributes nil)
-                               (db/update-where! User {:email "rasta@metabase.com"} :first_name "Rasta" :last_name "Toucan"))))))
+                               (db/update-where! User {:email "rasta@metabase.com"} :first_name "Rasta" :last_name "Toucan" :sso_source nil))))))
 
 (defmacro ^:private with-saml-default-setup [& body]
   `(with-valid-premium-features-token

--- a/src/metabase/api/user.clj
+++ b/src/metabase/api/user.clj
@@ -281,12 +281,9 @@
 (defn- valid-name-update?
   "This predicate tests whether or not the user is allowed to update the first/last name associated with this account.
   If the user is an SSO user, no name edits are allowed, but we accept if the new names are equal to the existing names."
-  [{:keys [google_auth ldap_auth sso_source first_name last_name]} new-first-name new-last-name]
+  [{:keys [google_auth ldap_auth sso_source] :as user} name-key new-name]
   (or
-   ;; allow the update if the names are the same as existing names, since nothing changes
-   (and
-    (or (nil? new-first-name) (= first_name new-first-name))
-    (or (nil? new-last-name) (= last_name new-last-name)))
+   (= (get user name-key) new-name)
    (and
     (not sso_source)
     (not google_auth)
@@ -316,10 +313,12 @@
     ;; Google/LDAP non-admin users can't change their email to prevent account hijacking
     (api/check-403 (valid-email-update? user-before-update email))
     ;; SSO users (JWT, SAML, LDAP, Google) can't change their first/last names
-    (when (or (contains? body :first_name)
-              (contains? body :last_name))
-      (api/checkp (valid-name-update? user-before-update first_name last_name)
-        "name" (tru "Editing names is not allowed for SSO users.")))
+    (when (contains? body :first_name)
+      (api/checkp (valid-name-update? user-before-update :first_name first_name)
+        "first_name" (tru "Editing first name is not allowed for SSO users.")))
+    (when (contains? body :last_name)
+      (api/checkp (valid-name-update? user-before-update :last_name last_name)
+        "last_name" (tru "Editing last name is not allowed for SSO users.")))
     ;; can't change email if it's already taken BY ANOTHER ACCOUNT
     (api/checkp (not (db/exists? User, :%lower.email (if email (u/lower-case-en email) email), :id [:not= id]))
                 "email" (tru "Email address already associated to another user."))

--- a/src/metabase/models/user.clj
+++ b/src/metabase/models/user.clj
@@ -121,7 +121,7 @@
 (def admin-or-self-visible-columns
   "Sequence of columns that we can/should return for admins fetching a list of all Users, or for the current user
   fetching themselves. Needed to power the admin page."
-  (into default-user-columns [:google_auth :ldap_auth :is_active :updated_at :login_attributes :locale]))
+  (into default-user-columns [:google_auth :ldap_auth :sso_source :is_active :updated_at :login_attributes :locale]))
 
 (def non-admin-or-self-visible-columns
   "Sequence of columns that we will allow non-admin Users to see when fetching a list of Users. Why can non-admins see

--- a/test/metabase/api/user_test.clj
+++ b/test/metabase/api/user_test.clj
@@ -670,7 +670,7 @@
     (testing "test that updating a user's email to an existing inactive user's email fails"
       (let [trashbird (mt/fetch-user :trashbird)
             rasta     (mt/fetch-user :rasta)]
-        (is (= {:errors {:first_name "ASDF"}}
+        (is (= {:errors {:email "Email address already associated to another user."}}
                (mt/user-http-request :crowberto :put 400 (str "user/" (u/the-id rasta))
                                      (select-keys trashbird [:email]))))))))
 

--- a/test/metabase/api/user_test.clj
+++ b/test/metabase/api/user_test.clj
@@ -35,6 +35,7 @@
       :is_active        true
       :last_login       false
       :ldap_auth        false
+      :sso_source       nil
       :login_attributes nil
       :updated_at       true
       :locale           nil})))

--- a/test/metabase/api/user_test.clj
+++ b/test/metabase/api/user_test.clj
@@ -650,19 +650,17 @@
                                          :email        "sso-user@metabase.com"
                                          :sso_source   "jwt"
                                          :is_superuser true}]
-        (letfn [(change-user-via-api! [m]
-                  (mt/user-http-request :crowberto :put 400 (str "user/" user-id) m))]
+        (letfn [(change-user-via-api! [expected-status m]
+                  (mt/user-http-request :crowberto :put expected-status (str "user/" user-id) m))]
           (testing "`:first_name` changes are rejected"
             (is (= {:errors {:first_name "Editing first name is not allowed for SSO users."}}
-                   (change-user-via-api! {:first_name "NOT-SSO"}))))
+                   (change-user-via-api! 400 {:first_name "NOT-SSO"}))))
           (testing "`:last_name` changes are rejected"
             (is (= {:errors {:last_name "Editing last name is not allowed for SSO users."}}
-                   (change-user-via-api! {:last_name "USER"}))))
+                   (change-user-via-api! 400 {:last_name "USER"}))))
           (testing "New names that are the same as existing names succeed because there is no change."
-            (is (partial= {:first_name "SSO"
-                           :last_name  "User"}
-                          (mt/user-http-request :crowberto :put 200 (str "user/" user-id) {:first_name "SSO"
-                                                                                           :last_name  "User"})))))))))
+            (is (partial= {:first_name "SSO" :last_name  "User"}
+                          (change-user-via-api! 200 {:first_name "SSO" :last_name  "User"})))))))))
 
 (deftest update-email-check-if-already-used-test
   (testing "PUT /api/user/:id"

--- a/test/metabase/api/user_test.clj
+++ b/test/metabase/api/user_test.clj
@@ -659,11 +659,10 @@
             (is (= {:errors {:last_name "Editing last name is not allowed for SSO users."}}
                    (change-user-via-api! {:last_name "USER"}))))
           (testing "New names that are the same as existing names succeed because there is no change."
-            (is (= {:first_name "SSO"
-                    :last_name  "User"}
-                   (-> (mt/user-http-request :crowberto :put 200 (str "user/" user-id) {:first_name "SSO"
-                                                                                        :last_name  "User"})
-                       (select-keys [:first_name :last_name]))))))))))
+            (is (partial= {:first_name "SSO"
+                           :last_name  "User"}
+                          (mt/user-http-request :crowberto :put 200 (str "user/" user-id) {:first_name "SSO"
+                                                                                           :last_name  "User"})))))))))
 
 (deftest update-email-check-if-already-used-test
   (testing "PUT /api/user/:id"

--- a/test/metabase/api/user_test.clj
+++ b/test/metabase/api/user_test.clj
@@ -651,7 +651,7 @@
                                          :sso_source   "jwt"
                                          :is_superuser true}]
         (letfn [(change-user-via-api! [m]
-                  (-> (mt/user-http-request :crowberto :put 400 (str "user/" user-id) m)))]
+                  (mt/user-http-request :crowberto :put 400 (str "user/" user-id) m))]
           (testing "`:first_name` changes are rejected"
             (is (= {:errors {:first_name "Editing first name is not allowed for SSO users."}}
                    (change-user-via-api! {:first_name "NOT-SSO"}))))

--- a/test/metabase/api/user_test.clj
+++ b/test/metabase/api/user_test.clj
@@ -653,10 +653,10 @@
         (letfn [(change-user-via-api! [m]
                   (-> (mt/user-http-request :crowberto :put 400 (str "user/" user-id) m)))]
           (testing "`:first_name` changes are rejected"
-            (is (= {:errors {:name "Editing names is not allowed for SSO users."}}
+            (is (= {:errors {:first_name "Editing first name is not allowed for SSO users."}}
                    (change-user-via-api! {:first_name "NOT-SSO"}))))
           (testing "`:last_name` changes are rejected"
-            (is (= {:errors {:name "Editing names is not allowed for SSO users."}}
+            (is (= {:errors {:last_name "Editing last name is not allowed for SSO users."}}
                    (change-user-via-api! {:last_name "USER"}))))
           (testing "New names that are the same as existing names succeed because there is no change."
             (is (= {:first_name "SSO"


### PR DESCRIPTION
Fixes: https://github.com/metabase/metabase/issues/16315
(since frontend changes to the UI already address the same concerns)

The ability for an SSO user to edit their names should be disallowed via API to mirror the same behaviour on the frontend.