### PR TITLE
Do not overwrite non-main accent colors when generating chart colors

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/ChartColorSettings/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/ChartColorSettings/utils.ts
@@ -24,21 +24,18 @@ export const getAutoChartColors = (
   groups: string[][],
   palette: Record<string, string>,
 ) => {
-  const oldColors = _.chain(groups)
+  const oldColors = groups
     .map(([name]) => values[name])
-    .map(value => (value ? Color(value) : undefined))
-    .value();
+    .map(value => (value ? Color(value) : undefined));
 
   const fallbackColor = Color(palette["brand"]);
   const newColors = getAutoColors(oldColors, fallbackColor);
 
-  const newValues = _.chain(groups)
+  const newValues = groups
     .map(([name], index) => [name, newColors[index]?.hex()])
-    .filter(([_, value]) => value != null)
-    .object()
-    .value();
+    .filter(([_, value]) => value != null);
 
-  return { ...values, ...newValues };
+  return { ...values, ...Object.fromEntries(newValues) };
 };
 
 const getAutoColors = (

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/ChartColorSettings/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/ChartColorSettings/utils.ts
@@ -31,7 +31,6 @@ export const getAutoChartColors = (
 
   const fallbackColor = Color(palette["brand"]);
   const newColors = getAutoColors(oldColors, fallbackColor);
-  const defaultValues = getDefaultChartColors(values, groups);
 
   const newValues = _.chain(groups)
     .map(([name], index) => [name, newColors[index]?.hex()])
@@ -39,7 +38,7 @@ export const getAutoChartColors = (
     .object()
     .value();
 
-  return { ...defaultValues, ...newValues };
+  return { ...values, ...newValues };
 };
 
 const getAutoColors = (

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/ChartColorSettings/utils.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/ChartColorSettings/utils.unit.spec.ts
@@ -42,12 +42,14 @@ describe("getAutoChartColors", () => {
     const values = {
       brand: "blue",
       accent2: "green",
+      "accent2-light": "red",
     };
 
     const newValues = getAutoChartColors(values, groups, palette);
 
     expect(newValues).toEqual({
-      brand: "blue",
+      brand: "blue", // unchanged
+      "accent2-light": "red", // unchanged
       accent1: Color.rgb(138, 230, 230).hex(), // generated
       accent2: Color.rgb(0, 128, 0).hex(), // green, unchanged
       accent3: Color.rgb(138, 161, 230).hex(), // generated


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/22816

How to test:
- Run Metabase EE
- Go to Admin -> Settings -> Appearance
- Enter a value for a non-main chart color
- Click `Generate chart colors`
- Make sure that your custom value is not overwritten

<img width="616" alt="Screenshot 2022-07-25 at 15 04 11" src="https://user-images.githubusercontent.com/8542534/180773866-2151b05e-4729-420d-84fa-1ef952b75e78.png">
<img width="599" alt="Screenshot 2022-07-25 at 15 04 20" src="https://user-images.githubusercontent.com/8542534/180773884-79db1922-13f1-4b4a-9ad4-d07f2f2140d4.png">
