### PR TITLE
Properly Display Remapped Categories in Bulk Filter Modal

### DIFF
--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineCategoryPicker/InlineCategoryPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineCategoryPicker/InlineCategoryPicker.tsx
@@ -107,7 +107,7 @@ export function InlineCategoryPickerComponent({
       <SimpleCategoryFilterPicker
         filter={filter ?? newFilter}
         onChange={onChange}
-        options={fieldValues.flat().filter(isValidOption)}
+        options={fieldValues.filter(([value]) => isValidOption(value))}
       />
     );
   }

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineCategoryPicker/InlineCategoryPicker.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineCategoryPicker/InlineCategoryPicker.unit.spec.tsx
@@ -84,6 +84,26 @@ const nullCategoryField = new Field({
   metadata,
 });
 
+const remappedCategoryField = new Field({
+  database_type: "test",
+  semantic_type: "type/Category",
+  effective_type: "type/Text",
+  base_type: "type/Text",
+  table_id: 8,
+  name: "small_category_field",
+  has_field_values: "list",
+  values: [
+    ["Michaelangelo", "party turtle"],
+    ["Donatello", "engineer turtle"],
+    ["Raphael", "cool turtle"],
+    ["Leonardo", "leader turtle"],
+  ],
+  dimensions: {},
+  dimension_options: [],
+  id: 141,
+  metadata,
+});
+
 // @ts-ignore
 metadata.fields[smallCategoryField.id] = smallCategoryField;
 // @ts-ignore
@@ -92,6 +112,8 @@ metadata.fields[largeCategoryField.id] = largeCategoryField;
 metadata.fields[emptyCategoryField.id] = emptyCategoryField;
 // @ts-ignore
 metadata.fields[nullCategoryField.id] = nullCategoryField;
+// @ts-ignore
+metadata.fields[remappedCategoryField.id] = remappedCategoryField;
 
 const card = {
   dataset_query: {
@@ -111,6 +133,7 @@ const smallDimension = smallCategoryField.dimension();
 const largeDimension = largeCategoryField.dimension();
 const emptyDimension = emptyCategoryField.dimension();
 const nullDimension = nullCategoryField.dimension();
+const remappedDimension = remappedCategoryField.dimension();
 
 describe("InlineCategoryPicker", () => {
   beforeEach(() => {
@@ -264,6 +287,33 @@ describe("InlineCategoryPicker", () => {
     expect(screen.getByLabelText("Leonardo")).toBeChecked();
     expect(screen.getByLabelText("Raphael")).not.toBeChecked();
     expect(screen.getByLabelText("Michaelangelo")).not.toBeChecked();
+  });
+
+  it("should display remapped field values if present", () => {
+    const testFilter = new Filter(
+      ["=", ["field", remappedCategoryField.id, null], "Donatello", "Leonardo"],
+      null,
+      query,
+    );
+    const changeSpy = jest.fn();
+    const fetchSpy = jest.fn();
+
+    render(
+      <InlineCategoryPickerComponent
+        filter={testFilter}
+        newFilter={testFilter}
+        onChange={changeSpy}
+        fieldValues={remappedCategoryField.values}
+        fetchFieldValues={fetchSpy}
+        dimension={remappedDimension}
+      />,
+    );
+
+    screen.getByTestId("category-picker");
+    expect(screen.getByLabelText("engineer turtle")).toBeChecked();
+    expect(screen.getByLabelText("leader turtle")).toBeChecked();
+    expect(screen.getByLabelText("cool turtle")).not.toBeChecked();
+    expect(screen.getByLabelText("party turtle")).not.toBeChecked();
   });
 
   it("should save a filter based on selection", () => {

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineCategoryPicker/SimpleCategoryFilterPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineCategoryPicker/SimpleCategoryFilterPicker.tsx
@@ -9,9 +9,14 @@ import { PickerContainer, PickerGrid } from "./InlineCategoryPicker.styled";
 import { isValidOption } from "./utils";
 import { LONG_OPTION_LENGTH } from "./constants";
 
+type Option = [
+  string | number,
+  (string | number)?, // optional remapped display value
+];
+
 interface SimpleCategoryFilterPickerProps {
   filter: Filter;
-  options: (string | number)[];
+  options: Option[];
   onChange: (newFilter: Filter) => void;
 }
 
@@ -31,7 +36,8 @@ export function SimpleCategoryFilterPicker({
   };
 
   const hasShortOptions = !options.find(
-    option => String(option).length > LONG_OPTION_LENGTH,
+    ([value, displayValue]) =>
+      String(displayValue ?? value).length > LONG_OPTION_LENGTH,
   );
   // because we want options to flow by column, we have to explicitly set the number of rows
   const rows = Math.round(options.length / 2);
@@ -39,12 +45,12 @@ export function SimpleCategoryFilterPicker({
   return (
     <PickerContainer data-testid="category-picker">
       <PickerGrid multiColumn={hasShortOptions} rows={rows}>
-        {options.map((option: string | number) => (
+        {options.map(([option, displayOption]) => (
           <Checkbox
             key={option?.toString() ?? "empty"}
             checked={filterValues.includes(option)}
             onChange={e => handleChange(option, e.target.checked)}
-            label={option?.toString() ?? t`empty`}
+            label={(displayOption ?? option)?.toString() ?? t`empty`}
           />
         ))}
       </PickerGrid>


### PR DESCRIPTION
## Before

The bulk filter modal was flattening all filter options, which caused it to display both actual filter values as well as remapped display values.

![Screen Shot 2022-08-09 at 10 45 30 AM](https://user-images.githubusercontent.com/30528226/183709797-ee7c6a8b-a66d-4bb5-b90b-4c83f0551c51.png)

## Changes

- Respect remapped values and display properly in the `SimpleCategoryFilterPicker`
- Add unit tests for remapped display values

Resolves https://github.com/metabase/metabase/issues/24626

## After

Remapped values display properly, and apply the correct internal values as well.

![Screen Shot 2022-08-09 at 10 43 29 AM](https://user-images.githubusercontent.com/30528226/183709381-c96d1bee-07a7-4c27-86b3-5dbe96155ffc.png)

## Testing Steps

- follow the repro steps [here](https://github.com/metabase/metabase/issues/24626#issuecomment-1209256656) to remap the rating field on the reviews table
- refresh your browser
- open a bulk filter modal on the reviews table, you should see the remapped values only
- applying a filter on the remapped values works properly

(note, the filter tag widgets do not pull in the remapped values, this is a pre-existing issue unrelated to the filter modal)
![Screen Shot 2022-08-09 at 10 43 40 AM](https://user-images.githubusercontent.com/30528226/183709481-c6f72f34-390b-47d8-992a-501560a852d7.png)

