### PR TITLE
Add a link to env var docs to settings

### DIFF
--- a/frontend/src/metabase/admin/settings/components/SettingsSetting.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsSetting.jsx
@@ -1,10 +1,10 @@
 /* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-
+import { jt } from "ttag";
+import MetabaseSettings from "metabase/lib/settings";
+import ExternalLink from "metabase/core/components/ExternalLink";
 import SettingHeader from "./SettingHeader";
-import { t } from "ttag";
-
 import SettingInput from "./widgets/SettingInput";
 import SettingNumber from "./widgets/SettingNumber";
 import SettingPassword from "./widgets/SettingPassword";
@@ -69,7 +69,11 @@ export default class SettingsSetting extends Component {
         <SettingContent>
           {setting.is_env_setting ? (
             <SettingEnvVarMessage>
-              {t`Using ` + setting.env_name}
+              {jt`This has been set by the ${(
+                <ExternalLink href={getEnvVarDocsUrl(setting.env_name)}>
+                  {setting.env_name}
+                </ExternalLink>
+              )} environment variable.`}
             </SettingEnvVarMessage>
           ) : (
             <Widget id={settingId} {...widgetProps} />
@@ -85,3 +89,10 @@ export default class SettingsSetting extends Component {
     );
   }
 }
+
+const getEnvVarDocsUrl = envName => {
+  return MetabaseSettings.docsUrl(
+    "configuring-metabase/environment-variables",
+    envName?.toLowerCase(),
+  );
+};


### PR DESCRIPTION
Follow up on https://github.com/metabase/metabase/pull/25067#issuecomment-1241123892

How to test:
- Run `MB_EMAIL_SMTP_PORT=25 yarn dev`
- Go to Admin -> Settings -> Email
- Make sure that there is a link to the environment variables page

<img width="508" alt="Screenshot 2022-09-09 at 10 46 45" src="https://user-images.githubusercontent.com/8542534/189299361-6823153e-0970-4a4d-8940-3375fa0288cf.png">
