### PR TITLE
Refactor DataReference to use redux store for stack state

### DIFF
--- a/frontend/src/metabase/query_builder/actions/native.js
+++ b/frontend/src/metabase/query_builder/actions/native.js
@@ -25,6 +25,9 @@ export const toggleDataReference = createAction(TOGGLE_DATA_REFERENCE, () => {
   MetabaseAnalytics.trackStructEvent("QueryBuilder", "Toggle Data Reference");
 });
 
+export const SET_DATA_REFERENCE_STACK = "metabase/qb/SET_DATA_REFERENCE_STACK";
+export const setDataReferenceStack = createAction(SET_DATA_REFERENCE_STACK);
+
 export const TOGGLE_TEMPLATE_TAGS_EDITOR =
   "metabase/qb/TOGGLE_TEMPLATE_TAGS_EDITOR";
 export const toggleTemplateTagsEditor = createAction(

--- a/frontend/src/metabase/query_builder/reducers.js
+++ b/frontend/src/metabase/query_builder/reducers.js
@@ -6,6 +6,7 @@ import Utils from "metabase/lib/utils";
 import {
   RESET_QB,
   INITIALIZE_QB,
+  SET_DATA_REFERENCE_STACK,
   TOGGLE_DATA_REFERENCE,
   TOGGLE_TEMPLATE_TAGS_EDITOR,
   TOGGLE_SNIPPET_SIDEBAR,
@@ -63,6 +64,7 @@ import {
 } from "./actions";
 
 const DEFAULT_UI_CONTROLS = {
+  dataReferenceStack: [],
   isShowingDataReference: false,
   isShowingTemplateTagsEditor: false,
   isShowingNewbModal: false,
@@ -155,6 +157,12 @@ export const uiControls = handleActions(
         ...state,
         ...CLOSED_NATIVE_EDITOR_SIDEBARS,
         isShowingDataReference: !state.isShowingDataReference,
+      }),
+    },
+    [SET_DATA_REFERENCE_STACK]: {
+      next: (state, { payload }) => ({
+        ...state,
+        dataReferenceStack: payload,
       }),
     },
     [TOGGLE_TEMPLATE_TAGS_EDITOR]: {


### PR DESCRIPTION
This PR is a small step towards the next milestone of [[Epic] Improve native query UX on models](https://github.com/metabase/metabase/issues/25050): "Automatically open model schema in the sidebar when typing".

To open the Data reference sidebar automatically when typing, we first need to move the `stack` state of the DataReference component to the redux store. This PR does just that.

While doing so, I converted DataReference from a class component to a function component.