### PR TITLE
[WIP] Conditionally use longer wait for refreshes on ExplicitSize

### DIFF
--- a/frontend/src/metabase/components/DebouncedFrame.jsx
+++ b/frontend/src/metabase/components/DebouncedFrame.jsx
@@ -105,4 +105,4 @@ class DebouncedFrame extends React.Component {
   }
 }
 
-export default ExplicitSize()(DebouncedFrame);
+export default ExplicitSize({ useLongerWaitTime: true })(DebouncedFrame);

--- a/frontend/src/metabase/components/ExplicitSize.jsx
+++ b/frontend/src/metabase/components/ExplicitSize.jsx
@@ -28,6 +28,8 @@ export default ({
     selector,
     wrapped,
     refreshMode = "throttle",
+    // In rare cases we may need extra long times
+    // between refreshes
     useLongerWaitTime = false,
   } = {}) =>
   ComposedComponent => {


### PR DESCRIPTION
Fixes #25492 

🎗️ Before submitting for review, I'll check if a tweak only in `DebouncedFrame` will fix. If so, it will be much better for the whole.

### How to Test

1. `+ New`
2. SQL Query
3. `select * from {{#...}}` and autocomplete with a model 
4. (make sure model has columns enough to cover the width of the monitor)
5. Run the query
6. Edit the query so that you delete the `{{#}}`
7. Go for the autocomplete again, but type fairly slowly `{{#`

Typing should no longer freeze

#### Notes on the solution

Some kind of race condition may have been at play between `ExplicitSize` and `DebouncedFrame`.

This may have been exacerbated by the fact that a SQL query page uses `ExplicitSize` in 5 different places, being called a lot of times.

To cope, we add a new possibility in `ExplicitSize`: to have extra large times between resize refreshes.

And we make use of it, only in `DebouncedFrame`.
