### PR TITLE
Fetch all columns for List visualization

### DIFF
--- a/frontend/src/metabase/visualizations/components/List/List.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/List/List.styled.tsx
@@ -1,6 +1,8 @@
 import styled from "@emotion/styled";
 import { css } from "@emotion/react";
 
+import Button from "metabase/core/components/Button";
+
 import { color } from "metabase/lib/colors";
 
 export const Root = styled.div`
@@ -83,4 +85,8 @@ export const ListRow = styled.tr`
 
     pointer-events: none;
   }
+`;
+
+export const RowActionButton = styled(Button)`
+  margin-left: 0.5rem;
 `;

--- a/frontend/src/metabase/visualizations/components/List/List.tsx
+++ b/frontend/src/metabase/visualizations/components/List/List.tsx
@@ -7,10 +7,30 @@ import React, {
 } from "react";
 import { getIn } from "icepick";
 import _ from "lodash";
+import { t } from "ttag";
+import { connect } from "react-redux";
 
 import ExplicitSize from "metabase/components/ExplicitSize";
+import Modal from "metabase/components/Modal";
 
+import { useConfirmation } from "metabase/hooks/use-confirmation";
+
+import WritebackModalForm from "metabase/writeback/containers/WritebackModalForm";
+import {
+  DeleteRowFromDataAppPayload,
+  UpdateRowFromDataAppPayload,
+  deleteRowFromDataApp,
+  updateRowFromDataApp,
+} from "metabase/dashboard/writeback-actions";
+
+import Question from "metabase-lib/lib/Question";
+import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
+import Metadata from "metabase-lib/lib/metadata/Metadata";
+
+import { SavedCard } from "metabase-types/types/Card";
+import { DashboardWithCards } from "metabase-types/types/Dashboard";
 import { VisualizationProps } from "metabase-types/types/Visualization";
+import { State } from "metabase-types/store";
 
 import ListCell from "./ListCell";
 import TableFooter from "../TableSimple/TableFooter";
@@ -20,30 +40,56 @@ import {
   Table,
   TableContainer,
   ListRow,
+  RowActionButton,
 } from "./List.styled";
+import { CellRoot } from "./ListCell.styled";
 
 function getBoundingClientRectSafe(ref: React.RefObject<HTMLBaseElement>) {
   return ref.current?.getBoundingClientRect?.() ?? ({} as DOMRect);
 }
 
-export interface ListVizProps extends VisualizationProps {
+interface ListVizDispatchProps {
+  updateRow: (payload: UpdateRowFromDataAppPayload) => void;
+  deleteRow: (payload: DeleteRowFromDataAppPayload) => void;
+}
+
+interface ListVizOwnProps extends VisualizationProps {
+  dashboard?: DashboardWithCards;
+  isDataApp?: boolean;
+  metadata: Metadata;
   getColumnTitle: (columnIndex: number) => string;
 }
 
+export type ListVizProps = ListVizOwnProps & ListVizDispatchProps;
+
+const mapDispatchToProps = {
+  deleteRow: deleteRowFromDataApp,
+  updateRow: updateRowFromDataApp,
+};
+
 function List({
   card,
+  dashboard,
   data,
   series,
   settings,
+  metadata,
   height,
   className,
+  isDataApp,
   getColumnTitle,
   onVisualizationClick,
   visualizationIsClickable,
   getExtraDataForClick,
+  updateRow,
+  deleteRow,
 }: ListVizProps) {
   const [page, setPage] = useState(0);
   const [pageSize, setPageSize] = useState(1);
+
+  const [focusedRow, setFocusedRow] = useState<unknown[] | null>(null);
+  const { modalContent: confirmationModalContent, show: requestConfirmation } =
+    useConfirmation();
 
   const headerRef = useRef(null);
   const footerRef = useRef(null);
@@ -62,9 +108,77 @@ function List({
     }
   }, [height, pageSize]);
 
+  const resetFocusedRow = useCallback(() => {
+    setFocusedRow(null);
+  }, []);
+
   const checkIsVisualizationClickable = useCallback(
     clickedItem => visualizationIsClickable?.(clickedItem),
     [visualizationIsClickable],
+  );
+
+  const table = useMemo(() => {
+    const question = new Question(card, metadata);
+    if (question.isNative()) {
+      return null;
+    }
+    const query = question.query() as StructuredQuery;
+    if (!query.isRaw()) {
+      return null;
+    }
+    return query.table();
+  }, [card, metadata]);
+
+  const connectedDashCard = useMemo(() => {
+    const maybeSavedCard = card as SavedCard;
+    return dashboard?.ordered_cards.find(
+      dc => dc.card_id === maybeSavedCard.id,
+    );
+  }, [dashboard, card]);
+
+  const handleUpdate = useCallback(
+    (values: Record<string, unknown>) => {
+      if (!table || !focusedRow || !connectedDashCard) {
+        return;
+      }
+      const pkColumnIndex = table.fields.findIndex(field => field.isPK());
+      const pkValue = focusedRow[pkColumnIndex];
+      if (typeof pkValue === "string" || typeof pkValue === "number") {
+        return updateRow({
+          id: pkValue,
+          table,
+          values,
+          dashCard: connectedDashCard,
+        });
+      }
+    },
+    [table, connectedDashCard, focusedRow, updateRow],
+  );
+
+  const handleDelete = useCallback(
+    (row: unknown[]) => {
+      if (!table || !connectedDashCard) {
+        return;
+      }
+      const pkColumnIndex = table.fields.findIndex(field => field.isPK());
+      const pkValue = row[pkColumnIndex];
+
+      if (typeof pkValue !== "string" && typeof pkValue !== "number") {
+        return;
+      }
+      requestConfirmation({
+        title: t`Delete?`,
+        message: t`This can't be undone.`,
+        onConfirm: async () => {
+          deleteRow({
+            id: pkValue,
+            table,
+            dashCard: connectedDashCard,
+          });
+        },
+      });
+    },
+    [table, connectedDashCard, deleteRow, requestConfirmation],
   );
 
   const { rows, cols } = data;
@@ -113,10 +227,24 @@ function List({
     return [...left, ...right];
   }, [cols, settings]);
 
+  const hasEditButton = settings["buttons.edit"];
+  const hasDeleteButton = settings["buttons.edit"];
+
   const renderRow = useCallback(
     (rowIndex, index) => {
       const ref = index === 0 ? firstRowRef : null;
       const row = data.rows[rowIndex];
+
+      const onEditClick = (event: React.SyntheticEvent) => {
+        setFocusedRow(row);
+        event.stopPropagation();
+      };
+
+      const onDeleteClick = (event: React.SyntheticEvent) => {
+        handleDelete(row);
+        event.stopPropagation();
+      };
+
       return (
         <ListRow key={rowIndex} ref={ref} data-testid="table-row">
           {listColumnIndexes.map((columnIndex, slotIndex) => (
@@ -134,6 +262,23 @@ function List({
               onVisualizationClick={onVisualizationClick}
             />
           ))}
+          {hasEditButton && (
+            <CellRoot type="action">
+              <RowActionButton
+                disabled={!isDataApp}
+                onClick={onEditClick}
+              >{t`Edit`}</RowActionButton>
+            </CellRoot>
+          )}
+          {hasDeleteButton && (
+            <CellRoot type="action">
+              <RowActionButton
+                disabled={!isDataApp}
+                onClick={onDeleteClick}
+                danger
+              >{t`Delete`}</RowActionButton>
+            </CellRoot>
+          )}
         </ListRow>
       );
     },
@@ -142,42 +287,73 @@ function List({
       data,
       series,
       settings,
+      isDataApp,
+      hasEditButton,
+      hasDeleteButton,
       checkIsVisualizationClickable,
       getExtraDataForClick,
       onVisualizationClick,
+      handleDelete,
     ],
   );
 
   return (
-    <Root className={className}>
-      <ContentContainer>
-        <TableContainer className="scroll-show scroll-show--hover">
-          <Table className="fullscreen-normal-text fullscreen-night-text">
-            <thead ref={headerRef} className="hide">
-              <tr>{cols.map(renderColumnHeader)}</tr>
-            </thead>
-            <tbody>{paginatedRowIndexes.map(renderRow)}</tbody>
-          </Table>
-        </TableContainer>
-      </ContentContainer>
-      {pageSize < rows.length && (
-        <TableFooter
-          start={start}
-          end={end}
-          limit={limit}
-          total={rows.length}
-          handlePreviousPage={handlePreviousPage}
-          handleNextPage={handleNextPage}
-          ref={footerRef}
-        />
+    <>
+      <Root className={className}>
+        <ContentContainer>
+          <TableContainer className="scroll-show scroll-show--hover">
+            <Table className="fullscreen-normal-text fullscreen-night-text">
+              <thead ref={headerRef} className="hide">
+                <tr>
+                  {cols.map(renderColumnHeader)}
+                  {hasEditButton && <th data-testid="column-header" />}
+                  {hasDeleteButton && <th data-testid="column-header" />}
+                </tr>
+              </thead>
+              <tbody>{paginatedRowIndexes.map(renderRow)}</tbody>
+            </Table>
+          </TableContainer>
+        </ContentContainer>
+        {pageSize < rows.length && (
+          <TableFooter
+            start={start}
+            end={end}
+            limit={limit}
+            total={rows.length}
+            handlePreviousPage={handlePreviousPage}
+            handleNextPage={handleNextPage}
+            ref={footerRef}
+          />
+        )}
+      </Root>
+      {isDataApp && table && Array.isArray(focusedRow) && (
+        <Modal onClose={resetFocusedRow}>
+          <WritebackModalForm
+            table={table}
+            row={focusedRow}
+            onSubmit={handleUpdate}
+            onClose={resetFocusedRow}
+          />
+        </Modal>
       )}
-    </Root>
+      {isDataApp && confirmationModalContent}
+    </>
   );
 }
+
+const ConnectedList = connect<
+  unknown,
+  ListVizDispatchProps,
+  ListVizOwnProps,
+  State
+>(
+  null,
+  mapDispatchToProps,
+)(List);
 
 export default ExplicitSize({
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   refreshMode: (props: VisualizationProps) =>
     props.isDashboard && !props.isEditing ? "debounce" : "throttle",
-})(List);
+})(ConnectedList);

--- a/frontend/src/metabase/visualizations/components/List/List.tsx
+++ b/frontend/src/metabase/visualizations/components/List/List.tsx
@@ -97,15 +97,33 @@ function List({
     [getColumnTitle],
   );
 
+  const listColumnIndexes = useMemo(() => {
+    const left = settings["list.columns"].left.map((idOrFieldRef: any) =>
+      cols.findIndex(
+        col =>
+          col.id === idOrFieldRef || _.isEqual(col.field_ref, idOrFieldRef),
+      ),
+    );
+    const right = settings["list.columns"].right.map((idOrFieldRef: any) =>
+      cols.findIndex(
+        col =>
+          col.id === idOrFieldRef || _.isEqual(col.field_ref, idOrFieldRef),
+      ),
+    );
+    return [...left, ...right];
+  }, [cols, settings]);
+
   const renderRow = useCallback(
     (rowIndex, index) => {
       const ref = index === 0 ? firstRowRef : null;
+      const row = data.rows[rowIndex];
       return (
         <ListRow key={rowIndex} ref={ref} data-testid="table-row">
-          {data.rows[rowIndex].map((value, columnIndex) => (
+          {listColumnIndexes.map((columnIndex, slotIndex) => (
             <ListCell
               key={`${rowIndex}-${columnIndex}`}
-              value={value}
+              value={row[columnIndex]}
+              slot={slotIndex <= 2 ? "left" : "right"}
               data={data}
               series={series}
               settings={settings}
@@ -120,6 +138,7 @@ function List({
       );
     },
     [
+      listColumnIndexes,
       data,
       series,
       settings,

--- a/frontend/src/metabase/visualizations/components/List/ListCell.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/List/ListCell.styled.tsx
@@ -9,11 +9,8 @@ function getCellWidth(type: CellType) {
   if (type === "image") {
     return "5%";
   }
-  if (type === "pk") {
-    return "2%";
-  }
   if (type === "primary") {
-    return "30%";
+    return "10%";
   }
   return "unset";
 }
@@ -24,7 +21,7 @@ export const CellRoot = styled.td<{ type: CellType }>`
 
   color: ${color("text-dark")};
   font-weight: bold;
-  text-align: ${props => (props.type === "secondary" ? "right" : "unset")};
+  text-align: ${props => (props.type === "secondary" ? "right" : "left")};
   white-space: nowrap;
 
   width: ${props => getCellWidth(props.type)};

--- a/frontend/src/metabase/visualizations/components/List/ListCell.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/List/ListCell.styled.tsx
@@ -6,7 +6,7 @@ import { color } from "metabase/lib/colors";
 import { CellType } from "./types";
 
 function getCellWidth(type: CellType) {
-  if (type === "image") {
+  if (type === "image" || type === "action") {
     return "5%";
   }
   if (type === "primary") {
@@ -15,13 +15,20 @@ function getCellWidth(type: CellType) {
   return "unset";
 }
 
+function getCellAlignment(type: CellType) {
+  if (type === "primary" || type === "image") {
+    return "left";
+  }
+  return "right";
+}
+
 export const CellRoot = styled.td<{ type: CellType }>`
   padding-left: 0.5rem;
   padding-right: 0.5rem;
 
   color: ${color("text-dark")};
   font-weight: bold;
-  text-align: ${props => (props.type === "secondary" ? "right" : "left")};
+  text-align: ${props => getCellAlignment(props.type)};
   white-space: nowrap;
 
   width: ${props => getCellWidth(props.type)};

--- a/frontend/src/metabase/visualizations/components/List/ListCell.tsx
+++ b/frontend/src/metabase/visualizations/components/List/ListCell.tsx
@@ -34,6 +34,7 @@ export interface ListCellProps
   value: Value;
   rowIndex: number;
   columnIndex: number;
+  slot: "left" | "right";
   checkIsVisualizationClickable: (clickObject: ClickObject) => boolean;
 }
 
@@ -84,6 +85,7 @@ function ListCell({
   settings,
   rowIndex,
   columnIndex,
+  slot,
   getExtraDataForClick,
   checkIsVisualizationClickable,
   onVisualizationClick,
@@ -146,17 +148,13 @@ function ListCell({
   }, [clicked, extraData, onVisualizationClick]);
 
   const type: CellType = useMemo(() => {
-    const isPrimarySlot = columnIndex < 3;
+    const isPrimarySlot = slot === "left";
     const isListItemImage = isPrimarySlot && columnSettings.view_as === "image";
     if (isListItemImage) {
       return "image";
     }
-    const isPK = cols[columnIndex].semantic_type === "type/PK";
-    if (isPrimarySlot && isPK) {
-      return "pk";
-    }
     return isPrimarySlot ? "primary" : "secondary";
-  }, [cols, columnIndex, columnSettings]);
+  }, [slot, columnSettings]);
 
   const classNames = cx("fullscreen-normal-text fullscreen-night-text", {
     link: isClickable,

--- a/frontend/src/metabase/visualizations/components/List/types.ts
+++ b/frontend/src/metabase/visualizations/components/List/types.ts
@@ -1,1 +1,1 @@
-export type CellType = "image" | "pk" | "primary" | "secondary";
+export type CellType = "image" | "action" | "primary" | "secondary";

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingsListColumns/ChartSettingsListColumns.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingsListColumns/ChartSettingsListColumns.styled.tsx
@@ -9,6 +9,16 @@ export const GroupName = styled.p`
   color: ${color("text-medium")};
 `;
 
-export const StyledSelect = styled(Select)`
+export const StyledSelect = styled(Select)``;
+
+export const ColumnItemContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+
   margin-top: 1rem;
+
+  ${StyledSelect} {
+    width: 100%;
+  }
 `;

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingsListColumns/ChartSettingsListColumns.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingsListColumns/ChartSettingsListColumns.styled.tsx
@@ -1,0 +1,14 @@
+import styled from "@emotion/styled";
+
+import Select from "metabase/core/components/Select";
+
+import { color } from "metabase/lib/colors";
+
+export const GroupName = styled.p`
+  font-weight: 700;
+  color: ${color("text-medium")};
+`;
+
+export const StyledSelect = styled(Select)`
+  margin-top: 1rem;
+`;

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingsListColumns/ChartSettingsListColumns.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingsListColumns/ChartSettingsListColumns.tsx
@@ -1,0 +1,82 @@
+import React, { useCallback } from "react";
+import { t } from "ttag";
+
+import Question from "metabase-lib/lib/Question";
+
+import { Column } from "metabase-types/types/Dataset";
+import { FieldId } from "metabase-types/types/Field";
+import { ConcreteField } from "metabase-types/types/Query";
+
+import { GroupName, StyledSelect } from "./ChartSettingsListColumns.styled";
+
+type FieldIdOrFieldRef = FieldId | ConcreteField;
+
+type SettingValue = {
+  left: FieldIdOrFieldRef[];
+  right: FieldIdOrFieldRef[];
+};
+
+interface Props {
+  value: SettingValue;
+  columns: Column[];
+  question: Question;
+  onChange: (value: SettingValue) => void;
+}
+
+type ListColumnSlot = "left" | "right";
+
+type WrappedEvent = {
+  target: {
+    value: FieldIdOrFieldRef;
+  };
+};
+
+function ChartSettingsListColumns({ value, columns, onChange }: Props) {
+  const onChangeColumn = useCallback(
+    (slot: ListColumnSlot, index: number, val: FieldIdOrFieldRef) => {
+      onChange({
+        ...value,
+        [slot]: [
+          ...value[slot].slice(0, index),
+          val,
+          ...value[slot].slice(index + 1),
+        ],
+      });
+    },
+    [value, onChange],
+  );
+
+  const options = columns.map(column => ({
+    name: column.display_name,
+    value: column.id || column.field_ref,
+  }));
+
+  return (
+    <div>
+      <GroupName>{t`Left`}</GroupName>
+      {value.left.map((fieldIdOrFieldRef, index) => (
+        <StyledSelect
+          key={index}
+          value={fieldIdOrFieldRef}
+          options={options}
+          onChange={(e: WrappedEvent) =>
+            onChangeColumn("left", index, e.target.value)
+          }
+        />
+      ))}
+      <GroupName>{t`Right`}</GroupName>
+      {value.right.map((fieldIdOrFieldRef, index) => (
+        <StyledSelect
+          key={index}
+          value={fieldIdOrFieldRef}
+          options={options}
+          onChange={(e: WrappedEvent) =>
+            onChangeColumn("right", index, e.target.value)
+          }
+        />
+      ))}
+    </div>
+  );
+}
+
+export default ChartSettingsListColumns;

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingsListColumns/index.ts
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingsListColumns/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ChartSettingsListColumns";

--- a/frontend/src/metabase/visualizations/visualizations/List.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/List.tsx
@@ -61,6 +61,18 @@ export default Object.assign(ListViz, {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     ...columnSettings({ hidden: true }),
+    "buttons.edit": {
+      section: t`Actions`,
+      title: t`Edit button`,
+      widget: "toggle",
+      default: true,
+    },
+    "buttons.delete": {
+      section: t`Actions`,
+      title: t`Delete button`,
+      widget: "toggle",
+      default: true,
+    },
     "list.columns": {
       section: t`Columns`,
       title: t`Columns`,

--- a/frontend/src/metabase/writeback/containers/WritebackModalForm.tsx
+++ b/frontend/src/metabase/writeback/containers/WritebackModalForm.tsx
@@ -11,11 +11,13 @@ interface WritebackModalFormProps extends WritebackFormProps {
 
 function WritebackModalForm({
   table,
+  row,
   onClose,
   onSubmit,
   ...props
 }: WritebackModalFormProps) {
-  const title = t`New ${table.objectName()}`;
+  const objectName = table.objectName();
+  const title = row ? t`Edit ${objectName}` : t`New ${objectName}`;
 
   const handleSubmit = useCallback(
     async (values: Record<string, unknown>) => {
@@ -27,7 +29,12 @@ function WritebackModalForm({
 
   return (
     <ModalContent title={title} onClose={onClose}>
-      <WritebackForm table={table} onSubmit={handleSubmit} {...props} />
+      <WritebackForm
+        table={table}
+        row={row}
+        onSubmit={handleSubmit}
+        {...props}
+      />
     </ModalContent>
   );
 }


### PR DESCRIPTION
Replaces List viz's `table.columns` setting to `list.columns` that'd just let you pick which three columns to show on the left and which three columns to show on the right. When removing a column via `table.columns` viz setting, the FE won't request it to be included in the query results, so it won't be available at all. It doesn't play nice with List viz:

1. We need PK values to configure navigation between data app pages, so they must be shown in the list, however, they don't make too much sense visually
2. It's harder to implement inline/bulk deletes. The writeback form is not that smart for now and it relies on field numbers and order to be original. It's easy to break this expectation when using `table.columns`. `list.columns`, on the other hand, preserves the column order and makes sure we always fetch all the columns and only changes how things are displayed

This change is not backward-compatible, so we'll need to re-create List viz question to use that