### PR TITLE
Update MB_DB_CONNECTION_TIMEOUT_MS

### DIFF
--- a/docs/configuring-metabase/environment-variables.md
+++ b/docs/configuring-metabase/environment-variables.md
@@ -219,9 +219,9 @@ When set to `false`, Metabase will print migrations needed to be done in the app
 ### `MB_DB_CONNECTION_TIMEOUT_MS`
 
 Type: integer<br>
-Default: `5000`
+Default: `10000`
 
-Timeout in milliseconds for connecting to the application database.
+Timeout in milliseconds for connecting to databases, both Metabase application database and data connections. In case you're connecting via an SSH tunnel and run into a timeout, you might consider increasing this value as the connections via tunnels have more overhead than connections without.
 
 ### `MB_DB_CONNECTION_URI`
 


### PR DESCRIPTION
There are two things that needed some change:
1) default value: it's 10 secs rather than 5
2) this env var applies to both app db and external db's (check https://github.com/metabase/metabase/blob/58ea89ce2bd89d26a097bfd7518d5872c8d4839c/src/metabase/driver/util.clj#L108)