### PR TITLE
Include new site UUID in version check requests

### DIFF
--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -101,6 +101,13 @@
   :setter     :none
   :type       ::uuid-nonce)
 
+(defsetting site-uuid-for-version-info-fetching
+  "A *different* site-wide UUID that we use for the version info fetching API calls. It works in fundamentally the
+  same way as [[site-uuid]] but should only be used by the version info fetching logic for the sake of privacy."
+  :visibility :internal
+  :setter     :none
+  :type       ::uuid-nonce)
+
 (defn- normalize-site-url [^String s]
   (let [ ;; remove trailing slashes
         s (str/replace s #"/$" "")

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -102,8 +102,8 @@
   :type       ::uuid-nonce)
 
 (defsetting site-uuid-for-version-info-fetching
-  "A *different* site-wide UUID that we use for the version info fetching API calls. It works in fundamentally the
-  same way as [[site-uuid]] but should only be used by the version info fetching logic for the sake of privacy."
+  "A *different* site-wide UUID that we use for the version info fetching API calls. Do not use this for any other
+  applications. (See [[site-uuid-for-premium-features-token-checks]] for more reasoning.)"
   :visibility :internal
   :setter     :none
   :type       ::uuid-nonce)

--- a/src/metabase/task/upgrade_checks.clj
+++ b/src/metabase/task/upgrade_checks.clj
@@ -15,8 +15,10 @@
 (defn- get-version-info []
   (let [version-info-url-key  (if config/ee-available? :mb-version-info-ee-url :mb-version-info-url)
         version-info-url      (config/config-str version-info-url-key)
-        {:keys [status body]} (http/get version-info-url {:content-type "application/json"
-                                                          :query-params {"instance" (public-settings/site-uuid-for-version-info-fetching)}})]
+        {:keys [status body]} (http/get version-info-url (merge
+                                                          {:content-type "application/json"}
+                                                          (when config/is-prod?
+                                                            {:query-params {"instance" (public-settings/site-uuid-for-version-info-fetching)}})))]
     (when (not= status 200)
       (throw (Exception. (format "[%d]: %s" status body))))
     (json/parse-string body keyword)))

--- a/src/metabase/task/upgrade_checks.clj
+++ b/src/metabase/task/upgrade_checks.clj
@@ -16,7 +16,7 @@
   (let [version-info-url-key  (if config/ee-available? :mb-version-info-ee-url :mb-version-info-url)
         version-info-url      (config/config-str version-info-url-key)
         {:keys [status body]} (http/get version-info-url {:content-type "application/json"
-                                                          :query-params {"version-info-uuid" (public-settings/site-uuid-for-version-info-fetching)}})]
+                                                          :query-params {"instance" (public-settings/site-uuid-for-version-info-fetching)}})]
     (when (not= status 200)
       (throw (Exception. (format "[%d]: %s" status body))))
     (json/parse-string body keyword)))

--- a/src/metabase/task/upgrade_checks.clj
+++ b/src/metabase/task/upgrade_checks.clj
@@ -15,7 +15,8 @@
 (defn- get-version-info []
   (let [version-info-url-key  (if config/ee-available? :mb-version-info-ee-url :mb-version-info-url)
         version-info-url      (config/config-str version-info-url-key)
-        {:keys [status body]} (http/get version-info-url {:content-type "application/json"})]
+        {:keys [status body]} (http/get version-info-url {:content-type "application/json"
+                                                          :query-params {"version-info-uuid" (public-settings/site-uuid-for-version-info-fetching)}})]
     (when (not= status 200)
       (throw (Exception. (format "[%d]: %s" status body))))
     (json/parse-string body keyword)))

--- a/test/metabase/task/upgrade_checks_test.clj
+++ b/test/metabase/task/upgrade_checks_test.clj
@@ -7,9 +7,7 @@
 (deftest site-uuid-test
   (testing "A unique and stable site UUID is included in version info requests"
     (http-fake/with-fake-routes-in-isolation
-      {#"http://static.metabase.com/version-info(-ee)?.json.*"
-       (fn [req]
-         (is (= (str "instance=" (public-settings/site-uuid-for-version-info-fetching))
-                (get-in req [:query-string])))
-         {:status 200 :body "{}"})}
+      {{:address #"http://static.metabase.com/version-info(-ee)?.json"
+        :query-params {:instance (public-settings/site-uuid-for-version-info-fetching)}}
+       (constantly {:status 200 :body ""})}
       (@#'upgrade-checks/get-version-info))))

--- a/test/metabase/task/upgrade_checks_test.clj
+++ b/test/metabase/task/upgrade_checks_test.clj
@@ -1,0 +1,15 @@
+(ns metabase.task.upgrade-checks-test
+  (:require [clj-http.fake :as http-fake]
+            [clojure.test :refer :all]
+            [metabase.public-settings :as public-settings]
+            [metabase.task.upgrade-checks :as upgrade-checks]))
+
+(deftest site-uuid-test
+  (testing "A unique and stable site UUID is included in version info requests"
+    (http-fake/with-fake-routes-in-isolation
+      {#"http://static.metabase.com/version-info(-ee)?.json.*"
+       (fn [req]
+         (is (= (str "instance=" (public-settings/site-uuid-for-version-info-fetching))
+                (get-in req [:query-string])))
+         {:status 200 :body "{}"})}
+      (@#'upgrade-checks/get-version-info))))

--- a/test/metabase/task/upgrade_checks_test.clj
+++ b/test/metabase/task/upgrade_checks_test.clj
@@ -1,13 +1,23 @@
 (ns metabase.task.upgrade-checks-test
   (:require [clj-http.fake :as http-fake]
             [clojure.test :refer :all]
+            [metabase.config :as config]
             [metabase.public-settings :as public-settings]
             [metabase.task.upgrade-checks :as upgrade-checks]))
 
 (deftest site-uuid-test
-  (testing "A unique and stable site UUID is included in version info requests"
-    (http-fake/with-fake-routes-in-isolation
-      {{:address #"http://static.metabase.com/version-info(-ee)?.json"
-        :query-params {:instance (public-settings/site-uuid-for-version-info-fetching)}}
-       (constantly {:status 200 :body ""})}
-      (@#'upgrade-checks/get-version-info))))
+  (testing "A unique and stable instance UUID is included in version info requests in prod"
+    (with-redefs [config/is-prod? true]
+      (http-fake/with-fake-routes-in-isolation
+        {{:address #"http://static.metabase.com/version-info(-ee)?.json.*"
+          :query-params {:instance (public-settings/site-uuid-for-version-info-fetching)}}
+         (constantly {:status 200 :body "{}"})}
+        (is (= {} (@#'upgrade-checks/get-version-info))))))
+
+  (testing "Instance UUID is not included when not running in prod"
+    (with-redefs [config/is-prod? false]
+      (http-fake/with-fake-routes-in-isolation
+        {{:address #"http://static.metabase.com/version-info(-ee)?.json.*"
+          :query-params {}}
+         (constantly {:status 200 :body "{}"})}
+        (is (= {} (@#'upgrade-checks/get-version-info)))))))


### PR DESCRIPTION
Pursuant to https://www.notion.so/metabase/Track-sign-up-activation-and-churn-data-points-for-OSS-instances-f2b0ca9b96c74c80ac7480f9fdbfe322

Adds a new UUID setting that is included in version check HTTP requests as a query param. This is separate from other existing UUID settings for the sake of anonymity.