### PR TITLE
Handle tables that were hidden during the initial sync

### DIFF
--- a/frontend/src/metabase-types/api/table.ts
+++ b/frontend/src/metabase-types/api/table.ts
@@ -4,7 +4,7 @@ import { Field } from "./field";
 
 export type TableId = number | string; // can be string for virtual questions (e.g. "card__17")
 
-export type VisibilityType =
+export type TableVisibilityType =
   | null
   | "details-only"
   | "hidden"
@@ -24,6 +24,6 @@ export interface Table {
   schema: string;
   fks?: ForeignKey[];
   schema_name?: string;
-  visibility_type: VisibilityType;
+  visibility_type: TableVisibilityType;
   fields?: Field[];
 }

--- a/frontend/src/metabase/admin/datamodel/components/database/MetadataTable/MetadataTable.styled.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/MetadataTable/MetadataTable.styled.tsx
@@ -71,26 +71,3 @@ export const TableDescription = styled.div`
   border: 1px solid transparent;
   margin-top: -1px;
 `;
-
-export const VisibilityWarning = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  margin-top: 2rem;
-`;
-
-export const VisibilityWarningTitle = styled.div`
-  color: ${color("text-dark")};
-  font-size: 1.25rem;
-  font-weight: bold;
-  line-height: 1.5rem;
-  margin-bottom: 0.5rem;
-`;
-
-export const VisibilityWarningDescription = styled.div`
-  color: ${color("text-dark")};
-  line-height: 1.5rem;
-  margin-bottom: 1.5rem;
-  max-width: 25rem;
-  text-align: center;
-`;

--- a/frontend/src/metabase/admin/datamodel/components/database/MetadataTable/MetadataTable.styled.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/MetadataTable/MetadataTable.styled.tsx
@@ -71,3 +71,8 @@ export const TableDescription = styled.div`
   border: 1px solid transparent;
   margin-top: -1px;
 `;
+
+export const TableSyncMessage = styled.div`
+  color: ${color("text-medium")};
+  margin-left: 0.5rem;
+`;

--- a/frontend/src/metabase/admin/datamodel/components/database/MetadataTable/MetadataTable.styled.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/MetadataTable/MetadataTable.styled.tsx
@@ -72,7 +72,25 @@ export const TableDescription = styled.div`
   margin-top: -1px;
 `;
 
-export const TableSyncMessage = styled.div`
-  color: ${color("text-medium")};
-  margin-left: 0.5rem;
+export const VisibilityWarning = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 2rem;
+`;
+
+export const VisibilityWarningTitle = styled.div`
+  color: ${color("text-dark")};
+  font-size: 1.25rem;
+  font-weight: bold;
+  line-height: 1.5rem;
+  margin-bottom: 0.5rem;
+`;
+
+export const VisibilityWarningDescription = styled.div`
+  color: ${color("text-dark")};
+  line-height: 1.5rem;
+  margin-bottom: 1.5rem;
+  max-width: 25rem;
+  text-align: center;
 `;

--- a/frontend/src/metabase/admin/datamodel/components/database/MetadataTable/MetadataTable.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/MetadataTable/MetadataTable.tsx
@@ -8,23 +8,21 @@ import withTableMetadataLoaded from "metabase/admin/datamodel/hoc/withTableMetad
 import Radio from "metabase/core/components/Radio";
 import { isSyncCompleted } from "metabase/lib/syncing";
 import { DatabaseEntity, TableEntity } from "metabase-types/entities";
+import { TableVisibilityType } from "metabase-types/api";
 import { State } from "metabase-types/store";
 
 import ColumnsList from "../ColumnsList";
 import MetadataSchema from "../MetadataSchema";
+import TableSyncWarning from "../TableSyncWarning";
 import {
   TableDescription,
   TableDescriptionInput,
   TableName,
   TableNameInput,
-  VisibilityWarning,
-  VisibilityWarningDescription,
-  VisibilityWarningTitle,
   VisibilityType,
 } from "./MetadataTable.styled";
 import { Field } from "metabase-types/api/field";
 import { PLUGIN_FEATURE_LEVEL_PERMISSIONS } from "metabase/plugins";
-import Button from "metabase/core/components/Button";
 
 const getDescriptionPlaceholder = () => t`No table description yet`;
 
@@ -68,8 +66,13 @@ const MetadataTable = ({
     handlePropertyUpdate("description", event.target.value);
   };
 
+  const handleVisibilityTypeChange = (visibilityType: TableVisibilityType) => {
+    handlePropertyUpdate("visibility_type", visibilityType);
+  };
+
   const isHidden = !!table.visibility_type;
   const isSynced = isSyncCompleted(table);
+  const hasFields = table.fields && table.fields.length > 0;
 
   if (!table) {
     return null;
@@ -161,18 +164,8 @@ const MetadataTable = ({
           )}
         </div>
       )}
-      {!isSynced && isHidden && (
-        <VisibilityWarning>
-          <VisibilityWarningTitle>
-            {t`This table hasn’t been synced yet`}
-          </VisibilityWarningTitle>
-          <VisibilityWarningDescription>
-            {t`It was automatically marked as Hidden during the initial sync of this database. Do you want to make it queryable and sync it?`}
-          </VisibilityWarningDescription>
-          <Button onClick={() => handlePropertyUpdate("visibility_type", null)}>
-            {t`Change to Queryable and sync it`}
-          </Button>
-        </VisibilityWarning>
+      {!isSynced && isHidden && !hasFields && (
+        <TableSyncWarning onVisibilityTypeChange={handleVisibilityTypeChange} />
       )}
     </div>
   );

--- a/frontend/src/metabase/admin/datamodel/components/database/MetadataTable/MetadataTable.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/MetadataTable/MetadataTable.tsx
@@ -17,11 +17,14 @@ import {
   TableDescriptionInput,
   TableName,
   TableNameInput,
+  VisibilityWarning,
+  VisibilityWarningDescription,
+  VisibilityWarningTitle,
   VisibilityType,
-  TableSyncMessage,
 } from "./MetadataTable.styled";
 import { Field } from "metabase-types/api/field";
 import { PLUGIN_FEATURE_LEVEL_PERMISSIONS } from "metabase/plugins";
+import Button from "metabase/core/components/Button";
 
 const getDescriptionPlaceholder = () => t`No table description yet`;
 
@@ -134,12 +137,6 @@ const MetadataTable = ({
           )}
         </span>
       </div>
-      {!isSynced && (
-        <TableSyncMessage>
-          {t`The table was hidden during the initial sync.`}{" "}
-          {t`You need to make it Queryable so we can sync this table and its columns.`}
-        </TableSyncMessage>
-      )}
       <div className="mx1 border-bottom">
         <Radio
           colorScheme="default"
@@ -163,6 +160,19 @@ const MetadataTable = ({
             />
           )}
         </div>
+      )}
+      {!isSynced && isHidden && (
+        <VisibilityWarning>
+          <VisibilityWarningTitle>
+            {t`This table hasn’t been synced yet`}
+          </VisibilityWarningTitle>
+          <VisibilityWarningDescription>
+            {t`It was automatically marked as Hidden during the initial sync of this database. Do you want to make it queryable and sync it?`}
+          </VisibilityWarningDescription>
+          <Button onClick={() => handlePropertyUpdate("visibility_type", null)}>
+            {t`Change to Queryable and sync it`}
+          </Button>
+        </VisibilityWarning>
       )}
     </div>
   );

--- a/frontend/src/metabase/admin/datamodel/components/database/MetadataTable/MetadataTable.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/MetadataTable/MetadataTable.tsx
@@ -136,8 +136,8 @@ const MetadataTable = ({
       </div>
       {!isSynced && (
         <TableSyncMessage>
-          {t`This table was omitted during the database sync process.`}{" "}
-          {t`Make it Queryable to scan its fields for the first time.`}
+          {t`The table was hidden during the initial sync.`}{" "}
+          {t`You need to make it Queryable so we can sync this table and its columns.`}
         </TableSyncMessage>
       )}
       <div className="mx1 border-bottom">

--- a/frontend/src/metabase/admin/datamodel/components/database/MetadataTable/MetadataTable.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/MetadataTable/MetadataTable.tsx
@@ -6,6 +6,7 @@ import Databases from "metabase/entities/databases";
 import Tables from "metabase/entities/tables";
 import withTableMetadataLoaded from "metabase/admin/datamodel/hoc/withTableMetadataLoaded";
 import Radio from "metabase/core/components/Radio";
+import { isSyncCompleted } from "metabase/lib/syncing";
 import { DatabaseEntity, TableEntity } from "metabase-types/entities";
 import { State } from "metabase-types/store";
 
@@ -17,6 +18,7 @@ import {
   TableName,
   TableNameInput,
   VisibilityType,
+  TableSyncMessage,
 } from "./MetadataTable.styled";
 import { Field } from "metabase-types/api/field";
 import { PLUGIN_FEATURE_LEVEL_PERMISSIONS } from "metabase/plugins";
@@ -64,6 +66,7 @@ const MetadataTable = ({
   };
 
   const isHidden = !!table.visibility_type;
+  const isSynced = isSyncCompleted(table);
 
   if (!table) {
     return null;
@@ -131,6 +134,12 @@ const MetadataTable = ({
           )}
         </span>
       </div>
+      {!isSynced && (
+        <TableSyncMessage>
+          {t`This table was omitted during the database sync process.`}{" "}
+          {t`Make it Queryable to scan its fields for the first time.`}
+        </TableSyncMessage>
+      )}
       <div className="mx1 border-bottom">
         <Radio
           colorScheme="default"

--- a/frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx
@@ -14,7 +14,6 @@ import cx from "classnames";
 
 import { regexpEscape } from "metabase/lib/string";
 import { color } from "metabase/lib/colors";
-import { isSyncCompleted } from "metabase/lib/syncing";
 
 class MetadataTableList extends Component {
   constructor(props, context) {
@@ -174,20 +173,18 @@ function TableRow({
       <a
         className={cx(
           "AdminList-item flex align-center no-decoration text-wrap justify-between",
-          { selected, disabled: !isSyncCompleted(table) },
+          { selected },
         )}
         onClick={() => selectTable(table)}
       >
         {table.display_name}
-        {isSyncCompleted(table) && (
-          <div className="hover-child float-right">
-            <ToggleHiddenButton
-              tables={[table]}
-              isHidden={table.visibility_type != null}
-              setVisibilityForTables={setVisibilityForTables}
-            />
-          </div>
-        )}
+        <div className="hover-child float-right">
+          <ToggleHiddenButton
+            tables={[table]}
+            isHidden={table.visibility_type != null}
+            setVisibilityForTables={setVisibilityForTables}
+          />
+        </div>
       </a>
     </li>
   );

--- a/frontend/src/metabase/admin/datamodel/components/database/MetadataTablePicker.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/MetadataTablePicker.jsx
@@ -2,8 +2,10 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import _ from "underscore";
+import Databases from "metabase/entities/databases";
 import Tables from "metabase/entities/tables";
 import { isSyncInProgress } from "metabase/lib/syncing";
+import { SAVED_QUESTIONS_VIRTUAL_DB_ID } from "metabase/lib/saved-questions";
 import { PLUGIN_FEATURE_LEVEL_PERMISSIONS } from "metabase/plugins";
 import MetadataTableList from "./MetadataTableList";
 import MetadataSchemaList from "./MetadataSchemaList";
@@ -63,16 +65,28 @@ class MetadataTablePicker extends Component {
   }
 }
 
-export default Tables.loadList({
-  query: (state, { databaseId }) => ({
-    dbId: databaseId,
-    include_hidden: true,
-    ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.dataModelQueryProps,
+export default _.compose(
+  Databases.load({
+    id: (state, { databaseId }) =>
+      databaseId !== SAVED_QUESTIONS_VIRTUAL_DB_ID ? databaseId : undefined,
   }),
-  reloadInterval: (state, props, tables = []) => {
-    return tables.some(t => !t.visibility_type && isSyncInProgress(t))
-      ? RELOAD_INTERVAL
-      : 0;
-  },
-  selectorName: "getListUnfiltered",
-})(MetadataTablePicker);
+  Tables.loadList({
+    query: (state, { databaseId }) => ({
+      dbId: databaseId,
+      include_hidden: true,
+      ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.dataModelQueryProps,
+    }),
+    reloadInterval: (state, { database }, tables = []) => {
+      if (
+        database &&
+        isSyncInProgress(database) &&
+        tables.some(t => isSyncInProgress(t))
+      ) {
+        return RELOAD_INTERVAL;
+      } else {
+        return 0;
+      }
+    },
+    selectorName: "getListUnfiltered",
+  }),
+)(MetadataTablePicker);

--- a/frontend/src/metabase/admin/datamodel/components/database/MetadataTablePicker.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/MetadataTablePicker.jsx
@@ -2,6 +2,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import _ from "underscore";
+import Databases from "metabase/entities/databases";
 import Tables from "metabase/entities/tables";
 import { isSyncInProgress } from "metabase/lib/syncing";
 import { PLUGIN_FEATURE_LEVEL_PERMISSIONS } from "metabase/plugins";
@@ -63,14 +64,23 @@ class MetadataTablePicker extends Component {
   }
 }
 
-export default Tables.loadList({
-  query: (state, { databaseId }) => ({
-    dbId: databaseId,
-    include_hidden: true,
-    ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.dataModelQueryProps,
+export default _.compose(
+  Databases.load({
+    id: (state, { databaseId }) => databaseId,
   }),
-  reloadInterval: (state, props, tables = []) => {
-    return tables.some(t => isSyncInProgress(t)) ? RELOAD_INTERVAL : 0;
-  },
-  selectorName: "getListUnfiltered",
-})(MetadataTablePicker);
+  Tables.loadList({
+    query: (state, { databaseId }) => ({
+      dbId: databaseId,
+      include_hidden: true,
+      ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.dataModelQueryProps,
+    }),
+    reloadInterval: (state, { database }, tables = []) => {
+      if (isSyncInProgress(database) && tables.some(t => isSyncInProgress(t))) {
+        return RELOAD_INTERVAL;
+      } else {
+        return 0;
+      }
+    },
+    selectorName: "getListUnfiltered",
+  }),
+)(MetadataTablePicker);

--- a/frontend/src/metabase/admin/datamodel/components/database/TableSyncWarning/TableSyncWarning.styled.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/TableSyncWarning/TableSyncWarning.styled.tsx
@@ -1,0 +1,25 @@
+import styled from "@emotion/styled";
+import { color } from "metabase/lib/colors";
+
+export const SyncWarningRoot = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 2rem;
+`;
+
+export const SyncWarningTitle = styled.div`
+  color: ${color("text-dark")};
+  font-size: 1.25rem;
+  font-weight: bold;
+  line-height: 1.5rem;
+  margin-bottom: 0.5rem;
+`;
+
+export const SyncWarningDescription = styled.div`
+  color: ${color("text-dark")};
+  line-height: 1.5rem;
+  margin-bottom: 1.5rem;
+  max-width: 25rem;
+  text-align: center;
+`;

--- a/frontend/src/metabase/admin/datamodel/components/database/TableSyncWarning/TableSyncWarning.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/TableSyncWarning/TableSyncWarning.tsx
@@ -1,0 +1,37 @@
+import React, { useCallback } from "react";
+import { t } from "ttag";
+import Button from "metabase/core/components/Button/Button";
+import { Table, TableVisibilityType } from "metabase-types/api";
+import {
+  SyncWarningRoot,
+  SyncWarningDescription,
+  SyncWarningTitle,
+} from "./TableSyncWarning.styled";
+
+export interface TableSyncWarningProps {
+  onVisibilityTypeChange: (visibilityType: TableVisibilityType) => void;
+}
+
+const TableSyncWarning = ({
+  onVisibilityTypeChange,
+}: TableSyncWarningProps) => {
+  const handleVisibilityClick = () => {
+    onVisibilityTypeChange(null);
+  };
+
+  return (
+    <SyncWarningRoot>
+      <SyncWarningTitle>
+        {t`This table hasn’t been synced yet`}
+      </SyncWarningTitle>
+      <SyncWarningDescription>
+        {t`It was automatically marked as Hidden during the initial sync of this database. Do you want to make it queryable and sync it?`}
+      </SyncWarningDescription>
+      <Button onClick={handleVisibilityClick}>
+        {t`Change to Queryable and sync it`}
+      </Button>
+    </SyncWarningRoot>
+  );
+};
+
+export default TableSyncWarning;

--- a/frontend/src/metabase/admin/datamodel/components/database/TableSyncWarning/index.ts
+++ b/frontend/src/metabase/admin/datamodel/components/database/TableSyncWarning/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./TableSyncWarning";

--- a/frontend/src/metabase/browse/components/TableBrowser/TableBrowser.unit.spec.js
+++ b/frontend/src/metabase/browse/components/TableBrowser/TableBrowser.unit.spec.js
@@ -26,12 +26,17 @@ describe("TableBrowser", () => {
   });
 
   it("should render syncing tables", () => {
+    const database = getDatabase({
+      initial_sync_status: "incomplete",
+    });
+
     const tables = [
       getTable({ id: 1, name: "Orders", initial_sync_status: "incomplete" }),
     ];
 
     render(
       <TableBrowser
+        database={database}
         tables={tables}
         getTableUrl={getTableUrl}
         xraysEnabled={true}
@@ -44,12 +49,17 @@ describe("TableBrowser", () => {
   });
 
   it("should render tables with a sync error", () => {
+    const database = getDatabase({
+      initial_sync_status: "incomplete",
+    });
+
     const tables = [
       getTable({ id: 1, name: "Orders", initial_sync_status: "aborted" }),
     ];
 
     render(
       <TableBrowser
+        database={database}
         tables={tables}
         getTableUrl={getTableUrl}
         xraysEnabled={true}
@@ -57,9 +67,15 @@ describe("TableBrowser", () => {
     );
 
     expect(screen.getByText("Orders")).toBeInTheDocument();
-    expect(screen.queryByLabelText("bolt icon")).not.toBeInTheDocument();
-    expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
+    expect(screen.getByLabelText("bolt icon")).toBeInTheDocument();
+    expect(screen.queryByTestId("loading-spinner")).not.toBeInTheDocument();
   });
+});
+
+const getDatabase = ({ id, name, initial_sync_status }) => ({
+  id,
+  name,
+  initial_sync_status,
 });
 
 const getTable = ({ id, name, initial_sync_status }) => ({

--- a/frontend/src/metabase/browse/containers/TableBrowser/TableBrowser.jsx
+++ b/frontend/src/metabase/browse/containers/TableBrowser/TableBrowser.jsx
@@ -2,8 +2,7 @@ import { connect } from "react-redux";
 import _ from "underscore";
 import * as Urls from "metabase/lib/urls";
 import { isSyncInProgress } from "metabase/lib/syncing";
-import Databases from "metabase/entities/databases";
-import Tables from "metabase/entities/tables";
+import Table from "metabase/entities/tables";
 import { getMetadata } from "metabase/selectors/metadata";
 import { getXraysEnabled } from "metabase/selectors/settings";
 import { RELOAD_INTERVAL } from "../../constants";
@@ -23,8 +22,8 @@ const getSchemaName = props => {
   return props.schemaName || props.params.schemaName;
 };
 
-const getReloadInterval = (state, { database }, tables = []) => {
-  if (isSyncInProgress(database) && tables.some(t => isSyncInProgress(t))) {
+const getReloadInterval = (state, props, tables = []) => {
+  if (tables.some(t => !t.visibility_type && isSyncInProgress(t))) {
     return RELOAD_INTERVAL;
   } else {
     return 0;
@@ -37,10 +36,7 @@ const getTableUrl = (table, metadata) => {
 };
 
 export default _.compose(
-  Databases.load({
-    id: (state, props) => getDatabaseId(props),
-  }),
-  Tables.loadList({
+  Table.loadList({
     query: (state, props) => ({
       dbId: getDatabaseId(props),
       schemaName: getSchemaName(props),

--- a/frontend/src/metabase/browse/containers/TableBrowser/TableBrowser.jsx
+++ b/frontend/src/metabase/browse/containers/TableBrowser/TableBrowser.jsx
@@ -2,28 +2,40 @@ import { connect } from "react-redux";
 import _ from "underscore";
 import * as Urls from "metabase/lib/urls";
 import { isSyncInProgress } from "metabase/lib/syncing";
-import Table from "metabase/entities/tables";
+import { SAVED_QUESTIONS_VIRTUAL_DB_ID } from "metabase/lib/saved-questions";
+import Databases from "metabase/entities/databases";
+import Tables from "metabase/entities/tables";
 import { getMetadata } from "metabase/selectors/metadata";
 import { getXraysEnabled } from "metabase/selectors/settings";
 import { RELOAD_INTERVAL } from "../../constants";
 import TableBrowser from "../../components/TableBrowser";
 
-const getDatabaseId = props => {
+const getDatabaseId = (props, { includeVirtual } = {}) => {
   const { params } = props;
   const dbId =
     parseInt(props.dbId) ||
     parseInt(params.dbId) ||
     Urls.extractEntityId(params.slug);
 
-  return Number.isSafeInteger(dbId) ? dbId : undefined;
+  if (!Number.isSafeInteger(dbId)) {
+    return undefined;
+  } else if (dbId === SAVED_QUESTIONS_VIRTUAL_DB_ID && !includeVirtual) {
+    return undefined;
+  } else {
+    return dbId;
+  }
 };
 
 const getSchemaName = props => {
   return props.schemaName || props.params.schemaName;
 };
 
-const getReloadInterval = (state, props, tables = []) => {
-  if (tables.some(t => !t.visibility_type && isSyncInProgress(t))) {
+const getReloadInterval = (state, { database }, tables = []) => {
+  if (
+    database &&
+    isSyncInProgress(database) &&
+    tables.some(t => isSyncInProgress(t))
+  ) {
     return RELOAD_INTERVAL;
   } else {
     return 0;
@@ -36,15 +48,18 @@ const getTableUrl = (table, metadata) => {
 };
 
 export default _.compose(
-  Table.loadList({
+  Databases.load({
+    id: (state, props) => getDatabaseId(props),
+  }),
+  Tables.loadList({
     query: (state, props) => ({
-      dbId: getDatabaseId(props),
+      dbId: getDatabaseId(props, { includeVirtual: true }),
       schemaName: getSchemaName(props),
     }),
     reloadInterval: getReloadInterval,
   }),
   connect((state, props) => ({
-    dbId: getDatabaseId(props),
+    dbId: getDatabaseId(props, { includeVirtual: true }),
     schemaName: getSchemaName(props),
     metadata: getMetadata(state),
     xraysEnabled: getXraysEnabled(state),


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/24900

The problem is that tables can be marked as hidden automatically during the initial sync. This leaves `initial_sync_status: "incomplete"` forever for such tables. The UI wasn't aware of this edge case, and kept polling tables and showing spinners. As a workaround:
- We could also check for `database.initial_sync_status`. It is set correctly and it would be `incomplete` only during the sync.
- We need to keep in mind that we have a virtual database called `Saved questions` which has questions as virtual tables. We should ignore such tables and act as they have completed syncing.
- We could suggest that the user changes the visibility type to visible and re-scan table columns. The problem is that, while we could detect correctly in-progress tables with the database check, there is no reliable way to detect tables with broken sync since `initial_sync_status` is not updated for subsequent sync runs. My best attempt is to check that the table is hidden, the `initial_sync_status` is `incomplete`, and there are no fields. If that's the case, we'll show a warning with a button to make the table visible to sync it.

Changes:
- Prevents infinite polling for broken tables
- Allows selecting such tables in Data Model, changing visibility type etc.
- Adds a message explaining that the table wasn't synced and it needs to become visible for that

How to test:
- Go to Admin -> Databases -> New -> H2
- Add our app db `metabase.db`. The connection string would look like this `/Users/alex/Work/metabase/metabase.db`.
- Go to Admin -> Data Model -> App DB and select `Databasechangeloglock` table.
- There should be a new message with details why this table wasn't synced yet.
- Clicking on the button should make it visible and its columns should appear.
- Also make sure that there was no backend polling while in Data Model tab.

<img width="662" alt="Screenshot 2022-08-30 at 18 34 49" src="https://user-images.githubusercontent.com/8542534/187465682-b25aeb9b-69b2-4a8c-b933-44329b4750fd.png">

<img width="1710" alt="Screenshot 2022-08-30 at 18 28 51" src="https://user-images.githubusercontent.com/8542534/187464863-2ee8016d-a907-45f7-96ee-1593c8b955d3.png">
