### PR TITLE
Duplicate question button missing, when question is in a view-only collection

### DIFF
--- a/frontend/src/metabase/query_builder/components/QueryModals.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryModals.jsx
@@ -55,8 +55,14 @@ class QueryModals extends React.Component {
   };
 
   render() {
-    const { modal, modalContext, question, onCloseModal, onOpenModal } =
-      this.props;
+    const {
+      modal,
+      modalContext,
+      question,
+      initialCollectionId,
+      onCloseModal,
+      onOpenModal,
+    } = this.props;
 
     return modal === MODAL_TYPES.SAVE ? (
       <Modal form onClose={onCloseModal}>
@@ -211,10 +217,15 @@ class QueryModals extends React.Component {
       <Modal onClose={onCloseModal}>
         <EntityCopyModal
           entityType="questions"
-          entityObject={this.props.card}
+          entityObject={{
+            ...question.card(),
+            collection_id: question.canWrite()
+              ? question.collectionId()
+              : initialCollectionId,
+          }}
           copy={async formValues => {
             const object = await this.props.onCreate({
-              ...this.props.card,
+              ...question.card(),
               ...formValues,
               description: formValues.description || null,
               collection_position: null,

--- a/frontend/src/metabase/query_builder/components/QuestionActions.tsx
+++ b/frontend/src/metabase/query_builder/components/QuestionActions.tsx
@@ -178,12 +178,18 @@ const QuestionActions = ({
         action: turnDatasetIntoQuestion,
       });
     }
+  }
+
+  if (!question.query().readOnly()) {
     extraButtons.push({
       title: t`Duplicate`,
       icon: "segment",
       action: () => onOpenModal(MODAL_TYPES.CLONE),
       testId: CLONE_TESTID,
     });
+  }
+
+  if (canWrite) {
     extraButtons.push({
       title: t`Archive`,
       icon: "view_archive",

--- a/frontend/test/metabase/scenarios/permissions/reproductions/22726-readonly-collection-duplicate-question.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/reproductions/22726-readonly-collection-duplicate-question.cy.spec.js
@@ -1,0 +1,37 @@
+import {
+  restore,
+  popover,
+  visitQuestion,
+  openQuestionActions,
+} from "__support__/e2e/helpers";
+import { USER_GROUPS } from "__support__/e2e/cypress_data";
+
+const { ALL_USERS_GROUP } = USER_GROUPS;
+
+describe("issue 22726", () => {
+  beforeEach(() => {
+    cy.intercept("POST", "/api/dataset").as("dataset");
+    cy.intercept("POST", "/api/card").as("createCard");
+
+    restore();
+    cy.signInAsAdmin();
+
+    // Let's give all users a read only access to "Our analytics"
+    cy.updateCollectionGraph({
+      [ALL_USERS_GROUP]: { root: "read" },
+    });
+
+    cy.signIn("nocollection");
+  });
+
+  it("should offer to duplicate a question in a view-only collection (metabase#22726)", () => {
+    visitQuestion(1);
+
+    openQuestionActions();
+    popover().findByText("Duplicate").click();
+    cy.findByTextEnsureVisible("No Collection Tableton's Personal Collection");
+
+    cy.button("Duplicate").click();
+    cy.wait("@createCard");
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/22726
Reproduces https://github.com/metabase/metabase/issues/22726

How to test:
- Create a question and save it in `Our analytics`
- Go to Admin -> Permissions and change access `All Users` -> `Our analytics` to view-only.
- You would need a non-admin user. Go to Admin -> People and create one if there is none yet.
- Login as this user and open the saved question.
- Open the question menu and click on `Duplicate`
- Make sure the suggested collection is not `Our analytics` since the user doesn't have access to it.

<img width="656" alt="Screenshot 2022-07-26 at 16 35 52" src="https://user-images.githubusercontent.com/8542534/181022328-11785e82-7d6b-419d-8db0-06cad607ba59.png">
