### PR TITLE
Fix incorrect scoring of search results

### DIFF
--- a/frontend/test/metabase/scenarios/onboarding/search/search.cy.spec.js
+++ b/frontend/test/metabase/scenarios/onboarding/search/search.cy.spec.js
@@ -47,7 +47,6 @@ describe("scenarios > auth > search", () => {
       cy.wait("@search");
 
       cy.get("body").trigger("keydown", { key: "ArrowDown" });
-      cy.get("body").trigger("keydown", { key: "ArrowDown" });
       cy.get("body").trigger("keydown", { key: "Enter" });
 
       cy.url().should("match", /\/question\/1-orders$/);

--- a/frontend/test/metabase/scenarios/question/new.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/new.cy.spec.js
@@ -80,6 +80,7 @@ describe("scenarios > question > new", () => {
 
       it("should allow to search and select tables", () => {
         cy.findAllByText("Orders")
+          .eq(1)
           .closest("li")
           .findByText("Table in")
           .parent()

--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -418,14 +418,8 @@
                              ;; MySQL returns `:bookmark` and `:archived` as `1` or `0` so convert those to boolean as needed
                              (map #(update % :bookmark bit->boolean))
                              (map #(update % :archived bit->boolean))
-                             (map (partial scoring/score-and-result (:search-string search-ctx))))
-                             ;; Archived search with a blank search string is used by the client for "show me everything that is archived".
-                             ;; see https://github.com/metabase/metabase/pull/15604
-                             ;; Otherwise, we remove all search results with a score of zero.
-          xf                 (if-not (and (:archived? search-ctx)
-                                          (str/blank? (:search-string search-ctx)))
-                               (comp xf (filter #(pos? (:score %))))
-                               xf)
+                             (map (partial scoring/score-and-result (:search-string search-ctx)))
+                             (filter #(pos? (:score %))))
           total-results     (scoring/top-results reducible-results xf)]
       ;; We get to do this slicing and dicing with the result data because
       ;; the pagination of search is for UI improvement, not for performance.

--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -419,7 +419,7 @@
                              (map #(update % :bookmark bit->boolean))
                              (map #(update % :archived bit->boolean))
                              (map (partial scoring/score-and-result (:search-string search-ctx)))
-                             (filter some?))
+                             (filter #(pos? (:score %))))
           total-results     (scoring/top-results reducible-results xf)]
       ;; We get to do this slicing and dicing with the result data because
       ;; the pagination of search is for UI improvement, not for performance.

--- a/src/metabase/search/scoring.clj
+++ b/src/metabase/search/scoring.clj
@@ -178,17 +178,17 @@
   [{:keys [model collection_position]}]
   ;; We experimented with favoring lower collection positions, but it wasn't good
   ;; So instead, just give a bonus for items that are pinned at all
-  (when (#{"card" "dashboard" "pulse"} model)
-    (if ((fnil pos? 0) collection_position)
-      1
-      0)))
+  (if (and (#{"card" "dashboard" "pulse"} model)
+           ((fnil pos? 0) collection_position))
+    1
+    0))
 
 (defn- bookmarked-score
   [{:keys [model bookmark]}]
-  (when (#{"card" "collection" "dashboard"} model)
-    (if bookmark
-      1
-      0)))
+  (if (and (#{"card" "collection" "dashboard"} model)
+           bookmark)
+    1
+    0))
 
 (defn- dashboard-count-score
   [{:keys [model dashboardcard_count]}]

--- a/test/metabase/search/scoring_test.clj
+++ b/test/metabase/search/scoring_test.clj
@@ -280,15 +280,6 @@
                 (map :result)
                 (map :name))))))
 
-(deftest no-text-match-scoring-test
-  (testing "Results without a text match should have zero score"
-   (let [search-string "dashboard"
-         result        {:name                "my dash"
-                        :model               "dashboard"
-                        :bookmark            true
-                        :collection_position 1}]
-     (is (zero? (:score (scoring/score-and-result search-string result)))))))
-
 (deftest score-and-result-test
   (testing "If all scores are 0, does not divide by zero"
     (with-redefs [scoring/score-result

--- a/test/metabase/search/scoring_test.clj
+++ b/test/metabase/search/scoring_test.clj
@@ -280,6 +280,22 @@
                 (map :result)
                 (map :name))))))
 
+(deftest no-text-match-scoring-test
+  (testing "Results with a word match should always rank higher than those without"
+   (let [search-string     "dashboard"
+         labeled-results   {:a {:name "my dashboard" :model "dashboard"}
+                            :b {:name "my dash" :model "dashboard" :bookmark true :collection_position 1}}
+         {:keys [a b]} labeled-results]
+     (is (= (map :name [a   ; Text match
+                        b]) ; No text match, but it's bookmarked and pinned
+            (->> labeled-results
+                 vals
+                 (map (partial scoring/score-and-result search-string))
+                 (sort-by :score)
+                 reverse
+                 (map :result)
+                 (map :name)))))))
+
 (deftest score-and-result-test
   (testing "If all scores are 0, does not divide by zero"
     (with-redefs [scoring/score-result

--- a/test/metabase/search/scoring_test.clj
+++ b/test/metabase/search/scoring_test.clj
@@ -53,10 +53,10 @@
              (score ["rasta"]
                     (result-row "Rasta")))))
     (testing "misses"
-      (is (nil?
+      (is (zero?
            (score ["rasta"]
                   (result-row "just a straight-up imposter"))))
-      (is (nil?
+      (is (zero?
            (score ["rasta" "the" "toucan"]
                   (result-row "")))))))
 
@@ -83,10 +83,10 @@
              (score ["rasta" "the" "toucan"]
                     (result-row "Rasta may be my favorite of the toucans")))))
     (testing "misses"
-      (is (nil?
+      (is (zero?
            (score ["rasta"]
                   (result-row "just a straight-up imposter"))))
-      (is (nil?
+      (is (zero?
            (score ["rasta" "the" "toucan"]
                   (result-row "")))))))
 
@@ -101,16 +101,16 @@
              (score ["rasta" "the" "toucan"]
                     (result-row "Rasta the Toucan")))))
     (testing "misses"
-      (is (nil?
+      (is (zero?
            (score ["rasta"]
                   (result-row "just a straight-up imposter"))))
-      (is (nil?
+      (is (zero?
            (score ["rasta" "the" "toucan"]
                   (result-row "")))))))
 
 (deftest exact-match-scorer-test
   (let [score (scorer->score #'scoring/exact-match-scorer)]
-    (is (nil?
+    (is (zero?
          (score ["rasta" "the" "toucan"]
                 (result-row "Crowberto el tucan"))))
     (is (= 1/3
@@ -281,20 +281,13 @@
                 (map :name))))))
 
 (deftest no-text-match-scoring-test
-  (testing "Results with a word match should always rank higher than those without"
-   (let [search-string     "dashboard"
-         labeled-results   {:a {:name "my dashboard" :model "dashboard"}
-                            :b {:name "my dash" :model "dashboard" :bookmark true :collection_position 1}}
-         {:keys [a b]} labeled-results]
-     (is (= (map :name [a   ; Text match
-                        b]) ; No text match, but it's bookmarked and pinned
-            (->> labeled-results
-                 vals
-                 (map (partial scoring/score-and-result search-string))
-                 (sort-by :score)
-                 reverse
-                 (map :result)
-                 (map :name)))))))
+  (testing "Results without a text match should have zero score"
+   (let [search-string "dashboard"
+         result        {:name                "my dash"
+                        :model               "dashboard"
+                        :bookmark            true
+                        :collection_position 1}]
+     (is (zero? (:score (scoring/score-and-result search-string result)))))))
 
 (deftest score-and-result-test
   (testing "If all scores are 0, does not divide by zero"


### PR DESCRIPTION
This fixes https://github.com/metabase/metabase/issues/24132 and fixes https://github.com/metabase/metabase/issues/18465

### **Bug description**

This PR fixes two bugs with two independent root causes.
1. The search results currently include results that don't have a text match.
2. The scoring of search results is incorrect. It ranks results incorrectly based on the model type (e.g. biasing tables over dashboards), and can rank results with no text match higher than results with a text match (e.g. if a question is bookmarked or pinned).

This PR fixes both parts, although the first part is also addressed by https://github.com/metabase/metabase/pull/24133.

The bug in action:
![image](https://user-images.githubusercontent.com/39073188/179158328-3b9dc8a2-00b8-4667-82cb-1300ef4fc657.png)

### **Steps to reproduce**

I haven't been able to reproduce this yet locally, but I can reproduce it easily on stats.metabase.com.

In any case, the test in this PR acts as a reproduction as would fail without the implementation.

To reproduce on stats.metabase.com
1. Search for `clearbit base exploration table`
2. Notice that the first results will not match the search string at all, even though there is a question with the exact name, and they are ranked higher.

### **Technical background of what's causing the bug in scoring, and why the fix works**
As an example, let's simulate a search for "dashboard", given the results contain a non-matching result and a matching result. You can ignore how the results got there in the first place, but they came from [this query](https://github.com/metabase/metabase/blob/18465-fix-search-scoring-no-matches/src/metabase/api/search.clj#L388).

```clojure
(ns metabase.search.scoring-test)
nil
clj꞉metabase.search.scoring-test꞉> 
(let [search-string     "dashboard"
      labeled-results   {:a {:name  "my dashboard" ;; This matches the search string
                             :model "dashboard"}
                         :b {:name                "my dash" ;; This doesn't match the search string
                             :model               "dashboard"
                             :bookmark            true
                             :collection_position 1}}
      {:keys [a b]} labeled-results]
  (->> labeled-results
       vals
       (map (partial scoring/score-and-result search-string))))
({:result {:collection {:authority_level nil, :id nil, :name nil},
           :context nil,
           :dataset_query nil,
           :model "dashboard",
           :name "my dashboard",
           :scores ({:name "pinned", :score 0, :weight 2}
                    {:name "bookmarked", :score 0, :weight 2}
                    {:name "recency", :score 0, :weight 3/2}
                    {:name "model", :score 8/9, :weight 1/2}
                    {:name "official collection score", :score 0, :weight 2}
                    {:name "verified", :score 0, :weight 2}
                    {:name "text score", :score 7/9, :weight 10})},
  :score 37/90}
 {:result {:bookmark true,
           :collection {:authority_level nil, :id nil, :name nil},
           :collection_position 1,
           :context nil,
           :dataset_query nil,
           :model "dashboard",
           :name "my dash",
           :scores ({:name "pinned", :score 1, :weight 2}
                    {:name "bookmarked", :score 1, :weight 2}
                    {:name "recency", :score 0, :weight 3/2}
                    {:name "model", :score 8/9, :weight 1/2}
                    {:name "official collection score", :score 0, :weight 2}
                    {:name "verified", :score 0, :weight 2})},
  :score 4/9})
```
Compare the scores: The first is 37/90 = 0.433. The second is 4/9 = 0.444, and ranks higher. But the second doesn't even have a "text score". The problem is in the denominator of the two score calculations. The denominator is calculated from summing all the score weights, and the second result is missing the text score weight in that sum.
Hence the fix [here](https://github.com/metabase/metabase/compare/18465-fix-search-scoring-no-matches?expand=1#diff-7f2653f8c0f476e8c282b17d0512711d156e14a3cdc2204465b841490bc2ff8bR275), which makes sure the second result still gets a text-score of 0 with a weight of 10 even if there is no text match.

**Update: a second example**

I made [a spreadsheet](https://docs.google.com/spreadsheets/d/1KetXYa5IiT-Y8e9f4cRJgsPinTI8c6xwaNoihKYdJHk/edit#gid=0) to document the effect of the change on a pair of "normal" search results. It demonstrates that the current behaviour implicitly favours tables over cards, probably unintentionally. A lot of implicit ordering by model is currently happening. Tables, databases, and datasets are all being scored higher than cards and dashboards, which contradicts the explicit order ranking [here](https://github.com/metabase/metabase/blob/18465-fix-search-scoring-no-matches/src/metabase/search/config.clj#L58).