### PR TITLE
Action Creator 7: Customize Placeholder text

### DIFF
--- a/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/FieldSettingsPopover.styled.tsx
+++ b/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/FieldSettingsPopover.styled.tsx
@@ -10,11 +10,11 @@ export const SettingsPopoverBody = styled.div`
 export const SectionLabel = styled.div`
   color: ${color("text-medium")};
   font-weight: bold;
+  padding-left: ${space(0)};
   margin-bottom: ${space(1)};
 `;
 
-export const FieldTypeWrapper = styled.div`
-  margin-bottom: ${space(2)};
-  padding-bottom: ${space(2)};
+export const Divider = styled.div`
   border-bottom: 1px solid ${color("border")};
+  margin: ${space(2)} 0;
 `;

--- a/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/FieldSettingsPopover.tsx
+++ b/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/FieldSettingsPopover.tsx
@@ -147,7 +147,12 @@ function PlaceholderInput({
   return (
     <div>
       <SectionLabel>{t`Placeholder text`}</SectionLabel>
-      <Input fullWidth value={value} onChange={e => onChange(e.target.value)} />
+      <Input
+        fullWidth
+        value={value}
+        onChange={e => onChange(e.target.value)}
+        data-testid="placeholder-input"
+      />
     </div>
   );
 }

--- a/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/FieldSettingsPopover.tsx
+++ b/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/FieldSettingsPopover.tsx
@@ -4,6 +4,7 @@ import { t } from "ttag";
 import TippyPopoverWithTrigger from "metabase/components/PopoverWithTrigger/TippyPopoverWithTrigger";
 import type { FieldSettings, FieldType, InputType } from "metabase-types/api";
 
+import Input from "metabase/core/components/Input";
 import Radio from "metabase/core/components/Radio";
 import Icon from "metabase/components/Icon";
 
@@ -11,7 +12,7 @@ import { getFieldTypes, getInputTypes } from "./constants";
 import {
   SettingsPopoverBody,
   SectionLabel,
-  FieldTypeWrapper,
+  Divider,
 } from "./FieldSettingsPopover.styled";
 
 export function FieldSettingsPopover({
@@ -58,17 +59,35 @@ export function FormCreatorPopoverBody({
       inputType: newInputType,
     });
 
+  const handleUpdatePlaceholder = (newPlaceholder: string) =>
+    onChange({
+      ...fieldSettings,
+      placeholder: newPlaceholder,
+    });
+
+  const hasPlaceholder =
+    fieldSettings.fieldType !== "date" &&
+    fieldSettings.inputType !== "inline-select";
+
   return (
     <SettingsPopoverBody data-testid="field-settings-popover">
       <FieldTypeSelect
         value={fieldSettings.fieldType}
         onChange={handleUpdateFieldType}
       />
+      <Divider />
       <InputTypeSelect
         value={fieldSettings.inputType}
         fieldType={fieldSettings.fieldType}
         onChange={handleUpdateInputType}
       />
+      <Divider />
+      {hasPlaceholder && (
+        <PlaceholderInput
+          value={fieldSettings.placeholder ?? ""}
+          onChange={handleUpdatePlaceholder}
+        />
+      )}
     </SettingsPopoverBody>
   );
 }
@@ -83,7 +102,7 @@ function FieldTypeSelect({
   const fieldTypes = useMemo(getFieldTypes, []);
 
   return (
-    <FieldTypeWrapper>
+    <div>
       <SectionLabel>{t`Field type`}</SectionLabel>
       <Radio
         variant="bubble"
@@ -91,7 +110,7 @@ function FieldTypeSelect({
         options={fieldTypes}
         onChange={onChange}
       />
-    </FieldTypeWrapper>
+    </div>
   );
 }
 
@@ -113,5 +132,22 @@ function InputTypeSelect({
       options={inputTypes[fieldType ?? "string"]}
       onChange={onChange}
     />
+  );
+}
+
+function PlaceholderInput({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (newPlaceholder: string) => void;
+}) {
+  const inputTypes = useMemo(getInputTypes, []);
+
+  return (
+    <div>
+      <SectionLabel>{t`Placeholder text`}</SectionLabel>
+      <Input fullWidth value={value} onChange={e => onChange(e.target.value)} />
+    </div>
   );
 }

--- a/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/FieldSettingsPopover.unit.spec.tsx
+++ b/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/FieldSettingsPopover.unit.spec.tsx
@@ -69,4 +69,26 @@ describe("writeback > FormCreator > FieldSettingsPopover", () => {
       inputType: "dropdown",
     });
   });
+
+  it("should fire onChange handler editing placeholder", async () => {
+    const changeSpy = jest.fn();
+    const settings = getDefaultFieldSettings();
+
+    render(
+      <FieldSettingsPopover fieldSettings={settings} onChange={changeSpy} />,
+    );
+
+    await userEvent.click(screen.getByLabelText("gear icon"));
+
+    expect(
+      await screen.findByTestId("field-settings-popover"),
+    ).toBeInTheDocument();
+
+    await userEvent.type(screen.getByTestId("placeholder-input"), "$");
+
+    expect(changeSpy).toHaveBeenLastCalledWith({
+      ...settings,
+      placeholder: "$",
+    });
+  });
 });


### PR DESCRIPTION
## Description

Allows customizing placeholder text for form fields that have placeholder text (not dates or radios).

## Screenshots

![Screen Shot 2022-09-13 at 3 21 41 PM](https://user-images.githubusercontent.com/30528226/190014538-cf2a683f-b0e2-4937-a125-14c087d99cf5.png)

![placeholderEdit](https://user-images.githubusercontent.com/30528226/190014674-44ab2e6a-bd5f-4cfa-9c02-c40e8634b220.gif)


In an app form modal:

![Screen Shot 2022-09-13 at 4 21 40 PM](https://user-images.githubusercontent.com/30528226/190019669-6fbe774c-ef3e-4592-958f-69d937186b89.png)



