### PR TITLE
Display the original field name when editing model column metadata

### DIFF
--- a/frontend/src/metabase/components/form/widgets/FormInputWidget.jsx
+++ b/frontend/src/metabase/components/form/widgets/FormInputWidget.jsx
@@ -31,23 +31,21 @@ const FormInputWidget = forwardRef(function FormInputWidget(
   ref,
 ) {
   return (
-    <div>
-      <Input
-        {...formDomOnlyProps(field)}
-        type={type}
-        placeholder={placeholder}
-        aria-labelledby={`${field.name}-label`}
-        readOnly={readOnly}
-        autoFocus={autoFocus}
-        error={field.visited && !field.active && field.error != null}
-        rightIcon={helperText && "info"}
-        rightIconTooltip={helperText}
-        tabIndex={tabIndex}
-        fullWidth
-        subtitle={subtitle}
-        ref={ref}
-      />
-    </div>
+    <Input
+      {...formDomOnlyProps(field)}
+      type={type}
+      placeholder={placeholder}
+      aria-labelledby={`${field.name}-label`}
+      readOnly={readOnly}
+      autoFocus={autoFocus}
+      error={field.visited && !field.active && field.error != null}
+      rightIcon={helperText && "info"}
+      rightIconTooltip={helperText}
+      tabIndex={tabIndex}
+      fullWidth
+      subtitle={subtitle}
+      ref={ref}
+    />
   );
 });
 

--- a/frontend/src/metabase/components/form/widgets/FormInputWidget.jsx
+++ b/frontend/src/metabase/components/form/widgets/FormInputWidget.jsx
@@ -14,6 +14,7 @@ const propTypes = {
   autoFocus: PropTypes.bool,
   helperText: PropTypes.node,
   tabIndex: PropTypes.string,
+  fieldName: PropTypes.string,
 };
 
 const FormInputWidget = forwardRef(function FormInputWidget(
@@ -25,24 +26,28 @@ const FormInputWidget = forwardRef(function FormInputWidget(
     autoFocus,
     helperText,
     tabIndex,
+    fieldName,
   },
   ref,
 ) {
   return (
-    <Input
-      {...formDomOnlyProps(field)}
-      type={type}
-      placeholder={placeholder}
-      aria-labelledby={`${field.name}-label`}
-      readOnly={readOnly}
-      autoFocus={autoFocus}
-      error={field.visited && !field.active && field.error != null}
-      rightIcon={helperText && "info"}
-      rightIconTooltip={helperText}
-      tabIndex={tabIndex}
-      fullWidth
-      ref={ref}
-    />
+    <div>
+      <div className="h6 text-bold text-uppercase text-light">{fieldName}</div>
+      <Input
+        {...formDomOnlyProps(field)}
+        type={type}
+        placeholder={placeholder}
+        aria-labelledby={`${field.name}-label`}
+        readOnly={readOnly}
+        autoFocus={autoFocus}
+        error={field.visited && !field.active && field.error != null}
+        rightIcon={helperText && "info"}
+        rightIconTooltip={helperText}
+        tabIndex={tabIndex}
+        fullWidth
+        ref={ref}
+      />
+    </div>
   );
 });
 

--- a/frontend/src/metabase/components/form/widgets/FormInputWidget.jsx
+++ b/frontend/src/metabase/components/form/widgets/FormInputWidget.jsx
@@ -14,7 +14,7 @@ const propTypes = {
   autoFocus: PropTypes.bool,
   helperText: PropTypes.node,
   tabIndex: PropTypes.string,
-  fieldName: PropTypes.string,
+  subtitle: PropTypes.string,
 };
 
 const FormInputWidget = forwardRef(function FormInputWidget(
@@ -26,13 +26,12 @@ const FormInputWidget = forwardRef(function FormInputWidget(
     autoFocus,
     helperText,
     tabIndex,
-    fieldName,
+    subtitle,
   },
   ref,
 ) {
   return (
     <div>
-      <div className="h6 text-bold text-uppercase text-light">{fieldName}</div>
       <Input
         {...formDomOnlyProps(field)}
         type={type}
@@ -45,6 +44,7 @@ const FormInputWidget = forwardRef(function FormInputWidget(
         rightIconTooltip={helperText}
         tabIndex={tabIndex}
         fullWidth
+        subtitle={subtitle}
         ref={ref}
       />
     </div>

--- a/frontend/src/metabase/core/components/Input/Input.styled.tsx
+++ b/frontend/src/metabase/core/components/Input/Input.styled.tsx
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
 import { css } from "@emotion/react";
 import { color } from "metabase/lib/colors";
-import { space } from "metabase/styled-components/theme";
+import { monospaceFontFamily, space } from "metabase/styled-components/theme";
 import IconButtonWrapper from "metabase/components/IconButtonWrapper";
 import { InputSize } from "./types";
 
@@ -11,6 +11,7 @@ export interface InputProps {
   fullWidth?: boolean;
   hasLeftIcon?: boolean;
   hasRightIcon?: boolean;
+  subtitle?: string;
 }
 
 export const InputRoot = styled.div<InputProps>`
@@ -68,6 +69,12 @@ export const InputField = styled.input<InputProps>`
       line-height: 1rem;
       padding: 0.4375rem 0.625rem;
     `};
+
+  ${props =>
+    props.subtitle &&
+    css`
+      padding-top: 1.75rem;
+    `};
 `;
 
 export const InputButton = styled(IconButtonWrapper)`
@@ -83,4 +90,13 @@ export const InputLeftButton = styled(InputButton)`
 
 export const InputRightButton = styled(InputButton)`
   right: 0;
+`;
+
+export const InputSubtitle = styled.div`
+  color: ${color("text-light")};
+  position: absolute;
+  top: 1.25em;
+  left: 1.25em;
+  font-family: ${monospaceFontFamily};
+  font-size: 0.75em;
 `;

--- a/frontend/src/metabase/core/components/Input/Input.tsx
+++ b/frontend/src/metabase/core/components/Input/Input.tsx
@@ -12,6 +12,7 @@ import {
   InputLeftButton,
   InputRightButton,
   InputRoot,
+  InputSubtitle,
 } from "./Input.styled";
 import { InputSize } from "./types";
 
@@ -31,6 +32,7 @@ export interface InputProps extends InputAttributes {
   rightIconTooltip?: ReactNode;
   onLeftIconClick?: (event: MouseEvent<HTMLButtonElement>) => void;
   onRightIconClick?: (event: MouseEvent<HTMLButtonElement>) => void;
+  subtitle?: string;
 }
 
 const Input = forwardRef(function Input(
@@ -47,6 +49,7 @@ const Input = forwardRef(function Input(
     rightIconTooltip,
     onLeftIconClick,
     onRightIconClick,
+    subtitle,
     ...props
   }: InputProps,
   ref: Ref<HTMLDivElement>,
@@ -58,6 +61,8 @@ const Input = forwardRef(function Input(
       style={style}
       fullWidth={fullWidth}
     >
+      {subtitle && <InputSubtitle>{subtitle}</InputSubtitle>}
+
       <InputField
         {...props}
         ref={inputRef}
@@ -65,6 +70,7 @@ const Input = forwardRef(function Input(
         hasError={error}
         fullWidth={fullWidth}
         hasRightIcon={Boolean(rightIcon)}
+        subtitle={subtitle}
       />
       {leftIcon && (
         <Tooltip tooltip={leftIconTooltip} placement="left" offset={[0, 24]}>

--- a/frontend/src/metabase/core/components/Input/Input.tsx
+++ b/frontend/src/metabase/core/components/Input/Input.tsx
@@ -30,9 +30,9 @@ export interface InputProps extends InputAttributes {
   leftIconTooltip?: ReactNode;
   rightIcon?: string;
   rightIconTooltip?: ReactNode;
+  subtitle?: string;
   onLeftIconClick?: (event: MouseEvent<HTMLButtonElement>) => void;
   onRightIconClick?: (event: MouseEvent<HTMLButtonElement>) => void;
-  subtitle?: string;
 }
 
 const Input = forwardRef(function Input(

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataSidebar.jsx
@@ -68,7 +68,7 @@ function getSemanticTypeOptions() {
   ];
 }
 
-function getFormFields({ dataset }) {
+function getFormFields({ dataset, field }) {
   const visibilityTypeOptions = field_visibility_types
     .filter(type => type.id !== "sensitive")
     .map(type => ({
@@ -78,7 +78,12 @@ function getFormFields({ dataset }) {
 
   return formFieldValues =>
     [
-      { name: "display_name", title: t`Display name` },
+      {
+        // TODO: change the widget from FormInputWidget
+        name: "display_name",
+        title: t`Display name`,
+        fieldName: field.name,
+      },
       {
         name: "description",
         title: t`Description`,
@@ -172,9 +177,9 @@ function DatasetFieldMetadataSidebar({
 
   const form = useMemo(
     () => ({
-      fields: getFormFields({ dataset }),
+      fields: getFormFields({ dataset, field }),
     }),
-    [dataset],
+    [field, dataset],
   );
 
   const [tab, setTab] = useState(TAB.SETTINGS);

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataSidebar.jsx
@@ -79,10 +79,9 @@ function getFormFields({ dataset, field }) {
   return formFieldValues =>
     [
       {
-        // TODO: change the widget from FormInputWidget
         name: "display_name",
         title: t`Display name`,
-        fieldName: field.name,
+        subtitle: field.name,
       },
       {
         name: "description",

--- a/frontend/src/metabase/styled-components/theme/index.ts
+++ b/frontend/src/metabase/styled-components/theme/index.ts
@@ -1,2 +1,3 @@
 export * from "./media-queries";
 export * from "./space";
+export * from "./typography";

--- a/frontend/src/metabase/styled-components/theme/typography.ts
+++ b/frontend/src/metabase/styled-components/theme/typography.ts
@@ -1,0 +1,1 @@
+export const monospaceFontFamily = "Monaco, monospace";


### PR DESCRIPTION
Resolves #24824

[Notion link](https://www.notion.so/metabase/Make-model-editing-faster-and-easier-ee31edef605c486e8f9c0fbe70fa3af2#28b8ceb4917d40068c69b08a05e2e7f6)

### How to Test

1. `+ New`
2. Question
3. Sample dataset
4. Any table
5. Save question
6. Convert it to a Model
7. Visit Model page and "Edit Metadata"
8. Click on table column headers to test for all columns:

On the right sidebar,  Display Name input should now contain a subtitle on the top left, with the original name of the db column.

##### Notes

This PR adds a 'subtitle' to the `Input` component that displays the original field name of a model's column.

<img width="1422" alt="Captura de Pantalla 2022-08-18 a las 13 44 28" src="https://user-images.githubusercontent.com/39073188/185386913-356e7120-ce1c-44b3-a656-5b3e733af35d.png">

[From Gus, on the implementation](https://github.com/metabase/metabase/pull/24859#issue-1342396031):

> We add a prop, called subtitle, that is passed to the input component.
> 
> I did consider and experiment with Cal's suggestion of a dedicated widget for this.
> 
> However, we would end up with one more widget (whose "manager" has complicated logic as it is), plus a prop to Input. Or, at best, a variation on the input which would mean more cost than benefit.
> 