### PR TITLE
Respect data app homepage setting

### DIFF
--- a/frontend/src/metabase/entities/data-apps/utils.ts
+++ b/frontend/src/metabase/entities/data-apps/utils.ts
@@ -9,7 +9,10 @@ export function isDataAppCollection(collection: Collection) {
   return typeof collection.app_id === "number";
 }
 
-export function getDataAppHomePageId(pages: Dashboard[]) {
+export function getDataAppHomePageId(dataApp: DataApp, pages: Dashboard[]) {
+  if (dataApp.dashboard_id) {
+    return dataApp.dashboard_id;
+  }
   const [firstPage] = _.sortBy(pages, "name");
   return firstPage?.id;
 }

--- a/frontend/src/metabase/entities/data-apps/utils.unit.spec.ts
+++ b/frontend/src/metabase/entities/data-apps/utils.unit.spec.ts
@@ -1,18 +1,45 @@
-import { createMockDataAppPage } from "metabase-types/api/mocks";
+import {
+  createMockDataApp,
+  createMockDataAppPage,
+} from "metabase-types/api/mocks";
 import { getDataAppHomePageId } from "./utils";
 
 describe("data app utils", () => {
-  describe("getDataAppHomePageId", () => {
-    it("returns fist page in alphabetical order", () => {
-      const page1 = createMockDataAppPage({ id: 1, name: "A" });
-      const page2 = createMockDataAppPage({ id: 2, name: "B" });
-      const page3 = createMockDataAppPage({ id: 3, name: "C" });
+  const dataAppWithoutHomepage = createMockDataApp({ dashboard_id: null });
+  const dataAppWithHomepage = createMockDataApp({ dashboard_id: 3 });
 
-      expect(getDataAppHomePageId([page2, page1, page3])).toEqual(page1.id);
+  const page1 = createMockDataAppPage({ id: 1, name: "A" });
+  const page2 = createMockDataAppPage({ id: 2, name: "B" });
+  const page3 = createMockDataAppPage({ id: 3, name: "C" });
+  const pages = [page1, page2, page3];
+
+  describe("getDataAppHomePageId", () => {
+    describe("with explicit homepage", () => {
+      it("returns data app's dashboard_id", () => {
+        expect(getDataAppHomePageId(dataAppWithHomepage, pages)).toEqual(
+          dataAppWithHomepage.dashboard_id,
+        );
+      });
+
+      it("returns data app's dashboard_id even if page list is empty", () => {
+        expect(getDataAppHomePageId(dataAppWithHomepage, [])).toEqual(
+          dataAppWithHomepage.dashboard_id,
+        );
+      });
     });
 
-    it("returns undefined when there're no pages", () => {
-      expect(getDataAppHomePageId([])).toBeUndefined();
+    describe("without explicit homepage", () => {
+      it("returns fist page in alphabetical order", () => {
+        expect(getDataAppHomePageId(dataAppWithoutHomepage, pages)).toEqual(
+          page1.id,
+        );
+      });
+
+      it("returns undefined when there're no pages", () => {
+        expect(
+          getDataAppHomePageId(dataAppWithoutHomepage, []),
+        ).toBeUndefined();
+      });
     });
   });
 });

--- a/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbar/DataAppNavbarContainer.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbar/DataAppNavbarContainer.tsx
@@ -64,13 +64,13 @@ function DataAppNavbarContainer({
       return [
         {
           type: "data-app-page",
-          id: getDataAppHomePageId(pages),
+          id: getDataAppHomePageId(dataApp, pages),
         },
       ];
     }
 
     return selectedItems;
-  }, [pages, selectedItems]);
+  }, [dataApp, pages, selectedItems]);
 
   const onEditAppSettings = useCallback(() => {
     setModal("MODAL_APP_SETTINGS");

--- a/frontend/src/metabase/writeback/containers/DataAppLanding.tsx
+++ b/frontend/src/metabase/writeback/containers/DataAppLanding.tsx
@@ -47,7 +47,7 @@ const DataAppLanding = ({
         loadingAndErrorWrapper={false}
       >
         {({ list: pages = [] }: { list: any[] }) => {
-          const homepageId = getDataAppHomePageId(pages);
+          const homepageId = getDataAppHomePageId(dataApp, pages);
           return homepageId ? (
             <DashboardApp
               dashboardId={homepageId}


### PR DESCRIPTION
Part of #24861

When scaffolding a new app, the app has a `dashboard_id` column containing the app homepage ID. The homepage is a page that should be open first as you launch an app. Right now the FE just opens the first one in the list which is a bit annoying.

### To Verify

1. New > App > Select a table > Create
2. Make sure the List page is selected instead of the detail page