### PR TITLE
Refactor QB `updateQuestion` action

### DIFF
--- a/frontend/src/metabase/query_builder/actions/core/updateQuestion.js
+++ b/frontend/src/metabase/query_builder/actions/core/updateQuestion.js
@@ -39,7 +39,6 @@ function hasNewColumns(question, queryResult) {
 
 /**
  * Replaces the currently active question with the given Question object.
- * Also shows/hides the template tag editor if the number of template tags has changed.
  */
 export const UPDATE_QUESTION = "metabase/qb/UPDATE_QUESTION";
 export const updateQuestion = (
@@ -52,8 +51,6 @@ export const updateQuestion = (
 
     const shouldConvertIntoAdHoc = newQuestion.query().isEditable();
 
-    // TODO Atte Keinänen 6/2/2017 Ways to have this happen automatically when modifying a question?
-    // Maybe the Question class or a QB-specific question wrapper class should know whether it's being edited or not?
     if (
       shouldConvertIntoAdHoc &&
       !getIsEditing(getState()) &&
@@ -81,8 +78,6 @@ export const updateQuestion = (
       run = false;
     }
 
-    // <PIVOT LOGIC>
-    // We have special logic when going to, coming from, or updating a pivot table.
     const isPivot = newQuestion.display() === "pivot";
     const wasPivot = oldQuestion.display() === "pivot";
     const queryHasBreakouts =
@@ -90,7 +85,6 @@ export const updateQuestion = (
       newQuestion.isStructured() &&
       newQuestion.query().breakouts().length > 0;
 
-    // we can only pivot queries with breakouts
     if (isPivot && queryHasBreakouts) {
       // compute the pivot setting now so we can query the appropriate data
       const series = assocIn(
@@ -107,9 +101,7 @@ export const updateQuestion = (
     }
 
     if (
-      // switching to pivot
       (isPivot && !wasPivot && queryHasBreakouts) ||
-      // switching away from pivot
       (!isPivot && wasPivot) ||
       // updating the pivot rows/cols
       (isPivot &&
@@ -121,7 +113,6 @@ export const updateQuestion = (
     ) {
       run = true; // force a run when switching to/from pivot or updating it's setting
     }
-    // </PIVOT LOGIC>
 
     // Native query should never be in notebook mode (metabase#12651)
     if (mode === "notebook" && newQuestion.isNative()) {
@@ -140,7 +131,6 @@ export const updateQuestion = (
       newQuestion = newQuestion.setParameters(parameters);
     }
 
-    // Replace the current question with a new one
     await dispatch({
       type: UPDATE_QUESTION,
       payload: { card: newQuestion.card() },
@@ -150,7 +140,6 @@ export const updateQuestion = (
       dispatch(updateUrl(null, { dirty: true }));
     }
 
-    // See if the template tags editor should be shown/hidden
     const isTemplateTagEditorVisible = getIsShowingTemplateTagsEditor(
       getState(),
     );
@@ -191,7 +180,6 @@ export const updateQuestion = (
       console.warn("Couldn't load metadata", e);
     }
 
-    // run updated query
     if (run) {
       dispatch(runQuestionQuery());
     }

--- a/frontend/src/metabase/query_builder/actions/core/updateQuestion.js
+++ b/frontend/src/metabase/query_builder/actions/core/updateQuestion.js
@@ -198,13 +198,10 @@ export const updateQuestion = (
       }
     }
 
+    const currentDependencies = currentQuestion.query().dependentMetadata();
+    const nextDependencies = newQuestion.query().dependentMetadata();
     try {
-      if (
-        !_.isEqual(
-          currentQuestion.query().dependentMetadata(),
-          newQuestion.query().dependentMetadata(),
-        )
-      ) {
+      if (!_.isEqual(currentDependencies, nextDependencies)) {
         await dispatch(loadMetadataForCard(newQuestion.card()));
       }
 

--- a/frontend/src/metabase/query_builder/actions/core/updateQuestion.js
+++ b/frontend/src/metabase/query_builder/actions/core/updateQuestion.js
@@ -47,7 +47,7 @@ export const updateQuestion = (
 ) => {
   return async (dispatch, getState) => {
     const currentQuestion = getQuestion(getState());
-    const mode = getQueryBuilderMode(getState());
+    const queryBuilderMode = getQueryBuilderMode(getState());
 
     const shouldConvertIntoAdHoc = newQuestion.query().isEditable();
 
@@ -55,7 +55,7 @@ export const updateQuestion = (
       shouldConvertIntoAdHoc &&
       !getIsEditing(getState()) &&
       newQuestion.isSaved() &&
-      mode !== "dataset"
+      queryBuilderMode !== "dataset"
     ) {
       newQuestion = newQuestion.withoutNameAndId();
 
@@ -118,7 +118,7 @@ export const updateQuestion = (
     }
 
     // Native query should never be in notebook mode (metabase#12651)
-    if (mode === "notebook" && newQuestion.isNative()) {
+    if (queryBuilderMode === "notebook" && newQuestion.isNative()) {
       await dispatch(
         setQueryBuilderMode("view", {
           shouldUpdateUrl: false,
@@ -150,7 +150,7 @@ export const updateQuestion = (
       oldQuestion: currentQuestion,
       newQuestion,
       isTemplateTagEditorVisible,
-      queryBuilderMode: mode,
+      queryBuilderMode,
     });
     if (nextTagEditorVisibilityState !== "deferToCurrentState") {
       dispatch(

--- a/frontend/src/metabase/query_builder/actions/core/updateQuestion.js
+++ b/frontend/src/metabase/query_builder/actions/core/updateQuestion.js
@@ -49,14 +49,13 @@ export const updateQuestion = (
     const currentQuestion = getQuestion(getState());
     const queryBuilderMode = getQueryBuilderMode(getState());
 
-    const shouldConvertIntoAdHoc = newQuestion.query().isEditable();
-
-    if (
-      shouldConvertIntoAdHoc &&
-      !getIsEditing(getState()) &&
+    const shouldTurnIntoAdHoc =
       newQuestion.isSaved() &&
-      queryBuilderMode !== "dataset"
-    ) {
+      newQuestion.query().isEditable() &&
+      queryBuilderMode !== "dataset" &&
+      !getIsEditing(getState());
+
+    if (shouldTurnIntoAdHoc) {
       newQuestion = newQuestion.withoutNameAndId();
 
       // When the dataset query changes, we should loose the dataset flag,

--- a/frontend/src/metabase/query_builder/actions/core/updateQuestion.js
+++ b/frontend/src/metabase/query_builder/actions/core/updateQuestion.js
@@ -46,7 +46,7 @@ export const updateQuestion = (
   { run = false, shouldUpdateUrl = false } = {},
 ) => {
   return async (dispatch, getState) => {
-    const oldQuestion = getQuestion(getState());
+    const currentQuestion = getQuestion(getState());
     const mode = getQueryBuilderMode(getState());
 
     const shouldConvertIntoAdHoc = newQuestion.query().isEditable();
@@ -68,7 +68,10 @@ export const updateQuestion = (
     }
 
     const queryResult = getFirstQueryResult(getState());
-    newQuestion = newQuestion.syncColumnsAndSettings(oldQuestion, queryResult);
+    newQuestion = newQuestion.syncColumnsAndSettings(
+      currentQuestion,
+      queryResult,
+    );
 
     if (run === "auto") {
       run = hasNewColumns(newQuestion, queryResult);
@@ -79,7 +82,7 @@ export const updateQuestion = (
     }
 
     const isPivot = newQuestion.display() === "pivot";
-    const wasPivot = oldQuestion.display() === "pivot";
+    const wasPivot = currentQuestion.display() === "pivot";
     const queryHasBreakouts =
       isPivot &&
       newQuestion.isStructured() &&
@@ -108,7 +111,7 @@ export const updateQuestion = (
         queryHasBreakouts &&
         !_.isEqual(
           newQuestion.setting("pivot_table.column_split"),
-          oldQuestion.setting("pivot_table.column_split"),
+          currentQuestion.setting("pivot_table.column_split"),
         ))
     ) {
       run = true; // force a run when switching to/from pivot or updating it's setting
@@ -144,7 +147,7 @@ export const updateQuestion = (
       getState(),
     );
     const nextTagEditorVisibilityState = getNextTemplateTagVisibilityState({
-      oldQuestion,
+      oldQuestion: currentQuestion,
       newQuestion,
       isTemplateTagEditorVisible,
       queryBuilderMode: mode,
@@ -160,7 +163,7 @@ export const updateQuestion = (
     try {
       if (
         !_.isEqual(
-          oldQuestion.query().dependentMetadata(),
+          currentQuestion.query().dependentMetadata(),
           newQuestion.query().dependentMetadata(),
         )
       ) {

--- a/frontend/src/metabase/query_builder/actions/core/updateQuestion.js
+++ b/frontend/src/metabase/query_builder/actions/core/updateQuestion.js
@@ -61,7 +61,7 @@ function checkShouldRerunPivotTableQuestion({
   );
 }
 
-export function getNextTemplateTagState({
+function getNextTemplateTagEditorState({
   currentQuestion,
   newQuestion,
   isVisible,
@@ -187,7 +187,7 @@ export const updateQuestion = (
 
     if (currentQuestion.isNative() && newQuestion.isNative()) {
       const isVisible = getIsShowingTemplateTagsEditor(getState());
-      const nextState = getNextTemplateTagState({
+      const nextState = getNextTemplateTagEditorState({
         currentQuestion,
         newQuestion,
         queryBuilderMode,

--- a/frontend/src/metabase/query_builder/actions/core/updateQuestion.js
+++ b/frontend/src/metabase/query_builder/actions/core/updateQuestion.js
@@ -185,7 +185,7 @@ export const updateQuestion = (
       dispatch(updateUrl(null, { dirty: true }));
     }
 
-    if (currentQuestion.isNative() && newQuestion.isNative()) {
+    if (currentQuestion.isNative() || newQuestion.isNative()) {
       const isVisible = getIsShowingTemplateTagsEditor(getState());
       const nextState = getNextTemplateTagEditorState({
         currentQuestion,
@@ -194,7 +194,7 @@ export const updateQuestion = (
         isVisible,
       });
       if (nextState) {
-        setIsShowingTemplateTagsEditor(nextState === "visible");
+        dispatch(setIsShowingTemplateTagsEditor(nextState === "visible"));
       }
     }
 

--- a/frontend/src/metabase/query_builder/utils.js
+++ b/frontend/src/metabase/query_builder/utils.js
@@ -1,7 +1,5 @@
 import querystring from "querystring";
-import { isSupportedTemplateTagForModel } from "metabase/lib/data-modeling/utils";
 import * as Urls from "metabase/lib/urls";
-import NativeQuery from "metabase-lib/lib/queries/NativeQuery";
 
 export function getPathNameFromQueryBuilderMode({
   pathname,
@@ -44,36 +42,4 @@ export function getURLForCardState(
     }
   }
   return Urls.question(card, options);
-}
-
-function getTemplateTagWithoutSnippetsCount(question) {
-  const query = question.query();
-  return query instanceof NativeQuery
-    ? query.templateTagsWithoutSnippets()
-    : [];
-}
-
-export function getNextTemplateTagVisibilityState({
-  oldQuestion,
-  newQuestion,
-  isTemplateTagEditorVisible,
-  queryBuilderMode,
-}) {
-  const previousTags = getTemplateTagWithoutSnippetsCount(oldQuestion);
-  const nextTags = getTemplateTagWithoutSnippetsCount(newQuestion);
-
-  if (nextTags.length > previousTags.length) {
-    if (queryBuilderMode !== "dataset") {
-      return "visible";
-    }
-    return nextTags.every(isSupportedTemplateTagForModel)
-      ? "visible"
-      : "hidden";
-  }
-
-  if (nextTags.length === 0 && isTemplateTagEditorVisible) {
-    return "hidden";
-  }
-
-  return "deferToCurrentState";
 }


### PR DESCRIPTION
Refactors QB `updateQuestion` action relying on test-coverage added in #24141. The action has a few responsibilities, I tried to focus on extracting some of their logic to other functions to make the whole thing a bit easier to reason about:

* native questions — extracted code figuring out the next state of template tag editor
* pivot tables — extracted code checking if we should re-run the query
* bunch of smaller improvements

I feel there's more room for improvement, but I can't see it yet. Would appreciate any feedback and contributions.

Previous refactoring PRs:

* #24140
* #24141

Next refactoring PRs:

* #24143