### PR TITLE
Repro #22695: Databases with no permission are still shown as search results

### DIFF
--- a/frontend/test/metabase/scenarios/permissions/reproductions/22695-search-databases-no-permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/reproductions/22695-search-databases-no-permissions.cy.spec.js
@@ -1,0 +1,35 @@
+import { restore } from "__support__/e2e/helpers";
+import { USER_GROUPS, SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
+
+const { ALL_USERS_GROUP, DATA_GROUP } = USER_GROUPS;
+
+describe("issue 22695 ", () => {
+  beforeEach(() => {
+    cy.intercept("GET", "/api/search?*").as("searchResults");
+
+    restore();
+    cy.signInAsAdmin();
+
+    cy.updatePermissionsGraph({
+      [ALL_USERS_GROUP]: {
+        [SAMPLE_DB_ID]: { data: { schemas: "block" } },
+      },
+      [DATA_GROUP]: {
+        [SAMPLE_DB_ID]: { data: { schemas: "block" } },
+      },
+    });
+  });
+
+  // https://github.com/metabase/metaboat/issues/159
+  it("should not expose database names to which the user has no access permissions (metabase#22695)", () => {
+    cy.signIn("nocollection");
+    cy.visit("/");
+
+    cy.findByPlaceholderText("Search…").click().type("S");
+    cy.wait("@searchResults");
+
+    cy.findAllByTestId("search-result-item-name")
+      .should("have.length", 1)
+      .and("not.contain", "Sample Database");
+  });
+});

--- a/frontend/test/metabase/scenarios/permissions/reproductions/22695-search-databases-no-permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/reproductions/22695-search-databases-no-permissions.cy.spec.js
@@ -22,14 +22,27 @@ describe("issue 22695 ", () => {
 
   // https://github.com/metabase/metaboat/issues/159
   it("should not expose database names to which the user has no access permissions (metabase#22695)", () => {
+    // Nocollection user belongs to a "data" group which we blocked for this repro,
+    // but they have access to data otherwise (as name suggests)
     cy.signIn("nocollection");
-    cy.visit("/");
+    assert();
 
-    cy.findByPlaceholderText("Search…").click().type("S");
-    cy.wait("@searchResults");
+    cy.signOut();
 
-    cy.findAllByTestId("search-result-item-name")
-      .should("have.length", 1)
-      .and("not.contain", "Sample Database");
+    // Nodata user belongs to the group that has access to collections,
+    // but has no-self-service data permissions
+    cy.signIn("nodata");
+    assert();
   });
 });
+
+function assert() {
+  cy.visit("/");
+
+  cy.findByPlaceholderText("Search…").click().type("S");
+  cy.wait("@searchResults");
+
+  cy.findAllByTestId("search-result-item-name")
+    .should("have.length.above", 0)
+    .and("not.contain", "Sample Database");
+}


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #22695 

### How to test this manually?
- `yarn test-cypress-open`
- `metabase/scenarios/permissions/reproductions/22695-search-databases-no-permissions.cy.spec.js`
- All tests should pass

### Additional notes:
- The bug was fixed in #23678

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/177855670-8b32035b-c3de-4ede-8133-ece96e8f301d.png)

