### PR TITLE
[Apps] Hide is_write cards from collection items

### DIFF
--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -281,6 +281,7 @@
        :where     [:and
                    [:= :collection_id (:id collection)]
                    [:= :archived (boolean archived?)]
+                   [:= :is_write false]
                    [:= :dataset dataset?]]}
       (hh/merge-where (pinned-state->clause pinned-state))))
 

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -1126,7 +1126,11 @@
                    :model               "card"
                    :fully_parametrized  true}]
                  (for [item (:data (mt/user-http-request :crowberto :get 200 "collection/root/items?archived=true"))]
-                   (dissoc item :id)))))))
+                   (dissoc item :id))))))
+
+      (testing "Are is_write cards excluded?"
+        (mt/with-temp Card [_ {:name "Action Card" :is_write true}]
+          (is (nil? (some (comp #(= % "Action Card") :name) (:data (mt/user-http-request :crowberto :get 200 "collection/root/items"))))))))
 
     (testing "fully_parametrized of a card"
       (testing "can be false"


### PR DESCRIPTION
Action cards should only be accessed through action editing - if we want actions to be accessible in collection items then it should be the action itself, so that it will work with HTTPAction as well.