### PR TITLE
Move ddl namespaces under driver package

### DIFF
--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -12,7 +12,7 @@
             [metabase.db.spec :as mdb.spec]
             [metabase.driver :as driver]
             [metabase.driver.common :as driver.common]
-            [metabase.driver.ddl.mysql :as ddl.mysql]
+            [metabase.driver.mysql.ddl :as mysql.ddl]
             [metabase.driver.sql-jdbc.common :as sql-jdbc.common]
             [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
             [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
@@ -31,7 +31,7 @@
            [java.time LocalDateTime OffsetDateTime OffsetTime ZonedDateTime]
            metabase.util.honeysql_extensions.Identifier))
 (comment
-  ddl.mysql/keep-me)
+  mysql.ddl/keep-me)
 
 (driver/register! :mysql, :parent :sql-jdbc)
 

--- a/src/metabase/driver/mysql/ddl.clj
+++ b/src/metabase/driver/mysql/ddl.clj
@@ -1,12 +1,12 @@
-(ns metabase.driver.ddl.mysql
+(ns metabase.driver.mysql.ddl
   (:require [clojure.core.async :as a]
             [clojure.java.jdbc :as jdbc]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
             [java-time :as t]
             [metabase.driver.ddl.interface :as ddl.i]
-            [metabase.driver.ddl.sql :as ddl.sql]
             [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
+            [metabase.driver.sql.ddl :as sql.ddl]
             [metabase.public-settings :as public-settings]
             [metabase.query-processor :as qp]
             [metabase.util.i18n :refer [trs]])
@@ -16,9 +16,9 @@
   (a/thread
     (jdbc/with-db-connection [conn db-spec]
       (try
-        (let [pid (:pid (first (ddl.sql/jdbc-query conn ["select connection_id() pid"])))]
+        (let [pid (:pid (first (sql.ddl/jdbc-query conn ["select connection_id() pid"])))]
           (a/put! conn-chan pid)
-          (ddl.sql/jdbc-query conn sql+params))
+          (sql.ddl/jdbc-query conn sql+params))
         (catch SQLNonTransientConnectionException _e
           ;; Our connection may be killed due to timeout, `kill` will throw an appropriate exception
           nil)
@@ -28,14 +28,14 @@
     true))
 
 (defn- kill [conn pid]
-  (let [results (ddl.sql/jdbc-query conn ["show processlist"])
+  (let [results (sql.ddl/jdbc-query conn ["show processlist"])
         result? (some (fn [r]
                         (and (= (:id r) pid)
                           (str/starts-with? (or (:info r) "") "-- Metabase")))
                       results)]
     (when result?
       ;; Can't use a prepared parameter with these statements
-      (ddl.sql/execute! conn [(str "kill " pid)])
+      (sql.ddl/execute! conn [(str "kill " pid)])
       (throw (Exception. (trs "Killed mysql process id {0} due to timeout." pid))))))
 
 (defn- execute-with-timeout!
@@ -57,20 +57,20 @@
   (let [{:keys [query params]} (qp/compile dataset-query)
         db-spec (sql-jdbc.conn/db->pooled-connection-spec database)]
     (jdbc/with-db-connection [conn db-spec]
-      (ddl.sql/execute! conn [(ddl.sql/drop-table-sql database (:table-name definition))])
+      (sql.ddl/execute! conn [(sql.ddl/drop-table-sql database (:table-name definition))])
       ;; It is possible that this fails and rollback would not restore the table.
       ;; That is ok, the persisted-info will be marked inactive and the next refresh will try again.
       (execute-with-timeout! conn
                              db-spec
                              (.toMillis (t/minutes 10))
-                             (into [(ddl.sql/create-table-sql database definition query)] params))
+                             (into [(sql.ddl/create-table-sql database definition query)] params))
       {:state :success})))
 
 (defmethod ddl.i/unpersist! :mysql
   [_driver database persisted-info]
   (jdbc/with-db-connection [conn (sql-jdbc.conn/db->pooled-connection-spec database)]
     (try
-      (ddl.sql/execute! conn [(ddl.sql/drop-table-sql database (:table_name persisted-info))])
+      (sql.ddl/execute! conn [(sql.ddl/drop-table-sql database (:table_name persisted-info))])
       (catch Exception e
         (log/warn e)
         (throw e)))))
@@ -83,34 +83,34 @@
         steps [[:persist.check/create-schema
                 (fn check-schema [conn]
                   (let [existing-schemas (->> ["select schema_name from information_schema.schemata"]
-                                              (ddl.sql/jdbc-query conn)
+                                              (sql.ddl/jdbc-query conn)
                                               (map :schema_name)
                                               (into #{}))]
                     (or (contains? existing-schemas schema-name)
-                      (ddl.sql/execute! conn [(ddl.sql/create-schema-sql database)]))))
+                      (sql.ddl/execute! conn [(sql.ddl/create-schema-sql database)]))))
                 (fn undo-check-schema [conn]
-                  (ddl.sql/execute! conn [(ddl.sql/drop-schema-sql database)]))]
+                  (sql.ddl/execute! conn [(sql.ddl/drop-schema-sql database)]))]
                [:persist.check/create-table
                 (fn create-table [conn]
                   (execute-with-timeout! conn
                                          db-spec
                                          (.toMillis (t/minutes 10))
-                                         [(ddl.sql/create-table-sql
+                                         [(sql.ddl/create-table-sql
                                             database
                                             {:table-name table-name
                                              :field-definitions [{:field-name "field"
                                                                   :base-type :type/Text}]}
                                             "values (1)")]))
                 (fn undo-create-table [conn]
-                  (ddl.sql/execute! conn [(ddl.sql/drop-table-sql database table-name)]))]
+                  (sql.ddl/execute! conn [(sql.ddl/drop-table-sql database table-name)]))]
                [:persist.check/read-table
                 (fn read-table [conn]
-                  (ddl.sql/jdbc-query conn [(format "select * from %s.%s"
+                  (sql.ddl/jdbc-query conn [(format "select * from %s.%s"
                                                     schema-name table-name)]))
                 (constantly nil)]
                [:persist.check/delete-table
                 (fn delete-table [conn]
-                  (ddl.sql/execute! conn [(ddl.sql/drop-table-sql database table-name)]))
+                  (sql.ddl/execute! conn [(sql.ddl/drop-table-sql database table-name)]))
                 ;; This will never be called, if the last step fails it does not need to be undone
                 (constantly nil)]]]
     ;; Unlike postgres, mysql ddl clauses will not rollback in a transaction.

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -13,7 +13,7 @@
             [metabase.driver :as driver]
             [metabase.driver.common :as driver.common]
             [metabase.driver.ddl.interface :as ddl.i]
-            [metabase.driver.ddl.postgres :as ddl.postgres]
+            [metabase.driver.postgres.ddl :as postgres.ddl]
             [metabase.driver.sql-jdbc.common :as sql-jdbc.common]
             [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
             [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
@@ -37,7 +37,7 @@
            metabase.util.honeysql_extensions.Identifier))
 
 (comment
-  ddl.postgres/keep-me)
+  postgres.ddl/keep-me)
 
 (driver/register! :postgres, :parent :sql-jdbc)
 

--- a/src/metabase/driver/sql/ddl.clj
+++ b/src/metabase/driver/sql/ddl.clj
@@ -1,4 +1,4 @@
-(ns metabase.driver.ddl.sql
+(ns metabase.driver.sql.ddl
   (:require [clojure.java.jdbc :as jdbc]
             [metabase.driver.ddl.interface :as ddl.i]
             [metabase.driver.sql.util :as sql.u]

--- a/test/metabase/driver/mysql_test.clj
+++ b/test/metabase/driver/mysql_test.clj
@@ -7,8 +7,8 @@
             [metabase.config :as config]
             [metabase.db.metadata-queries :as metadata-queries]
             [metabase.driver :as driver]
-            [metabase.driver.ddl.mysql :as ddl.mysql]
             [metabase.driver.mysql :as mysql]
+            [metabase.driver.mysql.ddl :as mysql.ddl]
             [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
             [metabase.driver.sql-jdbc.sync :as sql-jdbc.sync]
             [metabase.driver.sql.query-processor :as sql.qp]
@@ -503,5 +503,5 @@
         (is (thrown-with-msg?
               Exception
               #"Killed mysql process id \d+ due to timeout."
-              (#'ddl.mysql/execute-with-timeout! db-spec db-spec 10 ["select sleep(5)"])))
-        (is (= true (#'ddl.mysql/execute-with-timeout! db-spec db-spec 5000 ["select sleep(0.1) as val"])))))))
+              (#'mysql.ddl/execute-with-timeout! db-spec db-spec 10 ["select sleep(5)"])))
+        (is (= true (#'mysql.ddl/execute-with-timeout! db-spec db-spec 5000 ["select sleep(0.1) as val"])))))))


### PR DESCRIPTION
Fixes #23938

metabase.driver.ddl.postgres should be named metabase.driver.postgres.ddl
metabase.driver.ddl.mysql    should be named metabase.driver.mysql.ddl
metabase.driver.ddl.sql      should be named metabase.driver.sql.ddl

Renamed aliases to match new structure
