### PR TITLE
Smarter hashing for Advanced FieldValues

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sandbox/api/gtap.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/api/gtap.clj
@@ -13,7 +13,6 @@
 (api/defendpoint GET "/"
   "Fetch a list of all the GTAPs currently in use."
   []
-  ;; TODO - do we need to hydrate anything here?
   (db/select GroupTableAccessPolicy))
 
 (api/defendpoint GET "/:id"
@@ -21,10 +20,8 @@
   [id]
   (api/check-404 (GroupTableAccessPolicy id)))
 
-;; TODO - not sure what other endpoints we might need, e.g. for fetching the list above but for a given group or Table
-
-#_(def ^:private AttributeRemappings
-  (su/with-api-error-message (s/maybe {su/NonBlankString su/NonBlankString})
+(def ^:private AttributeRemappings
+  (su/with-api-error-message (s/maybe {s/Keyword s/Any})
     "value must be a valid attribute remappings map (attribute name -> remapped name)"))
 
 (api/defendpoint POST "/"
@@ -33,7 +30,7 @@
   {table_id             su/IntGreaterThanZero
    card_id              (s/maybe su/IntGreaterThanZero)
    group_id             su/IntGreaterThanZero
-   #_attribute_remappings #_AttributeRemappings} ; TODO -  fix me
+   attribute_remappings AttributeRemappings}
   (db/insert! GroupTableAccessPolicy
     {:table_id             table_id
      :card_id              card_id
@@ -44,9 +41,9 @@
   "Update a GTAP entry. The only things you're allowed to update for a GTAP are the Card being used (`card_id`) or the
   paramter mappings; changing `table_id` or `group_id` would effectively be deleting this entry and creating a new
   one. If that's what you want to do, do so explicity with appropriate calls to the `DELETE` and `POST` endpoints."
-  [id :as {{:keys [card_id #_attribute_remappings], :as body} :body}]
+  [id :as {{:keys [card_id attribute_remappings], :as body} :body}]
   {card_id              (s/maybe su/IntGreaterThanZero)
-   #_attribute_remappings #_AttributeRemappings} ; TODO -  fix me
+   attribute_remappings AttributeRemappings}
   (api/check-404 (GroupTableAccessPolicy id))
   ;; Only update `card_id` and/or `attribute_remappings` if the values are present in the body of the request.
   ;; This allows existing values to be "cleared" by being set to nil

--- a/enterprise/backend/src/metabase_enterprise/sandbox/api/gtap.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/api/gtap.clj
@@ -13,6 +13,7 @@
 (api/defendpoint GET "/"
   "Fetch a list of all the GTAPs currently in use."
   []
+  ;; TODO - do we need to hydrate anything here?
   (db/select GroupTableAccessPolicy))
 
 (api/defendpoint GET "/:id"
@@ -20,9 +21,11 @@
   [id]
   (api/check-404 (GroupTableAccessPolicy id)))
 
-(def ^:private AttributeRemappings
-  (su/with-api-error-message (s/maybe {s/Keyword s/Any})
-    "value must be a valid attribute remappings map (attribute name -> remapped name)"))
+;; TODO - not sure what other endpoints we might need, e.g. for fetching the list above but for a given group or Table
+
+#_(def ^:private AttributeRemappings
+   (su/with-api-error-message (s/maybe {su/NonBlankString su/NonBlankString})
+     "value must be a valid attribute remappings map (attribute name -> remapped name)"))
 
 (api/defendpoint POST "/"
   "Create a new GTAP."
@@ -30,7 +33,7 @@
   {table_id             su/IntGreaterThanZero
    card_id              (s/maybe su/IntGreaterThanZero)
    group_id             su/IntGreaterThanZero
-   attribute_remappings AttributeRemappings}
+   #_attribute_remappings #_AttributeRemappings} ; TODO -  fix me
   (db/insert! GroupTableAccessPolicy
     {:table_id             table_id
      :card_id              card_id
@@ -41,9 +44,9 @@
   "Update a GTAP entry. The only things you're allowed to update for a GTAP are the Card being used (`card_id`) or the
   paramter mappings; changing `table_id` or `group_id` would effectively be deleting this entry and creating a new
   one. If that's what you want to do, do so explicity with appropriate calls to the `DELETE` and `POST` endpoints."
-  [id :as {{:keys [card_id attribute_remappings], :as body} :body}]
+  [id :as {{:keys [card_id #_attribute_remappings], :as body} :body}]
   {card_id              (s/maybe su/IntGreaterThanZero)
-   attribute_remappings AttributeRemappings}
+   #_attribute_remappings #_AttributeRemappings} ; TODO -  fix me
   (api/check-404 (GroupTableAccessPolicy id))
   ;; Only update `card_id` and/or `attribute_remappings` if the values are present in the body of the request.
   ;; This allows existing values to be "cleared" by being set to nil

--- a/enterprise/backend/src/metabase_enterprise/sandbox/models/params/field_values.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/models/params/field_values.clj
@@ -4,7 +4,7 @@
             [metabase-enterprise.sandbox.query-processor.middleware.row-level-restrictions :as row-level-restrictions]
             [metabase.api.common :as api]
             [metabase.mbql.util :as mbql.u]
-            [metabase.models :refer [Field User PermissionsGroupMembership]]
+            [metabase.models :refer [Field PermissionsGroupMembership User]]
             [metabase.models.field :as field]
             [metabase.models.field-values :as field-values]
             [metabase.models.params.field-values :as params.field-values]

--- a/enterprise/backend/src/metabase_enterprise/sandbox/models/params/field_values.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/models/params/field_values.clj
@@ -53,8 +53,7 @@
   ;; -> [1, {\"State\" \"CA\"}]"
   [{:keys [table_id id] :as _field}]
   (when-let [gtap (table-id->gtap table_id)]
-    (let [login-attributes (or (:login_attributes @api/*current-user*)
-                               (db/select-one-field :login_attributes User :id api/*current-user-id*))
+    (let [login-attributes     (:login_attributes @api/*current-user*)
           attribute_remappings (:attribute_remappings gtap)]
       [(:card_id gtap)
        (into {} (for [[k v] attribute_remappings

--- a/enterprise/backend/src/metabase_enterprise/sandbox/models/params/field_values.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/models/params/field_values.clj
@@ -4,7 +4,7 @@
             [metabase-enterprise.sandbox.query-processor.middleware.row-level-restrictions :as row-level-restrictions]
             [metabase.api.common :as api]
             [metabase.mbql.util :as mbql.u]
-            [metabase.models :refer [Field PermissionsGroupMembership User]]
+            [metabase.models :refer [Field PermissionsGroupMembership]]
             [metabase.models.field :as field]
             [metabase.models.field-values :as field-values]
             [metabase.models.params.field-values :as params.field-values]

--- a/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions.clj
@@ -58,7 +58,7 @@
      ;; User does have segmented access
      (perms/set-has-full-permissions? @*current-user-permissions-set* (perms/table-segmented-query-path table)))))
 
-(defn- assert-one-gtap-per-table
+(defn assert-one-gtap-per-table
   "Make sure all referenced Tables have at most one GTAP."
   [gtaps]
   (doseq [[table-id gtaps] (group-by :table_id gtaps)

--- a/enterprise/backend/test/metabase_enterprise/sandbox/models/params/field_values_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/models/params/field_values_test.clj
@@ -1,8 +1,12 @@
 (ns metabase-enterprise.sandbox.models.params.field-values-test
   (:require [clojure.test :refer :all]
-            [metabase.models :refer [Field FieldValues]]
+            [metabase-enterprise.sandbox.models.group-table-access-policy :refer [GroupTableAccessPolicy]]
+            [metabase-enterprise.sandbox.models.params.field-values :as ee-params.field-values]
+            [metabase.models :refer [Card Field FieldValues User PermissionsGroup PermissionsGroupMembership]]
             [metabase.models.field-values :as field-values]
             [metabase.models.params.field-values :as params.field-values]
+            [metabase.public-settings.premium-features-test :as premium-features-test]
+            [metabase.server.middleware.session :as mw.session]
             [metabase.test :as mt]
             [toucan.db :as db]))
 
@@ -41,3 +45,120 @@
                  (:values (params.field-values/get-or-create-advanced-field-values!
                             fv-type
                             (db/select-one Field :id (mt/id :categories :name)))))))))))
+
+(deftest advanced-field-values-hash-test
+  (premium-features-test/with-premium-features #{:sandboxes}
+    ;; copy at top level so that `with-gtaps-for-user` does not create a new copy every it got call
+    (mt/with-temp-copy-of-db
+      (testing "gtap with remappings"
+        (letfn [(hash-for-user-id [user-id login-attributes]
+                  (mt/with-gtaps-for-user user-id
+                    {:gtaps      {:categories {:remappings {"State" [:dimension [:field (mt/id :categories :name) nil]]}}}
+                     :attributes login-attributes}
+                    (ee-params.field-values/hash-key-for-sandbox (mt/id :categories :name))))]
+          (mt/with-temp* [User [{user-id-1 :id}]
+                          User [{user-id-2 :id}]]
+
+            (testing "2 users with the same attribute should have the same hash"
+              (is (= (hash-for-user-id user-id-1 {"State" "CA"})
+                     (hash-for-user-id user-id-2 {"State" "CA"})))
+              (testing "having extra login attributes won't effect the hash"
+                (is (= (hash-for-user-id user-id-1 {"State" "CA"
+                                                    "City"  "San Jose"})
+                       (hash-for-user-id user-id-2 {"State" "CA"})))))
+
+            (testing "same users but the login_attributes change should have different hash"
+              (is (not= (hash-for-user-id user-id-1 {"State" "CA"})
+                        (hash-for-user-id user-id-1 {"State" "NY"}))))
+
+            (testing "2 users with different login_attributes should have different hash"
+              (is (not= (hash-for-user-id user-id-1 {"State" "CA"})
+                        (hash-for-user-id user-id-2 {"State" "NY"})))
+              (is (not= (hash-for-user-id user-id-1 {})
+                        (hash-for-user-id user-id-2 {"State" "NY"}))))))))
+
+    (testing "gtap with card and remappings"
+      ;; hack so that we don't have to setup all the sandbox permissions the table
+      (with-redefs [ee-params.field-values/field-is-sandboxed? (constantly true)]
+        (letfn [(hash-for-user-id-with-attributes [user-id login_attributes]
+                  (mt/with-temp-vals-in-db User user-id {:login_attributes login_attributes}
+                    (mw.session/with-current-user user-id
+                      (ee-params.field-values/hash-key-for-sandbox (mt/id :categories :name)))))]
+          (testing "2 users in the same group"
+            (mt/with-temp*
+              [Card                       [{card-id :id}]
+               PermissionsGroup           [{group-id :id}]
+               User                       [{user-id-1 :id}]
+               User                       [{user-id-2 :id}]
+               PermissionsGroupMembership [_ {:group_id group-id
+                                              :user_id user-id-1}]
+               PermissionsGroupMembership [_ {:group_id group-id
+                                              :user_id user-id-2}]
+               GroupTableAccessPolicy     [_ {:card_id card-id
+                                              :group_id group-id
+                                              :table_id (mt/id :categories)
+                                              :attribute_remappings {"State" [:dimension [:field (mt/id :categories :name) nil]]}}]]
+              (testing "if the have the same attributes, the hash should be the ssame"
+                (is (= (hash-for-user-id-with-attributes user-id-1 {"State" "CA"})
+                       (hash-for-user-id-with-attributes user-id-2 {"State" "CA"}))))
+
+              (testing "if the have the different attributes, the hash should be the different"
+                (is (not= (hash-for-user-id-with-attributes user-id-1 {"State" "CA"})
+                          (hash-for-user-id-with-attributes user-id-2 {"State" "NY"}))))))
+
+          (testing "2 users in different groups but gtaps use the same card"
+            (mt/with-temp*
+              [Card                       [{card-id :id}]
+
+               ;; user 1 in group 1
+               User                       [{user-id-1 :id}]
+               PermissionsGroup           [{group-id-1 :id}]
+               PermissionsGroupMembership [_ {:group_id group-id-1
+                                              :user_id user-id-1}]
+               GroupTableAccessPolicy     [_ {:card_id card-id
+                                              :group_id group-id-1
+                                              :table_id (mt/id :categories)
+                                              :attribute_remappings {"State" [:dimension [:field (mt/id :categories :name) nil]]}}]
+               ;; user 2 in group 2 with gtap using the same card
+               User                       [{user-id-2 :id}]
+               PermissionsGroup           [{group-id-2 :id}]
+               PermissionsGroupMembership [_ {:group_id group-id-2
+                                              :user_id user-id-2}]
+               GroupTableAccessPolicy     [_ {:card_id card-id
+                                              :group_id group-id-2
+                                              :table_id (mt/id :categories)
+                                              :attribute_remappings {"State" [:dimension [:field (mt/id :categories :name) nil]]}}]]
+              (testing "if the have the same attributes, the hash should be the ssame"
+                (is (= (hash-for-user-id-with-attributes user-id-1 {"State" "CA"})
+                       (hash-for-user-id-with-attributes user-id-2 {"State" "CA"}))))
+
+              (testing "if the have the different attributes, the hash should be the different"
+                (is (not= (hash-for-user-id-with-attributes user-id-1 {"State" "CA"})
+                          (hash-for-user-id-with-attributes user-id-2 {"State" "NY"}))))))
+
+          (testing "2 users in different groups and gtaps use 2 different cards"
+            (mt/with-temp*
+              [Card                       [{card-id-1 :id}]
+               User                       [{user-id-1 :id}]
+               PermissionsGroup           [{group-id-1 :id}]
+               PermissionsGroupMembership [_ {:group_id group-id-1
+                                              :user_id user-id-1}]
+               GroupTableAccessPolicy     [_ {:card_id card-id-1
+                                              :group_id group-id-1
+                                              :table_id (mt/id :categories)
+                                              :attribute_remappings {"State" [:dimension [:field (mt/id :categories :name) nil]]}}]
+               ;; user 2 in group 2 with gtap using card 2
+               Card                       [{card-id-2 :id}]
+               User                       [{user-id-2 :id}]
+               PermissionsGroup           [{group-id-2 :id}]
+               PermissionsGroupMembership [_ {:group_id group-id-2
+                                              :user_id user-id-2}]
+               GroupTableAccessPolicy     [_ {:card_id card-id-2
+                                              :group_id group-id-2
+                                              :table_id (mt/id :categories)
+                                              :attribute_remappings {"State" [:dimension [:field (mt/id :categories :name) nil]]}}]]
+              (testing "the hash are different even though they have the same attribute"
+                (is (not= (hash-for-user-id-with-attributes user-id-1 {"State" "CA"})
+                          (hash-for-user-id-with-attributes user-id-2 {"State" "CA"})))
+                (is (not= (hash-for-user-id-with-attributes user-id-1 {"State" "CA"})
+                          (hash-for-user-id-with-attributes user-id-2 {"State" "NY"})))))))))))

--- a/enterprise/backend/test/metabase_enterprise/sandbox/models/params/field_values_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/models/params/field_values_test.clj
@@ -48,7 +48,7 @@
 
 (deftest advanced-field-values-hash-test
   (premium-features-test/with-premium-features #{:sandboxes}
-    ;; copy at top level so that `with-gtaps-for-user` does not create a new copy every it got call
+    ;; copy at top level so that `with-gtaps-for-user` does not have to create a new copy every time it gets called
     (mt/with-temp-copy-of-db
       (testing "gtap with remappings"
         (letfn [(hash-for-user-id [user-id login-attributes]

--- a/enterprise/backend/test/metabase_enterprise/sandbox/models/params/field_values_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/models/params/field_values_test.clj
@@ -2,7 +2,7 @@
   (:require [clojure.test :refer :all]
             [metabase-enterprise.sandbox.models.group-table-access-policy :refer [GroupTableAccessPolicy]]
             [metabase-enterprise.sandbox.models.params.field-values :as ee-params.field-values]
-            [metabase.models :refer [Card Field FieldValues User PermissionsGroup PermissionsGroupMembership]]
+            [metabase.models :refer [Card Field FieldValues PermissionsGroup PermissionsGroupMembership User]]
             [metabase.models.field-values :as field-values]
             [metabase.models.params.field-values :as params.field-values]
             [metabase.public-settings.premium-features-test :as premium-features-test]

--- a/enterprise/backend/test/metabase_enterprise/sandbox/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/test_util.clj
@@ -117,7 +117,7 @@
   `(do-with-gtaps-for-user (fn [] ~gtaps-and-attributes-map) :rasta (fn [~'&group] ~@body)))
 
 (defmacro with-gtaps-for-user
-  "Like `with-gtaps` but with for a specific user."
+  "Like `with-gtaps` but for a specific user."
   {:style/indent 2}
   [test-user-name-or-user-id gtaps-and-attributes-map & body]
   `(do-with-gtaps-for-user (fn [] ~gtaps-and-attributes-map) ~test-user-name-or-user-id (fn [~'&group] ~@body)))

--- a/enterprise/backend/test/metabase_enterprise/sandbox/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/test_util.clj
@@ -1,5 +1,5 @@
 (ns metabase-enterprise.sandbox.test-util
-  "Shared test utilities for multi-tenant tests."
+  "Shared test utilities for sandbox tests."
   (:require [metabase-enterprise.sandbox.models.group-table-access-policy :refer [GroupTableAccessPolicy]]
             [metabase.models.card :refer [Card]]
             [metabase.models.permissions :as perms]
@@ -115,6 +115,12 @@
   {:style/indent 1}
   [gtaps-and-attributes-map & body]
   `(do-with-gtaps-for-user (fn [] ~gtaps-and-attributes-map) :rasta (fn [~'&group] ~@body)))
+
+(defmacro with-gtaps-for-user
+  "Like `with-gtaps` but with for a specific user."
+  {:style/indent 2}
+  [test-user-name-or-user-id gtaps-and-attributes-map & body]
+  `(do-with-gtaps-for-user (fn [] ~gtaps-and-attributes-map) ~test-user-name-or-user-id (fn [~'&group] ~@body)))
 
 (defn restricted-column-query
   "An MBQL query against Venues that only returns a subset of the columns."

--- a/enterprise/backend/test/metabase_enterprise/sandbox/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/test_util.clj
@@ -116,12 +116,6 @@
   [gtaps-and-attributes-map & body]
   `(do-with-gtaps-for-user (fn [] ~gtaps-and-attributes-map) :rasta (fn [~'&group] ~@body)))
 
-(defmacro with-gtaps-for-user
-  "Like `with-gtaps` but for a specific user."
-  {:style/indent 2}
-  [test-user-name-or-user-id gtaps-and-attributes-map & body]
-  `(do-with-gtaps-for-user (fn [] ~gtaps-and-attributes-map) ~test-user-name-or-user-id (fn [~'&group] ~@body)))
-
 (defn restricted-column-query
   "An MBQL query against Venues that only returns a subset of the columns."
   [db-id]


### PR DESCRIPTION
In https://github.com/metabase/metabase/pull/23435 we introduced "Advanced FieldValues" where we temporarily cache the field values for sandboxed users.

In these Advanced FieldValues we use a `hash-key` to differentiate FieldValeus of the same field but for different sandbox users.

But these `hash-key` were not efficient. 
Let's demonstrate it with an example, say we have:
- 2 users in the same group
- both users have the user's attributes State="CA"
- We sandbox the group of these 2 users by mapping User attribute: State -> People.State

Now, if these 2 users try to fetch the values of `People.State` column, they will get the same values because they're in the same State(CA).
But in the backend, we're still creating 2 FieldValues for each of them.  

Why're we creating 2 FieldValues with the same list of values? Could we just use the same FieldValues instead?
This PR tries to address these questions by making hashing a bit smarter.

Instead of hashing an array `field-id, user-id, user-permissions` like we did in the previous PR, we instead will hash with `field-id, card-id, user-attribute-map`. (for details please check the docs of `field->gtap-attributes-for-current-user`).

By doing this any users that have the same user's attributes will get to use the same FieldValues.

### How to test

0. Use an instance with enterprise features
1. Create 2 users, both have the same users attribute, State = "CA"
2. Create a group "Test Group" and add the 2 created users in
3. Go to Permissions > Data > All Users > Sample Database > set data access to no-self-service
4. Go to  Permissions > Data > Test Group > Sample Dataset > People > Data Access > Sandbox
5. Chose filter by column and map column "State" equals user' attribute "State"
6. Create a People question and add them to a dashboard
7. Create a location/dropdown parameter and link to the `People.City` column.
8. Now sign in as each users and open this parameters dropdown
9. Check in metabase_fieldvalues table, there will be only one record created.
10. Change one user attribute to State=NY
11. Open the dashboard parameter again, you should see a different list of values
12. Check in metabase_fieldvalues table, there should be 2 records created.