### PR TITLE
Migrate accent3 to JS colors

### DIFF
--- a/frontend/src/metabase/css/core/colors.css
+++ b/frontend/src/metabase/css/core/colors.css
@@ -6,7 +6,6 @@
   --color-brand-light: #ddecfa;
   --color-accent1: #88bf4d;
   --color-accent2: #a989c5;
-  --color-accent3: #ef8c8c;
   --color-accent4: #f9d45c;
   --color-accent5: #f2a86f;
   --color-accent6: #98d9d9;

--- a/frontend/src/metabase/css/pulse.css
+++ b/frontend/src/metabase/css/pulse.css
@@ -59,25 +59,6 @@
   box-shadow: 0 0 3px var(--color-shadow);
 }
 
-.DangerZone:hover {
-  border-color: var(--color-accent3);
-  transition: border 0.3s ease-in;
-}
-
-.DangerZone .Button--danger {
-  opacity: 0.4;
-  background: var(--color-bg-light);
-  border: 1px solid var(--color-border);
-  color: var(--color-text-dark);
-}
-
-.DangerZone:hover .Button--danger {
-  opacity: 1;
-  background-color: var(--color-accent3);
-  border-color: var(--color-accent3);
-  color: var(--color-text-white);
-}
-
 .Modal.WhatsAPulseModal {
   width: auto;
 }

--- a/frontend/src/metabase/query_builder/components/AlertModals.jsx
+++ b/frontend/src/metabase/query_builder/components/AlertModals.jsx
@@ -15,7 +15,7 @@ import Icon from "metabase/components/Icon";
 import ChannelSetupModal from "metabase/components/ChannelSetupModal";
 import ButtonWithStatus from "metabase/components/ButtonWithStatus";
 import PulseEditChannels from "metabase/pulse/components/PulseEditChannels";
-import { AlertModalFooter } from "./AlertModals.styled";
+import { AlertModalFooter, DangerZone } from "./AlertModals.styled";
 
 import User from "metabase/entities/users";
 
@@ -393,7 +393,7 @@ export class DeleteAlertSection extends Component {
     const { onDeleteAlert } = this.props;
 
     return (
-      <div className="DangerZone mt4 pt4 mb2 p3 rounded bordered relative">
+      <DangerZone className="DangerZone mt4 pt4 mb2 p3 rounded bordered relative">
         <h3
           className="text-error absolute top bg-white px1"
           style={{ marginTop: "-12px" }}
@@ -417,7 +417,7 @@ export class DeleteAlertSection extends Component {
             </ModalWithTrigger>
           </div>
         </div>
-      </div>
+      </DangerZone>
     );
   }
 }

--- a/frontend/src/metabase/query_builder/components/AlertModals.jsx
+++ b/frontend/src/metabase/query_builder/components/AlertModals.jsx
@@ -404,8 +404,9 @@ export class DeleteAlertSection extends Component {
             <p className="h4 pr2">{jt`Stop delivery and delete this alert. There's no undo, so be careful.`}</p>
             <ModalWithTrigger
               ref={ref => (this.deleteModal = ref)}
-              triggerClasses="Button Button--danger flex-align-right flex-no-shrink"
-              triggerElement="Delete this Alert"
+              as={Button}
+              triggerClasses="Button--danger flex-align-right flex-no-shrink"
+              triggerElement={t`Delete this Alert`}
             >
               <DeleteModalWithConfirm
                 objectType="alert"

--- a/frontend/src/metabase/query_builder/components/AlertModals.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/AlertModals.styled.jsx
@@ -1,9 +1,31 @@
 import styled from "@emotion/styled";
 import { space } from "metabase/styled-components/theme";
+import { color } from "metabase/lib/colors";
 
 export const AlertModalFooter = styled.div`
   display: flex;
   justify-content: right;
   align-items: center;
   margin-top: ${space(3)};
+`;
+
+export const DangerZone = styled.div`
+  .Button--danger {
+    opacity: 0.4;
+    background: ${color("bg-light")};
+    border: 1px solid ${color("border")};
+    color: ${color("text-dark")};
+  }
+
+  &:hover {
+    border-color: ${color("accent3")};
+    transition: border 0.3s ease-in;
+
+    .Button--danger {
+      opacity: 1;
+      background-color: ${color("accent3")};
+      border-color: ${color("accent3")};
+      color: ${color("text-white")};
+    }
+  }
 `;

--- a/frontend/src/metabase/query_builder/components/AlertModals.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/AlertModals.styled.jsx
@@ -1,6 +1,7 @@
 import styled from "@emotion/styled";
-import { space } from "metabase/styled-components/theme";
 import { color } from "metabase/lib/colors";
+import { space } from "metabase/styled-components/theme";
+import Button from "metabase/core/components/Button";
 
 export const AlertModalFooter = styled.div`
   display: flex;
@@ -10,18 +11,19 @@ export const AlertModalFooter = styled.div`
 `;
 
 export const DangerZone = styled.div`
-  .Button--danger {
+  ${Button.Root} {
     opacity: 0.4;
     background: ${color("bg-light")};
     border: 1px solid ${color("border")};
     color: ${color("text-dark")};
+    transition: none;
   }
 
   &:hover {
     border-color: ${color("accent3")};
     transition: border 0.3s ease-in;
 
-    .Button--danger {
+    ${Button.Root} {
       opacity: 1;
       background-color: ${color("accent3")};
       border-color: ${color("accent3")};


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/23954

How to test:
- Setup either email or slack
- Create a question
- Click Alerts -> Create an alert
- When created, click on Alerts -> Edit
- At the bottom of the page there is `DangerZone` with a button to delete the alert
- It should use `accent3` as it did before

<img width="602" alt="Screenshot 2022-07-15 at 18 07 41" src="https://user-images.githubusercontent.com/8542534/179253094-2d250970-6b66-4931-965d-a0c74746ec25.png">
<img width="629" alt="Screenshot 2022-07-15 at 18 07 36" src="https://user-images.githubusercontent.com/8542534/179253065-7ff2e7d1-1848-48d8-a7a1-eb82f38ba33d.png">