### PR TITLE
Do not run Percy on release branches

### DIFF
--- a/.github/workflows/e2e-main.yml
+++ b/.github/workflows/e2e-main.yml
@@ -159,7 +159,7 @@ jobs:
         if-no-files-found: ignore
 
   visual-regression-tests:
-    if: env.PERCY_TOKEN != null && ${{ github.ref == 'refs/heads/master' }}
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-20.04
     timeout-minutes: 45
     needs: build


### PR DESCRIPTION
## Changes

Fixes the `if` condition in the workflow `e2e-main.yml` workflow.

The original condition `if: env.PERCY_TOKEN != null && ${{ github.ref == 'refs/heads/master' }}` did not have the correct syntax but it was ignored because of https://github.com/actions/runner/issues/1173

It could be literally `if: you_can.write_anything.here != null && ${{ github.ref == 'refs/heads/master' }}` with `github.ref` not being 'refs/heads/master' and the GHA still runs the steps