### PR TITLE
Implement implicit actions for data apps

### DIFF
--- a/frontend/src/metabase-types/api/click-behavior.ts
+++ b/frontend/src/metabase-types/api/click-behavior.ts
@@ -51,14 +51,42 @@ export interface ArbitraryCustomDestinationClickBehavior {
   linkTextTemplate?: string;
 }
 
+export type ImplicitActionType = "insert" | "update" | "delete";
+
+interface BaseActionClickBehavior {
+  type: "action";
+  actionType?: ImplicitActionType;
+}
+
+interface InsertActionClickBehavior extends BaseActionClickBehavior {
+  actionType: "insert";
+  tableId: number;
+}
+
+interface UpdateActionClickBehavior extends BaseActionClickBehavior {
+  actionType: "update";
+  objectDetailDashCardId: number;
+}
+
+interface DeleteActionClickBehavior extends BaseActionClickBehavior {
+  actionType: "delete";
+  objectDetailDashCardId: number;
+}
+
 /**
  * This is a bit of a hack to allow us using click behavior code
  * for mapping _explicit_ action parameters. We don't actually use the click behavior though.
  * Remove this type and run the type-check to see the errors.
  */
-interface WritebackActionClickBehavior {
+interface HACK_ExplicitActionClickBehavior {
   type: "action";
 }
+
+export type ActionClickBehavior =
+  | InsertActionClickBehavior
+  | UpdateActionClickBehavior
+  | DeleteActionClickBehavior
+  | HACK_ExplicitActionClickBehavior;
 
 /**
  * Makes click handler use default drills.
@@ -77,4 +105,4 @@ export type ClickBehavior =
   | ActionMenuClickBehavior
   | CrossFilterClickBehavior
   | CustomDestinationClickBehavior
-  | WritebackActionClickBehavior;
+  | ActionClickBehavior;

--- a/frontend/src/metabase-types/api/click-behavior.ts
+++ b/frontend/src/metabase-types/api/click-behavior.ts
@@ -73,6 +73,11 @@ interface DeleteActionClickBehavior extends BaseActionClickBehavior {
   objectDetailDashCardId: number;
 }
 
+export type ImplicitActionClickBehavior =
+  | InsertActionClickBehavior
+  | UpdateActionClickBehavior
+  | DeleteActionClickBehavior;
+
 /**
  * This is a bit of a hack to allow us using click behavior code
  * for mapping _explicit_ action parameters. We don't actually use the click behavior though.
@@ -83,9 +88,7 @@ interface HACK_ExplicitActionClickBehavior {
 }
 
 export type ActionClickBehavior =
-  | InsertActionClickBehavior
-  | UpdateActionClickBehavior
-  | DeleteActionClickBehavior
+  | ImplicitActionClickBehavior
   | HACK_ExplicitActionClickBehavior;
 
 /**

--- a/frontend/src/metabase-types/api/dashboard.ts
+++ b/frontend/src/metabase-types/api/dashboard.ts
@@ -1,10 +1,12 @@
-import { EntityId } from "metabase-types/types";
-import {
+import type { EntityId } from "metabase-types/types";
+import type {
   ParameterTarget,
   ParameterId,
   Parameter,
 } from "metabase-types/types/Parameter";
-import { CardId, SavedCard } from "metabase-types/types/Card";
+import type { CardId, SavedCard } from "metabase-types/types/Card";
+
+import type { Dataset } from "./dataset";
 
 export type DashboardId = number;
 
@@ -46,3 +48,8 @@ export type DashboardParameterMapping = {
   parameter_id: ParameterId;
   target: ParameterTarget;
 };
+
+export type DashCardDataMap = Record<
+  DashCardId,
+  Record<CardId, Dataset | undefined>
+>;

--- a/frontend/src/metabase/components/ConfirmContent.jsx
+++ b/frontend/src/metabase/components/ConfirmContent.jsx
@@ -10,7 +10,7 @@ const nop = () => {};
 
 const ConfirmContent = ({
   title,
-  content,
+  content = null,
   message = t`Are you sure you want to do this?`,
   onClose = nop,
   onAction = nop,

--- a/frontend/src/metabase/dashboard/actions/data-fetching.js
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.js
@@ -400,6 +400,20 @@ export const fetchDashboardCardData = createThunkAction(
   },
 );
 
+export const reloadDashboardCards = () => async (dispatch, getState) => {
+  const dashboard = getDashboardComplete(getState());
+
+  const reloads = getAllDashboardCards(dashboard)
+    .filter(({ dashcard }) => !isVirtualDashCard(dashcard))
+    .map(({ card, dashcard }) =>
+      dispatch(
+        fetchCardData(card, dashcard, { reload: true, ignoreCache: true }),
+      ),
+    );
+
+  await Promise.all(reloads);
+};
+
 export const cancelFetchDashboardCardData = createThunkAction(
   CANCEL_FETCH_DASHBOARD_CARD_DATA,
   () => (dispatch, getState) => {

--- a/frontend/src/metabase/dashboard/actions/writeback.ts
+++ b/frontend/src/metabase/dashboard/actions/writeback.ts
@@ -20,10 +20,10 @@ import { ActionsApi } from "metabase/services";
 
 import type {
   Dashboard,
+  DashboardOrderedCard,
   ActionButtonDashboardCard,
   ParameterMappedForActionExecution,
 } from "metabase-types/api";
-import type { DashCard } from "metabase-types/types/Dashboard";
 import type { Dispatch } from "metabase-types/store";
 
 import { getCardData } from "../selectors";
@@ -57,22 +57,13 @@ export function updateButtonActionMapping(
   };
 }
 
-export type InsertRowFromDataAppPayload = InsertRowPayload & {
-  dashCard: DashCard;
-};
+export type InsertRowFromDataAppPayload = InsertRowPayload;
 
 export const createRowFromDataApp = (payload: InsertRowFromDataAppPayload) => {
   return async (dispatch: any) => {
     const result = await createRow(payload);
     const { table } = payload;
     if (result?.["created-row"]?.id) {
-      const { dashCard } = payload;
-      dispatch(
-        fetchCardData(dashCard.card, dashCard, {
-          reload: true,
-          ignoreCache: true,
-        }),
-      );
       dispatch(
         addUndo({
           message: t`Successfully inserted a row into the ${table.displayName()} table`,
@@ -84,7 +75,7 @@ export const createRowFromDataApp = (payload: InsertRowFromDataAppPayload) => {
 };
 
 export type UpdateRowFromDataAppPayload = UpdateRowPayload & {
-  dashCard: DashCard;
+  dashCard: DashboardOrderedCard;
 };
 
 export const updateRowFromDataApp = (payload: UpdateRowFromDataAppPayload) => {
@@ -103,7 +94,7 @@ export const updateRowFromDataApp = (payload: UpdateRowFromDataAppPayload) => {
 };
 
 export type DeleteRowFromDataAppPayload = DeleteRowPayload & {
-  dashCard: DashCard;
+  dashCard: DashboardOrderedCard;
 };
 
 export const deleteRowFromDataApp = (payload: DeleteRowFromDataAppPayload) => {
@@ -136,7 +127,7 @@ export type BulkUpdateFromDataAppPayload = Omit<
   BulkUpdatePayload,
   "records"
 > & {
-  dashCard: DashCard;
+  dashCard: DashboardOrderedCard;
   rowIndexes: number[];
   changes: Record<string, unknown>;
 };
@@ -203,7 +194,7 @@ export const updateManyRowsFromDataApp = (
 };
 
 export type BulkDeleteFromDataAppPayload = Omit<BulkDeletePayload, "ids"> & {
-  dashCard: DashCard;
+  dashCard: DashboardOrderedCard;
   rowIndexes: number[];
 };
 

--- a/frontend/src/metabase/dashboard/actions/writeback.ts
+++ b/frontend/src/metabase/dashboard/actions/writeback.ts
@@ -65,7 +65,7 @@ export const createRowFromDataApp = (payload: InsertRowFromDataAppPayload) => {
     if (result?.["created-row"]?.id) {
       dispatch(
         addUndo({
-          message: t`Successfully inserted a row into the ${table.displayName()} table`,
+          message: t`Successfully created a new ${table.objectName()}`,
           toastColor: "success",
         }),
       );

--- a/frontend/src/metabase/dashboard/selectors.js
+++ b/frontend/src/metabase/dashboard/selectors.js
@@ -12,7 +12,12 @@ import {
 import { getParameterMappingOptions as _getParameterMappingOptions } from "metabase/parameters/utils/mapping-options";
 
 import { SIDEBAR_NAME } from "metabase/dashboard/constants";
+
 import { getEmbedOptions, getIsEmbedded } from "metabase/selectors/embed";
+
+import Question from "metabase-lib/lib/Question";
+
+import { isVirtualDashCard } from "./utils";
 
 export const getDashboardId = state => state.dashboard.dashboardId;
 export const getIsEditing = state => !!state.dashboard.isEditing;
@@ -65,6 +70,30 @@ export const getDashboard = createSelector(
 );
 
 export const getLoadingDashCards = state => state.dashboard.loadingDashCards;
+
+export const getDashCardById = (state, dashcardId) => {
+  const dashcards = getDashcards(state);
+  return dashcards[dashcardId];
+};
+
+export const getSingleDashCardData = (state, dashcardId) => {
+  const dashcard = getDashCardById(state, dashcardId);
+  const cardDataMap = getCardData(state);
+  if (!dashcard || !cardDataMap) {
+    return;
+  }
+  return cardDataMap?.[dashcard.id]?.[dashcard.card_id]?.data;
+};
+
+export const getDashCardTable = (state, dashcardId) => {
+  const dashcard = getDashCardById(state, dashcardId);
+  if (!dashcard || isVirtualDashCard(dashcard)) {
+    return null;
+  }
+  const metadata = getMetadata(state);
+  const question = new Question(dashcard.card, metadata);
+  return question.table();
+};
 
 export const getDashboardComplete = createSelector(
   [getDashboard, getDashcards],

--- a/frontend/src/metabase/lib/click-behavior.js
+++ b/frontend/src/metabase/lib/click-behavior.js
@@ -10,6 +10,7 @@ import {
   dimensionFilterForParameter,
   variableFilterForParameter,
 } from "metabase/parameters/utils/filters";
+import { isValidImplicitActionClickBehavior } from "metabase/writeback/utils";
 import Question from "metabase-lib/lib/Question";
 import { TemplateTagVariable } from "metabase-lib/lib/Variable";
 import { TemplateTagDimension } from "metabase-lib/lib/Dimension";
@@ -246,6 +247,9 @@ export function clickBehaviorIsValid(clickBehavior) {
   } = clickBehavior;
   if (type === "crossfilter") {
     return Object.keys(parameterMapping).length > 0;
+  }
+  if (type === "action") {
+    return isValidImplicitActionClickBehavior(clickBehavior);
   }
   // if it's not a crossfilter/action, it's a link
   if (linkType === "url") {

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorFieldPicker/DataSelectorFieldPicker.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorFieldPicker/DataSelectorFieldPicker.unit.spec.tsx
@@ -3,7 +3,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { ORDERS } from "__support__/sample_database_fixture";
 
 import type { Table } from "metabase-types/api/table";
-import type { Field } from "metabase-types/api/field";
+
 import DataSelectorFieldPicker from "./DataSelectorFieldPicker";
 
 const props = {

--- a/frontend/src/metabase/visualizations/components/List/List.tsx
+++ b/frontend/src/metabase/visualizations/components/List/List.tsx
@@ -164,7 +164,6 @@ function List({
           id: pkValue,
           table,
           values,
-          dashCard: connectedDashCard,
         });
       }
     },
@@ -189,7 +188,6 @@ function List({
           deleteRow({
             id: pkValue,
             table,
-            dashCard: connectedDashCard,
           });
         },
       });

--- a/frontend/src/metabase/writeback/actions.ts
+++ b/frontend/src/metabase/writeback/actions.ts
@@ -1,6 +1,7 @@
 import { ActionsApi } from "metabase/services";
 
-import Table from "metabase-lib/lib/metadata/Table";
+import type { Value } from "metabase-types/types/Dataset";
+import type Table from "metabase-lib/lib/metadata/Table";
 
 export type InsertRowPayload = {
   table: Table;
@@ -21,7 +22,7 @@ export const createRow = (payload: InsertRowPayload) => {
 
 export type UpdateRowPayload = {
   table: Table;
-  id: number | string;
+  id: Value;
   values: Record<string, unknown>;
 };
 
@@ -62,7 +63,7 @@ export const updateManyRows = (payload: BulkUpdatePayload) => {
 
 export type DeleteRowPayload = {
   table: Table;
-  id: number | string;
+  id: Value;
 };
 
 export const deleteRow = (payload: DeleteRowPayload) => {

--- a/frontend/src/metabase/writeback/components/ActionButtonViz/ActionButton.tsx
+++ b/frontend/src/metabase/writeback/components/ActionButtonViz/ActionButton.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useMemo } from "react";
 import type { Dashboard } from "metabase-types/api";
 import type { VisualizationProps } from "metabase-types/types/Visualization";
 
-import { StyledButton } from "./ActionButton.styled";
+import ActionButtonView from "./ActionButtonView";
 
 interface ActionButtonProps extends VisualizationProps {
   dashboard: Dashboard;
@@ -15,14 +15,6 @@ function ActionButton({
   getExtraDataForClick,
   onVisualizationClick,
 }: ActionButtonProps) {
-  const label = settings["button.label"];
-  const variant = settings["button.variant"];
-
-  const variantProps: any = {};
-  if (variant !== "default") {
-    variantProps[variant] = true;
-  }
-
   const clickObject = useMemo(() => ({ settings }), [settings]);
 
   const extraData = useMemo(
@@ -38,13 +30,11 @@ function ActionButton({
   }, [clickObject, extraData, onVisualizationClick]);
 
   return (
-    <StyledButton
+    <ActionButtonView
       onClick={onClick}
+      settings={settings}
       isFullHeight={!isSettings}
-      {...variantProps}
-    >
-      {label}
-    </StyledButton>
+    />
   );
 }
 

--- a/frontend/src/metabase/writeback/components/ActionButtonViz/ActionButton.tsx
+++ b/frontend/src/metabase/writeback/components/ActionButtonViz/ActionButton.tsx
@@ -1,41 +1,23 @@
-import React, { useCallback, useMemo } from "react";
+import React from "react";
 
-import type { Dashboard } from "metabase-types/api";
+import { isImplicitActionButton } from "metabase/writeback/utils";
+
+import type { ActionButtonDashboardCard, Dashboard } from "metabase-types/api";
 import type { VisualizationProps } from "metabase-types/types/Visualization";
 
-import ActionButtonView from "./ActionButtonView";
+import DefaultActionButton from "./DefaultActionButton";
+import ImplicitActionButton from "./ImplicitActionButton";
 
 interface ActionButtonProps extends VisualizationProps {
+  dashcard: ActionButtonDashboardCard;
   dashboard: Dashboard;
 }
 
-function ActionButton({
-  isSettings,
-  settings,
-  getExtraDataForClick,
-  onVisualizationClick,
-}: ActionButtonProps) {
-  const clickObject = useMemo(() => ({ settings }), [settings]);
-
-  const extraData = useMemo(
-    () => getExtraDataForClick?.(clickObject),
-    [clickObject, getExtraDataForClick],
-  );
-
-  const onClick = useCallback(() => {
-    onVisualizationClick({
-      ...clickObject,
-      extraData,
-    });
-  }, [clickObject, extraData, onVisualizationClick]);
-
-  return (
-    <ActionButtonView
-      onClick={onClick}
-      settings={settings}
-      isFullHeight={!isSettings}
-    />
-  );
+function ActionButton({ dashcard, ...props }: ActionButtonProps) {
+  if (isImplicitActionButton(dashcard)) {
+    return <ImplicitActionButton {...props} />;
+  }
+  return <DefaultActionButton {...props} />;
 }
 
 export default ActionButton;

--- a/frontend/src/metabase/writeback/components/ActionButtonViz/ActionButtonView.tsx
+++ b/frontend/src/metabase/writeback/components/ActionButtonViz/ActionButtonView.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+
+import type { VisualizationProps } from "metabase-types/types/Visualization";
+
+import { StyledButton } from "./ActionButton.styled";
+
+interface ActionButtonViewProps extends Pick<VisualizationProps, "settings"> {
+  isFullHeight?: boolean;
+  onClick: () => void;
+}
+
+function ActionButtonView({
+  settings,
+  isFullHeight,
+  onClick,
+}: ActionButtonViewProps) {
+  const label = settings["button.label"];
+  const variant = settings["button.variant"];
+
+  const variantProps: any = {};
+  if (variant !== "default") {
+    variantProps[variant] = true;
+  }
+
+  return (
+    <StyledButton
+      onClick={onClick}
+      isFullHeight={isFullHeight}
+      {...variantProps}
+    >
+      {label}
+    </StyledButton>
+  );
+}
+
+export default ActionButtonView;

--- a/frontend/src/metabase/writeback/components/ActionButtonViz/DefaultActionButton.tsx
+++ b/frontend/src/metabase/writeback/components/ActionButtonViz/DefaultActionButton.tsx
@@ -1,0 +1,41 @@
+import React, { useCallback, useMemo } from "react";
+
+import type { Dashboard } from "metabase-types/api";
+import type { VisualizationProps } from "metabase-types/types/Visualization";
+
+import ActionButtonView from "./ActionButtonView";
+
+interface DefaultActionButtonProps extends VisualizationProps {
+  dashboard: Dashboard;
+}
+
+function DefaultActionButton({
+  isSettings,
+  settings,
+  getExtraDataForClick,
+  onVisualizationClick,
+}: DefaultActionButtonProps) {
+  const clickObject = useMemo(() => ({ settings }), [settings]);
+
+  const extraData = useMemo(
+    () => getExtraDataForClick?.(clickObject),
+    [clickObject, getExtraDataForClick],
+  );
+
+  const onClick = useCallback(() => {
+    onVisualizationClick({
+      ...clickObject,
+      extraData,
+    });
+  }, [clickObject, extraData, onVisualizationClick]);
+
+  return (
+    <ActionButtonView
+      onClick={onClick}
+      settings={settings}
+      isFullHeight={!isSettings}
+    />
+  );
+}
+
+export default DefaultActionButton;

--- a/frontend/src/metabase/writeback/components/ActionButtonViz/ImplicitActionButton.tsx
+++ b/frontend/src/metabase/writeback/components/ActionButtonViz/ImplicitActionButton.tsx
@@ -11,6 +11,7 @@ import type { VisualizationProps } from "metabase-types/types/Visualization";
 
 import ImplicitInsertModal from "./ImplicitInsertModal";
 import ImplicitUpdateModal from "./ImplicitUpdateModal";
+import ImplicitDeleteModal from "./ImplicitDeleteModal";
 
 import ActionButtonView from "./ActionButtonView";
 
@@ -28,6 +29,7 @@ const ACTION_COMPONENT_MAP: Record<
 > = {
   insert: ImplicitInsertModal,
   update: ImplicitUpdateModal,
+  delete: ImplicitDeleteModal,
 };
 
 function ImplicitActionButton({

--- a/frontend/src/metabase/writeback/components/ActionButtonViz/ImplicitActionButton.tsx
+++ b/frontend/src/metabase/writeback/components/ActionButtonViz/ImplicitActionButton.tsx
@@ -10,6 +10,7 @@ import type {
 import type { VisualizationProps } from "metabase-types/types/Visualization";
 
 import ImplicitInsertModal from "./ImplicitInsertModal";
+import ImplicitUpdateModal from "./ImplicitUpdateModal";
 
 import ActionButtonView from "./ActionButtonView";
 
@@ -26,6 +27,7 @@ const ACTION_COMPONENT_MAP: Record<
   React.ComponentType<any>
 > = {
   insert: ImplicitInsertModal,
+  update: ImplicitUpdateModal,
 };
 
 function ImplicitActionButton({

--- a/frontend/src/metabase/writeback/components/ActionButtonViz/ImplicitActionButton.tsx
+++ b/frontend/src/metabase/writeback/components/ActionButtonViz/ImplicitActionButton.tsx
@@ -1,0 +1,41 @@
+import React, { useCallback, useMemo } from "react";
+
+import type { Dashboard } from "metabase-types/api";
+import type { VisualizationProps } from "metabase-types/types/Visualization";
+
+import ActionButtonView from "./ActionButtonView";
+
+interface ImplicitActionButtonProps extends VisualizationProps {
+  dashboard: Dashboard;
+}
+
+function ImplicitActionButton({
+  isSettings,
+  settings,
+  getExtraDataForClick,
+  onVisualizationClick,
+}: ImplicitActionButtonProps) {
+  const clickObject = useMemo(() => ({ settings }), [settings]);
+
+  const extraData = useMemo(
+    () => getExtraDataForClick?.(clickObject),
+    [clickObject, getExtraDataForClick],
+  );
+
+  const onClick = useCallback(() => {
+    onVisualizationClick({
+      ...clickObject,
+      extraData,
+    });
+  }, [clickObject, extraData, onVisualizationClick]);
+
+  return (
+    <ActionButtonView
+      onClick={onClick}
+      settings={settings}
+      isFullHeight={!isSettings}
+    />
+  );
+}
+
+export default ImplicitActionButton;

--- a/frontend/src/metabase/writeback/components/ActionButtonViz/ImplicitDeleteModal.tsx
+++ b/frontend/src/metabase/writeback/components/ActionButtonViz/ImplicitDeleteModal.tsx
@@ -1,0 +1,108 @@
+import React from "react";
+import { t } from "ttag";
+import { connect } from "react-redux";
+
+import Modal from "metabase/components/Modal";
+import ConfirmContent from "metabase/components/ConfirmContent";
+
+import {
+  deleteRowFromDataApp,
+  DeleteRowFromDataAppPayload,
+} from "metabase/dashboard/actions";
+import {
+  getDashCardById,
+  getDashCardTable,
+  getSingleDashCardData,
+} from "metabase/dashboard/selectors";
+
+import type { State } from "metabase-types/store";
+import type { DashboardOrderedCard } from "metabase-types/api";
+import type { Row } from "metabase-types/types/Dataset";
+import type Table from "metabase-lib/lib/metadata/Table";
+
+interface OwnProps {
+  isOpen: boolean;
+  objectDetailDashCardId: number;
+  onClose: () => void;
+  children: React.ReactNode;
+}
+
+interface StateProps {
+  dashCard?: DashboardOrderedCard;
+  table?: Table | null;
+  row?: Row;
+}
+
+interface DispatchProps {
+  deleteRow: (payload: DeleteRowFromDataAppPayload) => void;
+}
+
+type ImplicitUpdateModalProps = OwnProps & StateProps & DispatchProps;
+
+function mapStateToProps(state: State, props: OwnProps) {
+  const dashCard = getDashCardById(state, props.objectDetailDashCardId);
+  const isObjectDetailView = dashCard?.card?.display === "object";
+
+  if (!isObjectDetailView) {
+    return {};
+  }
+
+  const table = getDashCardTable(state, props.objectDetailDashCardId);
+  const dashCardData = getSingleDashCardData(
+    state,
+    props.objectDetailDashCardId,
+  );
+  const row = dashCardData?.rows[0];
+
+  return { dashCard, table, row };
+}
+
+const mapDispatchToProps = {
+  deleteRow: deleteRowFromDataApp,
+};
+
+function ImplicitDeleteModal({
+  isOpen,
+  dashCard,
+  table,
+  row,
+  deleteRow,
+  onClose,
+  children,
+}: ImplicitUpdateModalProps) {
+  function handleDelete() {
+    if (!table || !dashCard || !row) {
+      return;
+    }
+
+    const primaryKeyFieldIndex = table.fields.findIndex(field => field.isPK());
+    const primaryKeyValue = row[primaryKeyFieldIndex];
+
+    deleteRow({
+      id: primaryKeyValue,
+      table,
+      dashCard,
+    });
+  }
+
+  return (
+    <>
+      {children}
+      {table && (
+        <Modal isOpen={isOpen} onClose={onClose}>
+          <ConfirmContent
+            title={t`Delete ${table.objectName()}?`}
+            message={t`This can't be undone.`}
+            onAction={handleDelete}
+            onClose={onClose}
+          />
+        </Modal>
+      )}
+    </>
+  );
+}
+
+export default connect<StateProps, DispatchProps, OwnProps, State>(
+  mapStateToProps,
+  mapDispatchToProps,
+)(ImplicitDeleteModal);

--- a/frontend/src/metabase/writeback/components/ActionButtonViz/ImplicitDeleteModal.tsx
+++ b/frontend/src/metabase/writeback/components/ActionButtonViz/ImplicitDeleteModal.tsx
@@ -81,7 +81,6 @@ function ImplicitDeleteModal({
     deleteRow({
       id: primaryKeyValue,
       table,
-      dashCard,
     });
   }
 

--- a/frontend/src/metabase/writeback/components/ActionButtonViz/ImplicitInsertModal.tsx
+++ b/frontend/src/metabase/writeback/components/ActionButtonViz/ImplicitInsertModal.tsx
@@ -1,0 +1,85 @@
+import React, { useCallback } from "react";
+import { connect } from "react-redux";
+
+import Modal from "metabase/components/Modal";
+
+import { getMetadata } from "metabase/selectors/metadata";
+
+import {
+  createRowFromDataApp,
+  InsertRowFromDataAppPayload,
+} from "metabase/dashboard/actions";
+import WritebackModalForm from "metabase/writeback/containers/WritebackModalForm";
+
+import type { State } from "metabase-types/store";
+import type Table from "metabase-lib/lib/metadata/Table";
+
+interface OwnProps {
+  isOpen: boolean;
+  tableId: Table["id"];
+  onClose: () => void;
+  children: React.ReactNode;
+}
+
+interface StateProps {
+  table: Table | null;
+}
+
+interface DispatchProps {
+  insertRow: (payload: InsertRowFromDataAppPayload) => void;
+}
+
+type ImplicitInsertModalProps = OwnProps & StateProps & DispatchProps;
+
+function mapStateToProps(state: State, props: OwnProps) {
+  const metadata = getMetadata(state);
+  return {
+    table: metadata.table(props.tableId),
+  };
+}
+
+const mapDispatchToProps = {
+  insertRow: createRowFromDataApp,
+};
+
+function ImplicitInsertModal({
+  isOpen,
+  table,
+  insertRow,
+  onClose,
+  children,
+}: ImplicitInsertModalProps) {
+  const handleSubmit = useCallback(
+    (values: Record<string, unknown>) => {
+      if (table) {
+        insertRow({
+          table,
+          values,
+        });
+      }
+    },
+    [table, insertRow],
+  );
+
+  return (
+    <>
+      {children}
+      {table && (
+        <Modal isOpen={isOpen} onClose={onClose}>
+          <WritebackModalForm
+            table={table}
+            type="insert"
+            mode="row"
+            onSubmit={handleSubmit}
+            onClose={onClose}
+          />
+        </Modal>
+      )}
+    </>
+  );
+}
+
+export default connect<StateProps, DispatchProps, OwnProps, State>(
+  mapStateToProps,
+  mapDispatchToProps,
+)(ImplicitInsertModal);

--- a/frontend/src/metabase/writeback/components/ActionButtonViz/ImplicitUpdateModal.tsx
+++ b/frontend/src/metabase/writeback/components/ActionButtonViz/ImplicitUpdateModal.tsx
@@ -1,0 +1,109 @@
+import React from "react";
+import { connect } from "react-redux";
+
+import Modal from "metabase/components/Modal";
+
+import {
+  updateRowFromDataApp,
+  UpdateRowFromDataAppPayload,
+} from "metabase/dashboard/actions";
+import {
+  getDashCardById,
+  getDashCardTable,
+  getSingleDashCardData,
+} from "metabase/dashboard/selectors";
+import WritebackModalForm from "metabase/writeback/containers/WritebackModalForm";
+
+import type { State } from "metabase-types/store";
+import type { DashboardOrderedCard } from "metabase-types/api";
+import type { Row } from "metabase-types/types/Dataset";
+import type Table from "metabase-lib/lib/metadata/Table";
+
+interface OwnProps {
+  isOpen: boolean;
+  objectDetailDashCardId: number;
+  onClose: () => void;
+  children: React.ReactNode;
+}
+
+interface StateProps {
+  dashCard?: DashboardOrderedCard;
+  table?: Table | null;
+  row?: Row;
+}
+
+interface DispatchProps {
+  updateRow: (payload: UpdateRowFromDataAppPayload) => void;
+}
+
+type ImplicitUpdateModalProps = OwnProps & StateProps & DispatchProps;
+
+function mapStateToProps(state: State, props: OwnProps) {
+  const dashCard = getDashCardById(state, props.objectDetailDashCardId);
+  const isObjectDetailView = dashCard?.card?.display === "object";
+
+  if (!isObjectDetailView) {
+    return {};
+  }
+
+  const table = getDashCardTable(state, props.objectDetailDashCardId);
+  const dashCardData = getSingleDashCardData(
+    state,
+    props.objectDetailDashCardId,
+  );
+  const row = dashCardData?.rows[0];
+
+  return { dashCard, table, row };
+}
+
+const mapDispatchToProps = {
+  updateRow: updateRowFromDataApp,
+};
+
+function ImplicitUpdateModal({
+  isOpen,
+  dashCard,
+  table,
+  row,
+  updateRow,
+  onClose,
+  children,
+}: ImplicitUpdateModalProps) {
+  function handleSubmit(values: Record<string, unknown>) {
+    if (!table || !dashCard || !row) {
+      return;
+    }
+
+    const primaryKeyFieldIndex = table.fields.findIndex(field => field.isPK());
+    const primaryKeyValue = row[primaryKeyFieldIndex];
+    return updateRow({
+      id: primaryKeyValue,
+      table,
+      values,
+      dashCard,
+    });
+  }
+
+  return (
+    <>
+      {children}
+      {table && (
+        <Modal isOpen={isOpen} onClose={onClose}>
+          <WritebackModalForm
+            table={table}
+            row={row}
+            type="update"
+            mode="row"
+            onSubmit={handleSubmit}
+            onClose={onClose}
+          />
+        </Modal>
+      )}
+    </>
+  );
+}
+
+export default connect<StateProps, DispatchProps, OwnProps, State>(
+  mapStateToProps,
+  mapDispatchToProps,
+)(ImplicitUpdateModal);

--- a/frontend/src/metabase/writeback/components/ActionButtonViz/ImplicitUpdateModal.tsx
+++ b/frontend/src/metabase/writeback/components/ActionButtonViz/ImplicitUpdateModal.tsx
@@ -80,7 +80,6 @@ function ImplicitUpdateModal({
       id: primaryKeyValue,
       table,
       values,
-      dashCard,
     });
   }
 

--- a/frontend/src/metabase/writeback/utils.ts
+++ b/frontend/src/metabase/writeback/utils.ts
@@ -86,7 +86,9 @@ export function isMappedExplicitActionButton(
   return isAction && typeof dashCard.action_id === "number";
 }
 
-function isValidImplicitActionClickBehavior(clickBehavior?: ClickBehavior) {
+export function isValidImplicitActionClickBehavior(
+  clickBehavior?: ClickBehavior,
+) {
   if (
     !clickBehavior ||
     clickBehavior.type !== "action" ||

--- a/frontend/src/metabase/writeback/utils.ts
+++ b/frontend/src/metabase/writeback/utils.ts
@@ -3,6 +3,7 @@ import { TYPE } from "metabase/lib/types";
 import type {
   ActionButtonDashboardCard,
   BaseDashboardOrderedCard,
+  ClickBehavior,
   Database as IDatabase,
 } from "metabase-types/api";
 import type { SavedCard } from "metabase-types/types/Card";
@@ -83,6 +84,39 @@ export function isMappedExplicitActionButton(
 ): dashCard is ActionButtonDashboardCard {
   const isAction = isActionButtonDashCard(dashCard);
   return isAction && typeof dashCard.action_id === "number";
+}
+
+function isValidImplicitActionClickBehavior(clickBehavior?: ClickBehavior) {
+  if (
+    !clickBehavior ||
+    clickBehavior.type !== "action" ||
+    !("actionType" in clickBehavior)
+  ) {
+    return false;
+  }
+  if (clickBehavior.actionType === "insert") {
+    return clickBehavior.tableId != null;
+  }
+  if (
+    clickBehavior.actionType === "update" ||
+    clickBehavior.actionType === "delete"
+  ) {
+    return typeof clickBehavior.objectDetailDashCardId === "number";
+  }
+  return false;
+}
+
+export function isImplicitActionButton(
+  dashCard: BaseDashboardOrderedCard,
+): dashCard is ActionButtonDashboardCard {
+  const isAction = isActionButtonDashCard(dashCard);
+  return (
+    isAction &&
+    dashCard.action_id == null &&
+    isValidImplicitActionClickBehavior(
+      dashCard.visualization_settings?.click_behavior,
+    )
+  );
 }
 
 export function getActionButtonLabel(dashCard: ActionButtonDashboardCard) {

--- a/frontend/src/metabase/writeback/utils.unit.spec.ts
+++ b/frontend/src/metabase/writeback/utils.unit.spec.ts
@@ -6,7 +6,7 @@ import type {
   ActionButtonDashboardCard,
   ActionButtonParametersMapping,
 } from "metabase-types/api";
-import { isMappedExplicitActionButton } from "./utils";
+import { isMappedExplicitActionButton, isImplicitActionButton } from "./utils";
 
 const PLAIN_BUTTON = createMockDashboardActionButton({
   action_id: null,
@@ -28,6 +28,42 @@ const PARAMETER_MAPPINGS: ActionButtonParametersMapping[] = [
     target: ["variable", ["template-tag", "foo"]],
   },
 ];
+
+const IMPLICIT_INSERT_ACTION = createMockDashboardActionButton({
+  action_id: null,
+  action: undefined,
+  visualization_settings: {
+    click_behavior: {
+      type: "action",
+      actionType: "insert",
+      tableId: 5,
+    },
+  },
+});
+
+const IMPLICIT_UPDATE_ACTION = createMockDashboardActionButton({
+  action_id: null,
+  action: undefined,
+  visualization_settings: {
+    click_behavior: {
+      type: "action",
+      actionType: "update",
+      objectDetailDashCardId: 5,
+    },
+  },
+});
+
+const IMPLICIT_DELETE_ACTION = createMockDashboardActionButton({
+  action_id: null,
+  action: undefined,
+  visualization_settings: {
+    click_behavior: {
+      type: "action",
+      actionType: "delete",
+      objectDetailDashCardId: 5,
+    },
+  },
+});
 
 const NAVIGATION_ACTION_BUTTON = createMockDashboardActionButton({
   action_id: null,
@@ -79,5 +115,71 @@ describe("isMappedExplicitActionButton", () => {
     };
 
     expect(isMappedExplicitActionButton(button)).toBe(true);
+  });
+});
+
+describe("isImplicitActionButton", () => {
+  const IMPLICIT_ACTIONS = [
+    { action: IMPLICIT_INSERT_ACTION, type: "insert" },
+    { action: IMPLICIT_UPDATE_ACTION, type: "update" },
+    { action: IMPLICIT_DELETE_ACTION, type: "delete" },
+  ];
+
+  it("returns false for navigation buttons", () => {
+    expect(isImplicitActionButton(NAVIGATION_ACTION_BUTTON)).toBe(false);
+  });
+
+  it("returns false for cards without action-button display", () => {
+    const dashcard = createMockDashboardActionButton({
+      visualization_settings: {
+        virtual_card: { display: "table" },
+      },
+    });
+    expect(isImplicitActionButton(dashcard)).toBe(false);
+  });
+
+  it("returns false for plain button", () => {
+    expect(isImplicitActionButton(PLAIN_BUTTON)).toBe(false);
+  });
+
+  it("returns false for explicit action buttons", () => {
+    expect(isImplicitActionButton(EXPLICIT_ACTION)).toBe(false);
+  });
+
+  it("returns false for implicit action with incomplete shape", () => {
+    const insertActionWithoutTableId = createMockDashboardActionButton({
+      action_id: null,
+      action: undefined,
+      visualization_settings: {
+        click_behavior: {
+          type: "action",
+          actionType: "insert",
+        },
+      },
+    });
+
+    expect(isImplicitActionButton(insertActionWithoutTableId)).toBe(false);
+  });
+
+  it("returns false for implicit action with unrecognized `actionType`", () => {
+    const unrecognizedAction = createMockDashboardActionButton({
+      action_id: null,
+      action: undefined,
+      visualization_settings: {
+        click_behavior: {
+          type: "action",
+          actionType: "play-some-tunes",
+          objectDetailDashCardId: 5,
+        },
+      },
+    });
+
+    expect(isImplicitActionButton(unrecognizedAction)).toBe(false);
+  });
+
+  IMPLICIT_ACTIONS.forEach(({ action, type }) => {
+    it(`returns true for implicit ${type} action`, () => {
+      expect(isImplicitActionButton(action)).toBe(true);
+    });
   });
 });

--- a/frontend/src/metabase/writeback/utils.unit.spec.ts
+++ b/frontend/src/metabase/writeback/utils.unit.spec.ts
@@ -168,6 +168,7 @@ describe("isImplicitActionButton", () => {
       visualization_settings: {
         click_behavior: {
           type: "action",
+          // @ts-expect-error — testing unrecognized actionType
           actionType: "play-some-tunes",
           objectDetailDashCardId: 5,
         },


### PR DESCRIPTION
Closes #25329, part of #25020 epic

Implements FE support for implicit actions. Implicit actions let you insert new rows or update/delete existing ones with minimum setup. Scaffolded app pages come with implicit actions included by default with the "New" button on the list page, "Edit" and "Delete" inlined in the list view itself for every record, and "Edit" and "Delete" buttons on the detail page.

Implicit actions are intended to be agnostic to schema changes. As a result, we're trying not to manipulate or persist any field references anywhere. Overall, implicit actions need a few inputs to work:

* know a table we're inserting to / updating / deleting from (need to pass it to the BE to build the query + needing table column metadata at run-time to generate a form for inserting/updating records)
* for inserts and deletes, we also need to know editable item PK values to identify the record when building a query
* for updates, we need editable row data so that we can prefill the editing form with it

Implicit actions are defined as button dashcard's `click_behavior`, although they don't reach the drill layer, and click handling is currently done locally inside the button component. They shape looks like that:

```js
// Insert
{
  type: "action",
  actionType: "insert",
  tableId: 1,
}

// Update
{
  type: "action",
  actionType: "update",
  objectDetailDashCardId 1,
}

// Delete
{
  type: "action",
  actionType: "delete",
  objectDetailDashCardId 1,
}
```

Using `objectDetailDashCardId` is not ideal long-term, but should work fine for now. We considered attaching a query to the button or mapping dashboard ID parameters to the button dash card, but it breaks the schema-change agnostic promise as we need PK field references to pop in at some point. It seems we'd be able to achieve full implicitness once we also introduce implicit data views and parameters. But for now the proposal is to stick with `objectDetailDashCardId`

### Things to keep in mind

1. Implicit delete doesn't perform a cascade delete. If you try to delete a record and another record is linked to it via a foreign key, it's going to fail. We'd need to decide how we want to handle it eventually (optional cascade deletes / show linked records that would also be deleted / just a human-friendly error message)
2. For now we don't have a way to do something once an action is performed. For instance, after deleting a record, it'd make sense to go back to the list

### To Verify

1. New > App > Select a database > Save
2. Click the "New" button above the list view, fill in the form and click "Create"
3. Ensure a new record was created (you can add a dashboard filter to search for an item by name or something to make this easier)
4. Go to a detail view (at this point, the easiest way is to select it from the app nav sidebar and fill in a row ID manually. #25366 should let you click the list item and jump to its details page right away)
5. Click "Edit", change something about an item, and click "Save"
6. Ensure the changes are immediately visible in the detail view card
7. Click "Delete", ensure there's a confirmation message that makes sense, click "Delete"
8. Ensure the item is gone. If you hit an error, check out item 1 from "Things to keep in mind" above


### Demo

https://user-images.githubusercontent.com/17258145/189955806-d1108ffa-422a-4dff-9f5d-0221714c0e8c.mp4

