### PR TITLE
Fix #25521: 403 page when visiting question's URL with a card template tag

### DIFF
--- a/frontend/src/metabase/query_builder/actions/core/parameterUtils.ts
+++ b/frontend/src/metabase/query_builder/actions/core/parameterUtils.ts
@@ -128,7 +128,11 @@ export async function handleDashboardParameters(
     deserializedCard,
     originalCard,
   });
-  if (shouldPropagateParameters && deserializedCard) {
+  if (
+    shouldPropagateParameters &&
+    deserializedCard &&
+    deserializedCard.dashcardId
+  ) {
     const { dashboardId, dashcardId, parameters } = deserializedCard;
     const metadata = getMetadata(getState());
     await verifyMatchingDashcardAndParameters({

--- a/frontend/src/metabase/query_builder/actions/core/parameterUtils.ts
+++ b/frontend/src/metabase/query_builder/actions/core/parameterUtils.ts
@@ -130,8 +130,7 @@ export async function handleDashboardParameters(
   });
   if (
     shouldPropagateParameters &&
-    deserializedCard &&
-    deserializedCard.dashcardId
+    deserializedCard?.dashcardId
   ) {
     const { dashboardId, dashcardId, parameters } = deserializedCard;
     const metadata = getMetadata(getState());

--- a/frontend/src/metabase/query_builder/actions/core/parameterUtils.ts
+++ b/frontend/src/metabase/query_builder/actions/core/parameterUtils.ts
@@ -128,10 +128,7 @@ export async function handleDashboardParameters(
     deserializedCard,
     originalCard,
   });
-  if (
-    shouldPropagateParameters &&
-    deserializedCard?.dashcardId
-  ) {
+  if (shouldPropagateParameters && deserializedCard?.dashcardId) {
     const { dashboardId, dashcardId, parameters } = deserializedCard;
     const metadata = getMetadata(getState());
     await verifyMatchingDashcardAndParameters({


### PR DESCRIPTION
This fixes https://github.com/metabase/metabase/issues/25521

### What the error page was designed to prevent:

The error page was designed to show a better error messages to the user if they were trying to view a dashcard that had been removed from a dashboard. Rather than an arbitrary server error, we show them a permissions error page. See [this PR for details](https://github.com/metabase/metabase/pull/19300).

### What causes the error page to show in this instance:

The error page is mistakenly shown when opening a link to a card with a serialized URL, e.g. [this](https://stats.metabase.com/question/3967-mom-mrr-growth#eyJuYW1lIjoiTW9NIE1SUiBHcm93dGgiLCJkZXNjcmlwdGlvbiI6Ik1vbnRoIG92ZXIgTW9udGggKE1vTSkgTVJSIGdyb3d0aCBpcyBjYWxjdWxhdGVkIGJ5IHN1YnRyYWN0aW5nIE5ldCBNUlIgaW4gdGhlIGN1cnJlbnQgcGVyaW9kIGZyb20gTmV0IE1SUiBpbiB0aGUgcHJldmlvdXMgcGVyaW9kLCBhbmQgZGl2aWRpbmcgdGhhdCBmaWd1cmUgYnkgTmV0IE1SUiBpbiB0aGUgcHJldmlvdXMgcGVyaW9kLiIsImRhdGFzZXRfcXVlcnkiOnsidHlwZSI6Im5hdGl2ZSIsIm5hdGl2ZSI6eyJxdWVyeSI6IndpdGggbXJyIGFzIChcbiAgc2VsZWN0XG4gICAgICBkYXRlX3RydW5jKCdtb250aCcsIGguZGF0ZSkgYXMgbW9udGgsXG4gICAgICBzdW0oYW1vdW50X2RvbGxhcnMpIGFzIG1yclxuICBmcm9tIHt7IzU0NDctY2hhcmdlc319IGhcbiAgaW5uZXIgam9pbiBkYnRfbW9kZWxzLnNlbGZfc2VydmljZV9hY2NvdW50cyBhXG4gICAgICBvbiBoLnN1YnNjcmlwdGlvbl9pZCA9IGEuc3RyaXBlX3N1YnNjcmlwdGlvbl9pZFxuICBncm91cCBieSAxIFxuICBvcmRlciBieSAxXG4pLCBtb21fbXJyX2dyb3d0aCBhcyAoXG4gICAgc2VsZWN0XG4gICAgICBtb250aCxcbiAgICAgIG1ycixcbiAgICAgIGxhZyhtcnIpIG92ZXIob3JkZXIgYnkgbW9udGggYXNjKSBhcyBwcmV2X21vbnRoX21ycixcbiAgICAgIChtcnIvbGFnKG1ycikgb3ZlcihvcmRlciBieSBtb250aCBhc2MpKSAtIDEgYXMgbW9tX21ycl9ncm93dGhcbiAgICBmcm9tIG1yclxuKVxuc2VsZWN0ICogXG5mcm9tIG1vbV9tcnJfZ3Jvd3RoIFxud2hlcmUgbW9udGggPj0gJzIwMjAtMTEtMDEnIiwidGVtcGxhdGUtdGFncyI6eyIjNTQ0Ny1jaGFyZ2VzIjp7ImlkIjoiODM1N2NhZTItNGE5Zi05NTRmLWFhMzItZmFjODU3YWQzNDRhIiwibmFtZSI6IiM1NDQ3LWNoYXJnZXMiLCJkaXNwbGF5LW5hbWUiOiIjNTQ0Ny1jaGFyZ2VzIiwidHlwZSI6ImNhcmQiLCJjYXJkLWlkIjo1NDQ3fX19LCJkYXRhYmFzZSI6MjZ9LCJkaXNwbGF5IjoiYmFyIiwiZGlzcGxheUlzTG9ja2VkIjp0cnVlLCJwYXJhbWV0ZXJzIjpbXSwidmlzdWFsaXphdGlvbl9zZXR0aW5ncyI6eyJncmFwaC55X2F4aXMudGl0bGVfdGV4dCI6IiUgTVJSIEdyb3d0aCIsImdyYXBoLnNob3dfdmFsdWVzIjp0cnVlLCJ0YWJsZS5jZWxsX2NvbHVtbiI6Im1yciIsImdyYXBoLnhfYXhpcy5heGlzX2VuYWJsZWQiOiJjb21wYWN0IiwiZ3JhcGgueF9heGlzLnRpdGxlX3RleHQiOiJNb250aCIsImdyYXBoLm1ldHJpY3MiOlsibW9tX21ycl9ncm93dGgiLG51bGxdLCJ0YWJsZS5waXZvdF9jb2x1bW4iOiJtb250aCIsImNvbHVtbl9zZXR0aW5ncyI6eyJbXCJuYW1lXCIsXCJtcnJcIl0iOnsibnVtYmVyX3N0eWxlIjoiY3VycmVuY3kiLCJkZWNpbWFscyI6MH0sIltcIm5hbWVcIixcInByZXZfbW9udGhfbXJyXCJdIjp7Im51bWJlcl9zdHlsZSI6ImN1cnJlbmN5IiwiZGVjaW1hbHMiOjB9LCJbXCJuYW1lXCIsXCJtb21fbXJyX2dyb3d0aFwiXSI6eyJudW1iZXJfc3R5bGUiOiJwZXJjZW50In0sIltcIm5hbWVcIixcIm1vbnRoXCJdIjp7InRpbWVfZW5hYmxlZCI6bnVsbCwiZGF0ZV9hYmJyZXZpYXRlIjp0cnVlfX0sInNlcmllc19zZXR0aW5ncyI6eyJtcnIiOnsidGl0bGUiOiJNUlIgKFRoaXMgTW9udGgpIn0sInByZXZfbW9udGhfbXJyIjp7InRpdGxlIjoiTVJSIChQcmV2aW91cyBNb250aCkifSwibW9tX21ycl9ncm93dGgiOnsidGl0bGUiOiJNb00gTVJSIEdyb3d0aCJ9fSwiZ3JhcGgueV9heGlzLmF1dG9fcmFuZ2UiOnRydWUsImdyYXBoLmRpbWVuc2lvbnMiOlsibW9udGgiXSwic3RhY2thYmxlLnN0YWNrX3R5cGUiOiJzdGFja2VkIn0sIm9yaWdpbmFsX2NhcmRfaWQiOjM5Njd9).

It happens because the serialized card contains an empty parameters list, which according to this [conditional](https://github.com/metabase/metabase/blob/49e023f673d58dc0ce2e362cf54a2a0089376304/frontend/src/metabase/query_builder/actions/core/parameterUtils.ts#L44), will cause the frontend to verify if the dashboard still has a matching dashcard that matches this card.

We then check for a dashcard's existence on the dashboard (unnecessarily in this case, since the card is not a dashcard, and it's not on a dashboard) [here](https://github.com/metabase/metabase/blob/49e023f673d58dc0ce2e362cf54a2a0089376304/frontend/src/metabase/parameters/utils/dashboards.ts#L220). Given the question doesn't have a dashcardId, the check fails, triggering the 403 error page. 

### How this PR fixes the bug, and doesn't cause any security issues.

Cards that are not dashcards shouldn't be checked whether they still exist on a dashboard or not. So we simply don't need to check if the card doesn't have a dashcardId. There is no risk of causing the original issue, 

Relevant links:
- Original Issue: https://github.com/metabase/metaboat/issues/121
- Original PR where the error handling is introduced: https://github.com/metabase/metabase/pull/19300
- [Notion doc](https://www.notion.so/metabase/Parameters-Security-Fix-360bbde060fc4e33a1c94f8bc61311e3) for the security fix