### PR TITLE
Derive backend application-colors from frontend palette

### DIFF
--- a/frontend/src/metabase/static-viz/index.js
+++ b/frontend/src/metabase/static-viz/index.js
@@ -1,9 +1,15 @@
 import React from "react";
 import ReactDOMServer from "react-dom/server";
 import StaticChart from "./containers/StaticChart";
+import { colors, color } from "metabase/lib/colors/palette";
 
 export function RenderChart(type, options) {
   return ReactDOMServer.renderToStaticMarkup(
     <StaticChart type={type} options={options} />,
   );
 }
+
+export function color_from_name(name) {
+  return color(name);
+}
+export const defaultColors = colors;

--- a/resources/frontend_shared/static_viz_interface.js
+++ b/resources/frontend_shared/static_viz_interface.js
@@ -107,3 +107,20 @@ function progress(data, settings) {
     settings: JSON.parse(settings),
   });
 }
+
+function default_colors() {
+    const defaults = StaticViz.defaultColors;
+    let light_colors = {};
+    Object.keys(defaults).map(k => {
+        const name = k.toString() + "-light";
+        light_colors[name] = StaticViz.color_from_name(name);
+    });
+    let dark_colors = {};
+    Object.keys(defaults).map(k => {
+        const name = k.toString() + "-dark";
+        dark_colors[name] = StaticViz.color_from_name(name);
+    });
+
+    let all_colors = {"default": defaults, "light": light_colors, "dark": dark_colors,};
+    return JSON.stringify(all_colors);
+}

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -365,6 +365,12 @@
    "#c589b9" "#efce8c" "#b5f95c" "#e35850" "#554dbf" "#bec589" "#8cefc6" "#5cc2f9" "#55e350" "#bf4d4f"
    "#89c3c5" "#be8cef" "#f95cd0" "#50e3ae" "#bf974d" "#899bc5" "#ef8cde" "#f95c67"])
 
+(def ^:private application-colors
+  "Colors for charts. These are defined in /metabase/frontend/src/metabase/lib/colors/palette.ts and merged with `public-settings/application-colors`."
+  (merge
+    (js-svg/default-colors)
+    (public-settings/application-colors)))
+
 (defn format-percentage
   "Format a percentage which includes site settings for locale. The first arg is a numeric value to format. The second
   is an optional string of decimal and grouping symbols to be used, ie \".,\". There will soon be a values.clj file

--- a/src/metabase/pulse/render/js_svg.clj
+++ b/src/metabase/pulse/render/js_svg.clj
@@ -39,6 +39,18 @@
   ;; todo is this thread safe? Should we have a resource pool on top of this? Or create them fresh for each invocation
   (delay (static-viz-context)))
 
+(defn default-colors
+  []
+  (let [{:keys [default light dark]} (-> (js/execute-fn-name @context "default_colors")
+                                         str
+                                         json/parse-string
+                                         (update-keys keyword))]
+    (-> (merge
+          default
+          (into {} (remove (fn [[k v]] (= k v)) light))
+          (into {} (remove (fn [[k v]] (= k v)) dark)))
+        (update-keys keyword))))
+
 (defn- post-process
   "Mutate in place the elements of the svg document. Remove the fill=transparent attribute in favor of
   fill-opacity=0.0. Our svg image renderer only understands the latter. Mutation is unfortunately necessary as the


### PR DESCRIPTION
Since we are building a static-viz bundle and calling JS from the backend, I figured it might be useful to grab the
palette definition from the frontend and give an interface to it.

Using the interface, you can build a Clojure map `application-colors` that contains all of the initial color values for the app's palette. Combining this with the `public-settings/application-colors`, we should be able to more reliably pass correct colors to static visualizations, since we can use the same keys as the frontend visualizations. For example, instead of `(nth colors 1)` for the `waterfallPositive` color, we could pass application-colors map (JSON-ified) to the JS side of things, where the component could reliably look up "accent1" in settings.colors (or some appropriate location).

The map `application-colors` looks like this:

```clojure
{:saturated-purple "#885AB1",
 :accent2 "#A989C5",
 :accent0-dark "#227FD2",
 :saturated-green "#70A63A",
 :accent5 "#F2A86F",
 :text-light "#B8BBC3",
 :bg-medium "#EDF2F5",
 :accent3-light "#F7C4C4",
 :bg-light "#F9FBFC",
 :white "#FFFFFF",
 :text-white "#FFFFFF",
 :accent5-dark "#ED8535",
 :saturated-red "#ED6E6E",
 :accent6-light "#C7EAEA",
 :accent3-dark "#E75454",
 :accent2-light "#C8B4DA",
 :accent1-light "#A7D07C",
 :bg-black "#2E353B",
 :admin-navbar "#7172AD",
 :accent6 "#98D9D9",
 :brand "#509EE3",
 :accent1 "#88BF4D",
 :brand-light "hsl(208.20000000000005, 72.4%, 92.2%)",
 :accent3 "#EF8C8C",
 :warning "#F9CF48",
 :filter "#7172AD",
 :accent0-light "#87BCEC",
 :danger "#ED6E6E",
 :success "#84BB4C",
 :bg-yellow "#FFFCF2",
 :accent6-dark "#69C8C8",
 :bg-night "#42484E",
 :accent0 "#509EE3",
 :accent4 "#F9D45C",
 :text-medium "#949AAB",
 :accent7-light "#999AC4",
 :accent2-dark "#8A5EB0",
 :bg-dark "#93A1AB",
 :text-dark "#4C5773",
 :bg-white "#FFFFFF",
 :error "#ED6E6E",
 :saturated-yellow "#F9CF48",
 :accent7-dark "#51528D",
 :accent4-dark "#F7C41F",
 :border "#EEECEC",
 :shadow "rgba(0,0,0,0.08)",
 :accent1-dark "#689636",
 :saturated-blue "#2D86D4",
 :accent7 "#7172AD",
 :accent4-light "#FBE499",
 :accent5-light "#F7CBA9",
 :bg-error "#ED6E6E55",
 :summarize "#88BF4D",
 :black "#2E353B"}
```

Which contains some useful keys that `public-settings/application-colors` will never have (as of this writing), for example, `:text-dark`, which is the color used for waterfallTotal in the frontend component.

### Caveat for this current approach
There are several color values which are derived: `accent1-light` is derived from `accent1` for instance. The values in the map on the backend perform this derivation only once, and always with the app's defaults, so those derived values will be wrong if there's a custom palette defined by the user.

The functions that calculate these values could be implemented on the backend to avoid this issue, but that's not done as of right now.