### PR TITLE
Large category picker in bulk filter modal

### DIFF
--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineCategoryPicker/InlineCategoryPicker.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineCategoryPicker/InlineCategoryPicker.styled.tsx
@@ -1,6 +1,9 @@
 import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
-import { space } from "metabase/styled-components/theme";
+import {
+  space,
+  breakpointMinHeightMedium,
+} from "metabase/styled-components/theme";
 
 import LoadingSpinner from "metabase/components/LoadingSpinner";
 
@@ -18,4 +21,33 @@ export const PickerGrid = styled.div`
   display: grid;
   align-items: center;
   gap: ${space(2)};
+`;
+
+export const TokenFieldContainer = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  padding: ${space(0)};
+  gap: ${space(0)};
+  font-weight: bold;
+  cursor: pointer;
+
+  max-height: 200px;
+  overflow-y: auto;
+
+  border-radius: ${space(1)};
+  border: 1px solid ${color("border-dark")};
+`;
+
+export const AddText = styled.div`
+  min-height: 30px;
+
+  ${breakpointMinHeightMedium} {
+    height: 46px;
+  }
+  margin-left: ${space(1)};
+  border: none;
+  display: flex;
+  align-items: center;
+
+  color: ${color("text-light")};
 `;

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineCategoryPicker/InlineCategoryPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineCategoryPicker/InlineCategoryPicker.tsx
@@ -2,24 +2,23 @@ import React, { useState, useEffect } from "react";
 import { connect } from "react-redux";
 import { t } from "ttag";
 
-import Filter from "metabase-lib/lib/queries/structured/Filter";
+import type Filter from "metabase-lib/lib/queries/structured/Filter";
 import Fields from "metabase/entities/fields";
 import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
 import Dimension from "metabase-lib/lib/Dimension";
 import { useSafeAsyncFunction } from "metabase/hooks/use-safe-async-function";
 
 import Warnings from "metabase/query_builder/components/Warnings";
-import Checkbox from "metabase/core/components/CheckBox";
 
-import { BulkFilterSelect } from "../BulkFilterSelect";
 import { InlineValuePicker } from "../InlineValuePicker";
 
 import { MAX_INLINE_CATEGORIES } from "./constants";
-import {
-  PickerContainer,
-  PickerGrid,
-  Loading,
-} from "./InlineCategoryPicker.styled";
+import { isValidOption } from "./utils";
+
+import { SimpleCategoryFilterPicker } from "./SimpleCategoryFilterPicker";
+import { LargeCategoryFilterPicker } from "./LargeCategoryFilterPicker";
+
+import { Loading } from "./InlineCategoryPicker.styled";
 
 const mapStateToProps = (state: any, props: any) => {
   const fieldId = props.dimension?.field?.()?.id;
@@ -83,8 +82,9 @@ export function InlineCategoryPickerComponent({
       });
   }, [dimension, safeFetchFieldValues, shouldFetchFieldValues]);
 
-  const hasCheckboxOperator =
-    !filter || ["=", "!="].includes(filter?.operatorName());
+  const hasCheckboxOperator = ["=", "!="].includes(
+    (filter ?? newFilter)?.operatorName(),
+  );
 
   const hasValidOptions = fieldValues.flat().find(isValidOption);
 
@@ -121,12 +121,12 @@ export function InlineCategoryPickerComponent({
 
   if (showPopoverPicker) {
     return (
-      <BulkFilterSelect
+      <LargeCategoryFilterPicker
         query={query}
-        filter={filter}
+        filter={filter ?? newFilter}
         dimension={dimension}
-        handleChange={onChange}
-        handleClear={onClear}
+        onChange={onChange}
+        onClear={onClear}
       />
     );
   }
@@ -139,45 +139,6 @@ export function InlineCategoryPickerComponent({
     />
   );
 }
-
-interface SimpleCategoryFilterPickerProps {
-  filter: Filter;
-  options: (string | number)[];
-  onChange: (newFilter: Filter) => void;
-}
-
-export function SimpleCategoryFilterPicker({
-  filter,
-  options,
-  onChange,
-}: SimpleCategoryFilterPickerProps) {
-  const filterValues = filter.arguments().filter(isValidOption);
-
-  const handleChange = (option: string | number, checked: boolean) => {
-    const newArgs = checked
-      ? [...filterValues, option]
-      : filterValues.filter(filterValue => filterValue !== option);
-
-    onChange(filter.setArguments(newArgs));
-  };
-
-  return (
-    <PickerContainer data-testid="category-picker">
-      <PickerGrid>
-        {options.map((option: string | number) => (
-          <Checkbox
-            key={option?.toString() ?? "empty"}
-            checked={filterValues.includes(option)}
-            onChange={e => handleChange(option, e.target.checked)}
-            label={option?.toString() ?? t`empty`}
-          />
-        ))}
-      </PickerGrid>
-    </PickerContainer>
-  );
-}
-
-const isValidOption = (option: any) => option !== undefined && option !== null;
 
 export const InlineCategoryPicker = connect(
   mapStateToProps,

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineCategoryPicker/LargeCategoryFilterPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineCategoryPicker/LargeCategoryFilterPicker.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+import { t } from "ttag";
+
+import type Filter from "metabase-lib/lib/queries/structured/Filter";
+import type StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
+import type Dimension from "metabase-lib/lib/Dimension";
+import { pluralize } from "metabase/lib/formatting";
+
+import Icon from "metabase/components/Icon";
+
+import { BulkFilterSelect } from "../BulkFilterSelect";
+import { TokenFieldContainer, AddText } from "./InlineCategoryPicker.styled";
+
+import {
+  TokenFieldItem,
+  TokenFieldAddon,
+} from "metabase/components/TokenFieldItem";
+
+import { isValidOption } from "./utils";
+
+interface LargeCategoryFilterPickerProps {
+  query: StructuredQuery;
+  filter: Filter;
+  dimension: Dimension;
+  onChange: (newFilter: Filter) => void;
+  onClear: () => void;
+}
+
+export function LargeCategoryFilterPicker({
+  query,
+  filter,
+  dimension,
+  onChange,
+  onClear,
+}: LargeCategoryFilterPickerProps) {
+  const filterValues = filter.arguments().filter(isValidOption);
+
+  const removeValue = (value: string | number) =>
+    onChange(
+      filter.setArguments(
+        filterValues.filter(filterValue => filterValue !== value),
+      ),
+    );
+
+  const preventDefault = (e: React.SyntheticEvent) => e.preventDefault();
+
+  return (
+    <BulkFilterSelect
+      query={query}
+      filter={filter}
+      dimension={dimension}
+      handleChange={onChange}
+      handleClear={onClear}
+      customTrigger={({ onClick }) => (
+        <TokenFieldContainer
+          data-testid="large-category-picker"
+          onClick={onClick}
+        >
+          {filterValues.map(filterValue => (
+            <TokenFieldItem key={filterValue} isValid onClick={preventDefault}>
+              <span>{filterValue}</span>
+              <TokenFieldAddon
+                isValid
+                onClick={e => {
+                  e.stopPropagation();
+                  removeValue(filterValue);
+                }}
+              >
+                <Icon name="close" className="flex align-center" size={12} />
+              </TokenFieldAddon>
+            </TokenFieldItem>
+          ))}
+          <AddText data-testid="select-filter-option">
+            {t`Select ${pluralize(dimension.displayName().toLowerCase())}...`}
+          </AddText>
+        </TokenFieldContainer>
+      )}
+    />
+  );
+}

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineCategoryPicker/SimpleCategoryFilterPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineCategoryPicker/SimpleCategoryFilterPicker.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { t } from "ttag";
+import Checkbox from "metabase/core/components/CheckBox";
+
+import type Filter from "metabase-lib/lib/queries/structured/Filter";
+
+import { PickerContainer, PickerGrid } from "./InlineCategoryPicker.styled";
+
+import { isValidOption } from "./utils";
+
+interface SimpleCategoryFilterPickerProps {
+  filter: Filter;
+  options: (string | number)[];
+  onChange: (newFilter: Filter) => void;
+}
+
+export function SimpleCategoryFilterPicker({
+  filter,
+  options,
+  onChange,
+}: SimpleCategoryFilterPickerProps) {
+  const filterValues = filter.arguments().filter(isValidOption);
+
+  const handleChange = (option: string | number, checked: boolean) => {
+    const newArgs = checked
+      ? [...filterValues, option]
+      : filterValues.filter(filterValue => filterValue !== option);
+
+    onChange(filter.setArguments(newArgs));
+  };
+
+  return (
+    <PickerContainer data-testid="category-picker">
+      <PickerGrid>
+        {options.map((option: string | number) => (
+          <Checkbox
+            key={option?.toString() ?? "empty"}
+            checked={filterValues.includes(option)}
+            onChange={e => handleChange(option, e.target.checked)}
+            label={option?.toString() ?? t`empty`}
+          />
+        ))}
+      </PickerGrid>
+    </PickerContainer>
+  );
+}

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineCategoryPicker/utils.ts
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineCategoryPicker/utils.ts
@@ -1,0 +1,2 @@
+export const isValidOption = (option: any) =>
+  option !== undefined && option !== null;

--- a/frontend/test/__support__/e2e/helpers/e2e-bi-basics-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-bi-basics-helpers.js
@@ -28,7 +28,7 @@ export function filterFieldPopover(
   { value, placeholder, order } = {},
 ) {
   getFilterField(fieldName, order).within(() => {
-    cy.findByTestId("select-button").click();
+    cy.findByTestId("select-filter-option").click();
   });
 
   if (value) {

--- a/frontend/test/metabase/scenarios/filters/filter-bulk.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/filter-bulk.cy.spec.js
@@ -98,10 +98,11 @@ describe("scenarios > filters > bulk filtering", () => {
     visitQuestionAdhoc(rawQuestionDetails);
     filter();
 
-    filterFieldPopover("Quantity", { value: "20" });
+    filterField("Quantity", { operator: "equal to" });
+    filterFieldPopover("Quantity");
 
     cy.findByLabelText("20").click();
-    cy.button("Add filter").click();
+    cy.button("Update filter").click();
     applyFilters();
 
     cy.findByText("Quantity is equal to 20").should("be.visible");
@@ -398,16 +399,12 @@ describe("scenarios > filters > bulk filtering", () => {
       cy.findByText("Showing 506 rows").should("be.visible");
     });
 
-    it("should not show inline category picker for state", () => {
-      modal().within(() => {
-        cy.findByLabelText("State").click();
-      });
-
-      popover().within(() => {
+    it("should show large category picker for state", () => {
+      cy.findByTestId("large-category-picker").should("exist");
+      filterFieldPopover("State").within(() => {
         cy.findByText("AZ").click();
-        cy.button("Add filter").click();
+        cy.button("Update filter").click();
       });
-
       applyFilters();
 
       cy.findByText("State is AZ").should("be.visible");

--- a/frontend/test/metabase/scenarios/filters/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/filter.cy.spec.js
@@ -121,7 +121,7 @@ describe("scenarios > question > filter", () => {
     filter();
 
     filterFieldPopover("Product ID").contains("Aerodynamic Linen Coat").click();
-    cy.findByText("Add filter").click();
+    cy.findByText("Update filter").click();
 
     cy.findByTestId("apply-filters").click();
 


### PR DESCRIPTION
## Description

Instead of hiding category selections behind a big select button, we'll show the tokens inline, but still keep selection in a popover - aligning the styles with the FieldValuesWidget

## Implementation

- Splits existings `SimpleCategoryFilterPicker` into its own file (used for up to 12 distinct values)
- Creates a new `LargeCategoryFilterPicker` for list selection for fields with more than 12 distinct values

![Screen Shot 2022-07-26 at 12 50 51 PM](https://user-images.githubusercontent.com/30528226/181088032-a87abc81-0e68-4b7c-a804-3dca12c7879b.png)

The component is responsive to viewport height
. | . 
-- | --
large | ![Screen Shot 2022-07-26 at 10 22 44 AM](https://user-images.githubusercontent.com/30528226/181088192-749cf390-366d-40c8-af26-55ee3d52ca31.png)
small | ![Screen Shot 2022-07-26 at 10 22 32 AM](https://user-images.githubusercontent.com/30528226/181088199-1783820e-0a4b-44f4-aba1-6c60ded3cdd6.png)



## Testing
- You should be able to add and remove values from long lists (the `State` Field in the `People` table is a good one to test) for is/is not operators
- Styling should look good on the FieldValuesWidget as well (any text field in the filter modal or in the column header popovers)
- Token Styling should be responsive to window height such that the inputs toggle between 40px and 56px high

