### PR TITLE
Add model and saved question columns to autocomplete results

### DIFF
--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -847,12 +847,12 @@ export const getAutocompleteResultsFn = state => {
 
     const query = getQuery(state);
     const templateTags = query.templateTagsWithoutSnippets();
-    const taggedCardIds = templateTags.map(tag => tag["card-id"]);
+    const referencedCardIds = templateTags.map(tag => tag["card-id"]);
     const apiCall = MetabaseApi.db_autocomplete_suggestions({
       dbId,
       searchString,
       matchStyle,
-      taggedCardIds: taggedCardIds.join(","),
+      referencedCardIds: referencedCardIds.join(","),
     });
     return apiCall;
   };

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -839,16 +839,20 @@ export const getAutocompleteResultsFn = state => {
     return null;
   }
 
-  return function autocompleteResults(query) {
+  return function autocompleteResults(searchString) {
     const dbId = state.qb.card?.dataset_query?.database;
     if (!dbId) {
       return [];
     }
 
+    const query = getQuery(state);
+    const templateTags = query.templateTagsWithoutSnippets();
+    const taggedCardIds = templateTags.map(tag => tag["card-id"]);
     const apiCall = MetabaseApi.db_autocomplete_suggestions({
       dbId,
-      query,
+      searchString,
       matchStyle,
+      taggedCardIds: taggedCardIds.join(","),
     });
     return apiCall;
   };

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -261,7 +261,7 @@ export const MetabaseApi = {
   db_fields: GET("/api/database/:dbId/fields"),
   db_idfields: GET("/api/database/:dbId/idfields"),
   db_autocomplete_suggestions: GET(
-    "/api/database/:dbId/autocomplete_suggestions?:matchStyle=:searchString&tagged-card-ids=:taggedCardIds",
+    "/api/database/:dbId/autocomplete_suggestions?:matchStyle=:searchString&referenced-card-ids=:referencedCardIds",
   ),
   db_sync_schema: POST("/api/database/:dbId/sync_schema"),
   db_dismiss_sync_spinner: POST("/api/database/:dbId/dismiss_spinner"),

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -261,7 +261,7 @@ export const MetabaseApi = {
   db_fields: GET("/api/database/:dbId/fields"),
   db_idfields: GET("/api/database/:dbId/idfields"),
   db_autocomplete_suggestions: GET(
-    "/api/database/:dbId/autocomplete_suggestions?:matchStyle=:query",
+    "/api/database/:dbId/autocomplete_suggestions?:matchStyle=:searchString&tagged-card-ids=:taggedCardIds",
   ),
   db_sync_schema: POST("/api/database/:dbId/sync_schema"),
   db_dismiss_sync_spinner: POST("/api/database/:dbId/dismiss_spinner"),

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -482,17 +482,12 @@
 (defn- autocomplete-results
   "Returns ordered and formatted autocomplete results for the client to display."
   [tables fields card-columns limit]
-  (let [;; Limit the number of tables according to the number of fields and columns
-        max-tables-count (- limit (/ (min (+ (count fields)
-                                             (count card-columns))
-                                          limit)
-                                     2))]
-    (->> (concat (map #(vector :card-column %) card-columns)
-                 (map #(vector :table %) (take max-tables-count tables))
-                 (map #(vector :field %) fields))
-         (map format-autocomplete-result)
-         distinct
-         (take limit))))
+  (->> (concat (map #(vector :card-column %) card-columns)
+               (map #(vector :table %) tables)
+               (map #(vector :field %) fields))
+       (map format-autocomplete-result)
+       distinct
+       (take limit)))
 
 (def ^:private autocomplete-matching-options
   "Valid options for the autocomplete types. Can match on a substring (\"%input%\"), on a prefix (\"input%\"), or reject

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -508,7 +508,7 @@
 
 (s/defn ^:private autocomplete-suggestions
   "match-string is a string that will be used with ilike. The it will be lowercased by autocomplete-{tables,fields}. "
-  [db-id match-string match-type :- (apply s/enum autocomplete-matching-options)]
+  [db-id match-string match-type :- (apply s/enum (disj autocomplete-matching-options :off))]
   (let [limit         50
         tables        (filter mi/can-read? (autocomplete-tables db-id match-string limit match-type))
         fields        (readable-fields-only (autocomplete-fields db-id match-string limit match-type))

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -483,15 +483,16 @@
   "Returns ordered and formatted autocomplete results for the client to display."
   [tables fields card-columns limit]
   (let [;; Limit the number of tables according to the number of fields and columns
-        max-tables-count (- limit (/ (+ (count fields)
-                                        (count card-columns))
+        max-tables-count (- limit (/ (min (+ (count fields)
+                                             (count card-columns))
+                                          limit)
                                      2))]
     (->> (concat (map #(vector :table %) (take max-tables-count tables))
                  (map #(vector :field %) fields)
                  (map #(vector :card-column %) card-columns))
+         (map format-autocomplete-result)
          (distinct)
-         (take limit)
-         (map format-autocomplete-result))))
+         (take limit))))
 
 (def ^:private autocomplete-matching-options
   "Valid options for the autocomplete types. Can match on a substring (\"%input%\"), on a prefix (\"input%\"), or reject

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -434,7 +434,7 @@
   "Returns a list of card column metadata given the `search-string` and a set of card ids.
    The search-string is matched against column names in the result_metadata of the cards.
   Each result contains all the metadata for the column, and the name of the card."
-  [db-id search-string limit match-type card-ids]
+  [db-id search-string card-ids limit match-type]
   (when (seq card-ids)
     (->> (db/select [Card :name :result_metadata :collection_id]
            :%lower.result_metadata         [:like (match-search-string :substring search-string)]

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -433,21 +433,21 @@
 (defn- autocomplete-card-columns
   [db-id search-string limit match-type tagged-card-ids]
   (when (seq tagged-card-ids)
-    (->> (db/select [Card :name :result_metadata]
+    (->> (db/select [Card :name :result_metadata :collection_id]
            :%lower.result_metadata         [:like (match-search-string :substring search-string)]
            :database_id                    db-id
            {:where [:in :id tagged-card-ids]
             :limit limit})
          (filter mi/can-read?)
          (mapcat (fn [{:keys [result_metadata name]}]
-                   (map (fn [metadata]
-                          (merge metadata
+                   (map (fn [column-metadata]
+                          (merge column-metadata
                                  {:card_name name}))
                         result_metadata)))
-         (filter (fn [metadata]
+         (filter (fn [column-metadata]
                    (re-find (re-pattern (case match-type
                                           :prefix    (str "(?i)^" search-string)
-                                          :substring (str "(?i)" search-string))) (:name metadata)))))))
+                                          :substring (str "(?i)" search-string))) (:name column-metadata)))))))
 
 (defmulti format-autocomplete-result
   "Format an autocomplete result for the client."

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -487,9 +487,9 @@
                                              (count card-columns))
                                           limit)
                                      2))]
-    (->> (concat (map #(vector :table %) (take max-tables-count tables))
-                 (map #(vector :field %) fields)
-                 (map #(vector :card-column %) card-columns))
+    (->> (concat (map #(vector :card-column %) card-columns)
+                 (map #(vector :table %) (take max-tables-count tables))
+                 (map #(vector :field %) fields))
          (map format-autocomplete-result)
          distinct
          (take limit))))

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -489,6 +489,7 @@
     (->> (concat (map #(vector :table %) (take max-tables-count tables))
                  (map #(vector :field %) fields)
                  (map #(vector :card-column %) card-columns))
+         (distinct)
          (take limit)
          (map format-autocomplete-result))))
 

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -436,8 +436,8 @@
   (->> (db/select [Card :name :result_metadata]
          :%lower.result_metadata         [:like (match-search-string :substring search-string)]
          :database_id                    db-id
-         {:limit limit
-          :where [:in :id tagged-card-ids]})
+         {:where [:in :id tagged-card-ids]
+          :limit limit})
        (mapcat (fn [{:keys [result_metadata name]}]
                  (map (fn [metadata]
                         (merge metadata
@@ -447,10 +447,6 @@
                  (re-find (re-pattern (case match-type
                                         :prefix    (str "(?i)^" search-string)
                                         :substring (str "(?i)" search-string))) (:name metadata))))))
-
-(comment
-  (autocomplete-model-columns 1 "product" 50 :substring [258104])
-  )
 
 (defmulti format-autocomplete-result
   "Format an autocomplete result for the client."

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -439,7 +439,7 @@
     (->> (db/select [Card :name :result_metadata :collection_id]
            :%lower.result_metadata         [:like (match-search-string :substring search-string)]
            :database_id                    db-id
-           {:where [:in :id card-ids]
+           :id [:in card-ids]
             :limit limit})
          (filter mi/can-read?)
          (mapcat (fn [{:keys [result_metadata name]}]

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -491,7 +491,7 @@
                  (map #(vector :field %) fields)
                  (map #(vector :card-column %) card-columns))
          (map format-autocomplete-result)
-         (distinct)
+         distinct
          (take limit))))
 
 (def ^:private autocomplete-matching-options

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -475,9 +475,9 @@
                (str " " semantic_type)))])
 
 (defn- autocomplete-results [tables fields model-columns limit]
-  (let [taken-tables        (take 5 tables)
-        taken-fields        (take 5 fields)
-        taken-model-columns (take 5 model-columns)]
+  (let [taken-tables        (take (- limit (/ (+ (count fields) (count model-columns)) 2)) tables)
+        taken-fields        fields
+        taken-model-columns model-columns]
     (->> (concat (map #(vector :table %) taken-tables)
                  (map #(vector :field %) taken-fields)
                  (map #(vector :model-column %) taken-model-columns))

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -337,12 +337,12 @@
                     (mt/user-http-request :rasta :get 200
                                           (format "database/%d/autocomplete_suggestions" db-id)
                                           :prefix prefix
-                                          :tagged-card-ids (str/join "," card-ids)))
+                                          :referenced-card-ids (str/join "," card-ids)))
         substring-fn (fn [db-id search card-ids]
                        (mt/user-http-request :rasta :get 200
                                              (format "database/%d/autocomplete_suggestions" db-id)
                                              :substring search
-                                             :tagged-card-ids (str/join "," card-ids)))]
+                                             :referenced-card-ids (str/join "," card-ids)))]
     (testing "GET /api/database/:id/autocomplete_suggestions"
       (doseq [[prefix expected] {"u"   [["USERS" "Table"]
                                         ["USER_ID" "CHECKINS :type/Integer :type/FK"]]
@@ -363,7 +363,8 @@
                              (:id (db/insert! Card (merge (mt/with-temp-defaults Card)
                                                           {:name            (format "My Card %d" i)
                                                            :database_id     (u/the-id tmp-db)
-                                                           :result_metadata [{:name (format "My Test Card Column %d" i)}]}))))]
+                                                           :result_metadata [{:name (format "My Test Card Column %d" i)}]
+                                                           :archived        false}))))]
               ;; for each type-specific prefix, we should get 50 fields
               (is (= 30 (count (prefix-fn (u/the-id tmp-db) "My Field" card-ids))))
               (is (= 30 (count (prefix-fn (u/the-id tmp-db) "My Table" card-ids))))


### PR DESCRIPTION
This PR extends autocomplete in the native SQL editor to include columns from saved questions and models that are referenced with template tags in the query.

[Notion block link](https://www.notion.so/metabase/Improve-native-query-UX-on-models-5f4505503cc64b4fa0b15e1d37651503#ebc8cac2c8364036a7b35bf91ae56ac5)

![image](https://user-images.githubusercontent.com/39073188/186956116-a1f00207-0ca0-4366-9cfb-c2257c147577.png)

### What's changed on the FE?

Requests to `/api/database/:dbId/autocomplete_suggestions` now include a `tagged-card-ids` parameter, which contains the card IDs that are referenced in the native SQL query (relevant code [here](https://github.com/metabase/metabase/pull/25025/files#diff-2fc40467e8370b516c4ce51320cd4d159278808493231640527a65f51d06e65aR855)).

### What's changed on the BE?

The `/api/database/:dbId/autocomplete_suggestions` endpoint now accepts a `tagged-card-ids` parameter. The results will only include model/saved question columns from this set of card IDs (relevant code [here](https://github.com/metabase/metabase/pull/25025/files#diff-6d3835674092bf06c0ac54208ff16b09988c7a3df3347a1ba20d30281be678d2R439)). Card column results are formatted identically to fields.
