### PR TITLE
Serdes v2: Find YAML files with human-friendly labels

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/ingest/yaml.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/ingest/yaml.clj
@@ -43,8 +43,9 @@
   original labels by eg. truncating them to keep the file names from getting too long. The labels aren't used at all on
   the loading side, so it's fine to drop them."
   [root-dir hierarchy]
-  (let [unlabeled (mapv #(dissoc % :label) hierarchy)]
-    (-> (u.yaml/hierarchy->file root-dir hierarchy) ; Use the original hierarchy for the filesystem.
+  (let [unlabeled (mapv #(dissoc % :label) hierarchy)
+        file      (u.yaml/hierarchy->file root-dir hierarchy)] ; Use the original hierarchy for the filesystem.
+    (-> (when (.exists file) file) ; If the returned file doesn't actually exist, replace it with nil.
         yaml/from-file
         read-timestamps
         (assoc :serdes/meta unlabeled)))) ; But return the hierarchy without labels.

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/utils/yaml.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/utils/yaml.clj
@@ -28,14 +28,14 @@
         {:keys [id model label]} (last hierarchy)
         leaf-name                (leaf-file-name id label)
         as-given                 (apply io/file root-dir (concat prefix [model leaf-name]))]
-    (if (.exists as-given)
+    (if (.exists ^File as-given)
       as-given
       ; If that file name doesn't exist, check the directory to see if there's one that's the requested file plus a
       ; human-readable portion.
       (let [dir       (apply io/file root-dir (concat prefix [model]))
-            matches   (filter #(and (.startsWith % (str id "+"))
-                                    (.endsWith % ".yaml"))
-                              (.list dir))]
+            matches   (filter #(and (.startsWith ^String % (str id "+"))
+                                    (.endsWith ^String % ".yaml"))
+                              (.list ^File dir))]
         (if (empty? matches)
           (io/file dir leaf-name)
           (io/file dir (first matches)))))))

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/utils/yaml.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/utils/yaml.clj
@@ -26,8 +26,19 @@
                                                  [model id]))
         ;; The last part of the hierarchy is used for the basename; this is the only part with the label.
         {:keys [id model label]} (last hierarchy)
-        leaf-name                (leaf-file-name id label)]
-    (apply io/file root-dir (concat prefix [model leaf-name]))))
+        leaf-name                (leaf-file-name id label)
+        as-given                 (apply io/file root-dir (concat prefix [model leaf-name]))]
+    (if (.exists as-given)
+      as-given
+      ; If that file name doesn't exist, check the directory to see if there's one that's the requested file plus a
+      ; human-readable portion.
+      (let [dir       (apply io/file root-dir (concat prefix [model]))
+            matches   (filter #(and (.startsWith % (str id "+"))
+                                    (.endsWith % ".yaml"))
+                              (.list dir))]
+        (if (empty? matches)
+          (io/file dir leaf-name)
+          (io/file dir (first matches)))))))
 
 (defn path-split
   "Given a root directory and a file underneath it, return a sequence of path parts to get there.


### PR DESCRIPTION
The YAML file names have an optional `:label` portion that becomes the
latter part of the filename. Reconstructed paths (eg. from
`serdes-dependencies`) don't have those labels.

This change makes the YAML ingestion code able to find a file with a
human-readable label even if the request didn't include it.
No ambiguity results because the file names are always based on the
unique serdes `:id`, usually an `entity_id`.
