### PR TITLE
Stop a few unnecessary query reruns in Models

### DIFF
--- a/frontend/src/metabase/query_builder/actions/core/core.js
+++ b/frontend/src/metabase/query_builder/actions/core/core.js
@@ -23,6 +23,7 @@ import Query from "metabase-lib/lib/queries/Query";
 import { trackNewQuestionSaved } from "../../analytics";
 import {
   getCard,
+  getIsResultDirty,
   getOriginalQuestion,
   getQuestion,
   getResultsMetadata,
@@ -210,10 +211,12 @@ export const apiCreateQuestion = question => {
 };
 
 export const API_UPDATE_QUESTION = "metabase/qb/API_UPDATE_QUESTION";
-export const apiUpdateQuestion = (question, { rerunQuery = false } = {}) => {
+export const apiUpdateQuestion = (question, { rerunQuery } = {}) => {
   return async (dispatch, getState) => {
     const originalQuestion = getOriginalQuestion(getState());
     question = question || getQuestion(getState());
+
+    rerunQuery = rerunQuery || getIsResultDirty(getState());
 
     // Needed for persisting visualization columns for pulses/alerts, see #6749
     const series = getTransformedSeries(getState());

--- a/frontend/src/metabase/query_builder/actions/models.js
+++ b/frontend/src/metabase/query_builder/actions/models.js
@@ -12,7 +12,7 @@ import { getMetadata } from "metabase/selectors/metadata";
 import { getOriginalCard, getQuestion, getResultsMetadata } from "../selectors";
 
 import { apiUpdateQuestion, updateQuestion, API_UPDATE_QUESTION } from "./core";
-import { runQuestionQuery } from "./querying";
+import { runDirtyQuestionQuery } from "./querying";
 import { setQueryBuilderMode } from "./ui";
 
 export const setDatasetEditorTab = datasetEditorTab => dispatch => {
@@ -25,7 +25,7 @@ export const onCancelDatasetChanges = () => (dispatch, getState) => {
   dispatch.action(CANCEL_DATASET_CHANGES, {
     card: cardBeforeChanges,
   });
-  dispatch(runQuestionQuery());
+  dispatch(runDirtyQuestionQuery());
 };
 
 export const turnQuestionIntoDataset = () => async (dispatch, getState) => {
@@ -63,7 +63,7 @@ export const turnDatasetIntoQuestion = () => async (dispatch, getState) => {
   dispatch(
     addUndo({
       message: t`This is a question now.`,
-      actions: [apiUpdateQuestion(dataset, { rerunQuery: true })],
+      actions: [apiUpdateQuestion(dataset)],
     }),
   );
 };

--- a/frontend/src/metabase/query_builder/actions/querying.js
+++ b/frontend/src/metabase/query_builder/actions/querying.js
@@ -22,6 +22,7 @@ import {
   getQueryResults,
   getQuestion,
   getTimeoutId,
+  getIsResultDirty,
 } from "../selectors";
 
 import { updateUrl } from "./navigation";
@@ -72,6 +73,19 @@ const loadCompleteUIControls = createThunkAction(
     }
   },
 );
+
+export const runDirtyQuestionQuery = () => async (dispatch, getState) => {
+  const areResultsDirty = getIsResultDirty(getState());
+  const queryResults = getQueryResults(getState());
+  const hasResults = !!queryResults;
+
+  if (hasResults && !areResultsDirty) {
+    const question = getQuestion(getState());
+    return dispatch(queryCompleted(question, queryResults));
+  }
+
+  return dispatch(runQuestionQuery());
+};
 
 /**
  * Queries the result for the currently active question or alternatively for the card provided in `overrideWithCard`.

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
@@ -304,7 +304,7 @@ function DatasetEditor(props) {
 
   const handleSave = useCallback(async () => {
     if (checkCanBeModel(dataset)) {
-      await onSave(dataset.card(), { rerunQuery: true });
+      await onSave(dataset.card());
       setQueryBuilderMode("view");
     } else {
       onOpenModal(MODAL_TYPES.CAN_NOT_CREATE_MODEL);

--- a/frontend/src/metabase/query_builder/reducers.js
+++ b/frontend/src/metabase/query_builder/reducers.js
@@ -413,7 +413,6 @@ export const lastRunCard = handleActions(
     [RESET_QB]: { next: (state, { payload }) => null },
     [QUERY_COMPLETED]: { next: (state, { payload }) => payload.card },
     [QUERY_ERRORED]: { next: (state, { payload }) => null },
-    [CANCEL_DATASET_CHANGES]: { next: () => null },
   },
   null,
 );
@@ -453,7 +452,6 @@ export const queryResults = handleActions(
       },
     },
     [CLEAR_QUERY_RESULT]: { next: (state, { payload }) => null },
-    [CANCEL_DATASET_CHANGES]: { next: () => null },
   },
   null,
 );

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -378,36 +378,50 @@ function areQueriesEqual(queryA, queryB, tableMetadata) {
   return _.isEqual(normalizedQueryA, normalizedQueryB);
 }
 
+// Model questions may be composed via the `composeDataset` method.
+// A composed model question should be treated as equivalent to its original form.
+// We need to handle scenarios where both the `lastRunQuestion` and the `currentQuestion` are
+// in either form.
 function areModelsEquivalent({
   originalQuestion,
   lastRunQuestion,
   currentQuestion,
   tableMetadata,
 }) {
-  if (!originalQuestion?.isDataset()) {
+  if (!lastRunQuestion || !currentQuestion || !originalQuestion?.isDataset()) {
     return false;
   }
 
-  // When viewing a model, its dataset_query is swapped with a clean query using the dataset as a source table
-  // (it's necessary for datasets to behave like tables opened in simple mode)
-  // We need to escape the isDirty check as it will always be true in this case,
-  // and the page will always be covered with a 'rerun' overlay.
-  // Once the dataset_query changes, the question will loose the "dataset" flag and it'll work normally
-  const isCurrentEquivalentToOriginal =
-    currentQuestion && isAdHocModelQuestion(currentQuestion, originalQuestion);
+  const composedOriginal = originalQuestion.composeDataset();
 
-  // When editing a model, the `currentQuestion` reverts to the form of the original question,
-  // but the model query might've already been run in its "ad-hoc" form.
-  const isLastRunUnchangedFromOriginal =
-    lastRunQuestion &&
-    isAdHocModelQuestion(lastRunQuestion, originalQuestion) &&
+  const isLastRunComposed = areQueriesEqual(
+    lastRunQuestion.datasetQuery(),
+    composedOriginal.datasetQuery(),
+    tableMetadata,
+  );
+  const isCurrentComposed = areQueriesEqual(
+    currentQuestion.datasetQuery(),
+    composedOriginal.datasetQuery(),
+    tableMetadata,
+  );
+
+  const isLastRunEquivalentToCurrent =
+    isLastRunComposed &&
     areQueriesEqual(
       currentQuestion.datasetQuery(),
       originalQuestion.datasetQuery(),
       tableMetadata,
     );
 
-  return isCurrentEquivalentToOriginal || isLastRunUnchangedFromOriginal;
+  const isCurrentEquivalentToLastRun =
+    isCurrentComposed &&
+    areQueriesEqual(
+      lastRunQuestion.datasetQuery(),
+      originalQuestion.datasetQuery(),
+      tableMetadata,
+    );
+
+  return isLastRunEquivalentToCurrent || isCurrentEquivalentToLastRun;
 }
 
 function areQueriesEquivalent({
@@ -417,17 +431,17 @@ function areQueriesEquivalent({
   tableMetadata,
 }) {
   return (
+    areQueriesEqual(
+      lastRunQuestion?.datasetQuery(),
+      currentQuestion?.datasetQuery(),
+      tableMetadata,
+    ) ||
     areModelsEquivalent({
       originalQuestion,
       lastRunQuestion,
       currentQuestion,
       tableMetadata,
-    }) ||
-    areQueriesEqual(
-      lastRunQuestion?.datasetQuery(),
-      currentQuestion?.datasetQuery(),
-      tableMetadata,
-    )
+    })
   );
 }
 

--- a/frontend/test/metabase/query_builder/selectors.unit.spec.js
+++ b/frontend/test/metabase/query_builder/selectors.unit.spec.js
@@ -299,7 +299,7 @@ describe("getIsResultDirty", () => {
         originalCard: dataset,
         lastRunCard: getDataset({ "source-table": 2 }),
       });
-      expect(getIsResultDirty(state)).toBe(false);
+      expect(getIsResultDirty(state)).toBe(true);
     });
 
     it("should not be dirty if model simple mode is active", () => {

--- a/frontend/test/metabase/scenarios/models/models-metadata.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models-metadata.cy.spec.js
@@ -258,7 +258,6 @@ describe("scenarios > models metadata", () => {
           });
 
           cy.go("back");
-          cy.wait("@dataset");
 
           // Drill to Reviews table
           // FK column has a FK semantic type, no mapping to real DB columns

--- a/frontend/test/metabase/scenarios/models/models-metadata.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models-metadata.cy.spec.js
@@ -24,45 +24,86 @@ describe("scenarios > models metadata", () => {
     restore();
     cy.signInAsAdmin();
     cy.intercept("POST", "/api/card/*/query").as("cardQuery");
+    cy.intercept("POST", "/api/dataset").as("dataset");
   });
 
-  it("should edit GUI model metadata", () => {
-    // Convert saved question "Orders" into a model
-    cy.request("PUT", "/api/card/1", {
-      name: "GUI Model",
-      dataset: true,
+  describe("GUI model", () => {
+    beforeEach(() => {
+      // Convert saved question "Orders" into a model
+      cy.request("PUT", "/api/card/1", {
+        name: "GUI Model",
+        dataset: true,
+      });
+
+      cy.visit("/model/1");
     });
 
-    cy.visit("/model/1");
+    it("should edit GUI model metadata", () => {
+      openQuestionActions();
 
-    openQuestionActions();
+      popover().within(() => {
+        cy.findByTextEnsureVisible("89%").trigger("mouseenter");
+      });
 
-    popover().within(() => {
-      cy.findByTextEnsureVisible("89%").trigger("mouseenter");
+      cy.findByText(
+        "Some columns are missing a column type, description, or friendly name.",
+      );
+      cy.findByText(
+        "Adding metadata makes it easier for your team to explore this data.",
+      );
+
+      cy.findByText("Edit metadata").click();
+
+      cy.url().should("include", "/metadata");
+      cy.findByTextEnsureVisible("Product ID");
+
+      openColumnOptions("Subtotal");
+
+      renameColumn("Subtotal", "Pre-tax");
+      setColumnType("No special type", "Cost");
+      cy.button("Save changes").click();
+
+      startQuestionFromModel("GUI Model");
+
+      visualize();
+      cy.findByText("Pre-tax ($)");
     });
 
-    cy.findByText(
-      "Some columns are missing a column type, description, or friendly name.",
-    );
-    cy.findByText(
-      "Adding metadata makes it easier for your team to explore this data.",
-    );
+    it("allows for canceling changes", () => {
+      openQuestionActions();
 
-    cy.findByText("Edit metadata").click();
+      cy.findByText("Edit metadata").click();
 
-    cy.url().should("include", "/metadata");
-    cy.findByTextEnsureVisible("Product ID");
+      openColumnOptions("Subtotal");
 
-    openColumnOptions("Subtotal");
+      renameColumn("Subtotal", "Pre-tax");
+      setColumnType("No special type", "Cost");
 
-    renameColumn("Subtotal", "Pre-tax");
-    setColumnType("No special type", "Cost");
-    cy.button("Save changes").click();
+      cy.button("Cancel").click();
 
-    startQuestionFromModel("GUI Model");
+      cy.findByText("Subtotal");
+    });
 
-    visualize();
-    cy.findByText("Pre-tax ($)");
+    it("clears custom metadata when a model is turned back into a question", () => {
+      openQuestionActions();
+
+      cy.findByText("Edit metadata").click();
+
+      openColumnOptions("Subtotal");
+
+      renameColumn("Subtotal", "Pre-tax");
+      setColumnType("No special type", "Cost");
+      cy.button("Save changes").click();
+
+      openQuestionActions();
+      popover().within(() => {
+        cy.findByText("Turn back to saved question").click();
+      });
+
+      cy.wait("@dataset");
+
+      cy.findByText("Subtotal");
+    });
   });
 
   it("should edit native model metadata", () => {

--- a/frontend/test/metabase/scenarios/models/models-query-editor.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models-query-editor.cy.spec.js
@@ -12,6 +12,7 @@ describe("scenarios > models query editor", () => {
   beforeEach(() => {
     cy.intercept("PUT", "/api/card/*").as("updateCard");
     cy.intercept("POST", "/api/dataset").as("dataset");
+    cy.intercept("POST", "/api/card/*/query").as("cardQuery");
 
     restore();
     cy.signInAsAdmin();
@@ -59,6 +60,37 @@ describe("scenarios > models query editor", () => {
       cy.get(".cellData")
         .should("contain", "37.65")
         .and("not.contain", "109.22");
+    });
+
+    it("allows for canceling changes", () => {
+      cy.visit("/model/1");
+      cy.wait("@dataset");
+
+      cy.get(".cellData").should("contain", "37.65").and("contain", "109.22");
+
+      openQuestionActions();
+
+      popover().within(() => {
+        cy.findByText("Edit query definition").click();
+      });
+
+      cy.findByText("Row limit").click();
+      cy.findByPlaceholderText("Enter a limit").type("2");
+
+      cy.get(".RunButton").click();
+      cy.wait("@dataset");
+
+      cy.get(".cellData")
+        .should("contain", "37.65")
+        .and("not.contain", "109.22");
+
+      cy.button("Cancel").click();
+      cy.wait("@cardQuery");
+
+      cy.url().should("include", "/model/1").and("not.include", "/query");
+      cy.location("hash").should("eq", "");
+
+      cy.get(".cellData").should("contain", "37.65").and("contain", "109.22");
     });
 
     it("locks display to table", () => {
@@ -115,6 +147,43 @@ describe("scenarios > models query editor", () => {
       cy.get(".cellData")
         .should("contain", "37.65")
         .and("not.contain", "109.22");
+    });
+
+    it("allows for canceling changes", () => {
+      cy.createNativeQuestion(
+        {
+          name: "Native Model",
+          dataset: true,
+          native: {
+            query: "SELECT * FROM orders limit 5",
+          },
+        },
+        { visitQuestion: true },
+      );
+
+      cy.get(".cellData").should("contain", "37.65").and("contain", "109.22");
+
+      openQuestionActions();
+
+      popover().within(() => {
+        cy.findByText("Edit query definition").click();
+      });
+
+      cy.url().should("include", "/query");
+      cy.button("Save changes").should("be.disabled");
+
+      cy.get(".ace_content").type("{backspace}2");
+
+      runNativeQuery();
+
+      cy.get(".cellData")
+        .should("contain", "37.65")
+        .and("not.contain", "109.22");
+
+      cy.button("Cancel").click();
+      cy.wait("@cardQuery");
+
+      cy.get(".cellData").should("contain", "37.65").and("contain", "109.22");
     });
 
     it("handles failing queries", () => {

--- a/frontend/test/metabase/scenarios/models/reproductions/19180-native-model-results-disappear.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/reproductions/19180-native-model-results-disappear.cy.spec.js
@@ -18,7 +18,6 @@ describe("issue 19180", () => {
           cy.visit(`/model/${QUESTION_ID}/query`);
           cy.wait("@cardQuery");
           cy.button("Cancel").click();
-          cy.wait("@cardQuery");
           cy.get(".TableInteractive");
           cy.findByText("Here's where your results will appear").should(
             "not.exist",

--- a/frontend/test/metabase/scenarios/models/reproductions/22517-add-remove-column-drops-metadata.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/reproductions/22517-add-remove-column-drops-metadata.cy.spec.js
@@ -46,7 +46,6 @@ describe("issue 22517", () => {
     cy.findByText("Foo");
 
     cy.findByText("Save changes").click();
-    cy.wait(["@cardQuery", "@cardQuery"]);
 
     cy.findByText("Foo");
   });


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/24825

This PR improves our handling of query reruns when editing models.
- Canceling edits made to a model now triggers `runDirtyQuestionQuery` which will only trigger a query rerun when the question's query is in a "dirty" state.
- I've made it so that the `apiUpdateQuestion` action always triggers a rerun whenever the question's query is dirty so that we aren't forced to pass it the `rerunQuery` prop. I've removed `rerunQuery: true` from a few places where we don't need to force a query rerun and can rely on the dirty state.
- I've refactored `areModelsEquivalent` to fix a bug in determining our dirty state related to the fact that `isCurrentEquivalentToOriginal` did not take into account the last run question.

My original solution changed `runQuestionQuery`, but that ended up being too far-reaching, and in the end I found that modifying `runQuestionQuery` to include a case where we don't actually run a query too confusing. Also, I was scared when pivot table e2e tests started failing; turns out our dirty state ought to rely on more than the query alone 🙂. Here's the PR for reference https://github.com/metabase/metabase/pull/25582.

**Native Model**

https://user-images.githubusercontent.com/13057258/192849062-00bfb998-7cae-4254-b90f-d7a14c072787.mov

**Structured Model**

https://user-images.githubusercontent.com/13057258/192849136-4ff8a59e-f3a8-4b48-804f-8b96532a36ee.mov

**Testing**
1. Create a model
2. Enter the model query edit mode. The query shouldn't rerun and there shouldn't be a dirty state mask.
3. Cancel to return to the original view. The query shouldn't rerun and there shouldn't be a dirty state mask.
4. Re-enter the model query edit mode. Refresh the page. Cancel to return to the original view. The query shouldn't rerun and there shouldn't be a dirty state mask.
5. Re-enter the model query edit mode. Edit the query. Save. The question should be saved and the query should rerun to reflect the difference in the query.
6. Re-enter the model query edit mode. Edit the query. Run the query manually. Save. The query shouldn't rerun and there shouldn't be a dirty state mask.
7. Edit the model's metadata. The query shouldn't rerun and there shouldn't be a dirty state mask.



