### PR TITLE
Support uploading keystore and truststore for presto

### DIFF
--- a/.github/scripts/run-presto-kerberos-integration-test.sh
+++ b/.github/scripts/run-presto-kerberos-integration-test.sh
@@ -45,20 +45,20 @@ openssl x509 -outform der -in $RESOURCES_DIR/presto-ssl-root-ca.pem  -out $RESOU
 keytool -noprompt -import -alias presto-kerberos -keystore $RESOURCES_DIR/cacerts-with-presto-ca.jks \
         -storepass changeit -file $RESOURCES_DIR/presto-ssl-root-ca.der -trustcacerts
 
-ADDITIONAL_OPTS="SSLKeyStorePath=$RESOURCES_DIR/ssl_keystore.jks&SSLKeyStorePassword=presto\
-&SSLTrustStorePath=$RESOURCES_DIR/cacerts-with-presto-ca.jks&SSLTrustStorePassword=changeit"
-
 # Set up the environment variables pointing to all of this, and run some tests
 DRIVERS=presto-jdbc \
 MB_ENABLE_PRESTO_JDBC_DRIVER=true \
 MB_PRESTO_JDBC_TEST_HOST=presto-kerberos \
 MB_PRESTO_JDBC_TEST_PORT=7778 \
 MB_PRESTO_JDBC_TEST_SSL=true \
+MB_PRESTO_JDBC_TEST_SSL_KEYSTORE_PATH=$RESOURCES_DIR/ssl_keystore.jks \
+MB_PRESTO_JDBC_TEST_SSL_KEYSTORE_PASSWORD=presto \
+MB_PRESTO_JDBC_TEST_SSL_TRUSTSTORE_PATH=$RESOURCES_DIR/cacerts-with-presto-ca.jks \
+MB_PRESTO_JDBC_TEST_SSL_TRUSTSTORE_PASSWORD=changeit \
 MB_PRESTO_JDBC_TEST_KERBEROS=true \
 MB_PRESTO_JDBC_TEST_USER=bob@EXAMPLE.COM \
 MB_PRESTO_JDBC_TEST_KERBEROS_PRINCIPAL=bob@EXAMPLE.COM \
 MB_PRESTO_JDBC_TEST_KERBEROS_REMOTE_SERVICE_NAME=HTTP \
 MB_PRESTO_JDBC_TEST_KERBEROS_KEYTAB_PATH=$RESOURCES_DIR/client.keytab \
 MB_PRESTO_JDBC_TEST_KERBEROS_CONFIG_PATH=$RESOURCES_DIR/krb5.conf \
-MB_PRESTO_JDBC_TEST_ADDITIONAL_OPTIONS=$ADDITIONAL_OPTS \
 clojure -X:dev:test:drivers:drivers-dev :only metabase.driver.presto-jdbc-test

--- a/modules/drivers/presto-jdbc/resources/metabase-plugin.yaml
+++ b/modules/drivers/presto-jdbc/resources/metabase-plugin.yaml
@@ -34,6 +34,44 @@ driver:
         - required: false
     - cloud-ip-address-info
     - ssl
+    - name: ssl-use-keystore
+      display-name: Use SSL server certificate?
+      type: boolean
+      visible-if:
+        ssl: true
+    - name: ssl-keystore
+      display-name: Keystore
+      type: secret
+      secret-kind: keystore
+      placeholder: /path/to/keystore.jks
+      visible-if:
+        ssl-use-keystore: true
+    - name: ssl-keystore-password
+      display-name: Keystore password
+      type: secret
+      secret-kind: password
+      required: false
+      visible-if:
+        ssl-use-keystore: true
+    - name: ssl-use-truststore
+      display-name: Use SSL truststore?
+      type: boolean
+      visible-if:
+        ssl: true
+    - name: ssl-truststore
+      display-name: Truststore
+      type: secret
+      secret-kind: keystore
+      placeholder: /path/to/truststore.jks
+      visible-if:
+        ssl-use-truststore: true
+    - name: ssl-truststore-password
+      display-name: Truststore password
+      type: secret
+      secret-kind: password
+      required: false
+      visible-if:
+        ssl-use-truststore: true
     - advanced-options-start
     - name: kerberos
       type: boolean

--- a/modules/drivers/presto-jdbc/test/metabase/driver/presto_jdbc_test.clj
+++ b/modules/drivers/presto-jdbc/test/metabase/driver/presto_jdbc_test.clj
@@ -16,9 +16,11 @@
             [metabase.query-processor :as qp]
             [metabase.sync :as sync]
             [metabase.test :as mt]
+            [metabase.test.data.presto-jdbc :as data.presto-jdbc]
             [metabase.test.fixtures :as fixtures]
             [metabase.test.util :as tu]
-            [toucan.db :as db]))
+            [toucan.db :as db])
+  (:import java.io.File))
 
 (use-fixtures :once (fixtures/initialize :db))
 
@@ -164,9 +166,20 @@
              (-> (sql.qp/unix-timestamp->honeysql :presto-jdbc :microseconds (hsql/raw 1623963256123456))
                (hformat/format)))))))
 
+(defn- clone-db-details
+  "Clones the details of the current DB ensuring fresh copies for the secrets
+  (keystore and truststore)."
+  []
+  (-> (:details (mt/db))
+      (dissoc :ssl-keystore-id :ssl-keystore-password-id
+              :ssl-truststore-id :ssl-truststore-password-id)
+      (merge (select-keys (data.presto-jdbc/dbdef->connection-details (:name (mt/db)))
+                          [:ssl-keystore-path :ssl-keystore-password-value
+                           :ssl-truststore-path :ssl-truststore-password-value]))))
+
 (defn- execute-ddl! [ddl-statements]
   (mt/with-driver :presto-jdbc
-    (let [jdbc-spec (sql-jdbc.conn/connection-details->spec :presto-jdbc (:details (mt/db)))]
+    (let [jdbc-spec (sql-jdbc.conn/connection-details->spec :presto-jdbc (clone-db-details))]
       (with-open [conn (jdbc/get-connection jdbc-spec)]
         (doseq [ddl-stmt ddl-statements]
           (with-open [stmt (.prepareStatement conn ddl-stmt)]
@@ -177,7 +190,7 @@
     (testing "When a specific schema is designated, only that one is synced"
       (let [s           "specific_schema"
             t           "specific_table"
-            db-details  (:details (mt/db))
+            db-details  (clone-db-details)
             with-schema (assoc db-details :schema s)]
         (execute-ddl! [(format "DROP TABLE IF EXISTS %s.%s" s t)
                        (format "DROP SCHEMA IF EXISTS %s" s)
@@ -217,3 +230,37 @@
                   "&KerberosRemoteServiceName=HTTP&KerberosKeytabPath=/path/to/client.keytab"
                   "&KerberosConfigPath=/path/to/krb5.conf")
              (:subname jdbc-spec))))))
+
+(defn- create-dummy-keystore
+  "Creates and empty file for simulating a JKS."
+  ^File [prefix]
+  (doto (File/createTempFile prefix ".jks")
+    .deleteOnExit))
+
+(deftest ssl-store-properties-test
+  (testing "SSL keystore and truststore properties are added as URL parameters"
+    (let [keystore   (create-dummy-keystore "keystore")
+          truststore (create-dummy-keystore "truststore")
+          details    {:host                          "presto-server"
+                      :port                          7778
+                      :catalog                       "my-catalog"
+                      :additional-options            "additional-options"
+                      :ssl                           true
+                      :ssl-use-keystore              true
+                      :ssl-keystore-path             (.getPath keystore)
+                      :ssl-keystore-password-value   "keystorepass"
+                      :ssl-use-truststore            true
+                      :ssl-truststore-path           (.getPath truststore)
+                      :ssl-truststore-password-value "truststorepass"}]
+      (try
+        (is (= (format (str "//presto-server:7778/my-catalog?additional-options"
+                            "&SSLKeyStorePath=%s"
+                            "&SSLKeyStorePassword=keystorepass"
+                            "&SSLTrustStorePath=%s"
+                            "&SSLTrustStorePassword=truststorepass")
+                       (.getCanonicalPath keystore)
+                       (.getCanonicalPath truststore))
+               (:subname (sql-jdbc.conn/connection-details->spec :presto-jdbc details))))
+        (finally
+          (.delete truststore)
+          (.delete keystore))))))

--- a/modules/drivers/presto-jdbc/test/metabase/test/data/presto_jdbc.clj
+++ b/modules/drivers/presto-jdbc/test/metabase/test/data/presto_jdbc.clj
@@ -37,23 +37,34 @@
                              :type/TimeWithTZ             "TIME WITH TIME ZONE"}]
   (defmethod sql.tx/field-base-type->sql-type [:presto-jdbc base-type] [_ _] db-type))
 
+(defn dbdef->connection-details [database-name]
+  (let [base-details
+        {:host                               (tx/db-test-env-var-or-throw :presto-jdbc :host "localhost")
+         :port                               (tx/db-test-env-var :presto-jdbc :port "8080")
+         :user                               (tx/db-test-env-var-or-throw :presto-jdbc :user "metabase")
+         :additional-options                 (tx/db-test-env-var :presto-jdbc :additional-options nil)
+         :ssl                                (tx/db-test-env-var :presto-jdbc :ssl "false")
+         :ssl-keystore-path                  (tx/db-test-env-var :presto-jdbc :ssl-keystore-path nil)
+         :ssl-keystore-password-value        (tx/db-test-env-var :presto-jdbc :ssl-keystore-password nil)
+         :ssl-truststore-path                (tx/db-test-env-var :presto-jdbc :ssl-truststore-path nil)
+         :ssl-truststore-password-value      (tx/db-test-env-var :presto-jdbc :ssl-truststore-password nil)
+         :kerberos                           (tx/db-test-env-var :presto-jdbc :kerberos "false")
+         :kerberos-principal                 (tx/db-test-env-var :presto-jdbc :kerberos-principal nil)
+         :kerberos-remote-service-name       (tx/db-test-env-var :presto-jdbc :kerberos-remote-service-name nil)
+         :kerberos-use-canonical-hostname    (tx/db-test-env-var :presto-jdbc :kerberos-use-canonical-hostname nil)
+         :kerberos-credential-cache-path     (tx/db-test-env-var :presto-jdbc :kerberos-credential-cache-path nil)
+         :kerberos-keytab-path               (tx/db-test-env-var :presto-jdbc :kerberos-keytab-path nil)
+         :kerberos-config-path               (tx/db-test-env-var :presto-jdbc :kerberos-config-path nil)
+         :kerberos-service-principal-pattern (tx/db-test-env-var :presto-jdbc :kerberos-service-principal-pattern nil)
+         :catalog                            (u/snake-key database-name)
+         :schema                             (tx/db-test-env-var :presto-jdbc :schema nil)}]
+    (assoc base-details
+           :ssl-use-keystore (every? some? (map base-details [:ssl-keystore-path :ssl-keystore-password-value]))
+           :ssl-use-truststore (every? some? (map base-details [:ssl-truststore-path :ssl-truststore-password-value])))))
+
 (defmethod tx/dbdef->connection-details :presto-jdbc
   [_ _ {:keys [database-name]}]
-  {:host                               (tx/db-test-env-var-or-throw :presto-jdbc :host "localhost")
-   :port                               (tx/db-test-env-var :presto-jdbc :port "8080")
-   :user                               (tx/db-test-env-var-or-throw :presto-jdbc :user "metabase")
-   :additional-options                 (tx/db-test-env-var :presto-jdbc :additional-options nil)
-   :ssl                                (tx/db-test-env-var :presto-jdbc :ssl "false")
-   :kerberos                           (tx/db-test-env-var :presto-jdbc :kerberos "false")
-   :kerberos-principal                 (tx/db-test-env-var :presto-jdbc :kerberos-principal nil)
-   :kerberos-remote-service-name       (tx/db-test-env-var :presto-jdbc :kerberos-remote-service-name nil)
-   :kerberos-use-canonical-hostname    (tx/db-test-env-var :presto-jdbc :kerberos-use-canonical-hostname nil)
-   :kerberos-credential-cache-path     (tx/db-test-env-var :presto-jdbc :kerberos-credential-cache-path nil)
-   :kerberos-keytab-path               (tx/db-test-env-var :presto-jdbc :kerberos-keytab-path nil)
-   :kerberos-config-path               (tx/db-test-env-var :presto-jdbc :kerberos-config-path nil)
-   :kerberos-service-principal-pattern (tx/db-test-env-var :presto-jdbc :kerberos-service-principal-pattern nil)
-   :catalog                            (u/snake-key database-name)
-   :schema                             (tx/db-test-env-var :presto-jdbc :schema nil)})
+  (dbdef->connection-details database-name))
 
 (defmethod execute/execute-sql! :presto-jdbc
   [& args]

--- a/src/metabase/models/secret.clj
+++ b/src/metabase/models/secret.clj
@@ -63,7 +63,7 @@
   resolved, in order to render a more user-friendly error message (by looking up the display names of the connection
   properties involved)."
   {:added "0.42.0"}
-  [{:keys [connection-property-name id value] :as secret} driver?]
+  ^File [{:keys [connection-property-name id value] :as secret} driver?]
   (if (= :file-path (:source secret))
     (let [secret-val          (value->string secret)
           ^File existing-file (File. secret-val)]


### PR DESCRIPTION
This PR fixes #19514 by providing the possibility to upload Java key stores both for custom trust providers and for custom client authentication.

There are a few things that made the implementation difficult:
1. Setting the SSL keystore and truststore properties doesn't seem to work, so they have to passed on as query parameters in the connection URL. (This was done with the Kerberos parameters too, but the reason is not documented.)
1. The `specific-schema-sync-test` creates a temporary database by copying the connection details of the "normal" test database. This overwrote the secrets with useless values and broke the rest of tests. I side stepped the problem by reusing `dbdef->connection-details` to get the keystore parameters. There might be a better/simpler solution for writing this test.
1. I don't know yet why, but without my changes the tests requiring a database are skipped. It seems they were not testing much.
1. The docker image used for testing is emulated on M1 and is unusably slow, prohibiting local testing.