### PR TITLE
Apply main args from bootstrap

### DIFF
--- a/src/metabase/bootstrap.clj
+++ b/src/metabase/bootstrap.clj
@@ -13,4 +13,4 @@
 (defn -main
   "Main entrypoint. Invokes [[metabase.core/-main]]"
   [& args]
-  ((requiring-resolve 'metabase.core/-main) args))
+  (apply (requiring-resolve 'metabase.core/-main) args))


### PR DESCRIPTION
Left out an apply in the new bootstrap entry point.

```shell
java -jar target/uberjar/metabase.jar migrate up
... logging
Metabase Enterprise Edition extensions are NOT PRESENT.
Exception in thread "main" java.lang.IllegalArgumentException: no conversion to symbol
	at clojure.core$symbol.invokeStatic(core.clj:598)
	at clojure.core$symbol.invoke(core.clj:591)
	at metabase.cmd$cmd__GT_var.invokeStatic(cmd.clj:173)
... more stacktrace
```

After:

```shell
❯ java -jar target/uberjar/metabase.jar migrate up
.. logging
2022-08-11 14:32:09,662 INFO db.setup :: Setting up Liquibase...
2022-08-11 14:32:10,048 INFO db.setup :: Liquibase is ready.
2022-08-11 14:32:10,049 INFO db.liquibase :: Checking if Database has unrun migrations...
2022-08-11 14:32:11,814 INFO db.liquibase :: Database has unrun migrations. Waiting for migration lock to be cleared...
2022-08-11 14:32:11,916 INFO db.liquibase :: Migration lock is cleared. Running migrations...
```