### PR TITLE
Static viz polish fixes improvements

### DIFF
--- a/frontend/src/metabase/static-viz/lib/numbers.unit.spec.js
+++ b/frontend/src/metabase/static-viz/lib/numbers.unit.spec.js
@@ -99,6 +99,13 @@ describe("formatNumber", () => {
 
     expect(text).toEqual("10000.11");
   });
+
+  it("should format small number", () => {
+    expect(formatNumber(0.00196)).toEqual("0.002");
+    expect(formatNumber(0.00201)).toEqual("0.002");
+    expect(formatNumber(-0.00119)).toEqual("-0.0012");
+    expect(formatNumber(-0.00191)).toEqual("-0.0019");
+  });
 });
 
 describe("formatPercent", () => {


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/24759

Fixes
- [x] Small numbers (between 0 and 0.001) were rendered as 0 making the chart labels useless. [Slack thread reference](https://metaboat.slack.com/archives/C03SD8HDJLC/p1662739312347619) 
    ![image](https://user-images.githubusercontent.com/1937582/189693790-9c095e11-847e-4eb8-8c0a-15a7cef67f89.png)
- [x] Fix multiple bar charts values overlapping (hide it using the same logic as the app viz)
    ![image](https://user-images.githubusercontent.com/1937582/189693919-d3792f06-1b6b-4cfb-8692-f2ed8e24ddcd.png)
