### PR TITLE
[E2E] Fix segments/metrics failures that started after #24682

### DIFF
--- a/frontend/test/metabase/scenarios/admin/datamodel/metrics.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/metrics.cy.spec.js
@@ -266,7 +266,18 @@ describe("scenarios > admin > datamodel > metrics", () => {
       cy.visit("/admin/datamodel/metrics");
       cy.findByText("New metric").click();
       cy.findByText("Select a table").click();
-      cy.findByText("Orders").click();
+
+      // Ugly hack to prevent failures that started after https://github.com/metabase/metabase/pull/24682 has been merged.
+      // For unknon reasons, popover doesn't open with expanded list of all Sample Database tables. Rather. it shows
+      // Sample Database (collapsed) only. We need to click on it to expand it.
+      // This conditional mechanism prevents failures even if that popover opens expanded in the future.
+      cy.get(".List-section").then($list => {
+        if ($list.length !== 5) {
+          cy.findByText("Sample Database").click();
+        }
+        cy.findByText("Orders").click();
+      });
+
       cy.findByText("Add filters to narrow your answer").click();
       cy.findByText("Custom Expression").click();
       cy.get(".ace_text-input").clear().type("[ID] > 0 OR [ID] < 9876543210");

--- a/frontend/test/metabase/scenarios/admin/datamodel/segments.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/segments.cy.spec.js
@@ -31,9 +31,18 @@ describe("scenarios > admin > datamodel > segments", () => {
       cy.visit("/admin/datamodel/segments");
       cy.findByText("New segment").click();
       cy.findByText("Select a table").click();
-      popover().within(() => {
+
+      // Ugly hack to prevent failures that started after https://github.com/metabase/metabase/pull/24682 has been merged.
+      // For unknon reasons, popover doesn't open with expanded list of all Sample Database tables. Rather. it shows
+      // Sample Database (collapsed) only. We need to click on it to expand it.
+      // This conditional mechanism prevents failures even if that popover opens expanded in the future.
+      cy.get(".List-section").then($list => {
+        if ($list.length !== 5) {
+          cy.findByText("Sample Database").click();
+        }
         cy.findByText("Orders").click();
       });
+
       cy.findByText("Add filters to narrow your answer").click();
 
       cy.log("Fails in v0.36.0 and v0.36.3. It exists in v0.35.4");


### PR DESCRIPTION
Here's the screenshot of the failure:
![image](https://user-images.githubusercontent.com/31325167/184013391-d76b9f6e-ea6d-41d5-ad90-5ad3a06be15a.png)

Popover doesn't expand the list of all Sample Database tables. This happens only in Cypress. I couldn't reproduce it manually.

This conditional mechanism should prevent further failures.

Failures:
- https://github.com/metabase/metabase/runs/7771849035?check_suite_focus=true
- https://github.com/metabase/metabase/runs/7772964488?check_suite_focus=true
- https://github.com/metabase/metabase/runs/7773722184?check_suite_focus=true