### PR TITLE
default dev env for non-BE is `clj -M:run` which misses our bootstrap

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -221,7 +221,7 @@
   ;; clojure -M:run:drivers (include all drivers)
   ;; clojure -M:run:ee (include EE code)
   :run
-  {:main-opts ["-m" "metabase.core"]
+  {:main-opts ["-m" "metabase.bootstrap"]
    :jvm-opts  ["-Dmb.run.mode=dev"
                "-Djava.awt.headless=true"                   ; prevent Java icon from randomly popping up in macOS dock
                "-Dmb.jetty.port=3000"]}


### PR DESCRIPTION
not a huge deal, just small logger stuff set in metabase.bootstrap
