### PR TITLE
Update routing/url logic to support unsaved Models

### DIFF
--- a/frontend/src/metabase/lib/urls/questions.ts
+++ b/frontend/src/metabase/lib/urls/questions.ts
@@ -104,12 +104,14 @@ export function newQuestion({
   objectId,
   ...options
 }: NewQuestionUrlBuilderParams = {}) {
-  const url = Question.create(options).getUrl({
+  const question = Question.create(options);
+  const url = question.getUrl({
     creationType,
     query: objectId ? { objectId } : undefined,
   });
   if (mode) {
-    return url.replace(/^\/question/, `/question\/${mode}`);
+    const entity = question.isDataset() ? "model" : "question";
+    return url.replace(/^\/(question|model)/, `/${entity}\/${mode}`);
   } else {
     return url;
   }

--- a/frontend/src/metabase/lib/urls/questions.ts
+++ b/frontend/src/metabase/lib/urls/questions.ts
@@ -53,14 +53,13 @@ export function question(
     query = "?" + query;
   }
 
+  const isModel = card?.dataset || card?.model === "dataset";
+  let path = isModel ? "model" : "question";
   if (!card || !card.id) {
-    return `/question${query}${hash}`;
+    return `/${path}${query}${hash}`;
   }
 
   const { card_id, id, name } = card;
-  const isModel = card?.dataset || card?.model === "dataset";
-  let path = isModel ? "model" : "question";
-
   /**
    * If the question has been added to the dashboard we're reading the dashCard's properties.
    * In that case `card_id` is the actual question's id, while `id` corresponds with the dashCard itself.

--- a/frontend/src/metabase/routes.jsx
+++ b/frontend/src/metabase/routes.jsx
@@ -291,6 +291,8 @@ export const getRoutes = store => (
           <Route path=":slug/query" component={QueryBuilder} />
           <Route path=":slug/metadata" component={QueryBuilder} />
           <Route path=":slug/:objectId" component={QueryBuilder} />
+          <Route path="query" component={QueryBuilder} />
+          <Route path="metadata" component={QueryBuilder} />
         </Route>
 
         <Route path="browse" component={BrowseApp}>

--- a/frontend/src/metabase/selectors/app.ts
+++ b/frontend/src/metabase/selectors/app.ts
@@ -19,7 +19,12 @@ export interface RouterProps {
 }
 
 const HOMEPAGE_PATH = /^\/$/;
-const PATHS_WITHOUT_NAVBAR = [/\/model\/.*\/query/, /\/model\/.*\/metadata/];
+const PATHS_WITHOUT_NAVBAR = [
+  /\/model\/.*\/query/,
+  /\/model\/.*\/metadata/,
+  /\/model\/query/,
+  /\/model\/metadata/,
+];
 const EMBEDDED_PATHS_WITH_NAVBAR = [
   HOMEPAGE_PATH,
   /^\/collection\/.*/,


### PR DESCRIPTION
Related to https://github.com/metabase/metabase/issues/25049

- Move the logic for setting the `path` variable to `"model"` or `"question"` above the return statement for cards without `id`.
- Add `/model/metadata` and `/model/query` routes (not sure if this actually does anything, but feels better than not adding them)
- Add the above routes to the `PATHS_WITHOUT_NAVBAR` list
- update `newQuestion` to support use with questions where `dataset` is set to `true`.