### PR TITLE
Fix flaky DB sync scheduling test

### DIFF
--- a/test/metabase/models/database_test.clj
+++ b/test/metabase/models/database_test.clj
@@ -52,7 +52,6 @@
         (is (schema= {:description         (s/eq (format "sync-and-analyze Database %d" db-id))
                       :key                 (s/eq (format "metabase.task.sync-and-analyze.trigger.%d" db-id))
                       :misfire-instruction (s/eq "DO_NOTHING")
-                      :state               (s/eq "NORMAL")
                       :may-fire-again?     (s/eq true)
                       :schedule            (s/eq "0 50 * * * ? *")
                       :final-fire-time     (s/eq nil)
@@ -215,9 +214,9 @@
                 (testing " updating the value works as expected"
                   (db/update! Database id :details (assoc details :password-path  "/path/to/my/password-file"))
                   (check-db-fn (db/select-one Database :id id) {:kind    :password
-                                              :source  :file-path
-                                              :version 2
-                                              :value   "/path/to/my/password-file"}))))
+                                                                :source  :file-path
+                                                                :version 2
+                                                                :value   "/path/to/my/password-file"}))))
             (testing "Secret instances are deleted from the app DB when the DatabaseInstance is deleted"
               (is (seq @secret-ids) "At least one Secret instance should have been created")
               (doseq [secret-id @secret-ids]


### PR DESCRIPTION
This test is marked as flaky since sometimes `:state` is `BLOCKED` instead of `NORMAL` (for example, [here](https://app.circleci.com/pipelines/github/metabase/metabase/45915/workflows/557a6d94-be3c-4140-b732-8249ad20db98/jobs/2175945)). This is value is an enum internal to Quartz and I don't think it has any relevance to what the test itself is asserting (that a sync task gets scheduled when a DB is created), so I think it's safe to remove that key from the expected schema.

Also included a small indentation fix.