### PR TITLE
Data Apps: better action-adding behavior

### DIFF
--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ActionOptions/ActionOptions.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ActionOptions/ActionOptions.tsx
@@ -30,6 +30,8 @@ interface ActionOptionsDispatchProps {
     dashCardId: number,
     settings: {
       action_id?: number | null;
+      action?: WritebackAction;
+      visualization_settings?: ActionDashboardCard["visualization_settings"];
       parameter_mappings?: ActionParametersMapping[] | null;
     },
   ) => void;
@@ -57,6 +59,12 @@ function ActionOptions({
     (action: WritebackAction) => {
       onUpdateButtonActionMapping(dashcard.id, {
         action_id: action.id,
+        action,
+        visualization_settings: {
+          ...dashcard.visualization_settings,
+          "button.label":
+            dashcard.visualization_settings["button.label"] ?? action.name,
+        },
 
         // Clean mappings from previous action
         // as they're most likely going to be irrelevant

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ActionOptions/ActionOptions.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ActionOptions/ActionOptions.tsx
@@ -5,6 +5,7 @@ import { connect } from "react-redux";
 import Actions from "metabase/entities/actions";
 
 import { updateButtonActionMapping } from "metabase/dashboard/actions";
+import { updateSettings } from "metabase/visualizations/lib/settings";
 
 import type {
   ActionDashboardCard,
@@ -60,12 +61,10 @@ function ActionOptions({
       onUpdateButtonActionMapping(dashcard.id, {
         action_id: action.id,
         action,
-        visualization_settings: {
-          ...dashcard.visualization_settings,
-          "button.label":
-            dashcard.visualization_settings["button.label"] ?? action.name,
-        },
-
+        visualization_settings: updateSettings(
+          { "button.label": action.name },
+          dashcard.visualization_settings,
+        ),
         // Clean mappings from previous action
         // as they're most likely going to be irrelevant
         parameter_mappings: null,

--- a/frontend/src/metabase/writeback/components/ActionViz/ActionButtonView.tsx
+++ b/frontend/src/metabase/writeback/components/ActionViz/ActionButtonView.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { t } from "ttag";
 
 import type { VisualizationProps } from "metabase-types/types/Visualization";
 
@@ -28,7 +29,7 @@ function ActionButtonView({
       isFullHeight={isFullHeight}
       {...variantProps}
     >
-      {label}
+      {label ?? t`Click me`}
     </StyledButton>
   );
 }

--- a/frontend/src/metabase/writeback/components/ActionViz/ActionViz.tsx
+++ b/frontend/src/metabase/writeback/components/ActionViz/ActionViz.tsx
@@ -38,7 +38,6 @@ export default Object.assign(Action, {
       section: t`Display`,
       title: t`Label`,
       widget: "input",
-      default: "Click Me",
     },
     "button.variant": {
       section: t`Display`,


### PR DESCRIPTION
## Description

Some small improvements to the experience of adding actions to dashboards (I'd like to do more, but I realized this was a quick win)

- action buttons get default names based on their action names (falling back to 'click me' still if there's no action connected)

![defaultbutton](https://user-images.githubusercontent.com/30528226/193135408-745d4535-b878-4141-82af-d7ac3101ac1d.gif)

- when you select an action with a form from the sidebar, you can preview it before saving the whole dashboard

![formpreview](https://user-images.githubusercontent.com/30528226/193135863-7ebccb6e-0d0e-43e5-9a83-23c65e457ff6.gif)


