### PR TITLE
fix reset password flow

### DIFF
--- a/frontend/src/metabase/auth/components/ForgotPassword/ForgotPassword.styled.tsx
+++ b/frontend/src/metabase/auth/components/ForgotPassword/ForgotPassword.styled.tsx
@@ -59,6 +59,7 @@ export const InfoTitle = styled.div`
 export const InfoMessage = styled.div`
   color: ${color("text-dark")};
   text-align: center;
+  margin-bottom: 1rem;
 `;
 
 export const InfoLink = styled(Link)`

--- a/frontend/src/metabase/auth/components/ForgotPassword/ForgotPassword.tsx
+++ b/frontend/src/metabase/auth/components/ForgotPassword/ForgotPassword.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useMemo, useState } from "react";
 import { t } from "ttag";
 import Users from "metabase/entities/users";
+import Button from "metabase/core/components/Button";
 import AuthLayout from "../../containers/AuthLayout";
 import { ForgotPasswordData } from "../../types";
 import {
@@ -99,10 +100,7 @@ const ForgotPasswordSuccess = (): JSX.Element => {
       <InfoMessage>
         {t`Check your email for instructions on how to reset your password.`}
       </InfoMessage>
-      <InfoLink
-        className="Button Button--primary"
-        to="/auth/login"
-      >{t`Back to sign in`}</InfoLink>
+      <Button primary as="a" href="/auth/login">{t`Back to sign in`}</Button>
     </InfoBody>
   );
 };

--- a/frontend/src/metabase/auth/components/ResetPassword/ResetPassword.styled.tsx
+++ b/frontend/src/metabase/auth/components/ResetPassword/ResetPassword.styled.tsx
@@ -23,20 +23,6 @@ export const InfoBody = styled.div`
   align-items: center;
 `;
 
-export const InfoIcon = styled(Icon)`
-  display: block;
-  color: ${color("brand")};
-  width: 1.5rem;
-  height: 1.5rem;
-`;
-
-export const InfoIconContainer = styled.div`
-  padding: 1.25rem;
-  border-radius: 50%;
-  background-color: ${color("brand-light")};
-  margin-bottom: 1.5rem;
-`;
-
 export const InfoTitle = styled.div`
   color: ${color("text-dark")};
   font-size: 1.25rem;

--- a/frontend/src/metabase/auth/components/ResetPassword/ResetPassword.tsx
+++ b/frontend/src/metabase/auth/components/ResetPassword/ResetPassword.tsx
@@ -21,7 +21,7 @@ export interface ResetPasswordProps {
   onResetPassword: (token: string, password: string) => void;
   onValidatePassword: (password: string) => void;
   onValidatePasswordToken: (token: string) => void;
-  showToast: (toast: { message: string }) => void;
+  onShowToast: (toast: { message: string }) => void;
   onRedirect: (url: string) => void;
 }
 
@@ -30,7 +30,7 @@ const ResetPassword = ({
   onResetPassword,
   onValidatePassword,
   onValidatePasswordToken,
-  showToast,
+  onShowToast,
   onRedirect,
 }: ResetPasswordProps): JSX.Element | null => {
   const [view, setView] = useState<ViewType>("none");
@@ -60,9 +60,9 @@ const ResetPassword = ({
     async ({ password }: ResetPasswordData) => {
       await onResetPassword(token, password);
       onRedirect("/");
-      showToast({ message: t`You've updated your password.` });
+      onShowToast({ message: t`You've updated your password.` });
     },
-    [onResetPassword, token, onRedirect, showToast],
+    [onResetPassword, token, onRedirect, onShowToast],
   );
 
   useEffect(() => {

--- a/frontend/src/metabase/auth/components/ResetPassword/ResetPassword.tsx
+++ b/frontend/src/metabase/auth/components/ResetPassword/ResetPassword.tsx
@@ -10,8 +10,6 @@ import {
   FormMessage,
   FormTitle,
   InfoBody,
-  InfoIcon,
-  InfoIconContainer,
   InfoMessage,
   InfoTitle,
 } from "./ResetPassword.styled";
@@ -23,6 +21,8 @@ export interface ResetPasswordProps {
   onResetPassword: (token: string, password: string) => void;
   onValidatePassword: (password: string) => void;
   onValidatePasswordToken: (token: string) => void;
+  showToast: (toast: { message: string }) => void;
+  onRedirect: (url: string) => void;
 }
 
 const ResetPassword = ({
@@ -30,6 +30,8 @@ const ResetPassword = ({
   onResetPassword,
   onValidatePassword,
   onValidatePasswordToken,
+  showToast,
+  onRedirect,
 }: ResetPasswordProps): JSX.Element | null => {
   const [view, setView] = useState<ViewType>("none");
 
@@ -57,9 +59,10 @@ const ResetPassword = ({
   const handlePasswordSubmit = useCallback(
     async ({ password }: ResetPasswordData) => {
       await onResetPassword(token, password);
-      setView("success");
+      onRedirect("/");
+      showToast({ message: t`You've updated your password.` });
     },
-    [token, onResetPassword],
+    [onResetPassword, token, onRedirect, showToast],
   );
 
   useEffect(() => {
@@ -74,7 +77,6 @@ const ResetPassword = ({
           onSubmit={handlePasswordSubmit}
         />
       )}
-      {view === "success" && <ResetPasswordSuccess />}
       {view === "expired" && <ResetPasswordExpired />}
     </AuthLayout>
   );
@@ -107,22 +109,6 @@ const ResetPasswordForm = ({
         onSubmit={onSubmit}
       />
     </div>
-  );
-};
-
-const ResetPasswordSuccess = (): JSX.Element => {
-  return (
-    <InfoBody>
-      <InfoIconContainer>
-        <InfoIcon name="check" />
-      </InfoIconContainer>
-      <InfoTitle>{t`All done!`}</InfoTitle>
-      <InfoMessage>{t`You've updated your password.`}</InfoMessage>
-      <Link
-        className="Button Button--primary"
-        to="/"
-      >{t`Sign in with your new password`}</Link>
-    </InfoBody>
   );
 };
 

--- a/frontend/src/metabase/auth/components/ResetPassword/ResetPassword.unit.spec.tsx
+++ b/frontend/src/metabase/auth/components/ResetPassword/ResetPassword.unit.spec.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode } from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import ResetPassword, { ResetPasswordProps } from "./ResetPassword";
 
@@ -27,18 +27,34 @@ describe("ResetPassword", () => {
   });
 
   it("should show a success message when the form is submitted", async () => {
+    const showToast = jest.fn();
+    const onRedirect = jest.fn();
+
     const props = getProps({
       onResetPassword: jest.fn().mockResolvedValue({}),
       onValidatePasswordToken: jest.fn().mockResolvedValue({}),
+      showToast,
+      onRedirect,
     });
 
-    render(<ResetPassword {...props} />);
+    render(
+      <ResetPassword
+        {...props}
+        showToast={showToast}
+        onRedirect={onRedirect}
+      />,
+    );
 
     const button = await screen.findByText("Save new password");
+
     userEvent.click(button);
 
-    const message = await screen.findByText("All done!");
-    expect(message).toBeInTheDocument();
+    await waitFor(() => {
+      expect(onRedirect).toHaveBeenCalledWith("/");
+      expect(showToast).toHaveBeenCalledWith({
+        message: "You've updated your password.",
+      });
+    });
   });
 });
 
@@ -48,6 +64,8 @@ const getProps = (opts?: Partial<ResetPasswordProps>): ResetPasswordProps => {
     onResetPassword: jest.fn(),
     onValidatePassword: jest.fn(),
     onValidatePasswordToken: jest.fn(),
+    showToast: jest.fn(),
+    onRedirect: jest.fn(),
     ...opts,
   };
 };

--- a/frontend/src/metabase/auth/components/ResetPassword/ResetPassword.unit.spec.tsx
+++ b/frontend/src/metabase/auth/components/ResetPassword/ResetPassword.unit.spec.tsx
@@ -27,20 +27,20 @@ describe("ResetPassword", () => {
   });
 
   it("should show a success message when the form is submitted", async () => {
-    const showToast = jest.fn();
+    const onShowToast = jest.fn();
     const onRedirect = jest.fn();
 
     const props = getProps({
       onResetPassword: jest.fn().mockResolvedValue({}),
       onValidatePasswordToken: jest.fn().mockResolvedValue({}),
-      showToast,
+      onShowToast,
       onRedirect,
     });
 
     render(
       <ResetPassword
         {...props}
-        showToast={showToast}
+        onShowToast={onShowToast}
         onRedirect={onRedirect}
       />,
     );
@@ -51,7 +51,7 @@ describe("ResetPassword", () => {
 
     await waitFor(() => {
       expect(onRedirect).toHaveBeenCalledWith("/");
-      expect(showToast).toHaveBeenCalledWith({
+      expect(onShowToast).toHaveBeenCalledWith({
         message: "You've updated your password.",
       });
     });
@@ -64,7 +64,7 @@ const getProps = (opts?: Partial<ResetPasswordProps>): ResetPasswordProps => {
     onResetPassword: jest.fn(),
     onValidatePassword: jest.fn(),
     onValidatePasswordToken: jest.fn(),
-    showToast: jest.fn(),
+    onShowToast: jest.fn(),
     onRedirect: jest.fn(),
     ...opts,
   };

--- a/frontend/src/metabase/auth/containers/ResetPasswordApp/ResetPasswordApp.tsx
+++ b/frontend/src/metabase/auth/containers/ResetPasswordApp/ResetPasswordApp.tsx
@@ -1,5 +1,7 @@
 import { connect } from "react-redux";
+import { replace } from "react-router-redux";
 import ResetPassword from "../../components/ResetPassword";
+import { addUndo } from "metabase/redux/undo";
 import {
   resetPassword,
   validatePassword,
@@ -14,6 +16,8 @@ const mapDispatchToProps = {
   onResetPassword: resetPassword,
   onValidatePassword: validatePassword,
   onValidatePasswordToken: validatePasswordToken,
+  showToast: addUndo,
+  onRedirect: replace,
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(ResetPassword);

--- a/frontend/src/metabase/auth/containers/ResetPasswordApp/ResetPasswordApp.tsx
+++ b/frontend/src/metabase/auth/containers/ResetPasswordApp/ResetPasswordApp.tsx
@@ -16,7 +16,7 @@ const mapDispatchToProps = {
   onResetPassword: resetPassword,
   onValidatePassword: validatePassword,
   onValidatePasswordToken: validatePasswordToken,
-  showToast: addUndo,
+  onShowToast: addUndo,
   onRedirect: replace,
 };
 

--- a/frontend/src/metabase/core/components/Button/Button.tsx
+++ b/frontend/src/metabase/core/components/Button/Button.tsx
@@ -37,6 +37,7 @@ interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
   as?: ElementType;
   className?: string;
   to?: string;
+  href?: string;
 
   icon?: string | ReactNode;
   iconSize?: number;

--- a/frontend/test/metabase/scenarios/onboarding/auth/forgot_password.cy.spec.js
+++ b/frontend/test/metabase/scenarios/onboarding/auth/forgot_password.cy.spec.js
@@ -26,10 +26,7 @@ describe("scenarios > auth > password", () => {
       cy.findByLabelText("Confirm your password").type(admin.password);
       cy.findByText("Save new password").click();
 
-      cy.findByText("All done!");
-      cy.findByText("Sign in with your new password").click();
-
-      cy.findByText(admin.first_name, { exact: false });
+      cy.findByText("You've updated your password.");
     });
   });
 });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/24700

## Changes

Redirect users to the home page after they changed their password and show a toast message. I've used the existing localized text message so that we can backport the fix.

<img width="1333" alt="Screen Shot 2022-08-11 at 11 54 57 PM" src="https://user-images.githubusercontent.com/14301985/184227918-f2560929-887c-46e6-b3e7-4132d64c8334.png">

## How to verify
Set up emails on your Metabase instance:
You can use a container with maildev: ` docker run -p 80:80 -p 25:25 maildev/maildev` 

- Log out
- Visit the login page and click the forgot password link
- Go through the reset password process
- Ensure you end up on the home page logged in the app
 