### PR TITLE
Toucan `:timestamped` property should not stomp explicit `:created_at` or `:updated_at`

### DIFF
--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -228,10 +228,12 @@
   ((resolve 'metabase.driver.sql.query-processor/current-datetime-honeysql-form) (mdb.connection/db-type)))
 
 (defn- add-created-at-timestamp [obj & _]
-  (assoc obj :created_at (now)))
+  (cond-> obj
+    (not (:created_at obj)) (assoc :created_at (now))))
 
 (defn- add-updated-at-timestamp [obj & _]
-  (assoc obj :updated_at (now)))
+  (cond-> obj
+    (not (:updated_at obj)) (assoc :updated_at (now))))
 
 (models/add-property! :timestamped?
   :insert (comp add-created-at-timestamp add-updated-at-timestamp)

--- a/test/metabase/models/interface_test.clj
+++ b/test/metabase/models/interface_test.clj
@@ -1,8 +1,14 @@
 (ns metabase.models.interface-test
-  (:require [cheshire.core :as json]
-            [clojure.test :refer :all]
-            [metabase.mbql.normalize :as mbql.normalize]
-            [toucan.models :as models]))
+  (:require
+   [cheshire.core :as json]
+   [clojure.test :refer :all]
+   [java-time :as t]
+   [metabase.db.connection :as mdb.connection]
+   [metabase.mbql.normalize :as mbql.normalize]
+   [metabase.models.field :refer [Field]]
+   [metabase.test :as mt]
+   [schema.core :as s]
+   [toucan.models :as models]))
 
 ;; let's make sure the `:metabase-query`/`:metric-segment-definition`/`::dashboard-card/parameter-mappings`
 ;; normalization functions respond gracefully to invalid stuff when pulling them out of the Database. See #8914
@@ -10,7 +16,7 @@
 (defn type-fn [toucan-type in-or-out]
   (-> @@#'models/type-fns toucan-type in-or-out))
 
-(deftest handle-bad-template-tags-test
+(deftest ^:parallel handle-bad-template-tags-test
   (testing (str "an malformed template tags map like the one below is invalid. Rather than potentially destroy an entire API "
                 "response because of one malformed Card, dump the error to the logs and return nil.")
     (is (= nil
@@ -20,7 +26,7 @@
               :type     :native
               :native   {:template-tags 1000}}))))))
 
-(deftest template-tag-validate-saves-test
+(deftest ^:parallel template-tag-validate-saves-test
   (testing "on the other hand we should be a little more strict on the way and disallow you from saving the invalid stuff"
     ;; TODO -- we should make sure this returns a good error message so we don't have to dig thru the exception chain.
     (is (thrown?
@@ -30,14 +36,14 @@
            :type     :native
            :native   {:template-tags {100 [:field-id "WOW"]}}})))))
 
-(deftest normalize-metric-segment-definition-test
+(deftest ^:parallel normalize-metric-segment-definition-test
   (testing "Legacy Metric/Segment definitions should get normalized"
     (is (= {:filter [:= [:field 1 nil] [:field 2 {:temporal-unit :month}]]}
            ((type-fn :metric-segment-definition :out)
             (json/generate-string
              {:filter [:= [:field-id 1] [:datetime-field [:field-id 2] :month]]}))))))
 
-(deftest dont-explode-on-way-out-from-db-test
+(deftest ^:parallel dont-explode-on-way-out-from-db-test
   (testing "`metric-segment-definition`s should avoid explosions coming out of the DB..."
     (is (= nil
            ((type-fn :metric-segment-definition :out)
@@ -66,3 +72,29 @@
          (with-redefs [mbql.normalize/normalize-tokens (fn [& _] (throw (Exception. "BARF")))]
            ((type-fn :parameters-list :in)
             [{:target [:dimension [:field "ABC" nil]]}]))))))
+
+(deftest timestamped-property-do-not-stomp-on-explicit-values-test
+  (testing "The :timestamped property should not stomp on :created_at/:updated_at if they are explicitly specified"
+    (mt/with-temp Field [field]
+      (testing "Nothing specified: use now() for both"
+        (is (schema= {:created_at java.time.temporal.Temporal
+                      :updated_at java.time.temporal.Temporal
+                      s/Keyword   s/Any}
+                     field))))
+    (let [t        #t "2022-10-13T19:21:00Z"
+          t-schema (s/eq (case (mdb.connection/db-type)
+                           ;; not sure why this is TIMESTAMP WITH TIME ZONE for Postgres but not for H2/MySQL. :shrug:
+                           :postgres    (t/offset-date-time "2022-10-13T19:21:00Z")
+                           (:h2 :mysql) (t/local-date-time "2022-10-13T19:21:00")))]
+      (testing "Explicitly specify :created_at"
+        (mt/with-temp Field [field {:created_at t}]
+          (is (schema= {:created_at t-schema
+                        :updated_at java.time.temporal.Temporal
+                        s/Keyword   s/Any}
+                       field))))
+      (testing "Explicitly specify :updated_at"
+        (mt/with-temp Field [field {:updated_at t}]
+          (is (schema= {:created_at java.time.temporal.Temporal
+                        :updated_at t-schema
+                        s/Keyword   s/Any}
+                       field)))))))


### PR DESCRIPTION
Models that have the Toucan `:timestamped` property automatically values for `:created_at` on `INSERT` and `:updated_at` on `INSERT` or `UPDATE` equal to `now()` or `current_timestamp` (or `current_timestamp(6)` for MySQL/MariaDB). However, this code always provides those values -- if you explicitly specify something different, it stomps on them.

This was never an issue in the past but with the new SerDes stuff we want to preserve `created_at` when it's present in the serialized YAML version of an object. This PR changes the Toucan `:timestamped` property to only provide values for the aforementioned columns if they are not already present.