### PR TITLE
Fix search bar results overflow

### DIFF
--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.jsx
@@ -4,12 +4,16 @@ import styled from "@emotion/styled";
 import { css } from "@emotion/react";
 import { IFRAMED } from "metabase/lib/dom";
 import { color } from "metabase/lib/colors";
-import { space } from "metabase/styled-components/theme";
+import { breakpointMaxSmall, space } from "metabase/styled-components/theme";
 
 import { FullWidthContainer } from "metabase/styled-components/layout/FullWidthContainer";
 
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
-import { APP_BAR_HEIGHT, NAV_SIDEBAR_WIDTH } from "metabase/nav/constants";
+import {
+  APP_BAR_HEIGHT,
+  APP_MOBILE_BAR_HEIGHT,
+  NAV_SIDEBAR_WIDTH,
+} from "metabase/nav/constants";
 
 // Class names are added here because we still use traditional css,
 // see dashboard.css
@@ -92,7 +96,7 @@ export const ParametersWidgetContainer = styled(FullWidthContainer)`
   flex-direction: column;
   padding-top: ${space(2)};
   padding-bottom: ${space(1)};
-  z-index: 4;
+  z-index: 3;
 
   ${({ isEditing }) =>
     isEditing &&
@@ -103,10 +107,19 @@ export const ParametersWidgetContainer = styled(FullWidthContainer)`
   ${({ isSticky }) =>
     isSticky &&
     css`
-      border-bottom: 1px solid ${color("border")};
       position: fixed;
       top: ${APP_BAR_HEIGHT};
       left: 0;
+      border-bottom: 1px solid ${color("border")};
+    `}
+
+  ${({ isSticky, isNavbarOpen }) =>
+    isSticky &&
+    !isNavbarOpen &&
+    css`
+      ${breakpointMaxSmall} {
+        top: ${APP_MOBILE_BAR_HEIGHT};
+      }
     `}
 
   ${({ isSticky, isNavbarOpen }) =>
@@ -114,9 +127,8 @@ export const ParametersWidgetContainer = styled(FullWidthContainer)`
     isNavbarOpen &&
     !IFRAMED &&
     css`
-      width: calc(100% - ${NAV_SIDEBAR_WIDTH});
       left: ${parseInt(NAV_SIDEBAR_WIDTH) + 1 + "px"};
-      top: ${APP_BAR_HEIGHT};
+      width: calc(100% - ${NAV_SIDEBAR_WIDTH});
     `}
 `;
 

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.jsx
@@ -11,7 +11,7 @@ import { FullWidthContainer } from "metabase/styled-components/layout/FullWidthC
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 import {
   APP_BAR_HEIGHT,
-  APP_MOBILE_BAR_HEIGHT,
+  APP_BAR_EXTENDED_HEIGHT,
   NAV_SIDEBAR_WIDTH,
 } from "metabase/nav/constants";
 
@@ -118,7 +118,7 @@ export const ParametersWidgetContainer = styled(FullWidthContainer)`
     !isNavbarOpen &&
     css`
       ${breakpointMaxSmall} {
-        top: ${APP_MOBILE_BAR_HEIGHT};
+        top: ${APP_BAR_EXTENDED_HEIGHT};
       }
     `}
 

--- a/frontend/src/metabase/nav/constants.ts
+++ b/frontend/src/metabase/nav/constants.ts
@@ -1,4 +1,4 @@
 export const APP_BAR_HEIGHT = "52px";
-export const APP_MOBILE_BAR_HEIGHT = "98px";
+export const APP_BAR_EXTENDED_HEIGHT = "98px";
 export const ADMIN_NAVBAR_HEIGHT = "65px";
 export const NAV_SIDEBAR_WIDTH = "324px";

--- a/frontend/src/metabase/nav/constants.ts
+++ b/frontend/src/metabase/nav/constants.ts
@@ -1,3 +1,4 @@
 export const APP_BAR_HEIGHT = "52px";
+export const APP_MOBILE_BAR_HEIGHT = "98px";
 export const ADMIN_NAVBAR_HEIGHT = "65px";
 export const NAV_SIDEBAR_WIDTH = "324px";


### PR DESCRIPTION
How to test:
- Open a dashboard with 2+ questions arranged to get vertical scroll
- Add a dashboard parameter
- Scroll down to make dashboard parameters sticky
- Focus on the search bar
- Make sure its contents are on top of the sticky parameters

<img width="842" alt="Screenshot 2022-07-14 at 12 57 34" src="https://user-images.githubusercontent.com/8542534/178957057-e8029835-c9cd-4156-b447-ced83e7191c9.png">
<img width="638" alt="Screenshot 2022-07-14 at 12 57 47" src="https://user-images.githubusercontent.com/8542534/178957069-f6ba1042-8c87-4ca9-8d69-7bdceaaa48af.png">
<img width="637" alt="Screenshot 2022-07-14 at 12 57 51" src="https://user-images.githubusercontent.com/8542534/178957078-ef7607bf-76a1-4898-960b-2fddd9e79498.png">
