### PR TITLE
[E2E] Unskip quarantined test due to #24900

### DIFF
--- a/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
@@ -165,9 +165,7 @@ describe("scenarios > admin > databases > add", () => {
     cy.findByText("Need help connecting?");
   });
 
-  // TODO:
-  // Enable once https://github.com/metabase/metabase/issues/24900 gets fixed!
-  it.skip("should respect users' decision to manually sync large database (metabase#17450)", () => {
+  it("should respect users' decision to manually sync large database (metabase#17450)", () => {
     const H2_CONNECTION_STRING =
       "zip:./target/uberjar/metabase.jar!/sample-database.db;USER=GUEST;PASSWORD=guest";
 


### PR DESCRIPTION
#24900 was fixed in https://github.com/metabase/metabase/pull/25061. There were a number of tests skipped because of this issue. Let's unskip one of those and observe the CI for a while.