### PR TITLE
Trigger a query run on tab change if the query is dirty

### DIFF
--- a/frontend/src/metabase/query_builder/actions/models.js
+++ b/frontend/src/metabase/query_builder/actions/models.js
@@ -17,6 +17,7 @@ import { setQueryBuilderMode } from "./ui";
 
 export const setDatasetEditorTab = datasetEditorTab => dispatch => {
   dispatch(setQueryBuilderMode("dataset", { datasetEditorTab }));
+  dispatch(runDirtyQuestionQuery());
 };
 
 export const CANCEL_DATASET_CHANGES = "metabase/qb/CANCEL_DATASET_CHANGES";

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
@@ -253,10 +253,10 @@ function DatasetEditor(props) {
     // Focused field has to be set once the query is completed and the result is rendered
     // Visualization render can remove the focus
     const hasQueryResults = !!result;
-    if (!focusedFieldRef && hasQueryResults && !result.error) {
+    if (!focusedField && hasQueryResults && !result.error) {
       focusFirstField();
     }
-  }, [result, focusedFieldRef, focusFirstField]);
+  }, [result, focusedFieldRef, fields, focusFirstField, focusedField]);
 
   const inheritMappedFieldProperties = useCallback(
     changes => {

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataSidebar.jsx
@@ -153,7 +153,7 @@ function DatasetFieldMetadataSidebar({
       setShouldAnimateFieldChange(true);
       // setTimeout is required as form fields are rerendered pretty frequently
       setTimeout(() => {
-        displayNameInputRef.current?.select();
+        displayNameInputRef.current?.select?.();
       });
     }
   }, [field, previousField]);

--- a/frontend/test/metabase/scenarios/models/models-metadata.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models-metadata.cy.spec.js
@@ -152,6 +152,34 @@ describe("scenarios > models metadata", () => {
     cy.findByText("Pre-tax ($)");
   });
 
+  it("should keep metadata in sync with the query", () => {
+    cy.createNativeQuestion(
+      {
+        name: "Native Model",
+        dataset: true,
+        native: {
+          query: "SELECT * FROM ORDERS",
+        },
+      },
+      { visitQuestion: true },
+    );
+
+    openQuestionActions();
+    popover().within(() => {
+      cy.findByText("Edit query definition").click();
+    });
+
+    cy.get(".ace_content").type(
+      "{selectAll}{backspace}SELECT TOTAL FROM ORDERS",
+    );
+
+    cy.findByTestId("editor-tabs-metadata-name").click();
+    cy.wait("@dataset");
+
+    cy.findByTestId("header-cell").should("have.length", 1);
+    cy.findByLabelText("Display name").should("have.value", "TOTAL");
+  });
+
   it("should allow reverting to a specific metadata revision", () => {
     cy.intercept("POST", "/api/revision/revert").as("revert");
 


### PR DESCRIPTION
Related to https://github.com/metabase/metabase/issues/24825 but this is a preexisting issue

If the user edits a model's query without rerunning it, they'll see old columns when they switch to the "metadata" tab. We want to make sure these two tabs stay consistent, so I'm adding `dispatch(runDirtyQuestionQuery());` to the action that updates the state that determines which tab we see so that whenever the query has been changed it'll trigger a rerun. If it hasn't changed, no query will trigger.

Column selection needed to be updated here because the field ref we hold onto might be out of date.


https://user-images.githubusercontent.com/13057258/193343814-b9277c9e-4a46-48ef-bdfd-04ca106725c7.mov


https://user-images.githubusercontent.com/13057258/193343829-8839d5d4-aebb-499a-ac2f-a1ce8e88274b.mov


