### PR TITLE
allow turning off mysql json unwrapping

### DIFF
--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -41,7 +41,10 @@
 (defmethod driver/display-name :mysql [_] "MySQL")
 
 (defmethod driver/database-supports? [:mysql :nested-field-columns] [_ _ database]
-  (or (get-in database [:details :json-unfolding]) true))
+  (let [json-setting (get-in database [:details :json-unfolding])
+        ;; If not set at all, default to true.
+        setting-nil? (nil? json-setting)]
+    (or json-setting setting-nil?)))
 
 (defmethod driver/database-supports? [:mysql :persist-models] [_driver _feat _db] true)
 

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -42,9 +42,9 @@
 
 (defmethod driver/database-supports? [:mysql :nested-field-columns] [_ _ database]
   (let [json-setting (get-in database [:details :json-unfolding])
-        ;; If not set at all, default to true.
-        setting-nil? (nil? json-setting)]
-    (or json-setting setting-nil?)))
+    (if (nil? json-setting)
+      true
+      json-setting)))
 
 (defmethod driver/database-supports? [:mysql :persist-models] [_driver _feat _db] true)
 

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -41,7 +41,7 @@
 (defmethod driver/display-name :mysql [_] "MySQL")
 
 (defmethod driver/database-supports? [:mysql :nested-field-columns] [_ _ database]
-  (let [json-setting (get-in database [:details :json-unfolding])
+  (let [json-setting (get-in database [:details :json-unfolding])]
     (if (nil? json-setting)
       true
       json-setting)))

--- a/test/metabase/driver/mysql_test.clj
+++ b/test/metabase/driver/mysql_test.clj
@@ -496,17 +496,18 @@
                          (hsql/format (sql.qp/->honeysql :mysql field-clause)))))))))))))
 
 (deftest can-shut-off-json-unwrapping
-  (try (mt/test-driver :mysql
-         ;; in here we fiddle with the mysql db details:
-         (let [db (db/select-one Database :id (mt/id))]
-           (db/update! Database (mt/id) {:details (assoc (:details db) :json-unfolding true)})
-           (is (= true (driver/database-supports? :mysql :nested-field-columns (mt/db))))
-           (db/update! Database (mt/id) {:details (assoc (:details db) :json-unfolding false)})
-           (is (= false (driver/database-supports? :mysql :nested-field-columns (mt/db))))
-           (db/update! Database (mt/id) {:details (assoc (:details db) :json-unfolding nil)})
-           (is (= true (driver/database-supports? :mysql :nested-field-columns (mt/db))))))
-       ;; un fiddle with the mysql db details.
-       (finally (db/update! Database (mt/id) :details (:details db)))))
+  (mt/test-driver :mysql
+    ;; in here we fiddle with the mysql db details
+    (let [db (db/select-one Database :id (mt/id))]
+      (try
+        (db/update! Database (mt/id) {:details (assoc (:details db) :json-unfolding true)})
+        (is (= true (driver/database-supports? :mysql :nested-field-columns (mt/db))))
+        (db/update! Database (mt/id) {:details (assoc (:details db) :json-unfolding false)})
+        (is (= false (driver/database-supports? :mysql :nested-field-columns (mt/db))))
+        (db/update! Database (mt/id) {:details (assoc (:details db) :json-unfolding nil)})
+        (is (= true (driver/database-supports? :mysql :nested-field-columns (mt/db))))
+        ;; un fiddle with the mysql db details.
+        (finally (db/update! Database (mt/id) :details (:details db)))))))
 
 (deftest ddl.execute-with-timeout-test
   (mt/test-driver :mysql
@@ -514,6 +515,6 @@
       (let [db-spec (sql-jdbc.conn/db->pooled-connection-spec (mt/db))]
         (is (thrown-with-msg?
               Exception
-              #"Killed mysql process id \d+ due to timeout."
+              #"Killed mysql process id [\d,]+ due to timeout."
               (#'mysql.ddl/execute-with-timeout! db-spec db-spec 10 ["select sleep(5)"])))
         (is (= true (#'mysql.ddl/execute-with-timeout! db-spec db-spec 5000 ["select sleep(0.1) as val"])))))))


### PR DESCRIPTION
fixes #25068

This value was set to always be true, now it will be false, iff `db.details.json-unfolding == false`