### PR TITLE
[E2E] Fix flaking models metadata test

### DIFF
--- a/frontend/test/metabase/scenarios/models/models-metadata.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models-metadata.cy.spec.js
@@ -134,8 +134,9 @@ describe("scenarios > models metadata", () => {
     cy.button("Save changes").click();
 
     // Revision 1
-    cy.findByText("Subtotal ($)");
-    cy.findByText("Tax ($)").should("not.exist");
+    cy.findAllByTestId("header-cell")
+      .should("contain", "Subtotal ($)")
+      .and("not.contain", "SUBTOTAL");
 
     openQuestionActions();
     cy.findByText("Edit metadata").click();
@@ -149,8 +150,10 @@ describe("scenarios > models metadata", () => {
     setColumnType("No special type", "Cost");
     cy.button("Save changes").click();
 
-    cy.findByText("Subtotal ($)");
-    cy.findByText("Tax ($)");
+    cy.findAllByTestId("header-cell")
+      .should("contain", "Subtotal ($)")
+      .and("contain", "Tax ($)")
+      .and("not.contain", "TAX");
 
     cy.reload();
     questionInfoButton().click();
@@ -161,9 +164,10 @@ describe("scenarios > models metadata", () => {
     });
 
     cy.wait("@revert");
-    cy.findByText("Subtotal ($)");
-    cy.findByText("Tax ($)").should("not.exist");
-    cy.findByText("TAX");
+    cy.findAllByTestId("header-cell")
+      .should("contain", "Subtotal ($)")
+      .and("not.contain", "Tax ($)")
+      .and("contain", "TAX");
   });
 
   describe("native models metadata overwrites", () => {


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Attempts to fix a flake by scoping the search for a specific string to a header cell (where it belongs)
    - Before this fix, it sometimes found multiple strings

The example of the latest failure:
https://github.com/metabase/metabase/actions/runs/3083661421/jobs/4985100648