### PR TITLE
Don't use error color for button hover

### DIFF
--- a/frontend/src/metabase/components/TokenFieldItem/TokenFieldItem.styled.ts
+++ b/frontend/src/metabase/components/TokenFieldItem/TokenFieldItem.styled.ts
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { color, alpha } from "metabase/lib/colors";
+import { color, alpha, darken } from "metabase/lib/colors";
 import { breakpointMinHeightMedium } from "metabase/styled-components/theme";
 
 export const TokenFieldItem = styled.li<{
@@ -26,6 +26,6 @@ export const TokenFieldAddon = styled.a<{
   color: ${({ isValid }) => (isValid ? "" : color("error"))};
 
   &:hover {
-    color: ${color("error")};
+    color: ${darken("brand", 0.2)};
   }
 `;


### PR DESCRIPTION
Error color was wrong for X hover

Before
![Screen Shot 2022-07-27 at 1 51 17 PM](https://user-images.githubusercontent.com/30528226/181359971-c4342cb0-2a46-441b-84ca-fa3f68d37364.png)

After
![Screen Shot 2022-07-27 at 1 49 21 PM](https://user-images.githubusercontent.com/30528226/181360008-5d1f3c17-b909-4811-919d-0a3322976d71.png)

