### PR TITLE
Fix Table Names Not Appearing in Dimension Option Lists

### DIFF
--- a/frontend/src/metabase-lib/lib/Dimension.ts
+++ b/frontend/src/metabase-lib/lib/Dimension.ts
@@ -274,6 +274,10 @@ export default class Dimension {
     );
   }
 
+  isExpression(): boolean {
+    return isExpressionDimension(this);
+  }
+
   foreign(dimension: Dimension): FieldDimension {
     return null;
   }

--- a/frontend/src/metabase-lib/lib/DimensionOptions/DimensionOptions.ts
+++ b/frontend/src/metabase-lib/lib/DimensionOptions/DimensionOptions.ts
@@ -36,7 +36,9 @@ export default class DimensionOptions {
   }
 
   sections({ extraItems = [] } = {}): DimensionOptionsSection[] {
-    const [dimension] = this.dimensions;
+    const dimension =
+      this.dimensions.find(dimension => !dimension.isExpression()) ??
+      this.dimensions[0];
     const table = dimension && dimension.field().table;
     const tableName = table ? table.objectName() : null;
     const mainSection: DimensionOptionsSection = {


### PR DESCRIPTION
This is a pretty cool bug (if you're into that sort of thing). ([notion link](https://www.notion.so/metabase/Bulk-filter-modal-tabs-aren-t-handling-joined-tables-correctly-fa182bb8a36a4821ac2111f04bb11108)). It actually pre-dates the bulk filter modal, but the way we built the bulk filter modal makes it more obvious.

## Bug Manifestation

On certain questions, table names would not show up in either the bulk filter modal, or the filter popover field list:

![Screen Shot 2022-07-29 at 10 34 14 AM](https://user-images.githubusercontent.com/30528226/181805133-7293a8a3-3923-402a-9532-68437d0f631f.png) ![Screen Shot 2022-07-29 at 10 34 03 AM](https://user-images.githubusercontent.com/30528226/181805138-dd7ad0c0-c34d-4ca7-b21e-4b56d810ff18.png)

To reproduce this, you must: 
1. add a custom column to a query
2. add a join to the query (this isn't strictly necessary to reproduce the bug, but it is to see it appear in the bulk filter modal)
3. save the question

When grouping dimensions to display possible filter options, we group by table. We extract the table name from the first dimension in each "section".  ExpressionDimensions _always_ sort to the top of the dimension list. Strangely, Dimensions that are ExpressionDimensions do not _always_ have a table property ( I really don't know why). Before you save the question, the ExpressionDimension has a table object and a name, but after it is saved, that data disappears.

## Solution

When we're extracting table name data in `DimensionOptions`, we will look for the first Dimension that is not an `ExpressionDimension` (i.e. a custom column)

![Screen Shot 2022-07-29 at 10 49 43 AM](https://user-images.githubusercontent.com/30528226/181806941-2eb0c8b2-e166-4bdc-96a4-c52b04053c72.png) ![Screen Shot 2022-07-29 at 10 49 34 AM](https://user-images.githubusercontent.com/30528226/181806943-b21f39f4-f362-40e7-97a2-e757968c11fc.png)


## Testing Steps

- using the reproduction steps above, save a question with a custom column
- on the master branch, see that question is missing the primary table name in the bulk filter modal tabs and in the filter popover in notebook mode
- switch to this branch, and see that those table names appear for that saved question
