### PR TITLE
Fix Column Filters for remapped model columns

### DIFF
--- a/frontend/src/metabase/modes/components/drill/ColumnFilterDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/ColumnFilterDrill.jsx
@@ -23,10 +23,17 @@ export default function ColumnFilterDrill({ question, clicked }) {
   }
 
   const { column } = clicked;
-  const initialFilter = new Filter([], null, query).setDimension(
-    column.field_ref,
-    { useDefaultOperator: true },
-  );
+
+  // if our field ref doesn't match our column id, we have a remapped column
+  // and need to use the field id instead of the ref
+  const fieldRef =
+    column.id !== undefined && column.id !== column.field_ref[1]
+      ? ["field", column.id, null]
+      : column.field_ref;
+
+  const initialFilter = new Filter([], null, query).setDimension(fieldRef, {
+    useDefaultOperator: true,
+  });
 
   return [
     {


### PR DESCRIPTION
## Description

Remapped columns in models were not filterable from their column header. This was because the remapping was causing the field ids to get lost in column filters. This finds the ids again and makes the column filters behave the same as the filter modal and filters in notebook mode.

![Screen Shot 2022-08-04 at 2 27 56 PM](https://user-images.githubusercontent.com/30528226/182947010-641e32eb-26f8-4fd8-b7ef-9d594738b1a2.png)


resolves https://github.com/metabase/metabase/issues/23091

## Testing Steps

1. Native > Sample > select * from products
1. Save question and turn into Model as "M1"
1. Edit Metadata and map CATEGORY to Products.Category field > Save changes
1. Click on the "Category" header cell
1. Click "Filter by this column
1. It correctly displays all filters but once you select any of them, "Add filter" button ~~stays disabled~~ is enabled
1. It is ~~not~~ possible to add any other filter type ("Is not", "Contains", "Is not empty"...)


- should still work for unmapped model columns
- should still work for regular question columns