### PR TITLE
Resizing Number Visualization adds a decimal even if Minimum number of decimal places is set to 0

### DIFF
--- a/frontend/src/metabase/lib/formatting/numbers.tsx
+++ b/frontend/src/metabase/lib/formatting/numbers.tsx
@@ -14,7 +14,7 @@ interface FormatNumberOptionsType {
   currency?: string;
   currency_in_header?: boolean;
   currency_style?: string;
-  decimals?: string | number;
+  decimals?: number;
   jsx?: any;
   maximumFractionDigits?: number;
   minimumFractionDigits?: number;
@@ -192,10 +192,11 @@ function formatNumberCompact(value: number, options: FormatNumberOptionsType) {
       minimumFractionDigits: 1,
     });
   }
-  return formatNumberCompactWithoutOptions(value);
+
+  return formatNumberCompactWithoutOptions(value, options.decimals);
 }
 
-function formatNumberCompactWithoutOptions(value: number) {
+function formatNumberCompactWithoutOptions(value: number, decimals?: number) {
   if (value === 0) {
     // 0 => 0
     return "0";
@@ -205,7 +206,7 @@ function formatNumberCompactWithoutOptions(value: number) {
   } else {
     // 1 => 1
     // 1000 => 1K
-    return Humanize.compactInteger(Math.round(value), 1);
+    return Humanize.compactInteger(Math.round(value), decimals ?? 1);
   }
 }
 

--- a/frontend/src/metabase/lib/formatting/numbers.tsx
+++ b/frontend/src/metabase/lib/formatting/numbers.tsx
@@ -14,7 +14,7 @@ interface FormatNumberOptionsType {
   currency?: string;
   currency_in_header?: boolean;
   currency_style?: string;
-  decimals?: number;
+  decimals?: string | number;
   jsx?: any;
   maximumFractionDigits?: number;
   minimumFractionDigits?: number;
@@ -193,7 +193,12 @@ function formatNumberCompact(value: number, options: FormatNumberOptionsType) {
     });
   }
 
-  return formatNumberCompactWithoutOptions(value, options.decimals);
+  const decimals =
+    typeof options.decimals === "string"
+      ? parseInt(options.decimals, 10) || 1
+      : options.decimals;
+
+  return formatNumberCompactWithoutOptions(value, decimals);
 }
 
 function formatNumberCompactWithoutOptions(value: number, decimals?: number) {

--- a/frontend/test/metabase/lib/formatting.unit.spec.js
+++ b/frontend/test/metabase/lib/formatting.unit.spec.js
@@ -171,6 +171,18 @@ describe("formatting", () => {
       expect(formatNumber(111.111)).toEqual("111.11");
     });
 
+    it("should format to correct number of decimal places set under 'minimum number of decimal places'", () => {
+      const options = {
+        compact: true,
+        number_style: "decimal",
+        decimals: 0,
+      };
+      expect(formatNumber(500000, options)).toEqual("500k");
+      expect(formatNumber(500000, { ...options, decimals: 1 })).toEqual(
+        "500.0k",
+      );
+    });
+
     describe("number_style = currency", () => {
       it("should handle positive currency", () => {
         expect(


### PR DESCRIPTION
###### Before submitting the PR, please make sure you do the following

- [ ] If you're attempting to fix a translation issue, please submit your changes to our [POEditor project](https://poeditor.com/join/project/ynjQmwSsGh) instead of opening a PR.

### Tests

- [X] Run the frontend and Cypress end-to-end tests with `yarn lint && yarn test`)
- [ ] If there are changes to the backend codebase, run the backend tests with `clojure -X:dev:test`
- [X] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
      (unless it's a tiny documentation change).

#### Screenshots
Zero and one decimal places were defined for the cards respectively.
<img width="539" alt="Screenshot 2022-10-06 at 13 43 59" src="https://user-images.githubusercontent.com/21334508/194293798-94afdae3-dcb3-41f6-ab94-0a0ec477831d.png">

