### PR TITLE
Fix `TableSimple` visual regressions

### DIFF
--- a/frontend/src/metabase/visualizations/components/TableSimple/TableCell.jsx
+++ b/frontend/src/metabase/visualizations/components/TableSimple/TableCell.jsx
@@ -143,6 +143,7 @@ function TableCell({
       isRightAligned={isColumnRightAligned(column)}
     >
       <CellContent
+        className="cellData"
         isClickable={isClickable}
         onClick={isClickable ? onClick : undefined}
         data-testid="cell-data"

--- a/frontend/src/metabase/visualizations/components/TableSimple/TableSimple.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/TableSimple/TableSimple.styled.tsx
@@ -58,6 +58,14 @@ export const Table = styled.table`
   }
 `;
 
+export const SortIcon = styled(Icon)`
+  margin-right: 3px;
+`;
+
+SortIcon.defaultProps = {
+  size: 8,
+};
+
 export const TableHeaderCellContent = styled.button<{
   isSorted: boolean;
   isRightAligned: boolean;
@@ -70,18 +78,14 @@ export const TableHeaderCellContent = styled.button<{
 
   cursor: pointer;
 
+  ${SortIcon} {
+    opacity: ${props => (props.isSorted ? 1 : 0.2)};
+  }
+
   &:hover {
     color: ${() => color("brand")};
   }
 `;
-
-export const SortIcon = styled(Icon)`
-  margin-right: 3px;
-`;
-
-SortIcon.defaultProps = {
-  size: 8,
-};
 
 export const TableFooterRoot = styled.div`
   display: flex;

--- a/frontend/src/metabase/visualizations/components/TableSimple/TableSimple.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/TableSimple/TableSimple.styled.tsx
@@ -71,6 +71,10 @@ export const TableHeaderCellContent = styled.button<{
   isRightAligned: boolean;
 }>`
   display: flex;
+  justify-content: ${props =>
+    props.isRightAligned ? "space-between" : "flex-start"};
+  width: 100%;
+
   margin-left: ${props => (props.isRightAligned ? "auto" : "unset")};
 
   color: ${props => (props.isSorted ? color("brand") : color("text-medium"))};


### PR DESCRIPTION
Fixes #23760, a regression caused by refactoring `TableSimple` viz at #22982

1. PK and FK indicators were gone
2. Inactive sort icon opacity was set to `1` instead of `0.2` as before
3. Sort icons were shown right next to column names all the time. Although before the refactoring there was plenty of space between them for right-aligned columns (usually numeric)

### To Verify

1. New > Question > Sample Database > Orders
2. Save and add to a dashboard
3. Ensure you can see light-blue wrappers around PK and FK cells (e.g. ID, User ID, Product ID). No hover style changes expected
4. Ensure the sort icons are transparent (opacity is expected to be `0.2`)
5. Ensure there is plenty of space between the sort icon and the column name for e.g. "Discount"
6. Click on any column to apply sorting. Make sure both the sort icon and the column name became blue and the icon became opaque

### Demo

**Before**
![before](https://user-images.githubusercontent.com/17258145/177832728-ef0b1615-1620-44f0-8ddf-3e2deb98d164.png)

**After**
![after](https://user-images.githubusercontent.com/17258145/177832739-cf1caa7a-a3ca-4d00-91c3-e87cd3f86865.png)

