### PR TITLE
Fix Dimension instance mismatch problems when filtering via a native Model's remapped field

### DIFF
--- a/frontend/src/metabase-lib/lib/Dimension.ts
+++ b/frontend/src/metabase-lib/lib/Dimension.ts
@@ -565,15 +565,11 @@ export default class Dimension {
     return this.withoutOptions("binning");
   }
 
-  withoutJoinAlias(): Dimension {
-    return this.withoutOptions("join-alias");
-  }
-
   /**
    * Return a copy of this Dimension with any temporal bucketing or binning options removed.
    */
   baseDimension(): Dimension {
-    return this.withoutTemporalBucketing().withoutBinning().withJoinAlias();
+    return this.withoutTemporalBucketing().withoutBinning();
   }
 
   /**

--- a/frontend/src/metabase-lib/lib/Dimension.ts
+++ b/frontend/src/metabase-lib/lib/Dimension.ts
@@ -740,9 +740,12 @@ export class FieldDimension extends Dimension {
 
   isEqual(somethingElse) {
     if (isFieldDimension(somethingElse)) {
+      const thisField = this.field();
+      const otherField = somethingElse.field();
       return (
-        somethingElse._fieldIdOrName === this._fieldIdOrName &&
-        _.isEqual(somethingElse._options, this._options)
+        thisField.id === otherField.id &&
+        thisField.table_id === otherField.table_id &&
+        _.isEqual(this._options, somethingElse._options)
       );
     }
 

--- a/frontend/src/metabase-lib/lib/metadata/Field.ts
+++ b/frontend/src/metabase-lib/lib/metadata/Field.ts
@@ -245,6 +245,8 @@ class FieldInner extends Base {
     if (Array.isArray(this.id)) {
       // if ID is an array, it's a MBQL field reference, typically "field"
       return this.id;
+    } else if (this.field_ref) {
+      return this.field_ref;
     } else {
       return ["field", this.id, null];
     }

--- a/frontend/src/metabase-lib/lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/lib/queries/StructuredQuery.ts
@@ -330,28 +330,16 @@ class StructuredQueryInner extends AtomicQuery {
     const sourceQuery = this.sourceQuery();
 
     if (sourceQuery) {
+      const fields = sourceQuery.columnDimensions().map(dimension => {
+        return dimension?.field();
+      });
+
       return new Table({
         id: this.sourceTableId(),
         name: "",
         display_name: "",
         db: sourceQuery.database(),
-        fields: sourceQuery.columns().map(
-          column =>
-            new Field({
-              ...column,
-              // TODO FIXME -- Do NOT use field-literal unless you're referring to a native query
-              id: [
-                "field",
-                column.name,
-                {
-                  "base-type": column.base_type,
-                },
-              ],
-              source: "fields",
-              // HACK: need to thread the query through to this fake Field
-              query: this,
-            }),
-        ),
+        fields,
         segments: [],
         metrics: [],
       });

--- a/frontend/src/metabase/modes/components/drill/ColumnFilterDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/ColumnFilterDrill.jsx
@@ -22,15 +22,8 @@ export default function ColumnFilterDrill({ question, clicked }) {
     return [];
   }
 
-  const { column } = clicked;
-
-  // if our field ref doesn't match our column id, we have a remapped column
-  // and need to use the field id instead of the ref
-  const fieldRef =
-    column.id !== undefined && column.id !== column.field_ref[1]
-      ? ["field", column.id, null]
-      : column.field_ref;
-
+  const { dimension } = clicked;
+  const fieldRef = dimension.mbql();
   const initialFilter = new Filter([], null, query).setDimension(fieldRef, {
     useDefaultOperator: true,
   });

--- a/frontend/src/metabase/modes/lib/actions.js
+++ b/frontend/src/metabase/modes/lib/actions.js
@@ -61,6 +61,10 @@ export function pivot(question, breakouts = [], dimensions = []) {
   }
 }
 
+function isJoinedColumn(column) {
+  return column.source_alias != null;
+}
+
 export function distribution(question, column) {
   const query = question.query();
   if (query instanceof StructuredQuery) {
@@ -70,6 +74,12 @@ export function distribution(question, column) {
       ? fieldRefWithOption(fieldRefForColumn(column), "binning", {
           strategy: "default",
         })
+      : isJoinedColumn(column)
+      ? fieldRefWithOption(
+          fieldRefForColumn(column),
+          "join-alias",
+          column.source_alias,
+        )
       : fieldRefForColumn(column);
     return query
       .clearAggregations()

--- a/frontend/src/metabase/query_builder/components/BreakoutPopover.jsx
+++ b/frontend/src/metabase/query_builder/components/BreakoutPopover.jsx
@@ -27,6 +27,8 @@ const BreakoutPopover = ({
       width={width}
       field={breakout}
       fieldOptions={fieldOptions}
+      query={query}
+      metadata={query.metadata()}
       onFieldChange={field => {
         onChangeBreakout(field);
         if (onClose) {

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataSidebar.jsx
@@ -151,7 +151,7 @@ function DatasetFieldMetadataSidebar({
       setShouldAnimateFieldChange(true);
       // setTimeout is required as form fields are rerendered pretty frequently
       setTimeout(() => {
-        displayNameInputRef.current.select();
+        displayNameInputRef.current?.select();
       });
     }
   }, [field, previousField]);
@@ -372,4 +372,4 @@ function DatasetFieldMetadataSidebar({
 
 DatasetFieldMetadataSidebar.propTypes = propTypes;
 
-export default DatasetFieldMetadataSidebar;
+export default React.memo(DatasetFieldMetadataSidebar);

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
@@ -407,14 +407,15 @@ class TableInteractive extends Component {
         this.props.data,
         columnIndex,
         this.props.isPivoted,
+        this.props.query,
       );
     } catch (e) {
       console.error(e);
     }
   }
   // NOTE: all arguments must be passed to the memoized method, not taken from this.props etc
-  _getHeaderClickedObjectCached(data, columnIndex, isPivoted) {
-    return getTableHeaderClickedObject(data, columnIndex, isPivoted);
+  _getHeaderClickedObjectCached(data, columnIndex, isPivoted, query) {
+    return getTableHeaderClickedObject(data, columnIndex, isPivoted, query);
   }
 
   visualizationIsClickable(clicked) {

--- a/frontend/src/metabase/visualizations/lib/table.js
+++ b/frontend/src/metabase/visualizations/lib/table.js
@@ -1,3 +1,4 @@
+import Dimension from "metabase-lib/lib/Dimension";
 import { isNumber, isCoordinate } from "metabase/lib/schema_metadata";
 
 export function getTableClickedObjectRowData(
@@ -74,7 +75,12 @@ export function getTableCellClickedObject(
   }
 }
 
-export function getTableHeaderClickedObject(data, columnIndex, isPivoted) {
+export function getTableHeaderClickedObject(
+  data,
+  columnIndex,
+  isPivoted,
+  query,
+) {
   const column = data.cols[columnIndex];
   if (isPivoted) {
     // if it's a pivot table, the first column is
@@ -84,7 +90,14 @@ export function getTableHeaderClickedObject(data, columnIndex, isPivoted) {
       return null; // FIXME?
     }
   } else {
-    return { column };
+    return {
+      column,
+      dimension: Dimension.parseMBQL(
+        column?.field_ref,
+        query?.metadata(),
+        query,
+      ),
+    };
   }
 }
 

--- a/frontend/test/metabase-lib/lib/Dimension.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/Dimension.unit.spec.js
@@ -812,21 +812,19 @@ describe("Dimension", () => {
       });
       describe("isEqual", () => {
         it("should return true for another Dimension with the same underlying MBQL", () => {
-          const anotherDimension = Dimension.parseMBQL([
-            "field",
-            ORDERS.TOTAL.id,
-            { "join-alias": "join1" },
-          ]);
+          const anotherDimension = Dimension.parseMBQL(
+            ["field", ORDERS.TOTAL.id, { "join-alias": "join1" }],
+            metadata,
+          );
           expect(dimension.isEqual(anotherDimension)).toBe(true);
         });
       });
       describe("isSameBaseDimension", () => {
         it("should return true for another Dimension with the same underlying MBQL", () => {
-          const anotherDimension = Dimension.parseMBQL([
-            "field",
-            ORDERS.TOTAL.id,
-            { "join-alias": "join1" },
-          ]);
+          const anotherDimension = Dimension.parseMBQL(
+            ["field", ORDERS.TOTAL.id, { "join-alias": "join1" }],
+            metadata,
+          );
           expect(dimension.isSameBaseDimension(anotherDimension)).toBe(true);
         });
       });

--- a/frontend/test/metabase-lib/lib/queries/StructuredQuery-filters.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/StructuredQuery-filters.unit.spec.js
@@ -1,4 +1,8 @@
-import { ORDERS, PRODUCTS } from "__support__/sample_database_fixture";
+import {
+  metadata,
+  ORDERS,
+  PRODUCTS,
+} from "__support__/sample_database_fixture";
 
 import Dimension from "metabase-lib/lib/Dimension";
 
@@ -70,7 +74,9 @@ describe("StructuredQuery", () => {
         const f = q.filters()[0];
         expect(f.isDimension(["field", ORDERS.TOTAL.id, null])).toBe(true);
         expect(
-          f.isDimension(Dimension.parseMBQL(["field", ORDERS.TOTAL.id, null])),
+          f.isDimension(
+            Dimension.parseMBQL(["field", ORDERS.TOTAL.id, null], metadata),
+          ),
         ).toBe(true);
       });
       it("should return false for different dimensions", () => {

--- a/frontend/test/metabase/scenarios/models/reproductions/22715-remapped-values-override-column-identifier.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/reproductions/22715-remapped-values-override-column-identifier.cy.spec.js
@@ -5,7 +5,7 @@ import {
   filter,
 } from "__support__/e2e/helpers";
 
-describe.skip("filtering based on the remapped column name should result in a correct query (metabase#22715)", () => {
+describe("filtering based on the remapped column name should result in a correct query (metabase#22715)", () => {
   beforeEach(() => {
     cy.intercept("POST", "/api/dataset").as("dataset");
     cy.intercept("PUT", "/api/card/*").as("updateModel");
@@ -26,10 +26,11 @@ describe.skip("filtering based on the remapped column name should result in a co
 
       // Let's go straight to the model metadata editor
       cy.visit(`/model/${id}/metadata`);
-      // Without this Cypress fails to remap the column because an element becomes detached from the DOM
-      cy.findByText(
-        "Use the tab key to navigate through settings and columns.",
-      );
+
+      // Without this Cypress fails to remap the column because an element becomes detached from the DOM.
+      // This is caused by the DatasetFieldMetadataSidebar component rerendering mulitple times.
+      cy.findByText("Database column this maps to");
+      cy.wait(3000);
 
       // The first column `ID` is automatically selected
       mapColumnTo({ table: "Orders", column: "ID" });
@@ -62,9 +63,9 @@ describe.skip("filtering based on the remapped column name should result in a co
   it("when done through the filter trigger (metabase#22715-2)", () => {
     filter();
 
-    cy.findByTestId("sidebar-right").within(() => {
-      cy.findByText("Created At").click();
+    cy.get(".Modal").within(() => {
       cy.findByText("Today").click();
+      cy.findByText("Apply Filters").click();
     });
 
     cy.wait("@dataset");


### PR DESCRIPTION
Fixes #22715

Two converging problems caused this bug:
1. There's still a lot of code in our app that relies on `field_refs` without the context of their associated queries. If we are in a scenario that depends on a card/query then we _need_ to instantiate Dimensions with field_refs, metadata, AND queries (typically via `Dimension.parseMBQL(field_ref, metadata, question.query())`). Otherwise, we won't be able to access all the metadata associated with a given field, since some overriding properties may exist in a card's `result_metadata` array. It is a sucky situation to need to juggle all these bits of state tucked away in the corners of different objects, but until we fix the overarching storage problems of our metadata system it is something we must deal with.
2. There's a looseness to the way in which we instantiate and use some of the fundamental data structures in our app. Part of the issue in this bug was that two equivalent Dimensions failed to be deemed equivalent due to the differing ways in which they were instantiated (one via a field_ref using an `id` and one via a field_ref using a `name`).

I've added some explanatory comments inlined in the changes.

**Testing**
Follow the steps as described here: https://github.com/metabase/metabase/issues/22715#issuecomment-1126958012

Demo of the fix:

https://user-images.githubusercontent.com/13057258/184416912-a2b80626-8538-4468-912f-86ea14ac101c.mov


