### PR TITLE
Fix achiving models doesn't remove them from the collection view

### DIFF
--- a/frontend/src/metabase/entities/schemas.js
+++ b/frontend/src/metabase/entities/schemas.js
@@ -96,6 +96,10 @@ export default createEntity({
       }
 
       return updateIn(state, [schemaId, "tables"], tables => {
+        if (!tables) {
+          return tables;
+        }
+
         if (question.archived) {
           return tables.filter(id => id !== virtualQuestionId);
         }


### PR DESCRIPTION
Epic: 22826
Task: https://www.notion.so/metabase/Archived-models-still-show-in-collections-until-a-page-refresh-d245837ac07a4bd3b3a7313cb5f7dde5

#### How to test
1. Create a model in any collection
2. Go to that collection
3. Refresh the collection page
4. Select a model
5. Archive model
6. When you're back on the collection view, that model should disappear