### PR TITLE
Move mbql DatePicker utils to `metabase-lib`

### DIFF
--- a/frontend/src/metabase-lib/lib/utils/date-filters.ts
+++ b/frontend/src/metabase-lib/lib/utils/date-filters.ts
@@ -12,16 +12,22 @@ import Dimension from "metabase-lib/lib/Dimension";
 
 import type Filter from "metabase-lib/lib/queries/structured/Filter";
 
-const getIntervals = ([op, _field, value, _unit]: Filter) =>
-  op === "time-interval" && typeof value === "number" ? Math.abs(value) : 30;
-const getUnit = ([op, _field, _value, unit]: Filter) => {
+function getIntervals([op, _field, value, _unit]: Filter) {
+  return op === "time-interval" && typeof value === "number"
+    ? Math.abs(value)
+    : 30;
+}
+
+function getUnit([op, _field, _value, unit]: Filter) {
   const result = op === "time-interval" && unit ? unit : "day";
   return result;
-};
-const getOptions = ([op, _field, _value, _unit, options]: Filter) =>
-  (op === "time-interval" && options) || {};
+}
 
-const getDate = (value: string): string => {
+function getOptions([op, _field, _value, _unit, options]: Filter) {
+  return (op === "time-interval" && options) || {};
+}
+
+function getDate(value: string): string {
   if (typeof value !== "string" || !moment(value).isValid()) {
     value = moment().format("YYYY-MM-DD");
   }
@@ -30,10 +36,11 @@ const getDate = (value: string): string => {
     return "day";
   }
   return value;
-};
+}
 
-const hasTime = (value: unknown) =>
-  typeof value === "string" && /T\d{2}:\d{2}:\d{2}$/.test(value);
+function hasTime(value: unknown) {
+  return typeof value === "string" && /T\d{2}:\d{2}:\d{2}$/.test(value);
+}
 
 /**
  * Returns MBQL :field clause with temporal bucketing applied.

--- a/frontend/src/metabase-lib/lib/utils/date-filters.ts
+++ b/frontend/src/metabase-lib/lib/utils/date-filters.ts
@@ -1,0 +1,222 @@
+import moment from "moment-timezone";
+
+import {
+  updateRelativeDatetimeFilter,
+  isRelativeDatetime,
+  getRelativeDatetimeInterval,
+  getRelativeDatetimeField,
+  getTimeComponent,
+  setTimeComponent,
+} from "metabase/lib/query_time";
+import Dimension from "metabase-lib/lib/Dimension";
+
+import type Filter from "metabase-lib/lib/queries/structured/Filter";
+
+const getIntervals = ([op, _field, value, _unit]: Filter) =>
+  op === "time-interval" && typeof value === "number" ? Math.abs(value) : 30;
+const getUnit = ([op, _field, _value, unit]: Filter) => {
+  const result = op === "time-interval" && unit ? unit : "day";
+  return result;
+};
+const getOptions = ([op, _field, _value, _unit, options]: Filter) =>
+  (op === "time-interval" && options) || {};
+
+const getDate = (value: string): string => {
+  if (typeof value !== "string" || !moment(value).isValid()) {
+    value = moment().format("YYYY-MM-DD");
+  }
+  // Relative date shortcut sets unit to "none" to avoid preselecting
+  if (value === "none") {
+    return "day";
+  }
+  return value;
+};
+
+const hasTime = (value: unknown) =>
+  typeof value === "string" && /T\d{2}:\d{2}:\d{2}$/.test(value);
+
+/**
+ * Returns MBQL :field clause with temporal bucketing applied.
+ * @deprecated -- just use FieldDimension to do this stuff.
+ */
+function getDateTimeDimension(filter: any, bucketing?: string | null) {
+  let dimension = filter?.dimension?.();
+  if (!dimension) {
+    dimension = Dimension.parseMBQL(getRelativeDatetimeField(filter));
+  }
+  if (dimension) {
+    if (bucketing) {
+      return dimension.withTemporalUnit(bucketing).mbql();
+    } else {
+      return dimension.withoutTemporalBucketing().mbql();
+    }
+  }
+  return null;
+}
+
+// add temporal-unit to fields if any of them have a time component
+function getDateTimeDimensionAndValues(filter: Filter) {
+  let values = filter.slice(2).map(value => value && getDate(value));
+  const bucketing = _.any(values, hasTime) ? "minute" : null;
+  const dimension = getDateTimeDimension(filter, bucketing);
+  const { hours, minutes } = getTimeComponent(values[0]);
+  if (
+    typeof hours === "number" &&
+    typeof minutes === "number" &&
+    values.length === 2
+  ) {
+    const { hours: otherHours, minutes: otherMinutes } = getTimeComponent(
+      values[1],
+    );
+    if (typeof otherHours !== "number" || typeof otherMinutes !== "number") {
+      values = [
+        values[0],
+        setTimeComponent(values[1], hours, minutes) || values[0],
+      ];
+    }
+  }
+  return [dimension, ...values.filter(value => value !== undefined)];
+}
+
+function getOnFilterDimensionAndValues(filter: Filter) {
+  const [op] = filter;
+  const [dimension, ...values] = getDateTimeDimensionAndValues(filter);
+
+  if (op === "between") {
+    return [dimension, values[1]];
+  } else {
+    return [dimension, values[0]];
+  }
+}
+
+function getBeforeFilterDimensionAndValues(filter: Filter) {
+  const [op] = filter;
+  const [dimension, ...values] = getDateTimeDimensionAndValues(filter);
+
+  if (op === "between") {
+    return [dimension, values[1]];
+  } else {
+    return [dimension, values[0]];
+  }
+}
+
+function getAfterFilterDimensionAndValues(filter: Filter) {
+  const [field, ...values] = getDateTimeDimensionAndValues(filter);
+  return [field, values[0]];
+}
+
+function getBetweenFilterDimensionAndValues(filter: Filter) {
+  const [op] = filter;
+  const [dimension, ...values] = getDateTimeDimensionAndValues(filter);
+
+  if (op === "=" || op === "<") {
+    const beforeDate = moment(values[0]).subtract(30, "day");
+    const beforeValue = beforeDate.format("YYYY-MM-DD");
+    return [dimension, beforeValue, values[0]];
+  } else if (op === ">") {
+    const afterDate = moment(values[0]).add(30, "day");
+    const afterValue = afterDate.format("YYYY-MM-DD");
+    return [dimension, values[0], afterValue];
+  } else {
+    return [dimension, ...values];
+  }
+}
+
+export function getPreviousDateFilter(filter: Filter) {
+  return (
+    updateRelativeDatetimeFilter(filter, false) || [
+      "time-interval",
+      getDateTimeDimension(filter),
+      -getIntervals(filter),
+      getUnit(filter),
+      getOptions(filter),
+    ]
+  );
+}
+
+export function isPreviousDateFilter(filter: Filter) {
+  const [op, _field, left] = filter;
+  if (op === "time-interval" && typeof left === "number" && left <= 0) {
+    return true;
+  }
+  const [value] = getRelativeDatetimeInterval(filter);
+  return typeof value === "number" && value <= 0;
+}
+
+export function getCurrentDateFilter(filter: Filter) {
+  return ["time-interval", getDateTimeDimension(filter), "current"];
+}
+
+export function isCurrentDateFilter(filter: Filter) {
+  const [op, , value] = filter;
+  return op === "time-interval" && (value === "current" || value === null);
+}
+
+export function getNextDateFilter(filter: Filter) {
+  return (
+    updateRelativeDatetimeFilter(filter, true) || [
+      "time-interval",
+      getDateTimeDimension(filter),
+      getIntervals(filter),
+      getUnit(filter),
+      getOptions(filter),
+    ]
+  );
+}
+
+export function isNextDateFilter(filter: Filter) {
+  const [op, _field, left] = filter;
+  if (op === "time-interval" && left > 0) {
+    return true;
+  }
+  const [value] = getRelativeDatetimeInterval(filter);
+  return typeof value === "number" && value > 0;
+}
+
+export function getBetweenDateFilter(filter: Filter) {
+  return ["between", ...getBetweenFilterDimensionAndValues(filter)];
+}
+
+export function isBetweenFilter(filter: Filter) {
+  const [op, , left, right] = filter;
+  return (
+    op === "between" && !isRelativeDatetime(left) && !isRelativeDatetime(right)
+  );
+}
+
+export function getBeforeDateFilter(filter: Filter) {
+  return ["<", ...getBeforeFilterDimensionAndValues(filter)];
+}
+
+export function isBeforeDateFilter(filter: Filter) {
+  const [op] = filter;
+  return op === "<";
+}
+
+export function getOnDateFilter(filter: Filter) {
+  return ["=", ...getOnFilterDimensionAndValues(filter)];
+}
+
+export function isOnDateFilter(filter: Filter) {
+  const [op] = filter;
+  return op === "=";
+}
+
+export function getAfterDateFilter(filter: Filter) {
+  return [">", ...getAfterFilterDimensionAndValues(filter)];
+}
+
+export function isAfterDateFilter(filter: Filter) {
+  const [op] = filter;
+  return op === ">";
+}
+
+export function getExcludeDateFilter(filter: Filter) {
+  const [op, field, ...values] = filter;
+  return op === "!=" ? [op, field, ...values] : [op, field];
+}
+
+export function isExcludeDateFilter(filter: Filter) {
+  const [op] = filter;
+  return ["!=", "is-null", "not-null"].indexOf(op) > -1;
+}

--- a/frontend/src/metabase-lib/lib/utils/date-filters.ts
+++ b/frontend/src/metabase-lib/lib/utils/date-filters.ts
@@ -1,4 +1,5 @@
 import moment from "moment-timezone";
+import _ from "underscore";
 
 import {
   updateRelativeDatetimeFilter,

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePicker.tsx
@@ -2,20 +2,28 @@
 import React from "react";
 import { t } from "ttag";
 import cx from "classnames";
-import moment from "moment-timezone";
 import _ from "underscore";
 
+import { isStartingFrom } from "metabase/lib/query_time";
 import {
-  updateRelativeDatetimeFilter,
-  isRelativeDatetime,
-  isStartingFrom,
-  getRelativeDatetimeInterval,
-  getRelativeDatetimeField,
-  getTimeComponent,
-  setTimeComponent,
-} from "metabase/lib/query_time";
-import Dimension from "metabase-lib/lib/Dimension";
-import Filter from "metabase-lib/lib/queries/structured/Filter";
+  getAfterDateFilter,
+  getBeforeDateFilter,
+  getBetweenDateFilter,
+  getCurrentDateFilter,
+  getExcludeDateFilter,
+  getNextDateFilter,
+  getOnDateFilter,
+  getPreviousDateFilter,
+  isAfterDateFilter,
+  isBeforeDateFilter,
+  isBetweenFilter,
+  isCurrentDateFilter,
+  isExcludeDateFilter,
+  isNextDateFilter,
+  isOnDateFilter,
+  isPreviousDateFilter,
+} from "metabase-lib/lib/utils/date-filters";
+import type Filter from "metabase-lib/lib/queries/structured/Filter";
 
 import DatePickerFooter from "./DatePickerFooter";
 import DatePickerHeader from "./DatePickerHeader";
@@ -26,116 +34,6 @@ import CurrentPicker from "./CurrentPicker";
 import { NextPicker, PastPicker } from "./RelativeDatePicker";
 import { AfterPicker, BeforePicker, BetweenPicker } from "./RangeDatePicker";
 import SingleDatePicker from "./SingleDatePicker";
-
-const getIntervals = ([op, _field, value, _unit]: Filter) =>
-  op === "time-interval" && typeof value === "number" ? Math.abs(value) : 30;
-const getUnit = ([op, _field, _value, unit]: Filter) => {
-  const result = op === "time-interval" && unit ? unit : "day";
-  return result;
-};
-const getOptions = ([op, _field, _value, _unit, options]: Filter) =>
-  (op === "time-interval" && options) || {};
-
-const getDate = (value: string): string => {
-  if (typeof value !== "string" || !moment(value).isValid()) {
-    value = moment().format("YYYY-MM-DD");
-  }
-  // Relative date shortcut sets unit to "none" to avoid preselecting
-  if (value === "none") {
-    return "day";
-  }
-  return value;
-};
-
-const hasTime = (value: unknown) =>
-  typeof value === "string" && /T\d{2}:\d{2}:\d{2}$/.test(value);
-
-/**
- * Returns MBQL :field clause with temporal bucketing applied.
- * @deprecated -- just use FieldDimension to do this stuff.
- */
-function getDateTimeDimension(filter: any, bucketing?: string | null) {
-  let dimension = filter?.dimension?.();
-  if (!dimension) {
-    dimension = Dimension.parseMBQL(getRelativeDatetimeField(filter));
-  }
-  if (dimension) {
-    if (bucketing) {
-      return dimension.withTemporalUnit(bucketing).mbql();
-    } else {
-      return dimension.withoutTemporalBucketing().mbql();
-    }
-  }
-  return null;
-}
-
-// add temporal-unit to fields if any of them have a time component
-function getDateTimeDimensionAndValues(filter: Filter) {
-  let values = filter.slice(2).map(value => value && getDate(value));
-  const bucketing = _.any(values, hasTime) ? "minute" : null;
-  const dimension = getDateTimeDimension(filter, bucketing);
-  const { hours, minutes } = getTimeComponent(values[0]);
-  if (
-    typeof hours === "number" &&
-    typeof minutes === "number" &&
-    values.length === 2
-  ) {
-    const { hours: otherHours, minutes: otherMinutes } = getTimeComponent(
-      values[1],
-    );
-    if (typeof otherHours !== "number" || typeof otherMinutes !== "number") {
-      values = [
-        values[0],
-        setTimeComponent(values[1], hours, minutes) || values[0],
-      ];
-    }
-  }
-  return [dimension, ...values.filter(value => value !== undefined)];
-}
-
-function getOnFilterDimensionAndValues(filter: Filter) {
-  const [op] = filter;
-  const [dimension, ...values] = getDateTimeDimensionAndValues(filter);
-
-  if (op === "between") {
-    return [dimension, values[1]];
-  } else {
-    return [dimension, values[0]];
-  }
-}
-
-function getBeforeFilterDimensionAndValues(filter: Filter) {
-  const [op] = filter;
-  const [dimension, ...values] = getDateTimeDimensionAndValues(filter);
-
-  if (op === "between") {
-    return [dimension, values[1]];
-  } else {
-    return [dimension, values[0]];
-  }
-}
-
-function getAfterFilterDimensionAndValues(filter: Filter) {
-  const [field, ...values] = getDateTimeDimensionAndValues(filter);
-  return [field, values[0]];
-}
-
-function getBetweenFilterDimensionAndValues(filter: Filter) {
-  const [op] = filter;
-  const [dimension, ...values] = getDateTimeDimensionAndValues(filter);
-
-  if (op === "=" || op === "<") {
-    const beforeDate = moment(values[0]).subtract(30, "day");
-    const beforeValue = beforeDate.format("YYYY-MM-DD");
-    return [dimension, beforeValue, values[0]];
-  } else if (op === ">") {
-    const afterDate = moment(values[0]).add(30, "day");
-    const afterValue = afterDate.format("YYYY-MM-DD");
-    return [dimension, values[0], afterValue];
-  } else {
-    return [dimension, ...values];
-  }
-}
 
 export type DatePickerGroup = "relative" | "specific";
 
@@ -154,22 +52,8 @@ export const DATE_OPERATORS: DateOperator[] = [
   {
     name: "previous",
     displayName: t`Past`,
-    init: filter =>
-      updateRelativeDatetimeFilter(filter, false) || [
-        "time-interval",
-        getDateTimeDimension(filter),
-        -getIntervals(filter),
-        getUnit(filter),
-        getOptions(filter),
-      ],
-    test: filter => {
-      const [op, _field, left] = filter;
-      if (op === "time-interval" && typeof left === "number" && left <= 0) {
-        return true;
-      }
-      const [value] = getRelativeDatetimeInterval(filter);
-      return typeof value === "number" && value <= 0;
-    },
+    init: filter => getPreviousDateFilter(filter),
+    test: filter => isPreviousDateFilter(filter),
     group: "relative",
     widget: PastPicker,
     options: { "include-current": true },
@@ -177,31 +61,16 @@ export const DATE_OPERATORS: DateOperator[] = [
   {
     name: "current",
     displayName: t`Current`,
-    init: filter => ["time-interval", getDateTimeDimension(filter), "current"],
-    test: ([op, field, value]) =>
-      op === "time-interval" && (value === "current" || value === null),
+    init: filter => getCurrentDateFilter(filter),
+    test: filter => isCurrentDateFilter(filter),
     group: "relative",
     widget: CurrentPicker,
   },
   {
     name: "next",
     displayName: t`Next`,
-    init: filter =>
-      updateRelativeDatetimeFilter(filter, true) || [
-        "time-interval",
-        getDateTimeDimension(filter),
-        getIntervals(filter),
-        getUnit(filter),
-        getOptions(filter),
-      ],
-    test: filter => {
-      const [op, _field, left] = filter;
-      if (op === "time-interval" && left > 0) {
-        return true;
-      }
-      const [value] = getRelativeDatetimeInterval(filter);
-      return typeof value === "number" && value > 0;
-    },
+    init: filter => getNextDateFilter(filter),
+    test: filter => isNextDateFilter(filter),
     group: "relative",
     widget: NextPicker,
     options: { "include-current": true },
@@ -209,35 +78,32 @@ export const DATE_OPERATORS: DateOperator[] = [
   {
     name: "between",
     displayName: t`Between`,
-    init: filter => ["between", ...getBetweenFilterDimensionAndValues(filter)],
-    test: ([op, _field, left, right]) =>
-      op === "between" &&
-      !isRelativeDatetime(left) &&
-      !isRelativeDatetime(right),
+    init: filter => getBetweenDateFilter(filter),
+    test: filter => isBetweenFilter(filter),
     group: "specific",
     widget: BetweenPicker,
   },
   {
     name: "before",
     displayName: t`Before`,
-    init: filter => ["<", ...getBeforeFilterDimensionAndValues(filter)],
-    test: ([op]) => op === "<",
+    init: filter => getBeforeDateFilter(filter),
+    test: filter => isBeforeDateFilter(filter),
     group: "specific",
     widget: BeforePicker,
   },
   {
     name: "on",
     displayName: t`On`,
-    init: filter => ["=", ...getOnFilterDimensionAndValues(filter)],
-    test: ([op]) => op === "=",
+    init: filter => getOnDateFilter(filter),
+    test: filter => isOnDateFilter(filter),
     group: "specific",
     widget: SingleDatePicker,
   },
   {
     name: "after",
     displayName: t`After`,
-    init: filter => [">", ...getAfterFilterDimensionAndValues(filter)],
-    test: ([op]) => op === ">",
+    init: filter => getAfterDateFilter(filter),
+    test: filter => isAfterDateFilter(filter),
     group: "specific",
     widget: AfterPicker,
   },
@@ -245,9 +111,8 @@ export const DATE_OPERATORS: DateOperator[] = [
     name: "exclude",
     displayName: t`Exclude...`,
     displayPrefix: t`Exclude`,
-    init: ([op, field, ...values]) =>
-      op === "!=" ? [op, field, ...values] : [op, field],
-    test: ([op]) => ["!=", "is-null", "not-null"].indexOf(op) > -1,
+    init: filter => getExcludeDateFilter(filter),
+    test: filter => isExcludeDateFilter(filter),
     widget: ExcludeDatePicker,
   },
 ];


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/25618

- `init` functions are now `get${name}DateFilter` in `metabase-lib/lib/utils/date-filters`
- `test` functions are now `is${name}DateFilter` in `metabase-lib/lib/utils/date-filters`
