### PR TITLE
Adding missing placeholders to various viz settings

### DIFF
--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx
@@ -376,6 +376,7 @@ const RuleEditor = ({
               type="number"
               value={rule.value}
               onChange={value => onChange({ ...rule, value })}
+              placeholder="0"
             />
           ) : hasOperand ? (
             <input
@@ -383,6 +384,7 @@ const RuleEditor = ({
               className={INPUT_CLASSNAME}
               value={rule.value}
               onChange={e => onChange({ ...rule, value: e.target.value })}
+              placeholder={t`Column value`}
             />
           ) : null}
           <h3 className="mt3 mb1">{t`…turn its background this color:`}</h3>

--- a/frontend/src/metabase/visualizations/lib/settings/column.js
+++ b/frontend/src/metabase/visualizations/lib/settings/column.js
@@ -391,7 +391,7 @@ export const NUMBER_COLUMN_SETTINGS = {
     widget: "number",
     variant: "form-field",
     props: {
-      placeholder: t`Min.`,
+      placeholder: "1",
     },
   },
   scale: {

--- a/frontend/src/metabase/visualizations/lib/settings/column.js
+++ b/frontend/src/metabase/visualizations/lib/settings/column.js
@@ -390,6 +390,9 @@ export const NUMBER_COLUMN_SETTINGS = {
     title: t`Minimum number of decimal places`,
     widget: "number",
     variant: "form-field",
+    props: {
+      placeholder: t`Min.`,
+    },
   },
   scale: {
     title: t`Multiply by a number`,
@@ -403,11 +406,17 @@ export const NUMBER_COLUMN_SETTINGS = {
     title: t`Add a prefix`,
     widget: "input",
     variant: "form-field",
+    props: {
+      placeholder: t`$`,
+    },
   },
   suffix: {
     title: t`Add a suffix`,
     widget: "input",
     variant: "form-field",
+    props: {
+      placeholder: t`dollars`,
+    },
   },
   // Optimization: build a single NumberFormat object that is used by formatting.js
   _numberFormatter: {

--- a/frontend/src/metabase/visualizations/lib/settings/column.js
+++ b/frontend/src/metabase/visualizations/lib/settings/column.js
@@ -407,7 +407,7 @@ export const NUMBER_COLUMN_SETTINGS = {
     widget: "input",
     variant: "form-field",
     props: {
-      placeholder: t`$`,
+      placeholder: "$",
     },
   },
   suffix: {

--- a/frontend/src/metabase/visualizations/visualizations/List.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/List.tsx
@@ -177,6 +177,9 @@ export default Object.assign(ListViz, {
       getHidden: (_: unknown, settings: VisualizationSettings) =>
         settings["view_as"] !== "link" && settings["view_as"] !== "email_link",
       readDependencies: ["view_as"],
+      props: {
+        placeholder: t`Link to {{bird_id}}`,
+      },
     };
 
     settings["link_url"] = {
@@ -187,6 +190,9 @@ export default Object.assign(ListViz, {
       getHidden: (_: unknown, settings: VisualizationSettings) =>
         settings["view_as"] !== "link",
       readDependencies: ["view_as"],
+      props: {
+        placeholder: t`http://toucan.example/{{bird_id}}`,
+      },
     };
 
     return settings;

--- a/frontend/src/metabase/visualizations/visualizations/Table.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Table.jsx
@@ -292,6 +292,9 @@ export default class Table extends Component {
       getHidden: (_, settings) =>
         settings["view_as"] !== "link" && settings["view_as"] !== "email_link",
       readDependencies: ["view_as"],
+      props: {
+        placeholder: t`Link to {{bird_id}}`,
+      },
     };
 
     settings["link_url"] = {
@@ -301,6 +304,9 @@ export default class Table extends Component {
       default: null,
       getHidden: (_, settings) => settings["view_as"] !== "link",
       readDependencies: ["view_as"],
+      props: {
+        placeholder: t`http://toucan.example/{{bird_id}}`,
+      },
     };
 
     return settings;


### PR DESCRIPTION
#### Link
- EPIC #25453
- [Product doc](https://www.notion.so/metabase/Improve-the-visualization-settings-user-experience-8e1fb8fadb3f4cd9ba79e3bad7b2847b#5eb050e11bea4dec94efa0369d77d6ea)
- [Slack convo about link placeholder](https://metaboat.slack.com/archives/C03SD8HDJLC/p1664286752122289)

PR to add in some missing placeholders.

Number column settings:
![image](https://user-images.githubusercontent.com/1328979/192590411-3d5cd3c5-577c-4022-aa30-39a0ee4ffbef.png)

Display as `link`:
![image](https://user-images.githubusercontent.com/1328979/192590344-e71c7977-c0e0-4392-b872-aaab08085b02.png)

