### PR TITLE
FieldValuesWidget: fix entering value which starts with a substring that is a selected value

### DIFF
--- a/frontend/src/metabase/components/FieldValuesWidget.jsx
+++ b/frontend/src/metabase/components/FieldValuesWidget.jsx
@@ -267,6 +267,7 @@ class FieldValuesWidgetInner extends Component {
       placeholder,
       showOptionsInPopover,
       checkedColor,
+      updateOnInputChange,
     } = this.props;
     const { loadingState, options = [], valuesMode } = this.state;
 
@@ -322,7 +323,7 @@ class FieldValuesWidgetInner extends Component {
             value={value.filter(v => v != null)}
             onChange={onChange}
             placeholder={tokenFieldPlaceholder}
-            updateOnInputChange
+            updateOnInputChange={updateOnInputChange}
             // forwarded props
             multi={multi}
             autoFocus={autoFocus}

--- a/frontend/src/metabase/components/TokenField/TokenField.tsx
+++ b/frontend/src/metabase/components/TokenField/TokenField.tsx
@@ -313,6 +313,7 @@ export default class TokenField extends Component<
       keyCode === KEYCODE_ENTER
     ) {
       if (this.addSelectedOption(event)) {
+        event.preventDefault();
         event.stopPropagation();
       }
     } else if (event.keyCode === KEYCODE_UP) {

--- a/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/ParameterFieldWidget.jsx
+++ b/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/ParameterFieldWidget.jsx
@@ -69,6 +69,7 @@ export default function ParameterFieldWidget({
               };
           return (
             <FieldValuesWidget
+              updateOnInputChange
               key={index}
               className={cx("input", numFields - 1 !== index && "mb1")}
               value={value}

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DefaultPicker.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DefaultPicker.jsx
@@ -119,6 +119,7 @@ export default function DefaultPicker({
         }
         return (
           <FieldValuesWidget
+            updateOnInputChange
             className="input"
             value={values}
             onChange={onValuesChange}

--- a/frontend/test/metabase/components/FieldValuesWidget.unit.spec.js
+++ b/frontend/test/metabase/components/FieldValuesWidget.unit.spec.js
@@ -1,5 +1,7 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders } from "__support__/ui";
 import "mutationobserver-shim";
 
 import { ORDERS, PRODUCTS, PEOPLE } from "__support__/sample_database_fixture";
@@ -23,6 +25,19 @@ const renderFieldValuesWidget = props =>
       {...props}
     />,
   );
+
+const renderFieldValuesWidgetWithProviders = props => {
+  renderWithProviders(
+    <FieldValuesWidget
+      value={[]}
+      onChange={() => {}}
+      fetchFieldValues={() => {}}
+      addRemappings={() => {}}
+      {...props}
+    />,
+    { withSettings: true, withEmbedSettings: true },
+  );
+};
 
 describe("FieldValuesWidget", () => {
   describe("category field", () => {
@@ -133,6 +148,26 @@ describe("FieldValuesWidget", () => {
         ];
         renderFieldValuesWidget({ fields });
         await screen.findByPlaceholderText("Search by Product");
+      });
+
+      it("accepts values that incluse already selected values as substrings", async () => {
+        const onChange = jest.fn();
+        renderFieldValuesWidgetWithProviders({
+          fields: [
+            mock(PRODUCTS.VENDOR, {
+              has_field_values: "search",
+            }),
+          ],
+          value: ["Meta"],
+          multi: true,
+          onChange,
+        });
+
+        const input = await screen.findByDisplayValue("");
+
+        userEvent.type(input, "Metabase{enter}");
+
+        expect(onChange).toHaveBeenCalledWith(["Meta", "Metabase"]);
       });
     });
   });


### PR DESCRIPTION
## Changes

Fixes inability to enter a filter value if a substring of it has already been selected.

## How to verify

- Create a native query
```sql
select 'Meta' as "Company"
union all select 'Metabase'
```
- Click "Explore results" -> Filter
- Enter "Meta", press Enter
- Enter "Metabase" and ensure it allows to do it

## Demo (before/after)

<video src="https://user-images.githubusercontent.com/14301985/183135234-99e9a3b3-dd26-4efe-87a6-2012177d8236.mov" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/24641)
<!-- Reviewable:end -->
