### PR TITLE
fix backports auto-approve

### DIFF
--- a/.github/workflows/auto-backport.yml
+++ b/.github/workflows/auto-backport.yml
@@ -49,6 +49,8 @@ jobs:
             exit 0
           fi
 
+          echo "::set-output name=has-conflicts::false"
+
           git checkout master
           git push -u origin ${BACKPORT_BRANCH}
 


### PR DESCRIPTION
## Changes

Fixes not working backports auto-approvals & auto-merge: set `has-conflicts` value to `false` when there is no conflicts so that the following steps execute