### PR TITLE
Update env variables

### DIFF
--- a/bin/docker/Dockerfile
+++ b/bin/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM eclipse-temurin:11-jre-alpine
 
-ENV FC_LANG en-US LC_CTYPE en_US.UTF-8
+ENV FC_LANG=en-US LC_CTYPE=en_US.UTF-8
 
 # dependencies
 RUN apk add -U bash ttf-dejavu fontconfig curl java-cacerts && \


### PR DESCRIPTION
As the user in https://github.com/metabase/metabase/pull/14585#discussion_r922696696 quickly noticed, the key value syntax in Dockerfiles is legacy and also we shouldn't use it with more than 1 key. This didn't make any effect as the base image had our Env keys already there, but if there's a change at some point, we might end up with weird env settings