### PR TITLE
Disable erroring json filters

### DIFF
--- a/frontend/src/metabase/modes/components/drill/ColumnFilterDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/ColumnFilterDrill.jsx
@@ -1,10 +1,13 @@
 /* eslint-disable react/prop-types */
 import React from "react";
 import { t } from "ttag";
+import _ from "underscore";
+import { TYPE, isa } from "metabase/lib/types";
 
 import Filter from "metabase-lib/lib/queries/structured/Filter";
-
 import FilterPopover from "metabase/query_builder/components/filters/FilterPopover";
+
+const INVALID_TYPES = [TYPE.Structured];
 
 export default function ColumnFilterDrill({ question, clicked }) {
   const query = question.query();
@@ -13,6 +16,7 @@ export default function ColumnFilterDrill({ question, clicked }) {
     !query.isEditable() ||
     !clicked ||
     !clicked.column ||
+    _.any(INVALID_TYPES, type => isa(clicked.column.base_type, type)) ||
     clicked.column.field_ref == null ||
     clicked.value !== undefined
   ) {

--- a/frontend/src/metabase/modes/components/drill/ColumnFilterDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/ColumnFilterDrill.jsx
@@ -1,7 +1,6 @@
 /* eslint-disable react/prop-types */
 import React from "react";
 import { t } from "ttag";
-import _ from "underscore";
 import { TYPE, isa } from "metabase/lib/types";
 
 import Filter from "metabase-lib/lib/queries/structured/Filter";
@@ -16,7 +15,7 @@ export default function ColumnFilterDrill({ question, clicked }) {
     !query.isEditable() ||
     !clicked ||
     !clicked.column ||
-    _.any(INVALID_TYPES, type => isa(clicked.column.base_type, type)) ||
+    INVALID_TYPES.some(type => isa(clicked.column.base_type, type)) ||
     clicked.column.field_ref == null ||
     clicked.value !== undefined
   ) {

--- a/frontend/src/metabase/modes/components/drill/DistributionDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/DistributionDrill.jsx
@@ -1,7 +1,6 @@
 /* eslint-disable react/prop-types */
 import { t } from "ttag";
 import { TYPE, isa } from "metabase/lib/types";
-import _ from "underscore";
 
 const DENYLIST_TYPES = [
   TYPE.PK,
@@ -15,7 +14,7 @@ export default ({ question, clicked }) => {
     !clicked ||
     !clicked.column ||
     clicked.value !== undefined ||
-    _.any(DENYLIST_TYPES, t => isa(clicked.column.semantic_type, t)) ||
+    DENYLIST_TYPES.some(t => isa(clicked.column.semantic_type, t)) ||
     !question.query().isEditable()
   ) {
     return [];

--- a/frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/prop-types */
 import React from "react";
-import _ from "underscore";
 import { jt } from "ttag";
+
 import { isFK, isPK, TYPE, isa } from "metabase/lib/types";
 import { isLocalField } from "metabase/lib/query/field_ref";
 import { isDate, isNumeric } from "metabase/lib/schema_metadata";
@@ -17,7 +17,7 @@ function getFiltersForColumn(column) {
       { name: "=", operator: "=" },
       { name: "≠", operator: "!=" },
     ];
-  } else if (!_.any(INVALID_TYPES, type => isa(column.base_type, type))) {
+  } else if (!INVALID_TYPES.some(type => isa(column.base_type, type))) {
     return [
       { name: "=", operator: "=" },
       { name: "≠", operator: "!=" },

--- a/frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx
@@ -1,10 +1,13 @@
 /* eslint-disable react/prop-types */
 import React from "react";
+import _ from "underscore";
 import { jt } from "ttag";
-import { isFK, isPK } from "metabase/lib/types";
+import { isFK, isPK, TYPE, isa } from "metabase/lib/types";
 import { isLocalField } from "metabase/lib/query/field_ref";
 import { isDate, isNumeric } from "metabase/lib/schema_metadata";
 import { singularize, pluralize, stripId } from "metabase/lib/formatting";
+
+const INVALID_TYPES = [TYPE.Structured];
 
 function getFiltersForColumn(column) {
   if (isNumeric(column) || isDate(column)) {
@@ -14,11 +17,13 @@ function getFiltersForColumn(column) {
       { name: "=", operator: "=" },
       { name: "≠", operator: "!=" },
     ];
-  } else {
+  } else if (!_.any(INVALID_TYPES, type => isa(column.base_type, type))) {
     return [
       { name: "=", operator: "=" },
       { name: "≠", operator: "!=" },
     ];
+  } else {
+    return [];
   }
 }
 

--- a/frontend/src/metabase/modes/components/drill/SortAction.jsx
+++ b/frontend/src/metabase/modes/components/drill/SortAction.jsx
@@ -1,6 +1,5 @@
 import { t } from "ttag";
 import Dimension from "metabase-lib/lib/Dimension";
-import _ from "underscore";
 import { TYPE, isa } from "metabase/lib/types";
 
 const INVALID_TYPES = [TYPE.Structured];
@@ -15,7 +14,7 @@ export default ({ question, clicked }) => {
     !clicked ||
     !clicked.column ||
     clicked.value !== undefined ||
-    _.any(INVALID_TYPES, type => isa(clicked.column.base_type, type)) ||
+    INVALID_TYPES.some(type => isa(clicked.column.base_type, type)) ||
     !clicked.column.source
   ) {
     return [];

--- a/frontend/src/metabase/modes/components/drill/SortAction.jsx
+++ b/frontend/src/metabase/modes/components/drill/SortAction.jsx
@@ -1,5 +1,9 @@
 import { t } from "ttag";
 import Dimension from "metabase-lib/lib/Dimension";
+import _ from "underscore";
+import { TYPE, isa } from "metabase/lib/types";
+
+const INVALID_TYPES = [TYPE.Structured];
 
 export default ({ question, clicked }) => {
   const query = question.query();
@@ -11,6 +15,7 @@ export default ({ question, clicked }) => {
     !clicked ||
     !clicked.column ||
     clicked.value !== undefined ||
+    _.any(INVALID_TYPES, type => isa(clicked.column.base_type, type)) ||
     !clicked.column.source
   ) {
     return [];

--- a/frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js
+++ b/frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js
@@ -1,10 +1,15 @@
 /* eslint-disable react/prop-types */
 import { fieldRefForColumn } from "metabase/lib/dataset";
+import { t } from "ttag";
+import _ from "underscore";
+
+import { TYPE, isa } from "metabase/lib/types";
 import {
   getAggregationOperator,
   isCompatibleAggregationOperatorForField,
 } from "metabase/lib/schema_metadata";
-import { t } from "ttag";
+
+const INVALID_TYPES = [TYPE.Structured];
 
 const AGGREGATIONS = {
   sum: {
@@ -26,7 +31,11 @@ const AGGREGATIONS = {
 
 export default ({ question, clicked = {} }) => {
   const { column, value } = clicked;
-  if (!column || value !== undefined) {
+  if (
+    !column ||
+    value !== undefined ||
+    _.any(INVALID_TYPES, type => isa(clicked.column.base_type, type))
+  ) {
     return [];
   }
 

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterList/BulkFilterList.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterList/BulkFilterList.tsx
@@ -43,7 +43,10 @@ const BulkFilterList = ({
 }: BulkFilterListProps): JSX.Element => {
   const [dimensions, segments] = useMemo(
     () => [
-      options.filter(isDimensionOption).sort(sortDimensions),
+      options
+        .filter(isDimensionOption)
+        .filter(isDimensionValid)
+        .sort(sortDimensions),
       options.filter(isSegmentOption),
     ],
     [options],

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterList/BulkFilterList.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterList/BulkFilterList.tsx
@@ -18,7 +18,7 @@ import { BulkFilterItem } from "../BulkFilterItem";
 import { SegmentFilterSelect } from "../BulkFilterSelect";
 import { InlineOperatorSelector } from "../InlineOperatorSelector";
 import { ListRoot, ListRow, FilterContainer } from "./BulkFilterList.styled";
-import { sortDimensions } from "./utils";
+import { sortDimensions, isDimensionValid } from "./utils";
 
 export interface BulkFilterListProps {
   query: StructuredQuery;

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterList/utils.ts
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterList/utils.ts
@@ -59,6 +59,4 @@ export const sortDimensions = (a: DimensionOption, b: DimensionOption) =>
   getSortValue(a) - getSortValue(b);
 
 export const isDimensionValid = (dimensionOption: DimensionOption) =>
-  dimensionOption.dimension.field().base_type === "type/Structured"
-    ? false
-    : true;
+  dimensionOption.dimension.field().base_type !== "type/Structured";

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterList/utils.ts
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterList/utils.ts
@@ -57,3 +57,8 @@ const getSortValue = (dimensionOption: DimensionOption): number => {
 
 export const sortDimensions = (a: DimensionOption, b: DimensionOption) =>
   getSortValue(a) - getSortValue(b);
+
+export const isDimensionValid = (dimensionOption: DimensionOption) =>
+  dimensionOption.dimension.field().base_type === "type/Structured"
+    ? false
+    : true;

--- a/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
@@ -146,9 +146,13 @@ class ChartClickActions extends Component {
     }
 
     const groupedClickActions = _.groupBy(clickActions, "section");
-    if (groupedClickActions["sum"] && groupedClickActions["sum"].length === 1) {
+
+    if (groupedClickActions?.["sum"]?.length === 1) {
       // if there's only one "sum" click action, merge it into "summarize" and change its button type and icon
-      groupedClickActions?.["summarize"]?.push({
+      if (!groupedClickActions?.["summarize"]) {
+        groupedClickActions["summarize"] = [];
+      }
+      groupedClickActions["summarize"].push({
         ...groupedClickActions["sum"][0],
         buttonType: "horizontal",
         icon: "number",

--- a/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
@@ -148,7 +148,7 @@ class ChartClickActions extends Component {
     const groupedClickActions = _.groupBy(clickActions, "section");
     if (groupedClickActions["sum"] && groupedClickActions["sum"].length === 1) {
       // if there's only one "sum" click action, merge it into "summarize" and change its button type and icon
-      groupedClickActions["summarize"].push({
+      groupedClickActions?.["summarize"]?.push({
         ...groupedClickActions["sum"][0],
         buttonType: "horizontal",
         icon: "number",
@@ -156,8 +156,8 @@ class ChartClickActions extends Component {
       delete groupedClickActions["sum"];
     }
     const hasOnlyOneSortAction = groupedClickActions["sort"]?.length === 1;
-    if (clicked.column?.source === "native" && hasOnlyOneSortAction) {
-      // restyle the Formatting action for SQL columns
+    if (hasOnlyOneSortAction) {
+      // restyle the Formatting action when there is only one option
       groupedClickActions["sort"][0] = {
         ...groupedClickActions["sort"][0],
         buttonType: "horizontal",


### PR DESCRIPTION
## Description

Our backend does not currently support filtering on json or xml fields. It's on the todo list (https://github.com/metabase/metabase/issues/21933), but until we get that support on the backend, we should not trick users into thinking they can filter on these fields, and then give them errors.

![Screen Shot 2022-07-12 at 2 30 00 PM](https://user-images.githubusercontent.com/30528226/178589583-b94150e1-d5a8-4d22-a277-1c9e2500ee98.png) ![Screen Shot 2022-07-12 at 2 30 05 PM](https://user-images.githubusercontent.com/30528226/178589580-83850087-2d4c-4edc-86ec-ae5365fb2348.png) 

![fake out](https://media.giphy.com/media/5XHvCVnmQL1Mk/giphy.gif)

![Screen Shot 2022-07-12 at 1 56 47 PM](https://user-images.githubusercontent.com/30528226/178585114-06be1880-da39-4f57-b368-33ff619c5cd8.png)
![Screen Shot 2022-07-12 at 1 56 33 PM](https://user-images.githubusercontent.com/30528226/178585120-d3fd4730-db87-4b24-ab0d-6770cc466aa9.png)

## Changes

Disable column and field click actions that don't work on json columns anyway. We shouldn't trick the user into getting an error.

![Screen Shot 2022-07-14 at 1 43 11 PM](https://user-images.githubusercontent.com/30528226/179070859-88abe146-0f9d-498d-8687-a564af1f3c46.png)

## How to test

You need a json column that doesn't parse out into individual fields: arrays work nicely.
- see that the column header no longer has sorting and filtering options
- see that individual cells in table view no longer have click options (which previously gave you broken `=` and `!=` filters)
- sort/filter/distribution shortcuts should still work on other column types