### PR TITLE
UI: the logo button should bring back to home, and the navbar should a standard icon for open/close

### DIFF
--- a/frontend/src/metabase/nav/components/AppBar/AppBarLarge.styled.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarLarge.styled.tsx
@@ -29,21 +29,6 @@ export const AppBarLeftContainer = styled.div<AppBarLeftContainerProps>`
   flex: 1 1 auto;
   align-items: center;
   min-width: 5rem;
-
-  ${SidebarButton} {
-    opacity: ${props => (props.isNavBarVisible ? 0 : 1)};
-  }
-
-  &:hover {
-    ${LogoLink} {
-      opacity: ${props => (props.isNavBarVisible ? 0 : 1)};
-      pointer-events: ${props => (props.isNavBarVisible ? "none" : "")};
-    }
-
-    ${SidebarButton} {
-      opacity: ${props => (props.isNavBarVisible ? 1 : 0)};
-    }
-  }
 `;
 
 export const AppBarRightContainer = styled.div`

--- a/frontend/src/metabase/nav/components/AppBar/AppBarLarge.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarLarge.tsx
@@ -46,7 +46,7 @@ const AppBarLarge = ({
       <AppBarLeftContainer isNavBarVisible={isNavBarVisible}>
         <AppBarLogo
           isNavBarOpen={isNavBarOpen}
-          isToggleVisible={isNavBarVisible}
+          isToggleVisible={!isNavBarOpen}
           onToggleClick={onToggleNavbar}
         />
         <AppBarInfoContainer

--- a/frontend/src/metabase/nav/components/AppBar/AppBarLogo.styled.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarLogo.styled.tsx
@@ -14,15 +14,10 @@ export const LogoLink = styled(Link)`
   border-radius: 0.375rem;
   padding: 0.5rem 1rem;
   transition: opacity 0.3s;
-
-  &:hover {
-    background-color: ${color("bg-light")};
-  }
 `;
 
 export const ToggleContainer = styled.div`
-  position: absolute;
-  top: 0.625rem;
-  left: 0.9375rem;
+  position: fixed;
+  top: 90%;
   transition: opacity 0.3s;
 `;

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.styled.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.styled.tsx
@@ -162,3 +162,27 @@ export const AddYourOwnDataLink = styled(SidebarLink)`
     }
   }
 `;
+
+export const SidebarButtonContainer = styled.div<{ isOpen: boolean }>`
+  position: fixed;
+  bottom: 0;
+  // Height is hard-set so it remains
+  // the same as the ArchiveBarContent
+  // in ArchiveApp
+  height: 49px;
+  left: 0;
+  padding: ${space(0)};
+  width: ${props => (props.isOpen ? NAV_SIDEBAR_WIDTH : 0)};
+  border-top: 1px solid ${color("border")};
+  background-color: ${color("white")};
+  display: none;
+  overflow: hidden;
+  align-items: center;
+  margin-right: ${space(2)};
+  color: ${color("text-light")};
+  justify-content: flex-end;
+
+  ${breakpointMinSmall} {
+    display: flex;
+  }
+`;

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarView.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useMemo } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
@@ -28,8 +28,12 @@ import {
   SidebarContentRoot,
   SidebarHeading,
   SidebarHeadingWrapper,
+  SidebarButtonContainer,
   SidebarSection,
 } from "./MainNavbar.styled";
+import SidebarButton from "../../components/SidebarButton/SidebarButton";
+import Tooltip from "metabase/components/Tooltip";
+import { isMac } from "metabase/lib/browser";
 
 interface CollectionTreeItem extends Collection {
   icon: string | IconProps;
@@ -45,6 +49,7 @@ type Props = {
   hasOwnDatabase: boolean;
   collections: CollectionTreeItem[];
   selectedItems: SelectedItem[];
+  openNavbar?: () => void;
   handleCloseNavbar: () => void;
   handleLogout: () => void;
   handleCreateNewCollection: () => void;
@@ -70,6 +75,7 @@ function MainNavbarView({
   hasOwnDatabase,
   selectedItems,
   hasDataAccess,
+  isOpen,
   reorderBookmarks,
   handleCreateNewCollection,
   handleCloseNavbar,
@@ -86,6 +92,12 @@ function MainNavbarView({
       handleCloseNavbar();
     }
   }, [handleCloseNavbar]);
+
+  const sidebarButtonTooltip = useMemo(() => {
+    const message = isOpen ? t`Close sidebar` : t`Open sidebar`;
+    const shortcut = isMac() ? "(⌘ + .)" : "(Ctrl + .)";
+    return `${message} ${shortcut}`;
+  }, [isOpen]);
 
   return (
     <SidebarContentRoot>
@@ -159,6 +171,13 @@ function MainNavbarView({
           )}
         </ul>
       </div>
+      {!IFRAMED && (
+        <SidebarButtonContainer isOpen={isOpen}>
+          <Tooltip tooltip={sidebarButtonTooltip} isEnabled={!isSmallScreen()}>
+            <SidebarButton isSidebarOpen={isOpen} onClick={handleCloseNavbar} />
+          </Tooltip>
+        </SidebarButtonContainer>
+      )}
     </SidebarContentRoot>
   );
 }


### PR DESCRIPTION
Fixes #23159 

###### Before submitting the PR, please make sure you do the following

- [x] If you're attempting to fix a translation issue, please submit your changes to our [POEditor project](https://poeditor.com/join/project/ynjQmwSsGh) instead of opening a PR.

### Tests

- [x] Run the frontend and Cypress end-to-end tests with `yarn lint && yarn test`)
- [x] If there are changes to the backend codebase, run the backend tests with `clojure -X:dev:test`
- [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
      (unless it's a tiny documentation change).

### Demo
https://www.loom.com/share/309c4a3c6e5846fe84d59396a9798d11

### TODO
- [x] Make logo button bring back to home.
- [x] Take out the action of opening/closing the navigation bar from the logo button.
- [x] Adjust behavior to design style.

### Warning

These changes need to be verified against user experience.
I tried to keep the design style. I haven't used the platform extensively, so it's possible that this solution affects other parts of the app, but it seems to me a little more adequate than the initial proposal of the original issue.
