### PR TITLE
Refactor debug query processor output

### DIFF
--- a/dev/src/dev/debug_qp.clj
+++ b/dev/src/dev/debug_qp.clj
@@ -193,6 +193,67 @@
                                        :class-name      nil}}))
   (println))
 
+(defmulti print-formatted-event
+  "Writes the debugger event to the standard output. Uses colors and
+  deep diffing to show changes made by middlewares.
+
+  This is the default printer of `process-query-debug`."
+  first)
+
+(defmethod print-formatted-event ::transformed-query
+  [[_ middleware-var before after]]
+  (println (format "[pre] %s transformed query:" middleware-var))
+  (when *print-full?*
+    (println (u/pprint-to-str 'cyan (format-output after))))
+  (print-diff before after))
+
+(defmethod print-formatted-event ::pre-process-query-error
+  [[_ middleware-var e]]
+  (println (format "Error pre-processing query in %s:\n%s"
+                   middleware-var
+                   (u/pprint-to-str 'red (Throwable->map e)))))
+
+(defmethod print-formatted-event ::transformed-metadata
+  [[_ middleware-var before after]]
+  (println (format "[post] %s transformed metadata:" middleware-var))
+  (when *print-full?*
+    (println (u/pprint-to-str 'cyan (format-output after))))
+  (print-diff before after))
+
+(defmethod print-formatted-event ::post-process-metadata-error
+  [[_ middleware-var e]]
+  (println (format "Error post-processing result metadata in %s:\n%s"
+                   middleware-var
+                   (u/pprint-to-str 'red (Throwable->map e)))))
+
+(defmethod print-formatted-event ::post-process-result-error
+  [[_ middleware-var e]]
+  (println (format "Error post-processing result in %s:\n%s"
+                   middleware-var
+                   (u/pprint-to-str 'red (Throwable->map e)))))
+
+(defmethod print-formatted-event ::transformed-result
+  [[_ middleware-var before after]]
+  (println (format "[post] %s transformed result:" middleware-var))
+  (when *print-full?*
+    (println (u/pprint-to-str 'cyan (format-output after))))
+  (print-diff before after))
+
+(defmethod print-formatted-event ::error-reduce-row
+  [[_ middleware-var e]]
+  (println (format "Error reducing row in %s:\n%s"
+                   middleware-var
+                   (u/pprint-to-str 'red (Throwable->map e)))))
+
+(defmethod print-formatted-event ::transformed-row
+  [[_ middleware-var before after]]
+  (println (format "[post] %s transformed row" middleware-var))
+  (when *print-full?*
+    (println (u/pprint-to-str 'cyan (format-output after))))
+  (print-diff before after))
+
+(def ^:private ^:dynamic *printer* print-formatted-event)
+
 (defn- debug-query-changes [middleware-var middleware]
   (fn [next-middleware]
     (fn [query-before rff context]
@@ -200,8 +261,7 @@
         ((middleware
           (fn [query-after rff context]
             (when-not (= query-before query-after)
-              (println (format "[pre] %s transformed query:" middleware-var))
-              (print-diff query-before query-after))
+              (*printer* [::transformed-query middleware-var query-before query-after]))
             (when *validate-query?*
               (try
                 (mbql.s/validate-query query-after)
@@ -219,9 +279,7 @@
         (catch Throwable e
           (when (::our-error? (ex-data e))
             (throw e))
-          (println (format "Error pre-processing query in %s:\n%s"
-                           middleware-var
-                           (u/pprint-to-str 'red (Throwable->map e))))
+          (*printer* [::pre-process-query-error middleware-var e])
           (throw (ex-info "Error pre-processing query"
                           {::our-error? true
                            :middleware  middleware-var
@@ -249,9 +307,7 @@
            (catch Throwable e
              (when (::our-error? (ex-data e))
                (throw e))
-             (println (format "Error post-processing result metadata in %s:\n%s"
-                              middleware-var
-                              (u/pprint-to-str 'red (Throwable->map e))))
+             (*printer* [::post-process-metadata-error middleware-var e])
              (throw (ex-info "Error post-processing result metadata"
                              {::our-error? true
                               :middleware  middleware-var
@@ -260,8 +316,7 @@
      (fn after-rff-xform [rff]
        (fn [metadata-after]
          (when-not (= @before metadata-after)
-           (println (format "[post] %s transformed metadata:" middleware-var))
-           (print-diff @before metadata-after))
+           (*printer* [::transformed-metadata middleware-var @before metadata-after]))
          (rff metadata-after))))))
 
 (defn- debug-rfs [middleware-var middleware before-xform after-xform]
@@ -292,9 +347,7 @@
             (catch Throwable e
               (when (::our-error? (ex-data e))
                 (throw e))
-              (println (format "Error post-processing result in %s:\n%s"
-                               middleware-var
-                               (u/pprint-to-str 'red (Throwable->map e))))
+              (*printer* [::post-process-result-error middleware-var e])
               (throw (ex-info "Error post-processing result"
                               {::our-error? true
                                :middleware  middleware-var
@@ -306,8 +359,7 @@
          ([] (rf))
          ([result]
           (when-not (= @before result)
-            (println (format "[post] %s transformed result:" middleware-var))
-            (print-diff @before result))
+            (*printer* [::transformed-result middleware @before result]))
           (rf result))
          ([result row] (rf result row)))))))
 
@@ -328,9 +380,7 @@
             (catch Throwable e
               (when (::our-error? (ex-data e))
                 (throw e))
-              (println (format "Error reducing row in %s:\n%s"
-                               middleware-var
-                               (u/pprint-to-str 'red (Throwable->map e))))
+              (*printer* [::error-reduce-row middleware-var e])
               (throw (ex-info "Error reducing row"
                               {::our-error? true
                                :middleware  middleware-var
@@ -344,8 +394,7 @@
           (rf result))
          ([result row]
           (when-not (= @before row)
-            (println (format "[post] %s transformed row" middleware-var))
-            (print-diff @before row))
+            (*printer* [::transformed-row @before row]))
           (rf result row)))))))
 
 (defn- default-debug-middleware
@@ -432,13 +481,17 @@
 
   * `:validate-query?` -- whether to validate the query after each preprocessing step, so you can figure out who's
     breaking it. (TODO -- `mbql-to-native` middleware currently leaves the old mbql `:query` in place,
-    which cases query to fail at that point -- manually comment that behavior out if needed"
-  [query & {:keys [print-full? print-metadata? print-names? validate-query? context]
-            :or   {print-full? true, print-metadata? false, print-names? true, validate-query? false}}]
+    which cases query to fail at that point -- manually comment that behavior out if needed
+
+  * :printer -- the function to process the debug events, defaults to `print-formatted-event`"
+  [query & {:keys [print-full? print-metadata? print-names? validate-query? printer context]
+            :or   {print-full? true, print-metadata? false, print-names? true, validate-query? false
+                   printer print-formatted-event}}]
   (binding [*print-full?*               print-full?
             *print-metadata?*           print-metadata?
             *print-names?*              print-names?
             *validate-query?*           validate-query?
+            *printer*                   printer
             pprint/*print-right-margin* 80]
     (with-altered-middleware
       (let [middleware (for [middleware-var (default-debug-middleware)

--- a/dev/src/dev/debug_qp.clj
+++ b/dev/src/dev/debug_qp.clj
@@ -193,6 +193,17 @@
                                        :class-name      nil}}))
   (println))
 
+(defn- print-transform-result [before after]
+  (when *print-full?*
+    (println (u/pprint-to-str 'cyan (format-output after))))
+  (print-diff before after))
+
+(defn- print-error [location middleware-var e]
+  (println (format "Error %s in %s:\n%s"
+                   location
+                   middleware-var
+                   (u/pprint-to-str 'red (Throwable->map e)))))
+
 (defmulti print-formatted-event
   "Writes the debugger event to the standard output. Uses colors and
   deep diffing to show changes made by middlewares.
@@ -203,54 +214,38 @@
 (defmethod print-formatted-event ::transformed-query
   [[_ middleware-var before after]]
   (println (format "[pre] %s transformed query:" middleware-var))
-  (when *print-full?*
-    (println (u/pprint-to-str 'cyan (format-output after))))
-  (print-diff before after))
+  (print-transform-result before after))
 
 (defmethod print-formatted-event ::pre-process-query-error
   [[_ middleware-var e]]
-  (println (format "Error pre-processing query in %s:\n%s"
-                   middleware-var
-                   (u/pprint-to-str 'red (Throwable->map e)))))
+  (print-error "pre-processing query" middleware-var e))
 
 (defmethod print-formatted-event ::transformed-metadata
   [[_ middleware-var before after]]
   (println (format "[post] %s transformed metadata:" middleware-var))
-  (when *print-full?*
-    (println (u/pprint-to-str 'cyan (format-output after))))
-  (print-diff before after))
+  (print-transform-result before after))
 
 (defmethod print-formatted-event ::post-process-metadata-error
   [[_ middleware-var e]]
-  (println (format "Error post-processing result metadata in %s:\n%s"
-                   middleware-var
-                   (u/pprint-to-str 'red (Throwable->map e)))))
+  (print-error "post-processing result metadata" middleware-var e))
 
 (defmethod print-formatted-event ::post-process-result-error
   [[_ middleware-var e]]
-  (println (format "Error post-processing result in %s:\n%s"
-                   middleware-var
-                   (u/pprint-to-str 'red (Throwable->map e)))))
+  (print-error "post-processing result" middleware-var e))
 
 (defmethod print-formatted-event ::transformed-result
   [[_ middleware-var before after]]
   (println (format "[post] %s transformed result:" middleware-var))
-  (when *print-full?*
-    (println (u/pprint-to-str 'cyan (format-output after))))
-  (print-diff before after))
+  (print-transform-result before after))
 
 (defmethod print-formatted-event ::error-reduce-row
   [[_ middleware-var e]]
-  (println (format "Error reducing row in %s:\n%s"
-                   middleware-var
-                   (u/pprint-to-str 'red (Throwable->map e)))))
+  (print-error "reducing row" middleware-var e))
 
 (defmethod print-formatted-event ::transformed-row
   [[_ middleware-var before after]]
   (println (format "[post] %s transformed row" middleware-var))
-  (when *print-full?*
-    (println (u/pprint-to-str 'cyan (format-output after))))
-  (print-diff before after))
+  (print-transform-result before after))
 
 (def ^:private ^:dynamic *printer* print-formatted-event)
 


### PR DESCRIPTION
Generalize the processing of debug events in the debug query processor.

Currently, debug events include transformations made by middleware and
errors occurring during processing.

This change enables processing the events in differently from just printing,
one frequent use case being sending them to tap listeners. For this, `tap>`
can be provided as `:printer`. Together with #25377, this can be used to
display debug events in a portal browser.

With `dev.portal` loaded, `dev.debug-qp/process-query-debug` can be
made to log in portal:

```clojure
  (dev.debug-qp/process-query-debug
   (mt/mbql-query venues
     {:source-query {:source-table $$venues}
      :breakout     [[:field [:field "category_id" {:base-type :type/Integer}] nil]]
      :limit        10})
   :printer (fn [[_ middleware-var before after :as event]]
              (if (and (var? middleware-var) before after)
                (dev.portal/send-log
                 (with-meta [before after]
                   {:portal.viewer/default :portal.viewer/diff})
                 (update (meta middleware-var) :ns #(.name %)))
                (dev.portal/send-log event))))
```