### PR TITLE
Replace deprecated `cy.server` with `cy.intercept`

### DIFF
--- a/frontend/test/__support__/e2e/helpers/e2e-assertion-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-assertion-helpers.js
@@ -1,9 +1,0 @@
-export function expectedRouteCalls({ route_alias, calls } = {}) {
-  const requestsCount = alias =>
-    cy.state("requests").filter(req => req.alias === alias);
-  // It is hard and unreliable to assert that something didn't happen in Cypress
-  // This solution was the only one that worked out of all others proposed in this SO topic: https://stackoverflow.com/a/59302542/8815185
-  cy.get("@" + route_alias).then(() => {
-    expect(requestsCount(route_alias)).to.have.length(calls);
-  });
-}

--- a/frontend/test/__support__/e2e/helpers/index.js
+++ b/frontend/test/__support__/e2e/helpers/index.js
@@ -7,7 +7,6 @@ export * from "./e2e-ad-hoc-question-helpers";
 export * from "./e2e-enterprise-helpers";
 export * from "./e2e-mock-app-settings-helpers";
 export * from "./e2e-notebook-helpers";
-export * from "./e2e-assertion-helpers";
 export * from "./e2e-cloud-helpers";
 export * from "./e2e-collection-helpers";
 export * from "./e2e-data-model-helpers";

--- a/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
@@ -26,15 +26,11 @@ describe("scenarios > admin > databases > add", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
-    cy.server();
   });
 
   it("should add a database and redirect to listing", () => {
-    cy.route({
-      method: "POST",
-      url: "/api/database",
-      response: { id: 42 },
-      delay: 1000,
+    cy.intercept("POST", "/api/database", req => {
+      req.reply({ body: { id: 42 }, delay: 1000 });
     }).as("createDatabase");
 
     cy.visit("/admin/databases/create");
@@ -63,8 +59,10 @@ describe("scenarios > admin > databases > add", () => {
     cy.findByText("Explore sample data");
   });
 
-  it("should trim fields needed to connect to the database", () => {
-    cy.route("POST", "/api/database", { id: 42 }).as("createDatabase");
+  it("should trim fields needed to connect to the database (metabase#12972)", () => {
+    cy.intercept("POST", "/api/database", req => {
+      req.reply({ body: { id: 42 } });
+    }).as("createDatabase");
 
     cy.visit("/admin/databases/create");
 
@@ -100,8 +98,12 @@ describe("scenarios > admin > databases > add", () => {
   });
 
   it("should show scheduling settings if you enable the toggle", () => {
-    cy.route("POST", "/api/database", { id: 42 }).as("createDatabase");
-    cy.route("POST", "/api/database/validate", { valid: true });
+    cy.intercept("POST", "/api/database", req => {
+      req.reply({ body: { id: 42 } });
+    }).as("createDatabase");
+    cy.intercept("POST", "/api/database/validate", req => {
+      req.reply({ body: { valid: true } });
+    });
 
     cy.visit("/admin/databases/create");
 
@@ -126,12 +128,12 @@ describe("scenarios > admin > databases > add", () => {
   });
 
   it("should show error correctly on server error", () => {
-    cy.route({
-      method: "POST",
-      url: "/api/database",
-      response: "DATABASE CONNECTION ERROR",
-      status: 400,
-      delay: 1000,
+    cy.intercept("POST", "/api/database", req => {
+      req.reply({
+        statusCode: 400,
+        body: "DATABASE CONNECTION ERROR",
+        delay: 1000,
+      });
     }).as("createDatabase");
 
     cy.visit("/admin/databases/create");
@@ -225,12 +227,12 @@ describe("scenarios > admin > databases > add", () => {
         .trigger("change", { force: true })
         .trigger("blur", { force: true });
 
-      cy.route({
-        method: "POST",
-        url: "/api/database",
-        response: { id: 123 },
-        status: 200,
-        delay: 100,
+      cy.intercept("POST", "/api/database", req => {
+        req.reply({
+          statusCode: 200,
+          body: { id: 123 },
+          delay: 100,
+        });
       }).as("createDatabase");
 
       // submit form and check that the file's body is included
@@ -243,23 +245,23 @@ describe("scenarios > admin > databases > add", () => {
     });
 
     it("should show the old BigQuery form for previously connected databases", () => {
-      cy.route({
-        method: "GET",
-        url: "/api/database/123",
-        response: {
-          id: 123,
-          engine: "bigquery",
-          details: {
-            "auth-code": "auth-code",
-            "client-id": "client-id",
-            "client-secret": "client-secret",
-            "dataset-id": "dataset-id",
-            "project-id": "project",
-            "use-jvm-timezone": false,
+      cy.intercept("GET", "/api/database/123", req => {
+        req.reply({
+          statusCode: 200,
+          body: {
+            id: 123,
+            engine: "bigquery",
+            details: {
+              "auth-code": "auth-code",
+              "client-id": "client-id",
+              "client-secret": "client-secret",
+              "dataset-id": "dataset-id",
+              "project-id": "project",
+              "use-jvm-timezone": false,
+            },
           },
-        },
-        status: 200,
-        delay: 100,
+          delay: 100,
+        });
       });
       cy.visit("/admin/databases/123");
 
@@ -304,12 +306,8 @@ describe("scenarios > admin > databases > add", () => {
         .trigger("change", { force: true })
         .trigger("blur", { force: true });
 
-      cy.route({
-        method: "POST",
-        url: "/api/database",
-        response: { id: 123 },
-        status: 200,
-        delay: 100,
+      cy.intercept("POST", "/api/database", req => {
+        req.reply({ statusCode: 200, body: { id: 123 }, delay: 100 });
       }).as("createDatabase");
 
       // submit form and check that the file's body is included

--- a/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
@@ -83,7 +83,7 @@ describe("scenarios > admin > databases > add", () => {
   });
 
   it("should show validation error if you enable scheduling toggle and enter invalid db connection info", () => {
-    cy.route("POST", "/api/database").as("createDatabase");
+    cy.intercept("POST", "/api/database").as("createDatabase");
     cy.visit("/admin/databases/create");
 
     chooseDatabase("H2");

--- a/frontend/test/metabase/scenarios/admin/databases/edit.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/edit.cy.spec.js
@@ -12,9 +12,7 @@ describe("scenarios > admin > databases > edit", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
-    cy.server();
-    cy.route("GET", "/api/database/*").as("databaseGet");
-    cy.route("PUT", "/api/database/*").as("databaseUpdate");
+    cy.intercept("PUT", "/api/database/*").as("databaseUpdate");
   });
 
   describe("Database type", () => {
@@ -209,7 +207,7 @@ describe("scenarios > admin > databases > edit", () => {
 
   describe("Actions sidebar", () => {
     it("lets you trigger the manual database schema sync", () => {
-      cy.route("POST", `/api/database/${SAMPLE_DB_ID}/sync_schema`).as(
+      cy.intercept("POST", `/api/database/${SAMPLE_DB_ID}/sync_schema`).as(
         "sync_schema",
       );
 
@@ -220,7 +218,7 @@ describe("scenarios > admin > databases > edit", () => {
     });
 
     it("lets you trigger the manual rescan of field values", () => {
-      cy.route("POST", `/api/database/${SAMPLE_DB_ID}/rescan_values`).as(
+      cy.intercept("POST", `/api/database/${SAMPLE_DB_ID}/rescan_values`).as(
         "rescan_values",
       );
 
@@ -231,7 +229,7 @@ describe("scenarios > admin > databases > edit", () => {
     });
 
     it("lets you discard saved field values", () => {
-      cy.route("POST", `/api/database/${SAMPLE_DB_ID}/discard_values`).as(
+      cy.intercept("POST", `/api/database/${SAMPLE_DB_ID}/discard_values`).as(
         "discard_values",
       );
 
@@ -242,7 +240,7 @@ describe("scenarios > admin > databases > edit", () => {
     });
 
     it("lets you remove the Sample Database", () => {
-      cy.route("DELETE", `/api/database/${SAMPLE_DB_ID}`).as("delete");
+      cy.intercept("DELETE", `/api/database/${SAMPLE_DB_ID}`).as("delete");
 
       cy.visit(`/admin/databases/${SAMPLE_DB_ID}`);
       cy.findByText("Remove this database").click();

--- a/frontend/test/metabase/scenarios/admin/datamodel/editor.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/editor.cy.spec.js
@@ -12,14 +12,13 @@ describe.skip("scenarios > admin > datamodel > editor", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
-    cy.server();
-    cy.route("PUT", "/api/table/*").as("tableUpdate");
-    cy.route("PUT", "/api/field/*").as("fieldUpdate");
+    cy.intercept("PUT", "/api/table/*").as("tableUpdate");
+    cy.intercept("PUT", "/api/field/*").as("fieldUpdate");
     cy.wrap(`${SAMPLE_DB_URL}/table/${ORDERS_ID}`).as(`ORDERS_URL`);
   });
 
   it("should allow editing of the name and description", () => {
-    cy.route(
+    cy.intercept(
       "GET",
       "/api/table/2/query_metadata?include_sensitive_fields=true",
     ).as("tableMetadataFetch");
@@ -141,7 +140,7 @@ describe.skip("scenarios > admin > datamodel > editor", () => {
   });
 
   it("should allow sorting columns", () => {
-    cy.route("PUT", "/api/table/2/fields/order").as("fieldReorder");
+    cy.intercept("PUT", "/api/table/2/fields/order").as("fieldReorder");
 
     visitAlias("@ORDERS_URL");
     cy.icon("sort_arrows").click();

--- a/frontend/test/metabase/scenarios/admin/datamodel/field.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/field.cy.spec.js
@@ -21,10 +21,8 @@ describe.skip("scenarios > admin > datamodel > field", () => {
       ).as(`ORDERS_${name}_URL`);
     });
 
-    cy.server();
-    cy.route("PUT", "/api/field/*").as("fieldUpdate");
-    cy.route("POST", "/api/field/*/dimension").as("fieldDimensionUpdate");
-    cy.route("POST", "/api/field/*/values").as("fieldValuesUpdate");
+    cy.intercept("PUT", "/api/field/*").as("fieldUpdate");
+    cy.intercept("POST", "/api/field/*/dimension").as("fieldDimensionUpdate");
   });
 
   describe("Name and Description", () => {

--- a/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
@@ -35,8 +35,7 @@ describe("scenarios > admin > settings", () => {
     const BASE_URL = Cypress.config().baseUrl;
     const DOMAIN_AND_PORT = BASE_URL.replace("http://", "");
 
-    cy.server();
-    cy.route("PUT", "/api/setting/site-url").as("url");
+    cy.intercept("PUT", "/api/setting/site-url").as("url");
 
     cy.visit("/admin/settings/general");
 
@@ -75,8 +74,7 @@ describe("scenarios > admin > settings", () => {
   });
 
   it("should save a setting", () => {
-    cy.server();
-    cy.route("PUT", "**/admin-email").as("saveSettings");
+    cy.intercept("PUT", "**/admin-email").as("saveSettings");
 
     cy.visit("/admin/settings/general");
 
@@ -108,8 +106,8 @@ describe("scenarios > admin > settings", () => {
 
   it("should check for working https before enabling a redirect", () => {
     cy.visit("/admin/settings/general");
-    cy.server();
-    cy.route("GET", "**/api/health", "ok").as("httpsCheck");
+
+    cy.intercept("GET", "**/api/health", "ok").as("httpsCheck");
 
     // settings have loaded, but there's no redirect setting visible
     cy.contains("Site URL");
@@ -189,8 +187,7 @@ describe("scenarios > admin > settings", () => {
   });
 
   it("should search for and select a new timezone", () => {
-    cy.server();
-    cy.route("PUT", "**/report-timezone").as("reportTimezone");
+    cy.intercept("PUT", "**/report-timezone").as("reportTimezone");
 
     cy.visit("/admin/settings/localization");
     cy.contains("Report Timezone")

--- a/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
@@ -45,12 +45,12 @@ describe("scenarios > admin > settings", () => {
       .type("foo", { delay: 100 })
       .blur();
 
-    cy.wait("@url").should(xhr => {
-      expect(xhr.status).to.eq(500);
+    cy.wait("@url").should(({ response }) => {
+      expect(response.statusCode).to.eq(500);
       // Switching to regex match for assertions - the test was flaky because of the "typing" issue
       // i.e. it sometimes doesn't type the whole string "foo", but only "oo".
       // We only care that the `cause` is starting with "Invalid site URL"
-      expect(xhr.response.body.cause).to.match(/^Invalid site URL/);
+      expect(response.body.cause).to.match(/^Invalid site URL/);
     });
 
     // NOTE: This test is not concerned with HOW we style the error message - only that there is one.

--- a/frontend/test/metabase/scenarios/admin/troubleshooting/tasks.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/troubleshooting/tasks.cy.spec.js
@@ -14,8 +14,7 @@ describe("scenarios > admin > troubleshooting > tasks", () => {
     for (let i = 0; i < 13; i++) {
       cy.request("POST", `/api/database/${SAMPLE_DB_ID}/sync_schema`);
     }
-    cy.server();
-    cy.route("GET", "/api/task?limit=50&offset=0").as("tasks");
+    cy.intercept("GET", "/api/task?limit=50&offset=0").as("tasks");
 
     cy.visit("/admin/troubleshooting/tasks");
 

--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -21,7 +21,6 @@ const PERMISSIONS = {
 describe("collection permissions", () => {
   beforeEach(() => {
     restore();
-    cy.server();
   });
 
   describe("item management", () => {

--- a/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
@@ -472,8 +472,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
         },
       ],
     });
-    cy.server();
-    cy.route("POST", "/api/dataset").as("dataset");
+    cy.intercept("POST", "/api/dataset").as("dataset");
 
     visitDashboard(1);
     // Product ID in the first row (query fails for User ID as well)

--- a/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
@@ -2,7 +2,6 @@ import {
   popover,
   restore,
   selectDashboardFilter,
-  expectedRouteCalls,
   editDashboard,
   showDashboardCardActions,
   filterWidget,
@@ -400,12 +399,15 @@ describe("scenarios > dashboard", () => {
       ],
     });
 
-    cy.server();
-    cy.route(`/api/dashboard/1/params/${FILTER_ID}/values`).as(
-      "fetchDashboardParams",
+    cy.intercept(
+      `/api/dashboard/1/params/${FILTER_ID}/values`,
+      cy.spy().as("fetchDashboardParams"),
     );
-    cy.route(`/api/field/${PRODUCTS.CATEGORY}`).as("fetchField");
-    cy.route(`/api/field/${PRODUCTS.CATEGORY}/values`).as("fetchFieldValues");
+    cy.intercept(`/api/field/${PRODUCTS.CATEGORY}`, cy.spy().as("fetchField"));
+    cy.intercept(
+      `/api/field/${PRODUCTS.CATEGORY}/values`,
+      cy.spy().as("fetchFieldValues"),
+    );
 
     visitDashboard(1);
 
@@ -415,9 +417,9 @@ describe("scenarios > dashboard", () => {
       cy.findByText(category);
     });
 
-    expectedRouteCalls({ route_alias: "fetchDashboardParams", calls: 1 });
-    expectedRouteCalls({ route_alias: "fetchField", calls: 0 });
-    expectedRouteCalls({ route_alias: "fetchFieldValues", calls: 0 });
+    cy.get("@fetchDashboardParams").should("have.been.calledOnce");
+    cy.get("@fetchField").should("not.have.been.called");
+    cy.get("@fetchFieldValues").should("not.have.been.called");
   });
 
   it("should be possible to visit a dashboard with click-behavior linked to the dashboard without permissions (metabase#15368)", () => {

--- a/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
@@ -457,8 +457,7 @@ describe("scenarios > dashboard", () => {
             ],
           });
 
-          cy.server();
-          cy.route("GET", `/api/dashboard/${NEW_DASHBOARD_ID}`).as(
+          cy.intercept("GET", `/api/dashboard/${NEW_DASHBOARD_ID}`).as(
             "loadDashboard",
           );
         });

--- a/frontend/test/metabase/scenarios/dashboard/dashboard_data_permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard_data_permissions.cy.spec.js
@@ -52,8 +52,7 @@ describe("support > permissions (metabase#8472)", () => {
   });
 
   it("should allow a nodata user to select the filter", () => {
-    cy.server();
-    cy.route("GET", "/api/dashboard/1/params/*/search/100 Main Street").as(
+    cy.intercept("GET", "/api/dashboard/1/params/*/search/100 Main Street").as(
       "search",
     );
 

--- a/frontend/test/metabase/scenarios/dashboard/dashboard_data_permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard_data_permissions.cy.spec.js
@@ -8,15 +8,18 @@ import {
 function filterDashboard(suggests = true) {
   visitDashboard(1);
   cy.contains("Orders");
+  cy.contains("Text").click();
 
   // We should get a suggested response and be able to click it if we're an admin
   if (suggests) {
-    cy.contains("Text").type("Main Street");
+    cy.findByPlaceholderText("Search by Address").type("Main Street");
     cy.contains("100 Main Street").click();
   } else {
-    cy.contains("Text").type("100 Main Street");
-    cy.wait("@search").should(xhr => {
-      expect(xhr.status).to.equal(403);
+    cy.findByPlaceholderText("Search by Address")
+      .type("100 Main Street")
+      .blur();
+    cy.wait("@search").should(({ response }) => {
+      expect(response.statusCode).to.equal(403);
     });
   }
   cy.contains("Add filter").click({ force: true });
@@ -26,6 +29,8 @@ function filterDashboard(suggests = true) {
 
 describe("support > permissions (metabase#8472)", () => {
   beforeEach(() => {
+    cy.intercept("GET", "/api/dashboard/1/params/*/search/*").as("search");
+
     restore();
     cy.signInAsAdmin();
 
@@ -52,10 +57,6 @@ describe("support > permissions (metabase#8472)", () => {
   });
 
   it("should allow a nodata user to select the filter", () => {
-    cy.intercept("GET", "/api/dashboard/1/params/*/search/100 Main Street").as(
-      "search",
-    );
-
     cy.signIn("nodata");
     filterDashboard(false);
   });

--- a/frontend/test/metabase/scenarios/dashboard/text-box.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/text-box.cy.spec.js
@@ -57,7 +57,6 @@ describe("scenarios > dashboard > text-box", () => {
 
   describe("when text-box is the only element on the dashboard", () => {
     beforeEach(() => {
-      cy.server();
       cy.createDashboard().then(({ body: { id } }) => {
         cy.intercept("PUT", `/api/dashboard/${id}`).as("dashboardUpdated");
 

--- a/frontend/test/metabase/scenarios/native/snippets/snippet-permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/snippets/snippet-permissions.cy.spec.js
@@ -78,8 +78,9 @@ describeEE("scenarios > question > snippets", () => {
       });
     modal().within(() => cy.findByText("Top folder").click());
     popover().within(() => cy.findByText("my favorite snippets").click());
-    cy.server();
-    cy.route("/api/collection/root/items?namespace=snippets").as("updateList");
+    cy.intercept("/api/collection/root/items?namespace=snippets").as(
+      "updateList",
+    );
     modal().within(() => cy.findByText("Save").click());
 
     // check that everything is in the right spot

--- a/frontend/test/metabase/scenarios/permissions/admin-permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/admin-permissions.cy.spec.js
@@ -60,12 +60,8 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
     cy.findAllByRole("option").contains("Unrestricted").click();
 
     // stub out the PUT and save
-    cy.server();
-    cy.route({
-      method: "PUT",
-      url: /\/api\/permissions\/graph$/,
-      status: 500,
-      response: "Server error",
+    cy.intercept("PUT", "/api/permissions/graph", req => {
+      req.reply(500, "Server error");
     });
     cy.contains("Save changes").click();
     cy.contains("button", "Yes").click();

--- a/frontend/test/metabase/scenarios/permissions/permissions-baseline.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/permissions-baseline.cy.spec.js
@@ -38,12 +38,10 @@ describe("scenarios > permissions", () => {
     cy.findAllByRole("button", { name: "refresh icon" }).should("be.disabled");
   });
 
-  // There's no pulse in the fixture data, so we stub out the api call to
-  // replace the 404 with a 403.
   it("should display the permissions screen for pulses", () => {
     cy.signIn("none");
-    cy.server();
-    cy.route({ url: /\/api\/pulse\/1/, status: 403, response: {} });
+    // There's no pulse in the fixture data, so we stub out the api call to replace the 404 with a 403.
+    cy.intercept("api/pulse/1", { statusCode: 403, body: {} });
     cy.visit("/pulse/1");
     checkUnauthorized();
   });

--- a/frontend/test/metabase/scenarios/permissions/sandboxes.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/sandboxes.cy.spec.js
@@ -731,9 +731,9 @@ describeEE("formatting > sandboxes", () => {
       cy.findByText(QUESTION_NAME).click();
       cy.button("Save").click();
 
-      cy.wait("@sandboxTable").then(xhr => {
-        expect(xhr.status).to.eq(400);
-        expect(xhr.response.body.message).to.eq(ERROR_MESSAGE);
+      cy.wait("@sandboxTable").then(({ response }) => {
+        expect(response.statusCode).to.eq(400);
+        expect(response.body.message).to.eq(ERROR_MESSAGE);
       });
       cy.get(".Modal").scrollTo("bottom");
       cy.findByText(ERROR_MESSAGE);

--- a/frontend/test/metabase/scenarios/permissions/sandboxes.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/sandboxes.cy.spec.js
@@ -321,9 +321,8 @@ describeEE("formatting > sandboxes", () => {
         cy.signOut();
         cy.signInAsSandboxedUser();
 
-        cy.server();
-        cy.route("POST", "/api/card/*/query").as("cardQuery");
-        cy.route("POST", "/api/dataset").as("dataset");
+        cy.intercept("POST", "/api/card/*/query").as("cardQuery");
+        cy.intercept("POST", "/api/dataset").as("dataset");
 
         // Find saved question in "Our analytics"
         cy.visit("/collection/root");
@@ -395,9 +394,8 @@ describeEE("formatting > sandboxes", () => {
       cy.signOut();
       cy.signInAsSandboxedUser();
 
-      cy.server();
-      cy.route("POST", "/api/card/*/query").as("cardQuery");
-      cy.route("POST", "/api/dataset").as("dataset");
+      cy.intercept("POST", "/api/card/*/query").as("cardQuery");
+      cy.intercept("POST", "/api/dataset").as("dataset");
 
       // Find saved question in "Our analytics"
       cy.visit("/collection/root");
@@ -432,9 +430,6 @@ describeEE("formatting > sandboxes", () => {
        * that uses a query builder instead of SQL based questions.
        */
       it("should be able to sandbox using query builder saved questions", () => {
-        cy.server();
-        cy.route("POST", "/api/dataset").as("dataset");
-
         cy.log("Create 'Orders'-based question using QB");
         cy.createQuestion({
           name: "520_Orders",
@@ -503,9 +498,8 @@ describeEE("formatting > sandboxes", () => {
       // which is a bug fixed in ssue metabase#14302
       ["normal" /* , "workaround" */].forEach(test => {
         it(`${test.toUpperCase()} version:\n advanced sandboxing should not ignore data model features like object detail of FK (metabase-enterprise#520)`, () => {
-          cy.server();
-          cy.route("POST", "/api/card/*/query").as("cardQuery");
-          cy.route("PUT", "/api/card/*").as("questionUpdate");
+          cy.intercept("POST", "/api/card/*/query").as("cardQuery");
+          cy.intercept("PUT", "/api/card/*").as("questionUpdate");
 
           cy.createNativeQuestion({
             name: "EE_520_Q1",
@@ -606,9 +600,6 @@ describeEE("formatting > sandboxes", () => {
       });
 
       it("simple sandboxing should work (metabase#14629)", () => {
-        cy.server();
-        cy.route("POST", "/api/dataset").as("dataset");
-
         cy.sandboxTable({
           table_id: ORDERS_ID,
           attribute_remappings: {
@@ -690,9 +681,8 @@ describeEE("formatting > sandboxes", () => {
         cy.signOut();
         cy.signInAsSandboxedUser();
 
-        cy.server();
-        cy.route("POST", "/api/card/*/query").as("cardQuery");
-        cy.route("POST", "/api/dataset").as("dataset");
+        cy.intercept("POST", "/api/card/*/query").as("cardQuery");
+        cy.intercept("POST", "/api/dataset").as("dataset");
 
         cy.visit("/collection/root");
         cy.findByText(QUESTION_NAME).click();
@@ -717,9 +707,8 @@ describeEE("formatting > sandboxes", () => {
       const ERROR_MESSAGE =
         "Sandbox Questions can't return columns that have different types than the Table they are sandboxing.";
 
-      cy.server();
-      cy.route("POST", "/api/mt/gtap").as("sandboxTable");
-      cy.route("GET", "/api/permissions/group").as("tablePermissions");
+      cy.intercept("POST", "/api/mt/gtap").as("sandboxTable");
+      cy.intercept("GET", "/api/permissions/group").as("tablePermissions");
 
       // Question with differently-typed columns than the sandboxed table
       cy.createNativeQuestion({
@@ -770,8 +759,7 @@ describeEE("formatting > sandboxes", () => {
     });
 
     it("should be able to remove columns via QB sidebar / settings (metabase#14841)", () => {
-      cy.server();
-      cy.route("POST", "/api/dataset").as("dataset");
+      cy.intercept("POST", "/api/dataset").as("dataset");
 
       cy.sandboxTable({
         table_id: ORDERS_ID,
@@ -894,8 +882,7 @@ describeEE("formatting > sandboxes", () => {
     it.skip("sandboxed user should be able to send pulses to Slack (metabase#14844)", () => {
       cy.viewport(1400, 1000);
 
-      cy.server();
-      cy.route("GET", "/api/collection/*").as("collection");
+      cy.intercept("GET", "/api/collection/*").as("collection");
 
       cy.sandboxTable({
         table_id: ORDERS_ID,
@@ -918,9 +905,6 @@ describeEE("formatting > sandboxes", () => {
     });
 
     it.skip("should be able to visit ad-hoc/dirty question when permission is granted to the linked table column, but not to the linked table itself (metabase#15105)", () => {
-      cy.server();
-      cy.route("POST", "/api/dataset").as("dataset");
-
       cy.sandboxTable({
         table_id: ORDERS_ID,
         attribute_remappings: {
@@ -942,9 +926,6 @@ describeEE("formatting > sandboxes", () => {
     });
 
     it("unsaved/dirty query should work on linked table column with multiple dimensions and remapping (metabase#15106)", () => {
-      cy.server();
-      cy.route("POST", "/api/dataset").as("dataset");
-
       remapDisplayValueToFK({
         display_value: ORDERS.USER_ID,
         name: "User ID",

--- a/frontend/test/metabase/scenarios/question/saved.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/saved.cy.spec.js
@@ -98,12 +98,9 @@ describe("scenarios > question > saved", () => {
   });
 
   it("should duplicate a saved question", () => {
-    cy.server();
-    cy.route("POST", "/api/card").as("cardCreate");
-    cy.route("POST", "/api/card/1/query").as("query");
+    cy.intercept("POST", "/api/card").as("cardCreate");
 
     visitQuestion(1);
-    cy.wait("@query");
 
     openQuestionActions();
     popover().within(() => {

--- a/frontend/test/metabase/scenarios/visualizations/pie_chart.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/pie_chart.cy.spec.js
@@ -19,7 +19,6 @@ describe("scenarios > visualizations > pie chart", () => {
   beforeEach(() => {
     restore();
     cy.signInAsNormalUser();
-    cy.server();
   });
 
   it("should render a pie chart (metabase#12506)", () => {


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Replaces the old and deprecated `cy.server` + `cy.route` API with the new `cy.intercept` command.