### PR TITLE
Update popper position when the filter changes

### DIFF
--- a/frontend/src/metabase/modes/components/drill/ColumnFilterDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/ColumnFilterDrill.jsx
@@ -32,11 +32,12 @@ export default function ColumnFilterDrill({ question, clicked }) {
       buttonType: "horizontal",
       icon: "filter",
       // eslint-disable-next-line react/display-name
-      popover: ({ onChangeCardAndRun, onClose }) => (
+      popover: ({ onChangeCardAndRun, onResize, onClose }) => (
         <FilterPopover
           query={query}
           filter={initialFilter}
           onClose={onClose}
+          onResize={onResize}
           onChangeFilter={filter => {
             const nextCard = query.filter(filter).question().card();
             onChangeCardAndRun({ nextCard });

--- a/frontend/src/metabase/query_builder/actions/navigation.js
+++ b/frontend/src/metabase/query_builder/actions/navigation.js
@@ -8,6 +8,7 @@ import Utils from "metabase/lib/utils";
 
 import { getMetadata } from "metabase/selectors/metadata";
 
+import { isEqualCard } from "metabase/lib/card";
 import Question from "metabase-lib/lib/Question";
 
 import {
@@ -29,7 +30,6 @@ import { initializeQB, setCardAndRun } from "./core";
 import { zoomInRow, resetRowZoom } from "./object-detail";
 import { cancelQuery } from "./querying";
 import { setQueryBuilderMode } from "./ui";
-import { isEqualCard } from "metabase/lib/card";
 
 export const SET_CURRENT_STATE = "metabase/qb/SET_CURRENT_STATE";
 const setCurrentState = createAction(SET_CURRENT_STATE);

--- a/frontend/src/metabase/query_builder/components/filters/FilterPopover/FilterPopover.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/FilterPopover/FilterPopover.tsx
@@ -35,7 +35,7 @@ type Props = {
   query: StructuredQuery;
   onChange?: (filter: Filter) => void;
   onChangeFilter: (filter: Filter) => void;
-
+  onResize?: () => void;
   onClose?: () => void;
 
   noCommitButton?: boolean;
@@ -70,6 +70,7 @@ export default function FilterPopover({
   checkedColor,
   onChange,
   onChangeFilter,
+  onResize,
   onClose,
 }: Props) {
   const [filter, setFilter] = useState(
@@ -148,6 +149,7 @@ export default function FilterPopover({
   const handleFilterChange = (mbql: any[] = []) => {
     const newFilter = filter ? filter.set(mbql) : new Filter(mbql, null, query);
     setFilter(newFilter);
+    onResize?.();
   };
 
   if (editingFilter) {

--- a/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
@@ -218,7 +218,7 @@ class ChartClickActions extends Component {
           this.close();
         }}
         placement="bottom-start"
-        offset={[0, 8]}
+        offset={[-8, 8]}
         popperOptions={{
           flip: true,
           modifiers: [

--- a/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
@@ -145,6 +145,9 @@ class ChartClickActions extends Component {
       const PopoverContent = popoverAction.popover;
       popover = (
         <PopoverContent
+          onResize={() => {
+            this.instance?.popperInstance?.update();
+          }}
           onChangeCardAndRun={({ nextCard }) => {
             if (popoverAction) {
               MetabaseAnalytics.trackStructEvent(
@@ -204,6 +207,9 @@ class ChartClickActions extends Component {
       <FlexTippyPopover
         reference={popoverAnchor}
         visible={!!popoverAnchor}
+        onShow={instance => {
+          this.instance = instance;
+        }}
         onClose={() => {
           MetabaseAnalytics.trackStructEvent(
             "Action",
@@ -212,7 +218,7 @@ class ChartClickActions extends Component {
           this.close();
         }}
         placement="bottom-start"
-        offset={[-8, 8]}
+        offset={[0, 8]}
         popperOptions={{
           flip: true,
           modifiers: [

--- a/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
@@ -218,7 +218,7 @@ class ChartClickActions extends Component {
           this.close();
         }}
         placement="bottom-start"
-        offset={[-8, 8]}
+        offset={[0, 8]}
         popperOptions={{
           flip: true,
           modifiers: [


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/25185

How to test:
- Open orders table
- Click on `Created At` -> `Filter by this column` -> `Specific dates`
- Make sure that when the right edge of the `Filter by this column` menu is close to the edge of the window, clicking on `Specific dates` flips the popper. 

<img width="347" alt="Screenshot 2022-09-13 at 14 39 46" src="https://user-images.githubusercontent.com/8542534/189891834-b26dff46-4237-4dc3-9477-f749ab57d6e9.png">
<img width="642" alt="Screenshot 2022-09-13 at 14 14 09" src="https://user-images.githubusercontent.com/8542534/189892386-b30e61e4-bf2a-4027-af9f-819d222893cf.png">



