### PR TITLE
[E2E] Skip test that manually adds H2 database

### DIFF
--- a/frontend/test/metabase/scenarios/question/new.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/new.cy.spec.js
@@ -22,19 +22,10 @@ describe("scenarios > question > new", () => {
   });
 
   describe("data picker", () => {
-    it.skip("data selector popover should not be too small (metabase#15591)", () => {
+    it("data selector popover should not be too small (metabase#15591)", () => {
       // Add 10 more databases
       for (let i = 0; i < 10; i++) {
-        cy.request("POST", "/api/database", {
-          engine: "h2",
-          name: "Sample" + i,
-          details: {
-            db: "zip:./target/uberjar/metabase.jar!/sample-database.db;USER=GUEST;PASSWORD=guest",
-          },
-          auto_run_queries: false,
-          is_full_sync: false,
-          schedules: {},
-        });
+        cy.addH2SampleDatabase({ name: "Sample" + i });
       }
 
       startNewQuestion();

--- a/frontend/test/metabase/scenarios/question/new.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/new.cy.spec.js
@@ -22,7 +22,7 @@ describe("scenarios > question > new", () => {
   });
 
   describe("data picker", () => {
-    it("data selector popover should not be too small (metabase#15591)", () => {
+    it.skip("data selector popover should not be too small (metabase#15591)", () => {
       // Add 10 more databases
       for (let i = 0; i < 10; i++) {
         cy.request("POST", "/api/database", {


### PR DESCRIPTION
This PR has the same goal as https://github.com/metabase/metabase/pull/25150, but that PR didn't take into account a manual request that adds H2 sample database.
The proof that the problem wasn't fully solved is this failure: https://github.com/metabase/metabase/runs/8120360796?check_suite_focus=true

This PR fixes that.

After this PR, all attempts to add another H2 sample database should be skipped.

