### PR TITLE
Ensure uploaded secrets are stable

### DIFF
--- a/src/metabase/models/secret.clj
+++ b/src/metabase/models/secret.clj
@@ -101,7 +101,9 @@
           (.write out v)))
       tmp-file)))
 
-(def ^{:arglists '([{:keys [connection-property-name id value] :as secret} driver?])}
+(def
+  ^java.io.File
+  ^{:arglists '([{:keys [connection-property-name id value] :as secret} driver?])}
   value->file!
   "Returns the value of the given `secret` instance in the form of a file. If the given instance has a `:file-path` as
   its source, a `File` referring to that is returned. Otherwise, the `:value` is written to a temporary file, which is

--- a/src/metabase/models/secret.clj
+++ b/src/metabase/models/secret.clj
@@ -117,7 +117,7 @@
      {::memoize/args-fn (fn [[secret _driver?]]
                           ;; not clear if value->string could return nil due to the cond so we'll just cache on a key
                           ;; that is unique
-                          [(or (value->string secret) (gensym))])})))
+                          [(vec (:value secret))])})))
 
 (defn get-sub-props
   "Return a map of secret subproperties for the property `connection-property-name`."

--- a/src/metabase/models/secret.clj
+++ b/src/metabase/models/secret.clj
@@ -1,5 +1,6 @@
 (ns metabase.models.secret
   (:require [cheshire.generate :refer [add-encoder encode-map]]
+            [clojure.core.memoize :as memoize]
             [clojure.java.io :as io]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
@@ -54,7 +55,7 @@
   (->> (filter #(= :secret (keyword (:type %))) conn-props)
     (reduce (fn [acc prop] (assoc acc (:name prop) prop)) {})))
 
-(defn value->file!
+(defn value->file!*
   "Returns the value of the given `secret` instance in the form of a file. If the given instance has a `:file-path` as
   its source, a `File` referring to that is returned. Otherwise, the `:value` is written to a temporary file, which is
   then returned.
@@ -99,6 +100,22 @@
                          ^bytes value)]
           (.write out v)))
       tmp-file)))
+
+(def ^{:arglists '([{:keys [connection-property-name id value] :as secret} driver?])}
+  value->file!
+  "Returns the value of the given `secret` instance in the form of a file. If the given instance has a `:file-path` as
+  its source, a `File` referring to that is returned. Otherwise, the `:value` is written to a temporary file, which is
+  then returned.
+
+  `driver?` is an optional argument that is only used if an ostensibly existing file value (i.e. `:file-path`) can't be
+  resolved, in order to render a more user-friendly error message (by looking up the display names of the connection
+  properties involved)."
+  (memoize/memo
+   (with-meta value->file!*
+     {::memoize/args-fn (fn [[secret _driver?]]
+                          ;; not clear if value->string could return nil due to the cond so we'll just cache on a key
+                          ;; that is unique
+                          [(or (value->string secret) (gensym))])})))
 
 (defn get-sub-props
   "Return a map of secret subproperties for the property `connection-property-name`."

--- a/test/metabase/models/secret_test.clj
+++ b/test/metabase/models/secret_test.clj
@@ -120,7 +120,30 @@
                                   (let [result (byte-array (.length val-file))]
                                     (with-open [in (DataInputStream. (io/input-stream val-file))]
                                       (.readFully in result))
-                                    result))))))))))
+                                    result)))))))))
+  (testing "value->file! returns the same file for secrets"
+    (testing "for file paths"
+      (let [file-secret-val "dingbat"
+            ^File tmp-file  (doto (File/createTempFile "value-to-file-test_" ".txt")
+                              (.deleteOnExit))]
+        (spit tmp-file file-secret-val)
+        (mt/with-temp* [Secret [secret {:name   "file based secret"
+                                        :kind   :perm-cert
+                                        :source "file-path"
+                                        :value  (.getAbsolutePath tmp-file)}]]
+          (is (instance? java.io.File (secret/value->file! secret nil)))
+          (is (= (secret/value->file! secret nil)
+                 (secret/value->file! secret nil))
+              "Secret did not return the same file"))))
+    (testing "for upload files (#23034)"
+      (mt/with-temp* [Secret [secret {:name   "file based secret"
+                                      :kind   :perm-cert
+                                      :source nil
+                                      :value  (.getBytes "super secret")}]]
+        (is (instance? java.io.File (secret/value->file! secret nil)))
+        (is (= (secret/value->file! secret nil)
+               (secret/value->file! secret nil))
+            "Secret did not return the same file")))))
 
 (defn- decode-ssl-db-property [content mime-type property]
   (let [value-key (keyword (str property "-value"))


### PR DESCRIPTION
Fixes: https://github.com/metabase/metabase/issues/23034

Background:
Uploaded secrets are stored as bytes in our application db since cloud
doesn't have a filesystem. To make db connections we stuff them into
temporary files and use those files.

We also are constantly watching for db detail changes so we can
recompose the connection pool. Each time you call
`db->pooled-connection-spec` we check if the hash of the connection spec
has changed and recompose the pool if it has.

Problem:
These uploaded files have temporary files and we make new temp files
each time we call `db->pooled-connection-spec`. So the hashes always
appear different:

```clojure
connection=> (= x y)
true
connection=> (take 2
                   (clojure.data/diff (connection-details->spec :postgres (:details x))
                                      (connection-details->spec :postgres (:details y))))
({:sslkey
  #object[java.io.File 0x141b0f09 "/var/folders/1d/3ns5s1gs7xjgb09bh1yb6wpc0000gn/T/metabase-secret_1388256635324085910.tmp"],
  :sslrootcert
  #object[java.io.File 0x6f443fac "/var/folders/1d/3ns5s1gs7xjgb09bh1yb6wpc0000gn/T/metabase-secret_9248342447139746747.tmp"],
  :sslcert
  #object[java.io.File 0xbb13300 "/var/folders/1d/3ns5s1gs7xjgb09bh1yb6wpc0000gn/T/metabase-secret_17076432929457451876.tmp"]}
 {:sslkey
  #object[java.io.File 0x6fbb3b7b "/var/folders/1d/3ns5s1gs7xjgb09bh1yb6wpc0000gn/T/metabase-secret_18336254363340056265.tmp"],
  :sslrootcert
  #object[java.io.File 0x6ba4c390 "/var/folders/1d/3ns5s1gs7xjgb09bh1yb6wpc0000gn/T/metabase-secret_11775804023700307206.tmp"],
  :sslcert
  #object[java.io.File 0x320184a0
  "/var/folders/1d/3ns5s1gs7xjgb09bh1yb6wpc0000gn/T/metabase-secret_10098480793225259237.tmp"]})
```

And this is quite a problem: each time we get a db connection we are
making a new file, putting the contents of the secret in it, and then
considering the pool stale, recomposing it, starting our query. And if
you are on a dashboard, each card will kill the pool of the previously
running cards.

This behavior does not happen with the local-file path because the
secret is actually the filepath and we load that. So the file returned
is always the same. It's only for the uploaded bits that we dump into a
temp file (each time).

Solution:
Let's memoize the temp file created by the secret. We cannot use the
secret as the key though because the secret can (always?) includes a
byte array:

```clojure
connection-test=> (hash {:x (.getBytes "hi")})
1771366777
connection-test=> (hash {:x (.getBytes "hi")})
-709002180
```

So we need to come up with a stable key. I'm using `value->string` here,
falling back to `(gensym)` because `value->string` doesn't always return
a value due to its cond.

```clojure
(defn value->string
  "Returns the value of the given `secret` as a String.  `secret` can be a Secret model object, or a
  secret-map (i.e. return value from `db-details-prop->secret-map`)."
  {:added "0.42.0"}
  ^String [{:keys [value] :as _secret}]
  (cond (string? value)
        value
        (bytes? value)
        (String. ^bytes value StandardCharsets/UTF_8)))
```

Why did this bug come up recently?
[pull/21604](https://github.com/metabase/metabase/pull/21604) gives some
light. That changed
`(hash details)` -> `(hash (connection-details->spec driver details))`

with the message

> also made some tweaks so the SQL JDBC driver connection pool cache is
> invalidated when the (unpooled) JDBC spec returned by
> connection-details->spec changes, rather than when the details map
> itself changes. This means that changes to other things outside of
> connection details that affect the JDBC connection parameters, for
> example the report-timezone or start-of-week Settings will now properly
> result in the connection pool cache being flushed

So we want to continue to hash the db spec but ensure that the spec is
stable.

#### How to test
our [dev-scripts](https://github.com/metabase/dev-scripts/tree/master/run_postgres_ssl) repo has a great postgres ssl setup.

Just run 
```
❯ ./run_postgres_ssh.sh
Generating a 2048 bit RSA private key
......+++
..........+++
writing new private key to 'privkey.pem'
-----
writing RSA key
--------------------------------------------------
To Connect, Run:

psql -p 5433 "sslmode=verify-full host=localhost dbname=postgres user=postgres sslrootcert=server.crt"

--------------------------------------------------
...
```

This will generate everything you need so you can add a db connection (note the port is 5433 so it doesn't step on any other locally running postgres). You'll need to create a db and a table inside of it so you have something to connect to and then use the following 
- ssl-mode: `verify-ca`
- ssl-root-cert: `dev-scripts/run_postgres_ssl/server.crt`
- SSL Client Certificate: `dev-scripts/run_postgres_ssl/privkey.pem`
- SSL Client Key: `dev-scripts/run_postgres_ssl/server.key`
- SSL Client Key Password: `abcd` (this is in the script : `openssl req -new -text -passout pass:abcd -subj /CN=localhost -out server.req -keyout privkey.pem`

Before this change you would see logs like the following:

```
2022-07-26 12:36:00,089 WARN sql-jdbc.connection :: Hash of database 3 details changed; marking pool invalid to reopen it
2022-07-26 12:36:00,217 INFO sync.util :: FINISHED: step 'sync-timezone' for postgres Database 3 'better' (154.5 ms)
2022-07-26 12:36:00,219 INFO sync.util :: STARTING: step 'sync-tables' for postgres Database 3 'better'
2022-07-26 12:36:00,234 WARN sql-jdbc.connection :: Hash of database 3 details changed; marking pool invalid to reopen it
2022-07-26 12:36:00,344 INFO sync.util :: FINISHED: step 'sync-tables' for postgres Database 3 'better' (124.6 ms)
2022-07-26 12:36:00,348 INFO sync.util :: STARTING: step 'sync-fields' for postgres Database 3 'better'
2022-07-26 12:36:00,362 WARN sql-jdbc.connection :: Hash of database 3 details changed; marking pool invalid to reopen it
2022-07-26 12:36:00,464 WARN sql-jdbc.connection :: Hash of database 3 details changed; marking pool invalid to reopen it
2022-07-26 12:36:00,558 WARN sql-jdbc.connection :: Hash of database 3 details changed; marking pool invalid to reopen it
```

Those warnings of details changing should be absent after this change.