### PR TITLE
Prototype model relationships section for the detail page

### DIFF
--- a/frontend/src/metabase-lib/lib/metadata/Table.ts
+++ b/frontend/src/metabase-lib/lib/metadata/Table.ts
@@ -139,6 +139,16 @@ class TableInner extends Base {
     return fks.map(fk => new Table(fk.origin.table));
   }
 
+  foreignTables(): Table[] {
+    if (!Array.isArray(this.fields)) {
+      return [];
+    }
+    return this.fields
+      .filter(field => field.isFK() && field.fk_target_field_id)
+      .map(field => this.metadata.field(field.fk_target_field_id)?.table)
+      .filter(Boolean);
+  }
+
   primaryKeys(): { field: Field; index: number }[] {
     const pks = [];
     this.fields.forEach((field, index) => {

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailPage.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailPage.tsx
@@ -9,6 +9,7 @@ import * as Urls from "metabase/lib/urls";
 
 import type { Card } from "metabase-types/api";
 import type Question from "metabase-lib/lib/Question";
+import type Table from "metabase-lib/lib/metadata/Table";
 
 import ModelActionDetails from "./ModelActionDetails";
 import ModelInfoSidePanel from "./ModelInfoSidePanel";
@@ -26,12 +27,13 @@ import {
 
 interface Props {
   model: Question;
+  mainTable?: Table | null;
   onChangeModel: (model: Card) => void;
 }
 
 type ModelTab = "schema" | "actions" | "usage";
 
-function ModelDetailPage({ model, onChangeModel }: Props) {
+function ModelDetailPage({ model, mainTable, onChangeModel }: Props) {
   const [tab, setTab] = useState<ModelTab>("usage");
 
   const modelCard = model.card();
@@ -93,6 +95,7 @@ function ModelDetailPage({ model, onChangeModel }: Props) {
       </ModelMain>
       <ModelInfoSidePanel
         model={model}
+        mainTable={mainTable}
         onChangeDescription={handleChangeDescription}
       />
     </RootLayout>

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelInfoSidePanel/ModelInfoSidePanel.styled.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelInfoSidePanel/ModelInfoSidePanel.styled.tsx
@@ -26,11 +26,15 @@ export const ModelInfoTitle = styled.span`
   padding-left: 4px;
 `;
 
-const commonInfoTextStyle = css`
+export const valueBlockStyle = css`
   display: block;
   margin-top: 0.5rem;
-  color: ${color("text-medium")};
   padding-left: 4px;
+`;
+
+const commonInfoTextStyle = css`
+  ${valueBlockStyle}
+  color: ${color("text-medium")};
 `;
 
 export const ModelInfoText = styled.span`

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelInfoSidePanel/ModelInfoSidePanel.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelInfoSidePanel/ModelInfoSidePanel.tsx
@@ -1,10 +1,9 @@
-import React, { useMemo } from "react";
+import React from "react";
 import { t } from "ttag";
 
-import * as Urls from "metabase/lib/urls";
-
-import type { Card, Table } from "metabase-types/api";
+import type { Card } from "metabase-types/api";
 import type Question from "metabase-lib/lib/Question";
+import type Table from "metabase-lib/lib/metadata/Table";
 
 import {
   ModelInfoPanel,
@@ -17,16 +16,15 @@ import {
 
 interface Props {
   model: Question;
+  mainTable?: Table | null;
   onChangeDescription: (description: string | null) => void;
 }
 
-function ModelInfoSidePanel({ model, onChangeDescription }: Props) {
+function ModelInfoSidePanel({ model, mainTable, onChangeDescription }: Props) {
   const modelCard = model.card() as Card;
 
   const canWrite = model.canWrite();
   const description = model.description();
-
-  const backingTable = useMemo(() => model.query().sourceTable(), [model]);
 
   return (
     <ModelInfoPanel>
@@ -49,13 +47,11 @@ function ModelInfoSidePanel({ model, onChangeDescription }: Props) {
           <ModelInfoText>{modelCard.creator.common_name}</ModelInfoText>
         </ModelInfoSection>
       )}
-      {backingTable && (
+      {mainTable && (
         <ModelInfoSection>
           <ModelInfoTitle>{t`Backing table`}</ModelInfoTitle>
-          <ModelInfoLink
-            to={backingTable.newQuestion().getUrl({ clean: false })}
-          >
-            {backingTable.displayName()}
+          <ModelInfoLink to={mainTable.newQuestion().getUrl({ clean: false })}>
+            {mainTable.displayName()}
           </ModelInfoLink>
         </ModelInfoSection>
       )}

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelInfoSidePanel/ModelInfoSidePanel.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelInfoSidePanel/ModelInfoSidePanel.tsx
@@ -5,6 +5,7 @@ import type { Card } from "metabase-types/api";
 import type Question from "metabase-lib/lib/Question";
 import type Table from "metabase-lib/lib/metadata/Table";
 
+import ModelRelationships from "./ModelRelationships";
 import {
   ModelInfoPanel,
   ModelInfoTitle,
@@ -41,6 +42,7 @@ function ModelInfoSidePanel({ model, mainTable, onChangeDescription }: Props) {
           onChange={onChangeDescription}
         />
       </ModelInfoSection>
+      <ModelRelationships model={model} mainTable={mainTable} />
       {modelCard.creator && (
         <ModelInfoSection>
           <ModelInfoTitle>{t`Contact`}</ModelInfoTitle>

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelInfoSidePanel/ModelRelationships.styled.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelInfoSidePanel/ModelRelationships.styled.tsx
@@ -1,0 +1,35 @@
+import styled from "@emotion/styled";
+
+import Link from "metabase/core/components/Link";
+import Icon from "metabase/components/Icon";
+
+import { color, darken } from "metabase/lib/colors";
+
+import { valueBlockStyle } from "./ModelInfoSidePanel.styled";
+
+export const List = styled.ul`
+  ${valueBlockStyle}
+
+  li:not(:first-of-type) {
+    margin-top: 6px;
+  }
+`;
+
+export const ListItemName = styled.span`
+  display: block;
+`;
+
+export const ListItemLink = styled(Link)`
+  display: flex;
+  align-items: center;
+
+  color: ${color("brand")};
+
+  ${ListItemName} {
+    margin-left: 4px;
+  }
+
+  &:hover {
+    color: ${darken("brand")};
+  }
+`;

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelInfoSidePanel/ModelRelationships.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelInfoSidePanel/ModelRelationships.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from "react";
 import { t } from "ttag";
+import _ from "underscore";
 
 import Icon from "metabase/components/Icon";
 
@@ -18,7 +19,10 @@ function ModelRelationships({ model, mainTable }: Props) {
   const relatedTables = useMemo(() => {
     const tablesMainTablePointsTo = model.table()?.foreignTables() || [];
     const tablesPointingToMainTable = mainTable?.connectedTables() || [];
-    return [...tablesMainTablePointsTo, ...tablesPointingToMainTable];
+    return _.uniq(
+      [...tablesMainTablePointsTo, ...tablesPointingToMainTable],
+      table => table.id,
+    );
   }, [model, mainTable]);
 
   if (relatedTables.length <= 0) {

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelInfoSidePanel/ModelRelationships.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelInfoSidePanel/ModelRelationships.tsx
@@ -1,0 +1,45 @@
+import React, { useMemo } from "react";
+import { t } from "ttag";
+
+import Icon from "metabase/components/Icon";
+
+import type Question from "metabase-lib/lib/Question";
+import type Table from "metabase-lib/lib/metadata/Table";
+
+import { ModelInfoTitle, ModelInfoSection } from "./ModelInfoSidePanel.styled";
+import { List, ListItemLink, ListItemName } from "./ModelRelationships.styled";
+
+interface Props {
+  model: Question;
+  mainTable?: Table | null;
+}
+
+function ModelRelationships({ model, mainTable }: Props) {
+  const relatedTables = useMemo(() => {
+    const tablesMainTablePointsTo = model.table()?.foreignTables() || [];
+    const tablesPointingToMainTable = mainTable?.connectedTables() || [];
+    return [...tablesMainTablePointsTo, ...tablesPointingToMainTable];
+  }, [model, mainTable]);
+
+  if (relatedTables.length <= 0) {
+    return null;
+  }
+
+  return (
+    <ModelInfoSection>
+      <ModelInfoTitle>{t`Relationships`}</ModelInfoTitle>
+      <List>
+        {relatedTables.map(table => (
+          <li key={table.id}>
+            <ListItemLink to={table.newQuestion().getUrl()}>
+              <Icon name="table" />
+              <ListItemName>{table.displayName()}</ListItemName>
+            </ListItemLink>
+          </li>
+        ))}
+      </List>
+    </ModelInfoSection>
+  );
+}
+
+export default ModelRelationships;


### PR DESCRIPTION
Part of #25487

Extends our model detail page prototype by adding a "Relationships" section to the info panel on the right. For MBQL models, it's going to list:

* tables a model points to via FKs (e.g. Products and People for Orders)
* tables that point to the main model table (e.g. Orders and Reviews for Products)

### To Verify

1. Create an MBQL model wrapping the Orders table
2. Go to `/model/:id/detail`
3. Make sure you see Products and People on the right in the Relationships section
4. Ensure table links are clickable and lead you to the chill-mode
5. Create an MBQL model wrapping the Products table
6. Go to `/model/:id/detail`
7. Make sure you see Orders and Reviews on the right in the Relationships section
8. Ensure table links are clickable and lead you to the chill-mode

### Demo

![CleanShot 2022-09-20 at 19 19 58@2x](https://user-images.githubusercontent.com/17258145/191334555-71195f32-3521-4df4-9729-e1c74e2fcc88.png)
