### PR TITLE
Return app collections as apps, page dashboards as pages

### DIFF
--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -43,11 +43,13 @@
 (def model-to-db-model
   "Mapping from string model to the Toucan model backing it."
   {"dashboard"  Dashboard
+   "page"       Dashboard
    "metric"     Metric
    "segment"    Segment
    "card"       Card
    "dataset"    Card
    "collection" Collection
+   "app"        Collection
    "table"      Table
    "pulse"      Pulse
    "database"   Database})
@@ -55,7 +57,7 @@
 (def all-models
   "All valid models to search for. The order of this list also influences the order of the results: items earlier in the
   list will be ranked higher."
-  ["dashboard" "metric" "segment" "card" "dataset" "collection" "table" "pulse" "database"])
+  ["dashboard" "page" "metric" "segment" "card" "dataset" "collection" "app" "table" "pulse" "database"])
 
 (def ^:const displayed-columns
   "All of the result components that by default are displayed by the frontend."
@@ -80,6 +82,10 @@
   [_]
   [:name
    :description])
+
+(defmethod searchable-columns-for-model "page"
+  [_]
+  (searchable-columns-for-model "dashboard"))
 
 (defmethod searchable-columns-for-model "database"
   [_]

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -78,6 +78,10 @@
    :dataset_query
    :description])
 
+(defmethod searchable-columns-for-model "dataset"
+  [_]
+  (searchable-columns-for-model "card"))
+
 (defmethod searchable-columns-for-model "dashboard"
   [_]
   [:name

--- a/test/metabase/api/search_test.clj
+++ b/test/metabase/api/search_test.clj
@@ -622,13 +622,21 @@
                     (not (#{"metric" "segment"} (:model result))) (assoc-in [:collection :app_id] true)
                     (= (:model result) "collection")              (assoc :model "app" :app_id true)))
                 (default-results-with-collection))
-               (search-request-data :rasta :q "test")))))))
+               (search-request-data :rasta :q "test"))))))
+  (testing "App collections should filterable as \"app\""
+    (mt/with-temp* [Collection [collection {:name "App collection to find"}]
+                    App [_ {:collection_id (:id collection)}]
+                    Collection [_ {:name "Another collection to find"}]]
+      (is (partial= [(assoc (select-keys collection [:name])
+                            :model "app")]
+             (search-request-data :rasta :q "find" :models "app"))))))
 
 (deftest page-test
   (testing "Search results should pages with model \"page\""
-    (mt/with-temp* [Dashboard [_page {:name        "Page"
-                                      :description "Contains important text!"
-                                      :is_app_page true}]]
-      (is (partial= [{:name "Page"
-                      :model "page"}]
-                    (search-request-data :rasta :q "important text"))))))
+    (mt/with-temp* [Dashboard [_ {:name "Not a page but contains important text!"}]
+                    Dashboard [page {:name        "Page"
+                                     :description "Contains important text!"
+                                     :is_app_page true}]]
+      (is (partial= [(assoc (select-keys page [:name :description])
+                            :model "page")]
+                    (search-request-data :rasta :q "important text" :models "page"))))))

--- a/test/metabase/api/search_test.clj
+++ b/test/metabase/api/search_test.clj
@@ -618,6 +618,15 @@
                 (fn [result]
                   (cond-> result
                     (not (#{"metric" "segment"} (:model result))) (assoc-in [:collection :app_id] true)
-                    (= (:model result) "collection")              (assoc :app_id true)))
+                    (= (:model result) "collection")              (assoc :model "app" :app_id true)))
                 (default-results-with-collection))
                (search-request-data :rasta :q "test")))))))
+
+(deftest page-test
+  (testing "Search results should pages with model \"page\""
+    (mt/with-temp* [Dashboard [_page {:name        "Page"
+                                      :description "Contains important text!"
+                                      :is_app_page true}]]
+      (is (partial= [{:name "Page"
+                      :model "page"}]
+                    (search-request-data :rasta :q "important text"))))))


### PR DESCRIPTION
Fixes #25176.

App collections and  app pages are returned with and can be searched for
as model `"app"` and model `"page"` respectively.

This PR also fixes searching for datasets by their descriptions.