### PR TITLE
adding reordering tests to funnel charts

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChartSettingsWidget.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettingsWidget.tsx
@@ -21,6 +21,7 @@ type Props = {
   props?: Record<string, unknown>;
   noPadding?: boolean;
   variant?: "default" | "form-field";
+  dataTestId?: string;
 };
 
 const ChartSettingsWidget = ({
@@ -33,6 +34,7 @@ const ChartSettingsWidget = ({
   inline = false,
   marginBottom = undefined,
   widget: Widget,
+  dataTestId,
   props,
   // disables X padding for certain widgets so divider line extends to edge
   noPadding,
@@ -50,6 +52,7 @@ const ChartSettingsWidget = ({
       className={cx({ "Form-field": isFormField })}
       inline={inline}
       marginBottom={marginBottom}
+      data-testid={dataTestId}
     >
       {title && (
         <Title variant={variant} className={cx({ "Form-label": isFormField })}>

--- a/frontend/src/metabase/visualizations/components/FunnelNormal.jsx
+++ b/frontend/src/metabase/visualizations/components/FunnelNormal.jsx
@@ -130,7 +130,10 @@ export default class FunnelNormal extends Component {
         <div
           className={cx(styles.FunnelStep, styles.Initial, "flex flex-column")}
         >
-          <Ellipsified className={styles.Head}>
+          <Ellipsified
+            className={styles.Head}
+            data-testid="funnel-chart-header"
+          >
             {formatDimension(rows[0][dimensionIndex])}
           </Ellipsified>
           <div className={styles.Start}>
@@ -156,7 +159,10 @@ export default class FunnelNormal extends Component {
               key={index}
               className={cx(styles.FunnelStep, "flex flex-column")}
             >
-              <Ellipsified className={styles.Head}>
+              <Ellipsified
+                className={styles.Head}
+                data-testid="funnel-chart-header"
+              >
                 {formatDimension(rows[index + 1][dimensionIndex])}
               </Ellipsified>
               <GraphSection

--- a/frontend/src/metabase/visualizations/visualizations/Funnel.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Funnel.jsx
@@ -114,7 +114,6 @@ export default class Funnel extends Component {
       section: t`Data`,
       widget: ChartSettingOrderedSimple,
       isValid: (series, settings) => {
-        console.log(series);
         const funnelRows = settings["funnel.rows"];
 
         if (!funnelRows || !_.isArray(funnelRows)) {
@@ -140,6 +139,7 @@ export default class Funnel extends Component {
       getProps: transformedSeries => ({
         items: transformedSeries.map(s => s.card),
       }),
+      dataTestId: "funnel-row-sort",
     },
     ...metricSetting("funnel.metric", {
       section: t`Data`,

--- a/frontend/test/metabase/scenarios/visualizations/funnel.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/funnel.cy.spec.js
@@ -26,46 +26,41 @@ describe("scenarios > visualizations > funnel chart", () => {
     sidebar().findByText("Data").click();
   });
 
-  it("should show the list of rows", () => {
-    cy.findAllByTestId(/draggable-item/).should("have.length", 5);
-  });
+  it("hould allow you to reorder and show/hide rows", () => {
+    cy.log("ensure that rows are shown");
+    getDraggableRows().should("have.length", 5);
 
-  it("should allow you to reorder rows", async () => {
-    cy.findAllByTestId(/draggable-item/)
+    getDraggableRows()
       .first()
       .invoke("text")
       .then(name => {
+        cy.log(`mode row ${name} down 2`);
         cy.findAllByTestId("funnel-chart-header")
           .first()
           .should("have.text", name);
 
-        moveColumnDown(cy.findAllByTestId(/draggable-item/).first(), 2);
+        moveColumnDown(getDraggableRows().first(), 2);
 
-        cy.findAllByTestId(/draggable-item/)
-          .eq(2)
-          .should("have.text", name);
+        getDraggableRows().eq(2).should("have.text", name);
 
         cy.findAllByTestId("funnel-chart-header")
           .eq(2)
           .should("have.text", name);
       });
-  });
 
-  it("should allow you toggle row visibility", async () => {
-    cy.findAllByTestId(/draggable-item/)
-      .eq(1)
-      .find(".Icon-eye_filled")
-      .click();
+    cy.log("toggle row visibility");
+    getDraggableRows().eq(1).find(".Icon-eye_filled").click();
     cy.findAllByTestId("funnel-chart-header").should("have.length", 4);
 
-    cy.findAllByTestId(/draggable-item/)
-      .eq(1)
-      .find(".Icon-eye_crossed_out")
-      .click();
+    getDraggableRows().eq(1).find(".Icon-eye_crossed_out").click();
 
     cy.findAllByTestId("funnel-chart-header").should("have.length", 5);
   });
 });
+
+function getDraggableRows() {
+  return cy.findAllByTestId(/draggable-item/);
+}
 
 function moveColumnDown(column, distance) {
   column

--- a/frontend/test/metabase/scenarios/visualizations/funnel.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/funnel.cy.spec.js
@@ -1,0 +1,76 @@
+import { restore, visitQuestionAdhoc, sidebar } from "__support__/e2e/helpers";
+
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+
+const { PEOPLE_ID, PEOPLE } = SAMPLE_DATABASE;
+
+describe("scenarios > visualizations > funnel chart", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsNormalUser();
+
+    visitQuestionAdhoc({
+      dataset_query: {
+        type: "query",
+        query: {
+          "source-table": PEOPLE_ID,
+          aggregation: [["count"]],
+          breakout: [["field", PEOPLE.SOURCE]],
+        },
+        database: SAMPLE_DB_ID,
+      },
+      display: "funnel",
+    });
+    cy.findByText("Settings").click();
+    sidebar().findByText("Data").click();
+  });
+
+  it("should show the list of rows", () => {
+    cy.findAllByTestId(/draggable-item/).should("have.length", 5);
+  });
+
+  it("should allow you to reorder rows", async () => {
+    cy.findAllByTestId(/draggable-item/)
+      .first()
+      .invoke("text")
+      .then(name => {
+        cy.findAllByTestId("funnel-chart-header")
+          .first()
+          .should("have.text", name);
+
+        moveColumnDown(cy.findAllByTestId(/draggable-item/).first(), 2);
+
+        cy.findAllByTestId(/draggable-item/)
+          .eq(2)
+          .should("have.text", name);
+
+        cy.findAllByTestId("funnel-chart-header")
+          .eq(2)
+          .should("have.text", name);
+      });
+  });
+
+  it("should allow you toggle row visibility", async () => {
+    cy.findAllByTestId(/draggable-item/)
+      .eq(1)
+      .find(".Icon-eye_filled")
+      .click();
+    cy.findAllByTestId("funnel-chart-header").should("have.length", 4);
+
+    cy.findAllByTestId(/draggable-item/)
+      .eq(1)
+      .find(".Icon-eye_crossed_out")
+      .click();
+
+    cy.findAllByTestId("funnel-chart-header").should("have.length", 5);
+  });
+});
+
+function moveColumnDown(column, distance) {
+  column
+    .trigger("mousedown", 0, 0, { force: true })
+    .trigger("mousemove", 5, 5, { force: true })
+    .trigger("mousemove", 0, distance * 50, { force: true })
+    .trigger("mouseup", 0, distance * 50, { force: true });
+}

--- a/frontend/test/metabase/scenarios/visualizations/funnel.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/funnel.cy.spec.js
@@ -49,11 +49,18 @@ describe("scenarios > visualizations > funnel chart", () => {
       });
 
     cy.log("toggle row visibility");
-    getDraggableRows().eq(1).find(".Icon-eye_filled").click();
+    getDraggableRows()
+      .eq(1)
+      .within(() => {
+        cy.icon("eye_filled").click();
+      });
     cy.findAllByTestId("funnel-chart-header").should("have.length", 4);
 
-    getDraggableRows().eq(1).find(".Icon-eye_crossed_out").click();
-
+    getDraggableRows()
+      .eq(1)
+      .within(() => {
+        cy.icon("eye_crossed_out").click();
+      });
     cy.findAllByTestId("funnel-chart-header").should("have.length", 5);
   });
 });


### PR DESCRIPTION
EPIC #24840

PR to add cypress tests to showing, reordering, and toggling row visibility.