### PR TITLE
Static visualization polish fixes

### DIFF
--- a/frontend/src/metabase/static-viz/components/LineAreaBarChart/LineAreaBarChart.tsx
+++ b/frontend/src/metabase/static-viz/components/LineAreaBarChart/LineAreaBarChart.tsx
@@ -29,21 +29,21 @@ const LineAreaBarChart = ({
       color: getColor("text-light"),
       ticks: {
         color: getColor("text-medium"),
-        fontSize: 11,
+        fontSize: 12,
       },
       labels: {
         color: getColor("text-medium"),
-        fontSize: 11,
+        fontSize: 14,
         fontWeight: 700,
       },
     },
     legend: {
-      fontSize: 13,
-      lineHeight: 16,
+      fontSize: 16,
+      lineHeight: 20,
     },
     value: {
       color: getColor("text-dark"),
-      fontSize: 11,
+      fontSize: 12,
       fontWeight: 800,
       stroke: getColor("white"),
       strokeWidth: 3,

--- a/frontend/src/metabase/static-viz/components/LineAreaBarChart/utils/settings.ts
+++ b/frontend/src/metabase/static-viz/components/LineAreaBarChart/utils/settings.ts
@@ -73,6 +73,6 @@ const handleCrowdedOrdinalXTicks = (
   }
 
   return xValuesCount > 10
-    ? assocIn(settings, ["x", "tick_display"], "rotate-45")
+    ? assocIn(settings, ["x", "tick_display"], "rotate-90")
     : settings;
 };

--- a/frontend/src/metabase/static-viz/components/LineAreaBarChart/utils/settings.unit.spec.ts
+++ b/frontend/src/metabase/static-viz/components/LineAreaBarChart/utils/settings.unit.spec.ts
@@ -55,7 +55,7 @@ describe("adjustSettings", () => {
         chartSize,
       );
 
-      expect(adjustedSettings.x.tick_display).toBe("rotate-45");
+      expect(adjustedSettings.x.tick_display).toBe("rotate-90");
     });
 
     it("hides X-ticks when they can't fit", () => {

--- a/frontend/src/metabase/static-viz/components/XYChart/Values/Values.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/Values/Values.tsx
@@ -14,8 +14,14 @@ import type {
   StackedDatum,
   VisualizationType,
   XScale,
-  XYAccessor,
 } from "../types";
+
+type XYAccessor<
+  T extends SeriesDatum | StackedDatum = SeriesDatum | StackedDatum,
+> = (
+  datum: T extends SeriesDatum ? SeriesDatum : StackedDatum,
+  flipped?: boolean,
+) => number;
 
 const VALUES_MARGIN = 6;
 const VALUES_STROKE_MARGIN = 3;
@@ -118,7 +124,7 @@ export default function Values({
             return null;
           }
 
-          const { xAccessor, yAccessor } = getXyAccessors(
+          const { xAccessor, yAccessor, dataYAccessor } = getXyAccessors(
             value.series.type,
             value.xScale,
             value.yScale,
@@ -126,17 +132,33 @@ export default function Values({
             value.flipped,
           );
 
+          const shouldRenderDataPoint = (
+            ["line", "area"] as VisualizationType[]
+          ).includes(value.series.type);
           return (
-            <OutlinedText
-              key={index}
-              x={xAccessor(value.datum)}
-              y={yAccessor(value.datum)}
-              textAnchor="middle"
-              verticalAnchor="end"
-              {...valueProps}
-            >
-              {formatter(getY(value.datum), compact)}
-            </OutlinedText>
+            <>
+              <OutlinedText
+                key={index}
+                x={xAccessor(value.datum)}
+                y={yAccessor(value.datum)}
+                textAnchor="middle"
+                verticalAnchor="end"
+                {...valueProps}
+              >
+                {formatter(getY(value.datum), compact)}
+              </OutlinedText>
+              {shouldRenderDataPoint && (
+                <circle
+                  key={index}
+                  r={2}
+                  fill="white"
+                  stroke={value.series.color}
+                  strokeWidth={1.5}
+                  cx={xAccessor(value.datum)}
+                  cy={dataYAccessor(value.datum)}
+                />
+              )}
+            </>
           );
         });
       })}
@@ -195,12 +217,14 @@ function getXyAccessors(
 ): {
   xAccessor: XYAccessor;
   yAccessor: XYAccessor;
+  dataYAccessor: XYAccessor;
 } {
   return {
     xAccessor: getXAccessor(type, xScale, barXOffset),
     yAccessor: (datum, overriddenFlipped = flipped) =>
       (yScale(getY(datum)) ?? 0) +
       (overriddenFlipped ? FLIPPED_VALUES_MARGIN : -VALUES_MARGIN),
+    dataYAccessor: datum => yScale(getY(datum)) ?? 0,
   };
 }
 
@@ -213,7 +237,7 @@ function getXAccessor(
     return datum => (xScale.barAccessor as XYAccessor)(datum) + barXOffset;
   }
   if (type === "line" || type === "area") {
-    return xScale.lineAccessor;
+    return xScale.lineAccessor as XYAccessor;
   }
   exhaustiveCheck(type);
 }

--- a/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
@@ -203,6 +203,16 @@ export const XYChart = ({
       />
 
       <Group left={valuesLeftOffset}>
+        <Group top={margin.top} left={xMin}>
+          {defaultYScale && (
+            <GridRows
+              scale={defaultYScale}
+              width={calculatedInnerWidth}
+              strokeDasharray="4"
+            />
+          )}
+        </Group>
+
         <AxisBottom
           scale={xScale.scale}
           label={areXTicksRotated ? undefined : settings.labels.bottom}
@@ -233,14 +243,6 @@ export const XYChart = ({
         />
 
         <Group top={margin.top} left={xMin}>
-          {defaultYScale && (
-            <GridRows
-              scale={defaultYScale}
-              width={calculatedInnerWidth}
-              strokeDasharray="4"
-            />
-          )}
-
           {xScale.barAccessor && xScale.bandwidth && (
             <BarSeries
               series={bars}

--- a/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
@@ -97,9 +97,10 @@ export const XYChart = ({
     series,
     VALUE_CHAR_SIZE,
   );
+  const calculatedInnerWidth = innerWidth - valuesLeftOffset;
   const xScale = createXScale(
     series,
-    [0, innerWidth - valuesLeftOffset],
+    [0, calculatedInnerWidth],
     settings.x.type,
   );
   const { yScaleLeft, yScaleRight } = createYScales(
@@ -235,7 +236,7 @@ export const XYChart = ({
           {defaultYScale && (
             <GridRows
               scale={defaultYScale}
-              width={innerWidth}
+              width={calculatedInnerWidth}
               strokeDasharray="4"
             />
           )}
@@ -267,7 +268,7 @@ export const XYChart = ({
             <GoalLine
               label={settings.goal.label}
               x1={0}
-              x2={innerWidth}
+              x2={calculatedInnerWidth}
               // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
               y={defaultYScale!(settings.goal.value)}
               color={style.goalColor}
@@ -287,7 +288,7 @@ export const XYChart = ({
               xScale={xScale}
               yScaleLeft={yScaleLeft}
               yScaleRight={yScaleRight}
-              innerWidth={innerWidth}
+              innerWidth={calculatedInnerWidth}
               areStacked={settings.stacking === "stack"}
               xAxisYPos={yMin - margin.top}
             />

--- a/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
@@ -79,7 +79,7 @@ export const XYChart = ({
   const margin = calculateMargin(
     yTickWidths.left,
     yTickWidths.right,
-    xTicksDimensions.height,
+    xTicksDimensions.height + style.axes.labels.fontSize * 2,
     xTicksDimensions.width,
     settings.labels,
     style.axes.ticks.fontSize,
@@ -152,7 +152,7 @@ export const XYChart = ({
     strokeWidth: style.value?.strokeWidth,
   };
 
-  const areXTicksRotated = settings.x.tick_display === "rotate-45";
+  const areXTicksRotated = settings.x.tick_display === "rotate-90";
   const areXTicksHidden = settings.x.tick_display === "hide";
   const xLabelOffset = areXTicksHidden ? -style.axes.ticks.fontSize : undefined;
 
@@ -215,7 +215,7 @@ export const XYChart = ({
 
         <AxisBottom
           scale={xScale.scale}
-          label={areXTicksRotated ? undefined : settings.labels.bottom}
+          label={settings.labels.bottom}
           top={yMin}
           left={xMin}
           numTicks={xTicksCount}
@@ -223,7 +223,12 @@ export const XYChart = ({
           stroke={style.axes.color}
           tickStroke={style.axes.color}
           hideTicks={settings.x.tick_display === "hide"}
-          labelProps={labelProps}
+          labelProps={{
+            ...labelProps,
+            transform: `translate(0, ${
+              areXTicksRotated ? xTickWidthLimit : CHART_PADDING
+            })`,
+          }}
           tickFormat={value =>
             formatXTick(value.valueOf(), settings.x.type, settings.x.format)
           }

--- a/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
@@ -80,11 +80,12 @@ export const XYChart = ({
 
   const yLabelOffsetLeft = yTickWidths.left + LABEL_PADDING;
   const yLabelOffsetRight = LABEL_PADDING;
+  const xTickVerticalMargins = style.axes.labels.fontSize * 2;
 
   const margin = calculateMargin(
     yTickWidths.left,
     yTickWidths.right,
-    xTicksDimensions.height + style.axes.labels.fontSize * 2,
+    xTicksDimensions.height + xTickVerticalMargins,
     xTicksDimensions.width,
     settings.labels,
     style.axes.ticks.fontSize,

--- a/frontend/src/metabase/static-viz/components/XYChart/shapes/AreaSeries.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/shapes/AreaSeries.tsx
@@ -8,14 +8,15 @@ import { AreaSeriesStacked } from "./AreaSeriesStacked";
 import type {
   Series,
   SeriesDatum,
-  XYAccessor,
+  DatumAccessor,
+  StackedDatumAccessor,
 } from "metabase/static-viz/components/XYChart/types";
 
 interface AreaSeriesProps {
   series: Series[];
   yScaleLeft: PositionScale | null;
   yScaleRight: PositionScale | null;
-  xAccessor: XYAccessor;
+  xAccessor: DatumAccessor;
   areStacked?: boolean;
 }
 
@@ -33,7 +34,7 @@ export const AreaSeries = ({
         // Stacked charts work only for a single dataset with one dimension and left Y-axis
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         yScale={yScaleLeft!}
-        xAccessor={xAccessor}
+        xAccessor={xAccessor as unknown as StackedDatumAccessor}
       />
     );
   }
@@ -50,30 +51,15 @@ export const AreaSeries = ({
 
         const yAccessor = (d: SeriesDatum) => yScale(getY(d)) ?? 0;
         return (
-          <>
-            <LineArea
-              key={series.name}
-              yScale={yScale}
-              color={series.color}
-              data={series.data}
-              x={xAccessor}
-              y={yAccessor}
-              y1={yScale(0) ?? 0}
-            />
-            {series.data.map((datum, dataIndex) => {
-              return (
-                <circle
-                  key={`${seriesIndex}-${dataIndex}`}
-                  r={2}
-                  fill="white"
-                  stroke={series.color}
-                  strokeWidth={1.5}
-                  cx={xAccessor(datum)}
-                  cy={yAccessor(datum)}
-                />
-              );
-            })}
-          </>
+          <LineArea
+            key={series.name}
+            yScale={yScale}
+            color={series.color}
+            data={series.data}
+            x={xAccessor as DatumAccessor}
+            y={yAccessor}
+            y1={yScale(0) ?? 0}
+          />
         );
       })}
     </Group>

--- a/frontend/src/metabase/static-viz/components/XYChart/shapes/AreaSeriesStacked.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/shapes/AreaSeriesStacked.tsx
@@ -4,14 +4,14 @@ import { PositionScale } from "@visx/shape/lib/types";
 import { LineArea } from "metabase/static-viz/components/XYChart/shapes/LineArea";
 import {
   HydratedSeries,
-  XYAccessor,
+  StackedDatumAccessor,
 } from "metabase/static-viz/components/XYChart/types";
 import { getY, getY1 } from "metabase/static-viz/components/XYChart/utils";
 
 interface AreaSeriesProps {
   series: HydratedSeries[];
   yScale: PositionScale;
-  xAccessor: XYAccessor;
+  xAccessor: StackedDatumAccessor;
 }
 
 export const AreaSeriesStacked = ({
@@ -23,30 +23,15 @@ export const AreaSeriesStacked = ({
     <Group>
       {multipleSeries.map((series, seriesIndex) => {
         return (
-          <>
-            <LineArea
-              key={series.name}
-              yScale={yScale}
-              color={series.color}
-              data={series.stackedData}
-              x={xAccessor as any}
-              y={datum => yScale(getY(datum)) ?? 0}
-              y1={datum => yScale(getY1(datum)) ?? 0}
-            />
-            {series.stackedData?.map((datum, dataIndex) => {
-              return (
-                <circle
-                  key={`${seriesIndex}-${dataIndex}`}
-                  r={2}
-                  fill="white"
-                  stroke={series.color}
-                  strokeWidth={1.5}
-                  cx={xAccessor(datum)}
-                  cy={yScale(getY(datum)) ?? 0}
-                />
-              );
-            })}
-          </>
+          <LineArea
+            key={series.name}
+            yScale={yScale}
+            color={series.color}
+            data={series.stackedData}
+            x={xAccessor}
+            y={datum => yScale(getY(datum)) ?? 0}
+            y1={datum => yScale(getY1(datum)) ?? 0}
+          />
         );
       })}
     </Group>

--- a/frontend/src/metabase/static-viz/components/XYChart/shapes/AreaSeriesStacked.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/shapes/AreaSeriesStacked.tsx
@@ -4,34 +4,49 @@ import { PositionScale } from "@visx/shape/lib/types";
 import { LineArea } from "metabase/static-viz/components/XYChart/shapes/LineArea";
 import {
   HydratedSeries,
-  SeriesDatum,
+  XYAccessor,
 } from "metabase/static-viz/components/XYChart/types";
 import { getY, getY1 } from "metabase/static-viz/components/XYChart/utils";
 
 interface AreaSeriesProps {
   series: HydratedSeries[];
   yScale: PositionScale;
-  xAccessor: (datum: SeriesDatum) => number;
+  xAccessor: XYAccessor;
 }
 
 export const AreaSeriesStacked = ({
-  series,
+  series: multipleSeries,
   yScale,
   xAccessor,
 }: AreaSeriesProps) => {
   return (
     <Group>
-      {series.map(s => {
+      {multipleSeries.map((series, seriesIndex) => {
         return (
-          <LineArea
-            key={s.name}
-            yScale={yScale}
-            color={s.color}
-            data={s.stackedData}
-            x={xAccessor as any}
-            y={d => yScale(getY(d)) ?? 0}
-            y1={d => yScale(getY1(d)) ?? 0}
-          />
+          <>
+            <LineArea
+              key={series.name}
+              yScale={yScale}
+              color={series.color}
+              data={series.stackedData}
+              x={xAccessor as any}
+              y={datum => yScale(getY(datum)) ?? 0}
+              y1={datum => yScale(getY1(datum)) ?? 0}
+            />
+            {series.stackedData?.map((datum, dataIndex) => {
+              return (
+                <circle
+                  key={`${seriesIndex}-${dataIndex}`}
+                  r={2}
+                  fill="white"
+                  stroke={series.color}
+                  strokeWidth={1.5}
+                  cx={xAccessor(datum)}
+                  cy={yScale(getY(datum)) ?? 0}
+                />
+              );
+            })}
+          </>
         );
       })}
     </Group>

--- a/frontend/src/metabase/static-viz/components/XYChart/shapes/BarSeries.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/shapes/BarSeries.tsx
@@ -6,15 +6,15 @@ import { PositionScale } from "@visx/shape/lib/types";
 import { getY } from "metabase/static-viz/components/XYChart/utils";
 
 import type {
+  DatumAccessor,
   Series,
-  SeriesDatum,
 } from "metabase/static-viz/components/XYChart/types";
 
 interface BarSeriesProps {
   series: Series[];
   yScaleLeft: PositionScale | null;
   yScaleRight: PositionScale | null;
-  xAccessor: (datum: SeriesDatum) => number;
+  xAccessor: DatumAccessor;
   bandwidth: number;
 }
 

--- a/frontend/src/metabase/static-viz/components/XYChart/shapes/LineArea.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/shapes/LineArea.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Area, LinePath } from "@visx/shape";
 import { AccessorForArrayItem, PositionScale } from "@visx/shape/lib/types";
+import { StackedDatum } from "../types";
 
 interface AreaProps<Datum> {
   x: AccessorForArrayItem<Datum, number>;

--- a/frontend/src/metabase/static-viz/components/XYChart/shapes/LineSeries.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/shapes/LineSeries.tsx
@@ -33,29 +33,14 @@ export const LineSeries = ({
 
         const yAccessor = (datum: SeriesDatum) => yScale(getY(datum)) ?? 0;
         return (
-          <>
-            <LinePath
-              key={series.name}
-              data={series.data}
-              x={xAccessor}
-              y={yAccessor}
-              stroke={series.color}
-              strokeWidth={2}
-            />
-            {series.data.map((datum, dataIndex) => {
-              return (
-                <circle
-                  key={`${seriesIndex}-${dataIndex}`}
-                  r={2}
-                  fill="white"
-                  stroke={series.color}
-                  strokeWidth={1.5}
-                  cx={xAccessor(datum)}
-                  cy={yAccessor(datum)}
-                />
-              );
-            })}
-          </>
+          <LinePath
+            key={series.name}
+            data={series.data}
+            x={xAccessor}
+            y={yAccessor}
+            stroke={series.color}
+            strokeWidth={2}
+          />
         );
       })}
     </Group>

--- a/frontend/src/metabase/static-viz/components/XYChart/shapes/LineSeries.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/shapes/LineSeries.tsx
@@ -17,29 +17,45 @@ interface LineSeriesProps {
 }
 
 export const LineSeries = ({
-  series,
+  series: multipleSeries,
   yScaleLeft,
   yScaleRight,
   xAccessor,
 }: LineSeriesProps) => {
   return (
     <Group>
-      {series.map(s => {
-        const yScale = s.yAxisPosition === "left" ? yScaleLeft : yScaleRight;
+      {multipleSeries.map((series, seriesIndex) => {
+        const yScale =
+          series.yAxisPosition === "left" ? yScaleLeft : yScaleRight;
         if (!yScale) {
           return null;
         }
 
         const yAccessor = (datum: SeriesDatum) => yScale(getY(datum)) ?? 0;
         return (
-          <LinePath
-            key={s.name}
-            data={s.data}
-            x={xAccessor}
-            y={yAccessor}
-            stroke={s.color}
-            strokeWidth={2}
-          />
+          <>
+            <LinePath
+              key={series.name}
+              data={series.data}
+              x={xAccessor}
+              y={yAccessor}
+              stroke={series.color}
+              strokeWidth={2}
+            />
+            {series.data.map((datum, dataIndex) => {
+              return (
+                <circle
+                  key={`${seriesIndex}-${dataIndex}`}
+                  r={2}
+                  fill="white"
+                  stroke={series.color}
+                  strokeWidth={1.5}
+                  cx={xAccessor(datum)}
+                  cy={yAccessor(datum)}
+                />
+              );
+            })}
+          </>
         );
       })}
     </Group>

--- a/frontend/src/metabase/static-viz/components/XYChart/types.ts
+++ b/frontend/src/metabase/static-viz/components/XYChart/types.ts
@@ -3,7 +3,7 @@ import type { NumberFormatOptions } from "metabase/static-viz/lib/numbers";
 import type { ScaleBand, ScaleLinear, ScaleTime } from "d3-scale";
 
 export type Range = [number, number];
-export type ContiniousDomain = [number, number];
+export type ContinuousDomain = [number, number];
 
 export type XValue = string | number;
 export type YValue = number;

--- a/frontend/src/metabase/static-viz/components/XYChart/types.ts
+++ b/frontend/src/metabase/static-viz/components/XYChart/types.ts
@@ -31,7 +31,7 @@ export type HydratedSeries = Series & {
   stackedData?: StackedDatum[];
 };
 
-type TickDisplay = "show" | "hide" | "rotate-45";
+type TickDisplay = "show" | "hide" | "rotate-90";
 type Stacking = "stack" | "none";
 
 export type ChartSettings = {

--- a/frontend/src/metabase/static-viz/components/XYChart/types.ts
+++ b/frontend/src/metabase/static-viz/components/XYChart/types.ts
@@ -97,11 +97,15 @@ export type ChartStyle = {
   goalColor: string;
 };
 
-export type XYAccessor<
-  T extends SeriesDatum | StackedDatum = SeriesDatum | StackedDatum,
-> = (
-  datum: T extends SeriesDatum ? SeriesDatum : StackedDatum,
-  flipped?: boolean,
+export type DatumAccessor = (
+  d: SeriesDatum,
+  index?: number,
+  data?: SeriesDatum[],
+) => number;
+export type StackedDatumAccessor = (
+  d: StackedDatum,
+  index?: number,
+  data?: StackedDatum[],
 ) => number;
 
 export interface XScale<T = any> {
@@ -111,6 +115,6 @@ export interface XScale<T = any> {
     ? ScaleTime<number, number, never>
     : ScaleLinear<number, number, never>;
   bandwidth?: number;
-  lineAccessor: XYAccessor<SeriesDatum>;
-  barAccessor?: XYAccessor<SeriesDatum>;
+  lineAccessor: DatumAccessor;
+  barAccessor?: DatumAccessor;
 }

--- a/frontend/src/metabase/static-viz/components/XYChart/utils/scales.ts
+++ b/frontend/src/metabase/static-viz/components/XYChart/utils/scales.ts
@@ -14,7 +14,7 @@ import {
 import type {
   SeriesDatum,
   XAxisType,
-  ContiniousDomain,
+  ContinuousDomain,
   Range,
   Series,
   YAxisType,
@@ -90,7 +90,7 @@ export const createXScale = (
 const calculateYDomain = (
   series: HydratedSeries[],
   goalValue?: number,
-): ContiniousDomain => {
+): ContinuousDomain => {
   const values = series
     .flatMap<SeriesDatum | StackedDatum>(
       series => series.stackedData ?? series.data,
@@ -130,7 +130,7 @@ export const calculateYDomains = (
 };
 
 export const createYScale = (
-  domain: ContiniousDomain,
+  domain: ContinuousDomain,
   range: Range,
   axisType: YAxisType,
 ) => {
@@ -158,8 +158,8 @@ export const createYScale = (
 export const createYScales = (
   range: Range,
   axisType: YAxisType,
-  leftYDomain?: ContiniousDomain,
-  rightYDomain?: ContiniousDomain,
+  leftYDomain?: ContinuousDomain,
+  rightYDomain?: ContinuousDomain,
 ) => {
   return {
     yScaleLeft: leftYDomain ? createYScale(leftYDomain, range, axisType) : null,

--- a/frontend/src/metabase/static-viz/components/XYChart/utils/ticks.ts
+++ b/frontend/src/metabase/static-viz/components/XYChart/utils/ticks.ts
@@ -111,7 +111,9 @@ export const getXTickProps = (
 
   const textBaseline = Math.floor(tickFontSize / 2);
   const transform = shouldRotate
-    ? `rotate(-45, ${x} ${y}) translate(${textBaseline}, 0)`
+    ? `rotate(-90, ${x} ${y}) translate(${textBaseline}, ${Math.floor(
+        tickFontSize / 3,
+      )})`
     : undefined;
 
   const textAnchor = shouldRotate ? "end" : "middle";

--- a/frontend/src/metabase/static-viz/components/XYChart/utils/ticks.ts
+++ b/frontend/src/metabase/static-viz/components/XYChart/utils/ticks.ts
@@ -16,7 +16,7 @@ import { MAX_ROTATED_TICK_WIDTH } from "metabase/static-viz/components/XYChart/c
 import { getX } from "metabase/static-viz/components/XYChart/utils/series";
 
 import type {
-  ContiniousDomain,
+  ContinuousDomain,
   Series,
   XAxisType,
   XValue,
@@ -131,7 +131,7 @@ export const getDistinctXValuesCount = (series: Series[]) =>
   new Set(series.flatMap(s => s.data).map(getX)).size;
 
 export const calculateYTickWidth = (
-  domain: ContiniousDomain,
+  domain: ContinuousDomain,
   settings: ChartSettings["y"]["format"],
   fontSize: number,
 ) => {
@@ -145,8 +145,8 @@ export const calculateYTickWidth = (
 export const getYTickWidths = (
   settings: ChartSettings["y"]["format"],
   fontSize: number,
-  leftYDomain?: ContiniousDomain,
-  rightYDomain?: ContiniousDomain,
+  leftYDomain?: ContinuousDomain,
+  rightYDomain?: ContinuousDomain,
 ) => {
   return {
     left:

--- a/frontend/src/metabase/static-viz/components/XYChart/utils/ticks.ts
+++ b/frontend/src/metabase/static-viz/components/XYChart/utils/ticks.ts
@@ -20,7 +20,7 @@ import {
 import { getX } from "metabase/static-viz/components/XYChart/utils/series";
 
 export const getRotatedXTickHeight = (tickWidth: number) => {
-  return Math.ceil(Math.sqrt(Math.pow(tickWidth, 2) / 2));
+  return tickWidth;
 };
 
 export const formatXTick = (
@@ -55,7 +55,7 @@ export const getXTickWidthLimit = (
     return Infinity;
   }
 
-  return settings.tick_display === "rotate-45"
+  return settings.tick_display === "rotate-90"
     ? Math.min(actualMaxWidth, MAX_ROTATED_TICK_WIDTH)
     : bandwidth;
 };
@@ -81,19 +81,19 @@ export const getXTicksDimensions = (
     })
     .reduce((a, b) => Math.max(a, b), 0);
 
-  if (settings.tick_display === "rotate-45") {
+  if (settings.tick_display === "rotate-90") {
     const rotatedSize = getRotatedXTickHeight(maxTextWidth);
 
     return {
-      width: rotatedSize,
-      height: rotatedSize,
+      width: Math.min(rotatedSize, MAX_ROTATED_TICK_WIDTH),
+      height: Math.min(rotatedSize, MAX_ROTATED_TICK_WIDTH),
       maxTextWidth,
     };
   }
 
   return {
+    width: Math.min(maxTextWidth, MAX_ROTATED_TICK_WIDTH),
     height: measureTextHeight(fontSize),
-    width: maxTextWidth,
     maxTextWidth,
   };
 };

--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "@types/crossfilter": "^0.0.34",
     "@types/d3": "^3.5.46",
     "@types/d3-scale": "^4.0.2",
+    "@types/d3-time": "^3.0.0",
     "@types/dc": "0.0.29",
     "@types/diff": "^3.5.4",
     "@types/eslint": "7.29.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4663,7 +4663,7 @@
   dependencies:
     "@types/d3-path" "^1"
 
-"@types/d3-time@*":
+"@types/d3-time@*", "@types/d3-time@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/d3-time/-/d3-time-3.0.0.tgz#e1ac0f3e9e195135361fa1a1d62f795d87e6e819"
   integrity sha512-sZLCdHvBUcNby1cB6Fd3ZBrABbjz3v1Vm90nysCQ6Vt7vd6e/h9Lt7SiJUoEX0l4Dzc7P5llKyhqSi1ycSf1Hg==


### PR DESCRIPTION
> **Note** to reviewers
> I intended to add more E2E tests, but as I'm ending the day now, I think it'll be better if this PR is reviewed first. And the E2E tests could be add in a followed-up PR


Epic: https://github.com/metabase/metabase/issues/24759

- #### Rotated x-axis tick should position x-axis label after the longest tick
  ![image](https://user-images.githubusercontent.com/1937582/189128154-40784218-663d-4698-be3f-130e8adf8af8.png)

- #### Update text element font size
  ![image](https://user-images.githubusercontent.com/1937582/189128223-8b4ea15d-5ef2-4c10-a40d-d2bbc83a781d.png)

- #### Render data point circle on visible data point labels
  ![image](https://user-images.githubusercontent.com/1937582/189128325-b7328be0-cf1b-4627-91da-1f47a6e6537a.png)

- #### Fix the axis covered by grid lines.

  ##### After
  ![image](https://user-images.githubusercontent.com/1937582/188827468-7675183f-4efa-44f1-bdf7-75b2d151ace2.png)

  ##### Before
  ![image](https://user-images.githubusercontent.com/1937582/188827248-7c9ec3ae-2002-404b-a645-7adedb2b7fe2.png)
- #### Fix timeseries tick labels sometimes overlap with each other
- 
  ##### After
  ![image](https://user-images.githubusercontent.com/1937582/189128960-8e905723-8547-42a5-83e8-08eb648ae804.png)

  ##### Before
  ![image](https://user-images.githubusercontent.com/1937582/189128850-272fc15a-ef79-4bc7-84e1-f3cc74da9b2d.png)
