### PR TITLE
Fix cljs compilation

### DIFF
--- a/frontend/src/metabase-lib/lib/metadata/Field.ts
+++ b/frontend/src/metabase-lib/lib/metadata/Field.ts
@@ -41,7 +41,7 @@ import { FieldDimension } from "../Dimension";
 import Base from "./Base";
 import type Table from "./Table";
 import type Metadata from "./Metadata";
-import { getUniqueFieldId } from "./utils";
+import { getUniqueFieldId } from "./utils/fields";
 
 export const LONG_TEXT_MIN = 80;
 

--- a/frontend/src/metabase-lib/lib/metadata/Metadata.ts
+++ b/frontend/src/metabase-lib/lib/metadata/Metadata.ts
@@ -8,7 +8,7 @@ import type Database from "./Database";
 import type Table from "./Table";
 import type Schema from "./Schema";
 import type Field from "./Field";
-import { getUniqueFieldId } from "./utils";
+import { getUniqueFieldId } from "./utils/fields";
 
 /**
  * @typedef { import("./metadata").DatabaseId } DatabaseId

--- a/frontend/src/metabase-lib/lib/metadata/utils/fields.ts
+++ b/frontend/src/metabase-lib/lib/metadata/utils/fields.ts
@@ -1,5 +1,5 @@
 import { isVirtualCardId } from "metabase/lib/saved-questions/saved-questions";
-import type Field from "./Field";
+import type Field from "../Field";
 
 export function getUniqueFieldId(field: Field): number | string {
   const { table_id } = field;

--- a/frontend/src/metabase-lib/lib/metadata/utils/fields.unit.spec.ts
+++ b/frontend/src/metabase-lib/lib/metadata/utils/fields.unit.spec.ts
@@ -1,5 +1,5 @@
-import { getUniqueFieldId } from "./utils";
-import { createMockConcreteField, createMockVirtualField } from "./mocks";
+import { createMockConcreteField, createMockVirtualField } from "../mocks";
+import { getUniqueFieldId } from "./fields";
 
 const structuredVirtualCardField = createMockConcreteField({
   apiOpts: {

--- a/frontend/src/metabase-lib/lib/queries/utils/description.js
+++ b/frontend/src/metabase-lib/lib/queries/utils/description.js
@@ -11,7 +11,7 @@ import { format as formatExpression } from "metabase/lib/expressions/format";
 import * as AGGREGATION from "./aggregation";
 import * as QUERY from "./query";
 import * as FIELD_REF from "./field-ref";
-import { FilterClause, MetricClause } from "./description.styled";
+import { FilterClause, MetricClause } from "./description.styled.tsx";
 
 // NOTE: This doesn't support every MBQL clause, e.x. joins. It should also be moved to StructuredQuery.
 

--- a/frontend/src/metabase/schema.js
+++ b/frontend/src/metabase/schema.js
@@ -3,7 +3,7 @@
 import { schema } from "normalizr";
 import { generateSchemaId, entityTypeForObject } from "metabase/lib/schema";
 import { SAVED_QUESTIONS_VIRTUAL_DB_ID } from "metabase/lib/saved-questions";
-import { getUniqueFieldId } from "metabase-lib/lib/metadata/utils";
+import { getUniqueFieldId } from "metabase-lib/lib/metadata/utils/fields";
 
 export const QuestionSchema = new schema.Entity("questions");
 export const BookmarkSchema = new schema.Entity("bookmarks");


### PR DESCRIPTION
The issue is that the CLJS compiler
- doesn't understand `tsx` extension by default
- doesn't work if there are both `dir/utils.js` and `dir/utils` directory

How to test:
- `yarn dev` should work