### PR TITLE
Show questions that join the table in the "Questions about table" page

### DIFF
--- a/frontend/src/metabase/reference/selectors.js
+++ b/frontend/src/metabase/reference/selectors.js
@@ -161,7 +161,15 @@ export const getSegmentQuestions = createSelector(
 export const getTableQuestions = createSelector(
   [getTable, getQuestions],
   (table, questions) =>
-    Object.values(questions).filter(question => question.table_id === table.id),
+    Object.values(questions).filter(question => {
+      if (question.table_id === table.id) {
+        return true
+      }
+      
+      const joins = (question['dataset_query']['query'] && question['dataset_query']['query']['joins']) || []
+    
+      return joins.some(join => join['source-table'] === table.id)
+    }),
 );
 
 const getDatabaseBySegment = createSelector(


### PR DESCRIPTION
On the "Questions about current table" page, only questions that are built directly from the table are shown.

This PR make questions that joined the table to show on the "Questions about current table" page.

NOTE: I haven't tested this PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/25146)
<!-- Reviewable:end -->
