### PR TITLE
Align prefix container

### DIFF
--- a/frontend/src/metabase/components/TokenField/TokenField.styled.tsx
+++ b/frontend/src/metabase/components/TokenField/TokenField.styled.tsx
@@ -35,3 +35,9 @@ export const TokenInputItem = styled.li`
     height: 46px;
   }
 `;
+
+export const PrefixContainer = styled.div`
+  display: flex;
+  align-items: center;
+  color: ${color("text-medium")};
+`;

--- a/frontend/src/metabase/components/TokenField/TokenField.tsx
+++ b/frontend/src/metabase/components/TokenField/TokenField.tsx
@@ -19,7 +19,11 @@ import {
 } from "metabase/lib/keyboard";
 import { isObscured } from "metabase/lib/dom";
 
-import { TokenInputItem, TokenFieldContainer } from "./TokenField.styled";
+import {
+  TokenInputItem,
+  TokenFieldContainer,
+  PrefixContainer,
+} from "./TokenField.styled";
 
 export type LayoutRendererArgs = {
   valuesList: React.ReactNode;
@@ -577,9 +581,7 @@ export default class TokenField extends Component<
         onMouseDownCapture={this.onMouseDownCapture}
       >
         {!!prefix && (
-          <span className="text-medium mb1 py1 pr1" data-testid="input-prefix">
-            {prefix}
-          </span>
+          <PrefixContainer data-testid="input-prefix">{prefix}</PrefixContainer>
         )}
         {value.map((v, index) => (
           <TokenFieldItem key={index} isValid={validateValue(v)}>


### PR DESCRIPTION
Some recent changes to TokenField margins and padding made the currency prefix misaligned

Before 🤢 

![Screen Shot 2022-07-29 at 4 55 01 PM](https://user-images.githubusercontent.com/30528226/181855545-96f84862-9b9d-4e58-a2e0-ca2ae12e0e06.png)


After 😀 

![Screen Shot 2022-07-29 at 4 53 05 PM](https://user-images.githubusercontent.com/30528226/181855553-357bcd42-d8dc-4d7a-9fa9-d5ad60864d24.png)

