### PR TITLE
Hide Popover suggestions on item removal

### DIFF
--- a/frontend/src/metabase/components/TokenField/TokenField.tsx
+++ b/frontend/src/metabase/components/TokenField/TokenField.tsx
@@ -455,18 +455,12 @@ export default class TokenField extends Component<
     } else {
       onChange(valueToAdd.slice(0, 1));
     }
-    // reset the input value
-    // setTimeout(() =>
-    //   this.setInputValue("")
-    // )
   }
 
   removeValue(valueToRemove: any) {
     const { value, onChange } = this.props;
     const values = value.filter(v => !this._valueIsEqual(v, valueToRemove));
     onChange(values);
-    // reset the input value
-    // this.setInputValue("");
   }
 
   _valueIsEqual(v1: any, v2: any) {
@@ -592,6 +586,7 @@ export default class TokenField extends Component<
                 onClick={e => {
                   e.preventDefault();
                   this.removeValue(v);
+                  this.inputRef?.current?.blur();
                 }}
                 onMouseDown={e => e.preventDefault()}
               >


### PR DESCRIPTION
## Description

When you remove an item from a tokenField, the suggestion popover should not stay open (or open at all).

Before

![beforepop](https://user-images.githubusercontent.com/30528226/181814917-48a8c396-594a-4daf-959b-0e1408ce277d.gif)

After

![after](https://user-images.githubusercontent.com/30528226/181814932-b0d5c8a3-86d2-4eb0-925a-0edcafa0d0a3.gif)
