### PR TITLE
fix editing filter updates wrong filter

### DIFF
--- a/frontend/src/metabase/query_builder/components/filters/FilterPopover/FilterPopover.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/FilterPopover/FilterPopover.tsx
@@ -152,7 +152,12 @@ export default class FilterPopover extends Component<Props, State> {
   };
 
   handleFilterChange = (mbql: any[] = []) => {
-    const newFilter = new Filter(mbql, null, this.props.query);
+    const newFilter = new Filter(
+      mbql,
+      this.state.filter?.index(),
+      this.props.query,
+    );
+
     this.setFilter(newFilter);
   };
 

--- a/frontend/test/metabase/scenarios/filters/reproductions/24664-multiple-filters-editing.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/reproductions/24664-multiple-filters-editing.cy.spec.js
@@ -1,0 +1,28 @@
+import { restore, openProductsTable } from "__support__/e2e/helpers";
+
+describe("issue 24664", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+    openProductsTable({ limit: 3 });
+  });
+
+  it("should be possible to create multiple filter that start with the same value (metabase#24664)", () => {
+    cy.findByText("Category").click();
+    cy.findByText("Filter by this column").click();
+    cy.findByTestId("Doohickey-filter-value").click();
+    cy.button("Add filter").click();
+
+    cy.findByText("Category").click();
+    cy.findByText("Filter by this column").click();
+    cy.findByTestId("Gizmo-filter-value").click();
+    cy.button("Add filter").click();
+
+    cy.findByText("Category is Gizmo").click();
+    cy.findByTestId("Widget-filter-value").click();
+    cy.button("Update filter").click();
+
+    // First filter is still there
+    cy.findByText("Category is Doohickey");
+  });
+});


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/24664

## Changes

Unobvious bug caused by https://github.com/metabase/metabase/pull/24152
We need to preserve Filter index when updating it.

## How to verify

- New -> Question -> Products table -> Visualize
- Click on the Vendor column header -> Filter by this column -> Contains `a`
- Again click on the Vendor column header -> Filter by this column -> Contains `b`
- Edit the second filter from `b` to `c`
- Ensure the first filter is unchanged, the second has been updated