### PR TITLE
[Actions] Add validations to action endpoints

### DIFF
--- a/frontend/src/metabase/writeback/containers/CreateActionPage.tsx
+++ b/frontend/src/metabase/writeback/containers/CreateActionPage.tsx
@@ -42,15 +42,14 @@ const CreateActionPage: React.FC<Props> = ({ createHttpAction }) => {
       const tags = Object.values(templateTags);
       const parameters = tags
         .filter(tag => tag.type != null)
-        .map(getHttpActionTemplateTagParameter)
-        .map(param => [param.name, param]);
+        .map(getHttpActionTemplateTagParameter);
       const entity = {
         name,
         description,
         ...data,
         template: {
           ...data.template,
-          parameters: Object.fromEntries(parameters),
+          parameters,
         },
         response_handle: responseHandler || null,
         error_handle: errorHandler || null,

--- a/frontend/src/metabase/writeback/containers/EditActionPage.tsx
+++ b/frontend/src/metabase/writeback/containers/EditActionPage.tsx
@@ -44,15 +44,14 @@ const EditActionPage: React.FC<Props> = ({ action, updateAction }: Props) => {
       const tags = Object.values(templateTags);
       const parameters = tags
         .filter(tag => tag.type != null)
-        .map(getHttpActionTemplateTagParameter)
-        .map(param => [param.name, param]);
+        .map(getHttpActionTemplateTagParameter);
       const entity = {
         name,
         description,
         ...data,
         template: {
           ...data.template,
-          parameters: Object.fromEntries(parameters),
+          parameters,
         },
         response_handle: responseHandler || null,
         error_handle: errorHandler || null,

--- a/src/metabase/api/action.clj
+++ b/src/metabase/api/action.clj
@@ -5,7 +5,6 @@
             [metabase.actions.http-action :as http-action]
             [metabase.api.common :as api]
             [metabase.driver :as driver]
-            [metabase.mbql.schema :as mbql.s]
             [metabase.models :refer [HTTPAction]]
             [metabase.models.action :as action]
             [metabase.models.database :refer [Database]]

--- a/src/metabase/api/action.clj
+++ b/src/metabase/api/action.clj
@@ -2,16 +2,40 @@
   "`/api/action/` endpoints."
   (:require [compojure.core :as compojure :refer [POST]]
             [metabase.actions :as actions]
+            [metabase.actions.http-action :as http-action]
             [metabase.api.common :as api]
             [metabase.driver :as driver]
+            [metabase.mbql.schema :as mbql.s]
             [metabase.models :refer [HTTPAction]]
             [metabase.models.action :as action]
             [metabase.models.database :refer [Database]]
             [metabase.models.setting :as setting]
             [metabase.models.table :as table]
             [metabase.util :as u]
-            [metabase.util.i18n :as i18n :refer [trs]]
+            [metabase.util.i18n :as i18n]
+            [metabase.util.schema :as su]
+            [schema.core :as s]
             [toucan.db :as db]))
+
+(def ^:private JsonQuerySchema
+  (su/with-api-error-message
+    (s/constrained
+      s/Str
+      #(http-action/apply-json-query {} %))
+    "must be a valid json-query"))
+
+(def ^:private SupportedActionType
+  (su/with-api-error-message
+    (s/enum "http")
+    "Only http actions are supported at this time."))
+
+(def ^:private HTTPActionTemplate
+  {:method (s/enum "GET" "POST" "PUT" "DELETE" "PATCH")
+   :url s/Str
+   (s/optional-key :body) (s/maybe s/Str)
+   (s/optional-key :headers) (s/maybe s/Str)
+   (s/optional-key :parameters) (s/maybe [su/Map])
+   (s/optional-key :parameter_mappings) (s/maybe su/Map)})
 
 (api/defendpoint POST "/:action-namespace/:action-name"
   "Generic API endpoint for executing any sort of Action."
@@ -61,9 +85,12 @@
 
 (api/defendpoint POST "/"
   "Create a new HTTP action."
-  [:as {action :body}]
-  (when (not= "http" (:type action))
-    (throw (ex-info (trs "Action type is not supported") {:status-code 400 :action action})))
+  [:as {{:keys [type name template response_handle error_handle] :as action} :body}]
+  {type SupportedActionType
+   name s/Str
+   template HTTPActionTemplate
+   response_handle (s/maybe JsonQuerySchema)
+   error_handle (s/maybe JsonQuerySchema)}
   (let [action-id (action/insert! action)]
     (if action-id
       (first (action/select-actions :id action-id))
@@ -72,9 +99,13 @@
       (last (action/select-actions :type "http")))))
 
 (api/defendpoint PUT "/:id"
-  [id :as {action :body}]
-  (when (not= "http" (:type action))
-    (throw (ex-info (trs "Action type is not supported") {:status-code 400 :action action})))
+  [id :as {{:keys [type name template response_handle error_handle] :as action} :body}]
+  {id su/IntGreaterThanZero
+   type SupportedActionType
+   name (s/maybe s/Str)
+   template (s/maybe HTTPActionTemplate)
+   response_handle (s/maybe JsonQuerySchema)
+   error_handle (s/maybe JsonQuerySchema)}
   (db/update! HTTPAction id action)
   (first (action/select-actions :id id)))
 

--- a/test/metabase/actions/test_util.clj
+++ b/test/metabase/actions/test_util.clj
@@ -148,7 +148,7 @@
     (let [action-id (action/insert! {:type :http
                                      :name "Echo Example"
                                      :template {:url (client/build-url "testing/echo[[?fail={{fail}}]]" {})
-                                                :method :post
+                                                :method "POST"
                                                 :body "{\"the_parameter\": {{id}}}"
                                                 :headers "{\"x-test\": \"{{id}}\"}"
                                                 :parameters [{:id "id" :type "number"}


### PR DESCRIPTION
The structure of actions was rather confusing in a few ways so this
aims to help.

- The necessary or optional fields of template were not clear.
- response_handle and error_handle could contain syntax errors so we can
  check those up front.
- Parameters are currently different between query and http action.

Fixes #24284