### PR TITLE
Handle the session storage error when saving a location state

### DIFF
--- a/frontend/src/metabase/query_builder/actions/navigation.js
+++ b/frontend/src/metabase/query_builder/actions/navigation.js
@@ -199,10 +199,16 @@ export const updateUrl = createThunkAction(
 
       // this is necessary because we can't get the state from history.state
       dispatch(setCurrentState(newState));
-      if (replaceState) {
-        dispatch(replace(locationDescriptor));
-      } else {
-        dispatch(push(locationDescriptor));
+
+      try {
+        if (replaceState) {
+          dispatch(replace(locationDescriptor));
+        } else {
+          dispatch(push(locationDescriptor));
+        }
+      } catch (e) {
+        // saving the location state can exceed the session storage quota (metabase#25312)
+        console.warn(e);
       }
     },
 );


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/25312

Currently QB navigation relies on the state saved to history (sessionStorage) too heavily to refactor this in reasonable time. This PR solves the original issue by not showing the history error message on the UI.

How to test:
- Follow the steps from the issue