### PR TITLE
docs - remove extra slash

### DIFF
--- a/docs/configuring-metabase/timezones.md
+++ b/docs/configuring-metabase/timezones.md
@@ -13,7 +13,7 @@ The following places where timezones are set can all impact the data you see:
 - `Database` - includes global database timezone settings, specific column type settings, and even individual data values.
 - `OS & JVM` - on whatever system is running Metabase the timezone settings of the Operating System as well as the Java Virtual Machine can impact your reports.
 - `Metabase` - inside Metabase the reporting timezone setting (if set) will influence how your data is reported.
-- `Metabase Cloud` - if you need to change the timezone on the server that hosts your Metabase Cloud instance, please [contact support](https://www.metabase.com//help-premium).
+- `Metabase Cloud` - if you need to change the timezone on the server that hosts your Metabase Cloud instance, please [contact support](https://www.metabase.com/help-premium).
 
 To ensure proper reporting it's important that timezones be set consistently in all places. Metabase recommends the following settings:
 

--- a/docs/people-and-groups/managing.md
+++ b/docs/people-and-groups/managing.md
@@ -59,7 +59,7 @@ To reset a password for someone, just click the three dots icon next to their ac
 
 ### Resetting the admin password
 
-If you're using Metabase Cloud, [contact support](https://www.metabase.com//help-premium) to reset your admin password.
+If you're using Metabase Cloud, [contact support](https://www.metabase.com/help-premium) to reset your admin password.
 
 If you're a Metabase admin and have access to the server console, you can get Metabase to send you a password reset token:
 

--- a/docs/people-and-groups/saml-okta.md
+++ b/docs/people-and-groups/saml-okta.md
@@ -106,7 +106,7 @@ This expression will return a list of strings containing User Group names that t
 For common issues, go to [Troubleshooting SAML][troubleshooting-saml].
 
 [enabling-saml-in-metabase]: ./authenticating-with-saml.md#enabling-saml-authentication-in-metabase
-[okta-saml-docs]: https:/help.okta.com/en-us/Content/Topics/Apps/Apps_App_Integration_Wizard_SAML.htm
+[okta-saml-docs]: https://help.okta.com/en-us/Content/Topics/Apps/Apps_App_Integration_Wizard_SAML.htm
 [okta-create-attribute-statement]: https://support.okta.com/help/s/article/How-to-define-and-configure-a-custom-SAML-attribute-statement
 [saml-doc]: ./authenticating-with-saml.md
 [site-url]: ../configuring-metabase/settings.md#site-url

--- a/docs/people-and-groups/saml-okta.md
+++ b/docs/people-and-groups/saml-okta.md
@@ -106,7 +106,7 @@ This expression will return a list of strings containing User Group names that t
 For common issues, go to [Troubleshooting SAML][troubleshooting-saml].
 
 [enabling-saml-in-metabase]: ./authenticating-with-saml.md#enabling-saml-authentication-in-metabase
-[okta-saml-docs]: https://help.okta.com/en-us/Content/Topics/Apps/Apps_App_Integration_Wizard_SAML.htm
+[okta-saml-docs]: https:/help.okta.com/en-us/Content/Topics/Apps/Apps_App_Integration_Wizard_SAML.htm
 [okta-create-attribute-statement]: https://support.okta.com/help/s/article/How-to-define-and-configure-a-custom-SAML-attribute-statement
 [saml-doc]: ./authenticating-with-saml.md
 [site-url]: ../configuring-metabase/settings.md#site-url

--- a/docs/troubleshooting-guide/cant-log-in.md
+++ b/docs/troubleshooting-guide/cant-log-in.md
@@ -78,7 +78,7 @@ If you can’t solve your problem using the troubleshooting guides:
 [cloud-docs]: https://www.metabase.com/cloud/docs/
 [config-settings]: ../configuring-metabase/settings.md
 [discourse]: https://discourse.metabase.com/
-[help-premium]: https://www.metabase.com//help-premium
+[help-premium]: https://www.metabase.com/help-premium
 [how-to-delete-an-account]: ../people-and-groups/managing.md#deleting-an-account
 [how-to-find-auth-method-for-an-account]: ../people-and-groups/managing.md#checking-someones-auth-method
 [how-to-reactivate-account]: ../people-and-groups/managing.md#reactivating-an-account


### PR DESCRIPTION
Some links could stand to lose some slashes. These links are already fixed in the release branch.