### PR TITLE
Fix for #23940: Error sending emails when reply-to setting contains empty string

### DIFF
--- a/frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx
@@ -21,7 +21,7 @@ const VALIDATIONS = {
   },
   email_list: {
     validate: value => value.every(MetabaseUtils.isEmail),
-    message: t`That's not a valid list of email addresses`,
+    message: t`That's not a valid email address`,
   },
   integer: {
     validate: value => !isNaN(parseInt(value)),

--- a/frontend/src/metabase/admin/settings/components/widgets/SettingCommaDelimitedInput.jsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/SettingCommaDelimitedInput.jsx
@@ -3,6 +3,8 @@ import React from "react";
 import InputBlurChange from "metabase/components/InputBlurChange";
 import cx from "classnames";
 
+const maybeSingletonList = value => (value ? [value] : null);
+
 const SettingCommaDelimitedInput = ({
   setting,
   onChange,
@@ -25,8 +27,13 @@ const SettingCommaDelimitedInput = ({
       // https://github.com/metabase/metabase/issues/22540
       value={setting.value ? setting.value[0] : ""}
       placeholder={setting.placeholder}
-      onChange={fireOnChange ? e => onChange([e.target.value]) : null}
-      onBlurChange={!fireOnChange ? e => onChange([e.target.value]) : null}
+      // If the input's value is empty, setting.value should be null
+      onChange={
+        fireOnChange ? e => onChange(maybeSingletonList(e.target.value)) : null
+      }
+      onBlurChange={
+        !fireOnChange ? e => onChange(maybeSingletonList(e.target.value)) : null
+      }
       autoFocus={autoFocus}
     />
   );

--- a/frontend/src/metabase/admin/settings/selectors.js
+++ b/frontend/src/metabase/admin/settings/selectors.js
@@ -214,7 +214,7 @@ const SECTIONS = updateSectionsWithPlugins({
         type: "string",
         required: false,
         widget: SettingCommaDelimitedInput,
-        validations: [["email_list", t`That's not a valid email addresses`]],
+        validations: [["email_list", t`That's not a valid email address`]],
       },
     ],
   },

--- a/frontend/test/metabase/scenarios/admin/settings/email.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/email.cy.spec.js
@@ -35,7 +35,7 @@ describe("scenarios > admin > settings > email settings", () => {
     cy.request("PUT", "/api/setting", {
       "email-from-address": "admin@metabase.test",
       "email-from-name": "Metabase Admin",
-      "email-reply-to": "reply-to@metabase.test",
+      "email-reply-to": ["reply-to@metabase.test"],
       "email-smtp-host": "localhost",
       "email-smtp-password": null,
       "email-smtp-port": "1234",

--- a/src/metabase/email.clj
+++ b/src/metabase/email.clj
@@ -22,9 +22,19 @@
 (defsetting email-from-name
   (deferred-tru "The name you want to use for the sender of emails."))
 
+(def ^:private ReplyToAddresses
+  (s/maybe [su/Email]))
+
+(def ^:private ^{:arglists '([reply-to-addresses])} validate-reply-to-addresses
+  (s/validator ReplyToAddresses))
+
 (defsetting email-reply-to
   (deferred-tru "The email address you want the replies to go to, if different from the from address. You can have multiple reply-to email addresses, just separate them with a comma.")
-  :type :json)
+  :type :json
+  :setter (fn [new-value]
+            (->> new-value
+                 (validate-reply-to-addresses)
+                 (setting/set-value-of-type! :json :email-reply-to))))
 
 (defsetting email-smtp-host
   (deferred-tru "The address of the SMTP server that handles your emails."))

--- a/src/metabase/email.clj
+++ b/src/metabase/email.clj
@@ -33,7 +33,7 @@
   :type :json
   :setter (fn [new-value]
             (->> new-value
-                 (validate-reply-to-addresses)
+                 validate-reply-to-addresses
                  (setting/set-value-of-type! :json :email-reply-to))))
 
 (defsetting email-smtp-host

--- a/src/metabase/email.clj
+++ b/src/metabase/email.clj
@@ -29,7 +29,7 @@
   (s/validator ReplyToAddresses))
 
 (defsetting email-reply-to
-  (deferred-tru "The email address you want the replies to go to, if different from the from address. You can have multiple reply-to email addresses, just separate them with a comma.")
+  (deferred-tru "The email address you want the replies to go to, if different from the from address.")
   :type :json
   :setter (fn [new-value]
             (->> new-value


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/23940
Bug introduced in https://github.com/metabase/metabase/pull/23381

Made a couple of changes:
- The value of the reply-to setting on the FE will be `null` instead of `[""]` if the input field's value is "".
- The value of the reply-to setting on the BE will be validated to be a list of emails, so the value can never set to [""] anyway.