### PR TITLE
new setting API for SAML and validation when setting `saml-configured`

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sso/api/sso.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/api/sso.clj
@@ -1,18 +1,21 @@
 (ns metabase-enterprise.sso.api.sso
   "`/auth/sso` Routes.
 
-  Implements the SSO routes needed for SAML and JWT. This namespace primarily provides hooks for those two backends so
-  we can have a uniform interface both via the API and code"
+  Implements the SSO routes needed for SAML and JWT. This namespace provides hooks for those two backends so
+  we can have a uniform interface both via the API and code, as well as APIs for updating SSO settings."
   (:require [clojure.tools.logging :as log]
             [compojure.core :refer [GET POST]]
             [metabase-enterprise.sso.api.interface :as sso.i]
             metabase-enterprise.sso.integrations.jwt
             metabase-enterprise.sso.integrations.saml
             [metabase.api.common :as api]
+            [metabase.api.common.validation :as validation]
+            [metabase.models.setting :as setting]
             [metabase.public-settings.premium-features :as premium-features]
             [metabase.util :as u]
             [metabase.util.i18n :refer [trs tru]]
-            [stencil.core :as stencil]))
+            [stencil.core :as stencil]
+            [toucan.db :as db]))
 
 ;; load the SSO integrations so their implementations for the multimethods below are available.
 (comment metabase-enterprise.sso.integrations.jwt/keep-me
@@ -52,5 +55,14 @@
     (catch Throwable e
       (log/error e (trs "Error logging in"))
       (sso-error-page e))))
+
+(api/defendpoint PUT "/saml/settings"
+  "Update SAML settings. You must be a superuser or have settings permissions to call this API."
+  [:as {{:keys [saml-enabled] :as new-settings} :body}]
+  (validation/check-has-application-permission :setting)
+  (let [settings (dissoc new-settings :saml-enabled)]
+    (db/transaction
+      (setting/set-many! settings)
+      (setting/set-value-of-type! :boolean :saml-enabled saml-enabled))))
 
 (api/define-routes)

--- a/enterprise/backend/src/metabase_enterprise/sso/api/sso.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/api/sso.clj
@@ -60,9 +60,13 @@
   "Update SAML settings. You must be a superuser or have settings permissions to call this API."
   [:as {{:keys [saml-enabled] :as new-settings} :body}]
   (validation/check-has-application-permission :setting)
-  (let [settings (dissoc new-settings :saml-enabled)]
-    (db/transaction
+  (try
+   (let [settings (dissoc new-settings :saml-enabled)]
+     (db/transaction
       (setting/set-many! settings)
-      (setting/set-value-of-type! :boolean :saml-enabled saml-enabled))))
+      (setting/set-value-of-type! :boolean :saml-enabled saml-enabled)))
+   (catch clojure.lang.ExceptionInfo e
+     (log/error e (trs "Error updating SAML settings"))
+     (throw (ex-info (ex-message e) (assoc (ex-data e) :status-code 400))))))
 
 (api/define-routes)

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
@@ -126,10 +126,10 @@
                             :credential (sp-cert-keystore-details)})
             relay-state  (saml/str->base64 redirect-url)]
         (saml/idp-redirect-response saml-request idp-url relay-state))
-    (catch Throwable e
-      (let [msg (trs "Error generating SAML request")]
-        (log/error e msg)
-        (throw (ex-info msg {:status-code 500} e)))))))
+     (catch Throwable e
+       (let [msg (trs "Error generating SAML request")]
+         (log/error e msg)
+         (throw (ex-info msg {:status-code 500} e)))))))
 
 (defn- validate-response [response]
   (let [idp-cert (or (sso-settings/saml-identity-provider-certificate)

--- a/enterprise/backend/test/metabase_enterprise/sso/api/sso_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/api/sso_test.clj
@@ -1,7 +1,9 @@
 (ns metabase-enterprise.sso.api.sso-test
   (:require [clojure.test :refer :all]
+            [metabase-enterprise.sso.integrations.saml-test :as saml-test]
+            [metabase-enterprise.sso.integrations.sso-settings :as sso-settings]
             [metabase.test :as mt]
-            [metabase-enterprise.sso.integrations.saml-test :as saml-test]))
+            [metabase.test.data.users :as test.users]))
 
 (def ^:private default-idp-uri  "http://test.idp.metabase.com")
 (def ^:private default-idp-cert (slurp "test_resources/sso/auth0-public-idp.cert"))
@@ -10,9 +12,23 @@
   (testing "PUT /auth/sso/saml/settings"
     (testing "Valid SAML settings can be saved via an API call"
       (mt/with-temporary-setting-values [saml-identity-provider-uri nil
-                                         saml-identity-provider-certificate nil]
-        (saml-test/client :put 200 "/auth/sso/saml/settings"
-                          {:body {:identity-provider-uri         default-idp-uri
-                                  :identity-provider-certificate default-idp-cert}})))))
+                                         saml-identity-provider-certificate nil
+                                         saml-enabled false]
+        (saml-test/client (test.users/username->token :crowberto) :put 200 "/auth/sso/saml/settings" {:saml-identity-provider-certificate default-idp-cert
+                                                                                                      :saml-identity-provider-uri         default-idp-uri
+                                                                                                      :saml-enabled                       true})
+        (is (= default-idp-uri  (sso-settings/saml-identity-provider-uri)))
+        (is (= default-idp-cert (sso-settings/saml-identity-provider-certificate)))
+        (is (= true             (sso-settings/saml-enabled)))))
 
-
+    (testing "Invalid SAML settings cannot be saved via an API call"
+      (mt/with-temporary-setting-values [saml-identity-provider-uri nil
+                                         saml-identity-provider-certificate nil
+                                         saml-enabled false]
+        (saml-test/client (test.users/username->token :crowberto)
+                          :put 400 "/auth/sso/saml/settings" {:saml-identity-provider-certificate "invalid cert"
+                                                              :saml-identity-provider-uri         default-idp-uri
+                                                              :saml-enabled                       true})
+        (is (= nil   (sso-settings/saml-identity-provider-uri)))
+        (is (= nil   (sso-settings/saml-identity-provider-certificate)))
+        (is (= false (sso-settings/saml-enabled)))))))

--- a/enterprise/backend/test/metabase_enterprise/sso/api/sso_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/api/sso_test.clj
@@ -1,0 +1,18 @@
+(ns metabase-enterprise.sso.api.sso-test
+  (:require [clojure.test :refer :all]
+            [metabase.test :as mt]
+            [metabase-enterprise.sso.integrations.saml-test :as saml-test]))
+
+(def ^:private default-idp-uri  "http://test.idp.metabase.com")
+(def ^:private default-idp-cert (slurp "test_resources/sso/auth0-public-idp.cert"))
+
+(deftest saml-settings-test
+  (testing "PUT /auth/sso/saml/settings"
+    (testing "Valid SAML settings can be saved via an API call"
+      (mt/with-temporary-setting-values [saml-identity-provider-uri nil
+                                         saml-identity-provider-certificate nil]
+        (saml-test/client :put 200 "/auth/sso/saml/settings"
+                          {:body {:identity-provider-uri         default-idp-uri
+                                  :identity-provider-certificate default-idp-cert}})))))
+
+

--- a/enterprise/backend/test/metabase_enterprise/sso/api/sso_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/api/sso_test.clj
@@ -1,12 +1,13 @@
 (ns metabase-enterprise.sso.api.sso-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.string :as str]
+            [clojure.test :refer :all]
             [metabase-enterprise.sso.integrations.saml-test :as saml-test]
             [metabase-enterprise.sso.integrations.sso-settings :as sso-settings]
             [metabase.test :as mt]
             [metabase.test.data.users :as test.users]))
 
 (def ^:private default-idp-uri  "http://test.idp.metabase.com")
-(def ^:private default-idp-cert (slurp "test_resources/sso/auth0-public-idp.cert"))
+(def ^:private default-idp-cert (str/trim (slurp "test_resources/sso/auth0-public-idp.cert")))
 
 (deftest saml-settings-test
   (testing "PUT /auth/sso/saml/settings"

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
@@ -102,22 +102,22 @@
 
   (testing "SSO requests fail if SAML is enabled but hasn't been configured"
     (with-valid-premium-features-token
-      (mt/with-temporary-setting-values [saml-enabled               true
-                                         saml-identity-provider-uri nil]
-        (is (some? (client :get 400 "/auth/sso"))))))
+      (mt/with-temporary-setting-values   [saml-identity-provider-uri nil]
+        (mt/with-temporary-raw-setting-values [saml-enabled true]
+          (is (some? (client :get 400 "/auth/sso")))))))
 
   (testing "The IDP provider certificate must also be included for SSO to be configured"
     (with-valid-premium-features-token
-      (mt/with-temporary-setting-values [saml-enabled                       true
-                                         saml-identity-provider-uri         default-idp-uri
+      (mt/with-temporary-setting-values [saml-identity-provider-uri         default-idp-uri
                                          saml-identity-provider-certificate nil]
-        (is (some? (client :get 400 "/auth/sso")))))))
+        (mt/with-temporary-raw-setting-values [saml-enabled true]
+          (is (some? (client :get 400 "/auth/sso"))))))))
 
 (defn- call-with-default-saml-config [f]
-  (mt/with-temporary-setting-values [saml-enabled                       true
-                                     saml-identity-provider-uri         default-idp-uri
+  (mt/with-temporary-setting-values [saml-identity-provider-uri         default-idp-uri
                                      saml-identity-provider-certificate default-idp-cert]
-    (f)))
+    (mt/with-temporary-raw-setting-values [saml-enabled true]
+      (f))))
 
 (defn call-with-login-attributes-cleared!
   "If login_attributes remain after these tests run, depending on the order that the tests run, lots of tests will

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
@@ -103,20 +103,20 @@
   (testing "SSO requests fail if SAML is enabled but hasn't been configured"
     (with-valid-premium-features-token
       (mt/with-temporary-setting-values   [saml-identity-provider-uri nil]
-        (mt/with-temporary-raw-setting-values [saml-enabled true]
+        (mt/with-temporary-raw-setting-values [saml-enabled "true"]
           (is (some? (client :get 400 "/auth/sso")))))))
 
   (testing "The IDP provider certificate must also be included for SSO to be configured"
     (with-valid-premium-features-token
       (mt/with-temporary-setting-values [saml-identity-provider-uri         default-idp-uri
                                          saml-identity-provider-certificate nil]
-        (mt/with-temporary-raw-setting-values [saml-enabled true]
+        (mt/with-temporary-raw-setting-values [saml-enabled "true"]
           (is (some? (client :get 400 "/auth/sso"))))))))
 
 (defn- call-with-default-saml-config [f]
   (mt/with-temporary-setting-values [saml-identity-provider-uri         default-idp-uri
                                      saml-identity-provider-certificate default-idp-cert]
-    (mt/with-temporary-raw-setting-values [saml-enabled true]
+    (mt/with-temporary-raw-setting-values [saml-enabled "true"]
       (f))))
 
 (defn call-with-login-attributes-cleared!


### PR DESCRIPTION
This PR includes backend changes for updating the SAML settings form UX similar to what has already been done for Google Auth and LDAP per [this project](https://www.notion.so/metabase/Clean-up-LDAP-and-Google-auth-set-up-experience-7499d138cf9845f9ab0b8fa459c1a7e1).

Essentially:
* Updating SAML settings should go through a new, dedicated API rather than the generic settings API
* The `saml-enabled` setting can be changed independently, but it requires the basic settings (provider URI and certificate) to already be set and valid, and will throw if this is not the case.

My big unknown here is about code organization. There's also an `/api/sso` enterprise API namespace which I've put this new API under temporarily but I'm not sure if this is the best fit since the other code here is related to the actual SSO implementations. But I'm also not sure where a new namespace would fit; open to suggestions here.