### PR TITLE
Change Funnel subtitle to display metric rather than dimension

### DIFF
--- a/frontend/src/metabase/visualizations/components/FunnelNormal.jsx
+++ b/frontend/src/metabase/visualizations/components/FunnelNormal.jsx
@@ -65,6 +65,9 @@ export default class FunnelNormal extends Component {
 
     let remaining = rows[0][metricIndex];
 
+    console.log(cols, metricIndex);
+    console.log(rows);
+
     rows.map((row, rowIndex) => {
       remaining -= infos[rowIndex].value - row[metricIndex];
 
@@ -138,7 +141,7 @@ export default class FunnelNormal extends Component {
               {formatMetric(rows[0][metricIndex])}
             </div>
             <div className={styles.Subtitle}>
-              {getFriendlyName(cols[dimensionIndex])}
+              {getFriendlyName(cols[metricIndex])}
             </div>
           </div>
           {/* This part of code in used only to share height between .Start and .Graph columns. */}

--- a/frontend/src/metabase/visualizations/components/FunnelNormal.jsx
+++ b/frontend/src/metabase/visualizations/components/FunnelNormal.jsx
@@ -65,9 +65,6 @@ export default class FunnelNormal extends Component {
 
     let remaining = rows[0][metricIndex];
 
-    console.log(cols, metricIndex);
-    console.log(rows);
-
     rows.map((row, rowIndex) => {
       remaining -= infos[rowIndex].value - row[metricIndex];
 


### PR DESCRIPTION
Fixes #19198

Quick change to Funnel charts to display the name of the metric in the main subtitle, rather than the name of the dimension. Tested with Counts, Averages, Sums etc.

Before:
![image](https://user-images.githubusercontent.com/1328979/186751504-f3c62be9-a4db-42b5-8e34-cc2dfdd63631.png)

After:
![image](https://user-images.githubusercontent.com/1328979/186751637-4b2dcc80-ae88-4466-bdca-9ec82c2c3632.png)

