### PR TITLE
Migrate bg-brand-dark-hover to JS colors

### DIFF
--- a/frontend/src/metabase/css/core/colors.css
+++ b/frontend/src/metabase/css/core/colors.css
@@ -54,18 +54,7 @@
   background-color: var(--color-brand-light);
 }
 
-.bg-brand-dark,
-.bg-brand-dark-hover:hover {
-  background-color: color-mod(var(--color-brand) blackness(12%));
-}
-
-.bg-brand-dark,
-.bg-brand-dark-hover:hover {
-  background-color: color-mod(var(--color-brand) blackness(12%));
-}
-
-.bg-brand-dark,
-.bg-brand-dark-hover:hover {
+.bg-brand-dark {
   background-color: color-mod(var(--color-brand) blackness(12%));
 }
 

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx
@@ -5,7 +5,7 @@ import { getIn } from "icepick";
 import _ from "underscore";
 import cx from "classnames";
 
-import { color, darken } from "metabase/lib/colors";
+import { color } from "metabase/lib/colors";
 
 import AccordionList from "metabase/core/components/AccordionList";
 import Button from "metabase/core/components/Button";
@@ -601,24 +601,16 @@ function LinkOptions({ clickBehavior, updateSettings, dashcard, parameters }) {
                       ? clickBehavior.linkTemplate
                       : t`URL`}
                   </h4>
-                  <span
-                    className="ml-auto bg-brand-dark-hover border-left"
-                    style={{
-                      borderLeftColor: darken(color("brand"), 0.2),
-                      padding: 17,
-                    }}
+                  <RemoveIconContainer
+                    onClick={() =>
+                      updateSettings({
+                        type: clickBehavior.type,
+                        linkType: null,
+                      })
+                    }
                   >
-                    <Icon
-                      name="close"
-                      size={12}
-                      onClick={() =>
-                        updateSettings({
-                          type: clickBehavior.type,
-                          linkType: null,
-                        })
-                      }
-                    />
-                  </span>
+                    <Icon name="close" size={12} />
+                  </RemoveIconContainer>
                 </div>
               </SidebarItemWrapper>
             }

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx
@@ -34,7 +34,11 @@ import {
 } from "metabase/lib/click-behavior";
 import { getIconForField } from "metabase/lib/schema_metadata";
 import { keyForColumn } from "metabase/lib/dataset";
-import { CloseIconContainer } from "./ClickBehaviorSidebar.styled";
+import {
+  CloseIconContainer,
+  RemoveIconContainer,
+  SidebarItem,
+} from "./ClickBehaviorSidebar.styled";
 
 const clickBehaviorOptions = [
   { value: "menu", icon: "popover" },
@@ -707,8 +711,7 @@ function QuestionDashboardPicker({ dashcard, clickBehavior, updateSettings }) {
                 color: color("white"),
               }}
             >
-              <div
-                className="flex align-center bg-brand-dark-hover full"
+              <SidebarItem
                 style={{
                   paddingLeft: SidebarItemStyle.paddingLeft,
                   paddingRight: SidebarItemStyle.paddingRight,
@@ -731,13 +734,8 @@ function QuestionDashboardPicker({ dashcard, clickBehavior, updateSettings }) {
                   )}
                   <Icon name="chevrondown" size={12} className="ml-auto" />
                 </div>
-              </div>
-              <span
-                className="ml-auto bg-brand-dark-hover border-left"
-                style={{
-                  borderLeftColor: darken(color("brand"), 0.2),
-                  padding: 17,
-                }}
+              </SidebarItem>
+              <RemoveIconContainer
                 onClick={() =>
                   updateSettings({
                     type: clickBehavior.type,
@@ -746,7 +744,7 @@ function QuestionDashboardPicker({ dashcard, clickBehavior, updateSettings }) {
                 }
               >
                 <Icon name="close" size={12} />
-              </span>
+              </RemoveIconContainer>
             </div>
           }
           isInitiallyOpen={clickBehavior.targetId == null}

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx
@@ -34,6 +34,7 @@ import {
 } from "metabase/lib/click-behavior";
 import { getIconForField } from "metabase/lib/schema_metadata";
 import { keyForColumn } from "metabase/lib/dataset";
+import { CloseIconContainer } from "./ClickBehaviorSidebar.styled";
 
 const clickBehaviorOptions = [
   { value: "menu", icon: "popover" },
@@ -471,15 +472,9 @@ class ClickBehaviorSidebar extends React.Component {
                     <h4>
                       {getClickBehaviorOptionName(clickBehavior.type, dashcard)}
                     </h4>
-                    <span
-                      className="ml-auto bg-brand-dark-hover border-left"
-                      style={{
-                        padding: 16,
-                        borderLeftColor: darken(color("brand"), 0.2),
-                      }}
-                    >
+                    <CloseIconContainer>
                       <Icon name="close" size={12} />
-                    </span>
+                    </CloseIconContainer>
                   </div>
                 </SidebarItemWrapper>
               </SidebarContentBordered>

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx
@@ -34,11 +34,7 @@ import {
 } from "metabase/lib/click-behavior";
 import { getIconForField } from "metabase/lib/schema_metadata";
 import { keyForColumn } from "metabase/lib/dataset";
-import {
-  CloseIconContainer,
-  RemoveIconContainer,
-  SidebarItem,
-} from "./ClickBehaviorSidebar.styled";
+import { CloseIconContainer, SidebarItem } from "./ClickBehaviorSidebar.styled";
 
 const clickBehaviorOptions = [
   { value: "menu", icon: "popover" },
@@ -601,7 +597,7 @@ function LinkOptions({ clickBehavior, updateSettings, dashcard, parameters }) {
                       ? clickBehavior.linkTemplate
                       : t`URL`}
                   </h4>
-                  <RemoveIconContainer
+                  <CloseIconContainer
                     onClick={() =>
                       updateSettings({
                         type: clickBehavior.type,
@@ -610,7 +606,7 @@ function LinkOptions({ clickBehavior, updateSettings, dashcard, parameters }) {
                     }
                   >
                     <Icon name="close" size={12} />
-                  </RemoveIconContainer>
+                  </CloseIconContainer>
                 </div>
               </SidebarItemWrapper>
             }
@@ -727,7 +723,7 @@ function QuestionDashboardPicker({ dashcard, clickBehavior, updateSettings }) {
                   <Icon name="chevrondown" size={12} className="ml-auto" />
                 </div>
               </SidebarItem>
-              <RemoveIconContainer
+              <CloseIconContainer
                 onClick={() =>
                   updateSettings({
                     type: clickBehavior.type,
@@ -736,7 +732,7 @@ function QuestionDashboardPicker({ dashcard, clickBehavior, updateSettings }) {
                 }
               >
                 <Icon name="close" size={12} />
-              </RemoveIconContainer>
+              </CloseIconContainer>
             </div>
           }
           isInitiallyOpen={clickBehavior.targetId == null}

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.styled.tsx
@@ -1,9 +1,29 @@
 import styled from "@emotion/styled";
 import { darken } from "metabase/lib/colors";
 
+export const SidebarItem = styled.div`
+  display: flex;
+  align-items: center;
+  width: 100%;
+
+  &:hover {
+    background-color: ${darken("brand", 0.12)};
+  }
+`;
+
 export const CloseIconContainer = styled.span`
   margin-left: auto;
   padding: 1rem;
+  border-left: 1px solid ${darken("brand", 0.2)};
+
+  &:hover {
+    background-color: ${darken("brand", 0.12)};
+  }
+`;
+
+export const RemoveIconContainer = styled.span`
+  margin-left: auto;
+  padding: 1.0625rem;
   border-left: 1px solid ${darken("brand", 0.2)};
 
   &:hover {

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.styled.tsx
@@ -12,9 +12,3 @@ export const CloseIconContainer = styled.span`
   padding: 1rem;
   border-left: 1px solid ${darken("brand", 0.2)};
 `;
-
-export const RemoveIconContainer = styled.span`
-  margin-left: auto;
-  padding: 1.0625rem;
-  border-left: 1px solid ${darken("brand", 0.2)};
-`;

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.styled.tsx
@@ -5,28 +5,16 @@ export const SidebarItem = styled.div`
   display: flex;
   align-items: center;
   width: 100%;
-
-  &:hover {
-    background-color: ${darken("brand", 0.12)};
-  }
 `;
 
 export const CloseIconContainer = styled.span`
   margin-left: auto;
   padding: 1rem;
   border-left: 1px solid ${darken("brand", 0.2)};
-
-  &:hover {
-    background-color: ${darken("brand", 0.12)};
-  }
 `;
 
 export const RemoveIconContainer = styled.span`
   margin-left: auto;
   padding: 1.0625rem;
   border-left: 1px solid ${darken("brand", 0.2)};
-
-  &:hover {
-    background-color: ${darken("brand", 0.12)};
-  }
 `;

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.styled.tsx
@@ -1,0 +1,12 @@
+import styled from "@emotion/styled";
+import { darken } from "metabase/lib/colors";
+
+export const CloseIconContainer = styled.span`
+  margin-left: auto;
+  padding: 1rem;
+  border-left: 1px solid ${darken("brand", 0.2)};
+
+  &:hover {
+    background-color: ${darken("brand", 0.12)};
+  }
+`;


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/23954

How to test:
- Edit a dashboard with a question
- Hover over a card and click `Click behavior`
- Click `Go to a custom destination`
- Select `dashboard` and close the picker
- Make sure the button to select a dashboard and `X` icon to remove the selection are the same here and in `master`

Please note that the entire button group is already `bg-brand-dark` so applying hover background color is not needed.

<img width="1086" alt="Screenshot 2022-07-29 at 16 59 49" src="https://user-images.githubusercontent.com/8542534/181776761-a59ff424-57cc-472c-b61f-5acaecaa24de.png">
