### PR TITLE
Adding maxDimensions to waterfall charts

### DIFF
--- a/frontend/src/metabase/visualizations/index.js
+++ b/frontend/src/metabase/visualizations/index.js
@@ -100,6 +100,11 @@ export function getMaxMetricsSupported(display) {
   return visualization.maxMetricsSupported || Infinity;
 }
 
+export function getMaxDimensionsSupported(display) {
+  const visualization = visualizations.get(display);
+  return visualization.maxDimensionsSupported || 2;
+}
+
 // removes columns with `remapped_from` property and adds a `remapping` to the appropriate column
 const extractRemappedColumns = data => {
   const cols = data.cols.map(col => ({

--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -23,7 +23,10 @@ import { getOptionFromColumn } from "metabase/visualizations/lib/settings/utils"
 import { dimensionIsNumeric } from "metabase/visualizations/lib/numeric";
 import { dimensionIsTimeseries } from "metabase/visualizations/lib/timeseries";
 
-import { getMaxMetricsSupported } from "metabase/visualizations";
+import {
+  getMaxMetricsSupported,
+  getMaxDimensionsSupported,
+} from "metabase/visualizations";
 
 import { ChartSettingOrderedSimple } from "metabase/visualizations/components/settings/ChartSettingOrderedSimple";
 
@@ -121,15 +124,16 @@ export const GRAPH_DATA_SETTINGS = {
       ),
     persistDefault: true,
     getProps: ([{ card, data }], vizSettings) => {
-      const value = vizSettings["graph.dimensions"];
+      const addedDimensions = vizSettings["graph.dimensions"];
+      const maxDimensionsSupported = getMaxDimensionsSupported(card.display);
       const options = data.cols
         .filter(vizSettings["graph._dimension_filter"])
         .map(getOptionFromColumn);
       return {
         options,
         addAnother:
-          options.length > value.length &&
-          value.length < 2 &&
+          options.length > addedDimensions.length &&
+          addedDimensions.length < maxDimensionsSupported &&
           vizSettings["graph.metrics"].length < 2
             ? t`Add series breakout`
             : null,

--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -70,7 +70,15 @@ function getDefaultScatterColumns([
 }
 
 function getDefaultLineAreaBarColumns(series) {
-  return getDefaultDimensionsAndMetrics(series);
+  const [
+    {
+      card: { display },
+    },
+  ] = series;
+  return getDefaultDimensionsAndMetrics(
+    series,
+    getMaxDimensionsSupported(display),
+  );
 }
 
 export const GRAPH_DATA_SETTINGS = {

--- a/frontend/src/metabase/visualizations/lib/utils.js
+++ b/frontend/src/metabase/visualizations/lib/utils.js
@@ -306,6 +306,22 @@ export function getDefaultDimensionsAndMetrics(
   ) {
     dimensions = dimensionNotMetricColumns;
     metrics = metricColumns;
+  } else if (
+    dimensionNotMetricColumns.length > maxDimensions &&
+    metricColumns.length <= maxMetrics
+  ) {
+    //We only sort up to 10 dimensions because calculating column cardinality can be expensive
+    const sortableDimensions = dimensionNotMetricColumns
+      .slice(0, 10)
+      .map(dimension => ({
+        dimension,
+        cardinality: getColumnCardinality(cols, rows, cols.indexOf(dimension)),
+      }));
+    dimensions = sortableDimensions
+      .sort((a, b) => b.cardinality - a.cardinality)
+      .map(sortedDimension => sortedDimension.dimension)
+      .slice(0, maxDimensions);
+    metrics = metricColumns;
   }
 
   if (dimensions.length === 2) {

--- a/frontend/src/metabase/visualizations/lib/utils.js
+++ b/frontend/src/metabase/visualizations/lib/utils.js
@@ -306,22 +306,6 @@ export function getDefaultDimensionsAndMetrics(
   ) {
     dimensions = dimensionNotMetricColumns;
     metrics = metricColumns;
-  } else if (
-    dimensionNotMetricColumns.length > maxDimensions &&
-    metricColumns.length <= maxMetrics
-  ) {
-    //We only sort up to 10 dimensions because calculating column cardinality can be expensive
-    const sortableDimensions = dimensionNotMetricColumns
-      .slice(0, 10)
-      .map(dimension => ({
-        dimension,
-        cardinality: getColumnCardinality(cols, rows, cols.indexOf(dimension)),
-      }));
-    dimensions = sortableDimensions
-      .sort((a, b) => b.cardinality - a.cardinality)
-      .map(sortedDimension => sortedDimension.dimension)
-      .slice(0, maxDimensions);
-    metrics = metricColumns;
   }
 
   if (dimensions.length === 2) {

--- a/frontend/src/metabase/visualizations/visualizations/WaterfallChart.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/WaterfallChart.jsx
@@ -17,6 +17,7 @@ export default class WaterfallChart extends LineAreaBarChart {
   static noun = t`waterfall chart`;
 
   static maxMetricsSupported = 1;
+  static maxDimensionsSupported = 1;
 
   static settings = {
     ...GRAPH_AXIS_SETTINGS,

--- a/frontend/test/metabase/scenarios/visualizations/waterfall.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/waterfall.cy.spec.js
@@ -10,7 +10,7 @@ import {
 import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
-const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
+const { ORDERS, ORDERS_ID, PRODUCTS } = SAMPLE_DATABASE;
 
 describe("scenarios > visualizations > waterfall", () => {
   beforeEach(() => {
@@ -138,9 +138,7 @@ describe("scenarios > visualizations > waterfall", () => {
         query: {
           "source-table": ORDERS_ID,
           aggregation: [["count"], ["sum", ["field-id", ORDERS.TOTAL]]],
-          breakout: [
-            ["datetime-field", ["field-id", ORDERS.CREATED_AT], "year"],
-          ],
+          breakout: [["field", ORDERS.CREATED_AT, { "temporal-unit": "year" }]],
         },
         database: SAMPLE_DB_ID,
       },
@@ -154,7 +152,32 @@ describe("scenarios > visualizations > waterfall", () => {
     cy.findByTestId("remove-count").click();
     cy.get(".CardVisualization svg"); // Chart renders after removing the second metric
 
-    cy.findByText("Add another series...").should("not.exist");
+    cy.findByText(/Add another/).should("not.exist");
+  });
+
+  it("should not allow you to choose X-axis breakout", () => {
+    visitQuestionAdhoc({
+      dataset_query: {
+        type: "query",
+        query: {
+          "source-table": ORDERS_ID,
+          aggregation: [["count"]],
+          breakout: [
+            ["field", ORDERS.CREATED_AT, { "temporal-unit": "year" }],
+            ["field", PRODUCTS.CATEGORY, { "source-field": ORDERS.PRODUCT_ID }],
+          ],
+        },
+        database: SAMPLE_DB_ID,
+      },
+      display: "line",
+    });
+
+    cy.findByText("Visualization").click();
+    cy.findByTestId("Waterfall-button").click();
+
+    cy.get(".CardVisualization svg"); // Chart renders after removing the second metric
+
+    cy.findByText(/Add another/).should("not.exist");
   });
 
   it("should work for unaggregated data (metabase#15465)", () => {

--- a/frontend/test/metabase/scenarios/visualizations/waterfall.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/waterfall.cy.spec.js
@@ -175,6 +175,11 @@ describe("scenarios > visualizations > waterfall", () => {
     cy.findByText("Visualization").click();
     cy.findByTestId("Waterfall-button").click();
 
+    cy.contains("Select a field").click();
+    cy.get(".List-item").contains("Created At").click();
+    cy.contains("Select a field").click();
+    cy.get(".List-item").contains("Count").click();
+
     cy.get(".CardVisualization svg"); // Chart renders after removing the second metric
 
     cy.findByText(/Add another/).should("not.exist");


### PR DESCRIPTION
EPIC #25453 

~~Adding a maxDimension of 1 to waterfall charts, and a getMaxDimensions function that will return 2 if no static value is undefined.~~

~~Updated to show an error message if we detect that a query with multiple breakouts is being rendered by a waterfall chart. This is done because even if the dimension is removed from the viz settings, the chart that is rendered will always be incorrect.~~

We are back to simply only allowing 1 dimensions to be selected. If a question has more than one potential dimension, the user will need to select fields to use for x and y axis. The rendering issue is still present, but will be handled in #25597 

Before: 
![image](https://user-images.githubusercontent.com/1328979/193725531-7f8e28e5-5bc7-4dfe-b1aa-31c247d24e4d.png)

After:
![image](https://user-images.githubusercontent.com/1328979/194141507-bc7224f6-a355-4835-9625-20e05bdaa77b.png)


