### PR TITLE
Expand dev docs for E2E tests running against EE version

### DIFF
--- a/docs/developers-guide/e2e-tests.md
+++ b/docs/developers-guide/e2e-tests.md
@@ -108,4 +108,5 @@ If you navigate to the `/admin/settings/license` page, the license input field s
 
 
 - If tests under `describeEE` block are greyed out and not running, make sure you entered the environment variables correctly.
-- If tests start running but the enterprise features are missing first make sure that the token is still valid and/or that it includes a certain feature. If everything with the token seems to be ok the only remaining solution is to kill all Java processes with `killall java` and to restart Cypress.
+- If tests start running but the enterprise features are missing: make sure that the token is still valid. 
+- If everything with the token seems to be okay, go nuclear and destroy all Java processes: run `killall java` and restart Cypress.

--- a/docs/developers-guide/e2e-tests.md
+++ b/docs/developers-guide/e2e-tests.md
@@ -95,7 +95,10 @@ These files can be found under the “Artifacts” tab in Circle:
 
 ## Running Cypress tests against EE version of Metabase
 
-Make sure you have a valid enterprise token prior to running Cypress. We have a special `describe` block called `describeEE` that will conditionally skip or run tests based on the existence of two environment variables (`MB_EDITION` and `MB_PREMIUM_EMBEDDING_TOKEN`).
+Prior to running Cypress, make sure you have a valid enterprise token. We have a special `describe` block called `describeEE` that will conditionally skip or run tests based on the existence of two environment variables:
+
+- `MB_EDITION`
+- `MB_PREMIUM_EMBEDDING_TOKEN`
 
 ```
 MB_EDITION=ee MB_PREMIUM_EMBEDDING_TOKEN=xxxxxx yarn test-cypress-open

--- a/docs/developers-guide/e2e-tests.md
+++ b/docs/developers-guide/e2e-tests.md
@@ -103,7 +103,6 @@ MB_EDITION=ee MB_PREMIUM_EMBEDDING_TOKEN=xxxxxx yarn test-cypress-open
 
 If you navigate to the `/admin/settings/license` page, the license input field should be disabled and already populated. It should say: "Using MB_PREMIUM_EMBEDDING_TOKEN".
 
-_Note:_
 
 - If tests under `describeEE` block are greyed out and not running, make sure you entered the environment variables correctly.
 - If tests start running but the enterprise features are missing first make sure that the token is still valid and/or that it includes a certain feature. If everything with the token seems to be ok the only remaining solution is to kill all Java processes with `killall java` and to restart Cypress.

--- a/docs/developers-guide/e2e-tests.md
+++ b/docs/developers-guide/e2e-tests.md
@@ -92,3 +92,18 @@ Cypress records videos of each test run, which can be helpful in debugging. Addi
 
 These files can be found under the “Artifacts” tab in Circle:
 ![Circle CI Artifacts tab](https://user-images.githubusercontent.com/691495/72190614-f5995380-33cd-11ea-875e-4203d6dcf1c1.png)
+
+## Running Cypress tests against EE version of Metabase
+
+Make sure you have a valid enterprise token prior to running Cypress. We have a special `describe` block called `describeEE` that will conditionally skip or run tests based on the existence of two environment variables (`MB_EDITION` and `MB_PREMIUM_EMBEDDING_TOKEN`).
+
+```
+MB_EDITION=ee MB_PREMIUM_EMBEDDING_TOKEN=xxxxxx yarn test-cypress-open
+```
+
+If you navigate to the `/admin/settings/license` page, the license input field should be disabled and already populated. It should say: "Using MB_PREMIUM_EMBEDDING_TOKEN".
+
+_Note:_
+
+- If tests under `describeEE` block are greyed out and not running, make sure you entered the environment variables correctly.
+- If tests start running but the enterprise features are missing first make sure that the token is still valid and/or that it includes a certain feature. If everything with the token seems to be ok the only remaining solution is to kill all Java processes with `killall java` and to restart Cypress.


### PR DESCRIPTION
@noah and I recently ran into the same issue where we had all the valid ENVs and the valid token, but the enterprise features were missing in Cypress tests. After some debugging Noah concluded that the only logical explanation must be some "phantom JVM process running".

The solution that worked for the both of us was to `killall java`.

That should be in the docs, imo.