### PR TITLE
Fix row/delete action; other misc. improvements

### DIFF
--- a/src/metabase/driver/postgres/actions.clj
+++ b/src/metabase/driver/postgres/actions.clj
@@ -14,6 +14,9 @@
       [{:message (tru "{0} violates not-null constraint" value)
         :column column}])))
 
+  ;; TODO -- we should probably be TTL caching this information. Otherwise parsing 100 errors for a bulk action will
+  ;; result in 100 identical data warehouse queries. It's not like constraint columns are something we would expect to
+  ;; change regularly anyway.
 (defn- constraint->column-names
   "Given a constraint with `constraint-name` fetch the column names associated with that constraint."
   [database constraint-name]

--- a/src/metabase/driver/sql_jdbc/actions.clj
+++ b/src/metabase/driver/sql_jdbc/actions.clj
@@ -14,7 +14,7 @@
             [metabase.query-processor.store :as qp.store]
             [metabase.util :as u]
             [metabase.util.honeysql-extensions :as hx]
-            [metabase.util.i18n :refer [tru trs]]
+            [metabase.util.i18n :refer [trs tru]]
             [toucan.db :as db])
   (:import java.sql.Connection))
 

--- a/src/metabase/driver/sql_jdbc/actions.clj
+++ b/src/metabase/driver/sql_jdbc/actions.clj
@@ -14,29 +14,32 @@
             [metabase.query-processor.store :as qp.store]
             [metabase.util :as u]
             [metabase.util.honeysql-extensions :as hx]
-            [metabase.util.i18n :refer [tru]]
+            [metabase.util.i18n :refer [tru trs]]
             [toucan.db :as db])
   (:import java.sql.Connection))
 
 (defmulti parse-sql-error
   "Parses the raw error message returned after an error in the driver database occurs, and converts it into a sequence
   of maps with a :column and :message key indicating what went wrong."
-  {:arglists '([driver ^java.sql.Connection connection e]), :added "0.44.0"}
+  {:arglists '([driver database e]), :added "0.44.0"}
   driver/dispatch-on-initialized-driver
   :hierarchy #'driver/hierarchy)
 
 (defn- parse-error
   "Returns errors in a way that indicates which column had the problem. Can be used to highlight errors in forms."
-  [driver conn e]
+  [driver database e]
   (let [default-method? (= (get-method parse-sql-error driver)
                            (get-method parse-sql-error :default))]
     (if default-method?
       (ex-data e)
       (let [message (ex-message e)]
-        (if-let [errors (and message
-                             (parse-sql-error driver conn message))]
-
-          {:errors (->> errors
+        (if-let [parsed-errors (when message
+                                 (try
+                                   (parse-sql-error driver database message)
+                                   (catch Throwable e
+                                     (log/error e (trs "Error parsing SQL error message {0}: {1}" (pr-str message) (ex-message e)))
+                                     nil)))]
+          {:errors (->> parsed-errors
                         (m/index-by :column)
                         (m/map-vals :message))}
           {:message (or message (pr-str e))})))))
@@ -129,7 +132,7 @@
   `(do-with-jdbc-transaction ~database-id (fn [~(vary-meta connection-binding assoc :tag 'Connection)] ~@body)))
 
 (defmethod actions/perform-action!* [:sql-jdbc :row/delete]
-  [driver _action _database {database-id :database, :as query}]
+  [driver _action database {database-id :database, :as query}]
   (let [raw-hsql    (qp.store/with-store
                       (try
                         (qp/preprocess query) ; seeds qp store as a side-effect so we can generate honeysql
@@ -155,13 +158,13 @@
         (catch Exception e
           (let [e-data (if (::incorrect-number-deleted (ex-data e))
                          (ex-data e)
-                         (parse-error driver conn e))]
+                         (parse-error driver database e))]
             (throw
              (ex-info (or (ex-message e) "Delete action error.")
                       (assoc e-data :status-code 400)))))))))
 
 (defmethod actions/perform-action!* [:sql-jdbc :row/update]
-  [driver _action _database {database-id :database :keys [update-row] :as query}]
+  [driver _action database {database-id :database :keys [update-row] :as query}]
   (let [raw-hsql     (qp.store/with-store
                        (try
                          (qp/preprocess query) ; seeds qp store as a side-effect so we can generate honeysql
@@ -189,7 +192,7 @@
         (catch Exception e
           (let [e-data (if (::incorrect-number-updated (ex-data e))
                          (ex-data e)
-                         (parse-error driver conn e))]
+                         (parse-error driver database e))]
             (throw
              (ex-info (or (ex-message e) "Update action error.")
                       (assoc e-data :status-code 400)))))))))

--- a/test/metabase/actions/test_util.clj
+++ b/test/metabase/actions/test_util.clj
@@ -7,7 +7,6 @@
     :refer [Card CardEmitter Database Emitter EmitterAction QueryAction]]
    [metabase.test :as mt]
    [metabase.test.data.dataset-definitions :as defs]
-   [metabase.test.data.impl :as data.impl]
    [metabase.test.data.interface :as tx]
    [toucan.db :as db]))
 

--- a/test/metabase/api/action_test.clj
+++ b/test/metabase/api/action_test.clj
@@ -250,7 +250,7 @@
 
 (deftest row-delete-fk-constraint-violation-test
   (testing "POST /api/action/row/delete"
-    (testing "FK constraint violations errors should have nice error messages (at least for Postgres)"
+    (testing "FK constraint violations errors should have nice error messages (at least for Postgres) (#24021)"
       (mt/test-drivers (mt/normal-drivers-with-feature :actions)
         (actions.test-util/with-actions-test-data-tables #{"venues" "categories"}
           (actions.test-util/with-actions-test-data-and-actions-enabled

--- a/test/metabase/driver/sql_jdbc/actions_test.clj
+++ b/test/metabase/driver/sql_jdbc/actions_test.clj
@@ -1,0 +1,34 @@
+(ns metabase.driver.sql-jdbc.actions-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.actions.test-util :as actions.test-util]
+   [metabase.driver :as driver]
+   [metabase.driver.sql-jdbc.actions :as sql-jdbc.actions]
+   [metabase.test :as mt]
+   [schema.core :as s]))
+
+;; this driver throws an Exception when you call `parse-sql-error`.
+(driver/register! ::parse-sql-error-exception, :parent :h2)
+
+(def ^:private parse-sql-error-called? (atom false))
+
+(defmethod sql-jdbc.actions/parse-sql-error ::parse-sql-error-exception
+  [_driver _database message]
+  (reset! parse-sql-error-called? true)
+  (throw (ex-info "OOPS I THREW AN EXCEPTION!" {:message message})))
+
+(deftest parse-sql-error-catch-exceptions-test
+  (testing "If parse-sql-error throws an Exception, log it and return the unparsed exception instead of failing entirely (#24021)"
+    (driver/with-driver ::parse-sql-error-exception
+      (actions.test-util/with-actions-test-data-tables #{"venues" "categories"}
+        (actions.test-util/with-actions-test-data-and-actions-enabled
+          (reset! parse-sql-error-called? false)
+          ;; attempting to delete the `Pizza` category should fail because there are several rows in `venues` that have
+          ;; this `category_id` -- it's an FK constraint violation.
+          (is (schema= {:message #"Referential integrity constraint violation:.*"
+                        s/Keyword s/Any}
+                       (mt/user-http-request :crowberto :post 400
+                                             "action/row/delete"
+                                             (mt/mbql-query categories {:filter [:= $id 58]}))))
+          (testing "Make sure our impl was actually called."
+            (is @parse-sql-error-called?)))))))


### PR DESCRIPTION
Fixes #24021

The root cause of this was a regression introduced in #23848 that we didn't catch because we didn't have test coverage around the Postgres error parsing code -- it was passing the parameters to `jdbc/query` in the wrong order.

Fixed and added new tests around this code.

In order to write the new tests I had to be able to trigger and FK constraint violation when deleting rows; to make this easy I introduced the new `actions.test-util/with-actions-test-data-tables` macro that makes it possible to specify which tables should be available in the actions test data. By default, we only copy the `categories` Table, for speed reasons; using this macro we can specify that we'd like to copy `categories` _and_ `venues` for example in order to test FK constraint violations.

```clj
(actions.test-util/with-actions-test-data-tables #{"venues" "categories"} 
  ...)
```

I made some other various improvements, including wrapping calls to `parse-sql-error` in a `try-catch` so future errors in parsing won't cause the entire operation to fail. I will call out other changes in comments.