### PR TITLE
Pass correct default colours to the static-viz waterfall chart

### DIFF
--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -774,15 +774,16 @@
         show-total     (if (nil? (:waterfall.show_total viz-settings))
                          true
                          (:waterfall.show_total viz-settings))
-        settings       (let [{inc-col :waterfall.increase_color
-                              dec-col :waterfall.decrease_color
-                              total-col :waterfall.total_color} viz-settings]
-                         (-> (->js-viz x-col y-col viz-settings)
-                             (update :colors merge
-                                     (when inc-col {:waterfallPositive inc-col})
-                                     (when dec-col {:waterfallNegative dec-col})
-                                     (when total-col {:waterfallTotal total-col}))
-                             (assoc :showTotal show-total)))
+        colors         (public-settings/application-colors)
+        settings       (let [inc-col   (or (:waterfall.increase_color viz-settings) (:accent1 colors))
+                             dec-col   (or (:waterfall.decrease_color viz-settings) (:accent3 colors))
+                             total-col (:waterfall.total_color viz-settings)]
+                       (-> (->js-viz x-col y-col viz-settings)
+                           (update :colors merge
+                                   (when inc-col {:waterfallPositive inc-col})
+                                   (when dec-col {:waterfallNegative dec-col})
+                                   (when total-col {:waterfallTotal total-col}))
+                           (assoc :showTotal show-total)))
         image-bundle   (image-bundle/make-image-bundle
                          render-type
                          (render-fn rows

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -779,9 +779,9 @@
                               total-col :waterfall.total_color} viz-settings]
                          (-> (->js-viz x-col y-col viz-settings)
                              (update :colors merge
-                                     (when inc-col {:waterfall.increase_color inc-col})
-                                     (when dec-col {:waterfall.increase_color dec-col})
-                                     (when total-col {:waterfall.increase_color total-col}))
+                                     (when inc-col {:waterfallPositive inc-col})
+                                     (when dec-col {:waterfallNegative dec-col})
+                                     (when total-col {:waterfallTotal total-col}))
                              (assoc :showTotal show-total)))
         image-bundle   (image-bundle/make-image-bundle
                          render-type

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -774,17 +774,20 @@
         show-total     (if (nil? (:waterfall.show_total viz-settings))
                          true
                          (:waterfall.show_total viz-settings))
-        settings       (-> (->js-viz x-col y-col viz-settings)
-                           (update :colors assoc
-                                   :waterfallTotal (or (:waterfall.total_color viz-settings) (nth colors 0))
-                                   :waterfallPositive (or (:waterfall.increase_color viz-settings) (nth colors 1))
-                                   :waterfallNegative (or (:waterfall.decrease_color viz-settings) (nth colors 2)))
-                           (assoc :showTotal show-total))
+        settings       (let [{inc-col :waterfall.increase_color
+                              dec-col :waterfall.decrease_color
+                              total-col :waterfall.total_color} viz-settings]
+                         (-> (->js-viz x-col y-col viz-settings)
+                             (update :colors merge
+                                     (when inc-col {:waterfall.increase_color inc-col})
+                                     (when dec-col {:waterfall.increase_color dec-col})
+                                     (when total-col {:waterfall.increase_color total-col}))
+                             (assoc :showTotal show-total)))
         image-bundle   (image-bundle/make-image-bundle
-                        render-type
-                        (render-fn rows
-                                   labels
-                                   settings))]
+                         render-type
+                         (render-fn rows
+                                    labels
+                                    settings))]
     {:attachments
      (when image-bundle
        (image-bundle/image-bundle->attachment image-bundle))


### PR DESCRIPTION
Fixes #20621

The waterfall chart implementation in js already has default colours hardcoded, so instead of passing the wrong colors
from the backend, rely on the chart's colors.

### Before
Incorrect colours are used for static waterfall charts. This is because the list of colors [here](https://github.com/metabase/metabase/blob/047a336b6b489985f2ef8457acf479174cff4405/src/metabase/pulse/render/body.clj#L362-L366) in the backend is just hardcoded, and seems to be out of date compared to colours hard-coded as defaults in the [Waterfall chart static viz code ](https://github.com/metabase/metabase/blob/f6085da31e4649069a9cbff63d4fdc12f5f3ce4b/frontend/src/metabase/static-viz/components/CategoricalWaterfallChart/CategoricalWaterfallChart.jsx#L57-L64).

To find out where those colour values came from, I compared the static waterfall chart code to the [waterfall chart code we use on the frontend](https://github.com/metabase/metabase/blob/7f1b701aaa3c53dd38ae6a877b6ae666723bfa6f/frontend/src/metabase/visualizations/visualizations/WaterfallChart.jsx#L22-L53), and noticed that:

```
"waterfall.increase_color": { ... getDefault: () => color("accent1") ... }
"waterfall.decrease_color": { ... getDefault: () => color("accent3") ... }
"waterfall.total_color": { ... getDefault: () => color("text-dark") ... }
```

Those colors are defined [here](https://github.com/metabase/metabase/blob/9eaf9c9b8f41003e067c6598d76c6401547bc849/frontend/src/metabase/lib/colors/palette.ts).

Duplicating these colour values in multiple places seems like a bit of an issue, and may also be confusing when a user has altered the colour palette in the Admin panel (Appearance tab).

Since I don't know the best place to put these changes, and have a few open questions: 
 - should the backend always assume sane and correct defaults on the js side?
 - should the backend always look for colors in `public-settings`? and respect them, falling back to defaults if there's nothing there
 - where should we put the defaults? (frontend, backend, hardcoded in static viz components?)

Before having all of these answered, I think it might be useful to merge this PR, as it's a simple change and moves us past the bug, at least.

### After
Colours are correct for static waterfall charts:
<img width="1505" alt="image" src="https://user-images.githubusercontent.com/21064735/184756434-82a8bb90-a579-4d2d-b14e-a0c00bf7114d.png">
(left is static-viz renders, right is the same card in the browsers)

Colors work when explicitly set in visualization settings:
<img width="1505" alt="image" src="https://user-images.githubusercontent.com/21064735/184928948-e5eece11-4e46-47e2-baa2-9c4beab72683.png">

Colors work when the palette is adjusted in 'Appearance' tab of the Admin Panel (Enterprise):
<img width="1482" alt="image" src="https://user-images.githubusercontent.com/21064735/184997513-cce70b45-ebd7-49dd-b247-9463c6cc9c36.png">
