### PR TITLE
Show caching controls only for questions

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.tsx
@@ -27,9 +27,10 @@ export const QuestionInfoSidebar = ({
   const description = question.description();
   const isDataset = question.isDataset();
   const isPersisted = isDataset && question.isPersisted();
-
-  const showCaching =
-    PLUGIN_CACHING.isEnabled() && MetabaseSettings.get("enable-query-caching");
+  const isCachingAvailable =
+    !isDataset &&
+    PLUGIN_CACHING.isEnabled() &&
+    MetabaseSettings.get("enable-query-caching");
 
   const handleSave = (description: string | null) => {
     if (question.description() !== description) {
@@ -63,7 +64,7 @@ export const QuestionInfoSidebar = ({
         </ContentSection>
       )}
 
-      {showCaching && (
+      {isCachingAvailable && (
         <ContentSection extraPadding>
           <PLUGIN_CACHING.QuestionCacheSection
             question={question}


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/22826
Demo https://www.loom.com/share/10062e28f0db4f2e98aa6178725af293

How to test:
- Go to Admin -> Settings -> Caching and enable caching for questions
- Open a model, then open the info panel
- There should be no question caching controls 