### PR TITLE
Confirmation modal when removing a text card from a dashboard says "Remove this Question?"

### DIFF
--- a/frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx
+++ b/frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx
@@ -25,9 +25,16 @@ export default class RemoveFromDashboardModal extends Component {
   }
 
   render() {
-    const { onClose } = this.props;
+    const { onClose, dashcard } = this.props;
     return (
-      <ModalContent title={t`Remove this card?`} onClose={onClose}>
+      <ModalContent
+        title={
+          dashcard.card.display === "text"
+            ? t`Remove this text box?`
+            : t`Remove this question?`
+        }
+        onClose={onClose}
+      >
         <div className="flex-align-right">
           <Button onClick={onClose}>{t`Cancel`}</Button>
           <Button danger ml={2} onClick={() => this.onRemove()}>


### PR DESCRIPTION
Fixes #23841

###### Before submitting the PR, please make sure you do the following

- [x] If you're attempting to fix a translation issue, please submit your changes to our [POEditor project](https://poeditor.com/join/project/ynjQmwSsGh) instead of opening a PR.

### Tests

- [x] Run the frontend and Cypress end-to-end tests with `yarn lint && yarn test`)
- [x] If there are changes to the backend codebase, run the backend tests with `clojure -X:dev:test`
- [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
      (unless it's a tiny documentation change).

### Why this PR?
This a replacement PR for #24063 because this seems more appropriate solution. There are just two types of cards we can add in the dashboard (question and text box), so instead of generalizing them, using text based on card type might be more appropriate.

### Demo
https://www.loom.com/share/d08bfa53ed20464eaa51649937e430f9