### PR TITLE
Repro #23449: Models fail on fields with custom remapped values

### DIFF
--- a/frontend/test/metabase/scenarios/models/reproductions/23449-remapped-custom-value.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/reproductions/23449-remapped-custom-value.cy.spec.js
@@ -1,0 +1,48 @@
+import { restore, openQuestionActions } from "__support__/e2e/helpers";
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+
+const { REVIEWS, REVIEWS_ID } = SAMPLE_DATABASE;
+
+const questionDetails = { query: { "source-table": REVIEWS_ID, limit: 2 } };
+
+describe.skip("issue 23449", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    cy.request("POST", `/api/field/${REVIEWS.RATING}/dimension`, {
+      type: "internal",
+      name: "Rating",
+    });
+
+    cy.request("POST", `/api/field/${REVIEWS.RATING}/values`, {
+      values: [
+        [1, "Awful"],
+        [2, "Unpleasant"],
+        [3, "Meh"],
+        [4, "Enjoyable"],
+        [5, "Perfecto"],
+      ],
+    });
+  });
+
+  it("should work with the remapped custom values from data model (metabase#23449)", () => {
+    cy.createQuestion(questionDetails, { visitQuestion: true });
+    cy.findByTextEnsureVisible("Perfecto");
+
+    turnIntoModel();
+    cy.findByTextEnsureVisible("Perfecto");
+  });
+});
+
+function turnIntoModel() {
+  cy.intercept("POST", "/api/dataset").as("dataset");
+
+  openQuestionActions();
+  cy.findByText("Turn into a model").click();
+  cy.findByText("Turn this into a model").click();
+
+  cy.wait("@dataset").then(({ response }) => {
+    expect(response.body.error).to.not.exist;
+  });
+}


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #23449 

### How to test this manually?
- `yarn test-cypress-open`
- `metabase/scenarios/models/reproductions/23449-remapped-custom-value.cy.spec.js`
- Unskip repro
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/178714968-0dff2a7b-47f0-4d9a-a2ea-e34949010603.png)

