### PR TITLE
[E2E] Fix a flake in 17160

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard/reproductions/17160-click-behavior-multiple-options.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/reproductions/17160-click-behavior-multiple-options.cy.spec.js
@@ -134,6 +134,10 @@ function setup() {
           });
 
           createTargetDashboard().then(targetDashboardId => {
+            cy.intercept("GET", `/api/dashboard/${targetDashboardId}`).as(
+              "targetDashboardLoaded",
+            );
+
             cy.wrap(targetDashboardId).as("targetDashboardId");
 
             // Create a click behavior and resize the question card
@@ -278,6 +282,7 @@ function createTargetDashboard() {
 function visitSourceDashboard() {
   cy.get("@sourceDashboardId").then(id => {
     visitDashboard(id);
+    cy.wait("@targetDashboardLoaded");
   });
 }
 


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Fixes a flake in repro for 17160
- I believe the flaky behavior was due to the race condition (see the screenshot below). Cypress tries to click on the link before the underlying data is loaded.

Although `visitDashboard` helper already waits for its own dashcard queries to load, that wasn't enough when there is a click behavior set on that card. Namely, this card is connected to a question and a dashboard. Examining the failed screenshot I could see that we failed to wait for both `GET` requests (for linked question and the linked dashboard) to finish.
![image](https://user-images.githubusercontent.com/31325167/183743958-cc833cb3-fcaf-40cb-bb81-59f7411da4c0.png)

This PR fixes that and with it, hopefully this stubborn flake.

The latest failure happened in `master`: https://github.com/metabase/metabase/runs/7751428670?check_suite_focus=true
