### PR TITLE
Fix 'Further reading' section not properly rendered

### DIFF
--- a/docs/people-and-groups/google-and-ldap.md
+++ b/docs/people-and-groups/google-and-ldap.md
@@ -127,10 +127,10 @@ Note that you must have at least one account with email and password login. This
  - [Can't log in](../troubleshooting-guide/cant-log-in.md).
  - [Troubleshooting LDAP](../troubleshooting-guide/ldap.md)
 
- ## Further reading
+## Further reading
 
-- [Using LDAP for authentication and access control](https://www.metabase.com/learn/permissions/ldap-auth-access-control).
-- [Permissions overview](../permissions/start.md).
+ - [Using LDAP for authentication and access control](https://www.metabase.com/learn/permissions/ldap-auth-access-control).
+ - [Permissions overview](../permissions/start.md).
 
 [data-sandboxing-docs]: ../permissions/data-sandboxes.md
 [google-saml-docs]: ./saml-google.md


### PR DESCRIPTION
###### Before submitting the PR, please make sure you do the following

- [x] If you're attempting to fix a translation issue, please submit your changes to our [POEditor project](https://poeditor.com/join/project/ynjQmwSsGh) instead of opening a PR.

### Tests

- [x] Run the frontend and Cypress end-to-end tests with `yarn lint && yarn test`)
- [x] If there are changes to the backend codebase, run the backend tests with `clojure -X:dev:test`
- [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
      (unless it's a tiny documentation change).

### Detail
If you look at the image below (source: https://www.metabase.com/docs/latest/people-and-groups/google-and-ldap), the `Further reading` section is not properly rendered.
It is rendered as `## Further reading` (as is, not as a valid markdown heading).
This PR is intended to fix this problem.
![image](https://user-images.githubusercontent.com/106017277/193572049-2f350311-80f1-469d-9b1f-316c68cc3521.png)
