### PR TITLE
#25543 Repro: Collection list fails to display if there's an invalid parameter in a question

### DIFF
--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -199,6 +199,17 @@ describe("scenarios > collection defaults", () => {
       cy.signInAsAdmin();
     });
 
+    it.skip("should show list of collection items even if one question has invalid parameters (metabase#25543)", () => {
+      const questionDetails = {
+        native: { query: "select 1 --[[]]", "template-tags": {} },
+      };
+
+      cy.createNativeQuestion(questionDetails);
+
+      visitRootCollection();
+      cy.findByText("Orders in a dashboard");
+    });
+
     it("should be able to drag an item to the root collection (metabase#16498)", () => {
       moveItemToCollection("Orders", "First collection");
 


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #25543 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/collections/collections.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/194950926-48a6508a-73c1-4fee-95ca-57e872e50caa.png)

