### PR TITLE
Add a preferred colors for cancelled

### DIFF
--- a/frontend/src/metabase/lib/colors/groups.ts
+++ b/frontend/src/metabase/lib/colors/groups.ts
@@ -48,6 +48,9 @@ export const getPreferredColor = (key: string) => {
     case "active":
     case "profit":
       return color("success");
+    case "cancel":
+    case "canceled":
+    case "cancelled":
     case "error":
     case "fail":
     case "failed":


### PR DESCRIPTION
Slack message https://metaboat.slack.com/archives/C01LQQ2UW03/p1662046327519899

Add a prefereed color for `cancelled`, `canceled`, and `cancel` words. That's an instant nice-to-have tweak but the proper solution will be to calculate similarity of colors to avoid situations like that.

## How to verify 

Save the query:
```
select 'active'
union all select 'cancelled'
union all select 'in trial'
```

- Click "Explore results"
- Click on the column header -> Distribution -> Change the visualization to Pie chart
- Ensure `active` is green and `cancelled` is red

Before
<img width="983" alt="Screen Shot 2022-09-01 at 8 38 19 PM" src="https://user-images.githubusercontent.com/14301985/187967140-d1737118-5334-49ee-8137-9df124adab0f.png">

After
<img width="1184" alt="Screen Shot 2022-09-01 at 8 43 57 PM" src="https://user-images.githubusercontent.com/14301985/187968110-6e6dedc2-4b76-4306-8dee-8a952863179a.png">
