### PR TITLE
Run GHA on backported PRs

### DIFF
--- a/.github/workflows/auto-backport.yml
+++ b/.github/workflows/auto-backport.yml
@@ -12,6 +12,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.METABASE_BOT_APP_ID }}
+          private_key: ${{ secrets.METABASE_BOT_APP_PRIVATE_KEY }}
+
       - uses: ./.github/actions/find-squashed-commit
         name: Find commit
         id: find_commit
@@ -25,8 +31,8 @@ jobs:
 
       - id: create_backport_pull_request
         run: |
-          git config --global user.email "metabase-github-automation@metabase.com"
-          git config --global user.name "$GITHUB_ACTOR"
+          git config --global user.email "metabase-bot@metabase.com"
+          git config --global user.name "Metabase bot"
 
           BACKPORT_BRANCH="backport-$COMMIT"
 
@@ -54,7 +60,7 @@ jobs:
           TARGET_BRANCH: ${{ steps.get_latest_release_branch.outputs.branch-name }}
           ORIGINAL_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
           ORIGINAL_TITLE: ${{ github.event.pull_request.title }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           COMMIT: ${{ steps.find_commit.outputs.commit }}
 
       - uses: ./.github/actions/notify-pull-request

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -23,6 +23,11 @@ jobs:
               echo User ${{ github.event.comment.user.login }} is not a member of Metabase organization
               exit 1
           fi
+      - uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.METABASE_BOT_APP_ID }}
+          private_key: ${{ secrets.METABASE_BOT_APP_PRIVATE_KEY }}
       - uses: actions/github-script@v4
         id: branch_info
         with:
@@ -80,8 +85,8 @@ jobs:
         with:
           fetch-depth: 0
       - run: |
-          git config --global user.email "metabase-github-automation@metabase.com"
-          git config --global user.name "$GITHUB_ACTOR"
+          git config --global user.email "metabase-bot@metabase.com"
+          git config --global user.name "Metabase bot"
 
           git fetch --all
 
@@ -120,7 +125,7 @@ jobs:
           BACKPORT_BRANCH: ${{ fromJson(steps.branch_info.outputs.result).backportBranch }}
           START_SHA: ${{ fromJson(steps.branch_info.outputs.result).startSha }}
           END_SHA: ${{ fromJson(steps.branch_info.outputs.result).endSha }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
 
   notify_when_failed:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
[Slack conversation](https://metaboat.slack.com/archives/C5XHN8GLW/p1657801028882719?thread_ts=1657728520.371129&cid=C5XHN8GLW)

## Changes

By design PRs greated by github-actions user cannot trigger Github Actions, otherwise it would be possible to have infinite loops of jobs. Hence, we need to use any other credentials to create backport PRs. I updates the workflows to use our own newly created "Metabase Bot" Github Application for that.

## How to verify

You can try to recreate everything on your fork or take a look at [this PR](https://github.com/alxnddr/metabase/pull/102) in my fork.

