### PR TITLE
Add a description for slack channel form field

### DIFF
--- a/frontend/src/metabase/admin/settings/slack/components/SlackStatusForm/SlackStatusForm.tsx
+++ b/frontend/src/metabase/admin/settings/slack/components/SlackStatusForm/SlackStatusForm.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useMemo } from "react";
+import { t } from "ttag";
 import Form from "metabase/containers/FormikForm";
 import { SlackSettings } from "metabase-types/api";
 import { getSlackForm } from "../../forms";
@@ -21,7 +22,10 @@ const SlackStatusForm = ({ settings }: SlackStatusFormProps): JSX.Element => {
       {({ Form, FormField }: FormProps) => (
         <Form>
           <FormField name="slack-app-token" />
-          <FormField name="slack-files-channel" />
+          <FormField
+            name="slack-files-channel"
+            description={t`We'll upload charts and tables here before sending out dashboard subscriptions.`}
+          />
         </Form>
       )}
     </Form>

--- a/frontend/src/metabase/admin/settings/slack/components/SlackStatusForm/types.ts
+++ b/frontend/src/metabase/admin/settings/slack/components/SlackStatusForm/types.ts
@@ -7,4 +7,5 @@ export interface FormProps {
 
 export interface FormFieldProps {
   name: string;
+  description?: string;
 }


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/20936

Since we want to backport the fix, our options here are limited and we can only use an existing message.

How to test:
- Go to Admin -> Settings -> Slack and complete setup
- Make sure there is this description for the slack channel form field after setup

<img width="690" alt="Screenshot 2022-09-12 at 14 15 39" src="https://user-images.githubusercontent.com/8542534/189640408-bb6849bb-77d1-4b94-8277-6a553f348bd2.png">
