### PR TITLE
Use `linux/amd64` as platform for Temurin images

### DIFF
--- a/bin/docker/Dockerfile
+++ b/bin/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11-jre-alpine
+FROM --platform=linux/amd64 eclipse-temurin:11-jre-alpine
 
 ENV FC_LANG=en-US LC_CTYPE=en_US.UTF-8
 


### PR DESCRIPTION
While we don't have a proper image supporting amd64 (M1 Mac Machines) we can explicitly pass the platform while downloading the image.

The same way we are already doing here: https://github.com/metabase/metabase/blob/master/Dockerfile#L22

Issue reference: https://github.com/adoptium/adoptium/issues/96