### PR TITLE
App bar border adjustment and dashboard alignment

### DIFF
--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.jsx
@@ -90,6 +90,7 @@ export const ParametersWidgetContainer = styled(FullWidthContainer)`
   flex-direction: column;
   padding-top: ${space(2)};
   padding-bottom: ${space(1)};
+
   z-index: 4;
 
   ${({ isEditing }) =>

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.jsx
@@ -90,7 +90,6 @@ export const ParametersWidgetContainer = styled(FullWidthContainer)`
   flex-direction: column;
   padding-top: ${space(2)};
   padding-bottom: ${space(1)};
-
   z-index: 4;
 
   ${({ isEditing }) =>

--- a/frontend/src/metabase/dashboard/components/DashboardHeader.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader.styled.tsx
@@ -11,12 +11,15 @@ import {
   breakpointMaxMedium,
 } from "metabase/styled-components/theme";
 import EditableText from "metabase/core/components/EditableText";
+import { FullWidthContainer } from "metabase/styled-components/layout/FullWidthContainer";
 
 interface TypeForItemsThatRespondToNavBarOpen {
   isNavBarOpen: boolean;
 }
 
-export const HeaderRoot = styled.div<TypeForItemsThatRespondToNavBarOpen>`
+export const HeaderRoot = styled(
+  FullWidthContainer,
+)<TypeForItemsThatRespondToNavBarOpen>`
   display: flex;
   align-items: center;
 
@@ -40,6 +43,7 @@ export const HeaderCaptionContainer = styled.div`
   transition: top 400ms ease;
   display: flex;
   padding-right: 2rem;
+  right: 0.25rem;
 `;
 
 export const HeaderCaption = styled(EditableText)`

--- a/frontend/src/metabase/nav/components/AppBar/AppBarLarge.styled.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarLarge.styled.tsx
@@ -4,14 +4,20 @@ import { APP_BAR_HEIGHT } from "metabase/nav/constants";
 import { LogoLink } from "./AppBarLogo.styled";
 import { SidebarButton } from "./AppBarToggle.styled";
 
-export const AppBarRoot = styled.div`
+interface AppBarRootProps {
+  isNavBarOpen?: boolean;
+}
+
+export const AppBarRoot = styled.div<AppBarRootProps>`
   display: flex;
   align-items: center;
   gap: 1rem;
   height: ${APP_BAR_HEIGHT};
   padding: 0 1rem;
-  border-bottom: 1px solid ${color("border")};
+  border-bottom: 1px solid
+    ${props => (props.isNavBarOpen ? color("border") : "transparent")};
   background-color: ${color("bg-white")};
+  transition: border-bottom-color 200ms ease;
 `;
 
 export interface AppBarLeftContainerProps {

--- a/frontend/src/metabase/nav/components/AppBar/AppBarLarge.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarLarge.tsx
@@ -42,7 +42,7 @@ const AppBarLarge = ({
   onLogout,
 }: AppBarLargeProps): JSX.Element => {
   return (
-    <AppBarRoot>
+    <AppBarRoot isNavBarOpen={isNavBarOpen}>
       <AppBarLeftContainer isNavBarVisible={isNavBarVisible}>
         <AppBarLogo
           isNavBarOpen={isNavBarOpen}

--- a/frontend/src/metabase/styled-components/layout/FullWidthContainer.tsx
+++ b/frontend/src/metabase/styled-components/layout/FullWidthContainer.tsx
@@ -10,12 +10,12 @@ export const FullWidthContainer = styled.div`
   width: 100%;
 
   ${breakpointMinSmall} {
-    padding-left: 2em;
-    padding-right: 2em;
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
   }
 
   ${breakpointMinMedium} {
-    padding-left: 3em;
-    padding-right: 3em;
+    padding-left: 2rem;
+    padding-right: 2rem;
   }
 `;


### PR DESCRIPTION
Small fix to [hide the bottom border of the app bar when the nav is open](https://www.notion.so/metabase/Hide-bottom-border-of-the-main-nav-when-sidebar-is-closed-c3c39ebc29af4193bc647f6c5a5d9b22). Also fixes Dashboard alignment to match the metabase logo.

![bpJxOy4XHA](https://user-images.githubusercontent.com/1328979/178058780-6159db25-dcec-46d2-a01d-a9bc134c666d.gif)

