### PR TITLE
Fix search results covered by sticky dashboard header

### DIFF
--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.jsx
@@ -92,7 +92,7 @@ export const ParametersWidgetContainer = styled(FullWidthContainer)`
   flex-direction: column;
   padding-top: ${space(2)};
   padding-bottom: ${space(1)};
-  z-index: 4;
+  z-index: 3;
 
   ${({ isEditing }) =>
     isEditing &&


### PR DESCRIPTION
We attempted to fix this in https://github.com/metabase/metabase/pull/23920, but found out shortly after that it broke other E2E tests.

We attempted https://github.com/metabase/metabase/pull/23923, but didn't pan out. So, https://github.com/metabase/metabase/pull/23926 reverted the original fix.

This is another attempt at fixing the issue.

Context: [Slack](https://metaboat.slack.com/archives/C03E8MQJZBM/p1657715422090549)

#### Edited
This is the PR that fixed the issue https://github.com/metabase/metabase/pull/23947