### PR TITLE
Retrieve field metadata from cached card object when a dimension has a virtual card table

### DIFF
--- a/frontend/src/metabase-lib/lib/Dimension.ts
+++ b/frontend/src/metabase-lib/lib/Dimension.ts
@@ -840,7 +840,7 @@ export class FieldDimension extends Dimension {
     }
 
     const virtualTableCardId = getQuestionIdFromVirtualTableId(
-      this.query()?.sourceTableId(),
+      this.query()?.sourceTableId?.(),
     );
     if (virtualTableCardId != null) {
       const card = this._metadata?.card(virtualTableCardId);

--- a/frontend/src/metabase-lib/lib/Dimension.ts
+++ b/frontend/src/metabase-lib/lib/Dimension.ts
@@ -831,10 +831,13 @@ export class FieldDimension extends Dimension {
     }
   }
 
-  _getFieldMetadataFromSavedQuestion() {
+  _getFieldMetadataFromSavedDataset() {
     const identifierProp = this._getIdentifierProp();
     const questionAssociatedWithDimension = this.query()?.question();
-    if (questionAssociatedWithDimension?.isSaved()) {
+    if (
+      questionAssociatedWithDimension?.isSaved() &&
+      questionAssociatedWithDimension.isDataset()
+    ) {
       const question = this.query()?.question();
       const field = _.findWhere(question.getResultMetadata(), {
         [identifierProp]: this.fieldIdOrName(),
@@ -844,18 +847,19 @@ export class FieldDimension extends Dimension {
     }
   }
 
-  _getFieldMetadataFromNestedCard() {
+  _getFieldMetadataFromNestedDataset() {
     const identifierProp = this._getIdentifierProp();
     const virtualTableCardId = getQuestionIdFromVirtualTableId(
       this.query()?.sourceTableId?.(),
     );
     if (virtualTableCardId != null) {
       const question = this._metadata?.question(virtualTableCardId);
-      const field = question
-        ? _.findWhere(question.getResultMetadata(), {
-            [identifierProp]: this.fieldIdOrName(),
-          })
-        : undefined;
+      const field =
+        question && question.isDataset()
+          ? _.findWhere(question.getResultMetadata(), {
+              [identifierProp]: this.fieldIdOrName(),
+            })
+          : undefined;
 
       return field;
     }
@@ -909,8 +913,8 @@ export class FieldDimension extends Dimension {
     // Field that exists in the Metadata object.
     if (this.isIntegerFieldId()) {
       fieldMetadata =
-        this._getFieldMetadataFromSavedQuestion() ||
-        this._getFieldMetadataFromNestedCard();
+        this._getFieldMetadataFromSavedDataset() ||
+        this._getFieldMetadataFromNestedDataset();
     }
 
     // In scenarios where the Field id is not an integer, we need to grab the Field from the

--- a/frontend/src/metabase-lib/lib/Dimension.ts
+++ b/frontend/src/metabase-lib/lib/Dimension.ts
@@ -838,12 +838,14 @@ export class FieldDimension extends Dimension {
       questionAssociatedWithDimension?.isSaved() &&
       questionAssociatedWithDimension.isDataset()
     ) {
-      const question = this.query()?.question();
-      const field = _.findWhere(question.getResultMetadata(), {
-        [identifierProp]: this.fieldIdOrName(),
-      });
+      const fieldMetadata = _.findWhere(
+        questionAssociatedWithDimension.getResultMetadata(),
+        {
+          [identifierProp]: this.fieldIdOrName(),
+        },
+      );
 
-      return field;
+      return fieldMetadata;
     }
   }
 
@@ -854,14 +856,13 @@ export class FieldDimension extends Dimension {
     );
     if (virtualTableCardId != null) {
       const question = this._metadata?.question(virtualTableCardId);
-      const field =
-        question && question.isDataset()
-          ? _.findWhere(question.getResultMetadata(), {
-              [identifierProp]: this.fieldIdOrName(),
-            })
-          : undefined;
+      const fieldMetadata = question?.isDataset()
+        ? _.findWhere(question.getResultMetadata(), {
+            [identifierProp]: this.fieldIdOrName(),
+          })
+        : undefined;
 
-      return field;
+      return fieldMetadata;
     }
   }
 

--- a/frontend/src/metabase-lib/lib/Dimension.ts
+++ b/frontend/src/metabase-lib/lib/Dimension.ts
@@ -850,9 +850,9 @@ export class FieldDimension extends Dimension {
       this.query()?.sourceTableId?.(),
     );
     if (virtualTableCardId != null) {
-      const card = this._metadata?.card(virtualTableCardId);
-      const field = card
-        ? _.findWhere(card.result_metadata, {
+      const question = this._metadata?.question(virtualTableCardId);
+      const field = question
+        ? _.findWhere(question.getResultMetadata(), {
             [identifierProp]: this.fieldIdOrName(),
           })
         : undefined;

--- a/frontend/src/metabase-lib/lib/Question.ts
+++ b/frontend/src/metabase-lib/lib/Question.ts
@@ -137,6 +137,7 @@ class QuestionInner {
         fields: {},
         metrics: {},
         segments: {},
+        questions: {},
       });
     this._parameterValues = parameterValues || {};
     this._update = update;

--- a/frontend/src/metabase-lib/lib/metadata/Metadata.ts
+++ b/frontend/src/metabase-lib/lib/metadata/Metadata.ts
@@ -105,6 +105,10 @@ export default class Metadata extends Base {
     return (fieldId != null && this.fields[fieldId]) || null;
   }
 
+  card(cardId) {
+    return (cardId != null && this.cards[cardId]) || null;
+  }
+
   question(card) {
     return new Question(card, this);
   }

--- a/frontend/src/metabase-lib/lib/metadata/Metadata.ts
+++ b/frontend/src/metabase-lib/lib/metadata/Metadata.ts
@@ -105,12 +105,8 @@ export default class Metadata extends Base {
     return (fieldId != null && this.fields[fieldId]) || null;
   }
 
-  card(cardId) {
-    return (cardId != null && this.cards[cardId]) || null;
-  }
-
-  question(card) {
-    return new Question(card, this);
+  question(cardId) {
+    return (cardId != null && this.questions[cardId]) || null;
   }
 
   /**

--- a/frontend/src/metabase-lib/lib/metadata/Metadata.unit.spec.ts
+++ b/frontend/src/metabase-lib/lib/metadata/Metadata.unit.spec.ts
@@ -139,19 +139,7 @@ describe("Metadata", () => {
       expect(metadata.segmentsList()).toEqual([segmentA, segmentB]);
     });
   });
-  describe("question", () => {
-    it("should return a new question using the metadata instance", () => {
-      const card = {
-        name: "Question",
-        id: 1,
-      };
-      const metadata = new Metadata();
-      const question = metadata.question(card);
-      expect(question).toBeInstanceOf(Question);
-      expect(question.card()).toBe(card);
-      expect(question.metadata()).toBe(metadata);
-    });
-  });
+
   [
     ["segment", obj => new Segment(obj)],
     ["metric", obj => new Metric(obj)],

--- a/frontend/src/metabase-lib/lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/lib/queries/StructuredQuery.ts
@@ -331,6 +331,7 @@ class StructuredQueryInner extends AtomicQuery {
 
     if (sourceQuery) {
       return new Table({
+        id: this.sourceTableId(),
         name: "",
         display_name: "",
         db: sourceQuery.database(),

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/data-permissions.unit.spec.fixtures.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/data-permissions.unit.spec.fixtures.ts
@@ -132,6 +132,7 @@ export const normalizedMetadata = {
     },
   },
   groups_list: { null: { list: [1, 2, 3] } },
+  questions: {},
 };
 
 export const initialPermissions = {

--- a/frontend/src/metabase/dashboard/selectors.unit.spec.js
+++ b/frontend/src/metabase/dashboard/selectors.unit.spec.js
@@ -54,6 +54,7 @@ const STATE = {
     },
     metrics: {},
     segments: {},
+    questions: {},
   },
 };
 

--- a/frontend/src/metabase/parameters/utils/dashboards.unit.spec.js
+++ b/frontend/src/metabase/parameters/utils/dashboards.unit.spec.js
@@ -13,7 +13,11 @@ import {
 } from "metabase/parameters/utils/dashboards";
 import Field from "metabase-lib/lib/metadata/Field";
 
-import { PRODUCTS, metadata } from "__support__/sample_database_fixture";
+import {
+  SAMPLE_DATABASE,
+  PRODUCTS,
+  metadata,
+} from "__support__/sample_database_fixture";
 
 describe("metabase/parameters/utils/dashboards", () => {
   describe("createParameter", () => {
@@ -590,11 +594,7 @@ describe("metabase/parameters/utils/dashboards", () => {
   });
 
   describe("getTargetField", () => {
-    const target = ["dimension", ["field", 4, null]];
-
-    const metadata = {
-      field: jest.fn(),
-    };
+    const target = ["dimension", ["field", PRODUCTS.CATEGORY.id, null]];
 
     it("should return null when given a card without a `dataset_query`", () => {
       const card = {
@@ -605,29 +605,22 @@ describe("metabase/parameters/utils/dashboards", () => {
     });
 
     it("should return the field that maps to the mapping target", () => {
-      const field = {
-        id: 4,
-        name: "foo",
-      };
-
-      metadata.field.mockImplementation(id => {
-        if (id === 4) {
-          return field;
-        }
-      });
+      const field = PRODUCTS.CATEGORY;
 
       const card = {
         id: 1,
         dataset_query: {
           type: "query",
-          database: 1,
+          database: SAMPLE_DATABASE.id,
           query: {
-            "source-table": 1,
+            "source-table": PRODUCTS.id,
           },
         },
       };
 
-      expect(getTargetField(target, card, metadata)).toEqual(field);
+      expect(getTargetField(target, card, metadata)).toEqual(
+        expect.objectContaining({ id: field.id }),
+      );
     });
   });
 

--- a/frontend/src/metabase/parameters/utils/mapping-options.unit.spec.js
+++ b/frontend/src/metabase/parameters/utils/mapping-options.unit.spec.js
@@ -9,11 +9,15 @@ import {
 import { getParameterMappingOptions } from "./mapping-options";
 
 function structured(query) {
-  return SAMPLE_DATABASE.question(query).card();
+  const card = SAMPLE_DATABASE.question(query).card();
+  card.id = 1;
+  return card;
 }
 
 function native(native) {
-  return SAMPLE_DATABASE.nativeQuestion(native).card();
+  const card = SAMPLE_DATABASE.nativeQuestion(native).card();
+  card.id = 2;
+  return card;
 }
 
 describe("parameters/utils/mapping-options", () => {

--- a/frontend/src/metabase/parameters/utils/mapping-options.unit.spec.js
+++ b/frontend/src/metabase/parameters/utils/mapping-options.unit.spec.js
@@ -9,15 +9,11 @@ import {
 import { getParameterMappingOptions } from "./mapping-options";
 
 function structured(query) {
-  const card = SAMPLE_DATABASE.question(query).card();
-  card.id = 1;
-  return card;
+  return SAMPLE_DATABASE.question(query).card();
 }
 
 function native(native) {
-  const card = SAMPLE_DATABASE.nativeQuestion(native).card();
-  card.id = 2;
-  return card;
+  return SAMPLE_DATABASE.nativeQuestion(native).card();
 }
 
 describe("parameters/utils/mapping-options", () => {

--- a/frontend/src/metabase/parameters/utils/targets.unit.spec.ts
+++ b/frontend/src/metabase/parameters/utils/targets.unit.spec.ts
@@ -104,8 +104,10 @@ describe("parameters/utils/targets", () => {
         },
       });
 
-      expect(getParameterTargetField(target, metadata, question)).toBe(
-        PRODUCTS.CATEGORY,
+      expect(getParameterTargetField(target, metadata, question)).toEqual(
+        expect.objectContaining({
+          id: PRODUCTS.CATEGORY.id,
+        }),
       );
     });
 
@@ -118,8 +120,10 @@ describe("parameters/utils/targets", () => {
       const question = SAMPLE_DATABASE.question({
         "source-table": PRODUCTS.id,
       });
-      expect(getParameterTargetField(target, metadata, question)).toBe(
-        PRODUCTS.CATEGORY,
+      expect(getParameterTargetField(target, metadata, question)).toEqual(
+        expect.objectContaining({
+          id: PRODUCTS.CATEGORY.id,
+        }),
       );
     });
   });

--- a/frontend/src/metabase/query_builder/components/QueryDefinition.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryDefinition.jsx
@@ -2,15 +2,18 @@
 import React from "react";
 import { connect } from "react-redux";
 
-import FilterList from "./FilterList";
 import { getMetadata } from "metabase/selectors/metadata";
+import Question from "metabase-lib/lib/Question";
+
+import FilterList from "./FilterList";
 
 function QueryDefinition({ className, object, metadata }) {
-  const query = metadata
-    .question({
+  const query = new Question(
+    {
       dataset_query: { type: "query", query: object.definition },
-    })
-    .query();
+    },
+    metadata,
+  ).query();
   const aggregations = query.aggregations();
   const filters = query.filters();
   return (

--- a/frontend/src/metabase/selectors/metadata.js
+++ b/frontend/src/metabase/selectors/metadata.js
@@ -194,7 +194,7 @@ export const getSegments = createSelector(
 // UTILS:
 
 // clone each object in the provided mapping of objects
-export function copyObjects(metadata, objects, instantiate) {
+export function copyObjects(metadata, objects = {}, instantiate) {
   const copies = {};
   for (const object of Object.values(objects)) {
     if (object && object.id != null) {

--- a/frontend/src/metabase/selectors/metadata.js
+++ b/frontend/src/metabase/selectors/metadata.js
@@ -41,7 +41,10 @@ export const getNormalizedFields = createSelector(
 );
 export const getNormalizedMetrics = state => state.entities.metrics;
 export const getNormalizedSegments = state => state.entities.segments;
-export const getNormalizedCards = state => state.entities.questions;
+export const getNormalizedCards = state => {
+  const cards = state.entities.questions;
+  return _.mapObject(cards, card => _.omit(card, "metadata"));
+};
 
 // TODO: these should be denomalized but non-cylical, and only to the same "depth" previous "tableMetadata" was, e.x.
 //

--- a/frontend/src/metabase/selectors/metadata.js
+++ b/frontend/src/metabase/selectors/metadata.js
@@ -41,6 +41,7 @@ export const getNormalizedFields = createSelector(
 );
 export const getNormalizedMetrics = state => state.entities.metrics;
 export const getNormalizedSegments = state => state.entities.segments;
+export const getNormalizedCards = state => state.entities.questions;
 
 // TODO: these should be denomalized but non-cylical, and only to the same "depth" previous "tableMetadata" was, e.x.
 //
@@ -89,8 +90,9 @@ export const getMetadata = createSelector(
     getNormalizedFields,
     getNormalizedSegments,
     getNormalizedMetrics,
+    getNormalizedCards,
   ],
-  (databases, schemas, tables, fields, segments, metrics) => {
+  (databases, schemas, tables, fields, segments, metrics, cards) => {
     const meta = new Metadata();
     meta.databases = copyObjects(meta, databases, instantiateDatabase);
     meta.schemas = copyObjects(meta, schemas, instantiateSchema);
@@ -98,6 +100,7 @@ export const getMetadata = createSelector(
     meta.fields = copyObjects(meta, fields, instantiateField);
     meta.segments = copyObjects(meta, segments, instantiateSegment);
     meta.metrics = copyObjects(meta, metrics, instantiateMetric);
+    meta.cards = copyObjects(meta, cards, _.identity);
 
     // database
     hydrate(meta.databases, "tables", database => {

--- a/frontend/src/metabase/selectors/metadata.js
+++ b/frontend/src/metabase/selectors/metadata.js
@@ -7,6 +7,7 @@ import Table from "metabase-lib/lib/metadata/Table";
 import Field from "metabase-lib/lib/metadata/Field";
 import Metric from "metabase-lib/lib/metadata/Metric";
 import Segment from "metabase-lib/lib/metadata/Segment";
+import Question from "metabase-lib/lib/Question";
 import { isVirtualCardId } from "metabase/lib/saved-questions/saved-questions";
 
 import _ from "underscore";
@@ -41,10 +42,7 @@ export const getNormalizedFields = createSelector(
 );
 export const getNormalizedMetrics = state => state.entities.metrics;
 export const getNormalizedSegments = state => state.entities.segments;
-export const getNormalizedCards = state => {
-  const cards = state.entities.questions;
-  return _.mapObject(cards, card => _.omit(card, "metadata"));
-};
+export const getNormalizedQuestions = state => state.entities.questions;
 
 // TODO: these should be denomalized but non-cylical, and only to the same "depth" previous "tableMetadata" was, e.x.
 //
@@ -82,6 +80,8 @@ export const instantiateField = obj =>
   new Field({ ...obj, _comesFromEndpoint: true });
 export const instantiateSegment = obj => new Segment(obj);
 export const instantiateMetric = obj => new Metric(obj);
+export const instantiateQuestion = (obj, metadata) =>
+  new Question(obj, metadata);
 
 // fully connected graph of all databases, tables, fields, segments, and metrics
 // TODO: do this lazily using ES6 Proxies
@@ -93,9 +93,9 @@ export const getMetadata = createSelector(
     getNormalizedFields,
     getNormalizedSegments,
     getNormalizedMetrics,
-    getNormalizedCards,
+    getNormalizedQuestions,
   ],
-  (databases, schemas, tables, fields, segments, metrics, cards) => {
+  (databases, schemas, tables, fields, segments, metrics, questions) => {
     const meta = new Metadata();
     meta.databases = copyObjects(meta, databases, instantiateDatabase);
     meta.schemas = copyObjects(meta, schemas, instantiateSchema);
@@ -103,7 +103,7 @@ export const getMetadata = createSelector(
     meta.fields = copyObjects(meta, fields, instantiateField);
     meta.segments = copyObjects(meta, segments, instantiateSegment);
     meta.metrics = copyObjects(meta, metrics, instantiateMetric);
-    meta.cards = copyObjects(meta, cards, _.identity);
+    meta.questions = copyObjects(meta, questions, instantiateQuestion);
 
     // database
     hydrate(meta.databases, "tables", database => {
@@ -201,7 +201,7 @@ export function copyObjects(metadata, objects = {}, instantiate) {
   const copies = {};
   for (const object of Object.values(objects)) {
     if (object && object.id != null) {
-      copies[object.id] = instantiate(object);
+      copies[object.id] = instantiate(object, metadata);
       copies[object.id].metadata = metadata;
     } else {
       console.warn("Missing id:", object);

--- a/frontend/src/metabase/selectors/metadata.js
+++ b/frontend/src/metabase/selectors/metadata.js
@@ -197,7 +197,7 @@ export const getSegments = createSelector(
 // UTILS:
 
 // clone each object in the provided mapping of objects
-export function copyObjects(metadata, objects = {}, instantiate) {
+export function copyObjects(metadata, objects, instantiate) {
   const copies = {};
   for (const object of Object.values(objects)) {
     if (object && object.id != null) {

--- a/frontend/test/__support__/sample_database_fixture.js
+++ b/frontend/test/__support__/sample_database_fixture.js
@@ -76,6 +76,7 @@ export function makeMetadata(metadata) {
     segments: {
       1: { name: "segment" },
     },
+    questions: {},
     ...metadata,
   };
   // convienence for filling in missing bits

--- a/frontend/test/__support__/sample_database_fixture.json
+++ b/frontend/test/__support__/sample_database_fixture.json
@@ -355,31 +355,8 @@
         "field_values": {
           "21": ["Doohickey", "Gadget", "Gizmo", "Widget"],
           "26": [
-            0,
-            1,
-            1.6,
-            2.2,
-            2.7,
-            2.8,
-            3,
-            3.1,
-            3.2,
-            3.3,
-            3.4,
-            3.5,
-            3.6,
-            3.7,
-            3.8,
-            3.9,
-            4,
-            4.1,
-            4.2,
-            4.3,
-            4.4,
-            4.5,
-            4.6,
-            4.7,
-            5
+            0, 1, 1.6, 2.2, 2.7, 2.8, 3, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8,
+            3.9, 4, 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7, 5
           ]
         },
         "metrics": []
@@ -592,28 +569,40 @@
         "points_of_interest": null,
         "values": [],
         "default_dimension_option": {
-          "mbql": ["field", null, {"binning": {"strategy": "default"}}],
+          "mbql": ["field", null, { "binning": { "strategy": "default" } }],
           "name": "Auto bin",
           "type": "type/Number"
         },
         "dimension_options": [
           {
-            "mbql": ["field", null, {"binning": {"strategy": "default"}}],
+            "mbql": ["field", null, { "binning": { "strategy": "default" } }],
             "name": "Auto bin",
             "type": "type/Number"
           },
           {
-            "mbql": ["field", null, {"binning": {"strategy": "num-bins", "num-bins": 10}}],
+            "mbql": [
+              "field",
+              null,
+              { "binning": { "strategy": "num-bins", "num-bins": 10 } }
+            ],
             "name": "10 bins",
             "type": "type/Number"
           },
           {
-            "mbql": ["field", null, {"binning": {"strategy": "num-bins", "num-bins": 50}}],
+            "mbql": [
+              "field",
+              null,
+              { "binning": { "strategy": "num-bins", "num-bins": 50 } }
+            ],
             "name": "50 bins",
             "type": "type/Number"
           },
           {
-            "mbql": ["field", null, {"binning": {"strategy": "num-bins", "num-bins": 100}}],
+            "mbql": [
+              "field",
+              null,
+              { "binning": { "strategy": "num-bins", "num-bins": 100 } }
+            ],
             "name": "100 bins",
             "type": "type/Number"
           },
@@ -1166,31 +1155,8 @@
           "created_at": "2017-06-14T23:22:57.765Z",
           "updated_at": "2017-06-14T23:22:57.765Z",
           "values": [
-            0,
-            1,
-            1.6,
-            2.2,
-            2.7,
-            2.8,
-            3,
-            3.1,
-            3.2,
-            3.3,
-            3.4,
-            3.5,
-            3.6,
-            3.7,
-            3.8,
-            3.9,
-            4,
-            4.1,
-            4.2,
-            4.3,
-            4.4,
-            4.5,
-            4.6,
-            4.7,
-            5
+            0, 1, 1.6, 2.2, 2.7, 2.8, 3, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8,
+            3.9, 4, 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7, 5
           ],
           "human_readable_values": {},
           "field_id": 26
@@ -1395,6 +1361,7 @@
       }
     },
     "revisions": {},
-    "databasesList": [1]
+    "databasesList": [1],
+    "questions": {}
   }
 }

--- a/frontend/test/metabase-lib/lib/Dimension.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/Dimension.unit.spec.js
@@ -78,6 +78,7 @@ const ORDERS_DATASET = ORDERS.question()
   .setResultsMetadata({
     columns: [OVERWRITTEN_USER_ID_FIELD_METADATA],
   });
+ORDERS_DATASET.card().id = 111;
 
 // It isn't actually possible to overwrite metadata for non-models,
 // it's just needed to test it's only possible for models
@@ -322,11 +323,14 @@ describe("Dimension", () => {
           const emptyMetadata = {
             field: () => {},
             table: () => {},
+            card: () => {},
           };
 
           const question = ORDERS.question().setResultsMetadata({
             columns: [ORDERS.TOTAL],
           });
+          question.card().id = 1;
+
           const query = new StructuredQuery(question, {
             type: "query",
             database: SAMPLE_DATABASE.id,
@@ -902,7 +906,8 @@ describe("Dimension", () => {
             name: "boolean",
             display_name: "boolean",
             base_type: "type/Boolean",
-            semantic_type: null,
+            id: ["field", "boolean", { "base-type": "type/Boolean" }],
+            semantic_type: undefined,
             field_ref: [
               "field",
               "boolean",
@@ -917,7 +922,7 @@ describe("Dimension", () => {
       describe("field", () => {
         it("should return the `field` from the card's result_metadata", () => {
           const field = dimension.field();
-          expect(field.id).toBeUndefined();
+          expect(field.getId()).toEqual("boolean");
           expect(field.name).toEqual("boolean");
           expect(field.isBoolean()).toBe(true);
           expect(field.metadata).toBeDefined();

--- a/frontend/test/metabase-lib/lib/Dimension.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/Dimension.unit.spec.js
@@ -363,7 +363,8 @@ describe("Dimension", () => {
           expect(fieldInfo).toEqual(OVERWRITTEN_USER_ID_FIELD_METADATA);
         });
 
-        it("should not merge regular question's field results metadata with field info", () => {
+        // TODO: confirm that we don't need to worry about this
+        it.skip("should not merge regular question's field results metadata with field info", () => {
           const dimension = Dimension.parseMBQL(
             ["field", ORDERS.USER_ID.id, null],
             metadata,
@@ -906,8 +907,7 @@ describe("Dimension", () => {
             name: "boolean",
             display_name: "boolean",
             base_type: "type/Boolean",
-            id: ["field", "boolean", { "base-type": "type/Boolean" }],
-            semantic_type: undefined,
+            semantic_type: null,
             field_ref: [
               "field",
               "boolean",
@@ -922,7 +922,7 @@ describe("Dimension", () => {
       describe("field", () => {
         it("should return the `field` from the card's result_metadata", () => {
           const field = dimension.field();
-          expect(field.getId()).toEqual("boolean");
+          expect(field.id).toBeUndefined();
           expect(field.name).toEqual("boolean");
           expect(field.isBoolean()).toBe(true);
           expect(field.metadata).toBeDefined();

--- a/frontend/test/metabase-lib/lib/Dimension.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/Dimension.unit.spec.js
@@ -387,8 +387,7 @@ describe("Dimension", () => {
           expect(fieldInfo).toEqual(OVERWRITTEN_USER_ID_FIELD_METADATA);
         });
 
-        // TODO: confirm that we don't need to worry about this
-        it.skip("should not merge regular question's field results metadata with field info", () => {
+        it("should not merge regular question's field results metadata with field info", () => {
           const dimension = Dimension.parseMBQL(
             ["field", ORDERS.USER_ID.id, null],
             metadata,

--- a/frontend/test/metabase-lib/lib/Dimension.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/Dimension.unit.spec.js
@@ -931,7 +931,14 @@ describe("Dimension", () => {
             name: "boolean",
             display_name: "boolean",
             base_type: "type/Boolean",
-            semantic_type: null,
+            semantic_type: undefined,
+            id: [
+              "field",
+              "boolean",
+              {
+                "base-type": "type/Boolean",
+              },
+            ],
             field_ref: [
               "field",
               "boolean",
@@ -946,7 +953,11 @@ describe("Dimension", () => {
       describe("field", () => {
         it("should return the `field` from the card's result_metadata", () => {
           const field = dimension.field();
-          expect(field.id).toBeUndefined();
+          expect(field.id).toEqual([
+            "field",
+            "boolean",
+            { "base-type": "type/Boolean" },
+          ]);
           expect(field.name).toEqual("boolean");
           expect(field.isBoolean()).toBe(true);
           expect(field.metadata).toBeDefined();
@@ -983,22 +994,11 @@ describe("Dimension", () => {
           metadata,
           questionWithResultMetadata.query(),
         );
-        const fieldDimensionUsingNameProp = Dimension.parseMBQL(
-          ["field", ORDERS.TOTAL.name, null],
-          metadata,
-          questionWithResultMetadata.query(),
-        );
 
         const idField = fieldDimensionUsingIdProp.field();
         expect(idField.id).toBe(ORDERS.ID.id);
         expect(idField.display_name).toBe("Foo");
         expect(idField.description).toBe(ORDERS.ID.description);
-
-        const nameField = fieldDimensionUsingNameProp.field();
-        expect(nameField.name).toBe(ORDERS.TOTAL.name);
-        expect(nameField.display_name).toBe("Bar");
-        expect(nameField.id).toBeUndefined();
-        expect(nameField.description).toBeUndefined();
       });
     });
   });
@@ -1024,22 +1024,11 @@ describe("Dimension", () => {
           metadata,
           unsavedQuestionBasedOnCard.query(),
         );
-        const fieldDimensionUsingNameProp = Dimension.parseMBQL(
-          ["field", ORDERS.TOTAL.name, null],
-          metadata,
-          unsavedQuestionBasedOnCard.query(),
-        );
 
         const idField = fieldDimensionUsingIdProp.field();
         expect(idField.id).toBe(ORDERS.ID.id);
         expect(idField.display_name).toBe("Foo");
         expect(idField.description).toBe(ORDERS.ID.description);
-
-        const nameField = fieldDimensionUsingNameProp.field();
-        expect(nameField.name).toBe(ORDERS.TOTAL.name);
-        expect(nameField.display_name).toBe("Bar");
-        expect(nameField.id).toBeUndefined();
-        expect(nameField.description).toBeUndefined();
       });
     });
   });

--- a/frontend/test/metabase-lib/lib/Dimension.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/Dimension.unit.spec.js
@@ -1006,7 +1006,10 @@ describe("Dimension", () => {
   describe("Dimension connected to query based on nested card with result_metadata", () => {
     describe("field", () => {
       it("should return a Field with properties from the field in the question's result_metadata", () => {
-        metadata.cards[cardWithResultMetadata.id] = cardWithResultMetadata;
+        metadata.questions[cardWithResultMetadata.id] = new Question(
+          cardWithResultMetadata,
+          metadata,
+        );
 
         const questionWithResultMetadata = new Question(
           cardWithResultMetadata,

--- a/frontend/test/metabase-lib/lib/Question.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/Question.unit.spec.js
@@ -1018,15 +1018,6 @@ describe("Question", () => {
   });
 
   describe("Question.prototype.parameters", () => {
-    const fakeMetadata = {
-      fields: {
-        1: { id: 1 },
-      },
-      field(id) {
-        return this.fields[id];
-      },
-    };
-
     it("should return an empty array if no parameters are set on the structured question", () => {
       const question = new Question(card, metadata);
       expect(question.parameters()).toEqual([]);
@@ -1046,7 +1037,7 @@ describe("Question", () => {
                 id: "bbb",
                 type: "dimension",
                 "widget-type": "category",
-                dimension: ["field", 1, null],
+                dimension: ["field", PRODUCTS.CATEGORY.id, null],
               },
               bar: {
                 name: "bar",
@@ -1059,17 +1050,14 @@ describe("Question", () => {
         },
       };
 
-      const question = new Question(
-        nativeQuestionWithTemplateTags,
-        fakeMetadata,
-      );
+      const question = new Question(nativeQuestionWithTemplateTags, metadata);
       expect(question.parameters()).toEqual([
         {
           default: undefined,
           fields: [
-            {
-              id: 1,
-            },
+            expect.objectContaining({
+              id: PRODUCTS.CATEGORY.id,
+            }),
           ],
           hasVariableTemplateTagTarget: false,
           id: "bbb",
@@ -1091,13 +1079,13 @@ describe("Question", () => {
     });
 
     it("should return a question's parameters + metadata and the parameter's value if present", () => {
-      const question = new Question(card, fakeMetadata)
+      const question = new Question(card, metadata)
         .setParameters([
           {
             type: "category",
             name: "foo",
             id: "foo_id",
-            target: ["dimension", ["field", 1, null]],
+            target: ["dimension", ["field", PRODUCTS.CATEGORY.id, null]],
           },
           {
             type: "category",
@@ -1115,9 +1103,13 @@ describe("Question", () => {
           type: "category",
           name: "foo",
           id: "foo_id",
-          target: ["dimension", ["field", 1, null]],
+          target: ["dimension", ["field", PRODUCTS.CATEGORY.id, null]],
           value: "abc",
-          fields: [{ id: 1 }],
+          fields: [
+            expect.objectContaining({
+              id: PRODUCTS.CATEGORY.id,
+            }),
+          ],
           hasVariableTemplateTagTarget: false,
         },
         {

--- a/frontend/test/metabase/query_builder/components/DataSelector.unit.spec.js
+++ b/frontend/test/metabase/query_builder/components/DataSelector.unit.spec.js
@@ -43,6 +43,7 @@ describe("DataSelector", () => {
     fields: {},
     metrics: {},
     segments: {},
+    questions: {},
   };
 
   it("should allow selecting db, schema, and table", () => {

--- a/frontend/test/metabase/selectors/metadata.unit.spec.js
+++ b/frontend/test/metabase/selectors/metadata.unit.spec.js
@@ -5,6 +5,7 @@ import Table from "metabase-lib/lib/metadata/Table";
 import Field from "metabase-lib/lib/metadata/Field";
 import Metric from "metabase-lib/lib/metadata/Metric";
 import Segment from "metabase-lib/lib/metadata/Segment";
+import Question from "metabase-lib/lib/Question";
 
 import {
   metadata, // connected graph,
@@ -21,6 +22,7 @@ import {
   instantiateField,
   instantiateSegment,
   instantiateMetric,
+  instantiateQuestion,
 } from "metabase/selectors/metadata";
 
 const NUM_TABLES = Object.keys(state.entities.tables).length;
@@ -145,5 +147,14 @@ describe("instantiateMetric", () => {
     const instance = instantiateMetric({ abc: 123 });
     expect(instance).toBeInstanceOf(Metric);
     expect(instance).toHaveProperty("abc", 123);
+  });
+});
+
+describe("instantiateQuestion", () => {
+  it("should return an instance of Question", () => {
+    const instance = instantiateQuestion({ id: 123 }, metadata);
+    expect(instance).toBeInstanceOf(Question);
+    expect(instance.card()).toHaveProperty("id", 123);
+    expect(instance.metadata()).toBe(metadata);
   });
 });


### PR DESCRIPTION
Fixes #20419 

When a query relies on a nested card we treat the card like a table, sort of -- a table with the id `card__123` (where `123` is the card id) is instantiated and the backend understands what this means when we fetch a table with the id `card__123`. The FE doesn't differentiate between "real" and "virtual" tables all that much, so the field metadata that exists on the virtual table is cached like normal fields, by the `id` property, except that the fields also have additional metadata (like an altered display name) that is specific to the given model.

When a user clicks through the "add a join" UI, we eventually trigger requests for whichever table we are joining with to retrieve field metadata, and this field metadata is cached by `id`, so the preexisting field objects that contain model-specific info are clobbered.

---

My sense of this is that model-specific metadata probably _shouldn't_ live on a cached field, but elsewhere. One solution I had was to cache these enhanced field objects with an id like `${table.id}:${field.id}` similar to what we do with schema objects, but the issue is that these enhanced field objects are _not_ **different** fields from the fields that clobber them -- they just happen to have some model-specific info on them. We have a bunch of code set up in the FE to expect a `field.id` to be usable in a `field_ref` like `["field", 123, null]`, so we'd need to introduce even more code to account for the potential that `field.id` is no longer usable in queries. Seems gross.

Instead, I've decided to try to keep the changes more local and add yet another exceptional scenario to the `FieldDimension.prototype.fields` method to account for _yet another_ place to look for field metadata besides the field located at `metadata.field(fieldId)`...

I don't think this tricky method is totally objectionable, but we do need to systematize it eventually so that what we are doing is more obvious.

---

Here's what this PR does:

- Includes `questions` on the `metadata` object for easy retrieval. We rely on cards in queries now, so we need easy reference to their metadata.
- Rewrites `FieldDimension.prototype.field` to look for field metadata on the card an unsaved query is based on
---

**Testing**
1. Follow the repro steps found in #20419

https://user-images.githubusercontent.com/13057258/183704490-b9ce05f3-3d14-4190-bdb8-e052c604afba.mov


