### PR TITLE
Distinguish data app collections from regular ones

### DIFF
--- a/frontend/src/metabase-types/api/collection.ts
+++ b/frontend/src/metabase-types/api/collection.ts
@@ -23,6 +23,11 @@ export interface Collection {
   // Assigned on FE
   originalName?: string;
   path?: CollectionId[];
+
+  // If collection is associated to a data app, it will get an app_id
+  // Data apps are technically collections with extended features
+  // and `app_id` is used to differentiate them from regular collections
+  app_id?: number;
 }
 
 export interface CollectionItem {

--- a/frontend/src/metabase/entities/collections/utils.js
+++ b/frontend/src/metabase/entities/collections/utils.js
@@ -7,12 +7,19 @@ import {
   isPersonalCollection,
   canonicalCollectionId,
 } from "metabase/collections/utils";
+import {
+  getDataAppIcon,
+  isDataAppCollection,
+} from "metabase/entities/data-apps/utils";
 
 import { PLUGIN_COLLECTIONS } from "metabase/plugins";
 
 import { ROOT_COLLECTION, PERSONAL_COLLECTIONS } from "./constants";
 
 export function getCollectionIcon(collection, { tooltip = "default" } = {}) {
+  if (isDataAppCollection(collection)) {
+    return getDataAppIcon();
+  }
   if (collection.id === PERSONAL_COLLECTIONS.id) {
     return { name: "group" };
   }

--- a/frontend/src/metabase/entities/data-apps/data-apps.ts
+++ b/frontend/src/metabase/entities/data-apps/data-apps.ts
@@ -9,7 +9,7 @@ import { Collection, DataApp } from "metabase-types/api";
 import { DEFAULT_COLLECTION_COLOR_ALIAS } from "../collections/constants";
 
 import { createForm } from "./forms";
-import { getDataAppIcon } from "./utils";
+import { getDataAppIcon, isDataAppCollection } from "./utils";
 
 type EditableDataAppParams = Pick<
   DataApp,
@@ -60,6 +60,6 @@ const DataApps = createEntity({
   },
 });
 
-export { getDataAppIcon };
+export { getDataAppIcon, isDataAppCollection };
 
 export default DataApps;

--- a/frontend/src/metabase/entities/data-apps/utils.ts
+++ b/frontend/src/metabase/entities/data-apps/utils.ts
@@ -1,4 +1,4 @@
-import { Collection, DataApp } from "metabase-types/api";
+import type { Collection, DataApp } from "metabase-types/api";
 
 export function getDataAppIcon(app?: DataApp) {
   return { name: "star" };

--- a/frontend/src/metabase/entities/data-apps/utils.ts
+++ b/frontend/src/metabase/entities/data-apps/utils.ts
@@ -1,5 +1,9 @@
-import { DataApp } from "metabase-types/api";
+import { Collection, DataApp } from "metabase-types/api";
 
-export function getDataAppIcon(app: DataApp) {
+export function getDataAppIcon(app?: DataApp) {
   return { name: "star" };
+}
+
+export function isDataAppCollection(collection: Collection) {
+  return typeof collection.app_id === "number";
 }

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer.tsx
@@ -19,7 +19,7 @@ import {
 } from "metabase-types/api";
 import { State } from "metabase-types/store";
 
-import DataApps from "metabase/entities/data-apps";
+import DataApps, { isDataAppCollection } from "metabase/entities/data-apps";
 import Bookmarks, { getOrderedBookmarks } from "metabase/entities/bookmarks";
 import Collections, {
   buildCollectionTree,
@@ -202,24 +202,19 @@ function MainNavbarContainer({
   }, [location, params, question, dashboard]);
 
   const collectionTree = useMemo<CollectionTreeItem[]>(() => {
-    const dataAppCollectionIDs = dataApps.map(dataApp => dataApp.collection_id);
-
     const preparedCollections = [];
     const userPersonalCollections = currentUserPersonalCollections(
       collections,
       currentUser.id,
     );
-    const nonPersonalOrArchivedCollections = collections.filter(
-      nonPersonalOrArchivedCollection,
-    );
-    const nonAppsCollections = nonPersonalOrArchivedCollections.filter(
+    const displayableCollections = collections.filter(
       collection =>
-        typeof collection.id === "number" &&
-        !dataAppCollectionIDs.includes(collection.id),
+        nonPersonalOrArchivedCollection(collection) &&
+        !isDataAppCollection(collection),
     );
 
     preparedCollections.push(...userPersonalCollections);
-    preparedCollections.push(...nonAppsCollections);
+    preparedCollections.push(...displayableCollections);
 
     const tree = buildCollectionTree(preparedCollections);
 
@@ -233,7 +228,7 @@ function MainNavbarContainer({
     } else {
       return tree;
     }
-  }, [rootCollection, collections, currentUser, dataApps]);
+  }, [rootCollection, collections, currentUser]);
 
   const reorderBookmarks = useCallback(
     ({ newIndex, oldIndex }) => {


### PR DESCRIPTION
Part of #24861, based on #24950

We're building data apps on top of collections technically (as they share a lot of logic). So we need a way to distinguish "app collections" from regular collections. #24950 extended collection endpoints to hydrate an `app_id` property for a collection if there is one. This PR makes the FE take this parameter in mind:

* app collections are going to be excluded from nav sidebar's "Collections" section — apps have their own dedicated section
* we're going to show a "star" icon instead of "folder" for apps, so it's easier to notice it's a different entity

> **Note**
> This is still work in progress and we'll need to fix how those collections are presented in a few more places. For instance search, activity or recent items. They have much lower priority though, so we'll probably get back to them a bit later

### To Verify

1. "+ New" > App > Fill in the details > Save
2. Make sure you can't see the "app collection" in the sidebar's "Collections" section
3. Make sure you see a "star" icon instead of "folder" when looking at the app at collection picker, saved question picker collection tree, etc.