### PR TITLE
Fix lost metadata when updating Model query

### DIFF
--- a/frontend/src/metabase-lib/lib/Question.ts
+++ b/frontend/src/metabase-lib/lib/Question.ts
@@ -1283,6 +1283,11 @@ class QuestionInner {
     return hasQueryBeenAltered ? question.markDirty() : question;
   }
 
+  /*
+   * Defines endpoint for Dataset (Model) updates,
+   * (not a save in db)
+   * inserts parameters, metadata, and a promise if cancelled
+   */
   buildDatasetRequest(parameters, cancelDeferred) {
     return query => {
       const endpoint = maybeUsePivotEndpoint(

--- a/frontend/src/metabase-lib/lib/Question.ts
+++ b/frontend/src/metabase-lib/lib/Question.ts
@@ -1126,6 +1126,7 @@ class QuestionInner {
       const datasetQueries = this.atomicQueries().map(query =>
         query.datasetQuery(),
       );
+
       return Promise.all(datasetQueries.map(getDatasetQueryResult));
     }
   }
@@ -1283,25 +1284,26 @@ class QuestionInner {
   }
 
   buildDatasetRequest(parameters, cancelDeferred) {
-    return datasetQuery => {
-      const datasetQueryWithParameters = {
-        ...datasetQuery,
+    return query => {
+      const endpoint = maybeUsePivotEndpoint(
+        MetabaseApi.dataset,
+        this.card(),
+        this.metadata(),
+      );
+
+      const queryWithParameters = {
+        ...query,
         parameters,
         metadata: this._card.result_metadata,
       };
 
-      return maybeUsePivotEndpoint(
-        MetabaseApi.dataset,
-        this.card(),
-        this.metadata(),
-      )(
-        datasetQueryWithParameters,
-        cancelDeferred
-          ? {
-              cancelled: cancelDeferred.promise,
-            }
-          : {},
-      );
+      const ifCancelled = cancelDeferred
+        ? {
+            cancelled: cancelDeferred.promise,
+          }
+        : {};
+
+      return endpoint(queryWithParameters, ifCancelled);
     };
   }
 

--- a/frontend/src/metabase-lib/lib/Question.ts
+++ b/frontend/src/metabase-lib/lib/Question.ts
@@ -298,7 +298,7 @@ class QuestionInner {
    * @returns boolean
    */
   isDataset() {
-    return this._card && this._card.dataset;
+    return this._card?.dataset;
   }
 
   isPersisted() {
@@ -1296,11 +1296,7 @@ class QuestionInner {
         this.metadata(),
       );
 
-      const queryWithParameters = {
-        ...query,
-        parameters,
-        "dataset-metadata": this._card.result_metadata,
-      };
+      const payload = this.buildDatasetQueryPayload(query, parameters);
 
       const ifCancelled = cancelDeferred
         ? {
@@ -1308,8 +1304,23 @@ class QuestionInner {
           }
         : {};
 
-      return endpoint(queryWithParameters, ifCancelled);
+      return endpoint(payload, ifCancelled);
     };
+  }
+
+  buildDatasetQueryPayload(query, parameters) {
+    const payload = {
+      ...query,
+      parameters,
+    };
+
+    const resultMetadata = this._card?.result_metadata;
+
+    if (this.isDataset() && resultMetadata) {
+      payload["dataset-metadata"] = resultMetadata;
+    }
+
+    return payload;
   }
 
   getUrlWithParameters(parameters, parameterValues, { objectId, clean } = {}) {

--- a/frontend/src/metabase-lib/lib/Question.ts
+++ b/frontend/src/metabase-lib/lib/Question.ts
@@ -1299,7 +1299,7 @@ class QuestionInner {
       const queryWithParameters = {
         ...query,
         parameters,
-        metadata: this._card.result_metadata,
+        "dataset-metadata": this._card.result_metadata,
       };
 
       const ifCancelled = cancelDeferred

--- a/frontend/test/metabase/scenarios/models/reproductions/22517-add-remove-column-drops-metadata.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/reproductions/22517-add-remove-column-drops-metadata.cy.spec.js
@@ -1,7 +1,6 @@
-import { restore } from "__support__/e2e/helpers";
-import { openDetailsSidebar } from "../helpers/e2e-models-helpers";
+import { openQuestionActions, restore } from "__support__/e2e/helpers";
 
-describe.skip("issue 22517", () => {
+describe("issue 22517", () => {
   beforeEach(() => {
     cy.intercept("POST", "/api/card/*/query").as("cardQuery");
     cy.intercept("PUT", "/api/card/*").as("updateMetadata");
@@ -18,9 +17,9 @@ describe.skip("issue 22517", () => {
       { visitQuestion: true },
     );
 
-    openDetailsSidebar();
+    openQuestionActions();
 
-    cy.findByText("Customize metadata").click();
+    cy.findByText("Edit metadata").click();
     cy.wait(["@cardQuery", "@cardQuery"]);
 
     renameColumn("ID", "Foo");
@@ -29,8 +28,8 @@ describe.skip("issue 22517", () => {
     cy.wait("@updateMetadata");
   });
 
-  it("adding or removging a column should not drop previously edited metadata (metabase#22517)", () => {
-    openDetailsSidebar();
+  it("adding or removing a column should not drop previously edited metadata (metabase#22517)", () => {
+    openQuestionActions();
 
     cy.findByText("Edit query definition").click();
     cy.wait(["@cardQuery", "@cardQuery"]);

--- a/src/metabase/api/dataset.clj
+++ b/src/metabase/api/dataset.clj
@@ -69,8 +69,7 @@
                                   :context     context
                                   :card-id     source-card-id}
                            dataset-metadata
-                           (assoc :metadata/dataset-metadata dataset-metadata))
-        query             (dissoc query :metadata)]
+                           (assoc :metadata/dataset-metadata dataset-metadata))]
     (binding [qp.perms/*card-id* source-card-id]
       (qp.streaming/streaming-response [context export-format]
         (qp-runner query info context)))))
@@ -78,7 +77,8 @@
 (api/defendpoint ^:streaming POST "/"
   "Execute a query and retrieve the results in the usual format.
 
-  Optionally passing `dataset-metadata` to blend an user edits metadata with the runtime computed metadata."
+  Optionally passing `dataset-metadata` to blend an user edits metadata with the runtime computed metadata.
+  This parameter is meant to be used for editting Models's query only."
   [:as {{:keys [database dataset-metadata] :as query} :body}]
   {database         (s/maybe s/Int)
    dataset-metadata (s/maybe qr/ResultsMetadata)}

--- a/src/metabase/api/dataset.clj
+++ b/src/metabase/api/dataset.clj
@@ -19,6 +19,7 @@
             [metabase.query-processor.pivot :as qp.pivot]
             [metabase.query-processor.streaming :as qp.streaming]
             [metabase.query-processor.util :as qp.util]
+            [metabase.sync.analyze.query-results :as qr]
             [metabase.shared.models.visualization-settings :as mb.viz]
             [metabase.util :as u]
             [metabase.util.i18n :refer [trs tru]]
@@ -40,7 +41,7 @@
     source-card-id))
 
 (defn- run-query-async
-  [{:keys [database], :as query}
+  [{:keys [database metadata], :as query}
    & {:keys [context export-format qp-runner]
       :or   {context       :ad-hoc
              export-format :api
@@ -56,24 +57,31 @@
     (when (int? table-id)
       (events/publish-event! :table-read (assoc (db/select-one Table :id table-id) :actor_id api/*current-user-id*))))
   ;; add sensible constraints for results limits on our query
-  (let [source-card-id (query->source-card-id query)
-        source-card    (when source-card-id
-                         (db/select-one [Card :result_metadata :dataset] :id source-card-id))
-        info           (cond-> {:executed-by api/*current-user-id*
-                                :context     context
-                                :card-id     source-card-id}
-                         (:dataset source-card)
-                         (assoc :metadata/dataset-metadata (:result_metadata source-card)))]
+  (let [source-card-id   (query->source-card-id query)
+        source-card      (when source-card-id
+                           (db/select-one [Card :result_metadata :dataset] :id source-card-id))
+        dataset-metadata (cond
+                           (:dataset source-card)
+                           (:result_metadata source-card)
+
+                           metadata
+                           (map mbql.normalize/normalize-source-metadata metadata))
+        info             (cond-> {:executed-by api/*current-user-id*
+                                  :context     context
+                                  :card-id     source-card-id}
+                           dataset-metadata
+                           (assoc :metadata/dataset-metadata dataset-metadata))
+        query             (dissoc query :metadata)]
     (binding [qp.perms/*card-id* source-card-id]
       (qp.streaming/streaming-response [context export-format]
         (qp-runner query info context)))))
 
 (api/defendpoint ^:streaming POST "/"
   "Execute a query and retrieve the results in the usual format."
-  [:as {{:keys [database] :as query} :body}]
-  {database (s/maybe s/Int)}
+  [:as {{:keys [database metadata] :as query} :body}]
+  {database        (s/maybe s/Int)
+   metadata        (s/maybe qr/ResultsMetadata)}
   (run-query-async (update-in query [:middleware :js-int-to-string?] (fnil identity true))))
-
 
 ;;; ----------------------------------- Downloading Query Results in Other Formats -----------------------------------
 

--- a/src/metabase/api/dataset.clj
+++ b/src/metabase/api/dataset.clj
@@ -78,7 +78,7 @@
   "Execute a query and retrieve the results in the usual format.
 
   Optionally passing `dataset-metadata` to blend an user edits metadata with the runtime computed metadata.
-  This parameter is meant to be used for editting Models's query only."
+  This parameter is meant to be used when editing Models's query."
   [:as {{:keys [database dataset-metadata] :as query} :body}]
   {database         (s/maybe s/Int)
    dataset-metadata (s/maybe qr/ResultsMetadata)}

--- a/src/metabase/api/dataset.clj
+++ b/src/metabase/api/dataset.clj
@@ -44,8 +44,7 @@
   "Run a query asynchronously."
   [{:keys [database], :as query}
    & {:keys [dataset-metadata context export-format qp-runner]
-      :or   {dataset-metadata nil
-             context          :ad-hoc
+      :or   {context          :ad-hoc
              export-format    :api
              qp-runner        qp/process-query-and-save-with-max-results-constraints!}}]
   (when (and (not= (:type query) "internal")
@@ -64,7 +63,7 @@
                            (db/select-one [Card :result_metadata :dataset] :id source-card-id))
         dataset-metadata (if (and (:dataset source-card) dataset-metadata)
                            (qp.util/combine-metadata (:result_metadata source-card) dataset-metadata)
-                           (or (:result_metadata source-card) dataset-metadata nil))
+                           (or (:result_metadata source-card) dataset-metadata))
         info             (cond-> {:executed-by api/*current-user-id*
                                   :context     context
                                   :card-id     source-card-id}

--- a/src/metabase/api/dataset.clj
+++ b/src/metabase/api/dataset.clj
@@ -19,8 +19,8 @@
             [metabase.query-processor.pivot :as qp.pivot]
             [metabase.query-processor.streaming :as qp.streaming]
             [metabase.query-processor.util :as qp.util]
-            [metabase.sync.analyze.query-results :as qr]
             [metabase.shared.models.visualization-settings :as mb.viz]
+            [metabase.sync.analyze.query-results :as qr]
             [metabase.util :as u]
             [metabase.util.i18n :refer [trs tru]]
             [metabase.util.schema :as su]
@@ -40,7 +40,8 @@
     (api/read-check Card source-card-id)
     source-card-id))
 
-(defn- run-query-async
+(defn run-query-async
+  "Run a query asynchronously."
   [{:keys [database], :as query}
    & {:keys [dataset-metadata context export-format qp-runner]
       :or   {dataset-metadata nil
@@ -76,7 +77,8 @@
 
 (api/defendpoint ^:streaming POST "/"
   "Execute a query and retrieve the results in the usual format.
-  Optional passing `dataset-metadata` to override the metadata returned by running the query."
+
+  Optionally passing `dataset-metadata` to blend an user edits metadata with the runtime computed metadata."
   [:as {{:keys [database dataset-metadata] :as query} :body}]
   {database         (s/maybe s/Int)
    dataset-metadata (s/maybe qr/ResultsMetadata)}

--- a/src/metabase/query_processor/middleware/resolve_fields.clj
+++ b/src/metabase/query_processor/middleware/resolve_fields.clj
@@ -15,11 +15,10 @@
 (defn resolve-fields
   "Resolve all field referenced in the `query`, and store them in the QP Store."
   [{:keys [info] :as query}]
-  (let [ids (into (set (concat
-                         (mbql.u/match (:query query) [:field (id :guard integer?) _] id)
-                         (mbql.u/match (:metadata/dataset-metadata info) [:field (id :guard integer?) _] id)))
-                  (comp cat (keep :id))
-                  (mbql.u/match (:query query) {:source-metadata source-metadata} source-metadata))]
+  (let [ids (-> (set (mbql.u/match (:query query) [:field (id :guard integer?) _] id))
+                (into (mbql.u/match (:metadata/dataset-metadata info) [:field (id :guard integer?) _] id))
+                (into (comp cat (keep :id))
+                      (mbql.u/match (:query query) {:source-metadata source-metadata} source-metadata)))]
     (try
       (u/prog1 query
         (resolve-fields-with-ids! ids))

--- a/src/metabase/query_processor/middleware/resolve_fields.clj
+++ b/src/metabase/query_processor/middleware/resolve_fields.clj
@@ -14,8 +14,10 @@
 
 (defn resolve-fields
   "Resolve all field referenced in the `query`, and store them in the QP Store."
-  [query]
-  (let [ids (into (set (mbql.u/match (:query query) [:field (id :guard integer?) _] id))
+  [{:keys [info] :as query}]
+  (let [ids (into (set (concat
+                         (mbql.u/match (:query query) [:field (id :guard integer?) _] id)
+                         (mbql.u/match (:metadata/dataset-metadata info) [:field (id :guard integer?) _] id)))
                   (comp cat (keep :id))
                   (mbql.u/match (:query query) {:source-metadata source-metadata} source-metadata))]
     (try

--- a/test/metabase/api/dataset_test.clj
+++ b/test/metabase/api/dataset_test.clj
@@ -110,7 +110,7 @@
 
 (deftest override-metadata-query-test
   (testing "POST /api/dataset"
-    (testing "when running a query with `:dataset-metadata`, make sure the end columns metadata get combined with it (#22517)"
+    (testing "when `:dataset-metadata` is passed in the body, make sure the returned columns metadata get combined with it (#22517)"
       (let [dataset-metadata [{:name          "ID"
                                :display_name  "VENUES ID CAPITALIZED"
                                :description   "normal venues id but capitalized"
@@ -142,11 +142,9 @@
                                :description   "User id"
                                :semantic_type "type/FK"
                                :base_type     "type/BigInteger"
-                               :field_ref     ["field" (mt/id :users :id) nil]}]
-            query            (assoc (mt/mbql-query venues {:fields [$id]})
-                                    :dataset-metadata dataset-metadata)]
-        (mt/user-http-request :rasta :post 202 "dataset" query)))))
-
+                               :field_ref     ["field" (mt/id :users :id) nil]}]]
+        (mt/user-http-request :rasta :post 202 "dataset" (assoc (mt/mbql-query venues {:fields [$id]})
+                                                          :dataset-metadata dataset-metadata))))))
 
 (deftest failure-test
   ;; clear out recent query executions!

--- a/test/metabase/api/dataset_test.clj
+++ b/test/metabase/api/dataset_test.clj
@@ -133,7 +133,7 @@
 
     (testing "should run successfully even if dataset-metadata contains fields that is not in the query"
       (let [;; We're querying venues but this dataset-metadata contains a user-id
-            ;; This is to simulate the cases where `dataset-metadata` sent from FE can
+            ;; This is to simulate the cases where `dataset-metadata` sent from FE
             ;; contains fields that are not resolved anywhere in our query.
             ;; Since we're allowing this behavior of sending custom dataset-metadata
             ;; we expect the query to run successfully.

--- a/test/metabase/query_processor/middleware/resolve_fields_test.clj
+++ b/test/metabase/query_processor/middleware/resolve_fields_test.clj
@@ -1,15 +1,13 @@
 (ns metabase.query-processor.middleware.resolve-fields-test
   (:require [clojure.test :refer :all]
             [metabase.models :refer [Field]]
-            [metabase.query-processor :as qp]
-            [metabase.query-processor.middleware.resolve-fields :as resolve-fields]
+            [metabase.query-processor.middleware.resolve-fields :as qp.resolve-fields]
             [metabase.test :as mt]
             [toucan.db :as db]))
 
-
 (defn- resolve-and-return-store-contents [query]
   (mt/with-store-contents
-    (resolve-fields/resolve-fields query)))
+    (qp.resolve-fields/resolve-fields query)))
 
 (deftest resolves-field-in-metadata-dataset-metadata-test
   ;; there are cases where FE can send a `dataset-metadata` via the POST /api/dataset
@@ -18,9 +16,9 @@
   ;; - source card
   ;; - joined tables
   ;; - etc
-  ;; We're currently allow this behavior when editing models query, so let's make sure
-  ;; the `resolve-fields` find fields in it as well.
-  (testing "it should looks for fields in the [:info [:metadata/dataset-metadata]]"
+  ;; We allow this behavior for editing models query, so let's make sure
+  ;; the `resolve-fields` find fields in [:info :metadata/dataset-metadata] as well.
+  (testing "`resolve-fields` should finds fields in [:info :metadata/dataset-metadata] (more context in #25000)"
     (let [;; a field that is totally unrelated to the query
           unrelated-field-id (mt/id :users :id)]
       (is (= #{[nil (db/select-one-field :name Field :id unrelated-field-id)]}

--- a/test/metabase/query_processor/middleware/resolve_fields_test.clj
+++ b/test/metabase/query_processor/middleware/resolve_fields_test.clj
@@ -11,14 +11,14 @@
 
 (deftest resolves-field-in-metadata-dataset-metadata-test
   ;; there are cases where FE can send a `dataset-metadata` via the POST /api/dataset
-  ;; and it could contains fields that might not included in the
+  ;; containing fields that are not present in
   ;; - selected-fields
   ;; - source card
   ;; - joined tables
   ;; - etc
   ;; We allow this behavior for editing models query, so let's make sure
-  ;; the `resolve-fields` find fields in [:info :metadata/dataset-metadata] as well.
-  (testing "`resolve-fields` should finds fields in [:info :metadata/dataset-metadata] (more context in #25000)"
+  ;; `resolve-fields` can find fields in [:info :metadata/dataset-metadata] as well.
+  (testing "`resolve-fields` finds fields in [:info :metadata/dataset-metadata] (more context in #25000)"
     (let [;; a field that is totally unrelated to the query
           unrelated-field-id (mt/id :users :id)]
       (is (= #{[nil (db/select-one-field :name Field :id unrelated-field-id)]}

--- a/test/metabase/query_processor/middleware/resolve_fields_test.clj
+++ b/test/metabase/query_processor/middleware/resolve_fields_test.clj
@@ -1,0 +1,30 @@
+(ns metabase.query-processor.middleware.resolve-fields-test
+  (:require [clojure.test :refer :all]
+            [metabase.models :refer [Field]]
+            [metabase.query-processor :as qp]
+            [metabase.query-processor.middleware.resolve-fields :as resolve-fields]
+            [metabase.test :as mt]
+            [toucan.db :as db]))
+
+
+(defn- resolve-and-return-store-contents [query]
+  (mt/with-store-contents
+    (resolve-fields/resolve-fields query)))
+
+(deftest resolves-field-in-metadata-dataset-metadata-test
+  ;; there are cases where FE can send a `dataset-metadata` via the POST /api/dataset
+  ;; and it could contains fields that might not included in the
+  ;; - selected-fields
+  ;; - source card
+  ;; - joined tables
+  ;; - etc
+  ;; We're currently allow this behavior when editing models query, so let's make sure
+  ;; the `resolve-fields` find fields in it as well.
+  (testing "it should looks for fields in the [:info [:metadata/dataset-metadata]]"
+    (let [;; a field that is totally unrelated to the query
+          unrelated-field-id (mt/id :users :id)]
+      (is (= #{[nil (db/select-one-field :name Field :id unrelated-field-id)]}
+             (:fields (resolve-and-return-store-contents
+                        (assoc (mt/mbql-query venues)
+                               :info
+                               {:metadata/dataset-metadata [{:field_ref [:field unrelated-field-id nil]}]}))))))))

--- a/test/metabase/query_processor/middleware/resolve_source_table_test.clj
+++ b/test/metabase/query_processor/middleware/resolve_source_table_test.clj
@@ -3,7 +3,6 @@
             [metabase.models.database :refer [Database]]
             [metabase.models.table :refer [Table]]
             [metabase.query-processor.middleware.resolve-source-table :as qp.resolve-source-table]
-            [metabase.query-processor.store :as qp.store]
             [metabase.test :as mt]))
 
 (defn- resolve-source-tables [query]

--- a/test/metabase/query_processor/middleware/resolve_source_table_test.clj
+++ b/test/metabase/query_processor/middleware/resolve_source_table_test.clj
@@ -9,19 +9,8 @@
 (defn- resolve-source-tables [query]
   (qp.resolve-source-table/resolve-source-tables query))
 
-(defn- do-with-store-contents [f]
-  ;; force creation of test data DB so things don't get left in the cache before running tests below
-  (mt/id)
-  (qp.store/with-store
-    (qp.store/fetch-and-store-database! (mt/id))
-    (f)
-    (mt/store-contents)))
-
-(defmacro ^:private with-store-contents {:style/indent 0} [& body]
-  `(do-with-store-contents (fn [] ~@body)))
-
 (defn- resolve-and-return-store-contents [query]
-  (with-store-contents
+  (mt/with-store-contents
     (resolve-source-tables query)))
 
 (deftest basic-test

--- a/test/metabase/query_processor/test_util.clj
+++ b/test/metabase/query_processor/test_util.clj
@@ -166,3 +166,17 @@
   "Override the determined results timezone ID and execute `body`. Intended primarily for REPL and test usage."
   [timezone-id & body]
   `(do-with-results-timezone-id ~timezone-id (fn [] ~@body)))
+
+
+(defn do-with-store-contents [f]
+  "Impl for `with-store-contents`"
+  ;; force creation of test data DB so things don't get left in the cache before running tests below
+  (data/id)
+  (qp.store/with-store
+    (qp.store/fetch-and-store-database! (data/id))
+    (f)
+    (store-contents)))
+
+(defmacro with-store-contents {:style/indent 0} [& body]
+  "Execute `body` then returns the content of the stores."
+  `(do-with-store-contents (fn [] ~@body)))

--- a/test/metabase/query_processor/test_util.clj
+++ b/test/metabase/query_processor/test_util.clj
@@ -168,8 +168,9 @@
   `(do-with-results-timezone-id ~timezone-id (fn [] ~@body)))
 
 
-(defn do-with-store-contents [f]
+(defn do-with-store-contents
   "Impl for `with-store-contents`"
+  [f]
   ;; force creation of test data DB so things don't get left in the cache before running tests below
   (data/id)
   (qp.store/with-store
@@ -177,6 +178,8 @@
     (f)
     (store-contents)))
 
-(defmacro with-store-contents {:style/indent 0} [& body]
+(defmacro with-store-contents
   "Execute `body` then returns the content of the stores."
+  {:style/indent 0}
+  [& body]
   `(do-with-store-contents (fn [] ~@body)))

--- a/test/metabase/test.clj
+++ b/test/metabase/test.clj
@@ -153,7 +153,8 @@
   with-database-timezone-id
   with-everything-store
   with-report-timezone-id
-  with-results-timezone-id]
+  with-results-timezone-id
+  with-store-contents]
 
  [sql-jdbc.tu
   sql-jdbc-drivers]


### PR DESCRIPTION
Fixes #22517 
### The problem
(Quoting @dpsutton comment [here](https://github.com/metabase/metabase/issues/22517#issuecomment-1143718139))
> So this bug happens because of the frontend. Editing the query doesn't actually erase the metadata. The problem happens when you run the query in the metadata editor. That hits a generic endpoint `POST api/dataset` with the edited query. This endpoint is not model related so doesn't use the model metadata. So the results end up without the edits you have in place. The bug is that the frontend keeps this metadata around instead of retaining the original metadata.
> 
> The metadata from this query run without a model context has only the "regular" metadata from the query itself. The frontend keeps this metadata associated with the model and sends it.
> 
> There are at least two possible ways to fix it:
> 
>   1. The frontend should just ignore this metadata from running the updated query. The backend will correctly handle this situation with the original edited metadata
> 
>   2. The frontend needs to send along the metadata when hitting the `POST api/dataset` when running the edited query. Either by enhancing `POST api/dataset` or a new endpoint that can handle this.
> 
> 
> Between these two, I think the second solution is better. Right now when previewing the edited query it does not show the effects of the edited metadata (column formatting, renaming, etc) so this feels like a bug. If we do the second option it allows this query preview to reflect the metadata changes.

### The solution

We went with the 2nd solution @dpsutton suggested
Which is:
- BE: updates `POST /api/dataset` to accept a new param `dataset-metadata`. This param is optional, when it's present we blend this `dataset-metadata` into the final results so that any user-edits metadata is preserved. 
  - We've done this by assoc the `dataset-metadata` as `[:info :metadata/dataset-metadata]` into our query. note that this key is what we use to preserve user-edits metadata for models.

- FE: If user is in a model, FE will now send the additional `dataset-metadata` to `POST /api/dataset`

### QP changes
This PR involves a change in the QP, in particular expanding the `resolve-fields` to resolve fields in `[:info :metadata/dataset-metdata]`.

To explain why I make this change, here is an example that will make QP fails to execute:
1. Checkout to this commit `579e491c62` -- this is where we implemented FE to send `dataset-metadata` but didn't fix the bug in QP.
2. Question > Orders > Save > Turn to model
3. Edit query definition > uncheck the created_at > Run

You'll see that the query will fail with an error: `Error: Field {created_at_id} is not present in the Query Processor Store.`

This is an error fired by `validate-temporal-bucketing` middleware and it fails because:
- The query is not selecting the `created_at` -- which is a DateTime column
  - So when we try to resolve fields in `resolve-fields` middleware, the `created_at` column **won't** be resolved
- But FE sends a `dataset-metadata` that contains the `created_at` column
  - And because the `validate-temporal-bucketting` find fields in the `outer-query` to validate, it'll find the `created_at` column inside `[:info :metadata/dataset-metadata]`
  - And because we haven't resolved it => qp.store throws an exception.

IMO this is just a symptom of the fact that we're not resolving fields inside `[:info :metadata/dataset-metadata]`, so I decided to update `resolve-fields` to resolves fields in it as well.

### How to Test

1. Question > SQL > Sample - save as "Q1"

```
select *, case when quantity>4 then 'large' else 'small' end size from orders
```

2. Turn into a Model
3. Click "Edit metadata" and spend time on configuring that, maybe rename column `ID`
4. Save changes
5. Click "Edit query definition" - change the query
   ```
   select *, case when quantity>4 then 'large' else 'smallyyyyyy' end size from orders
   ```
6. Run the query

Renamed columns should still be renamed after the query run.