### PR TITLE
Move QB `updateQuestion` and shared utils to their own files

### DIFF
--- a/frontend/src/metabase/query_builder/actions/core/core.js
+++ b/frontend/src/metabase/query_builder/actions/core/core.js
@@ -1,5 +1,4 @@
 import _ from "underscore";
-import { assocIn } from "icepick";
 import { createAction } from "redux-actions";
 
 import * as MetabaseAnalytics from "metabase/lib/analytics";
@@ -20,54 +19,27 @@ import { setRequestUnloaded } from "metabase/redux/requests";
 import Questions from "metabase/entities/questions";
 import { fetchAlertsForQuestion } from "metabase/alert/alert";
 
-import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
-
-import {
-  getTemplateTagsForParameters,
-  getTemplateTagParameters,
-} from "metabase/parameters/utils/cards";
-
 import { trackNewQuestionSaved } from "../../analytics";
 import {
   getCard,
-  getFirstQueryResult,
-  getIsEditing,
-  getIsShowingTemplateTagsEditor,
   getOriginalQuestion,
-  getQueryBuilderMode,
   getQuestion,
-  getRawSeries,
   getResultsMetadata,
   getTransformedSeries,
   isBasedOnExistingQuestion,
 } from "../../selectors";
-import { getNextTemplateTagVisibilityState } from "../../utils";
 
 import { updateUrl } from "../navigation";
-import { setIsShowingTemplateTagsEditor } from "../native";
 import { zoomInRow } from "../object-detail";
 import { clearQueryResult, runQuestionQuery } from "../querying";
-import { onCloseSidebars, setQueryBuilderMode } from "../ui";
+import { onCloseSidebars } from "../ui";
 
-import { loadMetadataForCard } from "./metadata";
-import { getQuestionWithDefaultVisualizationSettings } from "./utils";
-
+import { updateQuestion } from "./updateQuestion";
 import { loadMetadataForCard } from "./metadata";
 import { getQuestionWithDefaultVisualizationSettings } from "./utils";
 
 export const RESET_QB = "metabase/qb/RESET_QB";
 export const resetQB = createAction(RESET_QB);
-
-function hasNewColumns(question, queryResult) {
-  // NOTE: this assume column names will change
-  // technically this is wrong because you could add and remove two columns with the same name
-  const query = question.query();
-  const previousColumns =
-    (queryResult && queryResult.data.cols.map(col => col.name)) || [];
-  const nextColumns =
-    query instanceof StructuredQuery ? query.columnNames() : [];
-  return _.difference(nextColumns, previousColumns).length > 0;
-}
 
 // refreshes the card without triggering a run of the card's query
 export const SOFT_RELOAD_CARD = "metabase/qb/SOFT_RELOAD_CARD";
@@ -182,166 +154,6 @@ export const navigateToNewCardInsideQB = createThunkAction(
     };
   },
 );
-
-/**
- * Replaces the currently active question with the given Question object.
- * Also shows/hides the template tag editor if the number of template tags has changed.
- */
-export const UPDATE_QUESTION = "metabase/qb/UPDATE_QUESTION";
-export const updateQuestion = (
-  newQuestion,
-  {
-    shouldStartAdHocQuestion = true,
-    run = false,
-    shouldUpdateUrl = false,
-  } = {},
-) => {
-  return async (dispatch, getState) => {
-    const oldQuestion = getQuestion(getState());
-    const mode = getQueryBuilderMode(getState());
-
-    // TODO Atte Keinänen 6/2/2017 Ways to have this happen automatically when modifying a question?
-    // Maybe the Question class or a QB-specific question wrapper class should know whether it's being edited or not?
-    if (
-      shouldStartAdHocQuestion &&
-      newQuestion.query().isEditable() &&
-      !getIsEditing(getState()) &&
-      newQuestion.isSaved() &&
-      mode !== "dataset"
-    ) {
-      newQuestion = newQuestion.withoutNameAndId();
-
-      // When the dataset query changes, we should loose the dataset flag,
-      // to start building a new ad-hoc question based on a dataset
-      if (newQuestion.isDataset()) {
-        newQuestion = newQuestion.setDataset(false);
-      }
-    }
-
-    const queryResult = getFirstQueryResult(getState());
-    newQuestion = newQuestion.syncColumnsAndSettings(oldQuestion, queryResult);
-
-    if (run === "auto") {
-      run = hasNewColumns(newQuestion, queryResult);
-    }
-
-    if (!newQuestion.canAutoRun()) {
-      run = false;
-    }
-
-    // <PIVOT LOGIC>
-    // We have special logic when going to, coming from, or updating a pivot table.
-    const isPivot = newQuestion.display() === "pivot";
-    const wasPivot = oldQuestion.display() === "pivot";
-    const queryHasBreakouts =
-      isPivot &&
-      newQuestion.isStructured() &&
-      newQuestion.query().breakouts().length > 0;
-
-    // we can only pivot queries with breakouts
-    if (isPivot && queryHasBreakouts) {
-      // compute the pivot setting now so we can query the appropriate data
-      const series = assocIn(
-        getRawSeries(getState()),
-        [0, "card"],
-        newQuestion.card(),
-      );
-      const key = "pivot_table.column_split";
-      const setting = getQuestionWithDefaultVisualizationSettings(
-        newQuestion,
-        series,
-      ).setting(key);
-      newQuestion = newQuestion.updateSettings({ [key]: setting });
-    }
-
-    if (
-      // switching to pivot
-      (isPivot && !wasPivot && queryHasBreakouts) ||
-      // switching away from pivot
-      (!isPivot && wasPivot) ||
-      // updating the pivot rows/cols
-      (isPivot &&
-        queryHasBreakouts &&
-        !_.isEqual(
-          newQuestion.setting("pivot_table.column_split"),
-          oldQuestion.setting("pivot_table.column_split"),
-        ))
-    ) {
-      run = true; // force a run when switching to/from pivot or updating it's setting
-    }
-    // </PIVOT LOGIC>
-
-    // Native query should never be in notebook mode (metabase#12651)
-    if (mode === "notebook" && newQuestion.isNative()) {
-      await dispatch(
-        setQueryBuilderMode("view", {
-          shouldUpdateUrl: false,
-        }),
-      );
-    }
-
-    const newDatasetQuery = newQuestion.query().datasetQuery();
-    // Sync card's parameters with the template tags;
-    if (newDatasetQuery.type === "native") {
-      const templateTags = getTemplateTagsForParameters(newQuestion.card());
-      const parameters = getTemplateTagParameters(templateTags);
-      newQuestion = newQuestion.setParameters(parameters);
-    }
-
-    // Replace the current question with a new one
-    await dispatch.action(UPDATE_QUESTION, { card: newQuestion.card() });
-
-    if (shouldUpdateUrl) {
-      dispatch(updateUrl(null, { dirty: true }));
-    }
-
-    // See if the template tags editor should be shown/hidden
-    const isTemplateTagEditorVisible = getIsShowingTemplateTagsEditor(
-      getState(),
-    );
-    const nextTagEditorVisibilityState = getNextTemplateTagVisibilityState({
-      oldQuestion,
-      newQuestion,
-      isTemplateTagEditorVisible,
-      queryBuilderMode: mode,
-    });
-    if (nextTagEditorVisibilityState !== "deferToCurrentState") {
-      dispatch(
-        setIsShowingTemplateTagsEditor(
-          nextTagEditorVisibilityState === "visible",
-        ),
-      );
-    }
-
-    try {
-      if (
-        !_.isEqual(
-          oldQuestion.query().dependentMetadata(),
-          newQuestion.query().dependentMetadata(),
-        )
-      ) {
-        await dispatch(loadMetadataForCard(newQuestion.card()));
-      }
-
-      // setDefaultQuery requires metadata be loaded, need getQuestion to use new metadata
-      const question = getQuestion(getState());
-      const questionWithDefaultQuery = question.setDefaultQuery();
-      if (!questionWithDefaultQuery.isEqual(question)) {
-        await dispatch.action(UPDATE_QUESTION, {
-          card: questionWithDefaultQuery.setDefaultDisplay().card(),
-        });
-      }
-    } catch (e) {
-      // this will fail if user doesn't have data permissions but thats ok
-      console.warn("Couldn't load metadata", e);
-    }
-
-    // run updated query
-    if (run) {
-      dispatch(runQuestionQuery());
-    }
-  };
-};
 
 // DEPRECATED, still used in a couple places
 export const setDatasetQuery =

--- a/frontend/src/metabase/query_builder/actions/core/core.js
+++ b/frontend/src/metabase/query_builder/actions/core/core.js
@@ -52,6 +52,8 @@ import { onCloseSidebars, setQueryBuilderMode } from "../ui";
 import { loadMetadataForCard } from "./metadata";
 import { getQuestionWithDefaultVisualizationSettings } from "./utils";
 
+import { getQuestionWithDefaultVisualizationSettings } from "./utils";
+
 export const RESET_QB = "metabase/qb/RESET_QB";
 export const resetQB = createAction(RESET_QB);
 

--- a/frontend/src/metabase/query_builder/actions/core/core.js
+++ b/frontend/src/metabase/query_builder/actions/core/core.js
@@ -13,7 +13,6 @@ import { createThunkAction } from "metabase/lib/redux";
 import { cardIsEquivalent, cardQueryIsEquivalent } from "metabase/meta/Card";
 
 import { getCardAfterVisualizationClick } from "metabase/visualizations/lib/utils";
-import { getPersistableDefaultSettingsForSeries } from "metabase/visualizations/lib/settings/visualization";
 
 import { openUrl } from "metabase/redux/app";
 import { setRequestUnloaded } from "metabase/redux/requests";
@@ -53,30 +52,10 @@ import { zoomInRow } from "../object-detail";
 import { clearQueryResult, runQuestionQuery } from "../querying";
 import { onCloseSidebars, setQueryBuilderMode } from "../ui";
 
+import { getQuestionWithDefaultVisualizationSettings } from "./utils";
+
 export const RESET_QB = "metabase/qb/RESET_QB";
 export const resetQB = createAction(RESET_QB);
-
-/**
- * Saves to `visualization_settings` property of a question those visualization settings that
- * 1) don't have a value yet and 2) have `persistDefault` flag enabled.
- *
- * Needed for persisting visualization columns for pulses/alerts, see #6749.
- */
-const getQuestionWithDefaultVisualizationSettings = (question, series) => {
-  const oldVizSettings = question.settings();
-  const newVizSettings = {
-    ...oldVizSettings,
-    ...getPersistableDefaultSettingsForSeries(series),
-  };
-
-  // Don't update the question unnecessarily
-  // (even if fields values haven't changed, updating the settings will make the question appear dirty)
-  if (!_.isEqual(oldVizSettings, newVizSettings)) {
-    return question.setSettings(newVizSettings);
-  } else {
-    return question;
-  }
-};
 
 function hasNewColumns(question, queryResult) {
   // NOTE: this assume column names will change

--- a/frontend/src/metabase/query_builder/actions/core/core.js
+++ b/frontend/src/metabase/query_builder/actions/core/core.js
@@ -16,13 +16,10 @@ import { getCardAfterVisualizationClick } from "metabase/visualizations/lib/util
 
 import { openUrl } from "metabase/redux/app";
 import { setRequestUnloaded } from "metabase/redux/requests";
-import { loadMetadataForQueries } from "metabase/redux/metadata";
-import { getMetadata } from "metabase/selectors/metadata";
 
 import Questions from "metabase/entities/questions";
 import { fetchAlertsForQuestion } from "metabase/alert/alert";
 
-import Question from "metabase-lib/lib/Question";
 import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
 
 import {
@@ -52,6 +49,7 @@ import { zoomInRow } from "../object-detail";
 import { clearQueryResult, runQuestionQuery } from "../querying";
 import { onCloseSidebars, setQueryBuilderMode } from "../ui";
 
+import { loadMetadataForCard } from "./metadata";
 import { getQuestionWithDefaultVisualizationSettings } from "./utils";
 
 export const RESET_QB = "metabase/qb/RESET_QB";
@@ -67,18 +65,6 @@ function hasNewColumns(question, queryResult) {
     query instanceof StructuredQuery ? query.columnNames() : [];
   return _.difference(nextColumns, previousColumns).length > 0;
 }
-
-export const loadMetadataForCard = card => (dispatch, getState) => {
-  const metadata = getMetadata(getState());
-  const question = new Question(card, metadata);
-  const queries = [question.query()];
-  if (question.isDataset()) {
-    queries.push(question.composeDataset().query());
-  }
-  return dispatch(
-    loadMetadataForQueries(queries, question.dependentMetadata()),
-  );
-};
 
 // refreshes the card without triggering a run of the card's query
 export const SOFT_RELOAD_CARD = "metabase/qb/SOFT_RELOAD_CARD";

--- a/frontend/src/metabase/query_builder/actions/core/core.js
+++ b/frontend/src/metabase/query_builder/actions/core/core.js
@@ -52,6 +52,7 @@ import { onCloseSidebars, setQueryBuilderMode } from "../ui";
 import { loadMetadataForCard } from "./metadata";
 import { getQuestionWithDefaultVisualizationSettings } from "./utils";
 
+import { loadMetadataForCard } from "./metadata";
 import { getQuestionWithDefaultVisualizationSettings } from "./utils";
 
 export const RESET_QB = "metabase/qb/RESET_QB";

--- a/frontend/src/metabase/query_builder/actions/core/index.ts
+++ b/frontend/src/metabase/query_builder/actions/core/index.ts
@@ -1,2 +1,4 @@
 export * from "./core";
 export * from "./initializeQB";
+export * from "./metadata";
+export * from "./updateQuestion";

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
@@ -32,7 +32,8 @@ import { getQueryBuilderModeFromLocation } from "../../typed-utils";
 import { redirectToNewQuestionFlow, updateUrl } from "../navigation";
 import { cancelQuery, runQuestionQuery } from "../querying";
 
-import { loadMetadataForCard, resetQB } from "./core";
+import { resetQB } from "./core";
+import { loadMetadataForCard } from "./metadata";
 import {
   handleDashboardParameters,
   getParameterValuesForQuestion,

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.unit.spec.ts
@@ -39,6 +39,7 @@ import * as navigation from "../navigation";
 import * as querying from "../querying";
 
 import * as core from "./core";
+import * as metadataActions from "./metadata";
 import { initializeQB } from "./initializeQB";
 
 type BaseSetupOpts = {
@@ -236,7 +237,7 @@ describe("QB Actions > initializeQB", () => {
 
         it("fetches question metadata", async () => {
           const loadMetadataForCardSpy = jest.spyOn(
-            core,
+            metadataActions,
             "loadMetadataForCard",
           );
 
@@ -767,7 +768,10 @@ describe("QB Actions > initializeQB", () => {
     });
 
     it("fetches question metadata", async () => {
-      const loadMetadataForCardSpy = jest.spyOn(core, "loadMetadataForCard");
+      const loadMetadataForCardSpy = jest.spyOn(
+        metadataActions,
+        "loadMetadataForCard",
+      );
 
       const { question } = await setupOrdersTable();
 

--- a/frontend/src/metabase/query_builder/actions/core/metadata.ts
+++ b/frontend/src/metabase/query_builder/actions/core/metadata.ts
@@ -8,17 +8,15 @@ import Question from "metabase-lib/lib/Question";
 import { Card } from "metabase-types/types/Card";
 import { Dispatch, GetState } from "metabase-types/store";
 
-export const loadMetadataForCard = (card: Card) => (
-  dispatch: Dispatch,
-  getState: GetState,
-) => {
-  const metadata = getMetadata(getState());
-  const question = new Question(card, metadata);
-  const queries = [question.query()];
-  if (question.isDataset()) {
-    queries.push(question.composeDataset().query());
-  }
-  return dispatch(
-    loadMetadataForQueries(queries, question.dependentMetadata()),
-  );
-};
+export const loadMetadataForCard =
+  (card: Card) => (dispatch: Dispatch, getState: GetState) => {
+    const metadata = getMetadata(getState());
+    const question = new Question(card, metadata);
+    const queries = [question.query()];
+    if (question.isDataset()) {
+      queries.push(question.composeDataset().query());
+    }
+    return dispatch(
+      loadMetadataForQueries(queries, question.dependentMetadata()),
+    );
+  };

--- a/frontend/src/metabase/query_builder/actions/core/metadata.ts
+++ b/frontend/src/metabase/query_builder/actions/core/metadata.ts
@@ -1,0 +1,24 @@
+import _ from "underscore";
+
+import { loadMetadataForQueries } from "metabase/redux/metadata";
+import { getMetadata } from "metabase/selectors/metadata";
+
+import Question from "metabase-lib/lib/Question";
+
+import { Card } from "metabase-types/types/Card";
+import { Dispatch, GetState } from "metabase-types/store";
+
+export const loadMetadataForCard = (card: Card) => (
+  dispatch: Dispatch,
+  getState: GetState,
+) => {
+  const metadata = getMetadata(getState());
+  const question = new Question(card, metadata);
+  const queries = [question.query()];
+  if (question.isDataset()) {
+    queries.push(question.composeDataset().query());
+  }
+  return dispatch(
+    loadMetadataForQueries(queries, question.dependentMetadata()),
+  );
+};

--- a/frontend/src/metabase/query_builder/actions/core/updateQuestion.js
+++ b/frontend/src/metabase/query_builder/actions/core/updateQuestion.js
@@ -1,0 +1,196 @@
+import _ from "underscore";
+import { assocIn } from "icepick";
+
+import {
+  getTemplateTagsForParameters,
+  getTemplateTagParameters,
+} from "metabase/parameters/utils/cards";
+
+import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
+
+import {
+  getFirstQueryResult,
+  getIsEditing,
+  getIsShowingTemplateTagsEditor,
+  getQueryBuilderMode,
+  getQuestion,
+  getRawSeries,
+} from "../../selectors";
+import { getNextTemplateTagVisibilityState } from "../../utils";
+
+import { updateUrl } from "../navigation";
+import { setIsShowingTemplateTagsEditor } from "../native";
+import { runQuestionQuery } from "../querying";
+import { onCloseQuestionInfo, setQueryBuilderMode } from "../ui";
+
+import { loadMetadataForCard } from "./metadata";
+import { getQuestionWithDefaultVisualizationSettings } from "./utils";
+
+function hasNewColumns(question, queryResult) {
+  // NOTE: this assume column names will change
+  // technically this is wrong because you could add and remove two columns with the same name
+  const query = question.query();
+  const previousColumns =
+    (queryResult && queryResult.data.cols.map(col => col.name)) || [];
+  const nextColumns =
+    query instanceof StructuredQuery ? query.columnNames() : [];
+  return _.difference(nextColumns, previousColumns).length > 0;
+}
+
+/**
+ * Replaces the currently active question with the given Question object.
+ * Also shows/hides the template tag editor if the number of template tags has changed.
+ */
+export const UPDATE_QUESTION = "metabase/qb/UPDATE_QUESTION";
+export const updateQuestion = (
+  newQuestion,
+  { run = false, shouldUpdateUrl = false } = {},
+) => {
+  return async (dispatch, getState) => {
+    const oldQuestion = getQuestion(getState());
+    const mode = getQueryBuilderMode(getState());
+
+    const shouldConvertIntoAdHoc = newQuestion.query().isEditable();
+
+    // TODO Atte Keinänen 6/2/2017 Ways to have this happen automatically when modifying a question?
+    // Maybe the Question class or a QB-specific question wrapper class should know whether it's being edited or not?
+    if (
+      shouldConvertIntoAdHoc &&
+      !getIsEditing(getState()) &&
+      newQuestion.isSaved() &&
+      mode !== "dataset"
+    ) {
+      newQuestion = newQuestion.withoutNameAndId();
+
+      // When the dataset query changes, we should loose the dataset flag,
+      // to start building a new ad-hoc question based on a dataset
+      if (newQuestion.isDataset()) {
+        newQuestion = newQuestion.setDataset(false);
+        dispatch(onCloseQuestionInfo());
+      }
+    }
+
+    const queryResult = getFirstQueryResult(getState());
+    newQuestion = newQuestion.syncColumnsAndSettings(oldQuestion, queryResult);
+
+    if (run === "auto") {
+      run = hasNewColumns(newQuestion, queryResult);
+    }
+
+    if (!newQuestion.canAutoRun()) {
+      run = false;
+    }
+
+    // <PIVOT LOGIC>
+    // We have special logic when going to, coming from, or updating a pivot table.
+    const isPivot = newQuestion.display() === "pivot";
+    const wasPivot = oldQuestion.display() === "pivot";
+    const queryHasBreakouts =
+      isPivot &&
+      newQuestion.isStructured() &&
+      newQuestion.query().breakouts().length > 0;
+
+    // we can only pivot queries with breakouts
+    if (isPivot && queryHasBreakouts) {
+      // compute the pivot setting now so we can query the appropriate data
+      const series = assocIn(
+        getRawSeries(getState()),
+        [0, "card"],
+        newQuestion.card(),
+      );
+      const key = "pivot_table.column_split";
+      const setting = getQuestionWithDefaultVisualizationSettings(
+        newQuestion,
+        series,
+      ).setting(key);
+      newQuestion = newQuestion.updateSettings({ [key]: setting });
+    }
+
+    if (
+      // switching to pivot
+      (isPivot && !wasPivot && queryHasBreakouts) ||
+      // switching away from pivot
+      (!isPivot && wasPivot) ||
+      // updating the pivot rows/cols
+      (isPivot &&
+        queryHasBreakouts &&
+        !_.isEqual(
+          newQuestion.setting("pivot_table.column_split"),
+          oldQuestion.setting("pivot_table.column_split"),
+        ))
+    ) {
+      run = true; // force a run when switching to/from pivot or updating it's setting
+    }
+    // </PIVOT LOGIC>
+
+    // Native query should never be in notebook mode (metabase#12651)
+    if (mode === "notebook" && newQuestion.isNative()) {
+      await dispatch(
+        setQueryBuilderMode("view", {
+          shouldUpdateUrl: false,
+        }),
+      );
+    }
+
+    const newDatasetQuery = newQuestion.query().datasetQuery();
+    // Sync card's parameters with the template tags;
+    if (newDatasetQuery.type === "native") {
+      const templateTags = getTemplateTagsForParameters(newQuestion.card());
+      const parameters = getTemplateTagParameters(templateTags);
+      newQuestion = newQuestion.setParameters(parameters);
+    }
+
+    // Replace the current question with a new one
+    await dispatch.action(UPDATE_QUESTION, { card: newQuestion.card() });
+
+    if (shouldUpdateUrl) {
+      dispatch(updateUrl(null, { dirty: true }));
+    }
+
+    // See if the template tags editor should be shown/hidden
+    const isTemplateTagEditorVisible = getIsShowingTemplateTagsEditor(
+      getState(),
+    );
+    const nextTagEditorVisibilityState = getNextTemplateTagVisibilityState({
+      oldQuestion,
+      newQuestion,
+      isTemplateTagEditorVisible,
+      queryBuilderMode: mode,
+    });
+    if (nextTagEditorVisibilityState !== "deferToCurrentState") {
+      dispatch(
+        setIsShowingTemplateTagsEditor(
+          nextTagEditorVisibilityState === "visible",
+        ),
+      );
+    }
+
+    try {
+      if (
+        !_.isEqual(
+          oldQuestion.query().dependentMetadata(),
+          newQuestion.query().dependentMetadata(),
+        )
+      ) {
+        await dispatch(loadMetadataForCard(newQuestion.card()));
+      }
+
+      // setDefaultQuery requires metadata be loaded, need getQuestion to use new metadata
+      const question = getQuestion(getState());
+      const questionWithDefaultQuery = question.setDefaultQuery();
+      if (!questionWithDefaultQuery.isEqual(question)) {
+        await dispatch.action(UPDATE_QUESTION, {
+          card: questionWithDefaultQuery.setDefaultDisplay().card(),
+        });
+      }
+    } catch (e) {
+      // this will fail if user doesn't have data permissions but thats ok
+      console.warn("Couldn't load metadata", e);
+    }
+
+    // run updated query
+    if (run) {
+      dispatch(runQuestionQuery());
+    }
+  };
+};

--- a/frontend/src/metabase/query_builder/actions/core/utils.ts
+++ b/frontend/src/metabase/query_builder/actions/core/utils.ts
@@ -1,0 +1,32 @@
+import _ from "underscore";
+
+import { getPersistableDefaultSettingsForSeries } from "metabase/visualizations/lib/settings/visualization";
+
+import Question from "metabase-lib/lib/Question";
+
+import { Series } from "metabase-types/types/Visualization";
+
+/**
+ * Saves to `visualization_settings` property of a question those visualization settings that
+ * 1) don't have a value yet and 2) have `persistDefault` flag enabled.
+ *
+ * Needed for persisting visualization columns for pulses/alerts, see metabase#6749.
+ */
+export function getQuestionWithDefaultVisualizationSettings(
+  question: Question,
+  series: Series,
+) {
+  const oldVizSettings = question.settings();
+  const newVizSettings = {
+    ...oldVizSettings,
+    ...getPersistableDefaultSettingsForSeries(series),
+  };
+
+  // Don't update the question unnecessarily
+  // (even if fields values haven't changed, updating the settings will make the question appear dirty)
+  if (!_.isEqual(oldVizSettings, newVizSettings)) {
+    return question.setSettings(newVizSettings);
+  } else {
+    return question;
+  }
+}

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -82,7 +82,6 @@ const viewTitleHeaderPropTypes = {
   onAddFilter: PropTypes.func,
   onCloseFilter: PropTypes.func,
   onOpenQuestionDetails: PropTypes.func,
-  onCloseQuestionDetails: PropTypes.func,
 
   isPreviewable: PropTypes.bool,
   isPreviewing: PropTypes.bool,


### PR DESCRIPTION
The first step towards refactoring QB `updateQuestion` action:

* extracts `updateQuestion` action to its file without any code changes, so it's easier to add test coverage, refactor and convert it to TypeScript
* extracts some of the shared utilities from the `core.js` actions file so that they can be used in both files

Next refactoring PRs:

* #24141
* #24142
* #24143