### PR TITLE
Port fixes for Postgresql JSON issues to MySQL

### DIFF
--- a/src/metabase/driver/common.clj
+++ b/src/metabase/driver/common.clj
@@ -170,10 +170,12 @@
 (def json-unfolding
   "Map representing the `json-unfolding` option in a DB connection form"
   {:name         "json-unfolding"
-   :display-name (trs "Unfold JSON Columns")
+   :display-name (deferred-tru "Unfold JSON Columns")
    :type         :boolean
    :visible-if   {"advanced-options" true}
-   :description  (trs "We unfold JSON columns into component fields. This is on by default but you can turn it off if performance is slow.")
+   :description  (deferred-tru
+                   (str "We unfold JSON columns into component fields."
+                        "This is on by default but you can turn it off if performance is slow."))
    :default      true})
 
 (def refingerprint

--- a/src/metabase/driver/common.clj
+++ b/src/metabase/driver/common.clj
@@ -174,7 +174,7 @@
    :type         :boolean
    :visible-if   {"advanced-options" true}
    :description  (trs "We unfold JSON columns into component fields. This is on by default but you can turn it off if performance is slow.")
-   :default      true}
+   :default      true})
 
 (def refingerprint
   "Map representing the `refingerprint` option in a DB connection form."

--- a/src/metabase/driver/common.clj
+++ b/src/metabase/driver/common.clj
@@ -167,6 +167,15 @@
                         "and cache field values?"))
    :visible-if   {"let-user-control-scheduling" true}})
 
+(def json-unfolding
+  "Map representing the `json-unfolding` option in a DB connection form"
+  {:name         "json-unfolding"
+   :display-name (trs "Unfold JSON Columns")
+   :type         :boolean
+   :visible-if   {"advanced-options" true}
+   :description  (trs "We unfold JSON columns into component fields. This is on by default but you can turn it off if performance is slow.")
+   :default      true}
+
 (def refingerprint
   "Map representing the `refingerprint` option in a DB connection form."
   {:name         "refingerprint"

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -41,10 +41,7 @@
 (defmethod driver/display-name :mysql [_] "MySQL")
 
 (defmethod driver/database-supports? [:mysql :nested-field-columns] [_ _ database]
-  (let [json-setting (get-in database [:details :json-unfolding])
-        ;; If not set at all, default to true, actually
-        setting-nil? (nil? json-setting)]
-    (or json-setting setting-nil?)))
+  (or (get-in database [:details :json-unfolding]) true))
 
 (defmethod driver/database-supports? [:mysql :persist-models] [_driver _feat _db] true)
 

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -240,10 +240,9 @@
   (hsql/call :char_length (sql.qp/->honeysql driver arg)))
 
 (defmethod sql.qp/json-query :mysql
-  [_ identifier stored-field]
+  [_ unwrapped-identifier stored-field]
   (letfn [(handle-name [x] (str "\"" (if (number? x) (str x) (name x)) "\""))]
     (let [nfc-path             (:nfc_path stored-field)
-          unwrapped-identifier (:form identifier)
           parent-identifier    (field/nfc-field->parent-identifier unwrapped-identifier stored-field)
           jsonpath-query       (format "$.%s" (str/join "." (map handle-name (rest nfc-path))))]
       (reify

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -38,7 +38,11 @@
 
 (defmethod driver/display-name :mysql [_] "MySQL")
 
-(defmethod driver/database-supports? [:mysql :nested-field-columns] [_ _ _] true)
+(defmethod driver/database-supports? [:mysql :nested-field-columns] [_ _ _]
+  (let [json-setting (get-in database [:details :json-unfolding])
+        ;; If not set at all, default to true, actually
+        setting-nil? (nil? json-setting)]
+    (or json-setting setting-nil?)))
 
 (defmethod driver/database-supports? [:mysql :persist-models] [_driver _feat _db] true)
 
@@ -110,6 +114,7 @@
     default-ssl-cert-details
     driver.common/ssh-tunnel-preferences
     driver.common/advanced-options-start
+    driver.common/json-unfolding
     (assoc driver.common/additional-options
            :placeholder  "tinyInt1isBit=false")
     driver.common/default-advanced-options]

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -166,12 +166,8 @@
      :visible-if   {"ssl-use-client-auth" true}}
     driver.common/ssh-tunnel-preferences
     driver.common/advanced-options-start
-    {:name         "json-unfolding"
-     :display-name (trs "Unfold JSON Columns")
-     :type         :boolean
-     :visible-if   {"advanced-options" true}
-     :description  (trs "We unfold JSON columns into component fields. This is on by default but you can turn it off if performance is slow.")
-     :default      true}
+    driver.common/json-unfolding
+
     (assoc driver.common/additional-options
            :placeholder "prepareThreshold=0")
     driver.common/default-advanced-options]

--- a/test/metabase/driver/mysql_test.clj
+++ b/test/metabase/driver/mysql_test.clj
@@ -443,7 +443,7 @@
                    {:name "big_json"}))))))))
 
 (deftest json-query-test
-  (let [boop-identifier (hx/with-type-info (hx/identifier :field "boop" "bleh -> meh") {})]
+  (let [boop-identifier (:form (hx/with-type-info (hx/identifier :field "boop" "bleh -> meh") {}))]
     (testing "Transforming MBQL query with JSON in it to mysql query works"
       (let [boop-field {:nfc_path [:bleh :meh] :database_type "integer"}]
         (is (= ["JSON_EXTRACT(boop.bleh, ?)" "$.\"meh\""]

--- a/test/metabase/driver/mysql_test.clj
+++ b/test/metabase/driver/mysql_test.clj
@@ -493,7 +493,7 @@
                                                               :min-value 0.75,
                                                               :max-value 54.0,
                                                               :bin-width 0.75}}]]
-                  (is (= ["((floor((((complicated_identifiers.jsons#>> ?::text[])::integer  - 0.75) / 0.75)) * 0.75) + 0.75)" "{values,qty}"]
+                  (is (= ["((floor(((JSON_EXTRACT(json.json_bit, ?) - 0.75) / 0.75)) * 0.75) + 0.75)" "$.\"1234\""]
                          (hsql/format (sql.qp/->honeysql :mysql field-clause)))))))))))))
 
 (deftest ddl.execute-with-timeout-test

--- a/test/metabase/driver/mysql_test.clj
+++ b/test/metabase/driver/mysql_test.clj
@@ -483,13 +483,10 @@
       (testing "Deal with complicated identifier (#22967, but for mysql)"
         (mt/dataset json
           (let [database (mt/db)
-                table    (db/select-one Table :db_id (u/id (mt/db)) :name "json")]
+                table    (db/select-one Table :db_id (u/id database) :name "json")]
             (sync/sync-table! table)
             (let [field    (db/select-one Field :table_id (u/id table) :name "json_bit → 1234")]
-              (qp.store/with-store
-                (qp.store/fetch-and-store-database! (u/the-id database))
-                (qp.store/fetch-and-store-tables! [(u/the-id table)])
-                (qp.store/fetch-and-store-fields! [(u/the-id field)])
+              (mt/with-everything-store
                 (let [field-clause [:field (u/the-id field) {:binning
                                                              {:strategy :num-bins,
                                                               :num-bins 100,


### PR DESCRIPTION
#22967 and boat#161 also apply to MySQL JSON implementation. This PR ports the fixes for those (in #23278 and #22997 respectively) to MySQL.

There are many other JSON implementation fixes which don't need a separate port because we moved the `describe-table` mechanism to the SQL JDBC driver instead of just the Postgres driver.