### PR TITLE
Support filtering by "app" and "page" models

### DIFF
--- a/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbarContainer.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbarContainer.tsx
@@ -17,7 +17,7 @@ import { MainNavbarProps, MainNavbarOwnProps, SelectedItem } from "./types";
 import NavbarLoadingView from "./NavbarLoadingView";
 import DataAppNavbarView from "./DataAppNavbarView";
 
-const FETCHING_SEARCH_MODELS = ["dashboard", "dataset", "card"];
+const FETCHING_SEARCH_MODELS = ["page"];
 const LIMIT = 100;
 
 function isAtDataAppHomePage(selectedItems: SelectedItem[]) {
@@ -63,9 +63,7 @@ function DataAppNavbarContainer({
       return [
         {
           type: "data-app-page",
-          id: getDataAppHomePageId(
-            items.filter(item => item.model === "dashboard"),
-          ),
+          id: getDataAppHomePageId(items),
         },
       ];
     }

--- a/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbarContainer.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbarContainer.tsx
@@ -29,7 +29,7 @@ type NavbarModal = "MODAL_APP_SETTINGS" | "MODAL_NEW_PAGE" | null;
 
 interface DataAppNavbarContainerProps extends MainNavbarProps {
   dataApp: DataApp;
-  items: any[];
+  pages: any[];
   selectedItems: SelectedItem[];
   onChangeLocation: (location: LocationDescriptor) => void;
 }
@@ -45,7 +45,7 @@ type SearchRenderProps = {
 
 function DataAppNavbarContainer({
   dataApp,
-  items,
+  pages,
   selectedItems,
   onChangeLocation,
   ...props
@@ -63,13 +63,13 @@ function DataAppNavbarContainer({
       return [
         {
           type: "data-app-page",
-          id: getDataAppHomePageId(items),
+          id: getDataAppHomePageId(pages),
         },
       ];
     }
 
     return selectedItems;
-  }, [items, selectedItems]);
+  }, [pages, selectedItems]);
 
   const onEditAppSettings = useCallback(() => {
     setModal("MODAL_APP_SETTINGS");
@@ -118,7 +118,7 @@ function DataAppNavbarContainer({
       <DataAppNavbarView
         {...props}
         dataApp={dataApp}
-        items={items}
+        pages={pages}
         selectedItems={finalSelectedItems}
         onNewPage={onNewPage}
         onEditAppSettings={onEditAppSettings}
@@ -150,7 +150,7 @@ function DataAppNavbarContainerLoader({
           return <NavbarLoadingView />;
         }
         return (
-          <DataAppNavbarContainer {...props} dataApp={dataApp} items={list} />
+          <DataAppNavbarContainer {...props} dataApp={dataApp} pages={list} />
         );
       }}
     </Search.ListLoader>

--- a/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbarView.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React from "react";
 import _ from "underscore";
 import { t } from "ttag";
 
@@ -25,7 +25,7 @@ import {
 
 interface Props extends MainNavbarProps {
   dataApp: DataApp;
-  items: any[];
+  pages: any[];
   selectedItems: SelectedItem[];
   onEditAppSettings: () => void;
   onNewPage: () => void;
@@ -33,16 +33,11 @@ interface Props extends MainNavbarProps {
 
 function DataAppNavbarView({
   dataApp,
-  items,
+  pages,
   selectedItems,
   onEditAppSettings,
   onNewPage,
 }: Props) {
-  const appPages = useMemo(
-    () => items.filter(item => item.model === "dashboard"),
-    [items],
-  );
-
   const { "data-app-page": dataAppPage } = _.indexBy(
     selectedItems,
     item => item.type,
@@ -56,7 +51,7 @@ function DataAppNavbarView({
             <SidebarHeading>{dataApp.collection.name}</SidebarHeading>
           </SidebarHeadingWrapper>
           <ul>
-            {appPages.map(page => (
+            {pages.map(page => (
               <PaddedSidebarLink
                 key={page.id}
                 url={Urls.dataAppPage(dataApp, page)}


### PR DESCRIPTION
Fixes #25209.

Data app pages are technically dashboards with the `is_app_page: true` flag. Before #25158, various endpoints like `/api/search` were returning them with `model: "dashboard"` property. We've changed that to use `model: "page"`, but it also affected the `GET /api/collection/:id/items` endpoint. As a result, when you launch an app, the sidebar still tries to fetch dashboards, but can't find any

### To Verify

1. "+ New" > App > Fill in details > Save
2. Select your app from the main navigation sidebar
3. Click "Launch app" button at the top right
4. Use the "Add new page" button to add a few pages to your app
5. Ensure you can see and navigate between pages in the app sidebar