### PR TITLE
Mysql filters for JSON columns which are heterogeneous (#24214)

### DIFF
--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -251,7 +251,6 @@
           nfc-path             (:nfc_path stored-field)
           parent-identifier    (field/nfc-field->parent-identifier unwrapped-identifier stored-field)
           jsonpath-query       (format "$.%s" (str/join "." (map handle-name (rest nfc-path))))
-          printo               (println (hformat/to-sql parent-identifier))
           default-cast         (hsql/call :convert
                                           (hsql/call :json_extract (hsql/raw (hformat/to-sql parent-identifier)) jsonpath-query)
                                           (hsql/raw (str/upper-case field-type)))

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -246,12 +246,12 @@
 (defmethod sql.qp/json-query :mysql
   [_ unwrapped-identifier stored-field]
   (letfn [(handle-name [x] (str "\"" (if (number? x) (str x) (name x)) "\""))]
-    (let [field-type           (:database_type stored-field)
-          field-type           (get database-type->mysql-cast-type-name field-type field-type)
-          nfc-path             (:nfc_path stored-field)
-          parent-identifier    (field/nfc-field->parent-identifier unwrapped-identifier stored-field)
-          jsonpath-query       (format "$.%s" (str/join "." (map handle-name (rest nfc-path))))
-          default-cast         (hsql/call :convert
+    (let [field-type        (:database_type stored-field)
+          field-type        (get database-type->mysql-cast-type-name field-type field-type)
+          nfc-path          (:nfc_path stored-field)
+          parent-identifier (field/nfc-field->parent-identifier unwrapped-identifier stored-field)
+          jsonpath-query    (format "$.%s" (str/join "." (map handle-name (rest nfc-path))))
+          default-cast      (hsql/call :convert
                                           (hsql/call :json_extract (hsql/raw (hformat/to-sql parent-identifier)) jsonpath-query)
                                           (hsql/raw (str/upper-case field-type)))
           ;; If we see JSON datetimes we expect them to be in ISO8601. However, MySQL expects them as something different.

--- a/test/metabase/driver/mysql_test.clj
+++ b/test/metabase/driver/mysql_test.clj
@@ -446,15 +446,15 @@
   (let [boop-identifier (:form (hx/with-type-info (hx/identifier :field "boop" "bleh -> meh") {}))]
     (testing "Transforming MBQL query with JSON in it to mysql query works"
       (let [boop-field {:nfc_path [:bleh :meh] :database_type "integer"}]
-        (is (= ["CAST(JSON_EXTRACT(boop.bleh, ?) AS integer)" "$.\"meh\""]
+        (is (= ["convert(json_extract(boop.bleh, ?), SIGNED)" "$.\"meh\""]
                (hsql/format (#'sql.qp/json-query :mysql boop-identifier boop-field))))))
     (testing "What if types are weird and we have lists"
       (let [weird-field {:nfc_path [:bleh "meh" :foobar 1234] :database_type "integer"}]
-        (is (= ["CAST(JSON_EXTRACT(boop.bleh, ?) AS integer)" "$.\"meh\".\"foobar\".\"1234\""]
+        (is (= ["convert(json_extract(boop.bleh, ?), SIGNED)" "$.\"meh\".\"foobar\".\"1234\""]
                (hsql/format (#'sql.qp/json-query :mysql boop-identifier weird-field))))))
     (testing "Doesn't complain when field is boolean"
       (let [boolean-boop-field {:database_type "boolean" :nfc_path [:bleh "boop" :foobar 1234]}]
-        (is (= ["CAST(JSON_EXTRACT(boop.bleh, ?) AS boolean)" "$.\"boop\".\"foobar\".\"1234\""]
+        (is (= ["convert(json_extract(boop.bleh, ?), BOOLEAN)" "$.\"boop\".\"foobar\".\"1234\""]
                (hsql/format (#'sql.qp/json-query :mysql boop-identifier boolean-boop-field))))))))
 
 (deftest json-alias-test
@@ -471,9 +471,9 @@
                                  :query    {:source-table (u/the-id table)
                                             :aggregation  [[:count]]
                                             :breakout     [[:field (u/the-id field) nil]]}})]
-              (is (= (str "SELECT JSON_EXTRACT(`json`.`json_bit`, ?) AS `json_bit → 1234`, "
-                          "count(*) AS `count` FROM `json` GROUP BY JSON_EXTRACT(`json`.`json_bit`, ?) "
-                          "ORDER BY JSON_EXTRACT(`json`.`json_bit`, ?) ASC")
+              (is (= (str "SELECT convert(json_extract(json.json_bit, ?), SIGNED) AS `json_bit → 1234`, "
+                          "count(*) AS `count` FROM `json` GROUP BY convert(json_extract(json.json_bit, ?), SIGNED) "
+                          "ORDER BY convert(json_extract(json.json_bit, ?), SIGNED) ASC")
                      (:query compile-res)))
               (is (= '("$.\"1234\"" "$.\"1234\"" "$.\"1234\"") (:params compile-res))))))))))
 
@@ -493,7 +493,7 @@
                                                               :min-value 0.75,
                                                               :max-value 54.0,
                                                               :bin-width 0.75}}]]
-                  (is (= ["((floor(((JSON_EXTRACT(json.json_bit, ?) - 0.75) / 0.75)) * 0.75) + 0.75)" "$.\"1234\""]
+                  (is (= ["((floor(((convert(json_extract(json.json_bit, ?), SIGNED) - 0.75) / 0.75)) * 0.75) + 0.75)" "$.\"1234\""]
                          (hsql/format (sql.qp/->honeysql :mysql field-clause)))))))))))))
 
 (deftest ddl.execute-with-timeout-test

--- a/test/metabase/driver/mysql_test.clj
+++ b/test/metabase/driver/mysql_test.clj
@@ -446,15 +446,15 @@
   (let [boop-identifier (:form (hx/with-type-info (hx/identifier :field "boop" "bleh -> meh") {}))]
     (testing "Transforming MBQL query with JSON in it to mysql query works"
       (let [boop-field {:nfc_path [:bleh :meh] :database_type "integer"}]
-        (is (= ["JSON_EXTRACT(boop.bleh, ?)" "$.\"meh\""]
+        (is (= ["CAST(JSON_EXTRACT(boop.bleh, ?) AS integer)" "$.\"meh\""]
                (hsql/format (#'sql.qp/json-query :mysql boop-identifier boop-field))))))
     (testing "What if types are weird and we have lists"
       (let [weird-field {:nfc_path [:bleh "meh" :foobar 1234] :database_type "integer"}]
-        (is (= ["JSON_EXTRACT(boop.bleh, ?)" "$.\"meh\".\"foobar\".\"1234\""]
+        (is (= ["CAST(JSON_EXTRACT(boop.bleh, ?) AS integer)" "$.\"meh\".\"foobar\".\"1234\""]
                (hsql/format (#'sql.qp/json-query :mysql boop-identifier weird-field))))))
     (testing "Doesn't complain when field is boolean"
       (let [boolean-boop-field {:database_type "boolean" :nfc_path [:bleh "boop" :foobar 1234]}]
-        (is (= ["JSON_EXTRACT(boop.bleh, ?)" "$.\"boop\".\"foobar\".\"1234\""]
+        (is (= ["CAST(JSON_EXTRACT(boop.bleh, ?) AS boolean)" "$.\"boop\".\"foobar\".\"1234\""]
                (hsql/format (#'sql.qp/json-query :mysql boop-identifier boolean-boop-field))))))))
 
 (deftest json-alias-test


### PR DESCRIPTION
Pursuant to #24214. Previously MySQL JSON spunout fields didn't work when the individual fields had heterogeneous contents because type information was missing, unlike where type information was provided in Postgres JSON fields. Now they are provided, along with a refactor to not use `reify` which was used in Postgres JSON fields because the type operator was really annoying otherwise to add (MySQL type cast is a function qua function).