### PR TITLE
Fix flakiness of "autocomplete should work for referencing saved questions" test

### DIFF
--- a/frontend/test/metabase/scenarios/native/native_subquery.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/native_subquery.cy.spec.js
@@ -109,16 +109,7 @@ describe("scenarios > question > native subquery", () => {
 
           cy.findByText("Open Editor").click();
 
-          cy.get(".ace_editor").should("be.visible").type(" a");
-
-          // Can't use cy.type here as it doesn't consistently keep the autocomplete open
-          cy.realPress("_");
-          cy.realPress("u");
-          cy.realPress("n");
-          cy.realPress("i");
-          cy.realPress("q");
-          cy.realPress("u");
-          cy.realPress("e");
+          cy.get(".ace_editor").should("be.visible").type(" ").type("a_unique");
 
           // Wait until another explicit autocomplete is triggered
           // (slightly longer than AUTOCOMPLETE_DEBOUNCE_DURATION)
@@ -140,14 +131,11 @@ describe("scenarios > question > native subquery", () => {
           // Wait until another explicit autocomplete is triggered
           cy.wait(1000);
 
-          cy.get(".ace_editor:not(.ace_autocomplete)").type(" a");
-
-          cy.realPress("n");
-          cy.realPress("o");
-          cy.realPress("t");
-          cy.realPress("h");
-          cy.realPress("e");
-          cy.realPress("r");
+          // Again, typing in in one go doesn't always work
+          // so type it in two parts
+          cy.get(".ace_editor:not(.ace_autocomplete)")
+            .type(" ")
+            .type("another");
 
           cy.get(".ace_autocomplete")
             .should("be.visible")


### PR DESCRIPTION
This test was flaking, so I fixed it. 

The ace editor autocomplete popup sometimes doesn't trigger unless we call `type` twice as in `cy.get(....).type(...).type(...)`. This test was working before, so it seems this is nondeterministic.

Unfortunately I don't understand why we need to do this with cypress, because I can't reproduce locally.