### PR TITLE
Confusing warning message even when the time zones are equivalent

### DIFF
--- a/frontend/src/metabase/visualizations/lib/timeseries.js
+++ b/frontend/src/metabase/visualizations/lib/timeseries.js
@@ -232,7 +232,12 @@ export function getTimezone(series, warn) {
   }
   // Warn if the query was run in an unexpected timezone.
   const { results_timezone, requested_timezone } = series[0].data;
-  if (requested_timezone && requested_timezone !== results_timezone) {
+
+  if (
+    requested_timezone &&
+    moment().tz(requested_timezone).format() !==
+      moment().tz(results_timezone).format()
+  ) {
     warn(unexpectedTimezoneWarning({ results_timezone, requested_timezone }));
   }
   return results_timezone || DEFAULT_TIMEZONE;


### PR DESCRIPTION
Fixes #14040 

###### Before submitting the PR, please make sure you do the following

- [x] If you're attempting to fix a translation issue, please submit your changes to our [POEditor project](https://poeditor.com/join/project/ynjQmwSsGh) instead of opening a PR.

### Tests

- [x] Run the frontend and Cypress end-to-end tests with `yarn lint && yarn test`)
- [x] If there are changes to the backend codebase, run the backend tests with `clojure -X:dev:test`
- [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
      (unless it's a tiny documentation change).

### Demo
https://www.loom.com/share/0682ef355c574d2fb5b71ea2f64a7111

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/24892)
<!-- Reviewable:end -->
