### PR TITLE
using flex to layout app header and app content

### DIFF
--- a/frontend/src/metabase/App.styled.tsx
+++ b/frontend/src/metabase/App.styled.tsx
@@ -3,16 +3,20 @@ import { color } from "metabase/lib/colors";
 
 import { APP_BAR_HEIGHT } from "metabase/nav/constants";
 
+export const AppContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
 export const AppContentContainer = styled.div<{
   isAdminApp: boolean;
   isAppBarVisible: boolean;
 }>`
+  flex-grow: 1;
   display: flex;
   flex-direction: ${props => (props.isAdminApp ? "column" : "row")};
   position: relative;
   overflow: hidden;
-  height: ${props =>
-    props.isAppBarVisible ? `calc(100vh - ${APP_BAR_HEIGHT})` : "100vh"};
   background-color: ${props =>
     color(props.isAdminApp ? "bg-white" : "content")};
 

--- a/frontend/src/metabase/App.tsx
+++ b/frontend/src/metabase/App.tsx
@@ -29,7 +29,7 @@ import { ContentViewportContext } from "metabase/core/context/ContentViewportCon
 
 import { AppErrorDescriptor, State } from "metabase-types/store";
 
-import { AppContent, AppContentContainer } from "./App.styled";
+import { AppContainer, AppContent, AppContentContainer } from "./App.styled";
 
 const getErrorComponent = ({ status, data, context }: AppErrorDescriptor) => {
   if (status === 403 || data?.error_code === "unauthorized") {
@@ -100,7 +100,7 @@ function App({
   return (
     <ErrorBoundary onError={setErrorInfo}>
       <ScrollToTop>
-        <div className="spread">
+        <AppContainer className="spread">
           {isAppBarVisible && <AppBar isNavBarVisible={isNavBarVisible} />}
           <AppContentContainer
             isAdminApp={isAdminApp}
@@ -116,7 +116,7 @@ function App({
             <StatusListing />
           </AppContentContainer>
           <AppErrorCard errorInfo={errorInfo} />
-        </div>
+        </AppContainer>
       </ScrollToTop>
     </ErrorBoundary>
   );


### PR DESCRIPTION
PR to address the fact that in mobile, the app bar can now grow/shrink depending on the page, which can cause the footer of questions to be off screen. Wraps our `<AppBar>` and `<AppContentContainer>` in `display:flex; flex-direction: column`, which handles sizing the AppConentContainer correctly.

While this is a very broad PR that could potentially affect many things, I tested the following and found no issues:
- Login page
- Setup page
- Questions and dashboards (both mobile and desktop)
- Admin app
- Public Embedding questions
- Full app embedding (By setting [IFRAMED](https://github.com/metabase/metabase/blob/1aa9565c451fb2c92c4cab46c45dde7a0adab174/frontend/src/metabase/lib/dom.js#L13) to true