### PR TITLE
Enable private key authentication for Snowflake

### DIFF
--- a/modules/drivers/snowflake/resources/metabase-plugin.yaml
+++ b/modules/drivers/snowflake/resources/metabase-plugin.yaml
@@ -14,9 +14,11 @@ driver:
       placeholder: xxxxxxxx.us-east-2.aws
       required: true
     - user
-    - merge:
-        - password
-        - required: true
+    - password
+    - name: private-key
+      display-name: RSA private key (PEM)
+      type: secret
+      secret-kind: pem-cert
     - name: warehouse
       display-name: Warehouse
       helper-text: If your user doesn't have a default warehouse, enter the warehouse to connect to.

--- a/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
+++ b/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
@@ -125,8 +125,7 @@
 
 (deftest can-connect-test
   (mt/test-driver :snowflake
-    (letfn [(can-connect? [details]
-              (driver/can-connect? :snowflake details))]
+    (let [can-connect? (partial driver/can-connect? :snowflake)]
       (is (= true
              (can-connect? (:details (mt/db))))
           "can-connect? should return true for normal Snowflake DB details")
@@ -137,10 +136,11 @@
       (let [pk-user (tx/db-test-env-var-or-throw :snowflake :pk-user)
             pk-key  (format-env-key (tx/db-test-env-var-or-throw :snowflake :pk-private-key))]
         (is (= true
-               (can-connect? (-> (:details (mt/db))
-                                 (dissoc :password)
-                                 (assoc :user pk-user
-                                        :private-key-value pk-key))))
+               (-> (:details (mt/db))
+                   (dissoc :password)
+                   (assoc :user pk-user
+                          :private-key-value pk-key)
+                   can-connect?))
             "can-connect? should return true when authenticating with private key")))))
 
 (deftest report-timezone-test

--- a/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
+++ b/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
@@ -130,12 +130,15 @@
            (can-connect? (assoc (:details (mt/db)) :db (mt/random-name))))
           "can-connect? should throw for Snowflake databases that don't exist (#9511)")
       (let [pk-user (tx/db-test-env-var-or-throw :snowflake :pk-user)
-            pk-key  (tx/db-test-env-var-or-throw :snowflake :pk-private-key)]
+            pk-key  (str/replace (tx/db-test-env-var-or-throw :snowflake :pk-private-key) #"\s+" "\n")]
         (is (= true
-               (can-connect? (-> (:details (mt/db))
-                                 (dissoc :password)
-                                 (assoc :user pk-user
-                                        :private-key-value pk-key))))
+               (try
+                 (can-connect? (-> (:details (mt/db))
+                                   (dissoc :password)
+                                   (assoc :user pk-user
+                                          :private-key-value pk-key)))
+                 (catch IllegalArgumentException e
+                   (throw (ex-info "connection failed" {:u pk-user :k pk-key} e)))))
             "can-connect? should return true when authenticating with private key")))))
 
 (deftest report-timezone-test

--- a/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
+++ b/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
@@ -11,6 +11,7 @@
             [metabase.sync :as sync]
             [metabase.test :as mt]
             [metabase.test.data.dataset-definitions :as defs]
+            [metabase.test.data.interface :as tx]
             [metabase.test.data.sql :as sql.tx]
             [metabase.test.data.sql.ddl :as ddl]
             [metabase.util :as u]
@@ -127,7 +128,15 @@
       (is (thrown?
            net.snowflake.client.jdbc.SnowflakeSQLException
            (can-connect? (assoc (:details (mt/db)) :db (mt/random-name))))
-          "can-connect? should throw for Snowflake databases that don't exist (#9511)"))))
+          "can-connect? should throw for Snowflake databases that don't exist (#9511)")
+      (let [pk-user (tx/db-test-env-var-or-throw :snowflake :pk-user)
+            pk-key  (tx/db-test-env-var-or-throw :snowflake :pk-private-key)]
+        (is (= true
+               (can-connect? (-> (:details (mt/db))
+                                 (dissoc :password)
+                                 (assoc :user pk-user
+                                        :private-key-value pk-key))))
+            "can-connect? should return true when authenticating with private key")))))
 
 (deftest report-timezone-test
   (mt/test-driver :snowflake

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -482,7 +482,7 @@
   (when-let [m (re-find #"^-----BEGIN (?:(\p{Alnum}+) )?PRIVATE KEY-----\n" key-string)]
     (m 1)))
 
-(defn- parse-rsa-key
+(defn parse-rsa-key
   "Parses an RSA private key from the PEM string `key-string`."
   ^PrivateKey [key-string]
   (let [algorithm (or (key-type key-string) "RSA")

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -482,7 +482,7 @@
   (when-let [m (re-find #"^-----BEGIN (?:(\p{Alnum}+) )?PRIVATE KEY-----\n" key-string)]
     (m 1)))
 
-(defn parse-rsa-key
+(defn- parse-rsa-key
   "Parses an RSA private key from the PEM string `key-string`."
   ^PrivateKey [key-string]
   (let [algorithm (or (key-type key-string) "RSA")

--- a/src/metabase/models/secret.clj
+++ b/src/metabase/models/secret.clj
@@ -63,7 +63,7 @@
   resolved, in order to render a more user-friendly error message (by looking up the display names of the connection
   properties involved)."
   {:added "0.42.0"}
-  [{:keys [connection-property-name id value] :as secret} driver?]
+  ^File [{:keys [connection-property-name id value] :as secret} driver?]
   (if (= :file-path (:source secret))
     (let [secret-val          (value->string secret)
           ^File existing-file (File. secret-val)]

--- a/src/metabase/models/secret.clj
+++ b/src/metabase/models/secret.clj
@@ -100,6 +100,13 @@
           (.write out v)))
       tmp-file)))
 
+(defn get-sub-props
+  "Return a map of secret subproperties for the property `connection-property-name`."
+  [connection-property-name]
+  (let [sub-prop-types [:path :value :options :id]
+        sub-prop #(keyword (str connection-property-name "-" (name %)))]
+    (zipmap sub-prop-types (map sub-prop sub-prop-types))))
+
 (def ^:private uploaded-base-64-pattern #"^data:application/([^;]*);base64,")
 
 (defn db-details-prop->secret-map
@@ -118,37 +125,33 @@
                 intermediate subproperties are removed from the connection-properties before building the JDBC spec)."
   {:added "0.42.0"}
   [details conn-prop-nm]
-  (let [sub-prop   (fn [suffix]
-                     (keyword (str conn-prop-nm suffix)))
-        path-kw    (sub-prop "-path")
-        value-kw   (sub-prop "-value")
-        options-kw (sub-prop "-options")
-        id-kw      (sub-prop "-id")
-        value      (cond
-                     ;; ssl-root-certs will need their prefix removed, and to be base 64 decoded (#20319)
-                     (and (value-kw details) (#{"ssl-client-cert" "ssl-root-cert"} conn-prop-nm)
-                          (re-find uploaded-base-64-pattern (value-kw details)))
-                     (-> (value-kw details) (str/replace-first uploaded-base-64-pattern "") u/decode-base64)
+  (let [{path-kw :path, value-kw :value, options-kw :options, id-kw :id}
+        (get-sub-props conn-prop-nm)
+        value  (cond
+                 ;; ssl-root-certs will need their prefix removed, and to be base 64 decoded (#20319)
+                 (and (value-kw details) (#{"ssl-client-cert" "ssl-root-cert"} conn-prop-nm)
+                      (re-find uploaded-base-64-pattern (value-kw details)))
+                 (-> (value-kw details) (str/replace-first uploaded-base-64-pattern "") u/decode-base64)
 
-                     (and (value-kw details) (#{"ssl-key"} conn-prop-nm)
-                          (re-find uploaded-base-64-pattern (value-kw details)))
-                     (.decode (java.util.Base64/getDecoder)
-                              (str/replace-first (value-kw details) uploaded-base-64-pattern ""))
+                 (and (value-kw details) (#{"ssl-key"} conn-prop-nm)
+                      (re-find uploaded-base-64-pattern (value-kw details)))
+                 (.decode (java.util.Base64/getDecoder)
+                          (str/replace-first (value-kw details) uploaded-base-64-pattern ""))
 
-                     ;; the -value suffix was specified; use that
-                     (value-kw details)
-                     (value-kw details)
+                 ;; the -value suffix was specified; use that
+                 (value-kw details)
+                 (value-kw details)
 
-                     ;; the -path suffix was specified; this is actually a :file-path
-                     (path-kw details)
-                     (u/prog1 (path-kw details)
-                       (when (premium-features/is-hosted?)
-                         (throw (ex-info
-                                 (tru "{0} (a local file path) cannot be used in Metabase hosted environment" path-kw)
-                                 {:invalid-db-details-entry (select-keys details [path-kw])}))))
+                 ;; the -path suffix was specified; this is actually a :file-path
+                 (path-kw details)
+                 (u/prog1 (path-kw details)
+                   (when (premium-features/is-hosted?)
+                     (throw (ex-info
+                             (tru "{0} (a local file path) cannot be used in Metabase hosted environment" path-kw)
+                             {:invalid-db-details-entry (select-keys details [path-kw])}))))
 
-                     (id-kw details)
-                     (:value (Secret (id-kw details))))
+                 (id-kw details)
+                 (:value (Secret (id-kw details))))
         source (cond
                  ;; set the :source due to the -path suffix (see above))
                  (and (not= "uploaded" (options-kw details)) (path-kw details))
@@ -164,17 +167,14 @@
 (defn get-secret-string
   "Get the value of a secret property from the database details as a string."
   [details secret-property]
-  (let [value-key (keyword (str secret-property "-value"))
-        options-key (keyword (str secret-property "-options"))
-        path-key (keyword (str secret-property "-path"))
-        id-key (keyword (str secret-property "-id"))
-        id (id-key details)
+  (let [{path-kw :path, value-kw :value, options-kw :options, id-kw :id} (get-sub-props secret-property)
+        id (id-kw details)
         value (if id
                 (String. ^bytes (:value (Secret id)) "UTF-8")
-                (value-key details))]
-    (case (options-key details)
+                (value-kw details))]
+    (case (options-kw details)
       "uploaded" (String. ^bytes (driver.u/decode-uploaded value) "UTF-8")
-      "local" (slurp (if id value (path-key details)))
+      "local" (slurp (if id value (path-kw details)))
       value)))
 
 (def


### PR DESCRIPTION
Fixes #19191. This PR enables uploading _unencrypted_ RSA private keys to support private key authentication with Snowflake.