### PR TITLE
Serdes v2: Add `--v2 true` flag to the `dump` and `load` commands

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
@@ -3,6 +3,10 @@
   (:require [clojure.tools.logging :as log]
             [metabase-enterprise.serialization.dump :as dump]
             [metabase-enterprise.serialization.load :as load]
+            [metabase-enterprise.serialization.v2.extract :as v2.extract]
+            [metabase-enterprise.serialization.v2.ingest.yaml :as v2.ingest]
+            [metabase-enterprise.serialization.v2.load :as v2.load]
+            [metabase-enterprise.serialization.v2.storage.yaml :as v2.storage]
             [metabase.db :as mdb]
             [metabase.models.card :refer [Card]]
             [metabase.models.collection :refer [Collection]]
@@ -36,7 +40,7 @@
      (s/optional-key :mode)     Mode}
     (deferred-trs "invalid context seed value")))
 
-(s/defn load
+(s/defn v1-load
   "Load serialized metabase instance as created by `dump` command from directory `path`."
   [path context :- Context]
   (plugins/load-plugins!)               ;
@@ -62,6 +66,22 @@
       (catch Throwable e
         (log/error e (trs "ERROR LOAD from {0}: {1}" path (.getMessage e)))
         (throw e)))))
+
+(defn- v2-load
+  [path _args]
+  (plugins/load-plugins!)               ;
+  (mdb/setup-db!)
+  ; TODO This should be restored, but there's no manifest or other meta file written by v2 dumps.
+  ;(when-not (load/compatible? path)
+  ;  (log/warn (trs "Dump was produced using a different version of Metabase. Things may break!")))
+  (v2.load/load-metabase (v2.ingest/ingest-yaml path)))
+
+(defn load
+  "Load serialized metabase instance as created by `dump` command from directory `path`."
+  [path args]
+  (if (:v2 args)
+    (v2-load path args)
+    (v1-load path args)))
 
 (defn- select-entities-in-collections
   ([model collections]
@@ -115,48 +135,55 @@
            (into base-collections))))))
 
 
+(defn- v1-dump
+  [path state user opts]
+  (log/info (trs "BEGIN DUMP to {0} via user {1}" path user))
+  (let [users       (if user
+                      (let [user (db/select-one User
+                                                :email        user
+                                                :is_superuser true)]
+                        (assert user (trs "{0} is not a valid user" user))
+                        [user])
+                      [])
+        databases   (if (contains? opts :only-db-ids)
+                      (db/select Database :id [:in (:only-db-ids opts)] {:order-by [[:id :asc]]})
+                      (Database))
+        tables      (if (contains? opts :only-db-ids)
+                      (db/select Table :db_id [:in (:only-db-ids opts)] {:order-by [[:id :asc]]})
+                      (Table))
+        fields      (if (contains? opts :only-db-ids)
+                      (db/select Field :table_id [:in (map :id tables)] {:order-by [[:id :asc]]})
+                      (Field))
+        metrics     (if (contains? opts :only-db-ids)
+                      (db/select Metric :table_id [:in (map :id tables)] {:order-by [[:id :asc]]})
+                      (Metric))
+        collections (select-collections users state)]
+    (dump/dump path
+               databases
+               tables
+               (field/with-values fields)
+               metrics
+               (select-segments-in-tables tables state)
+               collections
+               (select-entities-in-collections NativeQuerySnippet collections state)
+               (select-entities-in-collections Card collections state)
+               (select-entities-in-collections Dashboard collections state)
+               (select-entities-in-collections Pulse collections state)
+               users))
+  (dump/dump-settings path)
+  (dump/dump-dependencies path)
+  (dump/dump-dimensions path)
+  (log/info (trs "END DUMP to {0} via user {1}" path user)))
+
+(defn- v2-dump [path opts]
+  (v2.storage/store! (v2.extract/extract-metabase opts) path))
+
 (defn dump
   "Serialized metabase instance into directory `path`."
-  ([path user]
-   (dump path user :active {}))
-  ([path user opts]
-   (dump path user :active opts))
-  ([path user state opts]
-   (mdb/setup-db!)
-   (log/info (trs "BEGIN DUMP to {0} via user {1}" path user))
-   (let [users       (if user
-                       (let [user (db/select-one User
-                                    :email        user
-                                    :is_superuser true)]
-                         (assert user (trs "{0} is not a valid user" user))
-                         [user])
-                       [])
-         databases   (if (contains? opts :only-db-ids)
-                       (db/select Database :id [:in (:only-db-ids opts)] {:order-by [[:id :asc]]})
-                       (Database))
-         tables      (if (contains? opts :only-db-ids)
-                       (db/select Table :db_id [:in (:only-db-ids opts)] {:order-by [[:id :asc]]})
-                       (Table))
-         fields      (if (contains? opts :only-db-ids)
-                       (db/select Field :table_id [:in (map :id tables)] {:order-by [[:id :asc]]})
-                       (Field))
-         metrics     (if (contains? opts :only-db-ids)
-                       (db/select Metric :table_id [:in (map :id tables)] {:order-by [[:id :asc]]})
-                       (Metric))
-         collections (select-collections users state)]
-     (dump/dump path
-                databases
-                tables
-                (field/with-values fields)
-                metrics
-                (select-segments-in-tables tables state)
-                collections
-                (select-entities-in-collections NativeQuerySnippet collections state)
-                (select-entities-in-collections Card collections state)
-                (select-entities-in-collections Dashboard collections state)
-                (select-entities-in-collections Pulse collections state)
-                users))
-   (dump/dump-settings path)
-   (dump/dump-dependencies path)
-   (dump/dump-dimensions path)
-   (log/info (trs "END DUMP to {0} via user {1}" path user))))
+  [path {:keys [state user v2]
+         :or {state :active}
+         :as opts}]
+  (mdb/setup-db!) (db/select 'User)
+  (if v2
+    (v2-dump path opts)
+    (v1-dump path state user opts)))

--- a/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
@@ -43,7 +43,7 @@
 (s/defn v1-load
   "Load serialized metabase instance as created by `dump` command from directory `path`."
   [path context :- Context]
-  (plugins/load-plugins!)               ;
+  (plugins/load-plugins!)
   (mdb/setup-db!)
   (when-not (load/compatible? path)
     (log/warn (trs "Dump was produced using a different version of Metabase. Things may break!")))
@@ -69,7 +69,7 @@
 
 (defn- v2-load
   [path _args]
-  (plugins/load-plugins!)               ;
+  (plugins/load-plugins!)
   (mdb/setup-db!)
   ; TODO This should be restored, but there's no manifest or other meta file written by v2 dumps.
   ;(when-not (load/compatible? path)

--- a/enterprise/backend/test/metabase_enterprise/serialization/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/load_test.clj
@@ -299,7 +299,8 @@
                                                              table-id-categories
                                                              table-id-users
                                                              table-id-checkins])
-                          (dump dump-dir (:email (test.users/fetch-user :crowberto)) {:only-db-ids #{db-id}})
+                          (dump dump-dir {:user        (:email (test.users/fetch-user :crowberto))
+                                          :only-db-ids #{db-id}})
                           {:query-results (gather-orig-results [card-id
                                                                 card-arch-id
                                                                 card-id-root

--- a/src/metabase/cmd.clj
+++ b/src/metabase/cmd.clj
@@ -151,9 +151,8 @@
   `active` (default), `all`. With `active` option, do not dump archived entities."
   ([path] (dump path {"--state" :active}))
   ([path & args]
-   (let [cmd (resolve-enterprise-command 'metabase-enterprise.serialization.cmd/dump)
-         {:keys [user]} (cmd-args->map args)]
-     (cmd path user))))
+   (let [cmd (resolve-enterprise-command 'metabase-enterprise.serialization.cmd/dump)]
+     (cmd path (cmd-args->map args)))))
 
 (defn ^:command rotate-encryption-key
   "Rotate the encryption key of a metabase database. The MB_ENCRYPTION_SECRET_KEY environment variable has to be set to

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -441,6 +441,7 @@
 (defmethod serdes.base/load-xform "Dashboard"
   [dash]
   (-> dash
+      serdes.base/load-xform-basics
       (update :collection_id serdes.util/import-fk 'Collection)
       (update :creator_id    serdes.util/import-fk-keyed 'User :email)))
 


### PR DESCRIPTION
This is the last piece for end-to-end serialization and deserialization.
The results should be similar to v1, though probably not identical.

