### PR TITLE
Fix for redshift late-binding view sync error

### DIFF
--- a/docs/developers-guide/driver-changelog.md
+++ b/docs/developers-guide/driver-changelog.md
@@ -12,6 +12,11 @@ title: Driver interface changelog
   `metabase.driver.sql-jdbc.connection/with-connection-spec-for-testing-connection` instead, which properly cleans up
   after itself.
 
+### New methods
+
+- `metabase.driver.sql-jdbc.sync.describe-table-fields` has been added. Implement this method if you want to override
+  the default behavior for fetching field metadata (such as types) for a table.
+
 ## Metabase 0.43.0
 
 - The `:expressions` map in an MBQL query now uses strings as keys rather than keywords (see

--- a/modules/drivers/redshift/deps.edn
+++ b/modules/drivers/redshift/deps.edn
@@ -5,4 +5,4 @@
  {"redshift" {:url "https://s3.amazonaws.com/redshift-maven-repository/release"}}
 
  :deps
- {com.amazon.redshift/redshift-jdbc42 {:mvn/version "2.1.0.3"}}}
+ {com.amazon.redshift/redshift-jdbc42 {:mvn/version "2.1.0.9"}}}

--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -11,6 +11,7 @@
             [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
             [metabase.driver.sql-jdbc.execute.legacy-impl :as sql-jdbc.legacy]
             [metabase.driver.sql-jdbc.sync :as sql-jdbc.sync]
+            [metabase.driver.sql-jdbc.sync.describe-table :as sql-jdbc.describe-table]
             [metabase.driver.sql.query-processor :as sql.qp]
             [metabase.mbql.util :as mbql.u]
             [metabase.public-settings :as public-settings]
@@ -278,3 +279,15 @@
                                                                   metadata
                                                                   schema-inclusion-patterns
                                                                   schema-exclusion-patterns))))
+
+(defmethod sql-jdbc.describe-table/describe-table-fields :redshift
+  [driver conn {schema :schema, table-name :name :as table} db-name-or-nil]
+  (let [parent-method (get-method sql-jdbc.describe-table/describe-table-fields :sql-jdbc)]
+    (try (parent-method driver conn table db-name-or-nil)
+         (catch Exception e
+           (log/error e (trs "Error fetching field metadata for table {0}" table-name))
+           ;; Use the fallback method (a SELECT * query) if the JDBC driver throws an exception (#21215)
+           (into
+            #{}
+            (sql-jdbc.describe-table/describe-table-fields-xf driver table)
+            (sql-jdbc.describe-table/fallback-fields-metadata-from-select-query driver conn schema table-name))))))

--- a/src/metabase/driver/sql_jdbc/sync/describe_table.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_table.clj
@@ -64,7 +64,7 @@
         honeysql (sql.qp/apply-top-level-clause driver :limit honeysql {:limit 0})]
     (sql.qp/format-honeysql driver honeysql)))
 
-(defn- fallback-fields-metadata-from-select-query
+(defn fallback-fields-metadata-from-select-query
   "In some rare cases `:column_name` is blank (eg. SQLite's views with group by) fallback to sniffing the type from a
   SELECT * query."
   [driver ^Connection conn table-schema table-name]
@@ -109,9 +109,8 @@
              (when-not (str/blank? remarks)
                {:field-comment remarks})))))))
 
-(defn- fields-metadata
-  "Returns reducible metadata for the Fields in a `table`."
-  [driver ^Connection conn {schema :schema, table-name :name} & [^String db-name-or-nil]]
+(defn ^:private fields-metadata
+  [driver ^Connection conn {schema :schema, table-name :name} ^String db-name-or-nil]
   {:pre [(instance? Connection conn) (string? table-name)]}
   (reify clojure.lang.IReduceInit
     (reduce [_ rf init]
@@ -143,26 +142,37 @@
          init
          [jdbc-metadata fallback-metadata])))))
 
-(defn describe-table-fields
+(defn describe-table-fields-xf
+  "Returns a transducer for computing metatdata about the fields in `table`."
+  [driver table]
+  (map-indexed (fn [i {:keys [database-type], column-name :name, :as col}]
+                 (let [semantic-type (calculated-semantic-type driver column-name database-type)]
+                   (merge
+                    (u/select-non-nil-keys col [:name :database-type :field-comment :database-required])
+                    {:base-type         (database-type->base-type-or-warn driver database-type)
+                     :database-position i}
+                    (when semantic-type
+                      {:semantic-type semantic-type})
+                    (when (and
+                           (isa? semantic-type :type/SerializedJSON)
+                           (driver/database-supports?
+                            driver
+                            :nested-field-columns
+                            (table/database table)))
+                      {:visibility-type :details-only}))))))
+
+(defmulti describe-table-fields
   "Returns a set of column metadata for `table` using JDBC Connection `conn`."
-  [driver conn table & [db-name-or-nil]]
+  {:added    "0.45.0"
+   :arglists '([driver ^Connection conn table ^String db-name-or-nil])}
+  driver/dispatch-on-initialized-driver
+  :hierarchy #'driver/hierarchy)
+
+(defmethod describe-table-fields :sql-jdbc
+  [driver conn table db-name-or-nil]
   (into
    #{}
-   (map-indexed (fn [i {:keys [database-type], column-name :name, :as col}]
-                  (let [semantic-type (calculated-semantic-type driver column-name database-type)]
-                    (merge
-                      (u/select-non-nil-keys col [:name :database-type :field-comment :database-required])
-                      {:base-type         (database-type->base-type-or-warn driver database-type)
-                       :database-position i}
-                      (when semantic-type
-                        {:semantic-type semantic-type})
-                      (when (and
-                              (isa? semantic-type :type/SerializedJSON)
-                              (driver/database-supports?
-                                driver
-                                :nested-field-columns
-                                (table/database table)))
-                        {:visibility-type :details-only})))))
+   (describe-table-fields-xf driver table)
    (fields-metadata driver conn table db-name-or-nil)))
 
 (defn add-table-pks
@@ -180,7 +190,7 @@
 (defn- describe-table* [driver ^Connection conn table]
   {:pre [(instance? Connection conn)]}
   (->> (assoc (select-keys table [:name :schema])
-              :fields (describe-table-fields driver conn table))
+              :fields (describe-table-fields driver conn table nil))
        ;; find PKs and mark them
        (add-table-pks (.getMetaData conn))))
 
@@ -367,7 +377,7 @@
   (with-open [conn (jdbc/get-connection spec)]
     (let [table-identifier-info [(:schema table) (:name table)]
 
-          table-fields          (describe-table-fields driver conn table)
+          table-fields          (describe-table-fields driver conn table nil)
           json-fields           (filter #(= (:semantic-type %) :type/SerializedJSON) table-fields)]
       (if (nil? (seq json-fields))
         #{}


### PR DESCRIPTION
Fixes #21215

Some specific field types in late-binding views cause the Redshift JDBC driver to throw an error on the `.getColumns` call when fetching field metadata (https://github.com/metabase/metabase/blob/nm-redshift-latebinding/src/metabase/driver/sql_jdbc/sync/describe_table.clj#L89)

Bumping the driver version seems to fix some of these cases, but not all. Specifically, a case statement that produces a mix of numeric and null values still results in an error.

To fix this, we can use the fallback method for determining field metadata in these cases, which uses a `SELECT *` query rather than JDBC methods. I've done this specifically for Redshift by converting `describe-table-fields` to a driver method with a custom Redshift implementation that has a try/catch around the default method. I've also added a test for this case with an example derived from the one in #21215.