### PR TITLE
Update dashboard endpoints and `FieldValuesWidget` to handle `has_more_values` scenario

### DIFF
--- a/frontend/src/metabase/components/FieldValuesWidget.jsx
+++ b/frontend/src/metabase/components/FieldValuesWidget.jsx
@@ -514,24 +514,32 @@ export function isSearchable({
   disablePKRemappingForSearch,
   valuesMode,
 }) {
+  function everyFieldIsSearchable() {
+    return fields.every(field =>
+      searchField(field, disablePKRemappingForSearch),
+    );
+  }
+
+  function someFieldIsConfiguredForSearch() {
+    return fields.some(
+      f =>
+        f.has_field_values === "search" ||
+        (f.has_field_values === "list" && f.has_more_values === true),
+    );
+  }
+
+  function everyFieldIsConfiguredToShowValues() {
+    return fields.every(
+      f => f.has_field_values === "search" || f.has_field_values === "list",
+    );
+  }
+
   return (
     !disableSearch &&
-    // search is available if:
-    // all fields have a valid search field
-    // the component has already been set to "search" mode
-    // (`valuesMode` can be set by the dashboard parameter values endpoint call)
     (valuesMode === "search" ||
-      (fields.every(field => searchField(field, disablePKRemappingForSearch)) &&
-        // at least one field is set to display as "search" or is a list field that has an incomplete value set
-        fields.some(
-          f =>
-            f.has_field_values === "search" ||
-            (f.has_field_values === "list" && f.has_more_values === true),
-        ) &&
-        // and all fields are either "search" or "list"
-        fields.every(
-          f => f.has_field_values === "search" || f.has_field_values === "list",
-        )))
+      (everyFieldIsSearchable() &&
+        someFieldIsConfiguredForSearch() &&
+        everyFieldIsConfiguredToShowValues()))
   );
 }
 

--- a/frontend/src/metabase/components/FieldValuesWidget.jsx
+++ b/frontend/src/metabase/components/FieldValuesWidget.jsx
@@ -508,12 +508,12 @@ function isExtensionOfPreviousSearch(value, lastValue, options, maxResults) {
   );
 }
 
-function isSearchable(
+function isSearchable({
   fields,
   disableSearch,
   disablePKRemappingForSearch,
   valuesMode,
-) {
+}) {
   return (
     !disableSearch &&
     // search is available if:
@@ -558,7 +558,12 @@ function getTokenFieldPlaceholder({
   ) {
     return t`Search the list`;
   } else if (
-    isSearchable(fields, disableSearch, disablePKRemappingForSearch, valuesMode)
+    isSearchable({
+      fields,
+      disableSearch,
+      disablePKRemappingForSearch,
+      valuesMode,
+    })
   ) {
     return getSearchableTokenFieldPlaceholder(
       fields,
@@ -598,12 +603,12 @@ function renderOptions(
         return <EveryOptionState />;
       }
     } else if (
-      isSearchable(
+      isSearchable({
         fields,
         disableSearch,
         disablePKRemappingForSearch,
         valuesMode,
-      )
+      })
     ) {
       if (loadingState === "LOADING") {
         return <LoadingState />;
@@ -639,7 +644,12 @@ function getValuesMode(fields, disableSearch, disablePKRemappingForSearch) {
   }
 
   if (
-    isSearchable(fields, disableSearch, disablePKRemappingForSearch, undefined)
+    isSearchable({
+      fields,
+      disableSearch,
+      disablePKRemappingForSearch,
+      valuesMode: undefined,
+    })
   ) {
     return "search";
   }

--- a/frontend/src/metabase/components/FieldValuesWidget.jsx
+++ b/frontend/src/metabase/components/FieldValuesWidget.jsx
@@ -452,7 +452,7 @@ function getNonSearchableTokenFieldPlaceholder(firstField) {
   return t`Enter some text`;
 }
 
-function searchField(field, disablePKRemappingForSearch) {
+export function searchField(field, disablePKRemappingForSearch) {
   if (disablePKRemappingForSearch && field.isPK()) {
     return field.isSearchable() ? field : null;
   }
@@ -508,7 +508,7 @@ function isExtensionOfPreviousSearch(value, lastValue, options, maxResults) {
   );
 }
 
-function isSearchable({
+export function isSearchable({
   fields,
   disableSearch,
   disablePKRemappingForSearch,
@@ -518,19 +518,20 @@ function isSearchable({
     !disableSearch &&
     // search is available if:
     // all fields have a valid search field
-    ((fields.every(field => searchField(field, disablePKRemappingForSearch)) &&
-      // at least one field is set to display as "search" or is a list field that has an incomplete value set
-      fields.some(
-        f =>
-          f.has_field_values === "search" ||
-          (f.has_field_values === "list" && f.has_more_values === true),
-      ) &&
-      // and all fields are either "search" or "list"
-      fields.every(
-        f => f.has_field_values === "search" || f.has_field_values === "list",
-      )) ||
-      // OR if the component has been set to valuesMode by the dashboard params value action call
-      valuesMode === "search")
+    // the component has already been set to "search" mode
+    // (`valuesMode` can be set by the dashboard parameter values endpoint call)
+    (valuesMode === "search" ||
+      (fields.every(field => searchField(field, disablePKRemappingForSearch)) &&
+        // at least one field is set to display as "search" or is a list field that has an incomplete value set
+        fields.some(
+          f =>
+            f.has_field_values === "search" ||
+            (f.has_field_values === "list" && f.has_more_values === true),
+        ) &&
+        // and all fields are either "search" or "list"
+        fields.every(
+          f => f.has_field_values === "search" || f.has_field_values === "list",
+        )))
   );
 }
 
@@ -638,7 +639,11 @@ function renderValue(fields, formatOptions, value, options) {
   );
 }
 
-function getValuesMode(fields, disableSearch, disablePKRemappingForSearch) {
+export function getValuesMode(
+  fields,
+  disableSearch,
+  disablePKRemappingForSearch,
+) {
   if (fields.length === 0) {
     return "none";
   }

--- a/frontend/src/metabase/dashboard/actions.js
+++ b/frontend/src/metabase/dashboard/actions.js
@@ -1118,7 +1118,7 @@ export const fetchDashboardParameterValuesWithCache = createThunkAction(
       const endpoint = query
         ? DashboardApi.parameterSearch
         : DashboardApi.parameterValues;
-      const results = await endpoint({
+      const { values, has_more_values } = await endpoint({
         paramId: parameter.id,
         dashId: dashboardId,
         query,
@@ -1127,7 +1127,8 @@ export const fetchDashboardParameterValuesWithCache = createThunkAction(
 
       return {
         cacheKey,
-        results: results.map(result => [].concat(result)),
+        results: values.map(value => [].concat(value)),
+        has_more_values: query ? true : has_more_values,
       };
     },
 );

--- a/frontend/src/metabase/dashboard/actions.unit.spec.js
+++ b/frontend/src/metabase/dashboard/actions.unit.spec.js
@@ -176,13 +176,19 @@ describe("dashboard actions", () => {
 
     beforeEach(() => {
       DashboardApi.parameterSearch.mockReset();
-      DashboardApi.parameterSearch.mockResolvedValue([1, 2, 3]);
+      DashboardApi.parameterSearch.mockResolvedValue({
+        has_more_values: false,
+        values: [1, 2, 3],
+      });
       DashboardApi.parameterValues.mockReset();
-      DashboardApi.parameterValues.mockResolvedValue([4, 5, 6]);
+      DashboardApi.parameterValues.mockResolvedValue({
+        has_more_values: true,
+        values: [4, 5, 6],
+      });
       parameterValuesSearchCache = {};
     });
 
-    it("should fetch parameter values using the given query string", async () => {
+    it("should fetch parameter values using the given query string and always set has_more_values to true", async () => {
       const action = await fetchDashboardParameterValuesWithCache({
         dashboardId,
         parameter,
@@ -199,6 +205,7 @@ describe("dashboard actions", () => {
         payload: {
           cacheKey:
             "dashboardId: 1, parameterId: a, query: foo, filteringParameterValues: []",
+          has_more_values: true,
           results: [[1], [2], [3]],
         },
         type: FETCH_DASHBOARD_PARAMETER_FIELD_VALUES_WITH_CACHE,
@@ -222,6 +229,7 @@ describe("dashboard actions", () => {
           cacheKey:
             "dashboardId: 1, parameterId: a, query: null, filteringParameterValues: []",
           results: [[4], [5], [6]],
+          has_more_values: true,
         },
         type: FETCH_DASHBOARD_PARAMETER_FIELD_VALUES_WITH_CACHE,
       });
@@ -246,6 +254,7 @@ describe("dashboard actions", () => {
           cacheKey:
             'dashboardId: 1, parameterId: a, query: bar, filteringParameterValues: [["b","bbb"]]',
           results: [[1], [2], [3]],
+          has_more_values: true,
         },
         type: FETCH_DASHBOARD_PARAMETER_FIELD_VALUES_WITH_CACHE,
       });
@@ -269,6 +278,7 @@ describe("dashboard actions", () => {
           cacheKey:
             'dashboardId: 1, parameterId: a, query: null, filteringParameterValues: [["b","bbb"]]',
           results: [[4], [5], [6]],
+          has_more_values: true,
         },
         type: FETCH_DASHBOARD_PARAMETER_FIELD_VALUES_WITH_CACHE,
       });

--- a/frontend/src/metabase/dashboard/reducers.js
+++ b/frontend/src/metabase/dashboard/reducers.js
@@ -286,7 +286,12 @@ const parameterValuesSearchCache = handleActions(
     },
     [FETCH_DASHBOARD_PARAMETER_FIELD_VALUES_WITH_CACHE]: {
       next: (state, { payload }) =>
-        payload ? assoc(state, payload.cacheKey, payload.results) : state,
+        payload
+          ? assoc(state, payload.cacheKey, {
+              results: payload.results,
+              has_more_values: payload.has_more_values,
+            })
+          : state,
     },
     [RESET]: { next: state => ({}) },
   },


### PR DESCRIPTION
Related to https://github.com/metabase/metabase/issues/23162

https://github.com/metabase/metabase/pull/23985 adds the `has_more_values` property to the dashboard parameter chain filter endpoints. This PR updates related code and the `FieldValuesWidget` component to handle the new return value. When a field has the property `has_field_values` of `"list"` but the dashboard parameter endpoint returns `has_more_values` as `true` it will put the widget into search mode so that the user can search through all the values.

**Testing**
1. Go to Admin> Data model > Sample dataset > People > City.
2. Scroll down and change the "filtering on this field" to "A list of values"
3. Create a notebook question with source Is "People"
4. Add the question to a dashboard
5. Create a `location/city` parameter and map it to the City field 
6. Open the parameter widget -- typing should still search
