### PR TITLE
bump snowflake jdbc driver

### DIFF
--- a/modules/drivers/snowflake/deps.edn
+++ b/modules/drivers/snowflake/deps.edn
@@ -2,4 +2,4 @@
  ["src" "resources"]
 
  :deps
- {net.snowflake/snowflake-jdbc {:mvn/version "3.13.14"}}}
+ {net.snowflake/snowflake-jdbc {:mvn/version "3.13.21"}}}


### PR DESCRIPTION
Bumping snowflake-jdbc from `3.13.14` to `3.13.21` hopefully fixing memory leak issues.

Context:
https://metaboat.slack.com/archives/C03E3Q5T4P4/p1658451847056789
https://github.com/snowflakedb/snowflake-jdbc/releases

(first time doing this, so a review is welcome)


