### PR TITLE
[E2E] Optimize looping logic in tests for dashboard date filters

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-date.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-date.cy.spec.js
@@ -26,6 +26,7 @@ describe("scenarios > dashboard > filters > date", () => {
   it(`should work when set through the filter widget`, () => {
     // Add and connect every single available date filter type
     Object.entries(DASHBOARD_DATE_FILTERS).forEach(([filter]) => {
+      cy.log(`Make sure we can connect ${filter} filter`);
       setFilter("Time", filter);
 
       cy.findByText("Select…").click();
@@ -44,6 +45,7 @@ describe("scenarios > dashboard > filters > date", () => {
           filterValue: value,
         });
 
+        cy.log(`Make sure ${filter} filter returns correct result`);
         cy.get(".Card").within(() => {
           cy.findByText(representativeResult);
         });

--- a/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-date.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-date.cy.spec.js
@@ -11,56 +11,75 @@ import {
 import { DASHBOARD_DATE_FILTERS } from "./helpers/e2e-dashboard-filter-data-objects";
 import * as DateFilter from "../native-filters/helpers/e2e-date-filter-helpers";
 
-Object.entries(DASHBOARD_DATE_FILTERS).forEach(
-  ([filter, { value, representativeResult }]) => {
-    describe("scenarios > dashboard > filters > date", () => {
-      beforeEach(() => {
-        cy.intercept("GET", "/api/table/*/query_metadata").as("metadata");
+describe("scenarios > dashboard > filters > date", () => {
+  beforeEach(() => {
+    cy.intercept("GET", "/api/table/*/query_metadata").as("metadata");
 
-        restore();
-        cy.signInAsAdmin();
+    restore();
+    cy.signInAsAdmin();
 
-        visitDashboard(1);
+    visitDashboard(1);
 
-        editDashboard();
-        setFilter("Time", filter);
+    editDashboard();
+  });
 
-        cy.findByText("Select…").click();
-        popover().contains("Created At").first().click();
-      });
+  it(`should work when set through the filter widget`, () => {
+    // Add and connect every single available date filter type
+    Object.entries(DASHBOARD_DATE_FILTERS).forEach(([filter]) => {
+      setFilter("Time", filter);
 
-      it(`should work for "${filter}" when set through the filter widget`, () => {
-        saveDashboard();
-
-        filterWidget().click();
-
-        dateFilterSelector({
-          filterType: filter,
-          filterValue: value,
-        });
-
-        cy.get(".Card").within(() => {
-          cy.findByText(representativeResult);
-        });
-      });
-
-      it(`should work for "${filter}" when set as the default filter`, () => {
-        cy.findByText("Default value").next().click();
-
-        dateFilterSelector({
-          filterType: filter,
-          filterValue: value,
-        });
-
-        saveDashboard();
-
-        cy.get(".Card").within(() => {
-          cy.findByText(representativeResult);
-        });
-      });
+      cy.findByText("Select…").click();
+      popover().contains("Created At").first().click();
     });
-  },
-);
+
+    saveDashboard();
+
+    // Go through each of the filters and make sure they work individually
+    Object.entries(DASHBOARD_DATE_FILTERS).forEach(
+      ([filter, { value, representativeResult }], index) => {
+        filterWidget().eq(index).click();
+
+        dateFilterSelector({
+          filterType: filter,
+          filterValue: value,
+        });
+
+        cy.get(".Card").within(() => {
+          cy.findByText(representativeResult);
+        });
+
+        clearFilter(index);
+      },
+    );
+  });
+
+  // Rather than going through every single filter type,
+  // make sure the default filter works for just one of the available options
+  it(`should work when set as the default filter`, () => {
+    setFilter("Time", "Month and Year");
+    cy.findByText("Default value").next().click();
+
+    DateFilter.setMonthAndYear({
+      month: "November",
+      year: "2016",
+    });
+
+    cy.findByText("Select…").click();
+    popover().contains("Created At").first().click();
+
+    saveDashboard();
+
+    // The default value should immediately be applied
+    cy.get(".Card").within(() => {
+      cy.findByText("85.88");
+    });
+
+    // Make sure we can override the default value
+    cy.findByText("November, 2016").click();
+    popover().contains("June").click();
+    cy.findByText("33.9");
+  });
+});
 
 function dateFilterSelector({ filterType, filterValue } = {}) {
   switch (filterType) {
@@ -93,4 +112,9 @@ function dateFilterSelector({ filterType, filterValue } = {}) {
     default:
       throw new Error("Wrong filter type!");
   }
+}
+
+function clearFilter(index) {
+  filterWidget().eq(index).find(".Icon-close").click();
+  cy.wait("@dashcardQuery1");
 }

--- a/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-sql-date.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-sql-date.cy.spec.js
@@ -9,89 +9,81 @@ import {
   visitDashboard,
 } from "__support__/e2e/helpers";
 
-import { DASHBOARD_SQL_DATE_FILTERS } from "./helpers/e2e-dashboard-filter-sql-data-objects";
+import {
+  DASHBOARD_SQL_DATE_FILTERS,
+  questionDetails,
+} from "./helpers/e2e-dashboard-filter-sql-data-objects";
 import * as DateFilter from "../native-filters/helpers/e2e-date-filter-helpers";
 
-import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+describe("scenarios > dashboard > filters > SQL > date", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
 
-const { PEOPLE } = SAMPLE_DATABASE;
+    cy.createNativeQuestionAndDashboard({ questionDetails }).then(
+      ({ body: { card_id, dashboard_id } }) => {
+        visitQuestion(card_id);
 
-Object.entries(DASHBOARD_SQL_DATE_FILTERS).forEach(
-  ([filter, { value, representativeResult, sqlFilter }]) => {
-    describe("scenarios > dashboard > filters > SQL > date", () => {
-      beforeEach(() => {
-        restore();
-        cy.signInAsAdmin();
-
-        const questionDetails = getQuestionDetails(sqlFilter);
-
-        cy.createNativeQuestionAndDashboard({ questionDetails }).then(
-          ({ body: { card_id, dashboard_id } }) => {
-            visitQuestion(card_id);
-
-            visitDashboard(dashboard_id);
-          },
-        );
-
-        editDashboard();
-        setFilter("Time", filter);
-
-        cy.findByText("Select…").click();
-        popover().contains("Filter").click();
-      });
-
-      it(`should work for "${filter}" when set through the filter widget`, () => {
-        saveDashboard();
-
-        filterWidget().click();
-
-        dateFilterSelector({
-          filterType: filter,
-          filterValue: value,
-        });
-
-        cy.get(".Card").within(() => {
-          cy.contains(representativeResult);
-        });
-      });
-
-      it(`should work for "${filter}" when set as the default filter`, () => {
-        cy.findByText("Default value").next().click();
-
-        dateFilterSelector({
-          filterType: filter,
-          filterValue: value,
-        });
-
-        saveDashboard();
-
-        cy.get(".Card").within(() => {
-          cy.contains(representativeResult);
-        });
-      });
-    });
-  },
-);
-
-function getQuestionDetails(filter) {
-  return {
-    name: "SQL with Field Filter",
-    native: {
-      query:
-        "select PEOPLE.NAME, PEOPLE.CREATED_AT from people where {{filter}} limit 10",
-      "template-tags": {
-        filter: {
-          id: "7136f057-cfa6-e6fb-40c1-02046a1df9fb",
-          name: "filter",
-          "display-name": "Filter",
-          type: "dimension",
-          dimension: ["field", PEOPLE.CREATED_AT, null],
-          "widget-type": filter,
-        },
+        visitDashboard(dashboard_id);
       },
-    },
-  };
-}
+    );
+
+    editDashboard();
+  });
+
+  it(`should work when set through the filter widget`, () => {
+    Object.entries(DASHBOARD_SQL_DATE_FILTERS).forEach(([filter]) => {
+      cy.log(`Make sure we can connect ${filter} filter`);
+      setFilter("Time", filter);
+
+      cy.findByText("Select…").click();
+      popover().contains(filter).click();
+    });
+
+    saveDashboard();
+
+    Object.entries(DASHBOARD_SQL_DATE_FILTERS).forEach(
+      ([filter, { value, representativeResult }], index) => {
+        filterWidget().eq(index).click();
+        dateFilterSelector({
+          filterType: filter,
+          filterValue: value,
+        });
+
+        cy.log(`Make sure ${filter} filter returns correct result`);
+        cy.get(".Card").within(() => {
+          cy.contains(representativeResult);
+        });
+
+        clearFilter(index);
+      },
+    );
+  });
+
+  it(`should work when set as the default filter`, () => {
+    setFilter("Time", "Month and Year");
+
+    cy.findByText("Default value").next().click();
+    DateFilter.setMonthAndYear({
+      month: "October",
+      year: "2017",
+    });
+
+    cy.findByText("Select…").click();
+    popover().contains("Month and Year").click();
+    saveDashboard();
+
+    // The default value should immediately be applied
+    cy.get(".Card").within(() => {
+      cy.contains("Hudson Borer");
+    });
+
+    // Make sure we can override the default value
+    cy.findByText("October, 2017").click();
+    popover().contains("August").click();
+    cy.findByText("Oda Brakus");
+  });
+});
 
 function dateFilterSelector({ filterType, filterValue } = {}) {
   switch (filterType) {
@@ -124,4 +116,9 @@ function dateFilterSelector({ filterType, filterValue } = {}) {
     default:
       throw new Error("Wrong filter type!");
   }
+}
+
+function clearFilter(index) {
+  filterWidget().eq(index).find(".Icon-close").click();
+  cy.wait("@dashcardQuery2");
 }

--- a/frontend/test/metabase/scenarios/dashboard-filters/helpers/e2e-dashboard-filter-sql-data-objects.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/helpers/e2e-dashboard-filter-sql-data-objects.js
@@ -1,3 +1,7 @@
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+
+const { PEOPLE } = SAMPLE_DATABASE;
+
 export const DASHBOARD_SQL_TEXT_FILTERS = {
   Dropdown: {
     sqlFilter: "string/=",
@@ -133,5 +137,70 @@ export const DASHBOARD_SQL_DATE_FILTERS = {
       timeBucket: "years",
     },
     representativeResult: "Hudson Borer",
+  },
+};
+
+export const questionDetails = {
+  name: "SQL with Field Filters",
+  native: {
+    query:
+      "  select PEOPLE.NAME, PEOPLE.CREATED_AT from people where true\n  [[AND {{monthyear}}]]\n  [[AND {{quarteryear}}]]\n  [[AND {{single}}]]\n  [[AND {{range}}]]\n  [[AND {{relative}}]]\n  [[AND {{date}}]]\n  limit 10",
+    "template-tags": {
+      monthyear: {
+        default: null,
+        dimension: ["field", PEOPLE.CREATED_AT, null],
+        "display-name": "Month and Year",
+        id: "5e40619a-34ff-426d-a5b8-251defe355e5",
+        name: "monthyear",
+        type: "dimension",
+        "widget-type": "date/month-year",
+      },
+      quarteryear: {
+        default: null,
+        dimension: ["field", PEOPLE.CREATED_AT, null],
+        "display-name": "Quarter and Year",
+        id: "1f4ddbaf-e071-7be3-ce5d-fdc5b4f62ab9",
+        name: "quarteryear",
+        type: "dimension",
+        "widget-type": "date/quarter-year",
+      },
+      single: {
+        default: null,
+        dimension: ["field", PEOPLE.CREATED_AT, null],
+        "display-name": "Single Date",
+        id: "726fd574-ed18-5b06-4d9d-4f901ef3378a",
+        name: "single",
+        type: "dimension",
+        "widget-type": "date/single",
+      },
+      range: {
+        default: null,
+        dimension: ["field", PEOPLE.CREATED_AT, null],
+        "display-name": "Date Range",
+        id: "f4ed832a-8882-d25a-1517-95a7ac478660",
+        name: "range",
+        type: "dimension",
+        "widget-type": "date/range",
+      },
+      relative: {
+        default: null,
+        dimension: ["field", PEOPLE.CREATED_AT, null],
+        "display-name": "Relative Date",
+        id: "4a6c70c8-8b39-7058-5b4e-7a7ede920fca",
+        name: "relative",
+        type: "dimension",
+        "widget-type": "date/relative",
+      },
+
+      date: {
+        default: null,
+        dimension: ["field", PEOPLE.CREATED_AT, null],
+        "display-name": "All Options",
+        id: "04171d50-5901-edaf-fba1-9b14211e965e",
+        name: "date",
+        type: "dimension",
+        "widget-type": "date/all-options",
+      },
+    },
   },
 };


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Optimizes the looping logic in dashboard filters date tests (both GUI and SQL)
- Removes checks for ALL filter types when they are set as the default filter, picks one and makes sure it works

 
This reduces the total running time:
- `dashboard-filters-date` from more than two minutes to about 35 seconds
- `dashboard-filters-sql-date` from more than two minutes to about 45 seconds

In total, we should save between between two and three minutes in total running time just by optimizing date filters in this group.