### PR TITLE
[E2E] Skip verification test conditionally

### DIFF
--- a/frontend/test/metabase/scenarios/organization/moderation-question.cy.spec.js
+++ b/frontend/test/metabase/scenarios/organization/moderation-question.cy.spec.js
@@ -141,6 +141,8 @@ describeEE("scenarios > saved question moderation", () => {
 });
 
 function verifyQuestion() {
+  cy.intercept("GET", "/api/card/*").as("loadCard");
+
   openQuestionActions();
   cy.findByTextEnsureVisible("Verify this question").click();
 


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Conditionally skips question verification test if there is an error (or rather a race condition) in H2, causing the response to include `moderation_reviews: []`
- Prevents test failures obstructing people's work in PRs and forcing us to rerun the whole test group

According to @dpsutton 's analysis and explanation, we do a number of checks in one transaction on backend when someone clicks "Review question". H2 quite possibly (for whatever reason) doesn't commit all those changes so the backend sends an empty `moderation_reviews` field to frontend.
More info: https://metaboat.slack.com/archives/C505ZNNH4/p1657300770484219?thread_ts=1657295926.728949&cid=C505ZNNH4

### How to test?
- In CI
    - We shouldn't see failures [like this one](https://github.com/metabase/metabase/runs/7257262505?check_suite_focus=true#step:10:611) anymore
- locally
    - stub the response and make sure the test is skipped
```js
cy.intercept("GET", "/api/card/*", req => {
  req.reply(res => {
    res.body["moderation_reviews"] = [];
  });
}).as("loadCard");
```

Should yield this result
![image](https://user-images.githubusercontent.com/31325167/178297665-2dc96bb4-d748-4401-9c85-81de00e0aaea.png)
