### PR TITLE
Remove deprecated function formatDay

### DIFF
--- a/frontend/src/metabase/lib/time.js
+++ b/frontend/src/metabase/lib/time.js
@@ -101,28 +101,6 @@ export function parseTime(value) {
   return moment.utc(value);
 }
 
-// @deprecated use formatDateTimeWithUnit(day, "day-of-week")
-export function formatDay(day) {
-  switch (day) {
-    case "mon":
-      return t`Monday`;
-    case "tue":
-      return t`Tuesday`;
-    case "wed":
-      return t`Wednesday`;
-    case "thu":
-      return t`Thursday`;
-    case "fri":
-      return t`Friday`;
-    case "sat":
-      return t`Saturday`;
-    case "sun":
-      return t`Sunday`;
-    default:
-      return day;
-  }
-}
-
 export function formatFrame(frame) {
   switch (frame) {
     case "first":

--- a/frontend/src/metabase/sharing/components/PulsesListSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/PulsesListSidebar.jsx
@@ -14,8 +14,11 @@ import Subhead from "metabase/components/type/Subhead";
 import Sidebar from "metabase/dashboard/components/Sidebar";
 import Tooltip from "metabase/components/Tooltip";
 
-import { formatTimeWithUnit } from "metabase/lib/formatting";
-import { formatDay, formatFrame } from "metabase/lib/time";
+import {
+  formatDateTimeWithUnit,
+  formatTimeWithUnit,
+} from "metabase/lib/formatting";
+import { formatFrame } from "metabase/lib/time";
 import { getActivePulseParameters } from "metabase/lib/pulse";
 
 import { getParameters } from "metabase/dashboard/selectors";
@@ -250,13 +253,15 @@ function friendlySchedule(channel) {
     }
     case "weekly": {
       const hour = formatTimeWithUnit(schedule_hour, "hour-of-day");
-      const day = formatDay(schedule_day);
+      const day = formatDateTimeWithUnit(schedule_day, "day-of-week");
       scheduleString += t`${day} at ${hour}`;
       break;
     }
     case "monthly": {
       const hour = formatTimeWithUnit(schedule_hour, "hour-of-day");
-      const day = schedule_day ? formatDay(schedule_day) : "calendar day";
+      const day = schedule_day
+        ? formatDateTimeWithUnit(schedule_day, "day-of-week")
+        : "calendar day";
       const frame = formatFrame(schedule_frame);
       scheduleString += t`monthly on the ${frame} ${day} at ${hour}`;
       break;


### PR DESCRIPTION
### How to Test

#### UI

1. In a dashboard page, click on Subscriptions icon (top right)
2. Create daily, weekly and monthly subscriptions

After subscriptions are set, hours for each subscription should be rendered correctly.

#### Codebase

1. grep 'formatDay' in codebase.

It should not be found.

<img width="677" alt="image" src="https://user-images.githubusercontent.com/380816/181495682-0c8a0586-6cc3-4490-a1cb-c2a9d95b00f0.png">
