### PR TITLE
Fix validation for the saml form

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx
@@ -49,6 +49,7 @@ class SettingsSAMLForm extends Component {
         className="mx2"
         style={{ maxWidth: 520 }}
         initialValues={initialValues}
+        overwriteOnInitialValuesChange
         onSubmit={updateSettings}
       >
         <Breadcrumbs
@@ -70,7 +71,7 @@ class SettingsSAMLForm extends Component {
           <h3 className="mb0">{t`Configure your identity provider (IdP)`}</h3>
           <p className="mb4 mt1 text-medium">{t`Your identity provider will need the following info about Metabase.`}</p>
 
-          <div className="Form-field" s>
+          <div className="Form-field">
             <div className="Form-label">{t`URL the IdP should redirect back to`}</div>
             <div className="pb1">{t`This is called the Single Sign On URL in Okta, the Application Callback URL in Auth0,
                                   and the ACS (Consumer) URL in OneLogin. `}</div>


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/24738

How to test:
- Run Metabase EE
- Go to Admin -> Settings -> Authentication -> SAML
- Enter something in `SAML Identity Provider URL` and `SAML Identity Provider Certificate`
- You should be able to click on `Save changes`, it shouldn't say that the required fields are missing