### PR TITLE
Remove Horizontal Scroll From Picker Components

### DIFF
--- a/frontend/src/metabase/query_builder/components/filters/FilterPopover.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/FilterPopover.tsx
@@ -314,7 +314,6 @@ export default class FilterPopover extends Component<Props, State> {
                     filter={filter}
                     onFilterChange={this.handleFilterChange}
                     onCommit={this.handleCommit}
-                    minWidth={isSidebar ? null : MIN_WIDTH}
                     maxWidth={isSidebar ? null : MAX_WIDTH}
                     primaryColor={primaryColor}
                     checkedColor={checkedColor}

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterSelect/BulkFilterSelect.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterSelect/BulkFilterSelect.styled.tsx
@@ -12,7 +12,6 @@ type SelectFilterButtonProps = {
 export const SelectFilterButton = styled(SelectButton)<SelectFilterButtonProps>`
   grid-column: 2;
   height: 55px;
-  max-width: 500px; // to match inputs
 
   ${({ isActive }) => (isActive ? `border-color: ${color("brand")};` : "")}
 
@@ -23,7 +22,6 @@ export const SelectFilterButton = styled(SelectButton)<SelectFilterButtonProps>`
 
 export const SegmentSelect = styled(Select)`
   height: 55px;
-  max-width: 500px; // to match inputs
 `;
 
 export const SelectFilterPopover = styled(FilterPopover)`

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineValuePicker/InlineValuePicker.styled.ts
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineValuePicker/InlineValuePicker.styled.ts
@@ -10,7 +10,6 @@ export const ArgumentSelector = styled(FieldValuesWidget)`
 `;
 
 export const ValuesPickerContainer = styled.div`
-  grid-column: 2;
   ul.input {
     margin-bottom: 0;
     :focus-within {

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineValuePicker/InlineValuePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineValuePicker/InlineValuePicker.tsx
@@ -82,6 +82,8 @@ function ValuesInput({
         className="input"
         fields={[field]}
         multi={!!filter?.operator()?.multi}
+        expand={false}
+        maxWidth="100%"
         showOptionsInPopover
         disableList
       />


### PR DESCRIPTION
This fixes two horizontal scroll issues, both involving the `FieldValuesPicker` component

1. In the Bulk filter modal, if you changed the size of the window, you could get horizontal scroll because the FieldValuesWidget would get stuck at 500px wide.

before | after
--- | ---
![badResize](https://user-images.githubusercontent.com/30528226/179619434-0394cd5d-4203-402e-a16b-c2aa77b4eb3a.gif) |  ![goodResize](https://user-images.githubusercontent.com/30528226/179619446-60ae8e01-e4fb-4577-8bc0-9bcc1f51c141.gif)

2. This is a bug that has existed at least since 0.42: namely the filter popover widget has had horizontal scrollbars when the fieldValuesWidget shows checkbox options, *but only on Firefox and Safari*. I think this has to do with how those browsers handle the width of scrollbars differently from Chrome. Whenever a vertical scrollbar is present, Safari and Firefox widen the container and cause a horizontal scrollbar to appear.

browser | Before | After
--- | --- | ---
Firefox | ![Screen Shot 2022-07-18 at 3 06 03 PM](https://user-images.githubusercontent.com/30528226/179619920-935836d3-f68c-4bba-80ea-912ea12722ab.png) | ![Screen Shot 2022-07-18 at 3 11 09 PM](https://user-images.githubusercontent.com/30528226/179619924-f7e10060-a73f-484a-871b-b5c5124ca7ca.png)
Safari | ![Screen Shot 2022-07-18 at 3 12 37 PM](https://user-images.githubusercontent.com/30528226/179619823-6ca494e0-07f4-4976-a897-5fef186adef5.png) | ![Screen Shot 2022-07-18 at 3 13 01 PM](https://user-images.githubusercontent.com/30528226/179619821-5b5f9636-b5d9-44c7-8e7d-1631c9ecf391.png)

## Testing Steps
1. Open a bulk filter modal on a table (like products) that has text inputs - see that changing the window width does not cause horiztonal scroll
2. Open a table (like orders) that has a column that will list field values (like quantity on the orders table, or states on the people table), and see that in the column header and the filter modal there is no horizontal scroll.

