### PR TITLE
fix redirect url after login

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/auth/middleware/session-middleware.js
+++ b/enterprise/frontend/src/metabase-enterprise/auth/middleware/session-middleware.js
@@ -35,8 +35,9 @@ export const createSessionMiddleware = (
           wasLoggedIn = isLoggedIn;
 
           if (isLoggedIn) {
-            await store.dispatch(refreshSession());
+            // get the redirect url before refreshing the session because after the refresh the url will be reset
             const redirectUrl = getRedirectUrl();
+            await store.dispatch(refreshSession());
 
             if (redirectUrl !== null) {
               store.dispatch(replace(redirectUrl));


### PR DESCRIPTION
## Changes

While fixing other bugs before merging the session timeout PR this tiny bug was introduced. When we automatically login in background tabs, we need to read the `redirect` parameter before refreshing the session because after the refresh user will be redirected to the home page and there won't be the `redirect` parameter anymore

## How to verify

- Run Metabase EE
- Go to [Auth settings](http://localhost:3000/admin/settings/authentication)
- Enable the session timeout with any value
- Open one tab with a dashboard, open another one with anything
- Logout from the second tab
- Ensure both tabs are on the login page
- Login in the second tab
- Ensure the first tab shows the dashboard that was open before logout