### PR TITLE
Fix 2 Dashboard console warnings

### DIFF
--- a/frontend/src/metabase/dashboard/containers/DashboardSharingEmbeddingModal.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardSharingEmbeddingModal.jsx
@@ -60,7 +60,7 @@ class DashboardSharingEmbeddingModal extends Component {
         full
         disabled={!isLinkEnabled}
         triggerElement={
-          <a
+          <span
             className={linkClassNames}
             aria-disabled={!isLinkEnabled}
             onClick={() => {
@@ -74,7 +74,7 @@ class DashboardSharingEmbeddingModal extends Component {
             }}
           >
             {linkText}
-          </a>
+          </span>
         }
         triggerClasses={cx(className, "text-brand-hover")}
         className="scroll-y"

--- a/frontend/src/metabase/sharing/components/SharingSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/SharingSidebar.jsx
@@ -122,7 +122,7 @@ class SharingSidebarInner extends React.Component {
     saveEditingPulse: PropTypes.func.isRequired,
     testPulse: PropTypes.func.isRequired,
     updateEditingPulse: PropTypes.func.isRequired,
-    pulses: PropTypes.array.isRequired,
+    pulses: PropTypes.array,
     onCancel: PropTypes.func.isRequired,
     setPulseArchived: PropTypes.func.isRequired,
     users: PropTypes.array,


### PR DESCRIPTION
### How to Test

#### Dashboard

1. Enable public sharing at http://localhost:3000/admin/settings/public-sharing
2. Create and save a dashboard
3. Visit dashboard

Browser console should no longer display warnings about:

1. `pulses` propType in SharingSidebarInner.
2. An `<a>` being a descendant of another `<a>` 
