### PR TITLE
docs - remove generated api doc tables of contents

### DIFF
--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -1,10 +1,14 @@
 ---
-title: Metabase API documentation
+title: "Metabase API documentation"
 ---
 
 # Metabase API documentation
 
-_These reference files were generated from source comments by running `clojure -M:ee:run api-documentation`_.
+_These reference files were generated from source comments by running:
+
+```
+clojure -M:ee:run api-documentation
+```
 
 ## About the Metabase API
 
@@ -20,9 +24,11 @@ Check out an introduction to the [Metabase API](https://www.metabase.com/learn/a
 _* indicates endpoints used for features available on [paid plans](https://www.metabase.com/pricing/)._
 
 
+- [Action](api/action.md)
 - [Activity](api/activity.md)
 - [Advanced permissions application*](api/ee/advanced-permissions-application.md)
 - [Alert](api/alert.md)
+- [App](api/app.md)
 - [Audit app user*](api/ee/audit-app-user.md)
 - [Automagic dashboards](api/automagic-dashboards.md)
 - [Bookmark](api/bookmark.md)
@@ -34,6 +40,7 @@ _* indicates endpoints used for features available on [paid plans](https://www.m
 - [Dataset](api/dataset.md)
 - [Email](api/email.md)
 - [Embed](api/embed.md)
+- [Emitter](api/emitter.md)
 - [Field](api/field.md)
 - [GeoJSON](api/geojson.md)
 - [LDAP](api/ldap.md)

--- a/docs/api/action.md
+++ b/docs/api/action.md
@@ -1,0 +1,101 @@
+---
+title: "Action"
+summary: |
+  `/api/action/` endpoints.
+---
+
+# Action
+
+`/api/action/` endpoints.
+
+## `DELETE /api/action/:action-id`
+
+### PARAMS:
+
+*  **`action-id`**
+
+## `GET /api/action/`
+
+Returns cards that can be used for QueryActions.
+
+## `GET /api/action/:action-id`
+
+### PARAMS:
+
+*  **`action-id`**
+
+## `POST /api/action/`
+
+Create a new HTTP action.
+
+### PARAMS:
+
+*  **`type`** Only http actions are supported at this time.
+
+*  **`name`** value must be a string.
+
+*  **`template`** value must be a map with schema: (
+  body (optional) : value may be nil, or if non-nil, value must be a string.
+  headers (optional) : value may be nil, or if non-nil, value must be a string.
+  parameter_mappings (optional) : value may be nil, or if non-nil, value must be a map.
+  parameters (optional) : value may be nil, or if non-nil, value must be an array. Each value must be a map.
+  method : value must be one of: `DELETE`, `GET`, `PATCH`, `POST`, `PUT`.
+  url : value must be a string.
+)
+
+*  **`response_handle`** value may be nil, or if non-nil, must be a valid json-query
+
+*  **`error_handle`** value may be nil, or if non-nil, must be a valid json-query
+
+*  **`action`**
+
+## `POST /api/action/:action-namespace/:action-name`
+
+Generic API endpoint for executing any sort of Action.
+
+### PARAMS:
+
+*  **`action-namespace`** 
+
+*  **`action-name`**
+
+## `POST /api/action/:action-namespace/:action-name/:table-id`
+
+Generic API endpoint for executing any sort of Action with source Table ID specified as part of the route.
+
+### PARAMS:
+
+*  **`action-namespace`** 
+
+*  **`action-name`** 
+
+*  **`table-id`**
+
+## `PUT /api/action/:id`
+
+### PARAMS:
+
+*  **`id`** value must be an integer greater than zero.
+
+*  **`type`** Only http actions are supported at this time.
+
+*  **`name`** value may be nil, or if non-nil, value must be a string.
+
+*  **`template`** value may be nil, or if non-nil, value must be a map with schema: (
+  body (optional) : value may be nil, or if non-nil, value must be a string.
+  headers (optional) : value may be nil, or if non-nil, value must be a string.
+  parameter_mappings (optional) : value may be nil, or if non-nil, value must be a map.
+  parameters (optional) : value may be nil, or if non-nil, value must be an array. Each value must be a map.
+  method : value must be one of: `DELETE`, `GET`, `PATCH`, `POST`, `PUT`.
+  url : value must be a string.
+)
+
+*  **`response_handle`** value may be nil, or if non-nil, must be a valid json-query
+
+*  **`error_handle`** value may be nil, or if non-nil, must be a valid json-query
+
+*  **`action`**
+
+---
+
+[<< Back to API index](../api-documentation.md)

--- a/docs/api/activity.md
+++ b/docs/api/activity.md
@@ -8,10 +8,6 @@ summary: |
 
 API endpoints for Activity.
 
-  - [GET /api/activity/](#get-apiactivity)
-  - [GET /api/activity/popular_items](#get-apiactivitypopular_items)
-  - [GET /api/activity/recent_views](#get-apiactivityrecent_views)
-
 ## `GET /api/activity/`
 
 Get recent activity.

--- a/docs/api/alert.md
+++ b/docs/api/alert.md
@@ -8,13 +8,6 @@ summary: |
 
 /api/alert endpoints.
 
-  - [DELETE /api/alert/:id/subscription](#delete-apialertidsubscription)
-  - [GET /api/alert/](#get-apialert)
-  - [GET /api/alert/:id](#get-apialertid)
-  - [GET /api/alert/question/:id](#get-apialertquestionid)
-  - [POST /api/alert/](#post-apialert)
-  - [PUT /api/alert/:id](#put-apialertid)
-
 ## `DELETE /api/alert/:id/subscription`
 
 For users to unsubscribe themselves from the given alert.

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1,0 +1,90 @@
+---
+title: "App"
+summary: |
+  API endpoints for App.
+---
+
+# App
+
+API endpoints for App.
+
+## `GET /api/app/`
+
+Fetch a list of all Apps that the current user has read permissions for.
+
+  By default, this returns Apps with non-archived Collections, but instead you can show archived ones by passing
+  `?archived=true`.
+
+### PARAMS:
+
+*  **`archived`** value may be nil, or if non-nil, value must be a valid boolean string ('true' or 'false').
+
+## `GET /api/app/:id`
+
+Fetch a specific App.
+
+### PARAMS:
+
+*  **`id`**
+
+## `POST /api/app/`
+
+Endpoint to create an app.
+
+### PARAMS:
+
+*  **`options`** value may be nil, or if non-nil, value must be a map.
+
+*  **`namespace`** value may be nil, or if non-nil, value must be a non-blank string.
+
+*  **`dashboard_id`** value may be nil, or if non-nil, value must be an integer greater than or equal to zero.
+
+*  **`nav_items`** value may be nil, or if non-nil, value must be an array. Each value may be nil, or if non-nil, value must be a map.
+
+*  **`authority_level`** value may be nil, or if non-nil, value must be one of: `official`.
+
+*  **`description`** value may be nil, or if non-nil, value must be a non-blank string.
+
+*  **`color`** value must be a string that matches the regex `^#[0-9A-Fa-f]{6}$`.
+
+*  **`name`** value must be a non-blank string.
+
+*  **`app`**
+
+## `POST /api/app/:app-id/scaffold`
+
+Endpoint to scaffold a new table onto an existing data-app.
+
+### PARAMS:
+
+*  **`app-id`** 
+
+*  **`table-ids`**
+
+## `POST /api/app/scaffold`
+
+Endpoint to scaffold a fully working data-app.
+
+### PARAMS:
+
+*  **`table-ids`** 
+
+*  **`app-name`**
+
+## `PUT /api/app/:app-id`
+
+Endpoint to change an app.
+
+### PARAMS:
+
+*  **`app-id`** value must be an integer greater than or equal to zero.
+
+*  **`dashboard_id`** value may be nil, or if non-nil, value must be an integer greater than or equal to zero.
+
+*  **`options`** value may be nil, or if non-nil, value must be a map.
+
+*  **`nav_items`** value may be nil, or if non-nil, value must be an array. Each value may be nil, or if non-nil, value must be a map.
+
+---
+
+[<< Back to API index](../api-documentation.md)

--- a/docs/api/automagic-dashboards.md
+++ b/docs/api/automagic-dashboards.md
@@ -8,16 +8,6 @@ summary: |
 
 API endpoints for Automagic dashboards.
 
-  - [GET /api/automagic-dashboards/:entity/:entity-id-or-query](#get-apiautomagic-dashboardsentityentity-id-or-query)
-  - [GET /api/automagic-dashboards/:entity/:entity-id-or-query/cell/:cell-query](#get-apiautomagic-dashboardsentityentity-id-or-querycellcell-query)
-  - [GET /api/automagic-dashboards/:entity/:entity-id-or-query/cell/:cell-query/compare/:comparison-entity/:comparison-entity-id-or-query](#get-apiautomagic-dashboardsentityentity-id-or-querycellcell-querycomparecomparison-entitycomparison-entity-id-or-query)
-  - [GET /api/automagic-dashboards/:entity/:entity-id-or-query/cell/:cell-query/rule/:prefix/:rule](#get-apiautomagic-dashboardsentityentity-id-or-querycellcell-queryruleprefixrule)
-  - [GET /api/automagic-dashboards/:entity/:entity-id-or-query/cell/:cell-query/rule/:prefix/:rule/compare/:comparison-entity/:comparison-entity-id-or-query](#get-apiautomagic-dashboardsentityentity-id-or-querycellcell-queryruleprefixrulecomparecomparison-entitycomparison-entity-id-or-query)
-  - [GET /api/automagic-dashboards/:entity/:entity-id-or-query/compare/:comparison-entity/:comparison-entity-id-or-query](#get-apiautomagic-dashboardsentityentity-id-or-querycomparecomparison-entitycomparison-entity-id-or-query)
-  - [GET /api/automagic-dashboards/:entity/:entity-id-or-query/rule/:prefix/:rule](#get-apiautomagic-dashboardsentityentity-id-or-queryruleprefixrule)
-  - [GET /api/automagic-dashboards/:entity/:entity-id-or-query/rule/:prefix/:rule/compare/:comparison-entity/:comparison-entity-id-or-query](#get-apiautomagic-dashboardsentityentity-id-or-queryruleprefixrulecomparecomparison-entitycomparison-entity-id-or-query)
-  - [GET /api/automagic-dashboards/database/:id/candidates](#get-apiautomagic-dashboardsdatabaseidcandidates)
-
 ## `GET /api/automagic-dashboards/:entity/:entity-id-or-query`
 
 Return an automagic dashboard for entity `entity` with id `id`.

--- a/docs/api/bookmark.md
+++ b/docs/api/bookmark.md
@@ -16,11 +16,6 @@ Handle creating bookmarks for the user. Bookmarks are in three tables and should
   underlying tables the id on the actual bookmark itself is not unique among "bookmarks" and is not a good
   identifier for using in the API.
 
-  - [DELETE /api/bookmark/:model/:id](#delete-apibookmarkmodelid)
-  - [GET /api/bookmark/](#get-apibookmark)
-  - [POST /api/bookmark/:model/:id](#post-apibookmarkmodelid)
-  - [PUT /api/bookmark/ordering](#put-apibookmarkordering)
-
 ## `DELETE /api/bookmark/:model/:id`
 
 Delete a bookmark. Will delete a bookmark assigned to the user making the request by model and id.
@@ -51,7 +46,10 @@ Sets the order of bookmarks for user.
 
 ### PARAMS:
 
-*  **`orderings`** value must be an array.
+*  **`orderings`** value must be an array. Each value must be a map with schema: (
+  item_id : value must be an integer greater than zero.
+  type : value must be one of: `card`, `collection`, `dashboard`.
+)
 
 ---
 

--- a/docs/api/card.md
+++ b/docs/api/card.md
@@ -8,27 +8,6 @@ summary: |
 
 /api/card endpoints.
 
-  - [DELETE /api/card/:card-id/public_link](#delete-apicardcard-idpublic_link)
-  - [DELETE /api/card/:id](#delete-apicardid)
-  - [GET /api/card/](#get-apicard)
-  - [GET /api/card/:id](#get-apicardid)
-  - [GET /api/card/:id/related](#get-apicardidrelated)
-  - [GET /api/card/:id/timelines](#get-apicardidtimelines)
-  - [GET /api/card/embeddable](#get-apicardembeddable)
-  - [GET /api/card/public](#get-apicardpublic)
-  - [POST /api/card/](#post-apicard)
-  - [POST /api/card/:card-id/persist](#post-apicardcard-idpersist)
-  - [POST /api/card/:card-id/public_link](#post-apicardcard-idpublic_link)
-  - [POST /api/card/:card-id/query](#post-apicardcard-idquery)
-  - [POST /api/card/:card-id/query/:export-format](#post-apicardcard-idqueryexport-format)
-  - [POST /api/card/:card-id/refresh](#post-apicardcard-idrefresh)
-  - [POST /api/card/:card-id/unpersist](#post-apicardcard-idunpersist)
-  - [POST /api/card/:id/copy](#post-apicardidcopy)
-  - [POST /api/card/collections](#post-apicardcollections)
-  - [POST /api/card/pivot/:card-id/query](#post-apicardpivotcard-idquery)
-  - [POST /api/card/related](#post-apicardrelated)
-  - [PUT /api/card/:id](#put-apicardid)
-
 ## `DELETE /api/card/:card-id/public_link`
 
 Delete the publicly-accessible link to this Card.
@@ -106,6 +85,8 @@ Create a new `Card`.
 
 *  **`visualization_settings`** value must be a map.
 
+*  **`is_write`** value may be nil, or if non-nil, value must be a boolean.
+
 *  **`parameters`** value may be nil, or if non-nil, value must be an array. Each parameter must be a map with :id and :type keys
 
 *  **`description`** value may be nil, or if non-nil, value must be a non-blank string.
@@ -120,7 +101,7 @@ Create a new `Card`.
 
 *  **`cache_ttl`** value may be nil, or if non-nil, value must be an integer greater than zero.
 
-*  **`dataset_query`** 
+*  **`dataset_query`** value must be a map.
 
 *  **`parameter_mappings`** value may be nil, or if non-nil, value must be an array. Each parameter_mapping must be a map with :parameter_id and :target keys
 

--- a/docs/api/collection.md
+++ b/docs/api/collection.md
@@ -16,19 +16,6 @@ summary: |
   To use these endpoints for other Collections namespaces, you can pass the `?namespace=` parameter (e.g.
   `?namespace=snippet`).
 
-  - [GET /api/collection/](#get-apicollection)
-  - [GET /api/collection/:id](#get-apicollectionid)
-  - [GET /api/collection/:id/items](#get-apicollectioniditems)
-  - [GET /api/collection/:id/timelines](#get-apicollectionidtimelines)
-  - [GET /api/collection/graph](#get-apicollectiongraph)
-  - [GET /api/collection/root](#get-apicollectionroot)
-  - [GET /api/collection/root/items](#get-apicollectionrootitems)
-  - [GET /api/collection/root/timelines](#get-apicollectionroottimelines)
-  - [GET /api/collection/tree](#get-apicollectiontree)
-  - [POST /api/collection/](#post-apicollection)
-  - [PUT /api/collection/:id](#put-apicollectionid)
-  - [PUT /api/collection/graph](#put-apicollectiongraph)
-
 ## `GET /api/collection/`
 
 Fetch a list of all Collections that the current user has read permissions for (`:can_write` is returned as an
@@ -65,7 +52,7 @@ Fetch a specific Collection's items with the following options:
 
 *  **`id`** 
 
-*  **`models`** value may be nil, or if non-nil, value must satisfy one of the following requirements: 1) value must be an array. Each value must be one of: `card`, `collection`, `dashboard`, `dataset`, `no_models`, `pulse`, `snippet`, `timeline`. 2) value must be one of: `card`, `collection`, `dashboard`, `dataset`, `no_models`, `pulse`, `snippet`, `timeline`.
+*  **`models`** value may be nil, or if non-nil, value must satisfy one of the following requirements: 1) value must be an array. Each value must be one of: `app`, `card`, `collection`, `dashboard`, `dataset`, `no_models`, `page`, `pulse`, `snippet`, `timeline`. 2) value must be one of: `app`, `card`, `collection`, `dashboard`, `dataset`, `no_models`, `page`, `pulse`, `snippet`, `timeline`.
 
 *  **`archived`** value may be nil, or if non-nil, value must be a valid boolean string ('true' or 'false').
 
@@ -123,7 +110,7 @@ Fetch objects that the current user should see at their root level. As mentioned
 
 ### PARAMS:
 
-*  **`models`** value may be nil, or if non-nil, value must satisfy one of the following requirements: 1) value must be an array. Each value must be one of: `card`, `collection`, `dashboard`, `dataset`, `no_models`, `pulse`, `snippet`, `timeline`. 2) value must be one of: `card`, `collection`, `dashboard`, `dataset`, `no_models`, `pulse`, `snippet`, `timeline`.
+*  **`models`** value may be nil, or if non-nil, value must satisfy one of the following requirements: 1) value must be an array. Each value must be one of: `app`, `card`, `collection`, `dashboard`, `dataset`, `no_models`, `page`, `pulse`, `snippet`, `timeline`. 2) value must be one of: `app`, `card`, `collection`, `dashboard`, `dataset`, `no_models`, `page`, `pulse`, `snippet`, `timeline`.
 
 *  **`archived`** value may be nil, or if non-nil, value must be a valid boolean string ('true' or 'false').
 

--- a/docs/api/dashboard.md
+++ b/docs/api/dashboard.md
@@ -8,31 +8,6 @@ summary: |
 
 /api/dashboard endpoints.
 
-  - [DELETE /api/dashboard/:dashboard-id/public_link](#delete-apidashboarddashboard-idpublic_link)
-  - [DELETE /api/dashboard/:id](#delete-apidashboardid)
-  - [DELETE /api/dashboard/:id/cards](#delete-apidashboardidcards)
-  - [GET /api/dashboard/](#get-apidashboard)
-  - [GET /api/dashboard/:id](#get-apidashboardid)
-  - [GET /api/dashboard/:id/params/:param-key/search/:query](#get-apidashboardidparamsparam-keysearchquery)
-  - [GET /api/dashboard/:id/params/:param-key/values](#get-apidashboardidparamsparam-keyvalues)
-  - [GET /api/dashboard/:id/related](#get-apidashboardidrelated)
-  - [GET /api/dashboard/:id/revisions](#get-apidashboardidrevisions)
-  - [GET /api/dashboard/embeddable](#get-apidashboardembeddable)
-  - [GET /api/dashboard/params/valid-filter-fields](#get-apidashboardparamsvalid-filter-fields)
-  - [GET /api/dashboard/public](#get-apidashboardpublic)
-  - [POST /api/dashboard/](#post-apidashboard)
-  - [POST /api/dashboard/:dashboard-id/dashcard/:dashcard-id/card/:card-id/query](#post-apidashboarddashboard-iddashcarddashcard-idcardcard-idquery)
-  - [POST /api/dashboard/:dashboard-id/dashcard/:dashcard-id/card/:card-id/query/:export-format](#post-apidashboarddashboard-iddashcarddashcard-idcardcard-idqueryexport-format)
-  - [POST /api/dashboard/:dashboard-id/public_link](#post-apidashboarddashboard-idpublic_link)
-  - [POST /api/dashboard/:from-dashboard-id/copy](#post-apidashboardfrom-dashboard-idcopy)
-  - [POST /api/dashboard/:id/cards](#post-apidashboardidcards)
-  - [POST /api/dashboard/:id/revert](#post-apidashboardidrevert)
-  - [POST /api/dashboard/pivot/:dashboard-id/dashcard/:dashcard-id/card/:card-id/query](#post-apidashboardpivotdashboard-iddashcarddashcard-idcardcard-idquery)
-  - [POST /api/dashboard/save](#post-apidashboardsave)
-  - [POST /api/dashboard/save/collection/:parent-collection-id](#post-apidashboardsavecollectionparent-collection-id)
-  - [PUT /api/dashboard/:id](#put-apidashboardid)
-  - [PUT /api/dashboard/:id/cards](#put-apidashboardidcards)
-
 ## `DELETE /api/dashboard/:dashboard-id/public_link`
 
 Delete the publicly-accessible link to this Dashboard.
@@ -189,7 +164,28 @@ Create a new Dashboard.
 
 *  **`collection_position`** value may be nil, or if non-nil, value must be an integer greater than zero.
 
+*  **`is_app_page`** value may be nil, or if non-nil, value must be a boolean.
+
 *  **`_dashboard`**
+
+## `POST /api/dashboard/:dashboard-id/dashcard/:dashcard-id/action/execute`
+
+Execute the associated Action in the context of a `Dashboard` and `DashboardCard` that includes it.
+
+   `parameters` should be the mapped dashboard parameters with values.
+   `extra_parameters` should be the extra, user entered parameter values.
+
+### PARAMS:
+
+*  **`dashboard-id`** 
+
+*  **`dashcard-id`** 
+
+*  **`parameters`** value may be nil, or if non-nil, value must be an array. Each value must be a parameter map with an 'id' key
+
+*  **`extra_parameters`** value may be nil, or if non-nil, value must be an array. Each value must be a parameter map with a 'target' key
+
+*  **`_body`**
 
 ## `POST /api/dashboard/:dashboard-id/dashcard/:dashcard-id/card/:card-id/query`
 
@@ -267,7 +263,10 @@ Add a `Card` to a Dashboard.
 
 *  **`cardId`** value may be nil, or if non-nil, value must be an integer greater than zero.
 
-*  **`parameter_mappings`** value may be nil, or if non-nil, value must be an array.
+*  **`parameter_mappings`** value may be nil, or if non-nil, value must be an array. Each value must be a map with schema: (
+  parameter_id : value must be a non-blank string.
+   : 
+)
 
 *  **`dashboard-card`**
 
@@ -344,6 +343,8 @@ Update a Dashboard.
 *  **`name`** value may be nil, or if non-nil, value must be a non-blank string.
 
 *  **`caveats`** value may be nil, or if non-nil, value must be a string.
+
+*  **`is_app_page`** value may be nil, or if non-nil, value must be a boolean.
 
 *  **`embedding_params`** value may be nil, or if non-nil, value must be a valid embedding params map.
 

--- a/docs/api/database.md
+++ b/docs/api/database.md
@@ -8,34 +8,6 @@ summary: |
 
 /api/database endpoints.
 
-  - [DELETE /api/database/:id](#delete-apidatabaseid)
-  - [GET /api/database/](#get-apidatabase)
-  - [GET /api/database/:id](#get-apidatabaseid)
-  - [GET /api/database/:id/autocomplete_suggestions](#get-apidatabaseidautocomplete_suggestions)
-  - [GET /api/database/:id/fields](#get-apidatabaseidfields)
-  - [GET /api/database/:id/idfields](#get-apidatabaseididfields)
-  - [GET /api/database/:id/metadata](#get-apidatabaseidmetadata)
-  - [GET /api/database/:id/schema/](#get-apidatabaseidschema)
-  - [GET /api/database/:id/schema/:schema](#get-apidatabaseidschemaschema)
-  - [GET /api/database/:id/schemas](#get-apidatabaseidschemas)
-  - [GET /api/database/:virtual-db/datasets](#get-apidatabasevirtual-dbdatasets)
-  - [GET /api/database/:virtual-db/datasets/:schema](#get-apidatabasevirtual-dbdatasetsschema)
-  - [GET /api/database/:virtual-db/metadata](#get-apidatabasevirtual-dbmetadata)
-  - [GET /api/database/:virtual-db/schema/:schema](#get-apidatabasevirtual-dbschemaschema)
-  - [GET /api/database/:virtual-db/schemas](#get-apidatabasevirtual-dbschemas)
-  - [GET /api/database/db-ids-with-deprecated-drivers](#get-apidatabasedb-ids-with-deprecated-drivers)
-  - [POST /api/database/](#post-apidatabase)
-  - [POST /api/database/:id/discard_values](#post-apidatabaseiddiscard_values)
-  - [POST /api/database/:id/dismiss_spinner](#post-apidatabaseiddismiss_spinner)
-  - [POST /api/database/:id/persist](#post-apidatabaseidpersist)
-  - [POST /api/database/:id/rescan_values](#post-apidatabaseidrescan_values)
-  - [POST /api/database/:id/sync](#post-apidatabaseidsync)
-  - [POST /api/database/:id/sync_schema](#post-apidatabaseidsync_schema)
-  - [POST /api/database/:id/unpersist](#post-apidatabaseidunpersist)
-  - [POST /api/database/sample_database](#post-apidatabasesample_database)
-  - [POST /api/database/validate](#post-apidatabasevalidate)
-  - [PUT /api/database/:id](#put-apidatabaseid)
-
 ## `DELETE /api/database/:id`
 
 Delete a `Database`.
@@ -106,9 +78,10 @@ Get a single Database with `id`. Optionally pass `?include=tables` or `?include=
 
 ## `GET /api/database/:id/autocomplete_suggestions`
 
-Return a list of autocomplete suggestions for a given `prefix`.
+Return a list of autocomplete suggestions for a given `prefix`, or `substring`. Should only specify one, but
+  `substring` will have priority if both are present.
 
-  This is intened for use with the ACE Editor when the User is typing raw SQL. Suggestions include matching `Tables`
+  This is intended for use with the ACE Editor when the User is typing raw SQL. Suggestions include matching `Tables`
   and `Fields` in this `Database`.
 
   Tables are returned in the format `[table_name "Table"]`;
@@ -117,11 +90,23 @@ Return a list of autocomplete suggestions for a given `prefix`.
 
 ### PARAMS:
 
-*  **`id`** 
+*  **`id`** value must be an integer.
 
-*  **`prefix`** 
+*  **`prefix`** value may be nil, or if non-nil, value must be a non-blank string.
 
-*  **`search`**
+*  **`substring`** value may be nil, or if non-nil, value must be a non-blank string.
+
+## `GET /api/database/:id/card_autocomplete_suggestions`
+
+Return a list of `Card` autocomplete suggestions for a given `query` in a given `Database`.
+
+  This is intended for use with the ACE Editor when the User is typing in a template tag for a `Card`, e.g. {{#...}}.
+
+### PARAMS:
+
+*  **`id`** value must be an integer.
+
+*  **`query`** value must be a non-blank string.
 
 ## `GET /api/database/:id/fields`
 

--- a/docs/api/dataset.md
+++ b/docs/api/dataset.md
@@ -8,15 +8,9 @@ summary: |
 
 /api/dataset endpoints.
 
-  - [POST /api/dataset/](#post-apidataset)
-  - [POST /api/dataset/:export-format](#post-apidatasetexport-format)
-  - [POST /api/dataset/duration](#post-apidatasetduration)
-  - [POST /api/dataset/native](#post-apidatasetnative)
-  - [POST /api/dataset/pivot](#post-apidatasetpivot)
-
 ## `POST /api/dataset/`
 
-Execute a query and retrieve the results in the usual format.
+Execute a query and retrieve the results in the usual format. The query will not use the cache.
 
 ### PARAMS:
 

--- a/docs/api/ee/advanced-permissions-application.md
+++ b/docs/api/ee/advanced-permissions-application.md
@@ -12,9 +12,6 @@ summary: |
   Implements the Permissions routes needed for application permission - a class of permissions that control access to features
   like access Setting pages, access monitoring tools ... etc.
 
-  - [GET /api/ee/advanced-permissions/application/graph](#get-apieeadvanced-permissionsapplicationgraph)
-  - [PUT /api/ee/advanced-permissions/application/graph](#put-apieeadvanced-permissionsapplicationgraph)
-
 ## `GET /api/ee/advanced-permissions/application/graph`
 
 Fetch a graph of Application Permissions.

--- a/docs/api/ee/audit-app-user.md
+++ b/docs/api/ee/audit-app-user.md
@@ -8,8 +8,6 @@ summary: |
 
 `/api/ee/audit-app/user` endpoints. These only work if you have a premium token with the `:audit-app` feature.
 
-  - [DELETE /api/ee/audit-app/user/:id/subscriptions](#delete-apieeaudit-appuseridsubscriptions)
-
 ## `DELETE /api/ee/audit-app/user/:id/subscriptions`
 
 Delete all Alert and DashboardSubscription subscriptions for a User (i.e., so they will no longer receive them).

--- a/docs/api/ee/content-management-review.md
+++ b/docs/api/ee/content-management-review.md
@@ -8,8 +8,6 @@ summary: |
 
 API endpoints for Content management review.
 
-  - [POST /api/moderation-review/review/](#post-apimoderation-reviewreview)
-
 ## `POST /api/moderation-review/review/`
 
 Create a new `ModerationReview`.

--- a/docs/api/ee/sandbox-gtap.md
+++ b/docs/api/ee/sandbox-gtap.md
@@ -8,12 +8,6 @@ summary: |
 
 `/api/mt/gtap` endpoints, for CRUD operations and the like on GTAPs (Group Table Access Policies).
 
-  - [DELETE /api/mt/gtap/:id](#delete-apimtgtapid)
-  - [GET /api/mt/gtap/](#get-apimtgtap)
-  - [GET /api/mt/gtap/:id](#get-apimtgtapid)
-  - [POST /api/mt/gtap/](#post-apimtgtap)
-  - [PUT /api/mt/gtap/:id](#put-apimtgtapid)
-
 ## `DELETE /api/mt/gtap/:id`
 
 Delete a GTAP entry.

--- a/docs/api/ee/sandbox-table.md
+++ b/docs/api/ee/sandbox-table.md
@@ -8,8 +8,6 @@ summary: |
 
 API endpoints for Sandbox table.
 
-  - [GET /api/table/:id/query_metadata](#get-apitableidquery_metadata)
-
 ## `GET /api/table/:id/query_metadata`
 
 This endpoint essentially acts as a wrapper for the OSS version of this route. When a user has segmented permissions

--- a/docs/api/ee/sandbox-user.md
+++ b/docs/api/ee/sandbox-user.md
@@ -8,9 +8,6 @@ summary: |
 
 Endpoint(s)for setting user attributes.
 
-  - [GET /api/mt/user/attributes](#get-apimtuserattributes)
-  - [PUT /api/mt/user/:id/attributes](#put-apimtuseridattributes)
-
 ## `GET /api/mt/user/attributes`
 
 Fetch a list of possible keys for User `login_attributes`. This just looks at keys that have already been set for

--- a/docs/api/ee/sso.md
+++ b/docs/api/ee/sso.md
@@ -14,9 +14,6 @@ summary: |
   Implements the SSO routes needed for SAML and JWT. This namespace primarily provides hooks for those two backends so
   we can have a uniform interface both via the API and code.
 
-  - [GET /auth/sso/](#get-authsso)
-  - [POST /auth/sso/](#post-authsso)
-
 ## `GET /auth/sso/`
 
 SSO entry-point for an SSO user that has not logged in yet.

--- a/docs/api/email.md
+++ b/docs/api/email.md
@@ -8,10 +8,6 @@ summary: |
 
 /api/email endpoints.
 
-  - [DELETE /api/email/](#delete-apiemail)
-  - [POST /api/email/test](#post-apiemailtest)
-  - [PUT /api/email/](#put-apiemail)
-
 ## `DELETE /api/email/`
 
 Clear all email related settings. You must be a superuser or have `setting` permission to do this.

--- a/docs/api/embed.md
+++ b/docs/api/embed.md
@@ -36,23 +36,6 @@ Various endpoints that use [JSON web tokens](https://jwt.io/introduction/) to fe
                   :dashboard <dashboard-id>}
        :params   <params>}.
 
-  - [GET /api/embed/card/:token](#get-apiembedcardtoken)
-  - [GET /api/embed/card/:token/field/:field-id/remapping/:remapped-id](#get-apiembedcardtokenfieldfield-idremappingremapped-id)
-  - [GET /api/embed/card/:token/field/:field-id/search/:search-field-id](#get-apiembedcardtokenfieldfield-idsearchsearch-field-id)
-  - [GET /api/embed/card/:token/field/:field-id/values](#get-apiembedcardtokenfieldfield-idvalues)
-  - [GET /api/embed/card/:token/query](#get-apiembedcardtokenquery)
-  - [GET /api/embed/card/:token/query/:export-format](#get-apiembedcardtokenqueryexport-format)
-  - [GET /api/embed/dashboard/:token](#get-apiembeddashboardtoken)
-  - [GET /api/embed/dashboard/:token/dashcard/:dashcard-id/card/:card-id](#get-apiembeddashboardtokendashcarddashcard-idcardcard-id)
-  - [GET /api/embed/dashboard/:token/dashcard/:dashcard-id/card/:card-id/:export-format](#get-apiembeddashboardtokendashcarddashcard-idcardcard-idexport-format)
-  - [GET /api/embed/dashboard/:token/field/:field-id/remapping/:remapped-id](#get-apiembeddashboardtokenfieldfield-idremappingremapped-id)
-  - [GET /api/embed/dashboard/:token/field/:field-id/search/:search-field-id](#get-apiembeddashboardtokenfieldfield-idsearchsearch-field-id)
-  - [GET /api/embed/dashboard/:token/field/:field-id/values](#get-apiembeddashboardtokenfieldfield-idvalues)
-  - [GET /api/embed/dashboard/:token/params/:param-key/search/:prefix](#get-apiembeddashboardtokenparamsparam-keysearchprefix)
-  - [GET /api/embed/dashboard/:token/params/:param-key/values](#get-apiembeddashboardtokenparamsparam-keyvalues)
-  - [GET /api/embed/pivot/card/:token/query](#get-apiembedpivotcardtokenquery)
-  - [GET /api/embed/pivot/dashboard/:token/dashcard/:dashcard-id/card/:card-id](#get-apiembedpivotdashboardtokendashcarddashcard-idcardcard-id)
-
 ## `GET /api/embed/card/:token`
 
 Fetch a Card via a JSON Web Token signed with the `embedding-secret-key`.

--- a/docs/api/emitter.md
+++ b/docs/api/emitter.md
@@ -1,0 +1,57 @@
+---
+title: "Emitter"
+summary: |
+  API endpoints for Emitter.
+---
+
+# Emitter
+
+API endpoints for Emitter.
+
+## `DELETE /api/emitter/:emitter-id`
+
+Endpoint to delete an emitter.
+
+### PARAMS:
+
+*  **`emitter-id`**
+
+## `POST /api/emitter/`
+
+Endpoint to create an emitter.
+
+### PARAMS:
+
+*  **`action_id`** value must be an integer greater than zero.
+
+*  **`card_id`** value may be nil, or if non-nil, value must be an integer greater than or equal to zero.
+
+*  **`dashboard_id`** value may be nil, or if non-nil, value must be an integer greater than or equal to zero.
+
+*  **`options`** value may be nil, or if non-nil, value must be a map.
+
+*  **`parameter_mappings`** value may be nil, or if non-nil, value must be a map.
+
+## `POST /api/emitter/:id/execute`
+
+Execute a custom emitter.
+
+### PARAMS:
+
+*  **`id`** 
+
+*  **`parameters`** value may be nil, or if non-nil, map of parameter name or ID -> map of parameter `:value` and `:type` of the value
+
+## `PUT /api/emitter/:emitter-id`
+
+Endpoint to update an emitter.
+
+### PARAMS:
+
+*  **`emitter-id`** 
+
+*  **`emitter`**
+
+---
+
+[<< Back to API index](../api-documentation.md)

--- a/docs/api/field.md
+++ b/docs/api/field.md
@@ -8,20 +8,6 @@ summary: |
 
 API endpoints for Field.
 
-  - [DELETE /api/field/:id/dimension](#delete-apifieldiddimension)
-  - [GET /api/field/:id](#get-apifieldid)
-  - [GET /api/field/:id/related](#get-apifieldidrelated)
-  - [GET /api/field/:id/remapping/:remapped-id](#get-apifieldidremappingremapped-id)
-  - [GET /api/field/:id/search/:search-id](#get-apifieldidsearchsearch-id)
-  - [GET /api/field/:id/summary](#get-apifieldidsummary)
-  - [GET /api/field/:id/values](#get-apifieldidvalues)
-  - [GET /api/field/field%2C:field-name%2C:options/values](#get-apifieldfield2cfield-name2coptionsvalues)
-  - [POST /api/field/:id/dimension](#post-apifieldiddimension)
-  - [POST /api/field/:id/discard_values](#post-apifieldiddiscard_values)
-  - [POST /api/field/:id/rescan_values](#post-apifieldidrescan_values)
-  - [POST /api/field/:id/values](#post-apifieldidvalues)
-  - [PUT /api/field/:id](#put-apifieldid)
-
 ## `DELETE /api/field/:id/dimension`
 
 Remove the dimension associated to field at ID.

--- a/docs/api/geojson.md
+++ b/docs/api/geojson.md
@@ -8,9 +8,6 @@ summary: |
 
 API endpoints for GeoJSON.
 
-  - [GET /api/geojson/](#get-apigeojson)
-  - [GET /api/geojson/:key](#get-apigeojsonkey)
-
 ## `GET /api/geojson/`
 
 Load a custom GeoJSON file based on a URL or file path provided as a query parameter.

--- a/docs/api/ldap.md
+++ b/docs/api/ldap.md
@@ -8,8 +8,6 @@ summary: |
 
 /api/ldap endpoints.
 
-  - [PUT /api/ldap/settings](#put-apildapsettings)
-
 ## `PUT /api/ldap/settings`
 
 Update LDAP related settings. You must be a superuser to do this.

--- a/docs/api/login-history.md
+++ b/docs/api/login-history.md
@@ -8,8 +8,6 @@ summary: |
 
 API endpoints for Login history.
 
-  - [GET /api/login-history/current](#get-apilogin-historycurrent)
-
 ## `GET /api/login-history/current`
 
 Fetch recent logins for the current user.

--- a/docs/api/metric.md
+++ b/docs/api/metric.md
@@ -8,16 +8,6 @@ summary: |
 
 /api/metric endpoints.
 
-  - [DELETE /api/metric/:id](#delete-apimetricid)
-  - [GET /api/metric/](#get-apimetric)
-  - [GET /api/metric/:id](#get-apimetricid)
-  - [GET /api/metric/:id/related](#get-apimetricidrelated)
-  - [GET /api/metric/:id/revisions](#get-apimetricidrevisions)
-  - [POST /api/metric/](#post-apimetric)
-  - [POST /api/metric/:id/revert](#post-apimetricidrevert)
-  - [PUT /api/metric/:id](#put-apimetricid)
-  - [PUT /api/metric/:id/important_fields](#put-apimetricidimportant_fields)
-
 ## `DELETE /api/metric/:id`
 
 Archive a Metric. (DEPRECATED -- Just pass updated value of `:archived` to the `PUT` endpoint instead.).

--- a/docs/api/native-query-snippet.md
+++ b/docs/api/native-query-snippet.md
@@ -8,11 +8,6 @@ summary: |
 
 Native query snippet (/api/native-query-snippet) endpoints.
 
-  - [GET /api/native-query-snippet/](#get-apinative-query-snippet)
-  - [GET /api/native-query-snippet/:id](#get-apinative-query-snippetid)
-  - [POST /api/native-query-snippet/](#post-apinative-query-snippet)
-  - [PUT /api/native-query-snippet/:id](#put-apinative-query-snippetid)
-
 ## `GET /api/native-query-snippet/`
 
 Fetch all snippets.
@@ -43,8 +38,6 @@ Create a new `NativeQuerySnippet`.
 
 *  **`collection_id`** value may be nil, or if non-nil, value must be an integer greater than zero.
 
-*  **`template_tags`** value may be nil, or if non-nil, template tags must be a map with key of name->TemplateTag.
-
 ## `PUT /api/native-query-snippet/:id`
 
 Update an existing `NativeQuerySnippet`.
@@ -62,8 +55,6 @@ Update an existing `NativeQuerySnippet`.
 *  **`name`** value may be nil, or if non-nil, snippet names cannot include } or start with spaces
 
 *  **`collection_id`** value may be nil, or if non-nil, value must be an integer greater than zero.
-
-*  **`template_tags`** value may be nil, or if non-nil, template tags must be a map with key of name->TemplateTag.
 
 ---
 

--- a/docs/api/notify.md
+++ b/docs/api/notify.md
@@ -8,8 +8,6 @@ summary: |
 
 /api/notify/* endpoints which receive inbound etl server notifications.
 
-  - [POST /api/notify/db/:id](#post-apinotifydbid)
-
 ## `POST /api/notify/db/:id`
 
 Notification about a potential schema change to one of our `Databases`.

--- a/docs/api/permissions.md
+++ b/docs/api/permissions.md
@@ -8,18 +8,6 @@ summary: |
 
 /api/permissions endpoints.
 
-  - [DELETE /api/permissions/group/:group-id](#delete-apipermissionsgroupgroup-id)
-  - [DELETE /api/permissions/membership/:id](#delete-apipermissionsmembershipid)
-  - [GET /api/permissions/graph](#get-apipermissionsgraph)
-  - [GET /api/permissions/group](#get-apipermissionsgroup)
-  - [GET /api/permissions/group/:id](#get-apipermissionsgroupid)
-  - [GET /api/permissions/membership](#get-apipermissionsmembership)
-  - [POST /api/permissions/group](#post-apipermissionsgroup)
-  - [POST /api/permissions/membership](#post-apipermissionsmembership)
-  - [PUT /api/permissions/graph](#put-apipermissionsgraph)
-  - [PUT /api/permissions/group/:group-id](#put-apipermissionsgroupgroup-id)
-  - [PUT /api/permissions/membership/:id](#put-apipermissionsmembershipid)
-
 ## `DELETE /api/permissions/group/:group-id`
 
 Delete a specific `PermissionsGroup`.

--- a/docs/api/persist.md
+++ b/docs/api/persist.md
@@ -8,13 +8,6 @@ summary: |
 
 API endpoints for Persist.
 
-  - [GET /api/persist/](#get-apipersist)
-  - [GET /api/persist/:persisted-info-id](#get-apipersistpersisted-info-id)
-  - [GET /api/persist/card/:card-id](#get-apipersistcardcard-id)
-  - [POST /api/persist/disable](#post-apipersistdisable)
-  - [POST /api/persist/enable](#post-apipersistenable)
-  - [POST /api/persist/set-refresh-schedule](#post-apipersistset-refresh-schedule)
-
 ## `GET /api/persist/`
 
 List the entries of [[PersistedInfo]] in order to show a status page.

--- a/docs/api/premium-features.md
+++ b/docs/api/premium-features.md
@@ -8,11 +8,10 @@ summary: |
 
 API endpoints for Premium features.
 
-  - [GET /api/premium-features/token/status](#get-apipremium-featurestokenstatus)
-
 ## `GET /api/premium-features/token/status`
 
-Fetch info about the current Premium-Features premium features token including whether it is `valid`, a `trial` token, its `features`, and when it is `valid_thru`.
+Fetch info about the current Premium-Features premium features token including whether it is `valid`, a `trial` token, its
+  `features`, when it is `valid_thru`, and the `status` of the account.
 
 ---
 

--- a/docs/api/preview-embed.md
+++ b/docs/api/preview-embed.md
@@ -24,13 +24,6 @@ Endpoints for previewing how Cards and Dashboards will look when embedding them.
 
    Refer to the documentation for those endpoints for further details.
 
-  - [GET /api/preview-embed/card/:token](#get-apipreview-embedcardtoken)
-  - [GET /api/preview-embed/card/:token/query](#get-apipreview-embedcardtokenquery)
-  - [GET /api/preview-embed/dashboard/:token](#get-apipreview-embeddashboardtoken)
-  - [GET /api/preview-embed/dashboard/:token/dashcard/:dashcard-id/card/:card-id](#get-apipreview-embeddashboardtokendashcarddashcard-idcardcard-id)
-  - [GET /api/preview-embed/pivot/card/:token/query](#get-apipreview-embedpivotcardtokenquery)
-  - [GET /api/preview-embed/pivot/dashboard/:token/dashcard/:dashcard-id/card/:card-id](#get-apipreview-embedpivotdashboardtokendashcarddashcard-idcardcard-id)
-
 ## `GET /api/preview-embed/card/:token`
 
 Fetch a Card you're considering embedding by passing a JWT `token`.

--- a/docs/api/public.md
+++ b/docs/api/public.md
@@ -8,23 +8,6 @@ summary: |
 
 Metabase API endpoints for viewing publicly-accessible Cards and Dashboards.
 
-  - [GET /api/public/card/:uuid](#get-apipubliccarduuid)
-  - [GET /api/public/card/:uuid/field/:field-id/remapping/:remapped-id](#get-apipubliccarduuidfieldfield-idremappingremapped-id)
-  - [GET /api/public/card/:uuid/field/:field-id/search/:search-field-id](#get-apipubliccarduuidfieldfield-idsearchsearch-field-id)
-  - [GET /api/public/card/:uuid/field/:field-id/values](#get-apipubliccarduuidfieldfield-idvalues)
-  - [GET /api/public/card/:uuid/query](#get-apipubliccarduuidquery)
-  - [GET /api/public/card/:uuid/query/:export-format](#get-apipubliccarduuidqueryexport-format)
-  - [GET /api/public/dashboard/:uuid](#get-apipublicdashboarduuid)
-  - [GET /api/public/dashboard/:uuid/dashcard/:dashcard-id/card/:card-id](#get-apipublicdashboarduuiddashcarddashcard-idcardcard-id)
-  - [GET /api/public/dashboard/:uuid/field/:field-id/remapping/:remapped-id](#get-apipublicdashboarduuidfieldfield-idremappingremapped-id)
-  - [GET /api/public/dashboard/:uuid/field/:field-id/search/:search-field-id](#get-apipublicdashboarduuidfieldfield-idsearchsearch-field-id)
-  - [GET /api/public/dashboard/:uuid/field/:field-id/values](#get-apipublicdashboarduuidfieldfield-idvalues)
-  - [GET /api/public/dashboard/:uuid/params/:param-key/search/:query](#get-apipublicdashboarduuidparamsparam-keysearchquery)
-  - [GET /api/public/dashboard/:uuid/params/:param-key/values](#get-apipublicdashboarduuidparamsparam-keyvalues)
-  - [GET /api/public/oembed](#get-apipublicoembed)
-  - [GET /api/public/pivot/card/:uuid/query](#get-apipublicpivotcarduuidquery)
-  - [GET /api/public/pivot/dashboard/:uuid/dashcard/:dashcard-id/card/:card-id](#get-apipublicpivotdashboarduuiddashcarddashcard-idcardcard-id)
-
 ## `GET /api/public/card/:uuid`
 
 Fetch a publicly-accessible Card an return query results as well as `:card` information. Does not require auth

--- a/docs/api/pulse.md
+++ b/docs/api/pulse.md
@@ -8,17 +8,6 @@ summary: |
 
 /api/pulse endpoints.
 
-  - [DELETE /api/pulse/:id/subscription](#delete-apipulseidsubscription)
-  - [GET /api/pulse/](#get-apipulse)
-  - [GET /api/pulse/:id](#get-apipulseid)
-  - [GET /api/pulse/form_input](#get-apipulseform_input)
-  - [GET /api/pulse/preview_card/:id](#get-apipulsepreview_cardid)
-  - [GET /api/pulse/preview_card_info/:id](#get-apipulsepreview_card_infoid)
-  - [GET /api/pulse/preview_card_png/:id](#get-apipulsepreview_card_pngid)
-  - [POST /api/pulse/](#post-apipulse)
-  - [POST /api/pulse/test](#post-apipulsetest)
-  - [PUT /api/pulse/:id](#put-apipulseid)
-
 ## `DELETE /api/pulse/:id/subscription`
 
 For users to unsubscribe themselves from a pulse subscription.

--- a/docs/api/revision.md
+++ b/docs/api/revision.md
@@ -8,9 +8,6 @@ summary: |
 
 API endpoints for Revision.
 
-  - [GET /api/revision/](#get-apirevision)
-  - [POST /api/revision/revert](#post-apirevisionrevert)
-
 ## `GET /api/revision/`
 
 Get revisions of an object.

--- a/docs/api/search.md
+++ b/docs/api/search.md
@@ -8,9 +8,6 @@ summary: |
 
 API endpoints for Search.
 
-  - [GET /api/search/](#get-apisearch)
-  - [GET /api/search/models](#get-apisearchmodels)
-
 ## `GET /api/search/`
 
 Search within a bunch of models for the substring `q`.

--- a/docs/api/segment.md
+++ b/docs/api/segment.md
@@ -8,15 +8,6 @@ summary: |
 
 /api/segment endpoints.
 
-  - [DELETE /api/segment/:id](#delete-apisegmentid)
-  - [GET /api/segment/](#get-apisegment)
-  - [GET /api/segment/:id](#get-apisegmentid)
-  - [GET /api/segment/:id/related](#get-apisegmentidrelated)
-  - [GET /api/segment/:id/revisions](#get-apisegmentidrevisions)
-  - [POST /api/segment/](#post-apisegment)
-  - [POST /api/segment/:id/revert](#post-apisegmentidrevert)
-  - [PUT /api/segment/:id](#put-apisegmentid)
-
 ## `DELETE /api/segment/:id`
 
 Archive a Segment. (DEPRECATED -- Just pass updated value of `:archived` to the `PUT` endpoint instead.).

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -8,14 +8,6 @@ summary: |
 
 /api/session endpoints.
 
-  - [DELETE /api/session/](#delete-apisession)
-  - [GET /api/session/password_reset_token_valid](#get-apisessionpassword_reset_token_valid)
-  - [GET /api/session/properties](#get-apisessionproperties)
-  - [POST /api/session/](#post-apisession)
-  - [POST /api/session/forgot_password](#post-apisessionforgot_password)
-  - [POST /api/session/google_auth](#post-apisessiongoogle_auth)
-  - [POST /api/session/reset_password](#post-apisessionreset_password)
-
 ## `DELETE /api/session/`
 
 Logout.

--- a/docs/api/setting.md
+++ b/docs/api/setting.md
@@ -8,11 +8,6 @@ summary: |
 
 /api/setting endpoints.
 
-  - [GET /api/setting/](#get-apisetting)
-  - [GET /api/setting/:key](#get-apisettingkey)
-  - [PUT /api/setting/](#put-apisetting)
-  - [PUT /api/setting/:key](#put-apisettingkey)
-
 ## `GET /api/setting/`
 
 Get all `Settings` and their values. You must be a superuser or have `setting` permission to do this.

--- a/docs/api/setup.md
+++ b/docs/api/setup.md
@@ -8,11 +8,6 @@ summary: |
 
 API endpoints for Setup.
 
-  - [GET /api/setup/admin_checklist](#get-apisetupadmin_checklist)
-  - [GET /api/setup/user_defaults](#get-apisetupuser_defaults)
-  - [POST /api/setup/](#post-apisetup)
-  - [POST /api/setup/validate](#post-apisetupvalidate)
-
 ## `GET /api/setup/admin_checklist`
 
 Return various "admin checklist" steps and whether they've been completed. You must be a superuser to see this!

--- a/docs/api/slack.md
+++ b/docs/api/slack.md
@@ -8,9 +8,6 @@ summary: |
 
 /api/slack endpoints.
 
-  - [GET /api/slack/manifest](#get-apislackmanifest)
-  - [PUT /api/slack/settings](#put-apislacksettings)
-
 ## `GET /api/slack/manifest`
 
 Returns the YAML manifest file that should be used to bootstrap new Slack apps.

--- a/docs/api/table.md
+++ b/docs/api/table.md
@@ -8,19 +8,6 @@ summary: |
 
 /api/table endpoints.
 
-  - [GET /api/table/](#get-apitable)
-  - [GET /api/table/:id](#get-apitableid)
-  - [GET /api/table/:id/fks](#get-apitableidfks)
-  - [GET /api/table/:id/query_metadata](#get-apitableidquery_metadata)
-  - [GET /api/table/:id/related](#get-apitableidrelated)
-  - [GET /api/table/card__:id/fks](#get-apitablecard__idfks)
-  - [GET /api/table/card__:id/query_metadata](#get-apitablecard__idquery_metadata)
-  - [POST /api/table/:id/discard_values](#post-apitableiddiscard_values)
-  - [POST /api/table/:id/rescan_values](#post-apitableidrescan_values)
-  - [PUT /api/table/](#put-apitable)
-  - [PUT /api/table/:id](#put-apitableid)
-  - [PUT /api/table/:id/fields/order](#put-apitableidfieldsorder)
-
 ## `GET /api/table/`
 
 Get all `Tables`.

--- a/docs/api/task.md
+++ b/docs/api/task.md
@@ -8,10 +8,6 @@ summary: |
 
 /api/task endpoints.
 
-  - [GET /api/task/](#get-apitask)
-  - [GET /api/task/:id](#get-apitaskid)
-  - [GET /api/task/info](#get-apitaskinfo)
-
 ## `GET /api/task/`
 
 Fetch a list of recent tasks stored as Task History.

--- a/docs/api/tiles.md
+++ b/docs/api/tiles.md
@@ -8,8 +8,6 @@ summary: |
 
 `/api/tiles` endpoints.
 
-  - [GET /api/tiles/:zoom/:x/:y/:lat-field/:lon-field](#get-apitileszoomxylat-fieldlon-field)
-
 ## `GET /api/tiles/:zoom/:x/:y/:lat-field/:lon-field`
 
 This endpoints provides an image with the appropriate pins rendered given a MBQL `query` (passed as a GET query

--- a/docs/api/timeline-event.md
+++ b/docs/api/timeline-event.md
@@ -8,11 +8,6 @@ summary: |
 
 /api/timeline-event endpoints.
 
-  - [DELETE /api/timeline-event/:id](#delete-apitimeline-eventid)
-  - [GET /api/timeline-event/:id](#get-apitimeline-eventid)
-  - [POST /api/timeline-event/](#post-apitimeline-event)
-  - [PUT /api/timeline-event/:id](#put-apitimeline-eventid)
-
 ## `DELETE /api/timeline-event/:id`
 
 Delete a [[TimelineEvent]].

--- a/docs/api/timeline.md
+++ b/docs/api/timeline.md
@@ -8,12 +8,6 @@ summary: |
 
 /api/timeline endpoints.
 
-  - [DELETE /api/timeline/:id](#delete-apitimelineid)
-  - [GET /api/timeline/](#get-apitimeline)
-  - [GET /api/timeline/:id](#get-apitimelineid)
-  - [POST /api/timeline/](#post-apitimeline)
-  - [PUT /api/timeline/:id](#put-apitimelineid)
-
 ## `DELETE /api/timeline/:id`
 
 Delete a [[Timeline]]. Will cascade delete its events as well.

--- a/docs/api/transform.md
+++ b/docs/api/transform.md
@@ -8,8 +8,6 @@ summary: |
 
 API endpoints for Transform.
 
-  - [GET /api/transform/:db-id/:schema/:transform-name](#get-apitransformdb-idschematransform-name)
-
 ## `GET /api/transform/:db-id/:schema/:transform-name`
 
 Look up a database schema transform.

--- a/docs/api/user.md
+++ b/docs/api/user.md
@@ -8,17 +8,6 @@ summary: |
 
 /api/user endpoints.
 
-  - [DELETE /api/user/:id](#delete-apiuserid)
-  - [GET /api/user/](#get-apiuser)
-  - [GET /api/user/:id](#get-apiuserid)
-  - [GET /api/user/current](#get-apiusercurrent)
-  - [POST /api/user/](#post-apiuser)
-  - [POST /api/user/:id/send_invite](#post-apiuseridsend_invite)
-  - [PUT /api/user/:id](#put-apiuserid)
-  - [PUT /api/user/:id/modal/:modal](#put-apiuseridmodalmodal)
-  - [PUT /api/user/:id/password](#put-apiuseridpassword)
-  - [PUT /api/user/:id/reactivate](#put-apiuseridreactivate)
-
 ## `DELETE /api/user/:id`
 
 Disable a `User`.  This does not remove the `User` from the DB, but instead disables their account.
@@ -82,7 +71,10 @@ You must be a superuser to do this.
 
 *  **`email`** value must be a valid email address.
 
-*  **`user_group_memberships`** value may be nil, or if non-nil, value must be an array.
+*  **`user_group_memberships`** value may be nil, or if non-nil, value must be an array. Each value must be a map with schema: (
+  is_group_manager (optional) : value must be a boolean.
+  id : value must be an integer greater than zero.
+)
 
 *  **`login_attributes`** value may be nil, or if non-nil, login attribute keys must be a keyword or string
 
@@ -112,7 +104,10 @@ Update an existing, active `User`.
 
 *  **`locale`** value may be nil, or if non-nil, String must be a valid two-letter ISO language or language-country code e.g. en or en_US.
 
-*  **`user_group_memberships`** value may be nil, or if non-nil, value must be an array.
+*  **`user_group_memberships`** value may be nil, or if non-nil, value must be an array. Each value must be a map with schema: (
+  is_group_manager (optional) : value must be a boolean.
+  id : value must be an integer greater than zero.
+)
 
 *  **`id`** 
 

--- a/docs/api/util.md
+++ b/docs/api/util.md
@@ -10,13 +10,6 @@ summary: |
 Random utilty endpoints for things that don't belong anywhere else in particular, e.g. endpoints for certain admin
   page tasks.
 
-  - [GET /api/util/bug_report_details](#get-apiutilbug_report_details)
-  - [GET /api/util/diagnostic_info/connection_pool_info](#get-apiutildiagnostic_infoconnection_pool_info)
-  - [GET /api/util/logs](#get-apiutillogs)
-  - [GET /api/util/random_token](#get-apiutilrandom_token)
-  - [GET /api/util/stats](#get-apiutilstats)
-  - [POST /api/util/password_check](#post-apiutilpassword_check)
-
 ## `GET /api/util/bug_report_details`
 
 Returns version and system information relevant to filing a bug report against Metabase.

--- a/src/metabase/cmd/endpoint_dox.clj
+++ b/src/metabase/cmd/endpoint_dox.clj
@@ -99,32 +99,6 @@
       desc
       (str desc "\n\n"))))
 
-;;;; API endpoint page route table of contents
-
-(defn- anchor-link
-  "Converts an endpoint string to an anchor link, like [GET /api/alert](#get-apialert),
-  for use in tables of contents for endpoint routes."
-  [ep-name]
-  (let [al (-> (str "#" (str/lower-case ep-name))
-               (str/replace #"[/:%]" "")
-               (str/replace " " "-")
-               (#(str "(" % ")")))]
-    (str "[" ep-name "]" al)))
-
-(defn- toc-links
-  "Creates a list of links to endpoints in the relevant namespace."
-  [endpoint]
-  (-> (:endpoint-str endpoint)
-      (str/replace #"[#+`]" "")
-      str/trim
-      anchor-link
-      (#(str "  - " %))))
-
-(defn route-toc
-  "Generates a table of contents for routes in a page."
-  [ep-data]
-  (str (str/join "\n" (map toc-links ep-data)) "\n\n"))
-
 ;;;; API endpoints
 
 (defn- endpoint-str
@@ -190,7 +164,6 @@
          (endpoint-page-frontmatter ep ep-data)
          (endpoint-page-title ep)
          (endpoint-page-description ep ep-data)
-         (route-toc ep-data)
          (endpoint-docs ep-data)
          (endpoint-footer ep-data)))
 

--- a/src/metabase/cmd/resources/api-intro.md
+++ b/src/metabase/cmd/resources/api-intro.md
@@ -4,7 +4,11 @@ title: "Metabase API documentation"
 
 # Metabase API documentation
 
-_These reference files were generated from source comments by running `clojure -M:ee:run api-documentation`_.
+_These reference files were generated from source comments by running:
+
+```
+clojure -M:ee:run api-documentation
+```
 
 ## About the Metabase API
 

--- a/test/metabase/cmd/endpoint_dox_test.clj
+++ b/test/metabase/cmd/endpoint_dox_test.clj
@@ -29,7 +29,7 @@
                   :doc
                   "## `GET /api/activity/recent_views`\n\nGet the list of 10 things the current user has been viewing most recently."}]})
 
-(def page-markdown (str "---\ntitle: \"Activity\"\nsummary: |\n  API endpoints for Activity.\n---\n\n# Activity\n\nAPI endpoints for Activity.\n\n  - [GET /api/activity/](#get-apiactivity)\n  - [GET /api/activity/recent_views](#get-apiactivityrecent_views)\n\n## `GET /api/activity/`\n\nGet recent activity.\n\n## `GET /api/activity/recent_views`\n\nGet the list of 10 things the current user has been viewing most recently." (endpoint-dox/endpoint-footer (val (first endpoints)))))
+(def page-markdown (str "---\ntitle: \"Activity\"\nsummary: |\n  API endpoints for Activity.\n---\n\n# Activity\n\nAPI endpoints for Activity.\n\n## `GET /api/activity/`\n\nGet recent activity.\n\n## `GET /api/activity/recent_views`\n\nGet the list of 10 things the current user has been viewing most recently." (endpoint-dox/endpoint-footer (val (first endpoints)))))
 
 (deftest build-endpoint-link-test
   (testing "Links to endpoint pages are generated correctly."


### PR DESCRIPTION
- Updates the api-documentation script to omit tables of contents. Since we've included TOCs for all pages, these TOCs are now redundant.
- Updates the API documentation.

I'll create a separate PR that targets the release branch to update the script and docs.