### PR TITLE
Add flow from +New button to a page where user chooses between new Visual and Native Query Models without questions

### DIFF
--- a/frontend/src/metabase-lib/lib/Question.ts
+++ b/frontend/src/metabase-lib/lib/Question.ts
@@ -1386,6 +1386,7 @@ export default class Question extends memoizeClass<QuestionInner>(
       collection_id: collectionId,
       display,
       visualization_settings,
+      dataset,
       dataset_query,
     };
 

--- a/frontend/src/metabase-lib/lib/Question.ts
+++ b/frontend/src/metabase-lib/lib/Question.ts
@@ -956,7 +956,7 @@ class QuestionInner {
       !question.id() ||
       (originalQuestion && question.isDirtyComparedTo(originalQuestion))
     ) {
-      return Urls.question(question.card(), {
+      return Urls.question(null, {
         hash: question._serializeForUrl({
           clean,
           includeDisplayIsLocked,
@@ -1383,7 +1383,6 @@ export default class Question extends memoizeClass<QuestionInner>(
   }: QuestionCreatorOpts = {}) {
     let card: CardObject = {
       name,
-      dataset,
       collection_id: collectionId,
       display,
       visualization_settings,

--- a/frontend/src/metabase-lib/lib/Question.ts
+++ b/frontend/src/metabase-lib/lib/Question.ts
@@ -86,6 +86,7 @@ import {
 
 export type QuestionCreatorOpts = {
   databaseId?: DatabaseId;
+  dataset?: boolean;
   tableId?: TableId;
   collectionId?: CollectionId;
   metadata?: Metadata;
@@ -941,6 +942,7 @@ class QuestionInner {
     query,
     includeDisplayIsLocked,
     creationType,
+    ...options
   }: {
     originalQuestion?: Question;
     clean?: boolean;
@@ -954,7 +956,7 @@ class QuestionInner {
       !question.id() ||
       (originalQuestion && question.isDirtyComparedTo(originalQuestion))
     ) {
-      return Urls.question(null, {
+      return Urls.question(question.card(), {
         hash: question._serializeForUrl({
           clean,
           includeDisplayIsLocked,
@@ -1374,12 +1376,14 @@ export default class Question extends memoizeClass<QuestionInner>(
     name,
     display = "table",
     visualization_settings = {},
+    dataset,
     dataset_query = type === "native"
       ? NATIVE_QUERY_TEMPLATE
       : STRUCTURED_QUERY_TEMPLATE,
   }: QuestionCreatorOpts = {}) {
     let card: CardObject = {
       name,
+      dataset,
       collection_id: collectionId,
       display,
       visualization_settings,

--- a/frontend/src/metabase/components/NewItemMenu/NewItemMenu.tsx
+++ b/frontend/src/metabase/components/NewItemMenu/NewItemMenu.tsx
@@ -117,7 +117,6 @@ const NewItemMenu = ({
     );
 
     if (hasNativeWrite) {
-      // we should probably get more granular with who sees this
       items.push({
         title: t`Model`,
         icon: "model",

--- a/frontend/src/metabase/components/NewItemMenu/NewItemMenu.tsx
+++ b/frontend/src/metabase/components/NewItemMenu/NewItemMenu.tsx
@@ -121,11 +121,7 @@ const NewItemMenu = ({
       items.push({
         title: t`Model`,
         icon: "model",
-        link: Urls.newDataset({
-          type: "native",
-          creationType: "native_question",
-          dataset: true,
-        }),
+        link: "/model/new",
         event: `${analyticsContext};New Model Click;`,
         onClose: onCloseNavbar,
       });

--- a/frontend/src/metabase/components/NewItemMenu/NewItemMenu.tsx
+++ b/frontend/src/metabase/components/NewItemMenu/NewItemMenu.tsx
@@ -116,6 +116,21 @@ const NewItemMenu = ({
       },
     );
 
+    if (hasNativeWrite) {
+      // we should probably get more granular with who sees this
+      items.push({
+        title: t`Model`,
+        icon: "model",
+        link: Urls.newDataset({
+          type: "native",
+          creationType: "native_question",
+          dataset: true,
+        }),
+        event: `${analyticsContext};New Model Click;`,
+        onClose: onCloseNavbar,
+      });
+    }
+
     return items;
   }, [
     hasDataAccess,

--- a/frontend/src/metabase/lib/urls/questions.ts
+++ b/frontend/src/metabase/lib/urls/questions.ts
@@ -54,7 +54,6 @@ export function question(
   }
 
   const isModel = card?.dataset || card?.model === "dataset";
-  let path = isModel ? "model" : "question";
   if (!card || !card.id) {
     return `/${path}${query}${hash}`;
   }
@@ -96,6 +95,7 @@ type NewQuestionUrlBuilderParams = QuestionCreatorOpts & {
   mode?: "view" | "notebook";
   creationType?: string;
   objectId?: number | string;
+  dataset?: true;
 };
 
 export function newQuestion({
@@ -112,6 +112,23 @@ export function newQuestion({
   if (mode) {
     const entity = question.isDataset() ? "model" : "question";
     return url.replace(/^\/(question|model)/, `/${entity}\/${mode}`);
+  } else {
+    return url;
+  }
+}
+
+export function newDataset({
+  mode,
+  creationType,
+  objectId,
+  ...options
+}: NewQuestionUrlBuilderParams = {}) {
+  const url = Question.create(options).getUrl({
+    creationType,
+    query: objectId ? { objectId } : undefined,
+  });
+  if (mode) {
+    return url.replace(/^\/model/, `/model\/${mode}`);
   } else {
     return url;
   }

--- a/frontend/src/metabase/lib/urls/questions.ts
+++ b/frontend/src/metabase/lib/urls/questions.ts
@@ -54,6 +54,7 @@ export function question(
   }
 
   const isModel = card?.dataset || card?.model === "dataset";
+  let path = isModel ? "model" : "question";
   if (!card || !card.id) {
     return `/${path}${query}${hash}`;
   }
@@ -95,7 +96,6 @@ type NewQuestionUrlBuilderParams = QuestionCreatorOpts & {
   mode?: "view" | "notebook";
   creationType?: string;
   objectId?: number | string;
-  dataset?: true;
 };
 
 export function newQuestion({
@@ -109,11 +109,13 @@ export function newQuestion({
     creationType,
     query: objectId ? { objectId } : undefined,
   });
+
+  const entity = question.isDataset() ? "model" : "question";
+
   if (mode) {
-    const entity = question.isDataset() ? "model" : "question";
     return url.replace(/^\/(question|model)/, `/${entity}\/${mode}`);
   } else {
-    return url;
+    return url.replace(/^\/(question|model)/, `/${entity}`);
   }
 }
 

--- a/frontend/src/metabase/lib/urls/questions.ts
+++ b/frontend/src/metabase/lib/urls/questions.ts
@@ -115,7 +115,7 @@ export function newQuestion({
   if (mode) {
     return url.replace(/^\/(question|model)/, `/${entity}\/${mode}`);
   } else {
-    return url.replace(/^\/(question|model)/, `/${entity}`);
+    return url;
   }
 }
 

--- a/frontend/src/metabase/lib/urls/questions.ts
+++ b/frontend/src/metabase/lib/urls/questions.ts
@@ -117,23 +117,6 @@ export function newQuestion({
   }
 }
 
-export function newDataset({
-  mode,
-  creationType,
-  objectId,
-  ...options
-}: NewQuestionUrlBuilderParams = {}) {
-  const url = Question.create(options).getUrl({
-    creationType,
-    query: objectId ? { objectId } : undefined,
-  });
-  if (mode) {
-    return url.replace(/^\/model/, `/model\/${mode}`);
-  } else {
-    return url;
-  }
-}
-
 export function dataset(...args: Parameters<typeof question>) {
   return question(...args);
 }

--- a/frontend/src/metabase/lib/urls/questions.ts
+++ b/frontend/src/metabase/lib/urls/questions.ts
@@ -93,7 +93,7 @@ export function serializedQuestion(card: Card, opts = {}) {
 }
 
 type NewQuestionUrlBuilderParams = QuestionCreatorOpts & {
-  mode?: "view" | "notebook";
+  mode?: "view" | "notebook" | "query";
   creationType?: string;
   objectId?: number | string;
 };

--- a/frontend/src/metabase/new_query/containers/NewDatasetOptions.jsx
+++ b/frontend/src/metabase/new_query/containers/NewDatasetOptions.jsx
@@ -80,7 +80,7 @@ class NewDatasetOptions extends Component {
                 description={t`Use the advanced notebook editor to join data, create custom columns, do math, and more.`}
                 width={180}
                 to={Urls.newQuestion({
-                  mode: "notebook",
+                  mode: "query",
                   creationType: "custom_question",
                   dataset: true,
                 })}
@@ -95,6 +95,7 @@ class NewDatasetOptions extends Component {
                 title={t`Use a native query`}
                 description={t`For more complicated questions, you can write your own SQL or native query.`}
                 to={Urls.newQuestion({
+                  mode: "query",
                   type: "native",
                   creationType: "native_question",
                   dataset: true,

--- a/frontend/src/metabase/new_query/containers/NewDatasetOptions.jsx
+++ b/frontend/src/metabase/new_query/containers/NewDatasetOptions.jsx
@@ -1,0 +1,113 @@
+/* eslint-disable react/prop-types */
+import React, { Component } from "react";
+
+import { connect } from "react-redux";
+import { push } from "react-router-redux";
+
+import { t } from "ttag";
+
+import { Grid } from "metabase/components/Grid";
+
+import NewQueryOption from "metabase/new_query/components/NewQueryOption";
+import NoDatabasesEmptyState from "metabase/reference/databases/NoDatabasesEmptyState";
+
+import * as Urls from "metabase/lib/urls";
+
+import {
+  getHasDataAccess,
+  getHasNativeWrite,
+} from "metabase/new_query/selectors";
+import Database from "metabase/entities/databases";
+import {
+  QueryOptionsGridItem,
+  QueryOptionsRoot,
+} from "./NewQueryOptions.styled";
+
+const mapStateToProps = state => ({
+  hasDataAccess: getHasDataAccess(state),
+  hasNativeWrite: getHasNativeWrite(state),
+});
+
+const mapDispatchToProps = {
+  prefetchDatabases: () => Database.actions.fetchList(),
+  push,
+};
+
+class NewQueryOptions extends Component {
+  componentDidMount() {
+    // We need to check if any databases exist otherwise show an empty state.
+    // Be aware that the embedded version does not have the Navbar, which also
+    // loads databases, so we should not remove it.
+    this.props.prefetchDatabases();
+
+    const { location, push } = this.props;
+    if (Object.keys(location.query).length > 0) {
+      const { database, table, ...options } = location.query;
+      push(
+        Urls.newQuestion({
+          ...options,
+          databaseId: database ? parseInt(database) : undefined,
+          tableId: table ? parseInt(table) : undefined,
+        }),
+      );
+    }
+  }
+
+  render() {
+    const { hasDataAccess, hasNativeWrite } = this.props;
+
+    if (!hasDataAccess && !hasNativeWrite) {
+      return (
+        <div className="full-height flex align-center justify-center">
+          <NoDatabasesEmptyState />
+        </div>
+      );
+    }
+
+    {
+      /* Determine how many items will be shown based on permissions etc so we can make sure the layout adapts */
+    }
+    const itemsCount = (hasDataAccess ? 1 : 0) + (hasNativeWrite ? 1 : 0);
+
+    return (
+      <QueryOptionsRoot>
+        <Grid className="justifyCenter">
+          {hasDataAccess && (
+            <QueryOptionsGridItem itemsCount={itemsCount}>
+              <NewQueryOption
+                image="app/img/notebook_mode_illustration"
+                title={t`Use the notebook editor`}
+                description={t`Use the advanced notebook editor to join data, create custom columns, do math, and more.`}
+                width={180}
+                to={Urls.newDataset({
+                  mode: "notebook",
+                  creationType: "custom_question",
+                  dataset: true,
+                })}
+                data-metabase-event="New Dataset; Custom Question Start"
+              />
+            </QueryOptionsGridItem>
+          )}
+          {hasNativeWrite && (
+            <QueryOptionsGridItem itemsCount={itemsCount}>
+              <NewQueryOption
+                image="app/img/sql_illustration"
+                title={t`Use a native query`}
+                description={t`For more complicated questions, you can write your own SQL or native query.`}
+                to={Urls.newDataset({
+                  type: "native",
+                  creationType: "native_question",
+                  dataset: true,
+                })}
+                width={180}
+                data-metabase-event="New Dataset; Native Query Start"
+              />
+            </QueryOptionsGridItem>
+          )}
+        </Grid>
+      </QueryOptionsRoot>
+    );
+  }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(NewQueryOptions);

--- a/frontend/src/metabase/new_query/containers/NewDatasetOptions.jsx
+++ b/frontend/src/metabase/new_query/containers/NewDatasetOptions.jsx
@@ -33,7 +33,7 @@ const mapDispatchToProps = {
   push,
 };
 
-class NewQueryOptions extends Component {
+class NewDatasetOptions extends Component {
   componentDidMount() {
     // We need to check if any databases exist otherwise show an empty state.
     // Be aware that the embedded version does not have the Navbar, which also
@@ -79,7 +79,7 @@ class NewQueryOptions extends Component {
                 title={t`Use the notebook editor`}
                 description={t`Use the advanced notebook editor to join data, create custom columns, do math, and more.`}
                 width={180}
-                to={Urls.newDataset({
+                to={Urls.newQuestion({
                   mode: "notebook",
                   creationType: "custom_question",
                   dataset: true,
@@ -94,7 +94,7 @@ class NewQueryOptions extends Component {
                 image="app/img/sql_illustration"
                 title={t`Use a native query`}
                 description={t`For more complicated questions, you can write your own SQL or native query.`}
-                to={Urls.newDataset({
+                to={Urls.newQuestion({
                   type: "native",
                   creationType: "native_question",
                   dataset: true,
@@ -110,4 +110,4 @@ class NewQueryOptions extends Component {
   }
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(NewQueryOptions);
+export default connect(mapStateToProps, mapDispatchToProps)(NewDatasetOptions);

--- a/frontend/src/metabase/routes.jsx
+++ b/frontend/src/metabase/routes.jsx
@@ -42,6 +42,7 @@ import PulseEditApp from "metabase/pulse/containers/PulseEditApp";
 import SetupApp from "metabase/setup/containers/SetupApp";
 // new question
 import NewQueryOptions from "metabase/new_query/containers/NewQueryOptions";
+import NewDatasetOptions from "metabase/new_query/containers/NewDatasetOptions";
 
 import CreateDashboardModal from "metabase/components/CreateDashboardModal";
 
@@ -285,6 +286,11 @@ export const getRoutes = store => (
 
         <Route path="/model">
           <IndexRoute component={QueryBuilder} />
+          <Route
+            path="new"
+            title={t`New Model`}
+            component={NewDatasetOptions}
+          />
           <Route path="notebook" component={QueryBuilder} />
           <Route path=":slug" component={QueryBuilder} />
           <Route path=":slug/notebook" component={QueryBuilder} />


### PR DESCRIPTION
Solves https://github.com/metabase/metabase/issues/25602

### How to Test

1. `+New`
2. Model
3. Click on one of the two possible ways to create a model

As of now, both hrefs are pointing to `model/query#aHash`, and the hash for a visual query is different than the hash for a native query.

