### PR TITLE
Do now show "Our analytics" in breadcrumbs if the user doesn't have access to it

### DIFF
--- a/frontend/src/metabase/containers/ItemPicker.jsx
+++ b/frontend/src/metabase/containers/ItemPicker.jsx
@@ -18,6 +18,7 @@ import { connect } from "react-redux";
 import EntityListLoader, {
   entityListLoader,
 } from "metabase/entities/containers/EntityListLoader";
+import { entityObjectLoader } from "metabase/entities/containers/EntityObjectLoader";
 
 import Collections from "metabase/entities/collections";
 import {
@@ -264,10 +265,13 @@ class ItemPicker extends React.Component {
 }
 
 export default _.compose(
+  entityObjectLoader({
+    id: () => "root",
+    entityType: (state, props) => props.entity?.name ?? "collections",
+    loadingAndErrorWrapper: false,
+  }),
   entityListLoader({
-    entityType: (state, props) => {
-      return props.entity ? props.entity.name : "collections";
-    },
+    entityType: (state, props) => props.entity?.name ?? "collections",
     loadingAndErrorWrapper: false,
   }),
   connect((state, props) => ({

--- a/frontend/src/metabase/dashboard/components/add-card-sidebar/QuestionPicker.jsx
+++ b/frontend/src/metabase/dashboard/components/add-card-sidebar/QuestionPicker.jsx
@@ -6,6 +6,7 @@ import { t } from "ttag";
 
 import Icon from "metabase/components/Icon";
 import Breadcrumbs from "metabase/components/Breadcrumbs";
+import { entityObjectLoader } from "metabase/entities/containers/EntityObjectLoader";
 import { entityListLoader } from "metabase/entities/containers/EntityListLoader";
 import Collections, { ROOT_COLLECTION } from "metabase/entities/collections";
 import { getCrumbs } from "metabase/lib/collections";
@@ -110,6 +111,11 @@ function QuestionPicker({
 }
 
 export default _.compose(
+  entityObjectLoader({
+    id: () => "root",
+    entityType: "collections",
+    loadingAndErrorWrapper: false,
+  }),
   entityListLoader({
     entityType: "collections",
     loadingAndErrorWrapper: false,

--- a/frontend/src/metabase/dashboard/components/add-card-sidebar/QuestionPicker.jsx
+++ b/frontend/src/metabase/dashboard/components/add-card-sidebar/QuestionPicker.jsx
@@ -24,8 +24,6 @@ import {
 import { SEARCH_DEBOUNCE_DURATION } from "metabase/lib/constants";
 import SelectList from "metabase/components/SelectList";
 
-const { isRegularCollection } = PLUGIN_COLLECTIONS;
-
 QuestionPicker.propTypes = {
   onSelect: PropTypes.func.isRequired,
   collectionsById: PropTypes.object,
@@ -76,7 +74,9 @@ function QuestionPicker({
             <SelectList>
               {collections.map(collection => {
                 const icon = getCollectionIcon(collection);
-                const iconColor = isRegularCollection(collection)
+                const iconColor = PLUGIN_COLLECTIONS.isRegularCollection(
+                  collection,
+                )
                   ? "text-light"
                   : icon.color;
                 return (

--- a/frontend/src/metabase/entities/collections/collections.js
+++ b/frontend/src/metabase/entities/collections/collections.js
@@ -159,6 +159,9 @@ export function getExpandedCollectionsById(
   // "Our Analytics"
   collectionsById[ROOT_COLLECTION.id] = {
     ...ROOT_COLLECTION,
+    name: collectionsById[ROOT_COLLECTION.id]
+      ? ROOT_COLLECTION.name
+      : t`Collections`,
     parent: null,
     children: [],
     ...(collectionsById[ROOT_COLLECTION.id] || {}),

--- a/frontend/src/metabase/query_builder/components/saved-question-picker/SavedQuestionPicker.jsx
+++ b/frontend/src/metabase/query_builder/components/saved-question-picker/SavedQuestionPicker.jsx
@@ -34,7 +34,7 @@ const propTypes = {
   databaseId: PropTypes.string,
   tableId: PropTypes.string,
   collectionName: PropTypes.string,
-  collection: PropTypes.object,
+  rootCollection: PropTypes.object,
 };
 
 const getOurAnalyticsCollection = collectionEntity => {
@@ -58,7 +58,7 @@ function SavedQuestionPicker({
   databaseId,
   tableId,
   collectionName,
-  collection: rootCollection,
+  rootCollection,
 }) {
   const collectionTree = useMemo(() => {
     const targetModels = isDatasets ? ["dataset"] : null;
@@ -146,6 +146,7 @@ const mapStateToProps = ({ currentUser }) => ({ currentUser });
 export default _.compose(
   Collection.load({
     id: () => "root",
+    entityAlias: "rootCollection",
     loadingAndErrorWrapper: false,
   }),
   Collection.loadList({

--- a/frontend/test/metabase/scenarios/permissions/reproductions/23981-root-collection-breadcrumbs.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/reproductions/23981-root-collection-breadcrumbs.cy.spec.js
@@ -1,0 +1,43 @@
+import { popover, restore, visitQuestionAdhoc } from "__support__/e2e/helpers";
+import { SAMPLE_DB_ID, USER_GROUPS } from "__support__/e2e/cypress_data";
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+
+const { ALL_USERS_GROUP } = USER_GROUPS;
+const { PEOPLE_ID } = SAMPLE_DATABASE;
+
+describe("issue 23981", () => {
+  beforeEach(() => {
+    cy.intercept("POST", "/api/dataset").as("dataset");
+
+    restore();
+    cy.signInAsAdmin();
+
+    // Let's revoke access to "Our analytics" from "All users"
+    cy.updateCollectionGraph({
+      [ALL_USERS_GROUP]: { root: "none" },
+    });
+
+    cy.signIn("nocollection");
+  });
+
+  it("should not show the root collection name in breadcrumbs if the user does not have access to it (metabase#22726)", () => {
+    visitQuestionAdhoc({
+      name: "23981",
+      dataset_query: {
+        database: SAMPLE_DB_ID,
+        type: "query",
+        query: {
+          "source-table": PEOPLE_ID,
+        },
+      },
+    });
+
+    cy.findByText("Save").click();
+    cy.findByText("No Collection Tableton's Personal Collection").click();
+
+    popover().within(() => {
+      cy.findByText("Our analytics").should("not.exist");
+      cy.findByText("Collections").should("be.visible");
+    });
+  });
+});

--- a/frontend/test/metabase/scenarios/permissions/reproductions/23981-root-collection-breadcrumbs.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/reproductions/23981-root-collection-breadcrumbs.cy.spec.js
@@ -20,7 +20,7 @@ describe("issue 23981", () => {
     cy.signIn("nocollection");
   });
 
-  it("should not show the root collection name in breadcrumbs if the user does not have access to it (metabase#22726)", () => {
+  it("should not show the root collection name in breadcrumbs if the user does not have access to it (metabase#23981)", () => {
     visitQuestionAdhoc({
       name: "23981",
       dataset_query: {


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/23981
Reproduces https://github.com/metabase/metabase/issues/23981
Related to https://github.com/metabase/metabase/pull/23887

The problem is that we display `Our analytics` title in breadcrumbs in `ItemPicker`. This PR uses the same approach as https://github.com/metabase/metabase/pull/23887:
- Tries to load the root collection via API
- If it works, the root collection will be in the redux store
- If it doesn't work, it means that the user doesn't have access to it
- Changes the title of the root breadcrumb depending on the presence of the root collection in the store

Please note that the entire token for the root collection cannot be removed from breadcrumbs because it also works as a button to navigate to the root.

How to test:
- Log in as an admin
- You need to have a non-admin user. If you don't have one, go to Admin -> People and create it.
- Go to Admin -> Permissions -> Collections and change access for `Our analytics` for `All users` to `No access`
- Login in as the regular user
- New -> Question -> People -> Visualize
- Click `Save` and open the collection picker
- Make sure `Our analytics` breadcrumb is replaced with `Collections`

<img width="716" alt="Screenshot 2022-07-27 at 20 39 42" src="https://user-images.githubusercontent.com/8542534/181313701-a3fa0bd8-ab99-441b-8e01-13ebf8519bbe.png">

With access:
<img width="670" alt="Screenshot 2022-07-27 at 20 05 39" src="https://user-images.githubusercontent.com/8542534/181307430-d7dbe241-7ccc-465b-b006-cc8b8d27699b.png">

Without access:
<img width="661" alt="Screenshot 2022-07-27 at 20 04 46" src="https://user-images.githubusercontent.com/8542534/181307769-3bab1739-3452-4e7f-902b-e6ff99c36098.png">
