### PR TITLE
Redshift late-binding views don't play well with JDBC metadata description fix (#21215)

### DIFF
--- a/modules/drivers/redshift/deps.edn
+++ b/modules/drivers/redshift/deps.edn
@@ -5,4 +5,4 @@
  {"redshift" {:url "https://s3.amazonaws.com/redshift-maven-repository/release"}}
 
  :deps
- {com.amazon.redshift/redshift-jdbc42 {:mvn/version "2.1.0.3"}}}
+ {com.amazon.redshift/redshift-jdbc42 {:mvn/version "2.1.0.5"}}}

--- a/modules/drivers/redshift/resources/metabase-plugin.yaml
+++ b/modules/drivers/redshift/resources/metabase-plugin.yaml
@@ -1,6 +1,6 @@
 info:
   name: Metabase Redshift Driver
-  version: 1.1.0-SNAPSHOT-2.0.0.3
+  version: 1.2.0-SNAPSHOT-2.1.0.5
   description: Allows Metabase to connect to Redshift databases.
 driver:
   name: redshift

--- a/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
+++ b/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
@@ -195,8 +195,9 @@
            (str "DROP TABLE IF EXISTS %1$s;%n"
                 "CREATE TABLE %1$s(weird_varchar CHARACTER VARYING(50), numeric_col NUMERIC(10,2));%n"
                 "CREATE OR REPLACE VIEW %2$s AS SELECT * FROM %1$s WITH NO SCHEMA BINDING;"
-                "CREATE OR REPLACE VIEW %3$s AS SELECT CASE WHEN true = false THEN 11387.133 END AS numeric_col,
-                CASE WHEN true = false THEN 'blah blah blah' END AS weird_varchar FROM %1$s WITH NO SCHEMA BINDING;")
+                "CREATE OR REPLACE VIEW %3$s AS"
+                  "SELECT CASE WHEN true = false THEN 11387.133 END AS numeric_col,"
+                  "CASE WHEN true = false THEN 'blah blah blah' END AS weird_varchar FROM %1$s WITH NO SCHEMA BINDING;")
            qual-tbl-nm
            qual-view-nm
            qual-view-nm-2)

--- a/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
+++ b/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
@@ -186,7 +186,7 @@
             qual-tbl-nm    (str redshift.test/session-schema-name "." tbl-nm)
             view-nm        "late_binding_view"
             qual-view-nm   (str redshift.test/session-schema-name "." view-nm)
-            ;; pursuant to #21215, weirder late binding views will not even have the parameterization
+            ;; pursuant to #21215, weirder late binding views will not even have the parameters called
             view-nm-2      "weirder_late_binding_view"
             qual-view-nm-2 (str redshift.test/session-schema-name "." view-nm-2)]
         (mt/with-temp Database [database {:engine :redshift, :details db-details}]

--- a/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
+++ b/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
@@ -195,9 +195,9 @@
            (str "DROP TABLE IF EXISTS %1$s;%n"
                 "CREATE TABLE %1$s(weird_varchar CHARACTER VARYING(50), numeric_col NUMERIC(10,2));%n"
                 "CREATE OR REPLACE VIEW %2$s AS SELECT * FROM %1$s WITH NO SCHEMA BINDING;"
-                "CREATE OR REPLACE VIEW %3$s AS"
-                  "SELECT CASE WHEN true = false THEN 11387.133 END AS numeric_col,"
-                  "CASE WHEN true = false THEN 'blah blah blah' END AS weird_varchar FROM %1$s WITH NO SCHEMA BINDING;")
+                "CREATE OR REPLACE VIEW %3$s AS "
+                "SELECT CASE WHEN true = false THEN 11387.133 END AS numeric_col, "
+                "CASE WHEN true = false THEN 'blah blah blah' END AS weird_varchar FROM %1$s WITH NO SCHEMA BINDING;")
            qual-tbl-nm
            qual-view-nm
            qual-view-nm-2)

--- a/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
+++ b/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
@@ -195,7 +195,8 @@
            (str "DROP TABLE IF EXISTS %1$s;%n"
                 "CREATE TABLE %1$s(weird_varchar CHARACTER VARYING(50), numeric_col NUMERIC(10,2));%n"
                 "CREATE OR REPLACE VIEW %2$s AS SELECT * FROM %1$s WITH NO SCHEMA BINDING;"
-                "CREATE OR REPLACE VIEW %3$s AS SELECT numeric_col::numeric, cast(weird_varchar as character varying) FROM %1$s WITH NO SCHEMA BINDING;")
+                "CREATE OR REPLACE VIEW %3$s AS SELECT CASE WHEN true = false THEN 11387.133 END AS numeric_col,
+                CASE WHEN true = false THEN 'blah blah blah' END AS weird_varchar FROM %1$s WITH NO SCHEMA BINDING;")
            qual-tbl-nm
            qual-view-nm
            qual-view-nm-2)

--- a/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
+++ b/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
@@ -196,8 +196,8 @@
                 "CREATE TABLE %1$s(weird_varchar CHARACTER VARYING(50), numeric_col NUMERIC(10,2));%n"
                 "CREATE OR REPLACE VIEW %2$s AS SELECT * FROM %1$s WITH NO SCHEMA BINDING;"
                 "CREATE OR REPLACE VIEW %3$s AS "
-                "SELECT CASE WHEN true = false THEN 11387.133 END AS numeric_col, "
-                "CASE WHEN true = false THEN 'blah blah blah' END AS weird_varchar FROM %1$s WITH NO SCHEMA BINDING;")
+                "SELECT CASE WHEN true = false THEN 11387.133 END AS numeric_col_2, "
+                "CASE WHEN true = false THEN 'blah blah blah' END AS weird_varchar_2 FROM %1$s WITH NO SCHEMA BINDING;")
            qual-tbl-nm
            qual-view-nm
            qual-view-nm-2)
@@ -212,13 +212,13 @@
           (let [table-id   (db/select-one-id Table :db_id (u/the-id database), :name view-nm)
                 table-id-2 (db/select-one-id Table :db_id (u/the-id database), :name view-nm-2)]
             ;; and its columns' :base_type should have been identified correctly
-            (is (= [{:name "numeric_col",   :database_type "numeric(10,2)",         :base_type :type/Decimal}
-                    {:name "weird_varchar", :database_type "character varying(50)", :base_type :type/Text}]
+            (is (= [{:name "numeric_col",   :database_type "numeric",         :base_type :type/Decimal}
+                    {:name "weird_varchar", :database_type "varchar", :base_type :type/Text}]
                    (map
                     (partial into {})
                     (db/select [Field :name :database_type :base_type] :table_id table-id {:order-by [:name]}))))
-            (is (= [{:name "numeric_col",   :database_type "numeric",           :base_type :type/Decimal}
-                    {:name "weird_varchar", :database_type "character varying", :base_type :type/Text}]
+            (is (= [{:name "numeric_col_2",   :database_type "numeric",           :base_type :type/Decimal}
+                    {:name "weird_varchar_2", :database_type "varchar", :base_type :type/Text}]
                    (map
                      (partial into {})
                      (db/select [Field :name :database_type :base_type] :table_id table-id-2 {:order-by [:name]}))))))))))


### PR DESCRIPTION
Pursuant to #21215.

There seems to be a bug materially identically in the stack trace to https://github.com/aws/amazon-redshift-jdbc-driver/issues/45 but not solved as of the 2.1.0.5 version that we encounter. To get around it, we just always use the fallback describe fields system for redshift case.

This doesn't seem to have perf impacts on local because it's redshift and web requests dominate either way - I need to go test for in-AWS-datacenter perf differences.

This is unfortunately a tad arbitrary as to the "weirdness if encountered arbitrarily" factor. However I tend to believe that it may have a better argument for that arbitrary if statement than one would expect - given our previous opinions hashed out on the idiosyncrasies of the first party redshift JDBC driver and the evident increased simplicity of the fallback field types