### PR TITLE
Do not offer to add model to dashboard once it's created and saved

### DIFF
--- a/frontend/src/metabase/query_builder/components/QueryModals.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryModals.jsx
@@ -83,12 +83,16 @@ class QueryModals extends React.Component {
           }}
           onCreate={async card => {
             await this.props.onCreate(card);
-            onOpenModal(MODAL_TYPES.SAVED);
+            if (question.isDataset()) {
+              onCloseModal();
+            } else {
+              onOpenModal(MODAL_TYPES.SAVED);
+            }
           }}
           onClose={onCloseModal}
         />
       </Modal>
-    ) : modal === MODAL_TYPES.SAVED && !question.isDataset() ? (
+    ) : modal === MODAL_TYPES.SAVED ? (
       <Modal small onClose={onCloseModal}>
         <QuestionSavedModal
           onClose={onCloseModal}

--- a/frontend/src/metabase/query_builder/components/QueryModals.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryModals.jsx
@@ -88,7 +88,7 @@ class QueryModals extends React.Component {
           onClose={onCloseModal}
         />
       </Modal>
-    ) : modal === MODAL_TYPES.SAVED ? (
+    ) : modal === MODAL_TYPES.SAVED && !question.isDataset() ? (
       <Modal small onClose={onCloseModal}>
         <QuestionSavedModal
           onClose={onCloseModal}

--- a/frontend/test/metabase/scenarios/models/create.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/create.cy.spec.js
@@ -22,8 +22,6 @@ describe("scenarios > models > create", () => {
 
     cy.findByText("Save").click();
 
-    cy.findByText("Not now").click();
-
     cy.findByText("Saved");
   });
 });


### PR DESCRIPTION
### How to Test

1. `+ New`
2. `Model`
3. Either notebook editor or native query
4. `Save`
5. Add a name 
6. `Save`

You should no longer see a model offering to add modal to dashboard.