### PR TITLE
adjust font size on scalar cards

### DIFF
--- a/frontend/src/metabase/lib/measure-text.ts
+++ b/frontend/src/metabase/lib/measure-text.ts
@@ -1,0 +1,19 @@
+let canvas: HTMLCanvasElement | null = null;
+
+export type FontStyle = {
+  size: string;
+  family: string;
+  weight: string;
+};
+
+export const measureText = (text: string, style: FontStyle) => {
+  canvas ??= document.createElement("canvas");
+  const context = canvas.getContext("2d");
+
+  if (!context) {
+    throw new Error("Could not create canvas context");
+  }
+
+  context.font = `${style.weight} ${style.size} ${style.family}`;
+  return context.measureText(text);
+};

--- a/frontend/src/metabase/visualizations/components/ScalarValue/ScalarValue.jsx
+++ b/frontend/src/metabase/visualizations/components/ScalarValue/ScalarValue.jsx
@@ -2,7 +2,7 @@
  * Shared component for Scalar and SmartScalar to make sure our number presentation stays in sync
  */
 /* eslint-disable react/prop-types */
-import React from "react";
+import React, { useMemo } from "react";
 import cx from "classnames";
 
 import Icon from "metabase/components/Icon";
@@ -14,31 +14,42 @@ import {
   ScalarTitleRoot,
 } from "./ScalarValue.styled";
 
+import { findSize, getMaxFontSize } from "./utils";
+
+const HORIZONTAL_PADDING = 32;
+
 export const ScalarWrapper = ({ children }) => (
   <ScalarRoot>{children}</ScalarRoot>
 );
 
 const ScalarValue = ({
   value,
-  isDashboard,
-  gridSize,
-  minGridSize,
   width,
-  height,
+  gridSize,
   totalNumGridCols,
-}) => (
-  <ScalarValueWrapper
-    className="ScalarValue"
-    isDashboard={isDashboard}
-    gridSize={gridSize}
-    minGridSize={minGridSize}
-    width={width}
-    height={height}
-    totalNumGridCols={totalNumGridCols}
-  >
-    {value}
-  </ScalarValueWrapper>
-);
+  fontFamily,
+}) => {
+  const fontSize = useMemo(
+    () =>
+      findSize({
+        text: value,
+        targetWidth: width - HORIZONTAL_PADDING,
+        fontFamily: fontFamily ?? "Lato",
+        fontWeight: 900,
+        unit: "rem",
+        step: 0.2,
+        min: 2.2,
+        max: gridSize ? getMaxFontSize(gridSize.width, totalNumGridCols) : 4,
+      }),
+    [fontFamily, gridSize, totalNumGridCols, value, width],
+  );
+
+  return (
+    <ScalarValueWrapper className="ScalarValue" fontSize={fontSize}>
+      {value}
+    </ScalarValueWrapper>
+  );
+};
 
 const ICON_WIDTH = 24;
 

--- a/frontend/src/metabase/visualizations/components/ScalarValue/ScalarValue.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/ScalarValue/ScalarValue.styled.tsx
@@ -2,8 +2,6 @@ import styled from "@emotion/styled";
 
 import { color } from "metabase/lib/colors";
 
-import { computeFontSize, PropsForFontSizeScaling } from "./utils";
-
 const TITLE_MAX_LINES = 2;
 const TITLE_LINE_HEIGHT_REM = 1.4;
 
@@ -20,13 +18,18 @@ export const ScalarRoot = styled.div`
   height: 100%;
 `;
 
-export const ScalarValueWrapper = styled.h1<PropsForFontSizeScaling>`
+interface ScalarValueWrapperProps {
+  fontSize: string;
+}
+
+export const ScalarValueWrapper = styled.h1<ScalarValueWrapperProps>`
   cursor: pointer;
   &:hover {
     color: ${color("brand")};
   }
+  padding: 0 4px;
 
-  font-size: ${computeFontSize};
+  font-size: ${props => props.fontSize};
 `;
 
 export const ScalarTitleRoot = styled.div`

--- a/frontend/src/metabase/visualizations/components/ScalarValue/utils.ts
+++ b/frontend/src/metabase/visualizations/components/ScalarValue/utils.ts
@@ -1,90 +1,61 @@
-export const WIDTH_ADJUSTMENT_FACTOR = 4;
-export const HEIGHT_ADJUSTMENT_FACTOR = 4;
-export const MAX_HEIGHT_GRID_SIZE = 10;
-export const MIN_SIZE_REM = 2.2;
-export const MAX_SIZE_REM = 12;
+import { GRID_WIDTH, DEFAULT_CARD_SIZE } from "metabase/lib/dashboard_grid";
+import { measureText } from "metabase/lib/measure-text";
 
-export type PropsForFontSizeScaling = {
-  isDashboard?: boolean;
-  gridSize?: { height: number; width: number };
-  minGridSize?: { height: number; width: number };
-  width?: number;
-  height?: number;
-  totalNumGridCols?: number;
+interface FindSizeInput {
+  text: string;
+  targetWidth: number;
+  unit: string;
+  fontFamily: string;
+  fontWeight: string;
+  step: number;
+  min: number;
+  max: number;
+}
+
+export const findSize = ({
+  text,
+  targetWidth,
+  unit,
+  fontFamily,
+  fontWeight,
+  step,
+  min,
+  max,
+}: FindSizeInput) => {
+  let size = max;
+  let width = measureText(text, {
+    size: `${size}${unit}`,
+    family: fontFamily,
+    weight: fontWeight,
+  }).width;
+
+  if (width > targetWidth) {
+    while (width > targetWidth && size > min) {
+      size = Math.max(size - step, min);
+
+      width = measureText(text, {
+        size: `${size}${unit}`,
+        family: fontFamily,
+        weight: fontWeight,
+      }).width;
+    }
+
+    return `${size}${unit}`;
+  }
+
+  return `${size}${unit}`;
 };
 
-export function computeFontSizeAdjustment({
-  isDashboard,
-  gridSize: cardGridUnitDimensions,
-  minGridSize: minCardGridUnitDimensions,
-  width: cardWidthPx,
-  height: cardHeightPx,
-  totalNumGridCols,
-}: PropsForFontSizeScaling): number {
-  if (
-    !isDashboard ||
-    !cardGridUnitDimensions ||
-    !minCardGridUnitDimensions ||
-    !cardWidthPx ||
-    !cardHeightPx ||
-    !totalNumGridCols
-  ) {
-    return 0;
+const MAX_SIZE_SMALL = 2.2;
+const MAX_SIZE_LARGE = 7;
+
+export const getMaxFontSize = (cardColWidth: number, totalCols: number) => {
+  if (totalCols < DEFAULT_CARD_SIZE.width) {
+    return MAX_SIZE_SMALL;
   }
 
-  const { height: gridUnitRows, width: gridUnitCols } = cardGridUnitDimensions;
-  const { height: minGridUnitRows, width: minGridUnitCols } =
-    minCardGridUnitDimensions;
-  if (!gridUnitRows || !gridUnitCols || !minGridUnitRows || !minGridUnitCols) {
-    return 0;
-  }
-
-  // at small viewport widths totalNumGridCols is set to 1, but the dashcard's gridSize.width isn't updated.
-  // in that scenario, the dashcard's grid width should be treated as 1 as well because it spans the entire grid
-  const cardGridWidth = Math.min(totalNumGridCols, gridUnitCols);
-
-  const widthPxPerGridUnit = cardWidthPx / cardGridWidth;
-  const maxCardWidthPx = totalNumGridCols * widthPxPerGridUnit;
-  const minCardWidthPx = minGridUnitCols * widthPxPerGridUnit;
-
-  // when the dashcard is at its min width, the `gridWidthAdjustment` value will be 0.
-  // as it increases in width, it will increase in value up to `WIDTH_ADJUSTMENT_FACTOR`.
-  const cardWidthFractionOfMax = Math.max(
-    0,
-    (cardWidthPx - minCardWidthPx) / (maxCardWidthPx - minCardWidthPx),
+  return (
+    (cardColWidth / GRID_WIDTH) * (MAX_SIZE_LARGE - MAX_SIZE_SMALL) +
+    MAX_SIZE_SMALL
   );
-  const gridWidthAdjustmentRem =
-    cardWidthFractionOfMax * WIDTH_ADJUSTMENT_FACTOR;
-
-  // Avoid a big height adjustment value for large height, small width cards by using the `dashCardGridWidth` when it is less than the `gridUnitRows`
-  const dashCardGridHeight = Math.min(cardGridWidth, gridUnitRows);
-  const heightPxPerGridUnit = cardHeightPx / dashCardGridHeight;
-  // `MAX_HEIGHT_GRID_SIZE` is approximately the number of grid rows that are visible when browser is fully expanded
-  const pseudoMaxCardHeightPx = MAX_HEIGHT_GRID_SIZE * heightPxPerGridUnit;
-  const minCardHeightPx = minGridUnitRows * heightPxPerGridUnit;
-
-  // when the dashcard is at its min height, the `gridHeightAdjustment` value will be 0.
-  // as it increases in height, it will increase in value up to `HEIGHT_ADJUSTMENT_FACTOR`.
-  const cardHeightFractionOfPseudoMax = Math.max(
-    0,
-    (cardHeightPx - minCardHeightPx) /
-      (pseudoMaxCardHeightPx - minCardHeightPx),
-  );
-  const gridHeightAdjustmentRem =
-    cardHeightFractionOfPseudoMax * HEIGHT_ADJUSTMENT_FACTOR;
-
-  return gridWidthAdjustmentRem + gridHeightAdjustmentRem;
-}
-
-export function computeFontSize(props: PropsForFontSizeScaling) {
-  const fontSizeAdjustment = computeFontSizeAdjustment(props);
-
-  // fail-safe to make sure the font size is within a reasonable range
-  const clampedScaledFontSize =
-    Math.min(
-      Math.max(MIN_SIZE_REM + fontSizeAdjustment, MIN_SIZE_REM),
-      MAX_SIZE_REM,
-    ) || MIN_SIZE_REM;
-
-  return `${clampedScaledFontSize}rem`;
-}
+};

--- a/frontend/src/metabase/visualizations/components/ScalarValue/utils.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/components/ScalarValue/utils.unit.spec.ts
@@ -1,213 +1,79 @@
-import {
-  computeFontSize,
-  computeFontSizeAdjustment,
-  WIDTH_ADJUSTMENT_FACTOR,
-  HEIGHT_ADJUSTMENT_FACTOR,
-  MAX_HEIGHT_GRID_SIZE,
-  MIN_SIZE_REM,
-  MAX_SIZE_REM,
-} from "./utils";
+import { findSize } from "./utils";
+import * as measureText from "metabase/lib/measure-text";
 
-describe("ScalarValue utils", () => {
-  const baseProps = {
-    isDashboard: true,
-    gridSize: { height: 5, width: 5 },
-    minGridSize: { height: 3, width: 3 },
-    width: 100,
-    height: 100,
-    totalNumGridCols: 15,
+jest.doMock("metabase/lib/measure-text", () => ({
+  measureText: jest.fn(),
+}));
+
+const createMockMeasureText = (width: number) => {
+  return (_text: string, _style: measureText.FontStyle) => {
+    return {
+      width,
+    } as TextMetrics;
   };
+};
 
-  describe("computeFontSize", () => {
-    it("should return a rem font size value", () => {
-      const fontSize = computeFontSize({
-        ...baseProps,
-        gridSize: { height: 10, width: 10 },
-        minGridSize: { height: 2, width: 2 },
-        totalNumGridCols: 10,
-      });
-      expect(fontSize).toEqual(
-        `${
-          MIN_SIZE_REM + HEIGHT_ADJUSTMENT_FACTOR + WIDTH_ADJUSTMENT_FACTOR
-        }rem`,
-      );
-    });
+const defaults = {
+  text: "test",
+  unit: "rem",
+  fontFamily: "Lato",
+  fontWeight: "900",
+};
 
-    it("1. should handle incorrect inputs", () => {
-      const fontSize = computeFontSize({
-        ...baseProps,
-        // results in font size < MIN_SIZE_REM
-        gridSize: { height: -10, width: -10 },
-        minGridSize: { height: 2, width: 2 },
-        totalNumGridCols: 10,
-      });
-      expect(fontSize).toEqual(`${MIN_SIZE_REM}rem`);
-    });
+describe("findSize", () => {
+  let measureTextSpy: jest.SpyInstance;
 
-    it("2. should handle incorrect inputs", () => {
-      const fontSize = computeFontSize({
-        ...baseProps,
-        gridSize: { height: 999, width: 999 },
-        minGridSize: { height: -1, width: -1 },
-        // causes a NaN
-        totalNumGridCols: -1,
-      });
-      expect(fontSize).toEqual(`${MIN_SIZE_REM}rem`);
-    });
-
-    it("3. should handle incorrect inputs", () => {
-      const fontSize = computeFontSize({
-        ...baseProps,
-        // results in font size > MAX_SIZE_REM
-        width: -100,
-        height: -100,
-        gridSize: { height: 123, width: 123 },
-        minGridSize: { height: 1, width: 1 },
-        totalNumGridCols: 123,
-      });
-      expect(fontSize).toEqual(`${MAX_SIZE_REM}rem`);
-    });
+  beforeEach(() => {
+    measureTextSpy = jest.spyOn(measureText, "measureText");
   });
 
-  describe("computeFontSizeAdjustment", () => {
-    it("should return 0 if any of the props are missing", () => {
-      const keys = Object.keys(baseProps);
-      for (const key of keys) {
-        const props = { ...baseProps, [key]: undefined };
-        expect(computeFontSizeAdjustment(props)).toEqual(0);
-      }
+  afterEach(() => {
+    measureTextSpy.mockRestore();
+  });
+
+  it("returns the max size if when text width is smaller than the target width", () => {
+    measureTextSpy.mockImplementation(createMockMeasureText(100));
+
+    const size = findSize({
+      ...defaults,
+      targetWidth: 100,
+      step: 0.2,
+      min: 2,
+      max: 5,
     });
 
-    it("should return 0 if any of the number props are 0", () => {
-      const numberKeys = Object.keys(baseProps).filter(key => {
-        const value = baseProps[key as keyof typeof baseProps];
-        return typeof value === "number";
-      });
+    expect(size).toEqual("5rem");
+  });
 
-      for (const key of numberKeys) {
-        const props = { ...baseProps, [key]: 0 };
-        expect(computeFontSizeAdjustment(props)).toEqual(0);
-      }
+  it("returns the first size with which text width is smaller than the target width", () => {
+    measureTextSpy
+      .mockImplementationOnce(createMockMeasureText(120))
+      .mockImplementationOnce(createMockMeasureText(110))
+      .mockImplementationOnce(createMockMeasureText(100)) // this is the one we want
+      .mockImplementationOnce(createMockMeasureText(90));
+
+    const size = findSize({
+      ...defaults,
+      targetWidth: 100,
+      step: 0.2,
+      min: 2,
+      max: 5,
     });
 
-    it("should return 0 for wonky gridSize values", () => {
-      const props = {
-        ...baseProps,
-        gridSize: { height: 0, width: 0 },
-        totalNumGridCols: 1,
-      };
+    expect(size).toEqual("4.6rem");
+  });
 
-      expect(computeFontSizeAdjustment(props)).toEqual(0);
+  it("returns the min size if text cannot fit into the target width", () => {
+    measureTextSpy.mockImplementation(createMockMeasureText(120));
+
+    const size = findSize({
+      ...defaults,
+      targetWidth: 100,
+      step: 0.2,
+      min: 2,
+      max: 5,
     });
 
-    it("should return 0 for wonky minGridSize values", () => {
-      const props = {
-        ...baseProps,
-        minGridSize: { height: 0, width: 0 },
-      };
-
-      expect(computeFontSizeAdjustment(props)).toEqual(0);
-    });
-
-    it("should return 0 when the gridSize match the minimum values", () => {
-      const props = {
-        ...baseProps,
-        gridSize: { height: 3, width: 3 },
-        minGridSize: { height: 3, width: 3 },
-      };
-
-      expect(computeFontSizeAdjustment(props)).toEqual(0);
-    });
-
-    it("should NOT consider height in the final output if the width is at the min", () => {
-      const props = {
-        ...baseProps,
-        gridSize: { height: MAX_HEIGHT_GRID_SIZE, width: 3 },
-        minGridSize: { height: 3, width: 3 },
-      };
-
-      expect(computeFontSizeAdjustment(props)).toEqual(0);
-    });
-
-    it("should only consider width in the final output if the height is at the min", () => {
-      const props = {
-        ...baseProps,
-        gridSize: { height: 3, width: 10 },
-        minGridSize: { height: 3, width: 3 },
-        totalNumGridCols: 10,
-      };
-
-      expect(computeFontSizeAdjustment(props)).toEqual(WIDTH_ADJUSTMENT_FACTOR);
-    });
-
-    it("should return WIDTH_ADJUSTMENT_FACTOR + HEIGHT_ADJUSTMENT_FACTOR when the gridSize matches the max values", () => {
-      const props = {
-        ...baseProps,
-        gridSize: { height: MAX_HEIGHT_GRID_SIZE, width: 15 },
-        totalNumGridCols: 15,
-      };
-
-      expect(computeFontSizeAdjustment(props)).toEqual(
-        WIDTH_ADJUSTMENT_FACTOR + HEIGHT_ADJUSTMENT_FACTOR,
-      );
-    });
-
-    it("should treat a totalNumGridCols < gridSize.width scenario as the dashcard spanning the entire grid", () => {
-      const props = {
-        ...baseProps,
-        gridSize: { height: 3, width: 10 },
-        totalNumGridCols: 1,
-      };
-
-      expect(computeFontSizeAdjustment(props)).toEqual(WIDTH_ADJUSTMENT_FACTOR);
-    });
-
-    it("should output reasonable values between the mins and the maxes", () => {
-      expect(
-        Math.round(
-          computeFontSizeAdjustment({
-            ...baseProps,
-            gridSize: { height: 3, width: 4 },
-            minGridSize: { height: 2, width: 2 },
-            totalNumGridCols: 10,
-          }),
-        ),
-      ).toEqual(2);
-
-      expect(
-        Math.round(
-          computeFontSizeAdjustment({
-            ...baseProps,
-            gridSize: { height: 7, width: 7 },
-            minGridSize: { height: 2, width: 2 },
-            totalNumGridCols: 10,
-          }),
-        ),
-      ).toEqual(5);
-
-      expect(
-        Math.round(
-          computeFontSizeAdjustment({
-            ...baseProps,
-            gridSize: { height: 9, width: 9 },
-            minGridSize: { height: 2, width: 2 },
-            totalNumGridCols: 10,
-          }),
-        ),
-      ).toEqual(7);
-    });
-
-    it("should avoid a large height adjustment for a low gridSize.width", () => {
-      expect(
-        Math.round(
-          computeFontSizeAdjustment({
-            ...baseProps,
-            gridSize: { height: 9, width: 5 },
-            minGridSize: { height: 2, width: 2 },
-            totalNumGridCols: 10,
-          }),
-        ),
-      ).toEqual(3);
-    });
+    expect(size).toEqual("2rem");
   });
 });

--- a/frontend/src/metabase/visualizations/components/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization.jsx
@@ -20,6 +20,7 @@ import {
 import { getComputedSettingsForSeries } from "metabase/visualizations/lib/settings/visualization";
 import { isSameSeries } from "metabase/visualizations/lib/utils";
 import { performDefaultAction } from "metabase/visualizations/lib/action";
+import { getFont } from "metabase/styled-components/selectors";
 
 import Utils from "metabase/lib/utils";
 import { datasetContainsNoResults } from "metabase/lib/dataset";
@@ -557,11 +558,15 @@ class Visualization extends React.PureComponent {
   }
 }
 
+const mapStateToProps = state => ({
+  fontFamily: getFont(state),
+});
+
 export default _.compose(
   ExplicitSize({
     selector: ".CardVisualization",
     refreshMode: props => (props.isDashboard ? "debounce" : "throttle"),
   }),
-  connect(),
+  connect(mapStateToProps),
   memoizeClass("_getQuestionForCardCached"),
 )(Visualization);

--- a/frontend/src/metabase/visualizations/visualizations/Scalar.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Scalar.jsx
@@ -177,9 +177,9 @@ export default class Scalar extends Component {
       visualizationIsClickable,
       onVisualizationClick,
       width,
-      height,
       gridSize,
       totalNumGridCols,
+      fontFamily,
     } = this.props;
 
     const columnIndex = this._getColumnIndex(cols, settings);
@@ -239,13 +239,11 @@ export default class Scalar extends Component {
             ref={scalar => (this._scalar = scalar)}
           >
             <ScalarValue
-              isDashboard={isDashboard}
-              gridSize={gridSize}
-              minGridSize={Scalar.minSize}
-              width={width}
-              height={height}
               value={displayValue}
+              width={width}
+              gridSize={gridSize}
               totalNumGridCols={totalNumGridCols}
+              fontFamily={fontFamily}
             />
           </span>
         </Ellipsified>

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx
@@ -97,8 +97,8 @@ export default class Smart extends React.Component {
       rawSeries,
       gridSize,
       width,
-      height,
       totalNumGridCols,
+      fontFamily,
     } = this.props;
 
     const metricIndex = cols.findIndex(col => !isDate(col));
@@ -173,12 +173,10 @@ export default class Smart extends React.Component {
           ref={scalar => (this._scalar = scalar)}
         >
           <ScalarValue
-            isDashboard={isDashboard}
             gridSize={gridSize}
-            minGridSize={Smart.minSize}
             width={width}
-            height={height}
             totalNumGridCols={totalNumGridCols}
+            fontFamily={fontFamily}
             value={formatValue(insight["last-value"], settings.column(column))}
           />
         </span>

--- a/frontend/test/__support__/ui.js
+++ b/frontend/test/__support__/ui.js
@@ -11,6 +11,10 @@ import { DragDropContextProvider } from "react-dnd";
 import HTML5Backend from "react-dnd-html5-backend";
 import { state as sampleDatabaseReduxState } from "__support__/sample_database_fixture";
 import { getStore } from "./entities-store";
+import {
+  createMockSettingsState,
+  createMockEmbedState,
+} from "metabase-types/store/mocks";
 
 function getUser(user = {}) {
   return {
@@ -48,6 +52,8 @@ export function renderWithProviders(
     withSampleDatabase,
     withRouter = false,
     withDND = false,
+    withSettings = false,
+    withEmbedSettings = false,
     ...options
   } = {},
 ) {
@@ -59,6 +65,8 @@ export function renderWithProviders(
     {
       form,
       currentUser: () => getUser(currentUser),
+      settings: withSettings ? () => createMockSettingsState() : undefined,
+      embed: withEmbedSettings ? () => createMockEmbedState() : undefined,
       ...reducers,
     },
     initialReduxState,

--- a/frontend/test/jest-setup.js
+++ b/frontend/test/jest-setup.js
@@ -1,5 +1,6 @@
 import "raf/polyfill";
 import "jest-localstorage-mock";
+import "jest-canvas-mock";
 import "__support__/mocks";
 
 // NOTE: this is needed because sometimes asynchronous code tries to access

--- a/frontend/test/metabase/visualizations/components/ChartSettings.unit.spec.js
+++ b/frontend/test/metabase/visualizations/components/ChartSettings.unit.spec.js
@@ -19,49 +19,48 @@ function widget(widget = {}) {
   };
 }
 
+const setup = props => {
+  return renderWithProviders(<ChartSettings {...DEFAULT_PROPS} {...props} />, {
+    withSettings: true,
+    withEmbedSettings: true,
+  });
+};
+
 describe("ChartSettings", () => {
   it("should not crash if there are no widgets", () => {
-    renderWithProviders(<ChartSettings {...DEFAULT_PROPS} widgets={[]} />);
+    setup({
+      widgets: [],
+    });
   });
   it("should not crash if the initial section is invalid", () => {
-    renderWithProviders(
-      <ChartSettings
-        {...DEFAULT_PROPS}
-        widgets={[widget({ section: "Foo" })]}
-        initial={{ section: "Bar" }}
-      />,
-    );
+    setup({
+      widgets: [widget({ section: "Foo" })],
+      initial: { section: "Bar" },
+    });
   });
   it("should default to the first section (if no section in DEFAULT_TAB_PRIORITY)", () => {
-    const { getByLabelText } = renderWithProviders(
-      <ChartSettings
-        {...DEFAULT_PROPS}
-        widgets={[widget({ section: "Foo" }), widget({ section: "Bar" })]}
-      />,
-    );
+    const { getByLabelText } = setup({
+      widgets: [widget({ section: "Foo" }), widget({ section: "Bar" })],
+    });
     expect(getByLabelText("Foo")).toBeChecked();
     expect(getByLabelText("Bar")).not.toBeChecked();
   });
   it("should default to the DEFAULT_TAB_PRIORITY", () => {
-    const { getByLabelText } = renderWithProviders(
-      <ChartSettings
-        {...DEFAULT_PROPS}
-        widgets={[
-          widget({ section: "Foo" }),
-          widget({ section: "Display" }), // Display is in DEFAULT_TAB_PRIORITY
-        ]}
-      />,
-    );
+    const { getByLabelText } = setup({
+      widgets: [
+        widget({ section: "Foo" }),
+        widget({ section: "Display" }), // Display is in DEFAULT_TAB_PRIORITY
+      ],
+    });
+
     expect(getByLabelText("Foo")).not.toBeChecked();
     expect(getByLabelText("Display")).toBeChecked();
   });
   it("should be able to switch sections", () => {
-    const { getByText, getByLabelText } = renderWithProviders(
-      <ChartSettings
-        {...DEFAULT_PROPS}
-        widgets={[widget({ section: "Foo" }), widget({ section: "Bar" })]}
-      />,
-    );
+    const { getByText, getByLabelText } = setup({
+      widgets: [widget({ section: "Foo" }), widget({ section: "Bar" })],
+    });
+
     expect(getByLabelText("Foo")).toBeChecked();
     expect(getByLabelText("Bar")).not.toBeChecked();
     fireEvent.click(getByText("Bar"));
@@ -70,56 +69,48 @@ describe("ChartSettings", () => {
   });
 
   it("should show widget names", () => {
-    const { getByText } = renderWithProviders(
-      <ChartSettings
-        {...DEFAULT_PROPS}
-        widgets={[
-          widget({ title: "Widget1", section: "Foo" }),
-          widget({ title: "Widget2", section: "Foo" }),
-        ]}
-      />,
-    );
+    const { getByText } = setup({
+      widgets: [
+        widget({ title: "Widget1", section: "Foo" }),
+        widget({ title: "Widget2", section: "Foo" }),
+      ],
+    });
+
     expect(getByText("Widget1", { exact: false })).toBeInTheDocument();
     expect(getByText("Widget2", { exact: false })).toBeInTheDocument();
   });
 
   it("should not show hidden widgets", () => {
-    const { getByText, queryByText } = renderWithProviders(
-      <ChartSettings
-        {...DEFAULT_PROPS}
-        widgets={[
-          widget({ title: "Widget1", section: "Foo" }),
-          widget({ title: "Widget2", section: "Foo", hidden: true }),
-        ]}
-      />,
-    );
+    const { getByText, queryByText } = setup({
+      widgets: [
+        widget({ title: "Widget1", section: "Foo" }),
+        widget({ title: "Widget2", section: "Foo", hidden: true }),
+      ],
+    });
+
     expect(getByText("Widget1", { exact: false })).toBeInTheDocument();
     expect(queryByText("Widget2", { exact: false })).toBe(null);
   });
 
   it("should show the section picker if there are multiple sections", () => {
-    const { getByText } = renderWithProviders(
-      <ChartSettings
-        {...DEFAULT_PROPS}
-        widgets={[
-          widget({ title: "Widget1", section: "Foo" }),
-          widget({ title: "Widget2", section: "Bar" }),
-        ]}
-      />,
-    );
+    const { getByText } = setup({
+      widgets: [
+        widget({ title: "Widget1", section: "Foo" }),
+        widget({ title: "Widget2", section: "Bar" }),
+      ],
+    });
+
     expect(getByText("Foo")).toBeInTheDocument();
   });
 
   it("should not show the section picker if there's only one section", () => {
-    const { queryByText } = renderWithProviders(
-      <ChartSettings
-        {...DEFAULT_PROPS}
-        widgets={[
-          widget({ title: "Something", section: "Foo" }),
-          widget({ title: "Other Thing", section: "Foo" }),
-        ]}
-      />,
-    );
+    const { queryByText } = setup({
+      widgets: [
+        widget({ title: "Something", section: "Foo" }),
+        widget({ title: "Other Thing", section: "Foo" }),
+      ],
+    });
+
     expect(queryByText("Foo")).toBe(null);
   });
 
@@ -130,17 +121,15 @@ describe("ChartSettings", () => {
       hidden: true,
       id: "column_settings",
     });
-    const { queryByText } = renderWithProviders(
-      <ChartSettings
-        {...DEFAULT_PROPS}
-        widgets={[
-          widget({ title: "List of columns", section: "Foo", id: "thing" }),
-          widget({ title: "Other Thing", section: "Bar", id: "other_thing" }),
-          columnSettingsWidget,
-        ]}
-        initial={{ widget: columnSettingsWidget }}
-      />,
-    );
+    const { queryByText } = setup({
+      widgets: [
+        widget({ title: "List of columns", section: "Foo", id: "thing" }),
+        widget({ title: "Other Thing", section: "Bar", id: "other_thing" }),
+        columnSettingsWidget,
+      ],
+      initial: { widget: columnSettingsWidget },
+    });
+
     expect(queryByText("Foo")).toBe(null);
   });
 });

--- a/frontend/test/metabase/visualizations/components/SmartScalar.unit.spec.js
+++ b/frontend/test/metabase/visualizations/components/SmartScalar.unit.spec.js
@@ -6,6 +6,12 @@ import { NumberColumn, DateTimeColumn } from "../__support__/visualizations";
 import Visualization from "metabase/visualizations/components/Visualization";
 import { getSettingsWidgetsForSeries } from "metabase/visualizations/lib/settings/visualization";
 
+const setup = series =>
+  renderWithProviders(<Visualization rawSeries={series} />, {
+    withSettings: true,
+    withEmbedSettings: true,
+  });
+
 const series = ({ rows, insights }) => {
   const cols = [
     DateTimeColumn({ name: "Month" }),
@@ -26,9 +32,8 @@ describe("SmartScalar", () => {
         col: "Count",
       },
     ];
-    const { getAllByText } = renderWithProviders(
-      <Visualization rawSeries={series({ rows, insights })} />,
-    );
+    const { getAllByText } = setup(series({ rows, insights }));
+
     getAllByText("120");
     getAllByText("20%");
     getAllByText("was 100");
@@ -46,9 +51,7 @@ describe("SmartScalar", () => {
         col: "Count",
       },
     ];
-    const { getAllByText } = renderWithProviders(
-      <Visualization rawSeries={series({ rows, insights })} />,
-    );
+    const { getAllByText } = setup(series({ rows, insights }));
     getAllByText("80");
     getAllByText("20%");
     getAllByText("was 100");
@@ -66,9 +69,7 @@ describe("SmartScalar", () => {
         col: "Count",
       },
     ];
-    const { getAllByText } = renderWithProviders(
-      <Visualization rawSeries={series({ rows, insights })} />,
-    );
+    const { getAllByText } = setup(series({ rows, insights }));
     getAllByText("100");
     getAllByText("No change from last month");
   });
@@ -87,9 +88,7 @@ describe("SmartScalar", () => {
         col: "Count",
       },
     ];
-    const { getAllByText } = renderWithProviders(
-      <Visualization rawSeries={series({ rows, insights })} />,
-    );
+    const { getAllByText } = setup(series({ rows, insights }));
     getAllByText("8,000%");
   });
 

--- a/frontend/test/metabase/visualizations/components/Visualization-pie.unit.spec.js
+++ b/frontend/test/metabase/visualizations/components/Visualization-pie.unit.spec.js
@@ -13,6 +13,12 @@ const series = rows => {
   return [{ card: { display: "pie" }, data: { rows, cols } }];
 };
 
+const setup = series =>
+  renderWithProviders(<Visualization rawSeries={series} />, {
+    withSettings: true,
+    withEmbedSettings: true,
+  });
+
 describe("pie chart", () => {
   it("should render correct percentages in legend", () => {
     const rows = [
@@ -20,9 +26,7 @@ describe("pie chart", () => {
       ["bar", 2],
       ["baz", 2],
     ];
-    const { getAllByText } = renderWithProviders(
-      <Visualization rawSeries={series(rows)} />,
-    );
+    const { getAllByText } = setup(series(rows));
     getAllByText("20%");
     getAllByText("40%");
   });
@@ -33,9 +37,7 @@ describe("pie chart", () => {
       ["bar", 0.499],
       ["baz", 0.001],
     ];
-    const { getAllByText } = renderWithProviders(
-      <Visualization rawSeries={series(rows)} />,
-    );
+    const { getAllByText } = setup(series(rows));
     getAllByText("50.0%");
     getAllByText("49.9%");
     getAllByText("0.1%");
@@ -48,9 +50,7 @@ describe("pie chart", () => {
       ["baz", 0.002],
       ["qux", 0.008],
     ];
-    const { getAllByText } = renderWithProviders(
-      <Visualization rawSeries={series(rows)} />,
-    );
+    const { getAllByText } = setup(series(rows));
     getAllByText("50%");
     getAllByText("49%");
     getAllByText("1%");
@@ -68,9 +68,7 @@ describe("pie chart", () => {
         data: { rows: [["foo", 1]], cols },
       },
     ];
-    const { getAllByText } = renderWithProviders(
-      <Visualization rawSeries={series} />,
-    );
+    const { getAllByText } = setup(series);
     getAllByText("100%"); // shouldn't multiply legend percent by `scale`
     getAllByText("123"); // should multiply the count in the center by `scale`
   });
@@ -93,9 +91,7 @@ describe("pie chart", () => {
         },
       },
     ];
-    const { getAllByText } = renderWithProviders(
-      <Visualization rawSeries={series} />,
-    );
+    const { getAllByText } = setup(series);
     getAllByText("50,1%");
   });
 
@@ -106,9 +102,7 @@ describe("pie chart", () => {
       ["baz", 0.002],
       ["qux", 0.008],
     ];
-    const { container, getAllByText, queryAllByText } = renderWithProviders(
-      <Visualization rawSeries={series(rows)} />,
-    );
+    const { container, getAllByText, queryAllByText } = setup(series(rows));
     const paths = container.querySelectorAll("path");
     const otherPath = paths[paths.length - 1];
 
@@ -127,9 +121,7 @@ describe("pie chart", () => {
       ["bar", 0.49],
       ["baz", 0.002],
     ];
-    const { container, queryAllByText } = renderWithProviders(
-      <Visualization rawSeries={series(rows)} />,
-    );
+    const { container, queryAllByText } = setup(series(rows));
     const paths = container.querySelectorAll("path");
     const otherPath = paths[paths.length - 1];
 

--- a/frontend/test/metabase/visualizations/components/Visualization-table.unit.spec.js
+++ b/frontend/test/metabase/visualizations/components/Visualization-table.unit.spec.js
@@ -39,6 +39,10 @@ describe("Table", () => {
     };
     const { getByText } = renderWithProviders(
       <Visualization rawSeries={series(rows, settings)} />,
+      {
+        withSettings: true,
+        withEmbedSettings: true,
+      },
     );
     jest.runAllTimers();
     const bgColors = rows.map(

--- a/frontend/test/metabase/visualizations/components/Visualization.unit.spec.js
+++ b/frontend/test/metabase/visualizations/components/Visualization.unit.spec.js
@@ -1,12 +1,7 @@
 import React from "react";
 import { renderWithProviders } from "__support__/ui";
 
-import {
-  NumberColumn,
-  StringColumn,
-  createFixture,
-  cleanupFixture,
-} from "../__support__/visualizations";
+import { NumberColumn, StringColumn } from "../__support__/visualizations";
 
 import { delay } from "metabase/lib/promise";
 
@@ -14,14 +9,11 @@ import { color } from "metabase/lib/colors";
 import Visualization from "metabase/visualizations/components/Visualization";
 
 describe("Visualization", () => {
-  // eslint-disable-next-line no-unused-vars
-  let element;
-
   const renderViz = async series => {
-    const utils = renderWithProviders(
-      <Visualization rawSeries={series} />,
-      element,
-    );
+    const utils = renderWithProviders(<Visualization rawSeries={series} />, {
+      withSettings: true,
+      withEmbedSettings: true,
+    });
     // The chart isn't rendered until the next tick. This is due to ExplicitSize
     // not setting the dimensions until after mounting.
     await delay(0);
@@ -32,14 +24,6 @@ describe("Visualization", () => {
     const bars = [...container.querySelectorAll(".bar")];
     return bars.map(bar => bar.getAttribute("fill"));
   };
-
-  beforeEach(() => {
-    element = createFixture();
-  });
-
-  afterEach(() => {
-    cleanupFixture(element);
-  });
 
   describe("scalar", () => {
     it("should render", async () => {

--- a/frontend/test/metabase/visualizations/components/settings/ChartNestedSettingsSeries.unit.spec.js
+++ b/frontend/test/metabase/visualizations/components/settings/ChartNestedSettingsSeries.unit.spec.js
@@ -18,14 +18,23 @@ function getSeries(display) {
     },
   ];
 }
+
+const setup = seriesDisplay => {
+  return renderWithProviders(
+    <ChartSettings
+      series={getSeries(seriesDisplay)}
+      initial={{ section: "Display" }}
+    />,
+    {
+      withSettings: true,
+      withEmbedSettings: true,
+    },
+  );
+};
+
 describe("ChartNestedSettingSeries", () => {
   it("shouldn't show line/area/bar buttons for row charts", () => {
-    const { queryByRole } = renderWithProviders(
-      <ChartSettings
-        series={getSeries("row")}
-        initial={{ section: "Display" }}
-      />,
-    );
+    const { queryByRole } = setup("row");
 
     expect(queryByRole("img", { name: /line/i })).not.toBeInTheDocument();
     expect(queryByRole("img", { name: /area/i })).not.toBeInTheDocument();
@@ -33,12 +42,7 @@ describe("ChartNestedSettingSeries", () => {
   });
 
   it("should show line/area/bar buttons for bar charts", () => {
-    const { getByRole } = renderWithProviders(
-      <ChartSettings
-        series={getSeries("bar")}
-        initial={{ section: "Display" }}
-      />,
-    );
+    const { getByRole } = setup("bar");
 
     getByRole("img", { name: /line/i });
     getByRole("img", { name: /area/i });

--- a/frontend/test/metabase/visualizations/visualizations/Scalar.unit.spec.js
+++ b/frontend/test/metabase/visualizations/visualizations/Scalar.unit.spec.js
@@ -1,6 +1,5 @@
 import React from "react";
 import { render } from "@testing-library/react";
-
 import Scalar from "metabase/visualizations/visualizations/Scalar";
 
 const series = (value = 1.23) => [

--- a/package.json
+++ b/package.json
@@ -220,6 +220,7 @@
     "html-webpack-plugin": "^5.3.1",
     "husky": "^7.0.4",
     "jest": "^27.0.6",
+    "jest-canvas-mock": "^2.4.0",
     "jest-localstorage-mock": "^2.2.0",
     "jest-watch-typeahead": "^0.6.4",
     "jsonwebtoken": "^8.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8020,7 +8020,7 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
-color-name@^1.0.0, color-name@~1.1.4:
+color-name@^1.0.0, color-name@^1.1.4, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
@@ -8938,6 +8938,11 @@ cssesc@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
   integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
+
+cssfontparser@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/cssfontparser/-/cssfontparser-1.2.1.tgz#f4022fc8f9700c68029d542084afbaf425a3f3e3"
+  integrity sha512-6tun4LoZnj7VN6YeegOVb67KBX/7JJsqvj+pv3ZA7F878/eN33AbGa5b/S/wXxS/tcp8nc40xRUrsPlxIyNUPg==
 
 cssnano@^3.10.0:
   version "3.10.0"
@@ -13271,6 +13276,14 @@ iterate-value@^1.0.2:
     es-get-iterator "^1.0.2"
     iterate-iterator "^1.0.1"
 
+jest-canvas-mock@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/jest-canvas-mock/-/jest-canvas-mock-2.4.0.tgz#947b71442d7719f8e055decaecdb334809465341"
+  integrity sha512-mmMpZzpmLzn5vepIaHk5HoH3Ka4WykbSoLuG/EKoJd0x0ID/t+INo1l8ByfcUJuDM+RIsL4QDg/gDnBbrj2/IQ==
+  dependencies:
+    cssfontparser "^1.2.1"
+    moo-color "^1.0.2"
+
 jest-changed-files@^27.0.6:
   version "27.0.6"
   resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-27.0.6.tgz#bed6183fcdea8a285482e3b50a9a7712d49a7a8b"
@@ -15362,6 +15375,13 @@ moment@2.19.3:
   version "2.29.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
   integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
+
+moo-color@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/moo-color/-/moo-color-1.0.3.tgz#d56435f8359c8284d83ac58016df7427febece74"
+  integrity sha512-i/+ZKXMDf6aqYtBhuOcej71YSlbjT3wCO/4H1j8rPvxDJEifdwgg5MaFyu6iYAT8GBZJg2z0dkgK4YMzvURALQ==
+  dependencies:
+    color-name "^1.1.4"
 
 move-concurrently@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/23093

## Changes

Scalar card text size was defined based only by a card dimenstions which frequently led to truncated text when it was possible to just decrease the font size. This PR changes the alrogithm of finding proper font-size. Now we define max font-size by a card width and then search for the largest font-size that does not overflow the text.

## How to verify

Create various scalar and trend visualizations, add them on a dashboard, try different card sizes, viewports and ensure it looks good.

### Before

Wide:
<img width="1706" alt="Screenshot 2022-07-15 at 23 40 03" src="https://user-images.githubusercontent.com/14301985/179299993-5ea6aeed-6aa6-44f0-b9d9-0786402ec039.png">

Narrow:
<img width="1072" alt="Screenshot 2022-07-15 at 23 40 33" src="https://user-images.githubusercontent.com/14301985/179300010-66d53c9b-f4c1-4145-8eab-9e68ca435ca3.png">

### After

Wide:
<img width="1716" alt="Screenshot 2022-07-15 at 23 39 32" src="https://user-images.githubusercontent.com/14301985/179300071-eb1f0780-6854-4d33-a94a-b81cbf93d45c.png">

Narrow:
<img width="1075" alt="Screenshot 2022-07-15 at 23 40 51" src="https://user-images.githubusercontent.com/14301985/179300062-9af64bfb-fa5d-45de-b5e9-2be8732608d6.png">

