### PR TITLE
Simple App Sidebar

### DIFF
--- a/frontend/src/metabase/collections/selectors.js
+++ b/frontend/src/metabase/collections/selectors.js
@@ -3,3 +3,5 @@ export const getIsBookmarked = (state, props) =>
     bookmark =>
       bookmark.type === "collection" && bookmark.item_id === props.collectionId,
   );
+
+export const getCollections = state => state.entities.collections;

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
@@ -20,10 +20,14 @@ import {
 import DashboardGrid from "../DashboardGrid";
 import SyncedParametersList from "metabase/parameters/components/SyncedParametersList/SyncedParametersList";
 import DashboardEmptyState from "./DashboardEmptyState/DashboardEmptyState";
+import DashboardPageNav from "./DashboardPageNav";
 import { updateParametersWidgetStickiness } from "./stickyParameters";
 import { getValuePopulatedParameters } from "metabase/parameters/utils/parameter-values";
 
 const SCROLL_THROTTLE_INTERVAL = 1000 / 24;
+
+// this is a kludge, that should be easily replaced with a check for whether the current dashboard is part of an app
+const IS_APP_FIXME_PLEASE = true;
 
 // NOTE: move DashboardControls HoC to container
 
@@ -46,6 +50,7 @@ class Dashboard extends Component {
       .isRequired,
     isEditingParameter: PropTypes.bool.isRequired,
     isNavbarOpen: PropTypes.bool.isRequired,
+    closeNavbar: PropTypes.func,
     isHeaderVisible: PropTypes.bool,
     isAdditionalInfoVisible: PropTypes.bool,
 
@@ -124,6 +129,10 @@ class Dashboard extends Component {
     main.addEventListener("resize", this.throttleParameterWidgetStickiness, {
       passive: true,
     });
+
+    if (IS_APP_FIXME_PLEASE && this.props.isNavbarOpen) {
+      this.props.closeNavbar();
+    }
   }
 
   componentDidUpdate(prevProps) {
@@ -266,7 +275,7 @@ class Dashboard extends Component {
       >
         {() => (
           <DashboardStyled>
-            {isHeaderVisible && (
+            {isHeaderVisible && !IS_APP_FIXME_PLEASE && (
               <HeaderContainer
                 isFullscreen={isFullscreen}
                 isNightMode={shouldRenderAsNightMode}
@@ -294,6 +303,7 @@ class Dashboard extends Component {
             )}
 
             <DashboardBody isEditingOrSharing={isEditing || isSharing}>
+              {IS_APP_FIXME_PLEASE && <DashboardPageNav />}
               <ParametersAndCardsContainer
                 data-testid="dashboard-parameters-and-cards"
                 ref={element => (this.parametersAndCardsContainerRef = element)}

--- a/frontend/src/metabase/dashboard/components/Dashboard/DashboardPageNav.styled.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/DashboardPageNav.styled.jsx
@@ -1,0 +1,40 @@
+import styled from "@emotion/styled";
+import { color, alpha } from "metabase/lib/colors";
+import { space } from "metabase/styled-components/theme";
+
+import Link from "metabase/core/components/Link";
+
+export const DashboardNavContainer = styled.div`
+  padding: ${space(2)};
+  width: 15rem;
+  border-right: 1px solid ${color("border")};
+  border-top: 1px solid ${color("border")};
+  color: ${color("text-dark")};
+  background-color: ${color("white")};
+`;
+
+const activeNavItem = `
+  background-color: ${alpha("brand", 0.2)};
+  color: ${color("brand")};
+`;
+
+export const DashboardNavItem = styled(Link)`
+  display: block;
+  margin-bottom: ${space(0)};
+  padding: ${space(1)} ${space(2)};
+  border-radius: ${space(0)};
+  cursor: pointer;
+  font-weight: 700;
+  :hover {
+    ${activeNavItem}
+  }
+  ${props => (props.active ? activeNavItem : "")}
+`;
+
+export const AppTitle = styled.div`
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: ${color("text-medium")};
+  margin-bottom: ${space(2)};
+`;

--- a/frontend/src/metabase/dashboard/components/Dashboard/DashboardPageNav.tsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/DashboardPageNav.tsx
@@ -1,0 +1,74 @@
+import React from "react";
+import _ from "underscore";
+import { connect } from "react-redux";
+
+import type { State } from "metabase-types/store";
+import type { Dashboard } from "metabase-types/api";
+
+import { getCollections } from "metabase/collections/selectors";
+import { getDashboard } from "metabase/dashboard/selectors";
+import { dashboard as formatDashboardUrl } from "metabase/lib/urls";
+
+import Search from "metabase/entities/search";
+
+// we may want to use this more complex component down the road, but
+// for now let's keep it simple
+// import { Tree } from "metabase/components/tree";
+
+import {
+  AppTitle,
+  DashboardNavContainer,
+  DashboardNavItem,
+} from "./DashboardPageNav.styled";
+
+const mapStateToProps = (state: State) => ({
+  currentDashboard: getDashboard(state),
+  collections: getCollections(state),
+});
+
+function DashboardPageNav({
+  list: dashboards,
+  currentDashboard,
+  collections,
+}: {
+  list: Dashboard[];
+  currentDashboard: Dashboard;
+  collections: any;
+}) {
+  const collectionId = currentDashboard?.collection_id;
+  if (!collectionId) {
+    return null;
+  }
+
+  const currentCollection = collections[collectionId];
+
+  const pages = Object.values(dashboards).filter(
+    d => d.collection_id === collectionId,
+  );
+
+  return (
+    <DashboardNavContainer>
+      <AppTitle>{currentCollection?.name ?? "Data App"}</AppTitle>
+      {pages.map((page: Dashboard) => (
+        <DashboardNavItem
+          to={formatDashboardUrl(page)}
+          key={page.id}
+          active={page.id === currentDashboard.id}
+        >
+          {page?.name ?? "Unknown"}
+        </DashboardNavItem>
+      ))}
+    </DashboardNavContainer>
+  );
+}
+
+export default _.compose(
+  connect(mapStateToProps),
+  Search.loadList({
+    query: (_: State, props: any) => ({
+      collection: props.currentDashboard.collection_id,
+      models: ["dashboard"],
+      archived: false,
+    }),
+  }),
+)(DashboardPageNav);

--- a/frontend/src/metabase/dashboard/containers/DashboardApp.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp.jsx
@@ -18,7 +18,7 @@ import { useWebNotification } from "metabase/hooks/use-web-notification";
 import { useOnUnmount } from "metabase/hooks/use-on-unmount";
 
 import { fetchDatabaseMetadata } from "metabase/redux/metadata";
-import { getIsNavbarOpen, setErrorPage } from "metabase/redux/app";
+import { getIsNavbarOpen, setErrorPage, closeNavbar } from "metabase/redux/app";
 
 import {
   getIsEditing,
@@ -97,6 +97,7 @@ const mapDispatchToProps = {
   ...dashboardActions,
   archiveDashboard: id => Dashboards.actions.setArchived({ id }, true),
   fetchDatabaseMetadata,
+  closeNavbar,
   setErrorPage,
   onChangeLocation: push,
 };


### PR DESCRIPTION
Create a Simple App Sidebar. 

(This is not mergeable without some more backend work and a frontend app entity)

![Screen Shot 2022-08-18 at 3 02 55 PM](https://user-images.githubusercontent.com/30528226/185494669-5d449e88-9e61-4a3d-b804-4d0a7a0add3c.png)

For now (this will change), it:
- uses a hacky `IS_APP_FIXME_PLEASE` constant that flags all dashboards as apps
- disables the dashboard header
- loads a list of all dashboards in the collection as the currently-viewed dashboard
- closes the main app nav (but does not disable it) when opening an app/dashboard

Trying to keep it simple for now, but in the future this will also
- allow draggable reordering and nesting
- allow pages to be added or removed
- allow external links to appear as pages