### PR TITLE
fixing button variant mapping for dashcard parameter filters

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCardCardParameterMapper.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCardCardParameterMapper.jsx
@@ -112,22 +112,22 @@ function DashCardCardParameterMapper({
     useMemo(() => {
       if (!hasPermissionsToMap) {
         return {
-          variant: "unauthed",
-          tooltip: t`You don’t have permission to see this question’s columns.`,
-          text: null,
+          buttonVariant: "unauthed",
+          buttonTooltip: t`You don’t have permission to see this question’s columns.`,
+          buttonText: null,
           buttonIcon: <KeyIcon />,
         };
       } else if (isDisabled && !isVirtual) {
         return {
-          variant: "disabled",
-          tooltip: t`This card doesn't have any fields or parameters that can be mapped to this parameter type.`,
+          buttonVariant: "disabled",
+          buttonTooltip: t`This card doesn't have any fields or parameters that can be mapped to this parameter type.`,
           buttonText: t`No valid fields`,
           buttonIcon: null,
         };
       } else if (selectedMappingOption) {
         return {
-          variant: "mapped",
-          tooltip: null,
+          buttonVariant: "mapped",
+          buttonTooltip: null,
           buttonText: formatSelected(selectedMappingOption),
           buttonIcon: (
             <CloseIconButton
@@ -140,8 +140,8 @@ function DashCardCardParameterMapper({
         };
       } else {
         return {
-          variant: "default",
-          tooltip: null,
+          buttonVariant: "default",
+          buttonTooltip: null,
           buttonText: t`Select…`,
           buttonIcon: <ChevrondownIcon />,
         };


### PR DESCRIPTION
Fixes #24650 

Object getting destructured wasn't returning an object with the correct keys.

after:
![image](https://user-images.githubusercontent.com/1328979/183715426-f9dcf0d8-0d23-4e4f-893d-e49fcead093e.png)
