### PR TITLE
Chaninging Pivot Table viz settings labels

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -44,21 +44,21 @@ const partitions = [
     name: "rows",
     columnFilter: isDimension,
     title: (
-      <PivotTableSettingLabel>{t`Fields to use for the table rows`}</PivotTableSettingLabel>
+      <PivotTableSettingLabel data-testId="pivot-table-setting">{t`Rows`}</PivotTableSettingLabel>
     ),
   },
   {
     name: "columns",
     columnFilter: isDimension,
     title: (
-      <PivotTableSettingLabel>{t`Fields to use for the table columns`}</PivotTableSettingLabel>
+      <PivotTableSettingLabel data-testId="pivot-table-setting">{t`Columns`}</PivotTableSettingLabel>
     ),
   },
   {
     name: "values",
     columnFilter: col => !isDimension(col),
     title: (
-      <PivotTableSettingLabel>{t`Fields to use for the table values`}</PivotTableSettingLabel>
+      <PivotTableSettingLabel data-testId="pivot-table-setting">{t`Measures`}</PivotTableSettingLabel>
     ),
   },
 ];

--- a/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
@@ -901,15 +901,15 @@ function assertOnPivotSettings() {
   cy.log("Implicit side-bar assertions");
   cy.findByText(/Pivot Table options/i);
 
-  cy.findAllByText(/Fields to use for the table/).eq(0);
+  cy.findAllByTestId("pivot-table-setting").eq(0);
   cy.get("@fieldOption")
     .eq(0)
     .contains(/Users? → Source/);
-  cy.findAllByText(/Fields to use for the table/).eq(1);
+  cy.findAllByTestId("pivot-table-setting").eq(1);
   cy.get("@fieldOption")
     .eq(1)
     .contains(/Products? → Category/);
-  cy.findAllByText(/Fields to use for the table/).eq(2);
+  cy.findAllByTestId("pivot-table-setting").eq(2);
   cy.get("@fieldOption").eq(2).contains("Count");
 }
 


### PR DESCRIPTION
EPIC #25453 

Small PR to change the copy used in Pivot Table Viz Settings. Needed to add test id's as the existing tests were looking for the old text.

![image](https://user-images.githubusercontent.com/1328979/192591403-d6e52719-effe-458a-a1c6-60b8f2dfe0dd.png)
