### PR TITLE
Snapshot of metric prototype 08/23

### DIFF
--- a/dev/src/dev.clj
+++ b/dev/src/dev.clj
@@ -128,6 +128,7 @@
         (throw e)))))
 
 (defn migrate!
-  "Run migrations for the Metabase application database."
-  []
-  (mdb.setup/migrate! (mdb.connection/db-type) (mdb.connection/data-source) :up))
+  "Run migrations for the Metabase application database. Default is `:up`. Can also be passed `:down-one`."
+  ([] (migrate! :up))
+  ([direction]
+   (mdb.setup/migrate! (mdb.connection/db-type) (mdb.connection/data-source) direction)))

--- a/frontend/src/metabase-lib/lib/DimensionOptions/DimensionOptions.ts
+++ b/frontend/src/metabase-lib/lib/DimensionOptions/DimensionOptions.ts
@@ -35,6 +35,10 @@ export default class DimensionOptions {
     return !!this.all().find(dim => dimension.isSameBaseDimension(dim));
   }
 
+  find(predicate: (dimension: Dimension) => boolean): Dimension | null {
+    return this.all().find(predicate) ?? null;
+  }
+
   sections({ extraItems = [] } = {}): DimensionOptionsSection[] {
     const dimension =
       this.dimensions.find(dimension => !dimension.isExpression()) ??

--- a/frontend/src/metabase-lib/lib/metadata/Field.ts
+++ b/frontend/src/metabase-lib/lib/metadata/Field.ts
@@ -244,7 +244,7 @@ class FieldInner extends Base {
     return getIconForField(this);
   }
 
-  reference() {
+  reference(): FieldRef {
     if (Array.isArray(this.id)) {
       // if ID is an array, it's a MBQL field reference, typically "field"
       return this.id;

--- a/frontend/src/metabase-lib/lib/newmetrics/utils.ts
+++ b/frontend/src/metabase-lib/lib/newmetrics/utils.ts
@@ -1,5 +1,5 @@
 import { isProduction } from "metabase/env";
-import Question from "metabase-lib/lib/Question";
+import Question, { MetricQuestion } from "metabase-lib/lib/Question";
 import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
 import Dimension from "metabase-lib/lib/Dimension";
 import Field from "metabase-lib/lib/metadata/Field";
@@ -37,6 +37,7 @@ export function canBeUsedAsMetric(
 ): question is Question {
   return (
     !!question &&
+    !(question instanceof MetricQuestion) &&
     question.isStructured() &&
     !!findDateDimension(question) &&
     !!findNumberDimension(question)
@@ -86,7 +87,7 @@ export function generateFakeMetricFromQuestion(
 export function applyMetricToQuestion(
   question: Question,
   metric: Metric,
-): Question | null {
+): MetricQuestion | null {
   const query = question.query() as StructuredQuery;
   const { dimensions, measure } = metric;
   const [, dateFieldRef] = dimensions[0];
@@ -117,5 +118,10 @@ export function applyMetricToQuestion(
     ]);
   }
 
-  return metricQuery.question();
+  const transformedQuestion = metricQuery.question();
+  return new MetricQuestion({
+    metric,
+    card: transformedQuestion.card(),
+    metadata: transformedQuestion.metadata(),
+  });
 }

--- a/frontend/src/metabase-lib/lib/newmetrics/utils.ts
+++ b/frontend/src/metabase-lib/lib/newmetrics/utils.ts
@@ -1,11 +1,10 @@
 import Question from "metabase-lib/lib/Question";
 import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
+import Field from "metabase-lib/lib/metadata/Field";
+import { Aggregation } from "metabase-types/types/Query";
+import { Metric } from "metabase-types/api/newmetric";
 
-function hasDateField(question: Question): boolean {
-  if (!question.isStructured()) {
-    return false;
-  }
-
+function findDateField(question: Question) {
   const query = question.query() as StructuredQuery;
 
   // note: `query.dimension()` excludes join dimensions, which I think we want to include
@@ -15,7 +14,17 @@ function hasDateField(question: Question): boolean {
     return field.isDate();
   });
 
-  return !!dateDimension;
+  return dateDimension?.field();
+}
+
+function hasDateField(question: Question): boolean {
+  if (!question.isStructured()) {
+    return false;
+  }
+
+  const dateField = findDateField(question);
+
+  return !!dateField;
 }
 
 export function canBeUsedAsMetric(
@@ -27,4 +36,35 @@ export function canBeUsedAsMetric(
     (question.query() as StructuredQuery).aggregations().length === 1 &&
     hasDateField(question)
   );
+}
+
+export function generateFakeMetricFromQuestion(
+  question: Question,
+): Metric | null {
+  // guaranteeing the below type assertions are valid
+  if (!canBeUsedAsMetric(question)) {
+    return null;
+  }
+
+  const query = question.query() as StructuredQuery;
+  const aggregation = query.aggregations()[0].raw() as Aggregation;
+  const dateField = findDateField(question) as Field;
+  const columnName = dateField.name;
+  const ref = dateField.reference();
+
+  return {
+    id: question.id(),
+    name: `${question.id()}_metric`,
+    display_name: `${question.displayName()} Metric`,
+    description: "",
+    archived: false,
+    card_id: question.id(),
+    measure: aggregation,
+    dimensions: [[columnName, ref]],
+    granularities: [],
+    default_granularity: "",
+    creator_id: 1,
+    created_at: "",
+    updated_at: "",
+  };
 }

--- a/frontend/src/metabase-lib/lib/newmetrics/utils.ts
+++ b/frontend/src/metabase-lib/lib/newmetrics/utils.ts
@@ -79,6 +79,7 @@ export function generateFakeMetricFromQuestion(
     granularities: ["quarter", "week", "month", "year"],
     default_granularity: "month",
     collection_id: null,
+    display_name: "", // remove, eventually
   };
 }
 

--- a/frontend/src/metabase-lib/lib/newmetrics/utils.ts
+++ b/frontend/src/metabase-lib/lib/newmetrics/utils.ts
@@ -42,7 +42,7 @@ export function canBeUsedAsMetric(
 
 export function generateFakeMetricFromQuestion(
   question: Question,
-): Metric | null {
+): Partial<Metric> | null {
   // guaranteeing the below type assertions are valid
   if (!canBeUsedAsMetric(question)) {
     return null;
@@ -58,7 +58,6 @@ export function generateFakeMetricFromQuestion(
   }
 
   return {
-    id: question.id(),
     name: `${question.id()}_metric`,
     display_name: `${question.displayName()} Metric`,
     description: "",
@@ -67,10 +66,8 @@ export function generateFakeMetricFromQuestion(
     measure: aggregation,
     dimensions: [[columnName, ref]],
     granularities: [],
-    default_granularity: "",
-    creator_id: 1,
-    created_at: "",
-    updated_at: "",
+    default_granularity: "month",
+    collection_id: null,
   };
 }
 

--- a/frontend/src/metabase-lib/lib/newmetrics/utils.ts
+++ b/frontend/src/metabase-lib/lib/newmetrics/utils.ts
@@ -70,8 +70,7 @@ export function generateFakeMetricFromQuestion(
   }
 
   return {
-    name: `${question.id()}_metric`,
-    display_name: `${question.displayName()} Metric`,
+    name: `${question.displayName()} Metric`,
     description: "",
     archived: false,
     card_id: question.id(),

--- a/frontend/src/metabase-lib/lib/newmetrics/utils.ts
+++ b/frontend/src/metabase-lib/lib/newmetrics/utils.ts
@@ -18,8 +18,11 @@ function hasDateField(question: Question): boolean {
   return !!dateDimension;
 }
 
-export function canBeUsedAsMetric(question: Question): boolean {
+export function canBeUsedAsMetric(
+  question: Question | null | undefined,
+): question is Question {
   return (
+    !!question &&
     question.isStructured() &&
     (question.query() as StructuredQuery).aggregations().length === 1 &&
     hasDateField(question)

--- a/frontend/src/metabase-lib/lib/newmetrics/utils.ts
+++ b/frontend/src/metabase-lib/lib/newmetrics/utils.ts
@@ -1,0 +1,27 @@
+import Question from "metabase-lib/lib/Question";
+import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
+
+function hasDateField(question: Question): boolean {
+  if (!question.isStructured()) {
+    return false;
+  }
+
+  const query = question.query() as StructuredQuery;
+
+  // note: `query.dimension()` excludes join dimensions, which I think we want to include
+  const dimensionOptions = query.dimensionOptions();
+  const dateDimension = dimensionOptions.find(dimension => {
+    const field = dimension.field();
+    return field.isDate();
+  });
+
+  return !!dateDimension;
+}
+
+export function canBeUsedAsMetric(question: Question): boolean {
+  return (
+    question.isStructured() &&
+    (question.query() as StructuredQuery).aggregations().length === 1 &&
+    hasDateField(question)
+  );
+}

--- a/frontend/src/metabase-lib/lib/newmetrics/utils.ts
+++ b/frontend/src/metabase-lib/lib/newmetrics/utils.ts
@@ -77,7 +77,7 @@ export function generateFakeMetricFromQuestion(
 export function applyMetricToQuestion(
   question: Question,
   metric: Metric,
-): Question {
+): Question | null {
   const query = question.query() as StructuredQuery;
   const { dimensions } = metric;
   const [, dateFieldRef] = dimensions[0];
@@ -90,7 +90,7 @@ export function applyMetricToQuestion(
   );
 
   if (!dateDimension) {
-    throw new Error("Could not parse the Metric's date dimension");
+    return null;
   }
 
   const dateDimensionWithTemporalUnit = dateDimension.withTemporalUnit(

--- a/frontend/src/metabase-types/api/newmetric.ts
+++ b/frontend/src/metabase-types/api/newmetric.ts
@@ -1,4 +1,4 @@
-import { Aggregation, Field } from "metabase-types/types/Query";
+import { Aggregation, ConcreteField } from "metabase-types/types/Query";
 import { CardId } from "metabase-types/api/card";
 
 export type UnsavedMetric = Partial<Metric>;
@@ -11,8 +11,7 @@ export type Metric = {
   archived: boolean;
   card_id: CardId;
   measure: Aggregation;
-  // maybe should be ConcreteField
-  dimensions: [string, Field][];
+  dimensions: [string, ConcreteField][];
   granularities: string[];
   default_granularity: string;
   creator_id: number;

--- a/frontend/src/metabase-types/api/newmetric.ts
+++ b/frontend/src/metabase-types/api/newmetric.ts
@@ -1,0 +1,21 @@
+import { Aggregation, Field } from "metabase-types/types/Query";
+import { CardId } from "metabase-types/api/card";
+
+export type UnsavedMetric = Partial<Metric>;
+
+export type Metric = {
+  id: number;
+  name: string;
+  display_name: string;
+  description: string;
+  archived: boolean;
+  card_id: CardId;
+  measure: Aggregation;
+  // maybe should be ConcreteField
+  dimensions: [string, Field][];
+  granularities: string[];
+  default_granularity: string;
+  creator_id: number;
+  created_at: string;
+  updated_at: string;
+};

--- a/frontend/src/metabase-types/api/newmetric.ts
+++ b/frontend/src/metabase-types/api/newmetric.ts
@@ -14,6 +14,7 @@ export type Metric = {
   dimensions: [string, ConcreteField][];
   granularities: string[];
   default_granularity: string;
+  collection_id: number | null;
   creator_id: number;
   created_at: string;
   updated_at: string;

--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -36,7 +36,14 @@ import {
 
 const PAGE_SIZE = 25;
 
-const ALL_MODELS = ["dashboard", "dataset", "card", "snippet", "pulse"];
+const ALL_MODELS = [
+  "dashboard",
+  "dataset",
+  "card",
+  "snippet",
+  "pulse",
+  "newmetric",
+];
 
 const itemKeyFn = item => `${item.id}:${item.model}`;
 

--- a/frontend/src/metabase/entities/index.js
+++ b/frontend/src/metabase/entities/index.js
@@ -29,3 +29,4 @@ export { default as persistedModels } from "./persisted-models";
 export { default as recentItems } from "./recent-items";
 export { default as popularItems } from "./popular-items";
 export { default as snippets } from "./snippets";
+export { default as newMetrics } from "./new-metrics";

--- a/frontend/src/metabase/entities/new-metrics.ts
+++ b/frontend/src/metabase/entities/new-metrics.ts
@@ -1,4 +1,19 @@
-import { createEntity } from "metabase/lib/entities";
+import { createEntity, undo } from "metabase/lib/entities";
+import { color } from "metabase/lib/colors";
+import { normalizedCollection } from "metabase/entities/collections";
+import { canonicalCollectionId } from "metabase/collections/utils";
+import { Dispatch } from "metabase-types/store";
+
+type Opts = Record<string, any>;
+
+type MetricModel = {
+  description: string | null;
+  entity_id: string | null;
+  model: "newmetric";
+  name: string;
+  id: number;
+  collection?: unknown;
+};
 
 const NewMetrics = createEntity({
   name: "newMetrics",
@@ -10,6 +25,52 @@ const NewMetrics = createEntity({
     getObject: (state: any, { entityId }: { entityId: number }) => {
       return state.entities.newMetrics[entityId];
     },
+  },
+
+  objectActions: {
+    setArchived: ({ id }: { id: number }, archived: boolean, opts: Opts) => {
+      return NewMetrics.actions.update(
+        { id },
+        { archived },
+        undo(opts, "metric", archived ? "archived" : "unarchived"),
+      );
+    },
+
+    setCollection: (
+      { id }: { id: number },
+      collection: { id: number } | null | undefined,
+      opts: Opts,
+    ) => {
+      return NewMetrics.actions.update(
+        { id },
+        { collection_id: canonicalCollectionId(collection?.id) },
+        undo(opts, "metric", "moved"),
+      );
+    },
+
+    setPinned: ({ id }: { id: number }, pinned: boolean, opts: Opts) => {
+      return NewMetrics.actions.update(
+        { id },
+        {
+          collection_position:
+            typeof pinned === "number" ? pinned : pinned ? 1 : null,
+        },
+        opts,
+      );
+    },
+
+    // setCollectionPreview: ({ id }, collection_preview, opts) =>
+    //   NewMetrics.actions.update({ id }, { collection_preview }, opts),
+  },
+
+  objectSelectors: {
+    getName: (metric: MetricModel) => metric?.name,
+    getUrl: (metric: MetricModel) => `/metric/${metric.id}`,
+    getColor: () => color("text-medium"),
+    getCollection: (metric: MetricModel) => {
+      return metric && normalizedCollection(metric.collection);
+    },
+    getIcon: () => ({ name: "star" }),
   },
 });
 

--- a/frontend/src/metabase/entities/new-metrics.ts
+++ b/frontend/src/metabase/entities/new-metrics.ts
@@ -1,0 +1,16 @@
+import { createEntity } from "metabase/lib/entities";
+
+const NewMetrics = createEntity({
+  name: "newMetrics",
+  nameOne: "newMetric",
+  nameMany: "newMetrics",
+  path: "/api/newmetric",
+
+  selectors: {
+    getObject: (state: any, { entityId }: { entityId: number }) => {
+      return state.entities.newMetrics[entityId];
+    },
+  },
+});
+
+export default NewMetrics;

--- a/frontend/src/metabase/entities/questions.js
+++ b/frontend/src/metabase/entities/questions.js
@@ -12,6 +12,7 @@ import Collections, {
   normalizedCollection,
 } from "metabase/entities/collections";
 import { canonicalCollectionId } from "metabase/collections/utils";
+import { getMetadata } from "metabase/selectors/metadata";
 
 import forms from "./questions/forms";
 import { updateIn } from "icepick";
@@ -69,6 +70,10 @@ const Questions = createEntity({
 
     setCollectionPreview: ({ id }, collection_preview, opts) =>
       Questions.actions.update({ id }, { collection_preview }, opts),
+  },
+
+  selectors: {
+    getObject: (state, { entityId }) => getMetadata(state).question(entityId),
   },
 
   objectSelectors: {

--- a/frontend/src/metabase/lib/request.js
+++ b/frontend/src/metabase/lib/request.js
@@ -1,4 +1,5 @@
 import _ from "underscore";
+
 export class RestfulRequest {
   // API endpoint that is used for the request
   endpoint = null;

--- a/frontend/src/metabase/lib/schema/schema.js
+++ b/frontend/src/metabase/lib/schema/schema.js
@@ -1,6 +1,15 @@
 // backend returns model = "card" instead of "question"
-export const entityTypeForModel = model =>
-  model === "card" || model === "dataset" ? "questions" : `${model}s`;
+export const entityTypeForModel = model => {
+  switch (model) {
+    case "card":
+    case "dataset":
+      return "questions";
+    case "newmetric":
+      return "newMetrics";
+    default:
+      return `${model}s`;
+  }
+};
 
 export const entityTypeForObject = object =>
   object && entityTypeForModel(object.model);

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
@@ -31,6 +31,7 @@ import { Card, SavedCard } from "metabase-types/types/Card";
 import { getQueryBuilderModeFromLocation } from "../../typed-utils";
 import { redirectToNewQuestionFlow, updateUrl } from "../navigation";
 import { cancelQuery, runQuestionQuery } from "../querying";
+import { initializeMetricMode } from "../newmetrics";
 
 import { resetQB } from "./core";
 import { loadMetadataForCard } from "./metadata";
@@ -233,6 +234,11 @@ async function handleQBInit(
     location.pathname?.startsWith("/model")
   ) {
     dispatch(setErrorPage(NOT_FOUND_ERROR));
+    return;
+  }
+
+  if (isSavedCard(card) && location.pathname?.startsWith("/metric")) {
+    dispatch(initializeMetricMode(card));
     return;
   }
 

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
@@ -196,6 +196,11 @@ async function handleQBInit(
   dispatch(resetQB());
   dispatch(cancelQuery());
 
+  if (location.pathname?.startsWith("/metric")) {
+    dispatch(initializeMetricMode(location, params));
+    return;
+  }
+
   const queryParams = location.query;
   const cardId = Urls.extractEntityId(params.slug);
   const uiControls: UIControls = getQueryBuilderModeFromLocation(location);
@@ -234,11 +239,6 @@ async function handleQBInit(
     location.pathname?.startsWith("/model")
   ) {
     dispatch(setErrorPage(NOT_FOUND_ERROR));
-    return;
-  }
-
-  if (isSavedCard(card) && location.pathname?.startsWith("/metric")) {
-    dispatch(initializeMetricMode(card));
     return;
   }
 

--- a/frontend/src/metabase/query_builder/actions/index.ts
+++ b/frontend/src/metabase/query_builder/actions/index.ts
@@ -9,3 +9,4 @@ export * from "./timelines";
 export * from "./ui";
 export * from "./visualization-settings";
 export * from "./writeback";
+export * from "./newmetrics";

--- a/frontend/src/metabase/query_builder/actions/navigation.js
+++ b/frontend/src/metabase/query_builder/actions/navigation.js
@@ -19,6 +19,7 @@ import {
   getOriginalQuestion,
   getQueryBuilderMode,
   getQuestion,
+  getMetric,
 } from "../selectors";
 import { getQueryBuilderModeFromLocation } from "../typed-utils";
 import {
@@ -136,6 +137,11 @@ export const updateUrl = createThunkAction(
     ) =>
     (dispatch, getState) => {
       let question;
+      const metric = getMetric(getState());
+      if (metric) {
+        return;
+      }
+
       if (!card) {
         card = getCard(getState());
         question = getQuestion(getState());

--- a/frontend/src/metabase/query_builder/actions/newmetrics.ts
+++ b/frontend/src/metabase/query_builder/actions/newmetrics.ts
@@ -2,12 +2,20 @@ import { t } from "ttag";
 import { push } from "react-router-redux";
 
 import { Dispatch, GetState } from "metabase-types/store";
+import { Card } from "metabase-types/types/Card";
 import { canBeUsedAsMetric } from "metabase-lib/lib/newmetrics/utils";
+import Question from "metabase-lib/lib/Question";
 import { addUndo } from "metabase/redux/undo";
+import { getMetadata } from "metabase/selectors/metadata";
 
 import { getQuestion } from "../selectors";
+import { runQuestionQuery } from "./querying";
+import { loadMetadataForCard } from "./core/metadata";
 
+// avoiding the circular dependency
+const INITIALIZE_QB = "metabase/qb/INITIALIZE_QB";
 export const CREATE_METRIC = "metabase/qb/CREATE_METRIC";
+export const ENTER_QB_METRIC_MODE = "metabase/qb/ENTER_QB_METRIC_MODE";
 
 export const createMetricFromQuestion =
   () => (dispatch: Dispatch, getState: GetState) => {
@@ -23,4 +31,34 @@ export const createMetricFromQuestion =
         }),
       );
     }
+  };
+
+export const initializeMetricMode =
+  (card: Card) => async (dispatch: Dispatch, getState: GetState) => {
+    // this action currently does nothing. is it needed?
+    dispatch({
+      type: ENTER_QB_METRIC_MODE,
+    });
+
+    await dispatch(initializeMetricCard(card));
+  };
+
+// this all comes from the core initializeQB action
+// excluded a few auxilliary things like loading alerts, showing modals,
+// so will need to revisit to ensure there aren't other things that we
+// want to do that's card/qb related
+export const initializeMetricCard =
+  (card: Card) => async (dispatch: Dispatch, getState: GetState) => {
+    await dispatch(loadMetadataForCard(card));
+    const metadata = getMetadata(getState());
+    const question = new Question(card, metadata).lockDisplay();
+    dispatch({
+      type: INITIALIZE_QB,
+      payload: {
+        card: question.card(),
+      },
+    });
+    // no need for setTimeout because there shouldn't be any paremeter widgets
+    // might not always be the case though
+    dispatch(runQuestionQuery({ shouldUpdateUrl: false }));
   };

--- a/frontend/src/metabase/query_builder/actions/newmetrics.ts
+++ b/frontend/src/metabase/query_builder/actions/newmetrics.ts
@@ -1,0 +1,21 @@
+import { t } from "ttag";
+
+import { Dispatch, GetState } from "metabase-types/store";
+import { canBeUsedAsMetric } from "metabase-lib/lib/newmetrics/utils";
+import { addUndo } from "metabase/redux/undo";
+
+import { getQuestion } from "../selectors";
+
+export const CREATE_METRIC = "metabase/qb/CREATE_METRIC";
+
+export const createMetricFromQuestion =
+  () => (dispatch: Dispatch, getState: GetState) => {
+    const question = getQuestion(getState());
+    if (question && canBeUsedAsMetric(question)) {
+      dispatch(
+        addUndo({
+          message: t`Created a metric`,
+        }),
+      );
+    }
+  };

--- a/frontend/src/metabase/query_builder/actions/newmetrics.ts
+++ b/frontend/src/metabase/query_builder/actions/newmetrics.ts
@@ -1,4 +1,5 @@
 import { t } from "ttag";
+import { push } from "react-router-redux";
 
 import { Dispatch, GetState } from "metabase-types/store";
 import { canBeUsedAsMetric } from "metabase-lib/lib/newmetrics/utils";
@@ -11,7 +12,11 @@ export const CREATE_METRIC = "metabase/qb/CREATE_METRIC";
 export const createMetricFromQuestion =
   () => (dispatch: Dispatch, getState: GetState) => {
     const question = getQuestion(getState());
-    if (question && canBeUsedAsMetric(question)) {
+    if (canBeUsedAsMetric(question)) {
+      // create a new metric
+      // navigate to /metric/:metric-id
+      // for now, navigating to same question but different path
+      dispatch(push(`/metric/${question.id()}`));
       dispatch(
         addUndo({
           message: t`Created a metric`,

--- a/frontend/src/metabase/query_builder/actions/newmetrics.ts
+++ b/frontend/src/metabase/query_builder/actions/newmetrics.ts
@@ -111,6 +111,7 @@ export const initializeMetricCard =
     }
 
     const metricCard = metricQuestion
+      .setDisplayName(metric.name)
       // eventually let user decide this?
       .setDisplay("line")
       // initializeQB does this to saved, structured cards, so we should, too?

--- a/frontend/src/metabase/query_builder/actions/querying.js
+++ b/frontend/src/metabase/query_builder/actions/querying.js
@@ -46,7 +46,7 @@ export const SET_DOCUMENT_TITLE_TIMEOUT_ID =
   "metabase/qb/SET_DOCUMENT_TITLE_TIMEOUT_ID";
 const setDocumentTitleTimeoutId = createAction(SET_DOCUMENT_TITLE_TIMEOUT_ID);
 
-const loadCompleteUIControls = createThunkAction(
+export const loadCompleteUIControls = createThunkAction(
   LOAD_COMPLETE_UI_CONTROLS,
   () => (dispatch, getState) => {
     const timeoutId = getTimeoutId(getState());
@@ -137,7 +137,7 @@ export const runQuestionQuery = ({
   };
 };
 
-const loadStartUIControls = createThunkAction(
+export const loadStartUIControls = createThunkAction(
   LOAD_START_UI_CONTROLS,
   () => (dispatch, getState) => {
     const loadingMessage = PLUGIN_SELECTORS.getLoadingMessage(getState());

--- a/frontend/src/metabase/query_builder/components/QuestionActions.tsx
+++ b/frontend/src/metabase/query_builder/components/QuestionActions.tsx
@@ -204,7 +204,7 @@ const QuestionActions = ({
     }
 
     extraButtons.push({
-      title: t`Turn into a metric`,
+      title: t`Make a metric from this`,
       icon: "star",
       disabled: !canBeMetric,
       action: () => {

--- a/frontend/src/metabase/query_builder/components/QuestionActions.tsx
+++ b/frontend/src/metabase/query_builder/components/QuestionActions.tsx
@@ -10,7 +10,10 @@ import { PLUGIN_MODERATION, PLUGIN_MODEL_PERSISTENCE } from "metabase/plugins";
 
 import { MODAL_TYPES } from "metabase/query_builder/constants";
 
-import { softReloadCard } from "metabase/query_builder/actions";
+import {
+  softReloadCard,
+  createMetricFromQuestion,
+} from "metabase/query_builder/actions";
 import { getUserIsAdmin } from "metabase/selectors/user";
 
 import { State } from "metabase-types/store";
@@ -45,6 +48,7 @@ const mapStateToProps = (state: State, props: Props) => ({
 
 const mapDispatchToProps = {
   softReloadCard,
+  createMetricFromQuestion,
 };
 
 interface Props {
@@ -64,6 +68,7 @@ interface Props {
   onModelPersistenceChange: () => void;
   isModerator: boolean;
   softReloadCard: () => void;
+  createMetricFromQuestion: () => void;
 }
 
 const QuestionActions = ({
@@ -80,6 +85,7 @@ const QuestionActions = ({
   onModelPersistenceChange,
   isModerator,
   softReloadCard,
+  createMetricFromQuestion,
 }: Props) => {
   const bookmarkTooltip = isBookmarked ? t`Remove from bookmarks` : t`Bookmark`;
 
@@ -202,7 +208,7 @@ const QuestionActions = ({
       icon: "star",
       disabled: !canBeMetric,
       action: () => {
-        console.log("sike!");
+        createMetricFromQuestion();
       },
     });
   }

--- a/frontend/src/metabase/query_builder/components/QuestionActions.tsx
+++ b/frontend/src/metabase/query_builder/components/QuestionActions.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useMemo } from "react";
 import { t } from "ttag";
 import { connect } from "react-redux";
 
@@ -21,6 +21,7 @@ import {
 } from "metabase/lib/data-modeling/utils";
 
 import Question from "metabase-lib/lib/Question";
+import { canBeUsedAsMetric } from "metabase-lib/lib/newmetrics/utils";
 
 import {
   QuestionActionsDivider,
@@ -91,6 +92,8 @@ const QuestionActions = ({
   const canWrite = question.canWrite();
   const isSaved = question.isSaved();
   const isNative = question.isNative();
+
+  const canBeMetric = useMemo(() => canBeUsedAsMetric(question), [question]);
 
   const canPersistDataset =
     PLUGIN_MODEL_PERSISTENCE.isModelLevelPersistenceEnabled() &&
@@ -191,6 +194,16 @@ const QuestionActions = ({
           : t`Turn into an action`,
         icon: "bolt",
         action: isAction ? turnActionIntoQuestion : turnQuestionIntoAction,
+      });
+    }
+
+    if (canBeMetric) {
+      extraButtons.push({
+        title: t`Turn into a metric`,
+        icon: "star",
+        action: () => {
+          console.log("sike!");
+        },
       });
     }
   }

--- a/frontend/src/metabase/query_builder/components/QuestionActions.tsx
+++ b/frontend/src/metabase/query_builder/components/QuestionActions.tsx
@@ -197,15 +197,14 @@ const QuestionActions = ({
       });
     }
 
-    if (canBeMetric) {
-      extraButtons.push({
-        title: t`Turn into a metric`,
-        icon: "star",
-        action: () => {
-          console.log("sike!");
-        },
-      });
-    }
+    extraButtons.push({
+      title: t`Turn into a metric`,
+      icon: "star",
+      disabled: !canBeMetric,
+      action: () => {
+        console.log("sike!");
+      },
+    });
   }
 
   if (!question.query().readOnly()) {

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
@@ -255,6 +255,7 @@ function QueryBuilder(props) {
   );
 
   const onClickBookmark = () => {
+    // note: move to redux action? so that we can alter behavior for metrics
     const {
       card: { id },
     } = props;

--- a/frontend/src/metabase/query_builder/reducers.js
+++ b/frontend/src/metabase/query_builder/reducers.js
@@ -395,6 +395,15 @@ export const originalCard = handleActions(
   null,
 );
 
+export const metric = handleActions(
+  {
+    [INITIALIZE_QB]: {
+      next: (state, { payload }) => payload?.metric ?? null,
+    },
+  },
+  null,
+);
+
 // references to FK tables specifically used on the ObjectDetail page.
 export const tableForeignKeyReferences = handleActions(
   {

--- a/frontend/src/metabase/query_builder/reducers.js
+++ b/frontend/src/metabase/query_builder/reducers.js
@@ -338,10 +338,10 @@ export const card = handleActions(
     [UPDATE_QUESTION]: (state, { payload: { card } }) => card,
 
     [QUERY_COMPLETED]: {
-      next: (state, { payload: { card } }) => ({
+      next: (state, { payload: { card, result_metadata, display } }) => ({
         ...state,
-        display: card.display,
-        result_metadata: card.result_metadata,
+        display: display ?? card.display,
+        result_metadata: result_metadata ?? card.result_metadata,
         visualization_settings: card.visualization_settings,
       }),
     },

--- a/frontend/src/metabase/routes.jsx
+++ b/frontend/src/metabase/routes.jsx
@@ -259,6 +259,14 @@ export const getRoutes = store => (
           <Route path=":slug/:objectId" component={QueryBuilder} />
         </Route>
 
+        <Route path="/metric">
+          <IndexRoute component={QueryBuilder} />
+          <Route path=":slug" component={QueryBuilder} />
+          <Route path=":slug/settings" component={QueryBuilder} />
+          <Route path=":slug/metadata" component={QueryBuilder} />
+          <Route path=":slug/:objectId" component={QueryBuilder} />
+        </Route>
+
         <Route path="browse" component={BrowseApp}>
           <IndexRoute component={DatabaseBrowser} />
           <Route path=":slug" component={SchemaBrowser} />

--- a/frontend/src/metabase/schema.js
+++ b/frontend/src/metabase/schema.js
@@ -50,6 +50,7 @@ export const SnippetSchema = new schema.Entity("snippets");
 export const SnippetCollectionSchema = new schema.Entity("snippetCollections");
 export const TimelineSchema = new schema.Entity("timelines");
 export const TimelineEventSchema = new schema.Entity("timelineEvents");
+export const NewMetricSchema = new schema.Entity("newMetrics");
 
 DatabaseSchema.define({
   tables: [TableSchema],

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -135,6 +135,10 @@ export const CardApi = {
   adHocRelated: POST("/api/card/related"),
 };
 
+export const NewMetricApi = {
+  query: POST("/api/newmetric/:id/query"),
+};
+
 export const DashboardApi = {
   list: GET("/api/dashboard"),
   // creates a new empty dashboard

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -12680,6 +12680,19 @@ databaseChangeLog:
                   constraints:
                     nullable: false
               - column:
+                  name: collection_preview
+                  type: boolean
+                  remarks: Indicating whether the newmetric should be visualized in the collection preview
+                  defaultValueBoolean: true
+                  constraints:
+                    nullable: false
+              - column:
+                  name: collection_position
+                  type: smallint
+                  remarks: 'Optional pinned position for this item in its Collection. NULL means item is not pinned.'
+                  constraints:
+                    nullable: true
+              - column:
                   remarks: ID of the collection containing the newmetric
                   name: collection_id
                   type: int

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -12634,6 +12634,12 @@ databaseChangeLog:
                   constraints:
                     nullable: false
               - column:
+                  remarks: Optional markdown description of the event
+                  name: description
+                  type: varchar(255)
+                  constraints:
+                    nullable: true
+              - column:
                   name: card_id
                   type: int
                   remarks: 'ID of the underlying query the newmetric is based on'
@@ -12652,6 +12658,13 @@ databaseChangeLog:
                   remarks: JSON object holding the dimensions, a sequence of breakout clauses for the metric
                   name: dimensions
                   type: ${text.type}
+                  constraints:
+                    nullable: false
+              - column:
+                  remarks: Whether or not the newmetric has been archived
+                  name: archived
+                  type: boolean
+                  defaultValueBoolean: false
                   constraints:
                     nullable: false
               - column:

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -12680,6 +12680,15 @@ databaseChangeLog:
                   constraints:
                     nullable: false
               - column:
+                  remarks: ID of the collection containing the newmetric
+                  name: collection_id
+                  type: int
+                  constraints:
+                    nullable: true
+                    references: collection(id)
+                    foreignKeyName: fk_newmetric_collection_id
+                    deleteCascade: true
+              - column:
                   remarks: ID of the user who created the event
                   name: creator_id
                   type: int

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -12661,6 +12661,18 @@ databaseChangeLog:
                   constraints:
                     nullable: false
               - column:
+                  remarks: JSON object holding the allowed granularities, treated as a set
+                  name: granularities
+                  type: ${text.type}
+                  constraints:
+                    nullable: false
+              - column:
+                  remarks: Default granularity of the measure
+                  name: default_granularity
+                  type: varchar(255)
+                  constraints:
+                    nullable: false
+              - column:
                   remarks: Whether or not the newmetric has been archived
                   name: archived
                   type: boolean

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -12605,6 +12605,90 @@ databaseChangeLog:
         - dropTable:
             tableName: emitter_action
 
+  - changeSet:
+      id: v45.00-020
+      author: dpsutton
+      comment: Added 0.45.0 - newmetrics
+      changes:
+        - createTable:
+            tableName: newmetric
+            remarks: Table holding newmetric information
+            columns:
+              - column:
+                  name: id
+                  type: int
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: name
+                  type: varchar(255)
+                  remarks: 'name of the newmetric'
+                  constraints:
+                    nullable: false
+              - column:
+                  name: display_name
+                  type: varchar(255)
+                  remarks: 'display name of the newmetric'
+                  constraints:
+                    nullable: false
+              - column:
+                  name: card_id
+                  type: int
+                  remarks: 'ID of the underlying query the newmetric is based on'
+                  constraints:
+                    nullable: false
+                    references: report_card(id)
+                    foreignKeyName: fk_newmetric_card_id
+                    deleteCascade: true
+              - column:
+                  remarks: JSON object holding the primary measure, an aggregation clause for the metric
+                  name: measure
+                  type: ${text.type}
+                  constraints:
+                    nullable: false
+              - column:
+                  remarks: JSON object holding the dimensions, a sequence of breakout clauses for the metric
+                  name: dimensions
+                  type: ${text.type}
+                  constraints:
+                    nullable: false
+              - column:
+                  remarks: ID of the user who created the event
+                  name: creator_id
+                  type: int
+                  constraints:
+                    nullable: false
+                    references: core_user(id)
+                    foreignKeyName: fk_newmetric_creator_id
+                    deleteCascade: true
+              - column:
+                  remarks: The timestamp of when the newmetric was created
+                  name: created_at
+                  type: ${timestamp_type}
+                  defaultValueComputed: current_timestamp
+                  constraints:
+                    nullable: false
+              - column:
+                  remarks: The timestamp of when the event was modified
+                  name: updated_at
+                  type: ${timestamp_type}
+                  defaultValueComputed: current_timestamp
+                  constraints:
+                    nullable: false
+  - changeSet:
+      id: v45.00-021
+      author: dpsutton
+      comment: Added 0.45.0 - newmetric user_id index
+      changes:
+        - createIndex:
+            tableName: newmetric
+            columns:
+              - column:
+                  name: creator_id
+            indexName: idx_newmetric_user_id
+
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -235,10 +235,12 @@
             [:= :archived (boolean archived?)]]})
 
 (defmethod collection-children-query :newmetric
-  [_model collection {:keys [archived? _pinned-state]}]
-  {:select [:id :name :display_name [(hx/literal "newmetric") :model] :description]
+  [_model collection {:keys [archived? pinned-state]}]
+  {:select [:id :name :display_name [(hx/literal "newmetric") :model] :description
+            :collection_preview :collection_position]
    :from   [Newmetric]
    :where  [:and
+            (pinned-state->clause pinned-state)
             [:= :collection_id (:id collection)]
             [:= :archived (boolean archived?)]]})
 
@@ -254,8 +256,7 @@
   (for [row rows]
     (dissoc row
             ;; todo: will need collection_position soon, probably collection preview as well
-            :display :collection_position :authority_level :moderated_status :icon :personal_owner_id
-            :collection_preview :dataset_query)))
+            :display :authority_level :moderated_status :icon :personal_owner_id :dataset_query)))
 
 (defmethod post-process-collection-children :snippet
   [_ rows]

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -254,7 +254,7 @@
   (for [row rows]
     (dissoc row
             ;; todo: will need collection_position soon, probably collection preview as well
-            :display :collection_position :authority_level :moderated_status
+            :display :collection_position :authority_level :moderated_status :icon :personal_owner_id
             :collection_preview :dataset_query)))
 
 (defmethod post-process-collection-children :snippet

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -25,6 +25,7 @@
             [metabase.models.dashboard :refer [Dashboard]]
             [metabase.models.interface :as mi]
             [metabase.models.native-query-snippet :refer [NativeQuerySnippet]]
+            [metabase.models.newmetric :refer [Newmetric]]
             [metabase.models.permissions :as perms]
             [metabase.models.pulse :as pulse :refer [Pulse]]
             [metabase.models.pulse-card :refer [PulseCard]]
@@ -104,7 +105,9 @@
                               (db/reducible-query {:select    [:collection_id :dataset]
                                                    :modifiers [:distinct]
                                                    :from      [:report_card]
-                                                   :where     [:= :archived false]}))]
+                                                   :where     [:= :archived false]}))
+        coll-type-ids (assoc coll-type-ids :newmetric
+                             (db/select-field :collection_id Newmetric))]
     (->> (db/select Collection
                     {:where [:and
                              (when exclude-archived

--- a/src/metabase/api/newmetric.clj
+++ b/src/metabase/api/newmetric.clj
@@ -1,22 +1,41 @@
 (ns metabase.api.newmetric
   (:require [metabase.api.common :as api]
+            [metabase.mbql.normalize :as mbql.normalize]
             [metabase.mbql.schema :as mbql.s]
             [metabase.models.newmetric :refer [Newmetric]]
+            [metabase.util.i18n :refer [tru]]
             [metabase.util.schema :as su]
             [schema.core :as s]
             [toucan.db :as db]))
+
+(defn- validate-dimensions!
+  [dimensions]
+  ;; todo: validate unique names, fields belong to underlying `card_id`, etc.
+  (when (s/check [[(s/one su/NonBlankString "name") (s/one mbql.s/Field "clause")]]
+                 (into []
+                       (map (fn [[name form]]
+                              [name (mbql.normalize/normalize-tokens form)]))
+                       dimensions))
+    (throw (ex-info (tru "Bad dimensions")
+                    {:status-code 400
+                     :dimensions dimensions}))))
+
+(defn- validate-measure!
+  [measure]
+  ;; todo: validate field belongs to underlying `card_id`
+  (when (s/check mbql.s/Aggregation (mbql.normalize/normalize-tokens measure))
+    (throw (ex-info (tru "Bad measure")
+                    {:status-code 400
+                     :measure measure}))))
 
 (api/defendpoint POST "/"
   [:as {{:keys [name display_name description card_id measure dimensions] :as body} :body}]
   {card_id      su/IntGreaterThanZero
    name         su/NonBlankString
    display_name (s/maybe s/Str)
-   description  (s/maybe s/Str)
-   ;; todo: normalize and then check
-   ;; measure      mbql.s/Aggregation
-   ;; dimensions   [[(s/one su/NonBlankString "name") (s/one mbql.s/Field "clause")]]
-   }
-
+   description  (s/maybe s/Str)}
+  (validate-dimensions! dimensions)
+  (validate-measure! measure)
   (db/insert! Newmetric body))
 
 ;; name display_name card_id measure dimensions archived creator_id created_at updated_at
@@ -27,9 +46,9 @@
   {card_id      su/IntGreaterThanZero
    name         su/NonBlankString
    display_name (s/maybe s/Str)
-   description  (s/maybe s/Str)
-   measure      any?
-   dimensions   any?}
-  (db/update! Newmetric metric-updates))
+   description  (s/maybe s/Str)}
+  (validate-dimensions! dimensions)
+  (validate-measure! measure)
+  (db/update! Newmetric id metric-updates))
 
 (api/define-routes)

--- a/src/metabase/api/newmetric.clj
+++ b/src/metabase/api/newmetric.clj
@@ -1,6 +1,5 @@
 (ns metabase.api.newmetric
   (:require [metabase.api.common :as api]
-            [metabase.mbql.normalize :as mbql.normalize]
             [metabase.mbql.schema :as mbql.s]
             [metabase.models.newmetric :refer [Newmetric]]
             [metabase.util.schema :as su]
@@ -13,8 +12,11 @@
    name         su/NonBlankString
    display_name (s/maybe s/Str)
    description  (s/maybe s/Str)
-   measure      mbql.s/Aggregation
-   dimensions   [[(s/one su/NonBlankString "name") (s/one mbql.s/Field "clause")]]}
+   ;; todo: normalize and then check
+   ;; measure      mbql.s/Aggregation
+   ;; dimensions   [[(s/one su/NonBlankString "name") (s/one mbql.s/Field "clause")]]
+   }
+
   (db/insert! Newmetric body))
 
 ;; name display_name card_id measure dimensions archived creator_id created_at updated_at
@@ -29,3 +31,5 @@
    measure      any?
    dimensions   any?}
   (db/update! Newmetric metric-updates))
+
+(api/define-routes)

--- a/src/metabase/api/newmetric.clj
+++ b/src/metabase/api/newmetric.clj
@@ -44,8 +44,6 @@
   (validate-measure! measure)
   (db/insert! Newmetric (assoc body :creator_id api/*current-user-id*)))
 
-;; name display_name card_id measure dimensions archived creator_id created_at updated_at
-
 (api/defendpoint PUT "/:id"
   "Update a `Newmetric`."
   [id :as {{:keys [name display_name description card_id measure dimensions] :as metric-updates} :body}]

--- a/src/metabase/api/newmetric.clj
+++ b/src/metabase/api/newmetric.clj
@@ -1,0 +1,31 @@
+(ns metabase.api.newmetric
+  (:require [metabase.api.common :as api]
+            [metabase.mbql.normalize :as mbql.normalize]
+            [metabase.mbql.schema :as mbql.s]
+            [metabase.models.newmetric :refer [Newmetric]]
+            [metabase.util.schema :as su]
+            [schema.core :as s]
+            [toucan.db :as db]))
+
+(api/defendpoint POST "/"
+  [:as {{:keys [name display_name description card_id measure dimensions] :as body} :body}]
+  {card_id      su/IntGreaterThanZero
+   name         su/NonBlankString
+   display_name (s/maybe s/Str)
+   description  (s/maybe s/Str)
+   measure      mbql.s/Aggregation
+   dimensions   [[(s/one su/NonBlankString "name") (s/one mbql.s/Field "clause")]]}
+  (db/insert! Newmetric body))
+
+;; name display_name card_id measure dimensions archived creator_id created_at updated_at
+
+(api/defendpoint PUT "/:id"
+  "Update a `Card`."
+  [id :as {{:keys [name display_name description card_id measure dimensions] :as metric-updates} :body}]
+  {card_id      su/IntGreaterThanZero
+   name         su/NonBlankString
+   display_name (s/maybe s/Str)
+   description  (s/maybe s/Str)
+   measure      any?
+   dimensions   any?}
+  (db/update! Newmetric metric-updates))

--- a/src/metabase/api/newmetric.clj
+++ b/src/metabase/api/newmetric.clj
@@ -40,7 +40,7 @@
    description  (s/maybe s/Str)}
   (validate-dimensions! dimensions)
   (validate-measure! measure)
-  (db/insert! Newmetric body))
+  (db/insert! Newmetric (assoc body :creator_id api/*current-user-id*)))
 
 ;; name display_name card_id measure dimensions archived creator_id created_at updated_at
 

--- a/src/metabase/api/newmetric.clj
+++ b/src/metabase/api/newmetric.clj
@@ -64,14 +64,9 @@
    {:type :query
     :database (:database_id card)
     :query {:source-table (str "card__" (:id card))
-            :breakout    (into [] dimensions)
+            :breakout    dimensions
             ;; todo: filters?
             :aggregation [(:measure metric)]}}))
-
-(defn- run-query-async
-  ;; todo: export formats?
-  ;; copying liberally from dataset.clj
-  [{:keys [database] :as query}])
 
 (api/defendpoint ^:streaming POST "/:id/query"
   "Run a query for a metric"
@@ -85,6 +80,7 @@
                      (:dataset underlying)
                      (assoc :metadata/dataset-metadata (:result_metadata underlying)))]
     (binding [qp.perms/*card-id* (:id underlying)]
+      ;; todo: metric event (events/publish-event! :metric-read ...)
       (qp.streaming/streaming-response [context :api]
         (qp/process-query-and-save-execution! query info context)))))
 

--- a/src/metabase/api/newmetric.clj
+++ b/src/metabase/api/newmetric.clj
@@ -45,7 +45,7 @@
 ;; name display_name card_id measure dimensions archived creator_id created_at updated_at
 
 (api/defendpoint PUT "/:id"
-  "Update a `Card`."
+  "Update a `Newmetric`."
   [id :as {{:keys [name display_name description card_id measure dimensions] :as metric-updates} :body}]
   {card_id      su/IntGreaterThanZero
    name         su/NonBlankString
@@ -54,6 +54,11 @@
   (validate-dimensions! dimensions)
   (validate-measure! measure)
   (db/update! Newmetric id metric-updates))
+
+(api/defendpoint GET "/:id"
+  "Get a `Newmetric`"
+  [id]
+  (api/read-check (Newmetric id)))
 
 (defn- query-for-metric
   [card metric choices]

--- a/src/metabase/api/routes.clj
+++ b/src/metabase/api/routes.clj
@@ -18,6 +18,7 @@
             [metabase.api.geojson :as api.geojson]
             [metabase.api.ldap :as api.ldap]
             [metabase.api.login-history :as api.login-history]
+            [metabase.api.newmetric :as api.newmetric]
             [metabase.api.metric :as api.metric]
             [metabase.api.native-query-snippet :as api.native-query-snippet]
             [metabase.api.notify :as api.notify]
@@ -82,6 +83,7 @@
   (context "/login-history"        [] (+auth api.login-history/routes))
   (context "/premium-features"     [] (+auth api.premium-features/routes))
   (context "/metric"               [] (+auth api.metric/routes))
+  (context "/newmetric"            [] (+auth api.newmetric/routes))
   (context "/native-query-snippet" [] (+auth api.native-query-snippet/routes))
   (context "/notify"               [] (+apikey api.notify/routes))
   (context "/permissions"          [] (+auth api.permissions/routes))

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -207,6 +207,10 @@
   :in  u/qualified-name
   :out keyword)
 
+(models/add-type! :keyword-set
+  :in json-in
+  :out (comp #(into #{} (map keyword) %) json-out-with-keywordization))
+
 ;;; properties
 
 (defn now

--- a/src/metabase/models/newmetric.clj
+++ b/src/metabase/models/newmetric.clj
@@ -1,0 +1,22 @@
+(ns metabase.models.newmetric
+  (:require [metabase.models.interface :as mi]
+            [metabase.models.permissions :as perms]
+            [metabase.util :as u]
+            [toucan.models :as models]))
+
+(models/defmodel Newmetric :newmetric)
+
+(u/strict-extend (class Newmetric)
+  models/IModel
+  (merge models/IModelDefaults
+         {:types      (constantly {:measure    :json
+                                   :dimensions :json})
+          ;; todo: pre-insert/pre-update with verifications: should
+          ;; check that metrics/dimensions seem to be in the metadata
+          ;; of the source card_id
+
+          ;; todo: serialization
+          :properties (constantly {:timestamped? true})})
+
+  mi/IObjectPermissions
+  perms/IObjectPermissionsForParentCollection)

--- a/src/metabase/models/newmetric.clj
+++ b/src/metabase/models/newmetric.clj
@@ -1,16 +1,30 @@
 (ns metabase.models.newmetric
-  (:require [metabase.models.interface :as mi]
+  (:require [metabase.mbql.normalize :as mbql.normalize]
+            [metabase.models.interface :as mi]
             [metabase.models.permissions :as perms]
             [metabase.util :as u]
             [toucan.models :as models]))
 
 (models/defmodel Newmetric :newmetric)
 
+(models/add-type! ::measure
+  :in mi/json-in
+  :out (comp mbql.normalize/normalize-tokens mi/json-out-with-keywordization))
+
+(models/add-type! ::dimensions
+  :in mi/json-in
+  :out (comp #(into [] (map (fn [[name form]]
+                              [name (mbql.normalize/normalize-tokens form)])
+                            %))
+             mi/json-out-with-keywordization))
+
 (u/strict-extend (class Newmetric)
   models/IModel
   (merge models/IModelDefaults
-         {:types      (constantly {:measure    :json
-                                   :dimensions :json})
+         {:types (constantly {:measure             ::measure
+                              :dimensions          ::dimensions
+                              :granularities       :keyword-set
+                              :default_granularity :keyword})
           ;; todo: pre-insert/pre-update with verifications: should
           ;; check that metrics/dimensions seem to be in the metadata
           ;; of the source card_id

--- a/test/metabase/models/collection_test.clj
+++ b/test/metabase/models/collection_test.clj
@@ -1500,16 +1500,16 @@
   (is (= [{:name     "A"
            :id       1
            :location "/"
-           :below    #{:dataset :card}
+           :below    #{:dataset :card :newmetric}
            :children [{:name "B", :id 2, :location "/1/", :children []}
                       {:name     "C"
                        :id       3
                        :location "/1/"
-                       :below    #{:dataset :card}
+                       :below    #{:dataset :card :newmetric}
                        :children [{:name     "D"
                                    :id       4
                                    :location "/1/3/"
-                                   :here     #{:dataset}
+                                   :here     #{:dataset :newmetric}
                                    :below    #{:dataset}
                                    :children [{:name "E", :id 5, :location "/1/3/4/",
                                                :children [] :here #{:dataset}}]}
@@ -1517,11 +1517,16 @@
                                    :id       6
                                    :location "/1/3/"
                                    :here     #{:card}
-                                   :children [{:name "G", :id 7, :location "/1/3/6/", :children []}]}]}]}
+                                   :below    #{:newmetric}
+                                   :children [{:name "G"
+                                               :id 7
+                                               :location "/1/3/6/"
+                                               :here     #{:newmetric}
+                                               :children []}]}]}]}
           {:name "aaa", :id 9, :location "/", :children [] :here #{:card}}
           {:name "H", :id 8, :location "/", :children []}]
          (collection/collections->tree
-          {:dataset #{4 5} :card #{6 9}}
+          {:dataset #{4 5} :card #{6 9} :newmetric #{4 7}}
           [{:name "A", :id 1, :location "/"}
            {:name "B", :id 2, :location "/1/"}
            {:name "C", :id 3, :location "/1/"}


### PR DESCRIPTION
The behavior of this prototype is fairly similar to the state of things in https://github.com/metabase/metabase/pull/24905. I've attempted to override Question functionality by creating a `MetricQuestion` class that extends `Question` and overrides its behavior.

The biggest hill to climb (and it is a big one) in all of this metrics work, in my opinion, is that we are changing several fundamental assumptions of the query builder ("query builder" is an umbrella term for everything that falls under "simple mode," "gui mode," "notebook mode," and anything that operates on a "structured query" or query that uses mbql):
1. that the object we are operating on is a `card` or a `question`
2. that the `card` or `question` has a `dataset_query` (in the case of a card) or a `StructuredQuery` instance that is **open to modification**

Concerning point number 1, there are scattered bits of logic in the query builder that are specific to questions that will need to be reconsidered for the case of a `metric`. Here's a selection of lines from the top-level `QueryBuilder` that will need to be reworked for metrics:
https://github.com/metabase/metabase/blob/df02d46cbdc2719f5b224c69728bd8d0e4b3857b/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx#L233
https://github.com/metabase/metabase/blob/df02d46cbdc2719f5b224c69728bd8d0e4b3857b/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx#L234
https://github.com/metabase/metabase/blob/df02d46cbdc2719f5b224c69728bd8d0e4b3857b/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx#L259
https://github.com/metabase/metabase/blob/df02d46cbdc2719f5b224c69728bd8d0e4b3857b/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx#L270
https://github.com/metabase/metabase/blob/df02d46cbdc2719f5b224c69728bd8d0e4b3857b/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx#L281
https://github.com/metabase/metabase/blob/df02d46cbdc2719f5b224c69728bd8d0e4b3857b/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx#L360

This isn't just an issue with top-level components. The problem goes all the way down to some components near the bottom of the component hierarchy, such as this one called `DataSourceCrumbs`:
https://github.com/metabase/metabase/blob/df02d46cbdc2719f5b224c69728bd8d0e4b3857b/frontend/src/metabase/query_builder/components/view/QuestionDataSource.jsx#L89

There's no silver bullet to the explicit coupling of components to questions.

Assumption number 2 may be the more significant of the two. Every part of the query builder is set up not only to expect a `question` but to **modify** its internals. Various features of the query builder transform the card's query and then trigger the query builder to update:
https://github.com/metabase/metabase/blob/df02d46cbdc2719f5b224c69728bd8d0e4b3857b/frontend/src/metabase/modes/components/drill/ColumnFilterDrill.jsx#L46

Even a component as "simple" as the granularity picker below the line chart of a query with a date grouping is explicitly modifying the query and triggering changes:
https://github.com/metabase/metabase/blob/df02d46cbdc2719f5b224c69728bd8d0e4b3857b/frontend/src/metabase/modes/components/TimeseriesGroupingWidget.jsx#L54

None of this works for metrics because a change of granularity isn't mutating the card's query but a property on the metric. We can't easily examine how a query has been changed and then infer what the metric will look like. There are subtleties to the problem that are very difficult to understand and solve with simplicity and consistency. For example, examining the above component a little more, it gets its granularity options by looking at the `breakouts` on the card's query and then running code to collect a list of dimensions associated with the breakout. This little blip of functionality **doesn't work** for metrics -- metrics granularity options come from the metric object, so we would need to rewrite this component or create a new component.

Models skirt around the majority of these issues because models are still `card` objects. Models still challenge core assumptions about the QB, so you will find `question.isDataset() ? doModelSpecificLogic() : doQuestionSpecificLogic()` scattered around the codebase, increasing its sum complexity. We can't skirt these issues with metrics due to metrics challenging core assumption 2.

I don't think there's a simple, quick, easy way to get metrics working with current query builder code. I think the better path forward is to begin anew with a simplified version of the query builder specific to metrics that tries to avoid the traps of the current implementation.