### PR TITLE
Substitute locked params on embedded dashboards into text cards on the backend

### DIFF
--- a/src/metabase/api/embed.clj
+++ b/src/metabase/api/embed.clj
@@ -136,7 +136,7 @@
   make these parameters visible at all to the frontend."
   [dashboard token-params]
   (let [params             (:parameters dashboard)
-        ordered-cards       (:ordered_cards dashboard)
+        ordered-cards      (:ordered_cards dashboard)
         params-with-values (reduce
                             (fn [acc param]
                              (if-let [value (get token-params (keyword (:slug param)))]
@@ -144,14 +144,14 @@
                                 acc))
                             []
                             params)]
-    (assoc
-     dashboard
-     :ordered_cards
-     (map (fn [card]
-            (if (-> card :visualization_settings :virtual_card)
-              (params/process-virtual-dashcard card params-with-values)
-              card))
-          ordered-cards))))
+    (assoc dashboard
+           :ordered_cards
+           (map
+            (fn [card]
+              (if (-> card :visualization_settings :virtual_card)
+                (params/process-virtual-dashcard card params-with-values)
+                card))
+            ordered-cards))))
 
 (defn- template-tag-parameters
   "Transforms native query's `template-tags` into `parameters`."

--- a/src/metabase/api/embed.clj
+++ b/src/metabase/api/embed.clj
@@ -27,6 +27,7 @@
             [metabase.driver.common.parameters.operators :as params.ops]
             [metabase.models.card :refer [Card]]
             [metabase.models.dashboard :refer [Dashboard]]
+            [metabase.pulse.parameters :as params]
             [metabase.query-processor :as qp]
             [metabase.query-processor.middleware.constraints :as qp.constraints]
             [metabase.query-processor.pivot :as qp.pivot]
@@ -128,6 +129,29 @@
   user."
   [dashboard-or-card token-params]
   (update dashboard-or-card :parameters remove-params-in-set (set (keys token-params))))
+
+(defn- substitute-token-parameters-in-text
+  "For any dashboard parameters with slugs matching keys provided in `token-params`, substitute their values from the
+  token into any Markdown dashboard cards with linked variables. This needs to be done on the backend because we don't
+  make these parameters visible at all to the frontend."
+  [dashboard token-params]
+  (let [params             (:parameters dashboard)
+        ordered-cards       (:ordered_cards dashboard)
+        params-with-values (reduce
+                            (fn [acc param]
+                             (if-let [value (get token-params (keyword (:slug param)))]
+                                (conj acc (assoc param :value value))
+                                acc))
+                            []
+                            params)]
+    (assoc
+     dashboard
+     :ordered_cards
+     (map (fn [card]
+            (if (-> card :visualization_settings :virtual_card)
+              (params/process-virtual-dashcard card params-with-values)
+              card))
+          ordered-cards))))
 
 (defn- template-tag-parameters
   "Transforms native query's `template-tags` into `parameters`."
@@ -250,6 +274,7 @@
   (let [dashboard-id (embed/get-in-unsigned-token-or-throw unsigned-token [:resource :dashboard])
         token-params (embed/get-in-unsigned-token-or-throw unsigned-token [:params])]
     (-> (apply api.public/public-dashboard :id dashboard-id, constraints)
+        (substitute-token-parameters-in-text token-params)
         (remove-token-parameters token-params)
         (remove-locked-and-disabled-params (or embedding-params
                                                (db/select-one-field :embedding_params Dashboard, :id dashboard-id))))))

--- a/test/metabase/api/embed_test.clj
+++ b/test/metabase/api/embed_test.clj
@@ -420,6 +420,23 @@
         (is (= [{:id "_d", :slug "d", :name "d", :type "date"}]
                (:parameters (client/client :get 200 (dashboard-url dash {:params {:c 100}})))))))))
 
+(deftest locked-params-are-substituted-into-text-cards
+  (testing "check that locked params are substituted into text cards with mapped variables on the backend"
+    (with-embedding-enabled-and-new-secret-key
+      (mt/with-temp* [Dashboard     [dash {:enable_embedding true
+                                           :parameters       [{:id "_a" :slug "a", :name "a", :type :string/=}]}]
+                      DashboardCard [_ {:dashboard_id           (:id dash)
+                                        :parameter_mappings     [{:parameter_id "_a",
+                                                                  :target       [:text-tag "foo"]}]
+                                        :visualization_settings {:virtual_card {:display "text"}
+                                                                 :text         "Text card with variable: {{foo}}"}}]]
+        (is (= "Text card with variable: bar"
+               (-> (client/client :get 200 (dashboard-url dash {:params {:a "bar"}}))
+                   :ordered_cards
+                   first
+                   :visualization_settings
+                   :text)))))))
+
 
 ;;; ---------------------- GET /api/embed/dashboard/:token/dashcard/:dashcard-id/card/:card-id -----------------------
 


### PR DESCRIPTION
Locked params are removed from embedded dashboards on the backend before the dashboard is returned, and the frontend doesn't have any knowledge of them. Instead, values are provided via the embedding token. So if any params in the token are linked to variables in any Markdown cards, we need to do the substitution on the backend.