### PR TITLE
Clean up Slack error logging

### DIFF
--- a/src/metabase/integrations/slack.clj
+++ b/src/metabase/integrations/slack.clj
@@ -91,9 +91,8 @@
       ;; being used)
       (when (slack-token-valid?) (messages/send-slack-token-error-emails!))
       (slack-token-valid?! false))
-    (if invalid-token?
-      (log/warn (u/pprint-to-str 'red (trs "🔒 Your Slack authorization token is invalid or has been revoked. Please update your integration in Admin Settings -> Slack.")))
-      (log/warn (u/pprint-to-str 'red error)))
+    (when invalid-token?
+      (log/warn (u/pprint-to-str 'red (trs "🔒 Your Slack authorization token is invalid or has been revoked. Please update your integration in Admin Settings -> Slack."))))
     (throw (ex-info message error))))
 
 (defn- handle-response [{:keys [status body]}]
@@ -122,7 +121,7 @@
         (try
           (handle-response (request-fn url request))
           (catch Throwable e
-            (throw (ex-info (.getMessage e) (merge (ex-data e) {:url url, :request request}) e))))))))
+            (throw (ex-info (.getMessage e) (merge (ex-data e) {:url url}) e))))))))
 
 (defn- GET
   "Make a GET request to the Slack API."


### PR DESCRIPTION
Fixes #25849

* Removed `request` from the data we include when we re-throw a Slack exception. I thought about this for a bit and I came to the conclusion that logging the entire request doesn't really get us much in terms of debugging; Slack errors messages are pretty straightforward already. And this avoids us unintentionally logging the Slack token and the contents of a user's subscription.
* Removed duplicate logging that was happening for all errors aside from invalid token errors.