### PR TITLE
Fix failed E2E tests due to merge conflicts

### DIFF
--- a/frontend/test/metabase/scenarios/sharing/public.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/public.cy.spec.js
@@ -155,7 +155,7 @@ describe("scenarios > public", () => {
     });
 
     it("should show shared questions and dashboards in admin settings", () => {
-      cy.visit("/admin/settings/public_sharing");
+      cy.visit("/admin/settings/public-sharing");
 
       cy.findByText("Enable Public Sharing").should("be.visible");
 


### PR DESCRIPTION
This fixed failed CI on `master` currently.
- https://github.com/metabase/metabase/runs/7250664216?check_suite_focus=true
- https://github.com/metabase/metabase/runs/7250666187?check_suite_focus=true

It's because of [that PR](https://github.com/metabase/metabase/pull/23781) changed admin settings paths and this PR add a new test that [still uses the old path](https://github.com/metabase/metabase/pull/23726/files#diff-12433cfdc91e59a0ad52892d62e05fe472b060cb4430f24e3b0f0c1dd8766229R158).