### PR TITLE
Fix for #24132: Search returns irrelevant matches for non-native questions

### DIFF
--- a/test/metabase/api/search_test.clj
+++ b/test/metabase/api/search_test.clj
@@ -596,3 +596,11 @@
               (db/update! Pulse (:id pulse) :dashboard_id (:id dashboard))
               (is (= nil
                      (search-for-pulses pulse))))))))))
+
+(deftest non-native-card-dataset-query-test
+  (testing "You shouldn't see non-native Cards in the search results that match the keys of the dataset_query"
+    ;; https://github.com/metabase/metabase/issues/24132
+    (mt/with-temp Card [card {:name "Round Table" :query_type "query" :dataset_query {:query "select * from round_table"}}]
+      (do-test-users [user [:rasta]]
+         (is (= []
+                (search-request-data user :q "database")))))))

--- a/test/metabase/api/search_test.clj
+++ b/test/metabase/api/search_test.clj
@@ -600,9 +600,9 @@
 (deftest card-dataset-query-test
   (testing "The dataset_query field should only be searched if the card's query is native SQL"
     ;; https://github.com/metabase/metabase/issues/24132
-    (mt/with-temp* [Card [query-card {:name          "Venues Count"
-                                      :query_type    "query"
-                                      :dataset_query (mt/mbql-query venues {:aggregation [[:count]]})}]
+    (mt/with-temp* [Card [mbql-card   {:name          "Venues Count"
+                                       :query_type    "query"
+                                       :dataset_query (mt/mbql-query venues {:aggregation [[:count]]})}]
                     Card [native-card {:name          "Another SQL query"
                                        :query_type    "native"
                                        :dataset_query {:query "SELECT COUNT(1) AS aggregation FROM venues"}}]]


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/24132

This adds an extra condition on the search query, so that `dataset_query` is only searched if the question is native SQL. 

This will also partially addresses the performance problems in this issue https://github.com/metabase/metabase/issues/17631, as now only native SQL queries will have their text searched (speculative).