### PR TITLE
Don't run query when entering model edit mode & show the correct data source for model

### DIFF
--- a/frontend/src/metabase/query_builder/actions/core/updateQuestion.ts
+++ b/frontend/src/metabase/query_builder/actions/core/updateQuestion.ts
@@ -144,6 +144,13 @@ export const updateQuestion = (
       }
     }
 
+    // This scenario happens because the DatasetQueryEditor converts the dataset/model question into a normal question
+    // so that its query is shown properly in the notebook editor. Various child components of the notebook editor have access to
+    // this `updateQuestion` action, so they end up triggering the action with the altered question.
+    if (queryBuilderMode === "dataset" && !newQuestion.isDataset()) {
+      newQuestion = newQuestion.setDataset(true);
+    }
+
     const queryResult = getFirstQueryResult(getState());
     newQuestion = newQuestion.syncColumnsAndSettings(
       currentQuestion,

--- a/frontend/src/metabase/query_builder/actions/core/updateQuestion.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/actions/core/updateQuestion.unit.spec.ts
@@ -524,6 +524,15 @@ describe("QB Actions > updateQuestion", () => {
             }),
           );
         });
+
+        it("converts the question into a model if the query builder is in 'dataset' mode", async () => {
+          const { result } = await setup({
+            question,
+            queryBuilderMode: "dataset",
+          });
+
+          expect(result.card.dataset).toBe(true);
+        });
       });
     });
   });

--- a/frontend/src/metabase/query_builder/actions/ui.js
+++ b/frontend/src/metabase/query_builder/actions/ui.js
@@ -5,7 +5,7 @@ import * as MetabaseAnalytics from "metabase/lib/analytics";
 import { createThunkAction } from "metabase/lib/redux";
 import { UserApi } from "metabase/services";
 
-import { runQuestionQuery, cancelQuery } from "./querying";
+import { cancelQuery } from "./querying";
 import { updateUrl } from "./navigation";
 
 export const SET_UI_CONTROLS = "metabase/qb/SET_UI_CONTROLS";
@@ -32,9 +32,6 @@ export const setQueryBuilderMode =
     }
     if (queryBuilderMode === "notebook") {
       dispatch(cancelQuery());
-    }
-    if (queryBuilderMode === "dataset") {
-      dispatch(runQuestionQuery());
     }
   };
 

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
@@ -172,28 +172,14 @@ function DatasetEditor(props) {
     isMetadataDirty,
     height,
     isDirty: isModelQueryDirty,
-    isRunning,
     setQueryBuilderMode,
     setDatasetEditorTab,
     setFieldMetadata,
     onCancelDatasetChanges,
     onSave,
     handleResize,
-    runQuestionQuery,
     onOpenModal,
   } = props;
-
-  // It's important to reload the query to refresh metadata when coming from the model page
-  // On the model page, results metadata has a shape assuming you're building a nested question
-  // E.g. expression field refs are field literals ["field", "my_formula", ...] instead of ["expression", "my_formula"]
-  // Doing a reload will ensure the editor uses the correct metadata
-  useEffect(() => {
-    if (!isRunning) {
-      runQuestionQuery();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
   const orderedColumns = useMemo(
     () => dataset.setting("table.columns"),
     [dataset],

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetQueryEditor.jsx
@@ -17,7 +17,18 @@ const propTypes = {
   height: PropTypes.number.isRequired,
 };
 
-function DatasetQueryEditor({ question: dataset, isActive, height, ...props }) {
+function DatasetQueryEditor({
+  // See below, where we convert the dataset/model question back into a "normal" question
+  // so that we can do question-y things and not dataset-y things within the Notebook editor
+  question: dataset_DO_NOT_USE,
+  isActive,
+  height,
+  ...props
+}) {
+  // Datasets/models by default behave like they are already nested,
+  // so we need to edit the dataset/model question like it is a normal question
+  const question = dataset_DO_NOT_USE.lockDisplay().setDataset(false);
+
   const [isResizing, setResizing] = useState(false);
 
   const resizableBoxProps = useMemo(() => {
@@ -53,10 +64,10 @@ function DatasetQueryEditor({ question: dataset, isActive, height, ...props }) {
 
   return (
     <QueryEditorContainer isActive={isActive}>
-      {dataset.isNative() ? (
+      {question.isNative() ? (
         <NativeQueryEditor
           {...props}
-          question={dataset}
+          question={question}
           isInitiallyOpen
           hasTopBar={isActive}
           hasEditingSidebar={isActive}
@@ -71,7 +82,7 @@ function DatasetQueryEditor({ question: dataset, isActive, height, ...props }) {
       ) : (
         <ResizableNotebook
           {...props}
-          question={dataset}
+          question={question}
           isResizing={isResizing}
           resizableBoxProps={resizableBoxProps}
         />

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetQueryEditor.jsx
@@ -27,7 +27,7 @@ function DatasetQueryEditor({
 }) {
   // Datasets/models by default behave like they are already nested,
   // so we need to edit the dataset/model question like it is a normal question
-  const question = dataset_DO_NOT_USE.lockDisplay().setDataset(false);
+  const question = dataset_DO_NOT_USE.setDataset(false);
 
   const [isResizing, setResizing] = useState(false);
 

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -378,7 +378,7 @@ function areQueriesEqual(queryA, queryB, tableMetadata) {
   return _.isEqual(normalizedQueryA, normalizedQueryB);
 }
 
-function areDatasetsEquivalent({
+function areModelsEquivalent({
   originalQuestion,
   lastRunQuestion,
   currentQuestion,
@@ -417,7 +417,7 @@ function areQueriesEquivalent({
   tableMetadata,
 }) {
   return (
-    areDatasetsEquivalent({
+    areModelsEquivalent({
       originalQuestion,
       lastRunQuestion,
       currentQuestion,

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -313,6 +313,9 @@ export const getQuestion = createSelector(
     const question = new Question(card, metadata, parameterValues);
 
     const isEditingModel = queryBuilderMode === "dataset";
+    if (isEditingModel) {
+      return question.lockDisplay();
+    }
 
     // When opening a model, we swap it's `dataset_query`
     // with clean query using the model as a source table,

--- a/frontend/test/metabase/query_builder/selectors.unit.spec.js
+++ b/frontend/test/metabase/query_builder/selectors.unit.spec.js
@@ -105,6 +105,7 @@ describe("getQuestion", () => {
 
     expect(question.card()).toEqual({
       ...card,
+      displayIsLocked: true,
     });
   });
 });

--- a/frontend/test/metabase/query_builder/selectors.unit.spec.js
+++ b/frontend/test/metabase/query_builder/selectors.unit.spec.js
@@ -105,7 +105,6 @@ describe("getQuestion", () => {
 
     expect(question.card()).toEqual({
       ...card,
-      displayIsLocked: true,
     });
   });
 });

--- a/frontend/test/metabase/query_builder/selectors.unit.spec.js
+++ b/frontend/test/metabase/query_builder/selectors.unit.spec.js
@@ -111,7 +111,7 @@ describe("getQuestion", () => {
 });
 
 describe("getIsResultDirty", () => {
-  describe("structure query", () => {
+  describe("structured query", () => {
     function getCard(query) {
       return getBaseCard({ dataset_query: { type: "query", query } });
     }
@@ -328,6 +328,16 @@ describe("getIsResultDirty", () => {
         lastRunCard: dataset,
       });
       expect(getIsResultDirty(state)).toBe(true);
+    });
+
+    it("should not be dirty when the last run question is the composed model and the current question is equivalent to the original", () => {
+      const adHocDatasetCard = getDataset({ "source-table": "card__1" });
+      const state = getState({
+        card: dataset,
+        originalCard: dataset,
+        lastRunCard: adHocDatasetCard,
+      });
+      expect(getIsResultDirty(state)).toBe(false);
     });
   });
 });

--- a/frontend/test/metabase/scenarios/models/models-metadata.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models-metadata.cy.spec.js
@@ -50,7 +50,6 @@ describe("scenarios > models metadata", () => {
 
     cy.findByText("Edit metadata").click();
 
-    cy.wait(["@cardQuery", "@cardQuery"]);
     cy.url().should("include", "/metadata");
     cy.findByTextEnsureVisible("Product ID");
 
@@ -93,7 +92,6 @@ describe("scenarios > models metadata", () => {
 
     cy.findByText("Edit metadata").click();
 
-    cy.wait(["@cardQuery", "@cardQuery"]);
     cy.url().should("include", "/metadata");
     cy.findByTextEnsureVisible("PRODUCT_ID");
 
@@ -141,7 +139,6 @@ describe("scenarios > models metadata", () => {
     openQuestionActions();
     cy.findByText("Edit metadata").click();
 
-    cy.wait(["@cardQuery", "@cardQuery"]);
     cy.findByTextEnsureVisible("TAX");
 
     // Revision 2
@@ -292,7 +289,6 @@ describe("scenarios > models metadata", () => {
       openQuestionActions();
       cy.findByText("Vendor").should("not.exist");
       cy.findByText("Edit metadata").click();
-      cy.wait(["@cardQuery", "@cardQuery"]);
       cy.findByText("Vendor").should("be.visible");
     });
   });

--- a/frontend/test/metabase/scenarios/models/models-query-editor.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models-query-editor.cy.spec.js
@@ -114,8 +114,6 @@ describe("scenarios > models query editor", () => {
     });
 
     it("handles failing queries", () => {
-      cy.intercept("POST", "/api/card/*/query").as("cardQuery");
-
       cy.createNativeQuestion(
         {
           name: "Erroring Model",
@@ -134,12 +132,10 @@ describe("scenarios > models query editor", () => {
         cy.findByText("Edit metadata").click();
       });
 
-      cy.wait("@cardQuery");
       cy.findByText(/Syntax error in SQL/).should("be.visible");
 
       cy.findByText("Query").click();
 
-      cy.wait("@cardQuery");
       cy.findByText(/Syntax error in SQL/).should("be.visible");
 
       cy.get(".ace_content").type("1");

--- a/frontend/test/metabase/scenarios/models/models-query-editor.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models-query-editor.cy.spec.js
@@ -19,7 +19,10 @@ describe("scenarios > models query editor", () => {
 
   describe("GUI models", () => {
     beforeEach(() => {
-      cy.request("PUT", "/api/card/1", { dataset: true });
+      cy.request("PUT", "/api/card/1", {
+        name: "Orders Model",
+        dataset: true,
+      });
     });
 
     it("allows to edit GUI model query", () => {
@@ -34,6 +37,7 @@ describe("scenarios > models query editor", () => {
         cy.findByText("Edit query definition").click();
       });
 
+      cy.findByTestId("data-step-cell").contains("Orders");
       cy.button("Save changes").should("be.disabled");
 
       cy.findByText("Row limit").click();

--- a/frontend/test/metabase/scenarios/models/reproductions/22517-add-remove-column-drops-metadata.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/reproductions/22517-add-remove-column-drops-metadata.cy.spec.js
@@ -20,8 +20,6 @@ describe("issue 22517", () => {
     openQuestionActions();
     cy.findByText("Edit metadata").click();
 
-    cy.wait(["@cardQuery", "@cardQuery"]);
-
     renameColumn("ID", "Foo");
 
     cy.button("Save changes").click();
@@ -31,7 +29,6 @@ describe("issue 22517", () => {
   it("adding or removging a column should not drop previously edited metadata (metabase#22517)", () => {
     openQuestionActions();
     cy.findByText("Edit query definition").click();
-    cy.wait(["@cardQuery", "@cardQuery"]);
 
     // Make sure previous metadata changes are reflected in the UI
     cy.findByText("Foo");


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/25458
Fixes #24821 

- I've removed two extraneous query calls that happen when entering model "edit" mode. I don't think we need these now that we have better access to model metadata.
- The lack of new query runs makes `getIsResultDirty` return true in a scenario where we want it to return false, so I've refactored the selector and added new code to handle the scenario.
  - The last run question is the ad hoc model query, but after we enter "edit" mode the QB's `question` is reverted back to its original form, so the equality check on last run query vs next run query was failing even though the queries are equivalent and should not be considered "dirty"
- I've included a fix for #25458 because it was messing with my ability to test changes related to `getIsResultDirty`