### PR TITLE
Add dashboard layout visual tests

### DIFF
--- a/frontend/test/metabase-visual/dashboard/dashboard-layout.cy.spec.js
+++ b/frontend/test/metabase-visual/dashboard/dashboard-layout.cy.spec.js
@@ -28,14 +28,10 @@ describe("visual tests > dashboard", () => {
     cy.findByText("How these transactions are distributed");
   });
 
-  describe("layout", () => {
-    it("view mode", () => {
-      cy.createPercySnapshot();
-    });
+  it("layout", () => {
+    cy.createPercySnapshot("view mode");
 
-    it("editing mode", () => {
-      cy.icon("pencil").click();
-      cy.createPercySnapshot();
-    });
+    cy.icon("pencil").click();
+    cy.createPercySnapshot("edit mode");
   });
 });

--- a/frontend/test/metabase-visual/dashboard/dashboard-layout.cy.spec.js
+++ b/frontend/test/metabase-visual/dashboard/dashboard-layout.cy.spec.js
@@ -1,0 +1,41 @@
+import { restore } from "__support__/e2e/helpers";
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+
+const { ORDERS_ID } = SAMPLE_DATABASE;
+
+describe("visual tests > dashboard", () => {
+  const VIEWPORT_WIDTH = 2500;
+  const VIEWPORT_HEIGHT = 1500;
+
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+    cy.viewport(VIEWPORT_WIDTH, VIEWPORT_HEIGHT);
+
+    cy.intercept("GET", "/app/assets/geojson/**").as("geojson");
+    cy.intercept("POST", "/api/dashboard/save");
+
+    cy.visit(`/auto/dashboard/table/${ORDERS_ID}`);
+    // Need to wait until cards load before saving the dashboard
+    cy.wait("@geojson", { timeout: 10000 });
+    cy.button("Save this").click();
+
+    cy.findByText("Your dashboard was saved");
+    cy.findByText("See it").click();
+
+    // Find for cards to load
+    cy.get(".Card").contains("18,760");
+    cy.findByText("How these transactions are distributed");
+  });
+
+  describe("layout", () => {
+    it("view mode", () => {
+      cy.createPercySnapshot();
+    });
+
+    it("editing mode", () => {
+      cy.icon("pencil").click();
+      cy.createPercySnapshot();
+    });
+  });
+});


### PR DESCRIPTION
We'll introduce changes around dashboard code soon that might end up with visual regressions. We have some visual coverage mostly focused on dashboard filters and full-screen mode. This PR extends that one a bit so that we can cover:

* at least a few types of charts on dash cards
* markdown cards
* both view and editing mode

The test uses using x-rayed Orders table to simplify the setup

### Demo

<details>
<summary>View mode snapshot</summary>
<img width="1580" alt="dashboard-view-mode-snapshot" src="https://user-images.githubusercontent.com/17258145/186412086-62c4398d-13ed-4260-bada-cfa5a084859f.png">

</details>

<details>
<summary>Edit mode snapshot</summary>
<img width="1580" alt="dashboard-editing-mode-snapshot" src="https://user-images.githubusercontent.com/17258145/186412101-1a0c36f6-70eb-471b-84cd-d45b1cc290bd.png">

</details>