### PR TITLE
start using the data app when clicking on an app in the nav

### DIFF
--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarDataAppLink.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarDataAppLink.tsx
@@ -25,7 +25,7 @@ function SidebarDataAppLink({
   hovered: isHovered,
   isSelected,
 }: Props & DroppableProps) {
-  const url = Urls.dataApp(dataApp, { mode: "preview" });
+  const url = Urls.dataApp(dataApp, { mode: "app-url" });
   return (
     <DataAppLink
       url={url}


### PR DESCRIPTION
Takes users to the app itself instead of the "collection view" and then having to click "launch app."


### Tests
- [x] Run the frontend and Cypress end-to-end tests with `yarn lint && yarn test`)
