### PR TITLE
Change action execution implementation

### DIFF
--- a/frontend/src/metabase-types/api/dashboard.ts
+++ b/frontend/src/metabase-types/api/dashboard.ts
@@ -97,6 +97,10 @@ export interface ArbitraryCustomDestinationClickBehavior {
   linkTextTemplate?: string;
 }
 
+export interface WritebackActionClickBehavior {
+  type: "action";
+}
+
 // Makes click handler use default drills
 // This is virtual, i.e. if a card has no clickBehavior,
 // it'd behave as if it's an "actionMenu"
@@ -111,4 +115,5 @@ export type CustomDestinationClickBehavior =
 export type ClickBehavior =
   | ActionMenuClickBehavior
   | CrossFilterClickBehavior
-  | CustomDestinationClickBehavior;
+  | CustomDestinationClickBehavior
+  | WritebackActionClickBehavior;

--- a/frontend/src/metabase-types/api/dashboard.ts
+++ b/frontend/src/metabase-types/api/dashboard.ts
@@ -94,13 +94,6 @@ export interface ArbitraryCustomDestinationClickBehavior {
   linkTextTemplate?: string;
 }
 
-export interface WritebackActionClickBehavior {
-  type: "action";
-  action: EntityId;
-  emitter_id: EntityId;
-  parameterMapping?: ClickBehaviorParameterMapping;
-}
-
 // Makes click handler use default drills
 // This is virtual, i.e. if a card has no clickBehavior,
 // it'd behave as if it's an "actionMenu"
@@ -115,5 +108,4 @@ export type CustomDestinationClickBehavior =
 export type ClickBehavior =
   | ActionMenuClickBehavior
   | CrossFilterClickBehavior
-  | CustomDestinationClickBehavior
-  | WritebackActionClickBehavior;
+  | CustomDestinationClickBehavior;

--- a/frontend/src/metabase-types/api/dashboard.ts
+++ b/frontend/src/metabase-types/api/dashboard.ts
@@ -6,8 +6,6 @@ import {
 } from "metabase-types/types/Parameter";
 import { CardId, SavedCard } from "metabase-types/types/Card";
 
-import { WritebackAction } from "./writeback";
-
 export type DashboardId = number;
 
 export interface Dashboard {
@@ -29,19 +27,18 @@ export interface Dashboard {
 
 export type DashCardId = EntityId;
 
-export type DashboardOrderedCard = {
+export type BaseDashboardOrderedCard = {
   id: DashCardId;
-  card: SavedCard;
-  card_id: CardId;
-  parameter_mappings?: DashboardParameterMapping[] | null;
-  series?: SavedCard[];
   visualization_settings?: {
     [key: string]: unknown;
   };
+};
 
-  // Only for action buttons
-  action_id: number | null;
-  action?: WritebackAction;
+export type DashboardOrderedCard = BaseDashboardOrderedCard & {
+  card_id: CardId;
+  card: SavedCard;
+  parameter_mappings?: DashboardParameterMapping[] | null;
+  series?: SavedCard[];
 };
 
 export type DashboardParameterMapping = {

--- a/frontend/src/metabase-types/api/dashboard.ts
+++ b/frontend/src/metabase-types/api/dashboard.ts
@@ -6,6 +6,8 @@ import {
 } from "metabase-types/types/Parameter";
 import { CardId, SavedCard } from "metabase-types/types/Card";
 
+import { WritebackAction } from "./writeback";
+
 export type DashboardId = number;
 
 export interface Dashboard {
@@ -36,6 +38,10 @@ export type DashboardOrderedCard = {
   visualization_settings?: {
     [key: string]: unknown;
   };
+
+  // Only for action buttons
+  action_id: number | null;
+  action?: WritebackAction;
 };
 
 export type DashboardParameterMapping = {

--- a/frontend/src/metabase-types/api/dashboard.ts
+++ b/frontend/src/metabase-types/api/dashboard.ts
@@ -51,7 +51,7 @@ export type DashboardParameterMapping = {
 // Example: "[\"dimension\",[\"field\",17,null]]"
 type StringifiedDimension = string;
 
-type ClickBehaviorParameterMapping = Record<
+export type ClickBehaviorParameterMapping = Record<
   ParameterId | StringifiedDimension,
   {
     id: ParameterId | StringifiedDimension;

--- a/frontend/src/metabase-types/api/data-app.ts
+++ b/frontend/src/metabase-types/api/data-app.ts
@@ -1,4 +1,9 @@
 import { Collection, RegularCollectionId } from "./collection";
+import {
+  BaseDashboardOrderedCard,
+  DashboardParameterMapping,
+} from "./dashboard";
+import { WritebackAction } from "./writeback";
 
 export type DataAppId = number;
 
@@ -20,4 +25,21 @@ export interface DataAppSearchItem {
   id: RegularCollectionId;
   app_id: DataAppId;
   collection: Collection;
+}
+
+export type ActionButtonParametersMapping = Pick<
+  DashboardParameterMapping,
+  "parameter_id" | "target"
+>;
+
+export interface ActionButtonDashboardCard
+  extends Omit<BaseDashboardOrderedCard, "parameter_mappings"> {
+  action_id: number | null;
+  action?: WritebackAction;
+
+  parameter_mappings?: ActionButtonParametersMapping[] | null;
+  visualization_settings: {
+    [key: string]: unknown;
+    "button.label"?: string;
+  };
 }

--- a/frontend/src/metabase-types/api/mocks/data-app.ts
+++ b/frontend/src/metabase-types/api/mocks/data-app.ts
@@ -1,4 +1,8 @@
-import { DataApp, Dashboard } from "metabase-types/api";
+import {
+  ActionButtonDashboardCard,
+  DataApp,
+  Dashboard,
+} from "metabase-types/api";
 import { createMockCollection } from "./collection";
 import { createMockDashboard } from "./dashboard";
 
@@ -23,3 +27,13 @@ export const createMockDataApp = ({
 export const createMockDataAppPage = (
   params: Partial<Omit<Dashboard, "is_app_page">>,
 ): Dashboard => createMockDashboard({ ...params, is_app_page: true });
+
+export const createMockDashboardActionButton = (
+  opts?: Partial<ActionButtonDashboardCard>,
+): ActionButtonDashboardCard => ({
+  id: 1,
+  action_id: null,
+  parameter_mappings: null,
+  visualization_settings: {},
+  ...opts,
+});

--- a/frontend/src/metabase-types/api/mocks/index.ts
+++ b/frontend/src/metabase-types/api/mocks/index.ts
@@ -14,3 +14,4 @@ export * from "./table";
 export * from "./timeline";
 export * from "./settings";
 export * from "./user";
+export * from "./writeback";

--- a/frontend/src/metabase-types/api/mocks/writeback.ts
+++ b/frontend/src/metabase-types/api/mocks/writeback.ts
@@ -1,0 +1,39 @@
+import {
+  Card,
+  QueryAction,
+  WritebackAction,
+  QueryActionCard,
+} from "metabase-types/api";
+import { createMockCard } from "./card";
+import { createMockNativeDatasetQuery } from "./query";
+
+export function createMockQueryActionCard({
+  action_id = 1,
+  dataset_query = createMockNativeDatasetQuery(),
+  ...opts
+}: Partial<Omit<QueryActionCard, "is_write">> = {}) {
+  const card = createMockCard({ dataset_query, ...opts }) as QueryActionCard;
+
+  card.is_write = true;
+  card.action_id = action_id;
+
+  return card;
+}
+
+export const createMockQueryAction = ({
+  card = createMockQueryActionCard(),
+  ...opts
+}: Partial<WritebackAction & QueryAction> = {}): WritebackAction => {
+  return {
+    id: 1,
+    type: "query",
+    card_id: card.id,
+    card,
+    name: "Query Action Mock",
+    description: null,
+    parameters: [],
+    "updated-at": new Date().toISOString(),
+    "created-at": new Date().toISOString(),
+    ...opts,
+  };
+};

--- a/frontend/src/metabase-types/api/writeback.ts
+++ b/frontend/src/metabase-types/api/writeback.ts
@@ -56,16 +56,21 @@ export type WritebackAction = WritebackActionBase & (QueryAction | HttpAction);
 
 export type ParameterMappings = Record<ParameterId, ParameterTarget>;
 
-export type ParametersMappedToValues = Record<
-  ParameterId,
-  { type: string; value: string | number }
->;
-
-export type ParameterMappedForActionExecution = {
-  id: ParameterId;
+type ParameterForActionExecutionBase = {
   type: string;
   value: string | number;
 };
+
+export type ParameterMappedForActionExecution =
+  ParameterForActionExecutionBase & {
+    id: ParameterId;
+    target: ParameterTarget;
+  };
+
+export type ArbitraryParameterForActionExecution =
+  ParameterForActionExecutionBase & {
+    target: ParameterTarget;
+  };
 
 // we will tighten this up when we figure out what the form settings should look like
 export type ActionFormSettings = {

--- a/frontend/src/metabase-types/api/writeback.ts
+++ b/frontend/src/metabase-types/api/writeback.ts
@@ -55,17 +55,6 @@ export type WritebackQueryAction = WritebackActionBase & QueryAction;
 export type WritebackHttpAction = WritebackActionBase & HttpAction;
 export type WritebackAction = WritebackActionBase & (QueryAction | HttpAction);
 
-export interface WritebackActionEmitter {
-  id: number;
-  dashboard_id: number;
-  action: WritebackAction & {
-    emitter_id: number;
-  };
-  parameter_mappings: Record<ParameterId, ParameterTarget>;
-  updated_at: string;
-  created_at: string;
-}
-
 export type ParameterMappings = Record<ParameterId, ParameterTarget>;
 
 export type ActionClickBehaviorData = {

--- a/frontend/src/metabase-types/api/writeback.ts
+++ b/frontend/src/metabase-types/api/writeback.ts
@@ -8,15 +8,13 @@ import {
   ParameterValueOrArray,
 } from "metabase-types/types/Parameter";
 
-export type ActionParameterTuple = [string, Parameter];
-
 export type WritebackActionType = "http" | "query";
 
 export interface WritebackActionBase {
   id: number;
   name: string;
   description: string | null;
-  parameters: ActionParameterTuple[];
+  parameters: Parameter[];
   "updated-at": string;
   "created-at": string;
 }

--- a/frontend/src/metabase-types/api/writeback.ts
+++ b/frontend/src/metabase-types/api/writeback.ts
@@ -1,12 +1,13 @@
-import { SavedCard, NativeDatasetQuery } from "metabase-types/types/Card";
-import { DashboardWithCards } from "metabase-types/types/Dashboard";
-import { Column } from "metabase-types/types/Dataset";
+import { Card } from "metabase-types/api";
 import {
   Parameter,
   ParameterId,
   ParameterTarget,
-  ParameterValueOrArray,
 } from "metabase-types/types/Parameter";
+
+export interface WritebackParameter extends Parameter {
+  target: ParameterTarget;
+}
 
 export type WritebackActionType = "http" | "query";
 
@@ -14,12 +15,12 @@ export interface WritebackActionBase {
   id: number;
   name: string;
   description: string | null;
-  parameters: Parameter[];
+  parameters: WritebackParameter[];
   "updated-at": string;
   "created-at": string;
 }
 
-type QueryActionCard = SavedCard<NativeDatasetQuery> & {
+export type QueryActionCard = Card & {
   is_write: true;
   action_id: number;
 };
@@ -55,41 +56,16 @@ export type WritebackAction = WritebackActionBase & (QueryAction | HttpAction);
 
 export type ParameterMappings = Record<ParameterId, ParameterTarget>;
 
-export type ActionClickBehaviorData = {
-  column: Partial<Column>;
-  parameter: Record<ParameterId, { value: ParameterValueOrArray }>;
-  parameterByName: Record<string, { value: ParameterValueOrArray }>;
-  parameterBySlug: Record<string, { value: ParameterValueOrArray }>;
-  userAttributes: Record<string, unknown>;
-};
-
-export type ActionClickBehavior = {
-  action: number; // action id
-  emitter_id: number;
-  type: "action";
-  parameterMapping: ParameterMappings;
-};
-
-export type ActionClickExtraData = {
-  actions: Record<number, WritebackAction>;
-  dashboard: DashboardWithCards;
-  parameterBySlug: Record<string, { value: ParameterValueOrArray }>;
-  userAttributes: unknown[];
-};
-
-export type ParametersSourceTargetMap = Record<
-  ParameterId,
-  {
-    id: ParameterId;
-    source: { id: string; type: string; name: string };
-    target: { id: string; type: string };
-  }
->;
-
 export type ParametersMappedToValues = Record<
   ParameterId,
   { type: string; value: string | number }
 >;
+
+export type ParameterMappedForActionExecution = {
+  id: ParameterId;
+  type: string;
+  value: string | number;
+};
 
 // we will tighten this up when we figure out what the form settings should look like
 export type ActionFormSettings = {

--- a/frontend/src/metabase-types/store/state.ts
+++ b/frontend/src/metabase-types/store/state.ts
@@ -23,3 +23,8 @@ export interface State {
 export type Dispatch<T = unknown> = (action: T) => void;
 
 export type GetState = () => State;
+
+export type ReduxAction<Type = string, Payload = any> = {
+  type: Type;
+  payload: Payload;
+};

--- a/frontend/src/metabase/dashboard/actions/save.js
+++ b/frontend/src/metabase/dashboard/actions/save.js
@@ -77,6 +77,7 @@ export const saveDashboardAndCards = createThunkAction(
               // mark isAdded because addcard doesn't record the position
               return {
                 ...result,
+                action_id: dc.action_id,
                 col: dc.col,
                 row: dc.row,
                 sizeX: dc.sizeX,

--- a/frontend/src/metabase/dashboard/actions/save.js
+++ b/frontend/src/metabase/dashboard/actions/save.js
@@ -112,6 +112,7 @@ export const saveDashboardAndCards = createThunkAction(
         const cards = updatedDashcards.map(
           ({
             id,
+            action_id,
             card_id,
             row,
             col,
@@ -122,6 +123,7 @@ export const saveDashboardAndCards = createThunkAction(
             visualization_settings,
           }) => ({
             id,
+            action_id,
             card_id,
             row,
             col,

--- a/frontend/src/metabase/dashboard/actions/writeback.ts
+++ b/frontend/src/metabase/dashboard/actions/writeback.ts
@@ -244,7 +244,6 @@ export const deleteManyRowsFromDataApp = (
 
 export type ExecuteRowActionPayload = {
   dashboard: DashboardWithCards;
-  emitterId: number;
   parameters: Record<string, unknown>;
 };
 

--- a/frontend/src/metabase/dashboard/actions/writeback.ts
+++ b/frontend/src/metabase/dashboard/actions/writeback.ts
@@ -1,7 +1,6 @@
 import { t } from "ttag";
 
 import { createAction } from "metabase/lib/redux";
-import { EmittersApi } from "metabase/services";
 import { addUndo } from "metabase/redux/undo";
 
 import {
@@ -251,15 +250,13 @@ export type ExecuteRowActionPayload = {
 
 export const executeRowAction = ({
   dashboard,
-  emitterId,
   parameters,
 }: ExecuteRowActionPayload) => {
   return async function (dispatch: any) {
     try {
-      const result = await EmittersApi.execute({
-        id: emitterId,
-        parameters,
-      });
+      const result = {
+        "rows-affected": 0,
+      };
       if (result["rows-affected"] > 0) {
         dashboard.ordered_cards
           .filter(dashCard => !isVirtualDashCard(dashCard))

--- a/frontend/src/metabase/dashboard/actions/writeback.ts
+++ b/frontend/src/metabase/dashboard/actions/writeback.ts
@@ -24,9 +24,11 @@ import type {
   ParameterMappedForActionExecution,
 } from "metabase-types/api";
 import type { DashCard } from "metabase-types/types/Dashboard";
+import type { Dispatch } from "metabase-types/store";
 
 import { getCardData } from "../selectors";
 import { isVirtualDashCard } from "../utils";
+import { setDashCardAttributes } from "./core";
 import { fetchCardData } from "./data-fetching";
 
 export const OPEN_ACTION_PARAMETERS_MODAL =
@@ -40,6 +42,20 @@ export const CLOSE_ACTION_PARAMETERS_MODAL =
 export const closeActionParametersModal = createAction(
   CLOSE_ACTION_PARAMETERS_MODAL,
 );
+
+export function updateButtonActionMapping(
+  dashCardId: number,
+  attributes: { action_id?: number | null; parameter_mappings?: any },
+) {
+  return (dispatch: Dispatch) => {
+    dispatch(
+      setDashCardAttributes({
+        id: dashCardId,
+        attributes: attributes,
+      }),
+    );
+  };
+}
 
 export type InsertRowFromDataAppPayload = InsertRowPayload & {
   dashCard: DashCard;

--- a/frontend/src/metabase/dashboard/actions/writeback.ts
+++ b/frontend/src/metabase/dashboard/actions/writeback.ts
@@ -16,7 +16,14 @@ import {
   BulkDeletePayload,
 } from "metabase/writeback/actions";
 
-import { DashboardWithCards, DashCard } from "metabase-types/types/Dashboard";
+import { ActionsApi } from "metabase/services";
+
+import type {
+  Dashboard,
+  ActionButtonDashboardCard,
+  ParameterMappedForActionExecution,
+} from "metabase-types/api";
+import type { DashCard } from "metabase-types/types/Dashboard";
 
 import { getCardData } from "../selectors";
 import { isVirtualDashCard } from "../utils";
@@ -243,19 +250,24 @@ export const deleteManyRowsFromDataApp = (
 };
 
 export type ExecuteRowActionPayload = {
-  dashboard: DashboardWithCards;
-  parameters: Record<string, unknown>;
+  dashboard: Dashboard;
+  dashcard: ActionButtonDashboardCard;
+  parameters: ParameterMappedForActionExecution[];
 };
 
 export const executeRowAction = ({
   dashboard,
+  dashcard,
   parameters,
 }: ExecuteRowActionPayload) => {
   return async function (dispatch: any) {
     try {
-      const result = {
-        "rows-affected": 0,
-      };
+      const result = await ActionsApi.execute({
+        dashboardId: dashboard.id,
+        dashcardId: dashcard.id,
+        actionId: dashcard.action_id,
+        parameters,
+      });
       if (result["rows-affected"] > 0) {
         dashboard.ordered_cards
           .filter(dashCard => !isVirtualDashCard(dashCard))

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ActionOptions/ActionClickMappings.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ActionOptions/ActionClickMappings.tsx
@@ -1,0 +1,82 @@
+import React, { useCallback, useMemo } from "react";
+
+import ClickMappings from "metabase/dashboard/components/ClickMappings";
+
+import type {
+  ActionButtonDashboardCard,
+  ActionButtonParametersMapping,
+  ClickBehaviorParameterMapping,
+  WritebackAction,
+} from "metabase-types/api";
+import type { UiParameter } from "metabase/parameters/types";
+
+import {
+  turnClickBehaviorParameterMappingsIntoDashCardMappings,
+  turnDashCardParameterMappingsIntoClickBehaviorMappings,
+} from "./utils";
+
+// We're reusing the ClickMappings component for mapping parameters
+// ClickMappings is bound to click behavior, but for custom actions
+// we're using dash cards parameter mappings in another format
+// So here we need to convert these formats from one to another
+// Until we introduce another mapping component or refactor ClickMappings
+interface IntermediateActionClickBehavior {
+  type: "action";
+  parameterMapping?: ClickBehaviorParameterMapping;
+}
+
+interface ActionClickMappingsProps {
+  action?: WritebackAction;
+  dashcard: ActionButtonDashboardCard;
+  parameters: UiParameter[];
+  onChange: (parameterMappings: ActionButtonParametersMapping[] | null) => void;
+}
+
+function ActionClickMappings({
+  action,
+  dashcard,
+  parameters,
+  onChange,
+}: ActionClickMappingsProps) {
+  const clickBehavior = useMemo(() => {
+    if (!action) {
+      return { type: "action" };
+    }
+    const parameterMapping =
+      turnDashCardParameterMappingsIntoClickBehaviorMappings(
+        dashcard,
+        parameters,
+        action,
+      );
+    return { type: "action", parameterMapping };
+  }, [action, dashcard, parameters]);
+
+  const handleParameterMappingChange = useCallback(
+    (nextClickBehavior: IntermediateActionClickBehavior) => {
+      const { parameterMapping } = nextClickBehavior;
+      if (parameterMapping && action) {
+        const parameterMappings =
+          turnClickBehaviorParameterMappingsIntoDashCardMappings(
+            parameterMapping,
+            action,
+          );
+        onChange(parameterMappings);
+      } else {
+        onChange(null);
+      }
+    },
+    [action, onChange],
+  );
+
+  return (
+    <ClickMappings
+      isAction
+      object={action}
+      dashcard={dashcard}
+      clickBehavior={clickBehavior}
+      updateSettings={handleParameterMappingChange}
+    />
+  );
+}
+
+export default ActionClickMappings;

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ActionOptions/ActionOptionItem.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ActionOptions/ActionOptionItem.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+
+import { SidebarItem } from "../SidebarItem";
+import {
+  ActionSidebarItem,
+  ActionSidebarItemIcon,
+  ActionDescription,
+} from "./ActionOptions.styled";
+
+interface ActionOptionProps {
+  name: string;
+  description?: string | null;
+  isSelected: boolean;
+  onClick: () => void;
+}
+
+function ActionOptionItem({
+  name,
+  description,
+  isSelected,
+  onClick,
+}: ActionOptionProps) {
+  return (
+    <ActionSidebarItem
+      onClick={onClick}
+      isSelected={isSelected}
+      hasDescription={!!description}
+    >
+      <ActionSidebarItemIcon name="bolt" isSelected={isSelected} />
+      <div>
+        <SidebarItem.Name>{name}</SidebarItem.Name>
+        {description && <ActionDescription>{description}</ActionDescription>}
+      </div>
+    </ActionSidebarItem>
+  );
+}
+
+export default ActionOptionItem;

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ActionOptions/ActionOptions.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ActionOptions/ActionOptions.styled.tsx
@@ -28,3 +28,7 @@ export const ActionDescription = styled.span<{ isSelected?: boolean }>`
   color: ${props =>
     props.isSelected ? color("text-white") : color("text-medium")};
 `;
+
+export const ClickMappingsContainer = styled.div`
+  margin-top: 1rem;
+`;

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ActionOptions/ActionOptions.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ActionOptions/ActionOptions.tsx
@@ -57,6 +57,10 @@ function ActionOptions({
     (action: WritebackAction) => {
       onUpdateButtonActionMapping(dashcard.id, {
         action_id: action.id,
+
+        // Clean mappings from previous action
+        // as they're most likely going to be irrelevant
+        parameter_mappings: null,
       });
     },
     [dashcard, onUpdateButtonActionMapping],

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ActionOptions/ActionOptions.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ActionOptions/ActionOptions.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 import React, { useCallback } from "react";
 import { t } from "ttag";
 
@@ -12,41 +11,8 @@ import type {
   WritebackAction,
 } from "metabase-types/api";
 
-import { SidebarItem } from "../SidebarItem";
 import { Heading, SidebarContent } from "../ClickBehaviorSidebar.styled";
-import {
-  ActionSidebarItem,
-  ActionSidebarItemIcon,
-  ActionDescription,
-} from "./ActionOptions.styled";
-
-interface ActionOptionProps {
-  name: string;
-  description?: string | null;
-  isSelected: boolean;
-  onClick: () => void;
-}
-
-const ActionOption = ({
-  name,
-  description,
-  isSelected,
-  onClick,
-}: ActionOptionProps) => {
-  return (
-    <ActionSidebarItem
-      onClick={onClick}
-      isSelected={isSelected}
-      hasDescription={!!description}
-    >
-      <ActionSidebarItemIcon name="bolt" isSelected={isSelected} />
-      <div>
-        <SidebarItem.Name>{name}</SidebarItem.Name>
-        {description && <ActionDescription>{description}</ActionDescription>}
-      </div>
-    </ActionSidebarItem>
-  );
-};
+import ActionOptionItem from "./ActionOptionItem";
 
 interface ActionOptionsProps {
   dashcard: DashboardOrderedCard;
@@ -77,7 +43,7 @@ function ActionOptions({
           return (
             <>
               {actions.map(action => (
-                <ActionOption
+                <ActionOptionItem
                   key={action.id}
                   name={action.name}
                   description={action.description}

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ActionOptions/ActionOptions.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ActionOptions/ActionOptions.tsx
@@ -26,7 +26,12 @@ import {
 import ActionOptionItem from "./ActionOptionItem";
 import { ClickMappingsContainer } from "./ActionOptions.styled";
 
-interface WritebackActionClickBehavior {
+// We're reusing the ClickMappings component for mapping parameters
+// ClickMappings is bound to click behavior, but for custom actions
+// we're using dash cards parameter mappings in another format
+// So here we need to convert these formats from one to another
+// Until we introduce another mapping component or refactor ClickMappings
+interface IntermediateActionClickBehavior {
   type: "action";
   parameterMapping?: ClickBehaviorParameterMapping;
 }
@@ -87,7 +92,7 @@ function ActionOptions({
   );
 
   const handleParameterMappingChange = useCallback(
-    (nextClickBehavior: WritebackActionClickBehavior) => {
+    (nextClickBehavior: IntermediateActionClickBehavior) => {
       const { parameterMapping } = nextClickBehavior;
 
       const parameterMappings =

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ActionOptions/ActionOptions.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ActionOptions/ActionOptions.tsx
@@ -24,6 +24,7 @@ import {
   turnDashCardParameterMappingsIntoClickBehaviorMappings,
 } from "./utils";
 import ActionOptionItem from "./ActionOptionItem";
+import { ClickMappingsContainer } from "./ActionOptions.styled";
 
 interface WritebackActionClickBehavior {
   type: "action";
@@ -116,13 +117,15 @@ function ActionOptions({
         />
       ))}
       {selectedAction && (
-        <ClickMappings
-          isAction
-          object={selectedAction}
-          dashcard={dashcard}
-          clickBehavior={clickBehavior}
-          updateSettings={handleParameterMappingChange}
-        />
+        <ClickMappingsContainer>
+          <ClickMappings
+            isAction
+            object={selectedAction}
+            dashcard={dashcard}
+            clickBehavior={clickBehavior}
+            updateSettings={handleParameterMappingChange}
+          />
+        </ClickMappingsContainer>
       )}
     </>
   );

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ActionOptions/ActionOptions.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ActionOptions/ActionOptions.tsx
@@ -10,7 +10,6 @@ import type {
   DashboardOrderedCard,
   ClickBehavior,
   WritebackAction,
-  WritebackActionClickBehavior,
 } from "metabase-types/api";
 
 import { SidebarItem } from "../SidebarItem";
@@ -51,8 +50,8 @@ const ActionOption = ({
 
 interface ActionOptionsProps {
   dashcard: DashboardOrderedCard;
-  clickBehavior: WritebackActionClickBehavior;
-  updateSettings: (settings: ClickBehavior) => void;
+  clickBehavior: ClickBehavior;
+  updateSettings: (settings: Partial<ClickBehavior>) => void;
 }
 
 function ActionOptions({
@@ -61,11 +60,9 @@ function ActionOptions({
   updateSettings,
 }: ActionOptionsProps) {
   const handleActionSelected = useCallback(
-    action => {
+    (action: WritebackAction) => {
       updateSettings({
         type: clickBehavior.type,
-        emitter_id: clickBehavior.emitter_id,
-        action: action.id,
       });
     },
     [clickBehavior, updateSettings],
@@ -76,9 +73,7 @@ function ActionOptions({
       <Heading className="text-medium">{t`Pick an action`}</Heading>
       <Actions.ListLoader>
         {({ actions }: { actions: WritebackAction[] }) => {
-          const selectedAction = actions.find(
-            action => action.id === clickBehavior.action,
-          );
+          const selectedAction = null;
           return (
             <>
               {actions.map(action => (
@@ -86,7 +81,7 @@ function ActionOptions({
                   key={action.id}
                   name={action.name}
                   description={action.description}
-                  isSelected={clickBehavior.action === action.id}
+                  isSelected={false}
                   onClick={() => handleActionSelected(action)}
                 />
               ))}

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ActionOptions/ActionOptions.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ActionOptions/ActionOptions.tsx
@@ -21,10 +21,11 @@ interface ActionOptionsProps {
 }
 
 function ActionOptions({
+  actions,
   dashcard,
   clickBehavior,
   updateSettings,
-}: ActionOptionsProps) {
+}: ActionOptionsProps & { actions: WritebackAction[] }) {
   const handleActionSelected = useCallback(
     (action: WritebackAction) => {
       updateSettings({
@@ -34,38 +35,43 @@ function ActionOptions({
     [clickBehavior, updateSettings],
   );
 
+  const selectedAction = null;
+
+  return (
+    <>
+      {actions.map(action => (
+        <ActionOptionItem
+          key={action.id}
+          name={action.name}
+          description={action.description}
+          isSelected={false}
+          onClick={() => handleActionSelected(action)}
+        />
+      ))}
+      {selectedAction && (
+        <ClickMappings
+          isAction
+          object={selectedAction}
+          dashcard={dashcard}
+          clickBehavior={clickBehavior}
+          updateSettings={updateSettings}
+        />
+      )}
+    </>
+  );
+}
+
+function ActionOptionsContainer(props: ActionOptionsProps) {
   return (
     <SidebarContent>
       <Heading className="text-medium">{t`Pick an action`}</Heading>
-      <Actions.ListLoader>
-        {({ actions }: { actions: WritebackAction[] }) => {
-          const selectedAction = null;
-          return (
-            <>
-              {actions.map(action => (
-                <ActionOptionItem
-                  key={action.id}
-                  name={action.name}
-                  description={action.description}
-                  isSelected={false}
-                  onClick={() => handleActionSelected(action)}
-                />
-              ))}
-              {selectedAction && (
-                <ClickMappings
-                  isAction
-                  object={selectedAction}
-                  dashcard={dashcard}
-                  clickBehavior={clickBehavior}
-                  updateSettings={updateSettings}
-                />
-              )}
-            </>
-          );
-        }}
+      <Actions.ListLoader loadingAndErrorWrapper={false}>
+        {({ actions = [] }: { actions: WritebackAction[] }) => (
+          <ActionOptions {...props} actions={actions} />
+        )}
       </Actions.ListLoader>
     </SidebarContent>
   );
 }
 
-export default ActionOptions;
+export default ActionOptionsContainer;

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ActionOptions/utils.ts
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ActionOptions/utils.ts
@@ -1,0 +1,73 @@
+import _ from "underscore";
+
+import type {
+  ActionButtonDashboardCard,
+  ActionButtonParametersMapping,
+  ClickBehaviorParameterMapping,
+  WritebackAction,
+} from "metabase-types/api";
+import type { UiParameter } from "metabase/parameters/types";
+
+export function turnDashCardParameterMappingsIntoClickBehaviorMappings(
+  dashCard: ActionButtonDashboardCard,
+  parameters: UiParameter[],
+  action: WritebackAction,
+): ClickBehaviorParameterMapping {
+  const result: ClickBehaviorParameterMapping = {};
+
+  if (!Array.isArray(dashCard.parameter_mappings)) {
+    return result;
+  }
+
+  dashCard.parameter_mappings.forEach(mapping => {
+    const { parameter_id: sourceParameterId, target } = mapping;
+
+    const sourceParameter = parameters.find(
+      parameter => parameter.id === sourceParameterId,
+    );
+    const actionParameter = action?.parameters.find(p =>
+      _.isEqual(p.target, target),
+    );
+
+    if (sourceParameter && actionParameter) {
+      result[actionParameter.id] = {
+        id: actionParameter.id,
+        target: {
+          type: "parameter",
+          id: actionParameter.id,
+        },
+        source: {
+          type: "parameter",
+          id: sourceParameter.id,
+          name: sourceParameter.name,
+        },
+      };
+    }
+  });
+
+  return result;
+}
+
+export function turnClickBehaviorParameterMappingsIntoDashCardMappings(
+  clickBehaviorParameterMappings: ClickBehaviorParameterMapping,
+  action: WritebackAction,
+): ActionButtonParametersMapping[] {
+  const mappings = Object.values(clickBehaviorParameterMappings);
+  const parameter_mappings: ActionButtonParametersMapping[] = [];
+
+  mappings.forEach(mapping => {
+    const { source, target } = mapping;
+    const actionParameter = action?.parameters.find(
+      parameter => parameter.id === target.id,
+    );
+
+    if (actionParameter?.target) {
+      parameter_mappings.push({
+        parameter_id: source.id,
+        target: actionParameter?.target,
+      });
+    }
+  });
+
+  return parameter_mappings;
+}

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ActionOptions/utils.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ActionOptions/utils.unit.spec.ts
@@ -1,0 +1,181 @@
+import type {
+  ActionButtonParametersMapping,
+  ClickBehaviorParameterMapping,
+  WritebackParameter,
+} from "metabase-types/api";
+import type { UiParameter } from "metabase/parameters/types";
+
+import {
+  createMockDashboardActionButton,
+  createMockQueryAction,
+} from "metabase-types/api/mocks";
+import {
+  turnClickBehaviorParameterMappingsIntoDashCardMappings,
+  turnDashCardParameterMappingsIntoClickBehaviorMappings,
+} from "./utils";
+
+const WRITEBACK_PARAMETER: WritebackParameter = {
+  id: "param-1",
+  name: "Order ID",
+  type: "number",
+  slug: "order-id",
+  target: ["variable", ["template-tag", "order-id"]],
+};
+
+const DASHBOARD_FILTER_PARAMETER: UiParameter = {
+  id: "dashboard-filter-1",
+  name: "Order",
+  type: "number",
+  slug: "order",
+  value: 5,
+};
+
+const PARAMETER_MAPPING: ActionButtonParametersMapping = {
+  parameter_id: DASHBOARD_FILTER_PARAMETER.id,
+  target: WRITEBACK_PARAMETER.target,
+};
+
+const CLICK_BEHAVIOR_PARAMETER_MAPPINGS: ClickBehaviorParameterMapping = {
+  [WRITEBACK_PARAMETER.id]: {
+    id: WRITEBACK_PARAMETER.id,
+    target: {
+      id: WRITEBACK_PARAMETER.id,
+      type: "parameter",
+    },
+    source: {
+      id: DASHBOARD_FILTER_PARAMETER.id,
+      name: DASHBOARD_FILTER_PARAMETER.name,
+      type: "parameter",
+    },
+  },
+};
+
+describe("turnDashCardParameterMappingsIntoClickBehaviorMappings", () => {
+  type SetupOpts = {
+    actionParameters?: WritebackParameter[] | undefined;
+    dashCardParameterMappings?: ActionButtonParametersMapping[] | null;
+  };
+
+  function setup({
+    actionParameters = [],
+    dashCardParameterMappings = [],
+  }: SetupOpts = {}) {
+    const action = createMockQueryAction({ parameters: actionParameters });
+    const dashCard = createMockDashboardActionButton({
+      action,
+      action_id: action.id,
+      parameter_mappings: dashCardParameterMappings,
+    });
+    return { action, dashCard };
+  }
+
+  it("returns empty object if there are no parameter_mappings on the dashboard card", () => {
+    const { action, dashCard } = setup({
+      actionParameters: [WRITEBACK_PARAMETER],
+      dashCardParameterMappings: [],
+    });
+
+    const result = turnDashCardParameterMappingsIntoClickBehaviorMappings(
+      dashCard,
+      [DASHBOARD_FILTER_PARAMETER],
+      action,
+    );
+
+    expect(result).toEqual({});
+  });
+
+  it("returns empty object if there no parameters on the action", () => {
+    const { action, dashCard } = setup({
+      actionParameters: [],
+      dashCardParameterMappings: [PARAMETER_MAPPING],
+    });
+
+    const result = turnDashCardParameterMappingsIntoClickBehaviorMappings(
+      dashCard,
+      [DASHBOARD_FILTER_PARAMETER],
+      action,
+    );
+
+    expect(result).toEqual({});
+  });
+
+  it("returns empty object if dashboard parameters are unavailable", () => {
+    const { action, dashCard } = setup({
+      actionParameters: [WRITEBACK_PARAMETER],
+      dashCardParameterMappings: [PARAMETER_MAPPING],
+    });
+
+    const result = turnDashCardParameterMappingsIntoClickBehaviorMappings(
+      dashCard,
+      [],
+      action,
+    );
+
+    expect(result).toEqual({});
+  });
+
+  it("returns empty object if nothing is available", () => {
+    const { action, dashCard } = setup({
+      actionParameters: [],
+      dashCardParameterMappings: [],
+    });
+
+    const result = turnDashCardParameterMappingsIntoClickBehaviorMappings(
+      dashCard,
+      [],
+      action,
+    );
+
+    expect(result).toEqual({});
+  });
+
+  it("converts parameters correctly", () => {
+    const { action, dashCard } = setup({
+      actionParameters: [WRITEBACK_PARAMETER],
+      dashCardParameterMappings: [PARAMETER_MAPPING],
+    });
+
+    const result = turnDashCardParameterMappingsIntoClickBehaviorMappings(
+      dashCard,
+      [DASHBOARD_FILTER_PARAMETER],
+      action,
+    );
+
+    expect(result).toEqual(CLICK_BEHAVIOR_PARAMETER_MAPPINGS);
+  });
+});
+
+describe("turnClickBehaviorParameterMappingsIntoDashCardMappings", () => {
+  it("returns nothing if action parameters are empty", () => {
+    const action = createMockQueryAction({ parameters: [] });
+
+    const result = turnClickBehaviorParameterMappingsIntoDashCardMappings(
+      CLICK_BEHAVIOR_PARAMETER_MAPPINGS,
+      action,
+    );
+
+    expect(result).toEqual([]);
+  });
+
+  it("returns nothing if click behavior mappings are empty", () => {
+    const action = createMockQueryAction({ parameters: [WRITEBACK_PARAMETER] });
+
+    const result = turnClickBehaviorParameterMappingsIntoDashCardMappings(
+      {},
+      action,
+    );
+
+    expect(result).toEqual([]);
+  });
+
+  it("converts click behavior correctly", () => {
+    const action = createMockQueryAction({ parameters: [WRITEBACK_PARAMETER] });
+
+    const result = turnClickBehaviorParameterMappingsIntoDashCardMappings(
+      CLICK_BEHAVIOR_PARAMETER_MAPPINGS,
+      action,
+    );
+
+    expect(result).toEqual([PARAMETER_MAPPING]);
+  });
+});

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.tsx
@@ -12,6 +12,8 @@ import { usePrevious } from "metabase/hooks/use-previous";
 
 import Sidebar from "metabase/dashboard/components/Sidebar";
 
+import { isActionButtonWithMappedAction } from "metabase/writeback/utils";
+
 import type { UiParameter } from "metabase/parameters/types";
 import type {
   Dashboard,
@@ -157,7 +159,10 @@ function ClickBehaviorSidebar({
   ]);
 
   useOnMount(() => {
-    if (shouldShowTypeSelector(clickBehavior)) {
+    if (
+      !isActionButtonWithMappedAction(dashcard) &&
+      shouldShowTypeSelector(clickBehavior)
+    ) {
       setTypeSelectorVisible(true);
     }
     if (dashcard) {
@@ -187,7 +192,9 @@ function ClickBehaviorSidebar({
     <Sidebar
       onClose={hideClickBehaviorSidebar}
       onCancel={handleCancel}
-      closeIsDisabled={!isValidClickBehavior}
+      closeIsDisabled={
+        !isValidClickBehavior && !isActionButtonWithMappedAction(dashcard)
+      }
     >
       <ClickBehaviorSidebarHeader
         dashcard={dashcard}

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarContent.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarContent.tsx
@@ -47,7 +47,7 @@ function ClickBehaviorSidebar({
   onSettingsChange,
   onTypeSelectorVisibilityChange,
 }: Props) {
-  const finalClickBehavior = useMemo(() => {
+  const finalClickBehavior = useMemo<ClickBehavior>(() => {
     if (clickBehavior) {
       return clickBehavior;
     }

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarContent.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarContent.tsx
@@ -1,7 +1,9 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { getIn } from "icepick";
 
 import { isTableDisplay } from "metabase/lib/click-behavior";
+
+import { isActionButtonWithMappedAction } from "metabase/writeback/utils";
 
 import type { UiParameter } from "metabase/parameters/types";
 import type {
@@ -45,7 +47,15 @@ function ClickBehaviorSidebar({
   onSettingsChange,
   onTypeSelectorVisibilityChange,
 }: Props) {
-  const finalClickBehavior = clickBehavior || { type: "actionMenu" };
+  const finalClickBehavior = useMemo(() => {
+    if (clickBehavior) {
+      return clickBehavior;
+    }
+    if (isActionButtonWithMappedAction(dashcard)) {
+      return { type: "action" };
+    }
+    return { type: "actionMenu" };
+  }, [clickBehavior, dashcard]);
 
   if (isTableDisplay(dashcard) && !hasSelectedColumn) {
     const columns = getIn(dashcardData, [dashcard.card_id, "data", "cols"]);

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarHeader/ClickBehaviorSidebarHeader.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarHeader/ClickBehaviorSidebarHeader.tsx
@@ -4,6 +4,10 @@ import { t, jt } from "ttag";
 import Icon from "metabase/components/Icon";
 
 import { isTableDisplay } from "metabase/lib/click-behavior";
+import {
+  isActionButtonDashCard,
+  getActionButtonLabel,
+} from "metabase/writeback/utils";
 
 import type { DashboardOrderedCard } from "metabase-types/api";
 import type { Column } from "metabase-types/types/Dataset";
@@ -15,7 +19,7 @@ import {
   ItemName,
 } from "./ClickBehaviorSidebarHeader.styled";
 
-function DefaultHeader({ children }: { children: string }) {
+function DefaultHeader({ children }: { children: React.ReactNode }) {
   return (
     <Heading>{jt`Click behavior for ${(
       <ItemName>{children}</ItemName>
@@ -43,7 +47,10 @@ function HeaderContent({ dashcard, selectedColumn, onUnsetColumn }: Props) {
     }
     return <Heading>{t`On-click behavior for each column`}</Heading>;
   }
-
+  if (isActionButtonDashCard(dashcard)) {
+    const label = getActionButtonLabel(dashcard);
+    return <DefaultHeader>{label || t`an action button`}</DefaultHeader>;
+  }
   return <DefaultHeader>{dashcard.card.name}</DefaultHeader>;
 }
 

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarMainView/ClickBehaviorSidebarMainView.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarMainView/ClickBehaviorSidebarMainView.tsx
@@ -2,6 +2,7 @@ import React from "react";
 
 import type { UiParameter } from "metabase/parameters/types";
 import type {
+  ActionButtonDashboardCard,
   Dashboard,
   DashboardOrderedCard,
   ClickBehavior,
@@ -52,16 +53,12 @@ function ClickBehaviorOptions({
       />
     );
   }
-  if (clickBehavior.type === "action") {
-    return (
-      <ActionOptions
-        clickBehavior={clickBehavior}
-        dashcard={dashcard}
-        updateSettings={updateSettings}
-      />
-    );
-  }
-  return null;
+  return (
+    <ActionOptions
+      dashcard={dashcard as unknown as ActionButtonDashboardCard}
+      parameters={parameters}
+    />
+  );
 }
 
 interface ClickBehaviorSidebarMainViewProps {

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/TypeSelector/TypeSelector.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/TypeSelector/TypeSelector.tsx
@@ -1,7 +1,9 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useMemo } from "react";
 
 import Icon from "metabase/components/Icon";
 import { color } from "metabase/lib/colors";
+
+import { isActionButtonDashCard } from "metabase/writeback/utils";
 
 import type { UiParameter } from "metabase/parameters/types";
 import type { DashboardOrderedCard, ClickBehavior } from "metabase-types/api";
@@ -64,6 +66,13 @@ function TypeSelector({
   updateSettings,
   moveToNextPage,
 }: TypeSelectorProps) {
+  const options = useMemo(() => {
+    if (isActionButtonDashCard(dashcard)) {
+      return clickBehaviorOptions;
+    }
+    return clickBehaviorOptions.filter(option => option.value !== "action");
+  }, [dashcard]);
+
   const handleSelect = useCallback(
     value => {
       if (value !== clickBehavior.type) {
@@ -77,7 +86,7 @@ function TypeSelector({
 
   return (
     <div>
-      {clickBehaviorOptions.map(({ value, icon }) => (
+      {options.map(({ value, icon }) => (
         <div key={value} className="mb1">
           <BehaviorOption
             option={getClickBehaviorOptionName(value, dashcard)}

--- a/frontend/src/metabase/dashboard/components/DashCard.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard.jsx
@@ -27,6 +27,8 @@ import DashCardParameterMapper from "./DashCardParameterMapper";
 import { IS_EMBED_PREVIEW } from "metabase/lib/embed";
 import { getClickBehaviorDescription } from "metabase/lib/click-behavior";
 
+import { isActionButtonCard } from "metabase/writeback/utils";
+
 import cx from "classnames";
 import _ from "underscore";
 import { getIn } from "icepick";
@@ -177,7 +179,7 @@ export default class DashCard extends Component {
       parameterValues,
     );
 
-    const isActionButton = mainCard.display === "action-button";
+    const isActionButton = isActionButtonCard(mainCard);
 
     const hideBackground =
       !isEditing &&
@@ -381,7 +383,7 @@ const DashCardActionButtons = ({
         />,
       );
     }
-    if (!isVirtualDashCard || card.display === "action-button") {
+    if (!isVirtualDashCard || isActionButtonCard(card)) {
       buttons.push(
         <Tooltip key="click-behavior-tooltip" tooltip={t`Click behavior`}>
           <a

--- a/frontend/src/metabase/dashboard/containers/ActionParametersInputModal.tsx
+++ b/frontend/src/metabase/dashboard/containers/ActionParametersInputModal.tsx
@@ -6,7 +6,6 @@ import ModalContent from "metabase/components/ModalContent";
 
 import ActionParametersInputForm from "metabase/writeback/containers/ActionParametersInputForm";
 
-import type { WritebackActionEmitter } from "metabase-types/api";
 import type { DashboardWithCards } from "metabase-types/types/Dashboard";
 import type { State } from "metabase-types/store";
 
@@ -14,7 +13,7 @@ import { closeActionParametersModal } from "../actions";
 import { getEmitterParametersFormProps } from "../selectors";
 
 type DataAppDashboard = DashboardWithCards & {
-  emitters?: WritebackActionEmitter[];
+  emitters?: any[];
 };
 
 interface OwnProps {

--- a/frontend/src/metabase/dashboard/containers/ActionParametersInputModal.tsx
+++ b/frontend/src/metabase/dashboard/containers/ActionParametersInputModal.tsx
@@ -6,19 +6,14 @@ import ModalContent from "metabase/components/ModalContent";
 
 import ActionParametersInputForm from "metabase/writeback/containers/ActionParametersInputForm";
 
-import type { DashboardWithCards } from "metabase-types/types/Dashboard";
+import type { WritebackAction } from "metabase-types/api";
 import type { State } from "metabase-types/store";
 
 import { closeActionParametersModal } from "../actions";
-import { getEmitterParametersFormProps } from "../selectors";
-
-type DataAppDashboard = DashboardWithCards & {
-  emitters?: any[];
-};
+import { getActionParametersModalFormProps } from "../selectors";
 
 interface OwnProps {
-  dashboard: DataAppDashboard;
-  focusedEmitterId: number;
+  action: WritebackAction;
 }
 
 interface StateProps {
@@ -33,7 +28,7 @@ type Props = OwnProps & StateProps & DispatchProps;
 
 function mapStateToProps(state: State) {
   return {
-    formProps: getEmitterParametersFormProps(state),
+    formProps: getActionParametersModalFormProps(state),
   };
 }
 
@@ -43,20 +38,9 @@ const mapDispatchToProps = {
 
 function ActionParametersInputModal({
   formProps,
-  dashboard,
-  focusedEmitterId,
+  action,
   closeActionParametersModal,
 }: Props) {
-  const emitter = dashboard.emitters?.find(
-    emitter => emitter.id === focusedEmitterId,
-  );
-
-  if (!emitter) {
-    return null;
-  }
-
-  const action = emitter.action;
-
   return (
     <Modal onClose={closeActionParametersModal}>
       <ModalContent title={action.name} onClose={closeActionParametersModal}>

--- a/frontend/src/metabase/dashboard/containers/DashboardApp.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp.jsx
@@ -17,10 +17,8 @@ import { useLoadingTimer } from "metabase/hooks/use-loading-timer";
 import { useWebNotification } from "metabase/hooks/use-web-notification";
 import { useOnUnmount } from "metabase/hooks/use-on-unmount";
 
-import Actions from "metabase/entities/actions";
 import { fetchDatabaseMetadata } from "metabase/redux/metadata";
 import { getIsNavbarOpen, setErrorPage } from "metabase/redux/app";
-import MetabaseSettings from "metabase/lib/settings";
 
 import {
   getIsEditing,
@@ -205,15 +203,11 @@ const DashboardApp = props => {
 };
 
 export default _.compose(
-  ...[
-    connect(mapStateToProps, mapDispatchToProps),
-    favicon(({ pageFavicon }) => pageFavicon),
-    title(({ dashboard, documentTitle }) => ({
-      title: documentTitle || dashboard?.name,
-      titleIndex: 1,
-    })),
-    titleWithLoadingTime("loadingStartTime"),
-    MetabaseSettings.get("experimental-enable-actions") &&
-      Actions.loadList({ metadataPropName: "actionListMetadata" }),
-  ].filter(Boolean),
+  connect(mapStateToProps, mapDispatchToProps),
+  favicon(({ pageFavicon }) => pageFavicon),
+  title(({ dashboard, documentTitle }) => ({
+    title: documentTitle || dashboard?.name,
+    titleIndex: 1,
+  })),
+  titleWithLoadingTime("loadingStartTime"),
 )(DashboardApp);

--- a/frontend/src/metabase/dashboard/containers/DashboardApp.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp.jsx
@@ -45,7 +45,7 @@ import {
   getIsAdditionalInfoVisible,
 
   // Writeback
-  getFocusedEmitterId,
+  getActionParametersModalAction,
 } from "../selectors";
 import { getDatabases, getMetadata } from "metabase/selectors/metadata";
 import {
@@ -107,7 +107,7 @@ const mapStateToProps = (state, props) => {
     embedOptions: getEmbedOptions(state),
 
     // Writeback
-    focusedEmitterId: getFocusedEmitterId(state),
+    focusedActionWithMissingParameters: getActionParametersModalAction(state),
   };
 };
 
@@ -123,7 +123,12 @@ const mapDispatchToProps = {
 const DashboardApp = props => {
   const options = parseHashOptions(window.location.hash);
 
-  const { isRunning, isLoadingComplete, dashboard, focusedEmitterId } = props;
+  const {
+    isRunning,
+    isLoadingComplete,
+    dashboard,
+    focusedActionWithMissingParameters,
+  } = props;
 
   const [editingOnLoad] = useState(options.edit);
   const [addCardOnLoad] = useState(options.add && parseInt(options.add));
@@ -180,10 +185,9 @@ const DashboardApp = props => {
         />
         {/* For rendering modal urls */}
         {props.children}
-        {dashboard && focusedEmitterId && (
+        {dashboard && focusedActionWithMissingParameters && (
           <ActionParametersInputModal
-            dashboard={dashboard}
-            focusedEmitterId={focusedEmitterId}
+            action={focusedActionWithMissingParameters}
           />
         )}
         <Toaster

--- a/frontend/src/metabase/dashboard/reducers.js
+++ b/frontend/src/metabase/dashboard/reducers.js
@@ -414,14 +414,14 @@ const sidebar = handleActions(
 );
 
 // Writeback
-const missingEmitterParameters = handleActions(
+const missingActionParameters = handleActions(
   {
     [INITIALIZE]: {
       next: (state, payload) => null,
     },
     [OPEN_ACTION_PARAMETERS_MODAL]: {
-      next: (state, { payload: { emitterId, props } }) => ({
-        emitterId,
+      next: (state, { payload: { dashcardId, props } }) => ({
+        dashcardId,
         props,
       }),
     },
@@ -448,5 +448,5 @@ export default combineReducers({
   isAddParameterPopoverOpen,
   sidebar,
   parameterValuesSearchCache,
-  missingEmitterParameters,
+  missingActionParameters,
 });

--- a/frontend/src/metabase/dashboard/reducers.unit.spec.js
+++ b/frontend/src/metabase/dashboard/reducers.unit.spec.js
@@ -35,7 +35,8 @@ describe("dashboard reducers", () => {
       sidebar: { props: {} },
       slowCards: {},
       loadingControls: {},
-      missingEmitterParameters: null,
+
+      missingActionParameters: null,
     });
   });
 

--- a/frontend/src/metabase/dashboard/selectors.js
+++ b/frontend/src/metabase/dashboard/selectors.js
@@ -209,8 +209,20 @@ export const getIsAdditionalInfoVisible = createSelector(
   (isEmbedded, embedOptions) => !isEmbedded || embedOptions.additional_info,
 );
 
-// Writeback
-export const getFocusedEmitterId = state =>
-  state.dashboard.missingEmitterParameters?.emitterId;
-export const getEmitterParametersFormProps = state =>
-  state.dashboard.missingEmitterParameters?.props || {};
+const getMissingActionParametersModalState = state =>
+  state.dashboard.missingActionParameters;
+
+export const getActionParametersModalAction = createSelector(
+  [getDashboardComplete, getMissingActionParametersModalState],
+  (dashboard, missingActionParametersModalState) => {
+    const dashcardId = missingActionParametersModalState?.dashcardId;
+    const dashcard = dashboard?.ordered_cards.find(dc => dc.id === dashcardId);
+    return dashcard?.action;
+  },
+);
+
+export const getActionParametersModalFormProps = createSelector(
+  [getMissingActionParametersModalState],
+  missingActionParametersModalState =>
+    missingActionParametersModalState?.props || {},
+);

--- a/frontend/src/metabase/entities/containers/EntityListLoader.jsx
+++ b/frontend/src/metabase/entities/containers/EntityListLoader.jsx
@@ -244,7 +244,6 @@ const EntityListLoader = _.compose(
       allFetched,
       allError,
       selectorName = "getList",
-      metadataPropName = "metadata",
     } = props;
     if (typeof entityQuery === "function") {
       entityQuery = entityQuery(state, props);
@@ -275,7 +274,7 @@ const EntityListLoader = _.compose(
       list,
       entityQuery,
       reloadInterval,
-      [metadataPropName]: metadata,
+      metadata,
       loading,
       loaded,
       fetched,

--- a/frontend/src/metabase/lib/click-behavior.js
+++ b/frontend/src/metabase/lib/click-behavior.js
@@ -243,13 +243,9 @@ export function clickBehaviorIsValid(clickBehavior) {
     linkType,
     targetId,
     linkTemplate,
-    action,
   } = clickBehavior;
   if (type === "crossfilter") {
     return Object.keys(parameterMapping).length > 0;
-  }
-  if (type === "action") {
-    return typeof action === "number";
   }
   // if it's not a crossfilter/action, it's a link
   if (linkType === "url") {

--- a/frontend/src/metabase/lib/click-behavior.js
+++ b/frontend/src/metabase/lib/click-behavior.js
@@ -16,12 +16,12 @@ import {
 
 export function getDataFromClicked({
   extraData: { dashboard, parameterValuesBySlug, userAttributes } = {},
-  dimensions,
-  data,
+  dimensions = [],
+  data = [],
 }) {
   const column = [
-    ...(dimensions || []),
-    ...(data || []).map(d => ({
+    ...dimensions,
+    ...data.map(d => ({
       column: d.col,
       // When the data is changed to a display value for use in tooltips, we can set clickBehaviorValue to the raw value for filtering.
       value: d.clickBehaviorValue || d.value,

--- a/frontend/src/metabase/modes/components/drill/ActionClickDrill/ActionClickDrill.tsx
+++ b/frontend/src/metabase/modes/components/drill/ActionClickDrill/ActionClickDrill.tsx
@@ -1,0 +1,43 @@
+import { getDataFromClicked } from "metabase/lib/click-behavior";
+
+import { executeRowAction } from "metabase/dashboard/actions";
+
+import type { ParameterMappedForActionExecution } from "metabase-types/api";
+import type { ActionClickObject } from "./types";
+
+import { prepareParameter } from "./utils";
+
+function ActionClickDrill({ clicked }: { clicked: ActionClickObject }) {
+  const { dashboard, dashcard } = clicked.extraData;
+  const { action } = dashcard;
+
+  if (!action) {
+    return [];
+  }
+
+  const parameters: ParameterMappedForActionExecution[] = [];
+  const data = getDataFromClicked(clicked);
+
+  dashcard.parameter_mappings?.forEach?.(mapping => {
+    const parameter = prepareParameter(mapping, { action, data });
+    if (parameter) {
+      parameters.push(parameter);
+    }
+  });
+
+  return [
+    {
+      name: "click_behavior",
+      default: true,
+      defaultAlways: true,
+      action: () =>
+        executeRowAction({
+          dashboard,
+          dashcard,
+          parameters,
+        }),
+    },
+  ];
+}
+
+export default ActionClickDrill;

--- a/frontend/src/metabase/modes/components/drill/ActionClickDrill/ActionClickDrill.tsx
+++ b/frontend/src/metabase/modes/components/drill/ActionClickDrill/ActionClickDrill.tsx
@@ -1,11 +1,14 @@
 import { getDataFromClicked } from "metabase/lib/click-behavior";
 
-import { executeRowAction } from "metabase/dashboard/actions";
+import {
+  executeRowAction,
+  openActionParametersModal,
+} from "metabase/dashboard/actions";
 
 import type { ParameterMappedForActionExecution } from "metabase-types/api";
 import type { ActionClickObject } from "./types";
 
-import { prepareParameter } from "./utils";
+import { prepareParameter, getNotProvidedActionParameters } from "./utils";
 
 function ActionClickDrill({ clicked }: { clicked: ActionClickObject }) {
   const { dashboard, dashcard } = clicked.extraData;
@@ -17,25 +20,49 @@ function ActionClickDrill({ clicked }: { clicked: ActionClickObject }) {
 
   const parameters: ParameterMappedForActionExecution[] = [];
   const data = getDataFromClicked(clicked);
+  const parameterMappings = dashcard.parameter_mappings || [];
 
-  dashcard.parameter_mappings?.forEach?.(mapping => {
+  parameterMappings.forEach(mapping => {
     const parameter = prepareParameter(mapping, { action, data });
     if (parameter) {
       parameters.push(parameter);
     }
   });
 
+  const missingParameters = getNotProvidedActionParameters(
+    action,
+    parameterMappings,
+    parameters,
+  );
+
+  function clickAction() {
+    if (missingParameters.length > 0) {
+      return openActionParametersModal({
+        dashcardId: dashcard.id,
+        props: {
+          missingParameters,
+          onSubmit: (filledParameters: ParameterMappedForActionExecution[]) =>
+            executeRowAction({
+              dashboard,
+              dashcard,
+              parameters: [...parameters, ...filledParameters],
+            }),
+        },
+      });
+    }
+    return executeRowAction({
+      dashboard,
+      dashcard,
+      parameters,
+    });
+  }
+
   return [
     {
       name: "click_behavior",
       default: true,
       defaultAlways: true,
-      action: () =>
-        executeRowAction({
-          dashboard,
-          dashcard,
-          parameters,
-        }),
+      action: clickAction,
     },
   ];
 }

--- a/frontend/src/metabase/modes/components/drill/ActionClickDrill/ActionClickDrill.unit.spec.ts
+++ b/frontend/src/metabase/modes/components/drill/ActionClickDrill/ActionClickDrill.unit.spec.ts
@@ -1,0 +1,195 @@
+import * as dashboardActions from "metabase/dashboard/actions/writeback";
+
+import type {
+  ActionButtonParametersMapping,
+  DashboardOrderedCard,
+  WritebackParameter,
+} from "metabase-types/api";
+import type { UiParameter } from "metabase/parameters/types";
+
+import {
+  createMockDashboard,
+  createMockDashboardActionButton,
+  createMockQueryAction,
+} from "metabase-types/api/mocks";
+
+import { ActionClickBehaviorData } from "./types";
+import { prepareParameter } from "./utils";
+import ActionClickDrill from "./ActionClickDrill";
+
+const WRITEBACK_PARAMETER: WritebackParameter = {
+  id: "param-1",
+  name: "Order ID",
+  type: "number",
+  slug: "order-id",
+  target: ["variable", ["template-tag", "order-id"]],
+};
+
+const DASHBOARD_FILTER_PARAMETER: UiParameter = {
+  id: "dashboard-filter-1",
+  name: "Order",
+  type: "number",
+  slug: "order",
+  value: 5,
+};
+
+const PARAMETER_MAPPING: ActionButtonParametersMapping = {
+  parameter_id: DASHBOARD_FILTER_PARAMETER.id,
+  target: WRITEBACK_PARAMETER.target,
+};
+
+function getActionClickBehaviorData(value: any): ActionClickBehaviorData {
+  return {
+    column: {},
+    parameter: {
+      [DASHBOARD_FILTER_PARAMETER.id]: { value },
+    },
+    parameterByName: {
+      [DASHBOARD_FILTER_PARAMETER.name]: { value },
+    },
+    parameterBySlug: {
+      [DASHBOARD_FILTER_PARAMETER.slug]: { value },
+    },
+    userAttribute: {},
+  };
+}
+
+describe("prepareParameter", () => {
+  it("returns nothing if can't find source parameter", () => {
+    const action = createMockQueryAction({
+      parameters: [WRITEBACK_PARAMETER],
+    });
+
+    const parameter = prepareParameter(PARAMETER_MAPPING, {
+      data: {
+        column: {},
+        parameter: {},
+        parameterByName: {},
+        parameterBySlug: {},
+        userAttribute: {},
+      },
+      action,
+    });
+
+    expect(parameter).toBeUndefined();
+  });
+
+  it("returns nothing if can't find action parameter", () => {
+    const action = createMockQueryAction({
+      parameters: [],
+    });
+
+    const parameter = prepareParameter(PARAMETER_MAPPING, {
+      data: getActionClickBehaviorData(DASHBOARD_FILTER_PARAMETER.value),
+      action,
+    });
+
+    expect(parameter).toBeUndefined();
+  });
+
+  it("prepares parameter correctly", () => {
+    const action = createMockQueryAction({
+      parameters: [WRITEBACK_PARAMETER],
+    });
+
+    const parameter = prepareParameter(PARAMETER_MAPPING, {
+      data: getActionClickBehaviorData(DASHBOARD_FILTER_PARAMETER.value),
+      action,
+    });
+
+    expect(parameter).toEqual({
+      id: DASHBOARD_FILTER_PARAMETER.id,
+      type: WRITEBACK_PARAMETER.type,
+      value: DASHBOARD_FILTER_PARAMETER.value,
+    });
+  });
+
+  it("handles array-like parameter value", () => {
+    const action = createMockQueryAction({
+      parameters: [WRITEBACK_PARAMETER],
+    });
+
+    const parameter = prepareParameter(PARAMETER_MAPPING, {
+      data: getActionClickBehaviorData([DASHBOARD_FILTER_PARAMETER.value]),
+      action,
+    });
+
+    expect(parameter).toEqual({
+      id: DASHBOARD_FILTER_PARAMETER.id,
+      type: WRITEBACK_PARAMETER.type,
+      value: DASHBOARD_FILTER_PARAMETER.value,
+    });
+  });
+});
+
+describe("ActionClickDrill", () => {
+  it("executes action correctly", () => {
+    const executeActionSpy = jest.spyOn(dashboardActions, "executeRowAction");
+
+    const action = createMockQueryAction({ parameters: [WRITEBACK_PARAMETER] });
+    const dashcard = createMockDashboardActionButton({
+      action,
+      action_id: action.id,
+      parameter_mappings: [PARAMETER_MAPPING],
+    });
+    const dashboard = createMockDashboard({
+      ordered_cards: [dashcard as unknown as DashboardOrderedCard],
+      parameters: [DASHBOARD_FILTER_PARAMETER],
+    });
+
+    const [clickAction] = ActionClickDrill({
+      clicked: {
+        data: [],
+        extraData: {
+          dashboard,
+          dashcard,
+          parameterValuesBySlug: {
+            [DASHBOARD_FILTER_PARAMETER.slug]: DASHBOARD_FILTER_PARAMETER.value,
+          },
+          userAttributes: [],
+        },
+      },
+    });
+
+    clickAction.action();
+
+    expect(executeActionSpy).toBeCalledWith({
+      dashboard,
+      dashcard,
+      parameters: [
+        {
+          id: DASHBOARD_FILTER_PARAMETER.id,
+          type: WRITEBACK_PARAMETER.type,
+          value: DASHBOARD_FILTER_PARAMETER.value,
+        },
+      ],
+    });
+  });
+
+  it("does nothing for buttons without linked action", () => {
+    const dashcard = createMockDashboardActionButton({
+      action_id: null,
+      parameter_mappings: [PARAMETER_MAPPING],
+    });
+    const dashboard = createMockDashboard({
+      ordered_cards: [dashcard as unknown as DashboardOrderedCard],
+      parameters: [DASHBOARD_FILTER_PARAMETER],
+    });
+
+    const clickActions = ActionClickDrill({
+      clicked: {
+        data: [],
+        extraData: {
+          dashboard,
+          dashcard,
+          parameterValuesBySlug: {
+            [DASHBOARD_FILTER_PARAMETER.slug]: DASHBOARD_FILTER_PARAMETER.value,
+          },
+          userAttributes: [],
+        },
+      },
+    });
+
+    expect(clickActions).toHaveLength(0);
+  });
+});

--- a/frontend/src/metabase/modes/components/drill/ActionClickDrill/index.ts
+++ b/frontend/src/metabase/modes/components/drill/ActionClickDrill/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ActionClickDrill";

--- a/frontend/src/metabase/modes/components/drill/ActionClickDrill/types.ts
+++ b/frontend/src/metabase/modes/components/drill/ActionClickDrill/types.ts
@@ -1,0 +1,27 @@
+import type { ActionButtonDashboardCard, Dashboard } from "metabase-types/api";
+import type { Column } from "metabase-types/types/Dataset";
+import type {
+  ParameterId,
+  ParameterValueOrArray,
+} from "metabase-types/types/Parameter";
+import type { ClickObject } from "metabase-types/types/Visualization";
+
+type ActionClickExtraData = {
+  dashboard: Dashboard;
+  dashcard: ActionButtonDashboardCard;
+  parameterValuesBySlug: Record<string, { value: ParameterValueOrArray }>;
+  userAttributes: unknown[];
+};
+
+export type ActionClickObject = Omit<ClickObject, "extraData"> & {
+  data: any;
+  extraData: ActionClickExtraData;
+};
+
+export type ActionClickBehaviorData = {
+  column: Partial<Column>;
+  parameter: Record<ParameterId, { value: ParameterValueOrArray }>;
+  parameterByName: Record<string, { value: ParameterValueOrArray }>;
+  parameterBySlug: Record<string, { value: ParameterValueOrArray }>;
+  userAttribute: Record<string, unknown>;
+};

--- a/frontend/src/metabase/modes/components/drill/ActionClickDrill/utils.ts
+++ b/frontend/src/metabase/modes/components/drill/ActionClickDrill/utils.ts
@@ -1,0 +1,42 @@
+import _ from "underscore";
+
+import type {
+  ActionButtonParametersMapping,
+  WritebackAction,
+} from "metabase-types/api";
+import type { ParameterValueOrArray } from "metabase-types/types/Parameter";
+
+import type { ActionClickBehaviorData } from "./types";
+
+function formatParameterValue(value: ParameterValueOrArray) {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+export function prepareParameter(
+  mapping: ActionButtonParametersMapping,
+  {
+    data,
+    action,
+  }: {
+    data: ActionClickBehaviorData;
+    action: WritebackAction;
+  },
+) {
+  const { parameter_id: sourceParameterId, target: actionParameterTarget } =
+    mapping;
+
+  const sourceParameter = data.parameter[sourceParameterId];
+  const actionParameter = action.parameters.find(parameter =>
+    _.isEqual(parameter.target, actionParameterTarget),
+  );
+
+  if (!actionParameter || !sourceParameter) {
+    return;
+  }
+
+  return {
+    id: sourceParameterId,
+    type: actionParameter.type,
+    value: formatParameterValue(sourceParameter.value),
+  };
+}

--- a/frontend/src/metabase/modes/components/drill/ActionClickDrill/utils.ts
+++ b/frontend/src/metabase/modes/components/drill/ActionClickDrill/utils.ts
@@ -2,9 +2,14 @@ import _ from "underscore";
 
 import type {
   ActionButtonParametersMapping,
+  ParameterMappedForActionExecution,
   WritebackAction,
+  WritebackParameter,
 } from "metabase-types/api";
-import type { ParameterValueOrArray } from "metabase-types/types/Parameter";
+import type {
+  ParameterTarget,
+  ParameterValueOrArray,
+} from "metabase-types/types/Parameter";
 
 import type { ActionClickBehaviorData } from "./types";
 
@@ -38,5 +43,40 @@ export function prepareParameter(
     id: sourceParameterId,
     type: actionParameter.type,
     value: formatParameterValue(sourceParameter.value),
+    target: actionParameterTarget,
   };
+}
+
+function isMappedParameter(
+  parameter: WritebackParameter,
+  parameterMappings: ActionButtonParametersMapping[],
+) {
+  return parameterMappings.some(mapping =>
+    _.isEqual(mapping.target, parameter.target),
+  );
+}
+
+export function getNotProvidedActionParameters(
+  action: WritebackAction,
+  parameterMappings: ActionButtonParametersMapping[],
+  mappedParameters: ParameterMappedForActionExecution[],
+) {
+  const emptyParameterTargets: ParameterTarget[] = [];
+
+  mappedParameters.forEach(mapping => {
+    if (mapping.value === undefined) {
+      emptyParameterTargets.push(mapping.target);
+    }
+  });
+
+  return action.parameters.filter(parameter => {
+    if ("default" in parameter) {
+      return false;
+    }
+    const isNotMapped = !isMappedParameter(parameter, parameterMappings);
+    const isMappedButNoValue = emptyParameterTargets.some(target =>
+      _.isEqual(target, parameter.target),
+    );
+    return isNotMapped || isMappedButNoValue;
+  });
 }

--- a/frontend/src/metabase/modes/components/drill/DashboardClickDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/DashboardClickDrill.jsx
@@ -7,8 +7,6 @@ import Question from "metabase-lib/lib/Question";
 import {
   setOrUnsetParameterValues,
   setParameterValue,
-  openActionParametersModal,
-  executeRowAction,
 } from "metabase/dashboard/actions";
 import {
   getDataFromClicked,
@@ -17,10 +15,6 @@ import {
 } from "metabase/lib/click-behavior";
 import { renderLinkURLForClick } from "metabase/lib/formatting/link";
 import * as Urls from "metabase/lib/urls";
-import {
-  getActionParameters,
-  getNotProvidedActionParameters,
-} from "metabase/writeback/utils";
 
 export default ({ question, clicked }) => {
   const settings = (clicked && clicked.settings) || {};
@@ -47,49 +41,7 @@ export default ({ question, clicked }) => {
     return [];
   }
 
-  if (type === "action") {
-    const parameters = getActionParameters(parameterMapping, {
-      data,
-      extraData,
-      clickBehavior,
-    });
-    const action = extraData.actions[clickBehavior.action];
-    const missingParameters = getNotProvidedActionParameters(
-      action,
-      parameters,
-    );
-    const emitterId = clickBehavior.emitter_id || clickBehavior.id;
-
-    if (missingParameters.length > 0) {
-      behavior = {
-        action: () =>
-          openActionParametersModal({
-            emitterId: emitterId,
-            props: {
-              missingParameters,
-              onSubmit: filledMissingParameters =>
-                executeRowAction({
-                  dashboard: extraData.dashboard,
-                  emitterId: emitterId,
-                  parameters: {
-                    ...parameters,
-                    ...filledMissingParameters,
-                  },
-                }),
-            },
-          }),
-      };
-    } else {
-      behavior = {
-        action: () =>
-          executeRowAction({
-            dashboard: extraData.dashboard,
-            emitterId: emitterId,
-            parameters,
-          }),
-      };
-    }
-  } else if (type === "crossfilter") {
+  if (type === "crossfilter") {
     const parameterIdValuePairs = getParameterIdValuePairs(parameterMapping, {
       data,
       extraData,

--- a/frontend/src/metabase/modes/components/modes/ActionMode.jsx
+++ b/frontend/src/metabase/modes/components/modes/ActionMode.jsx
@@ -1,8 +1,8 @@
-import DashboardClickDrill from "../drill/DashboardClickDrill";
+import ActionClickDrill from "../drill/ActionClickDrill";
 
 const ActionMode = {
   name: "actions",
-  drills: () => [DashboardClickDrill],
+  drills: () => [ActionClickDrill],
 };
 
 export default ActionMode;

--- a/frontend/src/metabase/parameters/utils/mapping-options.js
+++ b/frontend/src/metabase/parameters/utils/mapping-options.js
@@ -63,7 +63,7 @@ export function getParameterMappingOptions(
   }
 
   if (isActionButtonCard(card)) {
-    // action cards don't have parameters
+    // Action parameters are mapped via click behavior UI for now
     return [];
   }
 

--- a/frontend/src/metabase/parameters/utils/mapping-options.js
+++ b/frontend/src/metabase/parameters/utils/mapping-options.js
@@ -1,6 +1,7 @@
 import Question from "metabase-lib/lib/Question";
-
 import { ExpressionDimension } from "metabase-lib/lib/Dimension";
+
+import { isActionButtonCard } from "metabase/writeback/utils";
 
 import {
   dimensionFilterForParameter,
@@ -61,7 +62,7 @@ export function getParameterMappingOptions(
     return tagNames ? tagNames.map(buildTextTagOption) : [];
   }
 
-  if (card.display === "action-button") {
+  if (isActionButtonCard(card)) {
     // action cards don't have parameters
     return [];
   }

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -536,4 +536,7 @@ export const ActionsApi = {
   delete: POST("/api/action/row/delete"),
   bulkUpdate: POST("/api/action/bulk/update/:tableId"),
   bulkDelete: POST("/api/action/bulk/delete/:tableId"),
+  execute: POST(
+    "/api/dashboard/:dashboardId/dashcard/:dashcardId/action/:actionId/execute",
+  ),
 };

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -537,10 +537,3 @@ export const ActionsApi = {
   bulkUpdate: POST("/api/action/bulk/update/:tableId"),
   bulkDelete: POST("/api/action/bulk/delete/:tableId"),
 };
-
-export const EmittersApi = {
-  create: POST("/api/emitter"),
-  update: PUT("/api/emitter/:id"),
-  delete: DELETE("/api/emitter/:id"),
-  execute: POST("/api/emitter/:id/execute"),
-};

--- a/frontend/src/metabase/visualizations/hoc/WithVizSettingsData.js
+++ b/frontend/src/metabase/visualizations/hoc/WithVizSettingsData.js
@@ -5,14 +5,10 @@ import _ from "underscore";
 
 import { getUserAttributes } from "metabase/selectors/user";
 
-import Actions from "metabase/entities/actions";
 import Questions from "metabase/entities/questions";
 import Dashboards from "metabase/entities/dashboards";
 
 function hasLinkedQuestionOrDashboard({ type, linkType, action } = {}) {
-  if (type === "action") {
-    return typeof action === "number";
-  }
   if (type === "link") {
     return linkType === "question" || linkType === "dashboard";
   }
@@ -20,12 +16,6 @@ function hasLinkedQuestionOrDashboard({ type, linkType, action } = {}) {
 }
 
 function mapLinkedEntityToEntityQuery({ type, linkType, action, targetId }) {
-  if (type === "action") {
-    return {
-      entity: Actions,
-      entityId: action,
-    };
-  }
   return {
     entity: linkType === "question" ? Questions : Dashboards,
     entityId: targetId,

--- a/frontend/src/metabase/visualizations/hoc/WithVizSettingsData.js
+++ b/frontend/src/metabase/visualizations/hoc/WithVizSettingsData.js
@@ -55,6 +55,7 @@ const WithVizSettingsData = ComposedComponent => {
           ...entitiesByTypeAndId,
           parameterValuesBySlug: props.parameterValuesBySlug,
           dashboard: props.dashboard,
+          dashcard: props.dashcard,
           userAttributes: getUserAttributes(state, props),
         };
       },

--- a/frontend/src/metabase/writeback/containers/ActionParametersInputForm.tsx
+++ b/frontend/src/metabase/writeback/containers/ActionParametersInputForm.tsx
@@ -3,7 +3,6 @@ import { connect } from "react-redux";
 import { t } from "ttag";
 
 import Form from "metabase/containers/Form";
-import { getActionParameterType } from "metabase/writeback/utils";
 
 import type { ParametersMappedToValues } from "metabase-types/api";
 import type { Parameter, ParameterId } from "metabase-types/types/Parameter";
@@ -18,6 +17,14 @@ interface Props {
   };
   onSubmitSuccess: () => void;
   dispatch: Dispatch;
+}
+
+function getActionParameterType(parameter: Parameter) {
+  const { type } = parameter;
+  if (type === "category") {
+    return "string/=";
+  }
+  return type;
 }
 
 function getParameterFieldProps(parameter: Parameter) {

--- a/frontend/src/metabase/writeback/utils.ts
+++ b/frontend/src/metabase/writeback/utils.ts
@@ -3,7 +3,10 @@ import { TYPE } from "metabase/lib/types";
 import type Database from "metabase-lib/lib/metadata/Database";
 import type Field from "metabase-lib/lib/metadata/Field";
 
-import type { DashboardOrderedCard } from "metabase-types/api";
+import type {
+  ActionButtonDashboardCard,
+  BaseDashboardOrderedCard,
+} from "metabase-types/api";
 import type { SavedCard } from "metabase-types/types/Card";
 import type { Database as IDatabase } from "metabase-types/types/Database";
 
@@ -61,15 +64,21 @@ export const isEditableField = (field: Field) => {
 export const isActionButtonCard = (card: SavedCard) =>
   card?.display === "action-button";
 
-export const isActionButtonDashCard = (dashCard: DashboardOrderedCard) =>
-  isActionButtonCard(
-    dashCard.visualization_settings?.virtual_card as SavedCard,
-  );
+export function isActionButtonDashCard(
+  dashCard: BaseDashboardOrderedCard,
+): dashCard is ActionButtonDashboardCard {
+  const virtualCard = dashCard.visualization_settings?.virtual_card;
+  return isActionButtonCard(virtualCard as SavedCard);
+}
 
-export const isActionButtonWithMappedAction = (
-  dashCard: DashboardOrderedCard,
-) => {
-  return (
-    isActionButtonDashCard(dashCard) && typeof dashCard.action_id === "number"
-  );
-};
+export function isActionButtonWithMappedAction(
+  dashCard: BaseDashboardOrderedCard,
+): dashCard is ActionButtonDashboardCard {
+  const isAction = isActionButtonDashCard(dashCard);
+  return isAction && typeof dashCard.action_id === "number";
+}
+
+export function getActionButtonLabel(dashCard: ActionButtonDashboardCard) {
+  const label = dashCard.visualization_settings?.["button.label"];
+  return label || "";
+}

--- a/frontend/src/metabase/writeback/utils.ts
+++ b/frontend/src/metabase/writeback/utils.ts
@@ -12,9 +12,10 @@ import type {
   ActionClickExtraData,
   ActionClickBehavior,
   ActionParameterTuple,
-} from "metabase-types/api/writeback";
+  DashboardOrderedCard,
+} from "metabase-types/api";
+import type { SavedCard } from "metabase-types/types/Card";
 import type { Database as IDatabase } from "metabase-types/types/Database";
-import type { DashCard } from "metabase-types/types/Dashboard";
 import type { Parameter, ParameterId } from "metabase-types/types/Parameter";
 
 const DB_WRITEBACK_FEATURE = "actions";
@@ -68,8 +69,13 @@ export const isEditableField = (field: Field) => {
   return true;
 };
 
-export const isActionButtonDashCard = (dashCard: DashCard) =>
-  dashCard.visualization_settings?.virtual_card?.display === "action-button";
+export const isActionButtonCard = (card: SavedCard) =>
+  card?.display === "action-button";
+
+export const isActionButtonDashCard = (dashCard: DashboardOrderedCard) =>
+  isActionButtonCard(
+    dashCard.visualization_settings?.virtual_card as SavedCard,
+  );
 
 export function getActionParameterType(parameter: Parameter) {
   const { type } = parameter;

--- a/frontend/src/metabase/writeback/utils.ts
+++ b/frontend/src/metabase/writeback/utils.ts
@@ -1,22 +1,11 @@
 import { TYPE } from "metabase/lib/types";
-import { formatSourceForTarget } from "metabase/lib/click-behavior";
 
 import type Database from "metabase-lib/lib/metadata/Database";
 import type Field from "metabase-lib/lib/metadata/Field";
 
-import type {
-  WritebackAction,
-  ParametersMappedToValues,
-  ParametersSourceTargetMap,
-  ActionClickBehaviorData,
-  ActionClickExtraData,
-  ActionClickBehavior,
-  ActionParameterTuple,
-  DashboardOrderedCard,
-} from "metabase-types/api";
 import type { SavedCard } from "metabase-types/types/Card";
 import type { Database as IDatabase } from "metabase-types/types/Database";
-import type { Parameter, ParameterId } from "metabase-types/types/Parameter";
+import type { Parameter } from "metabase-types/types/Parameter";
 
 const DB_WRITEBACK_FEATURE = "actions";
 const DB_WRITEBACK_SETTING = "database-enable-actions";
@@ -83,89 +72,4 @@ export function getActionParameterType(parameter: Parameter) {
     return "string/=";
   }
   return type;
-}
-
-function isParametersTuple(
-  listOrListOfTuples: ActionParameterTuple[] | Parameter[],
-): listOrListOfTuples is ActionParameterTuple[] {
-  const [sample] = listOrListOfTuples;
-  if (!sample) {
-    return false;
-  }
-  return Array.isArray(sample);
-}
-
-function getParametersFromTuples(
-  parameterTuples: ActionParameterTuple[] | Parameter[],
-): Parameter[] {
-  if (!isParametersTuple(parameterTuples)) {
-    return parameterTuples;
-  }
-  return parameterTuples.map(tuple => {
-    const [, parameter] = tuple;
-    return parameter;
-  });
-}
-
-export function getActionParameters(
-  parameterMapping: ParametersSourceTargetMap = {},
-  {
-    data,
-    extraData,
-    clickBehavior,
-  }: {
-    data: ActionClickBehaviorData;
-    extraData: ActionClickExtraData;
-    clickBehavior: ActionClickBehavior;
-  },
-) {
-  const action = extraData.actions[clickBehavior.action];
-
-  const parameters = getParametersFromTuples(action.parameters);
-  const parameterValuesMap: ParametersMappedToValues = {};
-
-  Object.values(parameterMapping).forEach(({ id, source, target }) => {
-    const targetParameter = parameters.find(parameter => parameter.id === id);
-    if (targetParameter) {
-      const result = formatSourceForTarget(source, target, {
-        data,
-        extraData,
-        clickBehavior,
-      });
-      // For some reason it's sometimes [1] and sometimes just 1
-      const value = Array.isArray(result) ? result[0] : result;
-
-      parameterValuesMap[id] = {
-        value,
-        type: getActionParameterType(targetParameter),
-      };
-    }
-  });
-
-  return parameterValuesMap;
-}
-
-export function getNotProvidedActionParameters(
-  action: WritebackAction,
-  parameterValuesMap: ParametersMappedToValues,
-) {
-  const parameters = getParametersFromTuples(action.parameters);
-  const mappedParameterIDs = Object.keys(parameterValuesMap);
-
-  const emptyParameterIDs: ParameterId[] = [];
-  mappedParameterIDs.forEach(parameterId => {
-    const { value } = parameterValuesMap[parameterId];
-    if (value === undefined) {
-      emptyParameterIDs.push(parameterId);
-    }
-  });
-
-  return parameters.filter(parameter => {
-    if ("default" in parameter) {
-      return false;
-    }
-    const isNotMapped = !mappedParameterIDs.includes(parameter.id);
-    const isMappedButNoValue = emptyParameterIDs.includes(parameter.id);
-    return isNotMapped || isMappedButNoValue;
-  });
 }

--- a/frontend/src/metabase/writeback/utils.ts
+++ b/frontend/src/metabase/writeback/utils.ts
@@ -3,9 +3,9 @@ import { TYPE } from "metabase/lib/types";
 import type Database from "metabase-lib/lib/metadata/Database";
 import type Field from "metabase-lib/lib/metadata/Field";
 
+import type { DashboardOrderedCard } from "metabase-types/api";
 import type { SavedCard } from "metabase-types/types/Card";
 import type { Database as IDatabase } from "metabase-types/types/Database";
-import type { Parameter } from "metabase-types/types/Parameter";
 
 const DB_WRITEBACK_FEATURE = "actions";
 const DB_WRITEBACK_SETTING = "database-enable-actions";
@@ -66,10 +66,10 @@ export const isActionButtonDashCard = (dashCard: DashboardOrderedCard) =>
     dashCard.visualization_settings?.virtual_card as SavedCard,
   );
 
-export function getActionParameterType(parameter: Parameter) {
-  const { type } = parameter;
-  if (type === "category") {
-    return "string/=";
-  }
-  return type;
-}
+export const isActionButtonWithMappedAction = (
+  dashCard: DashboardOrderedCard,
+) => {
+  return (
+    isActionButtonDashCard(dashCard) && typeof dashCard.action_id === "number"
+  );
+};

--- a/frontend/src/metabase/writeback/utils.ts
+++ b/frontend/src/metabase/writeback/utils.ts
@@ -6,7 +6,6 @@ import type Field from "metabase-lib/lib/metadata/Field";
 
 import type {
   WritebackAction,
-  ParameterMappings,
   ParametersMappedToValues,
   ParametersSourceTargetMap,
   ActionClickBehaviorData,
@@ -72,12 +71,6 @@ export const isEditableField = (field: Field) => {
 export const isActionButtonDashCard = (dashCard: DashCard) =>
   dashCard.visualization_settings?.virtual_card?.display === "action-button";
 
-export const getActionButtonEmitterId = (dashCard: DashCard) =>
-  dashCard.visualization_settings?.click_behavior?.emitter_id;
-
-export const getActionButtonActionId = (dashCard: DashCard) =>
-  dashCard.visualization_settings?.click_behavior?.action;
-
 export function getActionParameterType(parameter: Parameter) {
   const { type } = parameter;
   if (type === "category") {
@@ -107,20 +100,6 @@ function getParametersFromTuples(
     return parameter;
   });
 }
-
-export const getActionEmitterParameterMappings = (action: WritebackAction) => {
-  const parameters = getParametersFromTuples(action.parameters);
-  const parameterMappings: ParameterMappings = {};
-
-  parameters.forEach(parameter => {
-    parameterMappings[parameter.id] = [
-      "variable",
-      ["template-tag", parameter.slug],
-    ];
-  });
-
-  return parameterMappings;
-};
 
 export function getActionParameters(
   parameterMapping: ParametersSourceTargetMap = {},


### PR DESCRIPTION
Part of #25020. Closes #25234, closes #25235, closes #25236

In 44, we've prototyped custom query actions execution as a part of #22542 (FE PRs #23206 and #23371). That allows people to define parametrized write-queries on their data and run them on a need. The end goal is data apps, i.e. having pages where you can put some data, add buttons linked to actions and then run those queries on button clicks seeing how data changes.

After playing with what we've built in 44, we realized this design might be error-prone. So now we're changing the internal implementation. This PR should do all the necessary FE work. BE changes this branch is relying on are made in #25001 and #25198

### Motivation

In 44, we've introduced two new entities — actions and emitters.

An action contains a card with a write query. For instance:
`UPDATE orders SET discount = null WHERE id = {{ order_id }}`

An emitter links an action with a particular data app page (essentially a many-to-many relation table). The FE should have called an emitter endpoint to execute an action via `POST /api/emitter/:emittedId/execute`. We needed an entity between a page and an action for two main reasons:

1. Have a way to find out which page executed action (for things like Audit and permissions in the future)
2. For storing parameter mappings (for instance we need to persist that the `order_id` action's variable should receive its value from the page's "Order ID" filter)

**Problems with emitters**

People run actions by clicking buttons on their data apps' pages. We came up with two possible ways to put this all together:

1. Render emitters as buttons. This would require duplicating some of the dashcard behaviors on emitters. For instance, emitters should keep properties like `sizeX`, `sizeY`, `visualization_settings`. We figured that would be too difficult to implement as our dashboard code relies on everything being a dashboard card too much and it'd take too long.
2. Re-use the "virtual dashboard card" notion for buttons and link them with emitters. We have markdown-only cards that don't have any queriable questions attached. We can make action buttons look the same, store the corresponding `emitter_id` inside the dash card and make buttons re-using the "click behavior" feature.

In 44 we went with opt. 2 as it was way more straightforward. That opens a window for bugs though:

1. If you delete an emitter, you end up with a button dash card linked to it
2. Vice versa, if you delete a button, you can end up with an emitter attached to a dashboard that is not really in use

Both issues are fixable with a bunch of pre-save checks, but those checks make code more complex, and still can't guarantee we avoid these issues for good.

### New design

We're delegating emitter responsibilities to a dash card. Dash cards already have `parameter_mappings` we can reuse for actions. BE change in #25001 adds the `action_id` property to dash cards that we're only going to set for action buttons. This allows us to:

1. Avoid data inconsistency problems explained above
2. Avoid significant changes both on the FE and BE
3. Avoid a bunch of potential added complexity

**FE changes**

There are a few steps made in this PR:

1. Removed existing action execution implementation based on emitters and click behavior
2. Update the action section in the click behavior sidebar to support the new way of mapping parameters between dashboard and actions
3. Implement a new `ActionClickDrill` that'd prepare parameter values and finally execute an action
4. Add support for arbitrary parameters (basically #23371 reimplemented)

### Demo

https://user-images.githubusercontent.com/17258145/188471288-f5e861cd-1059-473e-b1da-f9528be72829.mp4


