### PR TITLE
Hacky support for bytea as PK/FK

### DIFF
--- a/shared/src/metabase/types.cljc
+++ b/shared/src/metabase/types.cljc
@@ -314,6 +314,8 @@
 (derive :Coercion/Bytes->Temporal :Coercion/*)
 (derive :Coercion/YYYYMMDDHHMMSSBytes->Temporal :Coercion/Bytes->Temporal)
 
+(derive :Coercion/Bytes->String :Coercion/*)
+
 (derive :Coercion/Number->Temporal :Coercion/*)
 (derive :Coercion/UNIXTime->Temporal :Coercion/Number->Temporal)
 (derive :Coercion/UNIXSeconds->DateTime :Coercion/UNIXTime->Temporal)
@@ -358,6 +360,8 @@
 (coercion-hierarchies/define-types! :Coercion/YYYYMMDDHHMMSSString->Temporal :type/Text                 :type/DateTime)
 
 (coercion-hierarchies/define-non-inheritable-type! :Coercion/YYYYMMDDHHMMSSBytes->Temporal :type/* :type/DateTime)
+
+(coercion-hierarchies/define-types! :Coercion/Bytes->String              :type/*                     :type/Text)
 
 (defn is-coercible-from?
   "Whether `coercion-strategy` is allowed for `base-type`."

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -240,6 +240,10 @@
   (sql.qp/cast-temporal-string driver :Coercion/YYYYMMDDHHMMSSString->Temporal
                                (hsql/call :convert_from expr (hx/literal "UTF8"))))
 
+(defmethod sql.qp/cast-bytes-string [:postgres  :Coercion/Bytes->String]
+  [driver _coercion-strategy expr]
+  (hx/->text expr))
+
 (defn- date-trunc [unit expr] (hsql/call :date_trunc (hx/literal unit) (->timestamp expr)))
 (defn- extract    [unit expr] (hsql/call :extract    unit              (->timestamp expr)))
 

--- a/src/metabase/driver/sql_jdbc.clj
+++ b/src/metabase/driver/sql_jdbc.clj
@@ -87,3 +87,7 @@
 (defmethod sql.qp/cast-temporal-string [:sql-jdbc :Coercion/YYYYMMDDHHMMSSString->Temporal]
   [_driver _semantic_type expr]
   (hx/->timestamp expr))
+
+(defmethod sql.qp/cast-bytes-string [:sql-jdbc :Coercion/String->Bytes]
+  [_driver _semantic_type expr]
+  (hx/->text expr));

--- a/src/metabase/util/honeysql_extensions.clj
+++ b/src/metabase/util/honeysql_extensions.clj
@@ -297,6 +297,7 @@
 (defn ->integer                  "CAST `x` to a `integer`."                  [x] (maybe-cast :integer x))
 (defn ->time                     "CAST `x` to a `time` datatype"             [x] (maybe-cast :time x))
 (defn ->boolean                  "CAST `x` to a `boolean` datatype"          [x] (maybe-cast :boolean x))
+(defn ->text                     "CAST `x` to a `text` datatype"             [x] (cast :text x))
 
 ;;; Random SQL fns. Not all DBs support all these!
 (def ^{:arglists '([& exprs])} floor   "SQL `floor` function."   (partial hsql/call :floor))


### PR DESCRIPTION
Hi folks, 

I bumped into [this issue](https://github.com/metabase/metabase/issues/1723) as we use bytea encoded SHA256 hashes everywhere in our postgres db as primary/foreign keys. I made patch I made which adds the ability to cast bytea to strings (a bit like you can do for binary/string encoded temporal stuff).

I've only tested it on postgres. It seems the option to use a 'cast' is not present if you first set the entity type to be a FK, but if you set the type to something else, then set up the cast, then switch it to being an FK it seems to work.

DISCLAMER: I have never written a line of clojure in my life before yesterday, it was a bit of a voyage of discovery so I've probably done everything wrong, but it WorksForMe(tm) and thought it might be more generally useful.

- [x] Run the frontend and Cypress end-to-end tests with `yarn lint && yarn test`)
- [x] If there are changes to the backend codebase, run the backend tests with `clojure -X:dev:test`
- [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
      (unless it's a tiny documentation change).

PS: I ran the tests and got some errors shown below.. My mind is already melted a bit and I can't quite face diving back into type coercion hierarchies; if anyone has any hints I'll gladly take them if this patch is of interest.
 
```
FAIL in metabase.types-test/coercion-possibilities-test (types_test.cljc:36)    1
expected: {:type/Instant #{:Coercion/UNIXMicroSeconds->DateTime
                           :Coercion/UNIXMilliSeconds->DateTime
                           :Coercion/UNIXSeconds->DateTime},
           :type/Text #{:metabase.types-test/Coerce-Int-To-Str}}
  actual: ({:type/Instant #{:Coercion/UNIXMicroSeconds->DateTime
                            :Coercion/UNIXMilliSeconds->DateTime
                            :Coercion/UNIXSeconds->DateTime},
            :type/Text #{:Coercion/Bytes->String
                         :metabase.types-test/Coerce-Int-To-Str}})

FAIL in metabase.types-test/coercion-possibilities-test (types_test.cljc:41)    1
expected: {:type/Instant #{:Coercion/UNIXMicroSeconds->DateTime
                           :Coercion/UNIXMilliSeconds->DateTime
                           :Coercion/UNIXSeconds->DateTime}}
  actual: ({:type/Instant #{:Coercion/UNIXMicroSeconds->DateTime
                            :Coercion/UNIXMilliSeconds->DateTime
                            :Coercion/UNIXSeconds->DateTime},
            :type/Text #{:Coercion/Bytes->String}})

FAIL in metabase.types-test/coercion-possibilities-test (types_test.cljc:47)    1
Should work for for subtypes of a the coercion base type(s)
expected: {:type/Instant #{:Coercion/UNIXMicroSeconds->DateTime
                           :Coercion/UNIXMilliSeconds->DateTime
                           :Coercion/UNIXSeconds->DateTime
                           :metabase.types-test/Coerce-BigInteger-To-Instant},
           :type/Text #{:metabase.types-test/Coerce-Int-To-Str}}
  actual: ({:type/Instant #{:Coercion/UNIXMicroSeconds->DateTime
                            :Coercion/UNIXMilliSeconds->DateTime
                            :Coercion/UNIXSeconds->DateTime
                            :metabase.types-test/Coerce-BigInteger-To-Instant},
            :type/Text #{:Coercion/Bytes->String
                         :metabase.types-test/Coerce-Int-To-Str}})

FAIL in metabase.types-test/coercion-possibilities-test (types_test.cljc:55)    1
Should *not* work for ancestor types of the coercion base type(s)
expected: nil
  actual: ({:type/Text #{:Coercion/Bytes->String}})

FAIL in metabase.types-test/coercion-possibilities-test (types_test.cljc:59)    1
Non-inheritable coercions
expected: {:type/* #{:Coercion/YYYYMMDDHHMMSSBytes->Temporal}}
  actual: ({:type/* #{:Coercion/YYYYMMDDHHMMSSBytes->Temporal},
            :type/Text #{:Coercion/Bytes->String}})

FAIL in metabase.types-test/coercion-possibilities-test (types_test.cljc:62)    1
Non-inheritable coercions
expected: nil
  actual: ({:type/Text #{:Coercion/Bytes->String}})
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/25247)
<!-- Reviewable:end -->
