### PR TITLE
Rename Dataset → Model in search item

### DIFF
--- a/frontend/src/metabase/nav/utils/model-names.ts
+++ b/frontend/src/metabase/nav/utils/model-names.ts
@@ -3,7 +3,7 @@ import { t } from "ttag";
 const TRANSLATED_NAME_BY_MODEL_TYPE: Record<string, string> = {
   app: t`App`,
   card: t`Question`,
-  dataset: t`Dataset`,
+  dataset: t`Model`,
   dashboard: t`Dashboard`,
   table: t`Table`,
   database: t`Database`,


### PR DESCRIPTION
Fixes #25447

### How to Test

1. Visit models
2. Open search
3. Recently viewed items, if models, should be labeled "Model" (not "Dataset")

![image](https://user-images.githubusercontent.com/380816/190532107-b9d46a33-3e20-428b-8378-a7b6acf8c831.png)
