### PR TITLE
Enable Kondo for tests part 3: enable deprecated var linter and fix warnings.

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -2,28 +2,27 @@
  :linters
  {:unresolved-symbol
   {:exclude
-   [schema=
-    re=
-    (metabase.util/prog1 [<>])
-    (metabase.mbql.util/match-one)
-    (metabase.mbql.util/match)
+   [instaparse.core/transform
+    (clojure.core.logic/fresh)
+    (clojure.core.logic/matcha)
+    (clojure.core.logic/run)
+    (clojure.test/is [partial= query= re= schema= sql=])
+    (clojure.tools.macro/macrolet)
+    (metabase.async.streaming-response/streaming-response)
+    (metabase.driver.druid.query-processor-test/druid-query-returning-rows)
     (metabase.mbql.util.match/match)
     (metabase.mbql.util.match/match-one)
     (metabase.mbql.util.match/replace)
     (metabase.mbql.util.match/replace-in)
+    (metabase.mbql.util/match)
+    (metabase.mbql.util/match-one)
     (metabase.mbql.util/replace)
     (metabase.mbql.util/replace-in)
     (metabase.query-processor.middleware.cache-backend.interface/with-cached-results)
     (metabase.util.regex/rx [opt])
-    (metabase.async.streaming-response/streaming-response)
-    (clojure.core.logic/fresh)
-    (clojure.core.logic/matcha)
-    (clojure.core.logic/run)
-    (clojure.test/is [query= sql= partial=])
+    (metabase.util/prog1 [<>])
     (taoensso.nippy/extend-freeze)
-    (taoensso.nippy/extend-thaw)
-    (metabase.driver.druid.query-processor-test/druid-query-returning-rows)
-    (clojure.tools.macro/macrolet)]}
+    (taoensso.nippy/extend-thaw)]}
 
   :refer-all                    {:level   :warning
                                  :exclude [clojure.test]}
@@ -661,9 +660,4 @@
     :private-call      {:level :off}
 
     ;; custom linters
-    :hooks.metabase.test.data/mbql-query-first-arg {:level :error}
-
-    ;; FIXME
-    ;; :unresolved-symbol {:level :off}
-    :deprecated-var {:level :off}
-    }}}}
+    :hooks.metabase.test.data/mbql-query-first-arg {:level :error}}}}}

--- a/enterprise/backend/test/metabase_enterprise/enhancements/api/collection_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/enhancements/api/collection_test.clj
@@ -12,7 +12,7 @@
     (mt/with-non-admin-groups-no-root-collection-for-namespace-perms "snippets"
       (mt/with-temp NativeQuerySnippet [snippet]
         (letfn [(can-see-snippet? []
-                  (let [response (:data ((mt/user->client :rasta) :get "collection/root/items?namespace=snippets"))]
+                  (let [response (:data (mt/user-http-request :rasta :get "collection/root/items?namespace=snippets"))]
                     (boolean (some (fn [a-snippet]
                                      (= (:id snippet) (:id a-snippet)))
                                    response))))]

--- a/enterprise/backend/test/metabase_enterprise/enhancements/api/native_query_snippet_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/enhancements/api/native_query_snippet_test.clj
@@ -57,7 +57,7 @@
           (some
            (fn [a-snippet]
              (= (u/the-id a-snippet) (u/the-id snippet)))
-           ((mt/user->client :rasta) :get "native-query-snippet"))))))))
+           (mt/user-http-request :rasta :get "native-query-snippet"))))))))
 
 (deftest fetch-test
   (testing "GET /api/native-query-snippet/:id"
@@ -65,7 +65,7 @@
       (test-perms
        :read
        (fn [snippet]
-         (let [response ((mt/user->client :rasta) :get (format "native-query-snippet/%d" (u/the-id snippet)))]
+         (let [response (mt/user-http-request :rasta :get (format "native-query-snippet/%d" (u/the-id snippet)))]
            (not= response "You don't have permissions to do that.")))))))
 
 (deftest create-test
@@ -78,7 +78,7 @@
          (let [snippet-name       (mt/random-name)
                snippet-properties (-> snippet (assoc :name snippet-name) (dissoc :id))]
            (try
-             (let [response ((mt/user->client :rasta) :post "native-query-snippet" snippet-properties)]
+             (let [response (mt/user-http-request :rasta :post "native-query-snippet" snippet-properties)]
                (not= response "You don't have permissions to do that."))
              (finally
                (db/delete! NativeQuerySnippet :name snippet-name)))))))))
@@ -89,7 +89,7 @@
       (test-perms
        :write
        (fn [snippet]
-         (let [response ((mt/user->client :rasta) :put (format "native-query-snippet/%d" (u/the-id snippet)) {:name (mt/random-name)})]
+         (let [response (mt/user-http-request :rasta :put (format "native-query-snippet/%d" (u/the-id snippet)) {:name (mt/random-name)})]
            (not= response "You don't have permissions to do that.")))))))
 
 (deftest move-perms-test
@@ -104,7 +104,7 @@
                 (letfn [(has-perms? []
                           ;; make sure the Snippet is back in the original Collection if it was changed
                           (db/update! NativeQuerySnippet (:id snippet) :collection_id (:id source-collection))
-                          (let [response ((mt/user->client :rasta) :put (format "native-query-snippet/%d" (:id snippet))
+                          (let [response (mt/user-http-request :rasta :put (format "native-query-snippet/%d" (:id snippet))
                                           {:collection_id (:id dest-collection)})]
                             (cond
                               (= response "You don't have permissions to do that.")                     false

--- a/enterprise/backend/test/metabase_enterprise/enhancements/integrations/ldap_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/enhancements/integrations/ldap_test.clj
@@ -11,7 +11,7 @@
             [toucan.db :as db]))
 
 (deftest find-test
-  (with-redefs [premium-features/enable-enhancements? (constantly true)]
+  (with-redefs [#_{:clj-kondo/ignore [:deprecated-var]} premium-features/enable-enhancements? (constantly true)]
     (ldap.test/with-ldap-server
       (testing "find by username"
         (is (= {:dn         "cn=John Smith,ou=People,dc=metabase,dc=com"
@@ -91,7 +91,7 @@
                  (ldap/find-user "sally.brown@metabase.com"))))))))
 
 (deftest attribute-sync-test
-  (with-redefs [premium-features/enable-enhancements? (constantly true)]
+  (with-redefs [#_{:clj-kondo/ignore [:deprecated-var]} premium-features/enable-enhancements? (constantly true)]
     (ldap.test/with-ldap-server
       (testing "find by email/username should return other attributes as well"
         (is (= {:dn         "cn=Lucky Pigeon,ou=Birds,dc=metabase,dc=com"
@@ -164,7 +164,7 @@
               (db/delete! User :%lower.email "john.smith@metabase.com"))))))))
 
 (deftest update-attributes-on-login-test
-  (with-redefs [premium-features/enable-enhancements? (constantly true)]
+  (with-redefs [#_{:clj-kondo/ignore [:deprecated-var]} premium-features/enable-enhancements? (constantly true)]
     (ldap.test/with-ldap-server
       (testing "Existing user's attributes are updated on fetch"
         (try
@@ -213,7 +213,7 @@
             (db/delete! User :%lower.email "john.smith@metabase.com")))))))
 
 (deftest fetch-or-create-user-test
-  (with-redefs [premium-features/enable-enhancements? (constantly true)]
+  (with-redefs [#_{:clj-kondo/ignore [:deprecated-var]} premium-features/enable-enhancements? (constantly true)]
     (ldap.test/with-ldap-server
       (testing "a new user is created when they don't already exist"
         (try

--- a/enterprise/backend/test/metabase_enterprise/pulse_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/pulse_test.clj
@@ -7,7 +7,7 @@
   (is (= [{:id "1" :v "a"}
           {:id "2" :v "b"}
           {:id "3" :v "yes"}]
-         (with-redefs [premium-features/enable-enhancements? (constantly true)]
+         (with-redefs [#_{:clj-kondo/ignore [:deprecated-var]} premium-features/enable-enhancements? (constantly true)]
            (pulse/the-parameters
             {:parameters [{:id "1" :v "a"} {:id "2" :v "b"}]}
             {:parameters [{:id "1" :v "no, since it's trumped by the pulse"} {:id "3" :v "yes"}]})))))

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/card_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/card_test.clj
@@ -21,7 +21,7 @@
             (perms/revoke-data-perms! (perms-group/all-users) db)
             (perms/grant-permissions! group (perms/table-segmented-query-path table))
             (perms/grant-collection-readwrite-permissions! group collection)
-            (is (some? ((mt/user->client :rasta) :post 200 "card"
+            (is (some? (mt/user-http-request :rasta :post 200 "card"
                         (assoc (api.card-test/card-with-name-and-query card-name (api.card-test/mbql-count-query db table))
                                :collection_id (u/the-id collection)))))))))
 
@@ -40,6 +40,6 @@
             (perms/grant-permissions! group (perms/table-segmented-query-path table))
             (perms/grant-collection-readwrite-permissions! group collection)
             (is (= "Another Name"
-                   (:name ((mt/user->client :rasta) :put 200 (str "card/" (u/the-id card))
+                   (:name (mt/user-http-request :rasta :put 200 (str "card/" (u/the-id card))
                            {:name          "Another Name"
                             :dataset_query (api.card-test/mbql-count-query db table)}))))))))))

--- a/enterprise/backend/test/metabase_enterprise/search/scoring_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/search/scoring_test.clj
@@ -5,7 +5,7 @@
             [metabase.public-settings.premium-features :as premium-features]
             [metabase.search.scoring :as scoring]))
 
-(deftest verified-score-test
+(deftest ^:parallel verified-score-test
   (let [score #'ee-scoring/verified-score
         item  (fn [id status] {:moderated_status status
                                :id               id
@@ -20,13 +20,13 @@
 (defn- ee-score
   [search-string]
   (fn [item]
-    (with-redefs [premium-features/enable-enhancements? (constantly true)]
+    (with-redefs [#_{:clj-kondo/ignore [:deprecated-var]} premium-features/enable-enhancements? (constantly true)]
       (-> (scoring/score-and-result search-string item) :score))))
 
 (defn- oss-score
   [search-string]
   (fn [item]
-    (with-redefs [premium-features/enable-enhancements? (constantly true)]
+    (with-redefs [#_{:clj-kondo/ignore [:deprecated-var]} premium-features/enable-enhancements? (constantly true)]
       (-> (scoring/score-and-result search-string item) :score))))
 
 (deftest official-collection-tests

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -148,10 +148,10 @@
       (is (= [[nil] [0.0] [0.0] [10.0] [8.0] [5.0] [5.0] [nil] [0.0] [0.0]]
              (calculate-bird-scarcity [:* 1 $count]))))))
 
-(deftest db-timezone-id-test
+(deftest db-default-timezone-test
   (mt/test-driver :bigquery-cloud-sdk
     (is (= "UTC"
-           (tu/db-timezone-id)))))
+           (driver/db-default-timezone :bigquery-cloud-sdk (mt/db))))))
 
 (defn- do-with-temp-obj [name-fmt-str create-args-fn drop-args-fn f]
   (driver/with-driver :bigquery-cloud-sdk

--- a/modules/drivers/druid/test/metabase/driver/druid/client_test.clj
+++ b/modules/drivers/druid/test/metabase/driver/druid/client_test.clj
@@ -6,7 +6,6 @@
             [metabase.query-processor :as qp]
             [metabase.query-processor.context.default :as default]
             [metabase.test :as mt]
-            [metabase.test.util.log :as tu.log]
             [metabase.timeseries-query-processor-test.util :as tqpt]))
 
 (deftest query-cancelation-test
@@ -63,8 +62,7 @@
                          ;; doesn't wrap every exception in an SshdException
                          :tunnel-port    21212
                          :tunnel-user    "bogus"}]
-            (tu.log/suppress-output
-             (driver.u/can-connect-with-details? engine details :throw-exceptions)))
+            (driver.u/can-connect-with-details? engine details :throw-exceptions))
           (catch Throwable e
             (loop [^Throwable e e]
               (or (when (instance? java.net.ConnectException e)

--- a/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
+++ b/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
@@ -177,7 +177,7 @@
 
 (deftest timezone-id-test
   (mt/test-driver :oracle
-    (is (= "UTC"
+    (is (= nil
            (driver/db-default-timezone :oracle (mt/db))))))
 
 (deftest insert-rows-ddl-test

--- a/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
+++ b/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
@@ -26,7 +26,6 @@
             [metabase.test.data.sql :as sql.tx]
             [metabase.test.data.sql.ddl :as ddl]
             [metabase.test.util :as tu]
-            [metabase.test.util.log :as tu.log]
             [metabase.util :as u]
             [metabase.util.honeysql-extensions :as hx]
             [toucan.db :as db]
@@ -169,8 +168,7 @@
                             ;; doesn't wrap every exception in an SshdException
                             :tunnel-port    21212
                             :tunnel-user    "bogus"}]
-               (tu.log/suppress-output
-                (driver.u/can-connect-with-details? engine details :throw-exceptions)))
+               (driver.u/can-connect-with-details? engine details :throw-exceptions))
              (catch Throwable e
                (loop [^Throwable e e]
                  (or (when (instance? java.net.ConnectException e)
@@ -180,7 +178,7 @@
 (deftest timezone-id-test
   (mt/test-driver :oracle
     (is (= "UTC"
-           (tu/db-timezone-id)))))
+           (driver/db-default-timezone :oracle (mt/db))))))
 
 (deftest insert-rows-ddl-test
   (mt/test-driver :oracle

--- a/modules/drivers/presto-jdbc/test/metabase/driver/presto_jdbc_test.clj
+++ b/modules/drivers/presto-jdbc/test/metabase/driver/presto_jdbc_test.clj
@@ -18,7 +18,6 @@
             [metabase.test :as mt]
             [metabase.test.data.presto-jdbc :as data.presto-jdbc]
             [metabase.test.fixtures :as fixtures]
-            [metabase.test.util :as tu]
             [toucan.db :as db])
   (:import java.io.File))
 
@@ -104,7 +103,7 @@
 (deftest db-default-timezone-test
   (mt/test-driver :presto-jdbc
     (is (= "UTC"
-           (tu/db-timezone-id)))))
+           (driver/db-default-timezone :presto-jdbc (mt/db))))))
 
 (deftest template-tag-timezone-test
   (mt/test-driver :presto-jdbc

--- a/modules/drivers/presto-jdbc/test/metabase/driver/presto_jdbc_test.clj
+++ b/modules/drivers/presto-jdbc/test/metabase/driver/presto_jdbc_test.clj
@@ -102,7 +102,7 @@
 
 (deftest db-default-timezone-test
   (mt/test-driver :presto-jdbc
-    (is (= "UTC"
+    (is (= nil
            (driver/db-default-timezone :presto-jdbc (mt/db))))))
 
 (deftest template-tag-timezone-test

--- a/modules/drivers/presto/test/metabase/driver/presto_test.clj
+++ b/modules/drivers/presto/test/metabase/driver/presto_test.clj
@@ -16,8 +16,6 @@
             [metabase.query-processor :as qp]
             [metabase.test :as mt]
             [metabase.test.fixtures :as fixtures]
-            [metabase.test.util :as tu]
-            [metabase.test.util.log :as tu.log]
             [metabase.util :as u]
             [schema.core :as s]
             [toucan.db :as db]))
@@ -169,8 +167,7 @@
                            ;; doesn't wrap every exception in an SshdException
                            :tunnel-port    21212
                            :tunnel-user    "bogus"}]
-              (tu.log/suppress-output
-               (driver.u/can-connect-with-details? engine details :throw-exceptions)))
+              (driver.u/can-connect-with-details? engine details :throw-exceptions))
             (catch Throwable e
               (loop [^Throwable e e]
                 (or (when (instance? java.net.ConnectException e)
@@ -180,7 +177,7 @@
 (deftest db-default-timezone-test
   (mt/test-driver :presto
     (is (= "UTC"
-           (tu/db-timezone-id)))))
+           (driver/db-default-timezone :presto-jdbc (mt/db))))))
 
 (deftest query-cancelation-test
   (mt/test-driver :presto

--- a/modules/drivers/presto/test/metabase/driver/presto_test.clj
+++ b/modules/drivers/presto/test/metabase/driver/presto_test.clj
@@ -176,7 +176,7 @@
 
 (deftest db-default-timezone-test
   (mt/test-driver :presto
-    (is (= "UTC"
+    (is (= nil
            (driver/db-default-timezone :presto-jdbc (mt/db))))))
 
 (deftest query-cancelation-test

--- a/modules/drivers/sqlite/test/metabase/driver/sqlite_test.clj
+++ b/modules/drivers/sqlite/test/metabase/driver/sqlite_test.clj
@@ -12,7 +12,6 @@
             [metabase.sync :as sync]
             [metabase.test :as mt]
             [metabase.test.data :as data]
-            [metabase.test.util :as tu]
             [metabase.util :as u]
             [toucan.db :as db]
             [toucan.hydrate :refer [hydrate]]))
@@ -20,7 +19,7 @@
 (deftest timezone-id-test
   (mt/test-driver :sqlite
     (is (= "UTC"
-           (tu/db-timezone-id)))))
+           (driver/db-default-timezone :sqlite (mt/db))))))
 
 (deftest filter-by-date-test
   (testing "Make sure filtering against a LocalDate works correctly in SQLite"

--- a/modules/drivers/sqlite/test/metabase/driver/sqlite_test.clj
+++ b/modules/drivers/sqlite/test/metabase/driver/sqlite_test.clj
@@ -18,7 +18,7 @@
 
 (deftest timezone-id-test
   (mt/test-driver :sqlite
-    (is (= "UTC"
+    (is (= nil
            (driver/db-default-timezone :sqlite (mt/db))))))
 
 (deftest filter-by-date-test

--- a/modules/drivers/vertica/test/metabase/driver/vertica_test.clj
+++ b/modules/drivers/vertica/test/metabase/driver/vertica_test.clj
@@ -7,7 +7,7 @@
 
 (deftest db-timezone-test
   (mt/test-driver :vertica
-    (is (= "UTC"
+    (is (= nil
            (driver/db-default-timezone :vertica (mt/db))))))
 
 (deftest additional-connection-string-options-test

--- a/modules/drivers/vertica/test/metabase/driver/vertica_test.clj
+++ b/modules/drivers/vertica/test/metabase/driver/vertica_test.clj
@@ -1,13 +1,14 @@
 (ns metabase.driver.vertica-test
   (:require [clojure.test :refer :all]
+            [metabase.driver :as driver]
             [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
             [metabase.query-processor :as qp]
-            [metabase.test :as mt]
-            [metabase.test.util :as tu]))
+            [metabase.test :as mt]))
 
 (deftest db-timezone-test
   (mt/test-driver :vertica
-    (is (= "UTC" (tu/db-timezone-id)))))
+    (is (= "UTC"
+           (driver/db-default-timezone :vertica (mt/db))))))
 
 (deftest additional-connection-string-options-test
   (mt/test-driver :vertica

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -631,12 +631,26 @@
 (defmulti db-default-timezone
   "Return the *system* timezone ID name of this database, i.e. the timezone that local dates/times/datetimes are
   considered to be in by default. Ideally, this method should return a timezone ID like `America/Los_Angeles`, but an
-  offset formatted like `-08:00` is acceptable in cases where the actual ID cannot be provided."
+  offset formatted like `-08:00` is acceptable in cases where the actual ID cannot be provided.
+
+  This is currently used only when syncing the
+  Database (see [[metabase.sync.sync-metadata.sync-timezone/sync-timezone!]]) -- the result of this method is stored
+  in the `timezone` column of Database.
+
+  *In theory* this method should probably not return `nil`, since every Database presumably assumes some timezone for
+  LocalDate(Time)s types, but *in practice* implementations of this method return `nil` for some drivers. For example
+  the default implementation for `:sql-jdbc` returns `nil` unless the driver in question
+  implements [[metabase.driver.sql-jdbc.sync/db-default-timezone]]; the `:h2` driver does not for example. Why is
+  this? Who knows, but it's something you should keep in mind.
+
+  TODO FIXME (cam) -- I think we need to fix this for drivers that return `nil`."
   {:added "0.34.0", :arglists '(^java.lang.String [driver database])}
   dispatch-on-initialized-driver
   :hierarchy #'hierarchy)
 
-(defmethod db-default-timezone ::driver [_ _] nil)
+(defmethod db-default-timezone ::driver
+  [_driver _database]
+  nil)
 
 ;; TIMEZONE FIXME — remove this method entirely
 (defmulti current-db-time
@@ -644,7 +658,7 @@
   `metabase.driver.common/current-db-time` to implement this. This should return a Joda-Time `DateTime`.
 
   deprecated — the only thing this method is ultimately used for is to determine the db's system timezone.
-  `db-default-timezone` has been introduced as an intended replacement for this method; implement it instead. this
+  [[db-default-timezone]] has been introduced as an intended replacement for this method; implement it instead. this
   method will be removed in a future release."
   {:deprecated "0.34.0", :arglists '(^org.joda.time.DateTime [driver database])}
   dispatch-on-initialized-driver

--- a/src/metabase/driver/common.clj
+++ b/src/metabase/driver/common.clj
@@ -260,7 +260,7 @@
       (time/to-time-zone (time.coerce/from-date parsed-date) joda-tz))))
 
 (defn ^:deprecated create-db-time-formatters
-  "Creates date formatters from `DATE-FORMAT-STR` that will preserve the offset/timezone information. Will return a
+  "Creates date formatters from `date-format-str` that will preserve the offset/timezone information. Will return a
   JodaTime date formatter and a core Java SimpleDateFormat. Results of this are threadsafe and can safely be def'd."
   [date-format-str]
   [(.withOffsetParsed ^DateTimeFormatter (time.format/formatter date-format-str))
@@ -275,22 +275,22 @@
         (parse formatter time-str))))
 
 (defmulti ^:deprecated current-db-time-native-query
-  "Return a native query that will fetch the current time (presumably as a string) used by the `current-db-time`
+  "Return a native query that will fetch the current time (presumably as a string) used by the [[current-db-time]]
   implementation below.
 
-  DEPRECATED — `metabase.driver/current-db-time`, the method this function provides an implementation for, is itself
-  deprecated. Implement `metabase.driver/db-default-timezone` instead directly."
+  DEPRECATED — [[metabase.driver/current-db-time]], the method this function provides an implementation for, is itself
+  deprecated. Implement [[metabase.driver/db-default-timezone]] instead directly."
   {:arglists '([driver])}
   driver/dispatch-on-initialized-driver
   :hierarchy #'driver/hierarchy)
 
 (defmulti ^:deprecated current-db-time-date-formatters
-  "Return JODA time date formatters to parse the current time returned by `current-db-time-native-query`. Used by
-  `current-db-time` implementation below. You can use `create-db-time-formatters` provided by this namespace to create
+  "Return JODA time date formatters to parse the current time returned by [[current-db-time-native-query`]] Used by
+  `current-db-time` implementation below. You can use [[create-db-time-formatters]] provided by this namespace to create
   formatters for a date format string.
 
-  DEPRECATED — `metabase.driver/current-db-time`, the method this function provides an implementation for, is itself
-  deprecated. Implement `metabase.driver/db-default-timezone` instead directly."
+  DEPRECATED — [[metabase.driver/current-db-time]], the method this function provides an implementation for, is itself
+  deprecated. Implement [[metabase.driver/db-default-timezone]] instead directly."
   {:arglists '([driver])}
   driver/dispatch-on-initialized-driver
   :hierarchy #'driver/hierarchy)
@@ -309,8 +309,8 @@
     (let [native-query    (current-db-time-native-query driver)
           date-formatters (current-db-time-date-formatters driver)
           time-str        (try
-                            ;; need to initialize the store since we're calling `execute-reducible-query` directly
-                            ;; instead of going thru normal QP pipeline
+                            ;; need to initialize the store since we're calling [[driver/execute-reducible-query]]
+                            ;; directly instead of going thru normal QP pipeline
                             (qp.store/with-store
                               (qp.store/fetch-and-store-database! (u/the-id database))
                               (let [query {:database (u/the-id database), :native {:query native-query}}

--- a/src/metabase/driver/sql_jdbc.clj
+++ b/src/metabase/driver/sql_jdbc.clj
@@ -48,6 +48,7 @@
 
 (defmethod driver/db-default-timezone :sql-jdbc
   [driver database]
+  ;; if the driver has a non-default implementation of [[sql-jdbc.sync/db-default-timezone]], use that.
   (when (not= (get-method sql-jdbc.sync/db-default-timezone driver)
               (get-method sql-jdbc.sync/db-default-timezone :sql-jdbc))
     (sql-jdbc.sync/db-default-timezone driver (sql-jdbc.conn/db->pooled-connection-spec database))))

--- a/src/metabase/driver/sql_jdbc/execute.clj
+++ b/src/metabase/driver/sql_jdbc/execute.clj
@@ -39,12 +39,12 @@
 
   1. Calls util fn `datasource` to get a c3p0 connection pool DataSource
   2. Calls `.getConnection()` the normal way
-  3. Executes `set-timezone-sql` if implemented by the driver.
+  3. Executes [[set-timezone-sql]] if implemented by the driver.
 
   `timezone-id` will be `nil` if a `report-timezone` Setting is not currently set; don't change the session time zone
   if this is the case.
 
-  For drivers that support session timezones, the default implementation and `set-timezone-sql` should be considered
+  For drivers that support session timezones, the default implementation and [[set-timezone-sql]] should be considered
   deprecated in favor of implementing `connection-with-timezone` directly. This way you can set the session timezone
   in the most efficient manner, e.g. only setting it if needed (if there's an easy way for you to check this), or by
   setting it as a parameter of the connection itself (the default connection pools are automatically flushed when

--- a/src/metabase/driver/sql_jdbc/execute/old_impl.clj
+++ b/src/metabase/driver/sql_jdbc/execute/old_impl.clj
@@ -15,8 +15,9 @@
 
     \"SET @@session.time_zone = %s;\"
 
-  This method is only called for drivers using the default implementatation of `connection-with-timezone`; it should
-  be considered deprecated in favor of implementing `connection-with-timezone` directly."
+  This method is only called for drivers using the default implementation
+  of [[metabase.driver.sql-jdbc.execute/connection-with-timezone]]; it should be considered deprecated in favor of
+  implementing `connection-with-timezone` directly."
   {:deprecated "0.35.0", :arglists '([driver])}
   driver/dispatch-on-initialized-driver
   :hierarchy #'driver/hierarchy)

--- a/src/metabase/driver/sql_jdbc/sync/interface.clj
+++ b/src/metabase/driver/sql_jdbc/sync/interface.clj
@@ -91,9 +91,9 @@
   :hierarchy #'driver/hierarchy)
 
 (defmulti db-default-timezone
-  "JDBC-specific version of of `metabase.driver/db-default-timezone` that takes a `clojure.java.jdbc` connection spec
-  rather than a set of DB details. If an implementation of this method is provided, it will be used automatically in
-  the default `:sql-jdbc` implementation of `metabase.driver/db-default-timezone`.
+  "JDBC-specific version of of [[metabase.driver/db-default-timezone]] that takes a [[clojure.java.jdbc]] connection
+  spec rather than a set of DB details. If an implementation of this method is provided, it will be used automatically
+  in the default `:sql-jdbc` implementation of [[metabase.driver/db-default-timezone]].
 
   This exists so we can reuse this code with the application database without having to create a new Connection pool
   for the application DB."
@@ -102,12 +102,12 @@
   :hierarchy #'driver/hierarchy)
 
 (defmethod db-default-timezone :sql-jdbc
-  [_ _]
+  [_driver _jdbc-spec]
   nil)
 
 (defmulti describe-nested-field-columns
-  "Return information about the nestable columns in a `table`. Required for drivers that support `:nested-field-columns`. Results
-  should match the [[metabase.sync.interface/NestedFCMetadata]] schema."
+  "Return information about the nestable columns in a `table`. Required for drivers that support
+  `:nested-field-columns`. Results should match the [[metabase.sync.interface/NestedFCMetadata]] schema."
   {:added "0.43.0", :arglists '([driver database table])}
   driver/dispatch-on-initialized-driver
   :hierarchy #'driver/hierarchy)

--- a/src/metabase/query_processor/util.clj
+++ b/src/metabase/query_processor/util.clj
@@ -11,12 +11,6 @@
 
 ;; TODO - I think most of the functions in this namespace that we don't remove could be moved to [[metabase.mbql.util]]
 
-(defn ^:deprecated mbql-query? ;; not really needed anymore since we don't need to normalize tokens
-  "Is the given query an MBQL query?
-   DEPRECATED: just look at `:type` directly since it is guaranteed to be normalized?"
-  [query]
-  (= :query (keyword (:type query))))
-
 (defn query-without-aggregations-or-limits?
   "Is the given query an MBQL query without a `:limit`, `:aggregation`, or `:page` clause?"
   [{{aggregations :aggregation, :keys [limit page]} :query}]

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -268,7 +268,7 @@
 
                       Dashboard     [{dashboard-id :id} {:name "Test Dashboard"}]
                       Card          [{card-id :id
-                                      :as     card}         {:name "Dashboard Test Card"}]
+                                      :as     card}     {:name "Dashboard Test Card"}]
                       DashboardCard [dashcard           {:dashboard_id       dashboard-id
                                                          :card_id            card-id
                                                          :parameter_mappings [{:card_id      1

--- a/test/metabase/api/dataset_test.clj
+++ b/test/metabase/api/dataset_test.clj
@@ -264,9 +264,8 @@
       (is (schema= {:status   (s/eq "failed")
                     :error    (s/eq "You do not have permissions to run this query.")
                     s/Keyword s/Any}
-                   (mt/suppress-output
-                     (mt/user-http-request :rasta :post "dataset"
-                                           (mt/mbql-query venues {:limit 1}))))))))
+                   (mt/user-http-request :rasta :post "dataset"
+                                         (mt/mbql-query venues {:limit 1})))))))
 
 (deftest compile-test
   (testing "POST /api/dataset/native"
@@ -291,17 +290,16 @@
                                         :filter [:= $date "2015-11-13"]})))))
 
       (testing "\nshould require that the user have ad-hoc native perms for the DB"
-        (mt/suppress-output
-          (mt/with-temp-copy-of-db
-            ;; Give All Users permissions to see the `venues` Table, but not ad-hoc native perms
-            (perms/revoke-data-perms! (perms-group/all-users) (mt/id))
-            (perms/grant-permissions! (perms-group/all-users) (mt/id) "PUBLIC" (mt/id :venues))
-            (is (schema= {:permissions-error? (s/eq true)
-                          :message            (s/eq "You do not have permissions to run this query.")
-                          s/Any               s/Any}
-                         (mt/user-http-request :rasta :post "dataset/native"
-                                               (mt/mbql-query venues
-                                                 {:fields [$id $name]}))))))))))
+        (mt/with-temp-copy-of-db
+          ;; Give All Users permissions to see the `venues` Table, but not ad-hoc native perms
+          (perms/revoke-data-perms! (perms-group/all-users) (mt/id))
+          (perms/grant-permissions! (perms-group/all-users) (mt/id) "PUBLIC" (mt/id :venues))
+          (is (schema= {:permissions-error? (s/eq true)
+                        :message            (s/eq "You do not have permissions to run this query.")
+                        s/Any               s/Any}
+                       (mt/user-http-request :rasta :post "dataset/native"
+                                             (mt/mbql-query venues
+                                               {:fields [$id $name]})))))))))
 
 (deftest report-timezone-test
   (mt/test-driver :postgres

--- a/test/metabase/api/embed_test.clj
+++ b/test/metabase/api/embed_test.clj
@@ -243,6 +243,7 @@
         (let [expected-status (response-format->status-code response-format)]
           (testing "it should be possible to run a Card successfully if you jump through the right hoops..."
             (with-temp-card [card {:enable_embedding true}]
+              #_{:clj-kondo/ignore [:deprecated-var]}
               (test-query-results
                response-format
                (client/client :get expected-status (card-query-url card response-format)
@@ -295,6 +296,7 @@
                  (client/client :get 400 (card-query-url card response-format)))))
 
         (testing "if `:locked` param is present, request should succeed"
+          #_{:clj-kondo/ignore [:deprecated-var]}
           (test-query-results
            response-format
            (client/client :get (response-format->status-code response-format)
@@ -328,6 +330,7 @@
                  (client/client :get 400 (str (card-query-url card response-format {:params {:venue_id 100}}) "?venue_id=200")))))
 
         (testing "If an `:enabled` param is present in the JWT, that's ok"
+          #_{:clj-kondo/ignore [:deprecated-var]}
           (test-query-results
            response-format
            (client/client :get (response-format->status-code response-format)
@@ -335,6 +338,7 @@
                           {:request-options request-options})))
 
         (testing "If an `:enabled` param is present in URL params but *not* the JWT, that's ok"
+          #_{:clj-kondo/ignore [:deprecated-var]}
           (test-query-results
            response-format
            (client/client :get (response-format->status-code response-format)
@@ -450,6 +454,7 @@
   (testing "it should be possible to run a Card successfully if you jump through the right hoops..."
     (with-embedding-enabled-and-new-secret-key
       (with-temp-dashcard [dashcard {:dash {:enable_embedding true}}]
+        #_{:clj-kondo/ignore [:deprecated-var]}
         (test-query-results (client/client :get 202 (dashcard-url dashcard)))))))
 
 (deftest downloading-csv-json-xlsx-results-from-the-dashcard-endpoint-shouldn-t-be-subject-to-the-default-query-constraints

--- a/test/metabase/api/field_test.clj
+++ b/test/metabase/api/field_test.clj
@@ -280,22 +280,21 @@
     (testing "Field values should be created when not present"
       ;; this will print an error message because it will try to fetch the FieldValues, but the Field doesn't
       ;; exist; we can ignore that
-      (mt/suppress-output
-       (mt/with-temp Field [{field-id :id} list-field]
-         (is (= {:values [], :field_id true, :has_more_values false}
-                (mt/boolean-ids-and-timestamps
-                 (mt/user-http-request :crowberto :get 200 (format "field/%d/values" field-id)))))
+      (mt/with-temp Field [{field-id :id} list-field]
+        (is (= {:values [], :field_id true, :has_more_values false}
+               (mt/boolean-ids-and-timestamps
+                (mt/user-http-request :crowberto :get 200 (format "field/%d/values" field-id)))))
 
-         (is (= {:status "success"}
-                (mt/user-http-request :crowberto :post 200 (format "field/%d/values" field-id)
-                 {:values [[1 "$"] [2 "$$"] [3 "$$$"] [4 "$$$$"]]})))
+        (is (= {:status "success"}
+               (mt/user-http-request :crowberto :post 200 (format "field/%d/values" field-id)
+                                     {:values [[1 "$"] [2 "$$"] [3 "$$$"] [4 "$$$$"]]})))
 
-         (is (= {:values [1 2 3 4], :human_readable_values ["$" "$$" "$$$" "$$$$"], :has_more_values false}
-                (into {} (db/select-one [FieldValues :values :human_readable_values, :has_more_values] :field_id field-id))))
+        (is (= {:values [1 2 3 4], :human_readable_values ["$" "$$" "$$$" "$$$$"], :has_more_values false}
+               (into {} (db/select-one [FieldValues :values :human_readable_values, :has_more_values] :field_id field-id))))
 
-         (is (= {:values [[1 "$"] [2 "$$"] [3 "$$$"] [4 "$$$$"]], :field_id true, :has_more_values false}
-                (mt/boolean-ids-and-timestamps
-                 (mt/user-http-request :crowberto :get 200 (format "field/%d/values" field-id))))))))))
+        (is (= {:values [[1 "$"] [2 "$$"] [3 "$$$"] [4 "$$$$"]], :field_id true, :has_more_values false}
+               (mt/boolean-ids-and-timestamps
+                (mt/user-http-request :crowberto :get 200 (format "field/%d/values" field-id)))))))))
 
 (deftest remove-field-values-test
   (testing "POST /api/field/:id/values"

--- a/test/metabase/api/native_query_snippet_test.clj
+++ b/test/metabase/api/native_query_snippet_test.clj
@@ -31,7 +31,7 @@
       (testing "list returns all snippets. Should work for all users"
         (doseq [test-user [:crowberto :rasta]]
           (testing (format "test user = %s" test-user)
-            (let [snippets-from-api (->> ((mt/user->client test-user) :get 200 (snippet-url))
+            (let [snippets-from-api (->> (mt/user-http-request test-user :get 200 (snippet-url))
                                          (map #(select-keys % test-snippet-fields))
                                          set)]
               (is (contains? snippets-from-api (select-keys snippet-1 test-snippet-fields)))
@@ -44,7 +44,7 @@
       (testing "all users should be able to see all snippets in CE"
         (doseq [test-user [:crowberto :rasta]]
           (testing (format "with test user %s" test-user)
-            (let [snippet-from-api ((mt/user->client test-user) :get 200 (snippet-url (:id snippet)))]
+            (let [snippet-from-api (mt/user-http-request test-user :get 200 (snippet-url (:id snippet)))]
               (is (= (select-keys snippet test-snippet-fields)
                      (select-keys snippet-from-api test-snippet-fields))))))))))
 
@@ -52,17 +52,17 @@
   (testing "POST /api/native-query-snippet"
     (testing "new snippet field validation"
       (is (= {:errors {:content "value must be a string."}}
-             ((mt/user->client :rasta) :post 400 (snippet-url) {})))
+             (mt/user-http-request :rasta :post 400 (snippet-url) {})))
 
-      (is (name-schema-error? ((mt/user->client :rasta)
+      (is (name-schema-error? (mt/user-http-request :rasta
                                :post 400 (snippet-url)
                                {:content "NULL"})))
 
-      (is (name-schema-error? ((mt/user->client :rasta) :post 400 (snippet-url)
+      (is (name-schema-error? (mt/user-http-request :rasta :post 400 (snippet-url)
                                {:content "NULL"
                                 :name    " starts with a space"})))
 
-      (is (name-schema-error? ((mt/user->client :rasta) :post 400 (snippet-url)
+      (is (name-schema-error? (mt/user-http-request :rasta :post 400 (snippet-url)
                                {:content "NULL"
                                 :name    "contains a } character"})))))
 
@@ -72,7 +72,7 @@
       (testing message
         (try
           (let [snippet-input    {:name "test-snippet", :description "Just null", :content "NULL"}
-                snippet-from-api ((mt/user->client user) :post 200 (snippet-url) snippet-input)]
+                snippet-from-api (mt/user-http-request user :post 200 (snippet-url) snippet-input)]
             (is (schema= {:id          su/IntGreaterThanZero
                           :name        (s/eq "test-snippet")
                           :description (s/eq "Just null")
@@ -90,7 +90,7 @@
     (try
       (mt/with-temp NativeQuerySnippet [_ {:name "test-snippet-1", :content "1"}]
         (is (= "A snippet with that name already exists. Please pick a different name."
-               ((mt/user->client :crowberto) :post 400 (snippet-url) {:name "test-snippet-1", :content "2"})))
+               (mt/user-http-request :crowberto :post 400 (snippet-url) {:name "test-snippet-1", :content "2"})))
         (is (= 1
                (db/count NativeQuerySnippet :name "test-snippet-1"))))
       (finally
@@ -98,7 +98,7 @@
 
   (testing "Shouldn't be able to specify non-default creator_id"
     (try
-      (let [snippet ((mt/user->client :crowberto) :post 200 (snippet-url)
+      (let [snippet (mt/user-http-request :crowberto :post 200 (snippet-url)
                      {:name "test-snippet", :content "1", :creator_id (mt/user->id :rasta)})]
         (is (= (mt/user->id :crowberto)
                (:creator_id snippet))))
@@ -110,7 +110,7 @@
     (testing "\nShould be able to create a Snippet in a Collection"
       (letfn [(create! [expected-status-code collection-id]
                 (try
-                  (let [response ((mt/user->client :rasta) :post expected-status-code (snippet-url)
+                  (let [response (mt/user-http-request :rasta :post expected-status-code (snippet-url)
                                   {:name "test-snippet", :description "Just null", :content "NULL", :collection_id collection-id})]
                     {:response response
                      :db       (some->> (:id response) (db/select-one NativeQuerySnippet :id))})
@@ -146,7 +146,7 @@
                                 "non-admin user should be able to update" :rasta}]
           (testing message
             (let [updated-desc    "Updated description."
-                  updated-snippet ((mt/user->client user)
+                  updated-snippet (mt/user-http-request user
                                    :put 200 (snippet-url (:id snippet))
                                    {:description updated-desc})]
               (is (= updated-desc (:description updated-snippet)))))))
@@ -155,18 +155,18 @@
         (mt/with-temp* [NativeQuerySnippet [_         {:name "test-snippet-1", :content "1"}]
                         NativeQuerySnippet [snippet-2 {:name "test-snippet-2", :content "2"}]]
           (is (= "A snippet with that name already exists. Please pick a different name."
-                 ((mt/user->client :crowberto) :put 400 (snippet-url (:id snippet-2)) {:name "test-snippet-1"})))
+                 (mt/user-http-request :crowberto :put 400 (snippet-url (:id snippet-2)) {:name "test-snippet-1"})))
           (is (= 1
                  (db/count NativeQuerySnippet :name "test-snippet-1")))
 
           (testing "Passing in the existing name (no change) shouldn't cause an error"
             (is (= {:id (:id snippet-2), :name "test-snippet-2"}
-                   (select-keys ((mt/user->client :crowberto) :put 200 (snippet-url (:id snippet-2)) {:name "test-snippet-2"})
+                   (select-keys (mt/user-http-request :crowberto :put 200 (snippet-url (:id snippet-2)) {:name "test-snippet-2"})
                                 [:id :name]))))))
 
       (testing "Shouldn't be able to change creator_id"
         (mt/with-temp NativeQuerySnippet [snippet {:name "test-snippet", :content "1", :creator_id (mt/user->id :lucky)}]
-          ((mt/user->client :crowberto) :put 200 (snippet-url (:id snippet)) {:creator_id (mt/user->id :rasta)})
+          (mt/user-http-request :crowberto :put 200 (snippet-url (:id snippet)) {:creator_id (mt/user->id :rasta)})
           (is (= (mt/user->id :lucky)
                  (db/select-one-field :creator_id NativeQuerySnippet :id (:id snippet)))))))))
 
@@ -183,7 +183,7 @@
               (tt/with-temp NativeQuerySnippet [{snippet-id :id} {:collection_id (:id source)}]
                 (testing "\nresponse"
                   (is (= {:collection_id (:id dest)}
-                         (-> ((mt/user->client :rasta) :put 200 (snippet-url snippet-id) {:collection_id (:id dest)})
+                         (-> (mt/user-http-request :rasta :put 200 (snippet-url snippet-id) {:collection_id (:id dest)})
                              (select-keys [:collection_id :errors])))))
                 (testing "\nvalue in app DB"
                   (is (= (:id dest)
@@ -195,9 +195,9 @@
           (is (= {:errors               {:collection_id "A NativeQuerySnippet can only go in Collections in the :snippets namespace."}
                   :allowed-namespaces   ["snippets"]
                   :collection-namespace nil}
-                 ((mt/user->client :rasta) :put 400 (snippet-url snippet-id) {:collection_id collection-id})))))
+                 (mt/user-http-request :rasta :put 400 (snippet-url snippet-id) {:collection_id collection-id})))))
 
       (testing "\nShould throw an error if Collection does not exist"
         (tt/with-temp NativeQuerySnippet [{snippet-id :id}]
           (is (= {:errors {:collection_id "Collection does not exist."}}
-                 ((mt/user->client :rasta) :put 404 (snippet-url snippet-id) {:collection_id Integer/MAX_VALUE}))))))))
+                 (mt/user-http-request :rasta :put 404 (snippet-url snippet-id) {:collection_id Integer/MAX_VALUE}))))))))

--- a/test/metabase/api/preview_embed_test.clj
+++ b/test/metabase/api/preview_embed_test.clj
@@ -71,6 +71,7 @@
     (embed-test/with-embedding-enabled-and-new-secret-key
       (embed-test/with-temp-card [card]
         (testing "It should be possible to run a Card successfully if you jump through the right hoops..."
+          #_{:clj-kondo/ignore [:deprecated-var]}
           (embed-test/test-query-results
            (mt/user-http-request :crowberto :get 202 (card-query-url card))))
 
@@ -97,6 +98,7 @@
                    (mt/user-http-request :crowberto :get 400 (card-query-url card {:_embedding_params {:venue_id "locked"}})))))
 
           (testing "if `:locked` param is supplied, request should succeed"
+            #_{:clj-kondo/ignore [:deprecated-var]}
             (embed-test/test-query-results
              (mt/user-http-request :crowberto :get 202 (card-query-url card {:_embedding_params {:venue_id "locked"}
                                                                              :params            {:venue_id 100}}))))
@@ -134,10 +136,12 @@
                                                                   "?venue_id=200")))))
 
           (testing "If an `:enabled` param is present in the JWT, that's ok"
+            #_{:clj-kondo/ignore [:deprecated-var]}
             (embed-test/test-query-results
              (mt/user-http-request :crowberto :get 202 (card-query-url card {:_embedding_params {:venue_id "enabled"}
                                                                              :params            {:venue_id "enabled"}}))))
           (testing "If an `:enabled` param is present in URL params but *not* the JWT, that's ok"
+            #_{:clj-kondo/ignore [:deprecated-var]}
             (embed-test/test-query-results
              (mt/user-http-request :crowberto :get 202 (str (card-query-url card {:_embedding_params {:venue_id "enabled"}})
                                                             "?venue_id=200")))))))))
@@ -223,6 +227,7 @@
     (embed-test/with-embedding-enabled-and-new-secret-key
       (embed-test/with-temp-dashcard [dashcard]
         (testing "It should be possible to run a Card successfully if you jump through the right hoops..."
+          #_{:clj-kondo/ignore [:deprecated-var]}
           (embed-test/test-query-results
            (mt/user-http-request :crowberto :get 202 (dashcard-url dashcard))))
 

--- a/test/metabase/api/table_test.clj
+++ b/test/metabase/api/table_test.clj
@@ -13,8 +13,6 @@
             [metabase.models.table :as table]
             [metabase.server.middleware.util :as mw.util]
             [metabase.test :as mt]
-            [metabase.test.mock.util :as mock.util]
-            [metabase.test.util :as tu]
             [metabase.timeseries-query-processor-test.util :as tqpt]
             [metabase.util :as u]
             [toucan.db :as db]))
@@ -502,42 +500,42 @@
                   :dimension_options (default-dimension-options)
                   :fields            (map (comp #(merge (default-card-field-for-venues card-virtual-table-id) %)
                                                 with-field-literal-id)
-                                          [{:name         "NAME"
-                                            :display_name "NAME"
-                                            :base_type    "type/Text"
-                                            :effective_type "type/Text"
-                                            :semantic_type "type/Name"
-                                            :fingerprint  (:name mock.util/venue-fingerprints)
-                                            :field_ref    ["field" "NAME" {:base-type "type/Text"}]}
-                                           {:name         "ID"
-                                            :display_name "ID"
-                                            :base_type    "type/BigInteger"
-                                            :effective_type "type/BigInteger"
-                                            :semantic_type nil
-                                            :fingerprint  (:id mock.util/venue-fingerprints)
-                                            :field_ref    ["field" "ID" {:base-type "type/BigInteger"}]}
-                                           (with-numeric-dimension-options
-                                             {:name         "PRICE"
-                                              :display_name "PRICE"
-                                              :base_type    "type/Integer"
-                                              :effective_type "type/Integer"
-                                              :semantic_type nil
-                                              :fingerprint  (:price mock.util/venue-fingerprints)
-                                              :field_ref    ["field" "PRICE" {:base-type "type/Integer"}]})
-                                           (with-coordinate-dimension-options
-                                             {:name         "LATITUDE"
-                                              :display_name "LATITUDE"
-                                              :base_type    "type/Float"
-                                              :effective_type "type/Float"
-                                              :semantic_type "type/Latitude"
-                                              :fingerprint  (:latitude mock.util/venue-fingerprints)
-                                              :field_ref    ["field" "LATITUDE" {:base-type "type/Float"}]})])})
+                                          (let [id->fingerprint   (db/select-id->field :fingerprint Field :table_id (mt/id :venues))
+                                                name->fingerprint (comp id->fingerprint (partial mt/id :venues))]
+                                            [{:name           "NAME"
+                                              :display_name   "NAME"
+                                              :base_type      "type/Text"
+                                              :effective_type "type/Text"
+                                              :semantic_type  "type/Name"
+                                              :fingerprint    (name->fingerprint :name)
+                                              :field_ref      ["field" "NAME" {:base-type "type/Text"}]}
+                                             {:name           "ID"
+                                              :display_name   "ID"
+                                              :base_type      "type/BigInteger"
+                                              :effective_type "type/BigInteger"
+                                              :semantic_type  nil
+                                              :fingerprint    (name->fingerprint :id)
+                                              :field_ref      ["field" "ID" {:base-type "type/BigInteger"}]}
+                                             (with-numeric-dimension-options
+                                               {:name           "PRICE"
+                                                :display_name   "PRICE"
+                                                :base_type      "type/Integer"
+                                                :effective_type "type/Integer"
+                                                :semantic_type  nil
+                                                :fingerprint    (name->fingerprint :price)
+                                                :field_ref      ["field" "PRICE" {:base-type "type/Integer"}]})
+                                             (with-coordinate-dimension-options
+                                               {:name           "LATITUDE"
+                                                :display_name   "LATITUDE"
+                                                :base_type      "type/Float"
+                                                :effective_type "type/Float"
+                                                :semantic_type  "type/Latitude"
+                                                :fingerprint    (name->fingerprint :latitude)
+                                                :field_ref      ["field" "LATITUDE" {:base-type "type/Float"}]})]))})
                (->> card
                     u/the-id
                     (format "table/card__%d/query_metadata")
-                    (mt/user-http-request :crowberto :get 200)
-                    (tu/round-fingerprint-cols [:fields])
-                    (mt/round-all-decimals 2))))))))
+                    (mt/user-http-request :crowberto :get 200))))))))
 
 (deftest include-date-dimensions-in-nested-query-test
   (testing "GET /api/table/:id/query_metadata"

--- a/test/metabase/async/streaming_response_test.clj
+++ b/test/metabase/async/streaming_response_test.clj
@@ -66,8 +66,7 @@
                   (when-let [chan @start-execution-chan]
                     (a/>!! chan ::started))
                   (Thread/sleep sleep)
-                  (mt/suppress-output
-                    (respond {:cols [{:name "Sleep", :base_type :type/Integer}]} [[sleep]]))
+                  (respond {:cols [{:name "Sleep", :base_type :type/Integer}]} [[sleep]])
                   (catch InterruptedException e
                     (reset! canceled? true)
                     (throw e))))]
@@ -85,7 +84,7 @@
     (with-test-driver-db
       (is (= [[10]]
              (mt/rows
-               ((mt/user->client :lucky)
+               (mt/user-http-request :lucky
                 :post 202 "dataset"
                 {:database (mt/id)
                  :type     "native"

--- a/test/metabase/driver/h2_test.clj
+++ b/test/metabase/driver/h2_test.clj
@@ -10,7 +10,6 @@
             [metabase.models :refer [Database]]
             [metabase.query-processor :as qp]
             [metabase.test :as mt]
-            [metabase.test.util :as tu]
             [metabase.util :as u]
             [metabase.util.honeysql-extensions :as hx]))
 
@@ -58,10 +57,14 @@
                   (and (re-matches #"Database .+ not found .+" (.getMessage e))
                        ::exception-thrown)))))))
 
-(deftest db-timezone-id-test
+(deftest db-default-timezone-test
   (mt/test-driver :h2
-    (is (= "UTC"
-           (tu/db-timezone-id)))))
+    ;; [[driver/db-default-timezone]] returns `nil`. This *probably* doesn't make sense. We should go in an fix it, by
+    ;; implementing [[metabase.driver.sql-jdbc.sync.interface/db-default-timezone]], which is what the default
+    ;; `:sql-jdbc` implementation of `db-default-timezone` hands off to. In the mean time, here is a placeholder test we
+    ;; can update when things are fixed.
+    (is (= nil
+           (driver/db-default-timezone :h2 (mt/db))))))
 
 (deftest disallow-admin-accounts-test
   (testing "Check that we're not allowed to run SQL against an H2 database with a non-admin account"

--- a/test/metabase/driver/mysql_test.clj
+++ b/test/metabase/driver/mysql_test.clj
@@ -114,7 +114,7 @@
           (is (= 1
                  (:updated-fingerprints (#'fingerprint/fingerprint-table! table fields)))))))))
 
-(deftest db-timezone-id-test
+(deftest db-default-timezone-test
   (mt/test-driver :mysql
     (let [timezone (fn [result-row]
                      (let [db (mt/db)]

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -750,9 +750,9 @@
               (mt/with-temporary-setting-values [report-timezone report-timezone]
                 (ffirst
                  (mt/rows
-                   (qp/process-query {:database (mt/id)
-                                      :type     :native
-                                      :native   {:query "SELECT current_setting('TIMEZONE') AS timezone;"}})))))]
+                  (qp/process-query {:database (mt/id)
+                                     :type     :native
+                                     :native   {:query "SELECT current_setting('TIMEZONE') AS timezone;"}})))))]
       (testing "check that if we set report-timezone to US/Pacific that the session timezone is in fact US/Pacific"
         (is  (= "US/Pacific"
                 (get-timezone-with-report-timezone "US/Pacific"))))
@@ -761,9 +761,8 @@
                (get-timezone-with-report-timezone "America/Chicago"))))
       (testing (str "ok, check that if we try to put in a fake timezone that the query still reëxecutes without a "
                     "custom timezone. This should give us the same result as if we didn't try to set a timezone at all")
-        (mt/suppress-output
-          (is (= (get-timezone-with-report-timezone nil)
-                 (get-timezone-with-report-timezone "Crunk Burger"))))))))
+        (is (= (get-timezone-with-report-timezone nil)
+               (get-timezone-with-report-timezone "Crunk Burger")))))))
 
 (deftest fingerprint-time-fields-test
   (mt/test-driver :postgres

--- a/test/metabase/driver/sql_jdbc/native_test.clj
+++ b/test/metabase/driver/sql_jdbc/native_test.clj
@@ -4,7 +4,6 @@
             [medley.core :as m]
             [metabase.query-processor :as qp]
             [metabase.test.data :as data]
-            [metabase.test.util.log :as tu.log]
             [metabase.util.schema :as su]
             [schema.core :as s]))
 
@@ -64,16 +63,15 @@
 
 (deftest malformed-sql-response-test
   (testing "Check that we get proper error responses for malformed SQL"
-    (tu.log/suppress-output
-      (is (schema= {:status     (s/eq :failed)
-                    :class      (s/eq org.h2.jdbc.JdbcSQLException)
-                    :error      #"^Column \"ZID\" not found"
-                    :stacktrace [su/NonBlankString]
-                    :json_query {:native   {:query (s/eq "SELECT ZID FROM CHECKINS LIMIT 2")}
-                                 :type     (s/eq :native)
-                                 s/Keyword s/Any}
-                    s/Keyword   s/Any}
-                   (qp/process-userland-query
-                    {:native   {:query "SELECT ZID FROM CHECKINS LIMIT 2"}
-                     :type     :native
-                     :database (data/id)}))))))
+    (is (schema= {:status     (s/eq :failed)
+                  :class      (s/eq org.h2.jdbc.JdbcSQLException)
+                  :error      #"^Column \"ZID\" not found"
+                  :stacktrace [su/NonBlankString]
+                  :json_query {:native   {:query (s/eq "SELECT ZID FROM CHECKINS LIMIT 2")}
+                               :type     (s/eq :native)
+                               s/Keyword s/Any}
+                  s/Keyword   s/Any}
+                 (qp/process-userland-query
+                  {:native   {:query "SELECT ZID FROM CHECKINS LIMIT 2"}
+                   :type     :native
+                   :database (data/id)})))))

--- a/test/metabase/driver/sql_jdbc_test.clj
+++ b/test/metabase/driver/sql_jdbc_test.clj
@@ -8,7 +8,6 @@
             [metabase.models.table :as table :refer [Table]]
             [metabase.query-processor :as qp]
             [metabase.test :as mt]
-            [metabase.test.util.log :as tu.log]
             [toucan.db :as db]))
 
 (deftest describe-database-test
@@ -112,8 +111,7 @@
                             :tunnel-port    21212
                             :tunnel-user    "example"
                             :user           "postgres"}]
-               (tu.log/suppress-output
-                (driver.u/can-connect-with-details? :postgres details :throw-exceptions)))
+               (driver.u/can-connect-with-details? :postgres details :throw-exceptions))
              (catch Throwable e
                (loop [^Throwable e e]
                  (or (when (instance? java.net.ConnectException e)

--- a/test/metabase/http_client.clj
+++ b/test/metabase/http_client.clj
@@ -151,8 +151,8 @@
   exception."
   [method-name url body expected-status-code actual-status-code]
   ;; if we get a 401 authenticated but weren't expecting it, this means we need to log in and get new credentials for
-  ;; the current user. Throw an Exception and then `user->client` will handle it and call `authenticate` to get new
-  ;; creds and retry the request automatically.
+  ;; the current user. Throw an Exception and then [[metabase.test/user-http-request]] will handle it and call
+  ;; `authenticate` to get new creds and retry the request automatically.
   (when (and (= actual-status-code 401)
              (not= expected-status-code 401))
     (let [message (format "%s %s expected a status code of %d, got %d."

--- a/test/metabase/integrations/ldap_test.clj
+++ b/test/metabase/integrations/ldap_test.clj
@@ -65,8 +65,8 @@
              (ldap/verify-password "cn=Fred Taylor,ou=People,dc=metabase,dc=com", "pa$$word"))))))
 
 (deftest find-test
-  ;; there are EE-specific versions of this test in `metabase-enterprise.enhancements.integrations.ldap-test`
-  (with-redefs [premium-features/enable-enhancements? (constantly false)]
+  ;; there are EE-specific versions of this test in [[metabase-enterprise.enhancements.integrations.ldap-test]]
+  (with-redefs [#_{:clj-kondo/ignore [:deprecated-var]} premium-features/enable-enhancements? (constantly false)]
     (ldap.test/with-ldap-server
       (testing "find by username"
         (is (= {:dn         "cn=John Smith,ou=People,dc=metabase,dc=com"
@@ -120,8 +120,8 @@
                (ldap/find-user "sbrown20")))))))
 
 (deftest fetch-or-create-user-test
-  ;; there are EE-specific versions of this test in `metabase-enterprise.enhancements.integrations.ldap-test`
-  (with-redefs [premium-features/enable-enhancements? (constantly false)]
+  ;; there are EE-specific versions of this test in [[metabase-enterprise.enhancements.integrations.ldap-test]]
+  (with-redefs [#_{:clj-kondo/ignore [:deprecated-var]} premium-features/enable-enhancements? (constantly false)]
     (ldap.test/with-ldap-server
       (testing "a new user is created when they don't already exist"
         (try

--- a/test/metabase/public_settings_test.clj
+++ b/test/metabase/public_settings_test.clj
@@ -56,7 +56,7 @@
       (is (= "https://&"
              (setting/get-value-of-type :string :site-url)))
       (is (= nil
-             (mt/suppress-output (public-settings/site-url)))))))
+             (public-settings/site-url))))))
 
 (deftest site-url-settings-normalize
   (testing "We should normalize `site-url` when set via env var we should still normalize it (#9764)"
@@ -70,13 +70,12 @@
 (deftest invalid-site-url-env-var-test
   (testing (str "If `site-url` is set via an env var, and it's invalid, we should return `nil` rather than having the"
                 " whole instance break")
-    (mt/suppress-output
-      (mt/with-temp-env-var-value [mb-site-url "asd_12w31%$;"]
-        (mt/with-temporary-setting-values [site-url nil]
-          (is (= "asd_12w31%$;"
-                 (setting/get-value-of-type :string :site-url)))
-          (is (= nil
-                 (public-settings/site-url))))))))
+    (mt/with-temp-env-var-value [mb-site-url "asd_12w31%$;"]
+      (mt/with-temporary-setting-values [site-url nil]
+        (is (= "asd_12w31%$;"
+               (setting/get-value-of-type :string :site-url)))
+        (is (= nil
+               (public-settings/site-url)))))))
 
 (deftest site-url-should-update-https-redirect-test
   (testing "Changing `site-url` to non-HTTPS should disable forced HTTPS redirection"

--- a/test/metabase/query_processor/middleware/permissions_test.clj
+++ b/test/metabase/query_processor/middleware/permissions_test.clj
@@ -223,12 +223,11 @@
                                :type                 (s/eq qp.error-type/missing-required-permissions)
                                s/Keyword             s/Any}
                     s/Keyword s/Any}
-                   (mt/suppress-output
-                     (qp/process-userland-query
-                      {:database (mt/id)
-                       :type     :query
-                       :query    {:source-table (mt/id :venues)
-                                  :limit        1}})))))))
+                   (qp/process-userland-query
+                    {:database (mt/id)
+                     :type     :query
+                     :query    {:source-table (mt/id :venues)
+                                :limit        1}}))))))
 
 (deftest e2e-nested-source-card-test
   (testing "Make sure permissions are calculated for Card -> Card -> Source Query (#12354)"

--- a/test/metabase/query_processor/middleware/results_metadata_test.clj
+++ b/test/metabase/query_processor/middleware/results_metadata_test.clj
@@ -2,78 +2,82 @@
   (:require [clojure.string :as str]
             [clojure.test :refer :all]
             [metabase.mbql.schema :as mbql.s]
-            [metabase.models :refer [Card Collection Dimension]]
+            [metabase.models :refer [Card Collection Dimension Field]]
             [metabase.models.permissions :as perms]
             [metabase.models.permissions-group :as perms-group]
             [metabase.query-processor :as qp]
             [metabase.query-processor.util :as qp.util]
             [metabase.sync.analyze.query-results :as qr]
             [metabase.test :as mt]
-            [metabase.test.mock.util :as mock.util]
-            [metabase.test.util :as tu]
             [metabase.util :as u]
             [metabase.util.schema :as su]
             [schema.core :as s]
             [toucan.db :as db]))
 
-(use-fixtures :each (fn [thunk]
-                      (mt/suppress-output (thunk))))
-
 (defn- card-metadata [card]
   (db/select-one-field :result_metadata Card :id (u/the-id card)))
 
 (defn- round-to-2-decimals
-  "Defaults `mt/round-all-decimals` to 2 digits"
+  "Defaults [[mt/round-all-decimals]] to 2 digits"
   [data]
   (mt/round-all-decimals 2 data))
 
-(def ^:private default-card-results
-  [{:name         "ID"
-    :display_name "ID"
-    :base_type    :type/BigInteger
-    :effective_type :type/BigInteger
-    :semantic_type :type/PK
-    :fingerprint  (:id mock.util/venue-fingerprints)
-    :field_ref    [:field "ID" {:base-type :type/BigInteger}]}
-   {:name         "NAME"
-    :display_name "Name"
-    :base_type    :type/Text
-    :effective_type :type/Text
-    :semantic_type :type/Name
-    :fingerprint  (:name mock.util/venue-fingerprints)
-    :field_ref    [:field "NAME" {:base-type :type/Text}]}
-   {:name         "PRICE"
-    :display_name "Price"
-    :base_type    :type/Integer
-    :effective_type :type/Integer
-    :semantic_type nil
-    :fingerprint  (:price mock.util/venue-fingerprints)
-    :field_ref    [:field "PRICE" {:base-type :type/Integer}]}
-   {:name         "CATEGORY_ID"
-    :display_name "Category ID"
-    :base_type    :type/Integer
-    :effective_type :type/Integer
-    :semantic_type nil
-    :fingerprint  (:category_id mock.util/venue-fingerprints)
-    :field_ref    [:field "CATEGORY_ID" {:base-type :type/Integer}]}
-   {:name         "LATITUDE"
-    :display_name "Latitude"
-    :base_type    :type/Float
-    :effective_type :type/Float
-    :semantic_type :type/Latitude
-    :fingerprint  (:latitude mock.util/venue-fingerprints)
-    :field_ref    [:field "LATITUDE" {:base-type :type/Float}]}
-   {:name         "LONGITUDE"
-    :display_name "Longitude"
-    :base_type    :type/Float
-    :effective_type :type/Float
-    :semantic_type :type/Longitude
-    :fingerprint  (:longitude mock.util/venue-fingerprints)
-    :field_ref    [:field "LONGITUDE" {:base-type :type/Float}]}])
+(defn- default-card-results []
+  (let [id->fingerprint   (db/select-id->field :fingerprint Field :table_id (mt/id :venues))
+        name->fingerprint (comp id->fingerprint (partial mt/id :venues))]
+    [{:name           "ID"
+      :display_name   "ID"
+      :base_type      :type/BigInteger
+      :effective_type :type/BigInteger
+      :semantic_type  :type/PK
+      :fingerprint    (name->fingerprint :id)
+      :field_ref      [:field "ID" {:base-type :type/BigInteger}]}
+     {:name           "NAME"
+      :display_name   "Name"
+      :base_type      :type/Text
+      :effective_type :type/Text
+      :semantic_type  :type/Name
+      :fingerprint    (name->fingerprint :name)
+      :field_ref      [:field "NAME" {:base-type :type/Text}]}
+     {:name           "PRICE"
+      :display_name   "Price"
+      :base_type      :type/Integer
+      :effective_type :type/Integer
+      :semantic_type  nil
+      :fingerprint    (name->fingerprint :price)
+      :field_ref      [:field "PRICE" {:base-type :type/Integer}]}
+     {:name           "CATEGORY_ID"
+      :display_name   "Category ID"
+      :base_type      :type/Integer
+      :effective_type :type/Integer
+      :semantic_type  nil
+      :fingerprint    (name->fingerprint :category_id)
+      :field_ref      [:field "CATEGORY_ID" {:base-type :type/Integer}]}
+     {:name           "LATITUDE"
+      :display_name   "Latitude"
+      :base_type      :type/Float
+      :effective_type :type/Float
+      :semantic_type  :type/Latitude
+      :fingerprint    (name->fingerprint :latitude)
+      :field_ref      [:field "LATITUDE" {:base-type :type/Float}]}
+     {:name           "LONGITUDE"
+      :display_name   "Longitude"
+      :base_type      :type/Float
+      :effective_type :type/Float
+      :semantic_type  :type/Longitude
+      :fingerprint    (name->fingerprint :longitude)
+      :field_ref      [:field "LONGITUDE" {:base-type :type/Float}]}]))
 
-(def ^:private default-card-results-native
-  (for [column (-> default-card-results
-                   (update-in [3 :fingerprint] assoc :type {:type/Number {:min 2.0, :max 74.0, :avg 29.98, :q1 7.0, :q3 49.0 :sd 23.06}}))]
+(defn- default-card-results-native
+  "These are rounded to two decimal places."
+  []
+  (for [column (-> (default-card-results)
+                   (update-in [3 :fingerprint] assoc :type {:type/Number {:min 2.0
+                                                                          :max 74.0
+                                                                          :avg 29.98
+                                                                          :q1  6.9
+                                                                          :q3  49.24
+                                                                          :sd  23.06}}))]
     (assoc column :display_name (:name column))))
 
 (deftest save-result-metadata-test
@@ -85,8 +89,8 @@
                                   :query-hash (qp.util/query-hash {})}))]
         (when-not (= :completed (:status result))
           (throw (ex-info "Query failed." result))))
-      (is (= default-card-results-native
-             (-> card card-metadata round-to-2-decimals tu/round-fingerprint-cols)))))
+      (is (= (round-to-2-decimals (default-card-results-native))
+             (-> card card-metadata round-to-2-decimals)))))
 
   (testing "check that using a Card as your source doesn't overwrite the results metadata..."
     (mt/with-temp Card [card {:dataset_query   (mt/native-query {:query "SELECT * FROM VENUES"})
@@ -113,15 +117,14 @@
 
 (deftest metadata-in-results-test
   (testing "make sure that queries come back with metadata"
-    (is (= {:columns  (for [col default-card-results-native]
+    (is (= {:columns  (for [col (round-to-2-decimals (default-card-results-native))]
                         (-> col (update :semantic_type keyword) (update :base_type keyword)))}
            (-> (qp/process-userland-query
                 {:database (mt/id)
                  :type     :native
                  :native   {:query "SELECT ID, NAME, PRICE, CATEGORY_ID, LATITUDE, LONGITUDE FROM VENUES"}})
                (get-in [:data :results_metadata])
-               round-to-2-decimals
-               (->> (tu/round-fingerprint-cols [:columns]))))))
+               round-to-2-decimals))))
   (testing "datasets"
     (testing "metadata from datasets can be preserved"
       (letfn [(choose [col] (select-keys col [:name :description :display_name :semantic_type]))
@@ -140,9 +143,9 @@
                                                :base_type)
                                               cols)))]
         (testing "native"
-          (let [fields (str/join ", " (map :name default-card-results-native))
+          (let [fields (str/join ", " (map :name (default-card-results-native)))
                 native-query (str "SELECT " fields " FROM VENUES")
-                existing-metadata (add-preserved default-card-results-native)
+                existing-metadata (add-preserved (default-card-results-native))
                 results (qp/process-userland-query
                          {:database (mt/id)
                           :type :native
@@ -198,12 +201,11 @@
                :semantic_type :type/Quantity
                :fingerprint  {:global {:distinct-count 3
                                        :nil%           0.0},
-                              :type   {:type/Number {:min 235.0, :max 498.0, :avg 333.33 :q1 243.0, :q3 440.0 :sd 143.5}}}
+                              :type   {:type/Number {:min 235.0, :max 498.0, :avg 333.33 :q1 243.0, :q3 440.25, :sd 143.5}}}
                :field_ref    [:aggregation 0]}]
              (-> card
                  card-metadata
-                 round-to-2-decimals
-                 tu/round-fingerprint-cols))))))
+                 round-to-2-decimals))))))
 
 (defn- results-metadata [query]
   (-> (qp/process-query query) :data :results_metadata :columns))

--- a/test/metabase/query_processor/util_test.clj
+++ b/test/metabase/query_processor/util_test.clj
@@ -3,14 +3,7 @@
   (:require [clojure.test :refer :all]
             [metabase.query-processor.util :as qp.util]))
 
-(deftest mbql-query?-test
-  (are [x expected] (= expected
-                       (qp.util/mbql-query? x))
-    {}               false
-    {:type "native"} false
-    {:type "query"}  true))
-
-(deftest query-without-aggregations-or-limits?-test
+(deftest ^:parallel query-without-aggregations-or-limits?-test
   (are [x expected] (= expected
                        (qp.util/query-without-aggregations-or-limits? x))
     {:query {:aggregation [[:count]]}} false
@@ -27,7 +20,7 @@
    (and (byte-array= a b)
         (apply byte-array= b more))))
 
-(deftest query-hash-test
+(deftest ^:parallel query-hash-test
   (testing "qp.util/query-hash"
     (testing "should always hash something the same way, every time"
       (is (byte-array=

--- a/test/metabase/query_processor_test/breakout_test.clj
+++ b/test/metabase/query_processor_test/breakout_test.clj
@@ -198,16 +198,15 @@
 
 (deftest binning-error-test
   (mt/test-drivers (mt/normal-drivers-with-feature :binning)
-    (mt/suppress-output
-      (mt/with-temp-vals-in-db Field (mt/id :venues :latitude) {:fingerprint {:type {:type/Number {:min nil, :max nil}}}}
-        (is (= {:status :failed
-                :class  clojure.lang.ExceptionInfo
-                :error  "Unable to bin Field without a min/max value"}
-               (-> (qp/process-userland-query
-                    (mt/mbql-query venues
-                      {:aggregation [[:count]]
-                       :breakout    [[:field %latitude {:binning {:strategy :default}}]]}))
-                   (select-keys [:status :class :error]))))))))
+    (mt/with-temp-vals-in-db Field (mt/id :venues :latitude) {:fingerprint {:type {:type/Number {:min nil, :max nil}}}}
+      (is (= {:status :failed
+              :class  clojure.lang.ExceptionInfo
+              :error  "Unable to bin Field without a min/max value"}
+             (-> (qp/process-userland-query
+                  (mt/mbql-query venues
+                                 {:aggregation [[:count]]
+                                  :breakout    [[:field %latitude {:binning {:strategy :default}}]]}))
+                 (select-keys [:status :class :error])))))))
 
 (defn- nested-venues-query [card-or-card-id]
   {:database mbql.s/saved-questions-virtual-database-id

--- a/test/metabase/query_processor_test/filter_test.clj
+++ b/test/metabase/query_processor_test/filter_test.clj
@@ -518,7 +518,7 @@
                        []
                        [[expected-count]])
                      (mt/formatted-rows [int]
-                                        (qp/process-query query)))))))))
+                       (qp/process-query query)))))))))
 
     (testing "Make sure we're not being too aggressive and encoding percent signs (e.g. SQL `LIKE`)"
       (is (= [[1]]

--- a/test/metabase/search/scoring_test.clj
+++ b/test/metabase/search/scoring_test.clj
@@ -12,7 +12,7 @@
    {:model model
     :name name}))
 
-(deftest tokenize-test
+(deftest ^:parallel tokenize-test
   (testing "basic tokenization"
     (is (= ["Rasta" "the" "Toucan's" "search"]
            (scoring/tokenize "Rasta the Toucan's search")))
@@ -25,12 +25,12 @@
     (is (thrown-with-msg? Exception #"does not match schema"
                           (scoring/tokenize nil)))))
 
-(defn scorer->score
+(defn- scorer->score
   [scorer]
   (comp :score
         (partial #'scoring/text-score-with [{:weight 1 :scorer scorer}])))
 
-(deftest consecutivity-scorer-test
+(deftest ^:parallel consecutivity-scorer-test
   (let [score (scorer->score #'scoring/consecutivity-scorer)]
     (testing "partial matches"
       (is (= 1/3
@@ -60,7 +60,7 @@
            (score ["rasta" "the" "toucan"]
                   (result-row "")))))))
 
-(deftest total-occurrences-scorer-test
+(deftest ^:parallel total-occurrences-scorer-test
   (let [score (scorer->score #'scoring/total-occurrences-scorer)]
     (testing "partial matches"
       (is (= 1/3
@@ -90,7 +90,7 @@
            (score ["rasta" "the" "toucan"]
                   (result-row "")))))))
 
-(deftest fullness-scorer-test
+(deftest ^:parallel fullness-scorer-test
   (let [score (scorer->score #'scoring/fullness-scorer)]
     (testing "partial matches"
       (is (= 1/8
@@ -108,7 +108,7 @@
            (score ["rasta" "the" "toucan"]
                   (result-row "")))))))
 
-(deftest exact-match-scorer-test
+(deftest ^:parallel exact-match-scorer-test
   (let [score (scorer->score #'scoring/exact-match-scorer)]
     (is (zero?
          (score ["rasta" "the" "toucan"]
@@ -123,7 +123,7 @@
            (score ["rasta" "the" "toucan"]
                   (result-row "Rasta the toucan"))))))
 
-(deftest top-results-test
+(deftest ^:parallel top-results-test
   (let [xf (map identity)]
     (testing "a non-full queue behaves normally"
       (let [items (->> (range 10)
@@ -145,7 +145,7 @@
                     (map :result))
                (scoring/top-results (shuffle sorted-items) xf)))))))
 
-(deftest match-context-test
+(deftest ^:parallel match-context-test
   (let [context  #'scoring/match-context
         tokens   (partial map str)
         match    (fn [text] {:text text :is_match true})
@@ -158,28 +158,29 @@
             (match "toucan")
             (no-match "things")]
            (context
-               ["rasta" "toucan"]
-               ["this" "is" "rasta" "toucan's" "collection" "of" "toucan" "things"]))))
+            ["rasta" "toucan"]
+            ["this" "is" "rasta" "toucan's" "collection" "of" "toucan" "things"]))))
     (testing "it handles no matches"
       (is (= [(no-match "aviary stats")]
              (context
-                 ["rasta" "toucan"]
-                 ["aviary" "stats"]))))
+              ["rasta" "toucan"]
+              ["aviary" "stats"]))))
     (testing "it abbreviates when necessary"
       (is (= [(no-match "one two…eleven twelve")
               (match "rasta toucan")
               (no-match "alpha beta…the end")]
              (context
-                 (tokens '(rasta toucan))
-                 (tokens '(one two
-                           this should not be included
-                           eleven twelve
-                           rasta toucan
-                           alpha beta
-                           some other noise
-                           the end))))))))
+              (tokens '(rasta toucan))
+              (tokens '(one
+                        two
+                        this should not be included
+                        eleven twelve
+                        rasta toucan
+                        alpha beta
+                        some other noise
+                        the end))))))))
 
-(deftest test-largest-common-subseq-length
+(deftest ^:parallel test-largest-common-subseq-length
   (let [subseq-length (partial #'scoring/largest-common-subseq-length =)]
     (testing "greedy choice can't be taken"
       (is (= 3
@@ -198,7 +199,7 @@
                                        it flies short distances between trees toucans rest in holes in trees
                                        here is some more filler))))))))
 
-(deftest pinned-score-test
+(deftest ^:parallel pinned-score-test
   (let [score #'scoring/pinned-score
         item (fn [collection-position] {:collection_position collection-position
                                         :model "card"})]
@@ -217,7 +218,7 @@
         (is (= #{nil 0}
                (set (take-last 2 result))))))))
 
-(deftest recency-score-test
+(deftest ^:parallel recency-score-test
   (let [score    #'scoring/recency-score
         now      (t/offset-date-time)
         item     (fn [id updated-at] {:id id :updated_at updated-at})
@@ -242,7 +243,7 @@
                     (sort-by score)
                     (map :id))))))))
 
-(deftest combined-test
+(deftest ^:parallel combined-test
   (let [search-string     "custom expression examples"
         labeled-results   {:a {:name "custom expression examples" :model "dashboard"}
                            :b {:name "examples of custom expressions" :model "dashboard"}
@@ -265,7 +266,7 @@
                 (map :result)
                 (map :name))))))
 
-(deftest bookmarked-test
+(deftest ^:parallel bookmarked-test
   (let [search-string     "my card"
         labeled-results   {:a {:name "my card a" :model "dashboard"}
                            :b {:name "my card b" :model "dashboard" :bookmark true :collection_position 1}
@@ -288,7 +289,7 @@
                      {:weight 100 :score 0 :name "Some other score type"}])]
       (is (= 0 (:score (scoring/score-and-result "" {:name "racing yo" :model "card"})))))))
 
-(deftest serialize-test
+(deftest ^:parallel serialize-test
   (testing "It normalizes dataset queries from strings"
     (let [query  {:type     :query
                   :query    {:source-query {:source-table 1}}

--- a/test/metabase/server/routes/index_test.clj
+++ b/test/metabase/server/routes/index_test.clj
@@ -2,16 +2,15 @@
   (:require [cheshire.core :as json]
             [clojure.test :refer :all]
             [metabase.server.routes.index :as index]
-            [metabase.test :as mt]
             [metabase.util.i18n :as i18n]))
 
-(deftest localization-json-file-name-test
+(deftest ^:parallel localization-json-file-name-test
   (is (= "frontend_client/app/locales/es.json"
          (#'index/localization-json-file-name "es")))
   (is (= "frontend_client/app/locales/es_MX.json"
          (#'index/localization-json-file-name "es-MX"))))
 
-(deftest load-localization-test
+(deftest ^:parallel load-localization-test
   (testing "make sure `load-localization` is correctly loading i18n files (#9938)"
     (is (= {"charset"      "utf-8"
             "headers"      {"mime-version"              "1.0"
@@ -29,17 +28,16 @@
             (update "translations" select-keys [""])
             (update-in ["translations" ""] select-keys ["Your database has been added!"]))))))
 
-(deftest fallback-localization-test
+(deftest ^:parallel fallback-localization-test
   (testing "if locale does not exist it should log a message and return the 'fallback' localalization (english)"
     (is (= {"headers"      {"language" "xx", "plural-forms" "nplurals=2; plural=(n != 1);"}
             "translations" {"" {"Metabase" {"msgid" "Metabase", "msgstr" ["Metabase"]}}}}
-           (mt/suppress-output
-             (some->
-              (binding [i18n/*user-locale* "xx"]
-                (#'index/load-localization nil))
-              json/parse-string))))))
+           (some->
+            (binding [i18n/*user-locale* "xx"]
+              (#'index/load-localization nil))
+            json/parse-string)))))
 
-(deftest english-test
+(deftest ^:parallel english-test
   (testing "english should return the fallback localization (english)"
     (is (= {"headers"      {"language" "en", "plural-forms" "nplurals=2; plural=(n != 1);"}
             "translations" {"" {"Metabase" {"msgid" "Metabase", "msgstr" ["Metabase"]}}}}
@@ -48,7 +46,7 @@
               (#'index/load-localization nil))
             json/parse-string)))))
 
-(deftest override-localization-test
+(deftest ^:parallel override-localization-test
   (testing "a valid override is honored no matter what the user locale is"
     (is (= {"charset"      "utf-8"
             "headers"      {"mime-version"              "1.0"
@@ -69,8 +67,7 @@
   (testing "an invalid override causes a fallback to English"
     (is (= {"headers"      {"language" "yy", "plural-forms" "nplurals=2; plural=(n != 1);"}
             "translations" {"" {"Metabase" {"msgid" "Metabase", "msgstr" ["Metabase"]}}}}
-           (mt/suppress-output
-             (some->
-              (binding [i18n/*user-locale* "xx"]
-                (#'index/load-localization "yy"))
-              json/parse-string))))))
+           (some->
+            (binding [i18n/*user-locale* "xx"]
+              (#'index/load-localization "yy"))
+            json/parse-string)))))

--- a/test/metabase/sync/analyze_test.clj
+++ b/test/metabase/sync/analyze_test.clj
@@ -163,14 +163,14 @@
   "Change the `visibility-type` of `table` via an API call. (This is done via the API so we can see which, if any, side
   effects (e.g. analysis) get triggered.)"
   [table visibility-type]
-  ((mt/user->client :crowberto) :put 200 (format "table/%d" (:id table)) {:display_name    "hiddentable"
-                                                                          :visibility_type visibility-type
-                                                                          :description     "What a nice table!"}))
+  (mt/user-http-request :crowberto :put 200 (format "table/%d" (:id table)) {:display_name    "hiddentable"
+                                                                             :visibility_type visibility-type
+                                                                             :description     "What a nice table!"}))
 
 (defn- api-sync!
   "Trigger a sync of `table` via the API."
   [table]
-  ((mt/user->client :crowberto) :post 200 (format "database/%d/sync" (:db_id table))))
+  (mt/user-http-request :crowberto :post 200 (format "database/%d/sync" (:db_id table))))
 
 ;; use these functions to create fake Tables & Fields that are actually backed by something real in the database.
 ;; Otherwise when we go to resync them the logic will figure out Table/Field doesn't exist and mark it as inactive

--- a/test/metabase/test.clj
+++ b/test/metabase/test.clj
@@ -173,7 +173,6 @@
  [test.users
   fetch-user
   test-user?
-  user->client
   user->credentials
   user->id
   user-descriptor
@@ -227,7 +226,6 @@
  [tu.log
   ns-log-level
   set-ns-log-level!
-  suppress-output
   with-log-messages-for-level
   with-log-level]
 
@@ -262,7 +260,7 @@
                                 with-gtaps-for-user
                                 with-user-attributes])))
 
-;; TODO -- move this stuff into some other namespace and refer to it here
+;;; TODO -- move all the stuff below into some other namespace and import it here.
 
 (defn do-with-clock [clock thunk]
   (test-runner.parallel/assert-test-is-not-parallel "with-clock")
@@ -285,10 +283,16 @@
   [clock & body]
   `(do-with-clock ~clock (fn [] ~@body)))
 
-;; New QP middleware test util fns. Experimental. These will be put somewhere better if confirmed useful.
+;;;; New QP middleware test util fns. Experimental. These will be put somewhere better if confirmed useful.
 
-(defn ^:deprecated test-qp-middleware
-  "Helper for testing QP middleware. Changes are returned in a map with keys:
+(defn test-qp-middleware
+  "Helper for testing QP middleware that uses the
+
+    (defn middleware [qp]
+      (fn [query rff context]
+        (qp query rff context)))
+
+  pattern, such as stuff in [[metabase.query-processor/around-middleware]]. Changes are returned in a map with keys:
 
     * `:result`   ­ final result
     * `:pre`      ­ `query` after preprocessing

--- a/test/metabase/test/data/impl.clj
+++ b/test/metabase/test/data/impl.clj
@@ -334,7 +334,7 @@
   (let [dbdef             (tx/get-dataset-definition dataset-definition)
         get-db-for-driver (mdb.connection/memoize-for-application-db
                            (fn [driver]
-                            (binding [db/*disable-db-logging* true]
+                             (binding [db/*disable-db-logging* true]
                                (let [db (get-or-create-database! driver dbdef)]
                                  (assert db)
                                  (assert (db/exists? Database :id (u/the-id db)))

--- a/test/metabase/test/data/sql_jdbc/load_data.clj
+++ b/test/metabase/test/data/sql_jdbc/load_data.clj
@@ -181,13 +181,13 @@
   (let [statements (ddl/insert-rows-ddl-statements driver table-identifier row-or-rows)]
     ;; `set-parameters` might try to look at DB timezone; we don't want to do that while loading the data because the
     ;; DB hasn't been synced yet
-    (when-let [set-timezone-format-string (sql-jdbc.execute/set-timezone-sql driver)]
+    (when-let [set-timezone-format-string #_{:clj-kondo/ignore [:deprecated-var]} (sql-jdbc.execute/set-timezone-sql driver)]
       (let [set-timezone-sql (format set-timezone-format-string "'UTC'")]
         (log/debugf "Setting timezone to UTC before inserting data with SQL \"%s\"" set-timezone-sql)
         (jdbc/execute! spec [set-timezone-sql])))
     (mt/with-database-timezone-id nil
       (try
-        ;; TODO - why don't we use `execute/execute-sql!` here like we do below?
+        ;; TODO - why don't we use [[execute/execute-sql!]] here like we do below?
         (doseq [sql+args statements]
           (log/tracef "[insert] %s" (pr-str sql+args))
           (jdbc/execute! spec sql+args {:set-parameters (fn [stmt params]

--- a/test/metabase/test/data/users.clj
+++ b/test/metabase/test/data/users.clj
@@ -166,18 +166,6 @@
         (binding [*retrying-authentication*  true]
           (apply client-fn username args))))))
 
-(s/defn ^:deprecated user->client :- (s/pred fn?)
-  "Returns a [[metabase.http-client/client]] partially bound with the credentials for User with `username`.
-   In addition, it forces lazy creation of the User if needed.
-
-     ((user->client) :get 200 \"meta/table\")
-
-  DEPRECATED -- use `user-http-request` instead, which has proper `:arglists` metadata which makes it a bit easier to
-  use when writing code."
-  [username :- TestUserName]
-  (fetch-user username) ; force creation of the user if not already created
-  (partial client-fn username))
-
 (defn user-http-request
   "A version of our test HTTP client that issues the request with credentials for a given User. User may be either a
   redefined test User name, e.g. `:rasta`, or any User or User ID. (Because we don't have the User's original

--- a/test/metabase/test/mock/util.clj
+++ b/test/metabase/test/mock/util.clj
@@ -41,26 +41,6 @@
    :entity_id      true
    :enabled        true})
 
-(def venue-fingerprints
-  "Fingerprints for the full venues table"
-  {:name        {:global {:distinct-count 100
-                          :nil%           0.0},
-                 :type   {:type/Text {:percent-json   0.0, :percent-url   0.0,
-                                      :percent-email  0.0, :percent-state 0.0,
-                                      :average-length 15.63}}}
-   :id          nil
-   :price       {:global {:distinct-count 4
-                          :nil%           0.0},
-                 :type   {:type/Number {:min 1.0, :max 4.0, :avg 2.03, :q1 1.0, :q3 2.0 :sd 0.77}}}
-   :latitude    {:global {:distinct-count 94
-                          :nil%           0.0},
-                 :type   {:type/Number {:min 10.06, :max 40.78, :avg 35.51, :q1 34.0, :q3 38.0 :sd 3.43}}}
-   :category_id {:global {:distinct-count 28
-                          :nil%           0.0}}
-   :longitude   {:global {:distinct-count 84
-                          :nil%           0.0},
-                 :type   {:type/Number {:min -165.37, :max -73.95, :avg -116.0 :q1 -122.0, :q3 -118.0 :sd 14.16}}}})
-
 (defn mock-execute-reducible-query [query respond]
   (respond
    {}

--- a/test/metabase/test/sync.clj
+++ b/test/metabase/test/sync.clj
@@ -3,7 +3,6 @@
             [metabase.models.database :refer [Database]]
             [metabase.models.task-history :refer [TaskHistory]]
             [metabase.sync :as sync]
-            [metabase.test :as mt]
             [metabase.test.data :as data]
             [toucan.db :as db]))
 
@@ -24,6 +23,5 @@
   "Can sync process survive `f` crashing?"
   [f]
   `(is (= (sync-steps-run-to-completion)
-          (mt/suppress-output
-            (with-redefs [~f crash-fn]
-              (sync-steps-run-to-completion))))))
+          (with-redefs [~f crash-fn]
+            (sync-steps-run-to-completion)))))

--- a/test/metabase/test/util/log.clj
+++ b/test/metabase/test/util/log.clj
@@ -6,58 +6,9 @@
             [metabase.test-runner.parallel :as test-runner.parallel]
             [potemkin :as p]
             [schema.core :as s])
-  (:import java.io.PrintStream
-           [org.apache.commons.io.output NullOutputStream NullWriter]
-           [org.apache.logging.log4j Level LogManager]
+  (:import [org.apache.logging.log4j Level LogManager]
            [org.apache.logging.log4j.core Appender LifeCycle LogEvent Logger LoggerContext]
            [org.apache.logging.log4j.core.config Configuration LoggerConfig]))
-
-(def ^:private ^:deprecated logger->original-level
-  (delay
-    (let [loggers (.getLoggers ^LoggerContext (LogManager/getContext false))]
-      (into {} (for [^Logger logger loggers]
-                 [logger (.getLevel logger)])))))
-
-(def ^:private ^:dynamic *suppressed* false)
-
-(defn ^:deprecated do-with-suppressed-output
-  "Impl for [[suppress-output]] macro; don't use this directly."
-  [f]
-  (if *suppressed*
-    (f)
-    (binding [*suppressed* true]
-      ;; yes, swapping out *out*/*err*, swapping out System.out/System.err, and setting all the log levels to OFF is
-      ;; really necessary to suppress everyting (!)
-      (let [orig-out (System/out)
-            orig-err (System/err)]
-        (with-open [null-stream (PrintStream. (NullOutputStream.))
-                    null-writer (NullWriter.)]
-          (try
-            (System/setOut null-stream)
-            (System/setErr null-stream)
-            (doseq [[^Logger logger] @logger->original-level]
-              (.setLevel logger Level/OFF))
-            (binding [*out* null-writer
-                      *err* null-writer]
-              (f))
-            (finally
-              (System/setOut orig-out)
-              (System/setErr orig-err)
-              (doseq [[^Logger logger, ^Level old-level] @logger->original-level]
-                (.setLevel logger old-level)))))))))
-
-(defmacro ^:deprecated suppress-output
-  "Execute `body` with all logging/`*out*`/`*err*` messages suppressed. Useful for avoiding cluttering up test output
-  for tests with stacktraces and error messages from tests that are supposed to fail.
-
-  DEPRECATED -- you don't need to do this anymore. Tests now have a default log level of `FATAL` which means error
-  logging will be suppressed by default. This macro predates the current test logging levels. You can remove usages of
-  this macro.
-
-  If you want to suppress log messages for REPL usage you can use [[with-log-level]] instead."
-  {:style/indent 0}
-  [& body]
-  `(do-with-suppressed-output (fn [] ~@body)))
 
 (def ^:private keyword->Level
   {:off   Level/OFF


### PR DESCRIPTION
Part of #24727
Follow-on to #24748

It was actually easier to remove some of the deprecated functions than it was to go add a bunch of kondo directive comments in places where they were used. So I managed to remove a handful of things that have been deprecated for a while. For other stuff I added inline exceptions rather than global ones which means future usage will still cause a warning.