### PR TITLE
25453 merge axis labels tab

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChartSettings.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings.jsx
@@ -196,16 +196,8 @@ class ChartSettings extends Component {
   }
 
   render() {
-    const {
-      className,
-      question,
-      addField,
-      noPreview,
-      children,
-      setSidebarPropsOverride,
-      dashboard,
-      isDashboard,
-    } = this.props;
+    const { className, question, addField, noPreview, dashboard, isDashboard } =
+      this.props;
     const { currentWidget, popoverRef } = this.state;
 
     const settings = this._getSettings();
@@ -237,7 +229,6 @@ class ChartSettings extends Component {
       "data",
       "display",
       "axes",
-      "labels",
       // include all section names so any forgotten sections are sorted to the end
       ...sectionNames.map(x => x.toLowerCase()),
     ];
@@ -287,30 +278,10 @@ class ChartSettings extends Component {
       </SectionContainer>
     );
 
-    // const widgetList = visibleWidgets.map(widget => (
-    //   <ChartSettingsWidget
-    //     key={widget.id}
-    //     {...widget}
-    //     {...extraWidgetProps}
-    //   />
-    // ));
-
     const onReset =
       !_.isEqual(settings, {}) && (settings || {}).virtual_card == null // resetting virtual cards wipes the text and broke the UI (metabase#14644)
         ? this.handleResetSettings
         : null;
-
-    // custom render prop layout:
-    // if (children) {
-    //   return children({
-    //     sectionNames,
-    //     sectionPicker,
-    //     widgetList,
-    //     onDone: this.handleDone,
-    //     onCancel: this.handleCancel,
-    //     onReset: onReset,
-    //   });
-    // }
 
     const showSectionPicker =
       // don't show section tabs for a single section

--- a/frontend/src/metabase/visualizations/components/ChartSettings.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings.jsx
@@ -25,6 +25,7 @@ import {
 
 import { getSettingDefintionsForColumn } from "metabase/visualizations/lib/settings/column";
 import ChartSettingsWidget from "./ChartSettingsWidget";
+import ChartSettingsWidgetList from "./ChartSettingsWidgetList";
 import ChartSettingsWidgetPopover from "./ChartSettingsWidgetPopover";
 import { SectionContainer, SectionWarnings } from "./ChartSettings.styled";
 
@@ -286,14 +287,13 @@ class ChartSettings extends Component {
       </SectionContainer>
     );
 
-    const widgetList = visibleWidgets.map(widget => (
-      <ChartSettingsWidget
-        key={widget.id}
-        {...widget}
-        {...extraWidgetProps}
-        setSidebarPropsOverride={setSidebarPropsOverride}
-      />
-    ));
+    // const widgetList = visibleWidgets.map(widget => (
+    //   <ChartSettingsWidget
+    //     key={widget.id}
+    //     {...widget}
+    //     {...extraWidgetProps}
+    //   />
+    // ));
 
     const onReset =
       !_.isEqual(settings, {}) && (settings || {}).virtual_card == null // resetting virtual cards wipes the text and broke the UI (metabase#14644)
@@ -301,16 +301,16 @@ class ChartSettings extends Component {
         : null;
 
     // custom render prop layout:
-    if (children) {
-      return children({
-        sectionNames,
-        sectionPicker,
-        widgetList,
-        onDone: this.handleDone,
-        onCancel: this.handleCancel,
-        onReset: onReset,
-      });
-    }
+    // if (children) {
+    //   return children({
+    //     sectionNames,
+    //     sectionPicker,
+    //     widgetList,
+    //     onDone: this.handleDone,
+    //     onCancel: this.handleCancel,
+    //     onReset: onReset,
+    //   });
+    // }
 
     const showSectionPicker =
       // don't show section tabs for a single section
@@ -337,7 +337,10 @@ class ChartSettings extends Component {
         )}
         {noPreview ? (
           <div className="full-height relative scroll-y scroll-show pt2 pb4">
-            {widgetList}
+            <ChartSettingsWidgetList
+              widgets={visibleWidgets}
+              extraWidgetProps={extraWidgetProps}
+            />
           </div>
         ) : (
           <div className="Grid flex-full">
@@ -345,7 +348,10 @@ class ChartSettings extends Component {
               className="Grid-cell Cell--1of3 scroll-y scroll-show border-right py4"
               data-testid="chartsettings-sidebar"
             >
-              {widgetList}
+              <ChartSettingsWidgetList
+                widgets={visibleWidgets}
+                extraWidgetProps={extraWidgetProps}
+              />
             </div>
             <div className="Grid-cell flex flex-column pt2">
               <div className="mx4 flex flex-column">

--- a/frontend/src/metabase/visualizations/components/ChartSettingsWidgetList.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettingsWidgetList.styled.tsx
@@ -1,0 +1,15 @@
+import styled from "@emotion/styled";
+
+import { color } from "metabase/lib/colors";
+
+export const ChartSettingsWidgetListHeader = styled.h4`
+  margin-left: 2rem;
+  margin-bottom: 1rem;
+  color: ${color("bg-dark")};
+  text-transform: uppercase;
+`;
+
+export const ChartSettingsWidgetListContainer = styled.div`
+  // border-bottom: 1px solid ${color("border")};
+  // margin-bottom: 1rem;
+`;

--- a/frontend/src/metabase/visualizations/components/ChartSettingsWidgetList.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettingsWidgetList.styled.tsx
@@ -2,6 +2,8 @@ import styled from "@emotion/styled";
 
 import { color } from "metabase/lib/colors";
 
+import ChartSettingsWidget from "./ChartSettingsWidget";
+
 export const ChartSettingsWidgetListHeader = styled.h4`
   margin-left: 2rem;
   margin-bottom: 1rem;
@@ -9,7 +11,11 @@ export const ChartSettingsWidgetListHeader = styled.h4`
   text-transform: uppercase;
 `;
 
-export const ChartSettingsWidgetListContainer = styled.div`
-  // border-bottom: 1px solid ${color("border")};
-  // margin-bottom: 1rem;
+export const ChartSettingsWidgetListDivider = styled.div`
+  background-color: ${color("border")};
+  height: 1px;
+  display: block;
+  margin-bottom: 1.5rem;
+  margin-left: 2rem;
+  margin-right: 2rem;
 `;

--- a/frontend/src/metabase/visualizations/components/ChartSettingsWidgetList.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettingsWidgetList.tsx
@@ -23,7 +23,7 @@ const ChartSettingsWidgetList = ({
       <ChartSettingsWidget key={widget.id} {...widget} {...extraWidgetProps} />
     ));
   } else {
-    const groupedWidgets = widgets.reduce<{ [key: string]: any[] }>(
+    const groupedWidgets = widgets.reduce<Record<string, any[]>>(
       (memo, widget) => {
         const group = widget.group || "";
         (memo[group] = memo[group] || []).push(widget);

--- a/frontend/src/metabase/visualizations/components/ChartSettingsWidgetList.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettingsWidgetList.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import _ from "underscore";
+import ChartSettingsWidget from "./ChartSettingsWidget";
+
+import {
+  ChartSettingsWidgetListHeader,
+  ChartSettingsWidgetListContainer,
+} from "./ChartSettingsWidgetList.styled";
+
+interface ChartSettingsWidgetListProps {
+  widgets: { id: string; group?: string }[];
+  extraWidgetProps: {};
+}
+
+const ChartSettingsWidgetList = ({
+  widgets,
+  extraWidgetProps,
+}: ChartSettingsWidgetListProps) => {
+  const widgetsAreGrouped = widgets.some(widget => widget.group);
+
+  if (!widgetsAreGrouped) {
+    return widgets.map(widget => (
+      <ChartSettingsWidget key={widget.id} {...widget} {...extraWidgetProps} />
+    ));
+  } else {
+    const groupedWidgets = widgets.reduce<{ [key: string]: any[] }>(
+      (memo, widget) => {
+        const group = widget.group || "";
+        (memo[group] = memo[group] || []).push(widget);
+        return memo;
+      },
+      {},
+    );
+
+    return Object.keys(groupedWidgets).map(group => {
+      return (
+        <div>
+          {group && (
+            <ChartSettingsWidgetListHeader>
+              {group}
+            </ChartSettingsWidgetListHeader>
+          )}
+          <ChartSettingsWidgetListContainer>
+            {_.sortBy(groupedWidgets[group], "index").map(widget => (
+              <ChartSettingsWidget
+                key={widget.id}
+                {...widget}
+                {...extraWidgetProps}
+              />
+            ))}
+          </ChartSettingsWidgetListContainer>
+        </div>
+      );
+    });
+  }
+};
+
+export default ChartSettingsWidgetList;

--- a/frontend/src/metabase/visualizations/components/ChartSettingsWidgetList.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettingsWidgetList.tsx
@@ -4,12 +4,12 @@ import ChartSettingsWidget from "./ChartSettingsWidget";
 
 import {
   ChartSettingsWidgetListHeader,
-  ChartSettingsWidgetListContainer,
+  ChartSettingsWidgetListDivider,
 } from "./ChartSettingsWidgetList.styled";
 
 interface ChartSettingsWidgetListProps {
   widgets: { id: string; group?: string }[];
-  extraWidgetProps: {};
+  extraWidgetProps: Record<string, unknown>;
 }
 
 const ChartSettingsWidgetList = ({
@@ -32,15 +32,16 @@ const ChartSettingsWidgetList = ({
       {},
     );
 
-    return Object.keys(groupedWidgets).map(group => {
+    return Object.keys(groupedWidgets).map((group, groupIndex, groups) => {
+      const lastGroup = groupIndex === groups.length - 1;
       return (
-        <div>
+        <div key={`group-${groupIndex}`}>
           {group && (
             <ChartSettingsWidgetListHeader>
               {group}
             </ChartSettingsWidgetListHeader>
           )}
-          <ChartSettingsWidgetListContainer>
+          <div>
             {_.sortBy(groupedWidgets[group], "index").map(widget => (
               <ChartSettingsWidget
                 key={widget.id}
@@ -48,7 +49,8 @@ const ChartSettingsWidgetList = ({
                 {...extraWidgetProps}
               />
             ))}
-          </ChartSettingsWidgetListContainer>
+            {!lastGroup && <ChartSettingsWidgetListDivider />}
+          </div>
         </div>
       );
     });

--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -467,7 +467,7 @@ export const GRAPH_AXIS_SETTINGS = {
   },
   "graph.x_axis.scale": {
     section: t`Axes`,
-    group: t`X-AXIS`,
+    group: t`X-axis`,
     title: t`Scale`,
     index: 4,
     widget: "select",
@@ -505,7 +505,7 @@ export const GRAPH_AXIS_SETTINGS = {
     section: t`Axes`,
     title: t`Scale`,
     index: 7,
-    group: t`Y-AXIS`,
+    group: t`Y-axis`,
     widget: "select",
     default: "linear",
     getProps: (series, vizSettings) => ({
@@ -518,7 +518,7 @@ export const GRAPH_AXIS_SETTINGS = {
   },
   "graph.x_axis.axis_enabled": {
     section: t`Axes`,
-    group: t`X-AXIS`,
+    group: t`X-axis`,
     title: t`Show lines and marks`,
     index: 3,
     widget: "select",
@@ -537,7 +537,7 @@ export const GRAPH_AXIS_SETTINGS = {
     section: t`Axes`,
     title: t`Show lines and marks`,
     index: 8,
-    group: t`Y-AXIS`,
+    group: t`Y-axis`,
     widget: "select",
     props: {
       options: [
@@ -549,7 +549,7 @@ export const GRAPH_AXIS_SETTINGS = {
   },
   "graph.y_axis.auto_range": {
     section: t`Axes`,
-    group: t`Y-AXIS`,
+    group: t`Y-axis`,
     index: 4,
     title: t`Auto y-axis range`,
     inline: true,
@@ -558,7 +558,7 @@ export const GRAPH_AXIS_SETTINGS = {
   },
   "graph.y_axis.min": {
     section: t`Axes`,
-    group: t`Y-AXIS`,
+    group: t`Y-axis`,
     index: 5,
     title: t`Min`,
     widget: "number",
@@ -568,7 +568,7 @@ export const GRAPH_AXIS_SETTINGS = {
   },
   "graph.y_axis.max": {
     section: t`Axes`,
-    group: t`Y-AXIS`,
+    group: t`Y-axis`,
     index: 6,
     title: t`Max`,
     widget: "number",
@@ -600,7 +600,7 @@ export const GRAPH_AXIS_SETTINGS = {
 */
   "graph.y_axis.auto_split": {
     section: t`Axes`,
-    group: t`Y-AXIS`,
+    group: t`Y-axis`,
     index: 3,
     title: t`Split y-axis when necessary`,
     widget: "toggle",
@@ -610,7 +610,7 @@ export const GRAPH_AXIS_SETTINGS = {
   },
   "graph.x_axis.labels_enabled": {
     section: t`Axes`,
-    group: t`X-AXIS`,
+    group: t`X-axis`,
     index: 1,
     title: t`Show label`,
     inline: true,
@@ -621,18 +621,22 @@ export const GRAPH_AXIS_SETTINGS = {
     section: t`Axes`,
     title: t`Label`,
     index: 2,
-    group: t`X-AXIS`,
+    group: t`X-axis`,
     widget: "input",
     getHidden: (series, vizSettings) =>
       vizSettings["graph.x_axis.labels_enabled"] === false,
     getDefault: (series, vizSettings) =>
-      series.length === 1 ? getFriendlyName(series[0].data.cols[0]) : null,
+      series.length > 1 ? getFriendlyName(series[0].data.cols[0]) : null,
+    getProps: series => ({
+      placeholder:
+        series.length > 1 ? getFriendlyName(series[0].data.cols[0]) : null,
+    }),
   },
   "graph.y_axis.labels_enabled": {
     section: t`Axes`,
     title: t`Show label`,
     index: 1,
-    group: t`Y-AXIS`,
+    group: t`Y-axis`,
     widget: "toggle",
     inline: true,
     default: true,
@@ -641,7 +645,7 @@ export const GRAPH_AXIS_SETTINGS = {
     section: t`Axes`,
     title: t`Label`,
     index: 2,
-    group: t`Y-AXIS`,
+    group: t`Y-axis`,
     widget: "input",
     getHidden: (series, vizSettings) =>
       vizSettings["graph.y_axis.labels_enabled"] === false,

--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -467,7 +467,9 @@ export const GRAPH_AXIS_SETTINGS = {
   },
   "graph.x_axis.scale": {
     section: t`Axes`,
-    title: t`X-axis scale`,
+    group: t`X-AXIS`,
+    title: t`Scale`,
+    index: 4,
     widget: "select",
     readDependencies: [
       "graph.x_axis._is_timeseries",
@@ -501,7 +503,9 @@ export const GRAPH_AXIS_SETTINGS = {
   },
   "graph.y_axis.scale": {
     section: t`Axes`,
-    title: t`Y-axis scale`,
+    title: t`Scale`,
+    index: 7,
+    group: t`Y-AXIS`,
     widget: "select",
     default: "linear",
     getProps: (series, vizSettings) => ({
@@ -514,7 +518,9 @@ export const GRAPH_AXIS_SETTINGS = {
   },
   "graph.x_axis.axis_enabled": {
     section: t`Axes`,
-    title: t`Show x-axis line and marks`,
+    group: t`X-AXIS`,
+    title: t`Show lines and marks`,
+    index: 3,
     widget: "select",
     props: {
       options: [
@@ -529,7 +535,9 @@ export const GRAPH_AXIS_SETTINGS = {
   },
   "graph.y_axis.axis_enabled": {
     section: t`Axes`,
-    title: t`Show y-axis line and marks`,
+    title: t`Show lines and marks`,
+    index: 8,
+    group: t`Y-AXIS`,
     widget: "select",
     props: {
       options: [
@@ -541,12 +549,17 @@ export const GRAPH_AXIS_SETTINGS = {
   },
   "graph.y_axis.auto_range": {
     section: t`Axes`,
+    group: t`Y-AXIS`,
+    index: 4,
     title: t`Auto y-axis range`,
+    inline: true,
     widget: "toggle",
     default: true,
   },
   "graph.y_axis.min": {
     section: t`Axes`,
+    group: t`Y-AXIS`,
+    index: 5,
     title: t`Min`,
     widget: "number",
     default: 0,
@@ -555,6 +568,8 @@ export const GRAPH_AXIS_SETTINGS = {
   },
   "graph.y_axis.max": {
     section: t`Axes`,
+    group: t`Y-AXIS`,
+    index: 6,
     title: t`Max`,
     widget: "number",
     default: 100,
@@ -585,20 +600,28 @@ export const GRAPH_AXIS_SETTINGS = {
 */
   "graph.y_axis.auto_split": {
     section: t`Axes`,
-    title: t`Use a split y-axis when necessary`,
+    group: t`Y-AXIS`,
+    index: 3,
+    title: t`Split y-axis when necessary`,
     widget: "toggle",
+    inline: true,
     default: true,
     getHidden: series => series.length < 2,
   },
   "graph.x_axis.labels_enabled": {
-    section: t`Labels`,
-    title: t`Show label on x-axis`,
+    section: t`Axes`,
+    group: t`X-AXIS`,
+    index: 1,
+    title: t`Show label`,
+    inline: true,
     widget: "toggle",
     default: true,
   },
   "graph.x_axis.title_text": {
-    section: t`Labels`,
-    title: t`X-axis label`,
+    section: t`Axes`,
+    title: t`Label`,
+    index: 2,
+    group: t`X-AXIS`,
     widget: "input",
     getHidden: (series, vizSettings) =>
       vizSettings["graph.x_axis.labels_enabled"] === false,
@@ -606,14 +629,19 @@ export const GRAPH_AXIS_SETTINGS = {
       series.length === 1 ? getFriendlyName(series[0].data.cols[0]) : null,
   },
   "graph.y_axis.labels_enabled": {
-    section: t`Labels`,
-    title: t`Show label on y-axis`,
+    section: t`Axes`,
+    title: t`Show label`,
+    index: 1,
+    group: t`Y-AXIS`,
     widget: "toggle",
+    inline: true,
     default: true,
   },
   "graph.y_axis.title_text": {
-    section: t`Labels`,
-    title: t`Y-axis label`,
+    section: t`Axes`,
+    title: t`Label`,
+    index: 2,
+    group: t`Y-AXIS`,
     widget: "input",
     getHidden: (series, vizSettings) =>
       vizSettings["graph.y_axis.labels_enabled"] === false,


### PR DESCRIPTION
EPIC #25453 

Adding the ability to group viz settings within `<ChartSettings/>` and provide a small header, as well as merging the Axes and Labels tab for graphs.

![image](https://user-images.githubusercontent.com/1328979/195189533-3d6ad7c8-8a5b-483b-ab01-f6d5699e8acd.png)

