### PR TITLE
adds ddiff2 as a dev dependency

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -181,7 +181,8 @@
                                                            :exclusions  [org.clojure/clojure
                                                                          org.clojure/clojurescript]}
     ring/ring-mock                                        {:mvn/version "0.4.0"}
-    talltale/talltale                                     {:mvn/version "0.5.8"}}
+    talltale/talltale                                     {:mvn/version "0.5.8"}
+    lambdaisland/deep-diff2                               {:mvn/version "2.3.127"}}
 
    :extra-paths ["dev/src" "local/src" "test" "shared/test" "test_resources"]
    :jvm-opts    ["-Dmb.run.mode=dev"

--- a/dev/src/dev/debug_qp.clj
+++ b/dev/src/dev/debug_qp.clj
@@ -191,7 +191,7 @@
                                        :function-symbol nil
                                        :class-delimiter nil
                                        :class-name      nil}}))
-  (println ""))
+  (println))
 
 (defn- debug-query-changes [middleware-var middleware]
   (fn [next-middleware]

--- a/dev/src/dev/debug_qp.clj
+++ b/dev/src/dev/debug_qp.clj
@@ -4,6 +4,7 @@
             [clojure.pprint :as pprint]
             [clojure.string :as str]
             [clojure.walk :as walk]
+            [lambdaisland.deep-diff2 :as ddiff]
             [medley.core :as m]
             [metabase.mbql.schema :as mbql.s]
             [metabase.mbql.util :as mbql.u]
@@ -171,13 +172,26 @@
 
 (defn- print-diff [before after]
   (assert (not= before after))
-  (let [[only-in-before only-in-after] (data/diff before after)]
-    (when *print-full?*
-      (println (u/pprint-to-str 'cyan (format-output after))))
-    (when (seq only-in-before)
-      (println (u/colorize 'red (str "-\n" (u/pprint-to-str (format-output only-in-before))))))
-    (when (seq only-in-after)
-      (println (u/colorize 'green (str "+\n" (u/pprint-to-str (format-output only-in-after))))))))
+  (ddiff/pretty-print (ddiff/diff before after)
+                      ;; the default printer is very (too?) colorful.
+                      ;; this is one that strips color except for the diffs:
+                      (ddiff/printer {:color-scheme
+                                      {:lambdaisland.deep-diff2.printer-impl/deletion  [:red]
+                                       :lambdaisland.deep-diff2.printer-impl/insertion [:green]
+                                       :lambdaisland.deep-diff2.printer-impl/other     [:white]
+                                       :delimiter       nil
+                                       :tag             nil
+                                       :nil             nil
+                                       :boolean         nil
+                                       :number          nil
+                                       :string          nil
+                                       :character       nil
+                                       :keyword         nil
+                                       :symbol          nil
+                                       :function-symbol nil
+                                       :class-delimiter nil
+                                       :class-name      nil}}))
+  (println ""))
 
 (defn- debug-query-changes [middleware-var middleware]
   (fn [next-middleware]


### PR DESCRIPTION
Adds [ddiff2](https://github.com/lambdaisland/deep-diff2) for better diff printing.

- used in process-query-debug
- prints out something like:

<img width="799" alt="Screen Shot 2022-08-26 at 2 23 02 PM" src="https://user-images.githubusercontent.com/343288/186985063-9db447da-62ba-4cc0-b40f-c72fc6fd428c.png">

