### PR TITLE
Implement scaffolding new pages for existing apps

### DIFF
--- a/frontend/src/metabase-types/api/data-app.ts
+++ b/frontend/src/metabase-types/api/data-app.ts
@@ -2,11 +2,19 @@ import { Collection, RegularCollectionId } from "./collection";
 import { ClickBehavior } from "./click-behavior";
 import {
   BaseDashboardOrderedCard,
+  Dashboard,
   DashboardParameterMapping,
 } from "./dashboard";
 import { WritebackAction } from "./writeback";
 
 export type DataAppId = number;
+export type DataAppPageId = Dashboard["id"];
+
+export interface DataAppNavItem {
+  page_id: DataAppPageId;
+  indent?: number;
+  hidden?: boolean;
+}
 
 export interface DataApp {
   id: DataAppId;
@@ -16,7 +24,7 @@ export interface DataApp {
   collection: Collection;
 
   options: Record<string, unknown> | null;
-  nav_items: null;
+  nav_items: DataAppNavItem[];
 
   created_at: string;
   updated_at: string;

--- a/frontend/src/metabase-types/api/mocks/data-app.ts
+++ b/frontend/src/metabase-types/api/mocks/data-app.ts
@@ -16,7 +16,7 @@ export const createMockDataApp = ({
     id: 1,
     dashboard_id: null,
     options: null,
-    nav_items: null,
+    nav_items: [],
     created_at: new Date().toISOString(),
     updated_at: new Date().toISOString(),
     ...dataAppProps,

--- a/frontend/src/metabase/entities/data-apps/data-apps.ts
+++ b/frontend/src/metabase/entities/data-apps/data-apps.ts
@@ -25,7 +25,7 @@ type UpdateDataAppParams = Pick<DataApp, "id" | "collection_id"> & {
   collection: Pick<Collection, "name" | "description">;
 };
 
-export type ScaffoldAppParams = {
+export type ScaffoldNewAppParams = {
   name: EditableDataAppParams["name"];
   tables: number[]; // list of table IDs
 };
@@ -67,8 +67,8 @@ const DataApps = createEntity({
   },
 
   objectActions: {
-    scaffold: async ({ name, tables }: ScaffoldAppParams) => {
-      const dataApp = await DataAppsApi.scaffold({
+    scaffoldNewApp: async ({ name, tables }: ScaffoldNewAppParams) => {
+      const dataApp = await DataAppsApi.scaffoldNewApp({
         "app-name": name,
         "table-ids": tables,
       });

--- a/frontend/src/metabase/entities/data-apps/data-apps.ts
+++ b/frontend/src/metabase/entities/data-apps/data-apps.ts
@@ -30,6 +30,11 @@ export type ScaffoldNewAppParams = {
   tables: number[]; // list of table IDs
 };
 
+export type ScaffoldNewPagesParams = {
+  dataAppId: DataApp["id"];
+  tables: number[]; // list of table IDs
+};
+
 const DataApps = createEntity({
   name: "dataApps",
   nameOne: "dataApp",
@@ -74,6 +79,16 @@ const DataApps = createEntity({
       });
       return {
         type: DataApps.actionTypes.CREATE,
+        payload: DataApps.normalize(dataApp),
+      };
+    },
+    scaffoldNewPages: async ({ dataAppId, tables }: ScaffoldNewPagesParams) => {
+      const dataApp = await DataAppsApi.scaffoldNewPages({
+        id: dataAppId,
+        "table-ids": tables,
+      });
+      return {
+        type: DataApps.actionTypes.UPDATE,
         payload: DataApps.normalize(dataApp),
       };
     },

--- a/frontend/src/metabase/lib/urls/dataApps.ts
+++ b/frontend/src/metabase/lib/urls/dataApps.ts
@@ -1,6 +1,11 @@
 import slugg from "slugg";
 
-import type { DataApp, DataAppSearchItem, Dashboard } from "metabase-types/api";
+import type {
+  DataApp,
+  DataAppNavItem,
+  DataAppSearchItem,
+  Dashboard,
+} from "metabase-types/api";
 
 import { appendSlug } from "./utils";
 
@@ -35,8 +40,15 @@ export function dataApp(
   return appendSlug(`/a/${appId}`, slugg(appName));
 }
 
-export function dataAppPage(app: DataApp, page: Dashboard) {
-  return `/a/${app.id}/page/${page.id}`;
+function isNavItem(
+  object: Dashboard | DataAppNavItem,
+): object is DataAppNavItem {
+  return "page_id" in object;
+}
+
+export function dataAppPage(app: DataApp, object: Dashboard | DataAppNavItem) {
+  const pageId = isNavItem(object) ? object.page_id : object.id;
+  return `/a/${app.id}/page/${pageId}`;
 }
 
 export function isDataAppPreviewPath(pathname: string) {

--- a/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbar/DataAppActionPanel.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbar/DataAppActionPanel.tsx
@@ -28,7 +28,7 @@ function DataAppActionPanel({ dataApp, onNewPage, onEditAppSettings }: Props) {
     () => [
       {
         title: t`Page`,
-        icon: "document",
+        icon: "pencil",
         action: onNewPage,
       },
     ],

--- a/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbar/DataAppActionPanel.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbar/DataAppActionPanel.tsx
@@ -1,8 +1,8 @@
-import React from "react";
+import React, { useMemo } from "react";
 import _ from "underscore";
 import { t } from "ttag";
 
-import ButtonGroup from "metabase/core/components/ButtonGroup";
+import EntityMenu from "metabase/components/EntityMenu";
 import Link from "metabase/core/components/Link";
 import Tooltip from "metabase/components/Tooltip";
 
@@ -11,6 +11,7 @@ import * as Urls from "metabase/lib/urls";
 import type { DataApp } from "metabase-types/api";
 
 import {
+  ActionGroup,
   DataAppActionsContainer,
   DataAppActionButton,
   ExitDataAppButton,
@@ -23,20 +24,36 @@ interface Props {
 }
 
 function DataAppActionPanel({ dataApp, onNewPage, onEditAppSettings }: Props) {
+  const addMenuItems = useMemo(
+    () => [
+      {
+        title: t`Page`,
+        icon: "document",
+        action: onNewPage,
+      },
+    ],
+    [onNewPage],
+  );
+
   return (
     <DataAppActionsContainer>
-      <ButtonGroup>
-        <Tooltip tooltip={t`Add`}>
-          <DataAppActionButton icon="add" onClick={onNewPage} onlyIcon />
-        </Tooltip>
-        <Tooltip tooltip={t`Settings`}>
-          <DataAppActionButton
-            icon="gear"
-            onClick={onEditAppSettings}
-            onlyIcon
+      <ActionGroup>
+        <ActionGroup.Cell>
+          <EntityMenu
+            items={addMenuItems}
+            trigger={
+              <Tooltip tooltip={t`Add`}>
+                <DataAppActionButton icon="add" />
+              </Tooltip>
+            }
           />
-        </Tooltip>
-      </ButtonGroup>
+        </ActionGroup.Cell>
+        <ActionGroup.Cell>
+          <Tooltip tooltip={t`Settings`}>
+            <DataAppActionButton icon="gear" />
+          </Tooltip>
+        </ActionGroup.Cell>
+      </ActionGroup>
       <ExitDataAppButton
         as={Link}
         to={Urls.dataApp(dataApp, { mode: "preview" })}

--- a/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbar/DataAppActionPanel.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbar/DataAppActionPanel.tsx
@@ -27,6 +27,11 @@ function DataAppActionPanel({ dataApp, onNewPage, onEditAppSettings }: Props) {
   const addMenuItems = useMemo(
     () => [
       {
+        title: t`Data`,
+        icon: "database",
+        action: onNewPage,
+      },
+      {
         title: t`Page`,
         icon: "pencil",
         action: onNewPage,

--- a/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbar/DataAppActionPanel.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbar/DataAppActionPanel.tsx
@@ -50,7 +50,7 @@ function DataAppActionPanel({ dataApp, onNewPage, onEditAppSettings }: Props) {
         </ActionGroup.Cell>
         <ActionGroup.Cell>
           <Tooltip tooltip={t`Settings`}>
-            <DataAppActionButton icon="gear" />
+            <DataAppActionButton icon="gear" onClick={onEditAppSettings} />
           </Tooltip>
         </ActionGroup.Cell>
       </ActionGroup>

--- a/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbar/DataAppActionPanel.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbar/DataAppActionPanel.tsx
@@ -18,15 +18,16 @@ import {
 
 interface Props {
   dataApp: DataApp;
+  onNewPage: () => void;
   onEditAppSettings: () => void;
 }
 
-function DataAppActionPanel({ dataApp, onEditAppSettings }: Props) {
+function DataAppActionPanel({ dataApp, onNewPage, onEditAppSettings }: Props) {
   return (
     <DataAppActionsContainer>
       <ButtonGroup>
         <Tooltip tooltip={t`Add`}>
-          <DataAppActionButton icon="add" onlyIcon />
+          <DataAppActionButton icon="add" onClick={onNewPage} onlyIcon />
         </Tooltip>
         <Tooltip tooltip={t`Settings`}>
           <DataAppActionButton

--- a/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbar/DataAppActionPanel.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbar/DataAppActionPanel.tsx
@@ -19,17 +19,23 @@ import {
 
 interface Props {
   dataApp: DataApp;
+  onAddData: () => void;
   onNewPage: () => void;
   onEditAppSettings: () => void;
 }
 
-function DataAppActionPanel({ dataApp, onNewPage, onEditAppSettings }: Props) {
+function DataAppActionPanel({
+  dataApp,
+  onAddData,
+  onNewPage,
+  onEditAppSettings,
+}: Props) {
   const addMenuItems = useMemo(
     () => [
       {
         title: t`Data`,
         icon: "database",
-        action: onNewPage,
+        action: onAddData,
       },
       {
         title: t`Page`,
@@ -37,7 +43,7 @@ function DataAppActionPanel({ dataApp, onNewPage, onEditAppSettings }: Props) {
         action: onNewPage,
       },
     ],
-    [onNewPage],
+    [onAddData, onNewPage],
   );
 
   return (

--- a/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbar/DataAppNavbarContainer.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbar/DataAppNavbarContainer.tsx
@@ -10,6 +10,8 @@ import DataApps, { getDataAppHomePageId } from "metabase/entities/data-apps";
 import Dashboards from "metabase/entities/dashboards";
 import Search from "metabase/entities/search";
 
+import ScaffoldDataAppPagesModal from "metabase/writeback/containers/ScaffoldDataAppPagesModal";
+
 import type { DataApp, Dashboard } from "metabase-types/api";
 import type { State } from "metabase-types/store";
 
@@ -26,7 +28,11 @@ function isAtDataAppHomePage(selectedItems: SelectedItem[]) {
   return selectedItems.length === 1 && selectedItem.type === "data-app";
 }
 
-type NavbarModal = "MODAL_APP_SETTINGS" | "MODAL_NEW_PAGE" | null;
+type NavbarModal =
+  | "MODAL_ADD_DATA"
+  | "MODAL_APP_SETTINGS"
+  | "MODAL_NEW_PAGE"
+  | null;
 
 interface DataAppNavbarContainerProps extends MainNavbarProps {
   dataApp: DataApp;
@@ -42,15 +48,17 @@ type DataAppNavbarContainerLoaderProps = DataAppNavbarContainerProps & {
 type SearchRenderProps = {
   list: any[];
   loading: boolean;
+  reload: () => Promise<void>;
 };
 
 function DataAppNavbarContainer({
   dataApp,
   pages,
   selectedItems,
+  onReloadNavbar,
   onChangeLocation,
   ...props
-}: DataAppNavbarContainerProps) {
+}: DataAppNavbarContainerProps & { onReloadNavbar: () => Promise<void> }) {
   const [modal, setModal] = useState<NavbarModal>(null);
 
   const finalSelectedItems: SelectedItem[] = useMemo(() => {
@@ -72,6 +80,29 @@ function DataAppNavbarContainer({
     return selectedItems;
   }, [dataApp, pages, selectedItems]);
 
+  const handleNewDataAdded = useCallback(
+    async (nextDataAppState: DataApp) => {
+      // refresh navbar content to show scaffolded pages
+      await onReloadNavbar();
+
+      // New pages are added to the end of data app's nav_items list,
+      // so 1st non-hidden page from the end is a good candidate to navigate to
+      const reversedNavItems = nextDataAppState.nav_items.reverse();
+      const newPageNavItem = reversedNavItems.find(
+        navItem => typeof navItem.page_id === "number" && !navItem.hidden,
+      );
+
+      if (newPageNavItem) {
+        onChangeLocation(Urls.dataAppPage(nextDataAppState, newPageNavItem));
+      }
+    },
+    [onReloadNavbar, onChangeLocation],
+  );
+
+  const onAddData = useCallback(() => {
+    setModal("MODAL_ADD_DATA");
+  }, []);
+
   const onEditAppSettings = useCallback(() => {
     setModal("MODAL_APP_SETTINGS");
   }, []);
@@ -79,10 +110,18 @@ function DataAppNavbarContainer({
   const onNewPage = useCallback(() => {
     setModal("MODAL_NEW_PAGE");
   }, []);
-
   const closeModal = useCallback(() => setModal(null), []);
 
   const renderModalContent = useCallback(() => {
+    if (modal === "MODAL_ADD_DATA") {
+      return (
+        <ScaffoldDataAppPagesModal
+          dataAppId={dataApp.id}
+          onAdd={handleNewDataAdded}
+          onClose={closeModal}
+        />
+      );
+    }
     if (modal === "MODAL_APP_SETTINGS") {
       return (
         <DataApps.ModalForm
@@ -112,7 +151,7 @@ function DataAppNavbarContainer({
       );
     }
     return null;
-  }, [dataApp, modal, closeModal, onChangeLocation]);
+  }, [dataApp, modal, handleNewDataAdded, closeModal, onChangeLocation]);
 
   return (
     <>
@@ -121,6 +160,7 @@ function DataAppNavbarContainer({
         dataApp={dataApp}
         pages={pages}
         selectedItems={finalSelectedItems}
+        onAddData={onAddData}
         onNewPage={onNewPage}
         onEditAppSettings={onEditAppSettings}
       />
@@ -144,14 +184,27 @@ function DataAppNavbarContainerLoader({
         models: FETCHING_SEARCH_MODELS,
         limit: LIMIT,
       }}
+      keepListWhileLoading
       loadingAndErrorWrapper={false}
     >
-      {({ list = [], loading: loadingAppContent }: SearchRenderProps) => {
-        if (loadingAppContent) {
+      {({
+        list = [],
+        loading: loadingAppContent,
+        reload,
+      }: SearchRenderProps) => {
+        // It's possible to appear in loading state with some data available
+        // This happens when we need to refresh navbar content
+        // This makes it show the previous state while loading to avoid flickering
+        if (loadingAppContent && list.length === 0) {
           return <NavbarLoadingView />;
         }
         return (
-          <DataAppNavbarContainer {...props} dataApp={dataApp} pages={list} />
+          <DataAppNavbarContainer
+            {...props}
+            dataApp={dataApp}
+            pages={list}
+            onReloadNavbar={reload}
+          />
         );
       }}
     </Search.ListLoader>

--- a/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbar/DataAppNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbar/DataAppNavbarView.tsx
@@ -20,6 +20,7 @@ interface Props extends MainNavbarProps {
   pages: any[];
   selectedItems: SelectedItem[];
   onEditAppSettings: () => void;
+  onAddData: () => void;
   onNewPage: () => void;
 }
 
@@ -28,6 +29,7 @@ function DataAppNavbarView({
   pages,
   selectedItems,
   onEditAppSettings,
+  onAddData,
   onNewPage,
 }: Props) {
   const { "data-app-page": dataAppPage } = _.indexBy(
@@ -55,6 +57,7 @@ function DataAppNavbarView({
       </SidebarSection>
       <DataAppActionPanel
         dataApp={dataApp}
+        onAddData={onAddData}
         onNewPage={onNewPage}
         onEditAppSettings={onEditAppSettings}
       />

--- a/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbar/DataAppNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbar/DataAppNavbarView.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import _ from "underscore";
-import { t } from "ttag";
 
 import * as Urls from "metabase/lib/urls";
 
@@ -8,7 +7,6 @@ import type { DataApp } from "metabase-types/api";
 
 import { MainNavbarProps, SelectedItem } from "../types";
 import {
-  DataAppNewButton,
   PaddedSidebarLink,
   SidebarContentRoot,
   SidebarHeading,
@@ -39,32 +37,25 @@ function DataAppNavbarView({
 
   return (
     <SidebarContentRoot>
-      <div>
-        <SidebarSection>
-          <SidebarHeadingWrapper>
-            <SidebarHeading>{dataApp.collection.name}</SidebarHeading>
-          </SidebarHeadingWrapper>
-          <ul>
-            {pages.map(page => (
-              <PaddedSidebarLink
-                key={page.id}
-                url={Urls.dataAppPage(dataApp, page)}
-                isSelected={dataAppPage?.id === page.id}
-              >
-                {page.name}
-              </PaddedSidebarLink>
-            ))}
-          </ul>
-        </SidebarSection>
-        <div>
-          <DataAppNewButton
-            icon="add"
-            onClick={onNewPage}
-          >{t`Add new page`}</DataAppNewButton>
-        </div>
-      </div>
+      <SidebarSection>
+        <SidebarHeadingWrapper>
+          <SidebarHeading>{dataApp.collection.name}</SidebarHeading>
+        </SidebarHeadingWrapper>
+        <ul>
+          {pages.map(page => (
+            <PaddedSidebarLink
+              key={page.id}
+              url={Urls.dataAppPage(dataApp, page)}
+              isSelected={dataAppPage?.id === page.id}
+            >
+              {page.name}
+            </PaddedSidebarLink>
+          ))}
+        </ul>
+      </SidebarSection>
       <DataAppActionPanel
         dataApp={dataApp}
+        onNewPage={onNewPage}
         onEditAppSettings={onEditAppSettings}
       />
     </SidebarContentRoot>

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.styled.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.styled.tsx
@@ -171,3 +171,29 @@ export const DataAppActionButton = styled(Button)`
     }
   }
 `;
+
+const ActionGroupCell = styled.div``;
+
+const _ActionGroup = styled.div`
+  display: flex;
+
+  ${ActionGroupCell} {
+    border: 1px solid ${color("border")};
+
+    &:not(:last-of-type) {
+      border-right-width: 0.5px;
+      border-top-left-radius: 8px;
+      border-bottom-left-radius: 8px;
+    }
+
+    &:not(:first-of-type) {
+      border-left-width: 0.5px;
+      border-top-right-radius: 8px;
+      border-bottom-right-radius: 8px;
+    }
+  }
+`;
+
+export const ActionGroup = Object.assign(_ActionGroup, {
+  Cell: ActionGroupCell,
+});

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.styled.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.styled.tsx
@@ -171,21 +171,3 @@ export const DataAppActionButton = styled(Button)`
     }
   }
 `;
-
-export const DataAppNewButton = styled(Button)`
-  color: ${color("brand")};
-  margin-left: 1rem;
-  padding: 0.5rem 0.5rem;
-
-  &:hover {
-    color: ${color("brand")};
-  }
-
-  .Icon {
-    color: ${color("brand")};
-  }
-`;
-
-DataAppNewButton.defaultProps = {
-  borderless: true,
-};

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.styled.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.styled.tsx
@@ -172,6 +172,10 @@ export const DataAppActionButton = styled(Button)`
   }
 `;
 
+DataAppActionButton.defaultProps = {
+  onlyIcon: true,
+};
+
 const ActionGroupCell = styled.div``;
 
 const _ActionGroup = styled.div`

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -183,8 +183,9 @@ export const CollectionsApi = {
 export const DataAppsApi = {
   list: GET("/api/app"),
   create: POST("/api/app"),
-  scaffold: POST("/api/app/scaffold"),
   update: PUT("/api/app/:id"),
+
+  scaffoldNewApp: POST("/api/app/scaffold"),
 };
 
 const PIVOT_PUBLIC_PREFIX = "/api/public/pivot/";

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -186,6 +186,7 @@ export const DataAppsApi = {
   update: PUT("/api/app/:id"),
 
   scaffoldNewApp: POST("/api/app/scaffold"),
+  scaffoldNewPages: POST("/api/app/:id/scaffold"),
 };
 
 const PIVOT_PUBLIC_PREFIX = "/api/public/pivot/";

--- a/frontend/src/metabase/writeback/components/DataAppDataPicker/DataAppDataPicker.tsx
+++ b/frontend/src/metabase/writeback/components/DataAppDataPicker/DataAppDataPicker.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+
+import { DatabaseSchemaAndTableDataSelector } from "metabase/query_builder/components/DataSelector";
+
+import type { TableId } from "metabase-types/api";
+
+interface Props {
+  tableId: TableId | null;
+  onTableChange: (tableId: TableId | null) => void;
+}
+
+function DataAppDataPicker({ tableId, onTableChange }: Props) {
+  return (
+    <DatabaseSchemaAndTableDataSelector
+      selectedTableId={tableId}
+      setSourceTableFn={onTableChange}
+      requireWriteback
+      isPopover={false}
+    />
+  );
+}
+
+export default DataAppDataPicker;

--- a/frontend/src/metabase/writeback/components/DataAppDataPicker/index.ts
+++ b/frontend/src/metabase/writeback/components/DataAppDataPicker/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DataAppDataPicker";

--- a/frontend/src/metabase/writeback/containers/CreateDataAppModal/CreateDataAppModal.tsx
+++ b/frontend/src/metabase/writeback/containers/CreateDataAppModal/CreateDataAppModal.tsx
@@ -8,7 +8,7 @@ import Button from "metabase/core/components/Button";
 
 import * as Urls from "metabase/lib/urls";
 
-import DataApps, { ScaffoldAppParams } from "metabase/entities/data-apps";
+import DataApps, { ScaffoldNewAppParams } from "metabase/entities/data-apps";
 
 import DataAppDataPicker from "metabase/writeback/components/DataAppDataPicker";
 
@@ -28,7 +28,7 @@ interface OwnProps {
 }
 
 interface DispatchProps {
-  onCreate: (params: ScaffoldAppParams) => Promise<DataApp>;
+  onCreate: (params: ScaffoldNewAppParams) => Promise<DataApp>;
   onChangeLocation: (location: LocationDescriptor) => void;
 }
 
@@ -36,8 +36,10 @@ type Props = OwnProps & DispatchProps;
 
 function mapDispatchToProps(dispatch: Dispatch) {
   return {
-    onCreate: async (params: ScaffoldAppParams) => {
-      const action = await dispatch(DataApps.objectActions.scaffold(params));
+    onCreate: async (params: ScaffoldNewAppParams) => {
+      const action = await dispatch(
+        DataApps.objectActions.scaffoldNewApp(params),
+      );
       return DataApps.HACK_getObjectFromAction(action);
     },
     onChangeLocation: (location: LocationDescriptor) =>

--- a/frontend/src/metabase/writeback/containers/CreateDataAppModal/CreateDataAppModal.tsx
+++ b/frontend/src/metabase/writeback/containers/CreateDataAppModal/CreateDataAppModal.tsx
@@ -9,9 +9,10 @@ import Button from "metabase/core/components/Button";
 import * as Urls from "metabase/lib/urls";
 
 import DataApps, { ScaffoldAppParams } from "metabase/entities/data-apps";
-import { DatabaseSchemaAndTableDataSelector } from "metabase/query_builder/components/DataSelector";
 
-import type { DataApp } from "metabase-types/api";
+import DataAppDataPicker from "metabase/writeback/components/DataAppDataPicker";
+
+import type { DataApp, TableId } from "metabase-types/api";
 import type { Dispatch, State } from "metabase-types/store";
 
 import {
@@ -45,7 +46,7 @@ function mapDispatchToProps(dispatch: Dispatch) {
 }
 
 function CreateDataAppModal({ onCreate, onChangeLocation, onClose }: Props) {
-  const [tableId, setTableId] = useState<number | null>(null);
+  const [tableId, setTableId] = useState<TableId | null>(null);
 
   const handleCreate = useCallback(async () => {
     const dataApp = await onCreate({
@@ -62,12 +63,7 @@ function CreateDataAppModal({ onCreate, onChangeLocation, onClose }: Props) {
         <ModalTitle>{t`Pick your starting data`}</ModalTitle>
       </ModalHeader>
       <ModalBody>
-        <DatabaseSchemaAndTableDataSelector
-          selectedTableId={tableId}
-          setSourceTableFn={setTableId}
-          requireWriteback
-          isPopover={false}
-        />
+        <DataAppDataPicker tableId={tableId} onTableChange={setTableId} />
       </ModalBody>
       <ModalFooter>
         <Button onClick={onClose}>{t`Cancel`}</Button>

--- a/frontend/src/metabase/writeback/containers/ScaffoldDataAppPagesModal/ScaffoldDataAppPagesModal.styled.tsx
+++ b/frontend/src/metabase/writeback/containers/ScaffoldDataAppPagesModal/ScaffoldDataAppPagesModal.styled.tsx
@@ -1,0 +1,40 @@
+import styled from "@emotion/styled";
+import { color } from "metabase/lib/colors";
+
+export const ModalRoot = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex: 1 0 auto;
+  min-height: 50vh;
+`;
+
+export const ModalHeader = styled.div`
+  display: flex;
+  align-items: center;
+  padding: 1.5rem 2rem;
+`;
+
+export const ModalTitle = styled.div`
+  flex: 1 1 auto;
+  color: ${color("text-dark")};
+  font-size: 1.25rem;
+  line-height: 1.5rem;
+  font-weight: bold;
+`;
+
+export const ModalBody = styled.div`
+  display: flex;
+  flex: 1;
+
+  padding: 0 1rem 1rem 1rem;
+`;
+
+export const ModalFooter = styled.div`
+  display: flex;
+  justify-content: flex-end;
+
+  gap: 1rem;
+  padding: 1.5rem 2rem;
+
+  border-top: 1px solid ${color("border")};
+`;

--- a/frontend/src/metabase/writeback/containers/ScaffoldDataAppPagesModal/ScaffoldDataAppPagesModal.tsx
+++ b/frontend/src/metabase/writeback/containers/ScaffoldDataAppPagesModal/ScaffoldDataAppPagesModal.tsx
@@ -1,0 +1,85 @@
+import React, { useCallback, useState } from "react";
+import { t } from "ttag";
+import { connect } from "react-redux";
+
+import Button from "metabase/core/components/Button";
+
+import DataApps, { ScaffoldNewPagesParams } from "metabase/entities/data-apps";
+
+import DataAppDataPicker from "metabase/writeback/components/DataAppDataPicker";
+
+import type { DataApp, TableId } from "metabase-types/api";
+import type { Dispatch, State } from "metabase-types/store";
+
+import {
+  ModalRoot,
+  ModalHeader,
+  ModalTitle,
+  ModalBody,
+  ModalFooter,
+} from "./ScaffoldDataAppPagesModal.styled";
+
+interface OwnProps {
+  dataAppId: DataApp["id"];
+  onAdd: (dataApp: DataApp) => void;
+  onClose: () => void;
+}
+
+interface DispatchProps {
+  onScaffold: (params: ScaffoldNewPagesParams) => Promise<DataApp>;
+}
+
+type Props = OwnProps & DispatchProps;
+
+function mapDispatchToProps(dispatch: Dispatch) {
+  return {
+    onScaffold: async (params: ScaffoldNewPagesParams) => {
+      const action = await dispatch(
+        DataApps.objectActions.scaffoldNewPages(params),
+      );
+      return DataApps.HACK_getObjectFromAction(action);
+    },
+  };
+}
+
+function ScaffoldDataAppPagesModal({
+  dataAppId,
+  onAdd,
+  onScaffold,
+  onClose,
+}: Props) {
+  const [tableId, setTableId] = useState<TableId | null>(null);
+
+  const handleAdd = useCallback(async () => {
+    const dataApp = await onScaffold({
+      dataAppId,
+      tables: [tableId] as number[],
+    });
+    onClose();
+    onAdd(dataApp);
+  }, [dataAppId, tableId, onAdd, onScaffold, onClose]);
+
+  return (
+    <ModalRoot>
+      <ModalHeader>
+        <ModalTitle>{t`Pick your data`}</ModalTitle>
+      </ModalHeader>
+      <ModalBody>
+        <DataAppDataPicker tableId={tableId} onTableChange={setTableId} />
+      </ModalBody>
+      <ModalFooter>
+        <Button onClick={onClose}>{t`Cancel`}</Button>
+        <Button
+          primary
+          disabled={tableId == null}
+          onClick={handleAdd}
+        >{t`Add`}</Button>
+      </ModalFooter>
+    </ModalRoot>
+  );
+}
+
+export default connect<unknown, DispatchProps, OwnProps, State>(
+  null,
+  mapDispatchToProps,
+)(ScaffoldDataAppPagesModal);

--- a/frontend/src/metabase/writeback/containers/ScaffoldDataAppPagesModal/index.ts
+++ b/frontend/src/metabase/writeback/containers/ScaffoldDataAppPagesModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ScaffoldDataAppPagesModal";


### PR DESCRIPTION
Earlier we introduced app scaffolding that lets you skip the boring manual work of building your apps from scratch. When scaffolding, you can select a database table your app will be about, and Metabase will bootstrap a basic List and Detail pages with basic actions.

Going forward, this PR adds a new "Add data" flow that lets you do exactly the same thing, but for existing apps to add new pages.

### To Verify

1. New > App > Pick a table > Create
2. Click the "+" button at the bottom of the app navbar
3. "Add data" > Pick another table > Add
4. Ensure you got List and Detail pages based on a new table added to your app

### Demo

https://user-images.githubusercontent.com/17258145/189984228-4977721c-3930-4c6d-ba65-5a99723b7f9d.mp4

