### PR TITLE
External PR backport: Keyboard focus switches from parameter input to SQL editor automatically after re-running query

### DIFF
--- a/frontend/src/metabase/query_builder/actions/querying.js
+++ b/frontend/src/metabase/query_builder/actions/querying.js
@@ -147,13 +147,6 @@ export const runQuestionQuery = ({
       })
       .catch(error => dispatch(queryErrored(startTime, error)));
 
-    // TODO Move this out from Redux action asap
-    // HACK: prevent SQL editor from losing focus
-    try {
-      // eslint-disable-next-line no-undef
-      ace.edit("id_sql").focus();
-    } catch (e) {}
-
     dispatch.action(RUN_QUERY, { cancelQueryDeferred });
   };
 };


### PR DESCRIPTION
Backport of the external PR: https://github.com/metabase/metabase/pull/23880