### PR TITLE
condense list rows, add icon for clickiness factor

### DIFF
--- a/frontend/src/metabase/visualizations/components/List/List.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/List/List.styled.tsx
@@ -56,7 +56,7 @@ export const RowActionButtonContainer = styled(CellRoot)`
 `;
 
 export const ListItemContainer = styled.tr<{ disabled?: boolean }>`
-  height: 4rem;
+  height: 2.75rem;
 
   background-color: ${color("bg-white")};
 
@@ -148,4 +148,11 @@ export const TableBody = styled.tbody`
 
 export const Footer = styled(TableFooter)`
   margin-top: 0.5rem;
+`;
+
+export const RowIconContainer = styled.td`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1em 0.25em 1em 1em;
 `;

--- a/frontend/src/metabase/visualizations/components/List/List.tsx
+++ b/frontend/src/metabase/visualizations/components/List/List.tsx
@@ -14,6 +14,8 @@ import Button from "metabase/core/components/Button";
 import CheckBox from "metabase/core/components/CheckBox";
 import ExplicitSize from "metabase/components/ExplicitSize";
 import Modal from "metabase/components/Modal";
+import Icon from "metabase/components/Icon";
+import { color } from "metabase/lib/colors";
 
 import { useConfirmation } from "metabase/hooks/use-confirmation";
 
@@ -49,6 +51,7 @@ import {
   InfoContentContainer,
   RowActionsContainer,
   RowActionButtonContainer,
+  RowIconContainer,
   LIST_ITEM_BORDER_DIVIDER_WIDTH,
 } from "./List.styled";
 
@@ -311,6 +314,9 @@ function List({
             {canSelectForBulkAction && renderBulkSelectionControl(rowIndex)}
             {renderListItemCell(rowIndex, firstColumnIndex)}
             <ListCell.Root>
+              <RowIconContainer>
+                <Icon name="document" color={color("text-light")} />
+              </RowIconContainer>
               <InfoContentContainer>
                 {secondColumnIndex !== null && (
                   <ListCell.Content
@@ -337,6 +343,9 @@ function List({
       return (
         <>
           {canSelectForBulkAction && renderBulkSelectionControl(rowIndex)}
+          <RowIconContainer>
+            <Icon name="document" color={color("text-light")} />
+          </RowIconContainer>
           {left.map(columnIndex => renderListItemCell(rowIndex, columnIndex))}
         </>
       );
@@ -542,7 +551,10 @@ function List({
         <div>
           <Table>
             <TableHeader>
-              <tr>{renderColumnHeaders()}</tr>
+              <tr>
+                <td></td> {/* for icon alignment */}
+                {renderColumnHeaders()}
+              </tr>
             </TableHeader>
             <TableBody>{paginatedRowIndexes.map(renderListItem)}</TableBody>
           </Table>


### PR DESCRIPTION
# Minor list view style tweaks

Couple small things to make default lists feel nicer.
- Add an icon.
- Condense the row height a bit.

### Before:
<img width="925" alt="Screen Shot 2022-10-05 at 11 18 15 AM" src="https://user-images.githubusercontent.com/5248953/194097866-7d95123a-d723-4f15-988c-ab069d2b291a.png">

### After: 
<img width="919" alt="Screen Shot 2022-10-05 at 11 14 52 AM" src="https://user-images.githubusercontent.com/5248953/194097344-df59a7aa-4a37-401f-b236-72ed79ca1a31.png">

