### PR TITLE
App DB data source should use default host/port for MySQL/Postgres

### DIFF
--- a/src/metabase/db/env.clj
+++ b/src/metabase/db/env.clj
@@ -132,8 +132,6 @@
 (def ^:private env
   (env* (config/config-kw :mb-db-type)))
 
-(println "(pr-str env):" (pr-str env)) ; NOCOMMIT
-
 (def db-type
   "Keyword type name of the application DB details specified by environment variables. Matches corresponding driver
   name e.g. `:h2`, `:mysql`, or `:postgres`."

--- a/src/metabase/db/env.clj
+++ b/src/metabase/db/env.clj
@@ -94,16 +94,45 @@
 
 ;;;; exports: [[db-type]], [[db-file]], and [[data-source]] created using environment variables.
 
+(defmulti ^:private env-defaults
+  {:arglists '([db-type])}
+  keyword)
+
+(defmethod env-defaults :h2
+  [_db-type]
+  nil)
+
+(defmethod env-defaults :mysql
+  [_db-type]
+  {:mb-db-host "localhost"
+   :mb-db-port 3306})
+
+(defmethod env-defaults :postgres
+  [_db-type]
+  {:mb-db-host "localhost"
+   :mb-db-port 5432})
+
+(defn- env* [db-type]
+  (merge-with
+   (fn [env-value default-value]
+     (if (nil? env-value)
+       default-value
+       env-value))
+   {:mb-db-type           db-type
+    :mb-db-in-memory      (config/config-bool :mb-db-in-memory)
+    :mb-db-file           (config/config-str :mb-db-file)
+    :mb-db-connection-uri (config/config-str :mb-db-connection-uri)
+    :mb-db-host           (config/config-str :mb-db-host)
+    :mb-db-port           (config/config-int :mb-db-port)
+    :mb-db-dbname         (config/config-str :mb-db-dbname)
+    :mb-db-user           (config/config-str :mb-db-user)
+    :mb-db-pass           (config/config-str :mb-db-pass)}
+   (env-defaults db-type)))
+
 (def ^:private env
-  {:mb-db-type           (config/config-kw :mb-db-type)
-   :mb-db-in-memory      (config/config-bool :mb-db-in-memory)
-   :mb-db-file           (config/config-str :mb-db-file)
-   :mb-db-connection-uri (config/config-str :mb-db-connection-uri)
-   :mb-db-host           (config/config-str :mb-db-host)
-   :mb-db-port           (config/config-int :mb-db-port)
-   :mb-db-dbname         (config/config-str :mb-db-dbname)
-   :mb-db-user           (config/config-str :mb-db-user)
-   :mb-db-pass           (config/config-str :mb-db-pass)})
+  (env* (config/config-kw :mb-db-type)))
+
+(println "(pr-str env):" (pr-str env)) ; NOCOMMIT
 
 (def db-type
   "Keyword type name of the application DB details specified by environment variables. Matches corresponding driver

--- a/test/metabase/db/env_test.clj
+++ b/test/metabase/db/env_test.clj
@@ -1,7 +1,8 @@
 (ns metabase.db.env-test
   (:require [clojure.test :refer :all]
             [metabase.db.data-source :as mdb.data-source]
-            [metabase.db.env :as mdb.env]))
+            [metabase.db.env :as mdb.env]
+            [metabase.test :as mt]))
 
 (deftest raw-connection-string->type-test
   (are [s expected] (= expected (#'mdb.env/raw-connection-string->type s))
@@ -27,3 +28,26 @@
       (is (= (mdb.data-source/raw-connection-string->DataSource "jdbc:postgresql://metabase" nil "1234")
              (#'mdb.env/env->DataSource :postgres {:mb-db-connection-uri "postgres://metabase", :mb-db-pass "1234"})
              (#'mdb.env/env->DataSource :postgres {:mb-db-connection-uri "postgres://metabase", :mb-db-user  "", :mb-db-pass "1234"}))))))
+
+(deftest env-test
+  (testing "default values for host and port"
+    (mt/with-temp-env-var-value [mb-db-host nil
+                                 mb-db-port nil]
+      (testing ":h2 -- don't supply defaults for host/port"
+        (is (partial= {:mb-db-port nil
+                       :mb-db-host nil}
+                      (#'mdb.env/env* :h2))))
+      (testing ":postgres"
+        (is (partial= {:mb-db-host "localhost"
+                       :mb-db-port 5432}
+                      (#'mdb.env/env* :postgres))))
+      (testing ":mysql"
+        (is (partial= {:mb-db-host "localhost"
+                       :mb-db-port 3306}
+                      (#'mdb.env/env* :mysql))))
+      (testing "Don't override values specified in environment variables with defaults."
+        (mt/with-temp-env-var-value [mb-db-port "3307"]
+          (doseq [db-type [:mysql :postgres]]
+            (testing db-type
+              (is (partial= {:mb-db-port 3307}
+                            (#'mdb.env/env* db-type))))))))))


### PR DESCRIPTION
I realized at some point after recent my app DB connection refactors over the last few cycles MySQL stopped working if you did not explicitly specify `MB_DB_HOST=localhost`... this used to be assumed if you did not say otherwise. 

This PR tweaks the application DB `DataSource`-from-env-vars logic to use `localhost` as the default host and `3306`/`5432` as the default ports for  MySQL and Postgres, respectively.