### PR TITLE
[Apps] Allow extra parameters to be passed to action execution

### DIFF
--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -691,21 +691,28 @@
 
 ;;; ---------------------------------- Executing the action associated with a Dashcard -------------------------------
 
+(def ParameterWithIDOrTarget
+  "Schema for a parameter map with an string `:id`."
+  (su/with-api-error-message
+    {(s/optional-key :id)       su/NonBlankString
+     (s/optional-key :target)   [s/Any]
+     s/Keyword s/Any}
+    "value must be a parameter map with an 'id' key"))
+
+(api/defendpoint POST "/:dashboard-id/dashcard/:dashcard-id/action/:action-id/execute"
+  "Execute the associated Action in the context of a `Dashboard` and `DashboardCard` that includes it."
+  [dashboard-id dashcard-id action-id :as {{:keys [parameters], :as _body} :body}]
+  {parameters (s/maybe [ParameterWithIDOrTarget])}
+  (actions.execution/execute-dashcard! action-id dashboard-id dashcard-id parameters))
+
+;;; ---------------------------------- Running the query associated with a Dashcard ----------------------------------
+
 (def ParameterWithID
   "Schema for a parameter map with an string `:id`."
   (su/with-api-error-message
     {:id       su/NonBlankString
      s/Keyword s/Any}
     "value must be a parameter map with an 'id' key"))
-
-
-(api/defendpoint POST "/:dashboard-id/dashcard/:dashcard-id/action/:action-id/execute"
-  "Execute the associated Action in the context of a `Dashboard` and `DashboardCard` that includes it."
-  [dashboard-id dashcard-id action-id :as {{:keys [parameters], :as _body} :body}]
-  {parameters (s/maybe [ParameterWithID])}
-  (actions.execution/execute-dashcard! action-id dashboard-id dashcard-id parameters))
-
-;;; ---------------------------------- Running the query associated with a Dashcard ----------------------------------
 
 (api/defendpoint POST "/:dashboard-id/dashcard/:dashcard-id/card/:card-id/query"
   "Run the query associated with a Saved Question (`Card`) in the context of a `Dashboard` that includes it."

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -692,12 +692,12 @@
 ;;; ---------------------------------- Executing the action associated with a Dashcard -------------------------------
 
 (def ParameterWithIDOrTarget
-  "Schema for a parameter map with an string `:id`."
+  "Schema for a parameter map with a string `:id` or mbql `:target`."
   (su/with-api-error-message
     {(s/optional-key :id)       su/NonBlankString
      (s/optional-key :target)   [s/Any]
      s/Keyword s/Any}
-    "value must be a parameter map with an 'id' key"))
+    "value must be a parameter map with an 'id' or 'target' key"))
 
 (api/defendpoint POST "/:dashboard-id/dashcard/:dashcard-id/action/:action-id/execute"
   "Execute the associated Action in the context of a `Dashboard` and `DashboardCard` that includes it."

--- a/test/metabase/actions/test_util.clj
+++ b/test/metabase/actions/test_util.clj
@@ -120,14 +120,24 @@
                                            :dataset_query {:database (mt/id)
                                                            :type     :native
                                                            :native   {:query         (str "UPDATE categories\n"
-                                                                                          "SET name = 'Bird Shop'\n"
+                                                                                          "SET name = [[{{name}} || ' ' ||]] 'Shop'\n"
                                                                                           "WHERE id = {{id}}")
                                                                       :template-tags {"id" {:name         "id"
                                                                                             :display-name "ID"
                                                                                             :type         :number
-                                                                                            :required     true}}}}
+                                                                                            :required     true}
+                                                                                      "name" {:name         "name"
+                                                                                              :display-name "Name"
+                                                                                              :type         :text
+                                                                                              :required     false}}}}
                                            :name          "Query Example"
-                                           :parameters    [{:id "id" :type "number"}]
+                                           :parameters    [{:id "id"
+                                                            :type "number"
+                                                            :target [:variable [:template-tag "id"]]}
+                                                           {:id "name"
+                                                            :type "text"
+                                                            :required false
+                                                            :target [:variable [:template-tag "name"]]}]
                                            :is_write      true
                                            :visualization_settings {:inline true}}
                                           (dissoc options-map :type))]]
@@ -144,8 +154,12 @@
                                                     :method "POST"
                                                     :body "{\"the_parameter\": {{id}}}"
                                                     :headers "{\"x-test\": \"{{id}}\"}"
-                                                    :parameters [{:id "id" :type "number"}
-                                                                 {:id "fail" :type "text"}]}
+                                                    :parameters [{:id "id"
+                                                                  :type "number"
+                                                                  :target [:template-tag "id"]}
+                                                                 {:id "fail"
+                                                                  :type "text"
+                                                                  :target [:template-tag "fail"]}]}
                                          :response_handle ".body"}
                                         options-map))]
         (f {:action-id action-id})))))

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -1884,12 +1884,23 @@
                                        dashboard-id
                                        dashcard-id
                                        action-id)]
-              (is (partial= {:rows-affected 1}
-                            (mt/user-http-request :crowberto :post 200 execute-path
-                                                  {:parameters [{:id "my_id" :type "id" :value 1}]})))
-              (is (= [1 "Bird Shop"]
-                     (mt/first-row
-                       (mt/run-mbql-query categories {:filter [:= $id 1]}))))
+              (testing "Dashcard parameter"
+                (is (partial= {:rows-affected 1}
+                              (mt/user-http-request :crowberto :post 200 execute-path
+                                                    {:parameters [{:id "my_id" :type "id" :value 1}]})))
+                (is (= [1 "Shop"]
+                       (mt/first-row
+                         (mt/run-mbql-query categories {:filter [:= $id 1]})))))
+              (testing "Extra target parameter"
+                (is (partial= {:rows-affected 1}
+                              (mt/user-http-request :crowberto :post 200 execute-path
+                                                    {:parameters [{:id "my_id" :type "id" :value 1}
+                                                                  {:target [:variable [:template-tag "name"]]
+                                                                   :type "text"
+                                                                   :value "Bird"}]})))
+                (is (= [1 "Bird Shop"]
+                       (mt/first-row
+                         (mt/run-mbql-query categories {:filter [:= $id 1]})))))
               (testing "Should affect 0 rows if id is out of range"
                 (is (= {:rows-affected 0}
                        (mt/user-http-request :crowberto :post 200 execute-path

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -1880,10 +1880,9 @@
                                                             :action_id action-id
                                                             :parameter_mappings [{:parameter_id "my_id"
                                                                                   :target [:variable [:template-tag "id"]]}]}]]
-            (let [execute-path (format "dashboard/%s/dashcard/%s/action/%s/execute"
+            (let [execute-path (format "dashboard/%s/dashcard/%s/action/execute"
                                        dashboard-id
-                                       dashcard-id
-                                       action-id)]
+                                       dashcard-id)]
               (testing "Dashcard parameter"
                 (is (partial= {:rows-affected 1}
                               (mt/user-http-request :crowberto :post 200 execute-path
@@ -1894,10 +1893,10 @@
               (testing "Extra target parameter"
                 (is (partial= {:rows-affected 1}
                               (mt/user-http-request :crowberto :post 200 execute-path
-                                                    {:parameters [{:id "my_id" :type "id" :value 1}
-                                                                  {:target [:variable [:template-tag "name"]]
-                                                                   :type "text"
-                                                                   :value "Bird"}]})))
+                                                    {:parameters [{:id "my_id" :type "id" :value 1}]
+                                                     :extra-parameters [{:target [:variable [:template-tag "name"]]
+                                                                         :type "text"
+                                                                         :value "Bird"}]})))
                 (is (= [1 "Bird Shop"]
                        (mt/first-row
                          (mt/run-mbql-query categories {:filter [:= $id 1]})))))
@@ -1934,10 +1933,9 @@
                                                                                   :target [:template-tag "id"]}
                                                                                  {:parameter_id "my_fail"
                                                                                   :target [:template-tag "fail"]}]}]]
-            (let [execute-path (format "dashboard/%s/dashcard/%s/action/%s/execute"
+            (let [execute-path (format "dashboard/%s/dashcard/%s/action/execute"
                                        dashboard-id
-                                       dashcard-id
-                                       action-id)]
+                                       dashcard-id)]
               (testing "Should be able to execute an emitter"
                 (is (= {:the_parameter 1}
                        (mt/user-http-request :crowberto :post 200 execute-path

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -1894,7 +1894,7 @@
                 (is (partial= {:rows-affected 1}
                               (mt/user-http-request :crowberto :post 200 execute-path
                                                     {:parameters [{:id "my_id" :type "id" :value 1}]
-                                                     :extra-parameters [{:target [:variable [:template-tag "name"]]
+                                                     :extra_parameters [{:target [:variable [:template-tag "name"]]
                                                                          :type "text"
                                                                          :value "Bird"}]})))
                 (is (= [1 "Bird Shop"]
@@ -1906,10 +1906,9 @@
                                              {:parameters [{:id "my_id" :type  :number/= :value Integer/MAX_VALUE}]}))))
               (testing "Should 404 if bad dashcard-id"
                 (is (= "Not found."
-                       (mt/user-http-request :crowberto :post 404 (format "dashboard/%d/dashcard/%s/action/%s/execute"
+                       (mt/user-http-request :crowberto :post 404 (format "dashboard/%d/dashcard/%s/action/execute"
                                                                           dashboard-id
-                                                                          Integer/MAX_VALUE
-                                                                          action-id)
+                                                                          Integer/MAX_VALUE)
                                              {}))))
               (testing "Missing parameter should fail gracefully"
                 (is (partial= {:message "Error executing Action: Error building query parameter map: Error determining value for parameter \"id\": You'll need to pick a value for 'ID' before this query can run."}
@@ -1967,10 +1966,9 @@
                                                           :action_id action-id
                                                           :parameter_mappings [{:parameter_id "my_id"
                                                                                 :target [:variable [:template-tag "id"]]}]}]]
-          (let [execute-path (format "dashboard/%s/dashcard/%s/action/%s/execute"
+          (let [execute-path (format "dashboard/%s/dashcard/%s/action/execute"
                                      dashboard-id
-                                     dashcard-id
-                                     action-id)]
+                                     dashcard-id)]
             (testing "Without actions enabled"
               (is (= "Actions are not enabled."
                      (mt/user-http-request :crowberto :post 400 execute-path

--- a/test/metabase/api/emitter_test.clj
+++ b/test/metabase/api/emitter_test.clj
@@ -72,7 +72,7 @@
                      (mt/user-http-request :crowberto :post 200 emitter-path
                                            {:parameters {"my_id" {:type  :number/=
                                                                   :value 1}}}))))
-            (is (= [1 "Bird Shop"]
+            (is (= [1 "Shop"]
                    (mt/first-row
                      (mt/run-mbql-query categories {:filter [:= $id 1]}))))
             (testing "Should affect 0 rows if id is out of range"


### PR DESCRIPTION
For actions, unlike queries, the user will be asked to fill in unmapped
parameters. This change allows the dashboard action execution to accept
incoming parameters without an "id" but with a "target". If that target
exists on the action, it will be accepted.