### PR TITLE
pie chart tweaks

### DIFF
--- a/frontend/src/metabase/lib/colors/index.ts
+++ b/frontend/src/metabase/lib/colors/index.ts
@@ -1,12 +1,1 @@
-export {
-  color,
-  alpha,
-  lighten,
-  darken,
-  tint,
-  shade,
-  hueRotate,
-  isLight,
-  isDark,
-  getTextColorForBackground,
-} from "./palette";
+export * from "./palette";

--- a/frontend/src/metabase/lib/colors/palette.ts
+++ b/frontend/src/metabase/lib/colors/palette.ts
@@ -155,25 +155,13 @@ const LIGHT_HSL_RANGES = [
 ];
 
 export const getTextColorForBackground = (backgroundColor: string) => {
-  const colorObject = Color(color(backgroundColor));
-  const hslColor = [
-    colorObject.hue(),
-    colorObject.saturationl(),
-    colorObject.lightness(),
-  ];
-
-  if (
-    LIGHT_HSL_RANGES.some(hslRanges => {
-      return hslRanges.every((range, index) => {
-        const [start, end] = range;
-        const colorComponentValue = hslColor[index];
-
-        return colorComponentValue >= start && colorComponentValue <= end;
-      });
-    })
-  ) {
-    return color("text-dark");
-  }
-
-  return color("white");
+  const whiteTextContrast = Color(color(backgroundColor)).contrast(
+    Color(color("white")),
+  );
+  const darkTextContrast = Color(color(backgroundColor)).contrast(
+    Color(color("text-dark")),
+  );
+  return whiteTextContrast > darkTextContrast
+    ? color("white")
+    : color("text-dark");
 };

--- a/frontend/src/metabase/visualizations/components/ChartWithLegend.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartWithLegend.jsx
@@ -82,7 +82,7 @@ class ChartWithLegend extends Component {
       type = "vertical";
       LegendComponent = LegendHorizontal;
       legendTitles = legendTitles.map(title =>
-        Array.isArray(title) ? title[0] : title,
+        Array.isArray(title) ? title.join(" – ") : title,
       );
       const desiredHeight = width * (1 / aspectRatio);
       if (desiredHeight > height * (3 / 4)) {

--- a/frontend/src/metabase/visualizations/visualizations/PieChart/PieChart.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PieChart/PieChart.jsx
@@ -121,6 +121,7 @@ export default class PieChart extends Component {
       section: t`Display`,
       title: t`Show legend`,
       widget: "toggle",
+      default: true,
     },
     "pie.show_legend_perecent": {
       section: t`Display`,
@@ -233,7 +234,8 @@ export default class PieChart extends Component {
   };
 
   updateChartViewportSize = () => {
-    requestAnimationFrame(() => {
+    // Measure chart viewport dimensions in the next tick to wait for DOM elements to resize
+    setTimeout(() => {
       if (!this.chartContainer.current) {
         return;
       }


### PR DESCRIPTION

## Changes

- The pie chart legend switch was disabled by default, but the legend was visible — **fixed by making it enabled by default**
- Show percentages in legend when it is rendered below the chart
- Choose text color based on WCAG color contrast instead of a custom algorithm
- Fix a bit more resizing glitches

<img width="390" alt="Screen Shot 2022-09-02 at 4 05 17 PM" src="https://user-images.githubusercontent.com/14301985/188139283-c8b54b06-f7a9-44b1-9a71-c60f1602092b.png">
