### PR TITLE
Infer types for new date functions

### DIFF
--- a/frontend/src/metabase/lib/expressions/config.js
+++ b/frontend/src/metabase/lib/expressions/config.js
@@ -363,12 +363,12 @@ export const MBQL_CLAUSES = {
   },
   "date-add": {
     displayName: `dateAdd`,
-    type: "number",
+    type: "expression",
     args: ["expression", "number", "string"],
   },
   "date-subtract": {
     displayName: `dateSubtract`,
-    type: "number",
+    type: "expression",
     args: ["expression", "number", "string"],
   },
 };

--- a/frontend/src/metabase/lib/expressions/typeinferencer.js
+++ b/frontend/src/metabase/lib/expressions/typeinferencer.js
@@ -12,6 +12,7 @@ export function infer(mbql, env) {
   if (!Array.isArray(mbql)) {
     return typeof mbql;
   }
+
   const op = mbql[0];
   switch (op) {
     case OP.Plus:
@@ -32,16 +33,13 @@ export function infer(mbql, env) {
       return MONOTYPE.Boolean;
   }
 
-  if (op === "case") {
-    const clauses = mbql[1];
-    const first = clauses[0];
-    // TODO: type-checker must ensure the consistent types of all clauses.
-    return infer(first[1], env);
-  }
-
-  if (op === "coalesce") {
-    // TODO: type-checker must ensure the consistent types of all arguments
-    return infer(mbql[1], env);
+  switch (op) {
+    case "case":
+      return infer(mbql[1][0], env);
+    case "coalesce":
+    case "date-add":
+    case "date-subtract":
+      return infer(mbql[1], env);
   }
 
   const func = MBQL_CLAUSES[op];

--- a/frontend/src/metabase/lib/expressions/typeinferencer.js
+++ b/frontend/src/metabase/lib/expressions/typeinferencer.js
@@ -35,7 +35,7 @@ export function infer(mbql, env) {
 
   switch (op) {
     case "case":
-      return infer(mbql[1][0], env);
+      return infer(mbql[1][0][1], env);
     case "coalesce":
     case "date-add":
     case "date-subtract":


### PR DESCRIPTION
Follow up on https://github.com/metabase/metabase/pull/25414

How to test:
- New -> Question -> Orders
- Add a custom column `dateAdd([Created At], 1, "month")`
- Try to filter by this custom column and make sure it is recognized as a date

<img width="860" alt="Screenshot 2022-09-29 at 11 40 45" src="https://user-images.githubusercontent.com/8542534/192983919-3e6d1f36-809e-4a2e-960f-cc66cc849bf2.png">
<img width="565" alt="Screenshot 2022-09-29 at 11 40 51" src="https://user-images.githubusercontent.com/8542534/192983938-670ffaa3-062d-43b9-a94a-f73f03bea439.png">
 