### PR TITLE
Fix scripting error in model metadata sidebar

### DIFF
--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
@@ -199,7 +199,9 @@ function DatasetEditor(props) {
       return columns;
     }
     return orderedColumns
-      .map(col => columns.find(c => isSameField(c.field_ref, col.fieldRef)))
+      .map(
+        col => columns.find(c => isSameField(c.field_ref, col.fieldRef)) || col,
+      )
       .filter(Boolean);
   }, [orderedColumns, result]);
 

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
@@ -186,6 +186,10 @@ function DatasetEditor(props) {
   );
 
   const fields = useMemo(() => {
+    const virtualCardTable = dataset.table();
+    const virtualCardColumns = (virtualCardTable?.fields ?? []).map(field =>
+      field.column(),
+    );
     // Columns in results_metadata contain all the necessary metadata
     // orderedColumns contain properly sorted columns, but they only contain field names and refs.
     // Normally, columns in results_metadata are ordered too,
@@ -200,10 +204,12 @@ function DatasetEditor(props) {
     }
     return orderedColumns
       .map(
-        col => columns.find(c => isSameField(c.field_ref, col.fieldRef)) || col,
+        col =>
+          columns.find(c => isSameField(c.field_ref, col.fieldRef)) ||
+          virtualCardColumns.find(c => isSameField(c.field_ref, col.fieldRef)),
       )
       .filter(Boolean);
-  }, [orderedColumns, result]);
+  }, [dataset, orderedColumns, result?.data?.results_metadata?.columns]);
 
   const isEditingQuery = datasetEditorTab === "query";
   const isEditingMetadata = datasetEditorTab === "metadata";

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataSidebar.jsx
@@ -153,7 +153,9 @@ function DatasetFieldMetadataSidebar({
       setShouldAnimateFieldChange(true);
       // setTimeout is required as form fields are rerendered pretty frequently
       setTimeout(() => {
-        displayNameInputRef.current?.select?.();
+        if (_.isFunction(displayNameInputRef.current?.select)) {
+          displayNameInputRef.current.select();
+        }
       });
     }
   }, [field, previousField]);


### PR DESCRIPTION
This seems to be breaking the model metadata sidebar on stats. See: https://metaboat.slack.com/archives/C03SHMZ266R/p1664815460770359?thread_ts=1663701716.003909&cid=C03SHMZ266R. I'm unable to repro locally for whatever reason.

The columns on a query and the columns on a card can differ slightly, specifically in the case of a column from a joined table. In the above scenario there's a column that lacks a `join-alias` in its `field_ref` when coming from a query, but not when it is coming from a card. Is this the result of relying on a query from `/api/dataset`?

Regardless, we shouldn't be filtering out columns when when we can't find metadata on the query results so that we can at least show data in the sidebar.