### PR TITLE
Update strings in failing tests

### DIFF
--- a/frontend/test/metabase/scenarios/embedding/embedding-smoketests.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/embedding-smoketests.cy.spec.js
@@ -240,30 +240,26 @@ function assertLinkMatchesUrl(text, url) {
 
 function ensureEmbeddingIsDisabled() {
   // This is implicit assertion - it would've failed if embedding was enabled
-  cy.findByText(/Embed this (question|dashboard) in an application/).closest(
-    ".disabled",
-  );
+  cy.findByText(/Embed in your application/).closest(".disabled");
 
   // Let's make sure embedding stays disabled after we enable public sharing
   enableSharing();
 
-  cy.findByText(/Embed this (question|dashboard) in an application/).closest(
-    ".disabled",
-  );
+  cy.findByText(/Embed in your application/).closest(".disabled");
 }
 
 function visitAndEnableSharing(object) {
   if (object === "question") {
     visitQuestion("1");
     cy.icon("share").click();
-    cy.findByText(/Embed this (question|dashboard) in an application/).click();
+    cy.findByText(/Embed in your application/).click();
   }
 
   if (object === "dashboard") {
     visitDashboard(1);
 
     cy.icon("share").click();
-    cy.findByText(/Embed this (question|dashboard) in an application/).click();
+    cy.findByText(/Embed in your application/).click();
   }
 }
 

--- a/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
@@ -619,18 +619,14 @@ describe("scenarios > visualizations > pivot tables", () => {
 
         // Skipped to avoid flake
         it.skip("should display pivot table in an embed preview", () => {
-          cy.findByText(
-            /Embed this (question|dashboard) in an application/,
-          ).click();
+          cy.findByText(/Embed in your application/).click();
           // we use preview endpoints when MB is iframed in itself
           cy.findByText(test.subject);
           getIframeBody().within(assertOnPivotFields);
         });
 
         it("should display pivot table in an embed URL", () => {
-          cy.findByText(
-            /Embed this (question|dashboard) in an application/,
-          ).click();
+          cy.findByText(/Embed in your application/).click();
 
           cy.findByText("Publish").click();
 


### PR DESCRIPTION
In https://github.com/metabase/metabase/pull/25371 I updated a string that was used in a _lot_ of tests, but I missed these tests here because I didn't think to search for this kind of `(question|dashboard)` syntax.