### PR TITLE
Show data point values on static viz

### DIFF
--- a/frontend/src/metabase/internal/components/Layout.jsx
+++ b/frontend/src/metabase/internal/components/Layout.jsx
@@ -105,11 +105,6 @@ export const InternalLayout = fitViewport(({ children }) => {
               <Label>Icons</Label>
             </Link>
           </li>
-          <li>
-            <Link className="link" to={"/_internal/colors"}>
-              <Label>Colors</Label>
-            </Link>
-          </li>
           <li className="my3">
             Components
             <IndentedList>

--- a/frontend/src/metabase/internal/components/Layout.jsx
+++ b/frontend/src/metabase/internal/components/Layout.jsx
@@ -105,6 +105,16 @@ export const InternalLayout = fitViewport(({ children }) => {
               <Label>Icons</Label>
             </Link>
           </li>
+          <li>
+            <Link className="link" to={"/_internal/modals"}>
+              <Label>Modals</Label>
+            </Link>
+          </li>
+          <li>
+            <Link className="link" to={"/_internal/static-viz"}>
+              <Label>Static Visualizations</Label>
+            </Link>
+          </li>
           <li className="my3">
             Components
             <IndentedList>

--- a/frontend/src/metabase/static-viz/components/LineAreaBarChart/LineAreaBarChart.tsx
+++ b/frontend/src/metabase/static-viz/components/LineAreaBarChart/LineAreaBarChart.tsx
@@ -1,3 +1,5 @@
+import { color } from "metabase/lib/colors";
+import { colors } from "metabase/lib/colors/palette";
 import React from "react";
 import { XYChart } from "../XYChart";
 import { ChartSettings, ChartStyle, Series } from "../XYChart/types";
@@ -8,13 +10,6 @@ import {
   getXValuesCount,
 } from "./utils/settings";
 
-const defaultColors = {
-  brand: "#509ee3",
-  brandLight: "#ddecfa",
-  textLight: "#b8bbc3",
-  textMedium: "#949aab",
-};
-
 interface LineAreaBarChartProps {
   series: Series[];
   settings: ChartSettings;
@@ -24,20 +19,20 @@ interface LineAreaBarChartProps {
 const LineAreaBarChart = ({
   series,
   settings,
-  colors,
+  colors: instanceColors,
 }: LineAreaBarChartProps) => {
-  const palette = { ...defaultColors, ...colors };
+  const palette = { ...colors, ...instanceColors };
 
   const chartStyle: ChartStyle = {
     fontFamily: "Lato, sans-serif",
     axes: {
-      color: palette.textLight,
+      color: color("text-light", palette),
       ticks: {
-        color: palette.textMedium,
+        color: color("text-medium", palette),
         fontSize: 11,
       },
       labels: {
-        color: palette.textMedium,
+        color: color("text-medium", palette),
         fontSize: 11,
         fontWeight: 700,
       },
@@ -46,7 +41,12 @@ const LineAreaBarChart = ({
       fontSize: 13,
       lineHeight: 16,
     },
-    goalColor: palette.textMedium,
+    value: {
+      color: color("text-dark", palette),
+      fontSize: 11,
+      fontWeight: 800,
+    },
+    goalColor: color("text-medium", palette),
   };
 
   const minTickSize = chartStyle.axes.ticks.fontSize * 1.5;

--- a/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
@@ -162,6 +162,9 @@ export const XYChart = ({
           yScaleRight={yScaleRight}
           xAccessor={xScale.lineAccessor}
           areStacked={settings.stacking === "stack"}
+          showValues={Boolean(settings.show_values)}
+          valueFormatter={value => formatNumber(value, settings.y.format)}
+          valueProps={labelProps}
         />
         <LineSeries
           series={lines}

--- a/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
@@ -168,6 +168,9 @@ export const XYChart = ({
           yScaleLeft={yScaleLeft}
           yScaleRight={yScaleRight}
           xAccessor={xScale.lineAccessor}
+          showValues={Boolean(settings.show_values)}
+          valueFormatter={value => formatNumber(value, settings.y.format)}
+          valueProps={labelProps}
         />
 
         {settings.goal && (

--- a/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
@@ -80,7 +80,7 @@ export const XYChart = ({
     xTicksDimensions.width,
     settings.labels,
     style.axes.ticks.fontSize,
-    !!settings.goal,
+    !!settings.goal || !!settings.show_values,
   );
 
   const { xMin, xMax, yMin, innerHeight, innerWidth } = calculateBounds(
@@ -151,6 +151,9 @@ export const XYChart = ({
             yScaleRight={yScaleRight}
             xAccessor={xScale.barAccessor}
             bandwidth={xScale.bandwidth}
+            showValues={Boolean(settings.show_values)}
+            valueFormatter={value => formatNumber(value, settings.y.format)}
+            valueProps={labelProps}
           />
         )}
         <AreaSeries

--- a/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
@@ -129,6 +129,14 @@ export const XYChart = ({
     textAnchor: "end",
   };
 
+  const valueProps: Partial<TextProps> = {
+    fontSize: style.value?.fontSize,
+    fontFamily: style.fontFamily,
+    fontWeight: style.value?.fontWeight,
+    fill: style.value?.color,
+    letterSpacing: 0.5,
+  };
+
   const areXTicksRotated = settings.x.tick_display === "rotate-45";
   const areXTicksHidden = settings.x.tick_display === "hide";
   const xLabelOffset = areXTicksHidden ? -style.axes.ticks.fontSize : undefined;
@@ -153,7 +161,7 @@ export const XYChart = ({
             bandwidth={xScale.bandwidth}
             showValues={Boolean(settings.show_values)}
             valueFormatter={value => formatNumber(value, settings.y.format)}
-            valueProps={labelProps}
+            valueProps={valueProps}
           />
         )}
         <AreaSeries
@@ -164,7 +172,7 @@ export const XYChart = ({
           areStacked={settings.stacking === "stack"}
           showValues={Boolean(settings.show_values)}
           valueFormatter={value => formatNumber(value, settings.y.format)}
-          valueProps={labelProps}
+          valueProps={valueProps}
         />
         <LineSeries
           series={lines}
@@ -173,7 +181,7 @@ export const XYChart = ({
           xAccessor={xScale.lineAccessor}
           showValues={Boolean(settings.show_values)}
           valueFormatter={value => formatNumber(value, settings.y.format)}
-          valueProps={labelProps}
+          valueProps={valueProps}
         />
 
         {settings.goal && (

--- a/frontend/src/metabase/static-viz/components/XYChart/shapes/AreaSeries.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/shapes/AreaSeries.tsx
@@ -2,12 +2,16 @@ import React from "react";
 import { Group } from "@visx/group";
 import { PositionScale } from "@visx/shape/lib/types";
 import { LineArea } from "metabase/static-viz/components/XYChart/shapes/LineArea";
-import {
+import { getY } from "metabase/static-viz/components/XYChart/utils";
+import { AreaSeriesStacked } from "./AreaSeriesStacked";
+
+import type {
   Series,
   SeriesDatum,
 } from "metabase/static-viz/components/XYChart/types";
-import { getY } from "metabase/static-viz/components/XYChart/utils";
-import { AreaSeriesStacked } from "./AreaSeriesStacked";
+import { Text, TextProps } from "@visx/text";
+
+const VALUES_MARGIN = 6;
 
 interface AreaSeriesProps {
   series: Series[];
@@ -15,6 +19,9 @@ interface AreaSeriesProps {
   yScaleRight: PositionScale | null;
   xAccessor: (datum: SeriesDatum) => number;
   areStacked?: boolean;
+  showValues: boolean;
+  valueFormatter: (value: number) => string;
+  valueProps: Partial<TextProps>;
 }
 
 export const AreaSeries = ({
@@ -23,6 +30,9 @@ export const AreaSeries = ({
   yScaleRight,
   xAccessor,
   areStacked,
+  showValues,
+  valueFormatter,
+  valueProps,
 }: AreaSeriesProps) => {
   if (areStacked) {
     return (
@@ -45,16 +55,34 @@ export const AreaSeries = ({
           return null;
         }
 
+        const yAccessor = (d: SeriesDatum) => yScale(getY(d)) ?? 0;
         return (
-          <LineArea
-            key={s.name}
-            yScale={yScale}
-            color={s.color}
-            data={s.data}
-            x={xAccessor as any}
-            y={d => yScale(getY(d)) ?? 0}
-            y1={yScale(0) ?? 0}
-          />
+          <>
+            <LineArea
+              key={s.name}
+              yScale={yScale}
+              color={s.color}
+              data={s.data}
+              x={xAccessor}
+              y={yAccessor}
+              y1={yScale(0) ?? 0}
+            />
+            {showValues &&
+              s.data.map((datum, index) => {
+                return (
+                  <Text
+                    key={index}
+                    x={xAccessor(datum)}
+                    y={yAccessor(datum) - VALUES_MARGIN}
+                    textAnchor="middle"
+                    verticalAnchor="end"
+                    {...valueProps}
+                  >
+                    {valueFormatter(getY(datum))}
+                  </Text>
+                );
+              })}
+          </>
         );
       })}
     </Group>

--- a/frontend/src/metabase/static-viz/components/XYChart/shapes/AreaSeries.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/shapes/AreaSeries.tsx
@@ -74,7 +74,7 @@ export const AreaSeries = ({
           />
         );
       })}
-      {/* Render all data point values last so they stay on top of the area chart background making them more legible */}
+      {/* Render all data point values last so they stay on top of the chart elements making them more legible */}
       {showValues &&
         series.map(s => {
           const yScale = s.yAxisPosition === "left" ? yScaleLeft : yScaleRight;

--- a/frontend/src/metabase/static-viz/components/XYChart/shapes/AreaSeries.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/shapes/AreaSeries.tsx
@@ -42,6 +42,9 @@ export const AreaSeries = ({
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         yScale={yScaleLeft!}
         xAccessor={xAccessor}
+        showValues={showValues}
+        valueFormatter={valueFormatter}
+        valueProps={valueProps}
       />
     );
   }

--- a/frontend/src/metabase/static-viz/components/XYChart/shapes/AreaSeries.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/shapes/AreaSeries.tsx
@@ -57,34 +57,42 @@ export const AreaSeries = ({
 
         const yAccessor = (d: SeriesDatum) => yScale(getY(d)) ?? 0;
         return (
-          <>
-            <LineArea
-              key={s.name}
-              yScale={yScale}
-              color={s.color}
-              data={s.data}
-              x={xAccessor}
-              y={yAccessor}
-              y1={yScale(0) ?? 0}
-            />
-            {showValues &&
-              s.data.map((datum, index) => {
-                return (
-                  <Text
-                    key={index}
-                    x={xAccessor(datum)}
-                    y={yAccessor(datum) - VALUES_MARGIN}
-                    textAnchor="middle"
-                    verticalAnchor="end"
-                    {...valueProps}
-                  >
-                    {valueFormatter(getY(datum))}
-                  </Text>
-                );
-              })}
-          </>
+          <LineArea
+            key={s.name}
+            yScale={yScale}
+            color={s.color}
+            data={s.data}
+            x={xAccessor}
+            y={yAccessor}
+            y1={yScale(0) ?? 0}
+          />
         );
       })}
+      {/* Render all data point values last so they stay on top of the area chart background making them more legible */}
+      {showValues &&
+        series.map(s => {
+          const yScale = s.yAxisPosition === "left" ? yScaleLeft : yScaleRight;
+
+          if (!yScale) {
+            return null;
+          }
+
+          const yAccessor = (d: SeriesDatum) => yScale(getY(d)) ?? 0;
+          return s.data.map((datum, index) => {
+            return (
+              <Text
+                key={index}
+                x={xAccessor(datum)}
+                y={yAccessor(datum) - VALUES_MARGIN}
+                textAnchor="middle"
+                verticalAnchor="end"
+                {...valueProps}
+              >
+                {valueFormatter(getY(datum))}
+              </Text>
+            );
+          });
+        })}
     </Group>
   );
 };

--- a/frontend/src/metabase/static-viz/components/XYChart/shapes/AreaSeries.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/shapes/AreaSeries.tsx
@@ -22,6 +22,7 @@ interface AreaSeriesProps {
   showValues: boolean;
   valueFormatter: (value: number) => string;
   valueProps: Partial<TextProps>;
+  valueStep: number;
 }
 
 export const AreaSeries = ({
@@ -33,6 +34,7 @@ export const AreaSeries = ({
   showValues,
   valueFormatter,
   valueProps,
+  valueStep,
 }: AreaSeriesProps) => {
   if (areStacked) {
     return (
@@ -45,6 +47,7 @@ export const AreaSeries = ({
         showValues={showValues}
         valueFormatter={valueFormatter}
         valueProps={valueProps}
+        valueStep={valueStep}
       />
     );
   }
@@ -83,16 +86,18 @@ export const AreaSeries = ({
           const yAccessor = (d: SeriesDatum) => yScale(getY(d)) ?? 0;
           return s.data.map((datum, index) => {
             return (
-              <Text
-                key={index}
-                x={xAccessor(datum)}
-                y={yAccessor(datum) - VALUES_MARGIN}
-                textAnchor="middle"
-                verticalAnchor="end"
-                {...valueProps}
-              >
-                {valueFormatter(getY(datum))}
-              </Text>
+              index % valueStep === 0 && (
+                <Text
+                  key={index}
+                  x={xAccessor(datum)}
+                  y={yAccessor(datum) - VALUES_MARGIN}
+                  textAnchor="middle"
+                  verticalAnchor="end"
+                  {...valueProps}
+                >
+                  {valueFormatter(getY(datum))}
+                </Text>
+              )
             );
           });
         })}

--- a/frontend/src/metabase/static-viz/components/XYChart/shapes/AreaSeriesStacked.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/shapes/AreaSeriesStacked.tsx
@@ -5,20 +5,33 @@ import { LineArea } from "metabase/static-viz/components/XYChart/shapes/LineArea
 import {
   HydratedSeries,
   SeriesDatum,
+  StackedDatum,
 } from "metabase/static-viz/components/XYChart/types";
 import { getY, getY1 } from "metabase/static-viz/components/XYChart/utils";
+import { Text } from "@visx/text";
+
+import type { TextProps } from "@visx/text";
+
+const VALUES_MARGIN = 6;
 
 interface AreaSeriesProps {
   series: HydratedSeries[];
   yScale: PositionScale;
   xAccessor: (datum: SeriesDatum) => number;
+  showValues: boolean;
+  valueFormatter: (value: number) => string;
+  valueProps: Partial<TextProps>;
 }
 
 export const AreaSeriesStacked = ({
   series,
   yScale,
   xAccessor,
+  showValues,
+  valueFormatter,
+  valueProps,
 }: AreaSeriesProps) => {
+  const yAccessor = (d: StackedDatum) => yScale(getY(d)) ?? 0;
   return (
     <Group>
       {series.map(s => {
@@ -34,6 +47,22 @@ export const AreaSeriesStacked = ({
           />
         );
       })}
+      {/* Render all data point values last so they stay on top of the area chart background making them more legible */}
+      {showValues &&
+        series[series.length - 1].stackedData?.map((datum, index) => {
+          return (
+            <Text
+              key={index}
+              x={(xAccessor as any)(datum)}
+              y={yAccessor(datum) - VALUES_MARGIN}
+              textAnchor="middle"
+              verticalAnchor="end"
+              {...valueProps}
+            >
+              {valueFormatter(getY(datum))}
+            </Text>
+          );
+        })}
     </Group>
   );
 };

--- a/frontend/src/metabase/static-viz/components/XYChart/shapes/AreaSeriesStacked.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/shapes/AreaSeriesStacked.tsx
@@ -21,6 +21,7 @@ interface AreaSeriesProps {
   showValues: boolean;
   valueFormatter: (value: number) => string;
   valueProps: Partial<TextProps>;
+  valueStep: number;
 }
 
 export const AreaSeriesStacked = ({
@@ -30,6 +31,7 @@ export const AreaSeriesStacked = ({
   showValues,
   valueFormatter,
   valueProps,
+  valueStep,
 }: AreaSeriesProps) => {
   const yAccessor = (d: StackedDatum) => yScale(getY(d)) ?? 0;
   return (
@@ -51,16 +53,18 @@ export const AreaSeriesStacked = ({
       {showValues &&
         series[series.length - 1].stackedData?.map((datum, index) => {
           return (
-            <Text
-              key={index}
-              x={(xAccessor as any)(datum)}
-              y={yAccessor(datum) - VALUES_MARGIN}
-              textAnchor="middle"
-              verticalAnchor="end"
-              {...valueProps}
-            >
-              {valueFormatter(getY(datum))}
-            </Text>
+            index % valueStep === 0 && (
+              <Text
+                key={index}
+                x={(xAccessor as any)(datum)}
+                y={yAccessor(datum) - VALUES_MARGIN}
+                textAnchor="middle"
+                verticalAnchor="end"
+                {...valueProps}
+              >
+                {valueFormatter(getY(datum))}
+              </Text>
+            )
           );
         })}
     </Group>

--- a/frontend/src/metabase/static-viz/components/XYChart/shapes/AreaSeriesStacked.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/shapes/AreaSeriesStacked.tsx
@@ -49,7 +49,7 @@ export const AreaSeriesStacked = ({
           />
         );
       })}
-      {/* Render all data point values last so they stay on top of the area chart background making them more legible */}
+      {/* Render all data point values last so they stay on top of the chart elements making them more legible */}
       {showValues &&
         series[series.length - 1].stackedData?.map((datum, index) => {
           return (

--- a/frontend/src/metabase/static-viz/components/XYChart/shapes/BarSeries.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/shapes/BarSeries.tsx
@@ -3,11 +3,16 @@ import { Bar } from "@visx/shape";
 import { Group } from "@visx/group";
 import { scaleBand } from "@visx/scale";
 import { PositionScale } from "@visx/shape/lib/types";
-import {
+import { getY } from "metabase/static-viz/components/XYChart/utils";
+import { Text } from "@visx/text";
+
+import type {
   Series,
   SeriesDatum,
 } from "metabase/static-viz/components/XYChart/types";
-import { getY } from "metabase/static-viz/components/XYChart/utils";
+import type { TextProps } from "@visx/text";
+
+const VALUES_MARGIN = 6;
 
 interface BarSeriesProps {
   series: Series[];
@@ -15,6 +20,9 @@ interface BarSeriesProps {
   yScaleRight: PositionScale | null;
   xAccessor: (datum: SeriesDatum) => number;
   bandwidth: number;
+  showValues: boolean;
+  valueFormatter: (value: number) => string;
+  valueProps: Partial<TextProps>;
 }
 
 export const BarSeries = ({
@@ -23,6 +31,9 @@ export const BarSeries = ({
   yScaleRight,
   xAccessor,
   bandwidth,
+  showValues,
+  valueFormatter,
+  valueProps,
 }: BarSeriesProps) => {
   const innerBarScaleDomain = series.map((_, index) => index);
 
@@ -56,14 +67,28 @@ export const BarSeries = ({
               const height = Math.abs(yValue - yZero);
 
               return (
-                <Bar
-                  key={index}
-                  fill={series.color}
-                  width={width}
-                  height={height}
-                  x={x}
-                  y={y}
-                />
+                <>
+                  <Bar
+                    key={index}
+                    fill={series.color}
+                    width={width}
+                    height={height}
+                    x={x}
+                    y={y}
+                  />
+                  {showValues && (
+                    <Text
+                      x={x + width / 2}
+                      y={y - VALUES_MARGIN}
+                      width={width}
+                      textAnchor="middle"
+                      verticalAnchor="end"
+                      {...valueProps}
+                    >
+                      {valueFormatter(getY(datum))}
+                    </Text>
+                  )}
+                </>
               );
             })}
           </Fragment>

--- a/frontend/src/metabase/static-viz/components/XYChart/shapes/BarSeries.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/shapes/BarSeries.tsx
@@ -23,6 +23,7 @@ interface BarSeriesProps {
   showValues: boolean;
   valueFormatter: (value: number) => string;
   valueProps: Partial<TextProps>;
+  valueStep: number;
 }
 
 export const BarSeries = ({
@@ -34,6 +35,7 @@ export const BarSeries = ({
   showValues,
   valueFormatter,
   valueProps,
+  valueStep,
 }: BarSeriesProps) => {
   const innerBarScaleDomain = series.map((_, index) => index);
 
@@ -76,7 +78,7 @@ export const BarSeries = ({
                     x={x}
                     y={y}
                   />
-                  {showValues && (
+                  {showValues && index % valueStep === 0 && (
                     <Text
                       x={x + width / 2}
                       y={y - VALUES_MARGIN}

--- a/frontend/src/metabase/static-viz/components/XYChart/shapes/BarSeries.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/shapes/BarSeries.tsx
@@ -69,28 +69,41 @@ export const BarSeries = ({
               const height = Math.abs(yValue - yZero);
 
               return (
-                <>
-                  <Bar
-                    key={index}
-                    fill={series.color}
+                <Bar
+                  key={index}
+                  fill={series.color}
+                  width={width}
+                  height={height}
+                  x={x}
+                  y={y}
+                />
+              );
+            })}
+            {/* Render all data point values last so they stay on top of the chart elements making them more legible */}
+            {series.data.map((datum, index) => {
+              const groupX = xAccessor(datum);
+              const innerX = innerBarScale(seriesIndex) ?? 0;
+
+              const x = groupX + innerX;
+              const width = innerBarScale.bandwidth();
+
+              const yZero = yScale(0) ?? 0;
+              const yValue = yScale(getY(datum)) ?? 0;
+              const y = Math.min(yValue, yZero);
+              return (
+                showValues &&
+                index % valueStep === 0 && (
+                  <Text
+                    x={x + width / 2}
+                    y={y - VALUES_MARGIN}
                     width={width}
-                    height={height}
-                    x={x}
-                    y={y}
-                  />
-                  {showValues && index % valueStep === 0 && (
-                    <Text
-                      x={x + width / 2}
-                      y={y - VALUES_MARGIN}
-                      width={width}
-                      textAnchor="middle"
-                      verticalAnchor="end"
-                      {...valueProps}
-                    >
-                      {valueFormatter(getY(datum))}
-                    </Text>
-                  )}
-                </>
+                    textAnchor="middle"
+                    verticalAnchor="end"
+                    {...valueProps}
+                  >
+                    {valueFormatter(getY(datum))}
+                  </Text>
+                )
               );
             })}
           </Fragment>

--- a/frontend/src/metabase/static-viz/components/XYChart/shapes/LineSeries.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/shapes/LineSeries.tsx
@@ -21,6 +21,7 @@ interface LineSeriesProps {
   showValues: boolean;
   valueFormatter: (value: number) => string;
   valueProps: Partial<TextProps>;
+  valueStep: number;
 }
 
 export const LineSeries = ({
@@ -31,6 +32,7 @@ export const LineSeries = ({
   showValues,
   valueFormatter,
   valueProps,
+  valueStep,
 }: LineSeriesProps) => {
   return (
     <Group>
@@ -61,15 +63,17 @@ export const LineSeries = ({
                   (index >= s.data.length - 1 ||
                     getY(s.data[index + 1]) > getY(datum));
                 return (
-                  <Value
-                    key={index}
-                    x={xAccessor(datum)}
-                    y={yAccessor(datum)}
-                    valueProps={valueProps}
-                    showLabelBelow={showLabelBelow}
-                  >
-                    {valueFormatter(getY(datum))}
-                  </Value>
+                  index % valueStep === 0 && (
+                    <Value
+                      key={index}
+                      x={xAccessor(datum)}
+                      y={yAccessor(datum)}
+                      valueProps={valueProps}
+                      showLabelBelow={showLabelBelow}
+                    >
+                      {valueFormatter(getY(datum))}
+                    </Value>
+                  )
                 );
               })}
           </>

--- a/frontend/src/metabase/static-viz/components/XYChart/shapes/LineSeries.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/shapes/LineSeries.tsx
@@ -3,16 +3,24 @@ import { Group } from "@visx/group";
 import { LinePath } from "@visx/shape";
 import { PositionScale } from "@visx/shape/lib/types";
 import { getY } from "metabase/static-viz/components/XYChart/utils";
-import {
+import { Text } from "@visx/text";
+
+import type {
   Series,
   SeriesDatum,
 } from "metabase/static-viz/components/XYChart/types";
+import type { TextProps } from "@visx/text";
+
+const VALUES_MARGIN = 6;
 
 interface LineSeriesProps {
   series: Series[];
   yScaleLeft: PositionScale | null;
   yScaleRight: PositionScale | null;
   xAccessor: (datum: SeriesDatum) => number;
+  showValues: boolean;
+  valueFormatter: (value: number) => string;
+  valueProps: Partial<TextProps>;
 }
 
 export const LineSeries = ({
@@ -20,6 +28,9 @@ export const LineSeries = ({
   yScaleLeft,
   yScaleRight,
   xAccessor,
+  showValues,
+  valueFormatter,
+  valueProps,
 }: LineSeriesProps) => {
   return (
     <Group>
@@ -29,17 +40,63 @@ export const LineSeries = ({
           return null;
         }
 
+        const yAccessor = (datum: SeriesDatum) => yScale(getY(datum)) ?? 0;
         return (
-          <LinePath
-            key={s.name}
-            data={s.data}
-            x={xAccessor}
-            y={d => yScale(getY(d)) ?? 0}
-            stroke={s.color}
-            strokeWidth={2}
-          />
+          <>
+            <LinePath
+              key={s.name}
+              data={s.data}
+              x={xAccessor}
+              y={yAccessor}
+              stroke={s.color}
+              strokeWidth={2}
+            />
+            {showValues &&
+              s.data.map((datum, index) => {
+                // Use the similar logic as presented in https://github.com/metabase/metabase/blob/3f4ca9c70bd263a7579613971ea8d7c47b1f776e/frontend/src/metabase/visualizations/lib/chart_values.js#L130
+                const showLabelBelow =
+                  // first point or prior is greater than y
+                  (index === 0 || getY(s.data[index - 1]) > getY(datum)) &&
+                  // last point point or next is greater than y
+                  (index >= s.data.length - 1 ||
+                    getY(s.data[index + 1]) > getY(datum));
+                return (
+                  <Value
+                    key={index}
+                    x={xAccessor(datum)}
+                    y={yAccessor(datum)}
+                    valueProps={valueProps}
+                    showLabelBelow={showLabelBelow}
+                  >
+                    {valueFormatter(getY(datum))}
+                  </Value>
+                );
+              })}
+          </>
         );
       })}
     </Group>
   );
 };
+
+interface ValueProps {
+  x: number;
+  y: number;
+  valueProps: Partial<TextProps>;
+  children: string;
+  showLabelBelow: boolean;
+}
+
+function Value({ x, y, valueProps, children, showLabelBelow }: ValueProps) {
+  return (
+    <Text
+      x={x}
+      y={showLabelBelow ? y + VALUES_MARGIN : y - VALUES_MARGIN}
+      textAnchor="middle"
+      verticalAnchor={showLabelBelow ? "start" : "end"}
+      {...valueProps}
+    >
+      {children}
+    </Text>
+  );
+}

--- a/frontend/src/metabase/static-viz/components/XYChart/types.ts
+++ b/frontend/src/metabase/static-viz/components/XYChart/types.ts
@@ -48,6 +48,7 @@ export type ChartSettings = {
     value: number;
     label: string;
   };
+  show_values?: boolean;
   labels: {
     left?: string;
     bottom?: string;

--- a/frontend/src/metabase/static-viz/components/XYChart/types.ts
+++ b/frontend/src/metabase/static-viz/components/XYChart/types.ts
@@ -86,5 +86,10 @@ export type ChartStyle = {
     fontSize: number;
     lineHeight: number;
   };
+  value?: {
+    color: string;
+    fontSize: number;
+    fontWeight: number;
+  };
   goalColor: string;
 };

--- a/frontend/src/metabase/static-viz/components/XYChart/utils/index.ts
+++ b/frontend/src/metabase/static-viz/components/XYChart/utils/index.ts
@@ -4,3 +4,4 @@ export * from "./ticks";
 export * from "./margin";
 export * from "./legend";
 export * from "./bounds";
+export * from "./values";

--- a/frontend/src/metabase/static-viz/components/XYChart/utils/margin.ts
+++ b/frontend/src/metabase/static-viz/components/XYChart/utils/margin.ts
@@ -3,7 +3,7 @@ import { CHART_PADDING } from "metabase/static-viz/components/XYChart/constants"
 import { ChartSettings } from "metabase/static-viz/components/XYChart/types";
 
 export const LABEL_OFFSET = 10;
-export const GOAL_MARGIN = 6;
+export const MARGIN = 6;
 
 const calculateSideMargin = (
   tickSpace: number,
@@ -27,12 +27,12 @@ export const calculateMargin = (
   xTickWidth: number,
   labels: ChartSettings["labels"],
   labelFontSize: number,
-  hasGoalLine?: boolean,
+  hasMargin?: boolean,
 ) => {
   const minHorizontalMargin = xTickWidth / 2;
 
   return {
-    top: hasGoalLine ? GOAL_MARGIN + CHART_PADDING : CHART_PADDING,
+    top: hasMargin ? MARGIN + CHART_PADDING : CHART_PADDING,
     left: calculateSideMargin(
       leftYTickWidth,
       labelFontSize,

--- a/frontend/src/metabase/static-viz/components/XYChart/utils/values.ts
+++ b/frontend/src/metabase/static-viz/components/XYChart/utils/values.ts
@@ -1,0 +1,33 @@
+import { getY } from "./series";
+
+import type { TextProps } from "@visx/text";
+import type { HydratedSeries } from "../types";
+import { measureText } from "metabase/static-viz/lib/text";
+
+// Use the same logic as in https://github.com/metabase/metabase/blob/72d23d2b8e5a1f93b288e5a8738758c9b05d3766/frontend/src/metabase/visualizations/lib/chart_values.js#L318
+export function getValueStep(
+  series: HydratedSeries[],
+  valueFormatter: (value: number) => string,
+  valueProps: Partial<TextProps>,
+  chartWidth: number,
+) {
+  if (series.length === 0) {
+    return 1;
+  }
+  const maxSeriesLength = Math.max(...series.map(serie => serie.data.length));
+  const LABEL_PADDING = 6;
+  const MAX_SAMPLE_SIZE = 30;
+  const sampleStep = Math.ceil(maxSeriesLength / MAX_SAMPLE_SIZE);
+  const sample = series[0].data.filter((_, index) => index % sampleStep === 0);
+  const totalWidth = sample.reduce(
+    (sum, sampledData) =>
+      sum +
+      measureText(
+        valueFormatter(getY(sampledData)),
+        valueProps.fontSize as number,
+      ),
+    0,
+  );
+  const labelWidth = totalWidth / sample.length + LABEL_PADDING;
+  return Math.ceil((labelWidth * maxSeriesLength) / chartWidth);
+}

--- a/frontend/src/metabase/static-viz/lib/numbers.ts
+++ b/frontend/src/metabase/static-viz/lib/numbers.ts
@@ -1,5 +1,5 @@
 export type NumberFormatOptions = {
-  number_style?: string;
+  number_style?: "currency" | "decimal" | "scientific" | "percentage";
   currency?: string;
   currency_style?: string;
   number_separators?: ".,";
@@ -7,10 +7,11 @@ export type NumberFormatOptions = {
   scale?: number;
   prefix?: string;
   suffix?: string;
+  compact?: boolean;
 };
 
 const DEFAULT_OPTIONS = {
-  number_style: "decimal",
+  number_style: "decimal" as NumberFormatOptions["number_style"],
   currency: undefined,
   currency_style: "symbol",
   number_separators: ".,",
@@ -30,17 +31,33 @@ export const formatNumber = (number: number, options?: NumberFormatOptions) => {
     scale,
     prefix,
     suffix,
+    compact,
   } = { ...DEFAULT_OPTIONS, ...options };
 
-  const format = new Intl.NumberFormat("en", {
-    style: number_style !== "scientific" ? number_style : "decimal",
-    notation: number_style !== "scientific" ? "standard" : "scientific",
-    currency: currency,
-    currencyDisplay: currency_style,
-    useGrouping: true,
-    minimumFractionDigits: decimals,
-    maximumFractionDigits: decimals != null ? decimals : 2,
-  });
+  function createFormat(compact?: boolean) {
+    if (compact) {
+      return new Intl.NumberFormat("en", {
+        style: number_style !== "scientific" ? number_style : "decimal",
+        notation: "compact",
+        compactDisplay: "short",
+        currency: currency,
+        currencyDisplay: currency_style,
+        useGrouping: true,
+      });
+    }
+
+    return new Intl.NumberFormat("en", {
+      style: number_style !== "scientific" ? number_style : "decimal",
+      notation: number_style !== "scientific" ? "standard" : "scientific",
+      currency: currency,
+      currencyDisplay: currency_style,
+      useGrouping: true,
+      minimumFractionDigits: decimals,
+      maximumFractionDigits: decimals != null ? decimals : 2,
+    });
+  }
+
+  const format = createFormat(compact);
 
   const formattedNumber = format
     .format(number * scale)

--- a/src/metabase/pulse/render/js_svg.clj
+++ b/src/metabase/pulse/render/js_svg.clj
@@ -180,15 +180,6 @@
                                                   (json/generate-string (public-settings/application-colors))))]
     (svg-string->bytes svg-string)))
 
-(defn categorical-bar
-  "Clojure entrypoint to render a categorical bar chart. Rows should be tuples of [stringable numeric-value]. Labels is
-  a map of {:left \"left-label\" :botton \"bottom-label\". Returns a byte array of a png file."
-  [rows labels settings]
-  (let [svg-string (.asString (js/execute-fn-name @context "categorical_bar" rows
-                                                  (map (fn [[k v]] [(name k) v]) labels)
-                                                  (json/generate-string settings)))]
-    (svg-string->bytes svg-string)))
-
 (defn categorical-area
   "Clojure entrypoint to render a categorical area chart. Rows should be tuples of [stringable numeric-value]. Labels is a
   map of {:left \"left-label\" :botton \"bottom-label\"}. Returns a byte array of a png file."


### PR DESCRIPTION
> **Warning**
> There are a few hacks I make on BE to show the actual result, and those shouldn't be merged. Once the BE is properly implemented these hacks should be removed from this PR.
> - https://github.com/metabase/metabase/pull/24813/commits/f1ce21efbf11e6d3624eab286171e92d18a01ca6
> - https://github.com/metabase/metabase/pull/24813/commits/c5d1b1be685f74c95ddc7a07ebc313be142ebf29

EPIC: #24759
Issue: #20554

## Todos
- [x] Bar
- [x] Line
- [x] Area
- [x] Stacked Area
- [x] Long values (shorten numbers like 100k, 1m)
- [x] Crowded lines
- [x] Crowded bars
- [x] Crowded areas

## How to test
- Checkout this PR and add changes from these 2 commits manually (without them static viz won't render any data point values when rendering with BE)
    - https://github.com/metabase/metabase/commit/f1ce21efbf11e6d3624eab286171e92d18a01ca6
    - https://github.com/metabase/metabase/commit/c5d1b1be685f74c95ddc7a07ebc313be142ebf29
- Set up an email e.g. using `maildev` with `docker run -p 25:25 -p 80:80 -d --rm maildev/maildev:1.1.0`
- Start adding a bunch of charts with data point value enabled to a dashboard and send a dashboard subscription.
    - The reason to test with dashboard subscription because you can instantly send an email rather than having to wait for a pulse
    ![image](https://user-images.githubusercontent.com/1937582/186085758-62dfa7a2-11bb-4e60-bd57-a11ecb7d38dd.png)

---
The following todos will be addressed in a separate PR (https://github.com/metabase/metabase/pull/24938)
- [ ] Multiseries bars
- [ ] Close to chart edges labels should be visible
- [ ] Negative bars


<img width="640" alt="Screen Shot 2022-08-17 at 1 24 09 PM" src="https://user-images.githubusercontent.com/14301985/185084090-80224720-9523-4171-b02c-e62774deb914.png">


<img width="638" alt="Screen Shot 2022-08-17 at 1 24 17 PM" src="https://user-images.githubusercontent.com/14301985/185084128-4fe21a1e-591d-44cf-ac9a-68c71ee281fd.png">

---

## Results

### Bar chart
#### Dashboard
![image](https://user-images.githubusercontent.com/1937582/184912766-bd99b3d6-2f4d-4ab3-a281-970befe9884d.png)

#### Static viz
![image](https://user-images.githubusercontent.com/1937582/184912618-3d2098ed-373d-490e-bb9b-11f2f94f9a6a.png)

### Line chart
#### Dashboard
![image](https://user-images.githubusercontent.com/1937582/184912537-b75384b4-68df-4b65-be7c-5d288ea298db.png)

#### Static viz
![image](https://user-images.githubusercontent.com/1937582/184912556-8f0f9741-4760-461a-9136-f582822be145.png)

### Area chart
#### Dashboard
![image](https://user-images.githubusercontent.com/1937582/184912716-ac4d751e-a1c4-46e1-ba35-2ee2a83f4035.png)

#### Static viz
![image](https://user-images.githubusercontent.com/1937582/184912661-77d0a24f-e80d-402f-a57b-f7e74fe75a9c.png)

### Stacked area chart
![image](https://user-images.githubusercontent.com/1937582/185419380-18b88d0c-f31d-43c5-9333-e2b9aca31ad9.png)

### Automatic compact value format
![image](https://user-images.githubusercontent.com/1937582/185419575-c2045ad3-63f8-4e6d-9611-c9605ec1f087.png)

### Crowded lines
![image](https://user-images.githubusercontent.com/1937582/185645074-8e7863a1-0016-4836-b4b0-6b0268f55564.png)

### Crowded bars
![image](https://user-images.githubusercontent.com/1937582/185647141-7cf1c01e-cf79-456e-a617-bd15cefb4ad3.png)

### Crowded areas
![image](https://user-images.githubusercontent.com/1937582/185647161-a8619593-ace5-4f50-8365-6030f0c1d724.png)
