### PR TITLE
Support click behavior in Gauge and Progress visualizations

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/Gauge.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Gauge.jsx
@@ -356,7 +356,7 @@ const GaugeArc = ({
 
   const clicked = segment && { value: segment.min, column, settings };
   const isClickable = clicked && visualizationIsClickable(clicked);
-  const options = column && settings?.column ? column.settings(column) : {};
+  const options = column && settings?.column ? settings.column(column) : {};
   const range = segment ? [segment.min, segment.max] : [];
   const value = range.map(v => formatValue(v, options)).join(" - ");
   const hovered = segment ? { data: [{ key: segment.label, value }] } : {};

--- a/frontend/src/metabase/visualizations/visualizations/Gauge.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Gauge.jsx
@@ -354,12 +354,14 @@ const GaugeArc = ({
     event => {
       if (onVisualizationClick) {
         onVisualizationClick({
+          value: segment.min,
+          column,
           settings,
           event: event.nativeEvent,
         });
       }
     },
-    [settings, onVisualizationClick],
+    [segment, column, settings, onVisualizationClick],
   );
 
   const handleMouseMove = useCallback(

--- a/frontend/src/metabase/visualizations/visualizations/Gauge.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Gauge.jsx
@@ -270,8 +270,8 @@ export default class Gauge extends Component {
                   segment={segment}
                   column={column}
                   settings={settings}
-                  onClick={onVisualizationClick}
                   onHoverChange={!showLabels ? onHoverChange : null}
+                  onVisualizationClick={onVisualizationClick}
                   testId={"gauge-arc-" + index}
                 />
               ))}
@@ -340,6 +340,7 @@ const GaugeArc = ({
   fill,
   segment,
   onHoverChange,
+  onVisualizationClick,
   settings,
   column,
   testId,
@@ -349,8 +350,20 @@ const GaugeArc = ({
     .outerRadius(OUTER_RADIUS)
     .innerRadius(OUTER_RADIUS * INNER_RADIUS_RATIO);
 
+  const handleClick = useCallback(
+    event => {
+      if (onVisualizationClick) {
+        onVisualizationClick({
+          settings,
+          event: event.nativeEvent,
+        });
+      }
+    },
+    [settings, onVisualizationClick],
+  );
+
   const handleMouseMove = useCallback(
-    e => {
+    event => {
       if (onHoverChange) {
         const options =
           settings && settings.column && column ? settings.column(column) : {};
@@ -363,7 +376,7 @@ const GaugeArc = ({
                 .join(" - "),
             },
           ],
-          event: e.nativeEvent,
+          event: event.nativeEvent,
         });
       }
     },
@@ -384,6 +397,7 @@ const GaugeArc = ({
       })}
       fill={fill}
       data-testid={testId}
+      onClick={handleClick}
       onMouseMove={handleMouseMove}
       onMouseLeave={handleMouseLeave}
     />

--- a/frontend/src/metabase/visualizations/visualizations/Gauge.styled.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Gauge.styled.tsx
@@ -1,0 +1,9 @@
+import styled from "@emotion/styled";
+
+export interface GaugeArcPathProps {
+  isClickable: boolean;
+}
+
+export const GaugeArcPath = styled.path<GaugeArcPathProps>`
+  cursor: ${props => props.isClickable && "pointer"};
+`;

--- a/frontend/src/metabase/visualizations/visualizations/Progress.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Progress.jsx
@@ -201,6 +201,7 @@ export default class Progress extends Component {
               borderRadius: BORDER_RADIUS,
               overflow: "hidden",
             }}
+            data-testid="progress-bar"
             onClick={
               isClickable &&
               (e => onVisualizationClick({ ...clicked, event: e.nativeEvent }))

--- a/frontend/src/metabase/visualizations/visualizations/Progress.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Progress.jsx
@@ -160,7 +160,7 @@ export default class Progress extends Component {
       barMessage = t`Goal exceeded`;
     }
 
-    const clicked = { value, column };
+    const clicked = { value, column, settings };
     const isClickable = visualizationIsClickable(clicked);
 
     return (

--- a/frontend/test/metabase/scenarios/dashboard/click-behavior.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/click-behavior.cy.spec.js
@@ -8,6 +8,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
+    cy.intercept("POST", "/api/dataset").as("dataset");
   });
 
   it("should show filters defined on a question with filter pass-thru (metabase#15993)", () => {
@@ -157,4 +158,65 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
       },
     });
   });
+
+  it("should navigate to a target from a gauge card", () => {
+    const target_id = 1;
+
+    cy.createQuestionAndDashboard({
+      questionDetails: getQuestionDetails({ display: "gauge" }),
+    }).then(({ body: { id, card_id, dashboard_id } }) => {
+      cy.request("PUT", `/api/dashboard/${dashboard_id}/cards`, {
+        cards: [getDashcardDetails({ id, card_id, target_id })],
+      });
+
+      visitDashboard(dashboard_id);
+    });
+
+    cy.findByTestId("gauge-arc-1").click();
+    cy.wait("@dataset");
+    cy.findByText("Orders");
+  });
+
+  it("should navigate to a target from a progress card", () => {
+    const target_id = 1;
+
+    cy.createQuestionAndDashboard({
+      questionDetails: getQuestionDetails({ display: "progress" }),
+    }).then(({ body: { id, card_id, dashboard_id } }) => {
+      cy.request("PUT", `/api/dashboard/${dashboard_id}/cards`, {
+        cards: [getDashcardDetails({ id, card_id, target_id })],
+      });
+
+      visitDashboard(dashboard_id);
+    });
+
+    cy.findByTestId("progress-bar").click();
+    cy.wait("@dataset");
+    cy.findByText("Orders");
+  });
+});
+
+const getQuestionDetails = ({ display }) => ({
+  display,
+  query: {
+    "source-table": REVIEWS_ID,
+    aggregation: [["count"]],
+  },
+});
+
+const getDashcardDetails = ({ id, card_id, target_id }) => ({
+  id,
+  card_id,
+  row: 0,
+  col: 0,
+  sizeX: 12,
+  sizeY: 10,
+  visualization_settings: {
+    click_behavior: {
+      type: "link",
+      linkType: "question",
+      targetId: target_id,
+      parameterMapping: {},
+    },
+  },
 });

--- a/frontend/test/metabase/scenarios/dashboard/click-behavior.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/click-behavior.cy.spec.js
@@ -159,7 +159,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
     });
   });
 
-  it("should navigate to a target from a gauge card", () => {
+  it("should navigate to a target from a gauge card (metabase#23137)", () => {
     const target_id = 1;
 
     cy.createQuestionAndDashboard({
@@ -177,7 +177,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
     cy.findByText("Orders");
   });
 
-  it("should navigate to a target from a progress card", () => {
+  it("should navigate to a target from a progress card (metabase#23137)", () => {
     const target_id = 1;
 
     cy.createQuestionAndDashboard({


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/23137
Reproduces https://github.com/metabase/metabase/issues/23137

How to test:
- Add a progress and a gauge questions to a dashboard
- Add a click behavior to them, e.g. navigate to a question
- Make sure that it is possible to click on gauge segments / progress bar and navigate to the question

<img width="367" alt="Screenshot 2022-08-04 at 15 27 57" src="https://user-images.githubusercontent.com/8542534/182847102-2381c713-21ae-4aab-aac9-3ba888da4ef4.png">
