### PR TITLE
Update name input placeholder for new question/model

### DIFF
--- a/frontend/src/metabase/containers/SaveQuestionModal.jsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal.jsx
@@ -99,15 +99,26 @@ export default class SaveQuestionModal extends Component {
 
     const questionType = card.dataset ? "model" : "question";
 
-    const title = this.props.multiStep
-      ? t`First, save your ${questionType}`
-      : t`Save ${questionType}`;
+    const multiStepTitle =
+      questionType === "question"
+        ? t`First, save your question`
+        : t`First, save your model`;
+
+    const singleStepTitle =
+      questionType === "question" ? t`Save question` : t`Save model`;
+
+    const title = this.props.multiStep ? multiStepTitle : singleStepTitle;
 
     const showSaveType =
       !card.id &&
       !!originalCard &&
       !originalCard.dataset &&
       originalCard.can_write;
+
+    const nameInputPlaceholder =
+      questionType === "question"
+        ? t`What is the name of your question?`
+        : t`What is the name of your model?`;
 
     return (
       <ModalContent
@@ -150,7 +161,7 @@ export default class SaveQuestionModal extends Component {
                       autoFocus
                       name="name"
                       title={t`Name`}
-                      placeholder={t`What is the name of your ${questionType}?`}
+                      placeholder={nameInputPlaceholder}
                     />
                     <FormField
                       name="description"

--- a/frontend/src/metabase/containers/SaveQuestionModal.jsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal.jsx
@@ -150,7 +150,7 @@ export default class SaveQuestionModal extends Component {
                       autoFocus
                       name="name"
                       title={t`Name`}
-                      placeholder={t`What is the name of your card?`}
+                      placeholder={t`What is the name of your ${questionType}?`}
                     />
                     <FormField
                       name="description"

--- a/frontend/test/metabase/scenarios/models/create.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/create.cy.spec.js
@@ -18,7 +18,7 @@ describe("scenarios > models > create", () => {
 
     cy.findByText("Save changes").click();
 
-    cy.findByPlaceholderText("What is the name of your card?").type("A name");
+    cy.findByPlaceholderText("What is the name of your model?").type("A name");
 
     cy.findByText("Save").click();
 

--- a/frontend/test/metabase/scenarios/native/reproductions/21597-query-build-card-save-modal.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/reproductions/21597-query-build-card-save-modal.cy.spec.js
@@ -65,7 +65,7 @@ describe("issue 21597", { tags: "@external" }, () => {
     // Try to save the native query
     cy.findByTestId("qb-header-action-panel").findByText("Save").click();
     modal().within(() => {
-      cy.findByPlaceholderText("What is the name of your card?").type("Q");
+      cy.findByPlaceholderText("What is the name of your question?").type("Q");
       cy.findByText("Save").click();
       cy.wait("@saveNativeQuestion");
       cy.findByText(


### PR DESCRIPTION
### How to Test

#### For new Question

1. `+New`
2. `SQL Query`
3. Add something to the query editor
4. `Save`

Name input placeholder should now be "What is the name of your question?" (not …of your card)

Same if you create a visual question, although the name input often is prefilled on open. Delete the prefilled name and you should see the updated placeholder text.

#### For new Model

1. `+New`
2. `Model`
3. `Native query`
3. Add something to the query editor
4. `Save`

Name input placeholder should now be "What is the name of your model?" (not …of your card)

Same if you create a visual model, although the name input often is prefilled on open. Delete the prefilled name and you should see the updated placeholder text.

![image](https://user-images.githubusercontent.com/380816/194105634-6bc5de45-296d-4343-86e4-fbe763f188c0.png)


