### PR TITLE
add find-replace search box to the native query editor

### DIFF
--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
@@ -4,6 +4,7 @@ import React, { Component } from "react";
 import cx from "classnames";
 import "ace/ace";
 import "ace/ext-language_tools";
+import "ace/ext-searchbox";
 import "ace/mode-sql";
 import "ace/mode-mysql";
 import "ace/mode-pgsql";
@@ -15,7 +16,6 @@ import "ace/snippets/mysql";
 import "ace/snippets/pgsql";
 import "ace/snippets/sqlserver";
 import "ace/snippets/json";
-import "ace/ext-searchbox";
 import _ from "underscore";
 import { ResizableBox } from "react-resizable";
 

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
@@ -15,6 +15,7 @@ import "ace/snippets/mysql";
 import "ace/snippets/pgsql";
 import "ace/snippets/sqlserver";
 import "ace/snippets/json";
+import "ace/ext-searchbox";
 import _ from "underscore";
 import { ResizableBox } from "react-resizable";
 

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor.styled.tsx
@@ -8,6 +8,35 @@ export const NativeQueryEditorRoot = styled.div`
     color: ${color("text-dark")};
   }
 
+  .ace_search {
+    font-family: Lato;
+    background-color: ${color("bg-light")};
+    color: ${color("text-dark")};
+    border-color: ${color("border")};
+    padding-bottom: 2px;
+  }
+
+  .ace_search_field,
+  .ace_searchbtn,
+  .ace_button {
+    background-color: ${color("white")};
+    border-radius: 5px;
+    border: 1px solid ${color("border")};
+  }
+
+  .ace_nomatch {
+    border-radius: 5px;
+    outline: 1px solid ${color("error")};
+  }
+
+  .ace_searchbtn {
+    margin-left: 2px;
+  }
+
+  .ace_button {
+    padding: 2px 4px;
+  }
+
   .ace_editor .ace_keyword {
     color: ${color("saturated-purple")};
   }

--- a/frontend/test/__mocks__/aceSearchBoxExtMock.js
+++ b/frontend/test/__mocks__/aceSearchBoxExtMock.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/jest.unit.conf.json
+++ b/jest.unit.conf.json
@@ -2,10 +2,16 @@
   "moduleNameMapper": {
     "\\.(css|less)$": "<rootDir>/frontend/test/__mocks__/styleMock.js",
     "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/frontend/test/__mocks__/fileMock.js",
-    "^promise-loader\\?global\\!metabase\\/lib\\/ga-metadata$": "<rootDir>/frontend/src/metabase/lib/ga-metadata.js"
+    "^promise-loader\\?global\\!metabase\\/lib\\/ga-metadata$": "<rootDir>/frontend/src/metabase/lib/ga-metadata.js",
+    "ace/ext-searchbox": "<rootDir>/frontend/test/__mocks__/aceSearchBoxExtMock.js"
   },
-  "testPathIgnorePatterns": ["<rootDir>/frontend/test/.*/.*.tz.unit.spec.{js,jsx,ts,tsx}"],
-  "testMatch": ["<rootDir>/**/*.unit.spec.js", "<rootDir>/**/*.unit.spec.{js,jsx,ts,tsx}"],
+  "testPathIgnorePatterns": [
+    "<rootDir>/frontend/test/.*/.*.tz.unit.spec.{js,jsx,ts,tsx}"
+  ],
+  "testMatch": [
+    "<rootDir>/**/*.unit.spec.js",
+    "<rootDir>/**/*.unit.spec.{js,jsx,ts,tsx}"
+  ],
   "modulePaths": [
     "<rootDir>/frontend/test",
     "<rootDir>/frontend/src",


### PR DESCRIPTION
An ad-hoc change: enable find-replace search box in the native query editor. Here is a [slack discussion](https://metaboat.slack.com/archives/C01LQQ2UW03/p1661864689931459).


## How to verify
- Create a native quesion
- Press ctrl+f or cmd+f
- Try search, replace, etc

<img width="1728" alt="Screen Shot 2022-08-30 at 5 06 45 PM" src="https://user-images.githubusercontent.com/14301985/187444520-ffcc251b-2dd3-486f-8645-c1bcc704613a.png">
