### PR TITLE
Disable object detail in notebook preview

### DIFF
--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
@@ -70,12 +70,12 @@ function pickRowsToMeasure(rows, columnIndex, count = 10) {
   return rowIndexes;
 }
 
-const mapDispatchToProps = dispatch => ({
-  onZoomRow: objectId => dispatch(zoomInRow({ objectId })),
-});
-
 const mapStateToProps = state => ({
   queryBuilderMode: getQueryBuilderMode(state),
+});
+
+const mapDispatchToProps = dispatch => ({
+  onZoomRow: objectId => dispatch(zoomInRow({ objectId })),
 });
 
 class TableInteractive extends Component {
@@ -179,9 +179,18 @@ class TableInteractive extends Component {
   _showDetailShortcut = (query, isPivoted) => {
     const hasAggregation = !!query?.aggregations?.()?.length;
     const isNotebookPreview = this.props.queryBuilderMode === "notebook";
-    this.setState({
-      showDetailShortcut: !(isPivoted || hasAggregation || isNotebookPreview),
-    });
+    const newShowDetailState = !(
+      isPivoted ||
+      hasAggregation ||
+      isNotebookPreview
+    );
+
+    if (newShowDetailState !== this.state.showDetailShortcut) {
+      this.setState({
+        showDetailShortcut: newShowDetailState,
+      });
+      this.recomputeColumnSizes();
+    }
   };
 
   _getColumnSettings(props) {

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
@@ -31,6 +31,7 @@ import { isAdHocModelQuestionCard } from "metabase/lib/data-modeling/utils";
 import Dimension from "metabase-lib/lib/Dimension";
 import { getScrollBarSize } from "metabase/lib/dom";
 import { zoomInRow } from "metabase/query_builder/actions";
+import { getQueryBuilderMode } from "metabase/query_builder/selectors";
 
 import ExplicitSize from "metabase/components/ExplicitSize";
 import MiniBar from "../MiniBar";
@@ -71,6 +72,10 @@ function pickRowsToMeasure(rows, columnIndex, count = 10) {
 
 const mapDispatchToProps = dispatch => ({
   onZoomRow: objectId => dispatch(zoomInRow({ objectId })),
+});
+
+const mapStateToProps = state => ({
+  queryBuilderMode: getQueryBuilderMode(state),
 });
 
 class TableInteractive extends Component {
@@ -173,8 +178,9 @@ class TableInteractive extends Component {
 
   _showDetailShortcut = (query, isPivoted) => {
     const hasAggregation = !!query?.aggregations?.()?.length;
+    const isNotebookPreview = this.props.queryBuilderMode === "notebook";
     this.setState({
-      showDetailShortcut: !(isPivoted || hasAggregation),
+      showDetailShortcut: !(isPivoted || hasAggregation || isNotebookPreview),
     });
   };
 
@@ -1114,7 +1120,7 @@ export default _.compose(
   ExplicitSize({
     refreshMode: props => (props.isDashboard ? "debounce" : "throttle"),
   }),
-  connect(null, mapDispatchToProps),
+  connect(mapStateToProps, mapDispatchToProps),
   memoizeClass(
     "_getCellClickedObjectCached",
     "_getHeaderClickedObjectCached",

--- a/frontend/test/metabase/visualizations/components/Visualization-table.unit.spec.js
+++ b/frontend/test/metabase/visualizations/components/Visualization-table.unit.spec.js
@@ -2,6 +2,7 @@ import React from "react";
 import { renderWithProviders } from "__support__/ui";
 
 import { NumberColumn } from "../__support__/visualizations";
+import { createMockQueryBuilderState } from "metabase-types/store/mocks/qb";
 
 import Visualization from "metabase/visualizations/components/Visualization";
 
@@ -37,11 +38,18 @@ describe("Table", () => {
         },
       ],
     };
+    const qbState = createMockQueryBuilderState();
     const { getByText } = renderWithProviders(
       <Visualization rawSeries={series(rows, settings)} />,
       {
         withSettings: true,
         withEmbedSettings: true,
+        storeInitialState: {
+          qb: qbState,
+        },
+        reducers: {
+          qb: () => qbState,
+        },
       },
     );
     jest.runAllTimers();


### PR DESCRIPTION
## Bug

When starting a new question from the "new" menu (without first opening a question in table view), object detail shortcut buttons in notebook previews would appear, but would not work

![Screen Shot 2022-07-21 at 1 49 25 PM](https://user-images.githubusercontent.com/30528226/180303065-da72e5dc-1237-4bce-8606-159713acb463.png)

## Cause

Object detail relies on cached query results in the `queryResults` redux store. However, we do not cache preview queries there, and we don't want to because it would overwrite question query data. Without queryResult data, the object detail modal has nothing to show.

## Solution

There are two possible solutions here
### 1. Make object detail work in notebook previews

This is absolutely possible, but would require pretty significant work. We would need to refactor object detail to take data passed as a prop, instead of from the redux store. In order to do that, we would need to either duplicate or extract certain logic from our redux selectors that find the correct row of data based on the clicked row.  This would be non-trivial.

### 2. Disable Object detail shortcuts in notebook previews

This is by far the simpler solution - we simply check the query builder mode property in redux, and disable the object detail shortcut buttons. I think this is also the correct UX decision, because we disable all other filtering and drill operations for preview tables, and I think we don't want people messing around too much in there - we just want them to get a quick preview of the data their queries will return.

 ## Result

No broken object detail shortcut buttons in preview mode 😁 

![Screen Shot 2022-07-21 at 1 57 01 PM](https://user-images.githubusercontent.com/30528226/180304172-2ea3fd7c-d8ad-4cd5-a8cd-cee14d6b1fbf.png)




