### PR TITLE
Fix crash in Model query visualization

### DIFF
--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
@@ -261,7 +261,7 @@ function DatasetEditor(props) {
 
   const focusFirstField = useCallback(() => {
     const [firstField] = fields;
-    setFocusedFieldRef(firstField.field_ref);
+    setFocusedFieldRef(firstField?.field_ref);
   }, [fields, setFocusedFieldRef]);
 
   useEffect(() => {

--- a/frontend/test/metabase/scenarios/models/reproductions/23421-visualization-settins-breaks-ui.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/reproductions/23421-visualization-settins-breaks-ui.cy.spec.js
@@ -15,7 +15,7 @@ const questionDetails = {
   dataset: true,
 };
 
-describe.skip("issue 23421", () => {
+describe("issue 23421", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();


### PR DESCRIPTION
Fixes #23421

### How to test

1. Create a question with a visualization_settings with an empty `table.columns` array, example: http://localhost:3000/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7InR5cGUiOiJuYXRpdmUiLCJuYXRpdmUiOnsicXVlcnkiOiJTRUxFQ1QgMSBBUyBcImlkXCIsIGN1cnJlbnRfdGltZXN0YW1wOjp0aW1lc3RhbXAgQVMgXCJjcmVhdGVkX2F0XCIiLCJ0ZW1wbGF0ZS10YWdzIjp7fX0sImRhdGFiYXNlIjoxfSwiZGlzcGxheSI6InRhYmxlIiwiZGlzcGxheUlzTG9ja2VkIjp0cnVlLCJ2aXN1YWxpemF0aW9uX3NldHRpbmdzIjp7InRhYmxlLmNvbHVtbnMiOltdLCJ0YWJsZS5waXZvdF9jb2x1bW4iOiJvcnBoYW5lZDEiLCJ0YWJsZS5jZWxsX2NvbHVtbiI6Im9ycGhhbmVkMiJ9fQ==
2. Turn into a Model
3. Try accessing Query definition

You should be able to edit the query — no crash.

<img width="600" alt="image" src="https://user-images.githubusercontent.com/380816/178045928-05d6de1c-b3f6-43a9-937b-99410891feca.png">
