### PR TITLE
Fix click-and-drag filtering in dashboards for firefox

### DIFF
--- a/frontend/src/metabase/visualizations/lib/graph/brush.js
+++ b/frontend/src/metabase/visualizations/lib/graph/brush.js
@@ -19,6 +19,8 @@ export function initBrush(parent, child, onBrushChange, onBrushEnd) {
   let cancelled = false;
   // the last updated range when brushing
   let range = null;
+  // remove deprecated createSVGPoint to fix d3.mouse bug (metabase#24912)
+  SVGSVGElement.prototype.createSVGPoint = undefined;
 
   // start
   parent.brush().on("brushstart.custom", () => {

--- a/frontend/src/metabase/visualizations/lib/graph/brush.js
+++ b/frontend/src/metabase/visualizations/lib/graph/brush.js
@@ -19,8 +19,11 @@ export function initBrush(parent, child, onBrushChange, onBrushEnd) {
   let cancelled = false;
   // the last updated range when brushing
   let range = null;
-  // remove deprecated createSVGPoint to fix d3.mouse bug (metabase#24912)
-  SVGSVGElement.prototype.createSVGPoint = undefined;
+
+  // remove deprecated createSVGPoint to fix d3.mouse firefox bug (metabase#24912)
+  if (SVGSVGElement.prototype.createSVGPoint) {
+    SVGSVGElement.prototype.createSVGPoint = undefined;
+  }
 
   // start
   parent.brush().on("brushstart.custom", () => {


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/24912

How to test:
- Follow the steps from the issue in **Firefox**
- You should get the correct filtering range while and after dragging