### PR TITLE
Do not allow to enter an empty relative time interval

### DIFF
--- a/frontend/src/metabase/lib/time.ts
+++ b/frontend/src/metabase/lib/time.ts
@@ -74,7 +74,7 @@ function addAbbreviatedLocale() {
   moment.locale(initialLocale);
 }
 
-export function isValidDateInterval(interval: number, unit: DurationInputArg2) {
+export function isValidTimeInterval(interval: number, unit: DurationInputArg2) {
   if (!interval) {
     return false;
   }

--- a/frontend/src/metabase/lib/time.ts
+++ b/frontend/src/metabase/lib/time.ts
@@ -74,15 +74,16 @@ function addAbbreviatedLocale() {
   moment.locale(initialLocale);
 }
 
-export function checkIfTimeSpanTooGreat(
-  amount: DurationInputArg1,
-  key: DurationInputArg2,
-) {
+export function isValidDateInterval(interval: number, unit: DurationInputArg2) {
+  if (!interval) {
+    return false;
+  }
+
   const now = moment();
-  const newTime = moment().add(amount, key);
+  const newTime = moment().add(interval, unit);
   const diff = now.diff(newTime, "years");
 
-  return Number.isNaN(diff);
+  return !Number.isNaN(diff);
 }
 
 export function formatFrame(frame: "first" | "last" | "mid") {

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RelativeDatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RelativeDatePicker.tsx
@@ -12,7 +12,7 @@ import {
   setStartingFrom,
   toTimeInterval,
 } from "metabase/lib/query_time";
-import { isValidDateInterval } from "metabase/lib/time";
+import { isValidTimeInterval } from "metabase/lib/time";
 import TippyPopover from "metabase/components/Popover/TippyPopover";
 
 import Filter from "metabase-lib/lib/queries/structured/Filter";
@@ -174,14 +174,14 @@ const RelativeDatePicker = (props: RelativeDatePickerProps) => {
   );
 
   const handleChangeDateNumericInput = (newIntervals: number) => {
-    const isValid = isValidDateInterval(newIntervals, unit);
+    const isValid = isValidTimeInterval(newIntervals, unit);
     const valueToUse = isValid ? newIntervals : Math.abs(intervals);
 
     onFilterChange(setRelativeDatetimeValue(filter, formatter(valueToUse)));
   };
 
   const handleChangeUnitInput = (newUnit: DurationInputArg2) => {
-    const isValid = isValidDateInterval(intervals, newUnit);
+    const isValid = isValidTimeInterval(intervals, newUnit);
     const unitToUse = isValid ? newUnit : unit;
 
     onFilterChange(setRelativeDatetimeUnit(filter, unitToUse));

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RelativeDatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RelativeDatePicker.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 import React from "react";
 import { t } from "ttag";
 import { assoc } from "icepick";
@@ -13,7 +12,7 @@ import {
   setStartingFrom,
   toTimeInterval,
 } from "metabase/lib/query_time";
-import { checkIfTimeSpanTooGreat, getRelativeTime } from "metabase/lib/time";
+import { isValidDateInterval } from "metabase/lib/time";
 import TippyPopover from "metabase/components/Popover/TippyPopover";
 
 import Filter from "metabase-lib/lib/queries/structured/Filter";
@@ -31,8 +30,8 @@ type RelativeDatePickerProps = {
   className?: string;
   filter: Filter;
   onFilterChange: (filter: any[]) => void;
-  formatter: (value: number) => number;
-  offsetFormatter: (value: number) => number;
+  formatter?: (value: number) => number;
+  offsetFormatter?: (value: number) => number;
   primaryColor?: string;
   reverseIconDirection?: boolean;
   supportsExpressions?: boolean;
@@ -100,14 +99,14 @@ function getCurrentIntervalName(filter: Filter) {
   return null;
 }
 
-const OptionsContent: React.FC<OptionsContentProps> = ({
+const OptionsContent = ({
   filter,
   primaryColor,
   onFilterChange,
   reverseIconDirection,
   setOptionsVisible,
   supportsExpressions,
-}) => {
+}: OptionsContentProps) => {
   const options = filter[4] || {};
   const includeCurrent = !!options["include-current"];
   const currentString = getCurrentString(filter);
@@ -152,7 +151,7 @@ const OptionsContent: React.FC<OptionsContentProps> = ({
   );
 };
 
-const RelativeDatePicker: React.FC<RelativeDatePickerProps> = props => {
+const RelativeDatePicker = (props: RelativeDatePickerProps) => {
   const {
     filter,
     onFilterChange,
@@ -175,15 +174,15 @@ const RelativeDatePicker: React.FC<RelativeDatePickerProps> = props => {
   );
 
   const handleChangeDateNumericInput = (newIntervals: number) => {
-    const timeSpanTooGreat = checkIfTimeSpanTooGreat(newIntervals, unit);
-    const valueToUse = timeSpanTooGreat ? intervals : newIntervals;
+    const isValid = isValidDateInterval(newIntervals, unit);
+    const valueToUse = isValid ? newIntervals : Math.abs(intervals);
 
     onFilterChange(setRelativeDatetimeValue(filter, formatter(valueToUse)));
   };
 
   const handleChangeUnitInput = (newUnit: DurationInputArg2) => {
-    const timeSpanTooGreat = checkIfTimeSpanTooGreat(intervals, newUnit);
-    const unitToUse = timeSpanTooGreat ? unit : newUnit;
+    const isValid = isValidDateInterval(intervals, newUnit);
+    const unitToUse = isValid ? newUnit : unit;
 
     onFilterChange(setRelativeDatetimeUnit(filter, unitToUse));
   };

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RelativeDatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RelativeDatePicker.unit.spec.tsx
@@ -16,7 +16,7 @@ describe("PastPicker", () => {
     expect(onFilterChange).toHaveBeenCalledWith(expectedFilter);
   });
 
-  it("should not allow to enter a zero time interval", () => {
+  it("should not allow to enter an empty time interval", () => {
     const filter = new Filter(["time-interval", null, -10, "month"]);
     const onFilterChange = jest.fn();
 
@@ -39,7 +39,7 @@ describe("NextPicker", () => {
     expect(onFilterChange).toHaveBeenCalledWith(expectedFilter);
   });
 
-  it("should not allow to enter a zero time interval", () => {
+  it("should not allow to enter an empty time interval", () => {
     const filter = new Filter(["time-interval", null, 10, "month"]);
     const onFilterChange = jest.fn();
 

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RelativeDatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RelativeDatePicker.unit.spec.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import Filter from "metabase-lib/lib/queries/structured/Filter";
+import { PastPicker, NextPicker } from "./RelativeDatePicker";
+
+describe("PastPicker", () => {
+  it("should change a filter", () => {
+    const filter = new Filter(["time-interval", null, -10, "month"]);
+    const onFilterChange = jest.fn();
+
+    render(<PastPicker filter={filter} onFilterChange={onFilterChange} />);
+    typeByDisplayValue("10", "20");
+
+    const expectedFilter = ["time-interval", null, -20, "month"];
+    expect(onFilterChange).toHaveBeenCalledWith(expectedFilter);
+  });
+
+  it("should not allow to enter a zero time interval", () => {
+    const filter = new Filter(["time-interval", null, -10, "month"]);
+    const onFilterChange = jest.fn();
+
+    render(<PastPicker filter={filter} onFilterChange={onFilterChange} />);
+    typeByDisplayValue("10", "0");
+
+    expect(onFilterChange).toHaveBeenCalledWith(filter);
+  });
+});
+
+describe("NextPicker", () => {
+  it("should change a filter", () => {
+    const filter = new Filter(["time-interval", null, 10, "month"]);
+    const onFilterChange = jest.fn();
+
+    render(<NextPicker filter={filter} onFilterChange={onFilterChange} />);
+    typeByDisplayValue("10", "20");
+
+    const expectedFilter = ["time-interval", null, 20, "month"];
+    expect(onFilterChange).toHaveBeenCalledWith(expectedFilter);
+  });
+
+  it("should not allow to enter a zero time interval", () => {
+    const filter = new Filter(["time-interval", null, 10, "month"]);
+    const onFilterChange = jest.fn();
+
+    render(<NextPicker filter={filter} onFilterChange={onFilterChange} />);
+    typeByDisplayValue("10", "0");
+
+    expect(onFilterChange).toHaveBeenCalledWith(filter);
+  });
+});
+
+const typeByDisplayValue = (label: string, value: string) => {
+  const input = screen.getByDisplayValue(label);
+  userEvent.clear(input);
+  userEvent.type(input, value);
+  userEvent.tab();
+};

--- a/frontend/test/metabase/lib/time.unit.spec.js
+++ b/frontend/test/metabase/lib/time.unit.spec.js
@@ -1,13 +1,13 @@
 import moment from "moment-timezone";
 import {
-  checkIfTimeSpanTooGreat,
+  getRelativeTimeAbbreviated,
+  hoursToSeconds,
+  isValidDateInterval,
+  msToHours,
+  msToMinutes,
+  msToSeconds,
   parseTime,
   parseTimestamp,
-  getRelativeTimeAbbreviated,
-  msToSeconds,
-  msToMinutes,
-  msToHours,
-  hoursToSeconds,
 } from "metabase/lib/time";
 
 describe("time", () => {
@@ -153,15 +153,17 @@ describe("time", () => {
     });
   });
 
-  describe("checkIfTimeSpanTooGreat", () => {
-    it(`returns false for small time spans`, () => {
-      const isTimeSpanTooGreat = checkIfTimeSpanTooGreat(10, "days");
-      expect(isTimeSpanTooGreat).toBeFalsy();
+  describe("isValidDateInterval", () => {
+    it(`is not valid for 0 time spans`, () => {
+      expect(isValidDateInterval(0, "days")).toBeFalsy();
     });
 
-    it(`returns truthy for large time spans`, () => {
-      const isTimeSpanTooGreat = checkIfTimeSpanTooGreat(1000000000, "years");
-      expect(isTimeSpanTooGreat).toBeTruthy();
+    it(`is valid for small time spans`, () => {
+      expect(isValidDateInterval(10, "days")).toBeTruthy();
+    });
+
+    it(`is not valid for large time spans`, () => {
+      expect(isValidDateInterval(1000000000, "years")).toBeFalsy();
     });
   });
 });

--- a/frontend/test/metabase/lib/time.unit.spec.js
+++ b/frontend/test/metabase/lib/time.unit.spec.js
@@ -154,7 +154,7 @@ describe("time", () => {
   });
 
   describe("isValidTimeInterval", () => {
-    it(`is not valid for 0 time spans`, () => {
+    it(`is not valid for 0 time span`, () => {
       expect(isValidTimeInterval(0, "days")).toBeFalsy();
     });
 

--- a/frontend/test/metabase/lib/time.unit.spec.js
+++ b/frontend/test/metabase/lib/time.unit.spec.js
@@ -2,7 +2,7 @@ import moment from "moment-timezone";
 import {
   getRelativeTimeAbbreviated,
   hoursToSeconds,
-  isValidDateInterval,
+  isValidTimeInterval,
   msToHours,
   msToMinutes,
   msToSeconds,
@@ -153,17 +153,17 @@ describe("time", () => {
     });
   });
 
-  describe("isValidDateInterval", () => {
+  describe("isValidTimeInterval", () => {
     it(`is not valid for 0 time spans`, () => {
-      expect(isValidDateInterval(0, "days")).toBeFalsy();
+      expect(isValidTimeInterval(0, "days")).toBeFalsy();
     });
 
     it(`is valid for small time spans`, () => {
-      expect(isValidDateInterval(10, "days")).toBeTruthy();
+      expect(isValidTimeInterval(10, "days")).toBeTruthy();
     });
 
     it(`is not valid for large time spans`, () => {
-      expect(isValidDateInterval(1000000000, "years")).toBeFalsy();
+      expect(isValidTimeInterval(1000000000, "years")).toBeFalsy();
     });
   });
 });


### PR DESCRIPTION
Related to https://github.com/metabase/metabase/issues/25481

Fixes the part of the issue where we allowed empty relative time intervals.

How to test:
- Open `Orders` table
- Click on `Created At` -> Filter by this column -> Relative dates
- Enter `0` instead of default `30` days
- It should revert back to the previous value
- The same should also work on the `Next` tab

<img width="391" alt="Screenshot 2022-09-21 at 15 50 40" src="https://user-images.githubusercontent.com/8542534/191508301-31c7add2-e061-44e7-a75e-76c1ef29052d.png">
