### PR TITLE
show browse data button when iframed

### DIFF
--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarView.tsx
@@ -12,7 +12,7 @@ import {
   getCollectionIcon,
   PERSONAL_COLLECTIONS,
 } from "metabase/entities/collections";
-import { IFRAMED, isSmallScreen } from "metabase/lib/dom";
+import { isSmallScreen } from "metabase/lib/dom";
 import * as Urls from "metabase/lib/urls";
 
 import { SelectedItem } from "./types";
@@ -128,7 +128,7 @@ function MainNavbarView({
           />
         </SidebarSection>
         <ul>
-          {hasDataAccess && !IFRAMED && (
+          {hasDataAccess && (
             <SidebarSection>
               <SidebarHeadingWrapper>
                 <SidebarHeading>{t`Data`}</SidebarHeading>


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/24610

## Changes

Show "Browse data" button in fully embedded Metabase instances too.

<img width="342" alt="Screen Shot 2022-08-05 at 6 25 25 PM" src="https://user-images.githubusercontent.com/14301985/183097662-2dc4d923-eca6-40da-bf4d-6a5842e39d09.png">

## How to verify

- Run a fully embedded Metabase (you can use [our example app](https://github.com/metabase/sso-examples/tree/master/app-embed-example))
- Ensure the main page shows the "Browse data" button