### PR TITLE
Action Creator 2: Action Updates

### DIFF
--- a/frontend/src/metabase-types/types/Card.ts
+++ b/frontend/src/metabase-types/types/Card.ts
@@ -33,6 +33,7 @@ export type SavedCard<Query = DatasetQuery> = UnsavedCard<Query> & {
   public_uuid: string;
   cache_ttl?: number | null;
   archived?: boolean;
+  collection_id?: number | null;
 
   // Only for native queries
   is_write?: boolean;

--- a/frontend/src/metabase/entities/actions/actions.ts
+++ b/frontend/src/metabase/entities/actions/actions.ts
@@ -1,10 +1,11 @@
 import { createEntity } from "metabase/lib/entities";
 
-import { saveForm } from "./forms";
-
 import type Question from "metabase-lib/lib/Question";
+import type { ActionFormSettings } from "metabase/writeback/types";
+
 import { CardApi } from "metabase/services";
-import { ActionFormSettings } from "metabase/writeback/types";
+
+import { saveForm } from "./forms";
 
 type ActionParams = {
   name: string;
@@ -14,24 +15,28 @@ type ActionParams = {
   formSettings: ActionFormSettings;
 };
 
-const createAction = async ({
-  name,
-  description,
-  question,
-  collection_id,
-  formSettings = {},
-}: ActionParams) => {
-  return CardApi.create({
-    ...question.card(),
+const getAPIFn =
+  (apifn: (args: any) => Promise<any>) =>
+  ({
     name,
     description,
-    parameters: question.parameters(),
-    is_write: true,
-    display: "table",
-    visualization_settings: formSettings,
+    question,
     collection_id,
-  });
-};
+    formSettings = {},
+  }: ActionParams) =>
+    apifn({
+      ...question.card(),
+      name,
+      description,
+      parameters: question.parameters(),
+      is_write: true,
+      display: "table",
+      visualization_settings: formSettings,
+      collection_id,
+    });
+
+const createAction = getAPIFn(CardApi.create);
+const updateAction = getAPIFn(CardApi.update);
 
 const Actions = createEntity({
   name: "actions",
@@ -39,6 +44,7 @@ const Actions = createEntity({
   path: "/api/action",
   api: {
     create: createAction,
+    update: updateAction,
   },
   forms: {
     saveForm,

--- a/frontend/src/metabase/writeback/components/ActionCreator/ActionCreator.tsx
+++ b/frontend/src/metabase/writeback/components/ActionCreator/ActionCreator.tsx
@@ -23,6 +23,12 @@ import {
 
 import { newQuestion } from "./utils";
 
+interface SaveActionFormData {
+  name?: string | null;
+  description?: string | null;
+  collection_id?: number | null;
+}
+
 const mapStateToProps = (state: State) => ({
   metadata: getMetadata(state),
 });
@@ -38,6 +44,26 @@ function ActionCreatorComponent({
     passedQuestion ?? newQuestion(metadata),
   );
   const [showSaveModal, setShowSaveModal] = useState(false);
+
+  const handleSave = async (questionData: SaveActionFormData) => {
+    const newQuestion = question
+      .setDisplayName(questionData.name)
+      .setDescription(questionData.description)
+      .setCollectionId(questionData.collection_id);
+
+    const response = await CardApi.create({
+      ...newQuestion.card(),
+      parameters: newQuestion.parameters(),
+      is_write: true,
+      display: "table",
+      visualization_settings: {},
+    });
+
+    if (response) {
+      setTimeout(() => setShowSaveModal(false), 1000);
+      // redirect somewhere?
+    }
+  };
 
   useEffect(() => {
     setQuestion(passedQuestion ?? newQuestion(metadata));

--- a/frontend/src/metabase/writeback/containers/ActionCreatorPage.tsx
+++ b/frontend/src/metabase/writeback/containers/ActionCreatorPage.tsx
@@ -2,6 +2,12 @@ import React from "react";
 
 import { ActionCreator } from "metabase/writeback/components/ActionCreator";
 
-export default function ActionCreatorPage() {
-  return <ActionCreator />;
+interface PageProps {
+  params: {
+    actionId?: string;
+  };
+}
+
+export default function ActionCreatorPage({ params: { actionId } }: PageProps) {
+  return <ActionCreator actionId={actionId} />;
 }

--- a/frontend/src/metabase/writeback/selectors.ts
+++ b/frontend/src/metabase/writeback/selectors.ts
@@ -1,6 +1,19 @@
+import Question from "metabase-lib/lib/Question";
 import { getSetting } from "metabase/selectors/settings";
-import { State } from "metabase-types/store";
+import { getMetadata } from "metabase/selectors/metadata";
+
+import type { State } from "metabase-types/store";
+import type { WritebackQueryAction } from "./types";
 
 export function getWritebackEnabled(state: State) {
   return getSetting(state, "experimental-enable-actions");
+}
+
+export function createQuestionFromAction(
+  state: State,
+  action: WritebackQueryAction,
+) {
+  return new Question(action.card, getMetadata(state)).setParameters(
+    action.parameters,
+  );
 }

--- a/frontend/src/metabase/writeback/types.ts
+++ b/frontend/src/metabase/writeback/types.ts
@@ -60,6 +60,8 @@ export interface HttpActionTemplate {
   parameter_mappings: Record<ParameterId, ParameterTarget>;
 }
 
+export type WritebackRowAction = WritebackActionBase & RowAction;
+export type WritebackHttpAction = WritebackActionBase & HttpAction;
 export type WritebackAction = WritebackActionBase & (RowAction | HttpAction);
 
 export interface WritebackActionEmitter {

--- a/frontend/src/metabase/writeback/types.ts
+++ b/frontend/src/metabase/writeback/types.ts
@@ -35,7 +35,7 @@ export interface WritebackActionBase {
   "created-at": string;
 }
 
-export interface RowAction {
+export interface QueryAction {
   type: "query";
   card: WritebackActionCard;
   card_id: number;
@@ -60,9 +60,9 @@ export interface HttpActionTemplate {
   parameter_mappings: Record<ParameterId, ParameterTarget>;
 }
 
-export type WritebackRowAction = WritebackActionBase & RowAction;
+export type WritebackQueryAction = WritebackActionBase & QueryAction;
 export type WritebackHttpAction = WritebackActionBase & HttpAction;
-export type WritebackAction = WritebackActionBase & (RowAction | HttpAction);
+export type WritebackAction = WritebackActionBase & (QueryAction | HttpAction);
 
 export interface WritebackActionEmitter {
   id: number;


### PR DESCRIPTION
## Description

- You can load and update an existing action at `/action/:id`
- updates in the modal windows should propagate back to the editor on save

*limitation: since we don't get `action_id` back from the card api on creation, we can't redirect newly-created actions to the correct `/action/:id` url yet. case is working on the BE implementation for that*

## Screenshots
![Screen Shot 2022-08-29 at 2 40 45 PM](https://user-images.githubusercontent.com/30528226/187299933-ca4e64a0-0942-4879-95c2-505dffa773dd.png)

## Testing steps

- Create
  - you can create a new action
  - after creating a new action, you can update it, and it, in fact, updates rather than creating another new question
 - Update
   - visiting `/action/1` for an action loads the data for action id 1
   - you can update the sql, title, description, and collection for that action
   - any changes in the save modal propagate back to the main editor screen after save
