### PR TITLE
Serdes v2: Portable `:visualization_settings` fields on (dash)cards.

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -536,30 +536,85 @@
             (reset! dash1s   (ts/create! Dashboard :name "My Dashboard" :collection_id (:id @coll1s) :creator_id (:id @user1s)))
             (reset! card1s   (ts/create! Card :name "The Card" :database_id (:id @db1s) :table_id (:id @table1s)
                                          :collection_id (:id @coll1s) :creator_id (:id @user1s)
+                                         :visualization_settings
+                                         {:table.pivot_column "SOURCE"
+                                          :table.cell_column "sum"
+                                          :table.columns
+                                          [{:name "SOME_FIELD"
+                                            :fieldRef [:field (:id @field1s) nil]
+                                            :enabled true}
+                                           {:name "sum"
+                                            :fieldRef [:field "sum" {:base-type :type/Float}]
+                                            :enabled true}
+                                           {:name "count"
+                                            :fieldRef [:field "count" {:base-type :type/BigInteger}]
+                                            :enabled true}
+                                           {:name "Average order total"
+                                            :fieldRef [:field "Average order total" {:base-type :type/Float}]
+                                            :enabled true}]
+                                          :column_settings
+                                          {(str "[\"ref\",[\"field\"," (:id @field2s) ",null]]") {:column_title "Locus"}}}
                                          :parameter_mappings [{:parameter_id "12345678"
                                                                :target [:dimension [:field (:id @field1s) {:source-field (:id @field2s)}]]}]))
             (reset! dashcard1s (ts/create! DashboardCard :dashboard_id (:id @dash1s) :card_id (:id @card1s)
+                                           :visualization_settings
+                                           {:table.pivot_column "SOURCE"
+                                            :table.cell_column "sum"
+                                            :table.columns
+                                            [{:name "SOME_FIELD"
+                                              :fieldRef [:field (:id @field1s) nil]
+                                              :enabled true}
+                                             {:name "sum"
+                                              :fieldRef [:field "sum" {:base-type :type/Float}]
+                                              :enabled true}
+                                             {:name "count"
+                                              :fieldRef [:field "count" {:base-type :type/BigInteger}]
+                                              :enabled true}
+                                             {:name "Average order total"
+                                              :fieldRef [:field "Average order total" {:base-type :type/Float}]
+                                              :enabled true}]
+                                            :column_settings
+                                            {(str "[\"ref\",[\"field\"," (:id @field2s) ",null]]") {:column_title "Locus"}}}
                                            :parameter_mappings [{:parameter_id "deadbeef"
                                                                  :card_id (:id @card1s)
                                                                  :target [:dimension [:field (:id @field1s) {:source-field (:id @field2s)}]]}]))
 
             (reset! serialized (into [] (serdes.extract/extract-metabase {})))
-            (testing "exported form is properly converted"
-              (is (= [{:parameter_id "12345678"
-                       :target [:dimension [:field ["my-db" nil "orders" "subtotal"]
-                                            {:source-field ["my-db" nil "orders" "invoice"]}]]}]
-                     (-> @serialized
-                         (by-model "Card")
-                         first
-                         :parameter_mappings)))
-              (is (= [{:parameter_id "deadbeef"
-                       :card_id (:entity_id @card1s)
-                       :target [:dimension [:field ["my-db" nil "orders" "subtotal"]
-                                            {:source-field ["my-db" nil "orders" "invoice"]}]]}]
-                     (-> @serialized
-                         (by-model "DashboardCard")
-                         first
-                         :parameter_mappings))))))
+            (let [card     (-> @serialized (by-model "Card") first)
+                  dashcard (-> @serialized (by-model "DashboardCard") first)]
+              (testing "exported :parameter_mappings are properly converted"
+                (is (= [{:parameter_id "12345678"
+                         :target [:dimension [:field ["my-db" nil "orders" "subtotal"]
+                                              {:source-field ["my-db" nil "orders" "invoice"]}]]}]
+                       (:parameter_mappings card)))
+                (is (= [{:parameter_id "deadbeef"
+                         :card_id (:entity_id @card1s)
+                         :target [:dimension [:field ["my-db" nil "orders" "subtotal"]
+                                              {:source-field ["my-db" nil "orders" "invoice"]}]]}]
+                       (:parameter_mappings dashcard))))
+
+              (testing "exported :visualization_settings are properly converted"
+                (let [expected {:table.pivot_column "SOURCE"
+                                :table.cell_column "sum"
+                                :table.columns
+                                [{:name "SOME_FIELD"
+                                  :fieldRef ["field" ["my-db" nil "orders" "subtotal"] nil]
+                                  :enabled true}
+                                 {:name "sum"
+                                  :fieldRef ["field" "sum" {:base-type "type/Float"}]
+                                  :enabled true}
+                                 {:name "count"
+                                  :fieldRef ["field" "count" {:base-type "type/BigInteger"}]
+                                  :enabled true}
+                                 {:name "Average order total"
+                                  :fieldRef ["field" "Average order total" {:base-type "type/Float"}]
+                                  :enabled true}]
+                                :column_settings
+                                {"[\"ref\",[\"field\",[\"my-db\",null,\"orders\",\"invoice\"],null]]" {:column_title "Locus"}}}]
+                  (is (= expected
+                         (:visualization_settings card)))
+                  (is (= expected
+                         (:visualization_settings dashcard))))))))
 
 
 
@@ -604,3 +659,10 @@
                        :card_id      (:id @card1d)
                        :target       [:dimension [:field (:id @field1d) {:source-field (:id @field2d)}]]}]
                      (:parameter_mappings @dashcard1d))))))))))
+
+
+(comment
+  (doseq [_ (range 100)]
+    (run-test dashboard-card-test)))
+
+

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -659,10 +659,3 @@
                        :card_id      (:id @card1d)
                        :target       [:dimension [:field (:id @field1d) {:source-field (:id @field2d)}]]}]
                      (:parameter_mappings @dashcard1d))))))))))
-
-
-(comment
-  (doseq [_ (range 100)]
-    (run-test dashboard-card-test)))
-
-

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -1,7 +1,8 @@
 (ns metabase.models.card
   "Underlying DB model for what is now most commonly referred to as a 'Question' in most user-facing situations. Card
   is a historical name, but is the same thing; both terms are used interchangeably in the backend codebase."
-  (:require [clojure.set :as set]
+  (:require [cheshire.core :as json]
+            [clojure.set :as set]
             [clojure.tools.logging :as log]
             [metabase.mbql.normalize :as mbql.normalize]
             [metabase.models.collection :as collection]
@@ -321,29 +322,34 @@
   ;; :collection_id is extracted as its entity_id or identity-hash.
   ;; :creator_id as the user's email.
   (-> (serdes.base/extract-one-basics "Card" card)
-      (update :database_id        serdes.util/export-fk-keyed 'Database :name)
-      (update :table_id           serdes.util/export-table-fk)
-      (update :collection_id      serdes.util/export-fk 'Collection)
-      (update :creator_id         serdes.util/export-fk-keyed 'User :email)
-      (update :dataset_query      serdes.util/export-json-mbql)
-      (update :parameter_mappings serdes.util/export-parameter-mappings)
+      (update :database_id            serdes.util/export-fk-keyed 'Database :name)
+      (update :table_id               serdes.util/export-table-fk)
+      (update :collection_id          serdes.util/export-fk 'Collection)
+      (update :creator_id             serdes.util/export-fk-keyed 'User :email)
+      (update :dataset_query          serdes.util/export-json-mbql)
+      (update :parameter_mappings     serdes.util/export-parameter-mappings)
+      (update :visualization_settings serdes.util/export-visualization-settings)
       (dissoc :result_metadata))) ; Not portable, and can be rebuilt on the other side.
 
 (defmethod serdes.base/load-xform "Card"
   [card]
   (-> card
       serdes.base/load-xform-basics
-      (update :database_id        serdes.util/import-fk-keyed 'Database :name)
-      (update :table_id           serdes.util/import-table-fk)
-      (update :creator_id         serdes.util/import-fk-keyed 'User :email)
-      (update :collection_id      serdes.util/import-fk 'Collection)
-      (update :dataset_query      serdes.util/import-json-mbql)
-      (update :parameter_mappings serdes.util/import-parameter-mappings)))
+      (update :database_id            serdes.util/import-fk-keyed 'Database :name)
+      (update :table_id               serdes.util/import-table-fk)
+      (update :creator_id             serdes.util/import-fk-keyed 'User :email)
+      (update :collection_id          serdes.util/import-fk 'Collection)
+      (update :dataset_query          serdes.util/import-json-mbql)
+      (update :parameter_mappings     serdes.util/import-parameter-mappings)
+      (update :visualization_settings serdes.util/import-visualization-settings)))
 
 (defmethod serdes.base/serdes-dependencies "Card"
-  [{:keys [collection_id dataset_query parameter_mappings table_id]}]
+  [{:keys [collection_id dataset_query parameter_mappings table_id visualization_settings]}]
   ;; The Table implicitly depends on the Database.
-  (into [] (reduce set/union #{(serdes.util/table->path table_id)
-                               [{:model "Collection" :id collection_id}]}
-                   (cons (serdes.util/mbql-deps dataset_query)
-                         (map serdes.util/mbql-deps parameter_mappings)))))
+  (->> (map serdes.util/mbql-deps parameter_mappings)
+       (reduce set/union)
+       (set/union #{(serdes.util/table->path table_id)
+                    [{:model "Collection" :id collection_id}]})
+       (set/union (serdes.util/mbql-deps dataset_query))
+       (set/union (serdes.util/visualization-settings-deps visualization_settings))
+       vec))

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -1,8 +1,7 @@
 (ns metabase.models.card
   "Underlying DB model for what is now most commonly referred to as a 'Question' in most user-facing situations. Card
   is a historical name, but is the same thing; both terms are used interchangeably in the backend codebase."
-  (:require [cheshire.core :as json]
-            [clojure.set :as set]
+  (:require [clojure.set :as set]
             [clojure.tools.logging :as log]
             [metabase.mbql.normalize :as mbql.normalize]
             [metabase.models.collection :as collection]


### PR DESCRIPTION
These fields hold JSON, which can contain field IDs in a few places.

Particularly nasty is the `:column_settings` subfield, which is a map
whose *keys* are JSON strings with field IDs.

