### PR TITLE
Preserve Model metadata when changing the Model's query

### DIFF
--- a/frontend/src/metabase/lib/query/field_ref.js
+++ b/frontend/src/metabase/lib/query/field_ref.js
@@ -25,8 +25,16 @@ export function isValidField(field) {
   );
 }
 
-export function isSameField(fieldA, fieldB, exact = false) {
-  if (exact) {
+function isNotComparingLocalFieldRefs(refA, refB) {
+  return !isLocalField(refA) || !isLocalField(refB);
+}
+
+export function isSameField(
+  fieldA,
+  fieldB,
+  useDeepEquality = isNotComparingLocalFieldRefs(fieldA, fieldB),
+) {
+  if (useDeepEquality) {
     return _.isEqual(fieldA, fieldB);
   } else {
     return getFieldTargetId(fieldA) === getFieldTargetId(fieldB);

--- a/frontend/src/metabase/query_builder/actions/models.js
+++ b/frontend/src/metabase/query_builder/actions/models.js
@@ -3,7 +3,7 @@ import _ from "underscore";
 import { merge } from "icepick";
 import { t } from "ttag";
 
-import { isLocalField, isSameField } from "metabase/lib/query/field_ref";
+import { isSameField } from "metabase/lib/query/field_ref";
 import { addUndo } from "metabase/redux/undo";
 import { loadMetadataForQueries } from "metabase/redux/metadata";
 import Questions from "metabase/entities/questions";
@@ -81,13 +81,7 @@ export const setFieldMetadata =
     const resultsMetadata = getResultsMetadata(getState());
 
     const nextColumnMetadata = resultsMetadata.columns.map(fieldMetadata => {
-      const compareExact =
-        !isLocalField(field_ref) || !isLocalField(fieldMetadata.field_ref);
-      const isTargetField = isSameField(
-        field_ref,
-        fieldMetadata.field_ref,
-        compareExact,
-      );
+      const isTargetField = isSameField(field_ref, fieldMetadata.field_ref);
       return isTargetField ? merge(fieldMetadata, changes) : fieldMetadata;
     });
 

--- a/frontend/src/metabase/query_builder/actions/querying.js
+++ b/frontend/src/metabase/query_builder/actions/querying.js
@@ -8,7 +8,7 @@ import { isAdHocModelQuestion } from "metabase/lib/data-modeling/utils";
 import { startTimer } from "metabase/lib/performance";
 import { defer } from "metabase/lib/promise";
 import { createThunkAction } from "metabase/lib/redux";
-import { isLocalField, isSameField } from "metabase/lib/query/field_ref";
+import { isSameField } from "metabase/lib/query/field_ref";
 
 import { getMetadata } from "metabase/selectors/metadata";
 import { getSensibleDisplays } from "metabase/visualizations";
@@ -223,9 +223,7 @@ function preserveModelMetadata(queryResults, originalModel) {
 function mergeQueryMetadataWithModelMetadata(queryMetadata, modelMetadata) {
   return queryMetadata.map((queryCol, index) => {
     const modelCol = modelMetadata.find(modelCol => {
-      const compareExact =
-        !isLocalField(queryCol.field_ref) || !isLocalField(modelCol.field_ref);
-      return isSameField(modelCol.field_ref, queryCol.field_ref, compareExact);
+      return isSameField(modelCol.field_ref, queryCol.field_ref);
     });
 
     if (modelCol) {

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
@@ -22,7 +22,7 @@ import {
   isResultsMetadataDirty,
 } from "metabase/query_builder/selectors";
 
-import { isLocalField, isSameField } from "metabase/lib/query/field_ref";
+import { isSameField } from "metabase/lib/query/field_ref";
 import { getSemanticTypeIcon } from "metabase/lib/schema_metadata";
 import { checkCanBeModel } from "metabase/lib/data-modeling/utils";
 import { usePrevious } from "metabase/hooks/use-previous";
@@ -163,11 +163,6 @@ const FIELDS = [
   "settings",
 ];
 
-function compareFields(fieldRef1, fieldRef2) {
-  const compareExact = !isLocalField(fieldRef1) || !isLocalField(fieldRef2);
-  return isSameField(fieldRef1, fieldRef2, compareExact);
-}
-
 function DatasetEditor(props) {
   const {
     question: dataset,
@@ -218,7 +213,7 @@ function DatasetEditor(props) {
       return columns;
     }
     return orderedColumns
-      .map(col => columns.find(c => compareFields(c.field_ref, col.fieldRef)))
+      .map(col => columns.find(c => isSameField(c.field_ref, col.fieldRef)))
       .filter(Boolean);
   }, [orderedColumns, result]);
 
@@ -246,7 +241,7 @@ function DatasetEditor(props) {
       return -1;
     }
     return fields.findIndex(field =>
-      compareFields(focusedFieldRef, field.field_ref),
+      isSameField(focusedFieldRef, field.field_ref),
     );
   }, [focusedFieldRef, fields]);
 

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataSidebar.jsx
@@ -15,7 +15,7 @@ import {
   field_visibility_types,
   field_semantic_types,
 } from "metabase/lib/core";
-import { isLocalField, isSameField } from "metabase/lib/query/field_ref";
+import { isSameField } from "metabase/lib/query/field_ref";
 import { isFK, getSemanticTypeIcon } from "metabase/lib/schema_metadata";
 
 import RootForm from "metabase/containers/FormikForm";
@@ -149,9 +149,7 @@ function DatasetFieldMetadataSidebar({
   const previousField = usePrevious(field);
 
   useEffect(() => {
-    const compareExact =
-      !isLocalField(field.field_ref) || !isLocalField(previousField?.field_ref);
-    if (!isSameField(field.field_ref, previousField?.field_ref, compareExact)) {
+    if (!isSameField(field.field_ref, previousField?.field_ref)) {
       setShouldAnimateFieldChange(true);
       // setTimeout is required as form fields are rerendered pretty frequently
       setTimeout(() => {

--- a/frontend/test/metabase/scenarios/models/reproductions/22517-add-remove-column-drops-metadata.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/reproductions/22517-add-remove-column-drops-metadata.cy.spec.js
@@ -1,7 +1,6 @@
-import { restore } from "__support__/e2e/helpers";
-import { openDetailsSidebar } from "../helpers/e2e-models-helpers";
+import { restore, openQuestionActions } from "__support__/e2e/helpers";
 
-describe.skip("issue 22517", () => {
+describe("issue 22517", () => {
   beforeEach(() => {
     cy.intercept("POST", "/api/card/*/query").as("cardQuery");
     cy.intercept("PUT", "/api/card/*").as("updateMetadata");
@@ -18,9 +17,9 @@ describe.skip("issue 22517", () => {
       { visitQuestion: true },
     );
 
-    openDetailsSidebar();
+    openQuestionActions();
+    cy.findByText("Edit metadata").click();
 
-    cy.findByText("Customize metadata").click();
     cy.wait(["@cardQuery", "@cardQuery"]);
 
     renameColumn("ID", "Foo");
@@ -30,8 +29,7 @@ describe.skip("issue 22517", () => {
   });
 
   it("adding or removging a column should not drop previously edited metadata (metabase#22517)", () => {
-    openDetailsSidebar();
-
+    openQuestionActions();
     cy.findByText("Edit query definition").click();
     cy.wait(["@cardQuery", "@cardQuery"]);
 
@@ -47,6 +45,11 @@ describe.skip("issue 22517", () => {
 
     cy.get(".NativeQueryEditor .Icon-play").click();
     cy.wait("@dataset");
+
+    cy.findByText("Foo");
+
+    cy.findByText("Save changes").click();
+    cy.wait(["@cardQuery", "@cardQuery"]);
 
     cy.findByText("Foo");
   });


### PR DESCRIPTION
Fixes #22517 

- Adds additional logic to the `QUERY_COMPLETE` QB action to replace columns coming from the latest query with columns from the original dataset.
- Using icepick's `merge` seems like overkill in this scenario. I've just made it so that whenever we find a matching column, use the model question's column over the query results' column.
- I'm passing the updated `modelMetadata` on the action payload so that the reducers can use it to update the `card` and the `queryResults` objects that live in the store.

https://user-images.githubusercontent.com/13057258/190516891-26b8a9fd-83c0-4e29-8c8d-18b8ee03a5d9.mov

