### PR TITLE
[E2E] Obtain version for Cypress runner synchronously

### DIFF
--- a/frontend/test/__runner__/cypress-runner-get-version.js
+++ b/frontend/test/__runner__/cypress-runner-get-version.js
@@ -1,8 +1,9 @@
-const { printBold, printCyan, readFile } = require("./cypress-runner-utils.js");
+const fs = require("fs");
+const { printBold, printCyan } = require("./cypress-runner-utils.js");
 
 const getVersion = async () => {
   try {
-    const version = await readFile(
+    const version = fs.readFileSync(
       __dirname + "/../../../resources/version.properties",
     );
 

--- a/frontend/test/__runner__/cypress-runner-utils.js
+++ b/frontend/test/__runner__/cypress-runner-utils.js
@@ -1,4 +1,3 @@
-const fs = require("fs");
 const chalk = require("chalk");
 const { exec } = require("child_process");
 
@@ -13,17 +12,6 @@ function printYellow(message) {
 function printCyan(message) {
   console.log(chalk.cyan(message));
 }
-
-const readFile = fileName => {
-  return new Promise(function (resolve, reject) {
-    fs.readFile(fileName, "utf8", (err, data) => {
-      if (err) {
-        reject(err);
-      }
-      resolve(data);
-    });
-  });
-};
 
 function executeYarnCommand({ command, message } = {}) {
   return new Promise((resolve, reject) => {
@@ -46,6 +34,5 @@ module.exports = {
   printBold,
   printYellow,
   printCyan,
-  readFile,
   executeYarnCommand,
 };


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Removes our own "promisified" version of `readFile` and replaces it with the synchronous NodeJS function `readFileSync`

Everything regarding Cypress and its invocation should still work as it did before. This is just a tech debt removal.