### PR TITLE
[CI] Create and use composite workaround action for required jobs

### DIFF
--- a/.github/actions/required-workaround/action.yml
+++ b/.github/actions/required-workaround/action.yml
@@ -1,0 +1,9 @@
+name: Conditionally skip required checks
+# https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+description: "Workaround to conditionally skip required checks if there is path filtering enabled in the workflow"
+
+runs:
+  using: "composite"
+  steps:
+    - run: echo "Didn't run due to conditional filtering"
+      shell: bash

--- a/.github/workflows/backend-skipped-checks.yml
+++ b/.github/workflows/backend-skipped-checks.yml
@@ -17,22 +17,19 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 10
     steps:
-      - run: |
-          echo "Didn't run due to conditional filtering"
+      - uses: ./.github/actions/required-workaround
 
   be-linter-eastwood:
     runs-on: ubuntu-20.04
     timeout-minutes: 20
     steps:
-      - run: |
-          echo "Didn't run due to conditional filtering"
+      - uses: ./.github/actions/required-workaround
 
   be-linter-namespace-decls:
     runs-on: ubuntu-20.04
     timeout-minutes: 10
     steps:
-      - run: |
-          echo "Didn't run due to conditional filtering"
+      - uses: ./.github/actions/required-workaround
 
   be-tests:
     runs-on: ubuntu-20.04
@@ -44,5 +41,4 @@ jobs:
         edition: [oss, ee]
         java-version: [11, 17]
     steps:
-      - run: |
-          echo "Didn't run due to conditional filtering"
+      - uses: ./.github/actions/required-workaround

--- a/.github/workflows/e2e-tests-skipped-checks.yml
+++ b/.github/workflows/e2e-tests-skipped-checks.yml
@@ -46,5 +46,4 @@ jobs:
             context: grep
             java-version: 11
     steps:
-      - run: |
-          echo "Didn't run due to conditional filtering"
+      - uses: ./.github/actions/required-workaround

--- a/.github/workflows/frontend-skipped-checks.yml
+++ b/.github/workflows/frontend-skipped-checks.yml
@@ -15,39 +15,33 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 10
     steps:
-      - run: |
-          echo "Didn't run due to conditional filtering"
+      - uses: ./.github/actions/required-workaround
 
   fe-linter-eslint:
     runs-on: ubuntu-20.04
     timeout-minutes: 20
     steps:
-      - run: |
-          echo "Didn't run due to conditional filtering"
+      - uses: ./.github/actions/required-workaround
 
   fe-type-check:
     runs-on: ubuntu-20.04
     timeout-minutes: 10
     steps:
-      - run: |
-          echo "Didn't run due to conditional filtering"
+      - uses: ./.github/actions/required-workaround
 
   fe-tests-unit:
     runs-on: ubuntu-20.04
     timeout-minutes: 20
     steps:
-      - run: |
-          echo "Didn't run due to conditional filtering"
+      - uses: ./.github/actions/required-workaround
 
   fe-tests-timezones:
     runs-on: ubuntu-20.04
     timeout-minutes: 14
     steps:
-      - run: |
-          echo "Didn't run due to conditional filtering"
+      - uses: ./.github/actions/required-workaround
 
   fe-chromatic:
     runs-on: ubuntu-20.04
     steps:
-      - run: |
-          echo "Didn't run due to conditional filtering"
+      - uses: ./.github/actions/required-workaround

--- a/.github/workflows/presto-kerberos-integration-test-skipped-checks.yml
+++ b/.github/workflows/presto-kerberos-integration-test-skipped-checks.yml
@@ -19,5 +19,4 @@ jobs:
   run-presto-kerberos-test:
     runs-on: ubuntu-latest
     steps:
-      - run: |
-          echo "Didn't run due to conditional filtering"
+      - uses: ./.github/actions/required-workaround

--- a/.github/workflows/snowplow-skipped-checks.yml
+++ b/.github/workflows/snowplow-skipped-checks.yml
@@ -15,5 +15,4 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - run: |
-          echo "Didn't run due to conditional filtering"
+      - uses: ./.github/actions/required-workaround


### PR DESCRIPTION
It seems that we're going to use [this workaround](https://github.com/metabase/metabase/pull/24361) in a [lot of places](https://github.com/metabase/metabase/issues/24429), so it makes sense to abstract the logic and to DRY the code a bit.

- Creates a composite action that prints the message using `echo` when the required check hits the conditional path filtering logic
- Applies that composite action to already affected workflows