### PR TITLE
Fix XLSX month bucketing regression

### DIFF
--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -198,17 +198,20 @@
       format-string)
     format-string))
 
-(def ^:private month-style-overrides
-  "Overrides for the date-style in a column's viz settings if :unit is :month."
-  {"m/d/yyyy"     "m/yyyy"
-   "yyyy/m/d"     "yyyy/m"
-   "mmmm d, yyyy" "mmmm, yyyy"})
+(defn- month-style
+  "For a given date format, returns the format to use in exports if :unit is :month"
+  [date-format]
+  (case date-format
+    "m/d/yyyy" "m/yyyy"
+    "yyyy/m/d" "yyyy/m"
+    ;; Default for all other styles
+    "mmmm, yyyy"))
 
 (defn- date-format
   [format-settings unit]
   (let [base-style (str/lower-case (::mb.viz/date-style format-settings "mmmm d, yyyy"))
         unit-style (case unit
-                     :month (get month-style-overrides base-style)
+                     :month (month-style base-style)
                      :year "yyyy"
                      base-style)]
     (->> unit-style

--- a/test/metabase/query_processor/streaming/xlsx_test.clj
+++ b/test/metabase/query_processor/streaming/xlsx_test.clj
@@ -216,6 +216,9 @@
             (is (= "mmmm, yyyy" (format-string {} month-col)))
             (is (= "m/yyyy"     (format-string {::mb.viz/date-style "M/D/YYYY"} month-col)))
             (is (= "yyyy/m"     (format-string {::mb.viz/date-style "YYYY/M/D"} month-col)))
+            (is (= "mmmm, yyyy" (format-string {::mb.viz/date-style "MMMM D, YYYY"} month-col)))
+            (is (= "mmmm, yyyy" (format-string {::mb.viz/date-style "D MMMM, YYYY"} month-col)))
+            (is (= "mmmm, yyyy" (format-string {::mb.viz/date-style "DDDD, MMMM D, YYYY"} month-col)))
             (is (= "yyyy"       (format-string {} year-col)))
             (is (= "yyyy"       (format-string {::mb.viz/date-style "M/D/YYYY"} year-col)))))
 


### PR DESCRIPTION
Fixes #23980

Basically the issue was we had a map for determining what style to use for formatting month buckets based on the current date format. But this map wasn't exhaustive -- it included the date styles that could be set in the viz settings on a question, but not a couple of styles that could be set in the admin panel. This led to an NPE later on in the code.

I've changed it to just use a `case` statement with a default value so that we never throw an error here.