### PR TITLE
Add white background to "Metabase tips" button in Home Page

### DIFF
--- a/frontend/src/metabase/home/homepage/components/HomeHelpCard/HomeHelpCard.styled.tsx
+++ b/frontend/src/metabase/home/homepage/components/HomeHelpCard/HomeHelpCard.styled.tsx
@@ -5,6 +5,7 @@ import ExternalLink from "metabase/core/components/ExternalLink";
 import { breakpointMinLarge } from "metabase/styled-components/theme";
 
 export const CardRoot = styled(ExternalLink)`
+  background: ${color("white")};
   display: flex;
   align-items: center;
   padding: 1rem;


### PR DESCRIPTION
Whenever the window was short, the button overlapped the illustration and got confusing.

### Before

<img width="815" alt="image" src="https://user-images.githubusercontent.com/380816/188726812-2671fbd8-17a9-4bef-b1b1-6659d84685d3.png">

### After

<img width="1237" alt="image" src="https://user-images.githubusercontent.com/380816/188726512-41db9c30-f716-4592-a610-5045eb0fd6a9.png">


