### PR TITLE
Make table column width reasonable

### DIFF
--- a/src/metabase/pulse/render/style.clj
+++ b/src/metabase/pulse/render/style.clj
@@ -60,13 +60,9 @@
   "Color for dark text."
   "#4C5773")
 
-(def ^:const color-header-row-border
-  "Used as color for the bottom border of table headers for charts with `:table` vizualization."
-  "#EDF0F1")
-
-(def ^:const color-body-row-border
-  "Used as color for the bottom border of table body rows for charts with `:table` vizualization."
-  "#F0F0F04D")
+(def ^:const color-border
+  "Used as color for the border of table, table header, and table body rows for charts with `:table` vizualization."
+  "#F0F0F0")
 
 ;; don't try to improve the code and make this a plain variable, in EE it's customizable which is why it's a function.
 ;; Too much of a hassle to have it be a fn in one version of the code an a constant in another
@@ -95,7 +91,7 @@
   []
   (merge
    (font-style)
-   {:font-size       :14px
+   {:font-size       :18px
     :font-weight     700
     :color           (primary-color)
     :text-decoration :none}))

--- a/src/metabase/pulse/render/table.clj
+++ b/src/metabase/pulse/render/table.clj
@@ -14,10 +14,9 @@
    (style/font-style)
    {:font-size :12px
     :font-weight     700
-    :color           style/color-text-medium
-    :border-bottom   (str "1px solid " style/color-header-row-border)
-    :padding-top     :20px
-    :padding-bottom  :5px}))
+    :color           style/color-text-dark
+    :border-bottom   (str "2px solid " style/color-border)
+    :border-right    0}))
 
 (def ^:private max-bar-width 106)
 
@@ -25,13 +24,12 @@
   (merge
    (style/font-style)
    {:font-size      :12px
-    :font-weight    700
+    :font-weight    400
     :text-align     :left
     :color          style/color-text-dark
-    :border-bottom  (str "1px solid " style/color-body-row-border)
-    :height         :28px
-    :padding-right  :0.375em
-    :padding-left   :0.375em}))
+    :border-bottom  (str "1px solid " style/color-border)
+    :border-right   (str "1px solid " style/color-border)
+    :padding        "0.75em 1em"}))
 
 (defn- bar-th-style-numeric []
   (merge (style/font-style) (bar-th-style) {:text-align :right}))
@@ -124,7 +122,11 @@
                       (row-style-for-type cell)
                       {:background-color (get-background-color cell (get column-names col-idx) row-idx)}
                       (when (and bar-width (= col-idx 1))
-                        {:font-weight 700}))}
+                        {:font-weight 700})
+                      (when (= row-idx (dec (count rows)))
+                        {:border-bottom 0})
+                      (when (= col-idx (dec (count row)))
+                        {:border-right 0}))}
          (h cell)])
       (some-> bar-width (render-bar normalized-zero))])])
 
@@ -139,8 +141,8 @@
   ([color-selector normalized-zero column-names [header & rows]]
    [:table {:style (style/style {:max-width "100%"
                                  :white-space :nowrap
-                                 :padding-bottom :8px
-                                 :border-collapse :collapse
+                                 :border  (str "1px solid " style/color-border)
+                                 :border-radius :6px
                                  :width "1%"})
             :cellpadding "0"
             :cellspacing "0"}

--- a/src/metabase/pulse/render/table.clj
+++ b/src/metabase/pulse/render/table.clj
@@ -74,12 +74,19 @@
   [score]
   (int (* (/ score 100.0) max-bar-width)))
 
+(def ^:private max-column-character-length 100)
+
+(defn- truncate-text [text]
+  (if (> (count text) max-column-character-length)
+    (str (subs text 0 max-column-character-length) "...")
+    text))
+
 (defn- render-table-head [{:keys [bar-width row]}]
   [:thead
    [:tr
     (for [header-cell row]
-      [:th {:style (style/style (row-style-for-type header-cell) (heading-style-for-type header-cell) {:min-width :42px})}
-       (h header-cell)])
+      [:th {:style (style/style (row-style-for-type header-cell) (heading-style-for-type header-cell) {:min-width :42px}) :title header-cell}
+       (h (truncate-text (str header-cell)))])
     (when bar-width
       [:th {:style (style/style (bar-td-style) (bar-th-style) {:width (str bar-width "%")})}])]])
 

--- a/src/metabase/pulse/render/table.clj
+++ b/src/metabase/pulse/render/table.clj
@@ -75,7 +75,7 @@
   [score]
   (int (* (/ score 100.0) max-bar-width)))
 
-(def ^:private max-column-character-length 100)
+(def ^:private max-column-character-length 16)
 
 (defn- truncate-text [text]
   (if (> (count text) max-column-character-length)

--- a/src/metabase/pulse/render/table.clj
+++ b/src/metabase/pulse/render/table.clj
@@ -1,5 +1,6 @@
 (ns metabase.pulse.render.table
-  (:require [hiccup.core :refer [h]]
+  (:require [clojure.string :as str]
+            [hiccup.core :refer [h]]
             [medley.core :as m]
             [metabase.pulse.render.color :as color]
             metabase.pulse.render.common
@@ -78,17 +79,17 @@
 
 (defn- truncate-text [text]
   (if (> (count text) max-column-character-length)
-    (str (subs text 0 max-column-character-length) "...")
+    (str (str/trim (subs text 0 max-column-character-length)) "...")
     text))
 
 (defn- render-table-head [{:keys [bar-width row]}]
   [:thead
-   [:tr
-    (for [header-cell row]
-      [:th {:style (style/style (row-style-for-type header-cell) (heading-style-for-type header-cell) {:min-width :42px}) :title header-cell}
-       (h (truncate-text (str header-cell)))])
-    (when bar-width
-      [:th {:style (style/style (bar-td-style) (bar-th-style) {:width (str bar-width "%")})}])]])
+   (conj (into [:tr]
+               (for [header-cell row]
+                 [:th {:style (style/style (row-style-for-type header-cell) (heading-style-for-type header-cell) {:min-width :42px}) :title header-cell}
+                  (h (truncate-text (str header-cell)))]))
+         (when bar-width
+           [:th {:style (style/style (bar-td-style) (bar-th-style) {:width (str bar-width "%")})}]))])
 
 (defn- render-bar
   [bar-width normalized-zero]

--- a/src/metabase/pulse/render/table.clj
+++ b/src/metabase/pulse/render/table.clj
@@ -85,7 +85,7 @@
    (conj (into [:tr]
                (for [header-cell row]
                  [:th {:style (style/style (row-style-for-type header-cell) (heading-style-for-type header-cell) {:min-width :42px}) :title header-cell}
-                  (h (truncate-text (str header-cell)))]))
+                  (truncate-text (h header-cell))]))
          (when bar-width
            [:th {:style (style/style (bar-td-style) (bar-th-style) {:width (str bar-width "%")})}]))])
 

--- a/test/metabase/pulse/render/table_test.clj
+++ b/test/metabase/pulse/render/table_test.clj
@@ -72,3 +72,14 @@
                (#'table/render-table 0 ["a" "b" "c"] (query-results->header+rows query-results))
                find-table-body
                cell-value->background-color)))))
+
+(deftest header-truncation-test []
+  (let [[normal-heading long-heading :as row] ["Count" (apply str (repeat 120 "A"))]
+        [normal-rendered long-rendered]       (->> (#'table/render-table-head {:row row})
+                                             (tree-seq vector? rest)
+                                             (filter #(= :th (first %)))
+                                             (map last))]
+    (testing "Table Headers are truncated if they are really long."
+      (is (= normal-heading normal-rendered))
+      (is (= "A..." (subs long-rendered (- (count long-rendered) 4) (count long-rendered))))
+      (is (not= long-heading long-rendered)))))


### PR DESCRIPTION
Epic: #24759
Product doc: https://www.notion.so/metabase/Further-polish-static-viz-and-add-support-for-new-charts-29e3a1d2c55a4bf39dc0b1e5a0b2d67f#183fc0a7874e4496a7c226b989393177

This PR updates the style of static viz's table and truncates long column names (longer than 16 characters according to the spec)

## Table used for testing
![image](https://user-images.githubusercontent.com/1937582/190470282-bf86f30b-6220-43ba-80ce-13e20d54aa05.png)

## Results

### Email

#### After
- ![image](https://user-images.githubusercontent.com/1937582/190599224-00ec3289-1792-4b49-962e-7320b2f8a708.png)
- ![image](https://user-images.githubusercontent.com/1937582/190599253-84bb4188-4a73-4de3-85ab-37a09a049b8b.png)

#### Before
- ![image](https://user-images.githubusercontent.com/1937582/190469767-28c6fcd3-e9b2-4769-b38f-6f51b5b7136b.png)
- ![image](https://user-images.githubusercontent.com/1937582/190469786-6fd29e15-0997-441e-a9cd-112940c5ab77.png)

### Slack

#### After
![image](https://user-images.githubusercontent.com/1937582/190599294-0f6bd1cb-6da1-4971-a2d1-7835640d54f8.png)

#### Before
![image](https://user-images.githubusercontent.com/1937582/190470036-b78fb9ea-22f7-4fbb-9020-3d68f3e6568f.png)

