### PR TITLE
Updating remaining Funnel Viz Settings style changes

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChartSettings.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings.jsx
@@ -297,10 +297,10 @@ class ChartSettings extends Component {
     return (
       <div className={cx(className, "flex flex-column")}>
         {showSectionPicker && (
-          <div className="flex flex-no-shrink pl4 pt2 pb1">{sectionPicker}</div>
+          <div className="flex flex-no-shrink pl4 pb1">{sectionPicker}</div>
         )}
         {noPreview ? (
-          <div className="full-height relative scroll-y scroll-show pt3 pb4">
+          <div className="full-height relative scroll-y scroll-show pt2 pb4">
             {widgetList}
           </div>
         ) : (

--- a/frontend/src/metabase/visualizations/components/ChartSettingsWidget.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettingsWidget.styled.tsx
@@ -11,12 +11,13 @@ export const Root = styled.div<{
   disabled?: boolean;
   noPadding?: boolean;
   inline?: boolean;
+  marginBottom?: string;
 }>`
   ${props =>
     !props.noPadding &&
     css`
-      margin-left: 2em;
-      margin-right: 2em;
+      margin-left: 2rem;
+      margin-right: 2rem;
     `}
 
   ${props =>
@@ -28,7 +29,7 @@ export const Root = styled.div<{
   ${props =>
     !props.hidden &&
     css`
-      margin-bottom: 1.5em;
+      margin-bottom: ${props.marginBottom || "1.5em"};
     `}
 
   ${props =>
@@ -64,7 +65,7 @@ export const Root = styled.div<{
 export const Title = styled.label<VariantProp>`
   display: flex;
   align-items: center;
-  margin-bottom: 0.5em;
+  margin-bottom: 1rem;
 
   ${props =>
     props.variant === "default" &&

--- a/frontend/src/metabase/visualizations/components/ChartSettingsWidget.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettingsWidget.tsx
@@ -17,6 +17,7 @@ type Props = {
   disabled?: boolean;
   widget?: React.ComponentType;
   inline?: boolean;
+  marginBottom?: string;
   props?: Record<string, unknown>;
   noPadding?: boolean;
   variant?: "default" | "form-field";
@@ -30,6 +31,7 @@ const ChartSettingsWidget = ({
   disabled,
   variant = "default",
   inline = false,
+  marginBottom = undefined,
   widget: Widget,
   props,
   // disables X padding for certain widgets so divider line extends to edge
@@ -47,6 +49,7 @@ const ChartSettingsWidget = ({
       disabled={disabled}
       className={cx({ "Form-field": isFormField })}
       inline={inline}
+      marginBottom={marginBottom}
     >
       {title && (
         <Title variant={variant} className={cx({ "Form-label": isFormField })}>

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx
@@ -5,7 +5,10 @@ import cx from "classnames";
 import _ from "underscore";
 import { keyForColumn } from "metabase/lib/dataset";
 import ChartSettingSelect from "./ChartSettingSelect";
-import { SettingsIcon } from "./ChartSettingFieldPicker.styled";
+import {
+  SettingsIcon,
+  ChartSettingFieldPickerRoot,
+} from "./ChartSettingFieldPicker.styled";
 
 const ChartSettingFieldPicker = ({
   value,
@@ -25,7 +28,7 @@ const ChartSettingFieldPicker = ({
     }
   }
   return (
-    <div className={cx(className, "flex align-center")}>
+    <ChartSettingFieldPickerRoot className={cx(className)}>
       <ChartSettingSelect
         className="flex-full"
         value={value}
@@ -34,10 +37,11 @@ const ChartSettingFieldPicker = ({
         placeholder={t`Select a field`}
         placeholderNoOptions={t`No valid fields`}
         isInitiallyOpen={value === undefined}
+        hiddenIcons
       />
       {columnKey && (
         <SettingsIcon
-          name="gear"
+          name="ellipsis"
           onClick={() => {
             onShowWidget({
               id: "column_settings",
@@ -53,7 +57,7 @@ const ChartSettingFieldPicker = ({
         name="close"
         onClick={onRemove}
       />
-    </div>
+    </ChartSettingFieldPickerRoot>
   );
 };
 

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx
@@ -1,7 +1,6 @@
 /* eslint-disable react/prop-types */
 import React from "react";
 import { t } from "ttag";
-import cx from "classnames";
 import _ from "underscore";
 import { keyForColumn } from "metabase/lib/dataset";
 import ChartSettingSelect from "./ChartSettingSelect";
@@ -28,7 +27,7 @@ const ChartSettingFieldPicker = ({
     }
   }
   return (
-    <ChartSettingFieldPickerRoot className={cx(className)}>
+    <ChartSettingFieldPickerRoot className={className}>
       <ChartSettingSelect
         className="flex-full"
         value={value}
@@ -52,11 +51,13 @@ const ChartSettingFieldPicker = ({
           }}
         />
       )}
-      <SettingsIcon
-        data-testid={`remove-${value}`}
-        name="close"
-        onClick={onRemove}
-      />
+      {onRemove && (
+        <SettingsIcon
+          data-testid={`remove-${value}`}
+          name="close"
+          onClick={onRemove}
+        />
+      )}
     </ChartSettingFieldPickerRoot>
   );
 };

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.styled.tsx
@@ -8,7 +8,7 @@ export const ChartSettingFieldPickerRoot = styled.div`
   align-items: center;
   border: 1px solid ${color("border")};
   border-radius: 0.5rem;
-  padding-right: 1.125rem;
+  padding-right: 1rem;
 
   ${SelectButton.Root} {
     border: none;
@@ -22,7 +22,7 @@ export const ChartSettingFieldPickerRoot = styled.div`
   }
 
   ${SelectButton.Content} {
-    font-size: 0.75rem;
+    font-size: 0.875rem;
     line-height: 1rem;
     margin-right: 0.25rem;
   }

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.styled.tsx
@@ -1,12 +1,40 @@
 import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
 import Icon from "metabase/components/Icon";
+import SelectButton from "metabase/core/components/SelectButton";
+
+export const ChartSettingFieldPickerRoot = styled.div`
+  display: flex;
+  align-items: center;
+  border: 1px solid ${color("border")};
+  border-radius: 0.5rem;
+  padding-right: 1.125rem;
+
+  ${SelectButton.Root} {
+    border: none;
+    padding: 0.75rem;
+  }
+
+  ${SelectButton.Icon} {
+    margin-left: 0;
+    color: ${color("text-dark")};
+    height: 0.625rem;
+  }
+
+  ${SelectButton.Content} {
+    font-size: 0.75rem;
+    line-height: 1rem;
+    margin-right: 0.25rem;
+  }
+`;
 
 export const SettingsIcon = styled(Icon)`
   margin-left: 0.5rem;
   color: ${color("text-medium")};
   cursor: pointer;
   visibility: ${props => (props.onClick ? "visible" : "hidden")};
+
+  display: ${props => (props.onClick ? "block" : "none")};
 
   &:hover {
     color: ${color("brand")};

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.styled.tsx
@@ -34,8 +34,6 @@ export const SettingsIcon = styled(Icon)`
   cursor: pointer;
   visibility: ${props => (props.onClick ? "visible" : "hidden")};
 
-  display: ${props => (props.onClick ? "block" : "none")};
-
   &:hover {
     color: ${color("brand")};
   }

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedRows.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedRows.styled.tsx
@@ -2,7 +2,7 @@ import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
 
 export const ChartSettingOrderedRowsRoot = styled.div`
-  margin-left: 0.5rem;
+  margin-left: 1rem;
 `;
 
 export const ChartSettingMessage = styled.div`

--- a/frontend/src/metabase/visualizations/components/settings/ColumnItem.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ColumnItem.jsx
@@ -31,7 +31,7 @@ const ColumnItem = ({
 }) => (
   <ColumnItemRoot draggable={draggable} onClick={onClick}>
     <ColumnItemContainer>
-      {draggable && <ColumnItemDragHandle name="grabber2" />}
+      {draggable && <ColumnItemDragHandle name="grabber2" size={12} />}
       <ColumnItemContent>
         <ColumnItemSpan>{title}</ColumnItemSpan>
         {onEdit && <ActionIcon icon="ellipsis" onClick={onEdit} />}

--- a/frontend/src/metabase/visualizations/components/settings/ColumnItem.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ColumnItem.styled.tsx
@@ -35,14 +35,14 @@ export const ColumnItemSpan = styled.span`
   word-wrap: anywhere;
   font-weight: 700;
   margin: 0;
-  font-size: 0.75rem;
+  font-size: 0.875rem;
   line-height: 1rem;
   flex: auto;
   color: ${color("text-dark")};
 `;
 
 export const ColumnItemContent = styled.div`
-  padding: 0 0.625rem;
+  padding: 0 0.5rem;
   position: relative;
   align-items: center;
   display: flex;
@@ -54,6 +54,7 @@ export const ColumnItemContainer = styled.div`
   position: relative;
   flex: auto;
   display: flex;
+  align-items: center;
 `;
 
 export const ColumnItemIcon = styled(Icon)`

--- a/frontend/src/metabase/visualizations/visualizations/Funnel.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Funnel.jsx
@@ -105,10 +105,11 @@ export default class Funnel extends Component {
     ...columnSettings({ hidden: true }),
     ...dimensionSetting("funnel.dimension", {
       section: t`Data`,
-      title: t`Step`,
+      title: t`Column with steps`,
       dashboard: false,
       useRawSeries: true,
       showColumnSetting: true,
+      marginBottom: "0.625rem",
     }),
     "funnel.rows": {
       section: t`Data`,


### PR DESCRIPTION
EPIC #24840 

A bundle of small style changes to viz settings components. Summary of changes includes:
- Adding ability for settings to define their own bottom margin. This allows the draggable columns to be much closer to their "parent setting"
- Moving icons inside of the border of the Field Picker, adjusting the size and position of the down chevron
- Adjusting margins of the `<ChartSettings/>` and `<SectionContainer />` components to bring them closer together
- Left aligning Chart Settings to the tab picker
- Text change for 'Column'

![image](https://user-images.githubusercontent.com/1328979/186960599-be3647e3-5aba-4320-a41f-18863724fd1c.png)

