### PR TITLE
Fix radio hover color

### DIFF
--- a/frontend/src/metabase/core/components/Radio/Radio.styled.tsx
+++ b/frontend/src/metabase/core/components/Radio/Radio.styled.tsx
@@ -66,7 +66,7 @@ export const RadioContainer = styled.div<RadioContainerProps>`
   &:hover {
     color: ${props =>
       !props.checked && !props.showButtons
-        ? getContrastSchemeColor(props.colorScheme)
+        ? getHoverColor(props.variant, props.colorScheme)
         : ""};
   }
 
@@ -145,4 +145,13 @@ const getSchemeColor = (colorScheme: RadioColorScheme): string => {
 const getContrastSchemeColor = (colorScheme: RadioColorScheme) => {
   const schemeColor = getSchemeColor(colorScheme);
   return isDark(schemeColor) ? tint(schemeColor, 0.5) : schemeColor;
+};
+
+const getHoverColor = (
+  variant: RadioVariant,
+  colorScheme: RadioColorScheme,
+) => {
+  return variant === "bubble"
+    ? getContrastSchemeColor(colorScheme)
+    : getSchemeColor(colorScheme);
 };

--- a/frontend/src/metabase/core/components/Radio/Radio.styled.tsx
+++ b/frontend/src/metabase/core/components/Radio/Radio.styled.tsx
@@ -66,7 +66,7 @@ export const RadioContainer = styled.div<RadioContainerProps>`
   &:hover {
     color: ${props =>
       !props.checked && !props.showButtons
-        ? getHoverColor(props.variant, props.colorScheme)
+        ? getSchemeColor(props.colorScheme)
         : ""};
   }
 
@@ -103,6 +103,10 @@ export const RadioContainerBubble = styled(RadioContainer)`
       : lighten(getSchemeColor(props.colorScheme))};
 
   &:hover {
+    color: ${props =>
+      !props.checked && !props.showButtons
+        ? getContrastSchemeColor(props.colorScheme)
+        : ""};
     background-color: ${props =>
       props.checked ? "" : lighten(getSchemeColor(props.colorScheme), 0.38)};
     transition: background-color 300ms linear;
@@ -145,13 +149,4 @@ const getSchemeColor = (colorScheme: RadioColorScheme): string => {
 const getContrastSchemeColor = (colorScheme: RadioColorScheme) => {
   const schemeColor = getSchemeColor(colorScheme);
   return isDark(schemeColor) ? tint(schemeColor, 0.5) : schemeColor;
-};
-
-const getHoverColor = (
-  variant: RadioVariant,
-  colorScheme: RadioColorScheme,
-) => {
-  return variant === "bubble"
-    ? getContrastSchemeColor(colorScheme)
-    : getSchemeColor(colorScheme);
 };


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/23975

How to test:
- Run `yarn storybook`
- Open `http://localhost:6006/?path=/story/core-radio--underlined&args=colorScheme:accent7`
- Hover over a radio item. It should not turn white