### PR TITLE
Repro #23076: Frontend incorrectly substitutes datetime field incorrect in Pivot Table

### DIFF
--- a/frontend/test/metabase/scenarios/visualizations/reproductions/23076.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/reproductions/23076.cy.spec.js
@@ -1,0 +1,51 @@
+import { restore } from "__support__/e2e/helpers";
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+
+const { ORDERS, ORDERS_ID, PRODUCTS, PEOPLE } = SAMPLE_DATABASE;
+
+const questionDetails = {
+  name: "Orders, Distinct values of ID, Grouped by Product → Title and Created At (month) and User → ID",
+
+  query: {
+    "source-table": ORDERS_ID,
+    aggregation: [["distinct", ["field", ORDERS.ID, null]]],
+    breakout: [
+      ["field", PRODUCTS.TITLE, { "source-field": ORDERS.PRODUCT_ID }],
+      ["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }],
+      ["field", PEOPLE.ID, { "source-field": ORDERS.USER_ID }],
+    ],
+  },
+  display: "pivot",
+  visualization_settings: {
+    "pivot_table.column_split": {
+      rows: [
+        ["field", PRODUCTS.TITLE, { "source-field": ORDERS.PRODUCT_ID }],
+        ["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }],
+        ["field", PEOPLE.ID, { "source-field": ORDERS.USER_ID }],
+      ],
+      columns: [],
+      values: [["aggregation", 0]],
+    },
+  },
+};
+
+describe.skip("issue 23076", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    cy.request("PUT", "/api/user/1", {
+      locale: "de",
+    });
+
+    cy.createQuestion(questionDetails, { visitQuestion: true });
+  });
+
+  it("should correctly translate dates (metabase#23076)", () => {
+    cy.findAllByText(/^Summen für/)
+      .should("be.visible")
+      .eq(1)
+      .invoke("text")
+      .should("eq", "Summen für Mai, 2017");
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #23076 

### How to test this manually?
- `yarn test-cypress-open`
- `metabase/scenarios/visualizations/reproductions/23076.cy.spec.js`
- Unskip repro
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/178779988-5fc78036-7a39-4240-b6e0-932927d9855a.png)

