### PR TITLE
Pass height in fit mode when embedded

### DIFF
--- a/frontend/src/metabase/lib/embed.js
+++ b/frontend/src/metabase/lib/embed.js
@@ -63,7 +63,7 @@ function sendMessage(message) {
 
 function getFrameSpec() {
   if (isFitViewportMode()) {
-    return { mode: "fit" };
+    return { mode: "fit", height: document.body.scrollHeight };
   } else {
     return { mode: "normal", height: document.body.scrollHeight };
   }


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/15732

Follows the suggestion from the last comment https://github.com/metabase/metabase/issues/15732#issuecomment-824872519 and provides the height for both modes.