### PR TITLE
Model Actions: View Actions List

### DIFF
--- a/frontend/src/metabase-types/api/writeback.ts
+++ b/frontend/src/metabase-types/api/writeback.ts
@@ -68,3 +68,15 @@ export type ArbitraryParameterForActionExecution =
   ParameterForActionExecutionBase & {
     target: ParameterTarget;
   };
+
+export interface ModelAction {
+  id: number;
+  action_id?: number; // empty for implicit actions
+  name?: string; // empty for implicit actions
+  card_id: number; // the card id of the model
+  entity_id: string;
+  requires_pk: boolean;
+  slug: string;
+  parameter_mappings?: ParameterMappings;
+  visualization_settings?: ActionFormSettings;
+}

--- a/frontend/src/metabase/entities/actions/actions.ts
+++ b/frontend/src/metabase/entities/actions/actions.ts
@@ -2,13 +2,14 @@ import { createEntity } from "metabase/lib/entities";
 
 import type { ActionFormSettings } from "metabase-types/api";
 
-import { CardApi, ModelActionsApi } from "metabase/services";
+import { ActionsApi, CardApi, ModelActionsApi } from "metabase/services";
 
 import {
   removeOrphanSettings,
   addMissingSettings,
   setParameterTypesFromFieldSettings,
   setTemplateTagTypesFromFieldSettings,
+  mapModelActionsToActions,
 } from "metabase/entities/actions/utils";
 import type Question from "metabase-lib/lib/Question";
 import { saveForm, updateForm } from "./forms";
@@ -88,6 +89,18 @@ const Actions = createEntity({
       return card;
     },
     update: updateAction,
+    list: async (props: any) => {
+      const { modelId } = props;
+
+      if (modelId) {
+        const modelActions = await ModelActionsApi.getModelActions({
+          id: modelId,
+        });
+        return modelActions.map(mapModelActionsToActions);
+      }
+
+      return ActionsApi.list(props);
+    },
   },
   forms: {
     saveForm,

--- a/frontend/src/metabase/entities/actions/utils.ts
+++ b/frontend/src/metabase/entities/actions/utils.ts
@@ -4,6 +4,7 @@ import type {
   FieldType,
   InputType,
   ParameterType,
+  ModelAction,
 } from "metabase-types/api";
 
 import { getDefaultFieldSettings } from "metabase/writeback/components/ActionCreator/FormCreator";
@@ -108,3 +109,9 @@ export const setTemplateTagTypesFromFieldSettings = (
 
   return question;
 };
+
+export const mapModelActionsToActions = (modelAction: ModelAction) => ({
+  ...modelAction,
+  model_action_id: modelAction.id,
+  id: modelAction.action_id,
+});

--- a/frontend/src/metabase/entities/actions/utils.unit.spec.ts
+++ b/frontend/src/metabase/entities/actions/utils.unit.spec.ts
@@ -6,12 +6,14 @@ import {
 import { metadata } from "__support__/sample_database_fixture";
 import type { Parameter as ParameterObject } from "metabase-types/types/Parameter";
 import { NativeDatasetQuery } from "metabase-types/types/Card";
+import { ModelAction } from "metabase-types/api";
 import Question from "metabase-lib/lib/Question";
 
 import {
   removeOrphanSettings,
   setParameterTypesFromFieldSettings,
   setTemplateTagTypesFromFieldSettings,
+  mapModelActionsToActions,
 } from "./utils";
 
 const creatQuestionWithTemplateTags = (tagType: string) =>
@@ -210,6 +212,38 @@ describe("entities > actions > utils", () => {
 
       expect(tags.name.type).toEqual("date");
       expect(tags.price.type).toEqual("date");
+    });
+  });
+
+  describe("mapModelActionsToAction", () => {
+    it("puts action_id into the id property", () => {
+      const modelAction = {
+        id: 123,
+        card_id: 456,
+        action_id: 789,
+        slug: "slug_name",
+        name: "Action Name",
+      };
+
+      const action = mapModelActionsToActions(modelAction as ModelAction);
+
+      expect(action.id).toEqual(789);
+      expect(action.model_action_id).toEqual(123);
+      expect(action.name).toEqual("Action Name");
+    });
+
+    it("preserves name property", () => {
+      const modelAction = {
+        id: 123,
+        card_id: 456,
+        action_id: 789,
+        slug: "slug_name",
+        name: "Action Name",
+      };
+
+      const action = mapModelActionsToActions(modelAction as ModelAction);
+
+      expect(action.name).toEqual("Action Name");
     });
   });
 });

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionDetails.styled.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionDetails.styled.tsx
@@ -15,7 +15,7 @@ export const ActionListItem = styled(Link)`
 
   width: 100%;
   border-radius: 8px;
-  padding: 1rem 0.5rem;
+  padding: 1rem;
 
   ${ActionTitle} {
     margin-left: 1rem;

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionDetails.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionDetails.tsx
@@ -1,27 +1,49 @@
 import React from "react";
+import { t } from "ttag";
 
+import Button from "metabase/core/components/Button";
+import Link from "metabase/core/components/Link";
 import Icon from "metabase/components/Icon";
 
 import Actions from "metabase/entities/actions";
+import { humanize } from "metabase/lib/formatting";
 
-import type { WritebackQueryAction } from "metabase-types/api";
+import type { ModelAction } from "metabase-types/api";
+import type { State } from "metabase-types/store";
 import type Question from "metabase-lib/lib/Question";
 
+import {
+  EmptyStateContainer,
+  EmptyStateTitle,
+} from "../ModelDetailPage.styled";
 import { ActionListItem, ActionTitle } from "./ModelActionDetails.styled";
 
 interface Props {
   model: Question;
-  actions: WritebackQueryAction[];
+  actions: ModelAction[];
 }
 
 function ModelActionDetails({ actions }: Props) {
+  if (!actions?.length) {
+    return (
+      <EmptyStateContainer>
+        <EmptyStateTitle>{t`This model does not have any actions yet.`}</EmptyStateTitle>
+        <Button
+          as={Link}
+          to={`/action/create`}
+          icon="add"
+        >{t`Create a new action`}</Button>
+      </EmptyStateContainer>
+    );
+  }
+
   return (
     <ul>
       {actions.map(action => (
         <li key={action.id}>
-          <ActionListItem to={`/action/${action.id}`}>
+          <ActionListItem to={`/action/${action.action_id}`}>
             <Icon name="insight" />
-            <ActionTitle>{action.name}</ActionTitle>
+            <ActionTitle>{action.name ?? humanize(action.slug)}</ActionTitle>
           </ActionListItem>
         </li>
       ))}
@@ -29,4 +51,8 @@ function ModelActionDetails({ actions }: Props) {
   );
 }
 
-export default Actions.loadList()(ModelActionDetails);
+export default Actions.loadList({
+  query: (state: State, props: { modelId?: number | null }) => ({
+    modelId: props?.modelId,
+  }),
+})(ModelActionDetails);

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailPage.styled.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailPage.styled.tsx
@@ -52,3 +52,21 @@ export const TabPanel = styled(BaseTabPanel)`
   display: flex;
   flex-direction: column;
 `;
+
+export const EmptyStateContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  margin-top: 3rem;
+`;
+
+export const EmptyStateTitle = styled.span`
+  display: block;
+  color: ${color("text-medium")};
+  font-size: 1rem;
+  line-height: 1.5rem;
+  margin-bottom: 1rem;
+  text-align: center;
+`;

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailPage.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailPage.tsx
@@ -78,7 +78,7 @@ function ModelDetailPage({ model, mainTable, onChangeModel }: Props) {
             options={[
               { value: "usage", name: t`Used by` },
               { value: "schema", name: t`Schema` },
-              // { value: "actions", name: t`Actions` },
+              { value: "actions", name: t`Actions` },
             ]}
             onChange={tab => setTab(tab as ModelTab)}
           />
@@ -89,7 +89,7 @@ function ModelDetailPage({ model, mainTable, onChangeModel }: Props) {
             <ModelSchemaDetails model={model} />
           </TabPanel>
           <TabPanel value="actions">
-            <ModelActionDetails model={model} />
+            <ModelActionDetails modelId={model.id()} />
           </TabPanel>
         </TabContent>
       </ModelMain>

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelUsageDetails/ModelUsageDetails.styled.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelUsageDetails/ModelUsageDetails.styled.tsx
@@ -25,21 +25,3 @@ export const CardListItem = styled(Link)`
     background-color: ${color("brand-light")};
   }
 `;
-
-export const EmptyStateContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-
-  margin-top: 3rem;
-`;
-
-export const EmptyStateTitle = styled.span`
-  display: block;
-  color: ${color("text-medium")};
-  font-size: 1rem;
-  line-height: 1.5rem;
-  margin-bottom: 1rem;
-  text-align: center;
-`;

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelUsageDetails/ModelUsageDetails.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelUsageDetails/ModelUsageDetails.tsx
@@ -17,13 +17,13 @@ import type { State } from "metabase-types/store";
 import type { Card as LegacyCardType } from "metabase-types/types/Card";
 import type Question from "metabase-lib/lib/Question";
 
-import { isQuestionUsingModel } from "./utils";
 import {
-  CardListItem,
-  CardTitle,
   EmptyStateContainer,
   EmptyStateTitle,
-} from "./ModelUsageDetails.styled";
+} from "../ModelDetailPage.styled";
+
+import { isQuestionUsingModel } from "./utils";
+import { CardListItem, CardTitle } from "./ModelUsageDetails.styled";
 
 interface OwnProps {
   model: Question;

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -537,6 +537,7 @@ function setParamsEndpoints(prefix) {
 }
 
 export const ActionsApi = {
+  list: GET("/api/action"),
   create: POST("/api/action/row/create"),
   update: POST("/api/action/row/update"),
   delete: POST("/api/action/row/delete"),
@@ -548,7 +549,7 @@ export const ActionsApi = {
 };
 
 export const ModelActionsApi = {
-  getModelActions: GET("/api/model-action"),
+  getModelActions: GET("/api/model-action?card-id=:id"),
   connectActionToModel: POST("/api/model-action"),
   updateConnection: PUT("/api/model-action/:id"),
   disconnectActionFromModel: POST("/api/model-action"),


### PR DESCRIPTION
## Description

Nothing fancy here, just uses the `model-actions` GET endpoint to get actions associated with a particular model and displays them as links on the model detail page under the "actions" tab.

![Screen Shot 2022-09-27 at 10 25 29 AM](https://user-images.githubusercontent.com/30528226/192582355-7a8a5f3a-41c3-4c09-a04e-3108e3b270df.png)

We also get a nice empty state that matches the empty state for the usage tab

![Screen Shot 2022-09-27 at 10 38 10 AM](https://user-images.githubusercontent.com/30528226/192585231-2747f41d-9713-4b3c-ba61-000c2545d1da.png)


## Testing steps

- save an action in a model
- navigate to the action detail page and click on the actions tab
- see your action!
- click your action! it should take you to the editor


