### PR TITLE
Adding text-overflow to ChartSettingsFieldPicker

### DIFF
--- a/frontend/src/metabase/components/Triggerable.jsx
+++ b/frontend/src/metabase/components/Triggerable.jsx
@@ -12,7 +12,8 @@ const Trigger = styled.a``;
 
 // higher order component that takes a component which takes props "isOpen" and optionally "onClose"
 // and returns a component that renders a <a> element "trigger", and tracks whether that component is open or not
-export default ComposedComponent =>
+
+const Triggerable = ComposedComponent =>
   class extends Component {
     static displayName =
       "Triggerable[" +
@@ -178,3 +179,7 @@ export default ComposedComponent =>
       );
     }
   };
+
+export default Object.assign(Triggerable, {
+  Trigger,
+});

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.styled.tsx
@@ -2,6 +2,7 @@ import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
 import Icon from "metabase/components/Icon";
 import SelectButton from "metabase/core/components/SelectButton";
+import Triggerable from "metabase/components/Triggerable";
 
 export const ChartSettingFieldPickerRoot = styled.div`
   display: flex;
@@ -9,6 +10,13 @@ export const ChartSettingFieldPickerRoot = styled.div`
   border: 1px solid ${color("border")};
   border-radius: 0.5rem;
   padding-right: 1rem;
+  overflow-x: hidden;
+  width: 100%;
+
+  ${Triggerable.Trigger} {
+    flex: 1;
+    overflow: hidden;
+  }
 
   ${SelectButton.Root} {
     border: none;
@@ -25,6 +33,10 @@ export const ChartSettingFieldPickerRoot = styled.div`
     font-size: 0.875rem;
     line-height: 1rem;
     margin-right: 0.25rem;
+    text-overflow: ellipsis;
+    max-width: 100%;
+    white-space: nowrap;
+    overflow: hidden;
   }
 `;
 

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.styled.tsx
@@ -10,8 +10,6 @@ export const ChartSettingFieldPickerRoot = styled.div`
   border: 1px solid ${color("border")};
   border-radius: 0.5rem;
   padding-right: 1rem;
-  overflow-x: hidden;
-  width: 100%;
 
   ${Triggerable.Trigger} {
     flex: 1;


### PR DESCRIPTION
EPIC #24840 

Small fix to add text-overflow properties to longer column names for the `<ChartSettingsFieldPicker />` component

![image](https://user-images.githubusercontent.com/1328979/188710788-39a4c2ec-eb62-487e-b07b-527a28b3e67b.png)
