### PR TITLE
Don't show an error page opening the variables sidebar if the user doesn't have permissions to the referenced card

### DIFF
--- a/frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx
@@ -130,6 +130,7 @@ class CardTagEditor extends Component {
 export default Questions.load({
   id: (state, { tag }) => tag["card-id"],
   loadingAndErrorWrapper: false,
+  dispatchApiErrorEvent: false,
 })(CardTagEditor);
 
 // This formats a timestamp as a date using any custom formatting options.


### PR DESCRIPTION
This PR fixes a small bug with permissions and referenced questions.

### The bug:

Under this scenario:

- User A has edit access to collection C and view access to model M
- User B has edit access to collection C and no access to model M
- If User A created a question in C using M
- Then User B edits that question in C

If User B opens the sidebar, an error page appears, because the variable sidebar component, CardTagEditor, tries to load a question the user doesn't have access to.

<img width="921" alt="image" src="https://user-images.githubusercontent.com/39073188/189409622-76c0e68e-4185-40b4-b03e-06e2a3c2c84a.png">

![image](https://user-images.githubusercontent.com/39073188/189409553-58d71d22-2b9d-4064-a11a-1867222f3e54.png)

### How this PR fixes the bug:

We set the `dispatchApiErrorEvent: true` option on an entity object loader, which means that the error page is never set [here](https://github.com/metabase/metabase/blob/c8ca6b0335e2536cea965a23f3aa7403ae12fad5/frontend/src/metabase/app-main.js#L46).