### PR TITLE
Fix header hover color

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.styled.jsx
@@ -71,7 +71,7 @@ export const HeaderButton = styled(Button)`
   color: ${({ active }) => (active ? "white" : color("text-dark"))};
   &:hover {
     background-color: ${({ color = getDefaultColor() }) => alpha(color, 0.15)};
-    color: ${color};
+    color: ${({ color }) => color};
   }
   transition: background 300ms linear, border 300ms linear;
   > .Icon {


### PR DESCRIPTION
How to test:
- Hover over `Summarize` button in the query builder

<img width="296" alt="Screenshot 2022-07-19 at 15 59 35" src="https://user-images.githubusercontent.com/8542534/179756137-0fb3db53-9d2a-4b97-9a12-62d1c1322229.png">
