### PR TITLE
Delete commented out code in query_time.js

### DIFF
--- a/frontend/src/metabase/lib/query_time.js
+++ b/frontend/src/metabase/lib/query_time.js
@@ -10,7 +10,6 @@ import { parseTimestamp } from "metabase/lib/time";
 import { FieldDimension } from "metabase-lib/lib/Dimension";
 
 export const DATETIME_UNITS = [
-  // "default",
   "minute",
   "hour",
   "day",
@@ -18,11 +17,9 @@ export const DATETIME_UNITS = [
   "month",
   "quarter",
   "year",
-  // "minute-of-hour",
   "hour-of-day",
   "day-of-week",
   "day-of-month",
-  // "day-of-year",
   "week-of-year",
   "month-of-year",
   "quarter-of-year",


### PR DESCRIPTION
This has been there for about 4 years, should be ok to remove for good.