### PR TITLE
Serdes v2: Handle other embedded MBQL fragments

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -429,24 +429,36 @@
                                                               :email      "ann@heart.band"}]
                        Database   [{db-id        :id}        {:name "My Database"}]
                        Table      [{no-schema-id :id}        {:name "Schemaless Table" :db_id db-id}]
+                       Field      [{field-id     :id}        {:name "Some Field" :table_id no-schema-id}]
                        Segment    [{s1-id        :id
                                     s1-eid       :entity_id} {:name       "My Segment"
                                                               :creator_id ann-id
-                                                              :table_id   no-schema-id}]]
+                                                              :table_id   no-schema-id
+                                                              :definition {:source-table no-schema-id
+                                                                           :aggregation [[:count]]
+                                                                           :filter [:< [:field field-id nil] 18]}}]]
       (testing "segment"
         (let [ser (serdes.base/extract-one "Segment" {} (select-one "Segment" [:= :id s1-id]))]
           (is (schema= {:serdes/meta                 (s/eq [{:model "Segment" :id s1-eid :label "My Segment"}])
                         :table_id                    (s/eq ["My Database" nil "Schemaless Table"])
                         :creator_id                  (s/eq "ann@heart.band")
                         :created_at                  LocalDateTime
+                        :definition                  (s/eq {:source-table ["My Database" nil "Schemaless Table"]
+                                                            :aggregation [[:count]]
+                                                            :filter ["<" [:field ["My Database" nil
+                                                                                 "Schemaless Table" "Some Field"]
+                                                                         nil] 18]})
                         (s/optional-key :updated_at) LocalDateTime
                         s/Keyword                    s/Any}
                        ser))
           (is (not (contains? ser :id)))
 
-          (testing "depend on the Table"
+          (testing "depend on the Table and any fields from the definition"
             (is (= #{[{:model "Database"   :id "My Database"}
-                      {:model "Table"      :id "Schemaless Table"}]}
+                      {:model "Table"      :id "Schemaless Table"}]
+                     [{:model "Database"   :id "My Database"}
+                      {:model "Table"      :id "Schemaless Table"}
+                      {:model "Field"      :id "Some Field"}]}
                    (set (serdes.base/serdes-dependencies ser))))))))))
 
 (deftest pulses-test

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -105,8 +105,7 @@
                                                                :schema      "PUBLIC"}]
                        Field      [{field2-id    :id}         {:name "Other Field" :table_id schema-id}]
                        Card       [{c1-id  :id
-                                    c1-eid :entity_id
-                                    :as c1}        {:name          "Some Question"
+                                    c1-eid :entity_id}        {:name          "Some Question"
                                                                :database_id   db-id
                                                                :table_id      no-schema-id
                                                                :collection_id coll-id

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -4,8 +4,8 @@
             [metabase-enterprise.serialization.v2.extract :as serdes.extract]
             [metabase-enterprise.serialization.v2.ingest :as serdes.ingest]
             [metabase-enterprise.serialization.v2.load :as serdes.load]
-            [metabase.models :refer [Card Collection Database Field Pulse PulseChannel PulseChannelRecipient Table
-                                     User]]
+            [metabase.models :refer [Card Collection Database Field Pulse PulseChannel PulseChannelRecipient Segment
+                                     Table User]]
             [metabase.models.serialization.base :as serdes.base]
             [metabase.models.serialization.hash :as serdes.hash]
             [toucan.db :as db]))
@@ -355,13 +355,13 @@
           db1s       (atom nil)
           table1s    (atom nil)
           field1s    (atom nil)
-          card1s     (atom nil)
+          seg1s      (atom nil)
           user1s     (atom nil)
           db1d       (atom nil)
           table1d    (atom nil)
           field1d    (atom nil)
           user1d     (atom nil)
-          card1d     (atom nil)
+          seg1d      (atom nil)
           db2d       (atom nil)
           table2d    (atom nil)
           field2d    (atom nil)]
@@ -375,22 +375,21 @@
             (reset! table1s (ts/create! Table :name "customers" :db_id (:id @db1s)))
             (reset! field1s (ts/create! Field :name "age"    :table_id (:id @table1s)))
             (reset! user1s  (ts/create! User  :first_name "Tom" :last_name "Scholz" :email "tom@bost.on"))
-            (reset! card1s  (ts/create! Card
-                                        :database_id   (:id @db1s)
-                                        :table_id      (:id @table1s)
-                                        :collection_id (:id @coll1s)
-                                        :creator_id    (:id @user1s)
-                                        :query_type    :query
-                                        :name          "Example Card"
-                                        :dataset_query {:type     :query
-                                                        :query    {:source-table (:id @table1s)
-                                                                   :filter       [:>= [:field (:id @field1s) nil] 18]
-                                                                   :aggregation  [[:count]]}
-                                                        :database (:id @db1s)}
-                                        :display        :line))
+            (reset! seg1s   (ts/create! Segment :table_id (:id @table1s) :name "Minors"
+                                        :definition {:source-table (:id @table1s)
+                                                     :aggregation [[:count]]
+                                                     :filter [:< [:field (:id @field1s) nil] 18]}
+                                        :creator_id (:id @user1s)))
             (reset! serialized (into [] (serdes.extract/extract-metabase {})))))
 
-        ;; TODO DO NOT SUBMIT Test that the serialized form is as expected?
+        (testing "exported form is properly converted"
+          (is (= {:source-table ["my-db" nil "customers"]
+                  :aggregation [[:count]]
+                  :filter ["<" [:field ["my-db" nil "customers" "age"] nil] 18]}
+                 (-> @serialized
+                     (by-model "Segment")
+                     first
+                     :definition))))
 
         (testing "deserializing adjusts the IDs properly"
           (ts/with-dest-db
@@ -407,19 +406,17 @@
             (reset! db1d    (db/select-one Database :name "my-db"))
             (reset! table1d (db/select-one Table :name "customers"))
             (reset! field1d (db/select-one Field :table_id (:id @table1d) :name "age"))
-            (reset! card1d  (db/select-one Card  :name "Example Card"))
+            (reset! seg1d   (db/select-one Segment :name "Minors"))
 
             (testing "the main Database, Table, and Field have different IDs now"
               (is (not= (:id @db1s) (:id @db1d)))
               (is (not= (:id @table1s) (:id @table1d)))
               (is (not= (:id @field1s) (:id @field1d))))
 
-            (is (not= (:dataset_query @card1s)
-                      (:dataset_query @card1d)))
-            (testing "the Card's query is based on the new Database, Table, and Field IDs"
-              (is (= {:type     :query
-                      :query    {:source-table (:id @table1d)
-                                 :filter       [:>= [:field (:id @field1d) nil] 18]
-                                 :aggregation  [[:count]]}
-                      :database (:id @db1d)}
-                     (:dataset_query @card1d))))))))))
+            (is (not= (:definition @seg1s)
+                      (:definition @seg1d)))
+            (testing "the Segment's definition is based on the new Database, Table, and Field IDs"
+              (is (= {:source-table (:id @table1d)
+                      :filter       [:< [:field (:id @field1d) nil] 18]
+                      :aggregation  [[:count]]}
+                     (:definition @seg1d))))))))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -4,8 +4,8 @@
             [metabase-enterprise.serialization.v2.extract :as serdes.extract]
             [metabase-enterprise.serialization.v2.ingest :as serdes.ingest]
             [metabase-enterprise.serialization.v2.load :as serdes.load]
-            [metabase.models :refer [Card Collection Database Field Pulse PulseChannel PulseChannelRecipient Segment
-                                     Table User]]
+            [metabase.models :refer [Card Collection Database Field Metric Pulse PulseChannel PulseChannelRecipient
+                                     Segment Table User]]
             [metabase.models.serialization.base :as serdes.base]
             [metabase.models.serialization.hash :as serdes.hash]
             [toucan.db :as db]))
@@ -347,7 +347,7 @@
 (deftest segment-test
   ;; Segment.definition is a JSON-encoded MBQL query, which contain database, table, and field IDs - these need to be
   ;; converted to a portable form and read back in.
-  ;; This test has a database, table and fields, that exist on both sides with different IDs, and expects a card that
+  ;; This test has a database, table and fields, that exist on both sides with different IDs, and expects a segment that
   ;; references those fields to be correctly loaded with the dest IDs.
   (testing "embedded MBQL in Segment :definition is portable"
     (let [serialized (atom nil)
@@ -420,3 +420,80 @@
                       :filter       [:< [:field (:id @field1d) nil] 18]
                       :aggregation  [[:count]]}
                      (:definition @seg1d))))))))))
+
+(deftest metric-test
+  ;; Metric.definition is a JSON-encoded MBQL query, which contain database, table, and field IDs - these need to be
+  ;; converted to a portable form and read back in.
+  ;; This test has a database, table and fields, that exist on both sides with different IDs, and expects a metric
+  ;; to be correctly loaded with the dest IDs.
+  (testing "embedded MBQL in Metric :definition is portable"
+    (let [serialized (atom nil)
+          coll1s     (atom nil)
+          db1s       (atom nil)
+          table1s    (atom nil)
+          field1s    (atom nil)
+          metric1s   (atom nil)
+          user1s     (atom nil)
+          db1d       (atom nil)
+          table1d    (atom nil)
+          field1d    (atom nil)
+          user1d     (atom nil)
+          metric1d   (atom nil)
+          db2d       (atom nil)
+          table2d    (atom nil)
+          field2d    (atom nil)]
+
+
+      (ts/with-source-and-dest-dbs
+        (testing "serializing the original database, table, field and card"
+          (ts/with-source-db
+            (reset! coll1s   (ts/create! Collection :name "pop! minis"))
+            (reset! db1s     (ts/create! Database :name "my-db"))
+            (reset! table1s  (ts/create! Table :name "orders" :db_id (:id @db1s)))
+            (reset! field1s  (ts/create! Field :name "subtotal"    :table_id (:id @table1s)))
+            (reset! user1s   (ts/create! User  :first_name "Tom" :last_name "Scholz" :email "tom@bost.on"))
+            (reset! metric1s (ts/create! Metric :table_id (:id @table1s) :name "Revenue"
+                                         :definition {:source-table (:id @table1s)
+                                                      :aggregation [[:sum [:field (:id @field1s) nil]]]}
+                                         :creator_id (:id @user1s)))
+            (reset! serialized (into [] (serdes.extract/extract-metabase {})))))
+
+        (testing "exported form is properly converted"
+          (is (= {:source-table ["my-db" nil "orders"]
+                  :aggregation [[:sum [:field ["my-db" nil "orders" "subtotal"] nil]]]}
+                 (-> @serialized
+                     (by-model "Metric")
+                     first
+                     :definition))))
+
+        (testing "deserializing adjusts the IDs properly"
+          (ts/with-dest-db
+            ;; A different database and tables, so the IDs don't match.
+            (reset! db2d    (ts/create! Database :name "other-db"))
+            (reset! table2d (ts/create! Table    :name "customers" :db_id (:id @db2d)))
+            (reset! field2d (ts/create! Field    :name "age" :table_id (:id @table2d)))
+            (reset! user1d  (ts/create! User  :first_name "Tom" :last_name "Scholz" :email "tom@bost.on"))
+
+            ;; Load the serialized content.
+            (serdes.load/load-metabase (ingestion-in-memory @serialized))
+
+            ;; Fetch the relevant bits
+            (reset! db1d     (db/select-one Database :name "my-db"))
+            (reset! table1d  (db/select-one Table :name "orders"))
+            (reset! field1d  (db/select-one Field :table_id (:id @table1d) :name "subtotal"))
+            (reset! metric1d (db/select-one Metric :name "Revenue"))
+
+            (testing "the main Database, Table, and Field have different IDs now"
+              (is (not= (:id @db1s) (:id @db1d)))
+              (is (not= (:id @table1s) (:id @table1d)))
+              (is (not= (:id @field1s) (:id @field1d))))
+
+            (is (some? @metric1s))
+            (is (some? @metric1d))
+            ;(clojure.pprint/pprint @metric1d)
+            (is (not= (:definition @metric1s)
+                      (:definition @metric1d)))
+            (testing "the Metric's definition is based on the new Database, Table, and Field IDs"
+              (is (= {:source-table (:id @table1d)
+                      :aggregation  [[:sum [:field (:id @field1d) nil]]]}
+                     (:definition @metric1d))))))))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -343,3 +343,83 @@
                                  :aggregation  [[:count]]}
                       :database (:id @db1d)}
                      (:dataset_query @card1d))))))))))
+
+(deftest segment-test
+  ;; Segment.definition is a JSON-encoded MBQL query, which contain database, table, and field IDs - these need to be
+  ;; converted to a portable form and read back in.
+  ;; This test has a database, table and fields, that exist on both sides with different IDs, and expects a card that
+  ;; references those fields to be correctly loaded with the dest IDs.
+  (testing "embedded MBQL in Segment :definition is portable"
+    (let [serialized (atom nil)
+          coll1s     (atom nil)
+          db1s       (atom nil)
+          table1s    (atom nil)
+          field1s    (atom nil)
+          card1s     (atom nil)
+          user1s     (atom nil)
+          db1d       (atom nil)
+          table1d    (atom nil)
+          field1d    (atom nil)
+          user1d     (atom nil)
+          card1d     (atom nil)
+          db2d       (atom nil)
+          table2d    (atom nil)
+          field2d    (atom nil)]
+
+
+      (ts/with-source-and-dest-dbs
+        (testing "serializing the original database, table, field and card"
+          (ts/with-source-db
+            (reset! coll1s  (ts/create! Collection :name "pop! minis"))
+            (reset! db1s    (ts/create! Database :name "my-db"))
+            (reset! table1s (ts/create! Table :name "customers" :db_id (:id @db1s)))
+            (reset! field1s (ts/create! Field :name "age"    :table_id (:id @table1s)))
+            (reset! user1s  (ts/create! User  :first_name "Tom" :last_name "Scholz" :email "tom@bost.on"))
+            (reset! card1s  (ts/create! Card
+                                        :database_id   (:id @db1s)
+                                        :table_id      (:id @table1s)
+                                        :collection_id (:id @coll1s)
+                                        :creator_id    (:id @user1s)
+                                        :query_type    :query
+                                        :name          "Example Card"
+                                        :dataset_query {:type     :query
+                                                        :query    {:source-table (:id @table1s)
+                                                                   :filter       [:>= [:field (:id @field1s) nil] 18]
+                                                                   :aggregation  [[:count]]}
+                                                        :database (:id @db1s)}
+                                        :display        :line))
+            (reset! serialized (into [] (serdes.extract/extract-metabase {})))))
+
+        ;; TODO DO NOT SUBMIT Test that the serialized form is as expected?
+
+        (testing "deserializing adjusts the IDs properly"
+          (ts/with-dest-db
+            ;; A different database and tables, so the IDs don't match.
+            (reset! db2d    (ts/create! Database :name "other-db"))
+            (reset! table2d (ts/create! Table    :name "orders" :db_id (:id @db2d)))
+            (reset! field2d (ts/create! Field    :name "subtotal" :table_id (:id @table2d)))
+            (reset! user1d  (ts/create! User  :first_name "Tom" :last_name "Scholz" :email "tom@bost.on"))
+
+            ;; Load the serialized content.
+            (serdes.load/load-metabase (ingestion-in-memory @serialized))
+
+            ;; Fetch the relevant bits
+            (reset! db1d    (db/select-one Database :name "my-db"))
+            (reset! table1d (db/select-one Table :name "customers"))
+            (reset! field1d (db/select-one Field :table_id (:id @table1d) :name "age"))
+            (reset! card1d  (db/select-one Card  :name "Example Card"))
+
+            (testing "the main Database, Table, and Field have different IDs now"
+              (is (not= (:id @db1s) (:id @db1d)))
+              (is (not= (:id @table1s) (:id @table1d)))
+              (is (not= (:id @field1s) (:id @field1d))))
+
+            (is (not= (:dataset_query @card1s)
+                      (:dataset_query @card1d)))
+            (testing "the Card's query is based on the new Database, Table, and Field IDs"
+              (is (= {:type     :query
+                      :query    {:source-table (:id @table1d)
+                                 :filter       [:>= [:field (:id @field1d) nil] 18]
+                                 :aggregation  [[:count]]}
+                      :database (:id @db1d)}
+                     (:dataset_query @card1d))))))))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -569,6 +569,8 @@
             (reset! db2d    (ts/create! Database :name "other-db"))
             (reset! table2d (ts/create! Table    :name "customers" :db_id (:id @db2d)))
             (reset! field3d (ts/create! Field    :name "age" :table_id (:id @table2d)))
+            (ts/create! Field :name "name" :table_id (:id @table2d))
+            (ts/create! Field :name "address" :table_id (:id @table2d))
             (reset! user1d  (ts/create! User  :first_name "Tom" :last_name "Scholz" :email "tom@bost.on"))
 
             ;; Load the serialized content.

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -4,8 +4,8 @@
             [metabase-enterprise.serialization.v2.extract :as serdes.extract]
             [metabase-enterprise.serialization.v2.ingest :as serdes.ingest]
             [metabase-enterprise.serialization.v2.load :as serdes.load]
-            [metabase.models :refer [Card Collection Database Field Metric Pulse PulseChannel PulseChannelRecipient
-                                     Segment Table User]]
+            [metabase.models :refer [Card Collection Dashboard DashboardCard Database Field Metric Pulse PulseChannel
+                                     PulseChannelRecipient Segment Table User]]
             [metabase.models.serialization.base :as serdes.base]
             [metabase.models.serialization.hash :as serdes.hash]
             [toucan.db :as db]))
@@ -488,12 +488,117 @@
               (is (not= (:id @table1s) (:id @table1d)))
               (is (not= (:id @field1s) (:id @field1d))))
 
-            (is (some? @metric1s))
-            (is (some? @metric1d))
-            ;(clojure.pprint/pprint @metric1d)
             (is (not= (:definition @metric1s)
                       (:definition @metric1d)))
             (testing "the Metric's definition is based on the new Database, Table, and Field IDs"
               (is (= {:source-table (:id @table1d)
                       :aggregation  [[:sum [:field (:id @field1d) nil]]]}
                      (:definition @metric1d))))))))))
+
+(deftest dashboard-card-test
+  ;; DashboardCard.parameter_mappings and Card.parameter_mappings are JSON-encoded lists of parameter maps, which
+  ;; contain field IDs - these need to be converted to a portable form and read back in.
+  ;; This test has a database, table and fields, that exist on both sides with different IDs, and expects a Card and
+  ;; DashboardCard to be correctly loaded with the dest IDs.
+  (testing "parameter_mappings are portable"
+    (let [serialized (atom nil)
+          coll1s     (atom nil)
+          db1s       (atom nil)
+          table1s    (atom nil)
+          field1s    (atom nil)
+          field2s    (atom nil)
+          dash1s     (atom nil)
+          card1s     (atom nil)
+          dashcard1s (atom nil)
+          user1s     (atom nil)
+          db1d       (atom nil)
+          table1d    (atom nil)
+          field1d    (atom nil)
+          field2d    (atom nil)
+          user1d     (atom nil)
+          dash1d     (atom nil)
+          card1d     (atom nil)
+          dashcard1d (atom nil)
+          db2d       (atom nil)
+          table2d    (atom nil)
+          field3d    (atom nil)]
+
+
+      (ts/with-source-and-dest-dbs
+        (testing "serializing the original database, table, field and card"
+          (ts/with-source-db
+            (reset! coll1s   (ts/create! Collection :name "pop! minis"))
+            (reset! db1s     (ts/create! Database :name "my-db"))
+            (reset! table1s  (ts/create! Table :name "orders" :db_id (:id @db1s)))
+            (reset! field1s  (ts/create! Field :name "subtotal" :table_id (:id @table1s)))
+            (reset! field2s  (ts/create! Field :name "invoice" :table_id (:id @table1s)))
+            (reset! user1s   (ts/create! User  :first_name "Tom" :last_name "Scholz" :email "tom@bost.on"))
+            (reset! dash1s   (ts/create! Dashboard :name "My Dashboard" :collection_id (:id @coll1s) :creator_id (:id @user1s)))
+            (reset! card1s   (ts/create! Card :name "The Card" :database_id (:id @db1s) :table_id (:id @table1s)
+                                         :collection_id (:id @coll1s) :creator_id (:id @user1s)
+                                         :parameter_mappings [{:parameter_id "12345678"
+                                                               :target [:dimension [:field (:id @field1s) {:source-field (:id @field2s)}]]}]))
+            (reset! dashcard1s (ts/create! DashboardCard :dashboard_id (:id @dash1s) :card_id (:id @card1s)
+                                           :parameter_mappings [{:parameter_id "deadbeef"
+                                                                 :card_id (:id @card1s)
+                                                                 :target [:dimension [:field (:id @field1s) {:source-field (:id @field2s)}]]}]))
+
+            (reset! serialized (into [] (serdes.extract/extract-metabase {})))
+            (testing "exported form is properly converted"
+              (is (= [{:parameter_id "12345678"
+                       :target [:dimension [:field ["my-db" nil "orders" "subtotal"]
+                                            {:source-field ["my-db" nil "orders" "invoice"]}]]}]
+                     (-> @serialized
+                         (by-model "Card")
+                         first
+                         :parameter_mappings)))
+              (is (= [{:parameter_id "deadbeef"
+                       :card_id (:entity_id @card1s)
+                       :target [:dimension [:field ["my-db" nil "orders" "subtotal"]
+                                            {:source-field ["my-db" nil "orders" "invoice"]}]]}]
+                     (-> @serialized
+                         (by-model "DashboardCard")
+                         first
+                         :parameter_mappings))))))
+
+        
+
+        (testing "deserializing adjusts the IDs properly"
+          (ts/with-dest-db
+            ;; A different database and tables, so the IDs don't match.
+            (reset! db2d    (ts/create! Database :name "other-db"))
+            (reset! table2d (ts/create! Table    :name "customers" :db_id (:id @db2d)))
+            (reset! field3d (ts/create! Field    :name "age" :table_id (:id @table2d)))
+            (reset! user1d  (ts/create! User  :first_name "Tom" :last_name "Scholz" :email "tom@bost.on"))
+
+            ;; Load the serialized content.
+            (serdes.load/load-metabase (ingestion-in-memory @serialized))
+
+            ;; Fetch the relevant bits
+            (reset! db1d       (db/select-one Database :name "my-db"))
+            (reset! table1d    (db/select-one Table :name "orders"))
+            (reset! field1d    (db/select-one Field :table_id (:id @table1d) :name "subtotal"))
+            (reset! field2d    (db/select-one Field :table_id (:id @table1d) :name "invoice"))
+            (reset! dash1d     (db/select-one Dashboard :name "My Dashboard"))
+            (reset! card1d     (db/select-one Card :name "The Card"))
+            (reset! dashcard1d (db/select-one DashboardCard :card_id (:id @card1d) :dashboard_id (:id @dash1d)))
+
+            (testing "the main Database, Table, and Field have different IDs now"
+              (is (not= (:id @db1s) (:id @db1d)))
+              (is (not= (:id @table1s) (:id @table1d)))
+              (is (not= (:id @field1s) (:id @field1d)))
+              (is (not= (:id @field2s) (:id @field2d))))
+
+            (is (not= (:parameter_mappings @dashcard1s)
+                      (:parameter_mappings @dashcard1d)))
+            (is (not= (:parameter_mappings @card1s)
+                      (:parameter_mappings @card1d)))
+            (testing "Card.parameter_mappings are based on the new Field IDs"
+              (is (= [{:parameter_id "12345678"
+                       :target       [:dimension [:field (:id @field1d) {:source-field (:id @field2d)}]]}]
+                     (:parameter_mappings @card1d))))
+            (testing "DashboardCard.parameter_mappings are based on the new Field IDs"
+              (is (= [{:parameter_id "deadbeef"
+                       :card_id      (:id @card1d)
+                       :target       [:dimension [:field (:id @field1d) {:source-field (:id @field2d)}]]}]
+                     (:parameter_mappings @dashcard1d))))))))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -561,7 +561,7 @@
                          first
                          :parameter_mappings))))))
 
-        
+
 
         (testing "deserializing adjusts the IDs properly"
           (ts/with-dest-db

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -321,26 +321,29 @@
   ;; :collection_id is extracted as its entity_id or identity-hash.
   ;; :creator_id as the user's email.
   (-> (serdes.base/extract-one-basics "Card" card)
-      (update :database_id   serdes.util/export-fk-keyed 'Database :name)
-      (update :table_id      serdes.util/export-table-fk)
-      (update :collection_id serdes.util/export-fk 'Collection)
-      (update :creator_id    serdes.util/export-fk-keyed 'User :email)
-      (update :dataset_query serdes.util/export-json-mbql)
+      (update :database_id        serdes.util/export-fk-keyed 'Database :name)
+      (update :table_id           serdes.util/export-table-fk)
+      (update :collection_id      serdes.util/export-fk 'Collection)
+      (update :creator_id         serdes.util/export-fk-keyed 'User :email)
+      (update :dataset_query      serdes.util/export-json-mbql)
+      (update :parameter_mappings serdes.util/export-parameter-mappings)
       (dissoc :result_metadata))) ; Not portable, and can be rebuilt on the other side.
 
 (defmethod serdes.base/load-xform "Card"
   [card]
   (-> card
       serdes.base/load-xform-basics
-      (update :database_id   serdes.util/import-fk-keyed 'Database :name)
-      (update :table_id      serdes.util/import-table-fk)
-      (update :creator_id    serdes.util/import-fk-keyed 'User :email)
-      (update :collection_id serdes.util/import-fk 'Collection)
-      (update :dataset_query serdes.util/import-json-mbql)))
+      (update :database_id        serdes.util/import-fk-keyed 'Database :name)
+      (update :table_id           serdes.util/import-table-fk)
+      (update :creator_id         serdes.util/import-fk-keyed 'User :email)
+      (update :collection_id      serdes.util/import-fk 'Collection)
+      (update :dataset_query      serdes.util/import-json-mbql)
+      (update :parameter_mappings serdes.util/import-parameter-mappings)))
 
 (defmethod serdes.base/serdes-dependencies "Card"
-  [{:keys [collection_id dataset_query table_id]}]
+  [{:keys [collection_id dataset_query parameter_mappings table_id]}]
   ;; The Table implicitly depends on the Database.
-  (into [] (set/union #{(serdes.util/table->path table_id)
-                        [{:model "Collection" :id collection_id}]}
-                      (serdes.util/mbql-deps dataset_query))))
+  (into [] (reduce set/union #{(serdes.util/table->path table_id)
+                               [{:model "Collection" :id collection_id}]}
+                   (cons (serdes.util/mbql-deps dataset_query)
+                         (map serdes.util/mbql-deps parameter_mappings)))))

--- a/src/metabase/models/dashboard_card.clj
+++ b/src/metabase/models/dashboard_card.clj
@@ -219,9 +219,11 @@
                    [:or [:= :coll.personal_owner_id user] [:is :coll.personal_owner_id nil]]
                    [:is :coll.personal_owner_id nil])}))
 
-(defmethod serdes.base/serdes-dependencies "DashboardCard" [{:keys [card_id dashboard_id]}]
-  [[{:model "Dashboard" :id dashboard_id}]
-   [{:model "Card"      :id card_id}]])
+(defmethod serdes.base/serdes-dependencies "DashboardCard" [{:keys [card_id dashboard_id parameter_mappings]}]
+  (->> (mapcat serdes.util/mbql-deps parameter_mappings)
+       set
+       (into [[{:model "Dashboard" :id dashboard_id}]
+              [{:model "Card"      :id card_id}]])))
 
 (defmethod serdes.base/serdes-generate-path "DashboardCard" [_ dashcard]
   [(serdes.base/infer-self-path "Dashboard" (db/select-one 'Dashboard :id (:dashboard_id dashcard)))
@@ -230,11 +232,13 @@
 (defmethod serdes.base/extract-one "DashboardCard"
   [_model-name _opts dashcard]
   (-> (serdes.base/extract-one-basics "DashboardCard" dashcard)
-      (update :card_id      serdes.util/export-fk 'Card)
-      (update :dashboard_id serdes.util/export-fk 'Dashboard)))
+      (update :card_id            serdes.util/export-fk 'Card)
+      (update :dashboard_id       serdes.util/export-fk 'Dashboard)
+      (update :parameter_mappings serdes.util/export-parameter-mappings)))
 
 (defmethod serdes.base/load-xform "DashboardCard"
   [dashcard]
   (-> (serdes.base/load-xform-basics dashcard)
-      (update :card_id      serdes.util/import-fk 'Card)
-      (update :dashboard_id serdes.util/import-fk 'Dashboard)))
+      (update :card_id            serdes.util/import-fk 'Card)
+      (update :dashboard_id       serdes.util/import-fk 'Dashboard)
+      (update :parameter_mappings serdes.util/import-parameter-mappings)))


### PR DESCRIPTION
This PR handles the other JSON-encoded MBQL snippets I was able to find.

These snippets contain `Table` and `Field` IDs, and so are not portable. These
fields are expanded during serialization and the IDs replaced with portable
references, then converted back in deserialization.

Note that the referenced field must already be loaded before it has a valid ID.
`serdes-dependencies` defines this order, therefore each entity depends on those
tables and fields referenced in its MBQL fragments.

The complete set of fields I found to convert:

- `Metric.definition`
- `Segment.definition`
- `DashboardCard.parameter_mappings`
- `Card.parameter_mappings`

