### PR TITLE
Hide ID filters in data app pages

### DIFF
--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
@@ -25,6 +25,10 @@ import { updateParametersWidgetStickiness } from "./stickyParameters";
 
 const SCROLL_THROTTLE_INTERVAL = 1000 / 24;
 
+function getVisibleParameters(parameters) {
+  return parameters.filter(parameter => !parameter.hidden);
+}
+
 // NOTE: move DashboardControls HoC to container
 
 class Dashboard extends Component {
@@ -102,9 +106,10 @@ class Dashboard extends Component {
     this.parametersAndCardsContainerRef = React.createRef();
   }
 
-  static getDerivedStateFromProps(props, state) {
-    return props.parameters.length !== state.parametersListLength
-      ? { parametersListLength: props.parameters.length }
+  static getDerivedStateFromProps({ parameters }, { parametersListLength }) {
+    const visibleParameters = getVisibleParameters(parameters);
+    return visibleParameters.length !== parametersListLength
+      ? { parametersListLength: visibleParameters.length }
       : null;
   }
 
@@ -231,10 +236,14 @@ class Dashboard extends Component {
 
     const shouldRenderAsNightMode = isNightMode && isFullscreen;
     const dashboardHasCards = dashboard => dashboard.ordered_cards.length > 0;
+    const visibleParameters = getVisibleParameters(parameters);
 
     const parametersWidget = (
       <SyncedParametersList
-        parameters={getValuePopulatedParameters(parameters, parameterValues)}
+        parameters={getValuePopulatedParameters(
+          visibleParameters,
+          parameterValues,
+        )}
         editingParameter={editingParameter}
         dashboard={dashboard}
         isFullscreen={isFullscreen}
@@ -247,10 +256,10 @@ class Dashboard extends Component {
     );
 
     const shouldRenderParametersWidgetInViewMode =
-      !isEditing && !isFullscreen && parameters.length > 0;
+      !isEditing && !isFullscreen && visibleParameters.length > 0;
 
     const shouldRenderParametersWidgetInEditMode =
-      isEditing && parameters.length > 0;
+      isEditing && visibleParameters.length > 0;
 
     const cardsContainerShouldHaveMarginTop =
       !shouldRenderParametersWidgetInViewMode &&

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
@@ -8,6 +8,7 @@ import { getMainElement } from "metabase/lib/dom";
 import DashboardHeader from "metabase/dashboard/containers/DashboardHeader";
 import SyncedParametersList from "metabase/parameters/components/SyncedParametersList/SyncedParametersList";
 import { getValuePopulatedParameters } from "metabase/parameters/utils/parameter-values";
+import { getVisibleParameters } from "metabase/parameters/utils/ui";
 import DashboardControls from "../../hoc/DashboardControls";
 import { DashboardSidebars } from "../DashboardSidebars";
 import DashboardGrid from "../DashboardGrid";
@@ -24,10 +25,6 @@ import DashboardEmptyState from "./DashboardEmptyState/DashboardEmptyState";
 import { updateParametersWidgetStickiness } from "./stickyParameters";
 
 const SCROLL_THROTTLE_INTERVAL = 1000 / 24;
-
-function getVisibleParameters(parameters) {
-  return parameters.filter(parameter => !parameter.hidden);
-}
 
 // NOTE: move DashboardControls HoC to container
 
@@ -240,10 +237,7 @@ class Dashboard extends Component {
 
     const parametersWidget = (
       <SyncedParametersList
-        parameters={getValuePopulatedParameters(
-          visibleParameters,
-          parameterValues,
-        )}
+        parameters={getValuePopulatedParameters(parameters, parameterValues)}
         editingParameter={editingParameter}
         dashboard={dashboard}
         isFullscreen={isFullscreen}

--- a/frontend/src/metabase/parameters/types.ts
+++ b/frontend/src/metabase/parameters/types.ts
@@ -10,7 +10,9 @@ export interface FieldFilterUiParameter extends ValuePopulatedParameter {
   hasVariableTemplateTagTarget?: boolean;
 }
 
-export type UiParameter = FieldFilterUiParameter | ValuePopulatedParameter;
+export type UiParameter = (FieldFilterUiParameter | ValuePopulatedParameter) & {
+  hidden?: boolean;
+};
 
 export type ParameterWithTarget = Parameter & {
   target: ParameterTarget;

--- a/frontend/src/metabase/parameters/utils/ui.ts
+++ b/frontend/src/metabase/parameters/utils/ui.ts
@@ -32,12 +32,14 @@ export function buildHiddenParametersSlugSet(
 
 export function getVisibleParameters(
   parameters: UiParameter[],
-  hiddenParameterSlugs: string | undefined,
+  hiddenParameterSlugs?: string,
 ) {
   const hiddenParametersSlugSet =
     buildHiddenParametersSlugSet(hiddenParameterSlugs);
 
-  return parameters.filter(p => !hiddenParametersSlugSet.has(p.slug));
+  return parameters.filter(
+    p => !hiddenParametersSlugSet.has(p.slug) && !p.hidden,
+  );
 }
 
 export function getParameterWidgetTitle(parameter: UiParameter) {

--- a/frontend/src/metabase/parameters/utils/ui.unit.spec.ts
+++ b/frontend/src/metabase/parameters/utils/ui.unit.spec.ts
@@ -54,6 +54,10 @@ describe("parameters/utils/ui", () => {
         id: "4",
         slug: "qux",
       }),
+      createMockUiParameter({
+        id: "5",
+        hidden: true,
+      }),
     ];
 
     const hiddenParameterSlugs = "bar,baz";


### PR DESCRIPTION
Scaffolded app detail pages (like Order detail) use PK filters, and an object detail viz mapped to them. It's an implementation detail, and we don't really want to expose these filters to the end user — changing the filters can essentially break the detail page experience completely.

The BE marks these filters with the `hidden: true` property. This PR makes the FE respect this setting.

> **Warning**
> Seems like navigation between the List and Detail pages doesn't work as expected at the moment. When you click a list record and end up on the detail page, it seems like the ID value can get lost. This is a known issue that exists on `master`

### To Verify

1. New > App > Pick a table > Save
2. Click on whatever record in the list view you've landed on
3. Ensure you're navigated to a detail page
4. Ensure the URL contains clicked record ID and you _can't_ see the ID filter anywhere
5. Try to add an action to the page and make sure you can pass the ID value to an action
6. Try to add a filter to a detail page (e.g. for a list of related items), and ensure that works well
7. Ensure normal dashboard filters work as before

