### PR TITLE
Handle embedded MBQL snippets portably in Serdes v2

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -302,7 +302,15 @@
                                         :display        :line))
             (reset! serialized (into [] (serdes.extract/extract-metabase {})))))
 
-        ;; TODO DO NOT SUBMIT Test that the serialized form is as expected?
+        (testing "the serialized form is as desired"
+          (is (= {:type "query"
+                  :query {:source-table ["my-db" nil "customers"]
+                          :filter       [">=" [:field ["my-db" nil "customers" "age"] nil] 18]
+                          :aggregation  [[:count]]}
+                  :database "my-db"}
+                 (->> (by-model @serialized "Card")
+                      first
+                      :dataset_query))))
 
         (testing "deserializing adjusts the IDs properly"
           (ts/with-dest-db

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -325,7 +325,8 @@
       (update :table_id      serdes.util/export-table-fk)
       (update :collection_id serdes.util/export-fk 'Collection)
       (update :creator_id    serdes.util/export-fk-keyed 'User :email)
-      (update :dataset_query serdes.util/export-json-mbql)))
+      (update :dataset_query serdes.util/export-json-mbql)
+      (dissoc :result_metadata))) ; Not portable, and can be rebuilt on the other side.
 
 (defmethod serdes.base/load-xform "Card"
   [card]

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -324,7 +324,8 @@
       (update :database_id   serdes.util/export-fk-keyed 'Database :name)
       (update :table_id      serdes.util/export-table-fk)
       (update :collection_id serdes.util/export-fk 'Collection)
-      (update :creator_id    serdes.util/export-fk-keyed 'User :email)))
+      (update :creator_id    serdes.util/export-fk-keyed 'User :email)
+      (update :dataset_query serdes.util/export-json-mbql)))
 
 (defmethod serdes.base/load-xform "Card"
   [card]
@@ -333,10 +334,12 @@
       (update :database_id   serdes.util/import-fk-keyed 'Database :name)
       (update :table_id      serdes.util/import-table-fk)
       (update :creator_id    serdes.util/import-fk-keyed 'User :email)
-      (update :collection_id serdes.util/import-fk 'Collection)))
+      (update :collection_id serdes.util/import-fk 'Collection)
+      (update :dataset_query serdes.util/import-json-mbql)))
 
 (defmethod serdes.base/serdes-dependencies "Card"
-  [{:keys [collection_id table_id]}]
+  [{:keys [collection_id dataset_query table_id]}]
   ;; The Table implicitly depends on the Database.
-  [(serdes.util/table->path table_id)
-   [{:model "Collection" :id collection_id}]])
+  (into [] (set/union #{(serdes.util/table->path table_id)
+                        [{:model "Collection" :id collection_id}]}
+                      (serdes.util/mbql-deps dataset_query))))

--- a/src/metabase/models/serialization/util.clj
+++ b/src/metabase/models/serialization/util.clj
@@ -2,7 +2,16 @@
   "Helpers intended to be shared by various models.
   Most of these are common operations done while (de)serializing several models, like handling a foreign key on a Table
   or user."
-  (:require [metabase.models.serialization.base :as serdes.base]
+  (:require [cheshire.core :as json]
+            [clojure.core.match :refer [match]]
+            [clojure.set :as set]
+            [clojure.string :as str]
+            [medley.core :as m]
+            [metabase.mbql.normalize :as mbql.normalize]
+            [metabase.mbql.schema :as mbql.s]
+            [metabase.mbql.util :as mbql.u]
+            [metabase.models.serialization.base :as serdes.base]
+            [metabase.shared.models.visualization-settings :as mb.viz]
             [toucan.db :as db]
             [toucan.models :as models]))
 
@@ -66,7 +75,7 @@
 (defn import-table-fk
   "Given a `table_id` as exported by [[export-table-fk]], resolve it back into a numeric `table_id`."
   [[db-name schema table-name]]
-  (db/select-one-field :id 'Table :name table-name :schema schema :db_id (db/select-one-id 'Database :name db-name)))
+  (db/select-one-field :id 'Table :name table-name :schema schema :db_id (db/select-one-field :id 'Database :name db-name)))
 
 (defn table->path
   "Given a `table_id` as exported by [[export-table-fk]], turn it into a `[{:model ...}]` path for the Table.
@@ -100,3 +109,153 @@
                   (when schema {:model "Schema" :id schema})
                   {:model "Table" :id table-name}
                   {:model "Field" :id field-name}]))
+
+;; ---------------------------------------------- JSON-encoded MBQL --------------------------------------------------
+(defn- mbql-entity-reference?
+  "Is given form an MBQL entity reference?"
+  [form]
+  (mbql.normalize/is-clause? #{:field :field-id :fk-> :metric :segment} form))
+
+(defn- mbql-id->fully-qualified-name
+  [mbql]
+  (-> mbql
+      mbql.normalize/normalize-tokens
+      (mbql.u/replace
+        ;; `integer?` guard is here to make the operation idempotent
+        [:field (id :guard integer?) opts]
+        [:field (export-field-fk id) (mbql-id->fully-qualified-name opts)]
+
+        ;; field-id is still used within parameter mapping dimensions
+        ;; example relevant clause - [:dimension [:fk-> [:field-id 1] [:field-id 2]]]
+        [:field-id (id :guard integer?)]
+        [:field-id (export-field-fk id)]
+
+        {:source-table (id :guard integer?)}
+        (assoc &match :source-table (export-table-fk id))
+
+        ;; source-field is also used within parameter mapping dimensions
+        ;; example relevant clause - [:field 2 {:source-field 1}]
+        {:source-field (id :guard integer?)}
+        (assoc &match :source-field (export-field-fk id))
+
+        [:metric (id :guard integer?)]
+        [:metric (export-fk id 'Metric)]
+
+        [:segment (id :guard integer?)]
+        [:segment (export-fk id 'Segment)])))
+
+(defn- ids->fully-qualified-names
+  [entity]
+  (mbql.u/replace entity
+    mbql-entity-reference?
+    (mbql-id->fully-qualified-name &match)
+
+    map?
+    (as-> &match entity
+      (m/update-existing entity :database (fn [db-id]
+                                            (if (= db-id mbql.s/saved-questions-virtual-database-id)
+                                              "database/__virtual"
+                                              (db/select-one-field :name 'Database :id db-id))))
+      (m/update-existing entity :card_id #(export-fk % 'Card)) ; attibutes that refer to db fields use _
+      (m/update-existing entity :card-id #(export-fk % 'Card)) ; template-tags use dash
+      (m/update-existing entity :source-table (fn [source-table]
+                                                (if (and (string? source-table)
+                                                         (str/starts-with? source-table "card__"))
+                                                  (export-fk (-> source-table
+                                                                 (str/split #"__")
+                                                                 second
+                                                                 Integer/parseInt)
+                                                             'Card)
+                                                  (export-table-fk source-table))))
+      (m/update-existing entity :breakout (fn [breakout]
+                                            (map mbql-id->fully-qualified-name breakout)))
+      (m/update-existing entity :aggregation (fn [aggregation]
+                                               (m/map-vals mbql-id->fully-qualified-name aggregation)))
+      (m/update-existing entity :filter (fn [filter]
+                                          (m/map-vals mbql-id->fully-qualified-name filter)))
+      (m/update-existing entity ::mb.viz/param-mapping-source export-field-fk)
+      (m/update-existing entity :snippet-id export-fk 'NativeQuerySnippet)
+      (m/map-vals ids->fully-qualified-names entity))))
+
+(defn export-json-mbql
+  "Given a JSON string with an MBQL expression inside it, convert it to an EDN structure and turn the non-portable
+  Database, Table and Field IDs inside it into portable references. Returns it as an EDN structure, which is more
+  human-fiendly in YAML."
+  [encoded]
+  (-> encoded
+      (json/parse-string true)
+      ids->fully-qualified-names))
+
+(defn- mbql-fully-qualified-names->ids*
+  [entity]
+  (mbql.u/replace entity
+    ;; handle legacy `:field-id` forms encoded prior to 0.39.0
+    ;; and also *current* expresion forms used in parameter mapping dimensions
+    ;; example relevant clause - [:dimension [:fk-> [:field-id 1] [:field-id 2]]]
+    [:field-id (fully-qualified-name :guard string?)]
+    (mbql-fully-qualified-names->ids* [:field fully-qualified-name nil])
+
+    [:field (fully-qualified-name :guard vector?) opts]
+    [:field (import-field-fk fully-qualified-name) (mbql-fully-qualified-names->ids* opts)]
+
+    ;; source-field is also used within parameter mapping dimensions
+    ;; example relevant clause - [:field 2 {:source-field 1}]
+    {:source-field (fully-qualified-name :guard vector?)}
+    (assoc &match :source-field (import-field-fk fully-qualified-name))
+
+    {:database (fully-qualified-name :guard string?)}
+    (-> &match
+        (assoc :database (db/select-one-id 'Database :name fully-qualified-name))
+        mbql-fully-qualified-names->ids*) ; Process other keys
+
+    [:metric (fully-qualified-name :guard serdes.base/entity-id?)]
+    [:metric (import-fk fully-qualified-name 'Metric)]
+
+    [:segment (fully-qualified-name :guard serdes.base/entity-id?)]
+    [:segment (import-fk fully-qualified-name 'Segment)]
+
+    (_ :guard (every-pred map? #(vector? (:source-table %))))
+    (-> &match
+        (assoc :source-table (import-table-fk (:source-table &match)))
+        mbql-fully-qualified-names->ids*))) ;; process other keys
+
+(defn- mbql-fully-qualified-names->ids
+  [entity]
+  (mbql-fully-qualified-names->ids* entity))
+
+(defn import-json-mbql
+  "Given an MBQL expression as an EDN structure with portable IDs embedded, convert the IDs back to raw numeric IDs
+  and then convert the result back into a JSON string."
+  [exported]
+  (-> exported
+      mbql-fully-qualified-names->ids
+      json/generate-string))
+
+(declare ^:private mbql-deps-map)
+
+(defn- mbql-deps-vector [entity]
+  (match entity
+         [:field (field :guard vector?) tail] (into #{(field->path field)} (mbql-deps-map tail))
+         :else (reduce #(cond
+                          (map? %2)    (into %1 (mbql-deps-map %2))
+                          (vector? %2) (into %1 (mbql-deps-vector %2))
+                          :else %1)
+                       #{}
+                       entity)))
+
+(defn- mbql-deps-map [entity]
+  (->> (for [[k v] entity]
+         (cond
+           (and (= k :database)     (string? v)) #{[{:model "Database" :id v}]}
+           (and (= k :source-table) (vector? v)) #{(table->path v)}
+           (and (= k :source-field) (vector? v)) #{(field->path v)}
+           (map? v)                              (mbql-deps-map v)
+           (vector? v)                           (mbql-deps-vector v)))
+       (reduce set/union #{})))
+
+(defn mbql-deps
+  "Given an MBQL expression as exported, with qualified names like `[\"some-db\" \"schema\" \"table_name\"]` instead of
+  raw IDs, return the corresponding set of serdes-dependencies. The query can't be imported until all the referenced
+  databases, tables and fields are loaded."
+  [entity]
+  (mbql-deps-map entity)) ;; process other keys


### PR DESCRIPTION
So far this is only supported for `Card.dataset_query`; it needs to be
extended to any other fields that hold MBQL as JSON.

Please help me build up a list of all the MBQL fields. A decent but imperfect
guide is to look for fields with interesting Toucan `:types`.
