### PR TITLE
fix timelines visual specs flakes

### DIFF
--- a/frontend/src/metabase/timelines/collections/components/TimelineEmptyState/TimelineEmptyState.tsx
+++ b/frontend/src/metabase/timelines/collections/components/TimelineEmptyState/TimelineEmptyState.tsx
@@ -54,7 +54,7 @@ const TimelineEmptyState = ({
           <EmptyStateTooltipIcon name="mail" />
           <EmptyStateTooltipBody>
             <EmptyStateTooltipTitle>{t`Launch of v2.0`}</EmptyStateTooltipTitle>
-            <EmptyStateTooltipDate value={date} unit="day" />
+            <EmptyStateTooltipDate value={date} unit="day" data-server-date />
           </EmptyStateTooltipBody>
         </EmptyStateTooltip>
         <EmptyStateThread>

--- a/frontend/test/metabase-visual/collections/timelines.cy.spec.js
+++ b/frontend/test/metabase-visual/collections/timelines.cy.spec.js
@@ -18,6 +18,7 @@ describe("timelines", () => {
 
   it("should display empty state", () => {
     cy.visit("/collection/root/timelines");
+    cy.findByText("Last edited at");
 
     cy.findByText("Our analytics events").should("be.visible");
     cy.createPercySnapshot();

--- a/frontend/test/metabase-visual/collections/timelines.cy.spec.js
+++ b/frontend/test/metabase-visual/collections/timelines.cy.spec.js
@@ -18,7 +18,7 @@ describe("timelines", () => {
 
   it("should display empty state", () => {
     cy.visit("/collection/root/timelines");
-    cy.findByText("Last edited at");
+    cy.findByText("Last edited at").should("be.visible");
 
     cy.findByText("Our analytics events").should("be.visible");
     cy.createPercySnapshot();


### PR DESCRIPTION
## Changes

Fixes a couple of Percy flakes:
- [One](https://percy.io/6a8dd5c9/metabase/builds/21331118/changed/1189060790?browser=chrome&browser_ids=23&subcategories=approved&viewLayout=side-by-side&viewMode=new&width=1280&widths=1280) is related to dates are coming from server
- [Another](https://percy.io/6a8dd5c9/metabase/builds/21331118/changed/1189060846?browser=chrome&browser_ids=23&subcategories=approved&viewLayout=side-by-side&viewMode=new&width=1280&widths=1280) did not await for content to be loaded