### PR TITLE
24840 position formatting popup column header

### DIFF
--- a/frontend/src/metabase/lib/dom.js
+++ b/frontend/src/metabase/lib/dom.js
@@ -490,3 +490,16 @@ export function isSmallScreen() {
   const mediaQuery = window.matchMedia("(max-width: 40em)");
   return mediaQuery && mediaQuery.matches;
 }
+
+export const getEventTarget = event => {
+  let target = document.getElementById("popover-event-target");
+  if (!target) {
+    target = document.createElement("div");
+    target.id = "popover-event-target";
+    document.body.appendChild(target);
+  }
+  target.style.left = event.clientX - 3 + "px";
+  target.style.top = event.clientY - 3 + "px";
+
+  return target;
+};

--- a/frontend/src/metabase/lib/dom.js
+++ b/frontend/src/metabase/lib/dom.js
@@ -491,6 +491,9 @@ export function isSmallScreen() {
   return mediaQuery && mediaQuery.matches;
 }
 
+/**
+ * @param {MouseEvent} event
+ */
 export const getEventTarget = event => {
   let target = document.getElementById("popover-event-target");
   if (!target) {

--- a/frontend/src/metabase/lib/dom.js
+++ b/frontend/src/metabase/lib/dom.js
@@ -492,7 +492,7 @@ export function isSmallScreen() {
 }
 
 /**
- * @param {MouseEvent} event
+ * @param {MouseEvent<Element, MouseEvent>} event
  */
 export const getEventTarget = event => {
   let target = document.getElementById("popover-event-target");

--- a/frontend/src/metabase/modes/components/drill/FormatAction.jsx
+++ b/frontend/src/metabase/modes/components/drill/FormatAction.jsx
@@ -28,7 +28,7 @@ export default ({ question, clicked }) => {
       buttonType: "formatting",
       icon: "gear",
       tooltip: t`Column formatting`,
-      popoverOptions: {
+      popoverProps: {
         placement: "right-end",
         offset: [0, 20],
       },
@@ -69,7 +69,7 @@ export default ({ question, clicked }) => {
 };
 
 const PopoverRoot = styled.div`
-  margin-top: 1.5rem;
+  padding-top: 1.5rem;
   max-height: 600px;
   overflow-y: auto;
 `;

--- a/frontend/src/metabase/modes/components/drill/FormatAction.jsx
+++ b/frontend/src/metabase/modes/components/drill/FormatAction.jsx
@@ -28,6 +28,10 @@ export default ({ question, clicked }) => {
       buttonType: "formatting",
       icon: "gear",
       tooltip: t`Column formatting`,
+      popoverOptions: {
+        placement: "right-end",
+        offset: [0, 20],
+      },
       popover: function FormatPopover({ series, onChange }) {
         const handleChangeSettings = changedSettings => {
           onChange(

--- a/frontend/src/metabase/modes/components/drill/FormatAction.jsx
+++ b/frontend/src/metabase/modes/components/drill/FormatAction.jsx
@@ -70,4 +70,6 @@ export default ({ question, clicked }) => {
 
 const PopoverRoot = styled.div`
   margin-top: 1.5rem;
+  max-height: 600px;
+  overflow-y: auto;
 `;

--- a/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
@@ -9,6 +9,7 @@ import Tooltip from "metabase/components/Tooltip";
 import "./ChartClickActions.css";
 
 import * as MetabaseAnalytics from "metabase/lib/analytics";
+import { getEventTarget } from "metabase/lib/dom";
 
 import { performAction } from "metabase/visualizations/lib/action";
 
@@ -113,6 +114,18 @@ class ChartClickActions extends Component {
     }
   };
 
+  getPopoverReference = clicked => {
+    if (clicked.element) {
+      if (clicked.element.firstChild instanceof HTMLElement) {
+        return clicked.element.firstChild;
+      } else {
+        return clicked.element;
+      }
+    } else if (clicked.event) {
+      return getEventTarget(clicked.event);
+    }
+  };
+
   render() {
     const {
       clicked,
@@ -185,10 +198,14 @@ class ChartClickActions extends Component {
 
     const hasOnlyOneSection = sections.length === 1;
 
+    const popoverAnchor = this.getPopoverReference(clicked);
+
+    console.log(popoverAnchor);
+
     return (
       <FlexTippyPopover
-        reference={clicked.element.firstChild || clicked.element}
-        visible={!!clicked.element}
+        reference={popoverAnchor}
+        visible={!!popoverAnchor}
         onClose={() => {
           MetabaseAnalytics.trackStructEvent(
             "Action",

--- a/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
@@ -4,7 +4,7 @@ import { connect } from "react-redux";
 import { t } from "ttag";
 
 import Icon from "metabase/components/Icon";
-import Popover from "metabase/components/Popover";
+import TippyPopover from "metabase/components/Popover/TippyPopover";
 import Tooltip from "metabase/components/Tooltip";
 
 import "./ChartClickActions.css";
@@ -184,9 +184,9 @@ class ChartClickActions extends Component {
     const hasOnlyOneSection = sections.length === 1;
 
     return (
-      <Popover
-        target={clicked.element}
-        targetEvent={clicked.event}
+      <TippyPopover
+        reference={clicked.element.children[0]}
+        visible={!!clicked.element}
         onClose={() => {
           MetabaseAnalytics.trackStructEvent(
             "Action",
@@ -194,81 +194,91 @@ class ChartClickActions extends Component {
           );
           this.close();
         }}
-        verticalAttachments={["top", "bottom"]}
-        horizontalAttachments={["left", "center", "right"]}
-        sizeToFit
-        pinInitialAttachment
-      >
-        {popover ? (
-          popover
-        ) : (
-          <div className="text-bold px2 pt2 pb1">
-            {sections.map(([key, actions]) => (
-              <div
-                key={key}
-                className={cx(
-                  "pb1",
-                  { pb2: SECTIONS[key].icon === "bolt" },
-                  {
-                    ml1:
-                      SECTIONS[key].icon === "bolt" ||
-                      SECTIONS[key].icon === "sum" ||
-                      SECTIONS[key].icon === "breakout" ||
-                      (SECTIONS[key].icon === "funnel_outline" &&
-                        !hasOnlyOneSection),
-                  },
-                )}
-              >
-                {SECTIONS[key].icon === "sum" && (
-                  <p className="mt0 text-medium text-small">{t`Summarize`}</p>
-                )}
-                {SECTIONS[key].icon === "breakout" && (
-                  <p className="my1 text-medium text-small">{t`Break out by a…`}</p>
-                )}
-                {SECTIONS[key].icon === "bolt" && (
-                  <p className="mt2 text-medium text-small">
-                    {t`Automatic explorations`}
-                  </p>
-                )}
-                {SECTIONS[key].icon === "funnel_outline" && (
-                  <p
-                    className={cx(
-                      "text-small",
-                      hasOnlyOneSection ? "mt0" : "mt2",
-                      hasOnlyOneSection ? "text-dark" : "text-medium",
-                    )}
-                  >
-                    {t`Filter by this value`}
-                  </p>
-                )}
-
+        placement="bottom-start"
+        popperOptions={{
+          flip: true,
+          modifiers: [
+            {
+              name: "preventOverflow",
+              options: {
+                padding: 16,
+              },
+            },
+          ],
+        }}
+        content={
+          popover ? (
+            popover
+          ) : (
+            <div className="text-bold px2 pt2 pb1">
+              {sections.map(([key, actions]) => (
                 <div
+                  key={key}
                   className={cx(
-                    "flex",
+                    "pb1",
+                    { pb2: SECTIONS[key].icon === "bolt" },
                     {
-                      "justify-end": SECTIONS[key].icon === "gear",
+                      ml1:
+                        SECTIONS[key].icon === "bolt" ||
+                        SECTIONS[key].icon === "sum" ||
+                        SECTIONS[key].icon === "breakout" ||
+                        (SECTIONS[key].icon === "funnel_outline" &&
+                          !hasOnlyOneSection),
                     },
-                    {
-                      "align-center justify-center":
-                        SECTIONS[key].icon === "gear",
-                    },
-                    { "flex-column my1": SECTIONS[key].icon === "summarize" },
                   )}
                 >
-                  {actions.map((action, index) => (
-                    <ChartClickAction
-                      key={index}
-                      action={action}
-                      isLastItem={index === actions.length - 1}
-                      handleClickAction={this.handleClickAction}
-                    />
-                  ))}
+                  {SECTIONS[key].icon === "sum" && (
+                    <p className="mt0 text-medium text-small">{t`Summarize`}</p>
+                  )}
+                  {SECTIONS[key].icon === "breakout" && (
+                    <p className="my1 text-medium text-small">{t`Break out by a…`}</p>
+                  )}
+                  {SECTIONS[key].icon === "bolt" && (
+                    <p className="mt2 text-medium text-small">
+                      {t`Automatic explorations`}
+                    </p>
+                  )}
+                  {SECTIONS[key].icon === "funnel_outline" && (
+                    <p
+                      className={cx(
+                        "text-small",
+                        hasOnlyOneSection ? "mt0" : "mt2",
+                        hasOnlyOneSection ? "text-dark" : "text-medium",
+                      )}
+                    >
+                      {t`Filter by this value`}
+                    </p>
+                  )}
+
+                  <div
+                    className={cx(
+                      "flex",
+                      {
+                        "justify-end": SECTIONS[key].icon === "gear",
+                      },
+                      {
+                        "align-center justify-center":
+                          SECTIONS[key].icon === "gear",
+                      },
+                      { "flex-column my1": SECTIONS[key].icon === "summarize" },
+                    )}
+                  >
+                    {actions.map((action, index) => (
+                      <ChartClickAction
+                        key={index}
+                        action={action}
+                        isLastItem={index === actions.length - 1}
+                        handleClickAction={this.handleClickAction}
+                      />
+                    ))}
+                  </div>
                 </div>
-              </div>
-            ))}
-          </div>
-        )}
-      </Popover>
+              ))}
+            </div>
+          )
+        }
+        {...popoverAction?.popoverOptions}
+      />
     );
   }
 }

--- a/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
@@ -4,7 +4,6 @@ import { connect } from "react-redux";
 import { t } from "ttag";
 
 import Icon from "metabase/components/Icon";
-import TippyPopover from "metabase/components/Popover/TippyPopover";
 import Tooltip from "metabase/components/Tooltip";
 
 import "./ChartClickActions.css";
@@ -16,7 +15,10 @@ import { performAction } from "metabase/visualizations/lib/action";
 import cx from "classnames";
 import _ from "underscore";
 import { Link } from "react-router";
-import { ClickActionButton } from "./ChartClickActions.styled";
+import {
+  ClickActionButton,
+  FlexTippyPopover,
+} from "./ChartClickActions.styled";
 
 // These icons used to be displayed for each row section of actions.
 // We're now just using them as a way to select different sections of actions to style them uniquely.
@@ -184,8 +186,8 @@ class ChartClickActions extends Component {
     const hasOnlyOneSection = sections.length === 1;
 
     return (
-      <TippyPopover
-        reference={clicked.element.children[0]}
+      <FlexTippyPopover
+        reference={clicked.element.firstChild || clicked.element}
         visible={!!clicked.element}
         onClose={() => {
           MetabaseAnalytics.trackStructEvent(
@@ -195,6 +197,7 @@ class ChartClickActions extends Component {
           this.close();
         }}
         placement="bottom-start"
+        offset={[-8, 8]}
         popperOptions={{
           flip: true,
           modifiers: [

--- a/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
@@ -295,7 +295,7 @@ class ChartClickActions extends Component {
             </div>
           )
         }
-        {...popoverAction?.popoverOptions}
+        {...popoverAction?.popoverProps}
       />
     );
   }

--- a/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
@@ -200,8 +200,6 @@ class ChartClickActions extends Component {
 
     const popoverAnchor = this.getPopoverReference(clicked);
 
-    console.log(popoverAnchor);
-
     return (
       <FlexTippyPopover
         reference={popoverAnchor}

--- a/frontend/src/metabase/visualizations/components/ChartClickActions.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartClickActions.styled.tsx
@@ -1,6 +1,7 @@
 import styled from "@emotion/styled";
 import { css } from "@emotion/react";
 import { alpha, color } from "metabase/lib/colors";
+import TippyPopover from "metabase/components/Popover/TippyPopover";
 
 export interface ClickActionButtonProps {
   type: "sort" | "formatting" | "horizontal" | "token" | "token-filter";
@@ -78,4 +79,8 @@ export const ClickActionButton = styled.div<ClickActionButtonProps>`
         background-color: ${color("filter")};
       }
     `}
+`;
+
+export const FlexTippyPopover = styled(TippyPopover)`
+  display: flex;
 `;

--- a/frontend/src/metabase/visualizations/components/ChartTooltip/ChartTooltip.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartTooltip/ChartTooltip.tsx
@@ -1,5 +1,6 @@
 import React, { MouseEvent, useMemo } from "react";
 import _ from "underscore";
+import { getEventTarget } from "metabase/lib/dom";
 import Tooltip from "metabase/components/Tooltip";
 import DataPointTooltip from "./DataPointTooltip";
 import TimelineEventTooltip from "./TimelineEventTooltip";
@@ -8,7 +9,6 @@ import {
   HoveredTimelineEvent,
   VisualizationSettings,
 } from "./types";
-import { getEventTarget } from "./utils";
 
 export interface ChartTooltipProps {
   hovered?: HoveredObject;

--- a/frontend/src/metabase/visualizations/components/ChartTooltip/utils.ts
+++ b/frontend/src/metabase/visualizations/components/ChartTooltip/utils.ts
@@ -19,16 +19,3 @@ export const formatValueForTooltip = ({
     type: "tooltip",
     majorWidth: 0,
   });
-
-export const getEventTarget = (event: MouseEvent) => {
-  let target = document.getElementById("popover-event-target");
-  if (!target) {
-    target = document.createElement("div");
-    target.id = "popover-event-target";
-    document.body.appendChild(target);
-  }
-  target.style.left = event.clientX - 3 + "px";
-  target.style.top = event.clientY - 3 + "px";
-
-  return target;
-};


### PR DESCRIPTION
EPIC #24840 

PR to convert `ChartClickAction` popovers to Tippy, as well as adjust positioning of the popover when adjusting the column formatting so you can see what you're doing.

![chrome_cdNj9o6CSZ](https://user-images.githubusercontent.com/1328979/188913663-c6b7bbe2-a6a4-444b-a1c2-eff64df199ce.gif)
