### PR TITLE
Tweak data app page style

### DIFF
--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
@@ -270,6 +270,7 @@ class Dashboard extends Component {
               <HeaderContainer
                 isFullscreen={isFullscreen}
                 isNightMode={shouldRenderAsNightMode}
+                isDataApp={dashboard.is_app_page}
               >
                 <DashboardHeader
                   {...this.props}
@@ -280,6 +281,7 @@ class Dashboard extends Component {
                   onSharingClick={this.onSharingClick}
                   onToggleAddQuestionSidebar={this.onToggleAddQuestionSidebar}
                   showAddQuestionSidebar={showAddQuestionSidebar}
+                  isDataApp={dashboard.is_app_page}
                 />
 
                 {shouldRenderParametersWidgetInEditMode && (

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.jsx
@@ -69,7 +69,7 @@ export const HeaderContainer = styled.header`
   ${({ isDataApp }) =>
     !isDataApp &&
     css`
-      background-color: white;
+      background-color: ${color("bg-white")};
       border-bottom: 1px solid ${color("border")};
     `}
 

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.jsx
@@ -63,10 +63,15 @@ export const DashboardBody = styled.div`
 `;
 
 export const HeaderContainer = styled.header`
-  background-color: white;
-  border-bottom: 1px solid ${color("border")};
   position: relative;
   z-index: 2;
+
+  ${({ isDataApp }) =>
+    !isDataApp &&
+    css`
+      background-color: white;
+      border-bottom: 1px solid ${color("border")};
+    `}
 
   ${({ isFullscreen }) =>
     isFullscreen &&

--- a/frontend/src/metabase/dashboard/components/DashboardHeader.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader.styled.tsx
@@ -86,15 +86,19 @@ export const HeaderContent = styled.div<HeaderContentProps>`
     opacity: ${props => (props.showSubHeader ? "1x" : "0")};
   }
 
-  &:hover,
-  &:focus-within {
-    ${HeaderCaptionContainer} {
-      top: 0;
-    }
-    ${HeaderLastEditInfoLabel} {
-      opacity: 1;
-    }
-  }
+  ${({ showSubHeader }) =>
+    showSubHeader &&
+    css`
+      &:hover,
+      &:focus-within {
+        ${HeaderCaptionContainer} {
+          top: 0;
+        }
+        ${HeaderLastEditInfoLabel} {
+          opacity: 1;
+        }
+      }
+    `}
 
   ${breakpointMaxSmall} {
     padding-top: 0;

--- a/frontend/src/metabase/dashboard/components/DashboardHeader.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader.tsx
@@ -38,6 +38,7 @@ interface DashboardHeaderProps {
   isEditing: boolean;
   isEditingInfo: boolean;
   isNavBarOpen: boolean;
+  isDataApp: boolean;
   dashboard: Dashboard;
   isBadgeVisible: boolean;
   isLastEditInfoVisible: boolean;
@@ -59,6 +60,7 @@ const DashboardHeader = ({
   headerModalMessage,
   isEditing,
   isNavBarOpen,
+  isDataApp,
   dashboard,
   isLastEditInfoVisible,
   children,

--- a/frontend/src/metabase/dashboard/components/DashboardHeader.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader.tsx
@@ -38,7 +38,6 @@ interface DashboardHeaderProps {
   isEditing: boolean;
   isEditingInfo: boolean;
   isNavBarOpen: boolean;
-  isDataApp: boolean;
   dashboard: Dashboard;
   isBadgeVisible: boolean;
   isLastEditInfoVisible: boolean;
@@ -60,7 +59,6 @@ const DashboardHeader = ({
   headerModalMessage,
   isEditing,
   isNavBarOpen,
-  isDataApp,
   dashboard,
   isLastEditInfoVisible,
   children,
@@ -115,6 +113,8 @@ const DashboardHeader = ({
     return () => clearTimeout(timerId);
   });
 
+  const isDataApp = dashboard.is_app_page;
+
   return (
     <div>
       {isEditing && (
@@ -137,7 +137,7 @@ const DashboardHeader = ({
         className={cx("QueryBuilder-section", headerClassName)}
         ref={header}
       >
-        <HeaderContent showSubHeader={showSubHeader}>
+        <HeaderContent showSubHeader={!isDataApp && showSubHeader}>
           <HeaderCaptionContainer>
             <HeaderCaption
               key={dashboard.name}


### PR DESCRIPTION
Cherry-picking @kdoh's changes. Makes app page header background transparent and borderless and removes the "Last edited at" copy below the page title.

### To Verify

1. New > App > Pick a table > Save
2. Ensure app pages don't have a white background
3. Hover the page title and ensure you can't see the "Last edited by" text show up beneath it
4. Make sure 2 and 3 don't apply to regular dashboards

### Demo

**Before**

<img width="1730" alt="CleanShot 2022-10-11 at 13 42 30@2x" src="https://user-images.githubusercontent.com/17258145/195093684-68af0df5-a180-4068-a36f-4cd3d9564269.png">

**After**

<img width="1730" alt="CleanShot 2022-10-11 at 13 32 33@2x" src="https://user-images.githubusercontent.com/17258145/195092315-a8243854-01d9-4bb1-addb-3026eb5c4dc8.png">
