### PR TITLE
Notify endpoint should 404 with incorrect table name/id (#25627)

### DIFF
--- a/src/metabase/api/notify.clj
+++ b/src/metabase/api/notify.clj
@@ -32,9 +32,9 @@
                           (thunk)))]
     (api/let-404 [database (db/select-one Database :id id)]
       (cond
-        table_id   (when-let [table (db/select-one Table :db_id id, :id (int table_id))]
+        table_id   (api/let-404 [table (db/select-one Table :db_id id, :id (int table_id))]
                      (execute! #(table-sync-fn table)))
-        table_name (when-let [table (db/select-one Table :db_id id, :name table_name)]
+        table_name (api/let-404 [table (db/select-one Table :db_id id, :name table_name)]
                      (execute! #(table-sync-fn table)))
         :else      (execute! #(db-sync-fn database)))))
   {:success true})

--- a/test/metabase/server/middleware/auth_test.clj
+++ b/test/metabase/server/middleware/auth_test.clj
@@ -91,10 +91,10 @@
 
 (deftest wrap-api-key-test
   (testing "No API key in the request"
-    (is (= nil
-           (:metabase-session-id
-            (wrapped-api-key-handler
-             (ring.mock/request :get "/anyurl"))))))
+    (is (nil?
+         (:metabase-session-id
+          (wrapped-api-key-handler
+           (ring.mock/request :get "/anyurl"))))))
 
   (testing "API Key in header"
     (is (= "foobar"


### PR DESCRIPTION
Fixes #25627; previously a missing table would silently fail (and return a 200).