### PR TITLE
Fix Models code that is dependent on the Model being a real entity

### DIFF
--- a/frontend/src/metabase-lib/lib/Question.ts
+++ b/frontend/src/metabase-lib/lib/Question.ts
@@ -600,7 +600,7 @@ class QuestionInner {
   }
 
   composeDataset() {
-    if (!this.isDataset()) {
+    if (!this.isDataset() || !this.isSaved()) {
       return this;
     }
 
@@ -1038,7 +1038,7 @@ class QuestionInner {
     // we frequently treat dataset/model questions like they are already nested
     // so we need to fetch the virtual card table representation of the Question
     // so that we can properly access the table's fields in various scenarios
-    if (this.isDataset()) {
+    if (this.isDataset() && this.isSaved()) {
       dependencies.push({
         type: "table",
         id: getQuestionVirtualTableId(this.card()),

--- a/frontend/src/metabase/query_builder/actions/querying.js
+++ b/frontend/src/metabase/query_builder/actions/querying.js
@@ -206,7 +206,8 @@ export const queryCompleted = (question, queryResults) => {
     const card = question.card();
 
     const isEditingModel = getQueryBuilderMode(getState()) === "dataset";
-    const modelMetadata = isEditingModel
+    const isEditingSavedModel = isEditingModel && !!originalQuestion;
+    const modelMetadata = isEditingSavedModel
       ? preserveModelMetadata(queryResults, originalQuestion)
       : undefined;
 


### PR DESCRIPTION
Related to https://github.com/metabase/metabase/issues/25049

- Return `this` when a model isn't saved as the nested query relies on the model having an `id`
- Skip fetching the model as a virtual table because you can't until it has an `id`
- Avoid running `preserveModelMetadata` when the `originalModel` value doesn't exist in state -- it won't exist when the model is unsaved.