### PR TITLE
docs - embedding

### DIFF
--- a/docs/embedding/start.md
+++ b/docs/embedding/start.md
@@ -6,24 +6,34 @@ title: Dashboards overview
 
 ## [Introduction to embedding](./introduction.md)
 
-How to embed charts and dashboards in applications and websites.
+Share your data securely.
 
-## [Public links](./public-links.md)
+## [Signed embedding](./signed-embedding.md)
 
-Sharing questions using public links.
+Put interactive charts and dashboards in your app.
 
 ## [Full-app embedding](./full-app-embedding.md)
 
-How to embed the graphical query builder and more in your application.
+Put interactive charts, dashboards, _and_ the [query builder](/glossary/query_builder) in your app.
+
+# Sharing results externally
+
+Make your data open to the public.
+
+## [Public links](./public-links)
+
+Send someone a link to your chart or dashboard, and tell them not to share it.
+
+## iframes
+
+Display a public link inside an iframe.
+
+# Appearance
+
+## [Appearance](./whitelabeling.md)
+
+Customize the look and feel of your charts and dashboards.
 
 ## [Customize embeds](./customize-embeds.md)
 
-Introduction to customizing embedded charts and dashboards.
-
-## [Whitelabeling](./whitelabeling.md)
-
-How to customize the look and feel of embedded charts and dashboards to match your application's branding.
-
-## [Fonts](./fonts.md)
-
-How to customize the fonts in your charts and dashboards.
+Additional customization for _embedded_ charts and dashboards.


### PR DESCRIPTION
Putting up an outline to show what I'm hoping to clarify (without necessarily moving things around!).

The goal is to make it clear that the "Embedding" feature only covers signed and full-app options, to help [customers and our sales team talk about pricing](https://metabase.zendesk.com/agent/tickets/11679).

To help make the Embedding definition clear, we also want to separate out related, but independent features:
- Public sharing (public links, iframes)
- Appearance (plus a note about _embedding-only_ appearance settings).

It should be easy to tell that you can:
- Customize the Appearance of your own instance, and share a public link -- without paying for additional seats because of Embedding customers. 
- Pay for additional seats for your Embedding customers to get _secure_ sharing, and use all of the regular Appearance settings for your embedded stuff, plus some bonus embedding-only Appearance options.
- Pick between two kinds of embedding, depending on how funky you want to get with self-serve.
