### PR TITLE
Fix highlighting collections after moving a dashboard

### DIFF
--- a/frontend/src/metabase/dashboard/reducers.js
+++ b/frontend/src/metabase/dashboard/reducers.js
@@ -1,5 +1,6 @@
 import { assoc, dissoc, assocIn, updateIn, chain, merge } from "icepick";
 import { handleActions, combineReducers } from "metabase/lib/redux";
+import Dashboards from "metabase/entities/dashboards";
 
 import {
   INITIALIZE,
@@ -133,6 +134,14 @@ const dashboards = handleActions(
           state,
           [payload.id, "enable_embedding"],
           payload.enable_embedding,
+        ),
+    },
+    [Dashboards.actionTypes.UPDATE]: {
+      next: (state, { payload }) =>
+        assocIn(
+          state,
+          [payload.dashboard.id, "collection_id"],
+          payload.dashboard.collection_id,
         ),
     },
   },


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/22826
Fixes https://www.notion.so/metabase/Moving-a-dashboard-does-not-update-the-highlighted-collection-in-the-navbar-3779943eee3b4bb58376643067c5b6b8

How to test:
- Open a dashboard
- Make sure the dashboard collection is highlighted in the sidebar
- Move the dashboard to another collection via the menu in the header
- Make sure the collection the dashboard has been moved to is now highlighted

<img width="714" alt="Screenshot 2022-07-21 at 13 11 21" src="https://user-images.githubusercontent.com/8542534/180189707-592952ed-4e85-405c-b40d-966ae0ac85be.png">
