### PR TITLE
Fixing null error when value is null and isCustom is true

### DIFF
--- a/frontend/src/metabase/admin/settings/components/widgets/ModelCachingScheduleWidget/ModelCachingScheduleWidget.jsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/ModelCachingScheduleWidget/ModelCachingScheduleWidget.jsx
@@ -41,7 +41,7 @@ const PersistedModelRefreshIntervalWidget = ({
   const [customCronSchedule, setCustomCronSchedule] = useState(
     // We don't allow to specify the "year" component, but it's present in the value
     // So we need to cut it visually to avoid confusion
-    isCustom ? formatCronExpression(setting.value) : "",
+    isCustom ? formatCronExpression(setting.value || setting.default) : "",
   );
 
   const handleScheduleChange = useCallback(
@@ -49,6 +49,7 @@ const PersistedModelRefreshIntervalWidget = ({
       if (nextValue === "custom") {
         setCustom(true);
         setCustomCronSchedule(DEFAULT_CUSTOM_SCHEDULE);
+        onChange(`0 ${DEFAULT_CUSTOM_SCHEDULE} *`);
       } else {
         setCustom(false);
         setCustomCronSchedule("");

--- a/frontend/src/metabase/admin/settings/components/widgets/ModelCachingScheduleWidget/ModelCachingScheduleWidget.jsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/ModelCachingScheduleWidget/ModelCachingScheduleWidget.jsx
@@ -41,7 +41,7 @@ const PersistedModelRefreshIntervalWidget = ({
   const [customCronSchedule, setCustomCronSchedule] = useState(
     // We don't allow to specify the "year" component, but it's present in the value
     // So we need to cut it visually to avoid confusion
-    isCustom ? formatCronExpression(setting.value || setting.default) : "",
+    isCustom ? formatCronExpression(setting.value ?? setting.default) : "",
   );
 
   const handleScheduleChange = useCallback(


### PR DESCRIPTION
Fixes #24053 

Error was caused by isCustom being true but setting.value being null and getting passed to `formatCronExpression()`. Also called onChange with the value to prevent users from needing to click and blur the input to save the default value.

![chrome_xsMin4i1C0](https://user-images.githubusercontent.com/1328979/182402467-cc6f998b-d9f8-4faa-bb83-c0b0cce6ac6e.gif)
