### PR TITLE
Adding drag and drop re-ordering to graph metrics

### DIFF
--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx
@@ -18,7 +18,7 @@ const ChartSettingFieldPicker = ({
   className,
   columns,
   showColumnSetting,
-  dragHandle,
+  showDragHandle,
 }) => {
   let columnKey;
   if (value && showColumnSetting && columns) {
@@ -32,7 +32,7 @@ const ChartSettingFieldPicker = ({
       className={className}
       disabled={options.length === 1 && options[0].value === value}
     >
-      {dragHandle && (
+      {showDragHandle && (
         <SettingsIcon name="grabber2" size={12} noPointer noMargin />
       )}
       <ChartSettingSelect

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx
@@ -18,6 +18,7 @@ const ChartSettingFieldPicker = ({
   className,
   columns,
   showColumnSetting,
+  dragHandle,
 }) => {
   let columnKey;
   if (value && showColumnSetting && columns) {
@@ -27,9 +28,12 @@ const ChartSettingFieldPicker = ({
     }
   }
   return (
-    <ChartSettingFieldPickerRoot className={className}>
+    <ChartSettingFieldPickerRoot
+      className={className}
+      disabled={options.length === 1 && options[0].value === value}
+    >
+      {dragHandle && <SettingsIcon name="grabber2" size={12} noPointer />}
       <ChartSettingSelect
-        className="flex-full"
         value={value}
         options={options}
         onChange={onChange}

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx
@@ -32,7 +32,9 @@ const ChartSettingFieldPicker = ({
       className={className}
       disabled={options.length === 1 && options[0].value === value}
     >
-      {dragHandle && <SettingsIcon name="grabber2" size={12} noPointer />}
+      {dragHandle && (
+        <SettingsIcon name="grabber2" size={12} noPointer noMargin />
+      )}
       <ChartSettingSelect
         value={value}
         options={options}

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.styled.tsx
@@ -4,12 +4,18 @@ import Icon from "metabase/components/Icon";
 import SelectButton from "metabase/core/components/SelectButton";
 import Triggerable from "metabase/components/Triggerable";
 
-export const ChartSettingFieldPickerRoot = styled.div`
+interface ChartSettingFieldPickerRootProps {
+  disabled: boolean;
+}
+
+export const ChartSettingFieldPickerRoot = styled.div<ChartSettingFieldPickerRootProps>`
   display: flex;
   align-items: center;
   border: 1px solid ${color("border")};
   border-radius: 0.5rem;
   padding-right: 1rem;
+  padding-left: 0.25rem;
+  background: ${color("white")};
 
   ${Triggerable.Trigger} {
     flex: 1;
@@ -18,13 +24,15 @@ export const ChartSettingFieldPickerRoot = styled.div`
 
   ${SelectButton.Root} {
     border: none;
-    padding: 0.75rem;
+    padding: 0.75rem 0.5rem;
   }
 
   ${SelectButton.Icon} {
     margin-left: 0;
     color: ${color("text-dark")};
     height: 0.625rem;
+
+    ${props => props.disabled && "display: none;"}
   }
 
   ${SelectButton.Content} {
@@ -35,13 +43,18 @@ export const ChartSettingFieldPickerRoot = styled.div`
     max-width: 100%;
     white-space: nowrap;
     overflow: hidden;
+    color: ${color("text-dark")};
   }
 `;
 
-export const SettingsIcon = styled(Icon)`
+interface SettingsIconProps {
+  noPointer?: boolean;
+}
+
+export const SettingsIcon = styled(Icon)<SettingsIconProps>`
   margin-left: 0.5rem;
   color: ${color("text-medium")};
-  cursor: pointer;
+  cursor: ${props => (props.noPointer ? "inherit" : "pointer")};
 
   &:hover {
     color: ${color("brand")};

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.styled.tsx
@@ -45,6 +45,10 @@ export const ChartSettingFieldPickerRoot = styled.div<ChartSettingFieldPickerRoo
     overflow: hidden;
     color: ${color("text-dark")};
   }
+
+  ${SelectButton.Root} {
+    ${props => props.disabled && `background-color: ${color("white")};`}
+  }
 `;
 
 interface SettingsIconProps {

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.styled.tsx
@@ -14,7 +14,7 @@ export const ChartSettingFieldPickerRoot = styled.div<ChartSettingFieldPickerRoo
   border: 1px solid ${color("border")};
   border-radius: 0.5rem;
   padding-right: 1rem;
-  padding-left: 0.25rem;
+  padding-left: 0.5rem;
   background: ${color("white")};
 
   ${Triggerable.Trigger} {
@@ -49,10 +49,11 @@ export const ChartSettingFieldPickerRoot = styled.div<ChartSettingFieldPickerRoo
 
 interface SettingsIconProps {
   noPointer?: boolean;
+  noMargin?: boolean;
 }
 
 export const SettingsIcon = styled(Icon)<SettingsIconProps>`
-  margin-left: 0.5rem;
+  margin-left: ${props => (props.noMargin ? "0" : "0.75rem")};
   color: ${color("text-medium")};
   cursor: ${props => (props.noPointer ? "inherit" : "pointer")};
 

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx
@@ -36,9 +36,12 @@ const ChartSettingFieldsPicker = ({
             {provided => (
               <div {...provided.droppableProps} ref={provided.innerRef}>
                 {value.map((v, index) => {
-                  console.log(v);
                   return (
-                    <Draggable key={v} draggableId={v} index={index}>
+                    <Draggable
+                      key={`draggable-${v}`}
+                      draggableId={`draggable-${v}`}
+                      index={index}
+                    >
                       {provided => (
                         <div
                           ref={provided.innerRef}

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/prop-types */
 import React from "react";
 import { t } from "ttag";
+import { DragDropContext, Droppable, Draggable } from "react-beautiful-dnd";
 import ChartSettingFieldPicker from "./ChartSettingFieldPicker";
 import { AddAnotherContainer } from "./ChartSettingFieldsPicker.styled";
 
@@ -10,62 +11,103 @@ const ChartSettingFieldsPicker = ({
   onChange,
   addAnother,
   ...props
-}) => (
-  <div>
-    {Array.isArray(value) ? (
-      value.map((v, index) => (
-        <ChartSettingFieldPicker
-          {...props}
-          className={index > 0 ? "mt1" : null}
-          key={index}
-          value={v}
-          options={options}
-          onChange={v => {
-            const newValue = [...value];
-            // this swaps the position of the existing value
-            const existingIndex = value.indexOf(v);
-            if (existingIndex >= 0) {
-              newValue.splice(existingIndex, 1, value[index]);
-            }
-            // replace with the new value
-            newValue.splice(index, 1, v);
-            onChange(newValue);
-          }}
-          onRemove={
-            value.filter(v => v != null).length > 1 ||
-            (value.length > 1 && v == null)
-              ? () =>
-                  onChange([
-                    ...value.slice(0, index),
-                    ...value.slice(index + 1),
-                  ])
-              : null
-          }
-        />
-      ))
-    ) : (
-      <span className="text-error">{t`error`}</span>
-    )}
-    {addAnother && (
-      <AddAnotherContainer>
-        <a
-          className="text-brand text-bold py1"
-          onClick={() => {
-            const remaining = options.filter(o => value.indexOf(o.value) < 0);
-            if (remaining.length === 1) {
-              // if there's only one unused option, use it
-              onChange(value.concat([remaining[0].value]));
-            } else {
-              // otherwise leave it blank
-              onChange(value.concat([undefined]));
-            }
-          }}
-        >
-          {addAnother}
-        </a>
-      </AddAnotherContainer>
-    )}
-  </div>
-);
+}) => {
+  const handleDragEnd = ({ source, destination }) => {
+    const oldIndex = source.index,
+      newIndex = destination.index;
+
+    const valueCopy = [...value];
+    valueCopy.splice(newIndex, 0, valueCopy.splice(oldIndex, 1)[0]);
+    onChange(valueCopy);
+  };
+
+  const calculateOptions = item => {
+    return options.filter(
+      option =>
+        value.findIndex(v => v === option.value) < 0 || option.value === item,
+    );
+  };
+
+  return (
+    <div>
+      {Array.isArray(value) ? (
+        <DragDropContext onDragEnd={handleDragEnd}>
+          <Droppable droppableId="droppable">
+            {provided => (
+              <div {...provided.droppableProps} ref={provided.innerRef}>
+                {value.map((v, index) => {
+                  console.log(v);
+                  return (
+                    <Draggable key={v} draggableId={v} index={index}>
+                      {provided => (
+                        <div
+                          ref={provided.innerRef}
+                          {...provided.draggableProps}
+                          {...provided.dragHandleProps}
+                          className="mb1"
+                        >
+                          <ChartSettingFieldPicker
+                            {...props}
+                            key={index}
+                            value={v}
+                            options={calculateOptions(v)}
+                            onChange={v => {
+                              const newValue = [...value];
+                              // this swaps the position of the existing value
+                              const existingIndex = value.indexOf(v);
+                              if (existingIndex >= 0) {
+                                newValue.splice(existingIndex, 1, value[index]);
+                              }
+                              // replace with the new value
+                              newValue.splice(index, 1, v);
+                              onChange(newValue);
+                            }}
+                            onRemove={
+                              value.filter(v => v != null).length > 1 ||
+                              (value.length > 1 && v == null)
+                                ? () =>
+                                    onChange([
+                                      ...value.slice(0, index),
+                                      ...value.slice(index + 1),
+                                    ])
+                                : null
+                            }
+                            dragHandle={value.length > 1}
+                          />
+                        </div>
+                      )}
+                    </Draggable>
+                  );
+                })}
+                {provided.placeholder}
+              </div>
+            )}
+          </Droppable>
+        </DragDropContext>
+      ) : (
+        <span className="text-error">{t`error`}</span>
+      )}
+      {addAnother && (
+        <AddAnotherContainer>
+          <a
+            className="text-brand text-bold py1"
+            onClick={() => {
+              const remaining = options.filter(o => value.indexOf(o.value) < 0);
+              if (remaining.length === 1) {
+                // if there's only one unused option, use it
+                onChange(value.concat([remaining[0].value]));
+              } else {
+                // otherwise leave it blank
+                onChange(value.concat([undefined]));
+              }
+            }}
+          >
+            {addAnother}
+          </a>
+        </AddAnotherContainer>
+      )}
+    </div>
+  );
+};
 
 export default ChartSettingFieldsPicker;

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.styled.tsx
@@ -5,5 +5,4 @@ export const AddAnotherContainer = styled.div`
   margin-top: 1rem;
   margin-bottom: 1rem;
   padding-bottom: 1rem;
-  border-bottom: 1px solid ${color("border")};
 `;

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedSimple.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedSimple.styled.tsx
@@ -4,7 +4,6 @@ import { color } from "metabase/lib/colors";
 export const ChartSettingOrderedSimpleRoot = styled.div`
   padding-left: 1rem;
   padding-bottom: 0.5rem;
-  border-bottom: 1px solid ${color("border")};
 `;
 
 export const ChartSettingMessage = styled.div`

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingSelect.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingSelect.jsx
@@ -17,11 +17,11 @@ const ChartSettingSelect = ({
   ...props
 }) => (
   <Select
-    className={cx(className, "block", {
-      disabled:
-        options.length === 0 ||
-        (options.length === 1 && options[0].value === value),
-    })}
+    className={cx(className, "block")}
+    disabled={
+      options.length === 0 ||
+      (options.length === 1 && options[0].value === value)
+    }
     value={value}
     onChange={e => onChange(e.target.value)}
     placeholder={options.length === 0 ? placeholderNoOptions : placeholder}

--- a/frontend/src/metabase/visualizations/components/settings/ColumnItem.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ColumnItem.styled.tsx
@@ -54,7 +54,7 @@ export const ColumnItemContent = styled.div`
 `;
 
 export const ColumnItemContainer = styled.div`
-  padding: 0.5rem;
+  padding: 0.75rem 0.5rem;
   position: relative;
   flex: auto;
   display: flex;

--- a/frontend/src/metabase/visualizations/lib/settings.js
+++ b/frontend/src/metabase/visualizations/lib/settings.js
@@ -122,6 +122,7 @@ function getSettingWidget(
   extra = {},
 ) {
   const settingDef = settingDefs[settingId];
+  console.log(settingDef);
   const value = computedSettings[settingId];
   const onChange = value => {
     const newSettings = { [settingId]: value };
@@ -143,6 +144,9 @@ function getSettingWidget(
     hidden: settingDef.getHidden
       ? settingDef.getHidden(object, computedSettings, extra)
       : settingDef.hidden || false,
+    marginBottom: settingDef.getMarginBottom
+      ? settingDef.getMarginBottom(object, computedSettings, extra)
+      : settingDef.marginBottom,
     disabled: settingDef.getDisabled
       ? settingDef.getDisabled(object, computedSettings, extra)
       : settingDef.disabled || false,

--- a/frontend/src/metabase/visualizations/lib/settings.js
+++ b/frontend/src/metabase/visualizations/lib/settings.js
@@ -122,7 +122,6 @@ function getSettingWidget(
   extra = {},
 ) {
   const settingDef = settingDefs[settingId];
-  console.log(settingDef);
   const value = computedSettings[settingId];
   const onChange = value => {
     const newSettings = { [settingId]: value };

--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -96,6 +96,10 @@ export const GRAPH_DATA_SETTINGS = {
     section: t`Data`,
     title: t`X-axis`,
     widget: "fields",
+    getMarginBottom: (series, vizSettings) =>
+      vizSettings["graph.dimensions"]?.length === 2 && series.length <= 20
+        ? 8
+        : 16,
     isValid: (series, vizSettings) =>
       series.some(
         ({ card, data }) =>
@@ -210,7 +214,7 @@ export const GRAPH_DATA_SETTINGS = {
 
       return {
         options,
-        addAnother: canAddAnother ? t`Add another series...` : null,
+        addAnother: canAddAnother ? t`Add another series` : null,
         columns: data.cols,
         showColumnSetting: true,
       };

--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -212,8 +212,7 @@ export const GRAPH_DATA_SETTINGS = {
         addedMetricsCount < maxMetricsSupportedCount &&
         hasMetricsToAdd &&
         !hasBreakout &&
-        addedMetrics.filter(metric => metric === null || metric === undefined)
-          .length === 0;
+        addedMetrics.every(metric => metric != null);
 
       return {
         options,

--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -98,8 +98,8 @@ export const GRAPH_DATA_SETTINGS = {
     widget: "fields",
     getMarginBottom: (series, vizSettings) =>
       vizSettings["graph.dimensions"]?.length === 2 && series.length <= 20
-        ? 8
-        : 16,
+        ? "0.5rem"
+        : "1rem",
     isValid: (series, vizSettings) =>
       series.some(
         ({ card, data }) =>
@@ -202,15 +202,18 @@ export const GRAPH_DATA_SETTINGS = {
         .filter(vizSettings["graph._metric_filter"])
         .map(getOptionFromColumn);
 
+      const addedMetrics = vizSettings["graph.metrics"];
       const hasBreakout = vizSettings["graph.dimensions"].length > 1;
-      const addedMetricsCount = vizSettings["graph.metrics"].length;
+      const addedMetricsCount = addedMetrics.length;
       const maxMetricsSupportedCount = getMaxMetricsSupported(card.display);
 
       const hasMetricsToAdd = options.length > addedMetricsCount;
       const canAddAnother =
         addedMetricsCount < maxMetricsSupportedCount &&
         hasMetricsToAdd &&
-        !hasBreakout;
+        !hasBreakout &&
+        addedMetrics.filter(metric => metric === null || metric === undefined)
+          .length === 0;
 
       return {
         options,

--- a/frontend/src/metabase/visualizations/lib/utils.js
+++ b/frontend/src/metabase/visualizations/lib/utils.js
@@ -390,3 +390,9 @@ export const preserveExistingColumnsOrder = (prevColumns, newColumns) => {
 
   return mergedColumnsResult;
 };
+
+export const moveElement = (array, oldIndex, newIndex) => {
+  const arrayCopy = [...array];
+  arrayCopy.splice(newIndex, 0, arrayCopy.splice(oldIndex, 1)[0]);
+  return arrayCopy;
+};

--- a/frontend/test/metabase/scenarios/visualizations/reproductions/11249-add-more-series-no-columns.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/reproductions/11249-add-more-series-no-columns.cy.spec.js
@@ -36,9 +36,9 @@ describe("issue 11249", () => {
       cy.findByText("Data").click();
       cy.findByText("Count").should("not.exist");
 
-      cy.findByText("Add another series...").click();
+      cy.findByText("Add another series").click();
       cy.findByText("Count").should("be.visible");
-      cy.findByText("Add another series...").should("not.exist");
+      cy.findByText("Add another series").should("not.exist");
     });
   });
 });

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "react": "~16.14.0",
     "react-ace": "^9.5.0",
     "react-ansi-style": "^1.0.0",
+    "react-beautiful-dnd": "^13.1.1",
     "react-collapse": "^4.0.3",
     "react-color": "^2.14.1",
     "react-copy-to-clipboard": "^5.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2342,6 +2342,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.15.4", "@babel/runtime@^7.9.2":
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.19.0.tgz#22b11c037b094d27a8a2504ea4dcff00f50e2259"
+  integrity sha512-eR8Lo9hnDS7tqkO7NsV+mKvCmv5boaXFSZ70DnfhcgiEne8hv9oCEd36Klw74EtizEqLsy4YnW8UWwpBVolHZA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.2.0":
   version "7.13.7"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.7.tgz#d494e39d198ee9ca04f4dcb76d25d9d7a1dc961a"
@@ -4819,6 +4826,14 @@
   resolved "https://registry.yarnpkg.com/@types/history/-/history-2.0.51.tgz#fbeb15d5d87592b21d92da23347361f151d507ec"
   integrity sha512-B5YRwLxbpFlmiKcOYsvNIcFT0GYNIGsYC1lLFqoiUeHdTzfGjz1NABo//FuPc/fQAdpGdq4pPSug/9eayOi1yg==
 
+"@types/hoist-non-react-statics@^3.3.0":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
+  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+
 "@types/html-minifier-terser@^5.0.0":
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/@types/html-minifier-terser/-/html-minifier-terser-5.1.1.tgz#3c9ee980f1a10d6021ae6632ca3e79ca2ec4fb50"
@@ -5191,6 +5206,16 @@
   dependencies:
     "@types/react" "*"
     redux "^3.6.0"
+
+"@types/react-redux@^7.1.20":
+  version "7.1.24"
+  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.1.24.tgz#6caaff1603aba17b27d20f8ad073e4c077e975c0"
+  integrity sha512-7FkurKcS1k0FHZEtdbbgN8Oc6b+stGSfZYjQGicofJ0j4U0qIn/jaSvnP2pLwZKiai3/17xqqxkkrxTgN8UNbQ==
+  dependencies:
+    "@types/hoist-non-react-statics" "^3.3.0"
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+    redux "^4.0.0"
 
 "@types/react-resizable@^1.7.4":
   version "1.7.4"
@@ -8793,6 +8818,13 @@ css-blank-pseudo@^0.1.4:
   integrity sha512-LHz35Hr83dnFeipc7oqFDmsjHdljj3TQtxGGiNWSOsTLIAubSm4TEz8qCaKFpk7idaQ1GfWscF4E6mgpBysA1w==
   dependencies:
     postcss "^7.0.5"
+
+css-box-model@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/css-box-model/-/css-box-model-1.2.1.tgz#59951d3b81fd6b2074a62d49444415b0d2b4d7c1"
+  integrity sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==
+  dependencies:
+    tiny-invariant "^1.0.6"
 
 css-color-keywords@^1.0.0:
   version "1.0.0"
@@ -15168,6 +15200,11 @@ memfs@^3.4.1:
   dependencies:
     fs-monkey "1.0.3"
 
+memoize-one@^5.1.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.2.1.tgz#8337aa3c4335581839ec01c3d594090cebe8f00e"
+  integrity sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==
+
 memoizerific@^1.11.3:
   version "1.11.3"
   resolved "https://registry.yarnpkg.com/memoizerific/-/memoizerific-1.11.3.tgz#7c87a4646444c32d75438570905f2dbd1b1a805a"
@@ -17991,6 +18028,11 @@ quick-lru@^4.0.1:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-4.0.1.tgz#5b8878f113a58217848c6482026c73e1ba57727f"
   integrity sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==
 
+raf-schd@^4.0.2:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/raf-schd/-/raf-schd-4.0.3.tgz#5d6c34ef46f8b2a0e880a8fcdb743efc5bfdbc1a"
+  integrity sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==
+
 raf@^3.1.0, raf@^3.4.0:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
@@ -18082,6 +18124,19 @@ react-ansi-style@^1.0.0:
   dependencies:
     ansi-style-parser "^1.0.1"
     js-managed-css "^1.4.1"
+
+react-beautiful-dnd@^13.1.1:
+  version "13.1.1"
+  resolved "https://registry.yarnpkg.com/react-beautiful-dnd/-/react-beautiful-dnd-13.1.1.tgz#b0f3087a5840920abf8bb2325f1ffa46d8c4d0a2"
+  integrity sha512-0Lvs4tq2VcrEjEgDXHjT98r+63drkKEgqyxdA7qD3mvKwga6a5SscbdLPO2IExotU1jW8L0Ksdl0Cj2AF67nPQ==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+    css-box-model "^1.2.0"
+    memoize-one "^5.1.1"
+    raf-schd "^4.0.2"
+    react-redux "^7.2.0"
+    redux "^4.0.4"
+    use-memo-one "^1.1.1"
 
 react-collapse@^4.0.3:
   version "4.0.3"
@@ -18342,6 +18397,18 @@ react-redux@^5.0.4:
     prop-types "^15.6.1"
     react-is "^16.6.0"
     react-lifecycles-compat "^3.0.0"
+
+react-redux@^7.2.0:
+  version "7.2.8"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.2.8.tgz#a894068315e65de5b1b68899f9c6ee0923dd28de"
+  integrity sha512-6+uDjhs3PSIclqoCk0kd6iX74gzrGc3W5zcAjbrFgEdIjRSQObdIwfx80unTkVUYvbQ95Y8Av3OvFHq1w5EOUw==
+  dependencies:
+    "@babel/runtime" "^7.15.4"
+    "@types/react-redux" "^7.1.20"
+    hoist-non-react-statics "^3.3.2"
+    loose-envify "^1.4.0"
+    prop-types "^15.7.2"
+    react-is "^17.0.2"
 
 react-refresh@^0.11.0:
   version "0.11.0"
@@ -18743,6 +18810,13 @@ redux@^3.5.2, redux@^3.6.0, redux@^3.7.2:
     lodash-es "^4.2.1"
     loose-envify "^1.1.0"
     symbol-observable "^1.0.3"
+
+redux@^4.0.4:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.2.0.tgz#46f10d6e29b6666df758780437651eeb2b969f13"
+  integrity sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
 
 refractor@^3.1.0:
   version "3.5.0"
@@ -20723,6 +20797,11 @@ timers-browserify@^2.0.4:
   dependencies:
     setimmediate "^1.0.4"
 
+tiny-invariant@^1.0.6:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.2.0.tgz#a1141f86b672a9148c72e978a19a73b9b94a15a9"
+  integrity sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg==
+
 tiny-lr@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/tiny-lr/-/tiny-lr-1.1.1.tgz#9fa547412f238fedb068ee295af8b682c98b2aab"
@@ -21406,6 +21485,11 @@ use-latest@^1.0.0:
   integrity sha512-d2TEuG6nSLKQLAfW3By8mKr8HurOlTkul0sOpxbClIv4SQ4iOd7BYr7VIzdbktUCnv7dua/60xzd8igMU6jmyw==
   dependencies:
     use-isomorphic-layout-effect "^1.0.0"
+
+use-memo-one@^1.1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/use-memo-one/-/use-memo-one-1.1.3.tgz#2fd2e43a2169eabc7496960ace8c79efef975e99"
+  integrity sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ==
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
EPIC #24840 

PR to allow drag and drop re-ordering of X and Y axis fields on Line / Area / Bar charts, as well as some small border and margin adjustments in certain scenarios.

## How to Test
- New -> Question -> Orders
- Summarize a few columns. I did: "Average of Total", "Average of Tax", "Count", "Min of Total", "Max of Total"
- Group by a few columns. I did: "User -> Source", "Product -> Category", "Created At: Year".
- Settings -> Data.

You should be able to re-order fields as you see fit.
![chrome_UL3YDB6YFX](https://user-images.githubusercontent.com/1328979/191589598-3cd790f9-b023-4c85-967a-66f5ca7f637e.gif)

A few things to watch for:
- If you add all possible Summaries, The fields should no longer have a `down_chevron` or be clickable. This appies to both X and Y axis options.
- Field options should only show the currently selected option, and options that are not currently in the graph.

