### PR TITLE
Backend for Google Sign-In setup improvements

### DIFF
--- a/frontend/test/metabase/scenarios/admin/people/people.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/people/people.cy.spec.js
@@ -256,6 +256,7 @@ describe("scenarios > admin > people", () => {
         cy.request("PUT", "/api/setting", {
           "google-auth-client-id": "fake-id.apps.googleusercontent.com",
           "google-auth-auto-create-accounts-domain": "metabase.com",
+          "google-auth-enabled": true,
         });
       });
 

--- a/frontend/test/metabase/scenarios/onboarding/auth/sso.cy.spec.js
+++ b/frontend/test/metabase/scenarios/onboarding/auth/sso.cy.spec.js
@@ -11,9 +11,10 @@ describe("scenarios > auth > signin > SSO", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
-    // Set fake Google client ID
-    cy.request("PUT", "/api/setting/google-auth-client-id", {
-      value: "fake-client-id.apps.googleusercontent.com",
+    // Set fake Google client ID and enable Google auth
+    cy.request("PUT", "/api/google/settings", {
+      "google-auth-client-id": "fake-client-id.apps.googleusercontent.com",
+      "google-auth-enabled": true,
     });
   });
 

--- a/src/metabase/analytics/stats.clj
+++ b/src/metabase/analytics/stats.clj
@@ -114,7 +114,7 @@
    :friendly_names       (= (humanization/humanization-strategy) "advanced")
    :email_configured     (email/email-configured?)
    :slack_configured     (slack/slack-configured?)
-   :sso_configured       (boolean (google/google-auth-client-id))
+   :sso_configured       (google/google-auth-enabled)
    :instance_started     (snowplow/instance-creation)
    :has_sample_data      (db/exists? Database, :is_sample true)})
 

--- a/src/metabase/api/common/validation.clj
+++ b/src/metabase/api/common/validation.clj
@@ -48,10 +48,10 @@
    (check-group-manager true))
 
   ([require-superuser?]
-  (if (premium-features/enable-advanced-permissions?)
-    (api/check-403 (or api/*is-superuser?* api/*is-group-manager?*))
-    (when require-superuser?
-      (api/check-superuser)))))
+   (if (premium-features/enable-advanced-permissions?)
+     (api/check-403 (or api/*is-superuser?* api/*is-group-manager?*))
+     (when require-superuser?
+       (api/check-superuser)))))
 
 (defn check-manager-of-group
   "If `advanced-permissions` is enabled, check is `*current-user*` is manager of `group-or-id`.

--- a/src/metabase/api/google.clj
+++ b/src/metabase/api/google.clj
@@ -1,0 +1,24 @@
+(ns metabase.api.google
+  "/api/google endpoints"
+  (:require [compojure.core :refer [PUT]]
+            [metabase.api.common :as api]
+            [metabase.api.common.validation :as validation]
+            [metabase.integrations.google :as google]
+            [metabase.models.setting :as setting]
+            [schema.core :as s]
+            [toucan.db :as db]))
+
+(api/defendpoint PUT "/settings"
+  "Update Google Sign-In related settings. You must be a superuser to do this."
+  [:as {{:keys [google-auth-client-id google-auth-enabled google-auth-auto-create-accounts-domain]} :body}]
+  {google-auth-client-id                   s/Str
+   google-auth-enabled                     (s/maybe s/Bool)
+   google-auth-auto-create-accounts-domain (s/maybe s/Str)}
+  (validation/check-has-application-permission :setting)
+  ;; Set google-auth-enabled in a separate step because it requires the client ID to be set first
+  (db/transaction
+   (setting/set-many! {:google-auth-client-id                   google-auth-client-id
+                       :google-auth-auto-create-accounts-domain google-auth-auto-create-accounts-domain})
+   (google/google-auth-enabled! google-auth-enabled)))
+
+(api/define-routes)

--- a/src/metabase/api/routes.clj
+++ b/src/metabase/api/routes.clj
@@ -17,6 +17,7 @@
             [metabase.api.emitter :as api.emitter]
             [metabase.api.field :as api.field]
             [metabase.api.geojson :as api.geojson]
+            [metabase.api.google :as api.google]
             [metabase.api.ldap :as api.ldap]
             [metabase.api.login-history :as api.login-history]
             [metabase.api.metric :as api.metric]
@@ -80,6 +81,7 @@
   (context "/emitter"              [] (+auth api.emitter/routes))
   (context "/field"                [] (+auth api.field/routes))
   (context "/geojson"              [] api.geojson/routes)
+  (context "/google"               [] (+auth api.google/routes))
   (context "/ldap"                 [] (+auth api.ldap/routes))
   (context "/login-history"        [] (+auth api.login-history/routes))
   (context "/premium-features"     [] (+auth api.premium-features/routes))

--- a/src/metabase/api/user.clj
+++ b/src/metabase/api/user.clj
@@ -349,8 +349,7 @@
     ;; if the user orignally logged in via Google Auth and it's no longer enabled, convert them into a regular user
     ;; (see metabase#3323)
     :google_auth   (boolean (and (:google_auth existing-user)
-                                 ;; if google-auth-client-id is set it means Google Auth is enabled
-                                 (google/google-auth-client-id)))
+                                 (google/google-auth-enabled)))
     :ldap_auth     (boolean (and (:ldap_auth existing-user)
                                  (api.ldap/ldap-enabled))))
   ;; now return the existing user whether they were originally active or not

--- a/src/metabase/integrations/google.clj
+++ b/src/metabase/integrations/google.clj
@@ -42,8 +42,8 @@
               (if-not (google-auth-client-id)
                 (throw (ex-info (tru "Google Sign-In is not configured. Please set the Client ID first.")
                                 {:status-code 400}))
-                (setting/set-value-of-type! :boolean :google-auth-enabled? new-value))
-              (setting/set-value-of-type! :boolean :google-auth-enabled? new-value))))
+                (setting/set-value-of-type! :boolean :google-auth-enabled new-value))
+              (setting/set-value-of-type! :boolean :google-auth-enabled new-value))))
 
 (define-multi-setting-impl google.i/google-auth-auto-create-accounts-domain :oss
   :getter (fn [] (setting/get-value-of-type :string :google-auth-auto-create-accounts-domain))

--- a/src/metabase/integrations/google.clj
+++ b/src/metabase/integrations/google.clj
@@ -23,27 +23,28 @@
 (defsetting google-auth-client-id
   (deferred-tru "Client ID for Google Sign-In.")
   :visibility :public
-  :setter (fn [client-id]
-            (if (seq client-id)
-              (let [trimmed-client-id (str/trim client-id)]
-                (when-not (str/ends-with? trimmed-client-id ".apps.googleusercontent.com")
-                  (throw (ex-info (tru "Invalid Google Sign-In Client ID: must end with \".apps.googleusercontent.com\"")
-                                  {:status-code 400})))
-                (setting/set-value-of-type! :string :google-auth-client-id trimmed-client-id))
-              (do
-               (setting/set-value-of-type! :string :google-auth-client-id nil)
-               (setting/set-value-of-type! :string :google-auth-enabled false)))))
+  :setter     (fn [client-id]
+                (if (seq client-id)
+                  (let [trimmed-client-id (str/trim client-id)]
+                    (when-not (str/ends-with? trimmed-client-id ".apps.googleusercontent.com")
+                      (throw (ex-info (tru "Invalid Google Sign-In Client ID: must end with \".apps.googleusercontent.com\"")
+                                      {:status-code 400})))
+                    (setting/set-value-of-type! :string :google-auth-client-id trimmed-client-id))
+                  (do
+                   (setting/set-value-of-type! :string :google-auth-client-id nil)
+                   (setting/set-value-of-type! :boolean :google-auth-enabled false)))))
 
 (defsetting google-auth-enabled
   (deferred-tru "Is Google Sign-in currently enabled?")
   :visibility :public
-  :setter (fn [new-value]
-            (if-let [new-value (boolean new-value)]
-              (if-not (google-auth-client-id)
-                (throw (ex-info (tru "Google Sign-In is not configured. Please set the Client ID first.")
-                                {:status-code 400}))
-                (setting/set-value-of-type! :boolean :google-auth-enabled new-value))
-              (setting/set-value-of-type! :boolean :google-auth-enabled new-value))))
+  :type       :boolean
+  :setter     (fn [new-value]
+                (if-let [new-value (boolean new-value)]
+                  (if-not (google-auth-client-id)
+                    (throw (ex-info (tru "Google Sign-In is not configured. Please set the Client ID first.")
+                                    {:status-code 400}))
+                    (setting/set-value-of-type! :boolean :google-auth-enabled new-value))
+                  (setting/set-value-of-type! :boolean :google-auth-enabled new-value))))
 
 (define-multi-setting-impl google.i/google-auth-auto-create-accounts-domain :oss
   :getter (fn [] (setting/get-value-of-type :string :google-auth-auto-create-accounts-domain))

--- a/src/metabase/integrations/google.clj
+++ b/src/metabase/integrations/google.clj
@@ -21,7 +21,7 @@
   (deferred-tru "You'll need an administrator to create a Metabase account before you can use Google to log in."))
 
 (defsetting google-auth-client-id
-  (deferred-tru "Client ID for Google Sign-In. If this is set, Google Sign-In is considered to be enabled.")
+  (deferred-tru "Client ID for Google Sign-In.")
   :visibility :public
   :setter (fn [client-id]
             (if (seq client-id)
@@ -30,7 +30,21 @@
                   (throw (ex-info (tru "Invalid Google Sign-In Client ID: must end with \".apps.googleusercontent.com\"")
                                   {:status-code 400})))
                 (setting/set-value-of-type! :string :google-auth-client-id trimmed-client-id))
-              (setting/set-value-of-type! :string :google-auth-client-id nil))))
+              (do
+               (setting/set-value-of-type! :string :google-auth-client-id nil)
+               (setting/set-value-of-type! :string :google-auth-enabled false)))))
+
+(defsetting google-auth-enabled
+  (deferred-tru "Is Google Sign-in currently enabled?")
+  :visibility :public
+  :setter (fn [new-value]
+            (if-let [new-value (boolean new-value)]
+              (if-not (google-auth-client-id)
+                (throw (ex-info (tru "Google Sign-In is not configured. Please set the Client ID first.")
+                                {:status-code 400}))
+                (setting/set-value-of-type! :boolean :google-auth-enabled? new-value))
+              (setting/set-value-of-type! :boolean :google-auth-enabled? new-value))))
+
 
 (define-multi-setting-impl google.i/google-auth-auto-create-accounts-domain :oss
   :getter (fn [] (setting/get-value-of-type :string :google-auth-auto-create-accounts-domain))

--- a/src/metabase/integrations/google.clj
+++ b/src/metabase/integrations/google.clj
@@ -45,7 +45,6 @@
                 (setting/set-value-of-type! :boolean :google-auth-enabled? new-value))
               (setting/set-value-of-type! :boolean :google-auth-enabled? new-value))))
 
-
 (define-multi-setting-impl google.i/google-auth-auto-create-accounts-domain :oss
   :getter (fn [] (setting/get-value-of-type :string :google-auth-auto-create-accounts-domain))
   :setter (fn [domain]

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -605,8 +605,7 @@
          :as setting}                     (resolve-setting setting-definition-or-name)
         obfuscated?                       (and sensitive? (obfuscated-value? new-value))
         setting-name                      (setting-name setting)]
-    ;; if someone attempts to set a sensitive setting to an obfuscated value (probably via a misuse of the `set-many!`
-    ;; function, setting values that have not changed), ignore the change. Log a message that we are ignoring it.
+    ;; if someone attempts to set a sensitive setting to an obfuscated value (probably via a misuse of the `set-many!` function, setting values that have not changed), ignore the change. Log a message that we are ignoring it.
     (if obfuscated?
       (log/info (trs "Attempted to set Setting {0} to obfuscated value. Ignoring change." setting-name))
       (do

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -19,8 +19,8 @@
 ;; These modules register settings but are otherwise unused. They still must be imported.
 (comment metabase.public-settings.premium-features/keep-me)
 
-(defn- google-auth-configured? []
-  (boolean (setting/get :google-auth-client-id)))
+(defn- google-auth-enabled? []
+  (boolean (setting/get :google-auth-enabled)))
 
 (defn- ldap-enabled? []
   (classloader/require 'metabase.api.ldap)
@@ -35,7 +35,7 @@
 (defn sso-enabled?
   "Any SSO provider is configured and enabled"
   []
-  (or (google-auth-configured?)
+  (or (google-auth-enabled?)
       (ldap-enabled?)
       (ee-sso-configured?)))
 

--- a/test/metabase/analytics/stats_test.clj
+++ b/test/metabase/analytics/stats_test.clj
@@ -70,7 +70,8 @@
   (with-redefs [email/email-configured? (constantly false)
                 slack/slack-configured? (constantly false)]
     (mt/with-temporary-setting-values [site-name          "Test"
-                                       startup-time-millis 1234.0]
+                                       startup-time-millis 1234.0
+                                       google-auth-enabled false]
       (let [stats (anonymous-usage-stats)]
         (is (partial= {:running_on          :unknown
                        :check_for_updates   true

--- a/test/metabase/api/google_test.clj
+++ b/test/metabase/api/google_test.clj
@@ -1,5 +1,7 @@
 (ns metabase.api.google-test
   (:require [clojure.test :refer :all]
+            [metabase.integrations.google :as google]
+            [metabase.integrations.google.interface :as google.i]
             [metabase.test :as mt]))
 
 (def ^:private test-client-id "test-client-id.apps.googleusercontent.com")
@@ -7,6 +9,12 @@
 (deftest google-settings-test
   (testing "PUT /api/google/settings"
     (testing "Valid Google Sign-In settings can be saved via an API call"
-      (mt/user-http-request :crowberto :put 200 "google/settings" {:google-auth-client-id test-client-id
-                                                                   :google-auth-enabled true
-                                                                   :google-auth-auto-create-accounts-domain "foo.com"}))))
+      (mt/with-temporary-setting-values [google-auth-client-id nil
+                                         google-auth-auto-create-accounts-domain nil
+                                         google-auth-enabled nil]
+        (mt/user-http-request :crowberto :put 200 "google/settings" {:google-auth-client-id test-client-id
+                                                                     :google-auth-enabled true
+                                                                     :google-auth-auto-create-accounts-domain "foo.com"})
+        (is (= (google/google-auth-enabled) true))
+        (is (= (google/google-auth-client-id) test-client-id))
+        (is (= (google.i/google-auth-auto-create-accounts-domain) "foo.com"))))))

--- a/test/metabase/api/google_test.clj
+++ b/test/metabase/api/google_test.clj
@@ -1,0 +1,12 @@
+(ns metabase.api.google-test
+  (:require [clojure.test :refer :all]
+            [metabase.test :as mt]))
+
+(def ^:private test-client-id "test-client-id.apps.googleusercontent.com")
+
+(deftest google-settings-test
+  (testing "PUT /api/google/settings"
+    (testing "Valid Google Sign-In settings can be saved via an API call"
+      (mt/user-http-request :crowberto :put 200 "google/settings" {:google-auth-client-id test-client-id
+                                                                   :google-auth-enabled true
+                                                                   :google-auth-auto-create-accounts-domain "foo.com"}))))

--- a/test/metabase/api/user_test.clj
+++ b/test/metabase/api/user_test.clj
@@ -907,11 +907,12 @@
 
     (testing (str "test that when disabling Google auth if a user gets disabled and re-enabled they are no longer "
                   "Google Auth (#3323)")
-      (mt/with-temporary-setting-values [google-auth-client-id "pretend-client-id.apps.googleusercontent.com"]
+      (mt/with-temporary-setting-values [google-auth-client-id "pretend-client-id.apps.googleusercontent.com"
+                                         google-auth-enabled    true]
         (mt/with-temp User [user {:google_auth true}]
           (db/update! User (u/the-id user)
             :is_active false)
-          (mt/with-temporary-setting-values [google-auth-client-id nil]
+          (mt/with-temporary-setting-values [google-auth-enabled false]
             (mt/user-http-request :crowberto :put 200 (format "user/%s/reactivate" (u/the-id user)))
             (is (= {:is_active true, :google_auth false}
                    (mt/derecordize (db/select-one [User :is_active :google_auth] :id (u/the-id user)))))))))))


### PR DESCRIPTION
Currently, the presence or absence of `google-auth-client-id` is what determines whether Google Sign-In is enabled. This PR adds a separate setting `google-auth-enabled` that can be turned on/off independently from the client ID, though it requires the client ID to already be set before enabling.

I've also added a new `/api/google/settings` endpoint (analogous to the similar one for LDAP) which should be the new target for the setup form, rather than going through the setting APIs directly.

Pursuant to #19428