### PR TITLE
Hot fix for the some enterprise api docs

### DIFF
--- a/src/metabase/api/common/internal.clj
+++ b/src/metabase/api/common/internal.clj
@@ -29,8 +29,17 @@
            (name method)
            (-> (.getName (the-ns endpoint-namespace))
                (str/replace #"^metabase\.api\." "/api/")
-               ;; This is only correct for EE endpoints following the usual convention. Not all of them do. The right
-               ;; way to fix this is to move them -- see #22687
+               ;; HACK to make sure some enterprise endpoints are consistent with the code.
+               ;; The right way to fix this is to move them -- see #22687
+               ;; /api/ee/sandbox/table -> /api/table, this is an override route for /api/table if sandbox is available
+               (str/replace #"^metabase-enterprise\.sandbox\.api\.table" "/api/table")
+               ;; /api/ee/sandbox -> /api/mt
+               (str/replace #"^metabase-enterprise\.sandbox\.api\." "/api/mt/")
+               ;; /api/ee/content-management -> /api/moderation-review
+               (str/replace #"^metabase-enterprise\.content-management\.api\." "/api/moderation-review/")
+               ;; /api/ee/sso/sso/ -> /auth/sso
+               (str/replace #"^metabase-enterprise\.sso\.api\." "/auth/")
+               ;; this should be only the replace for enterprise once we resolved #22687
                (str/replace #"^metabase-enterprise\.([^\.]+)\.api\." "/api/ee/$1/"))
            (if (vector? route)
              (first route)

--- a/src/metabase/cmd/endpoint_dox.clj
+++ b/src/metabase/cmd/endpoint_dox.clj
@@ -141,7 +141,7 @@
   [endpoint]
   (assoc endpoint
          :endpoint-str (endpoint-str endpoint)
-         :ns-name  (endpoint-ns-name endpoint)))
+         :ns-name (endpoint-ns-name endpoint)))
 
 (defn- api-namespaces []
   (for [ns-symb (ns.find/find-namespaces (classpath/system-classpath))
@@ -167,7 +167,12 @@
 (defn- paid?
   "Is the endpoint a paid feature?"
   [ep-data]
-  (str/includes? (:endpoint-str (first ep-data)) "/api/ee"))
+  (or (str/includes? (:endpoint-str (first ep-data)) "/api/ee")
+      ;; some ee endpoints are inconsistent in naming, see #22687
+      (str/includes? (:endpoint-str (first ep-data)) "/api/mt")
+      (= 'metabase-enterprise.sandbox.api.table (.getName (:ns (first ep-data))))
+      (str/includes? (:endpoint-str (first ep-data)) "/auth/sso")
+      (str/includes? (:endpoint-str (first ep-data)) "/api/moderation-review")))
 
 (defn endpoint-footer
   "Adds a footer with a link back to the API index."

--- a/src/metabase/cmd/endpoint_dox.clj
+++ b/src/metabase/cmd/endpoint_dox.clj
@@ -170,7 +170,7 @@
   (or (str/includes? (:endpoint-str (first ep-data)) "/api/ee")
       ;; some ee endpoints are inconsistent in naming, see #22687
       (str/includes? (:endpoint-str (first ep-data)) "/api/mt")
-      (= 'metabase-enterprise.sandbox.api.table (.getName (:ns (first ep-data))))
+      (= 'metabase-enterprise.sandbox.api.table (ns-name (:ns (first ep-data))))
       (str/includes? (:endpoint-str (first ep-data)) "/auth/sso")
       (str/includes? (:endpoint-str (first ep-data)) "/api/moderation-review")))
 


### PR DESCRIPTION
We have the command `api-documentation` to generate our [API docs](https://www.metabase.com/docs/latest/api-documentation.html). 

Currently, we have some mismatch in the endpoints we generate vs what it really is. So this PR is a hotfix to make sure our documents are consistent with the code.
- /api/ee/sandbox  -> /api/mt
- /api/ee/content-management -> /api/moderation-review
- /api/ee/sandbox/table -> /api/table
- /api/ee/sso/sso/ -> /auth/sso

Note that this is just a hotfix, the *right* way to fix this is to update the ee endpoint, see #22687