### PR TITLE
Add serdes v2 for FieldValues, which were previously excluded

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
@@ -9,6 +9,7 @@
    "Database"
    "Dimension"
    "Field"
+   "FieldValues"
    "Metric"
    "NativeQuerySnippet"
    "Pulse"

--- a/src/metabase/models/field.clj
+++ b/src/metabase/models/field.clj
@@ -418,11 +418,5 @@
 
 (defmethod serdes.base/load-find-local "Field"
   [path]
-  (let [db-name            (-> path first :id)
-        schema-name        (when (= 3 (count path))
-                             (-> path second :id))
-        [{table-name :id}
-         {field-name :id}] (take-last 2 path)
-        db-id              (db/select-one-field :id 'Database :name db-name)
-        table-id           (db/select-one-field :id 'Table :name table-name :db_id db-id :schema schema-name)]
-    (db/select-one-field :id Field :name field-name :table_id table-id)))
+  (let [table-id (serdes.base/load-find-local (pop path))]
+    (db/select-one-field :id Field :name (-> path last :id) :table_id table-id)))


### PR DESCRIPTION
FieldValues can be rebuilt by the sync process, but they are portable
and including them aids in the plans for content moderation via git.

