### PR TITLE
[Target 43] Parse parameter and parameters_mapping on cards

### DIFF
--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -289,7 +289,9 @@
                                        :embedding_params       :json
                                        :query_type             :keyword
                                        :result_metadata        ::result-metadata
-                                       :visualization_settings :visualization-settings})
+                                       :visualization_settings :visualization-settings
+                                       :parameters             :parameters-list
+                                       :parameters_mappings    :parameters-list})
           :properties     (constantly {:timestamped? true})
           ;; Make sure we normalize the query before calling `pre-update` or `pre-insert` because some of the
           ;; functions those fns call assume normalized queries

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -290,6 +290,8 @@
                                        :query_type             :keyword
                                        :result_metadata        ::result-metadata
                                        :visualization_settings :visualization-settings
+                                       ;; parameters and parameter_mappings are added in 44 but we have it
+                                       ;; here to make sure it doesn't break if an user downgrades from 44 to 43 #(24497)
                                        :parameters             :parameters-list
                                        :parameters_mappings    :parameters-list})
           :properties     (constantly {:timestamped? true})


### PR DESCRIPTION
Closes #24497

On 44, We added `parameters` `parameter_mappings` to `report_card` in #22976 and #23003.
Both of these columns are JSON-encoded string and it is parsed to JSON on read.

This change breaks downgrade ability to 43 because the code to parse it to JSON does not exist in 43, thus the API returns them as raw-string and FE seems to not happy with it.

In this PR I update the code so that the `parameters` and `parameter_mappings` is parsed as a JSON on-read for 43.