### PR TITLE
Lighter styling for selects in bulkFilterModal

### DIFF
--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterSelect/BulkFilterSelect.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterSelect/BulkFilterSelect.styled.tsx
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { color } from "metabase/lib/colors";
+import { color, alpha } from "metabase/lib/colors";
 import { breakpointMinHeightMedium } from "metabase/styled-components/theme";
 
 import SelectButton from "metabase/core/components/SelectButton";
@@ -8,26 +8,38 @@ import Select from "metabase/core/components/Select";
 
 type SelectFilterButtonProps = {
   isActive?: boolean;
+  hasValue?: boolean;
 };
 
-export const SelectFilterButton = styled(SelectButton)<SelectFilterButtonProps>`
-  grid-column: 2;
-  height: 40px;
-  ${breakpointMinHeightMedium} {
-    height: 56px;
-  }
+const lightSelectButton = ({ hasValue, isActive }: SelectFilterButtonProps) => `
+    height: 40px;
+    ${breakpointMinHeightMedium} {
+      height: 56px;
+    }
+    padding: 0.5rem 1rem;
 
-  ${({ isActive }) => (isActive ? `border-color: ${color("brand")};` : "")}
+    background-color: ${hasValue ? alpha("brand", 0.2) : "transparent"};
+    color: ${hasValue ? color("brand") : color("text-light")};
+    border-color: ${
+      isActive
+        ? color("brand")
+        : hasValue
+        ? "transparent"
+        : color("border-dark")
+    };
 
-  &:not(:first-of-type) {
-    margin-top: 0.75rem;
-  }
+    .Icon {
+      color: ${hasValue ? color("brand") : color("text-light")};
+    }
 `;
 
-export const SegmentSelect = styled(Select)`
-  height: 40px;
-  ${breakpointMinHeightMedium} {
-    height: 56px;
+export const SelectFilterButton = styled(SelectButton)<SelectFilterButtonProps>`
+  ${({ hasValue, isActive }) => lightSelectButton({ hasValue, isActive })}
+`;
+
+export const SegmentSelect = styled(Select)<SelectFilterButtonProps>`
+  button {
+    ${({ hasValue, isActive }) => lightSelectButton({ hasValue, isActive })}
   }
 `;
 

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterSelect/BulkFilterSelect.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterSelect/BulkFilterSelect.tsx
@@ -159,6 +159,7 @@ export const SegmentFilterSelect = ({
         icon: segment.icon,
       }))}
       value={activeSegmentOptions}
+      hasValue={activeSegmentOptions.length > 0}
       onChange={(e: any) => toggleSegment(e.target.value.changedItem)}
       multiple
       buttonProps={{


### PR DESCRIPTION
## Description

Aligning some styling we've settled on around light-blue active states for the segment select and the fallback bulk filter select

state | Before | After
-- | -- | --
Empty (unchanged) | ![Screen Shot 2022-07-27 at 2 24 27 PM](https://user-images.githubusercontent.com/30528226/181365406-60d32419-8142-4696-80ee-1138828b1420.png) | ![Screen Shot 2022-07-27 at 2 10 48 PM](https://user-images.githubusercontent.com/30528226/181365230-4e781e78-c3f5-4a86-8bcf-3eb1c02bc837.png)
Active | ![Screen Shot 2022-07-27 at 2 24 21 PM](https://user-images.githubusercontent.com/30528226/181365407-8f45415c-7078-4d4d-a4e8-7b84b44b4113.png) | ![Screen Shot 2022-07-27 at 2 10 55 PM](https://user-images.githubusercontent.com/30528226/181365228-505a932c-6967-4198-8988-77e8c4623cf0.png)





## Testing Steps

- find a table with segments defined (or [create a new segment](https://www.metabase.com/docs/latest/administration-guide/07-segments-and-metrics.html#creating-a-segment))
- open the bulk filter modal on that table
- see the new light-blue styling 

