### PR TITLE
Fix certain dashboard header button icons not centered

### DIFF
--- a/frontend/src/metabase/core/components/Button/Button.tsx
+++ b/frontend/src/metabase/core/components/Button/Button.tsx
@@ -37,7 +37,7 @@ interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
   as?: ElementType;
   className?: string;
 
-  icon?: string;
+  icon?: string | ReactNode;
   iconSize?: number;
   iconColor?: string;
   iconRight?: string;
@@ -94,8 +94,10 @@ const BaseButton = forwardRef(function BaseButton(
       purple={props.purple}
     >
       <ButtonContent iconVertical={iconVertical}>
-        {icon && (
+        {icon && typeof icon === "string" ? (
           <Icon color={iconColor} name={icon} size={iconSize ? iconSize : 14} />
+        ) : (
+          icon
         )}
         {children && (
           <ButtonTextContainer

--- a/frontend/src/metabase/dashboard/components/DashboardActions.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardActions.jsx
@@ -119,13 +119,15 @@ export const getDashboardActions = (
         tooltip={isNightMode ? t`Daytime mode` : t`Nighttime mode`}
       >
         <span data-metabase-event={"Dashboard;Night Mode;" + !isNightMode}>
-          <DashboardHeaderButton>
-            <NightModeIcon
-              className="text-brand-hover cursor-pointer"
-              isNightMode={isNightMode}
-              onClick={() => onNightModeChange(!isNightMode)}
-            />
-          </DashboardHeaderButton>
+          <DashboardHeaderButton
+            icon={
+              <NightModeIcon
+                className="text-brand-hover cursor-pointer"
+                isNightMode={isNightMode}
+                onClick={() => onNightModeChange(!isNightMode)}
+              />
+            }
+          />
         </span>
       </Tooltip>,
     );
@@ -142,13 +144,14 @@ export const getDashboardActions = (
           data-metabase-event={"Dashboard;Fullscreen Mode;" + !isFullscreen}
         >
           <DashboardHeaderButton
+            icon={
+              <FullscreenIcon
+                className="text-brand-hover"
+                isFullscreen={isFullscreen}
+              />
+            }
             onClick={e => onFullscreenChange(!isFullscreen, !e.altKey)}
-          >
-            <FullscreenIcon
-              className="text-brand-hover"
-              isFullscreen={isFullscreen}
-            />
-          </DashboardHeaderButton>
+          />
         </span>
       </Tooltip>,
     );

--- a/frontend/src/metabase/dashboard/components/RefreshWidget.jsx
+++ b/frontend/src/metabase/dashboard/components/RefreshWidget.jsx
@@ -60,9 +60,11 @@ export default class RefreshWidget extends Component {
         triggerElement={
           elapsed == null ? (
             <Tooltip tooltip={t`Auto-refresh`}>
-              <DashboardHeaderButton>
-                <ClockIcon width={16} height={16} className={className} />
-              </DashboardHeaderButton>
+              <DashboardHeaderButton
+                icon={
+                  <ClockIcon width={16} height={16} className={className} />
+                }
+              />
             </Tooltip>
           ) : (
             <Tooltip
@@ -75,13 +77,15 @@ export default class RefreshWidget extends Component {
                 Math.round(remaining % 60)
               }
             >
-              <DashboardHeaderButton>
-                <CountdownIcon
-                  width={18}
-                  height={18}
-                  percent={Math.min(0.95, (period - elapsed) / period)}
-                />
-              </DashboardHeaderButton>
+              <DashboardHeaderButton
+                icon={
+                  <CountdownIcon
+                    width={16}
+                    height={16}
+                    percent={Math.min(0.95, (period - elapsed) / period)}
+                  />
+                }
+              />
             </Tooltip>
           )
         }


### PR DESCRIPTION
Epic: #22826
Task: https://www.notion.so/metabase/Dashboard-icons-are-not-centered-in-header-buttons-9e8031df30a74efa8571daeeb1e292e2

This PR fixes some dashboard icons not staying vertically center

#### After
![image](https://user-images.githubusercontent.com/1937582/182397198-35799db2-c97a-42d0-ae2b-1ae71ba57780.png)

#### Before
![image](https://user-images.githubusercontent.com/1937582/182397248-7d6362c6-7363-4bba-88bf-2218e6ec28a7.png)
