### PR TITLE
Fix incorrect hash for Advanced fieldvalues

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sandbox/models/params/field_values.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/models/params/field_values.clj
@@ -54,10 +54,13 @@
   [{:keys [table_id id] :as _field}]
   (when-let [gtap (table-id->gtap table_id)]
     (let [login-attributes     (:login_attributes @api/*current-user*)
-          attribute_remappings (:attribute_remappings gtap)]
+          attribute_remappings (:attribute_remappings gtap)
+          field-ids            (db/select-field :id Field :table_id table_id)]
       [(:card_id gtap)
        (into {} (for [[k v] attribute_remappings
-                      :when (= (mbql.u/match-one v [:dimension [:field id _]] id) id)]
+                      ;; get any attribute that map to field inside the same table
+                      :when (contains? field-ids
+                                       (mbql.u/match-one v [:dimension [:field field-id _]] field-id))]
                   {k (get login-attributes k)}))])))
 
 (defenterprise get-or-create-field-values-for-current-user!*

--- a/enterprise/backend/src/metabase_enterprise/sandbox/models/params/field_values.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/models/params/field_values.clj
@@ -40,11 +40,11 @@
   The gtap-attributes is a list with 2 elements:
   1. card-id - for GTAP that use a saved question
   2. a map:
-    - with key is the user-attribute applied to `field-id`
+    - with key is the user-attribute that applied to the table that `field` is in
     - value is the user-attribute of current user corresponding to the key
 
   For example we have an GTAP rules
-  {:card_id 1
+  {:card_id              1
    :attribute_remappings {\"State\" [:dimension [:field 3 nil]]}}
 
   And users with login-attributes {\"State\" \"CA\"}
@@ -58,7 +58,7 @@
           field-ids            (db/select-field :id Field :table_id table_id)]
       [(:card_id gtap)
        (into {} (for [[k v] attribute_remappings
-                      ;; get any attribute that map to field inside the same table
+                      ;; get attribute that map to fields of the same table
                       :when (contains? field-ids
                                        (mbql.u/match-one v [:dimension [:field field-id _]] field-id))]
                   {k (get login-attributes k)}))])))

--- a/enterprise/backend/src/metabase_enterprise/sandbox/models/params/field_values.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/models/params/field_values.clj
@@ -51,7 +51,7 @@
 
   ;; (field-id->gtap-attributes-for-current-user (Field 3))
   ;; -> [1, {\"State\" \"CA\"}]"
-  [{:keys [table_id _id] :as _field}]
+  [{:keys [table_id] :as _field}]
   (when-let [gtap (table-id->gtap table_id)]
     (let [login-attributes     (:login_attributes @api/*current-user*)
           attribute_remappings (:attribute_remappings gtap)

--- a/enterprise/backend/src/metabase_enterprise/sandbox/models/params/field_values.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/models/params/field_values.clj
@@ -51,7 +51,7 @@
 
   ;; (field-id->gtap-attributes-for-current-user (Field 3))
   ;; -> [1, {\"State\" \"CA\"}]"
-  [{:keys [table_id id] :as _field}]
+  [{:keys [table_id _id] :as _field}]
   (when-let [gtap (table-id->gtap table_id)]
     (let [login-attributes     (:login_attributes @api/*current-user*)
           attribute_remappings (:attribute_remappings gtap)

--- a/enterprise/backend/test/metabase_enterprise/sandbox/models/params/field_values_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/models/params/field_values_test.clj
@@ -51,39 +51,47 @@
     ;; copy at top level so that `with-gtaps-for-user` does not have to create a new copy every time it gets called
     (mt/with-temp-copy-of-db
       (testing "gtap with remappings"
-        (letfn [(hash-for-user-id [user-id login-attributes]
+        (letfn [(hash-for-user-id [user-id login-attributes field-id]
                   (mt/with-gtaps-for-user user-id
                     {:gtaps      {:categories {:remappings {"State" [:dimension [:field (mt/id :categories :name) nil]]}}}
                      :attributes login-attributes}
-                    (ee-params.field-values/hash-key-for-sandbox (mt/id :categories :name))))]
+                    (ee-params.field-values/hash-key-for-sandbox field-id)))]
           (mt/with-temp* [User [{user-id-1 :id}]
                           User [{user-id-2 :id}]]
 
-            (testing "2 users with the same attribute should have the same hash"
-              (is (= (hash-for-user-id user-id-1 {"State" "CA"})
-                     (hash-for-user-id user-id-2 {"State" "CA"})))
+            (testing "2 users with the same attribute"
+              (testing "should have the same hash for the same field"
+                (is (= (hash-for-user-id user-id-1 {"State" "CA"} (mt/id :categories :name))
+                       (hash-for-user-id user-id-2 {"State" "CA"} (mt/id :categories :name)))))
+              (testing "should have different hash for different fields"
+                (is (not= (hash-for-user-id user-id-1 {"State" "CA"} (mt/id :categories :name))
+                          (hash-for-user-id user-id-2 {"State" "CA"} (mt/id :categories :id)))))
               (testing "having extra login attributes won't effect the hash"
                 (is (= (hash-for-user-id user-id-1 {"State" "CA"
-                                                    "City"  "San Jose"})
-                       (hash-for-user-id user-id-2 {"State" "CA"})))))
+                                                    "City"  "San Jose"} (mt/id :categories :name))
+                       (hash-for-user-id user-id-2 {"State" "CA"} (mt/id :categories :name))))))
 
-            (testing "same users but the login_attributes change should have different hash"
-              (is (not= (hash-for-user-id user-id-1 {"State" "CA"})
-                        (hash-for-user-id user-id-1 {"State" "NY"}))))
+            (testing "2 users with the same attribute should have the different hash for different "
+              (is (= (hash-for-user-id user-id-1 {"State" "CA"} (mt/id :categories :name))
+                     (hash-for-user-id user-id-2 {"State" "CA"} (mt/id :categories :name)))))
 
-            (testing "2 users with different login_attributes should have different hash"
-              (is (not= (hash-for-user-id user-id-1 {"State" "CA"})
-                        (hash-for-user-id user-id-2 {"State" "NY"})))
-              (is (not= (hash-for-user-id user-id-1 {})
-                        (hash-for-user-id user-id-2 {"State" "NY"}))))))))
+           (testing "same users but the login_attributes change should have different hash"
+             (is (not= (hash-for-user-id user-id-1 {"State" "CA"} (mt/id :categories :name))
+                       (hash-for-user-id user-id-1 {"State" "NY"} (mt/id :categories :name)))))
+
+           (testing "2 users with different login_attributes should have different hash"
+             (is (not= (hash-for-user-id user-id-1 {"State" "CA"} (mt/id :categories :name))
+                       (hash-for-user-id user-id-2 {"State" "NY"} (mt/id :categories :name))))
+             (is (not= (hash-for-user-id user-id-1 {} (mt/id :categories :name))
+                       (hash-for-user-id user-id-2 {"State" "NY"} (mt/id :categories :name)))))))))
 
     (testing "gtap with card and remappings"
       ;; hack so that we don't have to setup all the sandbox permissions the table
       (with-redefs [ee-params.field-values/field-is-sandboxed? (constantly true)]
-        (letfn [(hash-for-user-id-with-attributes [user-id login_attributes]
+        (letfn [(hash-for-user-id-with-attributes [user-id login_attributes field-id]
                   (mt/with-temp-vals-in-db User user-id {:login_attributes login_attributes}
                     (mw.session/with-current-user user-id
-                      (ee-params.field-values/hash-key-for-sandbox (mt/id :categories :name)))))]
+                      (ee-params.field-values/hash-key-for-sandbox field-id))))]
           (testing "2 users in the same group"
             (mt/with-temp*
               [Card                       [{card-id :id}]
@@ -98,13 +106,18 @@
                                               :group_id group-id
                                               :table_id (mt/id :categories)
                                               :attribute_remappings {"State" [:dimension [:field (mt/id :categories :name) nil]]}}]]
-              (testing "if the have the same attributes, the hash should be the ssame"
-                (is (= (hash-for-user-id-with-attributes user-id-1 {"State" "CA"})
-                       (hash-for-user-id-with-attributes user-id-2 {"State" "CA"}))))
 
-              (testing "if the have the different attributes, the hash should be the different"
-                (is (not= (hash-for-user-id-with-attributes user-id-1 {"State" "CA"})
-                          (hash-for-user-id-with-attributes user-id-2 {"State" "NY"}))))))
+              (testing "with same attributes, the hash should be the same field"
+                (is (= (hash-for-user-id-with-attributes user-id-1 {"State" "CA"} (mt/id :categories :name))
+                       (hash-for-user-id-with-attributes user-id-2 {"State" "CA"} (mt/id :categories :name)))))
+
+              (testing "with same attributes, the hash should different for different fields"
+                (is (not= (hash-for-user-id-with-attributes user-id-1 {"State" "CA"} (mt/id :categories :name))
+                          (hash-for-user-id-with-attributes user-id-2 {"State" "CA"} (mt/id :categories :id)))))
+
+             (testing "with different attributes, the hash should be the different"
+               (is (not= (hash-for-user-id-with-attributes user-id-1 {"State" "CA"} (mt/id :categories :name))
+                         (hash-for-user-id-with-attributes user-id-2 {"State" "NY"} (mt/id :categories :name)))))))
 
           (testing "2 users in different groups but gtaps use the same card"
             (mt/with-temp*
@@ -128,13 +141,17 @@
                                               :group_id group-id-2
                                               :table_id (mt/id :categories)
                                               :attribute_remappings {"State" [:dimension [:field (mt/id :categories :name) nil]]}}]]
-              (testing "if the have the same attributes, the hash should be the ssame"
-                (is (= (hash-for-user-id-with-attributes user-id-1 {"State" "CA"})
-                       (hash-for-user-id-with-attributes user-id-2 {"State" "CA"}))))
+              (testing "with the same attributes, the hash should be the same"
+                (is (= (hash-for-user-id-with-attributes user-id-1 {"State" "CA"} (mt/id :categories :name))
+                       (hash-for-user-id-with-attributes user-id-2 {"State" "CA"} (mt/id :categories :name)))))
 
-              (testing "if the have the different attributes, the hash should be the different"
-                (is (not= (hash-for-user-id-with-attributes user-id-1 {"State" "CA"})
-                          (hash-for-user-id-with-attributes user-id-2 {"State" "NY"}))))))
+              (testing "with same attributes, the hash should different for different fields"
+                (is (not= (hash-for-user-id-with-attributes user-id-1 {"State" "CA"} (mt/id :categories :name))
+                          (hash-for-user-id-with-attributes user-id-2 {"State" "CA"} (mt/id :categories :id)))))
+
+             (testing "with different attributes, the hash should be the different"
+               (is (not= (hash-for-user-id-with-attributes user-id-1 {"State" "CA"} (mt/id :categories :name))
+                         (hash-for-user-id-with-attributes user-id-2 {"State" "NY"} (mt/id :categories :name)))))))
 
           (testing "2 users in different groups and gtaps use 2 different cards"
             (mt/with-temp*
@@ -158,7 +175,7 @@
                                               :table_id (mt/id :categories)
                                               :attribute_remappings {"State" [:dimension [:field (mt/id :categories :name) nil]]}}]]
               (testing "the hash are different even though they have the same attribute"
-                (is (not= (hash-for-user-id-with-attributes user-id-1 {"State" "CA"})
-                          (hash-for-user-id-with-attributes user-id-2 {"State" "CA"})))
-                (is (not= (hash-for-user-id-with-attributes user-id-1 {"State" "CA"})
-                          (hash-for-user-id-with-attributes user-id-2 {"State" "NY"})))))))))))
+                (is (not= (hash-for-user-id-with-attributes user-id-1 {"State" "CA"} (mt/id :categories :name))
+                          (hash-for-user-id-with-attributes user-id-2 {"State" "CA"} (mt/id :categories :name))))
+                (is (not= (hash-for-user-id-with-attributes user-id-1 {"State" "CA"} (mt/id :categories :name))
+                          (hash-for-user-id-with-attributes user-id-2 {"State" "NY"} (mt/id :categories :name))))))))))))

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -608,7 +608,7 @@
       (try
         (let [results (map (if (seq query)
                                #(chain-filter/chain-filter-search % constraints query :limit result-limit)
-                                #(chain-filter/chain-filter % constraints :limit result-limit))
+                               #(chain-filter/chain-filter % constraints :limit result-limit))
                            field-ids)
               values (distinct (mapcat :values results))
               has_more_values (boolean (some true? (map :has_more_values results)))]


### PR DESCRIPTION
In #24096 we compute the hash for an AdvancedFieldValues using a map of user attributes (call it `user-attribute-map`).
Related to #15977

There is a bug that if users have a sandbox rule field People.State,
the hash will be the same for Field that **is not** `People.State`, even when the user attribute changes.

To reproduce, use `master` branch:

0. Activate enterprise
1. Create 1 user with attribute State = "CA"
2. Create a group "Test Group" and add the create user in
3. Go to Permissions > Data > All Users > Sample Database > set data access to no-self-service
4. Go to Permissions > Data > Test Group > Sample Dataset > People > Data Access > Sandbox
5. Go to Data Model > Sample Dataset > People, change "filtering on this field" to a "A list of values"
6. Choose filter by column and map column "State" equals user' attribute "State"
7. Create a People question and add them to a dashboard
8. Create a location/dropdown parameter and link to the `People.City` column.
9. Open a new window, log in as the created user, and open the parameter, notice it'll show a list with the 1st option is "Arbuckle"
10. Back to admin, change user attribute to State=NY
11. Back to the created user and open the parameter again. Notice it is still the same list as before( 1st option is Arbuckle)

The reason we had this bug was that we constructed the `user-attribute-map` by looking for a sandbox attribute that map to the field we're trying to access.
Thus if we have a sandbox rule on People.State and we try to access People.City, the `user-attribute-map` will be empty. Same for if the user tries to access People.Address.

In the hindsight, the sandbox rule applies to a table, not a field. We should look for a sandbox attribute 
- that map to fields of the table 
- that the field we try to access belongs.

It's a bit confusing and I think it's clearer in code, please check https://github.com/metabase/metabase/pull/24740/files#r944496010.

To test, follow the the reproduction instruction above, but at the last step you should see a different list of values that starts with "Albany"