### PR TITLE
docs - isnull and isempty

### DIFF
--- a/docs/users-guide/expressions-list.md
+++ b/docs/users-guide/expressions-list.md
@@ -34,8 +34,8 @@ For an introduction to expressions, check out [Writing expressions in the notebo
   - [exp](#exp)
   - [floor](#floor)
   - [interval](#interval)
-  - [isempty](#isempty)
-  - [isnull](#isnull)
+  - [isempty](./expressions/isempty)
+  - [isnull](./expressions/isnull)
   - [lefttrim](#lefttrim)
   - [length](#length)
   - [log](#log)
@@ -296,7 +296,7 @@ Example: `interval([Created At], -1, "month")`.
 
 Related: [between](#between).
 
-### isempty
+### [isempty](./expressions/isempty)
 
 Returns true if the column is empty.
 
@@ -304,7 +304,7 @@ Syntax: `isempty(column)`
 
 Example: `isempty([Discount])` would return true if there were no value in the discount field.
 
-### isnull
+### [isnull](./expressions/isnull)
 
 Returns true if the column is null.
 

--- a/docs/users-guide/expressions/isempty.md
+++ b/docs/users-guide/expressions/isempty.md
@@ -1,0 +1,95 @@
+---
+title: Isempty
+---
+
+# Isempty
+
+`isempty` checks if a value is an empty string (`""`).
+
+**In Metabase, you must combine `isempty` with another expression that accepts boolean arguments (i.e., true or false).** The table below shows you examples of the boolean output that will be passed to your other expression(s).
+
+| Syntax                                                             | Example with an empty string | Example with a true `null`   |
+| ------------------------------------------------------------------ | ---------------------------- | ---------------------------- |
+| `isempty(value)`                                                   | `isempty("")`                | `isempty(null)`              |
+| Returns `true` if the value is an empty string, `false` otherwise. | `true`                       | `false`                      |
+
+## How Metabase handles nulls
+
+In Metabase, columns with string data types can display empty or blank cells for empty strings or `null` values. For example, in the column below, the empty cells could contain either:
+
+- `""`: feedback was submitted and left intentionally blank, so the customer had "no feedback to give".
+- `null`: no feedback was submitted, so the customer's thoughts are "unknown".
+
+| Customer Feedback  | 
+| ------------------ | 
+|                    | 
+| I like your style. | 
+|                    |
+
+## Replacing empty strings with another value
+
+| Feedback           | `case(isempty([Feedback]), "No feedback.", "Unknown feedback.")`| 
+| ------------------ | --------------------------------------------------------------- | 
+|                    | Unknown feedback.                                               | 
+| I like your style. | I like your style.                                              | 
+|                    | No feedback.                                                    |
+
+Combine `isempty` with the [`case` expression](./case) to replace empty strings with something more descriptive.
+
+If the first row's blank cell is actually an empty string (or even an emoji that blends into your table background), then `isnull` will return `false`, and `case` will return the default output "No feedback".
+
+If the third row's blank cell is actually a `null`, then `isnull` will return `true`. The `case` statement evaluates `true` to return the first output "Unknown feedback".
+
+## Accepted data types
+
+| [Data type][data-types] | Works with `isempty`  |
+| ----------------------- | --------------------- |
+| String                  | ✅                    |
+| Number                  | ❌                    |
+| Timestamp               | ❌                    |
+| Boolean                 | ❌                    |
+| JSON                    | ❌                    |
+
+## Limitations
+
+- `isempty` only accepts values with a string data type. If you need to deal with columns that have contain other data type, use `isnull`.
+- In Metabase, you must combine `isempty` with another expression that accepts boolean arguments (i.e., `true` or `false`).
+
+## Converting a function into an `isempty` expression
+
+This section covers functions and formulas that can be used interchangeably with the Metabase `isempty` expression, with notes on how to choose the best option for your use case.
+
+**Metabase expressions**
+
+- [isempty](#isnull)
+
+**Other tools**
+
+- [SQL](#sql)
+- [Spreadsheets](#spreadsheets)
+- [Python](#python)
+
+## isnull
+
+When combined with `case`, the Metabase `isnull` expression can be used to figure out if a blank cell contains a `null` value instead of an empty string.
+
+```
+`case(isnull([Feedback]), "Unknown feedback.", [Feedback]="", "No feedback.")`
+```
+
+is equivalent to the Metabase `isempty` expression:
+
+```
+`case(isempty([Feedback]), "No feedback.", "Unknown feedback.")`
+```
+
+`isempty` cannot be used to check for `null` values.
+
+- Use `isempty` if you're working with columns that have a string data type _and_ your column are non-nullable.
+- Use `isnull` if your columns are nullable (or if you're not sure what type of blank values you're dealing with).
+
+### SQL
+
+### Spreadsheets
+
+### Python

--- a/docs/users-guide/expressions/isempty.md
+++ b/docs/users-guide/expressions/isempty.md
@@ -38,9 +38,9 @@ For example, in the column below, the empty cells could contain either:
 
 Combine `isempty` with the [`case` expression](./case) to replace empty strings with something more descriptive.
 
-If the second row's blank cell is actually an empty string, then `isempty` will return `true`. The `case` statement evaluates `true` to return the first output "No feedback".
+Let's say that the second row's blank cell is actually an empty string, so `isempty` will return `true`. The `case` statement evaluates `true` to return the first output "No feedback".
 
-If the first row's blank cell is actually a `null`, (or even an emoji that blends into your table background), then `isempty` will return `false`, and `case` will return whatever's in the Feedback column as the default output.
+The first row's blank cell doesn't have an empty string, but because it's blank, we're not sure what's in it either---it could be a `null`, or even an emoji that blends into your table background. No matter what the edge case is, `isempty` will return `false`, and `case` will return whatever's in the Feedback column as the default output.
 
 ## Accepted data types
 

--- a/docs/users-guide/expressions/isempty.md
+++ b/docs/users-guide/expressions/isempty.md
@@ -8,12 +8,12 @@ title: Isempty
 
 **In Metabase, you must combine `isempty` with another expression that accepts boolean values.** The table below shows you examples of the boolean output that will be passed to your other expression(s).
 
-| Syntax                                                             | Example with an empty string | Example with a true `null`   |
-| ------------------------------------------------------------------ | ---------------------------- | ---------------------------- |
-| `isempty(value)`                                                   | `isempty("")`                | `isempty(null)`              |
-| Returns `true` if the value is an empty string, `false` otherwise. | `true`                       | `false`                      |
+| Syntax                                                             | Example with an empty string | Example with a true `null` |
+| ------------------------------------------------------------------ | ---------------------------- | -------------------------- |
+| `isempty(value)`                                                   | `isempty("")`                | `isempty(null)`            |
+| Returns `true` if the value is an empty string, `false` otherwise. | `true`                       | `false`                    |
 
-## How Metabase handles nulls
+## How Metabase handles empty strings
 
 In Metabase, columns with string [data types][data-types] will display blank cells for empty strings _or_ `null` values (if the column is nullable in your database).
 
@@ -22,63 +22,61 @@ For example, in the column below, the empty cells could contain either:
 - `""`: feedback was submitted and left intentionally blank, so the person had "no feedback to give".
 - `null`: no feedback was submitted, so the person's thoughts are "unknown".
 
-| Feedback           | 
-| ------------------ | 
-|                    | 
-| I like your style. | 
+| Feedback           |
+| ------------------ |
 |                    |
+|                    |
+| I like your style. |
 
 ## Replacing empty strings with another value
 
-| Feedback           | `case(isempty([Feedback]), "No feedback.", [Feedback])`| 
-| ------------------ | ------------------------------------------------------ | 
-|                    |                                                        | 
-| I like your style. | I like your style.                                     | 
-|                    | No feedback.                                           |
+| Feedback           | `case(isempty([Feedback]), "No feedback.", [Feedback])` |
+| ------------------ | ------------------------------------------------------- |
+|                    |                                                         |
+|                    | No feedback.                                            |
+| I like your style. | I like your style.                                      |
 
 Combine `isempty` with the [`case` expression](./case) to replace empty strings with something more descriptive.
 
-If the first row's blank cell is actually an empty string, then `isempty` will return `true`. The `case` statement evaluates `true` to return the first output "No feedback".
+If the second row's blank cell is actually an empty string, then `isempty` will return `true`. The `case` statement evaluates `true` to return the first output "No feedback".
 
-If the third row's blank cell is actually a `null`, (or even an emoji that blends into your table background), then `isempty` will return `false`, and `case` will return whatever's in the Feedback column as the default output.
+If the first row's blank cell is actually a `null`, (or even an emoji that blends into your table background), then `isempty` will return `false`, and `case` will return whatever's in the Feedback column as the default output.
 
 ## Accepted data types
 
-| [Data type][data-types] | Works with `isempty`  |
-| ----------------------- | --------------------- |
-| String                  | ✅                    |
-| Number                  | ❌                    |
-| Timestamp               | ❌                    |
-| Boolean                 | ❌                    |
-| JSON                    | ❌                    |
+| [Data type][data-types] | Works with `isempty` |
+| ----------------------- | -------------------- |
+| String                  | ✅                   |
+| Number                  | ❌                   |
+| Timestamp               | ❌                   |
+| Boolean                 | ❌                   |
+| JSON                    | ❌                   |
 
 ## Limitations
 
 - In Metabase, you must combine `isempty` with another expression that accepts boolean arguments (i.e., `true` or `false`).
-- `isempty` only accepts one value at a time. If you need to deal with empty strings from multiple columns, you'll need to use multiple `isempty` expressions with [case](./case).
-- If `isempty` doesn't seem to do anything to your blank cells, you might have `null` values. Try the [`isnull` expression](./isempty) instead.
+- `isempty` only accepts one value at a time. If you need to deal with empty strings from multiple columns, you'll need to use multiple `isempty` expressions with the [case expression](./case).
+- If `isempty` doesn't seem to do anything to your blank cells, you might have `null` values. Try the [`isnull` expression](./isnull) instead.
 
 ## Converting a function into an `isempty` expression
 
 This section covers functions and formulas that can be used interchangeably with the Metabase `isempty` expression, with notes on how to choose the best option for your use case.
 
-**Other tools**
-
 - [SQL](#sql)
 - [Spreadsheets](#spreadsheets)
 - [Python](#python)
 
+All examples below use the table from the [Replacing empty strings](#replacing-empty-strings-with-another-value) example:
+
+| Feedback           | `case(isempty([Feedback]), "No feedback.", [Feedback])` |
+| ------------------ | ------------------------------------------------------- |
+|                    |                                                         |
+|                    | No feedback.                                            |
+| I like your style. | I like your style.                                      |
+
 ### SQL
 
 In most cases (unless you're using a NoSQL database), questions created from the [notebook editor][notebook-editor-def] are converted into SQL queries that run against your database or data warehouse.
-
-Using the table from the [Replacing empty strings](#replacing-null-values-with-another-value) example:
-
-| Feedback           | `case(isempty([Feedback]), "No feedback.", [Feedback])`| 
-| ------------------ | ------------------------------------------------------ | 
-|                    |                                                        | 
-| I like your style. | I like your style.                                     | 
-|                    | No feedback.                                           |
 
 ```sql
 CASE WHEN Feedback = "" THEN "No feedback"
@@ -93,7 +91,7 @@ case(isempty([Feedback]), "No feedback.", [Feedback])
 
 ### Spreadsheets
 
-If your [feedback table](#replacing-null-values-with-another-value) is in a spreadsheet where "Feedback" is in column A, then the formula
+If our sample [feedback column](#replacing-empty-strings-with-another-value) is in a spreadsheet where "Feedback" is in column A, then the formula
 
 ```
 =IF(A2 = "", "Unknown feedback.", A2)
@@ -107,13 +105,13 @@ case(isempty([Feedback]), "No feedback.", [Feedback])
 
 ### Python
 
-Assuming the [feedback table](#replacing-null-values-with-another-value) is in a dataframe column called `df["Feedback"]`:
+Assuming the sample [feedback column](#replacing-empty-strings-with-another-value) is in a dataframe column called `df["Feedback"]`:
 
 ```
 df["Custom Column"] = np.where(df["Feedback"] == "", "No feedback.", df["Feedback"])
 ```
 
-is equivalent to the Metabase `isnull` expression:
+is equivalent to the Metabase `isempty` expression:
 
 ```
 case(isempty([Feedback]), "No feedback.", [Feedback])
@@ -127,5 +125,6 @@ case(isempty([Feedback]), "No feedback.", [Feedback])
 [custom-expressions-doc]: ../expressions
 [custom-expressions-learn]: /learn/questions/custom-expressions
 [data-types]: /learn/databases/data-types-overview#examples-of-data-types
+[notebook-editor-def]: /glossary/notebook_editor
 [numpy]: https://numpy.org/doc/
 [pandas]: https://pandas.pydata.org/pandas-docs/stable/

--- a/docs/users-guide/expressions/isnull.md
+++ b/docs/users-guide/expressions/isnull.md
@@ -1,0 +1,96 @@
+---
+title: Isnull
+---
+
+# Isnull
+
+`isnull` checks if a value is a `null`, a special kind of placeholder that's used by a database when something is missing or unknown.
+
+**In Metabase, you must combine `isnull` with another expression that accepts boolean arguments (i.e., true or false).** The table below shows you examples of the boolean value that will be passed to your other expression(s).
+
+| Syntax                                                | Example with a true `null` | Example with an empty string |
+| ---------------------------------------------------   | -------------------------- | ---------------------------- |
+| `isnull(value)`                                       | `isnull(null)`             | `isnull("")`                 |
+| Returns `true` if a value is `null`, false otherwise. | `true`                     | `false`                      |
+
+## How Metabase handles nulls
+
+In Metabase tables, `null`s are displayed as empty or blank cells. For example, in the column below, the empty cells could contain either:
+
+- `null`: no feedback was submitted, so the customer's thoughts are "unknown".
+- `""`: feedback was submitted and left intentionally blank, so the customer had "no feedback to give".
+
+| Customer Feedback  | 
+| ------------------ | 
+|                    | 
+| I like your style. | 
+|                    |
+
+## Replacing null values with another value
+
+| Feedback           | `case(isnull([Feedback]), "Unknown feedback.", "No feedback.")` | 
+| ------------------ | --------------------------------------------------------------- | 
+|                    | Unknown feedback.                                               | 
+| I like your style. | I like your style.                                              | 
+|                    | No feedback.                                                    |
+
+Combine `isnull` with the [`case` expression](./case) to replace "unknown" information with something more descriptive.
+
+If the first row's blank cell is actually a `null`, then `isnull` will return `true`. The `case` statement evaluates `true` to return the first output "Unknown feedback".
+
+If the third row's blank cell is actually an empty string (or even an emoji that blends into your table background), then `isnull` will return `false`, and `case` will return the default output "No feedback".
+
+## Accepted data types
+
+| [Data type][data-types] | Works with `isnull`   |
+| ----------------------- | --------------------- |
+| String                  | ✅                    |
+| Number                  | ✅                    |
+| Timestamp               | ✅                    |
+| Boolean                 | ✅                    |
+| JSON                    | ✅                    |
+
+## Limitations
+
+- `isnull` only accepts one value at a time. If you need to deal with empty cells , see [coalesce](./coalesce).
+- In Metabase, you must combine `isnull` with another expression that accepts boolean arguments (i.e., `true` or `false`).
+
+## Converting a function into an `isnull` expression
+
+This section covers functions and formulas that can be used interchangeably with the Metabase `isnull` expression, with notes on how to choose the best option for your use case.
+
+**Metabase expressions**
+
+- [isempty]()
+
+**Other tools**
+
+- [SQL](#sql)
+- [Spreadsheets](#spreadsheets)
+- [Python](#python)
+
+## isempty
+
+When combined with `case`, the Metabase `isempty` expression can be used to figure out if a blank cell contains an empty string instead of a `null` value.
+
+```
+`case(isempty([Feedback]), "No feedback.", "Unknown feedback.")`
+```
+
+is equivalent to the Metabase `isnull` expression:
+
+```
+`case(isnull([Feedback]), "Unknown feedback.", [Feedback]="", "No feedback.")`
+```
+
+`isempty` cannot be used to check for `null` values.
+
+- Use `isempty` if you're working with columns that have a string data type _and_ your column are non-nullable.
+- Use `isnull` if your columns are nullable (or if you're not sure what type of blank values you're dealing with).
+
+### SQL
+
+### Spreadsheets
+
+### Python
+

--- a/docs/users-guide/expressions/isnull.md
+++ b/docs/users-guide/expressions/isnull.md
@@ -36,9 +36,9 @@ In Metabase tables, `null`s are displayed as blank cells. For example, in the Fe
 
 Combine `isnull` with the [`case` expression](./case) to replace "unknown" information with something more descriptive.
 
-If the first row's blank cell is actually a `null`, then `isnull` will return `true`. The `case` statement evaluates `true` to return the first output "Unknown feedback".
+Let's say that the first row's blank cell is actually a `null`, so `isnull` will return `true`. The `case` statement evaluates `true` to return the first output "Unknown feedback".
 
-If the second row's blank cell is actually an empty string (or even an emoji that blends into your table's background), then `isnull` will return `false`, and `case` will return whatever's in the Feedback column as the default output.
+The second row's blank cell doesn't have a `null`, but we're not sure what's in it either---it could be an empty string, or even an emoji that blends into your table's background. No matter what the edge case is, `isnull` will return `false`, and `case` will return whatever's in the Feedback column as the default output.
 
 ## Accepted data types
 

--- a/docs/users-guide/expressions/isnull.md
+++ b/docs/users-guide/expressions/isnull.md
@@ -9,51 +9,51 @@ title: Isnull
 **In Metabase, you must combine `isnull` with another expression that accepts boolean values.** The table below shows you examples of the boolean value that will be passed to your other expression(s).
 
 | Syntax                                                | Example with a true `null` | Example with an empty string |
-| ---------------------------------------------------   | -------------------------- | ---------------------------- |
+| ----------------------------------------------------- | -------------------------- | ---------------------------- |
 | `isnull(value)`                                       | `isnull(null)`             | `isnull("")`                 |
 | Returns `true` if a value is `null`, false otherwise. | `true`                     | `false`                      |
 
 ## How Metabase handles nulls
 
-In Metabase tables, `null`s are displayed as empty or blank cells. For example, in the Feedback column below, the empty cells could contain either:
+In Metabase tables, `null`s are displayed as blank cells. For example, in the Feedback column below, the blank cells could contain either:
 
 - `null`: no feedback was submitted, so the customer's thoughts are "unknown".
 - `""`: feedback was submitted and left intentionally blank, so the customer had "no feedback to give".
 
-| Customer Feedback  | 
-| ------------------ | 
-|                    | 
-| I like your style. | 
+| Customer Feedback  |
+| ------------------ |
 |                    |
+|                    |
+| I like your style. |
 
 ## Replacing null values with another value
 
-| Feedback           | `case(isnull([Feedback]), "Unknown feedback.", [Feedback])` | 
-| ------------------ | ----------------------------------------------------------- | 
-|                    | Unknown feedback.                                           | 
-| I like your style. | I like your style.                                          | 
+| Feedback           | `case(isnull([Feedback]), "Unknown feedback.", [Feedback])` |
+| ------------------ | ----------------------------------------------------------- |
+|                    | Unknown feedback.                                           |
 |                    |                                                             |
+| I like your style. | I like your style.                                          |
 
 Combine `isnull` with the [`case` expression](./case) to replace "unknown" information with something more descriptive.
 
 If the first row's blank cell is actually a `null`, then `isnull` will return `true`. The `case` statement evaluates `true` to return the first output "Unknown feedback".
 
-If the third row's blank cell is actually an empty string (or even an emoji that blends into your table background), then `isnull` will return `false`, and `case` will return whatever's in the Feedback column as the default output.
+If the second row's blank cell is actually an empty string (or even an emoji that blends into your table's background), then `isnull` will return `false`, and `case` will return whatever's in the Feedback column as the default output.
 
 ## Accepted data types
 
-| [Data type][data-types] | Works with `isnull`   |
-| ----------------------- | --------------------- |
-| String                  | ✅                    |
-| Number                  | ✅                    |
-| Timestamp               | ✅                    |
-| Boolean                 | ✅                    |
-| JSON                    | ✅                    |
+| [Data type][data-types] | Works with `isnull` |
+| ----------------------- | ------------------- |
+| String                  | ✅                  |
+| Number                  | ✅                  |
+| Timestamp               | ✅                  |
+| Boolean                 | ✅                  |
+| JSON                    | ✅                  |
 
 ## Limitations
 
 - In Metabase, you must combine `isnull` with another expression that accepts boolean arguments (i.e., `true` or `false`).
-- `isnull` only accepts one value at a time. If you need to deal with blank cells across multiple columns, see [coalesce](./coalesce).
+- `isnull` only accepts one value at a time. If you need to deal with blank cells across multiple columns, see the [coalesce expression](./coalesce).
 - If `isnull` doesn't seem to do anything to your blank cells, you might have empty strings. Try the [`isempty` expression](./isempty) instead.
 
 ## Converting a function into an `isnull` expression
@@ -64,13 +64,13 @@ This section covers functions and formulas that can be used interchangeably with
 - [Spreadsheets](#spreadsheets)
 - [Python](#python)
 
-All examples use the table from the [Replacing null values](#replacing-null-values-with-another-value) example:
+All examples below use the table from the [Replacing null values](#replacing-null-values-with-another-value) example:
 
-| Feedback           | `case(isempty([Feedback]), "Unknown feedback.", [Feedback])` | 
-| ------------------ | ------------------------------------------------------------ | 
-|                    | Unknown feedback.                                            | 
-| I like your style. | I like your style.                                           | 
-|                    |                                                              |
+| Feedback           | `case(isnull([Feedback]), "Unknown feedback.", [Feedback])` |
+| ------------------ | ----------------------------------------------------------- |
+|                    | Unknown feedback.                                           |
+|                    |                                                             |
+| I like your style. | I like your style.                                          |
 
 ### SQL
 
@@ -91,7 +91,7 @@ case(isnull([Feedback]), "Unknown feedback.", [Feedback])
 
 Spreadsheet `#N/A`s are the equivalent of database `null`s (placeholders for "unknown" or "missing" information).
 
-If your [feedback table](#replacing-null-values-with-another-value) is in a spreadsheet where "Feedback" is in column A, then the formula
+Assuming our sample [feedback column](#replacing-null-values-with-another-value) is in a spreadsheet where "Feedback" is in column A, then the formula
 
 ```
 =IF(ISNA(A2), "Unknown feedback.", A2)
@@ -107,7 +107,7 @@ case(isnull([Feedback]), "Unknown feedback.", [Feedback])
 
 [Numpy][numpy] and [pandas][pandas] use `NaN`s or `NA`s instead of `null`s.
 
-Assuming the [feedback table](#replacing-null-values-with-another-value) is in a dataframe column called `df["Feedback"]`:
+Assuming our sample [feedback column](#replacing-null-values-with-another-value) is in a dataframe column called `df["Feedback"]`:
 
 ```
 df["Custom Column"] = np.where(df["Feedback"].isnull(), "Unknown feedback.", df["Feedback"])
@@ -127,6 +127,6 @@ case(isnull([Feedback]), "Unknown feedback.", [Feedback])
 [custom-expressions-doc]: ../expressions
 [custom-expressions-learn]: /learn/questions/custom-expressions
 [data-types]: /learn/databases/data-types-overview#examples-of-data-types
+[notebook-editor-def]: /glossary/notebook_editor
 [numpy]: https://numpy.org/doc/
 [pandas]: https://pandas.pydata.org/pandas-docs/stable/
-


### PR DESCRIPTION
Putting up `isnull` and `isempty` together because they're so similar (and contain references to one another). 

I put in a [suggestion](https://www.notion.so/metabase/Link-to-targeted-custom-expression-docs-when-available-c16afcfa28134e7f83a4078bcd2c1689) to link to these custom expressions pages as they go out.

- Is it easier to organize everything in an expressions directory _before_ we share those links with product (to avoid breaking them in the near future)?
- If so, do we want the path to be `/questions/expressions`, or something else?