### PR TITLE
Label save button only “Save” when model is brand new

### DIFF
--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
@@ -424,7 +424,7 @@ function DatasetEditor(props) {
             key="save"
             disabled={!canSaveChanges}
             actionFn={handleSave}
-            normalText={dataset.id() ? t`Save changes` : t`Save`}
+            normalText={dataset.isSaved() ? t`Save changes` : t`Save`}
             activeText={t`Saving…`}
             failedText={t`Save failed`}
             successText={t`Saved`}

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
@@ -424,7 +424,7 @@ function DatasetEditor(props) {
             key="save"
             disabled={!canSaveChanges}
             actionFn={handleSave}
-            normalText={t`Save changes`}
+            normalText={dataset.id() ? t`Save changes` : t`Save`}
             activeText={t`Saving…`}
             failedText={t`Save failed`}
             successText={t`Saved`}

--- a/frontend/test/metabase/scenarios/models/create.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/create.cy.spec.js
@@ -16,7 +16,7 @@ describe("scenarios > models > create", () => {
 
     cy.get(".ace_editor").should("be.visible").type("select * from ORDERS");
 
-    cy.findByText("Save changes").click();
+    cy.findByText("Save").click();
 
     cy.findByPlaceholderText("What is the name of your card?").type("A name");
 


### PR DESCRIPTION
### How to Test

1. `+ New`
2. Model
3. Choose either mode

Button at the top right should now be labeled "Save" (not "Save changes").

Once model is saved, button should be labeled "Save changes"