### PR TITLE
use leading debounce for visualizations

### DIFF
--- a/frontend/src/metabase/visualizations/components/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization.jsx
@@ -565,7 +565,7 @@ const mapStateToProps = state => ({
 export default _.compose(
   ExplicitSize({
     selector: ".CardVisualization",
-    refreshMode: props => (props.isDashboard ? "debounce" : "throttle"),
+    refreshMode: props => (props.isDashboard ? "debounceLeading" : "throttle"),
   }),
   connect(mapStateToProps),
   memoizeClass("_getQuestionForCardCached"),


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/24332

## Changes

Recently we added a debounced rendering of our charts to deal with performance issues that have become more visible after we introduced the collections sidebar. This means that first few hundred milliseconds of the initial rendering the visualization components do not receive width and height so that the Scalar visualization is unable to calculate its font-size.

The slowest charts that give significant performance issues are Line/Area/Bar/Scatter/Waterfall chats which is not fixable without a significant rewriting. So these slow charts will be still rendered with `debounce` and not `debounceLeading` becaue they use `frontend/src/metabase/visualizations/components/CardRenderer.jsx` component which also uses `ExplicitSize` hoc so the change should not affect overall performance.

## How to verify

- Create a Scalar card, like a `select 100000`
- Add it on a dashboard and refresh the page
- Ensure when the page loads the Scalar value font size does not change