### PR TITLE
[Apps] Hydrate action_id on is_write Card

### DIFF
--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -163,7 +163,7 @@
                  (cond-> ;; card
                    api/*is-superuser?* (hydrate [:emitters [:action :card]])
                    (:dataset raw-card) (hydrate :persisted)
-                   (:is_write raw-card) (hydrate :card/emitter-usages))
+                   (:is_write raw-card) (hydrate :card/emitter-usages :card/action-id))
                  api/read-check
                  (last-edit/with-last-edit-info :card))]
     (u/prog1 card
@@ -361,6 +361,8 @@ saved later when it is ready."
                           :average_query_time
                           :last_query_start
                           :collection [:moderation_reviews :moderator_details])
+                 (cond-> ;; card
+                   (:is_write card) (hydrate :card/action-id))
                  (assoc :last-edit-info (last-edit/edit-information-for-user @api/*current-user*)))
       (when timed-out?
         (schedule-metadata-saving result-metadata-chan <>)))))
@@ -596,7 +598,7 @@ saved later when it is ready."
                  :collection [:moderation_reviews :moderator_details])
         (cond-> ;; card
           (:dataset card) (hydrate :persisted)
-          (:is_write card) (hydrate :card/emitter-usages))
+          (:is_write card) (hydrate :card/emitter-usages :card/action-id))
         (assoc :last-edit-info (last-edit/edit-information-for-user @api/*current-user*)))))
 
 (api/defendpoint PUT "/:id"

--- a/src/metabase/models/action.clj
+++ b/src/metabase/models/action.clj
@@ -138,3 +138,16 @@
       (for [{emitter-id :id, :as emitter} emitters]
         (some-> emitter (assoc :action (get actions-by-id (get action-id-by-emitter-id emitter-id))))))
     emitters))
+
+(defn cards-by-action-id
+  "Hydrates action_id from Card for is_write cards"
+  {:batched-hydrate :card/action-id}
+  [cards]
+  (if-let [card-id->action-id (not-empty (db/select-field->field
+                                           :card_id :action_id
+                                           'QueryAction
+                                           :card_id [:in (map :id cards)]))]
+
+    (for [card cards]
+      (m/assoc-some card :action_id (get card-id->action-id (:id card))))
+    cards))

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -2355,7 +2355,7 @@
      {:before-fn   (fn [{card-id :id}]
                      (db/update! Card card-id :dataset true))
       :status-code 400
-      :result-fn   (fn [result]
+      :result-fn   (fn [result _]
                      (is (= {:errors {:is_write "Cannot mark Saved Question as 'is_write': Saved Question is a Dataset."}}
                             result)))})))
 
@@ -2365,7 +2365,7 @@
                test-create-is-write-card]]
       (f {:status-code 403
           :user                 :rasta
-          :result-fn            (fn [result]
+          :result-fn            (fn [result _]
                                   (is (= "You don't have permissions to do that."
                                          result)))}))))
 
@@ -2375,7 +2375,7 @@
                test-create-is-write-card]]
       (f {:status-code 400
           :query       (mt/mbql-query venues)
-          :result-fn   (fn [result]
+          :result-fn   (fn [result _]
                          (is (schema= {:errors {:is_write #"Cannot mark Saved Question as 'is_write': Query must be a native query."}}
                                       result)))}))))
 


### PR DESCRIPTION
It'll be helpful for the frontend if we send back the created action_id
when saving an `is_write` Card.

Also update the `api/card` tests to ensure that a QueryAction (and by
fk constraints the Action) is created/deleted as expected when
changing `is_write`.
