### PR TITLE
open urls with the site-url origin in the same tab

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/auth/middleware/session-middleware.js
+++ b/enterprise/frontend/src/metabase-enterprise/auth/middleware/session-middleware.js
@@ -1,7 +1,7 @@
 import Cookies from "js-cookie";
 import { replace } from "react-router-redux";
 import { logout, refreshSession } from "metabase/auth/actions";
-import { isSameOrigin } from "metabase/lib/dom";
+import { isSameOrSiteUrlOrigin } from "metabase/lib/dom";
 
 export const SESSION_KEY = "metabase.TIMEOUT";
 export const COOKIE_POOLING_TIMEOUT = 3000;
@@ -11,7 +11,7 @@ const getRedirectUrl = () => {
   const params = new URLSearchParams(window.location.search);
   const redirectUrlParam = params.get("redirect");
 
-  return redirectUrlParam != null && isSameOrigin(redirectUrlParam)
+  return redirectUrlParam != null && isSameOrSiteUrlOrigin(redirectUrlParam)
     ? redirectUrlParam
     : null;
 };

--- a/frontend/src/metabase/lib/dom.js
+++ b/frontend/src/metabase/lib/dom.js
@@ -353,17 +353,23 @@ export function shouldOpenInBlankWindow(
   return false;
 }
 
-const a = document.createElement("a"); // reuse the same tag for performance
+const getOrigin = url => {
+  try {
+    return new URL(url).origin;
+  } catch {
+    return null;
+  }
+};
+
 export function isSameOrigin(url) {
-  a.href = url;
-  return a.origin === window.location.origin;
+  const origin = getOrigin(url);
+  return origin == null || origin === window.location.origin;
 }
 
 function isSiteUrlOrigin(url) {
-  a.href = MetabaseSettings.get("site-url");
-  const siteUrlOrigin = a.origin;
-  a.href = url;
-  return a.origin === siteUrlOrigin;
+  const siteUrl = getOrigin(MetabaseSettings.get("site-url"));
+  const urlOrigin = getOrigin(url);
+  return siteUrl === urlOrigin;
 }
 
 // When a url is either has the same origin or it is the same with the site url

--- a/frontend/src/metabase/lib/dom.js
+++ b/frontend/src/metabase/lib/dom.js
@@ -347,7 +347,7 @@ export function shouldOpenInBlankWindow(
     return true;
   } else if (blankOnMetaOrCtrlKey && (isMetaKey || isCtrlKey)) {
     return true;
-  } else if (blankOnDifferentOrigin && !isSameOrigin(url)) {
+  } else if (blankOnDifferentOrigin && !isSameOrSiteUrlOrigin(url)) {
     return true;
   }
   return false;
@@ -359,8 +359,21 @@ export function isSameOrigin(url) {
   return a.origin === window.location.origin;
 }
 
+function isSiteUrlOrigin(url) {
+  a.href = MetabaseSettings.get("site-url");
+  const siteUrlOrigin = a.origin;
+  a.href = url;
+  return a.origin === siteUrlOrigin;
+}
+
+// When a url is either has the same origin or it is the same with the site url
+// we want to open it in the same window (https://github.com/metabase/metabase/issues/24451)
+export function isSameOrSiteUrlOrigin(url) {
+  return isSameOrigin(url) || isSiteUrlOrigin(url);
+}
+
 export function getUrlTarget(url) {
-  return isSameOrigin(url) ? "_self" : "_blank";
+  return isSameOrSiteUrlOrigin(url) ? "_self" : "_blank";
 }
 
 export function removeAllChildren(element) {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/24451

## Changes

A bit hackish change: if the current url does not match the `site-url` setting but the click behavior url origin matches the site setting url origin, then we open the url in the same window.

## Explanation

<video src="https://user-images.githubusercontent.com/14301985/182228601-53936425-bace-4486-9afe-96302201054d.mov" />


