### PR TITLE
[E2E] Cross-version individual artifacts

### DIFF
--- a/.github/workflows/e2e-cross-version.yml
+++ b/.github/workflows/e2e-cross-version.yml
@@ -92,7 +92,7 @@ jobs:
       uses: actions/upload-artifact@v2
       if: always()
       with:
-        name: cypress-artifacts-{{ matrix.version.source}}-to-{{ matrix.version.target }}
+        name: cypress-artifacts-${{ matrix.version.source}}-to-${{ matrix.version.target }}
         path: |
           ./cypress
         if-no-files-found: ignore

--- a/.github/workflows/e2e-cross-version.yml
+++ b/.github/workflows/e2e-cross-version.yml
@@ -91,7 +91,7 @@ jobs:
       uses: actions/upload-artifact@v2
       if: failure()
       with:
-        name: cypress-artifacts
+        name: cypress-artifacts-{{ matrix.version.source}}-to-{{ matrix.version.target }}
         path: |
           ./cypress
         if-no-files-found: ignore

--- a/.github/workflows/e2e-cross-version.yml
+++ b/.github/workflows/e2e-cross-version.yml
@@ -1,7 +1,6 @@
 name: E2E Cross-version Tests
 
 on:
-  push:
   schedule:
     - cron: '0 9 * * 0'
 
@@ -90,7 +89,7 @@ jobs:
           --spec frontend/test/metabase/scenarios/cross-version/target/**/*.cy.spec.js
     - name: Upload Cypress Artifacts upon failure
       uses: actions/upload-artifact@v2
-      if: always()
+      if: failure()
       with:
         name: cypress-artifacts-${{ matrix.version.source}}-to-${{ matrix.version.target }}
         path: |

--- a/.github/workflows/e2e-cross-version.yml
+++ b/.github/workflows/e2e-cross-version.yml
@@ -1,6 +1,7 @@
 name: E2E Cross-version Tests
 
 on:
+  push:
   schedule:
     - cron: '0 9 * * 0'
 
@@ -89,7 +90,7 @@ jobs:
           --spec frontend/test/metabase/scenarios/cross-version/target/**/*.cy.spec.js
     - name: Upload Cypress Artifacts upon failure
       uses: actions/upload-artifact@v2
-      if: failure()
+      if: always()
       with:
         name: cypress-artifacts-{{ matrix.version.source}}-to-{{ matrix.version.target }}
         path: |


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Updates the cross-version E2E workflow by distinguishing between individual matrix artifacts

Previously:
If more jobs failed, only the screenshots and logs from the last one would have been uploaded.

Now:
Each failed job will store its own artifacts separately.

### How to test?
I already did it for you :)
https://github.com/metabase/metabase/actions/runs/2950552729

![image](https://user-images.githubusercontent.com/31325167/187268756-1c64181a-c07c-4043-98df-1bfac8338c27.png)
