### PR TITLE
Handle errors when turning model caching on/off

### DIFF
--- a/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/ModelCachingControl/ModelCachingControl.styled.tsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/ModelCachingControl/ModelCachingControl.styled.tsx
@@ -29,3 +29,9 @@ export const FeatureDescriptionText = styled.p`
   color: ${color("text-medium")};
   font-weight: 400;
 `;
+
+export const ErrorMessage = styled.p`
+  width: 80%;
+  color: ${color("error")};
+  line-height: 1.5rem;
+`;

--- a/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.jsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.jsx
@@ -19,8 +19,6 @@ const propTypes = {
   dismissSyncSpinner: PropTypes.func.isRequired,
   rescanDatabaseFields: PropTypes.func.isRequired,
   discardSavedFieldValues: PropTypes.func.isRequired,
-  persistDatabase: PropTypes.func.isRequired,
-  unpersistDatabase: PropTypes.func.isRequired,
   isAdmin: PropTypes.bool,
   isModelPersistenceEnabled: PropTypes.bool,
 };
@@ -32,8 +30,6 @@ const DatabaseEditAppSidebar = ({
   dismissSyncSpinner,
   rescanDatabaseFields,
   discardSavedFieldValues,
-  persistDatabase,
-  unpersistDatabase,
   isAdmin,
   isModelPersistenceEnabled,
 }) => {

--- a/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.jsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.jsx
@@ -85,17 +85,7 @@ const DatabaseEditAppSidebar = ({
             )}
             {isModelPersistenceEnabled && database.supportsPersistence() && (
               <li className="mt2">
-                <ModelCachingControl
-                  databaseId={database.id}
-                  isEnabled={database.isPersisted()}
-                  onToggle={isEnabled => {
-                    if (isEnabled) {
-                      return persistDatabase(database.id);
-                    } else {
-                      return unpersistDatabase(database.id);
-                    }
-                  }}
-                />
+                <ModelCachingControl database={database} />
               </li>
             )}
           </ol>

--- a/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx
@@ -32,8 +32,6 @@ import {
   discardSavedFieldValues,
   deleteDatabase,
   selectEngine,
-  persistDatabase,
-  unpersistDatabase,
 } from "../database";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 import {
@@ -65,8 +63,6 @@ const mapDispatchToProps = {
   dismissSyncSpinner,
   rescanDatabaseFields,
   discardSavedFieldValues,
-  persistDatabase,
-  unpersistDatabase,
   deleteDatabase,
   selectEngine,
 };
@@ -86,8 +82,6 @@ class DatabaseEditApp extends Component {
     dismissSyncSpinner: PropTypes.func.isRequired,
     rescanDatabaseFields: PropTypes.func.isRequired,
     discardSavedFieldValues: PropTypes.func.isRequired,
-    persistDatabase: PropTypes.func.isRequired,
-    unpersistDatabase: PropTypes.func.isRequired,
     deleteDatabase: PropTypes.func.isRequired,
     saveDatabase: PropTypes.func.isRequired,
     selectEngine: PropTypes.func.isRequired,
@@ -110,8 +104,6 @@ class DatabaseEditApp extends Component {
       rescanDatabaseFields,
       syncDatabaseSchema,
       dismissSyncSpinner,
-      persistDatabase,
-      unpersistDatabase,
       isAdmin,
       isModelPersistenceEnabled,
     } = this.props;
@@ -208,8 +200,6 @@ class DatabaseEditApp extends Component {
               rescanDatabaseFields={rescanDatabaseFields}
               syncDatabaseSchema={syncDatabaseSchema}
               dismissSyncSpinner={dismissSyncSpinner}
-              persistDatabase={persistDatabase}
-              unpersistDatabase={unpersistDatabase}
             />
           )}
         </DatabaseEditMain>

--- a/frontend/src/metabase/admin/databases/database.js
+++ b/frontend/src/metabase/admin/databases/database.js
@@ -299,20 +299,6 @@ export const discardSavedFieldValues = createThunkAction(
   },
 );
 
-export const persistDatabase = createThunkAction(
-  PERSIST_DATABASE,
-  databaseId => async () => {
-    await MetabaseApi.db_persist({ dbId: databaseId });
-  },
-);
-
-export const unpersistDatabase = createThunkAction(
-  UNPERSIST_DATABASE,
-  databaseId => async () => {
-    await MetabaseApi.db_unpersist({ dbId: databaseId });
-  },
-);
-
 export const closeSyncingModal = createThunkAction(
   CLOSE_SYNCING_MODAL,
   function () {


### PR DESCRIPTION
Adds proper error handling when people turn model caching on and off. The most common error we expect is a lack of database permissions. For model caching, Metabase is going to create a schema in the user's database and put model query results in there. So the database credentials must have "create schema" and "create table" permissions in order to make it work. In this case, we're going to show a special error message, otherwise, just display whatever message is coming from the backend.

### To Verify

1. Sign in as an admin
2. Go to `/admin/settings/caching` and enable model caching
3. Prepare a Postgres database and a read-only connection. I was using our [sample Postgres Docker image](https://github.com/metabase/metabase-qa#postgresql-12) and created a read-only user via pgAdmin
4. Go to `/admin/databases` and connect your Postgres DB using the read-only connection (you can also update an existing connection if you already have Postgres connected).
5. Click "Turn model caching on"
6. Ensure the button turns into a "Failed" state and you can see a friendly error message about lacking permissions under the button
7. Change the DB user to the one with write permissions (just "metabase" user if you're using metabase-qa DBs)
8. Click the button again, ensure the error is gone and model caching is turned on now

### Demo

![CleanShot 2022-07-11 at 17 09 57@2x](https://user-images.githubusercontent.com/17258145/178311867-3aab11b8-3736-42b4-adcd-32fbc59c5930.png)

