### PR TITLE
Support starting Metabase without starting Quartz scheduler

### DIFF
--- a/src/metabase/task.clj
+++ b/src/metabase/task.clj
@@ -11,17 +11,20 @@
   ## Quartz JavaDoc
 
   Find the JavaDoc for Quartz here: http://www.quartz-scheduler.org/api/2.3.0/index.html"
-  (:require [clojure.java.jdbc :as jdbc]
-            [clojure.string :as str]
-            [clojure.tools.logging :as log]
-            [clojurewerkz.quartzite.scheduler :as qs]
-            [metabase.db :as mdb]
-            [metabase.plugins.classloader :as classloader]
-            [metabase.util :as u]
-            [metabase.util.i18n :refer [trs]]
-            [schema.core :as s]
-            [toucan.db :as db])
-  (:import [org.quartz CronTrigger JobDetail JobKey Scheduler Trigger TriggerKey]))
+  (:require
+   [clojure.java.jdbc :as jdbc]
+   [clojure.string :as str]
+   [clojure.tools.logging :as log]
+   [clojurewerkz.quartzite.scheduler :as qs]
+   [environ.core :as env]
+   [metabase.db :as mdb]
+   [metabase.plugins.classloader :as classloader]
+   [metabase.util :as u]
+   [metabase.util.i18n :refer [trs]]
+   [schema.core :as s]
+   [toucan.db :as db])
+  (:import
+   (org.quartz CronTrigger JobDetail JobKey Scheduler Trigger TriggerKey)))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                               SCHEDULER INSTANCE                                               |
@@ -31,17 +34,23 @@
   "Override the global Quartz scheduler by binding this var."
   nil)
 
-(defonce ^:private quartz-scheduler
-  (atom nil))
+;;; seriously, don't use this directly. Use [[scheduler]] to get it, or [[set-scheduler!]] to change it. If you use it
+;;; directly it breaks our ability to mock it in tests using [[*quartz-scheduler*]]
+(defonce ^:private -global-scheduler-do-not-access-directly (atom nil))
 
-;; TODO - maybe we should make this a delay instead!
 (defn- scheduler
   "Fetch the instance of our Quartz scheduler. Call this function rather than dereffing the atom directly because there
   are a few places (e.g., in tests) where we swap the instance out."
   ;; TODO - why can't we just swap the atom out in the tests?
   ^Scheduler []
   (or *quartz-scheduler*
-      @quartz-scheduler))
+      @-global-scheduler-do-not-access-directly))
+
+(defn- set-scheduler! [new-scheduler]
+  (let [[old-scheduler] (reset-vals! -global-scheduler-do-not-access-directly new-scheduler)]
+    (when old-scheduler
+      (qs/shutdown old-scheduler))
+    new-scheduler))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -151,30 +160,36 @@
   standby mode. Call [[start-scheduler!]] to begin running scheduled tasks."
   []
   (classloader/the-classloader)
-  (when-not @quartz-scheduler
-    (set-jdbc-backend-properties!)
-    (let [new-scheduler (qs/initialize)]
-      (when (compare-and-set! quartz-scheduler nil new-scheduler)
-        (find-and-load-task-namespaces!)
-        (qs/standby new-scheduler)
-        (log/info (trs "Task scheduler initialized into standby mode."))
-        (init-tasks!)))))
+  (when-not (scheduler)
+    (locking init-scheduler!
+      (when-not (scheduler)
+        (set-jdbc-backend-properties!)
+        (let [new-scheduler (qs/initialize)]
+          (set-scheduler! new-scheduler)
+          (find-and-load-task-namespaces!)
+          (qs/standby new-scheduler)
+          (log/info (trs "Task scheduler initialized into standby mode."))
+          (init-tasks!))))))
+
+;;; this is a function mostly to facilitate testing.
+(defn- disable-scheduler? []
+  (some-> (env/env :mb-disable-scheduler) Boolean/parseBoolean))
 
 (defn start-scheduler!
   "Start an initialized scheduler. Tasks do not run before calling this function. It is an error to call this function
   when [[quartz-scheduler]] has not been set. The function [[init-scheduler!]] will initialize this correctly."
   []
-  (if-let [scheduler @quartz-scheduler]
-    (do (qs/start scheduler)
-        (log/info (trs "Task scheduler started")))
-    (throw (trs "Scheduler not initialized but `start-scheduler!` called. Please call `init-scheduler!` before attempting to start."))))
+  (if (disable-scheduler?)
+    (log/warn (trs "Metabase task scheduler disabled. Scheduled tasks will not be ran."))
+    (if-let [scheduler (scheduler)]
+      (do (qs/start scheduler)
+          (log/info (trs "Task scheduler started")))
+      (throw (trs "Scheduler not initialized but `start-scheduler!` called. Please call `init-scheduler!` before attempting to start.")))))
 
 (defn stop-scheduler!
   "Stop our Quartzite scheduler and shutdown any running executions."
   []
-  (let [[old-scheduler] (reset-vals! quartz-scheduler nil)]
-    (when old-scheduler
-      (qs/shutdown old-scheduler))))
+  (set-scheduler! nil))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/src/metabase/task.clj
+++ b/src/metabase/task.clj
@@ -11,18 +11,17 @@
   ## Quartz JavaDoc
 
   Find the JavaDoc for Quartz here: http://www.quartz-scheduler.org/api/2.3.0/index.html"
-  (:require
-   [clojure.java.jdbc :as jdbc]
-   [clojure.string :as str]
-   [clojure.tools.logging :as log]
-   [clojurewerkz.quartzite.scheduler :as qs]
-   [environ.core :as env]
-   [metabase.db :as mdb]
-   [metabase.plugins.classloader :as classloader]
-   [metabase.util :as u]
-   [metabase.util.i18n :refer [trs]]
-   [schema.core :as s]
-   [toucan.db :as db])
+  (:require [clojure.java.jdbc :as jdbc]
+            [clojure.string :as str]
+            [clojure.tools.logging :as log]
+            [clojurewerkz.quartzite.scheduler :as qs]
+            [environ.core :as env]
+            [metabase.db :as mdb]
+            [metabase.plugins.classloader :as classloader]
+            [metabase.util :as u]
+            [metabase.util.i18n :refer [trs]]
+            [schema.core :as s]
+            [toucan.db :as db])
   (:import
    (org.quartz CronTrigger JobDetail JobKey Scheduler Trigger TriggerKey)))
 
@@ -32,25 +31,12 @@
 
 (def ^:dynamic *quartz-scheduler*
   "Override the global Quartz scheduler by binding this var."
-  nil)
-
-;;; seriously, don't use this directly. Use [[scheduler]] to get it, or [[set-scheduler!]] to change it. If you use it
-;;; directly it breaks our ability to mock it in tests using [[*quartz-scheduler*]]
-(defonce ^:private -global-scheduler-do-not-access-directly (atom nil))
+  (atom nil))
 
 (defn- scheduler
-  "Fetch the instance of our Quartz scheduler. Call this function rather than dereffing the atom directly because there
-  are a few places (e.g., in tests) where we swap the instance out."
-  ;; TODO - why can't we just swap the atom out in the tests?
+  "Fetch the instance of our Quartz scheduler."
   ^Scheduler []
-  (or *quartz-scheduler*
-      @-global-scheduler-do-not-access-directly))
-
-(defn- set-scheduler! [new-scheduler]
-  (let [[old-scheduler] (reset-vals! -global-scheduler-do-not-access-directly new-scheduler)]
-    (when old-scheduler
-      (qs/shutdown old-scheduler))
-    new-scheduler))
+  @*quartz-scheduler*)
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -155,29 +141,13 @@
   (when (= (mdb/db-type) :postgres)
     (System/setProperty "org.quartz.jobStore.driverDelegateClass" "org.quartz.impl.jdbcjobstore.PostgreSQLDelegate")))
 
-(defn init-scheduler!
-  "Initialize our Quartzite scheduler which allows jobs to be submitted and triggers to scheduled. Puts scheduler in
-  standby mode. Call [[start-scheduler!]] to begin running scheduled tasks."
-  []
-  (classloader/the-classloader)
-  (when-not (scheduler)
-    (locking init-scheduler!
-      (when-not (scheduler)
-        (set-jdbc-backend-properties!)
-        (let [new-scheduler (qs/initialize)]
-          (set-scheduler! new-scheduler)
-          (find-and-load-task-namespaces!)
-          (qs/standby new-scheduler)
-          (log/info (trs "Task scheduler initialized into standby mode."))
-          (init-tasks!))))))
-
 ;;; this is a function mostly to facilitate testing.
 (defn- disable-scheduler? []
   (some-> (env/env :mb-disable-scheduler) Boolean/parseBoolean))
 
 (defn start-scheduler!
   "Start an initialized scheduler. Tasks do not run before calling this function. It is an error to call this function
-  when [[quartz-scheduler]] has not been set. The function [[init-scheduler!]] will initialize this correctly."
+  when [[*quartz-scheduler*]] has not been set. The function [[init-scheduler!]] will initialize this correctly."
   []
   (if (disable-scheduler?)
     (log/warn (trs "Metabase task scheduler disabled. Scheduled tasks will not be ran."))
@@ -189,7 +159,9 @@
 (defn stop-scheduler!
   "Stop our Quartzite scheduler and shutdown any running executions."
   []
-  (set-scheduler! nil))
+  (let [[old-scheduler] (reset-vals! *quartz-scheduler* nil)]
+    (when old-scheduler
+      (qs/shutdown old-scheduler))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/src/metabase/task.clj
+++ b/src/metabase/task.clj
@@ -29,8 +29,8 @@
 ;;; |                                               SCHEDULER INSTANCE                                               |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-(def ^:dynamic *quartz-scheduler*
-  "Override the global Quartz scheduler by binding this var."
+(defonce ^:dynamic ^{:doc "Override the global Quartz scheduler by binding this var."}
+  *quartz-scheduler*
   (atom nil))
 
 (defn- scheduler

--- a/test/metabase/task_test.clj
+++ b/test/metabase/task_test.clj
@@ -103,14 +103,14 @@
   (tu/do-with-unstarted-temp-scheduler
    (^:once fn* []
     (testing (format "task/start-scheduler! should no-op When MB_DISABLE_SCHEDULER is set")
-      (println "<HERE 3>")
       (testing "Sanity check"
         (is (identical? (#'task/scheduler) task/*quartz-scheduler*))
         (is (not (qs/started? (#'task/scheduler)))))
-      (println "<HERE 4>")
       (mt/with-temp-env-var-value ["MB_DISABLE_SCHEDULER" "TRUE"]
         (task/start-scheduler!)
         (is (not (qs/started? (#'task/scheduler)))))
+      (testing "Should still be able to 'schedule' tasks even if scheduler is unstarted"
+        (is (some? (task/schedule-task! (job) (trigger-1)))))
       (mt/with-temp-env-var-value ["MB_DISABLE_SCHEDULER" "FALSE"]
         (task/start-scheduler!)
         (is (qs/started? (#'task/scheduler))))))))

--- a/test/metabase/task_test.clj
+++ b/test/metabase/task_test.clj
@@ -1,16 +1,15 @@
 (ns metabase.task-test
-  (:require
-   [clojure.test :refer :all]
-   [clojurewerkz.quartzite.jobs :as jobs]
-   [clojurewerkz.quartzite.schedule.cron :as cron]
-   [clojurewerkz.quartzite.scheduler :as qs]
-   [clojurewerkz.quartzite.triggers :as triggers]
-   [metabase.task :as task]
-   [metabase.test :as mt]
-   [metabase.test.fixtures :as fixtures]
-   [metabase.test.util :as tu]
-   [metabase.util.schema :as su]
-   [schema.core :as s])
+  (:require [clojure.test :refer :all]
+            [clojurewerkz.quartzite.jobs :as jobs]
+            [clojurewerkz.quartzite.schedule.cron :as cron]
+            [clojurewerkz.quartzite.scheduler :as qs]
+            [clojurewerkz.quartzite.triggers :as triggers]
+            [metabase.task :as task]
+            [metabase.test :as mt]
+            [metabase.test.fixtures :as fixtures]
+            [metabase.test.util :as tu]
+            [metabase.util.schema :as su]
+            [schema.core :as s])
   (:import
    (org.quartz CronTrigger JobDetail)))
 
@@ -104,7 +103,6 @@
    (^:once fn* []
     (testing (format "task/start-scheduler! should no-op When MB_DISABLE_SCHEDULER is set")
       (testing "Sanity check"
-        (is (identical? (#'task/scheduler) task/*quartz-scheduler*))
         (is (not (qs/started? (#'task/scheduler)))))
       (mt/with-temp-env-var-value ["MB_DISABLE_SCHEDULER" "TRUE"]
         (task/start-scheduler!)

--- a/test/metabase/test.clj
+++ b/test/metabase/test.clj
@@ -204,7 +204,6 @@
   with-model-cleanup
   with-non-admin-groups-no-root-collection-for-namespace-perms
   with-non-admin-groups-no-root-collection-perms
-  with-scheduler
   with-temp-env-var-value
   with-temp-file
   with-temp-scheduler

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -615,10 +615,10 @@
 
 (defn do-with-unstarted-temp-scheduler [thunk]
   (let [temp-scheduler (in-memory-scheduler)
-        already-bound? (identical? task/*quartz-scheduler* temp-scheduler)]
+        already-bound? (identical? @task/*quartz-scheduler* temp-scheduler)]
     (if already-bound?
       (thunk)
-      (binding [task/*quartz-scheduler* temp-scheduler]
+      (binding [task/*quartz-scheduler* (atom temp-scheduler)]
         (try
           (assert (not (qs/started? temp-scheduler))
                   "temp in-memory scheduler already started: did you use it elsewhere without shutting it down?")
@@ -632,7 +632,7 @@
   (initialize/initialize-if-needed! :db)
   (do-with-unstarted-temp-scheduler
    (^:once fn* []
-    (qs/start task/*quartz-scheduler*)
+    (qs/start @task/*quartz-scheduler*)
     (thunk))))
 
 (defmacro with-temp-scheduler

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -36,11 +36,13 @@
             [toucan.db :as db]
             [toucan.models :as models]
             [toucan.util.test :as tt])
-  (:import [java.io File FileInputStream]
-           java.net.ServerSocket
-           java.util.concurrent.TimeoutException
-           java.util.Locale
-           [org.quartz CronTrigger JobDetail JobKey Scheduler Trigger]))
+  (:import
+   (java.io File FileInputStream)
+   (java.net ServerSocket)
+   (java.util Locale)
+   (java.util.concurrent TimeoutException)
+   (org.quartz CronTrigger JobDetail JobKey Scheduler Trigger)
+   (org.quartz.impl StdSchedulerFactory)))
 
 (comment tu.log/keep-me
          test-runner.assert-exprs/keep-me)
@@ -600,28 +602,38 @@
 ;; Various functions for letting us check that things get scheduled properly. Use these to put a temporary scheduler
 ;; in place and then check the tasks that get scheduled
 
-(defn do-with-scheduler [scheduler thunk]
-  (binding [task/*quartz-scheduler* scheduler]
-    (thunk)))
+(defn- in-memory-scheduler
+  "An in-memory Quartz Scheduler separate from the usual database-backend one we normally use. Every time you call this
+  it returns the same scheduler! So make sure you shut it down when you're done using it."
+  ^org.quartz.impl.StdScheduler []
+  (.getScheduler
+   (StdSchedulerFactory.
+    (doto (java.util.Properties.)
+      (.setProperty StdSchedulerFactory/PROP_SCHED_INSTANCE_NAME (str `in-memory-scheduler))
+      (.setProperty StdSchedulerFactory/PROP_JOB_STORE_CLASS (.getCanonicalName org.quartz.simpl.RAMJobStore))
+      (.setProperty (str StdSchedulerFactory/PROP_THREAD_POOL_PREFIX ".threadCount") "1")))))
 
-(defmacro with-scheduler
-  "Temporarily bind the Metabase Quartzite scheduler to `scheulder` and run `body`."
-  {:style/indent 1}
-  [scheduler & body]
-  `(do-with-scheduler ~scheduler (fn [] ~@body)))
-
-(defn do-with-temp-scheduler [f]
-  (classloader/the-classloader)
-  (initialize/initialize-if-needed! :db)
-  (let [temp-scheduler        (qs/start (qs/initialize))
-        is-default-scheduler? (identical? temp-scheduler (#'metabase.task/scheduler))]
-    (if is-default-scheduler?
-      (f)
-      (with-scheduler temp-scheduler
+(defn do-with-unstarted-temp-scheduler [thunk]
+  (let [temp-scheduler (in-memory-scheduler)
+        already-bound? (identical? task/*quartz-scheduler* temp-scheduler)]
+    (if already-bound?
+      (thunk)
+      (binding [task/*quartz-scheduler* temp-scheduler]
         (try
-          (f)
+          (assert (not (qs/started? temp-scheduler))
+                  "temp in-memory scheduler already started: did you use it elsewhere without shutting it down?")
+          (thunk)
           (finally
             (qs/shutdown temp-scheduler)))))))
+
+(defn do-with-temp-scheduler [thunk]
+  ;; not 100% sure we need to initialize the DB anymore since the temp scheduler is in-memory-only now.
+  (classloader/the-classloader)
+  (initialize/initialize-if-needed! :db)
+  (do-with-temp-scheduler
+   (^:once fn* []
+    (qs/start task/*quartz-scheduler*)
+    (thunk))))
 
 (defmacro with-temp-scheduler
   "Execute `body` with a temporary scheduler in place.

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -630,7 +630,7 @@
   ;; not 100% sure we need to initialize the DB anymore since the temp scheduler is in-memory-only now.
   (classloader/the-classloader)
   (initialize/initialize-if-needed! :db)
-  (do-with-temp-scheduler
+  (do-with-unstarted-temp-scheduler
    (^:once fn* []
     (qs/start task/*quartz-scheduler*)
     (thunk))))


### PR DESCRIPTION
As requested by @luizarakaki 

I think the main use case here is to disable sync locally and things like that for testing things -- we might be able to remove this in the future once we add more fine-grained sync controls to facilitate the new serialization stuff.

While writing tests I realized our `with-temp-scheduler` stuff **actually** used the same database-backed scheduler as everything else, which wasn't my intention when writing it. So I overhauled that a bit so it **actually** uses a different scheduler. This should fix some wonkiness in tests that I'm sure is in there somewhere.

I also tweaked things a bit to unify the atom that stores the Quartz task scheduler and the dynamic variable we use to override it in tests -- this should fix a few places where we were accessing the atom directly which means test mocking would not affect them