### PR TITLE
[E2E] Skip adding another H2 database to avoid failures in CI

### DIFF
--- a/frontend/test/__support__/e2e/commands/database/addH2SampleDatabase.js
+++ b/frontend/test/__support__/e2e/commands/database/addH2SampleDatabase.js
@@ -3,7 +3,7 @@ Cypress.Commands.add(
   ({ name, auto_run_queries = false, is_full_sync = false } = {}) => {
     // IMPORTANT!
     // TODO: Remove the following line when https://github.com/metabase/metabase/issues/24900 gets fixed.
-    cy.skipOn("true");
+    cy.skipOn(true);
     cy.log(`Add another H2 sample database DB called "${name}"`);
     cy.request("POST", "/api/database", {
       engine: "h2",

--- a/frontend/test/__support__/e2e/commands/database/addH2SampleDatabase.js
+++ b/frontend/test/__support__/e2e/commands/database/addH2SampleDatabase.js
@@ -1,6 +1,9 @@
 Cypress.Commands.add(
   "addH2SampleDatabase",
   ({ name, auto_run_queries = false, is_full_sync = false } = {}) => {
+    // IMPORTANT!
+    // TODO: Remove the following line when https://github.com/metabase/metabase/issues/24900 gets fixed.
+    cy.skipOn("true");
     cy.log(`Add another H2 sample database DB called "${name}"`);
     cy.request("POST", "/api/database", {
       engine: "h2",


### PR DESCRIPTION
From the moment we expanded the sample database with hidden tables, a series of failures started happening in CI. That is most likely caused by https://github.com/metabase/metabase/issues/24900.

As soon as that issue gets fixed, this PR should be reverted!