### PR TITLE
Fixing dashboard info sidebar height

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashboardInfoSidebar.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardInfoSidebar.styled.tsx
@@ -10,7 +10,7 @@ export const DashboardInfoSidebarRoot = styled.aside`
   padding: 0 2rem 0.5rem;
   background: ${color("white")};
   border-left: 1px solid ${color("border")};
-  height: 100%;
+  align-self: stretch
   overflow-y: auto;
   box-sizing: border-box;
 


### PR DESCRIPTION
Small adjustment to fix the height of the Dashboard info sidebar

Before: https://metaboat.slack.com/files/U01TH98M6J2/F03PP6HSTK5/cleanshot_2022-07-15_at_15.32.01.mp4

After:
![image](https://user-images.githubusercontent.com/1328979/179533740-7c7e65a6-9b23-4d7b-84ac-2c42f5283f53.png)
