### PR TITLE
Fix NaN in filter when beyond practicable times

### DIFF
--- a/frontend/src/metabase/lib/time.js
+++ b/frontend/src/metabase/lib/time.js
@@ -210,3 +210,11 @@ export function hasTimePart(date) {
 export function getDefaultTimezone() {
   return moment.tz.guess();
 }
+
+export function checkIfTimeSpanTooGreat(amount, key) {
+  const now = moment();
+  const newTime = moment().add(amount, key);
+  const diff = now.diff(newTime, "years");
+
+  return Number.isNaN(diff);
+}

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RelativeDatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RelativeDatePicker.tsx
@@ -173,7 +173,7 @@ const RelativeDatePicker: React.FC<RelativeDatePickerProps> = props => {
 
   const checkIfTimeDistanceTooGreat = (intervals: number, unit: string) => {
     const now = moment();
-    const newTime = moment().add(Math.abs(intervals), unit);
+    const newTime = moment().add(intervals as any, unit);
     const diff = now.diff(newTime, "years");
 
     return Number.isNaN(diff);
@@ -223,7 +223,7 @@ const RelativeDatePicker: React.FC<RelativeDatePickerProps> = props => {
       <DateUnitSelector
         value={unit}
         primaryColor={primaryColor}
-        onChange={handleChangeUnitInput}
+        onChange={newUnit => handleChangeUnitInput(newUnit as string)}
         testId="relative-datetime-unit"
         intervals={intervals}
         formatter={formatter}

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RelativeDatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RelativeDatePicker.tsx
@@ -171,27 +171,34 @@ const RelativeDatePicker: React.FC<RelativeDatePickerProps> = props => {
     <OptionsContent {...props} setOptionsVisible={setOptionsVisible} />
   );
 
-  const checkIfTimeDistanceTooGreat = (newValue: number, unit: string) => {
-    const maxDistanceInYears = 10;
-
+  const checkIfTimeDistanceTooGreat = (intervals: number, unit: string) => {
     const now = moment();
-    const newTime = now.clone().add(newValue, unit);
+    const newTime = moment().add(Math.abs(intervals), unit);
     const diff = now.diff(newTime, "years");
 
-    return Math.abs(diff) > maxDistanceInYears;
+    return Number.isNaN(diff);
   };
 
-  const handleChangeDateNumericInput = (
-    currentValue: number,
-    newValue: number,
-  ) => {
-    const timeDistanceTooGreat = checkIfTimeDistanceTooGreat(newValue, unit);
+  const handleChangeDateNumericInput = (newIntervals: number) => {
+    const timeDistanceTooGreat = checkIfTimeDistanceTooGreat(
+      newIntervals,
+      unit,
+    );
 
-    const valueToUse = timeDistanceTooGreat ? currentValue : newValue;
+    const valueToUse = timeDistanceTooGreat ? intervals : newIntervals;
 
     onFilterChange(setRelativeDatetimeValue(filter, formatter(valueToUse)));
+  };
 
-    return false;
+  const handleChangeUnitInput = (newUnit: string) => {
+    const timeDistanceTooGreat = checkIfTimeDistanceTooGreat(
+      intervals,
+      newUnit,
+    );
+
+    const unitToUse = timeDistanceTooGreat ? unit : newUnit;
+
+    onFilterChange(setRelativeDatetimeUnit(filter, unitToUse));
   };
 
   return (
@@ -210,17 +217,13 @@ const RelativeDatePicker: React.FC<RelativeDatePickerProps> = props => {
         data-ui-tag="relative-date-input"
         data-testid="relative-datetime-value"
         value={typeof intervals === "number" ? Math.abs(intervals) : intervals}
-        onChange={(newValue: number) =>
-          handleChangeDateNumericInput(intervals, newValue)
-        }
+        onChange={handleChangeDateNumericInput}
         placeholder="30"
       />
       <DateUnitSelector
         value={unit}
         primaryColor={primaryColor}
-        onChange={value => {
-          onFilterChange(setRelativeDatetimeUnit(filter, value));
-        }}
+        onChange={handleChangeUnitInput}
         testId="relative-datetime-unit"
         intervals={intervals}
         formatter={formatter}

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RelativeDatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RelativeDatePicker.tsx
@@ -13,6 +13,7 @@ import {
   setStartingFrom,
   toTimeInterval,
 } from "metabase/lib/query_time";
+import { getRelativeTime } from "metabase/lib/time";
 import TippyPopover from "metabase/components/Popover/TippyPopover";
 
 import Filter from "metabase-lib/lib/queries/structured/Filter";
@@ -170,6 +171,29 @@ const RelativeDatePicker: React.FC<RelativeDatePickerProps> = props => {
     <OptionsContent {...props} setOptionsVisible={setOptionsVisible} />
   );
 
+  const checkIfTimeDistanceTooGreat = (newValue: number, unit: string) => {
+    const maxDistanceInYears = 10;
+
+    const now = moment();
+    const newTime = now.clone().add(newValue, unit);
+    const diff = now.diff(newTime, "years");
+
+    return Math.abs(diff) > maxDistanceInYears;
+  };
+
+  const handleChangeDateNumericInput = (
+    currentValue: number,
+    newValue: number,
+  ) => {
+    const timeDistanceTooGreat = checkIfTimeDistanceTooGreat(newValue, unit);
+
+    const valueToUse = timeDistanceTooGreat ? currentValue : newValue;
+
+    onFilterChange(setRelativeDatetimeValue(filter, formatter(valueToUse)));
+
+    return false;
+  };
+
   return (
     <GridContainer
       className={className}
@@ -186,9 +210,9 @@ const RelativeDatePicker: React.FC<RelativeDatePickerProps> = props => {
         data-ui-tag="relative-date-input"
         data-testid="relative-datetime-value"
         value={typeof intervals === "number" ? Math.abs(intervals) : intervals}
-        onChange={(value: number) => {
-          onFilterChange(setRelativeDatetimeValue(filter, formatter(value)));
-        }}
+        onChange={(newValue: number) =>
+          handleChangeDateNumericInput(intervals, newValue)
+        }
         placeholder="30"
       />
       <DateUnitSelector

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RelativeDatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RelativeDatePicker.tsx
@@ -171,7 +171,7 @@ const RelativeDatePicker: React.FC<RelativeDatePickerProps> = props => {
     <OptionsContent {...props} setOptionsVisible={setOptionsVisible} />
   );
 
-  const checkIfTimeDistanceTooGreat = (intervals: number, unit: string) => {
+  const checkIfTimeSpanTooGreat = (intervals: number, unit: string) => {
     const now = moment();
     const newTime = moment().add(intervals as any, unit);
     const diff = now.diff(newTime, "years");
@@ -180,23 +180,15 @@ const RelativeDatePicker: React.FC<RelativeDatePickerProps> = props => {
   };
 
   const handleChangeDateNumericInput = (newIntervals: number) => {
-    const timeDistanceTooGreat = checkIfTimeDistanceTooGreat(
-      newIntervals,
-      unit,
-    );
-
-    const valueToUse = timeDistanceTooGreat ? intervals : newIntervals;
+    const timeSpanTooGreat = checkIfTimeSpanTooGreat(newIntervals, unit);
+    const valueToUse = timeSpanTooGreat ? intervals : newIntervals;
 
     onFilterChange(setRelativeDatetimeValue(filter, formatter(valueToUse)));
   };
 
   const handleChangeUnitInput = (newUnit: string) => {
-    const timeDistanceTooGreat = checkIfTimeDistanceTooGreat(
-      intervals,
-      newUnit,
-    );
-
-    const unitToUse = timeDistanceTooGreat ? unit : newUnit;
+    const timeSpanTooGreat = checkIfTimeSpanTooGreat(intervals, newUnit);
+    const unitToUse = timeSpanTooGreat ? unit : newUnit;
 
     onFilterChange(setRelativeDatetimeUnit(filter, unitToUse));
   };

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RelativeDatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RelativeDatePicker.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable react/prop-types */
 import React from "react";
 import { t } from "ttag";
-import moment from "moment";
 import { assoc } from "icepick";
 
 import {
@@ -13,7 +12,7 @@ import {
   setStartingFrom,
   toTimeInterval,
 } from "metabase/lib/query_time";
-import { getRelativeTime } from "metabase/lib/time";
+import { checkIfTimeSpanTooGreat, getRelativeTime } from "metabase/lib/time";
 import TippyPopover from "metabase/components/Popover/TippyPopover";
 
 import Filter from "metabase-lib/lib/queries/structured/Filter";
@@ -170,14 +169,6 @@ const RelativeDatePicker: React.FC<RelativeDatePickerProps> = props => {
   const optionsContent = (
     <OptionsContent {...props} setOptionsVisible={setOptionsVisible} />
   );
-
-  const checkIfTimeSpanTooGreat = (intervals: number, unit: string) => {
-    const now = moment();
-    const newTime = moment().add(intervals as any, unit);
-    const diff = now.diff(newTime, "years");
-
-    return Number.isNaN(diff);
-  };
 
   const handleChangeDateNumericInput = (newIntervals: number) => {
     const timeSpanTooGreat = checkIfTimeSpanTooGreat(newIntervals, unit);

--- a/frontend/test/metabase/lib/time.unit.spec.js
+++ b/frontend/test/metabase/lib/time.unit.spec.js
@@ -1,4 +1,5 @@
 import {
+  checkIfTimeSpanTooGreat,
   parseTime,
   parseTimestamp,
   getRelativeTimeAbbreviated,
@@ -149,6 +150,18 @@ describe("time", () => {
       it(`returns ${expected} for ${value}`, () => {
         expect(hoursToSeconds(value)).toBe(expected);
       });
+    });
+  });
+
+  describe("checkIfTimeSpanTooGreat", () => {
+    it(`returns false for small time spans`, () => {
+      const isTimeSpanTooGreat = checkIfTimeSpanTooGreat(10, "days");
+      expect(isTimeSpanTooGreat).toBeFalsy();
+    });
+
+    it(`returns truthy for large time spans`, () => {
+      const isTimeSpanTooGreat = checkIfTimeSpanTooGreat(1000000000, "years");
+      expect(isTimeSpanTooGreat).toBeTruthy();
     });
   });
 });


### PR DESCRIPTION
Fixes #24183

Solves issues were time filters with spans beyond what moment.js (or is it UNIX time?) can handle ended up displaying NaN in the time ranges.

### How to Test:

1. `+ New`
2. Question
3. Products
4. Add filters to narrow your answer
5. Created At
6. Last Month
7. Created At Previous Month

#### Valid input 

1. In the input that says `1` next to `month`, fill in, say 10
2. Tab or click away from input

Input number should be updated to `10` and unit input should be updated to `months` in the plural form.

#### Invalid input (time span too great)

1. In the input that said `1` next to `month`, fill in, say 1000000000000
2. Tab or click away from input

Input number should be reverted to the previously input number.
Thus, `NaN` should no longer be displayed in the date range below the inputs

🎗️ Same should happen if, in the filter popover, we switch from `Past` to `Next`.

##### Notes

I've experimented with showing error messages here.
Could be. However:
1. this popover is tight as it is
2. the components we use for input do not drill prop error messages in their current form
3. the input of one million years as a date range may be considered egregious and rare (although in fairness we may be serving universe-age-query-type customers) 

##### Screenshots

<img width="373" alt="image" src="https://user-images.githubusercontent.com/380816/180819276-558112d3-968b-4ebb-9aa4-ef5ee3036b72.png">

