### PR TITLE
Fix Dimension instance mismatch problems when filtering via a native Model's remapped field

### DIFF
--- a/frontend/src/metabase-lib/lib/Dimension.ts
+++ b/frontend/src/metabase-lib/lib/Dimension.ts
@@ -1141,9 +1141,14 @@ export class FieldDimension extends Dimension {
     if (this.fk()) {
       const fkDisplayName =
         this.fk() && stripId(this.fk().field().displayName());
-      displayName = `${fkDisplayName} ${FK_SYMBOL} ${displayName}`;
+      if (!displayName.startsWith(`${fkDisplayName} ${FK_SYMBOL}`)) {
+        displayName = `${fkDisplayName} ${FK_SYMBOL} ${displayName}`;
+      }
     } else if (this.joinAlias()) {
-      displayName = `${this.joinAlias()} ${FK_SYMBOL} ${displayName}`;
+      const joinAlias = this.joinAlias();
+      if (!displayName.startsWith(`${joinAlias} ${FK_SYMBOL}`)) {
+        displayName = `${joinAlias} ${FK_SYMBOL} ${displayName}`;
+      }
     }
 
     if (this.temporalUnit()) {

--- a/frontend/src/metabase-lib/lib/Dimension.ts
+++ b/frontend/src/metabase-lib/lib/Dimension.ts
@@ -565,6 +565,10 @@ export default class Dimension {
     return this.withoutOptions("binning");
   }
 
+  withoutJoinAlias(): Dimension {
+    return this.withoutOptions("join-alias");
+  }
+
   /**
    * Return a copy of this Dimension with any temporal bucketing or binning options removed.
    */

--- a/frontend/src/metabase-lib/lib/Dimension.ts
+++ b/frontend/src/metabase-lib/lib/Dimension.ts
@@ -982,8 +982,10 @@ export class FieldDimension extends Dimension {
       { ...this._options, ...options },
       this._metadata,
       this._query,
-      this._fieldInstance && {
+      {
         _fieldInstance: this._fieldInstance,
+        _subDisplayName: this._subDisplayName,
+        _subTriggerDisplayName: this._subTriggerDisplayName,
       },
     );
   }

--- a/frontend/src/metabase-lib/lib/metadata/Field.ts
+++ b/frontend/src/metabase-lib/lib/metadata/Field.ts
@@ -245,6 +245,8 @@ class FieldInner extends Base {
     if (Array.isArray(this.id)) {
       // if ID is an array, it's a MBQL field reference, typically "field"
       return this.id;
+    } else if (this.field_ref) {
+      return this.field_ref;
     } else {
       return ["field", this.id, null];
     }

--- a/frontend/src/metabase-lib/lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/lib/queries/StructuredQuery.ts
@@ -330,28 +330,51 @@ class StructuredQueryInner extends AtomicQuery {
     const sourceQuery = this.sourceQuery();
 
     if (sourceQuery) {
+      const columnNames = sourceQuery.columnNames();
+      const fields = sourceQuery.columnDimensions().map((d, i) => {
+        const name = columnNames[i];
+        const field = d.field();
+        const field_ref =
+          field.field_ref?.[1] != null
+            ? field.field_ref
+            : [
+                "field",
+                name,
+                {
+                  "base-type": field.base_type,
+                },
+              ];
+
+        return new Field({
+          ...field,
+          id: field_ref,
+        });
+      });
+
+      // const fields = sourceQuery.columns().map(
+      //   column =>
+      //     new Field({
+      //       ...column,
+      //       // TODO FIXME -- Do NOT use field-literal unless you're referring to a native query
+      // id: [
+      //   "field",
+      //   column.name,
+      //   {
+      //     "base-type": column.base_type,
+      //   },
+      // ],
+      //       source: "fields",
+      //       // HACK: need to thread the query through to this fake Field
+      //       query: this,
+      //     }),
+      // )
+
       return new Table({
         id: this.sourceTableId(),
         name: "",
         display_name: "",
         db: sourceQuery.database(),
-        fields: sourceQuery.columns().map(
-          column =>
-            new Field({
-              ...column,
-              // TODO FIXME -- Do NOT use field-literal unless you're referring to a native query
-              id: [
-                "field",
-                column.name,
-                {
-                  "base-type": column.base_type,
-                },
-              ],
-              source: "fields",
-              // HACK: need to thread the query through to this fake Field
-              query: this,
-            }),
-        ),
+        fields,
         segments: [],
         metrics: [],
       });

--- a/frontend/src/metabase-lib/lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/lib/queries/StructuredQuery.ts
@@ -330,44 +330,24 @@ class StructuredQueryInner extends AtomicQuery {
     const sourceQuery = this.sourceQuery();
 
     if (sourceQuery) {
-      const columnNames = sourceQuery.columnNames();
-      const fields = sourceQuery.columnDimensions().map((d, i) => {
-        const name = columnNames[i];
-        const field = d.field();
-        const field_ref =
-          field.field_ref?.[1] != null
-            ? field.field_ref
-            : [
-                "field",
-                name,
-                {
-                  "base-type": field.base_type,
-                },
-              ];
+      const fields = sourceQuery.columns().map(column => {
+        const id = [
+          "field",
+          column.name,
+          {
+            "base-type": column.base_type,
+          },
+        ];
 
         return new Field({
-          ...field,
-          id: field_ref,
+          ...column,
+          // TODO FIXME -- Do NOT use field-literal unless you're referring to a native query
+          id,
+          source: "fields",
+          // HACK: need to thread the query through to this fake Field
+          query: this,
         });
       });
-
-      // const fields = sourceQuery.columns().map(
-      //   column =>
-      //     new Field({
-      //       ...column,
-      //       // TODO FIXME -- Do NOT use field-literal unless you're referring to a native query
-      // id: [
-      //   "field",
-      //   column.name,
-      //   {
-      //     "base-type": column.base_type,
-      //   },
-      // ],
-      //       source: "fields",
-      //       // HACK: need to thread the query through to this fake Field
-      //       query: this,
-      //     }),
-      // )
 
       return new Table({
         id: this.sourceTableId(),

--- a/frontend/src/metabase/modes/components/drill/ColumnFilterDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/ColumnFilterDrill.jsx
@@ -22,15 +22,8 @@ export default function ColumnFilterDrill({ question, clicked }) {
     return [];
   }
 
-  const { column } = clicked;
-
-  // if our field ref doesn't match our column id, we have a remapped column
-  // and need to use the field id instead of the ref
-  const fieldRef =
-    column.id !== undefined && column.id !== column.field_ref[1]
-      ? ["field", column.id, null]
-      : column.field_ref;
-
+  const { dimension } = clicked;
+  const fieldRef = dimension.mbql();
   const initialFilter = new Filter([], null, query).setDimension(fieldRef, {
     useDefaultOperator: true,
   });

--- a/frontend/src/metabase/query_builder/components/BreakoutPopover.jsx
+++ b/frontend/src/metabase/query_builder/components/BreakoutPopover.jsx
@@ -26,6 +26,8 @@ const BreakoutPopover = ({
       className={className}
       width={width}
       field={breakout}
+      query={query}
+      metadata={query.metadata()}
       fieldOptions={fieldOptions}
       onFieldChange={field => {
         onChangeBreakout(field);

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataSidebar.jsx
@@ -151,7 +151,7 @@ function DatasetFieldMetadataSidebar({
       setShouldAnimateFieldChange(true);
       // setTimeout is required as form fields are rerendered pretty frequently
       setTimeout(() => {
-        displayNameInputRef.current.select();
+        displayNameInputRef.current?.select();
       });
     }
   }, [field, previousField]);
@@ -372,4 +372,4 @@ function DatasetFieldMetadataSidebar({
 
 DatasetFieldMetadataSidebar.propTypes = propTypes;
 
-export default DatasetFieldMetadataSidebar;
+export default React.memo(DatasetFieldMetadataSidebar);

--- a/frontend/src/metabase/query_builder/components/DimensionList.jsx
+++ b/frontend/src/metabase/query_builder/components/DimensionList.jsx
@@ -7,8 +7,9 @@ import AccordionList from "metabase/core/components/AccordionList";
 import Icon from "metabase/components/Icon";
 import PopoverWithTrigger from "metabase/components/PopoverWithTrigger";
 import Tooltip from "metabase/components/Tooltip";
-
+import { isVirtualCardId } from "metabase/lib/saved-questions";
 import { FieldDimension } from "metabase-lib/lib/Dimension";
+
 import { DimensionPicker } from "./DimensionPicker";
 import { FieldListGroupingTrigger } from "./DimensionList.styled";
 
@@ -60,12 +61,14 @@ export default class DimensionList extends Component {
 
   itemIsSelected = item => {
     const dimensions = this._getDimensions();
+    const { dimension } = item;
     return (
       item.dimension &&
-      _.any(dimensions, d =>
-        // shouldn't need to do this but these dimensions don't retain their join-alias
-        item.dimension.withoutJoinAlias().isSameBaseDimension(d),
-      )
+      _.any(dimensions, d => {
+        return isVirtualCardId(dimension?.query()?.table()?.id)
+          ? d.isSameBaseDimension(dimension.withoutJoinAlias())
+          : d.isSameBaseDimension(dimension);
+      })
     );
   };
 

--- a/frontend/src/metabase/query_builder/components/DimensionList.jsx
+++ b/frontend/src/metabase/query_builder/components/DimensionList.jsx
@@ -62,7 +62,10 @@ export default class DimensionList extends Component {
     const dimensions = this._getDimensions();
     return (
       item.dimension &&
-      _.any(dimensions, d => item.dimension.isSameBaseDimension(d))
+      _.any(dimensions, d =>
+        // shouldn't need to do this but these dimensions don't retain their join-alias
+        item.dimension.withoutJoinAlias().isSameBaseDimension(d),
+      )
     );
   };
 

--- a/frontend/src/metabase/query_builder/components/DimensionList.jsx
+++ b/frontend/src/metabase/query_builder/components/DimensionList.jsx
@@ -7,7 +7,6 @@ import AccordionList from "metabase/core/components/AccordionList";
 import Icon from "metabase/components/Icon";
 import PopoverWithTrigger from "metabase/components/PopoverWithTrigger";
 import Tooltip from "metabase/components/Tooltip";
-import { isVirtualCardId } from "metabase/lib/saved-questions";
 import { FieldDimension } from "metabase-lib/lib/Dimension";
 
 import { DimensionPicker } from "./DimensionPicker";
@@ -65,9 +64,8 @@ export default class DimensionList extends Component {
     return (
       item.dimension &&
       _.any(dimensions, d => {
-        return isVirtualCardId(dimension?.query()?.table()?.id)
-          ? d.isSameBaseDimension(dimension.withoutJoinAlias())
-          : d.isSameBaseDimension(dimension);
+        // sometimes `dimension` has a join-alias and `d` doesn't -- with/without is equivalent in this scenario
+        return d.isSameBaseDimension(dimension.withoutJoinAlias());
       })
     );
   };

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/DimensionList/DimensionList.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/DimensionList/DimensionList.jsx
@@ -6,7 +6,6 @@ import TextInput from "metabase/components/TextInput";
 import Icon from "metabase/components/Icon";
 import { useDebouncedValue } from "metabase/hooks/use-debounced-value";
 import { SEARCH_DEBOUNCE_DURATION } from "metabase/lib/constants";
-import { isVirtualCardId } from "metabase/lib/saved-questions";
 
 import { DimensionListItem } from "./DimensionListItem";
 import {
@@ -45,9 +44,8 @@ export const DimensionList = ({
 }) => {
   const isDimensionSelected = dimension =>
     dimensions.some(d => {
-      return isVirtualCardId(dimension?.query()?.table()?.id)
-        ? d.isSameBaseDimension(dimension.withoutJoinAlias())
-        : d.isSameBaseDimension(dimension);
+      // sometimes `dimension` has a join-alias and `d` doesn't -- with/without is equivalent in this scenario
+      return d.isSameBaseDimension(dimension.withoutJoinAlias());
     });
 
   const [filter, setFilter] = useState("");

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/DimensionList/DimensionList.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/DimensionList/DimensionList.jsx
@@ -43,7 +43,10 @@ export const DimensionList = ({
   onRemoveDimension,
 }) => {
   const isDimensionSelected = dimension =>
-    dimensions.some(d => d.isSameBaseDimension(dimension));
+    dimensions.some(d => {
+      // shouldn't need to do this, but breakout dimensions don't retain their join-alias option
+      return d.isSameBaseDimension(dimension.withoutJoinAlias());
+    });
 
   const [filter, setFilter] = useState("");
   const debouncedFilter = useDebouncedValue(filter, SEARCH_DEBOUNCE_DURATION);

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/DimensionList/DimensionList.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/DimensionList/DimensionList.jsx
@@ -6,6 +6,7 @@ import TextInput from "metabase/components/TextInput";
 import Icon from "metabase/components/Icon";
 import { useDebouncedValue } from "metabase/hooks/use-debounced-value";
 import { SEARCH_DEBOUNCE_DURATION } from "metabase/lib/constants";
+import { isVirtualCardId } from "metabase/lib/saved-questions";
 
 import { DimensionListItem } from "./DimensionListItem";
 import {
@@ -44,8 +45,9 @@ export const DimensionList = ({
 }) => {
   const isDimensionSelected = dimension =>
     dimensions.some(d => {
-      // shouldn't need to do this, but breakout dimensions don't retain their join-alias option
-      return d.isSameBaseDimension(dimension.withoutJoinAlias());
+      return isVirtualCardId(dimension?.query()?.table()?.id)
+        ? d.isSameBaseDimension(dimension.withoutJoinAlias())
+        : d.isSameBaseDimension(dimension);
     });
 
   const [filter, setFilter] = useState("");

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
@@ -407,14 +407,15 @@ class TableInteractive extends Component {
         this.props.data,
         columnIndex,
         this.props.isPivoted,
+        this.props.query,
       );
     } catch (e) {
       console.error(e);
     }
   }
   // NOTE: all arguments must be passed to the memoized method, not taken from this.props etc
-  _getHeaderClickedObjectCached(data, columnIndex, isPivoted) {
-    return getTableHeaderClickedObject(data, columnIndex, isPivoted);
+  _getHeaderClickedObjectCached(data, columnIndex, isPivoted, query) {
+    return getTableHeaderClickedObject(data, columnIndex, isPivoted, query);
   }
 
   visualizationIsClickable(clicked) {

--- a/frontend/src/metabase/visualizations/lib/table.js
+++ b/frontend/src/metabase/visualizations/lib/table.js
@@ -1,3 +1,4 @@
+import Dimension from "metabase-lib/lib/Dimension";
 import { isNumber, isCoordinate } from "metabase/lib/schema_metadata";
 
 export function getTableClickedObjectRowData(
@@ -74,7 +75,12 @@ export function getTableCellClickedObject(
   }
 }
 
-export function getTableHeaderClickedObject(data, columnIndex, isPivoted) {
+export function getTableHeaderClickedObject(
+  data,
+  columnIndex,
+  isPivoted,
+  query,
+) {
   const column = data.cols[columnIndex];
   if (isPivoted) {
     // if it's a pivot table, the first column is
@@ -84,7 +90,14 @@ export function getTableHeaderClickedObject(data, columnIndex, isPivoted) {
       return null; // FIXME?
     }
   } else {
-    return { column };
+    return {
+      column,
+      dimension: Dimension.parseMBQL(
+        column?.field_ref,
+        query?.metadata(),
+        query,
+      ),
+    };
   }
 }
 

--- a/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
@@ -254,7 +254,7 @@ describe("binning related reproductions", () => {
 
       changeBinningForDimension({
         name: "Average of Subtotal",
-        fromBinning: "Auto binned",
+        fromBinning: "Auto bin",
         toBinning: "10 bins",
       });
 
@@ -270,7 +270,7 @@ describe("binning related reproductions", () => {
 
       changeBinningForDimension({
         name: "Average of Subtotal",
-        fromBinning: "Auto binned",
+        fromBinning: "Auto bin",
         toBinning: "10 bins",
       });
 

--- a/frontend/test/metabase/scenarios/binning/qb-implicit-joins.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/qb-implicit-joins.cy.spec.js
@@ -62,9 +62,7 @@ describe("scenarios > binning > from a saved QB question using implicit joins", 
       changeBinningForDimension({
         name: "Longitude",
         fromBinning: "Auto bin",
-        // Test is currently incorrect in that it displays wrong binning options (please see: https://github.com/metabase/metabase/issues/16674)
-        // Once #16674 gets fixed, update the following line to say: `bucketSize: "Bin every 20 degrees"`
-        toBinning: "20°",
+        toBinning: "Bin every 20 degrees",
       });
 
       assertQueryBuilderState({
@@ -130,9 +128,7 @@ describe("scenarios > binning > from a saved QB question using implicit joins", 
       changeBinningForDimension({
         name: "Longitude",
         fromBinning: "Auto bin",
-        // Test is currently incorrect in that it displays wrong binning options (please see: https://github.com/metabase/metabase/issues/16674)
-        // Once #16674 gets fixed, update the following line to say: `bucketSize: "Bin every 20 degrees"`
-        toBinning: "20°",
+        toBinning: "Bin every 20 degrees",
       });
 
       assertQueryBuilderState({

--- a/frontend/test/metabase/scenarios/binning/qb-implicit-joins.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/qb-implicit-joins.cy.spec.js
@@ -48,7 +48,7 @@ describe("scenarios > binning > from a saved QB question using implicit joins", 
     it("should work for number", () => {
       changeBinningForDimension({
         name: "Price",
-        fromBinning: "Auto binned",
+        fromBinning: "Auto bin",
         toBinning: "50 bins",
       });
 
@@ -61,7 +61,7 @@ describe("scenarios > binning > from a saved QB question using implicit joins", 
     it("should work for longitude", () => {
       changeBinningForDimension({
         name: "Longitude",
-        fromBinning: "Auto binned",
+        fromBinning: "Auto bin",
         // Test is currently incorrect in that it displays wrong binning options (please see: https://github.com/metabase/metabase/issues/16674)
         // Once #16674 gets fixed, update the following line to say: `bucketSize: "Bin every 20 degrees"`
         toBinning: "20°",
@@ -112,7 +112,7 @@ describe("scenarios > binning > from a saved QB question using implicit joins", 
 
       changeBinningForDimension({
         name: "Price",
-        fromBinning: "Auto binned",
+        fromBinning: "Auto bin",
         toBinning: "50 bins",
       });
 
@@ -129,7 +129,7 @@ describe("scenarios > binning > from a saved QB question using implicit joins", 
 
       changeBinningForDimension({
         name: "Longitude",
-        fromBinning: "Auto binned",
+        fromBinning: "Auto bin",
         // Test is currently incorrect in that it displays wrong binning options (please see: https://github.com/metabase/metabase/issues/16674)
         // Once #16674 gets fixed, update the following line to say: `bucketSize: "Bin every 20 degrees"`
         toBinning: "20°",

--- a/frontend/test/metabase/scenarios/binning/sql.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/sql.cy.spec.js
@@ -62,7 +62,7 @@ describe("scenarios > binning > from a saved sql question", () => {
     it("should work for number", () => {
       changeBinningForDimension({
         name: "TOTAL",
-        fromBinning: "Auto binned",
+        fromBinning: "Auto bin",
         toBinning: "50 bins",
       });
 
@@ -73,17 +73,10 @@ describe("scenarios > binning > from a saved sql question", () => {
     });
 
     it("should work for longitude", () => {
-      /**
-       * The correct option should say "Bin every 10 degrees", but this is out of the scope of this test.
-       * It was covered in `frontend/test/metabase/scenarios/binning/binning-options.cy.spec.js`
-       * Please see: https://github.com/metabase/metabase/issues/16675.
-       *
-       * TODO: Change back to "Bin every 10 degrees" once metabase#16675 gets fixed.
-       */
       changeBinningForDimension({
         name: "LONGITUDE",
-        fromBinning: "Auto binned",
-        toBinning: "10°",
+        fromBinning: "Auto bin",
+        toBinning: "Bin every 10 degrees",
       });
 
       waitAndAssertOnRequest("@dataset");
@@ -123,7 +116,7 @@ describe("scenarios > binning > from a saved sql question", () => {
     it("should work for number", () => {
       changeBinningForDimension({
         name: "TOTAL",
-        fromBinning: "Auto binned",
+        fromBinning: "Auto bin",
         toBinning: "50 bins",
       });
 
@@ -137,17 +130,10 @@ describe("scenarios > binning > from a saved sql question", () => {
     });
 
     it("should work for longitude", () => {
-      /**
-       * The correct option should say "Bin every 10 degrees", but this is out of the scope of this test.
-       * It was covered in `frontend/test/metabase/scenarios/binning/binning-options.cy.spec.js`
-       * Please see: https://github.com/metabase/metabase/issues/16675
-       *
-       * TODO: Change back to "Bin every 10 degrees" once metabase#16675 gets fixed.
-       */
       changeBinningForDimension({
         name: "LONGITUDE",
-        fromBinning: "Auto binned",
-        toBinning: "10°",
+        fromBinning: "Auto bin",
+        toBinning: "Bin every 10 degrees",
       });
 
       cy.findByText("Count by LONGITUDE: 10°");

--- a/frontend/test/metabase/scenarios/models/reproductions/22715-remapped-values-override-column-identifier.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/reproductions/22715-remapped-values-override-column-identifier.cy.spec.js
@@ -5,7 +5,7 @@ import {
   filter,
 } from "__support__/e2e/helpers";
 
-describe.skip("filtering based on the remapped column name should result in a correct query (metabase#22715)", () => {
+describe("filtering based on the remapped column name should result in a correct query (metabase#22715)", () => {
   beforeEach(() => {
     cy.intercept("POST", "/api/dataset").as("dataset");
     cy.intercept("PUT", "/api/card/*").as("updateModel");
@@ -26,10 +26,10 @@ describe.skip("filtering based on the remapped column name should result in a co
 
       // Let's go straight to the model metadata editor
       cy.visit(`/model/${id}/metadata`);
-      // Without this Cypress fails to remap the column because an element becomes detached from the DOM
-      cy.findByText(
-        "Use the tab key to navigate through settings and columns.",
-      );
+      // Without this Cypress fails to remap the column because an element becomes detached from the DOM.
+      // This is caused by the DatasetFieldMetadataSidebar component rerendering mulitple times.
+      cy.findByText("Database column this maps to");
+      cy.wait(5000);
 
       // The first column `ID` is automatically selected
       mapColumnTo({ table: "Orders", column: "ID" });
@@ -62,9 +62,9 @@ describe.skip("filtering based on the remapped column name should result in a co
   it("when done through the filter trigger (metabase#22715-2)", () => {
     filter();
 
-    cy.findByTestId("sidebar-right").within(() => {
-      cy.findByText("Created At").click();
+    cy.get(".Modal").within(() => {
       cy.findByText("Today").click();
+      cy.findByText("Apply Filters").click();
     });
 
     cy.wait("@dataset");


### PR DESCRIPTION
Fixes #22715
Fixes #16674
Fixes #16675

Root cause
1. `ColumnFilterDrill` was sending a filter with the incorrect `field_ref`
2. Code in `Filter` to determine if it is valid was returning false because we fail to hold onto a field_ref's third entry (the `options` object) in several different scenarios

The fix for this improves our ability to hold onto a field_ref's options, but this object is used when comparing dimensions for equality, so it had some consequences elsewhere in the app that I had to deal with in this PR. The upside is that it fixed a couple of other bugs.

I've added in-lined comments to explain my changes.

**Testing**
Follow the steps as described here: https://github.com/metabase/metabase/issues/22715#issuecomment-1126958012

Demo of the fix:

https://user-images.githubusercontent.com/13057258/184416912-a2b80626-8538-4468-912f-86ea14ac101c.mov


