### PR TITLE
BE fix for 23505: Models should not allow variables

### DIFF
--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -365,6 +365,11 @@ saved later when it is ready."
       (when timed-out?
         (schedule-metadata-saving result-metadata-chan <>)))))
 
+(defn- check-valid-card-info [{:keys [dataset dataset_query]}]
+  (when (and dataset
+             (not (every? #(contains? #{"card" "snippet"} %) (get-in dataset_query [:native :template-tags]))))
+    (throw (ex-info (tru "A model made from a native SQL question cannot have a variable or field filter.") {:status-code 400}))))
+
 (api/defendpoint POST "/"
   "Create a new `Card`."
   [:as {{:keys [collection_id collection_position dataset_query description display name
@@ -381,6 +386,7 @@ saved later when it is ready."
    result_metadata        (s/maybe qr/ResultsMetadata)
    cache_ttl              (s/maybe su/IntGreaterThanZero)
    is_write               (s/maybe s/Bool)}
+  (check-valid-card-info body)
   ;; check that we have permissions to run the query that we're trying to save
   (check-data-permissions-for-query dataset_query)
   ;; check that we have permissions for the collection we're trying to save this card to, if applicable
@@ -622,6 +628,7 @@ saved later when it is ready."
    collection_preview     (s/maybe s/Bool)}
   (let [card-before-update (hydrate (api/write-check Card id)
                                     [:moderation_reviews :moderator_details])]
+    (check-valid-card-info (merge card-before-update card-updates))
     ;; Do various permissions checks
     (doseq [f [collection/check-allowed-to-change-collection
                check-allowed-to-modify-query

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -248,7 +248,7 @@
 (defn- pre-update [{archived? :archived, id :id, :as changes}]
   ;; TODO - don't we need to be doing the same permissions check we do in `pre-insert` if the query gets changed? Or
   ;; does that happen in the `PUT` endpoint?
-  (let [card (Card id)]
+  (let [card (db/select-one Card :id 257262)]
     (u/prog1 changes
       ;; if the Card is archived, then remove it from any Dashboards
       (when archived?

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -248,7 +248,7 @@
 (defn- pre-update [{archived? :archived, id :id, :as changes}]
   ;; TODO - don't we need to be doing the same permissions check we do in `pre-insert` if the query gets changed? Or
   ;; does that happen in the `PUT` endpoint?
-  (let [card (db/select-one Card :id 257262)]
+  (let [card (db/select-one Card :id id)]
     (u/prog1 changes
       ;; if the Card is archived, then remove it from any Dashboards
       (when archived?

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -200,6 +200,16 @@
   (when (not is-write?)
     (db/delete! action/QueryAction :card_id card-id)))
 
+(defn- assert-valid-model
+  "Check that the card is a valid model if being saved as one. Throw an exception if not."
+  [{:keys [dataset dataset_query]}]
+  (when dataset
+    (let [template-tag-types (->> (vals (get-in dataset_query [:native :template-tags]))
+                                  (map (comp keyword :type)))]
+      (when (some (complement #{:card :snippet}) template-tag-types)
+        (throw (ex-info (tru "A model made from a native SQL question cannot have a variable or field filter.")
+                        {:status-code 400}))))))
+
 ;; TODO -- consider whether we should validate the Card query when you save/update it??
 (defn- pre-insert [card]
   (let [defaults {:parameters         []
@@ -210,6 +220,7 @@
      (check-for-circular-source-query-references card)
      (check-field-filter-fields-are-from-correct-database card)
      ;; TODO: add a check to see if all id in :parameter_mappings are in :parameters
+     (assert-valid-model card)
      (params/assert-valid-parameters card)
      (params/assert-valid-parameter-mappings card)
      (collection/check-collection-namespace Card (:collection_id card)))))
@@ -237,38 +248,40 @@
 (defn- pre-update [{archived? :archived, id :id, :as changes}]
   ;; TODO - don't we need to be doing the same permissions check we do in `pre-insert` if the query gets changed? Or
   ;; does that happen in the `PUT` endpoint?
-  (u/prog1 changes
-    ;; if the Card is archived, then remove it from any Dashboards
-    (when archived?
-      (db/delete! 'DashboardCard :card_id id))
-    ;; if the template tag params for this Card have changed in any way we need to update the FieldValues for
-    ;; On-Demand DB Fields
-    (when (get-in changes [:dataset_query :native])
-      (let [old-param-field-ids (params/card->template-tag-field-ids (db/select-one [Card :dataset_query] :id id))
-            new-param-field-ids (params/card->template-tag-field-ids changes)]
-        (when (and (seq new-param-field-ids)
-                   (not= old-param-field-ids new-param-field-ids))
-          (let [newly-added-param-field-ids (set/difference new-param-field-ids old-param-field-ids)]
-            (log/info "Referenced Fields in Card params have changed. Was:" old-param-field-ids
-                      "Is Now:" new-param-field-ids
-                      "Newly Added:" newly-added-param-field-ids)
-            ;; Now update the FieldValues for the Fields referenced by this Card.
-            (field-values/update-field-values-for-on-demand-dbs! newly-added-param-field-ids)))))
-    ;; make sure this Card doesn't have circular source query references if we're updating the query
-    (when (:dataset_query changes)
-      (check-for-circular-source-query-references changes))
-    ;; Make sure any native query template tags match the DB in the query.
-    (check-field-filter-fields-are-from-correct-database changes)
-    ;; Make sure the Collection is in the default Collection namespace (e.g. as opposed to the Snippets Collection namespace)
-    (collection/check-collection-namespace Card (:collection_id changes))
-    (params/assert-valid-parameters changes)
-    (params/assert-valid-parameter-mappings changes)
-    ;; additional checks (Enterprise Edition only)
-    (@pre-update-check-sandbox-constraints changes)
-    ;; create Action and QueryAction when is_write is set true
-    (create-actions-when-is-writable! changes)
-    ;; delete Action and QueryAction when is_write is set false
-    (delete-actions-when-not-writable! changes)))
+  (let [card (Card id)]
+    (u/prog1 changes
+      ;; if the Card is archived, then remove it from any Dashboards
+      (when archived?
+        (db/delete! 'DashboardCard :card_id id))
+      ;; if the template tag params for this Card have changed in any way we need to update the FieldValues for
+      ;; On-Demand DB Fields
+      (when (get-in changes [:dataset_query :native])
+        (let [old-param-field-ids (params/card->template-tag-field-ids (select-keys card [:dataset_query]))
+              new-param-field-ids (params/card->template-tag-field-ids changes)]
+          (when (and (seq new-param-field-ids)
+                     (not= old-param-field-ids new-param-field-ids))
+            (let [newly-added-param-field-ids (set/difference new-param-field-ids old-param-field-ids)]
+              (log/info "Referenced Fields in Card params have changed. Was:" old-param-field-ids
+                        "Is Now:" new-param-field-ids
+                        "Newly Added:" newly-added-param-field-ids)
+              ;; Now update the FieldValues for the Fields referenced by this Card.
+              (field-values/update-field-values-for-on-demand-dbs! newly-added-param-field-ids)))))
+      ;; make sure this Card doesn't have circular source query references if we're updating the query
+      (when (:dataset_query changes)
+        (check-for-circular-source-query-references changes))
+      ;; Make sure any native query template tags match the DB in the query.
+      (check-field-filter-fields-are-from-correct-database changes)
+      ;; Make sure the Collection is in the default Collection namespace (e.g. as opposed to the Snippets Collection namespace)
+      (collection/check-collection-namespace Card (:collection_id changes))
+      (params/assert-valid-parameters changes)
+      (params/assert-valid-parameter-mappings changes)
+      ;; additional checks (Enterprise Edition only)
+      (@pre-update-check-sandbox-constraints changes)
+      ;; create Action and QueryAction when is_write is set true
+      (create-actions-when-is-writable! changes)
+      ;; delete Action and QueryAction when is_write is set false
+      (delete-actions-when-not-writable! changes)
+      (assert-valid-model (merge card changes)))))
 
 ;; Cards don't normally get deleted (they get archived instead) so this mostly affects tests
 (defn- pre-delete [{:keys [id]}]

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -250,8 +250,8 @@
   ;; does that happen in the `PUT` endpoint?
   (u/prog1 changes
     (let [;; Fetch old card data if necessary, and share the data between multiple checks.
-          old-card-info (when (or (true? (:dataset changes))
-                              (get-in changes [:dataset_query :native]))
+          old-card-info (when (or (:dataset changes)
+                                  (get-in changes [:dataset_query :native]))
                           (db/select-one [Card :dataset_query :dataset] :id id))]
       ;; if the Card is archived, then remove it from any Dashboards
       (when archived?

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -382,13 +382,35 @@
 
 (deftest create-card-validation-test
   (testing "POST /api/card"
-   (is (= {:errors {:visualization_settings "value must be a map."}}
-          (mt/user-http-request :crowberto :post 400 "card" {:visualization_settings "ABC"})))
+    (is (= {:errors {:visualization_settings "value must be a map."}}
+           (mt/user-http-request :crowberto :post 400 "card" {:visualization_settings "ABC"})))
 
-   (is (= {:errors {:parameters (str "value may be nil, or if non-nil, value must be an array. "
-                                     "Each parameter must be a map with :id and :type keys")}}
-          (mt/user-http-request :crowberto :post 400 "card" {:visualization_settings {:global {:title nil}}
-                                                             :parameters             "abc"})))))
+    (is (= {:errors {:parameters (str "value may be nil, or if non-nil, value must be an array. "
+                                      "Each parameter must be a map with :id and :type keys")}}
+           (mt/user-http-request :crowberto :post 400 "card" {:visualization_settings {:global {:title nil}}
+                                                              :parameters             "abc"})))
+    (with-temp-native-card-with-params [db card]
+      (testing "You cannot create a card with variables as a model"
+        (is (= "A model made from a native SQL question cannot have a variable or field filter."
+               (mt/user-http-request :rasta :post 400 "card"
+                                     (merge
+                                      (mt/with-temp-defaults Card)
+                                      {:dataset       true
+                                       :query_type    "native"
+                                       :dataset_query (:dataset_query card)})))))
+      (testing "You can create a card with a saved question CTE as a model"
+        (let [card-reference (str "#" (u/the-id card))]
+          (mt/user-http-request :rasta :post 200 "card"
+                                (merge
+                                 (mt/with-temp-defaults Card)
+                                 {:dataset_query {:database (u/the-id db)
+                                                  :type     :native
+                                                  :native   {:query         (format "SELECT * FROM {{%s}};" card-reference)
+                                                             :template-tags {card-reference {:card-id      (u/the-id card),
+                                                                                             :display-name card-reference,
+                                                                                             :id           (str (random-uuid))
+                                                                                             :name         card-reference,
+                                                                                             :type         :card}}}}})))))))
 
 (deftest create-card-disallow-setting-enable-embedding-test
   (testing "POST /api/card"
@@ -760,7 +782,7 @@
                (:emitters (mt/user-http-request :rasta :get 200 (format "card/%d" (u/the-id read-card)))))))))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
-;;; |                                                UPDATING A CARD                                                 |
+;;; |                                       UPDATING A CARD (PUT /api/card/:id)
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 
@@ -930,6 +952,13 @@
                             {:collection_position nil})
       (is (= 1
              (db/select-one-field :collection_position Card :id (u/the-id card)))))))
+
+(deftest update-card-validation-test
+  (testing "PUT /api/card"
+    (with-temp-native-card-with-params [db card]
+      (testing  "You cannot update a model to have variables"
+        (is (= "A model made from a native SQL question cannot have a variable or field filter."
+               (mt/user-http-request :rasta :put 400 (format "card/%d" (:id card)) {:dataset true})))))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -2378,30 +2407,3 @@
           (is (not (contains? (task.persist-refresh/job-info-for-individual-refresh)
                               (u/the-id parchived)))
               "Scheduled refresh of archived model"))))))
-
-(deftest template-tags-model-validation
-  (with-temp-native-card-with-params [db card]
-    (testing "You cannot create a card with variables as a model"
-      (is (= "A model made from a native SQL question cannot have a variable or field filter."
-             (mt/user-http-request :rasta :post 400 "card"
-                                   (merge
-                                    (mt/with-temp-defaults Card)
-                                    {:dataset       true
-                                     :query_type    "native"
-                                     :dataset_query (:dataset_query card)})))))
-    (testing "You can create a card with a saved question CTE as a model"
-      (let [card-reference (str "#" (u/the-id card))]
-        (mt/user-http-request :rasta :post 200 "card"
-                              (merge
-                               (mt/with-temp-defaults Card)
-                               {:dataset_query {:database (u/the-id db)
-                                                :type     :native
-                                                :native   {:query         (format "SELECT * FROM {{%s}};" card-reference)
-                                                           :template-tags {card-reference {:card-id      (u/the-id card),
-                                                                                           :display-name card-reference,
-                                                                                           :id           (str (random-uuid))
-                                                                                           :name         card-reference,
-                                                                                           :type         :card}}}}}))))
-    (testing  "You cannot update a model to have variables"
-      (is (= "A model made from a native SQL question cannot have a variable or field filter."
-             (mt/user-http-request :rasta :put 400 (format "card/%d" (:id card)) {:dataset true}))))))

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -2378,3 +2378,17 @@
           (is (not (contains? (task.persist-refresh/job-info-for-individual-refresh)
                               (u/the-id parchived)))
               "Scheduled refresh of archived model"))))))
+
+(deftest model-validation
+  (with-temp-native-card-with-params [_ card]
+    (testing "You cannot create a card with variables as a model"
+      (is (= "A model made from a native SQL question cannot have a variable or field filter."
+             (mt/user-http-request :rasta :post 400 "card"
+                                   (merge
+                                    (mt/with-temp-defaults Card)
+                                    {:dataset       true
+                                     :query_type    "native"
+                                     :dataset_query (:dataset_query card)})))))
+    (testing  "You cannot update a model to have variables"
+      (is (= "A model made from a native SQL question cannot have a variable or field filter."
+             (mt/user-http-request :rasta :put 400 (format "card/%d" (:id card)) {:dataset true}))))))


### PR DESCRIPTION
Reduces the chance of issues like https://github.com/metabase/metabase/issues/23505 happening again. 

This https://github.com/metabase/metabase/pull/24089 on the FE works to solve the issue, but validation should happen on the BE too.

This PR adds checks on the card PUT and POST endpoints that rules out saving a model with variables or filter fields.