### PR TITLE
Refactor `backend.js` #4 - Run Cypress against already existing app db

### DIFF
--- a/frontend/test/__runner__/backend.js
+++ b/frontend/test/__runner__/backend.js
@@ -18,22 +18,14 @@ const BackendResource = createSharedResource("BackendResource", {
   create({ dbKey }) {
     const dbFile = generateTempDbPath();
     const absoluteDbKey = dbKey ? __dirname + dbKey : dbFile;
-    const e2eHost = process.env["E2E_HOST"];
-    if (e2eHost) {
-      return {
-        dbKey: absoluteDbKey,
-        host: e2eHost,
-        process: { kill: () => {} },
-      };
-    } else {
-      const port = getPort();
-      return {
-        dbKey: absoluteDbKey,
-        dbFile: dbFile,
-        host: `http://localhost:${port}`,
-        port: port,
-      };
-    }
+    const port = getPort();
+
+    return {
+      dbKey: absoluteDbKey,
+      dbFile: dbFile,
+      host: `http://localhost:${port}`,
+      port: port,
+    };
   },
   async start(server) {
     if (!server.process) {

--- a/frontend/test/__runner__/run_cypress_tests.js
+++ b/frontend/test/__runner__/run_cypress_tests.js
@@ -4,26 +4,33 @@ const getVersion = require("./cypress-runner-get-version");
 const generateSnapshots = require("./cypress-runner-generate-snapshots");
 const BackendResource = require("./backend.js");
 
+const e2eHost = process.env["E2E_HOST"];
+
 const server = BackendResource.get({ dbKey: "" });
-const baseUrl = server.host;
+const baseUrl = e2eHost || server.host;
 
 const init = async () => {
-  printBold("Metabase version info");
-  await getVersion();
+  if (!e2eHost) {
+    printBold("Metabase version info");
+    await getVersion();
 
-  printBold("Starting backend");
-  await BackendResource.start(server);
+    printBold("Starting backend");
+    await BackendResource.start(server);
 
-  printBold("Generating snapshots");
-  await generateSnapshots(baseUrl, cleanup);
+    printBold("Generating snapshots");
+    await generateSnapshots(baseUrl, cleanup);
+  }
 
   printBold("Starting Cypress");
   await runCypress(baseUrl, cleanup);
 };
 
 const cleanup = async (exitCode = 0) => {
-  printBold("Cleaning up...");
-  await BackendResource.stop(server);
+  if (!e2eHost) {
+    printBold("Cleaning up...");
+    await BackendResource.stop(server);
+  }
+
   process.exit(exitCode);
 };
 


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- This is the fourth step/task in https://github.com/metabase/metabase/issues/24023
- It separates the logic needed for running the Cypress with and without backend, effectively making it possible to spin Cypress against already running and existing app db
    - A number of people from the backend team voiced their wish to have something like this available because it helps them debug issues more easily

### How to test?
- All Cypress tests should still pass both locally and in the CI
- If you want to run Cypress against your app db, do the following:

1. Make sure you have both frontend **and** backend running and make sure Metabase is available at `localhost:3000`
2. `yarn test-cypress-open-no-backend` (it should open Cypress GUI almost instantly)
3. Choose an isolated repro from the Cypress GUI and run it

> **Warning**
> Running Cypress against your own app db will irreversibly alter it! Use with caution.
