### PR TITLE
[E2E] Replace hard coded sample database IDs

### DIFF
--- a/frontend/test/metabase-visual/admin/permissions.cy.spec.js
+++ b/frontend/test/metabase-visual/admin/permissions.cy.spec.js
@@ -1,4 +1,9 @@
 import { restore } from "__support__/e2e/helpers";
+import { USER_GROUPS, SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+
+const { ALL_USERS_GROUP } = USER_GROUPS;
+const { PRODUCTS_ID } = SAMPLE_DATABASE;
 
 describe("visual tests > admin > permissions", () => {
   beforeEach(() => {
@@ -8,26 +13,30 @@ describe("visual tests > admin > permissions", () => {
 
   describe("data permissions", () => {
     it("database focused view", () => {
-      cy.visit("/admin/permissions/data/database/1");
+      cy.visit(`/admin/permissions/data/database/${SAMPLE_DB_ID}`);
       cy.findByPlaceholderText("Search for a group");
       cy.createPercySnapshot();
     });
 
     it("database focused view > table", () => {
-      cy.visit("/admin/permissions/data/database/1/schema/PUBLIC/table/1");
+      cy.visit(
+        `/admin/permissions/data/database/${SAMPLE_DB_ID}/schema/PUBLIC/table/${PRODUCTS_ID}`,
+      );
       cy.findByPlaceholderText("Search for a group");
       cy.findByPlaceholderText("Search for a table");
       cy.createPercySnapshot();
     });
 
     it("group focused view", () => {
-      cy.visit("/admin/permissions/data/group/1");
+      cy.visit(`/admin/permissions/data/group/${ALL_USERS_GROUP}`);
       cy.findByPlaceholderText("Search for a database");
       cy.createPercySnapshot();
     });
 
     it("group focused view > database", () => {
-      cy.visit("/admin/permissions/data/group/1/database/1");
+      cy.visit(
+        `/admin/permissions/data/group/${ALL_USERS_GROUP}/database/${SAMPLE_DB_ID}`,
+      );
       cy.findByPlaceholderText("Search for a table");
       cy.createPercySnapshot();
     });

--- a/frontend/test/metabase-visual/onboarding/urls.cy.spec.js
+++ b/frontend/test/metabase-visual/onboarding/urls.cy.spec.js
@@ -1,4 +1,5 @@
 import { restore } from "__support__/e2e/helpers";
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 
 describe("visual tests > onboarding > URLs", () => {
   beforeEach(() => {
@@ -52,7 +53,7 @@ describe("visual tests > onboarding > URLs", () => {
   });
 
   it("browse/1 (Sample Database)", () => {
-    cy.intercept("GET", `api/database/1/schemas`).as("schemas");
+    cy.intercept("GET", `api/database/${SAMPLE_DB_ID}/schemas`).as("schemas");
     cy.visit("/browse/1");
 
     cy.wait("@schemas");

--- a/frontend/test/metabase/scenarios/admin/databases/edit.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/edit.cy.spec.js
@@ -6,6 +6,8 @@ import {
   mockSessionProperty,
 } from "__support__/e2e/helpers";
 
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
+
 describe("scenarios > admin > databases > edit", () => {
   beforeEach(() => {
     restore();
@@ -17,14 +19,14 @@ describe("scenarios > admin > databases > edit", () => {
 
   describe("Database type", () => {
     it("should be disabled for the Sample Dataset (metabase#16382)", () => {
-      cy.visit("/admin/databases/1");
+      cy.visit(`/admin/databases/${SAMPLE_DB_ID}`);
       cy.findByText("H2").parentsUntil("a").should("be.disabled");
     });
   });
 
   describe("Connection settings", () => {
     it("shows the connection settings for sample database correctly", () => {
-      cy.visit("/admin/databases/1");
+      cy.visit(`/admin/databases/${SAMPLE_DB_ID}`);
       cy.findByLabelText("Display name").should(
         "have.value",
         "Sample Database",
@@ -35,7 +37,7 @@ describe("scenarios > admin > databases > edit", () => {
     });
 
     it("lets you modify the connection settings", () => {
-      cy.visit("/admin/databases/1");
+      cy.visit(`/admin/databases/${SAMPLE_DB_ID}`);
 
       cy.findByText("Show advanced options").click();
       cy.findByLabelText("Choose when syncs and scans happen").click();
@@ -51,7 +53,7 @@ describe("scenarios > admin > databases > edit", () => {
     });
 
     it("`auto_run_queries` toggle should be ON by default for `SAMPLE_DATABASE`", () => {
-      cy.visit("/admin/databases/1");
+      cy.visit(`/admin/databases/${SAMPLE_DB_ID}`);
 
       cy.findByText("Show advanced options").click();
       cy.findByLabelText("Rerun queries for simple explorations").should(
@@ -63,11 +65,11 @@ describe("scenarios > admin > databases > edit", () => {
 
     it("should respect the settings for automatic query running (metabase#13187)", () => {
       cy.log("Turn off `auto run queries`");
-      cy.request("PUT", "/api/database/1", {
+      cy.request("PUT", `/api/database/${SAMPLE_DB_ID}`, {
         auto_run_queries: false,
       });
 
-      cy.visit("/admin/databases/1");
+      cy.visit(`/admin/databases/${SAMPLE_DB_ID}`);
 
       cy.log("Reported failing on v0.36.4");
       cy.findByText("Show advanced options").click();
@@ -84,7 +86,7 @@ describe("scenarios > admin > databases > edit", () => {
       });
 
       it("allows to manage cache ttl", () => {
-        cy.visit("/admin/databases/1");
+        cy.visit(`/admin/databases/${SAMPLE_DB_ID}`);
 
         cy.findByText("Show advanced options").click();
         cy.findByText("Use instance default (TTL)").click();
@@ -114,7 +116,7 @@ describe("scenarios > admin > databases > edit", () => {
   describe("Scheduling settings", () => {
     beforeEach(() => {
       // Turn on scheduling without relying on the previous test(s)
-      cy.request("PUT", "/api/database/1", {
+      cy.request("PUT", `/api/database/${SAMPLE_DB_ID}`, {
         details: {
           "let-user-control-scheduling": true,
         },
@@ -123,7 +125,7 @@ describe("scenarios > admin > databases > edit", () => {
     });
 
     it("shows the initial scheduling settings correctly", () => {
-      cy.visit("/admin/databases/1");
+      cy.visit(`/admin/databases/${SAMPLE_DB_ID}`);
 
       cy.findByText("Show advanced options").click();
       cy.findByText("Database syncing")
@@ -136,7 +138,7 @@ describe("scenarios > admin > databases > edit", () => {
     });
 
     it("lets you change the metadata_sync period", () => {
-      cy.visit("/admin/databases/1");
+      cy.visit(`/admin/databases/${SAMPLE_DB_ID}`);
 
       cy.findByText("Show advanced options").click();
       cy.findByText("Database syncing").closest(".Form-field").as("sync");
@@ -159,7 +161,7 @@ describe("scenarios > admin > databases > edit", () => {
     });
 
     it("lets you change the cache_field_values perid", () => {
-      cy.visit("/admin/databases/1");
+      cy.visit(`/admin/databases/${SAMPLE_DB_ID}`);
       cy.findByText("Show advanced options").click();
 
       cy.findByText("Regularly, on a schedule")
@@ -181,7 +183,7 @@ describe("scenarios > admin > databases > edit", () => {
     });
 
     it("lets you change the cache_field_values to 'Only when adding a new filter widget'", () => {
-      cy.visit("/admin/databases/1");
+      cy.visit(`/admin/databases/${SAMPLE_DB_ID}`);
       cy.findByText("Show advanced options").click();
 
       cy.findByText("Only when adding a new filter widget").click();
@@ -193,7 +195,7 @@ describe("scenarios > admin > databases > edit", () => {
     });
 
     it("lets you change the cache_field_values to Never", () => {
-      cy.visit("/admin/databases/1");
+      cy.visit(`/admin/databases/${SAMPLE_DB_ID}`);
       cy.findByText("Show advanced options").click();
 
       cy.findByText("Never, I'll do this manually if I need to").click();
@@ -207,36 +209,42 @@ describe("scenarios > admin > databases > edit", () => {
 
   describe("Actions sidebar", () => {
     it("lets you trigger the manual database schema sync", () => {
-      cy.route("POST", "/api/database/1/sync_schema").as("sync_schema");
+      cy.route("POST", `/api/database/${SAMPLE_DB_ID}/sync_schema`).as(
+        "sync_schema",
+      );
 
-      cy.visit("/admin/databases/1");
+      cy.visit(`/admin/databases/${SAMPLE_DB_ID}`);
       cy.findByText("Sync database schema now").click();
       cy.wait("@sync_schema");
       cy.findByText("Sync triggered!");
     });
 
     it("lets you trigger the manual rescan of field values", () => {
-      cy.route("POST", "/api/database/1/rescan_values").as("rescan_values");
+      cy.route("POST", `/api/database/${SAMPLE_DB_ID}/rescan_values`).as(
+        "rescan_values",
+      );
 
-      cy.visit("/admin/databases/1");
+      cy.visit(`/admin/databases/${SAMPLE_DB_ID}`);
       cy.findByText("Re-scan field values now").click();
       cy.wait("@rescan_values");
       cy.findByText("Scan triggered!");
     });
 
     it("lets you discard saved field values", () => {
-      cy.route("POST", "/api/database/1/discard_values").as("discard_values");
+      cy.route("POST", `/api/database/${SAMPLE_DB_ID}/discard_values`).as(
+        "discard_values",
+      );
 
-      cy.visit("/admin/databases/1");
+      cy.visit(`/admin/databases/${SAMPLE_DB_ID}`);
       cy.findByText("Discard saved field values").click();
       cy.findByText("Yes").click();
       cy.wait("@discard_values");
     });
 
     it("lets you remove the Sample Database", () => {
-      cy.route("DELETE", "/api/database/1").as("delete");
+      cy.route("DELETE", `/api/database/${SAMPLE_DB_ID}`).as("delete");
 
-      cy.visit("/admin/databases/1");
+      cy.visit(`/admin/databases/${SAMPLE_DB_ID}`);
       cy.findByText("Remove this database").click();
       modal().within(() => {
         cy.get("input").type("Sample Database");
@@ -248,9 +256,9 @@ describe("scenarios > admin > databases > edit", () => {
     });
 
     it("should not display a setup help card", () => {
-      cy.intercept("GET", "/api/database/1").as("loadDatabase");
+      cy.intercept("GET", `/api/database/${SAMPLE_DB_ID}`).as("loadDatabase");
 
-      cy.visit("/admin/databases/1");
+      cy.visit(`/admin/databases/${SAMPLE_DB_ID}`);
       cy.wait("@loadDatabase");
 
       cy.findByText("Need help connecting?").should("not.exist");

--- a/frontend/test/metabase/scenarios/admin/databases/list.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/list.cy.spec.js
@@ -1,4 +1,5 @@
 import { restore, describeEE, isOSS } from "__support__/e2e/helpers";
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 
 describe("scenarios > admin > databases > list", () => {
   beforeEach(() => {
@@ -88,13 +89,13 @@ describe("scenarios > admin > databases > list", () => {
   it("should let you access edit page a database", () => {
     cy.visit("/admin/databases");
     cy.contains("Sample Database").click();
-    cy.url().should("match", /\/admin\/databases\/1$/);
+    cy.location("pathname").should("eq", `admin/databases/${SAMPLE_DB_ID}`);
   });
 
   it("should let you bring back the sample database", () => {
     cy.intercept("POST", "/api/database/sample_database").as("sample_database");
 
-    cy.request("DELETE", "/api/database/1").as("delete");
+    cy.request("DELETE", `/api/database/${SAMPLE_DB_ID}`).as("delete");
     cy.visit("/admin/databases");
     cy.contains("Bring the sample database back").click();
     cy.wait("@sample_database");

--- a/frontend/test/metabase/scenarios/admin/databases/list.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/list.cy.spec.js
@@ -89,7 +89,7 @@ describe("scenarios > admin > databases > list", () => {
   it("should let you access edit page a database", () => {
     cy.visit("/admin/databases");
     cy.contains("Sample Database").click();
-    cy.location("pathname").should("eq", `admin/databases/${SAMPLE_DB_ID}`);
+    cy.location("pathname").should("eq", `/admin/databases/${SAMPLE_DB_ID}`);
   });
 
   it("should let you bring back the sample database", () => {

--- a/frontend/test/metabase/scenarios/admin/datamodel/editor.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/editor.cy.spec.js
@@ -3,9 +3,9 @@ import { restore, popover, visitAlias } from "__support__/e2e/helpers";
 import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
-const { ORDERS_ID } = SAMPLE_DATABASE;
+const { ORDERS_ID, PRODUCTS_ID } = SAMPLE_DATABASE;
 
-const SAMPLE_DB_URL = "/admin/datamodel/database/1";
+const SAMPLE_DB_URL = `/admin/datamodel/database/${SAMPLE_DB_ID}`;
 
 // [quarantine] flaky
 describe.skip("scenarios > admin > datamodel > editor", () => {
@@ -115,7 +115,10 @@ describe.skip("scenarios > admin > datamodel > editor", () => {
 
     // click over to products and back so we refresh the columns
     cy.contains("Products").click();
-    cy.url().should("include", "/admin/datamodel/database/1/table/1");
+    cy.url().should(
+      "include",
+      `/admin/datamodel/database/${SAMPLE_DB_ID}/table/${PRODUCTS_ID}`,
+    );
     cy.contains("Orders").click();
 
     // created at should still be there

--- a/frontend/test/metabase/scenarios/admin/datamodel/field-type.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/field-type.cy.spec.js
@@ -1,4 +1,5 @@
 import { restore, visitAlias, popover } from "__support__/e2e/helpers";
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
@@ -17,7 +18,7 @@ describe("scenarios > admin > datamodel > field > field type", () => {
 
     ordersColumns.forEach(column => {
       cy.wrap(
-        `/admin/datamodel/database/1/table/${ORDERS_ID}/${ORDERS[column]}/general`,
+        `/admin/datamodel/database/${SAMPLE_DB_ID}/table/${ORDERS_ID}/${ORDERS[column]}/general`,
       ).as(`ORDERS_${column}_URL`);
     });
 

--- a/frontend/test/metabase/scenarios/admin/datamodel/field.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/field.cy.spec.js
@@ -5,7 +5,7 @@ import {
   popover,
   startNewQuestion,
 } from "__support__/e2e/helpers";
-
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
@@ -17,7 +17,7 @@ describe.skip("scenarios > admin > datamodel > field", () => {
 
     ["CREATED_AT", "PRODUCT_ID", "QUANTITY"].forEach(name => {
       cy.wrap(
-        `/admin/datamodel/database/1/table/${ORDERS_ID}/${ORDERS[name]}/general`,
+        `/admin/datamodel/database/${SAMPLE_DB_ID}/table/${ORDERS_ID}/${ORDERS[name]}/general`,
       ).as(`ORDERS_${name}_URL`);
     });
 

--- a/frontend/test/metabase/scenarios/admin/datamodel/hide_tables.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/hide_tables.cy.spec.js
@@ -3,7 +3,7 @@ import { restore, startNewQuestion } from "__support__/e2e/helpers";
 import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
-const { ORDERS_ID } = SAMPLE_DATABASE;
+const { ORDERS_ID, PRODUCTS_ID } = SAMPLE_DATABASE;
 
 describe("scenarios > admin > datamodel > hidden tables (metabase#9759)", () => {
   beforeEach(() => {
@@ -16,13 +16,13 @@ describe("scenarios > admin > datamodel > hidden tables (metabase#9759)", () => 
 
   it("hidden table should not show up in various places in UI", () => {
     // Visit the main page, we shouldn't be able to see the table
-    cy.visit("/browse/1");
+    cy.visit(`/browse/${PRODUCTS_ID}`);
     cy.contains("Products");
     cy.contains("Orders").should("not.exist");
 
     // It shouldn't show up for a normal user either
     cy.signInAsNormalUser();
-    cy.visit("/browse/1");
+    cy.visit(`/browse/${PRODUCTS_ID}`);
     cy.contains("Products");
     cy.contains("Orders").should("not.exist");
 

--- a/frontend/test/metabase/scenarios/admin/datamodel/metadata.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/metadata.cy.spec.js
@@ -5,6 +5,7 @@ import {
   popover,
   summarize,
 } from "__support__/e2e/helpers";
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID, REVIEWS, REVIEWS_ID } = SAMPLE_DATABASE;
@@ -17,7 +18,7 @@ describe("scenarios > admin > datamodel > metadata", () => {
 
   it("should correctly show remapped column value", () => {
     // go directly to Data Model page for Sample Database
-    cy.visit("/admin/datamodel/database/1");
+    cy.visit(`/admin/datamodel/database/${SAMPLE_DB_ID}`);
     // edit "Product ID" column in "Orders" table
     cy.findByText("Orders").click();
     cy.findByDisplayValue("Product ID").parent().find(".Icon-gear").click();
@@ -48,7 +49,7 @@ describe("scenarios > admin > datamodel > metadata", () => {
     };
 
     // go directly to Data Model page for Sample Database
-    cy.visit("/admin/datamodel/database/1");
+    cy.visit(`/admin/datamodel/database/${SAMPLE_DB_ID}`);
     // edit "Rating" values in "Reviews" table
     cy.findByText("Reviews").click();
     cy.findByDisplayValue("Rating").parent().find(".Icon-gear").click();
@@ -119,7 +120,7 @@ describe("scenarios > admin > datamodel > metadata", () => {
 
   it("display value 'custom mapping' should be available regardless of the chosen filtering type (metabase#16322)", () => {
     cy.visit(
-      `/admin/datamodel/database/1/table/${REVIEWS_ID}/${REVIEWS.RATING}/general`,
+      `/admin/datamodel/database/${SAMPLE_DB_ID}/table/${REVIEWS_ID}/${REVIEWS.RATING}/general`,
     );
 
     openOptionsForSection("Filtering on this field");

--- a/frontend/test/metabase/scenarios/admin/datamodel/reproductions/17768-entity-key-showing-binning-options.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/reproductions/17768-entity-key-showing-binning-options.cy.spec.js
@@ -4,6 +4,7 @@ import {
   popover,
   summarize,
 } from "__support__/e2e/helpers";
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { REVIEWS } = SAMPLE_DATABASE;
@@ -19,7 +20,7 @@ describe("issue 17768", () => {
     });
 
     // Sync "Sample Database" schema
-    cy.request("POST", `/api/database/1/sync_schema`);
+    cy.request("POST", `/api/database/${SAMPLE_DB_ID}/sync_schema`);
 
     waitForSyncToFinish();
 

--- a/frontend/test/metabase/scenarios/admin/datamodel/reproductions/18384-field-settings-breaks-ui.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/reproductions/18384-field-settings-breaks-ui.cy.spec.js
@@ -1,4 +1,5 @@
 import { restore } from "__support__/e2e/helpers";
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { PEOPLE_ID, PEOPLE, REVIEWS_ID } = SAMPLE_DATABASE;
@@ -16,13 +17,13 @@ describe("issue 18384", () => {
   });
 
   it("should be able to open field properties even when one of the tables is hidden (metabase#18384)", () => {
-    cy.visit(`/admin/datamodel/database/1/table/${PEOPLE_ID}`);
+    cy.visit(`/admin/datamodel/database/${SAMPLE_DB_ID}/table/${PEOPLE_ID}`);
 
     cy.findByDisplayValue("Address").parent().find(".Icon-gear").click();
 
     cy.location("pathname").should(
       "eq",
-      `/admin/datamodel/database/1/table/${PEOPLE_ID}/${PEOPLE.ADDRESS}/general`,
+      `/admin/datamodel/database/${SAMPLE_DB_ID}/table/${PEOPLE_ID}/${PEOPLE.ADDRESS}/general`,
     );
 
     cy.findByText(/Address – Field Settings/i);

--- a/frontend/test/metabase/scenarios/admin/datamodel/table.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/table.cy.spec.js
@@ -1,4 +1,5 @@
 import { restore, filter, visitQuestion } from "__support__/e2e/helpers";
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
@@ -10,12 +11,12 @@ describe("scenarios > admin > databases > table", () => {
   });
 
   it("should see four tables in sample database", () => {
-    cy.visit("/admin/datamodel/database/1");
+    cy.visit(`/admin/datamodel/database/${SAMPLE_DB_ID}`);
     cy.get(".AdminList-item").should("have.length", 4);
   });
 
   it("should be able to see details of each table", () => {
-    cy.visit("/admin/datamodel/database/1");
+    cy.visit(`/admin/datamodel/database/${SAMPLE_DB_ID}`);
     cy.findByText(
       "Select any table to see its schema and add or edit metadata.",
     );
@@ -39,7 +40,7 @@ describe("scenarios > admin > databases > table", () => {
 
   describe("in orders table", () => {
     beforeEach(() => {
-      cy.visit("/admin/datamodel/database/1/table/2");
+      cy.visit(`/admin/datamodel/database/${SAMPLE_DB_ID}/table/${ORDERS_ID}`);
     });
 
     it("should see multiple fields", () => {

--- a/frontend/test/metabase/scenarios/admin/people/people.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/people/people.cy.spec.js
@@ -10,7 +10,7 @@ import { USERS, USER_GROUPS } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { normal, admin } = USERS;
-const { DATA_GROUP } = USER_GROUPS;
+const { ALL_USERS_GROUP, DATA_GROUP } = USER_GROUPS;
 const TOTAL_USERS = Object.entries(USERS).length;
 const TOTAL_GROUPS = Object.entries(USER_GROUPS).length;
 const { ORDERS_ID } = SAMPLE_DATABASE;
@@ -354,7 +354,7 @@ describe("scenarios > admin > people", () => {
 
       it("should allow paginating group members forward and backward", () => {
         const PAGE_SIZE = 25;
-        cy.visit("admin/people/groups/1");
+        cy.visit(`admin/people/groups/${ALL_USERS_GROUP}`);
 
         // Total
         cy.findByText(`${NEW_TOTAL_USERS} members`);

--- a/frontend/test/metabase/scenarios/admin/troubleshooting/tasks.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/troubleshooting/tasks.cy.spec.js
@@ -1,4 +1,5 @@
 import { restore } from "__support__/e2e/helpers";
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 
 describe("scenarios > admin > troubleshooting > tasks", () => {
   beforeEach(() => {
@@ -11,7 +12,7 @@ describe("scenarios > admin > troubleshooting > tasks", () => {
     // Since this happens async, that number may vary but it should always be greater than 50 [1] and less than 100 [2]
     // Note: each sync generates 6 tasks and we start with 12 tasks already for the testing sample database
     for (let i = 0; i < 13; i++) {
-      cy.request("POST", "/api/database/1/sync_schema");
+      cy.request("POST", `/api/database/${SAMPLE_DB_ID}/sync_schema`);
     }
     cy.server();
     cy.route("GET", "/api/task?limit=50&offset=0").as("tasks");

--- a/frontend/test/metabase/scenarios/custom-column/reproductions/14843-cc-apply-filter-not-equal-to.cy.spec.js
+++ b/frontend/test/metabase/scenarios/custom-column/reproductions/14843-cc-apply-filter-not-equal-to.cy.spec.js
@@ -1,4 +1,5 @@
 import { restore, popover, visualize, filter } from "__support__/e2e/helpers";
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { PEOPLE, PEOPLE_ID } = SAMPLE_DATABASE;
@@ -15,7 +16,9 @@ const questionDetails = {
 describe("issue 14843", () => {
   beforeEach(() => {
     cy.intercept("POST", "/api/dataset").as("dataset");
-    cy.intercept("GET", "/api/database/1/schema/PUBLIC").as("schema");
+    cy.intercept("GET", `/api/database/${SAMPLE_DB_ID}/schema/PUBLIC`).as(
+      "schema",
+    );
 
     restore();
     cy.signInAsAdmin();

--- a/frontend/test/metabase/scenarios/custom-column/reproductions/21135-cc-same-name-as-existing-column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/custom-column/reproductions/21135-cc-same-name-as-existing-column.cy.spec.js
@@ -1,4 +1,5 @@
 import { restore } from "__support__/e2e/helpers";
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { PRODUCTS_ID, PRODUCTS } = SAMPLE_DATABASE;
@@ -42,7 +43,9 @@ describe("issue 21135", () => {
 });
 
 function switchToNotebookView() {
-  cy.intercept("GET", "/api/database/1/schema/PUBLIC").as("publicSchema");
+  cy.intercept("GET", `/api/database/${SAMPLE_DB_ID}/schema/PUBLIC`).as(
+    "publicSchema",
+  );
 
   cy.icon("notebook").click();
   cy.wait("@publicSchema");

--- a/frontend/test/metabase/scenarios/filters/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/filter.cy.spec.js
@@ -759,7 +759,7 @@ describe("scenarios > question > filter", () => {
   describe("currency filters", () => {
     beforeEach(() => {
       // set the currency on the Orders/Discount column to Euro
-      cy.visit("/admin/datamodel/database/1/table/2");
+      cy.visit(`/admin/datamodel/database/${SAMPLE_DB_ID}/table/${ORDERS_ID}`);
       // this value isn't actually selected, it's just the default
       cy.findByText("US Dollar").click();
       cy.findByText("Euro").click();

--- a/frontend/test/metabase/scenarios/joins/reproductions/18502-cannot-join-two-saved-questions-same-table.cy.spec.js
+++ b/frontend/test/metabase/scenarios/joins/reproductions/18502-cannot-join-two-saved-questions-same-table.cy.spec.js
@@ -4,6 +4,8 @@ import {
   visualize,
   startNewQuestion,
 } from "__support__/e2e/helpers";
+
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { PEOPLE, PEOPLE_ID } = SAMPLE_DATABASE;
@@ -19,7 +21,7 @@ describe("issue 18502", () => {
   });
 
   it("should be able to join two saved questions based on the same table (metabase#18502)", () => {
-    cy.intercept("/api/database/1/schema/PUBLIC").as("schema");
+    cy.intercept(`/api/database/${SAMPLE_DB_ID}/schema/PUBLIC`).as("schema");
 
     cy.createQuestion(question1);
     cy.createQuestion(question2);

--- a/frontend/test/metabase/scenarios/joins/reproductions/20519-cannot-join-on-aggregation-with-implicit-joins-and-nested-query.cy.spec.js
+++ b/frontend/test/metabase/scenarios/joins/reproductions/20519-cannot-join-on-aggregation-with-implicit-joins-and-nested-query.cy.spec.js
@@ -3,6 +3,8 @@ import {
   enterCustomColumnDetails,
   visualize,
 } from "__support__/e2e/helpers";
+
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
@@ -63,7 +65,9 @@ describe("issue 20519", () => {
 });
 
 function switchToNotebookView() {
-  cy.intercept("GET", "/api/database/1/schema/PUBLIC").as("publicSchema");
+  cy.intercept("GET", `/api/database/${SAMPLE_DB_ID}/schema/PUBLIC`).as(
+    "publicSchema",
+  );
 
   cy.icon("notebook").click();
   cy.wait("@publicSchema");

--- a/frontend/test/metabase/scenarios/models/models.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models.cy.spec.js
@@ -16,6 +16,7 @@ import {
   closeQuestionActions,
 } from "__support__/e2e/helpers";
 
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 import { questionInfoButton } from "../../../__support__/e2e/helpers/e2e-ui-elements-helpers";
 
@@ -245,7 +246,7 @@ describe("scenarios > models", () => {
     });
 
     it("allows to create a question based on a model", () => {
-      cy.intercept("/api/database/1/schema/PUBLIC").as("schema");
+      cy.intercept(`/api/database/${SAMPLE_DB_ID}/schema/PUBLIC`).as("schema");
       startNewQuestion();
 
       popover().within(() => {

--- a/frontend/test/metabase/scenarios/permissions/admin-permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/admin-permissions.cy.spec.js
@@ -14,8 +14,11 @@ import {
 } from "__support__/e2e/helpers";
 
 import { SAMPLE_DB_ID, USER_GROUPS } from "__support__/e2e/cypress_data";
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
-const { ALL_USERS_GROUP } = USER_GROUPS;
+const { ORDERS_ID } = SAMPLE_DATABASE;
+
+const { ALL_USERS_GROUP, ADMIN_GROUP } = USER_GROUPS;
 
 const COLLECTION_ACCESS_PERMISSION_INDEX = 0;
 
@@ -31,10 +34,12 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
   });
 
   it("shows hidden tables", () => {
-    cy.visit("/admin/datamodel/database/1");
+    cy.visit(`/admin/datamodel/database/${SAMPLE_DB_ID}`);
     cy.icon("eye_crossed_out").eq(0).click();
 
-    cy.visit("admin/permissions/data/group/1/database/1");
+    cy.visit(
+      `admin/permissions/data/group/${ALL_USERS_GROUP}/database/${SAMPLE_DB_ID}`,
+    );
 
     assertPermissionTable([
       ["Orders", "No self-service", "No"],
@@ -46,7 +51,7 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
 
   it("should display error on failed save", () => {
     // revoke some permissions
-    cy.visit("/admin/permissions/data/group/1");
+    cy.visit(`/admin/permissions/data/group/${ALL_USERS_GROUP}`);
     cy.icon("eye").first().click();
     cy.findAllByRole("option").contains("Unrestricted").click();
 
@@ -281,7 +286,10 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
 
         selectSidebarItem("Administrators");
 
-        cy.url().should("include", "/admin/permissions/data/group/2");
+        cy.url().should(
+          "include",
+          `/admin/permissions/data/group/${ADMIN_GROUP}`,
+        );
 
         cy.findByText("Permissions for the Administrators group");
         cy.findByText("1 person");
@@ -499,7 +507,9 @@ describeEE("scenarios > admin > permissions", () => {
   });
 
   it("allows editing sandboxed access in the database focused view", () => {
-    cy.visit("/admin/permissions/data/database/1/schema/PUBLIC/table/2");
+    cy.visit(
+      `/admin/permissions/data/database/${SAMPLE_DB_ID}/schema/PUBLIC/table/${ORDERS_ID}`,
+    );
 
     modifyPermission("All Users", DATA_ACCESS_PERMISSION_INDEX, "Sandboxed");
 
@@ -510,7 +520,7 @@ describeEE("scenarios > admin > permissions", () => {
 
     cy.url().should(
       "include",
-      "/admin/permissions/data/database/1/schema/PUBLIC/table/2/segmented/group/1",
+      `/admin/permissions/data/database/${SAMPLE_DB_ID}/schema/PUBLIC/table/${ORDERS_ID}/segmented/group/${ALL_USERS_GROUP}`,
     );
     cy.findByText("Grant sandboxed access to this table");
     cy.button("Save").should("be.disabled");
@@ -539,7 +549,7 @@ describeEE("scenarios > admin > permissions", () => {
 
     cy.url().should(
       "include",
-      "/admin/permissions/data/database/1/schema/PUBLIC/table/2/segmented/group/1",
+      `/admin/permissions/data/database/${SAMPLE_DB_ID}/schema/PUBLIC/table/${ORDERS_ID}/segmented/group/${ALL_USERS_GROUP}`,
     );
     cy.findByText("Grant sandboxed access to this table");
 
@@ -559,7 +569,7 @@ describeEE("scenarios > admin > permissions", () => {
   });
 
   it("'block' data permission should not have editable 'native query editing' option (metabase#17738)", () => {
-    cy.visit("/admin/permissions/data/database/1");
+    cy.visit(`/admin/permissions/data/database/${SAMPLE_DB_ID}`);
 
     cy.findByText("All Users")
       .closest("tr")

--- a/frontend/test/metabase/scenarios/permissions/data-model-permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/data-model-permissions.cy.spec.js
@@ -6,6 +6,11 @@ import {
   modifyPermission,
 } from "__support__/e2e/helpers";
 
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+
+const { ORDERS_ID } = SAMPLE_DATABASE;
+
 const DATA_ACCESS_PERMISSION_INDEX = 0;
 const DATA_MODEL_PERMISSION_INDEX = 3;
 
@@ -23,7 +28,7 @@ describeEE("scenarios > admin > permissions", () => {
   });
 
   it("allows data model permission for a table in database", () => {
-    cy.visit("/admin/permissions/data/database/1");
+    cy.visit(`/admin/permissions/data/database/${SAMPLE_DB_ID}`);
 
     // Change permission
     modifyPermission("All Users", DATA_ACCESS_PERMISSION_INDEX, "Granular");
@@ -66,7 +71,7 @@ describeEE("scenarios > admin > permissions", () => {
   });
 
   it("allows changing data model permission for an entire database", () => {
-    cy.visit("/admin/permissions/data/database/1");
+    cy.visit(`/admin/permissions/data/database/${SAMPLE_DB_ID}`);
 
     // Change data model permission
     modifyPermission("All Users", DATA_MODEL_PERMISSION_INDEX, "Yes");
@@ -94,7 +99,7 @@ describeEE("scenarios > admin > permissions", () => {
   });
 
   it("shows `Field access denied` for foreign keys from tables user does not have access to (metabase#21762)", () => {
-    cy.visit("/admin/permissions/data/database/1");
+    cy.visit(`/admin/permissions/data/database/${SAMPLE_DB_ID}`);
 
     // Change data model permission
     modifyPermission("All Users", DATA_MODEL_PERMISSION_INDEX, "Granular");
@@ -106,7 +111,7 @@ describeEE("scenarios > admin > permissions", () => {
 
     // Check limited access as a non-admin user
     cy.signIn("none");
-    cy.visit("/admin/datamodel/database/1/table/2");
+    cy.visit(`/admin/datamodel/database/${SAMPLE_DB_ID}/table/${ORDERS_ID}`);
 
     // Find foreign key from table the user does not have access to
     cy.findByTestId("column-USER_ID").within(() => {

--- a/frontend/test/metabase/scenarios/permissions/database-details-permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/database-details-permissions.cy.spec.js
@@ -6,6 +6,8 @@ import {
   modifyPermission,
 } from "__support__/e2e/helpers";
 
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
+
 const DATA_ACCESS_PERMISSION_INDEX = 0;
 const DETAILS_PERMISSION_INDEX = 4;
 
@@ -19,7 +21,7 @@ describeEE(
 
     it("allows database managers to see and edit database details but not to delete a database (metabase#22293)", () => {
       // As an admin, grant database details permissions to all users
-      cy.visit("/admin/permissions/data/database/1");
+      cy.visit(`/admin/permissions/data/database/${SAMPLE_DB_ID}`);
 
       modifyPermission(
         "All Users",
@@ -62,7 +64,7 @@ describeEE(
 
       cy.request({
         method: "DELETE",
-        url: "/api/database/1",
+        url: `/api/database/${SAMPLE_DB_ID}`,
         failOnStatusCode: false,
       }).then(({ status }) => {
         expect(status).to.eq(403);

--- a/frontend/test/metabase/scenarios/permissions/reproductions/17763-cannot-edit-granular-after-block.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/reproductions/17763-cannot-edit-granular-after-block.cy.spec.js
@@ -1,5 +1,5 @@
 import { restore, popover, describeEE } from "__support__/e2e/helpers";
-import { USER_GROUPS } from "__support__/e2e/cypress_data";
+import { SAMPLE_DB_ID, USER_GROUPS } from "__support__/e2e/cypress_data";
 
 const { ALL_USERS_GROUP } = USER_GROUPS;
 
@@ -16,7 +16,7 @@ describeEE("issue 17763", () => {
   });
 
   it('should be able to edit tables permissions in granular view after "block" permissions (metabase#17763)', () => {
-    cy.visit("/admin/permissions/data/database/1");
+    cy.visit(`/admin/permissions/data/database/${SAMPLE_DB_ID}`);
 
     cy.findByText("Block").click();
 
@@ -24,7 +24,7 @@ describeEE("issue 17763", () => {
 
     cy.location("pathname").should(
       "eq",
-      `/admin/permissions/data/group/${ALL_USERS_GROUP}/database/1`,
+      `/admin/permissions/data/group/${ALL_USERS_GROUP}/database/${SAMPLE_DB_ID}`,
     );
 
     cy.findByTestId("permission-table").within(() => {

--- a/frontend/test/metabase/scenarios/permissions/reproductions/17777-hidden-tables-not-available.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/reproductions/17777-hidden-tables-not-available.cy.spec.js
@@ -1,5 +1,8 @@
 import { restore, popover } from "__support__/e2e/helpers";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+import { USER_GROUPS, SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
+
+const { ALL_USERS_GROUP } = USER_GROUPS;
 
 const { ORDERS_ID, PRODUCTS_ID, PEOPLE_ID, REVIEWS_ID } = SAMPLE_DATABASE;
 
@@ -12,14 +15,14 @@ describe.skip("issue 17777", () => {
   });
 
   it("should still be able to set permissions on individual tables, even though they are hidden in data model (metabase#17777)", () => {
-    cy.visit("/admin/permissions/data/group/1");
+    cy.visit(`/admin/permissions/data/group/${ALL_USERS_GROUP}`);
 
     cy.findByText("Permissions for the All Users group");
     cy.findByTextEnsureVisible("Sample Database").click();
 
     cy.location("pathname").should(
       "eq",
-      "/admin/permissions/data/group/1/database/1",
+      `/admin/permissions/data/group/${ALL_USERS_GROUP}/database/${SAMPLE_DB_ID}`,
     );
 
     cy.findByTestId("permission-table").within(() => {

--- a/frontend/test/metabase/scenarios/permissions/sandboxes.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/sandboxes.cy.spec.js
@@ -727,7 +727,9 @@ describeEE("formatting > sandboxes", () => {
         native: { query: "SELECT CAST(ID AS VARCHAR) AS ID FROM ORDERS;" },
       });
 
-      cy.visit("/admin/permissions/data/database/1/schema/PUBLIC/table/2");
+      cy.visit(
+        `/admin/permissions/data/database/${SAMPLE_DB_ID}/schema/PUBLIC/table/${ORDERS_ID}`,
+      );
       cy.wait("@tablePermissions");
       cy.icon("eye")
         .eq(1) // No better way of doing this, undfortunately (see table above)


### PR DESCRIPTION
As part of https://github.com/metabase/metabase/issues/20722, it's been long overdue to fix all database and table hard coded IDs in our E2E tests.

Never ever ever use hard coded IDs because those can easily change. Variables will always be in sync and up to date with the real world scenario.