### PR TITLE
Speed up model detail page's usage section

### DIFF
--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelUsageDetails/ModelUsageDetails.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelUsageDetails/ModelUsageDetails.tsx
@@ -13,6 +13,7 @@ import Questions, {
 import { getQuestionVirtualTableId } from "metabase/lib/saved-questions";
 
 import type { Card } from "metabase-types/api";
+import type { State } from "metabase-types/store";
 import type { Card as LegacyCardType } from "metabase-types/types/Card";
 import type Question from "metabase-lib/lib/Question";
 
@@ -24,10 +25,15 @@ import {
   EmptyStateTitle,
 } from "./ModelUsageDetails.styled";
 
-interface Props {
-  cards: Card[];
+interface OwnProps {
   model: Question;
 }
+
+interface EntityLoaderProps {
+  cards: Card[];
+}
+
+type Props = OwnProps & EntityLoaderProps;
 
 function ModelUsageDetails({ model, cards }: Props) {
   const modelConsumers = useMemo(() => {
@@ -66,4 +72,14 @@ function ModelUsageDetails({ model, cards }: Props) {
   );
 }
 
-export default Questions.loadList({ listName: "cards" })(ModelUsageDetails);
+function getCardListingQuery(state: State, { model }: OwnProps) {
+  return {
+    f: "database",
+    model_id: model.databaseId(),
+  };
+}
+
+export default Questions.loadList({
+  listName: "cards",
+  query: getCardListingQuery,
+})(ModelUsageDetails);


### PR DESCRIPTION
Speeds up the "Used by" section for `/model/:id/detail` that could take too long to load. The section is implemented in a pretty rough manner for now as we're experimenting (grab _all_ the cards we got and filter out the ones using the model on the FE). The change should make the FE fetch only the cards using the same DB as the model which hopefully should speed up the page a bit.

### To Verify

1. Open a model from collection / search / recent items
2. Ensure the FE requests `GET /api/card?f=database&model_id=$MODEL_DB_ID` instead of `GET /api/card`