### PR TITLE
Prevent modifying app permissions via the collection endpoint

### DIFF
--- a/src/metabase/models/collection/graph.clj
+++ b/src/metabase/models/collection/graph.clj
@@ -97,7 +97,8 @@
 (defn- check-no-app-collections [changes]
   (let [coll-ids (into #{}
                        (comp (mapcat second)
-                             (map first))
+                             (map first)
+                             (filter int?))
                        changes)]
     (when-let [app-ids (and (seq coll-ids)
                             (db/select-ids 'App :collection_id [:in coll-ids]))]

--- a/test/metabase/models/collection/graph_test.clj
+++ b/test/metabase/models/collection/graph_test.clj
@@ -3,7 +3,7 @@
             [clojure.test :refer :all]
             [medley.core :as m]
             [metabase.api.common :refer [*current-user-id*]]
-            [metabase.models :refer [User]]
+            [metabase.models :refer [App User]]
             [metabase.models.collection :as collection :refer [Collection]]
             [metabase.models.collection-permission-graph-revision :as c-perm-revision
              :refer [CollectionPermissionGraphRevision]]
@@ -434,3 +434,12 @@
     (with-n-temp-users-with-personal-collections 2000
       (is (>= (db/count Collection :personal_owner_id [:not= nil]) 2000))
       (is (map? (graph/graph))))))
+
+(deftest modify-perms-for-app-collections-test
+  (testing "that we cannot modify perms for app collections"
+    (mt/with-temp* [Collection [{coll-id :id}]
+                    App [_app {:collection_id coll-id}]]
+      (is (thrown? clojure.lang.ExceptionInfo
+                   (graph/update-graph! (assoc-in (graph/graph)
+                                                  [:groups (u/the-id (perms-group/all-users)) coll-id]
+                                                  :readl)))))))

--- a/test/metabase/models/collection/graph_test.clj
+++ b/test/metabase/models/collection/graph_test.clj
@@ -439,7 +439,7 @@
   (testing "that we cannot modify perms for app collections"
     (mt/with-temp* [Collection [{coll-id :id}]
                     App [_app {:collection_id coll-id}]]
-      (is (thrown? clojure.lang.ExceptionInfo
-                   (graph/update-graph! (assoc-in (graph/graph)
-                                                  [:groups (u/the-id (perms-group/all-users)) coll-id]
-                                                  :readl)))))))
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Cannot set app permissions using this endpoint"
+                            (graph/update-graph! (assoc-in (graph/graph)
+                                                           [:groups (u/the-id (perms-group/all-users)) coll-id]
+                                                           :read)))))))


### PR DESCRIPTION
Fixes #25680, part of #25420.

This PR prevents using the collection permission endpoint to be used for modifying permissions on app collections. (There are/will be app specific endpoints for doing this.)