### PR TITLE
Extract `DraggableSidebarLink` component

### DIFF
--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/BookmarkList/BookmarkList.styled.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/BookmarkList/BookmarkList.styled.tsx
@@ -1,28 +1,11 @@
 import styled from "@emotion/styled";
-import { css } from "@emotion/react";
 
 import { color } from "metabase/lib/colors";
 
-import Icon from "metabase/components/Icon";
+import { DraggableSidebarLink } from "../../SidebarItems";
 
-import { SidebarLink } from "../../SidebarItems";
-
-type SidebarBookmarkItem = {
-  isSorting: boolean;
-};
-
-export const DragIcon = styled(Icon)`
-  left: 2px;
-  opacity: 0;
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-  cursor: grab;
-`;
-
-export const SidebarBookmarkItem = styled(SidebarLink)<SidebarBookmarkItem>`
+export const SidebarBookmarkItem = styled(DraggableSidebarLink)`
   padding-left: 0.75rem;
-  position: relative;
 
   &:hover {
     button {
@@ -32,10 +15,6 @@ export const SidebarBookmarkItem = styled(SidebarLink)<SidebarBookmarkItem>`
       > svg:focus {
         outline: none;
       }
-    }
-
-    > svg {
-      opacity: 0.3;
     }
   }
 
@@ -50,20 +29,4 @@ export const SidebarBookmarkItem = styled(SidebarLink)<SidebarBookmarkItem>`
       outline: none;
     }
   }
-
-  ${props =>
-    props.isSorting &&
-    css`
-      &:hover {
-        background: white;
-
-        svg {
-          color: ${color("brand-light")} !important;
-        }
-
-        button {
-          opacity: 0;
-        }
-      }
-    `}
 `;

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/BookmarkList/BookmarkList.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/BookmarkList/BookmarkList.tsx
@@ -2,8 +2,6 @@ import React, { useCallback, useEffect, useState } from "react";
 import { t } from "ttag";
 import { connect } from "react-redux";
 
-import "./sortable.css";
-
 import {
   SortableContainer,
   SortableElement,
@@ -20,7 +18,7 @@ import * as Urls from "metabase/lib/urls";
 import { SelectedItem } from "../../types";
 import { SidebarHeading } from "../../MainNavbar.styled";
 
-import { DragIcon, SidebarBookmarkItem } from "./BookmarkList.styled";
+import { SidebarBookmarkItem } from "./BookmarkList.styled";
 
 const mapDispatchToProps = {
   onDeleteBookmark: ({ item_id, type }: Bookmark) =>
@@ -91,10 +89,9 @@ const BookmarkItem = ({
         url={url}
         icon={icon}
         isSelected={isSelected}
-        isSorting={isSorting}
+        isDragging={isSorting}
         hasDefaultIconStyle={!isIrregularCollection}
         onClick={onSelect}
-        left={<DragIcon name="grabber2" size={12} />}
         right={
           <button onClick={onRemove}>
             <Tooltip tooltip={t`Remove bookmark`} placement="bottom">

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/DraggableSidebarLink.styled.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/DraggableSidebarLink.styled.tsx
@@ -16,6 +16,8 @@ export const DragIcon = styled(Icon)`
   cursor: grab;
 `;
 
+// Notice that dragged item styles are defined in sortable.css file
+// This is a limitation of react-sortable-hoc library
 export const StyledSidebarLink = styled(SidebarLink)<{ isDragging: boolean }>`
   position: relative;
 
@@ -31,7 +33,7 @@ export const StyledSidebarLink = styled(SidebarLink)<{ isDragging: boolean }>`
       &:hover {
         background: ${color("bg-white")};
 
-        ${DragIcon} {
+        ${SidebarLink.Icon}, ${DragIcon} {
           color: ${color("brand-light")} !important;
         }
 

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/DraggableSidebarLink.styled.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/DraggableSidebarLink.styled.tsx
@@ -1,0 +1,43 @@
+import styled from "@emotion/styled";
+import { css } from "@emotion/react";
+
+import Icon from "metabase/components/Icon";
+
+import { color } from "metabase/lib/colors";
+
+import SidebarLink from "./SidebarLink";
+
+export const DragIcon = styled(Icon)`
+  left: 2px;
+  opacity: 0;
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  cursor: grab;
+`;
+
+export const StyledSidebarLink = styled(SidebarLink)<{ isDragging: boolean }>`
+  position: relative;
+
+  &:hover {
+    ${DragIcon} {
+      opacity: 0.3;
+    }
+  }
+
+  ${props =>
+    props.isDragging &&
+    css`
+      &:hover {
+        background: ${color("bg-white")};
+
+        ${DragIcon} {
+          color: ${color("brand-light")} !important;
+        }
+
+        ${SidebarLink.RightElement} {
+          opacity: 0;
+        }
+      }
+    `}
+`;

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/DraggableSidebarLink.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/DraggableSidebarLink.tsx
@@ -3,6 +3,8 @@ import React from "react";
 import { SidebarLinkProps } from "./SidebarLink";
 import { DragIcon, StyledSidebarLink } from "./DraggableSidebarLink.styled";
 
+import "./sortable.css";
+
 interface Props extends Omit<SidebarLinkProps, "left"> {
   isDragging: boolean;
 }

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/DraggableSidebarLink.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/DraggableSidebarLink.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+import { SidebarLinkProps } from "./SidebarLink";
+import { DragIcon, StyledSidebarLink } from "./DraggableSidebarLink.styled";
+
+interface Props extends Omit<SidebarLinkProps, "left"> {
+  isDragging: boolean;
+}
+
+function DraggableSidebarLink(props: Props) {
+  return (
+    <StyledSidebarLink
+      {...props}
+      left={<DragIcon name="grabber2" size={12} />}
+    />
+  );
+}
+
+export default DraggableSidebarLink;

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarItems.styled.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarItems.styled.tsx
@@ -127,3 +127,6 @@ export function NameContainer({ children: itemName }: { children: string }) {
   }
   return <TreeNode.NameContainer>{itemName}</TreeNode.NameContainer>;
 }
+
+export const LeftElementContainer = styled.div``;
+export const RightElementContainer = styled.div``;

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarLink.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarLink.tsx
@@ -11,6 +11,8 @@ import {
   NodeRoot,
   SidebarIcon,
   FullWidthButton,
+  LeftElementContainer,
+  RightElementContainer,
 } from "./SidebarItems.styled";
 
 interface SidebarLinkProps {
@@ -83,12 +85,16 @@ function SidebarLink({
       onMouseDown={disableImageDragging}
       {...props}
     >
-      {React.isValidElement(left) && left}
+      {React.isValidElement(left) && (
+        <LeftElementContainer>{left}</LeftElementContainer>
+      )}
       <Content>
         {icon && renderIcon()}
         <NameContainer>{children}</NameContainer>
       </Content>
-      {React.isValidElement(right) && right}
+      {React.isValidElement(right) && (
+        <RightElementContainer>{right}</RightElementContainer>
+      )}
     </NodeRoot>
   );
 }
@@ -97,4 +103,6 @@ export type { SidebarLinkProps };
 
 export default Object.assign(SidebarLink, {
   NameContainers: [ItemName, TreeNode.NameContainer],
+  LeftElement: LeftElementContainer,
+  RightElement: RightElementContainer,
 });

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarLink.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarLink.tsx
@@ -103,6 +103,7 @@ export type { SidebarLinkProps };
 
 export default Object.assign(SidebarLink, {
   NameContainers: [ItemName, TreeNode.NameContainer],
+  Icon: SidebarIcon,
   LeftElement: LeftElementContainer,
   RightElement: RightElementContainer,
 });

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarLink.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarLink.tsx
@@ -13,7 +13,7 @@ import {
   FullWidthButton,
 } from "./SidebarItems.styled";
 
-interface Props {
+interface SidebarLinkProps {
   children: string;
   url?: string;
   icon?: string | IconProps | React.ReactElement;
@@ -51,7 +51,7 @@ function SidebarLink({
   left = null,
   right = null,
   ...props
-}: Props) {
+}: SidebarLinkProps) {
   const renderIcon = useCallback(() => {
     if (!icon) {
       return null;
@@ -92,6 +92,8 @@ function SidebarLink({
     </NodeRoot>
   );
 }
+
+export type { SidebarLinkProps };
 
 export default Object.assign(SidebarLink, {
   NameContainers: [ItemName, TreeNode.NameContainer],

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/index.ts
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/index.ts
@@ -1,3 +1,4 @@
+export { default as DraggableSidebarLink } from "./DraggableSidebarLink";
 export { default as SidebarCollectionLink } from "./SidebarCollectionLink";
 export { default as SidebarDataAppLink } from "./SidebarDataAppLink";
 export { default as SidebarLink } from "./SidebarLink";

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/sortable.css
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/sortable.css
@@ -1,9 +1,8 @@
 .react-sortable-hoc-helper.sorting {
-  background: white;
   border-bottom: 2px solid var(--color-brand);
 }
 
-.react-sortable-hoc-helper.sorting > svg {
+.react-sortable-hoc-helper.sorting .Icon-grabber2 {
   color: var(--color-brand);
   opacity: 0.5;
 }


### PR DESCRIPTION
In #25456 we want to let people rearrange items in their data app navigation sidebar. This is the first step towards it, we already have reorderable sidebar items for bookmarks. This PR extracts the `DraggableSidebarLink` component from there that would be used for both bookmarks and data apps

### To Verify

1. Bookmark a few questions / models / dashboards / collections
2. Try reordering bookmarks, removing items from the bookmark bar
3. Ensure everything works the same as on `master`