### PR TITLE
Lift the row limit for saved question references in native SQL

### DIFF
--- a/src/metabase/query_processor/interface.clj
+++ b/src/metabase/query_processor/interface.clj
@@ -3,7 +3,11 @@
 ;; TODO - Not 100% sure we really need this namespace since it's almost completely empty these days. Seems like the
 ;; things here could be moved elsewhere
 
-;; TODO - I think this could go in the `limit` namespace
+;; TODO - I think these could go in the `limit` namespace
+(def absolute-max-results-for-model-nested-queries
+  "This is a large number for when a limit is required, but we actually don't want one."
+  1000000000)
+
 (def absolute-max-results
   "Maximum number of rows the QP should ever return.
 

--- a/src/metabase/query_processor/middleware/limit.clj
+++ b/src/metabase/query_processor/middleware/limit.clj
@@ -24,7 +24,9 @@
   [query]
   (or (qp.constraints/max-results-bare-rows)
       (mbql.u/query->max-rows-limit query)
-      qp.i/absolute-max-results))
+      (if (some? (get-in query [:info :card-id]))
+        qp.i/absolute-max-results-for-model-nested-queries
+        qp.i/absolute-max-results)))
 
 (defn add-default-limit
   "Pre-processing middleware. Add default `:limit` to MBQL queries without any aggregations."

--- a/test/metabase/query_processor/middleware/limit_test.clj
+++ b/test/metabase/query_processor/middleware/limit_test.clj
@@ -27,6 +27,19 @@
                        :query       {:aggregation [[:count]]}})
                mt/rows count)))))
 
+(deftest max-results-models-test
+  (testing "A query on a model should have a default limit of [[qp.i/absolute-max-results-for-model-nested-queries]]"
+    (let [query (assoc (mt/mbql-query venues)
+                       :info {:card-id 1234})]
+      (is (= qp.i/absolute-max-results-for-model-nested-queries
+             (-> (limit/add-default-limit query)
+                 :query :limit)))))
+  (testing "But otherwise, the query should have a limit of [[qp.i/absolute-max-results]]"
+    (let [query (mt/mbql-query venues)]
+      (is (= qp.i/absolute-max-results
+             (-> (limit/add-default-limit query)
+                 :query :limit))))))
+
 (deftest no-aggregation-test
   (testing "Apply a max-results-bare-rows limit specifically on no-aggregation query"
     (let [query  {:constraints {:max-results 46}


### PR DESCRIPTION
WIP - there a few BE tests failing

Should fix https://github.com/metabase/metabase/issues/24969

To reproduce this bug on stats.metabase.com:
1. Open the query builder, using the Snowplow database, select the "Page Views" model for Data, and "Count rows of..." for summarization. Observe the result is 7,965,583.
2. Open a native SQL query editor, using the Snowplow database. Run this query: `select count(*) from {{#3367}}`. The result will be 1,048,575.

