### PR TITLE
[E2E] Fix and unskip revoked collection tests

### DIFF
--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -280,7 +280,7 @@ describe("scenarios > collection defaults", () => {
         // Click to choose which collection should this question be saved to
         cy.findByText(revokedUsersPersonalCollectionName).click();
         popover().within(() => {
-          cy.findByText(/Our analytics/i);
+          cy.findByText(/Collections/i);
           cy.findByText(/My personal collection/i);
           cy.findByText("Parent").should("not.exist");
           cy.log("Reported failing from v0.34.3");

--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -219,7 +219,7 @@ describe("scenarios > collection defaults", () => {
       cy.findByText("Orders");
     });
 
-    describe.skip("nested collections with revoked parent access", () => {
+    describe("nested collections with revoked parent access", () => {
       const { first_name, last_name } = nocollection;
       const revokedUsersPersonalCollectionName = `${first_name} ${last_name}'s Personal Collection`;
 


### PR DESCRIPTION
This was a temporary fix needed to fix the broken `master` at one point. Now we unskip it and update the test according to the changes/fix from https://github.com/metabase/metabase/pull/24354

![image](https://user-images.githubusercontent.com/31325167/181607361-d1bbf538-80d6-4449-b3f4-1cfbe30bb978.png)
