### PR TITLE
bump e2e specs timeout from 35 to 45 minutes

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -44,7 +44,7 @@ jobs:
 
   e2e-tests:
     runs-on: ubuntu-20.04
-    timeout-minutes: 35
+    timeout-minutes: 45
     needs: build
     name: e2e-tests-${{ matrix.folder }}${{ matrix.context }}-${{ matrix.edition }}
     env:


### PR DESCRIPTION
bump e2e specs timeout from 35 to 45 minutes due to more frequent failures recently