### PR TITLE
Fix joined table names

### DIFF
--- a/frontend/src/metabase-lib/lib/queries/structured/Join.ts
+++ b/frontend/src/metabase-lib/lib/queries/structured/Join.ts
@@ -559,14 +559,14 @@ export default class Join extends MBQLObjectClause {
     const sourceTable = this.joinSourceTableId();
     const sourceQuery = this.joinSourceQuery();
     return sourceTable
-      ? new StructuredQuery(this.query().question(), {
+      ? new StructuredQuery(this.query().question().setDataset(false), {
           type: "query",
           query: {
             "source-table": sourceTable,
           },
         })
       : sourceQuery
-      ? new StructuredQuery(this.query().question(), {
+      ? new StructuredQuery(this.query().question().setDataset(false), {
           type: "query",
           query: sourceQuery,
         })


### PR DESCRIPTION
Related to #23021 (and fixed in conjunction with https://github.com/metabase/metabase/pull/25109)

This is a "hack" sort of, but the method itself is already a hack in that we are hijacking the current query's question to create a fake query so that we can represent the dimensions coming from a Join as coming from a distinct query so that logic down the line can do `query.table().displayName()` or whatever.

I won't close the issue when this PR merges as it needs to land in conjunction with https://github.com/metabase/metabase/pull/25109 to be fixed entirely -- note that the names are still wrong in the Join dimension picker steps shown below:

![Screen Shot 2022-09-08 at 3 20 47 PM](https://user-images.githubusercontent.com/13057258/189208112-bdbe0b32-200f-42dc-abc3-fd32cf3b61f8.png)

When combined with #25109 it becomes:
![Screen Shot 2022-09-08 at 5 53 49 PM](https://user-images.githubusercontent.com/13057258/189232686-714e3488-7bc0-4970-a6cd-bdf82e5cfbb0.png)
