### PR TITLE
Improve search performance with PostgreSQL

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -11947,6 +11947,23 @@ databaseChangeLog:
                   constraints:
                     nullable: true
 
+  - changeSet:
+      id: v44.00-043
+      author: calherries
+      comment: Added 0.44.0 - Add tsvector column for postgres full text search of dataset_query
+      changes:
+        - addColumn:
+            dbms: postgresql
+            tableName: report_card
+            columns:
+              - column:
+                  name: dataset_query_tokens
+                  type: tsvector
+                  constraints:
+                    nullable: true
+        - sql:
+            sql: update report_card set dataset_query_tokens = to_tsvector(dataset_query) where query_type = 'native';
+
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -11949,11 +11949,11 @@ databaseChangeLog:
 
   - changeSet:
       id: v44.00-043
+      dbms: postgresql
       author: calherries
       comment: Added 0.44.0 - Add tsvector column for postgres full text search of dataset_query
       changes:
         - addColumn:
-            dbms: postgresql
             tableName: report_card
             columns:
               - column:
@@ -11962,7 +11962,6 @@ databaseChangeLog:
                   constraints:
                     nullable: true
         - sql:
-            dbms: postgresql
             sql: update report_card set dataset_query_tokens = to_tsvector(dataset_query) where query_type = 'native';
 
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -11962,7 +11962,7 @@ databaseChangeLog:
                   constraints:
                     nullable: true
         - sql:
-            sql: update report_card set dataset_query_tokens = to_tsvector(cast(dataset_query as json) -> 'native' -> 'query') where query_type = 'native';
+            sql: update report_card set dataset_query_tokens = to_tsvector('simple', cast(dataset_query as json) -> 'native' -> 'query') where query_type = 'native';
       rollback: alter table report_card drop column dataset_query_tokens;
 
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -11962,7 +11962,8 @@ databaseChangeLog:
                   constraints:
                     nullable: true
         - sql:
-            sql: update report_card set dataset_query_tokens = to_tsvector(dataset_query) where query_type = 'native';
+            sql: update report_card set dataset_query_tokens = to_tsvector(cast(dataset_query as json) -> 'native' -> 'query') where query_type = 'native';
+      rollback: alter table report_card drop column dataset_query_tokens;
 
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -11962,6 +11962,7 @@ databaseChangeLog:
                   constraints:
                     nullable: true
         - sql:
+            dbms: postgresql
             sql: update report_card set dataset_query_tokens = to_tsvector(dataset_query) where query_type = 'native';
 
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<

--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -395,7 +395,9 @@
         sql-alias    :alias_is_required_by_sql_but_not_needed_here
         order-clause [((fnil order-clause "") (:search-string search-ctx))]]
     (if (= (count models) 1)
-      (search-query-for-model (first models) search-ctx)
+      {:select   [:*]
+       :from     (search-query-for-model (first models) search-ctx)
+       :order-by order-clause}
       {:select [:*]
        :from [[{:union-all (for [model models
                                  :let  [query (search-query-for-model model search-ctx)]

--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -358,8 +358,7 @@
                             (map (fn [col]
                                    (if (and (= col :dataset_query)
                                             (= (mdb/db-type) :postgres))
-                                     ;; TODO qualify the column
-                                     (hsql/raw (str "dataset_query_tokens @@ phraseto_tsquery('" #sql/param :search-tokens "')"))
+                                     (hsql/raw (str "dataset_query_tokens @@ phraseto_tsquery('simple', '" #sql/param :search-string "')"))
                                      [:like (hsql/call :lower col) match])) <>)
                             (interleave <> (repeat 0))
                             (concat <> [:else 1]))]
@@ -429,7 +428,8 @@
           search-sql        (hsql/format search-query
                                          :quoting             (db/quoting-style)
                                          :allow-dashed-names? (not (db/automatically-convert-dashes-and-underscores?))
-                                         :params              {:search-tokens (str "'" (str/join "|" search-tokens) "'")})
+                                         :params              {:search-string (:search-string search-ctx)
+                                                               :search-tokens (str "'" (str/join "|" search-tokens) "'")})
           reducible-results (jdbc/reducible-query (db/connection)
                                                   search-sql
                                                   (merge {:max-rows search-config/*db-max-results*}

--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -193,7 +193,7 @@
                                 :let [qualified-column (hsql/qualify (model->alias model) column)]]
                             (if (and (= column :dataset_query)
                                      (= (mdb/db-type) :postgres))
-                              [(hsql/raw ["dataset_query_tokens @@ to_tsquery(" #sql/param :search-tokens ")"])]
+                              [(hsql/raw ["dataset_query_tokens @@ plainto_tsquery('simple', " #sql/param :search-tokens ")"])]
                               (for [token tokens]
                                 [:like
                                  (hsql/call :lower qualified-column)
@@ -358,7 +358,7 @@
                             (map (fn [col]
                                    (if (and (= col :dataset_query)
                                             (= (mdb/db-type) :postgres))
-                                     (hsql/raw (str "dataset_query_tokens @@ phraseto_tsquery('simple', '" #sql/param :search-string "')"))
+                                     (hsql/raw (str "dataset_query_tokens @@ plainto_tsquery('simple', '" #sql/param :search-string "')"))
                                      [:like (hsql/call :lower col) match])) <>)
                             (interleave <> (repeat 0))
                             (concat <> [:else 1]))]

--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -432,8 +432,8 @@
                                                                :search-tokens (str "'" (str/join "|" search-sql-tokens) "'")})
           reducible-results (jdbc/reducible-query (db/connection)
                                                   search-sql
-                                                  (merge {:max-rows search-config/*db-max-results*}
-                                                         @(var-get #'db/default-jdbc-options)))
+                                                  (merge @(var-get #'db/default-jdbc-options)
+                                                         {:max-rows search-config/*db-max-results*}))
           xf                (comp
                              (filter check-permissions-for-model)
                              ;; MySQL returns `:bookmark` and `:archived` as `1` or `0` so convert those to boolean as needed

--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -63,35 +63,37 @@
   Columns that aren't used in any individual query are replaced with `SELECT cast(NULL AS <type>)` statements. (These
   are cast to the appropriate type because Postgres will assume `SELECT NULL` is `TEXT` by default and will refuse to
   `UNION` two columns of two different types.)"
-  (ordered-map/ordered-map
-   ;; returned for all models. Important to be first for changing model for dataset
-   :model               :text
-   :id                  :integer
-   :name                :text
-   :display_name        :text
-   :description         :text
-   :archived            :boolean
-   ;; returned for Card, Dashboard, Pulse, and Collection
-   :collection_id       :integer
-   :collection_name     :text
-   :collection_authority_level :text
-   ;; returned for Card and Dashboard
-   :collection_position :integer
-   :bookmark            :boolean
-   ;; returned for everything except Collection
-   :updated_at          :timestamp
-   ;; returned for Card only
-   :dashboardcard_count :integer
-   :dataset_query       :text
-   :moderated_status    :text
-   ;; returned for Metric and Segment
-   :table_id            :integer
-   :database_id         :integer
-   :table_schema        :text
-   :table_name          :text
-   :table_description   :text
-   ;; returned for Database and Table
-   :initial_sync_status :text))
+  (cond-> (ordered-map/ordered-map
+           ;; returned for all models. Important to be first for changing model for dataset
+           :model :text
+           :id :integer
+           :name :text
+           :display_name :text
+           :description :text
+           :archived :boolean
+           ;; returned for Card, Dashboard, Pulse, and Collection
+           :collection_id :integer
+           :collection_name     :text
+           :collection_authority_level :text
+           ;; returned for Card and Dashboard
+           :collection_position :integer
+           :bookmark            :boolean
+           ;; returned for everything except Collection
+           :updated_at          :timestamp
+           ;; returned for Card only
+           :dashboardcard_count :integer
+           :dataset_query       :text
+           :moderated_status    :text
+           ;; returned for Metric and Segment
+           :table_id            :integer
+           :database_id         :integer
+           :table_schema        :text
+           :table_name          :text
+           :table_description   :text
+           ;; returned for Database and Table
+           :initial_sync_status :text)
+    (= (mdb/db-type) :postgres)
+    (assoc :dataset_query_tokens :tsvector)))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                               Shared Query Logic                                               |

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -281,7 +281,6 @@
             (field-values/update-field-values-for-on-demand-dbs! newly-added-param-field-ids)))))
     ;; make sure this Card doesn't have circular source query references if we're updating the query
     (when (:dataset_query changes)
-      ;; TODO change dataset_query_tokens for postgres
       (check-for-circular-source-query-references changes))
     ;; Make sure any native query template tags match the DB in the query.
     (check-field-filter-fields-are-from-correct-database changes)

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -229,7 +229,7 @@
      (params/assert-valid-parameter-mappings card)
      (collection/check-collection-namespace Card (:collection_id card)))))
 
-(defn- tokenize-dataset-query [card]
+(defn- tokenize-dataset-query! [card]
   (when (and (= (mdb/db-type) :postgres)
              (= (:query_type card) :native))
     (db/execute! {:update Card
@@ -237,7 +237,7 @@
                   :where  [:= :id (:id card)]})))
 
 (defn- post-update [card]
-  (tokenize-dataset-query card))
+  (tokenize-dataset-query! card))
 
 (defn- post-insert [card]
   ;; if this Card has any native template tag parameters we need to update FieldValues for any Fields that are
@@ -246,7 +246,7 @@
     (when-let [field-ids (seq (params/card->template-tag-field-ids card))]
       (log/info "Card references Fields in params:" field-ids)
       (field-values/update-field-values-for-on-demand-dbs! field-ids))
-    (tokenize-dataset-query card)))
+    (tokenize-dataset-query! card)))
 
 (defonce
   ^{:doc "Atom containing a function used to check additional sandboxing constraints for Metabase Enterprise Edition.

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -233,7 +233,7 @@
   (when (and (= (mdb/db-type) :postgres)
              (= (:query_type card) :native))
     (db/execute! {:update Card
-                  :set    {:dataset_query_tokens (hsql/call :to_tsvector :dataset_query)}
+                  :set    {:dataset_query_tokens (hsql/raw "to_tsvector(cast(dataset_query as json) -> 'native' -> 'query'")}
                   :where  [:= :id (:id card)]})))
 
 (defn- post-insert [card]

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -233,7 +233,7 @@
   (when (and (= (mdb/db-type) :postgres)
              (= (:query_type card) :native))
     (db/execute! {:update Card
-                  :set    {:dataset_query_tokens (hsql/raw "to_tsvector(cast(dataset_query as json) -> 'native' -> 'query'")}
+                  :set    {:dataset_query_tokens (hsql/raw "to_tsvector('simple', cast(dataset_query as json) -> 'native' -> 'query'")}
                   :where  [:= :id (:id card)]})))
 
 (defn- post-update [card]

--- a/src/metabase/search/scoring.clj
+++ b/src/metabase/search/scoring.clj
@@ -17,10 +17,11 @@
   (str/lower-case query))
 
 (s/defn tokenize :- [s/Str]
-  "Break a search `query` into its constituent tokens"
+  "Break a search `query` into its constituent tokens
+   Note 'foo.bar' is tokenized to ['foo.bar'] but 'foo(bar)' is tokenized to ['foo', 'bar']"
   [query :- s/Str]
   (filter seq
-          (str/split query #"\s+")))
+          (str/split query #"[\s+\(\)\[\]\{\}]")))
 
 (def ^:private largest-common-subseq-length
   (memoize/fifo

--- a/src/metabase/search/scoring.clj
+++ b/src/metabase/search/scoring.clj
@@ -16,12 +16,12 @@
   [query :- s/Str]
   (str/lower-case query))
 
-(s/defn tokenize :- [s/Str]
+(defn tokenize
   "Break a search `query` into its constituent tokens
    Note 'foo.bar' is tokenized to ['foo.bar'] but 'foo(bar)' is tokenized to ['foo', 'bar']"
-  [query :- s/Str]
+  [query]
   (filter seq
-          (str/split query #"[\s+\(\)\[\]\{\}]")))
+          (str/split query #"[\s+\(\)\[\]\{\}\,]")))
 
 (def ^:private largest-common-subseq-length
   (memoize/fifo

--- a/src/metabase/search/scoring.clj
+++ b/src/metabase/search/scoring.clj
@@ -16,16 +16,18 @@
   [query :- s/Str]
   (str/lower-case query))
 
-(defn tokenize
-  "Break a search `query` into its constituent tokens"
-  [query]
+(s/defn tokenize
+  "Break a search `query` into its constituent tokens.
+   Don't add a return value schema to this function, it slows down the search."
+  [query :- s/Str]
   (filter seq
           (str/split query #"\s+")))
 
-(defn sql-tokenize
+(s/defn sql-tokenize
   "Break a search `query` into its constituent tokens for searching in a native SQL query
-   Note 'foo.bar' is tokenized to ['foo.bar'] but 'foo(bar)' is tokenized to ['foo', 'bar']"
-  [query]
+   'foo.bar' is tokenized to ['foo.bar'] but 'foo(bar)' is tokenized to ['foo', 'bar'].
+   Don't add a return value schema to this function, it slows down the search."
+  [query :- s/Str]
   (filter seq
           (str/split query #"[\s+\(\)\[\]\{\}\,\'\"]")))
 

--- a/src/metabase/search/scoring.clj
+++ b/src/metabase/search/scoring.clj
@@ -17,7 +17,13 @@
   (str/lower-case query))
 
 (defn tokenize
-  "Break a search `query` into its constituent tokens
+  "Break a search `query` into its constituent tokens"
+  [query]
+  (filter seq
+          (str/split query #"\s+")))
+
+(defn sql-tokenize
+  "Break a search `query` into its constituent tokens for searching in a native SQL query
    Note 'foo.bar' is tokenized to ['foo.bar'] but 'foo(bar)' is tokenized to ['foo', 'bar']"
   [query]
   (filter seq

--- a/src/metabase/search/scoring.clj
+++ b/src/metabase/search/scoring.clj
@@ -21,7 +21,7 @@
    Note 'foo.bar' is tokenized to ['foo.bar'] but 'foo(bar)' is tokenized to ['foo', 'bar']"
   [query]
   (filter seq
-          (str/split query #"[\s+\(\)\[\]\{\}\,]")))
+          (str/split query #"[\s+\(\)\[\]\{\}\,\'\"]")))
 
 (def ^:private largest-common-subseq-length
   (memoize/fifo

--- a/test/metabase/search/scoring_test.clj
+++ b/test/metabase/search/scoring_test.clj
@@ -24,14 +24,14 @@
            (scoring/tokenize "foo[bar  ] as foo_bar")))
     (is (= ["foo" "bar" "as" "foo_bar"]
            (scoring/tokenize "foo{bar  } as foo_bar")))
+    (is (= ["foo" "bar" "as" "foo_bar"]
+           (scoring/tokenize "foo, bar as foo_bar")))
     (is (= ["foo.bar" "as" "foo_bar"]
            (scoring/tokenize "foo.bar as foo_bar")))
     (is (= []
            (scoring/tokenize " \t\n\t ")))
     (is (= []
-           (scoring/tokenize "")))
-    (is (thrown-with-msg? Exception #"does not match schema"
-                          (scoring/tokenize nil)))))
+           (scoring/tokenize "")))))
 
 (defn scorer->score
   [scorer]

--- a/test/metabase/search/scoring_test.clj
+++ b/test/metabase/search/scoring_test.clj
@@ -14,7 +14,7 @@
 
 (deftest tokenize-test
   (testing "basic tokenization"
-    (is (= ["Rasta" "the" "Toucan's" "search"]
+    (is (= ["Rasta" "the" "Toucan" "s" "search"]
            (scoring/tokenize "Rasta the Toucan's search")))
     (is (= ["Rasta" "the" "Toucan"]
            (scoring/tokenize "                Rasta\tthe    \tToucan     ")))
@@ -26,6 +26,8 @@
            (scoring/tokenize "foo{bar  } as foo_bar")))
     (is (= ["foo" "bar" "as" "foo_bar"]
            (scoring/tokenize "foo, bar as foo_bar")))
+    (is (= ["c.local" "=" "en"]
+           (scoring/tokenize "c.local = 'en'")))
     (is (= ["foo.bar" "as" "foo_bar"]
            (scoring/tokenize "foo.bar as foo_bar")))
     (is (= []

--- a/test/metabase/search/scoring_test.clj
+++ b/test/metabase/search/scoring_test.clj
@@ -21,7 +21,9 @@
     (is (= []
            (scoring/tokenize " \t\n\t ")))
     (is (= []
-           (scoring/tokenize "")))))
+           (scoring/tokenize "")))
+    (is (thrown-with-msg? Exception #"does not match schema"
+                          (scoring/tokenize nil)))))
 
 (deftest sql-tokenize-test
   (testing "tokenization for sql queries"
@@ -36,7 +38,9 @@
     (is (= ["c.local" "=" "en"]
            (scoring/sql-tokenize "c.local = 'en'")))
     (is (= ["foo.bar" "as" "foo_bar"]
-           (scoring/sql-tokenize "foo.bar as foo_bar")))))
+           (scoring/sql-tokenize "foo.bar as foo_bar")))
+    (is (thrown-with-msg? Exception #"does not match schema"
+                          (scoring/sql-tokenize nil)))))
 
 (defn scorer->score
   [scorer]

--- a/test/metabase/search/scoring_test.clj
+++ b/test/metabase/search/scoring_test.clj
@@ -14,26 +14,29 @@
 
 (deftest tokenize-test
   (testing "basic tokenization"
-    (is (= ["Rasta" "the" "Toucan" "s" "search"]
+    (is (= ["Rasta" "the" "Toucan's" "search"]
            (scoring/tokenize "Rasta the Toucan's search")))
     (is (= ["Rasta" "the" "Toucan"]
            (scoring/tokenize "                Rasta\tthe    \tToucan     ")))
-    (is (= ["foo" "bar" "as" "foo_bar"]
-           (scoring/tokenize "foo(bar  ) as foo_bar")))
-    (is (= ["foo" "bar" "as" "foo_bar"]
-           (scoring/tokenize "foo[bar  ] as foo_bar")))
-    (is (= ["foo" "bar" "as" "foo_bar"]
-           (scoring/tokenize "foo{bar  } as foo_bar")))
-    (is (= ["foo" "bar" "as" "foo_bar"]
-           (scoring/tokenize "foo, bar as foo_bar")))
-    (is (= ["c.local" "=" "en"]
-           (scoring/tokenize "c.local = 'en'")))
-    (is (= ["foo.bar" "as" "foo_bar"]
-           (scoring/tokenize "foo.bar as foo_bar")))
     (is (= []
            (scoring/tokenize " \t\n\t ")))
     (is (= []
            (scoring/tokenize "")))))
+
+(deftest sql-tokenize-test
+  (testing "tokenization for sql queries"
+    (is (= ["foo" "bar" "as" "foo_bar"]
+           (scoring/sql-tokenize "foo(bar  ) as foo_bar")))
+    (is (= ["foo" "bar" "as" "foo_bar"]
+           (scoring/sql-tokenize "foo[bar  ] as foo_bar")))
+    (is (= ["foo" "bar" "as" "foo_bar"]
+           (scoring/sql-tokenize "foo{bar  } as foo_bar")))
+    (is (= ["foo" "bar" "as" "foo_bar"]
+           (scoring/sql-tokenize "foo, bar as foo_bar")))
+    (is (= ["c.local" "=" "en"]
+           (scoring/sql-tokenize "c.local = 'en'")))
+    (is (= ["foo.bar" "as" "foo_bar"]
+           (scoring/sql-tokenize "foo.bar as foo_bar")))))
 
 (defn scorer->score
   [scorer]

--- a/test/metabase/search/scoring_test.clj
+++ b/test/metabase/search/scoring_test.clj
@@ -18,6 +18,14 @@
            (scoring/tokenize "Rasta the Toucan's search")))
     (is (= ["Rasta" "the" "Toucan"]
            (scoring/tokenize "                Rasta\tthe    \tToucan     ")))
+    (is (= ["foo" "bar" "as" "foo_bar"]
+           (scoring/tokenize "foo(bar  ) as foo_bar")))
+    (is (= ["foo" "bar" "as" "foo_bar"]
+           (scoring/tokenize "foo[bar  ] as foo_bar")))
+    (is (= ["foo" "bar" "as" "foo_bar"]
+           (scoring/tokenize "foo{bar  } as foo_bar")))
+    (is (= ["foo.bar" "as" "foo_bar"]
+           (scoring/tokenize "foo.bar as foo_bar")))
     (is (= []
            (scoring/tokenize " \t\n\t ")))
     (is (= []


### PR DESCRIPTION
This PR speeds up `/api/search` for customers using Postgres for their Metabase DB. It fixes the search performance issues reported here https://github.com/metabase/metabase/issues/17631.

Previously, a search would involve a full table scan on all searchable columns of `report_card` (except those searches excluding the card model). The problem is we were performing substring matches on native SQL with `dataset_query LIKE '%<search-word>%'`, which doesn't scale well across a lot of long SQL queries. The issue was introduced in 39 when we introduced [searches on native SQL](https://github.com/metabase/metabase/pull/14583).

**Summary of changes**
We can use the [full-text search features built into Postgres](https://www.postgresql.org/docs/current/textsearch.html) to replace substring matches on native SQL queries. Unlike the `pg_trgm` extension this requires no extra setup for the user.

Only on Postgres, an extra column will be added to the report_card table, `dataset_query_tokens` of type `tsvector`. This column contains an index of tokens in the `dataset_query` SQL string. Every time a native query card is saved, this value will update.

Instead of searching with `dataset_query LIKE '%<search-word>%'`, we can now use `dataset_query_tokens @@ to_tsquery('<search-word>')`, which is much faster.

**Potential problems?**
1. We might not allow different columns by DB? As far as I know this could be the first time different DBs have needed different schemas.
2. The initial migration could take a long time, because the index must be created for each native SQL query. With 100,000 native SQL questions, the initial migration took 5-10 minutes. This should only affect customers which are having the problem in the first place though, so they should be happy to wait.

**Benchmarking**
With a realistic-ish mix of 100,000 native SQL questions, I found a consistent ~6x speedup in response time from the BE across a range of search strings. For perspective, the longest search I tested improved from 26s to 4s, and the shortest from 7.5s to 1.2s.

**Changes in behaviour**
There some minor differences in the behaviour of full text search, compared to previous search behaviour. A full text search column is essentially an index of words, so substrings of words won't match. Unfortunately the default parser from Postgres parses strings with a dot (`.`) as one word, so `b.bar` would be indexed as one word in `select foo(b.bar) from baz b`. This is customizable and could be avoided, but doing so would add steps to setting up a Metabase instance.

To be clear, here's a summary of differences before and after the change:

Native SQL of question | Search query | before | after | explanation
-- | -- | -- | -- | --
select foo(b.bar) from baz b | ba | Y | N | ba isn't indexed
select foo(b.bar) from baz b | bar | Y | N | bar isn't indexed
select foo(b.bar) from baz b | b.bar | Y | Y | b.bar is indexed


TODO
- [ ] Adjust for Postgres 9.4
- [ ] Write tests
- [x] Benchmarking

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/24171)
<!-- Reviewable:end -->
