### PR TITLE
Move `DatePickerShortcutOptions` logic utils to `metabase-lib`

### DIFF
--- a/frontend/src/metabase-lib/lib/queries/utils/date-filters.ts
+++ b/frontend/src/metabase-lib/lib/queries/utils/date-filters.ts
@@ -47,7 +47,10 @@ function hasTime(value: unknown) {
  * Returns MBQL :field clause with temporal bucketing applied.
  * @deprecated -- just use FieldDimension to do this stuff.
  */
-function getDateTimeDimension(filter: any, bucketing?: string | null) {
+function getDateTimeDimensionFromFilter(
+  filter: any,
+  bucketing?: string | null,
+) {
   let dimension = filter?.dimension?.();
   if (!dimension) {
     dimension = Dimension.parseMBQL(getRelativeDatetimeField(filter));
@@ -62,11 +65,24 @@ function getDateTimeDimension(filter: any, bucketing?: string | null) {
   return null;
 }
 
+// note: this is probably buggy because we aren't passing `metadata` and `query`
+function getDateTimeDimensionFromMbql(mbql: any, bucketing?: string) {
+  const dimension = Dimension.parseMBQL(mbql);
+  if (dimension) {
+    if (bucketing) {
+      return dimension.withTemporalUnit(bucketing).mbql();
+    } else {
+      return dimension.withoutTemporalBucketing().mbql();
+    }
+  }
+  return mbql;
+}
+
 // add temporal-unit to fields if any of them have a time component
-function getDateTimeDimensionAndValues(filter: Filter) {
+function getDateTimeDimensionFromFilterAndValues(filter: Filter) {
   let values = filter.slice(2).map(value => value && getDate(value));
   const bucketing = _.any(values, hasTime) ? "minute" : null;
-  const dimension = getDateTimeDimension(filter, bucketing);
+  const dimension = getDateTimeDimensionFromFilter(filter, bucketing);
   const { hours, minutes } = getTimeComponent(values[0]);
   if (
     typeof hours === "number" &&
@@ -88,7 +104,8 @@ function getDateTimeDimensionAndValues(filter: Filter) {
 
 function getOnFilterDimensionAndValues(filter: Filter) {
   const [op] = filter;
-  const [dimension, ...values] = getDateTimeDimensionAndValues(filter);
+  const [dimension, ...values] =
+    getDateTimeDimensionFromFilterAndValues(filter);
 
   if (op === "between") {
     return [dimension, values[1]];
@@ -99,7 +116,8 @@ function getOnFilterDimensionAndValues(filter: Filter) {
 
 function getBeforeFilterDimensionAndValues(filter: Filter) {
   const [op] = filter;
-  const [dimension, ...values] = getDateTimeDimensionAndValues(filter);
+  const [dimension, ...values] =
+    getDateTimeDimensionFromFilterAndValues(filter);
 
   if (op === "between") {
     return [dimension, values[1]];
@@ -109,13 +127,14 @@ function getBeforeFilterDimensionAndValues(filter: Filter) {
 }
 
 function getAfterFilterDimensionAndValues(filter: Filter) {
-  const [field, ...values] = getDateTimeDimensionAndValues(filter);
+  const [field, ...values] = getDateTimeDimensionFromFilterAndValues(filter);
   return [field, values[0]];
 }
 
 function getBetweenFilterDimensionAndValues(filter: Filter) {
   const [op] = filter;
-  const [dimension, ...values] = getDateTimeDimensionAndValues(filter);
+  const [dimension, ...values] =
+    getDateTimeDimensionFromFilterAndValues(filter);
 
   if (op === "=" || op === "<") {
     const beforeDate = moment(values[0]).subtract(30, "day");
@@ -134,7 +153,7 @@ export function getPreviousDateFilter(filter: Filter) {
   return (
     updateRelativeDatetimeFilter(filter, false) || [
       "time-interval",
-      getDateTimeDimension(filter),
+      getDateTimeDimensionFromFilter(filter),
       -getIntervals(filter),
       getUnit(filter),
       getOptions(filter),
@@ -152,7 +171,7 @@ export function isPreviousDateFilter(filter: Filter) {
 }
 
 export function getCurrentDateFilter(filter: Filter) {
-  return ["time-interval", getDateTimeDimension(filter), "current"];
+  return ["time-interval", getDateTimeDimensionFromFilter(filter), "current"];
 }
 
 export function isCurrentDateFilter(filter: Filter) {
@@ -164,7 +183,7 @@ export function getNextDateFilter(filter: Filter) {
   return (
     updateRelativeDatetimeFilter(filter, true) || [
       "time-interval",
-      getDateTimeDimension(filter),
+      getDateTimeDimensionFromFilter(filter),
       getIntervals(filter),
       getUnit(filter),
       getOptions(filter),
@@ -227,4 +246,91 @@ export function getExcludeDateFilter(filter: Filter) {
 export function isExcludeDateFilter(filter: Filter) {
   const [op] = filter;
   return ["!=", "is-null", "not-null"].indexOf(op) > -1;
+}
+
+export function getTodayDateFilter(filter: Filter) {
+  return [
+    "time-interval",
+    getDateTimeDimensionFromMbql(filter[1]),
+    "current",
+    "day",
+    { include_current: true },
+  ];
+}
+
+export function getYesterdayDateFilter(filter: Filter) {
+  return [
+    "time-interval",
+    getDateTimeDimensionFromMbql(filter[1]),
+    -1,
+    "day",
+    { include_current: false },
+  ];
+}
+
+export function getLast7DaysDateFilter(filter: Filter) {
+  return [
+    "time-interval",
+    getDateTimeDimensionFromMbql(filter[1]),
+    -7,
+    "day",
+    { include_current: false },
+  ];
+}
+
+export function getLast30DaysDateFilter(filter: Filter) {
+  return [
+    "time-interval",
+    getDateTimeDimensionFromMbql(filter[1]),
+    -30,
+    "day",
+    { include_current: false },
+  ];
+}
+
+export function getLastMonthDateFilter(filter: Filter) {
+  return [
+    "time-interval",
+    getDateTimeDimensionFromMbql(filter[1]),
+    -1,
+    "month",
+    { include_current: false },
+  ];
+}
+
+export function getLast3MonthsDateFilter(filter: Filter) {
+  return [
+    "time-interval",
+    getDateTimeDimensionFromMbql(filter[1]),
+    -3,
+    "month",
+    { include_current: false },
+  ];
+}
+
+export function getLast12MonthsDateFilter(filter: Filter) {
+  return [
+    "time-interval",
+    getDateTimeDimensionFromMbql(filter[1]),
+    -12,
+    "month",
+    { include_current: false },
+  ];
+}
+
+export function getInitialSpecificDatesShortcut(filter: Filter) {
+  return [
+    "between",
+    getDateTimeDimensionFromMbql(filter[1]),
+    moment().subtract(30, "day").format("YYYY-MM-DD"),
+    moment().format("YYYY-MM-DD"),
+  ];
+}
+
+export function getInitialRelativeDatesShortcut(filter: Filter) {
+  return ["time-interval", getDateTimeDimensionFromMbql(filter[1]), -30, "day"];
+}
+
+export function getInitialExcludeShortcut(filter: Filter) {
+  return ["!=", getDateTimeDimensionFromMbql(filter[1])];
 }

--- a/frontend/src/metabase-lib/lib/queries/utils/date-filters.ts
+++ b/frontend/src/metabase-lib/lib/queries/utils/date-filters.ts
@@ -287,6 +287,16 @@ export function getYesterdayDateFilter(filter: Filter) {
   ];
 }
 
+export function getLastWeekDateFilter(filter: Filter) {
+  return [
+    "time-interval",
+    getDateTimeDimensionFromMbql(filter[1]),
+    -1,
+    "week",
+    { include_current: false },
+  ];
+}
+
 export function getLast7DaysDateFilter(filter: Filter) {
   return [
     "time-interval",
@@ -379,6 +389,6 @@ export function getInitialHourOfDayFilter(filter: Filter) {
 }
 
 export const isDayOfWeekDateFilter = testTemporalUnit("day-of-week");
-export const isMonthOfYearDateFilter = testTemporalUnit("day-of-week");
-export const isQuarterofYearDateFilter = testTemporalUnit("day-of-week");
-export const isHourOfDayDateFilter = testTemporalUnit("day-of-week");
+export const isMonthOfYearDateFilter = testTemporalUnit("month-of-year");
+export const isQuarterofYearDateFilter = testTemporalUnit("quarter-of-year");
+export const isHourOfDayDateFilter = testTemporalUnit("hour-of-day");

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePickerShortcutOptions.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePickerShortcutOptions.tsx
@@ -1,20 +1,18 @@
 import { t } from "ttag";
-import moment from "moment-timezone";
+import {
+  getInitialExcludeShortcut,
+  getInitialSpecificDatesShortcut,
+  getInitialRelativeDatesShortcut,
+  getLast12MonthsDateFilter,
+  getLast30DaysDateFilter,
+  getLast3MonthsDateFilter,
+  getLast7DaysDateFilter,
+  getLastMonthDateFilter,
+  getTodayDateFilter,
+  getYesterdayDateFilter,
+} from "metabase-lib/lib/utils/date-filters";
 
-import Dimension from "metabase-lib/lib/Dimension";
-import Filter from "metabase-lib/lib/queries/structured/Filter";
-
-function getDateTimeDimension(mbql: any, bucketing?: string) {
-  const dimension = Dimension.parseMBQL(mbql);
-  if (dimension) {
-    if (bucketing) {
-      return dimension.withTemporalUnit(bucketing).mbql();
-    } else {
-      return dimension.withoutTemporalBucketing().mbql();
-    }
-  }
-  return mbql;
-}
+import type Filter from "metabase-lib/lib/queries/structured/Filter";
 
 type Option = {
   displayName: string;
@@ -24,111 +22,53 @@ type Option = {
 const DAY_OPTIONS: Option[] = [
   {
     displayName: t`Today`,
-    init: filter => [
-      "time-interval",
-      getDateTimeDimension(filter[1]),
-      "current",
-      "day",
-      { include_current: true },
-    ],
+    init: filter => getTodayDateFilter(filter),
   },
   {
     displayName: t`Yesterday`,
-    init: filter => [
-      "time-interval",
-      getDateTimeDimension(filter[1]),
-      -1,
-      "day",
-      { include_current: false },
-    ],
+    init: filter => getYesterdayDateFilter(filter),
   },
   {
     displayName: t`Last Week`,
-    init: filter => [
-      "time-interval",
-      getDateTimeDimension(filter[1]),
-      -1,
-      "week",
-      { include_current: false },
-    ],
+    init: filter => getYesterdayDateFilter(filter),
   },
   {
     displayName: t`Last 7 Days`,
-    init: filter => [
-      "time-interval",
-      getDateTimeDimension(filter[1]),
-      -7,
-      "day",
-      { include_current: false },
-    ],
+    init: filter => getLast7DaysDateFilter(filter),
   },
   {
     displayName: t`Last 30 Days`,
-    init: filter => [
-      "time-interval",
-      getDateTimeDimension(filter[1]),
-      -30,
-      "day",
-      { include_current: false },
-    ],
+    init: filter => getLast30DaysDateFilter(filter),
   },
 ];
 
 const MONTH_OPTIONS: Option[] = [
   {
     displayName: t`Last Month`,
-    init: filter => [
-      "time-interval",
-      getDateTimeDimension(filter[1]),
-      -1,
-      "month",
-      { include_current: false },
-    ],
+    init: filter => getLastMonthDateFilter(filter),
   },
   {
     displayName: t`Last 3 Months`,
-    init: filter => [
-      "time-interval",
-      getDateTimeDimension(filter[1]),
-      -3,
-      "month",
-      { include_current: false },
-    ],
+    init: filter => getLast3MonthsDateFilter(filter),
   },
   {
     displayName: t`Last 12 Months`,
-    init: filter => [
-      "time-interval",
-      getDateTimeDimension(filter[1]),
-      -12,
-      "month",
-      { include_current: false },
-    ],
+    init: filter => getLast12MonthsDateFilter(filter),
   },
 ];
 
 const MISC_OPTIONS: Option[] = [
   {
     displayName: t`Specific dates...`,
-    init: filter => [
-      "between",
-      getDateTimeDimension(filter[1]),
-      moment().subtract(30, "day").format("YYYY-MM-DD"),
-      moment().format("YYYY-MM-DD"),
-    ],
+    init: filter => getInitialSpecificDatesShortcut(filter),
   },
   {
     displayName: t`Relative dates...`,
-    init: filter => [
-      "time-interval",
-      getDateTimeDimension(filter[1]),
-      -30,
-      "day",
-    ],
+    init: filter => getInitialRelativeDatesShortcut(filter),
   },
   {
     displayName: t`Exclude...`,
-    init: filter => ["!=", getDateTimeDimension(filter[1])],
+    init: filter => getInitialExcludeShortcut(filter),
   },
 ];
 

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePickerShortcutOptions.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePickerShortcutOptions.tsx
@@ -10,6 +10,7 @@ import {
   getLastMonthDateFilter,
   getTodayDateFilter,
   getYesterdayDateFilter,
+  getLastWeekDateFilter,
 } from "metabase-lib/lib/queries/utils/date-filters";
 
 import type Filter from "metabase-lib/lib/queries/structured/Filter";
@@ -30,7 +31,7 @@ const DAY_OPTIONS: Option[] = [
   },
   {
     displayName: t`Last Week`,
-    init: filter => getYesterdayDateFilter(filter),
+    init: filter => getLastWeekDateFilter(filter),
   },
   {
     displayName: t`Last 7 Days`,

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePickerShortcutOptions.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePickerShortcutOptions.tsx
@@ -10,7 +10,7 @@ import {
   getLastMonthDateFilter,
   getTodayDateFilter,
   getYesterdayDateFilter,
-} from "metabase-lib/lib/utils/date-filters";
+} from "metabase-lib/lib/queries/utils/date-filters";
 
 import type Filter from "metabase-lib/lib/queries/structured/Filter";
 

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/ExcludeDatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/ExcludeDatePicker.tsx
@@ -1,13 +1,23 @@
 import React from "react";
 import { t } from "ttag";
-import moment from "moment-timezone";
 import _ from "underscore";
 
-import { Field } from "metabase-types/types/Field";
 import { color } from "metabase/lib/colors";
 import { EXCLUDE_OPTIONS } from "metabase-lib/lib/queries/utils/query-time";
 import Filter from "metabase-lib/lib/queries/structured/Filter";
-import { FieldDimension } from "metabase-lib/lib/Dimension";
+import {
+  getInitialDayOfWeekFilter,
+  getInitialMonthOfYearFilter,
+  getInitialQuarterOfYearFilter,
+  getInitialHourOfDayFilter,
+  isDayOfWeekDateFilter,
+  isMonthOfYearDateFilter,
+  isQuarterofYearDateFilter,
+  isHourOfDayDateFilter,
+  getNotNullDateFilter,
+  getIsNullDateFilter,
+} from "metabase-lib/lib/queries/utils/date-filters";
+
 import {
   ExcludeCheckBox,
   ExcludeColumn,
@@ -16,16 +26,6 @@ import {
   OptionButton,
   Separator,
 } from "./ExcludeDatePicker.styled";
-
-function getDateTimeField(field: Field, bucketing?: string) {
-  const dimension =
-    FieldDimension.parseMBQLOrWarn(field) ?? new FieldDimension(null);
-  if (bucketing) {
-    return dimension.withTemporalUnit(bucketing).mbql();
-  } else {
-    return dimension.withoutTemporalBucketing().mbql();
-  }
-}
 
 type Option = {
   displayName: string;
@@ -42,41 +42,33 @@ type Group = {
   getOptions: () => Option[][];
 };
 
-const testTemporalUnit = (unit: string) => (filter: Filter) => {
-  const dimension = FieldDimension.parseMBQLOrWarn(filter[1]);
-  if (dimension) {
-    return dimension.temporalUnit() === unit;
-  }
-  return filter[1]?.[2]?.["temporal-unit"] === unit;
-};
-
 export const EXCLUDE_OPERATORS: Group[] = [
   {
     name: "days",
     displayName: t`Days of the week...`,
-    test: testTemporalUnit("day-of-week"),
-    init: filter => ["!=", getDateTimeField(filter[1], "day-of-week")],
+    test: filter => isDayOfWeekDateFilter(filter),
+    init: filter => getInitialDayOfWeekFilter(filter),
     getOptions: EXCLUDE_OPTIONS["day-of-week"],
   },
   {
     name: "months",
     displayName: t`Months of the year...`,
-    test: testTemporalUnit("month-of-year"),
-    init: filter => ["!=", getDateTimeField(filter[1], "month-of-year")],
+    test: filter => isMonthOfYearDateFilter(filter),
+    init: filter => getInitialMonthOfYearFilter(filter),
     getOptions: EXCLUDE_OPTIONS["month-of-year"],
   },
   {
     name: "quarters",
     displayName: t`Quarters of the year...`,
-    test: testTemporalUnit("quarter-of-year"),
-    init: filter => ["!=", getDateTimeField(filter[1], "quarter-of-year")],
+    test: filter => isQuarterofYearDateFilter(filter),
+    init: filter => getInitialQuarterOfYearFilter(filter),
     getOptions: EXCLUDE_OPTIONS["quarter-of-year"],
   },
   {
     name: "hours",
     displayName: t`Hours of the day...`,
-    test: testTemporalUnit("hour-of-day"),
-    init: filter => ["!=", getDateTimeField(filter[1], "hour-of-day")],
+    test: filter => isHourOfDayDateFilter(filter),
+    init: filter => getInitialHourOfDayFilter(filter),
     getOptions: EXCLUDE_OPTIONS["hour-of-day"],
   },
 ];
@@ -130,7 +122,7 @@ export default function ExcludeDatePicker({
               selected={operator === "not-null"}
               primaryColor={primaryColor}
               onClick={() => {
-                onCommit(["not-null", getDateTimeField(filter[1])]);
+                onCommit(getNotNullDateFilter(filter));
               }}
             >
               {t`Is empty`}
@@ -139,7 +131,7 @@ export default function ExcludeDatePicker({
               selected={operator === "is-null"}
               primaryColor={primaryColor}
               onClick={() => {
-                onCommit(["is-null", getDateTimeField(filter[1])]);
+                onCommit(getIsNullDateFilter(filter));
               }}
             >
               {t`Is not empty`}


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/25618

This PR moves more date filter-building logic to `metabase-lib/lib/queries/utils/date-filters`.