### PR TITLE
add dummy workflow clones to make originals required

### DIFF
--- a/.github/workflows/e2e-tests-skipped-checks.yml
+++ b/.github/workflows/e2e-tests-skipped-checks.yml
@@ -46,4 +46,5 @@ jobs:
             context: grep
             java-version: 11
     steps:
-      - run: 'echo "No build required" '
+      - run: |
+          echo "Didn't run due to conditional filtering"

--- a/.github/workflows/e2e-tests-skipped-checks.yml
+++ b/.github/workflows/e2e-tests-skipped-checks.yml
@@ -1,0 +1,49 @@
+# Required checks with path filtering rules will block pull requests from merging if they change only the excluded files.
+# This is a workaround to allow the PR to be merged.
+# https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+name: E2E Tests for PR
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - "docs/**"
+      - "**.md"
+      - ".circleci/**"
+      - "**.unit.spec.*"
+
+jobs:
+  e2e-tests:
+    runs-on: ubuntu-latest
+    name: e2e-tests-${{ matrix.folder }}${{ matrix.context }}-${{ matrix.edition }}
+    strategy:
+      fail-fast: false
+      matrix:
+        java-version: [11]
+        edition: [ee]
+        folder:
+          - "admin"
+          - "binning"
+          - "collections"
+          - "custom-column"
+          - "dashboard"
+          - "dashboard-filters"
+          - "downloads"
+          - "embedding"
+          - "filters"
+          - "joins"
+          - "models"
+          - "native"
+          - "native-filters"
+          - "onboarding"
+          - "organization"
+          - "permissions"
+          - "question"
+          - "sharing"
+          - "visualizations"
+        include:
+          - edition: oss
+            context: grep
+            java-version: 11
+    steps:
+      - run: 'echo "No build required" '

--- a/.github/workflows/fuzzing-skipped-checks.yml
+++ b/.github/workflows/fuzzing-skipped-checks.yml
@@ -17,9 +17,11 @@ jobs:
   fe-fuzz-tokenizer:
     runs-on: ubuntu-latest
     steps:
-      - run: 'echo "No build required" '
+      - run: |
+          echo "Didn't run due to conditional filtering"
 
   fe-fuzz-recursive-parser:
     runs-on: ubuntu-latest
     steps:
-      - run: 'echo "No build required" '
+      - run: |
+          echo "Didn't run due to conditional filtering"

--- a/.github/workflows/fuzzing-skipped-checks.yml
+++ b/.github/workflows/fuzzing-skipped-checks.yml
@@ -1,0 +1,25 @@
+# Required checks with path filtering rules will block pull requests from merging if they change only the excluded files.
+# This is a workaround to allow the PR to be merged.
+# https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+name: Fuzzing
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'release-**'
+  pull_request:
+    paths:
+    - 'docs/**'
+
+jobs:
+
+  fe-fuzz-tokenizer:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required" '
+
+  fe-fuzz-recursive-parser:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required" '

--- a/.github/workflows/presto-kerberos-integration-test-skipped-checks.yml
+++ b/.github/workflows/presto-kerberos-integration-test-skipped-checks.yml
@@ -19,4 +19,5 @@ jobs:
   run-presto-kerberos-test:
     runs-on: ubuntu-latest
     steps:
-      - run: 'echo "No build required" '
+      - run: |
+          echo "Didn't run due to conditional filtering"

--- a/.github/workflows/presto-kerberos-integration-test-skipped-checks.yml
+++ b/.github/workflows/presto-kerberos-integration-test-skipped-checks.yml
@@ -1,0 +1,22 @@
+# Required checks with path filtering rules will block pull requests from merging if they change only the excluded files.
+# This is a workaround to allow the PR to be merged.
+# https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+name: Kerberized Presto Integration Test
+
+on:
+  pull_request:
+    paths-ignore:
+    - '**/presto_jdbc/**'
+    - '**/presto_jdbc.clj'
+  push:
+    branches:
+      - 'feature**'
+    paths-ignore:
+    - '**/presto_jdbc/**'
+    - '**/presto_jdbc.clj'
+
+jobs:
+  run-presto-kerberos-test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required" '

--- a/.github/workflows/snowplow-skipped-checks.yml
+++ b/.github/workflows/snowplow-skipped-checks.yml
@@ -1,0 +1,18 @@
+# Required checks with path filtering rules will block pull requests from merging if they change only the excluded files.
+# This is a workaround to allow the PR to be merged.
+# https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+name: Snowplow
+
+on:
+  pull_request:
+    branches:
+      - "**"
+    paths-ignore:
+      - "snowplow/**"
+      - ".github/workflows/**"
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required" '

--- a/.github/workflows/snowplow-skipped-checks.yml
+++ b/.github/workflows/snowplow-skipped-checks.yml
@@ -15,4 +15,5 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - run: 'echo "No build required" '
+      - run: |
+          echo "Didn't run due to conditional filtering"


### PR DESCRIPTION
## Changes

Unfortunately, due to GH limitations required checks with path filtering rules will block pull requests from merging if they change only the excluded files. The pretty unpleasant workaround suggested by GH is to create dummy workflows with inverted path filtering rules 😬

[GH docs](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks)

After merging we can mark the following checks as required:

```
e2e-tests-admin-ee
e2e-tests-binning-ee
e2e-tests-collections-ee
e2e-tests-custom-column-ee
e2e-tests-dashboard-ee
e2e-tests-dashboard-filters-ee
e2e-tests-downloads-ee
e2e-tests-embedding-ee
e2e-tests-filters-ee
e2e-tests-joins-ee
e2e-tests-models-ee
e2e-tests-native-ee
e2e-tests-native-filters-ee
e2e-tests-onboarding-ee
e2e-tests-organization-ee
e2e-tests-permissions-ee
e2e-tests-question-ee
e2e-tests-sharing-ee
e2e-tests-visualizations-ee
e2e-tests-grep-oss

fe-fuzz-tokenizer
fe-fuzz-recursive-parser

fe-linter-prettier
fe-linter-eslint
fe-type-check
fe-tests-unit
fe-tests-timezones
fe-chromatic

shared-tests-cljs
test-build-scripts

fe-linter-docs-links

run-presto-kerberos-test

lint
```
