### PR TITLE
Fix `is_app_page` prop usage

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard.jsx
@@ -238,7 +238,7 @@ export default class DashCard extends Component {
           headerIcon={headerIcon}
           errorIcon={errorIcon}
           isSlow={isSlow}
-          isDataApp={dashboard.is_data_app}
+          isDataApp={dashboard.is_app_page}
           expectedDuration={expectedDuration}
           rawSeries={series}
           showTitle={!dashboard.is_app_page}


### PR DESCRIPTION
Just messed up the naming. I miss TypeScript coverage here 😢 