### PR TITLE
Ensure currency symbols are shown in table data if settings say so

### DIFF
--- a/frontend/src/metabase/lib/formatting.js
+++ b/frontend/src/metabase/lib/formatting.js
@@ -180,6 +180,15 @@ export function formatNumber(number, options = {}) {
         formatted = replaceNumberSeparators(formatted, separators);
       }
 
+      // fixes issue where certain symbols, such as
+      // czech Kč, and Bitcoin ₿, are not displayed
+      if (options["currency_style"] === "symbol") {
+        formatted = formatted.replace(
+          options["currency"],
+          getCurrencySymbol(options["currency"]),
+        );
+      }
+
       return formatted;
     } catch (e) {
       console.warn("Error formatting number", e);

--- a/frontend/test/metabase/scenarios/question/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/settings.cy.spec.js
@@ -154,15 +154,6 @@ describe("scenarios > question > settings", () => {
        * Helper functions related to THIS test only
        */
 
-      function getSidebarColumns() {
-        return cy
-          .findByText("Click and drag to change their order")
-          .scrollIntoView()
-          .should("be.visible")
-          .parent()
-          .find(".cursor-grab");
-      }
-
       function reloadResults() {
         cy.icon("play").last().click();
       }
@@ -221,6 +212,28 @@ describe("scenarios > question > settings", () => {
 
       sidebar().findByText(newColumnTitle);
     });
+
+    it("should respect symbol settings for all currencies", () => {
+      openOrdersTable();
+      cy.contains("Settings").click();
+
+      getSidebarColumns()
+        .eq("4")
+        .within(() => {
+          cy.icon("gear").click();
+        });
+
+      cy.findByText("Normal").click();
+      cy.findByText("Currency").click();
+
+      cy.findByText("US Dollar").click();
+      cy.findByText("Bitcoin").click();
+
+      cy.findByText("In every table cell").click();
+
+      cy.findByText("₿ 2.07");
+      cy.findByText("₿ 6.10");
+    });
   });
 
   describe("resetting state", () => {
@@ -247,3 +260,12 @@ describe("scenarios > question > settings", () => {
     });
   });
 });
+
+function getSidebarColumns() {
+  return cy
+    .findByText("Click and drag to change their order")
+    .scrollIntoView()
+    .should("be.visible")
+    .parent()
+    .find(".cursor-grab");
+}


### PR DESCRIPTION
Fixes #23157 

### How to Test

See Loom: https://www.loom.com/share/be87d65e1cdb4ebaa39a7ede2f84c79f

or do as below:

1. `+ New`
2. Question
3. Raw data
4. Sample database
5. Orders
6. Summarize by `Sum of…` tax
7. Group by `Created at` by `month`
8. Visualization
9. Table
10. Click on cog icon for `Sum of tax` conditional formatting settings
<img width="300" alt="image" src="https://user-images.githubusercontent.com/380816/178598849-b12172ae-1d43-40b2-adde-00e030821fa8.png">

11. Set style as `currency`
12. Switch unit of currency to bitcoin
13. Set `Where to display the unit of currency` to `In every table cell`


