### PR TITLE
Serdes v2 for Pulse, PulseCard, PulseChannel

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
@@ -11,6 +11,8 @@
    "Field"
    "Metric"
    "NativeQuerySnippet"
+   "Pulse"
+   "PulseCard"
    "Segment"
    "Setting"
    "Table"

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
@@ -13,6 +13,7 @@
    "NativeQuerySnippet"
    "Pulse"
    "PulseCard"
+   "PulseChannel"
    "Segment"
    "Setting"
    "Table"

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e/yaml_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e/yaml_test.clj
@@ -39,52 +39,54 @@
     (ts/with-empty-h2-app-db
       ;; TODO Generating some nested collections would make these tests more robust.
       (test-gen/insert!
-        {:collection             [[100 {:refs {:personal_owner_id ::rs/omit}}]
-                                  [10  {:refs     {:personal_owner_id ::rs/omit}
-                                        :spec-gen {:namespace :snippets}}]]
-         :database               [[10]]
-         :table                  (into [] (for [db [:db0 :db1 :db2 :db3 :db4 :db5 :db6 :db7 :db8 :db9]]
-                                            [10 {:refs {:db_id db}}]))
-         :field                  (into [] (for [n     (range 100)
-                                                :let [table (keyword (str "t" n))]]
-                                            [10 {:refs {:table_id table}}]))
-         :core-user              [[10]]
-         :card                   [[100 {:refs (let [db (rand-int 10)
-                                                    t  (rand-int 10)]
-                                                {:database_id   (keyword (str "db" db))
-                                                 :table_id      (keyword (str "t" (+ t (* 10 db))))
-                                                 :collection_id (random-keyword "coll" 100)
-                                                 :creator_id    (random-keyword "u" 10)})}]]
-         :dashboard              [[100 {:refs {:collection_id   (random-keyword "coll" 100)
-                                               :creator_id      (random-keyword "u" 10)}}]]
-         :dashboard-card         [[300 {:refs {:card_id      (random-keyword "c" 100)
-                                               :dashboard_id (random-keyword "d" 100)}}]]
-         :dimension              [;; 20 with both IDs set
-                                  [20 {:refs {:field_id                (random-keyword "field" 1000)
-                                              :human_readable_field_id (random-keyword "field" 1000)}}]
-                                  ;; 20 with just :field_id
-                                  [20 {:refs {:field_id                (random-keyword "field" 1000)
-                                              :human_readable_field_id ::rs/omit}}]]
-         :metric                 [[30 {:refs {:table_id   (random-keyword "t" 100)
-                                              :creator_id (random-keyword "u" 10)}}]]
-         :segment                [[30 {:refs {:table_id   (random-keyword "t" 100)
-                                              :creator_id (random-keyword "u" 10)}}]]
-         :native-query-snippet   [[10 {:refs {:creator_id    (random-keyword "u" 10)
-                                              :collection_id (random-keyword "coll" 10 100)}}]]
-         :timeline               [[10 {:refs {:creator_id    (random-keyword "u" 10)
-                                              :collection_id (random-keyword "coll" 100)}}]]
-         :timeline-event         [[90 {:refs {:timeline_id   (random-keyword "timeline" 10)}}]]
-         :pulse                  [[10 {:refs {:collection_id (random-keyword "coll" 100)}}]
-                                  [10 {:refs {:collection_id ::rs/omit}}]
-                                  [10 {:refs {:collection_id ::rs/omit
-                                              :dashboard_id  (random-keyword "d" 100)}}]]
-         :pulse-card             [[60 {:refs {:card_id       (random-keyword "c" 100)
-                                              :pulse_id      (random-keyword "pulse" 10)}}]
-                                  [60 {:refs {:card_id       (random-keyword "c" 100)
-                                              :pulse_id      (random-keyword "pulse" 10 20)
-                                              :dashboard_card_id (random-keyword "dc" 300)}}]]
-         :pulse-channel          [[15 {:refs {:pulse_id      (random-keyword "pulse" 10)}}]
-                                  [15 {:refs {:pulse_id      (random-keyword "pulse" 10 20)}}]]})
+        {:collection              [[100 {:refs {:personal_owner_id ::rs/omit}}]
+                                   [10  {:refs     {:personal_owner_id ::rs/omit}
+                                         :spec-gen {:namespace :snippets}}]]
+         :database                [[10]]
+         :table                   (into [] (for [db [:db0 :db1 :db2 :db3 :db4 :db5 :db6 :db7 :db8 :db9]]
+                                             [10 {:refs {:db_id db}}]))
+         :field                   (into [] (for [n     (range 100)
+                                                 :let [table (keyword (str "t" n))]]
+                                             [10 {:refs {:table_id table}}]))
+         :core-user               [[10]]
+         :card                    [[100 {:refs (let [db (rand-int 10)
+                                                     t  (rand-int 10)]
+                                                 {:database_id   (keyword (str "db" db))
+                                                  :table_id      (keyword (str "t" (+ t (* 10 db))))
+                                                  :collection_id (random-keyword "coll" 100)
+                                                  :creator_id    (random-keyword "u" 10)})}]]
+         :dashboard               [[100 {:refs {:collection_id   (random-keyword "coll" 100)
+                                                :creator_id      (random-keyword "u" 10)}}]]
+         :dashboard-card          [[300 {:refs {:card_id      (random-keyword "c" 100)
+                                                :dashboard_id (random-keyword "d" 100)}}]]
+         :dimension               [;; 20 with both IDs set
+                                   [20 {:refs {:field_id                (random-keyword "field" 1000)
+                                               :human_readable_field_id (random-keyword "field" 1000)}}]
+                                   ;; 20 with just :field_id
+                                   [20 {:refs {:field_id                (random-keyword "field" 1000)
+                                               :human_readable_field_id ::rs/omit}}]]
+         :metric                  [[30 {:refs {:table_id   (random-keyword "t" 100)
+                                               :creator_id (random-keyword "u" 10)}}]]
+         :segment                 [[30 {:refs {:table_id   (random-keyword "t" 100)
+                                               :creator_id (random-keyword "u" 10)}}]]
+         :native-query-snippet    [[10 {:refs {:creator_id    (random-keyword "u" 10)
+                                               :collection_id (random-keyword "coll" 10 100)}}]]
+         :timeline                [[10 {:refs {:creator_id    (random-keyword "u" 10)
+                                               :collection_id (random-keyword "coll" 100)}}]]
+         :timeline-event          [[90 {:refs {:timeline_id   (random-keyword "timeline" 10)}}]]
+         :pulse                   [[10 {:refs {:collection_id (random-keyword "coll" 100)}}]
+                                   [10 {:refs {:collection_id ::rs/omit}}]
+                                   [10 {:refs {:collection_id ::rs/omit
+                                               :dashboard_id  (random-keyword "d" 100)}}]]
+         :pulse-card              [[60 {:refs {:card_id       (random-keyword "c" 100)
+                                               :pulse_id      (random-keyword "pulse" 10)}}]
+                                   [60 {:refs {:card_id       (random-keyword "c" 100)
+                                               :pulse_id      (random-keyword "pulse" 10 20)
+                                               :dashboard_card_id (random-keyword "dc" 300)}}]]
+         :pulse-channel           [[15 {:refs {:pulse_id      (random-keyword "pulse" 10)}}]
+                                   [15 {:refs {:pulse_id      (random-keyword "pulse" 10 20)}}]]
+         :pulse-channel-recipient [[40 {:refs {:pulse_channel_id (random-keyword "pulse-channel" 30)
+                                               :user_id          (random-keyword "u" 10)}}]]})
       (let [extraction (into [] (extract/extract-metabase {}))
             entities   (reduce (fn [m entity]
                                  (update m (-> entity :serdes/meta last :model)
@@ -235,6 +237,8 @@
                                   (->> (io/file dump-dir "Pulse" (:entity_id pulse) "PulseChannel")
                                        dir->file-set
                                        count)))))
+            (is (= 40 (reduce + (for [{:keys [recipients]} (get entities "PulseChannel")]
+                                  (count recipients)))))
             (doseq [{:keys [entity_id pulse_id] :as channel} (get entities "PulseChannel")
                     :let [filename (#'u.yaml/leaf-file-name entity_id)]]
               (is (= (-> channel

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -3,7 +3,7 @@
             [metabase-enterprise.serialization.test-util :as ts]
             [metabase-enterprise.serialization.v2.extract :as extract]
             [metabase.models :refer [Card Collection Dashboard DashboardCard Database Dimension Field Metric
-                                     NativeQuerySnippet Segment Table Timeline TimelineEvent User]]
+                                     NativeQuerySnippet Pulse PulseCard Segment Table Timeline TimelineEvent User]]
             [metabase.models.serialization.base :as serdes.base]
             [schema.core :as s])
   (:import [java.time LocalDateTime OffsetDateTime]))
@@ -432,4 +432,173 @@
           (testing "depend on the Table"
             (is (= #{[{:model "Database"   :id "My Database"}
                       {:model "Table"      :id "Schemaless Table"}]}
+                   (set (serdes.base/serdes-dependencies ser))))))))))
+
+(deftest pulses-test
+  (ts/with-empty-h2-app-db
+    (ts/with-temp-dpc [User       [{ann-id       :id}        {:first_name "Ann"
+                                                              :last_name  "Wilson"
+                                                              :email      "ann@heart.band"}]
+                       Collection [{coll-id      :id
+                                    coll-eid     :entity_id} {:name "Some Collection"}]
+                       Dashboard  [{dash-id      :id
+                                    dash-eid     :entity_id} {:name "A Dashboard"}]
+                       Pulse      [{p-none-id    :id
+                                    p-none-eid   :entity_id} {:name       "Pulse w/o collection or dashboard"
+                                                              :creator_id ann-id}]
+                       Pulse      [{p-coll-id    :id
+                                    p-coll-eid   :entity_id} {:name          "Pulse with only collection"
+                                                              :creator_id    ann-id
+                                                              :collection_id coll-id}]
+                       Pulse      [{p-dash-id    :id
+                                    p-dash-eid   :entity_id} {:name         "Pulse with only dashboard"
+                                                              :creator_id   ann-id
+                                                              :dashboard_id dash-id}]
+                       Pulse      [{p-both-id    :id
+                                    p-both-eid   :entity_id} {:name          "Pulse with both collection and dashboard"
+                                                              :creator_id    ann-id
+                                                              :collection_id coll-id
+                                                              :dashboard_id  dash-id}]]
+      (testing "pulse with neither collection nor dashboard"
+        (let [ser (serdes.base/extract-one "Pulse" {} (select-one "Pulse" [:= :id p-none-id]))]
+          (is (schema= {:serdes/meta                    (s/eq [{:model "Pulse" :id p-none-eid}])
+                        :creator_id                     (s/eq "ann@heart.band")
+                        :created_at                     LocalDateTime
+                        (s/optional-key :updated_at)    LocalDateTime
+                        (s/optional-key :dashboard_id)  (s/eq nil)
+                        (s/optional-key :collection_id) (s/eq nil)
+                        s/Keyword                       s/Any}
+                       ser))
+          (is (not (contains? ser :id)))
+
+          (testing "has no deps"
+            (is (= #{}
+                   (set (serdes.base/serdes-dependencies ser)))))))
+
+      (testing "pulse with just collection"
+        (let [ser (serdes.base/extract-one "Pulse" {} (select-one "Pulse" [:= :id p-coll-id]))]
+          (is (schema= {:serdes/meta                    (s/eq [{:model "Pulse" :id p-coll-eid}])
+                        :creator_id                     (s/eq "ann@heart.band")
+                        :created_at                     LocalDateTime
+                        (s/optional-key :updated_at)    LocalDateTime
+                        (s/optional-key :dashboard_id)  (s/eq nil)
+                        :collection_id                  (s/eq coll-eid)
+                        s/Keyword                       s/Any}
+                       ser))
+          (is (not (contains? ser :id)))
+
+          (testing "depends on the collection"
+            (is (= #{[{:model "Collection" :id coll-eid}]}
+                   (set (serdes.base/serdes-dependencies ser)))))))
+
+      (testing "pulse with just dashboard"
+        (let [ser (serdes.base/extract-one "Pulse" {} (select-one "Pulse" [:= :id p-dash-id]))]
+          (is (schema= {:serdes/meta                    (s/eq [{:model "Pulse" :id p-dash-eid}])
+                        :creator_id                     (s/eq "ann@heart.band")
+                        :created_at                     LocalDateTime
+                        (s/optional-key :updated_at)    LocalDateTime
+                        :dashboard_id                   (s/eq dash-eid)
+                        (s/optional-key :collection_id) (s/eq nil)
+                        s/Keyword                       s/Any}
+                       ser))
+          (is (not (contains? ser :id)))
+
+          (testing "depends on the dashboard"
+            (is (= #{[{:model "Dashboard" :id dash-eid}]}
+                   (set (serdes.base/serdes-dependencies ser)))))))
+
+      (testing "pulse with both collection and dashboard"
+        (let [ser (serdes.base/extract-one "Pulse" {} (select-one "Pulse" [:= :id p-both-id]))]
+          (is (schema= {:serdes/meta                    (s/eq [{:model "Pulse" :id p-both-eid}])
+                        :creator_id                     (s/eq "ann@heart.band")
+                        :created_at                     LocalDateTime
+                        (s/optional-key :updated_at)    LocalDateTime
+                        :dashboard_id                   (s/eq dash-eid)
+                        :collection_id                  (s/eq coll-eid)
+                        s/Keyword                       s/Any}
+                       ser))
+          (is (not (contains? ser :id)))
+
+          (testing "depends on the collection and dashboard"
+            (is (= #{[{:model "Collection" :id coll-eid}]
+                     [{:model "Dashboard"  :id dash-eid}]}
+                   (set (serdes.base/serdes-dependencies ser))))))))))
+
+(deftest pulse-cards-test
+  (ts/with-empty-h2-app-db
+    (ts/with-temp-dpc [User          [{ann-id       :id}        {:first_name "Ann"
+                                                                 :last_name  "Wilson"
+                                                                 :email      "ann@heart.band"}]
+                       Dashboard     [{dash-id      :id}        {:name "A Dashboard"}]
+                       Database      [{db-id        :id}        {:name "My Database"}]
+                       Table         [{table-id     :id}        {:name "Schemaless Table" :db_id db-id}]
+                       Card          [{card1-id     :id
+                                       card1-eid    :entity_id} {:name          "Some Question"
+                                                                 :database_id   db-id
+                                                                 :table_id      table-id
+                                                                 :creator_id    ann-id
+                                                                 :dataset_query "{\"json\": \"string values\"}"}]
+                       DashboardCard [{dashcard-id  :id
+                                       dashcard-eid :entity_id} {:card_id       card1-id
+                                                                 :dashboard_id  dash-id}]
+                       Pulse         [{pulse-id     :id
+                                       pulse-eid    :entity_id} {:name       "Legacy Pulse"
+                                                                 :creator_id ann-id}]
+                       Pulse         [{sub-id       :id
+                                       sub-eid      :entity_id} {:name       "Dashboard sub"
+                                                                 :creator_id ann-id
+                                                                 :dashboard_id dash-id}]
+                       PulseCard     [{pc1-pulse-id :id}        {:pulse_id          pulse-id
+                                                                 :card_id           card1-id
+                                                                 :position          1}]
+                       PulseCard     [{pc2-pulse-id :id}        {:pulse_id          pulse-id
+                                                                 :card_id           card1-id
+                                                                 :position          2}]
+                       PulseCard     [{pc1-sub-id   :id}        {:pulse_id          sub-id
+                                                                 :card_id           card1-id
+                                                                 :position          1
+                                                                 :dashboard_card_id dashcard-id}]]
+      (testing "legacy pulse cards"
+        (let [ser (serdes.base/extract-one "PulseCard" {} (select-one "PulseCard" [:= :id pc1-pulse-id]))]
+          (is (schema= {:serdes/meta                        (s/eq [{:model "Pulse" :id pulse-eid}
+                                                                   {:model "PulseCard" :id "1"}])
+                        :card_id                            (s/eq card1-eid)
+                        (s/optional-key :dashboard_card_id) (s/eq nil)
+                        s/Keyword                           s/Any}
+                       ser))
+          (is (not (contains? ser :id)))
+
+          (testing "depends on the pulse and card"
+            (is (= #{[{:model "Pulse" :id pulse-eid}]
+                     [{:model "Card"  :id card1-eid}]}
+                   (set (serdes.base/serdes-dependencies ser))))))
+
+        (let [ser (serdes.base/extract-one "PulseCard" {} (select-one "PulseCard" [:= :id pc2-pulse-id]))]
+          (is (schema= {:serdes/meta                        (s/eq [{:model "Pulse" :id pulse-eid}
+                                                                   {:model "PulseCard" :id "2"}])
+                        :card_id                            (s/eq card1-eid)
+                        (s/optional-key :dashboard_card_id) (s/eq nil)
+                        s/Keyword                           s/Any}
+                       ser))
+          (is (not (contains? ser :id)))
+
+          (testing "depends on the pulse and card"
+            (is (= #{[{:model "Pulse" :id pulse-eid}]
+                     [{:model "Card"  :id card1-eid}]}
+                   (set (serdes.base/serdes-dependencies ser)))))))
+
+      (testing "dashboard sub cards"
+        (let [ser (serdes.base/extract-one "PulseCard" {} (select-one "PulseCard" [:= :id pc1-sub-id]))]
+          (is (schema= {:serdes/meta                    (s/eq [{:model "Pulse" :id sub-eid}
+                                                               {:model "PulseCard" :id "1"}])
+                        :card_id                        (s/eq card1-eid)
+                        :dashboard_card_id              (s/eq dashcard-eid)
+                        s/Keyword                       s/Any}
+                       ser))
+          (is (not (contains? ser :id)))
+
+          (testing "depends on the pulse, card and dashcard"
+            (is (= #{[{:model "Pulse" :id sub-eid}]
+                     [{:model "Card"  :id card1-eid}]
+                     [{:model "DashboardCard" :id dashcard-eid}]}
                    (set (serdes.base/serdes-dependencies ser))))))))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -526,42 +526,45 @@
 
 (deftest pulse-cards-test
   (ts/with-empty-h2-app-db
-    (ts/with-temp-dpc [User          [{ann-id       :id}        {:first_name "Ann"
-                                                                 :last_name  "Wilson"
-                                                                 :email      "ann@heart.band"}]
-                       Dashboard     [{dash-id      :id}        {:name "A Dashboard"}]
-                       Database      [{db-id        :id}        {:name "My Database"}]
-                       Table         [{table-id     :id}        {:name "Schemaless Table" :db_id db-id}]
-                       Card          [{card1-id     :id
-                                       card1-eid    :entity_id} {:name          "Some Question"
-                                                                 :database_id   db-id
-                                                                 :table_id      table-id
-                                                                 :creator_id    ann-id
-                                                                 :dataset_query "{\"json\": \"string values\"}"}]
-                       DashboardCard [{dashcard-id  :id
-                                       dashcard-eid :entity_id} {:card_id       card1-id
-                                                                 :dashboard_id  dash-id}]
-                       Pulse         [{pulse-id     :id
-                                       pulse-eid    :entity_id} {:name       "Legacy Pulse"
-                                                                 :creator_id ann-id}]
-                       Pulse         [{sub-id       :id
-                                       sub-eid      :entity_id} {:name       "Dashboard sub"
-                                                                 :creator_id ann-id
-                                                                 :dashboard_id dash-id}]
-                       PulseCard     [{pc1-pulse-id :id}        {:pulse_id          pulse-id
-                                                                 :card_id           card1-id
-                                                                 :position          1}]
-                       PulseCard     [{pc2-pulse-id :id}        {:pulse_id          pulse-id
-                                                                 :card_id           card1-id
-                                                                 :position          2}]
-                       PulseCard     [{pc1-sub-id   :id}        {:pulse_id          sub-id
-                                                                 :card_id           card1-id
-                                                                 :position          1
-                                                                 :dashboard_card_id dashcard-id}]]
+    (ts/with-temp-dpc [User          [{ann-id        :id}        {:first_name "Ann"
+                                                                  :last_name  "Wilson"
+                                                                  :email      "ann@heart.band"}]
+                       Dashboard     [{dash-id       :id}        {:name "A Dashboard"}]
+                       Database      [{db-id         :id}        {:name "My Database"}]
+                       Table         [{table-id      :id}        {:name "Schemaless Table" :db_id db-id}]
+                       Card          [{card1-id      :id
+                                       card1-eid     :entity_id} {:name          "Some Question"
+                                                                  :database_id   db-id
+                                                                  :table_id      table-id
+                                                                  :creator_id    ann-id
+                                                                  :dataset_query "{\"json\": \"string values\"}"}]
+                       DashboardCard [{dashcard-id   :id
+                                       dashcard-eid  :entity_id} {:card_id       card1-id
+                                                                  :dashboard_id  dash-id}]
+                       Pulse         [{pulse-id      :id
+                                       pulse-eid     :entity_id} {:name       "Legacy Pulse"
+                                                                  :creator_id ann-id}]
+                       Pulse         [{sub-id        :id
+                                       sub-eid       :entity_id} {:name       "Dashboard sub"
+                                                                  :creator_id ann-id
+                                                                  :dashboard_id dash-id}]
+                       PulseCard     [{pc1-pulse-id  :id
+                                       pc1-pulse-eid :entity_id} {:pulse_id          pulse-id
+                                                                  :card_id           card1-id
+                                                                  :position          1}]
+                       PulseCard     [{pc2-pulse-id  :id
+                                       pc2-pulse-eid :entity_id} {:pulse_id          pulse-id
+                                                                  :card_id           card1-id
+                                                                  :position          2}]
+                       PulseCard     [{pc1-sub-id    :id
+                                       pc1-sub-eid   :entity_id} {:pulse_id          sub-id
+                                                                  :card_id           card1-id
+                                                                  :position          1
+                                                                  :dashboard_card_id dashcard-id}]]
       (testing "legacy pulse cards"
         (let [ser (serdes.base/extract-one "PulseCard" {} (select-one "PulseCard" [:= :id pc1-pulse-id]))]
           (is (schema= {:serdes/meta                        (s/eq [{:model "Pulse" :id pulse-eid}
-                                                                   {:model "PulseCard" :id "1"}])
+                                                                   {:model "PulseCard" :id pc1-pulse-eid}])
                         :card_id                            (s/eq card1-eid)
                         (s/optional-key :dashboard_card_id) (s/eq nil)
                         s/Keyword                           s/Any}
@@ -575,7 +578,7 @@
 
         (let [ser (serdes.base/extract-one "PulseCard" {} (select-one "PulseCard" [:= :id pc2-pulse-id]))]
           (is (schema= {:serdes/meta                        (s/eq [{:model "Pulse" :id pulse-eid}
-                                                                   {:model "PulseCard" :id "2"}])
+                                                                   {:model "PulseCard" :id pc2-pulse-eid}])
                         :card_id                            (s/eq card1-eid)
                         (s/optional-key :dashboard_card_id) (s/eq nil)
                         s/Keyword                           s/Any}
@@ -590,7 +593,7 @@
       (testing "dashboard sub cards"
         (let [ser (serdes.base/extract-one "PulseCard" {} (select-one "PulseCard" [:= :id pc1-sub-id]))]
           (is (schema= {:serdes/meta                    (s/eq [{:model "Pulse" :id sub-eid}
-                                                               {:model "PulseCard" :id "1"}])
+                                                               {:model "PulseCard" :id pc1-sub-eid}])
                         :card_id                        (s/eq card1-eid)
                         :dashboard_card_id              (s/eq dashcard-eid)
                         s/Keyword                       s/Any}

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -4,7 +4,7 @@
             [metabase-enterprise.serialization.v2.extract :as serdes.extract]
             [metabase-enterprise.serialization.v2.ingest :as serdes.ingest]
             [metabase-enterprise.serialization.v2.load :as serdes.load]
-            [metabase.models :refer [Collection Database Table]]
+            [metabase.models :refer [Collection Database Pulse PulseChannel PulseChannelRecipient Table User]]
             [metabase.models.serialization.base :as serdes.base]
             [metabase.models.serialization.hash :as serdes.hash]
             [toucan.db :as db]))
@@ -12,11 +12,13 @@
 (defn- no-labels [path]
   (mapv #(dissoc % :label) path))
 
+(defn- by-model [entities model-name]
+  (filter #(-> % :serdes/meta last :model (= model-name))
+          entities))
+
 (defn- ids-by-model [entities model-name]
-  (->> entities
-       (map (comp last :serdes/meta))
-       (filter #(= model-name (:model %)))
-       (map :id)
+  (->> (by-model entities model-name)
+       (map (comp :id last :serdes/meta))
        set))
 
 (defn- ingestion-in-memory [extractions]
@@ -148,9 +150,7 @@
           db2s       (atom nil)
           db2d       (atom nil)
           t1s        (atom nil)
-          t1d        (atom nil)
-          t2s        (atom nil)
-          t2d        (atom nil)]
+          t2s        (atom nil)]
       (ts/with-source-and-dest-dbs
         (testing "serializing the two collections"
           (ts/with-source-db
@@ -184,3 +184,73 @@
                    (db/select-field :db_id Table :name "posts")))
             (is (db/exists? Table :name "posts" :db_id (:id @db1d)))
             (is (db/exists? Table :name "posts" :db_id (:id @db2d)))))))))
+
+(deftest pulse-channel-recipient-merging-test
+  (testing "pulse channel recipients are listed as emails on a channel, then merged with the existing ones"
+    (let [serialized (atom nil)
+          u1s        (atom nil)
+          u2s        (atom nil)
+          u3s        (atom nil)
+          pulse-s    (atom nil)
+          pc1s       (atom nil)
+          pc2s       (atom nil)
+          pcr1s      (atom nil)
+          pcr2s      (atom nil)
+
+          u1d        (atom nil)
+          u2d        (atom nil)
+          u3d        (atom nil)
+          pulse-d    (atom nil)
+          pc1d       (atom nil)]
+      (ts/with-source-and-dest-dbs
+        (testing "serializing the pulse, channel and recipients"
+          (ts/with-source-db
+            (reset! u1s (ts/create! User :first_name "Alex"  :last_name "Lifeson" :email "alifeson@rush.yyz"))
+            (reset! u2s (ts/create! User :first_name "Geddy" :last_name "Lee"     :email "glee@rush.yyz"))
+            (reset! u3s (ts/create! User :first_name "Neil"  :last_name "Peart"   :email "neil@rush.yyz"))
+            (reset! pulse-s (ts/create! Pulse :name "Heartbeat" :creator_id (:id @u1s)))
+            (reset! pc1s    (ts/create! PulseChannel
+                                        :pulse_id      (:id @pulse-s)
+                                        :channel_type  :email
+                                        :schedule_type :daily
+                                        :schedule_hour 16))
+            (reset! pc2s    (ts/create! PulseChannel
+                                        :pulse_id      (:id @pulse-s)
+                                        :channel_type  :slack
+                                        :schedule_type :hourly))
+            ;; Only Lifeson and Lee are recipients in the source.
+            (reset! pcr1s  (ts/create! PulseChannelRecipient :pulse_channel_id (:id @pc1s) :user_id (:id @u1s)))
+            (reset! pcr2s  (ts/create! PulseChannelRecipient :pulse_channel_id (:id @pc1s) :user_id (:id @u2s)))
+            (reset! serialized (into [] (serdes.extract/extract-metabase {})))))
+
+        (testing "recipients are serialized as :recipients [email] on the PulseChannel"
+          (is (= #{["alifeson@rush.yyz" "glee@rush.yyz"]
+                   []}
+                 (set (map :recipients (by-model @serialized "PulseChannel"))))))
+
+        (testing "deserialization merges the existing recipients with the new ones"
+          (ts/with-dest-db
+            ;; Users in a different order, so different IDs.
+            (reset! u2d (ts/create! User :first_name "Geddy" :last_name "Lee"     :email "glee@rush.yyz"))
+            (reset! u1d (ts/create! User :first_name "Alex"  :last_name "Lifeson" :email "alifeson@rush.yyz"))
+            (reset! u3d (ts/create! User :first_name "Neil"  :last_name "Peart"   :email "neil@rush.yyz"))
+            (reset! pulse-d (ts/create! Pulse :name "Heartbeat" :creator_id (:id @u1d) :entity_id (:entity_id @pulse-s)))
+            (reset! pc1d    (ts/create! PulseChannel
+                                        :entity_id     (:entity_id @pc1s)
+                                        :pulse_id      (:id @pulse-d)
+                                        :channel_type  :email
+                                        :schedule_type :daily
+                                        :schedule_hour 16))
+            ;; Only Lee and Peart are recipients in the source.
+            (ts/create! PulseChannelRecipient :pulse_channel_id (:id @pc1d) :user_id (:id @u2d))
+            (ts/create! PulseChannelRecipient :pulse_channel_id (:id @pc1d) :user_id (:id @u3d))
+
+            (is (= 2 (db/count PulseChannelRecipient)))
+            (is (= #{(:id @u2d) (:id @u3d)}
+                   (db/select-field :user_id PulseChannelRecipient)))
+
+            (serdes.load/load-metabase (ingestion-in-memory @serialized))
+
+            (is (= 3 (db/count PulseChannelRecipient)))
+            (is (= #{(:id @u1d) (:id @u2d) (:id @u3d)}
+                   (db/select-field :user_id PulseChannelRecipient)))))))))

--- a/src/metabase/models/pulse.clj
+++ b/src/metabase/models/pulse.clj
@@ -26,7 +26,9 @@
             [metabase.models.pulse-card :refer [PulseCard]]
             [metabase.models.pulse-channel :as pulse-channel :refer [PulseChannel]]
             [metabase.models.pulse-channel-recipient :refer [PulseChannelRecipient]]
+            [metabase.models.serialization.base :as serdes.base]
             [metabase.models.serialization.hash :as serdes.hash]
+            [metabase.models.serialization.util :as serdes.util]
             [metabase.util :as u]
             [metabase.util.i18n :refer [deferred-tru tru]]
             [metabase.util.schema :as su]
@@ -561,3 +563,22 @@
   ;; fetch the fully updated pulse and return it (and fire off an event)
   (->> (retrieve-alert (u/the-id alert))
        (events/publish-event! :pulse-update)))
+
+;;; ------------------------------------------------- Serialization --------------------------------------------------
+
+(defmethod serdes.base/extract-one "Pulse"
+  [_model-name _opts pulse]
+  (cond-> (serdes.base/extract-one-basics "Pulse" pulse)
+    (:collection_id pulse) (update :collection_id serdes.util/export-fk 'Collection)
+    (:dashboard_id  pulse) (update :dashboard_id  serdes.util/export-fk 'Dashboard)
+    true                   (update :creator_id serdes.util/export-fk-keyed 'User :email)))
+
+(defmethod serdes.base/load-xform "Pulse" [pulse]
+  (cond-> (serdes.base/load-xform-basics pulse)
+      true                   (update :creator_id    serdes.util/import-fk-keyed 'User :email)
+      (:collection_id pulse) (update :collection_id serdes.util/import-fk 'Collection)
+      (:dashboard_id  pulse) (update :dashboard_id  serdes.util/import-fk 'Dashboard)))
+
+(defmethod serdes.base/serdes-dependencies "Pulse" [{:keys [collection_id dashboard_id]}]
+  (filterv some? [(when collection_id [{:model "Collection" :id collection_id}])
+                  (when dashboard_id  [{:model "Dashboard"  :id dashboard_id}])]))

--- a/src/metabase/models/pulse_card.clj
+++ b/src/metabase/models/pulse_card.clj
@@ -1,5 +1,7 @@
 (ns metabase.models.pulse-card
-  (:require [metabase.models.serialization.hash :as serdes.hash]
+  (:require [metabase.models.serialization.base :as serdes.base]
+            [metabase.models.serialization.hash :as serdes.hash]
+            [metabase.models.serialization.util :as serdes.util]
             [metabase.util :as u]
             [metabase.util.schema :as su]
             [schema.core :as s]
@@ -45,3 +47,44 @@
        :position          (u/or-with some? position (next-position-for pulse_id))
        :include_csv       (u/or-with some? include_csv false)
        :include_xls       (u/or-with some? include_xls false)})))
+
+; ----------------------------------------------------- Serialization -------------------------------------------------
+
+(defmethod serdes.base/serdes-entity-id "PulseCard" [_ {:keys [position]}]
+  (str position))
+
+(defmethod serdes.base/serdes-generate-path "PulseCard"
+  [_ {:keys [pulse_id] :as card}]
+  [(serdes.base/infer-self-path "Pulse" (db/select-one 'Pulse :id pulse_id))
+   (serdes.base/infer-self-path "PulseCard" card)])
+
+(defmethod serdes.base/extract-one "PulseCard"
+  [_model-name _opts card]
+  (cond-> (serdes.base/extract-one-basics "PulseCard" card)
+    true                      (update :card_id            serdes.util/export-fk 'Card)
+    true                      (update :pulse_id           serdes.util/export-fk 'Pulse)
+    (:dashboard_card_id card) (update :dashboard_card_id  serdes.util/export-fk 'DashboardCard)
+    ))
+
+(defmethod serdes.base/load-xform "PulseCard" [card]
+  (cond-> (serdes.base/load-xform-basics card)
+    true                      (update :card_id            serdes.util/import-fk 'Card)
+    true                      (update :pulse_id           serdes.util/import-fk 'Pulse)
+    (:dashboard_card_id card) (update :dashboard_card_id  serdes.util/import-fk 'DashboardCard)))
+
+;; TODO Using position as the ID for Pulses is not ideal - better to add an entity_id.
+(defmethod serdes.base/load-find-local "PulseCard"
+  [path]
+  (let [pulse-eid   (-> path first :id)
+        pulse       (serdes.base/lookup-by-id 'Pulse pulse-eid)
+        position    (-> path last :id)]
+    (db/select-one-field :id PulseCard :position position :pulse_id (:id pulse))))
+
+;; Depends on the Pulse, Card and (optional) dashboard card.
+(defmethod serdes.base/serdes-dependencies "PulseCard" [{:keys [card_id dashboard_card_id pulse_id]}]
+  (let [base [[{:model "Card" :id card_id}]
+              [{:model "Pulse" :id pulse_id}]]]
+    (if dashboard_card_id
+      (conj base [{:model "DashboardCard" :id dashboard_card_id}])
+      base)))
+;; START HERE: Add entity_id columns to PulseCard, PulseChannel.

--- a/test/metabase/test/generate.clj
+++ b/test/metabase/test/generate.clj
@@ -5,8 +5,8 @@
             [metabase.mbql.util :as mbql.u]
             [metabase.models :refer [Activity Card Collection Dashboard DashboardCard DashboardCardSeries Database
                                      Dimension Field Metric NativeQuerySnippet PermissionsGroup
-                                     PermissionsGroupMembership Pulse PulseCard PulseChannel Segment Table
-                                     Timeline TimelineEvent User]]
+                                     PermissionsGroupMembership Pulse PulseCard PulseChannel PulseChannelRecipient
+                                     Segment Table Timeline TimelineEvent User]]
             [reifyhealth.specmonstah.core :as rs]
             [reifyhealth.specmonstah.spec-gen :as rsg]
             [talltale.core :as tt]
@@ -157,6 +157,7 @@
 (s/def ::schedule_type ::not-empty-string)
 
 (s/def ::pulse-channel (s/keys :req-un [::id ::channel_type ::details ::schedule_type]))
+(s/def ::pulse-channel-recipient (s/keys :req-un [::id]))
 
 (s/def ::icon           (s/and ::name #(< (count %) 100)))
 (s/def ::time_matters   boolean?)
@@ -249,6 +250,11 @@
                                   :spec      ::pulse-channel
                                   :insert!   {:model PulseChannel}
                                   :relations {:pulse_id [:pulse :id]}}
+   :pulse-channel-recipient      {:prefix    :pcr
+                                  :spec      ::pulse-channel-recipient
+                                  :insert!   {:model PulseChannelRecipient}
+                                  :relations {:pulse_channel_id [:pulse-channel :id]
+                                              :user_id          [:core-user     :id]}}
    :timeline                     {:prefix    :timeline
                                   :spec      ::timeline
                                   :insert!   {:model Timeline}

--- a/test/metabase/test/generate.clj
+++ b/test/metabase/test/generate.clj
@@ -243,7 +243,8 @@
                                   :spec      ::pulse-card
                                   :insert!   {:model PulseCard}
                                   :relations {:pulse_id [:pulse :id]
-                                              :card_id  [:card :id]}}
+                                              :card_id  [:card :id]
+                                              :dashboard_card_id [:dashboard-card :id]}}
    :pulse-channel                {:prefix    :pulse-channel
                                   :spec      ::pulse-channel
                                   :insert!   {:model PulseChannel}


### PR DESCRIPTION
This uses the new `entity_id` columns added to `PulseCard` and `PulseChannel`.

Of particular interest is the way `PulseChannelRecipient`s are handled. Since
this is just a `(id, user_id, pulse_channel_id)` relationship, it's not worth
making it a full entity. Instead, it gets turned into `:recipients
["email@somewhere.com"]` on the `PulseChannel` and merged in on the receiving
end. There's a test for this merging behavior, see `load_test.clj`.
