### PR TITLE
[Apps] exclude is_write cards from virtual tables

### DIFF
--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -154,6 +154,7 @@
                           :where    (into [:and
                                            [:not= :result_metadata nil]
                                            [:= :archived false]
+                                           [:= :is_write false]
                                            [:= :dataset (= question-type :dataset)]
                                            [:in :database_id ids-of-dbs-that-support-source-queries]
                                            (collection/visible-collection-ids->honeysql-filter-clause

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -1016,7 +1016,8 @@
     (testing "should work for the saved questions 'virtual' database"
       (mt/with-temp* [Collection [coll   {:name "My Collection"}]
                       Card       [card-1 (assoc (card-with-native-query "Card 1") :collection_id (:id coll))]
-                      Card       [card-2 (card-with-native-query "Card 2")]]
+                      Card       [card-2 (card-with-native-query "Card 2")]
+                      Card       [_card-3 (assoc (card-with-native-query "Card 3") :is_write true :result_metadata {})]]
         ;; run the cards to populate their result_metadata columns
         (doseq [card [card-1 card-2]]
           (mt/user-http-request :crowberto :post 202 (format "card/%d/query" (u/the-id card))))
@@ -1040,6 +1041,7 @@
                            :schema           (s/eq (api.table/root-collection-schema-name))
                            :description      (s/maybe s/Str)}]
                          response))
+            (is (not (contains? (set (map :display_name response)) "Card 3")))
             (is (contains? (set response)
                            {:id               (format "card__%d" (:id card-2))
                             :db_id            (mt/id)


### PR DESCRIPTION
When creating a new question, you can choose an existing saved question as your starting point. However, we want to exclude is_write cards from that list.
