### PR TITLE
Remove redirectToNewQuestionFlow

### DIFF
--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
@@ -29,7 +29,7 @@ import {
 import { Card, SavedCard } from "metabase-types/types/Card";
 
 import { getQueryBuilderModeFromLocation } from "../../typed-utils";
-import { redirectToNewQuestionFlow, updateUrl } from "../navigation";
+import { updateUrl } from "../navigation";
 import { cancelQuery, runQuestionQuery } from "../querying";
 
 import { resetQB } from "./core";
@@ -200,17 +200,6 @@ async function handleQBInit(
   const uiControls: UIControls = getQueryBuilderModeFromLocation(location);
   const { options, serializedCard } = parseHash(location.hash);
   const hasCard = cardId || serializedCard;
-
-  if (
-    !hasCard &&
-    !options.db &&
-    !options.table &&
-    !options.segment &&
-    !options.metric
-  ) {
-    dispatch(redirectToNewQuestionFlow());
-    return;
-  }
 
   const deserializedCard = serializedCard
     ? deserializeCard(serializedCard)

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.unit.spec.ts
@@ -693,12 +693,6 @@ describe("QB Actions > initializeQB", () => {
       };
     }
 
-    it("redirects to new question flow if missing any options", async () => {
-      const redirectSpy = jest.spyOn(navigation, "redirectToNewQuestionFlow");
-      await setupBlank();
-      expect(redirectSpy).toHaveBeenCalledTimes(1);
-    });
-
     it("constructs a card based on provided 'db' param", async () => {
       const expectedCard = Question.create({
         databaseId: SAMPLE_DATABASE?.id,

--- a/frontend/src/metabase/query_builder/actions/navigation.js
+++ b/frontend/src/metabase/query_builder/actions/navigation.js
@@ -112,14 +112,6 @@ export const locationChanged =
     }
   };
 
-export const REDIRECT_TO_NEW_QUESTION_FLOW =
-  "metabase/qb/REDIRECT_TO_NEW_QUESTION_FLOW";
-
-export const redirectToNewQuestionFlow = createThunkAction(
-  REDIRECT_TO_NEW_QUESTION_FLOW,
-  () => dispatch => dispatch(replace("/question/new")),
-);
-
 export const UPDATE_URL = "metabase/qb/UPDATE_URL";
 export const updateUrl = createThunkAction(
   UPDATE_URL,


### PR DESCRIPTION
Logic is no longer used — we have stopped displaying the screen with the choice of simple question, custom question etc.