### PR TITLE
Extract updateTemplateTagNames from initializeQB

### DIFF
--- a/frontend/src/metabase-lib/lib/queries/NativeQuery.ts
+++ b/frontend/src/metabase-lib/lib/queries/NativeQuery.ts
@@ -124,7 +124,7 @@ function isSnippetTagName(name: string): boolean {
   return name.startsWith("snippet:");
 }
 
-export function updateCardTagNames(
+export function updateCardTemplateTagNames(
   query: NativeQuery,
   cards: Card[],
 ): NativeQuery {
@@ -141,37 +141,6 @@ export function updateCardTagNames(
     const newTagName = `#${card.id}-${slugg(card.name)}`;
     return replaceTagName(query, tag.name, newTagName);
   }, query);
-}
-
-export async function updateTemplateTagNames(
-  query: NativeQuery,
-  getState: GetState,
-  dispatch: Dispatch,
-): Promise<NativeQuery> {
-  if (query.hasReferencedQuestions()) {
-    // fetch all referenced questions, ignoring errors
-    const referencedQuestions = (
-      await Promise.all(
-        query.referencedQuestionIds().map(async id => {
-          try {
-            const actionResult = await dispatch(
-              Questions.actions.fetch({ id }, { noEvent: true }),
-            );
-            return Questions.HACK_getObjectFromAction(actionResult);
-          } catch {
-            return null;
-          }
-        }),
-      )
-    ).filter(Boolean);
-    query = updateCardTagNames(query, referencedQuestions);
-  }
-  if (query.hasSnippets()) {
-    await dispatch(Snippets.actions.fetchList());
-    const snippets = Snippets.selectors.getList(getState());
-    query = query.updateSnippetNames(snippets);
-  }
-  return query;
 }
 
 // QUERY TEXT TAG UTILS END

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
@@ -25,7 +25,7 @@ import {
 import { Card, SavedCard } from "metabase-types/types/Card";
 import Question from "metabase-lib/lib/Question";
 import NativeQuery, {
-  updateTemplateTagNames,
+  updateCardTemplateTagNames,
 } from "metabase-lib/lib/queries/NativeQuery";
 import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
 
@@ -203,6 +203,39 @@ function isSavedCard(card: Card): card is SavedCard {
 }
 
 export const INITIALIZE_QB = "metabase/qb/INITIALIZE_QB";
+
+/**
+ * Updates the template tag names in the query
+ * to match the latest on the backend, because
+ * they might have changed since the query was last opened.
+ */
+export async function updateTemplateTagNames(
+  query: NativeQuery,
+  getState: GetState,
+  dispatch: Dispatch,
+): Promise<NativeQuery> {
+  const referencedCards = (
+    await Promise.all(
+      query.referencedQuestionIds().map(async id => {
+        try {
+          const actionResult = await dispatch(
+            Questions.actions.fetch({ id }, { noEvent: true }),
+          );
+          return Questions.HACK_getObjectFromAction(actionResult);
+        } catch {
+          return null;
+        }
+      }),
+    )
+  ).filter(Boolean);
+  query = updateCardTemplateTagNames(query, referencedCards);
+  if (query.hasSnippets()) {
+    await dispatch(Snippets.actions.fetchList());
+    const snippets = Snippets.selectors.getList(getState());
+    query = query.updateSnippetNames(snippets);
+  }
+  return query;
+}
 
 async function handleQBInit(
   dispatch: Dispatch,

--- a/frontend/test/metabase-lib/lib/queries/NativeQuery.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/NativeQuery.unit.spec.js
@@ -10,7 +10,7 @@ import NativeQuery, {
   replaceCardTagNameById,
   recognizeTemplateTags,
   cardIdFromTagName,
-  updateCardTagNames,
+  updateCardTemplateTagNames,
 } from "metabase-lib/lib/queries/NativeQuery";
 
 function makeDatasetQuery(queryText, templateTags, databaseId) {
@@ -375,11 +375,11 @@ describe("NativeQuery", () => {
     });
   });
 
-  describe("updateCardTagNames", () => {
+  describe("updateCardTemplateTagNames", () => {
     it("should update the query text with new tag names", () => {
       const query = makeQuery().setQueryText("{{#123-foo}} {{#1234-bar}}");
       const newCards = [{ id: 123, name: "Foo New" }]; // newCards is deliberately missing a the bar card
-      const templateTagsMap = updateCardTagNames(
+      const templateTagsMap = updateCardTemplateTagNames(
         query,
         newCards,
       ).templateTagsMap();


### PR DESCRIPTION
This is a refactor to untangle initializeQB from the innards of updating native query template tags.