### PR TITLE
Back to light input borders

### DIFF
--- a/frontend/src/metabase/admin/datamodel/components/database/ColumnItem/ColumnItem.styled.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/ColumnItem/ColumnItem.styled.tsx
@@ -7,7 +7,7 @@ interface ColumnItemInputProps {
 }
 
 export const ColumnItemInput = styled(InputBlurChange)<ColumnItemInputProps>`
-  border-color: ${color("border-dark")};
+  border-color: ${color("border")};
 
   background-color: ${props =>
     color(props.variant === "primary" ? "white" : "bg-light")};

--- a/frontend/src/metabase/components/InputBlurChange.styled.tsx
+++ b/frontend/src/metabase/components/InputBlurChange.styled.tsx
@@ -2,5 +2,5 @@ import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
 
 export const Input = styled.input`
-  border: 1px solid ${color("border-dark")};
+  border: 1px solid ${color("border")};
 `;

--- a/frontend/src/metabase/components/TextInput/TextInput.styled.tsx
+++ b/frontend/src/metabase/components/TextInput/TextInput.styled.tsx
@@ -33,7 +33,7 @@ const getBorderColor = (colorScheme: ColorScheme, invalid?: boolean) => {
     return color("error");
   }
 
-  return colorScheme === "transparent" ? "transparent" : color("border-dark");
+  return colorScheme === "transparent" ? "transparent" : color("border");
 };
 
 export const Input = styled.input<InputProps>`

--- a/frontend/src/metabase/components/TokenField/TokenField.styled.tsx
+++ b/frontend/src/metabase/components/TokenField/TokenField.styled.tsx
@@ -21,7 +21,7 @@ export const TokenFieldContainer = styled.ul`
   overflow-x: auto;
   overflow-y: auto;
   border-radius: ${space(1)};
-  border: 1px solid ${color("border-dark")};
+  border: 1px solid ${color("border")};
 `;
 
 export const TokenInputItem = styled.li`

--- a/frontend/src/metabase/core/components/Input/Input.styled.tsx
+++ b/frontend/src/metabase/core/components/Input/Input.styled.tsx
@@ -26,7 +26,7 @@ export const InputField = styled.input<InputProps>`
   font-size: 1rem;
   color: ${color("text-dark")};
   padding: 0.75rem;
-  border: 1px solid ${color("border-dark")};
+  border: 1px solid ${color("border")};
   border-radius: ${space(1)};
   background-color: ${props => color(props.readOnly ? "bg-light" : "bg-white")};
   outline: none;

--- a/frontend/src/metabase/core/components/SelectButton/SelectButton.styled.tsx
+++ b/frontend/src/metabase/core/components/SelectButton/SelectButton.styled.tsx
@@ -24,7 +24,7 @@ export const SelectButtonRoot = styled.button<SelectButtonRootProps>`
   padding: 0.6em;
   border: 1px solid
     ${({ hasValue, highlighted }) =>
-      hasValue && highlighted ? color("brand") : color("border-dark")};
+      hasValue && highlighted ? color("brand") : color("border")};
   background-color: ${({ hasValue, highlighted }) =>
     hasValue && highlighted ? color("brand") : color("white")};
   border-radius: ${space(1)};

--- a/frontend/src/metabase/css/components/form.css
+++ b/frontend/src/metabase/css/components/form.css
@@ -1,5 +1,5 @@
 :root {
-  --form-field-border-color: var(--color-border-dark);
+  --form-field-border-color: var(--color-border);
   --input-border-radius: 8px;
 }
 ::-webkit-input-placeholder {

--- a/frontend/src/metabase/css/core/colors.css
+++ b/frontend/src/metabase/css/core/colors.css
@@ -23,7 +23,6 @@
   --color-focus: #cbe2f7;
   --color-shadow: rgba(0, 0, 0, 0.13);
   --color-border: #eeecec;
-  --color-border-dark: #c9ced3;
 }
 
 .text-default,

--- a/frontend/src/metabase/css/core/inputs.css
+++ b/frontend/src/metabase/css/core/inputs.css
@@ -1,5 +1,5 @@
 :root {
-  --input-border-color: var(--color-border-dark);
+  --input-border-color: var(--color-border);
   --input-border-active-color: var(--color-brand);
   --input-border-radius: 8px;
 }

--- a/frontend/src/metabase/dashboard/containers/DashboardHeader.styled.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardHeader.styled.jsx
@@ -8,7 +8,7 @@ export const DashboardHeaderActionDivider = styled.div`
   padding-left: 0.5rem;
   margin-left: 0.5rem;
   width: 0px;
-  border-left: 1px solid ${color("border-dark")};
+  border-left: 1px solid ${color("border")};
 `;
 
 export const DashboardHeaderButton = styled(Button)`

--- a/frontend/src/metabase/lib/colors/palette.ts
+++ b/frontend/src/metabase/lib/colors/palette.ts
@@ -39,7 +39,6 @@ export const colors: ColorPalette = {
   "bg-error": "#ED6E6E55",
   shadow: "rgba(0,0,0,0.08)",
   border: "#EEECEC",
-  "border-dark": "#C9CED3",
 
   /* Saturated colors for the SQL editor. Shouldn't be used elsewhere since they're not white-labelable. */
   "saturated-blue": "#2D86D4",

--- a/frontend/src/metabase/query_builder/components/QuestionActions.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/QuestionActions.styled.tsx
@@ -3,7 +3,7 @@ import { color } from "metabase/lib/colors";
 import DatasetMetadataStrengthIndicator from "./view/sidebars/DatasetManagementSection/DatasetMetadataStrengthIndicator";
 
 export const QuestionActionsDivider = styled.div`
-  border-left: 1px solid ${color("border-dark")};
+  border-left: 1px solid ${color("border")};
   margin-left: 0.5rem;
   margin-right: 0.5rem;
   height: 1.25rem;

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterSelect/BulkFilterSelect.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterSelect/BulkFilterSelect.styled.tsx
@@ -21,11 +21,7 @@ const lightSelectButton = ({ hasValue, isActive }: SelectFilterButtonProps) => `
     background-color: ${hasValue ? alpha("brand", 0.2) : "transparent"};
     color: ${hasValue ? color("brand") : color("text-light")};
     border-color: ${
-      isActive
-        ? color("brand")
-        : hasValue
-        ? "transparent"
-        : color("border-dark")
+      isActive ? color("brand") : hasValue ? "transparent" : color("border")
     };
 
     .Icon {


### PR DESCRIPTION
## Description

The darker input borders weren't working out as well as we had hoped, so this reverts all `border-dark` references back to `border` ([notion issue](https://www.notion.so/metabase/Input-border-color-6ca679518376467aaee3c477993e9877))

border-dark | border
--- | ---
![Screen Shot 2022-07-29 at 9 30 51 AM](https://user-images.githubusercontent.com/30528226/181793704-3f058959-37cb-41cd-9364-522b64ce3c8c.png) | ![Screen Shot 2022-07-29 at 9 26 00 AM](https://user-images.githubusercontent.com/30528226/181793788-0c5de0db-0f51-4e0f-811c-10566aa1bf18.png)
![Screen Shot 2022-07-29 at 9 29 31 AM](https://user-images.githubusercontent.com/30528226/181793748-99fe658f-df85-44f3-8883-bcf95ce1e916.png) | ![Screen Shot 2022-07-29 at 9 29 03 AM](https://user-images.githubusercontent.com/30528226/181793769-9505b835-5273-4b01-bbff-80f5e9bd1292.png)





