### PR TITLE
Ensure static visualizations with multiple cards are rendered

### DIFF
--- a/frontend/test/metabase/scenarios/sharing/reproductions/21559-subscription-bar-sent-as-scalar.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/reproductions/21559-subscription-bar-sent-as-scalar.cy.spec.js
@@ -31,7 +31,7 @@ const q2Details = {
   display: "scalar",
 };
 
-describe.skip("issue 21559", { tags: "@external" }, () => {
+describe("issue 21559", { tags: "@external" }, () => {
   beforeEach(() => {
     cy.intercept("POST", "/api/pulse/test").as("emailSent");
     restore();

--- a/src/metabase/pulse/render.clj
+++ b/src/metabase/pulse/render.clj
@@ -86,6 +86,11 @@
              (= @col-sample-count @row-sample-count 1))
         (chart-type :scalar "result has one row and one column")
 
+        (and (some? maybe-dashcard)
+             (pos? (count (dashboard-card/dashcard->multi-cards maybe-dashcard)))
+             (not (#{:combo} display-type)))
+        (chart-type :multiple "result has multiple card semantics, a multiple chart")
+
         (#{:scalar
            :smartscalar
            :line
@@ -99,11 +104,6 @@
            :table
            :waterfall} display-type)
         (chart-type display-type "display-type is %s" display-type)
-
-        (and (some? maybe-dashcard)
-             (> (count (dashboard-card/dashcard->multi-cards maybe-dashcard)) 0)
-             (not (#{:combo} display-type)))
-        (chart-type :multiple "result has multiple card semantics, a multiple chart")
 
         (= display-type :pie)
         (chart-type :categorical/donut "result has two cols (%s and %s (number))" (col-description @col-1) (col-description @col-2))

--- a/src/metabase/pulse/render.clj
+++ b/src/metabase/pulse/render.clj
@@ -81,15 +81,15 @@
         (#{:pin_map :state :country} display-type)
         (chart-type nil "display-type is %s" display-type)
 
-        ;; for scalar/smartscalar, the display-type might actually be :line, so we can't have line above
-        (and (not (contains? #{:progress :gauge} display-type))
-             (= @col-sample-count @row-sample-count 1))
-        (chart-type :scalar "result has one row and one column")
-
         (and (some? maybe-dashcard)
              (pos? (count (dashboard-card/dashcard->multi-cards maybe-dashcard)))
              (not (#{:combo} display-type)))
         (chart-type :multiple "result has multiple card semantics, a multiple chart")
+
+        ;; for scalar/smartscalar, the display-type might actually be :line, so we can't have line above
+        (and (not (contains? #{:progress :gauge} display-type))
+             (= @col-sample-count @row-sample-count 1))
+        (chart-type :scalar "result has one row and one column")
 
         (#{:scalar
            :smartscalar

--- a/src/metabase/pulse/render/common.clj
+++ b/src/metabase/pulse/render/common.clj
@@ -121,4 +121,6 @@
   - Removes any rows that have a nil value for the `x-axis-fn` OR `y-axis-fn`
   - Normalizes bigints and bigdecs to ordinary sizes"
   [x-axis-fn y-axis-fn rows]
-  (map coerce-bignum-to-int (filter (every-pred x-axis-fn y-axis-fn) rows)))
+  (->> rows
+       (filter (every-pred x-axis-fn y-axis-fn))
+       (map coerce-bignum-to-int)))

--- a/src/metabase/pulse/render/js_svg.clj
+++ b/src/metabase/pulse/render/js_svg.clj
@@ -134,12 +134,12 @@
   Rows should be tuples of [datetime numeric-value]. Labels is a
   map of {:left \"left-label\" :botton \"bottom-label\"}. Returns a byte array of a png file."
   [series settings]
-  (let [svg-string (.asString (js/execute-fn-name (context)
-                                                  "combo_chart"
-                                                  (json/generate-string series)
-                                                  (json/generate-string settings)
-                                                  (json/generate-string (:colors settings))))]
-    (svg-string->bytes svg-string)))
+  (svg-string->bytes
+   (.asString (js/execute-fn-name (context)
+                                  "combo_chart"
+                                  (json/generate-string series)
+                                  (json/generate-string settings)
+                                  (json/generate-string (:colors settings))))))
 
 (defn row-chart
   "Clojure entrypoint to render a row chart."

--- a/test/metabase/pulse/render_test.clj
+++ b/test/metabase/pulse/render_test.clj
@@ -118,6 +118,18 @@
                                              {:cols [{:base_type :type/Temporal}
                                                      {:base_type :type/Number}]
                                               :rows [[#t "2020" 2]
+                                                     [#t "2021" 3]]}))))
+        (is (= :multiple
+           (mt/with-temp* [Card                [card1 {:display :line}]
+                           Card                [card2 {:display :funnel}]
+                           Dashboard           [dashboard]
+                           DashboardCard       [dc1 {:dashboard_id (u/the-id dashboard) :card_id (u/the-id card1)}]
+                           DashboardCardSeries [_   {:dashboardcard_id (u/the-id dc1) :card_id (u/the-id card2)}]]
+             (render/detect-pulse-chart-type card1
+                                             dc1
+                                             {:cols [{:base_type :type/Temporal}
+                                                     {:base_type :type/Number}]
+                                              :rows [[#t "2020" 2]
                                                      [#t "2021" 3]]}))))))
 
 (deftest make-description-if-needed-test


### PR DESCRIPTION
[Fixes #21559]

Given this card in a dashboard:

![image](https://user-images.githubusercontent.com/784417/194299768-a132dbf3-7864-44d6-8673-582e707b8fc7.png)

Slack alerts used to look like this:

![image](https://user-images.githubusercontent.com/784417/194299828-1dbdf1c0-fdf1-46ef-ba1d-ef321d05afd0.png)


and now they look like this:

![image](https://user-images.githubusercontent.com/784417/194299879-482c7a25-a318-4b3d-85da-fd44fbc16b1a.png)


:arrow_up: this was due to an order bug in `detect-pulse-chart-type`.

A thornier issue is that when multiple scalar cards are combined they should result in a bar chart (see screenshots in [the below comment](https://github.com/metabase/metabase/pull/25811#issuecomment-1277599092)), which had to be fixed by creating the `render-multiple-scalars` function you see.

