### PR TITLE
Show Date Picker Consistently

### DIFF
--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterItem/utils.ts
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterItem/utils.ts
@@ -4,10 +4,10 @@ import { FieldPicker } from "./types";
 export const getFieldPickerType = (field: Field): FieldPicker => {
   if (field.isBoolean()) {
     return "boolean";
-  } else if (field.has_field_values === "list") {
-    return "category";
   } else if (field.isDate() && !field.isTime()) {
     return "date";
+  } else if (field.has_field_values === "list") {
+    return "category";
   } else if (
     field.isNumeric() ||
     field.isPK() ||


### PR DESCRIPTION
## Description

Bug: if a date field had `has_field_values: "list"`, it would show up as a default picker instead of a date picker.

![Screen Shot 2022-07-15 at 3 17 20 PM](https://user-images.githubusercontent.com/30528226/179311921-b5a6a22e-5a9a-42ac-85cd-054087d4c5c9.png)

Fix: check whether the field is a date field before checking`has_field_values`