### PR TITLE
Introduce data apps and implement basic "New App" flow

### DIFF
--- a/frontend/src/metabase-types/api/data-app.ts
+++ b/frontend/src/metabase-types/api/data-app.ts
@@ -1,0 +1,17 @@
+import { Collection } from "./collection";
+
+export type DataAppId = number;
+
+export interface DataApp {
+  id: DataAppId;
+
+  collection_id: number;
+  dashboard_id: number | null; // homepage
+  collection: Collection;
+
+  options: Record<string, unknown> | null;
+  nav_items: null;
+
+  created_at: string;
+  updated_at: string;
+}

--- a/frontend/src/metabase-types/api/index.ts
+++ b/frontend/src/metabase-types/api/index.ts
@@ -4,6 +4,7 @@ export * from "./bookmark";
 export * from "./card";
 export * from "./collection";
 export * from "./dashboard";
+export * from "./data-app";
 export * from "./database";
 export * from "./dataset";
 export * from "./field";

--- a/frontend/src/metabase-types/api/mocks/data-app.ts
+++ b/frontend/src/metabase-types/api/mocks/data-app.ts
@@ -1,0 +1,20 @@
+import { DataApp } from "metabase-types/api";
+import { createMockCollection } from "./collection";
+
+export const createMockDataApp = ({
+  collection: collectionProps,
+  ...dataAppProps
+}: Omit<Partial<DataApp>, "collection_id"> = {}): DataApp => {
+  const collection = createMockCollection(collectionProps);
+  return {
+    id: 1,
+    dashboard_id: null,
+    options: null,
+    nav_items: null,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    ...dataAppProps,
+    collection_id: collection.id as number,
+    collection,
+  };
+};

--- a/frontend/src/metabase-types/api/mocks/index.ts
+++ b/frontend/src/metabase-types/api/mocks/index.ts
@@ -3,6 +3,7 @@ export * from "./automagic-dashboards";
 export * from "./card";
 export * from "./collection";
 export * from "./dashboard";
+export * from "./data-app";
 export * from "./database";
 export * from "./dataset";
 export * from "./metric";

--- a/frontend/src/metabase-types/store/entities.ts
+++ b/frontend/src/metabase-types/store/entities.ts
@@ -1,6 +1,7 @@
-import { Database, Table } from "metabase-types/api";
+import { Collection, CollectionId, Database, Table } from "metabase-types/api";
 
 export interface EntitiesState {
+  collections?: Record<CollectionId, Collection>;
   databases?: Record<number, Database>;
   tables?: Record<number | string, Table>;
 }

--- a/frontend/src/metabase/components/NewItemMenu/NewItemMenu.tsx
+++ b/frontend/src/metabase/components/NewItemMenu/NewItemMenu.tsx
@@ -1,10 +1,14 @@
 import React, { ReactNode, useCallback, useMemo, useState } from "react";
 import { t } from "ttag";
-import * as Urls from "metabase/lib/urls";
+
 import Modal from "metabase/components/Modal";
 import EntityMenu from "metabase/components/EntityMenu";
 import CreateDashboardModal from "metabase/components/CreateDashboardModal";
+
+import * as Urls from "metabase/lib/urls";
+
 import CollectionCreate from "metabase/collections/containers/CollectionCreate";
+
 import { Collection, CollectionId } from "metabase-types/api";
 
 type ModalType = "new-dashboard" | "new-collection";

--- a/frontend/src/metabase/components/NewItemMenu/NewItemMenu.tsx
+++ b/frontend/src/metabase/components/NewItemMenu/NewItemMenu.tsx
@@ -7,11 +7,13 @@ import CreateDashboardModal from "metabase/components/CreateDashboardModal";
 
 import * as Urls from "metabase/lib/urls";
 
+import DataApps from "metabase/entities/data-apps";
+
 import CollectionCreate from "metabase/collections/containers/CollectionCreate";
 
 import { Collection, CollectionId } from "metabase-types/api";
 
-type ModalType = "new-dashboard" | "new-collection";
+type ModalType = "new-app" | "new-dashboard" | "new-collection";
 
 export interface NewItemMenuProps {
   className?: string;
@@ -98,6 +100,12 @@ const NewItemMenu = ({
         action: () => setModal("new-collection"),
         event: `${analyticsContext};New Collection Click;`,
       },
+      {
+        title: t`App`,
+        icon: "star",
+        action: () => setModal("new-app"),
+        event: `${analyticsContext};New App Click;`,
+      },
     );
 
     return items;
@@ -130,6 +138,12 @@ const NewItemMenu = ({
           ) : modal === "new-dashboard" ? (
             <CreateDashboardModal
               collectionId={collectionId}
+              onClose={handleModalClose}
+            />
+          ) : modal === "new-app" ? (
+            <DataApps.ModalForm
+              form={DataApps.forms.details}
+              onSaved={handleModalClose}
               onClose={handleModalClose}
             />
           ) : null}

--- a/frontend/src/metabase/entities/collections/constants.js
+++ b/frontend/src/metabase/entities/collections/constants.js
@@ -1,5 +1,7 @@
 import { t } from "ttag";
 
+export const DEFAULT_COLLECTION_COLOR_ALIAS = "brand";
+
 export const ROOT_COLLECTION = {
   id: "root",
   name: t`Our analytics`,

--- a/frontend/src/metabase/entities/collections/forms.js
+++ b/frontend/src/metabase/entities/collections/forms.js
@@ -10,6 +10,8 @@ import {
   isPersonalCollectionChild,
 } from "metabase/collections/utils";
 
+import { DEFAULT_COLLECTION_COLOR_ALIAS } from "./constants";
+
 function createForm({ extraFields = [] } = {}) {
   return {
     fields: (
@@ -37,7 +39,7 @@ function createForm({ extraFields = [] } = {}) {
         name: "color",
         title: t`Color`,
         type: "hidden",
-        initial: () => color("brand"),
+        initial: () => color(DEFAULT_COLLECTION_COLOR_ALIAS),
         validate: color => !color && t`Color is required`,
       },
       {

--- a/frontend/src/metabase/entities/collections/forms.js
+++ b/frontend/src/metabase/entities/collections/forms.js
@@ -12,6 +12,28 @@ import {
 
 import { DEFAULT_COLLECTION_COLOR_ALIAS } from "./constants";
 
+export function createNameField() {
+  return {
+    name: "name",
+    title: t`Name`,
+    placeholder: t`My new fantastic collection`,
+    autoFocus: true,
+    validate: name =>
+      (!name && t`Name is required`) ||
+      (name && name.length > 100 && t`Name must be 100 characters or less`),
+  };
+}
+
+export function createDescriptionField() {
+  return {
+    name: "description",
+    title: t`Description`,
+    type: "text",
+    placeholder: t`It's optional but oh, so helpful`,
+    normalize: description => description || null, // expected to be nil or non-empty string
+  };
+}
+
 function createForm({ extraFields = [] } = {}) {
   return {
     fields: (
@@ -19,22 +41,8 @@ function createForm({ extraFields = [] } = {}) {
         color: color("brand"),
       },
     ) => [
-      {
-        name: "name",
-        title: t`Name`,
-        placeholder: t`My new fantastic collection`,
-        autoFocus: true,
-        validate: name =>
-          (!name && t`Name is required`) ||
-          (name && name.length > 100 && t`Name must be 100 characters or less`),
-      },
-      {
-        name: "description",
-        title: t`Description`,
-        type: "text",
-        placeholder: t`It's optional but oh, so helpful`,
-        normalize: description => description || null, // expected to be nil or non-empty string
-      },
+      createNameField(),
+      createDescriptionField(),
       {
         name: "color",
         title: t`Color`,

--- a/frontend/src/metabase/entities/data-apps/data-apps.js
+++ b/frontend/src/metabase/entities/data-apps/data-apps.js
@@ -1,0 +1,50 @@
+import { color } from "metabase/lib/colors";
+import { createEntity } from "metabase/lib/entities";
+
+import { DataAppSchema } from "metabase/schema";
+import { CollectionsApi, DataAppsApi } from "metabase/services";
+
+import { DEFAULT_COLLECTION_COLOR_ALIAS } from "../collections/constants";
+
+import { createForm } from "./forms";
+import { getDataAppIcon } from "./utils";
+
+const DataApps = createEntity({
+  name: "dataApps",
+  nameOne: "dataApp",
+
+  displayNameOne: "app",
+  displayNameMany: "apps",
+
+  path: "/api/app",
+  schema: DataAppSchema,
+
+  api: {
+    create: async ({ name, description, ...dataAppProps }) => {
+      const collection = await CollectionsApi.create({
+        name,
+        description: description || null,
+        parent_id: null, // apps should always live in root collection
+        color: color(DEFAULT_COLLECTION_COLOR_ALIAS),
+      });
+      return DataAppsApi.create({
+        ...dataAppProps,
+        collection_id: collection.id,
+      });
+    },
+  },
+
+  objectSelectors: {
+    getIcon: getDataAppIcon,
+  },
+
+  forms: {
+    details: {
+      fields: createForm,
+    },
+  },
+});
+
+export { getDataAppIcon };
+
+export default DataApps;

--- a/frontend/src/metabase/entities/data-apps/data-apps.ts
+++ b/frontend/src/metabase/entities/data-apps/data-apps.ts
@@ -4,10 +4,21 @@ import { createEntity } from "metabase/lib/entities";
 import { DataAppSchema } from "metabase/schema";
 import { CollectionsApi, DataAppsApi } from "metabase/services";
 
+import { Collection, DataApp } from "metabase-types/api";
+
 import { DEFAULT_COLLECTION_COLOR_ALIAS } from "../collections/constants";
 
 import { createForm } from "./forms";
 import { getDataAppIcon } from "./utils";
+
+type EditableDataAppParams = Pick<
+  DataApp,
+  "dashboard_id" | "options" | "nav_items"
+> &
+  Pick<Collection, "name" | "description">;
+
+type CreateDataAppParams = Partial<EditableDataAppParams> &
+  Pick<EditableDataAppParams, "name">;
 
 const DataApps = createEntity({
   name: "dataApps",
@@ -20,7 +31,11 @@ const DataApps = createEntity({
   schema: DataAppSchema,
 
   api: {
-    create: async ({ name, description, ...dataAppProps }) => {
+    create: async ({
+      name,
+      description,
+      ...dataAppProps
+    }: CreateDataAppParams) => {
       const collection = await CollectionsApi.create({
         name,
         description: description || null,

--- a/frontend/src/metabase/entities/data-apps/forms.ts
+++ b/frontend/src/metabase/entities/data-apps/forms.ts
@@ -1,0 +1,5 @@
+import { createNameField, createDescriptionField } from "../collections/forms";
+
+export function createForm() {
+  return [createNameField(), createDescriptionField()];
+}

--- a/frontend/src/metabase/entities/data-apps/index.ts
+++ b/frontend/src/metabase/entities/data-apps/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./data-apps";
+export * from "./data-apps";

--- a/frontend/src/metabase/entities/data-apps/utils.ts
+++ b/frontend/src/metabase/entities/data-apps/utils.ts
@@ -1,0 +1,5 @@
+import { DataApp } from "metabase-types/api";
+
+export function getDataAppIcon(app: DataApp) {
+  return { name: "star" };
+}

--- a/frontend/src/metabase/entities/index.js
+++ b/frontend/src/metabase/entities/index.js
@@ -2,6 +2,7 @@ export { default as actions } from "./actions";
 export { default as alerts } from "./alerts";
 export { default as collections } from "./collections";
 export { default as snippetCollections } from "./snippet-collections";
+export { default as dataApps } from "./data-apps";
 export { default as dashboards } from "./dashboards";
 export { default as databaseCandidates } from "./database-candidates";
 export { default as pulses } from "./pulses";

--- a/frontend/src/metabase/lib/urls/dataApps.ts
+++ b/frontend/src/metabase/lib/urls/dataApps.ts
@@ -1,0 +1,13 @@
+import slugg from "slugg";
+
+import { DataApp } from "metabase-types/api";
+
+import { appendSlug } from "./utils";
+
+function dataAppInternal(app: DataApp) {
+  return appendSlug(`/a/${app.id}`, slugg(app.collection.name));
+}
+
+export function dataApp(app: DataApp) {
+  return dataAppInternal(app);
+}

--- a/frontend/src/metabase/lib/urls/dataApps.ts
+++ b/frontend/src/metabase/lib/urls/dataApps.ts
@@ -4,10 +4,10 @@ import { DataApp } from "metabase-types/api";
 
 import { appendSlug } from "./utils";
 
-function dataAppInternal(app: DataApp) {
+function dataAppInternalPath(app: DataApp) {
   return appendSlug(`/a/${app.id}`, slugg(app.collection.name));
 }
 
 export function dataApp(app: DataApp) {
-  return dataAppInternal(app);
+  return dataAppInternalPath(app);
 }

--- a/frontend/src/metabase/lib/urls/index.ts
+++ b/frontend/src/metabase/lib/urls/index.ts
@@ -2,6 +2,7 @@ export * from "./admin";
 export * from "./browse";
 export * from "./collections";
 export * from "./dashboards";
+export * from "./dataApps";
 export * from "./misc";
 export * from "./pulses";
 export * from "./questions";

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.styled.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.styled.tsx
@@ -135,6 +135,10 @@ export const BrowseLink = styled(SidebarLink)`
   padding-left: 14px;
 `;
 
+export const DataAppLink = styled(SidebarLink)`
+  padding-left: 14px;
+`;
+
 export const AddYourOwnDataLink = styled(SidebarLink)`
   background: ${color("brand")};
   border-radius: 8px;

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarView.tsx
@@ -2,7 +2,7 @@ import React, { useCallback } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
-import { Bookmark, Collection, User } from "metabase-types/api";
+import { Bookmark, Collection, DataApp, User } from "metabase-types/api";
 
 import { IconProps } from "metabase/components/Icon";
 import { Tree } from "metabase/components/tree";
@@ -12,6 +12,7 @@ import {
   getCollectionIcon,
   PERSONAL_COLLECTIONS,
 } from "metabase/entities/collections";
+import { getDataAppIcon } from "metabase/entities/data-apps";
 import { isSmallScreen } from "metabase/lib/dom";
 import * as Urls from "metabase/lib/urls";
 
@@ -24,6 +25,7 @@ import {
   CollectionMenuList,
   CollectionsMoreIcon,
   CollectionsMoreIconContainer,
+  DataAppLink,
   HomePageLink,
   SidebarContentRoot,
   SidebarHeading,
@@ -44,6 +46,7 @@ type Props = {
   hasDataAccess: boolean;
   hasOwnDatabase: boolean;
   collections: CollectionTreeItem[];
+  dataApps: DataApp[];
   selectedItems: SelectedItem[];
   handleCloseNavbar: () => void;
   handleLogout: () => void;
@@ -67,6 +70,7 @@ function MainNavbarView({
   currentUser,
   bookmarks,
   collections,
+  dataApps,
   hasOwnDatabase,
   selectedItems,
   hasDataAccess,
@@ -78,6 +82,7 @@ function MainNavbarView({
     card: cardItem,
     collection: collectionItem,
     dashboard: dashboardItem,
+    "data-app": dataAppItem,
     "non-entity": nonEntityItem,
   } = _.indexBy(selectedItems, item => item.type);
 
@@ -107,7 +112,9 @@ function MainNavbarView({
           <SidebarSection>
             <BookmarkList
               bookmarks={bookmarks}
-              selectedItem={cardItem ?? dashboardItem ?? collectionItem}
+              selectedItem={
+                cardItem ?? dashboardItem ?? dataAppItem ?? collectionItem
+              }
               onSelect={onItemSelect}
               reorderBookmarks={reorderBookmarks}
             />
@@ -127,6 +134,27 @@ function MainNavbarView({
             role="tree"
           />
         </SidebarSection>
+
+        {dataApps.length > 0 && (
+          <SidebarSection>
+            <SidebarHeadingWrapper>
+              <SidebarHeading>{t`Apps`}</SidebarHeading>
+            </SidebarHeadingWrapper>
+            <ul>
+              {dataApps.map(app => (
+                <DataAppLink
+                  key={`app-${app.id}`}
+                  icon={getDataAppIcon(app)}
+                  url={Urls.dataApp(app)}
+                  isSelected={dataAppItem?.id === app.id}
+                >
+                  {app.collection.name}
+                </DataAppLink>
+              ))}
+            </ul>
+          </SidebarSection>
+        )}
+
         <ul>
           {hasDataAccess && (
             <SidebarSection>

--- a/frontend/src/metabase/nav/containers/MainNavbar/types.ts
+++ b/frontend/src/metabase/nav/containers/MainNavbar/types.ts
@@ -1,5 +1,5 @@
 export interface SelectedItem {
-  type: "card" | "collection" | "dashboard" | "non-entity";
+  type: "card" | "collection" | "dashboard" | "data-app" | "non-entity";
   id?: number | string;
   url?: string;
 }

--- a/frontend/src/metabase/routes.jsx
+++ b/frontend/src/metabase/routes.jsx
@@ -70,6 +70,8 @@ import TableQuestionsContainer from "metabase/reference/databases/TableQuestions
 import FieldListContainer from "metabase/reference/databases/FieldListContainer";
 import FieldDetailContainer from "metabase/reference/databases/FieldDetailContainer";
 
+import DataAppLanding from "metabase/writeback/containers/DataAppLanding";
+
 import getAccountRoutes from "metabase/account/routes";
 import getAdminRoutes from "metabase/admin/routes";
 import getCollectionTimelineRoutes from "metabase/timelines/collections/routes";
@@ -215,6 +217,15 @@ export const getRoutes = store => (
         </Route>
 
         <Route path="collection/:slug" component={CollectionLanding}>
+          <ModalRoute path="move" modal={MoveCollectionModal} />
+          <ModalRoute path="archive" modal={ArchiveCollectionModal} />
+          <ModalRoute path="new_collection" modal={CollectionCreate} />
+          <ModalRoute path="new_dashboard" modal={CreateDashboardModal} />
+          <ModalRoute path="permissions" modal={CollectionPermissionsModal} />
+          {getCollectionTimelineRoutes()}
+        </Route>
+
+        <Route path="a/:slug" component={DataAppLanding}>
           <ModalRoute path="move" modal={MoveCollectionModal} />
           <ModalRoute path="archive" modal={ArchiveCollectionModal} />
           <ModalRoute path="new_collection" modal={CollectionCreate} />

--- a/frontend/src/metabase/schema.js
+++ b/frontend/src/metabase/schema.js
@@ -11,6 +11,7 @@ export const PulseSchema = new schema.Entity("pulses");
 export const CollectionSchema = new schema.Entity("collections");
 
 export const DatabaseSchema = new schema.Entity("databases");
+export const DataAppSchema = new schema.Entity("dataApps");
 export const SchemaSchema = new schema.Entity("schemas");
 export const TableSchema = new schema.Entity(
   "tables",
@@ -91,9 +92,14 @@ TimelineSchema.define({
   events: [TimelineEventSchema],
 });
 
+DataAppSchema.define({
+  collection: CollectionSchema,
+});
+
 export const ENTITIES_SCHEMA_MAP = {
   questions: QuestionSchema,
   bookmarks: BookmarkSchema,
+  dataApps: DataAppSchema,
   dashboards: DashboardSchema,
   pulses: PulseSchema,
   collections: CollectionSchema,

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -180,6 +180,12 @@ export const CollectionsApi = {
   updateGraph: PUT("/api/collection/graph"),
 };
 
+export const DataAppsApi = {
+  list: GET("/api/app"),
+  create: POST("/api/app"),
+  update: PUT("/api/app"),
+};
+
 const PIVOT_PUBLIC_PREFIX = "/api/public/pivot/";
 
 export const PublicApi = {

--- a/frontend/src/metabase/writeback/containers/DataAppLanding.tsx
+++ b/frontend/src/metabase/writeback/containers/DataAppLanding.tsx
@@ -1,0 +1,35 @@
+import React, { ReactNode } from "react";
+
+import { extractCollectionId } from "metabase/lib/urls";
+
+import DataApps from "metabase/entities/data-apps";
+
+import CollectionContent from "metabase/collections/containers/CollectionContent";
+
+import { DataApp } from "metabase-types/api";
+import { State } from "metabase-types/store";
+
+interface DataAppLandingOwnProps {
+  params: {
+    slug: string;
+  };
+  children?: ReactNode;
+}
+
+interface DataAppLandingProps extends DataAppLandingOwnProps {
+  dataApp: DataApp;
+}
+
+const DataAppLanding = ({ dataApp, children }: DataAppLandingProps) => {
+  return (
+    <>
+      <CollectionContent collectionId={dataApp.collection_id} isRoot={false} />
+      {children}
+    </>
+  );
+};
+
+export default DataApps.load({
+  id: (state: State, { params }: DataAppLandingOwnProps) =>
+    extractCollectionId(params.slug),
+})(DataAppLanding);


### PR DESCRIPTION
Part of #24861. Specifically resolves #24918, resolves #24919, and resolves #24920.

Implements a new Data App entity and basic "New App" flow started from the "+ New" button. Technically, we're building apps on top of collections as they share a lot of logic (they contain other entities, you should be able to save other entities inside an app, collection permissions, etc.). It's worth mentioning though that apps are not another type of collection; we're just reusing most of their logic under the hood. This leads to a list of known issues we're going to tackle in subsequent PRs:

* archiving an app doesn't remove it from the sidebar
* apps look like collections in pickers, bookmarks bar, search, recent items, etc
* there is a lot of "collection" wording around apps we're going to fix (the collection UI is temporary)
* "move" collection action is not suitable for apps

### To Verify

1. Click the "+ New" button at the top right
2. Select "App", fill in your name and optionally a description, and click "Save"
3. Your app should appear in a dedicated "Apps" section in the nav sidebar
4. Click it; you should end up on the `/a/:app-id-app-name` URL and for now, see a usual empty collection page

### Demo

https://user-images.githubusercontent.com/17258145/186183393-e8a74231-5ae9-481c-9035-a65deb257697.mp4

