### PR TITLE
Remove `u/optional`

### DIFF
--- a/src/metabase/api/common.clj
+++ b/src/metabase/api/common.clj
@@ -235,7 +235,7 @@
    :route       (some-fn string? sequential?)
    :docstr      (s/? string?)
    :args        vector?
-   :arg->schema (s/? (every-pred map? #(every? symbol? (keys %))))
+   :arg->schema (s/? (s/map-of symbol? any?))
    :body        (s/* any?)))
 
 (defn- parse-defendpoint-args [args]
@@ -243,12 +243,12 @@
     (when (= parsed ::s/invalid)
       (throw (ex-info (str "Invalid defendpoint args: " (s/explain-str ::defendpoint-args args))
                       (s/explain-data ::defendpoint-args args))))
-    (let [{:keys [method route docstr arg->schema body]} parsed
-          fn-name                                        (route-fn-name method route)
-          route                                          (add-route-param-regexes route)
+    (let [{:keys [method route docstr args arg->schema body]} parsed
+          fn-name                                             (route-fn-name method route)
+          route                                               (add-route-param-regexes route)
           ;; eval the vals in arg->schema to make sure the actual schemas are resolved so we can document
           ;; their API error messages
-          docstr                                         (route-dox method route docstr args (m/map-vals eval arg->schema) body)]
+          docstr                                              (route-dox method route docstr args (m/map-vals eval arg->schema) body)]
       ;; Don't i18n this, it's dev-facing only
       (when-not docstr
         (log/warn (u/format-color 'red "Warning: endpoint %s/%s does not have a docstring. Go add one."

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -89,25 +89,6 @@
   [& body]
   `(try ~@body (catch Throwable ~'_)))
 
-(defn optional
-  "Helper function for defining functions that accept optional arguments. If `pred?` is true of the first item in `args`,
-  a pair like `[first-arg other-args]` is returned; otherwise, a pair like `[default other-args]` is returned.
-
-  If `default` is not specified, `nil` will be returned when `pred?` is false.
-
-    (defn
-      ^{:arglists ([key? numbers])}
-      wrap-nums [& args]
-      (let [[k nums] (optional keyword? args :nums)]
-        {k nums}))
-    (wrap-nums 1 2 3)          -> {:nums [1 2 3]}
-    (wrap-nums :numbers 1 2 3) -> {:numbers [1 2 3]}"
-  {:arglists '([pred? args]
-               [pred? args default])}
-  [pred? args & [default]]
-  (if (pred? (first args)) [(first args) (next args)]
-      [default args]))
-
 (defmacro varargs
   "Make a properly-tagged Java interop varargs argument. This is basically the same as `into-array` but properly tags
   the result.

--- a/test/metabase/api/common_test.clj
+++ b/test/metabase/api/common_test.clj
@@ -1,12 +1,12 @@
 (ns metabase.api.common-test
   (:require [clojure.test :refer :all]
-            [metabase.api.common :as api :refer :all]
-            [metabase.api.common.internal :refer :all]
+            [metabase.api.common :as api]
+            [metabase.api.common.internal :as api.internal]
             [metabase.server.middleware.exceptions :as mw.exceptions]
             [metabase.server.middleware.misc :as mw.misc]
             [metabase.server.middleware.security :as mw.security]
-            [metabase.test.data :refer :all]
-            [metabase.util.schema :as su]))
+            [metabase.util.schema :as su]
+            [schema.core :as s]))
 
 ;;; TESTS FOR CHECK (ETC)
 
@@ -36,19 +36,19 @@
    identity
    (fn [e] (throw e))))
 
-(defn- my-mock-api-fn []
+(defn my-mock-api-fn []
   (mock-api-fn
    (fn [_]
-     (check-404 @*current-user*)
+     (api/check-404 @api/*current-user*)
      {:status 200
-      :body   @*current-user*})))
+      :body   @api/*current-user*})))
 
 (deftest check-404-test
   (testing "check that `check-404` doesn't throw an exception if `test` is true"
     (is (= {:status  200
             :body    "Cam Saul"
             :headers {"Content-Type" "text/plain"}}
-           (binding [*current-user* (atom "Cam Saul")]
+           (binding [api/*current-user* (atom "Cam Saul")]
              (my-mock-api-fn)))))
 
   (testing "check that 404 is returned otherwise"
@@ -60,7 +60,7 @@
     (is (= four-oh-four
            (-> (mock-api-fn
                 (fn [_]
-                  (let-404 [user nil]
+                  (api/let-404 [user nil]
                     {:user user})))
                (update-in [:headers "Last-Modified"] string?)))))
 
@@ -69,15 +69,33 @@
            ((mw.exceptions/catch-api-exceptions
              (fn [_ respond _]
                (respond
-                (let-404 [user {:name "Cam"}]
+                (api/let-404 [user {:name "Cam"}]
                   {:user user}))))
             nil
             identity
             (fn [e] (throw e)))))))
 
+(deftest parse-defendpoint-args-test
+  (is (= {:method      'POST
+          :route       ["/:id/dimension" :id "[0-9]+"]
+          :docstr      String
+          :args        '[id :as {{dimension-type :type, dimension-name :name} :body}]
+          :arg->schema '{dimension-type schema.core/Int, dimension-name schema.core/Str}
+          :fn-name     'POST_:id_dimension}
+         (-> (#'api/parse-defendpoint-args
+              '[POST "/:id/dimension"
+                "Sets the dimension for the given object with ID."
+                [id :as {{dimension-type :type, dimension-name :name} :body}]
+                {dimension-type schema.core/Int
+                 dimension-name schema.core/Str}])
+             (update :docstr class)
+             ;; two regex patterns are not equal even if they're the exact same pattern so convert to string so we can
+             ;; compare easily.
+             (update-in [:route 2] str)))))
+
 (deftest defendpoint-test
   ;; replace regex `#"[0-9]+"` with str `"#[0-9]+" so expectations doesn't barf
-  (binding [*auto-parse-types* (update-in *auto-parse-types* [:int :route-param-regex] (partial str "#"))]
+  (binding [api.internal/*auto-parse-types* (update-in api.internal/*auto-parse-types* [:int :route-param-regex] (partial str "#"))]
     (is (= '(def GET_:id
               (compojure.core/GET ["/:id" :id "#[0-9]+"] [id]
                                   (metabase.api.common.internal/auto-parse [id]

--- a/test/metabase/api/common_test.clj
+++ b/test/metabase/api/common_test.clj
@@ -41,7 +41,7 @@
      {:status 200
       :body   @api/*current-user*})))
 
-(deftest check-404-test
+(deftest ^:parallel check-404-test
   (testing "check that `check-404` doesn't throw an exception if `test` is true"
     (is (= {:status  200
             :body    "Cam Saul"
@@ -73,7 +73,7 @@
             identity
             (fn [e] (throw e)))))))
 
-(deftest parse-defendpoint-args-test
+(deftest ^:parallel parse-defendpoint-args-test
   (is (= {:method      'POST
           :route       ["/:id/dimension" :id "[0-9]+"]
           :docstr      String
@@ -91,7 +91,7 @@
              ;; compare easily.
              (update-in [:route 2] str)))))
 
-(deftest defendpoint-test
+(deftest ^:parallel defendpoint-test
   ;; replace regex `#"[0-9]+"` with str `"#[0-9]+" so expectations doesn't barf
   (binding [api.internal/*auto-parse-types* (update-in api.internal/*auto-parse-types* [:int :route-param-regex] (partial str "#"))]
     (is (= '(def GET_:id

--- a/test/metabase/api/common_test.clj
+++ b/test/metabase/api/common_test.clj
@@ -97,10 +97,14 @@
   ;; replace regex `#"[0-9]+"` with str `"#[0-9]+" so expectations doesn't barf
   (binding [api.internal/*auto-parse-types* (update-in api.internal/*auto-parse-types* [:int :route-param-regex] (partial str "#"))]
     (is (= '(def GET_:id
-              (compojure.core/GET ["/:id" :id "#[0-9]+"] [id]
-                                  (metabase.api.common.internal/auto-parse [id]
-                                    (metabase.api.common.internal/validate-param 'id id metabase.util.schema/IntGreaterThanZero)
-                                    (metabase.api.common.internal/wrap-response-if-needed (do (select-one Card :id id))))))
-           (macroexpand `(defendpoint GET "/:id" [~'id]
-                           {~'id su/IntGreaterThanZero}
-                           (~'select-one ~'Card :id ~'id)))))))
+              (compojure.core/GET
+               ["/:id" :id "#[0-9]+"]
+               [id]
+               (metabase.api.common.internal/auto-parse [id]
+                 (metabase.api.common.internal/validate-param 'id id metabase.util.schema/IntGreaterThanZero)
+                 (metabase.api.common.internal/wrap-response-if-needed
+                  (do
+                    (select-one Card :id id))))))
+           (macroexpand '(metabase.api.common/defendpoint compojure.core/GET "/:id" [id]
+                           {id metabase.util.schema/IntGreaterThanZero}
+                           (select-one Card :id id)))))))

--- a/test/metabase/api/common_test.clj
+++ b/test/metabase/api/common_test.clj
@@ -4,9 +4,7 @@
             [metabase.api.common.internal :as api.internal]
             [metabase.server.middleware.exceptions :as mw.exceptions]
             [metabase.server.middleware.misc :as mw.misc]
-            [metabase.server.middleware.security :as mw.security]
-            [metabase.util.schema :as su]
-            [schema.core :as s]))
+            [metabase.server.middleware.security :as mw.security]))
 
 ;;; TESTS FOR CHECK (ETC)
 

--- a/test/metabase/test/data/users.clj
+++ b/test/metabase/test/data/users.clj
@@ -167,7 +167,7 @@
           (apply client-fn username args))))))
 
 (s/defn ^:deprecated user->client :- (s/pred fn?)
-  "Returns a `metabase.http-client/client` partially bound with the credentials for User with `username`.
+  "Returns a [[metabase.http-client/client]] partially bound with the credentials for User with `username`.
    In addition, it forces lazy creation of the User if needed.
 
      ((user->client) :get 200 \"meta/table\")

--- a/test/metabase/util/schema_test.clj
+++ b/test/metabase/util/schema_test.clj
@@ -17,8 +17,9 @@
 (api/defendpoint POST "/:id/dimension"
   "Sets the dimension for the given object with ID."
   [id :as {{dimension-type :type, dimension-name :name} :body}]
-  {dimension-type          (su/api-param "type" (s/enum "internal" "external"))
-   dimension-name          su/NonBlankString})
+  {dimension-type (su/api-param "type" (s/enum "internal" "external"))
+   dimension-name su/NonBlankString})
+
 (alter-meta! #'POST_:id_dimension assoc :private true)
 
 (deftest ^:parallel api-param-test
@@ -53,13 +54,10 @@
 (deftest ^:parallel distinct-test
   (is (= nil
          (s/check (su/distinct [s/Int]) [])))
-
   (is (= nil
          (s/check (su/distinct [s/Int]) [1])))
-
   (is (= nil
          (s/check (su/distinct [s/Int]) [1 2])))
-
   (is (some? (s/check (su/distinct [s/Int]) [1 2 1]))))
 
 (deftest ^:parallel open-schema-test


### PR DESCRIPTION
`u/optional` was a util fn I wrote 6 or 7 years ago to make it easier to handle complicated arglists with optional args. Spec didn't exist at the time, but now that it does, it's much better suited for this task. Remove `u/optional` and rework the three places that were using it to use Spec instead.

Also loosens up the restriction that our test HTTP client can only have maps as request bodies -- now vectors are ok too. (Needed to implement #23848)