### PR TITLE
bump postgres to 42.4.1

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -118,7 +118,7 @@
                                              :exclusions  [ch.qos.logback/logback-classic]}
   org.mariadb.jdbc/mariadb-java-client      {:mvn/version "2.7.6"}              ; MySQL/MariaDB driver
   org.mindrot/jbcrypt                       {:mvn/version "0.4"}                ; Crypto library
-  org.postgresql/postgresql                 {:mvn/version "42.3.6"}             ; Postgres driver
+  org.postgresql/postgresql                 {:mvn/version "42.4.1"}             ; Postgres driver
   org.quartz-scheduler/quartz               {:mvn/version "2.3.2"}              ; Quartz job scheduler, provided by quartzite but this is a newer version.
   org.slf4j/slf4j-api                       {:mvn/version "1.7.36"}             ; abstraction for logging frameworks -- allows end user to plug in desired logging framework at deployment time
   org.tcrawley/dynapath                     {:mvn/version "1.1.0"}              ; Dynamically add Jars (e.g. Oracle or Vertica) to classpath


### PR DESCRIPTION
addresses https://nvd.nist.gov/vuln/detail/CVE-2022-31197

https://github.com/pgjdbc/pgjdbc/blob/master/CHANGELOG.md

> fix: CVE-2022-31197 Fixes SQL generated in PgResultSet.refresh() to
>    escape column identifiers so as to prevent SQL injection.
>
>    Previously, the column names for both key and data columns in the
>    table were copied as-is into the generated SQL. This allowed a
>    malicious table with column names that include statement terminator
>    to be parsed and executed as multiple separate commands.
