### PR TITLE
Remove unused /api/card filter options

### DIFF
--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -57,63 +57,10 @@
   [_]
   (db/select Card, :archived false, {:order-by [[:%lower.name :asc]]}))
 
-;; return Cards created by the current user
-(defmethod cards-for-filter-option* :mine
-  [_]
-  (db/select Card, :creator_id api/*current-user-id*, :archived false, {:order-by [[:%lower.name :asc]]}))
-
-;; return all Cards bookmarked by the current user.
-(defmethod cards-for-filter-option* :bookmarked
-  [_]
-  (let [cards (for [{{:keys [archived], :as card} :card} (hydrate (db/select [CardBookmark :card_id]
-                                                                    :user_id api/*current-user-id*)
-                                                                  :card)
-                    :when                                 (not archived)]
-                card)]
-    (sort-by :name cards)))
-
 ;; Return all Cards belonging to Database with `database-id`.
 (defmethod cards-for-filter-option* :database
   [_ database-id]
   (db/select Card, :database_id database-id, :archived false, {:order-by [[:%lower.name :asc]]}))
-
-;; Return all Cards belonging to `Table` with `table-id`.
-(defmethod cards-for-filter-option* :table
-  [_ table-id]
-  (db/select Card, :table_id table-id, :archived false, {:order-by [[:%lower.name :asc]]}))
-
-(s/defn ^:private cards-with-ids :- (s/maybe [CardInstance])
-  "Return unarchived Cards with `card-ids`.
-  Make sure cards are returned in the same order as `card-ids`; `[in card-ids]` won't preserve the order."
-  [card-ids :- [su/IntGreaterThanZero]]
-  (when (seq card-ids)
-    (let [card-id->card (m/index-by :id (db/select Card, :id [:in (set card-ids)], :archived false))]
-      (filter identity (map card-id->card card-ids)))))
-
-;; Return the 10 Cards most recently viewed by the current user, sorted by how recently they were viewed.
-(defmethod cards-for-filter-option* :recent
-  [_]
-  (cards-with-ids (map :model_id (db/select [ViewLog :model_id [:%max.timestamp :max]]
-                                   :model   "card"
-                                   :user_id api/*current-user-id*
-                                   {:group-by [:model_id]
-                                    :order-by [[:max :desc]]
-                                    :limit    10}))))
-
-;; All Cards, sorted by popularity (the total number of times they are viewed in `ViewLogs`). (yes, this isn't
-;; actually filtering anything, but for the sake of simplicitiy it is included amongst the filter options for the time
-;; being).
-(defmethod cards-for-filter-option* :popular
-  [_]
-  (cards-with-ids (map :model_id (db/select [ViewLog :model_id [:%count.* :count]]
-                                   :model "card"
-                                   {:group-by [:model_id]
-                                    :order-by [[:count :desc]]}))))
-
-;; Cards that have been archived.
-(defmethod cards-for-filter-option* :archived
-  [_]
-  (db/select Card, :archived true, {:order-by [[:%lower.name :asc]]}))
 
 (defn- cards-for-filter-option [filter-option model-id-or-nil]
   (-> (apply cards-for-filter-option* (or filter-option :all) (when model-id-or-nil [model-id-or-nil]))
@@ -133,12 +80,10 @@
   {f        (s/maybe CardFilterOption)
    model_id (s/maybe su/IntGreaterThanZero)}
   (let [f (keyword f)]
-    (when (contains? #{:database :table} f)
+    (when (= f :database)
       (api/checkp (integer? model_id) "model_id" (format "model_id is a required parameter when filter mode is '%s'"
                                                          (name f)))
-      (case f
-        :database (api/read-check Database model_id)
-        :table    (api/read-check Database (db/select-one-field :db_id Table, :id model_id))))
+      (api/read-check Database model_id))
     (let [cards (filter mi/can-read? (cards-for-filter-option f model_id))
           last-edit-info (:card (last-edit/fetch-last-edited-info {:card-ids (map :id cards)}))]
       (into []

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -17,7 +17,7 @@
             [metabase.email.messages :as messages]
             [metabase.events :as events]
             [metabase.mbql.normalize :as mbql.normalize]
-            [metabase.models :refer [Card CardBookmark Collection Database PersistedInfo Pulse Table ViewLog]]
+            [metabase.models :refer [Card Collection Database PersistedInfo Pulse]]
             [metabase.models.collection :as collection]
             [metabase.models.interface :as mi]
             [metabase.models.moderation-review :as moderation-review]
@@ -42,8 +42,7 @@
             [toucan.db :as db]
             [toucan.hydrate :refer [hydrate]])
   (:import clojure.core.async.impl.channels.ManyToManyChannel
-           java.util.UUID
-           metabase.models.card.CardInstance))
+           java.util.UUID))
 
 ;;; ----------------------------------------------- Filtered Fetch Fns -----------------------------------------------
 
@@ -73,9 +72,9 @@
   (apply s/enum (map name (keys (methods cards-for-filter-option*)))))
 
 (api/defendpoint GET "/"
-  "Get all the Cards. Option filter param `f` can be used to change the set of Cards that are returned; default is
-  `all`, but other options include `mine`, `bookmarked`, `database`, `table`, `recent`, `popular`, and `archived`. See
-  corresponding implementation functions above for the specific behavior of each filter option. :card_index:"
+  "Get all the Cards. Optional filter parameter `f` can be used to change the set of Cards that are returned;
+  The default filter parameter is `all` which returns all Cards. Using `database` returns all cards
+  in a database of the given `model_id` parameter."
   [f model_id]
   {f        (s/maybe CardFilterOption)
    model_id (s/maybe su/IntGreaterThanZero)}

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -6,7 +6,6 @@
             [clojure.tools.macro :as tools.macro]
             [clojurewerkz.quartzite.scheduler :as qs]
             [dk.ative.docjure.spreadsheet :as spreadsheet]
-            [java-time :as t]
             [medley.core :as m]
             [metabase.api.card :as api.card]
             [metabase.api.pivots :as api.pivots]
@@ -14,7 +13,6 @@
             [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
             [metabase.http-client :as client]
             [metabase.models :refer [Card
-                                     CardBookmark
                                      CardEmitter
                                      Collection
                                      Dashboard
@@ -29,8 +27,7 @@
                                      QueryAction
                                      Table
                                      Timeline
-                                     TimelineEvent
-                                     ViewLog]]
+                                     TimelineEvent]]
             [metabase.models.moderation-review :as moderation-review]
             [metabase.models.permissions :as perms]
             [metabase.models.permissions-group :as perms-group]


### PR DESCRIPTION
This PR makes breaking changes to the GET `/api/card` endpoint - BE only

I found a lot of unused "filter options" for the GET `/api/card` endpoint, so I removed them to save us maintaining this code in the future.

The filter options date back to the original [Saved Question PR](https://github.com/metabase/metabase/pull/2325), and have long been unused on the frontend.

I know they're unused because I grep'd for `\bf:`, `"f"`, `'f'`, and `\bf\s*=[^>]` on the frontend code, which are the only ways I know that a `f` can be assigned on an object (except for silly string hacks we wouldn't use). The only uses with the `/api/card` endpoint are:
- `api/card/?f=using_model` [here](https://github.com/metabase/metabase/blob/b1298421ac2d7b157bb3578ac1679a0da6ba8f9f/frontend/src/metabase/models/components/ModelDetailPage/ModelUsageDetails/ModelUsageDetails.tsx#L71)
- `api/card/?f=all` [here](https://github.com/metabase/metabase/blob/b0b308f48eb0f8df33371140c8b55a347e0a95c0/frontend/src/metabase/dashboard/components/AddSeriesModal/AddSeriesModal.jsx#L242)

So we can eliminate all other options. These include: 
- `api/card/?f=database`
- `api/card/?f=archived`
- `api/card/?f=popular`
- `api/card/?f=recent`
- `api/card/?f=table`
- `api/card/?f=bookmarked`
- `api/card/?f=mine`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/25707)
<!-- Reviewable:end -->
