### PR TITLE
Automatically pick data app homepage

### DIFF
--- a/frontend/src/metabase-types/api/mocks/data-app.ts
+++ b/frontend/src/metabase-types/api/mocks/data-app.ts
@@ -1,5 +1,6 @@
-import { DataApp } from "metabase-types/api";
+import { DataApp, Dashboard } from "metabase-types/api";
 import { createMockCollection } from "./collection";
+import { createMockDashboard } from "./dashboard";
 
 export const createMockDataApp = ({
   collection: collectionProps,
@@ -18,3 +19,7 @@ export const createMockDataApp = ({
     collection,
   };
 };
+
+export const createMockDataAppPage = (
+  params: Partial<Omit<Dashboard, "is_app_page">>,
+): Dashboard => createMockDashboard({ ...params, is_app_page: true });

--- a/frontend/src/metabase/entities/data-apps/data-apps.ts
+++ b/frontend/src/metabase/entities/data-apps/data-apps.ts
@@ -9,7 +9,7 @@ import { Collection, DataApp } from "metabase-types/api";
 import { DEFAULT_COLLECTION_COLOR_ALIAS } from "../collections/constants";
 
 import { createNewAppForm, createAppSettingsForm } from "./forms";
-import { getDataAppIcon, isDataAppCollection } from "./utils";
+import { getDataAppIcon } from "./utils";
 
 type EditableDataAppParams = Pick<
   DataApp,
@@ -74,6 +74,5 @@ const DataApps = createEntity({
   },
 });
 
-export { getDataAppIcon, isDataAppCollection };
-
+export * from "./utils";
 export default DataApps;

--- a/frontend/src/metabase/entities/data-apps/utils.ts
+++ b/frontend/src/metabase/entities/data-apps/utils.ts
@@ -1,4 +1,5 @@
-import type { Collection, DataApp } from "metabase-types/api";
+import _ from "underscore";
+import type { Collection, DataApp, Dashboard } from "metabase-types/api";
 
 export function getDataAppIcon(app?: DataApp) {
   return { name: "star" };
@@ -6,4 +7,9 @@ export function getDataAppIcon(app?: DataApp) {
 
 export function isDataAppCollection(collection: Collection) {
   return typeof collection.app_id === "number";
+}
+
+export function getDataAppHomePageId(pages: Dashboard[]) {
+  const [firstPage] = _.sortBy(pages, "name");
+  return firstPage?.id;
 }

--- a/frontend/src/metabase/entities/data-apps/utils.unit.spec.ts
+++ b/frontend/src/metabase/entities/data-apps/utils.unit.spec.ts
@@ -1,0 +1,18 @@
+import { createMockDataAppPage } from "metabase-types/api/mocks";
+import { getDataAppHomePageId } from "./utils";
+
+describe("data app utils", () => {
+  describe("getDataAppHomePageId", () => {
+    it("returns fist page in alphabetical order", () => {
+      const page1 = createMockDataAppPage({ id: 1, name: "A" });
+      const page2 = createMockDataAppPage({ id: 2, name: "B" });
+      const page3 = createMockDataAppPage({ id: 3, name: "C" });
+
+      expect(getDataAppHomePageId([page2, page1, page3])).toEqual(page1.id);
+    });
+
+    it("returns undefined when there're no pages", () => {
+      expect(getDataAppHomePageId([])).toBeUndefined();
+    });
+  });
+});

--- a/frontend/src/metabase/writeback/containers/DataAppLanding.tsx
+++ b/frontend/src/metabase/writeback/containers/DataAppLanding.tsx
@@ -1,15 +1,19 @@
 import React, { ReactNode } from "react";
+import { Location } from "history";
 
-import { extractCollectionId } from "metabase/lib/urls";
+import * as Urls from "metabase/lib/urls";
 
-import DataApps from "metabase/entities/data-apps";
+import DataApps, { getDataAppHomePageId } from "metabase/entities/data-apps";
+import Search from "metabase/entities/search";
 
 import CollectionContent from "metabase/collections/containers/CollectionContent";
+import DashboardApp from "metabase/dashboard/containers/DashboardApp";
 
 import { DataApp } from "metabase-types/api";
 import { State } from "metabase-types/store";
 
 interface DataAppLandingOwnProps {
+  location: Location;
   params: {
     slug: string;
   };
@@ -20,10 +24,39 @@ interface DataAppLandingProps extends DataAppLandingOwnProps {
   dataApp: DataApp;
 }
 
-const DataAppLanding = ({ dataApp, children }: DataAppLandingProps) => {
+const DataAppLanding = ({
+  dataApp,
+  location,
+  params,
+  children,
+}: DataAppLandingProps) => {
+  if (Urls.isDataAppPreviewPath(location.pathname)) {
+    return (
+      <CollectionContent collectionId={dataApp.collection_id} isRoot={false} />
+    );
+  }
+
   return (
     <>
-      <CollectionContent collectionId={dataApp.collection_id} isRoot={false} />
+      <Search.ListLoader
+        query={{
+          collection: dataApp.collection_id,
+          models: ["dashboard"],
+          limit: 100,
+        }}
+        loadingAndErrorWrapper={false}
+      >
+        {({ list: pages = [] }: { list: any[] }) => {
+          const homepageId = getDataAppHomePageId(pages);
+          return homepageId ? (
+            <DashboardApp
+              dashboardId={homepageId}
+              location={location}
+              params={params}
+            />
+          ) : null;
+        }}
+      </Search.ListLoader>
       {children}
     </>
   );
@@ -31,5 +64,5 @@ const DataAppLanding = ({ dataApp, children }: DataAppLandingProps) => {
 
 export default DataApps.load({
   id: (state: State, { params }: DataAppLandingOwnProps) =>
-    extractCollectionId(params.slug),
+    Urls.extractCollectionId(params.slug),
 })(DataAppLanding);


### PR DESCRIPTION
Part of #24861

Every data app should have a homepage — a dashboard people would see first when they launch the app. Later in the cycle, we'll make it possible to handpick the homepage, but by default, we'll just open the first page.

### To Verify

1. + New > App > Fill in the details > Save
2. Click "Launch app"
3. Use the "Add a new page" button to add a few pages
4. Exit the app and launch it again
5. Ensure the first page in the app sidebar is selected and you can see its contents
6. Refresh the page
7. Make sure it still shows the page correctly and highlights it in the sidebar

### Demo

**Before**

https://user-images.githubusercontent.com/17258145/187425215-a1047d38-ca07-4fab-8c0e-50e53c703e34.mp4

**After**

https://user-images.githubusercontent.com/17258145/187425231-91e285af-da5c-42ba-95d2-edeafa07df8c.mp4

