### PR TITLE
Allow disabling custom GeoJSON via env var

### DIFF
--- a/docs/configuring-metabase/environment-variables.md
+++ b/docs/configuring-metabase/environment-variables.md
@@ -202,6 +202,13 @@ Default: `"{}"`
 
 JSON object containing information about custom GeoJSON files for use in map visualizations instead of the default US State or World GeoJSON.
 
+### `MB_CUSTOM_GEOJSON_ENABLED`
+
+Type: boolean<br>
+Default: `true`
+
+Whether or not the use of custom GeoJSON is enabled.
+
 ### `MB_DB_AUTOMIGRATE`
 
 Type: boolean<br>

--- a/src/metabase/api/geojson.clj
+++ b/src/metabase/api/geojson.clj
@@ -12,6 +12,13 @@
   (:import [java.net InetAddress URL]
            org.apache.commons.io.input.ReaderInputStream))
 
+(defsetting custom-geojson-enabled
+  (deferred-tru "Is custom GeoJSON enabled?")
+  :visibility :admin
+  :type       :boolean
+  :setter     :none
+  :default    true)
+
 (def ^:private CustomGeoJSON
   {s/Keyword {:name                     su/NonBlankString
               :url                      su/NonBlankString
@@ -99,6 +106,8 @@
   file specified for `key`)."
   [{{:keys [key]} :params} respond raise]
   {key su/NonBlankString}
+  (when-not (or (custom-geojson-enabled) (builtin-geojson (keyword key)))
+    (raise (ex-info (tru "Custom GeoJSON is not enabled") {:status-code 400})))
   (if-let [url (get-in (custom-geojson) [(keyword key) :url])]
     (try
       (with-open [reader (io/reader (or (io/resource url)
@@ -116,6 +125,8 @@
   [{{:keys [url]} :params} respond raise]
   {url su/NonBlankString}
   (validation/check-has-application-permission :setting)
+  (when-not (custom-geojson-enabled)
+    (raise (ex-info (tru "Custom GeoJSON is not enabled") {:status-code 400})))
   (let [decoded-url (codec/url-decode url)]
     (try
       (when-not (valid-geojson-url? decoded-url)

--- a/src/metabase/api/geojson.clj
+++ b/src/metabase/api/geojson.clj
@@ -13,7 +13,7 @@
            org.apache.commons.io.input.ReaderInputStream))
 
 (defsetting custom-geojson-enabled
-  (deferred-tru "Is custom GeoJSON enabled?")
+  (deferred-tru "Whether or not the use of custom GeoJSON is enabled.")
   :visibility :admin
   :type       :boolean
   :setter     :none

--- a/test/metabase/api/geojson_test.clj
+++ b/test/metabase/api/geojson_test.clj
@@ -198,3 +198,14 @@
             (testing "Env var value SHOULD come back with [[setting/user-readable-values-map]] -- should be READABLE."
               (is (= expected-value
                      (get (setting/user-readable-values-map :public) :custom-geojson))))))))))
+
+(deftest disable-custom-geojson-test
+  (testing "Should be able to disable GeoJSON proxying endpoints by env var"
+    (mt/with-temporary-setting-values [custom-geojson test-custom-geojson]
+      (mt/with-temp-env-var-value [mb-custom-geojson-enabled false]
+        (testing "Should not be able to fetch GeoJSON via URL proxy endpoint"
+          (is (= "Custom GeoJSON is not enabled"
+                 (mt/user-http-request :crowberto :get 400 "geojson" :url test-geojson-url))))
+        (testing "Should not be able to fetch custom GeoJSON via key proxy endpoint"
+          (is (= "Custom GeoJSON is not enabled"
+                 (mt/user-http-request :crowberto :get 400 "geojson/middle-earth"))))))))


### PR DESCRIPTION
Pretty straightforward boolean setting to disable the GeoJSON proxying endpoints, settable only via env var.

Resolves #19189