### PR TITLE
Position form error messages when footer elements are reversed

### DIFF
--- a/frontend/src/metabase/components/form/CustomForm/CustomFormFooter/CustomFormFooter.tsx
+++ b/frontend/src/metabase/components/form/CustomForm/CustomFormFooter/CustomFormFooter.tsx
@@ -24,15 +24,17 @@ function CustomFormFooter({
   isModal,
   isContextModal,
 }: CustomFormFooterProps & { isContextModal?: boolean }) {
+  const shouldReverse = isModal || isContextModal;
+
   return (
-    <CustomFormFooterStyled shouldReverse={isModal || isContextModal}>
+    <CustomFormFooterStyled shouldReverse={shouldReverse}>
       <CustomFormSubmit fullWidth={fullWidth}>{submitTitle}</CustomFormSubmit>
       {onCancel && (
         <Button className="mx1" type="button" onClick={onCancel}>
           {cancelTitle}
         </Button>
       )}
-      <CustomFormMessage className="mt1 flex-full" />
+      <CustomFormMessage className="mt1 flex-full" autoWidth={shouldReverse} />
       {footerExtraButtons}
     </CustomFormFooterStyled>
   );

--- a/frontend/src/metabase/components/form/CustomForm/CustomFormMessage.tsx
+++ b/frontend/src/metabase/components/form/CustomForm/CustomFormMessage.tsx
@@ -6,6 +6,7 @@ import FormMessage from "metabase/components/form/FormMessage";
 import { FormLegacyContext, LegacyContextTypes } from "./types";
 
 export interface CustomFormMessageProps {
+  autoWidth?: boolean;
   className?: string;
   noPadding?: boolean;
 }

--- a/frontend/src/metabase/components/form/FormMessage/FormMessage.styled.tsx
+++ b/frontend/src/metabase/components/form/FormMessage/FormMessage.styled.tsx
@@ -5,6 +5,7 @@ import { space } from "metabase/styled-components/theme";
 import { color } from "metabase/lib/colors";
 
 export const FormMessageStyled = styled.span<{
+  autoWidth?: boolean;
   visible?: boolean;
   hasSucceeded?: boolean;
   noPadding?: boolean;
@@ -22,5 +23,12 @@ export const FormMessageStyled = styled.span<{
     css`
       opacity: 1;
       transition: opacity 500ms linear;
+    `}
+
+  ${({ autoWidth }) =>
+    autoWidth &&
+    css`
+      width: auto;
+      max-width: 100%;
     `}
 `;

--- a/frontend/src/metabase/components/form/FormMessage/FormMessage.tsx
+++ b/frontend/src/metabase/components/form/FormMessage/FormMessage.tsx
@@ -11,6 +11,7 @@ type Response = {
 };
 
 interface FormMessageProps {
+  autoWidth?: boolean;
   className?: string;
   message?: string;
   noPadding?: boolean;
@@ -49,6 +50,7 @@ export const getSuccessMessage = (formSuccess?: Response) => {
 };
 
 function FormMessage({
+  autoWidth,
   className,
   message,
   formSuccess,
@@ -58,6 +60,7 @@ function FormMessage({
   const treatedMessage = getMessage({ message, formSuccess, formError });
   return (
     <FormMessageStyled
+      autoWidth={autoWidth}
       className={className}
       visible={!!message}
       noPadding={noPadding}


### PR DESCRIPTION
Fixes #23861

### How to Test

#### Inside a popup

1. In test question-management.cy.spec.js, run any test with user "nodata" and signing in with `cy.signIn("nodata")`.
2. After test is done, and it may pass, duplicate the question.

Error message should not be cut to the left.

#### Inlined in page (one path to check)

1. Add a user
2. Deactivate user
3. Try to login with deactivated user
4. Error message should continue to be displayed ok.