### PR TITLE
Remove current action execution implementation

### DIFF
--- a/frontend/src/metabase-types/api/dashboard.ts
+++ b/frontend/src/metabase-types/api/dashboard.ts
@@ -94,13 +94,6 @@ export interface ArbitraryCustomDestinationClickBehavior {
   linkTextTemplate?: string;
 }
 
-export interface WritebackActionClickBehavior {
-  type: "action";
-  action: EntityId;
-  emitter_id: EntityId;
-  parameterMapping?: ClickBehaviorParameterMapping;
-}
-
 // Makes click handler use default drills
 // This is virtual, i.e. if a card has no clickBehavior,
 // it'd behave as if it's an "actionMenu"
@@ -115,5 +108,4 @@ export type CustomDestinationClickBehavior =
 export type ClickBehavior =
   | ActionMenuClickBehavior
   | CrossFilterClickBehavior
-  | CustomDestinationClickBehavior
-  | WritebackActionClickBehavior;
+  | CustomDestinationClickBehavior;

--- a/frontend/src/metabase-types/api/writeback.ts
+++ b/frontend/src/metabase-types/api/writeback.ts
@@ -55,17 +55,6 @@ export type WritebackQueryAction = WritebackActionBase & QueryAction;
 export type WritebackHttpAction = WritebackActionBase & HttpAction;
 export type WritebackAction = WritebackActionBase & (QueryAction | HttpAction);
 
-export interface WritebackActionEmitter {
-  id: number;
-  dashboard_id: number;
-  action: WritebackAction & {
-    emitter_id: number;
-  };
-  parameter_mappings: Record<ParameterId, ParameterTarget>;
-  updated_at: string;
-  created_at: string;
-}
-
 export type ParameterMappings = Record<ParameterId, ParameterTarget>;
 
 export type ActionClickBehaviorData = {

--- a/frontend/src/metabase-types/api/writeback.ts
+++ b/frontend/src/metabase-types/api/writeback.ts
@@ -8,15 +8,13 @@ import {
   ParameterValueOrArray,
 } from "metabase-types/types/Parameter";
 
-export type ActionParameterTuple = [string, Parameter];
-
 export type WritebackActionType = "http" | "query";
 
 export interface WritebackActionBase {
   id: number;
   name: string;
   description: string | null;
-  parameters: ActionParameterTuple[];
+  parameters: Parameter[];
   "updated-at": string;
   "created-at": string;
 }

--- a/frontend/src/metabase-types/api/writeback.ts
+++ b/frontend/src/metabase-types/api/writeback.ts
@@ -1,12 +1,13 @@
-import { SavedCard, NativeDatasetQuery } from "metabase-types/types/Card";
-import { DashboardWithCards } from "metabase-types/types/Dashboard";
-import { Column } from "metabase-types/types/Dataset";
+import { Card } from "metabase-types/api";
 import {
   Parameter,
   ParameterId,
   ParameterTarget,
-  ParameterValueOrArray,
 } from "metabase-types/types/Parameter";
+
+export interface WritebackParameter extends Parameter {
+  target: ParameterTarget;
+}
 
 export type WritebackActionType = "http" | "query";
 
@@ -14,12 +15,12 @@ export interface WritebackActionBase {
   id: number;
   name: string;
   description: string | null;
-  parameters: Parameter[];
+  parameters: WritebackParameter[];
   "updated-at": string;
   "created-at": string;
 }
 
-type QueryActionCard = SavedCard<NativeDatasetQuery> & {
+export type QueryActionCard = Card & {
   is_write: true;
   action_id: number;
 };
@@ -55,38 +56,18 @@ export type WritebackAction = WritebackActionBase & (QueryAction | HttpAction);
 
 export type ParameterMappings = Record<ParameterId, ParameterTarget>;
 
-export type ActionClickBehaviorData = {
-  column: Partial<Column>;
-  parameter: Record<ParameterId, { value: ParameterValueOrArray }>;
-  parameterByName: Record<string, { value: ParameterValueOrArray }>;
-  parameterBySlug: Record<string, { value: ParameterValueOrArray }>;
-  userAttributes: Record<string, unknown>;
-};
-
-export type ActionClickBehavior = {
-  action: number; // action id
-  emitter_id: number;
-  type: "action";
-  parameterMapping: ParameterMappings;
-};
-
-export type ActionClickExtraData = {
-  actions: Record<number, WritebackAction>;
-  dashboard: DashboardWithCards;
-  parameterBySlug: Record<string, { value: ParameterValueOrArray }>;
-  userAttributes: unknown[];
-};
-
-export type ParametersSourceTargetMap = Record<
-  ParameterId,
-  {
-    id: ParameterId;
-    source: { id: string; type: string; name: string };
-    target: { id: string; type: string };
-  }
->;
-
 export type ParametersMappedToValues = Record<
   ParameterId,
   { type: string; value: string | number }
 >;
+
+export type ParameterMappedForActionExecution = {
+  id: ParameterId;
+  type: string;
+  value: string | number;
+};
+
+// we will tighten this up when we figure out what the form settings should look like
+export type ActionFormSettings = {
+  [key: string]: any;
+};

--- a/frontend/src/metabase-types/api/writeback.ts
+++ b/frontend/src/metabase-types/api/writeback.ts
@@ -66,8 +66,3 @@ export type ParameterMappedForActionExecution = {
   type: string;
   value: string | number;
 };
-
-// we will tighten this up when we figure out what the form settings should look like
-export type ActionFormSettings = {
-  [key: string]: any;
-};

--- a/frontend/src/metabase/dashboard/actions/writeback.ts
+++ b/frontend/src/metabase/dashboard/actions/writeback.ts
@@ -28,12 +28,6 @@ export const openActionParametersModal = createAction(
   OPEN_ACTION_PARAMETERS_MODAL,
 );
 
-export const CLOSE_ACTION_PARAMETERS_MODAL =
-  "metabase/data-app/CLOSE_ACTION_PARAMETERS_MODAL";
-export const closeActionParametersModal = createAction(
-  CLOSE_ACTION_PARAMETERS_MODAL,
-);
-
 export type InsertRowFromDataAppPayload = InsertRowPayload & {
   dashCard: DashCard;
 };

--- a/frontend/src/metabase/dashboard/actions/writeback.ts
+++ b/frontend/src/metabase/dashboard/actions/writeback.ts
@@ -244,7 +244,6 @@ export const deleteManyRowsFromDataApp = (
 
 export type ExecuteRowActionPayload = {
   dashboard: DashboardWithCards;
-  emitterId: number;
   parameters: Record<string, unknown>;
 };
 

--- a/frontend/src/metabase/dashboard/actions/writeback.ts
+++ b/frontend/src/metabase/dashboard/actions/writeback.ts
@@ -1,7 +1,6 @@
 import { t } from "ttag";
 
 import { createAction } from "metabase/lib/redux";
-import { EmittersApi } from "metabase/services";
 import { addUndo } from "metabase/redux/undo";
 
 import {
@@ -251,15 +250,13 @@ export type ExecuteRowActionPayload = {
 
 export const executeRowAction = ({
   dashboard,
-  emitterId,
   parameters,
 }: ExecuteRowActionPayload) => {
   return async function (dispatch: any) {
     try {
-      const result = await EmittersApi.execute({
-        id: emitterId,
-        parameters,
-      });
+      const result = {
+        "rows-affected": 0,
+      };
       if (result["rows-affected"] > 0) {
         dashboard.ordered_cards
           .filter(dashCard => !isVirtualDashCard(dashCard))

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ActionOptions/ActionOptions.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ActionOptions/ActionOptions.tsx
@@ -10,7 +10,6 @@ import type {
   DashboardOrderedCard,
   ClickBehavior,
   WritebackAction,
-  WritebackActionClickBehavior,
 } from "metabase-types/api";
 
 import { SidebarItem } from "../SidebarItem";
@@ -51,8 +50,8 @@ const ActionOption = ({
 
 interface ActionOptionsProps {
   dashcard: DashboardOrderedCard;
-  clickBehavior: WritebackActionClickBehavior;
-  updateSettings: (settings: ClickBehavior) => void;
+  clickBehavior: ClickBehavior;
+  updateSettings: (settings: Partial<ClickBehavior>) => void;
 }
 
 function ActionOptions({
@@ -61,11 +60,9 @@ function ActionOptions({
   updateSettings,
 }: ActionOptionsProps) {
   const handleActionSelected = useCallback(
-    action => {
+    (action: WritebackAction) => {
       updateSettings({
         type: clickBehavior.type,
-        emitter_id: clickBehavior.emitter_id,
-        action: action.id,
       });
     },
     [clickBehavior, updateSettings],
@@ -76,9 +73,7 @@ function ActionOptions({
       <Heading className="text-medium">{t`Pick an action`}</Heading>
       <Actions.ListLoader>
         {({ actions }: { actions: WritebackAction[] }) => {
-          const selectedAction = actions.find(
-            action => action.id === clickBehavior.action,
-          );
+          const selectedAction = null;
           return (
             <>
               {actions.map(action => (
@@ -86,7 +81,7 @@ function ActionOptions({
                   key={action.id}
                   name={action.name}
                   description={action.description}
-                  isSelected={clickBehavior.action === action.id}
+                  isSelected={false}
                   onClick={() => handleActionSelected(action)}
                 />
               ))}

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarMainView/ClickBehaviorSidebarMainView.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarMainView/ClickBehaviorSidebarMainView.tsx
@@ -8,7 +8,6 @@ import type {
 } from "metabase-types/api";
 
 import { clickBehaviorOptions, getClickBehaviorOptionName } from "../utils";
-import ActionOptions from "../ActionOptions";
 import CrossfilterOptions from "../CrossfilterOptions";
 import LinkOptions from "../LinkOptions";
 import { SidebarItem } from "../SidebarItem";
@@ -47,15 +46,6 @@ function ClickBehaviorOptions({
       <CrossfilterOptions
         clickBehavior={clickBehavior}
         dashboard={dashboard}
-        dashcard={dashcard}
-        updateSettings={updateSettings}
-      />
-    );
-  }
-  if (clickBehavior.type === "action") {
-    return (
-      <ActionOptions
-        clickBehavior={clickBehavior}
         dashcard={dashcard}
         updateSettings={updateSettings}
       />

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/utils.ts
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/utils.ts
@@ -19,7 +19,7 @@ export const clickBehaviorOptions: ClickBehaviorOption[] = [
   { value: "menu", icon: "popover" },
   { value: "link", icon: "link" },
   { value: "crossfilter", icon: "filter" },
-  { value: "action", icon: "play" },
+  // { value: "action", icon: "play" },
 ];
 
 export function getClickBehaviorOptionName(

--- a/frontend/src/metabase/dashboard/components/DashCard.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard.jsx
@@ -27,6 +27,8 @@ import DashCardParameterMapper from "./DashCardParameterMapper";
 import { IS_EMBED_PREVIEW } from "metabase/lib/embed";
 import { getClickBehaviorDescription } from "metabase/lib/click-behavior";
 
+import { isActionButtonCard } from "metabase/writeback/utils";
+
 import cx from "classnames";
 import _ from "underscore";
 import { getIn } from "icepick";
@@ -177,7 +179,7 @@ export default class DashCard extends Component {
       parameterValues,
     );
 
-    const isActionButton = mainCard.display === "action-button";
+    const isActionButton = isActionButtonCard(mainCard);
 
     const hideBackground =
       !isEditing &&
@@ -381,7 +383,7 @@ const DashCardActionButtons = ({
         />,
       );
     }
-    if (!isVirtualDashCard || card.display === "action-button") {
+    if (!isVirtualDashCard || isActionButtonCard(card)) {
       buttons.push(
         <Tooltip key="click-behavior-tooltip" tooltip={t`Click behavior`}>
           <a

--- a/frontend/src/metabase/dashboard/containers/ActionParametersInputModal.tsx
+++ b/frontend/src/metabase/dashboard/containers/ActionParametersInputModal.tsx
@@ -9,16 +9,10 @@ import ActionParametersInputForm from "metabase/writeback/containers/ActionParam
 import type { DashboardWithCards } from "metabase-types/types/Dashboard";
 import type { State } from "metabase-types/store";
 
-import { closeActionParametersModal } from "../actions";
-import { getEmitterParametersFormProps } from "../selectors";
-
-type DataAppDashboard = DashboardWithCards & {
-  emitters?: any[];
-};
+type DataAppDashboard = DashboardWithCards;
 
 interface OwnProps {
   dashboard: DataAppDashboard;
-  focusedEmitterId: number;
 }
 
 interface StateProps {
@@ -33,33 +27,23 @@ type Props = OwnProps & StateProps & DispatchProps;
 
 function mapStateToProps(state: State) {
   return {
-    formProps: getEmitterParametersFormProps(state),
+    formProps: {},
   };
 }
 
 const mapDispatchToProps = {
-  closeActionParametersModal,
+  closeActionParametersModal: () => {
+    // pass
+  },
 };
 
 function ActionParametersInputModal({
   formProps,
-  dashboard,
-  focusedEmitterId,
   closeActionParametersModal,
 }: Props) {
-  const emitter = dashboard.emitters?.find(
-    emitter => emitter.id === focusedEmitterId,
-  );
-
-  if (!emitter) {
-    return null;
-  }
-
-  const action = emitter.action;
-
   return (
     <Modal onClose={closeActionParametersModal}>
-      <ModalContent title={action.name} onClose={closeActionParametersModal}>
+      <ModalContent onClose={closeActionParametersModal}>
         <ActionParametersInputForm
           {...formProps}
           onSubmitSuccess={closeActionParametersModal}

--- a/frontend/src/metabase/dashboard/containers/ActionParametersInputModal.tsx
+++ b/frontend/src/metabase/dashboard/containers/ActionParametersInputModal.tsx
@@ -6,7 +6,6 @@ import ModalContent from "metabase/components/ModalContent";
 
 import ActionParametersInputForm from "metabase/writeback/containers/ActionParametersInputForm";
 
-import type { WritebackActionEmitter } from "metabase-types/api";
 import type { DashboardWithCards } from "metabase-types/types/Dashboard";
 import type { State } from "metabase-types/store";
 
@@ -14,7 +13,7 @@ import { closeActionParametersModal } from "../actions";
 import { getEmitterParametersFormProps } from "../selectors";
 
 type DataAppDashboard = DashboardWithCards & {
-  emitters?: WritebackActionEmitter[];
+  emitters?: any[];
 };
 
 interface OwnProps {

--- a/frontend/src/metabase/dashboard/containers/DashboardApp.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp.jsx
@@ -43,9 +43,6 @@ import {
   getIsLoadingComplete,
   getIsHeaderVisible,
   getIsAdditionalInfoVisible,
-
-  // Writeback
-  getFocusedEmitterId,
 } from "../selectors";
 import { getDatabases, getMetadata } from "metabase/selectors/metadata";
 import {
@@ -62,8 +59,6 @@ import * as Urls from "metabase/lib/urls";
 import Dashboards from "metabase/entities/dashboards";
 
 import DataAppContext from "metabase/writeback/containers/DataAppContext";
-
-import ActionParametersInputModal from "./ActionParametersInputModal";
 
 function getDashboardId({ dashboardId, location, params }) {
   if (dashboardId) {
@@ -105,9 +100,6 @@ const mapStateToProps = (state, props) => {
     isHeaderVisible: getIsHeaderVisible(state),
     isAdditionalInfoVisible: getIsAdditionalInfoVisible(state),
     embedOptions: getEmbedOptions(state),
-
-    // Writeback
-    focusedEmitterId: getFocusedEmitterId(state),
   };
 };
 
@@ -123,7 +115,7 @@ const mapDispatchToProps = {
 const DashboardApp = props => {
   const options = parseHashOptions(window.location.hash);
 
-  const { isRunning, isLoadingComplete, dashboard, focusedEmitterId } = props;
+  const { isRunning, isLoadingComplete, dashboard } = props;
 
   const [editingOnLoad] = useState(options.edit);
   const [addCardOnLoad] = useState(options.add && parseInt(options.add));
@@ -180,12 +172,6 @@ const DashboardApp = props => {
         />
         {/* For rendering modal urls */}
         {props.children}
-        {dashboard && focusedEmitterId && (
-          <ActionParametersInputModal
-            dashboard={dashboard}
-            focusedEmitterId={focusedEmitterId}
-          />
-        )}
         <Toaster
           message={
             dashboard?.is_app_page

--- a/frontend/src/metabase/dashboard/containers/DashboardApp.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp.jsx
@@ -17,10 +17,8 @@ import { useLoadingTimer } from "metabase/hooks/use-loading-timer";
 import { useWebNotification } from "metabase/hooks/use-web-notification";
 import { useOnUnmount } from "metabase/hooks/use-on-unmount";
 
-import Actions from "metabase/entities/actions";
 import { fetchDatabaseMetadata } from "metabase/redux/metadata";
 import { getIsNavbarOpen, setErrorPage } from "metabase/redux/app";
-import MetabaseSettings from "metabase/lib/settings";
 
 import {
   getIsEditing,
@@ -205,15 +203,11 @@ const DashboardApp = props => {
 };
 
 export default _.compose(
-  ...[
-    connect(mapStateToProps, mapDispatchToProps),
-    favicon(({ pageFavicon }) => pageFavicon),
-    title(({ dashboard, documentTitle }) => ({
-      title: documentTitle || dashboard?.name,
-      titleIndex: 1,
-    })),
-    titleWithLoadingTime("loadingStartTime"),
-    MetabaseSettings.get("experimental-enable-actions") &&
-      Actions.loadList({ metadataPropName: "actionListMetadata" }),
-  ].filter(Boolean),
+  connect(mapStateToProps, mapDispatchToProps),
+  favicon(({ pageFavicon }) => pageFavicon),
+  title(({ dashboard, documentTitle }) => ({
+    title: documentTitle || dashboard?.name,
+    titleIndex: 1,
+  })),
+  titleWithLoadingTime("loadingStartTime"),
 )(DashboardApp);

--- a/frontend/src/metabase/dashboard/reducers.js
+++ b/frontend/src/metabase/dashboard/reducers.js
@@ -37,10 +37,6 @@ import {
   SET_SHOW_LOADING_COMPLETE_FAVICON,
   RESET,
   SET_PARAMETER_VALUES,
-
-  // Writeback
-  OPEN_ACTION_PARAMETERS_MODAL,
-  CLOSE_ACTION_PARAMETERS_MODAL,
 } from "./actions";
 
 import { isVirtualDashCard, syncParametersAndEmbeddingParams } from "./utils";
@@ -413,28 +409,6 @@ const sidebar = handleActions(
   DEFAULT_SIDEBAR,
 );
 
-// Writeback
-const missingEmitterParameters = handleActions(
-  {
-    [INITIALIZE]: {
-      next: (state, payload) => null,
-    },
-    [OPEN_ACTION_PARAMETERS_MODAL]: {
-      next: (state, { payload: { emitterId, props } }) => ({
-        emitterId,
-        props,
-      }),
-    },
-    [CLOSE_ACTION_PARAMETERS_MODAL]: {
-      next: (state, payload) => null,
-    },
-    [RESET]: {
-      next: (state, payload) => null,
-    },
-  },
-  null,
-);
-
 export default combineReducers({
   dashboardId,
   isEditing,
@@ -448,5 +422,4 @@ export default combineReducers({
   isAddParameterPopoverOpen,
   sidebar,
   parameterValuesSearchCache,
-  missingEmitterParameters,
 });

--- a/frontend/src/metabase/dashboard/reducers.unit.spec.js
+++ b/frontend/src/metabase/dashboard/reducers.unit.spec.js
@@ -35,7 +35,6 @@ describe("dashboard reducers", () => {
       sidebar: { props: {} },
       slowCards: {},
       loadingControls: {},
-      missingEmitterParameters: null,
     });
   });
 

--- a/frontend/src/metabase/dashboard/selectors.js
+++ b/frontend/src/metabase/dashboard/selectors.js
@@ -208,9 +208,3 @@ export const getIsAdditionalInfoVisible = createSelector(
   [getIsEmbedded, getEmbedOptions],
   (isEmbedded, embedOptions) => !isEmbedded || embedOptions.additional_info,
 );
-
-// Writeback
-export const getFocusedEmitterId = state =>
-  state.dashboard.missingEmitterParameters?.emitterId;
-export const getEmitterParametersFormProps = state =>
-  state.dashboard.missingEmitterParameters?.props || {};

--- a/frontend/src/metabase/entities/containers/EntityListLoader.jsx
+++ b/frontend/src/metabase/entities/containers/EntityListLoader.jsx
@@ -244,7 +244,6 @@ const EntityListLoader = _.compose(
       allFetched,
       allError,
       selectorName = "getList",
-      metadataPropName = "metadata",
     } = props;
     if (typeof entityQuery === "function") {
       entityQuery = entityQuery(state, props);
@@ -275,7 +274,7 @@ const EntityListLoader = _.compose(
       list,
       entityQuery,
       reloadInterval,
-      [metadataPropName]: metadata,
+      metadata,
       loading,
       loaded,
       fetched,

--- a/frontend/src/metabase/lib/click-behavior.js
+++ b/frontend/src/metabase/lib/click-behavior.js
@@ -243,13 +243,9 @@ export function clickBehaviorIsValid(clickBehavior) {
     linkType,
     targetId,
     linkTemplate,
-    action,
   } = clickBehavior;
   if (type === "crossfilter") {
     return Object.keys(parameterMapping).length > 0;
-  }
-  if (type === "action") {
-    return typeof action === "number";
   }
   // if it's not a crossfilter/action, it's a link
   if (linkType === "url") {

--- a/frontend/src/metabase/modes/components/drill/DashboardClickDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/DashboardClickDrill.jsx
@@ -7,8 +7,6 @@ import Question from "metabase-lib/lib/Question";
 import {
   setOrUnsetParameterValues,
   setParameterValue,
-  openActionParametersModal,
-  executeRowAction,
 } from "metabase/dashboard/actions";
 import {
   getDataFromClicked,
@@ -17,10 +15,6 @@ import {
 } from "metabase/lib/click-behavior";
 import { renderLinkURLForClick } from "metabase/lib/formatting/link";
 import * as Urls from "metabase/lib/urls";
-import {
-  getActionParameters,
-  getNotProvidedActionParameters,
-} from "metabase/writeback/utils";
 
 export default ({ question, clicked }) => {
   const settings = (clicked && clicked.settings) || {};
@@ -47,49 +41,7 @@ export default ({ question, clicked }) => {
     return [];
   }
 
-  if (type === "action") {
-    const parameters = getActionParameters(parameterMapping, {
-      data,
-      extraData,
-      clickBehavior,
-    });
-    const action = extraData.actions[clickBehavior.action];
-    const missingParameters = getNotProvidedActionParameters(
-      action,
-      parameters,
-    );
-    const emitterId = clickBehavior.emitter_id || clickBehavior.id;
-
-    if (missingParameters.length > 0) {
-      behavior = {
-        action: () =>
-          openActionParametersModal({
-            emitterId: emitterId,
-            props: {
-              missingParameters,
-              onSubmit: filledMissingParameters =>
-                executeRowAction({
-                  dashboard: extraData.dashboard,
-                  emitterId: emitterId,
-                  parameters: {
-                    ...parameters,
-                    ...filledMissingParameters,
-                  },
-                }),
-            },
-          }),
-      };
-    } else {
-      behavior = {
-        action: () =>
-          executeRowAction({
-            dashboard: extraData.dashboard,
-            emitterId: emitterId,
-            parameters,
-          }),
-      };
-    }
-  } else if (type === "crossfilter") {
+  if (type === "crossfilter") {
     const parameterIdValuePairs = getParameterIdValuePairs(parameterMapping, {
       data,
       extraData,

--- a/frontend/src/metabase/parameters/utils/mapping-options.js
+++ b/frontend/src/metabase/parameters/utils/mapping-options.js
@@ -63,7 +63,7 @@ export function getParameterMappingOptions(
   }
 
   if (isActionButtonCard(card)) {
-    // action cards don't have parameters
+    // Action parameters are mapped via click behavior UI for now
     return [];
   }
 

--- a/frontend/src/metabase/parameters/utils/mapping-options.js
+++ b/frontend/src/metabase/parameters/utils/mapping-options.js
@@ -1,6 +1,7 @@
 import Question from "metabase-lib/lib/Question";
-
 import { ExpressionDimension } from "metabase-lib/lib/Dimension";
+
+import { isActionButtonCard } from "metabase/writeback/utils";
 
 import {
   dimensionFilterForParameter,
@@ -61,7 +62,7 @@ export function getParameterMappingOptions(
     return tagNames ? tagNames.map(buildTextTagOption) : [];
   }
 
-  if (card.display === "action-button") {
+  if (isActionButtonCard(card)) {
     // action cards don't have parameters
     return [];
   }

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -537,10 +537,3 @@ export const ActionsApi = {
   bulkUpdate: POST("/api/action/bulk/update/:tableId"),
   bulkDelete: POST("/api/action/bulk/delete/:tableId"),
 };
-
-export const EmittersApi = {
-  create: POST("/api/emitter"),
-  update: PUT("/api/emitter/:id"),
-  delete: DELETE("/api/emitter/:id"),
-  execute: POST("/api/emitter/:id/execute"),
-};

--- a/frontend/src/metabase/visualizations/hoc/WithVizSettingsData.js
+++ b/frontend/src/metabase/visualizations/hoc/WithVizSettingsData.js
@@ -5,14 +5,10 @@ import _ from "underscore";
 
 import { getUserAttributes } from "metabase/selectors/user";
 
-import Actions from "metabase/entities/actions";
 import Questions from "metabase/entities/questions";
 import Dashboards from "metabase/entities/dashboards";
 
 function hasLinkedQuestionOrDashboard({ type, linkType, action } = {}) {
-  if (type === "action") {
-    return typeof action === "number";
-  }
   if (type === "link") {
     return linkType === "question" || linkType === "dashboard";
   }
@@ -20,12 +16,6 @@ function hasLinkedQuestionOrDashboard({ type, linkType, action } = {}) {
 }
 
 function mapLinkedEntityToEntityQuery({ type, linkType, action, targetId }) {
-  if (type === "action") {
-    return {
-      entity: Actions,
-      entityId: action,
-    };
-  }
   return {
     entity: linkType === "question" ? Questions : Dashboards,
     entityId: targetId,

--- a/frontend/src/metabase/writeback/containers/ActionParametersInputForm.tsx
+++ b/frontend/src/metabase/writeback/containers/ActionParametersInputForm.tsx
@@ -3,7 +3,6 @@ import { connect } from "react-redux";
 import { t } from "ttag";
 
 import Form from "metabase/containers/Form";
-import { getActionParameterType } from "metabase/writeback/utils";
 
 import type { ParametersMappedToValues } from "metabase-types/api";
 import type { Parameter, ParameterId } from "metabase-types/types/Parameter";
@@ -18,6 +17,14 @@ interface Props {
   };
   onSubmitSuccess: () => void;
   dispatch: Dispatch;
+}
+
+function getActionParameterType(parameter: Parameter) {
+  const { type } = parameter;
+  if (type === "category") {
+    return "string/=";
+  }
+  return type;
 }
 
 function getParameterFieldProps(parameter: Parameter) {

--- a/frontend/src/metabase/writeback/utils.ts
+++ b/frontend/src/metabase/writeback/utils.ts
@@ -6,7 +6,6 @@ import type Field from "metabase-lib/lib/metadata/Field";
 
 import type {
   WritebackAction,
-  ParameterMappings,
   ParametersMappedToValues,
   ParametersSourceTargetMap,
   ActionClickBehaviorData,
@@ -72,12 +71,6 @@ export const isEditableField = (field: Field) => {
 export const isActionButtonDashCard = (dashCard: DashCard) =>
   dashCard.visualization_settings?.virtual_card?.display === "action-button";
 
-export const getActionButtonEmitterId = (dashCard: DashCard) =>
-  dashCard.visualization_settings?.click_behavior?.emitter_id;
-
-export const getActionButtonActionId = (dashCard: DashCard) =>
-  dashCard.visualization_settings?.click_behavior?.action;
-
 export function getActionParameterType(parameter: Parameter) {
   const { type } = parameter;
   if (type === "category") {
@@ -107,20 +100,6 @@ function getParametersFromTuples(
     return parameter;
   });
 }
-
-export const getActionEmitterParameterMappings = (action: WritebackAction) => {
-  const parameters = getParametersFromTuples(action.parameters);
-  const parameterMappings: ParameterMappings = {};
-
-  parameters.forEach(parameter => {
-    parameterMappings[parameter.id] = [
-      "variable",
-      ["template-tag", parameter.slug],
-    ];
-  });
-
-  return parameterMappings;
-};
 
 export function getActionParameters(
   parameterMapping: ParametersSourceTargetMap = {},

--- a/frontend/src/metabase/writeback/utils.ts
+++ b/frontend/src/metabase/writeback/utils.ts
@@ -1,5 +1,4 @@
 import { TYPE } from "metabase/lib/types";
-import { formatSourceForTarget } from "metabase/lib/click-behavior";
 
 import type Database from "metabase-lib/lib/metadata/Database";
 import type Field from "metabase-lib/lib/metadata/Field";
@@ -7,16 +6,9 @@ import type Field from "metabase-lib/lib/metadata/Field";
 import type {
   DashboardOrderedCard,
   Database as IDatabase,
-  WritebackAction,
-  ParametersMappedToValues,
-  ParametersSourceTargetMap,
-  ActionClickBehaviorData,
-  ActionClickExtraData,
-  ActionClickBehavior,
-  ActionParameterTuple,
 } from "metabase-types/api";
 import type { SavedCard } from "metabase-types/types/Card";
-import type { Parameter, ParameterId } from "metabase-types/types/Parameter";
+import type { Parameter } from "metabase-types/types/Parameter";
 
 const DB_WRITEBACK_FEATURE = "actions";
 const DB_WRITEBACK_SETTING = "database-enable-actions";
@@ -83,89 +75,4 @@ export function getActionParameterType(parameter: Parameter) {
     return "string/=";
   }
   return type;
-}
-
-function isParametersTuple(
-  listOrListOfTuples: ActionParameterTuple[] | Parameter[],
-): listOrListOfTuples is ActionParameterTuple[] {
-  const [sample] = listOrListOfTuples;
-  if (!sample) {
-    return false;
-  }
-  return Array.isArray(sample);
-}
-
-function getParametersFromTuples(
-  parameterTuples: ActionParameterTuple[] | Parameter[],
-): Parameter[] {
-  if (!isParametersTuple(parameterTuples)) {
-    return parameterTuples;
-  }
-  return parameterTuples.map(tuple => {
-    const [, parameter] = tuple;
-    return parameter;
-  });
-}
-
-export function getActionParameters(
-  parameterMapping: ParametersSourceTargetMap = {},
-  {
-    data,
-    extraData,
-    clickBehavior,
-  }: {
-    data: ActionClickBehaviorData;
-    extraData: ActionClickExtraData;
-    clickBehavior: ActionClickBehavior;
-  },
-) {
-  const action = extraData.actions[clickBehavior.action];
-
-  const parameters = getParametersFromTuples(action.parameters);
-  const parameterValuesMap: ParametersMappedToValues = {};
-
-  Object.values(parameterMapping).forEach(({ id, source, target }) => {
-    const targetParameter = parameters.find(parameter => parameter.id === id);
-    if (targetParameter) {
-      const result = formatSourceForTarget(source, target, {
-        data,
-        extraData,
-        clickBehavior,
-      });
-      // For some reason it's sometimes [1] and sometimes just 1
-      const value = Array.isArray(result) ? result[0] : result;
-
-      parameterValuesMap[id] = {
-        value,
-        type: getActionParameterType(targetParameter),
-      };
-    }
-  });
-
-  return parameterValuesMap;
-}
-
-export function getNotProvidedActionParameters(
-  action: WritebackAction,
-  parameterValuesMap: ParametersMappedToValues,
-) {
-  const parameters = getParametersFromTuples(action.parameters);
-  const mappedParameterIDs = Object.keys(parameterValuesMap);
-
-  const emptyParameterIDs: ParameterId[] = [];
-  mappedParameterIDs.forEach(parameterId => {
-    const { value } = parameterValuesMap[parameterId];
-    if (value === undefined) {
-      emptyParameterIDs.push(parameterId);
-    }
-  });
-
-  return parameters.filter(parameter => {
-    if ("default" in parameter) {
-      return false;
-    }
-    const isNotMapped = !mappedParameterIDs.includes(parameter.id);
-    const isMappedButNoValue = emptyParameterIDs.includes(parameter.id);
-    return isNotMapped || isMappedButNoValue;
-  });
 }

--- a/frontend/src/metabase/writeback/utils.ts
+++ b/frontend/src/metabase/writeback/utils.ts
@@ -67,11 +67,3 @@ export const isActionButtonDashCard = (dashCard: DashboardOrderedCard) =>
   isActionButtonCard(
     dashCard.visualization_settings?.virtual_card as SavedCard,
   );
-
-export const isActionButtonWithMappedAction = (
-  dashCard: DashboardOrderedCard,
-) => {
-  return (
-    isActionButtonDashCard(dashCard) && typeof dashCard.action_id === "number"
-  );
-};

--- a/frontend/src/metabase/writeback/utils.ts
+++ b/frontend/src/metabase/writeback/utils.ts
@@ -5,6 +5,8 @@ import type Database from "metabase-lib/lib/metadata/Database";
 import type Field from "metabase-lib/lib/metadata/Field";
 
 import type {
+  DashboardOrderedCard,
+  Database as IDatabase,
   WritebackAction,
   ParametersMappedToValues,
   ParametersSourceTargetMap,
@@ -13,8 +15,7 @@ import type {
   ActionClickBehavior,
   ActionParameterTuple,
 } from "metabase-types/api";
-import type { Database as IDatabase } from "metabase-types/api/database";
-import type { DashCard } from "metabase-types/types/Dashboard";
+import type { SavedCard } from "metabase-types/types/Card";
 import type { Parameter, ParameterId } from "metabase-types/types/Parameter";
 
 const DB_WRITEBACK_FEATURE = "actions";
@@ -68,8 +69,13 @@ export const isEditableField = (field: Field) => {
   return true;
 };
 
-export const isActionButtonDashCard = (dashCard: DashCard) =>
-  dashCard.visualization_settings?.virtual_card?.display === "action-button";
+export const isActionButtonCard = (card: SavedCard) =>
+  card?.display === "action-button";
+
+export const isActionButtonDashCard = (dashCard: DashboardOrderedCard) =>
+  isActionButtonCard(
+    dashCard.visualization_settings?.virtual_card as SavedCard,
+  );
 
 export function getActionParameterType(parameter: Parameter) {
   const { type } = parameter;

--- a/frontend/src/metabase/writeback/utils.ts
+++ b/frontend/src/metabase/writeback/utils.ts
@@ -8,7 +8,6 @@ import type {
   Database as IDatabase,
 } from "metabase-types/api";
 import type { SavedCard } from "metabase-types/types/Card";
-import type { Parameter } from "metabase-types/types/Parameter";
 
 const DB_WRITEBACK_FEATURE = "actions";
 const DB_WRITEBACK_SETTING = "database-enable-actions";
@@ -69,10 +68,10 @@ export const isActionButtonDashCard = (dashCard: DashboardOrderedCard) =>
     dashCard.visualization_settings?.virtual_card as SavedCard,
   );
 
-export function getActionParameterType(parameter: Parameter) {
-  const { type } = parameter;
-  if (type === "category") {
-    return "string/=";
-  }
-  return type;
-}
+export const isActionButtonWithMappedAction = (
+  dashCard: DashboardOrderedCard,
+) => {
+  return (
+    isActionButtonDashCard(dashCard) && typeof dashCard.action_id === "number"
+  );
+};


### PR DESCRIPTION
The first step for #25265

Removes FE code touching action emitters and action button click behavior. We're abandoning this approach, and the first step is to remove the old code. This PR exists to make reviewing subsequent work easier.