### PR TITLE
Add deprecation warning to types namespace

### DIFF
--- a/frontend/src/metabase-types/types/Auto.ts
+++ b/frontend/src/metabase-types/types/Auto.ts
@@ -1,3 +1,8 @@
+/**
+ * ⚠️
+ * @deprecated use existing types from, or add to metabase-types/api/*
+ */
+
 import { TableId, SchemaName } from "metabase-types/types/Table";
 
 export type DatabaseCandidates = SchemaCandidates[];

--- a/frontend/src/metabase-types/types/Card.ts
+++ b/frontend/src/metabase-types/types/Card.ts
@@ -1,3 +1,8 @@
+/**
+ * ⚠️
+ * @deprecated use existing types from, or add to metabase-types/api/*
+ */
+
 import { DatabaseId } from "./Database";
 import { StructuredQuery, NativeQuery } from "./Query";
 import { Parameter, ParameterQueryObject } from "./Parameter";

--- a/frontend/src/metabase-types/types/Collection.ts
+++ b/frontend/src/metabase-types/types/Collection.ts
@@ -1,3 +1,8 @@
+/**
+ * ⚠️
+ * @deprecated use existing types from, or add to metabase-types/api/*
+ */
+
 export type CollectionId = number;
 
 export type Collection = {

--- a/frontend/src/metabase-types/types/Dashboard.ts
+++ b/frontend/src/metabase-types/types/Dashboard.ts
@@ -1,3 +1,8 @@
+/**
+ * ⚠️
+ * @deprecated use existing types from, or add to metabase-types/api/*
+ */
+
 import { Card, CardId } from "./Card";
 import { VisualizationSettings } from "metabase-types/api/card";
 import { Parameter, ParameterMapping } from "./Parameter";

--- a/frontend/src/metabase-types/types/Database.ts
+++ b/frontend/src/metabase-types/types/Database.ts
@@ -1,3 +1,8 @@
+/**
+ * ⚠️
+ * @deprecated use existing types from, or add to metabase-types/api/*
+ */
+
 import { ISO8601Time } from ".";
 import { Table } from "./Table";
 

--- a/frontend/src/metabase-types/types/Dataset.ts
+++ b/frontend/src/metabase-types/types/Dataset.ts
@@ -1,3 +1,8 @@
+/**
+ * ⚠️
+ * @deprecated use existing types from, or add to metabase-types/api/*
+ */
+
 import { ISO8601Time } from ".";
 import { FieldId } from "./Field";
 import { DatasetQuery } from "./Card";

--- a/frontend/src/metabase-types/types/Field.ts
+++ b/frontend/src/metabase-types/types/Field.ts
@@ -1,3 +1,8 @@
+/**
+ * ⚠️
+ * @deprecated use existing types from, or add to metabase-types/api/*
+ */
+
 import { ISO8601Time } from ".";
 import { Table, TableId } from "./Table";
 import { Value } from "./Dataset";

--- a/frontend/src/metabase-types/types/Label.ts
+++ b/frontend/src/metabase-types/types/Label.ts
@@ -1,3 +1,8 @@
+/**
+ * ⚠️
+ * @deprecated use existing types from, or add to metabase-types/api/*
+ */
+
 export type LabelId = number;
 
 export type Label = {

--- a/frontend/src/metabase-types/types/Metadata.ts
+++ b/frontend/src/metabase-types/types/Metadata.ts
@@ -1,3 +1,8 @@
+/**
+ * ⚠️
+ * @deprecated use existing types from, or add to metabase-types/api/*
+ */
+
 // Legacy "tableMetadata" etc
 
 import { Database, DatabaseId } from "metabase-types/types/Database";

--- a/frontend/src/metabase-types/types/Metric.ts
+++ b/frontend/src/metabase-types/types/Metric.ts
@@ -1,3 +1,8 @@
+/**
+ * ⚠️
+ * @deprecated use existing types from, or add to metabase-types/api/*
+ */
+
 import { TableId } from "./Table";
 
 export type MetricId = number;

--- a/frontend/src/metabase-types/types/Parameter.ts
+++ b/frontend/src/metabase-types/types/Parameter.ts
@@ -1,3 +1,8 @@
+/**
+ * ⚠️
+ * @deprecated use existing types from, or add to metabase-types/api/*
+ */
+
 import { CardId } from "./Card";
 import { LocalFieldReference, ForeignFieldReference } from "./Query";
 

--- a/frontend/src/metabase-types/types/Query.ts
+++ b/frontend/src/metabase-types/types/Query.ts
@@ -1,3 +1,8 @@
+/**
+ * ⚠️
+ * @deprecated use existing types from, or add to metabase-types/api/*
+ */
+
 import { TableId } from "./Table";
 import { FieldId, BaseType } from "./Field";
 import { SegmentId } from "./Segment";

--- a/frontend/src/metabase-types/types/Revision.ts
+++ b/frontend/src/metabase-types/types/Revision.ts
@@ -1,3 +1,8 @@
+/**
+ * ⚠️
+ * @deprecated use existing types from, or add to metabase-types/api/*
+ */
+
 export type RevisionId = string;
 
 export type Revision = {

--- a/frontend/src/metabase-types/types/Segment.ts
+++ b/frontend/src/metabase-types/types/Segment.ts
@@ -1,3 +1,8 @@
+/**
+ * ⚠️
+ * @deprecated use existing types from, or add to metabase-types/api/*
+ */
+
 import { TableId } from "./Table";
 
 export type SegmentId = number;

--- a/frontend/src/metabase-types/types/Snippet.ts
+++ b/frontend/src/metabase-types/types/Snippet.ts
@@ -1,3 +1,8 @@
+/**
+ * ⚠️
+ * @deprecated use existing types from, or add to metabase-types/api/*
+ */
+
 export type Snippet = {
   id?: number;
   archived?: boolean;

--- a/frontend/src/metabase-types/types/Table.ts
+++ b/frontend/src/metabase-types/types/Table.ts
@@ -1,3 +1,8 @@
+/**
+ * ⚠️
+ * @deprecated use existing types from, or add to metabase-types/api/*
+ */
+
 import { ISO8601Time } from ".";
 
 import { Field } from "./Field";

--- a/frontend/src/metabase-types/types/User.ts
+++ b/frontend/src/metabase-types/types/User.ts
@@ -1,3 +1,8 @@
+/**
+ * ⚠️
+ * @deprecated use existing types from, or add to metabase-types/api/*
+ */
+
 export type User = {
   id: number;
   common_name: string;

--- a/frontend/src/metabase-types/types/Visualization.ts
+++ b/frontend/src/metabase-types/types/Visualization.ts
@@ -1,3 +1,8 @@
+/**
+ * ⚠️
+ * @deprecated use existing types from, or add to metabase-types/api/*
+ */
+
 import { DatasetData, Column, Row, Value } from "metabase-types/types/Dataset";
 import { Card } from "metabase-types/types/Card";
 import { VisualizationSettings } from "metabase-types/api/card";

--- a/frontend/src/metabase-types/types/index.ts
+++ b/frontend/src/metabase-types/types/index.ts
@@ -1,3 +1,8 @@
+/**
+ * ⚠️
+ * @deprecated use existing types from, or add to metabase-types/api/*
+ */
+
 // ISO8601 timestamp
 export type ISO8601Time = string;
 

--- a/frontend/src/metabase-types/types/redux.ts
+++ b/frontend/src/metabase-types/types/redux.ts
@@ -1,3 +1,8 @@
+/**
+ * ⚠️
+ * @deprecated use existing types from, or add to metabase-types/api/*
+ */
+
 // "Flux standard action" style redux action
 export type ReduxAction =
   | { type: string; payload?: any; error?: boolean }


### PR DESCRIPTION
Commenting files in the `metabase-types/types` namespace to warn that these files are deprecated.