### PR TITLE
Forms Refactoring 1 — Clean up types

### DIFF
--- a/frontend/src/metabase-types/forms/index.ts
+++ b/frontend/src/metabase-types/forms/index.ts
@@ -31,7 +31,7 @@ export type BaseFieldDefinition = {
 };
 
 export type StandardFormFieldDefinition = BaseFieldDefinition & {
-  type: string;
+  type: string | (() => JSX.Element);
 };
 
 export type CustomFormFieldDefinition = BaseFieldDefinition & {

--- a/frontend/src/metabase-types/forms/index.ts
+++ b/frontend/src/metabase-types/forms/index.ts
@@ -49,8 +49,6 @@ export type FormField<Value = DefaultFieldValue> = {
   initialValue: Value;
 
   active: boolean;
-  autofilled: boolean;
-  checked: boolean;
   dirty: boolean;
   invalid: boolean;
   pristine: boolean;
@@ -58,14 +56,9 @@ export type FormField<Value = DefaultFieldValue> = {
   valid: boolean;
   visited: boolean;
 
-  autofill: () => void;
-
   onBlur: () => void;
-  onChange: () => void;
-  onDragStart: () => void;
-  onDrop: () => void;
   onFocus: () => void;
-  onUpdate: () => void;
+  onChange: (value: Value) => void;
 };
 
 export type FormObject = {

--- a/frontend/src/metabase/components/form/CustomForm/CustomForm.tsx
+++ b/frontend/src/metabase/components/form/CustomForm/CustomForm.tsx
@@ -6,7 +6,7 @@ import { FormFieldDefinition, FormObject } from "metabase-types/forms";
 import {
   BaseFormProps,
   OptionalFormViewProps,
-  FormLegacyContext,
+  CustomFormLegacyContext,
   LegacyContextTypes,
 } from "./types";
 
@@ -50,7 +50,7 @@ function CustomForm(props: CustomFormProps) {
 class CustomFormWithLegacyContext extends React.Component<CustomFormProps> {
   static childContextTypes = LegacyContextTypes;
 
-  getChildContext(): FormLegacyContext {
+  getChildContext(): CustomFormLegacyContext {
     const {
       fields,
       values,

--- a/frontend/src/metabase/components/form/CustomForm/CustomFormField.tsx
+++ b/frontend/src/metabase/components/form/CustomForm/CustomFormField.tsx
@@ -16,7 +16,11 @@ import {
   FormFieldDefinition,
 } from "metabase-types/forms";
 
-import { FormLegacyContext, LegacyContextTypes } from "./types";
+import {
+  CustomFormLegacyContext,
+  FormContainerLegacyContext,
+  LegacyContextTypes,
+} from "./types";
 
 function isCustomWidget(
   formField: FormFieldDefinition,
@@ -31,10 +35,9 @@ export interface CustomFormFieldProps extends BaseFieldDefinition {
   onChange?: (e: unknown) => void;
 }
 
-interface LegacyContextProps extends FormLegacyContext {
-  registerFormField?: (field: BaseFieldDefinition) => void;
-  unregisterFormField?: (field: BaseFieldDefinition) => void;
-}
+interface LegacyContextProps
+  extends CustomFormLegacyContext,
+    FormContainerLegacyContext {}
 
 function getFieldDefinition(props: CustomFormFieldProps): BaseFieldDefinition {
   return _.pick(
@@ -112,7 +115,7 @@ function RawCustomFormField({
 
 const CustomFormFieldLegacyContext = (
   props: CustomFormFieldProps & { forwardedRef?: any },
-  context: FormLegacyContext,
+  context: LegacyContextProps,
 ) => <RawCustomFormField {...props} {...context} />;
 
 CustomFormFieldLegacyContext.contextTypes = {

--- a/frontend/src/metabase/components/form/CustomForm/CustomFormMessage.tsx
+++ b/frontend/src/metabase/components/form/CustomForm/CustomFormMessage.tsx
@@ -3,7 +3,7 @@ import _ from "underscore";
 
 import FormMessage from "metabase/components/form/FormMessage";
 
-import { FormLegacyContext, LegacyContextTypes } from "./types";
+import { CustomFormLegacyContext, LegacyContextTypes } from "./types";
 
 export interface CustomFormMessageProps {
   className?: string;
@@ -13,7 +13,7 @@ export interface CustomFormMessageProps {
 function CustomFormMessage({
   error,
   ...props
-}: CustomFormMessageProps & FormLegacyContext) {
+}: CustomFormMessageProps & CustomFormLegacyContext) {
   if (error) {
     return <FormMessage {...props} message={error} />;
   }
@@ -22,7 +22,7 @@ function CustomFormMessage({
 
 const CustomFormMessageLegacyContext = (
   props: CustomFormMessageProps,
-  context: FormLegacyContext,
+  context: CustomFormLegacyContext,
 ) => <CustomFormMessage {...props} {...context} />;
 
 CustomFormMessageLegacyContext.contextTypes = _.pick(

--- a/frontend/src/metabase/components/form/CustomForm/CustomFormSubmit.tsx
+++ b/frontend/src/metabase/components/form/CustomForm/CustomFormSubmit.tsx
@@ -4,7 +4,7 @@ import _ from "underscore";
 
 import ActionButton from "metabase/components/ActionButton";
 
-import { FormLegacyContext, LegacyContextTypes } from "./types";
+import { CustomFormLegacyContext, LegacyContextTypes } from "./types";
 
 export interface CustomFormSubmitProps {
   children: React.ReactNode;
@@ -23,7 +23,7 @@ function CustomFormSubmit({
   disablePristineSubmit,
   children,
   ...props
-}: CustomFormSubmitProps & FormLegacyContext) {
+}: CustomFormSubmitProps & CustomFormLegacyContext) {
   const title = children || submitTitle || t`Submit`;
   const canSubmit = !(
     submitting ||
@@ -52,7 +52,7 @@ function CustomFormSubmit({
 
 const CustomFormSubmitLegacyContext = (
   props: CustomFormSubmitProps,
-  context: FormLegacyContext,
+  context: CustomFormLegacyContext,
 ) => <CustomFormSubmit {...props} {...context} />;
 
 CustomFormSubmitLegacyContext.contextTypes = _.pick(

--- a/frontend/src/metabase/components/form/CustomForm/Form.tsx
+++ b/frontend/src/metabase/components/form/CustomForm/Form.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import _ from "underscore";
-import { FormLegacyContext, LegacyContextTypes } from "./types";
+import { CustomFormLegacyContext, LegacyContextTypes } from "./types";
 
 type Props = {
   children: React.ReactNode;
@@ -11,7 +11,7 @@ function Form({
   handleSubmit,
   className,
   style,
-}: Props & FormLegacyContext) {
+}: Props & CustomFormLegacyContext) {
   return (
     <form onSubmit={handleSubmit} className={className} style={style}>
       {children}
@@ -19,9 +19,10 @@ function Form({
   );
 }
 
-const FormUsingLegacyContext = (props: Props, context: FormLegacyContext) => (
-  <Form {...props} {...context} />
-);
+const FormUsingLegacyContext = (
+  props: Props,
+  context: CustomFormLegacyContext,
+) => <Form {...props} {...context} />;
 
 FormUsingLegacyContext.contextTypes = _.pick(
   LegacyContextTypes,

--- a/frontend/src/metabase/components/form/CustomForm/types.ts
+++ b/frontend/src/metabase/components/form/CustomForm/types.ts
@@ -13,7 +13,7 @@ export interface BaseFormProps {
   formName: string;
   formObject: FormObject;
 
-  fields: FormField[];
+  fields: Record<string, FormField>;
   values: FieldValues;
   errors: Record<FieldName, string>;
 

--- a/frontend/src/metabase/components/form/CustomForm/types.ts
+++ b/frontend/src/metabase/components/form/CustomForm/types.ts
@@ -36,11 +36,6 @@ export interface BaseFormProps {
   onChangeField: (fieldName: FieldName, value: DefaultFieldValue) => void;
   onSubmitSuccess: () => void;
   resetForm: () => void;
-  submitPassback: () => void;
-  touch: () => void;
-  touchAll: () => void;
-  untouch: () => void;
-  untouchAll: () => void;
 }
 
 type RenderSubmitProps = {

--- a/frontend/src/metabase/components/form/CustomForm/types.ts
+++ b/frontend/src/metabase/components/form/CustomForm/types.ts
@@ -1,5 +1,6 @@
 import PropTypes from "prop-types";
 import {
+  BaseFieldDefinition,
   FieldName,
   DefaultFieldValue,
   FieldValues,
@@ -55,10 +56,13 @@ export interface OptionalFormViewProps {
   style?: React.CSSProperties;
 }
 
-export interface FormLegacyContext
+export interface CustomFormLegacyContext
   extends OptionalFormViewProps,
     Pick<
       BaseFormProps,
+      | "formFields"
+      | "formFieldsByName"
+      | "disablePristineSubmit"
       | "handleSubmit"
       | "fields"
       | "values"
@@ -67,10 +71,11 @@ export interface FormLegacyContext
       | "pristine"
       | "error"
       | "onChangeField"
-    > {
-  formFields: FormFieldDefinition[];
-  formFieldsByName: Record<FieldName, FormFieldDefinition>;
-  disablePristineSubmit?: boolean;
+    > {}
+
+export interface FormContainerLegacyContext {
+  registerFormField: (fieldDef: BaseFieldDefinition) => void;
+  unregisterFormField: (fieldDef: BaseFieldDefinition) => void;
 }
 
 export const LegacyContextTypes = {

--- a/frontend/src/metabase/components/form/CustomForm/types.ts
+++ b/frontend/src/metabase/components/form/CustomForm/types.ts
@@ -13,6 +13,10 @@ export interface BaseFormProps {
   formName?: string;
   formObject: FormObject;
 
+  formFields: FormFieldDefinition[];
+  formFieldsByName: Record<FieldName, FormFieldDefinition>;
+  disablePristineSubmit?: boolean;
+
   fields: Record<string, FormField>;
   values: FieldValues;
   errors: Record<FieldName, string>;

--- a/frontend/src/metabase/components/form/CustomForm/types.ts
+++ b/frontend/src/metabase/components/form/CustomForm/types.ts
@@ -10,7 +10,7 @@ import {
 
 export interface BaseFormProps {
   formKey?: string;
-  formName: string;
+  formName?: string;
   formObject: FormObject;
 
   fields: Record<string, FormField>;
@@ -18,13 +18,13 @@ export interface BaseFormProps {
   errors: Record<FieldName, string>;
 
   active?: boolean;
-  asyncValidating: boolean;
+  asyncValidating?: boolean;
   dirty: boolean;
   error?: string;
   invalid: boolean;
   overwriteOnInitialValuesChange?: boolean;
   pristine: boolean;
-  readonly: boolean;
+  readonly?: boolean;
   submitFailed: boolean;
   submitting: boolean;
   valid: boolean;


### PR DESCRIPTION
Part of #22372 and, more specifically, #24637

These types were initially extracted in #22373, but appeared not to be exactly accurate. This PR should fix that, remove some of the types usually coming from `redux-form` that are not really used in Metabase, etc. This makes it easier to type the upcoming `Form` container replacement