### PR TITLE
Really use the alternate names for the release container

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,11 +107,11 @@ jobs:
     - name: Determine the target Docker Hub repository
       run: |
         if [[ ${{ github.ref_name }} == v1* ]]; then
-          echo "Metabase EE: image is going to be pushed to ${{ github.repository_owner }}/Metabase-enterprise"
-          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/metabase-enterprise" >> $GITHUB_ENV
+          echo "Metabase EE: image is going to be pushed to ${{ github.repository_owner }}/test-metabase-enterprise"
+          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/test-metabase-enterprise" >> $GITHUB_ENV
         else
-          echo "Metabase OSS: image is going to be pushed to ${{ github.repository_owner }}/Metabase"
-          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/metabase" >> $GITHUB_ENV
+          echo "Metabase OSS: image is going to be pushed to ${{ github.repository_owner }}/test-metabase"
+          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/test-metabase" >> $GITHUB_ENV
         fi
 
 


### PR DESCRIPTION
Unfortunately the previous attempt in PR #24885 is flawed for two reasons:
* it did not actually change the image name (only in the console/stdout message)
* the name with uppercase letters will be rejected anyway by Docker Hub

This new PR remedies that, the image names are now `metabase/test-metabase` and `metabase/test-metabase-enterprise` (we'll remove them once this investigation reaches its conclusion).

![image](https://user-images.githubusercontent.com/7288/187829823-297b7f47-8ed9-4cd2-8ab8-a07d64f48101.png)
