### PR TITLE
docs - add frontmatter to API doc page

### DIFF
--- a/src/metabase/cmd/resources/api-intro.md
+++ b/src/metabase/cmd/resources/api-intro.md
@@ -1,3 +1,7 @@
+---
+title: "Metabase API documentation"
+---
+
 # Metabase API documentation
 
 _These reference files were generated from source comments by running `clojure -M:ee:run api-documentation`_.


### PR DESCRIPTION
Adds frontmatter and title to API docs intro. Useful for the incoming sidebar.