### PR TITLE
Dont tokenize single input values

### DIFF
--- a/frontend/src/metabase/components/TokenField/TokenField.tsx
+++ b/frontend/src/metabase/components/TokenField/TokenField.tsx
@@ -539,7 +539,8 @@ export default class TokenField extends Component<
       selectedOptionValue,
     } = this.state;
 
-    if (!multi && isFocused) {
+    // for non-multi fields, keep the value in the input
+    if (!multi) {
       inputValue = inputValue || value[0];
       value = [];
     }
@@ -549,7 +550,8 @@ export default class TokenField extends Component<
       value.length > 0 &&
       updateOnInputChange &&
       parseFreeformValue &&
-      value[value.length - 1] === parseFreeformValue(inputValue)
+      value[value.length - 1] === parseFreeformValue(inputValue) &&
+      multi
     ) {
       if (isFocused) {
         // if focused, don't render the last value

--- a/frontend/src/metabase/components/TokenField/TokenField.unit.spec.js
+++ b/frontend/src/metabase/components/TokenField/TokenField.unit.spec.js
@@ -5,7 +5,7 @@ import React from "react";
 import { render, screen, fireEvent, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import TokenField from "metabase/components/TokenField";
+import TokenField from "./TokenField";
 
 import {
   KEYCODE_DOWN,
@@ -120,7 +120,11 @@ describe("TokenField", () => {
 
   it("should render with 1 options and 1 values", () => {
     render(
-      <TokenFieldWithStateAndDefaults value={["foo"]} options={["bar"]} />,
+      <TokenFieldWithStateAndDefaults
+        multi
+        value={["foo"]}
+        options={["bar"]}
+      />,
     );
     findWithinValues(["foo"]);
     findWithinOptions(["bar"]);
@@ -186,7 +190,11 @@ describe("TokenField", () => {
 
   it("should add clicked option to values and hide it in options list", () => {
     render(
-      <TokenFieldWithStateAndDefaults value={[]} options={["bar", "baz"]} />,
+      <TokenFieldWithStateAndDefaults
+        multi
+        value={[]}
+        options={["bar", "baz"]}
+      />,
     );
     findWithinOptions(["bar", "baz"]);
 
@@ -197,7 +205,11 @@ describe("TokenField", () => {
 
   it("should add option when filtered and clicked", () => {
     render(
-      <TokenFieldWithStateAndDefaults value={[]} options={["foo", "bar"]} />,
+      <TokenFieldWithStateAndDefaults
+        multi
+        value={[]}
+        options={["foo", "bar"]}
+      />,
     );
     type("ba");
     clickText("bar");
@@ -463,6 +475,7 @@ describe("TokenField", () => {
           getData: () => "1,2,3",
         },
       });
+
       findWithinValues(["1", "2", "3"]);
       // prevent pasting into <input>
       expect(input().value).toBe("");
@@ -482,7 +495,7 @@ describe("TokenField", () => {
       type("asdf");
       input().focus();
       userEvent.tab();
-      findWithinValues(["asdf"]);
+      expect(input()).not.toHaveFocus();
     });
 
     it('should paste "1,2,3" as one value', () => {
@@ -499,8 +512,8 @@ describe("TokenField", () => {
           getData: () => DATA,
         },
       });
-      findWithinValues([DATA]);
-      expect(input().value).toBe("");
+
+      expect(input().value).toBe(DATA);
     });
   });
 

--- a/frontend/src/metabase/parameters/components/widgets/StringInputWidget/StringInputWidget.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/StringInputWidget/StringInputWidget.unit.spec.tsx
@@ -17,8 +17,7 @@ describe("StringInputWidget", () => {
 
       const textbox = screen.getByRole("textbox");
       expect(textbox).toBeInTheDocument();
-      const values = screen.getAllByRole("list")[0];
-      expect(values.textContent).toEqual("foo");
+      expect(screen.getByDisplayValue("foo")).toBeInTheDocument();
     });
 
     it("should render an empty input", () => {

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterItem/BulkFilterItem.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterItem/BulkFilterItem.unit.spec.tsx
@@ -329,7 +329,7 @@ describe("BulkFilterItem", () => {
       />,
     );
     screen.getByTestId("value-picker");
-    screen.getByText("foo");
+    screen.getByDisplayValue("foo");
   });
 
   it("defaults key filters to 'is' operator", () => {

--- a/frontend/test/metabase/scenarios/filters/reproductions/9339-clipboard-numeric-filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/reproductions/9339-clipboard-numeric-filter.cy.spec.js
@@ -15,7 +15,7 @@ describe("issue 9339", () => {
     cy.findByText("Greater than").click();
 
     paste(cy.findByPlaceholderText("Enter a number"), "9339,1234");
-    cy.findByText("9,339").should("be.visible");
+    cy.findByDisplayValue("9339").should("be.visible");
     cy.findByText("1,234").should("not.exist");
     cy.button("Add filter").should("be.enabled");
   });


### PR DESCRIPTION
## Description

It doesn't make sense to put single value inputs (like `contains`, `starts with`, `ends with`, etc) in a token. this keeps them in an input

![bettertokens](https://user-images.githubusercontent.com/30528226/181378150-63d36699-1691-4c3d-ba42-d24e03fadc0d.png)


## Testing

- In Application locations: In the bulk filter modal, or in a column filter popover, or in a filter popover in notebook mode
- For Different field types: strings or numbers
- All of these operations work as expected
  - single input operators like `less than`, `contains`, or `ends with` keep their single value in an input, and do not create a light blue token
  - field search works for fields like name
  - clicking search suggestions works as expected
  - multi-token inputs (`is` and `is not`) continue to tokenize inputs on blur or comma
  - adding and removing values continues to work properly