### PR TITLE
Add tooltip to verify icon for questions

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationReviewBanner/ModerationReviewBanner.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationReviewBanner/ModerationReviewBanner.jsx
@@ -7,7 +7,7 @@ import Icon from "metabase/components/Icon";
 
 import { color, alpha } from "metabase/lib/colors";
 import { getUser } from "metabase/selectors/user";
-import { getRelativeTimeAbbreviated } from "metabase/lib/time";
+import { getRelativeTime } from "metabase/lib/time";
 import {
   getTextForReviewBanner,
   getIconForReview,
@@ -54,9 +54,7 @@ export function ModerationReviewBanner({
     moderator,
     currentUser,
   );
-  const relativeCreationTime = getRelativeTimeAbbreviated(
-    moderationReview.created_at,
-  );
+  const relativeCreationTime = getRelativeTime(moderationReview.created_at);
   const { name: iconName, color: iconColor } =
     getIconForReview(moderationReview);
 

--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationReviewBanner/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationReviewBanner/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ModerationReviewBanner";

--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationReviewIcon/ModerationReviewIcon.styled.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationReviewIcon/ModerationReviewIcon.styled.tsx
@@ -1,21 +1,7 @@
 import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
 
-export const TooltipContainer = styled.div`
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-`;
-
-export const TooltipText = styled.span`
-  font-size: 0.875rem;
-  line-height: 1rem;
-  margin-bottom: 0.25rem;
-  font-weight: 700;
-`;
-
 export const TooltipTime = styled.time`
   color: ${color("text-medium")};
-  font-size: 0.766rem;
-  line-height: 1.25rem;
+  font-size: 0.875em;
 `;

--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationReviewIcon/ModerationReviewIcon.styled.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationReviewIcon/ModerationReviewIcon.styled.tsx
@@ -1,0 +1,21 @@
+import styled from "@emotion/styled";
+import { color } from "metabase/lib/colors";
+
+export const TooltipContainer = styled.div`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+`;
+
+export const TooltipText = styled.span`
+  font-size: 0.875rem;
+  line-height: 1rem;
+  margin-bottom: 0.25rem;
+  font-weight: 700;
+`;
+
+export const TooltipTime = styled.time`
+  color: ${color("text-medium")};
+  font-size: 0.766rem;
+  line-height: 1.25rem;
+`;

--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationReviewIcon/ModerationReviewIcon.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationReviewIcon/ModerationReviewIcon.tsx
@@ -1,15 +1,11 @@
 import React from "react";
 import { color } from "metabase/lib/colors";
-import { getRelativeTimeAbbreviated } from "metabase/lib/time";
+import { getRelativeTime } from "metabase/lib/time";
 import Icon from "metabase/components/Icon";
 import Tooltip from "metabase/components/Tooltip";
 import { ModerationReview, User } from "metabase-types/api";
 import { getIconForReview, getModeratorDisplayText } from "../../service";
-import {
-  TooltipContainer,
-  TooltipText,
-  TooltipTime,
-} from "./ModerationReviewIcon.styled";
+import { TooltipTime } from "./ModerationReviewIcon.styled";
 
 export interface ModerationReviewIconProps {
   review: ModerationReview;
@@ -25,14 +21,12 @@ const ModerationReviewIcon = ({
   const { name: iconName, color: iconColor } = getIconForReview(review);
 
   const tooltip = moderator && (
-    <TooltipContainer>
-      <TooltipText>
-        {getModeratorDisplayText(moderator, currentUser)}
-      </TooltipText>
+    <div>
+      <div>{getModeratorDisplayText(moderator, currentUser)}</div>
       <TooltipTime dateTime={review.created_at}>
-        {getRelativeTimeAbbreviated(review.created_at)}
+        {getRelativeTime(review.created_at)}
       </TooltipTime>
-    </TooltipContainer>
+    </div>
   );
 
   return (

--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationReviewIcon/ModerationReviewIcon.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationReviewIcon/ModerationReviewIcon.tsx
@@ -1,7 +1,10 @@
 import React from "react";
+import { color } from "metabase/lib/colors";
 import { getRelativeTimeAbbreviated } from "metabase/lib/time";
+import Icon from "metabase/components/Icon";
+import Tooltip from "metabase/components/Tooltip";
 import { ModerationReview, User } from "metabase-types/api";
-import { getModeratorDisplayText } from "../../service";
+import { getIconForReview, getModeratorDisplayText } from "../../service";
 import {
   TooltipContainer,
   TooltipText,
@@ -19,14 +22,23 @@ const ModerationReviewIcon = ({
   moderator,
   currentUser,
 }: ModerationReviewIconProps): JSX.Element => {
-  const text = moderator && getModeratorDisplayText(moderator, currentUser);
-  const createdAt = getRelativeTimeAbbreviated(review.created_at);
+  const { name: iconName, color: iconColor } = getIconForReview(review);
+
+  const tooltip = moderator && (
+    <TooltipContainer>
+      <TooltipText>
+        {getModeratorDisplayText(moderator, currentUser)}
+      </TooltipText>
+      <TooltipTime dateTime={review.created_at}>
+        {getRelativeTimeAbbreviated(review.created_at)}
+      </TooltipTime>
+    </TooltipContainer>
+  );
 
   return (
-    <TooltipContainer>
-      <TooltipText>{text}</TooltipText>
-      <TooltipTime dateTime={review.created_at}>{createdAt}</TooltipTime>
-    </TooltipContainer>
+    <Tooltip tooltip={tooltip}>
+      <Icon name={iconName} color={color(iconColor)} />
+    </Tooltip>
   );
 };
 

--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationReviewIcon/ModerationReviewIcon.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationReviewIcon/ModerationReviewIcon.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { getRelativeTimeAbbreviated } from "metabase/lib/time";
+import { ModerationReview, User } from "metabase-types/api";
+import { getModeratorDisplayText } from "../../service";
+import {
+  TooltipContainer,
+  TooltipText,
+  TooltipTime,
+} from "./ModerationReviewIcon.styled";
+
+export interface ModerationReviewIconProps {
+  review: ModerationReview;
+  moderator?: User;
+  currentUser: User;
+}
+
+const ModerationReviewIcon = ({
+  review,
+  moderator,
+  currentUser,
+}: ModerationReviewIconProps): JSX.Element => {
+  const text = moderator && getModeratorDisplayText(moderator, currentUser);
+  const createdAt = getRelativeTimeAbbreviated(review.created_at);
+
+  return (
+    <TooltipContainer>
+      <TooltipText>{text}</TooltipText>
+      <TooltipTime dateTime={review.created_at}>{createdAt}</TooltipTime>
+    </TooltipContainer>
+  );
+};
+
+export default ModerationReviewIcon;

--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationReviewIcon/ModerationReviewIcon.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationReviewIcon/ModerationReviewIcon.unit.spec.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import {
   createMockModerationReview,
   createMockUser,
@@ -7,7 +8,6 @@ import {
 import ModerationReviewIcon, {
   ModerationReviewIconProps,
 } from "./ModerationReviewIcon";
-import userEvent from "@testing-library/user-event";
 
 describe("ModerationReviewIcon", () => {
   beforeEach(() => {

--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationReviewIcon/ModerationReviewIcon.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationReviewIcon/ModerationReviewIcon.unit.spec.tsx
@@ -12,7 +12,7 @@ import ModerationReviewIcon, {
 describe("ModerationReviewIcon", () => {
   beforeEach(() => {
     jest.useFakeTimers();
-    jest.setSystemTime(new Date(2022, 6, 7));
+    jest.setSystemTime(new Date(2022, 1, 7));
   });
 
   afterEach(() => {
@@ -20,9 +20,7 @@ describe("ModerationReviewIcon", () => {
   });
 
   it("should render correctly when moderator is loading", () => {
-    const props = getProps({
-      currentUser: createMockUser({ id: 1 }),
-    });
+    const props = getProps();
 
     render(<ModerationReviewIcon {...props} />);
 
@@ -31,15 +29,19 @@ describe("ModerationReviewIcon", () => {
 
   it("should show a tooltip on hover when moderator is loaded", () => {
     const props = getProps({
-      currentUser: createMockUser({ id: 1 }),
+      review: createMockModerationReview({
+        moderator_id: 1,
+        created_at: "2021-01-01T20:10:30.200",
+      }),
       moderator: createMockUser({ id: 1 }),
+      currentUser: createMockUser({ id: 1 }),
     });
 
     render(<ModerationReviewIcon {...props} />);
     userEvent.hover(screen.getByLabelText("verified icon"));
 
     expect(screen.getByText("You verified this")).toBeInTheDocument();
-    expect(screen.getByText("8 years ago")).toBeInTheDocument();
+    expect(screen.getByText("a year ago")).toBeInTheDocument();
   });
 });
 

--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationReviewIcon/ModerationReviewIcon.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationReviewIcon/ModerationReviewIcon.unit.spec.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import {
+  createMockModerationReview,
+  createMockUser,
+} from "metabase-types/api/mocks";
+import ModerationReviewIcon, {
+  ModerationReviewIconProps,
+} from "./ModerationReviewIcon";
+import userEvent from "@testing-library/user-event";
+
+describe("ModerationReviewIcon", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(2022, 6, 7));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("should render correctly when moderator is loading", () => {
+    const props = getProps({
+      currentUser: createMockUser({ id: 1 }),
+    });
+
+    render(<ModerationReviewIcon {...props} />);
+
+    expect(screen.getByLabelText("verified icon")).toBeInTheDocument();
+  });
+
+  it("should show a tooltip on hover when moderator is loaded", () => {
+    const props = getProps({
+      currentUser: createMockUser({ id: 1 }),
+      moderator: createMockUser({ id: 1 }),
+    });
+
+    render(<ModerationReviewIcon {...props} />);
+    userEvent.hover(screen.getByLabelText("verified icon"));
+
+    expect(screen.getByText("You verified this")).toBeInTheDocument();
+    expect(screen.getByText("8 years ago")).toBeInTheDocument();
+  });
+});
+
+const getProps = (
+  opts?: Partial<ModerationReviewIconProps>,
+): ModerationReviewIconProps => ({
+  review: createMockModerationReview(),
+  currentUser: createMockUser(),
+  ...opts,
+});

--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationReviewIcon/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationReviewIcon/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ModerationReviewIcon";

--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationStatusIcon/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationStatusIcon/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ModerationStatusIcon";

--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/QuestionModerationButton/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/QuestionModerationButton/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./QuestionModerationButton";

--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/QuestionModerationIcon/QuestionModerationIcon.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/QuestionModerationIcon/QuestionModerationIcon.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import Question from "metabase-lib/lib/Question";
-import { getLatestModerationReview } from "metabase-enterprise/moderation/service";
+import { getLatestModerationReview } from "../../service";
 import ModerationReviewIcon from "../../containers/ModerationReviewIcon";
 
 export interface QuestionModerationIconProps {

--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/QuestionModerationIcon/QuestionModerationIcon.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/QuestionModerationIcon/QuestionModerationIcon.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import Question from "metabase-lib/lib/Question";
+import { getLatestModerationReview } from "metabase-enterprise/moderation/service";
+import ModerationReviewIcon from "../../containers/ModerationReviewIcon";
+
+export interface QuestionModerationIconProps {
+  question: Question;
+}
+
+const QuestionModerationIcon = ({
+  question,
+}: QuestionModerationIconProps): JSX.Element | null => {
+  const review = getLatestModerationReview(question.getModerationReviews());
+
+  if (review) {
+    return <ModerationReviewIcon review={review} />;
+  } else {
+    return null;
+  }
+};
+
+export default QuestionModerationIcon;

--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/QuestionModerationIcon/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/QuestionModerationIcon/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./QuestionModerationIcon";

--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/QuestionModerationSection/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/QuestionModerationSection/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./QuestionModerationSection";

--- a/enterprise/frontend/src/metabase-enterprise/moderation/containers/ModerationReviewIcon/ModerationReviewIcon.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/containers/ModerationReviewIcon/ModerationReviewIcon.tsx
@@ -17,6 +17,7 @@ const mapStateToProps = (state: State) => ({
 const userProps = {
   id: (state: State, props: ModerationReviewIconProps) =>
     props.review.moderator_id,
+  entityAlias: "moderator",
   loadingAndErrorWrapper: false,
 };
 

--- a/enterprise/frontend/src/metabase-enterprise/moderation/containers/ModerationReviewIcon/ModerationReviewIcon.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/containers/ModerationReviewIcon/ModerationReviewIcon.tsx
@@ -1,0 +1,26 @@
+import { connect } from "react-redux";
+import _ from "underscore";
+import Users from "metabase/entities/users";
+import { getUser } from "metabase/selectors/user";
+import { ModerationReview } from "metabase-types/api";
+import { State } from "metabase-types/store";
+import ModerationReviewIcon from "../../components/ModerationReviewIcon";
+
+interface ModerationReviewIconProps {
+  review: ModerationReview;
+}
+
+const mapStateToProps = (state: State) => ({
+  currentUser: getUser(state),
+});
+
+const userProps = {
+  id: (state: State, props: ModerationReviewIconProps) =>
+    props.review.moderator_id,
+  loadingAndErrorWrapper: false,
+};
+
+export default _.compose(
+  Users.load(userProps),
+  connect(mapStateToProps),
+)(ModerationReviewIcon);

--- a/enterprise/frontend/src/metabase-enterprise/moderation/containers/ModerationReviewIcon/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/containers/ModerationReviewIcon/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ModerationReviewIcon";

--- a/enterprise/frontend/src/metabase-enterprise/moderation/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/index.js
@@ -3,14 +3,14 @@ import { t } from "ttag";
 import { PLUGIN_MODERATION } from "metabase/plugins";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 
-import QuestionModerationSection from "./components/QuestionModerationSection/QuestionModerationSection";
-import QuestionModerationButton from "./components/QuestionModerationButton/QuestionModerationButton";
-import ModerationReviewBanner from "./components/ModerationReviewBanner/ModerationReviewBanner";
-import ModerationStatusIcon from "./components/ModerationStatusIcon/ModerationStatusIcon";
+import QuestionModerationIcon from "./components/QuestionModerationIcon";
+import QuestionModerationSection from "./components/QuestionModerationSection";
+import QuestionModerationButton from "./components/QuestionModerationButton";
+import ModerationReviewBanner from "./components/ModerationReviewBanner";
+import ModerationStatusIcon from "./components/ModerationStatusIcon";
 
 import {
   MODERATION_STATUS,
-  getStatusIconForQuestion,
   getStatusIcon,
   getModerationTimelineEvents,
   verifyItem,
@@ -22,11 +22,11 @@ import {
 if (hasPremiumFeature("content_management")) {
   Object.assign(PLUGIN_MODERATION, {
     isEnabled: () => true,
+    QuestionModerationIcon,
     QuestionModerationSection,
     QuestionModerationButton,
     ModerationReviewBanner,
     ModerationStatusIcon,
-    getStatusIconForQuestion,
     getStatusIcon,
     getModerationTimelineEvents,
     getMenuItems: (model, isModerator, reload) => {

--- a/enterprise/frontend/src/metabase-enterprise/moderation/service.js
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/service.js
@@ -62,11 +62,10 @@ export function getTextForReviewBanner(
   moderator,
   currentUser,
 ) {
-  const moderatorName = getModeratorDisplayName(moderator, currentUser);
   const { status } = moderationReview;
 
   if (status === "verified") {
-    const bannerText = t`${moderatorName} verified this`;
+    const bannerText = getModeratorDisplayText(moderator, currentUser);
     const tooltipText = t`Remove verification`;
     return { bannerText, tooltipText };
   }
@@ -74,17 +73,22 @@ export function getTextForReviewBanner(
   return {};
 }
 
-function getModeratorDisplayName(user, currentUser) {
-  const { id: userId, common_name } = user || {};
+export function getModeratorDisplayName(moderator, currentUser) {
+  const { id: moderatorId, common_name } = moderator || {};
   const { id: currentUserId } = currentUser || {};
 
-  if (currentUserId != null && userId === currentUserId) {
+  if (currentUserId != null && moderatorId === currentUserId) {
     return t`You`;
-  } else if (userId != null) {
+  } else if (moderatorId != null) {
     return common_name;
   } else {
     return t`A moderator`;
   }
+}
+
+export function getModeratorDisplayText(moderator, currentUser) {
+  const moderatorName = getModeratorDisplayName(moderator, currentUser);
+  return t`${moderatorName} verified this`;
 }
 
 // a `status` of `null` represents the removal of a review, since we can't delete reviews

--- a/frontend/src/metabase-types/api/card.ts
+++ b/frontend/src/metabase-types/api/card.ts
@@ -1,3 +1,12 @@
 export type VisualizationSettings = {
   [key: string]: any;
 };
+
+export interface ModerationReview {
+  moderator_id: number;
+  status: ModerationReviewStatus | null;
+  created_at: string;
+  most_recent: boolean;
+}
+
+export type ModerationReviewStatus = "verified";

--- a/frontend/src/metabase-types/api/index.ts
+++ b/frontend/src/metabase-types/api/index.ts
@@ -1,6 +1,7 @@
 export * from "./activity";
 export * from "./automagic-dashboards";
 export * from "./bookmark";
+export * from "./card";
 export * from "./collection";
 export * from "./dashboard";
 export * from "./database";

--- a/frontend/src/metabase-types/api/mocks/card.ts
+++ b/frontend/src/metabase-types/api/mocks/card.ts
@@ -1,0 +1,11 @@
+import { ModerationReview } from "metabase-types/api";
+
+export const createMockModerationReview = (
+  opts?: Partial<ModerationReview>,
+): ModerationReview => ({
+  moderator_id: 1,
+  status: "verified",
+  created_at: "2015-01-01T20:10:30.200",
+  most_recent: true,
+  ...opts,
+});

--- a/frontend/src/metabase-types/api/mocks/index.ts
+++ b/frontend/src/metabase-types/api/mocks/index.ts
@@ -1,5 +1,6 @@
 export * from "./activity";
 export * from "./automagic-dashboards";
+export * from "./card";
 export * from "./collection";
 export * from "./dashboard";
 export * from "./database";

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -120,11 +120,11 @@ export const PLUGIN_COLLECTION_COMPONENTS = {
 
 export const PLUGIN_MODERATION = {
   isEnabled: () => false,
+  QuestionModerationIcon: PluginPlaceholder,
   QuestionModerationSection: PluginPlaceholder,
   QuestionModerationButton: PluginPlaceholder,
   ModerationReviewBanner: PluginPlaceholder,
   ModerationStatusIcon: PluginPlaceholder,
-  getStatusIconForQuestion: object,
   getStatusIcon: object,
   getModerationTimelineEvents: array,
   getMenuItems: (

--- a/frontend/src/metabase/query_builder/components/SavedQuestionHeaderButton/SavedQuestionHeaderButton.jsx
+++ b/frontend/src/metabase/query_builder/components/SavedQuestionHeaderButton/SavedQuestionHeaderButton.jsx
@@ -2,12 +2,7 @@ import React from "react";
 import { t } from "ttag";
 import PropTypes from "prop-types";
 import { PLUGIN_MODERATION } from "metabase/plugins";
-import { color } from "metabase/lib/colors";
-import {
-  HeaderRoot,
-  HeaderReviewIcon,
-  HeaderTitle,
-} from "./SavedQuestionHeaderButton.styled";
+import { HeaderRoot, HeaderTitle } from "./SavedQuestionHeaderButton.styled";
 
 SavedQuestionHeaderButton.propTypes = {
   className: PropTypes.string,
@@ -15,12 +10,7 @@ SavedQuestionHeaderButton.propTypes = {
   onSave: PropTypes.func,
 };
 
-const ICON_SIZE = 16;
-
-function SavedQuestionHeaderButton({ className, question, onSave }) {
-  const { name: reviewIconName, color: reviewIconColor } =
-    PLUGIN_MODERATION.getStatusIconForQuestion(question);
-
+function SavedQuestionHeaderButton({ question, onSave }) {
   return (
     <HeaderRoot>
       <HeaderTitle
@@ -29,13 +19,7 @@ function SavedQuestionHeaderButton({ className, question, onSave }) {
         onChange={onSave}
         data-testid="saved-question-header-title"
       />
-      {reviewIconName && (
-        <HeaderReviewIcon
-          name={reviewIconName}
-          color={color(reviewIconColor)}
-          size={ICON_SIZE}
-        />
-      )}
+      <PLUGIN_MODERATION.QuestionModerationIcon question={question} />
     </HeaderRoot>
   );
 }

--- a/frontend/src/metabase/query_builder/components/SavedQuestionHeaderButton/SavedQuestionHeaderButton.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/SavedQuestionHeaderButton/SavedQuestionHeaderButton.styled.jsx
@@ -1,18 +1,14 @@
 import styled from "@emotion/styled";
-import Icon from "metabase/components/Icon";
 import EditableText from "metabase/core/components/EditableText";
 
 export const HeaderRoot = styled.div`
   display: flex;
   align-items: center;
+  gap: 0.25rem;
 `;
 
 export const HeaderTitle = styled(EditableText)`
   font-size: 1.25rem;
   font-weight: 700;
   line-height: 1.5rem;
-`;
-
-export const HeaderReviewIcon = styled(Icon)`
-  padding-left: 0.25rem;
 `;


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/22826

How to test:
- Run Metabase EE
- Open a saved question
- Click on the `...` menu and then `Verify this question`
- Make sure that verify badge appears near the title of the question
- Make sure the tooltip is displayed on hover

<img width="232" alt="Screenshot 2022-07-07 at 17 42 17" src="https://user-images.githubusercontent.com/8542534/177801762-5374f9a4-d9d2-4f66-8a96-5f0cffc1806b.png">
<img width="691" alt="Screenshot 2022-07-07 at 17 42 26" src="https://user-images.githubusercontent.com/8542534/177801792-48b699a2-a600-4851-85a7-06bb98eda385.png">
