### PR TITLE
Serdes v2: Order the YAML keys alphabetically

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/storage/yaml.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/storage/yaml.clj
@@ -15,7 +15,7 @@
 (defn- spit-yaml
   [file obj]
   (io/make-parents file)
-  (spit (io/file file) (yaml/generate-string obj :dumper-options {:flow-style :block})))
+  (spit (io/file file) (yaml/generate-string (into (sorted-map) obj) :dumper-options {:flow-style :block})))
 
 (defn- store-entity! [{:keys [root-dir]} entity]
   (spit-yaml (u.yaml/hierarchy->file root-dir (serdes.base/serdes-path entity))


### PR DESCRIPTION
This is a simple expedient: convert our entities to a `(sorted-map)` before
passing them to the YAML writer!
This gives a consistent, platform-agnostic order between dumps.
(It might have already been fine, since it's based on Clojure's `hash`?)

