### PR TITLE
Consolidate query/http action helpers

### DIFF
--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx
@@ -593,8 +593,8 @@ function ActionOptions({ dashcard, clickBehavior, updateSettings }) {
               {actions.map(action => (
                 <ActionOption
                   key={action.id}
-                  name={action.card?.name || action.name}
-                  description={action.card?.description || action.description}
+                  name={action.name}
+                  description={action.description}
                   isSelected={clickBehavior.action === action.id}
                   onClick={() =>
                     updateSettings({
@@ -607,15 +607,11 @@ function ActionOptions({ dashcard, clickBehavior, updateSettings }) {
               ))}
               {selectedAction && (
                 <ClickMappings
-                  object={
-                    selectedAction.type === "query"
-                      ? selectedAction.card
-                      : selectedAction
-                  }
+                  isAction
+                  object={selectedAction}
                   dashcard={dashcard}
                   clickBehavior={clickBehavior}
                   updateSettings={updateSettings}
-                  isHTTPAction={selectedAction.type === "http"}
                 />
               )}
             </>

--- a/frontend/src/metabase/dashboard/components/ClickMappings.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickMappings.jsx
@@ -115,11 +115,11 @@ class ClickMappingsInner extends React.Component {
 
 const ClickMappings = _.compose(
   loadQuestionMetadata((state, props) =>
-    props.isDash || props.isHTTPAction ? null : props.object,
+    props.isDash || props.isAction ? null : props.object,
   ),
   withUserAttributes,
   connect((state, props) => {
-    const { object, isDash, isHTTPAction, dashcard, clickBehavior } = props;
+    const { object, isDash, dashcard, clickBehavior } = props;
     const metadata = getMetadata(state, props);
     let parameters = getParameters(state, props);
 
@@ -138,8 +138,8 @@ const ClickMappings = _.compose(
 
     const [setTargets, unsetTargets] = _.partition(
       getTargetsWithSourceFilters({
+        isAction: props.isAction,
         isDash,
-        isHTTPAction,
         dashcard,
         object,
         metadata,

--- a/frontend/src/metabase/dashboard/containers/ActionParametersInputModal.tsx
+++ b/frontend/src/metabase/dashboard/containers/ActionParametersInputModal.tsx
@@ -57,11 +57,10 @@ function ActionParametersInputModal({
   }
 
   const action = emitter.action;
-  const title = action.type === "query" ? action.card.name : action.name;
 
   return (
     <Modal onClose={closeActionParametersModal}>
-      <ModalContent title={title} onClose={closeActionParametersModal}>
+      <ModalContent title={action.name} onClose={closeActionParametersModal}>
         <ActionParametersInputForm
           {...formProps}
           onSubmitSuccess={closeActionParametersModal}

--- a/frontend/src/metabase/lib/click-behavior.js
+++ b/frontend/src/metabase/lib/click-behavior.js
@@ -74,21 +74,21 @@ function notRelativeDateOrRange({ type }) {
 
 export function getTargetsWithSourceFilters({
   isDash,
-  isHTTPAction,
+  isAction,
   dashcard,
   object,
   metadata,
 }) {
-  if (isHTTPAction) {
-    return getTargetsForHTTPAction(object);
+  if (isAction) {
+    return getTargetsForAction(object);
   }
   return isDash
     ? getTargetsForDashboard(object, dashcard)
     : getTargetsForQuestion(object, metadata);
 }
 
-function getTargetsForHTTPAction(template) {
-  const parameters = Object.values(template.parameters);
+function getTargetsForAction(action) {
+  const parameters = Object.values(action.parameters);
   return parameters.map(parameter => {
     const { id, name } = parameter;
     return {

--- a/frontend/src/metabase/query_builder/actions/writeback.ts
+++ b/frontend/src/metabase/query_builder/actions/writeback.ts
@@ -1,6 +1,5 @@
 import _ from "underscore";
 import { t } from "ttag";
-import { push } from "react-router-redux";
 
 import { addUndo } from "metabase/redux/undo";
 
@@ -9,17 +8,6 @@ import { Dispatch, GetState } from "metabase-types/store";
 import { getQuestion } from "../selectors";
 
 import { apiUpdateQuestion } from "./core";
-import Actions from "metabase/entities/actions";
-import {
-  HttpActionErrorHandle,
-  HttpActionResponseHandle,
-  HttpActionTemplate,
-} from "metabase/writeback/types";
-import {
-  Parameter,
-  ParameterId,
-  ParameterTarget,
-} from "metabase-types/types/Parameter";
 
 export const turnQuestionIntoAction =
   () => async (dispatch: Dispatch, getState: GetState) => {
@@ -47,62 +35,4 @@ export const turnActionIntoQuestion =
         actions: [apiUpdateQuestion(action, { rerunQuery: true })],
       }),
     );
-  };
-
-export type CreateHttpActionPayload = {
-  name: string;
-  description: string;
-  template: HttpActionTemplate;
-  response_handle: HttpActionResponseHandle;
-  error_handle: HttpActionErrorHandle;
-  parameters: Record<ParameterId, Parameter>;
-  parameter_mappings: Record<ParameterId, ParameterTarget>;
-};
-
-export const createHttpAction =
-  (payload: CreateHttpActionPayload) =>
-  async (dispatch: Dispatch, getState: GetState) => {
-    const {
-      name,
-      description,
-      template,
-      error_handle = null,
-      response_handle = null,
-      parameters,
-      parameter_mappings,
-    } = payload;
-    const data = {
-      method: template.method || "GET",
-      url: template.url,
-      body: template.body || JSON.stringify({}),
-      headers: JSON.stringify(template.headers || {}),
-      parameters: template.parameters || {},
-      parameter_mappings: template.parameter_mappings || {},
-    };
-    const newAction = {
-      name,
-      type: "http",
-      description,
-      template: data,
-      error_handle,
-      response_handle,
-      parameters,
-      parameter_mappings,
-    };
-    const response = await dispatch(Actions.actions.create(newAction));
-    const action = Actions.HACK_getObjectFromAction(response);
-    if (action.id) {
-      dispatch(
-        addUndo({
-          message: t`Action saved!`,
-        }),
-      );
-      dispatch(push(`/action/${action.id}`));
-    } else {
-      dispatch(
-        addUndo({
-          message: t`Could not save action`,
-        }),
-      );
-    }
   };

--- a/frontend/src/metabase/query_builder/components/QueryModals.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryModals.jsx
@@ -24,7 +24,6 @@ import QuestionHistoryModal from "metabase/query_builder/containers/QuestionHist
 import { CreateAlertModalContent } from "metabase/query_builder/components/AlertModals";
 import { ImpossibleToCreateModelModal } from "metabase/query_builder/components/ImpossibleToCreateModelModal";
 import NewDatasetModal from "metabase/query_builder/components/NewDatasetModal";
-
 import EntityCopyModal from "metabase/entities/containers/EntityCopyModal";
 import BulkFilterModal from "metabase/query_builder/components/filters/modals/BulkFilterModal";
 import NewEventModal from "metabase/timelines/questions/containers/NewEventModal";

--- a/frontend/src/metabase/writeback/actions.ts
+++ b/frontend/src/metabase/writeback/actions.ts
@@ -1,5 +1,24 @@
+import { t } from "ttag";
+import { push } from "react-router-redux";
+
+import Actions from "metabase/entities/actions";
 import { ActionsApi } from "metabase/services";
+import { addUndo } from "metabase/redux/undo";
+
 import Table from "metabase-lib/lib/metadata/Table";
+
+import {
+  Parameter,
+  ParameterId,
+  ParameterTarget,
+} from "metabase-types/types/Parameter";
+import { Dispatch, GetState } from "metabase-types/store";
+
+import {
+  HttpActionErrorHandle,
+  HttpActionResponseHandle,
+  HttpActionTemplate,
+} from "./types";
 
 export type InsertRowPayload = {
   table: Table;
@@ -97,3 +116,61 @@ export const deleteManyRows = (payload: BulkDeletePayload) => {
     { bodyParamName: "body" },
   );
 };
+
+export type CreateHttpActionPayload = {
+  name: string;
+  description: string;
+  template: HttpActionTemplate;
+  response_handle: HttpActionResponseHandle;
+  error_handle: HttpActionErrorHandle;
+  parameters: Record<ParameterId, Parameter>;
+  parameter_mappings: Record<ParameterId, ParameterTarget>;
+};
+
+export const createHttpAction =
+  (payload: CreateHttpActionPayload) =>
+  async (dispatch: Dispatch, getState: GetState) => {
+    const {
+      name,
+      description,
+      template,
+      error_handle = null,
+      response_handle = null,
+      parameters,
+      parameter_mappings,
+    } = payload;
+    const data = {
+      method: template.method || "GET",
+      url: template.url,
+      body: template.body || JSON.stringify({}),
+      headers: JSON.stringify(template.headers || {}),
+      parameters: template.parameters || {},
+      parameter_mappings: template.parameter_mappings || {},
+    };
+    const newAction = {
+      name,
+      type: "http",
+      description,
+      template: data,
+      error_handle,
+      response_handle,
+      parameters,
+      parameter_mappings,
+    };
+    const response = await dispatch(Actions.actions.create(newAction));
+    const action = Actions.HACK_getObjectFromAction(response);
+    if (action.id) {
+      dispatch(
+        addUndo({
+          message: t`Action saved!`,
+        }),
+      );
+      dispatch(push(`/action/${action.id}`));
+    } else {
+      dispatch(
+        addUndo({
+          message: t`Could not save action`,
+        }),
+      );
+    }
+  };

--- a/frontend/src/metabase/writeback/containers/ActionParametersInputForm/ActionParametersInputForm.tsx
+++ b/frontend/src/metabase/writeback/containers/ActionParametersInputForm/ActionParametersInputForm.tsx
@@ -3,44 +3,24 @@ import { connect } from "react-redux";
 import { t } from "ttag";
 
 import { useDataAppContext } from "metabase/writeback/containers/DataAppContext";
-import {
-  getActionTemplateTagType,
-  getActionParameterType,
-} from "metabase/writeback/utils";
+import { getActionParameterType } from "metabase/writeback/utils";
+import { ParametersMappedToValues } from "metabase/writeback/types";
 
 import RootForm from "metabase/containers/Form";
-import { TemplateTag } from "metabase-types/types/Query";
 import { Parameter, ParameterId } from "metabase-types/types/Parameter";
+import { Dispatch } from "metabase-types/store";
 
 import { FormDescription } from "./ActionParametersInputForm.styled";
 
-type MappedParameters = Record<
-  string,
-  { type: string; value: string | number }
->;
-
 interface Props {
-  missingParameters: TemplateTag[] | Parameter[];
   description?: string;
-  onSubmit: (parameters: MappedParameters) => { type: string; payload: any };
+  missingParameters: Parameter[];
+  onSubmit: (parameters: ParametersMappedToValues) => {
+    type: string;
+    payload: any;
+  };
   onSubmitSuccess: () => void;
-  dispatch: (action: any) => void;
-}
-
-function isTemplateTag(
-  tagOrParameter: TemplateTag | Parameter,
-): tagOrParameter is TemplateTag {
-  return "display-name" in tagOrParameter;
-}
-
-function getTemplateTagFieldProps(tag: TemplateTag) {
-  if (tag.type === "date") {
-    return { type: "date" };
-  }
-  if (tag.type === "number") {
-    return { type: "integer" };
-  }
-  return { type: "input" };
+  dispatch: Dispatch;
 }
 
 function getParameterFieldProps(parameter: Parameter) {
@@ -53,14 +33,6 @@ function getParameterFieldProps(parameter: Parameter) {
   return { type: "input" };
 }
 
-function getFormFieldForTemplateTag(tag: TemplateTag) {
-  return {
-    name: tag.id,
-    title: tag["display-name"],
-    ...getTemplateTagFieldProps(tag),
-  };
-}
-
 function getFormFieldForParameter(parameter: Parameter) {
   return {
     name: parameter.id,
@@ -69,30 +41,11 @@ function getFormFieldForParameter(parameter: Parameter) {
   };
 }
 
-function formatTemplateTagsBeforeSubmit(
-  values: Record<ParameterId, string | number>,
-  missingParameters: TemplateTag[],
-) {
-  const formattedParams: MappedParameters = {};
-
-  Object.keys(values).forEach(parameterId => {
-    const tag = missingParameters.find(tag => tag.id === parameterId);
-    if (tag) {
-      formattedParams[parameterId] = {
-        value: values[parameterId],
-        type: getActionTemplateTagType(tag),
-      };
-    }
-  });
-
-  return formattedParams;
-}
-
 function formatParametersBeforeSubmit(
   values: Record<ParameterId, string | number>,
   missingParameters: Parameter[],
 ) {
-  const formattedParams: MappedParameters = {};
+  const formattedParams: ParametersMappedToValues = {};
 
   Object.keys(values).forEach(parameterId => {
     const parameter = missingParameters.find(tag => tag.id === parameterId);
@@ -118,27 +71,16 @@ function ActionParametersInputForm({
 
   const form = useMemo(() => {
     return {
-      fields: missingParameters.map(tagOrParameter => {
-        const isTag = isTemplateTag(tagOrParameter);
-        return isTag
-          ? getFormFieldForTemplateTag(tagOrParameter)
-          : getFormFieldForParameter(tagOrParameter);
-      }),
+      fields: missingParameters.map(getFormFieldForParameter),
     };
   }, [missingParameters]);
 
   const handleSubmit = useCallback(
     params => {
-      const [sampleParameter] = missingParameters;
-      const formattedParams = isTemplateTag(sampleParameter)
-        ? formatTemplateTagsBeforeSubmit(
-            params,
-            missingParameters as TemplateTag[],
-          )
-        : formatParametersBeforeSubmit(
-            params,
-            missingParameters as Parameter[],
-          );
+      const formattedParams = formatParametersBeforeSubmit(
+        params,
+        missingParameters as Parameter[],
+      );
       dispatch(onSubmit(formattedParams));
       onSubmitSuccess();
     },

--- a/frontend/src/metabase/writeback/containers/CreateActionPage.tsx
+++ b/frontend/src/metabase/writeback/containers/CreateActionPage.tsx
@@ -4,15 +4,16 @@ import { connect } from "react-redux";
 
 import Header from "metabase/writeback/components/HttpAction/Header";
 import HttpAction from "metabase/writeback/components/HttpAction/HttpAction";
-import { ActionType } from "metabase/writeback/types";
-import { useWritebackAction } from "../hooks";
 import {
   createHttpAction,
   CreateHttpActionPayload,
-} from "metabase/query_builder/actions";
+} from "metabase/writeback/actions";
+import { getHttpActionTemplateTagParameter } from "metabase/writeback/utils";
+import { ActionType } from "metabase/writeback/types";
+
+import { useWritebackAction } from "../hooks";
 
 import { Container, Content } from "./ActionPage.styled";
-import { getHttpActionTemplateTagParameter } from "../utils";
 
 type Props = {
   createHttpAction: (payload: CreateHttpActionPayload) => void;

--- a/frontend/src/metabase/writeback/containers/EditActionPage.tsx
+++ b/frontend/src/metabase/writeback/containers/EditActionPage.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import Header from "metabase/writeback/components/HttpAction/Header";
 import HttpAction from "metabase/writeback/components/HttpAction/HttpAction";
-import { ActionType, WritebackAction } from "metabase/writeback/types";
+import { WritebackAction } from "metabase/writeback/types";
 import { useWritebackAction } from "../hooks";
 import _ from "underscore";
 import Actions from "metabase/entities/actions";

--- a/frontend/src/metabase/writeback/hooks.ts
+++ b/frontend/src/metabase/writeback/hooks.ts
@@ -1,5 +1,4 @@
 import React from "react";
-import { t } from "ttag";
 import _ from "underscore";
 import { isEqual } from "lodash";
 
@@ -38,26 +37,6 @@ export type CreateActionHook = {
   setTemplateTags: (templateTags: TemplateTags) => void;
 };
 
-const getName = (action: Partial<WritebackAction>): string => {
-  if (action.type === "http") {
-    return action.name || t`New Action`;
-  } else if (action.type === "query") {
-    return action.card?.name || t`New Action`;
-  } else {
-    throw new Error("Action type is not supported");
-  }
-};
-
-const getDescription = (action: Partial<WritebackAction>): string => {
-  if (action.type === "http") {
-    return action?.description || "";
-  } else if (action.type === "query") {
-    return action.card?.description || "";
-  } else {
-    throw new Error("Action type is not supported");
-  }
-};
-
 const getData = (action: Partial<WritebackAction>): unknown => {
   if (action.type === "http") {
     const { name, description, ...rest } = action;
@@ -89,9 +68,9 @@ export const useWritebackAction = (
   action: Partial<WritebackAction> & { type: ActionType },
 ): CreateActionHook => {
   const { type } = action;
-  const [name, setName] = React.useState<string>(getName(action));
+  const [name, setName] = React.useState<string>(action?.name || "");
   const [description, setDescription] = React.useState<string>(
-    getDescription(action),
+    action?.description || "",
   );
   const [responseHandler, setResponseHandler] = React.useState<string>(
     getResponseHandler(action),

--- a/frontend/src/metabase/writeback/types.ts
+++ b/frontend/src/metabase/writeback/types.ts
@@ -24,8 +24,13 @@ export type WritebackActionCard = SavedCard<NativeDatasetQuery> & {
   is_write: true;
 };
 
+export type ActionParameterTuple = [string, Parameter];
+
 export interface WritebackActionBase {
   id: number;
+  name: string;
+  description: string | null;
+  parameters: ActionParameterTuple[];
   "updated-at": string;
   "created-at": string;
 }
@@ -38,11 +43,7 @@ export interface RowAction {
 
 export interface HttpAction {
   type: "http";
-  name: string;
-  description: string;
   template: HttpActionTemplate;
-  parameters: Record<ParameterId, Parameter>;
-  parameter_mappings: Record<ParameterId, ParameterTarget>;
   response_handle: string | null;
   error_handle: string | null;
 }

--- a/frontend/src/metabase/writeback/types.ts
+++ b/frontend/src/metabase/writeback/types.ts
@@ -1,9 +1,13 @@
 import Field from "metabase-lib/lib/metadata/Field";
+
 import { SavedCard, NativeDatasetQuery } from "metabase-types/types/Card";
+import { DashboardWithCards } from "metabase-types/types/Dashboard";
+import { Column } from "metabase-types/types/Dataset";
 import {
   Parameter,
   ParameterId,
   ParameterTarget,
+  ParameterValueOrArray,
 } from "metabase-types/types/Parameter";
 
 export interface CategoryWidgetProps {
@@ -69,3 +73,41 @@ export interface WritebackActionEmitter {
 }
 
 export type ActionType = "http" | "query";
+
+export type ParameterMappings = Record<ParameterId, ParameterTarget>;
+
+export type ActionClickBehaviorData = {
+  column: Partial<Column>;
+  parameter: Record<ParameterId, { value: ParameterValueOrArray }>;
+  parameterByName: Record<string, { value: ParameterValueOrArray }>;
+  parameterBySlug: Record<string, { value: ParameterValueOrArray }>;
+  userAttributes: Record<string, unknown>;
+};
+
+export type ActionClickBehavior = {
+  action: number; // action id
+  emitter_id: number;
+  type: "action";
+  parameterMapping: ParameterMappings;
+};
+
+export type ActionClickExtraData = {
+  actions: Record<number, WritebackAction>;
+  dashboard: DashboardWithCards;
+  parameterBySlug: Record<string, { value: ParameterValueOrArray }>;
+  userAttributes: unknown[];
+};
+
+export type ParametersSourceTargetMap = Record<
+  ParameterId,
+  {
+    id: ParameterId;
+    source: { id: string; type: string; name: string };
+    target: { id: string; type: string };
+  }
+>;
+
+export type ParametersMappedToValues = Record<
+  ParameterId,
+  { type: string; value: string | number }
+>;

--- a/frontend/src/metabase/writeback/utils.ts
+++ b/frontend/src/metabase/writeback/utils.ts
@@ -57,7 +57,7 @@ const isAutomaticDateTimeField = (field: Field) => {
   return AUTOMATIC_DATE_TIME_FIELDS.includes(field.semantic_type);
 };
 
-export const isEditableField = (field: Field) => {
+const isEditableField = (field: Field) => {
   const isRealField = typeof field.id === "number";
   if (!isRealField) {
     // Filters out custom, aggregated columns, etc.
@@ -78,13 +78,13 @@ export const isEditableField = (field: Field) => {
   return true;
 };
 
-export const isQueryAction = (
+const isQueryAction = (
   action: WritebackAction,
 ): action is WritebackAction & RowAction => {
   return action.type === "query";
 };
 
-export const isHttpAction = (
+const isHttpAction = (
   action: WritebackAction,
 ): action is WritebackAction & HttpAction => {
   return action.type === "http";
@@ -120,7 +120,7 @@ export function getActionParameterType(parameter: Parameter) {
   return type;
 }
 
-export const getQueryActionParameterMappings = (
+const getQueryActionParameterMappings = (
   action: WritebackAction & RowAction,
 ) => {
   const templateTags = Object.values(


### PR DESCRIPTION
We used to handle query and HTTP actions differently on the FE:

* for query actions, we used to access `action.card.dataset_query` and grab parameters out of `template-tags`
* for HTTP actions, we used to use `action.parameters`

Now when action shapes are aligned, we can just use `action.parameters` every time. 

Also, moves `createHTTPAction` action from `query_builder` actions to `writeback` actions