### PR TITLE
Fix boolean fields for public questions

### DIFF
--- a/frontend/src/metabase/public/containers/PublicQuestion.jsx
+++ b/frontend/src/metabase/public/containers/PublicQuestion.jsx
@@ -62,7 +62,6 @@ class PublicQuestion extends Component {
       setErrorPage,
       params: { uuid, token },
       location: { query },
-      metadata,
     } = this.props;
 
     if (uuid) {
@@ -82,15 +81,15 @@ class PublicQuestion extends Component {
       }
 
       if (card.param_values) {
-        this.props.addParamValues(card.param_values);
+        await this.props.addParamValues(card.param_values);
       }
       if (card.param_fields) {
-        this.props.addFields(card.param_fields);
+        await this.props.addFields(card.param_fields);
       }
 
       const parameters = getCardUiParameters(
         card,
-        metadata,
+        this.props.metadata,
         {},
         card.parameters || undefined,
       );


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/22591

The issue was that `metadata` was updated by async actions, but the old object was used in other methods.

How to test:
- Follow the steps from the issue. Please note that you would need to connect to a PostgreSQL db since it isn't possible to add a field filter for H2 boolean fields. You can run a new db via `docker run --name postgres -e POSTGRES_PASSWORD=postgres -p 5432:5432 -d postgres`
