### PR TITLE
Replace moment with moment-timezone in remaining files

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/license/components/LicenseAndBillingSettings/LicenseAndBillingSettings.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/license/components/LicenseAndBillingSettings/LicenseAndBillingSettings.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { t, jt } from "ttag";
 import { connect } from "react-redux";
-import moment from "moment";
+import moment from "moment-timezone";
 import { showLicenseAcceptedToast } from "metabase-enterprise/license/actions";
 import {
   TokenStatus,

--- a/frontend/src/metabase-lib/lib/metadata/Field.ts
+++ b/frontend/src/metabase-lib/lib/metadata/Field.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import _ from "underscore";
-import moment from "moment";
+import moment from "moment-timezone";
 import { createLookupByProperty, memoizeClass } from "metabase-lib/lib/utils";
 import { formatField, stripId } from "metabase/lib/formatting";
 import { getFieldValues } from "metabase/lib/query/field";

--- a/frontend/src/metabase/account/login-history/components/LoginHistory/LoginHistory.jsx
+++ b/frontend/src/metabase/account/login-history/components/LoginHistory/LoginHistory.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/prop-types */
 import React from "react";
 import _ from "underscore";
-import moment from "moment";
+import moment from "moment-timezone";
 import { t } from "ttag";
 
 import Card from "metabase/components/Card";

--- a/frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx
@@ -6,7 +6,7 @@ import RevisionDiff from "./RevisionDiff";
 import { t } from "ttag";
 import UserAvatar from "metabase/components/UserAvatar";
 
-import moment from "moment";
+import moment from "moment-timezone";
 
 export default class Revision extends Component {
   static propTypes = {

--- a/frontend/src/metabase/admin/people/components/PeopleListRow.jsx
+++ b/frontend/src/metabase/admin/people/components/PeopleListRow.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/prop-types */
 import React, { useMemo } from "react";
 import { t } from "ttag";
-import moment from "moment";
+import moment from "moment-timezone";
 import _ from "underscore";
 
 import { color } from "metabase/lib/colors";

--- a/frontend/src/metabase/admin/settings/containers/PremiumEmbeddingLicensePage/PremiumEmbeddingLicensePage.tsx
+++ b/frontend/src/metabase/admin/settings/containers/PremiumEmbeddingLicensePage/PremiumEmbeddingLicensePage.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from "react";
 import { jt, t } from "ttag";
 import { connect } from "react-redux";
-import moment from "moment";
+import moment from "moment-timezone";
 import AdminLayout from "metabase/components/AdminLayout";
 import ExternalLink from "metabase/core/components/ExternalLink";
 import MetabaseSettings from "metabase/lib/settings";

--- a/frontend/src/metabase/admin/tasks/containers/Logs.jsx
+++ b/frontend/src/metabase/admin/tasks/containers/Logs.jsx
@@ -9,7 +9,7 @@ import reactAnsiStyle from "react-ansi-style";
 import "react-ansi-style/inject-css";
 
 import _ from "underscore";
-import moment from "moment";
+import moment from "moment-timezone";
 import { t } from "ttag";
 
 import Select, { Option } from "metabase/core/components/Select";

--- a/frontend/src/metabase/admin/tasks/containers/ModelCacheRefreshJobs/ModelCacheRefreshJobs.tsx
+++ b/frontend/src/metabase/admin/tasks/containers/ModelCacheRefreshJobs/ModelCacheRefreshJobs.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from "react";
 import { t } from "ttag";
-import moment from "moment";
+import moment from "moment-timezone";
 import { connect } from "react-redux";
 
 import Link from "metabase/core/components/Link";

--- a/frontend/src/metabase/collections/components/BaseTableItem.jsx
+++ b/frontend/src/metabase/collections/components/BaseTableItem.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback } from "react";
 import PropTypes from "prop-types";
-import moment from "moment";
+import moment from "moment-timezone";
 
 import { PLUGIN_MODERATION } from "metabase/plugins";
 

--- a/frontend/src/metabase/components/Calendar.info.js
+++ b/frontend/src/metabase/components/Calendar.info.js
@@ -1,5 +1,5 @@
 import React from "react";
-import moment from "moment";
+import moment from "moment-timezone";
 import Calendar from "./Calendar";
 
 export const component = Calendar;

--- a/frontend/src/metabase/components/Calendar.tsx
+++ b/frontend/src/metabase/components/Calendar.tsx
@@ -5,7 +5,7 @@ import PropTypes from "prop-types";
 import "./Calendar.css";
 
 import cx from "classnames";
-import moment, { Moment } from "moment";
+import moment, { Moment } from "moment-timezone";
 import { t } from "ttag";
 import Icon from "metabase/components/Icon";
 import { alpha, color } from "metabase/lib/colors";

--- a/frontend/src/metabase/components/DateMonthYearWidget/DateMonthYearWidget.tsx
+++ b/frontend/src/metabase/components/DateMonthYearWidget/DateMonthYearWidget.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import moment from "moment";
+import moment from "moment-timezone";
 import _ from "underscore";
 import cx from "classnames";
 

--- a/frontend/src/metabase/components/DateQuarterYearWidget/DateQuarterYearWidget.tsx
+++ b/frontend/src/metabase/components/DateQuarterYearWidget/DateQuarterYearWidget.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import moment from "moment";
+import moment from "moment-timezone";
 import _ from "underscore";
 import cx from "classnames";
 import { t } from "ttag";

--- a/frontend/src/metabase/components/DateRangeWidget/DateRangeWidget.tsx
+++ b/frontend/src/metabase/components/DateRangeWidget/DateRangeWidget.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import moment from "moment";
+import moment from "moment-timezone";
 import DateAllOptionsWidget from "metabase/components/DateAllOptionsWidget";
 
 interface DateRangeWidgetProps {

--- a/frontend/src/metabase/components/DateSingleWidget/DateSingleWidget.tsx
+++ b/frontend/src/metabase/components/DateSingleWidget/DateSingleWidget.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import moment from "moment";
+import moment from "moment-timezone";
 import DateAllOptionsWidget from "metabase/components/DateAllOptionsWidget";
 
 interface DateSingleWidgetProps {

--- a/frontend/src/metabase/components/DrawerSection/DrawerSection.info.js
+++ b/frontend/src/metabase/components/DrawerSection/DrawerSection.info.js
@@ -1,7 +1,7 @@
 import React from "react";
 import DrawerSection from "./DrawerSection";
 
-import moment from "moment";
+import moment from "moment-timezone";
 import styled from "@emotion/styled";
 import Timeline from "metabase/components/Timeline";
 import { color } from "metabase/lib/colors";

--- a/frontend/src/metabase/components/HistoryModal.jsx
+++ b/frontend/src/metabase/components/HistoryModal.jsx
@@ -8,7 +8,7 @@ import {
   getRevisionDescription,
 } from "metabase/lib/revisions";
 
-import moment from "moment";
+import moment from "moment-timezone";
 
 function formatDate(date) {
   const m = moment(date);

--- a/frontend/src/metabase/components/LastEditInfoLabel.js
+++ b/frontend/src/metabase/components/LastEditInfoLabel.js
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { t } from "ttag";
-import moment from "moment";
+import moment from "moment-timezone";
 
 import { getUser } from "metabase/selectors/user";
 import { getFullName } from "metabase/lib/user";

--- a/frontend/src/metabase/components/ListField/utils.unit.spec.ts
+++ b/frontend/src/metabase/components/ListField/utils.unit.spec.ts
@@ -1,5 +1,5 @@
 import { isValidOptionItem } from "./utils";
-import moment from "moment";
+import moment from "moment-timezone";
 
 describe("ListField - utils", () => {
   describe("isValidOptionItem", () => {

--- a/frontend/src/metabase/components/Timeline.info.js
+++ b/frontend/src/metabase/components/Timeline.info.js
@@ -1,5 +1,5 @@
 import React from "react";
-import moment from "moment";
+import moment from "moment-timezone";
 import styled from "@emotion/styled";
 
 import Timeline from "metabase/components/Timeline";

--- a/frontend/src/metabase/components/form/widgets/FormDateWidget/FormDateWidget.tsx
+++ b/frontend/src/metabase/components/form/widgets/FormDateWidget/FormDateWidget.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, Ref, useCallback, useMemo } from "react";
-import { Moment } from "moment";
+import { Moment } from "moment-timezone";
 import {
   getNumericDateStyleFromSettings,
   getTimeStyleFromSettings,

--- a/frontend/src/metabase/components/form/widgets/FormDateWidget/FormDateWidget.tsx
+++ b/frontend/src/metabase/components/form/widgets/FormDateWidget/FormDateWidget.tsx
@@ -62,7 +62,7 @@ const FormDateWidget = forwardRef(function FormDateWidget(
   return (
     <DateWidget
       ref={ref}
-      value={value as Moment | undefined}
+      value={value}
       placeholder={placeholder}
       hasTime={Boolean(values[hasTimeField])}
       dateFormat={getNumericDateStyleFromSettings()}

--- a/frontend/src/metabase/core/components/DateInput/DateInput.stories.tsx
+++ b/frontend/src/metabase/core/components/DateInput/DateInput.stories.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Moment } from "moment";
+import { Moment } from "moment-timezone";
 import { ComponentStory } from "@storybook/react";
 import DateInput from "./DateInput";
 

--- a/frontend/src/metabase/core/components/DateInput/DateInput.tsx
+++ b/frontend/src/metabase/core/components/DateInput/DateInput.tsx
@@ -9,7 +9,7 @@ import React, {
   useMemo,
   useState,
 } from "react";
-import moment, { Moment } from "moment";
+import moment, { Moment } from "moment-timezone";
 import { t } from "ttag";
 import Input from "metabase/core/components/Input";
 

--- a/frontend/src/metabase/core/components/DateInput/DateInput.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/DateInput/DateInput.unit.spec.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useState } from "react";
-import moment, { Moment } from "moment";
+import moment, { Moment } from "moment-timezone";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import DateInput, { DateInputProps } from "./DateInput";

--- a/frontend/src/metabase/core/components/DateSelector/DateSelector.stories.tsx
+++ b/frontend/src/metabase/core/components/DateSelector/DateSelector.stories.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import moment, { Moment } from "moment";
+import moment, { Moment } from "moment-timezone";
 import { ComponentStory } from "@storybook/react";
 import DateSelector from "./DateSelector";
 

--- a/frontend/src/metabase/core/components/DateSelector/DateSelector.tsx
+++ b/frontend/src/metabase/core/components/DateSelector/DateSelector.tsx
@@ -6,7 +6,7 @@ import React, {
   useMemo,
   useState,
 } from "react";
-import moment, { Moment } from "moment";
+import moment, { Moment } from "moment-timezone";
 import { t } from "ttag";
 import TimeInput from "metabase/core/components/TimeInput";
 import Calendar from "metabase/components/Calendar";

--- a/frontend/src/metabase/core/components/DateWidget/DateWidget.stories.tsx
+++ b/frontend/src/metabase/core/components/DateWidget/DateWidget.stories.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Moment } from "moment";
+import { Moment } from "moment-timezone";
 import { ComponentStory } from "@storybook/react";
 import DateWidget from "./DateWidget";
 

--- a/frontend/src/metabase/core/components/DateWidget/DateWidget.tsx
+++ b/frontend/src/metabase/core/components/DateWidget/DateWidget.tsx
@@ -5,7 +5,7 @@ import React, {
   useCallback,
   useState,
 } from "react";
-import { Moment } from "moment";
+import { Moment } from "moment-timezone";
 import DateInput from "metabase/core/components/DateInput";
 import DateSelector from "metabase/core/components/DateSelector";
 import TippyPopover from "metabase/components/Popover/TippyPopover";

--- a/frontend/src/metabase/core/components/TimeInput/TimeInput.stories.tsx
+++ b/frontend/src/metabase/core/components/TimeInput/TimeInput.stories.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import moment from "moment";
+import moment from "moment-timezone";
 import { ComponentStory } from "@storybook/react";
 import TimeInput from "./TimeInput";
 

--- a/frontend/src/metabase/core/components/TimeInput/TimeInput.tsx
+++ b/frontend/src/metabase/core/components/TimeInput/TimeInput.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef, Ref } from "react";
 import { t } from "ttag";
-import { Moment } from "moment";
+import { Moment } from "moment-timezone";
 import Tooltip from "metabase/components/Tooltip";
 
 import useTimeInput, { BaseTimeInputProps } from "./useTimeInput";

--- a/frontend/src/metabase/core/components/TimeInput/TimeInput.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/TimeInput/TimeInput.unit.spec.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useState } from "react";
-import moment, { Moment } from "moment";
+import moment, { Moment } from "moment-timezone";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import TimeInput, { TimeInputProps } from "./TimeInput";

--- a/frontend/src/metabase/core/components/TimeInput/useTimeInput.ts
+++ b/frontend/src/metabase/core/components/TimeInput/useTimeInput.ts
@@ -1,5 +1,5 @@
 import { useCallback } from "react";
-import moment, { Moment } from "moment";
+import moment, { Moment } from "moment-timezone";
 
 export interface BaseTimeInputProps {
   value: Moment;

--- a/frontend/src/metabase/home/actions.js
+++ b/frontend/src/metabase/home/actions.js
@@ -1,5 +1,5 @@
 import _ from "underscore";
-import moment from "moment";
+import moment from "moment-timezone";
 
 import { createThunkAction } from "metabase/lib/redux";
 

--- a/frontend/src/metabase/lib/redux.js
+++ b/frontend/src/metabase/lib/redux.js
@@ -1,4 +1,4 @@
-import moment from "moment";
+import moment from "moment-timezone";
 import _ from "underscore";
 import { getIn } from "icepick";
 

--- a/frontend/src/metabase/modes/lib/actions.js
+++ b/frontend/src/metabase/modes/lib/actions.js
@@ -1,4 +1,4 @@
-import moment from "moment";
+import moment from "moment-timezone";
 
 import {
   rangeForValue,

--- a/frontend/src/metabase/parameters/utils/date-formatting.ts
+++ b/frontend/src/metabase/parameters/utils/date-formatting.ts
@@ -1,6 +1,6 @@
 import { t } from "ttag";
 import _ from "underscore";
-import moment from "moment";
+import moment from "moment-timezone";
 
 import { DATE_MBQL_FILTER_MAPPING } from "metabase/parameters/constants";
 import { dateParameterValueToMBQL } from "metabase/parameters/utils/mbql";

--- a/frontend/src/metabase/parameters/utils/mbql.js
+++ b/frontend/src/metabase/parameters/utils/mbql.js
@@ -1,4 +1,4 @@
-import moment from "moment";
+import moment from "moment-timezone";
 import _ from "underscore";
 
 import Dimension, {

--- a/frontend/src/metabase/parameters/utils/mbql.unit.spec.js
+++ b/frontend/src/metabase/parameters/utils/mbql.unit.spec.js
@@ -1,4 +1,4 @@
-import moment from "moment";
+import moment from "moment-timezone";
 
 import {
   dateParameterValueToMBQL,

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePicker.tsx
@@ -2,7 +2,7 @@
 import React from "react";
 import { t } from "ttag";
 import cx from "classnames";
-import moment from "moment";
+import moment from "moment-timezone";
 import _ from "underscore";
 
 import { FieldDimension } from "metabase-lib/lib/Dimension";

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePickerFooter.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePickerFooter.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/prop-types */
 import React from "react";
 import { t } from "ttag";
-import moment from "moment";
+import moment from "moment-timezone";
 import _ from "underscore";
 
 import Filter from "metabase-lib/lib/queries/structured/Filter";

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePickerShortcutOptions.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePickerShortcutOptions.tsx
@@ -1,5 +1,5 @@
 import { t } from "ttag";
-import moment from "moment";
+import moment from "moment-timezone";
 
 import { Field } from "metabase-types/types/Field";
 import { FieldDimension } from "metabase-lib/lib/Dimension";

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/ExcludeDatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/ExcludeDatePicker.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { t } from "ttag";
-import moment from "moment";
+import moment from "moment-timezone";
 import _ from "underscore";
 
 import {

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/HoursMinutesInput.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/HoursMinutesInput.tsx
@@ -4,7 +4,7 @@ import { has24HourModeSetting } from "metabase/lib/time";
 import NumericInput from "metabase/components/NumericInput";
 import Icon from "metabase/components/Icon";
 
-import moment from "moment";
+import moment from "moment-timezone";
 import { AmPmLabel } from "./HoursMinutesInput.styled";
 
 type Props = {

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RangeDatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RangeDatePicker.tsx
@@ -3,7 +3,7 @@ import React from "react";
 
 import Calendar from "metabase/components/Calendar";
 
-import moment from "moment";
+import moment from "moment-timezone";
 import Filter from "metabase-lib/lib/queries/structured/Filter";
 import { TimeContainer } from "./RangeDatePicker.styled";
 import {

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/SpecificDatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/SpecificDatePicker.tsx
@@ -8,8 +8,7 @@ import InputBlurChange from "metabase/components/InputBlurChange";
 import ExpandingContent from "metabase/components/ExpandingContent";
 import HoursMinutesInput from "./HoursMinutesInput";
 
-import moment from "moment";
-import momentTimezone from "moment-timezone";
+import moment, { Moment } from "moment-timezone";
 import { getTimeComponent, setTimeComponent } from "metabase/lib/query_time";
 import { CalendarIcon } from "./SpecificDatePicker.styled";
 
@@ -27,7 +26,7 @@ type Props = {
 
 const SpecificDatePicker: React.FC<Props> = props => {
   const onChange = (
-    date?: string | momentTimezone.Moment,
+    date?: string | Moment,
     hours?: number | null,
     minutes?: number | null,
   ) => {
@@ -99,8 +98,8 @@ const SpecificDatePicker: React.FC<Props> = props => {
       {calendar && (
         <ExpandingContent isOpen={showCalendar}>
           <Calendar
-            selected={date as moment.Moment}
-            initial={(date as moment.Moment) || moment()}
+            selected={date as Moment}
+            initial={(date as Moment) || moment()}
             onChange={value => onChange(value, hours, minutes)}
             isRangePicker={false}
             selectAll={selectAll}

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/SpecificDatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/SpecificDatePicker.tsx
@@ -65,7 +65,7 @@ const SpecificDatePicker: React.FC<Props> = props => {
           onBlurChange={({ target: { value } }: any) => {
             const date = moment(value, dateFormat);
             if (date.isValid()) {
-              onChange(date as momentTimezone.Moment, hours, minutes);
+              onChange(date, hours, minutes);
             } else {
               onChange();
             }

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/SpecificDatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/SpecificDatePicker.tsx
@@ -98,8 +98,8 @@ const SpecificDatePicker: React.FC<Props> = props => {
       {calendar && (
         <ExpandingContent isOpen={showCalendar}>
           <Calendar
-            selected={date as Moment}
-            initial={(date as Moment) || moment()}
+            selected={date}
+            initial={date || moment()}
             onChange={value => onChange(value, hours, minutes)}
             isRangePicker={false}
             selectAll={selectAll}

--- a/frontend/src/metabase/query_builder/components/filters/pickers/LegacyDatePicker/DatePicker.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/LegacyDatePicker/DatePicker.jsx
@@ -3,7 +3,7 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { t } from "ttag";
 import cx from "classnames";
-import moment from "moment";
+import moment from "moment-timezone";
 import _ from "underscore";
 
 import SpecificDatePicker from "./SpecificDatePicker";

--- a/frontend/src/metabase/query_builder/components/filters/pickers/LegacyDatePicker/HoursMinutesInput.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/LegacyDatePicker/HoursMinutesInput.jsx
@@ -5,7 +5,7 @@ import { has24HourModeSetting } from "metabase/lib/time";
 import NumericInput from "metabase/components/NumericInput";
 import Icon from "metabase/components/Icon";
 
-import moment from "moment";
+import moment from "moment-timezone";
 import { AmPmLabel } from "./HoursMinutesInput.styled";
 
 const HoursMinutesInput = ({

--- a/frontend/src/metabase/query_builder/components/filters/pickers/LegacyDatePicker/SpecificDatePicker.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/LegacyDatePicker/SpecificDatePicker.jsx
@@ -10,7 +10,7 @@ import Icon from "metabase/components/Icon";
 import ExpandingContent from "metabase/components/ExpandingContent";
 import HoursMinutesInput from "../DatePicker/HoursMinutesInput";
 
-import moment from "moment";
+import moment from "moment-timezone";
 import cx from "classnames";
 import { CalendarIcon, TimeLabel } from "./SpecificDatePicker.styled";
 

--- a/frontend/src/metabase/query_builder/components/view/QuestionLastUpdated.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionLastUpdated.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/prop-types */
 import React from "react";
 
-import moment from "moment";
+import moment from "moment-timezone";
 import { t } from "ttag";
 
 import Icon from "metabase/components/Icon";

--- a/frontend/src/metabase/query_builder/components/view/sidebars/ModelCacheManagementSection/ModelCacheManagementSection.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/ModelCacheManagementSection/ModelCacheManagementSection.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { t } from "ttag";
-import moment from "moment";
+import moment from "moment-timezone";
 import { connect } from "react-redux";
 
 import PersistedModels from "metabase/entities/persisted-models";

--- a/frontend/src/metabase/query_builder/components/view/sidebars/ModelCacheManagementSection/ModelCacheManagementSection.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/ModelCacheManagementSection/ModelCacheManagementSection.unit.spec.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import moment from "moment";
+import moment from "moment-timezone";
 import xhrMock from "xhr-mock";
 
 import PersistedModels from "metabase/entities/persisted-models";

--- a/frontend/src/metabase/query_builder/components/view/sidebars/TimelineSidebar/TimelineSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/TimelineSidebar/TimelineSidebar.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from "react";
 import { t } from "ttag";
-import { Moment } from "moment";
+import { Moment } from "moment-timezone";
 import Question from "metabase-lib/lib/Question";
 import { MODAL_TYPES } from "metabase/query_builder/constants";
 import SidebarContent from "metabase/query_builder/components/SidebarContent";

--- a/frontend/src/metabase/reference/databases/TableQuestions.jsx
+++ b/frontend/src/metabase/reference/databases/TableQuestions.jsx
@@ -2,7 +2,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
-import moment from "moment";
+import moment from "moment-timezone";
 import { t } from "ttag";
 import visualizations from "metabase/visualizations";
 import * as Urls from "metabase/lib/urls";

--- a/frontend/src/metabase/reference/metrics/MetricQuestions.jsx
+++ b/frontend/src/metabase/reference/metrics/MetricQuestions.jsx
@@ -2,7 +2,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
-import moment from "moment";
+import moment from "moment-timezone";
 import { t } from "ttag";
 import visualizations from "metabase/visualizations";
 import * as Urls from "metabase/lib/urls";

--- a/frontend/src/metabase/reference/segments/SegmentQuestions.jsx
+++ b/frontend/src/metabase/reference/segments/SegmentQuestions.jsx
@@ -2,7 +2,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
-import moment from "moment";
+import moment from "moment-timezone";
 import { t } from "ttag";
 import visualizations from "metabase/visualizations";
 import * as Urls from "metabase/lib/urls";

--- a/frontend/src/metabase/timelines/collections/components/TimelineEmptyState/TimelineEmptyState.tsx
+++ b/frontend/src/metabase/timelines/collections/components/TimelineEmptyState/TimelineEmptyState.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { t } from "ttag";
-import moment from "moment";
+import moment from "moment-timezone";
 import * as Urls from "metabase/lib/urls";
 import Link from "metabase/core/components/Link";
 import { Collection, Timeline } from "metabase-types/api";

--- a/frontend/src/metabase/visualizations/lib/apply_tooltips.js
+++ b/frontend/src/metabase/visualizations/lib/apply_tooltips.js
@@ -1,7 +1,7 @@
 /// code to "apply" chart tooltips. (How does one apply a tooltip?)
 
 import d3 from "d3";
-import moment from "moment";
+import moment from "moment-timezone";
 import { getIn } from "icepick";
 import _ from "underscore";
 

--- a/frontend/src/metabase/visualizations/lib/graph/addons.js
+++ b/frontend/src/metabase/visualizations/lib/graph/addons.js
@@ -1,5 +1,5 @@
 import dc from "dc";
-import moment from "moment";
+import moment from "moment-timezone";
 
 export const lineAddons = _chart => {
   _chart.fadeDeselectedArea = function () {

--- a/frontend/src/metabase/visualizations/lib/settings/column.js
+++ b/frontend/src/metabase/visualizations/lib/settings/column.js
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 import { t } from "ttag";
-import moment from "moment";
+import moment from "moment-timezone";
 import _ from "underscore";
 
 import { nestedSettings } from "./nested";

--- a/frontend/src/metabase/visualizations/lib/trends.js
+++ b/frontend/src/metabase/visualizations/lib/trends.js
@@ -1,5 +1,5 @@
 import _ from "underscore";
-import moment from "moment";
+import moment from "moment-timezone";
 
 // mappings of allowed operators
 const EXPRESSION_OPERATORS = new Map([

--- a/frontend/test/metabase/collections/BaseItemsTable.unit.spec.js
+++ b/frontend/test/metabase/collections/BaseItemsTable.unit.spec.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { renderWithProviders } from "__support__/ui";
 import userEvent from "@testing-library/user-event";
-import moment from "moment";
+import moment from "moment-timezone";
 
 import {
   DEFAULT_DATE_STYLE,

--- a/frontend/test/metabase/components/Calendar.unit.spec.js
+++ b/frontend/test/metabase/components/Calendar.unit.spec.js
@@ -1,5 +1,5 @@
 import React from "react";
-import moment from "moment";
+import moment from "moment-timezone";
 import mockDate from "mockdate";
 import { render, screen, fireEvent } from "@testing-library/react";
 

--- a/frontend/test/metabase/components/DateTime.unit.spec.js
+++ b/frontend/test/metabase/components/DateTime.unit.spec.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { render } from "@testing-library/react";
-import moment from "moment";
+import moment from "moment-timezone";
 
 import {
   DEFAULT_DATE_STYLE,

--- a/frontend/test/metabase/components/LastEditInfoLabel.unit.spec.js
+++ b/frontend/test/metabase/components/LastEditInfoLabel.unit.spec.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { renderWithProviders } from "__support__/ui";
 import mockDate from "mockdate";
-import moment from "moment";
+import moment from "moment-timezone";
 import LastEditInfoLabel from "metabase/components/LastEditInfoLabel";
 
 describe("LastEditInfoLabel", () => {

--- a/frontend/test/metabase/lib/query_time.unit.spec.js
+++ b/frontend/test/metabase/lib/query_time.unit.spec.js
@@ -1,4 +1,4 @@
-import moment from "moment";
+import moment from "moment-timezone";
 
 import {
   parseFieldBucketing,

--- a/frontend/test/metabase/lib/time.unit.spec.js
+++ b/frontend/test/metabase/lib/time.unit.spec.js
@@ -8,7 +8,7 @@ import {
   msToHours,
   hoursToSeconds,
 } from "metabase/lib/time";
-import moment from "moment";
+import moment from "moment-timezone";
 
 describe("time", () => {
   describe("parseTimestamp", () => {

--- a/frontend/test/metabase/modes/components/drill/UnderlyingRecordsDrill.unit.spec.js
+++ b/frontend/test/metabase/modes/components/drill/UnderlyingRecordsDrill.unit.spec.js
@@ -1,7 +1,7 @@
 import { ORDERS, PEOPLE } from "__support__/sample_database_fixture";
 
 import { assocIn } from "icepick";
-import moment from "moment";
+import moment from "moment-timezone";
 
 import UnderlyingRecordsDrill from "metabase/modes/components/drill/UnderlyingRecordsDrill";
 

--- a/frontend/test/metabase/scenarios/dashboard-filters/reproductions/22482-round-relative-ranges.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/reproductions/22482-round-relative-ranges.cy.spec.js
@@ -1,4 +1,4 @@
-import moment from "moment";
+import moment from "moment-timezone";
 import {
   restore,
   popover,

--- a/frontend/test/metabase/scenarios/filters/relative-datetime.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/relative-datetime.cy.spec.js
@@ -1,4 +1,4 @@
-import moment from "moment";
+import moment from "moment-timezone";
 import _ from "underscore";
 import { restore, popover, openOrdersTable } from "__support__/e2e/helpers";
 

--- a/frontend/test/metabase/visualizations/lib/apply_axis.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/apply_axis.unit.spec.js
@@ -2,7 +2,7 @@ import {
   maybeRoundValueToZero,
   stretchTimeseriesDomain,
 } from "metabase/visualizations/lib/apply_axis";
-import moment from "moment";
+import moment from "moment-timezone";
 
 describe("visualization.lib.apply_axis", () => {
   describe("stretchTimeseriesDomain", () => {

--- a/frontend/test/metabase/visualizations/lib/apply_tooltips.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/apply_tooltips.unit.spec.js
@@ -1,4 +1,4 @@
-import moment from "moment";
+import moment from "moment-timezone";
 
 import { getClickHoverObject } from "metabase/visualizations/lib/apply_tooltips";
 import { getDatas } from "metabase/visualizations/lib/renderer_utils";

--- a/frontend/test/metabase/visualizations/lib/fill_data.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/fill_data.unit.spec.js
@@ -1,4 +1,4 @@
-import moment from "moment";
+import moment from "moment-timezone";
 
 import fillMissingValuesInDatas from "metabase/visualizations/lib/fill_data";
 

--- a/frontend/test/metabase/visualizations/lib/renderer_utils.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/renderer_utils.unit.spec.js
@@ -1,4 +1,4 @@
-import moment from "moment";
+import moment from "moment-timezone";
 
 import {
   getDatas,

--- a/frontend/test/metabase/visualizations/lib/timeseriesScale.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/timeseriesScale.unit.spec.js
@@ -1,4 +1,4 @@
-import moment from "moment";
+import moment from "moment-timezone";
 
 import timeseriesScale from "metabase/visualizations/lib/timeseriesScale";
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "mochawesome": "^7.1.3",
     "mochawesome-merge": "^4.2.1",
     "mochawesome-report-generator": "^6.2.0",
-    "moment": "2.19.3",
     "moment-timezone": "^0.5.26",
     "mustache": "^2.3.2",
     "node-polyfill-webpack-plugin": "^1.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15485,11 +15485,6 @@ moment-timezone@^0.5.26:
   dependencies:
     moment ">= 2.9.0"
 
-moment@2.19.3:
-  version "2.19.3"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.19.3.tgz#bdb99d270d6d7fda78cc0fbace855e27fe7da69f"
-  integrity sha1-vbmdJw1tf9p4zA+6zoVeJ/59pp8=
-
 "moment@>= 2.9.0":
   version "2.29.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"


### PR DESCRIPTION
To date, we have used "moment" and "moment-timezone" in components.

"moment" does not respect locale settings.
"moment-timezone" does.

This PR removes "moment".