### PR TITLE
Implement navigation between data app pages

### DIFF
--- a/frontend/src/metabase-types/api/click-behavior.ts
+++ b/frontend/src/metabase-types/api/click-behavior.ts
@@ -39,7 +39,7 @@ export interface CrossFilterClickBehavior {
 
 export interface EntityCustomDestinationClickBehavior {
   type: "link";
-  linkType: "dashboard" | "question";
+  linkType: "dashboard" | "question" | "page";
   targetId: EntityId;
   parameterMapping?: ClickBehaviorParameterMapping;
 }

--- a/frontend/src/metabase-types/api/click-behavior.ts
+++ b/frontend/src/metabase-types/api/click-behavior.ts
@@ -27,9 +27,13 @@ export type ClickBehaviorType =
   | "crossfilter"
   | "link";
 
-export type CustomDestinationClickBehaviorLinkType =
+export type CustomDestinationClickBehaviorEntity =
   | "dashboard"
   | "question"
+  | "page";
+
+export type CustomDestinationClickBehaviorLinkType =
+  | CustomDestinationClickBehaviorEntity
   | "url";
 
 export interface CrossFilterClickBehavior {
@@ -39,7 +43,7 @@ export interface CrossFilterClickBehavior {
 
 export interface EntityCustomDestinationClickBehavior {
   type: "link";
-  linkType: "dashboard" | "question" | "page";
+  linkType: CustomDestinationClickBehaviorEntity;
   targetId: EntityId;
   parameterMapping?: ClickBehaviorParameterMapping;
 }

--- a/frontend/src/metabase/containers/DataAppPagePicker.jsx
+++ b/frontend/src/metabase/containers/DataAppPagePicker.jsx
@@ -1,0 +1,20 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+import ItemPicker from "./ItemPicker";
+
+const DataAppPagePicker = ({ value, onChange, ...props }) => (
+  <ItemPicker
+    {...props}
+    value={value === undefined ? undefined : { model: "page", id: value }}
+    onChange={page => onChange(page ? page.id : undefined)}
+    models={["page"]}
+  />
+);
+
+DataAppPagePicker.propTypes = {
+  value: PropTypes.number,
+  onChange: PropTypes.func.isRequired,
+};
+
+export default DataAppPagePicker;

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkOptions.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkOptions.tsx
@@ -34,6 +34,7 @@ function LinkTypeOptions({
   const linkTypeOptions: LinkTypeOption[] = [
     { type: "dashboard", icon: "dashboard", name: t`Dashboard` },
     { type: "question", icon: "bar", name: t`Saved question` },
+    { type: "page", icon: "document", name: t`Page` },
     { type: "url", icon: "link", name: t`URL` },
   ];
   return (

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkOptions.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkOptions.tsx
@@ -4,7 +4,7 @@ import { t } from "ttag";
 import { isTableDisplay } from "metabase/lib/click-behavior";
 
 import CustomLinkText from "./CustomLinkText";
-import QuestionDashboardPicker from "./QuestionDashboardPicker";
+import LinkedEntityPicker from "./LinkedEntityPicker";
 import { SidebarContent } from "../ClickBehaviorSidebar.styled";
 
 import type { UiParameter } from "metabase/parameters/types";
@@ -88,7 +88,7 @@ function LinkOptions({
       <div className="mt1">
         {hasSelectedLinkType && clickBehavior.linkType !== "url" && (
           <div>
-            <QuestionDashboardPicker
+            <LinkedEntityPicker
               dashcard={dashcard}
               clickBehavior={clickBehavior}
               updateSettings={updateSettings}

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkedEntityPicker.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkedEntityPicker.tsx
@@ -122,8 +122,7 @@ function LinkedEntityPicker({
       const nextSettings = { ...clickBehavior, targetId };
       const isNewTargetEntity = targetId !== clickBehavior.targetId;
       if (isNewTargetEntity) {
-        // For new target question/dashboard,
-        // parameter mappings for the previous link target question/dashboard
+        // For new target entity, parameter mappings for the previous link target
         // don't make sense and have to be reset
         nextSettings.parameterMapping = {};
       }

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkedEntityPicker.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkedEntityPicker.tsx
@@ -49,7 +49,7 @@ function PickerControl({
     if (hasSelectedTarget) {
       return <Entity.Name id={clickBehavior.targetId} />;
     }
-    return isDash ? t`Pick a dashboard...` : t`Pick a question...`;
+    return isDash ? t`Pick a dashboard…` : t`Pick a question…`;
   }, [Entity, isDash, clickBehavior]);
 
   return (

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkedEntityPicker.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkedEntityPicker.tsx
@@ -104,7 +104,7 @@ function TargetClickMappings({
   );
 }
 
-function QuestionDashboardPicker({
+function LinkedEntityPicker({
   dashcard,
   clickBehavior,
   updateSettings,
@@ -189,4 +189,4 @@ function QuestionDashboardPicker({
   );
 }
 
-export default QuestionDashboardPicker;
+export default LinkedEntityPicker;

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkedEntityPicker.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkedEntityPicker.tsx
@@ -35,59 +35,29 @@ import {
   SelectedEntityPickerContent,
 } from "./LinkOptions.styled";
 
-function getEntityForLinkTarget(
-  linkType: CustomDestinationClickBehaviorEntity,
-) {
-  if (linkType === "question") {
-    return Questions;
-  }
-  if (linkType === "dashboard" || linkType === "page") {
-    return Dashboards;
-  }
-}
-
-function getPickerComponentForLinkTarget(
-  linkType: CustomDestinationClickBehaviorEntity,
-) {
-  if (linkType === "question") {
-    return QuestionPicker;
-  }
-  if (linkType === "dashboard") {
-    return DashboardPicker;
-  }
-  if (linkType === "page") {
-    return DataAppPagePicker;
-  }
-}
-
-function getPickerIconForLinkTarget(
-  linkType: CustomDestinationClickBehaviorEntity,
-) {
-  if (linkType === "question") {
-    return "bar";
-  }
-  if (linkType === "dashboard") {
-    return "dashboard";
-  }
-  if (linkType === "page") {
-    return "document";
-  }
-  return "unknown";
-}
-
-function getPickerModalTitleForLinkTarget(
-  linkType: CustomDestinationClickBehaviorEntity,
-) {
-  if (linkType === "question") {
-    return t`Pick a question to link to`;
-  }
-  if (linkType === "dashboard") {
-    return t`Pick a dashboard to link to`;
-  }
-  if (linkType === "page") {
-    return t`Pick a page to link to`;
-  }
-}
+const LINK_TARGETS = {
+  question: {
+    Entity: Questions,
+    PickerComponent: QuestionPicker,
+    pickerIcon: "bar",
+    getModalTitle: () => t`Pick a question to link to`,
+    getPickerButtonLabel: () => t`Pick a question…`,
+  },
+  dashboard: {
+    Entity: Dashboards,
+    PickerComponent: DashboardPicker,
+    pickerIcon: "dashboard",
+    getModalTitle: () => t`Pick a dashboard to link to`,
+    getPickerButtonLabel: () => t`Pick a dashboard…`,
+  },
+  page: {
+    Entity: Dashboards,
+    PickerComponent: DataAppPagePicker,
+    pickerIcon: "document",
+    getModalTitle: () => t`Pick a page to link to`,
+    getPickerButtonLabel: () => t`Pick a page…`,
+  },
+};
 
 function PickerControl({
   clickBehavior,
@@ -96,30 +66,21 @@ function PickerControl({
   clickBehavior: EntityCustomDestinationClickBehavior;
   onCancel: () => void;
 }) {
-  const Entity = getEntityForLinkTarget(clickBehavior.linkType);
+  const { Entity, pickerIcon, getPickerButtonLabel } =
+    LINK_TARGETS[clickBehavior.linkType];
 
   const renderLabel = useCallback(() => {
     const hasSelectedTarget = clickBehavior.targetId != null;
     if (hasSelectedTarget) {
       return <Entity.Name id={clickBehavior.targetId} />;
     }
-    if (clickBehavior.linkType === "question") {
-      return t`Pick a question…`;
-    }
-    if (clickBehavior.linkType === "dashboard") {
-      return t`Pick a dashboard`;
-    }
-    if (clickBehavior.linkType === "page") {
-      return t`Pick a page`;
-    }
-  }, [Entity, clickBehavior]);
+    return getPickerButtonLabel();
+  }, [Entity, clickBehavior.targetId, getPickerButtonLabel]);
 
   return (
     <SidebarItem.Selectable isSelected padded={false}>
       <LinkTargetEntityPickerContent>
-        <SelectedEntityPickerIcon
-          name={getPickerIconForLinkTarget(clickBehavior.linkType)}
-        />
+        <SelectedEntityPickerIcon name={pickerIcon} />
         <SelectedEntityPickerContent>
           {renderLabel()}
           <Icon name="chevrondown" size={12} className="ml-auto" />
@@ -179,7 +140,7 @@ function LinkedEntityPicker({
 }) {
   const { linkType } = clickBehavior;
   const hasSelectedTarget = clickBehavior.targetId != null;
-  const Picker = getPickerComponentForLinkTarget(linkType);
+  const { PickerComponent, getModalTitle } = LINK_TARGETS[linkType];
 
   const handleSelectLinkTargetEntityId = useCallback(
     targetId => {
@@ -219,12 +180,12 @@ function LinkedEntityPicker({
         >
           {({ onClose }: { onClose: () => void }) => (
             <ModalContent
-              title={getPickerModalTitleForLinkTarget(linkType)}
+              title={getModalTitle()}
               onClose={hasSelectedTarget ? onClose : null}
             >
               {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */}
               {/* @ts-ignore */}
-              <Picker
+              <PickerComponent
                 value={clickBehavior.targetId}
                 onChange={(targetId: CardId | DashboardId) => {
                   handleSelectLinkTargetEntityId(targetId);

--- a/frontend/src/metabase/lib/click-behavior.js
+++ b/frontend/src/metabase/lib/click-behavior.js
@@ -251,8 +251,12 @@ export function clickBehaviorIsValid(clickBehavior) {
   if (linkType === "url") {
     return (linkTemplate || "").length > 0;
   }
-  // if we're linking to a question or dashboard we just need a targetId
-  if (linkType === "dashboard" || linkType === "question") {
+  // if we're linking to a Metabase entity we just need a targetId
+  if (
+    linkType === "dashboard" ||
+    linkType === "question" ||
+    linkType === "page"
+  ) {
     return targetId != null;
   }
   // we've picked "link" without picking a link type

--- a/frontend/src/metabase/modes/components/drill/DashboardClickDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/DashboardClickDrill.jsx
@@ -2,6 +2,7 @@
 import { getIn } from "icepick";
 import _ from "underscore";
 import querystring from "querystring";
+import { push } from "react-router-redux";
 
 import Question from "metabase-lib/lib/Question";
 import {
@@ -85,6 +86,28 @@ export default ({ question, clicked }) => {
 
         behavior = { url: () => url };
       }
+    } else if (linkType === "page") {
+      const { location, routerParams } = extraData;
+
+      if (!Urls.isDataAppPagePath(location.pathname)) {
+        return [];
+      }
+
+      const dataAppId = Urls.extractEntityId(routerParams.slug);
+      if (!dataAppId) {
+        return [];
+      }
+
+      const queryParams = getParameterValuesBySlug(parameterMapping, {
+        data,
+        extraData,
+        clickBehavior,
+      });
+
+      const path = Urls.dataAppPage({ id: dataAppId }, { id: targetId });
+      const url = `${path}?${querystring.stringify(queryParams)}`;
+
+      behavior = { action: () => push(url) };
     } else if (linkType === "question" && extraData && extraData.questions) {
       const queryParams = getParameterValuesBySlug(parameterMapping, {
         data,

--- a/frontend/src/metabase/visualizations/hoc/WithVizSettingsData.js
+++ b/frontend/src/metabase/visualizations/hoc/WithVizSettingsData.js
@@ -9,14 +9,14 @@ import { getUserAttributes } from "metabase/selectors/user";
 import Questions from "metabase/entities/questions";
 import Dashboards from "metabase/entities/dashboards";
 
-function hasLinkedQuestionOrDashboard({ type, linkType, action } = {}) {
+function hasLinkedQuestionOrDashboard({ type, linkType } = {}) {
   if (type === "link") {
     return linkType === "question" || linkType === "dashboard";
   }
   return false;
 }
 
-function mapLinkedEntityToEntityQuery({ type, linkType, action, targetId }) {
+function mapLinkedEntityToEntityQuery({ linkType, targetId }) {
   return {
     entity: linkType === "question" ? Questions : Dashboards,
     entityId: targetId,

--- a/frontend/src/metabase/visualizations/hoc/WithVizSettingsData.js
+++ b/frontend/src/metabase/visualizations/hoc/WithVizSettingsData.js
@@ -11,7 +11,9 @@ import Dashboards from "metabase/entities/dashboards";
 
 function hasLinkedQuestionOrDashboard({ type, linkType } = {}) {
   if (type === "link") {
-    return linkType === "question" || linkType === "dashboard";
+    return (
+      linkType === "question" || linkType === "dashboard" || linkType === "page"
+    );
   }
   return false;
 }

--- a/frontend/src/metabase/visualizations/hoc/WithVizSettingsData.js
+++ b/frontend/src/metabase/visualizations/hoc/WithVizSettingsData.js
@@ -1,6 +1,7 @@
 /* eslint-disable react/prop-types */
 import React from "react";
 import { connect } from "react-redux";
+import { withRouter } from "react-router";
 import _ from "underscore";
 
 import { getUserAttributes } from "metabase/selectors/user";
@@ -36,66 +37,70 @@ const WithVizSettingsData = ComposedComponent => {
       .filter(hasLinkedQuestionOrDashboard)
       .map(mapLinkedEntityToEntityQuery);
   }
-  return connect(
-    (state, props) => ({
-      getExtraDataForClick: clicked => {
-        const entitiesByTypeAndId = _.chain(getLinkTargets(clicked.settings))
-          .groupBy(target => target.entity.name)
-          .mapObject(targets =>
-            _.chain(targets)
-              .map(({ entity, entityId }) =>
-                entity.selectors.getObject(state, { entityId }),
-              )
-              .filter(object => object != null)
-              .indexBy(object => object.id)
-              .value(),
-          )
-          .value();
-        return {
-          ...entitiesByTypeAndId,
-          parameterValuesBySlug: props.parameterValuesBySlug,
-          dashboard: props.dashboard,
-          dashcard: props.dashcard,
-          userAttributes: getUserAttributes(state, props),
-        };
-      },
-    }),
-    dispatch => ({ dispatch }),
-  )(
-    class WithVizSettingsData extends React.Component {
-      dashcardSettings(props) {
-        const [firstSeries] = props.rawSeries || [{}];
-        const { visualization_settings } = firstSeries.card || {};
-        return visualization_settings;
-      }
+  return withRouter(
+    connect(
+      (state, props) => ({
+        getExtraDataForClick: clicked => {
+          const entitiesByTypeAndId = _.chain(getLinkTargets(clicked.settings))
+            .groupBy(target => target.entity.name)
+            .mapObject(targets =>
+              _.chain(targets)
+                .map(({ entity, entityId }) =>
+                  entity.selectors.getObject(state, { entityId }),
+                )
+                .filter(object => object != null)
+                .indexBy(object => object.id)
+                .value(),
+            )
+            .value();
+          return {
+            ...entitiesByTypeAndId,
+            location: props.location,
+            routerParams: props.params,
+            parameterValuesBySlug: props.parameterValuesBySlug,
+            dashboard: props.dashboard,
+            dashcard: props.dashcard,
+            userAttributes: getUserAttributes(state, props),
+          };
+        },
+      }),
+      dispatch => ({ dispatch }),
+    )(
+      class WithVizSettingsData extends React.Component {
+        dashcardSettings(props) {
+          const [firstSeries] = props.rawSeries || [{}];
+          const { visualization_settings } = firstSeries.card || {};
+          return visualization_settings;
+        }
 
-      fetch() {
-        getLinkTargets(this.dashcardSettings(this.props)).forEach(
-          ({ entity, entityId }) =>
-            this.props.dispatch(
-              entity.actions.fetch({ id: entityId }, { noEvent: true }),
-            ),
-        );
-      }
+        fetch() {
+          getLinkTargets(this.dashcardSettings(this.props)).forEach(
+            ({ entity, entityId }) =>
+              this.props.dispatch(
+                entity.actions.fetch({ id: entityId }, { noEvent: true }),
+              ),
+          );
+        }
 
-      componentDidMount() {
-        this.fetch();
-      }
-
-      componentDidUpdate(prevProps) {
-        if (
-          !_.isEqual(
-            this.dashcardSettings(this.props),
-            this.dashcardSettings(prevProps),
-          )
-        ) {
+        componentDidMount() {
           this.fetch();
         }
-      }
-      render() {
-        return <ComposedComponent {..._.omit(this.props, "dispatch")} />;
-      }
-    },
+
+        componentDidUpdate(prevProps) {
+          if (
+            !_.isEqual(
+              this.dashcardSettings(this.props),
+              this.dashcardSettings(prevProps),
+            )
+          ) {
+            this.fetch();
+          }
+        }
+        render() {
+          return <ComposedComponent {..._.omit(this.props, "dispatch")} />;
+        }
+      },
+    ),
   );
 };
 


### PR DESCRIPTION
Closes #25365, based on BE work from #25343

Implements smooth navigation between data app pages. When BE generates list and detail pages:

1. List page has a "list" dash card. It now has a [custom destination click behavior](https://www.metabase.com/learn/dashboards/custom-destinations) with `linkType: "page"` pointing to the detail page.
2. Detail page has a "Back to list" button with the same click behavior, but it points back to the list page

The "page" click behavior works almost the same as the "dashboard" click behavior, but it uses `react-router` to perform the transition, so it's absolutely smooth as opposed to a page reload.

### To Verify

1. New > App > Pick a table > Create
2. Select the "List" page in the app navigation sidebar (the detail page shouldn't be open first really, it's going to be fixed in one of the subsequent PRs)
3. Click any list item
4. Ensure you're navigated to a detail page with the item ID you clicked now passed to detail's page dashboard filter
5. Click the "Back to list" button under the ID filter
6. Ensure you're back to the list page

### Demo


https://user-images.githubusercontent.com/17258145/189723445-ef3d36a1-5a81-45e5-b829-a1857d9645a8.mp4

