### PR TITLE
Esc key behaves like Enter key on <TokenField />

### DIFF
--- a/frontend/src/metabase/components/TokenField/TokenField.tsx
+++ b/frontend/src/metabase/components/TokenField/TokenField.tsx
@@ -9,7 +9,6 @@ import TippyPopover from "metabase/components/Popover/TippyPopover";
 import { TokenFieldAddon, TokenFieldItem } from "../TokenFieldItem";
 
 import {
-  KEYCODE_ESCAPE,
   KEYCODE_ENTER,
   KEYCODE_TAB,
   KEYCODE_UP,
@@ -303,7 +302,6 @@ export default class TokenField extends Component<
 
     // enter, tab, comma
     if (
-      keyCode === KEYCODE_ESCAPE ||
       keyCode === KEYCODE_TAB ||
       // We check event.key for comma presses because some keyboard layouts
       // (e.g. Russian) have a letter on that key and require a modifier to type


### PR DESCRIPTION
Fixes #24629 

###### Before submitting the PR, please make sure you do the following

- [x] If you're attempting to fix a translation issue, please submit your changes to our [POEditor project](https://poeditor.com/join/project/ynjQmwSsGh) instead of opening a PR.

### Tests

- [x] Run the frontend and Cypress end-to-end tests with `yarn lint && yarn test`)
- [x] If there are changes to the backend codebase, run the backend tests with `clojure -X:dev:test`
- [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
      (unless it's a tiny documentation change).

### Demo
In the video, after selecting the first filter `Esc` was pressed several times
https://www.loom.com/share/24c20812d74a4e9394eb97532265de57

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/24893)
<!-- Reviewable:end -->
