### PR TITLE
Serdes v2 for Native Query Snippets

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
@@ -10,5 +10,6 @@
    "Dimension"
    "Field"
    "Metric"
+   "NativeQuerySnippet"
    "Setting"
    "Table"])

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e/yaml_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e/yaml_test.clj
@@ -85,9 +85,12 @@
 
           (testing "for Databases"
             (is (= 10 (count (dir->file-set (io/file dump-dir "Database")))))
-            (doseq [{:keys [name] :as db} (get entities "Database")
+            (doseq [{:keys [name] :as coll} (get entities "Database")
                     :let [filename (str name ".yaml")]]
-              (is (= (dissoc db :serdes/meta)
+              (is (= (-> coll
+                         (dissoc :serdes/meta)
+                         (update :created_at u.date/format)
+                         (update :updated_at u.date/format))
                      (yaml/from-file (io/file dump-dir "Database" filename))))))
 
           (testing "for Tables"
@@ -97,8 +100,11 @@
                                (count tables))))
                 "Tables are scattered, so the directories are harder to count")
 
-            (doseq [{:keys [db_id name] :as table} (get entities "Table")]
-              (is (= (dissoc table :serdes/meta)
+            (doseq [{:keys [db_id name] :as coll} (get entities "Table")]
+              (is (= (-> coll
+                         (dissoc :serdes/meta)
+                         (update :created_at u.date/format)
+                         (update :updated_at u.date/format))
                      (yaml/from-file (io/file dump-dir "Database" db_id "Table" (str name ".yaml")))))))
 
           (testing "for Fields"
@@ -110,23 +116,32 @@
                                     count))))
                 "Fields are scattered, so the directories are harder to count")
 
-            (doseq [{[db schema table] :table_id name :name :as field} (get entities "Field")]
+            (doseq [{[db schema table] :table_id name :name :as coll} (get entities "Field")]
               (is (nil? schema))
-              (is (= (dissoc field :serdes/meta)
+              (is (= (-> coll
+                         (dissoc :serdes/meta)
+                         (update :created_at u.date/format)
+                         (update :updated_at u.date/format))
                      (yaml/from-file (io/file dump-dir "Database" db "Table" table "Field" (str name ".yaml")))))))
 
           (testing "for cards"
             (is (= 100 (count (dir->file-set (io/file dump-dir "Card")))))
             (doseq [{:keys [entity_id] :as card} (get entities "Card")
                     :let [filename (str entity_id ".yaml")]]
-              (is (= (dissoc card :serdes/meta)
+              (is (= (-> card
+                         (dissoc :serdes/meta)
+                         (update :created_at u.date/format)
+                         (update :updated_at u.date/format))
                      (yaml/from-file (io/file dump-dir "Card" filename))))))
 
           (testing "for dashboards"
             (is (= 100 (count (dir->file-set (io/file dump-dir "Dashboard")))))
             (doseq [{:keys [entity_id] :as dash} (get entities "Dashboard")
                     :let [filename (str entity_id ".yaml")]]
-              (is (= (dissoc dash :serdes/meta)
+              (is (= (-> dash
+                         (dissoc :serdes/meta)
+                         (update :created_at u.date/format)
+                         (update :updated_at u.date/format))
                      (yaml/from-file (io/file dump-dir "Dashboard" filename))))))
 
           (testing "for dashboard cards"
@@ -140,28 +155,40 @@
             (doseq [{:keys [dashboard_id entity_id]
                      :as   dashcard}                (get entities "DashboardCard")
                     :let [filename (str entity_id ".yaml")]]
-              (is (= (dissoc dashcard :serdes/meta)
+              (is (= (-> dashcard
+                         (dissoc :serdes/meta)
+                         (update :created_at u.date/format)
+                         (update :updated_at u.date/format))
                      (yaml/from-file (io/file dump-dir "Dashboard" dashboard_id "DashboardCard" filename))))))
 
           (testing "for dimensions"
             (is (= 40 (count (dir->file-set (io/file dump-dir "Dimension")))))
             (doseq [{:keys [entity_id] :as dim} (get entities "Dimension")
                     :let [filename (str entity_id ".yaml")]]
-              (is (= (dissoc dim :serdes/meta)
+              (is (= (-> dim
+                         (dissoc :serdes/meta)
+                         (update :created_at u.date/format)
+                         (update :updated_at u.date/format))
                      (yaml/from-file (io/file dump-dir "Dimension" filename))))))
 
           (testing "for metrics"
             (is (= 30 (count (dir->file-set (io/file dump-dir "Metric")))))
             (doseq [{:keys [entity_id name] :as metric} (get entities "Metric")
                     :let [filename (str entity_id "+" (#'u.yaml/truncate-label name) ".yaml")]]
-              (is (= (dissoc metric :serdes/meta)
+              (is (= (-> metric
+                         (dissoc :serdes/meta)
+                         (update :created_at u.date/format)
+                         (update :updated_at u.date/format))
                      (yaml/from-file (io/file dump-dir "Metric" filename))))))
 
           (testing "for native query snippets"
             (is (= 10 (count (dir->file-set (io/file dump-dir "NativeQuerySnippet")))))
             (doseq [{:keys [entity_id name] :as snippet} (get entities "NativeQuerySnippet")
                     :let [filename (str entity_id "+" (#'u.yaml/truncate-label name) ".yaml")]]
-              (is (= (dissoc snippet :serdes/meta)
+              (is (= (-> snippet
+                         (dissoc :serdes/meta)
+                         (update :created_at u.date/format)
+                         (update :updated_at u.date/format))
                      (yaml/from-file (io/file dump-dir "NativeQuerySnippet" filename))))))
 
           (testing "for settings"

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e/yaml_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e/yaml_test.clj
@@ -38,8 +38,8 @@
       ;; TODO Generating some nested collections would make these tests more robust.
       (test-gen/insert!
         {:collection             [[100 {:refs {:personal_owner_id ::rs/omit}}]
-                                  [10  {:refs {:personal_owner_id ::rs/omit}
-                                        :namespace :snippets}]]
+                                  [10  {:refs     {:personal_owner_id ::rs/omit}
+                                        :spec-gen {:namespace :snippets}}]]
          :database               [[10]]
          :table                  (into [] (for [db [:db0 :db1 :db2 :db3 :db4 :db5 :db6 :db7 :db8 :db9]]
                                             [10 {:refs {:db_id db}}]))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -4,7 +4,8 @@
             [metabase-enterprise.serialization.v2.extract :as extract]
             [metabase.models :refer [Card Collection Dashboard DashboardCard Database Dimension Field Metric
                                      NativeQuerySnippet Table User]]
-            [metabase.models.serialization.base :as serdes.base]))
+            [metabase.models.serialization.base :as serdes.base])
+  (:import java.time.Instant))
 
 (defn- select-one [model-name where]
   (first (into [] (serdes.base/raw-reducible-query model-name {:where where}))))
@@ -130,6 +131,9 @@
                   :dataset_query "{\"json\": \"string values\"}"} ; Undecoded, still a string.
                  (select-keys ser [:serdes/meta :table_id :creator_id :collection_id :dataset_query])))
           (is (not (contains? ser :id)))
+          (is (instance? Instant (:created_at ser)))
+          (is (or (nil? (:updated_at ser))
+                  (instance? Instant (:updated_at ser))))
 
           (testing "cards depend on their Table and Collection"
             (is (= #{[{:model "Database"   :id "My Database"}
@@ -292,6 +296,9 @@
                     :creator_id              "ann@heart.band"}
                    (select-keys ser [:serdes/meta :collection_id :creator_id])))
             (is (not (contains? ser :id)))
+            (is (instance? Instant (:created_at ser)))
+            (is (or (nil? (:updated_at ser))
+                    (instance? Instant (:updated_at ser))))
 
             (testing "and depend on the Collection"
               (is (= #{[{:model "Collection" :id coll-eid}]}
@@ -304,6 +311,9 @@
                     :creator_id              "ann@heart.band"}
                    (select-keys ser [:serdes/meta :collection_id :creator_id])))
             (is (not (contains? ser :id)))
+            (is (instance? Instant (:created_at ser)))
+            (is (or (nil? (:updated_at ser))
+                    (instance? Instant (:updated_at ser))))
 
             (testing "and has no deps"
               (is (empty? (serdes.base/serdes-dependencies ser))))))))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -5,7 +5,7 @@
             [metabase.models :refer [Card Collection Dashboard DashboardCard Database Dimension Field Metric
                                      NativeQuerySnippet Table User]]
             [metabase.models.serialization.base :as serdes.base])
-  (:import java.time.Instant))
+  (:import java.time.ZonedDateTime))
 
 (defn- select-one [model-name where]
   (first (into [] (serdes.base/raw-reducible-query model-name {:where where}))))
@@ -131,9 +131,9 @@
                   :dataset_query "{\"json\": \"string values\"}"} ; Undecoded, still a string.
                  (select-keys ser [:serdes/meta :table_id :creator_id :collection_id :dataset_query])))
           (is (not (contains? ser :id)))
-          (is (instance? Instant (:created_at ser)))
+          (is (instance? ZonedDateTime (:created_at ser)))
           (is (or (nil? (:updated_at ser))
-                  (instance? Instant (:updated_at ser))))
+                  (instance? ZonedDateTime (:updated_at ser))))
 
           (testing "cards depend on their Table and Collection"
             (is (= #{[{:model "Database"   :id "My Database"}
@@ -296,9 +296,9 @@
                     :creator_id              "ann@heart.band"}
                    (select-keys ser [:serdes/meta :collection_id :creator_id])))
             (is (not (contains? ser :id)))
-            (is (instance? Instant (:created_at ser)))
+            (is (instance? ZonedDateTime (:created_at ser)))
             (is (or (nil? (:updated_at ser))
-                    (instance? Instant (:updated_at ser))))
+                    (instance? ZonedDateTime (:updated_at ser))))
 
             (testing "and depend on the Collection"
               (is (= #{[{:model "Collection" :id coll-eid}]}
@@ -311,9 +311,9 @@
                     :creator_id              "ann@heart.band"}
                    (select-keys ser [:serdes/meta :collection_id :creator_id])))
             (is (not (contains? ser :id)))
-            (is (instance? Instant (:created_at ser)))
+            (is (instance? ZonedDateTime (:created_at ser)))
             (is (or (nil? (:updated_at ser))
-                    (instance? Instant (:updated_at ser))))
+                    (instance? ZonedDateTime (:updated_at ser))))
 
             (testing "and has no deps"
               (is (empty? (serdes.base/serdes-dependencies ser))))))))))

--- a/src/metabase/models/native_query_snippet.clj
+++ b/src/metabase/models/native_query_snippet.clj
@@ -2,7 +2,9 @@
   (:require [metabase.models.collection :as collection]
             [metabase.models.interface :as mi]
             [metabase.models.native-query-snippet.permissions :as snippet.perms]
+            [metabase.models.serialization.base :as serdes.base]
             [metabase.models.serialization.hash :as serdes.hash]
+            [metabase.models.serialization.util :as serdes.util]
             [metabase.util :as u]
             [metabase.util.i18n :refer [deferred-tru tru]]
             [metabase.util.schema :as su]
@@ -63,3 +65,40 @@
             (complement #(boolean (re-find #"^\s+" %)))
             (complement #(boolean (re-find #"}" %)))))
    (deferred-tru "snippet names cannot include '}' or start with spaces")))
+
+;;; ------------------------------------------------- Serialization --------------------------------------------------
+
+(defmethod serdes.base/extract-query "NativeQuerySnippet" [_ {:keys [user]}]
+  ;; TODO This join over the subset of collections this user can see is shared by a few things - factor it out?
+  (serdes.base/raw-reducible-query
+    "NativeQuerySnippet"
+    {:select     [:snippet.*]
+     :from       [[:native_query_snippet :snippet]]
+     :left-join  [[:collection :coll] [:= :coll.id :snippet.collection_id]]
+     :where      (if user
+                   ;; :snippet.collection_id is nullable, but this is a left join, so it works out neatly:
+                   ;; if this snippet has no collection, :coll.personal_owner_id is effectively NULL.
+                   [:or [:= :coll.personal_owner_id user] [:is :coll.personal_owner_id nil]]
+                   [:is :coll.personal_owner_id nil])}))
+
+(defmethod serdes.base/serdes-generate-path "NativeQuerySnippet" [_ snippet]
+  [(assoc (serdes.base/infer-self-path "NativeQuerySnippet" snippet)
+          :label (:name snippet))])
+
+(defmethod serdes.base/extract-one "NativeQuerySnippet"
+  [_ _ snippet]
+  (-> (serdes.base/extract-one-basics "NativeQuerySnippet" snippet)
+      (update :creator_id serdes.util/export-fk-keyed 'User :email)
+      (update :collection_id #(when % (serdes.util/export-fk % 'Collection)))))
+
+(defmethod serdes.base/load-xform "NativeQuerySnippet" [snippet]
+  (-> snippet
+      serdes.base/load-xform-basics
+      (update :creator_id serdes.util/import-fk-keyed 'User :email)
+      (update :collection_id #(when % (serdes.util/import-fk % 'Collection)))))
+
+(defmethod serdes.base/serdes-dependencies "NativeQuerySnippet"
+  [{:keys [collection_id]}]
+  (if collection_id
+    [[{:model "Collection" :id collection_id}]]
+    []))

--- a/src/metabase/models/serialization/base.clj
+++ b/src/metabase/models/serialization/base.clj
@@ -221,6 +221,7 @@
   - Convert to a vanilla Clojure map.
   - Add `:serdes/meta` by calling [[serdes-generate-path]].
   - Drop the primary key.
+  - Drop :created_at and :updated_at.
 
   Returns the Clojure map."
   [model-name entity]
@@ -228,7 +229,7 @@
         pk    (models/primary-key model)]
     (-> entity
         (assoc :serdes/meta (serdes-generate-path model-name entity))
-        (dissoc pk))))
+        (dissoc pk :created_at :updated_at))))
 
 (defmethod extract-one :default [model-name _opts entity]
   (extract-one-basics model-name entity))

--- a/src/metabase/models/serialization/base.clj
+++ b/src/metabase/models/serialization/base.clj
@@ -222,9 +222,9 @@
   LocalDateTime is treated as already being in UTC."
   [t]
   (cond
-    (instance? LocalDateTime  t) (.atZone            t (ZoneId/of "UTC"))
-    (instance? OffsetDateTime t) (.atZoneSameInstant t (ZoneId/of "UTC"))
-    (instance? Instant        t) (.atZone            t (ZoneId/of "UTC"))
+    (instance? LocalDateTime  t) (.atZone            ^LocalDateTime  t (ZoneId/of "UTC"))
+    (instance? OffsetDateTime t) (.atZoneSameInstant ^OffsetDateTime t (ZoneId/of "UTC"))
+    (instance? Instant        t) (.atZone            ^Instant        t (ZoneId/of "UTC"))
     :else                        t))
 
 (defn extract-one-basics

--- a/test/metabase/test/generate.clj
+++ b/test/metabase/test/generate.clj
@@ -275,6 +275,10 @@
     (= :field ent-type)
     (update :name unique-name)
 
+    ;; [Field ID, Dimension name] pairs need to be unique. This enforces it, and appends junk to names if needed.
+    (= :dimension ent-type)
+    (update :name unique-name)
+
     (and (:description visit-val) (coin-toss 0.2))
     (dissoc :description)))
 


### PR DESCRIPTION
This adds serdes for NativeQuerySnippet.

It also required massaging the `:created_at` and `:updated_at` timestamps for
consistency - they are all transformed to `ZonedDateTime` values during
extraction.

At load time, the JDBC driver can transform these into the right type for the
column.

