### PR TITLE
Fix app layout after exiting admin

### DIFF
--- a/frontend/src/metabase/hoc/FitViewPort.jsx
+++ b/frontend/src/metabase/hoc/FitViewPort.jsx
@@ -38,14 +38,14 @@ function fitViewport(ComposedComponent) {
     componentDidMount() {
       const root = document.getElementById("root");
       if (root && root.firstChild) {
-        root.firstChild.classList.add("spread", "flex", "flex-column");
+        root.firstChild.classList.add("flex", "flex-column");
       }
     }
 
     componentWillUnmount() {
       const root = document.getElementById("root");
       if (root && root.firstChild) {
-        root.firstChild.classList.remove("spread", "flex", "flex-column");
+        root.firstChild.classList.remove("flex", "flex-column");
       }
     }
 


### PR DESCRIPTION
How to test:
- Go to Admin -> Permissions
- Click `Exit Admin`
- Make sure the homepage is not broken

Before:
<img width="1728" alt="Screenshot 2022-07-27 at 15 55 55" src="https://user-images.githubusercontent.com/8542534/181284237-84687589-9acd-4f2a-a888-6b622c478807.png">

After:
<img width="1067" alt="Screenshot 2022-07-27 at 18 15 01" src="https://user-images.githubusercontent.com/8542534/181284338-ce833ea1-3075-4ba1-a02a-fe38c31fb3c7.png">

