### PR TITLE
Adjust navbar padding

### DIFF
--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.styled.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.styled.tsx
@@ -31,7 +31,6 @@ export const Sidebar = styled.aside<{ isOpen: boolean }>`
   position: relative;
   flex-shrink: 0;
   align-items: center;
-  padding: 0.5rem 0;
   background-color: ${color("white")};
 
   overflow: auto;
@@ -57,7 +56,6 @@ export const NavRoot = styled.nav<{ isOpen: boolean }>`
 
   overflow-x: hidden;
   overflow-y: auto;
-  padding-bottom: 4rem;
 
   opacity: ${props => (props.isOpen ? 1 : 0)};
   transition: opacity 0.2s;


### PR DESCRIPTION
## Description

Little followup to https://github.com/metabase/metabase/pull/25010

I think we had some extra bottom padding leftover from when the settings button was in the navbar. There was also some seemingly unecessary top padding that made the container overflow a little bit.  This also allows the data apps buttons to properly bottom-align.

## Screenshots

Before | After
--- | ---
![Screen Shot 2022-08-26 at 10 33 31 AM](https://user-images.githubusercontent.com/30528226/186951752-d6e7de9d-ab77-4a16-81c3-03c45ca08727.png) | ![Screen Shot 2022-08-26 at 10 34 16 AM](https://user-images.githubusercontent.com/30528226/186951739-15b4788c-d2c5-4d83-bf75-378d1f60fb10.png)
![Screen Shot 2022-08-26 at 10 34 00 AM](https://user-images.githubusercontent.com/30528226/186951742-9223d43d-1de9-42da-abef-05af3aa188df.png) | ![Screen Shot 2022-08-26 at 10 33 44 AM](https://user-images.githubusercontent.com/30528226/186951749-92a3181e-20cc-4064-b852-20bb11e4d72a.png)
