### PR TITLE
Add func as propType to "reload"

### DIFF
--- a/frontend/src/metabase/entities/containers/EntityListLoader.jsx
+++ b/frontend/src/metabase/entities/containers/EntityListLoader.jsx
@@ -14,7 +14,7 @@ import { capitalize } from "metabase/lib/formatting";
 const propTypes = {
   entityType: PropTypes.string,
   entityQuery: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
-  reload: PropTypes.bool,
+  reload: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
   reloadInterval: PropTypes.oneOfType([PropTypes.number, PropTypes.func]),
   wrapped: PropTypes.bool,
   debounced: PropTypes.bool,

--- a/frontend/src/metabase/entities/containers/EntityListLoader.jsx
+++ b/frontend/src/metabase/entities/containers/EntityListLoader.jsx
@@ -14,6 +14,8 @@ import { capitalize } from "metabase/lib/formatting";
 const propTypes = {
   entityType: PropTypes.string,
   entityQuery: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+  // We generally expect booleans here,
+  // but a parent entity loader may pass `reload` as a function.
   reload: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
   reloadInterval: PropTypes.oneOfType([PropTypes.number, PropTypes.func]),
   wrapped: PropTypes.bool,


### PR DESCRIPTION
Clears a browser console warning that appears on the main page.

### How to test

1. Go to `http://localhost:3000` or your local uri:port.
2. Open the dev console in your browser

You should no longer see a warning that starts with:

```
checkPropTypes.js:20 Warning: Failed prop type: Invalid prop `reload` of type `function` supplied to `Connect(EntityType)`, expected `boolean`.
```