### PR TITLE
Truncate Slack attachments (namely dashboard filters) that are too long

### DIFF
--- a/test/metabase/dashboard_subscription_test.clj
+++ b/test/metabase/dashboard_subscription_test.clj
@@ -289,70 +289,71 @@
                   (pulse.test-util/thunk->boolean pulse-results)))))}}))
 
 (deftest dashboard-filter-test
-  (tests {:pulse     {:skip_if_empty false}
-          :dashboard pulse.test-util/test-dashboard}
-    "Dashboard subscription that includes a dashboard filters"
-    {:card (pulse.test-util/checkins-query-card {})
+  (with-redefs [metabase.pulse/attachment-text-length-limit 15]
+    (tests {:pulse     {:skip_if_empty false}
+            :dashboard pulse.test-util/test-dashboard}
+      "Dashboard subscription that includes a dashboard filters"
+      {:card (pulse.test-util/checkins-query-card {})
 
-     :fixture
-     (fn [_ thunk]
-       (mt/with-temporary-setting-values [site-name "Metabase Test"]
-          (thunk)))
+       :fixture
+       (fn [_ thunk]
+         (mt/with-temporary-setting-values [site-name "Metabase Test"]
+           (thunk)))
 
-     :assert
-     {:email
-       (fn [_ _]
-         (testing "Markdown cards are included in email subscriptions"
-           (is (= (rasta-pulse-email {:body [{"Aviary KPIs" true
-                                              "<a class=\\\"title\\\" href=\\\"https://metabase.com/testmb/dashboard/\\d+\\?state=CA&amp;state=NY&amp;state=NJ&amp;quarter_and_year=Q1-2021\\\"" true}
-                                             pulse.test-util/png-attachment]})
-                  (mt/summarize-multipart-email #"Aviary KPIs"
-                                                #"<a class=\"title\" href=\"https://metabase.com/testmb/dashboard/\d+\?state=CA&amp;state=NY&amp;state=NJ&amp;quarter_and_year=Q1-2021\"")))))
+       :assert
+       {:email
+        (fn [_ _]
+          (testing "Markdown cards are included in email subscriptions"
+            (is (= (rasta-pulse-email {:body [{"Aviary KPIs" true
+                                               "<a class=\\\"title\\\" href=\\\"https://metabase.com/testmb/dashboard/\\d+\\?state=CA&amp;state=NY&amp;state=NJ&amp;quarter_and_year=Q1-2021\\\"" true}
+                                              pulse.test-util/png-attachment]})
+                   (mt/summarize-multipart-email #"Aviary KPIs"
+                                                 #"<a class=\"title\" href=\"https://metabase.com/testmb/dashboard/\d+\?state=CA&amp;state=NY&amp;state=NJ&amp;quarter_and_year=Q1-2021\"")))))
 
-      :slack
-      (fn [{:keys [card-id dashboard-id]} [pulse-results]]
-        (testing "Markdown cards are included in attachments list as :blocks sublists, and markdown is
-                  converted to mrkdwn (Slack markup language)"
-          (is (= {:channel-id "#general"
-                  :attachments
-                  [{:blocks [{:type "header", :text {:type "plain_text", :text "Aviary KPIs", :emoji true}}
-                             {:type "section",
-                              :fields [{:type "mrkdwn", :text "*State*\nCA, NY and NJ"}
-                                       {:type "mrkdwn", :text "*Quarter and Year*\nQ1, 2021"}]}
-                             {:type "section", :fields [{:type "mrkdwn", :text "Sent by Rasta Toucan"}]}]}
-                   {:title           pulse.test-util/card-name
-                    :rendered-info   {:attachments false, :content true, :render/text true},
-                    :title_link      (str "https://metabase.com/testmb/question/" card-id)
-                    :attachment-name "image.png"
-                    :channel-id      "FOO"
-                    :fallback        pulse.test-util/card-name}
-                   {:blocks [{:type "divider"}
-                             {:type "context"
-                              :elements [{:type "mrkdwn"
-                                          :text (str "<https://metabase.com/testmb/dashboard/"
-                                                     dashboard-id
-                                                     "?state=CA&state=NY&state=NJ&quarter_and_year=Q1-2021|*Sent from Metabase Test*>")}]}]}]}
-                 (pulse.test-util/thunk->boolean pulse-results)))))}}))
+        :slack
+        (fn [{:keys [card-id dashboard-id]} [pulse-results]]
+          (testing "Markdown cards are included in attachments list as :blocks sublists, and markdown is
+                  converted to mrkdwn (Slack markup language) and truncated appropriately"
+            (is (= {:channel-id "#general"
+                    :attachments
+                    [{:blocks [{:type "header", :text {:type "plain_text", :text "Aviary KPIs", :emoji true}}
+                               {:type "section",
+                                :fields [{:type "mrkdwn", :text "*State*\nCA, NY…"}  ;; "*State*\nCA, NY and NJ"
+                                         {:type "mrkdwn", :text "*Quarter and Y…"}]} ;; "*Quarter and Year*\nQ1, 2021"
+                               {:type "section", :fields [{:type "mrkdwn", :text "Sent by Rasta Toucan"}]}]}
+                     {:title           pulse.test-util/card-name
+                      :rendered-info   {:attachments false, :content true, :render/text true},
+                      :title_link      (str "https://metabase.com/testmb/question/" card-id)
+                      :attachment-name "image.png"
+                      :channel-id      "FOO"
+                      :fallback        pulse.test-util/card-name}
+                     {:blocks [{:type "divider"}
+                               {:type "context"
+                                :elements [{:type "mrkdwn"
+                                            :text (str "<https://metabase.com/testmb/dashboard/"
+                                                       dashboard-id
+                                                       "?state=CA&state=NY&state=NJ&quarter_and_year=Q1-2021|*Sent from Metabase Test*>")}]}]}]}
+                   (pulse.test-util/thunk->boolean pulse-results)))))}})))
 
 (deftest mrkdwn-length-limit-test
-  (tests {:pulse {:skip_if_empty false}, :dashcard {:row 0, :col 0}}
-    "Dashboard subscription that includes a Markdown card that exceeds Slack's length limit when converted to mrkdwn"
-    {:card (pulse.test-util/checkins-query-card {})
+  (with-redefs [metabase.pulse/block-text-length-limit 10]
+    (tests {:pulse {:skip_if_empty false}, :dashcard {:row 0, :col 0}}
+           "Dashboard subscription that includes a Markdown card that exceeds Slack's length limit when converted to mrkdwn"
+           {:card (pulse.test-util/checkins-query-card {})
 
-     :fixture
-     (fn [{dashboard-id :dashboard-id} thunk]
-       (mt/with-temp DashboardCard [_ {:dashboard_id dashboard-id
-                                       :row 1
-                                       :col 1
-                                       :visualization_settings {:text "abcdefghijklmnopqrstuvwxyz"}}]
-         (binding [metabase.pulse/*slack-mrkdwn-length-limit* 10]
-           (thunk))))
+            :fixture
+            (fn [{dashboard-id :dashboard-id} thunk]
+              (mt/with-temp DashboardCard [_ {:dashboard_id dashboard-id
+                                              :row 1
+                                              :col 1
+                                              :visualization_settings {:text "abcdefghijklmnopqrstuvwxyz"}}]
+                (thunk)))
 
-     :assert
-     {:slack
-      (fn [_object-ids [pulse-results]]
-        (is (= {:blocks [{:type "section" :text {:type "mrkdwn" :text "abcdefghi…"}}]}
-               (nth (:attachments (pulse.test-util/thunk->boolean pulse-results)) 2))))}}))
+            :assert
+            {:slack
+             (fn [_object-ids [pulse-results]]
+               (is (= {:blocks [{:type "section" :text {:type "mrkdwn" :text "abcdefghi…"}}]}
+                      (nth (:attachments (pulse.test-util/thunk->boolean pulse-results)) 2))))}})))
 
 (deftest archived-dashboard-test
   (tests {:dashboard {:archived true}}


### PR DESCRIPTION
[Fixes #25704]

I have a soft preference for using real constants instead of dynamic vars if the only reason to be dynamic is for testing (as you can see), but if somebody has a good reason to do it the other way I'm happy to be converted.

Tested in #bot-testing 