### PR TITLE
[chain-filters] fix permissions check for users with no self-service

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/dashboard_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/dashboard_test.clj
@@ -16,16 +16,17 @@
     (mt/with-gtaps {:gtaps {:categories {:query (mt/mbql-query categories {:filter [:< $id 3]})}}}
       (mt/with-temp-vals-in-db FieldValues (u/the-id (db/select-one-id FieldValues :field_id (mt/id :categories :name))) {:values ["Good" "Bad"]}
         (api.dashboard-test/with-chain-filter-fixtures [{:keys [dashboard]}]
-          (testing "GET /api/dashboard/:id/params/:param-key/values"
-            (api.dashboard-test/let-url [url (api.dashboard-test/chain-filter-values-url dashboard "_CATEGORY_NAME_")]
-              (is (= {:values          ["African" "American"]
-                      :has_more_values false}
-                     (chain-filter-test/take-n-values 2 (mt/user-http-request :rasta :get 200 url))))))
-          (testing "GET /api/dashboard/:id/params/:param-key/search/:query"
-            (api.dashboard-test/let-url [url (api.dashboard-test/chain-filter-search-url dashboard "_CATEGORY_NAME_" "a")]
-              (is (= {:values          ["African" "American"]
-                      :has_more_values false}
-                     (mt/user-http-request :rasta :get 200 url))))))))))
+          (with-redefs [metabase.models.params.chain-filter/use-cached-field-values? (constantly false)]
+            (testing "GET /api/dashboard/:id/params/:param-key/values"
+              (api.dashboard-test/let-url [url (api.dashboard-test/chain-filter-values-url dashboard "_CATEGORY_NAME_")]
+                (is (= {:values          ["African" "American"]
+                        :has_more_values false}
+                       (chain-filter-test/take-n-values 2 (mt/user-http-request :rasta :get 200 url))))))
+            (testing "GET /api/dashboard/:id/params/:param-key/search/:query"
+              (api.dashboard-test/let-url [url (api.dashboard-test/chain-filter-search-url dashboard "_CATEGORY_NAME_" "a")]
+                (is (= {:values          ["African" "American"]
+                        :has_more_values false}
+                       (mt/user-http-request :rasta :get 200 url)))))))))))
 
 (deftest add-card-parameter-mapping-permissions-test
   (testing "POST /api/dashboard/:id/cards"

--- a/frontend/test/metabase/scenarios/dashboard/dashboard_data_permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard_data_permissions.cy.spec.js
@@ -58,6 +58,16 @@ describe("support > permissions (metabase#8472)", () => {
     );
 
     cy.signIn("nodata");
+    filterDashboard();
+  });
+
+  it("should not allow a nocollection user to select the filter", () => {
+    cy.server();
+    cy.route("GET", "/api/dashboard/1/params/*/search/100 Main Street").as(
+      "search",
+    );
+
+    cy.signIn("nocollection");
     filterDashboard(false);
   });
 });

--- a/frontend/test/metabase/scenarios/dashboard/dashboard_data_permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard_data_permissions.cy.spec.js
@@ -61,13 +61,19 @@ describe("support > permissions (metabase#8472)", () => {
     filterDashboard();
   });
 
-  it("should not allow a nocollection user to select the filter", () => {
+  it("should not allow a nocollection user to visit the page, hence cannot see the filter", () => {
     cy.server();
-    cy.route("GET", "/api/dashboard/1/params/*/search/100 Main Street").as(
+    cy.route("GET", "/api/dashboard/1/params/search/100 Main Street").as(
       "search",
     );
 
     cy.signIn("nocollection");
-    filterDashboard(false);
+    cy.request({
+      method: "GET",
+      url: "/api/dashboard/1",
+      failOnStatusCode: false,
+    }).should(xhr => {
+      expect(xhr.status).to.equal(403);
+    });
   });
 });

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -598,7 +598,9 @@
        (throw (ex-info (tru "Dashboard does not have a parameter with the ID {0}" (pr-str param-key))
                        {:resolved-params (keys resolved-params)
                         :status-code     400})))
-     (binding [qp.perms/*internal-ui-query* (mi/can-read? 'Dashboard (:id dashboard))] ;; fix for (#24832)
+     (binding [qp.perms/*card-id*
+               ;; make sure that the proper card-id is bound (#24832)
+               (-> (get resolved-params param-key) :mappings first :card_id)]
        (let [constraints (chain-filter-constraints dashboard constraint-param-key->value)
              field-ids   (param-key->field-ids dashboard param-key)]
          (when (empty? field-ids)

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -607,23 +607,22 @@
                           :status-code 400})))
        ;; TODO - we should combine these all into a single UNION ALL query against the data warehouse instead of doing a
        ;; separate query for each Field (for parameters that are mapped to more than one Field)
-       (binding [qp.perms/*internal-ui-query* true]
-         (try
-           (let [results (map (if (seq query)
-                                #(chain-filter/chain-filter-search % constraints query :limit result-limit)
-                                #(chain-filter/chain-filter % constraints :limit result-limit))
-                              field-ids)
-                 values (distinct (mapcat :values results))
-                 has_more_values (boolean (some true? (map :has_more_values results)))]
-             ;; results can come back as [v ...] *or* as [[orig remapped] ...]. Sort by remapped value if that's the case
-             {:values          (if (sequential? (first values))
-                                 (sort-by second values)
-                                 (sort values))
-              :has_more_values has_more_values})
-           (catch clojure.lang.ExceptionInfo e
-             (if (= (:type (u/all-ex-data e)) qp.error-type/missing-required-permissions)
-               (api/throw-403 e)
-               (throw e)))))))))
+       (try
+         (let [results (map (if (seq query)
+                              #(chain-filter/chain-filter-search % constraints query :limit result-limit)
+                              #(chain-filter/chain-filter % constraints :limit result-limit))
+                            field-ids)
+               values (distinct (mapcat :values results))
+               has_more_values (boolean (some true? (map :has_more_values results)))]
+           ;; results can come back as [v ...] *or* as [[orig remapped] ...]. Sort by remapped value if that's the case
+           {:values          (if (sequential? (first values))
+                               (sort-by second values)
+                               (sort values))
+            :has_more_values has_more_values})
+         (catch clojure.lang.ExceptionInfo e
+           (if (= (:type (u/all-ex-data e)) qp.error-type/missing-required-permissions)
+             (api/throw-403 e)
+             (throw e))))))))
 
 (api/defendpoint GET "/:id/params/:param-key/values"
   "Fetch possible values of the parameter whose ID is `:param-key`. Optionally restrict these values by passing query
@@ -633,7 +632,9 @@
     GET /api/dashboard/1/params/abc/values?def=100"
   [id param-key :as {:keys [query-params]}]
   (let [dashboard (api/read-check Dashboard id)]
-    (chain-filter dashboard param-key query-params)))
+    ;; If a user can read the dashboard, then they can lookup the chain-filter
+    (binding [qp.perms/*internal-ui-query* true]
+      (chain-filter dashboard param-key query-params))))
 
 (api/defendpoint GET "/:id/params/:param-key/search/:query"
   "Fetch possible values of the parameter whose ID is `:param-key` that contain `:query`. Optionally restrict
@@ -646,7 +647,9 @@
   Currently limited to first 1000 results."
   [id param-key query :as {:keys [query-params]}]
   (let [dashboard (api/read-check Dashboard id)]
-    (chain-filter dashboard param-key query-params query)))
+    ;; If a user can read the dashboard, then they can lookup the chain-filter
+    (binding [qp.perms/*internal-ui-query* true]
+      (chain-filter dashboard param-key query-params query))))
 
 (api/defendpoint GET "/params/valid-filter-fields"
   "Utility endpoint for powering Dashboard UI. Given some set of `filtered` Field IDs (presumably Fields used in

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -602,11 +602,11 @@
                        {:resolved-params (keys resolved-params)
                         :status-code     400})))
      (binding [qp.perms/*card-id* (or qp.perms/*card-id*
-                                      (and
-                                       ;; when we are using constrained filters
-                                       (not-empty constraint-param-key->value)
-                                       ;; make sure that the proper card-id is bound
-                                       (get-card-id-from-resolved-params resolved-params param-key)))]
+                                      (and ;; fixes #24832
+                                        ;; when we are using constrained filters
+                                        (not-empty constraint-param-key->value)
+                                        ;; make sure that the proper card-id is bound
+                                        (get-card-id-from-resolved-params resolved-params param-key)))]
        (let [constraints (chain-filter-constraints dashboard constraint-param-key->value)
              field-ids   (param-key->field-ids dashboard param-key)]
          (when (empty? field-ids)

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -28,6 +28,7 @@
             [metabase.query-processor.dashboard :as qp.dashboard]
             [metabase.query-processor.error-type :as qp.error-type]
             [metabase.query-processor.middleware.constraints :as qp.constraints]
+            [metabase.query-processor.middleware.permissions :as qp.perms]
             [metabase.query-processor.pivot :as qp.pivot]
             [metabase.query-processor.util :as qp.util]
             [metabase.related :as related]
@@ -36,8 +37,7 @@
             [metabase.util.schema :as su]
             [schema.core :as s]
             [toucan.db :as db]
-            [toucan.hydrate :refer [hydrate]]
-            [metabase.query-processor.middleware.permissions :as qp.perms])
+            [toucan.hydrate :refer [hydrate]])
   (:import java.util.UUID))
 
 (defn- dashboards-list [filter-option]
@@ -596,7 +596,7 @@
     param-key                   :- su/NonBlankString
     constraint-param-key->value :- su/Map
     query                       :- (s/maybe su/NonBlankString)]
-   (let [{:keys [resolved-params] :as dashboard'} (hydrate dashboard :resolved-params)]
+   (let [{:keys [resolved-params]} (hydrate dashboard :resolved-params)]
      (when-not (get resolved-params param-key)
        (throw (ex-info (tru "Dashboard does not have a parameter with the ID {0}" (pr-str param-key))
                        {:resolved-params (keys resolved-params)

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -598,7 +598,7 @@
        (throw (ex-info (tru "Dashboard does not have a parameter with the ID {0}" (pr-str param-key))
                        {:resolved-params (keys resolved-params)
                         :status-code     400})))
-     (binding [qp.perms/*internal-ui-query* true] ;; fix for (#24832)
+     (binding [qp.perms/*internal-ui-query* (mi/can-read? 'Dashboard (:id dashboard))] ;; fix for (#24832)
        (let [constraints (chain-filter-constraints dashboard constraint-param-key->value)
              field-ids   (param-key->field-ids dashboard param-key)]
          (when (empty? field-ids)

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -602,7 +602,11 @@
                        {:resolved-params (keys resolved-params)
                         :status-code     400})))
      (binding [qp.perms/*card-id* (or qp.perms/*card-id*
-                                      (get-card-id-from-resolved-params resolved-params param-key))]
+                                      (and
+                                       ;; when we are using constrained filters
+                                       (not-empty constraint-param-key->value)
+                                       ;; make sure that the proper card-id is bound
+                                       (get-card-id-from-resolved-params resolved-params param-key)))]
        (let [constraints (chain-filter-constraints dashboard constraint-param-key->value)
              field-ids   (param-key->field-ids dashboard param-key)]
          (when (empty? field-ids)

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -574,9 +574,6 @@
                  field-id          (param-key->field-ids dashboard param-key)]
              [field-id value])))
 
-(defn- get-card-id-from-resolved-params [resolved-params param-key]
-  (-> resolved-params (get param-key) :mappings first :card_id))
-
 (s/defn chain-filter
   "C H A I N filters!
 
@@ -601,12 +598,9 @@
        (throw (ex-info (tru "Dashboard does not have a parameter with the ID {0}" (pr-str param-key))
                        {:resolved-params (keys resolved-params)
                         :status-code     400})))
-     (binding [qp.perms/*card-id* (or qp.perms/*card-id*
-                                      (and ;; fixes #24832
-                                        ;; when we are using constrained filters
-                                        (not-empty constraint-param-key->value)
-                                        ;; make sure that the proper card-id is bound
-                                        (get-card-id-from-resolved-params resolved-params param-key)))]
+     (binding [qp.perms/*card-id*
+               ;; make sure that the proper card-id is bound (#24832)
+               (-> (get resolved-params param-key) :mappings first :card_id)]
        (let [constraints (chain-filter-constraints dashboard constraint-param-key->value)
              field-ids   (param-key->field-ids dashboard param-key)]
          (when (empty? field-ids)

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -598,9 +598,7 @@
        (throw (ex-info (tru "Dashboard does not have a parameter with the ID {0}" (pr-str param-key))
                        {:resolved-params (keys resolved-params)
                         :status-code     400})))
-     (binding [qp.perms/*card-id*
-               ;; make sure that the proper card-id is bound (#24832)
-               (-> (get resolved-params param-key) :mappings first :card_id)]
+     (binding [qp.perms/*internal-ui-query* (mi/can-read? 'Dashboard (:id dashboard))] ;; fix for (#24832)
        (let [constraints (chain-filter-constraints dashboard constraint-param-key->value)
              field-ids   (param-key->field-ids dashboard param-key)]
          (when (empty? field-ids)

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -598,7 +598,7 @@
        (throw (ex-info (tru "Dashboard does not have a parameter with the ID {0}" (pr-str param-key))
                        {:resolved-params (keys resolved-params)
                         :status-code     400})))
-     (binding [qp.perms/*internal-ui-query* (mi/can-read? 'Dashboard (:id dashboard))] ;; fix for (#24832)
+     (binding [qp.perms/*internal-ui-query* true] ;; fix for (#24832)
        (let [constraints (chain-filter-constraints dashboard constraint-param-key->value)
              field-ids   (param-key->field-ids dashboard param-key)]
          (when (empty? field-ids)

--- a/src/metabase/models/params/chain_filter.clj
+++ b/src/metabase/models/params/chain_filter.clj
@@ -415,7 +415,7 @@
    :middleware {:disable-remaps? true}})
 
 
-;;; ------------------------ Chain filter (powers GET /api/dashboard/:id/params/:key/values) -------------------------
+;;; ------------------------ Chain filter (powers GET /api/dashboard/:id/params/:param-key/values) -------------------------
 
 (s/defn ^:private unremapped-chain-filter
   "Chain filtering without all the fancy remapping stuff on top of it."
@@ -557,7 +557,7 @@
 
 (s/defn chain-filter
   "Fetch a sequence of possible values of Field with `field-id` by restricting the possible values to rows that match
-  values of other Fields in the `constraints` map. Powers the `GET /api/dashboard/:id/param/:key/values` chain filter
+  values of other Fields in the `constraints` map. Powers the `GET /api/dashboard/:id/param/:param-key/values` chain filter
   API endpoint.
 
     ;; fetch possible values of venue price (between 1 and 4 inclusive) where category name is 'BBQ'

--- a/src/metabase/models/permissions.clj
+++ b/src/metabase/models/permissions.clj
@@ -26,7 +26,7 @@
   permissions matching an path or path using `LIKE`; see [[metabase.models.database/pre-delete]] for
   an example of the sort of efficient queries the prefix system facilitates.
 
-  The union of all permissions the current User's gets from all groups of which they are a member are automatically
+  The union of all permissions the current user gets from all groups of which they are a member are automatically
   bound to [[metabase.api.common/*current-user-permissions-set*]] by
   [[metabase.server.middleware.session/bind-current-user]] for every REST API request, and in other places when
   queries are ran in a non-API thread (e.g. for scheduled Dashboard Subscriptions).

--- a/src/metabase/query_processor/middleware/permissions.clj
+++ b/src/metabase/query_processor/middleware/permissions.clj
@@ -86,16 +86,33 @@
   (doseq [{query :dataset_query} (qp.resolve-referenced/tags-referenced-cards outer-query)]
     (check-query-permissions* query)))
 
+(def ^:dynamic *internal-ui-query*
+  "The motivating example is the chain-filters dropdown, where the user has access to the collection
+
+  Bind this if we know the user has access to a resource, and the query is being run to populate a dropdown.
+
+
+  you can already see if you can do it fixme
+  "
+  nil)
+
 (s/defn ^:private check-query-permissions*
   "Check that User with `user-id` has permissions to run `query`, or throw an exception."
   [outer-query :- su/Map]
   (when *current-user-id*
     (log/tracef "Checking query permissions. Current user perms set = %s" (pr-str @*current-user-permissions-set*))
-    (if *card-id*
+    (cond
+
+      *internal-ui-query*
+      true
+
+      *card-id*
       (do
         (check-card-read-perms *card-id*)
         (when-not (has-data-perms? (required-perms outer-query))
           (check-block-permissions outer-query)))
+
+      :else
       (check-ad-hoc-query-perms outer-query))))
 
 (defn check-query-permissions

--- a/src/metabase/query_processor/middleware/permissions.clj
+++ b/src/metabase/query_processor/middleware/permissions.clj
@@ -87,7 +87,9 @@
     (check-query-permissions* query)))
 
 (def ^:dynamic *internal-ui-query*
-  "Certain queries have passed the checks reqired and do not need to be checked in check-query-permissions*"
+  "Certain queries have already passed permission checks and do not need to be checked
+  in [[check-query-permissions*]]. The motivating case is a query that finds
+  values to fill a dropdown in chained-filters."
   false)
 
 (s/defn ^:private check-query-permissions*
@@ -101,15 +103,10 @@
       (do
         (check-card-read-perms *card-id*) ;; check collection permissions
         (when-not (has-data-perms? (required-perms outer-query))
-          (or
-            (mi/can-read? *card-id*)
-            (check-block-permissions outer-query))
-          ;; TODO: do we need to check Segmented? (see: permission matrix in ns docs for metabase.models.permissions
-          ;; the case where: Data perms? no | Coll perms? yes | Block? no | Segmented? yes  should run in sandbox.
-          ))
+          (check-block-permissions outer-query)))
 
-      ;; *internal-ui-query*
-      ;; true
+      *internal-ui-query*
+      true
 
       :else
       (check-ad-hoc-query-perms outer-query))))

--- a/src/metabase/query_processor/middleware/permissions.clj
+++ b/src/metabase/query_processor/middleware/permissions.clj
@@ -98,9 +98,13 @@
     (cond
       *card-id*
       (do
-        (check-card-read-perms *card-id*)
+        (check-card-read-perms *card-id*) ;; check collection permissions
         (when-not (has-data-perms? (required-perms outer-query))
-          (check-block-permissions outer-query)))
+          (check-block-permissions outer-query)
+          ;; TODO: do we need to check Segmented? (see: permission matrix in ns docs for metabase.models.permissions
+          ;; the case where: Data perms? no | Coll perms? yes | Block? no | Segmented? yes  should run in sandbox.
+
+          ))
 
       *internal-ui-query*
       true

--- a/src/metabase/query_processor/middleware/permissions.clj
+++ b/src/metabase/query_processor/middleware/permissions.clj
@@ -86,33 +86,16 @@
   (doseq [{query :dataset_query} (qp.resolve-referenced/tags-referenced-cards outer-query)]
     (check-query-permissions* query)))
 
-(def ^:dynamic *internal-ui-query*
-  "The motivating example is the chain-filters dropdown, where the user has access to the collection
-
-  Bind this if we know the user has access to a resource, and the query is being run to populate a dropdown.
-
-
-  you can already see if you can do it fixme
-  "
-  nil)
-
 (s/defn ^:private check-query-permissions*
   "Check that User with `user-id` has permissions to run `query`, or throw an exception."
   [outer-query :- su/Map]
   (when *current-user-id*
     (log/tracef "Checking query permissions. Current user perms set = %s" (pr-str @*current-user-permissions-set*))
-    (cond
-
-      *internal-ui-query*
-      true
-
-      *card-id*
+    (if *card-id*
       (do
         (check-card-read-perms *card-id*)
         (when-not (has-data-perms? (required-perms outer-query))
           (check-block-permissions outer-query)))
-
-      :else
       (check-ad-hoc-query-perms outer-query))))
 
 (defn check-query-permissions

--- a/src/metabase/query_processor/middleware/permissions.clj
+++ b/src/metabase/query_processor/middleware/permissions.clj
@@ -96,18 +96,20 @@
   (when *current-user-id*
     (log/tracef "Checking query permissions. Current user perms set = %s" (pr-str @*current-user-permissions-set*))
     (cond
+
       *card-id*
       (do
         (check-card-read-perms *card-id*) ;; check collection permissions
         (when-not (has-data-perms? (required-perms outer-query))
-          (check-block-permissions outer-query)
+          (or
+            (mi/can-read? *card-id*)
+            (check-block-permissions outer-query))
           ;; TODO: do we need to check Segmented? (see: permission matrix in ns docs for metabase.models.permissions
           ;; the case where: Data perms? no | Coll perms? yes | Block? no | Segmented? yes  should run in sandbox.
-
           ))
 
-      *internal-ui-query*
-      true
+      ;; *internal-ui-query*
+      ;; true
 
       :else
       (check-ad-hoc-query-perms outer-query))))

--- a/src/metabase/query_processor/middleware/permissions.clj
+++ b/src/metabase/query_processor/middleware/permissions.clj
@@ -86,12 +86,14 @@
   (doseq [{query :dataset_query} (qp.resolve-referenced/tags-referenced-cards outer-query)]
     (check-query-permissions* query)))
 
+(def ^:dynamic *internal-ui-query* false)
+
 (s/defn ^:private check-query-permissions*
   "Check that User with `user-id` has permissions to run `query`, or throw an exception."
   [outer-query :- su/Map]
   (when *current-user-id*
     (log/tracef "Checking query permissions. Current user perms set = %s" (pr-str @*current-user-permissions-set*))
-    (if *card-id*
+    (if (or *card-id* *internal-ui-query*)
       (do
         (check-card-read-perms *card-id*)
         (when-not (has-data-perms? (required-perms outer-query))

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -69,8 +69,7 @@
    :cache_ttl           nil
    :average_query_time  nil
    :last_query_start    nil
-   :result_metadata     nil
-   :is_write            false})
+   :result_metadata     nil})
 
 ;; Used in dashboard tests
 (def card-defaults-no-hydrate

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -69,7 +69,8 @@
    :cache_ttl           nil
    :average_query_time  nil
    :last_query_start    nil
-   :result_metadata     nil})
+   :result_metadata     nil
+   :is_write            false})
 
 ;; Used in dashboard tests
 (def card-defaults-no-hydrate

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -1463,7 +1463,7 @@
                  (chain-filter-test/take-n-values 3 (mt/user-http-request :rasta :get 200 (chain-filter-values-url
                                                                                            (:id dashboard)
                                                                                            (:category-name param-keys)))))))))
-    (testing "data permissions should not  perms for the Fields in question"
+    (testing "data perms should not affect perms for the Fields in question when users have collection access"
       (mt/with-temp-copy-of-db
         (with-chain-filter-fixtures [{:keys [dashboard param-keys]}]
           (perms/revoke-data-perms! (perms-group/all-users) (mt/id))

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -242,7 +242,8 @@
                                                                       :display                "table"
                                                                       :entity_id              (:entity_id card)
                                                                       :visualization_settings {}
-                                                                      :result_metadata        nil})
+                                                                      :result_metadata        nil
+                                                                      :is_write               false})
                                       :series                 []}]})
                    (dashboard-response (mt/user-http-request :rasta :get 200 (format "dashboard/%d" dashboard-id)))))))))
 
@@ -294,7 +295,8 @@
                                                                             :display                "table"
                                                                             :query_type             nil
                                                                             :visualization_settings {}
-                                                                            :result_metadata        nil})
+                                                                            :result_metadata        nil
+                                                                            :is_write               false})
                                             :series                 []}]})
                    (dashboard-response (mt/user-http-request :rasta :get 200 (format "dashboard/%d" dashboard-id)))))))))
     (testing "fetch a dashboard from an official collection includes the collection type"

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -242,8 +242,7 @@
                                                                       :display                "table"
                                                                       :entity_id              (:entity_id card)
                                                                       :visualization_settings {}
-                                                                      :result_metadata        nil
-                                                                      :is_write               false})
+                                                                      :result_metadata        nil})
                                       :series                 []}]})
                    (dashboard-response (mt/user-http-request :rasta :get 200 (format "dashboard/%d" dashboard-id)))))))))
 
@@ -295,8 +294,7 @@
                                                                             :display                "table"
                                                                             :query_type             nil
                                                                             :visualization_settings {}
-                                                                            :result_metadata        nil
-                                                                            :is_write               false})
+                                                                            :result_metadata        nil})
                                             :series                 []}]})
                    (dashboard-response (mt/user-http-request :rasta :get 200 (format "dashboard/%d" dashboard-id)))))))))
     (testing "fetch a dashboard from an official collection includes the collection type"

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -15,6 +15,7 @@
             [metabase.models.dashboard-card :as dashboard-card]
             [metabase.models.dashboard-test :as dashboard-test]
             [metabase.models.field-values :as field-values]
+            [metabase.models.params.chain-filter :as chain-filter]
             [metabase.models.params.chain-filter-test :as chain-filter-test]
             [metabase.models.permissions :as perms]
             [metabase.models.permissions-group :as perms-group]
@@ -1400,7 +1401,7 @@
       (testing (str "\nGET /api/" url "\n")
         (testing "\nShow me names of categories that have expensive venues (price = 4), while I lack permisisons."
           ;; shut off the cache:
-          (with-redefs [metabase.models.params.chain-filter/use-cached-field-values? (constantly false)]
+          (with-redefs [chain-filter/use-cached-field-values? (constantly false)]
             (binding [qp.perms/*card-id* nil] ;; this situation was observed when running constrained chain filters.
               (is
                 (=

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -1461,10 +1461,9 @@
           (is (= {:values          ["African" "American" "Artisan"]
                   :has_more_values false}
                  (chain-filter-test/take-n-values 3 (mt/user-http-request :rasta :get 200 (chain-filter-values-url
-                                                                                            (:id dashboard)
-                                                                                            (:category-name param-keys)))))))))
-
-    (testing "revoking data permissions does not change ability to view chain-filter values"
+                                                                                           (:id dashboard)
+                                                                                           (:category-name param-keys)))))))))
+    (testing "should check perms for the Fields in question"
       (mt/with-temp-copy-of-db
         (with-chain-filter-fixtures [{:keys [dashboard param-keys]}]
           (perms/revoke-data-perms! (perms-group/all-users) (mt/id))
@@ -1472,22 +1471,8 @@
           ;; but 200 on calls that we could just use the cache.
           ;; It's not ideal and we definitely need to have a consistent behavior
           (with-redefs [field-values/field-should-have-field-values? (fn [_] false)]
-            (is (= {:values          ["African" "American" "Artisan"]
-                    :has_more_values false}
-                   (chain-filter-test/take-n-values
-                     3
-                     (mt/user-http-request :rasta :get 200 (chain-filter-values-url (:id dashboard) (:category-name param-keys))))))))))
-
-    (testing "when you cannot access the collection that a dashboard is in, cannot access the chain-filter values"
-      (with-chain-filter-fixtures [{:keys [dashboard param-keys]}]
-        (mt/with-temp Collection [collection]
-          (with-chain-filter-fixtures [{:keys [dashboard param-keys]} {:collection_id (:id collection)}]
-            (perms/revoke-collection-permissions! (perms-group/all-users) (:id collection))
             (is (= "You don't have permissions to do that."
-                   (mt/user-http-request :rasta :get 403 (chain-filter-values-url
-                                                           (:id dashboard)
-                                                           (:category-name param-keys)))))))))))
-
+                   (mt/user-http-request :rasta :get 403 (chain-filter-values-url (:id dashboard) (:category-name param-keys)))))))))))
 
 (deftest chain-filter-search-test
   (testing "GET /api/dashboard/:id/params/:param-key/search/:query"

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -1461,9 +1461,10 @@
           (is (= {:values          ["African" "American" "Artisan"]
                   :has_more_values false}
                  (chain-filter-test/take-n-values 3 (mt/user-http-request :rasta :get 200 (chain-filter-values-url
-                                                                                           (:id dashboard)
-                                                                                           (:category-name param-keys)))))))))
-    (testing "should check perms for the Fields in question"
+                                                                                            (:id dashboard)
+                                                                                            (:category-name param-keys)))))))))
+
+    (testing "revoking data permissions does not change ability to view chain-filter values"
       (mt/with-temp-copy-of-db
         (with-chain-filter-fixtures [{:keys [dashboard param-keys]}]
           (perms/revoke-data-perms! (perms-group/all-users) (mt/id))
@@ -1471,8 +1472,22 @@
           ;; but 200 on calls that we could just use the cache.
           ;; It's not ideal and we definitely need to have a consistent behavior
           (with-redefs [field-values/field-should-have-field-values? (fn [_] false)]
+            (is (= {:values          ["African" "American" "Artisan"]
+                    :has_more_values false}
+                   (chain-filter-test/take-n-values
+                     3
+                     (mt/user-http-request :rasta :get 200 (chain-filter-values-url (:id dashboard) (:category-name param-keys))))))))))
+
+    (testing "when you cannot access the collection that a dashboard is in, cannot access the chain-filter values"
+      (with-chain-filter-fixtures [{:keys [dashboard param-keys]}]
+        (mt/with-temp Collection [collection]
+          (with-chain-filter-fixtures [{:keys [dashboard param-keys]} {:collection_id (:id collection)}]
+            (perms/revoke-collection-permissions! (perms-group/all-users) (:id collection))
             (is (= "You don't have permissions to do that."
-                   (mt/user-http-request :rasta :get 403 (chain-filter-values-url (:id dashboard) (:category-name param-keys)))))))))))
+                   (mt/user-http-request :rasta :get 403 (chain-filter-values-url
+                                                           (:id dashboard)
+                                                           (:category-name param-keys)))))))))))
+
 
 (deftest chain-filter-search-test
   (testing "GET /api/dashboard/:id/params/:param-key/search/:query"

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -1463,7 +1463,7 @@
                  (chain-filter-test/take-n-values 3 (mt/user-http-request :rasta :get 200 (chain-filter-values-url
                                                                                            (:id dashboard)
                                                                                            (:category-name param-keys)))))))))
-    (testing "should check perms for the Fields in question"
+    (testing "data permissions should not  perms for the Fields in question"
       (mt/with-temp-copy-of-db
         (with-chain-filter-fixtures [{:keys [dashboard param-keys]}]
           (perms/revoke-data-perms! (perms-group/all-users) (mt/id))
@@ -1471,8 +1471,15 @@
           ;; but 200 on calls that we could just use the cache.
           ;; It's not ideal and we definitely need to have a consistent behavior
           (with-redefs [field-values/field-should-have-field-values? (fn [_] false)]
-            (is (= "You don't have permissions to do that."
-                   (mt/user-http-request :rasta :get 403 (chain-filter-values-url (:id dashboard) (:category-name param-keys)))))))))))
+            (is (= {:values          ["African" "American" "Artisan"]
+                    :has_more_values false}
+                   (chain-filter-test/take-n-values 3 (mt/user-http-request
+                                                        :rasta
+                                                        :get
+                                                        200
+                                                        (chain-filter-values-url
+                                                          (:id dashboard)
+                                                          (:category-name param-keys))))))))))))
 
 (deftest chain-filter-search-test
   (testing "GET /api/dashboard/:id/params/:param-key/search/:query"

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -1397,6 +1397,16 @@
 
 (deftest dashboard-chain-filter-permissions-test
   (with-chain-filter-fixtures [{:keys [dashboard param-keys]}]
+    (let [url (chain-filter-values-url dashboard (:category-name param-keys))]
+      (testing (str "\nGET /api/" url "\n")
+        (testing "\nShow me names of categories that have expensive venues (price = 4), while I lack permisisons."
+          ;; shut off the cache:
+          (with-redefs [metabase.models.params.chain-filter/use-cached-field-values? (constantly false)]
+            (binding [qp.perms/*card-id* nil] ;; this situation was observed when running constrained chain filters.
+              (is
+                (=
+                  {:values ["African" "American" "Artisan" "Asian"] :has_more_values false}
+                  (chain-filter-test/take-n-values 4 (mt/user-http-request :rasta :get 200 url)))))))))
     (let [url (chain-filter-values-url dashboard (:category-name param-keys) (:price param-keys) 4)]
       (testing (str "\nGET /api/" url "\n")
         (testing "\nShow me names of categories that have expensive venues (price = 4), while I lack permisisons."


### PR DESCRIPTION
Fixes #24029 and #13537

## Example

When selecting filters, we do this smart thing on a dashboard: when you select filter values to narrow down results we constrain the possible selections on the next filter dropdown you click.

So if you had a table resturaunts with the relevant structure:

| *kind* | *price* | ... |
| --- | --- | --- |
| pizza | `low` | |
| bbq   | `high` | |
| steak | `high` | |
| steak | `medium` | |

with 2 filters, one for *kind* and one for *price*, And you select steak for the *kind* filter:

Then the *price* filter's dropdown should only show `high` and `medium`. Thats what I am calling the constrained version of the api call.

This behavior usually works, but the _constrained_ version of the api call fails when the user does not have a permission for self-service. The non-constrained version still works without permission for self-service. So I made a change to allow the constrained version to work without a permission for self-service.

The un-constrained call to `chain-filter` works, and has the card id bound to `*card-id*`.
The cause of this bug is that the constrained call to `chain-filter` did Not work,
because it did not have a value bound for `*card-id*`. `*card-id*` is
important because it is used to determine which sort of permissions check is used in the query
processor [here](https://github.com/metabase/metabase/blob/users-with-no-self-service-permissions-can-use-cascading-filters/src/metabase/query_processor/middleware/permissions.clj#L94). `*card-id*` being nil is what caused permissions errors.

This change adds back in `*card-id*` when it is missing, therefore using
the same permission flow as the un-constrained codepath.

---

Re-bind `*card-id*` to get a genuine permission check

- also updates comments with s/`:key`/`:param-key` to match the code