### PR TITLE
Add entity_id columns to PulseCard, PulseChannel

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -11947,6 +11947,38 @@ databaseChangeLog:
                   constraints:
                     nullable: true
 
+  - changeSet:
+      id: v44.00-041
+      author: braden
+      comment: Added 0.44.0 - add entity_id column to PulseCard, PulseChannel
+      changes:
+        - addColumn:
+            columns:
+            - column:
+                remarks: Random NanoID tag for unique identity.
+                name: entity_id
+                type: char(21)
+                constraints:
+                  nullable: true
+                  unique: true
+            tableName: pulse_card
+
+  - changeSet:
+      id: v44.00-042
+      author: braden
+      comment: Added 0.44.0 - add entity_id column to PulseCard, PulseChannel
+      changes:
+        - addColumn:
+            columns:
+            - column:
+                remarks: Random NanoID tag for unique identity.
+                name: entity_id
+                type: char(21)
+                constraints:
+                  nullable: true
+                  unique: true
+            tableName: pulse_channel
+
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/src/metabase/models/pulse_card.clj
+++ b/src/metabase/models/pulse_card.clj
@@ -9,6 +9,10 @@
 (models/defmodel PulseCard :pulse_card)
 
 (u/strict-extend (class PulseCard)
+  models/IModel
+  (merge models/IModelDefaults
+         {:properties (constantly {:entity_id true})})
+
   serdes.hash/IdentityHashable
   {:identity-hash-fields (constantly [(serdes.hash/hydrated-hash :pulse) (serdes.hash/hydrated-hash :card)])})
 

--- a/src/metabase/models/pulse_channel.clj
+++ b/src/metabase/models/pulse_channel.clj
@@ -184,7 +184,8 @@
    models/IModelDefaults
    {:hydration-keys (constantly [:pulse_channel])
     :types          (constantly {:details :json, :channel_type :keyword, :schedule_type :keyword, :schedule_frame :keyword})
-    :properties     (constantly {:timestamped? true})
+    :properties     (constantly {:timestamped? true
+                                 :entity_id    true})
     :pre-delete     pre-delete
     :pre-insert     validate-email-domains
     :pre-update     validate-email-domains})

--- a/test/metabase/api/alert_test.clj
+++ b/test/metabase/api/alert_test.clj
@@ -282,6 +282,7 @@
 (def ^:private daily-email-channel
   {:enabled       true
    :channel_type  "email"
+   :entity_id     true
    :schedule_type "daily"
    :schedule_hour 12
    :schedule_day  nil

--- a/test/metabase/api/pulse_test.clj
+++ b/test/metabase/api/pulse_test.clj
@@ -141,7 +141,9 @@
 
 (defn- remove-extra-channels-fields [channels]
   (for [channel channels]
-    (dissoc channel :id :pulse_id :created_at :updated_at)))
+    (-> channel
+        (dissoc :id :pulse_id :created_at :updated_at)
+        (update :entity_id boolean))))
 
 (def ^:private pulse-defaults
   {:collection_id       nil

--- a/test/metabase/models/pulse_channel_test.clj
+++ b/test/metabase/models/pulse_channel_test.clj
@@ -137,6 +137,7 @@
         (hydrate :recipients)
         (update :recipients #(sort-by :email %))
         (dissoc :id :pulse_id :created_at :updated_at)
+        (update :entity_id boolean)
         (m/dissoc-in [:details :emails])
         mt/derecordize)))
 
@@ -146,6 +147,7 @@
   (-> (PulseChannel id)
       (hydrate :recipients)
       (dissoc :id :pulse_id :created_at :updated_at)
+      (update :entity_id boolean)
       (m/dissoc-in [:details :emails])
       mt/derecordize))
 
@@ -155,6 +157,7 @@
     (mt/with-model-cleanup [Pulse]
       (testing "disabled"
         (is (= {:enabled        false
+                :entity_id      true
                 :channel_type   :email
                 :schedule_type  :daily
                 :schedule_hour  18
@@ -174,6 +177,7 @@
                                  {:id (mt/user->id :crowberto)}]}))))
       (testing "email"
         (is (= {:enabled        true
+                :entity_id      true
                 :channel_type   :email
                 :schedule_type  :daily
                 :schedule_hour  18
@@ -194,6 +198,7 @@
 
       (testing "slack"
         (is (= {:enabled        true
+                :entity_id      true
                 :channel_type   :slack
                 :schedule_type  :hourly
                 :schedule_hour  nil
@@ -216,6 +221,7 @@
     (testing "simple starting case where we modify the schedule hour and add a recipient"
       (mt/with-temp PulseChannel [{channel-id :id, :as channel} {:pulse_id pulse-id}]
         (is (= {:enabled        true
+                :entity_id      true
                 :channel_type   :email
                 :schedule_type  :daily
                 :schedule_hour  18
@@ -233,6 +239,7 @@
     (testing "monthly schedules require a schedule_frame and can optionally omit they schedule_day"
       (mt/with-temp PulseChannel [{channel-id :id :as channel} {:pulse_id pulse-id}]
         (is (= {:enabled        true
+                :entity_id      true
                 :channel_type  :email
                 :schedule_type :monthly
                 :schedule_hour 8
@@ -252,6 +259,7 @@
     (testing "weekly schedule should have a day in it, show that we can get full users"
       (mt/with-temp PulseChannel [{channel-id :id} {:pulse_id pulse-id}]
         (is (= {:enabled        true
+                :entity_id      true
                 :channel_type   :email
                 :schedule_type  :weekly
                 :schedule_hour  8
@@ -271,6 +279,7 @@
       (mt/with-temp PulseChannel [{channel-id :id} {:pulse_id pulse-id, :details {:emails ["foo@bar.com"]}}]
         (pulse-channel/update-recipients! channel-id [(mt/user->id :rasta)])
         (is (= {:enabled       true
+                :entity_id     true
                 :channel_type  :email
                 :schedule_type :hourly
                 :schedule_hour nil
@@ -289,6 +298,7 @@
     (testing "custom details for channels that need it"
       (mt/with-temp PulseChannel [{channel-id :id} {:pulse_id pulse-id}]
         (is (= {:enabled       true
+                :entity_id     true
                 :channel_type  :email
                 :schedule_type :daily
                 :schedule_hour 12

--- a/test/metabase/models/pulse_test.clj
+++ b/test/metabase/models/pulse_test.clj
@@ -30,6 +30,7 @@
       (update :channels (fn [channels]
                           (for [channel channels]
                             (-> (dissoc channel :id :pulse_id :created_at :updated_at)
+                                (update :entity_id boolean)
                                 (m/dissoc-in [:details :emails])))))))
 ;; create a channel then select its details
 (defn- create-pulse-then-select!
@@ -92,6 +93,7 @@
                                                  (dissoc card :id))))
                  (update :channels (fn [channels] (for [channel channels]
                                                     (-> (dissoc channel :id :pulse_id :created_at :updated_at)
+                                                        (update :entity_id boolean)
                                                         (m/dissoc-in [:details :emails])))))
                  mt/derecordize))))))
 
@@ -135,6 +137,7 @@
            (-> (PulseChannel :pulse_id id)
                (hydrate :recipients)
                (dissoc :id :pulse_id :created_at :updated_at)
+               (update :entity_id boolean)
                (m/dissoc-in [:details :emails])
                mt/derecordize)))))
 

--- a/test/metabase/test/mock/util.clj
+++ b/test/metabase/test/mock/util.clj
@@ -38,6 +38,7 @@
   {:schedule_frame nil
    :schedule_hour  nil
    :schedule_day   nil
+   :entity_id      true
    :enabled        true})
 
 (def venue-fingerprints


### PR DESCRIPTION
When I came to serialization for PulseCards and PulseChannels, I realized
they have no IDs for sound de-duping - so I'm adding entity_id columns to them
too.
