### PR TITLE
Blurring EditableText component on Esc

### DIFF
--- a/frontend/src/metabase/core/components/EditableText/EditableText.tsx
+++ b/frontend/src/metabase/core/components/EditableText/EditableText.tsx
@@ -6,6 +6,7 @@ import React, {
   Ref,
   useCallback,
   useState,
+  useRef,
 } from "react";
 import { EditableTextArea, EditableTextRoot } from "./EditableText.styled";
 
@@ -40,15 +41,19 @@ const EditableText = forwardRef(function EditableText(
   const [inputValue, setInputValue] = useState(initialValue ?? "");
   const [submitValue, setSubmitValue] = useState(initialValue ?? "");
   const displayValue = inputValue ? inputValue : placeholder;
+  const submitOnBlur = useRef(true);
 
-  const handleBlur = useCallback(() => {
-    if (!isOptional && !inputValue) {
-      setInputValue(submitValue);
-    } else if (inputValue !== submitValue) {
-      setSubmitValue(inputValue);
-      onChange?.(inputValue);
-    }
-  }, [inputValue, submitValue, isOptional, onChange]);
+  const handleBlur = useCallback(
+    e => {
+      if (!isOptional && !inputValue) {
+        setInputValue(submitValue);
+      } else if (inputValue !== submitValue && submitOnBlur.current) {
+        setSubmitValue(inputValue);
+        onChange?.(inputValue);
+      }
+    },
+    [inputValue, submitValue, isOptional, onChange],
+  );
 
   const handleChange = useCallback(
     (event: ChangeEvent<HTMLTextAreaElement>) => {
@@ -61,8 +66,11 @@ const EditableText = forwardRef(function EditableText(
     (event: KeyboardEvent<HTMLTextAreaElement>) => {
       if (event.key === "Escape") {
         setInputValue(submitValue);
+        submitOnBlur.current = false;
+        event.currentTarget.blur();
       } else if (event.key === "Enter" && !isMultiline) {
         event.preventDefault();
+        submitOnBlur.current = true;
         event.currentTarget.blur();
       }
     },

--- a/frontend/src/metabase/core/components/EditableText/EditableText.tsx
+++ b/frontend/src/metabase/core/components/EditableText/EditableText.tsx
@@ -58,8 +58,9 @@ const EditableText = forwardRef(function EditableText(
   const handleChange = useCallback(
     (event: ChangeEvent<HTMLTextAreaElement>) => {
       setInputValue(event.currentTarget.value);
+      submitOnBlur.current = true;
     },
-    [],
+    [submitOnBlur],
   );
 
   const handleKeyDown = useCallback(


### PR DESCRIPTION
Small adjustment to Blur on `esc`. We needed to add an extra flag to check so that we do not end up calling `onChange` on `esc` well
![chrome_wDYB2XXGtV](https://user-images.githubusercontent.com/1328979/178997652-830b29f1-eea5-46dd-bd32-8a8bfe458e32.gif)

