### PR TITLE
Remove deprecated function formatHourAMPM

### DIFF
--- a/frontend/src/metabase/lib/time.js
+++ b/frontend/src/metabase/lib/time.js
@@ -101,20 +101,6 @@ export function parseTime(value) {
   return moment.utc(value);
 }
 
-// @deprecated - use formatTimeWithUnit(hour, "hour-of-day")
-export function formatHourAMPM(hour) {
-  if (hour > 12) {
-    const newHour = hour - 12;
-    return t`${newHour}:00 PM`;
-  } else if (hour === 0) {
-    return t`12:00 AM`;
-  } else if (hour === 12) {
-    return t`12:00 PM`;
-  } else {
-    return t`${hour}:00 AM`;
-  }
-}
-
 // @deprecated use formatDateTimeWithUnit(day, "day-of-week")
 export function formatDay(day) {
   switch (day) {

--- a/frontend/src/metabase/sharing/components/PulsesListSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/PulsesListSidebar.jsx
@@ -14,7 +14,8 @@ import Subhead from "metabase/components/type/Subhead";
 import Sidebar from "metabase/dashboard/components/Sidebar";
 import Tooltip from "metabase/components/Tooltip";
 
-import { formatHourAMPM, formatDay, formatFrame } from "metabase/lib/time";
+import { formatTimeWithUnit } from "metabase/lib/formatting";
+import { formatDay, formatFrame } from "metabase/lib/time";
 import { getActivePulseParameters } from "metabase/lib/pulse";
 
 import { getParameters } from "metabase/dashboard/selectors";
@@ -243,21 +244,21 @@ function friendlySchedule(channel) {
       scheduleString += t`hourly`;
       break;
     case "daily": {
-      const ampm = formatHourAMPM(schedule_hour);
-      scheduleString += t`daily at ${ampm}`;
+      const hour = formatTimeWithUnit(schedule_hour, "hour-of-day");
+      scheduleString += t`daily at ${hour}`;
       break;
     }
     case "weekly": {
-      const ampm = formatHourAMPM(schedule_hour);
+      const hour = formatTimeWithUnit(schedule_hour, "hour-of-day");
       const day = formatDay(schedule_day);
-      scheduleString += t`${day} at ${ampm}`;
+      scheduleString += t`${day} at ${hour}`;
       break;
     }
     case "monthly": {
-      const ampm = formatHourAMPM(schedule_hour);
+      const hour = formatTimeWithUnit(schedule_hour, "hour-of-day");
       const day = schedule_day ? formatDay(schedule_day) : "calendar day";
       const frame = formatFrame(schedule_frame);
-      scheduleString += t`monthly on the ${frame} ${day} at ${ampm}`;
+      scheduleString += t`monthly on the ${frame} ${day} at ${hour}`;
       break;
     }
     default:


### PR DESCRIPTION
### How to Test

#### UI

1. In a dashboard page, click on Subscriptions icon (top right)
2. Create daily, weekly and monthly subscriptions

After subscriptions are set, hours for each subscription should be rendered correctly.

#### Codebase

1. grep 'formatHourAMPM' in codebase.

It should not be found.

<img width="677" alt="image" src="https://user-images.githubusercontent.com/380816/181494275-7fa0bbb9-337c-499c-bfff-1524ae834f55.png">
