### PR TITLE
Bump shadow-cljs to 2.19.6

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Run clj-kondo
-      run: docker run -v $PWD:/work --rm cljkondo/clj-kondo:2022.04.25 clj-kondo --config /work/.clj-kondo/config.edn --config-dir /work/.clj-kondo --lint /work/src:/work/enterprise/backend/src:/work/shared/src
+      run: docker run -v $PWD:/work --rm cljkondo/clj-kondo:2022.08.03 clj-kondo --config /work/.clj-kondo/config.edn --config-dir /work/.clj-kondo --lint /work/src:/work/enterprise/backend/src:/work/shared/src
 
   be-linter-eastwood:
     runs-on: ubuntu-20.04

--- a/package.json
+++ b/package.json
@@ -238,7 +238,7 @@
     "promise-loader": "^1.0.0",
     "raf": "^3.4.0",
     "react-refresh": "^0.13.0",
-    "shadow-cljs": "2.11.20",
+    "shadow-cljs": "2.19.6",
     "style-loader": "0.23.1",
     "typescript": "^4.7.2",
     "webpack": "^5.69.0",

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -6,13 +6,12 @@
  ;; TODO -- share deps with deps.edn -- see https://shadow-cljs.github.io/docs/UsersGuide.html#deps-edn
  :dependencies
  [[org.clojure/core.match "1.0.0"]
-  [medley "1.3.0"]
+  [medley "1.4.0"]
   [net.cgrand/macrovich "0.2.1"]
   [prismatic/schema "1.2.0"]
 
   ;; new stuff
-  [lambdaisland/glogi "1.0.106"]]
-
+  [com.lambdaisland/glogi "1.1.144"]]
  :nrepl
  {:middleware
   [cider.nrepl/cider-middleware

--- a/shared/src/metabase/shared/parameters/parameters.cljc
+++ b/shared/src/metabase/shared/parameters/parameters.cljc
@@ -220,9 +220,9 @@
   "Normalize a single parameter by calling [[mbql.normalize/normalize-fragment]] on it, and converting all string keys
   to keywords."
   [parameter]
-  (->> (mbql.normalize/normalize-fragment [:parameters] [parameter])
-       first
-       (reduce-kv (fn [acc k v] (assoc acc (keyword k) v)) {})))
+  (-> (mbql.normalize/normalize-fragment [:parameters] [parameter])
+      first
+      (update-keys keyword)))
 
 (defn ^:export substitute_tags
   "Given the context of a text dashboard card, replace all template tags in the text with their corresponding values,
@@ -233,10 +233,7 @@
    (when text
      (let [tag->param #?(:clj tag->param
                          :cljs (js->clj tag->param))
-           tag->normalized-param (reduce-kv (fn [acc tag param]
-                                              (assoc acc tag (normalize-parameter param)))
-                                            {}
-                                            tag->param)]
+           tag->normalized-param (update-vals tag->param normalize-parameter)]
        ;; Most of the functions in this pipeline are relating to handling optional blocks in the text which use
        ;; the [[ ]] syntax.
        ;; For example, given an input "[[a {{b}}]] [[{{c}}]]", where `b` has no value and `c` = 3:

--- a/shared/src/metabase/shared/util/log.cljs
+++ b/shared/src/metabase/shared/util/log.cljs
@@ -3,9 +3,7 @@
             [goog.string.format :as gstring.format]
             [lambdaisland.glogi :as log]
             [lambdaisland.glogi.console :as glogi-console])
-  (:require-macros metabase.shared.util.log)
-  (:import goog.debug.Logger
-           goog.debug.Logger.Level))
+  (:require-macros metabase.shared.util.log))
 
 (comment metabase.shared.util.log/keep-me
          gstring.format/keep-me)
@@ -37,4 +35,4 @@
 (defn is-loggable?
   "Part of the impl for [[metabase.shared.util.log/js-logp]] and [[metabase.shared.util.log/js-logf]]."
   [logger-name level]
-  (.isLoggable ^Logger (log/logger logger-name) ^Level (log/levels level)))
+  (.isLoggable (log/logger logger-name) (log/levels level)))

--- a/yarn.lock
+++ b/yarn.lock
@@ -6666,11 +6666,6 @@ async-each@^1.0.1:
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.3.tgz#b727dbf87d7651602f06f4d4ac387f47d91b0cbf"
   integrity sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==
 
-async-limiter@~1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
-  integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
-
 async@^2.6.2:
   version "2.6.4"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.4.tgz#706b7ff6084664cd7eae713f6f965433b5504221"
@@ -19385,17 +19380,17 @@ shadow-cljs-jar@1.3.2:
   resolved "https://registry.yarnpkg.com/shadow-cljs-jar/-/shadow-cljs-jar-1.3.2.tgz#97273afe1747b6a2311917c1c88d9e243c81957b"
   integrity sha512-XmeffAZHv8z7451kzeq9oKh8fh278Ak+UIOGGrapyqrFBB773xN8vMQ3O7J7TYLnb9BUwcqadKkmgaq7q6fhZg==
 
-shadow-cljs@2.11.20:
-  version "2.11.20"
-  resolved "https://registry.yarnpkg.com/shadow-cljs/-/shadow-cljs-2.11.20.tgz#fa814b74a7fa7909ff056994a80f8f7435881046"
-  integrity sha512-TmZp1Hjp49oziqaTdBYwO0qzvoVMYa+O5c7rwdfO334bdYhTPMmJJeG/EbeJpRvLAKErjbxGmY4P28rqfPmZ3w==
+shadow-cljs@2.19.6:
+  version "2.19.6"
+  resolved "https://registry.yarnpkg.com/shadow-cljs/-/shadow-cljs-2.19.6.tgz#c0143434a87e215ca53658060357ea00775d3074"
+  integrity sha512-WL74UvWIWBhNt6p9bE4oAJqYpONe80EMRRA23K9zDZEC1y3Y8D1/n77wPM9oGmDo2fD4UpkRNAq1uf22d71Pug==
   dependencies:
     node-libs-browser "^2.2.1"
     readline-sync "^1.4.7"
     shadow-cljs-jar "1.3.2"
     source-map-support "^0.4.15"
     which "^1.3.1"
-    ws "^3.0.0"
+    ws "^7.4.6"
 
 shallow-clone@^3.0.0:
   version "3.0.1"
@@ -20905,11 +20900,6 @@ uglify-js@^3.1.4:
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.14.1.tgz#e2cb9fe34db9cb4cf7e35d1d26dfea28e09a7d06"
   integrity sha512-JhS3hmcVaXlp/xSo3PKY5R0JqKs5M3IV+exdLHW99qKvKivPO4Z8qbej6mte17SOPqAOVMjt/XGgWacnFSzM3g==
 
-ultron@~1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.1.1.tgz#9fe1536a10a664a65266a1e3ccf85fd36302bc9c"
-  integrity sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==
-
 unbox-primitive@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unbox-primitive/-/unbox-primitive-1.0.0.tgz#eeacbc4affa28e9b3d36b5eaeccc50b3251b1d3f"
@@ -22032,19 +22022,15 @@ write-file-atomic@^3.0.0:
     signal-exit "^3.0.2"
     typedarray-to-buffer "^3.1.5"
 
-ws@^3.0.0:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-3.3.3.tgz#f1cf84fe2d5e901ebce94efaece785f187a228f2"
-  integrity sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==
-  dependencies:
-    async-limiter "~1.0.0"
-    safe-buffer "~5.1.0"
-    ultron "~1.1.0"
-
 ws@^7.4.5:
   version "7.5.3"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.3.tgz#160835b63c7d97bfab418fc1b8a9fced2ac01a74"
   integrity sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==
+
+ws@^7.4.6:
+  version "7.5.9"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.9.tgz#54fa7db29f4c7cec68b1ddd3a89de099942bb591"
+  integrity sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==
 
 ws@^8.0.0, ws@^8.4.2:
   version "8.5.0"


### PR DESCRIPTION
* Bumps shadow-cljs to 2.19.6, and by extension ClojureScript to 1.11.60 (this was done by @dpsutton, thanks Dan)
* Updates a couple spots to use `update-keys` and `update-vals`

This was originally going to be a part of an earlier (pre-release) PR but it turned out I didn't need it, so I've split it into a separate PR to make it easier to debug/revert in case any potential issues that come up.