### PR TITLE
Pivot table conditional formatting

### DIFF
--- a/frontend/src/metabase/lib/data_grid.js
+++ b/frontend/src/metabase/lib/data_grid.js
@@ -1,6 +1,7 @@
 import _ from "underscore";
 import { getIn } from "icepick";
 import { t } from "ttag";
+import { makeCellBackgroundGetter } from "metabase/visualizations/lib/table_format";
 
 import { formatValue, formatColumn } from "metabase/lib/formatting";
 
@@ -38,12 +39,7 @@ export function multiLevelPivot(data, settings) {
       .filter(index => index !== -1),
   );
 
-  const { pivotData, columns } = splitPivotData(
-    data,
-    rowColumnIndexes,
-    columnColumnIndexes,
-  );
-
+  const { pivotData, columns } = splitPivotData(data);
   const columnSettings = columns.map(column => settings.column(column));
   const allCollapsedSubtotals = settings[COLLAPSED_ROWS_SETTING].value;
   const collapsedSubtotals = filterCollapsedSubtotals(
@@ -83,8 +79,13 @@ export function multiLevelPivot(data, settings) {
       columnColumnIndexes.concat(rowColumnIndexes).map(index => row[index]),
     );
     const values = valueColumnIndexes.map(index => row[index]);
+    const valueColumns = valueColumnIndexes.map(
+      index => columnSettings[index]?.column,
+    );
+
     valuesByKey[valueKey] = {
       values,
+      valueColumns,
       data: row.map((value, index) => ({ value, col: columns[index] })),
       dimensions: row
         .map((value, index) => ({
@@ -180,6 +181,12 @@ export function multiLevelPivot(data, settings) {
   const leftHeaderItems = treeToArray(formattedRowTree.flat());
   const topHeaderItems = treeToArray(formattedColumnTree.flat());
 
+  const colorGetter = makeCellBackgroundGetter(
+    pivotData[primaryRowsKey],
+    columns,
+    settings,
+  );
+
   const getRowSection = createRowSectionGetter({
     valuesByKey,
     subtotalValues,
@@ -188,6 +195,7 @@ export function multiLevelPivot(data, settings) {
     rowColumnIndexes,
     columnIndex,
     rowIndex,
+    colorGetter,
   });
 
   return {
@@ -206,7 +214,7 @@ export function multiLevelPivot(data, settings) {
 // This pulls apart the different aggregations that were packed into one result set.
 // There's a column indicating which breakouts were used to compute that row.
 // We use that column to split apart the data and convert the field refs to indexes.
-function splitPivotData(data, rowIndexes, columnIndexes) {
+function splitPivotData(data) {
   const groupIndex = data.cols.findIndex(isPivotGroupColumn);
   const columns = data.cols.filter(col => !isPivotGroupColumn(col));
   const breakouts = columns.filter(col => col.source === "breakout");
@@ -260,6 +268,7 @@ function createRowSectionGetter({
   rowColumnIndexes,
   columnIndex,
   rowIndex,
+  colorGetter,
 }) {
   const formatValues = values =>
     values === undefined
@@ -292,10 +301,20 @@ function createRowSectionGetter({
       const otherAttrs = rowValues.length === 0 ? { isGrandTotal: true } : {};
       return getSubtotals(indexes, indexValues, otherAttrs);
     }
-    const { values, data, dimensions } =
+    const { values, data, dimensions, valueColumns } =
       valuesByKey[JSON.stringify(indexValues)] || {};
-    return formatValues(values).map(o =>
-      data === undefined ? o : { ...o, clicked: { data, dimensions } },
+    return formatValues(values).map((o, index) =>
+      data === undefined
+        ? o
+        : {
+            ...o,
+            clicked: { data, dimensions },
+            backgroundColor: colorGetter(
+              o.value,
+              o.rowIndex,
+              valueColumns[index].name,
+            ),
+          },
     );
   };
   return _.memoize(getter, (i1, i2) => [i1, i2].join());

--- a/frontend/src/metabase/lib/data_grid.js
+++ b/frontend/src/metabase/lib/data_grid.js
@@ -310,7 +310,7 @@ function createRowSectionGetter({
             ...o,
             clicked: { data, dimensions },
             backgroundColor: colorGetter(
-              o.value,
+              values[index],
               o.rowIndex,
               valueColumns[index].name,
             ),

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx
@@ -94,11 +94,12 @@ export default class ChartSettingsTableFormatting extends React.Component {
     editingRuleIsNew: null,
   };
   render() {
-    const { value, onChange, cols } = this.props;
+    const { value, onChange, cols, canHighlightRow } = this.props;
     const { editingRule, editingRuleIsNew } = this.state;
     if (editingRule !== null && value[editingRule]) {
       return (
         <RuleEditor
+          canHighlightRow={canHighlightRow}
           rule={value[editingRule]}
           cols={cols}
           isNew={editingRuleIsNew}
@@ -297,7 +298,15 @@ const RuleDescription = ({ rule }) => {
   );
 };
 
-const RuleEditor = ({ rule, cols, isNew, onChange, onDone, onRemove }) => {
+const RuleEditor = ({
+  rule,
+  cols,
+  isNew,
+  onChange,
+  onDone,
+  onRemove,
+  canHighlightRow = true,
+}) => {
   const selectedColumns = rule.columns.map(name => _.findWhere(cols, { name }));
   const isStringRule =
     selectedColumns.length > 0 && _.all(selectedColumns, isString);
@@ -381,11 +390,16 @@ const RuleEditor = ({ rule, cols, isNew, onChange, onDone, onRemove }) => {
             colors={COLORS}
             onChange={color => onChange({ ...rule, color })}
           />
-          <h3 className="mt3 mb1">{t`Highlight the whole row`}</h3>
-          <Toggle
-            value={rule.highlight_row}
-            onChange={highlight_row => onChange({ ...rule, highlight_row })}
-          />
+          {canHighlightRow && (
+            <>
+              <h3 className="mt3 mb1">{t`Highlight the whole row`}</h3>
+
+              <Toggle
+                value={rule.highlight_row}
+                onChange={highlight_row => onChange({ ...rule, highlight_row })}
+              />
+            </>
+          )}
         </div>
       ) : rule.type === "range" ? (
         <div>

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -30,6 +30,7 @@ import { PLUGIN_SELECTORS } from "metabase/plugins";
 import {
   PivotTableCell,
   PivotTableTopLeftCellsContainer,
+  HeaderCellsCollection,
   RowToggleIconRoot,
 } from "./PivotTable.styled";
 
@@ -316,12 +317,15 @@ class PivotTable extends Component {
     const leftHeaderCellRenderer = ({ index, key, style }) => {
       const { value, isSubtotal, hasSubtotal, depth, path, clicked } =
         leftHeaderItems[index];
+
       return (
         <Cell
+          key={key}
           style={{
             ...style,
             ...(depth === 0 ? { paddingLeft: LEFT_HEADER_LEFT_SPACING } : {}),
           }}
+          isNightMode={isNightMode}
           value={value}
           isEmphasized={isSubtotal}
           isBold={isSubtotal}
@@ -361,13 +365,19 @@ class PivotTable extends Component {
     const topHeaderHeight = topHeaderRows * CELL_HEIGHT;
 
     const topHeaderCellRenderer = ({ index, key, style }) => {
-      const { value, hasChildren, clicked } = topHeaderItems[index];
+      const { value, hasChildren, clicked, isSubtotal, maxDepthBelow } =
+        topHeaderItems[index];
       return (
         <Cell
           key={key}
-          style={style}
+          style={{
+            ...style,
+          }}
           value={value}
+          isNightMode={isNightMode}
+          isBorderedHeader={maxDepthBelow === 0}
           isEmphasized={hasChildren}
+          isBold={isSubtotal}
           onClick={this.getCellClickHander(clicked)}
         />
       );
@@ -394,6 +404,7 @@ class PivotTable extends Component {
         {getRowSection(columnIndex, rowIndex).map(
           ({ value, isSubtotal, clicked, backgroundColor }, index) => (
             <Cell
+              isNightMode={isNightMode}
               key={index}
               value={value}
               isEmphasized={isSubtotal}
@@ -415,19 +426,27 @@ class PivotTable extends Component {
               <div className="flex" style={{ height: topHeaderHeight }}>
                 {/* top left corner - displays left header columns */}
                 <PivotTableTopLeftCellsContainer
+                  isNightMode={isNightMode}
                   style={{
                     width: leftHeaderWidth,
                   }}
                 >
                   {rowIndexes.map((rowIndex, index) => (
                     <Cell
-                      isEmphasized
                       key={rowIndex}
+                      isEmphasized
+                      isBold
+                      isBorderedHeader
+                      hasTopBorder={topHeaderRows > 1}
+                      isNightMode={isNightMode}
                       value={this.getColumnTitle(rowIndex)}
                       style={{
                         width: LEFT_HEADER_CELL_WIDTH,
                         ...(index === 0
                           ? { paddingLeft: LEFT_HEADER_LEFT_SPACING }
+                          : {}),
+                        ...(index === rowIndexes.length - 1
+                          ? { borderRight: "none" }
                           : {}),
                       }}
                       icon={
@@ -447,9 +466,10 @@ class PivotTable extends Component {
                   ))}
                 </PivotTableTopLeftCellsContainer>
                 {/* top header */}
-                <Collection
+                <HeaderCellsCollection
                   ref={e => (this.topHeaderRef = e)}
                   className="scroll-hide-all"
+                  isNightMode={isNightMode}
                   width={width - leftHeaderWidth}
                   height={topHeaderHeight}
                   cellCount={topHeaderItems.length}
@@ -606,18 +626,24 @@ function RowToggleIcon({
 
 function Cell({
   value,
-  isBold,
-  isEmphasized,
-  onClick,
   style,
-  isBody = false,
   icon,
   backgroundColor,
+  isBody = false,
+  isBold,
+  isEmphasized,
+  isNightMode,
+  isBorderedHeader,
+  hasTopBorder,
+  onClick,
 }) {
   return (
     <PivotTableCell
+      isNightMode={isNightMode}
       isBold={isBold}
       isEmphasized={isEmphasized}
+      isBorderedHeader={isBorderedHeader}
+      hasTopBorder={hasTopBorder}
       style={{
         ...style,
         ...(backgroundColor

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -202,6 +202,7 @@ class PivotTable extends Component {
       widget: ChartSettingsTableFormatting,
       default: [],
       getProps: series => ({
+        canHighlightRow: false,
         cols: series[0].data.cols.filter(isFormattablePivotColumn),
       }),
       getHidden: ([{ data }]) =>

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -6,7 +6,6 @@ import _ from "underscore";
 import { getIn, updateIn } from "icepick";
 import { Grid, Collection, ScrollSync, AutoSizer } from "react-virtualized";
 
-import { darken, lighten } from "metabase/lib/colors";
 import { getScrollBarSize } from "metabase/lib/dom";
 import ChartSettingsTableFormatting from "metabase/visualizations/components/settings/ChartSettingsTableFormatting";
 
@@ -28,27 +27,12 @@ import { findDOMNode } from "react-dom";
 import { connect } from "react-redux";
 import { PLUGIN_SELECTORS } from "metabase/plugins";
 import {
+  PivotTableRoot,
   PivotTableCell,
   PivotTableTopLeftCellsContainer,
-  HeaderCellsCollection,
   RowToggleIconRoot,
+  CELL_HEIGHT,
 } from "./PivotTable.styled";
-
-const getBgLightColor = (hasCustomColors, isNightMode) => {
-  if (isNightMode) {
-    return lighten("bg-black", 0.3);
-  }
-
-  return hasCustomColors ? darken("white", 0.01) : lighten("brand", 0.65);
-};
-
-const getBgDarkColor = (hasCustomColors, isNightMode) => {
-  if (isNightMode) {
-    return lighten("bg-black", 0.1);
-  }
-
-  return hasCustomColors ? darken("white", 0.035) : lighten("brand", 0.6);
-};
 
 const partitions = [
   {
@@ -76,7 +60,6 @@ const partitions = [
 
 // cell width and height for normal body cells
 const CELL_WIDTH = 100;
-const CELL_HEIGHT = 30;
 // the left header has a wider cell width and some additional spacing on the left to align with the title
 const LEFT_HEADER_LEFT_SPACING = 24;
 const LEFT_HEADER_CELL_WIDTH = 145;
@@ -273,6 +256,7 @@ class PivotTable extends Component {
       hasCustomColors,
       onUpdateVisualizationSettings,
       isNightMode,
+      isDashboard,
     } = this.props;
     if (data == null || !data.cols.some(isPivotGroupColumn)) {
       return null;
@@ -420,7 +404,7 @@ class PivotTable extends Component {
     );
 
     return (
-      <div className="no-outline text-small full-height">
+      <PivotTableRoot isDashboard={isDashboard} isNightMode={isNightMode}>
         <ScrollSync>
           {({ onScroll, scrollLeft, scrollTop }) => (
             <div className="full-height flex flex-column">
@@ -438,6 +422,7 @@ class PivotTable extends Component {
                       isEmphasized
                       isBold
                       isBorderedHeader
+                      isTransparent
                       hasTopBorder={topHeaderRows > 1}
                       isNightMode={isNightMode}
                       value={this.getColumnTitle(rowIndex)}
@@ -467,7 +452,7 @@ class PivotTable extends Component {
                   ))}
                 </PivotTableTopLeftCellsContainer>
                 {/* top header */}
-                <HeaderCellsCollection
+                <Collection
                   ref={e => (this.topHeaderRef = e)}
                   className="scroll-hide-all"
                   isNightMode={isNightMode}
@@ -528,7 +513,7 @@ class PivotTable extends Component {
             </div>
           )}
         </ScrollSync>
-      </div>
+      </PivotTableRoot>
     );
   }
 
@@ -606,13 +591,6 @@ function RowToggleIcon({
 
   return (
     <RowToggleIconRoot
-      style={{
-        padding: "4px",
-        borderRadius: "4px",
-        backgroundColor: isCollapsed
-          ? getBgLightColor(hasCustomColors, isNightMode)
-          : getBgDarkColor(hasCustomColors, isNightMode),
-      }}
       onClick={e => {
         e.stopPropagation();
         updateSettings({
@@ -635,6 +613,7 @@ function Cell({
   isEmphasized,
   isNightMode,
   isBorderedHeader,
+  isTransparent,
   hasTopBorder,
   onClick,
 }) {
@@ -645,6 +624,7 @@ function Cell({
       isEmphasized={isEmphasized}
       isBorderedHeader={isBorderedHeader}
       hasTopBorder={hasTopBorder}
+      isTransparent={isTransparent}
       style={{
         ...style,
         ...(backgroundColor

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.styled.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.styled.tsx
@@ -1,20 +1,22 @@
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
-import { color, alpha } from "metabase/lib/colors";
-import { Collection } from "react-virtualized";
+import { color, alpha, darken } from "metabase/lib/colors";
 
-const EMPHASIZED_BG_COLOR = "#F8FAFB";
-
-const CELL_HEIGHT = 30;
+export const CELL_HEIGHT = 30;
 
 export const RowToggleIconRoot = styled.div`
   display: flex;
   align-items: center;
   cursor: pointer;
-  color: ${color("text-light")};
+  color: ${color("white")};
+  padding: 4px;
+  border-radius: 4px;
+  background-color: ${color("text-light")};
+  transition: all 200ms;
+  outline: none;
 
   &:hover {
-    color: ${color("brand")};
+    background-color: ${darken("text-light", 0.2)};
   }
 `;
 
@@ -24,17 +26,23 @@ interface PivotTableCellProps {
   isNightMode?: boolean;
   isBorderedHeader?: boolean;
   hasTopBorder?: boolean;
+  isTransparent?: boolean;
 }
 
 const getCellBackgroundColor = ({
   isEmphasized,
   isNightMode,
+  isTransparent,
 }: Partial<PivotTableCellProps>) => {
+  if (isTransparent) {
+    return "transparent";
+  }
+
   if (!isEmphasized) {
     return isNightMode ? alpha("bg-black", 0.1) : color("white");
   }
 
-  return isNightMode ? color("bg-black") : EMPHASIZED_BG_COLOR;
+  return isNightMode ? color("bg-black") : alpha("border", 0.25);
 };
 
 const getColor = ({ isNightMode }: PivotTableCellProps) => {
@@ -54,10 +62,10 @@ export const PivotTableCell = styled.div<PivotTableCellProps>`
   font-weight: ${props => (props.isBold ? "bold" : "normal")};
   cursor: ${props => (props.onClick ? "pointer" : "default")};
   color: ${getColor};
-  border-right: 1px solid ${getBorderColor};
+  box-shadow: -1px 0 0 0 ${getBorderColor} inset;
   border-bottom: 1px solid
     ${props =>
-      props.isBorderedHeader ? color("bg-black") : getBorderColor(props)};
+      props.isBorderedHeader ? color("bg-dark") : getBorderColor(props)};
   background-color: ${getCellBackgroundColor};
   ${props =>
     props.hasTopBorder &&
@@ -68,7 +76,7 @@ export const PivotTableCell = styled.div<PivotTableCellProps>`
     `}
 
   &:hover {
-    background-color: ${alpha("brand", 0.1)};
+    background-color: ${color("border")};
   }
 `;
 
@@ -77,26 +85,29 @@ interface PivotTableTopLeftCellsContainerProps {
 }
 
 export const PivotTableTopLeftCellsContainer = styled.div<PivotTableTopLeftCellsContainerProps>`
+  display: flex;
+  align-items: flex-end;
+  box-shadow: -1px 0 0 0 ${getBorderColor} inset;
   background-color: ${props =>
     getCellBackgroundColor({
       isEmphasized: true,
       isNightMode: props.isNightMode,
     })};
-  display: flex;
-  align-items: flex-end;
-  border-right: 1px solid ${getBorderColor};
 `;
 
-interface HeaderCellsCollectionProps {
+interface PivotTableRootProps {
+  isDashboard?: boolean;
   isNightMode?: boolean;
 }
 
-export const HeaderCellsCollection = styled(
-  Collection,
-)<HeaderCellsCollectionProps>`
-  background-color: ${props =>
-    getCellBackgroundColor({
-      isEmphasized: true,
-      isNightMode: props.isNightMode,
-    })};
+export const PivotTableRoot = styled.div<PivotTableRootProps>`
+  height: 100%;
+  font-size: 0.875em;
+
+  ${props =>
+    props.isDashboard
+      ? css`
+          border-top: 1px solid ${getBorderColor(props)};
+        `
+      : null}
 `;

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.styled.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.styled.tsx
@@ -1,5 +1,7 @@
+import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import { color, alpha } from "metabase/lib/colors";
+import { Collection } from "react-virtualized";
 
 const EMPHASIZED_BG_COLOR = "#F8FAFB";
 
@@ -19,7 +21,29 @@ export const RowToggleIconRoot = styled.div`
 interface PivotTableCellProps {
   isBold?: boolean;
   isEmphasized?: boolean;
+  isNightMode?: boolean;
+  isBorderedHeader?: boolean;
+  hasTopBorder?: boolean;
 }
+
+const getCellBackgroundColor = ({
+  isEmphasized,
+  isNightMode,
+}: Partial<PivotTableCellProps>) => {
+  if (!isEmphasized) {
+    return isNightMode ? alpha("bg-black", 0.1) : color("white");
+  }
+
+  return isNightMode ? color("bg-black") : EMPHASIZED_BG_COLOR;
+};
+
+const getColor = ({ isNightMode }: PivotTableCellProps) => {
+  return isNightMode ? color("white") : color("text-dark");
+};
+
+const getBorderColor = ({ isNightMode }: PivotTableCellProps) => {
+  return isNightMode ? alpha("bg-black", 0.8) : color("border");
+};
 
 export const PivotTableCell = styled.div<PivotTableCellProps>`
   flex: 1 0 auto;
@@ -29,20 +53,50 @@ export const PivotTableCell = styled.div<PivotTableCellProps>`
   min-height: 0;
   font-weight: ${props => (props.isBold ? "bold" : "normal")};
   cursor: ${props => (props.onClick ? "pointer" : "default")};
-  color: ${color("text-dark")};
-  box-shadow: 1px 0 0 0 ${color("border")}, 0 1px 0 0 ${color("border")},
-    1px 1px 0 0 ${color("border")}, 1px 0 0 0 ${color("border")} inset,
-    0 1px 0 0 ${color("border")} inset;
-  background-color: ${props =>
-    props.isEmphasized ? EMPHASIZED_BG_COLOR : "white"};
+  color: ${getColor};
+  border-right: 1px solid ${getBorderColor};
+  border-bottom: 1px solid
+    ${props =>
+      props.isBorderedHeader ? color("bg-black") : getBorderColor(props)};
+  background-color: ${getCellBackgroundColor};
+  ${props =>
+    props.hasTopBorder &&
+    css`
+      // compensate the top border
+      line-height: ${CELL_HEIGHT - 1}px;
+      border-top: 1px solid ${getBorderColor(props)};
+    `}
 
   &:hover {
     background-color: ${alpha("brand", 0.1)};
   }
 `;
 
-export const PivotTableTopLeftCellsContainer = styled.div`
-  background-color: ${EMPHASIZED_BG_COLOR};
+interface PivotTableTopLeftCellsContainerProps {
+  isNightMode?: boolean;
+}
+
+export const PivotTableTopLeftCellsContainer = styled.div<PivotTableTopLeftCellsContainerProps>`
+  background-color: ${props =>
+    getCellBackgroundColor({
+      isEmphasized: true,
+      isNightMode: props.isNightMode,
+    })};
   display: flex;
   align-items: flex-end;
+  border-right: 1px solid ${getBorderColor};
+`;
+
+interface HeaderCellsCollectionProps {
+  isNightMode?: boolean;
+}
+
+export const HeaderCellsCollection = styled(
+  Collection,
+)<HeaderCellsCollectionProps>`
+  background-color: ${props =>
+    getCellBackgroundColor({
+      isEmphasized: true,
+      isNightMode: props.isNightMode,
+    })};
 `;

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.styled.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.styled.tsx
@@ -1,5 +1,9 @@
 import styled from "@emotion/styled";
-import { color } from "metabase/lib/colors";
+import { color, alpha } from "metabase/lib/colors";
+
+const EMPHASIZED_BG_COLOR = "#F8FAFB";
+
+const CELL_HEIGHT = 30;
 
 export const RowToggleIconRoot = styled.div`
   display: flex;
@@ -10,4 +14,35 @@ export const RowToggleIconRoot = styled.div`
   &:hover {
     color: ${color("brand")};
   }
+`;
+
+interface PivotTableCellProps {
+  isBold?: boolean;
+  isEmphasized?: boolean;
+}
+
+export const PivotTableCell = styled.div<PivotTableCellProps>`
+  flex: 1 0 auto;
+  flex-basis: 0;
+  line-height: ${CELL_HEIGHT}px;
+  min-width: 0;
+  min-height: 0;
+  font-weight: ${props => (props.isBold ? "bold" : "normal")};
+  cursor: ${props => (props.onClick ? "pointer" : "default")};
+  color: ${color("text-dark")};
+  box-shadow: 1px 0 0 0 ${color("border")}, 0 1px 0 0 ${color("border")},
+    1px 1px 0 0 ${color("border")}, 1px 0 0 0 ${color("border")} inset,
+    0 1px 0 0 ${color("border")} inset;
+  background-color: ${props =>
+    props.isEmphasized ? EMPHASIZED_BG_COLOR : "white"};
+
+  &:hover {
+    background-color: ${alpha("brand", 0.1)};
+  }
+`;
+
+export const PivotTableTopLeftCellsContainer = styled.div`
+  background-color: ${EMPHASIZED_BG_COLOR};
+  display: flex;
+  align-items: flex-end;
 `;

--- a/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
@@ -294,12 +294,12 @@ describe("scenarios > visualizations > pivot tables", () => {
 
     cy.log("Collapse the options panel");
     cy.icon("chevronup").click();
-    cy.findByText(/Formatting/).should("not.exist");
+    cy.findByText("Formatting").should("not.exist");
     cy.findByText(/See options/).should("not.exist");
 
     cy.log("Expand it again");
     cy.icon("chevrondown").first().click();
-    cy.findByText(/Formatting/);
+    cy.findByText("Formatting");
     cy.findByText(/See options/);
   });
 
@@ -340,7 +340,7 @@ describe("scenarios > visualizations > pivot tables", () => {
       .parent()
       .findAllByText(/Count/)
       .click();
-    cy.findByText(/Formatting/);
+    cy.findByText("Formatting");
     cy.findByText(/See options/).click();
 
     cy.log("New panel for the column options");
@@ -370,7 +370,7 @@ describe("scenarios > visualizations > pivot tables", () => {
       .findAllByText(/Count/)
       .click();
 
-    cy.findByText(/Formatting/);
+    cy.findByText("Formatting");
     cy.findByText(/Sort order/).should("not.exist");
   });
 


### PR DESCRIPTION
[Mockups](https://www.figma.com/file/leZMwxcyiFCT6UGaSby4Ju/Bring-select-chart-types-closer-to-feature-parity?node-id=101%3A19643)
Epic: https://github.com/metabase/metabase/issues/24877
Closes https://github.com/metabase/metabase/issues/15693

## Changes

- Add conditional formatting to pivot tables
  - "Highlight the whole row" does not apply to pivot tables since it makes less sense and it does not work for regular pivoted tables
- Update the look of pivot tables

## How to verify

- New -> Question -> Orders
- Summarize by: Created at, Total, User -> Source
- Add metrics: Count, Average of subtotal
- Select the pivot table visualization type
- Apply conditional formatting, ensure it works as defined
- Try other configurations of pivot tables to check the styling
- Add the pivot table on a dashboard, enter full-screen mode, enable night mode

## Screenshots

#### Conditional formatting

<img width="1029" alt="Screen Shot 2022-08-25 at 3 40 13 PM" src="https://user-images.githubusercontent.com/14301985/186654940-d01eebbf-81a0-4b13-9a18-b76d85609993.png">

<img width="911" alt="Screen Shot 2022-08-25 at 2 51 35 PM" src="https://user-images.githubusercontent.com/14301985/186645993-59475001-ed87-424a-8735-827904550588.png">

#### Dark mode
<img width="802" alt="Screen Shot 2022-08-25 at 2 25 33 PM" src="https://user-images.githubusercontent.com/14301985/186646124-26df1ca0-7e98-42a4-a7e7-09cdd49b40cb.png">

