### PR TITLE
fix incorrect value is used for the bubble size domain

### DIFF
--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -452,16 +452,14 @@ const getBubbleSizeMaxDomain = (datas, seriesIndex) => {
   return d3.max(sizeValues);
 };
 
-// TODO - give this a good name when I figure out what it does
-function doScatterChartStuff(chart, datas, index, { yExtent, yExtents }) {
+function configureScatterChart(chart, datas, index) {
   chart.keyAccessor(d => d.key[0]).valueAccessor(d => d.key[1]);
 
   if (chart.radiusValueAccessor) {
-    const isBubble = datas[index][0].length > BUBBLE_SIZE_INDEX;
-
+    const hasBubbleRaduisValues = datas[index][0].length > BUBBLE_SIZE_INDEX;
     const bubbleSizeMaxDomain = getBubbleSizeMaxDomain(datas, index);
 
-    if (isBubble) {
+    if (hasBubbleRaduisValues) {
       const BUBBLE_SCALE_FACTOR_MAX = 64;
       chart
         .radiusValueAccessor(d => d.key[2])
@@ -587,7 +585,7 @@ function getCharts(
       .useRightYAxis(yAxisSplit.length > 1 && yAxisSplit[1].includes(index));
 
     if (chartType === "scatter") {
-      doScatterChartStuff(chart, datas, index, yAxisProps);
+      configureScatterChart(chart, datas, index, yAxisProps);
     }
 
     if (chart.defined) {

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -444,12 +444,23 @@ function applyChartLineBarSettings(
   }
 }
 
+const BUBBLE_SIZE_INDEX = 2;
+
+const getBubbleSizeMaxDomain = (datas, seriesIndex) => {
+  const seriesData = datas[seriesIndex];
+  const sizeValues = seriesData.map(data => data[BUBBLE_SIZE_INDEX]);
+  return d3.max(sizeValues);
+};
+
 // TODO - give this a good name when I figure out what it does
 function doScatterChartStuff(chart, datas, index, { yExtent, yExtents }) {
   chart.keyAccessor(d => d.key[0]).valueAccessor(d => d.key[1]);
 
   if (chart.radiusValueAccessor) {
-    const isBubble = datas[index][0].length > 2;
+    const isBubble = datas[index][0].length > BUBBLE_SIZE_INDEX;
+
+    const bubbleSizeMaxDomain = getBubbleSizeMaxDomain(datas, index);
+
     if (isBubble) {
       const BUBBLE_SCALE_FACTOR_MAX = 64;
       chart
@@ -457,7 +468,7 @@ function doScatterChartStuff(chart, datas, index, { yExtent, yExtents }) {
         .r(
           d3.scale
             .sqrt()
-            .domain([0, yExtent[1] * BUBBLE_SCALE_FACTOR_MAX])
+            .domain([0, bubbleSizeMaxDomain * BUBBLE_SCALE_FACTOR_MAX])
             .range([0, 1]),
         );
     } else {

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -456,10 +456,10 @@ function configureScatterChart(chart, datas, index) {
   chart.keyAccessor(d => d.key[0]).valueAccessor(d => d.key[1]);
 
   if (chart.radiusValueAccessor) {
-    const hasBubbleRaduisValues = datas[index][0].length > BUBBLE_SIZE_INDEX;
+    const hasBubbleRadiusValues = datas[index][0].length > BUBBLE_SIZE_INDEX;
     const bubbleSizeMaxDomain = getBubbleSizeMaxDomain(datas, index);
 
-    if (hasBubbleRaduisValues) {
+    if (hasBubbleRadiusValues) {
       const BUBBLE_SCALE_FACTOR_MAX = 64;
       chart
         .radiusValueAccessor(d => d.key[2])


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/23977

## Changes

Fixes domain calculation for the bubble size dimension. It used yAxis domain before that.

## How to verify

Check the original issue for repro steps

## Screenshots

Before
<img width="1698" alt="Screenshot 2022-07-19 at 19 23 59" src="https://user-images.githubusercontent.com/14301985/179788286-ef34e32f-cd88-4b3c-903d-404680a7ae45.png">


After
<img width="1701" alt="Screenshot 2022-07-19 at 19 23 39" src="https://user-images.githubusercontent.com/14301985/179788303-7855ab74-e58a-497e-a8bf-f775bb354664.png">
