### PR TITLE
Fix filter changes not updating the root query

### DIFF
--- a/frontend/src/metabase-lib/lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/lib/queries/StructuredQuery.ts
@@ -1471,8 +1471,7 @@ class StructuredQueryInner extends AtomicQuery {
    * Returns the "first" of the nested queries, or this query it not nested
    */
   rootQuery(): StructuredQuery {
-    const sourceQuery = this.sourceQuery();
-    return sourceQuery ? sourceQuery.rootQuery() : this;
+    return this;
   }
 
   /**
@@ -1741,6 +1740,10 @@ class NestedStructuredQuery extends StructuredQuery {
       datasetQuery,
       this._parent,
     );
+  }
+
+  rootQuery(): StructuredQuery {
+    return this.parentQuery().rootQuery();
   }
 
   parentQuery() {

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterModal/BulkFilterModal.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterModal/BulkFilterModal.tsx
@@ -63,20 +63,20 @@ const BulkFilterModal = ({
   );
 
   const handleAddFilter = useCallback((filter: Filter) => {
-    setQuery(filter.add());
+    setQuery(filter.add().rootQuery());
     setIsChanged(true);
   }, []);
 
   const handleChangeFilter = useCallback(
     (filter: Filter, newFilter: Filter) => {
-      setQuery(filter.replace(newFilter));
+      setQuery(filter.replace(newFilter).rootQuery());
       setIsChanged(true);
     },
     [],
   );
 
   const handleRemoveFilter = useCallback((filter: Filter) => {
-    setQuery(filter.remove());
+    setQuery(filter.remove().rootQuery());
     setIsChanged(true);
   }, []);
 

--- a/frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx
@@ -56,7 +56,9 @@ export default function QuestionFilters({
               key={index}
               triggerElement={
                 <FilterPill
-                  onRemove={() => filter.remove().update(null, { run: true })}
+                  onRemove={() =>
+                    filter.remove().rootQuery().update(null, { run: true })
+                  }
                 >
                   {filter.displayName()}
                 </FilterPill>
@@ -69,7 +71,7 @@ export default function QuestionFilters({
                 query={query}
                 filter={filter}
                 onChangeFilter={newFilter =>
-                  newFilter.replace().update(null, { run: true })
+                  newFilter.replace().rootQuery().update(null, { run: true })
                 }
                 className="scroll-y"
               />
@@ -124,7 +126,9 @@ export function FilterHeader({ question, expanded }) {
             key={index}
             triggerElement={
               <FilterPill
-                onRemove={() => filter.remove().update(null, { run: true })}
+                onRemove={() =>
+                  filter.remove().rootQuery().update(null, { run: true })
+                }
               >
                 {filter.displayName()}
               </FilterPill>
@@ -137,7 +141,7 @@ export function FilterHeader({ question, expanded }) {
               query={query}
               filter={filter}
               onChangeFilter={newFilter =>
-                newFilter.replace().update(null, { run: true })
+                newFilter.replace().rootQuery().update(null, { run: true })
               }
               className="scroll-y"
             />

--- a/frontend/test/metabase/scenarios/custom-column/custom-column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/custom-column/custom-column.cy.spec.js
@@ -322,7 +322,7 @@ describe("scenarios > question > custom column", () => {
     cy.findAllByText("57911");
   });
 
-  it.skip("should not be dropped if filter is changed after aggregation (metaabase#14193)", () => {
+  it("should not be dropped if filter is changed after aggregation (metaabase#14193)", () => {
     const CC_NAME = "Double the fun";
 
     cy.createQuestion(

--- a/frontend/test/metabase/scenarios/filters/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/filter.cy.spec.js
@@ -159,7 +159,7 @@ describe("scenarios > question > filter", () => {
     cy.findAllByText("Gizmo");
   });
 
-  it.skip("should not drop aggregated filters (metabase#11957)", () => {
+  it("should not drop aggregated filters (metabase#11957)", () => {
     const AGGREGATED_FILTER = "Count is less than or equal to 20";
 
     cy.createQuestion(


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/14193
Fixes https://github.com/metabase/metabase/issues/11957

The root issue is that `filter.query()` returns the query for that stage level, and not the root query.

How to test:
- Follow the steps from the referenced issues or 
- Run the unskipped cypress tests