### PR TITLE
Open chill-mode when clicking bookmarked model

### DIFF
--- a/frontend/src/metabase/lib/urls/bookmarks.ts
+++ b/frontend/src/metabase/lib/urls/bookmarks.ts
@@ -1,9 +1,6 @@
 import slugg from "slugg";
 
-import {
-  isDataAppBookmark,
-  isModelBookmark,
-} from "metabase/entities/bookmarks";
+import { isDataAppBookmark } from "metabase/entities/bookmarks";
 
 import { Bookmark, DataApp } from "metabase-types/api";
 
@@ -25,10 +22,6 @@ export function bookmark(bookmark: Bookmark) {
       { id: bookmark.app_id, collection: { name: bookmark.name } } as DataApp,
       { mode: "preview" },
     );
-  }
-
-  if (isModelBookmark(bookmark)) {
-    return `/model/${itemId}/detail`;
   }
 
   const basePath = getBookmarkBasePath(bookmark);

--- a/frontend/test/metabase/lib/urls.unit.spec.js
+++ b/frontend/test/metabase/lib/urls.unit.spec.js
@@ -290,7 +290,7 @@ describe("urls", () => {
           name: "Product",
           type: "card",
         }),
-      ).toBe("/model/1/detail");
+      ).toBe("/model/1-product");
     });
 
     it("returns dashboard bookmark path", () => {


### PR DESCRIPTION
We made Metabase open a new model detail page when clicking a model bookmark. We're not sure it's the way to go at the moment, so we're reverting it back to chill-mode as a destination

### To Verify

1. Bookmark a model
2. Click a bookmark
3. Ensure you're navigated to `/model/:id` instead of `/model/:id/detail`