### PR TITLE
Run test only on EE version

### DIFF
--- a/frontend/test/metabase/scenarios/permissions/reproductions/22695-search-databases-no-permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/reproductions/22695-search-databases-no-permissions.cy.spec.js
@@ -1,9 +1,9 @@
-import { restore } from "__support__/e2e/helpers";
+import { restore, describeEE } from "__support__/e2e/helpers";
 import { USER_GROUPS, SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 
 const { ALL_USERS_GROUP, DATA_GROUP } = USER_GROUPS;
 
-describe("issue 22695 ", () => {
+describeEE("issue 22695 ", () => {
   beforeEach(() => {
     cy.intercept("GET", "/api/search?*").as("searchResults");
 


### PR DESCRIPTION
Quick fix for a mistake I made in https://github.com/metabase/metabase/pull/23772 by forgetting to use `describeEE` block. This feature is available only in Metabase Enterprise and cannot run against OSS version.

Otherwise, the test will fail like it did here:
https://github.com/metabase/metabase/actions/runs/2632809843