### PR TITLE
Show all "details-only" columns in the metadata tab of the DatasetEditor

### DIFF
--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
@@ -464,6 +464,7 @@ function DatasetEditor(props) {
                 className="spread"
                 noHeader
                 queryBuilderMode="dataset"
+                isShowingDetailsOnlyColumns={datasetEditorTab === "metadata"}
                 hasMetadataPopovers={false}
                 handleVisualizationClick={handleTableElementClick}
                 tableHeaderHeight={isEditingMetadata && TABLE_HEADER_HEIGHT}

--- a/frontend/src/metabase/query_builder/components/VisualizationResult.jsx
+++ b/frontend/src/metabase/query_builder/components/VisualizationResult.jsx
@@ -12,6 +12,8 @@ import Modal from "metabase/components/Modal";
 import { ALERT_TYPE_ROWS } from "metabase-lib/lib/Alert";
 
 const ALLOWED_VISUALIZATION_PROPS = [
+  // Table
+  "isShowingDetailsOnlyColumns",
   // Table Interactive
   "hasMetadataPopovers",
   "tableHeaderHeight",

--- a/frontend/src/metabase/visualizations/visualizations/Table.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Table.jsx
@@ -1,5 +1,6 @@
 /* eslint-disable react/prop-types */
 import React, { Component } from "react";
+import { connect } from "react-redux";
 
 import TableInteractive from "../components/TableInteractive/TableInteractive.jsx";
 import TableSimple from "../components/TableSimple";
@@ -21,6 +22,8 @@ import {
   isAvatarURL,
 } from "metabase/lib/schema_metadata";
 
+import { getDatasetEditorTab } from "metabase/query_builder/selectors";
+
 import ChartSettingOrderedColumns from "metabase/visualizations/components/settings/ChartSettingOrderedColumns";
 import ChartSettingsTableFormatting, {
   isFormattable,
@@ -34,7 +37,11 @@ import cx from "classnames";
 
 import { getIn } from "icepick";
 
-export default class Table extends Component {
+const mapStateToProps = state => ({
+  datasetEditorTab: getDatasetEditorTab(state),
+});
+
+class Table extends Component {
   static uiName = t`Table`;
   static identifier = "table";
   static iconName = "table";
@@ -185,7 +192,9 @@ export default class Table extends Component {
         cols.map(col => ({
           name: col.name,
           fieldRef: col.field_ref,
-          enabled: col.visibility_type !== "details-only",
+          enabled:
+            this.props.datasetEditorTab === "metadata" ||
+            col.visibility_type !== "details-only",
         })),
       getProps: ([
         {
@@ -432,3 +441,5 @@ export default class Table extends Component {
     );
   }
 }
+
+export default _.compose(connect(mapStateToProps))(Table);

--- a/frontend/src/metabase/visualizations/visualizations/Table.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Table.jsx
@@ -38,7 +38,7 @@ import cx from "classnames";
 import { getIn } from "icepick";
 
 const mapStateToProps = state => ({
-  datasetEditorTab: getDatasetEditorTab(state),
+  datasetEditorTab: "qb" in state && getDatasetEditorTab(state),
 });
 
 class Table extends Component {

--- a/frontend/src/metabase/visualizations/visualizations/Table.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Table.jsx
@@ -442,4 +442,4 @@ class Table extends Component {
   }
 }
 
-export default _.compose(connect(mapStateToProps))(Table);
+export default connect(mapStateToProps)(Table);

--- a/frontend/src/metabase/visualizations/visualizations/Table.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Table.jsx
@@ -1,6 +1,5 @@
 /* eslint-disable react/prop-types */
 import React, { Component } from "react";
-import { connect } from "react-redux";
 
 import TableInteractive from "../components/TableInteractive/TableInteractive.jsx";
 import TableSimple from "../components/TableSimple";
@@ -22,8 +21,6 @@ import {
   isAvatarURL,
 } from "metabase/lib/schema_metadata";
 
-import { getDatasetEditorTab } from "metabase/query_builder/selectors";
-
 import ChartSettingOrderedColumns from "metabase/visualizations/components/settings/ChartSettingOrderedColumns";
 import ChartSettingsTableFormatting, {
   isFormattable,
@@ -37,11 +34,7 @@ import cx from "classnames";
 
 import { getIn } from "icepick";
 
-const mapStateToProps = state => ({
-  datasetEditorTab: "qb" in state && getDatasetEditorTab(state),
-});
-
-class Table extends Component {
+export default class Table extends Component {
   static uiName = t`Table`;
   static identifier = "table";
   static iconName = "table";
@@ -360,7 +353,7 @@ class Table extends Component {
       const columnIndexes = columnSettings
         .filter(
           columnSetting =>
-            columnSetting.enabled || this.props.datasetEditorTab === "metadata",
+            columnSetting.enabled || this.props.isShowingDetailsOnlyColumns,
         )
         .map(columnSetting =>
           findColumnIndexForColumnSetting(cols, columnSetting),
@@ -441,5 +434,3 @@ class Table extends Component {
     );
   }
 }
-
-export default connect(mapStateToProps)(Table);

--- a/frontend/src/metabase/visualizations/visualizations/Table.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Table.jsx
@@ -192,9 +192,7 @@ class Table extends Component {
         cols.map(col => ({
           name: col.name,
           fieldRef: col.field_ref,
-          enabled:
-            this.props.datasetEditorTab === "metadata" ||
-            col.visibility_type !== "details-only",
+          enabled: col.visibility_type !== "details-only",
         })),
       getProps: ([
         {
@@ -360,7 +358,10 @@ class Table extends Component {
       const { cols, rows } = data;
       const columnSettings = settings["table.columns"];
       const columnIndexes = columnSettings
-        .filter(columnSetting => columnSetting.enabled)
+        .filter(
+          columnSetting =>
+            columnSetting.enabled || this.props.datasetEditorTab === "metadata",
+        )
         .map(columnSetting =>
           findColumnIndexForColumnSetting(cols, columnSetting),
         )
@@ -400,8 +401,7 @@ class Table extends Component {
     const [{ card }] = series;
     const sort = getIn(card, ["dataset_query", "query", "order-by"]) || null;
     const isPivoted = Table.isPivoted(series, settings);
-    const columnSettings = settings["table.columns"] || [];
-    const areAllColumnsHidden = !columnSettings.some(f => f.enabled);
+    const areAllColumnsHidden = data.cols.length === 0;
     const TableComponent = isDashboard ? TableSimple : TableInteractive;
 
     if (!data) {

--- a/frontend/test/metabase/scenarios/models/models-metadata.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models-metadata.cy.spec.js
@@ -20,7 +20,7 @@ import {
 
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
-const { PRODUCTS, PRODUCTS_ID, REVIEWS } = SAMPLE_DATABASE;
+const { PEOPLE, PRODUCTS, PRODUCTS_ID, REVIEWS } = SAMPLE_DATABASE;
 
 describe("scenarios > models metadata", () => {
   beforeEach(() => {

--- a/frontend/test/metabase/scenarios/models/models-metadata.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models-metadata.cy.spec.js
@@ -20,7 +20,7 @@ import {
 
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
-const { PEOPLE, REVIEWS } = SAMPLE_DATABASE;
+const { PRODUCTS, PRODUCTS_ID, REVIEWS } = SAMPLE_DATABASE;
 
 describe("scenarios > models metadata", () => {
   beforeEach(() => {
@@ -272,6 +272,27 @@ describe("scenarios > models metadata", () => {
           });
         });
       });
+    });
+
+    it("models metadata tab should show columns with details-only visibility (metabase#22521)", () => {
+      cy.request("PUT", `/api/field/${PRODUCTS.VENDOR}`, {
+        visibility_type: "details-only",
+      });
+
+      const questionDetails = {
+        name: "22521",
+        dataset: true,
+        query: {
+          "source-table": PRODUCTS_ID,
+        },
+      };
+
+      cy.createQuestion(questionDetails, { visitQuestion: true });
+      openQuestionActions();
+      cy.findByText("Vendor").should("not.exist");
+      cy.findByText("Edit metadata").click();
+      cy.wait(["@cardQuery", "@cardQuery"]);
+      cy.findByText("Vendor").should("be.visible");
     });
   });
 });


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/22521

### How this fix works:
Currently, the `Table` component hides columns by default if they have `visibility-type: "details-only"` in the `result_metadata` of the card. But columns _should_ be shown in the metadata tab, even if they're `"details-only"`. The missing columns were causing the bug because the DatasetEditor assumed that the all the columns in `result.data.result_metadata.columns` match up exactly with the columns shown in the `Table` component.

To use the example in the [issue](https://github.com/metabase/metabase/issues/22521), the Vendor column shouldn't be hidden at all, and it should appear in the metadata table:
![image](https://user-images.githubusercontent.com/39073188/185478331-ab231c7e-d6b2-4927-9051-8be993860d63.png)

This PR changes the `Table` component never filter "details-only" columns when the metadata tab is open.

**Context on how the columns in `Table` get filtered:**
The columns are determined as "enabled" or not in the table [here](https://github.com/metabase/metabase/blob/22521-metadata-tab-details-view-only/frontend/src/metabase/visualizations/visualizations/Table.jsx#L196), and finally filtered [here](https://github.com/metabase/metabase/blob/22521-metadata-tab-details-view-only/frontend/src/metabase/visualizations/visualizations/Table.jsx#L363). The `data` then gets passed from the `state` of the `Table` component [here](https://github.com/metabase/metabase/blob/22521-metadata-tab-details-view-only/frontend/src/metabase/visualizations/visualizations/Table.jsx#L399) into the child component for display. 

### How to verify:
Follow steps 1-5 in the issue.

Notice how the Vendor column isn't hidden in the "Metadata" tab, even though the "details-only" is set:
![image](https://user-images.githubusercontent.com/39073188/185481490-72e199c4-dece-414b-9d45-0a4d3460eed5.png)

But if you switch to the "Query" tab, it is hidden:
<img width="1284" alt="Captura de Pantalla 2022-08-18 a las 21 42 32" src="https://user-images.githubusercontent.com/39073188/185481349-a72aad18-5fd0-49c6-95a5-a73f1ed70d71.png">

Also, if you set "details-only" in on any other column in the metadata tab, the same logic applies.