### PR TITLE
exclude archived collections from navbar api call

### DIFF
--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer.tsx
@@ -287,7 +287,7 @@ export default _.compose(
     loadingAndErrorWrapper: false,
   }),
   Collections.loadList({
-    query: () => ({ tree: true }),
+    query: () => ({ tree: true, "exclude-archived": true }),
     loadingAndErrorWrapper: false,
   }),
   connect(mapStateToProps, mapDispatchToProps),


### PR DESCRIPTION
Fixes #24329 

One liner to exclude archived collections from the navbar `Collections.loadlist()` call.

![image](https://user-images.githubusercontent.com/1328979/182376819-ca135735-4cd1-4305-9176-90ee1ab9f2f6.png)

