### PR TITLE
Blocking monotonicity UI fix (#24380)

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/data-model-permission.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/data-model-permission.unit.spec.ts
@@ -181,7 +181,7 @@ describe("buildDataModelPermission", () => {
       const [downgradePermissionConfirmation] =
         permissionModel.confirmations("all");
 
-      expect(permissionModel.warning).toBe("");
+      expect(permissionModel.warning).toBe(null);
     });
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/data-model-permission.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/data-model-permission.unit.spec.ts
@@ -167,5 +167,21 @@ describe("buildDataModelPermission", () => {
       );
       expect(downgradePermissionConfirmation?.message).toBeUndefined();
     });
+
+    it("does not warn when group permissions is blocking", () => {
+      const permissionModel = buildDataModelPermission(
+        { databaseId },
+        groupId,
+        isNotAdmin,
+        getPermissionGraph("block"),
+        defaultGroup,
+        "schemas",
+      );
+
+      const [downgradePermissionConfirmation] =
+        permissionModel.confirmations("all");
+
+      expect(permissionModel.warning).toBe("");
+    });
   });
 });

--- a/frontend/src/metabase/admin/permissions/selectors/confirmations.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/confirmations.ts
@@ -14,7 +14,7 @@ export const getDefaultGroupHasHigherAccessText = (defaultGroup: Group) =>
   t`The "${defaultGroup.name}" group has a higher level of access than this, which will override this setting. You should limit or revoke the "${defaultGroup.name}" group's access to this item.`;
 
 // these are all the permission levels ordered by level of access
-const PERM_LEVELS = ["write", "read", "all", "controlled", "none", "block"];
+const PERM_LEVELS = ["write", "read", "all", "controlled", "none"];
 function hasGreaterPermissions(
   a: string,
   b: string,
@@ -33,7 +33,8 @@ export function getPermissionWarning(
   groupId: Group["id"],
   descendingPermissions?: string[],
 ) {
-  if (!defaultGroup || groupId === defaultGroup.id) {
+  // 'block' overrides any perm non-monotonically: see #24380
+  if (!defaultGroup || groupId === defaultGroup.id || value === "block") {
     return null;
   }
 


### PR DESCRIPTION
Pursuant to #24380. Previously, the UI said that blocking would be overridden by overall all access: this isn't actually the case, blocking overrides overall all access.