### PR TITLE
Do not show query / metadata options until dataset is saved

### DIFF
--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
@@ -400,6 +400,13 @@ function DatasetEditor(props) {
     onFieldMetadataChange,
   });
 
+  const editorTabOptions = dataset.isSaved()
+    ? [
+        { id: "query", name: t`Query`, icon: "notebook" },
+        { id: "metadata", name: t`Metadata`, icon: "label" },
+      ]
+    : [];
+
   return (
     <>
       <DatasetEditBar
@@ -408,10 +415,7 @@ function DatasetEditor(props) {
           <EditorTabs
             currentTab={datasetEditorTab}
             onChange={onChangeEditorTab}
-            options={[
-              { id: "query", name: t`Query`, icon: "notebook" },
-              { id: "metadata", name: t`Metadata`, icon: "label" },
-            ]}
+            options={editorTabOptions}
           />
         }
         buttons={[


### PR DESCRIPTION
tl;dr: This PR makes model-without-question-creation pages no longer display the `Query` and `Metadata` buttons in the top bar.

Please also look at https://github.com/metabase/metabase/pull/25877, another solution.

This is kind of a product question PR.

What should we do with the `Query` and `Metadata` buttons until a model is saved?

When a user decides to create a brand new model, they will land on a query page.

Now, what about metadata?
Until we have some firm query, a metadata makes little sense, correct?

Even if there is a coherent query, maybe the metadata will be changed before a save.
Does it make sense to even offer to edit metadata before a model is saved?
Especially considering that after a save we will offer the button to start editing metadata.

### How to Test

1. `+ New`
2. `Model`
3. `Native Query`

You won't see either the `Query` or the `Metadata` buttons in the top nav for models.

After saving the model, you will see both.

