### PR TITLE
Adding columnHasSettings function to ChartSettingFieldPicker

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChartSettings.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings.jsx
@@ -19,7 +19,11 @@ import {
 import {
   updateSettings,
   getClickBehaviorSettings,
+  getComputedSettings,
+  getSettingsWidgets,
 } from "metabase/visualizations/lib/settings";
+
+import { getSettingDefintionsForColumn } from "metabase/visualizations/lib/settings/column";
 import ChartSettingsWidget from "./ChartSettingsWidget";
 import ChartSettingsWidgetPopover from "./ChartSettingsWidgetPopover";
 import { SectionContainer, SectionWarnings } from "./ChartSettings.styled";
@@ -176,6 +180,20 @@ class ChartSettings extends Component {
     return transformedSeries;
   }
 
+  columnHasSettings(col) {
+    const { series } = this.props;
+    const settings = this._getSettings();
+    const settingsDefs = getSettingDefintionsForColumn(series, col);
+    const computedSettings = getComputedSettings(settingsDefs, col, settings);
+
+    return getSettingsWidgets(
+      settingsDefs,
+      settings,
+      computedSettings,
+      col,
+    ).some(w => !w.hidden);
+  }
+
   render() {
     const {
       className,
@@ -251,6 +269,7 @@ class ChartSettings extends Component {
       onShowWidget: this.handleShowWidget,
       onEndShowWidget: this.handleEndShowWidget,
       currentSectionHasColumnSettings,
+      columnHasSettings: col => this.columnHasSettings(col),
     };
 
     const sectionPicker = (

--- a/frontend/src/metabase/visualizations/components/ChartSettings.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings.jsx
@@ -191,7 +191,7 @@ class ChartSettings extends Component {
       settings,
       computedSettings,
       col,
-    ).some(w => !w.hidden);
+    ).some(widget => !widget.hidden);
   }
 
   render() {

--- a/frontend/src/metabase/visualizations/components/ChartSettings.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings.jsx
@@ -182,7 +182,7 @@ class ChartSettings extends Component {
 
   columnHasSettings(col) {
     const { series } = this.props;
-    const settings = this._getSettings();
+    const settings = this._getSettings() || {};
     const settingsDefs = getSettingDefintionsForColumn(series, col);
     const computedSettings = getComputedSettings(settingsDefs, col, settings);
 

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx
@@ -19,11 +19,12 @@ const ChartSettingFieldPicker = ({
   columns,
   showColumnSetting,
   showDragHandle,
+  columnHasSettings,
 }) => {
   let columnKey;
   if (value && showColumnSetting && columns) {
     const column = _.findWhere(columns, { name: value });
-    if (column) {
+    if (column && columnHasSettings(column)) {
       columnKey = keyForColumn(column);
     }
   }


### PR DESCRIPTION
EPIC #25453 (maybe? haha)

Adding a prop for `<ChartSettingFieldPicker />` to be able to check if a column has formatting options. This is passed in from `<ChartSettings />` because most of information needed to calculate the visible widgets is already there (mainly series and settings). We are also ignoring any global settings, it's possible we may need to include those.

Before:
![image](https://user-images.githubusercontent.com/1328979/193194414-09953b55-2526-4d4f-9523-51e6143bdeb2.png)

After:
![image](https://user-images.githubusercontent.com/1328979/193194370-919600ca-6c41-42d3-8656-24edefcccd10.png)


