### PR TITLE
fix suggesting read-only root as a parent collection

### DIFF
--- a/frontend/src/metabase/entities/collections/collections.js
+++ b/frontend/src/metabase/entities/collections/collections.js
@@ -90,25 +90,33 @@ const Collections = createEntity({
     getInitialCollectionId: createSelector(
       [
         state => state.entities.collections,
+        getUserPersonalCollectionId,
 
         // these are listed in order of priority
         byCollectionIdProp,
         byCollectionIdNavParam,
         byCollectionUrlId,
         byCollectionQueryParameter,
-
-        // defaults
-        () => ROOT_COLLECTION.id,
-        getUserPersonalCollectionId,
       ],
-      (collections, ...collectionIds) => {
-        for (const collectionId of collectionIds) {
+      (collections, personalId, ...collectionIds) => {
+        const allCollectionIds = [
+          ...collectionIds,
+          ROOT_COLLECTION.id,
+          personalId,
+        ];
+
+        for (const collectionId of allCollectionIds) {
           const collection = collections[collectionId];
           if (collection && collection.can_write) {
             return canonicalCollectionId(collectionId);
           }
         }
-        return canonicalCollectionId(ROOT_COLLECTION.id);
+
+        const rootCollection = collections[ROOT_COLLECTION.id];
+
+        return rootCollection?.can_write
+          ? canonicalCollectionId(ROOT_COLLECTION.id)
+          : canonicalCollectionId(personalId);
       },
     ),
   },

--- a/frontend/test/metabase/entities/collections/selectors.unit.spec.js
+++ b/frontend/test/metabase/entities/collections/selectors.unit.spec.js
@@ -1,4 +1,4 @@
-import Collections from "metabase/entities/collections";
+import Collections, { ROOT_COLLECTION } from "metabase/entities/collections";
 
 describe("Collection selectors", () => {
   const CANONICAL_ROOT_COLLECTION_ID = null;
@@ -43,13 +43,13 @@ describe("Collection selectors", () => {
       },
       entities: {
         collections: {
-          ...collections,
           root: {
             id: "root",
             name: "Our analytics",
             can_write: isAdmin,
           },
           [PERSONAL_COLLECTION.id]: PERSONAL_COLLECTION,
+          ...collections,
         },
       },
     };
@@ -185,6 +185,35 @@ describe("Collection selectors", () => {
             pathname: `/collection/${TEST_READ_ONLY_COLLECTION.id}-slug`,
             query: {
               collectionId: TEST_READ_ONLY_COLLECTION.id,
+            },
+          },
+        };
+        expect(getInitialCollectionId(state, props)).toBe(
+          PERSONAL_COLLECTION.id,
+        );
+      });
+
+      it("does not suggest a read-only root collection when others collections permissions had not been loaded yet", () => {
+        // eslint-disable-next-line no-unused-vars
+        const { can_write, ...personalCollectionWithoutPermissionsLoaded } =
+          PERSONAL_COLLECTION;
+
+        const state = getReduxState({
+          collections: {
+            [PERSONAL_COLLECTION.id]:
+              personalCollectionWithoutPermissionsLoaded,
+          },
+        });
+        const props = {
+          collectionId: ROOT_COLLECTION.id,
+          params: {
+            collectionId: CANONICAL_ROOT_COLLECTION_ID,
+            slug: ROOT_COLLECTION.id,
+          },
+          location: {
+            pathname: `/collection/${ROOT_COLLECTION.id}`,
+            query: {
+              collectionId: ROOT_COLLECTION.id,
             },
           },
         };


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/24015

## Changes

The `/api/collection/tree?tree=true` handler which returns the entire collection tree does not return `can_write` permission value it is `false` even for the personal collection. However, the selector of the initially selected collection ID falls back on the `root` collection which is not correct when a user do not have the permission to write to it.

## How to verify

- As an admin go to the [root collection permissions](http://localhost:3000/admin/permissions/collections/root) and make it read-only for all users
- Login under an another user and open the collections sidebar
- Click on `...` -> "New collection"
- Ensure it suggests your personal collection and does not show any errors