### PR TITLE
Fix sizing of dashboard cards for printing

### DIFF
--- a/frontend/src/metabase/components/ExplicitSize.jsx
+++ b/frontend/src/metabase/components/ExplicitSize.jsx
@@ -30,16 +30,9 @@ export default ({ selector, wrapped, refreshMode = "throttle" } = {}) =>
           height: null,
         };
 
-        if (isCypressActive) {
-          this._updateSize = this.__updateSize;
-        } else {
-          this._refreshMode =
-            typeof refreshMode === "function"
-              ? refreshMode(props)
-              : refreshMode;
-          const refreshFn = REFRESH_MODE[this._refreshMode];
-          this._updateSize = refreshFn(this.__updateSize);
-        }
+        this._printMediaQuery = window.matchMedia && window.matchMedia("print");
+        const refreshFn = REFRESH_MODE[this._getRefreshMode()];
+        this._updateSize = refreshFn(this.__updateSize);
       }
 
       _getElement() {
@@ -61,9 +54,7 @@ export default ({ selector, wrapped, refreshMode = "throttle" } = {}) =>
       componentDidUpdate() {
         // update ResizeObserver if element changes
         this._updateResizeObserver();
-        if (typeof refreshMode === "function" && !isCypressActive) {
-          this._updateRefreshMode();
-        }
+        this._updateRefreshMode();
       }
 
       componentWillUnmount() {
@@ -71,8 +62,18 @@ export default ({ selector, wrapped, refreshMode = "throttle" } = {}) =>
         this._teardownQueryMediaListener();
       }
 
+      _getRefreshMode = () => {
+        if (isCypressActive || this._printMediaQuery?.matches) {
+          return "none";
+        } else if (typeof refreshMode === "function") {
+          return refreshMode(this.props);
+        } else {
+          return refreshMode;
+        }
+      };
+
       _updateRefreshMode = () => {
-        const nextMode = refreshMode(this.props);
+        const nextMode = this._getRefreshMode();
         if (nextMode === this._refreshMode) {
           return;
         }
@@ -104,16 +105,13 @@ export default ({ selector, wrapped, refreshMode = "throttle" } = {}) =>
 
       // media query listener, ensure re-layout when printing
       _initMediaQueryListener() {
-        if (window.matchMedia) {
-          this._mql = window.matchMedia("print");
-          this._mql.addListener(this._updateSize);
-        }
+        this._printMediaQuery?.addEventListener(
+          "change",
+          this._updateRefreshMode,
+        );
       }
       _teardownQueryMediaListener() {
-        if (this._mql) {
-          this._mql.removeListener(this._updateSize);
-          this._mql = null;
-        }
+        this._printMediaQuery?.removeEventListener("change", this._updateSize);
       }
 
       __updateSize = () => {

--- a/frontend/src/metabase/components/ExplicitSize.jsx
+++ b/frontend/src/metabase/components/ExplicitSize.jsx
@@ -111,7 +111,10 @@ export default ({ selector, wrapped, refreshMode = "throttle" } = {}) =>
         );
       }
       _teardownQueryMediaListener() {
-        this._printMediaQuery?.removeEventListener("change", this._updateSize);
+        this._printMediaQuery?.removeEventListener(
+          "change",
+          this._updateRefreshMode,
+        );
       }
 
       __updateSize = () => {

--- a/frontend/src/metabase/css/dashboard.css
+++ b/frontend/src/metabase/css/dashboard.css
@@ -285,10 +285,6 @@
   nav {
     display: none;
   }
-  .DashCard .Card {
-    box-shadow: none;
-    border-color: var(--color-border);
-  }
   /* improve label contrast */
   .dc-chart .axis .tick text,
   .dc-chart .x-axis-label,


### PR DESCRIPTION
Fixes some cases in https://github.com/metabase/metabase/issues/23436
Related to https://github.com/metabase/metabase/pull/22094.

https://github.com/metabase/metabase/pull/22094 broke printing dashboards in Chrome because cards would not be resized before printing. This PR fixes the issue by immediately resizing cards when we are printing.

Please note that this PR doesn't solve scaling issues described by **flamber**.

How to test:
- Create a dashboard with Pie and Text cards, like this:
<img width="1230" alt="Screenshot 2022-08-03 at 14 24 14" src="https://user-images.githubusercontent.com/8542534/182596554-4abac2ce-02f0-4615-aabb-bac9159f3cda.png">
<img width="1145" alt="Screenshot 2022-08-03 at 14 24 40" src="https://user-images.githubusercontent.com/8542534/182596574-6d1857f3-69d4-4f50-8159-05faab4577ca.png">
- Press Cmd + P. Charts should be resized correctly to fit the page:
<img width="1174" alt="Screenshot 2022-08-03 at 18 41 15" src="https://user-images.githubusercontent.com/8542534/182650944-5b3954aa-d73d-42f5-8424-eec0735d1779.png">

