### PR TITLE
Check email test errors for javax.mail.AuthenticationFailedException

### DIFF
--- a/src/metabase/api/email.clj
+++ b/src/metabase/api/email.clj
@@ -33,14 +33,14 @@
                                 :email-smtp-password "Wrong username or password"}}
           exceptions  (u/full-exception-chain error)
           message     (str/join ": " (map ex-message exceptions))
-          check       (fn check [regex|exception-class [m es]]
-                        (cond (instance? java.util.regex.Pattern regex|exception-class)
-                              (re-find regex|exception-class m)
+          match-error (fn match-error [regex-or-exception-class [message exceptions]]
+                        (cond (instance? java.util.regex.Pattern regex-or-exception-class)
+                              (re-find regex-or-exception-class message)
 
-                              (class? regex|exception-class)
-                              (some (partial instance? regex|exception-class) es)))]
+                              (class? regex-or-exception-class)
+                              (some (partial instance? regex-or-exception-class) exceptions)))]
       (log/warn "Problem connecting to mail server:" message)
-      (condp check [message exceptions]
+      (condp match-error [message exceptions]
         ;; bad host = "Unknown SMTP host: foobar"
         #"^Unknown SMTP host:.*$"
         conn-error

--- a/test/metabase/api/email_test.clj
+++ b/test/metabase/api/email_test.clj
@@ -13,7 +13,16 @@
           {::email/error (Exception. "Couldn't connect to host, port: foobar, 789; timeout 1000: foobar")})))
   (is (= {:message "Sorry, something went wrong. Please try again. Error: Some unexpected message"}
          (#'api.email/humanize-error-messages
-          {::email/error (Exception. "Some unexpected message")}))))
+          {::email/error (Exception. "Some unexpected message")})))
+  (testing "Checks error classes for auth errors (#23918)"
+    (let [exception (javax.mail.AuthenticationFailedException.
+                     "" ;; Office365 returns auth exception with no message so we only saw "Read timed out" prior
+                     (javax.mail.MessagingException.
+                      "Exception reading response"
+                      (java.net.SocketTimeoutException. "Read timed out")))]
+      (is (= {:errors {:email-smtp-username "Wrong username or password"
+                       :email-smtp-password "Wrong username or password"}}
+             (#'api.email/humanize-error-messages {::email/error exception}))))))
 
 (defn- email-settings
   []


### PR DESCRIPTION
fixes #23918 (and with #23925 fixes #19662)

Authing with Office365 led to a less-than-great user experience. If you
type in the wrong username or password, we would display an unhelpful
message:

> Sorry, something went wrong. Please try again. Error::Exception
reading response.Read timed out.

This is an error from an inner nested exception which looks like:
```clojure
(javax.mail.AuthenticationFailedException.
 "" ;; Office365 returns auth exception with no message so we only saw "Read timed out" prior
 (javax.mail.MessagingException.
  "Exception reading response"
  (java.net.SocketTimeoutException. "Read timed out")))
```

We didn't get any message from the AuthenticationFailedException so our
humanization strategy only went on the underlying "Read timed out". Now
we can check against the error class and use that information.


#### Before

<img width="1038" alt="image" src="https://user-images.githubusercontent.com/6377293/178827855-fc6f533d-a6f0-41a2-8dd5-14d342dad88c.png">

#### After
<img width="1207" alt="image" src="https://user-images.githubusercontent.com/6377293/178827886-6d36a95f-bfe0-4073-a776-f5a9d44c036a.png">


#### Recreate:

give some invalid Office365 credentials:
- smtp host: smtp.office365.com
- smtp port: 587
- username: make up anything, I used `some@person.com`
- password: the world is your oyster here

Attempt to save those credentials. Before this change it seems like perhaps we don't work well with office365 (particularly if you don't know you mistyped your password or if you are hitting #23919 (which sends the obfuscated password on edits rather than what you think is the saved password)). Before this change you get a cryptic timeout error. After this change you get highlighted username and password fields.
