### PR TITLE
Bump Mariadb driver to 2.7.6

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -116,7 +116,7 @@
   org.graalvm.js/js                         {:mvn/version "22.1.0"}             ; JavaScript engine
   org.liquibase/liquibase-core              {:mvn/version "4.10.0"              ; migration management (Java lib)
                                              :exclusions  [ch.qos.logback/logback-classic]}
-  org.mariadb.jdbc/mariadb-java-client      {:mvn/version "2.7.5"}              ; MySQL/MariaDB driver
+  org.mariadb.jdbc/mariadb-java-client      {:mvn/version "2.7.6"}              ; MySQL/MariaDB driver
   org.mindrot/jbcrypt                       {:mvn/version "0.4"}                ; Crypto library
   org.postgresql/postgresql                 {:mvn/version "42.3.5"}             ; Postgres driver
   org.quartz-scheduler/quartz               {:mvn/version "2.3.2"}              ; Quartz job scheduler, provided by quartzite but this is a newer version.


### PR DESCRIPTION
Addresses https://jira.mariadb.org/browse/CONJ-983 (connector/j call may be stuck on acquiring lock).

See [full changelog between 2.7.5 -> 2.7.6](https://github.com/mariadb-corporation/mariadb-connector-j/compare/2.7.5...2.7.6). Since it seems to address this one issue without any other changes I've added the `backport` label to get this into 44.1.