### PR TITLE
Fixed a misslink redirection for `Alerts` documentation

### DIFF
--- a/docs/questions/sharing/alerts.md
+++ b/docs/questions/sharing/alerts.md
@@ -1,5 +1,6 @@
 ---
 title: Getting alerts about questions
+redirect_from:
   - /docs/latest/users-guide/15-alerts
 ---
 


### PR DESCRIPTION
Hey 👋🏻 

Here is a fix for a misslink to documentation page for `Alerts`.

It was introduced here - #24765. Author of the PR forgot to add `redirection_from` key to the meta information, so you have no correct redirection to the `Alerts` documentation. I found it in your README.md in [`Features` section](https://github.com/metabase/metabase#features).

![image](https://user-images.githubusercontent.com/3241812/187684817-68131d37-ec10-408e-a704-dbef76773d98.png)

• Expected result: `https://www.metabase.com/docs/latest/users-guide/15-alerts.html` should redirect to `https://www.metabase.com/docs/latest/questions/sharing/alerts` page.

• Actual result: `https://www.metabase.com/docs/latest/users-guide/15-alerts.html` could not be resolved and redirect users to «Not found» page – `https://www.metabase.com/404`.


