### PR TITLE
Hide data app ID filters when viewing an app page

### DIFF
--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
@@ -210,12 +210,13 @@ class Dashboard extends Component {
     const {
       addParameter,
       dashboard,
+      isDataApp,
       isEditing,
       isEditingParameter,
       isFullscreen,
       isNightMode,
       isSharing,
-      parameters,
+      parameters: allParameters,
       parameterValues,
       isNavbarOpen,
       showAddQuestionSidebar,
@@ -230,6 +231,17 @@ class Dashboard extends Component {
 
     const shouldRenderAsNightMode = isNightMode && isFullscreen;
     const dashboardHasCards = dashboard => dashboard.ordered_cards.length > 0;
+
+    const parameters = isDataApp
+      ? // Writeback hack for prototyping purposes
+        // We need ID parameters to configure custom destinations,
+        // but in the end we don't want to keep them visible to the user
+        // This lets us achieve the desired behavior
+        // when ID parameters are only visible in dashboard editing mode
+        allParameters.filter(parameter =>
+          isEditing ? parameter : parameter.type !== "id",
+        )
+      : allParameters;
 
     const parametersWidget = (
       <SyncedParametersList
@@ -316,7 +328,7 @@ class Dashboard extends Component {
                       {...this.props}
                       isNightMode={shouldRenderAsNightMode}
                       onEditingChange={this.setEditing}
-                      isDataApp={this.props.isDataApp}
+                      isDataApp={isDataApp}
                     />
                   ) : (
                     <DashboardEmptyState


### PR DESCRIPTION
Hacky prototype for ID filters in data apps. When we create list and detail app pages, we need an ID filter on the details page to connect them via the "custom destination" click behavior. We don't really want to let users change those parameters on the details page and would prefer to keep them hidden/implicit.

This PR basically hides any "ID" dashboard parameter when you're viewing a data app. You can still see it in the editing mode, at least so you're able to create/update it for testing purposes.

### Demo

https://user-images.githubusercontent.com/17258145/179510235-0736cf56-6698-4aca-847d-d071fff64517.mp4

