### PR TITLE
Hydrate app_id on collections in the search endpoint

### DIFF
--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -122,6 +122,7 @@
 (defmethod columns-for-model "card"
   [_]
   (conj default-columns :collection_id :collection_position :dataset_query
+        [:collection_app.collection_id :collection_app_id]
         [:collection.name :collection_name]
         [:collection.authority_level :collection_authority_level]
         [{:select   [:status]
@@ -140,6 +141,7 @@
 (defmethod columns-for-model "dashboard"
   [_]
   (conj default-columns :collection_id :collection_position bookmark-col
+        [:collection_app.collection_id :collection_app_id]
         [:collection.name :collection_name]
         [:collection.authority_level :collection_authority_level]))
 
@@ -149,12 +151,18 @@
 
 (defmethod columns-for-model "pulse"
   [_]
-  [:id :name :collection_id [:collection.name :collection_name]])
+  [:id :name :collection_id
+   [:collection_app.collection_id :collection_app_id]
+   [:collection.name :collection_name]])
 
 (defmethod columns-for-model "collection"
   [_]
-  (conj (remove #{:updated_at} default-columns) [:collection.id :collection_id] [:name :collection_name]
+  (conj (remove #{:updated_at} default-columns)
+        [:collection.id :collection_id]
+        [:name :collection_name]
         [:authority_level :collection_authority_level]
+        [:app.id :app_id]
+        [:app.id :collection_app_id]
         bookmark-col))
 
 (defmethod columns-for-model "segment"

--- a/src/metabase/search/scoring.clj
+++ b/src/metabase/search/scoring.clj
@@ -219,7 +219,7 @@
   "Massage the raw result from the DB and match data into something more useful for the client"
   [result {:keys [column match-context-thunk]} scores]
   (let [{:keys [name display_name
-                collection_id collection_name collection_authority_level]} result]
+                collection_id collection_name collection_authority_level collection_app_id]} result]
     (-> result
         (assoc
          :name           (if (or (= column :name)
@@ -231,12 +231,14 @@
                            (match-context-thunk))
          :collection     {:id              collection_id
                           :name            collection_name
-                          :authority_level collection_authority_level}
+                          :authority_level collection_authority_level
+                          :app_id          collection_app_id}
          :scores          scores)
         (update :dataset_query #(some-> % json/parse-string mbql.normalize/normalize))
         (dissoc
          :collection_id
          :collection_name
+         :collection_app_id
          :display_name))))
 
 (defn weights-and-scores

--- a/test/metabase/api/search_test.clj
+++ b/test/metabase/api/search_test.clj
@@ -617,9 +617,7 @@
         (is (= (mapv
                 (fn [result]
                   (cond-> result
-                    (not (#{"metric" "segment"} (:model result)))
-                    (assoc-in [:collection :app_id] true)
-                    (= (:model result) "collection")
-                    (assoc :app_id true)))
+                    (not (#{"metric" "segment"} (:model result))) (assoc-in [:collection :app_id] true)
+                    (= (:model result) "collection")              (assoc :app_id true)))
                 (default-results-with-collection))
                (search-request-data :rasta :q "test")))))))


### PR DESCRIPTION
Fixes #25105.

This PR sets the `app_id` in the search result for collections and the `app_id` in the `collection` property for card, collection, dashboard and pulse results.

Just as with the other collection properties like `authority_level`, `name` etc., in the case of collections the `app_id` in the `collection` property duplicates the top level `app_id` property. I implemented it like this to avoid surprises, although I think it would make sense if the `collection` property described the containing collection just like it does for cards and dashboards.