### PR TITLE
Remove propTypes from WidgetStatusIcon

### DIFF
--- a/frontend/src/metabase/parameters/components/WidgetStatusIcon/WidgetStatusIcon.tsx
+++ b/frontend/src/metabase/parameters/components/WidgetStatusIcon/WidgetStatusIcon.tsx
@@ -1,16 +1,6 @@
 import React from "react";
-import PropTypes from "prop-types";
 
 import Icon from "metabase/components/Icon";
-
-const propTypes = {
-  isFullscreen: PropTypes.bool.isRequired,
-  hasValue: PropTypes.bool.isRequired,
-  noReset: PropTypes.bool.isRequired,
-  noPopover: PropTypes.bool.isRequired,
-  isFocused: PropTypes.bool.isRequired,
-  setValue: PropTypes.func.isRequired,
-};
 
 type Props = {
   isFullscreen: boolean;
@@ -77,5 +67,3 @@ function WidgetStatusIcon({
 }
 
 export default WidgetStatusIcon;
-
-WidgetStatusIcon.propTypes = propTypes;


### PR DESCRIPTION
### How to Test

1. Create a dashboard and save it
2. Add a text filter to it.
3. Visit dashboard

You should no longer see a prop type error related to `WidgetStatusIcon`. It's implementation is in TypeScript, so removing propTypes.
