### PR TITLE
Join operator is not visible and cannot be changed before selecting a dimension

### DIFF
--- a/frontend/src/metabase-lib/lib/queries/structured/Join.ts
+++ b/frontend/src/metabase-lib/lib/queries/structured/Join.ts
@@ -339,7 +339,9 @@ export default class Join extends MBQLObjectClause {
 
   setOperator(index, operator) {
     if (index == null || !this.getConditionByIndex(index)) {
-      return this;
+      return this.setConditionByIndex({
+        condition: [operator, null, null],
+      });
     }
 
     const [_oldOperator, ...args] = this.getConditionByIndex(index);

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -246,7 +246,7 @@ function JoinClause({ color, join, updateQuery, showRemove }) {
             {displayConditions.map((condition, index) => {
               const isFirst = index === 0;
               const isLast = index === displayConditions.length - 1;
-              const [operator] = condition;
+              const operator = condition[0] ?? "=";
               const operatorSymbol = JOIN_OPERATOR_OPTIONS.find(
                 o => o.value === operator,
               )?.name;
@@ -298,7 +298,7 @@ function JoinClause({ color, join, updateQuery, showRemove }) {
                       <Select
                         hiddenIcons
                         width={80}
-                        value={operator}
+                        value={operator ?? "="}
                         onChange={updateOperator}
                         options={JOIN_OPERATOR_OPTIONS}
                         triggerElement={

--- a/frontend/test/metabase-lib/lib/queries/structured/Join.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/structured/Join.unit.spec.js
@@ -530,6 +530,16 @@ describe("Join", () => {
   });
 
   describe("setOperator", () => {
+    it("changes the operator without fields selected", () => {
+      let join = getJoin({
+        query: getOrdersJoinQuery({}),
+      });
+
+      join = join.setOperator(0, "!=");
+
+      expect(join.getConditions()).toEqual([["!=", null, null]]);
+    });
+
     it("changes the operator of a single condition join", () => {
       let join = getJoin({
         query: getOrdersJoinQuery({


### PR DESCRIPTION
## Changes

Fixes the case when a query has no joins yet so it did not show the join operator and did not allow to change it.

## How to verify

- New -> Question
- Orders -> join Reviews
    - Ensure it shows the `=` operator
- Change the `=` operator to something else 
    - Ensure the operator has been updated 