### PR TITLE
Fix "Lint doc Markdown links" running on all PRs

### DIFF
--- a/.github/workflows/doc-md-links.yml
+++ b/.github/workflows/doc-md-links.yml
@@ -3,7 +3,7 @@ name: Lint doc Markdown links
 on:
   push:
     paths:
-      - 'docs/**'
+      - docs/**
 jobs:
   markdown-link-check:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
The `Lint doc Markdown links / markdown-link-check (push)` job runs on all PRs, even though it doesn't make changes to the docs/.

For example this [commit](https://github.com/metabase/metabase/pull/25167/commits/75f21f1d6061146fa8b5a6eb3c245db229913b69) belongs to this PR https://github.com/metabase/metabase/pull/25167

Change it to run only when we have changes in the /docs folder.