### PR TITLE
Allow for "deep-copy" of a dashboard

### DIFF
--- a/frontend/src/metabase/collections/components/CollectionCopyEntityModal.jsx
+++ b/frontend/src/metabase/collections/components/CollectionCopyEntityModal.jsx
@@ -47,6 +47,28 @@ function CollectionCopyEntityModal({
     setIsShallowCopy(is_shallow_copy);
   };
 
+  const handleSaved = newEntityObject => {
+    const newEntityUrl = Urls.modelToUrl({
+      model: entityObject.model,
+      model_object: newEntityObject,
+    });
+
+    triggerToast(
+      <div className="flex align-center">
+        {/* A shallow-copied newEntityObject will not include `uncopied` */}
+        {newEntityObject.uncopied?.length > 0
+          ? t`Duplicated ${entityObject.model}, but couldn't duplicate some questions`
+          : t`Duplicated ${entityObject.model}`}
+        <Link className="link text-bold ml1" to={newEntityUrl}>
+          {t`See it`}
+        </Link>
+      </div>,
+      { icon: entityObject.model },
+    );
+
+    onSaved(newEntityObject);
+  };
+
   return (
     <EntityCopyModal
       overwriteOnInitialValuesChange
@@ -61,23 +83,7 @@ function CollectionCopyEntityModal({
         return entityObject.copy(dissoc(values, "id"));
       }}
       onClose={onClose}
-      onSaved={newEntityObject => {
-        const newEntityUrl = Urls.modelToUrl({
-          model: entityObject.model,
-          model_object: newEntityObject,
-        });
-        triggerToast(
-          <div className="flex align-center">
-            {t`Duplicated ${entityObject.model}`}
-            <Link className="link text-bold ml1" to={newEntityUrl}>
-              {t`See it`}
-            </Link>
-          </div>,
-          { icon: entityObject.model },
-        );
-
-        onSaved(newEntityObject);
-      }}
+      onSaved={handleSaved}
       onValuesChange={handleValuesChange}
     />
   );

--- a/frontend/src/metabase/collections/components/CollectionCopyEntityModal.jsx
+++ b/frontend/src/metabase/collections/components/CollectionCopyEntityModal.jsx
@@ -10,6 +10,7 @@ import { entityTypeForObject } from "metabase/lib/schema";
 
 import Link from "metabase/core/components/Link";
 
+import Dashboards from "metabase/entities/dashboards";
 import Collections from "metabase/entities/collections";
 import EntityCopyModal from "metabase/entities/containers/EntityCopyModal";
 
@@ -37,6 +38,7 @@ function CollectionCopyEntityModal({
         ...entityObject,
         collection_id: initialCollectionId,
       }}
+      form={Dashboards.forms.duplicate}
       copy={async values => {
         return entityObject.copy(dissoc(values, "id"));
       }}

--- a/frontend/src/metabase/collections/components/CollectionCopyEntityModal.jsx
+++ b/frontend/src/metabase/collections/components/CollectionCopyEntityModal.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import React from "react";
+import React, { useState } from "react";
 import { connect } from "react-redux";
 import { dissoc } from "icepick";
 import { t } from "ttag";
@@ -30,6 +30,21 @@ function CollectionCopyEntityModal({
   onSaved,
   triggerToast,
 }) {
+  const [isShallowCopy, setIsShallowCopy] = useState(true);
+  const handleValuesChange = ({ is_shallow_copy }) => {
+    setIsShallowCopy(is_shallow_copy);
+  };
+
+  const getTitle = () => {
+    if (entityObject.model !== "dashboard") {
+      return "";
+    } else if (isShallowCopy) {
+      return t`Duplicate "${entityObject.name}"`;
+    } else {
+      return t`Duplicate "${entityObject.name}" and its questions`;
+    }
+  };
+
   return (
     <EntityCopyModal
       overwriteOnInitialValuesChange
@@ -39,6 +54,7 @@ function CollectionCopyEntityModal({
         collection_id: initialCollectionId,
       }}
       form={Dashboards.forms.duplicate}
+      title={getTitle()}
       copy={async values => {
         return entityObject.copy(dissoc(values, "id"));
       }}
@@ -60,6 +76,7 @@ function CollectionCopyEntityModal({
 
         onSaved(newEntityObject);
       }}
+      onValuesChange={handleValuesChange}
     />
   );
 }

--- a/frontend/src/metabase/collections/components/CollectionCopyEntityModal.jsx
+++ b/frontend/src/metabase/collections/components/CollectionCopyEntityModal.jsx
@@ -23,6 +23,16 @@ function mapStateToProps(state, props) {
   };
 }
 
+const getTitle = (entityObject, isShallowCopy) => {
+  if (entityObject.model !== "dashboard") {
+    return "";
+  } else if (isShallowCopy) {
+    return t`Duplicate "${entityObject.name}"`;
+  } else {
+    return t`Duplicate "${entityObject.name}" and its questions`;
+  }
+};
+
 function CollectionCopyEntityModal({
   entityObject,
   initialCollectionId,
@@ -31,18 +41,10 @@ function CollectionCopyEntityModal({
   triggerToast,
 }) {
   const [isShallowCopy, setIsShallowCopy] = useState(true);
+  const title = getTitle(entityObject, isShallowCopy);
+
   const handleValuesChange = ({ is_shallow_copy }) => {
     setIsShallowCopy(is_shallow_copy);
-  };
-
-  const getTitle = () => {
-    if (entityObject.model !== "dashboard") {
-      return "";
-    } else if (isShallowCopy) {
-      return t`Duplicate "${entityObject.name}"`;
-    } else {
-      return t`Duplicate "${entityObject.name}" and its questions`;
-    }
   };
 
   return (
@@ -54,7 +56,7 @@ function CollectionCopyEntityModal({
         collection_id: initialCollectionId,
       }}
       form={Dashboards.forms.duplicate}
-      title={getTitle()}
+      title={title}
       copy={async values => {
         return entityObject.copy(dissoc(values, "id"));
       }}

--- a/frontend/src/metabase/containers/FormikForm/FormikForm.tsx
+++ b/frontend/src/metabase/containers/FormikForm/FormikForm.tsx
@@ -33,6 +33,7 @@ interface FormContainerProps<Values extends BaseFieldValues>
   initial?: () => void;
   normalize?: () => void;
 
+  onValuesChange?: (newValues: Record<string, any>) => void;
   onSubmit: (
     values: Values,
     formikHelpers?: FormikHelpers<Values>,
@@ -95,12 +96,18 @@ function Form<Values extends BaseFieldValues>({
   validate,
   initial,
   normalize,
+  onValuesChange,
   onSubmit,
   onSubmitSuccess,
   ...props
 }: FormContainerProps<Values>) {
   const [error, setError] = useState<string | null>(null);
   const [values, setValues] = useState({});
+
+  const handleValuesChange = (newValues: any) => {
+    onValuesChange?.(newValues);
+    setValues(newValues);
+  };
 
   const { inlineFields, registerFormField, unregisterFormField } =
     useInlineFields();
@@ -252,7 +259,7 @@ function Form<Values extends BaseFieldValues>({
           error={error}
           registerFormField={registerFormField}
           unregisterFormField={unregisterFormField}
-          onValuesChange={setValues}
+          onValuesChange={handleValuesChange}
         />
       )}
     </Formik>

--- a/frontend/src/metabase/dashboard/components/DashboardCopyModal.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardCopyModal.jsx
@@ -32,6 +32,16 @@ const mapDispatchToProps = {
   onReplaceLocation: replace,
 };
 
+const getTitle = (dashboard, isShallowCopy) => {
+  if (!dashboard?.name) {
+    return "";
+  } else if (isShallowCopy) {
+    return t`Duplicate "${dashboard.name}"`;
+  } else {
+    return t`Duplicate "${dashboard.name}" and its questions`;
+  }
+};
+
 const DashboardCopyModalInner = ({
   onClose,
   onReplaceLocation,
@@ -44,18 +54,10 @@ const DashboardCopyModalInner = ({
   const [isShallowCopy, setIsShallowCopy] = useState(true);
   const initialDashboardId = Urls.extractEntityId(params.slug);
 
+  const title = getTitle(dashboard, isShallowCopy);
+
   const handleValuesChange = ({ is_shallow_copy }) => {
     setIsShallowCopy(is_shallow_copy);
-  };
-
-  const getTitle = () => {
-    if (!dashboard?.name) {
-      return "";
-    } else if (isShallowCopy) {
-      return t`Duplicate "${dashboard.name}"`;
-    } else {
-      return t`Duplicate "${dashboard.name}" and its questions`;
-    }
   };
 
   return (
@@ -66,7 +68,7 @@ const DashboardCopyModalInner = ({
         collection_id: initialCollectionId,
       }}
       form={Dashboards.forms.duplicate}
-      title={getTitle()}
+      title={title}
       overwriteOnInitialValuesChange
       copy={object =>
         copyDashboard({ id: initialDashboardId }, dissoc(object, "id"))

--- a/frontend/src/metabase/dashboard/components/DashboardCopyModal.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardCopyModal.jsx
@@ -1,9 +1,10 @@
 /* eslint-disable react/prop-types */
-import React from "react";
+import React, { useState } from "react";
 import { withRouter } from "react-router";
 import { connect } from "react-redux";
 import { dissoc } from "icepick";
 import _ from "underscore";
+import { t } from "ttag";
 
 import { replace } from "react-router-redux";
 import * as Urls from "metabase/lib/urls";
@@ -31,39 +32,52 @@ const mapDispatchToProps = {
   onReplaceLocation: replace,
 };
 
-class DashboardCopyModalInner extends React.Component {
-  render() {
-    const {
-      onClose,
-      onReplaceLocation,
-      copyDashboard,
-      dashboard,
-      initialCollectionId,
-      params,
-      ...props
-    } = this.props;
+const DashboardCopyModalInner = ({
+  onClose,
+  onReplaceLocation,
+  copyDashboard,
+  dashboard,
+  initialCollectionId,
+  params,
+  ...props
+}) => {
+  const [isShallowCopy, setIsShallowCopy] = useState(true);
+  const initialDashboardId = Urls.extractEntityId(params.slug);
 
-    const initialDashboardId = Urls.extractEntityId(params.slug);
+  const handleValuesChange = ({ is_shallow_copy }) => {
+    setIsShallowCopy(is_shallow_copy);
+  };
 
-    return (
-      <EntityCopyModal
-        entityType="dashboards"
-        entityObject={{
-          ...dashboard,
-          collection_id: initialCollectionId,
-        }}
-        form={Dashboards.forms.duplicate}
-        overwriteOnInitialValuesChange
-        copy={object =>
-          copyDashboard({ id: initialDashboardId }, dissoc(object, "id"))
-        }
-        onClose={onClose}
-        onSaved={dashboard => onReplaceLocation(Urls.dashboard(dashboard))}
-        {...props}
-      />
-    );
-  }
-}
+  const getTitle = () => {
+    if (!dashboard || !dashboard?.name) {
+      return "";
+    } else if (isShallowCopy) {
+      return t`Duplicate "${dashboard.name}"`;
+    } else {
+      return t`Duplicate "${dashboard.name}" and its questions`;
+    }
+  };
+
+  return (
+    <EntityCopyModal
+      entityType="dashboards"
+      entityObject={{
+        ...dashboard,
+        collection_id: initialCollectionId,
+      }}
+      form={Dashboards.forms.duplicate}
+      title={getTitle()}
+      overwriteOnInitialValuesChange
+      copy={object =>
+        copyDashboard({ id: initialDashboardId }, dissoc(object, "id"))
+      }
+      onClose={onClose}
+      onSaved={dashboard => onReplaceLocation(Urls.dashboard(dashboard))}
+      {...props}
+      onValuesChange={handleValuesChange}
+    />
+  );
+};
 
 const DashboardCopyModal = _.compose(
   withRouter,

--- a/frontend/src/metabase/dashboard/components/DashboardCopyModal.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardCopyModal.jsx
@@ -49,7 +49,7 @@ const DashboardCopyModalInner = ({
   };
 
   const getTitle = () => {
-    if (!dashboard || !dashboard?.name) {
+    if (!dashboard?.name) {
       return "";
     } else if (isShallowCopy) {
       return t`Duplicate "${dashboard.name}"`;

--- a/frontend/src/metabase/dashboard/components/DashboardCopyModal.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardCopyModal.jsx
@@ -42,7 +42,9 @@ class DashboardCopyModalInner extends React.Component {
       params,
       ...props
     } = this.props;
+
     const initialDashboardId = Urls.extractEntityId(params.slug);
+
     return (
       <EntityCopyModal
         entityType="dashboards"
@@ -50,6 +52,7 @@ class DashboardCopyModalInner extends React.Component {
           ...dashboard,
           collection_id: initialCollectionId,
         }}
+        form={Dashboards.forms.duplicate}
         overwriteOnInitialValuesChange
         copy={object =>
           copyDashboard({ id: initialDashboardId }, dissoc(object, "id"))

--- a/frontend/src/metabase/dashboard/components/DashboardCopyModal/DashboardCopyModalShallowCheckboxLabel/DashboardCopyModalShallowCheckboxLabel.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardCopyModal/DashboardCopyModalShallowCheckboxLabel/DashboardCopyModalShallowCheckboxLabel.styled.tsx
@@ -1,0 +1,12 @@
+import styled from "@emotion/styled";
+import { space } from "metabase/styled-components/theme";
+
+export const CheckboxLabelRoot = styled.div`
+  display: flex;
+  align-items: center;
+  padding-left: ${space(0)};
+
+  > * {
+    padding-left: ${space(0)};
+  }
+`;

--- a/frontend/src/metabase/dashboard/components/DashboardCopyModal/DashboardCopyModalShallowCheckboxLabel/DashboardCopyModalShallowCheckboxLabel.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardCopyModal/DashboardCopyModalShallowCheckboxLabel/DashboardCopyModalShallowCheckboxLabel.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { t } from "ttag";
+
+import Icon from "metabase/components/Icon";
+import Tooltip from "metabase/components/Tooltip";
+
+import { CheckboxLabelRoot } from "./DashboardCopyModalShallowCheckboxLabel.styled";
+
+const DashboardCopyModalShallowCheckboxLabel = () => (
+  <CheckboxLabelRoot>
+    {t`Only duplicate the dashboard`}
+    <Tooltip
+      tooltip={t`If you check this, the cards in the duplicated dashboard will reference the original questions.`}
+    >
+      <Icon name="info" size={18} />
+    </Tooltip>
+  </CheckboxLabelRoot>
+);
+
+export default DashboardCopyModalShallowCheckboxLabel;

--- a/frontend/src/metabase/dashboard/components/DashboardCopyModal/DashboardCopyModalShallowCheckboxLabel/index.ts
+++ b/frontend/src/metabase/dashboard/components/DashboardCopyModal/DashboardCopyModalShallowCheckboxLabel/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DashboardCopyModalShallowCheckboxLabel";

--- a/frontend/src/metabase/entities/containers/EntityCopyModal.jsx
+++ b/frontend/src/metabase/entities/containers/EntityCopyModal.jsx
@@ -10,11 +10,15 @@ const EntityCopyModal = ({
   entityType,
   entityObject,
   copy,
+  title,
   onClose,
   onSaved,
   ...props
 }) => (
-  <ModalContent title={t`Duplicate "${entityObject.name}"`} onClose={onClose}>
+  <ModalContent
+    title={title || t`Duplicate "${entityObject.name}"`}
+    onClose={onClose}
+  >
     <EntityForm
       entityType={entityType}
       entityObject={{

--- a/frontend/src/metabase/entities/containers/EntityForm.jsx
+++ b/frontend/src/metabase/entities/containers/EntityForm.jsx
@@ -36,6 +36,7 @@ const EForm = ({
       />
     );
   }
+
   return (
     <Form
       {...props}

--- a/frontend/src/metabase/entities/dashboards.js
+++ b/frontend/src/metabase/entities/dashboards.js
@@ -94,6 +94,7 @@ const Dashboards = createEntity({
             await Dashboards.api.copy({
               id: entityObject.id,
               ...overrides,
+              is_deep_copy: !overrides.is_shallow_copy,
             }),
           );
           if (notify) {

--- a/frontend/src/metabase/entities/dashboards/forms.js
+++ b/frontend/src/metabase/entities/dashboards/forms.js
@@ -31,6 +31,24 @@ function createCollectionIdField() {
   };
 }
 
+function createShallowCopyField() {
+  return {
+    name: "is_shallow_copy",
+    type: "checkbox",
+    label: t`Only duplicate the dashboard`,
+    tooltip: t`This is a tooltip`,
+  };
+}
+
+function duplicateForm() {
+  return [
+    createNameField(),
+    createDescriptionField(),
+    createCollectionIdField(),
+    createShallowCopyField(),
+  ];
+}
+
 function createForm() {
   return [
     createNameField(),
@@ -42,6 +60,9 @@ function createForm() {
 export default {
   create: {
     fields: createForm,
+  },
+  duplicate: {
+    fields: duplicateForm,
   },
   edit: {
     fields: () => {

--- a/frontend/src/metabase/entities/dashboards/forms.jsx
+++ b/frontend/src/metabase/entities/dashboards/forms.jsx
@@ -1,6 +1,9 @@
+import React from "react";
 import { t } from "ttag";
 import MetabaseSettings from "metabase/lib/settings";
 import { PLUGIN_CACHING } from "metabase/plugins";
+
+import DashboardCopyModalShallowCheckboxLabel from "metabase/dashboard/components/DashboardCopyModal/DashboardCopyModalShallowCheckboxLabel";
 
 function createNameField() {
   return {
@@ -35,8 +38,7 @@ function createShallowCopyField() {
   return {
     name: "is_shallow_copy",
     type: "checkbox",
-    label: t`Only duplicate the dashboard`,
-    tooltip: t`This is a tooltip`,
+    label: <DashboardCopyModalShallowCheckboxLabel />,
   };
 }
 

--- a/frontend/test/metabase/scenarios/collections/collection-pinned-overview.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collection-pinned-overview.cy.spec.js
@@ -138,7 +138,9 @@ describe("scenarios > collection pinned items overview", () => {
     openPinnedItemMenu(DASHBOARD_NAME);
     popover().findByText("Duplicate").click();
 
-    cy.findByText(`Duplicate "${DASHBOARD_NAME}"`).should("be.visible");
+    cy.findByText(`Duplicate "${DASHBOARD_NAME}" and its questions`).should(
+      "be.visible",
+    );
   });
 
   it("should be able to archive a pinned dashboard", () => {

--- a/frontend/test/metabase/scenarios/dashboard/duplicate.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/duplicate.cy.spec.js
@@ -18,8 +18,10 @@ describe("scenarios > dashboard > duplicate", () => {
     });
 
     cy.findByText("Duplicate").click();
+    cy.findByText('Duplicate "Orders in a dashboard" and its questions');
 
     cy.findByRole("checkbox").click();
+    cy.findByText('Duplicate "Orders in a dashboard"');
 
     cy.button("Duplicate").click();
 

--- a/frontend/test/metabase/scenarios/dashboard/duplicate.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/duplicate.cy.spec.js
@@ -1,0 +1,52 @@
+import {
+  restore,
+  visitCollection,
+  visitDashboard,
+} from "__support__/e2e/helpers";
+
+describe("scenarios > dashboard > duplicate", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("shallow (duplicate dashboard but not its cards)", () => {
+    visitDashboard(1);
+
+    cy.get("main header").within(() => {
+      cy.icon("ellipsis").click();
+    });
+
+    cy.findByText("Duplicate").click();
+
+    cy.findByRole("checkbox").click();
+
+    cy.button("Duplicate").click();
+
+    cy.findByText("Orders in a dashboard - Duplicate");
+  });
+
+  it("deep (duplicate dashboard and its card)", () => {
+    visitDashboard(1);
+
+    cy.get("main header").within(() => {
+      cy.icon("ellipsis").click();
+    });
+
+    cy.findByText("Duplicate").click();
+
+    // Change destination collection
+    cy.findByTestId("select-button").click();
+    cy.findByText("My personal collection").click();
+
+    cy.button("Duplicate").click();
+
+    cy.findByText("Orders in a dashboard - Duplicate");
+
+    // Duplicated dashboard and question should live in personal collection
+    visitCollection(1);
+
+    cy.findByText("Orders");
+    cy.findByText("Orders in a dashboard - Duplicate");
+  });
+});

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -207,25 +207,38 @@
             valid-metadata?)
        ;; only sent valid metadata in the edit. Metadata might be the same, might be different. We save in either case
        (and (nil? query)
+            valid-metadata?)
+
+       ;; copying card and reusing existing metadata
+       (and (nil? original-query)
+            query
             valid-metadata?))
-      (a/to-chan! [metadata])
+      (do
+        (log/debug (trs "Reusing provided metadata"))
+        (a/to-chan! [metadata]))
 
       ;; frontend always sends query. But sometimes programatic don't (cypress, API usage). Returning an empty channel
       ;; means the metadata won't be updated at all.
       (nil? query)
-      (doto (a/chan) a/close!)
+      (do
+        (log/debug (trs "No query provided so not querying for metadata"))
+        (doto (a/chan) a/close!))
 
       ;; datasets need to incorporate the metadata either passed in or already in the db. Query has changed so we
       ;; re-run and blend the saved into the new metadata
       (and dataset? (or valid-metadata? (seq original-metadata)))
-      (a/go (let [metadata' (if valid-metadata?
-                              (map mbql.normalize/normalize-source-metadata metadata)
-                              original-metadata)
-                  fresh     (a/<! (qp.async/result-metadata-for-query-async query))]
-              (qp.util/combine-metadata fresh metadata')))
+      (do
+       (log/debug (trs "Querying for metadata and blending model metadata"))
+       (a/go (let [metadata' (if valid-metadata?
+                               (map mbql.normalize/normalize-source-metadata metadata)
+                               original-metadata)
+                   fresh     (a/<! (qp.async/result-metadata-for-query-async query))]
+               (qp.util/combine-metadata fresh metadata'))))
       :else
       ;; compute fresh
-      (qp.async/result-metadata-for-query-async query))))
+      (do
+        (log/debug (trs "Querying for metadata"))
+        (qp.async/result-metadata-for-query-async query)))))
 
 (defn check-data-permissions-for-query
   "Make sure the Current User has the appropriate *data* permissions to run `query`. We don't want Users saving Cards
@@ -346,7 +359,7 @@ saved later when it is ready."
                               ;; collection to change position, check that and fix it if needed
                               (api/maybe-reconcile-collection-position! card-data)
                               (db/insert! Card (cond-> card-data
-                                                 (not timed-out?)
+                                                 (and metadata (not timed-out?))
                                                  (assoc :result_metadata metadata))))]
     (events/publish-event! :card-create card)
     (when timed-out?

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -222,12 +222,17 @@
   card. The `:discard` key is a vector of cards which were not copied due to permissions."
   [ordered-cards]
   (letfn [(split-cards [{:keys [card series] :as db-card}]
+
             (cond
               (nil? (:card_id db-card)) ;; text card
               []
 
-              (mi/can-write? card)
-              (let [{writable true unwritable false} (group-by (comp boolean mi/can-write?)
+              (not (mi/instance-of? Card card)) ;; cards without permissions are just a map with an :id from
+                                                ;; [[hide-unreadable-card]]
+              [nil (into [card] series)]
+
+              (mi/can-read? card)
+              (let [{writable true unwritable false} (group-by (comp boolean mi/can-read?)
                                                                series)]
                 [(into [card] writable) unwritable])
               ;; if you can't write the base, we don't have anywhere to put the series

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -227,8 +227,8 @@
               (nil? (:card_id db-card)) ;; text card
               []
 
-              (not (mi/instance-of? Card card)) ;; cards without permissions are just a map with an :id from
-                                                ;; [[hide-unreadable-card]]
+              ;; cards without permissions are just a map with an :id from [[hide-unreadable-card]]
+              (not (mi/model card))
               [nil (into [card] series)]
 
               (mi/can-read? card)

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -292,8 +292,6 @@
    is_deep_copy           (s/maybe s/Bool)}
   ;; if we're trying to save the new dashboard in a Collection make sure we have permissions to do that
   (collection/check-write-perms-for-collection collection_id)
-  (when collection_id
-    (api/read-check Collection collection_id))
   (let [existing-dashboard (get-dashboard from-dashboard-id)
         dashboard-data {:name                (or name (:name existing-dashboard))
                         :description         (or description (:description existing-dashboard))

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -16,7 +16,7 @@
             [metabase.mbql.util :as mbql.u]
             [metabase.models.action :as action]
             [metabase.models.card :refer [Card]]
-            [metabase.models.collection :as collection]
+            [metabase.models.collection :as collection :refer [Collection]]
             [metabase.models.dashboard :as dashboard :refer [Dashboard]]
             [metabase.models.dashboard-card :as dashboard-card :refer [DashboardCard]]
             [metabase.models.field :refer [Field]]
@@ -253,6 +253,8 @@
    destination-collection (s/maybe su/IntGreaterThanZero)}
   ;; if we're trying to save the new dashboard in a Collection make sure we have permissions to do that
   (collection/check-write-perms-for-collection collection_id)
+  (when destination-collection
+    (api/read-check Collection destination-collection))
   (let [existing-dashboard (get-dashboard from-dashboard-id)
         dashboard-data {:name                (or name (:name existing-dashboard))
                         :description         (or description (:description existing-dashboard))

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -220,10 +220,17 @@
 (defn- duplicate-cards
   "Takes a dashboard id, and duplicates the cards both on the dashboard's cards and dashcardseries. Returns a map of
   {old-card-id duplicated-card} so that the new dashboard can adjust accordingly."
-  [dashboard destination-collection]
-  (let [card-ids (into #{} (comp
+  [dashboard dest-coll-id]
+  (let [same-collection? (= (:collection_id dashboard) dest-coll-id)
+        card-ids (into #{} (comp
                             (mapcat (fn [{:keys [card series]}]
-                                      (into [(:id card)] (map :id) series)))
+                                      ;; if there are series on top of a card they cannot write (ie, don't have curate
+                                      ;; perms for collection) the series can't be copied either
+                                      (when (and (:id card) (mi/can-write? card))
+                                        (into [(:id card)]
+                                              (comp (filter mi/can-write?)
+                                                    (map :id))
+                                              series))))
                             (keep identity))
                        (:ordered_cards dashboard))
         id->card (m/index-by :id (db/select 'Card :id [:in card-ids]))]
@@ -231,9 +238,42 @@
               (assoc m id
                      (if (:dataset card)
                        card
-                       (api.card/create-card! (assoc card :collection_id destination-collection)))))
+                       (api.card/create-card!
+                        (cond-> (assoc card :collection_id dest-coll-id)
+                          same-collection?
+                          (update :name #(str % " -- " (tru "Duplicate"))))))))
             {}
             id->card)))
+
+(defn update-cards-for-copy
+  "Update ordered-cards in a dashboard for copying. If shallow copy, returns the cards. If deep copy, replaces ids with
+  id from the newly-copied cards. If there is no new id, it means user lacked curate permissions for the cards
+  collections and it is omitted."
+  [ordered-cards copy-style id->new-card]
+  (if (not= copy-style "deep")
+    ordered-cards
+    (keep (fn [dashboard-card]
+            (cond
+              ;; text cards need no manipulation
+              (nil? (:card_id dashboard-card))
+              dashboard-card
+
+              ;; if we didn't duplicate, it doesn't go in the dashboard
+              (not (id->new-card (:card_id dashboard-card)))
+              nil
+
+              :else
+              (let [new-id (fn [id]
+                             (-> id id->new-card :id))]
+                (-> dashboard-card
+                    (update :card_id new-id)
+                    (update :card update :id new-id)
+                    (update :series (fn [series]
+                                      (keep (fn [card]
+                                              (when-let [id' (new-id (:id card))]
+                                                (assoc card :id id')))
+                                            series)))))))
+          ordered-cards)))
 
 (api/defendpoint POST "/:from-dashboard-id/copy"
   "Copy a Dashboard."
@@ -251,12 +291,13 @@
   (collection/check-write-perms-for-collection collection_id)
   (when destination-collection
     (api/read-check Collection destination-collection))
-  (let [existing-dashboard (get-dashboard from-dashboard-id)
+  (let [dest-coll-id   destination-collection ; if we want to change the api nothing downstream affected
+        existing-dashboard (get-dashboard from-dashboard-id)
         dashboard-data {:name                (or name (:name existing-dashboard))
                         :description         (or description (:description existing-dashboard))
                         :parameters          (or (:parameters existing-dashboard) [])
                         :creator_id          api/*current-user-id*
-                        :collection_id       (or destination-collection collection_id)
+                        :collection_id       (or dest-coll-id collection_id)
                         :collection_position collection_position
                         :is_app_page         (:is_app_page existing-dashboard)}
         dashboard      (db/transaction
@@ -267,27 +308,11 @@
                         (u/prog1 (db/insert! Dashboard dashboard-data)
                           ;; Get cards from existing dashboard and associate to copied dashboard
                           (let [id->new-card (when (= copy-style "deep")
-                                               (duplicate-cards existing-dashboard
-                                                                destination-collection))
-                                id->new-id  (if (seq id->new-card)
-                                              (fn [id]
-                                                (when id
-                                                  ;; text cards don't have ids
-                                                  (or (:id (id->new-card id))
-                                                      (throw (ex-info (tru "Card {0} not duplicated"
-                                                                           id)
-                                                                      {:id id
-                                                                       :ids id->new-card})))))
-                                              identity)]
-                            (doseq [card (:ordered_cards existing-dashboard)]
-                              (api/check-500 (dashboard/add-dashcard!
-                                              <>
-                                              (id->new-id (:card_id card))
-                                              (update card
-                                                      :series
-                                                      (fn [series]
-                                                        (map #(update % :id id->new-id)
-                                                             series)))))))))]
+                                               (duplicate-cards existing-dashboard dest-coll-id))]
+                            (doseq [card (update-cards-for-copy (:ordered_cards existing-dashboard)
+                                                                copy-style
+                                                                id->new-card)]
+                              (api/check-500 (dashboard/add-dashcard! <> (:card_id card) card))))))]
     (snowplow/track-event! ::snowplow/dashboard-created api/*current-user-id* {:dashboard-id (u/the-id dashboard)})
     (events/publish-event! :dashboard-create dashboard)))
 

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -273,11 +273,13 @@
                                                                 destination-collection))
                                 id->new-id  (if (seq id->new-card)
                                               (fn [id]
-                                                (or (:id (id->new-card id))
-                                                    (throw (ex-info (tru "Card {0} not duplicated"
-                                                                         id)
-                                                                    {:id id
-                                                                     :ids id->new-card}))))
+                                                (when id
+                                                  ;; text cards don't have ids
+                                                  (or (:id (id->new-card id))
+                                                      (throw (ex-info (tru "Card {0} not duplicated"
+                                                                           id)
+                                                                      {:id id
+                                                                       :ids id->new-card})))))
                                               identity)]
                             (doseq [card (:ordered_cards existing-dashboard)]
                               (api/check-500 (dashboard/add-dashcard!

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -288,9 +288,9 @@
                     (assoc :card (-> dashboard-card :card_id id->new-card))
                     (m/update-existing :parameter_mappings
                                        (fn [pms]
-                                         (map (fn [pm]
-                                                (m/update-existing pm :card_id new-id))
-                                              pms)))
+                                         (keep (fn [pm]
+                                                 (m/update-existing pm :card_id new-id))
+                                               pms)))
                     (m/update-existing :series
                                        (fn [series]
                                          (keep (fn [card]

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -249,8 +249,8 @@
   "Update ordered-cards in a dashboard for copying. If shallow copy, returns the cards. If deep copy, replaces ids with
   id from the newly-copied cards. If there is no new id, it means user lacked curate permissions for the cards
   collections and it is omitted."
-  [ordered-cards copy-style id->new-card]
-  (if (not= copy-style "deep")
+  [ordered-cards deep? id->new-card]
+  (if-not deep?
     ordered-cards
     (keep (fn [dashboard-card]
             (cond
@@ -284,26 +284,22 @@
 (api/defendpoint POST "/:from-dashboard-id/copy"
   "Copy a Dashboard."
   [from-dashboard-id :as {{:keys [name description collection_id collection_position
-                                  copy-style destination-collection], :as _dashboard} :body}]
+                                  is_deep_copy], :as _dashboard} :body}]
   {name                   (s/maybe su/NonBlankString)
    description            (s/maybe s/Str)
    collection_id          (s/maybe su/IntGreaterThanZero)
    collection_position    (s/maybe su/IntGreaterThanZero)
-   copy-style             (s/maybe (s/enum "deep" "shallow"))
-   ;; todo: do we want an explicit destination to override the provided collection_id?
-   ;; don't know how the FE likes to work
-   destination-collection (s/maybe su/IntGreaterThanZero)}
+   is_deep_copy           (s/maybe s/Bool)}
   ;; if we're trying to save the new dashboard in a Collection make sure we have permissions to do that
   (collection/check-write-perms-for-collection collection_id)
-  (when destination-collection
-    (api/read-check Collection destination-collection))
-  (let [dest-coll-id   destination-collection ; if we want to change the api nothing downstream affected
-        existing-dashboard (get-dashboard from-dashboard-id)
+  (when collection_id
+    (api/read-check Collection collection_id))
+  (let [existing-dashboard (get-dashboard from-dashboard-id)
         dashboard-data {:name                (or name (:name existing-dashboard))
                         :description         (or description (:description existing-dashboard))
                         :parameters          (or (:parameters existing-dashboard) [])
                         :creator_id          api/*current-user-id*
-                        :collection_id       (or dest-coll-id collection_id)
+                        :collection_id       collection_id
                         :collection_position collection_position
                         :is_app_page         (:is_app_page existing-dashboard)}
         dashboard      (db/transaction
@@ -313,10 +309,10 @@
                         ;; Ok, now save the Dashboard
                         (u/prog1 (db/insert! Dashboard dashboard-data)
                           ;; Get cards from existing dashboard and associate to copied dashboard
-                          (let [id->new-card (when (= copy-style "deep")
-                                               (duplicate-cards existing-dashboard dest-coll-id))]
+                          (let [id->new-card (when is_deep_copy
+                                               (duplicate-cards existing-dashboard collection_id))]
                             (doseq [card (update-cards-for-copy (:ordered_cards existing-dashboard)
-                                                                copy-style
+                                                                is_deep_copy
                                                                 id->new-card)]
                               (api/check-500 (dashboard/add-dashcard! <> (:card_id card) card))))))]
     (snowplow/track-event! ::snowplow/dashboard-created api/*current-user-id* {:dashboard-id (u/the-id dashboard)})

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -7,6 +7,7 @@
             [medley.core :as m]
             [metabase.actions.execution :as actions.execution]
             [metabase.analytics.snowplow :as snowplow]
+            [metabase.api.card :as api.card]
             [metabase.api.common :as api]
             [metabase.api.common.validation :as validation]
             [metabase.api.dataset :as api.dataset]
@@ -216,14 +217,40 @@
       hide-unreadable-cards
       add-query-average-durations))
 
+(defn- duplicate-cards
+  "Takes a dashboard id, and duplicates the cards both on the dashboard's cards and dashcardseries. Returns a map of
+  {old-card-id duplicated-card} so that the new dashboard can adjust accordingly."
+  [dashboard destination-collection]
+  (let [card-ids (into #{} (comp
+                            (mapcat (fn [{:keys [card series]}]
+                                      (into [(:id card)] (map :id) series)))
+                            (keep identity))
+                       (:ordered_cards dashboard))
+        id->card (m/index-by :id (db/select 'Card :id [:in card-ids]))]
+    (reduce (fn [m [id card]]
+              (assoc m id
+                     (if (:dataset card)
+                       card
+                       ;; todo: `create-card!` waits up to 1.5 seconds for metadata. But presumably we have that. So:
+                       ;; we want to avoid the wait either way, and if this transaction fails we don't want the
+                       ;; asynchronous metadata saving to attempt to save metadata to a card that won't be visible (if
+                       ;; transaction hasn't completed yet) or won't exist if transaction fails
+                       (api.card/create-card! (assoc card :collection_id destination-collection)))))
+            {}
+            id->card)))
 
 (api/defendpoint POST "/:from-dashboard-id/copy"
   "Copy a Dashboard."
-  [from-dashboard-id :as {{:keys [name description collection_id collection_position], :as _dashboard} :body}]
-  {name                (s/maybe su/NonBlankString)
-   description         (s/maybe s/Str)
-   collection_id       (s/maybe su/IntGreaterThanZero)
-   collection_position (s/maybe su/IntGreaterThanZero)}
+  [from-dashboard-id :as {{:keys [name description collection_id collection_position
+                                  copy-style destination-collection], :as _dashboard} :body}]
+  {name                   (s/maybe su/NonBlankString)
+   description            (s/maybe s/Str)
+   collection_id          (s/maybe su/IntGreaterThanZero)
+   collection_position    (s/maybe su/IntGreaterThanZero)
+   copy-style             (s/maybe (s/enum "deep" "shallow"))
+   ;; todo: do we want an explicit destination to override the provided collection_id?
+   ;; don't know how the FE likes to work
+   destination-collection (s/maybe su/IntGreaterThanZero)}
   ;; if we're trying to save the new dashboard in a Collection make sure we have permissions to do that
   (collection/check-write-perms-for-collection collection_id)
   (let [existing-dashboard (get-dashboard from-dashboard-id)
@@ -231,18 +258,36 @@
                         :description         (or description (:description existing-dashboard))
                         :parameters          (or (:parameters existing-dashboard) [])
                         :creator_id          api/*current-user-id*
-                        :collection_id       collection_id
+                        :collection_id       (or destination-collection collection_id)
                         :collection_position collection_position
                         :is_app_page         (:is_app_page existing-dashboard)}
         dashboard      (db/transaction
-                         ;; Adding a new dashboard at `collection_position` could cause other dashboards in this
-                         ;; collection to change position, check that and fix up if needed
-                         (api/maybe-reconcile-collection-position! dashboard-data)
-                         ;; Ok, now save the Dashboard
-                         (u/prog1 (db/insert! Dashboard dashboard-data)
-                           ;; Get cards from existing dashboard and associate to copied dashboard
-                           (doseq [card (:ordered_cards existing-dashboard)]
-                             (api/check-500 (dashboard/add-dashcard! <> (:card_id card) card)))))]
+                        ;; Adding a new dashboard at `collection_position` could cause other dashboards in this
+                        ;; collection to change position, check that and fix up if needed
+                        (api/maybe-reconcile-collection-position! dashboard-data)
+                        ;; Ok, now save the Dashboard
+                        (u/prog1 (db/insert! Dashboard dashboard-data)
+                          ;; Get cards from existing dashboard and associate to copied dashboard
+                          (let [id->new-card (when (= copy-style "deep")
+                                               (duplicate-cards existing-dashboard
+                                                                destination-collection))
+                                id->new-id  (if (seq id->new-card)
+                                              (fn [id]
+                                                (or (:id (id->new-card id))
+                                                    (throw (ex-info (tru "Card {0} not duplicated"
+                                                                         id)
+                                                                    {:id id
+                                                                     :ids id->new-card}))))
+                                              identity)]
+                            (doseq [card (:ordered_cards existing-dashboard)]
+                              (api/check-500 (dashboard/add-dashcard!
+                                              <>
+                                              (id->new-id (:card_id card))
+                                              (update card
+                                                      :series
+                                                      (fn [series]
+                                                        (map #(update % :id id->new-id)
+                                                             series)))))))))]
     (snowplow/track-event! ::snowplow/dashboard-created api/*current-user-id* {:dashboard-id (u/the-id dashboard)})
     (events/publish-event! :dashboard-create dashboard)))
 

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -217,23 +217,37 @@
       hide-unreadable-cards
       add-query-average-durations))
 
+(defn- cards-to-copy
+  "Returns a map of which cards we need to copy and which are not to be copied. The `:copy` key is a map from id to
+  card. The `:discard` key is a vector of cards which were not copied due to permissions."
+  [ordered-cards]
+  (letfn [(split-cards [{:keys [card series] :as db-card}]
+            (cond
+              (nil? (:card_id db-card)) ;; text card
+              []
+
+              (mi/can-write? card)
+              (let [{writable true unwritable false} (group-by (comp boolean mi/can-write?)
+                                                               series)]
+                [(into [card] writable) unwritable])
+              ;; if you can't write the base, we don't have anywhere to put the series
+              :else
+              [[] (into [card] series)]))]
+    (reduce (fn [acc db-card]
+              (let [[retain discard] (split-cards db-card)]
+                (-> acc
+                    (update :copy merge (m/index-by :id retain))
+                    (update :discard concat discard))))
+            {:copy {}
+             :discard []}
+            ordered-cards)))
+
 (defn- duplicate-cards
   "Takes a dashboard id, and duplicates the cards both on the dashboard's cards and dashcardseries. Returns a map of
   {old-card-id duplicated-card} so that the new dashboard can adjust accordingly."
   [dashboard dest-coll-id]
   (let [same-collection? (= (:collection_id dashboard) dest-coll-id)
-        card-ids (into #{} (comp
-                            (mapcat (fn [{:keys [card series]}]
-                                      ;; if there are series on top of a card they cannot write (ie, don't have curate
-                                      ;; perms for collection) the series can't be copied either
-                                      (when (and (:id card) (mi/can-write? card))
-                                        (into [(:id card)]
-                                              (comp (filter mi/can-write?)
-                                                    (map :id))
-                                              series))))
-                            (keep identity))
-                       (:ordered_cards dashboard))
-        id->card (m/index-by :id (db/select 'Card :id [:in card-ids]))]
+        {:keys [copy discard]} (cards-to-copy (:ordered_cards dashboard))]
     (reduce (fn [m [id card]]
               (assoc m id
                      (if (:dataset card)
@@ -242,8 +256,8 @@
                         (cond-> (assoc card :collection_id dest-coll-id)
                           same-collection?
                           (update :name #(str % " -- " (tru "Duplicate"))))))))
-            {}
-            id->card)))
+            {:uncopied discard}
+            copy)))
 
 (defn update-cards-for-copy
   "Update ordered-cards in a dashboard for copying. If shallow copy, returns the cards. If deep copy, replaces ids with
@@ -309,15 +323,17 @@
                         ;; collection to change position, check that and fix up if needed
                         (api/maybe-reconcile-collection-position! dashboard-data)
                         ;; Ok, now save the Dashboard
-                        (u/prog1 (db/insert! Dashboard dashboard-data)
-                          ;; Get cards from existing dashboard and associate to copied dashboard
-                          (let [id->new-card (when is_deep_copy
-                                               (duplicate-cards existing-dashboard collection_id))]
-                            (doseq [card (update-cards-for-copy from-dashboard-id
-                                                                (:ordered_cards existing-dashboard)
-                                                                is_deep_copy
-                                                                id->new-card)]
-                              (api/check-500 (dashboard/add-dashcard! <> (:card_id card) card))))))]
+                        (let [dash (db/insert! Dashboard dashboard-data)
+                              id->new-card (when is_deep_copy
+                                             (duplicate-cards existing-dashboard collection_id))]
+                          (doseq [card (update-cards-for-copy from-dashboard-id
+                                                              (:ordered_cards existing-dashboard)
+                                                              is_deep_copy
+                                                              id->new-card)]
+                            (api/check-500 (dashboard/add-dashcard! dash (:card_id card) card)))
+                          (cond-> dash
+                            (:uncopied id->new-card)
+                            (assoc :uncopied (:uncopied id->new-card)))))]
     (snowplow/track-event! ::snowplow/dashboard-created api/*current-user-id* {:dashboard-id (u/the-id dashboard)})
     (events/publish-event! :dashboard-create dashboard)))
 

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -267,12 +267,18 @@
                              (-> id id->new-card :id))]
                 (-> dashboard-card
                     (update :card_id new-id)
-                    (update :card update :id new-id)
-                    (update :series (fn [series]
-                                      (keep (fn [card]
-                                              (when-let [id' (new-id (:id card))]
-                                                (assoc card :id id')))
-                                            series)))))))
+                    (assoc :card (-> dashboard-card :card_id id->new-card))
+                    (m/update-existing :parameter_mappings
+                                       (fn [pms]
+                                         (map (fn [pm]
+                                                (m/update-existing pm :card_id new-id))
+                                              pms)))
+                    (m/update-existing :series
+                                       (fn [series]
+                                         (keep (fn [card]
+                                                 (when-let [id' (new-id (:id card))]
+                                                   (assoc card :id id')))
+                                               series)))))))
           ordered-cards)))
 
 (api/defendpoint POST "/:from-dashboard-id/copy"

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -16,7 +16,7 @@
             [metabase.mbql.util :as mbql.u]
             [metabase.models.action :as action]
             [metabase.models.card :refer [Card]]
-            [metabase.models.collection :as collection :refer [Collection]]
+            [metabase.models.collection :as collection]
             [metabase.models.dashboard :as dashboard :refer [Dashboard]]
             [metabase.models.dashboard-card :as dashboard-card :refer [DashboardCard]]
             [metabase.models.field :refer [Field]]

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -231,10 +231,6 @@
               (assoc m id
                      (if (:dataset card)
                        card
-                       ;; todo: `create-card!` waits up to 1.5 seconds for metadata. But presumably we have that. So:
-                       ;; we want to avoid the wait either way, and if this transaction fails we don't want the
-                       ;; asynchronous metadata saving to attempt to save metadata to a card that won't be visible (if
-                       ;; transaction hasn't completed yet) or won't exist if transaction fails
                        (api.card/create-card! (assoc card :collection_id destination-collection)))))
             {}
             id->card)))

--- a/src/metabase/models/dispatch.clj
+++ b/src/metabase/models/dispatch.clj
@@ -35,6 +35,7 @@
           (format "instance of a %s" (name model))))
 
 (p/defprotocol+ Model
+  :extend-via-metadata true ;; useful for testing. Not used in application proper
   (model [this]
     "Given either a Toucan model or a Toucan instance, return the Toucan model. Otherwise return `nil`."))
 

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -753,8 +753,8 @@
                                            (format "dashboard/%d/copy" (:id dashboard))
                                            {:name        "New dashboard"
                                             :description "A new description"
-                                            :copy-style :deep
-                                            :destination-collection (u/the-id dest-coll)})]
+                                            :is_deep_copy true
+                                            :collection_id (u/the-id dest-coll)})]
             (is (= (:collection_id resp) (u/the-id dest-coll))
                 "Dashboard should go into the destination collection")
             (is (= 3 (count (db/select 'Card :collection_id (u/the-id source-coll)))))
@@ -833,8 +833,8 @@
                                              (format "dashboard/%d/copy" (:id dashboard))
                                              {:name        "New dashboard"
                                               :description "A new description"
-                                              :copy-style :deep
-                                              :destination-collection (u/the-id dest-coll)})]
+                                              :is_deep_copy true
+                                              :collection_id (u/the-id dest-coll)})]
               (is (= (:collection_id resp) (u/the-id dest-coll))
                   "Dashboard should go into the destination collection")
               (let [copied-cards (db/select 'Card :collection_id (u/the-id dest-coll))
@@ -903,8 +903,8 @@
                                               (format "dashboard/%d/copy" (:id dashboard))
                                               {:name        "New dashboard"
                                                :description "A new description"
-                                               :copy-style :deep
-                                               :destination-collection (u/the-id source-coll)})
+                                               :is_deep_copy true
+                                               :collection_id (u/the-id source-coll)})
                   cards-in-coll (db/select 'Card :collection_id (u/the-id source-coll))]
               ;; original 3 plust 3 duplicates
               (is (= 6 (count cards-in-coll)) "Not all cards were copied")

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -26,7 +26,9 @@
                                      User]]
             [metabase.models.dashboard-card :as dashboard-card]
             [metabase.models.dashboard-test :as dashboard-test]
+            [metabase.models.dispatch :as models.dispatch]
             [metabase.models.field-values :as field-values]
+            [metabase.models.interface :as mi]
             [metabase.models.params.chain-filter-test :as chain-filter-test]
             [metabase.models.permissions :as perms]
             [metabase.models.permissions-group :as perms-group]
@@ -849,7 +851,10 @@
                          (into #{} (map :name) copied-cards))
                       "Should preserve the titles of the original cards"))
                 (testing "Should not create dashboardcardseries because the base card lacks permissions"
-                  (is (empty? (db/select DashboardCardSeries :card_id [:in (map :id copied-cards)])))))))))
+                  (is (empty? (db/select DashboardCardSeries :card_id [:in (map :id copied-cards)]))))
+                (testing "Response includes uncopied cards"
+                  (is (= #{"Total orders per month" "Average orders per month"}
+                         (->> resp :uncopied (map :name) set)))))))))
       (testing "When source and destination are the same"
         (mt/with-temp* [Collection [source-coll {:name "Source collection"}]
                         Dashboard  [dashboard {:name          "Dashboard to be Copied"
@@ -914,6 +919,47 @@
                            [total-card avg-card card])
                      (set (map :name cards-in-coll)))
                   "Cards should have \"-- Duplicate\" appended"))))))))
+
+(def ^:dynamic ^:private
+  ^{:doc "Set of ids that will report [[mi/can-write]] as true."}
+  *writable-card-ids* #{})
+
+(defmethod mi/can-write? ::dispatches-on-dynamic
+  ([fake-model]
+   (contains? *writable-card-ids* (:id fake-model)))
+  ([_fake-model id]
+   (contains? *writable-card-ids* id)))
+
+(defn- card-model
+  "Return a card \"model\" that reports as a `::dispatches-on-dynamic` model type, and checking `mi/can-write?` checks
+  if the `:id` is in the dynamic variable `*writable-card-ids*."
+  [card]
+  (with-meta card {`models.dispatch/model
+                   (fn [_] ::dispatches-on-dynamic)}))
+
+(deftest cards-to-copy-test
+  (testing "Identifies all cards to be copied"
+    (let [ordered-cards [{:card_id 1 :card (card-model {:id 1}) :series [(card-model {:id 2})]}
+                         {:card_id 3 :card (card-model{:id 3})}]]
+      (binding [*writable-card-ids* #{1 2 3}]
+        (is (= {:copy {1 {:id 1} 2 {:id 2} 3 {:id 3}}
+                :discard []}
+               (#'api.dashboard/cards-to-copy ordered-cards))))))
+  (testing "Identifies cards which cannot be copied"
+    (testing "If they are in a series"
+      (let [ordered-cards [{:card_id 1 :card (card-model {:id 1}) :series [(card-model {:id 2})]}
+                           {:card_id 3 :card (card-model{:id 3})}]]
+        (binding [*writable-card-ids* #{1 3}]
+          (is (= {:copy {1 {:id 1} 3 {:id 3}}
+                  :discard [{:id 2}]}
+                 (#'api.dashboard/cards-to-copy ordered-cards))))))
+    (testing "When the base of a series lacks permissions"
+      (let [ordered-cards [{:card_id 1 :card (card-model {:id 1}) :series [(card-model {:id 2})]}
+                           {:card_id 3 :card (card-model{:id 3})}]]
+        (binding [*writable-card-ids* #{3}]
+          (is (= {:copy {3 {:id 3}}
+                  :discard [{:id 1} {:id 2}]}
+                 (#'api.dashboard/cards-to-copy ordered-cards))))))))
 
 (deftest update-cards-for-copy-test
   (testing "When copy style is shallow returns original ordered-cards"

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -690,7 +690,78 @@
             (is (not= (:entity_id dashboard) (:entity_id response))
                 "The copy should have a new entity ID generated")
             (finally
-              (db/delete! Dashboard :id (u/the-id response)))))))))
+              (db/delete! Dashboard :id (u/the-id response))))))))
+  (testing "Deep copy: POST /api/dashboard/:id/copy"
+    (mt/dataset sample-dataset
+      (mt/with-temp* [Collection [source-coll {:name "Source collection"}]
+                      Collection [dest-coll   {:name "Destination collection"}]
+                      Dashboard [dashboard {:name        "Dashboard to be Copied"
+                                            :description "A description"
+                                            :collection_id (u/the-id source-coll)
+                                            :creator_id  (mt/user->id :rasta)}]
+                      Card      [total-card  {:name "Total orders per month"
+                                              :collection_id (u/the-id source-coll)
+                                              :display :line
+                                              :visualization_settings
+                                              {:graph.dimensions ["CREATED_AT"]
+                                               :graph.metrics ["sum"]}
+                                              :dataset_query
+                                              (mt/$ids
+                                               {:database (mt/id)
+                                                :type     :query
+                                                :query    {:source-table $$orders
+                                                           :aggregation  [[:sum $orders.total]]
+                                                           :breakout     [!month.orders.created_at]}})}]
+                      Card      [avg-card  {:name "Average orders per month"
+                                            :collection_id (u/the-id source-coll)
+                                            :display :line
+                                            :visualization_settings
+                                            {:graph.dimensions ["CREATED_AT"]
+                                             :graph.metrics ["sum"]}
+                                            :dataset_query
+                                            (mt/$ids
+                                             {:database (mt/id)
+                                              :type     :query
+                                              :query    {:source-table $$orders
+                                                         :aggregation  [[:avg $orders.total]]
+                                                         :breakout     [!month.orders.created_at]}})}]
+                      Card          [model {:name "A model"
+                                            :collection_id (u/the-id source-coll)
+                                            :dataset true
+                                            :dataset_query
+                                            (mt/$ids
+                                             {:database (mt/id)
+                                              :type :query
+                                              :query {:source-table $$orders
+                                                      :limit 4}})}]
+                      DashboardCard [dashcard {:dashboard_id (u/the-id dashboard)
+                                               :card_id    (u/the-id total-card)
+                                               :size_x 6, :size_y 6}]
+                      DashboardCard [_        {:dashboard_id (u/the-id dashboard)
+                                               :card_id    (u/the-id model)
+                                               :size_x 6, :size_y 6}]
+                      DashboardCardSeries [_ {:dashboardcard_id (u/the-id dashcard)
+                                              :card_id (u/the-id avg-card)
+                                              :position 0}]]
+        (mt/with-model-cleanup [Card Dashboard DashboardCard DashboardCardSeries]
+          (let [resp (mt/user-http-request :crowberto :post 200
+                                           (format "dashboard/%d/copy" (:id dashboard))
+                                           {:name        "New dashboard"
+                                            :description "A new description"
+                                            :copy-style :deep
+                                            :destination-collection (u/the-id dest-coll)})]
+            (is (= (:collection_id resp) (u/the-id dest-coll))
+                  "Dashboard should go into the destination collection")
+            (is (= 3 (count (db/select 'Card :collection_id (u/the-id source-coll)))))
+            (let [copied-cards (db/select 'Card :collection_id (u/the-id dest-coll))]
+              (is (= 2 (count copied-cards)))
+              (testing "Should copy cards"
+                (is (= #{"Total orders per month" "Average orders per month"}
+                       (into #{} (map :name) copied-cards))
+                    "Should preserve the titles of the original cards"))
+              (testing "Should not deep-copy models"
+                (is (every? (comp false? :dataset) copied-cards)
+                    "Copied a model")))))))))
 
 (deftest copy-dashboard-cards-test
   (testing "POST /api/dashboard/:id/copy"

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -695,23 +695,23 @@
     (mt/dataset sample-dataset
       (mt/with-temp* [Collection [source-coll {:name "Source collection"}]
                       Collection [dest-coll   {:name "Destination collection"}]
-                      Dashboard [dashboard {:name        "Dashboard to be Copied"
-                                            :description "A description"
-                                            :collection_id (u/the-id source-coll)
-                                            :creator_id  (mt/user->id :rasta)}]
-                      Card      [total-card  {:name "Total orders per month"
-                                              :collection_id (u/the-id source-coll)
-                                              :display :line
-                                              :visualization_settings
-                                              {:graph.dimensions ["CREATED_AT"]
-                                               :graph.metrics ["sum"]}
-                                              :dataset_query
-                                              (mt/$ids
-                                               {:database (mt/id)
-                                                :type     :query
-                                                :query    {:source-table $$orders
-                                                           :aggregation  [[:sum $orders.total]]
-                                                           :breakout     [!month.orders.created_at]}})}]
+                      Dashboard  [dashboard {:name          "Dashboard to be Copied"
+                                             :description   "A description"
+                                             :collection_id (u/the-id source-coll)
+                                             :creator_id    (mt/user->id :rasta)}]
+                      Card       [total-card  {:name "Total orders per month"
+                                               :collection_id (u/the-id source-coll)
+                                               :display :line
+                                               :visualization_settings
+                                               {:graph.dimensions ["CREATED_AT"]
+                                                :graph.metrics ["sum"]}
+                                               :dataset_query
+                                               (mt/$ids
+                                                {:database (mt/id)
+                                                 :type     :query
+                                                 :query    {:source-table $$orders
+                                                            :aggregation  [[:sum $orders.total]]
+                                                            :breakout     [!month.orders.created_at]}})}]
                       Card      [avg-card  {:name "Average orders per month"
                                             :collection_id (u/the-id source-coll)
                                             :display :line
@@ -737,6 +737,11 @@
                       DashboardCard [dashcard {:dashboard_id (u/the-id dashboard)
                                                :card_id    (u/the-id total-card)
                                                :size_x 6, :size_y 6}]
+                      DashboardCard [textcard {:dashboard_id (u/the-id dashboard)
+                                               :visualization_settings
+                                               {:virtual_card
+                                                {:display :text}
+                                                :text "here is some text"}}]
                       DashboardCard [_        {:dashboard_id (u/the-id dashboard)
                                                :card_id    (u/the-id model)
                                                :size_x 6, :size_y 6}]
@@ -753,8 +758,16 @@
             (is (= (:collection_id resp) (u/the-id dest-coll))
                   "Dashboard should go into the destination collection")
             (is (= 3 (count (db/select 'Card :collection_id (u/the-id source-coll)))))
-            (let [copied-cards (db/select 'Card :collection_id (u/the-id dest-coll))]
-              (is (= 2 (count copied-cards)))
+            (let [copied-cards (db/select 'Card :collection_id (u/the-id dest-coll))
+                  copied-db-cards (db/select 'DashboardCard :dashboard_id (u/the-id (:id resp)))
+                  source-db-cards (db/select 'DashboardCard :dashboard_id (u/the-id dashboard))]
+              (testing "Copies all of the questions on the dashboard"
+                (is (= 2 (count copied-cards))))
+              (testing "Copies all of the dashboard cards"
+                (is (= (count copied-db-cards) (count source-db-cards)))
+                (testing "Including text cards"
+                  (is (some (comp nil? :card_id) copied-db-cards))
+                  (is (some (comp :text :visualization_settings) copied-db-cards))))
               (testing "Should copy cards"
                 (is (= #{"Total orders per month" "Average orders per month"}
                        (into #{} (map :name) copied-cards))

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -737,11 +737,11 @@
                       DashboardCard [dashcard {:dashboard_id (u/the-id dashboard)
                                                :card_id    (u/the-id total-card)
                                                :size_x 6, :size_y 6}]
-                      DashboardCard [textcard {:dashboard_id (u/the-id dashboard)
-                                               :visualization_settings
-                                               {:virtual_card
-                                                {:display :text}
-                                                :text "here is some text"}}]
+                      DashboardCard [_textcard {:dashboard_id (u/the-id dashboard)
+                                                :text "here is some text"
+                                                :visualization_settings
+                                                {:virtual_card
+                                                 {:display :text}}}]
                       DashboardCard [_        {:dashboard_id (u/the-id dashboard)
                                                :card_id    (u/the-id model)
                                                :size_x 6, :size_y 6}]

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -914,6 +914,51 @@
                      (set (map :name cards-in-coll)))
                   "Cards should have \"-- Duplicate\" appended"))))))))
 
+(deftest update-cards-for-copy-test
+  (testing "When copy style is shallow returns original ordered-cards"
+    (let [ordered-cards [{:card_id 1 :card {:id 1} :series [{:id 2}]}
+                         {:card_id 3 :card {:id 3}}]]
+      (is (= ordered-cards
+             (api.dashboard/update-cards-for-copy ordered-cards
+                                                  "shallow"
+                                                  nil)))))
+  (testing "When copy style is deep"
+    (let [ordered-cards [{:card_id 1 :card {:id 1} :series [{:id 2} {:id 3}]}]]
+      (testing "Can omit series cards"
+        (is (= [{:card_id 5 :card {:id 5} :series [{:id 6}]}]
+               (api.dashboard/update-cards-for-copy ordered-cards
+                                                    "deep"
+                                                    {1 {:id 5}
+                                                     2 {:id 6}})))))
+    (testing "Can omit whole card with series if not copied"
+      (let [ordered-cards [{:card_id 1 :card {} :series [{:id 2} {:id 3}]}
+                           {:card_id 4 :card {} :series [{:id 5} {:id 6}]}]]
+        (is (= [{:card_id 7 :card {:id 7} :series [{:id 8} {:id 9}]}]
+               (api.dashboard/update-cards-for-copy ordered-cards
+                                                    "deep"
+                                                    {1 {:id 7}
+                                                     2 {:id 8}
+                                                     3 {:id 9}
+                                                     ;; not copying id 4 which is the base of the following two
+                                                     5 {:id 10}
+                                                     6 {:id 11}})))))
+    (testing "Updates parameter mappings to new card ids"
+      (let [ordered-cards [{:card_id 1
+                            :card {:id 1}
+                            :parameter_mappings [{:parameter_id "72d27de6",
+                                                  :card_id 1,
+                                                  :target [:dimension
+                                                           [:field 63 nil]]}]}]]
+        (is (= [{:card_id 2
+                 :card {:id 2}
+                 :parameter_mappings [{:parameter_id "72d27de6"
+                                       :card_id 2
+                                       :target [:dimension
+                                                [:field 63 nil]]}]}]
+               (api.dashboard/update-cards-for-copy ordered-cards
+                                                    "deep"
+                                                    {1 {:id 2}})))))))
+
 (deftest copy-dashboard-cards-test
   (testing "POST /api/dashboard/:id/copy"
     (testing "Ensure dashboard cards and parameters are copied (#23685)"

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -738,10 +738,10 @@
                                                :card_id    (u/the-id total-card)
                                                :size_x 6, :size_y 6}]
                       DashboardCard [_textcard {:dashboard_id (u/the-id dashboard)
-                                                :text "here is some text"
                                                 :visualization_settings
                                                 {:virtual_card
-                                                 {:display :text}}}]
+                                                 {:display :text}
+                                                 :text "here is some text"}}]
                       DashboardCard [_        {:dashboard_id (u/the-id dashboard)
                                                :card_id    (u/the-id model)
                                                :size_x 6, :size_y 6}]

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -756,7 +756,7 @@
                                             :copy-style :deep
                                             :destination-collection (u/the-id dest-coll)})]
             (is (= (:collection_id resp) (u/the-id dest-coll))
-                  "Dashboard should go into the destination collection")
+                "Dashboard should go into the destination collection")
             (is (= 3 (count (db/select 'Card :collection_id (u/the-id source-coll)))))
             (let [copied-cards (db/select 'Card :collection_id (u/the-id dest-coll))
                   copied-db-cards (db/select 'DashboardCard :dashboard_id (u/the-id (:id resp)))
@@ -774,7 +774,145 @@
                     "Should preserve the titles of the original cards"))
               (testing "Should not deep-copy models"
                 (is (every? (comp false? :dataset) copied-cards)
-                    "Copied a model")))))))))
+                    "Copied a model"))))))
+      (testing "When there are cards the user lacks write perms for"
+        (mt/with-temp* [Collection [source-coll {:name "Source collection"}]
+                        Collection [no-write-coll {:name "Crowberto lacks write coll"}]
+                        Collection [dest-coll   {:name "Destination collection"}]
+                        Dashboard  [dashboard {:name          "Dashboard to be Copied"
+                                               :description   "A description"
+                                               :collection_id (u/the-id source-coll)
+                                               :creator_id    (mt/user->id :rasta)}]
+                        Card       [total-card  {:name "Total orders per month"
+                                                 :collection_id (u/the-id no-write-coll)
+                                                 :display :line
+                                                 :visualization_settings
+                                                 {:graph.dimensions ["CREATED_AT"]
+                                                  :graph.metrics ["sum"]}
+                                                 :dataset_query
+                                                 (mt/$ids
+                                                  {:database (mt/id)
+                                                   :type     :query
+                                                   :query    {:source-table $$orders
+                                                              :aggregation  [[:sum $orders.total]]
+                                                              :breakout     [!month.orders.created_at]}})}]
+                        Card      [avg-card  {:name "Average orders per month"
+                                              :collection_id (u/the-id source-coll)
+                                              :display :line
+                                              :visualization_settings
+                                              {:graph.dimensions ["CREATED_AT"]
+                                               :graph.metrics ["sum"]}
+                                              :dataset_query
+                                              (mt/$ids
+                                               {:database (mt/id)
+                                                :type     :query
+                                                :query    {:source-table $$orders
+                                                           :aggregation  [[:avg $orders.total]]
+                                                           :breakout     [!month.orders.created_at]}})}]
+                        Card          [card {:name "A card"
+                                             :collection_id (u/the-id source-coll)
+                                             :dataset_query
+                                             (mt/$ids
+                                              {:database (mt/id)
+                                               :type :query
+                                               :query {:source-table $$orders
+                                                       :limit 4}})}]
+                        DashboardCard [dashcard {:dashboard_id (u/the-id dashboard)
+                                                 :card_id    (u/the-id total-card)
+                                                 :size_x 6, :size_y 6}]
+                        DashboardCard [_        {:dashboard_id (u/the-id dashboard)
+                                                 :card_id    (u/the-id card)
+                                                 :size_x 6, :size_y 6}]
+                        DashboardCardSeries [_ {:dashboardcard_id (u/the-id dashcard)
+                                                :card_id (u/the-id avg-card)
+                                                :position 0}]]
+          (mt/with-model-cleanup [Card Dashboard DashboardCard DashboardCardSeries]
+            (perms/revoke-collection-permissions! (perms-group/all-users) no-write-coll)
+            (perms/grant-collection-read-permissions! (perms-group/all-users) no-write-coll)
+            (let [resp (mt/user-http-request :rasta :post 200
+                                             (format "dashboard/%d/copy" (:id dashboard))
+                                             {:name        "New dashboard"
+                                              :description "A new description"
+                                              :copy-style :deep
+                                              :destination-collection (u/the-id dest-coll)})]
+              (is (= (:collection_id resp) (u/the-id dest-coll))
+                  "Dashboard should go into the destination collection")
+              (let [copied-cards (db/select 'Card :collection_id (u/the-id dest-coll))
+                    copied-db-cards (db/select 'DashboardCard :dashboard_id (u/the-id (:id resp)))]
+                (testing "Copies only one of the questions on the dashboard"
+                  (is (= 1 (count copied-cards))))
+                (testing "Copies one of the dashboard cards"
+                  (is (= 1 (count copied-db-cards))))
+                (testing "Should copy cards"
+                  (is (= #{"A card"}
+                         (into #{} (map :name) copied-cards))
+                      "Should preserve the titles of the original cards"))
+                (testing "Should not create dashboardcardseries because the base card lacks permissions"
+                  (is (empty? (db/select DashboardCardSeries :card_id [:in (map :id copied-cards)])))))))))
+      (testing "When source and destination are the same"
+        (mt/with-temp* [Collection [source-coll {:name "Source collection"}]
+                        Dashboard  [dashboard {:name          "Dashboard to be Copied"
+                                               :description   "A description"
+                                               :collection_id (u/the-id source-coll)
+                                               :creator_id    (mt/user->id :rasta)}]
+                        Card       [total-card  {:name "Total orders per month"
+                                                 :collection_id (u/the-id source-coll)
+                                                 :display :line
+                                                 :visualization_settings
+                                                 {:graph.dimensions ["CREATED_AT"]
+                                                  :graph.metrics ["sum"]}
+                                                 :dataset_query
+                                                 (mt/$ids
+                                                  {:database (mt/id)
+                                                   :type     :query
+                                                   :query    {:source-table $$orders
+                                                              :aggregation  [[:sum $orders.total]]
+                                                              :breakout     [!month.orders.created_at]}})}]
+                        Card      [avg-card  {:name "Average orders per month"
+                                              :collection_id (u/the-id source-coll)
+                                              :display :line
+                                              :visualization_settings
+                                              {:graph.dimensions ["CREATED_AT"]
+                                               :graph.metrics ["sum"]}
+                                              :dataset_query
+                                              (mt/$ids
+                                               {:database (mt/id)
+                                                :type     :query
+                                                :query    {:source-table $$orders
+                                                           :aggregation  [[:avg $orders.total]]
+                                                           :breakout     [!month.orders.created_at]}})}]
+                        Card          [card {:name "A card"
+                                             :collection_id (u/the-id source-coll)
+                                             :dataset_query
+                                             (mt/$ids
+                                              {:database (mt/id)
+                                               :type :query
+                                               :query {:source-table $$orders
+                                                       :limit 4}})}]
+                        DashboardCard [dashcard {:dashboard_id (u/the-id dashboard)
+                                                 :card_id    (u/the-id total-card)
+                                                 :size_x 6, :size_y 6}]
+                        DashboardCard [_        {:dashboard_id (u/the-id dashboard)
+                                                 :card_id    (u/the-id card)
+                                                 :size_x 6, :size_y 6}]
+                        DashboardCardSeries [_ {:dashboardcard_id (u/the-id dashcard)
+                                                :card_id (u/the-id avg-card)
+                                                :position 0}]]
+          (mt/with-model-cleanup [Card Dashboard DashboardCard DashboardCardSeries]
+            (let [_resp (mt/user-http-request :rasta :post 200
+                                              (format "dashboard/%d/copy" (:id dashboard))
+                                              {:name        "New dashboard"
+                                               :description "A new description"
+                                               :copy-style :deep
+                                               :destination-collection (u/the-id source-coll)})
+                  cards-in-coll (db/select 'Card :collection_id (u/the-id source-coll))]
+              ;; original 3 plust 3 duplicates
+              (is (= 6 (count cards-in-coll)) "Not all cards were copied")
+              (is (= (into #{} (comp (map :name)
+                                     (mapcat (fn [n] [n (str n " -- Duplicate")])))
+                           [total-card avg-card card])
+                     (set (map :name cards-in-coll)))
+                  "Cards should have \"-- Duplicate\" appended"))))))))
 
 (deftest copy-dashboard-cards-test
   (testing "POST /api/dashboard/:id/copy"


### PR DESCRIPTION
the existing copy dashboard url (dashboard/:id/copy) now takes two new arguments:

- destination-collection: a collection id to put the copies and dash
- copy-style: "deep" or "shallow" (omitting assumes prevoius behavior of "shallow"

Todo:
- [x] multi-series
- [x] text cards
- [x] validation
  - [x] destination collection exists
  - [x] user can read destination collection
- [x] reuse metadata when copying card
- [x] handle when source and destination collections are the same (append " -- Duplicate" to title)
- [x] don't copy cards if you lack ~curate~ read permissions
  - [x] don't copy series cards you _do_ have permission for if the base card lacks permissions
- [x] handle dashboard filters 
- [x] delay `card-create` event until transaction creating all cards and dashboard completes