### PR TITLE
Set default engine in admin database forms to postgres

### DIFF
--- a/frontend/src/metabase/admin/databases/database.js
+++ b/frontend/src/metabase/admin/databases/database.js
@@ -7,7 +7,6 @@ import {
 } from "metabase/lib/redux";
 import { push } from "react-router-redux";
 import * as MetabaseAnalytics from "metabase/lib/analytics";
-import MetabaseSettings from "metabase/lib/settings";
 
 import { MetabaseApi } from "metabase/services";
 import Databases from "metabase/entities/databases";
@@ -121,7 +120,7 @@ export const initializeDatabase = function (databaseId) {
       const newDatabase = {
         name: "",
         auto_run_queries: true,
-        engine: Object.keys(MetabaseSettings.get("engines"))[0],
+        engine: "postgres",
         details: {},
         created: false,
       };

--- a/frontend/src/metabase/admin/databases/database.js
+++ b/frontend/src/metabase/admin/databases/database.js
@@ -7,6 +7,7 @@ import {
 } from "metabase/lib/redux";
 import { push } from "react-router-redux";
 import * as MetabaseAnalytics from "metabase/lib/analytics";
+import { getDefaultEngine } from "metabase/lib/engine";
 
 import { MetabaseApi } from "metabase/services";
 import Databases from "metabase/entities/databases";
@@ -120,7 +121,7 @@ export const initializeDatabase = function (databaseId) {
       const newDatabase = {
         name: "",
         auto_run_queries: true,
-        engine: "postgres",
+        engine: getDefaultEngine(),
         details: {},
         created: false,
       };

--- a/frontend/src/metabase/lib/engine.js
+++ b/frontend/src/metabase/lib/engine.js
@@ -1,6 +1,11 @@
 import Settings from "metabase/lib/settings";
 import { formatSQL } from "metabase/lib/formatting";
 
+export function getDefaultEngine() {
+  const engines = Object.keys(Settings.get("engines"));
+  return engines.includes("postgres") ? "postgres" : engines[0];
+}
+
 export function getEngineNativeType(engine) {
   switch (engine) {
     case "mongo":


### PR DESCRIPTION
To avoid issues with the order of drivers in `engines` setting, let's statically set `postgres` since it's always included.