### PR TITLE
Set timezone when truncating dates

### DIFF
--- a/frontend/test/metabase/scenarios/visualizations/reproductions/16170-line-mongo-replace-missing-values.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/reproductions/16170-line-mongo-replace-missing-values.cy.spec.js
@@ -34,7 +34,7 @@ describe("issue 16170", () => {
       cy.get(".dot").eq(-2).trigger("mousemove", { force: true });
 
       popover().within(() => {
-        testPairedTooltipValues("Created At", "2018");
+        testPairedTooltipValues("Created At", "2019");
         testPairedTooltipValues("Count", "6,578");
       });
     });

--- a/frontend/test/metabase/scenarios/visualizations/reproductions/16170-line-mongo-replace-missing-values.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/reproductions/16170-line-mongo-replace-missing-values.cy.spec.js
@@ -35,7 +35,7 @@ describe("issue 16170", () => {
 
       popover().within(() => {
         testPairedTooltipValues("Created At", "2019");
-        testPairedTooltipValues("Count", "6,578");
+        testPairedTooltipValues("Count", "6,524");
       });
     });
   });

--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -123,13 +123,13 @@
   (let [field-name (str \$ (field->name field "."))]
     (cond
       (isa? coercion :Coercion/UNIXMicroSeconds->DateTime)
-      {:$dateFromParts {:millisecond {$divide [field-name 1000]}, :year 1970}}
+      {:$dateFromParts {:millisecond {$divide [field-name 1000]}, :year 1970, :timezone "UTC"}}
 
       (isa? coercion :Coercion/UNIXMilliSeconds->DateTime)
-      {:$dateFromParts {:millisecond field-name, :year 1970}}
+      {:$dateFromParts {:millisecond field-name, :year 1970, :timezone "UTC"}}
 
       (isa? coercion :Coercion/UNIXSeconds->DateTime)
-      {:$dateFromParts {:second field-name, :year 1970}}
+      {:$dateFromParts {:second field-name, :year 1970, :timezone "UTC"}}
 
       (isa? coercion :Coercion/YYYYMMDDHHMMSSString->Temporal)
       {"$dateFromString" {:dateString field-name

--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -181,11 +181,13 @@
                           (* 24 60 60 1000)]}]})
 
 (defn- truncate-to-resolution [column resolution]
-  (mongo-let [parts {:$dateToParts {:date column}}]
-    {:$dateFromParts (into {} (for [part (concat (take-while (partial not= resolution)
-                                                             [:year :month :day :hour :minute :second :millisecond])
-                                                 [resolution])]
-                                [part (str (name parts) \. (name part))]))}))
+  (mongo-let [parts {:$dateToParts {:timezone (qp.timezone/results-timezone-id)
+                                    :date column}}]
+    {:$dateFromParts (into {:timezone (qp.timezone/results-timezone-id)}
+                           (for [part (concat (take-while (partial not= resolution)
+                                                          [:year :month :day :hour :minute :second :millisecond])
+                                              [resolution])]
+                             [part (str (name parts) \. (name part))]))}))
 
 (defn- with-rvalue-temporal-bucketing
   [field unit]

--- a/modules/drivers/mongo/test/metabase/driver/mongo/query_processor_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo/query_processor_test.clj
@@ -118,6 +118,33 @@
                                 s/Keyword s/Any}
                                (qp/process-query (mt/native-query query)))))))))))))
 
+(deftest gruping-with-timezone-test
+  (mt/test-driver :mongo
+    (testing "Result timezone is respected when grouping by hour (#11149)"
+      (mt/dataset attempted-murders
+        (testing "Querying in UTC works"
+          (mt/with-system-timezone-id "UTC"
+            (is (= [["2019-11-20T20:00:00Z" 1]
+                    ["2019-11-19T00:00:00Z" 1]
+                    ["2019-11-18T20:00:00Z" 1]
+                    ["2019-11-17T14:00:00Z" 1]]
+                   (mt/rows (mt/run-mbql-query attempts
+                              {:aggregation [[:count]]
+                               :breakout [[:field %datetime {:temporal-unit :hour}]]
+                               :order-by [[:desc [:field %datetime {:temporal-unit :hour}]]]
+                               :limit 4}))))))
+        (testing "Querying in Kathmandu works"
+          (mt/with-system-timezone-id "Asia/Kathmandu"
+            (is (= [["2019-11-21T01:00:00+05:45" 1]
+                    ["2019-11-19T06:00:00+05:45" 1]
+                    ["2019-11-19T02:00:00+05:45" 1]
+                    ["2019-11-17T19:00:00+05:45" 1]]
+                   (mt/rows (mt/run-mbql-query attempts
+                              {:aggregation [[:count]]
+                               :breakout [[:field %datetime {:temporal-unit :hour}]]
+                               :order-by [[:desc [:field %datetime {:temporal-unit :hour}]]]
+                               :limit 4}))))))))))
+
 (deftest nested-columns-test
   (mt/test-driver :mongo
     (testing "Should generate correct queries against nested columns"

--- a/modules/drivers/mongo/test/metabase/driver/mongo/query_processor_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo/query_processor_test.clj
@@ -118,7 +118,7 @@
                                 s/Keyword s/Any}
                                (qp/process-query (mt/native-query query)))))))))))))
 
-(deftest gruping-with-timezone-test
+(deftest grouping-with-timezone-test
   (mt/test-driver :mongo
     (testing "Result timezone is respected when grouping by hour (#11149)"
       (mt/dataset attempted-murders

--- a/modules/drivers/mongo/test/metabase/driver/mongo/query_processor_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo/query_processor_test.clj
@@ -5,11 +5,11 @@
             [metabase.driver.mongo.query-processor :as mongo.qp]
             [metabase.models :refer [Field Table]]
             [metabase.query-processor :as qp]
+            [metabase.query-processor.timezone :as qp.timezone]
             [metabase.test :as mt]
             [metabase.util :as u]
             [schema.core :as s]
-            [toucan.db :as db]
-            [metabase.query-processor.timezone :as qp.timezone]))
+            [toucan.db :as db]))
 
 (deftest query->collection-name-test
   (testing "query->collection-name"


### PR DESCRIPTION
Fixes #11149.

Breaking date values into parts should happen in the time zone expected by the user and the construction of the
truncated date should happen in the same timezone. This is especially important when the difference between the
expected timezone and UTC is not an integer number of hours and the truncation resolution is hour.

The time zone chosen is the result time zone, which is used to parse (date)time literals and seems to be the time zone results are displayed to the user.