### PR TITLE
Serdes v2 for Dimension, plus refactoring

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
@@ -7,6 +7,7 @@
    "Dashboard"
    "DashboardCard"
    "Database"
+   "Dimension"
    "Field"
    "Setting"
    "Table"])

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e/yaml_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e/yaml_test.clj
@@ -52,7 +52,13 @@
                          :dashboard  [[100 {:refs {:collection_id   (random-key "coll" 100)
                                                    :creator_id      (random-key "u" 10)}}]]
                          :dashboard-card [[300 {:refs {:card_id      (random-key "c" 100)
-                                                       :dashboard_id (random-key "d" 100)}}]]})
+                                                       :dashboard_id (random-key "d" 100)}}]]
+                         :dimension  [;; 20 with both IDs set
+                                      [20 {:refs {:field_id                (random-key "field" 1000)
+                                                  :human_readable_field_id (random-key "field" 1000)}}]
+                                      ;; 20 with just :field_id
+                                      [20 {:refs {:field_id                (random-key "field" 1000)
+                                                  :human_readable_field_id ::rs/omit}}]]})
       (let [extraction (into [] (extract/extract-metabase {}))
             entities   (reduce (fn [m entity]
                                  (update m (-> entity :serdes/meta last :model)
@@ -146,6 +152,16 @@
                          (update :created_at u.date/format)
                          (update :updated_at u.date/format))
                      (yaml/from-file (io/file dump-dir "Dashboard" dashboard_id "DashboardCard" filename))))))
+
+          (testing "for dimensions"
+            (is (= 40 (count (dir->file-set (io/file dump-dir "Dimension")))))
+            (doseq [{:keys [entity_id] :as dim} (get entities "Dimension")
+                    :let [filename (str entity_id ".yaml")]]
+              (is (= (-> dim
+                         (dissoc :serdes/meta)
+                         (update :created_at u.date/format)
+                         (update :updated_at u.date/format))
+                     (yaml/from-file (io/file dump-dir "Dimension" filename))))))
 
           (testing "for settings"
             (is (= (into {} (for [{:keys [key value]} (get entities "Setting")]

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e/yaml_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e/yaml_test.clj
@@ -35,30 +35,30 @@
   (ts/with-random-dump-dir [dump-dir "serdesv2-"]
     (ts/with-empty-h2-app-db
       ;; TODO Generating some nested collections would make these tests more robust.
-      (test-gen/insert! {:collection [[100 {:refs {:personal_owner_id ::rs/omit}}]]
-                         :database   [[10]]
-                         :table      (into [] (for [db [:db0 :db1 :db2 :db3 :db4 :db5 :db6 :db7 :db8 :db9]]
-                                                [10 {:refs {:db_id db}}]))
-                         :field      (into [] (for [n     (range 100)
-                                                    :let [table (keyword (str "t" n))]]
-                                                [10 {:refs {:table_id table}}]))
-                         :core-user  [[10]]
-                         :card       [[100 {:refs (let [db (rand-int 10)
-                                                        t  (rand-int 10)]
-                                                    {:database_id   (keyword (str "db" db))
-                                                     :table_id      (keyword (str "t" (+ t (* 10 db))))
-                                                     :collection_id (random-key "coll" 100)
-                                                     :creator_id    (random-key "u" 10)})}]]
-                         :dashboard  [[100 {:refs {:collection_id   (random-key "coll" 100)
-                                                   :creator_id      (random-key "u" 10)}}]]
+      (test-gen/insert! {:collection     [[100 {:refs {:personal_owner_id ::rs/omit}}]]
+                         :database       [[10]]
+                         :table          (into [] (for [db [:db0 :db1 :db2 :db3 :db4 :db5 :db6 :db7 :db8 :db9]]
+                                                    [10 {:refs {:db_id db}}]))
+                         :field          (into [] (for [n     (range 100)
+                                                        :let [table (keyword (str "t" n))]]
+                                                    [10 {:refs {:table_id table}}]))
+                         :core-user      [[10]]
+                         :card           [[100 {:refs (let [db (rand-int 10)
+                                                            t  (rand-int 10)]
+                                                        {:database_id   (keyword (str "db" db))
+                                                         :table_id      (keyword (str "t" (+ t (* 10 db))))
+                                                         :collection_id (random-key "coll" 100)
+                                                         :creator_id    (random-key "u" 10)})}]]
+                         :dashboard      [[100 {:refs {:collection_id   (random-key "coll" 100)
+                                                       :creator_id      (random-key "u" 10)}}]]
                          :dashboard-card [[300 {:refs {:card_id      (random-key "c" 100)
                                                        :dashboard_id (random-key "d" 100)}}]]
-                         :dimension  [;; 20 with both IDs set
-                                      [20 {:refs {:field_id                (random-key "field" 1000)
-                                                  :human_readable_field_id (random-key "field" 1000)}}]
-                                      ;; 20 with just :field_id
-                                      [20 {:refs {:field_id                (random-key "field" 1000)
-                                                  :human_readable_field_id ::rs/omit}}]]})
+                         :dimension      [;; 20 with both IDs set
+                                          [20 {:refs {:field_id                (random-key "field" 1000)
+                                                      :human_readable_field_id (random-key "field" 1000)}}]
+                                          ;; 20 with just :field_id
+                                          [20 {:refs {:field_id                (random-key "field" 1000)
+                                                      :human_readable_field_id ::rs/omit}}]]})
       (let [extraction (into [] (extract/extract-metabase {}))
             entities   (reduce (fn [m entity]
                                  (update m (-> entity :serdes/meta last :model)

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -123,11 +123,11 @@
       (testing "table and database are extracted as [db schema table] triples"
         (let [ser (serdes.base/extract-one "Card" {} (select-one "Card" [:= :id c1-id]))]
           (is (= {:serdes/meta   [{:model "Card" :id c1-eid}]
-                  :table         ["My Database" nil "Schemaless Table"]
+                  :table_id      ["My Database" nil "Schemaless Table"]
                   :creator_id    "mark@direstrai.ts"
                   :collection_id coll-eid
                   :dataset_query "{\"json\": \"string values\"}"} ; Undecoded, still a string.
-                 (select-keys ser [:serdes/meta :table :creator_id :collection_id :dataset_query])))
+                 (select-keys ser [:serdes/meta :table_id :creator_id :collection_id :dataset_query])))
           (is (not (contains? ser :id)))
 
           (testing "cards depend on their Table and Collection"
@@ -138,11 +138,11 @@
 
         (let [ser (serdes.base/extract-one "Card" {} (select-one "Card" [:= :id c2-id]))]
           (is (= {:serdes/meta   [{:model "Card" :id c2-eid}]
-                  :table         ["My Database" "PUBLIC" "Schema'd Table"]
+                  :table_id      ["My Database" "PUBLIC" "Schema'd Table"]
                   :creator_id    "mark@direstrai.ts"
                   :collection_id coll-eid
                   :dataset_query "{}"} ; Undecoded, still a string.
-                 (select-keys ser [:serdes/meta :table :creator_id :collection_id :dataset_query])))
+                 (select-keys ser [:serdes/meta :table_id :creator_id :collection_id :dataset_query])))
           (is (not (contains? ser :id)))
 
           (testing "cards depend on their Table and Collection"

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -2,7 +2,7 @@
   (:require [clojure.test :refer :all]
             [metabase-enterprise.serialization.test-util :as ts]
             [metabase-enterprise.serialization.v2.extract :as extract]
-            [metabase.models :refer [Card Collection Dashboard DashboardCard Database Table User]]
+            [metabase.models :refer [Card Collection Dashboard DashboardCard Database Dimension Field Table User]]
             [metabase.models.serialization.base :as serdes.base]))
 
 (defn- select-one [model-name where]
@@ -183,3 +183,61 @@
         (testing "dashboard cards whose dashboards are in personal collections are returned for the :user"
           (is (= #{dc1-eid dc2-eid}
                  (by-model "DashboardCard" (serdes.base/extract-all "DashboardCard" {:user dave-id})))))))))
+
+(deftest dimensions-test
+  (ts/with-empty-h2-app-db
+    (ts/with-temp-dpc [;; Simple case: a singular field, no human-readable field.
+                       Database   [{db-id        :id}        {:name "My Database"}]
+                       Table      [{no-schema-id :id}        {:name "Schemaless Table" :db_id db-id}]
+                       Field      [{email-id     :id}        {:name "email" :table_id no-schema-id}]
+                       Dimension  [{dim1-id      :id
+                                    dim1-eid     :entity_id} {:name     "Vanilla Dimension"
+                                                              :field_id email-id
+                                                              :type     "internal"}]
+
+                       ;; Advanced case: :field_id is the foreign key, :human_readable_field_id the real target field.
+                       Table      [{this-table   :id}        {:name        "Schema'd Table"
+                                                              :db_id       db-id
+                                                              :schema      "PUBLIC"}]
+                       Field      [{fk-id        :id}        {:name "foreign_id" :table_id this-table}]
+                       Table      [{other-table  :id}        {:name        "Foreign Table"
+                                                              :db_id       db-id
+                                                              :schema      "PUBLIC"}]
+                       Field      [{target-id    :id}        {:name "real_field" :table_id other-table}]
+                       Dimension  [{dim2-id      :id
+                                    dim2-eid     :entity_id} {:name     "Foreign Dimension"
+                                                              :type     "external"
+                                                              :field_id fk-id
+                                                              :human_readable_field_id target-id}]]
+      (testing "vanilla user-created dimensions"
+        (let [ser (serdes.base/extract-one "Dimension" {} (select-one "Dimension" [:= :id dim1-id]))]
+          (is (= {:serdes/meta             [{:model "Dimension" :id dim1-eid}]
+                  :field_id                ["My Database" nil "Schemaless Table" "email"]
+                  :human_readable_field_id nil}
+                 (select-keys ser [:serdes/meta :field_id :human_readable_field_id])))
+          (is (not (contains? ser :id)))
+
+          (testing "depend on the one Field"
+            (is (= #{[{:model "Database"   :id "My Database"}
+                      {:model "Table"      :id "Schemaless Table"}
+                      {:model "Field"      :id "email"}]}
+                   (set (serdes.base/serdes-dependencies ser)))))))
+
+      (testing "foreign key dimensions"
+        (let [ser (serdes.base/extract-one "Dimension" {} (select-one "Dimension" [:= :id dim2-id]))]
+          (is (= {:serdes/meta             [{:model "Dimension" :id dim2-eid}]
+                  :field_id                ["My Database" "PUBLIC" "Schema'd Table" "foreign_id"]
+                  :human_readable_field_id ["My Database" "PUBLIC" "Foreign Table"  "real_field"]}
+                 (select-keys ser [:serdes/meta :field_id :human_readable_field_id])))
+          (is (not (contains? ser :id)))
+
+          (testing "depend on both Fields"
+            (is (= #{[{:model "Database"   :id "My Database"}
+                      {:model "Schema"     :id "PUBLIC"}
+                      {:model "Table"      :id "Schema'd Table"}
+                      {:model "Field"      :id "foreign_id"}]
+                     [{:model "Database"   :id "My Database"}
+                      {:model "Schema"     :id "PUBLIC"}
+                      {:model "Table"      :id "Foreign Table"}
+                      {:model "Field"      :id "real_field"}]}
+                   (set (serdes.base/serdes-dependencies ser))))))))))

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -15,6 +15,7 @@
             [metabase.models.revision :as revision]
             [metabase.models.serialization.base :as serdes.base]
             [metabase.models.serialization.hash :as serdes.hash]
+            [metabase.models.serialization.util :as serdes.util]
             [metabase.moderation :as moderation]
             [metabase.plugins.classloader :as classloader]
             [metabase.public-settings :as public-settings]
@@ -339,44 +340,28 @@
                    [:is :coll.personal_owner_id nil])}))
 
 (defmethod serdes.base/extract-one "Card"
-  [_ _ {:keys [table_id database_id collection_id creator_id] :as card}]
+  [_ _ card]
   ;; Cards have :table_id, :database_id, :collection_id, :creator_id that need conversion.
-  ;; :table_id and :database_id are extracted as just :table [database_name schema table_name].
+  ;; :table_id and :database_id are extracted as just :table_id [database_name schema table_name].
   ;; :collection_id is extracted as its entity_id or identity-hash.
-  ;; :creator_id as the user's email
-  (let [db-name (db/select-one-field :name 'Database :id database_id)
-        {:keys [schema name]} (db/select-one 'Table :id table_id)
-        coll                  (db/select-one 'Collection :id collection_id)
-        {collection-eid :id}  (serdes.base/infer-self-path "Collection" coll)
-        email                 (db/select-one-field :email 'User :id creator_id)]
-    (-> (serdes.base/extract-one-basics "Card" card)
-        (dissoc :table_id :database_id)
-        (assoc :table         [db-name schema name]
-               :collection_id collection-eid
-               :creator_id    email))))
+  ;; :creator_id as the user's email.
+  (-> (serdes.base/extract-one-basics "Card" card)
+      (update :database_id   serdes.util/export-fk-field 'Database :name)
+      (update :table_id      serdes.util/export-table-fk)
+      (update :collection_id serdes.util/export-fk 'Collection)
+      (update :creator_id    serdes.util/export-fk-field 'User :email)))
 
 (defmethod serdes.base/load-xform "Card"
-  [{[db-name schema table-name] :table
-    email                       :creator_id
-    collection-eid              :collection_id
-    :as card}]
-  (let [db-id    (db/select-one-id 'Database :name db-name)
-        table-id (db/select-one-id 'Table :database_id db-id :schema schema :name table-name)
-        coll-id  (serdes.base/lookup-by-id 'Collection collection-eid)
-        user-id  (db/select-one-id 'User :email email)]
-    (-> card
-        serdes.base/load-xform-basics
-        (dissoc :table)
-        (assoc :database_id   db-id
-               :table_id      table-id
-               :collection_id coll-id
-               :creator_id    user-id))))
+  [card]
+  (-> card
+      serdes.base/load-xform-basics
+      (update :database_id   serdes.util/import-fk-field 'Database :name)
+      (update :table_id      serdes.util/import-table-fk)
+      (update :creator_id    serdes.util/import-fk-field 'User :email)
+      (update :collection_id serdes.util/import-fk 'Collection)))
 
 (defmethod serdes.base/serdes-dependencies "Card"
-  [{[db-name schema table-name] :table
-    :keys [collection_id]}]
+  [{:keys [collection_id table_id]}]
   ;; The Table implicitly depends on the Database.
-  [(filterv some? [{:model "Database" :id db-name}
-                   (when schema {:model "Schema" :id schema})
-                   {:model "Table" :id table-name}])
+  [(serdes.util/table->path table_id)
    [{:model "Collection" :id collection_id}]])

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -346,18 +346,18 @@
   ;; :collection_id is extracted as its entity_id or identity-hash.
   ;; :creator_id as the user's email.
   (-> (serdes.base/extract-one-basics "Card" card)
-      (update :database_id   serdes.util/export-fk-field 'Database :name)
+      (update :database_id   serdes.util/export-fk-keyed 'Database :name)
       (update :table_id      serdes.util/export-table-fk)
       (update :collection_id serdes.util/export-fk 'Collection)
-      (update :creator_id    serdes.util/export-fk-field 'User :email)))
+      (update :creator_id    serdes.util/export-fk-keyed 'User :email)))
 
 (defmethod serdes.base/load-xform "Card"
   [card]
   (-> card
       serdes.base/load-xform-basics
-      (update :database_id   serdes.util/import-fk-field 'Database :name)
+      (update :database_id   serdes.util/import-fk-keyed 'Database :name)
       (update :table_id      serdes.util/import-table-fk)
-      (update :creator_id    serdes.util/import-fk-field 'User :email)
+      (update :creator_id    serdes.util/import-fk-keyed 'User :email)
       (update :collection_id serdes.util/import-fk 'Collection)))
 
 (defmethod serdes.base/serdes-dependencies "Card"

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -436,13 +436,13 @@
   [_ _ dash]
   (-> (serdes.base/extract-one-basics "Dashboard" dash)
       (update :collection_id serdes.util/export-fk 'Collection)
-      (update :creator_id    serdes.util/export-fk-field 'User :email)))
+      (update :creator_id    serdes.util/export-fk-keyed 'User :email)))
 
 (defmethod serdes.base/load-xform "Dashboard"
   [dash]
   (-> dash
       (update :collection_id serdes.util/import-fk 'Collection)
-      (update :creator_id    serdes.util/import-fk-field 'User :email)))
+      (update :creator_id    serdes.util/import-fk-keyed 'User :email)))
 
 (defmethod serdes.base/serdes-dependencies "Dashboard"
   [{:keys [collection_id]}]

--- a/src/metabase/models/dimension.clj
+++ b/src/metabase/models/dimension.clj
@@ -42,7 +42,8 @@
       (update :human_readable_field_id #(some-> % serdes.util/import-field-fk))))
 
 (defmethod serdes.base/serdes-dependencies "Dimension"
-  [{:keys [collection_id field_id]}]
+  [{:keys [field_id human_readable_field_id]}]
   ;; The Field depends on the Table, and Table on the Database.
-  [(serdes.util/field->path field_id)
-   [{:model "Collection" :id collection_id}]])
+  (->> [field_id human_readable_field_id]
+       (filter some?)
+       (mapv serdes.util/field->path)))

--- a/src/metabase/models/dimension.clj
+++ b/src/metabase/models/dimension.clj
@@ -2,8 +2,10 @@
   "Dimensions are used to define remappings for Fields handled automatically when those Fields are encountered by the
   Query Processor. For a more detailed explanation, refer to the documentation in
   `metabase.query-processor.middleware.add-dimension-projections`."
-  (:require [metabase.models.serialization.hash :as serdes.hash]
+  (:require [metabase.models.serialization.base :as serdes.base]
+            [metabase.models.serialization.hash :as serdes.hash]
             [metabase.util :as u]
+            [toucan.db :as db]
             [toucan.models :as models]))
 
 (def dimension-types
@@ -23,3 +25,50 @@
   serdes.hash/IdentityHashable
   {:identity-hash-fields (constantly [(serdes.hash/hydrated-hash :field)
                                       (serdes.hash/hydrated-hash :human_readable_field)])})
+
+;;; ------------------------------------------------- Serialization --------------------------------------------------
+(defn- foreign-field [field_id]
+  (let [{:keys [table_id db_id name]}     (db/select-one 'Field :id field_id)
+        {schema :schema table-name :name} (db/select-one 'Table :id table_id)
+        db-name                           (db/select-one-field :name 'Database :id db_id)]
+    (filterv some? [db-name schema table-name name])))
+
+(defn- resolve-field [field]
+  (let [[db-name schema table-name field-name] (case (count field)
+                                                 4 field
+                                                 3 nil)]) ; START HERE - extract these to utils
+  )
+
+(defmethod serdes.base/extract-one "Dimension"
+  [_ _ {:keys [field_id human_readable_field_id] :as dim}]
+  ;; The field IDs are converted to {:field [DB (schema) table field]} portable values.
+  (cond-> (serdes.base/extract-one-basics "Dimension" dim)
+    true (dissoc :field_id :human_readable_field_id)
+    true (assoc :field (foreign-field field_id))
+    human_readable_field_id (assoc :human_readable_field (foreign-field human_readable_field_id))))
+
+(defmethod serdes.base/load-xform "Dimension"
+  [{:keys [field human_readable_field] :as card}]
+  (let [field_id                (resolve-field field)
+        human_readable_field_id (when human_readable_field
+                                  (resolve-field human_readable_field))
+        db-id    (db/select-one-id 'Database :name db-name)
+        table-id (db/select-one-id 'Table :database_id db-id :schema schema :name table-name)
+        coll-id  (serdes.base/lookup-by-id 'Collection collection-eid)
+        user-id  (db/select-one-id 'User :email email)]
+    (-> card
+        serdes.base/load-xform-basics
+        (dissoc :table)
+        (assoc :database_id   db-id
+               :table_id      table-id
+               :collection_id coll-id
+               :creator_id    user-id))))
+
+(defmethod serdes.base/serdes-dependencies "Card"
+  [{[db-name schema table-name] :table
+    :keys [collection_id]}]
+  ;; The Table implicitly depends on the Database.
+  [(filterv some? [{:model "Database" :id db-name}
+                   (when schema {:model "Schema" :id schema})
+                   {:model "Table" :id table-name}])
+   [{:model "Collection" :id collection_id}]])

--- a/src/metabase/models/dimension.clj
+++ b/src/metabase/models/dimension.clj
@@ -4,8 +4,8 @@
   `metabase.query-processor.middleware.add-dimension-projections`."
   (:require [metabase.models.serialization.base :as serdes.base]
             [metabase.models.serialization.hash :as serdes.hash]
+            [metabase.models.serialization.util :as serdes.util]
             [metabase.util :as u]
-            [toucan.db :as db]
             [toucan.models :as models]))
 
 (def dimension-types
@@ -27,48 +27,22 @@
                                       (serdes.hash/hydrated-hash :human_readable_field)])})
 
 ;;; ------------------------------------------------- Serialization --------------------------------------------------
-(defn- foreign-field [field_id]
-  (let [{:keys [table_id db_id name]}     (db/select-one 'Field :id field_id)
-        {schema :schema table-name :name} (db/select-one 'Table :id table_id)
-        db-name                           (db/select-one-field :name 'Database :id db_id)]
-    (filterv some? [db-name schema table-name name])))
-
-(defn- resolve-field [field]
-  (let [[db-name schema table-name field-name] (case (count field)
-                                                 4 field
-                                                 3 nil)]) ; START HERE - extract these to utils
-  )
-
 (defmethod serdes.base/extract-one "Dimension"
-  [_ _ {:keys [field_id human_readable_field_id] :as dim}]
-  ;; The field IDs are converted to {:field [DB (schema) table field]} portable values.
-  (cond-> (serdes.base/extract-one-basics "Dimension" dim)
-    true (dissoc :field_id :human_readable_field_id)
-    true (assoc :field (foreign-field field_id))
-    human_readable_field_id (assoc :human_readable_field (foreign-field human_readable_field_id))))
+  [_ _ dim]
+  ;; The field IDs are converted to {:field [db schema table field]} portable values.
+  (-> (serdes.base/extract-one-basics "Dimension" dim)
+      (update :field_id serdes.util/export-field-fk)
+      (update :human_readable_field_id #(some-> % serdes.util/export-field-fk))))
 
 (defmethod serdes.base/load-xform "Dimension"
-  [{:keys [field human_readable_field] :as card}]
-  (let [field_id                (resolve-field field)
-        human_readable_field_id (when human_readable_field
-                                  (resolve-field human_readable_field))
-        db-id    (db/select-one-id 'Database :name db-name)
-        table-id (db/select-one-id 'Table :database_id db-id :schema schema :name table-name)
-        coll-id  (serdes.base/lookup-by-id 'Collection collection-eid)
-        user-id  (db/select-one-id 'User :email email)]
-    (-> card
-        serdes.base/load-xform-basics
-        (dissoc :table)
-        (assoc :database_id   db-id
-               :table_id      table-id
-               :collection_id coll-id
-               :creator_id    user-id))))
+  [dim]
+  (-> dim
+      serdes.base/load-xform-basics
+      (update :field_id serdes.util/import-field-fk)
+      (update :human_readable_field_id #(some-> % serdes.util/import-field-fk))))
 
-(defmethod serdes.base/serdes-dependencies "Card"
-  [{[db-name schema table-name] :table
-    :keys [collection_id]}]
-  ;; The Table implicitly depends on the Database.
-  [(filterv some? [{:model "Database" :id db-name}
-                   (when schema {:model "Schema" :id schema})
-                   {:model "Table" :id table-name}])
+(defmethod serdes.base/serdes-dependencies "Dimension"
+  [{:keys [collection_id field_id]}]
+  ;; The Field depends on the Table, and Table on the Database.
+  [(serdes.util/field->path field_id)
    [{:model "Collection" :id collection_id}]])

--- a/src/metabase/models/dimension.clj
+++ b/src/metabase/models/dimension.clj
@@ -44,6 +44,7 @@
 (defmethod serdes.base/serdes-dependencies "Dimension"
   [{:keys [field_id human_readable_field_id]}]
   ;; The Field depends on the Table, and Table on the Database.
-  (->> [field_id human_readable_field_id]
-       (filter some?)
-       (mapv serdes.util/field->path)))
+  (let [base  (serdes.util/field->path field_id)]
+    (if-let [human (some-> human_readable_field_id serdes.util/field->path)]
+      [base human]
+      [base])))

--- a/src/metabase/models/serialization/util.clj
+++ b/src/metabase/models/serialization/util.clj
@@ -1,0 +1,103 @@
+(ns metabase.models.serialization.util
+  "Helpers intended to be shared by various models.
+  Most of these are common operations done while (de)serializing several models, like handling a foreign key on a Table
+  or user."
+  (:require [metabase.models.serialization.base :as serdes.base]
+            [toucan.db :as db]
+            [toucan.models :as models]))
+
+;; -------------------------------------------- General Foreign Keys -------------------------------------------------
+(defn export-fk
+  "Given a numeric foreign key and its model (symbol, name or IModel), looks up the entity by ID and gets its entity ID
+  or identity hash.
+  Unusual parameter order means this can be used as `(update x :some_id export-fk 'SomeModel)`."
+  [id model]
+  (let [model-name (name model)
+        model      (db/resolve-model (symbol model-name))
+        entity     (db/select-one model (models/primary-key model) id)
+        {eid :id}  (serdes.base/infer-self-path model-name entity)]
+    eid))
+
+(defn import-fk
+  "Given an entity ID or identity hash, and the model it represents (symbol, name or IModel), looks up the corresponding
+  entity and gets its primary key.
+
+  Throws if the corresponding entity cannot be found.
+
+  Unusual parameter order means this can be used as `(update x :some_id import-fk 'SomeModel)`."
+  [eid model]
+  (let [model-name (name model)
+        model      (db/resolve-model (symbol model-name))
+        entity     (serdes.base/lookup-by-id model eid)]
+    (if entity
+      (get entity (models/primary-key model))
+      (throw (ex-info "Could not find foreign key target - bad serdes-dependencies or other serialization error"
+                      {:entity_id eid :model (name model)})))))
+
+(defn export-fk-field
+  "Given a numeric ID, look up a different identifying field for that entity, and return it as a portable ID.
+  Eg. `User.email`, `Database.name`.
+  [[import-fk-field]] is the inverse.
+  Unusual parameter order lets this be called as, for example, `(update x :creator_id export-fk-field 'User :email).
+
+  Note: This assumes the primary key is called `:id`."
+  [id model field]
+  (db/select-one-field field model :id id))
+
+(defn import-fk-field
+  "Given a single, portable, identifying field and the model it refers to, this resolves the entity and returns its
+  numeric `:id`.
+  Eg. `User.email` or `Database.name`.
+
+  Unusual parameter order lets this be called as, for example, `(update x :creator_id import-fk-field 'User :email)`."
+  [portable model field]
+  (db/select-one-id model field portable))
+
+;; -------------------------------------------------- Tables ---------------------------------------------------------
+(defn export-table-fk
+  "Given a numeric `table_id`, return a portable table reference.
+  That has the form `[db-name schema table-name]`, where the `schema` might be nil.
+  [[import-table-fk]] is the inverse."
+  [table-id]
+  (let [{:keys [db_id name schema]} (db/select-one 'Table :id table-id)
+        db-name                     (db/select-one-field :name 'Database :id db_id)]
+    [db-name schema name]))
+
+(defn import-table-fk
+  "Given a `table_id` as exported by [[export-table-fk]], resolve it back into a numeric `table_id`."
+  [[db-name schema table-name]]
+  (db/select-one-field :id 'Table :name table-name :schema schema :db_id (db/select-one-id 'Database :name db-name)))
+
+(defn table->path
+  "Given a `table_id` as exported by [[export-table-fk]], turn it into a `[{:model ...}]` path for the Table.
+  This is useful for writing [[metabase.models.serialization.base/serdes-dependencies]] implementations."
+  [[db-name schema table-name]]
+  (filterv some? [{:model "Database" :id db-name}
+                  (when schema {:model "Schema" :id schema})
+                  {:model "Table" :id table-name}]))
+
+;; -------------------------------------------------- Fields ---------------------------------------------------------
+(defn export-field-fk
+  "Given a numeric `field_id`, return a portable field reference.
+  That has the form `[db-name schema table-name field-name]`, where the `schema` might be nil.
+  [[import-field-fk]] is the inverse."
+  [field-id]
+  (let [{:keys [name table_id]}     (db/select-one 'Field :id field-id)
+        [db-name schema field-name] (export-table-fk table_id)]
+    [db-name schema field-name name]))
+
+(defn import-field-fk
+  "Given a `field_id` as exported by [[export-field-fk]], resolve it back into a numeric `field_id`."
+  [[db-name schema table-name field-name]]
+  (let [table_id (import-table-fk [db-name schema table-name])]
+    (db/select-one-id 'Field :table_id table_id :name field-name)))
+
+(defn field->path
+  "Given a `field_id` as exported by [[export-field-fk]], turn it into a `[{:model ...}]` path for the Field.
+  This is useful for writing [[metabase.models.serialization.base/serdes-dependencies]] implementations."
+  [[db-name schema table-name field-name]]
+  (filterv some? [{:model "Database" :id db-name}
+                  (when schema {:model "Schema" :id schema})
+                  {:model "Table" :id table-name}
+                  {:model "Field" :id field-name}]))
+

--- a/src/metabase/models/serialization/util.clj
+++ b/src/metabase/models/serialization/util.clj
@@ -100,4 +100,3 @@
                   (when schema {:model "Schema" :id schema})
                   {:model "Table" :id table-name}
                   {:model "Field" :id field-name}]))
-

--- a/src/metabase/models/serialization/util.clj
+++ b/src/metabase/models/serialization/util.clj
@@ -34,22 +34,22 @@
       (throw (ex-info "Could not find foreign key target - bad serdes-dependencies or other serialization error"
                       {:entity_id eid :model (name model)})))))
 
-(defn export-fk-field
+(defn export-fk-keyed
   "Given a numeric ID, look up a different identifying field for that entity, and return it as a portable ID.
   Eg. `User.email`, `Database.name`.
-  [[import-fk-field]] is the inverse.
-  Unusual parameter order lets this be called as, for example, `(update x :creator_id export-fk-field 'User :email).
+  [[import-fk-keyed]] is the inverse.
+  Unusual parameter order lets this be called as, for example, `(update x :creator_id export-fk-keyed 'User :email).
 
   Note: This assumes the primary key is called `:id`."
   [id model field]
   (db/select-one-field field model :id id))
 
-(defn import-fk-field
+(defn import-fk-keyed
   "Given a single, portable, identifying field and the model it refers to, this resolves the entity and returns its
   numeric `:id`.
   Eg. `User.email` or `Database.name`.
 
-  Unusual parameter order lets this be called as, for example, `(update x :creator_id import-fk-field 'User :email)`."
+  Unusual parameter order lets this be called as, for example, `(update x :creator_id import-fk-keyed 'User :email)`."
   [portable model field]
   (db/select-one-id model field portable))
 

--- a/test/metabase/test/generate.clj
+++ b/test/metabase/test/generate.clj
@@ -210,7 +210,9 @@
                                   :insert! {:model DashboardCardSeries}}
    :dimension                    {:prefix  :dim
                                   :spec    ::dimension
-                                  :insert! {:model Dimension}}
+                                  :insert! {:model Dimension}
+                                  :relations {:field_id                [:field :id]
+                                              :human_readable_field_id [:field :id]}}
    :field                        {:prefix      :field
                                   :spec        ::field
                                   :insert!     {:model Field}


### PR DESCRIPTION
This includes a bunch of refactoring to make it easier to write `extract-one`,
`load-xform` and `serdes-dependencies` implementations.

Most of the work in these functions is transforming foreign keys to a portable
form and back again. The new namespace `metabase.models.serialization.util` has
support for several common patterns here:
- Using `(or (:entity_id foreign-entity) (identity-hash foreign-entity))`
- Using an already portable value (eg. `Database.name`, `User.email`)
- Turning a `table_id` into `[db-name schema table]` (and similarly for
  `field_id`)
