### PR TITLE
Include a link to cloud ip address docs in database admin screen

### DIFF
--- a/src/metabase/driver/common.clj
+++ b/src/metabase/driver/common.clj
@@ -211,7 +211,7 @@
              (when-let [ips (public-settings/cloud-gateway-ips)]
                (str (deferred-tru
                       (str "If your database is behind a firewall, you may need to allow connections from our Metabase "
-                           "Cloud IP addresses:"))
+                           "[Cloud IP addresses](https://www.metabase.com/cloud/docs/ip-addresses-to-whitelist.html):"))
                     "\n"
                     (str/join " - " ips))))})
 


### PR DESCRIPTION
When `(premium-features/is-hosted?)` is true (IE, in the cloud) we
display some information about whitelisted ip addresses on the database
admin screen.

> If your database is behind a firewall, you may need to allow connections from our Metabase Cloud
> IP addresses: 18.207.81.126 - 3.211.20.157 - 50.17.234.169

A previous change interpreted this text as markdown so now we can
include the link here.

One problem is that this markdown is a translated string. So we're gonna
need this markdown duplicated into all of our other languages. And those
will point to english documentation. Not sure if there's a great
solution there.

For testing:

If you want to see this in the app, edit public settings cloud-gateway-ips:

```clojure
(defsetting cloud-gateway-ips
  (deferred-tru "Metabase Cloud gateway IP addresses, to configure connections to DBs behind firewalls")
  :visibility :public
  :type       :json
  :setter     :none
  :getter     (fn []
                (when #_(premium-features/is-hosted?) true
                  (fetch-cloud-gateway-ips-fn))))
```

And then go to admin > databases and edit a db or start to create a new one

<img width="774" alt="image" src="https://user-images.githubusercontent.com/6377293/177841110-3d34299c-72a7-4b35-a1b6-1bb820c41db2.png">
