### PR TITLE
Fix SQL query turning to funnel chart crashes the app

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/Funnel.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Funnel.jsx
@@ -77,7 +77,7 @@ export default class Funnel extends Component {
     ["Tiers Page", 700],
     ["Trial Form", 200],
     ["Trial Confirmation", 40],
-  ].map(row => ({
+  ].map((row, index) => ({
     card: {
       display: "funnel",
       visualization_settings: {
@@ -85,6 +85,7 @@ export default class Funnel extends Component {
         "funnel.dimension": "Total Sessions",
       },
       dataset_query: { type: "null" },
+      rowIndex: index,
     },
     data: {
       rows: [row],


### PR DESCRIPTION
EPIC #24840
Possibly missed from https://github.com/metabase/metabase/pull/24948/files#diff-9f01cd146d8a2f731e1aebe875778f1886dc1495bfaaa2543ab2991d8a305703

For reference https://github.com/metabase/metabase/pull/24948

## How to test
1. Go to stats.
2. Create a Native query from `sample database`
3. Paste this and run query
    ```sql
    select * from
    values (1, 100), (2, 80),(3, 50), (4, 20)
    
    as X(x,y)
    ```
4. Change visualization to funnel chart
5. Should not crash
    ![image](https://user-images.githubusercontent.com/1937582/187153059-2137f4be-70d0-4d41-b7dd-69299a1d209b.png)
 