### PR TITLE
Edit rows from List viz

### DIFF
--- a/frontend/src/metabase/visualizations/components/List/List.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/List/List.styled.tsx
@@ -1,6 +1,8 @@
 import styled from "@emotion/styled";
 import { css } from "@emotion/react";
 
+import Button from "metabase/core/components/Button";
+
 import { color } from "metabase/lib/colors";
 
 export const Root = styled.div`
@@ -83,4 +85,8 @@ export const ListRow = styled.tr`
 
     pointer-events: none;
   }
+`;
+
+export const RowActionButton = styled(Button)`
+  margin-left: 0.5rem;
 `;

--- a/frontend/src/metabase/visualizations/components/List/List.tsx
+++ b/frontend/src/metabase/visualizations/components/List/List.tsx
@@ -7,6 +7,7 @@ import React, {
 } from "react";
 import { getIn } from "icepick";
 import _ from "lodash";
+import { t } from "ttag";
 
 import ExplicitSize from "metabase/components/ExplicitSize";
 
@@ -20,6 +21,7 @@ import {
   Table,
   TableContainer,
   ListRow,
+  RowActionButton,
 } from "./List.styled";
 
 function getBoundingClientRectSafe(ref: React.RefObject<HTMLBaseElement>) {
@@ -134,6 +136,16 @@ function List({
               onVisualizationClick={onVisualizationClick}
             />
           ))}
+          {settings["buttons.edit"] && (
+            <td>
+              <RowActionButton>{t`Edit`}</RowActionButton>
+            </td>
+          )}
+          {settings["buttons.delete"] && (
+            <td>
+              <RowActionButton danger>{t`Delete`}</RowActionButton>
+            </td>
+          )}
         </ListRow>
       );
     },

--- a/frontend/src/metabase/visualizations/components/List/List.tsx
+++ b/frontend/src/metabase/visualizations/components/List/List.tsx
@@ -87,10 +87,8 @@ function List({
   const [pageSize, setPageSize] = useState(1);
 
   const [focusedRow, setFocusedRow] = useState<unknown[] | null>(null);
-  const {
-    modalContent: confirmationModalContent,
-    show: requestConfirmation,
-  } = useConfirmation();
+  const { modalContent: confirmationModalContent, show: requestConfirmation } =
+    useConfirmation();
 
   const headerRef = useRef(null);
   const footerRef = useRef(null);
@@ -195,11 +193,10 @@ function List({
 
   const rowIndexes = useMemo(() => _.range(0, rows.length), [rows]);
 
-  const paginatedRowIndexes = useMemo(() => rowIndexes.slice(start, end + 1), [
-    rowIndexes,
-    start,
-    end,
-  ]);
+  const paginatedRowIndexes = useMemo(
+    () => rowIndexes.slice(start, end + 1),
+    [rowIndexes, start, end],
+  );
 
   const renderColumnHeader = useCallback(
     (col, colIndex) => (

--- a/frontend/src/metabase/visualizations/components/List/List.tsx
+++ b/frontend/src/metabase/visualizations/components/List/List.tsx
@@ -37,6 +37,7 @@ import {
   ListRow,
   RowActionButton,
 } from "./List.styled";
+import { CellRoot } from "./ListCell.styled";
 
 function getBoundingClientRectSafe(ref: React.RefObject<HTMLBaseElement>) {
   return ref.current?.getBoundingClientRect?.() ?? ({} as DOMRect);
@@ -78,8 +79,10 @@ function List({
   const [page, setPage] = useState(0);
   const [pageSize, setPageSize] = useState(1);
 
-  const { modalContent: confirmationModalContent, show: requestConfirmation } =
-    useConfirmation();
+  const {
+    modalContent: confirmationModalContent,
+    show: requestConfirmation,
+  } = useConfirmation();
 
   const headerRef = useRef(null);
   const footerRef = useRef(null);
@@ -99,7 +102,7 @@ function List({
   }, [height, pageSize]);
 
   const checkIsVisualizationClickable = useCallback(
-    (clickedItem) => visualizationIsClickable?.(clickedItem),
+    clickedItem => visualizationIsClickable?.(clickedItem),
     [visualizationIsClickable],
   );
 
@@ -116,7 +119,7 @@ function List({
   }, [card, metadata]);
 
   const connectedDashCard = useMemo(() => {
-    return dashboard?.ordered_cards.find((dc) => dc.card_id === card.id);
+    return dashboard?.ordered_cards.find(dc => dc.card_id === card.id);
   }, [dashboard, card]);
 
   const handleDelete = useCallback(
@@ -124,7 +127,7 @@ function List({
       if (!table || !connectedDashCard) {
         return;
       }
-      const pkColumnIndex = table.fields.findIndex((field) => field.isPK());
+      const pkColumnIndex = table.fields.findIndex(field => field.isPK());
       const pkValue = row[pkColumnIndex];
 
       if (typeof pkValue !== "string" && typeof pkValue !== "number") {
@@ -152,19 +155,20 @@ function List({
   const end = Math.min(rows.length - 1, pageSize * (page + 1) - 1);
 
   const handlePreviousPage = useCallback(() => {
-    setPage((p) => p - 1);
+    setPage(p => p - 1);
   }, []);
 
   const handleNextPage = useCallback(() => {
-    setPage((p) => p + 1);
+    setPage(p => p + 1);
   }, []);
 
   const rowIndexes = useMemo(() => _.range(0, rows.length), [rows]);
 
-  const paginatedRowIndexes = useMemo(
-    () => rowIndexes.slice(start, end + 1),
-    [rowIndexes, start, end],
-  );
+  const paginatedRowIndexes = useMemo(() => rowIndexes.slice(start, end + 1), [
+    rowIndexes,
+    start,
+    end,
+  ]);
 
   const renderColumnHeader = useCallback(
     (col, colIndex) => (
@@ -178,18 +182,20 @@ function List({
   const listColumnIndexes = useMemo(() => {
     const left = settings["list.columns"].left.map((idOrFieldRef: any) =>
       cols.findIndex(
-        (col) =>
+        col =>
           col.id === idOrFieldRef || _.isEqual(col.field_ref, idOrFieldRef),
       ),
     );
     const right = settings["list.columns"].right.map((idOrFieldRef: any) =>
       cols.findIndex(
-        (col) =>
+        col =>
           col.id === idOrFieldRef || _.isEqual(col.field_ref, idOrFieldRef),
       ),
     );
     return [...left, ...right];
   }, [cols, settings]);
+
+  const hasDeleteButton = settings["buttons.edit"];
 
   const renderRow = useCallback(
     (rowIndex, index) => {
@@ -218,19 +224,14 @@ function List({
               onVisualizationClick={onVisualizationClick}
             />
           ))}
-          {settings["buttons.edit"] && (
-            <td>
-              <RowActionButton disabled={!isDataApp}>{t`Edit`}</RowActionButton>
-            </td>
-          )}
-          {settings["buttons.delete"] && (
-            <td>
+          {hasDeleteButton && (
+            <CellRoot type="action">
               <RowActionButton
                 disabled={!isDataApp}
                 onClick={onDeleteClick}
                 danger
               >{t`Delete`}</RowActionButton>
-            </td>
+            </CellRoot>
           )}
         </ListRow>
       );
@@ -241,6 +242,7 @@ function List({
       series,
       settings,
       isDataApp,
+      hasDeleteButton,
       checkIsVisualizationClickable,
       getExtraDataForClick,
       onVisualizationClick,
@@ -255,7 +257,10 @@ function List({
           <TableContainer className="scroll-show scroll-show--hover">
             <Table className="fullscreen-normal-text fullscreen-night-text">
               <thead ref={headerRef} className="hide">
-                <tr>{cols.map(renderColumnHeader)}</tr>
+                <tr>
+                  {cols.map(renderColumnHeader)}
+                  {hasDeleteButton && <th data-testid="column-header" />}
+                </tr>
               </thead>
               <tbody>{paginatedRowIndexes.map(renderRow)}</tbody>
             </Table>

--- a/frontend/src/metabase/visualizations/components/List/List.tsx
+++ b/frontend/src/metabase/visualizations/components/List/List.tsx
@@ -220,12 +220,13 @@ function List({
           ))}
           {settings["buttons.edit"] && (
             <td>
-              <RowActionButton>{t`Edit`}</RowActionButton>
+              <RowActionButton disabled={!isDataApp}>{t`Edit`}</RowActionButton>
             </td>
           )}
           {settings["buttons.delete"] && (
             <td>
               <RowActionButton
+                disabled={!isDataApp}
                 onClick={onDeleteClick}
                 danger
               >{t`Delete`}</RowActionButton>
@@ -239,6 +240,7 @@ function List({
       data,
       series,
       settings,
+      isDataApp,
       checkIsVisualizationClickable,
       getExtraDataForClick,
       onVisualizationClick,
@@ -271,7 +273,7 @@ function List({
           />
         )}
       </Root>
-      {confirmationModalContent}
+      {isDataApp && confirmationModalContent}
     </>
   );
 }

--- a/frontend/src/metabase/visualizations/components/List/List.tsx
+++ b/frontend/src/metabase/visualizations/components/List/List.tsx
@@ -27,6 +27,7 @@ import Question from "metabase-lib/lib/Question";
 import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
 import Metadata from "metabase-lib/lib/metadata/Metadata";
 
+import { SavedCard } from "metabase-types/types/Card";
 import { DashboardWithCards } from "metabase-types/types/Dashboard";
 import { VisualizationProps } from "metabase-types/types/Visualization";
 import { State } from "metabase-types/store";
@@ -129,7 +130,10 @@ function List({
   }, [card, metadata]);
 
   const connectedDashCard = useMemo(() => {
-    return dashboard?.ordered_cards.find(dc => dc.card_id === card.id);
+    const maybeSavedCard = card as SavedCard;
+    return dashboard?.ordered_cards.find(
+      dc => dc.card_id === maybeSavedCard.id,
+    );
   }, [dashboard, card]);
 
   const handleUpdate = useCallback(

--- a/frontend/src/metabase/visualizations/components/List/ListCell.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/List/ListCell.styled.tsx
@@ -6,7 +6,7 @@ import { color } from "metabase/lib/colors";
 import { CellType } from "./types";
 
 function getCellWidth(type: CellType) {
-  if (type === "image") {
+  if (type === "image" || type === "action") {
     return "5%";
   }
   if (type === "primary") {
@@ -15,13 +15,20 @@ function getCellWidth(type: CellType) {
   return "unset";
 }
 
+function getCellAlignment(type: CellType) {
+  if (type === "primary" || type === "image") {
+    return "left";
+  }
+  return "right";
+}
+
 export const CellRoot = styled.td<{ type: CellType }>`
   padding-left: 0.5rem;
   padding-right: 0.5rem;
 
   color: ${color("text-dark")};
   font-weight: bold;
-  text-align: ${props => (props.type === "secondary" ? "right" : "left")};
+  text-align: ${props => getCellAlignment(props.type)};
   white-space: nowrap;
 
   width: ${props => getCellWidth(props.type)};

--- a/frontend/src/metabase/visualizations/components/List/types.ts
+++ b/frontend/src/metabase/visualizations/components/List/types.ts
@@ -1,1 +1,1 @@
-export type CellType = "image" | "pk" | "primary" | "secondary";
+export type CellType = "image" | "action" | "primary" | "secondary";

--- a/frontend/src/metabase/visualizations/visualizations/List.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/List.tsx
@@ -61,6 +61,18 @@ export default Object.assign(ListViz, {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     ...columnSettings({ hidden: true }),
+    "buttons.edit": {
+      section: t`Actions`,
+      title: t`Edit button`,
+      widget: "toggle",
+      default: true,
+    },
+    "buttons.delete": {
+      section: t`Actions`,
+      title: t`Delete button`,
+      widget: "toggle",
+      default: true,
+    },
     "list.columns": {
       section: t`Columns`,
       title: t`Columns`,
@@ -70,12 +82,12 @@ export default Object.assign(ListViz, {
           data: { cols },
         },
       ]: Series) => {
-        const columns = cols.filter(col => col.visibility_type === "normal");
+        const columns = cols.filter((col) => col.visibility_type === "normal");
         const firstThreeColumns = columns.slice(0, 3).filter(Boolean);
         const nextThreeColumns = columns.slice(3, 6).filter(Boolean);
         return {
-          left: firstThreeColumns.map(col => col.id || col.field_ref),
-          right: nextThreeColumns.map(col => col.id || col.field_ref),
+          left: firstThreeColumns.map((col) => col.id || col.field_ref),
+          right: nextThreeColumns.map((col) => col.id || col.field_ref),
         };
       },
       getProps: ([
@@ -83,7 +95,7 @@ export default Object.assign(ListViz, {
           data: { cols },
         },
       ]: Series) => ({
-        columns: cols.filter(col => col.visibility_type === "normal"),
+        columns: cols.filter((col) => col.visibility_type === "normal"),
       }),
     },
   },

--- a/frontend/src/metabase/visualizations/visualizations/List.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/List.tsx
@@ -82,12 +82,12 @@ export default Object.assign(ListViz, {
           data: { cols },
         },
       ]: Series) => {
-        const columns = cols.filter((col) => col.visibility_type === "normal");
+        const columns = cols.filter(col => col.visibility_type === "normal");
         const firstThreeColumns = columns.slice(0, 3).filter(Boolean);
         const nextThreeColumns = columns.slice(3, 6).filter(Boolean);
         return {
-          left: firstThreeColumns.map((col) => col.id || col.field_ref),
-          right: nextThreeColumns.map((col) => col.id || col.field_ref),
+          left: firstThreeColumns.map(col => col.id || col.field_ref),
+          right: nextThreeColumns.map(col => col.id || col.field_ref),
         };
       },
       getProps: ([
@@ -95,7 +95,7 @@ export default Object.assign(ListViz, {
           data: { cols },
         },
       ]: Series) => ({
-        columns: cols.filter((col) => col.visibility_type === "normal"),
+        columns: cols.filter(col => col.visibility_type === "normal"),
       }),
     },
   },

--- a/frontend/src/metabase/writeback/containers/WritebackModalForm.tsx
+++ b/frontend/src/metabase/writeback/containers/WritebackModalForm.tsx
@@ -11,11 +11,13 @@ interface WritebackModalFormProps extends WritebackFormProps {
 
 function WritebackModalForm({
   table,
+  row,
   onClose,
   onSubmit,
   ...props
 }: WritebackModalFormProps) {
-  const title = t`New ${table.objectName()}`;
+  const objectName = table.objectName();
+  const title = row ? t`Edit ${objectName}` : t`New ${objectName}`;
 
   const handleSubmit = useCallback(
     async (values: Record<string, unknown>) => {
@@ -27,7 +29,12 @@ function WritebackModalForm({
 
   return (
     <ModalContent title={title} onClose={onClose}>
-      <WritebackForm table={table} onSubmit={handleSubmit} {...props} />
+      <WritebackForm
+        table={table}
+        row={row}
+        onSubmit={handleSubmit}
+        {...props}
+      />
     </ModalContent>
   );
 }


### PR DESCRIPTION
Adds an ability to add "Edit" and "Delete" buttons to List viz rows. In the data app page, the buttons can be used to edit/delete corresponding records without going to their detail view. There are also new visualization settings that let manage button visibility (both buttons are visible by default).

Based on #23902 changes to List viz which are not backward compatible, so you'll need to create a fresh List viz question in order to test this change
