### PR TITLE
Reimplement action parameters mapping and execution

### DIFF
--- a/frontend/src/metabase-types/api/dashboard.ts
+++ b/frontend/src/metabase-types/api/dashboard.ts
@@ -97,6 +97,10 @@ export interface ArbitraryCustomDestinationClickBehavior {
   linkTextTemplate?: string;
 }
 
+export interface WritebackActionClickBehavior {
+  type: "action";
+}
+
 // Makes click handler use default drills
 // This is virtual, i.e. if a card has no clickBehavior,
 // it'd behave as if it's an "actionMenu"
@@ -111,4 +115,5 @@ export type CustomDestinationClickBehavior =
 export type ClickBehavior =
   | ActionMenuClickBehavior
   | CrossFilterClickBehavior
-  | CustomDestinationClickBehavior;
+  | CustomDestinationClickBehavior
+  | WritebackActionClickBehavior;

--- a/frontend/src/metabase-types/api/dashboard.ts
+++ b/frontend/src/metabase-types/api/dashboard.ts
@@ -6,8 +6,6 @@ import {
 } from "metabase-types/types/Parameter";
 import { CardId, SavedCard } from "metabase-types/types/Card";
 
-import { WritebackAction } from "./writeback";
-
 export type DashboardId = number;
 
 export interface Dashboard {
@@ -29,19 +27,18 @@ export interface Dashboard {
 
 export type DashCardId = EntityId;
 
-export type DashboardOrderedCard = {
+export type BaseDashboardOrderedCard = {
   id: DashCardId;
-  card: SavedCard;
-  card_id: CardId;
-  parameter_mappings?: DashboardParameterMapping[] | null;
-  series?: SavedCard[];
   visualization_settings?: {
     [key: string]: unknown;
   };
+};
 
-  // Only for action buttons
-  action_id: number | null;
-  action?: WritebackAction;
+export type DashboardOrderedCard = BaseDashboardOrderedCard & {
+  card_id: CardId;
+  card: SavedCard;
+  parameter_mappings?: DashboardParameterMapping[] | null;
+  series?: SavedCard[];
 };
 
 export type DashboardParameterMapping = {

--- a/frontend/src/metabase-types/api/dashboard.ts
+++ b/frontend/src/metabase-types/api/dashboard.ts
@@ -6,6 +6,8 @@ import {
 } from "metabase-types/types/Parameter";
 import { CardId, SavedCard } from "metabase-types/types/Card";
 
+import { WritebackAction } from "./writeback";
+
 export type DashboardId = number;
 
 export interface Dashboard {
@@ -36,6 +38,10 @@ export type DashboardOrderedCard = {
   visualization_settings?: {
     [key: string]: unknown;
   };
+
+  // Only for action buttons
+  action_id: number | null;
+  action?: WritebackAction;
 };
 
 export type DashboardParameterMapping = {

--- a/frontend/src/metabase-types/api/dashboard.ts
+++ b/frontend/src/metabase-types/api/dashboard.ts
@@ -51,7 +51,7 @@ export type DashboardParameterMapping = {
 // Example: "[\"dimension\",[\"field\",17,null]]"
 type StringifiedDimension = string;
 
-type ClickBehaviorParameterMapping = Record<
+export type ClickBehaviorParameterMapping = Record<
   ParameterId | StringifiedDimension,
   {
     id: ParameterId | StringifiedDimension;

--- a/frontend/src/metabase-types/api/data-app.ts
+++ b/frontend/src/metabase-types/api/data-app.ts
@@ -1,4 +1,9 @@
 import { Collection, RegularCollectionId } from "./collection";
+import {
+  BaseDashboardOrderedCard,
+  DashboardParameterMapping,
+} from "./dashboard";
+import { WritebackAction } from "./writeback";
 
 export type DataAppId = number;
 
@@ -20,4 +25,21 @@ export interface DataAppSearchItem {
   id: RegularCollectionId;
   app_id: DataAppId;
   collection: Collection;
+}
+
+export type ActionButtonParametersMapping = Pick<
+  DashboardParameterMapping,
+  "parameter_id" | "target"
+>;
+
+export interface ActionButtonDashboardCard
+  extends Omit<BaseDashboardOrderedCard, "parameter_mappings"> {
+  action_id: number | null;
+  action?: WritebackAction;
+
+  parameter_mappings?: ActionButtonParametersMapping[] | null;
+  visualization_settings: {
+    [key: string]: unknown;
+    "button.label"?: string;
+  };
 }

--- a/frontend/src/metabase-types/api/mocks/data-app.ts
+++ b/frontend/src/metabase-types/api/mocks/data-app.ts
@@ -1,4 +1,8 @@
-import { DataApp, Dashboard } from "metabase-types/api";
+import {
+  ActionButtonDashboardCard,
+  DataApp,
+  Dashboard,
+} from "metabase-types/api";
 import { createMockCollection } from "./collection";
 import { createMockDashboard } from "./dashboard";
 
@@ -23,3 +27,13 @@ export const createMockDataApp = ({
 export const createMockDataAppPage = (
   params: Partial<Omit<Dashboard, "is_app_page">>,
 ): Dashboard => createMockDashboard({ ...params, is_app_page: true });
+
+export const createMockDashboardActionButton = (
+  opts?: Partial<ActionButtonDashboardCard>,
+): ActionButtonDashboardCard => ({
+  id: 1,
+  action_id: null,
+  parameter_mappings: null,
+  visualization_settings: {},
+  ...opts,
+});

--- a/frontend/src/metabase-types/api/mocks/index.ts
+++ b/frontend/src/metabase-types/api/mocks/index.ts
@@ -14,3 +14,4 @@ export * from "./table";
 export * from "./timeline";
 export * from "./settings";
 export * from "./user";
+export * from "./writeback";

--- a/frontend/src/metabase-types/api/mocks/writeback.ts
+++ b/frontend/src/metabase-types/api/mocks/writeback.ts
@@ -1,0 +1,39 @@
+import {
+  Card,
+  QueryAction,
+  WritebackAction,
+  QueryActionCard,
+} from "metabase-types/api";
+import { createMockCard } from "./card";
+import { createMockNativeDatasetQuery } from "./query";
+
+export function createMockQueryActionCard({
+  action_id = 1,
+  dataset_query = createMockNativeDatasetQuery(),
+  ...opts
+}: Partial<Omit<QueryActionCard, "is_write">> = {}) {
+  const card = createMockCard({ dataset_query, ...opts }) as QueryActionCard;
+
+  card.is_write = true;
+  card.action_id = action_id;
+
+  return card;
+}
+
+export const createMockQueryAction = ({
+  card = createMockQueryActionCard(),
+  ...opts
+}: Partial<WritebackAction & QueryAction> = {}): WritebackAction => {
+  return {
+    id: 1,
+    type: "query",
+    card_id: card.id,
+    card,
+    name: "Query Action Mock",
+    description: null,
+    parameters: [],
+    "updated-at": new Date().toISOString(),
+    "created-at": new Date().toISOString(),
+    ...opts,
+  };
+};

--- a/frontend/src/metabase/dashboard/actions/save.js
+++ b/frontend/src/metabase/dashboard/actions/save.js
@@ -112,6 +112,7 @@ export const saveDashboardAndCards = createThunkAction(
         const cards = updatedDashcards.map(
           ({
             id,
+            action_id,
             card_id,
             row,
             col,
@@ -122,6 +123,7 @@ export const saveDashboardAndCards = createThunkAction(
             visualization_settings,
           }) => ({
             id,
+            action_id,
             card_id,
             row,
             col,

--- a/frontend/src/metabase/dashboard/actions/save.js
+++ b/frontend/src/metabase/dashboard/actions/save.js
@@ -77,6 +77,7 @@ export const saveDashboardAndCards = createThunkAction(
               // mark isAdded because addcard doesn't record the position
               return {
                 ...result,
+                action_id: dc.action_id,
                 col: dc.col,
                 row: dc.row,
                 size_x: dc.size_x,

--- a/frontend/src/metabase/dashboard/actions/writeback.ts
+++ b/frontend/src/metabase/dashboard/actions/writeback.ts
@@ -16,7 +16,14 @@ import {
   BulkDeletePayload,
 } from "metabase/writeback/actions";
 
-import { DashboardWithCards, DashCard } from "metabase-types/types/Dashboard";
+import { ActionsApi } from "metabase/services";
+
+import type {
+  Dashboard,
+  ActionButtonDashboardCard,
+  ParameterMappedForActionExecution,
+} from "metabase-types/api";
+import type { DashCard } from "metabase-types/types/Dashboard";
 
 import { getCardData } from "../selectors";
 import { isVirtualDashCard } from "../utils";
@@ -237,19 +244,24 @@ export const deleteManyRowsFromDataApp = (
 };
 
 export type ExecuteRowActionPayload = {
-  dashboard: DashboardWithCards;
-  parameters: Record<string, unknown>;
+  dashboard: Dashboard;
+  dashcard: ActionButtonDashboardCard;
+  parameters: ParameterMappedForActionExecution[];
 };
 
 export const executeRowAction = ({
   dashboard,
+  dashcard,
   parameters,
 }: ExecuteRowActionPayload) => {
   return async function (dispatch: any) {
     try {
-      const result = {
-        "rows-affected": 0,
-      };
+      const result = await ActionsApi.execute({
+        dashboardId: dashboard.id,
+        dashcardId: dashcard.id,
+        actionId: dashcard.action_id,
+        parameters,
+      });
       if (result["rows-affected"] > 0) {
         dashboard.ordered_cards
           .filter(dashCard => !isVirtualDashCard(dashCard))

--- a/frontend/src/metabase/dashboard/actions/writeback.ts
+++ b/frontend/src/metabase/dashboard/actions/writeback.ts
@@ -24,9 +24,11 @@ import type {
   ParameterMappedForActionExecution,
 } from "metabase-types/api";
 import type { DashCard } from "metabase-types/types/Dashboard";
+import type { Dispatch } from "metabase-types/store";
 
 import { getCardData } from "../selectors";
 import { isVirtualDashCard } from "../utils";
+import { setDashCardAttributes } from "./core";
 import { fetchCardData } from "./data-fetching";
 
 export const OPEN_ACTION_PARAMETERS_MODAL =
@@ -34,6 +36,20 @@ export const OPEN_ACTION_PARAMETERS_MODAL =
 export const openActionParametersModal = createAction(
   OPEN_ACTION_PARAMETERS_MODAL,
 );
+
+export function updateButtonActionMapping(
+  dashCardId: number,
+  attributes: { action_id?: number | null; parameter_mappings?: any },
+) {
+  return (dispatch: Dispatch) => {
+    dispatch(
+      setDashCardAttributes({
+        id: dashCardId,
+        attributes: attributes,
+      }),
+    );
+  };
+}
 
 export type InsertRowFromDataAppPayload = InsertRowPayload & {
   dashCard: DashCard;

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ActionOptions/ActionClickMappings.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ActionOptions/ActionClickMappings.tsx
@@ -1,0 +1,82 @@
+import React, { useCallback, useMemo } from "react";
+
+import ClickMappings from "metabase/dashboard/components/ClickMappings";
+
+import type {
+  ActionButtonDashboardCard,
+  ActionButtonParametersMapping,
+  ClickBehaviorParameterMapping,
+  WritebackAction,
+} from "metabase-types/api";
+import type { UiParameter } from "metabase/parameters/types";
+
+import {
+  turnClickBehaviorParameterMappingsIntoDashCardMappings,
+  turnDashCardParameterMappingsIntoClickBehaviorMappings,
+} from "./utils";
+
+// We're reusing the ClickMappings component for mapping parameters
+// ClickMappings is bound to click behavior, but for custom actions
+// we're using dash cards parameter mappings in another format
+// So here we need to convert these formats from one to another
+// Until we introduce another mapping component or refactor ClickMappings
+interface IntermediateActionClickBehavior {
+  type: "action";
+  parameterMapping?: ClickBehaviorParameterMapping;
+}
+
+interface ActionClickMappingsProps {
+  action?: WritebackAction;
+  dashcard: ActionButtonDashboardCard;
+  parameters: UiParameter[];
+  onChange: (parameterMappings: ActionButtonParametersMapping[] | null) => void;
+}
+
+function ActionClickMappings({
+  action,
+  dashcard,
+  parameters,
+  onChange,
+}: ActionClickMappingsProps) {
+  const clickBehavior = useMemo(() => {
+    if (!action) {
+      return { type: "action" };
+    }
+    const parameterMapping =
+      turnDashCardParameterMappingsIntoClickBehaviorMappings(
+        dashcard,
+        parameters,
+        action,
+      );
+    return { type: "action", parameterMapping };
+  }, [action, dashcard, parameters]);
+
+  const handleParameterMappingChange = useCallback(
+    (nextClickBehavior: IntermediateActionClickBehavior) => {
+      const { parameterMapping } = nextClickBehavior;
+      if (parameterMapping && action) {
+        const parameterMappings =
+          turnClickBehaviorParameterMappingsIntoDashCardMappings(
+            parameterMapping,
+            action,
+          );
+        onChange(parameterMappings);
+      } else {
+        onChange(null);
+      }
+    },
+    [action, onChange],
+  );
+
+  return (
+    <ClickMappings
+      isAction
+      object={action}
+      dashcard={dashcard}
+      clickBehavior={clickBehavior}
+      updateSettings={handleParameterMappingChange}
+    />
+  );
+}
+
+export default ActionClickMappings;

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ActionOptions/ActionOptionItem.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ActionOptions/ActionOptionItem.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+
+import { SidebarItem } from "../SidebarItem";
+import {
+  ActionSidebarItem,
+  ActionSidebarItemIcon,
+  ActionDescription,
+} from "./ActionOptions.styled";
+
+interface ActionOptionProps {
+  name: string;
+  description?: string | null;
+  isSelected: boolean;
+  onClick: () => void;
+}
+
+function ActionOptionItem({
+  name,
+  description,
+  isSelected,
+  onClick,
+}: ActionOptionProps) {
+  return (
+    <ActionSidebarItem
+      onClick={onClick}
+      isSelected={isSelected}
+      hasDescription={!!description}
+    >
+      <ActionSidebarItemIcon name="bolt" isSelected={isSelected} />
+      <div>
+        <SidebarItem.Name>{name}</SidebarItem.Name>
+        {description && <ActionDescription>{description}</ActionDescription>}
+      </div>
+    </ActionSidebarItem>
+  );
+}
+
+export default ActionOptionItem;

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ActionOptions/ActionOptionItem.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ActionOptions/ActionOptionItem.tsx
@@ -26,7 +26,7 @@ function ActionOptionItem({
       isSelected={isSelected}
       hasDescription={!!description}
     >
-      <ActionSidebarItemIcon name="bolt" isSelected={isSelected} />
+      <ActionSidebarItemIcon name="insight" isSelected={isSelected} />
       <div>
         <SidebarItem.Name>{name}</SidebarItem.Name>
         {description && <ActionDescription>{description}</ActionDescription>}

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ActionOptions/ActionOptions.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ActionOptions/ActionOptions.styled.tsx
@@ -28,3 +28,7 @@ export const ActionDescription = styled.span<{ isSelected?: boolean }>`
   color: ${props =>
     props.isSelected ? color("text-white") : color("text-medium")};
 `;
+
+export const ClickMappingsContainer = styled.div`
+  margin-top: 1rem;
+`;

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ActionOptions/ActionOptions.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ActionOptions/ActionOptions.tsx
@@ -57,6 +57,10 @@ function ActionOptions({
     (action: WritebackAction) => {
       onUpdateButtonActionMapping(dashcard.id, {
         action_id: action.id,
+
+        // Clean mappings from previous action
+        // as they're most likely going to be irrelevant
+        parameter_mappings: null,
       });
     },
     [dashcard, onUpdateButtonActionMapping],

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ActionOptions/ActionOptions.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ActionOptions/ActionOptions.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 import React, { useCallback } from "react";
 import { t } from "ttag";
 
@@ -12,41 +11,8 @@ import type {
   WritebackAction,
 } from "metabase-types/api";
 
-import { SidebarItem } from "../SidebarItem";
 import { Heading, SidebarContent } from "../ClickBehaviorSidebar.styled";
-import {
-  ActionSidebarItem,
-  ActionSidebarItemIcon,
-  ActionDescription,
-} from "./ActionOptions.styled";
-
-interface ActionOptionProps {
-  name: string;
-  description?: string | null;
-  isSelected: boolean;
-  onClick: () => void;
-}
-
-const ActionOption = ({
-  name,
-  description,
-  isSelected,
-  onClick,
-}: ActionOptionProps) => {
-  return (
-    <ActionSidebarItem
-      onClick={onClick}
-      isSelected={isSelected}
-      hasDescription={!!description}
-    >
-      <ActionSidebarItemIcon name="bolt" isSelected={isSelected} />
-      <div>
-        <SidebarItem.Name>{name}</SidebarItem.Name>
-        {description && <ActionDescription>{description}</ActionDescription>}
-      </div>
-    </ActionSidebarItem>
-  );
-};
+import ActionOptionItem from "./ActionOptionItem";
 
 interface ActionOptionsProps {
   dashcard: DashboardOrderedCard;
@@ -77,7 +43,7 @@ function ActionOptions({
           return (
             <>
               {actions.map(action => (
-                <ActionOption
+                <ActionOptionItem
                   key={action.id}
                   name={action.name}
                   description={action.description}

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ActionOptions/ActionOptions.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ActionOptions/ActionOptions.tsx
@@ -26,7 +26,12 @@ import {
 import ActionOptionItem from "./ActionOptionItem";
 import { ClickMappingsContainer } from "./ActionOptions.styled";
 
-interface WritebackActionClickBehavior {
+// We're reusing the ClickMappings component for mapping parameters
+// ClickMappings is bound to click behavior, but for custom actions
+// we're using dash cards parameter mappings in another format
+// So here we need to convert these formats from one to another
+// Until we introduce another mapping component or refactor ClickMappings
+interface IntermediateActionClickBehavior {
   type: "action";
   parameterMapping?: ClickBehaviorParameterMapping;
 }
@@ -87,7 +92,7 @@ function ActionOptions({
   );
 
   const handleParameterMappingChange = useCallback(
-    (nextClickBehavior: WritebackActionClickBehavior) => {
+    (nextClickBehavior: IntermediateActionClickBehavior) => {
       const { parameterMapping } = nextClickBehavior;
 
       const parameterMappings =

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ActionOptions/ActionOptions.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ActionOptions/ActionOptions.tsx
@@ -24,6 +24,7 @@ import {
   turnDashCardParameterMappingsIntoClickBehaviorMappings,
 } from "./utils";
 import ActionOptionItem from "./ActionOptionItem";
+import { ClickMappingsContainer } from "./ActionOptions.styled";
 
 interface WritebackActionClickBehavior {
   type: "action";
@@ -116,13 +117,15 @@ function ActionOptions({
         />
       ))}
       {selectedAction && (
-        <ClickMappings
-          isAction
-          object={selectedAction}
-          dashcard={dashcard}
-          clickBehavior={clickBehavior}
-          updateSettings={handleParameterMappingChange}
-        />
+        <ClickMappingsContainer>
+          <ClickMappings
+            isAction
+            object={selectedAction}
+            dashcard={dashcard}
+            clickBehavior={clickBehavior}
+            updateSettings={handleParameterMappingChange}
+          />
+        </ClickMappingsContainer>
       )}
     </>
   );

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ActionOptions/ActionOptions.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ActionOptions/ActionOptions.tsx
@@ -21,10 +21,11 @@ interface ActionOptionsProps {
 }
 
 function ActionOptions({
+  actions,
   dashcard,
   clickBehavior,
   updateSettings,
-}: ActionOptionsProps) {
+}: ActionOptionsProps & { actions: WritebackAction[] }) {
   const handleActionSelected = useCallback(
     (action: WritebackAction) => {
       updateSettings({
@@ -34,38 +35,43 @@ function ActionOptions({
     [clickBehavior, updateSettings],
   );
 
+  const selectedAction = null;
+
+  return (
+    <>
+      {actions.map(action => (
+        <ActionOptionItem
+          key={action.id}
+          name={action.name}
+          description={action.description}
+          isSelected={false}
+          onClick={() => handleActionSelected(action)}
+        />
+      ))}
+      {selectedAction && (
+        <ClickMappings
+          isAction
+          object={selectedAction}
+          dashcard={dashcard}
+          clickBehavior={clickBehavior}
+          updateSettings={updateSettings}
+        />
+      )}
+    </>
+  );
+}
+
+function ActionOptionsContainer(props: ActionOptionsProps) {
   return (
     <SidebarContent>
       <Heading className="text-medium">{t`Pick an action`}</Heading>
-      <Actions.ListLoader>
-        {({ actions }: { actions: WritebackAction[] }) => {
-          const selectedAction = null;
-          return (
-            <>
-              {actions.map(action => (
-                <ActionOptionItem
-                  key={action.id}
-                  name={action.name}
-                  description={action.description}
-                  isSelected={false}
-                  onClick={() => handleActionSelected(action)}
-                />
-              ))}
-              {selectedAction && (
-                <ClickMappings
-                  isAction
-                  object={selectedAction}
-                  dashcard={dashcard}
-                  clickBehavior={clickBehavior}
-                  updateSettings={updateSettings}
-                />
-              )}
-            </>
-          );
-        }}
+      <Actions.ListLoader loadingAndErrorWrapper={false}>
+        {({ actions = [] }: { actions: WritebackAction[] }) => (
+          <ActionOptions {...props} actions={actions} />
+        )}
       </Actions.ListLoader>
     </SidebarContent>
   );
 }
 
-export default ActionOptions;
+export default ActionOptionsContainer;

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ActionOptions/utils.ts
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ActionOptions/utils.ts
@@ -1,0 +1,73 @@
+import _ from "underscore";
+
+import type {
+  ActionButtonDashboardCard,
+  ActionButtonParametersMapping,
+  ClickBehaviorParameterMapping,
+  WritebackAction,
+} from "metabase-types/api";
+import type { UiParameter } from "metabase/parameters/types";
+
+export function turnDashCardParameterMappingsIntoClickBehaviorMappings(
+  dashCard: ActionButtonDashboardCard,
+  parameters: UiParameter[],
+  action: WritebackAction,
+): ClickBehaviorParameterMapping {
+  const result: ClickBehaviorParameterMapping = {};
+
+  if (!Array.isArray(dashCard.parameter_mappings)) {
+    return result;
+  }
+
+  dashCard.parameter_mappings.forEach(mapping => {
+    const { parameter_id: sourceParameterId, target } = mapping;
+
+    const sourceParameter = parameters.find(
+      parameter => parameter.id === sourceParameterId,
+    );
+    const actionParameter = action?.parameters.find(p =>
+      _.isEqual(p.target, target),
+    );
+
+    if (sourceParameter && actionParameter) {
+      result[actionParameter.id] = {
+        id: actionParameter.id,
+        target: {
+          type: "parameter",
+          id: actionParameter.id,
+        },
+        source: {
+          type: "parameter",
+          id: sourceParameter.id,
+          name: sourceParameter.name,
+        },
+      };
+    }
+  });
+
+  return result;
+}
+
+export function turnClickBehaviorParameterMappingsIntoDashCardMappings(
+  clickBehaviorParameterMappings: ClickBehaviorParameterMapping,
+  action: WritebackAction,
+): ActionButtonParametersMapping[] {
+  const mappings = Object.values(clickBehaviorParameterMappings);
+  const parameter_mappings: ActionButtonParametersMapping[] = [];
+
+  mappings.forEach(mapping => {
+    const { source, target } = mapping;
+    const actionParameter = action?.parameters.find(
+      parameter => parameter.id === target.id,
+    );
+
+    if (actionParameter?.target) {
+      parameter_mappings.push({
+        parameter_id: source.id,
+        target: actionParameter?.target,
+      });
+    }
+  });
+
+  return parameter_mappings;
+}

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ActionOptions/utils.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ActionOptions/utils.unit.spec.ts
@@ -1,0 +1,181 @@
+import type {
+  ActionButtonParametersMapping,
+  ClickBehaviorParameterMapping,
+  WritebackParameter,
+} from "metabase-types/api";
+import type { UiParameter } from "metabase/parameters/types";
+
+import {
+  createMockDashboardActionButton,
+  createMockQueryAction,
+} from "metabase-types/api/mocks";
+import {
+  turnClickBehaviorParameterMappingsIntoDashCardMappings,
+  turnDashCardParameterMappingsIntoClickBehaviorMappings,
+} from "./utils";
+
+const WRITEBACK_PARAMETER: WritebackParameter = {
+  id: "param-1",
+  name: "Order ID",
+  type: "number",
+  slug: "order-id",
+  target: ["variable", ["template-tag", "order-id"]],
+};
+
+const DASHBOARD_FILTER_PARAMETER: UiParameter = {
+  id: "dashboard-filter-1",
+  name: "Order",
+  type: "number",
+  slug: "order",
+  value: 5,
+};
+
+const PARAMETER_MAPPING: ActionButtonParametersMapping = {
+  parameter_id: DASHBOARD_FILTER_PARAMETER.id,
+  target: WRITEBACK_PARAMETER.target,
+};
+
+const CLICK_BEHAVIOR_PARAMETER_MAPPINGS: ClickBehaviorParameterMapping = {
+  [WRITEBACK_PARAMETER.id]: {
+    id: WRITEBACK_PARAMETER.id,
+    target: {
+      id: WRITEBACK_PARAMETER.id,
+      type: "parameter",
+    },
+    source: {
+      id: DASHBOARD_FILTER_PARAMETER.id,
+      name: DASHBOARD_FILTER_PARAMETER.name,
+      type: "parameter",
+    },
+  },
+};
+
+describe("turnDashCardParameterMappingsIntoClickBehaviorMappings", () => {
+  type SetupOpts = {
+    actionParameters?: WritebackParameter[] | undefined;
+    dashCardParameterMappings?: ActionButtonParametersMapping[] | null;
+  };
+
+  function setup({
+    actionParameters = [],
+    dashCardParameterMappings = [],
+  }: SetupOpts = {}) {
+    const action = createMockQueryAction({ parameters: actionParameters });
+    const dashCard = createMockDashboardActionButton({
+      action,
+      action_id: action.id,
+      parameter_mappings: dashCardParameterMappings,
+    });
+    return { action, dashCard };
+  }
+
+  it("returns empty object if there are no parameter_mappings on the dashboard card", () => {
+    const { action, dashCard } = setup({
+      actionParameters: [WRITEBACK_PARAMETER],
+      dashCardParameterMappings: [],
+    });
+
+    const result = turnDashCardParameterMappingsIntoClickBehaviorMappings(
+      dashCard,
+      [DASHBOARD_FILTER_PARAMETER],
+      action,
+    );
+
+    expect(result).toEqual({});
+  });
+
+  it("returns empty object if there no parameters on the action", () => {
+    const { action, dashCard } = setup({
+      actionParameters: [],
+      dashCardParameterMappings: [PARAMETER_MAPPING],
+    });
+
+    const result = turnDashCardParameterMappingsIntoClickBehaviorMappings(
+      dashCard,
+      [DASHBOARD_FILTER_PARAMETER],
+      action,
+    );
+
+    expect(result).toEqual({});
+  });
+
+  it("returns empty object if dashboard parameters are unavailable", () => {
+    const { action, dashCard } = setup({
+      actionParameters: [WRITEBACK_PARAMETER],
+      dashCardParameterMappings: [PARAMETER_MAPPING],
+    });
+
+    const result = turnDashCardParameterMappingsIntoClickBehaviorMappings(
+      dashCard,
+      [],
+      action,
+    );
+
+    expect(result).toEqual({});
+  });
+
+  it("returns empty object if nothing is available", () => {
+    const { action, dashCard } = setup({
+      actionParameters: [],
+      dashCardParameterMappings: [],
+    });
+
+    const result = turnDashCardParameterMappingsIntoClickBehaviorMappings(
+      dashCard,
+      [],
+      action,
+    );
+
+    expect(result).toEqual({});
+  });
+
+  it("converts parameters correctly", () => {
+    const { action, dashCard } = setup({
+      actionParameters: [WRITEBACK_PARAMETER],
+      dashCardParameterMappings: [PARAMETER_MAPPING],
+    });
+
+    const result = turnDashCardParameterMappingsIntoClickBehaviorMappings(
+      dashCard,
+      [DASHBOARD_FILTER_PARAMETER],
+      action,
+    );
+
+    expect(result).toEqual(CLICK_BEHAVIOR_PARAMETER_MAPPINGS);
+  });
+});
+
+describe("turnClickBehaviorParameterMappingsIntoDashCardMappings", () => {
+  it("returns nothing if action parameters are empty", () => {
+    const action = createMockQueryAction({ parameters: [] });
+
+    const result = turnClickBehaviorParameterMappingsIntoDashCardMappings(
+      CLICK_BEHAVIOR_PARAMETER_MAPPINGS,
+      action,
+    );
+
+    expect(result).toEqual([]);
+  });
+
+  it("returns nothing if click behavior mappings are empty", () => {
+    const action = createMockQueryAction({ parameters: [WRITEBACK_PARAMETER] });
+
+    const result = turnClickBehaviorParameterMappingsIntoDashCardMappings(
+      {},
+      action,
+    );
+
+    expect(result).toEqual([]);
+  });
+
+  it("converts click behavior correctly", () => {
+    const action = createMockQueryAction({ parameters: [WRITEBACK_PARAMETER] });
+
+    const result = turnClickBehaviorParameterMappingsIntoDashCardMappings(
+      CLICK_BEHAVIOR_PARAMETER_MAPPINGS,
+      action,
+    );
+
+    expect(result).toEqual([PARAMETER_MAPPING]);
+  });
+});

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.tsx
@@ -12,6 +12,8 @@ import { usePrevious } from "metabase/hooks/use-previous";
 
 import Sidebar from "metabase/dashboard/components/Sidebar";
 
+import { isActionButtonWithMappedAction } from "metabase/writeback/utils";
+
 import type { UiParameter } from "metabase/parameters/types";
 import type {
   Dashboard,
@@ -157,7 +159,10 @@ function ClickBehaviorSidebar({
   ]);
 
   useOnMount(() => {
-    if (shouldShowTypeSelector(clickBehavior)) {
+    if (
+      !isActionButtonWithMappedAction(dashcard) &&
+      shouldShowTypeSelector(clickBehavior)
+    ) {
       setTypeSelectorVisible(true);
     }
     if (dashcard) {
@@ -187,7 +192,9 @@ function ClickBehaviorSidebar({
     <Sidebar
       onClose={hideClickBehaviorSidebar}
       onCancel={handleCancel}
-      closeIsDisabled={!isValidClickBehavior}
+      closeIsDisabled={
+        !isValidClickBehavior && !isActionButtonWithMappedAction(dashcard)
+      }
     >
       <ClickBehaviorSidebarHeader
         dashcard={dashcard}

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarContent.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarContent.tsx
@@ -47,7 +47,7 @@ function ClickBehaviorSidebar({
   onSettingsChange,
   onTypeSelectorVisibilityChange,
 }: Props) {
-  const finalClickBehavior = useMemo(() => {
+  const finalClickBehavior = useMemo<ClickBehavior>(() => {
     if (clickBehavior) {
       return clickBehavior;
     }

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarContent.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarContent.tsx
@@ -1,7 +1,9 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { getIn } from "icepick";
 
 import { isTableDisplay } from "metabase/lib/click-behavior";
+
+import { isActionButtonWithMappedAction } from "metabase/writeback/utils";
 
 import type { UiParameter } from "metabase/parameters/types";
 import type {
@@ -45,7 +47,15 @@ function ClickBehaviorSidebar({
   onSettingsChange,
   onTypeSelectorVisibilityChange,
 }: Props) {
-  const finalClickBehavior = clickBehavior || { type: "actionMenu" };
+  const finalClickBehavior = useMemo(() => {
+    if (clickBehavior) {
+      return clickBehavior;
+    }
+    if (isActionButtonWithMappedAction(dashcard)) {
+      return { type: "action" };
+    }
+    return { type: "actionMenu" };
+  }, [clickBehavior, dashcard]);
 
   if (isTableDisplay(dashcard) && !hasSelectedColumn) {
     const columns = getIn(dashcardData, [dashcard.card_id, "data", "cols"]);

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarHeader/ClickBehaviorSidebarHeader.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarHeader/ClickBehaviorSidebarHeader.tsx
@@ -4,6 +4,10 @@ import { t, jt } from "ttag";
 import Icon from "metabase/components/Icon";
 
 import { isTableDisplay } from "metabase/lib/click-behavior";
+import {
+  isActionButtonDashCard,
+  getActionButtonLabel,
+} from "metabase/writeback/utils";
 
 import type { DashboardOrderedCard } from "metabase-types/api";
 import type { Column } from "metabase-types/types/Dataset";
@@ -15,7 +19,7 @@ import {
   ItemName,
 } from "./ClickBehaviorSidebarHeader.styled";
 
-function DefaultHeader({ children }: { children: string }) {
+function DefaultHeader({ children }: { children: React.ReactNode }) {
   return (
     <Heading>{jt`Click behavior for ${(
       <ItemName>{children}</ItemName>
@@ -43,7 +47,10 @@ function HeaderContent({ dashcard, selectedColumn, onUnsetColumn }: Props) {
     }
     return <Heading>{t`On-click behavior for each column`}</Heading>;
   }
-
+  if (isActionButtonDashCard(dashcard)) {
+    const label = getActionButtonLabel(dashcard);
+    return <DefaultHeader>{label || t`an action button`}</DefaultHeader>;
+  }
   return <DefaultHeader>{dashcard.card.name}</DefaultHeader>;
 }
 

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarMainView/ClickBehaviorSidebarMainView.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarMainView/ClickBehaviorSidebarMainView.tsx
@@ -2,12 +2,14 @@ import React from "react";
 
 import type { UiParameter } from "metabase/parameters/types";
 import type {
+  ActionButtonDashboardCard,
   Dashboard,
   DashboardOrderedCard,
   ClickBehavior,
 } from "metabase-types/api";
 
 import { clickBehaviorOptions, getClickBehaviorOptionName } from "../utils";
+import ActionOptions from "../ActionOptions";
 import CrossfilterOptions from "../CrossfilterOptions";
 import LinkOptions from "../LinkOptions";
 import { SidebarItem } from "../SidebarItem";
@@ -51,7 +53,12 @@ function ClickBehaviorOptions({
       />
     );
   }
-  return null;
+  return (
+    <ActionOptions
+      dashcard={dashcard as unknown as ActionButtonDashboardCard}
+      parameters={parameters}
+    />
+  );
 }
 
 interface ClickBehaviorSidebarMainViewProps {

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/TypeSelector/TypeSelector.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/TypeSelector/TypeSelector.tsx
@@ -1,7 +1,9 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useMemo } from "react";
 
 import Icon from "metabase/components/Icon";
 import { color } from "metabase/lib/colors";
+
+import { isActionButtonDashCard } from "metabase/writeback/utils";
 
 import type { UiParameter } from "metabase/parameters/types";
 import type { DashboardOrderedCard, ClickBehavior } from "metabase-types/api";
@@ -64,6 +66,13 @@ function TypeSelector({
   updateSettings,
   moveToNextPage,
 }: TypeSelectorProps) {
+  const options = useMemo(() => {
+    if (isActionButtonDashCard(dashcard)) {
+      return clickBehaviorOptions;
+    }
+    return clickBehaviorOptions.filter(option => option.value !== "action");
+  }, [dashcard]);
+
   const handleSelect = useCallback(
     value => {
       if (value !== clickBehavior.type) {
@@ -77,7 +86,7 @@ function TypeSelector({
 
   return (
     <div>
-      {clickBehaviorOptions.map(({ value, icon }) => (
+      {options.map(({ value, icon }) => (
         <div key={value} className="mb1">
           <BehaviorOption
             option={getClickBehaviorOptionName(value, dashcard)}

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/utils.ts
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/utils.ts
@@ -19,7 +19,7 @@ export const clickBehaviorOptions: ClickBehaviorOption[] = [
   { value: "menu", icon: "popover" },
   { value: "link", icon: "link" },
   { value: "crossfilter", icon: "filter" },
-  // { value: "action", icon: "play" },
+  { value: "action", icon: "play" },
 ];
 
 export function getClickBehaviorOptionName(

--- a/frontend/src/metabase/lib/click-behavior.js
+++ b/frontend/src/metabase/lib/click-behavior.js
@@ -16,12 +16,12 @@ import {
 
 export function getDataFromClicked({
   extraData: { dashboard, parameterValuesBySlug, userAttributes } = {},
-  dimensions,
-  data,
+  dimensions = [],
+  data = [],
 }) {
   const column = [
-    ...(dimensions || []),
-    ...(data || []).map(d => ({
+    ...dimensions,
+    ...data.map(d => ({
       column: d.col,
       // When the data is changed to a display value for use in tooltips, we can set clickBehaviorValue to the raw value for filtering.
       value: d.clickBehaviorValue || d.value,

--- a/frontend/src/metabase/modes/components/drill/ActionClickDrill/ActionClickDrill.tsx
+++ b/frontend/src/metabase/modes/components/drill/ActionClickDrill/ActionClickDrill.tsx
@@ -1,0 +1,43 @@
+import { getDataFromClicked } from "metabase/lib/click-behavior";
+
+import { executeRowAction } from "metabase/dashboard/actions";
+
+import type { ParameterMappedForActionExecution } from "metabase-types/api";
+import type { ActionClickObject } from "./types";
+
+import { prepareParameter } from "./utils";
+
+function ActionClickDrill({ clicked }: { clicked: ActionClickObject }) {
+  const { dashboard, dashcard } = clicked.extraData;
+  const { action } = dashcard;
+
+  if (!action) {
+    return [];
+  }
+
+  const parameters: ParameterMappedForActionExecution[] = [];
+  const data = getDataFromClicked(clicked);
+
+  dashcard.parameter_mappings?.forEach?.(mapping => {
+    const parameter = prepareParameter(mapping, { action, data });
+    if (parameter) {
+      parameters.push(parameter);
+    }
+  });
+
+  return [
+    {
+      name: "click_behavior",
+      default: true,
+      defaultAlways: true,
+      action: () =>
+        executeRowAction({
+          dashboard,
+          dashcard,
+          parameters,
+        }),
+    },
+  ];
+}
+
+export default ActionClickDrill;

--- a/frontend/src/metabase/modes/components/drill/ActionClickDrill/ActionClickDrill.unit.spec.ts
+++ b/frontend/src/metabase/modes/components/drill/ActionClickDrill/ActionClickDrill.unit.spec.ts
@@ -1,0 +1,195 @@
+import * as dashboardActions from "metabase/dashboard/actions/writeback";
+
+import type {
+  ActionButtonParametersMapping,
+  DashboardOrderedCard,
+  WritebackParameter,
+} from "metabase-types/api";
+import type { UiParameter } from "metabase/parameters/types";
+
+import {
+  createMockDashboard,
+  createMockDashboardActionButton,
+  createMockQueryAction,
+} from "metabase-types/api/mocks";
+
+import { ActionClickBehaviorData } from "./types";
+import { prepareParameter } from "./utils";
+import ActionClickDrill from "./ActionClickDrill";
+
+const WRITEBACK_PARAMETER: WritebackParameter = {
+  id: "param-1",
+  name: "Order ID",
+  type: "number",
+  slug: "order-id",
+  target: ["variable", ["template-tag", "order-id"]],
+};
+
+const DASHBOARD_FILTER_PARAMETER: UiParameter = {
+  id: "dashboard-filter-1",
+  name: "Order",
+  type: "number",
+  slug: "order",
+  value: 5,
+};
+
+const PARAMETER_MAPPING: ActionButtonParametersMapping = {
+  parameter_id: DASHBOARD_FILTER_PARAMETER.id,
+  target: WRITEBACK_PARAMETER.target,
+};
+
+function getActionClickBehaviorData(value: any): ActionClickBehaviorData {
+  return {
+    column: {},
+    parameter: {
+      [DASHBOARD_FILTER_PARAMETER.id]: { value },
+    },
+    parameterByName: {
+      [DASHBOARD_FILTER_PARAMETER.name]: { value },
+    },
+    parameterBySlug: {
+      [DASHBOARD_FILTER_PARAMETER.slug]: { value },
+    },
+    userAttribute: {},
+  };
+}
+
+describe("prepareParameter", () => {
+  it("returns nothing if can't find source parameter", () => {
+    const action = createMockQueryAction({
+      parameters: [WRITEBACK_PARAMETER],
+    });
+
+    const parameter = prepareParameter(PARAMETER_MAPPING, {
+      data: {
+        column: {},
+        parameter: {},
+        parameterByName: {},
+        parameterBySlug: {},
+        userAttribute: {},
+      },
+      action,
+    });
+
+    expect(parameter).toBeUndefined();
+  });
+
+  it("returns nothing if can't find action parameter", () => {
+    const action = createMockQueryAction({
+      parameters: [],
+    });
+
+    const parameter = prepareParameter(PARAMETER_MAPPING, {
+      data: getActionClickBehaviorData(DASHBOARD_FILTER_PARAMETER.value),
+      action,
+    });
+
+    expect(parameter).toBeUndefined();
+  });
+
+  it("prepares parameter correctly", () => {
+    const action = createMockQueryAction({
+      parameters: [WRITEBACK_PARAMETER],
+    });
+
+    const parameter = prepareParameter(PARAMETER_MAPPING, {
+      data: getActionClickBehaviorData(DASHBOARD_FILTER_PARAMETER.value),
+      action,
+    });
+
+    expect(parameter).toEqual({
+      id: DASHBOARD_FILTER_PARAMETER.id,
+      type: WRITEBACK_PARAMETER.type,
+      value: DASHBOARD_FILTER_PARAMETER.value,
+    });
+  });
+
+  it("handles array-like parameter value", () => {
+    const action = createMockQueryAction({
+      parameters: [WRITEBACK_PARAMETER],
+    });
+
+    const parameter = prepareParameter(PARAMETER_MAPPING, {
+      data: getActionClickBehaviorData([DASHBOARD_FILTER_PARAMETER.value]),
+      action,
+    });
+
+    expect(parameter).toEqual({
+      id: DASHBOARD_FILTER_PARAMETER.id,
+      type: WRITEBACK_PARAMETER.type,
+      value: DASHBOARD_FILTER_PARAMETER.value,
+    });
+  });
+});
+
+describe("ActionClickDrill", () => {
+  it("executes action correctly", () => {
+    const executeActionSpy = jest.spyOn(dashboardActions, "executeRowAction");
+
+    const action = createMockQueryAction({ parameters: [WRITEBACK_PARAMETER] });
+    const dashcard = createMockDashboardActionButton({
+      action,
+      action_id: action.id,
+      parameter_mappings: [PARAMETER_MAPPING],
+    });
+    const dashboard = createMockDashboard({
+      ordered_cards: [dashcard as unknown as DashboardOrderedCard],
+      parameters: [DASHBOARD_FILTER_PARAMETER],
+    });
+
+    const [clickAction] = ActionClickDrill({
+      clicked: {
+        data: [],
+        extraData: {
+          dashboard,
+          dashcard,
+          parameterValuesBySlug: {
+            [DASHBOARD_FILTER_PARAMETER.slug]: DASHBOARD_FILTER_PARAMETER.value,
+          },
+          userAttributes: [],
+        },
+      },
+    });
+
+    clickAction.action();
+
+    expect(executeActionSpy).toBeCalledWith({
+      dashboard,
+      dashcard,
+      parameters: [
+        {
+          id: DASHBOARD_FILTER_PARAMETER.id,
+          type: WRITEBACK_PARAMETER.type,
+          value: DASHBOARD_FILTER_PARAMETER.value,
+        },
+      ],
+    });
+  });
+
+  it("does nothing for buttons without linked action", () => {
+    const dashcard = createMockDashboardActionButton({
+      action_id: null,
+      parameter_mappings: [PARAMETER_MAPPING],
+    });
+    const dashboard = createMockDashboard({
+      ordered_cards: [dashcard as unknown as DashboardOrderedCard],
+      parameters: [DASHBOARD_FILTER_PARAMETER],
+    });
+
+    const clickActions = ActionClickDrill({
+      clicked: {
+        data: [],
+        extraData: {
+          dashboard,
+          dashcard,
+          parameterValuesBySlug: {
+            [DASHBOARD_FILTER_PARAMETER.slug]: DASHBOARD_FILTER_PARAMETER.value,
+          },
+          userAttributes: [],
+        },
+      },
+    });
+
+    expect(clickActions).toHaveLength(0);
+  });
+});

--- a/frontend/src/metabase/modes/components/drill/ActionClickDrill/index.ts
+++ b/frontend/src/metabase/modes/components/drill/ActionClickDrill/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ActionClickDrill";

--- a/frontend/src/metabase/modes/components/drill/ActionClickDrill/types.ts
+++ b/frontend/src/metabase/modes/components/drill/ActionClickDrill/types.ts
@@ -1,0 +1,27 @@
+import type { ActionButtonDashboardCard, Dashboard } from "metabase-types/api";
+import type { Column } from "metabase-types/types/Dataset";
+import type {
+  ParameterId,
+  ParameterValueOrArray,
+} from "metabase-types/types/Parameter";
+import type { ClickObject } from "metabase-types/types/Visualization";
+
+type ActionClickExtraData = {
+  dashboard: Dashboard;
+  dashcard: ActionButtonDashboardCard;
+  parameterValuesBySlug: Record<string, { value: ParameterValueOrArray }>;
+  userAttributes: unknown[];
+};
+
+export type ActionClickObject = Omit<ClickObject, "extraData"> & {
+  data: any;
+  extraData: ActionClickExtraData;
+};
+
+export type ActionClickBehaviorData = {
+  column: Partial<Column>;
+  parameter: Record<ParameterId, { value: ParameterValueOrArray }>;
+  parameterByName: Record<string, { value: ParameterValueOrArray }>;
+  parameterBySlug: Record<string, { value: ParameterValueOrArray }>;
+  userAttribute: Record<string, unknown>;
+};

--- a/frontend/src/metabase/modes/components/drill/ActionClickDrill/utils.ts
+++ b/frontend/src/metabase/modes/components/drill/ActionClickDrill/utils.ts
@@ -1,0 +1,42 @@
+import _ from "underscore";
+
+import type {
+  ActionButtonParametersMapping,
+  WritebackAction,
+} from "metabase-types/api";
+import type { ParameterValueOrArray } from "metabase-types/types/Parameter";
+
+import type { ActionClickBehaviorData } from "./types";
+
+function formatParameterValue(value: ParameterValueOrArray) {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+export function prepareParameter(
+  mapping: ActionButtonParametersMapping,
+  {
+    data,
+    action,
+  }: {
+    data: ActionClickBehaviorData;
+    action: WritebackAction;
+  },
+) {
+  const { parameter_id: sourceParameterId, target: actionParameterTarget } =
+    mapping;
+
+  const sourceParameter = data.parameter[sourceParameterId];
+  const actionParameter = action.parameters.find(parameter =>
+    _.isEqual(parameter.target, actionParameterTarget),
+  );
+
+  if (!actionParameter || !sourceParameter) {
+    return;
+  }
+
+  return {
+    id: sourceParameterId,
+    type: actionParameter.type,
+    value: formatParameterValue(sourceParameter.value),
+  };
+}

--- a/frontend/src/metabase/modes/components/modes/ActionMode.jsx
+++ b/frontend/src/metabase/modes/components/modes/ActionMode.jsx
@@ -1,8 +1,8 @@
-import DashboardClickDrill from "../drill/DashboardClickDrill";
+import ActionClickDrill from "../drill/ActionClickDrill";
 
 const ActionMode = {
   name: "actions",
-  drills: () => [DashboardClickDrill],
+  drills: () => [ActionClickDrill],
 };
 
 export default ActionMode;

--- a/frontend/src/metabase/modes/components/modes/ActionMode.jsx
+++ b/frontend/src/metabase/modes/components/modes/ActionMode.jsx
@@ -1,8 +1,9 @@
 import ActionClickDrill from "../drill/ActionClickDrill";
+import DashboardClickDrill from "../drill/DashboardClickDrill";
 
 const ActionMode = {
   name: "actions",
-  drills: () => [ActionClickDrill],
+  drills: () => [ActionClickDrill, DashboardClickDrill],
 };
 
 export default ActionMode;

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -536,4 +536,7 @@ export const ActionsApi = {
   delete: POST("/api/action/row/delete"),
   bulkUpdate: POST("/api/action/bulk/update/:tableId"),
   bulkDelete: POST("/api/action/bulk/delete/:tableId"),
+  execute: POST(
+    "/api/dashboard/:dashboardId/dashcard/:dashcardId/action/:actionId/execute",
+  ),
 };

--- a/frontend/src/metabase/visualizations/hoc/WithVizSettingsData.js
+++ b/frontend/src/metabase/visualizations/hoc/WithVizSettingsData.js
@@ -55,6 +55,7 @@ const WithVizSettingsData = ComposedComponent => {
           ...entitiesByTypeAndId,
           parameterValuesBySlug: props.parameterValuesBySlug,
           dashboard: props.dashboard,
+          dashcard: props.dashcard,
           userAttributes: getUserAttributes(state, props),
         };
       },

--- a/frontend/src/metabase/writeback/utils.ts
+++ b/frontend/src/metabase/writeback/utils.ts
@@ -4,7 +4,8 @@ import type Database from "metabase-lib/lib/metadata/Database";
 import type Field from "metabase-lib/lib/metadata/Field";
 
 import type {
-  DashboardOrderedCard,
+  ActionButtonDashboardCard,
+  BaseDashboardOrderedCard,
   Database as IDatabase,
 } from "metabase-types/api";
 import type { SavedCard } from "metabase-types/types/Card";
@@ -63,15 +64,21 @@ export const isEditableField = (field: Field) => {
 export const isActionButtonCard = (card: SavedCard) =>
   card?.display === "action-button";
 
-export const isActionButtonDashCard = (dashCard: DashboardOrderedCard) =>
-  isActionButtonCard(
-    dashCard.visualization_settings?.virtual_card as SavedCard,
-  );
+export function isActionButtonDashCard(
+  dashCard: BaseDashboardOrderedCard,
+): dashCard is ActionButtonDashboardCard {
+  const virtualCard = dashCard.visualization_settings?.virtual_card;
+  return isActionButtonCard(virtualCard as SavedCard);
+}
 
-export const isActionButtonWithMappedAction = (
-  dashCard: DashboardOrderedCard,
-) => {
-  return (
-    isActionButtonDashCard(dashCard) && typeof dashCard.action_id === "number"
-  );
-};
+export function isActionButtonWithMappedAction(
+  dashCard: BaseDashboardOrderedCard,
+): dashCard is ActionButtonDashboardCard {
+  const isAction = isActionButtonDashCard(dashCard);
+  return isAction && typeof dashCard.action_id === "number";
+}
+
+export function getActionButtonLabel(dashCard: ActionButtonDashboardCard) {
+  const label = dashCard.visualization_settings?.["button.label"];
+  return label || "";
+}

--- a/frontend/src/metabase/writeback/utils.ts
+++ b/frontend/src/metabase/writeback/utils.ts
@@ -67,3 +67,11 @@ export const isActionButtonDashCard = (dashCard: DashboardOrderedCard) =>
   isActionButtonCard(
     dashCard.visualization_settings?.virtual_card as SavedCard,
   );
+
+export const isActionButtonWithMappedAction = (
+  dashCard: DashboardOrderedCard,
+) => {
+  return (
+    isActionButtonDashCard(dashCard) && typeof dashCard.action_id === "number"
+  );
+};


### PR DESCRIPTION
The core part of #25265 (read for more context). Closes #25234, closes #25235

Reimplements writeback actions parameter mapping and executions code (removed in #25255). The main difference is that we don't use `emitter` objects anymore and don't rely on action button dash cards `click_behavior` for mapping parameters and handling button clicks. Instead, dash cards now have an `action_id` column we can set, and we can re-use the `parameter_mappings` column.

**Highlights**

1. Earlier we extended [`DashboardClickDrill`](https://github.com/metabase/metabase/blob/master/frontend/src/metabase/modes/components/drill/DashboardClickDrill.jsx) to also perform writeback actions. Instead, this PR introduces a new [`ActionClickDrill`](https://github.com/metabase/metabase/blob/new-action-exec/2-new-approach/frontend/src/metabase/modes/components/drill/ActionClickDrill/ActionClickDrill.tsx) that's responsible only for running writeback actions.
2. We're still using the click behavior sidebar for configuring action buttons, although we're not setting the `click_behavior` property onto the dash card `visualization_settings`
3. We're re-using the `ClickMappings` component for configuring action parameters and dashboard parameter mappings. `ClickMappings` only works with the `click_behavior` shape, so this PR introduces [`ActionClickMappings` component](https://github.com/metabase/metabase/blob/new-action-exec/2-new-approach/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ActionOptions/ActionClickMappings.tsx) that serves as an adapter between two formats.

### Demo

https://user-images.githubusercontent.com/17258145/188714110-e7b257a1-16be-4353-9c6c-dd1d19d68e99.mp4


