### PR TITLE
reverts the ability to connect public dashboards and questions in the click behavior

### DIFF
--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx
@@ -20,7 +20,6 @@ import DashboardPicker from "metabase/containers/DashboardPicker";
 import Questions from "metabase/entities/questions";
 import QuestionPicker from "metabase/containers/QuestionPicker";
 import Sidebar from "metabase/dashboard/components/Sidebar";
-import CheckBox from "metabase/core/components/CheckBox";
 import ClickMappings, {
   withUserAttributes,
   clickTargetObjectType,
@@ -786,18 +785,6 @@ function QuestionDashboardPicker({ dashcard, clickBehavior, updateSettings }) {
         <Entity.Loader id={clickBehavior.targetId}>
           {({ object }) => (
             <div className="pt1">
-              {object.public_uuid && (
-                <CheckBox
-                  label={t`Use public link`}
-                  checked={clickBehavior.use_public_link}
-                  onChange={e =>
-                    updateSettings({
-                      ...clickBehavior,
-                      use_public_link: e.target.checked,
-                    })
-                  }
-                />
-              )}
               <Heading>
                 {
                   {

--- a/frontend/src/metabase/modes/components/drill/DashboardClickDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/DashboardClickDrill.jsx
@@ -74,17 +74,13 @@ export default ({ question, clicked }) => {
           },
         };
       } else {
-        const targetDashboard = extraData.dashboards[targetId];
         const queryParams = getParameterValuesBySlug(parameterMapping, {
           data,
           extraData,
           clickBehavior,
         });
 
-        const path =
-          clickBehavior.use_public_link && targetDashboard.public_uuid
-            ? Urls.publicDashboard(targetDashboard.public_uuid)
-            : Urls.dashboard({ id: targetId });
+        const path = Urls.dashboard({ id: targetId });
         const url = `${path}?${querystring.stringify(queryParams)}`;
 
         behavior = { url: () => url };
@@ -111,18 +107,9 @@ export default ({ question, clicked }) => {
         }))
         .value();
 
-      let url = null;
-      if (clickBehavior.use_public_link && targetQuestion.publicUUID()) {
-        url = Urls.publicQuestion(
-          targetQuestion.publicUUID(),
-          null,
-          querystring.stringify(queryParams),
-        );
-      } else {
-        url = targetQuestion.isStructured()
-          ? targetQuestion.getUrlWithParameters(parameters, queryParams)
-          : `${targetQuestion.getUrl()}?${querystring.stringify(queryParams)}`;
-      }
+      const url = targetQuestion.isStructured()
+        ? targetQuestion.getUrlWithParameters(parameters, queryParams)
+        : `${targetQuestion.getUrl()}?${querystring.stringify(queryParams)}`;
 
       behavior = { url: () => url };
     }

--- a/frontend/test/metabase/scenarios/dashboard/reproductions/17160-click-behavior-multiple-options.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/reproductions/17160-click-behavior-multiple-options.cy.spec.js
@@ -15,7 +15,7 @@ describe("issue 17160", () => {
   });
 
   it("should pass multiple filter values to questions and dashboards (metabase#17160-1)", () => {
-    setupRegularDashboards();
+    setup();
 
     // 1. Check click behavior connected to a question
     visitSourceDashboard();
@@ -46,8 +46,9 @@ describe("issue 17160", () => {
     assertMultipleValuesFilterState();
   });
 
-  it("should pass multiple filter values to public questions and dashboards (metabase#17160-2)", () => {
-    setupPublicDashboards();
+  it.skip("should pass multiple filter values to public questions and dashboards (metabase#17160-2)", () => {
+    // FIXME: setup public dashboards
+    setup();
 
     // 1. Check click behavior connected to a public question
     visitPublicSourceDashboard();
@@ -83,7 +84,7 @@ function assertMultipleValuesFilterState() {
   );
 }
 
-function setup(shouldUsePublicLinks) {
+function setup() {
   cy.createNativeQuestion({
     name: `17160Q`,
     native: {
@@ -155,7 +156,6 @@ function setup(shouldUsePublicLinks) {
                   visualization_settings: getVisualSettingsWithClickBehavior(
                     questionId,
                     targetDashboardId,
-                    shouldUsePublicLinks,
                   ),
                 },
               ],
@@ -167,16 +167,11 @@ function setup(shouldUsePublicLinks) {
   });
 }
 
-function getVisualSettingsWithClickBehavior(
-  questionTarget,
-  dashboardTarget,
-  shouldUsePublicLinks = false,
-) {
+function getVisualSettingsWithClickBehavior(questionTarget, dashboardTarget) {
   return {
     column_settings: {
       '["name","ID"]': {
         click_behavior: {
-          use_public_link: shouldUsePublicLinks,
           targetId: questionTarget,
           parameterMapping: {
             "6b8b10ef-0104-1047-1e1b-2492d5954322": {
@@ -200,7 +195,6 @@ function getVisualSettingsWithClickBehavior(
 
       '["name","EAN"]': {
         click_behavior: {
-          use_public_link: shouldUsePublicLinks,
           targetId: dashboardTarget,
           parameterMapping: {
             dd19ec03: {
@@ -279,14 +273,6 @@ function createTargetDashboard() {
           return dashboard_id;
         });
     });
-}
-
-function setupRegularDashboards() {
-  return setup(false);
-}
-
-function setupPublicDashboards() {
-  return setup(true);
 }
 
 function visitSourceDashboard() {


### PR DESCRIPTION
## Changes

Removes the ability to connect public versions of dashboards and questions in the click behavior that was introduced [here](https://github.com/metabase/metabase/pull/22801).
Due to unimplemented https://github.com/metabase/metabase/issues/23873 the feature does not make sense to be put in the release.

## How to verify

Ensure there is no "Use public link" checkbox anymore when you connect dashboards/questions in the click behavior