### PR TITLE
Fetch pages instead of dashboards for app sidebar

### DIFF
--- a/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbarContainer.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbarContainer.tsx
@@ -17,7 +17,7 @@ import { MainNavbarProps, MainNavbarOwnProps, SelectedItem } from "./types";
 import NavbarLoadingView from "./NavbarLoadingView";
 import DataAppNavbarView from "./DataAppNavbarView";
 
-const FETCHING_SEARCH_MODELS = ["dashboard", "dataset", "card"];
+const FETCHING_SEARCH_MODELS = ["page"];
 const LIMIT = 100;
 
 function isAtDataAppHomePage(selectedItems: SelectedItem[]) {
@@ -63,9 +63,7 @@ function DataAppNavbarContainer({
       return [
         {
           type: "data-app-page",
-          id: getDataAppHomePageId(
-            items.filter(item => item.model === "dashboard"),
-          ),
+          id: getDataAppHomePageId(items),
         },
       ];
     }


### PR DESCRIPTION
⚠️ BE part of the fix is in progress

Data app pages are technically dashboards with the `is_app_page: true` flag. Before #25158, various endpoints like `/api/search` were returning them with `model: "dashboard"` property. We've changed that to use `model: "page"`, but it also affected the `GET /api/collection/:id/items` endpoint. As a result, when you launch an app, the sidebar still tries to fetch dashboards, but can't find any