### PR TITLE
Add goal line settings to the viz-settings map passed to combo chart

### DIFF
--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -309,24 +309,28 @@
         x-col-settings (or (settings-from-column x-col column-settings) {})
         y-col-settings (or (settings-from-column y-col column-settings) {})
         x-format       (merge
-                         (if (isa? (:effective_type x-col) :type/Temporal)
-                           {:date_style "MMMM D, YYYY"}
-                           default-format)
-                         x-col-settings)
+                        (if (isa? (:effective_type x-col) :type/Temporal)
+                          {:date_style "MMMM D, YYYY"}
+                          default-format)
+                        x-col-settings)
         y-format       (merge
-                         default-format
-                         y-col-settings)
+                        default-format
+                        y-col-settings)
         default-x-type (if (isa? (:effective_type x-col) :type/Temporal)
                          "timeseries"
                          "ordinal")]
-    {:colors      (public-settings/application-colors)
-     :stacking    (if (:stackable.stack_type viz-settings) "stack" "none")
-     :show_values (boolean (:graph.show_values viz-settings))
-     :x           {:type   (or (:graph.x_axis.scale viz-settings) default-x-type)
-                   :format x-format}
-     :y           {:type   (or (:graph.y_axis.scale viz-settings) "linear")
-                   :format y-format}
-     :labels      labels}))
+    (merge
+     {:colors      (public-settings/application-colors)
+      :stacking    (if (:stackable.stack_type viz-settings) "stack" "none")
+      :show_values (boolean (:graph.show_values viz-settings))
+      :x           {:type   (or (:graph.x_axis.scale viz-settings) default-x-type)
+                    :format x-format}
+      :y           {:type   (or (:graph.y_axis.scale viz-settings) "linear")
+                    :format y-format}
+      :labels      labels}
+     (when (:graph.show_goal viz-settings)
+       {:goal {:value (:graph.goal_value viz-settings)
+               :label (or (:graph.goal_label viz-settings) (tru "Goal"))}}))))
 
 (defn- set-default-stacked
   "Default stack type is stacked for area chart with more than one metric.


### PR DESCRIPTION
Fixes:  #5433

This passes goal line viz-settings into the combo-chart component.

If the user sets a goal line:
<img width="774" alt="image" src="https://user-images.githubusercontent.com/21064735/188726818-a78e6f67-7a36-4918-8b04-a4ea43db5fce.png">

Those settings were previously not considered when rendering static-viz:

### Before
![image](https://user-images.githubusercontent.com/21064735/188726612-a870fc3d-db71-4fa3-aa8c-6dcafd62b0b7.png)

### After
But now the goal line is shown:
![image](https://user-images.githubusercontent.com/21064735/188726950-24d482de-a108-4886-9d9e-4b519db0de4e.png)
