### PR TITLE
First take at parameterized data app page titles

### DIFF
--- a/frontend/src/metabase-types/api/data-app.ts
+++ b/frontend/src/metabase-types/api/data-app.ts
@@ -7,7 +7,6 @@ import {
 } from "./dashboard";
 import { WritebackAction } from "./writeback";
 import { ActionDisplayType } from "./writeback-form-settings";
-import { Card } from "./card";
 
 export type DataAppId = number;
 export type DataAppPage = Dashboard;
@@ -15,6 +14,7 @@ export type DataAppPageId = Dashboard["id"];
 
 export interface DataAppNavItem {
   page_id: DataAppPageId;
+  title_template?: string;
   indent?: number;
   hidden?: boolean;
 }

--- a/frontend/src/metabase/core/components/EditableText/EditableText.styled.tsx
+++ b/frontend/src/metabase/core/components/EditableText/EditableText.styled.tsx
@@ -1,7 +1,10 @@
 import styled from "@emotion/styled";
+import { css } from "@emotion/react";
+
 import { color } from "metabase/lib/colors";
 
 export interface EditableTextRootProps {
+  isEditing?: boolean;
   isDisabled: boolean;
 }
 
@@ -16,6 +19,13 @@ export const EditableTextRoot = styled.div<EditableTextRootProps>`
   &:focus-within {
     border-color: ${props => (props.isDisabled ? "" : color("border"))};
   }
+
+  ${props =>
+    props.isEditing &&
+    !props.isDisabled &&
+    css`
+      border-color: ${color("border")};
+    `}
 
   &:after {
     content: attr(data-value);

--- a/frontend/src/metabase/core/components/EditableText/EditableText.tsx
+++ b/frontend/src/metabase/core/components/EditableText/EditableText.tsx
@@ -22,6 +22,7 @@ export type EditableTextAttributes = Omit<
 export interface EditableTextProps extends EditableTextAttributes {
   initialValue?: string | null;
   placeholder?: string;
+  isEditing?: boolean;
   isOptional?: boolean;
   isMultiline?: boolean;
   isDisabled?: boolean;
@@ -35,6 +36,7 @@ const EditableText = forwardRef(function EditableText(
   {
     initialValue,
     placeholder,
+    isEditing = false,
     isOptional = false,
     isMultiline = false,
     isDisabled = false,
@@ -98,6 +100,7 @@ const EditableText = forwardRef(function EditableText(
     <EditableTextRoot
       {...props}
       ref={ref}
+      isEditing={isEditing}
       isDisabled={isDisabled}
       data-value={`${displayValue}\u00A0`}
     >

--- a/frontend/src/metabase/core/components/EditableText/EditableText.tsx
+++ b/frontend/src/metabase/core/components/EditableText/EditableText.tsx
@@ -26,6 +26,8 @@ export interface EditableTextProps extends EditableTextAttributes {
   isMultiline?: boolean;
   isDisabled?: boolean;
   onChange?: (value: string) => void;
+  onFocus?: () => void;
+  onBlur?: () => void;
   "data-testid"?: string;
 }
 
@@ -37,6 +39,8 @@ const EditableText = forwardRef(function EditableText(
     isMultiline = false,
     isDisabled = false,
     onChange,
+    onFocus,
+    onBlur,
     "data-testid": dataTestId,
     ...props
   }: EditableTextProps,
@@ -62,8 +66,9 @@ const EditableText = forwardRef(function EditableText(
         setSubmitValue(inputValue);
         onChange?.(inputValue);
       }
+      onBlur?.();
     },
-    [inputValue, submitValue, isOptional, onChange],
+    [inputValue, submitValue, isOptional, onChange, onBlur],
   );
 
   const handleChange = useCallback(
@@ -101,6 +106,7 @@ const EditableText = forwardRef(function EditableText(
         placeholder={placeholder}
         disabled={isDisabled}
         data-testid={dataTestId}
+        onFocus={onFocus}
         onBlur={handleBlur}
         onChange={handleChange}
         onKeyDown={handleKeyDown}

--- a/frontend/src/metabase/core/components/EditableText/index.ts
+++ b/frontend/src/metabase/core/components/EditableText/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./EditableText";
+export type { EditableTextProps } from "./EditableText";

--- a/frontend/src/metabase/dashboard/actions/writeback.ts
+++ b/frontend/src/metabase/dashboard/actions/writeback.ts
@@ -33,6 +33,10 @@ import { getCardData } from "../selectors";
 import { setDashCardAttributes } from "./core";
 import { reloadDashboardCards } from "./data-fetching";
 
+export const SET_PAGE_TITLE_TEMPLATE =
+  "metabase/data-app/SET_PAGE_TITLE_TEMPLATE";
+export const setPageTitleTemplate = createAction(SET_PAGE_TITLE_TEMPLATE);
+
 interface DashboardAttributes {
   card_id?: number | null;
   action?: WritebackAction | null;

--- a/frontend/src/metabase/dashboard/components/DashboardHeader.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader.styled.tsx
@@ -1,16 +1,18 @@
 import styled from "@emotion/styled";
 import { css } from "@emotion/react";
 
+import EditableText from "metabase/core/components/EditableText";
 import LastEditInfoLabel from "metabase/components/LastEditInfoLabel";
 
-import { alpha, color } from "metabase/lib/colors";
+import { color } from "metabase/lib/colors";
 import {
   breakpointMaxSmall,
   breakpointMinSmall,
   breakpointMaxMedium,
 } from "metabase/styled-components/theme";
-import EditableText from "metabase/core/components/EditableText";
 import { FullWidthContainer } from "metabase/styled-components/layout/FullWidthContainer";
+
+import DataAppPageTitle from "metabase/writeback/containers/DataAppPageTitle";
 
 interface TypeForItemsThatRespondToNavBarOpen {
   isNavBarOpen: boolean;
@@ -47,10 +49,19 @@ export const HeaderCaptionContainer = styled.div`
   right: 0.25rem;
 `;
 
-export const HeaderCaption = styled(EditableText)`
+const headerCaptionStyle = css`
   font-size: 1.25rem;
   font-weight: 700;
   line-height: 1.5rem;
+  min-width: 200px;
+`;
+
+export const HeaderCaption = styled(EditableText)`
+  ${headerCaptionStyle};
+`;
+
+export const DataAppPageCaption = styled(DataAppPageTitle)`
+  ${headerCaptionStyle};
 `;
 
 export const HeaderBadges = styled.div`

--- a/frontend/src/metabase/dashboard/components/DashboardHeader.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader.tsx
@@ -145,6 +145,8 @@ const DashboardHeader = ({
               <DataAppPageCaption
                 key={dashboard.name}
                 page={dashboard}
+                isEditing={isEditing}
+                isDisabled={!isEditing}
                 placeholder={t`Add title`}
                 data-testid="dashboard-name-heading"
                 onChange={handleUpdateCaption}

--- a/frontend/src/metabase/dashboard/components/DashboardHeader.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader.tsx
@@ -16,6 +16,7 @@ import { Dashboard } from "metabase-types/api";
 import EditBar from "metabase/components/EditBar";
 import EditWarning from "metabase/components/EditWarning";
 import HeaderModal from "metabase/components/HeaderModal";
+
 import {
   HeaderRoot,
   HeaderBadges,
@@ -25,6 +26,7 @@ import {
   HeaderLastEditInfoLabel,
   HeaderCaption,
   HeaderCaptionContainer,
+  DataAppPageCaption,
 } from "./DashboardHeader.styled";
 
 interface DashboardHeaderProps {
@@ -139,14 +141,24 @@ const DashboardHeader = ({
       >
         <HeaderContent hasSubHeader={!isDataApp} showSubHeader={showSubHeader}>
           <HeaderCaptionContainer>
-            <HeaderCaption
-              key={dashboard.name}
-              initialValue={dashboard.name}
-              placeholder={t`Add title`}
-              isDisabled={!dashboard.can_write}
-              data-testid="dashboard-name-heading"
-              onChange={handleUpdateCaption}
-            />
+            {isDataApp ? (
+              <DataAppPageCaption
+                key={dashboard.name}
+                page={dashboard}
+                placeholder={t`Add title`}
+                data-testid="dashboard-name-heading"
+                onChange={handleUpdateCaption}
+              />
+            ) : (
+              <HeaderCaption
+                key={dashboard.name}
+                initialValue={dashboard.name}
+                placeholder={t`Add title`}
+                isDisabled={!dashboard.can_write}
+                data-testid="dashboard-name-heading"
+                onChange={handleUpdateCaption}
+              />
+            )}
           </HeaderCaptionContainer>
           <HeaderBadges>
             {isLastEditInfoVisible && (

--- a/frontend/src/metabase/dashboard/components/DashboardHeader.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader.tsx
@@ -11,7 +11,7 @@ import cx from "classnames";
 import { useOnMount } from "metabase/hooks/use-on-mount";
 
 import { getScrollY } from "metabase/lib/dom";
-import { Dashboard } from "metabase-types/api";
+import type { Dashboard, DataAppNavItem } from "metabase-types/api";
 
 import EditBar from "metabase/components/EditBar";
 import EditWarning from "metabase/components/EditWarning";
@@ -41,6 +41,8 @@ interface DashboardHeaderProps {
   isEditingInfo: boolean;
   isNavBarOpen: boolean;
   dashboard: Dashboard;
+  dataAppNavItem?: DataAppNavItem;
+  pageTitleTemplate?: string;
   isBadgeVisible: boolean;
   isLastEditInfoVisible: boolean;
   children: React.ReactNode;
@@ -49,6 +51,7 @@ interface DashboardHeaderProps {
   onLastEditInfoClick: () => null;
   onSave: () => null;
   setDashboardAttribute: (prop: string, value: string) => null;
+  setPageTitleTemplate: (titleTemplate: string) => void;
 }
 
 const DashboardHeader = ({
@@ -62,6 +65,8 @@ const DashboardHeader = ({
   isEditing,
   isNavBarOpen,
   dashboard,
+  dataAppNavItem,
+  pageTitleTemplate,
   isLastEditInfoVisible,
   children,
   onHeaderModalDone,
@@ -69,6 +74,7 @@ const DashboardHeader = ({
   onLastEditInfoClick,
   onSave,
   setDashboardAttribute,
+  setPageTitleTemplate,
 }: DashboardHeaderProps) => {
   const [headerHeight, setHeaderHeight] = useState(0);
   const [showSubHeader, setShowSubHeader] = useState(true);
@@ -144,12 +150,14 @@ const DashboardHeader = ({
             {isDataApp ? (
               <DataAppPageCaption
                 key={dashboard.name}
+                value={pageTitleTemplate}
                 page={dashboard}
+                navItem={dataAppNavItem}
                 isEditing={isEditing}
                 isDisabled={!isEditing}
                 placeholder={t`Add title`}
                 data-testid="dashboard-name-heading"
-                onChange={handleUpdateCaption}
+                onChange={setPageTitleTemplate}
               />
             ) : (
               <HeaderCaption

--- a/frontend/src/metabase/dashboard/components/DashboardInfoSidebar.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardInfoSidebar.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useMemo } from "react";
 import _ from "underscore";
 import { t } from "ttag";
 import { connect } from "react-redux";
+import type { Location } from "history";
 
 import { PLUGIN_CACHING } from "metabase/plugins";
 import MetabaseSettings from "metabase/lib/settings";
@@ -26,19 +27,26 @@ import {
 
 interface DashboardInfoSidebarProps {
   dashboard: Dashboard;
-  setDashboardAttribute: (name: string, value: string | number | null) => void;
-  saveDashboardAndCards: (id: number) => void;
   revisions: RevisionType[];
   currentUser: User;
+  location?: Location;
+  params?: Record<string, string>;
+  setDashboardAttribute: (name: string, value: string | number | null) => void;
+  saveDashboardAndCards: (
+    id: number,
+    routerOpts: { location?: Location; params?: Record<string, string> },
+  ) => void;
   revertToRevision: (revision: RevisionType) => void;
 }
 
 const DashboardInfoSidebar = ({
   dashboard,
-  setDashboardAttribute,
-  saveDashboardAndCards,
   revisions,
   currentUser,
+  location,
+  params,
+  setDashboardAttribute,
+  saveDashboardAndCards,
   revertToRevision,
 }: DashboardInfoSidebarProps) => {
   const canWrite = dashboard.can_write;
@@ -49,14 +57,14 @@ const DashboardInfoSidebar = ({
   const handleDescriptionChange = useCallback(
     async (description: string) => {
       await setDashboardAttribute("description", description);
-      saveDashboardAndCards(dashboard.id);
+      saveDashboardAndCards(dashboard.id, { location, params });
     },
-    [setDashboardAttribute, saveDashboardAndCards, dashboard],
+    [setDashboardAttribute, saveDashboardAndCards, dashboard, location, params],
   );
 
   const handleUpdateCacheTTL = async (cache_ttl: number | null) => {
     await setDashboardAttribute("cache_ttl", cache_ttl);
-    saveDashboardAndCards(dashboard.id);
+    saveDashboardAndCards(dashboard.id, { location, params });
   };
 
   const events = useMemo(

--- a/frontend/src/metabase/dashboard/components/DashboardSidebars.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardSidebars.jsx
@@ -35,6 +35,7 @@ DashboardSidebars.propTypes = {
   isFullscreen: PropTypes.bool.isRequired,
   onCancel: PropTypes.func.isRequired,
   params: PropTypes.object,
+  location: PropTypes.object,
   sidebar: PropTypes.shape({
     name: PropTypes.string,
     props: PropTypes.object,
@@ -62,6 +63,7 @@ export function DashboardSidebars({
   setParameterFilteringParameters,
   isFullscreen,
   onCancel,
+  location,
   params,
   sidebar,
   closeSidebar,
@@ -157,6 +159,8 @@ export function DashboardSidebars({
       return (
         <DashboardInfoSidebar
           dashboard={dashboard}
+          location={location}
+          params={params}
           saveDashboardAndCards={saveDashboardAndCards}
           setDashboardAttribute={setDashboardAttribute}
         />

--- a/frontend/src/metabase/dashboard/containers/DashboardHeader.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardHeader.jsx
@@ -135,7 +135,8 @@ class DashboardHeader extends Component {
   }
 
   async onSave() {
-    await this.props.saveDashboardAndCards(this.props.dashboard.id);
+    const { dashboard, location, params, saveDashboardAndCards } = this.props;
+    await saveDashboardAndCards(dashboard.id, { location, params });
     this.onDoneEditing();
   }
 

--- a/frontend/src/metabase/dashboard/containers/DashboardHeader.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardHeader.jsx
@@ -24,8 +24,10 @@ import TippyPopover from "metabase/components/Popover/TippyPopover";
 import {
   getIsBookmarked,
   getIsShowDashboardInfoSidebar,
+  getDataAppNavItem,
+  getPageTitleTemplateChange,
 } from "metabase/dashboard/selectors";
-import { toggleSidebar } from "../actions";
+import { toggleSidebar, setPageTitleTemplate } from "../actions";
 
 import Header from "../components/DashboardHeader";
 import { SIDEBAR_NAME } from "../constants";
@@ -35,14 +37,21 @@ import {
 } from "./DashboardHeader.styled";
 
 const mapStateToProps = (state, props) => {
-  const isDataApp = props.dashboard.is_app_page;
-  const isShowingDashboardInfoSidebar =
-    !isDataApp && getIsShowDashboardInfoSidebar(state);
-  return {
+  const stateProps = {
     isBookmarked: getIsBookmarked(state, props),
     isNavBarOpen: getIsNavbarOpen(state),
-    isShowingDashboardInfoSidebar,
   };
+
+  const isDataApp = props.dashboard.is_app_page;
+  stateProps.isShowingDashboardInfoSidebar =
+    !isDataApp && getIsShowDashboardInfoSidebar(state);
+
+  if (isDataApp) {
+    stateProps.pageTitleTemplate = getPageTitleTemplateChange(state);
+    stateProps.dataAppNavItem = getDataAppNavItem(state, props.params);
+  }
+
+  return stateProps;
 };
 
 const mapDispatchToProps = {
@@ -52,6 +61,7 @@ const mapDispatchToProps = {
     Bookmark.actions.delete({ id, type: "dashboard" }),
   onChangeLocation: push,
   toggleSidebar,
+  setPageTitleTemplate,
 };
 
 class DashboardHeader extends Component {
@@ -68,6 +78,8 @@ class DashboardHeader extends Component {
 
   static propTypes = {
     dashboard: PropTypes.object.isRequired,
+    dataAppNavItem: PropTypes.object,
+    pageTitleTemplate: PropTypes.string,
     isEditable: PropTypes.bool.isRequired,
     isEditing: PropTypes.oneOfType([PropTypes.bool, PropTypes.object])
       .isRequired,
@@ -98,6 +110,8 @@ class DashboardHeader extends Component {
     sidebar: PropTypes.string.isRequired,
     setSidebar: PropTypes.func.isRequired,
     closeSidebar: PropTypes.func.isRequired,
+
+    setPageTitleTemplate: PropTypes.func.isRequired,
   };
 
   handleEdit(dashboard) {
@@ -163,6 +177,12 @@ class DashboardHeader extends Component {
   }
 
   getEditingButtons() {
+    const { dashboard, pageTitleTemplate } = this.props;
+
+    const isDataAppPage = dashboard.is_app_page;
+    const canSave =
+      !isDataAppPage || pageTitleTemplate === null || pageTitleTemplate !== "";
+
     return [
       <Button
         data-metabase-event="Dashboard;Cancel Edits"
@@ -175,6 +195,7 @@ class DashboardHeader extends Component {
       <ActionButton
         key="save"
         actionFn={() => this.onSave()}
+        disabled={!canSave}
         className="Button Button--primary Button--small"
         normalText={t`Save`}
         activeText={t`Saving…`}
@@ -410,11 +431,14 @@ class DashboardHeader extends Component {
   render() {
     const {
       dashboard,
+      dataAppNavItem,
+      pageTitleTemplate,
       isEditing,
       isFullscreen,
       isAdditionalInfoVisible,
       setDashboardAttribute,
       setSidebar,
+      setPageTitleTemplate,
     } = this.props;
 
     const isDataAppPage = dashboard.is_app_page;
@@ -426,6 +450,8 @@ class DashboardHeader extends Component {
         objectType="dashboard"
         analyticsContext="Dashboard"
         dashboard={dashboard}
+        dataAppNavItem={dataAppNavItem}
+        pageTitleTemplate={pageTitleTemplate}
         isEditing={isEditing}
         isBadgeVisible={!isEditing && !isFullscreen && isAdditionalInfoVisible}
         isLastEditInfoVisible={
@@ -444,6 +470,7 @@ class DashboardHeader extends Component {
         setDashboardAttribute={setDashboardAttribute}
         onLastEditInfoClick={() => setSidebar({ name: SIDEBAR_NAME.info })}
         onSave={() => this.onSave()}
+        setPageTitleTemplate={setPageTitleTemplate}
       />
     );
   }

--- a/frontend/src/metabase/dashboard/reducers.js
+++ b/frontend/src/metabase/dashboard/reducers.js
@@ -418,6 +418,9 @@ const titleTemplateChange = handleActions(
     [SET_PAGE_TITLE_TEMPLATE]: {
       next: (state, { payload }) => payload,
     },
+    [SET_EDITING_DASHBOARD]: {
+      next: (state, { payload: isEditing }) => (isEditing ? state : null),
+    },
     [RESET]: {
       next: () => null,
     },

--- a/frontend/src/metabase/dashboard/reducers.js
+++ b/frontend/src/metabase/dashboard/reducers.js
@@ -37,6 +37,7 @@ import {
   SET_SHOW_LOADING_COMPLETE_FAVICON,
   RESET,
   SET_PARAMETER_VALUES,
+  SET_PAGE_TITLE_TEMPLATE,
 } from "./actions";
 
 import { isVirtualDashCard, syncParametersAndEmbeddingParams } from "./utils";
@@ -409,6 +410,21 @@ const sidebar = handleActions(
   DEFAULT_SIDEBAR,
 );
 
+const titleTemplateChange = handleActions(
+  {
+    [INITIALIZE]: {
+      next: () => null,
+    },
+    [SET_PAGE_TITLE_TEMPLATE]: {
+      next: (state, { payload }) => payload,
+    },
+    [RESET]: {
+      next: () => null,
+    },
+  },
+  null,
+);
+
 const missingActionParameters = handleActions(
   {
     [INITIALIZE]: {
@@ -435,4 +451,5 @@ export default combineReducers({
   sidebar,
   parameterValuesSearchCache,
   missingActionParameters,
+  titleTemplateChange,
 });

--- a/frontend/src/metabase/dashboard/reducers.unit.spec.js
+++ b/frontend/src/metabase/dashboard/reducers.unit.spec.js
@@ -36,6 +36,7 @@ describe("dashboard reducers", () => {
       slowCards: {},
       loadingControls: {},
       missingActionParameters: null,
+      titleTemplateChange: null,
     });
   });
 

--- a/frontend/src/metabase/dashboard/selectors.js
+++ b/frontend/src/metabase/dashboard/selectors.js
@@ -4,6 +4,8 @@ import { createSelector } from "reselect";
 import { getMetadata } from "metabase/selectors/metadata";
 import { LOAD_COMPLETE_FAVICON } from "metabase/hoc/Favicon";
 
+import DataApps from "metabase/entities/data-apps";
+
 import {
   getDashboardUiParameters,
   getFilteringParameterValuesMap,
@@ -237,3 +239,14 @@ export const getIsAdditionalInfoVisible = createSelector(
   [getIsEmbedded, getEmbedOptions],
   (isEmbedded, embedOptions) => !isEmbedded || embedOptions.additional_info,
 );
+
+export const getDataApp = (state, routerParams) => {
+  const dataAppId = Number(routerParams.slug);
+  return DataApps.selectors.getObject(state, { entityId: dataAppId });
+};
+
+export const getDataAppNavItem = (state, routerParams) => {
+  const dashboard = getDashboardComplete(state);
+  const dataApp = getDataApp(state, routerParams);
+  return dataApp?.nav_items.find(navItem => navItem.page_id === dashboard.id);
+};

--- a/frontend/src/metabase/dashboard/selectors.js
+++ b/frontend/src/metabase/dashboard/selectors.js
@@ -250,3 +250,6 @@ export const getDataAppNavItem = (state, routerParams) => {
   const dataApp = getDataApp(state, routerParams);
   return dataApp?.nav_items.find(navItem => navItem.page_id === dashboard.id);
 };
+
+export const getPageTitleTemplateChange = state =>
+  state.dashboard.titleTemplateChange;

--- a/frontend/src/metabase/entities/data-apps/data-apps.ts
+++ b/frontend/src/metabase/entities/data-apps/data-apps.ts
@@ -67,7 +67,9 @@ const DataApps = createEntity({
       collection_id,
       ...rest
     }: UpdateDataAppParams) => {
-      await CollectionsApi.update({ ...collection, id: collection_id });
+      if (typeof collection_id === "number") {
+        await CollectionsApi.update({ ...collection, id: collection_id });
+      }
       return DataAppsApi.update({ id, ...rest });
     },
   },

--- a/frontend/src/metabase/writeback/components/DataAppPageTitle/DataAppPageTitle.styled.tsx
+++ b/frontend/src/metabase/writeback/components/DataAppPageTitle/DataAppPageTitle.styled.tsx
@@ -1,0 +1,39 @@
+import styled from "@emotion/styled";
+
+import IconButtonWrapper from "metabase/components/IconButtonWrapper";
+import Icon from "metabase/components/Icon";
+import SelectList from "metabase/components/SelectList";
+
+import { color } from "metabase/lib/colors";
+
+export const IconButton = styled(IconButtonWrapper)`
+  ${Icon.Root} {
+    color: ${color("brand-light")};
+  }
+
+  &:hover {
+    ${Icon.Root} {
+      color: ${color("brand")};
+    }
+  }
+`;
+
+export const Root = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 0.5rem;
+
+  &:hover {
+    ${IconButton} {
+      opacity: 1;
+    }
+  }
+`;
+
+export const OptionsList = styled(SelectList)`
+  padding: 0.5rem;
+  min-width: 300px;
+  height: 300px;
+  overflow-y: scroll;
+`;

--- a/frontend/src/metabase/writeback/components/DataAppPageTitle/DataAppPageTitle.styled.tsx
+++ b/frontend/src/metabase/writeback/components/DataAppPageTitle/DataAppPageTitle.styled.tsx
@@ -1,4 +1,5 @@
 import styled from "@emotion/styled";
+import { css } from "@emotion/react";
 
 import IconButtonWrapper from "metabase/components/IconButtonWrapper";
 import Icon from "metabase/components/Icon";
@@ -11,11 +12,22 @@ export const IconButton = styled(IconButtonWrapper)`
     color: ${color("brand-light")};
   }
 
-  &:hover {
-    ${Icon.Root} {
-      color: ${color("brand")};
-    }
-  }
+  ${props =>
+    props.disabled &&
+    css`
+      opacity: 0.5;
+      cursor: not-allowed;
+    `}
+
+  ${props =>
+    !props.disabled &&
+    css`
+      &:hover {
+        ${Icon.Root} {
+          color: ${color("brand")};
+        }
+      }
+    `}
 `;
 
 export const Root = styled.div`

--- a/frontend/src/metabase/writeback/components/DataAppPageTitle/DataAppPageTitle.tsx
+++ b/frontend/src/metabase/writeback/components/DataAppPageTitle/DataAppPageTitle.tsx
@@ -1,0 +1,42 @@
+import React, { useCallback, useState } from "react";
+
+import EditableText, {
+  EditableTextProps,
+} from "metabase/core/components/EditableText";
+
+export interface DataAppPageTitleProps
+  extends Omit<EditableTextProps, "initialValue"> {
+  titleTemplate: string;
+  compiledTitle?: string;
+}
+
+function DataAppPageTitle({
+  titleTemplate,
+  compiledTitle,
+  onFocus,
+  onBlur,
+  ...props
+}: DataAppPageTitleProps) {
+  const [isEditing, setEditing] = useState(false);
+
+  const handleFocus = useCallback(() => {
+    setEditing(true);
+    onFocus?.();
+  }, [onFocus]);
+
+  const handleBlur = useCallback(() => {
+    setEditing(false);
+    onBlur?.();
+  }, [onBlur]);
+
+  return (
+    <EditableText
+      {...props}
+      initialValue={isEditing ? titleTemplate : compiledTitle}
+      onFocus={handleFocus}
+      onBlur={handleBlur}
+    />
+  );
+}
+
+export default DataAppPageTitle;

--- a/frontend/src/metabase/writeback/components/DataAppPageTitle/DataAppPageTitle.tsx
+++ b/frontend/src/metabase/writeback/components/DataAppPageTitle/DataAppPageTitle.tsx
@@ -44,6 +44,10 @@ function DataAppPageTitle({
     [selectedCardName, titleTemplate, onChange],
   );
 
+  const handleBack = selectedCardName
+    ? () => setSelectedCardName("")
+    : undefined;
+
   return (
     <TippyPopoverWithTrigger
       renderTrigger={({ onClick: handleShowPopover }) => (
@@ -78,6 +82,7 @@ function DataAppPageTitle({
             onSelect(columnName);
             closePopover();
           }}
+          onBack={handleBack}
         />
       )}
     />

--- a/frontend/src/metabase/writeback/components/DataAppPageTitle/DataAppPageTitle.tsx
+++ b/frontend/src/metabase/writeback/components/DataAppPageTitle/DataAppPageTitle.tsx
@@ -38,7 +38,7 @@ function DataAppPageTitle({
   const onSelect = useCallback(
     (columnName: string) => {
       const token = `{{ data.${selectedCardName}.${columnName} }}`;
-      onChange?.(`${titleTemplate} ${token}`);
+      onChange?.(titleTemplate + token);
       setSelectedCardName("");
     },
     [selectedCardName, titleTemplate, onChange],

--- a/frontend/src/metabase/writeback/components/DataAppPageTitle/DataAppPageTitle.tsx
+++ b/frontend/src/metabase/writeback/components/DataAppPageTitle/DataAppPageTitle.tsx
@@ -1,40 +1,74 @@
 import React, { useCallback, useState } from "react";
+import _ from "lodash";
 
 import EditableText, {
   EditableTextProps,
 } from "metabase/core/components/EditableText";
+import TippyPopoverWithTrigger from "metabase/components/PopoverWithTrigger/TippyPopoverWithTrigger";
+
+import Icon from "metabase/components/Icon";
+
+import Suggestions from "./Suggestions";
+import { Root, IconButton } from "./DataAppPageTitle.styled";
+
+type CardName = string;
+type ColumnName = string;
 
 export interface DataAppPageTitleProps
   extends Omit<EditableTextProps, "initialValue"> {
   titleTemplate: string;
   compiledTitle?: string;
+  suggestions: Record<CardName, ColumnName[]>;
+  isEditing?: boolean;
 }
 
 function DataAppPageTitle({
   titleTemplate,
   compiledTitle,
-  onFocus,
-  onBlur,
+  suggestions,
+  isEditing = false,
+  onChange,
   ...props
 }: DataAppPageTitleProps) {
-  const [isEditing, setEditing] = useState(false);
+  const [selectedCardName, setSelectedCardName] = useState("");
 
-  const handleFocus = useCallback(() => {
-    setEditing(true);
-    onFocus?.();
-  }, [onFocus]);
-
-  const handleBlur = useCallback(() => {
-    setEditing(false);
-    onBlur?.();
-  }, [onBlur]);
+  const onSelect = useCallback(
+    (columnName: string) => {
+      const token = `{{ data.${selectedCardName}.${columnName} }}`;
+      onChange?.(`${titleTemplate} ${token}`);
+      setSelectedCardName("");
+    },
+    [selectedCardName, titleTemplate, onChange],
+  );
 
   return (
-    <EditableText
-      {...props}
-      initialValue={isEditing ? titleTemplate : compiledTitle}
-      onFocus={handleFocus}
-      onBlur={handleBlur}
+    <TippyPopoverWithTrigger
+      renderTrigger={({ onClick: handleShowPopover }) => (
+        <Root>
+          <EditableText
+            {...props}
+            initialValue={isEditing ? titleTemplate : compiledTitle}
+            isEditing={isEditing}
+            onChange={onChange}
+          />
+          {isEditing && (
+            <IconButton onClick={handleShowPopover}>
+              <Icon name="database" />
+            </IconButton>
+          )}
+        </Root>
+      )}
+      popoverContent={({ closePopover }) => (
+        <Suggestions
+          suggestions={suggestions}
+          selectedCardName={selectedCardName}
+          onSelectCard={setSelectedCardName}
+          onSelectColumn={columnName => {
+            onSelect(columnName);
+            closePopover();
+          }}
+        />
+      )}
     />
   );
 }

--- a/frontend/src/metabase/writeback/components/DataAppPageTitle/DataAppPageTitle.tsx
+++ b/frontend/src/metabase/writeback/components/DataAppPageTitle/DataAppPageTitle.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useState } from "react";
+import { t } from "ttag";
 import _ from "lodash";
 
 import EditableText, {
@@ -32,6 +33,8 @@ function DataAppPageTitle({
 }: DataAppPageTitleProps) {
   const [selectedCardName, setSelectedCardName] = useState("");
 
+  const hasSuggestions = Object.keys(suggestions).length > 0;
+
   const onSelect = useCallback(
     (columnName: string) => {
       const token = `{{ data.${selectedCardName}.${columnName} }}`;
@@ -52,8 +55,15 @@ function DataAppPageTitle({
             onChange={onChange}
           />
           {isEditing && (
-            <IconButton onClick={handleShowPopover}>
-              <Icon name="database" />
+            <IconButton onClick={handleShowPopover} disabled={!hasSuggestions}>
+              <Icon
+                name="database"
+                tooltip={
+                  hasSuggestions
+                    ? null
+                    : t`Page should have an object detail card to reference data`
+                }
+              />
             </IconButton>
           )}
         </Root>

--- a/frontend/src/metabase/writeback/components/DataAppPageTitle/DataAppPageTitle.tsx
+++ b/frontend/src/metabase/writeback/components/DataAppPageTitle/DataAppPageTitle.tsx
@@ -52,6 +52,7 @@ function DataAppPageTitle({
             {...props}
             initialValue={isEditing ? titleTemplate : compiledTitle}
             isEditing={isEditing}
+            isOptional
             onChange={onChange}
           />
           {isEditing && (

--- a/frontend/src/metabase/writeback/components/DataAppPageTitle/Suggestions.tsx
+++ b/frontend/src/metabase/writeback/components/DataAppPageTitle/Suggestions.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+import _ from "lodash";
+
+import SelectList from "metabase/components/SelectList";
+
+import { OptionsList } from "./DataAppPageTitle.styled";
+
+type CardName = string;
+type ColumnName = string;
+
+export interface SuggestionsProps {
+  suggestions: Record<CardName, ColumnName[]>;
+  selectedCardName?: CardName;
+  onSelectCard: (cardName: CardName) => void;
+  onSelectColumn: (columnName: ColumnName) => void;
+}
+
+function humanizeCamelCase(str: string) {
+  const words = _.words(str);
+  return words.map(word => _.capitalize(word)).join(" ");
+}
+
+function Suggestions({
+  suggestions,
+  selectedCardName,
+  onSelectCard,
+  onSelectColumn,
+}: SuggestionsProps) {
+  const options = selectedCardName
+    ? suggestions[selectedCardName]
+    : Object.keys(suggestions);
+
+  const icon = selectedCardName ? "field" : "document";
+
+  return (
+    <OptionsList>
+      {options.map(option => {
+        const name = humanizeCamelCase(option);
+        return (
+          <SelectList.Item
+            key={option}
+            id={option}
+            name={name}
+            icon={icon}
+            onSelect={() => {
+              if (selectedCardName) {
+                onSelectColumn(option);
+              } else {
+                onSelectCard(option);
+              }
+            }}
+          >
+            {name}
+          </SelectList.Item>
+        );
+      })}
+    </OptionsList>
+  );
+}
+
+export default Suggestions;

--- a/frontend/src/metabase/writeback/components/DataAppPageTitle/Suggestions.tsx
+++ b/frontend/src/metabase/writeback/components/DataAppPageTitle/Suggestions.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import _ from "lodash";
+import { t } from "ttag";
 
 import SelectList from "metabase/components/SelectList";
 
@@ -13,6 +14,7 @@ export interface SuggestionsProps {
   selectedCardName?: CardName;
   onSelectCard: (cardName: CardName) => void;
   onSelectColumn: (columnName: ColumnName) => void;
+  onBack?: () => void;
 }
 
 function humanizeCamelCase(str: string) {
@@ -25,6 +27,7 @@ function Suggestions({
   selectedCardName,
   onSelectCard,
   onSelectColumn,
+  onBack,
 }: SuggestionsProps) {
   const options = selectedCardName
     ? suggestions[selectedCardName]
@@ -34,6 +37,16 @@ function Suggestions({
 
   return (
     <OptionsList>
+      {typeof onBack === "function" && (
+        <SelectList.Item
+          id="back"
+          name={t`Back`}
+          icon="chevronleft"
+          onSelect={onBack}
+        >
+          {t`Back`}
+        </SelectList.Item>
+      )}
       {options.map(option => {
         const name = humanizeCamelCase(option);
         return (

--- a/frontend/src/metabase/writeback/components/DataAppPageTitle/index.ts
+++ b/frontend/src/metabase/writeback/components/DataAppPageTitle/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./DataAppPageTitle";
+export type { DataAppPageTitleProps } from "./DataAppPageTitle";

--- a/frontend/src/metabase/writeback/containers/DataAppContext/DataAppContext.ts
+++ b/frontend/src/metabase/writeback/containers/DataAppContext/DataAppContext.ts
@@ -1,14 +1,14 @@
 import { createContext, useContext } from "react";
 import _ from "lodash";
 
-import { Column } from "metabase-types/types/Dataset";
+import type { Column, Value } from "metabase-types/types/Dataset";
 
 type FieldName = string;
 type CardName = string;
 
-type ObjectDetailField = {
+export type ObjectDetailField = {
   column: Column;
-  value: unknown;
+  value: Value;
 };
 
 export type FormattedObjectDetail = Record<FieldName, ObjectDetailField>;

--- a/frontend/src/metabase/writeback/containers/DataAppContext/DataAppContext.ts
+++ b/frontend/src/metabase/writeback/containers/DataAppContext/DataAppContext.ts
@@ -1,7 +1,22 @@
 import { createContext, useContext } from "react";
-import _ from "underscore";
+import _ from "lodash";
+
+import { Column } from "metabase-types/types/Dataset";
+
+type FieldName = string;
+type CardName = string;
+
+type ObjectDetailField = {
+  column: Column;
+  value: unknown;
+};
+
+export type FormattedObjectDetail = Record<FieldName, ObjectDetailField>;
+
+export type DataContextType = Record<CardName, FormattedObjectDetail>;
 
 export type DataAppContextType = {
+  data: DataContextType;
   bulkActions: {
     cardId: number | null;
     selectedRowIndexes: number[];
@@ -9,9 +24,12 @@ export type DataAppContextType = {
     removeRow: (index: number) => void;
     clearSelection: () => void;
   };
+  isLoaded: boolean;
+  format: (text: string) => string;
 };
 
 export const DataAppContext = createContext<DataAppContextType>({
+  data: {},
   bulkActions: {
     cardId: null,
     selectedRowIndexes: [],
@@ -19,6 +37,8 @@ export const DataAppContext = createContext<DataAppContextType>({
     removeRow: _.noop,
     clearSelection: _.noop,
   },
+  isLoaded: true,
+  format: (text: string) => text,
 });
 
 export function useDataAppContext() {

--- a/frontend/src/metabase/writeback/containers/DataAppContext/utils.ts
+++ b/frontend/src/metabase/writeback/containers/DataAppContext/utils.ts
@@ -2,9 +2,13 @@ import _ from "lodash";
 import { getIn } from "icepick";
 import { t } from "ttag";
 
-import { Dataset } from "metabase-types/types/Dataset";
+import type { Dataset } from "metabase-types/types/Dataset";
 
-import { DataAppContextType, FormattedObjectDetail } from "./DataAppContext";
+import type {
+  DataAppContextType,
+  FormattedObjectDetail,
+  ObjectDetailField,
+} from "./DataAppContext";
 
 export function turnRawDataIntoObjectDetail({ data }: Dataset) {
   const objectDetail: FormattedObjectDetail = {};
@@ -38,6 +42,17 @@ function getContextPath(accessorString: string) {
 
 const PARAMETER_ACCESSOR_REGEXP = /{{(.*?)}}/m;
 
+function getTemplateParameterDisplayValue(
+  templateParameter?: ObjectDetailField,
+) {
+  const isLoading = !templateParameter;
+  if (isLoading) {
+    return t`Loading…`;
+  }
+  const missingValue = templateParameter.value === null;
+  return missingValue ? t`N/A` : String(templateParameter.value);
+}
+
 /**
  * Takes a string and replaces all instances of {{parameterName}} with the value of the parameter
  *
@@ -60,10 +75,10 @@ export function formatDataAppString(
   const [parameterAccessor] = match;
   let formattedText = text;
   const path = getContextPath(parameterAccessor);
-  const parameter = getIn(context, path);
+  const parameter: ObjectDetailField = getIn(context, path);
   formattedText = formattedText.replace(
     parameterAccessor,
-    parameter?.value ? parameter.value : t`Loading…`,
+    getTemplateParameterDisplayValue(parameter),
   );
   return formatDataAppString(formattedText, context);
 }

--- a/frontend/src/metabase/writeback/containers/DataAppContext/utils.ts
+++ b/frontend/src/metabase/writeback/containers/DataAppContext/utils.ts
@@ -1,0 +1,69 @@
+import _ from "lodash";
+import { getIn } from "icepick";
+import { t } from "ttag";
+
+import { Dataset } from "metabase-types/types/Dataset";
+
+import { DataAppContextType, FormattedObjectDetail } from "./DataAppContext";
+
+export function turnRawDataIntoObjectDetail({ data }: Dataset) {
+  const objectDetail: FormattedObjectDetail = {};
+  const { cols, rows } = data;
+  const [row] = rows;
+
+  if (!row) {
+    return objectDetail;
+  }
+
+  cols.forEach((column, columnIndex) => {
+    const formattedColumnName = _.camelCase(column.display_name);
+    objectDetail[formattedColumnName] = {
+      column,
+      value: row[columnIndex],
+    };
+  });
+
+  return objectDetail;
+}
+
+// Accessor string looks like "{{ data.user.name }}"
+// Output looks like [ "data", "user", "name" ]
+function getContextPath(accessorString: string) {
+  const cleanPathString = accessorString
+    .replaceAll("{", "")
+    .replaceAll("}", "")
+    .trim();
+  return cleanPathString.split(".");
+}
+
+const PARAMETER_ACCESSOR_REGEXP = /{{(.*?)}}/m;
+
+/**
+ * Takes a string and replaces all instances of {{parameterName}} with the value of the parameter
+ *
+ * @example
+ * Input: "### {{ data.user.name }} from {{ data.user.company }}"
+ * Output: "### John from Metabase"
+ *
+ * @param text parameterized text
+ * @param context data app context to use when resolving parameter values
+ * @returns formatted text with parameters replaced with real values
+ */
+export function formatDataAppString(
+  text: string,
+  context: DataAppContextType,
+): string {
+  const match = PARAMETER_ACCESSOR_REGEXP.exec(text);
+  if (!match) {
+    return text;
+  }
+  const [parameterAccessor] = match;
+  let formattedText = text;
+  const path = getContextPath(parameterAccessor);
+  const parameter = getIn(context, path);
+  formattedText = formattedText.replace(
+    parameterAccessor,
+    parameter?.value ? parameter.value : t`Loading…`,
+  );
+  return formatDataAppString(formattedText, context);
+}

--- a/frontend/src/metabase/writeback/containers/DataAppPageTitle.tsx
+++ b/frontend/src/metabase/writeback/containers/DataAppPageTitle.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 
 import { useDataAppContext } from "metabase/writeback/containers/DataAppContext";
 
@@ -9,18 +9,33 @@ import DataAppPageTitleView, {
 import type { DataAppPage } from "metabase-types/api";
 
 interface Props
-  extends Omit<DataAppPageTitleViewProps, "titleTemplate" | "compiledTitle"> {
+  extends Omit<
+    DataAppPageTitleViewProps,
+    "titleTemplate" | "compiledTitle" | "suggestions"
+  > {
   page: DataAppPage;
 }
 
 function DataAppPageTitle({ page, ...props }: Props) {
-  const { format } = useDataAppContext();
+  const { data, format } = useDataAppContext();
+
+  const suggestions = useMemo(() => {
+    const entries = Object.entries(data);
+    return Object.fromEntries(
+      entries.map(entry => {
+        const [cardName, columnsNameValueMap] = entry;
+        const columnNames = Object.keys(columnsNameValueMap);
+        return [cardName, columnNames];
+      }),
+    );
+  }, [data]);
 
   return (
     <DataAppPageTitleView
       titleTemplate={page.name}
       compiledTitle={format(page.name)}
       isDisabled={!page.can_write}
+      suggestions={suggestions}
       {...props}
     />
   );

--- a/frontend/src/metabase/writeback/containers/DataAppPageTitle.tsx
+++ b/frontend/src/metabase/writeback/containers/DataAppPageTitle.tsx
@@ -13,7 +13,7 @@ interface Props
   page: DataAppPage;
 }
 
-function DataAppTitle({ page, ...props }: Props) {
+function DataAppPageTitle({ page, ...props }: Props) {
   const { format } = useDataAppContext();
 
   return (
@@ -26,4 +26,4 @@ function DataAppTitle({ page, ...props }: Props) {
   );
 }
 
-export default DataAppTitle;
+export default DataAppPageTitle;

--- a/frontend/src/metabase/writeback/containers/DataAppPageTitle.tsx
+++ b/frontend/src/metabase/writeback/containers/DataAppPageTitle.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+
+import { useDataAppContext } from "metabase/writeback/containers/DataAppContext";
+
+import DataAppPageTitleView, {
+  DataAppPageTitleProps as DataAppPageTitleViewProps,
+} from "metabase/writeback/components/DataAppPageTitle";
+
+import type { DataAppPage } from "metabase-types/api";
+
+interface Props
+  extends Omit<DataAppPageTitleViewProps, "titleTemplate" | "compiledTitle"> {
+  page: DataAppPage;
+}
+
+function DataAppTitle({ page, ...props }: Props) {
+  const { format } = useDataAppContext();
+
+  return (
+    <DataAppPageTitleView
+      titleTemplate={page.name}
+      compiledTitle={format(page.name)}
+      isDisabled={!page.can_write}
+      {...props}
+    />
+  );
+}
+
+export default DataAppTitle;

--- a/frontend/src/metabase/writeback/containers/DataAppPageTitle.tsx
+++ b/frontend/src/metabase/writeback/containers/DataAppPageTitle.tsx
@@ -6,18 +6,27 @@ import DataAppPageTitleView, {
   DataAppPageTitleProps as DataAppPageTitleViewProps,
 } from "metabase/writeback/components/DataAppPageTitle";
 
-import type { DataAppPage } from "metabase-types/api";
+import type { DataAppPage, DataAppNavItem } from "metabase-types/api";
 
 interface Props
   extends Omit<
     DataAppPageTitleViewProps,
     "titleTemplate" | "compiledTitle" | "suggestions"
   > {
+  value?: string;
   page: DataAppPage;
+  navItem?: DataAppNavItem;
 }
 
-function DataAppPageTitle({ page, ...props }: Props) {
+function DataAppPageTitle({
+  page,
+  navItem,
+  value: initialValue,
+  ...props
+}: Props) {
   const { data, format } = useDataAppContext();
+
+  const value = initialValue ?? navItem?.title_template ?? page.name;
 
   const suggestions = useMemo(() => {
     const entries = Object.entries(data);
@@ -32,8 +41,8 @@ function DataAppPageTitle({ page, ...props }: Props) {
 
   return (
     <DataAppPageTitleView
-      titleTemplate={page.name}
-      compiledTitle={format(page.name)}
+      titleTemplate={value}
+      compiledTitle={format(value)}
       isDisabled={!page.can_write}
       suggestions={suggestions}
       {...props}


### PR DESCRIPTION
Adds basic implementation of parameterized page titles.

The implementation is based on the approach taken in the #23533 prototype PR. The key difference is that this PR only lets us parameterize page titles as opposed to markdown cards. Also adds some UI to explore available data a user can mention in the page title.

The resulting title is stored in the page's nav item. That required changes to the dashboard code to make it more aware of data apps and pages and added a bit of extra diff.

### To Verify

1. New > App > Sample Dataset > People > Create
2. Open a user detail page
3. Make sure page name is used by default when there is no title template provided yet (should say something like People Detail)
5. Enter editing mode
6. Clear the name input and make sure the "Save" button becomes disabled
7. Use the "data" icon next to the name input to browse data you can put into the page title
8. Build a title template that looks good to you, click Save
9. Go through a few pages and make sure you see expected data in page titles

#### Demo

https://user-images.githubusercontent.com/17258145/195879433-315ebbeb-79c6-41f5-9284-ddc0c982d2f4.mp4

