### PR TITLE
Use the `Questions` entity to fetch cards/questions for the query builder

### DIFF
--- a/frontend/src/metabase/containers/SavedQuestionLoader.jsx
+++ b/frontend/src/metabase/containers/SavedQuestionLoader.jsx
@@ -90,8 +90,7 @@ export class SavedQuestionLoader extends React.Component {
     try {
       this.setState({ loading: true, error: null });
       // get the saved question via the card API
-      const action = await this.propsfetchQuestion({ id: questionId });
-      const card = Questions.HACK_getObjectFromAction(action);
+      const card = await this.props.fetchQuestion(questionId);
 
       // pass the retrieved card to load any necessary metadata
       // (tables, source db, segments, etc) into
@@ -129,9 +128,14 @@ function mapStateToProps(state) {
   };
 }
 
-const mapDispatchToProps = {
-  loadMetadataForCard,
-  fetchQuestion: Questions.actions.fetch,
+const mapDispatchToProps = dispatch => {
+  return {
+    loadMetadataForCard: card => dispatch(loadMetadataForCard(card)),
+    fetchQuestion: async id => {
+      const action = await dispatch(Questions.actions.fetch({ id }));
+      return Questions.HACK_getObjectFromAction(action);
+    },
+  };
 };
 
 export default connect(

--- a/frontend/src/metabase/containers/SavedQuestionLoader.jsx
+++ b/frontend/src/metabase/containers/SavedQuestionLoader.jsx
@@ -2,12 +2,11 @@
 import React from "react";
 import { connect } from "react-redux";
 
-// things that will eventually load the quetsion
-import { CardApi } from "metabase/services";
 import { loadMetadataForCard } from "metabase/query_builder/actions";
 import { getMetadata } from "metabase/selectors/metadata";
 
 import Question from "metabase-lib/lib/Question";
+import Questions from "metabase/entities/questions";
 
 // type annotations
 
@@ -91,7 +90,8 @@ export class SavedQuestionLoader extends React.Component {
     try {
       this.setState({ loading: true, error: null });
       // get the saved question via the card API
-      const card = await CardApi.get({ cardId: questionId });
+      const action = await this.propsfetchQuestion({ id: questionId });
+      const card = Questions.HACK_getObjectFromAction(action);
 
       // pass the retrieved card to load any necessary metadata
       // (tables, source db, segments, etc) into
@@ -131,6 +131,7 @@ function mapStateToProps(state) {
 
 const mapDispatchToProps = {
   loadMetadataForCard,
+  fetchQuestion: Questions.actions.fetch,
 };
 
 export default connect(

--- a/frontend/src/metabase/lib/card.js
+++ b/frontend/src/metabase/lib/card.js
@@ -2,8 +2,8 @@ import _ from "underscore";
 import * as Q_DEPRECATED from "metabase/lib/query";
 import Utils from "metabase/lib/utils";
 
-import { CardApi } from "metabase/services";
 import { b64hash_to_utf8, utf8_to_b64url } from "metabase/lib/encoding";
+import Questions from "metabase/entities/questions";
 
 export function createCard(name = null) {
   return {
@@ -25,9 +25,13 @@ export function startNewCard(type, databaseId, tableId) {
 
 // load a card either by ID or from a base64 serialization.  if both are present then they are merged, which the serialized version taking precedence
 // TODO: move to redux
-export async function loadCard(cardId) {
+export async function loadCard(cardId, dispatch) {
   try {
-    return await CardApi.get({ cardId: cardId });
+    const action = await dispatch(
+      Questions.actions.fetch({ id: cardId }, { reload: true }),
+    );
+    const card = Questions.HACK_getObjectFromAction(action);
+    return card;
   } catch (error) {
     console.log("error loading card", error);
     throw error;

--- a/frontend/src/metabase/lib/card.js
+++ b/frontend/src/metabase/lib/card.js
@@ -25,12 +25,12 @@ export function startNewCard(type, databaseId, tableId) {
 
 // load a card either by ID or from a base64 serialization.  if both are present then they are merged, which the serialized version taking precedence
 // TODO: move to redux
-export async function loadCard(cardId, dispatch) {
+export async function loadCard(cardId, { dispatch, getState }) {
   try {
-    const action = await dispatch(
-      Questions.actions.fetch({ id: cardId }, { reload: true }),
-    );
-    const card = Questions.HACK_getObjectFromAction(action);
+    await dispatch(Questions.actions.fetch({ id: cardId }, { reload: true }));
+    const card = Questions.selectors.getObject(getState(), {
+      entityId: cardId,
+    });
     return card;
   } catch (error) {
     console.log("error loading card", error);

--- a/frontend/src/metabase/query_builder/actions/core/core.js
+++ b/frontend/src/metabase/query_builder/actions/core/core.js
@@ -96,7 +96,7 @@ export const setCardAndRun = (nextCard, shouldUpdateUrl = true) => {
 
     const originalCard = card.original_card_id
       ? // If the original card id is present, dynamically load its information for showing lineage
-        await loadCard(card.original_card_id, dispatch)
+        await loadCard(card.original_card_id, { dispatch, getState })
       : // Otherwise, use a current card as the original card if the card has been saved
       // This is needed for checking whether the card is in dirty state or not
       card.id
@@ -131,7 +131,9 @@ export const navigateToNewCardInsideQB = createThunkAction(
         // Do not reload questions with breakouts when clicked on a legend item
       } else if (cardIsEquivalent(previousCard, nextCard)) {
         // This is mainly a fallback for scenarios where a visualization legend is clicked inside QB
-        dispatch(setCardAndRun(await loadCard(nextCard.id, dispatch)));
+        dispatch(
+          setCardAndRun(await loadCard(nextCard.id, { dispatch, getState })),
+        );
       } else {
         const card = getCardAfterVisualizationClick(nextCard, previousCard);
         const url = Urls.serializedQuestion(card);

--- a/frontend/src/metabase/query_builder/actions/core/core.js
+++ b/frontend/src/metabase/query_builder/actions/core/core.js
@@ -96,7 +96,7 @@ export const setCardAndRun = (nextCard, shouldUpdateUrl = true) => {
 
     const originalCard = card.original_card_id
       ? // If the original card id is present, dynamically load its information for showing lineage
-        await loadCard(card.original_card_id)
+        await loadCard(card.original_card_id, dispatch)
       : // Otherwise, use a current card as the original card if the card has been saved
       // This is needed for checking whether the card is in dirty state or not
       card.id
@@ -131,7 +131,7 @@ export const navigateToNewCardInsideQB = createThunkAction(
         // Do not reload questions with breakouts when clicked on a legend item
       } else if (cardIsEquivalent(previousCard, nextCard)) {
         // This is mainly a fallback for scenarios where a visualization legend is clicked inside QB
-        dispatch(setCardAndRun(await loadCard(nextCard.id)));
+        dispatch(setCardAndRun(await loadCard(nextCard.id, dispatch)));
       } else {
         const card = getCardAfterVisualizationClick(nextCard, previousCard);
         const url = Urls.serializedQuestion(card);

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
@@ -14,6 +14,7 @@ import { getMetadata } from "metabase/selectors/metadata";
 import { getUser } from "metabase/selectors/user";
 
 import Snippets from "metabase/entities/snippets";
+import Questions from "metabase/entities/questions";
 import { fetchAlertsForQuestion } from "metabase/alert/alert";
 
 import Question from "metabase-lib/lib/Question";
@@ -103,8 +104,11 @@ function deserializeCard(serializedCard: string) {
   return card;
 }
 
-async function fetchAndPrepareSavedQuestionCards(cardId: number) {
-  const card = await loadCard(cardId);
+async function fetchAndPrepareSavedQuestionCards(
+  cardId: number,
+  dispatch: Dispatch,
+) {
+  const card = await loadCard(cardId, dispatch);
   const originalCard = { ...card };
 
   // for showing the "started from" lineage correctly when adding filters/breakouts and when going back and forth
@@ -114,7 +118,10 @@ async function fetchAndPrepareSavedQuestionCards(cardId: number) {
   return { card, originalCard };
 }
 
-async function fetchAndPrepareAdHocQuestionCards(deserializedCard: Card) {
+async function fetchAndPrepareAdHocQuestionCards(
+  deserializedCard: Card,
+  dispatch: Dispatch,
+) {
   if (!deserializedCard.original_card_id) {
     return {
       card: deserializedCard,
@@ -122,7 +129,10 @@ async function fetchAndPrepareAdHocQuestionCards(deserializedCard: Card) {
     };
   }
 
-  const originalCard = await loadCard(deserializedCard.original_card_id);
+  const originalCard = await loadCard(
+    deserializedCard.original_card_id,
+    dispatch,
+  );
 
   if (cardIsEquivalent(deserializedCard, originalCard)) {
     return {
@@ -146,10 +156,12 @@ async function resolveCards({
   cardId,
   deserializedCard,
   options,
+  dispatch,
 }: {
   cardId?: number;
   deserializedCard?: Card;
   options: BlankQueryOptions;
+  dispatch: Dispatch;
 }): Promise<ResolveCardsResult> {
   if (!cardId && !deserializedCard) {
     return {
@@ -157,8 +169,8 @@ async function resolveCards({
     };
   }
   return cardId
-    ? fetchAndPrepareSavedQuestionCards(cardId)
-    : fetchAndPrepareAdHocQuestionCards(deserializedCard as Card);
+    ? fetchAndPrepareSavedQuestionCards(cardId, dispatch)
+    : fetchAndPrepareAdHocQuestionCards(deserializedCard as Card, dispatch);
 }
 
 function parseHash(hash?: string) {
@@ -209,6 +221,7 @@ async function handleQBInit(
     cardId,
     deserializedCard,
     options,
+    dispatch,
   });
 
   if (isSavedCard(card) && card.archived) {

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
@@ -107,8 +107,9 @@ function deserializeCard(serializedCard: string) {
 async function fetchAndPrepareSavedQuestionCards(
   cardId: number,
   dispatch: Dispatch,
+  getState: GetState,
 ) {
-  const card = await loadCard(cardId, dispatch);
+  const card = await loadCard(cardId, { dispatch, getState });
   const originalCard = { ...card };
 
   // for showing the "started from" lineage correctly when adding filters/breakouts and when going back and forth
@@ -121,6 +122,7 @@ async function fetchAndPrepareSavedQuestionCards(
 async function fetchAndPrepareAdHocQuestionCards(
   deserializedCard: Card,
   dispatch: Dispatch,
+  getState: GetState,
 ) {
   if (!deserializedCard.original_card_id) {
     return {
@@ -129,10 +131,10 @@ async function fetchAndPrepareAdHocQuestionCards(
     };
   }
 
-  const originalCard = await loadCard(
-    deserializedCard.original_card_id,
+  const originalCard = await loadCard(deserializedCard.original_card_id, {
     dispatch,
-  );
+    getState,
+  });
 
   if (cardIsEquivalent(deserializedCard, originalCard)) {
     return {
@@ -157,11 +159,13 @@ async function resolveCards({
   deserializedCard,
   options,
   dispatch,
+  getState,
 }: {
   cardId?: number;
   deserializedCard?: Card;
   options: BlankQueryOptions;
   dispatch: Dispatch;
+  getState: GetState;
 }): Promise<ResolveCardsResult> {
   if (!cardId && !deserializedCard) {
     return {
@@ -169,8 +173,12 @@ async function resolveCards({
     };
   }
   return cardId
-    ? fetchAndPrepareSavedQuestionCards(cardId, dispatch)
-    : fetchAndPrepareAdHocQuestionCards(deserializedCard as Card, dispatch);
+    ? fetchAndPrepareSavedQuestionCards(cardId, dispatch, getState)
+    : fetchAndPrepareAdHocQuestionCards(
+        deserializedCard as Card,
+        dispatch,
+        getState,
+      );
 }
 
 function parseHash(hash?: string) {
@@ -222,6 +230,7 @@ async function handleQBInit(
     deserializedCard,
     options,
     dispatch,
+    getState,
   });
 
   if (isSavedCard(card) && card.archived) {

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.unit.spec.ts
@@ -123,6 +123,8 @@ async function setup({
     });
   }
 
+  jest.spyOn(CardLib, "loadCard").mockReturnValue(Promise.resolve({ ...card }));
+
   return baseSetup({ location, params, ...opts });
 }
 
@@ -437,6 +439,10 @@ describe("QB Actions > initializeQB", () => {
         xhrMock.get(`/api/card/${originalQuestion.id()}`, {
           body: JSON.stringify(originalQuestion.card()),
         });
+
+        jest
+          .spyOn(CardLib, "loadCard")
+          .mockReturnValueOnce(Promise.resolve({ ...originalQuestion.card() }));
 
         return setup({ question: q, ...opts });
       }

--- a/frontend/test/metabase/containers/SavedQuestionLoader.unit.spec.js
+++ b/frontend/test/metabase/containers/SavedQuestionLoader.unit.spec.js
@@ -3,7 +3,6 @@ import { render } from "@testing-library/react";
 
 import Question from "metabase-lib/lib/Question";
 import { delay } from "metabase/lib/promise";
-import { CardApi } from "metabase/services";
 
 // import the un-connected component so we can test its internal logic sans
 // redux
@@ -25,12 +24,13 @@ describe("SavedQuestionLoader", () => {
   it("should load a question given a questionId", async () => {
     const questionId = 1;
     const q = Question.create({ databaseId: 1, tableId: 2 });
-    jest.spyOn(CardApi, "get").mockReturnValue(q.card());
+    const mockFetchQuestion = jest.fn().mockResolvedValue(q.card());
 
     render(
       <SavedQuestionLoader
         questionId={questionId}
         loadMetadataForCard={loadMetadataSpy}
+        fetchQuestion={mockFetchQuestion}
       >
         {mockChild}
       </SavedQuestionLoader>,


### PR DESCRIPTION
Related to https://github.com/metabase/metabase/issues/25048 and pulled out of a much large PR https://github.com/metabase/metabase/pull/25030

I'm removing direct usage of `CardApi.get` and replacing it with a `Questions.actions.fetch` action call so that the questions we are fetching are properly cached and added to the `metadata.questions` map. Fetching behavior is identical as I am using the `reload: true` option. This change is needed for the changes in https://github.com/metabase/metabase/pull/25030 as I'm relying on `metadata.question(questionId)` to grab questions out of state in several new places.

Passing around `dispatch` and `getState` is kinda gross, but I was aiming for the minimal change to get things working so that I could focus on the rest of #25030 🙂 

**Testing**
1. Query builder should work as before -- ie cards are fetched etc.
2. Additionally, question instances should be found on the `Metadata` instance and in the entity area of the our redux store.