### PR TITLE
Fix dashboard header button icons not centering on fullscreen

### DIFF
--- a/frontend/src/metabase/dashboard/containers/DashboardHeader.styled.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardHeader.styled.jsx
@@ -16,6 +16,7 @@ export const DashboardHeaderButton = styled(Button)`
   height: 2rem;
   width: 2rem;
   color: ${props => (props.isActive ? color("brand") : color("text-dark"))};
+  font-size: 1rem;
 
   &:hover {
     color: ${color("brand")};


### PR DESCRIPTION
Epic: #22826
Task: https://www.notion.so/metabase/Clean-up-common-actions-across-entities-4f00c1a0934249c68048d21ad949d7fa

This was due to the button getting different `font-size` when going fullscreen, and with different font-size than the icon size, the line-height cause the icon to shift down a bit.

https://github.com/metabase/metabase/blob/353e7097540859dc027f7bc4c9738f387297e664/frontend/src/metabase/css/dashboard.css#L276-L280

#### Before
![image](https://user-images.githubusercontent.com/1937582/180421429-a53df0f7-9a15-499e-ab33-cb6cd9be4a67.png)


#### After
![image](https://user-images.githubusercontent.com/1937582/180421382-d82766f0-5205-4236-9cd7-819f1e071545.png)
