### PR TITLE
Remove Mongo SSL private key password parameter

### DIFF
--- a/modules/drivers/mongo/resources/metabase-plugin.yaml
+++ b/modules/drivers/mongo/resources/metabase-plugin.yaml
@@ -50,12 +50,6 @@ driver:
       secret-kind: pem-cert
       visible-if:
         ssl-use-client-auth: true
-    - name: client-ssl-key-password
-      display-name: Client SSL private key password
-      type: secret
-      secret-kind: password
-      visible-if:
-        ssl-use-client-auth: true
     - ssh-tunnel
     - advanced-options-start
     - merge:

--- a/modules/drivers/mongo/src/metabase/driver/mongo/util.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/util.clj
@@ -54,7 +54,7 @@
   `readPreference=nearest`, can be specified as well; when passed, these are parsed into a `MongoClientOptions` that
   serves as a starting point for the changes made below."
   ^MongoClientOptions [{:keys [ssl additional-options ssl-cert
-                               ssl-use-client-auth client-ssl-cert client-ssl-key client-ssl-key-password]
+                               ssl-use-client-auth client-ssl-cert client-ssl-key]
                         :or   {ssl false, ssl-use-client-auth false}
                         :as   details}]
   (let [client-options (-> (client-options-for-url-params additional-options)
@@ -65,12 +65,11 @@
                            (.sslEnabled ssl))
         server-cert? (not (str/blank? ssl-cert))
         client-cert? (and ssl-use-client-auth
-                          (not-any? str/blank? [client-ssl-cert client-ssl-key client-ssl-key-password]))]
+                          (not-any? str/blank? [client-ssl-cert client-ssl-key]))]
     (if (or server-cert? client-cert?)
       (let [ssl-params (cond-> {}
                          server-cert? (assoc :trust-cert ssl-cert)
                          client-cert? (assoc :private-key client-ssl-key
-                                             :password client-ssl-key-password
                                              :own-cert client-ssl-cert))]
         (.socketFactory client-options (driver.u/ssl-socket-factory ssl-params)))
       client-options)))
@@ -123,8 +122,7 @@
      :ssl-cert                ssl-cert
      :ssl-use-client-auth     ssl-use-client-auth
      :client-ssl-cert         client-ssl-cert
-     :client-ssl-key          (secret/get-secret-string details "client-ssl-key")
-     :client-ssl-key-password (secret/get-secret-string details "client-ssl-key-password")}))
+     :client-ssl-key          (secret/get-secret-string details "client-ssl-key")}))
 
 (defn- fqdn?
   "A very simple way to check if a hostname is fully-qualified:

--- a/modules/drivers/mongo/test/metabase/test/data/mongo.clj
+++ b/modules/drivers/mongo/test/metabase/test/data/mongo.clj
@@ -26,7 +26,6 @@
   {:ssl true
    :ssl-use-client-auth true
    :client-ssl-key-value (-> "ssl/mongo/metabase.key" io/resource slurp)
-   :client-ssl-key-password-value "passw"
    :client-ssl-cert (-> "ssl/mongo/metabase.crt" io/resource slurp)
    :ssl-cert (-> "ssl/mongo/metaca.crt" io/resource slurp)})
 

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -548,10 +548,10 @@
 
 (defn ssl-socket-factory
   "Generates an `SocketFactory` with the custom certificates added"
-  ^SocketFactory [& {:keys [private-key password own-cert trust-cert]}]
+  ^SocketFactory [& {:keys [private-key own-cert trust-cert]}]
   (let [ssl-context (SSLContext/getInstance "TLS")]
     (.init ssl-context
-           (when (and private-key password own-cert) (key-managers private-key password own-cert))
+           (when (and private-key own-cert) (key-managers private-key (str (random-uuid)) own-cert))
            (when trust-cert (trust-managers trust-cert))
            nil)
     (.getSocketFactory ssl-context)))


### PR DESCRIPTION
This parameter makes the impression that Metabase can deal with encrypted
private keys, but this is not the case. The internal keystore password can just
as well be randomly generated in the code.
