### PR TITLE
Run 24966 repro on EE only

### DIFF
--- a/frontend/test/metabase/scenarios/permissions/reproductions/24966-saved-native-q-field-values.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/reproductions/24966-saved-native-q-field-values.cy.spec.js
@@ -3,6 +3,7 @@ import {
   visitQuestion,
   visitDashboard,
   filterWidget,
+  describeEE,
 } from "__support__/e2e/helpers";
 
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
@@ -44,7 +45,7 @@ const dashboardFilter = {
 
 const dashboardDetails = { parameters: [dashboardFilter] };
 
-describe("issue 24966", () => {
+describeEE("issue 24966", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();


### PR DESCRIPTION
`frontend/test/metabase/scenarios/permissions/reproductions/24966-saved-native-q-field-values.cy.spec.js` fails on the OSS test run because it uses sandboxing which is EE only