### PR TITLE
docs - add dev guide to readme sidebar section

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -174,6 +174,10 @@ Metabase's reference documentation.
 
 - [Troubleshooting guides](./troubleshooting-guide/index.md)
 
+### Developer guide
+
+- [Developer guide](./developers-guide/start.md)
+
 ## Getting help
 
 ### Troubleshooting

--- a/docs/developers-guide/start.md
+++ b/docs/developers-guide/start.md
@@ -1,10 +1,10 @@
 ---
-title: "Developer's Guide"
+title: "Developer Guide"
 redirect_from:
   - /docs/latest/developers-guide
 ---
 
-# Developer's Guide
+# Developer Guide
 
 This guide contains detailed information on how to work on Metabase codebase.
 


### PR DESCRIPTION
This PR positions dev guide so that it will appear in the docs sidebar (like the Metabase API and Troubleshooting sections).