### PR TITLE
Extract `ClickBehaviorSidebar` components

### DIFF
--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ActionOptions.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ActionOptions.jsx
@@ -1,0 +1,97 @@
+/* eslint-disable react/prop-types */
+import React from "react";
+import { t } from "ttag";
+import _ from "underscore";
+
+import Icon from "metabase/components/Icon";
+
+import { color } from "metabase/lib/colors";
+
+import Actions from "metabase/entities/actions";
+
+import ClickMappings from "metabase/dashboard/components/ClickMappings";
+
+import { SidebarItemWrapper, SidebarItemStyle } from "./SidebarItem";
+import {
+  Heading,
+  SidebarContent,
+  SidebarIconWrapper,
+} from "./ClickBehaviorSidebar.styled";
+
+const ActionOption = ({ name, description, isSelected, onClick }) => {
+  return (
+    <SidebarItemWrapper
+      onClick={onClick}
+      style={{
+        ...SidebarItemStyle,
+        backgroundColor: isSelected ? color("brand") : "transparent",
+        color: isSelected ? color("white") : "inherit",
+        alignItems: description ? "flex-start" : "center",
+        marginTop: "2px",
+      }}
+    >
+      <SidebarIconWrapper>
+        <Icon
+          name="bolt"
+          color={isSelected ? color("text-white") : color("brand")}
+        />
+      </SidebarIconWrapper>
+      <div>
+        <h4>{name}</h4>
+        {description && (
+          <span
+            className={isSelected ? "text-white" : "text-medium"}
+            style={{ width: "95%", marginTop: "2px" }}
+          >
+            {description}
+          </span>
+        )}
+      </div>
+    </SidebarItemWrapper>
+  );
+};
+
+function ActionOptions({ dashcard, clickBehavior, updateSettings }) {
+  return (
+    <SidebarContent>
+      <Heading className="text-medium">{t`Pick an action`}</Heading>
+      <Actions.ListLoader>
+        {({ actions }) => {
+          const selectedAction = actions.find(
+            action => action.id === clickBehavior.action,
+          );
+          return (
+            <>
+              {actions.map(action => (
+                <ActionOption
+                  key={action.id}
+                  name={action.name}
+                  description={action.description}
+                  isSelected={clickBehavior.action === action.id}
+                  onClick={() =>
+                    updateSettings({
+                      type: clickBehavior.type,
+                      action: action.id,
+                      emitter_id: clickBehavior.emitter_id,
+                    })
+                  }
+                />
+              ))}
+              {selectedAction && (
+                <ClickMappings
+                  isAction
+                  object={selectedAction}
+                  dashcard={dashcard}
+                  clickBehavior={clickBehavior}
+                  updateSettings={updateSettings}
+                />
+              )}
+            </>
+          );
+        }}
+      </Actions.ListLoader>
+    </SidebarContent>
+  );
+}
+
+export default ActionOptions;

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.jsx
@@ -4,11 +4,7 @@ import { t, jt } from "ttag";
 import { getIn } from "icepick";
 import _ from "underscore";
 
-import Button from "metabase/core/components/Button";
 import Icon from "metabase/components/Icon";
-import InputBlurChange from "metabase/components/InputBlurChange";
-import ModalContent from "metabase/components/ModalContent";
-import ModalWithTrigger from "metabase/components/ModalWithTrigger";
 
 import { color } from "metabase/lib/colors";
 import {
@@ -24,11 +20,8 @@ import { clickBehaviorOptions, getClickBehaviorOptionName } from "./utils";
 import ActionOptions from "./ActionOptions";
 import Column from "./Column";
 import CrossfilterOptions from "./CrossfilterOptions";
-import CustomLinkText from "./CustomLinkText";
-import LinkOption from "./LinkOption";
+import LinkOptions from "./LinkOptions";
 import TypeSelector from "./TypeSelector";
-import ValuesYouCanReference from "./ValuesYouCanReference";
-import QuestionDashboardPicker from "./QuestionDashboardPicker";
 import { SidebarItemWrapper } from "./SidebarItem";
 import {
   CloseIconContainer,
@@ -334,133 +327,6 @@ class ClickBehaviorSidebar extends React.Component {
       </Sidebar>
     );
   }
-}
-
-function LinkOptions({ clickBehavior, updateSettings, dashcard, parameters }) {
-  const linkTypeOptions = [
-    { type: "dashboard", icon: "dashboard", name: t`Dashboard` },
-    { type: "question", icon: "bar", name: t`Saved question` },
-    { type: "url", icon: "link", name: t`URL` },
-  ];
-
-  return (
-    <SidebarContent>
-      <p className="text-medium mt3 mb1">{t`Link to`}</p>
-      <div>
-        {clickBehavior.linkType == null ? (
-          linkTypeOptions.map(({ type, icon, name }, index) => (
-            <LinkOption
-              key={name}
-              option={name}
-              icon={icon}
-              onClick={() =>
-                updateSettings({ type: clickBehavior.type, linkType: type })
-              }
-            />
-          ))
-        ) : clickBehavior.linkType === "url" ? (
-          <ModalWithTrigger
-            isInitiallyOpen={clickBehavior.linkTemplate == null}
-            triggerElement={
-              <SidebarItemWrapper
-                style={{
-                  backgroundColor: color("brand"),
-                  color: color("white"),
-                }}
-              >
-                <SidebarIconWrapper
-                  style={{ borderColor: "transparent", marginLeft: 8 }}
-                >
-                  <Icon name="link" />
-                </SidebarIconWrapper>
-                <div className="flex align-center full">
-                  <h4 className="pr1">
-                    {clickBehavior.linkTemplate
-                      ? clickBehavior.linkTemplate
-                      : t`URL`}
-                  </h4>
-                  <CloseIconContainer
-                    onClick={() =>
-                      updateSettings({
-                        type: clickBehavior.type,
-                        linkType: null,
-                      })
-                    }
-                  >
-                    <Icon name="close" size={12} />
-                  </CloseIconContainer>
-                </div>
-              </SidebarItemWrapper>
-            }
-          >
-            {({ onClose }) => (
-              <ModalContent
-                title={t`Enter a URL to link to`}
-                onClose={clickBehavior.targetId != null ? onClose : null}
-              >
-                <div className="mb1">{t`You can insert the value of a column or dashboard filter using its name, like this: {{some_column}}`}</div>
-                <InputBlurChange
-                  autoFocus
-                  className="input block full"
-                  placeholder={t`e.g. http://acme.com/id/\{\{user_id\}\}`}
-                  value={clickBehavior.linkTemplate}
-                  onChange={e =>
-                    updateSettings({
-                      ...clickBehavior,
-                      linkTemplate: e.target.value,
-                    })
-                  }
-                />
-                {isTableDisplay(dashcard) && (
-                  <CustomLinkText
-                    updateSettings={updateSettings}
-                    clickBehavior={clickBehavior}
-                  />
-                )}
-                <ValuesYouCanReference
-                  dashcard={dashcard}
-                  parameters={parameters}
-                />
-                <div className="flex">
-                  <Button
-                    primary
-                    onClick={() => onClose()}
-                    className="ml-auto mt2"
-                    disabled={!clickBehaviorIsValid(clickBehavior)}
-                  >{t`Done`}</Button>
-                </div>
-              </ModalContent>
-            )}
-          </ModalWithTrigger>
-        ) : (
-          <div></div>
-        )}
-      </div>
-      <div className="mt1">
-        {clickBehavior.linkType != null && clickBehavior.linkType !== "url" && (
-          <div>
-            <QuestionDashboardPicker
-              dashcard={dashcard}
-              clickBehavior={clickBehavior}
-              updateSettings={updateSettings}
-            />
-            {isTableDisplay(dashcard) && (
-              <div>
-                <CustomLinkText
-                  updateSettings={updateSettings}
-                  clickBehavior={clickBehavior}
-                />
-                <ValuesYouCanReference
-                  dashcard={dashcard}
-                  parameters={parameters}
-                />
-              </div>
-            )}
-          </div>
-        )}
-      </div>
-    </SidebarContent>
-  );
 }
 
 export default ClickBehaviorSidebar;

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.jsx
@@ -31,6 +31,7 @@ import ClickMappings, {
   clickTargetObjectType,
 } from "metabase/dashboard/components/ClickMappings";
 
+import { clickBehaviorOptions, getClickBehaviorOptionName } from "./utils";
 import Column from "./Column";
 import CustomLinkText from "./CustomLinkText";
 import LinkOption from "./LinkOption";
@@ -49,31 +50,6 @@ import {
   SidebarIconWrapper,
   SidebarItem,
 } from "./ClickBehaviorSidebar.styled";
-
-const clickBehaviorOptions = [
-  { value: "menu", icon: "popover" },
-  { value: "link", icon: "link" },
-  { value: "crossfilter", icon: "filter" },
-  { value: "action", icon: "play" },
-];
-
-function getClickBehaviorOptionName(value, dashcard) {
-  if (value === "menu") {
-    return hasActionsMenu(dashcard)
-      ? t`Open the Metabase actions menu`
-      : t`Do nothing`;
-  }
-  if (value === "link") {
-    return t`Go to a custom destination`;
-  }
-  if (value === "crossfilter") {
-    return t`Update a dashboard filter`;
-  }
-  if (value === "action") {
-    return t`Perform action`;
-  }
-  return t`Unknown`;
-}
 
 const BehaviorOption = ({
   option,

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 import React from "react";
-import { t, jt, ngettext, msgid } from "ttag";
+import { t, jt } from "ttag";
 import { getIn } from "icepick";
 import _ from "underscore";
 import cx from "classnames";
@@ -17,7 +17,6 @@ import {
   isTableDisplay,
   clickBehaviorIsValid,
 } from "metabase/lib/click-behavior";
-import { getIconForField } from "metabase/lib/schema_metadata";
 import { keyForColumn } from "metabase/lib/dataset";
 
 import Actions from "metabase/entities/actions";
@@ -32,6 +31,7 @@ import ClickMappings, {
   clickTargetObjectType,
 } from "metabase/dashboard/components/ClickMappings";
 
+import Column from "./Column";
 import CustomLinkText from "./CustomLinkText";
 import LinkOption from "./LinkOption";
 import ValuesYouCanReference from "./ValuesYouCanReference";
@@ -74,52 +74,6 @@ function getClickBehaviorOptionName(value, dashcard) {
   }
   return t`Unknown`;
 }
-
-const LinkTargetName = ({ clickBehavior: { linkType, targetId } }) => (
-  <span>
-    {linkType === "url" ? (
-      t`URL`
-    ) : linkType === "question" ? (
-      <span>
-        {'"'}
-        <Questions.Name id={targetId} />
-        {'"'}
-      </span>
-    ) : linkType === "dashboard" ? (
-      <span>
-        {'"'}
-        <Dashboards.Name id={targetId} />
-        {'"'}
-      </span>
-    ) : (
-      "Unknown"
-    )}
-  </span>
-);
-
-const Column = ({ column, clickBehavior, onClick }) => (
-  <SidebarItemWrapper onClick={onClick} style={{ ...SidebarItemStyle }}>
-    <SidebarIconWrapper>
-      <Icon name={getIconForField(column)} color={color("brand")} size={18} />
-    </SidebarIconWrapper>
-    <div>
-      <h4>
-        {clickBehavior && clickBehavior.type === "crossfilter"
-          ? (n =>
-              ngettext(
-                msgid`${column.display_name} updates ${n} filter`,
-                `${column.display_name} updates ${n} filters`,
-                n,
-              ))(Object.keys(clickBehavior.parameterMapping || {}).length)
-          : clickBehavior && clickBehavior.type === "link"
-          ? jt`${column.display_name} goes to ${(
-              <LinkTargetName clickBehavior={clickBehavior} />
-            )}`
-          : column.display_name}
-      </h4>
-    </div>
-  </SidebarItemWrapper>
-);
 
 const BehaviorOption = ({
   option,

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.jsx
@@ -34,6 +34,12 @@ import {
 } from "metabase/lib/click-behavior";
 import { getIconForField } from "metabase/lib/schema_metadata";
 import { keyForColumn } from "metabase/lib/dataset";
+
+import {
+  SidebarItemWrapper,
+  SidebarItemClasses,
+  SidebarItemStyle,
+} from "./SidebarItem";
 import {
   CloseIconContainer,
   Heading,
@@ -68,27 +74,6 @@ function getClickBehaviorOptionName(value, dashcard) {
   }
   return t`Unknown`;
 }
-
-const SidebarItemClasses =
-  "border-brand-hover bordered border-transparent rounded flex align-center cursor-pointer overflow-hidden";
-const SidebarItemStyle = {
-  paddingTop: 8,
-  paddingBottom: 8,
-  paddingLeft: 12,
-  paddingRight: 12,
-};
-
-const SidebarItemWrapper = ({ children, onClick, style, disabled }) => (
-  <div
-    className={cx(SidebarItemClasses, { disabled })}
-    onClick={!disabled && onClick}
-    style={{
-      ...style,
-    }}
-  >
-    {children}
-  </div>
-);
 
 const LinkTargetName = ({ clickBehavior: { linkType, targetId } }) => (
   <span>

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.jsx
@@ -828,12 +828,7 @@ function QuestionDashboardPicker({ dashcard, clickBehavior, updateSettings }) {
   );
 }
 
-const CustomLinkText = ({
-  clickBehavior,
-  dashcard,
-  parameters,
-  updateSettings,
-}) => {
+const CustomLinkText = ({ clickBehavior, updateSettings }) => {
   return (
     <div className="mt2 mb1">
       <Heading>{t`Customize link text (optional)`}</Heading>

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.jsx
@@ -1,6 +1,5 @@
 /* eslint-disable react/prop-types */
 import React from "react";
-import { jt } from "ttag";
 import { getIn } from "icepick";
 
 import Icon from "metabase/components/Icon";
@@ -16,6 +15,7 @@ import Sidebar from "metabase/dashboard/components/Sidebar";
 
 import { clickBehaviorOptions, getClickBehaviorOptionName } from "./utils";
 import ActionOptions from "./ActionOptions";
+import ClickBehaviorSidebarHeader from "./ClickBehaviorSidebarHeader";
 import CrossfilterOptions from "./CrossfilterOptions";
 import LinkOptions from "./LinkOptions";
 import TableClickBehaviorView from "./TableClickBehaviorView";
@@ -23,10 +23,8 @@ import TypeSelector from "./TypeSelector";
 import { SidebarItemWrapper } from "./SidebarItem";
 import {
   CloseIconContainer,
-  Heading,
   SidebarContent,
   SidebarContentBordered,
-  SidebarHeader,
   SidebarIconWrapper,
 } from "./ClickBehaviorSidebar.styled";
 
@@ -177,39 +175,11 @@ class ClickBehaviorSidebar extends React.Component {
         onCancel={this.handleCancel}
         closeIsDisabled={!clickBehaviorIsValid(clickBehavior)}
       >
-        <SidebarHeader>
-          {selectedColumn == null ? (
-            <Heading>{jt`Click behavior for ${(
-              <span className="text-brand">{dashcard.card.name}</span>
-            )}`}</Heading>
-          ) : (
-            <div
-              onClick={this.unsetSelectedColumn}
-              className="flex align-center text-brand-hover cursor-pointer"
-            >
-              <div
-                className="bordered"
-                style={{
-                  marginRight: 8,
-                  paddingTop: 4,
-                  paddingBottom: 4,
-                  paddingRight: 6,
-                  paddingLeft: 6,
-                  borderRadius: 4,
-                }}
-              >
-                <Icon name="chevronleft" className="text-medium" size={12} />
-              </div>
-              <Heading>
-                {jt`Click behavior for ${(
-                  <span className="text-brand">
-                    {selectedColumn.display_name}
-                  </span>
-                )}`}
-              </Heading>
-            </div>
-          )}
-        </SidebarHeader>
+        <ClickBehaviorSidebarHeader
+          dashcard={dashcard}
+          selectedColumn={selectedColumn}
+          hasSelectedColumn={selectedColumn != null}
+        />
         <div>
           {showTypeSelector ? (
             <SidebarContent>

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.jsx
@@ -34,7 +34,15 @@ import {
 } from "metabase/lib/click-behavior";
 import { getIconForField } from "metabase/lib/schema_metadata";
 import { keyForColumn } from "metabase/lib/dataset";
-import { CloseIconContainer, SidebarItem } from "./ClickBehaviorSidebar.styled";
+import {
+  CloseIconContainer,
+  Heading,
+  SidebarContent,
+  SidebarContentBordered,
+  SidebarHeader,
+  SidebarIconWrapper,
+  SidebarItem,
+} from "./ClickBehaviorSidebar.styled";
 
 const clickBehaviorOptions = [
   { value: "menu", icon: "popover" },
@@ -61,27 +69,6 @@ function getClickBehaviorOptionName(value, dashcard) {
   return t`Unknown`;
 }
 
-const Heading = ({ children }) => (
-  <h4
-    className="text-dark"
-    style={{ paddingTop: 22, paddingBottom: 16, marginBottom: 8 }}
-  >
-    {children}
-  </h4>
-);
-
-const SidebarContent = ({ children }) => (
-  <div style={{ paddingLeft: 32, paddingRight: 32 }}>{children}</div>
-);
-const SidebarContentBordered = ({ children }) => (
-  <div
-    className="border-bottom pb2"
-    style={{ paddingLeft: 32, paddingRight: 32 }}
-  >
-    {children}
-  </div>
-);
-
 const SidebarItemClasses =
   "border-brand-hover bordered border-transparent rounded flex align-center cursor-pointer overflow-hidden";
 const SidebarItemStyle = {
@@ -96,30 +83,6 @@ const SidebarItemWrapper = ({ children, onClick, style, disabled }) => (
     className={cx(SidebarItemClasses, { disabled })}
     onClick={!disabled && onClick}
     style={{
-      ...style,
-    }}
-  >
-    {children}
-  </div>
-);
-
-const SidebarHeader = ({ children }) => (
-  <div
-    className="border-bottom"
-    style={{ paddingLeft: 32, paddingRight: 36, marginBottom: 16 }}
-  >
-    {children}
-  </div>
-);
-
-const SidebarIconWrapper = ({ children, style }) => (
-  <div
-    className="flex justify-center align-center bordered rounded flex-no-shrink"
-    style={{
-      borderColor: "#F2F2F2",
-      width: 36,
-      height: 36,
-      marginRight: 10,
       ...style,
     }}
   >

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.jsx
@@ -167,6 +167,7 @@ class ClickBehaviorSidebar extends React.Component {
           dashcard={dashcard}
           selectedColumn={selectedColumn}
           hasSelectedColumn={selectedColumn != null}
+          onUnsetColumn={this.unsetSelectedColumn}
         />
         <div>
           {showTypeSelector ? (
@@ -187,6 +188,10 @@ class ClickBehaviorSidebar extends React.Component {
               dashboard={dashboard}
               dashcard={dashcard}
               parameters={parameters}
+              handleShowTypeSelector={() =>
+                this.setState({ showTypeSelector: true })
+              }
+              updateSettings={this.updateSettings}
             />
           )}
         </div>

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.jsx
@@ -32,6 +32,7 @@ import ClickMappings, {
   clickTargetObjectType,
 } from "metabase/dashboard/components/ClickMappings";
 
+import CustomLinkText from "./CustomLinkText";
 import ValuesYouCanReference from "./ValuesYouCanReference";
 import {
   SidebarItemWrapper,
@@ -825,24 +826,5 @@ function QuestionDashboardPicker({ dashcard, clickBehavior, updateSettings }) {
     </div>
   );
 }
-
-const CustomLinkText = ({ clickBehavior, updateSettings }) => {
-  return (
-    <div className="mt2 mb1">
-      <Heading>{t`Customize link text (optional)`}</Heading>
-      <InputBlurChange
-        className="input block full"
-        placeholder={t`E.x. Details for {{Column Name}}`}
-        value={clickBehavior.linkTextTemplate}
-        onBlurChange={e =>
-          updateSettings({
-            ...clickBehavior,
-            linkTextTemplate: e.target.value,
-          })
-        }
-      />
-    </div>
-  );
-};
 
 export default ClickBehaviorSidebar;

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.jsx
@@ -19,11 +19,11 @@ import {
 import { keyForColumn } from "metabase/lib/dataset";
 
 import Sidebar from "metabase/dashboard/components/Sidebar";
-import ClickMappings from "metabase/dashboard/components/ClickMappings";
 
 import { clickBehaviorOptions, getClickBehaviorOptionName } from "./utils";
 import ActionOptions from "./ActionOptions";
 import Column from "./Column";
+import CrossfilterOptions from "./CrossfilterOptions";
 import CustomLinkText from "./CustomLinkText";
 import LinkOption from "./LinkOption";
 import TypeSelector from "./TypeSelector";
@@ -334,27 +334,6 @@ class ClickBehaviorSidebar extends React.Component {
       </Sidebar>
     );
   }
-}
-
-function CrossfilterOptions({
-  clickBehavior,
-  dashboard,
-  dashcard,
-  updateSettings,
-}) {
-  return (
-    <SidebarContent>
-      <Heading className="text-medium">{t`Pick one or more filters to update`}</Heading>
-      <ClickMappings
-        object={dashboard}
-        dashcard={dashcard}
-        isDash
-        clickBehavior={clickBehavior}
-        updateSettings={updateSettings}
-        excludeParametersSources
-      />
-    </SidebarContent>
-  );
 }
 
 function LinkOptions({ clickBehavior, updateSettings, dashcard, parameters }) {

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.jsx
@@ -35,6 +35,7 @@ import { clickBehaviorOptions, getClickBehaviorOptionName } from "./utils";
 import Column from "./Column";
 import CustomLinkText from "./CustomLinkText";
 import LinkOption from "./LinkOption";
+import TypeSelector from "./TypeSelector";
 import ValuesYouCanReference from "./ValuesYouCanReference";
 import {
   SidebarItemWrapper,
@@ -50,40 +51,6 @@ import {
   SidebarIconWrapper,
   SidebarItem,
 } from "./ClickBehaviorSidebar.styled";
-
-const BehaviorOption = ({
-  option,
-  icon,
-  onClick,
-  hasNextStep,
-  selected,
-  disabled,
-}) => (
-  <SidebarItemWrapper
-    style={{
-      ...SidebarItemStyle,
-      backgroundColor: selected ? color("brand") : "transparent",
-      color: selected ? color("white") : "inherit",
-    }}
-    onClick={onClick}
-    disabled={disabled}
-  >
-    <SidebarIconWrapper style={{ borderColor: selected && "transparent" }}>
-      <Icon
-        name={selected ? "check" : icon}
-        color={selected ? color("white") : color("brand")}
-      />
-    </SidebarIconWrapper>
-    <div className="flex align-center full">
-      <h4>{option}</h4>
-      {hasNextStep && (
-        <span className="ml-auto">
-          <Icon name="chevronright" size={12} />
-        </span>
-      )}
-    </div>
-  </SidebarItemWrapper>
-);
 
 class ClickBehaviorSidebar extends React.Component {
   state = {
@@ -380,37 +347,6 @@ class ClickBehaviorSidebar extends React.Component {
       </Sidebar>
     );
   }
-}
-
-function TypeSelector({
-  updateSettings,
-  clickBehavior,
-  dashcard,
-  parameters,
-  moveToNextPage,
-}) {
-  return (
-    <div>
-      {clickBehaviorOptions.map(({ value, icon }) => (
-        <div key={value} className="mb1">
-          <BehaviorOption
-            onClick={() => {
-              if (value !== clickBehavior.type) {
-                updateSettings(value === "menu" ? undefined : { type: value });
-              } else if (value !== "menu") {
-                moveToNextPage(); // if it didn't change, we need to advance here rather than in `componentDidUpdate`
-              }
-            }}
-            icon={icon}
-            option={getClickBehaviorOptionName(value, dashcard)}
-            hasNextStep={value !== "menu"}
-            selected={clickBehavior.type === value}
-            disabled={value === "crossfilter" && parameters.length === 0}
-          />
-        </div>
-      ))}
-    </div>
-  );
 }
 
 const ActionOption = ({ name, description, isSelected, onClick }) => {

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.jsx
@@ -19,7 +19,6 @@ import {
 } from "metabase/lib/click-behavior";
 import { keyForColumn } from "metabase/lib/dataset";
 
-import Actions from "metabase/entities/actions";
 import Dashboards from "metabase/entities/dashboards";
 import Questions from "metabase/entities/questions";
 
@@ -32,6 +31,7 @@ import ClickMappings, {
 } from "metabase/dashboard/components/ClickMappings";
 
 import { clickBehaviorOptions, getClickBehaviorOptionName } from "./utils";
+import ActionOptions from "./ActionOptions";
 import Column from "./Column";
 import CustomLinkText from "./CustomLinkText";
 import LinkOption from "./LinkOption";
@@ -347,82 +347,6 @@ class ClickBehaviorSidebar extends React.Component {
       </Sidebar>
     );
   }
-}
-
-const ActionOption = ({ name, description, isSelected, onClick }) => {
-  return (
-    <SidebarItemWrapper
-      onClick={onClick}
-      style={{
-        ...SidebarItemStyle,
-        backgroundColor: isSelected ? color("brand") : "transparent",
-        color: isSelected ? color("white") : "inherit",
-        alignItems: description ? "flex-start" : "center",
-        marginTop: "2px",
-      }}
-    >
-      <SidebarIconWrapper>
-        <Icon
-          name="bolt"
-          color={isSelected ? color("text-white") : color("brand")}
-        />
-      </SidebarIconWrapper>
-      <div>
-        <h4>{name}</h4>
-        {description && (
-          <span
-            className={isSelected ? "text-white" : "text-medium"}
-            style={{ width: "95%", marginTop: "2px" }}
-          >
-            {description}
-          </span>
-        )}
-      </div>
-    </SidebarItemWrapper>
-  );
-};
-
-function ActionOptions({ dashcard, clickBehavior, updateSettings }) {
-  return (
-    <SidebarContent>
-      <Heading className="text-medium">{t`Pick an action`}</Heading>
-      <Actions.ListLoader>
-        {({ actions }) => {
-          const selectedAction = actions.find(
-            action => action.id === clickBehavior.action,
-          );
-          return (
-            <>
-              {actions.map(action => (
-                <ActionOption
-                  key={action.id}
-                  name={action.name}
-                  description={action.description}
-                  isSelected={clickBehavior.action === action.id}
-                  onClick={() =>
-                    updateSettings({
-                      type: clickBehavior.type,
-                      action: action.id,
-                      emitter_id: clickBehavior.emitter_id,
-                    })
-                  }
-                />
-              ))}
-              {selectedAction && (
-                <ClickMappings
-                  isAction
-                  object={selectedAction}
-                  dashcard={dashcard}
-                  clickBehavior={clickBehavior}
-                  updateSettings={updateSettings}
-                />
-              )}
-            </>
-          );
-        }}
-      </Actions.ListLoader>
-    </SidebarContent>
-  );
 }
 
 function CrossfilterOptions({

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.jsx
@@ -5,28 +5,15 @@ import { getIn } from "icepick";
 import _ from "underscore";
 import cx from "classnames";
 
-import { color } from "metabase/lib/colors";
-
 import AccordionList from "metabase/core/components/AccordionList";
 import Button from "metabase/core/components/Button";
 import Icon from "metabase/components/Icon";
-import ModalWithTrigger from "metabase/components/ModalWithTrigger";
-import ModalContent from "metabase/components/ModalContent";
 import InputBlurChange from "metabase/components/InputBlurChange";
+import ModalContent from "metabase/components/ModalContent";
+import ModalWithTrigger from "metabase/components/ModalWithTrigger";
 import PopoverWithTrigger from "metabase/components/PopoverWithTrigger";
 
-import Actions from "metabase/entities/actions";
-import Dashboards from "metabase/entities/dashboards";
-import DashboardPicker from "metabase/containers/DashboardPicker";
-import Questions from "metabase/entities/questions";
-import QuestionPicker from "metabase/containers/QuestionPicker";
-import Sidebar from "metabase/dashboard/components/Sidebar";
-import ClickMappings, {
-  withUserAttributes,
-  clickTargetObjectType,
-  isMappableColumn,
-} from "metabase/dashboard/components/ClickMappings";
-
+import { color } from "metabase/lib/colors";
 import {
   hasActionsMenu,
   isTableDisplay,
@@ -34,6 +21,20 @@ import {
 } from "metabase/lib/click-behavior";
 import { getIconForField } from "metabase/lib/schema_metadata";
 import { keyForColumn } from "metabase/lib/dataset";
+
+import Actions from "metabase/entities/actions";
+import Dashboards from "metabase/entities/dashboards";
+import Questions from "metabase/entities/questions";
+
+import DashboardPicker from "metabase/containers/DashboardPicker";
+import QuestionPicker from "metabase/containers/QuestionPicker";
+
+import Sidebar from "metabase/dashboard/components/Sidebar";
+import ClickMappings, {
+  withUserAttributes,
+  clickTargetObjectType,
+  isMappableColumn,
+} from "metabase/dashboard/components/ClickMappings";
 
 import {
   SidebarItemWrapper,

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.jsx
@@ -33,6 +33,7 @@ import ClickMappings, {
 } from "metabase/dashboard/components/ClickMappings";
 
 import CustomLinkText from "./CustomLinkText";
+import LinkOption from "./LinkOption";
 import ValuesYouCanReference from "./ValuesYouCanReference";
 import {
   SidebarItemWrapper,
@@ -150,17 +151,6 @@ const BehaviorOption = ({
           <Icon name="chevronright" size={12} />
         </span>
       )}
-    </div>
-  </SidebarItemWrapper>
-);
-
-const LinkOption = ({ option, icon, onClick }) => (
-  <SidebarItemWrapper onClick={onClick} style={{ ...SidebarItemStyle }}>
-    <SidebarIconWrapper>
-      <Icon name={icon} color={color("brand")} />
-    </SidebarIconWrapper>
-    <div>
-      <h4>{option}</h4>
     </div>
   </SidebarItemWrapper>
 );

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.jsx
@@ -5,13 +5,11 @@ import { getIn } from "icepick";
 import _ from "underscore";
 import cx from "classnames";
 
-import AccordionList from "metabase/core/components/AccordionList";
 import Button from "metabase/core/components/Button";
 import Icon from "metabase/components/Icon";
 import InputBlurChange from "metabase/components/InputBlurChange";
 import ModalContent from "metabase/components/ModalContent";
 import ModalWithTrigger from "metabase/components/ModalWithTrigger";
-import PopoverWithTrigger from "metabase/components/PopoverWithTrigger";
 
 import { color } from "metabase/lib/colors";
 import {
@@ -31,11 +29,10 @@ import QuestionPicker from "metabase/containers/QuestionPicker";
 
 import Sidebar from "metabase/dashboard/components/Sidebar";
 import ClickMappings, {
-  withUserAttributes,
   clickTargetObjectType,
-  isMappableColumn,
 } from "metabase/dashboard/components/ClickMappings";
 
+import ValuesYouCanReference from "./ValuesYouCanReference";
 import {
   SidebarItemWrapper,
   SidebarItemClasses,
@@ -847,60 +844,5 @@ const CustomLinkText = ({ clickBehavior, updateSettings }) => {
     </div>
   );
 };
-
-const ValuesYouCanReference = withUserAttributes(
-  ({ dashcard, parameters, userAttributes }) => {
-    const columnMetadata = dashcard.card.result_metadata || [];
-    const columns = columnMetadata?.filter(isMappableColumn).map(c => c.name);
-    const parameterNames = parameters.map(p => p.name);
-    const sections = [
-      {
-        items: prefixIfNeeded(columns, "column", [
-          parameterNames,
-          userAttributes,
-        ]),
-        name: t`Columns`,
-      },
-      {
-        items: prefixIfNeeded(parameterNames, "filter", [
-          columns,
-          userAttributes,
-        ]),
-        name: t`Dashboard filters`,
-      },
-      {
-        items: prefixIfNeeded(userAttributes, "user", [
-          parameterNames,
-          columns,
-        ]),
-        name: t`User attributes`,
-      },
-    ].filter(section => section.items.length > 0);
-    return (
-      <PopoverWithTrigger
-        triggerElement={
-          <div className="flex align-center cursor-pointer my2 text-medium text-brand-hover">
-            <h4>{t`Values you can reference`}</h4>
-            <Icon name="chevrondown" className="ml1" size={12} />
-          </div>
-        }
-      >
-        <AccordionList
-          alwaysExpanded
-          sections={sections}
-          renderItemName={name => name}
-          itemIsClickable={() => false}
-        />
-      </PopoverWithTrigger>
-    );
-  },
-);
-
-function prefixIfNeeded(values, prefix, otherLists) {
-  const otherValues = otherLists.flat().map(s => s.toLowerCase());
-  return values.map(value =>
-    otherValues.includes(value.toLowerCase()) ? `${prefix}:${value}` : value,
-  );
-}
 
 export default ClickBehaviorSidebar;

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.jsx
@@ -2,9 +2,6 @@
 import React from "react";
 import { getIn } from "icepick";
 
-import Icon from "metabase/components/Icon";
-
-import { color } from "metabase/lib/colors";
 import {
   isTableDisplay,
   clickBehaviorIsValid,
@@ -13,20 +10,11 @@ import { keyForColumn } from "metabase/lib/dataset";
 
 import Sidebar from "metabase/dashboard/components/Sidebar";
 
-import { clickBehaviorOptions, getClickBehaviorOptionName } from "./utils";
-import ActionOptions from "./ActionOptions";
 import ClickBehaviorSidebarHeader from "./ClickBehaviorSidebarHeader";
-import CrossfilterOptions from "./CrossfilterOptions";
-import LinkOptions from "./LinkOptions";
+import ClickBehaviorSidebarMainView from "./ClickBehaviorSidebarMainView";
 import TableClickBehaviorView from "./TableClickBehaviorView";
 import TypeSelector from "./TypeSelector";
-import { SidebarItemWrapper } from "./SidebarItem";
-import {
-  CloseIconContainer,
-  SidebarContent,
-  SidebarContentBordered,
-  SidebarIconWrapper,
-} from "./ClickBehaviorSidebar.styled";
+import { SidebarContent } from "./ClickBehaviorSidebar.styled";
 
 class ClickBehaviorSidebar extends React.Component {
   state = {
@@ -194,60 +182,12 @@ class ClickBehaviorSidebar extends React.Component {
               />
             </SidebarContent>
           ) : (
-            <div>
-              <SidebarContentBordered>
-                <SidebarItemWrapper
-                  onClick={() => this.setState({ showTypeSelector: true })}
-                  style={{
-                    backgroundColor: color("brand"),
-                    color: color("white"),
-                  }}
-                >
-                  <SidebarIconWrapper
-                    style={{ borderColor: "transparent", paddingLeft: 12 }}
-                  >
-                    <Icon
-                      name={
-                        clickBehaviorOptions.find(
-                          o => o.value === clickBehavior.type,
-                        ).icon
-                      }
-                    />
-                  </SidebarIconWrapper>
-                  <div className="flex align-center full">
-                    <h4>
-                      {getClickBehaviorOptionName(clickBehavior.type, dashcard)}
-                    </h4>
-                    <CloseIconContainer>
-                      <Icon name="close" size={12} />
-                    </CloseIconContainer>
-                  </div>
-                </SidebarItemWrapper>
-              </SidebarContentBordered>
-
-              {clickBehavior.type === "link" ? (
-                <LinkOptions
-                  clickBehavior={clickBehavior}
-                  dashcard={dashcard}
-                  parameters={parameters}
-                  updateSettings={this.updateSettings}
-                />
-              ) : clickBehavior.type === "crossfilter" ? (
-                <CrossfilterOptions
-                  clickBehavior={clickBehavior}
-                  dashboard={dashboard}
-                  dashcard={dashcard}
-                  updateSettings={this.updateSettings}
-                />
-              ) : clickBehavior.type === "action" ? (
-                <ActionOptions
-                  clickBehavior={clickBehavior}
-                  dashcard={dashcard}
-                  parameters={parameters}
-                  updateSettings={this.updateSettings}
-                />
-              ) : null}
-            </div>
+            <ClickBehaviorSidebarMainView
+              clickBehavior={clickBehavior}
+              dashboard={dashboard}
+              dashcard={dashcard}
+              parameters={parameters}
+            />
           )}
         </div>
       </Sidebar>

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.jsx
@@ -3,7 +3,6 @@ import React from "react";
 import { t, jt } from "ttag";
 import { getIn } from "icepick";
 import _ from "underscore";
-import cx from "classnames";
 
 import Button from "metabase/core/components/Button";
 import Icon from "metabase/components/Icon";
@@ -19,16 +18,8 @@ import {
 } from "metabase/lib/click-behavior";
 import { keyForColumn } from "metabase/lib/dataset";
 
-import Dashboards from "metabase/entities/dashboards";
-import Questions from "metabase/entities/questions";
-
-import DashboardPicker from "metabase/containers/DashboardPicker";
-import QuestionPicker from "metabase/containers/QuestionPicker";
-
 import Sidebar from "metabase/dashboard/components/Sidebar";
-import ClickMappings, {
-  clickTargetObjectType,
-} from "metabase/dashboard/components/ClickMappings";
+import ClickMappings from "metabase/dashboard/components/ClickMappings";
 
 import { clickBehaviorOptions, getClickBehaviorOptionName } from "./utils";
 import ActionOptions from "./ActionOptions";
@@ -37,11 +28,8 @@ import CustomLinkText from "./CustomLinkText";
 import LinkOption from "./LinkOption";
 import TypeSelector from "./TypeSelector";
 import ValuesYouCanReference from "./ValuesYouCanReference";
-import {
-  SidebarItemWrapper,
-  SidebarItemClasses,
-  SidebarItemStyle,
-} from "./SidebarItem";
+import QuestionDashboardPicker from "./QuestionDashboardPicker";
+import { SidebarItemWrapper } from "./SidebarItem";
 import {
   CloseIconContainer,
   Heading,
@@ -49,7 +37,6 @@ import {
   SidebarContentBordered,
   SidebarHeader,
   SidebarIconWrapper,
-  SidebarItem,
 } from "./ClickBehaviorSidebar.styled";
 
 class ClickBehaviorSidebar extends React.Component {
@@ -494,116 +481,6 @@ function LinkOptions({ clickBehavior, updateSettings, dashcard, parameters }) {
         )}
       </div>
     </SidebarContent>
-  );
-}
-
-function QuestionDashboardPicker({ dashcard, clickBehavior, updateSettings }) {
-  const isDash = clickBehavior.linkType === "dashboard";
-  const Entity = isDash ? Dashboards : Questions;
-  const Picker = isDash ? DashboardPicker : QuestionPicker;
-  return (
-    <div>
-      <div className="pb1">
-        <ModalWithTrigger
-          triggerElement={
-            <div
-              className={cx(SidebarItemClasses, "overflow-hidden")}
-              style={{
-                marginLeft: SidebarItemStyle.marginLeft,
-                marginRight: SidebarItemStyle.marginRight,
-                backgroundColor: color("brand"),
-                color: color("white"),
-              }}
-            >
-              <SidebarItem
-                style={{
-                  paddingLeft: SidebarItemStyle.paddingLeft,
-                  paddingRight: SidebarItemStyle.paddingRight,
-                  paddingTop: SidebarItemStyle.paddingTop,
-                  paddingBottom: SidebarItemStyle.paddingBottom,
-                }}
-              >
-                <SidebarIconWrapper style={{ borderColor: "transparent" }}>
-                  <Icon name={isDash ? "dashboard" : "bar"} />
-                </SidebarIconWrapper>
-                <div className="flex align-center full text-bold">
-                  {clickBehavior.targetId == null ? (
-                    isDash ? (
-                      t`Pick a dashboard...`
-                    ) : (
-                      t`Pick a question...`
-                    )
-                  ) : (
-                    <Entity.Name id={clickBehavior.targetId} />
-                  )}
-                  <Icon name="chevrondown" size={12} className="ml-auto" />
-                </div>
-              </SidebarItem>
-              <CloseIconContainer
-                onClick={() =>
-                  updateSettings({
-                    type: clickBehavior.type,
-                    linkType: null,
-                  })
-                }
-              >
-                <Icon name="close" size={12} />
-              </CloseIconContainer>
-            </div>
-          }
-          isInitiallyOpen={clickBehavior.targetId == null}
-        >
-          {({ onClose }) => (
-            <ModalContent
-              title={
-                isDash
-                  ? t`Pick a dashboard to link to`
-                  : t`Pick a question to link to`
-              }
-              onClose={clickBehavior.targetId != null ? onClose : null}
-            >
-              <Picker
-                value={clickBehavior.targetId}
-                onChange={targetId => {
-                  updateSettings({
-                    ...clickBehavior,
-                    ...(targetId !== clickBehavior.targetId
-                      ? { parameterMapping: {} }
-                      : {}),
-                    targetId,
-                  });
-                  onClose();
-                }}
-              />
-            </ModalContent>
-          )}
-        </ModalWithTrigger>
-      </div>
-      {clickBehavior.targetId != null && (
-        <Entity.Loader id={clickBehavior.targetId}>
-          {({ object }) => (
-            <div className="pt1">
-              <Heading>
-                {
-                  {
-                    dashboard: t`Pass values to this dashboard's filters (optional)`,
-                    native: t`Pass values to this question's variables (optional)`,
-                    gui: t`Pass values to filter this question (optional)`,
-                  }[clickTargetObjectType(object)]
-                }
-              </Heading>
-              <ClickMappings
-                object={object}
-                dashcard={dashcard}
-                isDash={isDash}
-                clickBehavior={clickBehavior}
-                updateSettings={updateSettings}
-              />
-            </div>
-          )}
-        </Entity.Loader>
-      )}
-    </div>
   );
 }
 

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.jsx
@@ -1,14 +1,12 @@
 /* eslint-disable react/prop-types */
 import React from "react";
-import { t, jt } from "ttag";
+import { jt } from "ttag";
 import { getIn } from "icepick";
-import _ from "underscore";
 
 import Icon from "metabase/components/Icon";
 
 import { color } from "metabase/lib/colors";
 import {
-  hasActionsMenu,
   isTableDisplay,
   clickBehaviorIsValid,
 } from "metabase/lib/click-behavior";
@@ -18,9 +16,9 @@ import Sidebar from "metabase/dashboard/components/Sidebar";
 
 import { clickBehaviorOptions, getClickBehaviorOptionName } from "./utils";
 import ActionOptions from "./ActionOptions";
-import Column from "./Column";
 import CrossfilterOptions from "./CrossfilterOptions";
 import LinkOptions from "./LinkOptions";
+import TableClickBehaviorView from "./TableClickBehaviorView";
 import TypeSelector from "./TypeSelector";
 import { SidebarItemWrapper } from "./SidebarItem";
 import {
@@ -155,59 +153,17 @@ class ClickBehaviorSidebar extends React.Component {
 
     if (isTableDisplay(dashcard) && selectedColumn == null) {
       return (
-        <Sidebar
-          onClose={hideClickBehaviorSidebar}
+        <TableClickBehaviorView
+          columns={this.getColumns()}
+          dashcard={dashcard}
+          getClickBehaviorForColumn={column =>
+            this.getClickBehaviorForColumn(this.props, column)
+          }
+          canClose={clickBehaviorIsValid(clickBehavior)}
+          onColumnClick={this.setSelectedColumn}
           onCancel={this.handleCancel}
-          closeIsDisabled={!clickBehaviorIsValid(clickBehavior)}
-        >
-          <SidebarHeader>
-            <Heading className="text-paragraph">{t`On-click behavior for each column`}</Heading>
-          </SidebarHeader>
-          <div>
-            {_.chain(this.getColumns())
-              .map(column => ({
-                column,
-                clickBehavior: this.getClickBehaviorForColumn(
-                  this.props,
-                  column,
-                ),
-              }))
-              .groupBy(({ clickBehavior }) => {
-                const { type = "actionMenu" } = clickBehavior || {};
-                return type;
-              })
-              .pairs()
-              .sortBy(([linkType]) =>
-                ["link", "crossfilter", "actionMenu"].indexOf(linkType),
-              )
-              .map(([linkType, columnsWithClickBehavior]) => (
-                <div key={linkType} className="mb2 px4">
-                  <h5 className="text-uppercase text-medium my1">
-                    {
-                      {
-                        link: t`Go to custom destination`,
-                        crossfilter: t`Update a dashboard filter`,
-                        actionMenu: hasActionsMenu(dashcard)
-                          ? t`Open the actions menu`
-                          : t`Do nothing`,
-                      }[linkType]
-                    }
-                  </h5>
-                  {columnsWithClickBehavior.map(
-                    ({ column, clickBehavior }, index) => (
-                      <Column
-                        key={index}
-                        column={column}
-                        clickBehavior={clickBehavior}
-                        onClick={() => this.setSelectedColumn(column)}
-                      />
-                    ),
-                  )}
-                </div>
-              ))
-              .value()}
-          </div>
-        </Sidebar>
+          onClose={hideClickBehaviorSidebar}
+        />
       );
     }
 

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.styled.tsx
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { darken } from "metabase/lib/colors";
+import { color, darken } from "metabase/lib/colors";
 
 export const SidebarItem = styled.div`
   display: flex;
@@ -11,4 +11,42 @@ export const CloseIconContainer = styled.span`
   margin-left: auto;
   padding: 1rem;
   border-left: 1px solid ${darken("brand", 0.2)};
+`;
+
+export const Heading = styled.h4`
+  color: ${color("text-dark")};
+  padding-top: 22px;
+  padding-bottom: 16px;
+  margin-bottom: 8px;
+`;
+
+export const SidebarContent = styled.div`
+  padding-left: 32px;
+  padding-right: 32px;
+`;
+
+export const SidebarContentBordered = styled(SidebarContent)`
+  padding-bottom: 2rem;
+  border-bottom: 1px solid ${color("border")};
+`;
+
+export const SidebarHeader = styled.div`
+  border-bottom: 1px solid ${color("border")};
+  padding-left: 32px;
+  padding-right: 36px;
+  margin-bottom: 16px;
+`;
+
+export const SidebarIconWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-shrink: 0;
+
+  width: 36px;
+  height: 36px;
+  margin-right: 10px;
+
+  border: 1px solid #f2f2f2;
+  border-radius: 8px;
 `;

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarHeader.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarHeader.jsx
@@ -1,0 +1,49 @@
+/* eslint-disable react/prop-types */
+import React from "react";
+import { jt } from "ttag";
+
+import Icon from "metabase/components/Icon";
+
+import { Heading, SidebarHeader } from "./ClickBehaviorSidebar.styled";
+
+function ClickBehaviorSidebarHeader({
+  dashcard,
+  selectedColumn,
+  hasSelectedColumn,
+}) {
+  return (
+    <SidebarHeader>
+      {!hasSelectedColumn ? (
+        <Heading>{jt`Click behavior for ${(
+          <span className="text-brand">{dashcard.card.name}</span>
+        )}`}</Heading>
+      ) : (
+        <div
+          onClick={this.unsetSelectedColumn}
+          className="flex align-center text-brand-hover cursor-pointer"
+        >
+          <div
+            className="bordered"
+            style={{
+              marginRight: 8,
+              paddingTop: 4,
+              paddingBottom: 4,
+              paddingRight: 6,
+              paddingLeft: 6,
+              borderRadius: 4,
+            }}
+          >
+            <Icon name="chevronleft" className="text-medium" size={12} />
+          </div>
+          <Heading>
+            {jt`Click behavior for ${(
+              <span className="text-brand">{selectedColumn.display_name}</span>
+            )}`}
+          </Heading>
+        </div>
+      )}
+    </SidebarHeader>
+  );
+}
+
+export default ClickBehaviorSidebarHeader;

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarHeader.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarHeader.jsx
@@ -10,6 +10,7 @@ function ClickBehaviorSidebarHeader({
   dashcard,
   selectedColumn,
   hasSelectedColumn,
+  onUnsetColumn,
 }) {
   return (
     <SidebarHeader>
@@ -19,7 +20,7 @@ function ClickBehaviorSidebarHeader({
         )}`}</Heading>
       ) : (
         <div
-          onClick={this.unsetSelectedColumn}
+          onClick={onUnsetColumn}
           className="flex align-center text-brand-hover cursor-pointer"
         >
           <div

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarMainView.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarMainView.jsx
@@ -21,12 +21,14 @@ function ClickBehaviorSidebarMainView({
   dashboard,
   dashcard,
   parameters,
+  handleShowTypeSelector,
+  updateSettings,
 }) {
   return (
     <div>
       <SidebarContentBordered>
         <SidebarItemWrapper
-          onClick={() => this.setState({ showTypeSelector: true })}
+          onClick={handleShowTypeSelector}
           style={{
             backgroundColor: color("brand"),
             color: color("white"),
@@ -56,21 +58,21 @@ function ClickBehaviorSidebarMainView({
           clickBehavior={clickBehavior}
           dashcard={dashcard}
           parameters={parameters}
-          updateSettings={this.updateSettings}
+          updateSettings={updateSettings}
         />
       ) : clickBehavior.type === "crossfilter" ? (
         <CrossfilterOptions
           clickBehavior={clickBehavior}
           dashboard={dashboard}
           dashcard={dashcard}
-          updateSettings={this.updateSettings}
+          updateSettings={updateSettings}
         />
       ) : clickBehavior.type === "action" ? (
         <ActionOptions
           clickBehavior={clickBehavior}
           dashcard={dashcard}
           parameters={parameters}
-          updateSettings={this.updateSettings}
+          updateSettings={updateSettings}
         />
       ) : null}
     </div>

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarMainView.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarMainView.jsx
@@ -1,0 +1,80 @@
+/* eslint-disable react/prop-types */
+import React from "react";
+
+import Icon from "metabase/components/Icon";
+
+import { color } from "metabase/lib/colors";
+
+import { clickBehaviorOptions, getClickBehaviorOptionName } from "./utils";
+import ActionOptions from "./ActionOptions";
+import CrossfilterOptions from "./CrossfilterOptions";
+import LinkOptions from "./LinkOptions";
+import { SidebarItemWrapper } from "./SidebarItem";
+import {
+  CloseIconContainer,
+  SidebarContentBordered,
+  SidebarIconWrapper,
+} from "./ClickBehaviorSidebar.styled";
+
+function ClickBehaviorSidebarMainView({
+  clickBehavior,
+  dashboard,
+  dashcard,
+  parameters,
+}) {
+  return (
+    <div>
+      <SidebarContentBordered>
+        <SidebarItemWrapper
+          onClick={() => this.setState({ showTypeSelector: true })}
+          style={{
+            backgroundColor: color("brand"),
+            color: color("white"),
+          }}
+        >
+          <SidebarIconWrapper
+            style={{ borderColor: "transparent", paddingLeft: 12 }}
+          >
+            <Icon
+              name={
+                clickBehaviorOptions.find(o => o.value === clickBehavior.type)
+                  .icon
+              }
+            />
+          </SidebarIconWrapper>
+          <div className="flex align-center full">
+            <h4>{getClickBehaviorOptionName(clickBehavior.type, dashcard)}</h4>
+            <CloseIconContainer>
+              <Icon name="close" size={12} />
+            </CloseIconContainer>
+          </div>
+        </SidebarItemWrapper>
+      </SidebarContentBordered>
+
+      {clickBehavior.type === "link" ? (
+        <LinkOptions
+          clickBehavior={clickBehavior}
+          dashcard={dashcard}
+          parameters={parameters}
+          updateSettings={this.updateSettings}
+        />
+      ) : clickBehavior.type === "crossfilter" ? (
+        <CrossfilterOptions
+          clickBehavior={clickBehavior}
+          dashboard={dashboard}
+          dashcard={dashcard}
+          updateSettings={this.updateSettings}
+        />
+      ) : clickBehavior.type === "action" ? (
+        <ActionOptions
+          clickBehavior={clickBehavior}
+          dashcard={dashcard}
+          parameters={parameters}
+          updateSettings={this.updateSettings}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+export default ClickBehaviorSidebarMainView;

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/Column.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/Column.jsx
@@ -1,0 +1,63 @@
+/* eslint-disable react/prop-types */
+import React from "react";
+import { t, jt, ngettext, msgid } from "ttag";
+import _ from "underscore";
+
+import Icon from "metabase/components/Icon";
+
+import { color } from "metabase/lib/colors";
+import { getIconForField } from "metabase/lib/schema_metadata";
+
+import Dashboards from "metabase/entities/dashboards";
+import Questions from "metabase/entities/questions";
+
+import { SidebarItemWrapper, SidebarItemStyle } from "./SidebarItem";
+import { SidebarIconWrapper } from "./ClickBehaviorSidebar.styled";
+
+const LinkTargetName = ({ clickBehavior: { linkType, targetId } }) => (
+  <span>
+    {linkType === "url" ? (
+      t`URL`
+    ) : linkType === "question" ? (
+      <span>
+        {'"'}
+        <Questions.Name id={targetId} />
+        {'"'}
+      </span>
+    ) : linkType === "dashboard" ? (
+      <span>
+        {'"'}
+        <Dashboards.Name id={targetId} />
+        {'"'}
+      </span>
+    ) : (
+      "Unknown"
+    )}
+  </span>
+);
+
+const Column = ({ column, clickBehavior, onClick }) => (
+  <SidebarItemWrapper onClick={onClick} style={{ ...SidebarItemStyle }}>
+    <SidebarIconWrapper>
+      <Icon name={getIconForField(column)} color={color("brand")} size={18} />
+    </SidebarIconWrapper>
+    <div>
+      <h4>
+        {clickBehavior && clickBehavior.type === "crossfilter"
+          ? (n =>
+              ngettext(
+                msgid`${column.display_name} updates ${n} filter`,
+                `${column.display_name} updates ${n} filters`,
+                n,
+              ))(Object.keys(clickBehavior.parameterMapping || {}).length)
+          : clickBehavior && clickBehavior.type === "link"
+          ? jt`${column.display_name} goes to ${(
+              <LinkTargetName clickBehavior={clickBehavior} />
+            )}`
+          : column.display_name}
+      </h4>
+    </div>
+  </SidebarItemWrapper>
+);
+
+export default Column;

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/CrossfilterOptions.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/CrossfilterOptions.jsx
@@ -1,0 +1,30 @@
+/* eslint-disable react/prop-types */
+import React from "react";
+import { t } from "ttag";
+
+import ClickMappings from "metabase/dashboard/components/ClickMappings";
+
+import { Heading, SidebarContent } from "./ClickBehaviorSidebar.styled";
+
+function CrossfilterOptions({
+  clickBehavior,
+  dashboard,
+  dashcard,
+  updateSettings,
+}) {
+  return (
+    <SidebarContent>
+      <Heading className="text-medium">{t`Pick one or more filters to update`}</Heading>
+      <ClickMappings
+        object={dashboard}
+        dashcard={dashcard}
+        isDash
+        clickBehavior={clickBehavior}
+        updateSettings={updateSettings}
+        excludeParametersSources
+      />
+    </SidebarContent>
+  );
+}
+
+export default CrossfilterOptions;

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/CustomLinkText.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/CustomLinkText.jsx
@@ -1,0 +1,29 @@
+/* eslint-disable react/prop-types */
+import React from "react";
+import { t } from "ttag";
+import _ from "underscore";
+
+import InputBlurChange from "metabase/components/InputBlurChange";
+
+import { Heading } from "./ClickBehaviorSidebar.styled";
+
+const CustomLinkText = ({ clickBehavior, updateSettings }) => {
+  return (
+    <div className="mt2 mb1">
+      <Heading>{t`Customize link text (optional)`}</Heading>
+      <InputBlurChange
+        className="input block full"
+        placeholder={t`E.x. Details for {{Column Name}}`}
+        value={clickBehavior.linkTextTemplate}
+        onBlurChange={e =>
+          updateSettings({
+            ...clickBehavior,
+            linkTextTemplate: e.target.value,
+          })
+        }
+      />
+    </div>
+  );
+};
+
+export default CustomLinkText;

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOption.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOption.jsx
@@ -1,0 +1,23 @@
+/* eslint-disable react/prop-types */
+import React from "react";
+import _ from "underscore";
+
+import Icon from "metabase/components/Icon";
+
+import { color } from "metabase/lib/colors";
+
+import { SidebarItemWrapper, SidebarItemStyle } from "./SidebarItem";
+import { SidebarIconWrapper } from "./ClickBehaviorSidebar.styled";
+
+const LinkOption = ({ option, icon, onClick }) => (
+  <SidebarItemWrapper onClick={onClick} style={{ ...SidebarItemStyle }}>
+    <SidebarIconWrapper>
+      <Icon name={icon} color={color("brand")} />
+    </SidebarIconWrapper>
+    <div>
+      <h4>{option}</h4>
+    </div>
+  </SidebarItemWrapper>
+);
+
+export default LinkOption;

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions.jsx
@@ -1,0 +1,156 @@
+/* eslint-disable react/prop-types */
+import React from "react";
+import { t } from "ttag";
+import _ from "underscore";
+
+import Button from "metabase/core/components/Button";
+import Icon from "metabase/components/Icon";
+import InputBlurChange from "metabase/components/InputBlurChange";
+import ModalContent from "metabase/components/ModalContent";
+import ModalWithTrigger from "metabase/components/ModalWithTrigger";
+
+import { color } from "metabase/lib/colors";
+import {
+  isTableDisplay,
+  clickBehaviorIsValid,
+} from "metabase/lib/click-behavior";
+
+import CustomLinkText from "./CustomLinkText";
+import LinkOption from "./LinkOption";
+import ValuesYouCanReference from "./ValuesYouCanReference";
+import QuestionDashboardPicker from "./QuestionDashboardPicker";
+import { SidebarItemWrapper } from "./SidebarItem";
+import {
+  CloseIconContainer,
+  SidebarContent,
+  SidebarIconWrapper,
+} from "./ClickBehaviorSidebar.styled";
+
+function LinkOptions({ clickBehavior, updateSettings, dashcard, parameters }) {
+  const linkTypeOptions = [
+    { type: "dashboard", icon: "dashboard", name: t`Dashboard` },
+    { type: "question", icon: "bar", name: t`Saved question` },
+    { type: "url", icon: "link", name: t`URL` },
+  ];
+
+  return (
+    <SidebarContent>
+      <p className="text-medium mt3 mb1">{t`Link to`}</p>
+      <div>
+        {clickBehavior.linkType == null ? (
+          linkTypeOptions.map(({ type, icon, name }, index) => (
+            <LinkOption
+              key={name}
+              option={name}
+              icon={icon}
+              onClick={() =>
+                updateSettings({ type: clickBehavior.type, linkType: type })
+              }
+            />
+          ))
+        ) : clickBehavior.linkType === "url" ? (
+          <ModalWithTrigger
+            isInitiallyOpen={clickBehavior.linkTemplate == null}
+            triggerElement={
+              <SidebarItemWrapper
+                style={{
+                  backgroundColor: color("brand"),
+                  color: color("white"),
+                }}
+              >
+                <SidebarIconWrapper
+                  style={{ borderColor: "transparent", marginLeft: 8 }}
+                >
+                  <Icon name="link" />
+                </SidebarIconWrapper>
+                <div className="flex align-center full">
+                  <h4 className="pr1">
+                    {clickBehavior.linkTemplate
+                      ? clickBehavior.linkTemplate
+                      : t`URL`}
+                  </h4>
+                  <CloseIconContainer
+                    onClick={() =>
+                      updateSettings({
+                        type: clickBehavior.type,
+                        linkType: null,
+                      })
+                    }
+                  >
+                    <Icon name="close" size={12} />
+                  </CloseIconContainer>
+                </div>
+              </SidebarItemWrapper>
+            }
+          >
+            {({ onClose }) => (
+              <ModalContent
+                title={t`Enter a URL to link to`}
+                onClose={clickBehavior.targetId != null ? onClose : null}
+              >
+                <div className="mb1">{t`You can insert the value of a column or dashboard filter using its name, like this: {{some_column}}`}</div>
+                <InputBlurChange
+                  autoFocus
+                  className="input block full"
+                  placeholder={t`e.g. http://acme.com/id/\{\{user_id\}\}`}
+                  value={clickBehavior.linkTemplate}
+                  onChange={e =>
+                    updateSettings({
+                      ...clickBehavior,
+                      linkTemplate: e.target.value,
+                    })
+                  }
+                />
+                {isTableDisplay(dashcard) && (
+                  <CustomLinkText
+                    updateSettings={updateSettings}
+                    clickBehavior={clickBehavior}
+                  />
+                )}
+                <ValuesYouCanReference
+                  dashcard={dashcard}
+                  parameters={parameters}
+                />
+                <div className="flex">
+                  <Button
+                    primary
+                    onClick={() => onClose()}
+                    className="ml-auto mt2"
+                    disabled={!clickBehaviorIsValid(clickBehavior)}
+                  >{t`Done`}</Button>
+                </div>
+              </ModalContent>
+            )}
+          </ModalWithTrigger>
+        ) : (
+          <div></div>
+        )}
+      </div>
+      <div className="mt1">
+        {clickBehavior.linkType != null && clickBehavior.linkType !== "url" && (
+          <div>
+            <QuestionDashboardPicker
+              dashcard={dashcard}
+              clickBehavior={clickBehavior}
+              updateSettings={updateSettings}
+            />
+            {isTableDisplay(dashcard) && (
+              <div>
+                <CustomLinkText
+                  updateSettings={updateSettings}
+                  clickBehavior={clickBehavior}
+                />
+                <ValuesYouCanReference
+                  dashcard={dashcard}
+                  parameters={parameters}
+                />
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </SidebarContent>
+  );
+}
+
+export default LinkOptions;

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/QuestionDashboardPicker.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/QuestionDashboardPicker.jsx
@@ -1,0 +1,141 @@
+/* eslint-disable react/prop-types */
+import React from "react";
+import { t } from "ttag";
+import _ from "underscore";
+import cx from "classnames";
+
+import Icon from "metabase/components/Icon";
+import ModalContent from "metabase/components/ModalContent";
+import ModalWithTrigger from "metabase/components/ModalWithTrigger";
+
+import { color } from "metabase/lib/colors";
+
+import Dashboards from "metabase/entities/dashboards";
+import Questions from "metabase/entities/questions";
+
+import DashboardPicker from "metabase/containers/DashboardPicker";
+import QuestionPicker from "metabase/containers/QuestionPicker";
+
+import ClickMappings, {
+  clickTargetObjectType,
+} from "metabase/dashboard/components/ClickMappings";
+
+import { SidebarItemClasses, SidebarItemStyle } from "./SidebarItem";
+import {
+  CloseIconContainer,
+  Heading,
+  SidebarIconWrapper,
+  SidebarItem,
+} from "./ClickBehaviorSidebar.styled";
+
+function QuestionDashboardPicker({ dashcard, clickBehavior, updateSettings }) {
+  const isDash = clickBehavior.linkType === "dashboard";
+  const Entity = isDash ? Dashboards : Questions;
+  const Picker = isDash ? DashboardPicker : QuestionPicker;
+  return (
+    <div>
+      <div className="pb1">
+        <ModalWithTrigger
+          triggerElement={
+            <div
+              className={cx(SidebarItemClasses, "overflow-hidden")}
+              style={{
+                marginLeft: SidebarItemStyle.marginLeft,
+                marginRight: SidebarItemStyle.marginRight,
+                backgroundColor: color("brand"),
+                color: color("white"),
+              }}
+            >
+              <SidebarItem
+                style={{
+                  paddingLeft: SidebarItemStyle.paddingLeft,
+                  paddingRight: SidebarItemStyle.paddingRight,
+                  paddingTop: SidebarItemStyle.paddingTop,
+                  paddingBottom: SidebarItemStyle.paddingBottom,
+                }}
+              >
+                <SidebarIconWrapper style={{ borderColor: "transparent" }}>
+                  <Icon name={isDash ? "dashboard" : "bar"} />
+                </SidebarIconWrapper>
+                <div className="flex align-center full text-bold">
+                  {clickBehavior.targetId == null ? (
+                    isDash ? (
+                      t`Pick a dashboard...`
+                    ) : (
+                      t`Pick a question...`
+                    )
+                  ) : (
+                    <Entity.Name id={clickBehavior.targetId} />
+                  )}
+                  <Icon name="chevrondown" size={12} className="ml-auto" />
+                </div>
+              </SidebarItem>
+              <CloseIconContainer
+                onClick={() =>
+                  updateSettings({
+                    type: clickBehavior.type,
+                    linkType: null,
+                  })
+                }
+              >
+                <Icon name="close" size={12} />
+              </CloseIconContainer>
+            </div>
+          }
+          isInitiallyOpen={clickBehavior.targetId == null}
+        >
+          {({ onClose }) => (
+            <ModalContent
+              title={
+                isDash
+                  ? t`Pick a dashboard to link to`
+                  : t`Pick a question to link to`
+              }
+              onClose={clickBehavior.targetId != null ? onClose : null}
+            >
+              <Picker
+                value={clickBehavior.targetId}
+                onChange={targetId => {
+                  updateSettings({
+                    ...clickBehavior,
+                    ...(targetId !== clickBehavior.targetId
+                      ? { parameterMapping: {} }
+                      : {}),
+                    targetId,
+                  });
+                  onClose();
+                }}
+              />
+            </ModalContent>
+          )}
+        </ModalWithTrigger>
+      </div>
+      {clickBehavior.targetId != null && (
+        <Entity.Loader id={clickBehavior.targetId}>
+          {({ object }) => (
+            <div className="pt1">
+              <Heading>
+                {
+                  {
+                    dashboard: t`Pass values to this dashboard's filters (optional)`,
+                    native: t`Pass values to this question's variables (optional)`,
+                    gui: t`Pass values to filter this question (optional)`,
+                  }[clickTargetObjectType(object)]
+                }
+              </Heading>
+              <ClickMappings
+                object={object}
+                dashcard={dashcard}
+                isDash={isDash}
+                clickBehavior={clickBehavior}
+                updateSettings={updateSettings}
+              />
+            </div>
+          )}
+        </Entity.Loader>
+      )}
+    </div>
+  );
+}
+
+export default QuestionDashboardPicker;

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/SidebarItem.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/SidebarItem.jsx
@@ -1,0 +1,25 @@
+/* eslint-disable react/prop-types */
+import React from "react";
+import cx from "classnames";
+
+export const SidebarItemClasses =
+  "border-brand-hover bordered border-transparent rounded flex align-center cursor-pointer overflow-hidden";
+
+export const SidebarItemStyle = {
+  paddingTop: 8,
+  paddingBottom: 8,
+  paddingLeft: 12,
+  paddingRight: 12,
+};
+
+export const SidebarItemWrapper = ({ children, onClick, style, disabled }) => (
+  <div
+    className={cx(SidebarItemClasses, { disabled })}
+    onClick={!disabled && onClick}
+    style={{
+      ...style,
+    }}
+  >
+    {children}
+  </div>
+);

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/TableClickBehaviorView.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/TableClickBehaviorView.jsx
@@ -1,0 +1,72 @@
+/* eslint-disable react/prop-types */
+import React from "react";
+import { t } from "ttag";
+import _ from "underscore";
+
+import { hasActionsMenu } from "metabase/lib/click-behavior";
+
+import Sidebar from "metabase/dashboard/components/Sidebar";
+
+import Column from "./Column";
+import { Heading, SidebarHeader } from "./ClickBehaviorSidebar.styled";
+
+function TableClickBehaviorView({
+  columns,
+  dashcard,
+  getClickBehaviorForColumn,
+  canClose,
+  onColumnClick,
+  onCancel,
+  onClose,
+}) {
+  return (
+    <Sidebar onClose={onClose} onCancel={onCancel} closeIsDisabled={!canClose}>
+      <SidebarHeader>
+        <Heading className="text-paragraph">{t`On-click behavior for each column`}</Heading>
+      </SidebarHeader>
+      <div>
+        {_.chain(columns)
+          .map(column => ({
+            column,
+            clickBehavior: getClickBehaviorForColumn(column),
+          }))
+          .groupBy(({ clickBehavior }) => {
+            const { type = "actionMenu" } = clickBehavior || {};
+            return type;
+          })
+          .pairs()
+          .sortBy(([linkType]) =>
+            ["link", "crossfilter", "actionMenu"].indexOf(linkType),
+          )
+          .map(([linkType, columnsWithClickBehavior]) => (
+            <div key={linkType} className="mb2 px4">
+              <h5 className="text-uppercase text-medium my1">
+                {
+                  {
+                    link: t`Go to custom destination`,
+                    crossfilter: t`Update a dashboard filter`,
+                    actionMenu: hasActionsMenu(dashcard)
+                      ? t`Open the actions menu`
+                      : t`Do nothing`,
+                  }[linkType]
+                }
+              </h5>
+              {columnsWithClickBehavior.map(
+                ({ column, clickBehavior }, index) => (
+                  <Column
+                    key={index}
+                    column={column}
+                    clickBehavior={clickBehavior}
+                    onClick={() => onColumnClick(column)}
+                  />
+                ),
+              )}
+            </div>
+          ))
+          .value()}
+      </div>
+    </Sidebar>
+  );
+}
+
+export default TableClickBehaviorView;

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/TypeSelector.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/TypeSelector.jsx
@@ -1,0 +1,78 @@
+/* eslint-disable react/prop-types */
+import React from "react";
+import _ from "underscore";
+
+import Icon from "metabase/components/Icon";
+
+import { color } from "metabase/lib/colors";
+
+import { clickBehaviorOptions, getClickBehaviorOptionName } from "./utils";
+import { SidebarItemWrapper, SidebarItemStyle } from "./SidebarItem";
+import { SidebarIconWrapper } from "./ClickBehaviorSidebar.styled";
+
+const BehaviorOption = ({
+  option,
+  icon,
+  onClick,
+  hasNextStep,
+  selected,
+  disabled,
+}) => (
+  <SidebarItemWrapper
+    style={{
+      ...SidebarItemStyle,
+      backgroundColor: selected ? color("brand") : "transparent",
+      color: selected ? color("white") : "inherit",
+    }}
+    onClick={onClick}
+    disabled={disabled}
+  >
+    <SidebarIconWrapper style={{ borderColor: selected && "transparent" }}>
+      <Icon
+        name={selected ? "check" : icon}
+        color={selected ? color("white") : color("brand")}
+      />
+    </SidebarIconWrapper>
+    <div className="flex align-center full">
+      <h4>{option}</h4>
+      {hasNextStep && (
+        <span className="ml-auto">
+          <Icon name="chevronright" size={12} />
+        </span>
+      )}
+    </div>
+  </SidebarItemWrapper>
+);
+
+function TypeSelector({
+  updateSettings,
+  clickBehavior,
+  dashcard,
+  parameters,
+  moveToNextPage,
+}) {
+  return (
+    <div>
+      {clickBehaviorOptions.map(({ value, icon }) => (
+        <div key={value} className="mb1">
+          <BehaviorOption
+            onClick={() => {
+              if (value !== clickBehavior.type) {
+                updateSettings(value === "menu" ? undefined : { type: value });
+              } else if (value !== "menu") {
+                moveToNextPage(); // if it didn't change, we need to advance here rather than in `componentDidUpdate`
+              }
+            }}
+            icon={icon}
+            option={getClickBehaviorOptionName(value, dashcard)}
+            hasNextStep={value !== "menu"}
+            selected={clickBehavior.type === value}
+            disabled={value === "crossfilter" && parameters.length === 0}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default TypeSelector;

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ValuesYouCanReference.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ValuesYouCanReference.jsx
@@ -1,0 +1,70 @@
+/* eslint-disable react/prop-types */
+import React from "react";
+import { t } from "ttag";
+import _ from "underscore";
+
+import AccordionList from "metabase/core/components/AccordionList";
+import Icon from "metabase/components/Icon";
+import PopoverWithTrigger from "metabase/components/PopoverWithTrigger";
+
+import {
+  withUserAttributes,
+  isMappableColumn,
+} from "metabase/dashboard/components/ClickMappings";
+
+function prefixIfNeeded(values, prefix, otherLists) {
+  const otherValues = otherLists.flat().map(s => s.toLowerCase());
+  return values.map(value =>
+    otherValues.includes(value.toLowerCase()) ? `${prefix}:${value}` : value,
+  );
+}
+
+const ValuesYouCanReference = withUserAttributes(
+  ({ dashcard, parameters, userAttributes }) => {
+    const columnMetadata = dashcard.card.result_metadata || [];
+    const columns = columnMetadata?.filter(isMappableColumn).map(c => c.name);
+    const parameterNames = parameters.map(p => p.name);
+    const sections = [
+      {
+        items: prefixIfNeeded(columns, "column", [
+          parameterNames,
+          userAttributes,
+        ]),
+        name: t`Columns`,
+      },
+      {
+        items: prefixIfNeeded(parameterNames, "filter", [
+          columns,
+          userAttributes,
+        ]),
+        name: t`Dashboard filters`,
+      },
+      {
+        items: prefixIfNeeded(userAttributes, "user", [
+          parameterNames,
+          columns,
+        ]),
+        name: t`User attributes`,
+      },
+    ].filter(section => section.items.length > 0);
+    return (
+      <PopoverWithTrigger
+        triggerElement={
+          <div className="flex align-center cursor-pointer my2 text-medium text-brand-hover">
+            <h4>{t`Values you can reference`}</h4>
+            <Icon name="chevrondown" className="ml1" size={12} />
+          </div>
+        }
+      >
+        <AccordionList
+          alwaysExpanded
+          sections={sections}
+          renderItemName={name => name}
+          itemIsClickable={() => false}
+        />
+      </PopoverWithTrigger>
+    );
+  },
+);
+
+export default ValuesYouCanReference;

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/utils.js
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/utils.js
@@ -1,0 +1,27 @@
+import { t } from "ttag";
+import { hasActionsMenu } from "metabase/lib/click-behavior";
+
+export const clickBehaviorOptions = [
+  { value: "menu", icon: "popover" },
+  { value: "link", icon: "link" },
+  { value: "crossfilter", icon: "filter" },
+  { value: "action", icon: "play" },
+];
+
+export function getClickBehaviorOptionName(value, dashcard) {
+  if (value === "menu") {
+    return hasActionsMenu(dashcard)
+      ? t`Open the Metabase actions menu`
+      : t`Do nothing`;
+  }
+  if (value === "link") {
+    return t`Go to a custom destination`;
+  }
+  if (value === "crossfilter") {
+    return t`Update a dashboard filter`;
+  }
+  if (value === "action") {
+    return t`Perform action`;
+  }
+  return t`Unknown`;
+}


### PR DESCRIPTION
Part of #25091

This PR breaks down `ClickBehaviorSidebar` into a few components and extracts some reusable bits:

* the file contains components for every possible sidebar state. It grew up big enough to make it difficult to reason about
* styles for reusable components are primarily hardcoded, so we're also extract those