### PR TITLE
Bulk Filter Modal v3

### DIFF
--- a/frontend/src/metabase-lib/lib/DimensionOptions/DimensionOptions.ts
+++ b/frontend/src/metabase-lib/lib/DimensionOptions/DimensionOptions.ts
@@ -41,7 +41,7 @@ export default class DimensionOptions {
     const tableName = table ? table.objectName() : null;
     const mainSection: DimensionOptionsSection = {
       name: this.name || tableName,
-      icon: this.icon || "table2",
+      icon: this.icon || "table",
       items: [
         ...extraItems,
         ...this.dimensions.map(dimension => ({

--- a/frontend/src/metabase-lib/lib/queries/structured/Filter.ts
+++ b/frontend/src/metabase-lib/lib/queries/structured/Filter.ts
@@ -30,6 +30,7 @@ import _ from "underscore";
 
 export interface FilterDisplayNameOpts {
   includeDimension?: boolean;
+  includeOperator?: boolean;
 }
 
 export default class Filter extends MBQLClause {
@@ -62,7 +63,10 @@ export default class Filter extends MBQLClause {
   /**
    * Returns the display name for the filter
    */
-  displayName({ includeDimension = true }: FilterDisplayNameOpts = {}) {
+  displayName({
+    includeDimension = true,
+    includeOperator = true,
+  }: FilterDisplayNameOpts = {}) {
     if (this.isSegment()) {
       const segment = this.segment();
       return segment ? segment.displayName() : t`Unknown Segment`;
@@ -72,7 +76,10 @@ export default class Filter extends MBQLClause {
       const dimensionName =
         dimension && includeDimension && dimension.displayName();
       const operatorName =
-        operator && !isStartingFrom(this) && operator.moreVerboseName;
+        operator &&
+        includeOperator &&
+        !isStartingFrom(this) &&
+        operator.moreVerboseName;
       const argumentNames = this.formattedArguments().join(" ");
       return `${dimensionName || ""} ${operatorName || ""} ${argumentNames}`;
     } else if (this.isCustom()) {

--- a/frontend/src/metabase/components/FieldValuesWidget.jsx
+++ b/frontend/src/metabase/components/FieldValuesWidget.jsx
@@ -258,6 +258,7 @@ class FieldValuesWidgetInner extends Component {
       formatOptions,
       placeholder,
       showOptionsInPopover,
+      checkedColor,
     } = this.props;
     const { loadingState, options = [] } = this.state;
 
@@ -300,6 +301,7 @@ class FieldValuesWidgetInner extends Component {
                   autoLoad: false,
                 })
               }
+              checkedColor={checkedColor}
             />
           ))}
         {!usesListField && (

--- a/frontend/src/metabase/components/ListField/ListField.tsx
+++ b/frontend/src/metabase/components/ListField/ListField.tsx
@@ -31,6 +31,7 @@ const ListField = ({
   optionRenderer,
   placeholder,
   isDashboardFilter,
+  checkedColor,
 }: ListFieldProps) => {
   const [selectedValues, setSelectedValues] = useState(new Set(value));
   const [addedOptions, setAddedOptions] = useState<Option>(() =>
@@ -129,7 +130,9 @@ const ListField = ({
           <OptionContainer key={option[0]}>
             <Checkbox
               data-testid={`${option[0]}-filter-value`}
-              checkedColor={isDashboardFilter ? "brand" : "accent7"}
+              checkedColor={
+                checkedColor ?? isDashboardFilter ? "brand" : "filter"
+              }
               checked={selectedValues.has(option[0])}
               label={<LabelWrapper>{optionRenderer(option)}</LabelWrapper>}
               onChange={() => handleToggleOption(option[0])}

--- a/frontend/src/metabase/components/ListField/types.ts
+++ b/frontend/src/metabase/components/ListField/types.ts
@@ -7,4 +7,5 @@ export interface ListFieldProps {
   optionRenderer: (option: any) => JSX.Element;
   placeholder: string;
   isDashboardFilter?: boolean;
+  checkedColor?: string;
 }

--- a/frontend/src/metabase/components/Modal.jsx
+++ b/frontend/src/metabase/components/Modal.jsx
@@ -60,7 +60,7 @@ export class WindowModal extends Component {
   _modalComponent() {
     const className = cx(
       this.props.className,
-      ...["small", "medium", "wide", "tall"]
+      ...["small", "medium", "wide", "tall", "fit"]
         .filter(type => this.props[type])
         .map(type => `Modal--${type}`),
     );

--- a/frontend/src/metabase/components/PopoverWithTrigger/TippyPopoverWithTrigger.tsx
+++ b/frontend/src/metabase/components/PopoverWithTrigger/TippyPopoverWithTrigger.tsx
@@ -6,27 +6,16 @@ import ControlledPopoverWithTrigger, {
 
 export type TippyPopoverWithTriggerProps = {
   isInitiallyVisible?: boolean;
-  afterOpen?: () => void;
-  afterClose?: () => void;
 } & Omit<ControlledPopoverWithTriggerProps, "visible" | "onClose" | "onOpen">;
 
 function UncontrolledPopoverWithTrigger({
   isInitiallyVisible,
-  afterOpen,
-  afterClose,
   ...props
 }: TippyPopoverWithTriggerProps) {
   const [visible, setVisible] = useState(isInitiallyVisible || false);
 
-  const onOpen = useCallback(() => {
-    setVisible(true);
-    typeof afterOpen === "function" && afterOpen();
-  }, [afterOpen]);
-
-  const onClose = useCallback(() => {
-    setVisible(false);
-    typeof afterClose === "function" && afterClose();
-  }, [afterClose]);
+  const onOpen = useCallback(() => setVisible(true), []);
+  const onClose = useCallback(() => setVisible(false), []);
 
   return (
     <ControlledPopoverWithTrigger

--- a/frontend/src/metabase/components/PopoverWithTrigger/TippyPopoverWithTrigger.tsx
+++ b/frontend/src/metabase/components/PopoverWithTrigger/TippyPopoverWithTrigger.tsx
@@ -6,16 +6,27 @@ import ControlledPopoverWithTrigger, {
 
 export type TippyPopoverWithTriggerProps = {
   isInitiallyVisible?: boolean;
+  afterOpen?: () => void;
+  afterClose?: () => void;
 } & Omit<ControlledPopoverWithTriggerProps, "visible" | "onClose" | "onOpen">;
 
 function UncontrolledPopoverWithTrigger({
   isInitiallyVisible,
+  afterOpen,
+  afterClose,
   ...props
 }: TippyPopoverWithTriggerProps) {
   const [visible, setVisible] = useState(isInitiallyVisible || false);
 
-  const onOpen = useCallback(() => setVisible(true), []);
-  const onClose = useCallback(() => setVisible(false), []);
+  const onOpen = useCallback(() => {
+    setVisible(true);
+    typeof afterOpen === "function" && afterOpen();
+  }, [afterOpen]);
+
+  const onClose = useCallback(() => {
+    setVisible(false);
+    typeof afterClose === "function" && afterClose();
+  }, [afterClose]);
 
   return (
     <ControlledPopoverWithTrigger

--- a/frontend/src/metabase/core/components/Tab/Tab.styled.tsx
+++ b/frontend/src/metabase/core/components/Tab/Tab.styled.tsx
@@ -10,15 +10,20 @@ export interface TabProps {
 export const TabRoot = styled.button<TabProps>`
   display: inline-flex;
   align-items: center;
-  color: ${props => (props.isSelected ? color("brand") : color("text-dark"))};
+  color: ${props =>
+    props.isSelected ? color("text-dark") : color("text-light")};
   cursor: pointer;
-  padding-bottom: 0.75rem;
-  border-bottom: 0.125rem solid
-    ${props => (props.isSelected ? color("brand") : "transparent")};
+
+  margin-bottom: 0.75rem;
+  padding-bottom: 0.25rem;
+
+  &:first-of-type {
+    padding-right: 1.5rem;
+    border-right: ${color("border")} 1px solid;
+  }
 
   &:hover {
     color: ${color("brand")};
-    border-color: ${color("brand")};
   }
 
   &:focus {
@@ -31,9 +36,9 @@ export const TabRoot = styled.button<TabProps>`
 `;
 
 export const TabIcon = styled(Icon)`
-  width: 1rem;
-  height: 1rem;
-  margin-right: 0.25rem;
+  width: 0.8rem;
+  height: 0.8rem;
+  margin-right: 0.5rem;
 `;
 
 export const TabLabel = styled(Ellipsified)`

--- a/frontend/src/metabase/core/components/TabList/TabList.styled.tsx
+++ b/frontend/src/metabase/core/components/TabList/TabList.styled.tsx
@@ -12,7 +12,7 @@ export const TabListContent = styled.div`
   overflow-x: hidden;
   display: flex;
   align-items: flex-start;
-  gap: 2.5rem;
+  gap: 1.5rem;
   scroll-behavior: smooth;
 `;
 

--- a/frontend/src/metabase/css/components/modal.css
+++ b/frontend/src/metabase/css/components/modal.css
@@ -35,6 +35,11 @@
   width: 85%;
 }
 
+.Modal.Modal--fit {
+  width: auto;
+  max-height: 100%;
+}
+
 .Modal.Modal--tall {
   min-height: 85%;
 }

--- a/frontend/src/metabase/nav/components/AppBar/AppBar.styled.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBar.styled.tsx
@@ -2,7 +2,7 @@ import styled from "@emotion/styled";
 
 export const AppBarRoot = styled.header`
   position: relative;
-  z-index: 5;
+  z-index: 4;
 
   @media print {
     display: none;

--- a/frontend/src/metabase/query_builder/components/QueryModals.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryModals.jsx
@@ -159,7 +159,7 @@ class QueryModals extends React.Component {
         />
       </Modal>
     ) : modal === MODAL_TYPES.FILTERS ? (
-      <Modal medium onClose={onCloseModal}>
+      <Modal fit onClose={onCloseModal}>
         <BulkFilterModal question={question} onClose={onCloseModal} />
       </Modal>
     ) : modal === MODAL_TYPES.HISTORY ? (

--- a/frontend/src/metabase/query_builder/components/filters/FilterPopover.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/FilterPopover.tsx
@@ -49,6 +49,7 @@ type Props = {
   isNew?: boolean;
   isSidebar?: boolean;
   isTopLevel?: boolean;
+  checkedColor?: string;
 };
 
 type State = {
@@ -167,6 +168,7 @@ export default class FilterPopover extends Component<Props, State> {
       isTopLevel,
       showCustom,
       dateShortcutOptions,
+      checkedColor,
     } = this.props;
     const { filter, editingFilter, choosingField } = this.state;
 
@@ -312,6 +314,7 @@ export default class FilterPopover extends Component<Props, State> {
                     minWidth={isSidebar ? null : MIN_WIDTH}
                     maxWidth={isSidebar ? null : MAX_WIDTH}
                     primaryColor={primaryColor}
+                    checkedColor={checkedColor}
                   />
                 </>
               )}

--- a/frontend/src/metabase/query_builder/components/filters/FilterPopoverPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/FilterPopoverPicker.tsx
@@ -15,6 +15,7 @@ type Props = {
   minWidth?: number | null;
   maxWidth?: number | null;
   primaryColor?: string;
+  checkedColor?: string;
 };
 
 export default class FilterPopoverPicker extends React.Component<Props> {
@@ -42,6 +43,7 @@ export default class FilterPopoverPicker extends React.Component<Props> {
       minWidth,
       maxWidth,
       primaryColor,
+      checkedColor,
     } = this.props;
 
     const setValue = (index: number, value: any) => {
@@ -80,6 +82,7 @@ export default class FilterPopoverPicker extends React.Component<Props> {
         minWidth={minWidth}
         maxWidth={maxWidth}
         isSidebar={isSidebar}
+        checkedColor={checkedColor}
       />
     );
   }

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterItem/BulkFilterItem.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterItem/BulkFilterItem.tsx
@@ -74,7 +74,10 @@ export const BulkFilterItem = ({
         <>
           <InlineOperatorSelector
             fieldName={dimension.displayName()}
+            iconName="io"
             tableName={tableName}
+            value={currentOperator}
+            operators={dimension.filterOperators(currentOperator)}
           />
           <BooleanPickerCheckbox
             filter={filter ?? newFilter}
@@ -87,6 +90,9 @@ export const BulkFilterItem = ({
         <>
           <InlineOperatorSelector
             fieldName={dimension.displayName()}
+            value={currentOperator}
+            operators={dimension.filterOperators(currentOperator)}
+            iconName="list"
             tableName={tableName}
           />
           <InlineCategoryPicker
@@ -104,6 +110,7 @@ export const BulkFilterItem = ({
         <>
           <InlineOperatorSelector
             fieldName={dimension.displayName()}
+            iconName={dimension.icon() ?? undefined}
             tableName={tableName}
             value={currentOperator}
             operators={dimension.filterOperators(currentOperator)}
@@ -121,6 +128,7 @@ export const BulkFilterItem = ({
         <>
           <InlineOperatorSelector
             fieldName={dimension.displayName()}
+            iconName={dimension.icon() ?? undefined}
             tableName={tableName}
           />
           <InlineDatePicker
@@ -138,6 +146,9 @@ export const BulkFilterItem = ({
         <>
           <InlineOperatorSelector
             fieldName={dimension.displayName()}
+            value={currentOperator}
+            operators={dimension.filterOperators(currentOperator)}
+            iconName={dimension.icon() ?? undefined}
             tableName={tableName}
           />
           <BulkFilterSelect

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterItem/BulkFilterItem.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterItem/BulkFilterItem.unit.spec.tsx
@@ -234,9 +234,9 @@ describe("BulkFilterItem", () => {
       </Provider>,
     );
     screen.getByTestId("value-picker");
-    screen.getByText("Between");
-    screen.getByPlaceholderText("min");
-    screen.getByPlaceholderText("max");
+    screen.getByText(/between/i);
+    screen.getByPlaceholderText("Min");
+    screen.getByPlaceholderText("Max");
   });
 
   it("renders a category picker for category type", () => {
@@ -347,7 +347,7 @@ describe("BulkFilterItem", () => {
         />
       </Provider>,
     );
-    screen.getByText("Is");
+    screen.getByText(/is/i);
   });
 
   it("defaults text filters to 'contains' operator", () => {
@@ -365,6 +365,6 @@ describe("BulkFilterItem", () => {
         />
       </Provider>,
     );
-    screen.getByText("Contains");
+    screen.getByText(/contains/i);
   });
 });

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterList/BulkFilterList.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterList/BulkFilterList.styled.tsx
@@ -4,15 +4,11 @@ import { space } from "metabase/styled-components/theme";
 import Ellipsified from "metabase/core/components/Ellipsified";
 
 export const ListRoot = styled.div`
-  margin-top: 1rem;
   margin-bottom: 1rem;
 `;
 
 export const ListRow = styled.div`
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 2fr);
-  gap: ${space(2)};
-  padding: 1.5rem 2rem;
+  padding: 2.5rem 2rem;
   border-bottom: 1px solid ${color("border")};
   &:last-of-type {
     border-bottom: none;
@@ -29,7 +25,9 @@ export const ListRowLabel = styled(Ellipsified)`
 export const FilterDivider = styled.div`
   grid-column: 2;
   border-top: 1px solid ${color("border")};
-  &:last-child {
+  margin: ${space(2)} 0;
+  &:last-of-type {
+    margin: 0;
     display: none;
   }
 `;

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterList/BulkFilterList.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterList/BulkFilterList.tsx
@@ -173,7 +173,9 @@ const SegmentListItem = ({
     <ListRow data-testid="filter-field-segments">
       <InlineOperatorSelector
         fieldName={t`Segments`}
+        iconName="filter"
         tableName={isSearch ? query.table().displayName() : undefined}
+        value="is"
       />
       <SegmentFilterSelect
         query={query}

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterModal/BulkFilterModal.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterModal/BulkFilterModal.styled.tsx
@@ -12,11 +12,11 @@ export const ModalRoot = styled.div`
   flex-direction: column;
   height: 90vh;
   width: 65vw;
+  max-width: 60rem;
   ${breakpointMaxSmall} {
     width: 98vw;
     height: 98vh;
   }
-  max-width: 60rem;
 `;
 
 export const ModalHeader = styled.div`

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterModal/BulkFilterModal.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterModal/BulkFilterModal.styled.tsx
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
-import { space } from "metabase/styled-components/theme";
+import { space, breakpointMaxSmall } from "metabase/styled-components/theme";
 
 import TabList from "metabase/core/components/TabList";
 import TabPanel from "metabase/core/components/TabPanel";
@@ -11,6 +11,12 @@ export const ModalRoot = styled.div`
   display: flex;
   flex-direction: column;
   height: 90vh;
+  width: 65vw;
+  ${breakpointMaxSmall} {
+    width: 98vw;
+    height: 98vh;
+  }
+  max-width: 60rem;
 `;
 
 export const ModalHeader = styled.div`
@@ -26,7 +32,7 @@ export const ModalBody = styled.div`
 
 export const ModalFooter = styled.div`
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
   gap: 1rem;
   padding: 1.5rem 2rem;
 `;

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterModal/BulkFilterModal.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterModal/BulkFilterModal.tsx
@@ -50,7 +50,7 @@ const BulkFilterModal = ({
 
   useOnMount(() => {
     const searchToggleListener = (e: KeyboardEvent) => {
-      if (e.ctrlKey && e.key === "k") {
+      if ((e.ctrlKey || e.metaKey) && e.key === "k") {
         setSearchQuery("");
         setShowSearch(showSearch => !showSearch);
       }
@@ -284,6 +284,7 @@ const FieldSearch = ({
         onChange={onChange}
         padding="sm"
         borderRadius="md"
+        autoFocus
         icon={<Icon name="search" size={13} style={{ marginTop: 2 }} />}
       />
     </SearchContainer>

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterModal/BulkFilterModal.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterModal/BulkFilterModal.tsx
@@ -1,15 +1,17 @@
 import React, { useCallback, useMemo, useState } from "react";
 import { t } from "ttag";
 
-import { useDebouncedValue } from "metabase/hooks/use-debounced-value";
+import { useDebouncedEffect } from "metabase/hooks/use-debounced-effect";
+import { useOnMount } from "metabase/hooks/use-on-mount";
+
 import Filter from "metabase-lib/lib/queries/structured/Filter";
 import StructuredQuery, {
   FilterSection,
   DimensionOption,
   SegmentOption,
 } from "metabase-lib/lib/queries/StructuredQuery";
-
 import Question from "metabase-lib/lib/Question";
+
 import Button from "metabase/core/components/Button";
 import Tab from "metabase/core/components/Tab";
 import TabContent from "metabase/core/components/TabContent";
@@ -30,7 +32,6 @@ import {
 } from "./BulkFilterModal.styled";
 
 import { fixBetweens, getSearchHits } from "./utils";
-import { useDebouncedEffect } from "metabase/hooks/use-debounced-effect";
 
 export interface BulkFilterModalProps {
   question: Question;
@@ -43,8 +44,20 @@ const BulkFilterModal = ({
 }: BulkFilterModalProps): JSX.Element | null => {
   const [query, setQuery] = useState(getQuery(question));
   const [isChanged, setIsChanged] = useState(false);
+  const [showSearch, setShowSearch] = useState(false);
 
   const [searchQuery, setSearchQuery] = useState("");
+
+  useOnMount(() => {
+    const searchToggleListener = (e: KeyboardEvent) => {
+      if (e.ctrlKey && e.key === "k") {
+        setSearchQuery("");
+        setShowSearch(showSearch => !showSearch);
+      }
+    };
+    window.addEventListener("keydown", searchToggleListener);
+    return () => window.removeEventListener("keydown", searchToggleListener);
+  });
 
   const filters = useMemo(() => {
     return query.topLevelFilters();
@@ -89,11 +102,22 @@ const BulkFilterModal = ({
     onClose?.();
   }, [query, onClose]);
 
+  const clearFilters = () => {
+    setQuery(query.clearFilters());
+    setIsChanged(true);
+  };
+
   return (
     <ModalRoot>
       <ModalHeader>
-        <ModalTitle>{getTitle(question, query)}</ModalTitle>
-        <FieldSearch value={searchQuery} onChange={setSearchQuery} />
+        <ModalTitle>{t`Filter by`}</ModalTitle>
+        {showSearch ? (
+          <FieldSearch value={searchQuery} onChange={setSearchQuery} />
+        ) : (
+          <ModalCloseButton onClick={onClose}>
+            <Icon name="close" />
+          </ModalCloseButton>
+        )}
       </ModalHeader>
       {sections.length === 1 || searchItems ? (
         <BulkFilterModalSection
@@ -119,12 +143,19 @@ const BulkFilterModal = ({
       )}
       <ModalDivider />
       <ModalFooter>
-        <Button onClick={onClose}>{t`Cancel`}</Button>
+        <Button
+          onClick={clearFilters}
+          borderless
+          disabled={!query.hasFilters()}
+        >
+          {t`Clear all filters`}
+        </Button>
         <Button
           primary
+          data-testid="apply-filters"
           disabled={!isChanged}
           onClick={handleApplyQuery}
-        >{t`Apply`}</Button>
+        >{t`Apply Filters`}</Button>
       </ModalFooter>
     </ModalRoot>
   );
@@ -192,7 +223,7 @@ const BulkFilterModalSectionList = ({
     <TabContent value={tab} onChange={setTab}>
       <ModalTabList>
         {sections.map((section, index) => (
-          <Tab key={index} value={index}>
+          <Tab key={index} value={index} icon={section.icon}>
             {section.name}
           </Tab>
         ))}

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterSelect/BulkFilterSelect.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterSelect/BulkFilterSelect.styled.tsx
@@ -1,12 +1,20 @@
 import styled from "@emotion/styled";
+import { color } from "metabase/lib/colors";
+
 import SelectButton from "metabase/core/components/SelectButton";
 import FilterPopover from "../../FilterPopover";
 import Select from "metabase/core/components/Select";
 
-export const SelectFilterButton = styled(SelectButton)`
+type SelectFilterButtonProps = {
+  isActive?: boolean;
+};
+
+export const SelectFilterButton = styled(SelectButton)<SelectFilterButtonProps>`
   grid-column: 2;
   height: 2.25rem;
   max-width: 500px; // to match inputs
+
+  ${({ isActive }) => (isActive ? `border-color: ${color("brand")};` : "")}
 
   &:not(:first-of-type) {
     margin-top: 0.75rem;

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterSelect/BulkFilterSelect.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterSelect/BulkFilterSelect.styled.tsx
@@ -11,7 +11,7 @@ type SelectFilterButtonProps = {
 
 export const SelectFilterButton = styled(SelectButton)<SelectFilterButtonProps>`
   grid-column: 2;
-  height: 2.25rem;
+  height: 55px;
   max-width: 500px; // to match inputs
 
   ${({ isActive }) => (isActive ? `border-color: ${color("brand")};` : "")}
@@ -22,7 +22,7 @@ export const SelectFilterButton = styled(SelectButton)<SelectFilterButtonProps>`
 `;
 
 export const SegmentSelect = styled(Select)`
-  height: 2.25rem;
+  height: 55px;
   max-width: 500px; // to match inputs
 `;
 

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterSelect/BulkFilterSelect.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterSelect/BulkFilterSelect.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useMemo } from "react";
 import { t } from "ttag";
 
 import StructuredQuery, {
@@ -37,8 +37,6 @@ export const BulkFilterSelect = ({
   handleChange,
   handleClear,
 }: BulkFilterSelectProps): JSX.Element => {
-  const [isSelecting, setIsSelecting] = useState(false);
-
   const name = useMemo(() => {
     return filter?.displayName({
       includeDimension: false,
@@ -53,19 +51,17 @@ export const BulkFilterSelect = ({
   return (
     <TippyPopoverWithTrigger
       sizeToFit
-      afterOpen={() => setIsSelecting(true)}
-      afterClose={() => setIsSelecting(false)}
       renderTrigger={
         customTrigger
           ? customTrigger
-          : ({ onClick }) => (
+          : ({ onClick, visible }) => (
               <SelectFilterButton
                 hasValue={filter != null}
                 highlighted
                 aria-label={dimension.displayName()}
                 onClick={onClick}
                 onClear={handleClear}
-                isActive={isSelecting}
+                isActive={visible}
               >
                 {name || t`Filter by ${dimension.displayName()}`}
               </SelectFilterButton>

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterSelect/BulkFilterSelect.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterSelect/BulkFilterSelect.tsx
@@ -1,4 +1,5 @@
-import React, { useCallback, useMemo } from "react";
+import React, { useCallback, useMemo, useState } from "react";
+import { t } from "ttag";
 
 import StructuredQuery, {
   SegmentOption,
@@ -36,8 +37,13 @@ export const BulkFilterSelect = ({
   handleChange,
   handleClear,
 }: BulkFilterSelectProps): JSX.Element => {
+  const [isSelecting, setIsSelecting] = useState(false);
+
   const name = useMemo(() => {
-    return filter?.displayName({ includeDimension: false });
+    return filter?.displayName({
+      includeDimension: false,
+      includeOperator: false,
+    });
   }, [filter]);
 
   const newFilter = useMemo(() => {
@@ -47,6 +53,8 @@ export const BulkFilterSelect = ({
   return (
     <TippyPopoverWithTrigger
       sizeToFit
+      afterOpen={() => setIsSelecting(true)}
+      afterClose={() => setIsSelecting(false)}
       renderTrigger={
         customTrigger
           ? customTrigger
@@ -57,8 +65,9 @@ export const BulkFilterSelect = ({
                 aria-label={dimension.displayName()}
                 onClick={onClick}
                 onClear={handleClear}
+                isActive={isSelecting}
               >
-                {name}
+                {name || t`Filter by ${dimension.displayName()}`}
               </SelectFilterButton>
             )
       }
@@ -72,6 +81,7 @@ export const BulkFilterSelect = ({
           dateShortcutOptions={dateShortcutOptions}
           onChangeFilter={handleChange}
           onClose={closePopover}
+          checkedColor="brand"
           commitOnBlur
         />
       )}
@@ -145,6 +155,7 @@ export const SegmentFilterSelect = ({
         highlighted: true,
         onClear: onClearSegments,
       }}
+      placeholder={t`Filter segments`}
       buttonText={
         activeSegmentOptions.length > 1
           ? `${activeSegmentOptions.length} segments`

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineDatePicker/InlineDatePicker.styled.ts
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineDatePicker/InlineDatePicker.styled.ts
@@ -20,6 +20,8 @@ export const OptionButton = styled(Button)<OptionButtonProps>`
   padding: 13px ${space(2)};
   margin-right: ${space(1)};
   margin-bottom: ${space(1)};
+  border: 1px solid
+    ${({ active }) => (active ? "transparent" : color("border"))};
 
   background-color: ${({ active }) =>
     active ? alpha("brand", 0.2) : "transparent"};

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineOperatorSelector/InlineOperatorSelector.styled.ts
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineOperatorSelector/InlineOperatorSelector.styled.ts
@@ -17,10 +17,11 @@ export const FieldTitle = styled.span`
 
 export const TableTitle = styled.span`
   color: ${color("text-dark")};
-  span.light {
-    color: ${color("text-light")};
-  }
   margin-right: ${space(1)};
+`;
+
+export const LightText = styled.span`
+  color: ${color("text-light")};
 `;
 
 export const OperatorDisplay = styled.button`

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineOperatorSelector/InlineOperatorSelector.styled.ts
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineOperatorSelector/InlineOperatorSelector.styled.ts
@@ -4,24 +4,31 @@ import { color, alpha, darken, lighten } from "metabase/lib/colors";
 
 export const InlineOperatorContainer = styled.div`
   font-weight: bold;
-  margin: ${space(1)} 0;
+  font-size: 1rem;
+  margin-bottom: 0.875rem;
+  display: inline-flex;
+  align-items: flex-start;
 `;
 
 export const FieldTitle = styled.span`
   color: ${color("text-dark")};
+  margin-right: ${space(1)};
 `;
 
-export const TableTitle = styled.div`
+export const TableTitle = styled.span`
   color: ${color("text-dark")};
-  margin-bottom: ${space(2)};
   span.light {
     color: ${color("text-light")};
   }
+  margin-right: ${space(1)};
 `;
 
 export const OperatorDisplay = styled.button`
   font-weight: bold;
-  color: ${props => (props.onClick ? color("brand") : color("text-light"))};
+  text-decoration: ${props => (props.onClick ? "underline" : "none")};
+  text-underline-offset: 2px;
+  color: ${color("text-light")};
+  text-transform: lowercase;
 
   ${props => (props.onClick ? "cursor: pointer;" : "")} &:hover {
     color: ${props =>

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineOperatorSelector/InlineOperatorSelector.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineOperatorSelector/InlineOperatorSelector.tsx
@@ -14,6 +14,7 @@ import { FilterOperatorName } from "metabase-types/types/Metadata";
 
 interface InlineOperatorSelectorProps {
   fieldName: string;
+  iconName?: string;
   tableName?: string;
   value?: FilterOperatorName;
   operators?: any[];
@@ -22,6 +23,7 @@ interface InlineOperatorSelectorProps {
 
 export function InlineOperatorSelector({
   fieldName,
+  iconName,
   tableName,
   value,
   operators,
@@ -34,42 +36,46 @@ export function InlineOperatorSelector({
 
   return (
     <InlineOperatorContainer>
-      {!!tableName && (
-        <TableTitle>
-          <span className="light">In</span>
-          {` ${tableName}`}
-        </TableTitle>
+      {!!iconName && (
+        <Icon name={iconName} size={20} style={{ marginRight: 8 }} />
       )}
-
-      <FieldTitle>{fieldName} </FieldTitle>
-      {!canChangeOperator && !!operatorDisplayName && (
-        <OperatorDisplay>{operatorDisplayName}</OperatorDisplay>
-      )}
-      {canChangeOperator && (
-        <TippyPopoverWithTrigger
-          sizeToFit
-          renderTrigger={({ onClick }) => (
-            <OperatorDisplay onClick={onClick} data-testid="operator-select">
-              {operatorDisplayName} <Icon name="chevrondown" size={8} />
-            </OperatorDisplay>
-          )}
-          popoverContent={({ closePopover }) => (
-            <OptionContainer data-testid="operator-options">
-              {operators.map(option => (
-                <Option
-                  key={option.name}
-                  onClick={() => {
-                    onChange(option.name);
-                    closePopover();
-                  }}
-                >
-                  {option.verboseName}
-                </Option>
-              ))}
-            </OptionContainer>
-          )}
-        />
-      )}
+      <div>
+        <FieldTitle>{fieldName}</FieldTitle>
+        {!!tableName && (
+          <TableTitle>
+            <span className="light">in</span>
+            {` ${tableName}`}
+          </TableTitle>
+        )}
+        {!canChangeOperator && !!operatorDisplayName && (
+          <OperatorDisplay>{operatorDisplayName}</OperatorDisplay>
+        )}
+        {canChangeOperator && (
+          <TippyPopoverWithTrigger
+            sizeToFit
+            renderTrigger={({ onClick }) => (
+              <OperatorDisplay onClick={onClick} data-testid="operator-select">
+                {operatorDisplayName} <Icon name="chevrondown" size={8} />
+              </OperatorDisplay>
+            )}
+            popoverContent={({ closePopover }) => (
+              <OptionContainer data-testid="operator-options">
+                {operators.map(option => (
+                  <Option
+                    key={option.name}
+                    onClick={() => {
+                      onChange(option.name);
+                      closePopover();
+                    }}
+                  >
+                    {option.verboseName}
+                  </Option>
+                ))}
+              </OptionContainer>
+            )}
+          />
+        )}
+      </div>
     </InlineOperatorContainer>
   );
 }

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineOperatorSelector/InlineOperatorSelector.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineOperatorSelector/InlineOperatorSelector.tsx
@@ -6,6 +6,7 @@ import {
   InlineOperatorContainer,
   FieldTitle,
   TableTitle,
+  LightText,
   OperatorDisplay,
   OptionContainer,
   Option,
@@ -43,7 +44,7 @@ export function InlineOperatorSelector({
         <FieldTitle>{fieldName}</FieldTitle>
         {!!tableName && (
           <TableTitle>
-            <span className="light">in</span>
+            <LightText>in</LightText>
             {` ${tableName}`}
           </TableTitle>
         )}

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineValuePicker/InlineValuePicker.styled.ts
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineValuePicker/InlineValuePicker.styled.ts
@@ -47,4 +47,7 @@ export const NumberSeparator = styled.span`
 
 export const NumberInput = styled(NumericInput)`
   width: 10rem;
+  input {
+    height: 55px;
+  }
 `;

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineValuePicker/InlineValuePicker.styled.ts
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineValuePicker/InlineValuePicker.styled.ts
@@ -11,7 +11,6 @@ export const OperatorSelector = styled(OperatorSelectorComponent)`
 `;
 
 export const ArgumentSelector = styled(FieldValuesWidget)`
-  margin-bottom: ${space(1)};
   min-height: 55px;
 `;
 
@@ -19,9 +18,17 @@ export const ValuesPickerContainer = styled.div`
   grid-column: 2;
   ul.input {
     margin-bottom: 0;
+    :focus-within {
+      border-color: ${color("brand")};
+    }
   }
   input {
     color: ${color("brand")};
+    font-size: 0.875rem;
+
+    ::placeholder {
+      color: ${color("text-medium")};
+    }
   }
 `;
 

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineValuePicker/InlineValuePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineValuePicker/InlineValuePicker.tsx
@@ -77,6 +77,7 @@ function ValuesInput({
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore: this component doesn't have types or propTypes
         value={filterArguments}
+        color="brand"
         onChange={onChange}
         className="input"
         fields={[field]}
@@ -89,14 +90,14 @@ function ValuesInput({
   return (
     <BetweenContainer>
       <NumberInput
-        placeholder={t`min`}
+        placeholder={t`Min`}
         value={filterArguments[0] ?? ""}
         onChange={val => onChange([val, filterArguments[1]])}
         fullWidth
       />
       <NumberSeparator>{t`and`}</NumberSeparator>
       <NumberInput
-        placeholder={t`max`}
+        placeholder={t`Max`}
         value={filterArguments[1] ?? ""}
         onChange={val => onChange([filterArguments[0], val])}
         fullWidth

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineValuePicker/InlineValuePicker.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineValuePicker/InlineValuePicker.unit.spec.tsx
@@ -268,8 +268,8 @@ describe("InlineValuePicker", () => {
       </Provider>,
     );
 
-    screen.getByPlaceholderText("min");
-    screen.getByPlaceholderText("max");
+    screen.getByPlaceholderText("Min");
+    screen.getByPlaceholderText("Max");
   });
 
   const noValueOperators = ["is-null", "not-null", "is-empty", "not-empty"];

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DefaultPicker.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DefaultPicker.jsx
@@ -36,6 +36,7 @@ const defaultPickerPropTypes = {
   isSidebar: PropTypes.bool,
   minWidth: PropTypes.number,
   maxWidth: PropTypes.number,
+  checkedColor: PropTypes.string,
 };
 
 const defaultLayoutPropTypes = {
@@ -52,6 +53,7 @@ export default function DefaultPicker({
   minWidth,
   maxWidth,
   isSidebar,
+  checkedColor,
 }) {
   const operator = filter.operator();
   if (!operator) {
@@ -133,6 +135,7 @@ export default function DefaultPicker({
             disableSearch={disableSearch}
             minWidth={minWidth}
             maxWidth={maxWidth}
+            checkedColor={checkedColor}
           />
         );
       } else if (operatorField.type === "text") {

--- a/frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx
@@ -26,6 +26,7 @@ export default class SelectPicker extends Component {
     onValuesChange: PropTypes.func.isRequired,
     placeholder: PropTypes.string,
     multi: PropTypes.bool,
+    checkedColor: PropTypes.string,
   };
 
   updateSearchText = value => {
@@ -70,7 +71,7 @@ export default class SelectPicker extends Component {
   }
 
   render() {
-    const { values, options, placeholder, multi } = this.props;
+    const { values, options, placeholder, multi, checkedColor } = this.props;
 
     const checked = new Set(values);
 
@@ -117,7 +118,7 @@ export default class SelectPicker extends Component {
                   >
                     <CheckBox
                       checked={checked.has(option.key)}
-                      checkedColor="accent2"
+                      checkedColor={checkedColor ?? "filter"}
                     />
                     <h4 className="ml1">{this.nameForOption(option)}</h4>
                   </label>

--- a/frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx
@@ -26,7 +26,6 @@ export default class SelectPicker extends Component {
     onValuesChange: PropTypes.func.isRequired,
     placeholder: PropTypes.string,
     multi: PropTypes.bool,
-    checkedColor: PropTypes.string,
   };
 
   updateSearchText = value => {
@@ -71,7 +70,7 @@ export default class SelectPicker extends Component {
   }
 
   render() {
-    const { values, options, placeholder, multi, checkedColor } = this.props;
+    const { values, options, placeholder, multi } = this.props;
 
     const checked = new Set(values);
 
@@ -118,7 +117,7 @@ export default class SelectPicker extends Component {
                   >
                     <CheckBox
                       checked={checked.has(option.key)}
-                      checkedColor={checkedColor ?? "filter"}
+                      checkedColor="accent2"
                     />
                     <h4 className="ml1">{this.nameForOption(option)}</h4>
                   </label>

--- a/frontend/test/metabase/scenarios/admin/datamodel/metrics.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/metrics.cy.spec.js
@@ -157,7 +157,7 @@ describe("scenarios > admin > datamodel > metrics", () => {
         value: "50",
       });
 
-      cy.button("Apply").click();
+      cy.findByTestId("apply-filters").click();
       cy.findByText("Save").click();
       cy.findAllByText("Save").last().click();
       cy.findByText("Not now").click();

--- a/frontend/test/metabase/scenarios/admin/datamodel/segments.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/segments.cy.spec.js
@@ -113,7 +113,7 @@ describe("scenarios > admin > datamodel > segments", () => {
       filterField("Product ID", {
         value: "14",
       });
-      cy.findByText("Apply").click();
+      cy.findByTestId("apply-filters").click();
 
       cy.findByText("Product ID is 14");
       cy.findByText("Save").click();

--- a/frontend/test/metabase/scenarios/filters/filter-bulk.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/filter-bulk.cy.spec.js
@@ -102,7 +102,7 @@ describe("scenarios > filters > bulk filtering", () => {
 
     cy.findByLabelText("20").click();
     cy.button("Add filter").click();
-    cy.button("Apply").click();
+    applyFilters();
 
     cy.findByText("Quantity is equal to 20").should("be.visible");
     cy.findByText("Showing 4 rows").should("be.visible");
@@ -148,7 +148,7 @@ describe("scenarios > filters > bulk filtering", () => {
     filter();
 
     modal().within(() => {
-      cy.findByText("is less than 30").click();
+      cy.findByText("30").click();
     });
 
     popover().within(() => {
@@ -169,7 +169,7 @@ describe("scenarios > filters > bulk filtering", () => {
     filter();
 
     modal().within(() => {
-      cy.findByText("is less than 30")
+      cy.findByText("30")
         .parent()
         .within(() => cy.icon("close").click());
     });
@@ -213,7 +213,9 @@ describe("scenarios > filters > bulk filtering", () => {
       filter();
 
       modal().within(() => {
-        filterField("segments").within(() => cy.get("button").click());
+        filterField("segments").within(() =>
+          cy.findByText("Filter segments").click(),
+        );
       });
 
       popover().within(() => {
@@ -229,7 +231,9 @@ describe("scenarios > filters > bulk filtering", () => {
       filter();
 
       modal().within(() => {
-        filterField("segments").within(() => cy.get("button").click());
+        filterField("segments").within(() =>
+          cy.findByText(SEGMENT_2_NAME).click(),
+        );
       });
 
       popover().within(() => {
@@ -543,6 +547,7 @@ describe("scenarios > filters > bulk filtering", () => {
     beforeEach(() => {
       visitQuestionAdhoc(productsQuestion);
       filter();
+      cy.get("body").type(`{ctrl}k`);
     });
 
     it("can search for a column", () => {
@@ -555,7 +560,7 @@ describe("scenarios > filters > bulk filtering", () => {
         cy.findByText("Category").should("not.exist");
 
         filterField("Vendor")
-          .findByText("In") // "In Products"
+          .findByText("in") // "In Products"
           .should("be.visible");
 
         filterField("Vendor").findByText("Vendor").should("be.visible");
@@ -591,7 +596,7 @@ const modal = () => {
 
 const applyFilters = () => {
   modal().within(() => {
-    cy.button("Apply").click();
+    cy.findByTestId("apply-filters").click();
   });
 
   cy.wait("@dataset");

--- a/frontend/test/metabase/scenarios/filters/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/filter.cy.spec.js
@@ -122,7 +122,7 @@ describe("scenarios > question > filter", () => {
     filterFieldPopover("Product ID").contains("Aerodynamic Linen Coat").click();
     cy.findByText("Add filter").click();
 
-    cy.button("Apply").click();
+    cy.findByTestId("apply-filters").click();
 
     cy.log("Reported failing on v0.36.4 and v0.36.5.1");
     cy.findByTestId("loading-spinner").should("not.exist");

--- a/frontend/test/metabase/scenarios/joins/joins-2.cy.spec.js
+++ b/frontend/test/metabase/scenarios/joins/joins-2.cy.spec.js
@@ -100,7 +100,7 @@ describe("scenarios > question > joined questions", () => {
           }
         });
       cy.findByText("wolf.dina@yahoo.com").click();
-      cy.button("Apply").click();
+      cy.findByTestId("apply-filters").click();
       cy.contains("Showing 1 row");
     });
 

--- a/frontend/test/metabase/scenarios/models/models-revision-history.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models-revision-history.cy.spec.js
@@ -52,7 +52,7 @@ describe("scenarios > models > revision history", () => {
       operator: "Not empty",
     });
 
-    cy.button("Apply").click();
+    cy.findByTestId("apply-filters").click();
 
     cy.findByText("Save").click();
     modal().within(() => {
@@ -90,7 +90,7 @@ describe("scenarios > models > revision history", () => {
       placeholder: "min",
       value: "2000",
     });
-    cy.button("Apply").click();
+    cy.findByTestId("apply-filters").click();
 
     assertQuestionIsBasedOnModel({
       model: "Orders Model",

--- a/frontend/test/metabase/scenarios/models/models.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models.cy.spec.js
@@ -51,7 +51,7 @@ describe("scenarios > models", () => {
       operator: "Not empty",
     });
 
-    cy.button("Apply").click();
+    cy.findByTestId("apply-filters").click();
     cy.wait("@dataset");
 
     assertQuestionIsBasedOnModel({
@@ -100,7 +100,7 @@ describe("scenarios > models", () => {
       operator: "Not empty",
     });
 
-    cy.button("Apply").click();
+    cy.findByTestId("apply-filters").click();
     cy.wait("@dataset");
 
     assertQuestionIsBasedOnModel({
@@ -309,7 +309,7 @@ describe("scenarios > models", () => {
       filterField("Discount", {
         operator: "Not empty",
       });
-      cy.button("Apply").click();
+      cy.findByTestId("apply-filters").click();
       cy.wait("@dataset");
 
       assertQuestionIsBasedOnModel({

--- a/frontend/test/metabase/scenarios/native/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/native.cy.spec.js
@@ -7,6 +7,7 @@ import {
   summarize,
   sidebar,
   filter,
+  filterField,
 } from "__support__/e2e/helpers";
 
 import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
@@ -159,12 +160,12 @@ describe("scenarios > question > native", () => {
     FILTERS.forEach(operator => {
       cy.log("Apply a filter");
       filter();
-      cy.findByText("Contains").click();
-      popover().within(() => {
-        cy.findByText(operator).click();
+      filterField("V", {
+        operator,
+        value: "This has a value",
       });
-      cy.findByPlaceholderText("Enter some text").type("This has a value");
-      cy.findByText("Apply").click();
+
+      cy.findByTestId("apply-filters").click();
 
       cy.log(
         `**Mid-point assertion for "${operator}" filter| FAILING in v0.36.6**`,

--- a/frontend/test/metabase/scenarios/question/saved.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/saved.cy.spec.js
@@ -168,7 +168,7 @@ describe("scenarios > question > saved", () => {
       operator: "Equal to",
       value: "4",
     });
-    cy.button("Apply").click();
+    cy.findByTestId("apply-filters").click();
 
     cy.findByText("Synergistic Granite Chair");
     cy.findByText("Rustic Paper Wallet").should("not.exist");

--- a/frontend/test/metabase/scenarios/visualizations/reproductions/17524.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/reproductions/17524.cy.spec.js
@@ -1,4 +1,9 @@
-import { restore, filterWidget, filter } from "__support__/e2e/helpers";
+import {
+  restore,
+  filterWidget,
+  filter,
+  filterField,
+} from "__support__/e2e/helpers";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
@@ -70,12 +75,11 @@ describe("issue 17524", () => {
 
       filter();
 
-      cy.findByText("ID").click();
-      cy.findByText("Is").click();
-      cy.findByText("Greater than").click();
-
-      cy.findByPlaceholderText("Enter an ID").type("1");
-      cy.button("Apply").click();
+      filterField("ID", {
+        operator: "Greater than",
+        value: "1",
+      });
+      cy.findByTestId("apply-filters").click();
 
       cy.get("polygon");
     });


### PR DESCRIPTION
## Updates

- column names
	- on their own line
	- most operators, even if not editable
	- all have icons
- more spacing between fields
- inputs all have focus states with `brand` color outline
- hide search bar by default
- restore outline to date filter select buttons
- bulk filter select
	- show placeholder text on filter button
	- show active state while popover is open
	- use `brand` color checkboxes in popover instead of `filter` color
- added clear all filters button
- added new `fit` modal size option to allow the modal contents to dictate its size
	- allows this modal to have a max width of `960px`
- Table Tabs
	- replaced tab icons
	- added divider after primary table
	- changed styling to black/gray (instead of using `brand` color and underline)
- Mobile
   - added a mobile breakpoint and it looks pretty good

## Images
![Screen Shot 2022-07-13 at 11 45 12 AM](https://user-images.githubusercontent.com/30528226/178797679-712ebb29-628d-48f4-9056-eae12e6467ee.png)

![Screen Shot 2022-07-13 at 11 45 35 AM](https://user-images.githubusercontent.com/30528226/178797632-532f7e88-7efe-4828-8834-58c3fcd41792.png)

![Screen Shot 2022-07-13 at 11 47 38 AM](https://user-images.githubusercontent.com/30528226/178797977-c87604b1-e19a-4af0-9ae3-baeceb584080.png)
