### PR TITLE
Remove google socket factory

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -34,8 +34,6 @@
                                              :exclusions  [it.unimi.dsi/fastutil
                                                            org.slf4j/slf4j-api]}
   com.draines/postal                        {:mvn/version "2.0.5"}              ; SMTP library
-  com.google.cloud.sql/postgres-socket-factory
-                                            {:mvn/version "1.6.0"}              ; Secure Google Cloud SQL postgres connections
   com.google.guava/guava                    {:mvn/version "31.0.1-jre"}         ; dep for BigQuery, Spark, and GA. Require here rather than letting different dep versions stomp on each other — see comments on #9697
   com.fasterxml.jackson.core/jackson-databind
                                             {:mvn/version "2.13.2.2"}           ; JSON processor used by snowplow-java-tracker (pinned version due to CVE-2020-36518)


### PR DESCRIPTION
Fixes #23895 

The presence of this lib was breaking BigQuery: see
https://github.com/metabase/metabase/issues/23895.

Running the RC-1 (or running bin/build and making your own) would error
on bigquery. Removing the dep restores bigquery access.

#### NOTE
The intention is to figure out the classpath errors and get this library back in but we can solve that without blocking the release.

