### PR TITLE
Remove sort-by first from combo chart rendering

### DIFF
--- a/src/metabase/pulse/render.clj
+++ b/src/metabase/pulse/render.clj
@@ -205,7 +205,7 @@
                    content]}))
 
 (s/defn render-pulse-card-to-png :- bytes
-  "Render a `pulse-card` as a PNG. `data` is the `:data` from a QP result (I think...)"
+  "Render a `pulse-card` as a PNG. `data` is the `:data` from a QP result."
   [timezone-id :- (s/maybe s/Str) pulse-card result width]
   (png/render-html-to-png (render-pulse-card :inline timezone-id pulse-card nil result) width))
 

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -535,7 +535,7 @@
           card-type     (or (series-setting viz-settings y-col-key :display)
                             chart-type
                             (nth default-combo-chart-types idx))
-          selected-rows (sort-by first (map #(vector (ffirst %) (nth (second %) idx)) joined-rows))
+          selected-rows (mapv #(vector (ffirst %) (nth (second %) idx)) joined-rows)
           y-axis-pos    (or (series-setting viz-settings y-col-key :axis)
                             (nth (default-y-pos viz-settings) idx))]
      {:name          card-name
@@ -555,7 +555,7 @@
         groups       (keys grouped-rows)]
     (for [[idx group-key] (map-indexed vector groups)]
       (let [row-group          (get grouped-rows group-key)
-            selected-row-group (sort-by first (map #(vector (ffirst %) (first (second %))) row-group))
+            selected-row-group (mapv #(vector (ffirst %) (first (second %))) row-group)
             card-name          (or (series-setting viz-settings group-key :name)
                                    group-key)
             card-color         (or (series-setting viz-settings group-key :color)
@@ -581,7 +581,7 @@
         y-axis-rowfn     (ui-logic/mult-y-axis-rowfn card data)
         x-rows           (filter some? (map x-axis-rowfn rows))
         y-rows           (filter some? (map y-axis-rowfn rows))
-        joined-rows      (map vector x-rows y-rows)
+        joined-rows      (mapv vector x-rows y-rows)
         viz-settings     (set-default-stacked viz-settings card)
         [x-cols y-cols]  ((juxt x-axis-rowfn y-axis-rowfn) (vec cols))
 

--- a/test/metabase/pulse/render/body_test.clj
+++ b/test/metabase/pulse/render/body_test.clj
@@ -469,7 +469,7 @@
 
 (deftest series-with-color-test
   (testing "Check if single x-axis combo series can convert colors"
-    (is (= [{:name "NumPurchased", :color "#a7cf7b", :type :bar, :data [[1.25 20] [5.0 10] [10.0 1]], :yAxisPosition "left"}]
+    (is (= [{:name "NumPurchased", :color "#a7cf7b", :type :bar, :data [[10.0 1] [5.0 10] [1.25 20]], :yAxisPosition "left"}]
            (#'body/single-x-axis-combo-series
             :bar
             [[[10.0] [1]] [[5.0] [10]] [[1.25] [20]]]


### PR DESCRIPTION
fixes: #20808

The card query (seems to) return the rows in a vector in the same order presented on the frontend UI. Having the row selection function sort the selected rows by first will always just sort things alphabetically. This may be fine in some generic case, but can break in situations where a user has created a query with a sort on some quantity.