### PR TITLE
Repro #22230: Unable to properly filter on an aggregation (max of)

### DIFF
--- a/frontend/test/metabase/scenarios/filters/reproductions/22230-filter-on-aggregation-max-of.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/reproductions/22230-filter-on-aggregation-max-of.cy.spec.js
@@ -1,0 +1,44 @@
+import {
+  restore,
+  visitQuestionAdhoc,
+  popover,
+  visualize,
+} from "__support__/e2e/helpers";
+
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
+
+const { PEOPLE, PEOPLE_ID } = SAMPLE_DATABASE;
+
+const questionDetails = {
+  dataset_query: {
+    database: SAMPLE_DB_ID,
+    query: {
+      "source-table": PEOPLE_ID,
+      aggregation: [["max", ["field", PEOPLE.NAME, null]]],
+      breakout: [["field", PEOPLE.SOURCE, null]],
+    },
+    type: "query",
+    display: "table",
+  },
+};
+
+describe.skip("issue 22230", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    visitQuestionAdhoc(questionDetails, { mode: "notebook" });
+  });
+
+  it("should be able to filter on an aggregation (metabase#22230)", () => {
+    cy.findByText("Filter").click();
+    popover().contains("Max of Name").click();
+
+    cy.findByPlaceholderText("Enter some text").type("Zora").blur();
+    cy.button("Add filter").click();
+
+    visualize();
+    cy.findByText("Zora Schamberger");
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #22230

### How to test this manually?
- `yarn test-cypress-open`
- `metabase/scenarios/filters/reproductions/22230-filter-on-aggregation-max-of.cy.spec.js`
- Unskip test
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/178578412-7581a5b7-ebfd-4456-90db-425e053d44df.png)

