### PR TITLE
docs - fix links

### DIFF
--- a/docs/configuring-metabase/appearance.md
+++ b/docs/configuring-metabase/appearance.md
@@ -79,6 +79,6 @@ Show the Metabase lighthouse image on the home and login pages.
 
 ## Further reading
 
-- [Customer-facing analytics](https://www.metabase.com/learn/embedding/).
+- [Customer-facing analytics](https://www.metabase.com/learn/customer-facing-analytics).
 - [Embedding introduction](../embedding/start.md).
 - [Brand your Metabase](https://www.metabase.com/learn/embedding/brand).

--- a/docs/configuring-metabase/fonts.md
+++ b/docs/configuring-metabase/fonts.md
@@ -127,5 +127,5 @@ In addition to the [included fonts](#included-fonts), if you set a custom font f
 ## Further reading
 
 - [Customizing Metabase's appearance](./appearance.md)
-- [Customer-facing analytics](https://www.metabase.com/learn/embedding/)
+- [Customer-facing analytics](https://www.metabase.com/learn/customer-facing-analytics)
 - [Embedding documentation](../embedding/start.md)

--- a/docs/troubleshooting-guide/my-dashboard-is-slow.md
+++ b/docs/troubleshooting-guide/my-dashboard-is-slow.md
@@ -117,12 +117,6 @@ Similarly, you probably don't need indexes for simple tables with a few tens of 
 2. Check the performance logs for the server where Metabase is running.
 3. If either is a bottleneck, upgrade to a more powerful server or one with more memory.
 
-## Does Metabase appear to freeze when you save a question that has not yet been run?
-
-**Root cause:** If you save a question that has never been executed, Metabase runs the question while saving it, which can make the UI look frozen.
-
-**Steps to take:** This is a bug, and we're working to fix it. Until we fix it, the workaround is to run the question before saving it. However, it's very likely that the root cause is one of the more common problems described above.
-
 [admin-caching]: ../configuring-metabase/caching.md
 [bi-best-practices]: https://www.metabase.com/learn/dashboards/bi-dashboard-best-practices
 [bugs]: ./bugs.md

--- a/docs/troubleshooting-guide/my-dashboard-is-slow.md
+++ b/docs/troubleshooting-guide/my-dashboard-is-slow.md
@@ -121,7 +121,7 @@ Similarly, you probably don't need indexes for simple tables with a few tens of 
 
 **Root cause:** If you save a question that has never been executed, Metabase runs the question while saving it, which can make the UI look frozen.
 
-**Steps to take:** This is [a bug][freeze-bug] and we are working to fix it. Until it's corrected, the workaround is to run the question before saving it. However, it's very likely that the root cause is one of the more common problems described above.
+**Steps to take:** This is a bug, and we're working to fix it. Until we fix it, the workaround is to run the question before saving it. However, it's very likely that the root cause is one of the more common problems described above.
 
 [admin-caching]: ../configuring-metabase/caching.md
 [bi-best-practices]: https://www.metabase.com/learn/dashboards/bi-dashboard-best-practices
@@ -131,6 +131,5 @@ Similarly, you probably don't need indexes for simple tables with a few tens of 
 [dbeaver]: https://dbeaver.io/
 [embedding]: https://www.metabase.com/learn/embedding/embedding-charts-and-dashboards
 [faster-dashboards]: https://www.metabase.com/learn/administration/making-dashboards-faster
-[freeze-bug]: https://github.com/metabase/metabase/issues/14957
 [metabase-at-scale]: https://www.metabase.com/learn/administration/metabase-at-scale
 [organizing-sql]: https://www.metabase.com/learn/sql-questions/organizing-sql


### PR DESCRIPTION
- Updates links to reflect new Learn track.
- Deletes a broken link to a GitHub issue. The link isn't necessary, and shouldn't block this PR, but @nllho: do you know which issue we could link to here?