### PR TITLE
Setting timeout to missing step on Build workflow

### DIFF
--- a/.github/workflows/build-scripts.yml
+++ b/.github/workflows/build-scripts.yml
@@ -14,6 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Prepare back-end environment
+      timeout-minutes: 5
       uses: ./.github/actions/prepare-backend
       with:
         m2-cache-key: 'build-scripts'


### PR DESCRIPTION
Recently we had an issue with cache download hanging the runner for 360 minutes on a [job](https://github.com/metabase/metabase/runs/7581705676?check_suite_focus=true) 

Since composite does not accept `timeout-minutes` (https://github.com/actions/runner/issues/1979), I've added a timeout specific to the step `Prepare back-end environment` to avoid this from happening again.
