### PR TITLE
Fix console warning in PieChart

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/PieChart.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PieChart.jsx
@@ -490,6 +490,8 @@ export default class PieChart extends Component {
                       "cursor-pointer": getSliceIsClickable(index),
                     })}
                     onClick={
+                      // We use a ternary here because using
+                      // `condition && function` yields a console warning.
                       getSliceIsClickable(index)
                         ? e =>
                             onVisualizationClick({

--- a/frontend/src/metabase/visualizations/visualizations/PieChart.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PieChart.jsx
@@ -490,12 +490,13 @@ export default class PieChart extends Component {
                       "cursor-pointer": getSliceIsClickable(index),
                     })}
                     onClick={
-                      getSliceIsClickable(index) &&
-                      (e =>
-                        onVisualizationClick({
-                          ...getSliceClickObject(index),
-                          event: e.nativeEvent,
-                        }))
+                      getSliceIsClickable(index)
+                        ? e =>
+                            onVisualizationClick({
+                              ...getSliceClickObject(index),
+                              event: event.nativeEvent,
+                            })
+                        : undefined
                     }
                   />
                 ))}


### PR DESCRIPTION
### How to Test

1. Create a question with a Pie Chart visualization
2. Save question, add it to a dashboard
3. Visit dashboard

In your browser console, you should no longer see a warning about `onClick` in a PieChart.