### PR TITLE
Fix data selector trigger wrapping

### DIFF
--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -828,7 +828,10 @@ export class UnconnectedDataSelector extends Component {
 
     return (
       <span
-        className={className || "px2 py2 text-bold cursor-pointer text-default"}
+        className={
+          className ||
+          "px2 py2 text-bold cursor-pointer text-default flex-no-shrink"
+        }
         style={style}
       >
         {React.createElement(getTriggerElementContent, {


### PR DESCRIPTION
How to test:
- New -> SQL query
- Select a database
- Make sure its name is not broken into multiple lines

Before
<img width="843" alt="Screenshot 2022-08-31 at 14 24 07" src="https://user-images.githubusercontent.com/8542534/187657532-413c8d87-7ee4-442b-9073-8d8a500d0d21.png">

After
<img width="848" alt="Screenshot 2022-08-31 at 14 23 54" src="https://user-images.githubusercontent.com/8542534/187657551-375892e0-6738-44f4-aad2-7063d641e4c3.png">
