### PR TITLE
Preserve false as default value in case clauses

### DIFF
--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -518,7 +518,7 @@
 (defmethod ->honeysql [:sql :case]
   [driver [_ cases options]]
   (->> (concat cases
-               (when (:default options)
+               (when (some? (:default options))
                  [[:else (:default options)]]))
        (apply concat)
        (mapv (partial ->honeysql driver))

--- a/test/metabase/driver/sql/query_processor_test.clj
+++ b/test/metabase/driver/sql/query_processor_test.clj
@@ -67,6 +67,19 @@
              mbql->native
              sql.qp-test-util/sql->sql-map))))
 
+(deftest case-test
+  (testing "Test that boolean case defaults are kept (#24100)"
+    (is (= [[1 1 true]
+            [2 0 false]]
+           (mt/rows
+            (mt/run-mbql-query venues
+              {:source-table $$venues
+               :order-by     [[:asc $id]]
+               :expressions  {"First int"  [:case [[[:= $id 1] 1]]    {:default 0}]
+                              "First bool" [:case [[[:= $id 1] true]] {:default false}]}
+               :fields       [$id [:expression "First int" nil] [:expression "First bool" nil]]
+               :limit        2}))))))
+
 (deftest join-test
   (testing "Test that correct identifiers are used for joins"
     (is (= '{:select    [VENUES.ID          AS ID


### PR DESCRIPTION
Fixes #24100.

This change makes sure that false as the default value in a case statement is not ignored.
