### PR TITLE
Update copy in confirmation modal when removing a text card from a dashboard 

### DIFF
--- a/frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx
+++ b/frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx
@@ -27,7 +27,7 @@ export default class RemoveFromDashboardModal extends Component {
   render() {
     const { onClose } = this.props;
     return (
-      <ModalContent title={t`Remove this question?`} onClose={() => onClose()}>
+      <ModalContent title={t`Remove this card?`} onClose={onClose}>
         <div className="flex-align-right">
           <Button onClick={onClose}>{t`Cancel`}</Button>
           <Button danger ml={2} onClick={() => this.onRemove()}>


### PR DESCRIPTION
Resolves #23841

### How to Test

1. Add a question to a dashboard
2. Edit dashboard
3. Click `×` to remove card from dashboard

Confirmation modal should now say "Remove this card?"

