### PR TITLE
Fix multi-level nested queries with joins

### DIFF
--- a/frontend/test/metabase/scenarios/joins/reproductions/22859-multi-nested-joins-wrong-aliasing.cy.spec.js
+++ b/frontend/test/metabase/scenarios/joins/reproductions/22859-multi-nested-joins-wrong-aliasing.cy.spec.js
@@ -29,7 +29,7 @@ const questionDetails = {
   },
 };
 
-describe.skip("issue 22859 - multiple levels of nesting", () => {
+describe("issue 22859 - multiple levels of nesting", () => {
   beforeEach(() => {
     cy.intercept("POST", "/api/card").as("saveQuestion");
 

--- a/src/metabase/query_processor/util/add_alias_info.clj
+++ b/src/metabase/query_processor/util/add_alias_info.clj
@@ -1,5 +1,5 @@
 (ns metabase.query-processor.util.add-alias-info
-  "Walks query and adds generates appropriate aliases for every selected column; and adds extra keys to the
+  "Walks query and generates appropriate aliases for every selected column; and adds extra keys to the
   corresponding MBQL clauses with this information. Deduplicates aliases and calls [[metabase.driver/escape-alias]]
   with the generated aliases. Adds information about the aliases in source queries and joins that correspond to
   columns in the parent level.

--- a/src/metabase/query_processor/util/add_alias_info.clj
+++ b/src/metabase/query_processor/util/add_alias_info.clj
@@ -289,9 +289,9 @@
     ;; suffix to escaped identifiers.)
     ;;
     ;; We'll have to look into this more in the future. For now, it seems to work for everything we try it with.
-    (and join-alias (not join-is-this-level?)) (prefix-field-alias join-alias field-name)
     (and join-is-this-level? alias-from-join)  alias-from-join
     alias-from-source-query                    alias-from-source-query
+    (and join-alias (not join-is-this-level?)) (prefix-field-alias join-alias field-name)
     :else                                      field-name))
 
 (defn- field-desired-alias

--- a/test/metabase/query_processor_test/nested_queries_test.clj
+++ b/test/metabase/query_processor_test/nested_queries_test.clj
@@ -230,7 +230,7 @@
 
 (deftest multilevel-nested-questions-with-joins
   (testing "Multilevel nested questions with joins work (#22859)"
-    (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries)
+    (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries :left-join)
       (mt/dataset sample-dataset
         (mt/with-temp* [Card [inner-card
                               {:dataset_query

--- a/test/metabase/query_processor_test/nested_queries_test.clj
+++ b/test/metabase/query_processor_test/nested_queries_test.clj
@@ -228,6 +228,31 @@
   ([card k v & {:as more}]
    (query-with-source-card card (merge {k v} more))))
 
+(deftest multilevel-nested-questions-with-joins
+  (testing "Multilevel nested questions with joins work (#22859)"
+    (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries)
+      (mt/dataset sample-dataset
+        (mt/with-temp* [Card [inner-card
+                              {:dataset_query
+                               (mt/mbql-query reviews
+                                 {:fields [$id]
+                                  :joins [{:source-table $$products
+                                           :alias "P"
+                                           :fields [&P.products.id &P.products.ean]
+                                           :condition [:= $product_id &P.products.id]}]})}]
+                        Card [outer-card
+                              {:dataset_query
+                               (mt/mbql-query orders
+                                 {:fields [$id]
+                                  :joins [{:source-table (str "card__" (:id inner-card))
+                                           :alias "RP"
+                                           :fields [&RP.reviews.id &RP.products.id &RP.products.ean]
+                                           :condition [:= $product_id &RP.products.id]}]})}]]
+          (is (= :completed
+                 (-> (query-with-source-card outer-card :limit 1)
+                     qp/process-query
+                     :status))))))))
+
 (deftest source-card-id-test
   (testing "Make sure we can run queries using source table `card__id` format."
     ;; This is the format that is actually used by the frontend; it gets translated to the normal `source-query`


### PR DESCRIPTION
Fixes #22859.

The problem is related to fields "inherited" from a join (i.e., having a join alias) in a nested query where the actual alias of the field is different from the "default" name, i.e., from the one that is generated for fields from joins (composed from the table name and the field name). The suggested fix is to prefer the actual name in the nested query to the default name for joined fields.

Before this change for such fields Metabase would generate a dangling name and the drivers would throw an exception. The test I added uses the query from the bug ticket which doesn't make much sense, so all I do is to check if the query can be run successfully.