### PR TITLE
Make it clearer how to connect a SQL question to a dashboard filter

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCardCardParameterMapper.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCardCardParameterMapper.jsx
@@ -244,7 +244,7 @@ function DashCardCardParameterMapper({
           </Tooltip>
         </>
       )}
-      {onlyAcceptsSingleValue && !isDisabled && (
+      {onlyAcceptsSingleValue && (
         <Warning>
           {t`This field only accepts a single value because it's used in a SQL query.`}
         </Warning>

--- a/frontend/src/metabase/dashboard/components/DashCardCardParameterMapper.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCardCardParameterMapper.jsx
@@ -244,7 +244,7 @@ function DashCardCardParameterMapper({
           </Tooltip>
         </>
       )}
-      {onlyAcceptsSingleValue && (
+      {onlyAcceptsSingleValue && !isDisabled && (
         <Warning>
           {t`This field only accepts a single value because it's used in a SQL query.`}
         </Warning>

--- a/frontend/src/metabase/dashboard/components/DashCardCardParameterMapper.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCardCardParameterMapper.jsx
@@ -4,6 +4,7 @@ import { connect } from "react-redux";
 import _ from "underscore";
 import { t } from "ttag";
 
+import MetabaseSettings from "metabase/lib/settings";
 import Icon from "metabase/components/Icon";
 import Tooltip from "metabase/components/Tooltip";
 import TippyPopover from "metabase/components/Popover/TippyPopover";
@@ -12,6 +13,7 @@ import { isVariableTarget } from "metabase/parameters/utils/targets";
 import { isDateParameter } from "metabase/parameters/utils/parameter-type";
 import { getMetadata } from "metabase/selectors/metadata";
 import {
+  isNativeDashCard,
   isVirtualDashCard,
   showVirtualDashCardInfoText,
 } from "metabase/dashboard/utils";
@@ -34,6 +36,10 @@ import {
   ChevrondownIcon,
   KeyIcon,
   Warning,
+  NativeCardDefault,
+  NativeCardIcon,
+  NativeCardText,
+  NativeCardLink,
 } from "./DashCardCardParameterMapper.styled";
 
 function formatSelected({ name, sectionName }) {
@@ -94,6 +100,7 @@ function DashCardCardParameterMapper({
   );
 
   const isVirtual = isVirtualDashCard(dashcard);
+  const isNative = isNativeDashCard(dashcard);
 
   const hasPermissionsToMap = useMemo(() => {
     if (isVirtual) {
@@ -155,14 +162,14 @@ function DashCardCardParameterMapper({
     ]);
 
   const headerContent = useMemo(() => {
-    if (!isVirtual) {
+    if (!isVirtual && !(isNative && isDisabled)) {
       return t`Column to filter on`;
     } else if (dashcard.size_y !== 1 || isMobile) {
       return t`Variable to map to`;
     } else {
       return null;
     }
-  }, [dashcard, isVirtual, isMobile]);
+  }, [dashcard, isVirtual, isNative, isDisabled, isMobile]);
 
   const mappingInfoText = t`You can connect widgets to {{variables}} in text cards.`;
 
@@ -185,6 +192,16 @@ function DashCardCardParameterMapper({
             />
           </TextCardDefault>
         )
+      ) : isNative && isDisabled ? (
+        <NativeCardDefault>
+          <NativeCardIcon name="info" />
+          <NativeCardText>{t`Add a variable to this question to connect it to a dashboard filter.`}</NativeCardText>
+          <NativeCardLink
+            href={MetabaseSettings.docsUrl(
+              "questions/native-editor/sql-parameters",
+            )}
+          >{t`Learn how`}</NativeCardLink>
+        </NativeCardDefault>
       ) : (
         <>
           {headerContent && <Header>{headerContent}</Header>}

--- a/frontend/src/metabase/dashboard/components/DashCardCardParameterMapper.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCardCardParameterMapper.jsx
@@ -13,6 +13,7 @@ import { isVariableTarget } from "metabase/parameters/utils/targets";
 import { isDateParameter } from "metabase/parameters/utils/parameter-type";
 import { getMetadata } from "metabase/selectors/metadata";
 import {
+  getNativeDashCardEmptyMappingText,
   isNativeDashCard,
   isVirtualDashCard,
   showVirtualDashCardInfoText,
@@ -195,7 +196,9 @@ function DashCardCardParameterMapper({
       ) : isNative && isDisabled ? (
         <NativeCardDefault>
           <NativeCardIcon name="info" />
-          <NativeCardText>{t`Add a variable to this question to connect it to a dashboard filter.`}</NativeCardText>
+          <NativeCardText>
+            {getNativeDashCardEmptyMappingText(editingParameter)}
+          </NativeCardText>
           <NativeCardLink
             href={MetabaseSettings.docsUrl(
               "questions/native-editor/sql-parameters",

--- a/frontend/src/metabase/dashboard/components/DashCardCardParameterMapper.styled.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCardCardParameterMapper.styled.jsx
@@ -38,7 +38,7 @@ export const NativeCardIcon = styled(Icon)`
 
 export const NativeCardText = styled.div`
   color: ${color("text-dark")};
-  max-width: 12.5rem;
+  max-width: 15rem;
   text-align: center;
   line-height: 1.5rem;
 `;

--- a/frontend/src/metabase/dashboard/components/DashCardCardParameterMapper.styled.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCardCardParameterMapper.styled.jsx
@@ -5,6 +5,7 @@ import { space } from "metabase/styled-components/theme";
 import { color, lighten } from "metabase/lib/colors";
 import Icon from "metabase/components/Icon";
 import Button from "metabase/core/components/Button";
+import ExternalLink from "metabase/core/components/ExternalLink";
 
 export const Container = styled.div`
   margin: ${space(1)} 0;
@@ -14,12 +15,38 @@ export const Container = styled.div`
 `;
 
 export const TextCardDefault = styled.div`
-  color: ${color("text-medium")};
+  color: ${color("text-dark")};
   margin: ${space(1)} 0;
   display: flex;
   flex-direction: row;
   align-items: baseline;
   line-height: 1.5rem;
+`;
+
+export const NativeCardDefault = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+export const NativeCardIcon = styled(Icon)`
+  color: ${color("text-medium")};
+  margin-bottom: 0.5rem;
+  width: 1.25rem;
+  height: 1.25rem;
+`;
+
+export const NativeCardText = styled.div`
+  color: ${color("text-dark")};
+  max-width: 12.5rem;
+  text-align: center;
+  line-height: 1.5rem;
+`;
+
+export const NativeCardLink = styled(ExternalLink)`
+  color: ${color("brand")};
+  font-weight: bold;
+  margin-top: 0.5rem;
 `;
 
 export const CardLabel = styled.div`

--- a/frontend/src/metabase/dashboard/utils.js
+++ b/frontend/src/metabase/dashboard/utils.js
@@ -80,7 +80,7 @@ export function getNativeDashCardEmptyMappingText(parameter) {
   } else if (isStringParameter(parameter)) {
     return t`Add a string variable to this question to connect it to a dashboard filter.`;
   } else {
-    return t`Add variable to this question to connect it to a dashboard filter.`;
+    return t`Add a variable to this question to connect it to a dashboard filter.`;
   }
 }
 

--- a/frontend/src/metabase/dashboard/utils.js
+++ b/frontend/src/metabase/dashboard/utils.js
@@ -1,6 +1,12 @@
 import _ from "underscore";
 import Utils from "metabase/lib/utils";
 import { isNative } from "metabase/lib/query";
+import { t } from "ttag";
+import {
+  isDateParameter,
+  isNumberParameter,
+  isStringParameter,
+} from "metabase/parameters/utils/parameter-type";
 
 export function syncParametersAndEmbeddingParams(before, after) {
   if (after.parameters && before.embedding_params) {
@@ -63,6 +69,18 @@ export function showVirtualDashCardInfoText(dashcard, isMobile) {
     return isMobile || dashcard.size_y > 2 || dashcard.size_x > 5;
   } else {
     return true;
+  }
+}
+
+export function getNativeDashCardEmptyMappingText(parameter) {
+  if (isDateParameter(parameter)) {
+    return t`Add a date variable to this question to connect it to a dashboard filter.`;
+  } else if (isNumberParameter(parameter)) {
+    return t`Add a number variable to this question to connect it to a dashboard filter.`;
+  } else if (isStringParameter(parameter)) {
+    return t`Add a string variable to this question to connect it to a dashboard filter.`;
+  } else {
+    return t`Add variable to this question to connect it to a dashboard filter.`;
   }
 }
 

--- a/frontend/src/metabase/dashboard/utils.js
+++ b/frontend/src/metabase/dashboard/utils.js
@@ -1,5 +1,6 @@
 import _ from "underscore";
 import Utils from "metabase/lib/utils";
+import { isNative } from "metabase/lib/query";
 
 export function syncParametersAndEmbeddingParams(before, after) {
   if (after.parameters && before.embedding_params) {
@@ -49,6 +50,10 @@ export function expandInlineCard(card) {
 
 export function isVirtualDashCard(dashcard) {
   return _.isObject(dashcard.visualization_settings.virtual_card);
+}
+
+export function isNativeDashCard(dashcard) {
+  return isNative(dashcard.card?.dataset_query);
 }
 
 // For a virtual (text) dashcard without any parameters, returns a boolean indicating whether we should display the

--- a/frontend/src/metabase/parameters/utils/parameter-type.ts
+++ b/frontend/src/metabase/parameters/utils/parameter-type.ts
@@ -33,6 +33,11 @@ export function isNumberParameter(parameter: Parameter) {
   return type === "number";
 }
 
+export function isStringParameter(parameter: Parameter) {
+  const type = getParameterType(parameter);
+  return type === "string";
+}
+
 export function isFieldFilterParameter(
   parameter: Parameter,
 ): parameter is FieldFilterUiParameter {

--- a/frontend/test/metabase/scenarios/dashboard-filters/parameters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/parameters.cy.spec.js
@@ -301,7 +301,9 @@ describe("scenarios > dashboard > parameters", () => {
       // Confirm that it is not possible to connect filter to the updated question anymore (metabase#9299)
       cy.icon("pencil").click();
       cy.findByText(matchingFilterType.name).find(".Icon-gear").click();
-      cy.findByText(/Add a variable to this question/).should("be.visible");
+      cy.findByText(/Add a string variable to this question/).should(
+        "be.visible",
+      );
     });
   });
 

--- a/frontend/test/metabase/scenarios/dashboard-filters/parameters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/parameters.cy.spec.js
@@ -453,6 +453,48 @@ describe("scenarios > dashboard > parameters", () => {
     cy.findAllByTestId("table-row").should("have.length", 1);
   });
 
+  it("should show an empty state for native questions without matching parameters", () => {
+    const questionDetails = {
+      name: "SQL",
+      native: {
+        database: SAMPLE_DB_ID,
+        query: "SELECT {{tag}}",
+        "template-tags": {
+          tag: {
+            id: "6b8b10ef-0104-1047-1e1b-2492d5954322",
+            name: "tag",
+            display_name: "tag",
+            type: "text",
+            default: "1",
+          },
+        },
+      },
+    };
+
+    const parameterDetails = {
+      name: "Text contains",
+      slug: "text_contains",
+      id: "1b9cd9f1",
+      type: "string/contains",
+      sectionId: "string",
+    };
+
+    const dashboardDetails = {
+      parameters: [parameterDetails],
+    };
+
+    cy.createNativeQuestionAndDashboard({
+      questionDetails,
+      dashboardDetails,
+    }).then(({ body: { dashboard_id } }) => {
+      visitDashboard(dashboard_id);
+    });
+
+    editDashboard();
+    cy.findByText(parameterDetails.name).click();
+    cy.findByText(/Add a variable to this question/).should("be.visible");
+  });
+
   describe("when the user does not have self-service data permissions", () => {
     beforeEach(() => {
       visitDashboard(1);

--- a/frontend/test/metabase/scenarios/dashboard-filters/parameters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/parameters.cy.spec.js
@@ -271,7 +271,7 @@ describe("scenarios > dashboard > parameters", () => {
       cy.icon("pencil").click();
       cy.icon("filter").click();
       cy.findByText("ID").click();
-      cy.findByText("No valid fields");
+      cy.findByText(/Add a variable to this question/).should("be.visible");
 
       // Confirm that the correct parameter type is connected to the native question's field filter
       cy.findByText(matchingFilterType.name).find(".Icon-gear").click();
@@ -301,7 +301,7 @@ describe("scenarios > dashboard > parameters", () => {
       // Confirm that it is not possible to connect filter to the updated question anymore (metabase#9299)
       cy.icon("pencil").click();
       cy.findByText(matchingFilterType.name).find(".Icon-gear").click();
-      cy.findByText("No valid fields");
+      cy.findByText(/Add a variable to this question/).should("be.visible");
     });
   });
 
@@ -451,48 +451,6 @@ describe("scenarios > dashboard > parameters", () => {
       "?title=Awesome%20Concrete%20Shoes&category=Widget&vendor=McClure-Lockman",
     );
     cy.findAllByTestId("table-row").should("have.length", 1);
-  });
-
-  it("should show an empty state for native questions without matching parameters", () => {
-    const questionDetails = {
-      name: "SQL",
-      native: {
-        database: SAMPLE_DB_ID,
-        query: "SELECT {{tag}}",
-        "template-tags": {
-          tag: {
-            id: "6b8b10ef-0104-1047-1e1b-2492d5954322",
-            name: "tag",
-            display_name: "tag",
-            type: "text",
-            default: "1",
-          },
-        },
-      },
-    };
-
-    const parameterDetails = {
-      name: "Text contains",
-      slug: "text_contains",
-      id: "1b9cd9f1",
-      type: "string/contains",
-      sectionId: "string",
-    };
-
-    const dashboardDetails = {
-      parameters: [parameterDetails],
-    };
-
-    cy.createNativeQuestionAndDashboard({
-      questionDetails,
-      dashboardDetails,
-    }).then(({ body: { dashboard_id } }) => {
-      visitDashboard(dashboard_id);
-    });
-
-    editDashboard();
-    cy.findByText(parameterDetails.name).click();
-    cy.findByText(/Add a variable to this question/).should("be.visible");
   });
 
   describe("when the user does not have self-service data permissions", () => {


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/25307

How to test:
- Add a sql question with a template tag, e.g. `SELECT {{tag}}` with some default value
- Add this question to a dashboard
- Add a parameter that doesn't match the template tag type, e.g. `Text -> Contains`
- Try to map this parameter to the card
- Make sure there is a new UI for this case

<img width="293" alt="Screenshot 2022-09-09 at 12 49 15" src="https://user-images.githubusercontent.com/8542534/189322875-627c8bad-2c4f-460f-a9a9-3e62b9c7ccf9.png">

