### PR TITLE
Update question name on duplicate

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -218,7 +218,7 @@ function SavedQuestionLeftSide(props) {
                 : []),
 
               <SavedQuestionHeaderButton
-                key="question-title"
+                key={question.displayName()}
                 question={question}
                 onSave={onHeaderChange}
               />,

--- a/frontend/test/metabase/scenarios/question/saved.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/saved.cy.spec.js
@@ -119,6 +119,14 @@ describe("scenarios > question > saved", () => {
       cy.findByText("Duplicate").click();
       cy.wait("@cardCreate");
     });
+
+    modal().within(() => {
+      cy.findByText("Not now").click();
+    });
+
+    cy.findByTestId("qb-header-left-side").within(() => {
+      cy.findByDisplayValue("Orders - Duplicate");
+    });
   });
 
   it("should revert a saved question to a previous version", () => {


### PR DESCRIPTION
Small bug to fix an issue with display names not updating after duplicating a question

![chrome_79ltnGSg8A](https://user-images.githubusercontent.com/1328979/178784253-6e3f9c88-9558-4ce3-84d2-98b2cc22d9ef.gif)

