### PR TITLE
Bulk filter responsive text sizes and spacing

### DIFF
--- a/frontend/src/metabase/components/TokenField/TokenField.styled.tsx
+++ b/frontend/src/metabase/components/TokenField/TokenField.styled.tsx
@@ -1,13 +1,17 @@
 import styled from "@emotion/styled";
 import { color, alpha } from "metabase/lib/colors";
+import { breakpointMinHeightMedium } from "metabase/styled-components/theme";
 
 export const TokenFieldItem = styled.li<{
   isValid: boolean;
 }>`
   display: flex;
   align-items: center;
-  margin: 0 0.25rem 0.25rem 0;
-  padding: 0.75rem 0.5rem;
+  margin: 0.25rem;
+  padding: 0.5rem 0.3rem;
+  ${breakpointMinHeightMedium} {
+    padding: 0.75rem 0.5rem;
+  }
   border-radius: 0.5rem;
   color: ${({ isValid }) => (isValid ? color("brand") : color("error"))};
   background-color: ${alpha("brand", 0.2)};
@@ -23,5 +27,18 @@ export const TokenFieldAddon = styled.a<{
 
   &:hover {
     color: ${color("error")};
+  }
+`;
+
+export const TokenInputItem = styled.li`
+  display: flex;
+  flex: 1 0 auto;
+  align-items: center;
+  margin-right: 0.5rem;
+  padding: 0.5rem;
+
+  height: 38px;
+  ${breakpointMinHeightMedium} {
+    height: 54px;
   }
 `;

--- a/frontend/src/metabase/components/TokenField/TokenField.tsx
+++ b/frontend/src/metabase/components/TokenField/TokenField.tsx
@@ -6,7 +6,11 @@ import cx from "classnames";
 
 import Icon from "metabase/components/Icon";
 import TippyPopover from "metabase/components/Popover/TippyPopover";
-import { TokenFieldAddon, TokenFieldItem } from "./TokenField.styled";
+import {
+  TokenFieldAddon,
+  TokenFieldItem,
+  TokenInputItem,
+} from "./TokenField.styled";
 
 import {
   KEYCODE_ESCAPE,
@@ -573,7 +577,7 @@ export default class TokenField extends Component<
       <ul
         className={cx(
           className,
-          "pl1 pt1 pb0 pr0 flex align-center flex-wrap bg-white scroll-x scroll-y",
+          "p0 flex align-center flex-wrap bg-white scroll-x scroll-y",
         )}
         style={{ maxHeight: 130, ...style }}
         onMouseDownCapture={this.onMouseDownCapture}
@@ -606,7 +610,7 @@ export default class TokenField extends Component<
           </TokenFieldItem>
         ))}
         {canAddItems && (
-          <li className={cx("flex-full flex align-center mr1 mb1 p1")}>
+          <TokenInputItem>
             <input
               ref={this.inputRef}
               style={{ ...defaultStyleValue, ...valueStyle }}
@@ -622,7 +626,7 @@ export default class TokenField extends Component<
               onBlur={this.onInputBlur}
               onPaste={this.onInputPaste}
             />
-          </li>
+          </TokenInputItem>
         )}
       </ul>
     );

--- a/frontend/src/metabase/core/components/Tab/Tab.styled.tsx
+++ b/frontend/src/metabase/core/components/Tab/Tab.styled.tsx
@@ -42,7 +42,6 @@ export const TabIcon = styled(Icon)`
 `;
 
 export const TabLabel = styled(Ellipsified)`
-  font-size: 1rem;
   font-weight: bold;
   max-width: 16rem;
 `;

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterList/BulkFilterList.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterList/BulkFilterList.styled.tsx
@@ -2,8 +2,7 @@ import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
 import {
   space,
-  breakpointMaxSmall,
-  breakpointMinLarge,
+  breakpointMinHeightMedium,
 } from "metabase/styled-components/theme";
 
 export const ListRoot = styled.div`
@@ -12,7 +11,7 @@ export const ListRoot = styled.div`
 
 export const ListRow = styled.div`
   padding: 1.5rem 2rem;
-  ${breakpointMinLarge} {
+  ${breakpointMinHeightMedium} {
     padding: 2.5rem 2rem;
   }
   border-bottom: 1px solid ${color("border")};

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterList/BulkFilterList.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterList/BulkFilterList.styled.tsx
@@ -1,13 +1,20 @@
 import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
-import { space } from "metabase/styled-components/theme";
+import {
+  space,
+  breakpointMaxSmall,
+  breakpointMinLarge,
+} from "metabase/styled-components/theme";
 
 export const ListRoot = styled.div`
   margin-bottom: 1rem;
 `;
 
 export const ListRow = styled.div`
-  padding: 2.5rem 2rem;
+  padding: 1.5rem 2rem;
+  ${breakpointMinLarge} {
+    padding: 2.5rem 2rem;
+  }
   border-bottom: 1px solid ${color("border")};
   &:last-of-type {
     border-bottom: none;

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterModal/BulkFilterModal.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterModal/BulkFilterModal.styled.tsx
@@ -1,6 +1,10 @@
 import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
-import { space, breakpointMaxSmall } from "metabase/styled-components/theme";
+import {
+  space,
+  breakpointMaxSmall,
+  breakpointMinLarge,
+} from "metabase/styled-components/theme";
 
 import TabList from "metabase/core/components/TabList";
 import TabPanel from "metabase/core/components/TabPanel";
@@ -22,12 +26,18 @@ export const ModalRoot = styled.div`
 export const ModalHeader = styled.div`
   display: flex;
   align-items: center;
-  padding: 2rem 2rem 0 2rem;
+  padding: 1rem 2rem 0 2rem;
+  ${breakpointMinLarge} {
+    padding: 2rem 2rem 0 2rem;
+  }
 `;
 
 export const ModalBody = styled.div`
   border-top: 1px solid ${color("border")};
-  margin-top: 1.5rem;
+  margin-top: 1rem;
+  ${breakpointMinLarge} {
+    margin-top: 1.5rem;
+  }
   overflow-y: auto;
   flex: 1;
 `;
@@ -42,7 +52,10 @@ export const ModalFooter = styled.div`
 export const ModalTitle = styled(Ellipsified)`
   flex: 1 1 auto;
   color: ${color("text-dark")};
-  font-size: 1.25rem;
+  font-size: 1rem;
+  ${breakpointMinLarge} {
+    font-size: 1.25rem;
+  }
   line-height: 1.5rem;
   font-weight: bold;
 `;

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterModal/BulkFilterModal.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterModal/BulkFilterModal.styled.tsx
@@ -3,7 +3,7 @@ import { color } from "metabase/lib/colors";
 import {
   space,
   breakpointMaxSmall,
-  breakpointMinLarge,
+  breakpointMinHeightMedium,
 } from "metabase/styled-components/theme";
 
 import TabList from "metabase/core/components/TabList";
@@ -27,7 +27,7 @@ export const ModalHeader = styled.div`
   display: flex;
   align-items: center;
   padding: 1rem 2rem 0 2rem;
-  ${breakpointMinLarge} {
+  ${breakpointMinHeightMedium} {
     padding: 2rem 2rem 0 2rem;
   }
 `;
@@ -35,7 +35,7 @@ export const ModalHeader = styled.div`
 export const ModalBody = styled.div`
   border-top: 1px solid ${color("border")};
   margin-top: 1rem;
-  ${breakpointMinLarge} {
+  ${breakpointMinHeightMedium} {
     margin-top: 1.5rem;
   }
   overflow-y: auto;
@@ -53,7 +53,7 @@ export const ModalTitle = styled(Ellipsified)`
   flex: 1 1 auto;
   color: ${color("text-dark")};
   font-size: 1rem;
-  ${breakpointMinLarge} {
+  ${breakpointMinHeightMedium} {
     font-size: 1.25rem;
   }
   line-height: 1.5rem;
@@ -61,6 +61,10 @@ export const ModalTitle = styled(Ellipsified)`
 `;
 
 export const ModalTabList = styled(TabList)`
+  font-size: 0.875rem;
+  ${breakpointMinHeightMedium} {
+    font-size: 1rem;
+  }
   margin: 1.5rem 2rem 0 2rem;
   flex-shrink: 0;
 `;

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterSelect/BulkFilterSelect.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterSelect/BulkFilterSelect.styled.tsx
@@ -1,5 +1,6 @@
 import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
+import { breakpointMinHeightMedium } from "metabase/styled-components/theme";
 
 import SelectButton from "metabase/core/components/SelectButton";
 import FilterPopover from "../../FilterPopover";
@@ -11,7 +12,10 @@ type SelectFilterButtonProps = {
 
 export const SelectFilterButton = styled(SelectButton)<SelectFilterButtonProps>`
   grid-column: 2;
-  height: 55px;
+  height: 40px;
+  ${breakpointMinHeightMedium} {
+    height: 56px;
+  }
 
   ${({ isActive }) => (isActive ? `border-color: ${color("brand")};` : "")}
 
@@ -21,7 +25,10 @@ export const SelectFilterButton = styled(SelectButton)<SelectFilterButtonProps>`
 `;
 
 export const SegmentSelect = styled(Select)`
-  height: 55px;
+  height: 40px;
+  ${breakpointMinHeightMedium} {
+    height: 56px;
+  }
 `;
 
 export const SelectFilterPopover = styled(FilterPopover)`

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineOperatorSelector/InlineOperatorSelector.styled.ts
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineOperatorSelector/InlineOperatorSelector.styled.ts
@@ -1,10 +1,13 @@
 import styled from "@emotion/styled";
-import { space } from "metabase/styled-components/theme";
+import { space, breakpointMinLarge } from "metabase/styled-components/theme";
 import { color, alpha, darken, lighten } from "metabase/lib/colors";
 
 export const InlineOperatorContainer = styled.div`
   font-weight: bold;
-  font-size: 1rem;
+  font-size: 0.875rem;
+  ${breakpointMinLarge} {
+    font-size: 1rem;
+  }
   margin-bottom: 0.875rem;
   display: inline-flex;
   align-items: flex-start;

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineOperatorSelector/InlineOperatorSelector.styled.ts
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineOperatorSelector/InlineOperatorSelector.styled.ts
@@ -1,16 +1,28 @@
 import styled from "@emotion/styled";
-import { space, breakpointMinLarge } from "metabase/styled-components/theme";
+import {
+  space,
+  breakpointMinHeightMedium,
+} from "metabase/styled-components/theme";
 import { color, alpha, darken, lighten } from "metabase/lib/colors";
 
 export const InlineOperatorContainer = styled.div`
   font-weight: bold;
   font-size: 0.875rem;
-  ${breakpointMinLarge} {
+  ${breakpointMinHeightMedium} {
     font-size: 1rem;
   }
   margin-bottom: 0.875rem;
   display: inline-flex;
   align-items: flex-start;
+
+  .field-icon {
+    width: 16px;
+    height: 16px;
+    ${breakpointMinHeightMedium} {
+      width: 20px;
+      height: 20px;
+    }
+  }
 `;
 
 export const FieldTitle = styled.span`

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineOperatorSelector/InlineOperatorSelector.styled.ts
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineOperatorSelector/InlineOperatorSelector.styled.ts
@@ -3,7 +3,10 @@ import {
   space,
   breakpointMinHeightMedium,
 } from "metabase/styled-components/theme";
-import { color, alpha, darken, lighten } from "metabase/lib/colors";
+
+import { color, lighten } from "metabase/lib/colors";
+
+import Icon from "metabase/components/Icon";
 
 export const InlineOperatorContainer = styled.div`
   font-weight: bold;
@@ -14,14 +17,15 @@ export const InlineOperatorContainer = styled.div`
   margin-bottom: 0.875rem;
   display: inline-flex;
   align-items: flex-start;
+`;
 
-  .field-icon {
-    width: 16px;
-    height: 16px;
-    ${breakpointMinHeightMedium} {
-      width: 20px;
-      height: 20px;
-    }
+export const FieldIcon = styled(Icon)`
+  margin-right: ${space(1)};
+  width: 1rem;
+  height: 1rem;
+  ${breakpointMinHeightMedium} {
+    width: 1.25rem;
+    height: 1.25rem;
   }
 `;
 

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineOperatorSelector/InlineOperatorSelector.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineOperatorSelector/InlineOperatorSelector.tsx
@@ -38,7 +38,11 @@ export function InlineOperatorSelector({
   return (
     <InlineOperatorContainer>
       {!!iconName && (
-        <Icon name={iconName} size={20} style={{ marginRight: 8 }} />
+        <Icon
+          className="field-icon"
+          name={iconName}
+          style={{ marginRight: 8 }}
+        />
       )}
       <div>
         <FieldTitle>{fieldName}</FieldTitle>

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineOperatorSelector/InlineOperatorSelector.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineOperatorSelector/InlineOperatorSelector.tsx
@@ -10,6 +10,7 @@ import {
   OperatorDisplay,
   OptionContainer,
   Option,
+  FieldIcon,
 } from "./InlineOperatorSelector.styled";
 import { FilterOperatorName } from "metabase-types/types/Metadata";
 
@@ -37,13 +38,7 @@ export function InlineOperatorSelector({
 
   return (
     <InlineOperatorContainer>
-      {!!iconName && (
-        <Icon
-          className="field-icon"
-          name={iconName}
-          style={{ marginRight: 8 }}
-        />
-      )}
+      {!!iconName && <FieldIcon name={iconName} />}
       <div>
         <FieldTitle>{fieldName}</FieldTitle>
         {!!tableName && (

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineValuePicker/InlineValuePicker.styled.ts
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineValuePicker/InlineValuePicker.styled.ts
@@ -1,13 +1,11 @@
 import styled from "@emotion/styled";
-import { space } from "metabase/styled-components/theme";
+import {
+  space,
+  breakpointMinHeightMedium,
+} from "metabase/styled-components/theme";
 import { color } from "metabase/lib/colors";
 
-import FieldValuesWidget from "metabase/components/FieldValuesWidget";
 import NumericInput from "metabase/core/components/NumericInput";
-
-export const ArgumentSelector = styled(FieldValuesWidget)`
-  min-height: 55px;
-`;
 
 export const ValuesPickerContainer = styled.div`
   ul.input {
@@ -42,6 +40,9 @@ export const NumberSeparator = styled.span`
 export const NumberInput = styled(NumericInput)`
   width: 10rem;
   input {
-    height: 55px;
+    height: 40px;
+    ${breakpointMinHeightMedium} {
+      height: 56px;
+    }
   }
 `;

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineValuePicker/InlineValuePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineValuePicker/InlineValuePicker.tsx
@@ -4,8 +4,9 @@ import { t } from "ttag";
 import Filter from "metabase-lib/lib/queries/structured/Filter";
 import Field from "metabase-lib/lib/metadata/Field";
 
+import FieldValuesWidget from "metabase/components/FieldValuesWidget";
+
 import {
-  ArgumentSelector,
   ValuesPickerContainer,
   BetweenContainer,
   NumberInput,
@@ -73,7 +74,7 @@ function ValuesInput({
 
   if (!isBetween) {
     return (
-      <ArgumentSelector
+      <FieldValuesWidget
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore: this component doesn't have types or propTypes
         value={filterArguments}


### PR DESCRIPTION
The bulk filter modal can be a little hard to use on smaller laptop screens when it only shows 2 or 3 fields at a time. This seeks to improve that experience.

Makes the following items in the Bulk filter model responsive to viewport height:
- Modal title text size & padding
- Column title text size & Icons & padding
- Select input heights
- FieldValues widget input and token padding
- Table tab text size

(modal buttons were already width-responsive)

![soResponsive](https://user-images.githubusercontent.com/30528226/180565932-52e017c9-b2ac-435a-9170-aed4cf17ea8c.gif)


. | .
--- | --- 
small tokens | ![Screen Shot 2022-07-22 at 2 45 57 PM](https://user-images.githubusercontent.com/30528226/180566085-548ea3e9-a111-4350-9967-7bed1175e72a.png) 
large tokens | ![Screen Shot 2022-07-22 at 2 45 50 PM](https://user-images.githubusercontent.com/30528226/180566089-105d3a34-0257-45d3-a70f-924696169128.png)
