### PR TITLE
Update email-to test helper with email-from-name setting

### DIFF
--- a/test/metabase/email_test.clj
+++ b/test/metabase/email_test.clj
@@ -190,7 +190,9 @@
   "Creates a default email map for `user-kwd` via `test.users/fetch-user`, as would be returned by `with-fake-inbox`"
   [user-kwd & [email-map]]
   (let [{:keys [email]} (test.users/fetch-user user-kwd)]
-    {email [(merge {:from (email/email-from-address)
+    {email [(merge {:from (if-let [from-name (email/email-from-name)]
+                            (str from-name " <" (email/email-from-address) ">")
+                            (email/email-from-address))
                     :to #{email}}
                    email-map)]}))
 


### PR DESCRIPTION
This fixes tests that fail locally if you have the new `email-from-name` setting set to anything other than nil.

The email-from-name setting was introduced in this PR https://github.com/metabase/metabase/pull/23381 ([relevant line here](https://github.com/metabase/metabase/blob/email-to-with-from-name/src/metabase/email.clj#L106))