### PR TITLE
[E2E] One more attempt in fixing the #18512 joins flake

### DIFF
--- a/frontend/test/metabase/scenarios/joins/reproductions/18512-cannot-join-two-saved-questions-with-same-implicit-explicit-grouped-field.cy.spec.js
+++ b/frontend/test/metabase/scenarios/joins/reproductions/18512-cannot-join-two-saved-questions-with-same-implicit-explicit-grouped-field.cy.spec.js
@@ -20,7 +20,7 @@ describe("issue 18512", () => {
   });
 
   it("should join two saved questions with the same implicit/explicit grouped field (metabase#18512)", () => {
-    cy.intercept("/api/database/1/schema/PUBLIC").as("schema");
+    cy.intercept("/api/table/card__*/query_metadata").as("cardQueryMetadata");
 
     cy.createQuestion(question1);
     cy.createQuestion(question2);
@@ -29,13 +29,15 @@ describe("issue 18512", () => {
     cy.findByText("Saved Questions").click();
 
     cy.findByText("18512#1").click();
+    cy.wait("@cardQueryMetadata");
+
     cy.icon("join_left_outer").click();
-    cy.wait("@schema");
 
     popover().within(() => {
       cy.findByTextEnsureVisible("Sample Database").click();
       cy.findByTextEnsureVisible("Saved Questions").click();
       cy.findByText("18512#2").click();
+      cy.wait("@cardQueryMetadata");
     });
 
     popover().findByText("Products → Created At").click();


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Attempts (one more time) to fix a stubborn flake in 18512 that messes up with the `joins` E2E group

I think I finally realized why it sometimes fails. It's (no surprise here) due to the race condition.
When we select the first question, we need to wait for its query metadata to load. This is exactly what this PR does.

Before
![image](https://user-images.githubusercontent.com/31325167/181521822-8cc0e52b-3a53-4f7f-8c5e-e8fa298f3ebe.png)

After
![image](https://user-images.githubusercontent.com/31325167/181522040-7c45a233-8448-41be-a2c0-ad7a4f1c324a.png)
