### PR TITLE
Prevent automatic replies to generated mails

### DIFF
--- a/src/metabase/email.clj
+++ b/src/metabase/email.clj
@@ -113,16 +113,17 @@
   ;; Now send the email
   (send-email! (smtp-settings)
                (merge
-                {:from    (if-let [from-name (email-from-name)]
-                            (str from-name " <" (email-from-address) ">")
-                            (email-from-address))
-                 :to      recipients
-                 :subject subject
-                 :body    (case message-type
-                            :attachments message
-                            :text        message
-                            :html        [{:type    "text/html; charset=utf-8"
-                                           :content message}])}
+                {:from       (if-let [from-name (email-from-name)]
+                               (str from-name " <" (email-from-address) ">")
+                               (email-from-address))
+                 :to         recipients
+                 :subject    subject
+                 :Precedence "bulk"
+                 :body       (case message-type
+                               :attachments message
+                               :text        message
+                               :html        [{:type    "text/html; charset=utf-8"
+                                              :content message}])}
                 (when-let [reply-to (email-reply-to)]
                   {:reply-to reply-to}))))
 

--- a/test/metabase/email/messages_test.clj
+++ b/test/metabase/email/messages_test.clj
@@ -7,10 +7,11 @@
   (:import java.io.IOException))
 
 (deftest new-user-email
-  (is (= [{:from    "notifications@metabase.com",
-           :to      ["test@test.com"],
-           :subject "You're invited to join Metabase Test's Metabase",
-           :body    [{:type "text/html; charset=utf-8"}]}]
+  (is (= [{:from       "notifications@metabase.com",
+           :to         ["test@test.com"],
+           :subject    "You're invited to join Metabase Test's Metabase",
+           :Precedence "bulk"
+           :body       [{:type "text/html; charset=utf-8"}]}]
          (tu/with-temporary-setting-values [site-name "Metabase Test"]
            (et/with-fake-inbox
              (messages/send-new-user-email! {:first_name "test" :email "test@test.com"}
@@ -24,10 +25,11 @@
   (testing "password reset email can be sent successfully"
     (et/with-fake-inbox
       (messages/send-password-reset-email! "test@test.com" false "http://localhost/some/url" true)
-      (is (= [{:from    "notifications@metabase.com",
-               :to      ["test@test.com"],
-               :subject "[Metabase] Password Reset Request",
-               :body    [{:type "text/html; charset=utf-8"}]}]
+      (is (= [{:from       "notifications@metabase.com",
+               :to         ["test@test.com"],
+               :subject    "[Metabase] Password Reset Request",
+               :Precedence "bulk"
+               :body       [{:type "text/html; charset=utf-8"}]}]
              (-> (@et/inbox "test@test.com")
                  (update-in [0 :body 0] dissoc :content))))))
   ;; Email contents contain randomized elements, so we only check for the inclusion of a single word to verify

--- a/test/metabase/email_test.clj
+++ b/test/metabase/email_test.clj
@@ -220,12 +220,13 @@
                                      email-smtp-security :none]
     (testing "basic sending"
       (is (=
-           [{:from     (str (email/email-from-name) " <" (email/email-from-address) ">")
-             :to       ["test@test.com"]
-             :subject  "101 Reasons to use Metabase"
-             :reply-to (email/email-reply-to)
-             :body     [{:type    "text/html; charset=utf-8"
-                         :content "101. Metabase will make you a better person"}]}]
+           [{:from       (str (email/email-from-name) " <" (email/email-from-address) ">")
+             :to         ["test@test.com"]
+             :subject    "101 Reasons to use Metabase"
+             :Precedence "bulk"
+             :reply-to   (email/email-reply-to)
+             :body       [{:type    "text/html; charset=utf-8"
+                           :content "101. Metabase will make you a better person"}]}]
            (with-fake-inbox
              (email/send-message!
               :subject      "101 Reasons to use Metabase"
@@ -236,12 +237,13 @@
     (testing "basic sending without email-from-name"
       (tu/with-temporary-setting-values [email-from-name nil]
         (is (=
-             [{:from     (email/email-from-address)
-               :to       ["test@test.com"]
-               :subject  "101 Reasons to use Metabase"
-               :reply-to (email/email-reply-to)
-               :body     [{:type    "text/html; charset=utf-8"
-                           :content "101. Metabase will make you a better person"}]}]
+             [{:from       (email/email-from-address)
+               :to         ["test@test.com"]
+               :subject    "101 Reasons to use Metabase"
+               :Precedence "bulk"
+               :reply-to   (email/email-reply-to)
+               :body       [{:type    "text/html; charset=utf-8"
+                             :content "101. Metabase will make you a better person"}]}]
              (with-fake-inbox
                (email/send-message!
                 :subject      "101 Reasons to use Metabase"
@@ -265,17 +267,18 @@
                                           :description  "very scientific data"}]}]
         (testing "it sends successfully"
           (is (=
-               [{:from     (str (email/email-from-name) " <" (email/email-from-address) ">")
-                 :to       [recipient]
-                 :subject  "101 Reasons to use Metabase"
-                 :reply-to (email/email-reply-to)
-                 :body     [{:type    "text/html; charset=utf-8"
-                             :content "100. Metabase will hug you when you're sad"}
-                            {:type         :attachment
-                             :content-type "text/csv"
-                             :file-name    "metabase-reasons.csv"
-                             :content      csv-file
-                             :description  "very scientific data"}]}]
+               [{:from       (str (email/email-from-name) " <" (email/email-from-address) ">")
+                 :to         [recipient]
+                 :subject    "101 Reasons to use Metabase"
+                 :Precedence "bulk"
+                 :reply-to   (email/email-reply-to)
+                 :body       [{:type    "text/html; charset=utf-8"
+                               :content "100. Metabase will hug you when you're sad"}
+                              {:type         :attachment
+                               :content-type "text/csv"
+                               :file-name    "metabase-reasons.csv"
+                               :content      csv-file
+                               :description  "very scientific data"}]}]
                (with-fake-inbox
                  (m/mapply email/send-message! params)
                  (@inbox recipient)))))

--- a/test/metabase/pulse_test.clj
+++ b/test/metabase/pulse_test.clj
@@ -27,6 +27,7 @@
 
 (defn- rasta-pulse-email [& [email]]
   (mt/email-to :rasta (merge {:subject "Pulse: Pulse Name",
+                              :Precedence "bulk",
                               :body  [{"Pulse Name" true}
                                       png-attachment
                                       png-attachment]}


### PR DESCRIPTION
I occasionally receive automatic out-of-office replies as response to Metabase alerts. Adding the SMTP header `Precedence: bulk` should prevent these useless messages.

I have no experience with Clojure, but the attached change should do the job.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/24254)
<!-- Reviewable:end -->
