### PR TITLE
Updates to deps for 43

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -116,7 +116,7 @@
   org.clojure/tools.namespace               {:mvn/version "1.2.0"}
   org.clojure/tools.reader                  {:mvn/version "1.3.6"}
   org.clojure/tools.trace                   {:mvn/version "0.7.11"}             ; function tracing
-  org.eclipse.jetty/jetty-server            {:mvn/version "9.4.44.v20210927"}   ; web server
+  org.eclipse.jetty/jetty-server            {:mvn/version "9.4.48.v20220622"}   ; web server
   org.flatland/ordered                      {:mvn/version "1.15.10"}            ; ordered maps & sets
   org.graalvm.js/js                         {:mvn/version "22.0.0.2"}           ; JavaScript engine
   org.liquibase/liquibase-core              {:mvn/version "4.8.0"               ; migration management (Java lib)

--- a/modules/drivers/sparksql/deps.edn
+++ b/modules/drivers/sparksql/deps.edn
@@ -5,7 +5,7 @@
  ;; implementations of things like log4j <-> slf4j, or are part of both hadoop-common and hive-jdbc;
  :deps
  {org.apache.hive/hive-jdbc
-  {:mvn/version "3.1.2"
+  {:mvn/version "3.1.3"
    :exclusions  [aopalliance/aopalliance
                  ch.qos.logback/logback-classic
                  ch.qos.logback/logback-core


### PR DESCRIPTION
Some embedding customers are still on 43 and benefit from some of the dependency bumps made on 44 related to deps that flag for security issues. Though they're no known vulnerabilities in Metabase itself, many customers have infosec policies that require security scans to pass on software they're embedding in their product.

Two specific cherry-picks: bumping have to 3.1.3 and jetty-server to 9.4.48.