### PR TITLE
Fix #18439: Clicking in a question in the audit log tracks a view

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/audit_app/pages/AuditQuestionDetail.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/pages/AuditQuestionDetail.jsx
@@ -22,7 +22,11 @@ const pagePropTypes = {
 function AuditQuestionDetail({ params, ...props }) {
   const questionId = parseInt(params.questionId);
   return (
-    <Question.Loader id={questionId} wrapped>
+    <Question.Loader
+      id={questionId}
+      entityQuery={{ ignore_view: true }}
+      wrapped
+    >
       {({ question }) => (
         <AuditContent
           {...props}

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -153,7 +153,7 @@
 
 (api/defendpoint GET "/:id"
   "Get `Card` with ID."
-  [id]
+  [id ignore_view]
   (let [card (-> (Card id)
                  (hydrate :creator
                           :bookmarked
@@ -165,7 +165,8 @@
                  api/read-check
                  (last-edit/with-last-edit-info :card))]
     (u/prog1 (cond-> card (:dataset card) (hydrate :persisted))
-      (events/publish-event! :card-read (assoc <> :actor_id api/*current-user-id*)))))
+      (when-not (Boolean/parseBoolean ignore_view)
+        (events/publish-event! :card-read (assoc <> :actor_id api/*current-user-id*))))))
 
 (api/defendpoint GET "/:id/timelines"
   "Get the timelines for card with ID. Looks up the collection the card is in and uses that."


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/18439

Similar to https://github.com/metabase/metabase/pull/23780, we add an `ignore_view` parameter to the GET endpoint and use it whenever the request shouldn't count as a view.