### PR TITLE
Show Empty/Not Empty Date Filters

### DIFF
--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterSelect/BulkFilterSelect.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterSelect/BulkFilterSelect.tsx
@@ -7,7 +7,7 @@ import StructuredQuery, {
 
 import Filter from "metabase-lib/lib/queries/structured/Filter";
 import Dimension from "metabase-lib/lib/Dimension";
-import { isBoolean } from "metabase/lib/schema_metadata";
+import { isBoolean, isDate } from "metabase/lib/schema_metadata";
 
 import TippyPopoverWithTrigger from "metabase/components/PopoverWithTrigger/TippyPopoverWithTrigger";
 import { DateShortcutOptions } from "metabase/query_builder/components/filters/pickers/DatePicker/DatePickerShortcutOptions";
@@ -48,12 +48,13 @@ export const BulkFilterSelect = ({
     return getNewFilter(query, dimension);
   }, [query, dimension]);
 
-  const hideArgumentSelector = [
-    "is-null",
-    "not-null",
-    "is-empty",
-    "not-empty",
-  ].includes(filter?.operatorName());
+  const isDateField = useMemo(() => isDate(dimension?.field()), [dimension]);
+
+  const hideArgumentSelector =
+    !isDateField &&
+    ["is-null", "not-null", "is-empty", "not-empty"].includes(
+      filter?.operatorName(),
+    );
 
   if (hideArgumentSelector) {
     return null;


### PR DESCRIPTION
## Before

Adding an empty/not empty date filter would show up empty 😢 

![emptydateBad](https://user-images.githubusercontent.com/30528226/180573648-1c4aa512-c2bb-4fb1-a8d4-3a786b6cab0b.gif)


## Changes

Update InlineValuePicker to show for date fields.

## After

![Screen Shot 2022-07-22 at 3 46 01 PM](https://user-images.githubusercontent.com/30528226/180573018-d5c41a74-2972-46b1-8b87-995517203310.png) ![Screen Shot 2022-07-22 at 3 45 56 PM](https://user-images.githubusercontent.com/30528226/180573020-2bdd6c0f-b269-4ca9-921c-db2f67041636.png)

## How to test

- Open the filter modal on a table with date fields (like orders)
- Click on `...` > `Exclude` > `Is Empty`
- You should see "is not empty" - it's backwards because you're excluding

