### PR TITLE
Serdes v2: Several fixes that came out of the git <-> prod workflow

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
@@ -74,6 +74,7 @@
   ; TODO This should be restored, but there's no manifest or other meta file written by v2 dumps.
   ;(when-not (load/compatible? path)
   ;  (log/warn (trs "Dump was produced using a different version of Metabase. Things may break!")))
+  (log/info (trs "Loading serialized Metabase files from {0}" path))
   (v2.load/load-metabase (v2.ingest/ingest-yaml path)))
 
 (defn load

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/ingest/yaml.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/ingest/yaml.clj
@@ -56,10 +56,11 @@
       (eduction (comp (filter (fn [^File f] (.isFile f)))
                       ;; The immediate parent directory should be a recognized model name.
                       ;; If it's not, this may be in .git, or .github/actions/... or similar extra files.
-                      (filter (fn [^File f] (-> f
-                                                (.getParentFile)
-                                                (.getName)
-                                                model-set)))
+                      (filter (fn [^File f] (or (= (.getName f) "settings.yaml")
+                                                (-> f
+                                                    (.getParentFile)
+                                                    (.getName)
+                                                    model-set))))
                       (mapcat (partial build-metas root-dir)))
                 (file-seq root-dir))))
 

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/ingest/yaml.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/ingest/yaml.clj
@@ -3,6 +3,7 @@
   to avoid confusion with filesystem paths."
   (:require [clojure.java.io :as io]
             [metabase-enterprise.serialization.v2.ingest :as ingest]
+            [metabase-enterprise.serialization.v2.models :as models]
             [metabase-enterprise.serialization.v2.utils.yaml :as u.yaml]
             [metabase.util.date-2 :as u.date]
             [yaml.core :as yaml]
@@ -29,7 +30,8 @@
 
 (defn- read-timestamps [entity]
   (->> (keys entity)
-       (filter #(.endsWith (name %) "_at"))
+       (filter #(or (#{:last_analyzed} %)
+                    (.endsWith (name %) "_at")))
        (reduce #(update %1 %2 u.date/parse) entity)))
 
 (defn- ingest-entity
@@ -50,9 +52,16 @@
 (deftype YamlIngestion [^File root-dir settings]
   ingest/Ingestable
   (ingest-list [_]
-    (eduction (comp (filter (fn [^File f] (.isFile f)))
-                    (mapcat (partial build-metas root-dir)))
-              (file-seq root-dir)))
+    (let [model-set (set models/exported-models)]
+      (eduction (comp (filter (fn [^File f] (.isFile f)))
+                      ;; The immediate parent directory should be a recognized model name.
+                      ;; If it's not, this may be in .git, or .github/actions/... or similar extra files.
+                      (filter (fn [^File f] (-> f
+                                                (.getParentFile)
+                                                (.getName)
+                                                model-set)))
+                      (mapcat (partial build-metas root-dir)))
+                (file-seq root-dir))))
 
   (ingest-one [_ abs-path]
     (let [{:keys [model id]} (first abs-path)]

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -236,8 +236,9 @@
                        ser))
           (is (not (contains? ser :id)))
 
-          (testing "cards depend on their Table and Collection, and any fields in their parameter_mappings"
-            (is (= #{[{:model "Database"   :id "My Database"}
+          (testing "cards depend on their Database, Table and Collection, and any fields in their parameter_mappings"
+            (is (= #{[{:model "Database"   :id "My Database"}]
+                     [{:model "Database"   :id "My Database"}
                       {:model "Schema"     :id "PUBLIC"}
                       {:model "Table"      :id "Schema'd Table"}]
                      [{:model "Collection" :id coll-eid}]
@@ -283,8 +284,9 @@
                        ser))
           (is (not (contains? ser :id)))
 
-          (testing "cards depend on their Table and Collection, and any fields in their visualization_settings"
-            (is (= #{[{:model "Database"   :id "My Database"}
+          (testing "cards depend on their Database, Table and Collection, and any fields in their visualization_settings"
+            (is (= #{[{:model "Database"   :id "My Database"}]
+                     [{:model "Database"   :id "My Database"}
                       {:model "Schema"     :id "PUBLIC"}
                       {:model "Table"      :id "Schema'd Table"}]
                      [{:model "Collection" :id coll-eid}]

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -374,12 +374,13 @@
       (update :visualization_settings serdes.util/import-visualization-settings)))
 
 (defmethod serdes.base/serdes-dependencies "Card"
-  [{:keys [collection_id dataset_query parameter_mappings table_id visualization_settings]}]
-  ;; The Table implicitly depends on the Database.
+  [{:keys [collection_id database_id dataset_query parameter_mappings table_id visualization_settings]}]
   (->> (map serdes.util/mbql-deps parameter_mappings)
        (reduce set/union)
-       (set/union #{(serdes.util/table->path table_id)
-                    [{:model "Collection" :id collection_id}]})
+       (set/union #{[{:model "Database" :id database_id}]})
+       ; table_id and collection_id are nullable.
+       (set/union (when table_id #{(serdes.util/table->path table_id)}))
+       (set/union (when collection_id #{[{:model "Collection" :id collection_id}]}))
        (set/union (serdes.util/mbql-deps dataset_query))
        (set/union (serdes.util/visualization-settings-deps visualization_settings))
        vec))


### PR DESCRIPTION
- Limit the scanning of directories and files to those named after
  models; don't try to ingest `.git`, `README.md`, etc.
- `table_id` and `collection_id` are optional on Cards
- Deserialization was not resolving some deeply nested `:field`s inside MBQL
  queries.
