### PR TITLE
'Recently viewed' dropdown style fix

### DIFF
--- a/frontend/src/metabase/search/components/SearchResult.styled.jsx
+++ b/frontend/src/metabase/search/components/SearchResult.styled.jsx
@@ -87,7 +87,7 @@ export const ResultLink = styled(Link)`
   h3 {
     font-size: ${props => (props.compact ? "14px" : "16px")};
     line-height: 1.2em;
-    word-wrap: break-word;
+    overflow-wrap: anywhere;
     margin-bottom: 0;
     color: ${props => (props.active && props.isSelected ? color("brand") : "")};
   }


### PR DESCRIPTION
I noticed that if you have a long title in search results it displays okay:

![2022-09-29_08:48:07_414x136](https://user-images.githubusercontent.com/784417/193024084-4974cd45-ca45-4e41-9116-047a2fb58b79.png)

but the same thing in "Recently viewed" overflows:

![2022-09-29_08:47:03_459x272](https://user-images.githubusercontent.com/784417/193024159-0b0c0265-2cdf-41e0-abf4-2abf9978f6f7.png)

So I made it wrap instead:

![2022-09-29_09:17:51_407x289](https://user-images.githubusercontent.com/784417/193024211-2d0bda33-5401-41a2-a5ed-fe2a617b6bb4.png)

And that makes search results wrap (not truncate) as well, which feels right:

![2022-09-29_09:31:48_400x140](https://user-images.githubusercontent.com/784417/193024323-9b611d4d-07bf-4b4c-8e86-6753c90dd399.png)

The initial `break-word` is from the very early days of the new search: PR #14975.

PS: [MDN tells me](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap) that `overflow-wrap` is preferred to the synonymous `word-wrap`.