### PR TITLE
don't show object detail header in a data app context

### DIFF
--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
@@ -107,6 +107,7 @@ export interface ObjectDetailProps {
   canZoom: boolean;
   canZoomPreviousRow: boolean;
   canZoomNextRow: boolean;
+  isDataApp?: boolean;
   showActions?: boolean;
   showRelations?: boolean;
   onVisualizationClick: OnVisualizationClickType;
@@ -131,6 +132,7 @@ export function ObjectDetailFn({
   canZoom,
   canZoomPreviousRow,
   canZoomNextRow,
+  isDataApp = false,
   showActions = true,
   showRelations = true,
   onVisualizationClick,
@@ -249,17 +251,19 @@ export function ObjectDetailFn({
         </ErrorWrapper>
       ) : (
         <div className="ObjectDetail" data-testid="object-detail">
-          <ObjectDetailHeader
-            canZoom={canZoom && (canZoomNextRow || canZoomPreviousRow)}
-            objectName={objectName}
-            objectId={displayId}
-            canZoomPreviousRow={canZoomPreviousRow}
-            canZoomNextRow={canZoomNextRow}
-            showActions={showActions}
-            viewPreviousObjectDetail={viewPreviousObjectDetail}
-            viewNextObjectDetail={viewNextObjectDetail}
-            closeObjectDetail={closeObjectDetail}
-          />
+          {!isDataApp && (
+            <ObjectDetailHeader
+              canZoom={canZoom && (canZoomNextRow || canZoomPreviousRow)}
+              objectName={objectName}
+              objectId={displayId}
+              canZoomPreviousRow={canZoomPreviousRow}
+              canZoomNextRow={canZoomNextRow}
+              showActions={showActions}
+              viewPreviousObjectDetail={viewPreviousObjectDetail}
+              viewNextObjectDetail={viewNextObjectDetail}
+              closeObjectDetail={closeObjectDetail}
+            />
+          )}
           <ObjectDetailBodyWrapper>
             <ObjectDetailBody
               data={data}
@@ -304,6 +308,7 @@ function ObjectDetailWrapper({
         showActions={false}
         showRelations={false}
         closeObjectDetail={closeObjectDetail}
+        isDataApp={isDataApp}
       />
     );
   }


### PR DESCRIPTION
Small piece of working to improve hierarchy on app detail pages. By removing the title from the card in the context of a data app, the page title will be the main read. Once that can include parameters it'll allow for a clear read for the "thing I'm looking at" without redundant or distracting info.

Before:
<img width="1261" alt="Screen Shot 2022-10-06 at 8 48 15 AM" src="https://user-images.githubusercontent.com/5248953/194317252-c00b232f-f81e-4a01-aa2a-f7109364a6d1.png">

After:
<img width="1261" alt="Screen Shot 2022-10-06 at 8 48 02 AM" src="https://user-images.githubusercontent.com/5248953/194317233-42a7e7f6-4909-470e-937c-c98aaf0d510a.png">

Still shows the header as expected on row details:
<img width="1261" alt="Screen Shot 2022-10-06 at 8 48 33 AM" src="https://user-images.githubusercontent.com/5248953/194317263-fa59cd91-1748-41d3-a6b0-bac1e8f42406.png">

