### PR TITLE
[E2E] Fix the flake in nested questions test

### DIFF
--- a/frontend/test/metabase/scenarios/question/nested.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nested.cy.spec.js
@@ -61,7 +61,7 @@ describe("scenarios > question > nested", () => {
       { loadBaseQuestionMetadata: true },
     );
 
-    cy.contains("Count").click();
+    openHeaderCellContextMenu("Count");
     cy.contains("Distribution").click();
     cy.wait("@dataset");
     cy.contains("Count by Count: Auto binned");
@@ -70,7 +70,7 @@ describe("scenarios > question > nested", () => {
     // Go back to the nested question and make sure Sum over time works
     cy.findByText("Nested GUI").click();
 
-    cy.contains("Count").click();
+    openHeaderCellContextMenu("Count");
     cy.contains("Sum over time").click();
     cy.contains("Sum of Count");
     cy.findByText("137");
@@ -93,7 +93,7 @@ describe("scenarios > question > nested", () => {
       { loadBaseQuestionMetadata: true },
     );
 
-    cy.contains("COUNT").click();
+    openHeaderCellContextMenu("COUNT");
     cy.contains("Distribution").click();
     cy.wait("@dataset");
     cy.contains("Count by COUNT: Auto binned");
@@ -101,7 +101,7 @@ describe("scenarios > question > nested", () => {
 
     cy.findByText("Nested SQL").click();
 
-    cy.contains("COUNT").click();
+    openHeaderCellContextMenu("COUNT");
     cy.contains("Sum over time").click();
     cy.wait("@dataset");
     cy.contains("Sum of COUNT");
@@ -598,4 +598,8 @@ function visitNestedQueryAdHoc(id) {
       query: { "source-table": `card__${id}` },
     },
   });
+}
+
+function openHeaderCellContextMenu(cell) {
+  cy.findAllByTestId("header-cell").should("be.visible").contains(cell).click();
 }


### PR DESCRIPTION
Cypress keeps failing this test because the header cell is detached from the DOM when it tries to click on it.
This solution should make things better.
![image](https://user-images.githubusercontent.com/31325167/193335891-637a16cd-7eb8-423e-a59d-d9c3ebb90002.png)

What worries me is that this started happening all of a sudden a few weeks ago.
Not sure if FE changed the way it renders header cells?