### PR TITLE
Fix unused underscored not caught by ESLint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,7 +5,7 @@
     "no-var": 1,
     "no-unused-vars": [
       1,
-      { "vars": "all", "args": "none", "varsIgnorePattern": "^_" }
+      { "vars": "all", "args": "none", "varsIgnorePattern": "^_.+" }
     ],
     "no-empty": [1, { "allowEmptyCatch": true }],
     "curly": [1, "all"],

--- a/frontend/src/metabase/components/SelectList/BaseSelectListItem.jsx
+++ b/frontend/src/metabase/components/SelectList/BaseSelectListItem.jsx
@@ -1,6 +1,5 @@
 import React from "react";
 import PropTypes from "prop-types";
-import _ from "underscore";
 
 import { useScrollOnMount } from "metabase/hooks/use-scroll-on-mount";
 

--- a/frontend/src/metabase/core/components/AccordionList/AccordionListCell.jsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionListCell.jsx
@@ -3,7 +3,6 @@
 import React from "react";
 
 import cx from "classnames";
-import _ from "underscore";
 import { color } from "metabase/lib/colors";
 
 import Icon from "metabase/components/Icon";

--- a/frontend/src/metabase/query_builder/components/DataSelector/saved-question-picker/utils.js
+++ b/frontend/src/metabase/query_builder/components/DataSelector/saved-question-picker/utils.js
@@ -1,5 +1,3 @@
-import _ from "underscore";
-
 export const findCollectionByName = (collections, name) => {
   if (!collections || collections.length === 0) {
     return null;


### PR DESCRIPTION
Followed up from https://github.com/metabase/metabase/pull/25709

See more info in this [Slack convo](https://metaboat.slack.com/archives/C505ZNNH4/p1664375842564259)

> The current config is `^_` so any name with leading `_` would not be caught by this rule. This is to avoid catching names like (attached screenshot) that are never used when destructuring arrays, but I think it has side effect that it also doesn’t catch underscore `_` which, I assume, is not what we wanted.
> ![image](https://user-images.githubusercontent.com/1937582/193545964-8239c6d3-4b52-475c-8cf2-096d6011a7ec.png)

