### PR TITLE
Fix for #20716: "Our analytics" can be confusing when user does not have access to that collection

### DIFF
--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer.tsx
@@ -190,10 +190,6 @@ function MainNavbarContainer({
   }, [location, params, question, dashboard]);
 
   const collectionTree = useMemo<CollectionTreeItem[]>(() => {
-    if (!rootCollection) {
-      return [];
-    }
-
     const preparedCollections = [];
     const userPersonalCollections = currentUserPersonalCollections(
       collections,
@@ -206,13 +202,18 @@ function MainNavbarContainer({
     preparedCollections.push(...userPersonalCollections);
     preparedCollections.push(...nonPersonalOrArchivedCollections);
 
-    const root: CollectionTreeItem = {
-      ...rootCollection,
-      icon: getCollectionIcon(rootCollection),
-      children: [],
-    };
+    const tree = buildCollectionTree(preparedCollections);
 
-    return [root, ...buildCollectionTree(preparedCollections)];
+    if (rootCollection) {
+      const root: CollectionTreeItem = {
+        ...rootCollection,
+        icon: getCollectionIcon(rootCollection),
+        children: [],
+      };
+      return [root, ...tree];
+    } else {
+      return tree;
+    }
   }, [rootCollection, collections, currentUser]);
 
   const reorderBookmarks = useCallback(
@@ -253,7 +254,7 @@ function MainNavbarContainer({
     <>
       <Sidebar className="Nav" isOpen={isOpen} aria-hidden={!isOpen}>
         <NavRoot isOpen={isOpen}>
-          {allFetched && rootCollection ? (
+          {allFetched ? (
             <MainNavbarView
               {...props}
               bookmarks={bookmarks}

--- a/frontend/src/metabase/query_builder/components/saved-question-picker/SavedQuestionList.jsx
+++ b/frontend/src/metabase/query_builder/components/saved-question-picker/SavedQuestionList.jsx
@@ -12,6 +12,7 @@ import {
   SavedQuestionListRoot,
   SavedQuestionListItem,
   SavedQuestionListEmptyState,
+  LoadingWrapper,
 } from "./SavedQuestionList.styled";
 import { PERSONAL_COLLECTIONS } from "metabase/entities/collections";
 
@@ -43,46 +44,50 @@ function SavedQuestionList({
     </SavedQuestionListEmptyState>
   );
 
-  const isVirtualCollection = collection.id === PERSONAL_COLLECTIONS.id;
+  const isVirtualCollection = collection?.id === PERSONAL_COLLECTIONS.id;
   const schemaId = getCollectionVirtualSchemaId(collection, { isDatasets });
 
   return (
     <SavedQuestionListRoot>
-      {!isVirtualCollection && (
-        <Schemas.Loader id={schemaId}>
-          {({ schema }) => {
-            const tables =
-              databaseId != null
-                ? schema.tables.filter(table => table.db_id === databaseId)
-                : schema.tables;
-            return (
-              <React.Fragment>
-                {tables
-                  .sort((a, b) => a.display_name.localeCompare(b.display_name))
-                  .map(t => (
-                    <SavedQuestionListItem
-                      id={t.id}
-                      isSelected={selectedId === t.id}
-                      key={t.id}
-                      size="small"
-                      name={t.display_name}
-                      icon={{
-                        name: isDatasets ? "model" : "table2",
-                        size: 16,
-                      }}
-                      onSelect={() => onSelect(t)}
-                      rightIcon={PLUGIN_MODERATION.getStatusIcon(
-                        t.moderated_status,
-                      )}
-                    />
-                  ))}
-                {tables.length === 0 ? emptyState : null}
-              </React.Fragment>
-            );
-          }}
-        </Schemas.Loader>
-      )}
-      {isVirtualCollection && emptyState}
+      <LoadingWrapper loading={!collection}>
+        {!isVirtualCollection && (
+          <Schemas.Loader id={schemaId}>
+            {({ schema }) => {
+              const tables =
+                databaseId != null
+                  ? schema.tables.filter(table => table.db_id === databaseId)
+                  : schema.tables;
+              return (
+                <React.Fragment>
+                  {tables
+                    .sort((a, b) =>
+                      a.display_name.localeCompare(b.display_name),
+                    )
+                    .map(t => (
+                      <SavedQuestionListItem
+                        id={t.id}
+                        isSelected={selectedId === t.id}
+                        key={t.id}
+                        size="small"
+                        name={t.display_name}
+                        icon={{
+                          name: isDatasets ? "model" : "table2",
+                          size: 16,
+                        }}
+                        onSelect={() => onSelect(t)}
+                        rightIcon={PLUGIN_MODERATION.getStatusIcon(
+                          t.moderated_status,
+                        )}
+                      />
+                    ))}
+                  {tables.length === 0 ? emptyState : null}
+                </React.Fragment>
+              );
+            }}
+          </Schemas.Loader>
+        )}
+        {isVirtualCollection && emptyState}
+      </LoadingWrapper>
     </SavedQuestionListRoot>
   );
 }

--- a/frontend/src/metabase/query_builder/components/saved-question-picker/SavedQuestionList.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/saved-question-picker/SavedQuestionList.styled.jsx
@@ -1,4 +1,5 @@
 import styled from "@emotion/styled";
+import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 import SelectList from "metabase/components/SelectList";
 import { breakpointMaxSmall } from "metabase/styled-components/theme/media-queries";
 
@@ -20,4 +21,9 @@ export const SavedQuestionListItem = styled(SelectList.Item)`
 
 export const SavedQuestionListEmptyState = styled.div`
   margin: 7.5rem 0;
+`;
+
+export const LoadingWrapper = styled(LoadingAndErrorWrapper)`
+  min-height: unset;
+  heigth: 100%;
 `;

--- a/frontend/src/metabase/query_builder/components/saved-question-picker/SavedQuestionPicker.jsx
+++ b/frontend/src/metabase/query_builder/components/saved-question-picker/SavedQuestionPicker.jsx
@@ -7,7 +7,6 @@ import { connect } from "react-redux";
 import Icon from "metabase/components/Icon";
 import { Tree } from "metabase/components/tree";
 import Collection, {
-  ROOT_COLLECTION,
   PERSONAL_COLLECTIONS,
   buildCollectionTree,
 } from "metabase/entities/collections";
@@ -35,12 +34,15 @@ const propTypes = {
   databaseId: PropTypes.string,
   tableId: PropTypes.string,
   collectionName: PropTypes.string,
+  collection: PropTypes.object,
 };
 
-const OUR_ANALYTICS_COLLECTION = {
-  ...ROOT_COLLECTION,
-  schemaName: t`Everything else`,
-  icon: "folder",
+const getOurAnalyticsCollection = collectionEntity => {
+  return {
+    ...collectionEntity,
+    schemaName: t`Everything else`,
+    icon: "folder",
+  };
 };
 
 const ALL_PERSONAL_COLLECTIONS_ROOT = {
@@ -56,6 +58,7 @@ function SavedQuestionPicker({
   databaseId,
   tableId,
   collectionName,
+  collection: rootCollection,
 }) {
   const collectionTree = useMemo(() => {
     const targetModels = isDatasets ? ["dataset"] : null;
@@ -88,20 +91,20 @@ function SavedQuestionPicker({
     }
 
     return [
-      OUR_ANALYTICS_COLLECTION,
+      ...(rootCollection ? [getOurAnalyticsCollection(rootCollection)] : []),
       ...buildCollectionTree(preparedCollections, { targetModels }),
     ];
-  }, [collections, currentUser, isDatasets]);
+  }, [collections, rootCollection, currentUser, isDatasets]);
 
   const initialCollection = useMemo(
-    () => findCollectionByName(collectionTree, collectionName),
+    () =>
+      findCollectionByName(collectionTree, collectionName) ?? collectionTree[0],
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [],
   );
 
-  const [selectedCollection, setSelectedCollection] = useState(
-    initialCollection || OUR_ANALYTICS_COLLECTION,
-  );
+  const [selectedCollection, setSelectedCollection] =
+    useState(initialCollection);
 
   const handleSelect = useCallback(collection => {
     if (collection.id === PERSONAL_COLLECTIONS.id) {
@@ -121,7 +124,7 @@ function SavedQuestionPicker({
           <Tree
             data={collectionTree}
             onSelect={handleSelect}
-            selectedId={selectedCollection.id}
+            selectedId={selectedCollection?.id}
           />
         </TreeContainer>
       </CollectionsContainer>
@@ -141,6 +144,10 @@ SavedQuestionPicker.propTypes = propTypes;
 const mapStateToProps = ({ currentUser }) => ({ currentUser });
 
 export default _.compose(
+  Collection.load({
+    id: () => "root",
+    loadingAndErrorWrapper: false,
+  }),
   Collection.loadList({
     query: () => ({ tree: true }),
   }),

--- a/frontend/src/metabase/query_builder/components/saved-question-picker/SavedQuestionPicker.unit.spec.jsx
+++ b/frontend/src/metabase/query_builder/components/saved-question-picker/SavedQuestionPicker.unit.spec.jsx
@@ -32,31 +32,48 @@ function mockCollectionTreeEndpoint() {
   });
 }
 
-function mockCollectionEndpoint() {
-  xhrMock.get("/api/database/-1337/schema/Everything%20else", {
+function mockRootCollectionEndpoint(hasAccess) {
+  xhrMock.get("/api/collection/root", (req, res) => {
+    if (hasAccess) {
+      return res
+        .status(200)
+        .body(createMockCollection({ id: "root", name: "Our analytics" }));
+    }
+
+    return res.status(200).body("You don't have access to this collection");
+  });
+}
+
+function mockCollectionEndpoint(requestedCollectionName) {
+  const encodedName = encodeURIComponent(requestedCollectionName);
+  xhrMock.get(`/api/database/-1337/schema/${encodedName}`, {
     body: [
       createMockTable({
         id: "card__1",
         display_name: "B",
-        schema: "Everything else",
+        schema: requestedCollectionName,
       }),
       createMockTable({
         id: "card__2",
         display_name: "a",
-        schema: "Everything else",
+        schema: requestedCollectionName,
       }),
       createMockTable({
         id: "card__3",
         display_name: "A",
-        schema: "Everything else",
+        schema: requestedCollectionName,
       }),
     ],
   });
 }
 
-async function setup() {
+async function setup({
+  canAccessRoot = true,
+  requestedCollectionName = "Everything else",
+} = {}) {
   mockCollectionTreeEndpoint();
-  mockCollectionEndpoint();
+  mockCollectionEndpoint(requestedCollectionName);
+  mockRootCollectionEndpoint(canAccessRoot);
   renderWithProviders(
     <SavedQuestionPicker onSelect={jest.fn()} onBack={jest.fn()} />,
   );

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -60,7 +60,10 @@
       ;; include Root Collection at beginning or results if archived isn't `true`
       (if archived?
         collections
-        (cons (root-collection namespace) collections))
+        (let [root (root-collection namespace)]
+          (cond->> collections
+            (mi/can-read? root)
+            (cons root))))
       (hydrate collections :can_write)
       ;; remove the :metabase.models.collection.root/is-root? tag since FE doesn't need it
       ;; and for personal collections we translate the name to user's locale
@@ -649,7 +652,9 @@
   "Return the 'Root' Collection object with standard details added"
   [namespace]
   {namespace (s/maybe su/NonBlankString)}
-  (dissoc (root-collection namespace) ::collection.root/is-root?))
+  (-> (root-collection namespace)
+      (api/read-check)
+      (dissoc ::collection.root/is-root?)))
 
 (defn- visible-model-kwds
   "If you pass in explicitly keywords that you can't see, you can't see them.


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/20716

Basically, "Our analytics" should not be visible from the side menu if the user doesn't have read perms for it.

### Implementation details

Currently a GET request to `/api/collection/root` from a user without root permissions will return a 200 response with details about the root collection. This breaks the FEs expectation that it should only be able to load collections for which it has permissions to read. Any collections requested with `/api/collection/:id` receive a 403 response if the user doesn't have read permissions. Additionally, the FE expects all `/api/collection/root/items` to only contain collections it has permission to read.

So, this change does two things on the BE:
- makes a GET request to `/api/collection/root` return a 403 response if the user doesn't have root permissions
- makes a GET request to `/api/collection/root/items` exclude the root collection if the user doesn't have root permissions