### PR TITLE
LDAP setup improvements

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
@@ -5,7 +5,6 @@
             [metabase-enterprise.sso.integrations.sso-settings :as sso-settings]
             [metabase.config :as config]
             [metabase.http-client :as client]
-            [metabase.integrations.ldap :as ldap]
             [metabase.models.permissions-group :refer [PermissionsGroup]]
             [metabase.models.permissions-group-membership :refer [PermissionsGroupMembership]]
             [metabase.models.user :refer [User]]
@@ -27,7 +26,7 @@
 (use-fixtures :once (fixtures/initialize :test-users))
 
 (defn- disable-other-sso-types [thunk]
-  (mt/with-temporary-setting-values [ldap/ldap-enabled false
+  (mt/with-temporary-setting-values [ldap-enabled false
                                      jwt-enabled  false]
     (thunk)))
 

--- a/frontend/test/metabase/scenarios/admin/settings/sso/ldap.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/sso/ldap.cy.spec.js
@@ -49,7 +49,6 @@ describe("scenarios > admin > settings > SSO > LDAP", () => {
     cy.wait("@ldapUpdate").then(interception => {
       expect(interception.response.statusCode).to.eq(500);
     });
-    cy.button("Changes saved!");
   });
 
   it("should not reset previously populated fields when validation fails for just one of them (metabase#16226)", () => {

--- a/frontend/test/metabase/scenarios/admin/settings/sso/ldap.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/sso/ldap.cy.spec.js
@@ -47,7 +47,7 @@ describe("scenarios > admin > settings > SSO > LDAP", () => {
       .type("Smith");
     cy.button("Save changes").click();
     cy.wait("@ldapUpdate").then(interception => {
-      expect(interception.response.statusCode).to.eq(200);
+      expect(interception.response.statusCode).to.eq(500);
     });
     cy.button("Changes saved!");
   });

--- a/src/metabase/api/ldap.clj
+++ b/src/metabase/api/ldap.clj
@@ -8,8 +8,7 @@
             [metabase.integrations.ldap :as ldap]
             [metabase.models.setting :as setting :refer [defsetting]]
             [metabase.util.i18n :refer [deferred-tru tru]]
-            [metabase.util.schema :as su]
-            [toucan.db :as db]))
+            [metabase.util.schema :as su]))
 
 (defn- humanize-error-messages
   "Convert raw error message responses from our LDAP tests into our normal api error response structure."

--- a/src/metabase/api/ldap.clj
+++ b/src/metabase/api/ldap.clj
@@ -91,7 +91,7 @@
                       (when-not (= :SUCCESS (:status result))
                         (throw (ex-info (tru "Unable to connect to LDAP server with current settings")
                                         (humanize-error-messages result))))))
-                  (setting/set! :ldap-enabled? new-value)))
+                  (setting/set! :ldap-enabled new-value)))
   :default    false)
 
 (defn- update-password-if-needed
@@ -114,7 +114,6 @@
                           (update :ldap-password update-password-if-needed))
         ldap-details  (set/rename-keys ldap-settings ldap/mb-settings->ldap-details)
         results       (ldap/test-ldap-connection ldap-details)]
-    (def ldap-details ldap-details)
     (if (= :SUCCESS (:status results))
       ;; test succeeded, save our settings
       (do

--- a/src/metabase/api/ldap.clj
+++ b/src/metabase/api/ldap.clj
@@ -91,6 +91,7 @@
                       (when-not (= :SUCCESS (:status result))
                         (throw (ex-info (tru "Unable to connect to LDAP server with current settings")
                                         (humanize-error-messages result))))))
+                  (when new-value (ldap-ever-enabled?! true))
                   (setting/set-value-of-type! :boolean :ldap-enabled new-value)))
   :default    false)
 

--- a/src/metabase/api/ldap.clj
+++ b/src/metabase/api/ldap.clj
@@ -109,8 +109,7 @@
         ldap-details  (set/rename-keys ldap-settings ldap/mb-settings->ldap-details)
         results       (ldap/test-ldap-connection ldap-details)]
     (if (= :SUCCESS (:status results))
-      ;; test succeeded, save our settings
-      (setting/set-many! ldap-settings)
+       (setting/set-many! (assoc ldap-settings :ldap-enabled (:ldap-enabled settings)))
       ;; test failed, return result message
       {:status 500
        :body   (humanize-error-messages results)})))

--- a/src/metabase/api/session.clj
+++ b/src/metabase/api/session.clj
@@ -24,7 +24,8 @@
             [schema.core :as s]
             [throttle.core :as throttle]
             [toucan.db :as db]
-            [toucan.models :as models])
+            [toucan.models :as models]
+            [metabase.api.ldap :as api.ldap])
   (:import com.unboundid.util.LDAPSDKException
            java.util.UUID))
 
@@ -92,7 +93,7 @@
   "If LDAP is enabled and a matching user exists return a new Session for them, or `nil` if they couldn't be
   authenticated."
   [username password device-info :- request.u/DeviceInfo]
-  (when (ldap/ldap-configured?)
+  (when (api.ldap/ldap-enabled)
     (try
       (when-let [user-info (ldap/find-user username)]
         (when-not (ldap/verify-password user-info password)

--- a/src/metabase/api/session.clj
+++ b/src/metabase/api/session.clj
@@ -5,6 +5,7 @@
             [java-time :as t]
             [metabase.analytics.snowplow :as snowplow]
             [metabase.api.common :as api]
+            [metabase.api.ldap :as api.ldap]
             [metabase.config :as config]
             [metabase.email.messages :as messages]
             [metabase.events :as events]
@@ -24,8 +25,7 @@
             [schema.core :as s]
             [throttle.core :as throttle]
             [toucan.db :as db]
-            [toucan.models :as models]
-            [metabase.api.ldap :as api.ldap])
+            [toucan.models :as models])
   (:import com.unboundid.util.LDAPSDKException
            java.util.UUID))
 

--- a/src/metabase/api/user.clj
+++ b/src/metabase/api/user.clj
@@ -7,6 +7,7 @@
             [metabase.analytics.snowplow :as snowplow]
             [metabase.api.common :as api]
             [metabase.api.common.validation :as validation]
+            [metabase.api.ldap :as api.ldap]
             [metabase.email.messages :as messages]
             [metabase.integrations.google :as google]
             [metabase.integrations.ldap :as ldap]
@@ -352,7 +353,7 @@
                                  ;; if google-auth-client-id is set it means Google Auth is enabled
                                  (google/google-auth-client-id)))
     :ldap_auth     (boolean (and (:ldap_auth existing-user)
-                                 (ldap/ldap-configured?))))
+                                 (api.ldap/ldap-enabled))))
   ;; now return the existing user whether they were originally active or not
   (fetch-user :id (u/the-id existing-user)))
 

--- a/src/metabase/api/user.clj
+++ b/src/metabase/api/user.clj
@@ -10,7 +10,6 @@
             [metabase.api.ldap :as api.ldap]
             [metabase.email.messages :as messages]
             [metabase.integrations.google :as google]
-            [metabase.integrations.ldap :as ldap]
             [metabase.models.collection :as collection :refer [Collection]]
             [metabase.models.login-history :refer [LoginHistory]]
             [metabase.models.permissions-group :as perms-group]

--- a/src/metabase/integrations/ldap.clj
+++ b/src/metabase/integrations/ldap.clj
@@ -192,9 +192,8 @@
 (defn test-current-ldap-details
   "Tests the connection to an LDAP server using the currently set settings."
   []
-  (let [settings (into {} (map
-                           (fn [[k v]] [v (setting/get k)])
-                           mb-settings->ldap-details))]
+  (let [settings (into {} (for [[k v] mb-settings->ldap-details]
+                             [v (setting/get k)]))]
     (test-ldap-connection settings)))
 
 (defn verify-password

--- a/src/metabase/integrations/ldap.clj
+++ b/src/metabase/integrations/ldap.clj
@@ -17,11 +17,6 @@
 ;; Otherwise, this would only happen the first time `find-user` or `fetch-or-create-user!` is called.
 (u/ignore-exceptions (classloader/require ['metabase-enterprise.enhancements.integrations.ldap]))
 
-(defsetting ldap-enabled
-  (deferred-tru "Enable LDAP authentication.")
-  :type    :boolean
-  :default false)
-
 (defsetting ldap-host
   (deferred-tru "Server hostname."))
 
@@ -96,13 +91,27 @@
                    (setting/set-value-of-type! :json :ldap-group-mappings new-value)))))
 
 (defsetting ldap-configured?
-  "Check if LDAP is enabled and that the mandatory settings are configured."
+  (deferred-tru "Have the mandatory LDAP settings (host and user search base) been validated and saved?")
   :type       :boolean
   :visibility :public
   :setter     :none
-  :getter     (fn [] (boolean (and (ldap-enabled)
-                                   (ldap-host)
+  :getter     (fn [] (boolean (and (ldap-host)
                                    (ldap-user-base)))))
+
+(def mb-settings->ldap-details
+  "Mappings from Metabase setting names to keys to use for LDAP connections"
+  {:ldap-host                :host
+   :ldap-port                :port
+   :ldap-bind-dn             :bind-dn
+   :ldap-password            :password
+   :ldap-security            :security
+   :ldap-user-base           :user-base
+   :ldap-user-filter         :user-filter
+   :ldap-attribute-email     :attribute-email
+   :ldap-attribute-firstname :attribute-firstname
+   :ldap-attribute-lastname  :attribute-lastname
+   :ldap-group-sync          :group-sync
+   :ldap-group-base          :group-base})
 
 (defn- details->ldap-options [{:keys [host port bind-dn password security]}]
   (let [security (keyword security)
@@ -179,6 +188,14 @@
       {:status :ERROR, :message (.getMessage e), :code (.getResultCode e)})
     (catch Exception e
       {:status :ERROR, :message (.getMessage e)})))
+
+(defn test-current-ldap-details
+  "Tests the connection to an LDAP server using the currently set settings."
+  []
+  (let [settings (into {} (map
+                           (fn [[k v]] [v (setting/get k)])
+                           mb-settings->ldap-details))]
+    (test-ldap-connection settings)))
 
 (defn verify-password
   "Verifies if the supplied password is valid for the `user-info` (from `find-user`) or DN."

--- a/src/metabase/models/user.clj
+++ b/src/metabase/models/user.clj
@@ -244,7 +244,7 @@
 
 (defn- send-welcome-email! [new-user invitor sent-from-setup?]
   (let [reset-token               (set-password-reset-token! (u/the-id new-user))
-        should-link-to-login-page (and (public-settings/sso-configured?)
+        should-link-to-login-page (and (public-settings/sso-enabled?)
                                        (not (public-settings/enable-password-login)))
         join-url                  (if should-link-to-login-page
                                     (str (public-settings/site-url) "/auth/login")

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -22,9 +22,9 @@
 (defn- google-auth-configured? []
   (boolean (setting/get :google-auth-client-id)))
 
-(defn- ldap-configured? []
-  (classloader/require 'metabase.integrations.ldap)
-  ((resolve 'metabase.integrations.ldap/ldap-configured?)))
+(defn- ldap-enabled? []
+  (classloader/require 'metabase.api.ldap)
+  ((resolve 'metabase.api.ldap/ldap-enabled)))
 
 (defn- ee-sso-configured? []
   (u/ignore-exceptions
@@ -32,11 +32,11 @@
   (when-let [varr (resolve 'metabase-enterprise.sso.integrations.sso-settings/other-sso-configured?)]
     (varr)))
 
-(defn sso-configured?
-  "Any SSO provider is configured"
+(defn sso-enabled?
+  "Any SSO provider is configured and enabled"
   []
   (or (google-auth-configured?)
-      (ldap-configured?)
+      (ldap-enabled?)
       (ee-sso-configured?)))
 
 (defsetting check-for-updates
@@ -364,7 +364,7 @@
                 ;; otherwise this always returns true.
                 (let [v (setting/get-value-of-type :boolean :enable-password-login)]
                   (if (and (some? v)
-                           (sso-configured?))
+                           (sso-enabled?))
                     v
                     true))))
 

--- a/test/metabase/api/ldap_test.clj
+++ b/test/metabase/api/ldap_test.clj
@@ -47,7 +47,7 @@
     (testing "`ldap-enabled` setting validates currently saved LDAP settings, except for on the first time being set"
       (mt/with-temporary-setting-values [ldap-enabled       false
                                          ldap-ever-enabled? false]
-        (with-redefs [ldap/test-current-ldap-details (constantly {:status :ERROR})]
+        (with-redefs [ldap/test-current-ldap-details (constantly {:status :ERROR :message "test error"})]
           (api.ldap/ldap-enabled! true)
           (is (api.ldap/ldap-enabled))
           (is (api.ldap/ldap-ever-enabled?))
@@ -56,7 +56,6 @@
           (is (not (api.ldap/ldap-enabled)))
           (is (api.ldap/ldap-ever-enabled?))
 
-          #_(is (thrown-with-msg? clojure.lang.ExceptionInfo
-                                  #"Unable to connect to LDAP server"
-                                  (api.ldap/ldap-enabled! true))))))))
-
+          (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                                #"Unable to connect to LDAP server"
+                                (api.ldap/ldap-enabled! true))))))))

--- a/test/metabase/api/ldap_test.clj
+++ b/test/metabase/api/ldap_test.clj
@@ -1,7 +1,6 @@
 (ns metabase.api.ldap-test
   (:require [clojure.set :as set]
             [clojure.test :refer :all]
-            [metabase.api.ldap :as api.ldap]
             [metabase.integrations.ldap :as ldap]
             [metabase.models.setting :as setting]
             [metabase.test :as mt]
@@ -10,7 +9,7 @@
 (defn ldap-test-details
   []
   (-> (ldap.test/get-ldap-details)
-      (set/rename-keys (set/map-invert @#'api.ldap/mb-settings->ldap-details))
+      (set/rename-keys (set/map-invert @#'ldap/mb-settings->ldap-details))
       (assoc :ldap-enabled true)))
 
 (deftest ldap-settings-test

--- a/test/metabase/api/ldap_test.clj
+++ b/test/metabase/api/ldap_test.clj
@@ -8,9 +8,11 @@
             [metabase.test.integrations.ldap :as ldap.test]))
 
 (defn ldap-test-details
-  []
-  (-> (ldap.test/get-ldap-details)
-      (set/rename-keys (set/map-invert @#'ldap/mb-settings->ldap-details))))
+  ([] (ldap-test-details true))
+  ([enabled?]
+   (-> (ldap.test/get-ldap-details)
+       (set/rename-keys (set/map-invert @#'ldap/mb-settings->ldap-details))
+       (assoc :ldap-enabled enabled?))))
 
 (deftest ldap-settings-test
   (testing "PUT /api/ldap/settings"
@@ -27,6 +29,14 @@
                               (assoc (ldap-test-details)
                                      :ldap-port (Integer. (ldap.test/get-ldap-port)))))
 
+      (testing "Passing ldap-enabled=false will disable LDAP"
+        (mt/user-http-request :crowberto :put 200 "ldap/settings" (ldap-test-details false))
+        (is (not (api.ldap/ldap-enabled))))
+
+      (testing "Passing ldap-enabled=false still validates the LDAP settings"
+        (mt/user-http-request :crowberto :put 500 "ldap/settings"
+                              (assoc (ldap-test-details false) :ldap-password "wrong-password"))))))
+
       (with-redefs [ldap/test-ldap-connection (constantly {:status :SUCCESS})]
         (testing "LDAP port is saved as default value if passed as an empty string (#18936)"
           (mt/user-http-request :crowberto :put 200 "ldap/settings"
@@ -40,13 +50,12 @@
       (testing "Requires superusers"
         (is (= "You don't have permissions to do that."
                (mt/user-http-request :rasta :put 403 "ldap/settings"
-                                     (assoc (ldap-test-details) :ldap-port "" :ldap-enabled false))))))))
+                                     (assoc (ldap-test-details) :ldap-port "" :ldap-enabled false)))))
 
 (deftest ldap-enabled-test
   (ldap.test/with-ldap-server
     (testing "`ldap-enabled` setting validates currently saved LDAP settings"
-      (mt/with-temporary-setting-values [ldap-enabled       false
-                                         ldap-ever-enabled? false]
+      (mt/with-temporary-setting-values [ldap-enabled false]
         (with-redefs [ldap/test-current-ldap-details (constantly {:status :ERROR :message "test error"})]
           (is (thrown-with-msg? clojure.lang.ExceptionInfo
                                 #"Unable to connect to LDAP server"

--- a/test/metabase/api/ldap_test.clj
+++ b/test/metabase/api/ldap_test.clj
@@ -35,7 +35,7 @@
 
       (testing "Passing ldap-enabled=false still validates the LDAP settings"
         (mt/user-http-request :crowberto :put 500 "ldap/settings"
-                              (assoc (ldap-test-details false) :ldap-password "wrong-password"))))))
+                              (assoc (ldap-test-details false) :ldap-password "wrong-password")))
 
       (with-redefs [ldap/test-ldap-connection (constantly {:status :SUCCESS})]
         (testing "LDAP port is saved as default value if passed as an empty string (#18936)"
@@ -50,7 +50,7 @@
       (testing "Requires superusers"
         (is (= "You don't have permissions to do that."
                (mt/user-http-request :rasta :put 403 "ldap/settings"
-                                     (assoc (ldap-test-details) :ldap-port "" :ldap-enabled false)))))
+                                     (assoc (ldap-test-details) :ldap-port "" :ldap-enabled false))))))))
 
 (deftest ldap-enabled-test
   (ldap.test/with-ldap-server

--- a/test/metabase/api/ldap_test.clj
+++ b/test/metabase/api/ldap_test.clj
@@ -44,18 +44,16 @@
 
 (deftest ldap-enabled-test
   (ldap.test/with-ldap-server
-    (testing "`ldap-enabled` setting validates currently saved LDAP settings, except for on the first time being set"
+    (testing "`ldap-enabled` setting validates currently saved LDAP settings"
       (mt/with-temporary-setting-values [ldap-enabled       false
                                          ldap-ever-enabled? false]
         (with-redefs [ldap/test-current-ldap-details (constantly {:status :ERROR :message "test error"})]
-          (api.ldap/ldap-enabled! true)
-          (is (api.ldap/ldap-enabled))
-          (is (api.ldap/ldap-ever-enabled?))
-
-          (api.ldap/ldap-enabled! false)
-          (is (not (api.ldap/ldap-enabled)))
-          (is (api.ldap/ldap-ever-enabled?))
-
           (is (thrown-with-msg? clojure.lang.ExceptionInfo
                                 #"Unable to connect to LDAP server"
-                                (api.ldap/ldap-enabled! true))))))))
+                                (api.ldap/ldap-enabled! true))))
+        (with-redefs [ldap/test-current-ldap-details (constantly {:status :SUCCESS})]
+          (api.ldap/ldap-enabled! true)
+          (is (api.ldap/ldap-enabled))
+
+          (api.ldap/ldap-enabled! false)
+          (is (not (api.ldap/ldap-enabled))))))))

--- a/test/metabase/test/integrations/ldap.clj
+++ b/test/metabase/test/integrations/ldap.clj
@@ -61,7 +61,8 @@
                                          ldap-user-base  "dc=metabase,dc=com"
                                          ldap-group-sync true
                                          ldap-group-base "dc=metabase,dc=com"]
-        (f))
+         (tu/with-temporary-raw-setting-values [ldap-enabled true]
+          (f)))
       (finally (.shutDown *ldap-server* true)))))
 
 (defmacro with-ldap-server

--- a/test/metabase/test/integrations/ldap.clj
+++ b/test/metabase/test/integrations/ldap.clj
@@ -54,8 +54,7 @@
   [f options]
   (binding [*ldap-server* (start-ldap-server! options)]
     (try
-      (tu/with-temporary-setting-values [ldap-enabled    true
-                                         ldap-host       "localhost"
+      (tu/with-temporary-setting-values [ldap-host       "localhost"
                                          ldap-port       (get-ldap-port)
                                          ldap-bind-dn    "cn=Directory Manager"
                                          ldap-password   "password"

--- a/test/metabase/test/integrations/ldap.clj
+++ b/test/metabase/test/integrations/ldap.clj
@@ -61,7 +61,7 @@
                                          ldap-user-base  "dc=metabase,dc=com"
                                          ldap-group-sync true
                                          ldap-group-base "dc=metabase,dc=com"]
-         (tu/with-temporary-raw-setting-values [ldap-enabled true]
+         (tu/with-temporary-raw-setting-values [ldap-enabled "true"]
           (f)))
       (finally (.shutDown *ldap-server* true)))))
 


### PR DESCRIPTION
This PR makes some revisions to the way LDAP is configured and enabled/disabled according to the expectations in https://github.com/metabase/metabase/issues/19428.

Here's a quick outline of the new behavior:
* On initial setup, we validate and save the details. The FE must pass `ldap-enabled` as `true`.
* If LDAP is disabled via the toggle, we set `ldap-enabled` to false, and don't modify any other settings.
* If LDAP is re-enabled via the toggle, we set `ldap-enabled` to true. The setter will double-check that the existing settings are still valid.
* If the LDAP details are edited after the initial setup, we validate the details before saving them, but we don't change the value of `ldap-enabled` unless passed by the frontend.

Technical comments
* Moved `ldap-enabled` to the API namespace so it can have access to `humanize-error-messages`
* `ldap-enabled` is now the source of truth for whether LDAP can be used elsewhere in the code base instead of `ldap-configured?`