### PR TITLE
Snapshot of metrics prototype 08/18

### DIFF
--- a/frontend/src/metabase-lib/lib/DimensionOptions/DimensionOptions.ts
+++ b/frontend/src/metabase-lib/lib/DimensionOptions/DimensionOptions.ts
@@ -35,6 +35,10 @@ export default class DimensionOptions {
     return !!this.all().find(dim => dimension.isSameBaseDimension(dim));
   }
 
+  find(predicate: (dimension: Dimension) => boolean): Dimension | null {
+    return this.all().find(predicate) ?? null;
+  }
+
   sections({ extraItems = [] } = {}): DimensionOptionsSection[] {
     const dimension =
       this.dimensions.find(dimension => !dimension.isExpression()) ??

--- a/frontend/src/metabase-lib/lib/metadata/Field.ts
+++ b/frontend/src/metabase-lib/lib/metadata/Field.ts
@@ -241,7 +241,7 @@ class FieldInner extends Base {
     return getIconForField(this);
   }
 
-  reference() {
+  reference(): FieldRef {
     if (Array.isArray(this.id)) {
       // if ID is an array, it's a MBQL field reference, typically "field"
       return this.id;

--- a/frontend/src/metabase-lib/lib/newmetrics/utils.ts
+++ b/frontend/src/metabase-lib/lib/newmetrics/utils.ts
@@ -1,11 +1,10 @@
 import Question from "metabase-lib/lib/Question";
 import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
+import Field from "metabase-lib/lib/metadata/Field";
+import { Aggregation } from "metabase-types/types/Query";
+import { Metric } from "metabase-types/api/newmetric";
 
-function hasDateField(question: Question): boolean {
-  if (!question.isStructured()) {
-    return false;
-  }
-
+function findDateField(question: Question) {
   const query = question.query() as StructuredQuery;
 
   // note: `query.dimension()` excludes join dimensions, which I think we want to include
@@ -15,7 +14,17 @@ function hasDateField(question: Question): boolean {
     return field.isDate();
   });
 
-  return !!dateDimension;
+  return dateDimension?.field();
+}
+
+function hasDateField(question: Question): boolean {
+  if (!question.isStructured()) {
+    return false;
+  }
+
+  const dateField = findDateField(question);
+
+  return !!dateField;
 }
 
 export function canBeUsedAsMetric(
@@ -27,4 +36,35 @@ export function canBeUsedAsMetric(
     (question.query() as StructuredQuery).aggregations().length === 1 &&
     hasDateField(question)
   );
+}
+
+export function generateFakeMetricFromQuestion(
+  question: Question,
+): Metric | null {
+  // guaranteeing the below type assertions are valid
+  if (!canBeUsedAsMetric(question)) {
+    return null;
+  }
+
+  const query = question.query() as StructuredQuery;
+  const aggregation = query.aggregations()[0].raw() as Aggregation;
+  const dateField = findDateField(question) as Field;
+  const columnName = dateField.name;
+  const ref = dateField.reference();
+
+  return {
+    id: question.id(),
+    name: `${question.id()}_metric`,
+    display_name: `${question.displayName()} Metric`,
+    description: "",
+    archived: false,
+    card_id: question.id(),
+    measure: aggregation,
+    dimensions: [[columnName, ref]],
+    granularities: [],
+    default_granularity: "",
+    creator_id: 1,
+    created_at: "",
+    updated_at: "",
+  };
 }

--- a/frontend/src/metabase-lib/lib/newmetrics/utils.ts
+++ b/frontend/src/metabase-lib/lib/newmetrics/utils.ts
@@ -18,8 +18,11 @@ function hasDateField(question: Question): boolean {
   return !!dateDimension;
 }
 
-export function canBeUsedAsMetric(question: Question): boolean {
+export function canBeUsedAsMetric(
+  question: Question | null | undefined,
+): question is Question {
   return (
+    !!question &&
     question.isStructured() &&
     (question.query() as StructuredQuery).aggregations().length === 1 &&
     hasDateField(question)

--- a/frontend/src/metabase-lib/lib/newmetrics/utils.ts
+++ b/frontend/src/metabase-lib/lib/newmetrics/utils.ts
@@ -1,0 +1,27 @@
+import Question from "metabase-lib/lib/Question";
+import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
+
+function hasDateField(question: Question): boolean {
+  if (!question.isStructured()) {
+    return false;
+  }
+
+  const query = question.query() as StructuredQuery;
+
+  // note: `query.dimension()` excludes join dimensions, which I think we want to include
+  const dimensionOptions = query.dimensionOptions();
+  const dateDimension = dimensionOptions.find(dimension => {
+    const field = dimension.field();
+    return field.isDate();
+  });
+
+  return !!dateDimension;
+}
+
+export function canBeUsedAsMetric(question: Question): boolean {
+  return (
+    question.isStructured() &&
+    (question.query() as StructuredQuery).aggregations().length === 1 &&
+    hasDateField(question)
+  );
+}

--- a/frontend/src/metabase-lib/lib/newmetrics/utils.ts
+++ b/frontend/src/metabase-lib/lib/newmetrics/utils.ts
@@ -77,7 +77,7 @@ export function generateFakeMetricFromQuestion(
 export function applyMetricToQuestion(
   question: Question,
   metric: Metric,
-): Question {
+): Question | null {
   const query = question.query() as StructuredQuery;
   const { dimensions } = metric;
   const [, dateFieldRef] = dimensions[0];
@@ -90,7 +90,7 @@ export function applyMetricToQuestion(
   );
 
   if (!dateDimension) {
-    throw new Error("Could not parse the Metric's date dimension");
+    return null;
   }
 
   const dateDimensionWithTemporalUnit = dateDimension.withTemporalUnit(

--- a/frontend/src/metabase-types/api/newmetric.ts
+++ b/frontend/src/metabase-types/api/newmetric.ts
@@ -1,4 +1,4 @@
-import { Aggregation, Field } from "metabase-types/types/Query";
+import { Aggregation, ConcreteField } from "metabase-types/types/Query";
 import { CardId } from "metabase-types/api/card";
 
 export type UnsavedMetric = Partial<Metric>;
@@ -11,8 +11,7 @@ export type Metric = {
   archived: boolean;
   card_id: CardId;
   measure: Aggregation;
-  // maybe should be ConcreteField
-  dimensions: [string, Field][];
+  dimensions: [string, ConcreteField][];
   granularities: string[];
   default_granularity: string;
   creator_id: number;

--- a/frontend/src/metabase-types/api/newmetric.ts
+++ b/frontend/src/metabase-types/api/newmetric.ts
@@ -1,0 +1,21 @@
+import { Aggregation, Field } from "metabase-types/types/Query";
+import { CardId } from "metabase-types/api/card";
+
+export type UnsavedMetric = Partial<Metric>;
+
+export type Metric = {
+  id: number;
+  name: string;
+  display_name: string;
+  description: string;
+  archived: boolean;
+  card_id: CardId;
+  measure: Aggregation;
+  // maybe should be ConcreteField
+  dimensions: [string, Field][];
+  granularities: string[];
+  default_granularity: string;
+  creator_id: number;
+  created_at: string;
+  updated_at: string;
+};

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
@@ -31,6 +31,7 @@ import { Card, SavedCard } from "metabase-types/types/Card";
 import { getQueryBuilderModeFromLocation } from "../../typed-utils";
 import { redirectToNewQuestionFlow, updateUrl } from "../navigation";
 import { cancelQuery, runQuestionQuery } from "../querying";
+import { initializeMetricMode } from "../newmetrics";
 
 import { resetQB } from "./core";
 import { loadMetadataForCard } from "./metadata";
@@ -233,6 +234,11 @@ async function handleQBInit(
     location.pathname?.startsWith("/model")
   ) {
     dispatch(setErrorPage(NOT_FOUND_ERROR));
+    return;
+  }
+
+  if (isSavedCard(card) && location.pathname?.startsWith("/metric")) {
+    dispatch(initializeMetricMode(card));
     return;
   }
 

--- a/frontend/src/metabase/query_builder/actions/index.ts
+++ b/frontend/src/metabase/query_builder/actions/index.ts
@@ -8,3 +8,4 @@ export * from "./sharing";
 export * from "./timelines";
 export * from "./ui";
 export * from "./visualization-settings";
+export * from "./newmetrics";

--- a/frontend/src/metabase/query_builder/actions/newmetrics.ts
+++ b/frontend/src/metabase/query_builder/actions/newmetrics.ts
@@ -2,12 +2,20 @@ import { t } from "ttag";
 import { push } from "react-router-redux";
 
 import { Dispatch, GetState } from "metabase-types/store";
+import { Card } from "metabase-types/types/Card";
 import { canBeUsedAsMetric } from "metabase-lib/lib/newmetrics/utils";
+import Question from "metabase-lib/lib/Question";
 import { addUndo } from "metabase/redux/undo";
+import { getMetadata } from "metabase/selectors/metadata";
 
 import { getQuestion } from "../selectors";
+import { runQuestionQuery } from "./querying";
+import { loadMetadataForCard } from "./core/metadata";
 
+// avoiding the circular dependency
+const INITIALIZE_QB = "metabase/qb/INITIALIZE_QB";
 export const CREATE_METRIC = "metabase/qb/CREATE_METRIC";
+export const ENTER_QB_METRIC_MODE = "metabase/qb/ENTER_QB_METRIC_MODE";
 
 export const createMetricFromQuestion =
   () => (dispatch: Dispatch, getState: GetState) => {
@@ -23,4 +31,34 @@ export const createMetricFromQuestion =
         }),
       );
     }
+  };
+
+export const initializeMetricMode =
+  (card: Card) => async (dispatch: Dispatch, getState: GetState) => {
+    // this action currently does nothing. is it needed?
+    dispatch({
+      type: ENTER_QB_METRIC_MODE,
+    });
+
+    await dispatch(initializeMetricCard(card));
+  };
+
+// this all comes from the core initializeQB action
+// excluded a few auxilliary things like loading alerts, showing modals,
+// so will need to revisit to ensure there aren't other things that we
+// want to do that's card/qb related
+export const initializeMetricCard =
+  (card: Card) => async (dispatch: Dispatch, getState: GetState) => {
+    await dispatch(loadMetadataForCard(card));
+    const metadata = getMetadata(getState());
+    const question = new Question(card, metadata).lockDisplay();
+    dispatch({
+      type: INITIALIZE_QB,
+      payload: {
+        card: question.card(),
+      },
+    });
+    // no need for setTimeout because there shouldn't be any paremeter widgets
+    // might not always be the case though
+    dispatch(runQuestionQuery({ shouldUpdateUrl: false }));
   };

--- a/frontend/src/metabase/query_builder/actions/newmetrics.ts
+++ b/frontend/src/metabase/query_builder/actions/newmetrics.ts
@@ -1,0 +1,21 @@
+import { t } from "ttag";
+
+import { Dispatch, GetState } from "metabase-types/store";
+import { canBeUsedAsMetric } from "metabase-lib/lib/newmetrics/utils";
+import { addUndo } from "metabase/redux/undo";
+
+import { getQuestion } from "../selectors";
+
+export const CREATE_METRIC = "metabase/qb/CREATE_METRIC";
+
+export const createMetricFromQuestion =
+  () => (dispatch: Dispatch, getState: GetState) => {
+    const question = getQuestion(getState());
+    if (question && canBeUsedAsMetric(question)) {
+      dispatch(
+        addUndo({
+          message: t`Created a metric`,
+        }),
+      );
+    }
+  };

--- a/frontend/src/metabase/query_builder/actions/newmetrics.ts
+++ b/frontend/src/metabase/query_builder/actions/newmetrics.ts
@@ -1,4 +1,5 @@
 import { t } from "ttag";
+import { push } from "react-router-redux";
 
 import { Dispatch, GetState } from "metabase-types/store";
 import { canBeUsedAsMetric } from "metabase-lib/lib/newmetrics/utils";
@@ -11,7 +12,11 @@ export const CREATE_METRIC = "metabase/qb/CREATE_METRIC";
 export const createMetricFromQuestion =
   () => (dispatch: Dispatch, getState: GetState) => {
     const question = getQuestion(getState());
-    if (question && canBeUsedAsMetric(question)) {
+    if (canBeUsedAsMetric(question)) {
+      // create a new metric
+      // navigate to /metric/:metric-id
+      // for now, navigating to same question but different path
+      dispatch(push(`/metric/${question.id()}`));
       dispatch(
         addUndo({
           message: t`Created a metric`,

--- a/frontend/src/metabase/query_builder/components/QuestionActions.tsx
+++ b/frontend/src/metabase/query_builder/components/QuestionActions.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useMemo } from "react";
 import { t } from "ttag";
 import { connect } from "react-redux";
 
@@ -21,6 +21,7 @@ import {
 } from "metabase/lib/data-modeling/utils";
 
 import Question from "metabase-lib/lib/Question";
+import { canBeUsedAsMetric } from "metabase-lib/lib/newmetrics/utils";
 
 import {
   QuestionActionsDivider,
@@ -85,6 +86,8 @@ const QuestionActions = ({
   const isDataset = question.isDataset();
   const canWrite = question.canWrite();
   const isSaved = question.isSaved();
+
+  const canBeMetric = useMemo(() => canBeUsedAsMetric(question), [question]);
 
   const canPersistDataset =
     PLUGIN_MODEL_PERSISTENCE.isModelLevelPersistenceEnabled() &&
@@ -176,6 +179,16 @@ const QuestionActions = ({
         title: t`Turn back to saved question`,
         icon: "model_framed",
         action: turnDatasetIntoQuestion,
+      });
+    }
+
+    if (canBeMetric) {
+      extraButtons.push({
+        title: t`Turn into a metric`,
+        icon: "star",
+        action: () => {
+          console.log("sike!");
+        },
       });
     }
   }

--- a/frontend/src/metabase/query_builder/components/QuestionActions.tsx
+++ b/frontend/src/metabase/query_builder/components/QuestionActions.tsx
@@ -10,7 +10,10 @@ import { PLUGIN_MODERATION, PLUGIN_MODEL_PERSISTENCE } from "metabase/plugins";
 
 import { MODAL_TYPES } from "metabase/query_builder/constants";
 
-import { softReloadCard } from "metabase/query_builder/actions";
+import {
+  softReloadCard,
+  createMetricFromQuestion,
+} from "metabase/query_builder/actions";
 import { getUserIsAdmin } from "metabase/selectors/user";
 
 import { State } from "metabase-types/store";
@@ -45,6 +48,7 @@ const mapStateToProps = (state: State, props: Props) => ({
 
 const mapDispatchToProps = {
   softReloadCard,
+  createMetricFromQuestion,
 };
 
 interface Props {
@@ -62,6 +66,7 @@ interface Props {
   onModelPersistenceChange: () => void;
   isModerator: boolean;
   softReloadCard: () => void;
+  createMetricFromQuestion: () => void;
 }
 
 const QuestionActions = ({
@@ -76,6 +81,7 @@ const QuestionActions = ({
   onModelPersistenceChange,
   isModerator,
   softReloadCard,
+  createMetricFromQuestion,
 }: Props) => {
   const bookmarkTooltip = isBookmarked ? t`Remove from bookmarks` : t`Bookmark`;
 
@@ -187,7 +193,7 @@ const QuestionActions = ({
       icon: "star",
       disabled: !canBeMetric,
       action: () => {
-        console.log("sike!");
+        createMetricFromQuestion();
       },
     });
   }

--- a/frontend/src/metabase/query_builder/components/QuestionActions.tsx
+++ b/frontend/src/metabase/query_builder/components/QuestionActions.tsx
@@ -189,7 +189,7 @@ const QuestionActions = ({
     }
 
     extraButtons.push({
-      title: t`Turn into a metric`,
+      title: t`Make a metric from this`,
       icon: "star",
       disabled: !canBeMetric,
       action: () => {

--- a/frontend/src/metabase/query_builder/components/QuestionActions.tsx
+++ b/frontend/src/metabase/query_builder/components/QuestionActions.tsx
@@ -182,15 +182,14 @@ const QuestionActions = ({
       });
     }
 
-    if (canBeMetric) {
-      extraButtons.push({
-        title: t`Turn into a metric`,
-        icon: "star",
-        action: () => {
-          console.log("sike!");
-        },
-      });
-    }
+    extraButtons.push({
+      title: t`Turn into a metric`,
+      icon: "star",
+      disabled: !canBeMetric,
+      action: () => {
+        console.log("sike!");
+      },
+    });
   }
 
   if (!question.query().readOnly()) {

--- a/frontend/src/metabase/query_builder/reducers.js
+++ b/frontend/src/metabase/query_builder/reducers.js
@@ -395,6 +395,15 @@ export const originalCard = handleActions(
   null,
 );
 
+export const metric = handleActions(
+  {
+    [INITIALIZE_QB]: {
+      next: (state, { payload }) => payload?.metric ?? null,
+    },
+  },
+  null,
+);
+
 // references to FK tables specifically used on the ObjectDetail page.
 export const tableForeignKeyReferences = handleActions(
   {

--- a/frontend/src/metabase/routes.jsx
+++ b/frontend/src/metabase/routes.jsx
@@ -259,6 +259,14 @@ export const getRoutes = store => (
           <Route path=":slug/:objectId" component={QueryBuilder} />
         </Route>
 
+        <Route path="/metric">
+          <IndexRoute component={QueryBuilder} />
+          <Route path=":slug" component={QueryBuilder} />
+          <Route path=":slug/settings" component={QueryBuilder} />
+          <Route path=":slug/metadata" component={QueryBuilder} />
+          <Route path=":slug/:objectId" component={QueryBuilder} />
+        </Route>
+
         <Route path="browse" component={BrowseApp}>
           <IndexRoute component={DatabaseBrowser} />
           <Route path=":slug" component={SchemaBrowser} />


### PR DESCRIPTION
https://user-images.githubusercontent.com/13057258/185488790-ef914424-533e-449e-84fc-e266ff27e152.mov

Snapshot, 08/18
* I've added the button that "creates" a metric from the given saved question. Button ought to work as described in the first little bit of https://www.notion.so/metabase/Create-the-new-Metric-entity-6539b2977d764948b46ee7b629969bbd#16e98fb619d24f508f4b687dfd1d295c (some code runs to determine if a question is of the right form to be used as a metric)
* Clicking the button sends the user from /question/${questionId} to /metric/${questionId}
* Once I wire this up to the BE the ID in the metric route will become the metric's ID, but right now I am using the ID found in the url to create a mock metric object
* The mock metric object I generate from the saved question just grabs whatever date field it finds first in the list of dimensions I get from calling question.query().dimensionOptions()
* I use the mock metric to transform the saved question into a new question with a breakout that uses the date field from ^

There's not much more to it at the moment. Next steps are (in no order):
* Rebase on Dan's branch and wire the FE up to BE stuff so that this uses real metric entities
* Add a save modal
* Create sidebar for configuring the metric

The above tasks should be fairly trivial (no surprises).

The hard part will be updating the query builder's redux action layer to play nice with metrics. If you test the branch from my draft PR you'll notice that things are pretty wonky and interactions in the QB need a lot of work. I'm still trying to figure out various bits of QB logic and I'm still working through my thoughts on how best to approach QB changes without making the state of that code worse while also still moving fast.

Questions:
* When the user interacts with a metric at url /metric/1, what should the app's behavior be when the user interacts with QB? E.g. changing the breakout dimension's granularity or adding a filter, etc. When should it transition into ad hoc question mode and when should it stay at a /metric/1 path?
