### PR TITLE
Enable the shortcut to run the query by default

### DIFF
--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
@@ -67,6 +67,7 @@ class NativeQueryEditor extends Component {
 
   static defaultProps = {
     isOpen: false,
+    enableRun: true,
     cancelQueryOnLeave: true,
     resizable: true,
   };


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/25219
Regression since https://github.com/metabase/metabase/pull/24997

How to test:
- Question -> SQL Query
- `SELECT 1;`
- Press Command + Run
- Make sure the query was executed