### PR TITLE
Optional blocks in Markdown cards

### DIFF
--- a/shared/src/metabase/shared/parameters/parameters.cljc
+++ b/shared/src/metabase/shared/parameters/parameters.cljc
@@ -175,6 +175,8 @@
                      strs-or-var)))))
 
 (defn- add-values-to-variables
+  "Given `split-text`, containing a list of alternating strings and TextVariables, add a :value key to any TextVariables
+  with a corresponding value in `tag->normalized-param`."
   [tag->normalized-param locale split-text]
   (map
    (fn [maybe-variable]
@@ -183,7 +185,6 @@
          maybe-variable))
    split-text))
 
-;; Lots of lookahead/lookbehind in these regexes to handle escaping; see tests for examples
 (def ^:private optional-block-regex
   #"\[\[.*\]\]")
 

--- a/shared/src/metabase/shared/parameters/parameters.cljc
+++ b/shared/src/metabase/shared/parameters/parameters.cljc
@@ -185,10 +185,10 @@
 
 ;; Lots of lookahead/lookbehind in these regexes to handle escaping; see tests for examples
 (def ^:private optional-block-regex
-  #"(?<!\\)(?>\\\\)*\[\[.*(?<!\\)(?>\\\\)*\]\]")
+  #"(?<!\\)(?:\\\\)*\[\[.*(?<!\\)(?:\\\\)*\]\]")
 
 (def ^:private non-optional-block-regex
-  #"(?<!\\)(?>\\\\)*\[\[(.*)(?<!\\)(?>\\\\)*\]\]")
+  #"(?<!\\)(?:\\\\)*\[\[(.*)(?<!\\)(?:\\\\)*\]\]")
 
 (defn- strip-optional-blocks
   "Removes any [[optional]] blocks from individual strings in `split-text`, which are blocks that have no parameters

--- a/shared/src/metabase/shared/parameters/parameters.cljc
+++ b/shared/src/metabase/shared/parameters/parameters.cljc
@@ -186,10 +186,10 @@
    split-text))
 
 (def ^:private optional-block-regex
-  #"\[\[.*\]\]")
+  #"\[\[.+\]\]")
 
 (def ^:private non-optional-block-regex
-  #"\[\[(.*)\]\]")
+  #"\[\[(.+?)\]\]")
 
 (defn- strip-optional-blocks
   "Removes any [[optional]] blocks from individual strings in `split-text`, which are blocks that have no parameters
@@ -237,7 +237,7 @@
        ;; 2. `add-values-to-variables` =>
        ;;      ("[[a " {:tag "b" :source "{{b}}" :value nil} "]] [[" {:tag "c" :source "{{c}}" :value 3} "]]")
        ;; 3. `join-consecutive-strings` => ("[[a {{b}}]] [[" {:tag "b" :source "{{c}}" :value 3} "]])
-       ;; 4. `strip-optional-blocks`    => "3"
+       ;; 4. `strip-optional-blocks` => "3"
        (->> text
             split-on-tags
             (add-values-to-variables tag->normalized-param locale)

--- a/shared/src/metabase/shared/parameters/parameters.cljc
+++ b/shared/src/metabase/shared/parameters/parameters.cljc
@@ -230,6 +230,14 @@
                                               (assoc acc tag (normalize-parameter param)))
                                             {}
                                             tag->param)]
+       ;; Most of the functions in this pipeline are relating to handling [[optional] blocks in the text.
+       ;; For example, given an input "[[a {{b}}]] [[{{c}}]]", where `b` has no value and `c` = 3:
+       ;; 1. `split-on-tags` =>
+       ;;      ("[[a " {:tag "b" :source "{{b}}"} "]] [[" {:tag "c" :source "{{c}}"} "]]")
+       ;; 2. `add-values-to-variables` =>
+       ;;      ("[[a " {:tag "b" :source "{{b}}" :value nil} "]] [[" {:tag "c" :source "{{c}}" :value 3} "]]")
+       ;; 3. `join-consecutive-strings` => ("[[a {{b}}]] [[" {:tag "b" :source "{{c}}" :value 3} "]])
+       ;; 4. `strip-optional-blocks`    => "3"
        (->> text
             split-on-tags
             (add-values-to-variables tag->normalized-param locale)

--- a/shared/src/metabase/shared/parameters/parameters.cljc
+++ b/shared/src/metabase/shared/parameters/parameters.cljc
@@ -2,19 +2,19 @@
   "Util functions for dealing with parameters. Primarily used for substituting parameters into variables in Markdown
   dashboard cards."
   #?@
-   (:clj
-    [(:require [clojure.string :as str]
-               [metabase.mbql.normalize :as mbql.normalize]
-               [metabase.shared.util.i18n :refer [trs]]
-               [metabase.util.date-2 :as u.date]
-               [metabase.util.date-2.parse.builder :as b]
-               [metabase.util.i18n.impl :as i18n.impl])
-     (:import java.time.format.DateTimeFormatter)]
-    :cljs
-    [(:require ["moment" :as moment]
-               [clojure.string :as str]
-               [metabase.mbql.normalize :as mbql.normalize]
-               [metabase.shared.util.i18n :refer [trs]])]))
+      (:clj
+       [(:require [clojure.string :as str]
+                  [metabase.mbql.normalize :as mbql.normalize]
+                  [metabase.shared.util.i18n :refer [trs]]
+                  [metabase.util.date-2 :as u.date]
+                  [metabase.util.date-2.parse.builder :as b]
+                  [metabase.util.i18n.impl :as i18n.impl])
+        (:import java.time.format.DateTimeFormatter)]
+       :cljs
+       [(:require ["moment" :as moment]
+                  [clojure.string :as str]
+                  [metabase.mbql.normalize :as mbql.normalize]
+                  [metabase.shared.util.i18n :refer [trs]])]))
 
 ;; Without this comment, the namespace-checker linter incorrectly detects moment as unused
 #?(:cljs (comment moment/keep-me))

--- a/shared/src/metabase/shared/parameters/parameters.cljc
+++ b/shared/src/metabase/shared/parameters/parameters.cljc
@@ -185,10 +185,10 @@
 
 ;; Lots of lookahead/lookbehind in these regexes to handle escaping; see tests for examples
 (def ^:private optional-block-regex
-  #"(?<!\\)(?:\\\\)*\[\[.*(?<!\\)(?:\\\\)*\]\]")
+  #"\[\[.*\]\]")
 
 (def ^:private non-optional-block-regex
-  #"(?<!\\)(?:\\\\)*\[\[(.*)(?<!\\)(?:\\\\)*\]\]")
+  #"\[\[(.*)\]\]")
 
 (defn- strip-optional-blocks
   "Removes any [[optional]] blocks from individual strings in `split-text`, which are blocks that have no parameters

--- a/shared/src/metabase/shared/parameters/parameters.cljc
+++ b/shared/src/metabase/shared/parameters/parameters.cljc
@@ -230,7 +230,8 @@
                                               (assoc acc tag (normalize-parameter param)))
                                             {}
                                             tag->param)]
-       ;; Most of the functions in this pipeline are relating to handling [[optional] blocks in the text.
+       ;; Most of the functions in this pipeline are relating to handling optional blocks in the text which use
+       ;; the [[ ]] syntax.
        ;; For example, given an input "[[a {{b}}]] [[{{c}}]]", where `b` has no value and `c` = 3:
        ;; 1. `split-on-tags` =>
        ;;      ("[[a " {:tag "b" :source "{{b}}"} "]] [[" {:tag "c" :source "{{c}}"} "]]")

--- a/shared/src/metabase/shared/parameters/parameters.cljc
+++ b/shared/src/metabase/shared/parameters/parameters.cljc
@@ -183,14 +183,21 @@
          maybe-variable))
    split-text))
 
+;; Lots of lookahead/lookbehind in these regexes to handle escaping; see tests for examples
+(def ^:private optional-block-regex
+  #"(?<!\\)(?>\\\\)*\[\[.*(?<!\\)(?>\\\\)*\]\]")
+
+(def ^:private non-optional-block-regex
+  #"(?<!\\)(?>\\\\)*\[\[(.*)(?<!\\)(?>\\\\)*\]\]")
+
 (defn- strip-optional-blocks
   "Removes any [[optional]] blocks from individual strings in `split-text`, which are blocks that have no parameters
   with values. Then, concatenates the full string and removes the brackets from any remaining optional blocks."
   [split-text]
   (let [s (->> split-text
-               (map #(if (TextVariable? %) % (str/replace % #"\[\[.*\]\]" "")))
+               (map #(if (TextVariable? %) % (str/replace % optional-block-regex "")))
                str/join)]
-    (str/replace s #"(?<!\\)\[(?<!\\)\[(.*)(?<!\\)\](?<!\\)\]" second)))
+    (str/replace s non-optional-block-regex second)))
 
 (defn ^:export tag_names
   "Given the content of a text dashboard card, return a set of the unique names of template tags in the text."

--- a/shared/test/metabase/shared/parameters/parameters_test.cljc
+++ b/shared/test/metabase/shared/parameters/parameters_test.cljc
@@ -215,6 +215,10 @@
       {"foo" {:type :string/= :value "foo"}}
       "foofoo"
 
+      "[[{{foo}}]] [[{{bar}}]]"
+      {"foo" {:type :string/= :value 1} "bar" {:type :string/= :value 2}}
+      "1 2"
+
       "[[{{foo}}]"
       {"foo" {:type :string/= :value "bar"}}
       "[[bar]"

--- a/shared/test/metabase/shared/parameters/parameters_test.cljc
+++ b/shared/test/metabase/shared/parameters/parameters_test.cljc
@@ -230,4 +230,36 @@
 
       "[[{{foo}}]"
       {"foo" {:type :string/= :value "bar]"}}
-      "[[bar\\]]")))
+      "[[bar\\]]"
+
+      ;; Escaping weirdness (brackets should be able to be escaped by backslashes, unless they are themselves escaped)
+      "[[{{foo}}\\]]"
+      {}
+      "[[{{foo}}\\]]"
+
+      "[[{{foo}}]\\]"
+      {}
+      "[[{{foo}}]\\]"
+
+      "\\[[{{foo}}]]"
+      {}
+      "\\[[{{foo}}]]"
+
+      "[\\[{{foo}}]]"
+      {}
+      "[\\[{{foo}}]]"
+
+      "\\\\[[{{foo}}]]"
+      {}
+      ""
+
+      "\\\\\\[[{{foo}}]]"
+      {}
+      "\\\\\\[[{{foo}}]]"
+
+      "[[{{foo}}\\\\]]"
+      {}
+      ""
+      "[[{{foo}}\\\\\\]]"
+      {}
+      "[[{{foo}}\\\\\\]]")))

--- a/shared/test/metabase/shared/parameters/parameters_test.cljc
+++ b/shared/test/metabase/shared/parameters/parameters_test.cljc
@@ -226,40 +226,4 @@
       ;; Don't strip square brackets that are in parameter values
       "{{foo}}"
       {"foo" {:type :string/= :value "[[bar]]"}}
-      "\\[\\[bar\\]\\]"
-
-      "[[{{foo}}]"
-      {"foo" {:type :string/= :value "bar]"}}
-      "[[bar\\]]"
-
-      ;; Escaping weirdness (brackets should be able to be escaped by backslashes, unless they are themselves escaped)
-      "[[{{foo}}\\]]"
-      {}
-      "[[{{foo}}\\]]"
-
-      "[[{{foo}}]\\]"
-      {}
-      "[[{{foo}}]\\]"
-
-      "\\[[{{foo}}]]"
-      {}
-      "\\[[{{foo}}]]"
-
-      "[\\[{{foo}}]]"
-      {}
-      "[\\[{{foo}}]]"
-
-      "\\\\[[{{foo}}]]"
-      {}
-      ""
-
-      "\\\\\\[[{{foo}}]]"
-      {}
-      "\\\\\\[[{{foo}}]]"
-
-      "[[{{foo}}\\\\]]"
-      {}
-      ""
-      "[[{{foo}}\\\\\\]]"
-      {}
-      "[[{{foo}}\\\\\\]]")))
+      "\\[\\[bar\\]\\]")))

--- a/shared/test/metabase/shared/parameters/parameters_test.cljc
+++ b/shared/test/metabase/shared/parameters/parameters_test.cljc
@@ -185,3 +185,49 @@
        "{{foo}}"
        {"foo" {:type :date/month-year :value "2019-08"}}
        "agosto\\, 2019"))))
+
+(t/deftest substitute-tags-optional-blocks-test
+  (t/testing "Optional blocks are removed when necessary"
+    (t/are [text tag->param expected] (= expected (params/substitute_tags text tag->param))
+      "[[{{foo}}]]"
+      {}
+      ""
+
+      "[[{{foo}}]]"
+      {"foo" {:type :string/= :value "bar"}}
+      "bar"
+
+      "Customers[[ with over {{order_count}} orders]]"
+      {"order_count" {:type :number/= :value nil}}
+      "Customers"
+
+      "Customers[[ with over {{order_count}} orders]]"
+      {"order_count" {:type :number/= :value 10}}
+      "Customers with over 10 orders"
+
+      ;; Optional block is retained when *any* parameters within are substituted
+      "[[{{foo}} {{baz}}]]"
+      {"foo" {:type :string/= :value "bar"}}
+      "bar {{baz}}"
+
+      ;; Make sure `join-consecutive-strings` retains consecutive non-strings (this was a bug during implementation)
+      "[[{{foo}}{{foo}}]]"
+      {"foo" {:type :string/= :value "foo"}}
+      "foofoo"
+
+      "[[{{foo}}]"
+      {"foo" {:type :string/= :value "bar"}}
+      "[[bar]"
+
+      "[{{foo}}]]"
+      {"foo" {:type :string/= :value "bar"}}
+      "[bar]]"
+
+      ;; Don't strip square brackets that are in parameter values
+      "{{foo}}"
+      {"foo" {:type :string/= :value "[[bar]]"}}
+      "\\[\\[bar\\]\\]"
+
+      "[[{{foo}}]"
+      {"foo" {:type :string/= :value "bar]"}}
+      "[[bar\\]]")))


### PR DESCRIPTION
Epic #23543

This PR adds support for using `[[ ]]` syntax to delineate part of a text card which should be optional, and only displayed when at least one parameter within it has a value.

For example, you could create a text card with the contents `Orders [[in {{state}}]` and connect it to a `state` filter. When the filter has no values,  the card would just display `Orders`.

I went down a rabbit hole trying to get some escaping-related edge cases working... for example `\[[{{foo}}]]` should not be parsed as an optional block, since the first square bracket is escaped. I ran into issues getting the regexes for this to work with the Closure compiler so I've omitted them from the PR. I don't think these are blocking issues in the slightest.