### PR TITLE
Fix CircleCI job skipping magic: `$CIRCLE_STAGE` has been renamed to `$CIRCLE_JOB`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -498,6 +498,7 @@ jobs:
           name: 'If $CIRCLE_JOB is unset then bust the cache (see #24128 for details)'
           command: |
             if [ -z "$CIRCLE_JOB" ]; then
+              echo '$CIRCLE_JOB is unset. Using cache-busting prefix.'
               echo '<< pipeline.id >>' > .CACHE-PREFIX
             fi
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -495,6 +495,12 @@ jobs:
                echo '' > .CACHE-PREFIX
             fi
       - run:
+          name: 'If $CIRCLE_JOB is unset then bust the cache (see #24128 for details)'
+          command: |
+            if [ -z "$CIRCLE_JOB" ]; then
+              echo '<< pipeline.id >>' > .CACHE-PREFIX
+            fi
+      - run:
           name: Create static visualization js bundle
           command: yarn build-static-viz
       - run:
@@ -502,7 +508,7 @@ jobs:
           command: |
             if [[ $CIRCLE_BRANCH == release* || $CIRCLE_BRANCH == master  ]]; then
               echo 'This is a release or master branch; using cache-busting prefix'
-                echo '<< pipeline.id >>' > .CACHE-PREFIX
+              echo '<< pipeline.id >>' > .CACHE-PREFIX
             fi
       - run:
           name: Make SSL certificates for Mongo available

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -254,9 +254,9 @@ cache-key-backend-deps: &CacheKeyBackendDeps
   key: v5-{{ checksum ".CACHE-PREFIX" }}-be-deps-{{ checksum "deps.edn" }}-{{ checksum ".SCRIPTS-DEPS-CHECKSUMS" }}
 
 # Key used for implementation of run-on-change -- this is the cache key that contains the .SUCCESS dummy file
-# By default the key ALWAYS includes the name of the test job itself ($CIRCLE_STAGE) so you don't need to add that yourself.
+# By default the key ALWAYS includes the name of the test job itself ($CIRCLE_JOB) so you don't need to add that yourself.
 cache-key-run-on-change: &CacheKeyRunOnChange
-  key: v5-{{ checksum ".CACHE-PREFIX" }}-run-on-change-{{ .Environment.CIRCLE_STAGE }}-<< parameters.checksum >>
+  key: v5-{{ checksum ".CACHE-PREFIX" }}-run-on-change-{{ .Environment.CIRCLE_JOB }}-<< parameters.checksum >>
 
 ########################################################################################################################
 #                                                       COMMANDS                                                       #

--- a/modules/drivers/googleanalytics/test/metabase/driver/googleanalytics_test.clj
+++ b/modules/drivers/googleanalytics/test/metabase/driver/googleanalytics_test.clj
@@ -360,7 +360,7 @@
                   Table    [table {:db_id (u/the-id db)}]
                   Field    [field {:table_id (u/the-id table)}]]
     (let [cnt (->> (mt/user-http-request
-                    :crowberto :post 202 "card"
+                    :crowberto :post 200 "card"
                     {:name                   "Metabase Websites, Sessions and 1 Day Active Users, Grouped by Date (day)"
                      :display                :table
                      :visualization_settings {}


### PR DESCRIPTION
I spent a few hours trying to figure out why Postgres tests didn't fail in CircleCI for PRs like #24009 when they should have failed (and failed if you ran the tests locally)

I wrote special magic in our CircleCI config to skip jobs if they've previously succeeded with the exact same relevant code. It was supposed to be unique **PER JOB** e.g.` be-tests-postgres-latest` but it looks like that stopped working because CircleCI changed the env var they store the job name in from `$CIRCLE_STAGE` to `$CIRCLE_JOB`. So actually it was getting confused and thinking the Postgres tests had already passed because it was looking at stuff like `be-tests-java-17` , and seeing that it already passed, and then skipping the PG tests.

As far as I know CircleCI never announced this change (at least I can't find an announcement anywhere in a Google search). So I'm not super happy that they broke CI for us without anyone knowing about it. I guess that's another reason we can't ditch CircleCI for GH Actions soon enough 🤷‍♂️ 

I don't think this really ended up busting **too many** things since we don't use the cache for `master` runs or for `release-*` branch CI runs. So test failures that got introduced should have still been caught pretty quickly (hopefully)