### PR TITLE
Don't run mapping logic that expects a `dataset_query` when there isn't one

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCardCardParameterMapper.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCardCardParameterMapper.jsx
@@ -98,10 +98,14 @@ function DashCardCardParameterMapper({
   const hasPermissionsToMap = useMemo(() => {
     if (isVirtual) {
       return true;
-    } else {
-      const question = new Question(card, metadata);
-      return question.query().isEditable();
     }
+
+    if (!card.dataset_query) {
+      return false;
+    }
+
+    const question = new Question(card, metadata);
+    return question.query().isEditable();
   }, [card, metadata, isVirtual]);
 
   const { buttonVariant, buttonTooltip, buttonText, buttonIcon } =

--- a/frontend/src/metabase/parameters/utils/mapping-options.js
+++ b/frontend/src/metabase/parameters/utils/mapping-options.js
@@ -63,6 +63,10 @@ export function getParameterMappingOptions(
     return tagNames ? tagNames.map(buildTextTagOption) : [];
   }
 
+  if (!card.dataset_query) {
+    return [];
+  }
+
   const question = new Question(card, metadata);
   const query = question.query();
   const options = [];

--- a/frontend/test/metabase/scenarios/dashboard-filters/reproductions/20656-dashboard-breaks-for-user-without-card-permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/reproductions/20656-dashboard-breaks-for-user-without-card-permissions.cy.spec.js
@@ -1,4 +1,9 @@
-import { restore, filterWidget, visitDashboard } from "__support__/e2e/helpers";
+import {
+  restore,
+  filterWidget,
+  visitDashboard,
+  editDashboard,
+} from "__support__/e2e/helpers";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
@@ -17,7 +22,7 @@ describe("issue 20656", () => {
     cy.signInAsAdmin();
   });
 
-  it("should allow a user to visit a dashboard even without a permission to see the dashboard card (metabase#20656)", () => {
+  it("should allow a user to visit a dashboard even without a permission to see the dashboard card (metabase#20656, metabase#24536)", () => {
     cy.createQuestionAndDashboard({
       questionDetails: {
         query: { "source-table": PRODUCTS_ID, limit: 2 },
@@ -54,7 +59,20 @@ describe("issue 20656", () => {
 
     // Make sure the filter widget is there
     filterWidget();
-
     cy.findByText("Sorry, you don't have permission to see this card.");
+
+    // Trying to edit the filter should not show mapping fields and shouldn't break frontend (metabase#24536)
+    editDashboard();
+
+    // TODO: Uncomment when the issue gets fixed!
+    // cy.findByTestId("edit-dashboard-parameters-widget-container")
+    //   .find(".Icon-gear")
+    //   .click();
+
+    // cy.findByText("Column to filter on")
+    //   .parent()
+    //   .within(() => {
+    //     cy.icon("key");
+    //   });
   });
 });

--- a/frontend/test/metabase/scenarios/dashboard-filters/reproductions/20656-dashboard-breaks-for-user-without-card-permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/reproductions/20656-dashboard-breaks-for-user-without-card-permissions.cy.spec.js
@@ -64,15 +64,14 @@ describe("issue 20656", () => {
     // Trying to edit the filter should not show mapping fields and shouldn't break frontend (metabase#24536)
     editDashboard();
 
-    // TODO: Uncomment when the issue gets fixed!
-    // cy.findByTestId("edit-dashboard-parameters-widget-container")
-    //   .find(".Icon-gear")
-    //   .click();
+    cy.findByTestId("edit-dashboard-parameters-widget-container")
+      .find(".Icon-gear")
+      .click();
 
-    // cy.findByText("Column to filter on")
-    //   .parent()
-    //   .within(() => {
-    //     cy.icon("key");
-    //   });
+    cy.findByText("Column to filter on")
+      .parent()
+      .within(() => {
+        cy.icon("key");
+      });
   });
 });


### PR DESCRIPTION
Fixes #24530 
Reproduces #24530 

The fix is simple enough. Add another `if` statement to check for the existence of `card.dataset_query` before running logic that expects the existence of `dataset_query.`

`DashCardCardParameterMapper`, the component responsible for this error, runs the logic `new Question(card, metadata).query()` that expects the existence of `card.dataset_query`. We shouldn't ever let a `card` without a `dataset_query` get so far, but it's tough because we're doing things like `new Question(card, metadata).query()` all over the place without any consistency with respect to varying levels of user permissioning. `DashCardCardParameterMapper` probably knows too much about `cards` to begin with -- should only be involved with UI concerns, yet it inspects the `card` object in order to know what to do. 

Testing
Follow the steps described in #24530 