### PR TITLE
Fix filter pills in notebook mode when updating nested queries

### DIFF
--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterModal/BulkFilterModal.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterModal/BulkFilterModal.tsx
@@ -63,23 +63,45 @@ const BulkFilterModal = ({
     [searchQuery, sections],
   );
 
-  const handleAddFilter = useCallback((filter: Filter) => {
-    setQuery(filter.add());
-    setIsChanged(true);
-  }, []);
+  const handleAddFilter = useCallback(
+    (filter: Filter) => {
+      const oldQuery = getQuery(question);
+      if (oldQuery.sourceQuery() && !filter.query().sourceQuery()) {
+        setQuery(oldQuery.setSourceQuery(filter.add()));
+      } else {
+        setQuery(filter.add());
+      }
+      setIsChanged(true);
+    },
+    [question],
+  );
 
   const handleChangeFilter = useCallback(
     (filter: Filter, newFilter: Filter) => {
-      setQuery(filter.replace(newFilter));
+      const newQuery = filter.replace(newFilter);
+      const oldQuery = getQuery(question);
+      if (oldQuery.sourceQuery() && !newQuery.sourceQuery()) {
+        setQuery(oldQuery.setSourceQuery(newQuery));
+      } else {
+        setQuery(newQuery);
+      }
       setIsChanged(true);
     },
-    [],
+    [question],
   );
 
-  const handleRemoveFilter = useCallback((filter: Filter) => {
-    setQuery(filter.remove());
-    setIsChanged(true);
-  }, []);
+  const handleRemoveFilter = useCallback(
+    (filter: Filter) => {
+      const oldQuery = getQuery(question);
+      if (oldQuery.sourceQuery() && !filter.query().sourceQuery()) {
+        setQuery(oldQuery.setSourceQuery(filter.remove()));
+      } else {
+        setQuery(filter.remove());
+      }
+      setIsChanged(true);
+    },
+    [question],
+  );
 
   const handleClearSegments = useCallback(() => {
     setQuery(query.clearSegments());
@@ -87,10 +109,16 @@ const BulkFilterModal = ({
   }, [query]);
 
   const handleApplyQuery = useCallback(() => {
-    const preCleanedQuery = fixBetweens(query);
-    preCleanedQuery.clean().update(undefined, { run: true });
+    const newQuery = fixBetweens(query);
+    const oldQuery = getQuery(question);
+    if (oldQuery.sourceQuery() && !newQuery.sourceQuery()) {
+      oldQuery.setSourceQuery(newQuery).update(undefined, { run: true });
+    } else {
+      newQuery.clean().update(undefined, { run: true });
+    }
+    newQuery.clean().update(undefined, { run: true });
     onClose?.();
-  }, [query, onClose]);
+  }, [question, query, onClose]);
 
   const clearFilters = () => {
     setQuery(query.clearFilters());

--- a/frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx
@@ -137,9 +137,19 @@ export function FilterHeader({ question, expanded }) {
               isTopLevel
               query={query}
               filter={filter}
-              onChangeFilter={newFilter =>
-                newFilter.replace().update(null, { run: true })
-              }
+              onChangeFilter={newFilter => {
+                const filterQuery = filter.query();
+                const newQuery = filterQuery.updateFilter(
+                  filter.index(),
+                  newFilter,
+                );
+                if (query.sourceQuery() === filterQuery) {
+                  return query
+                    .setSourceQuery(newQuery)
+                    .update(null, { run: true });
+                }
+                return newQuery.update(null, { run: true });
+              }}
               className="scroll-y"
             />
           </PopoverWithTrigger>

--- a/frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx
@@ -135,7 +135,7 @@ export function FilterHeader({ question, expanded }) {
           >
             <FilterPopover
               isTopLevel
-              query={query}
+              query={filter.query()}
               filter={filter}
               onChangeFilter={newFilter => {
                 const filterQuery = filter.query();

--- a/frontend/test/metabase/scenarios/custom-column/custom-column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/custom-column/custom-column.cy.spec.js
@@ -322,7 +322,7 @@ describe("scenarios > question > custom column", () => {
     cy.findAllByText("57911");
   });
 
-  it.skip("should not be dropped if filter is changed after aggregation (metaabase#14193)", () => {
+  it("should not be dropped if filter is changed after aggregation (metaabase#14193)", () => {
     const CC_NAME = "Double the fun";
 
     cy.createQuestion(

--- a/frontend/test/metabase/scenarios/filters/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/filter.cy.spec.js
@@ -159,7 +159,7 @@ describe("scenarios > question > filter", () => {
     cy.findAllByText("Gizmo");
   });
 
-  it.skip("should not drop aggregated filters (metabase#11957)", () => {
+  it("should not drop aggregated filters (metabase#11957)", () => {
     const AGGREGATED_FILTER = "Count is less than or equal to 20";
 
     cy.createQuestion(


### PR DESCRIPTION
Resolves #11957
Resolves #14193

Reproduce:
1. Simple question > Sample Dataset > Orders
2. Filter by CreatedAt=CurrentMonth
3. Summarize by Count-of-rows, grouped by CreatedAt:Day
4. Filter by Metric "# Count" <= 20
5.
   A. Modify the CreatedAt filter (i.e. CurrentYear) and it should not drop the aggregated ("# Count") filter.
   B. Add/remove a non-aggregated filter and it should not drop the aggregated ("# Count") filter.

(Includes fix from #25065 for testing)