### PR TITLE
Refactor Filter Popover to functional component

### DIFF
--- a/frontend/src/metabase/query_builder/components/filters/FilterPopover/FilterPopover.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/FilterPopover/FilterPopover.tsx
@@ -84,7 +84,7 @@ export default function FilterPopover({
 
   // if the underlying query changes (e.x. additional metadata is loaded) update the filter's query
   useEffect(() => {
-    if (filter && query !== previousQuery) {
+    if (filter && previousQuery && query !== previousQuery) {
       setFilter(filter.setQuery(query));
     }
   }, [query, previousQuery, filter]);

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterSelect/BulkFilterSelect.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterSelect/BulkFilterSelect.tsx
@@ -93,7 +93,6 @@ export const BulkFilterSelect = ({
           onChangeFilter={handleChange}
           onClose={closePopover}
           checkedColor="brand"
-          commitOnBlur
         />
       )}
     />


### PR DESCRIPTION
This refactors `<FilterPopover />` to a functional component and gets rid of all prop and state spreading. There should be no functional changes.

I had hoped this would help me nail down some unit testing problems. This didn't actually fix anything, but it's a marginal improvement in code quality that I think is worth merging.