### PR TITLE
Fix toggling model caching was starting an ad-hoc question

### DIFF
--- a/frontend/src/metabase/query_builder/actions/core/updateQuestion.ts
+++ b/frontend/src/metabase/query_builder/actions/core/updateQuestion.ts
@@ -109,6 +109,7 @@ function getNextTemplateTagEditorState({
 type UpdateQuestionOpts = {
   run?: boolean | "auto";
   shouldUpdateUrl?: boolean;
+  shouldStartAdHocQuestion?: boolean;
 };
 
 /**
@@ -117,13 +118,18 @@ type UpdateQuestionOpts = {
 export const UPDATE_QUESTION = "metabase/qb/UPDATE_QUESTION";
 export const updateQuestion = (
   newQuestion: Question,
-  { run = false, shouldUpdateUrl = false }: UpdateQuestionOpts = {},
+  {
+    run = false,
+    shouldStartAdHocQuestion = true,
+    shouldUpdateUrl = false,
+  }: UpdateQuestionOpts = {},
 ) => {
   return async (dispatch: Dispatch, getState: GetState) => {
     const currentQuestion = getQuestion(getState());
     const queryBuilderMode = getQueryBuilderMode(getState());
 
     const shouldTurnIntoAdHoc =
+      shouldStartAdHocQuestion &&
       newQuestion.isSaved() &&
       newQuestion.query().isEditable() &&
       queryBuilderMode !== "dataset";

--- a/frontend/src/metabase/query_builder/actions/core/updateQuestion.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/actions/core/updateQuestion.unit.spec.ts
@@ -46,6 +46,7 @@ type SetupOpts = {
   originalQuestion?: Question;
   run?: boolean;
   shouldUpdateUrl?: boolean;
+  shouldStartAdHocQuestion?: boolean;
   queryBuilderMode?: QueryBuilderMode;
   isShowingTemplateTagsEditor?: boolean;
 };
@@ -66,6 +67,7 @@ async function setup({
   isShowingTemplateTagsEditor = false,
   run,
   shouldUpdateUrl,
+  shouldStartAdHocQuestion,
 }: SetupOpts) {
   const dispatch = jest.fn().mockReturnValue({ mock: "mock" });
 
@@ -90,7 +92,11 @@ async function setup({
     qb: qbState,
   });
 
-  await updateQuestion(question, { run, shouldUpdateUrl })(dispatch, getState);
+  await updateQuestion(question, {
+    run,
+    shouldUpdateUrl,
+    shouldStartAdHocQuestion,
+  })(dispatch, getState);
 
   const actions = dispatch.mock.calls.find(
     call => call[0]?.type === UPDATE_QUESTION,
@@ -287,6 +293,21 @@ describe("QB Actions > updateQuestion", () => {
             expect(result.card.id).toBeUndefined();
             expect(result.card.name).toBeUndefined();
             expect(result.card.description).toBeUndefined();
+            expect(result.card.dataset_query).toEqual(question.datasetQuery());
+            expect(result.card.visualization_settings).toEqual(
+              question.settings(),
+            );
+          });
+
+          it("doesn't turn question into ad-hoc if `shouldStartAdHocQuestion` option is disabled", async () => {
+            const { result } = await setup({
+              question,
+              shouldStartAdHocQuestion: false,
+            });
+
+            expect(result.card.id).toBe(question.id());
+            expect(result.card.name).toBe(question.displayName());
+            expect(result.card.description).toBe(question.description());
             expect(result.card.dataset_query).toEqual(question.datasetQuery());
             expect(result.card.visualization_settings).toEqual(
               question.settings(),


### PR DESCRIPTION
QB `updateQuestion` used to have a `shouldStartAdHocQuestion` option. It got accidentally removed during the action refactoring (#24142). The option used to be `true` by default, and the only place we're explicitly setting it to `false` was [the model caching change handler](https://github.com/metabase/metabase/blob/f32550c66e41e529671737710d94b4021cbe0162/frontend/src/metabase/query_builder/actions/models.js#L93). 

We want to dispatch `updateQuestion` to change card's state in redux, but we don't want to mark the question as dirty as we do as if you're changing a query. It makes me think we should have a more lightweight way to update the question in the future.

> **Note**
> This isn't supposed to be backported. The refactoring causing the problem in the first place was not backported to the release branch, so it works fine there.

### To Verify

1. Start Metabase Enterprise
2. Connect a database supporting model caching (Postgres for instance)
3. Enable model caching for this database (click "Turn model caching on" in the sidebar on the admin DB page)
4. Create a model based on this DB
5. On the model page, click the info icon at the top right and click "Turn model caching on/off"
6. Ensure the QB doesn't turn into an ad-hoc mode (there is no "Save" button and the URL is `/model/:id-:slug` instead of the question hash)

### Demo

**Before**

https://user-images.githubusercontent.com/17258145/182440685-8482d248-a9cb-4e71-a29a-001dc25007ca.mp4


**After**

https://user-images.githubusercontent.com/17258145/182440706-7df64706-4630-4e44-8355-ab754143a712.mp4


