### PR TITLE
updating question parameters on mobile

### DIFF
--- a/frontend/src/metabase-types/types/Parameter.ts
+++ b/frontend/src/metabase-types/types/Parameter.ts
@@ -40,6 +40,7 @@ export interface Parameter {
   sectionId?: string;
   default?: any;
   filteringParameters?: ParameterId[];
+  value?: any;
 }
 
 export type ParameterQueryObject = {

--- a/frontend/src/metabase/parameters/components/ParameterWidget.css
+++ b/frontend/src/metabase/parameters/components/ParameterWidget.css
@@ -2,7 +2,7 @@
   composes: flex align-center from "style";
   transition: opacity 500ms linear;
   border: 2px solid var(--color-border);
-  margin: 0 0 0.5em 0;
+  margin: 0.5em 0;
   padding: 0.25em 1em;
   width: 100%;
 }

--- a/frontend/src/metabase/parameters/components/SyncedParametersList/index.js
+++ b/frontend/src/metabase/parameters/components/SyncedParametersList/index.js
@@ -1,0 +1,1 @@
+export { default } from "./SyncedParametersList";

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
@@ -25,7 +25,7 @@ import ExplicitSize from "metabase/components/ExplicitSize";
 import Snippets from "metabase/entities/snippets";
 import SnippetCollections from "metabase/entities/snippet-collections";
 import SnippetModal from "metabase/query_builder/components/template_tags/SnippetModal";
-import SyncedParametersList from "metabase/parameters/components/SyncedParametersList/SyncedParametersList";
+import { ResponsiveParametersList } from "./ResponsiveParametersList";
 import NativeQueryEditorSidebar from "./NativeQueryEditor/NativeQueryEditorSidebar";
 import VisibilityToggler from "./NativeQueryEditor/VisibilityToggler";
 import RightClickPopover from "./NativeQueryEditor/RightClickPopover";
@@ -53,6 +53,7 @@ class NativeQueryEditor extends Component {
     this.state = {
       initialHeight: calcInitialEditorHeight({ query, viewHeight }),
       isSelectedTextPopoverOpen: false,
+      mobileShowParameterList: false,
     };
 
     // Ace sometimes fires multiple "change" events in rapid succession
@@ -390,6 +391,12 @@ class NativeQueryEditor extends Component {
       .update(setDatasetQuery);
   };
 
+  handleFilterButtonClick = () => {
+    this.setState({
+      mobileShowParameterList: !this.state.mobileShowParameterList,
+    });
+  };
+
   render() {
     const {
       query,
@@ -430,13 +437,10 @@ class NativeQueryEditor extends Component {
               />
             </div>
             {hasParametersList && (
-              <SyncedParametersList
-                className="mt1 mx2"
+              <ResponsiveParametersList
                 parameters={parameters}
                 setParameterValue={setParameterValue}
                 setParameterIndex={this.setParameterIndex}
-                isEditing
-                commitImmediately
               />
             )}
             {query.hasWritePermission() && (

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/VisibilityToggler/VisibilityToggler.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/VisibilityToggler/VisibilityToggler.jsx
@@ -29,7 +29,7 @@ const VisibilityToggler = ({
   );
 
   return (
-    <Container>
+    <Container className="hide sm-show">
       <a className={classNames} onClick={toggleEditor}>
         <Span>{text}</Span>
         <Icon name={icon} size={18} />

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/VisibilityToggler/VisibilityToggler.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/VisibilityToggler/VisibilityToggler.jsx
@@ -29,7 +29,7 @@ const VisibilityToggler = ({
   );
 
   return (
-    <Container className="hide sm-show">
+    <Container>
       <a className={classNames} onClick={toggleEditor}>
         <Span>{text}</Span>
         <Icon name={icon} size={18} />

--- a/frontend/src/metabase/query_builder/components/ResponsiveParametersList.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/ResponsiveParametersList.styled.tsx
@@ -1,0 +1,31 @@
+import styled from "@emotion/styled";
+import Button from "metabase/core/components/Button";
+import SyncedParametersList from "metabase/parameters/components/SyncedParametersList";
+
+import { color } from "metabase/lib/colors";
+
+export const FilterButton = styled(Button)`
+  color: ${color("brand")};
+  margin: 0.5rem;
+`;
+interface ParametersListContainerProps {
+  isSmallScreen: boolean;
+}
+export const ParametersListContainer = styled.div<ParametersListContainerProps>`
+  ${props =>
+    props.isSmallScreen &&
+    `
+    max-height: 200px;
+    overflow-y: auto;
+  `}
+`;
+export const ParametersListHeader = styled.div`
+  padding: 0.75rem 1rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+export const StyledParametersList = styled(SyncedParametersList)`
+  margin: 0 1rem 0.5rem 1rem;
+`;

--- a/frontend/src/metabase/query_builder/components/ResponsiveParametersList.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/ResponsiveParametersList.styled.tsx
@@ -8,17 +8,28 @@ export const FilterButton = styled(Button)`
   color: ${color("brand")};
   margin: 0.5rem;
 `;
-interface ParametersListContainerProps {
+interface ResponsiveParametersListRootProps {
   isSmallScreen: boolean;
 }
-export const ParametersListContainer = styled.div<ParametersListContainerProps>`
+export const ResponsiveParametersListRoot = styled.div<ResponsiveParametersListRootProps>`
+  position: relative;
+  width: 100%;
+`;
+
+export const ParametersListContainer = styled.div`
+  background-color: ${color("bg-light")};
   ${props =>
     props.isSmallScreen &&
     `
-    max-height: 200px;
-    overflow-y: auto;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    border-bottom: 1px solid ${color("border")};
+    padding-bottom: 0.5rem;
   `}
 `;
+
 export const ParametersListHeader = styled.div`
   padding: 0.75rem 1rem;
   display: flex;
@@ -27,5 +38,5 @@ export const ParametersListHeader = styled.div`
 `;
 
 export const StyledParametersList = styled(SyncedParametersList)`
-  margin: 0 1rem 0.5rem 1rem;
+  margin: 0 1rem;
 `;

--- a/frontend/src/metabase/query_builder/components/ResponsiveParametersList.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/ResponsiveParametersList.styled.tsx
@@ -12,7 +12,6 @@ interface ResponsiveParametersListRootProps {
   isSmallScreen: boolean;
 }
 export const ResponsiveParametersListRoot = styled.div<ResponsiveParametersListRootProps>`
-  position: relative;
   width: 100%;
 `;
 
@@ -24,9 +23,11 @@ export const ParametersListContainer = styled.div`
     position: absolute;
     top: 0;
     left: 0;
+    bottom: 0;
     width: 100%;
     border-bottom: 1px solid ${color("border")};
     padding-bottom: 0.5rem;
+    overflow-y: auto;
   `}
 `;
 

--- a/frontend/src/metabase/query_builder/components/ResponsiveParametersList.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/ResponsiveParametersList.styled.tsx
@@ -8,26 +8,40 @@ export const FilterButton = styled(Button)`
   color: ${color("brand")};
   margin: 0.5rem;
 `;
-interface ResponsiveParametersListRootProps {
-  isSmallScreen: boolean;
-}
-export const ResponsiveParametersListRoot = styled.div<ResponsiveParametersListRootProps>`
+
+export const ResponsiveParametersListRoot = styled.div`
   width: 100%;
 `;
 
-export const ParametersListContainer = styled.div`
+interface ParametersListContainerProps {
+  isSmallScreen: boolean;
+  mobileShow: boolean;
+}
+
+export const ParametersListContainer = styled.div<ParametersListContainerProps>`
   background-color: ${color("bg-light")};
-  ${props =>
-    props.isSmallScreen &&
+
+  ${({ isSmallScreen, mobileShow }) =>
+    isSmallScreen &&
     `
     position: absolute;
     top: 0;
     left: 0;
-    bottom: 0;
+    
     width: 100%;
     border-bottom: 1px solid ${color("border")};
-    padding-bottom: 0.5rem;
+    
     overflow-y: auto;
+    bottom: ${mobileShow ? "0" : "100%"};
+    padding-bottom: ${mobileShow ? "0.5rem" : "0"};
+    opacity: ${mobileShow ? "1" : "0"};
+    transition: opacity 250ms;
+
+    ${StyledParametersList} {
+      position: relative;
+      top: ${mobileShow ? "0" : "15px"};
+      transition: top 250ms;
+    }
   `}
 `;
 

--- a/frontend/src/metabase/query_builder/components/ResponsiveParametersList.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/ResponsiveParametersList.styled.tsx
@@ -1,4 +1,5 @@
 import styled from "@emotion/styled";
+import { css } from "@emotion/react";
 import Button from "metabase/core/components/Button";
 import SyncedParametersList from "metabase/parameters/components/SyncedParametersList";
 
@@ -15,34 +16,34 @@ export const ResponsiveParametersListRoot = styled.div`
 
 interface ParametersListContainerProps {
   isSmallScreen: boolean;
-  mobileShow: boolean;
+  isShowingMobile: boolean;
 }
 
 export const ParametersListContainer = styled.div<ParametersListContainerProps>`
   background-color: ${color("bg-light")};
 
-  ${({ isSmallScreen, mobileShow }) =>
+  ${({ isSmallScreen, isShowingMobile }) =>
     isSmallScreen &&
-    `
-    position: absolute;
-    top: 0;
-    left: 0;
-    
-    width: 100%;
-    border-bottom: 1px solid ${color("border")};
-    
-    overflow-y: auto;
-    bottom: ${mobileShow ? "0" : "100%"};
-    padding-bottom: ${mobileShow ? "0.5rem" : "0"};
-    opacity: ${mobileShow ? "1" : "0"};
-    transition: opacity 250ms;
+    css`
+      position: absolute;
+      top: 0;
+      left: 0;
 
-    ${StyledParametersList} {
-      position: relative;
-      top: ${mobileShow ? "0" : "15px"};
-      transition: top 250ms;
-    }
-  `}
+      width: 100%;
+      border-bottom: 1px solid ${color("border")};
+
+      overflow-y: auto;
+      bottom: ${isShowingMobile ? "0" : "100%"};
+      padding-bottom: ${isShowingMobile ? "0.5rem" : "0"};
+      opacity: ${isShowingMobile ? "1" : "0"};
+      transition: opacity 250ms;
+
+      ${StyledParametersList} {
+        position: relative;
+        top: ${isShowingMobile ? "0" : "15px"};
+        transition: top 250ms;
+      }
+    `}
 `;
 
 export const ParametersListHeader = styled.div`

--- a/frontend/src/metabase/query_builder/components/ResponsiveParametersList.tsx
+++ b/frontend/src/metabase/query_builder/components/ResponsiveParametersList.tsx
@@ -1,0 +1,71 @@
+import React, { useCallback, useState, useMemo } from "react";
+
+import useIsSmallScreen from "metabase/hooks/use-is-small-screen";
+
+import Button from "metabase/core/components/Button";
+
+import {
+  FilterButton,
+  ParametersListHeader,
+  StyledParametersList,
+  ParametersListContainer,
+} from "./ResponsiveParametersList.styled";
+
+interface ResponsiveParametersListProps {
+  parameters: any;
+  setParameterValue: any;
+  setParameterIndex: any;
+}
+
+export const ResponsiveParametersList = ({
+  parameters,
+  setParameterValue,
+  setParameterIndex,
+}: ResponsiveParametersListProps) => {
+  const [mobileShowParameterList, setShowMobileParameterList] = useState(false);
+  const isSmallScreen = useIsSmallScreen();
+
+  const handleFilterButtonClick = useCallback(() => {
+    setShowMobileParameterList(!mobileShowParameterList);
+  }, [mobileShowParameterList]);
+
+  const activeFilters = useMemo(() => {
+    return parameters.filter(p => !!p.value).length;
+  }, [parameters]);
+
+  return (
+    <ParametersListContainer isSmallScreen={isSmallScreen}>
+      {isSmallScreen && !mobileShowParameterList && (
+        <FilterButton
+          borderless
+          primary
+          icon="filter"
+          onClick={handleFilterButtonClick}
+        >
+          {activeFilters > 0 ? `${activeFilters} active filters` : `Filters`}
+        </FilterButton>
+      )}
+      {isSmallScreen && mobileShowParameterList && (
+        <ParametersListHeader>
+          <h3>Filters</h3>
+          <Button
+            onlyIcon
+            borderless
+            icon="close"
+            onClick={handleFilterButtonClick}
+            iconSize={14}
+          />
+        </ParametersListHeader>
+      )}
+      {(!isSmallScreen || mobileShowParameterList) && (
+        <StyledParametersList
+          parameters={parameters}
+          setParameterValue={setParameterValue}
+          setParameterIndex={setParameterIndex}
+          isEditing
+          commitImmediately
+        />
+      )}
+    </ParametersListContainer>
+  );
+};

--- a/frontend/src/metabase/query_builder/components/ResponsiveParametersList.tsx
+++ b/frontend/src/metabase/query_builder/components/ResponsiveParametersList.tsx
@@ -1,8 +1,8 @@
 import React, { useCallback, useState, useMemo } from "react";
-
 import useIsSmallScreen from "metabase/hooks/use-is-small-screen";
-
 import Button from "metabase/core/components/Button";
+
+import { Parameter } from "metabase-types/types/Parameter";
 
 import {
   FilterButton,
@@ -13,9 +13,9 @@ import {
 } from "./ResponsiveParametersList.styled";
 
 interface ResponsiveParametersListProps {
-  parameters: any;
-  setParameterValue: any;
-  setParameterIndex: any;
+  parameters: Parameter[];
+  setParameterValue: (parameterId: string, value: string) => void;
+  setParameterIndex: (parameterId: string, parameterIndex: number) => void;
 }
 
 export const ResponsiveParametersList = ({
@@ -35,7 +35,7 @@ export const ResponsiveParametersList = ({
   }, [parameters]);
 
   return (
-    <ResponsiveParametersListRoot isSmallScreen={isSmallScreen}>
+    <ResponsiveParametersListRoot>
       {isSmallScreen && (
         <FilterButton
           borderless
@@ -46,41 +46,30 @@ export const ResponsiveParametersList = ({
           {activeFilters > 0 ? `${activeFilters} active filters` : `Filters`}
         </FilterButton>
       )}
-      {/* {isSmallScreen && mobileShowParameterList && (
-        <ParametersListHeader>
-          <h3>Filters</h3>
-          <Button
-            onlyIcon
-            borderless
-            icon="close"
-            onClick={handleFilterButtonClick}
-            iconSize={14}
-          />
-        </ParametersListHeader>
-      )} */}
-      {(!isSmallScreen || mobileShowParameterList) && (
-        <ParametersListContainer isSmallScreen={isSmallScreen}>
-          {isSmallScreen && (
-            <ParametersListHeader>
-              <h3>Filters</h3>
-              <Button
-                onlyIcon
-                borderless
-                icon="close"
-                onClick={handleFilterButtonClick}
-                iconSize={14}
-              />
-            </ParametersListHeader>
-          )}
-          <StyledParametersList
-            parameters={parameters}
-            setParameterValue={setParameterValue}
-            setParameterIndex={setParameterIndex}
-            isEditing
-            commitImmediately
-          />
-        </ParametersListContainer>
-      )}
+      <ParametersListContainer
+        isSmallScreen={isSmallScreen}
+        mobileShow={mobileShowParameterList}
+      >
+        {isSmallScreen && (
+          <ParametersListHeader>
+            <h3>Filters</h3>
+            <Button
+              onlyIcon
+              borderless
+              icon="close"
+              onClick={handleFilterButtonClick}
+              iconSize={14}
+            />
+          </ParametersListHeader>
+        )}
+        <StyledParametersList
+          parameters={parameters}
+          setParameterValue={setParameterValue}
+          setParameterIndex={setParameterIndex}
+          isEditing
+          commitImmediately
+        />
+      </ParametersListContainer>
     </ResponsiveParametersListRoot>
   );
 };

--- a/frontend/src/metabase/query_builder/components/ResponsiveParametersList.tsx
+++ b/frontend/src/metabase/query_builder/components/ResponsiveParametersList.tsx
@@ -8,6 +8,7 @@ import {
   FilterButton,
   ParametersListHeader,
   StyledParametersList,
+  ResponsiveParametersListRoot,
   ParametersListContainer,
 } from "./ResponsiveParametersList.styled";
 
@@ -34,8 +35,8 @@ export const ResponsiveParametersList = ({
   }, [parameters]);
 
   return (
-    <ParametersListContainer isSmallScreen={isSmallScreen}>
-      {isSmallScreen && !mobileShowParameterList && (
+    <ResponsiveParametersListRoot isSmallScreen={isSmallScreen}>
+      {isSmallScreen && (
         <FilterButton
           borderless
           primary
@@ -45,7 +46,7 @@ export const ResponsiveParametersList = ({
           {activeFilters > 0 ? `${activeFilters} active filters` : `Filters`}
         </FilterButton>
       )}
-      {isSmallScreen && mobileShowParameterList && (
+      {/* {isSmallScreen && mobileShowParameterList && (
         <ParametersListHeader>
           <h3>Filters</h3>
           <Button
@@ -56,16 +57,30 @@ export const ResponsiveParametersList = ({
             iconSize={14}
           />
         </ParametersListHeader>
-      )}
+      )} */}
       {(!isSmallScreen || mobileShowParameterList) && (
-        <StyledParametersList
-          parameters={parameters}
-          setParameterValue={setParameterValue}
-          setParameterIndex={setParameterIndex}
-          isEditing
-          commitImmediately
-        />
+        <ParametersListContainer isSmallScreen={isSmallScreen}>
+          {isSmallScreen && (
+            <ParametersListHeader>
+              <h3>Filters</h3>
+              <Button
+                onlyIcon
+                borderless
+                icon="close"
+                onClick={handleFilterButtonClick}
+                iconSize={14}
+              />
+            </ParametersListHeader>
+          )}
+          <StyledParametersList
+            parameters={parameters}
+            setParameterValue={setParameterValue}
+            setParameterIndex={setParameterIndex}
+            isEditing
+            commitImmediately
+          />
+        </ParametersListContainer>
       )}
-    </ParametersListContainer>
+    </ResponsiveParametersListRoot>
   );
 };

--- a/frontend/src/metabase/query_builder/components/ResponsiveParametersList.tsx
+++ b/frontend/src/metabase/query_builder/components/ResponsiveParametersList.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useState, useMemo } from "react";
+import { msgid, ngettext } from "ttag";
 import useIsSmallScreen from "metabase/hooks/use-is-small-screen";
 import Button from "metabase/core/components/Button";
 
@@ -27,8 +28,8 @@ export const ResponsiveParametersList = ({
   const isSmallScreen = useIsSmallScreen();
 
   const handleFilterButtonClick = useCallback(() => {
-    setShowMobileParameterList(!mobileShowParameterList);
-  }, [mobileShowParameterList]);
+    setShowMobileParameterList(mobileShow => !mobileShow);
+  }, []);
 
   const activeFilters = useMemo(() => {
     return parameters.filter(p => !!p.value).length;
@@ -43,12 +44,18 @@ export const ResponsiveParametersList = ({
           icon="filter"
           onClick={handleFilterButtonClick}
         >
-          {activeFilters > 0 ? `${activeFilters} active filters` : `Filters`}
+          {activeFilters > 0
+            ? ngettext(
+                msgid`${activeFilters} active filter`,
+                `${activeFilters} active filters`,
+                activeFilters,
+              )
+            : `Filters`}
         </FilterButton>
       )}
       <ParametersListContainer
         isSmallScreen={isSmallScreen}
-        mobileShow={mobileShowParameterList}
+        isShowingMobile={mobileShowParameterList}
       >
         {isSmallScreen && (
           <ParametersListHeader>

--- a/frontend/src/metabase/query_builder/components/view/View.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/view/View.styled.tsx
@@ -39,6 +39,7 @@ export const QueryBuilderMain = styled.main<{ isSidebarOpen: boolean }>`
       css`
         display: none !important;
       `};
+    position: relative;
   }
 `;
 

--- a/frontend/test/metabase/scenarios/native-filters/sql-filters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native-filters/sql-filters.cy.spec.js
@@ -138,15 +138,12 @@ describe("scenarios > filters > sql filters > basic filter types", () => {
       cy.get(".Icon-close").click();
     });
 
+    cy.icon("contract").click();
+
     // resize window to mobile form factor
     cy.viewport(480, 800);
 
-    cy.get("fieldset")
-      .findByText("Testingparamvisbility77")
-      .should("be.visible");
-
-    // collapse editor
-    cy.get(".Icon-contract").first().click();
+    cy.findByText("1 active filters").click();
 
     cy.get("fieldset")
       .findByText("Testingparamvisbility77")

--- a/frontend/test/metabase/scenarios/native-filters/sql-filters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native-filters/sql-filters.cy.spec.js
@@ -143,7 +143,7 @@ describe("scenarios > filters > sql filters > basic filter types", () => {
     // resize window to mobile form factor
     cy.viewport(480, 800);
 
-    cy.findByText("1 active filters").click();
+    cy.findByText("1 active filter").click();
 
     cy.get("fieldset")
       .findByText("Testingparamvisbility77")


### PR DESCRIPTION
Fixes #23983
Fixes #23870

Updates the mobile view to show a scrollable panel with filters, rather than having all filters always display above the question contents. Should not have any impact on the desktop experience.

[Design discussion on Slack
](https://metaboat.slack.com/archives/C02H619CJ8K/p1659721931593549)

![chrome_ICc0UEPRgG](https://user-images.githubusercontent.com/1328979/183660563-72066a38-1a93-403e-951f-141a0cc22ea3.gif)

