### PR TITLE
Automerge backported PRs

### DIFF
--- a/.github/workflows/auto-backport.yml
+++ b/.github/workflows/auto-backport.yml
@@ -11,13 +11,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-
-      - uses: tibdex/github-app-token@v1
+      - uses: tibdex/github-app-token@v1.6.0
         id: generate-token
         with:
           app_id: ${{ secrets.METABASE_BOT_APP_ID }}
           private_key: ${{ secrets.METABASE_BOT_APP_PRIVATE_KEY }}
-
       - uses: ./.github/actions/find-squashed-commit
         name: Find commit
         id: find_commit
@@ -30,6 +28,7 @@ jobs:
         id: get_latest_release_branch
 
       - id: create_backport_pull_request
+        name: Create backport pull request
         run: |
           git config --global user.email "metabase-bot@metabase.com"
           git config --global user.name "Metabase bot"
@@ -53,15 +52,32 @@ jobs:
           git checkout master
           git push -u origin ${BACKPORT_BRANCH}
 
-          hub pull-request -b "${TARGET_BRANCH}" -h "${BACKPORT_BRANCH}" -l "auto-backported" -a "${GITHUB_ACTOR}" -F- <<<"🤖 backported \"${ORIGINAL_TITLE}\"
+          BACKPORT_PR_URL=$(hub pull-request -b "${TARGET_BRANCH}" -h "${BACKPORT_BRANCH}" -l "auto-backported,automerge" -a "${GITHUB_ACTOR}" -F- <<<"🤖 backported \"${ORIGINAL_TITLE}\"
 
-          #${ORIGINAL_PULL_REQUEST_NUMBER}"
+          #${ORIGINAL_PULL_REQUEST_NUMBER}")
+
+          BACKPORT_PR_NUMBER=${BACKPORT_PR_URL##*/}
+
+          echo "::set-output name=backport_pr_number::$BACKPORT_PR_NUMBER"
         env:
           TARGET_BRANCH: ${{ steps.get_latest_release_branch.outputs.branch-name }}
           ORIGINAL_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
           ORIGINAL_TITLE: ${{ github.event.pull_request.title }}
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           COMMIT: ${{ steps.find_commit.outputs.commit }}
+
+      - name: Auto approve backport PR
+        uses: juliangruber/approve-pull-request-action@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          number: ${{ steps.create_backport_pull_request.outputs.backport_pr_number }}
+
+      - name: Enable Pull Request Automerge
+        uses: peter-evans/enable-pull-request-automerge@v2
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          pull-request-number: ${{ steps.create_backport_pull_request.outputs.backport_pr_number }}
+          merge-method: squash
 
       - uses: ./.github/actions/notify-pull-request
         if: ${{ steps.create_backport_pull_request.outputs.has-conflicts == 'true' }}

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -23,7 +23,7 @@ jobs:
               echo User ${{ github.event.comment.user.login }} is not a member of Metabase organization
               exit 1
           fi
-      - uses: tibdex/github-app-token@v1
+      - uses: tibdex/github-app-token@v1.6.0
         id: generate-token
         with:
           app_id: ${{ secrets.METABASE_BOT_APP_ID }}
@@ -84,7 +84,9 @@ jobs:
         name: Cherry-pick commits and create PR
         with:
           fetch-depth: 0
-      - run: |
+      - id: create_backport_pull_request
+        name: Create backport pull request
+        run: |
           git config --global user.email "metabase-bot@metabase.com"
           git config --global user.name "Metabase bot"
 
@@ -109,9 +111,13 @@ jobs:
           if [[ $(hub pr list -b "${TARGET_BRANCH}" -h "${BACKPORT_BRANCH}" -s "open") ]]; then
               echo "PR already exists"
           else
-              hub pull-request -b "${TARGET_BRANCH}" -h "${BACKPORT_BRANCH}" -l "auto-backported" -a "${GITHUB_ACTOR}" -F- <<<"🤖 backported \"${ORIGINAL_TITLE}\"
+              BACKPORT_PR_URL=$(hub pull-request -b "${TARGET_BRANCH}" -h "${BACKPORT_BRANCH}" -l "auto-backported" -a "${GITHUB_ACTOR}" -F- <<<"🤖 backported \"${ORIGINAL_TITLE}\"
 
-              #${ORIGINAL_PULL_REQUEST_NUMBER}"
+              #${ORIGINAL_PULL_REQUEST_NUMBER}")
+
+              BACKPORT_PR_NUMBER=${BACKPORT_PR_URL##*/}
+
+              echo "::set-output name=backport_pr_number::$BACKPORT_PR_NUMBER"
               echo "New PR has been created"
           fi
         env:
@@ -126,6 +132,17 @@ jobs:
           START_SHA: ${{ fromJson(steps.branch_info.outputs.result).startSha }}
           END_SHA: ${{ fromJson(steps.branch_info.outputs.result).endSha }}
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+      - name: Auto approve backport PR
+        uses: juliangruber/approve-pull-request-action@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          number: ${{ steps.create_backport_pull_request.outputs.backport_pr_number }}
+      - name: Enable Pull Request Automerge
+        uses: peter-evans/enable-pull-request-automerge@v2
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          pull-request-number: ${{ steps.create_backport_pull_request.outputs.backport_pr_number }}
+          merge-method: squash
 
   notify_when_failed:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
## Changes

Update the backport workflows to automerge autobackported PRs.

### Required changes:
- Enable automerge on the repo level
- Make `release-*` branches protected
    - Mark checks as required that are considered by us as required

### How to verify
- Try the workflow on your repo or check [my fork](https://github.com/alxnddr/metabase/pull/125)