### PR TITLE
Fix `ul` position in `MainNavbarView`

### DIFF
--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarView.tsx
@@ -155,12 +155,12 @@ function MainNavbarView({
           </SidebarSection>
         )}
 
-        <ul>
-          {hasDataAccess && (
-            <SidebarSection>
-              <SidebarHeadingWrapper>
-                <SidebarHeading>{t`Data`}</SidebarHeading>
-              </SidebarHeadingWrapper>
+        {hasDataAccess && (
+          <SidebarSection>
+            <SidebarHeadingWrapper>
+              <SidebarHeading>{t`Data`}</SidebarHeading>
+            </SidebarHeadingWrapper>
+            <ul>
               <BrowseLink
                 icon="database"
                 url={BROWSE_URL}
@@ -183,9 +183,9 @@ function MainNavbarView({
                   {t`Add your own data`}
                 </AddYourOwnDataLink>
               )}
-            </SidebarSection>
-          )}
-        </ul>
+            </ul>
+          </SidebarSection>
+        )}
       </div>
     </SidebarContentRoot>
   );


### PR DESCRIPTION
Fixes an incorrect HTML structure in the navigation sidebar. We use `ul` and `li` to organize sidebar links. It's expected that `li` are direct children of `ul` and we didn't follow that for the "Data" section. Also, there might be a case when we don't show the "Data" section at all, but we'd still have an empty `ul` in the markup. Both issues should be fixed now