### PR TITLE
Fix metabot and illustration settings for OSS

### DIFF
--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -47,8 +47,8 @@ export interface Settings {
   "show-homepage-data": boolean;
   "show-homepage-xrays": boolean;
   "show-homepage-pin-message": boolean;
-  "show-lighthouse-illustration": boolean;
-  "show-metabot": boolean;
+  "show-lighthouse-illustration": boolean | null;
+  "show-metabot": boolean | null;
   "slack-token": string | undefined;
   "slack-token-valid?": boolean;
   "slack-app-token": string | undefined;

--- a/frontend/src/metabase/auth/containers/AuthLayout/AuthLayout.tsx
+++ b/frontend/src/metabase/auth/containers/AuthLayout/AuthLayout.tsx
@@ -3,7 +3,8 @@ import AuthLayout from "../../components/AuthLayout";
 import { State } from "metabase-types/store";
 
 const mapStateToProps = (state: State) => ({
-  showIllustration: state.settings.values["show-lighthouse-illustration"],
+  showIllustration:
+    state.settings.values["show-lighthouse-illustration"] ?? true,
 });
 
 export default connect(mapStateToProps)(AuthLayout);

--- a/frontend/src/metabase/home/homepage/containers/HomeGreeting/HomeGreeting.tsx
+++ b/frontend/src/metabase/home/homepage/containers/HomeGreeting/HomeGreeting.tsx
@@ -5,7 +5,7 @@ import HomeGreeting from "../../components/HomeGreeting";
 
 const mapStateToProps = (state: State) => ({
   user: getUser(state),
-  showLogo: state.settings.values["show-metabot"],
+  showLogo: state.settings.values["show-metabot"] ?? true,
 });
 
 export default connect(mapStateToProps)(HomeGreeting);

--- a/frontend/src/metabase/home/homepage/containers/HomeLayout/HomeLayout.tsx
+++ b/frontend/src/metabase/home/homepage/containers/HomeLayout/HomeLayout.tsx
@@ -3,7 +3,8 @@ import { State } from "metabase-types/store";
 import HomeLayout from "../../components/HomeLayout";
 
 const mapStateToProps = (state: State) => ({
-  showIllustration: state.settings.values["show-lighthouse-illustration"],
+  showIllustration:
+    state.settings.values["show-lighthouse-illustration"] ?? true,
 });
 
 export default connect(mapStateToProps)(HomeLayout);


### PR DESCRIPTION
Regression since https://github.com/metabase/metabase/pull/23890

The issue is that disabled settings doesn't invoke `:getter` but only `:default`, so these settings return `null` in OSS. For now, just check for null on the frontend and default to `true`. Please note that backend changes to the settings will be reverted in 0.45 so this fix would be reverted too.

How to test:
- Run Metabase OSS
- Go to the homepage
- Make sure both Metabot and illustration are there 