### PR TITLE
Hide automatic datetime fields from writeback form

### DIFF
--- a/frontend/src/metabase/writeback/utils.ts
+++ b/frontend/src/metabase/writeback/utils.ts
@@ -1,3 +1,5 @@
+import { TYPE } from "metabase/lib/types";
+
 import { getTemplateTagParameterTarget } from "metabase/parameters/utils/cards";
 
 import Database from "metabase-lib/lib/metadata/Database";
@@ -19,6 +21,27 @@ export const isDatabaseWritebackEnabled = (database?: IDatabase | null) =>
 export const isWritebackSupported = (database?: Database | null) =>
   !!database?.hasFeature(DB_WRITEBACK_FEATURE);
 
+const AUTOMATIC_DATE_TIME_FIELDS = [
+  TYPE.CreationDate,
+  TYPE.CreationTemporal,
+  TYPE.CreationTime,
+  TYPE.CreationTimestamp,
+
+  TYPE.DeletionDate,
+  TYPE.DeletionTemporal,
+  TYPE.DeletionTime,
+  TYPE.DeletionTimestamp,
+
+  TYPE.UpdatedDate,
+  TYPE.UpdatedTemporal,
+  TYPE.UpdatedTime,
+  TYPE.UpdatedTimestamp,
+];
+
+export const isAutomaticDateTimeField = (field: Field) => {
+  return AUTOMATIC_DATE_TIME_FIELDS.includes(field.semantic_type);
+};
+
 export const isEditableField = (field: Field) => {
   const isRealField = typeof field.id === "number";
   if (!isRealField) {
@@ -30,6 +53,10 @@ export const isEditableField = (field: Field) => {
     // Most of the time PKs are auto-generated,
     // but there are rare cases when they're not
     // In this case they're marked as `database_required`
+    return field.database_required;
+  }
+
+  if (isAutomaticDateTimeField(field)) {
     return field.database_required;
   }
 


### PR DESCRIPTION
Hides fields like "Created At" and "Updated At" that are usually set automatically by a database from writeback forms

### To Verify

1. Using a [sample Postgres database](https://github.com/metabase/metabase-qa#postgresql-12), create a data app listing Products
2. Connect CRUD action buttons to the Products listing card
3. Click "New"
4. Ensure you can't see "Created At" field and can create a new record