### PR TITLE
[E2E] Generate Mochawesome reports from within a Cypress runner

### DIFF
--- a/.github/workflows/e2e-main.yml
+++ b/.github/workflows/e2e-main.yml
@@ -148,10 +148,6 @@ jobs:
       env:
         TERM: xterm
 
-    - name: Generate Mochawesome Reports
-      if: failure()
-      run: yarn generate-cypress-html-report
-
     - name: Upload Cypress Artifacts upon failure
       uses: actions/upload-artifact@v2
       if: failure()

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -154,10 +154,6 @@ jobs:
       env:
         TERM: xterm
 
-    - name: Generate Mochawesome Reports
-      if: failure()
-      run: yarn generate-cypress-html-report
-
     - name: Upload Cypress Artifacts upon failure
       uses: actions/upload-artifact@v2
       if: failure()

--- a/frontend/test/__runner__/cypress-runner-run-tests.js
+++ b/frontend/test/__runner__/cypress-runner-run-tests.js
@@ -72,7 +72,7 @@ const runCypress = async (baseUrl, exitFunction) => {
       ? await cypress.open(finalConfig)
       : await cypress.run(finalConfig);
 
-    // At least one test failed, so let's generate a HTML report to helps us find what went wrong
+    // At least one test failed, so let's generate HTML report that helps us determine what went wrong
     if (totalFailed > 0) {
       await executeYarnCommand({
         command: "yarn run generate-cypress-html-report",

--- a/frontend/test/__runner__/cypress-runner-run-tests.js
+++ b/frontend/test/__runner__/cypress-runner-run-tests.js
@@ -2,6 +2,8 @@ const { patch } = require("cy2");
 const cypress = require("cypress");
 const arg = require("arg");
 
+const { executeYarnCommand } = require("./cypress-runner-utils");
+
 const args = arg(
   {
     "--folder": String, // The name of the folder to run files from
@@ -35,6 +37,11 @@ const getSourceFolder = folder => {
 };
 
 const runCypress = async (baseUrl, exitFunction) => {
+  await executeYarnCommand({
+    command: "yarn run clean-cypress-artifacts",
+    message: "Removing the existing Cypress artifacts\n",
+  });
+
   /**
    * We need to patch CYPRESS_API_URL with cy2 in order to use currents.dev dashboard for recording.
    * This is applicable only when you explicitly use the `--record` flag, with the provided `--key`.
@@ -65,8 +72,13 @@ const runCypress = async (baseUrl, exitFunction) => {
       ? await cypress.open(finalConfig)
       : await cypress.run(finalConfig);
 
-    // At least one test failed
+    // At least one test failed, so let's generate a HTML report to helps us find what went wrong
     if (totalFailed > 0) {
+      await executeYarnCommand({
+        command: "yarn run generate-cypress-html-report",
+        message: "Generating Mochawesome HTML report\n",
+      });
+
       await exitFunction(1);
     }
 

--- a/frontend/test/__runner__/cypress-runner-utils.js
+++ b/frontend/test/__runner__/cypress-runner-utils.js
@@ -1,5 +1,6 @@
 const fs = require("fs");
 const chalk = require("chalk");
+const { exec } = require("child_process");
 
 function printBold(message) {
   console.log(chalk.bold(message));
@@ -24,4 +25,27 @@ const readFile = fileName => {
   });
 };
 
-module.exports = { printBold, printYellow, printCyan, readFile };
+function executeYarnCommand({ command, message } = {}) {
+  return new Promise((resolve, reject) => {
+    exec(command, (error, stdout, stderr) => {
+      if (error) {
+        console.error(stderr);
+
+        reject(error);
+        return;
+      }
+
+      printBold(message);
+
+      resolve(stdout);
+    });
+  });
+}
+
+module.exports = {
+  printBold,
+  printYellow,
+  printCyan,
+  readFile,
+  executeYarnCommand,
+};


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Refactors the code and the logic behind how we generate Mochawesome reports for Cypress
- It builds on top of the work that @diogormendes started in https://github.com/metabase/metabase/pull/23603
- Rather than triggering the report generation inside a workflow, we now do it on a "lower level", just immediately after Cypress finishes the run and reports a failing test
- It prevents errors when the workflow (not Cypress) fails for whatever reason and then it tries to generate Mochawesome report with non-existing JSON partials
    - See [this comment](https://github.com/metabase/metabase/pull/23603/files#r911405444) for more details
- Simply running Cypress as we've always done locally will now [automatically delete previous report and all artifacts](https://github.com/metabase/metabase/pull/21727#discussion_r872566238)

### How to test
- Everything should still work exactly the same in CI and there should be Mochawesome report included in E2E artifacts
- Run any spec locally with `yarn test-cypress-run --spec ${spec}` and keep an eye on a few things:
    - If you had any previous artifacts, they should be deleted before Cypress main process starts
    ```
    Starting Cypress
    Removing the existing Cypress artifacts
    ```
    - If all tests pass, you shouldn't see reports being generated
    - If at least one test fails, Mochawesome report should be generated and you will see it in the folder strutcture

Example with intentionally failing spec
![image](https://user-images.githubusercontent.com/31325167/179072355-269af853-b98e-41b6-bd8c-b18cfa04b59b.png)
