### PR TITLE
Preserve metadata visibility-type

### DIFF
--- a/src/metabase/query_processor/middleware/results_metadata.clj
+++ b/src/metabase/query_processor/middleware/results_metadata.clj
@@ -49,7 +49,7 @@
      (merge
       (select-keys final-col [:id :description :display_name :semantic_type :fk_target_field_id
                               :settings :field_ref :name :base_type :effective_type
-                              :coercion_strategy :semantic_type])
+                              :coercion_strategy :visibility_type])
       insights-col
       (when (= our-base-type :type/*)
         {:base_type final-base-type})))

--- a/src/metabase/query_processor/util.clj
+++ b/src/metabase/query_processor/util.clj
@@ -116,7 +116,8 @@
   metadata, the types returned should be authoritative. But things like semantic_type, display_name, and description
   can be merged on top."
   ;; TODO: ideally we don't preserve :id but some notion of :user-entered-id or :identified-id
-  [:id :description :display_name :semantic_type :fk_target_field_id :settings])
+  [:id :description :display_name :semantic_type
+   :fk_target_field_id :settings :visibility_type])
 
 (defn combine-metadata
   "Blend saved metadata from previous runs into fresh metadata from an actual run of the query.

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -2109,7 +2109,7 @@
                             :result_metadata
                             (map :description)))))))))))
   (testing "Cards preserve edits to `visibility_type` (#22520)"
-    (mt/with-temp* [Card [model {:dataset_query (mt/mbql-query :venues
+    (mt/with-temp* [Card [model {:dataset_query (mt/mbql-query venues
                                                                {:fields [$id $name]
                                                                 :limit 2})
                                  :dataset       true}]]

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -2107,7 +2107,29 @@
                                                   :result_metadata (fn [m]
                                                                      (map #(assoc % :description "") m))))
                             :result_metadata
-                            (map :description))))))))))))
+                            (map :description)))))))))))
+  (testing "Cards preserve edits to `visibility_type` (#22520)"
+    (mt/with-temp* [Card [model {:dataset_query (mt/mbql-query :venues
+                                                               {:fields [$id $name]
+                                                                :limit 2})
+                                 :dataset       true}]]
+      (let [updated-metadata (-> model :result_metadata vec
+                                 (assoc-in [1 :visibility_type]
+                                           :details-only))
+            response         (mt/user-http-request :crowberto :put 200 (format "card/%d" (u/the-id model))
+                                                   (assoc model :result_metadata updated-metadata))]
+        ;; check they come back from saving the question
+        (is (= "details-only" (-> response :result_metadata last :visibility_type))
+            "saving metadata lacks visibility type")
+        (let [query-result (mt/user-http-request :crowberto :post 202 (format "card/%d/query"
+                                                                              (u/the-id model)))]
+          ;; ensure future responses also include them
+          (is (= "details-only" (-> query-result
+                                    :data :results_metadata :columns last :visibility_type))
+              "subsequent query lacks visibility type")
+          (is (= "details-only" (-> query-result
+                                    :data :cols last :visibility_type))
+              "in cols (important for the saved metadata)"))))))
 
 (defn- do-with-persistence-setup [f]
   ;; mt/with-temp-scheduler actually just reuses the current scheduler. The scheduler factory caches by name set in

--- a/test/metabase/query_processor/middleware/results_metadata_test.clj
+++ b/test/metabase/query_processor/middleware/results_metadata_test.clj
@@ -178,6 +178,7 @@
                    :query-hash (qp.util/query-hash {})}})
       (is (= [{:base_type    :type/DateTime
                :effective_type    :type/DateTime
+               :visibility_type :normal
                :coercion_strategy nil
                :display_name "Date"
                :name         "DATE"


### PR DESCRIPTION
Fixes #22520 

Was being saved but not preserved and merged correctly. There are two
points we need to preserve this information: in annotating the result
metadata, we need to "flow" them. This is the combine metadata function
which uses `preserve-keys`.

And finally that stuff needs to be selected to be saved in
`results_metadata`. That plucks off the `cols` map from the query run,
merges it with insights and saves it.

Missing this metadata in either location means we drop it: we have to
flow it through the metadata and then ensure we select it for the final
saving.
