### PR TITLE
Fix color pills in Safari

### DIFF
--- a/frontend/src/metabase/core/components/ColorPicker/ColorPicker.styled.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPicker.styled.tsx
@@ -3,6 +3,7 @@ import { color } from "metabase/lib/colors";
 
 export const TriggerContainer = styled.div`
   display: flex;
+  align-items: center;
   gap: 1rem;
 `;
 


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/22816

How to test:
- Run Metabase EE
- Go to Admin -> Settings -> Appearance
- Make sure sure colors pills are round in Safari

Before
<img width="226" alt="Screenshot 2022-07-14 at 12 26 08" src="https://user-images.githubusercontent.com/8542534/178950608-73453249-0711-46f2-a296-95e2361b0709.png">

After
<img width="218" alt="Screenshot 2022-07-14 at 12 25 42" src="https://user-images.githubusercontent.com/8542534/178950645-19f63107-3787-4ac9-867b-44a09f80654b.png">

