### PR TITLE
Fix warning: check if dimensionForColumn is function

### DIFF
--- a/frontend/src/metabase/visualizations/lib/table.js
+++ b/frontend/src/metabase/visualizations/lib/table.js
@@ -91,7 +91,9 @@ export function getTableHeaderClickedObject(
   } else {
     return {
       column,
-      dimension: query?.dimensionForColumn(column),
+      dimension:
+        typeof query?.dimensionForColumn === "function" &&
+        query?.dimensionForColumn(column),
     };
   }
 }


### PR DESCRIPTION
### Steps to Reproduce

1. `+ New`
2. SQL Query
3. select * from {{#...}} and autocomplete with a model
4. Run the query
5. Edit the query so that you delete the {{#}} then write it again

You should no longer see web console warnings saying `TypeError: query.dimensionForColumn is not a function……`

#### Notes

This came out of investigating #25492
As the warning is fired when that bug happens, we attempted to fix the bug by fixing this. Didn't work, but here we clean up the logs a bit.
