### PR TITLE
[E2E] Guard workflow against the missing recording key

### DIFF
--- a/.github/workflows/e2e-main.yml
+++ b/.github/workflows/e2e-main.yml
@@ -51,6 +51,7 @@ jobs:
       MB_PREMIUM_EMBEDDING_TOKEN: ${{ secrets.ENTERPRISE_TOKEN }}
       MB_SNOWPLOW_AVAILABLE: true
       MB_SNOWPLOW_URL: "http://localhost:9090"  # Snowplow micro
+      RECORDING_ENABLED: ${{ secrets.CURRENTS_KEY }}
     strategy:
       fail-fast: false
       matrix:
@@ -137,7 +138,7 @@ jobs:
         mv version.properties resources/
 
     - name: Run Cypress tests on ${{ matrix.folder }} - Master Branch
-      if: ${{ github.ref == 'refs/heads/master' }}
+      if: github.ref == 'refs/heads/master' && env.RECORDING_ENABLED != null
       run: |
         yarn run test-cypress-run \
           --folder ${{ matrix.folder }} \


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Adds another conditional to E2E workflow which runs run on a `master` branch. This should prevent the whole workflow from failing if `CURRENTS_KEY` is not present.

### Background Info
Currents is an open-source Cypress Dashboard (service) alternative that lets us record Cypress runs. It provides useful analytics. We decided to record only commits merged to `master`.