### PR TITLE
Add platform to Dockerfile to unblock releases on 43

### DIFF
--- a/bin/docker/Dockerfile
+++ b/bin/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11-jre-alpine
+FROM --platform=linux/amd64 eclipse-temurin:11-jre-alpine
 
 ENV FC_LANG en-US LC_CTYPE en_US.UTF-8
 


### PR DESCRIPTION
Add target platform to Dockerfile. This just backports a change from master and releas-x.44.x that allows releases to work on `release-x.43.x` (in case we need to ever do hotfixes in the future). I ran into it while releasing 43.5.
