### PR TITLE
Cutoff instead of null out nested field column set if there are too many

### DIFF
--- a/src/metabase/driver/sql_jdbc/sync/describe_table.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_table.clj
@@ -373,5 +373,8 @@
           (if (> (count fields) max-nested-field-columns)
             (do
               (take max-nested-field-columns fields)
-              (log/warn (format "More nested field columns detected than maximum. Limiting the number of nested field columns.")))
+              (log/warn
+                (format
+                  "More nested field columns detected than maximum. Limiting the number of nested field columns to %d."
+                  max-nested-field-columns)))
             fields))))))

--- a/src/metabase/driver/sql_jdbc/sync/describe_table.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_table.clj
@@ -372,9 +372,9 @@
               fields           (field-types->fields field-types)]
           (if (> (count fields) max-nested-field-columns)
             (do
-              (take max-nested-field-columns fields)
               (log/warn
                 (format
                   "More nested field columns detected than maximum. Limiting the number of nested field columns to %d."
-                  max-nested-field-columns)))
+                  max-nested-field-columns))
+              (take max-nested-field-columns fields))
             fields))))))

--- a/src/metabase/driver/sql_jdbc/sync/describe_table.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_table.clj
@@ -371,5 +371,7 @@
               field-types      (transduce describe-json-xform describe-json-rf query)
               fields           (field-types->fields field-types)]
           (if (> (count fields) max-nested-field-columns)
-            #{}
+            (do
+              (take max-nested-field-columns fields)
+              (log/warn (format "More nested field columns detected than maximum. Limiting the number of nested field columns.")))
             fields))))))

--- a/src/metabase/driver/sql_jdbc/sync/describe_table.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_table.clj
@@ -376,5 +376,5 @@
                 (format
                   "More nested field columns detected than maximum. Limiting the number of nested field columns to %d."
                   max-nested-field-columns))
-              (take max-nested-field-columns fields))
+              (set (take max-nested-field-columns fields)))
             fields))))))

--- a/test/metabase/driver/mysql_test.clj
+++ b/test/metabase/driver/mysql_test.clj
@@ -436,11 +436,11 @@
     (mt/dataset json
       (when (not (is-mariadb? (u/id (mt/db))))
         (testing "Nested field column listing, but big"
-          (is (= #{}
-                 (sql-jdbc.sync/describe-nested-field-columns
-                   :mysql
-                   (mt/db)
-                   {:name "big_json"}))))))))
+          (is (= metabase.driver.sql-jdbc.sync.describe-table/max-nested-field-columns
+                 (count (sql-jdbc.sync/describe-nested-field-columns
+                          :mysql
+                          (mt/db)
+                          {:name "big_json"})))))))))
 
 (deftest json-query-test
   (let [boop-identifier (:form (hx/with-type-info (hx/identifier :field "boop" "bleh -> meh") {}))]


### PR DESCRIPTION
Pursuant to #23635. Previous behavior was to blank out the nested field columns if there were too many for our arbitrary limit (of 100). However, this silent behavior was very user-unfriendly, and people were perplexed that the feature just seemed to turn off out of nowhere. New, better behavior is to log that there are too many and cut it off at 100, but still have some if there are 100.