### PR TITLE
Fix airports test data for bigquery

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/test/data/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/test/data/bigquery_cloud_sdk.clj
@@ -116,7 +116,7 @@
 
 ;; Fields must contain only letters, numbers, and underscores, start with a letter or underscore, and be at most 128
 ;; characters long.
-(def ^:private ValidFieldName #"^[A-Za-z_]\w{0,127}$")
+(def ^:private ValidFieldName #"^[A-Za-z_][\w-]{0,127}$")
 
 (s/defn ^:private delete-table!
   [dataset-id :- su/NonBlankString, table-id :- su/NonBlankString]
@@ -128,15 +128,15 @@
    table-id           :- su/NonBlankString
    field-name->type   :- {ValidFieldName (apply s/enum valid-field-types)}]
   (u/ignore-exceptions
-   (delete-table! dataset-id table-id)
-   (let [tbl-id (TableId/of dataset-id table-id)
-         schema (Schema/of (u/varargs Field (for [[^String field-name field-type] field-name->type]
-                                              (Field/of
-                                                field-name
-                                                (LegacySQLTypeName/valueOf (name field-type))
-                                                (u/varargs Field [])))))
-         tbl    (TableInfo/of tbl-id (StandardTableDefinition/of schema))]
-     (.create (bigquery) tbl (u/varargs BigQuery$TableOption))))
+   (delete-table! dataset-id table-id))
+  (let [tbl-id (TableId/of dataset-id table-id)
+        schema (Schema/of (u/varargs Field (for [[^String field-name field-type] field-name->type]
+                                             (Field/of
+                                               field-name
+                                               (LegacySQLTypeName/valueOf (name field-type))
+                                               (u/varargs Field [])))))
+        tbl    (TableInfo/of tbl-id (StandardTableDefinition/of schema))]
+    (.create (bigquery) tbl (u/varargs BigQuery$TableOption)))
   ;; now verify that the Table was created
   (.listTables (bigquery) dataset-id (u/varargs BigQuery$TableListOption))
   (println (u/format-color 'blue "Created BigQuery table `%s.%s.%s`." (project-id) dataset-id table-id)))

--- a/src/metabase/models/params/chain_filter.clj
+++ b/src/metabase/models/params/chain_filter.clj
@@ -274,7 +274,7 @@
     (find-joins my-database-id <airport> <country>)
     ;; ->
     ;; 3 joins needed: airport -> municipality; municipality -> region; region -> country
-    [{:lhs {:table <airport>, :field <airport.municipality-id>}
+    [{:lhs {:table <airport>, :field <airport.municipality_id>}
       :rhs {:table <municipality>, :field <municipality.id>}}
      {:lhs {:table <municipality>, :field <region.id>}
       :rhs {:table <region>, :field <country.id>}}

--- a/test/metabase/models/params/chain_filter_test.clj
+++ b/test/metabase/models/params/chain_filter_test.clj
@@ -192,29 +192,29 @@
   (mt/dataset airports
     (mt/$ids nil
       (testing "airport -> municipality"
-        (is (= [{:lhs {:table $$airport, :field %airport.municipality-id}
+        (is (= [{:lhs {:table $$airport, :field %airport.municipality_id}
                  :rhs {:table $$municipality, :field %municipality.id}}]
                (#'chain-filter/find-joins (mt/id) $$airport $$municipality))))
       (testing "airport [-> municipality -> region] -> country"
-        (is (= [{:lhs {:table $$airport, :field %airport.municipality-id}
+        (is (= [{:lhs {:table $$airport, :field %airport.municipality_id}
                  :rhs {:table $$municipality, :field %municipality.id}}
-                {:lhs {:table $$municipality, :field %municipality.region-id}
+                {:lhs {:table $$municipality, :field %municipality.region_id}
                  :rhs {:table $$region, :field %region.id}}
-                {:lhs {:table $$region, :field %region.country-id}
+                {:lhs {:table $$region, :field %region.country_id}
                  :rhs {:table $$country, :field %country.id}}]
                (#'chain-filter/find-joins (mt/id) $$airport $$country))))
       (testing "[backwards]"
         (testing "municipality -> airport"
           (is (= [{:lhs {:table $$municipality, :field %municipality.id}
-                   :rhs {:table $$airport, :field %airport.municipality-id}}]
+                   :rhs {:table $$airport, :field %airport.municipality_id}}]
                  (#'chain-filter/find-joins (mt/id) $$municipality $$airport))))
         (testing "country [-> region -> municipality] -> airport"
           (is (= [{:lhs {:table $$country, :field %country.id}
-                   :rhs {:table $$region, :field %region.country-id}}
+                   :rhs {:table $$region, :field %region.country_id}}
                   {:lhs {:table $$region, :field %region.id}
-                   :rhs {:table $$municipality, :field %municipality.region-id}}
+                   :rhs {:table $$municipality, :field %municipality.region_id}}
                   {:lhs {:table $$municipality, :field %municipality.id}
-                   :rhs {:table $$airport, :field %airport.municipality-id}}]
+                   :rhs {:table $$airport, :field %airport.municipality_id}}]
                  (#'chain-filter/find-joins (mt/id) $$country $$airport))))))))
 
 (deftest find-all-joins-test
@@ -227,9 +227,9 @@
     (mt/$ids nil
       (testing "airport [-> municipality] -> region"
         (testing "even though we're joining against the same Table multiple times, duplicate joins should be removed"
-          (is (= [{:lhs {:table $$airport, :field %airport.municipality-id}
+          (is (= [{:lhs {:table $$airport, :field %airport.municipality_id}
                    :rhs {:table $$municipality, :field %municipality.id}}
-                  {:lhs {:table $$municipality, :field %municipality.region-id}
+                  {:lhs {:table $$municipality, :field %municipality.region_id}
                    :rhs {:table $$region, :field %region.id}}]
                  (#'chain-filter/find-all-joins $$airport #{%region.name %municipality.name %region.id}))))))))
 

--- a/test/metabase/test/data/dataset_definitions/airports.edn
+++ b/test/metabase/test/data/dataset_definitions/airports.edn
@@ -3,25 +3,25 @@
 ;; Adapted from https://raw.githubusercontent.com/datasets/airport-codes/master/data/airport-codes.csv and
 ;; https://ourairports.com/help/data-dictionary.html
 ;;
-;; continent (INTEGER id, TEXT name, TEXT iso-code)
+;; continent (INTEGER id, TEXT name, TEXT iso_code)
 ;; 6 rows
 ;;
-;; country (INTEGER id, TEXT name, TEXT iso-code, INTEGER continent-id)
+;; country (INTEGER id, TEXT name, TEXT iso_code, INTEGER continent_id)
 ;; 147 rows
 ;;
-;; region (INTEGER id, TEXT name, TEXT iso-code, INTEGER country-id)
+;; region (INTEGER id, TEXT name, TEXT iso_code, INTEGER country_id)
 ;; This is a subdivision of the country such as state.
 ;; 415 rows
 ;;
-;; municipality (INTEGER id, TEXT name, INTEGER region-id)
+;; municipality (INTEGER id, TEXT name, INTEGER region_id)
 ;; This is the municipality the airport serves -- usually, but not always, a city
 ;; 577 rows
 ;;
-;; airport (INTEGER id, TEXT name, TEXT code, DOUBLE latitude, DOUBLE longitude, INTEGER elevation-ft, INTEGER municipality-id)
+;; airport (INTEGER id, TEXT name, TEXT code, DOUBLE latitude, DOUBLE longitude, INTEGER elevation_ft, INTEGER municipality_id)
 ;; 601 rows
 [["continent"
   [{:field-name "name", :base-type :type/Text}
-   {:field-name "iso-code", :base-type :type/Text}]
+   {:field-name "iso_code", :base-type :type/Text}]
   [[       "Africa" "AF"]               ;   1
    [         "Asia" "AS"]               ;   2
    [       "Europe" "EU"]               ;   3
@@ -32,8 +32,8 @@
 
  ["country"
   [{:field-name "name", :base-type :type/Text}
-   {:field-name "iso-code", :base-type :type/Text}
-   {:field-name "continent-id", :base-type :type/Integer, :fk "continent"}]
+   {:field-name "iso_code", :base-type :type/Text}
+   {:field-name "continent_id", :base-type :type/Integer, :fk "continent"}]
   [[               "Albania" "AL" 3]    ;   1
    [               "Algeria" "DZ" 1]    ;   2
    [                "Angola" "AO" 1]    ;   3
@@ -185,8 +185,8 @@
 
  ["region"
   [{:field-name "name", :base-type :type/Text}
-   {:field-name "iso-code", :base-type :type/Text}
-   {:field-name "country-id", :base-type :type/Integer, :fk "country"}]
+   {:field-name "iso_code", :base-type :type/Text}
+   {:field-name "country_id", :base-type :type/Integer, :fk "country"}]
   [[                                       nil  "UG-102" 137] ;   1
    [                                       nil    "FR-B"  46] ;   2
    [                                       nil    "FR-N"  46] ;   3
@@ -606,7 +606,7 @@
 
  ["municipality"
   [{:field-name "name", :base-type :type/Text}
-   {:field-name "region-id", :base-type :type/Integer, :fk "region"}]
+   {:field-name "region_id", :base-type :type/Integer, :fk "region"}]
   [[                                    nil   9] ;   1
    [                                    nil  10] ;   2
    [                                    nil  21] ;   3
@@ -1191,7 +1191,7 @@
    {:field-name "code", :base-type :type/Text}
    {:field-name "latitude", :base-type :type/Float}
    {:field-name "longitude", :base-type :type/Float}
-   {:field-name "municipality-id", :base-type :type/Integer, :fk "municipality"}]
+   {:field-name "municipality_id", :base-type :type/Integer, :fk "municipality"}]
   [[                                                  "Aalborg Airport" "AAL"       57.0927589138        9.84924316406   9] ;   1
    [                         "Abeid Amani Karume International Airport" "ZNZ"            -6.22202            39.224899 573] ;   2
    [                                            "Aberdeen Dyce Airport" "ABZ"  57.201900482177734   -2.197779893875122  10] ;   3


### PR DESCRIPTION
Found in #25451 that the v3_airports dataset creation always fails on BigQuery, as the column names fail regex validation. I assume it's only working on the main CI project because the dataset has already been created previously.

This PR fixes the column names.

### Tests

- [x] Run the frontend and Cypress end-to-end tests with `yarn lint && yarn test`)
- [x] If there are changes to the backend codebase, run the backend tests with `clojure -X:dev:test`
- [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
      (unless it's a tiny documentation change).
