### PR TITLE
Fix inconsistent left y-axis padding

### DIFF
--- a/frontend/src/metabase/static-viz/components/LineAreaBarChart/LineAreaBarChart.tsx
+++ b/frontend/src/metabase/static-viz/components/LineAreaBarChart/LineAreaBarChart.tsx
@@ -1,6 +1,4 @@
 import React from "react";
-import { color } from "metabase/lib/colors";
-import { colors } from "metabase/lib/colors/palette";
 import { ColorGetter } from "metabase/static-viz/lib/colors";
 import { XYChart } from "../XYChart";
 import { ChartSettings, ChartStyle, Series } from "../XYChart/types";

--- a/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
@@ -39,8 +39,6 @@ import type {
   ChartSettings,
   ChartStyle,
   HydratedSeries,
-  XScale,
-  XAxisType,
 } from "metabase/static-viz/components/XYChart/types";
 import Values from "./Values";
 

--- a/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
@@ -5,7 +5,6 @@ import { GridRows } from "@visx/grid";
 import { Group } from "@visx/group";
 import { assoc } from "icepick";
 
-import type { TimeInterval } from "d3-time";
 import { formatNumber } from "metabase/static-viz/lib/numbers";
 import { LineSeries } from "metabase/static-viz/components/XYChart/shapes/LineSeries";
 import { BarSeries } from "metabase/static-viz/components/XYChart/shapes/BarSeries";

--- a/frontend/src/metabase/static-viz/components/XYChart/constants.ts
+++ b/frontend/src/metabase/static-viz/components/XYChart/constants.ts
@@ -1,6 +1,6 @@
 export const MAX_ROTATED_TICK_WIDTH = 100;
 
-export const CHART_PADDING = 10;
+export const CHART_PADDING = 12;
 
 export const LABEL_PADDING = 12;
 

--- a/frontend/src/metabase/static-viz/components/XYChart/utils/margin.ts
+++ b/frontend/src/metabase/static-viz/components/XYChart/utils/margin.ts
@@ -2,7 +2,7 @@ import { measureTextHeight } from "metabase/static-viz/lib/text";
 import { CHART_PADDING } from "metabase/static-viz/components/XYChart/constants";
 import { ChartSettings } from "metabase/static-viz/components/XYChart/types";
 
-export const LABEL_OFFSET = 10;
+export const LABEL_OFFSET = 12;
 export const MARGIN = 6;
 
 const calculateSideMargin = (

--- a/frontend/src/metabase/static-viz/components/XYChart/utils/ticks.ts
+++ b/frontend/src/metabase/static-viz/components/XYChart/utils/ticks.ts
@@ -91,7 +91,7 @@ export const getXTicksDimensions = (
     const rotatedSize = getRotatedXTickHeight(maxTextWidth);
 
     return {
-      width: Math.min(rotatedSize, MAX_ROTATED_TICK_WIDTH),
+      width: measureTextHeight(fontSize),
       height: Math.min(rotatedSize, MAX_ROTATED_TICK_WIDTH),
       maxTextWidth,
     };


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/24759

This PR fixes:
- Inconsistent left margin
- XY charts without a left y-axis label sometimes is cut off