### PR TITLE
Make Database details NOT NULL; add defaults for Database created_at and updated_at

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -12825,6 +12825,100 @@ databaseChangeLog:
               CHANGE updated_at
               updated_at timestamp(6) NOT NULL DEFAULT current_timestamp(6);
 
+  # The next 4 values add default values for Database `created_at` and `updated_at`; previously this was handled by
+  # Toucan but it's more convenient to do this at the application database level instead -- it facilitates stuff like
+  # schema migration tests that don't use Toucan, or other manual scripting
+  - changeSet:
+      id: v45.00-038
+      author: camsaul
+      comment: Added 0.45.0 -- add default value for Database created_at (Postgres/H2)
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: postgresql,h2
+      changes:
+        - addDefaultValue:
+            tableName: metabase_database
+            columnName: created_at
+            columnDataType: ${timestamp_type}
+            defaultValueComputed: current_timestamp
+
+    # addDefaultValue with defaultValueComputed doesn't work for MySQL/MariaDB so we have to do this the hard way.
+  - changeSet:
+      id: v45.00-039
+      author: camsaul
+      comment: Added 0.45.0 -- add default value for Database created_at (MySQL/MariaDB)
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+      changes:
+        - sql:
+            sql: >-
+              ALTER TABLE metabase_database
+              CHANGE created_at
+              created_at timestamp(6) NOT NULL DEFAULT current_timestamp(6);
+
+  - changeSet:
+      id: v45.00-040
+      author: camsaul
+      comment: Added 0.45.0 -- add default value for Database updated_at (Postgres/H2)
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: postgresql,h2
+      changes:
+        - addDefaultValue:
+            tableName: metabase_database
+            columnName: updated_at
+            columnDataType: ${timestamp_type}
+            defaultValueComputed: current_timestamp
+
+  - changeSet:
+      id: v45.00-041
+      author: camsaul
+      comment: Added 0.45.0 -- add default value for Database updated_at (MySQL/MariaDB)
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+      changes:
+        - sql:
+            sql: >-
+              ALTER TABLE metabase_database
+              CHANGE updated_at
+              updated_at timestamp(6) NOT NULL DEFAULT current_timestamp(6);
+
+  # It was probably an oversight, but while we validated Database `details` in the API layer it was not a required/NOT
+  # NULL column in the application Database itself. No problem; let's add it now that we've noticed it.
+  #
+  # MySQL (at least 5.7) won't let us have nice things:
+  #
+  # https://dev.mysql.com/doc/refman/5.7/en/data-type-defaults.html
+  #
+  # The BLOB, TEXT, GEOMETRY, and JSON data types cannot be assigned a default value.
+  #
+  # Because of this restriction we will just have to update existing NULL values in SQL and then add a NOT NULL
+  # restriction separately; we can use Toucan `pre-insert` to set defaults values when saving things.
+  - changeSet:
+      id: v45.00-042
+      author: camsaul
+      comment: Added 0.45.0 -- add default value for Database with NULL details
+      changes:
+        - sql:
+            sql: >-
+              UPDATE metabase_database SET details = '{}' WHERE details IS NULL;
+
+  - changeSet:
+      id: v45.00-043
+      author: camsaul
+      comment: Added 0.45.0 -- make Database details NOT NULL
+      changes:
+        - addNotNullConstraint:
+            columnDataType: ${text.type}
+            tableName: metabase_database
+            columnName: details
+
 
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -184,8 +184,9 @@
                       :metadata_sync_schedule      new-metadata-schedule
                       :cache_field_values_schedule new-fieldvalues-schedule)))))))))
 
-(defn- pre-insert [database]
-  (-> database
+(defn- pre-insert [{:keys [details], :as database}]
+  (-> (cond-> database
+        (not details) (assoc :details {}))
       handle-secrets-changes
       (assoc :initial_sync_status "incomplete")))
 
@@ -206,7 +207,6 @@
                                        :cache_field_values_schedule :cron-string
                                        :start_of_week               :keyword
                                        :settings                    :encrypted-json})
-          :properties     (constantly {:timestamped? true})
           :post-insert    post-insert
           :post-select    post-select
           :pre-insert     pre-insert

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -303,6 +303,9 @@
   [[{:keys [id]}]]
   (db/select-one-field :id Database :name id))
 
-(defmethod serdes.base/load-xform "Database" [entity]
-  (-> (serdes.base/load-xform-basics entity)
-    (update :creator_id serdes.util/import-user)))
+(defmethod serdes.base/load-xform "Database"
+  [database]
+  (-> (cond-> database
+        (not (:details database)) (assoc :details "{}"))
+      serdes.base/load-xform-basics
+      (update :creator_id serdes.util/import-user)))

--- a/src/metabase/models/serialization/base.clj
+++ b/src/metabase/models/serialization/base.clj
@@ -332,6 +332,7 @@
 
   Keyed on the model name for this entity.
   Default implementation returns an empty vector, so only models that have dependencies need to implement this."
+  {:arglists '([ingested])}
   ingested-model)
 
 (defmethod serdes-dependencies :default [_]
@@ -346,6 +347,7 @@
 
   By default, this just calls [[load-xform-basics]].
   If you override this, call [[load-xform-basics]] as well."
+  {:arglists '([ingested])}
   ingested-model)
 
 (defn load-xform-basics
@@ -370,6 +372,7 @@
   Keyed on the model name (the first argument), because the second argument doesn't have its `:serdes/meta` anymore.
 
   Returns the primary key of the updated entity."
+  {:arglists '([model-name ingested local])}
   (fn [model _ _] model))
 
 (defmethod load-update! :default [model-name ingested local]
@@ -394,6 +397,7 @@
   Keyed on the model name (the first argument), because the second argument doesn't have its `:serdes/meta` anymore.
 
   Returns the primary key of the newly inserted entity."
+  {:arglists '([model ingested])}
   (fn [model _] model))
 
 (defmethod load-insert! :default [model ingested]

--- a/test/metabase/db/fix_mysql_utf8_test.clj
+++ b/test/metabase/db/fix_mysql_utf8_test.clj
@@ -62,8 +62,8 @@
 (def ^:private test-unicode-str "Cam 𝌆 Saul 💩")
 
 (defn- insert-row! []
-  (jdbc/execute! db/*db-connection* [(str "INSERT INTO metabase_database (engine, name, created_at, updated_at) "
-                                          "VALUES ('mysql', ?, current_timestamp, current_timestamp)")
+  (jdbc/execute! db/*db-connection* [(str "INSERT INTO metabase_database (engine, name, created_at, updated_at, details) "
+                                          "VALUES ('mysql', ?, current_timestamp, current_timestamp, '{}')")
                                      test-unicode-str]))
 
 ;; The basic idea behind this test is:

--- a/test/metabase/models/database_test.clj
+++ b/test/metabase/models/database_test.clj
@@ -254,3 +254,10 @@
              (serdes.hash/identity-hash db)))
       (is (= "b6f1a9e8"
              (serdes.hash/identity-hash db))))))
+
+(deftest create-database-with-null-details-test
+  (testing "Details should get a default value of {} if unspecified"
+    (mt/with-model-cleanup [Database]
+      (let [db (db/insert! Database (dissoc (mt/with-temp-defaults Database) :details))]
+        (is (partial= {:details {}}
+                      db))))))


### PR DESCRIPTION
Resolves #25658

We've long validated Database `details` in the REST API layer; it was probably an oversight that we never made it required in the application database schema itself. This PR sets changes all `NULL` `details` to `{}` and then adds a `NOT NULL` constraint to the column. Because older MySQL won't let us have nice things, [we cannot add a default value to `text` columns](https://dev.mysql.com/doc/refman/5.7/en/blob.html), so instead I am simulating a default value in Toucan `pre-insert`.

Note that in regular usage you still shouldn't be able to create a Database with invalid details, but in SerDes v2 it's possible to load a Database without including details -- see #25658.

While I was at it I also went ahead and added default values for Database `created_at` and `updated_at` -- we were previously simulating them in Toucan but it's probably better to do this in the application database itself where we can because it facilitates non-Toucan usage of the app DB, for example scripting or writing schema migration tests.