### PR TITLE
docs - update full-app embedding

### DIFF
--- a/docs/embedding/full-app-embedding.md
+++ b/docs/embedding/full-app-embedding.md
@@ -39,10 +39,10 @@ If you're dealing with a [multi-tenant](https://www.metabase.com/learn/customer-
    - [Add your license token](../configuring-metabase/environment-variables.md#mb_premium_embedding_token).
    - [Embed Metabase in a different domain](#embedding-metabase-in-a-different-domain).
    - [Secure your full-app embed](#securing-full-app-embeds).
-3. Optional: Set up [`postMessage` methods](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) in your JavaScript to:
+3. Optional: Enable communication to and from the embedded Metabase using[`postMessage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage):
    - [Fill an entire iframe with an embedded Metabase page](#filling-an-entire-iframe-with-an-embedded-metabase-page).
    - [Fit an iframe to a Metabase page with a fixed size](#fitting-an-iframe-to-a-metabase-page-with-a-fixed-size).
-   - [Get a specific embedding URL](#getting-a-specific-embedding-url).
+   - [Pass an embedding URL between Metabase and your app](#passing-an-embedding-url-between-metabase-and-your-app).
 4. Optional: Set parameters to [show or hide Metabase UI components](#showing-or-hiding-metabase-ui-components).
 
 Once you're ready to roll out your full-app embed, make sure that people **allow** browser cookies from Metabase, otherwise they won't be able to log in.
@@ -123,7 +123,7 @@ If you're using [JWT](../people-and-groups/authenticating-with-jwt.md) for SSO, 
 
 ## Filling an entire iframe with an embedded Metabase page
 
-To make an embedded Metabase page fill up the entire iframe (e.g., a question page), use [postMessage()](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) to send a "frame" message from Metabase:
+To make an embedded Metabase page fill up the entire iframe (e.g., a question page), use [postMessage](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) to send a "frame" message _from_ Metabase to your app:
 
 ```
 { “metabase”: { “type”: “frame”, “frame”: { “mode”: “normal” }}}
@@ -131,21 +131,21 @@ To make an embedded Metabase page fill up the entire iframe (e.g., a question pa
 
 ## Fitting an iframe to a Metabase page with a fixed size
 
-To specify the size of an iframe so that it matches an embedded Metabase page (e.g., a dashboard page), use [postMessage()](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) to send a "frame" message from Metabase:
+To specify the size of an iframe so that it matches an embedded Metabase page (e.g., a dashboard page), use [postMessage()](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) to send a "frame" message _from_ Metabase to your app:
 
 ```
 { “metabase”: { “type”: “frame”, “frame”: { “mode”: “fit”, height: HEIGHT_IN_PIXELS }}}
 ```
 
-## Getting a specific embedding URL
+## Passing an embedding URL between Metabase and your app
 
-To make a request for an particular embedding URL (e.g., for deep linking), use [postMessage()](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) to send a "location" message _from_ your embedded Metabase:
+To make a request for an particular embedding URL (e.g., for deep linking), you can use [postMessage](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) to send a "location" message _from_ your embedded Metabase to your app:
 
 ```
 { “metabase”: { “type”: “location”, “location”: LOCATION_OBJECT }}
 ```
 
-Or, send a "location" message _to_ your embedded Metabase:
+Or, send a "location" message _to_ your embedded Metabase from your app:
 
 ```
 { “metabase”: { “type”: “location”, “location”: LOCATION_OBJECT_OR_URL }}

--- a/docs/embedding/full-app-embedding.md
+++ b/docs/embedding/full-app-embedding.md
@@ -139,7 +139,7 @@ To specify the size of an iframe so that it matches an embedded Metabase page (e
 
 ## Passing an embedding URL between Metabase and your app
 
-To make a request for an particular embedding URL (e.g., for deep linking), you can use [postMessage](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) to send a "location" message _from_ your embedded Metabase to your app:
+To make a request for a particular embedding URL (e.g., for deep linking), you can use [postMessage](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) to send a "location" message _from_ your embedded Metabase to your app:
 
 ```
 { “metabase”: { “type”: “location”, “location”: LOCATION_OBJECT }}

--- a/docs/embedding/full-app-embedding.md
+++ b/docs/embedding/full-app-embedding.md
@@ -39,7 +39,7 @@ If you're dealing with a [multi-tenant](https://www.metabase.com/learn/customer-
    - [Add your license token](../configuring-metabase/environment-variables.md#mb_premium_embedding_token).
    - [Embed Metabase in a different domain](#embedding-metabase-in-a-different-domain).
    - [Secure your full-app embed](#securing-full-app-embeds).
-3. Optional: Enable communication to and from the embedded Metabase using[`postMessage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage):
+3. Optional: Enable communication to and from the embedded Metabase using [`postMessage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage):
    - [Fill an entire iframe with an embedded Metabase page](#filling-an-entire-iframe-with-an-embedded-metabase-page).
    - [Fit an iframe to a Metabase page with a fixed size](#fitting-an-iframe-to-a-metabase-page-with-a-fixed-size).
    - [Pass an embedding URL between Metabase and your app](#passing-an-embedding-url-between-metabase-and-your-app).

--- a/docs/embedding/full-app-embedding.md
+++ b/docs/embedding/full-app-embedding.md
@@ -131,7 +131,7 @@ To make an embedded Metabase page fill up the entire iframe (e.g., a question pa
 
 ## Fitting an iframe to a Metabase page with a fixed size
 
-To specify the size of an iframe so that it matches an embedded Metabase page (e.g., a dashboard page), use [postMessage()](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) to send a "frame" message _from_ Metabase to your app:
+To specify the size of an iframe so that it matches an embedded Metabase page (e.g., a dashboard page), use [postMessage](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) to send a "frame" message _from_ Metabase to your app:
 
 ```
 { “metabase”: { “type”: “frame”, “frame”: { “mode”: “fit”, height: HEIGHT_IN_PIXELS }}}


### PR DESCRIPTION
Updating based on customer feedback: they pointed out that the old doc description (i.e., communication between apps) was more accurate.