### PR TITLE
[App] Raise card visualization_settings onto actions

### DIFF
--- a/src/metabase/models/action.clj
+++ b/src/metabase/models/action.clj
@@ -99,7 +99,7 @@
                        :description description
                        :disabled (::disabled card)
                        :card (dissoc card ::disabled)}
-                      (select-keys card [:parameters :parameter_mappings])))))
+                      (select-keys card [:parameters :parameter_mappings :visualization_settings])))))
             actions))))
 
 (defn- normalize-http-actions [actions]
@@ -112,7 +112,8 @@
                    (merge
                      {:disabled false
                       :parameters []
-                      :parameter_mappings {}}
+                      :parameter_mappings {}
+                      :visualization_settings {}}
                      (select-keys http-action [:name :description :template :response_handle :error_handle])
                      (select-keys (:template http-action) [:parameters :parameter_mappings])))))
            actions))))

--- a/test/metabase/actions/test_util.clj
+++ b/test/metabase/actions/test_util.clj
@@ -128,7 +128,8 @@
                                                                                             :required     true}}}}
                                            :name          "Query Example"
                                            :parameters    [{:id "id" :type "number"}]
-                                           :is_write      true}
+                                           :is_write      true
+                                           :visualization_settings {:inline true}}
                                           (dissoc options-map :type))]]
       (let [action-id (db/select-one-field :action_id QueryAction :card_id card-id)]
         (f {:query-action-card-id card-id

--- a/test/metabase/api/action_test.clj
+++ b/test/metabase/api/action_test.clj
@@ -25,6 +25,8 @@
                                          s/Keyword s/Any}
                               s/Keyword s/Any}
               s/Keyword      s/Any}
+   :parameters s/Any
+   :visualization_settings su/Map
    s/Keyword s/Any})
 
 (deftest list-actions-test


### PR DESCRIPTION
Addresses #25042

Like `parameters`, it is desirable to use an `is_write` card's
visualization_settings to store information for form customizations.
When fetching an action, pull up the card's visualization_settings to
the root of action, later http actions can add a visualization_settings
field and they can be unified with query actions in the same way that
we do with parameters.
