### PR TITLE
Fix for #24715: "Remember Me" functionality doesn't work

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/auth/middleware/session-middleware.js
+++ b/enterprise/frontend/src/metabase-enterprise/auth/middleware/session-middleware.js
@@ -44,7 +44,7 @@ export const createSessionMiddleware = (
             }
           } else {
             const url = location.pathname + location.search + location.hash;
-            store.dispatch(logout(url, false));
+            store.dispatch(logout(url));
           }
         }
       }, COOKIE_POOLING_TIMEOUT);

--- a/enterprise/frontend/src/metabase-enterprise/auth/middleware/session-middleware.js
+++ b/enterprise/frontend/src/metabase-enterprise/auth/middleware/session-middleware.js
@@ -44,7 +44,7 @@ export const createSessionMiddleware = (
             }
           } else {
             const url = location.pathname + location.search + location.hash;
-            store.dispatch(logout(url, true));
+            store.dispatch(logout(url, false));
           }
         }
       }, COOKIE_POOLING_TIMEOUT);

--- a/enterprise/frontend/src/metabase-enterprise/auth/middleware/session-middleware.unit.spec.js
+++ b/enterprise/frontend/src/metabase-enterprise/auth/middleware/session-middleware.unit.spec.js
@@ -97,7 +97,7 @@ describe("createSessionMiddleware", () => {
       clock.tick(COOKIE_POOLING_TIMEOUT);
 
       expect(dispatchMock).toHaveBeenCalled();
-      expect(logout).toHaveBeenCalledWith("/question/1?query=5#hash", true);
+      expect(logout).toHaveBeenCalledWith("/question/1?query=5#hash");
     });
   });
 

--- a/frontend/src/metabase/auth/actions.ts
+++ b/frontend/src/metabase/auth/actions.ts
@@ -66,27 +66,22 @@ export const loginGoogle = createThunkAction(
 );
 
 export const LOGOUT = "metabase/auth/LOGOUT";
-export const logout = createThunkAction(
-  LOGOUT,
-  (redirectUrl: string, isSessionAlreadyExpired: boolean) => {
-    return async (dispatch: any) => {
-      if (!isSessionAlreadyExpired) {
-        await deleteSession();
-      }
-      await dispatch(clearCurrentUser());
-      await dispatch(refreshLocale());
-      trackLogout();
+export const logout = createThunkAction(LOGOUT, (redirectUrl: string) => {
+  return async (dispatch: any) => {
+    await deleteSession();
+    await dispatch(clearCurrentUser());
+    await dispatch(refreshLocale());
+    trackLogout();
 
-      let loginUrl = "/auth/login";
-      if (redirectUrl) {
-        loginUrl += `?redirect=${encodeURIComponent(redirectUrl)}`;
-      }
+    let loginUrl = "/auth/login";
+    if (redirectUrl) {
+      loginUrl += `?redirect=${encodeURIComponent(redirectUrl)}`;
+    }
 
-      dispatch(push(loginUrl));
-      window.location.reload(); // clears redux state and browser caches
-    };
-  },
-);
+    dispatch(push(loginUrl));
+    window.location.reload(); // clears redux state and browser caches
+  };
+});
 
 export const FORGOT_PASSWORD = "metabase/auth/FORGOT_PASSWORD";
 export const forgotPassword = createThunkAction(

--- a/src/metabase/server/middleware/session.clj
+++ b/src/metabase/server/middleware/session.clj
@@ -168,8 +168,6 @@
         (set-session-timeout-cookie request session-type request-time)
         (response/set-cookie (session-cookie-name session-type) (str session-uuid) cookie-options))))
 
-(session-cookie-name :full-app-embed)
-
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                                wrap-session-id                                                 |
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/src/metabase/server/middleware/session.clj
+++ b/src/metabase/server/middleware/session.clj
@@ -64,15 +64,6 @@
                                                        metabase-embedded-session-cookie
                                                        metabase-session-timeout-cookie]))
 
-(defn- use-permanent-cookies?
-  "Check if we should use permanent cookies for a given request, which are not cleared when a browser sesion ends."
-  [request]
-  (if (public-settings/session-cookies)
-    ;; Disallow permanent cookies if MB_SESSION_COOKIES is set
-    false
-    ;; Otherwise check whether the user selected "remember me" during login
-    (get-in request [:body :remember])))
-
 (defmulti default-session-cookie-attributes
   "The appropriate cookie attributes to persist a newly created Session to `response`."
   {:arglists '([session-type request])}
@@ -133,6 +124,15 @@
     metabase-session-cookie
     :full-app-embed
     metabase-embedded-session-cookie))
+
+(defn- use-permanent-cookies?
+  "Check if we should use permanent cookies for a given request, which are not cleared when a browser sesion ends."
+  [request]
+  (if (public-settings/session-cookies)
+    ;; Disallow permanent cookies if MB_SESSION_COOKIES is set
+    false
+    ;; Otherwise check whether the user selected "remember me" during login
+    (get-in request [:body :remember])))
 
 (s/defn set-session-cookies
   "Add the appropriate cookies to the `response` for the Session."

--- a/src/metabase/server/middleware/session.clj
+++ b/src/metabase/server/middleware/session.clj
@@ -29,7 +29,8 @@
 
 ;; How do authenticated API requests work? Metabase first looks for a cookie called `metabase.SESSION`. This is the
 ;; normal way of doing things; this cookie gets set automatically upon login. `metabase.SESSION` is an HttpOnly
-;; cookie and thus can't be viewed by FE code.
+;; cookie and thus can't be viewed by FE code. If the session is a full-app embedded session, then the cookie is
+;; `metabase.EMBEDDED_SESSION` instead.
 ;;
 ;; If that cookie is isn't present, we look for the `metabase.SESSION_ID`, which is the old session cookie set in
 ;; 0.31.x and older. Unlike `metabase.SESSION`, this cookie was set directly by the frontend and thus was not
@@ -138,6 +139,7 @@
         (response/set-cookie metabase-session-timeout-cookie "alive" cookie-options))))
 
 (s/defn set-session-cookies
+  "Add the appropriate cookies to the `response` for the Session."
   [request
    response
    {session-uuid :id

--- a/src/metabase/server/middleware/session.clj
+++ b/src/metabase/server/middleware/session.clj
@@ -46,19 +46,6 @@
 (def ^:private ^String metabase-session-timeout-cookie  "metabase.TIMEOUT")
 (def ^:private ^String anti-csrf-token-header           "x-metabase-anti-csrf-token")
 
-(defmulti session-cookie-name
-  "Returns the appropriate cookie name for the session type"
-  {:arglists '([session-type])}
-  (fn [session-type] session-type))
-
-(defmethod session-cookie-name :normal
-  [_]
-  metabase-session-cookie)
-
-(defmethod session-cookie-name :full-app-embed
-  [_]
-  metabase-embedded-session-cookie)
-
 (defn- clear-cookie [response cookie-name]
   (response/set-cookie response cookie-name nil {:expires "Thu, 1 Jan 1970 00:00:00 GMT", :path "/"}))
 
@@ -137,6 +124,15 @@
     (-> response
         wrap-body-if-needed
         (response/set-cookie metabase-session-timeout-cookie "alive" cookie-options))))
+
+(defn session-cookie-name
+  "Returns the appropriate cookie name for the session type."
+  [session-type]
+  (case session-type
+    :normal
+    metabase-session-cookie
+    :full-app-embed
+    metabase-embedded-session-cookie))
 
 (s/defn set-session-cookies
   "Add the appropriate cookies to the `response` for the Session."


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/24715. This is a regression from https://github.com/metabase/metabase/pull/23349

## Explanation of problems this PR solves

**Bug 1**
If the session timeout setting is off, checking "remember me" doesn't work. This is the bug reported in https://github.com/metabase/metabase/issues/24715. Before session timeouts, the session cookie (`metabase.SESSION`) was being used to implement "remember me" functionality. If the "remember me" checkbox ticked, the session cookie's `max-age` attribute would be set far off into the future. If the user closed the browser and opened the app, the session cookie would still be there. This worked because the session cookie was being set once, on login. But when we introduced session timeouts, we started resetting the session cookie on every request. That means overwriting the `Max-Age` attribute with an `Expires` attribute if the session timeout setting was on (correct), but also removing the `Max-Age` attribute if the session timeout setting was off (wrong).

**Bug 2**
There is another bug not reported in https://github.com/metabase/metabase/issues/24715. If the session timeout setting is off, leaving "remember me" unchecked doesn't work.

To reproduce:
1. Toggle on the session timeout setting, with any value
2. Log out
3. Log in again, and leave "remember me" unchecked on login
4. Close the browser
5. Open the app again. You will still be logged in

The expected behaviour is to be logged out, because "remember me" was unchecked.

This happens for a very similar reason as the other bug. The session cookie initially has no `Max-Age` or `Expires` attribute, which means it will expire when the browser closes. But because we're updating it on every request, it gets an `Expires` attribute.

## How the solution works

In both of the bugs, the problem arises from setting the expires/max-age attributes on the two session cookies (`metabase.SESSION` and `metabase.TIMEOUT`) **together** for two purposes: tracking when the browser closes, and when the timeout expires. The assumption was that their expires/max-age attributes should be kept in sync, so when the timeout cookie expires, the session cookie will expire automatically, and vice versa.

This PR breaks that assumption, and allows metabase.SESSION and metabase.TIMEOUT cookies max-age/expires attributes to be set separately. The `metabase.SESSION` cookie's max-age is set for the "remember me" functionality, and the `metabase.TIMEOUT` cookie's expires attribute is used for the timeout. The `metabase.SESSION` cookie's max-age attribute is set on login once, and from then on, only the `metabase.TIMEOUT` is updated. 

**Specifically, how this solves Bug 1:**
When "remember me" is unchecked the `metabase.SESSION` cookie has no max-age or expires attribute, regardless of the timeout setting. So the cookie disappears when the browser is closed.

**Specifically, how this solves Bug 2:**
When the timeout setting is on, the `metabase.TIMEOUT` cookie is set to expire regardless of whether "Remember me" was checked or not. When it does, the frontend will make a logout request, clearing the `metabase.SESSION` cookie.