### PR TITLE
exception for none and block

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/data-model-permission.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/data-model-permission.unit.spec.ts
@@ -167,5 +167,21 @@ describe("buildDataModelPermission", () => {
       );
       expect(downgradePermissionConfirmation?.message).toBeUndefined();
     });
+
+    it("does not warn when group permissions is blocking", () => {
+      const permissionModel = buildDataModelPermission(
+        { databaseId },
+        groupId,
+        isNotAdmin,
+        getPermissionGraph("block"),
+        defaultGroup,
+        "schemas",
+      );
+
+      const [downgradePermissionConfirmation] =
+        permissionModel.confirmations("all");
+
+      expect(permissionModel.warning).toBe(null);
+    });
   });
 });

--- a/frontend/src/metabase/admin/permissions/selectors/confirmations.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/confirmations.ts
@@ -20,9 +20,15 @@ function hasGreaterPermissions(
   b: string,
   descendingPermissions = PERM_LEVELS,
 ) {
-  return (
-    descendingPermissions.indexOf(a) - descendingPermissions.indexOf(b) < 0
-  );
+  // Avoids scenario where the logic of the PERM_LEVELS ordering suggests that
+  // a default group permission of "none" would overrule "block".
+  if (a === "none" && b === "block") {
+    return false;
+  } else {
+    return (
+      descendingPermissions.indexOf(a) - descendingPermissions.indexOf(b) < 0
+    );
+  }
 }
 
 export function getPermissionWarning(


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/24380

![image](https://user-images.githubusercontent.com/17343328/182190454-99b2fbea-1db3-4286-84e8-3ee255e8828f.png)

Adds a conditional to `hasGreaterPermissions` function to account for a scenario where the logic of the `PERM_LEVELS` ordering fails. With this fix, the warning shown above will NOT appear when the all users default group permission is set to "No self-service" (`"none"`), and the value being set is `"block"`.
