### PR TITLE
Changing axis label copy in Viz Settings

### DIFF
--- a/frontend/src/metabase/visualizations/lib/settings/series.js
+++ b/frontend/src/metabase/visualizations/lib/settings/series.js
@@ -109,7 +109,7 @@ export function seriesSetting({
       readDependencies: ["display"],
     },
     axis: {
-      title: t`Which axis?`,
+      title: t`Y-axis position`,
       widget: "segmentedControl",
       default: null,
       props: {

--- a/frontend/test/metabase/scenarios/visualizations/reproductions/17619-line-more-options.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/reproductions/17619-line-more-options.cy.spec.js
@@ -32,7 +32,7 @@ describe("issue 17619", () => {
     cy.findByText("Line style");
     cy.findByText("Show dots on lines");
     cy.findByText("Replace missing values with");
-    cy.findByText("Which axis?");
+    cy.findByText("Y-axis position");
     cy.findByText("Show values for this series");
 
     cy.icon("chevronup");


### PR DESCRIPTION
EPIC #25453 
[Product doc](https://www.notion.so/metabase/Improve-the-visualization-settings-user-experience-8e1fb8fadb3f4cd9ba79e3bad7b2847b#976ec63bd1f64afe8aaa005375e087da)

PR to update the copy for the `axis` setting in a series.

Single series:
![image](https://user-images.githubusercontent.com/1328979/192603212-d9b8e3c4-2696-4bac-ba98-91ca4682bbb2.png)

Multiple series:
![image](https://user-images.githubusercontent.com/1328979/192603286-78906e77-cc54-4ba0-bb27-fb0d18d1ed03.png)
