### PR TITLE
Bump postgres to 42.3.6

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -118,7 +118,7 @@
                                              :exclusions  [ch.qos.logback/logback-classic]}
   org.mariadb.jdbc/mariadb-java-client      {:mvn/version "2.7.5"}              ; MySQL/MariaDB driver
   org.mindrot/jbcrypt                       {:mvn/version "0.4"}                ; Crypto library
-  org.postgresql/postgresql                 {:mvn/version "42.3.5"}             ; Postgres driver
+  org.postgresql/postgresql                 {:mvn/version "42.3.6"}             ; Postgres driver
   org.quartz-scheduler/quartz               {:mvn/version "2.3.2"}              ; Quartz job scheduler, provided by quartzite but this is a newer version.
   org.slf4j/slf4j-api                       {:mvn/version "1.7.36"}             ; abstraction for logging frameworks -- allows end user to plug in desired logging framework at deployment time
   org.tcrawley/dynapath                     {:mvn/version "1.1.0"}              ; Dynamically add Jars (e.g. Oracle or Vertica) to classpath


### PR DESCRIPTION
Fixes https://github.com/pgjdbc/pgjdbc/pull/2377 (close refcursors when undlerying cursor is null). 

See full [changelog between 42.3.5 -> 42.3.6](https://github.com/pgjdbc/pgjdbc/compare/REL42.3.5..REL42.3.6). This change also seems to tackle one specific issue so seems like it might be low risk to get into 44.1.
