### PR TITLE
Fix failing migrations

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -8009,12 +8009,17 @@ databaseChangeLog:
         - onFail: MARK_RAN
         - and:
             - dbms:
-                type: postgresql,mysql,mariadb
+                type: postgresql
+      # This has maybe never succeeded in creating the index because (at least with the current DB versions)
+      # the syntax was wrong on all requested databases (postgresql, mysql and mariadb). Since this change is
+      # not critical it's OK to ignore it.
+      validCheckSum: 8:9da2f706a7cd42b5101601e0106fa929
       changes:
         - createIndex:
             columns:
              - column:
                  name: lower(email)
+                 computed: true
                  type: varchar(254)
             tableName: core_user
             indexName: idx_lower_email
@@ -8062,6 +8067,7 @@ databaseChangeLog:
       comment: Added 0.37.0 # for H2 convert column to VARCHAR_IGNORECASE
       failOnError: false
       preConditions:
+         - onFail: MARK_RAN
          - or:
              - dbms:
                    type: h2


### PR DESCRIPTION
Fixes #22867.

There are two change sets that are skipped and not marked as "run": `268` and `272`. The latter is trivial, we just have to tell liquibase to consider the change set as run for databases other than H2. The former is a bit more complicated:
the command generated by liquibase is invalid for all three database types specified in the pre-condition but the error gets ignored and the change set is re-tried on every migration.

Since this problem has not been reported earlier, I assume that it's not very important. Also, as far as I know string comparisons in MySQL and MariaDB are case insensitive unless we explicitly select binary mode, so the engine might optimize away `lower` when looking up users by email. (I haven't checked if they do.) MariaDB doesn't support function indexes at all, so this change doesn't make sense for it.

The suggested fix for change set `268` is then 
- remove MySQL and MariaDB from the list of datatabase types it should be applied for,
- fix the command for PostgreSQL, and
- ignore the checksum mismatch with the previous version.

If change `268` _is_ important for MySQL, then I can add a new change set for it.

I have tested the fix with PostgreSQL, MySQL and MariaDB manually. The other database types have been tested by CI only.