### PR TITLE
Support arbitrary parameter input for actions

### DIFF
--- a/frontend/src/metabase-types/api/writeback.ts
+++ b/frontend/src/metabase-types/api/writeback.ts
@@ -56,13 +56,18 @@ export type WritebackAction = WritebackActionBase & (QueryAction | HttpAction);
 
 export type ParameterMappings = Record<ParameterId, ParameterTarget>;
 
-export type ParametersMappedToValues = Record<
-  ParameterId,
-  { type: string; value: string | number }
->;
-
-export type ParameterMappedForActionExecution = {
-  id: ParameterId;
+type ParameterForActionExecutionBase = {
   type: string;
   value: string | number;
 };
+
+export type ParameterMappedForActionExecution =
+  ParameterForActionExecutionBase & {
+    id: ParameterId;
+    target: ParameterTarget;
+  };
+
+export type ArbitraryParameterForActionExecution =
+  ParameterForActionExecutionBase & {
+    target: ParameterTarget;
+  };

--- a/frontend/src/metabase-types/store/state.ts
+++ b/frontend/src/metabase-types/store/state.ts
@@ -23,3 +23,8 @@ export interface State {
 export type Dispatch<T = unknown> = (action: T) => void;
 
 export type GetState = () => State;
+
+export type ReduxAction<Type = string, Payload = any> = {
+  type: Type;
+  payload: Payload;
+};

--- a/frontend/src/metabase/dashboard/actions/writeback.ts
+++ b/frontend/src/metabase/dashboard/actions/writeback.ts
@@ -37,6 +37,12 @@ export const openActionParametersModal = createAction(
   OPEN_ACTION_PARAMETERS_MODAL,
 );
 
+export const CLOSE_ACTION_PARAMETERS_MODAL =
+  "metabase/data-app/CLOSE_ACTION_PARAMETERS_MODAL";
+export const closeActionParametersModal = createAction(
+  CLOSE_ACTION_PARAMETERS_MODAL,
+);
+
 export function updateButtonActionMapping(
   dashCardId: number,
   attributes: { action_id?: number | null; parameter_mappings?: any },

--- a/frontend/src/metabase/dashboard/actions/writeback.ts
+++ b/frontend/src/metabase/dashboard/actions/writeback.ts
@@ -269,12 +269,14 @@ export type ExecuteRowActionPayload = {
   dashboard: Dashboard;
   dashcard: ActionButtonDashboardCard;
   parameters: ParameterMappedForActionExecution[];
+  extra_parameters: ParameterMappedForActionExecution[];
 };
 
 export const executeRowAction = ({
   dashboard,
   dashcard,
   parameters,
+  extra_parameters,
 }: ExecuteRowActionPayload) => {
   return async function (dispatch: any) {
     try {
@@ -282,6 +284,7 @@ export const executeRowAction = ({
         dashboardId: dashboard.id,
         dashcardId: dashcard.id,
         parameters,
+        extra_parameters,
       });
       if (result["rows-affected"] > 0) {
         dashboard.ordered_cards

--- a/frontend/src/metabase/dashboard/actions/writeback.ts
+++ b/frontend/src/metabase/dashboard/actions/writeback.ts
@@ -281,7 +281,6 @@ export const executeRowAction = ({
       const result = await ActionsApi.execute({
         dashboardId: dashboard.id,
         dashcardId: dashcard.id,
-        actionId: dashcard.action_id,
         parameters,
       });
       if (result["rows-affected"] > 0) {

--- a/frontend/src/metabase/dashboard/containers/ActionParametersInputModal.tsx
+++ b/frontend/src/metabase/dashboard/containers/ActionParametersInputModal.tsx
@@ -6,13 +6,14 @@ import ModalContent from "metabase/components/ModalContent";
 
 import ActionParametersInputForm from "metabase/writeback/containers/ActionParametersInputForm";
 
-import type { DashboardWithCards } from "metabase-types/types/Dashboard";
+import type { WritebackAction } from "metabase-types/api";
 import type { State } from "metabase-types/store";
 
-type DataAppDashboard = DashboardWithCards;
+import { closeActionParametersModal } from "../actions";
+import { getActionParametersModalFormProps } from "../selectors";
 
 interface OwnProps {
-  dashboard: DataAppDashboard;
+  action: WritebackAction;
 }
 
 interface StateProps {
@@ -27,23 +28,22 @@ type Props = OwnProps & StateProps & DispatchProps;
 
 function mapStateToProps(state: State) {
   return {
-    formProps: {},
+    formProps: getActionParametersModalFormProps(state),
   };
 }
 
 const mapDispatchToProps = {
-  closeActionParametersModal: () => {
-    // pass
-  },
+  closeActionParametersModal,
 };
 
 function ActionParametersInputModal({
   formProps,
+  action,
   closeActionParametersModal,
 }: Props) {
   return (
     <Modal onClose={closeActionParametersModal}>
-      <ModalContent onClose={closeActionParametersModal}>
+      <ModalContent title={action.name} onClose={closeActionParametersModal}>
         <ActionParametersInputForm
           {...formProps}
           onSubmitSuccess={closeActionParametersModal}

--- a/frontend/src/metabase/dashboard/containers/DashboardApp.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp.jsx
@@ -43,6 +43,7 @@ import {
   getIsLoadingComplete,
   getIsHeaderVisible,
   getIsAdditionalInfoVisible,
+  getActionParametersModalAction,
 } from "../selectors";
 import { getDatabases, getMetadata } from "metabase/selectors/metadata";
 import {
@@ -59,6 +60,8 @@ import * as Urls from "metabase/lib/urls";
 import Dashboards from "metabase/entities/dashboards";
 
 import DataAppContext from "metabase/writeback/containers/DataAppContext";
+
+import ActionParametersInputModal from "./ActionParametersInputModal";
 
 function getDashboardId({ dashboardId, location, params }) {
   if (dashboardId) {
@@ -100,6 +103,7 @@ const mapStateToProps = (state, props) => {
     isHeaderVisible: getIsHeaderVisible(state),
     isAdditionalInfoVisible: getIsAdditionalInfoVisible(state),
     embedOptions: getEmbedOptions(state),
+    focusedActionWithMissingParameters: getActionParametersModalAction(state),
   };
 };
 
@@ -115,7 +119,12 @@ const mapDispatchToProps = {
 const DashboardApp = props => {
   const options = parseHashOptions(window.location.hash);
 
-  const { isRunning, isLoadingComplete, dashboard } = props;
+  const {
+    isRunning,
+    isLoadingComplete,
+    dashboard,
+    focusedActionWithMissingParameters,
+  } = props;
 
   const [editingOnLoad] = useState(options.edit);
   const [addCardOnLoad] = useState(options.add && parseInt(options.add));
@@ -172,6 +181,11 @@ const DashboardApp = props => {
         />
         {/* For rendering modal urls */}
         {props.children}
+        {dashboard?.is_app_page && focusedActionWithMissingParameters && (
+          <ActionParametersInputModal
+            action={focusedActionWithMissingParameters}
+          />
+        )}
         <Toaster
           message={
             dashboard?.is_app_page

--- a/frontend/src/metabase/dashboard/reducers.js
+++ b/frontend/src/metabase/dashboard/reducers.js
@@ -37,6 +37,8 @@ import {
   SET_SHOW_LOADING_COMPLETE_FAVICON,
   RESET,
   SET_PARAMETER_VALUES,
+  OPEN_ACTION_PARAMETERS_MODAL,
+  CLOSE_ACTION_PARAMETERS_MODAL,
 } from "./actions";
 
 import { isVirtualDashCard, syncParametersAndEmbeddingParams } from "./utils";
@@ -409,6 +411,27 @@ const sidebar = handleActions(
   DEFAULT_SIDEBAR,
 );
 
+const missingActionParameters = handleActions(
+  {
+    [INITIALIZE]: {
+      next: (state, payload) => null,
+    },
+    [OPEN_ACTION_PARAMETERS_MODAL]: {
+      next: (state, { payload: { dashcardId, props } }) => ({
+        dashcardId,
+        props,
+      }),
+    },
+    [CLOSE_ACTION_PARAMETERS_MODAL]: {
+      next: (state, payload) => null,
+    },
+    [RESET]: {
+      next: (state, payload) => null,
+    },
+  },
+  null,
+);
+
 export default combineReducers({
   dashboardId,
   isEditing,
@@ -422,4 +445,5 @@ export default combineReducers({
   isAddParameterPopoverOpen,
   sidebar,
   parameterValuesSearchCache,
+  missingActionParameters,
 });

--- a/frontend/src/metabase/dashboard/reducers.unit.spec.js
+++ b/frontend/src/metabase/dashboard/reducers.unit.spec.js
@@ -35,6 +35,7 @@ describe("dashboard reducers", () => {
       sidebar: { props: {} },
       slowCards: {},
       loadingControls: {},
+      missingActionParameters: null,
     });
   });
 

--- a/frontend/src/metabase/dashboard/selectors.js
+++ b/frontend/src/metabase/dashboard/selectors.js
@@ -208,3 +208,21 @@ export const getIsAdditionalInfoVisible = createSelector(
   [getIsEmbedded, getEmbedOptions],
   (isEmbedded, embedOptions) => !isEmbedded || embedOptions.additional_info,
 );
+
+const getMissingActionParametersModalState = state =>
+  state.dashboard.missingActionParameters;
+
+export const getActionParametersModalAction = createSelector(
+  [getDashboardComplete, getMissingActionParametersModalState],
+  (dashboard, missingActionParametersModalState) => {
+    const dashcardId = missingActionParametersModalState?.dashcardId;
+    const dashcard = dashboard?.ordered_cards.find(dc => dc.id === dashcardId);
+    return dashcard?.action;
+  },
+);
+
+export const getActionParametersModalFormProps = createSelector(
+  [getMissingActionParametersModalState],
+  missingActionParametersModalState =>
+    missingActionParametersModalState?.props || {},
+);

--- a/frontend/src/metabase/modes/components/drill/ActionClickDrill/ActionClickDrill.tsx
+++ b/frontend/src/metabase/modes/components/drill/ActionClickDrill/ActionClickDrill.tsx
@@ -1,11 +1,14 @@
 import { getDataFromClicked } from "metabase/lib/click-behavior";
 
-import { executeRowAction } from "metabase/dashboard/actions";
+import {
+  executeRowAction,
+  openActionParametersModal,
+} from "metabase/dashboard/actions";
 
 import type { ParameterMappedForActionExecution } from "metabase-types/api";
 import type { ActionClickObject } from "./types";
 
-import { prepareParameter } from "./utils";
+import { prepareParameter, getNotProvidedActionParameters } from "./utils";
 
 function ActionClickDrill({ clicked }: { clicked: ActionClickObject }) {
   const { dashboard, dashcard } = clicked.extraData;
@@ -17,25 +20,49 @@ function ActionClickDrill({ clicked }: { clicked: ActionClickObject }) {
 
   const parameters: ParameterMappedForActionExecution[] = [];
   const data = getDataFromClicked(clicked);
+  const parameterMappings = dashcard.parameter_mappings || [];
 
-  dashcard.parameter_mappings?.forEach?.(mapping => {
+  parameterMappings.forEach(mapping => {
     const parameter = prepareParameter(mapping, { action, data });
     if (parameter) {
       parameters.push(parameter);
     }
   });
 
+  const missingParameters = getNotProvidedActionParameters(
+    action,
+    parameterMappings,
+    parameters,
+  );
+
+  function clickAction() {
+    if (missingParameters.length > 0) {
+      return openActionParametersModal({
+        dashcardId: dashcard.id,
+        props: {
+          missingParameters,
+          onSubmit: (filledParameters: ParameterMappedForActionExecution[]) =>
+            executeRowAction({
+              dashboard,
+              dashcard,
+              parameters: [...parameters, ...filledParameters],
+            }),
+        },
+      });
+    }
+    return executeRowAction({
+      dashboard,
+      dashcard,
+      parameters,
+    });
+  }
+
   return [
     {
       name: "click_behavior",
       default: true,
       defaultAlways: true,
-      action: () =>
-        executeRowAction({
-          dashboard,
-          dashcard,
-          parameters,
-        }),
+      action: clickAction,
     },
   ];
 }

--- a/frontend/src/metabase/modes/components/drill/ActionClickDrill/ActionClickDrill.tsx
+++ b/frontend/src/metabase/modes/components/drill/ActionClickDrill/ActionClickDrill.tsx
@@ -41,11 +41,12 @@ function ActionClickDrill({ clicked }: { clicked: ActionClickObject }) {
         dashcardId: dashcard.id,
         props: {
           missingParameters,
-          onSubmit: (filledParameters: ParameterMappedForActionExecution[]) =>
+          onSubmit: (extra_parameters: ParameterMappedForActionExecution[]) =>
             executeRowAction({
               dashboard,
               dashcard,
-              parameters: [...parameters, ...filledParameters],
+              parameters,
+              extra_parameters,
             }),
         },
       });
@@ -54,6 +55,7 @@ function ActionClickDrill({ clicked }: { clicked: ActionClickObject }) {
       dashboard,
       dashcard,
       parameters,
+      extra_parameters: [],
     });
   }
 

--- a/frontend/src/metabase/modes/components/drill/ActionClickDrill/utils.ts
+++ b/frontend/src/metabase/modes/components/drill/ActionClickDrill/utils.ts
@@ -2,9 +2,14 @@ import _ from "underscore";
 
 import type {
   ActionButtonParametersMapping,
+  ParameterMappedForActionExecution,
   WritebackAction,
+  WritebackParameter,
 } from "metabase-types/api";
-import type { ParameterValueOrArray } from "metabase-types/types/Parameter";
+import type {
+  ParameterTarget,
+  ParameterValueOrArray,
+} from "metabase-types/types/Parameter";
 
 import type { ActionClickBehaviorData } from "./types";
 
@@ -38,5 +43,40 @@ export function prepareParameter(
     id: sourceParameterId,
     type: actionParameter.type,
     value: formatParameterValue(sourceParameter.value),
+    target: actionParameterTarget,
   };
+}
+
+function isMappedParameter(
+  parameter: WritebackParameter,
+  parameterMappings: ActionButtonParametersMapping[],
+) {
+  return parameterMappings.some(mapping =>
+    _.isEqual(mapping.target, parameter.target),
+  );
+}
+
+export function getNotProvidedActionParameters(
+  action: WritebackAction,
+  parameterMappings: ActionButtonParametersMapping[],
+  mappedParameters: ParameterMappedForActionExecution[],
+) {
+  const emptyParameterTargets: ParameterTarget[] = [];
+
+  mappedParameters.forEach(mapping => {
+    if (mapping.value === undefined) {
+      emptyParameterTargets.push(mapping.target);
+    }
+  });
+
+  return action.parameters.filter(parameter => {
+    if ("default" in parameter) {
+      return false;
+    }
+    const isNotMapped = !isMappedParameter(parameter, parameterMappings);
+    const isMappedButNoValue = emptyParameterTargets.some(target =>
+      _.isEqual(target, parameter.target),
+    );
+    return isNotMapped || isMappedButNoValue;
+  });
 }

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -537,6 +537,6 @@ export const ActionsApi = {
   bulkUpdate: POST("/api/action/bulk/update/:tableId"),
   bulkDelete: POST("/api/action/bulk/delete/:tableId"),
   execute: POST(
-    "/api/dashboard/:dashboardId/dashcard/:dashcardId/action/:actionId/execute",
+    "/api/dashboard/:dashboardId/dashcard/:dashcardId/action/execute",
   ),
 };


### PR DESCRIPTION
The final bit of #25265. Closes #25236

> **Warning**
> This branch relies on BE changes from #25198. Be sure to merge it in locally if you want to test the changes

Adds support for user-filled parameter values for explicit actions. Let's say I have an action running a query like:

```sql
UPDATE orders SET discount = {{ discount }} WHERE id = {{ order_id }}
```

We can map `order_id` to a detail page filter, but it doesn't make sense to map `discount` to anything — it can vary from an order to order and should actually be user-filled.

This PR extends `ActionClickDrill` added in #25256 to handle that. Once it builds a list of action parameters with mapped values, it's going to look for fields that are left without any value. If there are missing parameters, we're going to show a modal asking a user to fill in those.

### Demo

https://user-images.githubusercontent.com/17258145/188714110-e7b257a1-16be-4353-9c6c-dd1d19d68e99.mp4