### PR TITLE
Do not save card twice into session storage

### DIFF
--- a/frontend/src/metabase/lib/card.js
+++ b/frontend/src/metabase/lib/card.js
@@ -38,14 +38,13 @@ export async function loadCard(cardId, { dispatch, getState }) {
   }
 }
 
-// TODO Atte Keinänen 5/31/17 Deprecated, we should move tests to Questions.spec.js
-export function serializeCardForUrl(card) {
+function getCleanCard(card) {
   const dataset_query = Utils.copy(card.dataset_query);
   if (dataset_query.query) {
     dataset_query.query = Q_DEPRECATED.cleanQuery(dataset_query.query);
   }
 
-  const cardCopy = {
+  return {
     name: card.name,
     description: card.description,
     dataset_query: dataset_query,
@@ -57,20 +56,21 @@ export function serializeCardForUrl(card) {
     visualization_settings: card.visualization_settings,
     original_card_id: card.original_card_id,
   };
+}
 
-  return utf8_to_b64url(JSON.stringify(cardCopy));
+export function isEqualCard(card1, card2) {
+  if (card1 && card2) {
+    return Utils.equals(getCleanCard(card1), getCleanCard(card2));
+  } else {
+    return false;
+  }
+}
+
+// TODO Atte Keinänen 5/31/17 Deprecated, we should move tests to Questions.spec.js
+export function serializeCardForUrl(card) {
+  return utf8_to_b64url(JSON.stringify(getCleanCard(card)));
 }
 
 export function deserializeCardFromUrl(serialized) {
   return JSON.parse(b64hash_to_utf8(serialized));
-}
-
-export function cleanCopyCard(card) {
-  const cardCopy = {};
-  for (const name in card) {
-    if (name.charAt(0) !== "$") {
-      cardCopy[name] = card[name];
-    }
-  }
-  return cardCopy;
 }

--- a/frontend/src/metabase/query_builder/actions/navigation.js
+++ b/frontend/src/metabase/query_builder/actions/navigation.js
@@ -1,9 +1,12 @@
-import _ from "underscore";
 import { parse as parseUrl } from "url";
 import { createAction } from "redux-actions";
 import { push, replace } from "react-router-redux";
 
-import { cleanCopyCard, serializeCardForUrl } from "metabase/lib/card";
+import {
+  cleanCopyCard,
+  deserializeCardFromUrl,
+  serializeCardForUrl,
+} from "metabase/lib/card";
 import { isAdHocModelQuestion } from "metabase/lib/data-modeling/utils";
 import { createThunkAction } from "metabase/lib/redux";
 import Utils from "metabase/lib/utils";
@@ -15,10 +18,10 @@ import Question from "metabase-lib/lib/Question";
 import {
   getCard,
   getDatasetEditorTab,
-  getZoomedObjectId,
   getOriginalQuestion,
   getQueryBuilderMode,
   getQuestion,
+  getZoomedObjectId,
 } from "../selectors";
 import { getQueryBuilderModeFromLocation } from "../typed-utils";
 import {
@@ -28,7 +31,7 @@ import {
 } from "../utils";
 
 import { initializeQB, setCardAndRun } from "./core";
-import { zoomInRow, resetRowZoom } from "./object-detail";
+import { resetRowZoom, zoomInRow } from "./object-detail";
 import { cancelQuery } from "./querying";
 import { setQueryBuilderMode } from "./ui";
 
@@ -59,11 +62,19 @@ export const popState = createThunkAction(
     }
 
     const card = getCard(getState());
-    if (location.state && location.state.card) {
-      if (!Utils.equals(card, location.state.card)) {
-        const shouldRefreshUrl = location.state.card.dataset;
-        await dispatch(setCardAndRun(location.state.card, shouldRefreshUrl));
-        await dispatch(setCurrentState(location.state));
+    if (location.hash) {
+      const cardFromUrl = deserializeCardFromUrl(location.hash);
+
+      if (!Utils.equals(card, cardFromUrl)) {
+        const newState = {
+          card: cardFromUrl,
+          cardId: cardFromUrl.id,
+          serializedCard: serializeCardForUrl(cardFromUrl),
+          objectId: location.state?.objectId,
+        };
+
+        await dispatch(setCardAndRun(cardFromUrl, cardFromUrl.dataset));
+        await dispatch(setCurrentState(newState));
       }
     }
 
@@ -178,7 +189,7 @@ export const updateUrl = createThunkAction(
         }),
         search: urlParsed.search,
         hash: urlParsed.hash,
-        state: newState,
+        state: objectId !== undefined ? { objectId } : undefined,
       };
 
       const isSameURL =

--- a/frontend/src/metabase/query_builder/actions/navigation.js
+++ b/frontend/src/metabase/query_builder/actions/navigation.js
@@ -189,7 +189,7 @@ export const updateUrl = createThunkAction(
         }),
         search: urlParsed.search,
         hash: urlParsed.hash,
-        state: objectId !== undefined ? { objectId } : undefined,
+        state: { objectId },
       };
 
       const isSameURL =

--- a/frontend/src/metabase/query_builder/actions/navigation.js
+++ b/frontend/src/metabase/query_builder/actions/navigation.js
@@ -2,7 +2,6 @@ import { parse as parseUrl } from "url";
 import { createAction } from "redux-actions";
 import { push, replace } from "react-router-redux";
 
-import { cleanCopyCard } from "metabase/lib/card";
 import { isAdHocModelQuestion } from "metabase/lib/data-modeling/utils";
 import { createThunkAction } from "metabase/lib/redux";
 import Utils from "metabase/lib/utils";
@@ -30,6 +29,7 @@ import { initializeQB, setCardAndRun } from "./core";
 import { zoomInRow, resetRowZoom } from "./object-detail";
 import { cancelQuery } from "./querying";
 import { setQueryBuilderMode } from "./ui";
+import { isEqualCard } from "metabase/lib/card";
 
 export const SET_CURRENT_STATE = "metabase/qb/SET_CURRENT_STATE";
 const setCurrentState = createAction(SET_CURRENT_STATE);
@@ -155,11 +155,9 @@ export const updateUrl = createThunkAction(
         datasetEditorTab = getDatasetEditorTab(getState());
       }
 
-      const copy = cleanCopyCard(card);
-
       const newState = {
-        card: copy,
-        cardId: copy.id,
+        card,
+        cardId: card.id,
         objectId,
       };
 
@@ -184,7 +182,7 @@ export const updateUrl = createThunkAction(
         (locationDescriptor.search || "") === (window.location.search || "") &&
         (locationDescriptor.hash || "") === (window.location.hash || "");
       const isSameCard =
-        currentState && Utils.equals(currentState.card, newState.card);
+        currentState && isEqualCard(currentState.card, newState.card);
       const isSameMode =
         getQueryBuilderModeFromLocation(locationDescriptor).mode ===
         getQueryBuilderModeFromLocation(window.location).mode;

--- a/frontend/src/metabase/query_builder/actions/navigation.js
+++ b/frontend/src/metabase/query_builder/actions/navigation.js
@@ -2,7 +2,7 @@ import { parse as parseUrl } from "url";
 import { createAction } from "redux-actions";
 import { push, replace } from "react-router-redux";
 
-import { cleanCopyCard, serializeCardForUrl } from "metabase/lib/card";
+import { cleanCopyCard } from "metabase/lib/card";
 import { isAdHocModelQuestion } from "metabase/lib/data-modeling/utils";
 import { createThunkAction } from "metabase/lib/redux";
 import Utils from "metabase/lib/utils";
@@ -160,7 +160,6 @@ export const updateUrl = createThunkAction(
       const newState = {
         card: copy,
         cardId: copy.id,
-        serializedCard: serializeCardForUrl(copy),
         objectId,
       };
 
@@ -185,7 +184,7 @@ export const updateUrl = createThunkAction(
         (locationDescriptor.search || "") === (window.location.search || "") &&
         (locationDescriptor.hash || "") === (window.location.hash || "");
       const isSameCard =
-        currentState && currentState.serializedCard === newState.serializedCard;
+        currentState && Utils.equals(currentState.card, newState.card);
       const isSameMode =
         getQueryBuilderModeFromLocation(locationDescriptor).mode ===
         getQueryBuilderModeFromLocation(window.location).mode;

--- a/frontend/src/metabase/query_builder/utils.js
+++ b/frontend/src/metabase/query_builder/utils.js
@@ -1,5 +1,6 @@
 import querystring from "querystring";
 import * as Urls from "metabase/lib/urls";
+import { serializeCardForUrl } from "metabase/lib/card";
 
 export function getPathNameFromQueryBuilderMode({
   pathname,
@@ -23,14 +24,9 @@ export function getCurrentQueryParams() {
   return querystring.parse(search);
 }
 
-export function getURLForCardState(
-  { card, serializedCard },
-  dirty,
-  query = {},
-  objectId,
-) {
+export function getURLForCardState({ card }, dirty, query = {}, objectId) {
   const options = {
-    hash: serializedCard && dirty ? serializedCard : "",
+    hash: card && dirty ? serializeCardForUrl(card) : "",
     query,
   };
   const isAdHocQuestion = !card.id;


### PR DESCRIPTION
Related https://github.com/metabase/metabase/issues/25312

Currently both card and its url-encoded version are saved into sessionStorage. As a quick fix, lets save only card and url-encode it when needed, making it use 2x less sessionStorage.

How to test:
- Make sure that navigation via browser back and forward buttons work in the same way it does now