### PR TITLE
fix static viz waterfall colors

### DIFF
--- a/frontend/src/metabase/static-viz/components/CategoricalAreaChart/CategoricalAreaChart.jsx
+++ b/frontend/src/metabase/static-viz/components/CategoricalAreaChart/CategoricalAreaChart.jsx
@@ -32,6 +32,7 @@ const propTypes = {
     left: PropTypes.string,
     bottom: PropTypes.string,
   }),
+  getColor: PropTypes.func,
 };
 
 const layout = {
@@ -65,6 +66,7 @@ const CategoricalAreaChart = ({
   accessors = POSITIONAL_ACCESSORS,
   settings,
   labels,
+  getColor,
 }) => {
   const colors = settings?.colors;
   const isVertical = data.length > 10;
@@ -138,9 +140,9 @@ const CategoricalAreaChart = ({
         labelOffset={yLabelOffset}
         hideTicks
         hideAxisLine
-        labelProps={getLabelProps(layout)}
+        labelProps={getLabelProps(layout, getColor)}
         tickFormat={value => formatNumber(value, settings?.y)}
-        tickLabelProps={() => getYTickLabelProps(layout)}
+        tickLabelProps={() => getYTickLabelProps(layout, getColor)}
       />
       <LinePath
         data={data}
@@ -156,9 +158,9 @@ const CategoricalAreaChart = ({
         numTicks={data.length}
         stroke={palette.textLight}
         tickStroke={palette.textLight}
-        labelProps={getLabelProps(layout)}
+        labelProps={getLabelProps(layout, getColor)}
         tickComponent={props => <Text {...getXTickProps(props)} />}
-        tickLabelProps={() => getXTickLabelProps(layout, isVertical)}
+        tickLabelProps={() => getXTickLabelProps(layout, isVertical, getColor)}
       />
     </svg>
   );

--- a/frontend/src/metabase/static-viz/components/CategoricalBarChart/CategoricalBarChart.jsx
+++ b/frontend/src/metabase/static-viz/components/CategoricalBarChart/CategoricalBarChart.jsx
@@ -32,6 +32,7 @@ const propTypes = {
     left: PropTypes.string,
     bottom: PropTypes.string,
   }),
+  getColor: PropTypes.func,
 };
 
 const layout = {
@@ -64,6 +65,7 @@ const CategoricalBarChart = ({
   accessors = POSITIONAL_ACCESSORS,
   settings,
   labels,
+  getColor,
 }) => {
   const colors = settings?.colors;
   const isVertical = data.length > 10;
@@ -142,9 +144,9 @@ const CategoricalBarChart = ({
         labelOffset={yLabelOffset}
         hideTicks
         hideAxisLine
-        labelProps={getLabelProps(layout)}
+        labelProps={getLabelProps(layout, getColor)}
         tickFormat={value => formatNumber(value, settings?.y)}
-        tickLabelProps={() => getYTickLabelProps(layout)}
+        tickLabelProps={() => getYTickLabelProps(layout, getColor)}
       />
       <AxisBottom
         scale={xScale}
@@ -153,9 +155,9 @@ const CategoricalBarChart = ({
         numTicks={data.length}
         stroke={palette.textLight}
         tickStroke={palette.textLight}
-        labelProps={getLabelProps(layout)}
+        labelProps={getLabelProps(layout, getColor)}
         tickComponent={props => <Text {...getXTickProps(props)} />}
-        tickLabelProps={() => getXTickLabelProps(layout, isVertical)}
+        tickLabelProps={() => getXTickLabelProps(layout, isVertical, getColor)}
       />
     </svg>
   );

--- a/frontend/src/metabase/static-viz/components/CategoricalLineChart/CategoricalLineChart.jsx
+++ b/frontend/src/metabase/static-viz/components/CategoricalLineChart/CategoricalLineChart.jsx
@@ -32,6 +32,7 @@ const propTypes = {
     left: PropTypes.string,
     bottom: PropTypes.string,
   }),
+  getColor: PropTypes.func,
 };
 
 const layout = {
@@ -64,6 +65,7 @@ const CategoricalLineChart = ({
   accessors = POSITIONAL_ACCESSORS,
   settings,
   labels,
+  getColor,
 }) => {
   const colors = settings?.colors;
   const isVertical = data.length > 10;
@@ -136,9 +138,9 @@ const CategoricalLineChart = ({
         labelOffset={yLabelOffset}
         hideTicks
         hideAxisLine
-        labelProps={getLabelProps(layout)}
+        labelProps={getLabelProps(layout, getColor)}
         tickFormat={value => formatNumber(value, settings?.y)}
-        tickLabelProps={() => getYTickLabelProps(layout)}
+        tickLabelProps={() => getYTickLabelProps(layout, getColor)}
       />
       <AxisBottom
         scale={xScale}
@@ -147,9 +149,9 @@ const CategoricalLineChart = ({
         numTicks={data.length}
         stroke={palette.textLight}
         tickStroke={palette.textLight}
-        labelProps={getLabelProps(layout)}
+        labelProps={getLabelProps(layout, getColor)}
         tickComponent={props => <Text {...getXTickProps(props)} />}
-        tickLabelProps={() => getXTickLabelProps(layout, isVertical)}
+        tickLabelProps={() => getXTickLabelProps(layout, isVertical, getColor)}
       />
     </svg>
   );

--- a/frontend/src/metabase/static-viz/components/CategoricalWaterfallChart/CategoricalWaterfallChart.jsx
+++ b/frontend/src/metabase/static-viz/components/CategoricalWaterfallChart/CategoricalWaterfallChart.jsx
@@ -22,6 +22,7 @@ import {
   getWaterfallEntryColor,
 } from "metabase/static-viz/lib/waterfall";
 import { POSITIONAL_ACCESSORS } from "../../constants/accessors";
+import { getWaterfallColors } from "../../lib/colors";
 
 const propTypes = {
   data: PropTypes.array.isRequired,
@@ -39,6 +40,7 @@ const propTypes = {
     left: PropTypes.string,
     bottom: PropTypes.string,
   }),
+  getColor: PropTypes.func,
 };
 
 const layout = {
@@ -54,14 +56,6 @@ const layout = {
     size: 11,
     family: "Lato, sans-serif",
   },
-  colors: {
-    brand: "#509ee3",
-    textLight: "#b8bbc3",
-    textMedium: "#949aab",
-    waterfallTotal: "#4C5773",
-    waterfallPositive: "#88BF4D",
-    waterfallNegative: "#EF8C8C",
-  },
   barPadding: 0.2,
   labelFontWeight: 700,
   labelPadding: 12,
@@ -74,13 +68,14 @@ const CategoricalWaterfallChart = ({
   accessors = POSITIONAL_ACCESSORS,
   settings,
   labels,
+  getColor,
 }) => {
   const entries = calculateWaterfallEntries(
     data,
     accessors,
     settings?.showTotal,
   );
-  const colors = settings?.colors;
+  const colors = settings?.colors ?? {};
   const isVertical = entries.length > 10;
   const xTickWidth = getXTickWidth(
     data,
@@ -100,7 +95,6 @@ const CategoricalWaterfallChart = ({
   const textBaseline = Math.floor(layout.font.size / 2);
   const leftLabel = labels?.left;
   const bottomLabel = !isVertical ? labels?.bottom : undefined;
-  const palette = { ...layout.colors, ...colors };
 
   const xScale = scaleBand({
     domain: entries.map(entry => entry.x),
@@ -119,7 +113,11 @@ const CategoricalWaterfallChart = ({
     const height = Math.abs(yScale(entry.start) - yScale(entry.end));
     const x = xScale(entry.x);
     const y = yScale(Math.max(entry.start, entry.end));
-    const fill = getWaterfallEntryColor(entry, palette);
+
+    const fill = getWaterfallEntryColor(
+      entry,
+      getWaterfallColors(colors, getColor),
+    );
 
     return { x, y, width, height, fill };
   };
@@ -158,9 +156,9 @@ const CategoricalWaterfallChart = ({
         labelOffset={yLabelOffset}
         hideTicks
         hideAxisLine
-        labelProps={getLabelProps(layout)}
+        labelProps={getLabelProps(layout, getColor)}
         tickFormat={value => formatNumber(value, settings?.y)}
-        tickLabelProps={() => getYTickLabelProps(layout)}
+        tickLabelProps={() => getYTickLabelProps(layout, getColor)}
       />
 
       <AxisBottom
@@ -169,11 +167,11 @@ const CategoricalWaterfallChart = ({
         top={yMax + layout.margin.top}
         label={bottomLabel}
         numTicks={entries.length}
-        stroke={palette.textLight}
-        tickStroke={palette.textLight}
-        labelProps={getLabelProps(layout)}
+        stroke={getColor("text-light")}
+        tickStroke={getColor("text-light")}
+        labelProps={getLabelProps(layout, getColor)}
         tickComponent={props => <Text {...getXTickProps(props)} />}
-        tickLabelProps={() => getXTickLabelProps(layout, isVertical)}
+        tickLabelProps={() => getXTickLabelProps(layout, isVertical, getColor)}
       />
     </svg>
   );

--- a/frontend/src/metabase/static-viz/components/CategoricalWaterfallChart/CategoricalWaterfallChart.jsx
+++ b/frontend/src/metabase/static-viz/components/CategoricalWaterfallChart/CategoricalWaterfallChart.jsx
@@ -75,7 +75,6 @@ const CategoricalWaterfallChart = ({
     accessors,
     settings?.showTotal,
   );
-  const colors = settings?.colors ?? {};
   const isVertical = entries.length > 10;
   const xTickWidth = getXTickWidth(
     data,
@@ -116,7 +115,7 @@ const CategoricalWaterfallChart = ({
 
     const fill = getWaterfallEntryColor(
       entry,
-      getWaterfallColors(colors, getColor),
+      getWaterfallColors(settings?.colors, getColor),
     );
 
     return { x, y, width, height, fill };

--- a/frontend/src/metabase/static-viz/components/TimeSeriesAreaChart/TimeSeriesAreaChart.jsx
+++ b/frontend/src/metabase/static-viz/components/TimeSeriesAreaChart/TimeSeriesAreaChart.jsx
@@ -30,6 +30,7 @@ const propTypes = {
     left: PropTypes.string,
     bottom: PropTypes.string,
   }),
+  getColor: PropTypes.func,
 };
 
 const layout = {
@@ -64,6 +65,7 @@ const TimeSeriesAreaChart = ({
   accessors = DATE_ACCESSORS,
   settings,
   labels,
+  getColor,
 }) => {
   data = sortTimeSeries(data);
   const colors = settings?.colors;
@@ -119,9 +121,9 @@ const TimeSeriesAreaChart = ({
         labelOffset={yLabelOffset}
         hideTicks
         hideAxisLine
-        labelProps={getLabelProps(layout)}
+        labelProps={getLabelProps(layout, getColor)}
         tickFormat={value => formatNumber(value, settings?.y)}
-        tickLabelProps={() => getYTickLabelProps(layout)}
+        tickLabelProps={() => getYTickLabelProps(layout, getColor)}
       />
       <AxisBottom
         scale={xScale}
@@ -130,9 +132,9 @@ const TimeSeriesAreaChart = ({
         numTicks={layout.numTicks}
         stroke={palette.textLight}
         tickStroke={palette.textLight}
-        labelProps={getLabelProps(layout)}
+        labelProps={getLabelProps(layout, getColor)}
         tickFormat={value => formatDate(value, settings?.x)}
-        tickLabelProps={() => getXTickLabelProps(layout)}
+        tickLabelProps={() => getXTickLabelProps(layout, false, getColor)}
       />
     </svg>
   );

--- a/frontend/src/metabase/static-viz/components/TimeSeriesBarChart/TimeSeriesBarChart.jsx
+++ b/frontend/src/metabase/static-viz/components/TimeSeriesBarChart/TimeSeriesBarChart.jsx
@@ -30,6 +30,7 @@ const propTypes = {
     left: PropTypes.string,
     bottom: PropTypes.string,
   }),
+  getColor: PropTypes.func,
 };
 
 const layout = {
@@ -62,6 +63,7 @@ const TimeSeriesBarChart = ({
   accessors = DATE_ACCESSORS,
   settings,
   labels,
+  getColor,
 }) => {
   data = sortTimeSeries(data);
   const colors = settings?.colors;
@@ -116,9 +118,9 @@ const TimeSeriesBarChart = ({
         labelOffset={yLabelOffset}
         hideTicks
         hideAxisLine
-        labelProps={getLabelProps(layout)}
+        labelProps={getLabelProps(layout, getColor)}
         tickFormat={value => formatNumber(value, settings?.y)}
-        tickLabelProps={() => getYTickLabelProps(layout)}
+        tickLabelProps={() => getYTickLabelProps(layout, getColor)}
       />
       <AxisBottom
         scale={xScale}
@@ -127,9 +129,9 @@ const TimeSeriesBarChart = ({
         numTicks={layout.numTicks}
         stroke={palette.textLight}
         tickStroke={palette.textLight}
-        labelProps={getLabelProps(layout)}
+        labelProps={getLabelProps(layout, getColor)}
         tickFormat={value => formatDate(value, settings?.x)}
-        tickLabelProps={() => getXTickLabelProps(layout)}
+        tickLabelProps={() => getXTickLabelProps(layout, false, getColor)}
       />
     </svg>
   );

--- a/frontend/src/metabase/static-viz/components/TimeSeriesLineChart/TimeSeriesLineChart.jsx
+++ b/frontend/src/metabase/static-viz/components/TimeSeriesLineChart/TimeSeriesLineChart.jsx
@@ -30,6 +30,7 @@ const propTypes = {
     left: PropTypes.string,
     bottom: PropTypes.string,
   }),
+  getColor: PropTypes.func,
 };
 
 const layout = {
@@ -62,6 +63,7 @@ const TimeSeriesLineChart = ({
   accessors = DATE_ACCESSORS,
   settings,
   labels,
+  getColor,
 }) => {
   data = sortTimeSeries(data);
   const colors = settings?.colors;
@@ -109,9 +111,9 @@ const TimeSeriesLineChart = ({
         labelOffset={yLabelOffset}
         hideTicks
         hideAxisLine
-        labelProps={getLabelProps(layout)}
+        labelProps={getLabelProps(layout, getColor)}
         tickFormat={value => formatNumber(value, settings?.y)}
-        tickLabelProps={() => getYTickLabelProps(layout)}
+        tickLabelProps={() => getYTickLabelProps(layout, getColor)}
       />
       <AxisBottom
         scale={xScale}
@@ -120,9 +122,9 @@ const TimeSeriesLineChart = ({
         numTicks={layout.numTicks}
         stroke={palette.textLight}
         tickStroke={palette.textLight}
-        labelProps={getLabelProps(layout)}
+        labelProps={getLabelProps(layout, getColor)}
         tickFormat={value => formatDate(value, settings?.x)}
-        tickLabelProps={() => getXTickLabelProps(layout)}
+        tickLabelProps={() => getXTickLabelProps(layout, false, getColor)}
       />
     </svg>
   );

--- a/frontend/src/metabase/static-viz/components/TimeSeriesWaterfallChart/TimeSeriesWaterfallChart.jsx
+++ b/frontend/src/metabase/static-viz/components/TimeSeriesWaterfallChart/TimeSeriesWaterfallChart.jsx
@@ -69,7 +69,6 @@ const TimeSeriesWaterfallChart = ({
   getColor,
 }) => {
   data = sortTimeSeries(data);
-  const colors = settings?.colors ?? {};
   const yTickWidth = getYTickWidth(data, accessors, settings, layout.font.size);
   const yLabelOffset = yTickWidth + layout.labelPadding;
   const xMin = yLabelOffset + layout.font.size * 1.5;
@@ -104,7 +103,7 @@ const TimeSeriesWaterfallChart = ({
     const y = yScale(Math.max(entry.start, entry.end));
     const fill = getWaterfallEntryColor(
       entry,
-      getWaterfallColors(colors, getColor),
+      getWaterfallColors(settings?.colors, getColor),
     );
 
     return { x, y, width, height, fill };

--- a/frontend/src/metabase/static-viz/components/TimeSeriesWaterfallChart/TimeSeriesWaterfallChart.jsx
+++ b/frontend/src/metabase/static-viz/components/TimeSeriesWaterfallChart/TimeSeriesWaterfallChart.jsx
@@ -20,6 +20,7 @@ import {
 } from "metabase/static-viz/lib/waterfall";
 import { sortTimeSeries } from "../../lib/sort";
 import { DATE_ACCESSORS } from "../../constants/accessors";
+import { getWaterfallColors } from "../../lib/colors";
 
 const propTypes = {
   data: PropTypes.array.isRequired,
@@ -37,6 +38,7 @@ const propTypes = {
     left: PropTypes.string,
     bottom: PropTypes.string,
   }),
+  getColor: PropTypes.func,
 };
 
 const layout = {
@@ -52,14 +54,6 @@ const layout = {
     size: 11,
     family: "Lato, sans-serif",
   },
-  colors: {
-    brand: "#509ee3",
-    textLight: "#b8bbc3",
-    textMedium: "#949aab",
-    waterfallTotal: "#4C5773",
-    waterfallPositive: "#88BF4D",
-    waterfallNegative: "#EF8C8C",
-  },
   numTicks: 4,
   barPadding: 0.2,
   labelFontWeight: 700,
@@ -72,9 +66,10 @@ const TimeSeriesWaterfallChart = ({
   accessors = DATE_ACCESSORS,
   settings,
   labels,
+  getColor,
 }) => {
   data = sortTimeSeries(data);
-  const colors = settings?.colors;
+  const colors = settings?.colors ?? {};
   const yTickWidth = getYTickWidth(data, accessors, settings, layout.font.size);
   const yLabelOffset = yTickWidth + layout.labelPadding;
   const xMin = yLabelOffset + layout.font.size * 1.5;
@@ -83,7 +78,6 @@ const TimeSeriesWaterfallChart = ({
   const innerWidth = xMax - xMin;
   const leftLabel = labels?.left;
   const bottomLabel = labels?.bottom;
-  const palette = { ...layout.colors, ...colors };
 
   const entries = calculateWaterfallEntries(
     data,
@@ -108,7 +102,10 @@ const TimeSeriesWaterfallChart = ({
     const height = Math.abs(yScale(entry.start) - yScale(entry.end));
     const x = xScale(entry.x);
     const y = yScale(Math.max(entry.start, entry.end));
-    const fill = getWaterfallEntryColor(entry, palette);
+    const fill = getWaterfallEntryColor(
+      entry,
+      getWaterfallColors(colors, getColor),
+    );
 
     return { x, y, width, height, fill };
   };
@@ -133,9 +130,9 @@ const TimeSeriesWaterfallChart = ({
         labelOffset={yLabelOffset}
         hideTicks
         hideAxisLine
-        labelProps={getLabelProps(layout)}
+        labelProps={getLabelProps(layout, getColor)}
         tickFormat={value => formatNumber(value, settings?.y)}
-        tickLabelProps={() => getYTickLabelProps(layout)}
+        tickLabelProps={() => getYTickLabelProps(layout, getColor)}
       />
       <AxisBottom
         scale={xScale}
@@ -143,11 +140,11 @@ const TimeSeriesWaterfallChart = ({
         top={yMax + layout.margin.top}
         label={bottomLabel}
         numTicks={layout.numTicks}
-        stroke={palette.textLight}
-        tickStroke={palette.textLight}
-        labelProps={getLabelProps(layout)}
+        stroke={getColor("text-light")}
+        tickStroke={getColor("text-light")}
+        labelProps={getLabelProps(layout, getColor)}
         tickFormat={value => formatTimescaleWaterfallTick(value, settings)}
-        tickLabelProps={() => getXTickLabelProps(layout)}
+        tickLabelProps={() => getXTickLabelProps(layout, false, getColor)}
       />
     </svg>
   );

--- a/frontend/src/metabase/static-viz/containers/StaticChart/StaticChart.tsx
+++ b/frontend/src/metabase/static-viz/containers/StaticChart/StaticChart.tsx
@@ -26,8 +26,8 @@ import { FUNNEL_CHART_TYPE } from "../../components/FunnelChart/constants";
 import { createColorGetter } from "metabase/static-viz/lib/colors";
 import { StaticChartProps } from "./types";
 
-const StaticChart = ({ type, options, colors = {} }: StaticChartProps) => {
-  const getColor = createColorGetter(colors);
+const StaticChart = ({ type, options }: StaticChartProps) => {
+  const getColor = createColorGetter(options.colors);
   const chartProps = { ...options, getColor };
 
   switch (type) {

--- a/frontend/src/metabase/static-viz/containers/StaticChart/StaticChart.tsx
+++ b/frontend/src/metabase/static-viz/containers/StaticChart/StaticChart.tsx
@@ -23,34 +23,38 @@ import LineAreaBarChart from "../../components/LineAreaBarChart";
 import { LINE_AREA_BAR_CHART_TYPE } from "../../components/LineAreaBarChart/constants";
 import Funnel from "../../components/FunnelChart";
 import { FUNNEL_CHART_TYPE } from "../../components/FunnelChart/constants";
+import { createColorGetter } from "metabase/static-viz/lib/colors";
 import { StaticChartProps } from "./types";
 
-const StaticChart = ({ type, options }: StaticChartProps) => {
+const StaticChart = ({ type, options, colors = {} }: StaticChartProps) => {
+  const getColor = createColorGetter(colors);
+  const chartProps = { ...options, getColor };
+
   switch (type) {
     case CATEGORICAL_AREA_CHART_TYPE:
-      return <CategoricalAreaChart {...options} />;
+      return <CategoricalAreaChart {...chartProps} />;
     case CATEGORICAL_BAR_CHART_TYPE:
-      return <CategoricalBarChart {...options} />;
+      return <CategoricalBarChart {...chartProps} />;
     case CATEGORICAL_DONUT_CHART_TYPE:
-      return <CategoricalDonutChart {...options} />;
+      return <CategoricalDonutChart {...chartProps} />;
     case CATEGORICAL_LINE_CHART_TYPE:
-      return <CategoricalLineChart {...options} />;
+      return <CategoricalLineChart {...chartProps} />;
     case CATEGORICAL_WATERFALL_CHART_TYPE:
-      return <CategoricalWaterfallChart {...options} />;
+      return <CategoricalWaterfallChart {...chartProps} />;
     case TIME_SERIES_AREA_CHART_TYPE:
-      return <TimeSeriesAreaChart {...options} />;
+      return <TimeSeriesAreaChart {...chartProps} />;
     case TIME_SERIES_BAR_CHART_TYPE:
-      return <TimeSeriesBarChart {...options} />;
+      return <TimeSeriesBarChart {...chartProps} />;
     case TIME_SERIES_LINE_CHART_TYPE:
-      return <TimeSeriesLineChart {...options} />;
+      return <TimeSeriesLineChart {...chartProps} />;
     case TIME_SERIES_WATERFALL_CHART_TYPE:
-      return <TimeSeriesWaterfallChart {...options} />;
+      return <TimeSeriesWaterfallChart {...chartProps} />;
     case PROGRESS_BAR_TYPE:
-      return <ProgressBar {...options} />;
+      return <ProgressBar {...chartProps} />;
     case LINE_AREA_BAR_CHART_TYPE:
-      return <LineAreaBarChart {...options} />;
+      return <LineAreaBarChart {...chartProps} />;
     case FUNNEL_CHART_TYPE:
-      return <Funnel {...options} />;
+      return <Funnel {...chartProps} />;
   }
 };
 

--- a/frontend/src/metabase/static-viz/containers/StaticChart/types.ts
+++ b/frontend/src/metabase/static-viz/containers/StaticChart/types.ts
@@ -1,3 +1,4 @@
+import { ColorPalette } from "metabase/lib/colors/types";
 import { STATIC_CHART_TYPES } from "./constants";
 
 type StaticChartType = typeof STATIC_CHART_TYPES[number];
@@ -5,4 +6,5 @@ type StaticChartType = typeof STATIC_CHART_TYPES[number];
 export interface StaticChartProps {
   type: StaticChartType;
   options: any;
+  colors?: ColorPalette;
 }

--- a/frontend/src/metabase/static-viz/index.js
+++ b/frontend/src/metabase/static-viz/index.js
@@ -4,6 +4,6 @@ import StaticChart from "./containers/StaticChart";
 
 export function RenderChart(type, options) {
   return ReactDOMServer.renderToStaticMarkup(
-    <StaticChart type={type} options={options} />,
+    <StaticChart type={type} options={options} colors={options.colors} />,
   );
 }

--- a/frontend/src/metabase/static-viz/index.js
+++ b/frontend/src/metabase/static-viz/index.js
@@ -4,6 +4,6 @@ import StaticChart from "./containers/StaticChart";
 
 export function RenderChart(type, options) {
   return ReactDOMServer.renderToStaticMarkup(
-    <StaticChart type={type} options={options} colors={options.colors} />,
+    <StaticChart type={type} options={options} />,
   );
 }

--- a/frontend/src/metabase/static-viz/lib/axes.js
+++ b/frontend/src/metabase/static-viz/lib/axes.js
@@ -26,24 +26,24 @@ export const getYTickWidth = (data, accessors, settings, fontSize) => {
     .reduce((a, b) => Math.max(a, b), 0);
 };
 
-export const getXTickLabelProps = (layout, isVertical) => ({
+export const getXTickLabelProps = (layout, isVertical, getColor) => ({
   fontSize: layout.font.size,
   fontFamily: layout.font.family,
-  fill: layout.colors.textMedium,
+  fill: getColor("text-medium"),
   textAnchor: isVertical ? "start" : "middle",
 });
 
-export const getYTickLabelProps = layout => ({
+export const getYTickLabelProps = (layout, getColor) => ({
   fontSize: layout.font.size,
   fontFamily: layout.font.family,
-  fill: layout.colors.textMedium,
+  fill: getColor("text-medium"),
   textAnchor: "end",
 });
 
-export const getLabelProps = layout => ({
+export const getLabelProps = (layout, getColor) => ({
   fontWeight: layout.labelFontWeight,
   fontSize: layout.font.size,
   fontFamily: layout.font.family,
-  fill: layout.colors.textMedium,
+  fill: getColor("text-medium"),
   textAnchor: "middle",
 });

--- a/frontend/src/metabase/static-viz/lib/colors.ts
+++ b/frontend/src/metabase/static-viz/lib/colors.ts
@@ -1,13 +1,15 @@
 import { colors, color } from "metabase/lib/colors/palette";
 import { ColorPalette } from "metabase/lib/colors/types";
 
-export const createColorGetter = (instanceColors: ColorPalette = {}) => {
+export type ColorGetter = (colorName: string) => string;
+
+export const createColorGetter = (
+  instanceColors: ColorPalette = {},
+): ColorGetter => {
   const palette = { ...colors, ...instanceColors };
 
   return (colorName: string) => color(colorName, palette);
 };
-
-export type ColorGetter = ReturnType<typeof createColorGetter>;
 
 export type WaterfallColors = {
   waterfallTotal: string;

--- a/frontend/src/metabase/static-viz/lib/colors.ts
+++ b/frontend/src/metabase/static-viz/lib/colors.ts
@@ -1,0 +1,27 @@
+import { colors, color } from "metabase/lib/colors/palette";
+import { ColorPalette } from "metabase/lib/colors/types";
+
+export const createColorGetter = (instanceColors: ColorPalette = {}) => {
+  const palette = { ...colors, ...instanceColors };
+
+  return (colorName: string) => color(colorName, palette);
+};
+
+export type ColorGetter = ReturnType<typeof createColorGetter>;
+
+export type WaterfallColors = {
+  waterfallTotal: string;
+  waterfallPositive: string;
+  waterfallNegative: string;
+};
+
+export const getWaterfallColors = (
+  colorSettings: Partial<WaterfallColors> = {},
+  getColor: ColorGetter,
+): WaterfallColors => {
+  return {
+    waterfallTotal: colorSettings.waterfallTotal ?? getColor("text-dark"),
+    waterfallPositive: colorSettings.waterfallPositive ?? getColor("accent1"),
+    waterfallNegative: colorSettings.waterfallNegative ?? getColor("accent3"),
+  };
+};

--- a/resources/frontend_shared/static_viz_interface.js
+++ b/resources/frontend_shared/static_viz_interface.js
@@ -47,12 +47,12 @@ function combo_chart(series, settings, colors) {
   });
 }
 
-function timeseries_waterfall(data, labels, settings, colors) {
+function timeseries_waterfall(data, labels, settings, instanceColors) {
   return StaticViz.RenderChart("timeseries/waterfall", {
     data: toJSArray(data),
     labels: toJSMap(labels),
     settings: JSON.parse(settings),
-    colors: JSON.parse(colors),
+    colors: JSON.parse(instanceColors),
   });
 }
 
@@ -94,12 +94,12 @@ function categorical_donut(rows, colors) {
   });
 }
 
-function categorical_waterfall(data, labels, settings, colors) {
+function categorical_waterfall(data, labels, settings, instanceColors) {
   return StaticViz.RenderChart("categorical/waterfall", {
     data: toJSArray(data),
     labels: toJSMap(labels),
     settings: JSON.parse(settings),
-    colors: JSON.parse(colors),
+    colors: JSON.parse(instanceColors),
   });
 }
 

--- a/resources/frontend_shared/static_viz_interface.js
+++ b/resources/frontend_shared/static_viz_interface.js
@@ -47,11 +47,12 @@ function combo_chart(series, settings, colors) {
   });
 }
 
-function timeseries_waterfall(data, labels, settings) {
+function timeseries_waterfall(data, labels, settings, colors) {
   return StaticViz.RenderChart("timeseries/waterfall", {
     data: toJSArray(data),
     labels: toJSMap(labels),
     settings: JSON.parse(settings),
+    colors: JSON.parse(colors),
   });
 }
 
@@ -93,11 +94,12 @@ function categorical_donut(rows, colors) {
   });
 }
 
-function categorical_waterfall(data, labels, settings) {
+function categorical_waterfall(data, labels, settings, colors) {
   return StaticViz.RenderChart("categorical/waterfall", {
     data: toJSArray(data),
     labels: toJSMap(labels),
     settings: JSON.parse(settings),
+    colors: JSON.parse(colors),
   });
 }
 

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -776,9 +776,9 @@
                          (:waterfall.show_total viz-settings))
         settings       (-> (->js-viz x-col y-col viz-settings)
                            (update :colors assoc
-                                   :waterfallTotal (or (:waterfall.total_color viz-settings) (nth colors 0))
-                                   :waterfallPositive (or (:waterfall.increase_color viz-settings) (nth colors 1))
-                                   :waterfallNegative (or (:waterfall.decrease_color viz-settings) (nth colors 2)))
+                                   :waterfallTotal (:waterfall.total_color viz-settings)
+                                   :waterfallPositive (:waterfall.increase_color viz-settings)
+                                   :waterfallNegative (:waterfall.decrease_color viz-settings))
                            (assoc :showTotal show-total))
         image-bundle   (image-bundle/make-image-bundle
                         render-type

--- a/src/metabase/pulse/render/js_svg.clj
+++ b/src/metabase/pulse/render/js_svg.clj
@@ -5,6 +5,7 @@
   `toJSMap` functions to turn Clojure's normal datastructures into js native structures."
   (:require [cheshire.core :as json]
             [clojure.string :as str]
+            [metabase.public-settings :as public-settings]
             [metabase.pulse.render.js-engine :as js])
   (:import [java.io ByteArrayInputStream ByteArrayOutputStream]
            java.nio.charset.StandardCharsets
@@ -115,7 +116,8 @@
   [rows labels settings]
   (let [svg-string (.asString (js/execute-fn-name @context "timeseries_waterfall" rows
                                                   (map (fn [[k v]] [(name k) v]) labels)
-                                                  (json/generate-string settings)))]
+                                                  (json/generate-string settings)
+                                                  (json/generate-string (public-settings/application-colors))))]
     (svg-string->bytes svg-string)))
 
 (defn funnel
@@ -174,7 +176,8 @@
   [rows labels settings]
   (let [svg-string (.asString (js/execute-fn-name @context "categorical_waterfall" rows
                                                   (map (fn [[k v]] [(name k) v]) labels)
-                                                  (json/generate-string settings)))]
+                                                  (json/generate-string settings)
+                                                  (json/generate-string (public-settings/application-colors))))]
     (svg-string->bytes svg-string)))
 
 (defn categorical-bar

--- a/test/metabase/pulse/render/js_svg_test.clj
+++ b/test/metabase/pulse/render/js_svg_test.clj
@@ -9,6 +9,7 @@
             [clojure.set :as set]
             [clojure.spec.alpha :as s]
             [clojure.test :refer :all]
+            [metabase.public-settings :as public-settings]
             [metabase.pulse.render.js-engine :as js]
             [metabase.pulse.render.js-svg :as js-svg])
   (:import org.apache.batik.anim.dom.SVGOMDocument
@@ -175,7 +176,7 @@
     (testing "It returns bytes"
       (let [svg-bytes (js-svg/timelineseries-waterfall rows labels settings)]
         (is (bytes? svg-bytes))))
-    (let [svg-string (.asString (js/execute-fn-name @context "timeseries_waterfall" rows labels settings))]
+    (let [svg-string (.asString (js/execute-fn-name @context "timeseries_waterfall" rows labels settings (json/generate-string (public-settings/application-colors))))]
       (testing "it returns a valid svg string (no html in it)"
         (validate-svg-string :timelineseries-waterfall svg-string)))))
 
@@ -245,5 +246,5 @@
     (testing "It returns bytes"
       (let [svg-bytes (js-svg/categorical-waterfall rows labels {})]
         (is (bytes? svg-bytes))))
-    (let [svg-string (.asString ^Value (js/execute-fn-name @context "categorical_waterfall" rows labels settings))]
+    (let [svg-string (.asString ^Value (js/execute-fn-name @context "categorical_waterfall" rows labels settings (json/generate-string (public-settings/application-colors))))]
       (validate-svg-string :categorical/waterfall svg-string))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/20621

## Changes

Fixes default colors of static waterfall charts. Static viz JS code expects the instance colors from the BE to generate all necessary shades. If the instance colors are empty it uses the default ones.

We plan to remove the following chart types soon so I did not remove hardcoded colors from their `const layout = ...` definition.

```
CATEGORICAL_AREA_CHART_TYPE
CATEGORICAL_BAR_CHART_TYPE
CATEGORICAL_LINE_CHART_TYPE
TIME_SERIES_AREA_CHART_TYPE
TIME_SERIES_BAR_CHART_TYPE
TIME_SERIES_LINE_CHART_TYPE
```

<img width="1439" alt="Screen Shot 2022-08-17 at 11 40 36 PM" src="https://user-images.githubusercontent.com/14301985/185228077-a0d7e146-5989-4883-b806-a14fb9f5dc70.png">

<img width="633" alt="Screen Shot 2022-08-17 at 11 40 09 PM" src="https://user-images.githubusercontent.com/14301985/185228014-2496ceb5-8236-4ff6-8838-839534825495.png">

