### PR TITLE
Standardize input border radii to 8px

### DIFF
--- a/frontend/src/metabase/core/components/Input/Input.styled.tsx
+++ b/frontend/src/metabase/core/components/Input/Input.styled.tsx
@@ -1,6 +1,7 @@
 import styled from "@emotion/styled";
 import { css } from "@emotion/react";
-import { color, darken } from "metabase/lib/colors";
+import { color } from "metabase/lib/colors";
+import { space } from "metabase/styled-components/theme";
 import IconButtonWrapper from "metabase/components/IconButtonWrapper";
 import { InputSize } from "./types";
 
@@ -26,7 +27,7 @@ export const InputField = styled.input<InputProps>`
   color: ${color("text-dark")};
   padding: 0.75rem;
   border: 1px solid ${color("border-dark")};
-  border-radius: 4px;
+  border-radius: ${space(1)};
   background-color: ${props => color(props.readOnly ? "bg-light" : "bg-white")};
   outline: none;
   text-align: inherit;

--- a/frontend/src/metabase/core/components/SelectButton/SelectButton.styled.tsx
+++ b/frontend/src/metabase/core/components/SelectButton/SelectButton.styled.tsx
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
 import Icon from "metabase/components/Icon";
-
+import { space } from "metabase/styled-components/theme";
 interface SelectButtonRootProps {
   hasValue: boolean;
   fullWidth: boolean;
@@ -27,7 +27,7 @@ export const SelectButtonRoot = styled.button<SelectButtonRootProps>`
       hasValue && highlighted ? color("brand") : color("border-dark")};
   background-color: ${({ hasValue, highlighted }) =>
     hasValue && highlighted ? color("brand") : color("white")};
-  border-radius: 8px;
+  border-radius: ${space(1)};
   font-weight: 700;
   min-width: 104px;
   transition: all 200ms;

--- a/frontend/src/metabase/core/components/TimeInput/CompactTimeInput.styled.tsx
+++ b/frontend/src/metabase/core/components/TimeInput/CompactTimeInput.styled.tsx
@@ -1,5 +1,6 @@
 import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
+import { space } from "metabase/styled-components/theme";
 import NumericInput from "metabase/core/components/NumericInput";
 import Input from "metabase/core/components/Input";
 
@@ -8,7 +9,7 @@ export const CompactInputContainer = styled.div`
   align-items: center;
   padding: 0.55rem 1rem;
 
-  border-radius: 8px;
+  border-radius: ${space(1)};
   border: 1px solid ${color("border")};
   background-color: ${color("white")};
 `;

--- a/frontend/src/metabase/css/components/form.css
+++ b/frontend/src/metabase/css/components/form.css
@@ -1,5 +1,6 @@
 :root {
   --form-field-border-color: var(--color-border-dark);
+  --input-border-radius: 8px;
 }
 ::-webkit-input-placeholder {
   color: var(--color-text-light);
@@ -40,7 +41,7 @@
 .Form-input,
 .Form-input-border {
   border: 1px solid var(--form-field-border-color);
-  border-radius: 4px;
+  border-radius: var(--input-border-radius);
   outline: none;
 }
 

--- a/frontend/src/metabase/css/core/inputs.css
+++ b/frontend/src/metabase/css/core/inputs.css
@@ -1,7 +1,7 @@
 :root {
   --input-border-color: var(--color-border-dark);
   --input-border-active-color: var(--color-brand);
-  --input-border-radius: 4px;
+  --input-border-radius: 8px;
 }
 
 .input,


### PR DESCRIPTION
## Description

Our input border radii varied from 4px-8px. All of which look fine in isolation, but when inputs get put next to each other they look a bit funny.  This standardizes them all on `space(1)` in styled-components or `8px` in css;

## Examples

a | b | c | d
-- | -- | -- | --
![Screen Shot 2022-07-11 at 1 39 47 PM](https://user-images.githubusercontent.com/30528226/178345466-ddcc1cf1-717d-48b8-8ba2-c8b7601c96be.png) | ![Screen Shot 2022-07-11 at 1 40 15 PM](https://user-images.githubusercontent.com/30528226/178345472-3f0a47df-f285-4a74-ba14-eb285ed0ce8b.png) | ![Screen Shot 2022-07-11 at 1 39 59 PM](https://user-images.githubusercontent.com/30528226/178345474-44637f4e-af09-4ab1-a052-0b9fd4772990.png) | ![Screen Shot 2022-07-11 at 1 44 03 PM](https://user-images.githubusercontent.com/30528226/178345661-b6436992-3761-4a46-a42e-2315f97ca817.png)

