### PR TITLE
Change "dataset" to "model"

### DIFF
--- a/frontend/src/metabase/nav/utils/model-names.ts
+++ b/frontend/src/metabase/nav/utils/model-names.ts
@@ -3,7 +3,7 @@ import { t } from "ttag";
 const TRANSLATED_NAME_BY_MODEL_TYPE: Record<string, string> = {
   app: t`App`,
   card: t`Question`,
-  dataset: t`Dataset`,
+  dataset: t`Model`,
   dashboard: t`Dashboard`,
   table: t`Table`,
   database: t`Database`,


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/25447

I somehow ran into an instance of the word "dataset" in the UI, and though I'm having trouble repro-ing it, I did find this stray tagged instance of `dataset` in this file, and figured I'd correct it.

<img width="798" alt="image" src="https://user-images.githubusercontent.com/2223916/190532162-e341c972-ce32-416e-985a-28d01fe8dd1d.png">

