### PR TITLE
Show "Starting from" filters only when expressions are supported

### DIFF
--- a/frontend/src/metabase-lib/lib/metadata/Database.ts
+++ b/frontend/src/metabase-lib/lib/metadata/Database.ts
@@ -98,6 +98,10 @@ class DatabaseInner extends Base {
     return this.hasFeature("expressions") && this.hasFeature("left-join");
   }
 
+  supportsExpressions() {
+    return this.hasFeature("expressions");
+  }
+
   canWrite() {
     return this.native_permissions === "write";
   }

--- a/frontend/src/metabase/components/DateAllOptionsWidget/DateAllOptionsWidget.tsx
+++ b/frontend/src/metabase/components/DateAllOptionsWidget/DateAllOptionsWidget.tsx
@@ -50,6 +50,7 @@ const DateAllOptionsWidget = ({
         hideTimeSelectors
         hideEmptinessOperators
         disableOperatorSelection={disableOperatorSelection}
+        supportsExpressions
       >
         <UpdateButton
           className={cx({

--- a/frontend/src/metabase/query_builder/components/filters/FilterPopover/FilterPopover.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/FilterPopover/FilterPopover.tsx
@@ -250,6 +250,7 @@ export default class FilterPopover extends Component<Props, State> {
       };
 
       const shouldShowDatePicker = field?.isDate() && !field?.isTime();
+      const supportsExpressions = query.database()?.supportsExpressions();
 
       return (
         <div className={className} style={{ minWidth: MIN_WIDTH, ...style }}>
@@ -265,6 +266,7 @@ export default class FilterPopover extends Component<Props, State> {
               onCommit={this.handleCommit}
               onFilterChange={this.handleFilterChange}
               disableChangingDimension={!showFieldPicker}
+              supportsExpressions={supportsExpressions}
             >
               <Button
                 data-ui-tag="add-filter"

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePicker.tsx
@@ -237,6 +237,7 @@ type Props = {
   hideEmptinessOperators?: boolean;
   disableOperatorSelection?: boolean;
   disableChangingDimension?: boolean;
+  supportsExpressions?: boolean;
 
   primaryColor?: string;
   minWidth?: number | null;
@@ -255,6 +256,7 @@ const DatePicker: React.FC<Props> = props => {
     onFilterChange,
     disableOperatorSelection,
     disableChangingDimension,
+    supportsExpressions,
     primaryColor,
     onCommit,
     children,
@@ -313,6 +315,7 @@ const DatePicker: React.FC<Props> = props => {
               filter={filter}
               onCommit={onCommit}
               primaryColor={primaryColor}
+              supportsExpressions={supportsExpressions}
               onFilterChange={(filter: Filter) => {
                 if (!isStartingFrom(filter) && operator && operator.init) {
                   onFilterChange(operator.init(filter));

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RelativeDatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RelativeDatePicker.tsx
@@ -111,7 +111,7 @@ const OptionsContent: React.FC<OptionsContentProps> = ({
   const includeCurrent = !!options["include-current"];
   const currentString = getCurrentString(filter);
   const database = filter.query().database();
-  const supportsExpressions = database?.hasFeature("expressions");
+  const supportsStartingFromFilters = database?.supportsExpressions();
 
   const handleClickOnStartingFrom = () => {
     setOptionsVisible(false);
@@ -130,7 +130,7 @@ const OptionsContent: React.FC<OptionsContentProps> = ({
 
   return (
     <OptionsContainer>
-      {supportsExpressions && (
+      {supportsStartingFromFilters && (
         <OptionButton
           icon="arrow_left_to_line"
           primaryColor={primaryColor}

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RelativeDatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RelativeDatePicker.tsx
@@ -36,6 +36,7 @@ type RelativeDatePickerProps = {
   offsetFormatter: (value: number) => number;
   primaryColor?: string;
   reverseIconDirection?: boolean;
+  supportsExpressions?: boolean;
 };
 
 type OptionsContentProps = RelativeDatePickerProps & {
@@ -106,12 +107,11 @@ const OptionsContent: React.FC<OptionsContentProps> = ({
   onFilterChange,
   reverseIconDirection,
   setOptionsVisible,
+  supportsExpressions,
 }) => {
   const options = filter[4] || {};
   const includeCurrent = !!options["include-current"];
   const currentString = getCurrentString(filter);
-  const database = filter.query().database();
-  const supportsStartingFromFilters = database?.supportsExpressions();
 
   const handleClickOnStartingFrom = () => {
     setOptionsVisible(false);
@@ -130,7 +130,7 @@ const OptionsContent: React.FC<OptionsContentProps> = ({
 
   return (
     <OptionsContainer>
-      {supportsStartingFromFilters && (
+      {supportsExpressions && (
         <OptionButton
           icon="arrow_left_to_line"
           primaryColor={primaryColor}
@@ -161,7 +161,6 @@ const RelativeDatePicker: React.FC<RelativeDatePickerProps> = props => {
     offsetFormatter = value => value,
     className,
     primaryColor,
-    reverseIconDirection,
   } = props;
 
   const startingFrom = getStartingFrom(filter);

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RelativeDatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RelativeDatePicker.tsx
@@ -110,6 +110,8 @@ const OptionsContent: React.FC<OptionsContentProps> = ({
   const options = filter[4] || {};
   const includeCurrent = !!options["include-current"];
   const currentString = getCurrentString(filter);
+  const database = filter.query().database();
+  const supportsExpressions = database?.hasFeature("expressions");
 
   const handleClickOnStartingFrom = () => {
     setOptionsVisible(false);
@@ -128,14 +130,16 @@ const OptionsContent: React.FC<OptionsContentProps> = ({
 
   return (
     <OptionsContainer>
-      <OptionButton
-        icon="arrow_left_to_line"
-        primaryColor={primaryColor}
-        reverseIconDirection={reverseIconDirection}
-        onClick={handleClickOnStartingFrom}
-      >
-        {t`Starting from...`}
-      </OptionButton>
+      {supportsExpressions && (
+        <OptionButton
+          icon="arrow_left_to_line"
+          primaryColor={primaryColor}
+          reverseIconDirection={reverseIconDirection}
+          onClick={handleClickOnStartingFrom}
+        >
+          {t`Starting from...`}
+        </OptionButton>
+      )}
       <OptionButton
         selected={includeCurrent}
         primaryColor={primaryColor}

--- a/frontend/src/metabase/query_builder/components/notebook/lib/steps.js
+++ b/frontend/src/metabase/query_builder/components/notebook/lib/steps.js
@@ -38,8 +38,7 @@ const STEPS = [
   },
   {
     type: "expression",
-    valid: query =>
-      query.hasData() && query.database().hasFeature("expressions"),
+    valid: query => query.hasData() && query.database().supportsExpressions(),
     active: query => query.hasExpressions(),
     revert: query => query.clearExpressions(),
     clean: query => query.cleanExpressions(),


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/23266

How to test:
1. Add a Druid database. Ping me if you need test credentials.
2. Create a new question and try to add a relative date filter within the query builder. You won't see `Starting from` option.
3. Do the same with the sample database. `Starting from` should be available.

No `expressions`
<img width="765" alt="Screenshot 2022-08-01 at 21 38 30" src="https://user-images.githubusercontent.com/8542534/182220559-11463073-91d8-4359-a0b3-df167bc34960.png">

With `expressions`
<img width="809" alt="Screenshot 2022-08-01 at 21 38 51" src="https://user-images.githubusercontent.com/8542534/182220571-85bddb5e-85f8-42b6-b935-8f0163b0e366.png">
