### PR TITLE
[CI] Run backend checks in GHA conditionally

### DIFF
--- a/.github/workflows/backend-skipped-checks.yml
+++ b/.github/workflows/backend-skipped-checks.yml
@@ -6,10 +6,10 @@ name: Backend
 on:
   pull_request:
     paths:
-    - "docs/**"
-    - "**.md"
-    - "frontend/test/**"
-    - "enterprise/frontend/test/**"
+      - "docs/**"
+      - "**.md"
+      - "frontend/test/**"
+      - "enterprise/frontend/test/**"
 
 jobs:
 

--- a/.github/workflows/backend-skipped-checks.yml
+++ b/.github/workflows/backend-skipped-checks.yml
@@ -1,0 +1,48 @@
+# Required checks with path filtering rules will block pull requests from merging if they change only the excluded files.
+# This is a workaround to allow the PR to be merged.
+# https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+name: Backend
+
+on:
+  pull_request:
+    paths:
+    - "docs/**"
+    - "**.md"
+    - "frontend/test/**"
+    - "enterprise/frontend/test/**"
+
+jobs:
+
+  be-linter-clj-kondo:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 10
+    steps:
+      - run: |
+          echo "Didn't run due to conditional filtering"
+
+  be-linter-eastwood:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 20
+    steps:
+      - run: |
+          echo "Didn't run due to conditional filtering"
+
+  be-linter-namespace-decls:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 10
+    steps:
+      - run: |
+          echo "Didn't run due to conditional filtering"
+
+  be-tests:
+    runs-on: ubuntu-20.04
+    name: be-tests-java-${{ matrix.java-version }}-${{ matrix.edition }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        edition: [oss, ee]
+        java-version: [11, 17]
+    steps:
+      - run: |
+          echo "Didn't run due to conditional filtering"

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -6,6 +6,11 @@ on:
       - 'master'
       - 'release-**'
   pull_request:
+    paths-ignore:
+    - "docs/**"
+    - "**.md"
+    - "frontend/test/**"
+    - "enterprise/frontend/test/**"
 
 jobs:
 

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -7,10 +7,10 @@ on:
       - 'release-**'
   pull_request:
     paths-ignore:
-    - "docs/**"
-    - "**.md"
-    - "frontend/test/**"
-    - "enterprise/frontend/test/**"
+      - "docs/**"
+      - "**.md"
+      - "frontend/test/**"
+      - "enterprise/frontend/test/**"
 
 jobs:
 


### PR DESCRIPTION
Now that [we have a mechanism](https://github.com/metabase/metabase/pull/24361) that circumvents the limitation of not being able to have conditional path filtering on the required checks, nothing is stopping us from making the `backend` workflow conditional as well.

It currently takes approximately 15 minutes to finish and it runs on every single commit in every single PR. Plus, these tests are flaking quite frequently.
There's absolutely no need to run backend checks if **the only** changes in the PR include documentation and/or markdown files, or frontend tests.

### Questions
Do we want to conditionally run the following checks:
- build-scripts? (takes 10-15 minutes per commit)
- cljs (takes ~10 minutes per commit)
- docs (takes ~10 minutes per commit)
- frontend (takes up to 15 minutes per commit and is especially important since we use `buildjet` machines)
- migrations (takes between 5 to 10 minutes per commit)
- whitespace (takes 8 minutes on average)
- yaml (should take under 10 minutes to finish)