### PR TITLE
Don't use list icon for fields in bulk filter modal

### DIFF
--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterItem/BulkFilterItem.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterItem/BulkFilterItem.tsx
@@ -92,7 +92,7 @@ export const BulkFilterItem = ({
             fieldName={dimension.displayName()}
             value={currentOperator}
             operators={dimension.filterOperators(currentOperator)}
-            iconName="list"
+            iconName={dimension?.icon() ?? undefined}
             tableName={tableName}
             onChange={changeOperator}
           />


### PR DESCRIPTION
## Description

We shouldn't use the list icon: we're not trying to depict the sort of filter we're displaying, we're depicting the type of data in the field.

Before

![Screen Shot 2022-07-27 at 6 00 07 PM](https://user-images.githubusercontent.com/30528226/181392381-7c73d977-48fb-4f99-9710-945452430132.png)

After

![Screen Shot 2022-07-27 at 5 59 57 PM](https://user-images.githubusercontent.com/30528226/181392388-4ca760a2-57b9-4ca3-9799-da76cb9ad1c5.png)
