### PR TITLE
Make the Between filter easier to use and understand

### DIFF
--- a/frontend/src/metabase/components/Calendar.styled.tsx
+++ b/frontend/src/metabase/components/Calendar.styled.tsx
@@ -31,11 +31,11 @@ export const CalendarDay = styled.div<CalendarDayProps>`
     color: white;
   }
 
-  ${({ isSelectedStart, isSelectedEnd }) =>
+  ${({ primaryColor, isSelectedStart, isSelectedEnd }) =>
     (isSelectedStart || isSelectedEnd) &&
     css`
       color: ${color("white")} !important;
-      background-color: ${color("filter")};
+      background-color: ${primaryColor};
       z-index: 1;
     `}
 `;

--- a/frontend/src/metabase/components/Calendar.tsx
+++ b/frontend/src/metabase/components/Calendar.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable react/prop-types */
 import React, { Component } from "react";
-import PropTypes from "prop-types";
 
 import "./Calendar.css";
 
@@ -8,7 +7,7 @@ import cx from "classnames";
 import moment, { Moment } from "moment-timezone";
 import { t } from "ttag";
 import Icon from "metabase/components/Icon";
-import { alpha, color } from "metabase/lib/colors";
+import { color } from "metabase/lib/colors";
 import { CalendarDay } from "./Calendar.styled";
 
 export type SelectAll = "after" | "before";
@@ -18,12 +17,13 @@ type Props = {
   selected?: Moment;
   selectedEnd?: Moment;
   selectAll?: SelectAll | null;
-  onChange: (
+  onChange?: (
     start: string,
     end: string | null,
     startMoment: Moment,
     endMoment?: Moment | null,
   ) => void;
+  onDateClick?: (date: string, dateMoment: Moment) => void;
   isRangePicker?: boolean;
   primaryColor?: string;
 };
@@ -77,18 +77,19 @@ export default class Calendar extends Component<Props, State> {
 
   onClickDay = (date: Moment) => {
     const { selected, selectedEnd, isRangePicker } = this.props;
+
     if (!isRangePicker || !selected || selectedEnd) {
-      this.props.onChange(date.format("YYYY-MM-DD"), null, date, null);
+      this.props.onChange?.(date.format("YYYY-MM-DD"), null, date, null);
     } else if (!selectedEnd) {
       if (date.isAfter(selected)) {
-        this.props.onChange(
+        this.props.onChange?.(
           selected.format("YYYY-MM-DD"),
           date.format("YYYY-MM-DD"),
           selected,
           date,
         );
       } else {
-        this.props.onChange(
+        this.props.onChange?.(
           date.format("YYYY-MM-DD"),
           selected.format("YYYY-MM-DD"),
           date,
@@ -96,6 +97,8 @@ export default class Calendar extends Component<Props, State> {
         );
       }
     }
+
+    this.props.onDateClick?.(date.format("YYYY-MM-DD"), date);
   };
 
   previous = () => {

--- a/frontend/src/metabase/components/Calendar.tsx
+++ b/frontend/src/metabase/components/Calendar.tsx
@@ -23,7 +23,7 @@ type Props = {
     startMoment: Moment,
     endMoment?: Moment | null,
   ) => void;
-  onDateClick?: (date: string, dateMoment: Moment) => void;
+  onChangeDate?: (date: string, dateMoment: Moment) => void;
   isRangePicker?: boolean;
   primaryColor?: string;
 };
@@ -98,7 +98,7 @@ export default class Calendar extends Component<Props, State> {
       }
     }
 
-    this.props.onDateClick?.(date.format("YYYY-MM-DD"), date);
+    this.props.onChangeDate?.(date.format("YYYY-MM-DD"), date);
   };
 
   previous = () => {

--- a/frontend/src/metabase/components/InputBlurChange.jsx
+++ b/frontend/src/metabase/components/InputBlurChange.jsx
@@ -22,6 +22,7 @@ export default class InputBlurChange extends Component {
     className: PropTypes.string,
     name: PropTypes.string,
     placeholder: PropTypes.string,
+    autoFocus: PropTypes.bool,
     onFocus: PropTypes.func,
     onChange: PropTypes.func,
     onBlurChange: PropTypes.func,

--- a/frontend/src/metabase/components/InputBlurChange.jsx
+++ b/frontend/src/metabase/components/InputBlurChange.jsx
@@ -22,6 +22,7 @@ export default class InputBlurChange extends Component {
     className: PropTypes.string,
     name: PropTypes.string,
     placeholder: PropTypes.string,
+    onFocus: PropTypes.func,
     onChange: PropTypes.func,
     onBlurChange: PropTypes.func,
   };

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePicker.unit.spec.tsx
@@ -168,7 +168,7 @@ describe("DatePicker", () => {
         render(<DatePickerStateWrapper filter={filter} />);
 
         userEvent.click(screen.getByText(new RegExp(type, "i")));
-        await screen.findByTestId(`${type}-date-picker`);
+        await screen.findAllByTestId(`${type}-date-picker`);
       });
     });
 
@@ -235,6 +235,7 @@ describe("DatePicker", () => {
             <DatePickerStateWrapper filter={filter} onChange={changeSpy} />,
           );
           userEvent.click(screen.getByText(/specific dates/i));
+          userEvent.click(screen.getByText("On"));
           await screen.findByTestId(`specific-date-picker`);
           userEvent.click(screen.getByText(new RegExp(description, "i")));
           const dateField = screen.getByText("21");
@@ -243,7 +244,7 @@ describe("DatePicker", () => {
           expect(changeSpy).toHaveBeenLastCalledWith([
             operator,
             CREATED_AT_FIELD,
-            "2020-05-21",
+            "2020-04-21",
           ]);
         });
       });
@@ -259,27 +260,27 @@ describe("DatePicker", () => {
         const dateField1 = screen.getByText("17");
         const dateField2 = screen.getByText("19");
 
-        userEvent.click(dateField1); // end range
         userEvent.click(dateField1); // begin range, clears end range
         userEvent.click(dateField2); // end range
 
         expect(changeSpy).toHaveBeenLastCalledWith([
           "between",
           CREATED_AT_FIELD,
-          "2020-05-17",
-          "2020-05-19",
+          "2020-04-17",
+          "2020-04-19",
         ]);
       });
 
       it("can navigate between months on the calendar using arrows", async () => {
         render(<DatePickerStateWrapper filter={filter} />);
         userEvent.click(screen.getByText(/specific/i));
+        userEvent.click(screen.getByText("On"));
 
+        await screen.findByText("April 2020");
+        userEvent.click(await screen.getByLabelText(/chevronright/i));
         await screen.findByText("May 2020");
         userEvent.click(await screen.getByLabelText(/chevronright/i));
         await screen.findByText("June 2020");
-        userEvent.click(await screen.getByLabelText(/chevronright/i));
-        await screen.findByText("July 2020");
       });
     });
 

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePicker.unit.spec.tsx
@@ -244,7 +244,7 @@ describe("DatePicker", () => {
           expect(changeSpy).toHaveBeenLastCalledWith([
             operator,
             CREATED_AT_FIELD,
-            "2020-04-21",
+            "2020-05-21",
           ]);
         });
       });
@@ -266,8 +266,8 @@ describe("DatePicker", () => {
         expect(changeSpy).toHaveBeenLastCalledWith([
           "between",
           CREATED_AT_FIELD,
-          "2020-04-17",
-          "2020-04-19",
+          "2020-05-17",
+          "2020-05-19",
         ]);
       });
 
@@ -276,11 +276,11 @@ describe("DatePicker", () => {
         userEvent.click(screen.getByText(/specific/i));
         userEvent.click(screen.getByText("On"));
 
-        await screen.findByText("April 2020");
-        userEvent.click(await screen.getByLabelText(/chevronright/i));
         await screen.findByText("May 2020");
         userEvent.click(await screen.getByLabelText(/chevronright/i));
         await screen.findByText("June 2020");
+        userEvent.click(await screen.getByLabelText(/chevronright/i));
+        await screen.findByText("July 2020");
       });
     });
 

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePickerShortcutOptions.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePickerShortcutOptions.tsx
@@ -112,8 +112,9 @@ const MISC_OPTIONS: Option[] = [
   {
     displayName: t`Specific dates...`,
     init: filter => [
-      "=",
+      "between",
       getDateTimeField(filter[1]),
+      moment().subtract(30, "day").format("YYYY-MM-DD"),
       moment().format("YYYY-MM-DD"),
     ],
   },

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RangeDatePicker.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RangeDatePicker.styled.tsx
@@ -1,8 +1,11 @@
 import styled from "@emotion/styled";
-import { space } from "metabase/styled-components/theme";
 
-export const TimeContainer = styled.div`
+export const DateContainer = styled.div`
   display: flex;
-  grid-gap: ${space(2)};
-  flex-wrap: no-wrap;
+  grid-gap: 0.25rem;
+  flex-wrap: nowrap;
+`;
+
+export const DateDivider = styled.div`
+  margin-top: 0.65rem;
 `;

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RangeDatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RangeDatePicker.tsx
@@ -41,6 +41,7 @@ export const BetweenPicker = ({
             value={endValue}
             primaryColor={primaryColor}
             hideTimeSelectors={hideTimeSelectors}
+            onChange={value => onFilterChange([op, field, startValue, value])}
             onClear={() =>
               onFilterChange([
                 op,
@@ -49,7 +50,6 @@ export const BetweenPicker = ({
                 setTimeComponent(endValue),
               ])
             }
-            onChange={value => onFilterChange([op, field, startValue, value])}
           />
         </div>
       </TimeContainer>

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RangeDatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RangeDatePicker.tsx
@@ -5,7 +5,7 @@ import { setTimeComponent } from "metabase/lib/query_time";
 import Calendar from "metabase/components/Calendar";
 import SingleDatePicker, { SingleDatePickerProps } from "./SingleDatePicker";
 import SpecificDatePicker from "./SpecificDatePicker";
-import { TimeContainer } from "./RangeDatePicker.styled";
+import { DateContainer, DateDivider } from "./RangeDatePicker.styled";
 
 interface BetweenPickerProps {
   className?: string;
@@ -73,29 +73,26 @@ export const BetweenPicker = ({
 
   return (
     <div className={className} data-testid="between-date-picker">
-      <TimeContainer>
-        <div>
-          <SpecificDatePicker
-            value={startValue}
-            primaryColor={primaryColor}
-            isActive={isStartDateActive}
-            hideTimeSelectors={hideTimeSelectors}
-            onFocus={handleStartDateFocus}
-            onChange={handleStartDateChange}
-          />
-        </div>
-        <div>
-          <SpecificDatePicker
-            value={endValue}
-            primaryColor={primaryColor}
-            isActive={!isStartDateActive}
-            hideTimeSelectors={hideTimeSelectors}
-            onFocus={handleEndDateFocus}
-            onChange={handleEndDateChange}
-            onClear={handleEndDateClear}
-          />
-        </div>
-      </TimeContainer>
+      <DateContainer>
+        <SpecificDatePicker
+          value={startValue}
+          primaryColor={primaryColor}
+          isActive={isStartDateActive}
+          hideTimeSelectors={hideTimeSelectors}
+          onFocus={handleStartDateFocus}
+          onChange={handleStartDateChange}
+        />
+        <DateDivider>–</DateDivider>
+        <SpecificDatePicker
+          value={endValue}
+          primaryColor={primaryColor}
+          isActive={!isStartDateActive}
+          hideTimeSelectors={hideTimeSelectors}
+          onFocus={handleEndDateFocus}
+          onChange={handleEndDateChange}
+          onClear={handleEndDateClear}
+        />
+      </DateContainer>
       <div className="Calendar--noContext">
         <Calendar
           isRangePicker

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RangeDatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RangeDatePicker.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback, useState } from "react";
 
 import Calendar from "metabase/components/Calendar";
 
@@ -24,6 +24,46 @@ export const BetweenPicker = ({
   hideTimeSelectors,
   onFilterChange,
 }: BetweenPickerProps) => {
+  const [isStartDatActive, setIsStartDateActive] = useState(true);
+
+  const handleStartDateFocus = useCallback(() => {
+    setIsStartDateActive(true);
+  }, []);
+
+  const handleEndDateFocus = useCallback(() => {
+    setIsStartDateActive(false);
+  }, []);
+
+  const handleDateRangeChange = useCallback(
+    (startValue: string | null, endValue: string | null) => {
+      onFilterChange([op, field, startValue, endValue]);
+    },
+    [op, field, onFilterChange],
+  );
+
+  const handleStartDateChange = useCallback(
+    (value: string | null) => {
+      onFilterChange([op, field, value, endValue]);
+    },
+    [op, field, endValue, onFilterChange],
+  );
+
+  const handleEndDateChange = useCallback(
+    (value: string | null) => {
+      onFilterChange([op, field, startValue, value]);
+    },
+    [op, field, startValue, onFilterChange],
+  );
+
+  const handleEndDateClear = useCallback(() => {
+    onFilterChange([
+      op,
+      field,
+      setTimeComponent(startValue),
+      setTimeComponent(endValue),
+    ]);
+  }, [op, field, startValue, endValue, onFilterChange]);
+
   return (
     <div className={className} data-testid="between-date-picker">
       <TimeContainer>
@@ -32,7 +72,7 @@ export const BetweenPicker = ({
             value={startValue}
             primaryColor={primaryColor}
             hideTimeSelectors={hideTimeSelectors}
-            onChange={value => onFilterChange([op, field, value, endValue])}
+            onChange={handleStartDateChange}
           />
         </div>
         <div>
@@ -40,15 +80,8 @@ export const BetweenPicker = ({
             value={endValue}
             primaryColor={primaryColor}
             hideTimeSelectors={hideTimeSelectors}
-            onChange={value => onFilterChange([op, field, startValue, value])}
-            onClear={() =>
-              onFilterChange([
-                op,
-                field,
-                setTimeComponent(startValue),
-                setTimeComponent(endValue),
-              ])
-            }
+            onChange={handleEndDateChange}
+            onClear={handleEndDateClear}
           />
         </div>
       </TimeContainer>
@@ -59,9 +92,7 @@ export const BetweenPicker = ({
           initial={startValue}
           selected={startValue && moment(startValue)}
           selectedEnd={endValue && moment(endValue)}
-          onChange={(startValue, endValue) =>
-            onFilterChange([op, field, startValue, endValue])
-          }
+          onChange={handleDateRangeChange}
         />
       </div>
     </div>

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RangeDatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RangeDatePicker.tsx
@@ -79,6 +79,7 @@ export const BetweenPicker = ({
           primaryColor={primaryColor}
           isActive={isStartDateActive}
           hideTimeSelectors={hideTimeSelectors}
+          autoFocus
           onFocus={handleStartDateFocus}
           onChange={handleStartDateChange}
         />

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RangeDatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RangeDatePicker.tsx
@@ -1,13 +1,11 @@
 import React, { useCallback, useState } from "react";
-
-import Calendar from "metabase/components/Calendar";
-
 import moment from "moment-timezone";
 import Filter from "metabase-lib/lib/queries/structured/Filter";
-import { TimeContainer } from "./RangeDatePicker.styled";
 import { setTimeComponent } from "metabase/lib/query_time";
+import Calendar from "metabase/components/Calendar";
 import SingleDatePicker, { SingleDatePickerProps } from "./SingleDatePicker";
 import SpecificDatePicker from "./SpecificDatePicker";
+import { TimeContainer } from "./RangeDatePicker.styled";
 
 interface BetweenPickerProps {
   className?: string;

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RangeDatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RangeDatePicker.tsx
@@ -97,7 +97,7 @@ export const BetweenPicker = ({
         <Calendar
           isRangePicker
           primaryColor={primaryColor}
-          initial={startValue}
+          initial={endValue}
           selected={startValue && moment(startValue)}
           selectedEnd={endValue && moment(endValue)}
           onDateClick={handleDateClick}

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RangeDatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RangeDatePicker.tsx
@@ -7,9 +7,9 @@ import SingleDatePicker, { SingleDatePickerProps } from "./SingleDatePicker";
 import SpecificDatePicker from "./SpecificDatePicker";
 import { DateContainer, DateDivider } from "./RangeDatePicker.styled";
 
-interface BetweenPickerProps {
+export interface BetweenPickerProps {
   className?: string;
-  filter: Filter;
+  filter: Filter | any[];
   primaryColor?: string;
   hideTimeSelectors?: boolean;
   onFilterChange: (filter: any[]) => void;

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RangeDatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RangeDatePicker.tsx
@@ -9,21 +9,20 @@ import { setTimeComponent } from "metabase/lib/query_time";
 import SingleDatePicker, { SingleDatePickerProps } from "./SingleDatePicker";
 import SpecificDatePicker from "./SpecificDatePicker";
 
-type BetweenPickerProps = {
+interface BetweenPickerProps {
   className?: string;
-  primaryColor?: string;
   filter: Filter;
-  onFilterChange: (filter: any[]) => void;
-
+  primaryColor?: string;
   hideTimeSelectors?: boolean;
-};
+  onFilterChange: (filter: any[]) => void;
+}
 
 export const BetweenPicker = ({
   className,
   filter: [op, field, startValue, endValue],
-  onFilterChange,
-  hideTimeSelectors,
   primaryColor,
+  hideTimeSelectors,
+  onFilterChange,
 }: BetweenPickerProps) => {
   return (
     <div className={className} data-testid="between-date-picker">

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RangeDatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RangeDatePicker.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 import React from "react";
 
 import Calendar from "metabase/components/Calendar";
@@ -6,12 +5,7 @@ import Calendar from "metabase/components/Calendar";
 import moment from "moment-timezone";
 import Filter from "metabase-lib/lib/queries/structured/Filter";
 import { TimeContainer } from "./RangeDatePicker.styled";
-import {
-  hasTimeComponent,
-  setTimeComponent,
-  TIME_SELECTOR_DEFAULT_HOUR,
-  TIME_SELECTOR_DEFAULT_MINUTE,
-} from "metabase/lib/query_time";
+import { setTimeComponent } from "metabase/lib/query_time";
 import SingleDatePicker, { SingleDatePickerProps } from "./SingleDatePicker";
 import SpecificDatePicker from "./SpecificDatePicker";
 
@@ -31,14 +25,6 @@ export const BetweenPicker = ({
   hideTimeSelectors,
   primaryColor,
 }: BetweenPickerProps) => {
-  let endDatetime = endValue;
-  if (hasTimeComponent(startValue) && !hasTimeComponent(endValue)) {
-    endDatetime = setTimeComponent(
-      endValue,
-      TIME_SELECTOR_DEFAULT_HOUR,
-      TIME_SELECTOR_DEFAULT_MINUTE,
-    );
-  }
   return (
     <div className={className} data-testid="between-date-picker">
       <TimeContainer>

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RangeDatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RangeDatePicker.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useState } from "react";
-import moment from "moment-timezone";
+import moment, { Moment } from "moment-timezone";
 import Filter from "metabase-lib/lib/queries/structured/Filter";
 import { setTimeComponent } from "metabase/lib/query_time";
 import Calendar from "metabase/components/Calendar";
@@ -22,7 +22,7 @@ export const BetweenPicker = ({
   hideTimeSelectors,
   onFilterChange,
 }: BetweenPickerProps) => {
-  const [isStartDatActive, setIsStartDateActive] = useState(true);
+  const [isStartDateActive, setIsStartDateActive] = useState(true);
 
   const handleStartDateFocus = useCallback(() => {
     setIsStartDateActive(true);
@@ -32,23 +32,32 @@ export const BetweenPicker = ({
     setIsStartDateActive(false);
   }, []);
 
-  const handleDateRangeChange = useCallback(
-    (startValue: string | null, endValue: string | null) => {
-      onFilterChange([op, field, startValue, endValue]);
+  const handleDateClick = useCallback(
+    (newValue: string, newDate: Moment) => {
+      if (isStartDateActive) {
+        onFilterChange([op, field, newValue, null]);
+      } else if (newDate.isBefore(startValue)) {
+        onFilterChange([op, field, newValue, startValue]);
+      } else {
+        onFilterChange([op, field, startValue, newValue]);
+      }
+      setIsStartDateActive(isActive => !isActive);
     },
-    [op, field, onFilterChange],
+    [op, field, startValue, isStartDateActive, onFilterChange],
   );
 
   const handleStartDateChange = useCallback(
-    (value: string | null) => {
-      onFilterChange([op, field, value, endValue]);
+    (newValue: string | null) => {
+      onFilterChange([op, field, newValue, endValue]);
+      setIsStartDateActive(isActive => !isActive);
     },
     [op, field, endValue, onFilterChange],
   );
 
   const handleEndDateChange = useCallback(
-    (value: string | null) => {
-      onFilterChange([op, field, startValue, value]);
+    (newValue: string | null) => {
+      onFilterChange([op, field, startValue, newValue]);
+      setIsStartDateActive(isActive => !isActive);
     },
     [op, field, startValue, onFilterChange],
   );
@@ -69,7 +78,9 @@ export const BetweenPicker = ({
           <SpecificDatePicker
             value={startValue}
             primaryColor={primaryColor}
+            isActive={isStartDateActive}
             hideTimeSelectors={hideTimeSelectors}
+            onFocus={handleStartDateFocus}
             onChange={handleStartDateChange}
           />
         </div>
@@ -77,7 +88,9 @@ export const BetweenPicker = ({
           <SpecificDatePicker
             value={endValue}
             primaryColor={primaryColor}
+            isActive={!isStartDateActive}
             hideTimeSelectors={hideTimeSelectors}
+            onFocus={handleEndDateFocus}
             onChange={handleEndDateChange}
             onClear={handleEndDateClear}
           />
@@ -90,7 +103,7 @@ export const BetweenPicker = ({
           initial={startValue}
           selected={startValue && moment(startValue)}
           selectedEnd={endValue && moment(endValue)}
-          onChange={handleDateRangeChange}
+          onDateClick={handleDateClick}
         />
       </div>
     </div>

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RangeDatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RangeDatePicker.tsx
@@ -100,7 +100,7 @@ export const BetweenPicker = ({
           initial={endValue}
           selected={startValue && moment(startValue)}
           selectedEnd={endValue && moment(endValue)}
-          onDateClick={handleDateClick}
+          onChangeDate={handleDateClick}
         />
       </div>
     </div>

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RangeDatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RangeDatePicker.unit.spec.tsx
@@ -1,0 +1,54 @@
+import React, { useState } from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { BetweenPicker } from "./RangeDatePicker";
+
+interface TestBetweenPickerProps {
+  initialFilter: any[];
+}
+
+const TestBetweenPicker = ({ initialFilter }: TestBetweenPickerProps) => {
+  const [filter, setFilter] = useState(initialFilter);
+  return <BetweenPicker filter={filter} onFilterChange={setFilter} />;
+};
+
+describe("BetweenPicker", () => {
+  const field = ["field", 10, null];
+
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2022-05-01 08:00:00"));
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  it("should change the filter by calendar", () => {
+    const initialFilter = ["between", field, "2022-08-10", "2022-08-29"];
+
+    render(<TestBetweenPicker initialFilter={initialFilter} />);
+    userEvent.click(screen.getByText("12"));
+    userEvent.click(screen.getByText("20"));
+
+    expect(screen.getByDisplayValue("08/12/2022")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("08/20/2022")).toBeInTheDocument();
+  });
+
+  it("should change the filter by keyboard and calendar", () => {
+    const initialFilter = ["between", field, "2022-08-10", "2022-08-29"];
+
+    render(<TestBetweenPicker initialFilter={initialFilter} />);
+
+    const startDateInput = screen.getByDisplayValue("08/10/2022");
+    userEvent.clear(startDateInput);
+    userEvent.type(startDateInput, "07/25/2022");
+    userEvent.tab();
+
+    const endDateInput = screen.getByDisplayValue("08/29/2022");
+    userEvent.click(screen.getByText("20"));
+
+    expect(startDateInput).toHaveValue("07/25/2022");
+    expect(endDateInput).toHaveValue("08/20/2022");
+  });
+});

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/SingleDatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/SingleDatePicker.tsx
@@ -31,8 +31,8 @@ const SingleDatePicker = ({
     selectAll={selectAll}
     onChange={value => onFilterChange([op, field, value])}
     onClear={() => onFilterChange([op, field, setTimeComponent(value)])}
+    hasCalendar
     hideTimeSelectors={hideTimeSelectors}
-    calendar
   />
 );
 

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/SingleDatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/SingleDatePicker.tsx
@@ -11,9 +11,8 @@ export type SingleDatePickerProps = {
   filter: Filter;
   selectAll?: SelectAll;
   primaryColor?: string;
-  onFilterChange: (filter: any[]) => void;
-
   hideTimeSelectors?: boolean;
+  onFilterChange: (filter: any[]) => void;
 };
 
 const SingleDatePicker = ({
@@ -31,6 +30,7 @@ const SingleDatePicker = ({
     selectAll={selectAll}
     onChange={value => onFilterChange([op, field, value])}
     onClear={() => onFilterChange([op, field, setTimeComponent(value)])}
+    autoFocus
     hasCalendar
     hideTimeSelectors={hideTimeSelectors}
   />

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/SpecificDatePicker.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/SpecificDatePicker.styled.tsx
@@ -1,6 +1,7 @@
 import styled from "@emotion/styled";
-import Icon from "metabase/components/Icon";
 import { color } from "metabase/lib/colors";
+import Icon from "metabase/components/Icon";
+import InputBlurChange from "metabase/components/InputBlurChange";
 
 export const CalendarIcon = styled(Icon)`
   margin-right: 0.5rem;
@@ -9,4 +10,23 @@ export const CalendarIcon = styled(Icon)`
   &:hover {
     color: ${color("filter")};
   }
+`;
+
+export const DateInput = styled(InputBlurChange)`
+  font-size: 1rem;
+  font-weight: 700;
+  width: 100%;
+  padding: 0.5rem;
+  border: none;
+  outline: none;
+  background: none;
+`;
+
+export const DateInputContainer = styled.div`
+  display: flex;
+  align-items: center;
+  width: 100%;
+  margin-bottom: 1rem;
+  border: 1px solid ${color("border")};
+  border-radius: 0.5rem;
 `;

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/SpecificDatePicker.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/SpecificDatePicker.styled.tsx
@@ -27,6 +27,6 @@ export const DateInputContainer = styled.div`
   align-items: center;
   width: 100%;
   margin-bottom: 1rem;
-  border: 1px solid ${color("border")};
+  border: 1px solid ${color("brand")};
   border-radius: 0.5rem;
 `;

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/SpecificDatePicker.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/SpecificDatePicker.styled.tsx
@@ -22,11 +22,16 @@ export const DateInput = styled(InputBlurChange)`
   background: none;
 `;
 
-export const DateInputContainer = styled.div`
+interface DateInputContainerProps {
+  isActive?: boolean;
+}
+
+export const DateInputContainer = styled.div<DateInputContainerProps>`
   display: flex;
   align-items: center;
   width: 100%;
   margin-bottom: 1rem;
-  border: 1px solid ${color("brand")};
+  border: 1px solid
+    ${({ isActive }) => (isActive ? color("brand") : color("border"))};
   border-radius: 0.5rem;
 `;

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/SpecificDatePicker.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/SpecificDatePicker.styled.tsx
@@ -34,4 +34,8 @@ export const DateInputContainer = styled.div<DateInputContainerProps>`
   border: 1px solid
     ${({ isActive }) => (isActive ? color("brand") : color("border"))};
   border-radius: 0.5rem;
+
+  &:focus-within {
+    border-color: ${color("brand")};
+  }
 `;

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/SpecificDatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/SpecificDatePicker.tsx
@@ -22,6 +22,7 @@ interface SpecificDatePickerProps {
   isActive?: boolean;
   hasCalendar?: boolean;
   hideTimeSelectors?: boolean;
+  autoFocus?: boolean;
   onFocus?: () => void;
   onChange: (startValue: string | null, endValue?: string) => void;
   onClear?: () => void;
@@ -35,6 +36,7 @@ const SpecificDatePicker = ({
   isActive,
   hasCalendar,
   hideTimeSelectors,
+  autoFocus,
   onFocus,
   onChange,
   onClear,
@@ -62,6 +64,7 @@ const SpecificDatePicker = ({
         <DateInput
           placeholder={moment().format(dateFormat)}
           value={date ? date.format(dateFormat) : ""}
+          autoFocus={autoFocus}
           onFocus={onFocus}
           onBlurChange={({ target: { value } }: any) => {
             const date = moment(value, dateFormat);

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/SpecificDatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/SpecificDatePicker.tsx
@@ -1,16 +1,18 @@
-/* eslint-disable react/prop-types */
 import React from "react";
 import { t } from "ttag";
 
 import { getDateStyleFromSettings } from "metabase/lib/time";
 import Calendar, { SelectAll } from "metabase/components/Calendar";
-import InputBlurChange from "metabase/components/InputBlurChange";
 import ExpandingContent from "metabase/components/ExpandingContent";
 import HoursMinutesInput from "./HoursMinutesInput";
 
 import moment, { Moment } from "moment-timezone";
 import { getTimeComponent, setTimeComponent } from "metabase/lib/query_time";
-import { CalendarIcon } from "./SpecificDatePicker.styled";
+import {
+  CalendarIcon,
+  DateInput,
+  DateInputContainer,
+} from "./SpecificDatePicker.styled";
 
 type Props = {
   className?: string;
@@ -24,7 +26,7 @@ type Props = {
   onClear?: () => void;
 };
 
-const SpecificDatePicker: React.FC<Props> = props => {
+const SpecificDatePicker = (props: Props) => {
   const onChange = (
     date?: string | Moment,
     hours?: number | null,
@@ -54,13 +56,9 @@ const SpecificDatePicker: React.FC<Props> = props => {
 
   return (
     <div className={className} data-testid="specific-date-picker">
-      <div className="mb2 full bordered rounded flex align-center">
-        <InputBlurChange
+      <DateInputContainer>
+        <DateInput
           placeholder={moment().format(dateFormat)}
-          className="borderless full p1 h3"
-          style={{
-            outline: "none",
-          }}
           value={date ? date.format(dateFormat) : ""}
           onBlurChange={({ target: { value } }: any) => {
             const date = moment(value, dateFormat);
@@ -79,7 +77,7 @@ const SpecificDatePicker: React.FC<Props> = props => {
             tooltip={showCalendar ? t`Hide calendar` : t`Show calendar`}
           />
         )}
-      </div>
+      </DateInputContainer>
 
       {showTimeSelectors && (
         <div>

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/SpecificDatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/SpecificDatePicker.tsx
@@ -19,6 +19,7 @@ interface SpecificDatePickerProps {
   value: string;
   primaryColor?: string;
   selectAll?: SelectAll;
+  isActive?: boolean;
   hasCalendar?: boolean;
   hideTimeSelectors?: boolean;
   onFocus?: () => void;
@@ -31,6 +32,7 @@ const SpecificDatePicker = ({
   value,
   primaryColor,
   selectAll,
+  isActive,
   hasCalendar,
   hideTimeSelectors,
   onFocus,
@@ -56,7 +58,7 @@ const SpecificDatePicker = ({
 
   return (
     <div className={className} data-testid="specific-date-picker">
-      <DateInputContainer>
+      <DateInputContainer isActive={isActive}>
         <DateInput
           placeholder={moment().format(dateFormat)}
           value={date ? date.format(dateFormat) : ""}

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/SpecificDatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/SpecificDatePicker.tsx
@@ -21,6 +21,7 @@ interface SpecificDatePickerProps {
   selectAll?: SelectAll;
   hasCalendar?: boolean;
   hideTimeSelectors?: boolean;
+  onFocus?: () => void;
   onChange: (startValue: string | null, endValue?: string) => void;
   onClear?: () => void;
 }
@@ -32,8 +33,9 @@ const SpecificDatePicker = ({
   selectAll,
   hasCalendar,
   hideTimeSelectors,
-  onClear,
+  onFocus,
   onChange,
+  onClear,
 }: SpecificDatePickerProps) => {
   const [showCalendar, setShowCalendar] = React.useState(true);
   const { hours, minutes, date } = getTimeComponent(value);
@@ -58,6 +60,7 @@ const SpecificDatePicker = ({
         <DateInput
           placeholder={moment().format(dateFormat)}
           value={date ? date.format(dateFormat) : ""}
+          onFocus={onFocus}
           onBlurChange={({ target: { value } }: any) => {
             const date = moment(value, dateFormat);
             if (date.isValid()) {

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/SpecificDatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/SpecificDatePicker.tsx
@@ -14,44 +14,42 @@ import {
   DateInputContainer,
 } from "./SpecificDatePicker.styled";
 
-type Props = {
+interface SpecificDatePickerProps {
   className?: string;
-  primaryColor?: string;
-  calendar?: boolean;
-  selectAll?: SelectAll;
-
-  hideTimeSelectors?: boolean;
   value: string;
+  primaryColor?: string;
+  selectAll?: SelectAll;
+  hasCalendar?: boolean;
+  hideTimeSelectors?: boolean;
   onChange: (startValue: string | null, endValue?: string) => void;
   onClear?: () => void;
-};
+}
 
-const SpecificDatePicker = (props: Props) => {
-  const onChange = (
-    date?: string | Moment,
-    hours?: number | null,
-    minutes?: number | null,
-  ) => {
-    props.onChange(setTimeComponent(date, hours, minutes));
-  };
-
-  const {
-    value,
-    calendar,
-    hideTimeSelectors,
-    onClear,
-    className,
-    selectAll,
-    primaryColor,
-  } = props;
+const SpecificDatePicker = ({
+  className,
+  value,
+  primaryColor,
+  selectAll,
+  hasCalendar,
+  hideTimeSelectors,
+  onClear,
+  onChange,
+}: SpecificDatePickerProps) => {
   const [showCalendar, setShowCalendar] = React.useState(true);
-
   const { hours, minutes, date } = getTimeComponent(value);
 
   const showTimeSelectors =
     !hideTimeSelectors &&
     typeof hours === "number" &&
     typeof minutes === "number";
+
+  const handleChange = (
+    date?: string | Moment,
+    hours?: number | null,
+    minutes?: number | null,
+  ) => {
+    onChange(setTimeComponent(date, hours, minutes));
+  };
   const dateFormat = getDateStyleFromSettings() || "MM/DD/YYYY";
 
   return (
@@ -63,14 +61,14 @@ const SpecificDatePicker = (props: Props) => {
           onBlurChange={({ target: { value } }: any) => {
             const date = moment(value, dateFormat);
             if (date.isValid()) {
-              onChange(date, hours, minutes);
+              handleChange(date, hours, minutes);
             } else {
-              onChange();
+              handleChange();
             }
           }}
         />
 
-        {calendar && (
+        {hasCalendar && (
           <CalendarIcon
             name="calendar"
             onClick={() => setShowCalendar(!showCalendar)}
@@ -85,20 +83,22 @@ const SpecificDatePicker = (props: Props) => {
             onClear={onClear}
             hours={hours}
             minutes={minutes}
-            onChangeHours={(hours: number) => onChange(date, hours, minutes)}
+            onChangeHours={(hours: number) =>
+              handleChange(date, hours, minutes)
+            }
             onChangeMinutes={(minutes: number) =>
-              onChange(date, hours, minutes)
+              handleChange(date, hours, minutes)
             }
           />
         </div>
       )}
 
-      {calendar && (
+      {hasCalendar && (
         <ExpandingContent isOpen={showCalendar}>
           <Calendar
             selected={date}
             initial={date || moment()}
-            onChange={value => onChange(value, hours, minutes)}
+            onChange={value => handleChange(value, hours, minutes)}
             isRangePicker={false}
             selectAll={selectAll}
             primaryColor={primaryColor}


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/25026
Demo 1 https://www.loom.com/share/c6e28955f0e848c097242009af55ef18
Demo 2 https://www.loom.com/share/8fcf1d1da8144545b4bc6c3ded7c3695

How to test:
- Open Orders table
- Click on `Created At` -> `Filter by this column` -> `Specific Dates`
- It should open `Between` tab with the date range from 30 days ago through today
- Make sure it is possible to change the date range by clicking on dates in the calendar and by typing in inputs