### PR TITLE
Fix gauge chart overflow

### DIFF
--- a/frontend/src/metabase/static-viz/components/Gauge/GaugeContainer.tsx
+++ b/frontend/src/metabase/static-viz/components/Gauge/GaugeContainer.tsx
@@ -21,6 +21,7 @@ import {
   calculateRelativeValueAngle,
   calculateSegmentLabelPosition,
   calculateSegmentLabelTextAnchor,
+  gaugeSorter,
 } from "./utils";
 
 import type { Card, Data, GaugeLabelData, Position } from "./types";
@@ -41,7 +42,7 @@ export default function GaugeContainer({
   const columnSettings =
     settings.column_settings &&
     populateDefaultColumnSettings(Object.values(settings.column_settings)[0]);
-  const segments = settings["gauge.segments"];
+  const segments = [...settings["gauge.segments"]].sort(gaugeSorter);
 
   const segmentMinValue = segments[0].min;
   const segmentMaxValue = segments[segments.length - 1].max;


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/24759
Fix the bug created by https://github.com/metabase/metabase/pull/25651 which is reported in https://metaboat.slack.com/archives/C010L1Z4F9S/p1665414924045689

The problem is that the code used to assume `gauge.segments` is sorted, but that's not the case. See [this question](https://stats.metabase.com/question/3921) as an example. And here's the result
![image](https://user-images.githubusercontent.com/1937582/194909743-21149d25-e11d-41f2-9789-e960a16fe68d.png)

#### After the fix (via `/_internal/static-viz`)
![image](https://user-images.githubusercontent.com/1937582/194910188-b96d5c79-37fe-4541-9b89-1ec96d290fe7.png)


#### How to test
Create a gauge question with this visualization settings.
```json
{
  "gauge.segments": [
    {
      "min": -100,
      "max": 0,
      "color": "#ED6E6E",
      "label": "Bad"
    },
    {
      "min": 25,
      "max": 50,
      "color": "#F9CF48",
      "label": "Good"
    },
    {
      "min": 50,
      "max": 70,
      "color": "#84BB4C",
      "label": "Excellent"
    },
    {
      "min": 70,
      "max": 100,
      "color": "#509EE3",
      "label": "World-class"
    },
    {
      "min": 0,
      "max": 25,
      "color": "#F2A86F",
      "label": "Fine"
    }
  ]
}
```

The value could be anything from -100 to 100