### PR TITLE
[GHA] Do not use `buildjet` for timezone tests

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -46,8 +46,8 @@ jobs:
       name: Check types
 
   fe-tests-unit:
-    runs-on: buildjet-2vcpu-ubuntu-2004
-    timeout-minutes: 20
+    runs-on: ubuntu-20.04
+    timeout-minutes: 30
     steps:
     - uses: actions/checkout@v3
     - name: Prepare front-end environment
@@ -61,8 +61,8 @@ jobs:
         flags: front-end
 
   fe-tests-timezones:
-    runs-on: buildjet-2vcpu-ubuntu-2004
-    timeout-minutes: 14
+    runs-on: ubuntu-20.04
+    timeout-minutes: 20
     steps:
     - uses: actions/checkout@v3
     - name: Prepare front-end environment

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -46,8 +46,8 @@ jobs:
       name: Check types
 
   fe-tests-unit:
-    runs-on: ubuntu-20.04
-    timeout-minutes: 30
+    runs-on: buildjet-2vcpu-ubuntu-2004
+    timeout-minutes: 20
     steps:
     - uses: actions/checkout@v3
     - name: Prepare front-end environment
@@ -62,7 +62,7 @@ jobs:
 
   fe-tests-timezones:
     runs-on: ubuntu-20.04
-    timeout-minutes: 20
+    timeout-minutes: 14
     steps:
     - uses: actions/checkout@v3
     - name: Prepare front-end environment


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Removes buildjet runners from FE timezone tests because it's pointless

E2E tests take much longer so this is definitely not a bottleneck.
Even regular FE tests could run on regular runners, but they take around 14 minutes which is comparable to the longest running E2E tests. Decided to leave them running on buildjet for now but we can easily remove that as well.

### Comparison:
|   | Buildjet  | GHA |
|---|---|---|
|  fe-tests-unit | 9m16s  | 14m48s |
|  fe-tests-timezones | 4m20s  | 6m11s |

### Why?
- It's redundant
- We can free up 2vCpu per commit which adds when a lot of people push at the same time