### PR TITLE
docs - note on viewing alerts

### DIFF
--- a/docs/users-guide/15-alerts.md
+++ b/docs/users-guide/15-alerts.md
@@ -81,5 +81,4 @@ There are a few ways alerts can be stopped:
 
 {% include plans-blockquote.html feature="Audit logs" %}
 
-To view a list of all alerts and dashboard subscriptions that people have set up in your Metabase, click on the **gears** icon  in the upper right and select **Admin settings** > **Audit** > **Subscriptions & Alerts**. See [Audit logs](../enterprise-guide/audit.md).
-
+To view a list of all alerts and dashboard subscriptions that people have set up in your Metabase, click on the **gears** icon in the upper right and select **Admin settings** > **Audit** > **Subscriptions & Alerts**. See [Audit logs](../enterprise-guide/audit.md).

--- a/docs/users-guide/15-alerts.md
+++ b/docs/users-guide/15-alerts.md
@@ -81,4 +81,4 @@ There are a few ways alerts can be stopped:
 
 {% include plans-blockquote.html feature="Audit logs" %}
 
-To view a list of all alerts and dashboard subscriptions that people have set up in your Metabase, click on the **gears** icon in the upper right and select **Admin settings** > **Audit** > **Subscriptions & Alerts**. See [Audit logs](../enterprise-guide/audit.md).
+To view a list of all alerts and dashboard subscriptions that people have set up in your Metabase, click on the **gear** icon in the upper right and select **Admin settings** > **Audit** > **Subscriptions & Alerts**. See [Audit logs](../enterprise-guide/audit.md).

--- a/docs/users-guide/15-alerts.md
+++ b/docs/users-guide/15-alerts.md
@@ -50,7 +50,7 @@ Next, click the bell icon in the bottom-right and you'll see that same screen of
 
 ## Results alerts
 
-Lastly, you can get an alert when one of your saved questions returns _any_ result. This kind of alert is the most useful if you have a question that doesn't _usually_ return any results, but you just want to know when it _does_ return results. 
+Lastly, you can get an alert when one of your saved questions returns _any_ result. This kind of alert is the most useful if you have a question that doesn't _usually_ return any results, but you just want to know when it _does_ return results.
 
 For example, you might have a table called `Reviews`, and you want to know any time a customer leaves a bad review, which you consider to be anything below three stars. To set up an alert for this situation, you'd go and create a raw data question (i.e., a question that returns a list of reviews), and add a filter to only include results with one or two stars.
 
@@ -76,3 +76,10 @@ There are a few ways alerts can be stopped:
 - Admins can edit any alert and delete it entirely. This can't be undone, so be careful!
 - If a saved question that has an alert on it gets edited in such a way that the alert doesn't make sense anymore, the alert will get deleted. For example, if a saved question with a goal line alert on it gets edited, and the goal line is removed entirely, that alert will get deleted.
 - If a question gets archived, any alerts on it will be deleted.
+
+## Viewing existing alerts
+
+{% include plans-blockquote.html feature="Audit logs" %}
+
+To view a list of all alerts and dashboard subscriptions that people have set up in your Metabase, click on the **gears** icon  in the upper right and select **Admin settings** > **Audit** > **Subscriptions & Alerts**. See [Audit logs](../enterprise-guide/audit.md).
+

--- a/docs/users-guide/dashboard-subscriptions.md
+++ b/docs/users-guide/dashboard-subscriptions.md
@@ -66,7 +66,7 @@ Some plans allow you to [customize filter values for each subscription](../enter
 
 {% include plans-blockquote.html feature="Audit logs" %}
 
-To view a list of all alerts and dashboard subscriptions that people have set up in your Metabase, click on the **gears** icon in the upper right and select **Admin settings** > **Audit** > **Subscriptions & Alerts**. See [Audit logs](../enterprise-guide/audit.md).
+To view a list of all alerts and dashboard subscriptions that people have set up in your Metabase, click on the **gear** icon in the upper right and select **Admin settings** > **Audit** > **Subscriptions & Alerts**. See [Audit logs](../enterprise-guide/audit.md).
 
 ## Related reading
 

--- a/docs/users-guide/dashboard-subscriptions.md
+++ b/docs/users-guide/dashboard-subscriptions.md
@@ -62,8 +62,13 @@ To remove a subscription from a dashboard, select the subscription you'd like to
 
 Some plans allow you to [customize filter values for each subscription](../enterprise-guide/dashboard-subscriptions.md), so you can set up subscriptions with different filter values applied for different subscribers.
 
+## Viewing existing dashboard subscriptions
+
+{% include plans-blockquote.html feature="Audit logs" %}
+
+To view a list of all alerts and dashboard subscriptions that people have set up in your Metabase, click on the **gears** icon in the upper right and select **Admin settings** > **Audit** > **Subscriptions & Alerts**. See [Audit logs](../enterprise-guide/audit.md).
+
 ## Related reading
 
 - [Setting up email](https://www.metabase.com/docs/latest/administration-guide/02-setting-up-email.html)
 - [Setting up Slack](https://www.metabase.com/docs/latest/administration-guide/09-setting-up-slack.html)
-


### PR DESCRIPTION
Got some feedback that people wanted to know how to view all the alerts and dashboard subscriptions. This PR adds notes in the alert and dashboard subscription sections.
