### PR TITLE
Make the question lineage visible when the sidebar is opened

### DIFF
--- a/frontend/src/metabase/nav/components/AppBar/AppBarLarge.styled.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarLarge.styled.tsx
@@ -49,16 +49,16 @@ export const AppBarRightContainer = styled.div`
 `;
 
 export interface AppBarInfoContainerProps {
-  isNavBarOpen?: boolean;
+  isVisible?: boolean;
 }
 
 export const AppBarInfoContainer = styled.div<AppBarInfoContainerProps>`
   display: flex;
   min-width: 0;
-  opacity: ${props => (props.isNavBarOpen ? 0 : 1)};
-  visibility: ${props => (props.isNavBarOpen ? "hidden" : "visible")};
+  opacity: ${props => (props.isVisible ? 1 : 0)};
+  visibility: ${props => (props.isVisible ? "visible" : "hidden")};
   transition: ${props =>
-    props.isNavBarOpen ? `opacity 0.5s, visibility 0s` : `opacity 0.5s`};
+    props.isVisible ? `opacity 0.5s` : `opacity 0.5s, visibility 0s`};
 `;
 
 export const AppBarProfileLinkContainer = styled.div`

--- a/frontend/src/metabase/nav/components/AppBar/AppBarLarge.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarLarge.tsx
@@ -49,7 +49,9 @@ const AppBarLarge = ({
           isToggleVisible={isNavBarVisible}
           onToggleClick={onToggleNavbar}
         />
-        <AppBarInfoContainer isNavBarOpen={isNavBarOpen}>
+        <AppBarInfoContainer
+          isVisible={!isNavBarOpen || isQuestionLineageVisible}
+        >
           {isQuestionLineageVisible ? (
             <QuestionLineage />
           ) : isCollectionPathVisible ? (


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/22826

How to test:
- Open a saved question
- Change the question, e.g. add a filter
- Make sure the `Starting from ...` label appears in the app bar
- It should stay visible when the sidebar is opened/closed

<img width="1001" alt="Screenshot 2022-07-07 at 18 12 29" src="https://user-images.githubusercontent.com/8542534/177808864-ee53c55f-8ca3-4e15-8472-4ef98ab1358d.png">
