### PR TITLE
Fix login form when ldap is enabled but password login is disabled

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/auth/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/auth/index.js
@@ -258,7 +258,10 @@ PLUGIN_AUTH_PROVIDERS.push(providers => {
   if (MetabaseSettings.get("other-sso-configured?")) {
     providers = [SSO_PROVIDER, ...providers];
   }
-  if (!MetabaseSettings.isPasswordLoginEnabled()) {
+  if (
+    !MetabaseSettings.isPasswordLoginEnabled() &&
+    !MetabaseSettings.isLdapConfigured()
+  ) {
     providers = providers.filter(p => p.name !== "password");
   }
   return providers;


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/25661

Please note that due to recent LDAP changes we need to fix the issue separately for 0.44 and 0.45 (master). I'll add e2e tests in master.

How to test:
- Run a test ldap server ` docker run -p 389:389 osixia/openldap:1.5.0`
- Run Metabase EE
- Go to Admin -> Settings -> Authentication -> LDAP and establish connection with the following settings
```
{
    "ldap-enabled": true,
    "ldap-host": "localhost",
    "ldap-port": "389",
    "ldap-bind-dn": "cn=admin,dc=example,dc=org",
    "ldap-password": "admin",
    "ldap-user-base": "dc=example,dc=org",
  }
```
- Go to Admin -> Settings -> Authentication and disable password login
- Log out and make sure the login form is not shown correctly (it's not possible to login with this test ldap server without providing user data)
