### PR TITLE
Use `humane-are` lib for tests

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -414,7 +414,6 @@
   metabase.sync.util/with-emoji-progress-bar                                           clojure.core/let
   metabase.test.data.interface/defdataset                                              clojure.core/def
   metabase.test.data.interface/defdataset-edn                                          clojure.core/def
-  metabase.test/are+                                                                   clojure.test/are
   metabase.test/defdataset                                                             clojure.core/def
   metabase.test/with-open-channels                                                     clojure.core/let
   metabase.test/with-temp-file                                                         clojure.core/let

--- a/deps.edn
+++ b/deps.edn
@@ -179,6 +179,7 @@
     cloverage/cloverage                                   {:mvn/version "1.2.2"}
     djblue/portal                                         {:mvn/version "0.30.0"}
     eftest/eftest                                         {:mvn/version "0.5.9"}
+    io.github.camsaul/humane-are                          {:mvn/version "1.0.2"}
     jonase/eastwood                                       {:mvn/version "1.2.2"}
     pjstadig/humane-test-output                           {:mvn/version "0.11.0"}
     reifyhealth/specmonstah                               {:mvn/version "2.0.0"

--- a/test/metabase/api/common/internal_test.clj
+++ b/test/metabase/api/common/internal_test.clj
@@ -3,7 +3,6 @@
             [medley.core :as m]
             [metabase.api.common.internal :as internal]
             [metabase.config :as config]
-            [metabase.test :as mt]
             [metabase.util :as u]))
 
 (deftest route-fn-name-test

--- a/test/metabase/api/common/internal_test.clj
+++ b/test/metabase/api/common/internal_test.clj
@@ -7,16 +7,16 @@
             [metabase.util :as u]))
 
 (deftest route-fn-name-test
-  (mt/are+ [method route expected] (= expected
-                                      (internal/route-fn-name method route))
+  (are [method route expected] (= expected
+                                  (internal/route-fn-name method route))
     'GET "/"                    'GET_
     'GET "/:id/cards"           'GET_:id_cards
     ;; check that internal/route-fn-name can handle routes with regex conditions
     'GET ["/:id" :id #"[0-9]+"] 'GET_:id))
 
 (deftest arg-type-test
-  (mt/are+ [param expected] (= expected
-                               (internal/arg-type param))
+  (are [param expected] (= expected
+                           (internal/arg-type param))
     :fish    nil
     :id      :int
     :card-id :int))
@@ -34,51 +34,51 @@
 
 (deftest route-param-regex-test
   (no-route-regexes
-    (mt/are+ [param expected] (= expected
-                                 (internal/route-param-regex param))
-      :fish    nil
-      :id      [:id "#[0-9]+"]
-      :card-id [:card-id "#[0-9]+"])))
+   (are [param expected] (= expected
+                            (internal/route-param-regex param))
+     :fish    nil
+     :id      [:id "#[0-9]+"]
+     :card-id [:card-id "#[0-9]+"])))
 
 (deftest route-arg-keywords-test
   (no-route-regexes
-    (mt/are+ [route expected] (= expected
-                                 (internal/route-arg-keywords route))
-      "/"             []
-      "/:id"          [:id]
-      "/:id/card"     [:id]
-      "/:id/etc/:org" [:id :org]
-      "/:card-id"     [:card-id])))
+   (are [route expected] (= expected
+                            (internal/route-arg-keywords route))
+     "/"             []
+     "/:id"          [:id]
+     "/:id/card"     [:id]
+     "/:id/etc/:org" [:id :org]
+     "/:card-id"     [:card-id])))
 
 (deftest type-args-test
   (no-route-regexes
-    (mt/are+ [args expected] (= expected
-                                (#'internal/typify-args args))
-      []             []
-      [:fish]        []
-      [:fish :fry]   []
-      [:id]          [:id "#[0-9]+"]
-      [:id :fish]    [:id "#[0-9]+"]
-      [:id :card-id] [:id "#[0-9]+" :card-id "#[0-9]+"])))
+   (are [args expected] (= expected
+                           (#'internal/typify-args args))
+     []             []
+     [:fish]        []
+     [:fish :fry]   []
+     [:id]          [:id "#[0-9]+"]
+     [:id :fish]    [:id "#[0-9]+"]
+     [:id :card-id] [:id "#[0-9]+" :card-id "#[0-9]+"])))
 
 (deftest add-route-param-regexes-test
   (no-route-regexes
-    (mt/are+ [route expected] (= expected
-                                 (internal/add-route-param-regexes route))
-      "/"                                    "/"
-      "/:id"                                 ["/:id" :id "#[0-9]+"]
-      "/:id/card"                            ["/:id/card" :id "#[0-9]+"]
-      "/:card-id"                            ["/:card-id" :card-id "#[0-9]+"]
-      "/:fish"                               "/:fish"
-      "/:id/tables/:card-id"                 ["/:id/tables/:card-id" :id "#[0-9]+" :card-id "#[0-9]+"]
-      ;; don't try to typify route that's already typified
-      ["/:id/:crazy-id" :crazy-id "#[0-9]+"] ["/:id/:crazy-id" :crazy-id "#[0-9]+"]
-      ;; Check :uuid args
-      "/:uuid/toucans"                       ["/:uuid/toucans" :uuid (str \# u/uuid-regex)])))
+   (are [route expected] (= expected
+                            (internal/add-route-param-regexes route))
+     "/"                                    "/"
+     "/:id"                                 ["/:id" :id "#[0-9]+"]
+     "/:id/card"                            ["/:id/card" :id "#[0-9]+"]
+     "/:card-id"                            ["/:card-id" :card-id "#[0-9]+"]
+     "/:fish"                               "/:fish"
+     "/:id/tables/:card-id"                 ["/:id/tables/:card-id" :id "#[0-9]+" :card-id "#[0-9]+"]
+     ;; don't try to typify route that's already typified
+     ["/:id/:crazy-id" :crazy-id "#[0-9]+"] ["/:id/:crazy-id" :crazy-id "#[0-9]+"]
+     ;; Check :uuid args
+     "/:uuid/toucans"                       ["/:uuid/toucans" :uuid (str \# u/uuid-regex)])))
 
 (deftest let-form-for-arg-test
-  (mt/are+ [arg expected] (= expected
-                             (internal/let-form-for-arg arg))
+  (are [arg expected] (= expected
+                         (internal/let-form-for-arg arg))
     'id           '[id (clojure.core/when id (metabase.api.common.internal/parse-int id))]
     'org_id       '[org_id (clojure.core/when org_id (metabase.api.common.internal/parse-int org_id))]
     'fish         nil
@@ -87,8 +87,8 @@
     '{body :body} nil))
 
 (deftest auto-parse-test
-  (mt/are+ [args expected] (= expected
-                              (macroexpand-1 `(internal/auto-parse ~args '~'body)))
+  (are [args expected] (= expected
+                          (macroexpand-1 `(internal/auto-parse ~args '~'body)))
     ;; when auto-parse gets an args form where arg is present in *autoparse-types*
     ;; the appropriate let binding should be generated
     '[id]
@@ -101,7 +101,7 @@
     ;; make sure multiple autoparse params work correctly
     '[id org_id]
     '(clojure.core/let [id (clojure.core/when id (metabase.api.common.internal/parse-int id))
-                       org_id (clojure.core/when org_id (metabase.api.common.internal/parse-int org_id))] 'body)
+                        org_id (clojure.core/when org_id (metabase.api.common.internal/parse-int org_id))] 'body)
 
     ;; make sure it still works if no autoparse params are passed
     '[some-other-param]

--- a/test/metabase/automagic_dashboards/rules_test.clj
+++ b/test/metabase/automagic_dashboards/rules_test.clj
@@ -26,8 +26,8 @@
   (is (some? (rules/get-rules ["table" "GenericTable" "ByCountry"]))))
 
 (deftest dimension-form?-test
-  (are [x expected] (is (= expected
-                           (rules/dimension-form? x)))
+  (are [x expected] (= expected
+                       (rules/dimension-form? x))
     [:dimension "Foo"]  true
     ["dimension" "Foo"] true
     ["DIMENSION" "Foo"] true

--- a/test/metabase/integrations/google_test.clj
+++ b/test/metabase/integrations/google_test.clj
@@ -32,9 +32,8 @@
 (deftest allow-autocreation-test
   (with-redefs [premium-features/enable-sso? (constantly false)]
     (mt/with-temporary-setting-values [google-auth-auto-create-accounts-domain "metabase.com"]
-      (are [allowed? email] (is (= allowed?
-                                   (#'google/autocreate-user-allowed-for-email? email))
-                                (format "Can we autocreate an account for email '%s'?" email))
+      (are [allowed? email] (= allowed?
+                               (#'google/autocreate-user-allowed-for-email? email))
         true  "cam@metabase.com"
         false "cam@expa.com"))))
 

--- a/test/metabase/pulse/render/body_test.clj
+++ b/test/metabase/pulse/render/body_test.clj
@@ -649,8 +649,8 @@
                (:percentages (donut-info 5 rows))))))))
 
 (deftest ^:parallel format-percentage-test
-  (mt/are+ [value expected] (= expected
-                               (body/format-percentage 12345.4321 value))
+  (are [value expected] (= expected
+                           (body/format-percentage 12345.4321 value))
     ".," "1,234,543.21%"
     "^&" "1&234&543^21%"
     " "  "1,234,543 21%"

--- a/test/metabase/pulse/render/body_test.clj
+++ b/test/metabase/pulse/render/body_test.clj
@@ -5,7 +5,6 @@
             [metabase.pulse.render.body :as body]
             [metabase.pulse.render.common :as common]
             [metabase.pulse.render.test-util :as render.tu]
-            [metabase.test :as mt]
             [schema.core :as s]))
 
 (use-fixtures :each

--- a/test/metabase/query_processor/middleware/binning_test.clj
+++ b/test/metabase/query_processor/middleware/binning_test.clj
@@ -26,15 +26,15 @@
                                        [:between [:field 3 nil] 5 10]]))))
 
 (deftest floor-to-test
-  (mt/are+ [x expected] (= expected
-                           (#'binning/floor-to 1.0 x))
+  (are [x expected] (= expected
+                       (#'binning/floor-to 1.0 x))
     1   1.0
     1.1 1.0
     1.8 1.0))
 
 (deftest ceil-to-test
-  (mt/are+ [precision x expected] (= expected
-                                     (#'binning/ceil-to precision x))
+  (are [precision x expected] (= expected
+                                 (#'binning/ceil-to precision x))
     1.0  1    1.0
     1.0  1.1  2.0
     1.0  1.8  2.0
@@ -43,8 +43,8 @@
     15.0 16.0 30.0))
 
 (deftest nicer-bin-width-test
-  (mt/are+ [min max num-bins expected] (= expected
-                                          (#'binning/nicer-bin-width min max num-bins))
+  (are [min max num-bins expected] (= expected
+                                      (#'binning/nicer-bin-width min max num-bins))
     27      135      8 20
     -0.0002 10000.34 8 2000))
 
@@ -52,8 +52,8 @@
   {:type {:type/Number {:min 100 :max 1000}}})
 
 (deftest extract-bounds-test
-  (mt/are+ [field-id->filters expected] (= expected
-                                           (#'binning/extract-bounds 1 test-min-max-fingerprint field-id->filters))
+  (are [field-id->filters expected] (= expected
+                                       (#'binning/extract-bounds 1 test-min-max-fingerprint field-id->filters))
     {1 [[:> [:field 1 nil] 1] [:< [:field 1 nil] 10]]}
     {:min-value 1, :max-value 10}
 
@@ -73,7 +73,7 @@
     {:min-value 600, :max-value 700}))
 
 (deftest nicer-breakout-test
-  (mt/are+ [strategy opts expected] (= expected
+  (are [strategy opts expected] (= expected
                                    (#'binning/nicer-breakout strategy opts))
     :num-bins  {:min-value 100, :max-value 1000, :num-bins 8, :bin-width 0}  {:min-value 0.0, :max-value 1000.0, :num-bins 8, :bin-width 125.0}
     :num-bins  {:min-value 200, :max-value 1600, :num-bins 8, :bin-width 0}  {:min-value 200N, :max-value 1600N, :num-bins 8, :bin-width 200}

--- a/test/metabase/test.clj
+++ b/test/metabase/test.clj
@@ -6,8 +6,8 @@
   (:refer-clojure :exclude [compile])
   (:require clojure.data
             [clojure.test :refer :all]
-            [clojure.tools.macro :as tools.macro]
             [environ.core :as env]
+            [humane-are.core :as humane-are]
             [java-time :as t]
             [medley.core :as m]
             [metabase.driver :as driver]
@@ -44,6 +44,7 @@
             [toucan.db :as db]
             [toucan.util.test :as tt]))
 
+(humane-are/install!)
 (humane-test-output/activate!)
 
 ;; Fool the linters into thinking these namespaces are used! See discussion on
@@ -354,27 +355,6 @@
      (test-runner.init/assert-tests-are-not-initializing (list 'object-defaults (symbol (name toucan-model))))
      (initialize/initialize-if-needed! :db)
      (db/resolve-model toucan-model))))
-
-(defn are+-message [expr arglist args]
-  (pr-str
-   (second
-    (macroexpand-1
-     (list
-      `tools.macro/symbol-macrolet
-      (vec (apply concat (map-indexed (fn [i arg]
-                                        [arg (nth args i)])
-                                      arglist)))
-      expr)))))
-
-(defmacro are+
-  "Like [[clojure.test/are]] but includes a message for easier test failure debugging. (Also this is somewhat more
-  efficient since it generates far less code ­ it uses `doseq` rather than repeating the entire test each time.)"
-  {:style/indent 2}
-  [argv expr & args]
-  `(doseq [args# ~(mapv vec (partition (count argv) args))
-           :let [~argv args#]]
-     (is ~expr
-         (str (are+-message '~expr '~argv args#)))))
 
 (defmacro disable-flaky-test-when-running-driver-tests-in-ci
   "Only run `body` when we're not running driver tests in CI (i.e., `DRIVERS` and `CI` are both not set). Perfect for

--- a/test/metabase/test_runner.clj
+++ b/test/metabase/test_runner.clj
@@ -10,6 +10,7 @@
             eftest.report.progress
             eftest.runner
             [environ.core :as env]
+            [humane-are.core :as humane-are]
             [metabase.config :as config]
             [metabase.test-runner.assert-exprs :as test-runner.assert-exprs]
             [metabase.test-runner.init :as test-runner.init]
@@ -24,6 +25,8 @@
 
 ;; initialize Humane Test Output if it's not already initialized.
 (humane-test-output/activate!)
+;;; Same for https://github.com/camsaul/humane-are
+(humane-are/install!)
 
 ;; Load redefinitions of stuff like `tt/with-temp` and `with-redefs` that throw an Exception when they are used inside
 ;; parallel tests.

--- a/test/metabase/transforms/specs_test.clj
+++ b/test/metabase/transforms/specs_test.clj
@@ -1,12 +1,11 @@
 (ns metabase.transforms.specs-test
   (:require [clojure.test :refer :all]
-            [metabase.test :as mt]
             [metabase.transforms.specs :as tf.specs]
             [metabase.util.schema :as su]))
 
 (deftest extract-dimensions-test
-  (mt/are+ [arg expected] (= expected
-                             (#'tf.specs/extract-dimensions arg))
+  (are [arg expected] (= expected
+                         (#'tf.specs/extract-dimensions arg))
     [:dimension "foo"]                    ["foo"]
     [:some-op 12 {:k [:dimension "foo"]}] ["foo"]
     nil                                   nil

--- a/test/metabase/util/honeysql_extensions_test.clj
+++ b/test/metabase/util/honeysql_extensions_test.clj
@@ -183,7 +183,7 @@
              (hx/with-database-type-info (hx/with-database-type-info :field "date") nil))))))
 
 (deftest ^:parallel is-of-type?-test
-  (mt/are+ [expr tyype expected] (= expected (hx/is-of-type? expr tyype))
+  (are [expr tyype expected] (= expected (hx/is-of-type? expr tyype))
     typed-form     "text" true
     typed-form     "TEXT" true
     typed-form     :text  true

--- a/test/metabase/util/i18n/plural_test.clj
+++ b/test/metabase/util/i18n/plural_test.clj
@@ -11,7 +11,7 @@
 
 (deftest basic-arithmetic-test
   (testing "basic arithmetic"
-    (are [formula expected] (is (= expected (compute formula)))
+    (are [formula expected] (= expected (compute formula))
       "0"                         0
       "1"                         1
       "123;"                      123
@@ -77,7 +77,7 @@
       "1 < 2 ? 1 < 3 ? 1 : 2 : 3" 1))
 
   (testing "Error cases"
-    (are [formula] (is (insta/failure? (compute formula)))
+    (are [formula] (insta/failure? (compute formula))
       ;; Empty formulas
       ""
       " "
@@ -103,33 +103,33 @@
   ;; This test uses selected example Plural-Forms from https://www.gnu.org/software/gettext/manual/html_node/Plural-forms.html
   ;; These do not necessarily correspond to languages available in Metabase.
   (testing "English, German, Dutch, Spanish, Portuguese, etc"
-    (are [n expected] (is (= expected (compute "n != 1" n)))
+    (are [n expected] (= expected (compute "n != 1" n))
       0 1
       1 0
       2 1))
 
   (testing "French"
-    (are [n expected] (is (= expected (compute "n > 1" n)))
+    (are [n expected] (= expected (compute "n > 1" n))
       0 0
       1 0
       2 1))
 
   (testing "Latvian"
-    (are [n expected] (is (= expected (compute "n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : 2" n)))
-     0   2
-     1   0
-     11  1
-     21  0
-     111 1))
+    (are [n expected] (= expected (compute "n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : 2" n))
+      0   2
+      1   0
+      11  1
+      21  0
+      111 1))
 
   (testing "Irish"
-    (are [n expected] (is (= expected (compute "n==1 ? 0 : n==2 ? 1 : 2" n)))
+    (are [n expected] (= expected (compute "n==1 ? 0 : n==2 ? 1 : 2" n))
       1 0
       2 1
       3 2))
 
   (testing "Romanian"
-    (are [n expected] (is (= expected (compute "n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < 20)) ? 1 : 2" n)))
+    (are [n expected] (= expected (compute "n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < 20)) ? 1 : 2" n))
       0   1
       1   0
       2   1
@@ -139,9 +139,9 @@
       101 1))
 
   (testing "Russian, Ukrainian, Serbian"
-    (are [n expected] (is (= expected (compute (str "n%10==1 && n%100!=11 ? 0 :"
-                                                    "n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2")
-                                               n)))
+    (are [n expected] (= expected (compute (str "n%10==1 && n%100!=11 ? 0 :"
+                                                "n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2")
+                                           n))
       0   2
       1   0
       11  2
@@ -152,7 +152,7 @@
       110 2))
 
   (testing "Czech, Slovak"
-    (are [n expected] (is (= expected (compute "(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2" n)))
+    (are [n expected] (= expected (compute "(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2" n))
       0 2
       1 0
       2 1
@@ -161,9 +161,9 @@
       5 2))
 
   (testing "Polish"
-    (are [n expected] (is (= expected (compute (str "n==1 ? 0 :"
-                                                    "n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2")
-                                               n)))
+    (are [n expected] (= expected (compute (str "n==1 ? 0 :"
+                                                "n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2")
+                                           n))
       0 2
       1 0
       12 2

--- a/test/metabase/util_test.clj
+++ b/test/metabase/util_test.clj
@@ -337,25 +337,23 @@
                     (u/sorted-take size kompare)
                     coll)))))
 (deftest ^:parallel email->domain-test
-  (are [domain email] (is (= domain
-                             (u/email->domain email))
-                          (format "Domain of email address '%s'" email))
+  (are [domain email] (= domain
+                         (u/email->domain email))
     nil              nil
     "metabase.com"   "cam@metabase.com"
     "metabase.co.uk" "cam@metabase.co.uk"
     "metabase.com"   "cam.saul+1@metabase.com"))
 
 (deftest ^:parallel email-in-domain-test
-  (are [in-domain? email domain] (is (= in-domain?
-                                        (u/email-in-domain? email domain))
-                                     (format "Is email '%s' in domain '%s'?" email domain))
+  (are [in-domain? email domain] (= in-domain?
+                                    (u/email-in-domain? email domain))
     true  "cam@metabase.com"          "metabase.com"
     false "cam.saul+1@metabase.co.uk" "metabase.com"
     true  "cam.saul+1@metabase.com"   "metabase.com"))
 
 (deftest ^:parallel round-to-precision-test
-  (are [exp figs n]
-       (is (= exp (u/round-to-precision figs n)))
+  (are [exp figs n] (= exp
+                       (u/round-to-precision figs n))
        1.0     1 1.234
        1.2     2 1.234
        1.3     2 1.278

--- a/test/metabase/util_test.clj
+++ b/test/metabase/util_test.clj
@@ -30,8 +30,8 @@
 
 (deftest ^:parallel host-up?-test
   (testing "host-up?"
-    (mt/are+ [s expected] (= expected
-                             (u/host-up? s))
+    (are [s expected] (= expected
+                         (u/host-up? s))
       "localhost"  true
       "nosuchhost" false))
   (testing "host-port-up?"
@@ -39,8 +39,8 @@
            (u/host-port-up? "nosuchhost" 8005)))))
 
 (deftest ^:parallel url?-test
-  (mt/are+ [s expected] (= expected
-                        (u/url? s))
+  (are [s expected] (= expected
+                       (u/url? s))
     "http://google.com"                                                                      true
     "https://google.com"                                                                     true
     "https://amazon.co.uk"                                                                   true
@@ -74,8 +74,8 @@
     "http:/"                                                                                 false))
 
 (deftest ^:parallel state?-test
-  (mt/are+ [x expected] (= expected
-                           (u/state? x))
+  (are [x expected] (= expected
+                       (u/state? x))
     "louisiana"      true
     "north carolina" true
     "WASHINGTON"     true
@@ -87,8 +87,8 @@
     (Object.)        false))
 
 (deftest ^:parallel qualified-name-test
-  (mt/are+ [k expected] (= expected
-                           (u/qualified-name k))
+  (are [k expected] (= expected
+                       (u/qualified-name k))
     :keyword                          "keyword"
     :namespace/keyword                "namespace/keyword"
     ;; `qualified-name` should return strings as-is
@@ -152,8 +152,8 @@
              (map ex-data (u/full-exception-chain e)))))))
 
 (deftest ^:parallel select-nested-keys-test
-  (mt/are+ [m keyseq expected] (= expected
-                                  (u/select-nested-keys m keyseq))
+  (are [m keyseq expected] (= expected
+                              (u/select-nested-keys m keyseq))
     {:a 100, :b {:c 200, :d 300}}              [:a [:b :d] :c]   {:a 100, :b {:d 300}}
     {:a 100, :b {:c 200, :d 300}}              [:b]              {:b {:c 200, :d 300}}
     {:a 100, :b {:c 200, :d 300}}              [[:b :c :d]]      {:b {:c 200, :d 300}}
@@ -168,8 +168,8 @@
     {}                                         [:c]              {}))
 
 (deftest ^:parallel base64-string?-test
-  (mt/are+ [s expected]    (= expected
-                        (u/base64-string? s))
+  (are [s expected]    (= expected
+                          (u/base64-string? s))
     "ABc="         true
     "ABc/+asdasd=" true
     100            false
@@ -198,8 +198,8 @@
              :non-nil #{:d :e :f})))))
 
 (deftest ^:parallel order-of-magnitude-test
-  (mt/are+ [n expected] (= expected
-                        (u/order-of-magnitude n))
+  (are [n expected] (= expected
+                       (u/order-of-magnitude n))
     0.01  -2
     0.5   -1
     4     0
@@ -222,16 +222,16 @@
          (u/snake-keys {:num-cans 2, :lisp-case? {:nested-maps? true}}))))
 
 (deftest ^:parallel one-or-many-test
-  (mt/are+ [input expected] (= expected
-                               (u/one-or-many input))
+  (are [input expected] (= expected
+                           (u/one-or-many input))
     nil   nil
     [nil] [nil]
     42    [42]
     [42]  [42]))
 
 (deftest ^:parallel topological-sort-test
-  (mt/are+ [input expected] (= expected
-                            (u/topological-sort identity input))
+  (are [input expected] (= expected
+                           (u/topological-sort identity input))
     {:b []
      :c [:a]
      :e [:d]
@@ -253,8 +253,8 @@
            (u/upper-case-en "id")))))
 
 (deftest ^:parallel parse-currency-test
-  (mt/are+ [s expected] (= expected
-                        (u/parse-currency s))
+  (are [s expected] (= expected
+                       (u/parse-currency s))
     nil             nil
     ""              nil
     "   "           nil
@@ -289,8 +289,8 @@
     (is (nil? (u/or-with even? 1 3 5)))))
 
 (deftest ^:parallel ip-address?-test
-  (mt/are+ [x expected] (= expected
-                           (u/ip-address? x))
+  (are [x expected] (= expected
+                       (u/ip-address? x))
     "8.8.8.8"              true
     "185.233.100.23"       true
     "500.1.1.1"            false


### PR DESCRIPTION
I think a few people saw my post in Clojurians Slack a few weeks ago, but I wrote a little library called [`humane-are`](https://github.com/camsaul/humane-are). It installs a drop-in replacement for `clojure.test/are` that does extra things:

1. Adds `testing` context about which specific test case failed
2. Adds `fdef` spec validation to make sure you don't accidentally include an extra `is` or `testing` in the expression (this is a bad idea because `are` does this for you automatically; see https://github.com/camsaul/humane-are#anti-foot-shooting-protection for more info)

This PR adds humane-are as a dep and removes our bespoke `are+` macro, which mostly did mostly the same thing (but with subtle differences from vanilla `are` since it didn't use `clojure.template` under the hood) WRT adding `testing` context, but did not include `fdef` spec validation 

Because of the `fdef` spec validation I found and fixed a handful of tests doing things the "wrong" way