### PR TITLE
Migrate whitelabel settings that were dependent on custom colors

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/index.js
@@ -89,6 +89,7 @@ if (hasPremiumFeature("whitelabel")) {
           key: "show-lighthouse-illustration",
           display_name: t`Lighthouse illustration`,
           type: "boolean",
+          defaultValue: true,
         },
       ],
     },

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -371,9 +371,11 @@
   :type       :boolean
   :enabled?   premium-features/enable-whitelabeling?
   :getter     (fn []
-                (if-some [v (setting/get-value-of-type :boolean :show-metabot)]
-                  v
-                  (not (has-custom-branding?)))))
+                (if-some [value (setting/get-value-of-type :boolean :show-metabot)]
+                  value
+                  (let [new-value (not (has-custom-branding?))]
+                    (setting/set-value-of-type! :boolean :show-metabot new-value)
+                    new-value))))
 
 (defsetting show-lighthouse-illustration
   (deferred-tru "Display the lighthouse illustration on the home and login pages.")
@@ -381,9 +383,11 @@
   :type       :boolean
   :enabled?   premium-features/enable-whitelabeling?
   :getter     (fn []
-                (if-some [v (setting/get-value-of-type :boolean :show-lighthouse-illustration)]
-                  v
-                  (not (has-custom-branding?)))))
+                (if-some [value (setting/get-value-of-type :boolean :show-lighthouse-illustration)]
+                  value
+                  (let [new-value (not (has-custom-branding?))]
+                    (setting/set-value-of-type! :boolean :show-lighthouse-illustration new-value)
+                    new-value))))
 
 (defsetting enable-password-login
   (deferred-tru "Allow logging in by email and password.")

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -289,13 +289,6 @@
   :type       :keyword
   :default    :doing-science)
 
-(defsetting show-metabot
-  (deferred-tru "Enables Metabot character on the home page")
-  :visibility :public
-  :type       :boolean
-  :enabled?   premium-features/enable-whitelabeling?
-  :default    true)
-
 (defsetting application-colors-migrated
   "Stores whether the `application-colors` setting has been migrated to 0.44 expectations"
   :visibility :internal
@@ -366,6 +359,32 @@
   :enabled?   premium-features/enable-whitelabeling?
   :default    "app/assets/img/favicon.ico")
 
+(defn has-custom-branding?
+  "Whether this instance has custom colors or logo set."
+  []
+  (or (not-empty (application-colors))
+      (not= (application-favicon-url) "app/assets/img/favicon.ico")))
+
+(defsetting show-metabot
+  (deferred-tru "Enables Metabot character on the home page")
+  :visibility :public
+  :type       :boolean
+  :enabled?   premium-features/enable-whitelabeling?
+  :getter     (fn []
+                (if-some [v (setting/get-value-of-type :boolean :show-metabot)]
+                  v
+                  (not (has-custom-branding?)))))
+
+(defsetting show-lighthouse-illustration
+  (deferred-tru "Display the lighthouse illustration on the home and login pages.")
+  :visibility :public
+  :type       :boolean
+  :enabled?   premium-features/enable-whitelabeling?
+  :getter     (fn []
+                (if-some [v (setting/get-value-of-type :boolean :show-lighthouse-illustration)]
+                  v
+                  (not (has-custom-branding?)))))
+
 (defsetting enable-password-login
   (deferred-tru "Allow logging in by email and password.")
   :visibility :public
@@ -429,13 +448,6 @@
   :type       :boolean
   :default    true
   :visibility :authenticated)
-
-(defsetting show-lighthouse-illustration
-  (deferred-tru "Display the lighthouse illustration on the home and login pages.")
-  :visibility :public
-  :type       :boolean
-  :enabled?   premium-features/enable-whitelabeling?
-  :default    true)
 
 (defsetting source-address-header
   (deferred-tru "Identify the source of HTTP requests by this header's value, instead of its remote address.")

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -363,7 +363,7 @@
   "Whether this instance has custom colors or logo set."
   []
   (or (not-empty (application-colors))
-      (not= (application-favicon-url) "app/assets/img/favicon.ico")))
+      (not= (application-logo-url) "app/assets/img/logo.svg")))
 
 (defsetting show-metabot
   (deferred-tru "Enables Metabot character on the home page")


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/22826

In 0.43 `show-metabot` and `show-lighthouse-illustration` settings didn't exist. Metabot was always hidden if there was at least one custom color or if there was a custom logo, and it was the same for the illustration. We no longer want this behavior in 0.44, and we want these settings to be true by default for everyone with an ability to toggle them off in Metabase EE. But, to make it easier for existing customers to update to 0.44, we decided to run a one-time migration and set these settings to what they effectively were set in 0.43. There will be a follow-up PR that will remove these custom getters for 0.45.

Case 1 - new instance:
- Switch to this branch and run Metabase EE
- Go to Admin -> Settings -> Licence and Billing and active EE
- Go to Admin -> Settings -> Appearance and make sure both Metabot and Illustration settings are **enabled**
- Make sure it is possible to toggle them on and off

Case 2 - no custom colors and custom logo:
- Remove the app DB and run Metabase EE from the `master` branch
- Setup the app
- Go to Admin -> Settings -> Licence and Billing and active EE
- Stop the instance, switch to this branch, and re-run the instance
- Go to Admin -> Settings -> Appearance and make sure both Metabot and Illustration settings are **enabled**
- Make sure it is possible to toggle them on and off

Case 3 - custom colors:
- Remove the app DB and run Metabase EE from the `master` branch
- Setup the app
- Go to Admin -> Settings -> Licence and Billing and active EE
- Go to Admin -> Settings -> Appearance and set a custom color, e.g. `brand`
- Stop the instance, switch to this branch, and re-run the instance
- Go to Admin -> Settings -> Appearance and make sure both Metabot and Illustration settings are visible and **disabled**
- Make sure it is possible to toggle them on and off

Case 4 - custom logo:
- Remove the app DB and run Metabase EE from the `master` branch
- Setup the app
- Go to Admin -> Settings -> Licence and Billing and active EE
- Go to Admin -> Settings -> Appearance and upload a custom logo
- Stop the instance, switch to this branch, and re-run the instance
- Go to Admin -> Settings -> Appearance and make sure both Metabot and Illustration settings are visible and **disabled**
- Make sure it is possible to toggle them on and off