### PR TITLE
Bump jetty-server to 9.4.48.v20220622

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -117,7 +117,7 @@
   org.clojure/tools.namespace               {:mvn/version "1.3.0"}
   org.clojure/tools.reader                  {:mvn/version "1.3.6"}
   org.clojure/tools.trace                   {:mvn/version "0.7.11"}             ; function tracing
-  org.eclipse.jetty/jetty-server            {:mvn/version "9.4.44.v20210927"}   ; web server
+  org.eclipse.jetty/jetty-server            {:mvn/version "9.4.48.v20220622"}   ; web server
   org.flatland/ordered                      {:mvn/version "1.15.10"}            ; ordered maps & sets
   org.graalvm.js/js                         {:mvn/version "22.1.0"}             ; JavaScript engine
   org.liquibase/liquibase-core              {:mvn/version "4.10.0"              ; migration management (Java lib)


### PR DESCRIPTION
Addresses 
- [CVE-2022-2047](https://github.com/advisories/GHSA-cj7v-27pg-wf7q)
- [CVE-2022-2048](https://github.com/advisories/GHSA-wgmr-mf83-7x4j)
- https://github.com/eclipse/jetty.project/issues/8184

And silences trivy alerts.

Note: Jetty 9.4.x has reached the [end of community support](https://github.com/eclipse/jetty.project/issues/7958) - we should look into moving onto 10 or 11 at some point.
