### PR TITLE
remove autocomplete match style setting ui

### DIFF
--- a/frontend/src/metabase/admin/settings/selectors.js
+++ b/frontend/src/metabase/admin/settings/selectors.js
@@ -120,17 +120,6 @@ const SECTIONS = updateSectionsWithPlugins({
         defaultValue: "simple",
       },
       {
-        key: "native-query-autocomplete-match-style",
-        display_name: t`Native query editor autocomplete match`,
-        type: "select",
-        defaultValue: "substring",
-        options: [
-          { value: "substring", name: t`Substring` },
-          { value: "prefix", name: t`Prefix` },
-          { value: "off", name: t`Off` },
-        ],
-      },
-      {
         key: "enable-nested-queries",
         display_name: t`Enable Nested Queries`,
         type: "boolean",


### PR DESCRIPTION
## Changes

The setting UI is not necessary because it affects instances in exceptional cases. Usage of the env var is enough for now.