### PR TITLE
Fix user-created pages don't show up in app nav

### DIFF
--- a/frontend/src/metabase-types/api/data-app.ts
+++ b/frontend/src/metabase-types/api/data-app.ts
@@ -9,6 +9,7 @@ import { WritebackAction } from "./writeback";
 import { FormType } from "./writeback-form-settings";
 
 export type DataAppId = number;
+export type DataAppPage = Dashboard;
 export type DataAppPageId = Dashboard["id"];
 
 export interface DataAppNavItem {


### PR DESCRIPTION
Fixes an issue that after creating a new data app page, it didn't show up in the app navigation bar. The issue is that we're just using `POST /api/dashboard` to create the page and the sidebar is now relying on the app's `nav_items` to render the page tree. Fixed by adding an extra step figuring out if there are pages not present in `nav_items` and rendering them separately. We should consider creating a nav item on the BE alongside the new page though

### To Verify

1. Launch app
2. Click "+" at the bottom of the app navbar
3. Pick "Page", fill in the form, and save
4. Make sure the page appears at the app navbar

### Demo

**Before**
https://user-images.githubusercontent.com/17258145/191570389-58ee17a2-10d4-4fca-a553-9c037e7c56d0.mp4

**After**
https://user-images.githubusercontent.com/17258145/191570377-cb60b37f-e6c9-4ad5-b166-6e7456393560.mp4
