### PR TITLE
Lift max results limit for cached models and questions

### DIFF
--- a/shared/src/metabase/mbql/schema.cljc
+++ b/shared/src/metabase/mbql/schema.cljc
@@ -1487,6 +1487,11 @@
    (s/optional-key :disable-mbql->native?)
    s/Bool
 
+   ;; Disable applying a default limit on the query results. Handled in the `add-default-limit` middleware.
+   ;; If true, this will override the `:max-results` and `:max-results-bare-rows` values in [[Constraints]].
+   (s/optional-key :disable-max-results?)
+   s/Bool
+
    ;; Userland queries are ones ran as a result of an API call, Pulse, or the like. Special handling is done in the
    ;; `process-userland-query` middleware for such queries -- results are returned in a slightly different format, and
    ;; QueryExecution entries are normally saved, unless you pass `:no-save` as the option.

--- a/src/metabase/models/persisted_info.clj
+++ b/src/metabase/models/persisted_info.clj
@@ -41,7 +41,7 @@
   (String. ^bytes (codecs/bytes->b64 (qp.util/query-hash query))))
 
 (def ^:dynamic *allow-persisted-substitution*
-  "Allow persisted substitution. When refreshing, set this to nil to ensure that all undelrying queries are used to
+  "Allow persisted substitution. When refreshing, set this to nil to ensure that all underlying queries are used to
   rebuild the persisted table."
   true)
 

--- a/src/metabase/query_processor/middleware/limit.clj
+++ b/src/metabase/query_processor/middleware/limit.clj
@@ -7,6 +7,12 @@
 
 ;;;; Pre-processing
 
+(defn disable-max-results? [query]
+  (get-in query [:middleware :disable-max-results?] false))
+
+(defn disable-max-results [query]
+  (assoc-in query [:middleware :disable-max-results?] true))
+
 (defn- add-limit [max-rows {query-type :type, {original-limit :limit}, :query, :as query}]
   (cond-> query
     (and (= query-type :query)
@@ -14,22 +20,25 @@
     (update :query assoc :limit max-rows, ::original-limit original-limit)))
 
 (defn determine-query-max-rows
-  "Given a `query`, return the max rows that should be returned.  This is the first non-nil value from (in decreasing
-  priority order):
+  "Given a `query`, return the max rows that should be returned, or `nil` if no limit should be applied.
+  If a limit should be applied, this is the first non-nil value from (in decreasing priority order):
 
   1. the value of the [[metabase.query-processor.middleware.constraints/max-results-bare-rows]] setting, which allows
      for database-local override
   2. the output of [[metabase.mbql.util/query->max-rows-limit]] when called on the given query
   3. [[metabase.query-processor.interface/absolute-max-results]] (a constant, non-nil backstop value)"
   [query]
-  (or (qp.constraints/max-results-bare-rows)
-      (mbql.u/query->max-rows-limit query)
-      qp.i/absolute-max-results))
+  (when-not (disable-max-results? query)
+    (or (qp.constraints/max-results-bare-rows)
+        (mbql.u/query->max-rows-limit query)
+        qp.i/absolute-max-results)))
 
 (defn add-default-limit
   "Pre-processing middleware. Add default `:limit` to MBQL queries without any aggregations."
   [query]
-  (add-limit (determine-query-max-rows query) query))
+  (if-let [max-rows (determine-query-max-rows query)]
+    (add-limit max-rows query)
+    query))
 
 
 ;;;; Post-processing

--- a/src/metabase/query_processor/middleware/limit.clj
+++ b/src/metabase/query_processor/middleware/limit.clj
@@ -7,10 +7,14 @@
 
 ;;;; Pre-processing
 
-(defn disable-max-results? [query]
+(defn disable-max-results?
+  "Returns the value of the disable-max-results? option in this query."
+  [query]
   (get-in query [:middleware :disable-max-results?] false))
 
-(defn disable-max-results [query]
+(defn disable-max-results
+  "Sets the value of the disable-max-results? option in this query."
+  [query]
   (assoc-in query [:middleware :disable-max-results?] true))
 
 (defn- add-limit [max-rows {query-type :type, {original-limit :limit}, :query, :as query}]

--- a/src/metabase/task/persist_refresh.clj
+++ b/src/metabase/task/persist_refresh.clj
@@ -17,6 +17,7 @@
             [metabase.models.persisted-info :as persisted-info :refer [PersistedInfo]]
             [metabase.models.task-history :refer [TaskHistory]]
             [metabase.public-settings :as public-settings]
+            [metabase.query-processor.middleware.limit :as limit]
             [metabase.query-processor.timezone :as qp.timezone]
             [metabase.task :as task]
             [metabase.util :as u]
@@ -53,7 +54,8 @@
   (reify Refresher
     (refresh! [_ database definition card]
       (binding [persisted-info/*allow-persisted-substitution* false]
-        (ddl.i/refresh! (:engine database) database definition (:dataset_query card))))
+        (let [query (limit/disable-max-results (:dataset_query card))]
+          (ddl.i/refresh! (:engine database) database definition query))))
     (unpersist! [_ database persisted-info]
      (ddl.i/unpersist! (:engine database) database persisted-info))))
 

--- a/test/metabase/query_processor/middleware/limit_test.clj
+++ b/test/metabase/query_processor/middleware/limit_test.clj
@@ -19,6 +19,20 @@
     (is (= test-max-results
            (-> (limit {:type :native}) mt/rows count)))))
 
+(deftest disable-max-results-test
+  (testing "Apply `absolute-max-results` limit in the default case"
+    (let [query {:type :query
+                 :query {}}]
+      (is (= {:type  :query
+              :query {:limit                qp.i/absolute-max-results
+                      ::limit/original-limit nil}}
+             (limit/add-default-limit query)))))
+  (testing "Don't apply the `absolute-max-results` limit when `disable-max-results` is used."
+    (let [query (limit/disable-max-results {:type :query
+                                            :query {}})]
+      (is (= query
+             (limit/add-default-limit query))))))
+
 (deftest max-results-constraint-test
   (testing "Apply an arbitrary max-results on the query and ensure our results size is appropriately constrained"
     (is (= 1234


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/24793

### The bug

Models and questions are by default limited by the `absolute-max-results` limit, if no other limit applies. This is a problem when their results are cached and we query on top of them.

### What changed?

I added a new option, `:disable-max-rows?` to the `:middleware` map on an MBQL query. This key gets handled in the `add-default-limit` middleware. I set this option to `true` in the [`refresh!` function](https://github.com/metabase/metabase/blob/f7d52f5b74f3f6c10973755d01698519038d179e/src/metabase/task/persist_refresh.clj#L57) for caching models.

### To verify:
1. Enable model caching ([instructions](http://localhost:3000/admin/tools/model-caching))
2. Create a test table with >1,048,575 rows. e.g.
```
persisted=# create table lots(id serial primary key not null, value int);
CREATE TABLE
persisted=# insert into lots (value) select i from generate_series(1, 2000000) as t(i);
INSERT 0 2000000
  INSERT 0 2000000
  persisted=# select count(*) from lots;
    count
  ---------
   2000000
  (1 row)
```
3. Sync the new table in Admin > Databases, choose the database, then "Sync the schema now"
4. Create a question from the test table that selects all rows from the test table, e.g.
<img width="988" alt="image" src="https://user-images.githubusercontent.com/39073188/186407622-1f3903c1-a43e-428f-9340-829704434199.png">

5. Turn the question into a model, and wait for caching to finish.

6. Create a new question from the model, counting rows. The result should be 2,000,000, where before it was 1,048,575.
<img width="996" alt="image" src="https://user-images.githubusercontent.com/39073188/186407901-4086897a-6058-4f52-993a-d45df257a7d3.png">