### PR TITLE
Repro #23862: Group by custom column fails in nested questions

### DIFF
--- a/frontend/test/metabase/scenarios/custom-column/reproductions/23862-cc-group-by-nested.cy.spec.js
+++ b/frontend/test/metabase/scenarios/custom-column/reproductions/23862-cc-group-by-nested.cy.spec.js
@@ -1,0 +1,53 @@
+import { restore, visitQuestionAdhoc } from "__support__/e2e/helpers";
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
+
+const { ORDERS_ID, ORDERS } = SAMPLE_DATABASE;
+
+const questionDetails = {
+  name: "23862",
+  query: {
+    "source-table": ORDERS_ID,
+    expressions: {
+      CC: [
+        "case",
+        [[[">", ["field", ORDERS.TOTAL, null], 10], "Large"]],
+        {
+          default: "Small",
+        },
+      ],
+    },
+    aggregation: [["sum", ["field", ORDERS.TOTAL, null]]],
+    breakout: [["expression", "CC"]],
+  },
+};
+
+describe.skip("issue 23862", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should group by a custom column and work in a nested question (metabase#23862)", () => {
+    cy.createQuestion(questionDetails).then(({ body: { id } }) => {
+      visitQuestionAdhoc(
+        {
+          dataset_query: {
+            type: "query",
+            query: {
+              "source-table": `card__${id}`,
+            },
+            database: SAMPLE_DB_ID,
+          },
+          display: "table",
+        },
+        {
+          callback: xhr => expect(xhr.response.body.error).not.to.exist,
+        },
+      );
+    });
+
+    cy.findByText("Small");
+    cy.findByText("-36.53");
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #23862 

### How to test this manually?
- `yarn test-cypress-open`
- `metabase/scenarios/custom-column/reproductions/23862-cc-group-by-nested.cy.spec.js`
- Unskip repro
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/178698525-196fe3cd-21bc-4e9a-9514-5e8e1c285ab7.png)

