### PR TITLE
Sql autocomplete options

### DIFF
--- a/frontend/src/metabase/admin/settings/selectors.js
+++ b/frontend/src/metabase/admin/settings/selectors.js
@@ -120,6 +120,16 @@ const SECTIONS = updateSectionsWithPlugins({
         defaultValue: "simple",
       },
       {
+        key: "sql-editor-autocomplete-match-style",
+        display_name: t`SQL Editor autocomplete match`,
+        type: "select",
+        options: [
+          { value: "substring", name: t`Substring` },
+          { value: "prefix", name: t`Prefix` },
+          { value: "off", name: t`Off` },
+        ],
+      },
+      {
         key: "enable-nested-queries",
         display_name: t`Enable Nested Queries`,
         type: "boolean",

--- a/frontend/src/metabase/admin/settings/selectors.js
+++ b/frontend/src/metabase/admin/settings/selectors.js
@@ -123,6 +123,7 @@ const SECTIONS = updateSectionsWithPlugins({
         key: "sql-editor-autocomplete-match-style",
         display_name: t`SQL Editor autocomplete match`,
         type: "select",
+        defaultValue: "substring",
         options: [
           { value: "substring", name: t`Substring` },
           { value: "prefix", name: t`Prefix` },

--- a/frontend/src/metabase/admin/settings/selectors.js
+++ b/frontend/src/metabase/admin/settings/selectors.js
@@ -120,8 +120,8 @@ const SECTIONS = updateSectionsWithPlugins({
         defaultValue: "simple",
       },
       {
-        key: "sql-editor-autocomplete-match-style",
-        display_name: t`SQL Editor autocomplete match`,
+        key: "native-query-autocomplete-match-style",
+        display_name: t`Native query editor autocomplete match`,
         type: "select",
         defaultValue: "substring",
         options: [

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
@@ -258,7 +258,11 @@ class NativeQueryEditor extends Component {
     this._lastAutoComplete = { timestamp: 0, prefix: null, results: null };
 
     aceLanguageTools.addCompleter({
-      getCompletions: async (editor, session, pos, prefix, callback) => {
+      getCompletions: async (_editor, _session, _pos, prefix, callback) => {
+        if (!this.props.autocompleteResultsFn) {
+          return callback(null, []);
+        }
+
         try {
           let { results, timestamp } = this._lastAutoComplete;
           const cacheHit =
@@ -267,7 +271,11 @@ class NativeQueryEditor extends Component {
           if (!cacheHit) {
             // HACK: call this.props.autocompleteResultsFn rather than caching the prop since it might change
             results = await this.props.autocompleteResultsFn(prefix);
-            this._lastAutoComplete = { timestamp: Date.now(), prefix, results };
+            this._lastAutoComplete = {
+              timestamp: Date.now(),
+              prefix,
+              results,
+            };
           }
 
           // transform results of the API call into what ACE expects

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
@@ -17,7 +17,6 @@ import Collections from "metabase/entities/collections";
 import Timelines from "metabase/entities/timelines";
 
 import { closeNavbar, getIsNavbarOpen } from "metabase/redux/app";
-import { MetabaseApi } from "metabase/services";
 import { getMetadata } from "metabase/selectors/metadata";
 import {
   getUser,
@@ -90,21 +89,9 @@ import {
   getIsHeaderVisible,
   getIsActionListVisible,
   getIsAdditionalInfoVisible,
+  getAutocompleteResultsFn,
 } from "../selectors";
 import * as actions from "../actions";
-
-function autocompleteResults(card, prefix) {
-  const databaseId = card && card.dataset_query && card.dataset_query.database;
-  if (!databaseId) {
-    return [];
-  }
-
-  const apiCall = MetabaseApi.db_autocomplete_suggestions({
-    dbId: databaseId,
-    prefix: prefix,
-  });
-  return apiCall;
-}
 
 const timelineProps = {
   query: { include: "events" },
@@ -176,7 +163,8 @@ const mapStateToProps = (state, props) => {
     questionAlerts: getQuestionAlerts(state),
     visualizationSettings: getVisualizationSettings(state),
 
-    autocompleteResultsFn: prefix => autocompleteResults(state.qb.card, prefix),
+    autocompleteResultsFn: getAutocompleteResultsFn(state),
+
     instanceSettings: getSettings(state),
 
     initialCollectionId: Collections.selectors.getInitialCollectionId(

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -11,6 +11,7 @@ import {
   extractRemappings,
   getVisualizationTransformed,
 } from "metabase/visualizations";
+import { MetabaseApi } from "metabase/services";
 import { getComputedSettingsForSeries } from "metabase/visualizations/lib/settings/visualization";
 import { getCardUiParameters } from "metabase/parameters/utils/cards";
 import { normalizeParameterValue } from "metabase/parameters/utils/parameter-values";
@@ -29,6 +30,7 @@ import { getAlerts } from "metabase/alert/selectors";
 import { getEmbedOptions, getIsEmbedded } from "metabase/selectors/embed";
 import { parseTimestamp } from "metabase/lib/time";
 import { getSortedTimelines } from "metabase/lib/timelines";
+import { getSetting } from "metabase/selectors/settings";
 import {
   getXValues,
   isTimeseries,
@@ -829,3 +831,25 @@ export const getIsAdditionalInfoVisible = createSelector(
   [getIsEmbedded, getEmbedOptions],
   (isEmbedded, embedOptions) => !isEmbedded || embedOptions.additional_info,
 );
+
+export const getAutocompleteResultsFn = state => {
+  const matchStyle = getSetting(state, "sql-editor-autocomplete-match-style");
+
+  if (matchStyle === "off") {
+    return null;
+  }
+
+  return function autocompleteResults(query) {
+    const dbId = state.qb.card?.dataset_query?.database;
+    if (!dbId) {
+      return [];
+    }
+
+    const apiCall = MetabaseApi.db_autocomplete_suggestions({
+      dbId,
+      query,
+      matchStyle,
+    });
+    return apiCall;
+  };
+};

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -833,7 +833,7 @@ export const getIsAdditionalInfoVisible = createSelector(
 );
 
 export const getAutocompleteResultsFn = state => {
-  const matchStyle = getSetting(state, "sql-editor-autocomplete-match-style");
+  const matchStyle = getSetting(state, "native-query-autocomplete-match-style");
 
   if (matchStyle === "off") {
     return null;

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -261,7 +261,7 @@ export const MetabaseApi = {
   db_fields: GET("/api/database/:dbId/fields"),
   db_idfields: GET("/api/database/:dbId/idfields"),
   db_autocomplete_suggestions: GET(
-    "/api/database/:dbId/autocomplete_suggestions?search=:prefix",
+    "/api/database/:dbId/autocomplete_suggestions?:matchStyle=:query",
   ),
   db_sync_schema: POST("/api/database/:dbId/sync_schema"),
   db_dismiss_sync_spinner: POST("/api/database/:dbId/dismiss_spinner"),

--- a/frontend/test/metabase/scenarios/native/reproductions/20625-prefix-match.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/reproductions/20625-prefix-match.cy.spec.js
@@ -4,7 +4,7 @@ describe("issue 20625", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
-    cy.request("PUT", "/api/setting/sql-editor-autocomplete-match-style", {
+    cy.request("PUT", "/api/setting/native-query-autocomplete-match-style", {
       value: "prefix",
     });
     cy.signInAsNormalUser();

--- a/frontend/test/metabase/scenarios/native/reproductions/20625-prefix-match.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/reproductions/20625-prefix-match.cy.spec.js
@@ -3,6 +3,10 @@ import { restore, openNativeEditor } from "__support__/e2e/helpers";
 describe("issue 20625", () => {
   beforeEach(() => {
     restore();
+    cy.signInAsAdmin();
+    cy.request("PUT", "/api/setting/sql-editor-autocomplete-match-style", {
+      value: "prefix",
+    });
     cy.signInAsNormalUser();
     cy.intercept("GET", "/api/database/*/autocomplete_suggestions**").as(
       "autocomplete",

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -452,9 +452,9 @@
   causes too many problems."
   #{:substring :prefix :off})
 
-(defsetting sql-editor-autocomplete-match-style
+(defsetting native-query-autocomplete-match-style
   (deferred-tru
-    (str "Matching style for sql editor's autocomplete. Can be \"substring\", \"prefix\", or \"off\". "
+    (str "Matching style for native query editor's autocomplete. Can be \"substring\", \"prefix\", or \"off\". "
          "Larger instances can have performance issues matching using substring, so can use prefix matching, "
          " or turn autocompletions off."))
   :visibility :public
@@ -463,8 +463,8 @@
   :setter     (fn [v]
                 (let [v (cond-> v (string? v) keyword)]
                   (if (autocomplete-matching-options v)
-                    (setting/set-value-of-type! :keyword :sql-editor-autocomplete-match-style v)
-                    (throw (ex-info (tru "Invalid `sql-editor-autocomplete-match-style` option")
+                    (setting/set-value-of-type! :keyword :native-query-autocomplete-match-style v)
+                    (throw (ex-info (tru "Invalid `native-query-autocomplete-match-style` option")
                                     {:option v
                                      :valid-options autocomplete-matching-options}))))))
 

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -469,7 +469,8 @@
                                      :valid-options autocomplete-matching-options}))))))
 
 (api/defendpoint GET "/:id/autocomplete_suggestions"
-  "Return a list of autocomplete suggestions for a given `prefix`.
+  "Return a list of autocomplete suggestions for a given `prefix`, or `substring`. Should only specify one, but
+  `substring` will have priority if both are present.
 
   This is intened for use with the ACE Editor when the User is typing raw SQL. Suggestions include matching `Tables`
   and `Fields` in this `Database`.
@@ -477,12 +478,12 @@
   Tables are returned in the format `[table_name \"Table\"]`;
   When Fields have a semantic_type, they are returned in the format `[field_name \"table_name base_type semantic_type\"]`
   When Fields lack a semantic_type, they are returned in the format `[field_name \"table_name base_type\"]`"
-  [id prefix search]
+  [id prefix substring]
   (api/read-check Database id)
   (try
     (cond
-      search
-      (autocomplete-suggestions id (str "%" search "%"))
+      substring
+      (autocomplete-suggestions id (str "%" substring "%"))
       prefix
       (autocomplete-suggestions id (str prefix "%"))
       :else

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -457,7 +457,7 @@
     (str "Matching style for sql editor's autocomplete. Can be \"substring\", \"prefix\", or \"off\". "
          "Larger instances can have performance issues matching using substring, so can use prefix matching, "
          " or turn autocompletions off."))
-  :visibility :admin
+  :visibility :public
   :type       :keyword
   :default    :substring
   :setter     (fn [v]

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -335,10 +335,10 @@
                     (mt/user-http-request :rasta :get 200
                                           (format "database/%d/autocomplete_suggestions" db-id)
                                           :prefix prefix))
-        search-fn (fn [db-id search]
-                    (mt/user-http-request :rasta :get 200
-                                          (format "database/%d/autocomplete_suggestions" db-id)
-                                          :search search))]
+        substring-fn (fn [db-id search]
+                       (mt/user-http-request :rasta :get 200
+                                             (format "database/%d/autocomplete_suggestions" db-id)
+                                             :substring search))]
     (testing "GET /api/database/:id/autocomplete_suggestions"
       (doseq [[prefix expected] {"u"   [["USERS" "Table"]
                                         ["USER_ID" "CHECKINS :type/Integer :type/FK"]]
@@ -367,12 +367,12 @@
                             count))))
             (testing " behaves differently with search and prefix query params"
               (is (= 0 (count (prefix-fn (u/the-id tmp-db) "a"))))
-              (is (= 50 (count (search-fn (u/the-id tmp-db) "a"))))
+              (is (= 50 (count (substring-fn (u/the-id tmp-db) "a"))))
               ;; setting both uses search:
               (is (= 50 (count (mt/user-http-request :rasta :get 200
                                                      (format "database/%d/autocomplete_suggestions" (u/the-id tmp-db))
                                                      :prefix "a"
-                                                     :search "a")))))))))))
+                                                     :substring "a")))))))))))
 
 
 (defn- card-with-native-query {:style/indent 1} [card-name & {:as kvs}]


### PR DESCRIPTION
Fixes #24452 

Additional context from slack:
> Autosuggestion query lockup AppDB. Regression since 43, which is causing major problems for a customer's setup. Have not been able to reproduce. Customer is on 43.4.

### Context

The sql query editor autocompletes as you are typing with a mix of fields and tables from the backend, and semantic keywords for sql presumably in the frontend. Version 43 used a "prefix" style search ( `where field.name like "input%"`). Version 44 adds a substring type search ( `where field.name like "%input%"`) and this seems to have caused a massive performance degradation as it searches the content of all strings and not just ones which match the beginning of the input. I think the instance the reported the problem had over 100,000 fields in the database.

This new behavior was added in https://github.com/metabase/metabase/pull/21887 , allowing for specifying the search type in the url

- `api/database/1/autocomplete_suggestions?search=b`
- `api/database/1/autocomplete_suggestions?prefix=b`

But the sql editor always used search.

### Solution:

Adds a defsetting `sql-editor-autocomplete-match-style` whose value can be `substring`, `prefix`, or `off`. Allows for retention of the new 44 behavior, reverting back to 43 behavior, or disabling the feature if performance remains degraded.

https://github.com/metabase/metabase/pull/21887#issuecomment-1106602270 anticipated some follow-up work for heuristics of when to switch between the two. But unfortunately issuing these queries right now is causing app-db lockup and preventing people from upgrading. So while those heuristics are formalized adding a setting to control it unequivocally seems the best, simplest, and quickest approach.

Some other contemplated fixes were to increase the timeout before issuing the query, and requiring a larger substring before firing the query. These sound like good ideas in general but still leave us open to the possibillity of a db lockup requiring a restart (full table scans for substring matches regardless of size of input)

#### Screenshots

##### Substring (default)
<img width="425" alt="image" src="https://user-images.githubusercontent.com/6377293/183771112-00dc02b8-f6df-402c-94b6-84e09a5f5a94.png">

##### prefix (behavior of 43)
<img width="455" alt="image" src="https://user-images.githubusercontent.com/6377293/183771191-3656640a-656a-4b2e-a44f-df9a79eb18d8.png">
(NOTE no longer matches suBtotal)

##### off
<img width="409" alt="image" src="https://user-images.githubusercontent.com/6377293/183771267-cc8553c4-cdee-42ed-98bf-568e4ca756b5.png">
(NOTE still autocompletes sql syntax but nothing related to tables/fields)
