### PR TITLE
Fix drag-n-drop for data apps

### DIFF
--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarView.tsx
@@ -27,7 +27,6 @@ import {
   CollectionMenuList,
   CollectionsMoreIcon,
   CollectionsMoreIconContainer,
-  DataAppLinkContainer,
   PaddedSidebarLink,
   SidebarContentRoot,
   SidebarHeading,

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarView.tsx
@@ -10,7 +10,6 @@ import {
   getCollectionIcon,
   PERSONAL_COLLECTIONS,
 } from "metabase/entities/collections";
-import { getDataAppIcon } from "metabase/entities/data-apps";
 import { isSmallScreen } from "metabase/lib/dom";
 import * as Urls from "metabase/lib/urls";
 
@@ -18,12 +17,17 @@ import type { Bookmark, Collection, DataApp, User } from "metabase-types/api";
 
 import { SelectedItem } from "./types";
 import BookmarkList from "./BookmarkList";
-import { SidebarCollectionLink, SidebarLink } from "./SidebarItems";
+import {
+  SidebarCollectionLink,
+  SidebarDataAppLink,
+  SidebarLink,
+} from "./SidebarItems";
 import {
   AddYourOwnDataLink,
   CollectionMenuList,
   CollectionsMoreIcon,
   CollectionsMoreIconContainer,
+  DataAppLinkContainer,
   PaddedSidebarLink,
   SidebarContentRoot,
   SidebarHeading,
@@ -140,14 +144,11 @@ function MainNavbarView({
             </SidebarHeadingWrapper>
             <ul>
               {dataApps.map(app => (
-                <PaddedSidebarLink
+                <SidebarDataAppLink
                   key={`app-${app.id}`}
-                  icon={getDataAppIcon(app)}
-                  url={Urls.dataApp(app, { mode: "preview" })}
+                  dataApp={app}
                   isSelected={dataAppItem?.id === app.id}
-                >
-                  {app.collection.name}
-                </PaddedSidebarLink>
+                />
               ))}
             </ul>
           </SidebarSection>

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarDataAppLink.styled.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarDataAppLink.styled.tsx
@@ -1,0 +1,12 @@
+import styled from "@emotion/styled";
+
+import { space } from "metabase/styled-components/theme";
+
+import SidebarLink from "./SidebarLink";
+import { collectionDragAndDropHoverStyle } from "./SidebarItems.styled";
+
+export const DataAppLink = styled(SidebarLink)<{ isHovered: boolean }>`
+  padding-left: ${space(2)};
+
+  ${props => props.isHovered && collectionDragAndDropHoverStyle}
+`;

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarDataAppLink.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarDataAppLink.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+
+import * as Urls from "metabase/lib/urls";
+
+import CollectionDropTarget from "metabase/containers/dnd/CollectionDropTarget";
+
+import { getDataAppIcon } from "metabase/entities/data-apps";
+
+import type { DataApp } from "metabase-types/api";
+
+import { DataAppLink } from "./SidebarDataAppLink.styled";
+
+type DroppableProps = {
+  hovered: boolean;
+  highlighted: boolean;
+};
+
+interface Props {
+  dataApp: DataApp;
+  isSelected: boolean;
+}
+
+function SidebarDataAppLink({
+  dataApp,
+  hovered: isHovered,
+  isSelected,
+}: Props & DroppableProps) {
+  const url = Urls.dataApp(dataApp, { mode: "preview" });
+  return (
+    <DataAppLink
+      url={url}
+      icon={getDataAppIcon(dataApp)}
+      isSelected={isSelected}
+      isHovered={isHovered}
+    >
+      {dataApp.collection.name}
+    </DataAppLink>
+  );
+}
+
+function DroppableSidebarDataAppLink({ dataApp, ...props }: Props) {
+  return (
+    <div data-testid="sidebar-collection-link-root">
+      <CollectionDropTarget collection={dataApp.collection}>
+        {(droppableProps: DroppableProps) => (
+          <SidebarDataAppLink
+            dataApp={dataApp}
+            {...props}
+            {...droppableProps}
+          />
+        )}
+      </CollectionDropTarget>
+    </div>
+  );
+}
+
+export default DroppableSidebarDataAppLink;

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarItems.styled.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarItems.styled.tsx
@@ -9,7 +9,7 @@ import Link from "metabase/core/components/Link";
 
 import { NAV_SIDEBAR_WIDTH } from "metabase/nav/constants";
 
-import { darken, color, lighten, alpha } from "metabase/lib/colors";
+import { darken, color, alpha } from "metabase/lib/colors";
 
 export const SidebarIcon = styled(Icon)<{
   color?: string | null;
@@ -72,13 +72,13 @@ NodeRoot.defaultProps = {
   hasDefaultIconStyle: true,
 };
 
+export const collectionDragAndDropHoverStyle = css`
+  color: ${color("text-white")};
+  background-color: ${color("brand")};
+`;
+
 export const CollectionNodeRoot = styled(NodeRoot)<{ hovered?: boolean }>`
-  ${props =>
-    props.hovered &&
-    css`
-      color: ${color("text-white")};
-      background-color: ${color("brand")};
-    `}
+  ${props => props.hovered && collectionDragAndDropHoverStyle}
 `;
 
 const itemContentStyle = css`

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/index.ts
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/index.ts
@@ -1,2 +1,3 @@
 export { default as SidebarCollectionLink } from "./SidebarCollectionLink";
+export { default as SidebarDataAppLink } from "./SidebarDataAppLink";
 export { default as SidebarLink } from "./SidebarLink";


### PR DESCRIPTION
Part of #24861

Allows moving items in and out of a data app with drag-n-drop in the same way we do for collections. Apps are technically collections, so we're reusing everything we already have for collections, just needed to wire up DND components.

### To Verify

1. + New > App > Fill in the details > Save. The app should appear in a dedicated nav sidebar section
2. Open any collection and drag a question/model/dashboard onto the app. The app should highlight when you hover it while dragging an item
3. Click the app name in the sidebar; you should see its contents in the main content area
4. Ensure the moved item appeared in the app
5. Ensure moving an item from the app to a collection works as well

### Demo

https://user-images.githubusercontent.com/17258145/187423957-69c6e1c8-bfe7-4f85-a2d1-00661e5d4569.mp4


