### PR TITLE
Closing all Dashboard sidebars when entering/exiting edit mode

### DIFF
--- a/frontend/src/metabase/dashboard/reducers.js
+++ b/frontend/src/metabase/dashboard/reducers.js
@@ -379,8 +379,7 @@ const sidebar = handleActions(
       next: () => DEFAULT_SIDEBAR,
     },
     [SET_EDITING_DASHBOARD]: {
-      next: (state, { payload: isEditing }) =>
-        isEditing ? state : DEFAULT_SIDEBAR,
+      next: () => DEFAULT_SIDEBAR,
     },
     [REMOVE_PARAMETER]: {
       next: () => DEFAULT_SIDEBAR,

--- a/frontend/src/metabase/dashboard/reducers.unit.spec.js
+++ b/frontend/src/metabase/dashboard/reducers.unit.spec.js
@@ -97,7 +97,7 @@ describe("dashboard reducers", () => {
   });
 
   describe("SET_EDITING_DASHBOARD", () => {
-    it("should preserve sidebar state if payload is true to signify the entering of dashboard edit mode", () => {
+    it("should clear sideabr state when entering edit mode", () => {
       const state = {
         ...initState,
         sidebar: { name: "foo", props: { abc: 123 } },
@@ -107,7 +107,7 @@ describe("dashboard reducers", () => {
           type: SET_EDITING_DASHBOARD,
           payload: true,
         }),
-      ).toEqual({ ...state, isEditing: true });
+      ).toEqual({ ...state, isEditing: true, sidebar: { props: {} } });
     });
 
     it("should clear sideabr state when leaving edit mode", () => {


### PR DESCRIPTION
Close info (and subscription) sidebar when entering edit mode
![chrome_16HzMbS6uK](https://user-images.githubusercontent.com/1328979/179574533-e00b094d-5e33-4929-b8b6-b67b9587839f.gif)

