### PR TITLE
Handle missing field id when generating field's uniqueId

### DIFF
--- a/frontend/src/metabase-lib/lib/metadata/Field.ts
+++ b/frontend/src/metabase-lib/lib/metadata/Field.ts
@@ -87,7 +87,7 @@ class FieldInner extends Base {
       return this.uniqueId;
     }
 
-    const uniqueId = getUniqueFieldId(this.getId(), this.table_id);
+    const uniqueId = getUniqueFieldId(this);
     this.uniqueId = uniqueId;
 
     return uniqueId;

--- a/frontend/src/metabase-lib/lib/metadata/Metadata.ts
+++ b/frontend/src/metabase-lib/lib/metadata/Metadata.ts
@@ -105,14 +105,18 @@ export default class Metadata extends Base {
   }
 
   field(
-    fieldId: Field["id"] | undefined | null,
+    fieldId: Field["id"] | Field["name"] | undefined | null,
     tableId?: Table["id"] | undefined | null,
   ): Field | null {
     if (fieldId == null) {
       return null;
     }
 
-    const uniqueId = getUniqueFieldId(fieldId, tableId);
+    const uniqueId = getUniqueFieldId({
+      id: fieldId,
+      table_id: tableId,
+    } as Field);
+
     return this.fields[uniqueId] || null;
   }
 

--- a/frontend/src/metabase-lib/lib/metadata/mocks.ts
+++ b/frontend/src/metabase-lib/lib/metadata/mocks.ts
@@ -16,3 +16,17 @@ export function createMockConcreteField({
 
   return instance;
 }
+
+export function createMockVirtualField({
+  constructorOpts,
+  instanceOpts,
+}: {
+  constructorOpts?: Partial<Field>;
+  instanceOpts?: Partial<Field>;
+}) {
+  const instance = new Field(constructorOpts);
+
+  Object.assign(instance, instanceOpts);
+
+  return instance;
+}

--- a/frontend/src/metabase-lib/lib/metadata/utils.ts
+++ b/frontend/src/metabase-lib/lib/metadata/utils.ts
@@ -1,11 +1,22 @@
 import { isVirtualCardId } from "metabase/lib/saved-questions/saved-questions";
 import type Field from "./Field";
-import type Table from "./Table";
 
-export function getUniqueFieldId(id: Field["id"], tableId: Table["id"]) {
-  if (isVirtualCardId(tableId)) {
-    return `${tableId}:${id}`;
+export function getUniqueFieldId(field: Field): number | string {
+  const { table_id } = field;
+  const fieldIdentifier = getFieldIdentifier(field);
+
+  if (isVirtualCardId(table_id)) {
+    return `${table_id}:${fieldIdentifier}`;
   }
 
-  return id;
+  return fieldIdentifier;
+}
+
+function getFieldIdentifier(field: Field): number | string {
+  const { id, name } = field;
+  if (Array.isArray(id)) {
+    return id[1];
+  }
+
+  return id || name;
 }

--- a/frontend/src/metabase-lib/lib/metadata/utils.unit.spec.ts
+++ b/frontend/src/metabase-lib/lib/metadata/utils.unit.spec.ts
@@ -1,18 +1,62 @@
 import { getUniqueFieldId } from "./utils";
+import { createMockConcreteField, createMockVirtualField } from "./mocks";
+
+const structuredVirtualCardField = createMockConcreteField({
+  apiOpts: {
+    id: 1,
+    table_id: "card__123",
+    name: "foo",
+  },
+});
+
+const nativeVirtualCardField = createMockConcreteField({
+  apiOpts: {
+    id: undefined,
+    table_id: "card__123",
+    name: "foo",
+  },
+});
+
+const concreteTableField = createMockConcreteField({
+  apiOpts: {
+    id: 1,
+    table_id: 123,
+    name: "foo",
+  },
+});
+
+const fieldWithFieldRefId = createMockVirtualField({
+  constructorOpts: {
+    id: ["field", 1, null],
+    table_id: 123,
+  },
+});
 
 describe("metabase-lib/metadata/utils", () => {
   describe("getUniqueFieldId", () => {
-    describe("when the given tableId arg is NOT a virtual card table", () => {
+    describe("when the given field is from a concrete table", () => {
       it("should return the field's id", () => {
-        expect(getUniqueFieldId(1, 2)).toEqual(1);
-        // @ts-expect-error -- testing for when our types fail
-        expect(getUniqueFieldId(1, undefined)).toEqual(1);
+        expect(getUniqueFieldId(concreteTableField)).toEqual(1);
       });
     });
 
-    describe("when the given tableId arg is a virtual card table", () => {
-      it("should return a string from the combined ids", () => {
-        expect(getUniqueFieldId(1, "card__123")).toEqual("card__123:1");
+    describe("when the given field is from a structured virtual card table", () => {
+      it("should return a combination of the field's id and table_id", () => {
+        expect(getUniqueFieldId(structuredVirtualCardField)).toBe(
+          "card__123:1",
+        );
+      });
+    });
+
+    describe("when the given field is from a native virtual card table", () => {
+      it("should return a combination of the field's name and table_id", () => {
+        expect(getUniqueFieldId(nativeVirtualCardField)).toBe("card__123:foo");
+      });
+    });
+
+    describe("when the given field has a field ref id", () => {
+      it("should return the field ref id", () => {
+        expect(getUniqueFieldId(fieldWithFieldRefId)).toBe(1);
       });
     });
   });

--- a/frontend/src/metabase-types/api/field.ts
+++ b/frontend/src/metabase-types/api/field.ts
@@ -33,10 +33,10 @@ export interface FieldFingerprint {
 }
 
 export interface Field {
-  id: number;
+  id?: number;
   dimensions?: FieldDimension;
   display_name: string;
-  table_id: number;
+  table_id: number | string;
   name: string;
   base_type: string;
   description: string | null;

--- a/frontend/src/metabase/schema.js
+++ b/frontend/src/metabase/schema.js
@@ -47,14 +47,14 @@ export const TableSchema = new schema.Entity(
 
 export const FieldSchema = new schema.Entity("fields", undefined, {
   processStrategy(field) {
-    const uniqueId = getUniqueFieldId(field.id, field.table_id);
+    const uniqueId = getUniqueFieldId(field);
     return {
       ...field,
       uniqueId,
     };
   },
   idAttribute: field => {
-    return getUniqueFieldId(field.id, field.table_id);
+    return getUniqueFieldId(field);
   },
 });
 


### PR DESCRIPTION
Fields from native question virtual tables don't have ids. In this PR I've updated `getUniqueFieldId` to handle field ids that are missing and field ids that are field refs so that these fields are properly keyed by our `normalizr` code.

**Testing**
1. Create a native question with the query `select * from ORDERS` and turn it into a model
2. Modify the name metadata on various columns.
3. Save the model and refresh the page.
4. Inspect the component hierarchy and check how the fields are cached in the `metadata.fields` map. You should see that fields are cached by a `uniqueId` that looks like `card__123:TOTAL` etc.