### PR TITLE
Serdes v2: Selective serialization from the command line

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
@@ -1,6 +1,7 @@
 (ns metabase-enterprise.serialization.cmd
   (:refer-clojure :exclude [load])
-  (:require [clojure.tools.logging :as log]
+  (:require [clojure.string :as str]
+            [clojure.tools.logging :as log]
             [metabase-enterprise.serialization.dump :as dump]
             [metabase-enterprise.serialization.load :as load]
             [metabase-enterprise.serialization.v2.extract :as v2.extract]
@@ -173,8 +174,15 @@
   (dump/dump-dimensions path)
   (log/info (trs "END DUMP to {0} via user {1}" path user)))
 
+(defn- v2-extract [opts]
+  (if (:collections opts)
+    (v2.extract/extract-subtrees (assoc opts :targets (for [c (str/split (:collections opts) #",")]
+                                                        ["Collection" (Integer/parseInt c)])))
+    (v2.extract/extract-metabase opts)))
+
 (defn- v2-dump [path opts]
-  (v2.storage/store! (v2.extract/extract-metabase opts) path))
+  (-> (v2-extract opts)
+      (v2.storage/store! path)))
 
 (defn dump
   "Serialized metabase instance into directory `path`."


### PR DESCRIPTION
Pass `--collections 123,456,789` to dump only these collections and
their transitive `serdes-descendants`.

