### PR TITLE
Make sandboxing middleware recursive

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions.clj
@@ -330,7 +330,12 @@
   [query]
   (or (when-let [table-id->gtap (when *current-user-id*
                                   (query->table-id->gtap query))]
-        (gtapped-query query table-id->gtap))
+        (let [gtapped-query (gtapped-query query table-id->gtap)]
+          (if (not= query gtapped-query)
+            ;; Applying GTAPs to the query may have introduced references to tables that are also sandboxed,
+            ;; so we need to recursively appby the middleware until new queries are not returned.
+            (apply-sandboxing gtapped-query)
+            gtapped-query)))
       query))
 
 

--- a/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions.clj
@@ -22,7 +22,7 @@
             [metabase.query-processor.middleware.permissions :as qp.perms]
             [metabase.query-processor.store :as qp.store]
             [metabase.util :as u]
-            [metabase.util.i18n :refer [tru]]
+            [metabase.util.i18n :refer [trs tru]]
             [metabase.util.schema :as su]
             [schema.core :as s]
             [toucan.db :as db]))
@@ -324,6 +324,9 @@
           (assoc ::original-metadata (expected-cols original-query))
           (update-in [::qp.perms/perms :gtaps] (fn [perms] (into (set perms) (gtaps->perms-set (vals table-id->gtap)))))))))
 
+(def ^:private default-recursion-limit 20)
+(def ^:private ^:dynamic *recursion-limit* default-recursion-limit)
+
 (defn apply-sandboxing
   "Pre-processing middleware. Replaces source tables a User was querying against with source queries that (presumably)
   restrict the rows returned, based on presence of segmented permission GTAPs."
@@ -334,7 +337,12 @@
           (if (not= query gtapped-query)
             ;; Applying GTAPs to the query may have introduced references to tables that are also sandboxed,
             ;; so we need to recursively appby the middleware until new queries are not returned.
-            (apply-sandboxing gtapped-query)
+            (if (= *recursion-limit* 0)
+              (throw (ex-info (trs "Reached recursion limit of {0} in \"apply-sandboxing\" middleware"
+                                   default-recursion-limit)
+                              query))
+              (binding [*recursion-limit* (dec *recursion-limit*)]
+                (apply-sandboxing gtapped-query)))
             gtapped-query)))
       query))
 

--- a/frontend/test/metabase/scenarios/permissions/sandboxes.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/sandboxes.cy.spec.js
@@ -941,7 +941,7 @@ describeEE("formatting > sandboxes", () => {
       cy.contains("37.65");
     });
 
-    it.skip("unsaved/dirty query should work on linked table column with multiple dimensions and remapping (metabase#15106)", () => {
+    it("unsaved/dirty query should work on linked table column with multiple dimensions and remapping (metabase#15106)", () => {
       cy.server();
       cy.route("POST", "/api/dataset").as("dataset");
 

--- a/src/metabase/models/permissions.clj
+++ b/src/metabase/models/permissions.clj
@@ -75,7 +75,7 @@
       permissions but no matching GTAP exists.
 
     * Segmented permissions can also be used to enforce column-level permissions -- any column not returned by the
-      underlying GTAP query is not allowed to be references by the parent query thru other means such as filter clauses.
+      underlying GTAP query is not allowed to be referenced by the parent query thru other means such as filter clauses.
       See [[metabase-enterprise.sandbox.query-processor.middleware.column-level-perms-check]].
 
     * GTAPs are not allowed to add columns not present in the original Table, or change their effective type to

--- a/src/metabase/query_processor.clj
+++ b/src/metabase/query_processor.clj
@@ -105,6 +105,7 @@
    #'resolve-joined-fields/resolve-joined-fields
    #'fix-bad-refs/fix-bad-references
    #'escape-join-aliases/escape-join-aliases
+   ;; yes, this is called a second time, because we need to handle any joins that got added
    (resolve 'ee.sandbox.rows/apply-sandboxing)
    #'qp.cumulative-aggregations/rewrite-cumulative-aggregations
    #'qp.pre-alias-aggregations/pre-alias-aggregations

--- a/src/metabase/query_processor/middleware/add_implicit_joins.clj
+++ b/src/metabase/query_processor/middleware/add_implicit_joins.clj
@@ -238,9 +238,5 @@
         (throw (ex-info (tru "{0} driver does not support foreign keys." driver/*driver*)
                         {:driver driver/*driver*
                          :type   qp.error-type/unsupported-feature})))
-      (def pre-query query)
-      (def post-query (update query :query resolve-implicit-joins))
-      (comment
-        (clojure.data/diff pre-query post-query))
-      post-query)
+      (update query :query resolve-implicit-joins))
     query))

--- a/src/metabase/query_processor/middleware/add_implicit_joins.clj
+++ b/src/metabase/query_processor/middleware/add_implicit_joins.clj
@@ -238,5 +238,9 @@
         (throw (ex-info (tru "{0} driver does not support foreign keys." driver/*driver*)
                         {:driver driver/*driver*
                          :type   qp.error-type/unsupported-feature})))
-      (update query :query resolve-implicit-joins))
+      (def pre-query query)
+      (def post-query (update query :query resolve-implicit-joins))
+      (comment
+        (clojure.data/diff pre-query post-query))
+      post-query)
     query))


### PR DESCRIPTION
Resolves #15106

Basically, there are three sandboxed tables involved in the repro for #15106, but each one is only added to the query after the previous sandboxing middleware is run. We only run the middleware twice, so the third table is not detected as a GTAP, leading to the permissions error. 

The fix is to change the middleware to be recursive, calling itself (with a reasonable recursion limit) until the query is no longer updated.