### PR TITLE
Fix in-memory logger

### DIFF
--- a/build.clj
+++ b/build.clj
@@ -69,7 +69,8 @@
         ns-symbols (set (map ns.parse/name-from-ns-decl ns-decls))]
     (->> (dependencies-graph ns-decls)
          ns.deps/topo-sort
-         (filter ns-symbols))))
+         (filter ns-symbols)
+         (cons 'metabase.bootstrap))))
 
 (defn compile-sources! [basis]
   (u/step "Compile Clojure source files"
@@ -104,7 +105,7 @@
    "Multi-Release"    "true"
    "Created-By"       "Metabase build.clj"
    "Build-Jdk-Spec"   (System/getProperty "java.specification.version")
-   "Main-Class"       "metabase.core"})
+   "Main-Class"       "metabase.bootstrap"})
 
 (defn manifest ^Manifest []
   (doto (Manifest.)

--- a/deps.edn
+++ b/deps.edn
@@ -4,110 +4,110 @@
  ;; !!                                   PLEASE KEEP THESE ORGANIZED ALPHABETICALLY                                  !!
  ;; !!                                   AND ADD A COMMENT EXPLAINING THEIR PURPOSE                                  !!
  ;; !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
- {amalloy/ring-buffer                       {:mvn/version "1.3.1" ; fixed length queue implementation, used in log buffering
+ {amalloy/ring-buffer                       {:mvn/version "1.3.1"               ; fixed length queue implementation, used in log buffering
                                              :exclusions  [org.clojure/clojure
                                                            org.clojure/clojurescript]}
-  amalloy/ring-gzip-middleware              {:mvn/version "0.1.4"} ; Ring middleware to GZIP responses if client can handle it
-  bigml/histogram                           {:mvn/version "4.1.4"} ; Histogram data structure
+  amalloy/ring-gzip-middleware              {:mvn/version "0.1.4"}              ; Ring middleware to GZIP responses if client can handle it
+  bigml/histogram                           {:mvn/version "4.1.4"}              ; Histogram data structure
   buddy/buddy-core                          {:mvn/version "1.10.413"            ; various cryptographic functions
                                              :exclusions  [commons-codec/commons-codec
                                                            org.bouncycastle/bcpkix-jdk15on
                                                            org.bouncycastle/bcprov-jdk15on]}
-  buddy/buddy-sign                          {:mvn/version "3.4.333"} ; JSON Web Tokens; High-Level message signing library
-  cheshire/cheshire                         {:mvn/version "5.10.2"} ; fast JSON encoding (used by Ring JSON middleware)
-  clj-http/clj-http                         {:mvn/version "3.12.3"  ; HTTP client
+  buddy/buddy-sign                          {:mvn/version "3.4.333"}            ; JSON Web Tokens; High-Level message signing library
+  cheshire/cheshire                         {:mvn/version "5.10.2"}             ; fast JSON encoding (used by Ring JSON middleware)
+  clj-http/clj-http                         {:mvn/version "3.12.3"              ; HTTP client
                                              :exclusions  [commons-codec/commons-codec
                                                            commons-io/commons-io
                                                            slingshot/slingshot]}
   clojurewerkz/quartzite                    {:mvn/version "2.1.0"               ; scheduling library
                                              :exclusions  [c3p0/c3p0
                                                            org.quartz-scheduler/quartz]}
-  colorize/colorize                         {:mvn/version "0.1.1"  ; string output with ANSI color codes (for logging)
+  colorize/colorize                         {:mvn/version "0.1.1"               ; string output with ANSI color codes (for logging)
                                              :exclusions  [org.clojure/clojure]}
   com.clearspring.analytics/stream          {:mvn/version "2.9.8"               ; Various sketching algorithms
                                              :exclusions  [it.unimi.dsi/fastutil
                                                            org.slf4j/slf4j-api]}
   com.draines/postal                        {:mvn/version "2.0.5"}              ; SMTP library
-  com.google.guava/guava                    {:mvn/version "31.0.1-jre"} ; dep for BigQuery, Spark, and GA. Require here rather than letting different dep versions stomp on each other — see comments on #9697
+  com.google.guava/guava                    {:mvn/version "31.0.1-jre"}         ; dep for BigQuery, Spark, and GA. Require here rather than letting different dep versions stomp on each other — see comments on #9697
   com.fasterxml.jackson.core/jackson-databind
-  {:mvn/version "2.13.2.2"}      ; JSON processor used by snowplow-java-tracker (pinned version due to CVE-2020-36518)
+                                            {:mvn/version "2.13.2.2"}           ; JSON processor used by snowplow-java-tracker (pinned version due to CVE-2020-36518)
   com.h2database/h2                         {:mvn/version "1.4.197"}            ; embedded SQL database
   com.snowplowanalytics/snowplow-java-tracker
-  {:mvn/version "0.12.0"                                                        ; Snowplow analytics
-   :exclusions [com.fasterxml.jackson.core/jackson-databind]}
-  com.taoensso/nippy                        {:mvn/version "3.1.1"} ; Fast serialization (i.e., GZIP) library for Clojure
+                                            {:mvn/version "0.12.0"              ; Snowplow analytics
+                                             :exclusions [com.fasterxml.jackson.core/jackson-databind]}
+  com.taoensso/nippy                        {:mvn/version "3.1.1"}              ; Fast serialization (i.e., GZIP) library for Clojure
   com.vladsch.flexmark/flexmark             {:mvn/version "0.64.0"}             ; Markdown parsing
   com.vladsch.flexmark/flexmark-ext-autolink
-  {:mvn/version "0.64.0"}                                              ; Flexmark extension for auto-linking bare URLs
-  commons-codec/commons-codec               {:mvn/version "1.15"}      ; Apache Commons -- useful codec util fns
-  commons-io/commons-io                     {:mvn/version "2.11.0"}    ; Apache Commons -- useful IO util fns
-  commons-validator/commons-validator       {:mvn/version "1.7"        ; Apache Commons -- useful validation util fns
+                                            {:mvn/version "0.64.0"}             ; Flexmark extension for auto-linking bare URLs
+  commons-codec/commons-codec               {:mvn/version "1.15"}               ; Apache Commons -- useful codec util fns
+  commons-io/commons-io                     {:mvn/version "2.11.0"}             ; Apache Commons -- useful IO util fns
+  commons-validator/commons-validator       {:mvn/version "1.7"                 ; Apache Commons -- useful validation util fns
                                              :exclusions  [commons-beanutils/commons-beanutils
                                                            commons-digester/commons-digester
                                                            commons-logging/commons-logging]}
   compojure/compojure                       {:mvn/version "1.6.2"               ; HTTP Routing library built on Ring
                                              :exclusions  [ring/ring-codec]}
-  crypto-random/crypto-random               {:mvn/version "1.2.1"} ; library for generating cryptographically secure random bytes and strings
-  dk.ative/docjure                          {:mvn/version "1.17.0" ; excel export
+  crypto-random/crypto-random               {:mvn/version "1.2.1"}              ; library for generating cryptographically secure random bytes and strings
+  dk.ative/docjure                          {:mvn/version "1.17.0"              ; excel export
                                              :exclusions  [org.apache.poi/poi
                                                            org.apache.poi/poi-ooxml]}
-  environ/environ                           {:mvn/version "1.2.0"}          ; env vars/Java properties abstraction
-  hiccup/hiccup                             {:mvn/version "1.0.5"}          ; HTML templating
-  honeysql/honeysql                         {:mvn/version "1.0.461"         ; Transform Clojure data structures to SQL
+  environ/environ                           {:mvn/version "1.2.0"}              ; env vars/Java properties abstraction
+  hiccup/hiccup                             {:mvn/version "1.0.5"}              ; HTML templating
+  honeysql/honeysql                         {:mvn/version "1.0.461"             ; Transform Clojure data structures to SQL
                                              :exclusions  [org.clojure/clojurescript]}
   instaparse/instaparse                     {:mvn/version "1.4.12"}             ; Make your own parser
-  io.forward/yaml                           {:mvn/version "1.0.11" ; Clojure wrapper for YAML library SnakeYAML. Don't upgrade yet, new version doesn't support Java 8 (see https://github.com/owainlewis/yaml/issues/37)
+  io.forward/yaml                           {:mvn/version "1.0.11"              ; Clojure wrapper for YAML library SnakeYAML. Don't upgrade yet, new version doesn't support Java 8 (see https://github.com/owainlewis/yaml/issues/37)
                                              :exclusions  [org.clojure/clojure
                                                            org.flatland/ordered
                                                            org.yaml/snakeyaml]}
   io.github.resilience4j/resilience4j-retry {:mvn/version "1.7.1"}              ; Support for retrying operations
   joda-time/joda-time                       {:mvn/version "2.10.13"}
-  kixi/stats                                {:mvn/version "0.4.4" ; Various statistic measures implemented as transducers
+  kixi/stats                                {:mvn/version "0.4.4"               ; Various statistic measures implemented as transducers
                                              :exclusions  [org.clojure/data.avl]}
   me.raynes/fs                              {:mvn/version "1.4.6"               ; Filesystem tools
                                              :exclusions  [org.apache.commons/commons-compress]}
-  medley/medley                             {:mvn/version "1.4.0"} ; lightweight lib of useful functions
-  metabase/connection-pool                  {:mvn/version "1.2.0"} ; simple wrapper around C3P0. JDBC connection pools
-  metabase/saml20-clj                       {:mvn/version "2.0.2"} ; EE SAML integration
-  metabase/throttle                         {:mvn/version "1.0.2"} ; Tools for throttling access to API endpoints and other code pathways
-  nano-id/nano-id                           {:mvn/version "1.0.0"} ; NanoID generator for generating entity_ids
-  net.cgrand/macrovich                      {:mvn/version "0.2.1"} ; utils for writing macros for both Clojure & ClojureScript
-  net.i2p.crypto/eddsa                      {:mvn/version "0.3.0"} ; ED25519 key support (optional dependency for org.apache.sshd/sshd-core)
-  net.redhogs.cronparser/cron-parser-core   {:mvn/version "3.5"    ; describe Cron schedule in human-readable language
-                                             :exclusions  [joda-time/joda-time ; exclude joda time 2.3 which has outdated timezone information
+  medley/medley                             {:mvn/version "1.4.0"}              ; lightweight lib of useful functions
+  metabase/connection-pool                  {:mvn/version "1.2.0"}              ; simple wrapper around C3P0. JDBC connection pools
+  metabase/saml20-clj                       {:mvn/version "2.0.2"}              ; EE SAML integration
+  metabase/throttle                         {:mvn/version "1.0.2"}              ; Tools for throttling access to API endpoints and other code pathways
+  nano-id/nano-id                           {:mvn/version "1.0.0"}              ; NanoID generator for generating entity_ids
+  net.cgrand/macrovich                      {:mvn/version "0.2.1"}              ; utils for writing macros for both Clojure & ClojureScript
+  net.i2p.crypto/eddsa                      {:mvn/version "0.3.0"}              ; ED25519 key support (optional dependency for org.apache.sshd/sshd-core)
+  net.redhogs.cronparser/cron-parser-core   {:mvn/version "3.5"                 ; describe Cron schedule in human-readable language
+                                             :exclusions  [joda-time/joda-time  ; exclude joda time 2.3 which has outdated timezone information
                                                            org.slf4j/slf4j-api]}
   net.sf.cssbox/cssbox                      {:mvn/version "5.0.0"               ; HTML / CSS rendering
                                              :exclusions  [org.slf4j/slf4j-api]}
-  org.apache.commons/commons-compress       {:mvn/version "1.21"}    ; compression utils
-  org.apache.commons/commons-lang3          {:mvn/version "3.12.0"}  ; helper methods for working with java.lang stuff
-  org.apache.logging.log4j/log4j-1.2-api    {:mvn/version "2.18.0"}  ; apache logging framework
-  org.apache.logging.log4j/log4j-api        {:mvn/version "2.18.0"}  ; add compatibility with log4j 1.2
-  org.apache.logging.log4j/log4j-core       {:mvn/version "2.18.0"}  ; apache logging framework
-  org.apache.logging.log4j/log4j-jcl        {:mvn/version "2.18.0"} ; allows the commons-logging API to work with log4j 2
-  org.apache.logging.log4j/log4j-jul        {:mvn/version "2.18.0"} ; java.util.logging (JUL) -> Log4j2 adapter
-  org.apache.logging.log4j/log4j-slf4j-impl {:mvn/version "2.18.0"} ; allows the slf4j API to work with log4j 2
-  org.apache.poi/poi                        {:mvn/version "5.2.2"} ; Work with Office documents (e.g. Excel spreadsheets) -- newer version than one specified by Docjure
+  org.apache.commons/commons-compress       {:mvn/version "1.21"}               ; compression utils
+  org.apache.commons/commons-lang3          {:mvn/version "3.12.0"}             ; helper methods for working with java.lang stuff
+  org.apache.logging.log4j/log4j-1.2-api    {:mvn/version "2.18.0"}             ; apache logging framework
+  org.apache.logging.log4j/log4j-api        {:mvn/version "2.18.0"}             ; add compatibility with log4j 1.2
+  org.apache.logging.log4j/log4j-core       {:mvn/version "2.18.0"}             ; apache logging framework
+  org.apache.logging.log4j/log4j-jcl        {:mvn/version "2.18.0"}             ; allows the commons-logging API to work with log4j 2
+  org.apache.logging.log4j/log4j-jul        {:mvn/version "2.18.0"}             ; java.util.logging (JUL) -> Log4j2 adapter
+  org.apache.logging.log4j/log4j-slf4j-impl {:mvn/version "2.18.0"}             ; allows the slf4j API to work with log4j 2
+  org.apache.poi/poi                        {:mvn/version "5.2.2"}              ; Work with Office documents (e.g. Excel spreadsheets) -- newer version than one specified by Docjure
   org.apache.poi/poi-ooxml                  {:mvn/version "5.2.2"
                                              :exclusions  [org.bouncycastle/bcpkix-jdk15on
                                                            org.bouncycastle/bcprov-jdk15on]}
   org.apache.sshd/sshd-core                 {:mvn/version "2.9.0"}              ; ssh tunneling and test server
   org.apache.xmlgraphics/batik-all          {:mvn/version "1.14"}               ; SVG -> image
   org.clojars.pntblnk/clj-ldap              {:mvn/version "0.0.17"}             ; LDAP client
-  org.bouncycastle/bcpkix-jdk15on           {:mvn/version "1.70"} ; Bouncy Castle crypto library -- explicit version of BC specified to resolve illegal reflective access errors
+  org.bouncycastle/bcpkix-jdk15on           {:mvn/version "1.70"}               ; Bouncy Castle crypto library -- explicit version of BC specified to resolve illegal reflective access errors
   org.bouncycastle/bcprov-jdk15on           {:mvn/version "1.70"}
   org.clojure/clojure                       {:mvn/version "1.11.1"}
   org.clojure/core.async                    {:mvn/version "1.5.648"
                                              :exclusions  [org.clojure/tools.reader]}
-  org.clojure/core.logic                    {:mvn/version "1.0.1"}    ; optimized pattern matching library for Clojure
+  org.clojure/core.logic                    {:mvn/version "1.0.1"}              ; optimized pattern matching library for Clojure
   org.clojure/core.match                    {:mvn/version "1.0.0"}
-  org.clojure/core.memoize                  {:mvn/version "1.0.257"}       ; useful FIFO, LRU, etc. caching mechanisms
-  org.clojure/data.csv                      {:mvn/version "1.0.1"}         ; CSV parsing / generation
-  org.clojure/java.classpath                {:mvn/version "1.0.0"}  ; examine the Java classpath from Clojure programs
-  org.clojure/java.jdbc                     {:mvn/version "0.7.12"} ; basic JDBC access from Clojure
-  org.clojure/java.jmx                      {:mvn/version "1.0.0"}  ; JMX bean library, for exporting diagnostic info
-  org.clojure/math.combinatorics            {:mvn/version "0.1.6"}  ; combinatorics functions
-  org.clojure/math.numeric-tower            {:mvn/version "0.0.5"}  ; math functions like `ceil`
-  org.clojure/tools.logging                 {:mvn/version "1.2.4"}  ; logging framework
+  org.clojure/core.memoize                  {:mvn/version "1.0.257"}            ; useful FIFO, LRU, etc. caching mechanisms
+  org.clojure/data.csv                      {:mvn/version "1.0.1"}              ; CSV parsing / generation
+  org.clojure/java.classpath                {:mvn/version "1.0.0"}              ; examine the Java classpath from Clojure programs
+  org.clojure/java.jdbc                     {:mvn/version "0.7.12"}             ; basic JDBC access from Clojure
+  org.clojure/java.jmx                      {:mvn/version "1.0.0"}              ; JMX bean library, for exporting diagnostic info
+  org.clojure/math.combinatorics            {:mvn/version "0.1.6"}              ; combinatorics functions
+  org.clojure/math.numeric-tower            {:mvn/version "0.0.5"}              ; math functions like `ceil`
+  org.clojure/tools.logging                 {:mvn/version "1.2.4"}              ; logging framework
   org.clojure/tools.namespace               {:mvn/version "1.3.0"}
   org.clojure/tools.reader                  {:mvn/version "1.3.6"}
   org.clojure/tools.trace                   {:mvn/version "0.7.11"}             ; function tracing
@@ -119,30 +119,30 @@
   org.mariadb.jdbc/mariadb-java-client      {:mvn/version "2.7.5"}              ; MySQL/MariaDB driver
   org.mindrot/jbcrypt                       {:mvn/version "0.4"}                ; Crypto library
   org.postgresql/postgresql                 {:mvn/version "42.3.5"}             ; Postgres driver
-  org.quartz-scheduler/quartz               {:mvn/version "2.3.2"} ; Quartz job scheduler, provided by quartzite but this is a newer version.
-  org.slf4j/slf4j-api                       {:mvn/version "1.7.36"} ; abstraction for logging frameworks -- allows end user to plug in desired logging framework at deployment time
-  org.tcrawley/dynapath                     {:mvn/version "1.1.0"} ; Dynamically add Jars (e.g. Oracle or Vertica) to classpath
-  org.threeten/threeten-extra               {:mvn/version "1.7.0"} ; extra Java 8 java.time classes like DayOfMonth and Quarter
-  org.yaml/snakeyaml                        {:mvn/version "1.30"}  ; YAML parser
-  potemkin/potemkin                         {:mvn/version "0.4.5"  ; utility macros & fns
+  org.quartz-scheduler/quartz               {:mvn/version "2.3.2"}              ; Quartz job scheduler, provided by quartzite but this is a newer version.
+  org.slf4j/slf4j-api                       {:mvn/version "1.7.36"}             ; abstraction for logging frameworks -- allows end user to plug in desired logging framework at deployment time
+  org.tcrawley/dynapath                     {:mvn/version "1.1.0"}              ; Dynamically add Jars (e.g. Oracle or Vertica) to classpath
+  org.threeten/threeten-extra               {:mvn/version "1.7.0"}              ; extra Java 8 java.time classes like DayOfMonth and Quarter
+  org.yaml/snakeyaml                        {:mvn/version "1.30"}               ; YAML parser
+  potemkin/potemkin                         {:mvn/version "0.4.5"               ; utility macros & fns
                                              :exclusions  [riddley/riddley]}
-  pretty/pretty                             {:mvn/version "1.0.5"} ; protocol for defining how custom types should be pretty printed
-  prismatic/schema                          {:mvn/version "1.2.1"} ; Data schema declaration and validation library
-  redux/redux                               {:mvn/version "0.1.4"} ; Utility functions for building and composing transducers
-  riddley/riddley                           {:mvn/version "0.2.0"} ; code walking lib -- used interally by Potemkin, manifold, etc.
-  ring/ring-core                            {:mvn/version "1.9.5"} ; web server (Jetty wrapper)
-  ring/ring-jetty-adapter                   {:mvn/version "1.9.5"} ; Ring adapter using Jetty webserver
-  ring/ring-json                            {:mvn/version "0.5.1"} ; Ring middleware for reading/writing JSON automatically
-  robdaemon/clojure.java-time               {:mvn/version "0.3.3-SNAPSHOT"} ; Java 8 java.time wrapper. Use this fork until https://github.com/dm3/clojure.java-time/issues/77 is fixed upstream
-  slingshot/slingshot                       {:mvn/version "0.12.2"}         ; enhanced throw/catch, used by other deps
-  stencil/stencil                           {:mvn/version "0.5.0"}          ; Mustache templates for Clojure
-  toucan/toucan                             {:mvn/version "1.18.0"          ; Model layer, hydration, and DB utilities
+  pretty/pretty                             {:mvn/version "1.0.5"}              ; protocol for defining how custom types should be pretty printed
+  prismatic/schema                          {:mvn/version "1.2.1"}              ; Data schema declaration and validation library
+  redux/redux                               {:mvn/version "0.1.4"}              ; Utility functions for building and composing transducers
+  riddley/riddley                           {:mvn/version "0.2.0"}              ; code walking lib -- used interally by Potemkin, manifold, etc.
+  ring/ring-core                            {:mvn/version "1.9.5"}              ; web server (Jetty wrapper)
+  ring/ring-jetty-adapter                   {:mvn/version "1.9.5"}              ; Ring adapter using Jetty webserver
+  ring/ring-json                            {:mvn/version "0.5.1"}              ; Ring middleware for reading/writing JSON automatically
+  robdaemon/clojure.java-time               {:mvn/version "0.3.3-SNAPSHOT"}     ; Java 8 java.time wrapper. Use this fork until https://github.com/dm3/clojure.java-time/issues/77 is fixed upstream
+  slingshot/slingshot                       {:mvn/version "0.12.2"}             ; enhanced throw/catch, used by other deps
+  stencil/stencil                           {:mvn/version "0.5.0"}              ; Mustache templates for Clojure
+  toucan/toucan                             {:mvn/version "1.18.0"              ; Model layer, hydration, and DB utilities
                                              :exclusions  [honeysql/honeysql
                                                            org.clojure/java.jdbc
                                                            org.clojure/tools.logging
                                                            org.clojure/tools.namespace]}
-  user-agent/user-agent                     {:mvn/version "0.1.0"} ; User-Agent string parser, for Login History page & elsewhere
-  weavejester/dependency                    {:mvn/version "0.2.1"}}        ; Dependency graphs and topological sorting
+  user-agent/user-agent                     {:mvn/version "0.1.0"}              ; User-Agent string parser, for Login History page & elsewhere
+  weavejester/dependency                    {:mvn/version "0.2.1"}}             ; Dependency graphs and topological sorting
 
  ;; !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
  ;; !!         PLEASE KEEP NEW DEPENDENCIES ABOVE ALPHABETICALLY ORGANIZED AND ADD COMMENTS EXPLAINING THEM.         !!
@@ -190,9 +190,6 @@
                  "-Dfile.encoding=UTF-8"
                  "-Duser.language=en"
                  "-Duser.country=US"
-                 ;; set the logging properties set in metabase.bootstrap. calling (dev) will load it but putting here to be sure
-                 "-Dlog4j2.contextSelector=org.apache.logging.log4j.core.selector.BasicContextSelector"
-                 "-Dclojure.tools.logging.factory=clojure.tools.logging.impl/log4j2-factory"
                  ;; If Clojure fails to start (e.g. because of a compilation error somewhere) print the error
                  ;; report/stacktrace to stderr rather than to a random EDN file in /tmp/
                  "-Dclojure.main.report=stderr"
@@ -295,7 +292,7 @@
   ;; clojure -X:dev:ee:ee-dev:drivers:drivers-dev:test:eastwood
   :eastwood
   {:exec-fn   metabase.linters.eastwood/eastwood
-   :exec-args { ;; manually specify the source paths for the time being (exclude test paths) until we fix Eastwood
+   :exec-args {;; manually specify the source paths for the time being (exclude test paths) until we fix Eastwood
                ;; errors in the test paths (once PR #17193 is merged)
                :source-paths    ["src"
                                  "shared/src"
@@ -416,7 +413,7 @@
   ;; Profile Metabase start time with clojure -M:profile
   :profile
   {:main-opts ["-m" "metabase.core" "profile"]
-   :jvm-opts  ["-XX:+CITime"                                                    ; print time spent in JIT compiler
+   :jvm-opts  ["-XX:+CITime" ; print time spent in JIT compiler
                "-XX:+PrintGC"]}
 
   ;; get the H2 shell with clojure -X:h2

--- a/deps.edn
+++ b/deps.edn
@@ -4,110 +4,110 @@
  ;; !!                                   PLEASE KEEP THESE ORGANIZED ALPHABETICALLY                                  !!
  ;; !!                                   AND ADD A COMMENT EXPLAINING THEIR PURPOSE                                  !!
  ;; !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
- {amalloy/ring-buffer                       {:mvn/version "1.3.1"               ; fixed length queue implementation, used in log buffering
+ {amalloy/ring-buffer                       {:mvn/version "1.3.1" ; fixed length queue implementation, used in log buffering
                                              :exclusions  [org.clojure/clojure
                                                            org.clojure/clojurescript]}
-  amalloy/ring-gzip-middleware              {:mvn/version "0.1.4"}              ; Ring middleware to GZIP responses if client can handle it
-  bigml/histogram                           {:mvn/version "4.1.4"}              ; Histogram data structure
+  amalloy/ring-gzip-middleware              {:mvn/version "0.1.4"} ; Ring middleware to GZIP responses if client can handle it
+  bigml/histogram                           {:mvn/version "4.1.4"} ; Histogram data structure
   buddy/buddy-core                          {:mvn/version "1.10.413"            ; various cryptographic functions
                                              :exclusions  [commons-codec/commons-codec
                                                            org.bouncycastle/bcpkix-jdk15on
                                                            org.bouncycastle/bcprov-jdk15on]}
-  buddy/buddy-sign                          {:mvn/version "3.4.333"}            ; JSON Web Tokens; High-Level message signing library
-  cheshire/cheshire                         {:mvn/version "5.10.2"}             ; fast JSON encoding (used by Ring JSON middleware)
-  clj-http/clj-http                         {:mvn/version "3.12.3"              ; HTTP client
+  buddy/buddy-sign                          {:mvn/version "3.4.333"} ; JSON Web Tokens; High-Level message signing library
+  cheshire/cheshire                         {:mvn/version "5.10.2"} ; fast JSON encoding (used by Ring JSON middleware)
+  clj-http/clj-http                         {:mvn/version "3.12.3"  ; HTTP client
                                              :exclusions  [commons-codec/commons-codec
                                                            commons-io/commons-io
                                                            slingshot/slingshot]}
   clojurewerkz/quartzite                    {:mvn/version "2.1.0"               ; scheduling library
                                              :exclusions  [c3p0/c3p0
                                                            org.quartz-scheduler/quartz]}
-  colorize/colorize                         {:mvn/version "0.1.1"               ; string output with ANSI color codes (for logging)
+  colorize/colorize                         {:mvn/version "0.1.1"  ; string output with ANSI color codes (for logging)
                                              :exclusions  [org.clojure/clojure]}
   com.clearspring.analytics/stream          {:mvn/version "2.9.8"               ; Various sketching algorithms
                                              :exclusions  [it.unimi.dsi/fastutil
                                                            org.slf4j/slf4j-api]}
   com.draines/postal                        {:mvn/version "2.0.5"}              ; SMTP library
-  com.google.guava/guava                    {:mvn/version "31.0.1-jre"}         ; dep for BigQuery, Spark, and GA. Require here rather than letting different dep versions stomp on each other — see comments on #9697
+  com.google.guava/guava                    {:mvn/version "31.0.1-jre"} ; dep for BigQuery, Spark, and GA. Require here rather than letting different dep versions stomp on each other — see comments on #9697
   com.fasterxml.jackson.core/jackson-databind
-                                            {:mvn/version "2.13.2.2"}           ; JSON processor used by snowplow-java-tracker (pinned version due to CVE-2020-36518)
+  {:mvn/version "2.13.2.2"}      ; JSON processor used by snowplow-java-tracker (pinned version due to CVE-2020-36518)
   com.h2database/h2                         {:mvn/version "1.4.197"}            ; embedded SQL database
   com.snowplowanalytics/snowplow-java-tracker
-                                            {:mvn/version "0.12.0"              ; Snowplow analytics
-                                             :exclusions [com.fasterxml.jackson.core/jackson-databind]}
-  com.taoensso/nippy                        {:mvn/version "3.1.1"}              ; Fast serialization (i.e., GZIP) library for Clojure
+  {:mvn/version "0.12.0"                                                        ; Snowplow analytics
+   :exclusions [com.fasterxml.jackson.core/jackson-databind]}
+  com.taoensso/nippy                        {:mvn/version "3.1.1"} ; Fast serialization (i.e., GZIP) library for Clojure
   com.vladsch.flexmark/flexmark             {:mvn/version "0.64.0"}             ; Markdown parsing
   com.vladsch.flexmark/flexmark-ext-autolink
-                                            {:mvn/version "0.64.0"}             ; Flexmark extension for auto-linking bare URLs
-  commons-codec/commons-codec               {:mvn/version "1.15"}               ; Apache Commons -- useful codec util fns
-  commons-io/commons-io                     {:mvn/version "2.11.0"}             ; Apache Commons -- useful IO util fns
-  commons-validator/commons-validator       {:mvn/version "1.7"                 ; Apache Commons -- useful validation util fns
+  {:mvn/version "0.64.0"}                                              ; Flexmark extension for auto-linking bare URLs
+  commons-codec/commons-codec               {:mvn/version "1.15"}      ; Apache Commons -- useful codec util fns
+  commons-io/commons-io                     {:mvn/version "2.11.0"}    ; Apache Commons -- useful IO util fns
+  commons-validator/commons-validator       {:mvn/version "1.7"        ; Apache Commons -- useful validation util fns
                                              :exclusions  [commons-beanutils/commons-beanutils
                                                            commons-digester/commons-digester
                                                            commons-logging/commons-logging]}
   compojure/compojure                       {:mvn/version "1.6.2"               ; HTTP Routing library built on Ring
                                              :exclusions  [ring/ring-codec]}
-  crypto-random/crypto-random               {:mvn/version "1.2.1"}              ; library for generating cryptographically secure random bytes and strings
-  dk.ative/docjure                          {:mvn/version "1.17.0"              ; excel export
+  crypto-random/crypto-random               {:mvn/version "1.2.1"} ; library for generating cryptographically secure random bytes and strings
+  dk.ative/docjure                          {:mvn/version "1.17.0" ; excel export
                                              :exclusions  [org.apache.poi/poi
                                                            org.apache.poi/poi-ooxml]}
-  environ/environ                           {:mvn/version "1.2.0"}              ; env vars/Java properties abstraction
-  hiccup/hiccup                             {:mvn/version "1.0.5"}              ; HTML templating
-  honeysql/honeysql                         {:mvn/version "1.0.461"             ; Transform Clojure data structures to SQL
+  environ/environ                           {:mvn/version "1.2.0"}          ; env vars/Java properties abstraction
+  hiccup/hiccup                             {:mvn/version "1.0.5"}          ; HTML templating
+  honeysql/honeysql                         {:mvn/version "1.0.461"         ; Transform Clojure data structures to SQL
                                              :exclusions  [org.clojure/clojurescript]}
   instaparse/instaparse                     {:mvn/version "1.4.12"}             ; Make your own parser
-  io.forward/yaml                           {:mvn/version "1.0.11"              ; Clojure wrapper for YAML library SnakeYAML. Don't upgrade yet, new version doesn't support Java 8 (see https://github.com/owainlewis/yaml/issues/37)
+  io.forward/yaml                           {:mvn/version "1.0.11" ; Clojure wrapper for YAML library SnakeYAML. Don't upgrade yet, new version doesn't support Java 8 (see https://github.com/owainlewis/yaml/issues/37)
                                              :exclusions  [org.clojure/clojure
                                                            org.flatland/ordered
                                                            org.yaml/snakeyaml]}
   io.github.resilience4j/resilience4j-retry {:mvn/version "1.7.1"}              ; Support for retrying operations
   joda-time/joda-time                       {:mvn/version "2.10.13"}
-  kixi/stats                                {:mvn/version "0.4.4"               ; Various statistic measures implemented as transducers
+  kixi/stats                                {:mvn/version "0.4.4" ; Various statistic measures implemented as transducers
                                              :exclusions  [org.clojure/data.avl]}
   me.raynes/fs                              {:mvn/version "1.4.6"               ; Filesystem tools
                                              :exclusions  [org.apache.commons/commons-compress]}
-  medley/medley                             {:mvn/version "1.4.0"}              ; lightweight lib of useful functions
-  metabase/connection-pool                  {:mvn/version "1.2.0"}              ; simple wrapper around C3P0. JDBC connection pools
-  metabase/saml20-clj                       {:mvn/version "2.0.2"}              ; EE SAML integration
-  metabase/throttle                         {:mvn/version "1.0.2"}              ; Tools for throttling access to API endpoints and other code pathways
-  nano-id/nano-id                           {:mvn/version "1.0.0"}              ; NanoID generator for generating entity_ids
-  net.cgrand/macrovich                      {:mvn/version "0.2.1"}              ; utils for writing macros for both Clojure & ClojureScript
-  net.i2p.crypto/eddsa                      {:mvn/version "0.3.0"}              ; ED25519 key support (optional dependency for org.apache.sshd/sshd-core)
-  net.redhogs.cronparser/cron-parser-core   {:mvn/version "3.5"                 ; describe Cron schedule in human-readable language
-                                             :exclusions  [joda-time/joda-time  ; exclude joda time 2.3 which has outdated timezone information
+  medley/medley                             {:mvn/version "1.4.0"} ; lightweight lib of useful functions
+  metabase/connection-pool                  {:mvn/version "1.2.0"} ; simple wrapper around C3P0. JDBC connection pools
+  metabase/saml20-clj                       {:mvn/version "2.0.2"} ; EE SAML integration
+  metabase/throttle                         {:mvn/version "1.0.2"} ; Tools for throttling access to API endpoints and other code pathways
+  nano-id/nano-id                           {:mvn/version "1.0.0"} ; NanoID generator for generating entity_ids
+  net.cgrand/macrovich                      {:mvn/version "0.2.1"} ; utils for writing macros for both Clojure & ClojureScript
+  net.i2p.crypto/eddsa                      {:mvn/version "0.3.0"} ; ED25519 key support (optional dependency for org.apache.sshd/sshd-core)
+  net.redhogs.cronparser/cron-parser-core   {:mvn/version "3.5"    ; describe Cron schedule in human-readable language
+                                             :exclusions  [joda-time/joda-time ; exclude joda time 2.3 which has outdated timezone information
                                                            org.slf4j/slf4j-api]}
   net.sf.cssbox/cssbox                      {:mvn/version "5.0.0"               ; HTML / CSS rendering
                                              :exclusions  [org.slf4j/slf4j-api]}
-  org.apache.commons/commons-compress       {:mvn/version "1.21"}               ; compression utils
-  org.apache.commons/commons-lang3          {:mvn/version "3.12.0"}             ; helper methods for working with java.lang stuff
-  org.apache.logging.log4j/log4j-1.2-api    {:mvn/version "2.18.0"}             ; apache logging framework
-  org.apache.logging.log4j/log4j-api        {:mvn/version "2.18.0"}             ; add compatibility with log4j 1.2
-  org.apache.logging.log4j/log4j-core       {:mvn/version "2.18.0"}             ; apache logging framework
-  org.apache.logging.log4j/log4j-jcl        {:mvn/version "2.18.0"}             ; allows the commons-logging API to work with log4j 2
-  org.apache.logging.log4j/log4j-jul        {:mvn/version "2.18.0"}             ; java.util.logging (JUL) -> Log4j2 adapter
-  org.apache.logging.log4j/log4j-slf4j-impl {:mvn/version "2.18.0"}             ; allows the slf4j API to work with log4j 2
-  org.apache.poi/poi                        {:mvn/version "5.2.2"}              ; Work with Office documents (e.g. Excel spreadsheets) -- newer version than one specified by Docjure
+  org.apache.commons/commons-compress       {:mvn/version "1.21"}    ; compression utils
+  org.apache.commons/commons-lang3          {:mvn/version "3.12.0"}  ; helper methods for working with java.lang stuff
+  org.apache.logging.log4j/log4j-1.2-api    {:mvn/version "2.18.0"}  ; apache logging framework
+  org.apache.logging.log4j/log4j-api        {:mvn/version "2.18.0"}  ; add compatibility with log4j 1.2
+  org.apache.logging.log4j/log4j-core       {:mvn/version "2.18.0"}  ; apache logging framework
+  org.apache.logging.log4j/log4j-jcl        {:mvn/version "2.18.0"} ; allows the commons-logging API to work with log4j 2
+  org.apache.logging.log4j/log4j-jul        {:mvn/version "2.18.0"} ; java.util.logging (JUL) -> Log4j2 adapter
+  org.apache.logging.log4j/log4j-slf4j-impl {:mvn/version "2.18.0"} ; allows the slf4j API to work with log4j 2
+  org.apache.poi/poi                        {:mvn/version "5.2.2"} ; Work with Office documents (e.g. Excel spreadsheets) -- newer version than one specified by Docjure
   org.apache.poi/poi-ooxml                  {:mvn/version "5.2.2"
                                              :exclusions  [org.bouncycastle/bcpkix-jdk15on
                                                            org.bouncycastle/bcprov-jdk15on]}
   org.apache.sshd/sshd-core                 {:mvn/version "2.9.0"}              ; ssh tunneling and test server
   org.apache.xmlgraphics/batik-all          {:mvn/version "1.14"}               ; SVG -> image
   org.clojars.pntblnk/clj-ldap              {:mvn/version "0.0.17"}             ; LDAP client
-  org.bouncycastle/bcpkix-jdk15on           {:mvn/version "1.70"}               ; Bouncy Castle crypto library -- explicit version of BC specified to resolve illegal reflective access errors
+  org.bouncycastle/bcpkix-jdk15on           {:mvn/version "1.70"} ; Bouncy Castle crypto library -- explicit version of BC specified to resolve illegal reflective access errors
   org.bouncycastle/bcprov-jdk15on           {:mvn/version "1.70"}
   org.clojure/clojure                       {:mvn/version "1.11.1"}
   org.clojure/core.async                    {:mvn/version "1.5.648"
                                              :exclusions  [org.clojure/tools.reader]}
-  org.clojure/core.logic                    {:mvn/version "1.0.1"}              ; optimized pattern matching library for Clojure
+  org.clojure/core.logic                    {:mvn/version "1.0.1"}    ; optimized pattern matching library for Clojure
   org.clojure/core.match                    {:mvn/version "1.0.0"}
-  org.clojure/core.memoize                  {:mvn/version "1.0.257"}            ; useful FIFO, LRU, etc. caching mechanisms
-  org.clojure/data.csv                      {:mvn/version "1.0.1"}              ; CSV parsing / generation
-  org.clojure/java.classpath                {:mvn/version "1.0.0"}              ; examine the Java classpath from Clojure programs
-  org.clojure/java.jdbc                     {:mvn/version "0.7.12"}             ; basic JDBC access from Clojure
-  org.clojure/java.jmx                      {:mvn/version "1.0.0"}              ; JMX bean library, for exporting diagnostic info
-  org.clojure/math.combinatorics            {:mvn/version "0.1.6"}              ; combinatorics functions
-  org.clojure/math.numeric-tower            {:mvn/version "0.0.5"}              ; math functions like `ceil`
-  org.clojure/tools.logging                 {:mvn/version "1.2.4"}              ; logging framework
+  org.clojure/core.memoize                  {:mvn/version "1.0.257"}       ; useful FIFO, LRU, etc. caching mechanisms
+  org.clojure/data.csv                      {:mvn/version "1.0.1"}         ; CSV parsing / generation
+  org.clojure/java.classpath                {:mvn/version "1.0.0"}  ; examine the Java classpath from Clojure programs
+  org.clojure/java.jdbc                     {:mvn/version "0.7.12"} ; basic JDBC access from Clojure
+  org.clojure/java.jmx                      {:mvn/version "1.0.0"}  ; JMX bean library, for exporting diagnostic info
+  org.clojure/math.combinatorics            {:mvn/version "0.1.6"}  ; combinatorics functions
+  org.clojure/math.numeric-tower            {:mvn/version "0.0.5"}  ; math functions like `ceil`
+  org.clojure/tools.logging                 {:mvn/version "1.2.4"}  ; logging framework
   org.clojure/tools.namespace               {:mvn/version "1.3.0"}
   org.clojure/tools.reader                  {:mvn/version "1.3.6"}
   org.clojure/tools.trace                   {:mvn/version "0.7.11"}             ; function tracing
@@ -119,30 +119,30 @@
   org.mariadb.jdbc/mariadb-java-client      {:mvn/version "2.7.5"}              ; MySQL/MariaDB driver
   org.mindrot/jbcrypt                       {:mvn/version "0.4"}                ; Crypto library
   org.postgresql/postgresql                 {:mvn/version "42.3.5"}             ; Postgres driver
-  org.quartz-scheduler/quartz               {:mvn/version "2.3.2"}              ; Quartz job scheduler, provided by quartzite but this is a newer version.
-  org.slf4j/slf4j-api                       {:mvn/version "1.7.36"}             ; abstraction for logging frameworks -- allows end user to plug in desired logging framework at deployment time
-  org.tcrawley/dynapath                     {:mvn/version "1.1.0"}              ; Dynamically add Jars (e.g. Oracle or Vertica) to classpath
-  org.threeten/threeten-extra               {:mvn/version "1.7.0"}              ; extra Java 8 java.time classes like DayOfMonth and Quarter
-  org.yaml/snakeyaml                        {:mvn/version "1.30"}               ; YAML parser
-  potemkin/potemkin                         {:mvn/version "0.4.5"               ; utility macros & fns
+  org.quartz-scheduler/quartz               {:mvn/version "2.3.2"} ; Quartz job scheduler, provided by quartzite but this is a newer version.
+  org.slf4j/slf4j-api                       {:mvn/version "1.7.36"} ; abstraction for logging frameworks -- allows end user to plug in desired logging framework at deployment time
+  org.tcrawley/dynapath                     {:mvn/version "1.1.0"} ; Dynamically add Jars (e.g. Oracle or Vertica) to classpath
+  org.threeten/threeten-extra               {:mvn/version "1.7.0"} ; extra Java 8 java.time classes like DayOfMonth and Quarter
+  org.yaml/snakeyaml                        {:mvn/version "1.30"}  ; YAML parser
+  potemkin/potemkin                         {:mvn/version "0.4.5"  ; utility macros & fns
                                              :exclusions  [riddley/riddley]}
-  pretty/pretty                             {:mvn/version "1.0.5"}              ; protocol for defining how custom types should be pretty printed
-  prismatic/schema                          {:mvn/version "1.2.1"}              ; Data schema declaration and validation library
-  redux/redux                               {:mvn/version "0.1.4"}              ; Utility functions for building and composing transducers
-  riddley/riddley                           {:mvn/version "0.2.0"}              ; code walking lib -- used interally by Potemkin, manifold, etc.
-  ring/ring-core                            {:mvn/version "1.9.5"}              ; web server (Jetty wrapper)
-  ring/ring-jetty-adapter                   {:mvn/version "1.9.5"}              ; Ring adapter using Jetty webserver
-  ring/ring-json                            {:mvn/version "0.5.1"}              ; Ring middleware for reading/writing JSON automatically
-  robdaemon/clojure.java-time               {:mvn/version "0.3.3-SNAPSHOT"}     ; Java 8 java.time wrapper. Use this fork until https://github.com/dm3/clojure.java-time/issues/77 is fixed upstream
-  slingshot/slingshot                       {:mvn/version "0.12.2"}             ; enhanced throw/catch, used by other deps
-  stencil/stencil                           {:mvn/version "0.5.0"}              ; Mustache templates for Clojure
-  toucan/toucan                             {:mvn/version "1.18.0"              ; Model layer, hydration, and DB utilities
+  pretty/pretty                             {:mvn/version "1.0.5"} ; protocol for defining how custom types should be pretty printed
+  prismatic/schema                          {:mvn/version "1.2.1"} ; Data schema declaration and validation library
+  redux/redux                               {:mvn/version "0.1.4"} ; Utility functions for building and composing transducers
+  riddley/riddley                           {:mvn/version "0.2.0"} ; code walking lib -- used interally by Potemkin, manifold, etc.
+  ring/ring-core                            {:mvn/version "1.9.5"} ; web server (Jetty wrapper)
+  ring/ring-jetty-adapter                   {:mvn/version "1.9.5"} ; Ring adapter using Jetty webserver
+  ring/ring-json                            {:mvn/version "0.5.1"} ; Ring middleware for reading/writing JSON automatically
+  robdaemon/clojure.java-time               {:mvn/version "0.3.3-SNAPSHOT"} ; Java 8 java.time wrapper. Use this fork until https://github.com/dm3/clojure.java-time/issues/77 is fixed upstream
+  slingshot/slingshot                       {:mvn/version "0.12.2"}         ; enhanced throw/catch, used by other deps
+  stencil/stencil                           {:mvn/version "0.5.0"}          ; Mustache templates for Clojure
+  toucan/toucan                             {:mvn/version "1.18.0"          ; Model layer, hydration, and DB utilities
                                              :exclusions  [honeysql/honeysql
                                                            org.clojure/java.jdbc
                                                            org.clojure/tools.logging
                                                            org.clojure/tools.namespace]}
-  user-agent/user-agent                     {:mvn/version "0.1.0"}              ; User-Agent string parser, for Login History page & elsewhere
-  weavejester/dependency                    {:mvn/version "0.2.1"}}             ; Dependency graphs and topological sorting
+  user-agent/user-agent                     {:mvn/version "0.1.0"} ; User-Agent string parser, for Login History page & elsewhere
+  weavejester/dependency                    {:mvn/version "0.2.1"}}        ; Dependency graphs and topological sorting
 
  ;; !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
  ;; !!         PLEASE KEEP NEW DEPENDENCIES ABOVE ALPHABETICALLY ORGANIZED AND ADD COMMENTS EXPLAINING THEM.         !!
@@ -190,6 +190,9 @@
                  "-Dfile.encoding=UTF-8"
                  "-Duser.language=en"
                  "-Duser.country=US"
+                 ;; set the logging properties set in metabase.bootstrap. calling (dev) will load it but putting here to be sure
+                 "-Dlog4j2.contextSelector=org.apache.logging.log4j.core.selector.BasicContextSelector"
+                 "-Dclojure.tools.logging.factory=clojure.tools.logging.impl/log4j2-factory"
                  ;; If Clojure fails to start (e.g. because of a compilation error somewhere) print the error
                  ;; report/stacktrace to stderr rather than to a random EDN file in /tmp/
                  "-Dclojure.main.report=stderr"
@@ -292,7 +295,7 @@
   ;; clojure -X:dev:ee:ee-dev:drivers:drivers-dev:test:eastwood
   :eastwood
   {:exec-fn   metabase.linters.eastwood/eastwood
-   :exec-args {;; manually specify the source paths for the time being (exclude test paths) until we fix Eastwood
+   :exec-args { ;; manually specify the source paths for the time being (exclude test paths) until we fix Eastwood
                ;; errors in the test paths (once PR #17193 is merged)
                :source-paths    ["src"
                                  "shared/src"
@@ -413,7 +416,7 @@
   ;; Profile Metabase start time with clojure -M:profile
   :profile
   {:main-opts ["-m" "metabase.core" "profile"]
-   :jvm-opts  ["-XX:+CITime" ; print time spent in JIT compiler
+   :jvm-opts  ["-XX:+CITime"                                                    ; print time spent in JIT compiler
                "-XX:+PrintGC"]}
 
   ;; get the H2 shell with clojure -X:h2

--- a/deps.edn
+++ b/deps.edn
@@ -190,6 +190,9 @@
                  "-Dfile.encoding=UTF-8"
                  "-Duser.language=en"
                  "-Duser.country=US"
+                 ;; set the logging properties set in metabase.bootstrap. calling (dev) will load it but putting here to be sure
+                 "-Dlog4j2.contextSelector=org.apache.logging.log4j.core.selector.BasicContextSelector"
+                 "-Dclojure.tools.logging.factory=clojure.tools.logging.impl/log4j2-factory"
                  ;; If Clojure fails to start (e.g. because of a compilation error somewhere) print the error
                  ;; report/stacktrace to stderr rather than to a random EDN file in /tmp/
                  "-Dclojure.main.report=stderr"

--- a/dev/src/user.clj
+++ b/dev/src/user.clj
@@ -3,6 +3,7 @@
 (defn dev
   "Load and switch to the 'dev' namespace."
   []
+  (require 'metabase.bootstrap)
   (require 'dev)
   (in-ns 'dev)
   :loaded)

--- a/src/metabase/bootstrap.clj
+++ b/src/metabase/bootstrap.clj
@@ -1,0 +1,14 @@
+(ns metabase.bootstrap
+  (:gen-class))
+
+;; ensure we use a `BasicContextSelector` instead of a `ClassLoaderContextSelector` for log4j2. Ensures there is only
+;; one LoggerContext instead of one per classpath root. Practical effect is that now `(LogManager/getContext true)`
+;; and `(LogManager/getContext false)` will return the same (and only)
+;; LoggerContext. https://logging.apache.org/log4j/2.x/manual/logsep.html
+(System/setProperty "log4j2.contextSelector" "org.apache.logging.log4j.core.selector.BasicContextSelector")
+
+;; ensure the [[clojure.tools.logging]] logger factory is the log4j2 version (slf4j is far slower and identified first)
+(System/setProperty "clojure.tools.logging.factory" "clojure.tools.logging.impl/log4j2-factory")
+
+(defn -main [& args]
+  ((requiring-resolve 'metabase.core/-main) args))

--- a/src/metabase/bootstrap.clj
+++ b/src/metabase/bootstrap.clj
@@ -10,5 +10,7 @@
 ;; ensure the [[clojure.tools.logging]] logger factory is the log4j2 version (slf4j is far slower and identified first)
 (System/setProperty "clojure.tools.logging.factory" "clojure.tools.logging.impl/log4j2-factory")
 
-(defn -main [& args]
+(defn -main
+  "Main entrypoint. Invokes [[metabase.core/-main]]"
+  [& args]
   ((requiring-resolve 'metabase.core/-main) args))

--- a/src/metabase/core.clj
+++ b/src/metabase/core.clj
@@ -1,5 +1,4 @@
 (ns metabase.core
-  (:gen-class)
   (:require [clojure.string :as str]
             [clojure.tools.logging :as log]
             [clojure.tools.trace :as trace]

--- a/src/metabase/logger.clj
+++ b/src/metabase/logger.clj
@@ -1,16 +1,7 @@
 (ns metabase.logger
-  "Configures the logger system for Metabase. Should be required at least once.
-
-  - Sets up an in-memory logger in a ring buffer for showing in the UI
-  - ensures uses the log4j2 factory for c.t.logging (two orders of magnitude penalty for using the default slf4j
-    factory)
-
-  Important to use `(LogManager/getContext false)`. This importance goes away if we can configure the
-  \"log4j2.contextSelector\" to be the `BasicContextSelector` instead of the default
-  `ClassLoaderContextSelector`. This is only configurable by system properties and seemingly not in our log4j2.xml
-  config. Under the classloaded selector we have two contexts: a default and a classloader version. We ideally just
-  want a single context for all purposes, but the log4j2 factory uses a closed over `(LogManager/getContext false)` so
-  we continue with that version."
+  "Configures the logger system for Metabase. Should be required at least once. Sets up an in-memory logger in a ring
+  buffer for showing in the UI. Other logging options are set in [[metabase.bootstrap]]: the context locator for
+  log4j2 and ensuring log4j2 is the logger that clojure.tools.logging uses."
   (:require [amalloy.ring-buffer :refer [ring-buffer]]
             [clj-time.coerce :as time.coerce]
             [clj-time.format :as time.format]

--- a/src/metabase/logger.clj
+++ b/src/metabase/logger.clj
@@ -97,7 +97,7 @@
   so the logger factory will pick them up."
   (memoize/memo
    (fn [a-namespace]
-     (.getLogger (LogManager/getContext false) (str a-namespace)))))
+     (.getLogger (LogManager/getContext true) (str a-namespace)))))
 
 (defn clear-memoized-ns-loggers!
   "Clear the memoization cache for [[ns-logger]]. This is used when [[metabase.test.util.log/set-ns-log-level!]]

--- a/src/metabase/logger.clj
+++ b/src/metabase/logger.clj
@@ -1,4 +1,16 @@
 (ns metabase.logger
+  "Configures the logger system for Metabase. Should be required at least once.
+
+  - Sets up an in-memory logger in a ring buffer for showing in the UI
+  - ensures uses the log4j2 factory for c.t.logging (two orders of magnitude penalty for using the default slf4j
+    factory)
+
+  Important to use `(LogManager/getContext false)`. This importance goes away if we can configure the
+  \"log4j2.contextSelector\" to be the `BasicContextSelector` instead of the default
+  `ClassLoaderContextSelector`. This is only configurable by system properties and seemingly not in our log4j2.xml
+  config. Under the classloaded selector we have two contexts: a default and a classloader version. We ideally just
+  want a single context for all purposes, but the log4j2 factory uses a closed over `(LogManager/getContext false)` so
+  we continue with that version."
   (:require [amalloy.ring-buffer :refer [ring-buffer]]
             [clj-time.coerce :as time.coerce]
             [clj-time.format :as time.format]

--- a/src/metabase/logger.clj
+++ b/src/metabase/logger.clj
@@ -6,9 +6,9 @@
             [clojure.tools.logging.impl :as log.impl]
             [metabase.config :as config])
   (:import org.apache.commons.lang3.exception.ExceptionUtils
-           [org.apache.logging.log4j LogManager]
            [org.apache.logging.log4j.core Appender LogEvent LoggerContext]
-           org.apache.logging.log4j.core.config.LoggerConfig))
+           org.apache.logging.log4j.core.config.LoggerConfig
+           org.apache.logging.log4j.LogManager))
 
 (def ^:private ^:const max-log-entries 2500)
 

--- a/src/metabase/logger.clj
+++ b/src/metabase/logger.clj
@@ -1,7 +1,7 @@
 (ns metabase.logger
-  "Configures the logger system for Metabase. Should be required at least once. Sets up an in-memory logger in a ring
-  buffer for showing in the UI. Other logging options are set in [[metabase.bootstrap]]: the context locator for
-  log4j2 and ensuring log4j2 is the logger that clojure.tools.logging uses."
+  "Configures the logger system for Metabase. Sets up an in-memory logger in a ring buffer for showing in the UI. Other
+  logging options are set in [[metabase.bootstrap]]: the context locator for log4j2 and ensuring log4j2 is the logger
+  that clojure.tools.logging uses."
   (:require [amalloy.ring-buffer :refer [ring-buffer]]
             [clj-time.coerce :as time.coerce]
             [clj-time.format :as time.format]

--- a/src/metabase/logger.clj
+++ b/src/metabase/logger.clj
@@ -2,12 +2,11 @@
   (:require [amalloy.ring-buffer :refer [ring-buffer]]
             [clj-time.coerce :as time.coerce]
             [clj-time.format :as time.format]
-            [clojure.core.memoize :as memoize]
             [clojure.tools.logging :as log]
             [clojure.tools.logging.impl :as log.impl]
             [metabase.config :as config])
   (:import org.apache.commons.lang3.exception.ExceptionUtils
-           [org.apache.logging.log4j Level Logger LogManager]
+           [org.apache.logging.log4j LogManager]
            [org.apache.logging.log4j.core Appender LogEvent LoggerContext]
            org.apache.logging.log4j.core.config.LoggerConfig))
 
@@ -45,7 +44,7 @@
 (when-not *compile-files*
   (when-not @has-added-appender?
     (reset! has-added-appender? true)
-    (let [^LoggerContext ctx                           (LogManager/getContext true)
+    (let [^LoggerContext ctx                           (LogManager/getContext false)
           config                                       (.getConfiguration ctx)
           appender                                     (metabase-appender)
           ^org.apache.logging.log4j.Level level        nil
@@ -56,62 +55,5 @@
         (.addAppender logger-config appender level filter))
       (.updateLoggers ctx))))
 
-;;; [[clojure.tools.logging]] should be using our custom Logging factory which performs NICELY and memoizes calls to
-;;; `.getLogger` instead of fetching it every single time which is SLOW in Multi-Release JARs. See #16830
-
-(defn- log-level-keyword->Level
-  "Return the Log4j2 [[Level]] that corresponds to a given [[clojure.tools.logging]] `level-keyword`."
-  ^Level [level-keyword]
-  (case level-keyword
-    :off   Level/OFF
-    :trace Level/TRACE
-    :debug Level/DEBUG
-    :info  Level/INFO
-    :warn  Level/WARN
-    :error Level/ERROR
-    :fatal Level/FATAL))
-
-;;; Extend [[org.apache.logging.log4j.Logger]] so it works with [[clojure.tools.logging]].
-;;;
-;;; Yes, https://github.com/clojure/tools.logging/blob/master/src/main/clojure/clojure/tools/logging/impl.clj#L178-L208
-;;; is presumably doing this already but it might not be a good idea to assume that code gets called. It seems like
-;;; [[clojure.tools.logging] tries to use the SLF4J logging factory by default rather than the Log4j2 factory. If that
-;;; happens then I think those lines don't get called at all. So better safe than sorry I guess.
-(extend-protocol log.impl/Logger
-  Logger
-  (enabled? [^Logger this level-keyword]
-    (.isEnabled this (log-level-keyword->Level level-keyword)))
-
-  (write! [^Logger this level-keyword ^Throwable e ^Object message]
-    (let [level (log-level-keyword->Level level-keyword)]
-      (if e
-        (.log this level message e)
-        (.log this level message)))))
-
-(def ^:private ^{:arglists '(^org.apache.logging.log4j.Logger [a-namespace])} ns-logger
-  "Get the appropriate [[Logger]] to use for a Clojure namespace. `a-namespace` can be either
-  a [[clojure.lang.Namespace]], a [[clojure.lang.Symbol]], or a [[String]]. This is memoized because `.getLogger` can
-  be pretty slow and it should never change in a prod run anyway.
-
-  When changing loggers at runtime e.g. in [[metabase.test.util.log]] you need to call [[clear-memoized-ns-loggers!]]
-  so the logger factory will pick them up."
-  (memoize/memo
-   (fn [a-namespace]
-     (.getLogger (LogManager/getContext true) (str a-namespace)))))
-
-(defn clear-memoized-ns-loggers!
-  "Clear the memoization cache for [[ns-logger]]. This is used when [[metabase.test.util.log/set-ns-log-level!]]
-  installs new loggers at runtime."
-  []
-  (memoize/memo-clear! ns-logger))
-
-(defrecord MetabaseLoggerFactory []
-  log.impl/LoggerFactory
-  (name [_this]
-    (str `MetabaseLoggerFactory))
-  (get-logger [_this logger-ns]
-    (ns-logger logger-ns)))
-
-;; switch out the [[clojure.tools.logging]] logger factory with our custom better-performing version.
-(alter-var-root #'log/*logger-factory* (constantly (->MetabaseLoggerFactory)))
-(log/infof "Setting clojure.tools.logging factory to %s" `MetabaseLoggerFactory)
+;; ensure the [[clojure.tools.logging]] logger factory is the log4j2 version (slf4j is far slower and identified first)
+(alter-var-root #'log/*logger-factory* (constantly (log.impl/log4j2-factory)))

--- a/src/metabase/logger.clj
+++ b/src/metabase/logger.clj
@@ -14,8 +14,6 @@
   (:require [amalloy.ring-buffer :refer [ring-buffer]]
             [clj-time.coerce :as time.coerce]
             [clj-time.format :as time.format]
-            [clojure.tools.logging :as log]
-            [clojure.tools.logging.impl :as log.impl]
             [metabase.config :as config])
   (:import org.apache.commons.lang3.exception.ExceptionUtils
            [org.apache.logging.log4j.core Appender LogEvent LoggerContext]

--- a/src/metabase/logger.clj
+++ b/src/metabase/logger.clj
@@ -66,6 +66,3 @@
       (doseq [[_ ^LoggerConfig logger-config] (.getLoggers config)]
         (.addAppender logger-config appender level filter))
       (.updateLoggers ctx))))
-
-;; ensure the [[clojure.tools.logging]] logger factory is the log4j2 version (slf4j is far slower and identified first)
-(alter-var-root #'log/*logger-factory* (constantly (log.impl/log4j2-factory)))

--- a/test/metabase/api/util_test.clj
+++ b/test/metabase/api/util_test.clj
@@ -20,7 +20,7 @@
 
 (deftest logs-test
   (testing "Call includes recent logs (#24616)"
-    (mt/with-log-messages-for-level :warn
+    (mt/with-log-level :warn
       (let [message "Sample warning message for test"]
         (log/warn message)
         (let [logs (mt/user-http-request :crowberto :get 200 "util/logs")]

--- a/test/metabase/api/util_test.clj
+++ b/test/metabase/api/util_test.clj
@@ -1,6 +1,7 @@
 (ns metabase.api.util-test
   "Tests for /api/util"
   (:require [clojure.test :refer :all]
+            [clojure.tools.logging :as log]
             [metabase.test :as mt]))
 
 (deftest password-check-test
@@ -16,6 +17,16 @@
     (testing "Should be a valid password"
       (is (= {:valid true}
              (mt/client :post 200 "util/password_check" {:password "something123"}))))))
+
+(deftest logs-test
+  (testing "Call includes recent logs (#24616)"
+    (mt/with-log-messages-for-level :warn
+      (let [message "Sample warning message for test"]
+        (log/warn message)
+        (let [logs (mt/user-http-request :crowberto :get 200 "util/logs")]
+          (is (pos? (count logs)) "No logs returned from `util/logs`")
+          (is (some (comp #(re-find (re-pattern message) %) :msg) logs)
+              "Recent message not found in `util/logs`"))))))
 
 (deftest permissions-test
   (testing "/util/logs"

--- a/test/metabase/logger_test.clj
+++ b/test/metabase/logger_test.clj
@@ -12,8 +12,13 @@
           "Logger does not contain `metabase-appender` logger")))
   (testing "logging adds to in-memory ringbuffer"
     (mt/with-log-level :warn
-      (log/warn "testing in-memory logger")
-      (is (pos? (count (mb.logger/messages)))))))
+      (let [before (count (mb.logger/messages))]
+        (log/warn "testing in-memory logger")
+        (let [after (count (mb.logger/messages))]
+          ;; it either increases (could have many logs from other tests) or it is the max capacity of the ring buffer
+          (is (or (> after before)
+                  (= before (var-get #'mb.logger/max-log-entries)))
+              "In memory ring buffer did not receive log message"))))))
 
 (deftest memoized-logger-test
   (testing "Using log4j2 logger"

--- a/test/metabase/logger_test.clj
+++ b/test/metabase/logger_test.clj
@@ -20,7 +20,7 @@
                   (= before (var-get #'mb.logger/max-log-entries)))
               "In memory ring buffer did not receive log message"))))))
 
-(deftest memoized-logger-test
+(deftest logger-test
   (testing "Using log4j2 logger"
     (is (= (log.impl/name log/*logger-factory*)
            "org.apache.logging.log4j")

--- a/test/metabase/logger_test.clj
+++ b/test/metabase/logger_test.clj
@@ -1,5 +1,6 @@
 (ns metabase.logger-test
   (:require [clojure.core.memoize :as memoize]
+            [clojure.string :as str]
             [clojure.test :refer :all]
             [clojure.tools.logging :as log]
             [clojure.tools.logging.impl :as log.impl]
@@ -18,7 +19,7 @@
 
 (deftest memoized-logger-test
   (testing "Installed custom logger"
-    (is (= (log.impl/name log/*logger-factory*) "metabase.logger.MetabaseLoggerFactory")
+    (is (str/includes? (log.impl/name log/*logger-factory*) "MetabaseLoggerFactory")
         "Custom `metabase.logger.MetabaseLoggerFactory` logger not installed"))
   (testing "memoizes loggers for namespaces"
     (log.impl/get-logger log/*logger-factory* *ns*)

--- a/test/metabase/logger_test.clj
+++ b/test/metabase/logger_test.clj
@@ -1,0 +1,26 @@
+(ns metabase.logger-test
+  (:require [clojure.core.memoize :as memoize]
+            [clojure.test :refer :all]
+            [clojure.tools.logging :as log]
+            [clojure.tools.logging.impl :as log.impl]
+            [metabase.logger :as mb.logger]))
+
+(deftest added-appender-tests
+  (testing "appender is added to the logger"
+    (let [logger (log.impl/get-logger log/*logger-factory* *ns*)]
+      (is (contains? (.getAppenders logger) "metabase-appender")
+          "Logger does not contain `metabase-appender` logger")))
+  (testing "logging adds to in-memory ringbuffer"
+    (log/warn "testing in-memory logger")
+    (is (pos? (count (mb.logger/messages))))))
+
+(deftest memoized-logger-test
+  (testing "Installed custom logger"
+    (is (= (log.impl/name log/*logger-factory*) "metabase.logger.MetabaseLoggerFactory")
+        "Custom `metabase.logger.MetabaseLoggerFactory` logger not installed"))
+  (testing "memoizes loggers for namespaces"
+    (log.impl/get-logger log/*logger-factory* *ns*)
+    (is (contains? (memoize/snapshot (var-get #'mb.logger/ns-logger))
+                   ;; memoization cache keeps the args vector
+                   [*ns*])
+        "Memoization cache does not include `*ns*`")))

--- a/test/metabase/logger_test.clj
+++ b/test/metabase/logger_test.clj
@@ -3,7 +3,8 @@
             [clojure.test :refer :all]
             [clojure.tools.logging :as log]
             [clojure.tools.logging.impl :as log.impl]
-            [metabase.logger :as mb.logger]))
+            [metabase.logger :as mb.logger]
+            [metabase.test :as mt]))
 
 (deftest added-appender-tests
   (testing "appender is added to the logger"
@@ -11,8 +12,9 @@
       (is (contains? (.getAppenders logger) "metabase-appender")
           "Logger does not contain `metabase-appender` logger")))
   (testing "logging adds to in-memory ringbuffer"
-    (log/warn "testing in-memory logger")
-    (is (pos? (count (mb.logger/messages))))))
+    (mt/with-log-level :warn
+      (log/warn "testing in-memory logger")
+      (is (pos? (count (mb.logger/messages)))))))
 
 (deftest memoized-logger-test
   (testing "Installed custom logger"

--- a/test/metabase/logger_test.clj
+++ b/test/metabase/logger_test.clj
@@ -1,7 +1,5 @@
 (ns metabase.logger-test
-  (:require [clojure.core.memoize :as memoize]
-            [clojure.string :as str]
-            [clojure.test :refer :all]
+  (:require [clojure.test :refer :all]
             [clojure.tools.logging :as log]
             [clojure.tools.logging.impl :as log.impl]
             [metabase.logger :as mb.logger]
@@ -18,12 +16,7 @@
       (is (pos? (count (mb.logger/messages)))))))
 
 (deftest memoized-logger-test
-  (testing "Installed custom logger"
-    (is (str/includes? (log.impl/name log/*logger-factory*) "MetabaseLoggerFactory")
-        "Custom `metabase.logger.MetabaseLoggerFactory` logger not installed"))
-  (testing "memoizes loggers for namespaces"
-    (log.impl/get-logger log/*logger-factory* *ns*)
-    (is (contains? (memoize/snapshot (var-get #'mb.logger/ns-logger))
-                   ;; memoization cache keeps the args vector
-                   [*ns*])
-        "Memoization cache does not include `*ns*`")))
+  (testing "Using log4j2 logger"
+    (is (= (log.impl/name log/*logger-factory*)
+           "org.apache.logging.log4j")
+        "Not using log4j2 logger factory. This could add two orders of magnitude of time to logging calls")))

--- a/test/metabase/test/util/log.clj
+++ b/test/metabase/test/util/log.clj
@@ -94,7 +94,7 @@
     (name a-namespace)))
 
 (defn- logger-context ^LoggerContext []
-  (LogManager/getContext false))
+  (LogManager/getContext true))
 
 (defn- configuration ^Configuration []
   (.getConfiguration (logger-context)))

--- a/test/metabase/test/util/log.clj
+++ b/test/metabase/test/util/log.clj
@@ -3,7 +3,6 @@
   (:require [clojure.test :refer :all]
             [clojure.tools.logging :as log]
             [clojure.tools.logging.impl :as log.impl]
-            [metabase.logger :as mb.logger]
             [metabase.test-runner.parallel :as test-runner.parallel]
             [potemkin :as p]
             [schema.core :as s])

--- a/test/metabase/test/util/log.clj
+++ b/test/metabase/test/util/log.clj
@@ -94,7 +94,7 @@
     (name a-namespace)))
 
 (defn- logger-context ^LoggerContext []
-  (LogManager/getContext true))
+  (LogManager/getContext false))
 
 (defn- configuration ^Configuration []
   (.getConfiguration (logger-context)))
@@ -141,7 +141,6 @@
                          (.getFilter parent-logger))]
       (.addLogger (configuration) (logger-name a-namespace) new-logger)
       (.updateLoggers (logger-context))
-      (mb.logger/clear-memoized-ns-loggers!)
       (println "Created a new logger for" (logger-name a-namespace)))))
 
 (s/defn set-ns-log-level!


### PR DESCRIPTION
Our Admin > Troubleshooting > Logs page broke, just showing a spinner
and never showing the logs.

#### Remove our memoizing logger

For 39.2 we made our uberjar multi-release but we had to revert due to degraded query performance. Jeff tracked this down to a huge decrease in speed of logging, even noops like `(log/trace "info")`.

To re-institute the multi-release property, we've attempted to increase the speed of this logging by memoizing the lookup from namespace to logger.

Summary from 
```
(bench (log/trace "no-op"))
Summary for benching log/info which is a no-op:
39.2:                              11534ns (11.534614 µs)
RC2:                               98.408357 ns
Multi-release:                     2236 ns (2.236756 µs)
multi-release with logger factory: 141.080913 ns
```

But we didn't notice one critical issue when doing this: it was using the `(log.impl/slf4j-factory)` which would delegate to log4j2.

But if we just set the logger factory as the log4j2 factor we're back to native speeds:

```
(bench (log/trace "no-op"))
Memoizing factory: 141 ns
slf4j factory:     2269 ns
log4j2 factory:    31 ns
```

One issue still remained: the difference between `(LogManager/getContext true)` vs when called with `false`. Log4j2 by default uses a `ClassLoaderContextSelector` which can handle multiple logging contexts, usually for web apps in the same jvm. (see [logging separation docs](https://logging.apache.org/log4j/2.x/manual/logsep.html)). We can change this with a system property to a `BasicContextSelector` where there is only ever one context. But to do this we need the system property set before the logging static initializers are run. Thus `metabase.bootstrap`.

```clojure
;; run locally built jar
;; MB_JETTY_PORT=4000 java "$(socket-repl 4001)" -cp locally-built.jar:criterium.jar metabase.bootstrap

❯ netcat localhost 4001
user=> (doto 'metabase.logger require in-ns)
metabase.logger

;; confirm that our context selector is the BasicContextSelector
metabase.logger=> (type (.. (LogManager/getFactory) getSelector))
org.apache.logging.log4j.core.selector.BasicContextSelector

;; and that selector ensures we have only one logger context
metabase.logger=> (identical? (LogManager/getContext true) (LogManager/getContext false))
true
metabase.logger=> (require '[criterium.core :refer [bench]])
nil

;; we're still speedy at 23 nanoseconds
metabase.logger=> (bench (log/trace "no-op"))
Evaluation count : 1953831000 in 60 samples of 32563850 calls.
             Execution time mean : 23.818734 ns
    Execution time std-deviation : 0.065813 ns
   Execution time lower quantile : 23.749761 ns ( 2.5%)
   Execution time upper quantile : 24.006678 ns (97.5%)
                   Overhead used : 6.883426 ns

Found 4 outliers in 60 samples (6.6667 %)
	low-severe	 1 (1.6667 %)
	low-mild	 3 (5.0000 %)
 Variance from outliers : 1.6389 % Variance is slightly inflated by outliers
nil

;; verify we are correctly setting the log4j2 factory
metabase.logger=> (clojure.tools.logging.impl/name clojure.tools.logging/*logger-factory*) 
"org.apache.logging.log4j"
metabase.logger=>
```


EDIT: no need to backport this since release-x.44.x doesn't have the new logger (related to multi-release and upgrading graal/js dep)