### PR TITLE
Add schema nesting map errors for defendpoint

### DIFF
--- a/src/metabase/util/schema.clj
+++ b/src/metabase/util/schema.clj
@@ -100,6 +100,7 @@
        (when (instance? schema.core.Maybe schema)
          (when-let [message (api-error-message (:schema schema))]
            (deferred-tru "value may be nil, or if non-nil, {0}" message)))
+
        ;; we can do something similar for enum schemas which are also likely to be defined inline
        (when (instance? schema.core.EnumSchema schema)
          (deferred-tru "value must be one of: {0}." (str/join ", " (for [v (sort (map str (:vs schema)))]
@@ -115,16 +116,12 @@
        (when (instance? schema.core.ConditionalSchema schema)
          (create-cond-schema-message (map second (:preds-and-schemas schema))))
 
-
-
-       
        ;; do the same for sequences of a schema
        (when (vector? schema)
          (str (deferred-tru "value must be an array.")
               (when (= (count schema) 1)
                 (when-let [message (api-error-message (first schema))]
                   (str " " (deferred-tru "Each {0}" message))))))
-
 
        ;; Optional map keys
        (when (instance? schema.core.OptionalKey schema)
@@ -138,19 +135,20 @@
        ;; this keeps track of indentation because the message is very difficult to read without it.
        (when (instance? clojure.lang.PersistentArrayMap schema)
          (let [spaces (str/join (repeat indent-depth "  "))]
-           (str (deferred-tru "value must be a map with schema: (\n")
-                spaces "  "
-                (str/join
-                 (str "\n" spaces "  ")
-                 (for [k (sort-by pr-str (keys schema))] ;; keep order of keys deterministic
-                   (str
-                    (api-error-message k (inc indent-depth))
-                    " : "
-                    (api-error-message (get schema k) (inc indent-depth)))
-                   ))
-                "\n"
-                spaces
-                ")"))))))
+           (str (deferred-tru "value must be a map with schema: (\n{0}{1}{2}{3}{4}{5}"
+                  spaces
+                  "  "
+                  (str/join
+                   (str "\n" spaces "  ")
+                   (for [k (sort-by pr-str (keys schema))] ;; keep order of keys deterministic
+                     (str
+                      (api-error-message k (inc indent-depth))
+                      " : "
+                      (api-error-message (get schema k) (inc indent-depth)))
+                     ))
+                  "\n"
+                  spaces
+                  ")")))))))
 
 (defn non-empty
   "Add an addditonal constraint to `schema` (presumably an array) that requires it to be non-empty

--- a/src/metabase/util/schema.clj
+++ b/src/metabase/util/schema.clj
@@ -90,36 +90,67 @@
     (api-error-message (s/maybe (non-empty [NonBlankString])))
     ;; -> \"value may be nil, or if non-nil, value must be an array. Each value must be a non-blank string.
             The array cannot be empty.\""
-  [schema]
-  (or (:api-error-message schema)
-      (existing-schema->api-error-message schema)
-      ;; for schemas wrapped by an `s/maybe` we can generate a nice error message like
-      ;; "value may be nil, or if non-nil, value must be ..."
-      (when (instance? schema.core.Maybe schema)
-        (when-let [message (api-error-message (:schema schema))]
-          (deferred-tru "value may be nil, or if non-nil, {0}" message)))
-      ;; we can do something similar for enum schemas which are also likely to be defined inline
-      (when (instance? schema.core.EnumSchema schema)
-        (deferred-tru "value must be one of: {0}." (str/join ", " (for [v (sort (map str (:vs schema)))]
-                                                                    (str "`" v "`")))))
-      ;; For cond-pre schemas we'll generate something like
-      ;; value must satisfy one of the following requirements:
-      ;; 1) value must be a boolean.
-      ;; 2) value must be a valid boolean string ('true' or 'false').
-      (when (instance? schema.core.CondPre schema)
-        (create-cond-schema-message (:schemas schema)))
 
-      ;; For conditional schemas we'll generate a string similar to `cond-pre` above
-      (when (instance? schema.core.ConditionalSchema schema)
-        (create-cond-schema-message (map second (:preds-and-schemas schema))))
+  ([schema] (api-error-message schema 0))
+  ([schema indent-depth]
+   (or (:api-error-message schema)
+       (existing-schema->api-error-message schema)
+       ;; for schemas wrapped by an `s/maybe` we can generate a nice error message like
+       ;; "value may be nil, or if non-nil, value must be ..."
+       (when (instance? schema.core.Maybe schema)
+         (when-let [message (api-error-message (:schema schema))]
+           (deferred-tru "value may be nil, or if non-nil, {0}" message)))
+       ;; we can do something similar for enum schemas which are also likely to be defined inline
+       (when (instance? schema.core.EnumSchema schema)
+         (deferred-tru "value must be one of: {0}." (str/join ", " (for [v (sort (map str (:vs schema)))]
+                                                                     (str "`" v "`")))))
+       ;; For cond-pre schemas we'll generate something like
+       ;; value must satisfy one of the following requirements:
+       ;; 1) value must be a boolean.
+       ;; 2) value must be a valid boolean string ('true' or 'false').
+       (when (instance? schema.core.CondPre schema)
+         (create-cond-schema-message (:schemas schema)))
 
-      ;; do the same for sequences of a schema
-      (when (vector? schema)
-        (str (deferred-tru "value must be an array.")
-             (when (= (count schema) 1)
-               (when-let [message (api-error-message (first schema))]
-                 (str " " (deferred-tru "Each {0}" message))))))))
+       ;; For conditional schemas we'll generate a string similar to `cond-pre` above
+       (when (instance? schema.core.ConditionalSchema schema)
+         (create-cond-schema-message (map second (:preds-and-schemas schema))))
 
+
+
+       
+       ;; do the same for sequences of a schema
+       (when (vector? schema)
+         (str (deferred-tru "value must be an array.")
+              (when (= (count schema) 1)
+                (when-let [message (api-error-message (first schema))]
+                  (str " " (deferred-tru "Each {0}" message))))))
+
+
+       ;; Optional map keys
+       (when (instance? schema.core.OptionalKey schema)
+         (deferred-tru "{0} (optional)" (api-error-message (:k schema))))
+
+       ;; schema map keys
+       (when (instance? clojure.lang.Keyword schema)
+         (name schema))
+
+       ;; for maps of a schema, write out what keys and values
+       ;; this keeps track of indentation because the message is very difficult to read without it.
+       (when (instance? clojure.lang.PersistentArrayMap schema)
+         (let [spaces (str/join (repeat indent-depth "  "))]
+           (str (deferred-tru "value must be a map with schema: (\n")
+                spaces "  "
+                (str/join
+                 (str "\n" spaces "  ")
+                 (for [k (sort-by pr-str (keys schema))] ;; keep order of keys deterministic
+                   (str
+                    (api-error-message k (inc indent-depth))
+                    " : "
+                    (api-error-message (get schema k) (inc indent-depth)))
+                   ))
+                "\n"
+                spaces
+                ")"))))))
 
 (defn non-empty
   "Add an addditonal constraint to `schema` (presumably an array) that requires it to be non-empty

--- a/test/metabase/api/action_test.clj
+++ b/test/metabase/api/action_test.clj
@@ -303,13 +303,13 @@
                           (mt/user-http-request :crowberto :post 400 "action" {:type "query"})))
             (is (partial= {:errors {:name "value must be a string."}}
                           (mt/user-http-request :crowberto :post 400 "action" {:type "http"})))
-            (is (partial= {:errors {:template "Value does not match schema: (not (map? nil))"}}
+            (is (partial= {:errors {:template "value must be a map with schema: (\n  body (optional) : value may be nil, or if non-nil, value must be a string.\n  headers (optional) : value may be nil, or if non-nil, value must be a string.\n  parameter_mappings (optional) : value may be nil, or if non-nil, value must be a map.\n  parameters (optional) : value may be nil, or if non-nil, value must be an array. Each value must be a map.\n  method : value must be one of: `DELETE`, `GET`, `PATCH`, `POST`, `PUT`.\n  url : value must be a string.\n)"}}
                           (mt/user-http-request :crowberto :post 400 "action" {:type "http" :name "test"}))))
           (testing "Template needs method and url"
-            (is (partial= {:errors {:template "Value does not match schema: {:method missing-required-key, :url missing-required-key}"}}
+            (is (partial= {:errors {:template "value must be a map with schema: (\n  body (optional) : value may be nil, or if non-nil, value must be a string.\n  headers (optional) : value may be nil, or if non-nil, value must be a string.\n  parameter_mappings (optional) : value may be nil, or if non-nil, value must be a map.\n  parameters (optional) : value may be nil, or if non-nil, value must be an array. Each value must be a map.\n  method : value must be one of: `DELETE`, `GET`, `PATCH`, `POST`, `PUT`.\n  url : value must be a string.\n)"}}
                           (mt/user-http-request :crowberto :post 400 "action" {:type "http" :name "Test" :template {}}))))
           (testing "Template parameters should be well formed"
-            (is (partial= {:errors {:template "Value does not match schema: {:parameters (not (sequential? {}))}"}}
+            (is (partial= {:errors {:template "value must be a map with schema: (\n  body (optional) : value may be nil, or if non-nil, value must be a string.\n  headers (optional) : value may be nil, or if non-nil, value must be a string.\n  parameter_mappings (optional) : value may be nil, or if non-nil, value must be a map.\n  parameters (optional) : value may be nil, or if non-nil, value must be an array. Each value must be a map.\n  method : value must be one of: `DELETE`, `GET`, `PATCH`, `POST`, `PUT`.\n  url : value must be a string.\n)"}}
                           (mt/user-http-request :crowberto :post 400 "action" {:type "http"
                                                                                :name "Test"
                                                                                :template {:url "https://example.com"
@@ -334,7 +334,7 @@
             (is (partial= {:errors {:type "Only http actions are supported at this time."}}
                           (mt/user-http-request :crowberto :put 400 action-path {:type "query"}))))
           (testing "Template needs method and url"
-            (is (partial= {:errors {:template "Value does not match schema: {:method missing-required-key, :url missing-required-key}"}}
+            (is (partial= {:errors {:template "value may be nil, or if non-nil, value must be a map with schema: (\n  body (optional) : value may be nil, or if non-nil, value must be a string.\n  headers (optional) : value may be nil, or if non-nil, value must be a string.\n  parameter_mappings (optional) : value may be nil, or if non-nil, value must be a map.\n  parameters (optional) : value may be nil, or if non-nil, value must be an array. Each value must be a map.\n  method : value must be one of: `DELETE`, `GET`, `PATCH`, `POST`, `PUT`.\n  url : value must be a string.\n)"}}
                           (mt/user-http-request :crowberto :put 400 action-path {:type "http" :template {}}))))
           (testing "Handles need to be valid jq"
             (is (partial= {:errors {:response_handle "value may be nil, or if non-nil, must be a valid json-query"}}

--- a/test/metabase/util/schema_test.clj
+++ b/test/metabase/util/schema_test.clj
@@ -42,17 +42,18 @@
 
 (deftest ^:parallel api-param-test
   (testing "check that API error message respects `api-param` when specified"
-    (is (= (str "## `POST metabase.util.schema-test/:id/dimension`\n"
-                "\n"
-                "Sets the dimension for the given object with ID.\n"
-                "\n"
-                "### PARAMS:\n"
-                "\n"
-                "*  **`id`** \n"
-                "\n"
-                "*  **`type`** value must be one of: `external`, `internal`.\n"
-                "\n"
-                "*  **`dimension-name`** value must be a non-blank string.")
+    (is (= (str/join "\n"
+                     ["## `POST metabase.util.schema-test/:id/dimension`"
+                      ""
+                      "Sets the dimension for the given object with ID."
+                      ""
+                      "### PARAMS:"
+                      ""
+                      "*  **`id`** "
+                      ""
+                      "*  **`type`** value must be one of: `external`, `internal`."
+                      ""
+                      "*  **`dimension-name`** value must be a non-blank string."])
            (:doc (meta #'POST_:id_dimension))))))
 
 (defn- ex-info-msg [f]

--- a/test/metabase/util/schema_test.clj
+++ b/test/metabase/util/schema_test.clj
@@ -1,12 +1,12 @@
 (ns metabase.util.schema-test
   "Tests for utility schemas and various API helper functions."
-  (:require [clojure.test :refer :all]
+  (:require [clojure.string :as str]
+            [clojure.test :refer :all]
             [compojure.core :refer [POST]]
             [metabase.api.common :as api]
             [metabase.test :as mt]
             [metabase.util.schema :as su]
-            [schema.core :as s]
-            [clojure.string :as str]))
+            [schema.core :as s]))
 
 (deftest ^:parallel generate-api-error-message-test
   (testing "check that the API error message generation is working as intended"


### PR DESCRIPTION
Improves error messages for nested maps in schemas for e.g. defendpoint

This was prompted by an error printed out in development because a certain defendpoint's spec value was a nested map, and that was not a handled case. I tried teasing the map out into a single layer in https://github.com/metabase/metabase/pull/24957, but the error messages returned were confusing. For example, an error with `{:template {:url "here"}}` is explained by `{"template-url": "this must be a string"}` or some-such message the error response, and the keys/paths do not line up.

see: the error for `metabase.api.action/HTTPActionTemplate`:

```
"value must be a map with schema: (
  body (optional) : value may be nil, or if non-nil, value must be a string.
  headers (optional) : value may be nil, or if non-nil, value must be a string.
  parameter_mappings (optional) : value may be nil, or if non-nil, value must be a map.
  parameters (optional) : value may be nil, or if non-nil, value must be an array. Each value must be a map.
  method : value must be one of: `DELETE`, `GET`, `PATCH`, `POST`, `PUT`.
  url : value must be a string.
)"
```