### PR TITLE
Add subtitle through to input component

### DIFF
--- a/frontend/src/metabase/components/form/widgets/FormInputWidget.jsx
+++ b/frontend/src/metabase/components/form/widgets/FormInputWidget.jsx
@@ -14,7 +14,7 @@ const propTypes = {
   autoFocus: PropTypes.bool,
   helperText: PropTypes.node,
   tabIndex: PropTypes.string,
-  fieldName: PropTypes.string,
+  subtitle: PropTypes.string,
 };
 
 const FormInputWidget = forwardRef(function FormInputWidget(
@@ -26,13 +26,12 @@ const FormInputWidget = forwardRef(function FormInputWidget(
     autoFocus,
     helperText,
     tabIndex,
-    fieldName,
+    subtitle,
   },
   ref,
 ) {
   return (
     <div>
-      <div className="h6 text-bold text-uppercase text-light">{fieldName}</div>
       <Input
         {...formDomOnlyProps(field)}
         type={type}
@@ -45,6 +44,7 @@ const FormInputWidget = forwardRef(function FormInputWidget(
         rightIconTooltip={helperText}
         tabIndex={tabIndex}
         fullWidth
+        subtitle={subtitle}
         ref={ref}
       />
     </div>

--- a/frontend/src/metabase/core/components/Input/Input.styled.tsx
+++ b/frontend/src/metabase/core/components/Input/Input.styled.tsx
@@ -73,7 +73,7 @@ export const InputField = styled.input<InputProps>`
   ${props =>
     props.subtitle &&
     css`
-      padding-top: 1.25rem;
+      padding-top: 1.75rem;
     `};
 `;
 
@@ -95,7 +95,7 @@ export const InputRightButton = styled(InputButton)`
 export const InputSubtitle = styled.div`
   color: ${color("text-light")};
   position: absolute;
-  top: 0.6em;
+  top: 1.25em;
   left: 1.25em;
   font-family: ${monospaceFontFamily};
   font-size: 0.75em;

--- a/frontend/src/metabase/core/components/Input/Input.styled.tsx
+++ b/frontend/src/metabase/core/components/Input/Input.styled.tsx
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
 import { css } from "@emotion/react";
 import { color } from "metabase/lib/colors";
-import { space } from "metabase/styled-components/theme";
+import { monospaceFontFamily, space } from "metabase/styled-components/theme";
 import IconButtonWrapper from "metabase/components/IconButtonWrapper";
 import { InputSize } from "./types";
 
@@ -11,6 +11,7 @@ export interface InputProps {
   fullWidth?: boolean;
   hasLeftIcon?: boolean;
   hasRightIcon?: boolean;
+  subtitle?: string;
 }
 
 export const InputRoot = styled.div<InputProps>`
@@ -68,6 +69,12 @@ export const InputField = styled.input<InputProps>`
       line-height: 1rem;
       padding: 0.4375rem 0.625rem;
     `};
+
+  ${props =>
+    props.subtitle &&
+    css`
+      padding-top: 1.25rem;
+    `};
 `;
 
 export const InputButton = styled(IconButtonWrapper)`
@@ -83,4 +90,13 @@ export const InputLeftButton = styled(InputButton)`
 
 export const InputRightButton = styled(InputButton)`
   right: 0;
+`;
+
+export const InputSubtitle = styled.div`
+  color: ${color("text-light")};
+  position: absolute;
+  top: 0.6em;
+  left: 1.25em;
+  font-family: ${monospaceFontFamily};
+  font-size: 0.75em;
 `;

--- a/frontend/src/metabase/core/components/Input/Input.tsx
+++ b/frontend/src/metabase/core/components/Input/Input.tsx
@@ -12,6 +12,7 @@ import {
   InputLeftButton,
   InputRightButton,
   InputRoot,
+  InputSubtitle,
 } from "./Input.styled";
 import { InputSize } from "./types";
 
@@ -31,6 +32,7 @@ export interface InputProps extends InputAttributes {
   rightIconTooltip?: ReactNode;
   onLeftIconClick?: (event: MouseEvent<HTMLButtonElement>) => void;
   onRightIconClick?: (event: MouseEvent<HTMLButtonElement>) => void;
+  subtitle?: string;
 }
 
 const Input = forwardRef(function Input(
@@ -47,6 +49,7 @@ const Input = forwardRef(function Input(
     rightIconTooltip,
     onLeftIconClick,
     onRightIconClick,
+    subtitle,
     ...props
   }: InputProps,
   ref: Ref<HTMLDivElement>,
@@ -58,6 +61,8 @@ const Input = forwardRef(function Input(
       style={style}
       fullWidth={fullWidth}
     >
+      {subtitle && <InputSubtitle>{subtitle}</InputSubtitle>}
+
       <InputField
         {...props}
         ref={inputRef}
@@ -65,6 +70,7 @@ const Input = forwardRef(function Input(
         hasError={error}
         fullWidth={fullWidth}
         hasRightIcon={Boolean(rightIcon)}
+        subtitle={subtitle}
       />
       {leftIcon && (
         <Tooltip tooltip={leftIconTooltip} placement="left" offset={[0, 24]}>

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataSidebar.jsx
@@ -79,10 +79,9 @@ function getFormFields({ dataset, field }) {
   return formFieldValues =>
     [
       {
-        // TODO: change the widget from FormInputWidget
         name: "display_name",
         title: t`Display name`,
-        fieldName: field.name,
+        subtitle: field.name,
       },
       {
         name: "description",

--- a/frontend/src/metabase/styled-components/theme/index.ts
+++ b/frontend/src/metabase/styled-components/theme/index.ts
@@ -1,2 +1,3 @@
 export * from "./media-queries";
 export * from "./space";
+export * from "./typography";

--- a/frontend/src/metabase/styled-components/theme/typography.ts
+++ b/frontend/src/metabase/styled-components/theme/typography.ts
@@ -1,0 +1,1 @@
+export const monospaceFontFamily = "Monaco, monospace";


### PR DESCRIPTION
In this PR we add a prop, called `subtitle`, that is passed to the input component.

I did consider and experiment with Cal's suggestion of a dedicated widget for this.

However, we would end up with one more widget (whose "manager" has complicated logic as it is), plus a prop to Input. Or, at best, a variation on the input which would mean more cost than benefit.