### PR TITLE
Add Pulumi+ECS as installation option

### DIFF
--- a/docs/operations-guide/installing-metabase.md
+++ b/docs/operations-guide/installing-metabase.md
@@ -27,6 +27,7 @@ To run a development branch of Metabase, check out our [developer's guide](../de
 ## Other installation options
 
 - [Running on AWS Elastic Beanstalk](running-metabase-on-elastic-beanstalk.md)
+- [Running on AWS ECS using Pulumi](https://www.pulumi.com/registry/packages/metabase/#quick-start)
 - [Running on Azure Web Apps](running-metabase-on-azure.md)
 - [Running on Heroku](running-metabase-on-heroku.md)
 - [Running on Debian as a service](running-metabase-on-debian.md)


### PR DESCRIPTION
This PR adds Pulumi's Metabase Package as an installation option. You can read more about the blog post [here](https://www.pulumi.com/blog/unlocking-your-data-with-metabase-and-aws/), but essentially this installation option allows a user to quickly deploy Metabase running on AWS ECS Fargate.

### Tests

- [ ] Run the frontend and Cypress end-to-end tests with `yarn lint && yarn test`)
- [ ] If there are changes to the backend codebase, run the backend tests with `clojure -X:dev:test`
- [ ] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
      (unless it's a tiny documentation change).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/24725)
<!-- Reviewable:end -->
