### PR TITLE
Don't hardcode the `localhost` serving for Webpack bundles

### DIFF
--- a/package.json
+++ b/package.json
@@ -279,7 +279,7 @@
     "test-timezones": "yarn && ./frontend/test/__runner__/run_timezone_tests",
     "build:js": "yarn && webpack --bail",
     "build-watch:js": "yarn && webpack --watch",
-    "build-hot:js": "yarn && NODE_OPTIONS=--max-old-space-size=8096 WEBPACK_BUNDLE=hot webpack serve --progress --host 0.0.0.0",
+    "build-hot:js": "yarn && NODE_OPTIONS=--max-old-space-size=8096 WEBPACK_BUNDLE=hot webpack serve",
     "build:cljs": "yarn && rm -rf frontend/src/cljs/* && shadow-cljs release app",
     "build-quick:cljs": "yarn build:cljs",
     "build-watch:cljs": "yarn cljs-server-restart && shadow-cljs watch app",

--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -56,7 +56,7 @@
                                      "https://www.google-analytics.com")
                                    ;; for webpack hot reloading
                                    (when config/is-dev?
-                                     "localhost:8080")
+                                     "*:8080")
                                    ;; for react dev tools to work in Firefox until resolution of
                                    ;; https://github.com/facebook/react/issues/17997
                                    (when config/is-dev?
@@ -85,7 +85,7 @@
                                    (snowplow/snowplow-url))
                                  ;; Webpack dev server
                                  (when config/is-dev?
-                                   "localhost:8080 ws://localhost:8080")]
+                                   "*:8080 ws://*:8080")]
                   :manifest-src ["'self'"]}]
       (format "%s %s; " (name k) (str/join " " vs))))})
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -217,10 +217,10 @@ const config = (module.exports = {
 
 if (WEBPACK_BUNDLE === "hot") {
 
-  const localIPAddress = getLocalIPAddress("IPv4") || getLocalIPAddress("IPv6") || "0.0.0.0";
+  const localIpAddress = getLocalIpAddress("IPv4") || getLocalIpAddress("IPv6") || "0.0.0.0";
 
   const webpackPort = 8080;
-  const webpackHost = `http://${localIPAddress}:${webpackPort}`
+  const webpackHost = `http://${localIpAddress}:${webpackPort}`
   config.target = "web";
   // suffixing with ".hot" allows us to run both `yarn run build-hot` and `yarn run test` or `yarn run test-watch` simultaneously
   config.output.filename = "[name].hot.bundle.js?[contenthash]";
@@ -323,9 +323,12 @@ if (WEBPACK_BUNDLE !== "production") {
   config.devtool = "source-map";
 }
 
-function getLocalIPAddress(ipFamily) {
+function getLocalIpAddress(ipFamily) {
   const networkInterfaces = os.networkInterfaces();
-  const interfaces = Object.keys(networkInterfaces).map(i => networkInterfaces[i]).reduce((p, q) => p.concat(q));
+  const interfaces = Object.keys(networkInterfaces)
+    .map(iface => networkInterfaces[iface])
+    .reduce((interfaces, iface) => interfaces.concat(iface));
+
   const externalInterfaces = interfaces.filter(iface => !iface.internal)
 
   const { address } = externalInterfaces.filter(({ family }) => family === ipFamily).shift();

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,6 +12,7 @@ const WebpackNotifierPlugin = require("webpack-notifier");
 const ReactRefreshPlugin = require("@pmmmwh/react-refresh-webpack-plugin");
 
 const fs = require("fs");
+const os = require("os");
 
 const ASSETS_PATH = __dirname + "/resources/frontend_client/app/assets";
 const FONTS_PATH = __dirname + "/resources/frontend_client/app/fonts";
@@ -215,13 +216,17 @@ const config = (module.exports = {
 });
 
 if (WEBPACK_BUNDLE === "hot") {
+
+  const localIPAddress = getLocalIPAddress("IPv4") || getLocalIPAddress("IPv6") || "0.0.0.0";
+
+  const webpackPort = 8080;
+  const webpackHost = `http://${localIPAddress}:${webpackPort}`
   config.target = "web";
   // suffixing with ".hot" allows us to run both `yarn run build-hot` and `yarn run test` or `yarn run test-watch` simultaneously
   config.output.filename = "[name].hot.bundle.js?[contenthash]";
 
   // point the publicPath (inlined in index.html by HtmlWebpackPlugin) to the hot-reloading server
-  config.output.publicPath =
-    "http://localhost:8080/" + config.output.publicPath;
+  config.output.publicPath = webpackHost + "/" + config.output.publicPath;
 
   config.module.rules.unshift({
     test: /\.(tsx?|jsx?)$/,
@@ -238,8 +243,14 @@ if (WEBPACK_BUNDLE === "hot") {
   });
 
   config.devServer = {
+    host: "local-ip",
+    port: webpackPort,
+    allowedHosts: "auto",
     hot: true,
-    client: { overlay: false },
+    client: {
+      progress: true,
+      overlay: false
+    },
     headers: {
       "Access-Control-Allow-Origin": "*",
     },
@@ -310,4 +321,13 @@ if (WEBPACK_BUNDLE !== "production") {
   );
 
   config.devtool = "source-map";
+}
+
+function getLocalIPAddress(ipFamily) {
+  const networkInterfaces = os.networkInterfaces();
+  const interfaces = Object.keys(networkInterfaces).map(i => networkInterfaces[i]).reduce((p, q) => p.concat(q));
+  const externalInterfaces = interfaces.filter(iface => !iface.internal)
+
+  const { address } = externalInterfaces.filter(({ family }) => family === ipFamily).shift();
+  return address;
 }


### PR DESCRIPTION
This is another step towards full-support of remote development/IDE (using e.g. GitHub Codespaces, VS Remote, etc).

How to test:
1. Get a remote machine running e.g. Linux. Let's assume the IP address is 192.168.1.71
2. Clone Metabase from Git, install all the deps, and run `yarn dev`
3. From a different machine, browse to `http://192.168.1.71:3000`

### Before this PR

Nothing will be displayed by the browser. Looking at the inspector, the network traffic reveals that Metabase from the remote machine (192.168.1.71:3000) is trying to load Webpack-served bundles from `localhost:8080`, which won't work.

### After this PR

It works as expected, since Metabase from the remote machine (192.168.1.71:3000) is correctly loading Webpack-served bundles from the same machine (192.168.1.71:8080).

![image](https://user-images.githubusercontent.com/7288/182039439-d410f73d-e372-4af1-834a-602e7724fda4.png)


