### PR TITLE
Replace redux-form in reference forms

### DIFF
--- a/frontend/src/metabase/core/components/Select/Select.jsx
+++ b/frontend/src/metabase/core/components/Select/Select.jsx
@@ -28,6 +28,7 @@ class Select extends Component {
     children: PropTypes.any,
 
     value: PropTypes.any.isRequired,
+    name: PropTypes.string,
     defaultValue: PropTypes.any,
     onChange: PropTypes.func.isRequired,
     multiple: PropTypes.bool,
@@ -132,7 +133,7 @@ class Select extends Component {
   itemIsClickable = option => !this.props.optionDisabledFn(option);
 
   handleChange = option => {
-    const { multiple, onChange } = this.props;
+    const { name, multiple, onChange } = this.props;
     const optionValue = this.props.optionValueFn(option);
     let value;
     if (multiple) {
@@ -144,7 +145,7 @@ class Select extends Component {
     } else {
       value = optionValue;
     }
-    onChange({ target: { value } });
+    onChange({ target: { name, value } });
     if (!multiple) {
       this._popover.close();
       this.handleClose();

--- a/frontend/src/metabase/reference/components/Field.jsx
+++ b/frontend/src/metabase/reference/components/Field.jsx
@@ -43,15 +43,14 @@ const Field = ({ field, foreignKeys, url, icon, isEditing, formField }) => (
         <div className={F.fieldType}>
           {isEditing ? (
             <Select
+              name={formField.semantic_type.name}
               placeholder={t`Select a field type`}
               value={
                 formField.semantic_type.value !== undefined
                   ? formField.semantic_type.value
                   : field.semantic_type
               }
-              onChange={({ target: { value } }) =>
-                formField.semantic_type.onChange(value)
-              }
+              onChange={formField.semantic_type.onChange}
               options={MetabaseCore.field_semantic_types.concat({
                 id: null,
                 name: t`No field type`,
@@ -92,14 +91,13 @@ const Field = ({ field, foreignKeys, url, icon, isEditing, formField }) => (
                 (isFK(field.semantic_type) &&
                   formField.semantic_type.value === undefined)) && (
                 <Select
+                  name={formField.fk_target_field_id.name}
                   placeholder={t`Select a target`}
                   value={
                     formField.fk_target_field_id.value ||
                     field.fk_target_field_id
                   }
-                  onChange={({ target: { value } }) =>
-                    formField.fk_target_field_id.onChange(value)
-                  }
+                  onChange={formField.fk_target_field_id.onChange}
                   options={Object.values(foreignKeys)}
                   optionValueFn={o => o.id}
                 />

--- a/frontend/src/metabase/reference/components/Field.jsx
+++ b/frontend/src/metabase/reference/components/Field.jsx
@@ -45,7 +45,7 @@ const Field = ({ field, foreignKeys, url, icon, isEditing, formField }) => (
             <Select
               placeholder={t`Select a field type`}
               value={
-                formField.semantic_type.value !== ""
+                formField.semantic_type.value !== undefined
                   ? formField.semantic_type.value
                   : field.semantic_type
               }

--- a/frontend/src/metabase/reference/databases/DatabaseDetail.jsx
+++ b/frontend/src/metabase/reference/databases/DatabaseDetail.jsx
@@ -66,7 +66,6 @@ const propTypes = {
   updateField: PropTypes.func.isRequired,
   loading: PropTypes.bool,
   loadingError: PropTypes.object,
-  submitting: PropTypes.bool,
   onSubmit: PropTypes.func.isRequired,
 };
 
@@ -81,11 +80,16 @@ const DatabaseDetail = props => {
     isEditing,
     startEditing,
     endEditing,
-    submitting,
     onSubmit,
   } = props;
 
-  const { getFieldProps, getFieldMeta, handleSubmit, handleReset } = useFormik({
+  const {
+    isSubmitting,
+    getFieldProps,
+    getFieldMeta,
+    handleSubmit,
+    handleReset,
+  } = useFormik({
     initialValues: {},
     onSubmit: fields => onSubmit(fields, { ...props, resetForm: handleReset }),
   });
@@ -100,7 +104,7 @@ const DatabaseDetail = props => {
           onSubmit={handleSubmit}
           endEditing={endEditing}
           reinitializeForm={handleReset}
-          submitting={submitting}
+          submitting={isSubmitting}
           revisionMessageFormField={getField("revision_message")}
         />
       )}

--- a/frontend/src/metabase/reference/databases/DatabaseDetail.jsx
+++ b/frontend/src/metabase/reference/databases/DatabaseDetail.jsx
@@ -94,7 +94,10 @@ const DatabaseDetail = props => {
     onSubmit: fields => onSubmit(fields, { ...props, resetForm: handleReset }),
   });
 
-  const getField = name => ({ ...getFieldProps(name), ...getFieldMeta(name) });
+  const getFormField = name => ({
+    ...getFieldProps(name),
+    ...getFieldMeta(name),
+  });
 
   return (
     <form style={style} className="full" onSubmit={handleSubmit}>
@@ -105,7 +108,7 @@ const DatabaseDetail = props => {
           endEditing={endEditing}
           reinitializeForm={handleReset}
           submitting={isSubmitting}
-          revisionMessageFormField={getField("revision_message")}
+          revisionMessageFormField={getFormField("revision_message")}
         />
       )}
       <EditableReferenceHeader
@@ -119,8 +122,8 @@ const DatabaseDetail = props => {
         hasSingleSchema={false}
         hasDisplayName={false}
         startEditing={startEditing}
-        displayNameFormField={getField("display_name")}
-        nameFormField={getField("name")}
+        displayNameFormField={getFormField("display_name")}
+        nameFormField={getFormField("name")}
       />
       <LoadingAndErrorWrapper
         loading={!loadingError && loading}
@@ -137,7 +140,7 @@ const DatabaseDetail = props => {
                     description={entity.description}
                     placeholder={t`No description yet`}
                     isEditing={isEditing}
-                    field={getField("description")}
+                    field={getFormField("description")}
                   />
                 </li>
                 <li className="relative">
@@ -147,7 +150,7 @@ const DatabaseDetail = props => {
                     description={entity.points_of_interest}
                     placeholder={t`Nothing interesting yet`}
                     isEditing={isEditing}
-                    field={getField("points_of_interest")}
+                    field={getFormField("points_of_interest")}
                   />
                 </li>
                 <li className="relative">
@@ -157,7 +160,7 @@ const DatabaseDetail = props => {
                     description={entity.caveats}
                     placeholder={t`Nothing to be aware of yet`}
                     isEditing={isEditing}
-                    field={getField("caveats")}
+                    field={getFormField("caveats")}
                   />
                 </li>
               </List>

--- a/frontend/src/metabase/reference/databases/DatabaseDetail.jsx
+++ b/frontend/src/metabase/reference/databases/DatabaseDetail.jsx
@@ -1,13 +1,12 @@
 /* eslint "react/prop-types": "warn" */
-import React, { Component } from "react";
+import React from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
-import { reduxForm } from "redux-form";
+import { useFormik } from "formik";
 import { push } from "react-router-redux";
 import { t } from "ttag";
 import List from "metabase/components/List";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
-import _ from "underscore";
 
 import EditHeader from "metabase/reference/components/EditHeader";
 import EditableReferenceHeader from "metabase/reference/components/EditableReferenceHeader";
@@ -49,148 +48,123 @@ const mapStateToProps = (state, props) => {
 const mapDispatchToProps = {
   ...metadataActions,
   ...actions,
+  onSubmit: actions.rUpdateDatabaseDetail,
   onChangeLocation: push,
 };
 
-const validate = (values, props) => {
-  return {};
+const propTypes = {
+  style: PropTypes.object.isRequired,
+  entity: PropTypes.object.isRequired,
+  table: PropTypes.object,
+  user: PropTypes.object.isRequired,
+  isEditing: PropTypes.bool,
+  startEditing: PropTypes.func.isRequired,
+  endEditing: PropTypes.func.isRequired,
+  startLoading: PropTypes.func.isRequired,
+  endLoading: PropTypes.func.isRequired,
+  setError: PropTypes.func.isRequired,
+  updateField: PropTypes.func.isRequired,
+  loading: PropTypes.bool,
+  loadingError: PropTypes.object,
+  submitting: PropTypes.bool,
+  onSubmit: PropTypes.func.isRequired,
 };
 
-class DatabaseDetail extends Component {
-  static propTypes = {
-    style: PropTypes.object.isRequired,
-    entity: PropTypes.object.isRequired,
-    table: PropTypes.object,
-    user: PropTypes.object.isRequired,
-    isEditing: PropTypes.bool,
-    startEditing: PropTypes.func.isRequired,
-    endEditing: PropTypes.func.isRequired,
-    startLoading: PropTypes.func.isRequired,
-    endLoading: PropTypes.func.isRequired,
-    setError: PropTypes.func.isRequired,
-    updateField: PropTypes.func.isRequired,
-    handleSubmit: PropTypes.func.isRequired,
-    resetForm: PropTypes.func.isRequired,
-    fields: PropTypes.object.isRequired,
-    loading: PropTypes.bool,
-    loadingError: PropTypes.object,
-    submitting: PropTypes.bool,
-  };
+const DatabaseDetail = props => {
+  const {
+    style,
+    entity,
+    table,
+    loadingError,
+    loading,
+    user,
+    isEditing,
+    startEditing,
+    endEditing,
+    submitting,
+    onSubmit,
+  } = props;
 
-  render() {
-    const {
-      fields: {
-        name,
-        display_name,
-        description,
-        revision_message,
-        points_of_interest,
-        caveats,
-      },
-      style,
-      entity,
-      table,
-      loadingError,
-      loading,
-      user,
-      isEditing,
-      startEditing,
-      endEditing,
-      handleSubmit,
-      resetForm,
-      submitting,
-    } = this.props;
+  const { getFieldProps, getFieldMeta, handleSubmit, handleReset } = useFormik({
+    initialValues: {},
+    onSubmit: fields => onSubmit(fields, { ...props, resetForm: handleReset }),
+  });
 
-    const onSubmit = handleSubmit(
-      async fields => await actions.rUpdateDatabaseDetail(fields, this.props),
-    );
+  const getField = name => ({ ...getFieldProps(name), ...getFieldMeta(name) });
 
-    return (
-      <form style={style} className="full" onSubmit={onSubmit}>
-        {isEditing && (
-          <EditHeader
-            hasRevisionHistory={false}
-            onSubmit={onSubmit}
-            endEditing={endEditing}
-            reinitializeForm={resetForm}
-            submitting={submitting}
-            revisionMessageFormField={revision_message}
-          />
-        )}
-        <EditableReferenceHeader
-          entity={entity}
-          table={table}
-          type="database"
-          name="Details"
-          headerIcon="database"
-          user={user}
-          isEditing={isEditing}
-          hasSingleSchema={false}
-          hasDisplayName={false}
-          startEditing={startEditing}
-          displayNameFormField={display_name}
-          nameFormField={name}
+  return (
+    <form style={style} className="full" onSubmit={handleSubmit}>
+      {isEditing && (
+        <EditHeader
+          hasRevisionHistory={false}
+          onSubmit={handleSubmit}
+          endEditing={endEditing}
+          reinitializeForm={handleReset}
+          submitting={submitting}
+          revisionMessageFormField={getField("revision_message")}
         />
-        <LoadingAndErrorWrapper
-          loading={!loadingError && loading}
-          error={loadingError}
-        >
-          {() => (
-            <div className="wrapper">
-              <div className="pl4 pr3 pt4 mb4 mb1 bg-white rounded bordered">
-                <List>
-                  <li className="relative">
-                    <Detail
-                      id="description"
-                      name={t`Description`}
-                      description={entity.description}
-                      placeholder={t`No description yet`}
-                      isEditing={isEditing}
-                      field={description}
-                    />
-                  </li>
-                  <li className="relative">
-                    <Detail
-                      id="points_of_interest"
-                      name={t`Why this database is interesting`}
-                      description={entity.points_of_interest}
-                      placeholder={t`Nothing interesting yet`}
-                      isEditing={isEditing}
-                      field={points_of_interest}
-                    />
-                  </li>
-                  <li className="relative">
-                    <Detail
-                      id="caveats"
-                      name={t`Things to be aware of about this database`}
-                      description={entity.caveats}
-                      placeholder={t`Nothing to be aware of yet`}
-                      isEditing={isEditing}
-                      field={caveats}
-                    />
-                  </li>
-                </List>
-              </div>
+      )}
+      <EditableReferenceHeader
+        entity={entity}
+        table={table}
+        type="database"
+        name="Details"
+        headerIcon="database"
+        user={user}
+        isEditing={isEditing}
+        hasSingleSchema={false}
+        hasDisplayName={false}
+        startEditing={startEditing}
+        displayNameFormField={getField("display_name")}
+        nameFormField={getField("getField")}
+      />
+      <LoadingAndErrorWrapper
+        loading={!loadingError && loading}
+        error={loadingError}
+      >
+        {() => (
+          <div className="wrapper">
+            <div className="pl4 pr3 pt4 mb4 mb1 bg-white rounded bordered">
+              <List>
+                <li className="relative">
+                  <Detail
+                    id="description"
+                    name={t`Description`}
+                    description={entity.description}
+                    placeholder={t`No description yet`}
+                    isEditing={isEditing}
+                    field={getField("description")}
+                  />
+                </li>
+                <li className="relative">
+                  <Detail
+                    id="points_of_interest"
+                    name={t`Why this database is interesting`}
+                    description={entity.points_of_interest}
+                    placeholder={t`Nothing interesting yet`}
+                    isEditing={isEditing}
+                    field={getField("points_of_interest")}
+                  />
+                </li>
+                <li className="relative">
+                  <Detail
+                    id="caveats"
+                    name={t`Things to be aware of about this database`}
+                    description={entity.caveats}
+                    placeholder={t`Nothing to be aware of yet`}
+                    isEditing={isEditing}
+                    field={getField("caveats")}
+                  />
+                </li>
+              </List>
             </div>
-          )}
-        </LoadingAndErrorWrapper>
-      </form>
-    );
-  }
-}
+          </div>
+        )}
+      </LoadingAndErrorWrapper>
+    </form>
+  );
+};
 
-export default _.compose(
-  connect(mapStateToProps, mapDispatchToProps),
-  reduxForm({
-    form: "details",
-    fields: [
-      "name",
-      "display_name",
-      "description",
-      "revision_message",
-      "points_of_interest",
-      "caveats",
-    ],
-    validate,
-  }),
-)(DatabaseDetail);
+DatabaseDetail.propTypes = propTypes;
+
+export default connect(mapStateToProps, mapDispatchToProps)(DatabaseDetail);

--- a/frontend/src/metabase/reference/databases/DatabaseDetail.jsx
+++ b/frontend/src/metabase/reference/databases/DatabaseDetail.jsx
@@ -120,7 +120,7 @@ const DatabaseDetail = props => {
         hasDisplayName={false}
         startEditing={startEditing}
         displayNameFormField={getField("display_name")}
-        nameFormField={getField("getField")}
+        nameFormField={getField("name")}
       />
       <LoadingAndErrorWrapper
         loading={!loadingError && loading}

--- a/frontend/src/metabase/reference/databases/FieldDetail.jsx
+++ b/frontend/src/metabase/reference/databases/FieldDetail.jsx
@@ -114,7 +114,6 @@ const propTypes = {
   updateField: PropTypes.func.isRequired,
   loading: PropTypes.bool,
   loadingError: PropTypes.object,
-  submitting: PropTypes.bool,
   metadata: PropTypes.object,
   onSubmit: PropTypes.func.isRequired,
 };
@@ -131,12 +130,17 @@ const FieldDetail = props => {
     isEditing,
     startEditing,
     endEditing,
-    submitting,
     metadata,
     onSubmit,
   } = props;
 
-  const { getFieldProps, getFieldMeta, handleSubmit, handleReset } = useFormik({
+  const {
+    isSubmitting,
+    getFieldProps,
+    getFieldMeta,
+    handleSubmit,
+    handleReset,
+  } = useFormik({
     initialValues: {},
     onSubmit: fields => onSubmit(fields, { ...props, resetForm: handleReset }),
   });
@@ -151,7 +155,7 @@ const FieldDetail = props => {
           onSubmit={handleSubmit}
           endEditing={endEditing}
           reinitializeForm={handleReset}
-          submitting={submitting}
+          submitting={isSubmitting}
           revisionMessageFormField={getField("revision_message")}
         />
       )}

--- a/frontend/src/metabase/reference/databases/FieldDetail.jsx
+++ b/frontend/src/metabase/reference/databases/FieldDetail.jsx
@@ -1,12 +1,11 @@
 /* eslint "react/prop-types": "warn" */
-import React, { Component } from "react";
+import React from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
-import { reduxForm } from "redux-form";
+import { useFormik } from "formik";
 import { push } from "react-router-redux";
 import { t } from "ttag";
 import S from "metabase/reference/Reference.css";
-import _ from "underscore";
 
 import List from "metabase/components/List";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
@@ -20,15 +19,15 @@ import UsefulQuestions from "metabase/reference/components/UsefulQuestions";
 import { getQuestionUrl } from "../utils";
 
 import {
-  getField,
-  getTable,
   getDatabase,
   getError,
-  getLoading,
-  getUser,
+  getField,
+  getForeignKeys,
   getIsEditing,
   getIsFormulaExpanded,
-  getForeignKeys,
+  getLoading,
+  getTable,
+  getUser,
 } from "../selectors";
 
 import * as metadataActions from "metabase/redux/metadata";
@@ -94,199 +93,170 @@ const mapStateToProps = (state, props) => {
 const mapDispatchToProps = {
   ...metadataActions,
   ...actions,
+  onSubmit: actions.rUpdateFieldDetail,
   onChangeLocation: push,
 };
 
-const validate = (values, props) => {
-  return {};
+const propTypes = {
+  style: PropTypes.object.isRequired,
+  entity: PropTypes.object.isRequired,
+  field: PropTypes.object.isRequired,
+  table: PropTypes.object,
+  user: PropTypes.object.isRequired,
+  database: PropTypes.object.isRequired,
+  foreignKeys: PropTypes.object,
+  isEditing: PropTypes.bool,
+  startEditing: PropTypes.func.isRequired,
+  endEditing: PropTypes.func.isRequired,
+  startLoading: PropTypes.func.isRequired,
+  endLoading: PropTypes.func.isRequired,
+  setError: PropTypes.func.isRequired,
+  updateField: PropTypes.func.isRequired,
+  loading: PropTypes.bool,
+  loadingError: PropTypes.object,
+  submitting: PropTypes.bool,
+  metadata: PropTypes.object,
+  onSubmit: PropTypes.func.isRequired,
 };
 
-class FieldDetail extends Component {
-  static propTypes = {
-    style: PropTypes.object.isRequired,
-    entity: PropTypes.object.isRequired,
-    field: PropTypes.object.isRequired,
-    table: PropTypes.object,
-    user: PropTypes.object.isRequired,
-    database: PropTypes.object.isRequired,
-    foreignKeys: PropTypes.object,
-    isEditing: PropTypes.bool,
-    startEditing: PropTypes.func.isRequired,
-    endEditing: PropTypes.func.isRequired,
-    startLoading: PropTypes.func.isRequired,
-    endLoading: PropTypes.func.isRequired,
-    setError: PropTypes.func.isRequired,
-    updateField: PropTypes.func.isRequired,
-    handleSubmit: PropTypes.func.isRequired,
-    resetForm: PropTypes.func.isRequired,
-    fields: PropTypes.object.isRequired,
-    loading: PropTypes.bool,
-    loadingError: PropTypes.object,
-    submitting: PropTypes.bool,
-    metadata: PropTypes.object,
-  };
+const FieldDetail = props => {
+  const {
+    style,
+    entity,
+    table,
+    loadingError,
+    loading,
+    user,
+    foreignKeys,
+    isEditing,
+    startEditing,
+    endEditing,
+    submitting,
+    metadata,
+    onSubmit,
+  } = props;
 
-  render() {
-    const {
-      fields: {
-        name,
-        display_name,
-        description,
-        revision_message,
-        points_of_interest,
-        caveats,
-        semantic_type,
-        fk_target_field_id,
-      },
-      style,
-      entity,
-      table,
-      loadingError,
-      loading,
-      user,
-      foreignKeys,
-      isEditing,
-      startEditing,
-      endEditing,
-      handleSubmit,
-      resetForm,
-      submitting,
-      metadata,
-    } = this.props;
+  const { getFieldProps, getFieldMeta, handleSubmit, handleReset } = useFormik({
+    initialValues: {},
+    onSubmit: fields => onSubmit(fields, { ...props, resetForm: handleReset }),
+  });
 
-    const onSubmit = handleSubmit(
-      async fields => await actions.rUpdateFieldDetail(fields, this.props),
-    );
+  const getField = name => ({ ...getFieldProps(name), ...getFieldMeta(name) });
 
-    return (
-      <form style={style} className="full" onSubmit={onSubmit}>
-        {isEditing && (
-          <EditHeader
-            hasRevisionHistory={false}
-            onSubmit={onSubmit}
-            endEditing={endEditing}
-            reinitializeForm={resetForm}
-            submitting={submitting}
-            revisionMessageFormField={revision_message}
-          />
-        )}
-        <EditableReferenceHeader
-          entity={entity}
-          table={table}
-          type="field"
-          headerIcon="field"
-          name="Details"
-          user={user}
-          isEditing={isEditing}
-          hasSingleSchema={false}
-          hasDisplayName={true}
-          startEditing={startEditing}
-          displayNameFormField={display_name}
-          nameFormField={name}
+  return (
+    <form style={style} className="full" onSubmit={handleSubmit}>
+      {isEditing && (
+        <EditHeader
+          hasRevisionHistory={false}
+          onSubmit={handleSubmit}
+          endEditing={endEditing}
+          reinitializeForm={handleReset}
+          submitting={submitting}
+          revisionMessageFormField={getField("revision_message")}
         />
-        <LoadingAndErrorWrapper
-          loading={!loadingError && loading}
-          error={loadingError}
-        >
-          {() => (
-            <div className="wrapper">
-              <div className="pl4 pr3 pt4 mb4 mb1 bg-white rounded bordered">
-                <List>
+      )}
+      <EditableReferenceHeader
+        entity={entity}
+        table={table}
+        type="field"
+        headerIcon="field"
+        name="Details"
+        user={user}
+        isEditing={isEditing}
+        hasSingleSchema={false}
+        hasDisplayName={true}
+        startEditing={startEditing}
+        displayNameFormField={getField("display_name")}
+        nameFormField={getField("getField")}
+      />
+      <LoadingAndErrorWrapper
+        loading={!loadingError && loading}
+        error={loadingError}
+      >
+        {() => (
+          <div className="wrapper">
+            <div className="pl4 pr3 pt4 mb4 mb1 bg-white rounded bordered">
+              <List>
+                <li className="relative">
+                  <Detail
+                    id="description"
+                    name={t`Description`}
+                    description={entity.description}
+                    placeholder={t`No description yet`}
+                    isEditing={isEditing}
+                    field={getField("description")}
+                  />
+                </li>
+                {!isEditing && (
                   <li className="relative">
                     <Detail
-                      id="description"
-                      name={t`Description`}
-                      description={entity.description}
-                      placeholder={t`No description yet`}
-                      isEditing={isEditing}
-                      field={description}
+                      id="name"
+                      name={t`Actual name in database`}
+                      description={entity.name}
+                      subtitleClass={S.tableActualName}
                     />
                   </li>
-                  {!isEditing && (
-                    <li className="relative">
-                      <Detail
-                        id="name"
-                        name={t`Actual name in database`}
-                        description={entity.name}
-                        subtitleClass={S.tableActualName}
-                      />
-                    </li>
-                  )}
-                  <li className="relative">
-                    <Detail
-                      id="points_of_interest"
-                      name={t`Why this field is interesting`}
-                      description={entity.points_of_interest}
-                      placeholder={t`Nothing interesting yet`}
-                      isEditing={isEditing}
-                      field={points_of_interest}
-                    />
-                  </li>
-                  <li className="relative">
-                    <Detail
-                      id="caveats"
-                      name={t`Things to be aware of about this field`}
-                      description={entity.caveats}
-                      placeholder={t`Nothing to be aware of yet`}
-                      isEditing={isEditing}
-                      field={caveats}
-                    />
-                  </li>
+                )}
+                <li className="relative">
+                  <Detail
+                    id="points_of_interest"
+                    name={t`Why this field is interesting`}
+                    description={entity.points_of_interest}
+                    placeholder={t`Nothing interesting yet`}
+                    isEditing={isEditing}
+                    field={getField("points_of_interest")}
+                  />
+                </li>
+                <li className="relative">
+                  <Detail
+                    id="caveats"
+                    name={t`Things to be aware of about this field`}
+                    description={entity.caveats}
+                    placeholder={t`Nothing to be aware of yet`}
+                    isEditing={isEditing}
+                    field={getField("caveats")}
+                  />
+                </li>
 
-                  {!isEditing && (
-                    <li className="relative">
-                      <Detail
-                        id="base_type"
-                        name={t`Data type`}
-                        description={entity.base_type}
-                      />
-                    </li>
-                  )}
+                {!isEditing && (
                   <li className="relative">
-                    <FieldTypeDetail
-                      field={entity}
-                      foreignKeys={foreignKeys}
-                      fieldTypeFormField={semantic_type}
-                      foreignKeyFormField={fk_target_field_id}
-                      isEditing={isEditing}
+                    <Detail
+                      id="base_type"
+                      name={t`Data type`}
+                      description={entity.base_type}
                     />
                   </li>
-                  {!isEditing && (
-                    <li className="relative">
-                      <UsefulQuestions
-                        questions={interestingQuestions(
-                          this.props.database,
-                          this.props.table,
-                          this.props.field,
-                          metadata,
-                        )}
-                      />
-                    </li>
-                  )}
-                </List>
-              </div>
+                )}
+                <li className="relative">
+                  <FieldTypeDetail
+                    field={entity}
+                    foreignKeys={foreignKeys}
+                    fieldTypeFormField={getField("semantic_type")}
+                    foreignKeyFormField={getField("fk_target_field_id")}
+                    isEditing={isEditing}
+                  />
+                </li>
+                {!isEditing && (
+                  <li className="relative">
+                    <UsefulQuestions
+                      questions={interestingQuestions(
+                        props.database,
+                        props.table,
+                        props.field,
+                        metadata,
+                      )}
+                    />
+                  </li>
+                )}
+              </List>
             </div>
-          )}
-        </LoadingAndErrorWrapper>
-      </form>
-    );
-  }
-}
+          </div>
+        )}
+      </LoadingAndErrorWrapper>
+    </form>
+  );
+};
 
-export default _.compose(
-  connect(mapStateToProps, mapDispatchToProps),
-  reduxForm({
-    form: "details",
-    fields: [
-      "name",
-      "display_name",
-      "description",
-      "revision_message",
-      "points_of_interest",
-      "caveats",
-      "semantic_type",
-      "fk_target_field_id",
-    ],
-    validate,
-  }),
-)(FieldDetail);
+FieldDetail.propTypes = propTypes;
+
+export default connect(mapStateToProps, mapDispatchToProps)(FieldDetail);

--- a/frontend/src/metabase/reference/databases/FieldDetail.jsx
+++ b/frontend/src/metabase/reference/databases/FieldDetail.jsx
@@ -171,7 +171,7 @@ const FieldDetail = props => {
         hasDisplayName={true}
         startEditing={startEditing}
         displayNameFormField={getField("display_name")}
-        nameFormField={getField("getField")}
+        nameFormField={getField("name")}
       />
       <LoadingAndErrorWrapper
         loading={!loadingError && loading}

--- a/frontend/src/metabase/reference/databases/FieldDetail.jsx
+++ b/frontend/src/metabase/reference/databases/FieldDetail.jsx
@@ -145,7 +145,10 @@ const FieldDetail = props => {
     onSubmit: fields => onSubmit(fields, { ...props, resetForm: handleReset }),
   });
 
-  const getField = name => ({ ...getFieldProps(name), ...getFieldMeta(name) });
+  const getFormField = name => ({
+    ...getFieldProps(name),
+    ...getFieldMeta(name),
+  });
 
   return (
     <form style={style} className="full" onSubmit={handleSubmit}>
@@ -156,7 +159,7 @@ const FieldDetail = props => {
           endEditing={endEditing}
           reinitializeForm={handleReset}
           submitting={isSubmitting}
-          revisionMessageFormField={getField("revision_message")}
+          revisionMessageFormField={getFormField("revision_message")}
         />
       )}
       <EditableReferenceHeader
@@ -170,8 +173,8 @@ const FieldDetail = props => {
         hasSingleSchema={false}
         hasDisplayName={true}
         startEditing={startEditing}
-        displayNameFormField={getField("display_name")}
-        nameFormField={getField("name")}
+        displayNameFormField={getFormField("display_name")}
+        nameFormField={getFormField("name")}
       />
       <LoadingAndErrorWrapper
         loading={!loadingError && loading}
@@ -188,7 +191,7 @@ const FieldDetail = props => {
                     description={entity.description}
                     placeholder={t`No description yet`}
                     isEditing={isEditing}
-                    field={getField("description")}
+                    field={getFormField("description")}
                   />
                 </li>
                 {!isEditing && (
@@ -208,7 +211,7 @@ const FieldDetail = props => {
                     description={entity.points_of_interest}
                     placeholder={t`Nothing interesting yet`}
                     isEditing={isEditing}
-                    field={getField("points_of_interest")}
+                    field={getFormField("points_of_interest")}
                   />
                 </li>
                 <li className="relative">
@@ -218,7 +221,7 @@ const FieldDetail = props => {
                     description={entity.caveats}
                     placeholder={t`Nothing to be aware of yet`}
                     isEditing={isEditing}
-                    field={getField("caveats")}
+                    field={getFormField("caveats")}
                   />
                 </li>
 
@@ -235,8 +238,8 @@ const FieldDetail = props => {
                   <FieldTypeDetail
                     field={entity}
                     foreignKeys={foreignKeys}
-                    fieldTypeFormField={getField("semantic_type")}
-                    foreignKeyFormField={getField("fk_target_field_id")}
+                    fieldTypeFormField={getFormField("semantic_type")}
+                    foreignKeyFormField={getFormField("fk_target_field_id")}
                     isEditing={isEditing}
                   />
                 </li>

--- a/frontend/src/metabase/reference/databases/FieldList.jsx
+++ b/frontend/src/metabase/reference/databases/FieldList.jsx
@@ -1,13 +1,12 @@
 /* eslint "react/prop-types": "warn" */
-import React, { Component } from "react";
+import React from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
-import { reduxForm } from "redux-form";
+import { useFormik } from "formik";
 import { t } from "ttag";
 import S from "metabase/components/List.css";
 import R from "metabase/reference/Reference.css";
 import F from "metabase/reference/components/Field.css";
-import _ from "underscore";
 
 import Field from "metabase/reference/components/Field";
 import List from "metabase/components/List";
@@ -20,16 +19,14 @@ import EditableReferenceHeader from "metabase/reference/components/EditableRefer
 import cx from "classnames";
 
 import {
-  getTable,
+  getError,
   getFieldsByTable,
   getForeignKeys,
-  getError,
-  getLoading,
-  getUser,
   getIsEditing,
+  getLoading,
+  getTable,
+  getUser,
 } from "../selectors";
-
-import { fieldsToFormFields } from "../utils";
 
 import { getIconForField } from "metabase/lib/schema_metadata";
 
@@ -51,150 +48,150 @@ const mapStateToProps = (state, props) => {
     loadingError: getError(state, props),
     user: getUser(state, props),
     isEditing: getIsEditing(state, props),
-    fields: fieldsToFormFields(data),
   };
 };
 
 const mapDispatchToProps = {
   ...metadataActions,
   ...actions,
+  onSubmit: actions.rUpdateFields,
 };
 
-const validate = (values, props) => {
-  return {};
+const propTypes = {
+  style: PropTypes.object.isRequired,
+  entities: PropTypes.object.isRequired,
+  foreignKeys: PropTypes.object.isRequired,
+  isEditing: PropTypes.bool,
+  startEditing: PropTypes.func.isRequired,
+  endEditing: PropTypes.func.isRequired,
+  startLoading: PropTypes.func.isRequired,
+  endLoading: PropTypes.func.isRequired,
+  setError: PropTypes.func.isRequired,
+  updateField: PropTypes.func.isRequired,
+  user: PropTypes.object.isRequired,
+  table: PropTypes.object.isRequired,
+  loading: PropTypes.bool,
+  loadingError: PropTypes.object,
+  onSubmit: PropTypes.func.isRequired,
+  "data-testid": PropTypes.string,
 };
 
-class FieldList extends Component {
-  static propTypes = {
-    style: PropTypes.object.isRequired,
-    entities: PropTypes.object.isRequired,
-    foreignKeys: PropTypes.object.isRequired,
-    isEditing: PropTypes.bool,
-    startEditing: PropTypes.func.isRequired,
-    endEditing: PropTypes.func.isRequired,
-    startLoading: PropTypes.func.isRequired,
-    endLoading: PropTypes.func.isRequired,
-    setError: PropTypes.func.isRequired,
-    updateField: PropTypes.func.isRequired,
-    handleSubmit: PropTypes.func.isRequired,
-    user: PropTypes.object.isRequired,
-    fields: PropTypes.object.isRequired,
-    table: PropTypes.object.isRequired,
-    loading: PropTypes.bool,
-    loadingError: PropTypes.object,
-    submitting: PropTypes.bool,
-    resetForm: PropTypes.func,
-    "data-testid": PropTypes.string,
-  };
+const FieldList = props => {
+  const {
+    style,
+    entities,
+    foreignKeys,
+    table,
+    loadingError,
+    loading,
+    user,
+    isEditing,
+    startEditing,
+    endEditing,
+    onSubmit,
+  } = props;
 
-  render() {
-    const {
-      style,
-      entities,
-      fields,
-      foreignKeys,
-      table,
-      loadingError,
-      loading,
-      user,
-      isEditing,
-      startEditing,
-      endEditing,
-      resetForm,
-      handleSubmit,
-      submitting,
-    } = this.props;
+  const {
+    isSubmitting,
+    getFieldProps,
+    getFieldMeta,
+    handleSubmit,
+    handleReset,
+  } = useFormik({
+    initialValues: {},
+    onSubmit: fields =>
+      onSubmit(entities, fields, { ...props, resetForm: handleReset }),
+  });
 
-    return (
-      <form
-        style={style}
-        className="full"
-        onSubmit={handleSubmit(
-          async formFields =>
-            await actions.rUpdateFields(
-              this.props.entities,
-              formFields,
-              this.props,
-            ),
-        )}
-        testID={this.props["data-testid"]}
-      >
-        {isEditing && (
-          <EditHeader
-            hasRevisionHistory={false}
-            reinitializeForm={resetForm}
-            endEditing={endEditing}
-            submitting={submitting}
-          />
-        )}
-        <EditableReferenceHeader
-          headerIcon="table2"
-          name={t`Fields in ${table.display_name}`}
-          user={user}
-          isEditing={isEditing}
-          startEditing={startEditing}
+  const getFormField = name => ({
+    ...getFieldProps(name),
+    ...getFieldMeta(name),
+  });
+
+  const getNestedFormField = id => ({
+    display_name: getFormField(`${id}.display_name`),
+    semantic_type: getFormField(`${id}.semantic_type`),
+    fk_target_field_id: getFormField(`${id}.fk_target_field_id`),
+  });
+
+  return (
+    <form
+      style={style}
+      className="full"
+      onSubmit={handleSubmit}
+      testID={props["data-testid"]}
+    >
+      {isEditing && (
+        <EditHeader
+          hasRevisionHistory={false}
+          reinitializeForm={handleReset}
+          endEditing={endEditing}
+          submitting={isSubmitting}
         />
-        <LoadingAndErrorWrapper
-          loading={!loadingError && loading}
-          error={loadingError}
-        >
-          {() =>
-            Object.keys(entities).length > 0 ? (
-              <div className="wrapper">
-                <div className="pl4 pb2 mb4 bg-white rounded bordered">
-                  <div className={S.item}>
-                    <div className={R.columnHeader}>
-                      <div className={cx(S.itemTitle, F.fieldNameTitle)}>
-                        {t`Field name`}
-                      </div>
-                      <div className={cx(S.itemTitle, F.fieldType)}>
-                        {t`Field type`}
-                      </div>
-                      <div className={cx(S.itemTitle, F.fieldDataType)}>
-                        {t`Data type`}
-                      </div>
+      )}
+      <EditableReferenceHeader
+        headerIcon="table2"
+        name={t`Fields in ${table.display_name}`}
+        user={user}
+        isEditing={isEditing}
+        startEditing={startEditing}
+      />
+      <LoadingAndErrorWrapper
+        loading={!loadingError && loading}
+        error={loadingError}
+      >
+        {() =>
+          Object.keys(entities).length > 0 ? (
+            <div className="wrapper">
+              <div className="pl4 pb2 mb4 bg-white rounded bordered">
+                <div className={S.item}>
+                  <div className={R.columnHeader}>
+                    <div className={cx(S.itemTitle, F.fieldNameTitle)}>
+                      {t`Field name`}
+                    </div>
+                    <div className={cx(S.itemTitle, F.fieldType)}>
+                      {t`Field type`}
+                    </div>
+                    <div className={cx(S.itemTitle, F.fieldDataType)}>
+                      {t`Data type`}
                     </div>
                   </div>
-                  <List>
-                    {Object.values(entities)
-                      // respect the column sort order
-                      .sort((a, b) => a.position - b.position)
-                      .map(
-                        entity =>
-                          entity &&
-                          entity.id &&
-                          entity.name && (
-                            <li key={entity.id}>
-                              <Field
-                                field={entity}
-                                foreignKeys={foreignKeys}
-                                url={`/reference/databases/${table.db_id}/tables/${table.id}/fields/${entity.id}`}
-                                icon={getIconForField(entity)}
-                                isEditing={isEditing}
-                                formField={fields[entity.id]}
-                              />
-                            </li>
-                          ),
-                      )}
-                  </List>
                 </div>
+                <List>
+                  {Object.values(entities)
+                    // respect the column sort order
+                    .sort((a, b) => a.position - b.position)
+                    .map(
+                      entity =>
+                        entity &&
+                        entity.id &&
+                        entity.name && (
+                          <li key={entity.id}>
+                            <Field
+                              field={entity}
+                              foreignKeys={foreignKeys}
+                              url={`/reference/databases/${table.db_id}/tables/${table.id}/fields/${entity.id}`}
+                              icon={getIconForField(entity)}
+                              isEditing={isEditing}
+                              formField={getNestedFormField(entity.id)}
+                            />
+                          </li>
+                        ),
+                    )}
+                </List>
               </div>
-            ) : (
-              <div className={S.empty}>
-                <EmptyState {...emptyStateData} />
-              </div>
-            )
-          }
-        </LoadingAndErrorWrapper>
-      </form>
-    );
-  }
-}
+            </div>
+          ) : (
+            <div className={S.empty}>
+              <EmptyState {...emptyStateData} />
+            </div>
+          )
+        }
+      </LoadingAndErrorWrapper>
+    </form>
+  );
+};
 
-export default _.compose(
-  connect(mapStateToProps, mapDispatchToProps),
-  reduxForm({
-    form: "fields",
-    validate,
-  }),
-)(FieldList);
+FieldList.propTypes = propTypes;
+
+export default connect(mapStateToProps, mapDispatchToProps)(FieldList);

--- a/frontend/src/metabase/reference/databases/TableDetail.jsx
+++ b/frontend/src/metabase/reference/databases/TableDetail.jsx
@@ -97,7 +97,6 @@ const propTypes = {
   hasSingleSchema: PropTypes.bool,
   loading: PropTypes.bool,
   loadingError: PropTypes.object,
-  submitting: PropTypes.bool,
   onSubmit: PropTypes.func.isRequired,
 };
 
@@ -113,11 +112,16 @@ const TableDetail = props => {
     startEditing,
     endEditing,
     hasSingleSchema,
-    submitting,
     onSubmit,
   } = props;
 
-  const { getFieldProps, getFieldMeta, handleSubmit, handleReset } = useFormik({
+  const {
+    isSubmitting,
+    getFieldProps,
+    getFieldMeta,
+    handleSubmit,
+    handleReset,
+  } = useFormik({
     initialValues: {},
     onSubmit: fields => onSubmit(fields, { ...props, resetForm: handleReset }),
   });
@@ -132,7 +136,7 @@ const TableDetail = props => {
           onSubmit={handleSubmit}
           endEditing={endEditing}
           reinitializeForm={handleReset}
-          submitting={submitting}
+          submitting={isSubmitting}
           revisionMessageFormField={getField("revision_message")}
         />
       )}

--- a/frontend/src/metabase/reference/databases/TableDetail.jsx
+++ b/frontend/src/metabase/reference/databases/TableDetail.jsx
@@ -1,12 +1,11 @@
 /* eslint "react/prop-types": "warn" */
-import React, { Component } from "react";
+import React from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
-import { reduxForm } from "redux-form";
+import { useFormik } from "formik";
 import { push } from "react-router-redux";
 import { t } from "ttag";
 import S from "metabase/reference/Reference.css";
-import _ from "underscore";
 
 import List from "metabase/components/List";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
@@ -76,171 +75,149 @@ const mapStateToProps = (state, props) => {
 const mapDispatchToProps = {
   ...metadataActions,
   ...actions,
+  onSubmit: actions.rUpdateTableDetail,
   onChangeLocation: push,
 };
 
-const validate = (values, props) => {
-  return {};
+const propTypes = {
+  style: PropTypes.object.isRequired,
+  entity: PropTypes.object.isRequired,
+  table: PropTypes.object,
+  user: PropTypes.object.isRequired,
+  isEditing: PropTypes.bool,
+  startEditing: PropTypes.func.isRequired,
+  endEditing: PropTypes.func.isRequired,
+  startLoading: PropTypes.func.isRequired,
+  endLoading: PropTypes.func.isRequired,
+  setError: PropTypes.func.isRequired,
+  updateField: PropTypes.func.isRequired,
+  handleSubmit: PropTypes.func.isRequired,
+  resetForm: PropTypes.func.isRequired,
+  fields: PropTypes.object.isRequired,
+  hasSingleSchema: PropTypes.bool,
+  loading: PropTypes.bool,
+  loadingError: PropTypes.object,
+  submitting: PropTypes.bool,
+  onSubmit: PropTypes.func.isRequired,
 };
 
-class TableDetail extends Component {
-  static propTypes = {
-    style: PropTypes.object.isRequired,
-    entity: PropTypes.object.isRequired,
-    table: PropTypes.object,
-    user: PropTypes.object.isRequired,
-    isEditing: PropTypes.bool,
-    startEditing: PropTypes.func.isRequired,
-    endEditing: PropTypes.func.isRequired,
-    startLoading: PropTypes.func.isRequired,
-    endLoading: PropTypes.func.isRequired,
-    setError: PropTypes.func.isRequired,
-    updateField: PropTypes.func.isRequired,
-    handleSubmit: PropTypes.func.isRequired,
-    resetForm: PropTypes.func.isRequired,
-    fields: PropTypes.object.isRequired,
-    hasSingleSchema: PropTypes.bool,
-    loading: PropTypes.bool,
-    loadingError: PropTypes.object,
-    submitting: PropTypes.bool,
-  };
+const TableDetail = props => {
+  const {
+    style,
+    entity,
+    table,
+    loadingError,
+    loading,
+    user,
+    isEditing,
+    startEditing,
+    endEditing,
+    hasSingleSchema,
+    submitting,
+    onSubmit,
+  } = props;
 
-  render() {
-    const {
-      fields: {
-        name,
-        display_name,
-        description,
-        revision_message,
-        points_of_interest,
-        caveats,
-      },
-      style,
-      entity,
-      table,
-      loadingError,
-      loading,
-      user,
-      isEditing,
-      startEditing,
-      endEditing,
-      hasSingleSchema,
-      handleSubmit,
-      resetForm,
-      submitting,
-    } = this.props;
+  const { getFieldProps, getFieldMeta, handleSubmit, handleReset } = useFormik({
+    initialValues: {},
+    onSubmit: fields => onSubmit(fields, { ...props, resetForm: handleReset }),
+  });
 
-    const onSubmit = handleSubmit(
-      async fields => await actions.rUpdateTableDetail(fields, this.props),
-    );
+  const getField = name => ({ ...getFieldProps(name), ...getFieldMeta(name) });
 
-    return (
-      <form style={style} className="full" onSubmit={onSubmit}>
-        {isEditing && (
-          <EditHeader
-            hasRevisionHistory={false}
-            onSubmit={onSubmit}
-            endEditing={endEditing}
-            reinitializeForm={resetForm}
-            submitting={submitting}
-            revisionMessageFormField={revision_message}
-          />
-        )}
-        <EditableReferenceHeader
-          entity={entity}
-          table={table}
-          type="table"
-          headerIcon="table2"
-          headerLink={getQuestionUrl({
-            dbId: entity.db_id,
-            tableId: entity.id,
-          })}
-          name={t`Details`}
-          user={user}
-          isEditing={isEditing}
-          hasSingleSchema={hasSingleSchema}
-          hasDisplayName={true}
-          startEditing={startEditing}
-          displayNameFormField={display_name}
-          nameFormField={name}
+  return (
+    <form style={style} className="full" onSubmit={handleSubmit}>
+      {isEditing && (
+        <EditHeader
+          hasRevisionHistory={false}
+          onSubmit={handleSubmit}
+          endEditing={endEditing}
+          reinitializeForm={handleReset}
+          submitting={submitting}
+          revisionMessageFormField={getField("revision_message")}
         />
-        <LoadingAndErrorWrapper
-          loading={!loadingError && loading}
-          error={loadingError}
-        >
-          {() => (
-            <div className="wrapper">
-              <div className="pl4 pr3 pt4 mb4 mb1 bg-white rounded bordered">
-                <List>
+      )}
+      <EditableReferenceHeader
+        entity={entity}
+        table={table}
+        type="table"
+        headerIcon="table2"
+        headerLink={getQuestionUrl({
+          dbId: entity.db_id,
+          tableId: entity.id,
+        })}
+        name={t`Details`}
+        user={user}
+        isEditing={isEditing}
+        hasSingleSchema={hasSingleSchema}
+        hasDisplayName={true}
+        startEditing={startEditing}
+        displayNameFormField={getField("display_name")}
+        nameFormField={getField("name")}
+      />
+      <LoadingAndErrorWrapper
+        loading={!loadingError && loading}
+        error={loadingError}
+      >
+        {() => (
+          <div className="wrapper">
+            <div className="pl4 pr3 pt4 mb4 mb1 bg-white rounded bordered">
+              <List>
+                <li className="relative">
+                  <Detail
+                    id="description"
+                    name={t`Description`}
+                    description={entity.description}
+                    placeholder={t`No description yet`}
+                    isEditing={isEditing}
+                    field={getField("description")}
+                  />
+                </li>
+                {!isEditing && (
                   <li className="relative">
                     <Detail
-                      id="description"
-                      name={t`Description`}
-                      description={entity.description}
-                      placeholder={t`No description yet`}
-                      isEditing={isEditing}
-                      field={description}
+                      id="name"
+                      name={t`Actual name in database`}
+                      description={entity.name}
+                      subtitleClass={S.tableActualName}
                     />
                   </li>
-                  {!isEditing && (
-                    <li className="relative">
-                      <Detail
-                        id="name"
-                        name={t`Actual name in database`}
-                        description={entity.name}
-                        subtitleClass={S.tableActualName}
-                      />
-                    </li>
-                  )}
+                )}
+                <li className="relative">
+                  <Detail
+                    id="points_of_interest"
+                    name={t`Why this table is interesting`}
+                    description={entity.points_of_interest}
+                    placeholder={t`Nothing interesting yet`}
+                    isEditing={isEditing}
+                    field={getField("points_of_interest")}
+                  />
+                </li>
+                <li className="relative">
+                  <Detail
+                    id="caveats"
+                    name={t`Things to be aware of about this table`}
+                    description={entity.caveats}
+                    placeholder={t`Nothing to be aware of yet`}
+                    isEditing={isEditing}
+                    field={getField("caveats")}
+                  />
+                </li>
+                {!isEditing && (
                   <li className="relative">
-                    <Detail
-                      id="points_of_interest"
-                      name={t`Why this table is interesting`}
-                      description={entity.points_of_interest}
-                      placeholder={t`Nothing interesting yet`}
-                      isEditing={isEditing}
-                      field={points_of_interest}
+                    <UsefulQuestions
+                      questions={interestingQuestions(props.table)}
                     />
                   </li>
-                  <li className="relative">
-                    <Detail
-                      id="caveats"
-                      name={t`Things to be aware of about this table`}
-                      description={entity.caveats}
-                      placeholder={t`Nothing to be aware of yet`}
-                      isEditing={isEditing}
-                      field={caveats}
-                    />
-                  </li>
-                  {!isEditing && (
-                    <li className="relative">
-                      <UsefulQuestions
-                        questions={interestingQuestions(this.props.table)}
-                      />
-                    </li>
-                  )}
-                </List>
-              </div>
+                )}
+              </List>
             </div>
-          )}
-        </LoadingAndErrorWrapper>
-      </form>
-    );
-  }
-}
+          </div>
+        )}
+      </LoadingAndErrorWrapper>
+    </form>
+  );
+};
 
-export default _.compose(
-  connect(mapStateToProps, mapDispatchToProps),
-  reduxForm({
-    form: "details",
-    fields: [
-      "name",
-      "display_name",
-      "description",
-      "revision_message",
-      "points_of_interest",
-      "caveats",
-    ],
-    validate,
-  }),
-)(TableDetail);
+TableDetail.propTypes = propTypes;
+
+export default connect(mapStateToProps, mapDispatchToProps)(TableDetail);

--- a/frontend/src/metabase/reference/databases/TableDetail.jsx
+++ b/frontend/src/metabase/reference/databases/TableDetail.jsx
@@ -126,7 +126,10 @@ const TableDetail = props => {
     onSubmit: fields => onSubmit(fields, { ...props, resetForm: handleReset }),
   });
 
-  const getField = name => ({ ...getFieldProps(name), ...getFieldMeta(name) });
+  const getFormField = name => ({
+    ...getFieldProps(name),
+    ...getFieldMeta(name),
+  });
 
   return (
     <form style={style} className="full" onSubmit={handleSubmit}>
@@ -137,7 +140,7 @@ const TableDetail = props => {
           endEditing={endEditing}
           reinitializeForm={handleReset}
           submitting={isSubmitting}
-          revisionMessageFormField={getField("revision_message")}
+          revisionMessageFormField={getFormField("revision_message")}
         />
       )}
       <EditableReferenceHeader
@@ -155,8 +158,8 @@ const TableDetail = props => {
         hasSingleSchema={hasSingleSchema}
         hasDisplayName={true}
         startEditing={startEditing}
-        displayNameFormField={getField("display_name")}
-        nameFormField={getField("name")}
+        displayNameFormField={getFormField("display_name")}
+        nameFormField={getFormField("name")}
       />
       <LoadingAndErrorWrapper
         loading={!loadingError && loading}
@@ -173,7 +176,7 @@ const TableDetail = props => {
                     description={entity.description}
                     placeholder={t`No description yet`}
                     isEditing={isEditing}
-                    field={getField("description")}
+                    field={getFormField("description")}
                   />
                 </li>
                 {!isEditing && (
@@ -193,7 +196,7 @@ const TableDetail = props => {
                     description={entity.points_of_interest}
                     placeholder={t`Nothing interesting yet`}
                     isEditing={isEditing}
-                    field={getField("points_of_interest")}
+                    field={getFormField("points_of_interest")}
                   />
                 </li>
                 <li className="relative">
@@ -203,7 +206,7 @@ const TableDetail = props => {
                     description={entity.caveats}
                     placeholder={t`Nothing to be aware of yet`}
                     isEditing={isEditing}
-                    field={getField("caveats")}
+                    field={getFormField("caveats")}
                   />
                 </li>
                 {!isEditing && (

--- a/frontend/src/metabase/reference/metrics/MetricDetail.jsx
+++ b/frontend/src/metabase/reference/metrics/MetricDetail.jsx
@@ -56,7 +56,7 @@ const mapDispatchToProps = {
   // The state and callbacks are received via props
   ..._.omit(actions, "startEditing", "endEditing"),
 
-  onUpdate: actions.rUpdateMetricDetail,
+  onSubmit: actions.rUpdateMetricDetail,
   onChangeLocation: push,
 };
 
@@ -84,7 +84,7 @@ const propTypes = {
   loading: PropTypes.bool,
   loadingError: PropTypes.object,
   submitting: PropTypes.bool,
-  onUpdate: PropTypes.func.isRequired,
+  onSubmit: PropTypes.func.isRequired,
   onChangeLocation: PropTypes.func.isRequired,
 };
 
@@ -104,7 +104,7 @@ const MetricDetail = props => {
     collapseFormula,
     isFormulaExpanded,
     submitting,
-    onUpdate,
+    onSubmit,
     onChangeLocation,
   } = props;
 
@@ -113,7 +113,7 @@ const MetricDetail = props => {
     initialValues: {},
     initialErrors: validate({}),
     onSubmit: fields =>
-      onUpdate(entity, fields, { ...props, resetForm: handleReset }),
+      onSubmit(entity, fields, { ...props, resetForm: handleReset }),
   });
 
   const getField = name => ({ ...getFieldProps(name), ...getFieldMeta(name) });

--- a/frontend/src/metabase/reference/metrics/MetricDetail.jsx
+++ b/frontend/src/metabase/reference/metrics/MetricDetail.jsx
@@ -120,7 +120,10 @@ const MetricDetail = props => {
       onSubmit(entity, fields, { ...props, resetForm: handleReset }),
   });
 
-  const getField = name => ({ ...getFieldProps(name), ...getFieldMeta(name) });
+  const getFormField = name => ({
+    ...getFieldProps(name),
+    ...getFieldMeta(name),
+  });
 
   return (
     <form style={style} className="full" onSubmit={handleSubmit}>
@@ -131,7 +134,7 @@ const MetricDetail = props => {
           endEditing={endEditing}
           reinitializeForm={handleReset}
           submitting={isSubmitting}
-          revisionMessageFormField={getField("revision_message")}
+          revisionMessageFormField={getFormField("revision_message")}
         />
       )}
       <EditableReferenceHeader
@@ -150,8 +153,8 @@ const MetricDetail = props => {
         hasSingleSchema={false}
         hasDisplayName={false}
         startEditing={startEditing}
-        displayNameFormField={getField("display_name")}
-        nameFormField={getField("name")}
+        displayNameFormField={getFormField("display_name")}
+        nameFormField={getFormField("name")}
       />
       <LoadingAndErrorWrapper
         loading={!loadingError && loading}
@@ -163,7 +166,7 @@ const MetricDetail = props => {
               <List>
                 <li className="relative">
                   <Detail
-                    field={getField("description")}
+                    field={getFormField("description")}
                     name={t`Description`}
                     description={entity.description}
                     placeholder={t`No description yet`}
@@ -172,7 +175,7 @@ const MetricDetail = props => {
                 </li>
                 <li className="relative">
                   <Detail
-                    field={getField("points_of_interest")}
+                    field={getFormField("points_of_interest")}
                     name={t`Why this metric is interesting`}
                     description={entity.points_of_interest}
                     placeholder={t`Nothing interesting yet`}
@@ -181,7 +184,7 @@ const MetricDetail = props => {
                 </li>
                 <li className="relative">
                   <Detail
-                    field={getField("caveats")}
+                    field={getFormField("caveats")}
                     name={t`Things to be aware of about this metric`}
                     description={entity.caveats}
                     placeholder={t`Nothing to be aware of yet`}
@@ -190,7 +193,7 @@ const MetricDetail = props => {
                 </li>
                 <li className="relative">
                   <Detail
-                    field={getField("how_is_this_calculated")}
+                    field={getFormField("how_is_this_calculated")}
                     name={t`How this metric is calculated`}
                     description={entity.how_is_this_calculated}
                     placeholder={t`Nothing on how it's calculated yet`}

--- a/frontend/src/metabase/reference/metrics/MetricDetail.jsx
+++ b/frontend/src/metabase/reference/metrics/MetricDetail.jsx
@@ -83,7 +83,6 @@ const propTypes = {
   isFormulaExpanded: PropTypes.bool,
   loading: PropTypes.bool,
   loadingError: PropTypes.object,
-  submitting: PropTypes.bool,
   onSubmit: PropTypes.func.isRequired,
   onChangeLocation: PropTypes.func.isRequired,
 };
@@ -103,12 +102,17 @@ const MetricDetail = props => {
     expandFormula,
     collapseFormula,
     isFormulaExpanded,
-    submitting,
     onSubmit,
     onChangeLocation,
   } = props;
 
-  const { getFieldProps, getFieldMeta, handleSubmit, handleReset } = useFormik({
+  const {
+    isSubmitting,
+    getFieldProps,
+    getFieldMeta,
+    handleSubmit,
+    handleReset,
+  } = useFormik({
     validate,
     initialValues: {},
     initialErrors: validate({}),
@@ -126,7 +130,7 @@ const MetricDetail = props => {
           onSubmit={handleSubmit}
           endEditing={endEditing}
           reinitializeForm={handleReset}
-          submitting={submitting}
+          submitting={isSubmitting}
           revisionMessageFormField={getField("revision_message")}
         />
       )}

--- a/frontend/src/metabase/reference/reference.js
+++ b/frontend/src/metabase/reference/reference.js
@@ -176,55 +176,62 @@ const updateDataWrapper = (props, fn) => {
 };
 
 export const rUpdateSegmentDetail = (formFields, props) => {
-  updateDataWrapper(props, props.updateSegment)(formFields);
+  return () => updateDataWrapper(props, props.updateSegment)(formFields);
 };
 export const rUpdateSegmentFieldDetail = (formFields, props) => {
-  updateDataWrapper(props, props.updateField)(formFields);
+  return () => updateDataWrapper(props, props.updateField)(formFields);
 };
 export const rUpdateDatabaseDetail = (formFields, props) => {
-  updateDataWrapper(props, props.updateDatabase)(formFields);
+  return () => updateDataWrapper(props, props.updateDatabase)(formFields);
 };
 export const rUpdateTableDetail = (formFields, props) => {
-  updateDataWrapper(props, props.updateTable)(formFields);
+  return () => updateDataWrapper(props, props.updateTable)(formFields);
 };
 export const rUpdateFieldDetail = (formFields, props) => {
-  updateDataWrapper(props, props.updateField)(formFields);
+  return () => updateDataWrapper(props, props.updateField)(formFields);
 };
 
-export const rUpdateMetricDetail = async (metric, formFields, props) => {
-  props.startLoading();
-  try {
-    const editedFields = filterUntouchedFields(formFields, metric);
-    if (!isEmptyObject(editedFields)) {
-      const newMetric = { ...metric, ...editedFields };
-      await props.updateMetric(newMetric);
+export const rUpdateMetricDetail = (metric, formFields, props) => {
+  return async () => {
+    props.startLoading();
+    try {
+      const editedFields = filterUntouchedFields(formFields, metric);
+      if (!isEmptyObject(editedFields)) {
+        const newMetric = { ...metric, ...editedFields };
+        await props.updateMetric(newMetric);
+      }
+    } catch (error) {
+      props.setError(error);
+      console.error(error);
     }
-  } catch (error) {
-    props.setError(error);
-    console.error(error);
-  }
 
-  resetForm(props);
+    resetForm(props);
+  };
 };
 
-export const rUpdateFields = async (fields, formFields, props) => {
-  props.startLoading();
-  try {
-    const updatedFields = Object.keys(formFields)
-      .map(fieldId => ({
-        field: fields[fieldId],
-        formField: filterUntouchedFields(formFields[fieldId], fields[fieldId]),
-      }))
-      .filter(({ field, formField }) => !isEmptyObject(formField))
-      .map(({ field, formField }) => ({ ...field, ...formField }));
+export const rUpdateFields = (fields, formFields, props) => {
+  return async () => {
+    props.startLoading();
+    try {
+      const updatedFields = Object.keys(formFields)
+        .map(fieldId => ({
+          field: fields[fieldId],
+          formField: filterUntouchedFields(
+            formFields[fieldId],
+            fields[fieldId],
+          ),
+        }))
+        .filter(({ field, formField }) => !isEmptyObject(formField))
+        .map(({ field, formField }) => ({ ...field, ...formField }));
 
-    await Promise.all(updatedFields.map(props.updateField));
-  } catch (error) {
-    props.setError(error);
-    console.error(error);
-  }
+      await Promise.all(updatedFields.map(props.updateField));
+    } catch (error) {
+      props.setError(error);
+      console.error(error);
+    }
 
-  resetForm(props);
+    resetForm(props);
+  };
 };
 
 const initialState = {

--- a/frontend/src/metabase/reference/segments/SegmentDetail.jsx
+++ b/frontend/src/metabase/reference/segments/SegmentDetail.jsx
@@ -133,7 +133,10 @@ const SegmentDetail = props => {
     onSubmit: fields => onSubmit(fields, { ...props, resetForm: handleReset }),
   });
 
-  const getField = name => ({ ...getFieldProps(name), ...getFieldMeta(name) });
+  const getFormField = name => ({
+    ...getFieldProps(name),
+    ...getFieldMeta(name),
+  });
 
   return (
     <form style={style} className="full" onSubmit={handleSubmit}>
@@ -144,7 +147,7 @@ const SegmentDetail = props => {
           endEditing={endEditing}
           reinitializeForm={handleReset}
           submitting={isSubmitting}
-          revisionMessageFormField={getField("revision_message")}
+          revisionMessageFormField={getFormField("revision_message")}
         />
       )}
       <EditableReferenceHeader
@@ -163,8 +166,8 @@ const SegmentDetail = props => {
         hasSingleSchema={false}
         hasDisplayName={false}
         startEditing={startEditing}
-        displayNameFormField={getField("display_name")}
-        nameFormField={getField("name")}
+        displayNameFormField={getFormField("display_name")}
+        nameFormField={getFormField("name")}
       />
       <LoadingAndErrorWrapper
         loading={!loadingError && loading}
@@ -202,7 +205,7 @@ const SegmentDetail = props => {
                     description={entity.description}
                     placeholder={t`No description yet`}
                     isEditing={isEditing}
-                    field={getField("description")}
+                    field={getFormField("description")}
                   />
                 </li>
                 <li className="relative">
@@ -212,7 +215,7 @@ const SegmentDetail = props => {
                     description={entity.points_of_interest}
                     placeholder={t`Nothing interesting yet`}
                     isEditing={isEditing}
-                    field={getField("points_of_interest")}
+                    field={getFormField("points_of_interest")}
                   />
                 </li>
                 <li className="relative">
@@ -222,7 +225,7 @@ const SegmentDetail = props => {
                     description={entity.caveats}
                     placeholder={t`Nothing to be aware of yet`}
                     isEditing={isEditing}
-                    field={getField("caveats")}
+                    field={getFormField("caveats")}
                   />
                 </li>
                 {!isEditing && (

--- a/frontend/src/metabase/reference/segments/SegmentDetail.jsx
+++ b/frontend/src/metabase/reference/segments/SegmentDetail.jsx
@@ -100,7 +100,6 @@ const propTypes = {
   isFormulaExpanded: PropTypes.bool,
   loading: PropTypes.bool,
   loadingError: PropTypes.object,
-  submitting: PropTypes.bool,
   onSubmit: PropTypes.func.isRequired,
 };
 
@@ -118,11 +117,16 @@ const SegmentDetail = props => {
     expandFormula,
     collapseFormula,
     isFormulaExpanded,
-    submitting,
     onSubmit,
   } = props;
 
-  const { getFieldProps, getFieldMeta, handleSubmit, handleReset } = useFormik({
+  const {
+    isSubmitting,
+    getFieldProps,
+    getFieldMeta,
+    handleSubmit,
+    handleReset,
+  } = useFormik({
     validate,
     initialValues: {},
     initialErrors: validate({}),
@@ -139,7 +143,7 @@ const SegmentDetail = props => {
           onSubmit={handleSubmit}
           endEditing={endEditing}
           reinitializeForm={handleReset}
-          submitting={submitting}
+          submitting={isSubmitting}
           revisionMessageFormField={getField("revision_message")}
         />
       )}

--- a/frontend/src/metabase/reference/segments/SegmentDetail.jsx
+++ b/frontend/src/metabase/reference/segments/SegmentDetail.jsx
@@ -75,7 +75,7 @@ const mapStateToProps = (state, props) => {
 const mapDispatchToProps = {
   ...metadataActions,
   ...actions,
-  onUpdate: actions.rUpdateSegmentDetail,
+  onSubmit: actions.rUpdateSegmentDetail,
 };
 
 const validate = values =>
@@ -101,7 +101,7 @@ const propTypes = {
   loading: PropTypes.bool,
   loadingError: PropTypes.object,
   submitting: PropTypes.bool,
-  onUpdate: PropTypes.func.isRequired,
+  onSubmit: PropTypes.func.isRequired,
 };
 
 const SegmentDetail = props => {
@@ -119,7 +119,7 @@ const SegmentDetail = props => {
     collapseFormula,
     isFormulaExpanded,
     submitting,
-    onUpdate,
+    onSubmit,
   } = props;
 
   const { getFieldProps, getFieldMeta, handleSubmit, handleReset } = useFormik({
@@ -127,7 +127,7 @@ const SegmentDetail = props => {
     initialValues: {},
     initialErrors: validate({}),
     onSubmit: fields =>
-      onUpdate(entity, fields, { ...props, resetForm: handleReset }),
+      onSubmit(entity, fields, { ...props, resetForm: handleReset }),
   });
 
   const getField = name => ({ ...getFieldProps(name), ...getFieldMeta(name) });

--- a/frontend/src/metabase/reference/segments/SegmentDetail.jsx
+++ b/frontend/src/metabase/reference/segments/SegmentDetail.jsx
@@ -126,8 +126,7 @@ const SegmentDetail = props => {
     validate,
     initialValues: {},
     initialErrors: validate({}),
-    onSubmit: fields =>
-      onSubmit(entity, fields, { ...props, resetForm: handleReset }),
+    onSubmit: fields => onSubmit(fields, { ...props, resetForm: handleReset }),
   });
 
   const getField = name => ({ ...getFieldProps(name), ...getFieldMeta(name) });

--- a/frontend/src/metabase/reference/segments/SegmentDetail.jsx
+++ b/frontend/src/metabase/reference/segments/SegmentDetail.jsx
@@ -1,13 +1,12 @@
 /* eslint "react/prop-types": "warn" */
-import React, { Component } from "react";
+import React from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
-import { reduxForm } from "redux-form";
+import { useFormik } from "formik";
 import { t } from "ttag";
 import S from "../components/Detail.css";
 import List from "metabase/components/List";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
-import _ from "underscore";
 
 import EditHeader from "metabase/reference/components/EditHeader";
 import EditableReferenceHeader from "metabase/reference/components/EditableReferenceHeader";
@@ -76,204 +75,184 @@ const mapStateToProps = (state, props) => {
 const mapDispatchToProps = {
   ...metadataActions,
   ...actions,
+  onUpdate: actions.rUpdateSegmentDetail,
 };
 
-const validate = (values, props) =>
+const validate = values =>
   !values.revision_message
     ? { revision_message: t`Please enter a revision message` }
     : {};
 
-class SegmentDetail extends Component {
-  static propTypes = {
-    style: PropTypes.object.isRequired,
-    entity: PropTypes.object.isRequired,
-    table: PropTypes.object,
-    user: PropTypes.object.isRequired,
-    isEditing: PropTypes.bool,
-    startEditing: PropTypes.func.isRequired,
-    endEditing: PropTypes.func.isRequired,
-    startLoading: PropTypes.func.isRequired,
-    endLoading: PropTypes.func.isRequired,
-    expandFormula: PropTypes.func.isRequired,
-    collapseFormula: PropTypes.func.isRequired,
-    setError: PropTypes.func.isRequired,
-    updateField: PropTypes.func.isRequired,
-    handleSubmit: PropTypes.func.isRequired,
-    resetForm: PropTypes.func.isRequired,
-    fields: PropTypes.object.isRequired,
-    isFormulaExpanded: PropTypes.bool,
-    loading: PropTypes.bool,
-    loadingError: PropTypes.object,
-    submitting: PropTypes.bool,
-  };
+const propTypes = {
+  style: PropTypes.object.isRequired,
+  entity: PropTypes.object.isRequired,
+  table: PropTypes.object,
+  user: PropTypes.object.isRequired,
+  isEditing: PropTypes.bool,
+  startEditing: PropTypes.func.isRequired,
+  endEditing: PropTypes.func.isRequired,
+  startLoading: PropTypes.func.isRequired,
+  endLoading: PropTypes.func.isRequired,
+  expandFormula: PropTypes.func.isRequired,
+  collapseFormula: PropTypes.func.isRequired,
+  setError: PropTypes.func.isRequired,
+  updateField: PropTypes.func.isRequired,
+  isFormulaExpanded: PropTypes.bool,
+  loading: PropTypes.bool,
+  loadingError: PropTypes.object,
+  submitting: PropTypes.bool,
+  onUpdate: PropTypes.func.isRequired,
+};
 
-  render() {
-    const {
-      fields: {
-        name,
-        display_name,
-        description,
-        revision_message,
-        points_of_interest,
-        caveats,
-      },
-      style,
-      entity,
-      table,
-      loadingError,
-      loading,
-      user,
-      isEditing,
-      startEditing,
-      endEditing,
-      expandFormula,
-      collapseFormula,
-      isFormulaExpanded,
-      handleSubmit,
-      resetForm,
-      submitting,
-    } = this.props;
+const SegmentDetail = props => {
+  const {
+    style,
+    entity,
+    table,
+    loadingError,
+    loading,
+    user,
+    isEditing,
+    startEditing,
+    endEditing,
+    expandFormula,
+    collapseFormula,
+    isFormulaExpanded,
+    submitting,
+    onUpdate,
+  } = props;
 
-    const onSubmit = handleSubmit(
-      async fields => await actions.rUpdateSegmentDetail(fields, this.props),
-    );
+  const { getFieldProps, getFieldMeta, handleSubmit, handleReset } = useFormik({
+    validate,
+    initialValues: {},
+    initialErrors: validate({}),
+    onSubmit: fields =>
+      onUpdate(entity, fields, { ...props, resetForm: handleReset }),
+  });
 
-    return (
-      <form style={style} className="full" onSubmit={onSubmit}>
-        {isEditing && (
-          <EditHeader
-            hasRevisionHistory={true}
-            onSubmit={onSubmit}
-            endEditing={endEditing}
-            reinitializeForm={resetForm}
-            submitting={submitting}
-            revisionMessageFormField={revision_message}
-          />
-        )}
-        <EditableReferenceHeader
-          entity={entity}
-          table={table}
-          type="segment"
-          headerIcon="segment"
-          headerLink={getQuestionUrl({
-            dbId: table && table.db_id,
-            tableId: entity.table_id,
-            segmentId: entity.id,
-          })}
-          name={t`Details`}
-          user={user}
-          isEditing={isEditing}
-          hasSingleSchema={false}
-          hasDisplayName={false}
-          startEditing={startEditing}
-          displayNameFormField={display_name}
-          nameFormField={name}
+  const getField = name => ({ ...getFieldProps(name), ...getFieldMeta(name) });
+
+  return (
+    <form style={style} className="full" onSubmit={handleSubmit}>
+      {isEditing && (
+        <EditHeader
+          hasRevisionHistory={true}
+          onSubmit={handleSubmit}
+          endEditing={endEditing}
+          reinitializeForm={handleReset}
+          submitting={submitting}
+          revisionMessageFormField={getField("revision_message")}
         />
-        <LoadingAndErrorWrapper
-          loading={!loadingError && loading}
-          error={loadingError}
-        >
-          {() => (
-            <div className="wrapper">
-              <div className="pl4 pr3 pt4 mb4 mb1 bg-white rounded bordered">
-                <List>
-                  <li>
-                    <div className={S.detail}>
-                      <div className={S.detailBody}>
-                        <div>
-                          <div className={S.detailTitle}>
-                            {t`Table this is based on`}
-                          </div>
-                          {table && (
-                            <div>
-                              <Link
-                                className="text-brand text-bold text-paragraph"
-                                to={`/reference/databases/${table.db_id}/tables/${table.id}`}
-                              >
-                                <span className="pt1">
-                                  {table.display_name}
-                                </span>
-                              </Link>
-                            </div>
-                          )}
+      )}
+      <EditableReferenceHeader
+        entity={entity}
+        table={table}
+        type="segment"
+        headerIcon="segment"
+        headerLink={getQuestionUrl({
+          dbId: table && table.db_id,
+          tableId: entity.table_id,
+          segmentId: entity.id,
+        })}
+        name={t`Details`}
+        user={user}
+        isEditing={isEditing}
+        hasSingleSchema={false}
+        hasDisplayName={false}
+        startEditing={startEditing}
+        displayNameFormField={getField("display_name")}
+        nameFormField={getField("name")}
+      />
+      <LoadingAndErrorWrapper
+        loading={!loadingError && loading}
+        error={loadingError}
+      >
+        {() => (
+          <div className="wrapper">
+            <div className="pl4 pr3 pt4 mb4 mb1 bg-white rounded bordered">
+              <List>
+                <li>
+                  <div className={S.detail}>
+                    <div className={S.detailBody}>
+                      <div>
+                        <div className={S.detailTitle}>
+                          {t`Table this is based on`}
                         </div>
+                        {table && (
+                          <div>
+                            <Link
+                              className="text-brand text-bold text-paragraph"
+                              to={`/reference/databases/${table.db_id}/tables/${table.id}`}
+                            >
+                              <span className="pt1">{table.display_name}</span>
+                            </Link>
+                          </div>
+                        )}
                       </div>
                     </div>
-                  </li>
+                  </div>
+                </li>
+                <li className="relative">
+                  <Detail
+                    id="description"
+                    name={t`Description`}
+                    description={entity.description}
+                    placeholder={t`No description yet`}
+                    isEditing={isEditing}
+                    field={getField("description")}
+                  />
+                </li>
+                <li className="relative">
+                  <Detail
+                    id="points_of_interest"
+                    name={t`Why this Segment is interesting`}
+                    description={entity.points_of_interest}
+                    placeholder={t`Nothing interesting yet`}
+                    isEditing={isEditing}
+                    field={getField("points_of_interest")}
+                  />
+                </li>
+                <li className="relative">
+                  <Detail
+                    id="caveats"
+                    name={t`Things to be aware of about this Segment`}
+                    description={entity.caveats}
+                    placeholder={t`Nothing to be aware of yet`}
+                    isEditing={isEditing}
+                    field={getField("caveats")}
+                  />
+                </li>
+                {!isEditing && (
                   <li className="relative">
-                    <Detail
-                      id="description"
-                      name={t`Description`}
-                      description={entity.description}
-                      placeholder={t`No description yet`}
-                      isEditing={isEditing}
-                      field={description}
+                    <UsefulQuestions
+                      questions={interestingQuestions(
+                        props.table,
+                        props.entity,
+                      )}
                     />
                   </li>
-                  <li className="relative">
-                    <Detail
-                      id="points_of_interest"
-                      name={t`Why this Segment is interesting`}
-                      description={entity.points_of_interest}
-                      placeholder={t`Nothing interesting yet`}
-                      isEditing={isEditing}
-                      field={points_of_interest}
+                )}
+                {table && !isEditing && (
+                  <li className="relative mb4">
+                    <Formula
+                      type="segment"
+                      entity={entity}
+                      table={table}
+                      isExpanded={isFormulaExpanded}
+                      expandFormula={expandFormula}
+                      collapseFormula={collapseFormula}
                     />
                   </li>
-                  <li className="relative">
-                    <Detail
-                      id="caveats"
-                      name={t`Things to be aware of about this Segment`}
-                      description={entity.caveats}
-                      placeholder={t`Nothing to be aware of yet`}
-                      isEditing={isEditing}
-                      field={caveats}
-                    />
-                  </li>
-                  {!isEditing && (
-                    <li className="relative">
-                      <UsefulQuestions
-                        questions={interestingQuestions(
-                          this.props.table,
-                          this.props.entity,
-                        )}
-                      />
-                    </li>
-                  )}
-                  {table && !isEditing && (
-                    <li className="relative mb4">
-                      <Formula
-                        type="segment"
-                        entity={entity}
-                        table={table}
-                        isExpanded={isFormulaExpanded}
-                        expandFormula={expandFormula}
-                        collapseFormula={collapseFormula}
-                      />
-                    </li>
-                  )}
-                </List>
-              </div>
+                )}
+              </List>
             </div>
-          )}
-        </LoadingAndErrorWrapper>
-      </form>
-    );
-  }
-}
+          </div>
+        )}
+      </LoadingAndErrorWrapper>
+    </form>
+  );
+};
 
-export default _.compose(
-  connect(mapStateToProps, mapDispatchToProps),
-  reduxForm({
-    form: "details",
-    fields: [
-      "name",
-      "display_name",
-      "description",
-      "revision_message",
-      "points_of_interest",
-      "caveats",
-    ],
-    validate,
-  }),
-)(SegmentDetail);
+SegmentDetail.propTypes = propTypes;
+
+export default connect(mapStateToProps, mapDispatchToProps)(SegmentDetail);

--- a/frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx
+++ b/frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx
@@ -116,8 +116,7 @@ const SegmentFieldDetail = props => {
 
   const { getFieldProps, getFieldMeta, handleSubmit, handleReset } = useFormik({
     initialValues: {},
-    onSubmit: fields =>
-      onSubmit(entity, fields, { ...props, resetForm: handleReset }),
+    onSubmit: fields => onSubmit(fields, { ...props, resetForm: handleReset }),
   });
 
   const getField = name => ({ ...getFieldProps(name), ...getFieldMeta(name) });

--- a/frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx
+++ b/frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx
@@ -123,7 +123,10 @@ const SegmentFieldDetail = props => {
     onSubmit: fields => onSubmit(fields, { ...props, resetForm: handleReset }),
   });
 
-  const getField = name => ({ ...getFieldProps(name), ...getFieldMeta(name) });
+  const getFormField = name => ({
+    ...getFieldProps(name),
+    ...getFieldMeta(name),
+  });
 
   return (
     <form style={style} className="full" onSubmit={handleSubmit}>
@@ -134,7 +137,7 @@ const SegmentFieldDetail = props => {
           endEditing={endEditing}
           reinitializeForm={handleReset()}
           submitting={isSubmitting}
-          revisionMessageFormField={getField("revision_message")}
+          revisionMessageFormField={getFormField("revision_message")}
         />
       )}
       <EditableReferenceHeader
@@ -148,8 +151,8 @@ const SegmentFieldDetail = props => {
         hasSingleSchema={false}
         hasDisplayName={true}
         startEditing={startEditing}
-        displayNameFormField={getField("display_name")}
-        nameFormField={getField("name")}
+        displayNameFormField={getFormField("display_name")}
+        nameFormField={getFormField("name")}
       />
       <LoadingAndErrorWrapper
         loading={!loadingError && loading}
@@ -166,7 +169,7 @@ const SegmentFieldDetail = props => {
                     description={entity.description}
                     placeholder={t`No description yet`}
                     isEditing={isEditing}
-                    field={getField("description")}
+                    field={getFormField("description")}
                   />
                 </li>
                 {!isEditing && (
@@ -186,7 +189,7 @@ const SegmentFieldDetail = props => {
                     description={entity.points_of_interest}
                     placeholder={t`Nothing interesting yet`}
                     isEditing={isEditing}
-                    field={getField("points_of_interest")}
+                    field={getFormField("points_of_interest")}
                   />
                 </li>
                 <li className="relative">
@@ -196,7 +199,7 @@ const SegmentFieldDetail = props => {
                     description={entity.caveats}
                     placeholder={t`Nothing to be aware of yet`}
                     isEditing={isEditing}
-                    field={getField("caveats")}
+                    field={getFormField("caveats")}
                   />
                 </li>
 
@@ -213,8 +216,8 @@ const SegmentFieldDetail = props => {
                   <FieldTypeDetail
                     field={entity}
                     foreignKeys={foreignKeys}
-                    fieldTypeFormField={getField("semantic_type")}
-                    foreignKeyFormField={getField("fk_target_field_id")}
+                    fieldTypeFormField={getFormField("semantic_type")}
+                    foreignKeyFormField={getFormField("fk_target_field_id")}
                     isEditing={isEditing}
                   />
                 </li>

--- a/frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx
+++ b/frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx
@@ -1,11 +1,10 @@
 /* eslint "react/prop-types": "warn" */
-import React, { Component } from "react";
+import React from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
-import { reduxForm } from "redux-form";
+import { useFormik } from "formik";
 import { t } from "ttag";
 import S from "metabase/reference/Reference.css";
-import _ from "underscore";
 
 import List from "metabase/components/List";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
@@ -77,193 +76,164 @@ const mapStateToProps = (state, props) => {
 const mapDispatchToProps = {
   ...metadataActions,
   ...actions,
+  onSubmit: actions.rUpdateSegmentFieldDetail,
 };
 
-const validate = (values, props) => {
-  return {};
+const propTypes = {
+  style: PropTypes.object.isRequired,
+  entity: PropTypes.object.isRequired,
+  table: PropTypes.object,
+  user: PropTypes.object.isRequired,
+  foreignKeys: PropTypes.object,
+  isEditing: PropTypes.bool,
+  startEditing: PropTypes.func.isRequired,
+  endEditing: PropTypes.func.isRequired,
+  startLoading: PropTypes.func.isRequired,
+  endLoading: PropTypes.func.isRequired,
+  setError: PropTypes.func.isRequired,
+  updateField: PropTypes.func.isRequired,
+  loading: PropTypes.bool,
+  loadingError: PropTypes.object,
+  submitting: PropTypes.bool,
+  onSubmit: PropTypes.func.isRequired,
 };
 
-class SegmentFieldDetail extends Component {
-  static propTypes = {
-    style: PropTypes.object.isRequired,
-    entity: PropTypes.object.isRequired,
-    table: PropTypes.object,
-    user: PropTypes.object.isRequired,
-    foreignKeys: PropTypes.object,
-    isEditing: PropTypes.bool,
-    startEditing: PropTypes.func.isRequired,
-    endEditing: PropTypes.func.isRequired,
-    startLoading: PropTypes.func.isRequired,
-    endLoading: PropTypes.func.isRequired,
-    setError: PropTypes.func.isRequired,
-    updateField: PropTypes.func.isRequired,
-    handleSubmit: PropTypes.func.isRequired,
-    resetForm: PropTypes.func.isRequired,
-    fields: PropTypes.object.isRequired,
-    loading: PropTypes.bool,
-    loadingError: PropTypes.object,
-    submitting: PropTypes.bool,
-  };
+const SegmentFieldDetail = props => {
+  const {
+    style,
+    entity,
+    table,
+    loadingError,
+    loading,
+    user,
+    foreignKeys,
+    isEditing,
+    startEditing,
+    endEditing,
+    submitting,
+    onSubmit,
+  } = props;
 
-  render() {
-    const {
-      fields: {
-        name,
-        display_name,
-        description,
-        revision_message,
-        points_of_interest,
-        caveats,
-        semantic_type,
-        fk_target_field_id,
-      },
-      style,
-      entity,
-      table,
-      loadingError,
-      loading,
-      user,
-      foreignKeys,
-      isEditing,
-      startEditing,
-      endEditing,
-      handleSubmit,
-      resetForm,
-      submitting,
-    } = this.props;
+  const { getFieldProps, getFieldMeta, handleSubmit, handleReset } = useFormik({
+    initialValues: {},
+    onSubmit: fields =>
+      onSubmit(entity, fields, { ...props, resetForm: handleReset }),
+  });
 
-    const onSubmit = handleSubmit(
-      async fields =>
-        await actions.rUpdateSegmentFieldDetail(fields, this.props),
-    );
+  const getField = name => ({ ...getFieldProps(name), ...getFieldMeta(name) });
 
-    return (
-      <form style={style} className="full" onSubmit={onSubmit}>
-        {isEditing && (
-          <EditHeader
-            hasRevisionHistory={false}
-            onSubmit={onSubmit}
-            endEditing={endEditing}
-            reinitializeForm={resetForm}
-            submitting={submitting}
-            revisionMessageFormField={revision_message}
-          />
-        )}
-        <EditableReferenceHeader
-          entity={entity}
-          table={table}
-          headerIcon="field"
-          name={t`Details`}
-          type="field"
-          user={user}
-          isEditing={isEditing}
-          hasSingleSchema={false}
-          hasDisplayName={true}
-          startEditing={startEditing}
-          displayNameFormField={display_name}
-          nameFormField={name}
+  return (
+    <form style={style} className="full" onSubmit={handleSubmit}>
+      {isEditing && (
+        <EditHeader
+          hasRevisionHistory={false}
+          onSubmit={handleSubmit}
+          endEditing={endEditing}
+          reinitializeForm={handleReset()}
+          submitting={submitting}
+          revisionMessageFormField={getField("revision_message")}
         />
-        <LoadingAndErrorWrapper
-          loading={!loadingError && loading}
-          error={loadingError}
-        >
-          {() => (
-            <div className="wrapper">
-              <div className="pl3 py2 mb4 bg-white bordered">
-                <List>
+      )}
+      <EditableReferenceHeader
+        entity={entity}
+        table={table}
+        headerIcon="field"
+        name={t`Details`}
+        type="field"
+        user={user}
+        isEditing={isEditing}
+        hasSingleSchema={false}
+        hasDisplayName={true}
+        startEditing={startEditing}
+        displayNameFormField={getField("display_name")}
+        nameFormField={getField("name")}
+      />
+      <LoadingAndErrorWrapper
+        loading={!loadingError && loading}
+        error={loadingError}
+      >
+        {() => (
+          <div className="wrapper">
+            <div className="pl3 py2 mb4 bg-white bordered">
+              <List>
+                <li className="relative">
+                  <Detail
+                    id="description"
+                    name={t`Description`}
+                    description={entity.description}
+                    placeholder={t`No description yet`}
+                    isEditing={isEditing}
+                    field={getField("description")}
+                  />
+                </li>
+                {!isEditing && (
                   <li className="relative">
                     <Detail
-                      id="description"
-                      name={t`Description`}
-                      description={entity.description}
-                      placeholder={t`No description yet`}
-                      isEditing={isEditing}
-                      field={description}
+                      id="name"
+                      name={t`Actual name in database`}
+                      description={entity.name}
+                      subtitleClass={S.tableActualName}
                     />
                   </li>
-                  {!isEditing && (
-                    <li className="relative">
-                      <Detail
-                        id="name"
-                        name={t`Actual name in database`}
-                        description={entity.name}
-                        subtitleClass={S.tableActualName}
-                      />
-                    </li>
-                  )}
-                  <li className="relative">
-                    <Detail
-                      id="points_of_interest"
-                      name={t`Why this field is interesting`}
-                      description={entity.points_of_interest}
-                      placeholder={t`Nothing interesting yet`}
-                      isEditing={isEditing}
-                      field={points_of_interest}
-                    />
-                  </li>
-                  <li className="relative">
-                    <Detail
-                      id="caveats"
-                      name={t`Things to be aware of about this field`}
-                      description={entity.caveats}
-                      placeholder={t`Nothing to be aware of yet`}
-                      isEditing={isEditing}
-                      field={caveats}
-                    />
-                  </li>
+                )}
+                <li className="relative">
+                  <Detail
+                    id="points_of_interest"
+                    name={t`Why this field is interesting`}
+                    description={entity.points_of_interest}
+                    placeholder={t`Nothing interesting yet`}
+                    isEditing={isEditing}
+                    field={getField("points_of_interest")}
+                  />
+                </li>
+                <li className="relative">
+                  <Detail
+                    id="caveats"
+                    name={t`Things to be aware of about this field`}
+                    description={entity.caveats}
+                    placeholder={t`Nothing to be aware of yet`}
+                    isEditing={isEditing}
+                    field={getField("caveats")}
+                  />
+                </li>
 
-                  {!isEditing && (
-                    <li className="relative">
-                      <Detail
-                        id="base_type"
-                        name={t`Data type`}
-                        description={entity.base_type}
-                      />
-                    </li>
-                  )}
+                {!isEditing && (
                   <li className="relative">
-                    <FieldTypeDetail
-                      field={entity}
-                      foreignKeys={foreignKeys}
-                      fieldTypeFormField={semantic_type}
-                      foreignKeyFormField={fk_target_field_id}
-                      isEditing={isEditing}
+                    <Detail
+                      id="base_type"
+                      name={t`Data type`}
+                      description={entity.base_type}
                     />
                   </li>
-                  {!isEditing && (
-                    <li className="relative">
-                      <UsefulQuestions
-                        questions={interestingQuestions(
-                          this.props.table,
-                          this.props.entity,
-                        )}
-                      />
-                    </li>
-                  )}
-                </List>
-              </div>
+                )}
+                <li className="relative">
+                  <FieldTypeDetail
+                    field={entity}
+                    foreignKeys={foreignKeys}
+                    fieldTypeFormField={getField("semantic_type")}
+                    foreignKeyFormField={getField("fk_target_field_id")}
+                    isEditing={isEditing}
+                  />
+                </li>
+                {!isEditing && (
+                  <li className="relative">
+                    <UsefulQuestions
+                      questions={interestingQuestions(
+                        props.table,
+                        props.entity,
+                      )}
+                    />
+                  </li>
+                )}
+              </List>
             </div>
-          )}
-        </LoadingAndErrorWrapper>
-      </form>
-    );
-  }
-}
+          </div>
+        )}
+      </LoadingAndErrorWrapper>
+    </form>
+  );
+};
 
-export default _.compose(
-  connect(mapStateToProps, mapDispatchToProps),
-  reduxForm({
-    form: "details",
-    fields: [
-      "name",
-      "display_name",
-      "description",
-      "revision_message",
-      "points_of_interest",
-      "caveats",
-      "semantic_type",
-      "fk_target_field_id",
-    ],
-    validate,
-  }),
-)(SegmentFieldDetail);
+SegmentFieldDetail.propTypes = propTypes;
+
+export default connect(mapStateToProps, mapDispatchToProps)(SegmentFieldDetail);

--- a/frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx
+++ b/frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx
@@ -94,7 +94,6 @@ const propTypes = {
   updateField: PropTypes.func.isRequired,
   loading: PropTypes.bool,
   loadingError: PropTypes.object,
-  submitting: PropTypes.bool,
   onSubmit: PropTypes.func.isRequired,
 };
 
@@ -110,11 +109,16 @@ const SegmentFieldDetail = props => {
     isEditing,
     startEditing,
     endEditing,
-    submitting,
     onSubmit,
   } = props;
 
-  const { getFieldProps, getFieldMeta, handleSubmit, handleReset } = useFormik({
+  const {
+    isSubmitting,
+    getFieldProps,
+    getFieldMeta,
+    handleSubmit,
+    handleReset,
+  } = useFormik({
     initialValues: {},
     onSubmit: fields => onSubmit(fields, { ...props, resetForm: handleReset }),
   });
@@ -129,7 +133,7 @@ const SegmentFieldDetail = props => {
           onSubmit={handleSubmit}
           endEditing={endEditing}
           reinitializeForm={handleReset()}
-          submitting={submitting}
+          submitting={isSubmitting}
           revisionMessageFormField={getField("revision_message")}
         />
       )}

--- a/frontend/src/metabase/reference/segments/SegmentFieldList.jsx
+++ b/frontend/src/metabase/reference/segments/SegmentFieldList.jsx
@@ -1,13 +1,12 @@
 /* eslint "react/prop-types": "warn" */
-import React, { Component } from "react";
+import React from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
-import { reduxForm } from "redux-form";
+import { useFormik } from "formik";
 import { t } from "ttag";
 import S from "metabase/components/List.css";
 import R from "metabase/reference/Reference.css";
 import F from "metabase/reference/components/Field.css";
-import _ from "underscore";
 
 import Field from "metabase/reference/components/Field";
 import List from "metabase/components/List";
@@ -20,16 +19,14 @@ import EditableReferenceHeader from "metabase/reference/components/EditableRefer
 import cx from "classnames";
 
 import {
+  getError,
   getFieldsBySegment,
   getForeignKeys,
-  getError,
-  getLoading,
-  getUser,
   getIsEditing,
+  getLoading,
   getSegment,
+  getUser,
 } from "../selectors";
-
-import { fieldsToFormFields } from "../utils";
 
 import { getIconForField } from "metabase/lib/schema_metadata";
 
@@ -51,146 +48,142 @@ const mapStateToProps = (state, props) => {
     loadingError: getError(state, props),
     user: getUser(state, props),
     isEditing: getIsEditing(state, props),
-    fields: fieldsToFormFields(data),
   };
 };
 
 const mapDispatchToProps = {
   ...metadataActions,
   ...actions,
+  onSubmit: actions.rUpdateFields,
 };
 
-const validate = (values, props) => {
-  return {};
+const propTypes = {
+  segment: PropTypes.object.isRequired,
+  style: PropTypes.object.isRequired,
+  entities: PropTypes.object.isRequired,
+  foreignKeys: PropTypes.object.isRequired,
+  isEditing: PropTypes.bool,
+  startEditing: PropTypes.func.isRequired,
+  endEditing: PropTypes.func.isRequired,
+  startLoading: PropTypes.func.isRequired,
+  endLoading: PropTypes.func.isRequired,
+  setError: PropTypes.func.isRequired,
+  updateField: PropTypes.func.isRequired,
+  user: PropTypes.object.isRequired,
+  loading: PropTypes.bool,
+  loadingError: PropTypes.object,
+  onSubmit: PropTypes.func,
 };
 
-class SegmentFieldList extends Component {
-  static propTypes = {
-    segment: PropTypes.object.isRequired,
-    style: PropTypes.object.isRequired,
-    entities: PropTypes.object.isRequired,
-    foreignKeys: PropTypes.object.isRequired,
-    isEditing: PropTypes.bool,
-    startEditing: PropTypes.func.isRequired,
-    endEditing: PropTypes.func.isRequired,
-    startLoading: PropTypes.func.isRequired,
-    endLoading: PropTypes.func.isRequired,
-    setError: PropTypes.func.isRequired,
-    updateField: PropTypes.func.isRequired,
-    handleSubmit: PropTypes.func.isRequired,
-    user: PropTypes.object.isRequired,
-    fields: PropTypes.object.isRequired,
-    loading: PropTypes.bool,
-    loadingError: PropTypes.object,
-    submitting: PropTypes.bool,
-    resetForm: PropTypes.func,
-  };
+const SegmentFieldList = props => {
+  const {
+    segment,
+    style,
+    entities,
+    foreignKeys,
+    loadingError,
+    loading,
+    user,
+    isEditing,
+    startEditing,
+    endEditing,
+    onSubmit,
+  } = props;
 
-  render() {
-    const {
-      segment,
-      style,
-      entities,
-      fields,
-      foreignKeys,
-      loadingError,
-      loading,
-      user,
-      isEditing,
-      startEditing,
-      endEditing,
-      resetForm,
-      handleSubmit,
-      submitting,
-    } = this.props;
+  const {
+    isSubmitting,
+    getFieldProps,
+    getFieldMeta,
+    handleSubmit,
+    handleReset,
+  } = useFormik({
+    initialValues: {},
+    onSubmit: fields =>
+      onSubmit(entities, fields, { ...props, resetForm: handleReset }),
+  });
 
-    return (
-      <form
-        style={style}
-        className="full"
-        onSubmit={handleSubmit(
-          async formFields =>
-            await actions.rUpdateFields(
-              this.props.entities,
-              formFields,
-              this.props,
-            ),
-        )}
-      >
-        {isEditing && (
-          <EditHeader
-            hasRevisionHistory={false}
-            reinitializeForm={resetForm}
-            endEditing={endEditing}
-            submitting={submitting}
-          />
-        )}
-        <EditableReferenceHeader
-          type="segment"
-          headerIcon="segment"
-          name={t`Fields in ${segment.name}`}
-          user={user}
-          isEditing={isEditing}
-          startEditing={startEditing}
+  const getFormField = name => ({
+    ...getFieldProps(name),
+    ...getFieldMeta(name),
+  });
+
+  const getNestedFormField = id => ({
+    display_name: getFormField(`${id}.display_name`),
+    semantic_type: getFormField(`${id}.semantic_type`),
+    fk_target_field_id: getFormField(`${id}.fk_target_field_id`),
+  });
+
+  return (
+    <form style={style} className="full" onSubmit={handleSubmit}>
+      {isEditing && (
+        <EditHeader
+          hasRevisionHistory={false}
+          reinitializeForm={handleReset}
+          endEditing={endEditing}
+          submitting={isSubmitting}
         />
-        <LoadingAndErrorWrapper
-          loading={!loadingError && loading}
-          error={loadingError}
-        >
-          {() =>
-            Object.keys(entities).length > 0 ? (
-              <div className="wrapper">
-                <div className="pl4 pb2 mb4 bg-white rounded bordered">
-                  <div className={S.item}>
-                    <div className={R.columnHeader}>
-                      <div className={cx(S.itemTitle, F.fieldNameTitle)}>
-                        {t`Field name`}
-                      </div>
-                      <div className={cx(S.itemTitle, F.fieldType)}>
-                        {t`Field type`}
-                      </div>
-                      <div className={cx(S.itemTitle, F.fieldDataType)}>
-                        {t`Data type`}
-                      </div>
+      )}
+      <EditableReferenceHeader
+        type="segment"
+        headerIcon="segment"
+        name={t`Fields in ${segment.name}`}
+        user={user}
+        isEditing={isEditing}
+        startEditing={startEditing}
+      />
+      <LoadingAndErrorWrapper
+        loading={!loadingError && loading}
+        error={loadingError}
+      >
+        {() =>
+          Object.keys(entities).length > 0 ? (
+            <div className="wrapper">
+              <div className="pl4 pb2 mb4 bg-white rounded bordered">
+                <div className={S.item}>
+                  <div className={R.columnHeader}>
+                    <div className={cx(S.itemTitle, F.fieldNameTitle)}>
+                      {t`Field name`}
+                    </div>
+                    <div className={cx(S.itemTitle, F.fieldType)}>
+                      {t`Field type`}
+                    </div>
+                    <div className={cx(S.itemTitle, F.fieldDataType)}>
+                      {t`Data type`}
                     </div>
                   </div>
-                  <List>
-                    {Object.values(entities).map(
-                      entity =>
-                        entity &&
-                        entity.id &&
-                        entity.name && (
-                          <li className="relative" key={entity.id}>
-                            <Field
-                              field={entity}
-                              foreignKeys={foreignKeys}
-                              url={`/reference/segments/${segment.id}/fields/${entity.id}`}
-                              icon={getIconForField(entity)}
-                              isEditing={isEditing}
-                              formField={fields[entity.id]}
-                            />
-                          </li>
-                        ),
-                    )}
-                  </List>
                 </div>
+                <List>
+                  {Object.values(entities).map(
+                    entity =>
+                      entity &&
+                      entity.id &&
+                      entity.name && (
+                        <li className="relative" key={entity.id}>
+                          <Field
+                            field={entity}
+                            foreignKeys={foreignKeys}
+                            url={`/reference/segments/${segment.id}/fields/${entity.id}`}
+                            icon={getIconForField(entity)}
+                            isEditing={isEditing}
+                            formField={getNestedFormField(entity.id)}
+                          />
+                        </li>
+                      ),
+                  )}
+                </List>
               </div>
-            ) : (
-              <div className={S.empty}>
-                <EmptyState {...emptyStateData} />
-              </div>
-            )
-          }
-        </LoadingAndErrorWrapper>
-      </form>
-    );
-  }
-}
+            </div>
+          ) : (
+            <div className={S.empty}>
+              <EmptyState {...emptyStateData} />
+            </div>
+          )
+        }
+      </LoadingAndErrorWrapper>
+    </form>
+  );
+};
 
-export default _.compose(
-  connect(mapStateToProps, mapDispatchToProps),
-  reduxForm({
-    form: "fields",
-    validate,
-  }),
-)(SegmentFieldList);
+SegmentFieldList.propTypes = propTypes;
+
+export default connect(mapStateToProps, mapDispatchToProps)(SegmentFieldList);

--- a/frontend/src/metabase/reference/utils.js
+++ b/frontend/src/metabase/reference/utils.js
@@ -45,15 +45,6 @@ export const databaseToForeignKeys = database =>
         .reduce((map, foreignKey) => assoc(map, foreignKey.id, foreignKey), {})
     : {};
 
-export const fieldsToFormFields = fields =>
-  Object.keys(fields)
-    .map(key => [
-      `${key}.display_name`,
-      `${key}.semantic_type`,
-      `${key}.fk_target_field_id`,
-    ])
-    .reduce((array, keys) => array.concat(keys), []);
-
 // TODO Atte Keinänen 7/3/17: Construct question with Question of metabase-lib instead of this using function
 export const getQuestion = ({
   dbId,


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/22372

Replaces `redux-form` in the following forms:
- `DatabaseDetail`
- `FieldDetail`
- `TableDetail`
- `SegmentDetail`
- `SegmentFieldDetail`
- `FieldList`
- `SegmentFieldList`

Please note that I needed to convert these components to function components. [Ignore whitespace to see the actual changes](https://github.com/metabase/metabase/pull/24722/files?diff=split&w=1).

How to test:
- Go to `/reference`
- Change entities of specified types and make sure it works

<img width="1728" alt="Screenshot 2022-08-11 at 15 26 33" src="https://user-images.githubusercontent.com/8542534/184133024-0c6780e4-7cb3-4c45-a397-6e0218f30a14.png">

