### PR TITLE
Add support for Google Cloud SQL proxy connections

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -29,6 +29,8 @@
                                                            org.slf4j/slf4j-api]}
   com.draines/postal                        {:mvn/version "2.0.5"}              ; SMTP library
   com.google.guava/guava                    {:mvn/version "31.0.1-jre"}         ; dep for BigQuery, Spark, and GA. Require here rather than letting different dep versions stomp on each other — see comments on #9697
+  com.google.cloud.sql/postgres-socket-factory
+                                            {:mvn/version "1.6.3"}              ; Support for Google Cloud SQL private sql proxy connections in connection string.
   com.fasterxml.jackson.core/jackson-databind
                                             {:mvn/version "2.13.2.2"}           ; JSON processor used by snowplow-java-tracker (pinned version due to CVE-2020-36518)
   com.h2database/h2                         {:mvn/version "1.4.197"}            ; embedded SQL database


### PR DESCRIPTION
This PR adds support for creating private secure connections to Google CloudSQL instances using the google sql proxy. Currently the connection string required for this is not accepted by metabase.
See for more details: https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory/blob/main/docs/jdbc-postgres.md