### PR TITLE
Remove unreachable QB editing mode feature code

### DIFF
--- a/frontend/src/metabase-types/store/mocks/qb.ts
+++ b/frontend/src/metabase-types/store/mocks/qb.ts
@@ -9,7 +9,6 @@ export const createMockQueryBuilderUIControlsState = (
   isShowingDataReference: false,
   isShowingTemplateTagsEditor: false,
   isShowingNewbModal: false,
-  isEditing: false,
   isRunning: false,
   isQueryComplete: false,
   isShowingSummarySidebar: false,

--- a/frontend/src/metabase-types/store/qb.ts
+++ b/frontend/src/metabase-types/store/qb.ts
@@ -17,7 +17,6 @@ export interface QueryBuilderUIControls {
   isShowingDataReference: boolean;
   isShowingTemplateTagsEditor: boolean;
   isShowingNewbModal: boolean;
-  isEditing: boolean;
   isRunning: boolean;
   isQueryComplete: boolean;
   isShowingSummarySidebar: boolean;

--- a/frontend/src/metabase/query_builder/actions/core/updateQuestion.ts
+++ b/frontend/src/metabase/query_builder/actions/core/updateQuestion.ts
@@ -17,7 +17,6 @@ import { Dispatch, GetState, QueryBuilderMode } from "metabase-types/store";
 
 import {
   getFirstQueryResult,
-  getIsEditing,
   getIsShowingTemplateTagsEditor,
   getQueryBuilderMode,
   getQuestion,
@@ -127,8 +126,7 @@ export const updateQuestion = (
     const shouldTurnIntoAdHoc =
       newQuestion.isSaved() &&
       newQuestion.query().isEditable() &&
-      queryBuilderMode !== "dataset" &&
-      !getIsEditing(getState());
+      queryBuilderMode !== "dataset";
 
     if (shouldTurnIntoAdHoc) {
       newQuestion = newQuestion.withoutNameAndId();

--- a/frontend/src/metabase/query_builder/actions/native.js
+++ b/frontend/src/metabase/query_builder/actions/native.js
@@ -118,11 +118,7 @@ export const setTemplateTag = createThunkAction(
       const updatedCard = Utils.copy(card);
 
       // when the query changes on saved card we change this into a new query w/ a known starting point
-      if (
-        !uiControls.isEditing &&
-        uiControls.queryBuilderMode !== "dataset" &&
-        updatedCard.id
-      ) {
+      if (uiControls.queryBuilderMode !== "dataset" && updatedCard.id) {
         delete updatedCard.id;
         delete updatedCard.name;
         delete updatedCard.description;

--- a/frontend/src/metabase/query_builder/reducers.js
+++ b/frontend/src/metabase/query_builder/reducers.js
@@ -66,7 +66,6 @@ const DEFAULT_UI_CONTROLS = {
   isShowingDataReference: false,
   isShowingTemplateTagsEditor: false,
   isShowingNewbModal: false,
-  isEditing: false,
   isRunning: false,
   isQueryComplete: false,
   isShowingSummarySidebar: false,
@@ -194,13 +193,6 @@ export const uiControls = handleActions(
     }),
     [CLOSE_QB_NEWB_MODAL]: {
       next: (state, { payload }) => ({ ...state, isShowingNewbModal: false }),
-    },
-
-    [API_UPDATE_QUESTION]: {
-      next: (state, { payload }) => ({ ...state, isEditing: false }),
-    },
-    [RELOAD_CARD]: {
-      next: (state, { payload }) => ({ ...state, isEditing: false }),
     },
 
     [RUN_QUERY]: state => ({

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -68,7 +68,6 @@ export const getIsAnySidebarOpen = createSelector([getUiControls], uiControls =>
   SIDEBARS.some(sidebar => uiControls[sidebar]),
 );
 
-export const getIsEditing = state => getUiControls(state).isEditing;
 export const getIsRunning = state => getUiControls(state).isRunning;
 export const getIsLoadingComplete = state =>
   getQueryStatus(state) === "complete";


### PR DESCRIPTION
Same flavor as #24257. There used to be an explicit editing mode for questions in the query builder, similar to the one we have for dashboards. It was a long time ago, but there's still some code related to it. However, there's no way to enter it. This PR removes this code.