### PR TITLE
fixing dashboard sticky params when embedded

### DIFF
--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
@@ -88,6 +88,7 @@ class Dashboard extends Component {
     closeSidebar: PropTypes.func.isRequired,
     openAddQuestionSidebar: PropTypes.func.isRequired,
     showAddQuestionSidebar: PropTypes.bool.isRequired,
+    embedOptions: PropTypes.object,
   };
 
   static defaultProps = {
@@ -223,6 +224,7 @@ class Dashboard extends Component {
       setParameterIndex,
       setEditingParameter,
       isHeaderVisible,
+      embedOptions,
     } = this.props;
 
     const { error, isParametersWidgetSticky } = this.state;
@@ -302,6 +304,7 @@ class Dashboard extends Component {
                     ref={element => (this.parametersWidgetRef = element)}
                     isNavbarOpen={isNavbarOpen}
                     isSticky={isParametersWidgetSticky}
+                    topNav={embedOptions?.top_nav}
                   >
                     {parametersWidget}
                   </ParametersWidgetContainer>

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.jsx
@@ -104,11 +104,11 @@ export const ParametersWidgetContainer = styled(FullWidthContainer)`
       border-top: 1px solid ${color("border")};
     `}
 
-  ${({ isSticky }) =>
+  ${({ isSticky, topNav }) =>
     isSticky &&
     css`
       position: fixed;
-      top: ${APP_BAR_HEIGHT};
+      top: ${IFRAMED && !topNav ? "0" : APP_BAR_HEIGHT};
       left: 0;
       border-bottom: 1px solid ${color("border")};
     `}

--- a/frontend/src/metabase/dashboard/components/Dashboard/stickyParameters.js
+++ b/frontend/src/metabase/dashboard/components/Dashboard/stickyParameters.js
@@ -51,7 +51,7 @@ const checkIfParametersWidgetShouldBeSticky = dashboard => {
 
   const offsetTop = getOffsetTop(dashboard);
 
-  return getMainElement().scrollTop >= offsetTop;
+  return getMainElement().scrollTop > offsetTop;
 };
 
 const updateParametersAndCardsContainerStyle = (dashboard, shouldBeSticky) => {

--- a/frontend/src/metabase/dashboard/containers/DashboardApp.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp.jsx
@@ -50,6 +50,8 @@ import {
   canManageSubscriptions,
 } from "metabase/selectors/user";
 
+import { getEmbedOptions } from "metabase/selectors/embed";
+
 import * as dashboardActions from "../actions";
 import { parseHashOptions } from "metabase/lib/browser";
 import * as Urls from "metabase/lib/urls";
@@ -87,6 +89,7 @@ const mapStateToProps = (state, props) => {
     isLoadingComplete: getIsLoadingComplete(state),
     isHeaderVisible: getIsHeaderVisible(state),
     isAdditionalInfoVisible: getIsAdditionalInfoVisible(state),
+    embedOptions: getEmbedOptions(state),
   };
 };
 


### PR DESCRIPTION
Fixes #24652 

Adding a check for both `IFRAMED` and `topNav` to position the `ParametersWidgetContainer` correctly. Also needed to adjust the `checkIfParametersWidgetShouldBeSticky` function because `isSticky` was not changing to false when scrolling to the top of the dashboard in embedded mode for some reason (didn't appear to be an issue when not embedded)

#### In both images, I've scrolled down a bit
embedded:
![chrome_TfBtRx7pxJ](https://user-images.githubusercontent.com/1328979/183479712-47d381af-d9ad-4354-863a-fa1e4b473237.png)

embedded, `top_nav=true`
![chrome_H1vcwfFB6K](https://user-images.githubusercontent.com/1328979/183479752-4a763be5-0fac-4b0d-9bb8-8dc5112d958a.png)

