### PR TITLE
Action Creator: Input type and Saving bugfixes

### DIFF
--- a/frontend/src/metabase/entities/actions/utils.ts
+++ b/frontend/src/metabase/entities/actions/utils.ts
@@ -74,7 +74,9 @@ export const setTemplateTagTypesFromFieldSettings = (
       question = question.setQuery(
         (question.query() as NativeQuery).setTemplateTag(tag.name, {
           ...tag,
-          type: getTagTypeFromFieldSettings(fields[tag.id].fieldType),
+          type: getTagTypeFromFieldSettings(
+            fields[tag.id]?.fieldType ?? "string",
+          ),
         }),
       );
     });

--- a/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/FieldSettingsPopover.tsx
+++ b/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/FieldSettingsPopover.tsx
@@ -43,10 +43,13 @@ export function FormCreatorPopoverBody({
   fieldSettings: FieldSettings;
   onChange: (fieldSettings: FieldSettings) => void;
 }) {
+  const inputTypes = useMemo(getInputTypes, []);
+
   const handleUpdateFieldType = (newFieldType: FieldType) =>
     onChange({
       ...fieldSettings,
       fieldType: newFieldType,
+      inputType: inputTypes[newFieldType][0].value,
     });
 
   const handleUpdateInputType = (newInputType: InputType) =>

--- a/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/FieldSettingsPopover.unit.spec.tsx
+++ b/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/FieldSettingsPopover.unit.spec.tsx
@@ -42,6 +42,7 @@ describe("writeback > FormCreator > FieldSettingsPopover", () => {
     expect(changeSpy).toHaveBeenCalledWith({
       ...settings,
       fieldType: "date",
+      inputType: "date", // should set default input type for new field type
     });
   });
 


### PR DESCRIPTION
## Description

Two little action creator bugfixes here:

1. Automatically change input types when a user changes field types (otherwise you could end up with a "number" input for a "category" field type 🤮 ) Input types auto-select the first option when changing field types:

![changeInputTypeWithFieldType](https://user-images.githubusercontent.com/30528226/189994640-8151656d-088b-4b16-a1ae-81232c115ef1.gif)

2.  Fix a saving error when a user had not selected any field options for a given parameter

![Screen Shot 2022-09-13 at 1 42 53 PM](https://user-images.githubusercontent.com/30528226/189994820-1eeb51d0-b079-4aa1-8e87-c100e1e47024.png)

