### PR TITLE
Obey `start_of_week` day setting in filter label

### DIFF
--- a/frontend/src/metabase/lib/i18n.js
+++ b/frontend/src/metabase/lib/i18n.js
@@ -75,6 +75,7 @@ function setLocalization(translationsObject) {
 
   updateMomentLocale(locale);
   updateMomentStartOfWeek(locale);
+  console.log("🚀", moment().localeData()._week);
 }
 
 function updateMomentLocale(locale) {

--- a/frontend/src/metabase/lib/i18n.js
+++ b/frontend/src/metabase/lib/i18n.js
@@ -75,7 +75,6 @@ function setLocalization(translationsObject) {
 
   updateMomentLocale(locale);
   updateMomentStartOfWeek(locale);
-  console.log("🚀", moment().localeData()._week);
 }
 
 function updateMomentLocale(locale) {

--- a/frontend/src/metabase/lib/query_time.js
+++ b/frontend/src/metabase/lib/query_time.js
@@ -274,6 +274,7 @@ export function absolute(date) {
   if (typeof date === "string") {
     return moment(date);
   } else if (Array.isArray(date) && date[0] === "relative-datetime") {
+    console.log("🚀", moment().localeData()._week);
     return moment().add(date[1], date[2]);
   } else {
     console.warn("Unknown datetime format", date);

--- a/frontend/src/metabase/lib/query_time.js
+++ b/frontend/src/metabase/lib/query_time.js
@@ -1,5 +1,5 @@
 import _ from "underscore";
-import moment from "moment";
+import moment from "moment-timezone";
 import { assoc } from "icepick";
 import inflection from "inflection";
 import { t, ngettext, msgid } from "ttag";
@@ -274,7 +274,6 @@ export function absolute(date) {
   if (typeof date === "string") {
     return moment(date);
   } else if (Array.isArray(date) && date[0] === "relative-datetime") {
-    console.log("🚀", moment().localeData()._week);
     return moment().add(date[1], date[2]);
   } else {
     console.warn("Unknown datetime format", date);

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/SpecificDatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/SpecificDatePicker.tsx
@@ -10,6 +10,7 @@ import ExpandingContent from "metabase/components/ExpandingContent";
 import HoursMinutesInput from "./HoursMinutesInput";
 
 import moment from "moment";
+import momentTimezone from "moment-timezone";
 import { getTimeComponent, setTimeComponent } from "metabase/lib/query_time";
 
 type Props = {
@@ -27,7 +28,7 @@ type Props = {
 
 const SpecificDatePicker: React.FC<Props> = props => {
   const onChange = (
-    date?: string | moment.Moment,
+    date?: string | momentTimezone.Moment,
     hours?: number | null,
     minutes?: number | null,
   ) => {
@@ -66,7 +67,7 @@ const SpecificDatePicker: React.FC<Props> = props => {
           onBlurChange={({ target: { value } }: any) => {
             const date = moment(value, dateFormat);
             if (date.isValid()) {
-              onChange(date, hours, minutes);
+              onChange(date as momentTimezone.Moment, hours, minutes);
             } else {
               onChange();
             }
@@ -100,8 +101,8 @@ const SpecificDatePicker: React.FC<Props> = props => {
       {calendar && (
         <ExpandingContent isOpen={showCalendar}>
           <Calendar
-            selected={date}
-            initial={date || moment()}
+            selected={date as moment.Moment}
+            initial={(date as moment.Moment) || moment()}
             onChange={value => onChange(value, hours, minutes)}
             isRangePicker={false}
             selectAll={selectAll}


### PR DESCRIPTION
Fixes #23142

### How to Test

1. Admin > Settings > Localization > First day of the week = Monday
2. _we don't have any current data, but this is a frontend issue, the correct data is filtered, so just open a filter "Past 1 week"_

Weekdays displayed should start on Monday and end on Sunday

![image](https://user-images.githubusercontent.com/1447303/171875053-dd1608fe-2c17-4a31-b3e0-28e437cf1ccf.png)