### PR TITLE
Repro #24660: Saved Questions data selector lists all questions for collections with the same name

### DIFF
--- a/frontend/test/metabase/scenarios/collections/reproductions/24660-same-name-parent-collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/reproductions/24660-same-name-parent-collections.cy.spec.js
@@ -1,0 +1,43 @@
+import { restore, startNewQuestion } from "__support__/e2e/helpers";
+
+const collectionName = "Parent";
+
+const questions = {
+  1: "Orders",
+  2: "Orders, Count",
+};
+
+describe.skip("issue 24660", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    createParentCollectionAndMoveQuestionToIt(1);
+    createParentCollectionAndMoveQuestionToIt(2);
+  });
+
+  it("should properly show contents of different collections with the same name (metabase#24660)", () => {
+    startNewQuestion();
+    cy.findByText("Saved Questions").click();
+    cy.findAllByTestId("tree-item-name")
+      .contains(collectionName)
+      .first()
+      .click();
+
+    cy.findByText(questions[1]);
+    cy.findByText(questions[2]).should("not.exist");
+  });
+});
+
+function createParentCollectionAndMoveQuestionToIt(questionId) {
+  return cy
+    .createCollection({
+      name: collectionName,
+      parent_id: null,
+    })
+    .then(({ body: { id } }) => {
+      cy.request("PUT", `/api/card/${questionId}`, {
+        collection_id: id,
+      });
+    });
+}


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #24660

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/collections/reproductions/24660-same-name-parent-collections.cy.spec.js`
- Unskip repro
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/195692752-7ca5cb50-b9b7-48b0-915d-4c4c42798f1f.png)

