### PR TITLE
Viz settings field partition dnd

### DIFF
--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPartition.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPartition.jsx
@@ -2,34 +2,22 @@
 import React from "react";
 import cx from "classnames";
 import { t } from "ttag";
-import { DragSource, DropTarget } from "react-dnd";
+import { DragDropContext, Droppable, Draggable } from "react-beautiful-dnd";
 import _ from "underscore";
 import { assocIn } from "icepick";
 import Label from "metabase/components/type/Label";
 
 import { keyForColumn } from "metabase-lib/lib/queries/utils/dataset";
-import { FieldPartitionColumn } from "./ChartSettingFieldsPartition.styled";
+import {
+  DroppableContainer,
+  FieldPartitionColumn,
+} from "./ChartSettingFieldsPartition.styled";
 
 class ChartSettingFieldsPartition extends React.Component {
   constructor(props) {
     super(props);
-    this.state = { displayedValue: null };
+    this.state = { draggingColumn: null };
   }
-
-  handleChangeColumnSetting = (column, settingName, value) => {
-    const { settings, onChangeSettings } = this.props;
-    const column_settings = assocIn(
-      settings.column_settings,
-      [keyForColumn(column), settingName],
-      value,
-    );
-    onChangeSettings({ column_settings });
-  };
-
-  getColumnSettingValue = (column, settingName) => {
-    const columnSettings = this.props.settings.column(column);
-    return columnSettings && columnSettings[settingName];
-  };
 
   handleEditFormatting = (column, targetElement) => {
     if (column) {
@@ -44,17 +32,47 @@ class ChartSettingFieldsPartition extends React.Component {
       );
     }
   };
-  updateDisplayedValue = displayedValue =>
-    this.setState({
-      displayedValue: _.mapObject(displayedValue, cols =>
-        cols.map(col => col.field_ref),
-      ),
-    });
-  commitDisplayedValue = () => {
-    const { displayedValue } = this.state;
-    if (displayedValue != null) {
-      this.props.onChange(displayedValue);
-      this.setState({ displayedValue: null });
+
+  getPartitionType = partitionName => {
+    return partitionName === "rows" || partitionName === "columns"
+      ? "dimension"
+      : "metric";
+  };
+
+  handleDragEnd = ({ source, destination }) => {
+    if (!source || !destination) {
+      return;
+    }
+    const { value, onChange } = this.props;
+    const { droppableId: sourcePartition, index: sourceIndex } = source;
+    const { droppableId: destinationPartition, index: destinationIndex } =
+      destination;
+
+    if (
+      sourcePartition === destinationPartition &&
+      sourceIndex !== destinationIndex
+    ) {
+      const partition = value[sourcePartition];
+      const partitionDup = [...partition];
+
+      partitionDup[sourceIndex] = partition[destinationIndex];
+      partitionDup[destinationIndex] = partition[sourceIndex];
+
+      onChange({ ...value, [sourcePartition]: partitionDup });
+    } else if (sourcePartition !== destinationPartition) {
+      const column = value[sourcePartition][sourceIndex];
+      onChange({
+        ...value,
+        [sourcePartition]: [
+          ...value[sourcePartition].slice(0, sourceIndex),
+          ...value[sourcePartition].slice(sourceIndex + 1),
+        ],
+        [destinationPartition]: [
+          ...value[destinationPartition].slice(0, destinationIndex),
+          column,
+          ...value[destinationPartition].slice(destinationIndex),
+        ],
+      });
     }
   };
 
@@ -68,124 +86,78 @@ class ChartSettingFieldsPartition extends React.Component {
           )
           .filter(col => col != null),
     );
+    console.log(this.props);
+
     return (
-      <div>
-        {this.props.partitions.map(({ name, title, columnFilter }, index) => (
-          <Partition
-            key={index}
-            className={cx("py2", { "border-top": index > 0 })}
-            title={title}
-            columnFilter={columnFilter}
-            partitionName={name}
-            columns={value[name]}
-            value={value}
-            getColumnSettingValue={this.getColumnSettingValue}
-            onChangeColumnSetting={this.handleChangeColumnSetting}
-            onEditFormatting={this.handleEditFormatting}
-            updateDisplayedValue={this.updateDisplayedValue}
-            commitDisplayedValue={this.commitDisplayedValue}
-          />
-        ))}
-      </div>
+      <DragDropContext onDragEnd={this.handleDragEnd}>
+        <div>
+          {this.props.partitions.map(
+            ({ name: partitionName, title, columnFilter }, index) => {
+              const columns = value[partitionName];
+              const partitionType = this.getPartitionType(partitionName);
+              console.log(partitionType);
+              return (
+                <div
+                  className={cx("py2", { "border-top": index > 0 })}
+                  key={partitionName}
+                >
+                  <Label color="medium">{title}</Label>
+                  <Droppable droppableId={partitionName} type={partitionType}>
+                    {(provided, snapshot) => {
+                      console.log(partitionName, snapshot);
+                      return (
+                        <DroppableContainer
+                          {...provided.droppableProps}
+                          ref={provided.innerRef}
+                          isDraggingOver={snapshot.isDraggingOver}
+                          isDragSource={!!snapshot.draggingFromThisWith}
+                        >
+                          {columns.length === 0 ? (
+                            <div className="p2 bg-light rounded text-medium">{t`Drag fields here`}</div>
+                          ) : (
+                            columns.map((col, index) => (
+                              <Draggable
+                                key={`draggable-${col.display_name}`}
+                                draggableId={`draggable-${col.display_name}`}
+                                index={index}
+                              >
+                                {provided => (
+                                  <div
+                                    ref={provided.innerRef}
+                                    {...provided.draggableProps}
+                                    {...provided.dragHandleProps}
+                                    className="mb1"
+                                  >
+                                    <Column
+                                      key={`${partitionName}-${col.display_name}`}
+                                      column={col}
+                                      index={index}
+                                      onEditFormatting={
+                                        this.handleEditFormatting
+                                      }
+                                    />
+                                  </div>
+                                )}
+                              </Draggable>
+                            ))
+                          )}
+
+                          {provided.placeholder}
+                        </DroppableContainer>
+                      );
+                    }}
+                  </Droppable>
+                </div>
+              );
+            },
+          )}
+        </div>
+      </DragDropContext>
     );
   }
 }
 
-class PartitionInner extends React.Component {
-  render() {
-    const {
-      columns = [],
-      partitionName,
-      columnFilter,
-      onChangeColumnSetting,
-      getColumnSettingValue,
-      onEditFormatting,
-      updateDisplayedValue,
-      commitDisplayedValue,
-      value,
-      connectDropTarget,
-      title,
-      className,
-    } = this.props;
-    return connectDropTarget(
-      <div className={className}>
-        <Label color="medium">{title}</Label>
-        {columns.length === 0 ? (
-          <EmptyPartition
-            columnFilter={columnFilter}
-            value={value}
-            partitionName={partitionName}
-            updateDisplayedValue={updateDisplayedValue}
-          />
-        ) : (
-          columns.map((col, index) => (
-            <Column
-              key={index}
-              partitionName={partitionName}
-              column={col}
-              index={index}
-              columnFilter={columnFilter}
-              value={value}
-              onChangeColumnSetting={onChangeColumnSetting}
-              getColumnSettingValue={getColumnSettingValue}
-              onEditFormatting={onEditFormatting}
-              updateDisplayedValue={updateDisplayedValue}
-              commitDisplayedValue={commitDisplayedValue}
-            />
-          ))
-        )}
-      </div>,
-    );
-  }
-}
-
-const Partition = DropTarget(
-  "columns",
-  {
-    // Using a drop target here is a hack to work around another issue.
-    // The version of react-dnd we're on has a bug where endDrag isn't called.
-    // Drop is still called here, so we trigger commit here.
-    drop: (props, monitor, component) => {
-      props.commitDisplayedValue();
-    },
-  },
-  (connect, monitor) => ({ connectDropTarget: connect.dropTarget() }),
-)(PartitionInner);
-
-class EmptyPartitionInner extends React.Component {
-  render() {
-    return this.props.connectDropTarget(
-      <div className="p2 bg-light rounded text-medium">{t`Drag fields here`}</div>,
-    );
-  }
-}
-
-const EmptyPartition = DropTarget(
-  "columns",
-  {
-    hover: (props, monitor, component) => {
-      const item = monitor.getItem();
-      if (props.columnFilter && props.columnFilter(item.column) === false) {
-        return;
-      }
-      const { index: dragIndex, partitionName: itemPartition } = item;
-      const { value, partitionName, updateDisplayedValue } = props;
-      updateDisplayedValue({
-        ...value,
-        [itemPartition]: [
-          ...value[itemPartition].slice(0, dragIndex),
-          ...value[itemPartition].slice(dragIndex + 1),
-        ],
-        [partitionName]: [value[itemPartition][dragIndex]],
-      });
-      item.index = 0;
-      item.partitionName = partitionName;
-    },
-  },
-  (connect, monitor) => ({ connectDropTarget: connect.dropTarget() }),
-)(EmptyPartitionInner);
-
-class ColumnInner extends React.Component {
+class Column extends React.Component {
   constructor(props) {
     super(props);
   }
@@ -194,86 +166,19 @@ class ColumnInner extends React.Component {
     const { column, onEditFormatting } = this.props;
     onEditFormatting && onEditFormatting(column, target);
   };
-  render() {
-    const { column, connectDragSource, connectDropTarget, isDragging } =
-      this.props;
 
-    return connectDropTarget(
-      connectDragSource(
-        <div>
-          <FieldPartitionColumn
-            title={column.display_name}
-            onEdit={this.handleEditFormatting}
-            draggable
-            isDisabled={isDragging}
-          />
-        </div>,
-      ),
+  render() {
+    const { column } = this.props;
+
+    return (
+      <FieldPartitionColumn
+        title={column.display_name}
+        onEdit={this.handleEditFormatting}
+        draggable
+        isDisabled={false}
+      />
     );
   }
 }
-
-const Column = _.compose(
-  DropTarget(
-    "columns",
-    {
-      hover: (props, monitor, component) => {
-        const item = monitor.getItem();
-        if (props.columnFilter && props.columnFilter(item.column) === false) {
-          return;
-        }
-        const { index: dragIndex, partitionName: itemPartition } = item;
-        const hoverIndex = props.index;
-        const { value, partitionName, updateDisplayedValue } = props;
-        if (partitionName === itemPartition && dragIndex !== hoverIndex) {
-          const columns = value[itemPartition];
-          const columnsDup = [...columns];
-          columnsDup[dragIndex] = columns[hoverIndex];
-          columnsDup[hoverIndex] = columns[dragIndex];
-          updateDisplayedValue({ ...value, [itemPartition]: columnsDup });
-          item.index = hoverIndex;
-        } else if (partitionName !== itemPartition) {
-          updateDisplayedValue({
-            ...value,
-            [itemPartition]: [
-              ...value[itemPartition].slice(0, dragIndex),
-              ...value[itemPartition].slice(dragIndex + 1),
-            ],
-            [partitionName]: [
-              ...value[partitionName].slice(0, hoverIndex),
-              value[itemPartition][dragIndex],
-              ...value[partitionName].slice(hoverIndex),
-            ],
-          });
-          item.index = hoverIndex;
-          item.partitionName = partitionName;
-        }
-      },
-      drop: ({ index, column, partitionName }, monitor, component) => ({
-        index,
-        column,
-        partitionName,
-      }),
-    },
-    (connect, monitor) => ({ connectDropTarget: connect.dropTarget() }),
-  ),
-  DragSource(
-    "columns",
-    {
-      beginDrag: ({ column, partitionName, index }) => ({
-        column,
-        partitionName,
-        index,
-      }),
-      endDrag: (props, monitor, component) => {
-        // props.commitDisplayedValue();
-      },
-    },
-    (connect, monitor) => ({
-      connectDragSource: connect.dragSource(),
-      isDragging: monitor.isDragging(),
-    }),
-  ),
-)(ColumnInner);
 
 export default ChartSettingFieldsPartition;

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPartition.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPartition.jsx
@@ -15,6 +15,20 @@ import {
   EmptyColumnPlaceholder,
 } from "./ChartSettingFieldsPartition.styled";
 
+const columnMove = (columns, from, to) => {
+  const columnCopy = [...columns];
+  columnCopy.splice(to, 0, columnCopy.splice(from, 1)[0]);
+  return columnCopy;
+};
+
+const columnRemove = (columns, from) => {
+  return splice(columns, from, 1);
+};
+
+const columnAdd = (columns, to, column) => {
+  return splice(columns, to, 0, column);
+};
+
 class ChartSettingFieldsPartition extends React.Component {
   constructor(props) {
     super(props);
@@ -35,9 +49,13 @@ class ChartSettingFieldsPartition extends React.Component {
   };
 
   getPartitionType = partitionName => {
-    return partitionName === "rows" || partitionName === "columns"
-      ? "dimension"
-      : "metric";
+    switch (partitionName) {
+      case "rows":
+      case "columns":
+        return "dimension";
+      default:
+        return "metric";
+    }
   };
 
   handleDragEnd = ({ source, destination }) => {
@@ -53,25 +71,22 @@ class ChartSettingFieldsPartition extends React.Component {
       sourcePartition === destinationPartition &&
       sourceIndex !== destinationIndex
     ) {
-      const partition = value[sourcePartition];
-      const partitionDup = [...partition];
-
-      partitionDup.splice(
-        destinationIndex,
-        0,
-        partitionDup.splice(sourceIndex, 1)[0],
-      );
-
-      onChange({ ...value, [sourcePartition]: partitionDup });
+      onChange({
+        ...value,
+        [sourcePartition]: columnMove(
+          value[sourcePartition],
+          sourceIndex,
+          destinationIndex,
+        ),
+      });
     } else if (sourcePartition !== destinationPartition) {
       const column = value[sourcePartition][sourceIndex];
       onChange({
         ...value,
-        [sourcePartition]: splice(value[sourcePartition], sourceIndex, 1),
-        [destinationPartition]: splice(
+        [sourcePartition]: columnRemove(value[sourcePartition], sourceIndex),
+        [destinationPartition]: columnAdd(
           value[destinationPartition],
           destinationIndex,
-          0,
           column,
         ),
       });

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPartition.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPartition.jsx
@@ -16,7 +16,6 @@ import {
 class ChartSettingFieldsPartition extends React.Component {
   constructor(props) {
     super(props);
-    this.state = { draggingColumn: null };
   }
 
   handleEditFormatting = (column, targetElement) => {
@@ -77,14 +76,12 @@ class ChartSettingFieldsPartition extends React.Component {
   };
 
   render() {
-    const value = _.mapObject(
-      this.state.displayedValue || this.props.value || {},
-      fieldRefs =>
-        fieldRefs
-          .map(field_ref =>
-            this.props.columns.find(col => _.isEqual(col.field_ref, field_ref)),
-          )
-          .filter(col => col != null),
+    const value = _.mapObject(this.props.value || {}, fieldRefs =>
+      fieldRefs
+        .map(field_ref =>
+          this.props.columns.find(col => _.isEqual(col.field_ref, field_ref)),
+        )
+        .filter(col => col != null),
     );
 
     return (
@@ -101,46 +98,42 @@ class ChartSettingFieldsPartition extends React.Component {
                 >
                   <Label color="medium">{title}</Label>
                   <Droppable droppableId={partitionName} type={partitionType}>
-                    {(provided, snapshot) => {
-                      return (
-                        <DroppableContainer
-                          {...provided.droppableProps}
-                          ref={provided.innerRef}
-                          isDragSource={!!snapshot.draggingFromThisWith}
-                        >
-                          {columns.length === 0 ? (
-                            <EmptyColumnPlaceholder>{t`Drag fields here`}</EmptyColumnPlaceholder>
-                          ) : (
-                            columns.map((col, index) => (
-                              <Draggable
-                                key={`draggable-${col.display_name}`}
-                                draggableId={`draggable-${col.display_name}`}
-                                index={index}
-                              >
-                                {provided => (
-                                  <div
-                                    ref={provided.innerRef}
-                                    {...provided.draggableProps}
-                                    {...provided.dragHandleProps}
-                                    className="mb1"
-                                  >
-                                    <Column
-                                      key={`${partitionName}-${col.display_name}`}
-                                      column={col}
-                                      index={index}
-                                      onEditFormatting={
-                                        this.handleEditFormatting
-                                      }
-                                    />
-                                  </div>
-                                )}
-                              </Draggable>
-                            ))
-                          )}
-                          {provided.placeholder}
-                        </DroppableContainer>
-                      );
-                    }}
+                    {(provided, snapshot) => (
+                      <DroppableContainer
+                        {...provided.droppableProps}
+                        ref={provided.innerRef}
+                        isDragSource={!!snapshot.draggingFromThisWith}
+                      >
+                        {columns.length === 0 ? (
+                          <EmptyColumnPlaceholder>{t`Drag fields here`}</EmptyColumnPlaceholder>
+                        ) : (
+                          columns.map((col, index) => (
+                            <Draggable
+                              key={`draggable-${col.display_name}`}
+                              draggableId={`draggable-${col.display_name}`}
+                              index={index}
+                            >
+                              {provided => (
+                                <div
+                                  ref={provided.innerRef}
+                                  {...provided.draggableProps}
+                                  {...provided.dragHandleProps}
+                                  className="mb1"
+                                >
+                                  <Column
+                                    key={`${partitionName}-${col.display_name}`}
+                                    column={col}
+                                    index={index}
+                                    onEditFormatting={this.handleEditFormatting}
+                                  />
+                                </div>
+                              )}
+                            </Draggable>
+                          ))
+                        )}
+                        {provided.placeholder}
+                      </DroppableContainer>
+                    )}
                   </Droppable>
                 </div>
               );

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPartition.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPartition.jsx
@@ -4,13 +4,13 @@ import cx from "classnames";
 import { t } from "ttag";
 import { DragDropContext, Droppable, Draggable } from "react-beautiful-dnd";
 import _ from "underscore";
-import { assocIn } from "icepick";
 import Label from "metabase/components/type/Label";
 
 import { keyForColumn } from "metabase-lib/lib/queries/utils/dataset";
 import {
   DroppableContainer,
   FieldPartitionColumn,
+  EmptyColumnPlaceholder,
 } from "./ChartSettingFieldsPartition.styled";
 
 class ChartSettingFieldsPartition extends React.Component {
@@ -86,16 +86,14 @@ class ChartSettingFieldsPartition extends React.Component {
           )
           .filter(col => col != null),
     );
-    console.log(this.props);
 
     return (
       <DragDropContext onDragEnd={this.handleDragEnd}>
         <div>
           {this.props.partitions.map(
-            ({ name: partitionName, title, columnFilter }, index) => {
+            ({ name: partitionName, title }, index) => {
               const columns = value[partitionName];
               const partitionType = this.getPartitionType(partitionName);
-              console.log(partitionType);
               return (
                 <div
                   className={cx("py2", { "border-top": index > 0 })}
@@ -104,16 +102,14 @@ class ChartSettingFieldsPartition extends React.Component {
                   <Label color="medium">{title}</Label>
                   <Droppable droppableId={partitionName} type={partitionType}>
                     {(provided, snapshot) => {
-                      console.log(partitionName, snapshot);
                       return (
                         <DroppableContainer
                           {...provided.droppableProps}
                           ref={provided.innerRef}
-                          isDraggingOver={snapshot.isDraggingOver}
                           isDragSource={!!snapshot.draggingFromThisWith}
                         >
                           {columns.length === 0 ? (
-                            <div className="p2 bg-light rounded text-medium">{t`Drag fields here`}</div>
+                            <EmptyColumnPlaceholder>{t`Drag fields here`}</EmptyColumnPlaceholder>
                           ) : (
                             columns.map((col, index) => (
                               <Draggable
@@ -141,7 +137,6 @@ class ChartSettingFieldsPartition extends React.Component {
                               </Draggable>
                             ))
                           )}
-
                           {provided.placeholder}
                         </DroppableContainer>
                       );

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPartition.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPartition.styled.tsx
@@ -1,4 +1,5 @@
 import styled from "@emotion/styled";
+import { color, lighten } from "metabase/lib/colors";
 import ColumnItem from "./ColumnItem";
 
 interface FieldPartitionColumnProps {
@@ -9,6 +10,7 @@ export const FieldPartitionColumn = styled(
   ColumnItem,
 )<FieldPartitionColumnProps>`
   padding: 0.25rem 0;
+  margin: 0;
 
   ${props =>
     props.isDisabled &&
@@ -16,4 +18,19 @@ export const FieldPartitionColumn = styled(
         pointer-events: none;
         opacity: 0.4;
       `}
+`;
+
+interface DroppableContainerProps {
+  isDraggingOver: boolean;
+  isDragSource: boolean;
+}
+
+export const DroppableContainer = styled.div<DroppableContainerProps>`
+  background-color: ${({ isDraggingOver, isDragSource }) =>
+    isDraggingOver
+      ? lighten("brand")
+      : isDragSource
+      ? color("border")
+      : "none"};
+  border-radius: 0.5rem;
 `;

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPartition.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPartition.styled.tsx
@@ -21,16 +21,22 @@ export const FieldPartitionColumn = styled(
 `;
 
 interface DroppableContainerProps {
-  isDraggingOver: boolean;
   isDragSource: boolean;
 }
 
 export const DroppableContainer = styled.div<DroppableContainerProps>`
-  background-color: ${({ isDraggingOver, isDragSource }) =>
-    isDraggingOver
-      ? lighten("brand")
-      : isDragSource
-      ? color("border")
-      : "none"};
+  background-color: ${({ isDragSource }) =>
+    isDragSource ? color("border") : "none"};
   border-radius: 0.5rem;
+  min-height: 58px;
+  position: relative;
+`;
+
+export const EmptyColumnPlaceholder = styled.div`
+  position: absolute;
+  width: 100%;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  background-color: ${color("bg-light")};
+  color: ${color("text-medium")};
 `;

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPartition.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPartition.styled.tsx
@@ -9,7 +9,6 @@ interface FieldPartitionColumnProps {
 export const FieldPartitionColumn = styled(
   ColumnItem,
 )<FieldPartitionColumnProps>`
-  padding: 0.25rem 0;
   margin: 0;
 
   ${props =>
@@ -28,14 +27,14 @@ export const DroppableContainer = styled.div<DroppableContainerProps>`
   background-color: ${({ isDragSource }) =>
     isDragSource ? color("border") : "none"};
   border-radius: 0.5rem;
-  min-height: 58px;
+  min-height: 40px;
   position: relative;
 `;
 
 export const EmptyColumnPlaceholder = styled.div`
   position: absolute;
   width: 100%;
-  padding: 1rem;
+  padding: 0.75rem;
   border-radius: 0.5rem;
   background-color: ${color("bg-light")};
   color: ${color("text-medium")};

--- a/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
@@ -897,7 +897,6 @@ function createAndVisitTestQuestion({ display = "pivot" } = {}) {
 
 function assertOnPivotSettings() {
   cy.findAllByTestId(/draggable-item/).as("fieldOption");
-  //cy.get("[draggable=true]").as("fieldOption");
 
   cy.log("Implicit side-bar assertions");
   cy.findByText(/Pivot Table options/i);

--- a/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
@@ -896,7 +896,8 @@ function createAndVisitTestQuestion({ display = "pivot" } = {}) {
 }
 
 function assertOnPivotSettings() {
-  cy.get("[draggable=true]").as("fieldOption");
+  cy.findAllByTestId(/draggable-item/).as("fieldOption");
+  //cy.get("[draggable=true]").as("fieldOption");
 
   cy.log("Implicit side-bar assertions");
   cy.findByText(/Pivot Table options/i);
@@ -929,9 +930,39 @@ function assertOnPivotFields() {
 function dragField(startIndex, dropIndex) {
   cy.get(".Icon-grabber2").should("be.visible").as("dragHandle");
 
-  cy.get("@dragHandle").eq(startIndex).trigger("dragstart");
-
-  cy.get("@dragHandle").eq(dropIndex).trigger("drop");
+  const BUTTON_INDEX = 0;
+  const SLOPPY_CLICK_THRESHOLD = 10;
+  cy.get("@dragHandle")
+    .eq(dropIndex)
+    .then($target => {
+      const coordsDrop = $target[0].getBoundingClientRect();
+      cy.get("@dragHandle")
+        .eq(startIndex)
+        .then(subject => {
+          const coordsDrag = subject[0].getBoundingClientRect();
+          cy.wrap(subject)
+            .trigger("mousedown", {
+              button: BUTTON_INDEX,
+              clientX: coordsDrag.x,
+              clientY: coordsDrag.y,
+              force: true,
+            })
+            .trigger("mousemove", {
+              button: BUTTON_INDEX,
+              clientX: coordsDrag.x + SLOPPY_CLICK_THRESHOLD,
+              clientY: coordsDrag.y,
+              force: true,
+            });
+          cy.get("body")
+            .trigger("mousemove", {
+              button: BUTTON_INDEX,
+              clientX: coordsDrop.x,
+              clientY: coordsDrop.y,
+              force: true,
+            })
+            .trigger("mouseup");
+        });
+    });
 }
 
 function getIframeBody(selector = "iframe") {


### PR DESCRIPTION
Fixes #25785 

Updating `ChartSettinFieldsPartition` to use `react-beautiful-dnd`. A lot of the logic updating state while dragging has been removed to keep the implementation light weight. The result is a slightly different experience, but much more understandable code.

![chrome_IrYShIyNUK](https://user-images.githubusercontent.com/1328979/195172742-d5c09d6d-ad8d-4c71-bebe-74f6f5601ba3.gif)
