### PR TITLE
Set `CookieSpecs/STANDARD` on HttpClient for Snowplow

### DIFF
--- a/src/metabase/analytics/snowplow.clj
+++ b/src/metabase/analytics/snowplow.clj
@@ -16,6 +16,7 @@
            [com.snowplowanalytics.snowplow.tracker.events Unstructured Unstructured$Builder]
            [com.snowplowanalytics.snowplow.tracker.http ApacheHttpClientAdapter ApacheHttpClientAdapter$Builder]
            com.snowplowanalytics.snowplow.tracker.payload.SelfDescribingJson
+           org.apache.http.client.config.CookieSpecs
            org.apache.http.impl.client.HttpClients
            org.apache.http.impl.conn.PoolingHttpClientConnectionManager))
 
@@ -82,6 +83,7 @@
   (let [emitter* (delay
                    (let [client (-> (HttpClients/custom)
                                     (.setConnectionManager (PoolingHttpClientConnectionManager.))
+                                    (.setCookieSpec (CookieSpecs/STANDARD))
                                     (.build))
                          builder (-> (ApacheHttpClientAdapter/builder)
                                      (.httpClient client)

--- a/src/metabase/analytics/snowplow.clj
+++ b/src/metabase/analytics/snowplow.clj
@@ -83,6 +83,8 @@
   (let [emitter* (delay
                    (let [client (-> (HttpClients/custom)
                                     (.setConnectionManager (PoolingHttpClientConnectionManager.))
+                                    ;; Set cookie spec to `STANDARD` to avoid warnings about an invalid cookie header
+                                    ;; in request response (PR #24579)
                                     (.setCookieSpec (CookieSpecs/STANDARD))
                                     (.build))
                          builder (-> (ApacheHttpClientAdapter/builder)


### PR DESCRIPTION
This should fix the `Invalid cookie header` garbage in the logs.

The tl;dr is that the Snowplow server tries to set certain cookies in response to HTTP requests for tracking event data. These cookies are only relevant for the JS tracker, not for the backend, but they cause the Apache HttpClient we're using to log an error (I think it doesn't understand the `SameSite=None` header). Setting `CookieSpecs/STANDARD` seems to fix this, per [this SO post](https://stackoverflow.com/questions/36473478/fixing-httpclient-warning-invalid-expires-attribute-using-fluent-api).

Tested locally and confirmed that the logs vanish with this change.

Closes #12934