### PR TITLE
Fix Visualization component handling of mode prop

### DIFF
--- a/frontend/src/metabase/visualizations/components/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization.jsx
@@ -213,14 +213,13 @@ class Visualization extends React.PureComponent {
       : question;
   }
 
-  getMode(question) {
-    const { mode } = this.props;
-    if (mode instanceof Mode) {
-      return mode;
+  getMode(maybeModeOrQueryMode, question) {
+    if (maybeModeOrQueryMode instanceof Mode) {
+      return maybeModeOrQueryMode;
     }
 
-    if (question && mode) {
-      return new Mode(question, mode);
+    if (question && maybeModeOrQueryMode) {
+      return new Mode(question, maybeModeOrQueryMode);
     }
 
     return question?.mode();
@@ -235,7 +234,7 @@ class Visualization extends React.PureComponent {
     const seriesIndex = clicked.seriesIndex || 0;
     const card = this.state.series[seriesIndex].card;
     const question = this._getQuestionForCardCached(metadata, card);
-    const mode = this.getMode(question);
+    const mode = this.getMode(this.props.mode, question);
 
     return mode
       ? mode.actionsForClick(

--- a/frontend/src/metabase/visualizations/components/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization.jsx
@@ -213,6 +213,19 @@ class Visualization extends React.PureComponent {
       : question;
   }
 
+  getMode(question) {
+    const { mode } = this.props;
+    if (mode instanceof Mode) {
+      return mode;
+    }
+
+    if (question && mode) {
+      return new Mode(question, mode);
+    }
+
+    return question?.mode();
+  }
+
   getClickActions(clicked) {
     if (!clicked) {
       return [];
@@ -222,9 +235,7 @@ class Visualization extends React.PureComponent {
     const seriesIndex = clicked.seriesIndex || 0;
     const card = this.state.series[seriesIndex].card;
     const question = this._getQuestionForCardCached(metadata, card);
-    const mode = this.props.mode
-      ? question && new Mode(question, this.props.mode)
-      : question && question.mode();
+    const mode = this.getMode(question);
 
     return mode
       ? mode.actionsForClick(


### PR DESCRIPTION
Fixes #25437 

1. `Visualization` accepts a prop named `mode` that is _not_ an instance of a `Mode`. It is a `QueryMode`, actually -- the second arg of the `Mode` constructor.
2. The `QueryBuilder` passes down a `mode` prop that _is_ a `Mode` instance.
3. The `DatasetEditor` component does not rely on the `mode`, so it just lets the `Mode` `mode` trickle down to `QueryVisualization`.
4. `Visualization` improperly instantiates a `Mode` instance with a `Mode` instance in the second constructor arg.
5. A subsequent method call on this improperly instantiated `Mode` instance causes a scripting error.

This is all very confusing. Well, there a few solutions we could do here:
1. Set `mode` to `undefined` or to `mode.queryMode()` in the `DatasetEditor`
2. Update the name of `Visualization`'s `mode` prop to `queryMode`.
3. Update `Visualization` to handle both scenarios.

Option 1 is too narrow of a solution: it'd surely happen again. Option 2 is too risky: I'd need to update the passing of `mode` to `Visualization` throughout the app and sometimes it is not always obvious where it gets passed due to our lovely usage of `{...props}`. I went with option 3: it fixes the bug and handles both scenarios with no changes outside of `Visualization` and, yes, it adds an extra `if` to this logic, but we're already mucking around with instantiating `Modes` inside of the component, so it felt like a relatively benign tweak.

**Testing**
Follow the steps in #25437 