### PR TITLE
Implement basic "New App" scaffolding flow

### DIFF
--- a/frontend/src/metabase/components/NewItemMenu/NewItemMenu.styled.tsx
+++ b/frontend/src/metabase/components/NewItemMenu/NewItemMenu.styled.tsx
@@ -1,0 +1,6 @@
+import styled from "@emotion/styled";
+import Modal from "metabase/components/Modal";
+
+export const WideModal = styled(Modal)`
+  width: 60%;
+`;

--- a/frontend/src/metabase/components/NewItemMenu/NewItemMenu.tsx
+++ b/frontend/src/metabase/components/NewItemMenu/NewItemMenu.tsx
@@ -7,12 +7,12 @@ import CreateDashboardModal from "metabase/components/CreateDashboardModal";
 
 import * as Urls from "metabase/lib/urls";
 
-import DataApps from "metabase/entities/data-apps";
-
 import CollectionCreate from "metabase/collections/containers/CollectionCreate";
 import CreateDataAppModal from "metabase/writeback/containers/CreateDataAppModal";
 
-import { Collection, CollectionId } from "metabase-types/api";
+import type { Collection, CollectionId } from "metabase-types/api";
+
+import { WideModal } from "./NewItemMenu.styled";
 
 type ModalType = "new-app" | "new-dashboard" | "new-collection";
 
@@ -135,22 +135,28 @@ const NewItemMenu = ({
         tooltip={triggerTooltip}
       />
       {modal && (
-        <Modal onClose={handleModalClose}>
+        <>
           {modal === "new-collection" ? (
-            <CollectionCreate
-              collectionId={collectionId}
-              onClose={handleModalClose}
-              onSaved={handleCollectionSave}
-            />
+            <Modal onClose={handleModalClose}>
+              <CollectionCreate
+                collectionId={collectionId}
+                onClose={handleModalClose}
+                onSaved={handleCollectionSave}
+              />
+            </Modal>
           ) : modal === "new-dashboard" ? (
-            <CreateDashboardModal
-              collectionId={collectionId}
-              onClose={handleModalClose}
-            />
+            <Modal onClose={handleModalClose}>
+              <CreateDashboardModal
+                collectionId={collectionId}
+                onClose={handleModalClose}
+              />
+            </Modal>
           ) : modal === "new-app" ? (
-            <CreateDataAppModal onClose={handleModalClose} />
+            <WideModal onClose={handleModalClose}>
+              <CreateDataAppModal onClose={handleModalClose} />
+            </WideModal>
           ) : null}
-        </Modal>
+        </>
       )}
     </>
   );

--- a/frontend/src/metabase/entities/data-apps/data-apps.ts
+++ b/frontend/src/metabase/entities/data-apps/data-apps.ts
@@ -25,6 +25,11 @@ type UpdateDataAppParams = Pick<DataApp, "id" | "collection_id"> & {
   collection: Pick<Collection, "name" | "description">;
 };
 
+export type ScaffoldAppParams = {
+  name: EditableDataAppParams["name"];
+  tables: number[]; // list of table IDs
+};
+
 const DataApps = createEntity({
   name: "dataApps",
   nameOne: "dataApp",
@@ -58,6 +63,19 @@ const DataApps = createEntity({
     }: UpdateDataAppParams) => {
       await CollectionsApi.update({ ...collection, id: collection_id });
       return DataAppsApi.update({ id, ...rest });
+    },
+  },
+
+  objectActions: {
+    scaffold: async ({ name, tables }: ScaffoldAppParams) => {
+      const dataApp = await DataAppsApi.scaffold({
+        "app-name": name,
+        "table-ids": tables,
+      });
+      return {
+        type: DataApps.actionTypes.CREATE,
+        payload: DataApps.normalize(dataApp),
+      };
     },
   },
 

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
@@ -297,6 +297,7 @@ export class UnconnectedDataSelector extends Component {
     hasTableSearch: false,
     canChangeDatabase: true,
     hasTriggerExpandControl: true,
+    isPopover: true,
   };
 
   // computes selected metadata objects (`selectedDatabase`, etc) and options (`databases`, etc)
@@ -1026,7 +1027,7 @@ export class UnconnectedDataSelector extends Component {
     return hasDataAccess || databases?.length > 0;
   };
 
-  render() {
+  renderContent = () => {
     const {
       searchText,
       isSavedQuestionPickerShown,
@@ -1042,71 +1043,85 @@ export class UnconnectedDataSelector extends Component {
     const isPickerOpen =
       isSavedQuestionPickerShown ||
       selectedDataBucketId === DATA_BUCKET.DATASETS;
-    return (
-      <PopoverWithTrigger
-        id="DataPopover"
-        autoWidth
-        ref={this.popover}
-        isInitiallyOpen={this.props.isInitiallyOpen}
-        containerClassName={this.props.containerClassName}
-        triggerElement={this.getTriggerElement}
-        triggerClasses={this.getTriggerClasses()}
-        hasArrow={this.props.hasArrow}
-        tetherOptions={this.props.tetherOptions}
-        sizeToFit
-        isOpen={this.props.isOpen}
-        onClose={this.handleClose}
-      >
-        {this.isLoadingDatasets() ? (
-          <LoadingAndErrorWrapper loading />
-        ) : this.hasDataAccess() ? (
-          <>
-            {this.showTableSearch() && (
-              <ListSearchField
-                hasClearButton
-                className="bg-white m1"
-                onChange={this.handleSearchTextChange}
-                value={searchText}
-                placeholder={this.getSearchInputPlaceholder()}
-                autoFocus
-              />
-            )}
-            {isSearchActive && (
-              <SearchResults
-                searchModels={this.getSearchModels()}
-                searchQuery={searchText.trim()}
-                databaseId={currentDatabaseId}
-                onSelect={this.handleSearchItemSelect}
-              />
-            )}
-            {!isSearchActive &&
-              (isPickerOpen ? (
-                <SavedQuestionPicker
-                  collectionName={
-                    selectedTable &&
-                    selectedTable.schema &&
-                    getSchemaName(selectedTable.schema.id)
-                  }
-                  isDatasets={selectedDataBucketId === DATA_BUCKET.DATASETS}
-                  tableId={selectedTable?.id}
-                  databaseId={currentDatabaseId}
-                  onSelect={this.handleSavedQuestionSelect}
-                  onBack={this.handleSavedQuestionPickerClose}
-                />
-              ) : (
-                this.renderActiveStep()
-              ))}
-          </>
-        ) : (
-          <EmptyStateContainer>
-            <EmptyState
-              message={t`To pick some data, you'll need to add some first`}
-              icon="database"
+
+    if (this.isLoadingDatasets()) {
+      return <LoadingAndErrorWrapper loading />;
+    }
+
+    if (this.hasDataAccess()) {
+      return (
+        <>
+          {this.showTableSearch() && (
+            <ListSearchField
+              hasClearButton
+              className="bg-white m1"
+              onChange={this.handleSearchTextChange}
+              value={searchText}
+              placeholder={this.getSearchInputPlaceholder()}
+              autoFocus
             />
-          </EmptyStateContainer>
-        )}
-      </PopoverWithTrigger>
+          )}
+          {isSearchActive && (
+            <SearchResults
+              searchModels={this.getSearchModels()}
+              searchQuery={searchText.trim()}
+              databaseId={currentDatabaseId}
+              onSelect={this.handleSearchItemSelect}
+            />
+          )}
+          {!isSearchActive &&
+            (isPickerOpen ? (
+              <SavedQuestionPicker
+                collectionName={
+                  selectedTable &&
+                  selectedTable.schema &&
+                  getSchemaName(selectedTable.schema.id)
+                }
+                isDatasets={selectedDataBucketId === DATA_BUCKET.DATASETS}
+                tableId={selectedTable?.id}
+                databaseId={currentDatabaseId}
+                onSelect={this.handleSavedQuestionSelect}
+                onBack={this.handleSavedQuestionPickerClose}
+              />
+            ) : (
+              this.renderActiveStep()
+            ))}
+        </>
+      );
+    }
+
+    return (
+      <EmptyStateContainer>
+        <EmptyState
+          message={t`To pick some data, you'll need to add some first`}
+          icon="database"
+        />
+      </EmptyStateContainer>
     );
+  };
+
+  render() {
+    if (this.props.isPopover) {
+      return (
+        <PopoverWithTrigger
+          id="DataPopover"
+          autoWidth
+          ref={this.popover}
+          isInitiallyOpen={this.props.isInitiallyOpen}
+          containerClassName={this.props.containerClassName}
+          triggerElement={this.getTriggerElement}
+          triggerClasses={this.getTriggerClasses()}
+          hasArrow={this.props.hasArrow}
+          tetherOptions={this.props.tetherOptions}
+          sizeToFit
+          isOpen={this.props.isOpen}
+          onClose={this.handleClose}
+        >
+          {this.renderContent()}
+        </PopoverWithTrigger>
+      );
+    }
+    return this.renderContent();
   }
 }
 

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -183,6 +183,7 @@ export const CollectionsApi = {
 export const DataAppsApi = {
   list: GET("/api/app"),
   create: POST("/api/app"),
+  scaffold: POST("/api/app/scaffold"),
   update: PUT("/api/app/:id"),
 };
 

--- a/frontend/src/metabase/writeback/containers/CreateDataAppModal/CreateDataAppModal.styled.tsx
+++ b/frontend/src/metabase/writeback/containers/CreateDataAppModal/CreateDataAppModal.styled.tsx
@@ -1,0 +1,40 @@
+import styled from "@emotion/styled";
+import { color } from "metabase/lib/colors";
+
+export const ModalRoot = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex: 1 0 auto;
+  min-height: 50vh;
+`;
+
+export const ModalHeader = styled.div`
+  display: flex;
+  align-items: center;
+  padding: 1.5rem 2rem;
+`;
+
+export const ModalTitle = styled.div`
+  flex: 1 1 auto;
+  color: ${color("text-dark")};
+  font-size: 1.25rem;
+  line-height: 1.5rem;
+  font-weight: bold;
+`;
+
+export const ModalBody = styled.div`
+  display: flex;
+  flex: 1;
+
+  padding: 0 1rem 1rem 1rem;
+`;
+
+export const ModalFooter = styled.div`
+  display: flex;
+  justify-content: flex-end;
+
+  gap: 1rem;
+  padding: 1.5rem 2rem;
+
+  border-top: 1px solid ${color("border")};
+`;

--- a/frontend/src/metabase/writeback/containers/CreateDataAppModal/CreateDataAppModal.tsx
+++ b/frontend/src/metabase/writeback/containers/CreateDataAppModal/CreateDataAppModal.tsx
@@ -1,44 +1,83 @@
-import React, { useCallback } from "react";
-import type { LocationDescriptor } from "history";
+import React, { useCallback, useState } from "react";
+import { t } from "ttag";
 import { connect } from "react-redux";
 import { push } from "react-router-redux";
+import type { LocationDescriptor } from "history";
+
+import Button from "metabase/core/components/Button";
 
 import * as Urls from "metabase/lib/urls";
 
-import DataApps from "metabase/entities/data-apps";
+import DataApps, { ScaffoldAppParams } from "metabase/entities/data-apps";
+import { DatabaseSchemaAndTableDataSelector } from "metabase/query_builder/components/DataSelector";
 
-import type { DataApp as IDataApp } from "metabase-types/api";
-import type { State } from "metabase-types/store";
+import type { DataApp } from "metabase-types/api";
+import type { Dispatch, State } from "metabase-types/store";
+
+import {
+  ModalRoot,
+  ModalHeader,
+  ModalTitle,
+  ModalBody,
+  ModalFooter,
+} from "./CreateDataAppModal.styled";
 
 interface OwnProps {
   onClose: () => void;
 }
 
 interface DispatchProps {
+  onCreate: (params: ScaffoldAppParams) => Promise<DataApp>;
   onChangeLocation: (location: LocationDescriptor) => void;
 }
 
 type Props = OwnProps & DispatchProps;
 
-const mapDispatchToProps = {
-  onChangeLocation: push,
-};
-
-function CreateDataAppModal({ onClose, onChangeLocation }: Props) {
-  const handleSave = useCallback(
-    (dataApp: IDataApp) => {
-      onClose();
-      onChangeLocation(Urls.dataApp(dataApp));
+function mapDispatchToProps(dispatch: Dispatch) {
+  return {
+    onCreate: async (params: ScaffoldAppParams) => {
+      const action = await dispatch(DataApps.objectActions.scaffold(params));
+      return DataApps.HACK_getObjectFromAction(action);
     },
-    [onClose, onChangeLocation],
-  );
+    onChangeLocation: (location: LocationDescriptor) =>
+      dispatch(push(location)),
+  };
+}
+
+function CreateDataAppModal({ onCreate, onChangeLocation, onClose }: Props) {
+  const [tableId, setTableId] = useState<number | null>(null);
+
+  const handleCreate = useCallback(async () => {
+    const dataApp = await onCreate({
+      name: t`New App`,
+      tables: [tableId] as number[],
+    });
+    onClose();
+    onChangeLocation(Urls.dataApp(dataApp));
+  }, [tableId, onCreate, onChangeLocation, onClose]);
 
   return (
-    <DataApps.ModalForm
-      form={DataApps.forms.create}
-      onSaved={handleSave}
-      onClose={onClose}
-    />
+    <ModalRoot>
+      <ModalHeader>
+        <ModalTitle>{t`Pick your starting data`}</ModalTitle>
+      </ModalHeader>
+      <ModalBody>
+        <DatabaseSchemaAndTableDataSelector
+          selectedTableId={tableId}
+          setSourceTableFn={setTableId}
+          requireWriteback
+          isPopover={false}
+        />
+      </ModalBody>
+      <ModalFooter>
+        <Button onClick={onClose}>{t`Cancel`}</Button>
+        <Button
+          primary
+          disabled={tableId == null}
+          onClick={handleCreate}
+        >{t`Create`}</Button>
+      </ModalFooter>
+    </ModalRoot>
   );
 }
 


### PR DESCRIPTION
Basic implementation of #25293

Replaces a new app form modal we used to have with a starting data picker. The picker lets you select a table (only one for now) that'd be used to scaffold an app (create basic pages with actions, filters, etc.)

### To Verify

1. New > App > Select a table > Create
2. Ensure you're navigated to your new app
3. Go back, and ensure you can see your app in the main sidebar

### Demo

https://user-images.githubusercontent.com/17258145/188960580-84add78c-799e-4c79-9bbd-a5d4235af43b.mp4

