### PR TITLE
Add a link to specific docs page for selected mbql functions

### DIFF
--- a/frontend/src/metabase/lib/expressions/helper-text-strings.ts
+++ b/frontend/src/metabase/lib/expressions/helper-text-strings.ts
@@ -1,6 +1,9 @@
 import { t } from "ttag";
+import MetabaseSettings from "metabase/lib/settings";
+import { getExpressionName } from "metabase/lib/expressions/config";
+import { HelpText } from "./types";
 
-const helperTextStrings = [
+const helperTextStrings: HelpText[] = [
   {
     name: "count",
     structure: "Count",
@@ -504,6 +507,7 @@ const helperTextStrings = [
         description: t`The column to check.`,
       },
     ],
+    hasDocsPage: true,
   },
   {
     name: "is-empty",
@@ -516,6 +520,7 @@ const helperTextStrings = [
         description: t`The column to check.`,
       },
     ],
+    hasDocsPage: true,
   },
   {
     name: "coalesce",
@@ -536,6 +541,7 @@ const helperTextStrings = [
         description: t`If value1 is empty, value2 gets returned if its not empty, and so on.`,
       },
     ],
+    hasDocsPage: true,
   },
   {
     name: "case",
@@ -563,7 +569,18 @@ const helperTextStrings = [
         description: t`The value that will be returned if the preceding condition is true, and so on.`,
       },
     ],
+    hasDocsPage: true,
   },
 ];
 
-export default name => helperTextStrings.find(h => h.name === name);
+export const getHelpText = (name: string): HelpText | undefined => {
+  return helperTextStrings.find(h => h.name === name);
+};
+
+export const getHelpDocsUrl = ({ name, hasDocsPage }: HelpText): string => {
+  const docsUrl = hasDocsPage
+    ? `questions/query-builder/expressions/${getExpressionName(name)}`
+    : "questions/query-builder/expressions";
+
+  return MetabaseSettings.docsUrl(docsUrl);
+};

--- a/frontend/src/metabase/lib/expressions/suggest.js
+++ b/frontend/src/metabase/lib/expressions/suggest.js
@@ -9,7 +9,7 @@ import {
 
 import { partialMatch, enclosingFunction } from "./completer";
 
-import getHelpText from "./helper_text_strings";
+import { getHelpText } from "./helper-text-strings";
 
 import {
   EXPRESSION_FUNCTIONS,

--- a/frontend/src/metabase/lib/expressions/types.ts
+++ b/frontend/src/metabase/lib/expressions/types.ts
@@ -1,0 +1,13 @@
+export interface HelpText {
+  name: string;
+  args: HelpTextArg[];
+  description: string;
+  example: string;
+  structure: string;
+  hasDocsPage?: boolean;
+}
+
+export interface HelpTextArg {
+  name: string;
+  description: string;
+}

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText.tsx
@@ -8,7 +8,7 @@ import ExternalLink from "metabase/core/components/ExternalLink";
 import Icon from "metabase/components/Icon";
 import TippyPopover from "metabase/components/Popover/TippyPopover";
 
-interface HelpTextProps {
+interface ExpressionEditorHelpTextProps {
   helpText: HelpText;
   width: number;
   target: Element;
@@ -18,7 +18,7 @@ const ExpressionEditorHelpText = ({
   helpText,
   width,
   target,
-}: HelpTextProps) => {
+}: ExpressionEditorHelpTextProps) => {
   if (!helpText) {
     return null;
   }

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText.tsx
@@ -1,23 +1,12 @@
 import React from "react";
 import { t } from "ttag";
 
-import MetabaseSettings from "metabase/lib/settings";
 import { color } from "metabase/lib/colors";
+import { getHelpDocsUrl } from "metabase/lib/expressions/helper-text-strings";
+import { HelpText } from "metabase/lib/expressions/types";
 import ExternalLink from "metabase/core/components/ExternalLink";
 import Icon from "metabase/components/Icon";
 import TippyPopover from "metabase/components/Popover/TippyPopover";
-
-type Arg = {
-  name: string;
-  description: string;
-};
-
-type HelpText = {
-  args: Arg[];
-  description: string;
-  example: string;
-  structure: string;
-};
 
 interface HelpTextProps {
   helpText: HelpText;
@@ -25,7 +14,11 @@ interface HelpTextProps {
   target: Element;
 }
 
-const HelpText = ({ helpText, width, target }: HelpTextProps) => {
+const ExpressionEditorHelpText = ({
+  helpText,
+  width,
+  target,
+}: HelpTextProps) => {
   if (!helpText) {
     return null;
   }
@@ -60,9 +53,7 @@ const HelpText = ({ helpText, width, target }: HelpTextProps) => {
               <ExternalLink
                 className="link text-bold block my1"
                 target="_blank"
-                href={MetabaseSettings.docsUrl(
-                  "questions/query-builder/expressions",
-                )}
+                href={getHelpDocsUrl(helpText)}
               >
                 <Icon name="reference" size={12} className="mr1" />
                 {t`Learn more`}
@@ -71,8 +62,8 @@ const HelpText = ({ helpText, width, target }: HelpTextProps) => {
           </div>
         </>
       }
-    ></TippyPopover>
+    />
   );
 };
 
-export default HelpText;
+export default ExpressionEditorHelpText;


### PR DESCRIPTION
Product doc https://www.notion.so/metabase/Link-to-targeted-custom-expression-docs-when-available-c16afcfa28134e7f83a4078bcd2c1689

How to test:
- New -> Question -> Custom Column
- Type `coalesce` and click on the suggestion or press tab
- Make sure that `Learn more` opens separate docs pages as specified in the product doc

<img width="579" alt="Screenshot 2022-09-16 at 19 02 20" src="https://user-images.githubusercontent.com/8542534/190681632-396e47e0-4942-455f-aa89-70f1d05c57b3.png">
