### PR TITLE
Fix data app scaffolding modal size

### DIFF
--- a/frontend/src/metabase/writeback/containers/CreateDataAppModal/CreateDataAppModal.styled.tsx
+++ b/frontend/src/metabase/writeback/containers/CreateDataAppModal/CreateDataAppModal.styled.tsx
@@ -5,7 +5,7 @@ export const ModalRoot = styled.div`
   display: flex;
   flex-direction: column;
   flex: 1 0 auto;
-  min-height: 50vh;
+  height: 60vh;
 `;
 
 export const ModalHeader = styled.div`
@@ -27,6 +27,8 @@ export const ModalBody = styled.div`
   flex: 1;
 
   padding: 0 1rem 1rem 1rem;
+
+  overflow-y: scroll;
 `;
 
 export const ModalFooter = styled.div`

--- a/frontend/src/metabase/writeback/containers/ScaffoldDataAppPagesModal/ScaffoldDataAppPagesModal.styled.tsx
+++ b/frontend/src/metabase/writeback/containers/ScaffoldDataAppPagesModal/ScaffoldDataAppPagesModal.styled.tsx
@@ -5,7 +5,7 @@ export const ModalRoot = styled.div`
   display: flex;
   flex-direction: column;
   flex: 1 0 auto;
-  min-height: 50vh;
+  height: 60vh;
 `;
 
 export const ModalHeader = styled.div`
@@ -27,6 +27,8 @@ export const ModalBody = styled.div`
   flex: 1;
 
   padding: 0 1rem 1rem 1rem;
+
+  overflow-y: scroll;
 `;
 
 export const ModalFooter = styled.div`


### PR DESCRIPTION
Fixes an issue with the data picker in scaffolding models stretch vertically and go beyond the viewport boundaries. Fixed by setting a fixed modal height and adding `overflow: scroll`

### To Verify

1. Connect a database with a few dozens of tables
2. New > App > Pick the database
3. Ensure the modal doesn't stretch and you can scroll through a list of tables
4. Launch any app > click + at the bottom of the nav sidebar > Data > Repeat step 3

### Demo

Using a database with sensitive table names, so I got them blurred

**Before**

![CleanShot 2022-09-21 at 18 10 50@2x](https://user-images.githubusercontent.com/17258145/191568920-6cf29846-bf70-444f-ad2d-856f8d368f38.png)

**After**

![after](https://user-images.githubusercontent.com/17258145/191568947-c6921e02-d640-4d83-82fc-0be564242d15.png)
