### PR TITLE
Make collection dashboard question buttons consistent

### DIFF
--- a/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.styled.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.styled.tsx
@@ -34,8 +34,9 @@ interface CollectionHeaderButtonProps {
 export const CollectionHeaderButton = styled(
   Button,
 )<CollectionHeaderButtonProps>`
-  padding: 0.5rem 0.75rem;
-  height: 2.5rem;
+  padding: 0.25rem 0.5rem;
+  height: 2rem;
+  width: 2rem;
 
   &:hover {
     color: ${color("brand")};

--- a/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.styled.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.styled.tsx
@@ -21,10 +21,7 @@ export const HeaderActions = styled.div`
   display: flex;
   margin-top: 0.5rem;
   align-self: start;
-
-  ${Button.Root} {
-    margin-left: 0.5rem;
-  }
+  gap: 0.5rem;
 `;
 
 interface CollectionHeaderButtonProps {

--- a/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.styled.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.styled.tsx
@@ -21,6 +21,10 @@ export const HeaderActions = styled.div`
   display: flex;
   margin-top: 0.5rem;
   align-self: start;
+
+  ${Button.Root} {
+    margin-left: 0.5rem;
+  }
 `;
 
 interface CollectionHeaderButtonProps {

--- a/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.styled.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.styled.tsx
@@ -37,6 +37,10 @@ export const CollectionHeaderButton = styled(
     color: ${color("brand")};
     background-color: ${color("bg-medium")};
   }
+
+  ${Button.Content} {
+    height: 100%;
+  }
 `;
 
 CollectionHeaderButton.defaultProps = {

--- a/frontend/src/metabase/core/components/BookmarkToggle/BookmarkToggle.tsx
+++ b/frontend/src/metabase/core/components/BookmarkToggle/BookmarkToggle.tsx
@@ -50,7 +50,7 @@ const BookmarkToggle = forwardRef(function BookmarkToggle(
       >
         <BookmarkIcon
           name="bookmark"
-          size={20}
+          size={16}
           isBookmarked={isBookmarked}
           isAnimating={isAnimating}
           onAnimationEnd={handleAnimationEnd}

--- a/frontend/src/metabase/dashboard/components/RefreshWidget.jsx
+++ b/frontend/src/metabase/dashboard/components/RefreshWidget.jsx
@@ -58,7 +58,7 @@ export default class RefreshWidget extends Component {
           elapsed == null ? (
             <Tooltip tooltip={t`Auto-refresh`}>
               <DashboardHeaderButton>
-                <ClockIcon width={18} height={18} className={className} />
+                <ClockIcon width={16} height={16} className={className} />
               </DashboardHeaderButton>
             </Tooltip>
           ) : (

--- a/frontend/src/metabase/dashboard/containers/DashboardHeader.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardHeader.jsx
@@ -20,6 +20,7 @@ import { getDashboardActions } from "metabase/dashboard/components/DashboardActi
 import {
   DashboardHeaderButton,
   DashboardHeaderActionDivider,
+  DashboardHeaderButtonContainer,
 } from "./DashboardHeader.styled";
 
 import ParametersPopover from "metabase/dashboard/components/ParametersPopover";
@@ -32,8 +33,6 @@ import {
 
 import Header from "../components/DashboardHeader";
 import { SIDEBAR_NAME } from "../constants";
-
-import cx from "classnames";
 
 const mapStateToProps = (state, props) => {
   return {
@@ -255,17 +254,12 @@ class DashboardHeader extends Component {
           >
             <div>
               <Tooltip tooltip={t`Add a filter`}>
-                <a
+                <DashboardHeaderButton
                   key="parameters"
-                  className={cx("text-brand-hover", {
-                    "text-brand": isAddParameterPopoverOpen,
-                  })}
                   onClick={showAddParameterPopover}
                 >
-                  <DashboardHeaderButton>
-                    <Icon name="filter" />
-                  </DashboardHeaderButton>
-                </a>
+                  <Icon name="filter" />
+                </DashboardHeaderButton>
               </Tooltip>
             </div>
           </TippyPopover>
@@ -350,12 +344,13 @@ class DashboardHeader extends Component {
               }
             />
           </Tooltip>,
-          <EntityMenu
-            key="dashboard-action-menu-button"
-            items={extraButtons}
-            triggerIcon="ellipsis"
-            tooltip={t`Move, archive, and more...`}
-          />,
+          <DashboardHeaderButtonContainer key="dashboard-action-menu-button">
+            <EntityMenu
+              items={extraButtons}
+              triggerIcon="ellipsis"
+              tooltip={t`Move, archive, and more...`}
+            />
+          </DashboardHeaderButtonContainer>,
         ],
       );
     }

--- a/frontend/src/metabase/dashboard/containers/DashboardHeader.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardHeader.jsx
@@ -20,7 +20,6 @@ import { getDashboardActions } from "metabase/dashboard/components/DashboardActi
 import {
   DashboardHeaderButton,
   DashboardHeaderActionDivider,
-  DashboardHeaderButtonContainer,
 } from "./DashboardHeader.styled";
 
 import ParametersPopover from "metabase/dashboard/components/ParametersPopover";
@@ -344,13 +343,12 @@ class DashboardHeader extends Component {
               }
             />
           </Tooltip>,
-          <DashboardHeaderButtonContainer key="dashboard-action-menu-button">
-            <EntityMenu
-              items={extraButtons}
-              triggerIcon="ellipsis"
-              tooltip={t`Move, archive, and more...`}
-            />
-          </DashboardHeaderButtonContainer>,
+          <EntityMenu
+            key="dashboard-action-menu-button"
+            items={extraButtons}
+            triggerIcon="ellipsis"
+            tooltip={t`Move, archive, and more...`}
+          />,
         ],
       );
     }

--- a/frontend/src/metabase/dashboard/containers/DashboardHeader.styled.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardHeader.styled.jsx
@@ -12,6 +12,7 @@ export const DashboardHeaderActionDivider = styled.div`
 `;
 
 export const DashboardHeaderButton = styled(Button)`
+  margin-left: 0.5rem;
   padding: 0.25rem 0.5rem;
   height: 2rem;
   width: 2rem;
@@ -31,3 +32,9 @@ DashboardHeaderButton.defaultProps = {
   onlyIcon: true,
   iconSize: 16,
 };
+
+export const DashboardHeaderButtonContainer = styled.div`
+  ${Button.Root} {
+    margin-left: 0.5rem;
+  }
+`;

--- a/frontend/src/metabase/dashboard/containers/DashboardHeader.styled.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardHeader.styled.jsx
@@ -12,7 +12,6 @@ export const DashboardHeaderActionDivider = styled.div`
 `;
 
 export const DashboardHeaderButton = styled(Button)`
-  margin-left: 0.5rem;
   padding: 0.25rem 0.5rem;
   height: 2rem;
   width: 2rem;
@@ -32,9 +31,3 @@ DashboardHeaderButton.defaultProps = {
   onlyIcon: true,
   iconSize: 16,
 };
-
-export const DashboardHeaderButtonContainer = styled.div`
-  ${Button.Root} {
-    margin-left: 0.5rem;
-  }
-`;

--- a/frontend/src/metabase/dashboard/containers/DashboardHeader.styled.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardHeader.styled.jsx
@@ -5,8 +5,8 @@ import Button from "metabase/core/components/Button";
 
 export const DashboardHeaderActionDivider = styled.div`
   height: 1.25rem;
-  padding-left: 0.75rem;
-  margin-left: 0.75rem;
+  padding-left: 0.5rem;
+  margin-left: 0.5rem;
   width: 0px;
   border-left: 1px solid ${color("border-dark")};
 `;

--- a/frontend/src/metabase/query_builder/components/QuestionActions.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/QuestionActions.styled.tsx
@@ -4,8 +4,8 @@ import DatasetMetadataStrengthIndicator from "./view/sidebars/DatasetManagementS
 
 export const QuestionActionsDivider = styled.div`
   border-left: 1px solid ${color("border-dark")};
-  margin-left: 1rem;
-  padding-left: 0.5rem;
+  margin-left: 0.5rem;
+  margin-right: 0.5rem;
   height: 1.25rem;
 `;
 

--- a/frontend/src/metabase/query_builder/components/QuestionActions.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/QuestionActions.styled.tsx
@@ -1,14 +1,6 @@
 import styled from "@emotion/styled";
-import { css } from "@emotion/react";
 import { color } from "metabase/lib/colors";
-import Button from "metabase/core/components/Button";
-import EntityMenu from "metabase/components/EntityMenu";
 import DatasetMetadataStrengthIndicator from "./view/sidebars/DatasetManagementSection/DatasetMetadataStrengthIndicator";
-
-import {
-  shrinkOrExpandOnClick,
-  shrinkOrExpandDuration,
-} from "metabase/styled-components/theme/button";
 
 export const QuestionActionsDivider = styled.div`
   border-left: 1px solid ${color("border-dark")};
@@ -20,33 +12,4 @@ export const QuestionActionsDivider = styled.div`
 export const StrengthIndicator = styled(DatasetMetadataStrengthIndicator)`
   float: none;
   margin-left: 3.5rem;
-`;
-
-export type AnimationStates = "expand" | "shrink" | null;
-
-interface BookmarkButtonProps {
-  animation: AnimationStates;
-  isBookmarked: boolean;
-}
-
-export const BookmarkButton = styled(Button)<BookmarkButtonProps>`
-  ${shrinkOrExpandOnClick}
-
-  ${props =>
-    props.animation === "expand" &&
-    css`
-      animation: expand linear ${shrinkOrExpandDuration};
-    `}
-
-  ${props =>
-    props.animation === "shrink" &&
-    css`
-      animation: shrink linear ${shrinkOrExpandDuration};
-    `}
-
-      &:hover {
-        color: ${props =>
-          props.isBookmarked ? color("brand") : color("text-dark")};
-      }
-  }
 `;

--- a/frontend/src/metabase/query_builder/components/QuestionActions.tsx
+++ b/frontend/src/metabase/query_builder/components/QuestionActions.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback } from "react";
 import { t } from "ttag";
 import { connect } from "react-redux";
 
@@ -24,10 +24,10 @@ import Question from "metabase-lib/lib/Question";
 
 import {
   QuestionActionsDivider,
-  BookmarkButton,
-  AnimationStates,
   StrengthIndicator,
 } from "./QuestionActions.styled";
+import BookmarkToggle from "metabase/core/components/BookmarkToggle";
+import { ViewHeaderIconButtonContainer } from "./view/ViewHeader.styled";
 
 const HEADER_ICON_SIZE = 16;
 
@@ -76,13 +76,6 @@ const QuestionActions = ({
   isModerator,
   softReloadCard,
 }: Props) => {
-  const [animation, setAnimation] = useState<AnimationStates>(null);
-
-  const handleClickBookmark = () => {
-    handleBookmark();
-    setAnimation(isBookmarked ? "shrink" : "expand");
-  };
-  const bookmarkButtonColor = isBookmarked ? color("brand") : undefined;
   const bookmarkTooltip = isBookmarked ? t`Remove from bookmarks` : t`Bookmark`;
 
   const infoButtonColor = isShowingQuestionInfoSidebar
@@ -203,25 +196,23 @@ const QuestionActions = ({
     <>
       <QuestionActionsDivider />
       <Tooltip tooltip={bookmarkTooltip}>
-        <BookmarkButton
-          animation={animation}
+        <BookmarkToggle
+          onCreateBookmark={handleBookmark}
+          onDeleteBookmark={handleBookmark}
           isBookmarked={isBookmarked}
-          onlyIcon
-          icon="bookmark"
-          iconSize={HEADER_ICON_SIZE}
-          onClick={handleClickBookmark}
-          color={bookmarkButtonColor}
         />
       </Tooltip>
       <Tooltip tooltip={t`More info`}>
-        <Button
-          onlyIcon
-          icon="info"
-          iconSize={HEADER_ICON_SIZE}
-          onClick={onInfoClick}
-          color={infoButtonColor}
-          data-testId="qb-header-info-button"
-        />
+        <ViewHeaderIconButtonContainer>
+          <Button
+            onlyIcon
+            icon="info"
+            iconSize={HEADER_ICON_SIZE}
+            onClick={onInfoClick}
+            color={infoButtonColor}
+            data-testId="qb-header-info-button"
+          />
+        </ViewHeaderIconButtonContainer>
       </Tooltip>
       <EntityMenu
         items={extraButtons}

--- a/frontend/src/metabase/query_builder/components/view/NativeQueryButton.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/view/NativeQueryButton.styled.jsx
@@ -10,7 +10,6 @@ import {
 import Button from "metabase/core/components/Button";
 
 export const SqlIconButton = styled(Button)`
-  margin-left: ${space(2)};
   padding: ${space(1)};
   border: none;
   background-color: transparent;

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -436,14 +436,13 @@ function ViewTitleHeaderRightSide(props) {
           primary
           icon="add"
           onClick={() => onOpenModal(MODAL_TYPES.INSERT_ROW)}
-          ml={1}
         >
           {t`New row`}
         </Button>
       )}
       {QuestionFilterWidget.shouldRender(props) && (
         <QuestionFilterWidget
-          className="hide sm-show ml1"
+          className="hide sm-show"
           isShowingFilterSidebar={isShowingFilterSidebar}
           onAddFilter={onAddFilter}
           onOpenModal={onOpenModal}
@@ -453,7 +452,6 @@ function ViewTitleHeaderRightSide(props) {
       {QuestionSummarizeWidget.shouldRender(props) && (
         <QuestionSummarizeWidget
           className="hide sm-show"
-          ml={1}
           isShowingSummarySidebar={isShowingSummarySidebar}
           onEditSummary={onEditSummary}
           onCloseSummary={onCloseSummary}
@@ -464,7 +462,6 @@ function ViewTitleHeaderRightSide(props) {
         <ViewHeaderIconButtonContainer>
           <QuestionNotebookButton
             iconSize={16}
-            ml={2}
             question={question}
             isShowingNotebook={isShowingNotebook}
             setQueryBuilderMode={setQueryBuilderMode}
@@ -486,17 +483,15 @@ function ViewTitleHeaderRightSide(props) {
         </ViewHeaderIconButtonContainer>
       )}
       {hasExploreResultsLink && <ExploreResultsLink question={question} />}
-      {hasRunButton && (
+      {hasRunButton && !isShowingNotebook && (
         <ViewHeaderIconButtonContainer>
           <RunButtonWithTooltip
             className={cx("text-brand-hover text-dark", {
-              hide: isShowingNotebook,
               "text-white-hover": isResultDirty,
             })}
             iconSize={16}
             onlyIcon
             medium
-            ml={1}
             compact
             result={result}
             isRunning={isRunning}

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -48,6 +48,7 @@ import {
   AdHocLeftSideRoot,
   HeaderDivider,
   ViewHeaderActionPanel,
+  ViewHeaderIconButtonContainer,
 } from "./ViewHeader.styled";
 
 const viewTitleHeaderPropTypes = {
@@ -460,43 +461,51 @@ function ViewTitleHeaderRightSide(props) {
         />
       )}
       {QuestionNotebookButton.shouldRender(props) && (
-        <QuestionNotebookButton
-          ml={2}
-          question={question}
-          isShowingNotebook={isShowingNotebook}
-          setQueryBuilderMode={setQueryBuilderMode}
-          data-metabase-event={
-            isShowingNotebook
-              ? `Notebook Mode;Go to View Mode`
-              : `View Mode; Go to Notebook Mode`
-          }
-        />
+        <ViewHeaderIconButtonContainer>
+          <QuestionNotebookButton
+            iconSize={16}
+            ml={2}
+            question={question}
+            isShowingNotebook={isShowingNotebook}
+            setQueryBuilderMode={setQueryBuilderMode}
+            data-metabase-event={
+              isShowingNotebook
+                ? `Notebook Mode;Go to View Mode`
+                : `View Mode; Go to Notebook Mode`
+            }
+          />
+        </ViewHeaderIconButtonContainer>
       )}
       {NativeQueryButton.shouldRender(props) && (
-        <NativeQueryButton
-          size={16}
-          question={question}
-          data-metabase-event="Notebook Mode; Convert to SQL Click"
-        />
+        <ViewHeaderIconButtonContainer>
+          <NativeQueryButton
+            size={16}
+            question={question}
+            data-metabase-event="Notebook Mode; Convert to SQL Click"
+          />
+        </ViewHeaderIconButtonContainer>
       )}
       {hasExploreResultsLink && <ExploreResultsLink question={question} />}
       {hasRunButton && (
-        <RunButtonWithTooltip
-          className={cx("text-brand-hover text-dark", {
-            hide: isShowingNotebook,
-            "text-white-hover": isResultDirty,
-          })}
-          medium
-          borderless
-          ml={1}
-          compact
-          result={result}
-          isRunning={isRunning}
-          isDirty={isResultDirty}
-          isPreviewing={isPreviewing}
-          onRun={() => runQuestionQuery({ ignoreCache: true })}
-          onCancel={cancelQuery}
-        />
+        <ViewHeaderIconButtonContainer>
+          <RunButtonWithTooltip
+            className={cx("text-brand-hover text-dark", {
+              hide: isShowingNotebook,
+              "text-white-hover": isResultDirty,
+            })}
+            iconSize={16}
+            onlyIcon
+            medium
+            ml={1}
+            compact
+            result={result}
+            isRunning={isRunning}
+            isDirty={isResultDirty}
+            isPreviewing={isPreviewing}
+            onRun={() => runQuestionQuery({ ignoreCache: true })}
+            onCancel={cancelQuery}
+          />
+        </ViewHeaderIconButtonContainer>
       )}
       {isSaved && (
         <QuestionActions

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.styled.jsx
@@ -205,8 +205,9 @@ export const ViewHeaderActionPanel = styled.div`
 
 export const ViewHeaderIconButtonContainer = styled.div`
   ${Button.Root} {
-    padding: 0.5rem 0.75rem;
-    height: 2.5rem;
+    padding: 0.25rem 0.5rem;
+    height: 2rem;
+    width: 2rem;
 
     &:hover {
       color: ${color("brand")};

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.styled.jsx
@@ -202,3 +202,15 @@ export const ViewHeaderActionPanel = styled.div`
     margin-left: 0.5rem;
   }
 `;
+
+export const ViewHeaderIconButtonContainer = styled.div`
+  ${Button.Root} {
+    padding: 0.5rem 0.75rem;
+    height: 2.5rem;
+
+    &:hover {
+      color: ${color("brand")};
+      background-color: ${color("bg-medium")};
+    }
+  }
+`;

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.styled.jsx
@@ -188,6 +188,7 @@ export const ViewHeaderActionPanel = styled.div`
   display: flex;
   align-items: center;
   margin-left: auto;
+  gap: 0.5rem;
 
   ${breakpointMaxSmall} {
     margin-left: 0;
@@ -196,10 +197,6 @@ export const ViewHeaderActionPanel = styled.div`
     border-top: 1px solid ${color("border")};
     margin-top: 1rem;
     padding: 0.5rem 2.5rem 0 2rem;
-  }
-
-  ${Button.Root} {
-    margin-left: 0.5rem;
   }
 `;
 


### PR DESCRIPTION
Epic #22826
Task: https://www.notion.so/metabase/Inconsistent-hover-effects-on-action-buttons-5e619a2f52e04765872e82f424260bdd

#### Note
- This is a follow-up work from https://github.com/metabase/metabase/pull/23833
- After https://github.com/metabase/metabase/pull/23833 is merged, this PR should change the base branch back to `master` now it's based on that PR to accommodate the PR review.

This PR:
- Change collection, dashboard, and question header [button icon size to `16px`](https://metaboat.slack.com/archives/C03E8MQJZBM/p1657818022315299?thread_ts=1657814825.802049&cid=C03E8MQJZBM)
- Make them all have a margin of `0.5rem`
- Make them have the same hover effect (background color, text color)