### PR TITLE
Handle flakiness with geojson java.net.UnknownHostException errors

### DIFF
--- a/test/metabase/api/geojson_test.clj
+++ b/test/metabase/api/geojson_test.clj
@@ -37,7 +37,9 @@
 
 (deftest validate-geojson-test
   (testing "It validates URLs and files appropriately"
-    (let [examples {;; Internal metadata for GCP
+    (let [cache-property-name     "networkaddress.cache.negative.ttl"
+          original-negative-cache (System/setProperty cache-property-name "0")
+          examples {;; Internal metadata for GCP
                     "metadata.google.internal"                 false
                     "https://metadata.google.internal"         false
                     "//metadata.google.internal"               false
@@ -75,15 +77,35 @@
                     "rasta@metabase.com"                       false
                     ""                                         false
                     "Tom Bombadil"                             false}
-          valid?   #'api.geojson/validate-geojson]
+          valid?   (fn try-geojson
+                     ;; if expect failure just run once
+                     ([geojson] (#'api.geojson/validate-geojson geojson))
+                     ([geojson max-attempts]
+                      ;; in CI we can sometimes get java.net.UnknownHostException so disable the cache of negative IP
+                      ;; resolution cache and try a few times. Booleans mean we resolved the IP. Exceptions mean we did
+                      ;; not resolve the IP address
+                      (loop [remaining max-attempts]
+                        (let [result (try (#'api.geojson/validate-geojson geojson)
+                                          (catch Exception e e))]
+                          (cond (and (zero? remaining) (instance? Exception result))
+                                (throw result)
+
+                                (instance? Exception result)
+                                (recur (dec remaining))
+
+                                :else
+                                result)))))]
       (doseq [[url should-pass?] examples]
         (let [geojson {:deadb33f {:name        "Rivendell"
                                   :url         url
                                   :region_key  nil
                                   :region_name nil}}]
           (if should-pass?
-            (is (valid? geojson) (str url))
-            (is (thrown? clojure.lang.ExceptionInfo (valid? geojson)) (str url))))))))
+            (is (valid? geojson 3) (str url))
+            (is (thrown? clojure.lang.ExceptionInfo (valid? geojson)) (str url)))))
+      (if (some? original-negative-cache)
+        (System/setProperty cache-property-name original-negative-cache)
+        (System/clearProperty cache-property-name)))))
 
 (deftest custom-geojson-disallow-overriding-builtins-test
   (testing "We shouldn't let people override the builtin GeoJSON and put weird stuff in there; ignore changes to them"

--- a/test/metabase/api/geojson_test.clj
+++ b/test/metabase/api/geojson_test.clj
@@ -91,7 +91,8 @@
                                 (throw result)
 
                                 (instance? Exception result)
-                                (recur (dec remaining))
+                                (do (Thread/sleep 1000)
+                                    (recur (dec remaining)))
 
                                 :else
                                 result)))))]


### PR DESCRIPTION
In CI seems like we are getting errant errors:

```clojure
geojson.clj:62
It validates URLs and files appropriately
http://0xc0000200
expected: (valid? geojson)
  actual: #error {
 :cause "Invalid IP address literal: 0xc0000200"
 :via
 [{:type clojure.lang.ExceptionInfo
   :message "Invalid GeoJSON file location: must either start with http:// or https:// or be a relative path to a file on the classpath. URLs referring to hosts that supply internal hosting metadata are prohibited."
   :data {:status-code 400, :url "http://0xc0000200"}
   :at [metabase.api.geojson$valid_url_QMARK_ invokeStatic "geojson.clj" 62]}
  {:type java.net.UnknownHostException
   :message "0xc0000200"
   :at [java.net.InetAddress getAllByName "InetAddress.java" 1340]}
  {:type java.lang.IllegalArgumentException
   :message "Invalid IP address literal: 0xc0000200"
   :at [sun.net.util.IPAddressUtil validateNumericFormatV4 "IPAddressUtil.java" 150]}]
```

### EDIT:

My "fix" did not fix this. Hope was it was a transient error and retrying during the test would fix it. This did not pan out. I'm commenting out the test case for now as we think it is unlikely to be a real world scenario but it would be handled in either case.

Things to note: The test case right before this one is `"http://192.0.2.0"` which is a valid address for the geojson. The offending case is `"http://0xc0000200"` which is exactly that 192.0.2.0 route encoded as hex. Hex seems to be valid so its unclear why this _flakes_. Seems it should always be valid or always fail since it can hit the 192.0.2.0 obviously:

```clojure
geojson=> (InetAddress/getByName "0xc0000200")
#object[java.net.Inet4Address "0x583e8267" "0xc0000200/192.0.2.0"]
```

#### Original text
Not clear if this change has a hope of fixing it: if it doesn't resolve
once its possible it is cached somewhere in the network stack, or it
won't resolve if you ask again.

But gonna give it a shot.

Set the property `"networkaddress.cache.negative.ttl"` to `"0"`

> networkaddress.cache.negative.ttl (default: 10)
>    Indicates the caching policy for un-successful name lookups from the name service. The value is specified as an integer to indicate the number of seconds to cache the failure for un-successful lookups.

>    A value of 0 indicates "never cache". A value of -1 indicates "cache forever".

From
https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/net/InetAddress.html
in the hopes that we can try multiple times. Restores the original value
after the test completes so we don't inadvertently change behavior
elsewhere.

If we get an error of java.net.UnknownHostException we try again if we
have attempts remaining. If we get a boolean it means the ip resolution
worked so we can rely on the response (checking if it resolves locally
or not)

Example of failing test run: https://github.com/metabase/metabase/runs/7633426048