### PR TITLE
Action Creator 4: Derive parameter types from form settings on save

### DIFF
--- a/frontend/src/metabase-types/api/index.ts
+++ b/frontend/src/metabase-types/api/index.ts
@@ -24,3 +24,4 @@ export * from "./timeline";
 export * from "./user";
 export * from "./writeback";
 export * from "./writeback-form-settings";
+export * from "./parameters";

--- a/frontend/src/metabase-types/api/parameters.ts
+++ b/frontend/src/metabase-types/api/parameters.ts
@@ -1,0 +1,27 @@
+export type StringParameterType =
+  | "string/="
+  | "string/!="
+  | "string/contains"
+  | "string/does-not-contain"
+  | "string/starts-with"
+  | "string/ends-with";
+
+export type NumberParameterType =
+  | "number/="
+  | "number/!="
+  | "number/between"
+  | "number/>="
+  | "number/<=";
+
+export type DateParameterType =
+  | "date/single"
+  | "date/range"
+  | "date/relative"
+  | "date/month-year"
+  | "date/quarter-year";
+("date/all-options");
+
+export type ParameterType =
+  | StringParameterType
+  | NumberParameterType
+  | DateParameterType;

--- a/frontend/src/metabase-types/api/writeback-form-settings.ts
+++ b/frontend/src/metabase-types/api/writeback-form-settings.ts
@@ -1,15 +1,16 @@
 export type FormType = "inline" | "modal";
-export type FieldType = "text" | "number" | "date" | "category";
+export type FieldType = "string" | "number" | "date" | "category";
+
+export type DateInputType = "date" | "datetime" | "monthyear" | "quarteryear";
+
 export type InputType =
+  | DateInputType
   | "string"
   | "text"
   | "number"
-  | "date"
-  | "datetime"
-  | "monthyear"
-  | "quarteryear"
   | "dropdown"
   | "inline-select";
+
 export type Size = "small" | "medium" | "large";
 
 export type DateRange = [string, string];

--- a/frontend/src/metabase/entities/actions/actions.ts
+++ b/frontend/src/metabase/entities/actions/actions.ts
@@ -6,7 +6,10 @@ import type { ActionFormSettings } from "metabase-types/api";
 import { CardApi } from "metabase/services";
 
 import { saveForm } from "./forms";
-import { removeOrphanSettings } from "metabase/entities/actions/utils";
+import {
+  removeOrphanSettings,
+  setParameterTypesFromFieldSettings,
+} from "metabase/entities/actions/utils";
 
 type ActionParams = {
   name: string;
@@ -29,7 +32,10 @@ const getAPIFn =
       ...question.card(),
       name,
       description,
-      parameters: question.parameters(),
+      parameters: setParameterTypesFromFieldSettings(
+        formSettings,
+        question.parameters(),
+      ),
       is_write: true,
       display: "table",
       visualization_settings: removeOrphanSettings(

--- a/frontend/src/metabase/entities/actions/actions.ts
+++ b/frontend/src/metabase/entities/actions/actions.ts
@@ -9,6 +9,7 @@ import { saveForm } from "./forms";
 import {
   removeOrphanSettings,
   setParameterTypesFromFieldSettings,
+  setTemplateTagTypesFromFieldSettings,
 } from "metabase/entities/actions/utils";
 
 type ActionParams = {
@@ -27,8 +28,10 @@ const getAPIFn =
     question,
     collection_id,
     formSettings,
-  }: ActionParams) =>
-    apifn({
+  }: ActionParams) => {
+    question = setTemplateTagTypesFromFieldSettings(formSettings, question);
+
+    return apifn({
       ...question.card(),
       name,
       description,
@@ -44,6 +47,7 @@ const getAPIFn =
       ),
       collection_id,
     });
+  };
 
 const createAction = getAPIFn(CardApi.create);
 const updateAction = getAPIFn(CardApi.update);

--- a/frontend/src/metabase/entities/actions/constants.ts
+++ b/frontend/src/metabase/entities/actions/constants.ts
@@ -1,7 +1,12 @@
 import type { ParameterType } from "metabase-types/api";
+import type { TemplateTagType } from "metabase-types/types/Query";
 
 interface FieldTypeMap {
   [key: string]: ParameterType;
+}
+
+interface TagTypeMap {
+  [key: string]: TemplateTagType;
 }
 
 export const fieldTypeToParameterTypeMap: FieldTypeMap = {
@@ -15,4 +20,11 @@ export const dateTypetoParameterTypeMap: FieldTypeMap = {
   datetime: "date/single",
   monthyear: "date/month-year",
   quarteryear: "date/quarter-year",
+};
+
+export const fieldTypeToTagTypeMap: TagTypeMap = {
+  string: "text",
+  category: "text",
+  number: "number",
+  date: "date",
 };

--- a/frontend/src/metabase/entities/actions/constants.ts
+++ b/frontend/src/metabase/entities/actions/constants.ts
@@ -1,0 +1,18 @@
+import type { ParameterType } from "metabase-types/api";
+
+interface FieldTypeMap {
+  [key: string]: ParameterType;
+}
+
+export const fieldTypeToParameterTypeMap: FieldTypeMap = {
+  string: "string/=",
+  category: "string/=",
+  number: "number/=",
+};
+
+export const dateTypetoParameterTypeMap: FieldTypeMap = {
+  date: "date/single",
+  datetime: "date/single",
+  monthyear: "date/month-year",
+  quarteryear: "date/quarter-year",
+};

--- a/frontend/src/metabase/entities/actions/utils.ts
+++ b/frontend/src/metabase/entities/actions/utils.ts
@@ -1,7 +1,16 @@
 import _ from "underscore";
-
-import type { ActionFormSettings } from "metabase-types/api";
+import type {
+  ActionFormSettings,
+  FieldType,
+  InputType,
+  ParameterType,
+} from "metabase-types/api";
 import type { Parameter as ParameterObject } from "metabase-types/types/Parameter";
+
+import {
+  fieldTypeToParameterTypeMap,
+  dateTypetoParameterTypeMap,
+} from "./constants";
 
 export const removeOrphanSettings = (
   settings: ActionFormSettings,
@@ -15,4 +24,31 @@ export const removeOrphanSettings = (
     ...settings,
     fields: _.omit(settings.fields, orphanIds),
   };
+};
+
+const getParameterTypeFromFieldSettings = (
+  fieldType: FieldType,
+  inputType: InputType,
+): ParameterType => {
+  if (fieldType === "date") {
+    return dateTypetoParameterTypeMap[inputType] ?? "date/single";
+  }
+
+  return fieldTypeToParameterTypeMap[fieldType] ?? "string/=";
+};
+
+export const setParameterTypesFromFieldSettings = (
+  settings: ActionFormSettings,
+  parameters: ParameterObject[],
+): ParameterObject[] => {
+  const fields = settings.fields;
+  return parameters.map(parameter => {
+    const field = fields[parameter.id];
+    return {
+      ...parameter,
+      type: field
+        ? getParameterTypeFromFieldSettings(field.fieldType, field.inputType)
+        : "string/=",
+    };
+  });
 };

--- a/frontend/src/metabase/entities/actions/utils.unit.spec.ts
+++ b/frontend/src/metabase/entities/actions/utils.unit.spec.ts
@@ -1,4 +1,7 @@
-import { removeOrphanSettings } from "./utils";
+import {
+  removeOrphanSettings,
+  setParameterTypesFromFieldSettings,
+} from "./utils";
 
 import {
   getDefaultFormSettings,
@@ -8,45 +11,130 @@ import {
 import type { Parameter as ParameterObject } from "metabase-types/types/Parameter";
 
 describe("entities > actions > utils", () => {
-  it("should remove orphan settings", () => {
-    const formSettings = getDefaultFormSettings();
-    formSettings.name = "test form";
-    formSettings.fields.aaa = getDefaultFieldSettings();
-    formSettings.fields.bbb = getDefaultFieldSettings();
-    formSettings.fields.ccc = getDefaultFieldSettings();
+  describe("removeOrphanSettings", () => {
+    it("should remove orphan settings", () => {
+      const formSettings = getDefaultFormSettings();
+      formSettings.name = "test form";
+      formSettings.fields.aaa = getDefaultFieldSettings();
+      formSettings.fields.bbb = getDefaultFieldSettings();
+      formSettings.fields.ccc = getDefaultFieldSettings();
 
-    const parameters = [
-      { id: "aaa", name: "foo" },
-      { id: "ccc", name: "bar" },
-    ] as ParameterObject[];
+      const parameters = [
+        { id: "aaa", name: "foo" },
+        { id: "ccc", name: "bar" },
+      ] as ParameterObject[];
 
-    const result = removeOrphanSettings(formSettings, parameters);
+      const result = removeOrphanSettings(formSettings, parameters);
 
-    expect(result.name).toEqual("test form");
-    expect(result.fields).toHaveProperty("aaa");
-    expect(result.fields).toHaveProperty("ccc");
-    expect(result.fields).not.toHaveProperty("bbb");
+      expect(result.name).toEqual("test form");
+      expect(result.fields).toHaveProperty("aaa");
+      expect(result.fields).toHaveProperty("ccc");
+      expect(result.fields).not.toHaveProperty("bbb");
+    });
+
+    it("should leave non-orphan settings intact", () => {
+      const formSettings = getDefaultFormSettings();
+      formSettings.name = "test form";
+
+      formSettings.fields.aaa = getDefaultFieldSettings();
+      formSettings.fields.bbb = getDefaultFieldSettings();
+      formSettings.fields.ccc = getDefaultFieldSettings();
+
+      const parameters = [
+        { id: "aaa", name: "foo" },
+        { id: "bbb", name: "foo" },
+        { id: "ccc", name: "bar" },
+      ] as ParameterObject[];
+
+      const result = removeOrphanSettings(formSettings, parameters);
+
+      expect(result.name).toEqual("test form");
+      expect(result.fields).toHaveProperty("aaa");
+      expect(result.fields).toHaveProperty("bbb");
+      expect(result.fields).toHaveProperty("ccc");
+    });
   });
 
-  it("should leave non-orphan settings intact", () => {
-    const formSettings = getDefaultFormSettings();
-    formSettings.name = "test form";
+  describe("setParameterTypesFromFieldSettings", () => {
+    it("should set string parameter types", () => {
+      const formSettings = getDefaultFormSettings();
+      formSettings.name = "test form";
 
-    formSettings.fields.aaa = getDefaultFieldSettings();
-    formSettings.fields.bbb = getDefaultFieldSettings();
-    formSettings.fields.ccc = getDefaultFieldSettings();
+      formSettings.fields.aaa = getDefaultFieldSettings();
+      formSettings.fields.aaa.fieldType = "string";
 
-    const parameters = [
-      { id: "aaa", name: "foo" },
-      { id: "bbb", name: "foo" },
-      { id: "ccc", name: "bar" },
-    ] as ParameterObject[];
+      formSettings.fields.bbb = getDefaultFieldSettings();
+      formSettings.fields.bbb.fieldType = "string";
 
-    const result = removeOrphanSettings(formSettings, parameters);
+      formSettings.fields.ccc = getDefaultFieldSettings();
+      formSettings.fields.ccc.fieldType = "string";
 
-    expect(result.name).toEqual("test form");
-    expect(result.fields).toHaveProperty("aaa");
-    expect(result.fields).toHaveProperty("bbb");
-    expect(result.fields).toHaveProperty("ccc");
+      const parameters = [
+        { id: "aaa", name: "foo", type: "number/=" },
+        { id: "bbb", name: "foo", type: "number/=" },
+        { id: "ccc", name: "bar", type: "number/=" },
+      ] as ParameterObject[];
+
+      const newParams = setParameterTypesFromFieldSettings(
+        formSettings,
+        parameters,
+      );
+
+      newParams.forEach(param => expect(param.type).toEqual("string/="));
+    });
+
+    it("should set number parameter types", () => {
+      const formSettings = getDefaultFormSettings();
+      formSettings.name = "test form";
+
+      formSettings.fields.aaa = getDefaultFieldSettings();
+      formSettings.fields.aaa.fieldType = "number";
+
+      formSettings.fields.bbb = getDefaultFieldSettings();
+      formSettings.fields.bbb.fieldType = "number";
+
+      formSettings.fields.ccc = getDefaultFieldSettings();
+      formSettings.fields.ccc.fieldType = "number";
+
+      const parameters = [
+        { id: "aaa", name: "foo", type: "string/=" },
+        { id: "bbb", name: "foo", type: "string/=" },
+        { id: "ccc", name: "bar", type: "string/=" },
+      ] as ParameterObject[];
+
+      const newParams = setParameterTypesFromFieldSettings(
+        formSettings,
+        parameters,
+      );
+
+      newParams.forEach(param => expect(param.type).toEqual("number/="));
+    });
+
+    it("should set date parameter types", () => {
+      const formSettings = getDefaultFormSettings();
+      formSettings.name = "test form";
+
+      formSettings.fields.aaa = getDefaultFieldSettings();
+      formSettings.fields.aaa.fieldType = "date";
+
+      formSettings.fields.bbb = getDefaultFieldSettings();
+      formSettings.fields.bbb.fieldType = "date";
+
+      formSettings.fields.ccc = getDefaultFieldSettings();
+      formSettings.fields.ccc.fieldType = "date";
+
+      const parameters = [
+        { id: "aaa", name: "foo", type: "string/=" },
+        { id: "bbb", name: "foo", type: "string/=" },
+        { id: "ccc", name: "bar", type: "string/=" },
+      ] as ParameterObject[];
+
+      const newParams = setParameterTypesFromFieldSettings(
+        formSettings,
+        parameters,
+      );
+
+      newParams.forEach(param => expect(param.type).toEqual("date/single"));
+    });
   });
 });

--- a/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/FieldSettingsPopover.tsx
+++ b/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/FieldSettingsPopover.tsx
@@ -107,7 +107,7 @@ function InputTypeSelect({
     <Radio
       vertical
       value={value}
-      options={inputTypes[fieldType ?? "text"]}
+      options={inputTypes[fieldType ?? "string"]}
       onChange={onChange}
     />
   );

--- a/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/constants.ts
+++ b/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/constants.ts
@@ -8,7 +8,7 @@ interface FieldOptionType {
 
 export const getFieldTypes = (): FieldOptionType[] => [
   {
-    value: "text",
+    value: "string",
     name: t`text`,
   },
   {
@@ -31,7 +31,7 @@ interface InputOptionType {
 }
 
 interface InputOptionsMap {
-  text: InputOptionType[];
+  string: InputOptionType[];
   number: InputOptionType[];
   date: InputOptionType[];
   category: InputOptionType[];
@@ -60,7 +60,7 @@ const getSelectInputs = (): InputOptionType[] => [
 ];
 
 export const getInputTypes = (): InputOptionsMap => ({
-  text: [...getTextInputs(), ...getSelectInputs()],
+  string: [...getTextInputs(), ...getSelectInputs()],
   number: [
     {
       value: "number",

--- a/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/utils.ts
+++ b/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/utils.ts
@@ -13,7 +13,7 @@ export const getDefaultFieldSettings = (): FieldSettings => ({
   order: 0,
   description: "",
   placeholder: "",
-  fieldType: "text",
+  fieldType: "string",
   inputType: "string",
   required: false,
   hidden: false,

--- a/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/utils.ts
+++ b/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/utils.ts
@@ -1,14 +1,19 @@
 import type { ActionFormSettings, FieldSettings } from "metabase-types/api";
 
-export const getDefaultFormSettings = (): ActionFormSettings => ({
+export const getDefaultFormSettings = (
+  overrides: Partial<ActionFormSettings> = {},
+): ActionFormSettings => ({
   name: "",
   type: "inline",
   description: "",
   fields: {},
   confirmMessage: "",
+  ...overrides,
 });
 
-export const getDefaultFieldSettings = (): FieldSettings => ({
+export const getDefaultFieldSettings = (
+  overrides: Partial<FieldSettings> = {},
+): FieldSettings => ({
   name: "",
   order: 0,
   description: "",
@@ -18,4 +23,5 @@ export const getDefaultFieldSettings = (): FieldSettings => ({
   required: false,
   hidden: false,
   width: "medium",
+  ...overrides,
 });


### PR DESCRIPTION
## Description

I discovered when reviewing https://github.com/metabase/metabase/pull/25257 that we need to properly set parameter types in the action creator. I had originally planned to just pull in the existing parameter settings sidebar in a popover, but I realized we can derive everything we need from the form settings and we don't need users to set multiple, potentially inconsistent types here.

> **Warning** 
> I want to wait until #25257 gets merged to make sure it all lines up properly

## Changes

- Change the `text` internal fieldType to `string` to make mapping to parameter types less confusing.
- Added enumerated parameter types to `metabase-types/api`, in `metabase-types/types` they're just defined as `string` 😢 
- Add a function that runs before action save and sets all of the parameter types based on the selected field settings
- add unit tests!

## Testing Steps

- Open the action creator and create an action like `insert into order (name, price) values ({{name}}, {{price}})`
- edit the form field settings so that `price` is a number
<img width="403" alt="Screen Shot 2022-09-07 at 2 16 19 PM" src="https://user-images.githubusercontent.com/30528226/188969071-9543620f-83a2-4293-906a-257c68f601a4.png">


In the request to the backend:
- the name parameter should be passed as `type: "string/="`
- the price parameter should be passed as `type: "number/="`




