### PR TITLE
Small FE writeback bug fix

### DIFF
--- a/frontend/src/metabase/containers/SaveQuestionModal.jsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal.jsx
@@ -128,6 +128,9 @@ class SaveQuestionModal extends Component {
       hasIsWriteField && { name: "is_write" },
     ].filter(Boolean);
 
+    const canUpdateExistingCard =
+      originalCard && !originalCard.dataset && originalCard.can_write;
+
     const initialValues = {
       name:
         card.name || isStructured
@@ -138,14 +141,15 @@ class SaveQuestionModal extends Component {
         card.collection_id === undefined
           ? initialCollectionId
           : card.collection_id,
-      saveType:
-        originalCard && !originalCard.dataset && originalCard.can_write
-          ? "overwrite"
-          : "create",
+      saveType: canUpdateExistingCard ? "overwrite" : "create",
     };
 
     if (hasIsWriteField) {
-      initialValues.is_write = false;
+      if (canUpdateExistingCard) {
+        initialValues.is_write = originalCard.is_write || false;
+      } else {
+        initialValues.is_write = false;
+      }
     }
 
     const title = this.props.multiStep

--- a/frontend/src/metabase/lib/click-behavior.js
+++ b/frontend/src/metabase/lib/click-behavior.js
@@ -185,7 +185,7 @@ function baseTypeFilterForParameterType(parameterType) {
   const [typePrefix] = parameterType.split("/");
   const allowedTypes = {
     date: [TYPE.Temporal],
-    id: [TYPE.Integer],
+    id: [TYPE.Integer, TYPE.UUID],
     category: [TYPE.Text, TYPE.Integer],
     location: [TYPE.Text],
   }[typePrefix];

--- a/frontend/src/metabase/modes/components/drill/DashboardClickDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/DashboardClickDrill.jsx
@@ -17,7 +17,7 @@ import {
 } from "metabase/lib/click-behavior";
 import { renderLinkURLForClick } from "metabase/lib/formatting/link";
 import * as Urls from "metabase/lib/urls";
-import { getTemplateTagType } from "metabase/parameters/utils/cards";
+import { getActionTemplateTagType } from "metabase/writeback/utils";
 
 export default ({ question, clicked }) => {
   const settings = (clicked && clicked.settings) || {};
@@ -209,7 +209,7 @@ function getActionParameters(
     parameters[id] = {
       value,
       type: isQueryAction
-        ? getTemplateTagType(targetTemplateTag)
+        ? getActionTemplateTagType(targetTemplateTag)
         : targetTemplateTag.type,
     };
   });

--- a/frontend/src/metabase/parameters/utils/cards.ts
+++ b/frontend/src/metabase/parameters/utils/cards.ts
@@ -21,7 +21,7 @@ export function getTemplateTagType(tag: TemplateTag) {
   if (type === "date") {
     return "date/single";
     // @ts-expect-error -- preserving preexisting incorrect types (for now)
-  } else if (type === "string" || type === "text") {
+  } else if (type === "string") {
     return "string/=";
   } else if (type === "number") {
     return "number/=";

--- a/frontend/src/metabase/parameters/utils/cards.ts
+++ b/frontend/src/metabase/parameters/utils/cards.ts
@@ -21,7 +21,7 @@ export function getTemplateTagType(tag: TemplateTag) {
   if (type === "date") {
     return "date/single";
     // @ts-expect-error -- preserving preexisting incorrect types (for now)
-  } else if (type === "string") {
+  } else if (type === "string" || type === "text") {
     return "string/=";
   } else if (type === "number") {
     return "number/=";

--- a/frontend/src/metabase/writeback/components/WritebackForm.styled.tsx
+++ b/frontend/src/metabase/writeback/components/WritebackForm.styled.tsx
@@ -1,0 +1,12 @@
+import styled from "@emotion/styled";
+
+import Radio from "metabase/core/components/Radio";
+
+import Form from "metabase/containers/Form";
+
+export const StyledForm = styled(Form)`
+  ${Radio.RadioGroupVariants.join(", ")} {
+    flex-wrap: wrap;
+    gap: 0.5rem 0;
+  }
+`;

--- a/frontend/src/metabase/writeback/containers/ActionParametersInputForm.tsx
+++ b/frontend/src/metabase/writeback/containers/ActionParametersInputForm.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useMemo } from "react";
 import { connect } from "react-redux";
 import { t } from "ttag";
 
-import { getTemplateTagType } from "metabase/parameters/utils/cards";
+import { getActionTemplateTagType } from "metabase/writeback/utils";
 
 import Form from "metabase/containers/Form";
 import { TemplateTag } from "metabase-types/types/Query";
@@ -52,7 +52,7 @@ function ActionParametersInputForm({
         if (tag) {
           formattedParams[paramId] = {
             value: params[paramId],
-            type: getTemplateTagType(tag),
+            type: getActionTemplateTagType(tag),
           };
         }
       });

--- a/frontend/src/metabase/writeback/containers/CreateActionPage.tsx
+++ b/frontend/src/metabase/writeback/containers/CreateActionPage.tsx
@@ -5,15 +5,13 @@ import { connect } from "react-redux";
 import Header from "metabase/writeback/components/HttpAction/Header";
 import HttpAction from "metabase/writeback/components/HttpAction/HttpAction";
 import { ActionType } from "metabase/writeback/types";
+import { getActionTemplateTagType } from "metabase/writeback/utils";
 import { useWritebackAction } from "../hooks";
 import {
   createHttpAction,
   CreateHttpActionPayload,
 } from "metabase/query_builder/actions";
-import {
-  getTemplateTagParameterTarget,
-  getTemplateTagType,
-} from "metabase/parameters/utils/cards";
+import { getTemplateTagParameterTarget } from "metabase/parameters/utils/cards";
 import { TemplateTag } from "metabase-types/types/Query";
 import { ParameterWithTarget } from "metabase/parameters/types";
 
@@ -100,7 +98,7 @@ export default connect(null, mapDispatchToProps)(CreateActionPage);
 function getTemplateTagParameter(tag: TemplateTag): ParameterWithTarget {
   return {
     id: tag.id,
-    type: tag["widget-type"] || getTemplateTagType(tag),
+    type: tag["widget-type"] || getActionTemplateTagType(tag),
     target: getTemplateTagParameterTarget(tag),
     name: tag.name,
     slug: tag.name,

--- a/frontend/src/metabase/writeback/containers/WritebackForm.tsx
+++ b/frontend/src/metabase/writeback/containers/WritebackForm.tsx
@@ -48,7 +48,7 @@ function getFieldTypeProps(field: Field) {
   if (field.semantic_type === TYPE.Title) {
     return { type: "input" };
   }
-  if (field.isCategory()) {
+  if (field.isCategory() && field.semantic_type !== TYPE.Name) {
     return {
       fieldInstance: field,
       widget: CategoryFieldPicker,

--- a/frontend/src/metabase/writeback/containers/WritebackForm.tsx
+++ b/frontend/src/metabase/writeback/containers/WritebackForm.tsx
@@ -1,13 +1,13 @@
 import React, { useCallback, useMemo } from "react";
 import { t } from "ttag";
 
-import Form from "metabase/containers/Form";
-
 import validate from "metabase/lib/validate";
 import { TYPE } from "metabase/lib/types";
 
 import Field from "metabase-lib/lib/metadata/Field";
 import Table from "metabase-lib/lib/metadata/Table";
+
+import { StyledForm } from "../components/WritebackForm.styled";
 
 import { isEditableField } from "../utils";
 import CategoryFieldPicker from "./CategoryFieldPicker";
@@ -123,7 +123,7 @@ function WritebackForm({ table, row, onSubmit, ...props }: WritebackFormProps) {
   const submitTitle = row ? t`Update` : t`Create`;
 
   return (
-    <Form
+    <StyledForm
       {...props}
       form={form}
       onSubmit={handleSubmit}

--- a/frontend/src/metabase/writeback/utils.ts
+++ b/frontend/src/metabase/writeback/utils.ts
@@ -4,6 +4,7 @@ import Database from "metabase-lib/lib/metadata/Database";
 import Field from "metabase-lib/lib/metadata/Field";
 
 import { Database as IDatabase } from "metabase-types/types/Database";
+import { TemplateTag } from "metabase-types/types/Query";
 import { DashCard } from "metabase-types/types/Dashboard";
 import { ParameterId, ParameterTarget } from "metabase-types/types/Parameter";
 
@@ -55,6 +56,19 @@ export const getActionButtonEmitterId = (dashCard: DashCard) =>
 
 export const getActionButtonActionId = (dashCard: DashCard) =>
   dashCard.visualization_settings?.click_behavior?.action;
+
+export function getActionTemplateTagType(tag: TemplateTag) {
+  const { type } = tag;
+  if (type === "date") {
+    return "date/single";
+  } else if (type === "text") {
+    return "string/=";
+  } else if (type === "number") {
+    return "number/=";
+  } else {
+    return "category";
+  }
+}
 
 const getQueryActionParameterMappings = (
   action: WritebackAction & RowAction,


### PR DESCRIPTION
1. Fixes an issue when updating query action query was resetting `is_write` flag to `false`
2. Properly handles "text" template tags when building emitter parameters
3. Radio group wrapping in write back form
4. Don't use searchable fields when they don't make sense
5. Allow using UUID for ID dashboard filters