### PR TITLE
[CI] Update DockerHub release tokens

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,8 +118,8 @@ jobs:
     - name: Login to Docker Hub
       uses: docker/login-action@v1
       with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
+        username: ${{ secrets.DOCKERHUB_RELEASE_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_RELEASE_TOKEN }}
     - name: Retag and push container image to Docker Hub
       run: |
         echo "Pushing ${{ github.ref_name }} to ${{ env.DOCKERHUB_REPO }} ..."


### PR DESCRIPTION
Previous attempts (#24885 and #25163) by @ariya to test the release script kept failing because of the permissions scoped to the user (`DOCKERHUB_USERNAME`).
We've created a dedicated release user in DockerHub since then. Two new credentials are available to this repo and to this workflow only.

This PR updates those tokens.

> **Note**
> Keep in mind that the `release` workflow still uses non-existing `test-metabase*` Docker repos from one of the previous Ariya's attempts.

We can either:
- Update the name of the repo to the correct one (remove `test-`) or
- Test the waters during the next tag/release and intentionally use the test repository on top of the canonical one, which will be manually uploaded by the release manager