### PR TITLE
Remove metabase/lib/schema_metadata dependency

### DIFF
--- a/frontend/src/metabase-lib/lib/metadata/Field.ts
+++ b/frontend/src/metabase-lib/lib/metadata/Field.ts
@@ -4,7 +4,6 @@ import _ from "underscore";
 import moment from "moment-timezone";
 
 import { formatField, stripId } from "metabase/lib/formatting";
-import { getIconForField } from "metabase/lib/schema_metadata";
 import type { FieldFingerprint } from "metabase-types/api/field";
 import type { Field as FieldRef } from "metabase-types/types/Query";
 import {
@@ -41,7 +40,7 @@ import { FieldDimension } from "../Dimension";
 import Base from "./Base";
 import type Table from "./Table";
 import type Metadata from "./Metadata";
-import { getUniqueFieldId } from "./utils/fields";
+import { getIconForField, getUniqueFieldId } from "./utils/fields";
 
 export const LONG_TEXT_MIN = 80;
 

--- a/frontend/src/metabase-lib/lib/metadata/utils/fields.ts
+++ b/frontend/src/metabase-lib/lib/metadata/utils/fields.ts
@@ -1,5 +1,34 @@
 import { isVirtualCardId } from "metabase-lib/lib/metadata/utils/saved-questions";
+import {
+  BOOLEAN,
+  COORDINATE,
+  FOREIGN_KEY,
+  LOCATION,
+  NUMBER,
+  PRIMARY_KEY,
+  STRING,
+  STRING_LIKE,
+  TEMPORAL,
+} from "metabase-lib/lib/types/constants";
+import { getFieldType } from "metabase-lib/lib/types/utils/isa";
 import type Field from "../Field";
+
+const ICON_MAPPING: Record<string, string> = {
+  [TEMPORAL]: "calendar",
+  [LOCATION]: "location",
+  [COORDINATE]: "location",
+  [STRING]: "string",
+  [STRING_LIKE]: "string",
+  [NUMBER]: "int",
+  [BOOLEAN]: "io",
+  [FOREIGN_KEY]: "connections",
+  [PRIMARY_KEY]: "label",
+};
+
+export function getIconForField(fieldOrColumn: any) {
+  const type = getFieldType(fieldOrColumn);
+  return type && ICON_MAPPING[type] ? ICON_MAPPING[type] : "unknown";
+}
 
 export function getUniqueFieldId(field: Field): number | string {
   const { table_id } = field;

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/TableClickBehaviorView/Column.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/TableClickBehaviorView/Column.tsx
@@ -2,8 +2,6 @@ import React from "react";
 import { t, jt, ngettext, msgid } from "ttag";
 
 import { color } from "metabase/lib/colors";
-import { getIconForField } from "metabase/lib/schema_metadata";
-
 import Dashboards from "metabase/entities/dashboards";
 import Questions from "metabase/entities/questions";
 
@@ -13,6 +11,7 @@ import type {
   EntityCustomDestinationClickBehavior,
 } from "metabase-types/api";
 import type { Column as IColumn } from "metabase-types/types/Dataset";
+import { getIconForField } from "metabase-lib/lib/metadata/utils/fields";
 
 import { SidebarItem } from "../SidebarItem";
 

--- a/frontend/src/metabase/lib/schema_metadata.js
+++ b/frontend/src/metabase/lib/schema_metadata.js
@@ -1,16 +1,4 @@
 import { field_semantic_types_map } from "metabase/lib/core";
-import { getFieldType } from "metabase-lib/lib/types/utils/isa";
-import {
-  TEMPORAL,
-  LOCATION,
-  COORDINATE,
-  FOREIGN_KEY,
-  PRIMARY_KEY,
-  STRING,
-  STRING_LIKE,
-  NUMBER,
-  BOOLEAN,
-} from "metabase-lib/lib/types/constants";
 
 export function foreignKeyCountsByOriginTable(fks) {
   if (fks === null || !Array.isArray(fks)) {
@@ -30,22 +18,6 @@ export function foreignKeyCountsByOriginTable(fks) {
 
       return prev;
     }, {});
-}
-
-export const ICON_MAPPING = {
-  [TEMPORAL]: "calendar",
-  [LOCATION]: "location",
-  [COORDINATE]: "location",
-  [STRING]: "string",
-  [STRING_LIKE]: "string",
-  [NUMBER]: "int",
-  [BOOLEAN]: "io",
-  [FOREIGN_KEY]: "connections",
-  [PRIMARY_KEY]: "label",
-};
-
-export function getIconForField(field) {
-  return ICON_MAPPING[getFieldType(field)] || "unknown";
 }
 
 export function getSemanticTypeIcon(semanticType, fallback) {

--- a/frontend/src/metabase/reference/databases/FieldList.jsx
+++ b/frontend/src/metabase/reference/databases/FieldList.jsx
@@ -17,10 +17,9 @@ import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 import EditHeader from "metabase/reference/components/EditHeader";
 import EditableReferenceHeader from "metabase/reference/components/EditableReferenceHeader";
 
-import { getIconForField } from "metabase/lib/schema_metadata";
-
 import * as metadataActions from "metabase/redux/metadata";
 import * as actions from "metabase/reference/reference";
+import { getIconForField } from "metabase-lib/lib/metadata/utils/fields";
 import {
   getError,
   getFieldsByTable,

--- a/frontend/src/metabase/reference/segments/SegmentFieldList.jsx
+++ b/frontend/src/metabase/reference/segments/SegmentFieldList.jsx
@@ -17,10 +17,9 @@ import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 import EditHeader from "metabase/reference/components/EditHeader";
 import EditableReferenceHeader from "metabase/reference/components/EditableReferenceHeader";
 
-import { getIconForField } from "metabase/lib/schema_metadata";
-
 import * as metadataActions from "metabase/redux/metadata";
 import * as actions from "metabase/reference/reference";
+import { getIconForField } from "metabase-lib/lib/metadata/utils/fields";
 import {
   getError,
   getFieldsBySegment,


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/pull/25905

This is somewhat controversial. The problem is that we have `.icon()` methods for other metabase-lib entities, so I thought that just for now it makes sense to simply move code for icons for fields as well and deal with it later. I also tried untangling this by removing `.icon` but it's apparently quite hard not to break things by doing that. 