### PR TITLE
fix excluding empty or non-empty date values

### DIFF
--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/ExcludeDatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/ExcludeDatePicker.tsx
@@ -128,19 +128,19 @@ export default function ExcludeDatePicker({
           <>
             <Separator />
             <OptionButton
-              selected={operator === "is-null"}
+              selected={operator === "not-null"}
               primaryColor={primaryColor}
               onClick={() => {
-                onCommit(["is-null", getDateTimeField(filter[1])]);
+                onCommit(["not-null", getDateTimeField(filter[1])]);
               }}
             >
               {t`Is empty`}
             </OptionButton>
             <OptionButton
-              selected={operator === "not-null"}
+              selected={operator === "is-null"}
               primaryColor={primaryColor}
               onClick={() => {
-                onCommit(["not-null", getDateTimeField(filter[1])]);
+                onCommit(["is-null", getDateTimeField(filter[1])]);
               }}
             >
               {t`Is not empty`}

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/ExcludeDatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/ExcludeDatePicker.unit.spec.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import { render, fireEvent, screen } from "@testing-library/react";
+import Filter from "metabase-lib/lib/queries/structured/Filter";
+import { ORDERS } from "__support__/sample_database_fixture";
+import ExcludeDatePicker from "./ExcludeDatePicker";
+
+const query = ORDERS.query();
+
+const filter = new Filter(
+  [null, ["field", ORDERS.CREATED_AT.id, null]],
+  null,
+  query,
+);
+
+describe("ExcludeDatePicker", () => {
+  it("is empty option should exclude empty values by applying not-null filter", () => {
+    const commitMock = jest.fn();
+    render(
+      <ExcludeDatePicker
+        onFilterChange={jest.fn()}
+        onCommit={commitMock}
+        filter={filter}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Is empty"));
+
+    expect(commitMock).toHaveBeenCalledWith([
+      "not-null",
+      ["field", ORDERS.CREATED_AT.id, null],
+    ]);
+  });
+
+  it("is not empty option should exclude non-empty values by applying is-null filter", () => {
+    const commitMock = jest.fn();
+    render(
+      <ExcludeDatePicker
+        onFilterChange={jest.fn()}
+        onCommit={commitMock}
+        filter={filter}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Is not empty"));
+
+    expect(commitMock).toHaveBeenCalledWith([
+      "is-null",
+      ["field", ORDERS.CREATED_AT.id, null],
+    ]);
+  });
+});


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/23677

## Changes

With the revamped in 43 release date filter, options `Is empty` and `Is not empty` were moved under the `Exclude` submenu. However, to be logically correct we should've inverted their effect.

## How to verify

- create a native query `select now() union all select null`
- filter the column by Exclude -> Is empty
- ensure it shows the row with a non-empty value
- filter the column by Exclude -> Is not empty
- ensure it shows the row with an empty value
