### PR TITLE
Fix filter updates in filter pill popover

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx
@@ -135,7 +135,7 @@ export function FilterHeader({ question, expanded }) {
           >
             <FilterPopover
               isTopLevel
-              query={query}
+              query={filter.query()}
               filter={filter}
               onChangeFilter={newFilter =>
                 newFilter.replace().update(null, { run: true })

--- a/frontend/test/metabase/scenarios/filters/reproductions/24994-update-filters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/reproductions/24994-update-filters.cy.spec.js
@@ -1,0 +1,66 @@
+import { restore } from "__support__/e2e/helpers";
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+
+const { PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
+
+const questionDetails = {
+  query: {
+    "source-query": {
+      "source-table": PRODUCTS_ID,
+      filter: [
+        "and",
+        ["=", ["field", PRODUCTS.CATEGORY, null], "Gadget", "Gizmo"],
+        [
+          "time-interval",
+          ["field", PRODUCTS.CREATED_AT, null],
+          -30,
+          "year",
+          {
+            include_current: false,
+          },
+        ],
+      ],
+      aggregation: [["count"]],
+      breakout: [["field", PRODUCTS.CATEGORY, null]],
+    },
+    filter: [
+      ">",
+      [
+        "field",
+        "count",
+        {
+          "base-type": "type/Integer",
+        },
+      ],
+      0,
+    ],
+  },
+};
+
+describe("issue 24994", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should allow updating filters (metabase#24994)", () => {
+    cy.createQuestion(questionDetails, { visitQuestion: true });
+
+    // Three filters
+    cy.findByTestId("filters-visibility-control").contains("3").click();
+
+    cy.findByText("Category is 2 selections").click();
+    assertFilterValueIsSelected("Gadget");
+    assertFilterValueIsSelected("Gizmo");
+    cy.findByText("Doohickey").click();
+    assertFilterValueIsSelected("Doohickey");
+    cy.button("Update filter").should("not.be.disabled").click();
+    cy.findByText("Category is 3 selections");
+  });
+});
+
+function assertFilterValueIsSelected(value) {
+  cy.findByTestId(`${value}-filter-value`).within(() =>
+    cy.get("input").should("be.checked"),
+  );
+}


### PR DESCRIPTION
Resolves #24994
Reproduces #24994

Reproduce:

Reproduce:
1. Question > Sample > Products
2. Filter Category=(select all) and CreatedAt=past 30 years
3. Count grouped by Category
4. Filter Count > 0
![image](https://user-images.githubusercontent.com/1447303/186667130-8d993222-6345-4b2d-86f4-dc4d7f42dd3f.png)
5. Try making any changes to the Category filter pill - the "Update filter" button should work and should update the filter