### PR TITLE
Mysql persistence

### DIFF
--- a/src/metabase/driver/mysql/ddl.clj
+++ b/src/metabase/driver/mysql/ddl.clj
@@ -87,7 +87,7 @@
                                               (map :schema_name)
                                               (into #{}))]
                     (or (contains? existing-schemas schema-name)
-                      (sql.ddl/execute! conn [(sql.ddl/create-schema-sql database)]))))
+                        (sql.ddl/execute! conn [(sql.ddl/create-schema-sql database)]))))
                 (fn undo-check-schema [conn]
                   (sql.ddl/execute! conn [(sql.ddl/drop-schema-sql database)]))]
                [:persist.check/create-table
@@ -96,11 +96,11 @@
                                          db-spec
                                          (.toMillis (t/minutes 10))
                                          [(sql.ddl/create-table-sql
-                                            database
-                                            {:table-name table-name
-                                             :field-definitions [{:field-name "field"
-                                                                  :base-type :type/Text}]}
-                                            "values (1)")]))
+                                           database
+                                           {:table-name table-name
+                                            :field-definitions [{:field-name "field"
+                                                                 :base-type :type/Text}]}
+                                           "values (1)")]))
                 (fn undo-create-table [conn]
                   (sql.ddl/execute! conn [(sql.ddl/drop-table-sql database table-name)]))]
                [:persist.check/read-table
@@ -116,27 +116,27 @@
     ;; Unlike postgres, mysql ddl clauses will not rollback in a transaction.
     ;; So we keep track of undo-steps to manually rollback previous, completed steps.
     (jdbc/with-db-connection [conn db-spec]
-                             (loop [[[step stepfn undofn] & remaining] steps
-                                    undo-steps []]
-                               (let [result (try (stepfn conn)
-                                                 (log/info (trs "Step {0} was successful for db {1}"
-                                                                step (:name database)))
-                                                 ::valid
-                                                 (catch Exception e
-                                                   (log/warn (trs "Error in `{0}` while checking for model persistence permissions." step))
-                                                   (log/warn e)
-                                                   (try
-                                                     (doseq [[undo-step undofn] (reverse undo-steps)]
-                                                       (log/warn (trs "Undoing step `{0}` for db {1}" undo-step (:name database)))
-                                                       (undofn conn))
-                                                     (catch Exception _e
-                                                       (log/warn (trs "Unable to rollback database check for model persistence"))))
-                                                   step))]
-                                 (cond (and (= result ::valid) remaining)
-                                       (recur remaining (conj undo-steps [step undofn]))
+      (loop [[[step stepfn undofn] & remaining] steps
+             undo-steps []]
+        (let [result (try (stepfn conn)
+                          (log/info (trs "Step {0} was successful for db {1}"
+                                         step (:name database)))
+                          ::valid
+                          (catch Exception e
+                            (log/warn (trs "Error in `{0}` while checking for model persistence permissions." step))
+                            (log/warn e)
+                            (try
+                              (doseq [[undo-step undofn] (reverse undo-steps)]
+                                (log/warn (trs "Undoing step `{0}` for db {1}" undo-step (:name database)))
+                                (undofn conn))
+                              (catch Exception _e
+                                (log/warn (trs "Unable to rollback database check for model persistence"))))
+                            step))]
+          (cond (and (= result ::valid) remaining)
+                (recur remaining (conj undo-steps [step undofn]))
 
-                                       (= result ::valid)
-                                       [true :persist.check/valid]
+                (= result ::valid)
+                [true :persist.check/valid]
 
-                                       :else
-                                       [false step]))))))
+                :else
+                [false step]))))))

--- a/src/metabase/driver/mysql/ddl.clj
+++ b/src/metabase/driver/mysql/ddl.clj
@@ -100,7 +100,7 @@
                                            {:table-name table-name
                                             :field-definitions [{:field-name "field"
                                                                  :base-type :type/Text}]}
-                                           "values (1)")]))
+                                           "select 1")]))
                 (fn undo-create-table [conn]
                   (sql.ddl/execute! conn [(sql.ddl/drop-table-sql database table-name)]))]
                [:persist.check/read-table

--- a/test/metabase/analytics/prometheus_test.clj
+++ b/test/metabase/analytics/prometheus_test.clj
@@ -132,7 +132,7 @@
                                          nil)
             _              (assert c3p0-collector "Did not find c3p0 collector")
             measurements   (.collect ^Collector c3p0-collector)
-            _              (is (pos? (doto (count measurements) tap>))
+            _              (is (pos? (count measurements))
                                "No measurements taken")]
         (is (= (count (:connection-pools (troubleshooting/connection-pool-info)))
                (count (.samples ^GaugeMetricFamily (first measurements))))

--- a/test/metabase/task/persist_refresh_test.clj
+++ b/test/metabase/task/persist_refresh_test.clj
@@ -3,6 +3,8 @@
             [clojurewerkz.quartzite.conversion :as qc]
             [java-time :as t]
             [medley.core :as m]
+            [metabase.driver :as driver]
+            [metabase.driver.ddl.interface :as ddl.i]
             [metabase.models :refer [Card Database PersistedInfo TaskHistory]]
             [metabase.query-processor :as qp]
             [metabase.query-processor.interface :as qp.i]
@@ -218,3 +220,12 @@
                                     :query    {:aggregation [[:count]]
                                                :source-table (str "card__" (:id model))}}]
                   (is (= [[num-rows-query]] (mt/rows (qp/process-query query-on-top)))))))))))))
+
+(deftest can-persist-test
+  (testing "Can each database that allows for persistence actually persist"
+    (mt/test-drivers (mt/normal-drivers-with-feature :persist-models)
+      (testing (str driver/*driver* " can persist")
+        (mt/dataset test-data
+          (let [[success? error] (ddl.i/check-can-persist (mt/db))]
+            (is success? (str "Not able to persist on " driver/*driver*))
+            (is (= :persist.check/valid error))))))))


### PR DESCRIPTION
Fixes #25552. Mysql wasn't able to persist due to bad sql in its tests to check if it could create tables.

Before:

>Exception in thread "async-thread-macro-1" java.sql.SQLSyntaxErrorException: (conn=160) You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '(1)' at line 2

```sql
create table `metabase_cache_e74a8_2`.`persistence_check_5422` as values (1)
```

After:

```sql
create table `metabase_cache_e74a8_2`.`persistence_check_3187` as select 1
```

Added a test that each database that supports persistence can run `ddl.i/check-can-persist` which does the steps of
- create the schema
- create a table in that schema
- read the table in that schema
- delete the table in that schema

See https://github.com/metabase/metabase/pull/24124 for a previous fix for postgres.