### PR TITLE
Use standalone docs pages for concat and substring mbql functions

### DIFF
--- a/frontend/src/metabase/lib/expressions/helper-text-strings.ts
+++ b/frontend/src/metabase/lib/expressions/helper-text-strings.ts
@@ -217,6 +217,7 @@ const helperTextStrings: HelpText[] = [
       },
       { name: t`length`, description: t`The number of characters to return.` },
     ],
+    hasDocsPage: true,
   },
   {
     name: "regex-match-first",
@@ -243,6 +244,7 @@ const helperTextStrings: HelpText[] = [
         description: t`This will be added to the end of value1, and so on.`,
       },
     ],
+    hasDocsPage: true,
   },
   {
     name: "replace",


### PR DESCRIPTION
Product doc https://www.notion.so/metabase/Link-to-targeted-custom-expression-docs-when-available-c16afcfa28134e7f83a4078bcd2c1689

How to test:
- New -> Question -> Add custom column
- Type `concat` or `substring` and a popover with docs should appear
- Click on `Learn more` - it should go to standalone doc pages for these expressions

<img width="588" alt="Screenshot 2022-09-30 at 19 12 58" src="https://user-images.githubusercontent.com/8542534/193313229-a7741cdf-fa5b-458c-9a81-5a21255e8174.png">
