### PR TITLE
[E2E] Fix broken `collections` tests

### DIFF
--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -258,13 +258,7 @@ describe("scenarios > collection defaults", () => {
         cy.signIn("nocollection");
       });
 
-      it("should not render collections in items list if user doesn't have collection access (metabase#16555)", () => {
-        cy.visit("/collection/root");
-        // Since this user doesn't have access rights to the root collection, we should render a warning
-        cy.findByText("You don't have permissions to do that.");
-      });
-
-      it("should see a child collection in a sidebar even with revoked access to its parents (metabase#14114)", () => {
+      it("should see a child collection in a sidebar even with revoked access to its parents (metabase#14114, metabase#16555, metabase#20716)", () => {
         cy.visit("/");
 
         navigationSidebar().within(() => {
@@ -273,6 +267,10 @@ describe("scenarios > collection defaults", () => {
           cy.findByText("Child");
           cy.findByText("Your personal collection");
         });
+
+        // Even if user tries to navigate directly to the root collection, we have to make sure its content is not shown
+        cy.visit("/collection/root");
+        cy.findByText("You don't have permissions to do that.");
       });
 
       it("should be able to choose a child collection when saving a question (metabase#14052)", () => {

--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -260,21 +260,17 @@ describe("scenarios > collection defaults", () => {
 
       it("should not render collections in items list if user doesn't have collection access (metabase#16555)", () => {
         cy.visit("/collection/root");
-        // Since this user doesn't have access rights to the root collection, it should render empty
-        cy.findByTestId("collection-empty-state");
+        // Since this user doesn't have access rights to the root collection, we should render a warning
+        cy.findByText("You don't have permissions to do that.");
       });
 
-      it("should see a child collection in a sidebar even with revoked access to its parent (metabase#14114)", () => {
+      it("should see a child collection in a sidebar even with revoked access to its parents (metabase#14114)", () => {
         cy.visit("/");
 
         navigationSidebar().within(() => {
-          cy.findByText("Our analytics").click();
-        });
-
-        navigationSidebar().within(() => {
-          cy.findByText("Our analytics");
-          cy.findByText("Child");
+          cy.findByText("Our analytics").should("not.exist");
           cy.findByText("Parent").should("not.exist");
+          cy.findByText("Child");
           cy.findByText("Your personal collection");
         });
       });


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Fixes E2E tests broken by https://github.com/metabase/metabase/pull/23887 and temporarily skipped in https://github.com/metabase/metabase/pull/23993.
- It also merges related tests together and adds an issue reference to (now reproduced) #20716