### PR TITLE
preserve url params when saving data app pages

### DIFF
--- a/frontend/src/metabase/dashboard/actions/save.js
+++ b/frontend/src/metabase/dashboard/actions/save.js
@@ -159,7 +159,12 @@ export const saveDashboardAndCards = createThunkAction(
 
       await dispatch(Dashboards.actions.update(dashboard));
 
-      dispatch(fetchDashboard(dashboard.id, window.location.search, true));
+      if (dashboard.is_app_page) {
+        dispatch(fetchDashboard(dashboard.id, window.location.search, true));
+      } else {
+        // make sure that we've fully cleared out any dirty state from editing (this is overkill, but simple)
+        dispatch(fetchDashboard(dashboard.id, null)); // disable using query parameters when saving
+      }
     };
   },
 );

--- a/frontend/src/metabase/dashboard/actions/save.js
+++ b/frontend/src/metabase/dashboard/actions/save.js
@@ -159,8 +159,7 @@ export const saveDashboardAndCards = createThunkAction(
 
       await dispatch(Dashboards.actions.update(dashboard));
 
-      // make sure that we've fully cleared out any dirty state from editing (this is overkill, but simple)
-      dispatch(fetchDashboard(dashboard.id, null)); // disable using query parameters when saving
+      dispatch(fetchDashboard(dashboard.id, window.location.search, true));
     };
   },
 );


### PR DESCRIPTION
Zeroing out URL params when saving a dashboard completely breaks the data app detail workflow. This is a naive first stab to get the proper behavior.