### PR TITLE
Backport a block of Serdes v2 changes, fixing embedded MBQL

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -1,5 +1,6 @@
 (ns metabase-enterprise.serialization.v2.extract-test
-  (:require [clojure.test :refer :all]
+  (:require [cheshire.core :as json]
+            [clojure.test :refer :all]
             [metabase-enterprise.serialization.test-util :as ts]
             [metabase-enterprise.serialization.v2.extract :as extract]
             [metabase.models :refer [Card Collection Dashboard DashboardCard Database Dimension Field Metric
@@ -98,52 +99,123 @@
 
                        Database   [{db-id      :id}           {:name "My Database"}]
                        Table      [{no-schema-id :id}         {:name "Schemaless Table" :db_id db-id}]
+                       Field      [{field-id     :id}         {:name "Some Field" :table_id no-schema-id}]
                        Table      [{schema-id    :id}         {:name        "Schema'd Table"
                                                                :db_id       db-id
                                                                :schema      "PUBLIC"}]
+                       Field      [{field2-id    :id}         {:name "Other Field" :table_id schema-id}]
                        Card       [{c1-id  :id
                                     c1-eid :entity_id}        {:name          "Some Question"
                                                                :database_id   db-id
                                                                :table_id      no-schema-id
                                                                :collection_id coll-id
                                                                :creator_id    mark-id
-                                                               :dataset_query "{\"json\": \"string values\"}"}]
+                                                               :dataset_query
+                                                               (json/generate-string
+                                                                 {:query {:source-table no-schema-id
+                                                                          :filter [:>= [:field field-id nil] 18]
+                                                                          :aggregation [[:count]]}
+                                                                  :database db-id})}]
                        Card       [{c2-id  :id
                                     c2-eid :entity_id}        {:name          "Second Question"
                                                                :database_id   db-id
                                                                :table_id      schema-id
                                                                :collection_id coll-id
-                                                               :creator_id    mark-id}]
+                                                               :creator_id    mark-id
+                                                               :parameter_mappings
+                                                               [{:parameter_id "deadbeef"
+                                                                 :card_id      c1-id
+                                                                 :target [:dimension [:field field-id
+                                                                                      {:source-field field2-id}]]}]}]
+                       Card       [{c3-id  :id
+                                    c3-eid :entity_id}        {:name          "Third Question"
+                                                               :database_id   db-id
+                                                               :table_id      schema-id
+                                                               :collection_id coll-id
+                                                               :creator_id    mark-id
+                                                               :visualization_settings
+                                                               {:table.pivot_column "SOURCE"
+                                                                :table.cell_column "sum"
+                                                                :table.columns
+                                                                [{:name "SOME_FIELD"
+                                                                  :fieldRef [:field field-id nil]
+                                                                  :enabled true}
+                                                                 {:name "OTHER_FIELD"
+                                                                  :fieldRef [:field field2-id nil]
+                                                                  :enabled true}
+                                                                 {:name "sum"
+                                                                  :fieldRef [:field "sum" {:base-type :type/Float}]
+                                                                  :enabled true}
+                                                                 {:name "count"
+                                                                  :fieldRef [:field "count" {:base-type :type/BigInteger}]
+                                                                  :enabled true}
+                                                                 {:name "Average order total"
+                                                                  :fieldRef [:field "Average order total" {:base-type :type/Float}]
+                                                                  :enabled true}]
+                                                                :column_settings
+                                                                {(str "[\"ref\",[\"field\"," field2-id ",null]]") {:column_title "Locus"}}}}]
                        Dashboard  [{dash-id  :id
                                     dash-eid :entity_id}      {:name          "Shared Dashboard"
                                                                :collection_id coll-id
                                                                :creator_id    mark-id
                                                                :parameters    []}]
                        Dashboard  [{other-dash-id :id
-                                    other-dash :entity_id}    {:name          "Dave's Dash"
+                                    other-dash    :entity_id} {:name          "Dave's Dash"
                                                                :collection_id dave-coll-id
                                                                :creator_id    mark-id
                                                                :parameters    []}]
-                       DashboardCard [{dc1-eid :entity_id}    {:card_id      c1-id
-                                                               :dashboard_id dash-id}]
-                       DashboardCard [{dc2-eid :entity_id}    {:card_id      c2-id
-                                                               :dashboard_id other-dash-id}]]
+                       DashboardCard [{dc1-id  :id
+                                       dc1-eid :entity_id}    {:card_id      c1-id
+                                                               :dashboard_id dash-id
+                                                               :parameter_mappings
+                                                               [{:parameter_id "12345678"
+                                                                 :card_id      c1-id
+                                                                 :target [:dimension [:field field-id
+                                                                                      {:source-field field2-id}]]}]}]
+                       DashboardCard [{dc2-id  :id
+                                       dc2-eid :entity_id}    {:card_id      c2-id
+                                                               :dashboard_id other-dash-id
+                                                               :visualization_settings
+                                                               {:table.pivot_column "SOURCE"
+                                                                :table.cell_column "sum"
+                                                                :table.columns
+                                                                [{:name "SOME_FIELD"
+                                                                  :fieldRef [:field field-id nil]
+                                                                  :enabled true}
+                                                                 {:name "sum"
+                                                                  :fieldRef [:field "sum" {:base-type :type/Float}]
+                                                                  :enabled true}
+                                                                 {:name "count"
+                                                                  :fieldRef [:field "count" {:base-type :type/BigInteger}]
+                                                                  :enabled true}
+                                                                 {:name "Average order total"
+                                                                  :fieldRef [:field "Average order total" {:base-type :type/Float}]
+                                                                  :enabled true}]
+                                                                :column_settings
+                                                                {(str "[\"ref\",[\"field\"," field2-id ",null]]") {:column_title "Locus"}}}}]]
       (testing "table and database are extracted as [db schema table] triples"
         (let [ser (serdes.base/extract-one "Card" {} (select-one "Card" [:= :id c1-id]))]
           (is (schema= {:serdes/meta                 (s/eq [{:model "Card" :id c1-eid}])
                         :table_id                    (s/eq ["My Database" nil "Schemaless Table"])
                         :creator_id                  (s/eq "mark@direstrai.ts")
                         :collection_id               (s/eq coll-eid)
-                        :dataset_query               (s/eq "{\"json\": \"string values\"}")
+                        :dataset_query               (s/eq {:query {:source-table ["My Database" nil "Schemaless Table"]
+                                                                    :filter [">=" [:field ["My Database" nil "Schemaless Table" "Some Field"] nil] 18]
+                                                                    :aggregation [[:count]]}
+                                                            :database "My Database"})
                         :created_at                  LocalDateTime
                         (s/optional-key :updated_at) LocalDateTime
                         s/Keyword                    s/Any}
                        ser))
           (is (not (contains? ser :id)))
 
-          (testing "cards depend on their Table and Collection"
-            (is (= #{[{:model "Database"   :id "My Database"}
+          (testing "cards depend on their Table and Collection, and also anything referenced in the query"
+            (is (= #{[{:model "Database"   :id "My Database"}]
+                     [{:model "Database"   :id "My Database"}
                       {:model "Table"      :id "Schemaless Table"}]
+                     [{:model "Database"   :id "My Database"}
+                      {:model "Table"      :id "Schemaless Table"}
+                      {:model "Field"      :id "Some Field"}]
                      [{:model "Collection" :id coll-eid}]}
                    (set (serdes.base/serdes-dependencies ser))))))
 
@@ -152,18 +224,138 @@
                         :table_id                    (s/eq ["My Database" "PUBLIC" "Schema'd Table"])
                         :creator_id                  (s/eq "mark@direstrai.ts")
                         :collection_id               (s/eq coll-eid)
-                        :dataset_query               (s/eq "{}") ; Undecoded, still a string.
+                        :dataset_query               (s/eq {})
+                        :parameter_mappings          (s/eq [{:parameter_id "deadbeef"
+                                                             :card_id      c1-eid
+                                                             :target [:dimension [:field ["My Database" nil "Schemaless Table" "Some Field"]
+                                                                                  {:source-field ["My Database" "PUBLIC" "Schema'd Table" "Other Field"]}]]}])
                         :created_at                  LocalDateTime
                         (s/optional-key :updated_at) LocalDateTime
                         s/Keyword      s/Any}
                        ser))
           (is (not (contains? ser :id)))
 
-          (testing "cards depend on their Table and Collection"
+          (testing "cards depend on their Table and Collection, and any fields in their parameter_mappings"
             (is (= #{[{:model "Database"   :id "My Database"}
                       {:model "Schema"     :id "PUBLIC"}
                       {:model "Table"      :id "Schema'd Table"}]
-                     [{:model "Collection" :id coll-eid}]}
+                     [{:model "Collection" :id coll-eid}]
+                     [{:model "Database"   :id "My Database"}
+                      {:model "Table"      :id "Schemaless Table"}
+                      {:model "Field"      :id "Some Field"}]
+                     [{:model "Database"   :id "My Database"}
+                      {:model "Schema"     :id "PUBLIC"}
+                      {:model "Table"      :id "Schema'd Table"}
+                      {:model "Field"      :id "Other Field"}]}
+                   (set (serdes.base/serdes-dependencies ser))))))
+
+        (let [ser (serdes.base/extract-one "Card" {} (select-one "Card" [:= :id c3-id]))]
+          (is (schema= {:serdes/meta                 (s/eq [{:model "Card" :id c3-eid}])
+                        :table_id                    (s/eq ["My Database" "PUBLIC" "Schema'd Table"])
+                        :creator_id                  (s/eq "mark@direstrai.ts")
+                        :collection_id               (s/eq coll-eid)
+                        :dataset_query               (s/eq {})
+                        :visualization_settings
+                        (s/eq {:table.pivot_column "SOURCE"
+                               :table.cell_column "sum"
+                               :table.columns
+                               [{:name "SOME_FIELD"
+                                 :fieldRef ["field" ["My Database" nil "Schemaless Table" "Some Field"] nil]
+                                 :enabled true}
+                                {:name "OTHER_FIELD"
+                                 :fieldRef ["field" ["My Database" "PUBLIC" "Schema'd Table" "Other Field"] nil]
+                                 :enabled true}
+                                {:name "sum"
+                                 :fieldRef ["field" "sum" {:base-type "type/Float"}]
+                                 :enabled true}
+                                {:name "count"
+                                 :fieldRef ["field" "count" {:base-type "type/BigInteger"}]
+                                 :enabled true}
+                                {:name "Average order total"
+                                 :fieldRef ["field" "Average order total" {:base-type "type/Float"}]
+                                 :enabled true}]
+                               :column_settings
+                               {"[\"ref\",[\"field\",[\"My Database\",\"PUBLIC\",\"Schema'd Table\",\"Other Field\"],null]]" {:column_title "Locus"}}})
+                        :created_at                  LocalDateTime
+                        (s/optional-key :updated_at) LocalDateTime
+                        s/Keyword      s/Any}
+                       ser))
+          (is (not (contains? ser :id)))
+
+          (testing "cards depend on their Table and Collection, and any fields in their visualization_settings"
+            (is (= #{[{:model "Database"   :id "My Database"}
+                      {:model "Schema"     :id "PUBLIC"}
+                      {:model "Table"      :id "Schema'd Table"}]
+                     [{:model "Collection" :id coll-eid}]
+                     [{:model "Database"   :id "My Database"}
+                      {:model "Table"      :id "Schemaless Table"}
+                      {:model "Field"      :id "Some Field"}]
+                     [{:model "Database"   :id "My Database"}
+                      {:model "Schema"     :id "PUBLIC"}
+                      {:model "Table"      :id "Schema'd Table"}
+                      {:model "Field"      :id "Other Field"}]}
+                   (set (serdes.base/serdes-dependencies ser))))))
+
+        (let [ser (serdes.base/extract-one "DashboardCard" {} (select-one "DashboardCard" [:= :id dc1-id]))]
+          (is (schema= {:serdes/meta                 (s/eq [{:model "Dashboard" :id dash-eid}
+                                                            {:model "DashboardCard" :id dc1-eid}])
+                        :dashboard_id                (s/eq dash-eid)
+                        :parameter_mappings          (s/eq [{:parameter_id "12345678"
+                                                             :card_id      c1-eid
+                                                             :target [:dimension [:field ["My Database" nil "Schemaless Table" "Some Field"]
+                                                                                  {:source-field ["My Database" "PUBLIC" "Schema'd Table" "Other Field"]}]]}])
+                        s/Keyword      s/Any}
+                       ser))
+          (is (not (contains? ser :id)))
+
+          (testing "cards depend on their Dashboard and Card, and any fields in their parameter_mappings"
+            (is (= #{[{:model "Card"       :id c1-eid}]
+                     [{:model "Dashboard"  :id dash-eid}]
+                     [{:model "Database"   :id "My Database"}
+                      {:model "Table"      :id "Schemaless Table"}
+                      {:model "Field"      :id "Some Field"}]
+                     [{:model "Database"   :id "My Database"}
+                      {:model "Schema"     :id "PUBLIC"}
+                      {:model "Table"      :id "Schema'd Table"}
+                      {:model "Field"      :id "Other Field"}]}
+                   (set (serdes.base/serdes-dependencies ser)))))))
+
+      (testing "Dashcard :visualization_settings are included in their deps"
+        (let [ser (serdes.base/extract-one "DashboardCard" {} (select-one "DashboardCard" [:= :id dc2-id]))]
+          (is (schema= {:serdes/meta            (s/eq [{:model "Dashboard" :id other-dash}
+                                                       {:model "DashboardCard" :id dc2-eid}])
+                        :dashboard_id           (s/eq other-dash)
+                        :visualization_settings (s/eq {:table.pivot_column "SOURCE"
+                                                       :table.cell_column "sum"
+                                                       :table.columns
+                                                       [{:name "SOME_FIELD"
+                                                         :fieldRef ["field" ["My Database" nil "Schemaless Table" "Some Field"] nil]
+                                                         :enabled true}
+                                                        {:name "sum"
+                                                         :fieldRef ["field" "sum" {:base-type "type/Float"}]
+                                                         :enabled true}
+                                                        {:name "count"
+                                                         :fieldRef ["field" "count" {:base-type "type/BigInteger"}]
+                                                         :enabled true}
+                                                        {:name "Average order total"
+                                                         :fieldRef ["field" "Average order total" {:base-type "type/Float"}]
+                                                         :enabled true}]
+                                                       :column_settings
+                                                       {"[\"ref\",[\"field\",[\"My Database\",\"PUBLIC\",\"Schema'd Table\",\"Other Field\"],null]]" {:column_title "Locus"}}})
+                        s/Keyword      s/Any}
+                       ser))
+          (is (not (contains? ser :id)))
+
+          (testing "DashboardCard depend on their Dashboard and Card, and any fields in their visualization_settings"
+            (is (= #{[{:model "Card"       :id c2-eid}]
+                     [{:model "Dashboard"  :id other-dash}]
+                     [{:model "Database"   :id "My Database"}
+                      {:model "Table"      :id "Schemaless Table"}
+                      {:model "Field"      :id "Some Field"}]
+                     [{:model "Database"   :id "My Database"}
+                      {:model "Schema"     :id "PUBLIC"}
+                      {:model "Table"      :id "Schema'd Table"}
+                      {:model "Field"      :id "Other Field"}]}
                    (set (serdes.base/serdes-dependencies ser)))))))
 
       (testing "collection filtering based on :user option"
@@ -265,24 +457,35 @@
                                                               :email      "ann@heart.band"}]
                        Database   [{db-id        :id}        {:name "My Database"}]
                        Table      [{no-schema-id :id}        {:name "Schemaless Table" :db_id db-id}]
+                       Field      [{field-id     :id}        {:name "Some Field" :table_id no-schema-id}]
                        Metric     [{m1-id        :id
                                     m1-eid       :entity_id} {:name       "My Metric"
                                                               :creator_id ann-id
-                                                              :table_id   no-schema-id}]]
+                                                              :table_id   no-schema-id
+                                                              :definition
+                                                              {:source-table no-schema-id
+                                                               :aggregation [[:sum [:field field-id nil]]]}}]]
       (testing "metrics"
         (let [ser (serdes.base/extract-one "Metric" {} (select-one "Metric" [:= :id m1-id]))]
           (is (schema= {:serdes/meta                 (s/eq [{:model "Metric" :id m1-eid :label "My Metric"}])
                         :table_id                    (s/eq ["My Database" nil "Schemaless Table"])
                         :creator_id                  (s/eq "ann@heart.band")
+                        :definition                  (s/eq {:source-table ["My Database" nil "Schemaless Table"]
+                                                            :aggregation
+                                                            [[:sum [:field ["My Database" nil
+                                                                            "Schemaless Table" "Some Field"] nil]]]})
                         :created_at                  LocalDateTime
                         (s/optional-key :updated_at) LocalDateTime
                         s/Keyword                    s/Any}
                        ser))
           (is (not (contains? ser :id)))
 
-          (testing "depend on the Table"
+          (testing "depend on the Table and any fields referenced in :definition"
             (is (= #{[{:model "Database"   :id "My Database"}
-                      {:model "Table"      :id "Schemaless Table"}]}
+                      {:model "Table"      :id "Schemaless Table"}]
+                     [{:model "Database"   :id "My Database"}
+                      {:model "Table"      :id "Schemaless Table"}
+                      {:model "Field"      :id "Some Field"}]}
                    (set (serdes.base/serdes-dependencies ser))))))))))
 
 (deftest native-query-snippets-test
@@ -414,24 +617,36 @@
                                                               :email      "ann@heart.band"}]
                        Database   [{db-id        :id}        {:name "My Database"}]
                        Table      [{no-schema-id :id}        {:name "Schemaless Table" :db_id db-id}]
+                       Field      [{field-id     :id}        {:name "Some Field" :table_id no-schema-id}]
                        Segment    [{s1-id        :id
                                     s1-eid       :entity_id} {:name       "My Segment"
                                                               :creator_id ann-id
-                                                              :table_id   no-schema-id}]]
+                                                              :table_id   no-schema-id
+                                                              :definition {:source-table no-schema-id
+                                                                           :aggregation [[:count]]
+                                                                           :filter [:< [:field field-id nil] 18]}}]]
       (testing "segment"
         (let [ser (serdes.base/extract-one "Segment" {} (select-one "Segment" [:= :id s1-id]))]
           (is (schema= {:serdes/meta                 (s/eq [{:model "Segment" :id s1-eid :label "My Segment"}])
                         :table_id                    (s/eq ["My Database" nil "Schemaless Table"])
                         :creator_id                  (s/eq "ann@heart.band")
                         :created_at                  LocalDateTime
+                        :definition                  (s/eq {:source-table ["My Database" nil "Schemaless Table"]
+                                                            :aggregation [[:count]]
+                                                            :filter ["<" [:field ["My Database" nil
+                                                                                 "Schemaless Table" "Some Field"]
+                                                                         nil] 18]})
                         (s/optional-key :updated_at) LocalDateTime
                         s/Keyword                    s/Any}
                        ser))
           (is (not (contains? ser :id)))
 
-          (testing "depend on the Table"
+          (testing "depend on the Table and any fields from the definition"
             (is (= #{[{:model "Database"   :id "My Database"}
-                      {:model "Table"      :id "Schemaless Table"}]}
+                      {:model "Table"      :id "Schemaless Table"}]
+                     [{:model "Database"   :id "My Database"}
+                      {:model "Table"      :id "Schemaless Table"}
+                      {:model "Field"      :id "Some Field"}]}
                    (set (serdes.base/serdes-dependencies ser))))))))))
 
 (deftest pulses-test

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -4,7 +4,8 @@
             [metabase-enterprise.serialization.v2.extract :as serdes.extract]
             [metabase-enterprise.serialization.v2.ingest :as serdes.ingest]
             [metabase-enterprise.serialization.v2.load :as serdes.load]
-            [metabase.models :refer [Collection Database Pulse PulseChannel PulseChannelRecipient Table User]]
+            [metabase.models :refer [Card Collection Dashboard DashboardCard Database Field Metric Pulse PulseChannel
+                                     PulseChannelRecipient Segment Table User]]
             [metabase.models.serialization.base :as serdes.base]
             [metabase.models.serialization.hash :as serdes.hash]
             [toucan.db :as db]))
@@ -254,3 +255,407 @@
             (is (= 3 (db/count PulseChannelRecipient)))
             (is (= #{(:id @u1d) (:id @u2d) (:id @u3d)}
                    (db/select-field :user_id PulseChannelRecipient)))))))))
+
+(deftest card-dataset-query-test
+  ;; Card.dataset_query is a JSON-encoded MBQL query, which contain database, table, and field IDs - these need to be
+  ;; converted to a portable form and read back in.
+  ;; This test has a database, table and fields, that exist on both sides with different IDs, and expects a card that
+  ;; references those fields to be correctly loaded with the dest IDs.
+  (testing "embedded MBQL in Card :dataset-query is portable"
+    (let [serialized (atom nil)
+          coll1s     (atom nil)
+          db1s       (atom nil)
+          table1s    (atom nil)
+          field1s    (atom nil)
+          card1s     (atom nil)
+          user1s     (atom nil)
+          db1d       (atom nil)
+          table1d    (atom nil)
+          field1d    (atom nil)
+          user1d     (atom nil)
+          card1d     (atom nil)
+          db2d       (atom nil)
+          table2d    (atom nil)
+          field2d    (atom nil)]
+
+
+      (ts/with-source-and-dest-dbs
+        (testing "serializing the original database, table, field and card"
+          (ts/with-source-db
+            (reset! coll1s  (ts/create! Collection :name "pop! minis"))
+            (reset! db1s    (ts/create! Database :name "my-db"))
+            (reset! table1s (ts/create! Table :name "customers" :db_id (:id @db1s)))
+            (reset! field1s (ts/create! Field :name "age"    :table_id (:id @table1s)))
+            (reset! user1s  (ts/create! User  :first_name "Tom" :last_name "Scholz" :email "tom@bost.on"))
+            (reset! card1s  (ts/create! Card
+                                        :database_id   (:id @db1s)
+                                        :table_id      (:id @table1s)
+                                        :collection_id (:id @coll1s)
+                                        :creator_id    (:id @user1s)
+                                        :query_type    :query
+                                        :name          "Example Card"
+                                        :dataset_query {:type     :query
+                                                        :query    {:source-table (:id @table1s)
+                                                                   :filter       [:>= [:field (:id @field1s) nil] 18]
+                                                                   :aggregation  [[:count]]}
+                                                        :database (:id @db1s)}
+                                        :display        :line))
+            (reset! serialized (into [] (serdes.extract/extract-metabase {})))))
+
+        (testing "the serialized form is as desired"
+          (is (= {:type "query"
+                  :query {:source-table ["my-db" nil "customers"]
+                          :filter       [">=" [:field ["my-db" nil "customers" "age"] nil] 18]
+                          :aggregation  [[:count]]}
+                  :database "my-db"}
+                 (->> (by-model @serialized "Card")
+                      first
+                      :dataset_query))))
+
+        (testing "deserializing adjusts the IDs properly"
+          (ts/with-dest-db
+            ;; A different database and tables, so the IDs don't match.
+            (reset! db2d    (ts/create! Database :name "other-db"))
+            (reset! table2d (ts/create! Table    :name "orders" :db_id (:id @db2d)))
+            (reset! field2d (ts/create! Field    :name "subtotal" :table_id (:id @table2d)))
+            (reset! user1d  (ts/create! User  :first_name "Tom" :last_name "Scholz" :email "tom@bost.on"))
+
+            ;; Load the serialized content.
+            (serdes.load/load-metabase (ingestion-in-memory @serialized))
+
+            ;; Fetch the relevant bits
+            (reset! db1d    (db/select-one Database :name "my-db"))
+            (reset! table1d (db/select-one Table :name "customers"))
+            (reset! field1d (db/select-one Field :table_id (:id @table1d) :name "age"))
+            (reset! card1d  (db/select-one Card  :name "Example Card"))
+
+            (testing "the main Database, Table, and Field have different IDs now"
+              (is (not= (:id @db1s) (:id @db1d)))
+              (is (not= (:id @table1s) (:id @table1d)))
+              (is (not= (:id @field1s) (:id @field1d))))
+
+            (is (not= (:dataset_query @card1s)
+                      (:dataset_query @card1d)))
+            (testing "the Card's query is based on the new Database, Table, and Field IDs"
+              (is (= {:type     :query
+                      :query    {:source-table (:id @table1d)
+                                 :filter       [:>= [:field (:id @field1d) nil] 18]
+                                 :aggregation  [[:count]]}
+                      :database (:id @db1d)}
+                     (:dataset_query @card1d))))))))))
+
+(deftest segment-test
+  ;; Segment.definition is a JSON-encoded MBQL query, which contain database, table, and field IDs - these need to be
+  ;; converted to a portable form and read back in.
+  ;; This test has a database, table and fields, that exist on both sides with different IDs, and expects a segment that
+  ;; references those fields to be correctly loaded with the dest IDs.
+  (testing "embedded MBQL in Segment :definition is portable"
+    (let [serialized (atom nil)
+          coll1s     (atom nil)
+          db1s       (atom nil)
+          table1s    (atom nil)
+          field1s    (atom nil)
+          seg1s      (atom nil)
+          user1s     (atom nil)
+          db1d       (atom nil)
+          table1d    (atom nil)
+          field1d    (atom nil)
+          user1d     (atom nil)
+          seg1d      (atom nil)
+          db2d       (atom nil)
+          table2d    (atom nil)
+          field2d    (atom nil)]
+
+
+      (ts/with-source-and-dest-dbs
+        (testing "serializing the original database, table, field and card"
+          (ts/with-source-db
+            (reset! coll1s  (ts/create! Collection :name "pop! minis"))
+            (reset! db1s    (ts/create! Database :name "my-db"))
+            (reset! table1s (ts/create! Table :name "customers" :db_id (:id @db1s)))
+            (reset! field1s (ts/create! Field :name "age"    :table_id (:id @table1s)))
+            (reset! user1s  (ts/create! User  :first_name "Tom" :last_name "Scholz" :email "tom@bost.on"))
+            (reset! seg1s   (ts/create! Segment :table_id (:id @table1s) :name "Minors"
+                                        :definition {:source-table (:id @table1s)
+                                                     :aggregation [[:count]]
+                                                     :filter [:< [:field (:id @field1s) nil] 18]}
+                                        :creator_id (:id @user1s)))
+            (reset! serialized (into [] (serdes.extract/extract-metabase {})))))
+
+        (testing "exported form is properly converted"
+          (is (= {:source-table ["my-db" nil "customers"]
+                  :aggregation [[:count]]
+                  :filter ["<" [:field ["my-db" nil "customers" "age"] nil] 18]}
+                 (-> @serialized
+                     (by-model "Segment")
+                     first
+                     :definition))))
+
+        (testing "deserializing adjusts the IDs properly"
+          (ts/with-dest-db
+            ;; A different database and tables, so the IDs don't match.
+            (reset! db2d    (ts/create! Database :name "other-db"))
+            (reset! table2d (ts/create! Table    :name "orders" :db_id (:id @db2d)))
+            (reset! field2d (ts/create! Field    :name "subtotal" :table_id (:id @table2d)))
+            (reset! user1d  (ts/create! User  :first_name "Tom" :last_name "Scholz" :email "tom@bost.on"))
+
+            ;; Load the serialized content.
+            (serdes.load/load-metabase (ingestion-in-memory @serialized))
+
+            ;; Fetch the relevant bits
+            (reset! db1d    (db/select-one Database :name "my-db"))
+            (reset! table1d (db/select-one Table :name "customers"))
+            (reset! field1d (db/select-one Field :table_id (:id @table1d) :name "age"))
+            (reset! seg1d   (db/select-one Segment :name "Minors"))
+
+            (testing "the main Database, Table, and Field have different IDs now"
+              (is (not= (:id @db1s) (:id @db1d)))
+              (is (not= (:id @table1s) (:id @table1d)))
+              (is (not= (:id @field1s) (:id @field1d))))
+
+            (is (not= (:definition @seg1s)
+                      (:definition @seg1d)))
+            (testing "the Segment's definition is based on the new Database, Table, and Field IDs"
+              (is (= {:source-table (:id @table1d)
+                      :filter       [:< [:field (:id @field1d) nil] 18]
+                      :aggregation  [[:count]]}
+                     (:definition @seg1d))))))))))
+
+(deftest metric-test
+  ;; Metric.definition is a JSON-encoded MBQL query, which contain database, table, and field IDs - these need to be
+  ;; converted to a portable form and read back in.
+  ;; This test has a database, table and fields, that exist on both sides with different IDs, and expects a metric
+  ;; to be correctly loaded with the dest IDs.
+  (testing "embedded MBQL in Metric :definition is portable"
+    (let [serialized (atom nil)
+          coll1s     (atom nil)
+          db1s       (atom nil)
+          table1s    (atom nil)
+          field1s    (atom nil)
+          metric1s   (atom nil)
+          user1s     (atom nil)
+          db1d       (atom nil)
+          table1d    (atom nil)
+          field1d    (atom nil)
+          user1d     (atom nil)
+          metric1d   (atom nil)
+          db2d       (atom nil)
+          table2d    (atom nil)
+          field2d    (atom nil)]
+
+
+      (ts/with-source-and-dest-dbs
+        (testing "serializing the original database, table, field and card"
+          (ts/with-source-db
+            (reset! coll1s   (ts/create! Collection :name "pop! minis"))
+            (reset! db1s     (ts/create! Database :name "my-db"))
+            (reset! table1s  (ts/create! Table :name "orders" :db_id (:id @db1s)))
+            (reset! field1s  (ts/create! Field :name "subtotal"    :table_id (:id @table1s)))
+            (reset! user1s   (ts/create! User  :first_name "Tom" :last_name "Scholz" :email "tom@bost.on"))
+            (reset! metric1s (ts/create! Metric :table_id (:id @table1s) :name "Revenue"
+                                         :definition {:source-table (:id @table1s)
+                                                      :aggregation [[:sum [:field (:id @field1s) nil]]]}
+                                         :creator_id (:id @user1s)))
+            (reset! serialized (into [] (serdes.extract/extract-metabase {})))))
+
+        (testing "exported form is properly converted"
+          (is (= {:source-table ["my-db" nil "orders"]
+                  :aggregation [[:sum [:field ["my-db" nil "orders" "subtotal"] nil]]]}
+                 (-> @serialized
+                     (by-model "Metric")
+                     first
+                     :definition))))
+
+        (testing "deserializing adjusts the IDs properly"
+          (ts/with-dest-db
+            ;; A different database and tables, so the IDs don't match.
+            (reset! db2d    (ts/create! Database :name "other-db"))
+            (reset! table2d (ts/create! Table    :name "customers" :db_id (:id @db2d)))
+            (reset! field2d (ts/create! Field    :name "age" :table_id (:id @table2d)))
+            (reset! user1d  (ts/create! User  :first_name "Tom" :last_name "Scholz" :email "tom@bost.on"))
+
+            ;; Load the serialized content.
+            (serdes.load/load-metabase (ingestion-in-memory @serialized))
+
+            ;; Fetch the relevant bits
+            (reset! db1d     (db/select-one Database :name "my-db"))
+            (reset! table1d  (db/select-one Table :name "orders"))
+            (reset! field1d  (db/select-one Field :table_id (:id @table1d) :name "subtotal"))
+            (reset! metric1d (db/select-one Metric :name "Revenue"))
+
+            (testing "the main Database, Table, and Field have different IDs now"
+              (is (not= (:id @db1s) (:id @db1d)))
+              (is (not= (:id @table1s) (:id @table1d)))
+              (is (not= (:id @field1s) (:id @field1d))))
+
+            (is (not= (:definition @metric1s)
+                      (:definition @metric1d)))
+            (testing "the Metric's definition is based on the new Database, Table, and Field IDs"
+              (is (= {:source-table (:id @table1d)
+                      :aggregation  [[:sum [:field (:id @field1d) nil]]]}
+                     (:definition @metric1d))))))))))
+
+(deftest dashboard-card-test
+  ;; DashboardCard.parameter_mappings and Card.parameter_mappings are JSON-encoded lists of parameter maps, which
+  ;; contain field IDs - these need to be converted to a portable form and read back in.
+  ;; This test has a database, table and fields, that exist on both sides with different IDs, and expects a Card and
+  ;; DashboardCard to be correctly loaded with the dest IDs.
+  (testing "parameter_mappings are portable"
+    (let [serialized (atom nil)
+          coll1s     (atom nil)
+          db1s       (atom nil)
+          table1s    (atom nil)
+          field1s    (atom nil)
+          field2s    (atom nil)
+          dash1s     (atom nil)
+          card1s     (atom nil)
+          dashcard1s (atom nil)
+          user1s     (atom nil)
+          db1d       (atom nil)
+          table1d    (atom nil)
+          field1d    (atom nil)
+          field2d    (atom nil)
+          user1d     (atom nil)
+          dash1d     (atom nil)
+          card1d     (atom nil)
+          dashcard1d (atom nil)
+          db2d       (atom nil)
+          table2d    (atom nil)
+          field3d    (atom nil)]
+
+
+      (ts/with-source-and-dest-dbs
+        (testing "serializing the original database, table, field and card"
+          (ts/with-source-db
+            (reset! coll1s   (ts/create! Collection :name "pop! minis"))
+            (reset! db1s     (ts/create! Database :name "my-db"))
+            (reset! table1s  (ts/create! Table :name "orders" :db_id (:id @db1s)))
+            (reset! field1s  (ts/create! Field :name "subtotal" :table_id (:id @table1s)))
+            (reset! field2s  (ts/create! Field :name "invoice" :table_id (:id @table1s)))
+            (reset! user1s   (ts/create! User  :first_name "Tom" :last_name "Scholz" :email "tom@bost.on"))
+            (reset! dash1s   (ts/create! Dashboard :name "My Dashboard" :collection_id (:id @coll1s) :creator_id (:id @user1s)))
+            (reset! card1s   (ts/create! Card :name "The Card" :database_id (:id @db1s) :table_id (:id @table1s)
+                                         :collection_id (:id @coll1s) :creator_id (:id @user1s)
+                                         :visualization_settings
+                                         {:table.pivot_column "SOURCE"
+                                          :table.cell_column "sum"
+                                          :table.columns
+                                          [{:name "SOME_FIELD"
+                                            :fieldRef [:field (:id @field1s) nil]
+                                            :enabled true}
+                                           {:name "sum"
+                                            :fieldRef [:field "sum" {:base-type :type/Float}]
+                                            :enabled true}
+                                           {:name "count"
+                                            :fieldRef [:field "count" {:base-type :type/BigInteger}]
+                                            :enabled true}
+                                           {:name "Average order total"
+                                            :fieldRef [:field "Average order total" {:base-type :type/Float}]
+                                            :enabled true}]
+                                          :column_settings
+                                          {(str "[\"ref\",[\"field\"," (:id @field2s) ",null]]") {:column_title "Locus"}}}
+                                         :parameter_mappings [{:parameter_id "12345678"
+                                                               :target [:dimension [:field (:id @field1s) {:source-field (:id @field2s)}]]}]))
+            (reset! dashcard1s (ts/create! DashboardCard :dashboard_id (:id @dash1s) :card_id (:id @card1s)
+                                           :visualization_settings
+                                           {:table.pivot_column "SOURCE"
+                                            :table.cell_column "sum"
+                                            :table.columns
+                                            [{:name "SOME_FIELD"
+                                              :fieldRef [:field (:id @field1s) nil]
+                                              :enabled true}
+                                             {:name "sum"
+                                              :fieldRef [:field "sum" {:base-type :type/Float}]
+                                              :enabled true}
+                                             {:name "count"
+                                              :fieldRef [:field "count" {:base-type :type/BigInteger}]
+                                              :enabled true}
+                                             {:name "Average order total"
+                                              :fieldRef [:field "Average order total" {:base-type :type/Float}]
+                                              :enabled true}]
+                                            :column_settings
+                                            {(str "[\"ref\",[\"field\"," (:id @field2s) ",null]]") {:column_title "Locus"}}}
+                                           :parameter_mappings [{:parameter_id "deadbeef"
+                                                                 :card_id (:id @card1s)
+                                                                 :target [:dimension [:field (:id @field1s) {:source-field (:id @field2s)}]]}]))
+
+            (reset! serialized (into [] (serdes.extract/extract-metabase {})))
+            (let [card     (-> @serialized (by-model "Card") first)
+                  dashcard (-> @serialized (by-model "DashboardCard") first)]
+              (testing "exported :parameter_mappings are properly converted"
+                (is (= [{:parameter_id "12345678"
+                         :target [:dimension [:field ["my-db" nil "orders" "subtotal"]
+                                              {:source-field ["my-db" nil "orders" "invoice"]}]]}]
+                       (:parameter_mappings card)))
+                (is (= [{:parameter_id "deadbeef"
+                         :card_id (:entity_id @card1s)
+                         :target [:dimension [:field ["my-db" nil "orders" "subtotal"]
+                                              {:source-field ["my-db" nil "orders" "invoice"]}]]}]
+                       (:parameter_mappings dashcard))))
+
+              (testing "exported :visualization_settings are properly converted"
+                (let [expected {:table.pivot_column "SOURCE"
+                                :table.cell_column "sum"
+                                :table.columns
+                                [{:name "SOME_FIELD"
+                                  :fieldRef ["field" ["my-db" nil "orders" "subtotal"] nil]
+                                  :enabled true}
+                                 {:name "sum"
+                                  :fieldRef ["field" "sum" {:base-type "type/Float"}]
+                                  :enabled true}
+                                 {:name "count"
+                                  :fieldRef ["field" "count" {:base-type "type/BigInteger"}]
+                                  :enabled true}
+                                 {:name "Average order total"
+                                  :fieldRef ["field" "Average order total" {:base-type "type/Float"}]
+                                  :enabled true}]
+                                :column_settings
+                                {"[\"ref\",[\"field\",[\"my-db\",null,\"orders\",\"invoice\"],null]]" {:column_title "Locus"}}}]
+                  (is (= expected
+                         (:visualization_settings card)))
+                  (is (= expected
+                         (:visualization_settings dashcard))))))))
+
+
+
+        (testing "deserializing adjusts the IDs properly"
+          (ts/with-dest-db
+            ;; A different database and tables, so the IDs don't match.
+            (reset! db2d    (ts/create! Database :name "other-db"))
+            (reset! table2d (ts/create! Table    :name "customers" :db_id (:id @db2d)))
+            (reset! field3d (ts/create! Field    :name "age" :table_id (:id @table2d)))
+            (ts/create! Field :name "name" :table_id (:id @table2d))
+            (ts/create! Field :name "address" :table_id (:id @table2d))
+            (reset! user1d  (ts/create! User  :first_name "Tom" :last_name "Scholz" :email "tom@bost.on"))
+
+            ;; Load the serialized content.
+            (serdes.load/load-metabase (ingestion-in-memory @serialized))
+
+            ;; Fetch the relevant bits
+            (reset! db1d       (db/select-one Database :name "my-db"))
+            (reset! table1d    (db/select-one Table :name "orders"))
+            (reset! field1d    (db/select-one Field :table_id (:id @table1d) :name "subtotal"))
+            (reset! field2d    (db/select-one Field :table_id (:id @table1d) :name "invoice"))
+            (reset! dash1d     (db/select-one Dashboard :name "My Dashboard"))
+            (reset! card1d     (db/select-one Card :name "The Card"))
+            (reset! dashcard1d (db/select-one DashboardCard :card_id (:id @card1d) :dashboard_id (:id @dash1d)))
+
+            (testing "the main Database, Table, and Field have different IDs now"
+              (is (not= (:id @db1s) (:id @db1d)))
+              (is (not= (:id @table1s) (:id @table1d)))
+              (is (not= (:id @field1s) (:id @field1d)))
+              (is (not= (:id @field2s) (:id @field2d))))
+
+            (is (not= (:parameter_mappings @dashcard1s)
+                      (:parameter_mappings @dashcard1d)))
+            (is (not= (:parameter_mappings @card1s)
+                      (:parameter_mappings @card1d)))
+            (testing "Card.parameter_mappings are based on the new Field IDs"
+              (is (= [{:parameter_id "12345678"
+                       :target       [:dimension [:field (:id @field1d) {:source-field (:id @field2d)}]]}]
+                     (:parameter_mappings @card1d))))
+            (testing "DashboardCard.parameter_mappings are based on the new Field IDs"
+              (is (= [{:parameter_id "deadbeef"
+                       :card_id      (:id @card1d)
+                       :target       [:dimension [:field (:id @field1d) {:source-field (:id @field2d)}]]}]
+                     (:parameter_mappings @dashcard1d))))))))))

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -348,22 +348,34 @@
   ;; :collection_id is extracted as its entity_id or identity-hash.
   ;; :creator_id as the user's email.
   (-> (serdes.base/extract-one-basics "Card" card)
-      (update :database_id   serdes.util/export-fk-keyed 'Database :name)
-      (update :table_id      serdes.util/export-table-fk)
-      (update :collection_id serdes.util/export-fk 'Collection)
-      (update :creator_id    serdes.util/export-fk-keyed 'User :email)))
+      (update :database_id            serdes.util/export-fk-keyed 'Database :name)
+      (update :table_id               serdes.util/export-table-fk)
+      (update :collection_id          serdes.util/export-fk 'Collection)
+      (update :creator_id             serdes.util/export-fk-keyed 'User :email)
+      (update :dataset_query          serdes.util/export-json-mbql)
+      (update :parameter_mappings     serdes.util/export-parameter-mappings)
+      (update :visualization_settings serdes.util/export-visualization-settings)
+      (dissoc :result_metadata))) ; Not portable, and can be rebuilt on the other side.
 
 (defmethod serdes.base/load-xform "Card"
   [card]
   (-> card
       serdes.base/load-xform-basics
-      (update :database_id   serdes.util/import-fk-keyed 'Database :name)
-      (update :table_id      serdes.util/import-table-fk)
-      (update :creator_id    serdes.util/import-fk-keyed 'User :email)
-      (update :collection_id serdes.util/import-fk 'Collection)))
+      (update :database_id            serdes.util/import-fk-keyed 'Database :name)
+      (update :table_id               serdes.util/import-table-fk)
+      (update :creator_id             serdes.util/import-fk-keyed 'User :email)
+      (update :collection_id          serdes.util/import-fk 'Collection)
+      (update :dataset_query          serdes.util/import-json-mbql)
+      (update :parameter_mappings     serdes.util/import-parameter-mappings)
+      (update :visualization_settings serdes.util/import-visualization-settings)))
 
 (defmethod serdes.base/serdes-dependencies "Card"
-  [{:keys [collection_id table_id]}]
+  [{:keys [collection_id dataset_query parameter_mappings table_id visualization_settings]}]
   ;; The Table implicitly depends on the Database.
-  [(serdes.util/table->path table_id)
-   [{:model "Collection" :id collection_id}]])
+  (->> (map serdes.util/mbql-deps parameter_mappings)
+       (reduce set/union)
+       (set/union #{(serdes.util/table->path table_id)
+                    [{:model "Collection" :id collection_id}]})
+       (set/union (serdes.util/mbql-deps dataset_query))
+       (set/union (serdes.util/visualization-settings-deps visualization_settings))
+       vec))

--- a/src/metabase/models/dashboard_card.clj
+++ b/src/metabase/models/dashboard_card.clj
@@ -219,9 +219,13 @@
                    [:or [:= :coll.personal_owner_id user] [:is :coll.personal_owner_id nil]]
                    [:is :coll.personal_owner_id nil])}))
 
-(defmethod serdes.base/serdes-dependencies "DashboardCard" [{:keys [card_id dashboard_id]}]
-  [[{:model "Dashboard" :id dashboard_id}]
-   [{:model "Card"      :id card_id}]])
+(defmethod serdes.base/serdes-dependencies "DashboardCard"
+  [{:keys [card_id dashboard_id parameter_mappings visualization_settings]}]
+  (->> (mapcat serdes.util/mbql-deps parameter_mappings)
+       (concat (serdes.util/visualization-settings-deps visualization_settings))
+       (concat #{[{:model "Dashboard" :id dashboard_id}]
+                 [{:model "Card"      :id card_id}]})
+       set))
 
 (defmethod serdes.base/serdes-generate-path "DashboardCard" [_ dashcard]
   [(serdes.base/infer-self-path "Dashboard" (db/select-one 'Dashboard :id (:dashboard_id dashcard)))
@@ -230,11 +234,15 @@
 (defmethod serdes.base/extract-one "DashboardCard"
   [_model-name _opts dashcard]
   (-> (serdes.base/extract-one-basics "DashboardCard" dashcard)
-      (update :card_id      serdes.util/export-fk 'Card)
-      (update :dashboard_id serdes.util/export-fk 'Dashboard)))
+      (update :card_id                serdes.util/export-fk 'Card)
+      (update :dashboard_id           serdes.util/export-fk 'Dashboard)
+      (update :parameter_mappings     serdes.util/export-parameter-mappings)
+      (update :visualization_settings serdes.util/export-visualization-settings)))
 
 (defmethod serdes.base/load-xform "DashboardCard"
   [dashcard]
   (-> (serdes.base/load-xform-basics dashcard)
-      (update :card_id      serdes.util/import-fk 'Card)
-      (update :dashboard_id serdes.util/import-fk 'Dashboard)))
+      (update :card_id                serdes.util/import-fk 'Card)
+      (update :dashboard_id           serdes.util/import-fk 'Dashboard)
+      (update :parameter_mappings     serdes.util/import-parameter-mappings)
+      (update :visualization_settings serdes.util/import-visualization-settings)))

--- a/src/metabase/models/metric.clj
+++ b/src/metabase/models/metric.clj
@@ -2,7 +2,8 @@
   "A Metric is a saved MBQL 'macro' expanding to a combination of `:aggregation` and/or `:filter` clauses.
   It is passed in as an `:aggregation` clause but is replaced by the `expand-macros` middleware with the appropriate
   clauses."
-  (:require [medley.core :as m]
+  (:require [clojure.set :as set]
+            [medley.core :as m]
             [metabase.mbql.util :as mbql.u]
             [metabase.models.dependency :as dependency :refer [Dependency]]
             [metabase.models.interface :as mi]
@@ -108,16 +109,19 @@
   [_model-name _opts metric]
   (-> (serdes.base/extract-one-basics "Metric" metric)
       (update :table_id   serdes.util/export-table-fk)
-      (update :creator_id serdes.util/export-fk-keyed 'User :email)))
+      (update :creator_id serdes.util/export-fk-keyed 'User :email)
+      (update :definition serdes.util/export-json-mbql)))
 
 (defmethod serdes.base/load-xform "Metric" [metric]
   (-> metric
       serdes.base/load-xform-basics
       (update :table_id   serdes.util/import-table-fk)
-      (update :creator_id serdes.util/import-fk-keyed 'User :email)))
+      (update :creator_id serdes.util/import-fk-keyed 'User :email)
+      (update :definition serdes.util/import-json-mbql)))
 
-(defmethod serdes.base/serdes-dependencies "Metric" [{:keys [table_id]}]
-  [(serdes.util/table->path table_id)])
+(defmethod serdes.base/serdes-dependencies "Metric" [{:keys [definition table_id]}]
+  (into [] (set/union #{(serdes.util/table->path table_id)}
+                      (serdes.util/mbql-deps definition))))
 
 ;;; ----------------------------------------------------- OTHER ------------------------------------------------------
 

--- a/src/metabase/models/serialization/util.clj
+++ b/src/metabase/models/serialization/util.clj
@@ -2,7 +2,16 @@
   "Helpers intended to be shared by various models.
   Most of these are common operations done while (de)serializing several models, like handling a foreign key on a Table
   or user."
-  (:require [metabase.models.serialization.base :as serdes.base]
+  (:require [cheshire.core :as json]
+            [clojure.core.match :refer [match]]
+            [clojure.set :as set]
+            [clojure.string :as str]
+            [medley.core :as m]
+            [metabase.mbql.normalize :as mbql.normalize]
+            [metabase.mbql.schema :as mbql.s]
+            [metabase.mbql.util :as mbql.u]
+            [metabase.models.serialization.base :as serdes.base]
+            [metabase.shared.models.visualization-settings :as mb.viz]
             [toucan.db :as db]
             [toucan.models :as models]))
 
@@ -12,11 +21,12 @@
   or identity hash.
   Unusual parameter order means this can be used as `(update x :some_id export-fk 'SomeModel)`."
   [id model]
-  (let [model-name (name model)
-        model      (db/resolve-model (symbol model-name))
-        entity     (db/select-one model (models/primary-key model) id)
-        {eid :id}  (serdes.base/infer-self-path model-name entity)]
-    eid))
+  (when id
+    (let [model-name (name model)
+          model      (db/resolve-model (symbol model-name))
+          entity     (db/select-one model (models/primary-key model) id)
+          {eid :id}  (serdes.base/infer-self-path model-name entity)]
+      eid)))
 
 (defn import-fk
   "Given an entity ID or identity hash, and the model it represents (symbol, name or IModel), looks up the corresponding
@@ -26,13 +36,14 @@
 
   Unusual parameter order means this can be used as `(update x :some_id import-fk 'SomeModel)`."
   [eid model]
-  (let [model-name (name model)
-        model      (db/resolve-model (symbol model-name))
-        entity     (serdes.base/lookup-by-id model eid)]
-    (if entity
-      (get entity (models/primary-key model))
-      (throw (ex-info "Could not find foreign key target - bad serdes-dependencies or other serialization error"
-                      {:entity_id eid :model (name model)})))))
+  (when eid
+    (let [model-name (name model)
+          model      (db/resolve-model (symbol model-name))
+          entity     (serdes.base/lookup-by-id model eid)]
+      (if entity
+        (get entity (models/primary-key model))
+        (throw (ex-info "Could not find foreign key target - bad serdes-dependencies or other serialization error"
+                        {:entity_id eid :model (name model)}))))))
 
 (defn export-fk-keyed
   "Given a numeric ID, look up a different identifying field for that entity, and return it as a portable ID.
@@ -66,7 +77,7 @@
 (defn import-table-fk
   "Given a `table_id` as exported by [[export-table-fk]], resolve it back into a numeric `table_id`."
   [[db-name schema table-name]]
-  (db/select-one-field :id 'Table :name table-name :schema schema :db_id (db/select-one-id 'Database :name db-name)))
+  (db/select-one-field :id 'Table :name table-name :schema schema :db_id (db/select-one-field :id 'Database :name db-name)))
 
 (defn table->path
   "Given a `table_id` as exported by [[export-table-fk]], turn it into a `[{:model ...}]` path for the Table.
@@ -100,3 +111,263 @@
                   (when schema {:model "Schema" :id schema})
                   {:model "Table" :id table-name}
                   {:model "Field" :id field-name}]))
+
+;; ---------------------------------------------- JSON-encoded MBQL --------------------------------------------------
+(defn- mbql-entity-reference?
+  "Is given form an MBQL entity reference?"
+  [form]
+  (mbql.normalize/is-clause? #{:field :field-id :fk-> :dimension :metric :segment} form))
+
+(defn- mbql-id->fully-qualified-name
+  [mbql]
+  (-> mbql
+      mbql.normalize/normalize-tokens
+      (mbql.u/replace
+        ;; `integer?` guard is here to make the operation idempotent
+        [:field (id :guard integer?) opts]
+        [:field (export-field-fk id) (mbql-id->fully-qualified-name opts)]
+
+        ;; `integer?` guard is here to make the operation idempotent
+        [:field (id :guard integer?)]
+        [:field (export-field-fk id)]
+
+        ;; field-id is still used within parameter mapping dimensions
+        ;; example relevant clause - [:dimension [:fk-> [:field-id 1] [:field-id 2]]]
+        [:field-id (id :guard integer?)]
+        [:field-id (export-field-fk id)]
+
+        {:source-table (id :guard integer?)}
+        (assoc &match :source-table (export-table-fk id))
+
+        ;; source-field is also used within parameter mapping dimensions
+        ;; example relevant clause - [:field 2 {:source-field 1}]
+        {:source-field (id :guard integer?)}
+        (assoc &match :source-field (export-field-fk id))
+
+        [:dimension (dim :guard vector?)]
+        [:dimension (mbql-id->fully-qualified-name dim)]
+
+        [:metric (id :guard integer?)]
+        [:metric (export-fk id 'Metric)]
+
+        [:segment (id :guard integer?)]
+        [:segment (export-fk id 'Segment)])))
+
+(defn- ids->fully-qualified-names
+  [entity]
+  (mbql.u/replace entity
+    mbql-entity-reference?
+    (mbql-id->fully-qualified-name &match)
+
+    map?
+    (as-> &match entity
+      (m/update-existing entity :database (fn [db-id]
+                                            (if (= db-id mbql.s/saved-questions-virtual-database-id)
+                                              "database/__virtual"
+                                              (db/select-one-field :name 'Database :id db-id))))
+      (m/update-existing entity :card_id #(export-fk % 'Card)) ; attibutes that refer to db fields use _
+      (m/update-existing entity :card-id #(export-fk % 'Card)) ; template-tags use dash
+      (m/update-existing entity :source-table (fn [source-table]
+                                                (if (and (string? source-table)
+                                                         (str/starts-with? source-table "card__"))
+                                                  (export-fk (-> source-table
+                                                                 (str/split #"__")
+                                                                 second
+                                                                 Integer/parseInt)
+                                                             'Card)
+                                                  (export-table-fk source-table))))
+      (m/update-existing entity :breakout (fn [breakout]
+                                            (map mbql-id->fully-qualified-name breakout)))
+      (m/update-existing entity :aggregation (fn [aggregation]
+                                               (m/map-vals mbql-id->fully-qualified-name aggregation)))
+      (m/update-existing entity :filter (fn [filter]
+                                          (m/map-vals mbql-id->fully-qualified-name filter)))
+      (m/update-existing entity ::mb.viz/param-mapping-source export-field-fk)
+      (m/update-existing entity :snippet-id export-fk 'NativeQuerySnippet)
+      (m/map-vals ids->fully-qualified-names entity))))
+
+(defn export-json-mbql
+  "Given a JSON string with an MBQL expression inside it, convert it to an EDN structure and turn the non-portable
+  Database, Table and Field IDs inside it into portable references. Returns it as an EDN structure, which is more
+  human-fiendly in YAML."
+  [encoded]
+  (-> encoded
+      (json/parse-string true)
+      ids->fully-qualified-names))
+
+(defn- mbql-fully-qualified-names->ids*
+  [entity]
+  (mbql.u/replace entity
+    ;; handle legacy `:field-id` forms encoded prior to 0.39.0
+    ;; and also *current* expresion forms used in parameter mapping dimensions
+    ;; example relevant clause - [:dimension [:fk-> [:field-id 1] [:field-id 2]]]
+    [:field-id (fully-qualified-name :guard string?)]
+    (mbql-fully-qualified-names->ids* [:field fully-qualified-name nil])
+
+    [:field (fully-qualified-name :guard vector?) opts]
+    [:field (import-field-fk fully-qualified-name) (mbql-fully-qualified-names->ids* opts)]
+
+    ;; source-field is also used within parameter mapping dimensions
+    ;; example relevant clause - [:field 2 {:source-field 1}]
+    {:source-field (fully-qualified-name :guard vector?)}
+    (assoc &match :source-field (import-field-fk fully-qualified-name))
+
+    {:database (fully-qualified-name :guard string?)}
+    (-> &match
+        (assoc :database (db/select-one-id 'Database :name fully-qualified-name))
+        mbql-fully-qualified-names->ids*) ; Process other keys
+
+    [:metric (fully-qualified-name :guard serdes.base/entity-id?)]
+    [:metric (import-fk fully-qualified-name 'Metric)]
+
+    [:segment (fully-qualified-name :guard serdes.base/entity-id?)]
+    [:segment (import-fk fully-qualified-name 'Segment)]
+
+    (_ :guard (every-pred map? #(vector? (:source-table %))))
+    (-> &match
+        (assoc :source-table (import-table-fk (:source-table &match)))
+        mbql-fully-qualified-names->ids*))) ;; process other keys
+
+(defn- mbql-fully-qualified-names->ids
+  [entity]
+  (mbql-fully-qualified-names->ids* entity))
+
+(defn import-json-mbql
+  "Given an MBQL expression as an EDN structure with portable IDs embedded, convert the IDs back to raw numeric IDs
+  and then convert the result back into a JSON string."
+  [exported]
+  (-> exported
+      mbql-fully-qualified-names->ids
+      json/generate-string))
+
+
+(declare ^:private mbql-deps-map)
+
+(defn- mbql-deps-vector [entity]
+  (match entity
+         [:field     (field :guard vector?) tail] (into #{(field->path field)} (mbql-deps-map tail))
+         ["field"    (field :guard vector?) tail] (into #{(field->path field)} (mbql-deps-map tail))
+         [:field-id  (field :guard vector?) tail] (into #{(field->path field)} (mbql-deps-map tail))
+         ["field-id" (field :guard vector?) tail] (into #{(field->path field)} (mbql-deps-map tail))
+         :else (reduce #(cond
+                          (map? %2)    (into %1 (mbql-deps-map %2))
+                          (vector? %2) (into %1 (mbql-deps-vector %2))
+                          :else %1)
+                       #{}
+                       entity)))
+
+(defn- mbql-deps-map [entity]
+  (->> (for [[k v] entity]
+         (cond
+           (and (= k :database)     (string? v)) #{[{:model "Database" :id v}]}
+           (and (= k :source-table) (vector? v)) #{(table->path v)}
+           (and (= k :source-field) (vector? v)) #{(field->path v)}
+           (map? v)                              (mbql-deps-map v)
+           (vector? v)                           (mbql-deps-vector v)))
+       (reduce set/union #{})))
+
+(defn mbql-deps
+  "Given an MBQL expression as exported, with qualified names like `[\"some-db\" \"schema\" \"table_name\"]` instead of
+  raw IDs, return the corresponding set of serdes-dependencies. The query can't be imported until all the referenced
+  databases, tables and fields are loaded."
+  [entity]
+  (cond
+    (map? entity)     (mbql-deps-map entity)
+    (seqable? entity) (mbql-deps-vector entity)
+    :else             (mbql-deps-vector [entity])))
+
+(defn export-parameter-mappings
+  "Given the :parameter_mappings field of a `Card` or `DashboardCard`, as a JSON-encoded list of objects, converts
+  it to a portable form with the field IDs replaced with `[db schema table field]` references."
+  [mappings]
+  (->> (json/parse-string mappings true)
+       (map ids->fully-qualified-names)))
+
+(defn import-parameter-mappings
+  "Given the :parameter_mappings field as exported by serialization convert its field references
+  (`[db schema table field]`) back into raw IDs, and encode it back into JSON."
+  [mappings]
+  (->> mappings
+       (map mbql-fully-qualified-names->ids)
+       (map #(m/update-existing % :card_id import-fk 'Card))
+       json/generate-string))
+
+(defn- export-visualizations [entity]
+  (mbql.u/replace
+    entity
+    ["field-id" (id :guard number?) tail]
+    ["field-id" (export-field-fk id) (export-visualizations tail)]
+
+    ["field" (id :guard number?) tail]
+    ["field" (export-field-fk id) (export-visualizations tail)]
+
+    (_ :guard map?)
+    (m/map-vals export-visualizations &match)
+
+    (_ :guard vector?)
+    (mapv export-visualizations &match)))
+
+(defn- export-column-settings
+  "Column settings use a JSON-encoded string as a map key, and it contains field numbers.
+  This function parses those keys, converts the IDs to portable values, and serializes them back to JSON."
+  [settings]
+  (when settings
+    (update-keys settings #(-> % json/parse-string export-visualizations json/generate-string))))
+
+(defn export-visualization-settings
+  "Given a JSON string encoding the visualization settings for a `Card` or `DashboardCard`, transform it to EDN and
+  convert all field-ids to portable `[db schema table field]` form."
+  [settings]
+  (when settings
+    (-> settings
+        (json/parse-string (fn [k] (if (re-matches #"^[a-zA-Z0-9_\.\-]+$" k)
+                                     (keyword k)
+                                     k)))
+        export-visualizations
+        (update :column_settings export-column-settings))))
+
+(defn- import-visualizations [entity]
+  (mbql.u/replace
+    entity
+    [:field-id (fully-qualified-name :guard vector?) tail]
+    [:field-id (import-field-fk fully-qualified-name) (import-visualizations tail)]
+
+    ["field-id" (fully-qualified-name :guard vector?) tail]
+    ["field-id" (import-field-fk fully-qualified-name) (import-visualizations tail)]
+
+    [:field (fully-qualified-name :guard vector?) tail]
+    [:field (import-field-fk fully-qualified-name) (import-visualizations tail)]
+
+    ["field" (fully-qualified-name :guard vector?) tail]
+    ["field" (import-field-fk fully-qualified-name) (import-visualizations tail)]
+
+    (_ :guard map?)
+    (m/map-vals import-visualizations &match)
+
+    (_ :guard vector?)
+    (mapv import-visualizations &match)))
+
+(defn- import-column-settings [settings]
+  (when settings
+    (update-keys settings #(-> % json/parse-string import-visualizations json/generate-string))))
+
+(defn import-visualization-settings
+  "Given an EDN value as exported by [[export-visualization-settings]], convert its portable `[db schema table field]`
+  references into Field IDs and serialize back to JSON."
+  [settings]
+  (when settings
+    (-> settings
+        import-visualizations
+        (update :column_settings import-column-settings)
+        json/generate-string)))
+
+(defn visualization-settings-deps
+  "Given the :visualization_settings (possibly nil) for an entity, return any embedded serdes-deps as a set.
+  Always returns an empty set even if the input is nil."
+  [viz]
+  (let [vis-column-settings (some->> viz
+                                     :column_settings
+                                     keys
+                                     (map (comp mbql-deps json/parse-string)))]
+    (reduce set/union (cons (mbql-deps viz)
+                            vis-column-settings))))

--- a/test/metabase/test/generate.clj
+++ b/test/metabase/test/generate.clj
@@ -281,6 +281,11 @@
 
 (def ^:private unique-name (mbql.u/unique-name-generator))
 
+(defn- unique-email [email]
+  (let [at (.indexOf email "@")]
+    (str (unique-name (subs email 0 at))
+         (subs email at))))
+
 (def ^:private field-positions (atom {:table-fields {}}))
 (defn- adjust
   "Some fields have to be semantically correct, or db correct. fields have position, and they do have to be unique.
@@ -295,12 +300,24 @@
            (-> (swap! field-positions update-in [:table-fields (:table_id visit-val)] (fnil inc 0))
                (get-in [:table-fields (:table_id visit-val)])))
 
+    ;; Users' emails need to be unique. This enforces it, and appends junk to before the @ if needed.
+    (= ent-type :core_user)
+    (update :email unique-email)
+
+    ;; Database names need to be unique. This enforces it, and appends junk to names if needed.
+    (= ent-type :database)
+    (update :name unique-name)
+
     ;; Table names need to be unique within their database. This enforces it, and appends junk to names if needed.
     (= ent-type :table)
     (update :name unique-name)
 
     ;; Field names need to be unique within their table. This enforces it, and appends junk to names if needed.
     (= ent-type :field)
+    (update :name unique-name)
+
+    ;; Native Query Snippet names need to be unique. This enforces it, and appends junk to names if needed.
+    (= ent-type :native-query-snippet)
     (update :name unique-name)
 
     ;; [Field ID, Dimension name] pairs need to be unique. This enforces it, and appends junk to names if needed.


### PR DESCRIPTION
Many fields in appdb hold encoded JSON, which hold MBQL fragments, which often
contain raw `Database`, `Table` and `Field` IDs.

That issue was discovered late in the release cycle, unfortunately.

These changes properly serialize these MBQL-embedded-in-JSON fields and
deserialize them again.

- Deflake the Serdes v2 e2e test by ensuring generated inputs are unique (#24320)
- Serdes v2: Handle `Card.dataset_query`, an embedded MBQL snippet (#24356)
- Serdes v2: Handle other embedded MBQL fragments (#24537)
- Serdes v2: Portable `:visualization_settings` fields on (dash)cards. (#24606)
