### PR TITLE
[E2E] Handle #17450 failures

### DIFF
--- a/frontend/test/metabase/scenarios/admin/databases/add-external.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/add-external.cy.spec.js
@@ -8,12 +8,19 @@ describe("admin > database > add > external databases", () => {
     cy.intercept("POST", "/api/database").as("createDatabase");
   });
 
-  it("should add Postgres database and redirect to listing", () => {
+  it("should add Postgres database and redirect to listing (metabase#17450)", () => {
     cy.visit("/admin/databases/create");
     cy.contains("Database type").closest(".Form-field").find("a").click();
     cy.contains("PostgreSQL").click({ force: true });
+
     cy.findByText("Show advanced options").click();
     cy.contains("Additional JDBC connection string options");
+    // Reproduces metabase#17450
+    cy.findByLabelText("Choose when syncs and scans happen")
+      .click()
+      .should("have.attr", "aria-checked", "true");
+
+    isSyncOptionSelected("Never, I'll do this manually if I need to");
 
     typeAndBlurUsingLabel("Display name", "QA Postgres12");
     typeAndBlurUsingLabel("Host", "localhost");
@@ -22,20 +29,31 @@ describe("admin > database > add > external databases", () => {
     typeAndBlurUsingLabel("Username", "metabase");
     typeAndBlurUsingLabel("Password", "metasample123");
 
-    cy.findByText("Save").should("not.be.disabled").click();
+    cy.button("Save").should("not.be.disabled").click();
 
     cy.wait("@createDatabase");
 
     cy.url().should("match", /\/admin\/databases\?created=true$/);
 
-    cy.findByRole("table").within(() => {
-      cy.findByText("QA Postgres12");
-    });
+    cy.findByText("We're taking a look at your database!");
+    cy.findByLabelText("close icon").click();
 
     cy.findByRole("status").within(() => {
       cy.findByText("Syncing…");
       cy.findByText("Done!");
     });
+
+    cy.findByRole("table").within(() => {
+      cy.findByText("QA Postgres12").click();
+    });
+
+    cy.findByLabelText("Choose when syncs and scans happen").should(
+      "have.attr",
+      "aria-checked",
+      "true",
+    );
+
+    isSyncOptionSelected("Never, I'll do this manually if I need to");
   });
 
   it("should add Mongo database and redirect to listing", () => {
@@ -106,3 +124,8 @@ describe("admin > database > add > external databases", () => {
     });
   });
 });
+
+function isSyncOptionSelected(option) {
+  // This is a really bad way to assert that the text element is selected/active. Can it be fixed in the FE code?
+  cy.findByText(option).parent().should("have.class", "text-brand");
+}

--- a/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
@@ -165,7 +165,9 @@ describe("scenarios > admin > databases > add", () => {
     cy.findByText("Need help connecting?");
   });
 
-  it("should respect users' decision to manually sync large database (metabase#17450)", () => {
+  // TODO:
+  // Enable once https://github.com/metabase/metabase/issues/24900 gets fixed!
+  it.skip("should respect users' decision to manually sync large database (metabase#17450)", () => {
     const H2_CONNECTION_STRING =
       "zip:./target/uberjar/metabase.jar!/sample-database.db;USER=GUEST;PASSWORD=guest";
 


### PR DESCRIPTION
This is a part of the effort to reduce failures in CI caused most likely by https://github.com/metabase/metabase/issues/24900

The first attempt was https://github.com/metabase/metabase/pull/25150, but it left some tests unskipped (see: https://github.com/metabase/metabase/pull/25160). Unfortunately, there's more.

This PR handles one such case, but instead of simply skipping the whole spec, we're now reproducing #17450 using Postgres database. That way, we don't lose coverage even when the offending test is skipped.

The related failure in CI: https://github.com/metabase/metabase/runs/8133038011?check_suite_focus=true#step:10:161