### PR TITLE
Fix pivot table formatting

### DIFF
--- a/frontend/src/metabase/lib/data_grid.js
+++ b/frontend/src/metabase/lib/data_grid.js
@@ -161,7 +161,6 @@ export function multiLevelPivot(data, settings) {
   );
   const formattedRowTree = addSubtotals(
     formattedRowTreeWithoutSubtotals,
-    leftIndexFormatters,
     showSubtotalsByColumn,
   );
   if (formattedRowTreeWithoutSubtotals.length > 1) {
@@ -360,7 +359,7 @@ function addValueColumnNodes(nodes, valueColumns) {
 
 // This inserts nodes into the left header tree for subtotals.
 // We also mark nodes with `hasSubtotal` to display collapsing UI
-function addSubtotals(rowColumnTree, formatters, showSubtotalsByColumn) {
+function addSubtotals(rowColumnTree, showSubtotalsByColumn) {
   // For top-level items we want to show subtotal even if they have only one child
   // Except the case when top-level items have flat structure
   // (meaning all of the items have just one child)
@@ -370,7 +369,7 @@ function addSubtotals(rowColumnTree, formatters, showSubtotalsByColumn) {
   const notFlat = rowColumnTree.some(item => item.children.length > 1);
 
   return rowColumnTree.flatMap(item =>
-    addSubtotal(item, formatters, showSubtotalsByColumn, {
+    addSubtotal(item, showSubtotalsByColumn, {
       shouldShowSubtotal: notFlat || item.children.length > 1,
     }),
   );
@@ -378,7 +377,6 @@ function addSubtotals(rowColumnTree, formatters, showSubtotalsByColumn) {
 
 function addSubtotal(
   item,
-  [formatter, ...formatters],
   [isSubtotalEnabled, ...showSubtotalsByColumn],
   { shouldShowSubtotal = false } = {},
 ) {
@@ -386,7 +384,7 @@ function addSubtotal(
   const subtotal = hasSubtotal
     ? [
         {
-          value: t`Totals for ${formatter(item.value)}`,
+          value: t`Totals for ${item.value}`,
           rawValue: item.rawValue,
           span: 1,
           isSubtotal: true,
@@ -403,7 +401,7 @@ function addSubtotal(
     children: item.children.flatMap(child =>
       // add subtotals until the last level
       child.children.length > 0
-        ? addSubtotal(child, formatters, showSubtotalsByColumn, {
+        ? addSubtotal(child, showSubtotalsByColumn, {
             shouldShowSubtotal: child.children.length > 1,
           })
         : child,

--- a/frontend/test/metabase/scenarios/visualizations/reproductions/23076.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/reproductions/23076.cy.spec.js
@@ -29,7 +29,7 @@ const questionDetails = {
   },
 };
 
-describe.skip("issue 23076", () => {
+describe("issue 23076", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/23076

The problem was that we formatted `item.value` twice for total columns - once in `formatValuesInTree`, then in `addSubtotal`. It didn't work well for non-english locales because `moment.utc` couldn't parse a non-english string in `parseTimestamp`.

How to test:
- Follow the steps from the referenced issue

<img width="627" alt="Screenshot 2022-07-20 at 20 00 26" src="https://user-images.githubusercontent.com/8542534/180040847-826a5a32-21b7-4eb0-bb5a-ab3f1f6419d5.png">
