### PR TITLE
Implement DB specific execution permissions

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions.clj
@@ -201,14 +201,9 @@
 
 (s/defn update-db-execute-permissions!
   "Update the DB details permissions for a database."
-  [group-id :- su/IntGreaterThanZero db-id :- su/IntGreaterThanZero new-perms :- perms/DetailsPermissions]
+  [group-id :- su/IntGreaterThanZero db-id :- su/IntGreaterThanZero new-perms :- perms/ExecutePermissions]
   (when-not (premium-features/enable-advanced-permissions?)
     (throw (perms/ee-permissions-exception :execute)))
-  (case new-perms
-    :all
-    (do
-      (revoke-permissions! :execute :all group-id db-id)
-      (grant-permissions! :execute :all group-id db-id))
-
-    :none
-    (revoke-permissions! :execute :all group-id db-id)))
+  (revoke-permissions! :execute :all group-id db-id)
+  (when (= new-perms :all)
+    (grant-permissions! :execute :all group-id db-id)))

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions_test.clj
@@ -234,6 +234,31 @@
                (ee-perms/update-db-details-permissions! group-id (mt/id) :yes))))))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                          DB execute permissions                                                |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+(defn- execute-perms-by-group-id [group-id]
+  (get-in (perms/execution-perms-graph) [:groups group-id (mt/id)]))
+
+(deftest update-db-execute-permissions-test
+  (mt/with-model-cleanup [Permissions]
+    (mt/with-temp PermissionsGroup [{group-id :id}]
+      (premium-features-test/with-premium-features #{:advanced-permissions}
+        (testing "Execute perms for a DB can be set and revoked"
+          (ee-perms/update-db-execute-permissions! group-id (mt/id) :all)
+          (is (= :all (execute-perms-by-group-id group-id)))
+
+          (ee-perms/update-db-execute-permissions! group-id (mt/id) :none)
+          (is (nil? (execute-perms-by-group-id group-id)))))
+
+      (premium-features-test/with-premium-features #{}
+        (testing "Execute permissions cannot be modified without the :advanced-permissions feature flag"
+          (is (thrown-with-msg?
+               clojure.lang.ExceptionInfo
+               #"The execute permissions functionality is only enabled if you have a premium token with the advanced-permissions feature."
+               (ee-perms/update-db-execute-permissions! group-id (mt/id) :all))))))))
+
+;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                                    Graph                                                       |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 

--- a/src/metabase/api/permission_graph.clj
+++ b/src/metabase/api/permission_graph.clj
@@ -36,6 +36,14 @@
   [[_ x]]
   x)
 
+(defmethod convert :global-execute
+  [[_ x]]
+  x)
+
+(defmethod convert :db-exeute
+  [[_ x]]
+  x)
+
 ;;; --------------------------------------------------- Common ----------------------------------------------------
 
 ;; ids come in asa keywordized numbers
@@ -84,20 +92,12 @@
 ;; language used on the frontend.
 (s/def ::details (s/or :str->kw #{"yes" "no"}))
 
-(s/def ::execute (s/or :str->kw #{"all" "none"}))
-
 (s/def ::db-perms (s/keys :opt-un [::data ::download ::data-model ::details ::execute]))
 
 (s/def ::db-graph
-  (s/and (s/map-of (s/or :global-execute #{:execute}
-                         :db-perms ::id)
-                   (s/or :global-execute ::execute
-                         :db-perms ::db-perms)
-                   :conform-keys true)
-         (s/conformer (fn [m]
-                        (if (every? (fn [[[key-tag] [value-tag]]] (= key-tag value-tag)) m)
-                          (into {} (map (partial mapv second)) m)
-                          :clojure.spec.alpha/invalid)))))
+  (s/map-of ::id
+            ::db-perms
+            :conform-keys true))
 
 (s/def :metabase.api.permission-graph.data/groups
   (s/map-of ::id ::db-graph
@@ -122,6 +122,23 @@
 
 (s/def ::collection-permissions-graph
   (s/keys :req-un [:metabase.api.permission-graph.collection/groups]))
+
+;;; --------------------------------------------- Execution Permissions ----------------------------------------------
+
+(s/def ::execute (s/or :str->kw #{"all" "none"}))
+
+(s/def ::execute-graph
+  (s/or :global-execute ::execute
+        :db-exeute      (s/map-of ::id ::execute
+                                  :conform-keys true)))
+
+(s/def :metabase.api.permission-graph.execution/groups
+  (s/map-of ::id
+            ::execute-graph
+            :conform-keys true))
+
+(s/def ::execution-permissions-graph
+  (s/keys :req-un [:metabase.api.permission-graph.execution/groups]))
 
 (defn converted-json->graph
   "The permissions graph is received as JSON. That JSON is naively converted. This performs a further conversion to

--- a/src/metabase/api/permissions.clj
+++ b/src/metabase/api/permissions.clj
@@ -214,4 +214,32 @@
     (db/delete! PermissionsGroupMembership :id id)
     api/generic-204-no-content))
 
+
+;;; ------------------------------------------- Execution Endpoints -------------------------------------------
+
+(api/defendpoint GET "/execution/graph"
+  "Fetch a graph of execution permissions."
+  []
+  (api/check-superuser)
+  (perms/execution-perms-graph))
+
+(api/defendpoint PUT "/execution/graph"
+  "Do a batch update of execution permissions by passing in a modified graph. The modified graph of the same
+  form as returned by the corresponding GET endpoint.
+
+  Revisions to the permissions graph are tracked. If you fetch the permissions graph and some other third-party
+  modifies it before you can submit you revisions, the endpoint will instead make no changes and return a
+  409 (Conflict) response. In this case, you should fetch the updated graph and make desired changes to that."
+  [:as {body :body}]
+  {body su/Map}
+  (api/check-superuser)
+  (let [graph (api.permission-graph/converted-json->graph ::api.permission-graph/execution-permissions-graph body)]
+    (when (= graph :clojure.spec.alpha/invalid)
+      (throw (ex-info (tru "Invalid execution permission graph: {0}"
+                           (s/explain-str ::api.permission-graph/execution-permissions-graph body))
+                      {:status-code 400
+                       :error       (s/explain-data ::api.permission-graph/execution-permissions-graph body)})))
+    (perms/update-execution-perms-graph! graph))
+  (perms/execution-perms-graph))
+
 (api/define-routes)

--- a/src/metabase/models/permissions.clj
+++ b/src/metabase/models/permissions.clj
@@ -666,6 +666,7 @@
    "Valid native perms option for a database"))
 
 (def ExecutePermissions
+  "Schema for execution permission values."
   (s/named
    (s/enum :all :none)
    "Valid execute perms option type"))

--- a/src/metabase/models/permissions.clj
+++ b/src/metabase/models/permissions.clj
@@ -1179,20 +1179,20 @@
 
 (s/defn ^:private update-group-permissions!
   [group-id :- su/IntGreaterThanZero new-group-perms :- StrictDBPermissionsGraph]
-  (doseq [[db-id new-db-perms] new-group-perms]
-    (doseq [[perm-type new-perms] new-db-perms]
-      (case perm-type
-        :data
-        (update-db-data-access-permissions! group-id db-id new-perms)
+  (doseq [[db-id new-db-perms] new-group-perms
+          [perm-type new-perms] new-db-perms]
+    (case perm-type
+      :data
+      (update-db-data-access-permissions! group-id db-id new-perms)
 
-        :download
-        (update-feature-level-permission! group-id db-id new-perms :download)
+      :download
+      (update-feature-level-permission! group-id db-id new-perms :download)
 
-        :data-model
-        (update-feature-level-permission! group-id db-id new-perms :data-model)
+      :data-model
+      (update-feature-level-permission! group-id db-id new-perms :data-model)
 
-        :details
-        (update-feature-level-permission! group-id db-id new-perms :details)))))
+      :details
+      (update-feature-level-permission! group-id db-id new-perms :details))))
 
 (defn update-global-execution-permission!
   "Set the global execution permission (\"/execute/\") for the group

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -1978,11 +1978,11 @@
                          (mt/user-http-request :rasta :post 403 execute-path
                                                {:parameters [{:id "my_id" :type :number/= :value 1}]})))))
               (testing "With execute rights on the DB"
-                (perms/update-global-execution-permission (:id (perms-group/all-users)) :all)
+                (perms/update-global-execution-permission! (:id (perms-group/all-users)) :all)
                 (try
                   (actions.test-util/with-actions-enabled
                     (is (= {:rows-affected 1}
                            (mt/user-http-request :rasta :post 200 execute-path
                                                  {:parameters [{:id "my_id" :type :number/= :value 1}]}))))
                   (finally
-                    (perms/update-global-execution-permission (:id (perms-group/all-users)) :none)))))))))))
+                    (perms/update-global-execution-permission! (:id (perms-group/all-users)) :none)))))))))))

--- a/test/metabase/api/permissions_test.clj
+++ b/test/metabase/api/permissions_test.clj
@@ -3,9 +3,11 @@
   (:require [clojure.test :refer :all]
             [medley.core :as m]
             [metabase.api.permissions :as api.permissions]
-            [metabase.models :refer [Database PermissionsGroup PermissionsGroupMembership Table User]]
+            [metabase.models :refer [Database Permissions PermissionsGroup PermissionsGroupMembership Table User]]
             [metabase.models.permissions :as perms]
             [metabase.models.permissions-group :as perms-group]
+            [metabase.plugins.classloader :as classloader]
+            [metabase.public-settings.premium-features-test :as premium-features-test]
             [metabase.test :as mt]
             [metabase.test.fixtures :as fixtures]
             [metabase.util :as u]
@@ -116,14 +118,15 @@
 (deftest update-perms-graph-test
   (testing "PUT /api/permissions/graph"
     (testing "make sure we can update the perms graph from the API"
-      (mt/with-temp PermissionsGroup [group]
-        (mt/user-http-request
-         :crowberto :put 200 "permissions/graph"
-         (assoc-in (perms/data-perms-graph)
-                   [:groups (u/the-id group) (mt/id) :data :schemas]
-                   {"PUBLIC" {(mt/id :venues) :all}}))
-        (is (= {(mt/id :venues) :all}
-               (get-in (perms/data-perms-graph) [:groups (u/the-id group) (mt/id) :data :schemas "PUBLIC"]))))
+      (let [db-id (mt/id :venues)]
+        (mt/with-temp PermissionsGroup [group]
+          (mt/user-http-request
+           :crowberto :put 200 "permissions/graph"
+           (assoc-in (perms/data-perms-graph)
+                     [:groups (u/the-id group) (mt/id) :data :schemas]
+                     {"PUBLIC" {db-id :all}}))
+          (is (= {db-id :all}
+                 (get-in (perms/data-perms-graph) [:groups (u/the-id group) (mt/id) :data :schemas "PUBLIC"])))))
 
       (testing "Table-specific perms"
         (mt/with-temp PermissionsGroup [group]
@@ -157,20 +160,78 @@
                    [:groups (u/the-id group) db-id :data :schemas]
                    :all))
         (is (= :all
-               (get-in (perms/data-perms-graph) [:groups (u/the-id group) db-id :data :schemas])))))
+               (get-in (perms/data-perms-graph) [:groups (u/the-id group) db-id :data :schemas])))))))
 
+(defn- ee-features-enabled? []
+  (u/ignore-exceptions
+   (classloader/require 'metabase-enterprise.advanced-permissions.models.permissions)
+   (some? (resolve 'metabase-enterprise.advanced-permissions.models.permissions/update-db-execute-permissions!))))
+
+(deftest update-execution-perms-graph-test
+  (mt/with-model-cleanup [Permissions]
     (testing "global execute permission"
-      (let [group-id (:id (perms-group/all-users))]
-        (try
-          (mt/user-http-request
-           :crowberto :put 200 "permissions/graph"
-           (assoc-in (perms/data-perms-graph)
-                     [:groups group-id :execute]
-                     :all))
-          (is (= :all
-                 (get-in (perms/data-perms-graph) [:groups group-id :execute])))
-          (finally
-            (perms/update-global-execution-permission group-id :none)))))))
+      (testing "without :advanced-permissions feature flag"
+        (testing "for All Users"
+          (let [group-id (:id (perms-group/all-users))]
+            (mt/user-http-request
+             :crowberto :put 200 "permissions/execution/graph"
+             (assoc-in (perms/execution-perms-graph) [:groups group-id] :all))
+            (is (= :all
+                   (get-in (perms/execution-perms-graph) [:groups group-id])))))
+        (testing "for non-magic group"
+          (mt/with-temp* [PermissionsGroup [{group-id :id}]]
+            (mt/user-http-request
+             :crowberto :put 402 "permissions/execution/graph"
+             (assoc-in (perms/execution-perms-graph) [:groups group-id] :all)))))
+
+      (when (ee-features-enabled?)
+        (testing "with :advanced-permissions feature flag"
+          (premium-features-test/with-premium-features #{:advanced-permissions}
+            (testing "for All Users"
+              (let [group-id (:id (perms-group/all-users))]
+                (mt/user-http-request
+                 :crowberto :put 200 "permissions/execution/graph"
+                 (assoc-in (perms/execution-perms-graph) [:groups group-id] :all))
+                (is (= :all
+                       (get-in (perms/execution-perms-graph) [:groups group-id])))))
+            (testing "for non-magic group"
+              (mt/with-temp* [PermissionsGroup [{group-id :id}]]
+                (mt/user-http-request
+                 :crowberto :put 200 "permissions/execution/graph"
+                 (assoc-in (perms/execution-perms-graph) [:groups group-id] :all))
+                (is (= :all
+                       (get-in (perms/execution-perms-graph) [:groups group-id])))))))))
+
+    (testing "DB execute permission"
+      (mt/with-temp* [PermissionsGroup [{group-id :id}]
+                      Database         [{db-id :id}]]
+        (testing "without :advanced-permissions feature flag"
+          (testing "for All Users"
+            (mt/user-http-request
+             :crowberto :put 402 "permissions/execution/graph"
+             (assoc-in (perms/execution-perms-graph) [:groups (:id (perms-group/all-users))] {db-id :all})))
+
+          (testing "for non-magic group"
+            (mt/user-http-request
+             :crowberto :put 402 "permissions/execution/graph"
+             (assoc-in (perms/execution-perms-graph) [:groups group-id db-id] :all))))
+
+        (when (ee-features-enabled?)
+          (testing "with :advanced-permissions feature flag"
+            (premium-features-test/with-premium-features #{:advanced-permissions}
+              (testing "for All Users"
+                (mt/user-http-request
+                 :crowberto :put 200 "permissions/execution/graph"
+                 (assoc-in (perms/execution-perms-graph) [:groups (:id (perms-group/all-users))] {db-id :all}))
+                (is (= :all
+                       (get-in (perms/execution-perms-graph) [:groups (:id (perms-group/all-users)) db-id]))))
+
+              (testing "for non-magic group"
+                (mt/user-http-request
+                 :crowberto :put 200 "permissions/execution/graph"
+                 (assoc-in (perms/execution-perms-graph) [:groups group-id] {db-id :all}))
+                (is (= :all
+                       (get-in (perms/execution-perms-graph) [:groups group-id db-id])))))))))))
 
 ;;; +---------------------------------------------- permissions membership apis -----------------------------------------------------------+
 

--- a/test/metabase/models/permissions_test.clj
+++ b/test/metabase/models/permissions_test.clj
@@ -674,13 +674,12 @@
   (testing "A \"/\" permission grants all dataset permissions"
     (mt/with-temp Database [{db-id :id}]
       (let [{:keys [group_id]} (db/select-one Permissions :object "/")]
-        (is (= {db-id    {:data       {:native  :write
-                                       :schemas :all}
-                          :download   {:native  :full
-                                       :schemas :full}
-                          :data-model {:schemas :all}
-                          :details    :yes}
-                :execute :all}
+        (is (= {db-id {:data       {:native  :write
+                                    :schemas :all}
+                       :download   {:native  :full
+                                    :schemas :full}
+                       :data-model {:schemas :all}
+                       :details    :yes}}
                (-> (perms/data-perms-graph)
                    (get-in [:groups group_id])
                    (select-keys [db-id :execute]))))))))


### PR DESCRIPTION
Fixes #25443. Part of the [Data Apps Permissions](https://www.notion.so/metabase/Implement-Data-Apps-Permissions-732e27313df14ec99a10d7603026a4f2) project.

This PR
- fixes some bugs,
- separates execution permissions from data permissions,
- adds the endpoint `/permissions/execution/graph` for querying and setting action execution permissions,
- adds advanced permissions functionality.

Block permissions are _not_ handled in this PR.
