### PR TITLE
Update query instead of datasetQuery in action editor

### DIFF
--- a/frontend/src/metabase/writeback/components/ActionCreator/QueryActionEditor.tsx
+++ b/frontend/src/metabase/writeback/components/ActionCreator/QueryActionEditor.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import type { DatasetQuery } from "metabase-types/types/Card";
+import type { Query } from "metabase-types/types/Card";
 
 import NativeQueryEditor from "metabase/query_builder/components/NativeQueryEditor";
 import type Question from "metabase-lib/lib/Question";
@@ -18,8 +18,8 @@ export function QueryActionEditor({
       <NativeQueryEditor
         query={question.query()}
         viewHeight="full"
-        setDatasetQuery={(newQuery: DatasetQuery) =>
-          setQuestion(question.setDatasetQuery(newQuery))
+        setDatasetQuery={(newQuery: Query) =>
+          setQuestion(question.setQuery(newQuery))
         }
         enableRun={false}
         hasEditingSidebar={false} // TODO: make sidebar components work in popovers

--- a/frontend/src/metabase/writeback/components/ActionCreator/QueryActionEditor.tsx
+++ b/frontend/src/metabase/writeback/components/ActionCreator/QueryActionEditor.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 
-import type { Query } from "metabase-types/types/Card";
-
 import NativeQueryEditor from "metabase/query_builder/components/NativeQueryEditor";
+import type Query from "metabase-lib/lib/queries/Query";
+
 import type Question from "metabase-lib/lib/Question";
 import { EditorContainer } from "./ActionCreator.styled";
 


### PR DESCRIPTION
## Description

As a result of #25531 , updates to queries in the action editor broke. Apparently the setDatasetQuery callback in the NativeQueryEditor now sends back a `Query` object instead of a `DatasetQuery` object.
