### PR TITLE
Revert "Fix #23689: Sandboxed group managers can't see other users in the People tab"

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/user_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/user_test.clj
@@ -1,0 +1,41 @@
+(ns metabase-enterprise.sandbox.api.user-test
+  "Tests that would logically be included in `metabase.api.user-test` but are separate as they are enterprise only."
+  (:require [clojure.test :refer :all]
+            [metabase.models.permissions-group-membership :refer [PermissionsGroupMembership]]
+            [metabase.test :as mt]
+            [metabase.test.fixtures :as fixtures]
+            [metabase.test.util :as tu]
+            [metabase.util :as u]
+            [toucan.db :as db]))
+
+(use-fixtures :once (fixtures/initialize :test-users-personal-collections))
+
+;; Non-segmented users are allowed to ask for a list of all of the users in the Metabase instance. Pulse email lists
+;; are an example usage of this. Segmented users should not have that ability. Instead they should only see
+;; themselves. This test checks that GET /api/user for a segmented user only returns themselves
+(deftest segmented-user-list-test
+  (testing "GET /api/user for a segmented user should return themselves"
+    (mt/with-gtaps {:gtaps {:venues {}}}
+      ;; Now do the request
+      (is (= [{:common_name "Rasta Toucan"
+               :last_name   "Toucan"
+               :first_name  "Rasta"
+               :email       "rasta@metabase.com"
+               :id          true}]
+             (tu/boolean-ids-and-timestamps ((mt/user-http-request :rasta :get 200 "user") :data))))
+      (testing "Should return themselves when the user is a segmented group manager"
+        (mt/with-group [group {:name "a group"}]
+          (let [membership (db/select-one PermissionsGroupMembership
+                                          :group_id (u/the-id group)
+                                          :user_id (mt/user->id :rasta))]
+            (db/update! PermissionsGroupMembership (:id membership)
+              :is_group_manager true))
+          (is (= [{:common_name "Rasta Toucan"
+                   :last_name   "Toucan"
+                   :first_name  "Rasta"
+                   :email       "rasta@metabase.com"
+                   :id          true}]
+                 (tu/boolean-ids-and-timestamps
+                  (-> (mt/user-http-request :rasta :get 200
+                                            (str "user?group_id=" (u/the-id group)))
+                      :data)))))))))

--- a/frontend/test/metabase/scenarios/admin/people/reproductions/23689-sandboxed-group-manager.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/people/reproductions/23689-sandboxed-group-manager.cy.spec.js
@@ -11,6 +11,9 @@ const totalUsers = Object.keys(USERS).length;
 
 describeEE("issue 23689", () => {
   beforeEach(() => {
+    // TODO: remove the next line when this issue gets fixed
+    cy.skipOn(true);
+
     cy.intercept("GET", "/api/permissions/membership").as("membership");
 
     restore();

--- a/frontend/test/metabase/scenarios/permissions/sandboxes.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/sandboxes.cy.spec.js
@@ -1013,8 +1013,6 @@ describeEE("formatting > sandboxes", () => {
       cy.findByText("Email it").click();
       cy.findByPlaceholderText("Enter user names or email addresses").click();
       cy.findByText("User 1").click();
-      // Click anywhere to close the popover that covers the "Send email now" button
-      cy.findByText("To:").click();
       cy.findByText("Send email now").click();
       cy.wait("@emailSent");
       cy.request("GET", "http://localhost:80/email").then(({ body }) => {

--- a/src/metabase/api/user.clj
+++ b/src/metabase/api/user.clj
@@ -126,6 +126,9 @@
   [status query group_id include_deactivated]
   (cond-> {}
         true (hh/merge-where (status-clause status include_deactivated))
+        true (hh/merge-where (when-let [segmented-user? (resolve 'metabase-enterprise.sandbox.api.util/segmented-user?)]
+                               (when (segmented-user?)
+                                 [:= :core_user.id api/*current-user-id*])))
         (some? query) (hh/merge-where (query-clause query))
         (some? group_id) (hh/merge-right-join :permissions_group_membership
                                               [:= :core_user.id :permissions_group_membership.user_id])


### PR DESCRIPTION
Reverts metabase/metabase#23825
Fixes https://github.com/metabase/metaboat/issues/164