### PR TITLE
Hydrate app_id for collections with apps attached

### DIFF
--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -104,17 +104,18 @@
                               (db/reducible-query {:select    [:collection_id :dataset]
                                                    :modifiers [:distinct]
                                                    :from      [:report_card]
-                                                   :where     [:= :archived false]}))]
-    (->> (db/select Collection
-                    {:where [:and
-                             (when exclude-archived
-                               [:= :archived false])
-                             [:= :namespace namespace]
-                             (collection/visible-collection-ids->honeysql-filter-clause
-                              :id
-                              (collection/permissions-set->visible-collection-ids @api/*current-user-permissions-set*))]})
-         (map collection/personal-collection-with-ui-details)
-         (collection/collections->tree coll-type-ids))))
+                                                   :where     [:= :archived false]}))
+        colls (db/select Collection
+                {:where [:and
+                         (when exclude-archived
+                           [:= :archived false])
+                         [:= :namespace namespace]
+                         (collection/visible-collection-ids->honeysql-filter-clause
+                          :id
+                          (collection/permissions-set->visible-collection-ids @api/*current-user-permissions-set*))]})
+        colls (map collection/personal-collection-with-ui-details colls)
+        colls (hydrate colls :app_id)]
+    (collection/collections->tree coll-type-ids colls)))
 
 ;;; --------------------------------- Fetching a single Collection & its 'children' ----------------------------------
 

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -65,7 +65,7 @@
           (cond->> collections
             (mi/can-read? root)
             (cons root))))
-      (hydrate collections :can_write)
+      (hydrate collections :can_write :app_id)
       ;; remove the :metabase.models.collection.root/is-root? tag since FE doesn't need it
       ;; and for personal collections we translate the name to user's locale
       (for [collection collections]
@@ -604,7 +604,7 @@
   [collection :- collection/CollectionWithLocationAndIDOrRoot]
   (-> collection
       collection/personal-collection-with-ui-details
-      (hydrate :parent_id :effective_location [:effective_ancestors :can_write] :can_write)))
+      (hydrate :parent_id :effective_location [:effective_ancestors :can_write] :can_write :app_id)))
 
 (api/defendpoint GET "/:id"
   "Fetch a specific Collection with standard details added"

--- a/src/metabase/models/app.clj
+++ b/src/metabase/models/app.clj
@@ -3,6 +3,7 @@
             [metabase.models.permissions :as perms]
             [metabase.models.serialization.hash :as serdes.hash]
             [metabase.util :as u]
+            [toucan.db :as db]
             [toucan.models :as models]))
 
 (models/defmodel App :app)
@@ -23,3 +24,22 @@
   ;; necessary to satisfy metabase-enterprise.models.entity-id-test/comprehensive-identity-hash-test.
   serdes.hash/IdentityHashable
   {:identity-hash-fields (constantly [:entity_id])})
+
+(defn add-app-id
+  "Add `app_id` to Collections that are linked with an App."
+  {:batched-hydrate :app_id}
+  [collections]
+  (if-let [coll-ids (seq (into #{}
+                               (comp (map :id)
+                                     ;; The ID "root" breaks the query.
+                                     (filter int?))
+                               collections))]
+    (let [coll-id->app-id (into {}
+                                (map (juxt :collection_id :id))
+                                (db/select [App :collection_id :id]
+                                           :collection_id [:in coll-ids]))]
+      (for [coll collections]
+        (let [app-id (coll-id->app-id (:id coll))]
+          (cond-> coll
+            app-id (assoc :app_id app-id)))))
+    collections))


### PR DESCRIPTION
Addresses #24941, part of #24861

Collections with an app attached will be returned with an `app_id` field
containing the ID of the App. Only the list and fetch endpoints hydrate
this field, e.g the update endpoint does not.