### PR TITLE
Change column selection icon in notebook

### DIFF
--- a/frontend/src/metabase/query_builder/components/notebook/FieldsPickerIcon.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/FieldsPickerIcon.jsx
@@ -26,7 +26,7 @@ export function FieldsPickerIcon({ isTriggeredComponentOpen }) {
       isEnabled={!isTriggeredComponentOpen}
     >
       <FieldPickerContentContainer data-testid="fields-picker">
-        <StyledIcon name="table" size={14} />
+        <StyledIcon name="chevrondown" size={14} />
       </FieldPickerContentContainer>
     </Tooltip>
   );


### PR DESCRIPTION
We heard some user feedback that people didn't know that you could click the grid icon next to a data source's name to pick the columns to include. This is a tiny change to see if this feels more obvious.

## Before
<img width="543" alt="image" src="https://user-images.githubusercontent.com/2223916/177831506-72947c4c-d679-481a-97b3-454ce229c35c.png">

## After
<img width="536" alt="image" src="https://user-images.githubusercontent.com/2223916/177831397-b5210235-84f6-4023-8896-80fe361206df.png">
