### PR TITLE
Invalidate collections on question moderation update

### DIFF
--- a/frontend/src/metabase/entities/questions.js
+++ b/frontend/src/metabase/entities/questions.js
@@ -86,8 +86,8 @@ const Questions = createEntity({
       const latestReview = payload.moderation_reviews?.find(x => x.most_recent);
 
       if (latestReview) {
-        return updateIn(state, [id], q => ({
-          ...q,
+        return updateIn(state, [id], question => ({
+          ...question,
           moderated_status: latestReview.status,
         }));
       }

--- a/frontend/src/metabase/entities/questions.js
+++ b/frontend/src/metabase/entities/questions.js
@@ -14,6 +14,7 @@ import Collections, {
 import { canonicalCollectionId } from "metabase/collections/utils";
 
 import forms from "./questions/forms";
+import { updateIn } from "icepick";
 
 const Questions = createEntity({
   name: "questions",
@@ -82,13 +83,13 @@ const Questions = createEntity({
   reducer: (state = {}, { type, payload, error }) => {
     if (type === SOFT_RELOAD_CARD) {
       const { id } = payload;
-      const verified =
-        payload.moderation_reviews?.find(x => x.most_recent)?.status ===
-        "verified"
-          ? "verified"
-          : null;
-      if (state[id]) {
-        state[id].moderated_status = verified;
+      const latestReview = payload.moderation_reviews?.find(x => x.most_recent);
+
+      if (latestReview) {
+        return updateIn(state, [id], q => ({
+          ...q,
+          moderated_status: latestReview.status,
+        }));
       }
     }
     return state;

--- a/frontend/src/metabase/entities/questions.js
+++ b/frontend/src/metabase/entities/questions.js
@@ -2,7 +2,10 @@ import { createEntity, undo } from "metabase/lib/entities";
 import * as Urls from "metabase/lib/urls";
 import { color } from "metabase/lib/colors";
 
-import { API_UPDATE_QUESTION } from "metabase/query_builder/actions";
+import {
+  API_UPDATE_QUESTION,
+  SOFT_RELOAD_CARD,
+} from "metabase/query_builder/actions";
 
 import Collections, {
   getCollectionType,
@@ -77,6 +80,17 @@ const Questions = createEntity({
   },
 
   reducer: (state = {}, { type, payload, error }) => {
+    if (type === SOFT_RELOAD_CARD) {
+      const { id } = payload;
+      const verified =
+        payload.moderation_reviews?.find(x => x.most_recent)?.status ===
+        "verified"
+          ? "verified"
+          : null;
+      if (state[id]) {
+        state[id].moderated_status = verified;
+      }
+    }
     return state;
   },
 


### PR DESCRIPTION
Fixes [Question moderation status not updating in collection view](https://www.notion.so/metabase/Verification-on-questions-and-models-not-reflected-in-collections-08f4e2b6b2d24b44bab3a54bd4a07204)

![chrome_7AsXaHJfSz](https://user-images.githubusercontent.com/1328979/180450814-fe97d3dc-261f-4f38-b4bf-1c95bc0220a3.gif)
