### PR TITLE
Ensure to use original query not persisted query when converting

### DIFF
--- a/src/metabase/api/dataset.clj
+++ b/src/metabase/api/dataset.clj
@@ -10,6 +10,7 @@
             [metabase.mbql.schema :as mbql.s]
             [metabase.models.card :refer [Card]]
             [metabase.models.database :as database :refer [Database]]
+            [metabase.models.persisted-info :as persisted-info]
             [metabase.models.query :as query]
             [metabase.models.table :refer [Table]]
             [metabase.query-processor :as qp]
@@ -149,8 +150,9 @@
 (api/defendpoint POST "/native"
   "Fetch a native version of an MBQL query."
   [:as {query :body}]
-  (qp.perms/check-current-user-has-adhoc-native-query-perms query)
-  (qp/compile-and-splice-parameters query))
+  (binding [persisted-info/*allow-persisted-substitution* false]
+    (qp.perms/check-current-user-has-adhoc-native-query-perms query)
+    (qp/compile-and-splice-parameters query)))
 
 (api/defendpoint ^:streaming POST "/pivot"
   "Generate a pivoted dataset for an ad-hoc query"


### PR DESCRIPTION
If you click "view sql" on a cached model you see the substituted query
rather than the "real" query.

The query based on cache:

```sql
SELECT "source"."login" AS "login", "source"."count" AS "count"
FROM (select "login", "count" from "metabase_cache_e449f_19"."model_4112_issue_assi") "source"
LIMIT 1048575
```

The real underlying query:

```sql
SELECT "source"."login" AS "login", "source"."count" AS "count"
FROM (SELECT "github_raw"."issue_events__issue__assignees"."login" AS "login", count(*) AS "count" FROM "github_raw"."issue_events__issue__assignees"
GROUP BY "github_raw"."issue_events__issue__assignees"."login"
ORDER BY "count" DESC, "github_raw"."issue_events__issue__assignees"."login" ASC) "source"
LIMIT 1048575
```

If you click the "convert to sql question" you will end up with a sql
question that is not based on the original question but the Metabase
managed table.

#### Viewing SQL
If you click "view sql" on a cached model you see the substituted query
rather than the "real" query.

The query based on cache:

```sql
SELECT "source"."login" AS "login", "source"."count" AS "count"
FROM (select "login", "count" from "metabase_cache_e449f_19"."model_4112_issue_assi") "source"
LIMIT 1048575
```

The real underlying query:

```sql
SELECT "source"."login" AS "login", "source"."count" AS "count"
FROM (SELECT "github_raw"."issue_events__issue__assignees"."login" AS "login", count(*) AS "count" FROM "github_raw"."issue_events__issue__assignees"
GROUP BY "github_raw"."issue_events__issue__assignees"."login"
ORDER BY "count" DESC, "github_raw"."issue_events__issue__assignees"."login" ASC) "source"
LIMIT 1048575
```

If you click the "convert to sql question" you will end up with a sql
question that is not based on the original question but the Metabase
managed table.
