### PR TITLE
[Apps] Data apps initial migration and endpoints

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -12622,6 +12622,13 @@ databaseChangeLog:
                     primaryKey: true
                     nullable: false
               - column:
+                  name: entity_id
+                  type: char(21)
+                  remarks: Random NanoID tag for unique identity.
+                  constraints:
+                    nullable: false
+                    unique: true
+              - column:
                   name: collection_id
                   type: int
                   remarks: The associated collection

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -12637,6 +12637,10 @@ databaseChangeLog:
                   type: int
                   remarks: The homepage of the app
               - column:
+                  remarks: JSON for the navigation items of the app
+                  name: nav_items
+                  type: ${text.type}
+              - column:
                   remarks: JSON for frontend related additions, such as styling
                   name: options
                   type: ${text.type}
@@ -12667,37 +12671,6 @@ databaseChangeLog:
             referencedColumnNames: id
             constraintName: fk_app_ref_dashboard_id
             onDelete: SET NULL
-
-  - changeSet:
-      id: v45.00-024
-      author: snoe
-      comment: Added 0.45.0 - add app container
-      changes:
-        - createTable:
-            tableName: app_nav_item
-            remarks: Defines navigation items for an app
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: app_id
-                  type: int
-                  remarks: The associated app
-                  constraints:
-                    nullable: false
-                    referencedTableName: app
-                    referencedColumnNames: id
-                    foreignKeyName: fk_app_entry_item_ref_app_id
-                    deleteCascade: true
-              - column:
-                  remarks: JSON for frontend related click_behavior, styling, ordering, positioning
-                  name: options
-                  type: ${text.type}
 
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -12605,6 +12605,100 @@ databaseChangeLog:
         - dropTable:
             tableName: emitter_action
 
+  - changeSet:
+      id: v45.00-022
+      author: snoe
+      comment: Added 0.45.0 - add app container
+      changes:
+        - createTable:
+            tableName: app
+            remarks: Defines top level concerns for App
+            columns:
+              - column:
+                  name: id
+                  type: int
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: collection_id
+                  type: int
+                  remarks: The associated collection
+                  constraints:
+                    nullable: false
+                    referencedTableName: collection
+                    referencedColumnNames: id
+                    foreignKeyName: fk_app_ref_collection_id
+                    deleteCascade: true
+                    unique: true
+              - column:
+                  name: dashboard_id
+                  type: int
+                  remarks: The homepage of the app
+              - column:
+                  remarks: JSON for frontend related additions, such as styling
+                  name: options
+                  type: ${text.type}
+              - column:
+                  remarks: The timestamp of when the app was created
+                  name: created_at
+                  type: ${timestamp_type}
+                  defaultValueComputed: current_timestamp
+                  constraints:
+                    nullable: false
+              - column:
+                  remarks: The timestamp of when the app was updated
+                  name: updated_at
+                  type: ${timestamp_type}
+                  defaultValueComputed: current_timestamp
+                  constraints:
+                    nullable: false
+
+  - changeSet:
+      id: v45.00-023
+      author: snoe
+      comment: Added 0.45.0 - add app container
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: app
+            baseColumnNames: dashboard_id
+            referencedTableName: report_dashboard
+            referencedColumnNames: id
+            constraintName: fk_app_ref_dashboard_id
+            onDelete: SET NULL
+
+  - changeSet:
+      id: v45.00-024
+      author: snoe
+      comment: Added 0.45.0 - add app container
+      changes:
+        - createTable:
+            tableName: app_nav_item
+            remarks: Defines navigation items for an app
+            columns:
+              - column:
+                  name: id
+                  type: int
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: app_id
+                  type: int
+                  remarks: The associated app
+                  constraints:
+                    nullable: false
+                    referencedTableName: app
+                    referencedColumnNames: id
+                    foreignKeyName: fk_app_entry_item_ref_app_id
+                    deleteCascade: true
+              - column:
+                  remarks: JSON for frontend related click_behavior, styling, ordering, positioning
+                  name: options
+                  type: ${text.type}
+
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/src/metabase/api/app.clj
+++ b/src/metabase/api/app.clj
@@ -14,13 +14,12 @@
   {collection_id su/IntGreaterThanOrEqualToZero
    dashboard_id (s/maybe su/IntGreaterThanOrEqualToZero)
    options (s/maybe su/Map)
-   nav_items (s/maybe [{:options (s/maybe su/Map)}])}
+   nav_items (s/maybe [(s/maybe su/Map)])}
   (api/write-check Collection collection_id)
-  (api/check
-    (not (db/select-one-id App :collection_id collection_id))
-    400 "An App already exists on this Collection")
+  (api/check (not (db/select-one-id App :collection_id collection_id))
+    [400 "An App already exists on this Collection"])
   (let [app (db/insert! App (select-keys body [:dashboard_id :collection_id :options :nav_items]))]
-   (hydrate app :collection)))
+    (hydrate app :collection)))
 
 (api/defendpoint PUT "/:app-id"
   "Endpoint to change an app"
@@ -28,7 +27,7 @@
   {app-id su/IntGreaterThanOrEqualToZero
    dashboard_id (s/maybe su/IntGreaterThanOrEqualToZero)
    options (s/maybe su/Map)
-   nav_items (s/maybe [{:options (s/maybe su/Map)}])}
+   nav_items (s/maybe [(s/maybe su/Map)])}
   (api/write-check Collection (db/select-one-field :collection_id App :id app-id))
   (db/update! App app-id (select-keys body [:dashboard_id :options :nav_items]))
   (hydrate (App app-id) :collection))

--- a/src/metabase/api/app.clj
+++ b/src/metabase/api/app.clj
@@ -1,0 +1,48 @@
+(ns metabase.api.app
+  (:require
+    [compojure.core :refer [POST PUT]]
+    [metabase.api.common :as api]
+    [metabase.models :refer [App AppNavItem Collection]]
+    [metabase.util.schema :as su]
+    [schema.core :as s]
+    [toucan.db :as db]
+    [toucan.hydrate :refer [hydrate]]))
+
+(api/defendpoint POST "/"
+  "Endpoint to create an app"
+  [:as {{:keys [collection_id dashboard_id options nav-items] :as body} :body}]
+  {collection_id su/IntGreaterThanOrEqualToZero
+   dashboard_id (s/maybe su/IntGreaterThanOrEqualToZero)
+   options (s/maybe su/Map)
+   nav-items (s/maybe [{:options (s/maybe su/Map)}])}
+  (api/write-check Collection collection_id)
+  (api/check
+    (not (db/select-one-id App :collection_id collection_id))
+    400 "An App already exists on this Collection")
+  (let [app (db/insert! App (select-keys body [:dashboard_id :collection_id :options]))]
+    (when (seq nav-items)
+      (db/insert-many! AppNavItem (for [nav-item nav-items]
+                                    (-> nav-item
+                                        (select-keys [:options])
+                                        (assoc :app_id (:id app))))))
+   (hydrate app :app/nav-items :collection)))
+
+(api/defendpoint PUT "/:app-id"
+  "Endpoint to change an app"
+  [app-id :as {{:keys [dashboard_id options nav-items] :as body} :body}]
+  {app-id su/IntGreaterThanOrEqualToZero
+   dashboard_id (s/maybe su/IntGreaterThanOrEqualToZero)
+   options (s/maybe su/Map)
+   nav-items (s/maybe [{:options (s/maybe su/Map)}])}
+  (api/write-check Collection (db/select-one-field :collection_id App :id app-id))
+  (when nav-items
+    (db/delete! AppNavItem :app-id app-id)
+    (when (seq nav-items)
+      (db/insert-many! AppNavItem (for [nav-item nav-items]
+                                    (-> nav-item
+                                        (select-keys [:options])
+                                        (assoc :app_id app-id))))))
+  (db/update! App app-id (select-keys body [:dashboard_id :options]))
+  (hydrate (App app-id) :app/nav-items :collection))
+
+(api/define-routes)

--- a/src/metabase/api/app.clj
+++ b/src/metabase/api/app.clj
@@ -51,4 +51,9 @@
            :order-by [[:%lower.collection.name :asc]]})
         (hydrate :collection))))
 
+(api/defendpoint GET "/:id"
+  "Fetch a specific App"
+  [id]
+  (hydrate (api/read-check App id) :collection))
+
 (api/define-routes)

--- a/src/metabase/api/app.clj
+++ b/src/metabase/api/app.clj
@@ -3,6 +3,7 @@
     [compojure.core :refer [POST PUT]]
     [metabase.api.common :as api]
     [metabase.models :refer [App Collection]]
+    [metabase.models.collection :as collection]
     [metabase.util.schema :as su]
     [schema.core :as s]
     [toucan.db :as db]
@@ -31,5 +32,23 @@
   (api/write-check Collection (db/select-one-field :collection_id App :id app-id))
   (db/update! App app-id (select-keys body [:dashboard_id :options :nav_items]))
   (hydrate (App app-id) :collection))
+
+;; TODO handle personal collections, see collection/personal-collection-with-ui-details
+(api/defendpoint GET "/"
+  "Fetch a list of all Apps that the current user has read permissions for.
+
+  By default, this returns Apps with non-archived Collections, but instead you can show archived ones by passing
+  `?archived=true`."
+  [archived]
+  {archived (s/maybe su/BooleanString)}
+  (let [archived? (Boolean/parseBoolean archived)]
+    (-> (db/select [App :app.*]
+          {:left-join [:collection [:= :collection.id :app.collection_id]]
+           :where    [:and
+                      [:= :collection.archived archived?]
+                      (collection/visible-collection-ids->honeysql-filter-clause
+                       (collection/permissions-set->visible-collection-ids @api/*current-user-permissions-set*))]
+           :order-by [[:%lower.collection.name :asc]]})
+        (hydrate :collection))))
 
 (api/define-routes)

--- a/src/metabase/api/routes.clj
+++ b/src/metabase/api/routes.clj
@@ -4,6 +4,7 @@
             [metabase.api.action :as api.action]
             [metabase.api.activity :as api.activity]
             [metabase.api.alert :as api.alert]
+            [metabase.api.app :as api.app]
             [metabase.api.automagic-dashboards :as api.magic]
             [metabase.api.bookmark :as api.bookmark]
             [metabase.api.card :as api.card]
@@ -66,6 +67,7 @@
   (context "/action"              [] (+auth api.action/routes))
   (context "/activity"             [] (+auth api.activity/routes))
   (context "/alert"                [] (+auth api.alert/routes))
+  (context "/app"                  [] (+auth api.app/routes))
   (context "/automagic-dashboards" [] (+auth api.magic/routes))
   (context "/card"                 [] (+auth api.card/routes))
   (context "/bookmark"             [] (+auth api.bookmark/routes))

--- a/src/metabase/cmd/copy.clj
+++ b/src/metabase/cmd/copy.clj
@@ -11,7 +11,6 @@
             [metabase.db.setup :as mdb.setup]
             [metabase.models :refer [Activity
                                      App
-                                     AppNavItem
                                      ApplicationPermissionsRevision
                                      BookmarkOrdering
                                      Card
@@ -106,7 +105,6 @@
    DashboardCardSeries
    Activity
    App
-   AppNavItem
    Pulse
    PulseCard
    PulseChannel

--- a/src/metabase/cmd/copy.clj
+++ b/src/metabase/cmd/copy.clj
@@ -10,6 +10,8 @@
             [metabase.db.data-migrations :refer [DataMigrations]]
             [metabase.db.setup :as mdb.setup]
             [metabase.models :refer [Activity
+                                     App
+                                     AppNavItem
                                      ApplicationPermissionsRevision
                                      BookmarkOrdering
                                      Card
@@ -103,6 +105,8 @@
    DashboardCard
    DashboardCardSeries
    Activity
+   App
+   AppNavItem
    Pulse
    PulseCard
    PulseChannel

--- a/src/metabase/models.clj
+++ b/src/metabase/models.clj
@@ -1,6 +1,7 @@
 (ns metabase.models
   (:require [metabase.models.action :as action]
             [metabase.models.activity :as activity]
+            [metabase.models.app :as app]
             [metabase.models.application-permissions-revision :as a-perm-revision]
             [metabase.models.bookmark :as bookmark]
             [metabase.models.card :as card]
@@ -46,6 +47,7 @@
 ;; Fool the linter
 (comment action/keep-me
          activity/keep-me
+         app/keep-me
          card/keep-me
          bookmark/keep-me
          collection/keep-me
@@ -90,6 +92,8 @@
 (p/import-vars
  [action Action HTTPAction QueryAction]
  [activity Activity]
+ [app App]
+ [app AppNavItem]
  [bookmark CardBookmark]
  [bookmark DashboardBookmark]
  [bookmark CollectionBookmark]

--- a/src/metabase/models.clj
+++ b/src/metabase/models.clj
@@ -93,7 +93,6 @@
  [action Action HTTPAction QueryAction]
  [activity Activity]
  [app App]
- [app AppNavItem]
  [bookmark CardBookmark]
  [bookmark DashboardBookmark]
  [bookmark CollectionBookmark]

--- a/src/metabase/models/app.clj
+++ b/src/metabase/models/app.clj
@@ -1,10 +1,10 @@
 (ns metabase.models.app
-  (:require [metabase.models.interface :as mi]
+  (:require [medley.core :as m]
+            [metabase.models.interface :as mi]
             [metabase.models.permissions :as perms]
             [metabase.util :as u]
             [toucan.db :as db]
-            [toucan.models :as models]
-            [medley.core :as m]))
+            [toucan.models :as models]))
 
 (models/defmodel App :app)
 (models/defmodel AppNavItem :app_nav_item)
@@ -25,6 +25,7 @@
          {:types (constantly {:options :json})}))
 
 (defn nav-items
+  "Hydrates app's nav-items."
   {:batched-hydrate :app/nav-items}
   [apps]
   (let [nav-items (db/select AppNavItem :app_id [:in (map :id apps)])

--- a/src/metabase/models/app.clj
+++ b/src/metabase/models/app.clj
@@ -1,38 +1,18 @@
 (ns metabase.models.app
-  (:require [medley.core :as m]
-            [metabase.models.interface :as mi]
+  (:require [metabase.models.interface :as mi]
             [metabase.models.permissions :as perms]
             [metabase.util :as u]
-            [toucan.db :as db]
             [toucan.models :as models]))
 
 (models/defmodel App :app)
-(models/defmodel AppNavItem :app_nav_item)
 
 (u/strict-extend (class App)
   models/IModel
   (merge models/IModelDefaults
-         {:types (constantly {:options :json})
+         {:types (constantly {:options :json
+                              :nav_items :json})
           :properties (constantly {:timestamped? true})})
 
-  ;; You can read/write an App if you can read/write its parent Collection
+  ;; You can read/write an App if you can read/write its Collection
   mi/IObjectPermissions
   perms/IObjectPermissionsForParentCollection)
-
-(u/strict-extend (class AppNavItem)
-  models/IModel
-  (merge models/IModelDefaults
-         {:types (constantly {:options :json})}))
-
-(defn nav-items
-  "Hydrates app's nav-items."
-  {:batched-hydrate :app/nav-items}
-  [apps]
-  (let [nav-items (db/select AppNavItem :app_id [:in (map :id apps)])
-        nav-items-by-app-id (reduce
-                              (fn [m nav-item]
-                                (update m (:app_id nav-item) (fnil conj []) (select-keys nav-item [:options])))
-                              {}
-                              nav-items)]
-    (for [app apps]
-      (m/assoc-some app :nav-items (get nav-items-by-app-id (:id app))))))

--- a/src/metabase/models/app.clj
+++ b/src/metabase/models/app.clj
@@ -1,6 +1,7 @@
 (ns metabase.models.app
   (:require [metabase.models.interface :as mi]
             [metabase.models.permissions :as perms]
+            [metabase.models.serialization.hash :as serdes.hash]
             [metabase.util :as u]
             [toucan.models :as models]))
 
@@ -11,8 +12,14 @@
   (merge models/IModelDefaults
          {:types (constantly {:options :json
                               :nav_items :json})
-          :properties (constantly {:timestamped? true})})
+          :properties (constantly {:timestamped? true
+                                   :entity_id    true})})
 
   ;; You can read/write an App if you can read/write its Collection
   mi/IObjectPermissions
-  perms/IObjectPermissionsForParentCollection)
+  perms/IObjectPermissionsForParentCollection
+
+  ;; Should not be needed as every app should have an entity_id, but currently it's
+  ;; necessary to satisfy metabase-enterprise.models.entity-id-test/comprehensive-identity-hash-test.
+  serdes.hash/IdentityHashable
+  {:identity-hash-fields (constantly [:entity_id])})

--- a/src/metabase/models/app.clj
+++ b/src/metabase/models/app.clj
@@ -1,0 +1,37 @@
+(ns metabase.models.app
+  (:require [metabase.models.interface :as mi]
+            [metabase.models.permissions :as perms]
+            [metabase.util :as u]
+            [toucan.db :as db]
+            [toucan.models :as models]
+            [medley.core :as m]))
+
+(models/defmodel App :app)
+(models/defmodel AppNavItem :app_nav_item)
+
+(u/strict-extend (class App)
+  models/IModel
+  (merge models/IModelDefaults
+         {:types (constantly {:options :json})
+          :properties (constantly {:timestamped? true})})
+
+  ;; You can read/write an App if you can read/write its parent Collection
+  mi/IObjectPermissions
+  perms/IObjectPermissionsForParentCollection)
+
+(u/strict-extend (class AppNavItem)
+  models/IModel
+  (merge models/IModelDefaults
+         {:types (constantly {:options :json})}))
+
+(defn nav-items
+  {:batched-hydrate :app/nav-items}
+  [apps]
+  (let [nav-items (db/select AppNavItem :app_id [:in (map :id apps)])
+        nav-items-by-app-id (reduce
+                              (fn [m nav-item]
+                                (update m (:app_id nav-item) (fnil conj []) (select-keys nav-item [:options])))
+                              {}
+                              nav-items)]
+    (for [app apps]
+      (m/assoc-some app :nav-items (get nav-items-by-app-id (:id app))))))

--- a/test/metabase/api/app_test.clj
+++ b/test/metabase/api/app_test.clj
@@ -73,7 +73,7 @@
         (let [expected (merge app-data {:id app-id
                                         :collection_id collection_id
                                         :dashboard_id dashboard_id
-                                        :collection collection})]
+                                        :collection (assoc collection :can_write true)})]
           (testing "can query non-archived apps"
             (is (partial= [expected]
                           (mt/user-http-request :crowberto :get 200 "app"))))))
@@ -88,7 +88,7 @@
             (let [expected (merge app-data {:id app-id
                                             :collection_id (:id collection-1)
                                             :dashboard_id dashboard_id
-                                            :collection collection-1})]
+                                            :collection (assoc collection-1 :can_write false)})]
               (is (partial= [expected]
                             (mt/user-http-request :rasta :get 200 "app")))))))
       (testing "archives"
@@ -101,14 +101,14 @@
             (let [expected (merge app-data {:id app-1-id
                                             :collection_id (:id collection-1)
                                             :dashboard_id dashboard_id
-                                            :collection collection-1})]
+                                            :collection (assoc collection-1 :can_write true)})]
              (is (partial= [expected]
                            (mt/user-http-request :rasta :get 200 "app")))))
           (testing "listing archived"
             (let [expected (merge app-data {:id app-2-id
                                             :collection_id (:id collection-2)
                                             :dashboard_id dashboard_id
-                                            :collection collection-2})]
+                                            :collection (assoc collection-2 :can_write true)})]
               (is (partial= [expected]
                             (mt/user-http-request :rasta :get 200 "app/?archived=true"))))))))))
 
@@ -123,7 +123,7 @@
           (let [expected (merge app-data {:id app-id
                                           :collection_id collection_id
                                           :dashboard_id dashboard_id
-                                          :collection collection})]
+                                          :collection (assoc collection :can_write true)})]
             (is (partial= expected
                           (mt/user-http-request :crowberto :get 200 (str "app/" app-id))))))
         (testing "that app detail properly checks permissions"

--- a/test/metabase/api/app_test.clj
+++ b/test/metabase/api/app_test.clj
@@ -1,0 +1,49 @@
+(ns metabase.api.app-test
+  (:require
+    [clojure.test :refer [deftest is testing]]
+    [metabase.models :refer [App Collection Dashboard]]
+    [metabase.test :as mt]))
+
+(deftest create-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :actions/custom)
+    (mt/with-temp* [Collection [{collection_id :id}]]
+      (is (partial= {:collection_id collection_id}
+                    (mt/user-http-request :crowberto :post 200 "app" {:collection_id collection_id})))
+      (is (= "An App already exists on this Collection"
+             (mt/user-http-request :crowberto :post 400 "app" {:collection_id collection_id}))))
+    (testing "Collection permissions"
+      (mt/with-non-admin-groups-no-root-collection-perms
+        (mt/with-temp* [Collection [{collection_id :id}]]
+          (is (= "You don't have permissions to do that."
+                 (mt/user-http-request :rasta :post 403 "app" {:collection_id collection_id})))))
+      (mt/with-temp* [Collection [{collection_id :id}]]
+        (is (partial= {:collection_id collection_id}
+                      (mt/user-http-request :rasta :post 200 "app" {:collection_id collection_id})))))
+    (testing "With initial dashboard and nav-items"
+      (mt/with-temp* [Collection [{collection_id :id}]
+                      Dashboard [{dashboard_id :id}]]
+        (let [nav-items [{:options {:click_behavior {}}}]]
+          (is (partial= {:collection_id collection_id
+                         :dashboard_id dashboard_id
+                         :nav-items nav-items}
+                        (mt/user-http-request :crowberto :post 200 "app" {:collection_id collection_id
+                                                                          :dashboard_id dashboard_id
+                                                                          :nav-items nav-items}))))))))
+
+(deftest update-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :actions/custom)
+    (mt/with-temp* [Collection [{collection_id :id}]
+                    App [{app_id :id} {:collection_id collection_id}]
+                    Dashboard [{dashboard_id :id}]]
+      (is (partial= {:collection_id collection_id :dashboard_id dashboard_id}
+                    (mt/user-http-request :crowberto :put 200 (str "app/" app_id) {:dashboard_id dashboard_id}))))
+    (testing "Collection permissions"
+      (mt/with-non-admin-groups-no-root-collection-perms
+        (mt/with-temp* [Collection [{collection_id :id}]
+                        App [{app_id :id} {:collection_id collection_id}]]
+          (is (= "You don't have permissions to do that."
+                 (mt/user-http-request :rasta :put 403 (str "app/" app_id) {})))))
+      (mt/with-temp* [Collection [{collection_id :id}]
+                      App [{app_id :id} {:collection_id collection_id}]]
+        (is (partial= {:collection_id collection_id}
+                      (mt/user-http-request :rasta :put 200 (str "app/" app_id) {})))))))

--- a/test/metabase/api/app_test.clj
+++ b/test/metabase/api/app_test.clj
@@ -111,3 +111,21 @@
                                             :collection collection-2})]
               (is (partial= [expected]
                             (mt/user-http-request :rasta :get 200 "app/?archived=true"))))))))))
+
+(deftest fetch-app-test
+  (let [app-data {:nav_items [{:options {:item "stuff"}}]
+                  :options {:frontend "stuff"}}]
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (mt/with-temp* [Collection [{collection_id :id :as collection}]
+                      Dashboard [{dashboard_id :id}]
+                      App [{app-id :id} (assoc app-data :collection_id collection_id :dashboard_id dashboard_id)]]
+        (testing "that we can see app details"
+          (let [expected (merge app-data {:id app-id
+                                          :collection_id collection_id
+                                          :dashboard_id dashboard_id
+                                          :collection collection})]
+            (is (partial= expected
+                          (mt/user-http-request :crowberto :get 200 (str "app/" app-id))))))
+        (testing "that app detail properly checks permissions"
+          (is (= "You don't have permissions to do that."
+                 (mt/user-http-request :rasta :get 403 (str "app/" app-id)))))))))

--- a/test/metabase/api/app_test.clj
+++ b/test/metabase/api/app_test.clj
@@ -19,16 +19,16 @@
       (mt/with-temp* [Collection [{collection_id :id}]]
         (is (partial= {:collection_id collection_id}
                       (mt/user-http-request :rasta :post 200 "app" {:collection_id collection_id})))))
-    (testing "With initial dashboard and nav-items"
+    (testing "With initial dashboard and nav_items"
       (mt/with-temp* [Collection [{collection_id :id}]
                       Dashboard [{dashboard_id :id}]]
-        (let [nav-items [{:options {:click_behavior {}}}]]
+        (let [nav_items [{:options {:click_behavior {}}}]]
           (is (partial= {:collection_id collection_id
                          :dashboard_id dashboard_id
-                         :nav-items nav-items}
+                         :nav_items nav_items}
                         (mt/user-http-request :crowberto :post 200 "app" {:collection_id collection_id
                                                                           :dashboard_id dashboard_id
-                                                                          :nav-items nav-items}))))))))
+                                                                          :nav_items nav_items}))))))))
 
 (deftest update-test
   (mt/test-drivers (mt/normal-drivers-with-feature :actions/custom)

--- a/test/metabase/api/app_test.clj
+++ b/test/metabase/api/app_test.clj
@@ -32,11 +32,24 @@
 
 (deftest update-test
   (mt/test-drivers (mt/normal-drivers-with-feature :actions/custom)
-    (mt/with-temp* [Collection [{collection_id :id}]
-                    App [{app_id :id} {:collection_id collection_id}]
-                    Dashboard [{dashboard_id :id}]]
-      (is (partial= {:collection_id collection_id :dashboard_id dashboard_id}
-                    (mt/user-http-request :crowberto :put 200 (str "app/" app_id) {:dashboard_id dashboard_id}))))
+    (let [app-data {:nav_items [{:options {:item "stuff"}}]
+                    :options {:frontend "stuff"}}]
+      (mt/with-temp* [Collection [{collection_id :id}]
+                      App [{app_id :id} (assoc app-data :collection_id collection_id)]
+                      Dashboard [{dashboard_id :id}]]
+        (let [expected (merge app-data {:collection_id collection_id
+                                        :dashboard_id dashboard_id})]
+          (testing "setting the dashboard_id doesn't affect the other fields"
+            (is (partial= expected
+                          (mt/user-http-request :crowberto :put 200 (str "app/" app_id) {:dashboard_id dashboard_id}))))
+          (testing "can remove nav items"
+            (is (partial= (assoc expected :nav_items nil)
+                          (mt/user-http-request :crowberto :put 200 (str "app/" app_id) {:dashboard_id dashboard_id
+                                                                                         :nav_items nil}))))
+          (testing "can remove options"
+            (is (partial= (assoc expected :nav_items nil :options nil)
+                          (mt/user-http-request :crowberto :put 200 (str "app/" app_id) {:dashboard_id dashboard_id
+                                                                                         :options nil})))))))
     (testing "Collection permissions"
       (mt/with-non-admin-groups-no-root-collection-perms
         (mt/with-temp* [Collection [{collection_id :id}]


### PR DESCRIPTION
Addresses #24879 and #24880, part of #24861

`App` is a container that brings various dashboards together into a
cohesive unit.

The field `nav_items` is used for sidebar navigation within the app.
The items in it will be managed by the front end and could contain
link definitions to dashboards or arbitrary urls.
