### PR TITLE
Set a timeout for `isValidTimeout`

### DIFF
--- a/resources/c3p0.properties
+++ b/resources/c3p0.properties
@@ -1,3 +1,3 @@
 c3p0.initialPoolSize=1
 c3p0.minPoolSize=1
-com.mchange.v2.c3p0.impl.DefaultConnectionTester.isValidTimeout=3
+com.mchange.v2.c3p0.impl.DefaultConnectionTester.isValidTimeout=6

--- a/resources/c3p0.properties
+++ b/resources/c3p0.properties
@@ -1,2 +1,3 @@
 c3p0.initialPoolSize=1
 c3p0.minPoolSize=1
+com.mchange.v2.c3p0.impl.DefaultConnectionTester.isValidTimeout=3


### PR DESCRIPTION
When using ssh with db connections:
Our theory is that the db connection has no idea that it sits on top of
an ssh connection. And if the ssh connection dies (ie, `show full
processlist` and then `kill <id>` from that list in mysql) the db
connection has no idea it is dead. "It" is valid but its ssh transport
is dead.

> It is possible to customize how c3p0's DefaultConnectionTester tests
> when no preferredTestQuery or automaticTestTable are available. Please
> see Configuring DefaultConnectionTester.isValidTimeout and Configuring
> DefaultConnectionTester.QuerylessTestRunner.

from https://www.mchange.com/projects/c3p0/#automaticTestTable

> Configuring DefaultConnectionTester.isValidTimeout

> Under circumstances when the JDBC 4+ isValid(...) test will be used by
> c3p0's built in DefaultConnectionTester (see below), by default the test
> will never time out. If you would the test to timeout and fail, set the
> following key

>    com.mchange.v2.c3p0.impl.DefaultConnectionTester.isValidTimeout

> to the desired timeout, in seconds.

https://www.mchange.com/projects/c3p0/#configuring_dctivt
