### PR TITLE
do not assign automerge label on the backported PRs

### DIFF
--- a/.github/workflows/auto-backport.yml
+++ b/.github/workflows/auto-backport.yml
@@ -52,7 +52,7 @@ jobs:
           git checkout master
           git push -u origin ${BACKPORT_BRANCH}
 
-          BACKPORT_PR_URL=$(hub pull-request -b "${TARGET_BRANCH}" -h "${BACKPORT_BRANCH}" -l "auto-backported,automerge" -a "${GITHUB_ACTOR}" -F- <<<"🤖 backported \"${ORIGINAL_TITLE}\"
+          BACKPORT_PR_URL=$(hub pull-request -b "${TARGET_BRANCH}" -h "${BACKPORT_BRANCH}" -l "auto-backported" -a "${GITHUB_ACTOR}" -F- <<<"🤖 backported \"${ORIGINAL_TITLE}\"
 
           #${ORIGINAL_PULL_REQUEST_NUMBER}")
 


### PR DESCRIPTION
Remove assigning `automerge` label on the backported PRs because it does not makes sense anymore. It is a leftover from my attempt to implement automerge on GHA