### PR TITLE
[FE] Remove unused `underscore` imports

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/license/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/license/index.js
@@ -1,5 +1,4 @@
 import { t } from "ttag";
-import _ from "underscore";
 import { updateIn } from "icepick";
 import { PLUGIN_ADMIN_SETTINGS_UPDATES } from "metabase/plugins";
 import LicenseAndBillingSettings from "./components/LicenseAndBillingSettings";

--- a/frontend/src/metabase/admin/people/components/GroupDetail.jsx
+++ b/frontend/src/metabase/admin/people/components/GroupDetail.jsx
@@ -2,7 +2,6 @@
 import React, { useEffect, useState } from "react";
 import { connect } from "react-redux";
 import { t, ngettext, msgid } from "ttag";
-import _ from "underscore";
 
 import {
   isAdminGroup,

--- a/frontend/src/metabase/admin/people/components/MembershipSelect/MembershipSelect.tsx
+++ b/frontend/src/metabase/admin/people/components/MembershipSelect/MembershipSelect.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { t } from "ttag";
-import _ from "underscore";
 
 import Icon from "metabase/components/Icon";
 import PopoverWithTrigger from "metabase/components/PopoverWithTrigger";

--- a/frontend/src/metabase/admin/people/components/PeopleListRow.jsx
+++ b/frontend/src/metabase/admin/people/components/PeopleListRow.jsx
@@ -2,7 +2,6 @@
 import React, { useMemo } from "react";
 import { t } from "ttag";
 import moment from "moment-timezone";
-import _ from "underscore";
 
 import { color } from "metabase/lib/colors";
 import { getFullName } from "metabase/lib/user";

--- a/frontend/src/metabase/admin/people/selectors.js
+++ b/frontend/src/metabase/admin/people/selectors.js
@@ -1,5 +1,4 @@
 import { createSelector } from "reselect";
-import _ from "underscore";
 
 export const getMemberships = state => state.admin.people.memberships;
 

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/breadcrumbs.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/breadcrumbs.ts
@@ -1,4 +1,3 @@
-import _ from "underscore";
 import { Group } from "metabase-types/api";
 import type Metadata from "metabase-lib/lib/metadata/Metadata";
 import type Schema from "metabase-lib/lib/metadata/Schema";

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/data-sidebar.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/data-sidebar.ts
@@ -1,6 +1,5 @@
 import { createSelector } from "reselect";
 import { t } from "ttag";
-import _ from "underscore";
 
 import { getMetadataWithHiddenTables } from "metabase/selectors/metadata";
 

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/fields.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/fields.ts
@@ -1,5 +1,3 @@
-import _ from "underscore";
-
 import {
   getFieldsPermission,
   getNativePermission,

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/group-sidebar.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/group-sidebar.ts
@@ -1,6 +1,5 @@
 import { createSelector } from "reselect";
 import { t } from "ttag";
-import _ from "underscore";
 
 import { State } from "metabase-types/store";
 import { Group } from "metabase-types/api";

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/schemas.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/schemas.ts
@@ -1,5 +1,3 @@
-import _ from "underscore";
-
 import {
   getNativePermission,
   getSchemasPermission,

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/tables.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/tables.ts
@@ -1,4 +1,3 @@
-import _ from "underscore";
 import { push } from "react-router-redux";
 
 import {

--- a/frontend/src/metabase/admin/permissions/utils/graph/permissions-diff.ts
+++ b/frontend/src/metabase/admin/permissions/utils/graph/permissions-diff.ts
@@ -1,5 +1,3 @@
-import _ from "underscore";
-
 import type {
   Group,
   GroupsPermissions,

--- a/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.stories.tsx
+++ b/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.stories.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import _ from "underscore";
+
 import { action } from "@storybook/addon-actions";
 import { ComponentStory } from "@storybook/react";
 import PinnedItemCard from "./PinnedItemCard";

--- a/frontend/src/metabase/components/DateAllOptionsWidget/DateAllOptionsWidget.tsx
+++ b/frontend/src/metabase/components/DateAllOptionsWidget/DateAllOptionsWidget.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
 import { t } from "ttag";
-import _ from "underscore";
 import cx from "classnames";
 
 import { dateParameterValueToMBQL } from "metabase/parameters/utils/mbql";

--- a/frontend/src/metabase/core/components/Select/Select.stories.tsx
+++ b/frontend/src/metabase/core/components/Select/Select.stories.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import _ from "underscore";
 import { ComponentStory } from "@storybook/react";
 import { field_semantic_types } from "metabase/lib/core";
 import Select from "./Select";

--- a/frontend/src/metabase/dashboard/actions/revisions.js
+++ b/frontend/src/metabase/dashboard/actions/revisions.js
@@ -1,5 +1,3 @@
-import _ from "underscore";
-
 import { createThunkAction } from "metabase/lib/redux";
 
 import { fetchDashboard, fetchDashboardCardData } from "./data-fetching";

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/ValuesYouCanReference.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/ValuesYouCanReference.jsx
@@ -1,7 +1,6 @@
 /* eslint-disable react/prop-types */
 import React from "react";
 import { t } from "ttag";
-import _ from "underscore";
 
 import AccordionList from "metabase/core/components/AccordionList";
 import Icon from "metabase/components/Icon";

--- a/frontend/src/metabase/hoc/Favicon.jsx
+++ b/frontend/src/metabase/hoc/Favicon.jsx
@@ -1,5 +1,4 @@
 import React, { useEffect } from "react";
-import _ from "underscore";
 import MetabaseSettings from "../lib/settings";
 
 const DEFAULT_FAVICON = () => MetabaseSettings.get("application-favicon-url");

--- a/frontend/src/metabase/lib/card.js
+++ b/frontend/src/metabase/lib/card.js
@@ -1,4 +1,3 @@
-import _ from "underscore";
 import * as Q_DEPRECATED from "metabase/lib/query";
 import Utils from "metabase/lib/utils";
 

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarCollectionLink.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarCollectionLink.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useCallback, useRef, KeyboardEvent } from "react";
-import _ from "underscore";
 
 import { Collection } from "metabase-types/api";
 

--- a/frontend/src/metabase/query_builder/actions/core/core.js
+++ b/frontend/src/metabase/query_builder/actions/core/core.js
@@ -1,4 +1,3 @@
-import _ from "underscore";
 import { createAction } from "redux-actions";
 
 import * as MetabaseAnalytics from "metabase/lib/analytics";

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
@@ -1,4 +1,3 @@
-import _ from "underscore";
 import querystring from "querystring";
 import { LocationDescriptorObject } from "history";
 

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.unit.spec.ts
@@ -1,5 +1,5 @@
 import { LocationDescriptorObject } from "history";
-import _ from "underscore";
+
 import xhrMock from "xhr-mock";
 
 import * as CardLib from "metabase/lib/card";

--- a/frontend/src/metabase/query_builder/actions/core/updateQuestion.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/actions/core/updateQuestion.unit.spec.ts
@@ -1,5 +1,3 @@
-import _ from "underscore";
-
 import { createMockDataset } from "metabase-types/api/mocks";
 import { Card, StructuredDatasetQuery } from "metabase-types/types/Card";
 import { ConcreteField, TemplateTag } from "metabase-types/types/Query";

--- a/frontend/src/metabase/query_builder/actions/models.js
+++ b/frontend/src/metabase/query_builder/actions/models.js
@@ -1,5 +1,4 @@
 import { createAction } from "redux-actions";
-import _ from "underscore";
 import { merge } from "icepick";
 import { t } from "ttag";
 

--- a/frontend/src/metabase/query_builder/actions/native.js
+++ b/frontend/src/metabase/query_builder/actions/native.js
@@ -1,4 +1,3 @@
-import _ from "underscore";
 import { assoc, updateIn } from "icepick";
 
 import { createAction } from "redux-actions";

--- a/frontend/src/metabase/query_builder/actions/querying.js
+++ b/frontend/src/metabase/query_builder/actions/querying.js
@@ -1,4 +1,3 @@
-import _ from "underscore";
 import { t } from "ttag";
 import { createAction } from "redux-actions";
 

--- a/frontend/src/metabase/query_builder/actions/ui.js
+++ b/frontend/src/metabase/query_builder/actions/ui.js
@@ -1,4 +1,3 @@
-import _ from "underscore";
 import { createAction } from "redux-actions";
 
 import * as MetabaseAnalytics from "metabase/lib/analytics";

--- a/frontend/src/metabase/query_builder/actions/visualization-settings.js
+++ b/frontend/src/metabase/query_builder/actions/visualization-settings.js
@@ -1,5 +1,3 @@
-import _ from "underscore";
-
 import {
   getDatasetEditorTab,
   getPreviousQueryBuilderMode,

--- a/frontend/src/metabase/query_builder/components/DataSelector/saved-question-picker/SavedQuestionList.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/saved-question-picker/SavedQuestionList.jsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { t } from "ttag";
 import PropTypes from "prop-types";
-import _ from "underscore";
 
 import { PLUGIN_MODERATION } from "metabase/plugins";
 import Schemas from "metabase/entities/schemas";

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/MappedFieldPicker/MappedFieldPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/MappedFieldPicker/MappedFieldPicker.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useRef } from "react";
 import { t } from "ttag";
-import _ from "underscore";
 
 import { isVirtualCardId } from "metabase/lib/saved-questions";
 import { SchemaTableAndFieldDataSelector } from "metabase/query_builder/components/DataSelector";

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePickerFooter.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePickerFooter.tsx
@@ -2,7 +2,6 @@
 import React from "react";
 import { t } from "ttag";
 import moment from "moment-timezone";
-import _ from "underscore";
 
 import Icon from "metabase/components/Icon";
 import {

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePickerShortcuts.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePickerShortcuts.tsx
@@ -1,5 +1,4 @@
 import React, { useMemo } from "react";
-import _ from "underscore";
 
 import SidebarHeader from "metabase/query_builder/components/SidebarHeader";
 import { Filter as FilterExpression } from "metabase-types/types/Query";

--- a/frontend/src/metabase/reducers-main.js
+++ b/frontend/src/metabase/reducers-main.js
@@ -1,7 +1,6 @@
 // Reducers needed for main application
 
 import { combineReducers } from "redux";
-import _ from "underscore";
 
 import { PLUGIN_REDUCERS } from "metabase/plugins";
 

--- a/frontend/src/metabase/visualizations/components/List/ListCell.tsx
+++ b/frontend/src/metabase/visualizations/components/List/ListCell.tsx
@@ -1,6 +1,5 @@
 import React, { useMemo } from "react";
 import cx from "classnames";
-import _ from "underscore";
 
 import ExternalLink from "metabase/core/components/ExternalLink";
 

--- a/frontend/src/metabase/visualizations/components/TableSimple/TableCell.jsx
+++ b/frontend/src/metabase/visualizations/components/TableSimple/TableCell.jsx
@@ -1,7 +1,6 @@
 /* eslint-disable react/prop-types */
 import React, { useMemo } from "react";
 import cx from "classnames";
-import _ from "underscore";
 
 import ExternalLink from "metabase/core/components/ExternalLink";
 

--- a/frontend/src/metabase/visualizations/lib/apply_tooltips.js
+++ b/frontend/src/metabase/visualizations/lib/apply_tooltips.js
@@ -3,7 +3,6 @@
 import d3 from "d3";
 import moment from "moment-timezone";
 import { getIn } from "icepick";
-import _ from "underscore";
 
 import { formatValue } from "metabase/lib/formatting";
 

--- a/frontend/test/metabase-lib/lib/Dimension.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/Dimension.unit.spec.js
@@ -1,4 +1,3 @@
-import _ from "underscore";
 import {
   metadata,
   ORDERS,

--- a/frontend/test/metabase-visual/notebook/notebook.cy.spec.js
+++ b/frontend/test/metabase-visual/notebook/notebook.cy.spec.js
@@ -1,4 +1,3 @@
-import _ from "underscore";
 import { restore, popover, startNewQuestion } from "__support__/e2e/helpers";
 
 describe("visual tests > notebook > major UI elements", () => {

--- a/frontend/test/metabase/scenarios/admin/people/group-managers.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/people/group-managers.cy.spec.js
@@ -1,4 +1,3 @@
-import _ from "underscore";
 import {
   restore,
   modal,

--- a/frontend/test/metabase/scenarios/filters/relative-datetime.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/relative-datetime.cy.spec.js
@@ -1,5 +1,4 @@
 import moment from "moment-timezone";
-import _ from "underscore";
 import { restore, popover, openOrdersTable } from "__support__/e2e/helpers";
 
 const STARTING_FROM_UNITS = [


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Removes unused `underscore` imports that linter failed to catch

### How to test?
Try searching using regex in VSCode:

- `import _ from(.|\n)*_` (`import _ from` that is followed by an underscore character `_`) - 439 results in 439 files
- `import _ from(.|\n)*_\.` (`import _ from` followed by `_.` pattern) - 438 results in 438 files

The number of found occurrences should match.

## Note!
The difference will be 1 file because of the pattern @kulyk used in `frontend/src/metabase/dashboard/components/grid/utils.js` where `_` is not directly followed by a method invocation

See: https://github.com/metabase/metabase/blob/master/frontend/src/metabase/dashboard/components/grid/utils.js#L38