### PR TITLE
fix backport shows generic error when conflicts

### DIFF
--- a/.github/workflows/auto-backport.yml
+++ b/.github/workflows/auto-backport.yml
@@ -67,12 +67,14 @@ jobs:
           COMMIT: ${{ steps.find_commit.outputs.commit }}
 
       - name: Auto approve backport PR
+        if: ${{ steps.create_backport_pull_request.outputs.has-conflicts == 'false' }}
         uses: juliangruber/approve-pull-request-action@v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           number: ${{ steps.create_backport_pull_request.outputs.backport_pr_number }}
 
       - name: Enable Pull Request Automerge
+        if: ${{ steps.create_backport_pull_request.outputs.has-conflicts == 'false' }}
         uses: peter-evans/enable-pull-request-automerge@v2
         with:
           token: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
[Slack conversation](https://metaboat.slack.com/archives/C5XHN8GLW/p1661188387376579)

## Changes

After adding automerging steps the backport workflow started posting a generic error comment when a backport failed due to conflicts. This PR fixes the issue.