### PR TITLE
Automatically pin models on creation

### DIFF
--- a/frontend/src/metabase-lib/lib/Question.ts
+++ b/frontend/src/metabase-lib/lib/Question.ts
@@ -322,6 +322,12 @@ class QuestionInner {
     return this.setCard(assoc(this.card(), "dataset", dataset));
   }
 
+  setPinned(pinned: boolean) {
+    return this.setCard(
+      assoc(this.card(), "collection_position", pinned ? 1 : null),
+    );
+  }
+
   setIsAction(isAction) {
     return this.setCard(assoc(this.card(), "is_write", isAction));
   }

--- a/frontend/src/metabase/query_builder/actions/models.js
+++ b/frontend/src/metabase/query_builder/actions/models.js
@@ -36,7 +36,7 @@ export const turnQuestionIntoDataset = () => async (dispatch, getState) => {
       {
         id: question.id(),
       },
-      question.setDataset(true).setDisplay("table").card(),
+      question.setDataset(true).setPinned(true).setDisplay("table").card(),
     ),
   );
 

--- a/frontend/src/metabase/query_builder/components/QueryModals.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryModals.jsx
@@ -228,7 +228,6 @@ class QueryModals extends React.Component {
               ...question.card(),
               ...formValues,
               description: formValues.description || null,
-              collection_position: null,
             });
             return { payload: { object } };
           }}

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
@@ -266,7 +266,7 @@ function QueryBuilder(props) {
 
   const handleCreate = useCallback(
     async card => {
-      const questionWithUpdatedCard = question.setCard(card);
+      const questionWithUpdatedCard = question.setCard(card).setPinned(false);
       await apiCreateQuestion(questionWithUpdatedCard);
       setRecentlySaved("created");
     },

--- a/frontend/test/__support__/e2e/helpers/e2e-ui-elements-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-ui-elements-helpers.js
@@ -79,3 +79,7 @@ export const closeQuestionActions = () => {
 export const questionInfoButton = () => {
   return cy.findByTestId("qb-header-info-button");
 };
+
+export const undo = () => {
+  cy.findByTestId("toast-undo").findByText("Undo").click();
+};

--- a/frontend/test/metabase/scenarios/models/models.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models.cy.spec.js
@@ -15,6 +15,7 @@ import {
   openQuestionActions,
   closeQuestionActions,
   visitCollection,
+  undo,
 } from "__support__/e2e/helpers";
 
 import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
@@ -477,11 +478,24 @@ describe("scenarios > models", () => {
 
   it("should automatically pin newly created models", () => {
     visitQuestion(1);
+
     turnIntoModel();
 
     visitCollection("root");
     cy.findByText("Useful data");
     cy.findByText("A model");
+  });
+
+  it("should undo pinning a question if turning into a model was undone", () => {
+    visitQuestion(1);
+
+    turnIntoModel();
+    undo();
+    cy.wait("@cardUpdate");
+
+    visitCollection("root");
+    cy.findByText("Useful data").should("not.exist");
+    cy.findByText("A model").should("not.exist");
   });
 
   describe("listing", () => {

--- a/frontend/test/metabase/scenarios/models/models.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models.cy.spec.js
@@ -73,7 +73,7 @@ describe("scenarios > models", () => {
     });
 
     cy.findByTestId("qb-header").findAllByText("Our analytics").first().click();
-    getCollectionItemRow("Orders Model").within(() => {
+    getCollectionItemCard("Orders Model").within(() => {
       cy.icon("model");
     });
     getCollectionItemRow("Q1").within(() => {
@@ -122,7 +122,7 @@ describe("scenarios > models", () => {
     });
 
     cy.findByTestId("qb-header").findAllByText("Our analytics").first().click();
-    getCollectionItemRow("Orders Model").within(() => {
+    getCollectionItemCard("Orders Model").within(() => {
       cy.icon("model");
     });
     getCollectionItemRow("Q1").within(() => {
@@ -540,6 +540,10 @@ describe("scenarios > models", () => {
 
 function getCollectionItemRow(itemName) {
   return cy.findByText(itemName).closest("tr");
+}
+
+function getCollectionItemCard(itemName) {
+  return cy.findByText(itemName).parent();
 }
 
 function testDataPickerSearch({

--- a/frontend/test/metabase/scenarios/models/models.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models.cy.spec.js
@@ -14,6 +14,7 @@ import {
   startNewQuestion,
   openQuestionActions,
   closeQuestionActions,
+  visitCollection,
 } from "__support__/e2e/helpers";
 
 import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
@@ -472,6 +473,15 @@ describe("scenarios > models", () => {
     cy.findByText("TEST MODEL").click();
     cy.wait("@cardQuery");
     cy.findByText(/This question is written in SQL/i).should("not.exist");
+  });
+
+  it("should automatically pin newly created models", () => {
+    visitQuestion(1);
+    turnIntoModel();
+
+    visitCollection("root");
+    cy.findByText("Useful data");
+    cy.findByText("A model");
   });
 
   describe("listing", () => {


### PR DESCRIPTION
Product doc https://www.notion.so/metabase/Automatically-pin-newly-created-models-by-default-597b7038bb574227a65ae21b49cb0208

How to test:
- Go to a saved question and turn into a model
- Go to the question's collection and make sure the model was pinned
- Make sure that undoing the conversion also unpins the question

<img width="479" alt="Screenshot 2022-09-19 at 11 52 34" src="https://user-images.githubusercontent.com/8542534/190982250-a87b4c23-2c4c-46c7-8aff-e8c2e1dbb174.png">
