### PR TITLE
Show data point values on static viz (followed-up PR)

### DIFF
--- a/frontend/src/metabase/static-viz/components/LineAreaBarChart/LineAreaBarChart.tsx
+++ b/frontend/src/metabase/static-viz/components/LineAreaBarChart/LineAreaBarChart.tsx
@@ -1,5 +1,6 @@
 import { color } from "metabase/lib/colors";
 import { colors } from "metabase/lib/colors/palette";
+import { ColorGetter } from "metabase/static-viz/lib/colors";
 import React from "react";
 import { XYChart } from "../XYChart";
 import { ChartSettings, ChartStyle, Series } from "../XYChart/types";
@@ -14,25 +15,24 @@ interface LineAreaBarChartProps {
   series: Series[];
   settings: ChartSettings;
   colors: Colors;
+  getColor: ColorGetter;
 }
 
 const LineAreaBarChart = ({
   series,
   settings,
-  colors: instanceColors,
+  getColor,
 }: LineAreaBarChartProps) => {
-  const palette = { ...colors, ...instanceColors };
-
   const chartStyle: ChartStyle = {
     fontFamily: "Lato, sans-serif",
     axes: {
-      color: color("text-light", palette),
+      color: getColor("text-light"),
       ticks: {
-        color: color("text-medium", palette),
+        color: getColor("text-medium"),
         fontSize: 11,
       },
       labels: {
-        color: color("text-medium", palette),
+        color: getColor("text-medium"),
         fontSize: 11,
         fontWeight: 700,
       },
@@ -42,11 +42,13 @@ const LineAreaBarChart = ({
       lineHeight: 16,
     },
     value: {
-      color: color("text-dark", palette),
+      color: getColor("text-dark"),
       fontSize: 11,
       fontWeight: 800,
+      stroke: getColor("white"),
+      strokeWidth: 3,
     },
-    goalColor: color("text-medium", palette),
+    goalColor: getColor("text-medium"),
   };
 
   const minTickSize = chartStyle.axes.ticks.fontSize * 1.5;

--- a/frontend/src/metabase/static-viz/components/Text/OutlinedText.tsx
+++ b/frontend/src/metabase/static-viz/components/Text/OutlinedText.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { Text, TextProps } from "@visx/text";
+
+export default function OutlinedText(props: TextProps) {
+  return (
+    <>
+      {/* Render 2 text elements instead of one as a workaround for BE environment that doesn't support `paint-order` CSS property */}
+      <Text {...props} />
+      <Text {...props} stroke={undefined} strokeWidth={undefined} />
+    </>
+  );
+}

--- a/frontend/src/metabase/static-viz/components/XYChart/Values/Values.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/Values/Values.tsx
@@ -17,6 +17,7 @@ import type {
 } from "../types";
 
 const VALUES_MARGIN = 6;
+const VALUES_STROKE_MARGIN = 3;
 const FLIPPED_VALUES_MARGIN = VALUES_MARGIN + 8;
 
 interface ValuesProps {
@@ -357,7 +358,10 @@ function hasCollisions(
   const minDistanceFromOtherValues = Math.min(
     ...otherValues.map(distanceFrom(value)),
   );
-  return minDistanceFromOtherValues < MIN_SPACING || value.yPos > xAxisYPos;
+  return (
+    minDistanceFromOtherValues < MIN_SPACING ||
+    value.yPos + VALUES_STROKE_MARGIN > xAxisYPos
+  );
 }
 
 function distanceFrom(value: { yPos: number }) {

--- a/frontend/src/metabase/static-viz/components/XYChart/Values/Values.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/Values/Values.tsx
@@ -17,7 +17,7 @@ const FLIPPED_VALUES_MARGIN = VALUES_MARGIN + 8;
 
 interface ValuesProps {
   series: HydratedSeries[];
-  formatter: (value: number, compact?: boolean) => string;
+  formatter: (value: number, compact: boolean) => string;
   valueProps: Partial<TextProps>;
   xScale: XScale;
   yScaleLeft: PositionScale | null;
@@ -50,13 +50,13 @@ export default function Values({
     <>
       {series.map(serie => {
         const { values } = getValues(serie, areStacked);
+        const compact = getCompact(serie);
         const valueStep = getValueStep(
           [serie],
-          formatter,
+          value => formatter(value, compact),
           valueProps,
           innerWidth,
         );
-        const compact = getCompact(serie);
 
         const yScale = (
           serie.yAxisPosition === "left" ? yScaleLeft : yScaleRight
@@ -70,16 +70,30 @@ export default function Values({
           );
           return (
             index % valueStep === 0 && (
-              <Text
-                key={index}
-                x={xAccessor(value.datum)}
-                y={yAccessor(value.datum)}
-                textAnchor="middle"
-                verticalAnchor="end"
-                {...valueProps}
-              >
-                {formatter(getY(value.datum), compact)}
-              </Text>
+              <>
+                <Text
+                  key={index}
+                  x={xAccessor(value.datum)}
+                  y={yAccessor(value.datum)}
+                  textAnchor="middle"
+                  verticalAnchor="end"
+                  {...valueProps}
+                >
+                  {formatter(getY(value.datum), compact)}
+                </Text>
+                <Text
+                  key={index}
+                  x={xAccessor(value.datum)}
+                  y={yAccessor(value.datum)}
+                  textAnchor="middle"
+                  verticalAnchor="end"
+                  {...valueProps}
+                  stroke={undefined}
+                  strokeWidth={undefined}
+                >
+                  {formatter(getY(value.datum), compact)}
+                </Text>
+              </>
             )
           );
         });

--- a/frontend/src/metabase/static-viz/components/XYChart/Values/Values.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/Values/Values.tsx
@@ -13,6 +13,7 @@ import type {
   SeriesDatum,
   StackedDatum,
   VisualizationType,
+  XScale,
   XYAccessor,
 } from "../types";
 
@@ -30,12 +31,6 @@ interface ValuesProps {
   innerWidth: number;
   areStacked: boolean;
   xAxisYPos: number;
-}
-
-interface XScale {
-  bandwidth?: number;
-  lineAccessor: XYAccessor<SeriesDatum>;
-  barAccessor?: XYAccessor<SeriesDatum>;
 }
 
 interface Value {

--- a/frontend/src/metabase/static-viz/components/XYChart/Values/Values.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/Values/Values.tsx
@@ -149,5 +149,13 @@ function getSeriesTransformer(
       });
   }
 
+  if (type === "bar") {
+    return values =>
+      values.map(value => {
+        const isNegative = getY(value.datum) < 0;
+        return { ...value, flipped: isNegative };
+      });
+  }
+
   return values => values;
 }

--- a/frontend/src/metabase/static-viz/components/XYChart/Values/Values.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/Values/Values.tsx
@@ -1,0 +1,153 @@
+import { Text } from "@visx/text";
+import React from "react";
+import { getValueStep, getY } from "../utils";
+
+import type { TextProps } from "@visx/text";
+import type {
+  HydratedSeries,
+  SeriesDatum,
+  VisualizationType,
+  XYAccessor,
+} from "../types";
+import { PositionScale } from "@visx/shape/lib/types";
+
+const VALUES_MARGIN = 6;
+const FLIPPED_VALUES_MARGIN = VALUES_MARGIN + 8;
+
+interface ValuesProps {
+  series: HydratedSeries[];
+  formatter: (value: number, compact?: boolean) => string;
+  valueProps: Partial<TextProps>;
+  xScale: XScale;
+  yScaleLeft: PositionScale | null;
+  yScaleRight: PositionScale | null;
+  innerWidth: number;
+}
+
+interface XScale {
+  lineAccessor: XYAccessor;
+}
+
+interface Value {
+  datum: SeriesDatum;
+  flipped?: boolean;
+  hidden?: boolean;
+}
+
+export default function Values({
+  series,
+  formatter,
+  valueProps,
+  xScale,
+  yScaleLeft,
+  yScaleRight,
+  innerWidth,
+}: ValuesProps) {
+  return (
+    <>
+      {series.map(serie => {
+        const { values } = getValues(serie);
+        const valueStep = getValueStep(
+          [serie],
+          formatter,
+          valueProps,
+          innerWidth,
+        );
+        const compact = getCompact(serie);
+
+        const yScale = (
+          serie.yAxisPosition === "left" ? yScaleLeft : yScaleRight
+        ) as PositionScale;
+        return values.map((value, index) => {
+          const { xAccessor, yAccessor } = getXyAccessors(
+            serie.type,
+            xScale,
+            yScale,
+            value.flipped,
+          );
+          return (
+            index % valueStep === 0 && (
+              <Text
+                key={index}
+                x={xAccessor(value.datum)}
+                y={yAccessor(value.datum)}
+                textAnchor="middle"
+                verticalAnchor="end"
+                {...valueProps}
+              >
+                {formatter(getY(value.datum), compact)}
+              </Text>
+            )
+          );
+        });
+      })}
+    </>
+  );
+
+  function getValues(s: HydratedSeries) {
+    const values = getSeriesTransformer(s.type)(
+      s.data.map(datum => {
+        return {
+          datum,
+        };
+      }),
+    );
+
+    return { values };
+  }
+
+  function getCompact(s: HydratedSeries) {
+    // Use the same logic as in https://github.com/metabase/metabase/blob/1276595f073883853fed219ac185d0293ced01b8/frontend/src/metabase/visualizations/lib/chart_values.js#L178-L179
+    const getAvgLength = (compact: boolean) => {
+      const lengths = s.data.map(
+        ([_, yValue]) => formatter(yValue, compact).length,
+      );
+      return lengths.reduce((sum, l) => sum + l, 0) / lengths.length;
+    };
+    const compact = getAvgLength(true) < getAvgLength(false) - 3;
+    return compact;
+  }
+}
+
+function getXyAccessors(
+  type: VisualizationType,
+  xScale: XScale,
+  yScale: PositionScale,
+  flipped?: boolean,
+): {
+  xAccessor: XYAccessor;
+  yAccessor: XYAccessor;
+} {
+  return {
+    xAccessor: xScale.lineAccessor,
+    yAccessor: datum =>
+      (yScale(getY(datum)) ?? 0) +
+      (flipped ? FLIPPED_VALUES_MARGIN : -VALUES_MARGIN),
+  };
+}
+
+function getSeriesTransformer(
+  type: VisualizationType,
+): <T extends Value>(values: T[]) => Value[] {
+  if (type === "line") {
+    return values =>
+      values.map((value, index) => {
+        // Use the similar logic as presented in https://github.com/metabase/metabase/blob/3f4ca9c70bd263a7579613971ea8d7c47b1f776e/frontend/src/metabase/visualizations/lib/chart_values.js#L130
+        const previousValue = values[index - 1];
+        const nextValue = values[index + 1];
+        const showLabelBelow =
+          // first point or prior is greater than y
+          (index === 0 || getY(previousValue.datum) > getY(value.datum)) &&
+          // last point point or next is greater than y
+          (index >= values.length - 1 ||
+            getY(nextValue.datum) > getY(value.datum));
+
+        return {
+          ...value,
+          flipped: showLabelBelow,
+        };
+      });
+  }
+
+  return values => values;
+}

--- a/frontend/src/metabase/static-viz/components/XYChart/Values/Values.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/Values/Values.tsx
@@ -112,7 +112,7 @@ export default function Values({
   return (
     <>
       {verticalOverlappingFreeValues.map((singleSerieValues, seriesIndex) => {
-        const compact = getCompact(series[seriesIndex]);
+        const compact = getCompact(singleSerieValues.map(value => value.datum));
 
         return fixHorizontalOverlappingValues(
           seriesIndex,
@@ -163,11 +163,11 @@ export default function Values({
     </>
   );
 
-  function getCompact(serie: HydratedSeries) {
+  function getCompact(data: (SeriesDatum | StackedDatum)[]) {
     // Use the same logic as in https://github.com/metabase/metabase/blob/1276595f073883853fed219ac185d0293ced01b8/frontend/src/metabase/visualizations/lib/chart_values.js#L178-L179
     const getAvgLength = (compact: boolean) => {
-      const lengths = serie.data.map(
-        ([_, yValue]) => formatter(yValue, compact).length,
+      const lengths = data.map(
+        ([_, yValue]) => formatter(Number(yValue), compact).length,
       );
       return lengths.reduce((sum, l) => sum + l, 0) / lengths.length;
     };

--- a/frontend/src/metabase/static-viz/components/XYChart/Values/Values.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/Values/Values.tsx
@@ -319,8 +319,8 @@ function fixValuesCollisions(
       const INDEX_OFFSET = 1;
       sortedByY.slice(INDEX_OFFSET).forEach((value, index) => {
         const otherValues = [
-          ...group.slice(0, index + INDEX_OFFSET),
-          ...group.slice(index + INDEX_OFFSET + 1),
+          ...sortedByY.slice(0, index + INDEX_OFFSET),
+          ...sortedByY.slice(index + INDEX_OFFSET + 1),
         ].map(value => value.position);
 
         fixValueCollision(otherValues, value);

--- a/frontend/src/metabase/static-viz/components/XYChart/Values/Values.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/Values/Values.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import _ from "underscore";
 
-import { Text } from "@visx/text";
 import { scaleBand } from "@visx/scale";
 
+import OutlinedText from "metabase/static-viz/components/Text/OutlinedText";
 import { getValueStep, getY } from "../utils";
 
 import type { TextProps } from "@visx/text";
@@ -127,31 +127,16 @@ export default function Values({
           );
 
           return (
-            <>
-              {/* Render 2 text elements instead of one as a workaround for BE environment that doesn't support `paint-order` CSS property */}
-              <Text
-                key={index}
-                x={xAccessor(value.datum)}
-                y={yAccessor(value.datum)}
-                textAnchor="middle"
-                verticalAnchor="end"
-                {...valueProps}
-              >
-                {formatter(getY(value.datum), compact)}
-              </Text>
-              <Text
-                key={index}
-                x={xAccessor(value.datum)}
-                y={yAccessor(value.datum)}
-                textAnchor="middle"
-                verticalAnchor="end"
-                {...valueProps}
-                stroke={undefined}
-                strokeWidth={undefined}
-              >
-                {formatter(getY(value.datum), compact)}
-              </Text>
-            </>
+            <OutlinedText
+              key={index}
+              x={xAccessor(value.datum)}
+              y={yAccessor(value.datum)}
+              textAnchor="middle"
+              verticalAnchor="end"
+              {...valueProps}
+            >
+              {formatter(getY(value.datum), compact)}
+            </OutlinedText>
           );
         });
       })}

--- a/frontend/src/metabase/static-viz/components/XYChart/Values/index.ts
+++ b/frontend/src/metabase/static-viz/components/XYChart/Values/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Values";

--- a/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
@@ -37,6 +37,7 @@ import {
   getValueStep,
 } from "metabase/static-viz/components/XYChart/utils";
 import { GoalLine } from "metabase/static-viz/components/XYChart/GoalLine";
+import Values from "./Values";
 
 export interface XYChartProps {
   width: number;
@@ -221,10 +222,6 @@ export const XYChart = ({
           yScaleLeft={yScaleLeft}
           yScaleRight={yScaleRight}
           xAccessor={xScale.lineAccessor}
-          showValues={Boolean(settings.show_values)}
-          valueFormatter={valueFormatter}
-          valueProps={valueProps}
-          valueStep={linesValueStep}
         />
 
         {settings.goal && (
@@ -235,6 +232,23 @@ export const XYChart = ({
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             y={defaultYScale!(settings.goal.value)}
             color={style.goalColor}
+          />
+        )}
+
+        {settings.show_values && (
+          <Values
+            series={series}
+            formatter={(value: number): string =>
+              formatNumber(
+                value,
+                maybeAssoc(settings.y.format, "compact", compact),
+              )
+            }
+            valueProps={valueProps}
+            xScale={xScale}
+            yScaleLeft={yScaleLeft}
+            yScaleRight={yScaleRight}
+            innerWidth={innerWidth}
           />
         )}
       </Group>

--- a/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
@@ -202,6 +202,7 @@ export const XYChart = ({
             valueFormatter={valueFormatter}
             valueProps={valueProps}
             valueStep={barsValueStep}
+            xAxisYPos={yMin - margin.top}
           />
         )}
         <AreaSeries

--- a/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
@@ -199,11 +199,6 @@ export const XYChart = ({
             yScaleRight={yScaleRight}
             xAccessor={xScale.barAccessor}
             bandwidth={xScale.bandwidth}
-            showValues={Boolean(settings.show_values)}
-            valueFormatter={valueFormatter}
-            valueProps={valueProps}
-            valueStep={barsValueStep}
-            xAxisYPos={yMin - margin.top}
           />
         )}
         <AreaSeries

--- a/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
@@ -147,69 +147,6 @@ export const XYChart = ({
 
   return (
     <svg width={width} height={height + legendHeight}>
-      <Group top={margin.top} left={xMin}>
-        {defaultYScale && (
-          <GridRows
-            scale={defaultYScale}
-            width={innerWidth}
-            strokeDasharray="4"
-          />
-        )}
-
-        {xScale.barAccessor && xScale.bandwidth && (
-          <BarSeries
-            series={bars}
-            yScaleLeft={yScaleLeft}
-            yScaleRight={yScaleRight}
-            xAccessor={xScale.barAccessor}
-            bandwidth={xScale.bandwidth}
-          />
-        )}
-        <AreaSeries
-          series={areas}
-          yScaleLeft={yScaleLeft}
-          yScaleRight={yScaleRight}
-          xAccessor={xScale.lineAccessor}
-          areStacked={settings.stacking === "stack"}
-        />
-        <LineSeries
-          series={lines}
-          yScaleLeft={yScaleLeft}
-          yScaleRight={yScaleRight}
-          xAccessor={xScale.lineAccessor}
-        />
-
-        {settings.goal && (
-          <GoalLine
-            label={settings.goal.label}
-            x1={0}
-            x2={innerWidth}
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            y={defaultYScale!(settings.goal.value)}
-            color={style.goalColor}
-          />
-        )}
-
-        {settings.show_values && (
-          <Values
-            series={series}
-            formatter={(value: number, compact: boolean): string =>
-              formatNumber(
-                value,
-                maybeAssoc(settings.y.format, "compact", compact),
-              )
-            }
-            valueProps={valueProps}
-            xScale={xScale}
-            yScaleLeft={yScaleLeft}
-            yScaleRight={yScaleRight}
-            innerWidth={innerWidth}
-            areStacked={settings.stacking === "stack"}
-            xAxisYPos={yMin - margin.top}
-          />
-        )}
-      </Group>
-
       {yScaleLeft && (
         <AxisLeft
           hideTicks
@@ -282,6 +219,69 @@ export const XYChart = ({
         lineHeight={style.legend.lineHeight}
         fontSize={style.legend.fontSize}
       />
+
+      <Group top={margin.top} left={xMin}>
+        {defaultYScale && (
+          <GridRows
+            scale={defaultYScale}
+            width={innerWidth}
+            strokeDasharray="4"
+          />
+        )}
+
+        {xScale.barAccessor && xScale.bandwidth && (
+          <BarSeries
+            series={bars}
+            yScaleLeft={yScaleLeft}
+            yScaleRight={yScaleRight}
+            xAccessor={xScale.barAccessor}
+            bandwidth={xScale.bandwidth}
+          />
+        )}
+        <AreaSeries
+          series={areas}
+          yScaleLeft={yScaleLeft}
+          yScaleRight={yScaleRight}
+          xAccessor={xScale.lineAccessor}
+          areStacked={settings.stacking === "stack"}
+        />
+        <LineSeries
+          series={lines}
+          yScaleLeft={yScaleLeft}
+          yScaleRight={yScaleRight}
+          xAccessor={xScale.lineAccessor}
+        />
+
+        {settings.goal && (
+          <GoalLine
+            label={settings.goal.label}
+            x1={0}
+            x2={innerWidth}
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            y={defaultYScale!(settings.goal.value)}
+            color={style.goalColor}
+          />
+        )}
+
+        {settings.show_values && (
+          <Values
+            series={series}
+            formatter={(value: number, compact: boolean): string =>
+              formatNumber(
+                value,
+                maybeAssoc(settings.y.format, "compact", compact),
+              )
+            }
+            valueProps={valueProps}
+            xScale={xScale}
+            yScaleLeft={yScaleLeft}
+            yScaleRight={yScaleRight}
+            innerWidth={innerWidth}
+            areStacked={settings.stacking === "stack"}
+            xAxisYPos={yMin - margin.top}
+          />
+        )}
+      </Group>
     </svg>
   );
 };

--- a/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
@@ -135,8 +135,10 @@ export const XYChart = ({
     fontSize: style.value?.fontSize,
     fontFamily: style.fontFamily,
     fontWeight: style.value?.fontWeight,
-    fill: style.value?.color,
     letterSpacing: 0.5,
+    fill: style.value?.color,
+    stroke: style.value?.stroke,
+    strokeWidth: style.value?.strokeWidth,
   };
 
   const areXTicksRotated = settings.x.tick_display === "rotate-45";
@@ -191,7 +193,7 @@ export const XYChart = ({
         {settings.show_values && (
           <Values
             series={series}
-            formatter={(value: number): string =>
+            formatter={(value: number, compact: boolean): string =>
               formatNumber(
                 value,
                 maybeAssoc(settings.y.format, "compact", compact),

--- a/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
@@ -34,7 +34,6 @@ import {
   sortSeries,
   getLegendColumns,
   calculateStackedItems,
-  getValueStep,
 } from "metabase/static-viz/components/XYChart/utils";
 import { GoalLine } from "metabase/static-viz/components/XYChart/GoalLine";
 import Values from "./Values";
@@ -144,43 +143,6 @@ export const XYChart = ({
   const areXTicksHidden = settings.x.tick_display === "hide";
   const xLabelOffset = areXTicksHidden ? -style.axes.ticks.fontSize : undefined;
 
-  // Use the same logic as in https://github.com/metabase/metabase/blob/1276595f073883853fed219ac185d0293ced01b8/frontend/src/metabase/visualizations/lib/chart_values.js#L178-L179
-  // TODO: set compact per series
-  const getAvgLength = (compact: boolean) => {
-    const lengths = series
-      .flatMap(s => s.data)
-      .map(
-        ([_, yValue]) =>
-          formatNumber(
-            yValue,
-            maybeAssoc(settings.y.format, "compact", compact),
-          ).length,
-      );
-    return lengths.reduce((sum, l) => sum + l, 0) / lengths.length;
-  };
-  const compact = getAvgLength(true) < getAvgLength(false) - 3;
-  const valueFormatter = (value: number): string =>
-    formatNumber(value, maybeAssoc(settings.y.format, "compact", compact));
-
-  const barsValueStep = getValueStep(
-    bars,
-    valueFormatter,
-    valueProps,
-    innerWidth,
-  );
-  const areasValueStep = getValueStep(
-    areas,
-    valueFormatter,
-    valueProps,
-    innerWidth,
-  );
-  const linesValueStep = getValueStep(
-    lines,
-    valueFormatter,
-    valueProps,
-    innerWidth,
-  );
-
   return (
     <svg width={width} height={height + legendHeight}>
       <Group top={margin.top} left={xMin}>
@@ -207,10 +169,6 @@ export const XYChart = ({
           yScaleRight={yScaleRight}
           xAccessor={xScale.lineAccessor}
           areStacked={settings.stacking === "stack"}
-          showValues={Boolean(settings.show_values)}
-          valueFormatter={valueFormatter}
-          valueProps={valueProps}
-          valueStep={areasValueStep}
         />
         <LineSeries
           series={lines}
@@ -244,6 +202,7 @@ export const XYChart = ({
             yScaleLeft={yScaleLeft}
             yScaleRight={yScaleRight}
             innerWidth={innerWidth}
+            areStacked={settings.stacking === "stack"}
           />
         )}
       </Group>

--- a/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
@@ -205,6 +205,7 @@ export const XYChart = ({
             yScaleRight={yScaleRight}
             innerWidth={innerWidth}
             areStacked={settings.stacking === "stack"}
+            xAxisYPos={yMin - margin.top}
           />
         )}
       </Group>

--- a/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
@@ -317,10 +317,12 @@ const APPROXIMATE_MAX_VALUE_CHAR_LENGTH = 7;
 const MAX_SERIES_LENGTH = 15;
 function getValuesLeftOffset(
   settings: ChartSettings,
-  series: HydratedSeries[],
+  multipleSeries: HydratedSeries[],
   valueCharSize: number,
 ) {
-  const maxSeriesLength = Math.max(...series.map(serie => serie.data.length));
+  const maxSeriesLength = Math.max(
+    ...multipleSeries.map(series => series.data.length),
+  );
   if (settings.show_values && maxSeriesLength > MAX_SERIES_LENGTH) {
     return valueCharSize * (APPROXIMATE_MAX_VALUE_CHAR_LENGTH / 2);
   }

--- a/frontend/src/metabase/static-viz/components/XYChart/shapes/AreaSeries.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/shapes/AreaSeries.tsx
@@ -9,9 +9,6 @@ import type {
   Series,
   SeriesDatum,
 } from "metabase/static-viz/components/XYChart/types";
-import { Text, TextProps } from "@visx/text";
-
-const VALUES_MARGIN = 6;
 
 interface AreaSeriesProps {
   series: Series[];
@@ -19,10 +16,6 @@ interface AreaSeriesProps {
   yScaleRight: PositionScale | null;
   xAccessor: (datum: SeriesDatum) => number;
   areStacked?: boolean;
-  showValues: boolean;
-  valueFormatter: (value: number) => string;
-  valueProps: Partial<TextProps>;
-  valueStep: number;
 }
 
 export const AreaSeries = ({
@@ -31,10 +24,6 @@ export const AreaSeries = ({
   yScaleRight,
   xAccessor,
   areStacked,
-  showValues,
-  valueFormatter,
-  valueProps,
-  valueStep,
 }: AreaSeriesProps) => {
   if (areStacked) {
     return (
@@ -44,10 +33,6 @@ export const AreaSeries = ({
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         yScale={yScaleLeft!}
         xAccessor={xAccessor}
-        showValues={showValues}
-        valueFormatter={valueFormatter}
-        valueProps={valueProps}
-        valueStep={valueStep}
       />
     );
   }
@@ -74,33 +59,6 @@ export const AreaSeries = ({
           />
         );
       })}
-      {/* Render all data point values last so they stay on top of the chart elements making them more legible */}
-      {showValues &&
-        series.map(s => {
-          const yScale = s.yAxisPosition === "left" ? yScaleLeft : yScaleRight;
-
-          if (!yScale) {
-            return null;
-          }
-
-          const yAccessor = (d: SeriesDatum) => yScale(getY(d)) ?? 0;
-          return s.data.map((datum, index) => {
-            return (
-              index % valueStep === 0 && (
-                <Text
-                  key={index}
-                  x={xAccessor(datum)}
-                  y={yAccessor(datum) - VALUES_MARGIN}
-                  textAnchor="middle"
-                  verticalAnchor="end"
-                  {...valueProps}
-                >
-                  {valueFormatter(getY(datum))}
-                </Text>
-              )
-            );
-          });
-        })}
     </Group>
   );
 };

--- a/frontend/src/metabase/static-viz/components/XYChart/shapes/AreaSeriesStacked.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/shapes/AreaSeriesStacked.tsx
@@ -5,35 +5,20 @@ import { LineArea } from "metabase/static-viz/components/XYChart/shapes/LineArea
 import {
   HydratedSeries,
   SeriesDatum,
-  StackedDatum,
 } from "metabase/static-viz/components/XYChart/types";
 import { getY, getY1 } from "metabase/static-viz/components/XYChart/utils";
-import { Text } from "@visx/text";
-
-import type { TextProps } from "@visx/text";
-
-const VALUES_MARGIN = 6;
 
 interface AreaSeriesProps {
   series: HydratedSeries[];
   yScale: PositionScale;
   xAccessor: (datum: SeriesDatum) => number;
-  showValues: boolean;
-  valueFormatter: (value: number) => string;
-  valueProps: Partial<TextProps>;
-  valueStep: number;
 }
 
 export const AreaSeriesStacked = ({
   series,
   yScale,
   xAccessor,
-  showValues,
-  valueFormatter,
-  valueProps,
-  valueStep,
 }: AreaSeriesProps) => {
-  const yAccessor = (d: StackedDatum) => yScale(getY(d)) ?? 0;
   return (
     <Group>
       {series.map(s => {
@@ -49,24 +34,6 @@ export const AreaSeriesStacked = ({
           />
         );
       })}
-      {/* Render all data point values last so they stay on top of the chart elements making them more legible */}
-      {showValues &&
-        series[series.length - 1].stackedData?.map((datum, index) => {
-          return (
-            index % valueStep === 0 && (
-              <Text
-                key={index}
-                x={(xAccessor as any)(datum)}
-                y={yAccessor(datum) - VALUES_MARGIN}
-                textAnchor="middle"
-                verticalAnchor="end"
-                {...valueProps}
-              >
-                {valueFormatter(getY(datum))}
-              </Text>
-            )
-          );
-        })}
     </Group>
   );
 };

--- a/frontend/src/metabase/static-viz/components/XYChart/shapes/BarSeries.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/shapes/BarSeries.tsx
@@ -24,6 +24,7 @@ interface BarSeriesProps {
   valueFormatter: (value: number) => string;
   valueProps: Partial<TextProps>;
   valueStep: number;
+  xAxisYPos: number;
 }
 
 export const BarSeries = ({
@@ -36,6 +37,7 @@ export const BarSeries = ({
   valueFormatter,
   valueProps,
   valueStep,
+  xAxisYPos,
 }: BarSeriesProps) => {
   const innerBarScaleDomain = series.map((_, index) => index);
 
@@ -87,18 +89,26 @@ export const BarSeries = ({
               const x = groupX + innerX;
               const width = innerBarScale.bandwidth();
 
-              const yZero = yScale(0) ?? 0;
               const yValue = yScale(getY(datum)) ?? 0;
-              const y = Math.min(yValue, yZero);
+              const isNegative = getY(datum) < 0;
+
+              const bottomTextYPos =
+                yValue + VALUES_MARGIN + (valueProps.fontSize as number);
+              const isOverflownXAxis = isNegative && bottomTextYPos > xAxisYPos;
+              const shouldFlipYPosition = isNegative && !isOverflownXAxis;
+              const y = shouldFlipYPosition
+                ? yValue + VALUES_MARGIN
+                : yValue - VALUES_MARGIN;
+
               return (
                 showValues &&
                 index % valueStep === 0 && (
                   <Text
                     x={x + width / 2}
-                    y={y - VALUES_MARGIN}
+                    y={y}
                     width={width}
                     textAnchor="middle"
-                    verticalAnchor="end"
+                    verticalAnchor={shouldFlipYPosition ? "start" : "end"}
                     {...valueProps}
                   >
                     {valueFormatter(getY(datum))}

--- a/frontend/src/metabase/static-viz/components/XYChart/shapes/BarSeries.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/shapes/BarSeries.tsx
@@ -4,15 +4,11 @@ import { Group } from "@visx/group";
 import { scaleBand } from "@visx/scale";
 import { PositionScale } from "@visx/shape/lib/types";
 import { getY } from "metabase/static-viz/components/XYChart/utils";
-import { Text } from "@visx/text";
 
 import type {
   Series,
   SeriesDatum,
 } from "metabase/static-viz/components/XYChart/types";
-import type { TextProps } from "@visx/text";
-
-const VALUES_MARGIN = 6;
 
 interface BarSeriesProps {
   series: Series[];
@@ -20,11 +16,6 @@ interface BarSeriesProps {
   yScaleRight: PositionScale | null;
   xAccessor: (datum: SeriesDatum) => number;
   bandwidth: number;
-  showValues: boolean;
-  valueFormatter: (value: number) => string;
-  valueProps: Partial<TextProps>;
-  valueStep: number;
-  xAxisYPos: number;
 }
 
 export const BarSeries = ({
@@ -33,11 +24,6 @@ export const BarSeries = ({
   yScaleRight,
   xAccessor,
   bandwidth,
-  showValues,
-  valueFormatter,
-  valueProps,
-  valueStep,
-  xAxisYPos,
 }: BarSeriesProps) => {
   const innerBarScaleDomain = series.map((_, index) => index);
 
@@ -79,41 +65,6 @@ export const BarSeries = ({
                   x={x}
                   y={y}
                 />
-              );
-            })}
-            {/* Render all data point values last so they stay on top of the chart elements making them more legible */}
-            {series.data.map((datum, index) => {
-              const groupX = xAccessor(datum);
-              const innerX = innerBarScale(seriesIndex) ?? 0;
-
-              const x = groupX + innerX;
-              const width = innerBarScale.bandwidth();
-
-              const yValue = yScale(getY(datum)) ?? 0;
-              const isNegative = getY(datum) < 0;
-
-              const bottomTextYPos =
-                yValue + VALUES_MARGIN + (valueProps.fontSize as number);
-              const isOverflownXAxis = isNegative && bottomTextYPos > xAxisYPos;
-              const shouldFlipYPosition = isNegative && !isOverflownXAxis;
-              const y = shouldFlipYPosition
-                ? yValue + VALUES_MARGIN
-                : yValue - VALUES_MARGIN;
-
-              return (
-                showValues &&
-                index % valueStep === 0 && (
-                  <Text
-                    x={x + width / 2}
-                    y={y}
-                    width={width}
-                    textAnchor="middle"
-                    verticalAnchor={shouldFlipYPosition ? "start" : "end"}
-                    {...valueProps}
-                  >
-                    {valueFormatter(getY(datum))}
-                  </Text>
-                )
               );
             })}
           </Fragment>

--- a/frontend/src/metabase/static-viz/components/XYChart/shapes/LineSeries.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/shapes/LineSeries.tsx
@@ -3,25 +3,17 @@ import { Group } from "@visx/group";
 import { LinePath } from "@visx/shape";
 import { PositionScale } from "@visx/shape/lib/types";
 import { getY } from "metabase/static-viz/components/XYChart/utils";
-import { Text } from "@visx/text";
 
 import type {
   Series,
   SeriesDatum,
 } from "metabase/static-viz/components/XYChart/types";
-import type { TextProps } from "@visx/text";
-
-const VALUES_MARGIN = 6;
 
 interface LineSeriesProps {
   series: Series[];
   yScaleLeft: PositionScale | null;
   yScaleRight: PositionScale | null;
   xAccessor: (datum: SeriesDatum) => number;
-  showValues: boolean;
-  valueFormatter: (value: number) => string;
-  valueProps: Partial<TextProps>;
-  valueStep: number;
 }
 
 export const LineSeries = ({
@@ -29,10 +21,6 @@ export const LineSeries = ({
   yScaleLeft,
   yScaleRight,
   xAccessor,
-  showValues,
-  valueFormatter,
-  valueProps,
-  valueStep,
 }: LineSeriesProps) => {
   return (
     <Group>
@@ -44,63 +32,16 @@ export const LineSeries = ({
 
         const yAccessor = (datum: SeriesDatum) => yScale(getY(datum)) ?? 0;
         return (
-          <>
-            <LinePath
-              key={s.name}
-              data={s.data}
-              x={xAccessor}
-              y={yAccessor}
-              stroke={s.color}
-              strokeWidth={2}
-            />
-            {showValues &&
-              s.data.map((datum, index) => {
-                // Use the similar logic as presented in https://github.com/metabase/metabase/blob/3f4ca9c70bd263a7579613971ea8d7c47b1f776e/frontend/src/metabase/visualizations/lib/chart_values.js#L130
-                const showLabelBelow =
-                  // first point or prior is greater than y
-                  (index === 0 || getY(s.data[index - 1]) > getY(datum)) &&
-                  // last point point or next is greater than y
-                  (index >= s.data.length - 1 ||
-                    getY(s.data[index + 1]) > getY(datum));
-                return (
-                  index % valueStep === 0 && (
-                    <Value
-                      key={index}
-                      x={xAccessor(datum)}
-                      y={yAccessor(datum)}
-                      valueProps={valueProps}
-                      showLabelBelow={showLabelBelow}
-                    >
-                      {valueFormatter(getY(datum))}
-                    </Value>
-                  )
-                );
-              })}
-          </>
+          <LinePath
+            key={s.name}
+            data={s.data}
+            x={xAccessor}
+            y={yAccessor}
+            stroke={s.color}
+            strokeWidth={2}
+          />
         );
       })}
     </Group>
   );
 };
-
-interface ValueProps {
-  x: number;
-  y: number;
-  valueProps: Partial<TextProps>;
-  children: string;
-  showLabelBelow: boolean;
-}
-
-function Value({ x, y, valueProps, children, showLabelBelow }: ValueProps) {
-  return (
-    <Text
-      x={x}
-      y={showLabelBelow ? y + VALUES_MARGIN : y - VALUES_MARGIN}
-      textAnchor="middle"
-      verticalAnchor={showLabelBelow ? "start" : "end"}
-      {...valueProps}
-    >
-      {children}
-    </Text>
-  );
-}

--- a/frontend/src/metabase/static-viz/components/XYChart/types.ts
+++ b/frontend/src/metabase/static-viz/components/XYChart/types.ts
@@ -93,3 +93,5 @@ export type ChartStyle = {
   };
   goalColor: string;
 };
+
+export type XYAccessor = (datum: SeriesDatum) => number;

--- a/frontend/src/metabase/static-viz/components/XYChart/types.ts
+++ b/frontend/src/metabase/static-viz/components/XYChart/types.ts
@@ -90,6 +90,8 @@ export type ChartStyle = {
     color: string;
     fontSize: number;
     fontWeight: number;
+    stroke: string;
+    strokeWidth: number;
   };
   goalColor: string;
 };

--- a/frontend/src/metabase/static-viz/components/XYChart/types.ts
+++ b/frontend/src/metabase/static-viz/components/XYChart/types.ts
@@ -94,4 +94,6 @@ export type ChartStyle = {
   goalColor: string;
 };
 
-export type XYAccessor = (datum: SeriesDatum) => number;
+export type XYAccessor<
+  T extends SeriesDatum | StackedDatum = SeriesDatum | StackedDatum,
+> = (datum: T extends SeriesDatum ? SeriesDatum : StackedDatum) => number;

--- a/frontend/src/metabase/static-viz/components/XYChart/types.ts
+++ b/frontend/src/metabase/static-viz/components/XYChart/types.ts
@@ -1,5 +1,6 @@
-import { DateFormatOptions } from "metabase/static-viz/lib/dates";
-import { NumberFormatOptions } from "metabase/static-viz/lib/numbers";
+import type { DateFormatOptions } from "metabase/static-viz/lib/dates";
+import type { NumberFormatOptions } from "metabase/static-viz/lib/numbers";
+import type { ScaleBand, ScaleLinear, ScaleTime } from "d3-scale";
 
 export type Range = [number, number];
 export type ContiniousDomain = [number, number];
@@ -102,3 +103,14 @@ export type XYAccessor<
   datum: T extends SeriesDatum ? SeriesDatum : StackedDatum,
   flipped?: boolean,
 ) => number;
+
+export interface XScale<T = any> {
+  scale: T extends ScaleBand<string | number>
+    ? ScaleBand<string | number>
+    : T extends ScaleTime<number, number, never>
+    ? ScaleTime<number, number, never>
+    : ScaleLinear<number, number, never>;
+  bandwidth?: number;
+  lineAccessor: XYAccessor<SeriesDatum>;
+  barAccessor?: XYAccessor<SeriesDatum>;
+}

--- a/frontend/src/metabase/static-viz/components/XYChart/types.ts
+++ b/frontend/src/metabase/static-viz/components/XYChart/types.ts
@@ -98,4 +98,7 @@ export type ChartStyle = {
 
 export type XYAccessor<
   T extends SeriesDatum | StackedDatum = SeriesDatum | StackedDatum,
-> = (datum: T extends SeriesDatum ? SeriesDatum : StackedDatum) => number;
+> = (
+  datum: T extends SeriesDatum ? SeriesDatum : StackedDatum,
+  flipped?: boolean,
+) => number;

--- a/frontend/src/metabase/static-viz/components/XYChart/utils/scales.ts
+++ b/frontend/src/metabase/static-viz/components/XYChart/utils/scales.ts
@@ -7,6 +7,11 @@ import {
   scaleTime,
 } from "@visx/scale";
 import {
+  getX,
+  getY,
+} from "metabase/static-viz/components/XYChart/utils/series";
+
+import type {
   SeriesDatum,
   XAxisType,
   ContiniousDomain,
@@ -15,17 +20,14 @@ import {
   YAxisType,
   HydratedSeries,
   StackedDatum,
+  XScale,
 } from "metabase/static-viz/components/XYChart/types";
-import {
-  getX,
-  getY,
-} from "metabase/static-viz/components/XYChart/utils/series";
 
 export const createXScale = (
   series: Series[],
   range: Range,
   axisType: XAxisType,
-) => {
+): XScale => {
   const hasBars = series.some(series => series.type === "bar");
   const isOrdinal = axisType === "ordinal";
 

--- a/frontend/src/metabase/static-viz/components/XYChart/utils/values.ts
+++ b/frontend/src/metabase/static-viz/components/XYChart/utils/values.ts
@@ -7,6 +7,7 @@ import { measureText } from "metabase/static-viz/lib/text";
 // Use the same logic as in https://github.com/metabase/metabase/blob/72d23d2b8e5a1f93b288e5a8738758c9b05d3766/frontend/src/metabase/visualizations/lib/chart_values.js#L318
 export function getValueStep(
   series: HydratedSeries[],
+  seriesIndex: number,
   valueFormatter: (value: number) => string,
   valueProps: Partial<TextProps>,
   chartWidth: number,
@@ -18,7 +19,9 @@ export function getValueStep(
   const LABEL_PADDING = 6;
   const MAX_SAMPLE_SIZE = 30;
   const sampleStep = Math.ceil(maxSeriesLength / MAX_SAMPLE_SIZE);
-  const sample = series[0].data.filter((_, index) => index % sampleStep === 0);
+  const sample = series[seriesIndex].data.filter(
+    (_, index) => index % sampleStep === 0,
+  );
   const totalWidth = sample.reduce(
     (sum, sampledData) =>
       sum +

--- a/frontend/src/metabase/static-viz/components/XYChart/utils/values.ts
+++ b/frontend/src/metabase/static-viz/components/XYChart/utils/values.ts
@@ -6,20 +6,22 @@ import { measureText } from "metabase/static-viz/lib/text";
 
 // Use the same logic as in https://github.com/metabase/metabase/blob/72d23d2b8e5a1f93b288e5a8738758c9b05d3766/frontend/src/metabase/visualizations/lib/chart_values.js#L318
 export function getValueStep(
-  series: HydratedSeries[],
+  multipleSeries: HydratedSeries[],
   seriesIndex: number,
   valueFormatter: (value: number) => string,
   valueProps: Partial<TextProps>,
   chartWidth: number,
 ) {
-  if (series.length === 0) {
+  if (multipleSeries.length === 0) {
     return 1;
   }
-  const maxSeriesLength = Math.max(...series.map(serie => serie.data.length));
+  const maxSeriesLength = Math.max(
+    ...multipleSeries.map(series => series.data.length),
+  );
   const LABEL_PADDING = 6;
   const MAX_SAMPLE_SIZE = 30;
   const sampleStep = Math.ceil(maxSeriesLength / MAX_SAMPLE_SIZE);
-  const sample = series[seriesIndex].data.filter(
+  const sample = multipleSeries[seriesIndex].data.filter(
     (_, index) => index % sampleStep === 0,
   );
   const totalWidth = sample.reduce(

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "@types/core-js": "^2.5.5",
     "@types/crossfilter": "^0.0.34",
     "@types/d3": "^3.5.46",
-    "@types/d3-scale": "^2.2.6",
+    "@types/d3-scale": "^4.0.2",
     "@types/dc": "0.0.29",
     "@types/diff": "^3.5.4",
     "@types/eslint": "7.29.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4642,19 +4642,19 @@
   resolved "https://registry.yarnpkg.com/@types/d3-path/-/d3-path-1.0.9.tgz#73526b150d14cd96e701597cbf346cfd1fd4a58c"
   integrity sha512-NaIeSIBiFgSC6IGUBjZWcscUJEq7vpVu7KthHN8eieTV9d9MqkSOZLH4chq1PmcKy06PNe3axLeKmRIyxJ+PZQ==
 
-"@types/d3-scale@^2.2.6":
-  version "2.2.6"
-  resolved "https://registry.yarnpkg.com/@types/d3-scale/-/d3-scale-2.2.6.tgz#28540b4dfc99d978970e873e4138a6bea2ea6ab8"
-  integrity sha512-CHu34T5bGrJOeuhGxyiz9Xvaa9PlsIaQoOqjDg7zqeGj2x0rwPhGquiy03unigvcMxmvY0hEaAouT0LOFTLpIw==
-  dependencies:
-    "@types/d3-time" "^1"
-
 "@types/d3-scale@^3.2.1", "@types/d3-scale@^3.3.0":
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/@types/d3-scale/-/d3-scale-3.3.2.tgz#18c94e90f4f1c6b1ee14a70f14bfca2bd1c61d06"
   integrity sha512-gGqr7x1ost9px3FvIfUMi5XA/F/yAf4UkUDtdQhpH92XCT0Oa7zkkRzY61gPVJq+DxpHn/btouw5ohWkbBsCzQ==
   dependencies:
     "@types/d3-time" "^2"
+
+"@types/d3-scale@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@types/d3-scale/-/d3-scale-4.0.2.tgz#41be241126af4630524ead9cb1008ab2f0f26e69"
+  integrity sha512-Yk4htunhPAwN0XGlIwArRomOjdoBFXC3+kCxK2Ubg7I9shQlVSJy/pG/Ht5ASN+gdMIalpk8TJ5xV74jFsetLA==
+  dependencies:
+    "@types/d3-time" "*"
 
 "@types/d3-shape@^1.3.1":
   version "1.3.8"
@@ -4663,7 +4663,12 @@
   dependencies:
     "@types/d3-path" "^1"
 
-"@types/d3-time@^1", "@types/d3-time@^1.0.10":
+"@types/d3-time@*":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-time/-/d3-time-3.0.0.tgz#e1ac0f3e9e195135361fa1a1d62f795d87e6e819"
+  integrity sha512-sZLCdHvBUcNby1cB6Fd3ZBrABbjz3v1Vm90nysCQ6Vt7vd6e/h9Lt7SiJUoEX0l4Dzc7P5llKyhqSi1ycSf1Hg==
+
+"@types/d3-time@^1.0.10":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/d3-time/-/d3-time-1.1.1.tgz#6cf3a4242c3bbac00440dfb8ba7884f16bedfcbf"
   integrity sha512-ULX7LoqXTCYtM+tLYOaeAJK7IwCT+4Gxlm2MaH0ErKLi07R5lh8NHCAyWcDkCCmx1AfRcBEV6H9QE9R25uP7jw==


### PR DESCRIPTION
> **Warning**
> There are a few hacks I make on BE to show the actual result, and those shouldn't be merged. Once the BE is properly implemented these hacks should be removed from this PR.
> - https://github.com/metabase/metabase/pull/24938/commits/c6fe8dbe8c6360c090ac861ccdbb008479c202ce
> - https://github.com/metabase/metabase/pull/24938/commits/5770e5eebca1384f843315ff73007f83ef909004

---

EPIC: #24759
Issue: #20554
Followed-up from: https://github.com/metabase/metabase/pull/24813

## Ideas
Every value is rendered by a single component `<Values />`, this is because when rendering values, they are dependent to each other as there is a logic to prevent both horizontal and vertical overlapping, and each value needs to be aware of value from other series. So letting each chart component render its own values doesn't solve this problem.

## Todos
- [x] Improve value legibility
- [x] Negative bars
- [x] Multiseries bars
- [x] Close to chart edges labels should be visible
- [x] X-axis collision
    - [x] Bars
    - [x] Lines
    - [x] Areas

## Results
![localhost_3000__internal_static-viz (3)](https://user-images.githubusercontent.com/1937582/186947713-be487258-6fbc-4fa0-a9a6-0ba17d45151a.png)

