### PR TITLE
Add a widget for the illustration setting

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/ImageToggle/ImageToggle.styled.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/ImageToggle/ImageToggle.styled.tsx
@@ -10,7 +10,6 @@ export const ToggleRoot = styled.div`
 `;
 
 export const ImageContainer = styled.div`
-  padding: 0.5rem 1rem 0.75rem 1.25rem;
   border-right: 1px solid ${color("border")};
 `;
 

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/ImageToggle/ImageToggle.styled.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/ImageToggle/ImageToggle.styled.tsx
@@ -1,0 +1,25 @@
+import styled from "@emotion/styled";
+import { color } from "metabase/lib/colors";
+
+export const ToggleRoot = styled.div`
+  display: flex;
+  align-items: stretch;
+  max-width: 33.125rem;
+  border: 1px solid ${color("border")};
+  border-radius: 0.5rem;
+`;
+
+export const ImageContainer = styled.div`
+  padding: 0.5rem 1rem 0.75rem 1.25rem;
+  border-right: 1px solid ${color("border")};
+`;
+
+export const ToggleContainer = styled.div`
+  display: flex;
+  align-items: center;
+  padding: 2rem 1.5rem;
+`;
+
+export const ToggleLabel = styled.label`
+  margin-right: 2rem;
+`;

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/ImageToggle/ImageToggle.styled.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/ImageToggle/ImageToggle.styled.tsx
@@ -3,8 +3,8 @@ import { color } from "metabase/lib/colors";
 
 export const ToggleRoot = styled.div`
   display: flex;
-  align-items: stretch;
-  max-width: 33.125rem;
+  flex: 1 1 auto;
+  max-width: 33rem;
   border: 1px solid ${color("border")};
   border-radius: 0.5rem;
 `;
@@ -16,7 +16,9 @@ export const ImageContainer = styled.div`
 
 export const ToggleContainer = styled.div`
   display: flex;
+  justify-content: space-between;
   align-items: center;
+  flex: 1 1 auto;
   padding: 2rem 1.5rem;
 `;
 

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/ImageToggle/ImageToggle.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/ImageToggle/ImageToggle.tsx
@@ -1,0 +1,43 @@
+import React, { ReactNode } from "react";
+import { useUniqueId } from "metabase/hooks/use-unique-id";
+import Toggle from "metabase/core/components/Toggle";
+import {
+  ImageContainer,
+  ToggleContainer,
+  ToggleLabel,
+  ToggleRoot,
+} from "./ImageToggle.styled";
+
+export interface ImageToggleProps {
+  label: string;
+  value: boolean;
+  children?: ReactNode;
+  onChange: (value: boolean) => void;
+}
+
+const ImageToggle = ({
+  label,
+  value,
+  children,
+  onChange,
+}: ImageToggleProps): JSX.Element => {
+  const toggleId = useUniqueId();
+
+  return (
+    <ToggleRoot>
+      <ImageContainer>{children}</ImageContainer>
+      <ToggleContainer>
+        <ToggleLabel htmlFor={toggleId}>{label}</ToggleLabel>
+        <Toggle
+          id={toggleId}
+          aria-checked={value}
+          role="switch"
+          value={value}
+          onChange={onChange}
+        />
+      </ToggleContainer>
+    </ToggleRoot>
+  );
+};
+
+export default ImageToggle;

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/ImageToggle/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/ImageToggle/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ImageToggle";

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/LighthouseToggleWidget/LighthouseToggleWidget.styled.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/LighthouseToggleWidget/LighthouseToggleWidget.styled.tsx
@@ -4,6 +4,7 @@ import { hueRotate } from "metabase/lib/colors";
 export const LighthouseImage = styled.div`
   width: 99.5px;
   height: 90px;
+  margin: 0.5rem 1rem;
   filter: hue-rotate(${() => hueRotate("brand")}deg);
   background-image: url("app/img/bridge.svg");
   background-size: 26rem auto;

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/LighthouseToggleWidget/LighthouseToggleWidget.styled.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/LighthouseToggleWidget/LighthouseToggleWidget.styled.tsx
@@ -2,11 +2,11 @@ import styled from "@emotion/styled";
 import { hueRotate } from "metabase/lib/colors";
 
 export const LighthouseImage = styled.div`
-  width: 5.875rem;
-  height: 5.3125rem;
+  width: 99.5px;
+  height: 90px;
   filter: hue-rotate(${() => hueRotate("brand")}deg);
   background-image: url("app/img/bridge.svg");
   background-size: 26rem auto;
   background-repeat: no-repeat;
-  background-position: 37% 50%;
+  background-position: 37.5% 50%;
 `;

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/LighthouseToggleWidget/LighthouseToggleWidget.styled.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/LighthouseToggleWidget/LighthouseToggleWidget.styled.tsx
@@ -1,7 +1,12 @@
 import styled from "@emotion/styled";
 import { hueRotate } from "metabase/lib/colors";
 
-export const LighthouseImage = styled.img`
+export const LighthouseImage = styled.div`
   width: 5.875rem;
+  height: 5.3125rem;
   filter: hue-rotate(${() => hueRotate("brand")}deg);
+  background-image: url("app/img/bridge.svg");
+  background-size: 26rem auto;
+  background-repeat: no-repeat;
+  background-position: 37% 50%;
 `;

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/LighthouseToggleWidget/LighthouseToggleWidget.styled.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/LighthouseToggleWidget/LighthouseToggleWidget.styled.tsx
@@ -4,7 +4,7 @@ import { hueRotate } from "metabase/lib/colors";
 export const LighthouseImage = styled.div`
   width: 100px;
   height: 90px;
-  margin: 0.5rem 1rem;
+  margin: 0.625rem 1.125rem;
   filter: hue-rotate(${() => hueRotate("brand")}deg);
   background-image: url("app/img/bridge.svg");
   background-size: 26rem auto;

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/LighthouseToggleWidget/LighthouseToggleWidget.styled.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/LighthouseToggleWidget/LighthouseToggleWidget.styled.tsx
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
 import { hueRotate } from "metabase/lib/colors";
 
-export const MetabotImage = styled.img`
+export const LighthouseImage = styled.img`
   width: 5.875rem;
   filter: hue-rotate(${() => hueRotate("brand")}deg);
 `;

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/LighthouseToggleWidget/LighthouseToggleWidget.styled.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/LighthouseToggleWidget/LighthouseToggleWidget.styled.tsx
@@ -2,7 +2,7 @@ import styled from "@emotion/styled";
 import { hueRotate } from "metabase/lib/colors";
 
 export const LighthouseImage = styled.div`
-  width: 99.5px;
+  width: 100px;
   height: 90px;
   margin: 0.5rem 1rem;
   filter: hue-rotate(${() => hueRotate("brand")}deg);

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/LighthouseToggleWidget/LighthouseToggleWidget.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/LighthouseToggleWidget/LighthouseToggleWidget.tsx
@@ -21,10 +21,7 @@ const LighthouseToggleWidget = ({
       value={isEnabled}
       onChange={onChange}
     >
-      <LighthouseImage
-        src="app/img/bridge.svg"
-        alt={t`Lighthouse illustration`}
-      />
+      <LighthouseImage />
     </ImageToggle>
   );
 };

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/LighthouseToggleWidget/LighthouseToggleWidget.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/LighthouseToggleWidget/LighthouseToggleWidget.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { t } from "ttag";
+import { LighthouseSetting } from "./types";
+import ImageToggle from "../ImageToggle";
+import { LighthouseImage } from "./LighthouseToggleWidget.styled";
+
+interface LighthouseToggleWidgetProps {
+  setting: LighthouseSetting;
+  onChange: (value: boolean) => void;
+}
+
+const LighthouseToggleWidget = ({
+  setting,
+  onChange,
+}: LighthouseToggleWidgetProps): JSX.Element => {
+  const isEnabled = setting.value ?? setting.default;
+
+  return (
+    <ImageToggle
+      label={t`Show this on the home and login pages`}
+      value={isEnabled}
+      onChange={onChange}
+    >
+      <LighthouseImage
+        src="app/img/bridge.svg"
+        alt={t`Lighthouse illustration`}
+      />
+    </ImageToggle>
+  );
+};
+
+export default LighthouseToggleWidget;

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/LighthouseToggleWidget/LighthouseToggleWidget.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/LighthouseToggleWidget/LighthouseToggleWidget.unit.spec.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import LighthouseToggleWidget from "./LighthouseToggleWidget";
+import { LighthouseSetting } from "./types";
+
+const TOGGLE_LABEL = "Show this on the home and login pages";
+
+describe("LighthouseToggleWidget", () => {
+  it("should disable the illustration", () => {
+    const setting = getSetting();
+    const onChange = jest.fn();
+
+    render(<LighthouseToggleWidget setting={setting} onChange={onChange} />);
+    userEvent.click(screen.getByText(TOGGLE_LABEL));
+
+    expect(onChange).toHaveBeenCalledWith(false);
+  });
+
+  it("should enable the illustration", () => {
+    const setting = getSetting({ value: false });
+    const onChange = jest.fn();
+
+    render(<LighthouseToggleWidget setting={setting} onChange={onChange} />);
+    userEvent.click(screen.getByText(TOGGLE_LABEL));
+
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+});
+
+const getSetting = (opts?: Partial<LighthouseSetting>): LighthouseSetting => ({
+  value: null,
+  default: true,
+  ...opts,
+});

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/LighthouseToggleWidget/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/LighthouseToggleWidget/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./LighthouseToggleWidget";

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/LighthouseToggleWidget/types.ts
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/LighthouseToggleWidget/types.ts
@@ -1,0 +1,4 @@
+export interface LighthouseSetting {
+  value: boolean | null;
+  default: boolean;
+}

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/MetabotToggleWidget/MetabotToggleWidget.styled.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/MetabotToggleWidget/MetabotToggleWidget.styled.tsx
@@ -3,5 +3,6 @@ import { hueRotate } from "metabase/lib/colors";
 
 export const MetabotImage = styled.img`
   width: 5.875rem;
+  height: 5.3125rem;
   filter: hue-rotate(${() => hueRotate("brand")}deg);
 `;

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/MetabotToggleWidget/MetabotToggleWidget.styled.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/MetabotToggleWidget/MetabotToggleWidget.styled.tsx
@@ -3,7 +3,7 @@ import { hueRotate } from "metabase/lib/colors";
 
 export const MetabotImage = styled.img`
   display: block;
-  width: 99.5px;
+  width: 100px;
   height: 90px;
   margin: 0.5rem 1rem 0.75rem 1.25rem;
   filter: hue-rotate(${() => hueRotate("brand")}deg);

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/MetabotToggleWidget/MetabotToggleWidget.styled.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/MetabotToggleWidget/MetabotToggleWidget.styled.tsx
@@ -1,29 +1,6 @@
 import styled from "@emotion/styled";
-import { color, hueRotate } from "metabase/lib/colors";
-
-export const MetabotSettingWidgetRoot = styled.div`
-  max-width: 530px;
-  border: 1px solid ${color("border")};
-  display: flex;
-  align-items: stretch;
-  border-radius: 0.5rem;
-`;
-
-export const MetabotContainer = styled.div`
-  padding: 0.5rem 1rem 0.75rem 1.25rem;
-  border-right: 1px solid ${color("border")};
-`;
+import { hueRotate } from "metabase/lib/colors";
 
 export const MetabotImage = styled.img`
   filter: hue-rotate(${() => hueRotate("brand")}deg);
-`;
-
-export const ToggleContainer = styled.div`
-  padding: 2rem 1.5rem;
-  display: flex;
-  align-items: center;
-`;
-
-export const ToggleLabel = styled.label`
-  margin-right: 2rem;
 `;

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/MetabotToggleWidget/MetabotToggleWidget.styled.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/MetabotToggleWidget/MetabotToggleWidget.styled.tsx
@@ -2,7 +2,8 @@ import styled from "@emotion/styled";
 import { hueRotate } from "metabase/lib/colors";
 
 export const MetabotImage = styled.img`
-  width: 5.875rem;
-  height: 5.3125rem;
+  display: block;
+  width: 99.5px;
+  height: 90px;
   filter: hue-rotate(${() => hueRotate("brand")}deg);
 `;

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/MetabotToggleWidget/MetabotToggleWidget.styled.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/MetabotToggleWidget/MetabotToggleWidget.styled.tsx
@@ -5,5 +5,6 @@ export const MetabotImage = styled.img`
   display: block;
   width: 99.5px;
   height: 90px;
+  margin: 0.5rem 1rem 0.75rem 1.25rem;
   filter: hue-rotate(${() => hueRotate("brand")}deg);
 `;

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/MetabotToggleWidget/MetabotToggleWidget.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/MetabotToggleWidget/MetabotToggleWidget.tsx
@@ -1,15 +1,8 @@
 import React from "react";
 import { t } from "ttag";
-import { useUniqueId } from "metabase/hooks/use-unique-id";
-import Toggle from "metabase/core/components/Toggle";
 import { MetabotSetting } from "./types";
-import {
-  MetabotSettingWidgetRoot,
-  MetabotContainer,
-  ToggleContainer,
-  ToggleLabel,
-  MetabotImage,
-} from "./MetabotToggleWidget.styled";
+import ImageToggle from "../ImageToggle";
+import { MetabotImage } from "./MetabotToggleWidget.styled";
 
 interface MetabotToggleWidgetProps {
   setting: MetabotSetting;
@@ -23,29 +16,18 @@ const MetabotToggleWidget = ({
   const isEnabled = setting.value ?? setting.default;
   const metabotImage = isEnabled ? "metabot-happy" : "metabot-sad";
 
-  const toggleId = useUniqueId("show-metabot-switch");
   return (
-    <MetabotSettingWidgetRoot>
-      <MetabotContainer>
-        <MetabotImage
-          src={`app/assets/img/${metabotImage}.gif`}
-          width="94px"
-          alt="Metabot"
-        />
-      </MetabotContainer>
-      <ToggleContainer>
-        <ToggleLabel
-          htmlFor={toggleId}
-        >{t`Display our little friend on the homepage`}</ToggleLabel>
-        <Toggle
-          id={toggleId}
-          aria-checked={isEnabled}
-          role="switch"
-          value={isEnabled}
-          onChange={onChange}
-        />
-      </ToggleContainer>
-    </MetabotSettingWidgetRoot>
+    <ImageToggle
+      label={t`Display our little friend on the homepage`}
+      value={isEnabled}
+      onChange={onChange}
+    >
+      <MetabotImage
+        src={`app/assets/img/${metabotImage}.gif`}
+        width={94}
+        alt="Metabot"
+      />
+    </ImageToggle>
   );
 };
 

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/MetabotToggleWidget/MetabotToggleWidget.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/MetabotToggleWidget/MetabotToggleWidget.tsx
@@ -24,8 +24,7 @@ const MetabotToggleWidget = ({
     >
       <MetabotImage
         src={`app/assets/img/${metabotImage}.gif`}
-        width={94}
-        alt="Metabot"
+        alt={t`Metabot`}
       />
     </ImageToggle>
   );

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/index.js
@@ -18,6 +18,7 @@ import MetabaseSettings from "metabase/lib/settings";
 import ColorSettingsWidget from "./components/ColorSettingsWidget";
 import FontWidget from "./components/FontWidget";
 import FontFilesWidget from "./components/FontFilesWidget";
+import LighthouseToggleWidget from "./components/LighthouseToggleWidget";
 import MetabotToggleWidget from "./components/MetabotToggleWidget";
 import LogoUpload from "./components/LogoUpload";
 import LogoIcon from "./components/LogoIcon";
@@ -88,7 +89,9 @@ if (hasPremiumFeature("whitelabel")) {
         {
           key: "show-lighthouse-illustration",
           display_name: t`Lighthouse illustration`,
+          description: null,
           type: "boolean",
+          widget: LighthouseToggleWidget,
           defaultValue: true,
         },
       ],


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/22826

Extract code from the Metabot widget and use it for the illustration widget.

How to test:
- Run Metabase EE
- Go to Admin -> Settings -> Appearance
- At the bottom of the page there should be a custom widget for the illustration setting
- Make sure the setting can be toggled on and off

<img width="560" alt="Screenshot 2022-07-13 at 21 45 55" src="https://user-images.githubusercontent.com/8542534/178808741-33c4a3a1-46ba-4f4a-b770-7faa12361efd.png">
