### PR TITLE
Experimental: parallel QP tests [WIP]

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -373,7 +373,8 @@
     toucan.models                                                   models}}
 
   :metabase/disallow-invoking-model         {:level :warning}
-  :metabase/disallow-class-or-type-on-model {:level :warning}}
+  :metabase/disallow-class-or-type-on-model {:level :warning}
+  :metabase/disallow-form-in-parallel-tests {:level :error}}
 
  :lint-as
  {clojure.core.logic/defne                                                             clj-kondo.lint-as/def-catch-all
@@ -434,6 +435,7 @@
  {:analyze-call
   {clojure.core/class                                                                                                        hooks.metabase.models.disallow-type-or-class/hook
    clojure.core/type                                                                                                         hooks.metabase.models.disallow-type-or-class/hook
+   clojure.test/deftest                                                                                                      hooks.clojure.test/deftest
    metabase-enterprise.advanced-permissions.models.permissions.application-permissions-test/with-new-group-and-current-graph hooks.common/with-two-top-level-bindings
    metabase-enterprise.audit-app.pages-test/with-temp-objects                                                                hooks.common/with-one-binding
    metabase-enterprise.serialization.test-util/with-temp-dpc                                                                 hooks.toucan.util.test/with-temp*

--- a/.clj-kondo/hooks/clojure/test.clj
+++ b/.clj-kondo/hooks/clojure/test.clj
@@ -1,0 +1,55 @@
+(ns hooks.clojure.test
+  (:require [clj-kondo.hooks-api :as hooks]
+            [clojure.walk :as walk]))
+
+;;; to make our lives a bit easier we'll ignore namespaces... it's not like there are some versions of `with-redefs`
+;;; that are ok while others aren't
+(def ^:private disallowed-forms
+  '#{notify-database-updated
+     with-clock
+     with-column-remappings
+     with-discarded-collections-perms-changes
+     with-locale
+     with-log-level
+     with-log-messages-for-level
+     with-model-cleanup
+     with-non-admin-groups-no-root-collection-perms
+     with-redefs
+     with-system-timezone-id
+     with-temp-env-var-value
+     with-temp-vals-in-db
+     with-temporary-raw-setting-values
+     with-temporary-setting-values})
+
+(defn- disallowed-form? [node]
+  (when (hooks/list-node? node)
+    (let [first-child (first (:children node))]
+      (when (hooks/token-node? first-child)
+        (let [unqualified-symbol (symbol (name (hooks/sexpr first-child)))]
+          (contains? disallowed-forms unqualified-symbol))))))
+
+(defn- check-for-disallowed-forms-in-parallel-tests
+  [nodes]
+  (walk/postwalk
+   (fn [node]
+     (when (disallowed-form? node)
+       (hooks/reg-finding!
+        (assoc (meta (first (:children node)))
+               :message (format "%s is not allowed inside parallel tests" (first (hooks/sexpr node)))
+               :type    :metabase/disallow-form-in-parallel-tests))))
+   nodes))
+
+(defn- parse-metadata
+  "Parse a sequence of metadata nodes into a map that we can actually read."
+  [metadata-nodes]
+  (into {} (for [node metadata-nodes]
+             (cond
+               (hooks/map-node? node)                                 (hooks/sexpr node)
+               ((some-fn hooks/token-node? hooks/keyword-node?) node) [(hooks/sexpr node) true]))))
+
+(defn deftest [{{[_deftest {test-metadata-nodes :meta, :as _test-name} & body] :children} :node, :as form}]
+  (let [test-metadata (parse-metadata test-metadata-nodes)
+        parallel?     (:parallel test-metadata)]
+    (when parallel?
+      (check-for-disallowed-forms-in-parallel-tests body)))
+  form)

--- a/src/metabase/events/driver_notifications.clj
+++ b/src/metabase/events/driver_notifications.clj
@@ -1,7 +1,7 @@
 (ns metabase.events.driver-notifications
   "Driver notifications are used to let drivers know database details or other relevant information has
   changed (`:database-update`) or that a Database has been deleted (`:database-delete`). Drivers can choose to be
-  notified of these events by implementing the `metabase.driver/notify-database-updated` multimethod. At the time of
+  notified of these events by implementing the [[metabase.driver/notify-database-updated]] multimethod. At the time of
   this writing, the SQL JDBC driver 'superclass' is the only thing that implements this method, and does so to close
   connection pools when database details change or when they are deleted."
   (:require [clojure.core.async :as a]

--- a/test/metabase/driver/sql/query_processor_test_util.clj
+++ b/test/metabase/driver/sql/query_processor_test_util.clj
@@ -1,82 +1,11 @@
 (ns metabase.driver.sql.query-processor-test-util
-  (:require [clojure.string :as str]
-            [clojure.test :refer :all]
-            [honeysql.format :as hformat]
-            [metabase.driver :as driver]
-            [metabase.driver.util :as driver.u]
-            [metabase.query-processor :as qp]
-            [metabase.util :as u]))
-
-;; [[install-pretty-formatters!]] -- tweaks the actual methods HoneySQL uses to generate SQL strings to add indentation
-
-(defonce ^:private ^clojure.lang.MultiFn orig-format-clause hformat/format-clause)
-
-(defn remove-pretty-formatters!
-  "Remove the pretty formatters installed by [[install-pretty-formatters!]]."
-  []
-  (alter-var-root #'hformat/format-clause (constantly orig-format-clause)))
-
-(defmulti ^:private pretty-format
-  "Special version of [[hformat/format-clause]] that indents and pretty-prints the resulting form."
-  {:arglists '([clause sql-map])}
-  (.dispatchFn orig-format-clause))
-
-(defn install-pretty-formatters!
-  "Install code so HoneySQL will pretty-print the SQL it generates."
-  []
-  (alter-var-root #'hformat/format-clause (constantly pretty-format)))
-
-(defn- pretty-formatters-installed?
-  "Whether pretty formatters were installed by [[install-pretty-formatters!]] or not."
-  []
-  (identical? hformat/format-clause pretty-format))
-
-(defn do-with-pretty-formatters
-  "Impl for [[with-pretty-formatters]]."
-  [thunk]
-  (if (pretty-formatters-installed?)
-    (thunk)
-    (try
-      (install-pretty-formatters!)
-      (thunk)
-      (finally
-        (remove-pretty-formatters!)))))
-
-(defmacro with-pretty-formatters
-  "Execute body with the pretty formatters from [[install-pretty-formatters!]] temporarily installed (if they are not
-  already installed)."
-  [& body]
-  `(do-with-pretty-formatters (fn [] ~@body)))
-
-(def ^:private ^:dynamic *indent* 0)
-
-(defn- indent [] (str/join (repeat (* *indent* 2) \space)))
-
-(defn- newline-and-indent []
-  (str \newline (indent)))
-
-(def ^:private ^:dynamic *indent-comma-join* true)
-
-(defn- indent-comma-join [strs]
-  (if *indent-comma-join*
-    (str (newline-and-indent)
-         (str/join (str "," (newline-and-indent))
-                   strs))
-    (str/join ", " strs)))
-
-(defmethod pretty-format :default
-  [clause sql-map]
-  (str
-   (newline-and-indent)
-   (binding [*indent*            (inc *indent*)
-             *indent-comma-join* true]
-     (let [to-sql hformat/to-sql]
-       (with-redefs [hformat/comma-join indent-comma-join
-                     hformat/to-sql     (fn [form]
-                                          (binding [*indent-comma-join* false]
-                                            (to-sql form)))]
-         (orig-format-clause clause sql-map))))))
-
+  (:require
+   [clojure.string :as str]
+   [clojure.test :refer :all]
+   [metabase.driver :as driver]
+   [metabase.driver.util :as driver.u]
+   [metabase.query-processor :as qp]
+   [metabase.util :as u]))
 
 ;;;; [[query->sql-map]] and [[sql->sql-map]] -- these parse an actual SQL map into a pseudo-HoneySQL form
 
@@ -180,26 +109,25 @@
 
 ;;;; [[testing]] context tooling
 
-(defn pprint-native-query-with-best-strategy
-  "Attempt to compile `query` to a native query, and pretty-print it if possible."
+(defn- print-native-query-to-str
+  "Attempt to compile `query` to a native query."
   [query]
-  (with-pretty-formatters
-    (u/ignore-exceptions
-      (let [{native :query, :as query} (query->raw-native-query query)]
-        (str "\nNative Query =\n"
-             (if (string? native)
-               native
-               (u/pprint-to-str native))
-             \newline
-             \newline
-             (u/pprint-to-str (dissoc query :query))
-             \newline)))))
+  (u/ignore-exceptions
+    (let [{native :query, :as query} (query->raw-native-query query)]
+      (str "\nNative Query =\n"
+           (if (string? native)
+             native
+             (u/pprint-to-str native))
+           \newline
+           \newline
+           (u/pprint-to-str (dissoc query :query))
+           \newline))))
 
 (defn do-with-native-query-testing-context
   [query thunk]
   ;; building the pretty-printing string is actually a little bit on the expensive side so only do the work needed if
   ;; someone actually looks at the [[testing]] context (i.e. if the test fails)
-  (testing (let [to-str (delay (pprint-native-query-with-best-strategy query))]
+  (testing (let [to-str (delay (print-native-query-to-str query))]
              (reify
                java.lang.Object
                (toString [_]

--- a/test/metabase/driver/sql_jdbc/connection_test.clj
+++ b/test/metabase/driver/sql_jdbc/connection_test.clj
@@ -114,7 +114,7 @@
                                        (swap! hash-change-called-times inc)
                                        nil)]
         (try
-          (sql-jdbc.conn/invalidate-pool-for-db! db)
+          (#'sql-jdbc.conn/invalidate-pool-for-db! db)
           ;; a little bit hacky to redefine the log fn, but it's the most direct way to test
           (with-redefs [sql-jdbc.conn/log-jdbc-spec-hash-change-msg! hash-change-fn]
             (let [pool-spec-1 (sql-jdbc.conn/db->pooled-connection-spec db)

--- a/test/metabase/query_processor/test_util.clj
+++ b/test/metabase/query_processor/test_util.clj
@@ -124,14 +124,9 @@
 ;;; ------------------------------------------------- Timezone Stuff -------------------------------------------------
 
 (defn do-with-report-timezone-id
-  "Impl for `with-report-timezone-id`."
+  "Impl for [[with-report-timezone-id]]."
   [timezone-id thunk]
   {:pre [((some-fn nil? string?) timezone-id)]}
-  ;; This will fail if the app DB isn't initialized yet. That's fine — there's no DBs to notify if the app DB isn't
-  ;; set up.
-  (try
-    (#'driver/notify-all-databases-updated)
-    (catch Throwable _))
   (binding [qp.timezone/*report-timezone-id-override* (or timezone-id ::nil)]
     (testing (format "\nreport timezone id = %s" timezone-id)
       (thunk))))

--- a/test/metabase/query_processor_test/advanced_math_test.clj
+++ b/test/metabase/query_processor_test/advanced_math_test.clj
@@ -17,43 +17,43 @@
        ;; Round to prevent minute differences across DBs due to differences in how float point math is handled
        (u/round-to-decimals 2)))
 
-(deftest test-round
+(deftest ^:parallel test-round
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
     (is (= 1.0 (test-math-expression [:round 0.7])))))
 
-(deftest test-floor
+(deftest ^:parallel test-floor
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
     (is (= 0.0 (test-math-expression [:floor 0.7])))))
 
-(deftest test-ceil
+(deftest ^:parallel test-ceil
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
     (is (= 1.0 (test-math-expression [:ceil 0.3])))))
 
-(deftest test-abs
+(deftest ^:parallel test-abs
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
     (is (= 2.0 (test-math-expression [:abs -2])))))
 
 
-(deftest test-power
+(deftest ^:parallel test-power
   (mt/test-drivers (mt/normal-drivers-with-feature :advanced-math-expressions)
     (is (= 4.0 (test-math-expression [:power 2.0 2])))
     (is (= 2.0 (test-math-expression [:power 4.0 0.5])))
     (is (= 0.25 (test-math-expression [:power 2.0 -2])))))
 
-(deftest test-sqrt
+(deftest ^:parallel test-sqrt
   (mt/test-drivers (mt/normal-drivers-with-feature :advanced-math-expressions)
     (is (= 2.0 (test-math-expression [:sqrt 4.0])))))
 
-(deftest test-exp
+(deftest ^:parallel test-exp
   (mt/test-drivers (mt/normal-drivers-with-feature :advanced-math-expressions)
     (is (= 7.39 (test-math-expression [:exp 2.0])))))
 
-(deftest test-log
+(deftest ^:parallel test-log
   (mt/test-drivers (mt/normal-drivers-with-feature :advanced-math-expressions)
     (is (= 1.0 (test-math-expression [:log 10.0])))))
 
 
-(deftest test-filter
+(deftest ^:parallel test-filter
   (mt/test-drivers (mt/normal-drivers-with-feature :advanced-math-expressions)
     (is (= 59 (->> {:aggregation [[:count]]
                     :filter      [:between [:- [:round [:power [:field (mt/id :venues :price) nil] 2]] 1] 1 5]}
@@ -72,19 +72,19 @@
        double
        (u/round-to-decimals 2)))
 
-(deftest test-variance
+(deftest ^:parallel test-variance
   (mt/test-drivers (mt/normal-drivers-with-feature :standard-deviation-aggregations)
     (is (= 0.59 (test-aggregation [:var [:field (mt/id :venues :price) nil]])))))
 
-(deftest test-median
+(deftest ^:parallel test-median
   (mt/test-drivers (mt/normal-drivers-with-feature :percentile-aggregations)
     (is (= 2.0 (test-aggregation [:median [:field (mt/id :venues :price) nil]])))))
 
-(deftest test-percentile
+(deftest ^:parallel test-percentile
   (mt/test-drivers (mt/normal-drivers-with-feature :percentile-aggregations)
     (is (= 3.0 (test-aggregation [:percentile [:field (mt/id :venues :price) nil] 0.9])))))
 
-(deftest test-nesting
+(deftest ^:parallel test-nesting
   (mt/test-drivers (mt/normal-drivers-with-feature :advanced-math-expressions)
     (is (= 2.0 (test-math-expression [:sqrt [:power 2.0 2]])))
     (is (= 59.0 (test-aggregation [:count-where [:between [:- [:round [:power [:field (mt/id :venues :price) nil] 2]] 1] 1 5]])))))

--- a/test/metabase/query_processor_test/aggregation_test.clj
+++ b/test/metabase/query_processor_test/aggregation_test.clj
@@ -7,7 +7,7 @@
             [metabase.test.data :as data]
             [metabase.test.util :as tu]))
 
-(deftest no-aggregation-test
+(deftest ^:parallel no-aggregation-test
   (mt/test-drivers (mt/normal-drivers)
     (testing "Test that no aggregation just returns rows as-is."
       (is (= [[1 "Red Medicine" 4 10.0646 -165.374 3]
@@ -24,7 +24,7 @@
                (mt/run-mbql-query venues
                  {:limit 10, :order-by [[:asc $id]]})))))))
 
-(deftest basic-aggregations-test
+(deftest ^:parallel basic-aggregations-test
   (mt/test-drivers (mt/normal-drivers)
     (testing "count aggregation"
       (is (= [[100]]
@@ -50,7 +50,7 @@
                (mt/run-mbql-query checkins
                  {:aggregation [[:distinct $user_id]]})))))))
 
-(deftest standard-deviation-test
+(deftest ^:parallel standard-deviation-test
   (mt/test-drivers (mt/normal-drivers-with-feature :standard-deviation-aggregations)
     (testing "standard deviation aggregations"
       (is (= {:cols [(qp.test/aggregate-col :stddev :venues :latitude)]
@@ -72,7 +72,7 @@
 ;;; |                                                   MIN & MAX                                                    |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-(deftest min-test
+(deftest ^:parallel min-test
   (mt/test-drivers (mt/normal-drivers)
     (is (= [1]
            (mt/first-row
@@ -86,7 +86,7 @@
                {:aggregation [[:min $latitude]]
                 :breakout    [$price]}))))))
 
-(deftest max-test
+(deftest ^:parallel max-test
   (mt/test-drivers (mt/normal-drivers)
     (is (= [4]
            (mt/first-row
@@ -105,7 +105,7 @@
 ;;; |                                             MULTIPLE AGGREGATIONS                                              |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-(deftest multiple-aggregations-test
+(deftest ^:parallel multiple-aggregations-test
   (mt/test-drivers (mt/normal-drivers)
     (testing "two aggregations"
       (is (= [[100 203]]
@@ -119,7 +119,7 @@
                (mt/run-mbql-query venues
                  {:aggregation [[:avg $price] [:count] [:sum $price]]})))))))
 
-(deftest multiple-aggregations-metadata-test
+(deftest ^:parallel multiple-aggregations-metadata-test
   ;; TODO - this isn't tested against Mongo because those driver doesn't currently work correctly with multiple
   ;; columns with the same name. It seems like it would be pretty easy to take the stuff we have for BigQuery and
   ;; generalize it so we can use it with Mongo
@@ -136,7 +136,7 @@
 
 ;;; ------------------------------------------------- CUMULATIVE SUM -------------------------------------------------
 
-(deftest cumulate-sum-test
+(deftest ^:parallel cumulate-sum-test
   (mt/test-drivers (mt/normal-drivers)
     (testing "cum_sum w/o breakout should be treated the same as sum"
       (is (= [[120]]
@@ -198,7 +198,7 @@
 
 
 ;;; ------------------------------------------------ CUMULATIVE COUNT ------------------------------------------------
-(deftest cumulative-count-test
+(deftest ^:parallel cumulative-count-test
   (mt/test-drivers (mt/normal-drivers)
     (testing "cumulative count aggregations"
       (testing "w/o breakout should be treated the same as count"
@@ -256,7 +256,7 @@
                (or (-> results mt/cols first)
                    results)))))))
 
-(deftest duplicate-aggregations-test
+(deftest ^:parallel duplicate-aggregations-test
   (mt/test-drivers (mt/normal-drivers)
     (testing "Do we properly handle queries that have more than one of the same aggregation? (#5393)"
       (is (= [[5050 203]]
@@ -264,7 +264,7 @@
                (mt/run-mbql-query venues
                                   {:aggregation [[:sum $id] [:sum $price]]})))))))
 
-(deftest multiple-distinct-aggregations-test
+(deftest ^:parallel multiple-distinct-aggregations-test
   (testing "Multiple `:distinct` aggregations should work correctly (#13097)"
     (mt/test-drivers (mt/normal-drivers)
       (is (= [[100 4]]

--- a/test/metabase/query_processor_test/alternative_date_test.clj
+++ b/test/metabase/query_processor_test/alternative_date_test.clj
@@ -11,7 +11,7 @@
             [metabase.util :as u])
   (:import java.time.OffsetDateTime))
 
-(deftest semantic-type->unix-timestamp-unit-test
+(deftest ^:parallel semantic-type->unix-timestamp-unit-test
   (testing "every descendant of `:Coercion/UNIXTime->Temporal` has a unit associated with it"
     (doseq [semantic-type (descendants :Coercion/UNIXTime->Temporal)]
       (is (sql.qp/semantic-type->unix-timestamp-unit semantic-type))))
@@ -31,7 +31,7 @@
     [[4 1433587200000000]
      [0 1433965860000000]]]])
 
-(deftest microseconds-test
+(deftest ^:parallel microseconds-test
   (mt/test-drivers (disj (mt/normal-drivers) :sqlite)
     (let [results (get {:sqlite #{[1 4 "2015-06-06 10:40:00"] [2 0 "2015-06-10 19:51:00"]}
                         :oracle #{[1M 4M "2015-06-06T10:40:00Z"] [2M 0M "2015-06-10T19:51:00Z"]}}
@@ -115,7 +115,7 @@
                        :limit       10}))
                   mt/rows (mt/format-rows-by [identity int])))))))
 
-(deftest substitute-native-parameters-test
+(deftest ^:parallel substitute-native-parameters-test
   (mt/test-drivers (mt/normal-drivers-with-feature :native-parameters)
     (testing "Make sure `:date/range` SQL field filters work correctly with UNIX timestamps (#11934)"
       (mt/dataset tupac-sightings
@@ -174,7 +174,7 @@
      ["bar" "2008-10-19 10:23:54" "2008-10-19" "10:23:54"]
      ["baz" "2012-10-19 10:23:54" "2012-10-19" "10:23:54"]]]])
 
-(deftest iso-8601-text-fields
+(deftest ^:parallel iso-8601-text-fields
   (testing "text fields with semantic_type :type/ISO8601DateTimeString"
     (testing "return as dates"
       (mt/test-drivers (disj (sql-jdbc.tu/sql-jdbc-drivers) :sqlite :oracle :sparksql)
@@ -267,7 +267,7 @@
      ["bar" (.getBytes "20200421164300")]
      ["baz" (.getBytes "20210421164300")]]]])
 
-(deftest yyyymmddhhmmss-binary-dates
+(deftest ^:parallel yyyymmddhhmmss-binary-dates
   (mt/test-drivers #{:postgres :h2 :mysql}
     (is (= (case driver/*driver*
              :postgres
@@ -286,7 +286,7 @@
                                   (assoc (mt/mbql-query times)
                                          :middleware {:format-rows? false})))))))))
 
-(deftest yyyymmddhhmmss-dates
+(deftest ^:parallel yyyymmddhhmmss-dates
   (mt/test-drivers #{:mongo :oracle :postgres :h2 :mysql :bigquery-cloud-sdk :snowflake :redshift :sqlserver :presto}
     (is (= (case driver/*driver*
              :mongo

--- a/test/metabase/query_processor_test/breakout_test.clj
+++ b/test/metabase/query_processor_test/breakout_test.clj
@@ -12,7 +12,7 @@
             [metabase.test :as mt]
             [metabase.util :as u]))
 
-(deftest basic-test
+(deftest ^:parallel basic-test
   (mt/test-drivers (mt/normal-drivers)
     (testing "single column"
       (testing "with breakout"
@@ -162,7 +162,7 @@
                                     [:> $latitude 20]]
                       :breakout    [[:field %latitude {:binning {:strategy :default}}]]})))))))))
 
-(deftest binning-info-test
+(deftest ^:parallel binning-info-test
   (mt/test-drivers (mt/normal-drivers-with-feature :binning)
     (testing "Validate binning info is returned with the binning-strategy"
       (testing "binning-strategy = default"
@@ -255,12 +255,11 @@
                    (qp/process-query
                     (nested-venues-query card)))))))))))
 
-(deftest field-in-breakout-and-fields-test
+(deftest ^:parallel field-in-breakout-and-fields-test
   (mt/test-drivers (mt/normal-drivers)
     (testing (str "if we include a Field in both breakout and fields, does the query still work? (Normalization should "
                   "be taking care of this) (#8760)")
-      (is (= :completed
-             (:status
-              (mt/run-mbql-query venues
-                {:breakout [$price]
-                 :fields   [$price]})))))))
+      (is (partial= {:status :completed}
+                    (mt/run-mbql-query venues
+                      {:breakout [$price]
+                       :fields   [$price]}))))))

--- a/test/metabase/query_processor_test/case_test.clj
+++ b/test/metabase/query_processor_test/case_test.clj
@@ -11,7 +11,7 @@
            ffirst
            double))
 
-(deftest test-case-aggregations
+(deftest ^:parallel test-case-aggregations
   (mt/test-drivers (mt/normal-drivers-with-feature :basic-aggregations)
     (is (= 116.0 (test-case [:sum [:case [[[:< [:field (mt/id :venues :price) nil] 2] 2]
                                           [[:< [:field (mt/id :venues :price) nil] 4] 1]]]])))
@@ -58,7 +58,7 @@
                   (map (fn [[k v]]
                          [(long k) (double v)]))))))))
 
-(deftest test-case-aggregations+expressions
+(deftest ^:parallel test-case-aggregations+expressions
   (mt/test-drivers (mt/normal-drivers-with-feature :basic-aggregations :expressions)
     (testing "Can we use case in metric expressions"
       (is (= 90.5  (test-case [:+ [:/ [:sum [:case [[[:< [:field (mt/id :venues :price) nil] 4] [:field (mt/id :venues :price) nil]]]
@@ -67,12 +67,12 @@
       (is (= 194.5 (test-case [:sum [:case [[[:< [:field (mt/id :venues :price) nil] 2] [:+ [:field (mt/id :venues :price) nil] 1]]
                                             [[:< [:field (mt/id :venues :price) nil] 4] [:+ [:/ [:field (mt/id :venues :price) nil] 2] 1]]]]]))))))
 
-(deftest test-case-normalization
+(deftest ^:parallel test-case-normalization
   (mt/test-drivers (mt/normal-drivers-with-feature :basic-aggregations)
     (is (= 116.0 (test-case ["sum" ["case" [[["<" ["field-id" (mt/id :venues :price)] 2] 2]
                                             [["<" ["field-id" (mt/id :venues :price)] 4] 1]]]])))))
 
-(deftest test-case-expressions
+(deftest ^:parallel test-case-expressions
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
     (is (= [nil -2.0 -1.0]
            (->> {:expressions {"case_test" [:case [[[:< [:field (mt/id :venues :price) nil] 2] -1.0]
@@ -84,7 +84,7 @@
                 distinct
                 sort)))))
 
-(deftest two-case-functions-test
+(deftest ^:parallel two-case-functions-test
   (testing "We should support expressions with two case statements (#15107)"
     (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
       (mt/dataset sample-dataset

--- a/test/metabase/query_processor_test/constraints_test.clj
+++ b/test/metabase/query_processor_test/constraints_test.clj
@@ -12,7 +12,7 @@
 (defn- native-query []
   (qp/compile (mbql-query)))
 
-(deftest max-results-test
+(deftest ^:parallel max-results-test
   (mt/test-drivers (mt/normal-drivers)
     (testing "Do `:max-results` constraints affect the number of rows returned by native queries?"
       (is (= [["Red Medicine"]
@@ -42,7 +42,7 @@
                  :constraints {:max-results 5}}
                 {:context :question})))))))
 
-(deftest override-limit-test
+(deftest ^:parallel override-limit-test
   (mt/test-drivers (mt/normal-drivers)
     (testing "constraints should override MBQL `:limit` if lower"
       (is (= [["Red Medicine"]

--- a/test/metabase/query_processor_test/count_where_test.clj
+++ b/test/metabase/query_processor_test/count_where_test.clj
@@ -4,7 +4,7 @@
             [metabase.models.segment :refer [Segment]]
             [metabase.test :as mt]))
 
-(deftest basic-test
+(deftest ^:parallel basic-test
   (mt/test-drivers (mt/normal-drivers-with-feature :basic-aggregations)
     (is (= 94
            (->> {:aggregation [[:count-where [:< [:field-id (mt/id :venues :price)] 4]]]}
@@ -20,7 +20,7 @@
                   ffirst
                   long))))))
 
-(deftest compound-condition-test
+(deftest ^:parallel compound-condition-test
   (mt/test-drivers (mt/normal-drivers-with-feature :basic-aggregations)
     (is (= 17
            (->> {:aggregation [[:count-where
@@ -34,7 +34,7 @@
                 ffirst
                 long)))))
 
-(deftest filter-test
+(deftest ^:parallel filter-test
   (mt/test-drivers (mt/normal-drivers-with-feature :basic-aggregations)
     (is (= nil
            (->> {:aggregation [[:count-where [:< [:field-id (mt/id :venues :price)] 4]]]
@@ -43,7 +43,7 @@
                 mt/rows
                 ffirst)))))
 
-(deftest breakout-test
+(deftest ^:parallel breakout-test
   (mt/test-drivers (mt/normal-drivers-with-feature :basic-aggregations)
     (is (= [[2 0]
             [3 0]
@@ -58,7 +58,7 @@
                 (map (fn [[k v]]
                        [(long k) (long v)])))))))
 
-(deftest count-where-inside-expression-test
+(deftest ^:parallel count-where-inside-expression-test
   (mt/test-drivers (mt/normal-drivers-with-feature :basic-aggregations :expressions)
     (is (= 48
            (->> {:aggregation [[:+
@@ -71,7 +71,7 @@
                 ffirst
                 long)))))
 
-(deftest segment-test
+(deftest ^:parallel segment-test
   (mt/test-drivers (mt/normal-drivers-with-feature :basic-aggregations)
     (mt/with-temp Segment [{segment-id :id} {:table_id   (mt/id :venues)
                                              :definition {:source-table (mt/id :venues)
@@ -83,7 +83,7 @@
                   ffirst
                   long))))))
 
-(deftest metric-test
+(deftest ^:parallel metric-test
   (mt/test-drivers (mt/normal-drivers-with-feature :basic-aggregations)
     (mt/with-temp Metric [{metric-id :id} {:table_id   (mt/id :venues)
                                            :definition {:source-table (mt/id :venues)

--- a/test/metabase/query_processor_test/date_bucketing_test.clj
+++ b/test/metabase/query_processor_test/date_bucketing_test.clj
@@ -51,7 +51,7 @@
     (get timezone x)
     x))
 
-(deftest sanity-check-test
+(deftest ^:parallel sanity-check-test
   ;; TIMEZONE FIXME — currently broken for Snowflake. UNIX timestamps are interpreted as being in the report timezone
   ;; rather than UTC.
   (mt/test-drivers (disj (mt/normal-drivers) :snowflake :redshift)
@@ -291,7 +291,7 @@
              (mt/with-system-timezone-id (timezone :pacific)
                (sad-toucan-incidents-with-bucketing :default :eastern)))))))
 
-(deftest group-by-minute-test
+(deftest ^:parallel group-by-minute-test
   (testing "This dataset doesn't have multiple events in a minute, the results are the same as the default grouping"
     (mt/test-drivers (mt/normal-drivers)
       (is (= (cond
@@ -308,7 +308,7 @@
                (sad-toucan-result (default-timezone-parse-fn :utc) (format-in-timezone-fn :utc)))
              (sad-toucan-incidents-with-bucketing :minute :pacific))))))
 
-(deftest group-by-minute-of-hour-test
+(deftest ^:parallel group-by-minute-of-hour-test
   (testing "Grouping by minute of hour is not affected by timezones"
     (mt/test-drivers (mt/normal-drivers)
       (is (= [[0 5]
@@ -348,7 +348,7 @@
 
 ;; For this test, the results are the same for each database, but the formatting of the time for that given count is
 ;; different depending on whether the database supports a report timezone and what timezone that database is in
-(deftest group-by-hour-test
+(deftest ^:parallel group-by-hour-test
   (mt/test-drivers (mt/normal-drivers)
     (is (= (cond
              (= :sqlite driver/*driver*)
@@ -367,7 +367,7 @@
 ;; The counts are affected by timezone as the times are shifted back by 7 hours. These count changes can be validated
 ;; by matching the first three results of the pacific results to the last three of the UTC results (i.e. pacific is 7
 ;; hours back of UTC at that time)
-(deftest group-by-hour-of-day-test
+(deftest ^:parallel group-by-hour-of-day-test
   (mt/test-drivers (mt/normal-drivers)
     (testing "results in pacific timezone"
       (is (= (if (and (not (qp.test/tz-shifted-driver-bug? driver/*driver*))
@@ -398,7 +398,7 @@
 ;; events to we gain and lose. Although this test is technically covered by the other grouping by day tests, it's
 ;; useful for debugging to answer why row counts change when the timezone shifts by removing timezones and the related
 ;; database settings
-(deftest new-events-after-timezone-shift-test
+(deftest ^:parallel new-events-after-timezone-shift-test
   (driver/with-driver :h2
     (doseq [[timezone-id expected-net-gains] {:pacific [2 -1 5 -5 2 0 -2 1 -1 1]
                                               :eastern [1 -1 3 -3 3 -2 -1 0 1 1]}]
@@ -547,7 +547,7 @@
              (mt/with-system-timezone-id (timezone :pacific)
                (sad-toucan-incidents-with-bucketing :day :pacific)))))))
 
-(deftest group-by-day-of-week-test
+(deftest ^:parallel group-by-day-of-week-test
   (mt/test-drivers (mt/normal-drivers)
     (testing "\nPacific timezone"
       (is (= (if (and (not (qp.test/tz-shifted-driver-bug? driver/*driver*))
@@ -559,7 +559,7 @@
       (is (= [[1 28] [2 38] [3 29] [4 27] [5 24] [6 30] [7 24]]
              (sad-toucan-incidents-with-bucketing :day-of-week :utc))))))
 
-(deftest group-by-day-of-month-test
+(deftest ^:parallel group-by-day-of-month-test
   (mt/test-drivers (mt/normal-drivers)
     (testing "\nPacific timezone"
       (is (= (if (and (not (qp.test/tz-shifted-driver-bug? driver/*driver*))
@@ -571,7 +571,7 @@
       (is (= [[1 6] [2 10] [3 4] [4 9] [5  9] [6 8] [7 8] [8  9] [9 7] [10  9]]
              (sad-toucan-incidents-with-bucketing :day-of-month :utc))))))
 
-(deftest group-by-day-of-year-test
+(deftest ^:parallel group-by-day-of-year-test
   (mt/test-drivers (mt/normal-drivers)
     (testing "\nPacific timezone"
       (is (= (if (and (not (qp.test/tz-shifted-driver-bug? driver/*driver*))
@@ -587,7 +587,7 @@
 ;; find how those counts would change if time was in pacific time. The results of this test are also in the UTC test
 ;; above and pacific test below, but this is still useful for debugging as it doesn't involve changing timezones or
 ;; database settings
-(deftest new-weekly-events-after-tz-shift-test
+(deftest ^:parallel new-weekly-events-after-tz-shift-test
   (driver/with-driver :h2
     (doseq [[timezone-id start-date->expected-net-gain] {:pacific {"2015-05-31" 3
                                                                    "2015-06-07" 0
@@ -719,14 +719,14 @@
              (mt/with-system-timezone-id (timezone :pacific)
                (sad-toucan-incidents-with-bucketing :week :pacific)))))))
 
-(deftest group-by-week-of-year-test
+(deftest ^:parallel group-by-week-of-year-test
   (mt/test-drivers (mt/normal-drivers)
     (is (= [[22 46] [23 47] [24 40] [25 60] [26 7]]
            (sad-toucan-incidents-with-bucketing :week-of-year :utc)))))
 
 ;; All of the sad toucan events in the test data fit in June. The results are the same on all databases and the only
 ;; difference is how the beginning of hte month is represented, since we always return times with our dates
-(deftest group-by-month-test
+(deftest ^:parallel group-by-month-test
   (mt/test-drivers (mt/normal-drivers)
     (testing "\nPacific timezone"
       (is (= [[(cond
@@ -754,12 +754,12 @@
                  200]]
                (sad-toucan-incidents-with-bucketing :month :eastern)))))))
 
-(deftest group-by-month-of-year-test
+(deftest ^:parallel group-by-month-of-year-test
   (mt/test-drivers (mt/normal-drivers)
     (is (= [[6 200]]
            (sad-toucan-incidents-with-bucketing :month-of-year :pacific)))))
 
-(deftest group-by-quarter-test
+(deftest ^:parallel group-by-quarter-test
   (mt/test-drivers (mt/normal-drivers)
     (testing "\nPacific timezone"
       (is (= [[(cond (= :sqlite driver/*driver*)
@@ -784,7 +784,7 @@
                200]]
              (sad-toucan-incidents-with-bucketing :quarter :eastern))))))
 
-(deftest group-by-quarter-of-year-test
+(deftest ^:parallel group-by-quarter-of-year-test
   (mt/test-drivers (mt/normal-drivers)
     (is (= [[2 200]]
            (sad-toucan-incidents-with-bucketing :quarter-of-year :pacific)))
@@ -798,7 +798,7 @@
                {:aggregation [[:count]]
                 :breakout    [!quarter-of-year.date]}))))))
 
-(deftest group-by-year-test
+(deftest ^:parallel group-by-year-test
   (mt/test-drivers (mt/normal-drivers)
     (is (= [[(cond
                (= :sqlite driver/*driver*)
@@ -892,6 +892,10 @@
 
 (def ^:private ^:dynamic *recreate-db-if-stale?* true)
 
+(defn- dataset-is-stale? [dataset]
+  (and (checkins-db-is-old? (* (.intervalSeconds dataset) 5))
+       *recreate-db-if-stale?*))
+
 (defn- count-of-grouping [^TimestampDatasetDef dataset field-grouping & relative-datetime-args]
   (mt/dataset dataset
     ;; DB has values in the range of now() - (interval-seconds * 15) and now() + (interval-seconds * 15). So if it
@@ -899,18 +903,21 @@
     ;; the tests pass.
     ;;
     ;; TODO - perhaps this should be rolled into `mt/dataset` itself -- it seems like a useful feature?
-    (if (and (checkins-db-is-old? (* (.intervalSeconds dataset) 5)) *recreate-db-if-stale?*)
-      (binding [*recreate-db-if-stale?* false]
-        (printf "DB for %s is stale! Deleteing and running test again\n" dataset)
-        (db/delete! Database :id (mt/id))
-        (apply count-of-grouping dataset field-grouping relative-datetime-args))
-      (let [results (mt/run-mbql-query checkins
-                      {:aggregation [[:count]]
-                       :filter      [:=
-                                     [:field %timestamp {:temporal-unit field-grouping}]
-                                     (cons :relative-datetime relative-datetime-args)]})]
-        (or (some-> results mt/first-row first int)
-            results)))))
+    (when (dataset-is-stale? dataset)
+      (locking *recreate-db-if-stale?*
+        (when (dataset-is-stale? dataset)
+          (binding [*recreate-db-if-stale?* false]
+            (printf "DB for %s is stale! Deleteing and running test again\n" dataset)
+            ;; database is stale; delete and then recreate.
+            (db/delete! Database :id (mt/id))))))
+    ;; now run the tests.
+    (let [results (mt/run-mbql-query checkins
+                    {:aggregation [[:count]]
+                     :filter      [:=
+                                   [:field %timestamp {:temporal-unit field-grouping}]
+                                   (cons :relative-datetime relative-datetime-args)]})]
+      (or (some-> results mt/first-row first int)
+          results))))
 
 ;; HACK - Don't run these tests against Snowflake/etc. because the databases need to be loaded every time the tests
 ;;        are ran and loading data into these DBs is mind-bogglingly slow.
@@ -918,7 +925,7 @@
 ;; Don't run the minute tests against Oracle because the Oracle tests are kind of slow and case CI to fail randomly
 ;; when it takes so long to load the data that the times are no longer current (these tests pass locally if your
 ;; machine isn't as slow as the CircleCI ones)
-(deftest count-of-grouping-test
+(deftest ^:parallel count-of-grouping-test
   (mt/test-drivers (mt/normal-drivers-except #{:snowflake})
     (testing "4 checkins per minute dataset"
       (testing "group by minute"
@@ -944,7 +951,7 @@
                (count-of-grouping checkins:1-per-day :week :current))
             "filter by week = [:relative-datetime :current]")))))
 
-(deftest time-interval-test
+(deftest ^:parallel time-interval-test
   (mt/test-drivers (mt/normal-drivers-except #{:snowflake})
     (testing "Syntactic sugar (`:time-interval` clause)"
       (mt/dataset checkins:1-per-day
@@ -976,7 +983,7 @@
                (throw (ex-info "Query failed!" results)))
      :unit (-> results :data :cols first :unit)}))
 
-(deftest date-bucketing-when-you-test
+(deftest ^:parallel date-bucketing-when-you-test
   (mt/test-drivers (mt/normal-drivers-except #{:snowflake})
     (is (= {:rows 1, :unit :day}
            (date-bucketing-unit-when-you :breakout-by "day", :filter-by "day")))
@@ -1004,7 +1011,7 @@
 ;;
 ;; We should get count = 1 for the current day, as opposed to count = 0 if we weren't auto-bucketing
 ;; (e.g. 2018-11-19T00:00 != 2018-11-19T12:37 or whatever time the checkin is at)
-(deftest default-bucketing-test
+(deftest ^:parallel default-bucketing-test
   (mt/test-drivers (mt/normal-drivers-except #{:snowflake})
     (mt/dataset checkins:1-per-day
       (is (= [[1]]
@@ -1080,7 +1087,7 @@
                     filter-value
                     expected-count)))))))))
 
-(deftest legacy-default-datetime-bucketing-test
+(deftest ^:parallel legacy-default-datetime-bucketing-test
   (testing (str ":type/Date or :type/DateTime fields that don't have `:temporal-unit` clauses should get default `:day` "
                 "bucketing for legacy reasons. See #9014")
     (is (= (str "SELECT count(*) AS \"count\" "
@@ -1096,7 +1103,7 @@
                {:aggregation [[:count]]
                 :filter      [:= $date [:relative-datetime :current]]})))))))
 
-(deftest compile-time-interval-test
+(deftest ^:parallel compile-time-interval-test
   (testing "Make sure time-intervals work the way they're supposed to."
     (testing "[:time-interval $date -4 :month] should give us something like Oct 01 2020 - Feb 01 2021 if today is Feb 17 2021"
       (is (= (str "SELECT CHECKINS.DATE AS DATE "
@@ -1181,7 +1188,7 @@
               (is (= expected-rows
                      (mt/formatted-rows [int int] (qp/process-query query)))))))))))
 
-(deftest filter-by-current-quarter-test
+(deftest ^:parallel filter-by-current-quarter-test
   ;; Oracle doesn't work on March 31st because March 31st + 3 months = June 31st, which doesn't exist. See #10072
   (mt/test-drivers (disj (mt/normal-drivers) :oracle)
     (testing "Should be able to filter by current quarter (#20683)"
@@ -1198,7 +1205,7 @@
                (mt/formatted-rows [int] (qp/process-query query)))))))))
 
 ;; TODO -- is this really date BUCKETING? Does this BELONG HERE?!
-(deftest june-31st-test
+(deftest ^:parallel june-31st-test
   (testing "What happens when you try to add 3 months to March 31st? It should still work (#10072, #21968, #21969)"
     ;; only testing the SQL drivers for now since I'm not 100% sure how to mock this for everyone else. Maybe one day
     ;; when we support expressions like `+` for temporal types we can do an `:absolute-datetime` plus

--- a/test/metabase/query_processor_test/date_time_zone_functions_test.clj
+++ b/test/metabase/query_processor_test/date_time_zone_functions_test.clj
@@ -75,7 +75,7 @@
                                     :aggregation [[:count]]
                                     :breakout    [[:expression "expr"]]})}])
 
-(deftest extraction-function-tests
+(deftest ^:parallel extraction-function-tests
   (mt/dataset times-mixed
     ;; need to have seperate tests for mongo because it doesn't have supports for casting yet
     (mt/test-drivers (disj (mt/normal-drivers-with-feature :temporal-extract) :mongo)
@@ -115,7 +115,7 @@
              (is (= (set (expected-fn op)) (set (test-temporal-extract (query-fn op field-id))))))))))))
 
 
-(deftest temporal-extraction-with-filter-expresion-tests
+(deftest ^:parallel temporal-extraction-with-filter-expresion-tests
   (mt/test-drivers (mt/normal-drivers-with-feature :temporal-extract)
     (mt/dataset times-mixed
       (doseq [{:keys [title expected query]}
@@ -194,7 +194,7 @@
          (mt/formatted-rows [normalize-timestamp-str])
          (map first))))
 
-(deftest date-math-tests
+(deftest ^:parallel date-math-tests
   (mt/dataset times-mixed
     ;; mongo doesn't supports coercion yet so we exclude it here, Tests for it are in [[metabase.driver.mongo.query-processor-test]]
     (mt/test-drivers (disj (mt/normal-drivers-with-feature :date-arithmetics) :mongo)
@@ -236,7 +236,7 @@
           (testing (format "%s %s function works as expected on %s column for driver %s" op unit col-type driver/*driver*)
             (is (= (set expected) (set (test-date-math query))))))))))
 
-(deftest date-math-with-extract-test
+(deftest ^:parallel date-math-with-extract-test
   (mt/test-drivers (mt/normal-drivers-with-feature :date-arithmetics)
     (mt/dataset times-mixed
       (doseq [{:keys [title expected query]}

--- a/test/metabase/query_processor_test/explicit_joins_test.clj
+++ b/test/metabase/query_processor_test/explicit_joins_test.clj
@@ -11,7 +11,7 @@
             [metabase.test :as mt]
             [metabase.test.data.interface :as tx]))
 
-(deftest explict-join-with-default-options-test
+(deftest ^:parallel explict-join-with-default-options-test
   (testing "Can we specify an *explicit* JOIN using the default options?"
     (let [query (mt/mbql-query venues
                   {:joins [{:source-table $$categories
@@ -39,7 +39,7 @@
                    :alias        "f"}]
        :order-by [[:asc $name]]})))
 
-(deftest left-outer-join-test
+(deftest ^:parallel left-outer-join-test
   (mt/test-drivers (mt/normal-drivers-with-feature :left-join)
     (testing "Can we supply a custom alias? Can we do a left outer join ??"
       (is (= [["Big Red"          "Bayview Brood"]
@@ -64,7 +64,7 @@
                (qp/process-query
                 (query-with-strategy :left-join))))))))
 
-(deftest right-outer-join-test
+(deftest ^:parallel right-outer-join-test
   (mt/test-drivers (mt/normal-drivers-with-feature :right-join)
     (testing "Can we do a right outer join?"
       ;; the [nil "Fillmore Flock"] row will either come first or last depending on the driver; the rest of the rows will
@@ -89,7 +89,7 @@
                  (qp/process-query
                   (query-with-strategy :right-join)))))))))
 
-(deftest inner-join-test
+(deftest ^:parallel inner-join-test
   (mt/test-drivers (mt/normal-drivers-with-feature :inner-join)
     (testing "Can we do an inner join?"
       (is (= [["Big Red"        "Bayview Brood"]
@@ -108,7 +108,7 @@
                (qp/process-query
                 (query-with-strategy :inner-join))))))))
 
-(deftest full-join-test
+(deftest ^:parallel full-join-test
   (mt/test-drivers (mt/normal-drivers-with-feature :full-join)
     (testing "Can we do a full join?"
       (let [rows [["Big Red"          "Bayview Brood"]
@@ -137,7 +137,7 @@
                  (qp/process-query
                   (query-with-strategy :full-join)))))))))
 
-(deftest automatically-include-all-fields-test
+(deftest ^:parallel automatically-include-all-fields-test
   (mt/test-drivers (mt/normal-drivers-with-feature :left-join)
     (testing "Can we automatically include `:all` Fields?"
       (is (= {:columns (mapv mt/format-name ["id" "name" "flock_id" "id_2" "name_2"])
@@ -169,7 +169,7 @@
                                   :fields       :all}]
                       :order-by [[:asc [:field-id $name]]]})))))))))
 
-(deftest include-no-fields-test
+(deftest ^:parallel include-no-fields-test
   (mt/test-drivers (mt/normal-drivers-with-feature :left-join)
     (testing "Can we include no Fields (with `:none`)"
       (is (= {:columns (mapv mt/format-name ["id" "name" "flock_id"])
@@ -201,7 +201,7 @@
                                   :fields       :none}]
                       :order-by [[:asc [:field-id $name]]]})))))))))
 
-(deftest specific-fields-test
+(deftest ^:parallel specific-fields-test
   (mt/test-drivers (mt/normal-drivers-with-feature :left-join)
     (testing "Can we include a list of specific Fields?"
       (let [{:keys [columns rows]} (mt/format-rows-by [#(some-> % int) str identity]
@@ -236,7 +236,7 @@
                 [1  "Russell Crow"    "Mission Street Murder"]]
                rows))))))
 
-(deftest all-fields-datetime-field-test
+(deftest ^:parallel all-fields-datetime-field-test
   (mt/test-drivers (mt/normal-drivers-with-feature :left-join)
     (testing (str "Do Joins with `:fields``:all` work if the joined table includes Fields that come back wrapped in"
                   " `:datetime-field` forms?")
@@ -258,7 +258,7 @@
                 [3 "Kaneonuskatew Eiran" "2014-11-06T16:15:00Z" 3 "2014-09-15T00:00:00Z" 8 56]]
                rows))))))
 
-(deftest select-*-source-query-test
+(deftest ^:parallel select-*-source-query-test
   (mt/test-drivers (mt/normal-drivers-with-feature :left-join)
     (testing "We should be able to run a query that for whatever reason ends up with a `SELECT *` for the source query"
       (let [{:keys [rows columns]} (mt/format-rows-by [int int]
@@ -277,7 +277,7 @@
         (is (= [[1 5] [2 1] [3 8]]
                rows))))))
 
-(deftest join-against-nested-mbql-query-test
+(deftest ^:parallel join-against-nested-mbql-query-test
   (mt/test-drivers (mt/normal-drivers-with-feature :left-join)
     (testing "Can we join against a source nested MBQL query?"
       (is (= [[29 "20th Century Cafe" 12  37.775 -122.423 2]
@@ -293,7 +293,7 @@
                     :order-by     [[:asc $name]]
                     :limit        3}))))))))
 
-(deftest join-against-card-source-query-test
+(deftest ^:parallel join-against-card-source-query-test
   (mt/test-drivers (mt/normal-drivers-with-feature :left-join)
     (testing "Can we join against a `card__id` source query and use `:fields` `:all`?"
       (is (= {:rows
@@ -314,7 +314,7 @@
                       :order-by [[:asc $name]]
                       :limit    3})))))))))
 
-(deftest join-on-field-literal-test
+(deftest ^:parallel join-on-field-literal-test
   (mt/test-drivers (mt/normal-drivers-with-feature :left-join)
     (testing "Can we join on a Field literal for a source query?"
       ;; Also: if you join against an *explicit* source query, do all columns for both queries come back? (Only applies
@@ -342,7 +342,7 @@
                       :order-by     [[:asc $venue_id]]
                       :limit        3})))))))))
 
-(deftest aggregate-join-results-test
+(deftest ^:parallel aggregate-join-results-test
   (mt/test-drivers (mt/normal-drivers-with-feature :left-join)
     (testing "Can we aggregate on the results of a JOIN?"
       (mt/with-temp Card [{card-id :id} (qp.test-util/card-with-source-metadata-for-query
@@ -372,7 +372,7 @@
                      (mt/rows+column-names
                       (qp/process-query query)))))))))))
 
-(deftest get-all-columns-without-metadata-test
+(deftest ^:parallel get-all-columns-without-metadata-test
   (mt/test-drivers (mt/normal-drivers-with-feature :left-join)
     (testing "NEW! Can we still get all of our columns, even if we *DON'T* specify the metadata?"
       (mt/with-temp Card [{card-id :id} (qp.test-util/card-with-source-metadata-for-query
@@ -397,7 +397,7 @@
                       :order-by     [[:asc $venue_id]]
                       :limit        3})))))))))
 
-(deftest joined-field-in-time-interval-test
+(deftest ^:parallel joined-field-in-time-interval-test
   (mt/test-drivers (mt/normal-drivers-with-feature :left-join)
     (testing "Should be able to use a joined field in a `:time-interval` clause"
       (is (= {:rows    []
@@ -412,7 +412,7 @@
                   :order-by [[:asc &c.checkins.id]]
                   :limit    10})))))))
 
-(deftest deduplicate-column-names-test
+(deftest ^:parallel deduplicate-column-names-test
   (mt/test-drivers (mt/normal-drivers-with-feature :left-join)
     (testing (str "Do we gracefully handle situtations where joins would produce multiple columns with the same name? "
                   "(Multiple columns named `id` in the example below)")
@@ -457,7 +457,7 @@
                  1 "Red Medicine" 4 10.065 -165.374 3]]
                rows))))))
 
-(deftest sql-question-source-query-test
+(deftest ^:parallel sql-question-source-query-test
   (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries :left-join)
     (testing "we should be able to use a SQL question as a source query in a Join"
       (mt/with-temp Card [{card-id :id} (qp.test-util/card-with-source-metadata-for-query
@@ -473,7 +473,7 @@
                     :order-by [[:asc $id]]
                     :limit    2}))))))))
 
-(deftest joined-date-filter-test
+(deftest ^:parallel joined-date-filter-test
   ;; TIMEZONE FIXME — The excluded drivers below don't have TIME types, so the `attempted-murders` dataset doesn't
   ;; currently work. We should use the closest equivalent types (e.g. `DATETIME` or `TIMESTAMP` so we can still load
   ;; the dataset and run tests using this dataset such as these, which doesn't even use the TIME type.
@@ -493,7 +493,7 @@
                              :fields       [&attempts_joined.datetime_tz]
                              :source-table $$attempts}]}))))))))
 
-(deftest expressions-referencing-joined-aggregation-expressions-test
+(deftest ^:parallel expressions-referencing-joined-aggregation-expressions-test
   (testing (mt/normal-drivers-with-feature :nested-queries :left-join :expressions)
     (testing "Should be able to use expressions against columns that come from aggregation expressions in joins"
       (is (= [[1 "Red Medicine"          4  10.065 -165.374 3 1.5  4 3 2 1]
@@ -519,7 +519,7 @@
                                  :fields       :all}]
                   :limit       3})))))))
 
-(deftest join-source-queries-with-joins-test
+(deftest ^:parallel join-source-queries-with-joins-test
   (testing "Should be able to join against source queries that themselves contain joins (#12928)"
     (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries :left-join :foreign-keys)
       (mt/dataset sample-dataset
@@ -583,7 +583,7 @@
                      (mt/formatted-rows [int int 2.0 int int]
                        (qp/process-query query)))))))))))
 
-(deftest join-against-saved-question-with-sort-test
+(deftest ^:parallel join-against-saved-question-with-sort-test
   (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries :left-join)
     (testing "Should be able to join against a Saved Question that is sorted (#13744)"
       (mt/dataset sample-dataset
@@ -611,7 +611,7 @@
                    (mt/formatted-rows [int str str str str 2.0 1.0 str str int]
                      (qp/process-query query))))))))))
 
-(deftest join-with-space-in-alias-test
+(deftest ^:parallel join-with-space-in-alias-test
   (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries :left-join)
     (testing "Some drivers don't allow Table alises with spaces in them. Make sure joins still work."
       (mt/dataset sample-dataset
@@ -631,7 +631,7 @@
                      (mt/formatted-rows [int int]
                        (qp/process-query query)))))))))))
 
-(deftest joining-nested-queries-with-same-aggregation-test
+(deftest ^:parallel joining-nested-queries-with-same-aggregation-test
   (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries :left-join)
     (testing (str "Should be able to join two nested queries with the same aggregation on a Field in their respective "
                   "source queries (#18512)")
@@ -665,7 +665,7 @@
                    (mt/formatted-rows [str int str int]
                      (qp/process-query query))))))))))
 
-(deftest join-against-same-table-as-source-query-source-table-test
+(deftest ^:parallel join-against-same-table-as-source-query-source-table-test
   (testing "Joining against the same table as the source table of the source query should work (#18502)"
     (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries :left-join)
       (mt/dataset sample-dataset
@@ -688,7 +688,7 @@
                    (mt/formatted-rows [str int str int]
                      (qp/process-query query))))))))))
 
-(deftest join-against-multiple-saved-questions-with-same-column-test
+(deftest ^:parallel join-against-multiple-saved-questions-with-same-column-test
   (testing "Should be able to join multiple against saved questions on the same column (#15863, #20362)"
     (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries :left-join)
       (mt/dataset sample-dataset
@@ -729,7 +729,7 @@
                           ["Widget"    54 "Widget"    3109.31 "Widget"    3.15]]
                          (mt/formatted-rows [str int str 2.0 str 2.0] results))))))))))))
 
-(deftest use-correct-source-alias-for-fields-from-joins-test
+(deftest ^:parallel use-correct-source-alias-for-fields-from-joins-test
   (testing "Make sure we use the correct escaped alias for a Fields coming from joins (#20413)"
     (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries :left-join)
       (mt/dataset sample-dataset
@@ -776,7 +776,7 @@
                                          int str str str str 2.0 2.0 str]
                        results))))))))))
 
-(deftest double-quotes-in-join-alias-test
+(deftest ^:parallel double-quotes-in-join-alias-test
   (mt/test-drivers (mt/normal-drivers-with-feature :left-join)
     (testing "Make sure our we handle (escape) double quotes in join aliases. Make sure we prevent SQL injection (#20307)"
       (let [expected-rows (mt/rows
@@ -816,7 +816,7 @@
   (str/join (for [i (range length)]
               (nth charset (mod i (count charset))))))
 
-(deftest very-long-join-name-test
+(deftest ^:parallel very-long-join-name-test
   (mt/test-drivers (mt/normal-drivers-with-feature :left-join)
     (testing "Drivers should work correctly even if joins have REALLLLLLY long names (#15978)"
       (doseq [[charset-name charset] charsets
@@ -847,7 +847,7 @@
                      (mt/formatted-rows [int str str str]
                        (qp/process-query query)))))))))))
 
-(deftest join-against-implicit-join-test
+(deftest ^:parallel join-against-implicit-join-test
   (testing "Should be able to explicitly join against an implicit join (#20519)"
     (mt/test-drivers (mt/normal-drivers-with-feature :left-join :expressions :basic-aggregations)
       (mt/with-bigquery-fks #{:bigquery-cloud-sdk}

--- a/test/metabase/query_processor_test/expression_aggregations_test.clj
+++ b/test/metabase/query_processor_test/expression_aggregations_test.clj
@@ -7,7 +7,7 @@
             [metabase.test :as mt]
             [metabase.util :as u]))
 
-(deftest sum-test
+(deftest ^:parallel sum-test
   (mt/test-drivers (mt/normal-drivers-with-feature :expression-aggregations)
     (testing "sum, *"
       (is (= [[1 1211]
@@ -19,7 +19,7 @@
                  {:aggregation [[:sum [:* $id $price]]]
                   :breakout    [$price]})))))))
 
-(deftest min-test
+(deftest ^:parallel min-test
   (mt/test-drivers (mt/normal-drivers-with-feature :expression-aggregations)
     (testing "min, +"
       (is (= [[1 10]
@@ -31,7 +31,7 @@
                  {:aggregation [[:min [:+ $id $price]]]
                   :breakout    [$price]})))))))
 
-(deftest max-test
+(deftest ^:parallel max-test
   (mt/test-drivers (mt/normal-drivers-with-feature :expression-aggregations)
     (testing "max, /"
       (is (= [[1 94]
@@ -43,7 +43,7 @@
                  {:aggregation [[:max [:/ $id $price]]]
                   :breakout    [$price]})))))))
 
-(deftest avg-test
+(deftest ^:parallel avg-test
   (mt/test-drivers (mt/normal-drivers-with-feature :expression-aggregations)
     (testing "avg, -"
       (is (= (if (= driver/*driver* :h2)
@@ -60,7 +60,7 @@
                  {:aggregation [[:avg [:* $id $price]]]
                   :breakout    [$price]})))))))
 
-(deftest post-aggregation-math-test
+(deftest ^:parallel post-aggregation-math-test
   (mt/test-drivers (mt/normal-drivers-with-feature :expression-aggregations)
     (testing "post-aggregation math"
       (testing "w/ 2 args: count + sum"
@@ -110,7 +110,7 @@
                    {:aggregation [[:+ [:count $id] [:avg $id]]]
                     :breakout    [$price]}))))))))
 
-(deftest nested-post-aggregation-mat-test
+(deftest ^:parallel nested-post-aggregation-mat-test
   (mt/test-drivers (mt/normal-drivers-with-feature :expression-aggregations)
     (testing "nested post-aggregation math: count + (count * sum)"
       (is (= [[1  506]
@@ -124,7 +124,7 @@
                                  [:* [:count $id] [:sum $price]]]]
                   :breakout    [$price]})))))))
 
-(deftest math-inside-aggregations-test
+(deftest ^:parallel math-inside-aggregations-test
   (mt/test-drivers (mt/normal-drivers-with-feature :expression-aggregations)
     (testing "post aggregation math + math inside aggregations: max(venue_price) + min(venue_price - id)"
       (is (= [[1 -92]
@@ -136,7 +136,7 @@
                  {:aggregation [[:+ [:max $price] [:min [:- $price $id]]]]
                   :breakout    [$price]})))))))
 
-(deftest aggregation-without-field-test
+(deftest ^:parallel aggregation-without-field-test
   (mt/test-drivers (mt/normal-drivers-with-feature :expression-aggregations)
     (testing "aggregation w/o field"
       (is (= [[1 23]
@@ -148,7 +148,7 @@
                  {:aggregation [[:+ 1 [:count]]]
                   :breakout    [$price]})))))))
 
-(deftest sort-by-unnamed-aggregate-expression-test
+(deftest ^:parallel sort-by-unnamed-aggregate-expression-test
   (mt/test-drivers (mt/normal-drivers-with-feature :expression-aggregations)
     (testing "Sorting by an un-named aggregate expression"
       (is (= [[1 2] [2 2] [12 2] [4 4] [7 4] [10 4] [11 4] [8 8]]
@@ -158,7 +158,7 @@
                   :breakout    [[:datetime-field $last_login :month-of-year]]
                   :order-by    [[:asc [:aggregation 0]]]})))))))
 
-(deftest math-inside-the-aggregation-test
+(deftest ^:parallel math-inside-the-aggregation-test
   (mt/test-drivers (mt/normal-drivers-with-feature :expression-aggregations)
     (testing "aggregation with math inside the aggregation :scream_cat:"
       (is (= [[1  44]
@@ -170,7 +170,7 @@
                  {:aggregation [[:sum [:+ $price 1]]]
                   :breakout    [$price]})))))))
 
-(deftest named-expression-aggregation-test
+(deftest ^:parallel named-expression-aggregation-test
   (mt/test-drivers (mt/normal-drivers-with-feature :expression-aggregations)
     (testing "check that we can name an expression aggregation w/ aggregation at top-level"
       (is (= {:rows    [[1  44]
@@ -198,7 +198,7 @@
                    {:aggregation [[:aggregation-options [:- [:sum $price] 41] {:name "sum_41"}]]
                     :breakout    [$price]}))))))))
 
-(deftest metrics-test
+(deftest ^:parallel metrics-test
   (mt/test-drivers (mt/normal-drivers-with-feature :expression-aggregations)
     (testing "check that we can handle Metrics inside expression aggregation clauses"
       (mt/with-temp Metric [metric {:table_id   (mt/id :venues)
@@ -243,7 +243,7 @@
                      {:aggregation [[:aggregation-options [:metric (u/the-id metric)] {:name "auto_generated_name"}]]
                       :breakout    [[:field-id $price]]})))))))))
 
-(deftest named-aggregations-metadata-test
+(deftest ^:parallel named-aggregations-metadata-test
   (mt/test-drivers (mt/normal-drivers-with-feature :expression-aggregations)
     (testing "check that named aggregations come back with the correct column metadata (#4002)"
       (is (= (assoc (qp.test/aggregate-col :count)
@@ -256,7 +256,7 @@
                  mt/cols
                  first))))))
 
-(deftest cumulative-count-test
+(deftest ^:parallel cumulative-count-test
   (mt/test-drivers (mt/normal-drivers-with-feature :expression-aggregations)
     (testing "check that we can use cumlative count in expression aggregations"
       (is (= [[1000]]
@@ -265,7 +265,7 @@
                  (mt/run-mbql-query venues
                    {:aggregation [["*" ["cum_count"] 10]]}))))))))
 
-(deftest named-expressions-inside-expression-aggregations-test
+(deftest ^:parallel named-expressions-inside-expression-aggregations-test
   (mt/test-drivers (mt/normal-drivers-with-feature :expression-aggregations)
     (testing "can we use named expressions inside expression aggregations?"
       (is (= [[406]]
@@ -274,7 +274,7 @@
                  {:aggregation [[:sum [:expression "double-price"]]]
                   :expressions {"double-price" [:* $price 2]}})))))))
 
-(deftest order-by-named-aggregation-test
+(deftest ^:parallel order-by-named-aggregation-test
   (testing "Ordering by a named aggregation whose alias has uppercase letters works (#18211)"
     (mt/test-drivers (mt/normal-drivers-with-feature :expression-aggregations)
       (mt/dataset sample-dataset
@@ -288,7 +288,7 @@
                    :breakout    [$category]
                    :order-by    [[:asc [:aggregation 0]]]}))))))))
 
-#_(deftest multiple-cumulative-sums-test
+#_(deftest ^:parallel multiple-cumulative-sums-test
   (mt/test-drivers (mt/normal-drivers-with-feature :expression-aggregations)
     (testing "The results of divide or multiply two CumulativeSum should be correct (#15118)"
       (mt/dataset sample-dataset

--- a/test/metabase/query_processor_test/expressions_test.clj
+++ b/test/metabase/query_processor_test/expressions_test.clj
@@ -11,7 +11,7 @@
             [metabase.util.date-2 :as u.date]
             [toucan.db :as db]))
 
-(deftest basic-test
+(deftest ^:parallel basic-test
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
     (testing "Do a basic query including an expression"
       (is (= [[1 "Red Medicine"                 4  10.0646 -165.374 3 5.0]
@@ -25,7 +25,7 @@
                   :limit       5
                   :order-by    [[:asc $id]]})))))))
 
-(deftest floating-point-division-test
+(deftest ^:parallel floating-point-division-test
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
     (testing "Make sure FLOATING POINT division is done"
       (is (= [[1 "Red Medicine"           4 10.0646 -165.374 3 1.5] ; 3 / 2 SHOULD BE 1.5, NOT 1 (!)
@@ -49,7 +49,7 @@
                   :limit       3
                   :order-by    [[:asc $id]]})))))))
 
-(deftest nested-expressions-test
+(deftest ^:parallel nested-expressions-test
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
     (testing "Can we do NESTED EXPRESSIONS ?"
       (is (= [[1 "Red Medicine"           4 10.0646 -165.374 3 3.0]
@@ -61,7 +61,7 @@
                   :limit       3
                   :order-by    [[:asc $id]]})))))))
 
-(deftest multiple-expressions-test
+(deftest ^:parallel multiple-expressions-test
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
     (testing "Can we have MULTIPLE EXPRESSIONS?"
       (is (= [[1 "Red Medicine"           4 10.0646 -165.374 3 2.0 4.0]
@@ -74,7 +74,7 @@
                   :limit       3
                   :order-by    [[:asc $id]]})))))))
 
-(deftest expressions-in-fields-test
+(deftest ^:parallel expressions-in-fields-test
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
     (testing "Can we refer to expressions inside a FIELDS clause?"
       (is (= [[4] [4] [5]]
@@ -85,7 +85,7 @@
                   :limit       3
                   :order-by    [[:asc $id]]})))))))
 
-(deftest dont-return-expressions-if-fields-is-explicit-test
+(deftest ^:parallel dont-return-expressions-if-fields-is-explicit-test
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
     ;; bigquery doesn't let you have hypthens in field, table, etc names
     (let [priceplusone (if (= driver/*driver* :bigquery-cloud-sdk) "price_plus_1" "Price + 1")
@@ -119,7 +119,7 @@
                     :order-by    [[:asc [:expression priceplusone]]]
                     :limit       3}))))))))
 
-(deftest expressions-in-order-by-test
+(deftest ^:parallel expressions-in-order-by-test
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
     (testing "Can we refer to expressions inside an ORDER BY clause?"
       (is (= [[100 "Mohawk Bend"         46 34.0777 -118.265 2 102.0]
@@ -131,7 +131,7 @@
                   :limit       3
                   :order-by    [[:desc [:expression :x]]]})))))))
 
-(deftest aggregate-breakout-expression-test
+(deftest ^:parallel aggregate-breakout-expression-test
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
     (testing "Can we AGGREGATE + BREAKOUT by an EXPRESSION?"
       (is (= [[2 22] [4 59] [6 13] [8 6]]
@@ -141,7 +141,7 @@
                   :aggregation [[:count]]
                   :breakout    [[:expression :x]]})))))))
 
-(deftest expressions-should-include-type-test
+(deftest ^:parallel expressions-should-include-type-test
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
     (testing "Custom aggregation expressions should include their type"
       (let [cols (mt/cols
@@ -183,7 +183,7 @@
      (mt/$ids ~'bird-count
               (calculate-bird-scarcity* ~formula ~filter-clause))))
 
-(deftest nulls-and-zeroes-test
+(deftest ^:parallel nulls-and-zeroes-test
   (mt/test-drivers (disj (mt/normal-drivers-with-feature :expressions)
                          ;; bigquery doesn't let you have hypthens in field, table, etc names
                          ;; therefore a different macro is tested in bigquery driver tests
@@ -285,7 +285,7 @@
 ;;; |                                                     JOINS                                                      |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-(deftest expressions+joins-test
+(deftest ^:parallel expressions+joins-test
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions :left-join)
     (testing "Do calculated columns play well with joins"
       (is (= "Simcha Yan"
@@ -335,7 +335,7 @@
 ;; Make sure no part of query compilation is lazy as that won't play well with dynamic bindings.
 ;; This is not an issue limited to expressions, but using expressions is the most straightforward
 ;; way to reproducing it.
-(deftest no-lazyness-test
+(deftest ^:parallel no-lazyness-test
   ;; Sometimes Kondo thinks this is unused, depending on the state of the cache -- see comments in
   ;; [[hooks.metabase.test.data]] for more information. It's definitely used to.
   #_{:clj-kondo/ignore [:unused-binding]}
@@ -359,7 +359,7 @@
           (testing "# of app DB calls should not be some insane number"
             (is (< (call-count-fn) 20))))))))
 
-(deftest expression-with-slashes
+(deftest ^:parallel expression-with-slashes
   (mt/test-drivers (disj
                      (mt/normal-drivers-with-feature :expressions)
                      ;; Slashes documented as not allowed in BQ
@@ -375,7 +375,7 @@
                   :limit       3
                   :order-by    [[:asc $id]]})))))))
 
-(deftest expression-using-aggregation-test
+(deftest ^:parallel expression-using-aggregation-test
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
     (testing "Can we use aggregations from previous steps in expressions (#12762)"
       (is (= [["20th Century Cafe" 2 2 0]
@@ -392,7 +392,7 @@
                                                [:field "max" {:base-type :type/Number}]
                                                [:field "min" {:base-type :type/Number}]]}})))))))
 
-(deftest expression-with-duplicate-column-name
+(deftest ^:parallel expression-with-duplicate-column-name
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
     (testing "Can we use expression with same column name as table (#14267)"
       (mt/dataset sample-dataset
@@ -407,7 +407,7 @@
                    (mt/formatted-rows [str int]
                      (qp/process-query query))))))))))
 
-(deftest fk-field-and-duplicate-names-test
+(deftest ^:parallel fk-field-and-duplicate-names-test
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions :foreign-keys)
     (testing "Expressions with `fk->` fields and duplicate names should work correctly (#14854)"
       (mt/dataset sample-dataset
@@ -424,7 +424,7 @@
                  (mt/formatted-rows [int int int 1.0 1.0 1.0 identity str int str]
                    results))))))))
 
-(deftest string-operations-from-subquery
+(deftest ^:parallel string-operations-from-subquery
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions :regex)
     (testing "regex-match-first and replace work when evaluated against a subquery (#14873)"
       (mt/dataset test-data
@@ -443,7 +443,7 @@
                   ["Rush Street" "Rush" "RushStreet"]]
                  (mt/formatted-rows [str str str] results))))))))
 
-(deftest expression-name-weird-characters-test
+(deftest ^:parallel expression-name-weird-characters-test
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
     (testing "An expression whose name contains weird characters works properly"
       (let [query (mt/mbql-query venues
@@ -455,7 +455,7 @@
                  (mt/formatted-rows [int str int 4.0 4.0 int int]
                    (qp/process-query query)))))))))
 
-(deftest join-table-on-itself-with-custom-column-test
+(deftest ^:parallel join-table-on-itself-with-custom-column-test
   (testing "Should be able to join a source query against itself using an expression (#17770)"
     (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries :expressions :left-join)
       (mt/dataset sample-dataset
@@ -483,7 +483,7 @@
                    (mt/formatted-rows [str int int str int int]
                      (qp/process-query query))))))))))
 
-(deftest nested-expressions-with-existing-names-test
+(deftest ^:parallel nested-expressions-with-existing-names-test
   (testing "Expressions with the same name as existing columns should work correctly in nested queries (#21131)"
     (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries :expressions)
       (mt/dataset sample-dataset

--- a/test/metabase/query_processor_test/failure_test.clj
+++ b/test/metabase/query_processor_test/failure_test.clj
@@ -39,7 +39,7 @@
                       "LIMIT 1048575"))
    :params (s/eq nil)})
 
-(deftest process-userland-query-test
+(deftest ^:parallel process-userland-query-test
   (testing "running a bad query via `process-query` should return stacktrace, query, preprocessed query, and native query"
     (is (schema= {:status       (s/eq :failed)
                   :class        Class
@@ -52,7 +52,7 @@
                   s/Keyword     s/Any}
                  (qp/process-userland-query (bad-query))))))
 
-(deftest process-query-and-save-execution-test
+(deftest ^:parallel process-query-and-save-execution-test
   (testing "running via `process-query-and-save-execution!` should return similar info and a bunch of other nonsense too"
     (is (schema= {:database_id  (s/eq (mt/id))
                   :started_at   java.time.ZonedDateTime

--- a/test/metabase/query_processor_test/field_visibility_test.clj
+++ b/test/metabase/query_processor_test/field_visibility_test.clj
@@ -35,7 +35,7 @@
 
 ;;; ----------------------------------------------- :sensitive fields ------------------------------------------------
 
-(deftest sensitive-fields-test
+(deftest ^:parallel sensitive-fields-test
   (mt/test-drivers (mt/normal-drivers)
     (testing "Make sure :sensitive information fields are never returned by the QP"
       (is (= {:cols (qp.test/expected-cols :users [:id :name :last_login])

--- a/test/metabase/query_processor_test/fields_test.clj
+++ b/test/metabase/query_processor_test/fields_test.clj
@@ -4,7 +4,7 @@
             [metabase.query-processor-test :as qp.test]
             [metabase.test :as mt]))
 
-(deftest fields-clause-test
+(deftest ^:parallel fields-clause-test
   (mt/test-drivers (mt/normal-drivers)
     (testing (str "Test that we can restrict the Fields that get returned to the ones specified, and that results come "
                   "back in the order of the IDs in the `fields` clause")

--- a/test/metabase/query_processor_test/filter_test.clj
+++ b/test/metabase/query_processor_test/filter_test.clj
@@ -9,7 +9,7 @@
             [metabase.query-processor-test.timezones-test :as timezones-test]
             [metabase.test :as mt]))
 
-(deftest and-test
+(deftest ^:parallel and-test
   (mt/test-drivers (mt/normal-drivers)
     (testing ":and, :>, :>="
       (is (= [[55 "Dal Rae Restaurant"       67 33.983  -118.096 4]
@@ -30,7 +30,7 @@
                  {:filter   [:and [:< $id 24] [:> $id 20] [:!= $id 22]]
                   :order-by [[:asc $id]]})))))))
 
-(deftest filter-by-false-test
+(deftest ^:parallel filter-by-false-test
   (mt/test-drivers (mt/normal-drivers)
     (testing (str "Check that we're checking for non-nil values, not just logically true ones. There's only one place "
                   "(out of 3) that I don't like")
@@ -50,7 +50,7 @@
     nil false
     x))
 
-(deftest comparison-test
+(deftest ^:parallel comparison-test
   (mt/test-drivers (mt/normal-drivers)
     (mt/dataset places-cam-likes
       (testing "Can we use true literal in comparisons"
@@ -125,7 +125,7 @@
    (conj (mt/normal-drivers-with-feature :expressions) :mongo)
    (timezones-test/timezone-aware-column-drivers)))
 
-(deftest temporal-arithmetic-test
+(deftest ^:parallel temporal-arithmetic-test
   (testing "Should be able to use temporal arithmetic expressions in filters (#22531)"
     (mt/test-drivers (timezone-arithmetic-drivers)
       (mt/dataset attempted-murders
@@ -157,7 +157,7 @@
                             (pos-int? result)))
                     (is (nat-int? result))))))))))))
 
-(deftest nonstandard-temporal-arithmetic-test
+(deftest ^:parallel nonstandard-temporal-arithmetic-test
   (testing "Nonstandard temporal arithmetic should also be supported"
     (mt/test-drivers (timezone-arithmetic-drivers)
       (mt/dataset attempted-murders
@@ -194,7 +194,7 @@
                             (pos-int? result)))
                     (is (nat-int? result))))))))))))
 
-(deftest or-test
+(deftest ^:parallel or-test
   (mt/test-drivers (mt/normal-drivers)
     (testing ":or, :<=, :="
       (is (= [[1 "Red Medicine"                  4 10.0646 -165.374 3]
@@ -206,7 +206,7 @@
                  {:filter   [:or [:<= $id 3] [:= $id 5]]
                   :order-by [[:asc $id]]})))))))
 
-(deftest inside-test
+(deftest ^:parallel inside-test
   (mt/test-drivers (mt/normal-drivers)
     (testing ":inside"
       (is (= [[1 "Red Medicine" 4 10.0646 -165.374 3]]
@@ -214,7 +214,7 @@
                (mt/run-mbql-query venues
                  {:filter [:inside $latitude $longitude 10.0649 -165.379 10.0641 -165.371]})))))))
 
-(deftest is-null-test
+(deftest ^:parallel is-null-test
   (mt/test-drivers (mt/normal-drivers)
     (let [result (mt/first-row (mt/run-mbql-query checkins
                                  {:aggregation [[:count]]
@@ -223,7 +223,7 @@
       (is (= true
              (contains? #{[0] [0M] [nil] nil} result))))))
 
-(deftest not-null-test
+(deftest ^:parallel not-null-test
   (mt/test-drivers (mt/normal-drivers)
     (is (= [1000]
            (mt/first-row
@@ -247,7 +247,7 @@
 
 ;;; -------------------------------------------------- starts-with ---------------------------------------------------
 
-(deftest starts-with-test
+(deftest ^:parallel starts-with-test
   (mt/test-drivers (mt/normal-drivers)
     (is (= [[41 "Cheese Steak Shop" 18 37.7855 -122.44  1]
             [74 "Chez Jay"           2 34.0104 -118.493 2]]
@@ -285,7 +285,7 @@
 
 ;;; --------------------------------------------------- ends-with ----------------------------------------------------
 
-(deftest ends-with-test
+(deftest ^:parallel ends-with-test
   (mt/test-drivers (mt/normal-drivers)
     (is (= [[ 5 "Brite Spot Family Restaurant" 20 34.0778 -118.261 2]
             [ 7 "Don Day Korean Restaurant"    44 34.0689 -118.305 2]
@@ -327,7 +327,7 @@
 
 ;;; ---------------------------------------------------- contains ----------------------------------------------------
 
-(deftest contains-test
+(deftest ^:parallel contains-test
   (mt/test-drivers (mt/normal-drivers)
     (is (= [[31 "Bludso's BBQ"             5 33.8894 -118.207 2]
             [34 "Beachwood BBQ & Brewing" 10 33.7701 -118.191 2]
@@ -388,7 +388,7 @@
 ;;; |                                         = AND != WITH MULTIPLE VALUES                                          |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-(deftest equals-and-not-equals-with-extra-args-test
+(deftest ^:parallel equals-and-not-equals-with-extra-args-test
   (mt/test-drivers (mt/normal-drivers))
   (testing ":= with >2 args"
     (is (= 81
@@ -408,7 +408,7 @@
 ;; equivalent expressions but I already wrote them so in this case it doesn't hurt to have a little more test coverage
 ;; than we need
 
-(deftest not-filter-test
+(deftest ^:parallel not-filter-test
   (mt/test-drivers (mt/normal-drivers)
     (testing "="
       (is (= 99
@@ -484,7 +484,7 @@
 ;;; |                                                      Etc                                                       |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-(deftest etc-test
+(deftest ^:parallel etc-test
   (mt/test-drivers (mt/normal-drivers)
     (mt/dataset office-checkins
       (testing "make sure that filtering with timestamps truncating to minutes works (#4632)"
@@ -497,7 +497,7 @@
       (is (= 7
              (count-with-filter-clause checkins [:= [:datetime-field $date :week] "2015-06-21T07:00:00.000000000-00:00"]))))))
 
-(deftest string-escape-test
+(deftest ^:parallel string-escape-test
   ;; test `:sql` drivers that support native parameters
   (mt/test-drivers (mt/normal-drivers-with-feature :native-parameters)
     (testing "Make sure single quotes in parameters are escaped properly for the current driver"
@@ -527,7 +527,7 @@
                  {:aggregation [[:count]]
                   :filter      [:starts-with $name "In-N-Out"]})))))))
 
-(deftest automatically-parse-strings-test
+(deftest ^:parallel automatically-parse-strings-test
   (mt/test-drivers (mt/normal-drivers)
     (testing "The QP should automatically parse String parameters in filter clauses to the correct type"
       (testing "String parameter to an Integer Field"
@@ -539,7 +539,7 @@
 ;; - there are 415 regions, and 8 have a `nil` name; 407 have non-empty, non-nil names
 ;; - there are 601 airports, and 1 has a `""` code; 600 have non-empty, non-nil codes
 
-(deftest text-equals-nil-empty-string-test
+(deftest ^:parallel text-equals-nil-empty-string-test
   (mt/test-drivers (mt/normal-drivers)
     (mt/dataset airports
       (testing ":= against a text column should match the correct columns when value is"
@@ -552,7 +552,7 @@
                    (mt/formatted-rows [int]
                      (mt/run-mbql-query airport {:aggregation [:count], :filter [:= $code ""]}))))))))))
 
-(deftest text-not-equals-nil-test
+(deftest ^:parallel text-not-equals-nil-test
   (mt/test-drivers (mt/normal-drivers)
     (mt/dataset airports
       (testing ":!= against a nil/NULL in a text column should be truthy"
@@ -564,7 +564,7 @@
                  (mt/formatted-rows [int]
                    (mt/run-mbql-query airport {:aggregation [:count], :filter [:!= $code "SFO"]})))))))))
 
-(deftest is-empty-not-empty-test
+(deftest ^:parallel is-empty-not-empty-test
   (mt/test-drivers (mt/normal-drivers)
     (mt/dataset airports
       (testing ":is-empty and :not-empty filters should work correctly (#13158)"
@@ -586,7 +586,7 @@
                    (mt/formatted-rows [int]
                      (mt/run-mbql-query airport {:aggregation [:count], :filter [:not-empty $code]}))))))))))
 
-(deftest order-by-nulls-test
+(deftest ^:parallel order-by-nulls-test
   (testing "Check that we can sort by numeric columns that contain NULLs (#6615)"
     (mt/dataset daily-bird-counts
       (mt/test-drivers (mt/normal-drivers)

--- a/test/metabase/query_processor_test/implicit_joins_test.clj
+++ b/test/metabase/query_processor_test/implicit_joins_test.clj
@@ -6,7 +6,7 @@
             [metabase.query-processor :as qp]
             [metabase.test :as mt]))
 
-(deftest breakout-on-fk-field-test
+(deftest ^:parallel breakout-on-fk-field-test
   (mt/test-drivers (mt/normal-drivers-with-feature :foreign-keys)
     (testing "Test that we can breakout on an FK field (Note how the FK Field is returned in the results)"
       (mt/dataset tupac-sightings
@@ -28,7 +28,7 @@
                     :order-by    [[:desc [:aggregation 0]]]
                     :limit       10}))))))))
 
-(deftest filter-by-fk-field-test
+(deftest ^:parallel filter-by-fk-field-test
   (mt/test-drivers (mt/normal-drivers-with-feature :foreign-keys)
     (testing "Test that we can filter on an FK field"
       (mt/dataset tupac-sightings
@@ -39,7 +39,7 @@
                    {:aggregation [[:count]]
                     :filter      [:= $category_id->categories.id 8]}))))))))
 
-(deftest fk-field-in-fields-test
+(deftest ^:parallel fk-field-in-fields-test
   (mt/test-drivers (mt/normal-drivers-with-feature :foreign-keys)
     (testing "Check that we can include an FK field in `:fields`"
       (mt/dataset tupac-sightings
@@ -60,7 +60,7 @@
                     :order-by [[:desc $timestamp]]
                     :limit    10}))))))))
 
-(deftest join-multiple-tables-test
+(deftest ^:parallel join-multiple-tables-test
   (mt/test-drivers (mt/normal-drivers-with-feature :foreign-keys)
     (testing (str "1. Check that we can order by Foreign Keys (this query targets sightings and orders by cities.name "
                   "and categories.name)"
@@ -90,7 +90,7 @@
                     (map butlast)
                     (mt/format-rows-by [int int int]))))))))
 
-(deftest feature-check-test
+(deftest ^:parallel feature-check-test
   (mt/test-drivers (mt/normal-drivers-without-feature :foreign-keys)
     (testing "Check that trying to use a Foreign Key fails for Mongo and other DBs"
       (is
@@ -104,7 +104,7 @@
                         [:asc $id]]
              :limit    10})))))))
 
-(deftest field-refs-test
+(deftest ^:parallel field-refs-test
   (testing "Implicit joins should come back with `:fk->` field refs"
     (is (= (mt/$ids venues $category_id->categories.name)
            (-> (mt/cols
@@ -115,7 +115,7 @@
                first
                :field_ref)))))
 
-(deftest multiple-joins-test
+(deftest ^:parallel multiple-joins-test
   (mt/test-drivers (mt/normal-drivers-with-feature :foreign-keys)
     (testing "Can we join against the same table twice (multiple fks to a single table?)"
       (mt/dataset avian-singles
@@ -140,7 +140,7 @@
                     :breakout    [$sender_id->users.name]
                     :filter      [:= $receiver_id->users.name "Rasta Toucan"]}))))))))
 
-(deftest implicit-joins-with-expressions-test
+(deftest ^:parallel implicit-joins-with-expressions-test
   (mt/test-drivers (mt/normal-drivers-with-feature :foreign-keys :expressions)
     (testing "Should be able to run query with multiple implicit joins and breakouts"
       (mt/dataset sample-dataset

--- a/test/metabase/query_processor_test/native_test.clj
+++ b/test/metabase/query_processor_test/native_test.clj
@@ -4,7 +4,7 @@
             [metabase.query-processor-test :as qp.test]
             [metabase.test :as mt]))
 
-(deftest native-test
+(deftest ^:parallel native-test
   (is (= {:rows
           [["Plato Yeshua"]
            ["Felipinho Asklepios"]

--- a/test/metabase/query_processor_test/nested_field_test.clj
+++ b/test/metabase/query_processor_test/nested_field_test.clj
@@ -3,7 +3,7 @@
   (:require [clojure.test :refer :all]
             [metabase.test :as mt]))
 
-(deftest filter-test
+(deftest ^:parallel filter-test
   (mt/test-drivers (mt/normal-drivers-with-feature :nested-fields)
     (testing "Nested Field in FILTER"
       (mt/dataset geographical-tips
@@ -25,7 +25,7 @@
                      :order-by [[:asc $id]]
                      :limit    10})))))))))
 
-(deftest order-by-test
+(deftest ^:parallel order-by-test
   (mt/test-drivers (mt/normal-drivers-with-feature :nested-fields)
     (testing "Nested Field in ORDER-BY"
       (mt/dataset geographical-tips
@@ -65,7 +65,7 @@
                                [:= $tips.source.username "kyle"]]
                     :order-by [[:asc $tips.venue.name]]}))))))))
 
-(deftest aggregation-test
+(deftest ^:parallel aggregation-test
   (mt/test-drivers (mt/normal-drivers-with-feature :nested-fields)
     (testing "Nested Field in AGGREGATION"
       (mt/dataset geographical-tips
@@ -83,7 +83,7 @@
                    (mt/run-mbql-query tips
                      {:aggregation [[:count $tips.venue.name]]})))))))))
 
-(deftest breakout-test
+(deftest ^:parallel breakout-test
   (mt/test-drivers (mt/normal-drivers-with-feature :nested-fields)
     (testing "Nested Field in BREAKOUT"
       ;; Let's see how many tips we have by source.service
@@ -108,7 +108,7 @@
                     :breakout    [$tips.source.username]
                     :limit       4}))))))))
 
-(deftest fields-test
+(deftest ^:parallel fields-test
   (mt/test-drivers (mt/normal-drivers-with-feature :nested-fields)
     (testing "Nested Field in FIELDS"
       (mt/dataset geographical-tips
@@ -129,7 +129,7 @@
                     :order-by [[:asc $id]]
                     :limit    10}))))))))
 
-(deftest order-by-aggregation-test
+(deftest ^:parallel order-by-aggregation-test
   (mt/test-drivers (mt/normal-drivers-with-feature :nested-fields)
     (testing "Nested Field w/ ordering by aggregation"
       (mt/dataset geographical-tips

--- a/test/metabase/query_processor_test/nested_queries_test.clj
+++ b/test/metabase/query_processor_test/nested_queries_test.clj
@@ -22,7 +22,7 @@
             [schema.core :as s]
             [toucan.db :as db]))
 
-(deftest basic-test
+(deftest ^:parallel basic-test
   (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries)
     (testing "make sure we can do a basic query with MBQL source-query"
       (is (= {:rows [[1 "Red Medicine"                  4 10.0646 -165.374 3]
@@ -41,7 +41,7 @@
                                    :limit        10}
                     :limit        5}))))))))
 
-(deftest basic-sql-source-query-test
+(deftest ^:parallel basic-sql-source-query-test
   (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries)
     (testing "make sure we can do a basic query with a SQL source-query"
       (is (= {:rows [[1 -165.374  4 3 "Red Medicine"                 10.0646]
@@ -77,7 +77,7 @@
             (dissoc :id :semantic_type :settings :fingerprint :table_id :coercion_strategy))
           (qp.test/aggregate-col :count)]})
 
-(deftest mbql-source-query-breakout-aggregation-test
+(deftest ^:parallel mbql-source-query-breakout-aggregation-test
   (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries)
     (testing "make sure we can do a query with breakout and aggregation using an MBQL source query"
       (is (= (breakout-results)
@@ -88,7 +88,7 @@
                     :aggregation  [:count]
                     :breakout     [$price]}))))))))
 
-(deftest breakout-fk-column-test
+(deftest ^:parallel breakout-fk-column-test
   (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries :foreign-keys)
     (testing "Test including a breakout of a nested query column that follows an FK"
       (is (= {:rows [[1 174] [2 474] [3 78] [4 39]]
@@ -103,7 +103,7 @@
                     :order-by     [[:asc $venue_id->venues.price]]
                     :breakout     [$venue_id->venues.price]}))))))))
 
-(deftest two-breakout-fk-columns-test
+(deftest ^:parallel two-breakout-fk-columns-test
   (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries :foreign-keys)
     (testing "Test two breakout columns from the nested query, both following an FK"
       (is (= {:rows [[2 33.7701 7]
@@ -125,7 +125,7 @@
                     :breakout     [$venue_id->venues.price
                                    $venue_id->venues.latitude]}))))))))
 
-(deftest two-breakouts-one-fk-test
+(deftest ^:parallel two-breakouts-one-fk-test
   (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries :foreign-keys)
     (testing "Test two breakout columns from the nested query, one following an FK the other from the source table"
       (is (= {:rows [[1 1 6]
@@ -147,7 +147,7 @@
                     :breakout     [$venue_id->venues.price $user_id]
                     :limit        5}))))))))
 
-(deftest nested-with-aggregations-at-both-levels-test
+(deftest ^:parallel nested-with-aggregations-at-both-levels-test
   (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries)
     (mt/dataset sample-dataset
       (doseq [dataset? [true false]]
@@ -190,7 +190,7 @@
 
 
 
-(deftest sql-source-query-breakout-aggregation-test
+(deftest ^:parallel sql-source-query-breakout-aggregation-test
   (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries)
     (testing "make sure we can do a query with breakout and aggregation using a SQL source query"
       (is (= (:rows (breakout-results))
@@ -232,7 +232,7 @@
   ([card k v & {:as more}]
    (query-with-source-card card (merge {k v} more))))
 
-(deftest multilevel-nested-questions-with-joins
+(deftest ^:parallel multilevel-nested-questions-with-joins
   (testing "Multilevel nested questions with joins work (#22859)"
     (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries :left-join)
       (mt/dataset sample-dataset
@@ -257,7 +257,7 @@
                      qp/process-query
                      :status))))))))
 
-(deftest source-card-id-test
+(deftest ^:parallel source-card-id-test
   (testing "Make sure we can run queries using source table `card__id` format."
     ;; This is the format that is actually used by the frontend; it gets translated to the normal `source-query`
     ;; format by middleware. It's provided as a convenience so only minimal changes need to be made to the frontend.
@@ -271,7 +271,7 @@
                       {:aggregation [:count]
                        :breakout    [$price]}))))))))))
 
-(deftest grouped-expression-in-card-test
+(deftest ^:parallel grouped-expression-in-card-test
   (testing "Nested grouped expressions work (#23862)."
     (mt/with-temp Card [card {:dataset_query
                               (mt/mbql-query venues
@@ -285,7 +285,7 @@
               (qp/process-query
                (query-with-source-card card))))))))
 
-(deftest card-id-native-source-queries-test
+(deftest ^:parallel card-id-native-source-queries-test
   (let [run-native-query
         (fn [sql]
           (mt/with-temp Card [card {:dataset_query {:database (mt/id), :type :native. :native {:query sql}}}]
@@ -307,7 +307,7 @@
         "Ensure trailing comments followed by a newline are trimmed and don't cause a wrapping SQL query to fail")))
 
 
-(deftest filter-by-field-literal-test
+(deftest ^:parallel filter-by-field-literal-test
   (testing "make sure we can filter by a field literal"
     (is (= {:rows [[1 "Red Medicine" 4 10.0646 -165.374 3]]
             :cols (mapv (partial qp.test/col :venues)
@@ -334,7 +334,7 @@
             [:PUBLIC.VENUES.PRICE :PRICE]]
    :from   [:PUBLIC.VENUES]})
 
-(deftest field-literals-test
+(deftest ^:parallel field-literals-test
   (is (= (honeysql->sql
           {:select [[:source.ID :ID]
                     [:source.NAME :NAME]
@@ -372,7 +372,7 @@
               :limit        10})))
       "make sure that field-literals work as DateTimeFields"))
 
-(deftest aggregatation-references-test
+(deftest ^:parallel aggregatation-references-test
   (testing "make sure that aggregation references match up to aggregations from the same level they're from"
     ;; e.g. the ORDER BY in the source-query should refer the 'stddev' aggregation, NOT the 'avg' aggregation
     (is (= {:query  (str "SELECT avg(\"source\".\"stddev\") AS \"avg\" FROM ("
@@ -390,7 +390,7 @@
                               :order-by     [[[:aggregation 0] :descending]]}
                :aggregation  [[:avg *stddev/Integer]]}))))))
 
-(deftest handle-incorrect-field-forms-gracefully-test
+(deftest ^:parallel handle-incorrect-field-forms-gracefully-test
   (testing "make sure that we handle [:field [:field <name> ...]] forms gracefully, despite that not making any sense"
     (is (sql= '{:select   [source.CATEGORY_ID AS CATEGORY_ID]
                 :from     [{:select [VENUES.ID          AS ID
@@ -409,7 +409,7 @@
                  :breakout     [[:field [:field "category_id" {:base-type :type/Integer}] nil]]
                  :limit        10})))))
 
-(deftest filter-by-string-fields-test
+(deftest ^:parallel filter-by-string-fields-test
   (testing "Make sure we can filter by string fields from a source query"
     (is (= (honeysql->sql
             {:select [[:source.ID :ID]
@@ -428,7 +428,7 @@
                :limit        10
                :filter       [:!= [:field "text" {:base-type :type/Text}] "Coo"]}))))))
 
-(deftest filter-by-number-fields-test
+(deftest ^:parallel filter-by-number-fields-test
   (testing "Make sure we can filter by number fields form a source query"
     (is (= (honeysql->sql
             {:select [[:source.ID :ID]
@@ -446,7 +446,7 @@
                :limit        10
                :filter       [:> *sender_id/Integer 3]}))))))
 
-(deftest native-query-with-default-params-as-source-test
+(deftest ^:parallel native-query-with-default-params-as-source-test
   (testing "make sure using a native query with default params as a source works"
     (is (= {:query  "SELECT \"source\".* FROM (SELECT * FROM PRODUCTS WHERE CATEGORY = ? LIMIT 10) \"source\" LIMIT 1048575"
             :params ["Widget"]}
@@ -463,7 +463,7 @@
                 :type     :query
                 :query    {:source-table (str "card__" (u/the-id card))}}))))))
 
-(deftest correct-column-metadata-test
+(deftest ^:parallel correct-column-metadata-test
   (testing "make sure a query using a source query comes back with the correct columns metadata"
     (is (= (map (partial qp.test/col :venues)
                 [:id :name :category_id :latitude :longitude :price])
@@ -502,7 +502,7 @@
                     {:aggregation [[:count]]
                      :breakout    [!day.*date]})))))))))
 
-(deftest breakout-year-test
+(deftest ^:parallel breakout-year-test
   (testing (str "make sure when doing a nested query we give you metadata that would suggest you should be able to "
                 "break out a *YEAR*")
     (let [source-query (mt/$ids checkins
@@ -529,7 +529,7 @@
     status
     results))
 
-(deftest time-interval-test
+(deftest ^:parallel time-interval-test
   (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries)
     (testing "make sure using a time interval filter works"
       (is (= :completed
@@ -540,7 +540,7 @@
                    qp/process-query
                    completed-status)))))))
 
-(deftest datetime-field-literals-in-filters-and-breakouts-test
+(deftest ^:parallel datetime-field-literals-in-filters-and-breakouts-test
   (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries)
     (testing "make sure that bucketing a `:field` w/ name works correctly in filters & breakouts"
       (mt/with-temp Card [card (mbql-card-def (mt/$ids {:source-table $$checkins}))]
@@ -553,7 +553,7 @@
                    qp/process-query
                    completed-status)))))))
 
-(deftest drag-to-filter-timeseries-test
+(deftest ^:parallel drag-to-filter-timeseries-test
   (testing "make sure timeseries queries generated by \"drag-to-filter\" work correctly"
     (mt/with-temp Card [card (mbql-card-def (mt/$ids {:source-table $$checkins}))]
       (is (= :completed
@@ -565,7 +565,7 @@
                  (qp/process-query)
                  (completed-status)))))))
 
-(deftest macroexpansion-test
+(deftest ^:parallel macroexpansion-test
   (testing "Make sure that macro expansion works inside of a neested query, when using a compound filter clause (#5974)"
     (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries)
       (mt/with-temp* [Segment [segment (mt/$ids {:table_id   $$venues
@@ -698,7 +698,7 @@
                             s/Keyword s/Any}
                            (save-card-via-API-with-native-source-query! 403 (mt/db) source-card-collection dest-card-collection))))))))))
 
-(deftest infer-source-fields-test
+(deftest ^:parallel infer-source-fields-test
   (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries)
     (testing (str "make sure that if we refer to a Field that is actually inside the source query, the QP is smart "
                   "enough to figure out what you were referring to and behave appropriately")
@@ -710,7 +710,7 @@
                   :aggregation  [[:count]]
                   :filter       [:= $category_id 50]})))))))
 
-(deftest nested-query-with-joins-test
+(deftest ^:parallel nested-query-with-joins-test
   (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries :foreign-keys)
     (testing "make sure that if a nested query includes joins queries based on it still work correctly (#8972)"
       (is (= [[31 "Bludso's BBQ"         5 33.8894 -118.207 2]
@@ -728,7 +728,7 @@
                     :filter       [:= $venues.category_id->categories.name "BBQ"]
                     :order-by     [[:asc $id]]}}))))))))
 
-(deftest parse-datetime-strings-test
+(deftest ^:parallel parse-datetime-strings-test
   (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries :foreign-keys)
     (testing "Make sure we parse datetime strings when compared against type/DateTime field literals (#9007)"
       (is (= [[395]
@@ -740,7 +740,7 @@
                   :fields       [$id]
                   :filter       [:= *date "2014-03-30"]})))))))
 
-(deftest aapply-filters-test
+(deftest ^:parallel aapply-filters-test
   (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries :foreign-keys)
     (testing "make sure filters in source queries are applied correctly!"
       (is (= [["Fred 62"     1]
@@ -754,7 +754,7 @@
                   :breakout     [$venue_id->venues.name]
                   :filter       [:starts-with $venue_id->venues.name "F"]})))))))
 
-(deftest two-of-the-same-aggregations-test
+(deftest ^:parallel two-of-the-same-aggregations-test
   (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries :foreign-keys)
     (testing "Do nested queries work with two of the same aggregation? (#9767)"
       (is (= [["2014-02-01T00:00:00Z" 302 1804]
@@ -768,7 +768,7 @@
                   :filter [:> *sum/Float 300]
                   :limit  2})))))))
 
-(deftest expressions-test
+(deftest ^:parallel expressions-test
   (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries :foreign-keys :expressions)
     (testing "can you use nested queries that have expressions in them?"
       (let [query (mt/mbql-query venues
@@ -788,7 +788,7 @@
                      (mt/run-mbql-query nil
                        {:source-table (str "card__" card-id)}))))))))))
 
-(deftest bucketing-already-bucketed-year-test
+(deftest ^:parallel bucketing-already-bucketed-year-test
   (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries)
     (testing "If a field is bucketed as a year in a source query, bucketing it as a year shouldn't break things (#10446)"
       ;; (Normally, it would break things, but the new `simplify` middleware eliminates the duplicate cast. It is not
@@ -804,7 +804,7 @@
                                  :limit        1}
                   :fields       [!year.*date]})))))))
 
-(deftest correctly-alias-duplicate-names-in-breakout-test
+(deftest ^:parallel correctly-alias-duplicate-names-in-breakout-test
   (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries :expressions :foreign-keys)
     (testing "Do we correctly alias name clashes in breakout (#10511)"
       (let [results (mt/run-mbql-query venues
@@ -868,8 +868,8 @@
                                   [2 1 123 110.93  6.1 117.03 nil "2018-05-15T08:04:04.58Z"  3 "Mediocre Wooden Bench"]]
                         :columns ["ID" "USER_ID" "PRODUCT_ID" "SUBTOTAL" "TAX" "TOTAL" "DISCOUNT" "CREATED_AT" "QUANTITY" "TITLE"]}
                        (mt/rows+column-names
-                         (mt/run-mbql-query orders
-                           {:source-table (str "card__" card-id), :limit 2, :order-by [[:asc $id]]}))))))))))))
+                        (mt/run-mbql-query orders
+                          {:source-table (str "card__" card-id), :limit 2, :order-by [[:asc $id]]}))))))))))))
 
 (deftest nested-query-with-joins-test-2
   (testing "Should be able to use a query that contains joins as a source query (#14724)"
@@ -901,7 +901,7 @@
                      4.0 "2017-12-31T14:41:56.87Z"]
                     (first (mt/rows results)))))))))))
 
-(deftest inception-metadata-test
+(deftest ^:parallel inception-metadata-test
   (testing "Should be able to do an 'inception-style' nesting of source > source > source with a join (#14724)"
     (mt/dataset sample-dataset
       ;; these tests look at the metadata for just one column so it's easier to spot the differences.
@@ -993,7 +993,7 @@
                         25.1 4.0 "2017-12-31T14:41:56.87Z"]
                        (mt/first-row result)))))))))))
 
-(deftest handle-unwrapped-joined-fields-correctly-test
+(deftest ^:parallel handle-unwrapped-joined-fields-correctly-test
   (mt/dataset sample-dataset
     (testing "References to joined fields should be handled correctly (#14766)"
       ;; using `$products.id` should give you the same results as properly referring to it with `&Products.products.id`
@@ -1041,7 +1041,7 @@
                   ["2016-08-01T00:00:00Z" "2016-05-01T00:00:00Z" 12]]
                  (mt/rows (qp/process-query query)))))))))
 
-(deftest nested-queries-with-joins-with-old-metadata-test
+(deftest ^:parallel nested-queries-with-joins-with-old-metadata-test
   (testing "Nested queries with joins using old pre-38 result metadata still work (#14788)"
     (mt/dataset sample-dataset
       ;; create the query we'll use as a source query
@@ -1101,7 +1101,7 @@
                   (test-query (for [col metadata]
                                 (dissoc col :field_ref :id))))))))))))
 
-(deftest support-legacy-filter-clauses-test
+(deftest ^:parallel support-legacy-filter-clauses-test
   (testing "We should handle legacy usage of field-literal inside filter clauses"
     (mt/dataset sample-dataset
       (testing "against joins (#14809)"
@@ -1124,7 +1124,7 @@
                         ;; not sure why FE is using `field-literal` here... but it should work anyway.
                         :filter       [:= *CATEGORY/Text "Widget"]})))))))
 
-(deftest support-legacy-dashboard-parameters-test
+(deftest ^:parallel support-legacy-dashboard-parameters-test
   (testing "We should handle legacy usage of field-literal inside (Dashboard) parameters (#14810)"
     (mt/dataset sample-dataset
       (is (schema= {:status   (s/eq :completed)
@@ -1142,7 +1142,7 @@
                                      :target [:dimension [:field "CATEGORY" {:base-type :type/Text}]]
                                      :value  "Widget"}]})))))))
 
-(deftest nested-queries-with-expressions-and-joins-test
+(deftest ^:parallel nested-queries-with-expressions-and-joins-test
   (mt/test-drivers (mt/normal-drivers-with-feature :foreign-keys :nested-queries :left-join)
     (mt/dataset sample-dataset
       (testing "Do nested queries in combination with joins and expressions still work correctly? (#14969)"
@@ -1214,7 +1214,7 @@
                    (mt/formatted-rows [str 2.0]
                      (qp/process-query query))))))))))
 
-(deftest date-range-test
+(deftest ^:parallel date-range-test
   (mt/test-drivers (mt/normal-drivers-with-feature :foreign-keys :nested-queries)
     (testing "Date ranges should work the same in nested queries as is regular queries (#15352)"
       (mt/dataset sample-dataset
@@ -1245,7 +1245,7 @@
               (is (= [[543]]
                      (mt/formatted-rows [int] (qp/process-query q2)))))))))))
 
-(deftest nested-query-with-metric-test
+(deftest ^:parallel nested-query-with-metric-test
   (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries)
     (testing "A nested query with a Metric should work as expected (#12507)"
       (mt/with-temp Metric [metric (mt/$ids checkins
@@ -1261,7 +1261,7 @@
                                    :breakout     [$venue_id]}
                     :aggregation  [[:count]]}))))))))
 
-(deftest nested-query-with-expressions-test
+(deftest ^:parallel nested-query-with-expressions-test
   (testing "Nested queries with expressions should work in top-level native queries (#12236)"
     (mt/test-drivers (mt/normal-drivers-with-feature
                       :nested-queries
@@ -1290,7 +1290,7 @@
                    (mt/formatted-rows [str int]
                      (qp/process-query query))))))))))
 
-(deftest join-against-query-with-implicit-joins-test
+(deftest ^:parallel join-against-query-with-implicit-joins-test
   (testing "Should be able to do subsequent joins against a query with implicit joins (#17767)"
     (mt/test-drivers (mt/normal-drivers-with-feature
                       :nested-queries
@@ -1322,9 +1322,9 @@
                        "Ad perspiciatis quis et consectetur. Laboriosam fuga voluptas ut et modi ipsum. Odio et eum numquam eos nisi. Assumenda aut magnam libero maiores nobis vel beatae officia."
                        "2018-05-15T20:25:48.517Z"]]
                      (mt/formatted-rows [int int int int str int str str]
-                       (qp/process-query query)))))))))))
+                                        (qp/process-query query)))))))))))
 
-(deftest breakout-on-temporally-bucketed-implicitly-joined-column-inside-source-query-test
+(deftest ^:parallel breakout-on-temporally-bucketed-implicitly-joined-column-inside-source-query-test
   (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries :basic-aggregations :left-join)
     (testing (str "Should be able to breakout on a temporally-bucketed, implicitly-joined column from the source query "
                   "incorrectly using `:field` literals to refer to the Field (#16389)")
@@ -1344,7 +1344,7 @@
                      (mt/formatted-rows [str int]
                        (qp/process-query query)))))))))))
 
-(deftest really-really-long-identifiers-test
+(deftest ^:parallel really-really-long-identifiers-test
   (testing "Should correctly handle really really long table and column names (#20627)"
     (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries :basic-aggregations :left-join)
       (mt/dataset sample-dataset

--- a/test/metabase/query_processor_test/order_by_test.clj
+++ b/test/metabase/query_processor_test/order_by_test.clj
@@ -4,7 +4,7 @@
             [metabase.driver :as driver]
             [metabase.test :as mt]))
 
-(deftest order-by-test
+(deftest ^:parallel order-by-test
   (mt/test-drivers (mt/normal-drivers)
     (is (= [[1 12 375]
             [1  9 139]
@@ -24,7 +24,7 @@
                            [:asc $id]]
                 :limit    10}))))))
 
-(deftest order-by-aggregate-fields-test
+(deftest ^:parallel order-by-aggregate-fields-test
   (mt/test-drivers (mt/normal-drivers)
     (testing :count
       (is (= [[4  6]

--- a/test/metabase/query_processor_test/page_test.clj
+++ b/test/metabase/query_processor_test/page_test.clj
@@ -4,7 +4,7 @@
             [metabase.query-processor :as qp]
             [metabase.test :as mt]))
 
-(deftest page-test
+(deftest ^:parallel page-test
   (mt/test-drivers (mt/normal-drivers)
     (testing "Test that we can get \"pages\" of results."
       (letfn [(page-is [expected page-num]

--- a/test/metabase/query_processor_test/parameters_test.clj
+++ b/test/metabase/query_processor_test/parameters_test.clj
@@ -48,7 +48,7 @@
                                  :target [:variable [:template-tag (name field)]]
                                  :value  param-value}]))))
 
-(deftest template-tag-param-test
+(deftest ^:parallel template-tag-param-test
   (mt/test-drivers (mt/normal-drivers-with-feature :native-parameters)
     (letfn [(count-with-params [table param-name param-type value & [options]]
               (run-count-query
@@ -105,7 +105,7 @@
 ;; Tried manually syncing the DB (with attempted-murders dataset), and storing it to an initialized QP, to no avail.
 
 ;; this isn't a complete test for all possible field filter types, but it covers mostly everything
-(deftest field-filter-param-test
+(deftest ^:parallel field-filter-param-test
   (letfn [(is-count-= [expected-count table field value-type value]
             (let [query (field-filter-count-query table field value-type value)]
               (testing (format "\nquery = \n%s" (u/pprint-to-str 'cyan query))
@@ -146,7 +146,7 @@
             (is-count-= 2
                         :places :liked :boolean true)))))))
 
-(deftest filter-nested-queries-test
+(deftest ^:parallel filter-nested-queries-test
   (mt/test-drivers (mt/normal-drivers-with-feature :native-parameters :nested-queries)
     (testing "We should be able to apply filters to queries that use native queries with parameters as their source (#9802)"
       (mt/with-temp Card [{card-id :id} {:dataset_query (mt/native-query (qp/compile (mt/mbql-query checkins)))}]
@@ -159,7 +159,7 @@
                  (mt/formatted-rows :checkins
                    (qp/process-query query)))))))))
 
-(deftest string-escape-test
+(deftest ^:parallel string-escape-test
   ;; test `:sql` drivers that support native parameters
   (mt/test-drivers (set (filter #(isa? driver/hierarchy % :sql) (mt/normal-drivers-with-feature :native-parameters)))
     (testing "Make sure field filter parameters are properly escaped"
@@ -168,7 +168,7 @@
         (is (= [[1]]
                (mt/formatted-rows [int] results)))))))
 
-(deftest native-with-spliced-params-test
+(deftest ^:parallel native-with-spliced-params-test
   (testing "Make sure we can convert a parameterized query to a native query with spliced params"
     (testing "Multiple values"
       (mt/dataset airports
@@ -205,7 +205,7 @@
                              :target [:dimension [:template-tag "price"]]
                              :value  [1 2]}]}))))))
 
-(deftest ignore-parameters-for-unparameterized-native-query-test
+(deftest ^:parallel ignore-parameters-for-unparameterized-native-query-test
   (testing "Parameters passed for unparameterized queries should get ignored"
     (let [query {:database (mt/id)
                  :type     :native
@@ -221,7 +221,7 @@
                  (m/dissoc-in [:data :native_form :params])
                  (m/dissoc-in [:data :results_metadata :checksum])))))))
 
-(deftest legacy-parameters-with-no-widget-type-test
+(deftest ^:parallel legacy-parameters-with-no-widget-type-test
   (testing "Legacy queries with parameters that don't specify `:widget-type` should still work (#20643)"
     (mt/dataset sample-dataset
       (let [query (mt/native-query
@@ -234,7 +234,7 @@
         (is (= [200]
                (mt/first-row (qp/process-query query))))))))
 
-(deftest date-parameter-for-native-query-with-nested-mbql-query-test
+(deftest ^:parallel date-parameter-for-native-query-with-nested-mbql-query-test
   (testing "Should be able to have a native query with a nested MBQL query and a date parameter (#21246)"
     (mt/dataset sample-dataset
       (mt/with-temp Card [{card-id :id} {:dataset_query (mt/mbql-query products)}]

--- a/test/metabase/query_processor_test/query_to_native_test.clj
+++ b/test/metabase/query_processor_test/query_to_native_test.clj
@@ -7,7 +7,7 @@
             [metabase.test :as mt]
             [metabase.util :as u]))
 
-(deftest compile-test
+(deftest ^:parallel compile-test
   (testing "Can we convert an MBQL query to a native query?"
     (is (= {:query  (str "SELECT \"PUBLIC\".\"VENUES\".\"ID\" AS \"ID\","
                          " \"PUBLIC\".\"VENUES\".\"NAME\" AS \"NAME\","
@@ -20,7 +20,7 @@
             :params nil}
            (qp/compile (mt/mbql-query venues))))))
 
-(deftest already-native-test
+(deftest ^:parallel already-native-test
   (testing "If query is already native, `compile` should still do stuff like parsing parameters"
     (is (= {:query  "SELECT * FROM VENUES WHERE price = 3;"
             :params []}
@@ -51,7 +51,7 @@
                                                         native-perms? (conj (perms/adhoc-native-query-path database-id))))]
     (qp/compile query)))
 
-(deftest permissions-test
+(deftest ^:parallel permissions-test
   (testing "If user permissions are bound, we should still NOT do permissions checking when you call `compile`"
     (testing "Should work if you have the right perms"
       (is (compile-with-user-perms
@@ -62,7 +62,7 @@
            (mt/mbql-query venues)
            {:object-perms? false, :native-perms? true})))))
 
-(deftest error-test
+(deftest ^:parallel error-test
   (testing "If the query is bad in some way it should return a relevant error (?)"
     (is (thrown-with-msg?
          clojure.lang.ExceptionInfo

--- a/test/metabase/query_processor_test/share_test.clj
+++ b/test/metabase/query_processor_test/share_test.clj
@@ -6,7 +6,7 @@
             [metabase.models.segment :refer [Segment]]
             [metabase.test :as mt]))
 
-(deftest basic-test
+(deftest ^:parallel basic-test
   (mt/test-drivers (mt/normal-drivers-with-feature :basic-aggregations)
     (is (= [[0.94]]
            (mt/formatted-rows [2.0]
@@ -40,7 +40,7 @@
                  {:aggregation [[:share [:< $price 4]]]
                   :filter      [:> $price Long/MAX_VALUE]})))))))
 
-(deftest segments-metrics-test
+(deftest ^:parallel segments-metrics-test
   (mt/test-drivers (mt/normal-drivers-with-feature :basic-aggregations)
     (testing "Share containing a Segment"
       (mt/with-temp Segment [{segment-id :id} {:table_id   (mt/id :venues)
@@ -60,7 +60,7 @@
                  (mt/run-mbql-query venues
                    {:aggregation [[:metric metric-id]]}))))))))
 
-(deftest expressions-test
+(deftest ^:parallel expressions-test
   (mt/test-drivers (mt/normal-drivers-with-feature :basic-aggregations :expressions)
     (testing "Share containing an expression"
       (is (= [[2 0.0]

--- a/test/metabase/query_processor_test/string_extracts_test.clj
+++ b/test/metabase/query_processor_test/string_extracts_test.clj
@@ -17,60 +17,60 @@
        mt/rows
        ffirst))
 
-(deftest test-length
+(deftest ^:parallel test-length
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
     (is (= 3 (int (test-string-extract [:length "foo"]))))))
 
-(deftest test-trim
+(deftest ^:parallel test-trim
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
     (is (= "foo" (test-string-extract [:trim " foo "])))))
 
-(deftest test-ltrim
+(deftest ^:parallel test-ltrim
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
     (is (= "foo " (test-string-extract [:ltrim " foo "])))))
 
-(deftest test-rtrim
+(deftest ^:parallel test-rtrim
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
     (is (= " foo" (test-string-extract [:rtrim " foo "])))))
 
-(deftest test-upper
+(deftest ^:parallel test-upper
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
     (is (= "RED MEDICINE" (test-string-extract [:upper [:field-id (data/id :venues :name)]])))))
 
-(deftest test-lower
+(deftest ^:parallel test-lower
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
     (is (= "red medicine" (test-string-extract [:lower [:field-id (data/id :venues :name)]])))))
 
-(deftest test-substring
+(deftest ^:parallel test-substring
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
     (is (= "Red" (test-string-extract [:substring [:field-id (data/id :venues :name)] 1 3])))
     (is (= "ed Medicine" (test-string-extract [:substring [:field-id (data/id :venues :name)] 2])))
     (is (= "Red Medicin" (test-string-extract [:substring [:field-id (data/id :venues :name)]
                                                1 [:- [:length [:field-id (data/id :venues :name)]] 1]])))))
 
-(deftest test-replace
+(deftest ^:parallel test-replace
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
     (is (= "Red Baloon" (test-string-extract [:replace [:field-id (data/id :venues :name)] "Medicine" "Baloon"])))))
 
-(deftest test-coalesce
+(deftest ^:parallel test-coalesce
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
     (is (= "a" (test-string-extract [:coalesce "a" "b"])))))
 
-(deftest test-concat
+(deftest ^:parallel test-concat
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
     (is (= "foobar" (test-string-extract [:concat "foo" "bar"])))
     (testing "Does concat work with >2 args"
       (is (= "foobar" (test-string-extract [:concat "f" "o" "o" "b" "a" "r"]))))))
 
-(deftest test-regex-match-first
+(deftest ^:parallel test-regex-match-first
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions :regex)
     (is (= "Red" (test-string-extract [:regex-match-first [:field-id (data/id :venues :name)] "(.ed+)"])))))
 
-(deftest test-nesting
+(deftest ^:parallel test-nesting
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
     (is (= "MED" (test-string-extract [:upper [:substring [:trim [:substring [:field-id (data/id :venues :name)] 4]] 1 3]])))))
 
-(deftest test-breakout
+(deftest ^:parallel test-breakout
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
     (is (= ["20th Century Cafefoo" 1]
            (->> {:expressions  {"test" [:concat [:field-id (data/id :venues :name)] "foo"]}
@@ -81,21 +81,21 @@
                 (mt/formatted-rows [identity int])
                 first)))))
 
-(deftest replace-escaping-test
+(deftest ^:parallel replace-escaping-test
   (mt/test-drivers
     (mt/normal-drivers-with-feature :expressions)
     (is (= "Larry's The Prime Rib" (test-string-extract
                                     [:replace [:field-id (data/id :venues :name)] "Lawry's" "Larry's"]
                                     [:= [:field-id (data/id :venues :name)] "Lawry's The Prime Rib"])))))
 
-(deftest regex-match-first-escaping-test
+(deftest ^:parallel regex-match-first-escaping-test
   (mt/test-drivers
     (mt/normal-drivers-with-feature :expressions :regex)
     (is (= "Taylor's" (test-string-extract
                        [:regex-match-first [:field-id (data/id :venues :name)] "^Taylor's"]
                        [:= [:field-id (data/id :venues :name)] "Taylor's Prime Steak House"])))))
 
-(deftest regex-extract-in-explict-join-test
+(deftest ^:parallel regex-extract-in-explict-join-test
   (testing "Should be able to use regex extra in an explict join (#17790)"
     (mt/test-drivers (mt/normal-drivers-with-feature :expressions :regex :left-join)
       (mt/dataset sample-dataset

--- a/test/metabase/query_processor_test/sum_where_test.clj
+++ b/test/metabase/query_processor_test/sum_where_test.clj
@@ -4,7 +4,7 @@
             [metabase.models.segment :refer [Segment]]
             [metabase.test :as mt]))
 
-(deftest basic-test
+(deftest ^:parallel basic-test
   (mt/test-drivers (mt/normal-drivers-with-feature :basic-aggregations)
     (is (= 179.0
            (->> {:aggregation [[:sum-where
@@ -25,7 +25,7 @@
                   ffirst
                   double))))))
 
-(deftest compound-condition-test
+(deftest ^:parallel compound-condition-test
   (mt/test-drivers (mt/normal-drivers-with-feature :basic-aggregations)
     (is (= 34.0
            (->> {:aggregation [[:sum-where
@@ -38,7 +38,7 @@
                 ffirst
                 double)))))
 
-(deftest filter-test
+(deftest ^:parallel filter-test
   (mt/test-drivers (mt/normal-drivers-with-feature :basic-aggregations)
     (is (= nil
            (->> {:aggregation [[:sum-where [:field-id (mt/id :venues :price)] [:< [:field-id (mt/id :venues :price)] 4]]]
@@ -47,7 +47,7 @@
                 mt/rows
                 ffirst)))))
 
-(deftest breakout-test
+(deftest ^:parallel breakout-test
   (mt/test-drivers (mt/normal-drivers-with-feature :basic-aggregations)
     (is (= [[2 0.0]
             [3 0.0]
@@ -64,7 +64,7 @@
                 (map (fn [[k v]]
                        [(long k) (double v)])))))))
 
-(deftest sum-where-inside-expressions-test
+(deftest ^:parallel sum-where-inside-expressions-test
   (mt/test-drivers (mt/normal-drivers-with-feature :basic-aggregations :expressions)
     (is (= 90.5
            (->> {:aggregation [[:+
@@ -79,7 +79,7 @@
                 ffirst
                 double)))))
 
-(deftest segment-test
+(deftest ^:parallel segment-test
   (mt/test-drivers (mt/normal-drivers-with-feature :basic-aggregations)
     (mt/with-temp Segment [{segment-id :id} {:table_id   (mt/id :venues)
                                              :definition {:source-table (mt/id :venues)
@@ -91,7 +91,7 @@
                   ffirst
                   double))))))
 
-(deftest metric-test
+(deftest ^:parallel metric-test
   (mt/test-drivers (mt/normal-drivers-with-feature :basic-aggregations)
     (mt/with-temp Metric [{metric-id :id} {:table_id   (mt/id :venues)
                                            :definition {:source-table (mt/id :venues)

--- a/test/metabase/query_processor_test/time_field_test.clj
+++ b/test/metabase/query_processor_test/time_field_test.clj
@@ -16,7 +16,7 @@
 (def ^:private skip-time-test-drivers
   #{:oracle :mongo :redshift :sparksql})
 
-(deftest basic-test
+(deftest ^:parallel basic-test
   (mt/test-drivers (mt/normal-drivers-except skip-time-test-drivers)
     (doseq [[message [start end]] {"Basic between query on a time field"
                                    ["08:00:00" "09:00:00"]
@@ -32,7 +32,7 @@
                   [4 "Simcha Yan"   "08:30:00Z"]])
                (time-query :between start end)))))))
 
-(deftest greater-than-test
+(deftest ^:parallel greater-than-test
   (mt/test-drivers (mt/normal-drivers-except skip-time-test-drivers)
     (is (= (if (= :sqlite driver/*driver*)
              [[3 "Kaneonuskatew Eiran" "16:15:00"]
@@ -44,7 +44,7 @@
               [10 "Frans Hevel" "19:30:00Z"]])
            (time-query :> "16:00:00Z")))))
 
-(deftest equals-test
+(deftest ^:parallel equals-test
   (mt/test-drivers (mt/normal-drivers-except skip-time-test-drivers)
     (is (= (if (= :sqlite driver/*driver*)
              [[3 "Kaneonuskatew Eiran" "16:15:00"]]

--- a/test/metabase/test/data.clj
+++ b/test/metabase/test/data.clj
@@ -235,11 +235,11 @@
                                           (not (get &env dataset)))
                                    `(data.impl/resolve-dataset-definition '~(ns-name *ns*) '~dataset)
                                    dataset)
-                                (fn [] ~@body))))
+                                (^:once fn* [] ~@body))))
 
 (defmacro with-temp-copy-of-db
-  "Run `body` with the current DB (i.e., the one that powers `data/db` and `data/id`) bound to a temporary copy of the
+  "Run `body` with the current DB (i.e., the one that powers [[db]] and [[id]]) bound to a temporary copy of the
   current DB. Tables and Fields are copied as well."
   {:style/indent 0}
   [& body]
-  `(data.impl/do-with-temp-copy-of-db (fn [] ~@body)))
+  `(data.impl/do-with-temp-copy-of-db (^:once fn* [] ~@body)))

--- a/test/metabase/test/data/h2.clj
+++ b/test/metabase/test/data/h2.clj
@@ -36,7 +36,7 @@
   [driver dbdef]
   (let [{:keys [database-name], :as dbdef} (tx/get-dataset-definition dbdef)]
     (destroy-test-database-if-created-by-another-instance! database-name)
-    ((get-method data.impl/get-or-create-database! :default) driver dbdef)))
+    ((get-method data.impl/get-or-create-database! :sql-jdbc) driver dbdef)))
 
 (doseq [[base-type database-type] {:type/BigInteger     "BIGINT"
                                    :type/Boolean        "BOOL"

--- a/test/metabase/test/data/impl.clj
+++ b/test/metabase/test/data/impl.clj
@@ -330,11 +330,11 @@
 
 (defn do-with-dataset
   "Impl for [[metabase.test/dataset]] macro."
-  [dataset-definition f]
+  [dataset-definition thunk]
   (let [dbdef             (tx/get-dataset-definition dataset-definition)
         get-db-for-driver (mdb.connection/memoize-for-application-db
                            (fn [driver]
-                            (binding [db/*disable-db-logging* true]
+                             (binding [db/*disable-db-logging* true]
                                (let [db (get-or-create-database! driver dbdef)]
                                  (assert db)
                                  (assert (db/exists? Database :id (u/the-id db)))
@@ -342,4 +342,4 @@
     (binding [*get-db* (fn []
                          (locking do-with-dataset
                            (get-db-for-driver (tx/driver))))]
-      (f))))
+      (thunk))))

--- a/test/metabase/test/redefs.clj
+++ b/test/metabase/test/redefs.clj
@@ -14,11 +14,6 @@
   ((resolve 'metabase.test.initialize/initialize-if-needed!) :db)
   ;; so with-temp-defaults are loaded
   (classloader/require 'metabase.test.util)
-  ;; disallow with-temp inside parallel tests.
-  ;;
-  ;; TODO -- there's not really a reason that we can't use with-temp in parallel tests -- it depends on the test -- so
-  ;; once we're a little more comfortable with the current parallel stuff we should remove this restriction.
-  (test-runner.parallel/assert-test-is-not-parallel "with-temp")
   ;; catch any Exceptions thrown when creating the object and rethrow them with some extra context to make them a
   ;; little easier to debug.
   (let [attributes-with-defaults (merge (tt/with-temp-defaults model)

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -399,8 +399,10 @@
   If `raw-setting?` is `true`, this works like [[with-temp*]] against the `Setting` table, but it ensures no exception
   is thrown if the `setting-k` already exists.
 
-  Prefer the macro [[with-temporary-setting-values]] or [[with-temporary-raw-setting-values]] over using this function directly."
+  Prefer the macro [[with-temporary-setting-values]] or [[with-temporary-raw-setting-values]] over using this function
+  directly."
   [setting-k value thunk & {:keys [raw-setting?]}]
+  (test-runner.parallel/assert-test-is-not-parallel "with-temporary-setting-values")
   ;; plugins have to be initialized because changing `report-timezone` will call driver methods
   (initialize/initialize-if-needed! :db :plugins)
   (let [setting-k     (name setting-k)
@@ -449,7 +451,6 @@
   To temporarily override the value of *read-only* env vars, use [[with-temp-env-var-value]]."
   [[setting-k value & more :as bindings] & body]
   (assert (even? (count bindings)) "mismatched setting/value pairs: is each setting name followed by a value?")
-  (test-runner.parallel/assert-test-is-not-parallel "with-temporary-setting-vales")
   (if (empty? bindings)
     `(do ~@body)
     `(do-with-temporary-setting-value ~(keyword setting-k) ~value
@@ -916,6 +917,7 @@
   `(call-with-locale ~locale-tag (fn [] ~@body)))
 
 (defn do-with-column-remappings [orig->remapped thunk]
+  (test-runner.parallel/assert-test-is-not-parallel "with-column-remappings")
   (transduce
    identity
    (fn

--- a/test/metabase/test/util/timezone.clj
+++ b/test/metabase/test/util/timezone.clj
@@ -18,8 +18,7 @@
         ;; only if the app DB is already set up, we need to make sure plugins are loaded and kill any connection pools that
         ;; might exist
         (when (initialize/initialized? :db)
-          (initialize/initialize-if-needed! :plugins)
-          (#'driver/notify-all-databases-updated))
+          (initialize/initialize-if-needed! :plugins))
         (try
           (TimeZone/setDefault new-timezone)
           (System/setProperty "user.timezone" timezone-id)


### PR DESCRIPTION
Work in progress. I'm playing around with making QP tests parallel. If this works out we can move forward and parallelize a huge chunk of our tests which will make running the test suite locally much nicer. 

Changes:

* Remove restriction that `mt/with-temp` is not allowed inside parallel tests -- this was never really needed, only in some cases like adding `Dimension` rows could it possibly affect other stuff
* Add custom Kondo linter for `clojure.test/deftest` to check for things like `with-redefs` that we do not allow in parallel tests -- although this is not strictly necessary since we have `metabase.test-runner.parallel/assert-test-is-not-parallel` it makes for a much faster feedback loop
* Add extra locking where needed around creating the datasets in `date-bucketing-test` so they play nicely when ran in parallel
* Remove `metabase.driver/notify-all-databases-updated` and remove call to `notify-database-updated` when changing the report timezone -- this logic is mostly historical and in practice it should not be necessary to wipe connection pools when report timezone changes anymore since we now have the `jdbc-spec-hash` logic to recreate them if the session timezone is an actual connection property 
* Remove the fancy Honey SQL formatting overrides in `with-native-query-context`: while it's nice to format the SQL in a pretty way in test errors, it runs afoul of our don't-use-`with-redefs`-in-parallel tests and it seems silly to make tests not-parallel simply because they include extra context on test failure. I'm not super duper happy about this change, but it's not compatible with Honey SQL 2 anyway, and since I hope to migrate us to Honey SQL 2 at some point in the future this will make that slightly easier

There are about 870 assertions in the `test/query_processor_test` namespace; currently 1 is failing (I'm still working out why) but once it's fixed this PR should be ready for review

I succeeded in getting the 270 of the 313 tests in the query-processor-test suite parallelized which shaves a massive TEN SECONDS off of our test suite run time (~40 seconds instead of ~50 seconds to run the QP test suite). Not that mind blowing but I was pretty conservative in putting global locks around the code that is responsible for loading test data; this can certainly be optimized a lot (e.g. there's no reason we can't create test-data and sample-dataset in parallel). Mostly all working but I'm still working out a few kinks. When I get some more free time I'll get it over the line... once this is in we can probably move forward and parallelize huge chunks of the backend test suite. 

Assuming we fix the recent regressions in test suite run times I think with a little bit of effort we could get the all-backend test suite run down to 2-3 minutes total. I think there are other tricks we can pull too, like loading namespaces in topological order and running tests immediately as we're loading namespaces, rather than loading up a couple thousand namespaces before running a single test. But that's a story for another day.