### PR TITLE
Restyle EntityMenu

### DIFF
--- a/frontend/src/metabase/components/EntityMenu.jsx
+++ b/frontend/src/metabase/components/EntityMenu.jsx
@@ -104,7 +104,7 @@ class EntityMenu extends Component {
                 >
                   <Card>
                     {menuItemContent || (
-                      <ol className="py1" style={{ minWidth: 210 }}>
+                      <ol className="p1" style={{ minWidth: 210 }}>
                         {items.map(item => {
                           if (!item) {
                             return null;

--- a/frontend/src/metabase/components/EntityMenu.jsx
+++ b/frontend/src/metabase/components/EntityMenu.jsx
@@ -104,7 +104,7 @@ class EntityMenu extends Component {
                 >
                   <Card>
                     {menuItemContent || (
-                      <ol className="p1" style={{ minWidth: 210 }}>
+                      <ol className="p1" style={{ minWidth: 184 }}>
                         {items.map(item => {
                           if (!item) {
                             return null;

--- a/frontend/src/metabase/components/EntityMenuItem.styled.jsx
+++ b/frontend/src/metabase/components/EntityMenuItem.styled.jsx
@@ -6,21 +6,21 @@ import { color } from "metabase/lib/colors";
 export const Item = styled.div`
   display: flex;
   align-items: center;
+  border-radius: 0.5em;
   cursor: ${props => (props.disabled ? "not-allowed" : "pointer")};
-  color: ${props => color(props.disabled ? "text-light" : "text-medium")};
+  color: ${props => color(props.disabled ? "text-light" : "text-dark")};
   padding: 0.85em 1.45em;
   text-decoration: none;
-  transition: all 300ms linear;
   :hover {
     color: ${props => !props.disabled && color("brand")};
+    background-color: ${props => !props.disabled && color("bg-light")};
   }
   > .Icon {
-    color: ${color("text-light")};
+    color: ${color("text-dark")};
     margin-right: 0.65em;
   }
   :hover > .Icon {
     color: ${props => !props.disabled && color("brand")};
-    transition: all 300ms linear;
   },
   /* icon specific tweaks
      the alert icon should be optically aligned  with the x-height of the text */


### PR DESCRIPTION
This should make each entity menu item easier to read and look less disabled.

## Before

<img width="551" alt="image" src="https://user-images.githubusercontent.com/2223916/179230493-18546358-41ab-48f3-8fe3-53db12e20c0a.png">

<img width="536" alt="image" src="https://user-images.githubusercontent.com/2223916/179230454-38c09f9c-d452-41ae-8376-4996648075de.png">

## After

<img width="543" alt="image" src="https://user-images.githubusercontent.com/2223916/179230931-083a556a-8939-42aa-8f7d-c9ec18afd5e3.png">

<img width="542" alt="image" src="https://user-images.githubusercontent.com/2223916/179230824-9378a3e7-c58f-4c51-a513-d8e8664cbfbf.png">

<img width="545" alt="image" src="https://user-images.githubusercontent.com/2223916/179232075-23e51e26-32dc-4df3-a0b5-02b89e71c767.png">
