### PR TITLE
AppBarRightContainer justify-content to end

### DIFF
--- a/frontend/src/metabase/nav/components/AppBar/AppBarLarge.styled.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarLarge.styled.tsx
@@ -52,6 +52,7 @@ export const AppBarRightContainer = styled.div`
   align-items: center;
   gap: 1rem;
   max-width: 32.5rem;
+  justify-content: end;
 `;
 
 export interface AppBarInfoContainerProps {


### PR DESCRIPTION
EPIC #22529 

Small change to fix position of "New" button when `top_nav=true` and `new_button=true` (withouth `search=true`)

Before: 
![image](https://user-images.githubusercontent.com/1328979/178800523-a6b4720c-5b3b-4c8c-b34d-7df563d28d6d.png)
After: 
![image](https://user-images.githubusercontent.com/1328979/178800563-b661d6f2-7d08-414e-93cd-aa29b840f193.png)

