### PR TITLE
Fix automatic homepage handling for data apps

### DIFF
--- a/frontend/src/metabase/writeback/containers/DataAppLanding.tsx
+++ b/frontend/src/metabase/writeback/containers/DataAppLanding.tsx
@@ -41,7 +41,7 @@ const DataAppLanding = ({
       <Search.ListLoader
         query={{
           collection: dataApp.collection_id,
-          models: ["dashboard"],
+          models: ["page"],
           limit: 100,
         }}
         loadingAndErrorWrapper={false}


### PR DESCRIPTION
Fixes an issue when launching a data app that would automatically open the first page, but the page itself won't load.

The regression happened when pages become separated from dashboards in search endpoints we're relying on for automatic homepage selection

### To Verify

Follow the steps from #25081