### PR TITLE
24840 reordering funnel charts

### DIFF
--- a/frontend/src/metabase/lib/dataset.js
+++ b/frontend/src/metabase/lib/dataset.js
@@ -82,11 +82,6 @@ export function findColumnForColumnSetting(columns, columnSetting) {
   }
 }
 
-export function findRowForColumnSetting(rows, rowSetting) {
-  console.log("dataset", rows, rowSetting);
-  return rows.find(r => r.rowIndex === rowSetting.rowId);
-}
-
 export function normalizeFieldRef(fieldRef) {
   const dimension = Dimension.parseMBQL(fieldRef);
   return dimension && dimension.mbql();

--- a/frontend/src/metabase/lib/dataset.js
+++ b/frontend/src/metabase/lib/dataset.js
@@ -82,6 +82,11 @@ export function findColumnForColumnSetting(columns, columnSetting) {
   }
 }
 
+export function findRowForColumnSetting(rows, rowSetting) {
+  console.log("dataset", rows, rowSetting);
+  return rows.find(r => r.rowIndex === rowSetting.rowId);
+}
+
 export function normalizeFieldRef(fieldRef) {
   const dimension = Dimension.parseMBQL(fieldRef);
   return dimension && dimension.mbql();

--- a/frontend/src/metabase/visualizations/components/FunnelNormal.jsx
+++ b/frontend/src/metabase/visualizations/components/FunnelNormal.jsx
@@ -26,7 +26,6 @@ export default class FunnelNormal extends Component {
     const dimensionIndex = 0;
     const metricIndex = 1;
     const cols = series[0].data.cols;
-    //console.log(settings, series);
     const rows = settings["funnel.rows"]
       ? settings["funnel.rows"]
           .filter(fr => fr.enabled)

--- a/frontend/src/metabase/visualizations/components/FunnelNormal.jsx
+++ b/frontend/src/metabase/visualizations/components/FunnelNormal.jsx
@@ -27,11 +27,12 @@ export default class FunnelNormal extends Component {
     const metricIndex = 1;
     const cols = series[0].data.cols;
     //console.log(settings, series);
-    const rows = settings["funnel.columns"]
-      ? settings["funnel.columns"]
-          .filter(fc => fc.enabled)
+    const rows = settings["funnel.rows"]
+      ? settings["funnel.rows"]
+          .filter(fr => fr.enabled)
           .map(
-            fc => series.find(s => s.card.rowIndex === fc.rowId).data.rows[0],
+            fr =>
+              series.find(s => s.card.rowIndex === fr.rowIndex).data.rows[0],
           )
       : series.map(s => s.data.rows[0]);
 

--- a/frontend/src/metabase/visualizations/components/FunnelNormal.jsx
+++ b/frontend/src/metabase/visualizations/components/FunnelNormal.jsx
@@ -29,10 +29,7 @@ export default class FunnelNormal extends Component {
     const rows = settings["funnel.rows"]
       ? settings["funnel.rows"]
           .filter(fr => fr.enabled)
-          .map(
-            fr =>
-              series.find(s => s.card.rowIndex === fr.rowIndex).data.rows[0],
-          )
+          .map(fr => series[fr.rowIndex].data.rows[0])
       : series.map(s => s.data.rows[0]);
 
     const isNarrow = gridSize && gridSize.width < 7;

--- a/frontend/src/metabase/visualizations/components/FunnelNormal.jsx
+++ b/frontend/src/metabase/visualizations/components/FunnelNormal.jsx
@@ -26,10 +26,13 @@ export default class FunnelNormal extends Component {
     const dimensionIndex = 0;
     const metricIndex = 1;
     const cols = series[0].data.cols;
+    //console.log(settings, series);
     const rows = settings["funnel.columns"]
       ? settings["funnel.columns"]
           .filter(fc => fc.enabled)
-          .map(fc => series.find(s => s.card.name === fc.name).data.rows[0])
+          .map(
+            fc => series.find(s => s.card.rowIndex === fc.rowId).data.rows[0],
+          )
       : series.map(s => s.data.rows[0]);
 
     const isNarrow = gridSize && gridSize.width < 7;

--- a/frontend/src/metabase/visualizations/components/FunnelNormal.jsx
+++ b/frontend/src/metabase/visualizations/components/FunnelNormal.jsx
@@ -26,7 +26,11 @@ export default class FunnelNormal extends Component {
     const dimensionIndex = 0;
     const metricIndex = 1;
     const cols = series[0].data.cols;
-    const rows = series.map(s => s.data.rows[0]);
+    const rows = settings["funnel.columns"]
+      ? settings["funnel.columns"]
+          .filter(fc => fc.enabled)
+          .map(fc => series.find(s => s.card.name === fc.name).data.rows[0])
+      : series.map(s => s.data.rows[0]);
 
     const isNarrow = gridSize && gridSize.width < 7;
     const isShort = gridSize && gridSize.height <= 5;

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx
@@ -3,10 +3,6 @@ import React, { Component } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
-import {
-  SortableContainer,
-  SortableElement,
-} from "metabase/components/sortable";
 import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
 import {
   keyForColumn,
@@ -17,35 +13,7 @@ import { getFriendlyName } from "metabase/visualizations/lib/utils";
 
 import ColumnItem from "./ColumnItem";
 
-const SortableColumn = SortableElement(
-  ({ columnSetting, getColumnName, onEdit, onRemove }) => (
-    <ColumnItem
-      title={getColumnName(columnSetting)}
-      onEdit={onEdit ? () => onEdit(columnSetting) : null}
-      onRemove={onRemove ? () => onRemove(columnSetting) : null}
-      draggable
-    />
-  ),
-);
-
-const SortableColumnList = SortableContainer(
-  ({ columnSettings, getColumnName, onEdit, onRemove }) => {
-    return (
-      <div>
-        {columnSettings.map((columnSetting, index) => (
-          <SortableColumn
-            key={`item-${index}`}
-            index={columnSetting.index}
-            columnSetting={columnSetting}
-            getColumnName={getColumnName}
-            onEdit={onEdit}
-            onRemove={onRemove}
-          />
-        ))}
-      </div>
-    );
-  },
-);
+import { ChartSettingOrderedItems } from "./ChartSettingOrderedItems";
 
 export default class ChartSettingOrderedColumns extends Component {
   handleEnable = columnSetting => {
@@ -103,21 +71,11 @@ export default class ChartSettingOrderedColumns extends Component {
   };
 
   render() {
-    const {
-      value,
-      question,
-      columns,
-      allowAdditionalFieldOptions = true,
-      rowMode = false,
-    } = this.props;
+    const { value, question, columns } = this.props;
     const query = question && question.query();
 
     let additionalFieldOptions = { count: 0 };
-    if (
-      columns &&
-      query instanceof StructuredQuery &&
-      allowAdditionalFieldOptions
-    ) {
+    if (columns && query instanceof StructuredQuery) {
       additionalFieldOptions = query.fieldsOptions(dimension => {
         return !_.find(columns, column =>
           dimension.isSameBaseDimension(column.field_ref),
@@ -128,22 +86,18 @@ export default class ChartSettingOrderedColumns extends Component {
     const [enabledColumns, disabledColumns] = _.partition(
       value
         .filter(columnSetting =>
-          rowMode
-            ? findRowForColumnSetting(columns, columnSetting)
-            : findColumnForColumnSetting(columns, columnSetting),
+          findColumnForColumnSetting(columns, columnSetting),
         )
         .map((columnSetting, index) => ({ ...columnSetting, index })),
       columnSetting => columnSetting.enabled,
     );
 
-    // console.log(value, columns);
-
     return (
       <div className="list">
         {enabledColumns.length > 0 ? (
-          <SortableColumnList
-            columnSettings={enabledColumns}
-            getColumnName={this.getColumnName}
+          <ChartSettingOrderedItems
+            items={enabledColumns}
+            getItemName={this.getColumnName}
             onEdit={this.handleEdit}
             onRemove={this.handleDisable}
             onSortEnd={this.handleSortEnd}

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx
@@ -4,11 +4,7 @@ import { t } from "ttag";
 import _ from "underscore";
 
 import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
-import {
-  keyForColumn,
-  findColumnForColumnSetting,
-  findRowForColumnSetting,
-} from "metabase/lib/dataset";
+import { keyForColumn, findColumnForColumnSetting } from "metabase/lib/dataset";
 import { getFriendlyName } from "metabase/visualizations/lib/utils";
 
 import ColumnItem from "./ColumnItem";
@@ -31,7 +27,6 @@ export default class ChartSettingOrderedColumns extends Component {
   };
 
   handleSortEnd = ({ oldIndex, newIndex }) => {
-    console.log(oldIndex, newIndex);
     const fields = [...this.props.value];
     fields.splice(newIndex, 0, fields.splice(oldIndex, 1)[0]);
     this.props.onChange(fields);
@@ -58,17 +53,12 @@ export default class ChartSettingOrderedColumns extends Component {
     onChange(columnSettings);
   };
 
-  getColumnName = columnSetting => {
-    const columnOrRow = this.props.rowMode
-      ? findRowForColumnSetting(this.props.columns, columnSetting)
-      : findColumnForColumnSetting(this.props.columns, columnSetting);
-
-    return getFriendlyName(
-      columnOrRow || {
+  getColumnName = columnSetting =>
+    getFriendlyName(
+      findColumnForColumnSetting(this.props.columns, columnSetting) || {
         display_name: "[Unknown]",
       },
     );
-  };
 
   render() {
     const { value, question, columns } = this.props;

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx
@@ -8,7 +8,11 @@ import {
   SortableElement,
 } from "metabase/components/sortable";
 import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
-import { keyForColumn, findColumnForColumnSetting } from "metabase/lib/dataset";
+import {
+  keyForColumn,
+  findColumnForColumnSetting,
+  findRowForColumnSetting,
+} from "metabase/lib/dataset";
 import { getFriendlyName } from "metabase/visualizations/lib/utils";
 
 import ColumnItem from "./ColumnItem";
@@ -59,6 +63,7 @@ export default class ChartSettingOrderedColumns extends Component {
   };
 
   handleSortEnd = ({ oldIndex, newIndex }) => {
+    console.log(oldIndex, newIndex);
     const fields = [...this.props.value];
     fields.splice(newIndex, 0, fields.splice(oldIndex, 1)[0]);
     this.props.onChange(fields);
@@ -85,12 +90,17 @@ export default class ChartSettingOrderedColumns extends Component {
     onChange(columnSettings);
   };
 
-  getColumnName = columnSetting =>
-    getFriendlyName(
-      findColumnForColumnSetting(this.props.columns, columnSetting) || {
+  getColumnName = columnSetting => {
+    const columnOrRow = this.props.rowMode
+      ? findRowForColumnSetting(this.props.columns, columnSetting)
+      : findColumnForColumnSetting(this.props.columns, columnSetting);
+
+    return getFriendlyName(
+      columnOrRow || {
         display_name: "[Unknown]",
       },
     );
+  };
 
   render() {
     const {
@@ -98,6 +108,7 @@ export default class ChartSettingOrderedColumns extends Component {
       question,
       columns,
       allowAdditionalFieldOptions = true,
+      rowMode = false,
     } = this.props;
     const query = question && question.query();
 
@@ -117,13 +128,15 @@ export default class ChartSettingOrderedColumns extends Component {
     const [enabledColumns, disabledColumns] = _.partition(
       value
         .filter(columnSetting =>
-          findColumnForColumnSetting(columns, columnSetting),
+          rowMode
+            ? findRowForColumnSetting(columns, columnSetting)
+            : findColumnForColumnSetting(columns, columnSetting),
         )
         .map((columnSetting, index) => ({ ...columnSetting, index })),
       columnSetting => columnSetting.enabled,
     );
 
-    console.log(value, columns);
+    // console.log(value, columns);
 
     return (
       <div className="list">

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx
@@ -93,11 +93,20 @@ export default class ChartSettingOrderedColumns extends Component {
     );
 
   render() {
-    const { value, question, columns } = this.props;
+    const {
+      value,
+      question,
+      columns,
+      allowAdditionalFieldOptions = true,
+    } = this.props;
     const query = question && question.query();
 
     let additionalFieldOptions = { count: 0 };
-    if (columns && query instanceof StructuredQuery) {
+    if (
+      columns &&
+      query instanceof StructuredQuery &&
+      allowAdditionalFieldOptions
+    ) {
       additionalFieldOptions = query.fieldsOptions(dimension => {
         return !_.find(columns, column =>
           dimension.isSameBaseDimension(column.field_ref),
@@ -113,6 +122,8 @@ export default class ChartSettingOrderedColumns extends Component {
         .map((columnSetting, index) => ({ ...columnSetting, index })),
       columnSetting => columnSetting.enabled,
     );
+
+    console.log(value, columns);
 
     return (
       <div className="list">

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedItems.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedItems.tsx
@@ -1,0 +1,113 @@
+import React from "react";
+
+import {
+  SortableContainer,
+  SortableElement,
+} from "metabase/components/sortable";
+
+import ColumnItem from "./ColumnItem";
+
+interface SortableColumnFunctions {
+  onRemove?: (item: any) => void;
+  onEdit?: (item: any) => void;
+  onClick?: (item: any) => void;
+  onAdd?: (item: any) => void;
+  onEnable?: (item: any) => void;
+  getItemName: (item: any) => string;
+}
+
+interface SortableColumnProps extends SortableColumnFunctions {
+  item: any;
+}
+
+const SortableColumn = SortableElement(
+  ({
+    item,
+    getItemName,
+    onEdit,
+    onRemove,
+    onClick,
+    onAdd,
+    onEnable,
+  }: SortableColumnProps) => (
+    <ColumnItem
+      title={getItemName(item)}
+      onEdit={onEdit ? () => onEdit(item) : null}
+      onRemove={onRemove && item.enabled ? () => onRemove(item) : null}
+      onClick={onClick ? () => onClick(item) : null}
+      onAdd={onAdd ? () => onAdd(item) : null}
+      onEnable={onEnable && !item.enabled ? () => onEnable(item) : null}
+      draggable
+    />
+  ),
+);
+
+interface SortableColumnListProps extends SortableColumnFunctions {
+  items: [];
+}
+
+const SortableColumnList = SortableContainer(
+  ({
+    items,
+    getItemName,
+    onEdit,
+    onRemove,
+    onEnable,
+    onAdd,
+  }: SortableColumnListProps) => {
+    return (
+      <div>
+        {items.map((item: any, index: number) => (
+          <SortableColumn
+            key={`item-${index}`}
+            index={index}
+            item={item}
+            getItemName={getItemName}
+            onEdit={onEdit}
+            onRemove={onRemove}
+            onEnable={onEnable}
+            onAdd={onAdd}
+          />
+        ))}
+      </div>
+    );
+  },
+);
+
+interface ChartSettingOrderedItemsProps extends SortableColumnFunctions {
+  onSortEnd: ({
+    oldIndex,
+    newIndex,
+  }: {
+    oldIndex: number;
+    newIndex: number;
+  }) => void;
+  items: any[];
+  distance: number;
+}
+
+export const ChartSettingOrderedItems = ({
+  onRemove,
+  onSortEnd,
+  onEdit,
+  onAdd,
+  onEnable,
+  onClick,
+  getItemName,
+  items,
+}: ChartSettingOrderedItemsProps) => {
+  return (
+    <SortableColumnList
+      helperClass=""
+      items={items}
+      getItemName={getItemName}
+      onEdit={onEdit}
+      onRemove={onRemove}
+      onAdd={onAdd}
+      onEnable={onEnable}
+      onClick={onClick}
+      onSortEnd={onSortEnd}
+      distance={5}
+    />
+  );
+};

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedItems.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedItems.tsx
@@ -1,14 +1,17 @@
-import React from "react";
+import React, { ReactElement } from "react";
 
 import {
   SortableContainer,
   SortableElement,
 } from "metabase/components/sortable";
 
+import type { SortableElementProps } from "react-sortable-hoc";
+
 import ColumnItem from "./ColumnItem";
 
 interface SortableItem {
   enabled: boolean;
+  [key: string]: any;
 }
 
 interface SortableColumnFunctions<T> {
@@ -46,7 +49,9 @@ const SortableColumn = SortableElement(function SortableColumn<
       draggable
     />
   );
-});
+}) as unknown as <T extends SortableItem>(
+  props: SortableColumnProps<T> & SortableElementProps,
+) => ReactElement;
 
 interface SortableColumnListProps<T extends SortableItem>
   extends SortableColumnFunctions<T> {
@@ -66,7 +71,7 @@ const SortableColumnList = SortableContainer(function SortableColumnList<
   return (
     <div>
       {items.map((item, index: number) => (
-        <SortableColumn<T>
+        <SortableColumn
           key={`item-${index}`}
           index={index}
           item={item}

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedItems.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedItems.tsx
@@ -7,29 +7,35 @@ import {
 
 import ColumnItem from "./ColumnItem";
 
-interface SortableColumnFunctions {
-  onRemove?: (item: any) => void;
-  onEdit?: (item: any) => void;
-  onClick?: (item: any) => void;
-  onAdd?: (item: any) => void;
-  onEnable?: (item: any) => void;
-  getItemName: (item: any) => string;
+interface SortableItem {
+  enabled: boolean;
 }
 
-interface SortableColumnProps extends SortableColumnFunctions {
-  item: any;
+interface SortableColumnFunctions<T> {
+  onRemove?: (item: T) => void;
+  onEdit?: (item: T) => void;
+  onClick?: (item: T) => void;
+  onAdd?: (item: T) => void;
+  onEnable?: (item: T) => void;
+  getItemName: (item: T) => string;
 }
 
-const SortableColumn = SortableElement(
-  ({
-    item,
-    getItemName,
-    onEdit,
-    onRemove,
-    onClick,
-    onAdd,
-    onEnable,
-  }: SortableColumnProps) => (
+interface SortableColumnProps<T> extends SortableColumnFunctions<T> {
+  item: T;
+}
+
+const SortableColumn = SortableElement(function SortableColumn<
+  T extends SortableItem,
+>({
+  item,
+  getItemName,
+  onEdit,
+  onRemove,
+  onClick,
+  onAdd,
+  onEnable,
+}: SortableColumnProps<T>) {
+  return (
     <ColumnItem
       title={getItemName(item)}
       onEdit={onEdit ? () => onEdit(item) : null}
@@ -39,42 +45,44 @@ const SortableColumn = SortableElement(
       onEnable={onEnable && !item.enabled ? () => onEnable(item) : null}
       draggable
     />
-  ),
-);
+  );
+});
 
-interface SortableColumnListProps extends SortableColumnFunctions {
-  items: [];
+interface SortableColumnListProps<T extends SortableItem>
+  extends SortableColumnFunctions<T> {
+  items: T[];
 }
 
-const SortableColumnList = SortableContainer(
-  ({
-    items,
-    getItemName,
-    onEdit,
-    onRemove,
-    onEnable,
-    onAdd,
-  }: SortableColumnListProps) => {
-    return (
-      <div>
-        {items.map((item: any, index: number) => (
-          <SortableColumn
-            key={`item-${index}`}
-            index={index}
-            item={item}
-            getItemName={getItemName}
-            onEdit={onEdit}
-            onRemove={onRemove}
-            onEnable={onEnable}
-            onAdd={onAdd}
-          />
-        ))}
-      </div>
-    );
-  },
-);
+const SortableColumnList = SortableContainer(function SortableColumnList<
+  T extends SortableItem,
+>({
+  items,
+  getItemName,
+  onEdit,
+  onRemove,
+  onEnable,
+  onAdd,
+}: SortableColumnListProps<T>) {
+  return (
+    <div>
+      {items.map((item, index: number) => (
+        <SortableColumn<T>
+          key={`item-${index}`}
+          index={index}
+          item={item}
+          getItemName={getItemName}
+          onEdit={onEdit}
+          onRemove={onRemove}
+          onEnable={onEnable}
+          onAdd={onAdd}
+        />
+      ))}
+    </div>
+  );
+});
 
-interface ChartSettingOrderedItemsProps extends SortableColumnFunctions {
+interface ChartSettingOrderedItemsProps<T>
+  extends SortableColumnFunctions<SortableItem> {
   onSortEnd: ({
     oldIndex,
     newIndex,
@@ -82,11 +90,11 @@ interface ChartSettingOrderedItemsProps extends SortableColumnFunctions {
     oldIndex: number;
     newIndex: number;
   }) => void;
-  items: any[];
+  items: T[];
   distance: number;
 }
 
-export const ChartSettingOrderedItems = ({
+export function ChartSettingOrderedItems<T extends SortableItem>({
   onRemove,
   onSortEnd,
   onEdit,
@@ -95,10 +103,10 @@ export const ChartSettingOrderedItems = ({
   onClick,
   getItemName,
   items,
-}: ChartSettingOrderedItemsProps) => {
+}: ChartSettingOrderedItemsProps<T>) {
   return (
     <SortableColumnList
-      helperClass=""
+      helperClass="dragging"
       items={items}
       getItemName={getItemName}
       onEdit={onEdit}
@@ -110,4 +118,4 @@ export const ChartSettingOrderedItems = ({
       distance={5}
     />
   );
-};
+}

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedItems.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedItems.tsx
@@ -11,7 +11,6 @@ import ColumnItem from "./ColumnItem";
 
 interface SortableItem {
   enabled: boolean;
-  [key: string]: any;
 }
 
 interface SortableColumnFunctions<T> {
@@ -86,8 +85,8 @@ const SortableColumnList = SortableContainer(function SortableColumnList<
   );
 });
 
-interface ChartSettingOrderedItemsProps<T>
-  extends SortableColumnFunctions<SortableItem> {
+interface ChartSettingOrderedItemsProps<T extends SortableItem>
+  extends SortableColumnFunctions<T> {
   onSortEnd: ({
     oldIndex,
     newIndex,

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedRows.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedRows.styled.tsx
@@ -1,0 +1,18 @@
+import styled from "@emotion/styled";
+import { color } from "metabase/lib/colors";
+
+export const ChartSettingOrderedRowsRoot = styled.div`
+  margin-left: 0.5rem;
+`;
+
+export const ChartSettingMessage = styled.div`
+  margin: 1rem 0;
+  padding: 1rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: ${color("bg-light")};
+  color: ${color("text-light")};
+  font-weight: 700;
+  border-radius: 0.5rem;
+`;

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedRows.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedRows.tsx
@@ -1,3 +1,4 @@
+import { updateIn } from "icepick";
 import React from "react";
 import { t } from "ttag";
 
@@ -10,7 +11,7 @@ import {
 
 interface Row {
   rowIndex: number;
-  display_name: string;
+  name: string;
   enabled: boolean;
 }
 
@@ -23,13 +24,18 @@ interface ChartSettingOrderedRowsProps {
 export const ChartSettingOrderedRows = ({
   onChange,
   rows,
-  value,
+  value: orderedRows,
 }: ChartSettingOrderedRowsProps) => {
-  const handleDisable = (row: any) => {
-    const rowsCopy = [...value];
-    const index = rowsCopy.findIndex((r: Row) => r.rowIndex === row.rowIndex);
-    rowsCopy[index] = { ...rowsCopy[index], enabled: !row.enabled };
-    onChange(rowsCopy);
+  const handleDisable = (row: Row) => {
+    const index = orderedRows.findIndex(
+      (r: Row) => r.rowIndex === row.rowIndex,
+    );
+    onChange(
+      updateIn(orderedRows, [index], row => ({
+        ...row,
+        enabled: !row.enabled,
+      })),
+    );
   };
 
   const handleSortEnd = ({
@@ -39,23 +45,22 @@ export const ChartSettingOrderedRows = ({
     oldIndex: number;
     newIndex: number;
   }) => {
-    const rowsCopy = [...value];
+    const rowsCopy = [...orderedRows];
     rowsCopy.splice(newIndex, 0, rowsCopy.splice(oldIndex, 1)[0]);
     onChange(rowsCopy);
   };
 
   const getRowTitle = (row: Row) => {
     return (
-      rows.find((r: Row) => r.rowIndex === row.rowIndex)?.display_name ||
-      "Unknown"
+      rows.find((r: Row) => r.rowIndex === row.rowIndex)?.name || "Unknown"
     );
   };
 
   return (
     <ChartSettingOrderedRowsRoot>
-      {value.length > 0 ? (
+      {orderedRows.length > 0 ? (
         <ChartSettingOrderedItems
-          items={value}
+          items={orderedRows}
           getItemName={getRowTitle}
           onRemove={handleDisable}
           onEnable={handleDisable}

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedRows.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedRows.tsx
@@ -10,9 +10,9 @@ import {
 } from "./ChartSettingOrderedRows.styled";
 
 interface Row {
+  enabled: boolean;
   rowIndex: number;
   name: string;
-  enabled: boolean;
 }
 
 interface ChartSettingOrderedRowsProps {
@@ -27,9 +27,7 @@ export const ChartSettingOrderedRows = ({
   value: orderedRows,
 }: ChartSettingOrderedRowsProps) => {
   const handleDisable = (row: Row) => {
-    const index = orderedRows.findIndex(
-      (r: Row) => r.rowIndex === row.rowIndex,
-    );
+    const index = orderedRows.findIndex(r => r.rowIndex === row.rowIndex);
     onChange(
       updateIn(orderedRows, [index], row => ({
         ...row,
@@ -51,9 +49,7 @@ export const ChartSettingOrderedRows = ({
   };
 
   const getRowTitle = (row: Row) => {
-    return (
-      rows.find((r: Row) => r.rowIndex === row.rowIndex)?.name || "Unknown"
-    );
+    return rows.find(r => r.rowIndex === row.rowIndex)?.name || "Unknown";
   };
 
   return (

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedRows.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedRows.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import { t } from "ttag";
+
+import { ChartSettingOrderedItems } from "./ChartSettingOrderedItems";
+
+import {
+  ChartSettingMessage,
+  ChartSettingOrderedRowsRoot,
+} from "./ChartSettingOrderedRows.styled";
+
+interface Row {
+  rowIndex: number;
+  display_name: string;
+  enabled: boolean;
+}
+
+interface ChartSettingOrderedRowsProps {
+  onChange: (rows: Row[]) => void;
+  rows: Row[];
+  value: Row[];
+}
+
+export const ChartSettingOrderedRows = ({
+  onChange,
+  rows,
+  value,
+}: ChartSettingOrderedRowsProps) => {
+  const handleDisable = (row: any) => {
+    const rowsCopy = [...value];
+    const index = rowsCopy.findIndex((r: Row) => r.rowIndex === row.rowIndex);
+    rowsCopy[index] = { ...rowsCopy[index], enabled: !row.enabled };
+    onChange(rowsCopy);
+  };
+
+  const handleSortEnd = ({
+    oldIndex,
+    newIndex,
+  }: {
+    oldIndex: number;
+    newIndex: number;
+  }) => {
+    const rowsCopy = [...value];
+    rowsCopy.splice(newIndex, 0, rowsCopy.splice(oldIndex, 1)[0]);
+    onChange(rowsCopy);
+  };
+
+  const getRowTitle = (row: Row) => {
+    return (
+      rows.find((r: Row) => r.rowIndex === row.rowIndex)?.display_name ||
+      "Unknown"
+    );
+  };
+
+  return (
+    <ChartSettingOrderedRowsRoot>
+      {value.length > 0 ? (
+        <ChartSettingOrderedItems
+          items={value}
+          getItemName={getRowTitle}
+          onRemove={handleDisable}
+          onEnable={handleDisable}
+          onSortEnd={handleSortEnd}
+          distance={5}
+        />
+      ) : (
+        <ChartSettingMessage>{t`Nothing to order`}</ChartSettingMessage>
+      )}
+    </ChartSettingOrderedRowsRoot>
+  );
+};

--- a/frontend/src/metabase/visualizations/components/settings/ColumnItem.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ColumnItem.jsx
@@ -20,7 +20,15 @@ const ActionIcon = ({ icon, onClick }) => (
   />
 );
 
-const ColumnItem = ({ title, onAdd, onRemove, onClick, onEdit, draggable }) => (
+const ColumnItem = ({
+  title,
+  onAdd,
+  onRemove,
+  onClick,
+  onEdit,
+  onEnable,
+  draggable,
+}) => (
   <ColumnItemRoot draggable={draggable} onClick={onClick}>
     <ColumnItemContainer>
       {draggable && <ColumnItemDragHandle name="grabber2" />}
@@ -29,6 +37,7 @@ const ColumnItem = ({ title, onAdd, onRemove, onClick, onEdit, draggable }) => (
         {onEdit && <ActionIcon icon="ellipsis" onClick={onEdit} />}
         {onAdd && <ActionIcon icon="add" onClick={onAdd} />}
         {onRemove && <ActionIcon icon="eye_filled" onClick={onRemove} />}
+        {onEnable && <ActionIcon icon="eye_crossed_out" onClick={onEnable} />}
       </ColumnItemContent>
     </ColumnItemContainer>
   </ColumnItemRoot>

--- a/frontend/src/metabase/visualizations/components/settings/ColumnItem.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ColumnItem.styled.tsx
@@ -12,6 +12,11 @@ export const ColumnItemRoot = styled.div`
   border-radius: 0.5rem;
   background: ${color("white")};
 
+  &.dragging {
+    cursor: grabbing;
+    pointer-events: auto !important;
+  }
+
   ${props =>
     props.draggable &&
     `

--- a/frontend/src/metabase/visualizations/visualizations/Funnel.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Funnel.jsx
@@ -26,6 +26,7 @@ import _ from "underscore";
 import cx from "classnames";
 
 import ChartCaption from "metabase/visualizations/components/ChartCaption";
+import ChartSettingOrderedColumns from "metabase/visualizations/components/settings/ChartSettingOrderedColumns";
 
 const propTypes = {
   headerIcon: PropTypes.shape(iconPropTypes),
@@ -109,6 +110,22 @@ export default class Funnel extends Component {
       useRawSeries: true,
       showColumnSetting: true,
     }),
+    "funnel.columns": {
+      section: t`Data`,
+      title: t`Breakouts`,
+      widget: ChartSettingOrderedColumns,
+      getDefault: props => {
+        console.log(props);
+        return props.map(p => ({
+          name: p.card.name,
+          enabled: true,
+        }));
+      },
+      getProps: props => ({
+        columns: props.map(p => ({ ...p.card, display_name: p.card.name })),
+        allowAdditionalFieldOptions: false,
+      }),
+    },
     ...metricSetting("funnel.metric", {
       section: t`Data`,
       title: t`Measure`,

--- a/frontend/src/metabase/visualizations/visualizations/Funnel.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Funnel.jsx
@@ -26,7 +26,7 @@ import _ from "underscore";
 import cx from "classnames";
 
 import ChartCaption from "metabase/visualizations/components/ChartCaption";
-import ChartSettingOrderedColumns from "metabase/visualizations/components/settings/ChartSettingOrderedColumns";
+import { ChartSettingOrderedRows } from "metabase/visualizations/components/settings/ChartSettingOrderedRows";
 
 const propTypes = {
   headerIcon: PropTypes.shape(iconPropTypes),
@@ -110,30 +110,33 @@ export default class Funnel extends Component {
       useRawSeries: true,
       showColumnSetting: true,
     }),
-    "funnel.columns": {
+    "funnel.rows": {
       section: t`Data`,
-      title: t`Breakouts`,
-      widget: ChartSettingOrderedColumns,
-      isValid: series => {
-        //console.log('is valid', series);
+      widget: ChartSettingOrderedRows,
+      isValid: (series, settings) => {
+        const setting = settings["funnel.rows"];
 
-        return true;
+        if (!setting || !_.isArray(setting)) {
+          return false;
+        }
+
+        return setting.reduce((memo, value) => {
+          return memo || !!value.rowIndex;
+        }, false);
       },
+
       getDefault: transformedSeries => {
-        // console.log(transformedSeries);
         return transformedSeries.map(s => ({
           name: s.card.name,
-          rowId: s.card.rowIndex,
+          rowIndex: s.card.rowIndex,
           enabled: true,
         }));
       },
       getProps: transformedSeries => ({
-        columns: transformedSeries.map(s => ({
+        rows: transformedSeries.map(s => ({
           ...s.card,
           display_name: s.card.name,
         })),
-        allowAdditionalFieldOptions: false,
-        rowMode: true,
       }),
     },
     ...metricSetting("funnel.metric", {

--- a/frontend/src/metabase/visualizations/visualizations/Funnel.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Funnel.jsx
@@ -114,16 +114,26 @@ export default class Funnel extends Component {
       section: t`Data`,
       title: t`Breakouts`,
       widget: ChartSettingOrderedColumns,
-      getDefault: props => {
-        console.log(props);
-        return props.map(p => ({
-          name: p.card.name,
+      isValid: series => {
+        //console.log('is valid', series);
+
+        return true;
+      },
+      getDefault: transformedSeries => {
+        // console.log(transformedSeries);
+        return transformedSeries.map(s => ({
+          name: s.card.name,
+          rowId: s.card.rowIndex,
           enabled: true,
         }));
       },
-      getProps: props => ({
-        columns: props.map(p => ({ ...p.card, display_name: p.card.name })),
+      getProps: transformedSeries => ({
+        columns: transformedSeries.map(s => ({
+          ...s.card,
+          display_name: s.card.name,
+        })),
         allowAdditionalFieldOptions: false,
+        rowMode: true,
       }),
     },
     ...metricSetting("funnel.metric", {
@@ -175,12 +185,13 @@ export default class Funnel extends Component {
       dimensionIndex >= 0 &&
       metricIndex >= 0
     ) {
-      return rows.map(row => ({
+      return rows.map((row, index) => ({
         card: {
           ...card,
           name: formatValue(row[dimensionIndex], {
             column: cols[dimensionIndex],
           }),
+          rowIndex: index,
           _transformed: true,
         },
         data: {

--- a/frontend/src/metabase/visualizations/visualizations/Funnel.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Funnel.jsx
@@ -114,15 +114,19 @@ export default class Funnel extends Component {
       section: t`Data`,
       widget: ChartSettingOrderedRows,
       isValid: (series, settings) => {
-        const setting = settings["funnel.rows"];
+        const funnelRows = settings["funnel.rows"];
 
-        if (!setting || !_.isArray(setting)) {
+        if (!funnelRows || !_.isArray(funnelRows)) {
+          return false;
+        }
+        if (!funnelRows.every(setting => setting.rowIndex !== undefined)) {
           return false;
         }
 
-        return setting.reduce((memo, value) => {
-          return memo || !!value.rowIndex;
-        }, false);
+        return (
+          funnelRows.every(setting => series[setting.rowIndex]) &&
+          funnelRows.length === series.length
+        );
       },
 
       getDefault: transformedSeries => {
@@ -133,10 +137,7 @@ export default class Funnel extends Component {
         }));
       },
       getProps: transformedSeries => ({
-        rows: transformedSeries.map(s => ({
-          ...s.card,
-          display_name: s.card.name,
-        })),
+        rows: transformedSeries.map(s => s.card),
       }),
     },
     ...metricSetting("funnel.metric", {


### PR DESCRIPTION
EPIC #24840

Refactored Chart Settings sortables into their own component and added ability to sort funnel rows, as well as toggle visibility. Should not impact current sorting of table columns


![chrome_tsrO50de7v](https://user-images.githubusercontent.com/1328979/186197413-f4227334-983b-4c53-82dd-2cf8351141d3.gif)

