### PR TITLE
Handle snippets when determining if a query is fully parametrized

### DIFF
--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -332,9 +332,13 @@
                                 (comp (filter params/Param?)
                                       (map :k))
                                 (params.parse/parse text))]
-    (and (every? #(or (:default %) (= (:type %) :dimension) (fully-parametrized-snippet? %))
+    (and (every? #(or (= (:type %) :dimension)
+                      (:default %)
+                      (fully-parametrized-snippet? %))
                  (map template-tags obligatory-params))
-         (every? #(or (:default %) (not (:required %))) (vals template-tags)))))
+         (every? #(or (not (:required %))
+                      (:default %))
+                 (vals template-tags)))))
 
 (defn- fully-parametrized-query? [row]
   (let [native-query (-> row :dataset_query json/parse-string mbql.normalize/normalize :native)]

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -1065,72 +1065,33 @@
                                                                            :param1 {:required false}
                                                                            :param2 {:required false}}
                                                            :query         "select {{param0}}, {{param1}} [[ , {{param2}} ]]"}}}]
-          (is (= (let [collection (collection/user->personal-collection (mt/user->id :crowberto))]
-                   [{:name                "Business Card"
-                     :description         nil
-                     :collection_position nil
-                     :collection_preview  true
-                     :display             "table"
-                     :moderated_status    nil
-                     :entity_id           (:entity_id card)
-                     :model               "card"
-                     :fully_parametrized  false}
-                    {:name            "Crowberto Corv's Personal Collection"
-                     :description     nil
-                     :model           "collection"
-                     :authority_level nil
-                     :entity_id       (:entity_id collection)
-                     :can_write       true}])
-                 (for [item (:data (mt/user-http-request :crowberto :get 200 "collection/root/items"))]
-                   (dissoc item :id))))))
+          (is (partial= [{:name                "Business Card"
+                          :entity_id           (:entity_id card)
+                          :model               "card"
+                          :fully_parametrized  false}]
+                        (:data (mt/user-http-request :crowberto :get 200 "collection/root/items"))))))
 
       (testing "is false even if a required field-filter parameter has no default"
         (mt/with-temp Card [card {:name          "Business Card"
                                   :dataset_query {:native {:template-tags {:param0 {:default 0}
                                                                            :param1 {:type "dimension", :required true}}
                                                            :query         "select {{param0}}, {{param1}}"}}}]
-          (is (= (let [collection (collection/user->personal-collection (mt/user->id :crowberto))]
-                   [{:name                "Business Card"
-                     :description         nil
-                     :collection_position nil
-                     :collection_preview  true
-                     :display             "table"
-                     :moderated_status    nil
-                     :entity_id           (:entity_id card)
-                     :model               "card"
-                     :fully_parametrized  false}
-                    {:name            "Crowberto Corv's Personal Collection"
-                     :description     nil
-                     :model           "collection"
-                     :authority_level nil
-                     :entity_id       (:entity_id collection)
-                     :can_write       true}])
-                 (for [item (:data (mt/user-http-request :crowberto :get 200 "collection/root/items"))]
-                   (dissoc item :id))))))
+          (is (partial= [{:name                "Business Card"
+                          :entity_id           (:entity_id card)
+                          :model               "card"
+                          :fully_parametrized  false}]
+                        (:data (mt/user-http-request :crowberto :get 200 "collection/root/items"))))))
 
       (testing "is false even if an optional required parameter has no default"
         (mt/with-temp Card [card {:name          "Business Card"
                                   :dataset_query {:native {:template-tags {:param0 {:default 0}
                                                                            :param1 {:required true}}
                                                            :query         "select {{param0}}, [[ , {{param1}} ]]"}}}]
-          (is (= (let [collection (collection/user->personal-collection (mt/user->id :crowberto))]
-                   [{:name                "Business Card"
-                     :description         nil
-                     :collection_position nil
-                     :collection_preview  true
-                     :display             "table"
-                     :moderated_status    nil
-                     :entity_id           (:entity_id card)
-                     :model               "card"
-                     :fully_parametrized  false}
-                    {:name            "Crowberto Corv's Personal Collection"
-                     :description     nil
-                     :model           "collection"
-                     :authority_level nil
-                     :entity_id       (:entity_id collection)
-                     :can_write       true}])
-                 (for [item (:data (mt/user-http-request :crowberto :get 200 "collection/root/items"))]
-                   (dissoc item :id))))))
+          (is (partial= [{:name                "Business Card"
+                          :entity_id           (:entity_id card)
+                          :model               "card"
+                          :fully_parametrized  false}]
+                        (:data (mt/user-http-request :crowberto :get 200 "collection/root/items"))))))
 
       (testing "is true if all obligatory parameters have defaults"
         (mt/with-temp Card [card {:name          "Business Card"
@@ -1139,24 +1100,11 @@
                                                                            :param2 {}
                                                                            :param3 {:type "dimension"}}
                                                            :query "select {{param0}}, {{param1}} [[ , {{param2}} ]] from t {{param3}}"}}}]
-          (is (= (let [collection (collection/user->personal-collection (mt/user->id :crowberto))]
-                   [{:name                "Business Card"
-                     :description         nil
-                     :collection_position nil
-                     :collection_preview  true
-                     :display             "table"
-                     :moderated_status    nil
-                     :entity_id           (:entity_id card)
-                     :model               "card"
-                     :fully_parametrized  true}
-                    {:name            "Crowberto Corv's Personal Collection"
-                     :description     nil
-                     :model           "collection"
-                     :authority_level nil
-                     :entity_id       (:entity_id collection)
-                     :can_write       true}])
-                 (for [item (:data (mt/user-http-request :crowberto :get 200 "collection/root/items"))]
-                   (dissoc item :id))))))
+          (is (partial= [{:name                "Business Card"
+                          :entity_id           (:entity_id card)
+                          :model               "card"
+                          :fully_parametrized  true}]
+                        (:data (mt/user-http-request :crowberto :get 200 "collection/root/items"))))))
 
       (testing "using a snippet without parameters is true"
         (mt/with-temp* [NativeQuerySnippet [snippet {:content    "table"
@@ -1170,24 +1118,11 @@
                                                                                        :snippet-name "snippet"
                                                                                        :snippet-id   (:id snippet)}}
                                                              :query "select {{param0}} from {{snippet}}"}}}]]
-          (is (= (let [collection (collection/user->personal-collection (mt/user->id :crowberto))]
-                   [{:name                "Business Card"
-                     :description         nil
-                     :collection_position nil
-                     :collection_preview  true
-                     :display             "table"
-                     :moderated_status    nil
-                     :entity_id           (:entity_id card)
-                     :model               "card"
-                     :fully_parametrized  true}
-                    {:name            "Crowberto Corv's Personal Collection"
-                     :description     nil
-                     :model           "collection"
-                     :authority_level nil
-                     :entity_id       (:entity_id collection)
-                     :can_write       true}])
-                 (for [item (:data (mt/user-http-request :crowberto :get 200 "collection/root/items"))]
-                   (dissoc item :id))))))
+          (is (partial= [{:name                "Business Card"
+                          :entity_id           (:entity_id card)
+                          :model               "card"
+                          :fully_parametrized  true}]
+                        (:data (mt/user-http-request :crowberto :get 200 "collection/root/items"))))))
 
       (testing "using a not fully parametrized snippet without parameters is false"
         (mt/with-temp* [NativeQuerySnippet [snippet {:content    "table where x = {{param}}"
@@ -1202,24 +1137,11 @@
                                                                                        :snippet-name "snippet"
                                                                                        :snippet-id   (:id snippet)}}
                                                              :query "select {{param0}} from {{snippet}}"}}}]]
-          (is (= (let [collection (collection/user->personal-collection (mt/user->id :crowberto))]
-                   [{:name                "Business Card"
-                     :description         nil
-                     :collection_position nil
-                     :collection_preview  true
-                     :display             "table"
-                     :moderated_status    nil
-                     :entity_id           (:entity_id card)
-                     :model               "card"
-                     :fully_parametrized  false}
-                    {:name            "Crowberto Corv's Personal Collection"
-                     :description     nil
-                     :model           "collection"
-                     :authority_level nil
-                     :entity_id       (:entity_id collection)
-                     :can_write       true}])
-                 (for [item (:data (mt/user-http-request :crowberto :get 200 "collection/root/items"))]
-                   (dissoc item :id))))))
+          (is (partial= [{:name                "Business Card"
+                          :entity_id           (:entity_id card)
+                          :model               "card"
+                          :fully_parametrized  false}]
+                        (:data (mt/user-http-request :crowberto :get 200 "collection/root/items"))))))
 
       (testing "using a nested snippet without parameters is true"
         (mt/with-temp* [NativeQuerySnippet [snippet {:content    "table"
@@ -1242,24 +1164,11 @@
                                                                               :snippet-name "parent-snippet"
                                                                               :snippet-id   (:id parent-snippet)}}
                                                              :query "select {{param0}} from {{parent-snippet}}"}}}]]
-          (is (= (let [collection (collection/user->personal-collection (mt/user->id :crowberto))]
-                   [{:name                "Business Card"
-                     :description         nil
-                     :collection_position nil
-                     :collection_preview  true
-                     :display             "table"
-                     :moderated_status    nil
-                     :entity_id           (:entity_id card)
-                     :model               "card"
-                     :fully_parametrized  true}
-                    {:name            "Crowberto Corv's Personal Collection"
-                     :description     nil
-                     :model           "collection"
-                     :authority_level nil
-                     :entity_id       (:entity_id collection)
-                     :can_write       true}])
-                 (for [item (:data (mt/user-http-request :crowberto :get 200 "collection/root/items"))]
-                   (dissoc item :id))))))
+          (is (partial= [{:name                "Business Card"
+                          :entity_id           (:entity_id card)
+                          :model               "card"
+                          :fully_parametrized  true}]
+                        (:data (mt/user-http-request :crowberto :get 200 "collection/root/items"))))))
 
       (testing "using a not fully parametrized nested snippet without parameters is false"
         (mt/with-temp* [NativeQuerySnippet [snippet {:content    "table where x = {{param}}"
@@ -1283,24 +1192,11 @@
                                                                               :snippet-name "parent-snippet"
                                                                               :snippet-id   (:id parent-snippet)}}
                                                              :query "select {{param0}} from {{parent-snippet}}"}}}]]
-          (is (= (let [collection (collection/user->personal-collection (mt/user->id :crowberto))]
-                   [{:name                "Business Card"
-                     :description         nil
-                     :collection_position nil
-                     :collection_preview  true
-                     :display             "table"
-                     :moderated_status    nil
-                     :entity_id           (:entity_id card)
-                     :model               "card"
-                     :fully_parametrized  false}
-                    {:name            "Crowberto Corv's Personal Collection"
-                     :description     nil
-                     :model           "collection"
-                     :authority_level nil
-                     :entity_id       (:entity_id collection)
-                     :can_write       true}])
-                 (for [item (:data (mt/user-http-request :crowberto :get 200 "collection/root/items"))]
-                   (dissoc item :id)))))))))
+          (is (partial= [{:name                "Business Card"
+                          :entity_id           (:entity_id card)
+                          :model               "card"
+                          :fully_parametrized  false}]
+                        (:data (mt/user-http-request :crowberto :get 200 "collection/root/items")))))))))
 
 ;;; ----------------------------------- Effective Children, Ancestors, & Location ------------------------------------
 

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -1156,6 +1156,150 @@
                      :entity_id       (:entity_id collection)
                      :can_write       true}])
                  (for [item (:data (mt/user-http-request :crowberto :get 200 "collection/root/items"))]
+                   (dissoc item :id))))))
+
+      (testing "using a snippet without parameters is true"
+        (mt/with-temp* [NativeQuerySnippet [snippet {:content    "table"
+                                                     :creator_id (mt/user->id :crowberto)
+                                                     :name       "snippet"}]
+                        Card [card {:name          "Business Card"
+                                    :dataset_query {:native {:template-tags {:param0  {:required false
+                                                                                       :default  0}
+                                                                             :snippet {:name         "snippet"
+                                                                                       :type         :snippet
+                                                                                       :snippet-name "snippet"
+                                                                                       :snippet-id   (:id snippet)}}
+                                                             :query "select {{param0}} from {{snippet}}"}}}]]
+          (is (= (let [collection (collection/user->personal-collection (mt/user->id :crowberto))]
+                   [{:name                "Business Card"
+                     :description         nil
+                     :collection_position nil
+                     :collection_preview  true
+                     :display             "table"
+                     :moderated_status    nil
+                     :entity_id           (:entity_id card)
+                     :model               "card"
+                     :fully_parametrized  true}
+                    {:name            "Crowberto Corv's Personal Collection"
+                     :description     nil
+                     :model           "collection"
+                     :authority_level nil
+                     :entity_id       (:entity_id collection)
+                     :can_write       true}])
+                 (for [item (:data (mt/user-http-request :crowberto :get 200 "collection/root/items"))]
+                   (dissoc item :id))))))
+
+      (testing "using a not fully parametrized snippet without parameters is false"
+        (mt/with-temp* [NativeQuerySnippet [snippet {:content    "table where x = {{param}}"
+                                                     :template_tags {"param" {:required false}}
+                                                     :creator_id (mt/user->id :crowberto)
+                                                     :name       "snippet"}]
+                        Card [card {:name          "Business Card"
+                                    :dataset_query {:native {:template-tags {:param0  {:required false
+                                                                                       :default  0}
+                                                                             :snippet {:name         "snippet"
+                                                                                       :type         :snippet
+                                                                                       :snippet-name "snippet"
+                                                                                       :snippet-id   (:id snippet)}}
+                                                             :query "select {{param0}} from {{snippet}}"}}}]]
+          (is (= (let [collection (collection/user->personal-collection (mt/user->id :crowberto))]
+                   [{:name                "Business Card"
+                     :description         nil
+                     :collection_position nil
+                     :collection_preview  true
+                     :display             "table"
+                     :moderated_status    nil
+                     :entity_id           (:entity_id card)
+                     :model               "card"
+                     :fully_parametrized  false}
+                    {:name            "Crowberto Corv's Personal Collection"
+                     :description     nil
+                     :model           "collection"
+                     :authority_level nil
+                     :entity_id       (:entity_id collection)
+                     :can_write       true}])
+                 (for [item (:data (mt/user-http-request :crowberto :get 200 "collection/root/items"))]
+                   (dissoc item :id))))))
+
+      (testing "using a nested snippet without parameters is true"
+        (mt/with-temp* [NativeQuerySnippet [snippet {:content    "table"
+                                                     :creator_id (mt/user->id :crowberto)
+                                                     :name       "snippet"}]
+                        NativeQuerySnippet [parent-snippet {:content    "{{snippet}}"
+                                                            :creator_id (mt/user->id :crowberto)
+                                                            :name       "parent-snippet"
+                                                            :template_tags
+                                                            {"snippet" {:name         "snippet"
+                                                                        :type         :snippet
+                                                                        :snippet-name "snippet"
+                                                                        :snippet-id   (:id snippet)}}}]
+                        Card [card {:name          "Business Card"
+                                    :dataset_query {:native {:template-tags {:param0  {:required false
+                                                                                       :default  0}
+                                                                             :parent-snippet
+                                                                             {:name         "parent-snippet"
+                                                                              :type         :snippet
+                                                                              :snippet-name "parent-snippet"
+                                                                              :snippet-id   (:id parent-snippet)}}
+                                                             :query "select {{param0}} from {{parent-snippet}}"}}}]]
+          (is (= (let [collection (collection/user->personal-collection (mt/user->id :crowberto))]
+                   [{:name                "Business Card"
+                     :description         nil
+                     :collection_position nil
+                     :collection_preview  true
+                     :display             "table"
+                     :moderated_status    nil
+                     :entity_id           (:entity_id card)
+                     :model               "card"
+                     :fully_parametrized  true}
+                    {:name            "Crowberto Corv's Personal Collection"
+                     :description     nil
+                     :model           "collection"
+                     :authority_level nil
+                     :entity_id       (:entity_id collection)
+                     :can_write       true}])
+                 (for [item (:data (mt/user-http-request :crowberto :get 200 "collection/root/items"))]
+                   (dissoc item :id))))))
+
+      (testing "using a not fully parametrized nested snippet without parameters is false"
+        (mt/with-temp* [NativeQuerySnippet [snippet {:content    "table where x = {{param}}"
+                                                     :template_tags {"param" {:required false}}
+                                                     :creator_id (mt/user->id :crowberto)
+                                                     :name       "snippet"}]
+                        NativeQuerySnippet [parent-snippet {:content    "{{snippet}}"
+                                                            :creator_id (mt/user->id :crowberto)
+                                                            :name       "parent-snippet"
+                                                            :template_tags
+                                                            {"snippet" {:name         "snippet"
+                                                                        :type         :snippet
+                                                                        :snippet-name "snippet"
+                                                                        :snippet-id   (:id snippet)}}}]
+                        Card [card {:name          "Business Card"
+                                    :dataset_query {:native {:template-tags {:param0  {:required false
+                                                                                       :default  0}
+                                                                             :parent-snippet
+                                                                             {:name         "parent-snippet"
+                                                                              :type         :snippet
+                                                                              :snippet-name "parent-snippet"
+                                                                              :snippet-id   (:id parent-snippet)}}
+                                                             :query "select {{param0}} from {{parent-snippet}}"}}}]]
+          (is (= (let [collection (collection/user->personal-collection (mt/user->id :crowberto))]
+                   [{:name                "Business Card"
+                     :description         nil
+                     :collection_position nil
+                     :collection_preview  true
+                     :display             "table"
+                     :moderated_status    nil
+                     :entity_id           (:entity_id card)
+                     :model               "card"
+                     :fully_parametrized  false}
+                    {:name            "Crowberto Corv's Personal Collection"
+                     :description     nil
+                     :model           "collection"
+                     :authority_level nil
+                     :entity_id       (:entity_id collection)
+                     :can_write       true}])
+                 (for [item (:data (mt/user-http-request :crowberto :get 200 "collection/root/items"))]
                    (dissoc item :id)))))))))
 
 ;;; ----------------------------------- Effective Children, Ancestors, & Location ------------------------------------


### PR DESCRIPTION
This PR is part of #23222 and follows up on #23691 adding support for snippets. It takes the changes made in #23658 into account.

The idea is to recursively check snippets just like queries.