### PR TITLE
Formatting for basic relative date parameters in markdown cards

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard/text-parameters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/text-parameters.cy.spec.js
@@ -70,7 +70,7 @@ describe("scenarios > dashboard > parameters in text cards", () => {
 
     addTextBox("Variable: {{foo}}", { parseSpecialCharSequences: false });
     editDashboard();
-    setFilter("Number", "Equal to");
+    setFilter("Time", "Relative Date");
 
     cy.findByText("Select…").click();
     cy.findByText("foo").click();
@@ -78,12 +78,10 @@ describe("scenarios > dashboard > parameters in text cards", () => {
 
     filterWidget().click();
     popover().within(() => {
-      cy.findByRole("textbox").type(`1{enter}`);
-      cy.findByRole("textbox").click().type("2{enter}");
-      cy.button("Add filter").click();
+      cy.findByText("Today").click();
     });
 
-    cy.findByText("Variable: 1 et 2").should("exist");
+    cy.findByText("Variable: Aujourd'hui").should("exist");
 
     // Let's make sure the localization was reset back to the user locale by checking that specific text exists in
     // English on the homepage.

--- a/shared/src/metabase/shared/parameters/parameters.cljc
+++ b/shared/src/metabase/shared/parameters/parameters.cljc
@@ -94,12 +94,11 @@
     #"^past1days$"                         (trs "Yesterday")
     #"^next1days$"                         (trs "Tomorrow")
     #"^(past|next)([0-9]+)([a-z]+)~?$" :>> (fn [[prefix n interval]]
-                                             (let [prefix   (case prefix
-                                                              "past" (trs "Previous")
-                                                              "next" (trs "Next"))
-                                                   n        (when (not= n "1") n)
+                                             (let [n        (when (not= n "1") n)
                                                    interval (time-intervals interval (boolean n))]
-                                               (str prefix " " n " " interval)))))
+                                               (case prefix
+                                                 "past" (trs "Previous {0} {1}" n interval)
+                                                 "next" (trs "Next {0} {1}" n interval))))))
 
 (defmethod formatted-value :date/all-options
   [_ value locale]
@@ -118,7 +117,7 @@
   [values]
   (if (= (count values) 1)
     (str (first values))
-    (str (str/join ", " (butlast values)) (trs " and ") (last values))))
+    (trs "{0} and {1}" (str/join ", " (butlast values)) (last values))))
 
 (defmethod formatted-value :default
   [_ value _]

--- a/shared/src/metabase/shared/parameters/parameters.cljc
+++ b/shared/src/metabase/shared/parameters/parameters.cljc
@@ -65,19 +65,18 @@
 
 (defn- translated-interval
   [interval n]
-  (get
-   {"minutes"  (trsn "Minute" "Minutes" n)
+  (case interval
+    "minutes"  (trsn "Minute" "Minutes" n)
     "hours"    (trsn "Hour" "Hours" n)
     "days"     (trsn "Day" "Days" n)
     "weeks"    (trsn "Week" "Weeks" n)
     "months"   (trsn "Month" "Months" n)
     "quarters" (trsn "Quarter" "Quarters" n)
-    "years"    (trsn "Year" "Years" n)}
-   interval))
+    "years"    (trsn "Year" "Years" n)))
 
 (defn- format-relative-date
   [prefix n interval]
-  (let [n        #?(:clj (Integer. ^String n) :cljs (js/parseInt n))
+  (let [n        #?(:clj (Integer/valueOf ^String n) :cljs (js/parseInt n))
         interval (translated-interval interval n)]
     (case [prefix (= n 1)]
       ["past" true]  (trs "Previous {0}" interval)

--- a/shared/src/metabase/shared/parameters/parameters.cljc
+++ b/shared/src/metabase/shared/parameters/parameters.cljc
@@ -77,7 +77,7 @@
 
 (defn- format-relative-date
   [prefix n interval]
-  (let [n        #?(:clj (Integer. n) :cljs (js/parseInt n))
+  (let [n        #?(:clj (Integer. ^String n) :cljs (js/parseInt n))
         interval (translated-interval interval n)]
     (case [prefix (= n 1)]
       ["past" true]  (trs "Previous {0}" interval)

--- a/shared/src/metabase/shared/parameters/parameters.cljc
+++ b/shared/src/metabase/shared/parameters/parameters.cljc
@@ -38,7 +38,7 @@
      :clj  (u.date/format "MMMM, yyyy" (u.date/parse value) locale)))
 
 #?(:clj
-    (def ^:private quarter-formatter-in
+   (def ^:private quarter-formatter-in
      (b/formatter
       "Q" (b/value :iso/quarter-of-year 1) "-" (b/value :year 4))))
 

--- a/shared/src/metabase/shared/parameters/parameters.cljc
+++ b/shared/src/metabase/shared/parameters/parameters.cljc
@@ -63,29 +63,10 @@
            (formatted-value :date/single end locale))
       "")))
 
-; (defn- time-intervals-2
-;   [interval plural?]
-;   (get
-;    {["minutes" false]  (trs "Minute")
-;     ["minutes" true]   (trs "Minutes")
-;     ["hours" false]    (trs "Hour")
-;     ["hours" true]     (trs "Hours")
-;     ["days" false]     (trs "Day")
-;     ["days" true]      (trs "Days")
-;     ["weeks" false]    (trs "Week")
-;     ["weeks" true]     (trs "Weeks")
-;     ["months" false]   (trs "Month")
-;     ["months" true]    (trs "Months")
-;     ["quarters" false] (trs "Quarter")
-;     ["quarters" true]  (trs "Quarters")
-;     ["years" false]    (trs "Year")
-;     ["years" true]     (trs "Years")}
-;    [interval plural?]))
-
 (defn- translated-interval
   [interval n]
   (get
-   {"minutes"  (trsn "Minute{0}" "Minutes" n)
+   {"minutes"  (trsn "Minute" "Minutes" n)
     "hours"    (trsn "Hour" "Hours" n)
     "days"     (trsn "Day" "Days" n)
     "weeks"    (trsn "Week" "Weeks" n)
@@ -93,6 +74,16 @@
     "quarters" (trsn "Quarter" "Quarters" n)
     "years"    (trsn "Year" "Years" n)}
    interval))
+
+(defn- format-relative-date
+  [prefix n interval]
+  (let [n        #?(:clj (Integer. n) :cljs (js/parseInt n))
+        interval (translated-interval interval n)]
+    (case [prefix (= n 1)]
+      ["past" true]  (trs "Previous {0}" interval)
+      ["past" false] (trs "Previous {0} {1}" n interval)
+      ["next" true]  (trs "Next {0}" interval)
+      ["next" false] (trs "Next {0} {1}" n interval))))
 
 (defmethod formatted-value :date/relative
   [_ value _]
@@ -105,12 +96,7 @@
     #"^thisyear$"                          (trs "This Year")
     #"^past1days$"                         (trs "Yesterday")
     #"^next1days$"                         (trs "Tomorrow")
-    #"^(past|next)([0-9]+)([a-z]+)~?$" :>> (fn [[prefix n interval]]
-                                             (let [n        #?(:clj (Integer. n) :cljs(js/parseInt n))
-                                                   interval (translated-interval interval n)]
-                                                 (case prefix
-                                                   "past" (trs "Previous {0} {1}" n interval)
-                                                   "next" (trs "Next {0} {1}" n interval))))))
+    #"^(past|next)([0-9]+)([a-z]+)~?$" :>> (fn [matches] (apply format-relative-date matches))))
 
 (defmethod formatted-value :date/all-options
   [_ value locale]

--- a/shared/src/metabase/shared/util/i18n.clj
+++ b/shared/src/metabase/shared/util/i18n.clj
@@ -33,3 +33,14 @@
 
     :cljs
     `(js-i18n ~format-string ~@args)))
+
+(defmacro trsn
+  [format-string format-string-pl n]
+  (macros/case
+    :clj
+    (do
+      (require 'metabase.util.i18n)
+      `(metabase.util.i18n/trsn ~format-string ~format-string-pl ~n))
+
+    :cljs
+    `(js-i18n-n ~format-string ~format-string-pl ~n)))

--- a/shared/src/metabase/shared/util/i18n.clj
+++ b/shared/src/metabase/shared/util/i18n.clj
@@ -35,6 +35,9 @@
     `(js-i18n ~format-string ~@args)))
 
 (defmacro trsn
+  "i18n a string with both singular and plural forms, using the site's locale. The appropriate plural form will be
+  returned based on the value of `n`. `n` can be interpolated into the format strings using the `{0}` syntax. (Other
+  placeholders are not supported). "
   [format-string format-string-pl n]
   (macros/case
     :clj

--- a/shared/src/metabase/shared/util/i18n.cljs
+++ b/shared/src/metabase/shared/util/i18n.cljs
@@ -1,5 +1,7 @@
 (ns metabase.shared.util.i18n
-  (:require ["ttag" :as ttag])
+  (:require ["ttag" :as ttag]
+            [clojure.string :as str]
+            [shadow.cljs.modern :refer [js-template]])
   (:require-macros metabase.shared.util.i18n))
 
 (comment metabase.shared.util.i18n/keep-me
@@ -8,4 +10,5 @@
 (defn js-i18n
   "Format an i18n `format-string` with `args` with a translated string in the user locale."
   [format-string & args]
-  (apply ttag/gettext format-string args))
+  (let [strings (str/split format-string #"\{\d+\}")]
+    (apply ttag/t (clj->js strings) (clj->js args))))

--- a/shared/src/metabase/shared/util/i18n.cljs
+++ b/shared/src/metabase/shared/util/i18n.cljs
@@ -1,7 +1,6 @@
 (ns metabase.shared.util.i18n
   (:require ["ttag" :as ttag]
-            [clojure.string :as str]
-            [shadow.cljs.modern :refer [js-template]])
+            [clojure.string :as str])
   (:require-macros metabase.shared.util.i18n))
 
 (comment metabase.shared.util.i18n/keep-me
@@ -12,3 +11,14 @@
   [format-string & args]
   (let [strings (str/split format-string #"\{\d+\}")]
     (apply ttag/t (clj->js strings) (clj->js args))))
+
+(defn js-i18n-n
+  "Format an i18n `format-string` with the appropritae plural form based on the value `n`.
+   Allows `n` to be interpolated into the string using {0}."
+  [format-string format-string-pl n]
+  (let [strings (str/split format-string #"\{0\}")
+        strings (if (= (count strings) 1) [format-string ""] strings)
+        has-n?  (re-find #".*\{0\}.*" format-string)]
+    (ttag/ngettext (ttag/msgid (clj->js strings) (if has-n? n ""))
+                   format-string-pl
+                   n)))

--- a/shared/test/metabase/shared/parameters/parameters_test.cljc
+++ b/shared/test/metabase/shared/parameters/parameters_test.cljc
@@ -93,7 +93,7 @@
 
       "{{foo}}"
       {"foo" {:type :date/relative :value "past7days"}}
-      "Past 7 Days"
+      "Previous 7 Days"
 
       "{{foo}}"
       {"foo" {:type :date/relative :value "thismonth"}}

--- a/shared/test/metabase/shared/parameters/parameters_test.cljc
+++ b/shared/test/metabase/shared/parameters/parameters_test.cljc
@@ -1,7 +1,6 @@
 (ns metabase.shared.parameters.parameters-test
   (:require [clojure.test :as t]
-            [metabase.shared.parameters.parameters :as params]
-            [metabase.test :as mt]))
+            [metabase.shared.parameters.parameters :as params]))
 
 (defn- tag-names
   [text]
@@ -220,30 +219,7 @@
 
       "{{foo}}"
       {"foo" {:type :date/month-year :value "2019-08"}}
-      "agosto\\, 2019"))
-
-  (t/testing "Relative date values are formatted using the site locale"
-    (mt/with-temporary-setting-values [site-locale "es"]
-      (t/are [text tag->param expected] (= expected (params/substitute_tags text tag->param))
-        "{{foo}}"
-        {"foo" {:type :date/all-options :value "thisday"}}
-        "Hoy"
-
-        "{{foo}}"
-        {"foo" {:type :date/all-options :value "past1weeks"}}
-        "Anterior Semana"
-
-        "{{foo}}"
-        {"foo" {:type :date/all-options :value "next1quarters"}}
-        "Siguiente Trimestre"
-
-        "{{foo}}"
-        {"foo" {:type :date/all-options :value "past60minutes"}}
-        "Anterior 60 Minuto"
-
-        "{{foo}}"
-        {"foo" {:type :date/all-options :value "next5years"}}
-        "Next 5 Año"))))
+      "agosto\\, 2019")))
 
 (t/deftest substitute-tags-optional-blocks-test
   (t/testing "Optional blocks are removed when necessary"


### PR DESCRIPTION
This PR adds support for proper formatting and translation of basic relative date values in Markdown cards. "Basic" means values like `Last week`, `Next 30 days`, etc. This doesn't include values with an offset (e.g. `Previous 30 days, starting 30 days ago`) or "exclude" filters.

This builds on top of the pluralization work that I previously landed, and uses the `trsn` macro. I've added a new version of this macro in the shared i18n code, which in CLJS is powered by a new `js-i18n-n` function which is essentially a wrapper around ttag's `ngettext`.

This should currently work as expected on the FE (i.e. when viewing a dashboard) but translations may not be correct in dashboard subscriptions. This is because these strings were not present in any BE files before now, so we'll need to go through the translation process for the next release before they're available in the BE localization bundles. This also makes it very difficult to write a shared test for the translation behavior, so I've just tested the formatting logic in English for now.