### PR TITLE
Bulk delete action

### DIFF
--- a/src/metabase/actions.clj
+++ b/src/metabase/actions.clj
@@ -1,17 +1,17 @@
 (ns metabase.actions
   "Code related to the new writeback Actions."
-  (:require
-   [clojure.spec.alpha :as s]
-   [metabase.api.common :as api]
-   [metabase.driver :as driver]
-   [metabase.mbql.normalize :as mbql.normalize]
-   [metabase.mbql.schema :as mbql.s]
-   [metabase.mbql.util :as mbql.u]
-   [metabase.models.database :refer [Database]]
-   [metabase.models.setting :as setting]
-   [metabase.util :as u]
-   [metabase.util.i18n :as i18n]
-   [schema.core :as schema]))
+  (:require [clojure.spec.alpha :as s]
+            [medley.core :as m]
+            [metabase.api.common :as api]
+            [metabase.driver :as driver]
+            [metabase.mbql.normalize :as mbql.normalize]
+            [metabase.mbql.schema :as mbql.s]
+            [metabase.mbql.util :as mbql.u]
+            [metabase.models.database :refer [Database]]
+            [metabase.models.setting :as setting]
+            [metabase.util :as u]
+            [metabase.util.i18n :as i18n]
+            [schema.core :as schema]))
 
 (setting/defsetting experimental-enable-actions
   (i18n/deferred-tru "Whether to enable using the new experimental Actions features globally. (Actions must also be enabled for each Database.)")
@@ -285,6 +285,9 @@
 
 ;;;; Bulk actions
 
+(s/def :actions.args.crud.bulk/table-id
+  :actions.args/id)
+
 ;;;; `:bulk/create`
 
 ;;; For `bulk/create` the request body is to `POST /api/action/:action-namespace/:action-name/:table-id` is just a
@@ -300,18 +303,54 @@
   [_action {:keys [database table-id], rows :arg, :as _arg-map}]
   {:database database, :table-id table-id, :rows rows})
 
-(s/def :actions.args.crud.bulk.create/table-id
-  :actions.args/id)
-
 (s/def :actions.args.crud.bulk.create/rows
   (s/cat :rows (s/+ (s/map-of keyword? any?))))
 
 (s/def :actions.args.crud.bulk/create
   (s/merge
    :actions.args/common
-   (s/keys :req-un [:actions.args.crud.bulk.create/table-id
+   (s/keys :req-un [:actions.args.crud.bulk/table-id
                     :actions.args.crud.bulk.create/rows])))
 
 (defmethod action-arg-map-spec :bulk/create
   [_action]
   :actions.args.crud.bulk/create)
+
+;;;; `:bulk/delete`
+
+;;; For `bulk/delete` the request body is to `POST /api/action/:action-namespace/:action-name/:table-id` is just a
+;;; vector of rows but the API endpoint itself calls [[perform-action!]] with
+;;;
+;;;    {:database <database-id>, :table-id <table-id>, :arg <request-body>}
+;;;
+;;; and we transform this to
+;;;
+;;;     {:database <database-id>, :table-id <table-id>, :pk-values <request-body>}
+;;;
+;;; Request-body should look like:
+;;;
+;;;    ;; single pk, two rows
+;;;    [{"ID": 76},
+;;;     {"ID": 77}]
+;;;
+;;;    ;; multiple pks, one row
+;;;    [{"PK1": 1, "PK2": "john"}]
+
+
+(defmethod normalize-action-arg-map :bulk/delete
+  [_action {:keys [database table-id], pk-values :arg, :as _arg-map}]
+  {:database database, :table-id table-id, :pk-values (map #(m/map-keys name %) pk-values)})
+
+(s/def :actions.args.crud.bulk.delete/pk-values
+  ;; TODO keys should be a mbql field??
+  (s/coll-of (s/map-of any? any?)))
+
+(s/def :actions.args.crud.bulk/delete
+  (s/merge
+    :actions.args/common
+    (s/keys :req-un [:actions.args.crud.bulk/table-id
+                     :actions.args.crud.bulk.delete/pk-values])))
+
+(defmethod action-arg-map-spec :bulk/delete
+  [_action]
+  :actions.args.crud.bulk/delete)

--- a/src/metabase/driver/sql_jdbc/actions.clj
+++ b/src/metabase/driver/sql_jdbc/actions.clj
@@ -4,17 +4,19 @@
             [clojure.tools.logging :as log]
             [medley.core :as m]
             [metabase.actions :as actions]
+            [metabase.db.util :as mdb.u]
             [metabase.driver :as driver]
             [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
             [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
             [metabase.driver.sql.query-processor :as sql.qp]
             [metabase.driver.util :as driver.u]
-            [metabase.models.table :as table :refer [Table]]
+            [metabase.models :refer [Field Table]]
+            [metabase.models.table :as table]
             [metabase.query-processor :as qp]
             [metabase.query-processor.store :as qp.store]
             [metabase.util :as u]
             [metabase.util.honeysql-extensions :as hx]
-            [metabase.util.i18n :refer [trs tru]]
+            [metabase.util.i18n :refer [tru]]
             [toucan.db :as db])
   (:import java.sql.Connection))
 
@@ -304,27 +306,59 @@
              created-rows]))))
      rows)))
 
-(defn- pk-values->filters [table-id pk-values]
-  ;; check that all pk-values have the same shape
-  (when-not (apply = (map (comp set keys) pk-values))
-    (throw (ex-info (trs "Inconsistent row selection.")
-                    {:status-code 400, :pk-values pk-values})))
-  (let [given-pks (set (keys (first pk-values)))
-        table-pks (into {} (map (juxt :name :id) (filter #(= (:semantic_type %) :type/PK) (:fields (first (table/with-fields [(Table table-id)]))))))]
-    (when-not (= given-pks (set (keys table-pks)))
-      (throw (ex-info (trs "Must select with all PKs.")
-                      {:status-code 400, :given-pks (sort given-pks) :table-pks (sort (keys table-pks))})))
-    (map
-      (fn [pk-value]
-        (into [:and]
-              (mapv (fn [[pk-name value]]
-                      [:= [:field (get table-pks pk-name) nil] value])
-                    pk-value)))
-      pk-values)))
+(defn- check-consistent-pk-value-map-keys [pk-value-maps]
+  (let [all-pk-value-map-column-sets (reduce
+                                      (fn [seen-set pk-value-map]
+                                        (conj seen-set (set (keys pk-value-map))))
+                                      #{}
+                                      pk-value-maps)]
+    (when (> (count all-pk-value-map-column-sets) 1)
+      (throw (ex-info (tru "Some rows have different sets of columns: {0}"
+                           (str/join ", " (map pr-str all-pk-value-map-column-sets)))
+                      {:status-code 400, :column-sets all-pk-value-map-column-sets})))))
+
+(defn- check-pk-value-maps-have-expected-columns [pk-value-maps expected-columns]
+  ;; we only actually need to check the first map since [[check-consistent-pk-value-map-keys]] should have checked that
+  ;; they all have the same keys.
+  (let [expected-columns (set expected-columns)
+        actual-columns   (set (keys (first pk-value-maps)))]
+    (when-not (= actual-columns expected-columns)
+      (throw (ex-info (tru "Rows have the wrong columns: expected {0}, but got {1}" expected-columns actual-columns)
+                      {:status-code 400, :expected-columns expected-columns, :actual-columns actual-columns})))))
+
+(defn- check-unique-pk-value-maps [pk-value-maps]
+  (when-let [repeats (->> pk-value-maps
+                          frequencies
+                          (filter (comp #(> % 1) val))
+                          set
+                          not-empty)]
+    (throw (ex-info (tru "Rows need to be unique: repeated rows {0}"
+                         (->> repeats
+                              (map #(format "%s × %d" (pr-str (key %)) (val %)))
+                              (str/join ", ")))
+                    {:status-code 400, :repeated-rows repeats}))))
+
+(defn- pk-value-maps->honeysql-filter-clauses [table-id pk-value-maps]
+  (let [pk-name->id (db/select-field->id
+                      :name Field
+                      {:where [:and
+                               [:= :table_id table-id]
+                               (mdb.u/isa :semantic_type :type/PK)]})]
+    ;; validate the keys in `pk-value-maps`
+    (check-consistent-pk-value-map-keys pk-value-maps)
+    (check-pk-value-maps-have-expected-columns pk-value-maps (keys pk-name->id))
+    (check-unique-pk-value-maps pk-value-maps)
+    ;; now build the HoneySQL filter clauses
+    (for [pk-value-map pk-value-maps]
+      (into [:and]
+            (for [[pk-name value] pk-value-map]
+              [:=
+               [:field (get pk-name->id pk-name) nil]
+               value])))))
 
 (defmethod actions/perform-action!* [:sql-jdbc :bulk/delete]
-  [driver _action {database-id :id, :as database} {:keys [table-id pk-values]}]
-  (log/tracef "Deleting %d rows" (count pk-values))
+  [driver _action {database-id :id, :as database} {:keys [table-id pk-value-maps]}]
+  (log/tracef "Deleting %d rows" (count pk-value-maps))
   (with-jdbc-transaction [conn database-id]
     (transduce
       (m/indexed)
@@ -356,4 +390,4 @@
            [errors]
            (catch Throwable e
              [(conj errors {:index row-index, :error (ex-message e)})]))))
-      (pk-values->filters table-id pk-values))))
+      (pk-value-maps->honeysql-filter-clauses table-id pk-value-maps))))

--- a/src/metabase/driver/sql_jdbc/actions.clj
+++ b/src/metabase/driver/sql_jdbc/actions.clj
@@ -14,7 +14,7 @@
             [metabase.query-processor.store :as qp.store]
             [metabase.util :as u]
             [metabase.util.honeysql-extensions :as hx]
-            [metabase.util.i18n :refer [tru trs]]
+            [metabase.util.i18n :refer [trs tru]]
             [toucan.db :as db])
   (:import java.sql.Connection))
 


### PR DESCRIPTION
Resolves #23849

Builds on the bulk create work, uses the following to select rows to delete, passed as the request body:

```
;; single pk, two rows
[{"ID": 76},
 {"ID": 77}]

;; multiple pks, one row
[{"PK1": 1, "PK2": "john"}]
```

Will check that the passed selections are all the same shape, as well as
provide the full range of the table's PKs.

