### PR TITLE
Fix the sample table sql

### DIFF
--- a/src/metabase/driver/postgres/ddl.clj
+++ b/src/metabase/driver/postgres/ddl.clj
@@ -67,7 +67,7 @@
                                                           {:table-name table-name
                                                            :field-definitions [{:field-name "field"
                                                                                 :base-type :type/Text}]}
-                                                          "values (1)")]))]
+                                                          "select 1")]))]
                      [:persist.check/read-table
                       (fn read-table [conn]
                         (sql.ddl/jdbc-query conn [(format "select * from %s.%s"


### PR DESCRIPTION
To persist we need:
- a schema
- to be able to create, read, and delete tables in that schema.

So we run the following sql:

```sql
create schema "metabase_cache_134ba_45"
create table "metabase_cache_134ba_45"."persistence_check_8667" as values (1)
select * from metabase_cache_134ba_45.persistence_check_8667
drop table if exists "metabase_cache_134ba_45"."persistence_check_8667"
```

The `create table ... as values (1)` seems to only be valid in pg not redshift.

```sql
dev=# create table "metabase_cache_4b4bb_2"."persistence_check_9755" as values (1);
ERROR:  syntax error at or near "values"
LINE 1: ...tabase_cache_4b4bb_2"."persistence_check_9755" as values (1)...
                                                             ^
dev=# create table "metabase_cache_4b4bb_2"."persistence_check_9755" as select 1;
SELECT
dev=# select * from metabase_cache_4b4bb_2.persistence_check_9755 ;
 ?column?
----------
        1
(1 row)
```

But it is valid to use `create table ... as select 1`

This is also valid in pg so we are gold again.
