### PR TITLE
Support data app bookmarks

### DIFF
--- a/frontend/src/metabase-types/api/bookmark.ts
+++ b/frontend/src/metabase-types/api/bookmark.ts
@@ -9,6 +9,9 @@ export interface Bookmark {
   name: string;
   type: BookmarkType;
 
+  // For questions and models
+  dataset?: boolean;
+
   // For data app collections
   app_id?: number;
 }

--- a/frontend/src/metabase-types/api/bookmark.ts
+++ b/frontend/src/metabase-types/api/bookmark.ts
@@ -8,4 +8,7 @@ export interface Bookmark {
   item_id: number;
   name: string;
   type: BookmarkType;
+
+  // For data app collections
+  app_id?: number;
 }

--- a/frontend/src/metabase/entities/bookmarks.js
+++ b/frontend/src/metabase/entities/bookmarks.js
@@ -111,6 +111,10 @@ function getIcon(bookmark) {
   return bookmarkEntity.objectSelectors.getIcon(bookmark);
 }
 
+export function isDataAppBookmark(bookmark) {
+  return bookmark.type === "collection" && typeof bookmark.app_id === "number";
+}
+
 export const getOrderedBookmarks = createSelector(
   [Bookmarks.selectors.getList],
   bookmarks => _.sortBy(bookmarks, bookmark => bookmark.index),

--- a/frontend/src/metabase/lib/urls/bookmarks.ts
+++ b/frontend/src/metabase/lib/urls/bookmarks.ts
@@ -1,5 +1,7 @@
 import slugg from "slugg";
 
+import { isDataAppBookmark } from "metabase/entities/bookmarks";
+
 import { Bookmark, DataApp } from "metabase-types/api";
 
 import { dataApp } from "./dataApps";
@@ -10,10 +12,6 @@ function getBookmarkBasePath(bookmark: Bookmark) {
     return bookmark.dataset ? "model" : "question";
   }
   return bookmark.type;
-}
-
-function isDataAppBookmark(bookmark: Bookmark) {
-  return bookmark.type === "collection" && typeof bookmark.app_id === "number";
 }
 
 export function bookmark(bookmark: Bookmark) {

--- a/frontend/src/metabase/lib/urls/bookmarks.ts
+++ b/frontend/src/metabase/lib/urls/bookmarks.ts
@@ -1,0 +1,10 @@
+import slugg from "slugg";
+
+import { Bookmark } from "metabase-types/api";
+
+import { appendSlug } from "./utils";
+
+export function bookmark({ id, type, name }: Bookmark) {
+  const [, idInteger] = id.split("-");
+  return `/${type}/${appendSlug(idInteger, slugg(name))}`;
+}

--- a/frontend/src/metabase/lib/urls/bookmarks.ts
+++ b/frontend/src/metabase/lib/urls/bookmarks.ts
@@ -1,7 +1,8 @@
 import slugg from "slugg";
 
-import { Bookmark } from "metabase-types/api";
+import { Bookmark, DataApp } from "metabase-types/api";
 
+import { dataApp } from "./dataApps";
 import { appendSlug } from "./utils";
 
 function getBookmarkBasePath(bookmark: Bookmark) {
@@ -11,8 +12,20 @@ function getBookmarkBasePath(bookmark: Bookmark) {
   return bookmark.type;
 }
 
+function isDataAppBookmark(bookmark: Bookmark) {
+  return bookmark.type === "collection" && typeof bookmark.app_id === "number";
+}
+
 export function bookmark(bookmark: Bookmark) {
   const [, itemId] = bookmark.id.split("-");
+
+  if (isDataAppBookmark(bookmark)) {
+    return dataApp(
+      { id: bookmark.app_id, collection: { name: bookmark.name } } as DataApp,
+      { mode: "preview" },
+    );
+  }
+
   const basePath = getBookmarkBasePath(bookmark);
   const itemPath = appendSlug(itemId, slugg(bookmark.name));
   return `/${basePath}/${itemPath}`;

--- a/frontend/src/metabase/lib/urls/bookmarks.ts
+++ b/frontend/src/metabase/lib/urls/bookmarks.ts
@@ -4,7 +4,16 @@ import { Bookmark } from "metabase-types/api";
 
 import { appendSlug } from "./utils";
 
-export function bookmark({ id, type, name }: Bookmark) {
-  const [, idInteger] = id.split("-");
-  return `/${type}/${appendSlug(idInteger, slugg(name))}`;
+function getBookmarkBasePath(bookmark: Bookmark) {
+  if (bookmark.type === "card") {
+    return bookmark.dataset ? "model" : "question";
+  }
+  return bookmark.type;
+}
+
+export function bookmark(bookmark: Bookmark) {
+  const [, itemId] = bookmark.id.split("-");
+  const basePath = getBookmarkBasePath(bookmark);
+  const itemPath = appendSlug(itemId, slugg(bookmark.name));
+  return `/${basePath}/${itemPath}`;
 }

--- a/frontend/src/metabase/lib/urls/index.ts
+++ b/frontend/src/metabase/lib/urls/index.ts
@@ -1,4 +1,5 @@
 export * from "./admin";
+export * from "./bookmarks";
 export * from "./browse";
 export * from "./collections";
 export * from "./dashboards";

--- a/frontend/src/metabase/lib/urls/misc.js
+++ b/frontend/src/metabase/lib/urls/misc.js
@@ -1,19 +1,11 @@
-import slugg from "slugg";
-
 import { dashboard } from "./dashboards";
 import { question, dataset, tableRowsQuery } from "./questions";
 import { pulse } from "./pulses";
-import { appendSlug } from "./utils";
 
 export const exportFormats = ["csv", "xlsx", "json"];
 
 export function accountSettings() {
   return "/account/profile";
-}
-
-export function bookmark({ id, type, name }) {
-  const [, idInteger] = id.split("-");
-  return `/${type}/${appendSlug(idInteger, slugg(name))}`;
 }
 
 function prepareModel(item) {

--- a/frontend/src/metabase/nav/containers/MainNavbar/BookmarkList/BookmarkList.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/BookmarkList/BookmarkList.tsx
@@ -14,7 +14,7 @@ import Tooltip from "metabase/components/Tooltip";
 
 import { Bookmark } from "metabase-types/api";
 import { PLUGIN_COLLECTIONS } from "metabase/plugins";
-import Bookmarks from "metabase/entities/bookmarks";
+import Bookmarks, { isDataAppBookmark } from "metabase/entities/bookmarks";
 import * as Urls from "metabase/lib/urls";
 
 import { SelectedItem } from "../types";
@@ -52,6 +52,20 @@ interface BookmarkItemProps {
 const BOOKMARKS_INITIALLY_VISIBLE =
   localStorage.getItem("shouldDisplayBookmarks") !== "false";
 
+function isBookmarkSelected(bookmark: Bookmark, selectedItem?: SelectedItem) {
+  if (!selectedItem) {
+    return false;
+  }
+  if (isDataAppBookmark(bookmark)) {
+    return (
+      selectedItem.type === "data-app" && selectedItem.id === bookmark.app_id
+    );
+  }
+  return (
+    bookmark.type === selectedItem.type && bookmark.item_id === selectedItem.id
+  );
+}
+
 const BookmarkItem = ({
   bookmark,
   index,
@@ -60,9 +74,7 @@ const BookmarkItem = ({
   onSelect,
   onDeleteBookmark,
 }: BookmarkItemProps) => {
-  const { id, item_id, name, type } = bookmark;
-  const isSelected =
-    selectedItem && selectedItem.type === type && selectedItem.id === item_id;
+  const isSelected = isBookmarkSelected(bookmark, selectedItem);
   const url = Urls.bookmark(bookmark);
   const icon = Bookmarks.objectSelectors.getIcon(bookmark);
   const onRemove = () => onDeleteBookmark(bookmark);
@@ -74,7 +86,7 @@ const BookmarkItem = ({
   return (
     <SortableBookmarkItem index={index} key={bookmark.id}>
       <SidebarBookmarkItem
-        key={`bookmark-${id}`}
+        key={`bookmark-${bookmark.id}`}
         url={url}
         icon={icon}
         isSelected={isSelected}
@@ -90,7 +102,7 @@ const BookmarkItem = ({
           </button>
         }
       >
-        {name}
+        {bookmark.name}
       </SidebarBookmarkItem>
     </SortableBookmarkItem>
   );

--- a/frontend/test/metabase/lib/urls.unit.spec.js
+++ b/frontend/test/metabase/lib/urls.unit.spec.js
@@ -1,4 +1,5 @@
 import {
+  bookmark,
   browseDatabase,
   collection,
   dashboard,
@@ -216,6 +217,51 @@ describe("urls", () => {
           personal_owner_id: 1,
         }),
       ).toBe("/collection/1-john-doe-s-personal-collection");
+    });
+  });
+
+  describe("bookmarks", () => {
+    it("returns card bookmark path", () => {
+      expect(
+        bookmark({
+          id: "card-5",
+          dataset: false,
+          name: "Orders",
+          type: "card",
+        }),
+      ).toBe("/card/5-orders");
+    });
+
+    it("returns model bookmark path", () => {
+      expect(
+        bookmark({
+          id: "card-1",
+          dataset: true,
+          name: "Product",
+          type: "card",
+        }),
+      ).toBe("/card/1-product");
+    });
+
+    it("returns dashboard bookmark path", () => {
+      expect(
+        bookmark({
+          id: "dashboard-3",
+          name: "Shop Stats",
+          type: "dashboard",
+        }),
+      ).toBe("/dashboard/3-shop-stats");
+    });
+
+    it("returns collection bookmark path", () => {
+      expect(
+        bookmark({
+          id: "collection-8",
+          item_id: 8,
+          name: "Growth",
+          type: "collection",
+        }),
+      ).toBe("/collection/8-growth");
     });
   });
 

--- a/frontend/test/metabase/lib/urls.unit.spec.js
+++ b/frontend/test/metabase/lib/urls.unit.spec.js
@@ -263,6 +263,18 @@ describe("urls", () => {
         }),
       ).toBe("/collection/8-growth");
     });
+
+    it("returns data app bookmark path", () => {
+      expect(
+        bookmark({
+          id: "collection-3",
+          item_id: 3,
+          name: "Shop",
+          type: "collection",
+          app_id: 14,
+        }),
+      ).toBe("/apps/14-shop");
+    });
   });
 
   describe("extractEntityId", () => {

--- a/frontend/test/metabase/lib/urls.unit.spec.js
+++ b/frontend/test/metabase/lib/urls.unit.spec.js
@@ -229,7 +229,7 @@ describe("urls", () => {
           name: "Orders",
           type: "card",
         }),
-      ).toBe("/card/5-orders");
+      ).toBe("/question/5-orders");
     });
 
     it("returns model bookmark path", () => {
@@ -240,7 +240,7 @@ describe("urls", () => {
           name: "Product",
           type: "card",
         }),
-      ).toBe("/card/1-product");
+      ).toBe("/model/1-product");
     });
 
     it("returns dashboard bookmark path", () => {


### PR DESCRIPTION
Part of #25173 issue and #24861 epic

Adds proper support for bookmarked data apps. Since data apps are technically built on top of collections, we could inherit the bookmarking logic from collections. This PR just makes Metabase handle data app bookmarks (build proper URLs + highlight data app in bookmarks list when it's open).

Also converts `Urls.bookmark` to TypeScript and adds some unit-test coverage. Also fixed we were using `/card` paths for questions and models. Not a big deal as our router and QB would replace the URL with the correct one

### To Verify

1. + New > App > Fill in the details > Create
2. Bookmark the app the same way you'd do that for collections
3. Open any other page with a nav sidebar available
4. Click your app in the bookmarks list
5. Ensure you're at `/apps/:appId-:appName`
6. Ensure the app bookmark item is highlighted in the sidebar