### PR TITLE
Cannot edit dashboard filter mapping on mobile

### DIFF
--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.jsx
@@ -64,10 +64,6 @@ export const DashboardBody = styled.div`
   ${breakpointMaxSmall} {
     overflow-y: auto;
     flex-wrap: wrap;
-
-    ${ParametersAndCardsContainer} {
-      order: 1;
-    }
   }
 `;
 
@@ -95,6 +91,10 @@ export const ParametersAndCardsContainer = styled.div`
   flex: auto;
   overflow-x: hidden;
   padding-bottom: 40px;
+
+  ${breakpointMaxSmall} {
+    order: 1;
+  }
 `;
 
 export const ParametersWidgetContainer = styled(FullWidthContainer)`

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.jsx
@@ -64,6 +64,10 @@ export const DashboardBody = styled.div`
   ${breakpointMaxSmall} {
     overflow-y: auto;
     flex-wrap: wrap;
+
+    ${ParametersAndCardsContainer} {
+      order: 1;
+    }
   }
 `;
 

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.jsx
@@ -60,6 +60,10 @@ export const DashboardBody = styled.div`
     css`
       flex-basis: 0;
     `}
+
+  ${breakpointMaxSmall} {
+    flex-wrap: wrap;
+  }
 `;
 
 export const HeaderContainer = styled.header`

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.jsx
@@ -62,6 +62,7 @@ export const DashboardBody = styled.div`
     `}
 
   ${breakpointMaxSmall} {
+    overflow-y: auto;
     flex-wrap: wrap;
   }
 `;

--- a/frontend/src/metabase/dashboard/components/Sidebar.jsx
+++ b/frontend/src/metabase/dashboard/components/Sidebar.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { t } from "ttag";
 import Button from "metabase/core/components/Button";
+import { SidebarContainer } from "./Sidebar.styled";
 
 const WIDTH = 384;
 
@@ -10,6 +11,7 @@ const propTypes = {
   children: PropTypes.node,
   onClose: PropTypes.func,
   onCancel: PropTypes.func,
+  className: PropTypes.string,
 };
 
 export default function Sidebar({
@@ -17,12 +19,10 @@ export default function Sidebar({
   children,
   onClose,
   onCancel,
+  className,
 }) {
   return (
-    <aside
-      style={{ width: WIDTH, minWidth: WIDTH }}
-      className="flex flex-column border-left bg-white"
-    >
+    <SidebarContainer width={WIDTH} className={className}>
       <div className="flex flex-column flex-auto overflow-y-auto">
         {children}
       </div>
@@ -50,7 +50,7 @@ export default function Sidebar({
           )}
         </div>
       )}
-    </aside>
+    </SidebarContainer>
   );
 }
 

--- a/frontend/src/metabase/dashboard/components/Sidebar.jsx
+++ b/frontend/src/metabase/dashboard/components/Sidebar.jsx
@@ -12,7 +12,12 @@ const propTypes = {
   onCancel: PropTypes.func,
 };
 
-function Sidebar({ closeIsDisabled, children, onClose, onCancel }) {
+export default function Sidebar({
+  closeIsDisabled,
+  children,
+  onClose,
+  onCancel,
+}) {
   return (
     <aside
       style={{ width: WIDTH, minWidth: WIDTH }}
@@ -50,5 +55,3 @@ function Sidebar({ closeIsDisabled, children, onClose, onCancel }) {
 }
 
 Sidebar.propTypes = propTypes;
-
-export default Sidebar;

--- a/frontend/src/metabase/dashboard/components/Sidebar.styled.ts
+++ b/frontend/src/metabase/dashboard/components/Sidebar.styled.ts
@@ -1,0 +1,21 @@
+import { css } from "@emotion/react";
+import styled from "@emotion/styled";
+import { color } from "metabase/lib/colors";
+
+interface SidebarContainerProps {
+  width: number;
+}
+
+export const SidebarContainer = styled.aside<SidebarContainerProps>`
+  display: flex;
+  flex-direction: column;
+  background-color: ${color("white")};
+  border-left: 1px solid ${color("border")};
+
+  ${({ width }) =>
+    width &&
+    css`
+      width: ${width}px;
+      min-width: ${width}px;
+    `};
+`;

--- a/frontend/src/metabase/parameters/components/ParameterSidebar.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterSidebar.jsx
@@ -17,7 +17,7 @@ import InputBlurChange from "metabase/components/InputBlurChange";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 
 import ParameterValueWidget from "metabase/parameters/components/ParameterValueWidget";
-import Sidebar from "metabase/dashboard/components/Sidebar";
+import { ResponsiveSidebar } from "./ParameterSidebar.styled";
 
 const LINKED_FILTER = "linked-filters";
 const TABS = [
@@ -62,7 +62,7 @@ class ParameterSidebar extends React.Component {
       : TABS.filter(({ value }) => value !== LINKED_FILTER);
 
     return (
-      <Sidebar onClose={done} onCancel={this.handleCancel}>
+      <ResponsiveSidebar onClose={done} onCancel={this.handleCancel}>
         <div className="flex justify-evenly border-bottom">
           <Radio
             options={tabs}
@@ -110,7 +110,7 @@ class ParameterSidebar extends React.Component {
             />
           )}
         </div>
-      </Sidebar>
+      </ResponsiveSidebar>
     );
   }
 }

--- a/frontend/src/metabase/parameters/components/ParameterSidebar.styled.ts
+++ b/frontend/src/metabase/parameters/components/ParameterSidebar.styled.ts
@@ -1,0 +1,10 @@
+import styled from "@emotion/styled";
+import Sidebar from "metabase/dashboard/components/Sidebar";
+import { breakpointMaxSmall } from "metabase/styled-components/theme";
+
+export const ResponsiveSidebar = styled(Sidebar)`
+  ${breakpointMaxSmall} {
+    width: 100%;
+    border-left: none;
+  }
+`;

--- a/frontend/test/metabase-visual/dashboard/parameters-widget.cy.spec.js
+++ b/frontend/test/metabase-visual/dashboard/parameters-widget.cy.spec.js
@@ -103,6 +103,7 @@ describe(`visual tests > dashboard > parameters widget`, () => {
         cy.icon("pencil").click();
 
         cy.findByTestId("dashboard-parameters-and-cards")
+          .parent()
           .scrollTo(0, 464)
           .then(() => {
             cy.createPercySnapshot(null, { widths: [MOBILE_WIDTH] });
@@ -201,6 +202,7 @@ describe(`visual tests > dashboard > parameters widget`, () => {
         cy.icon("pencil").click();
 
         cy.findByTestId("dashboard-parameters-and-cards")
+          .parent()
           .scrollTo(0, 464)
           .then(() => {
             cy.createPercySnapshot(null, { widths: [MOBILE_WIDTH] });


### PR DESCRIPTION
Fixes #23962

This PR fixes the issue by wrapping the dashboard content down at the bottom.

### Before
#### Desktop
![image](https://user-images.githubusercontent.com/1937582/182819168-3da3e51a-720f-4a91-abe2-9ee04ccbc1cb.png)

#### Mobile
1. Before editing
![image](https://user-images.githubusercontent.com/1937582/182819215-8819bdc0-d6ba-4b50-874d-3becb435f40d.png)

2. Clicked editing. You could see the dashboard width is almost 0 (shrunk via flex-shrink)
![image](https://user-images.githubusercontent.com/1937582/182820733-dbb88c0e-8209-40b1-a4b3-7f1a1e0b1e2d.png)

### After
#### Desktop (looks the same)
![image](https://user-images.githubusercontent.com/1937582/182819453-16731c35-e425-4139-8bd8-49a668283f06.png)


#### Mobile
1. Before editing
![image](https://user-images.githubusercontent.com/1937582/182819482-02d7c2ca-05da-45d3-b5f6-f7d3c59d6039.png)


2. Clicked editing
![image](https://user-images.githubusercontent.com/1937582/182819513-01ba98ac-d0f4-4d7f-a4ac-537464cb6003.png)

3. Scroll
![image](https://user-images.githubusercontent.com/1937582/182819538-b9f85330-089c-4c14-9b8f-50edd1cb5082.png)


