### PR TITLE
Use alternative image names for released container

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,10 +107,10 @@ jobs:
     - name: Determine the target Docker Hub repository
       run: |
         if [[ ${{ github.ref_name }} == v1* ]]; then
-          echo "Metabase EE: image is going to be pushed to ${{ github.repository_owner }}/metabase-enterprise"
+          echo "Metabase EE: image is going to be pushed to ${{ github.repository_owner }}/Metabase-enterprise"
           echo "DOCKERHUB_REPO=${{ github.repository_owner }}/metabase-enterprise" >> $GITHUB_ENV
         else
-          echo "Metabase OSS: image is going to be pushed to ${{ github.repository_owner }}/metabase"
+          echo "Metabase OSS: image is going to be pushed to ${{ github.repository_owner }}/Metabase"
           echo "DOCKERHUB_REPO=${{ github.repository_owner }}/metabase" >> $GITHUB_ENV
         fi
 


### PR DESCRIPTION
**Note: this doesn't affect the canonical container images pushed via the manual release process (by the release manager).**

The release workflow still failed pushing the container image to Docker Hub, e.g. [this particular run](https://github.com/metabase/metabase/runs/7866979656):

![image](https://user-images.githubusercontent.com/7288/185490137-dd30e6b9-d076-4cad-af0a-e4c72dc40d57.png)

This could be caused by one of the two things:

* Reason A: It is not possible to overwrite an existing container image (which was previously already pushed manually by the release manager)
* Reason B. The Docker Hub credentials don't work for the canonical image (i.e. `metabase/metabase` in this case)

To figure out which one of the above is the culprit, this PR slightly changes the target container image, e.g. from `metabase/metabase` to `metabase/Metabase` (note the capital `M`).

![image](https://user-images.githubusercontent.com/7288/185490927-5e63ea79-6a75-414f-a3f6-7581f52ca79c.png)

Once the PR is merged and backported, at the next maintenance release x.44.2, the success or failure of the `containerize` step can be used to deduce the culprit:

* If pushing a container image named `metabase/Metabase` is successful, that means the culprit is reason A.
* If pushing the above image still failed, it means the name doesn't matter and the issue is with the credentials (reason B).