### PR TITLE
Change model cache on/off button copy

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/model_persistence/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/model_persistence/index.ts
@@ -20,7 +20,7 @@ if (hasPremiumFeature("advanced_config")) {
     const isPersisted = model.isPersisted();
 
     return {
-      title: isPersisted ? t`Unpersist model` : t`Persist model`,
+      title: isPersisted ? t`Turn model caching off` : t`Turn model caching on`,
       action: () => toggleModelPersistence(model, onChange),
       icon: "database",
     };


### PR DESCRIPTION
Tiny copy change to keep the feature name consistent across Metabase. This should be safe to backport as [we already have this string on the admin database page](https://github.com/metabase/metabase/blob/f32550c66e41e529671737710d94b4021cbe0162/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/ModelCachingControl/ModelCachingControl.tsx#L59).

### Demo

| **Before** | **After** |
|------------|-----------|
|     ![CleanShot 2022-08-02 at 18 31 40@2x](https://user-images.githubusercontent.com/17258145/182438139-c2098b08-f2ae-467d-a609-c7808317091a.png)       |      ![CleanShot 2022-08-02 at 18 30 25@2x](https://user-images.githubusercontent.com/17258145/182438114-50ebb471-8c2b-451c-9b33-488321133670.png)     |