### PR TITLE
Show data app page ID parameters in editing mode

### DIFF
--- a/frontend/src/metabase/parameters/components/ParametersList.jsx
+++ b/frontend/src/metabase/parameters/components/ParametersList.jsx
@@ -31,6 +31,13 @@ const SortableParameterWidgetList = SortableContainer(
   StaticParameterWidgetList,
 );
 
+function DashboardParameterWidget({ parameter, ...props }) {
+  if (parameter.hidden) {
+    return null;
+  }
+  return <StaticParameterWidget parameter={parameter} {...props} />;
+}
+
 function ParametersList({
   className,
 
@@ -47,7 +54,6 @@ function ParametersList({
 
   setParameterValue,
   setParameterIndex,
-  removeParameter,
   setEditingParameter,
 }) {
   const handleSortStart = () => {
@@ -72,7 +78,7 @@ function ParametersList({
     ParameterWidget = SortableParameterWidget;
     ParameterWidgetList = SortableParameterWidgetList;
   } else {
-    ParameterWidget = StaticParameterWidget;
+    ParameterWidget = DashboardParameterWidget;
     ParameterWidgetList = StaticParameterWidgetList;
   }
 

--- a/frontend/src/metabase/parameters/utils/ui.ts
+++ b/frontend/src/metabase/parameters/utils/ui.ts
@@ -37,9 +37,7 @@ export function getVisibleParameters(
   const hiddenParametersSlugSet =
     buildHiddenParametersSlugSet(hiddenParameterSlugs);
 
-  return parameters.filter(
-    p => !hiddenParametersSlugSet.has(p.slug) && !p.hidden,
-  );
+  return parameters.filter(p => !hiddenParametersSlugSet.has(p.slug));
 }
 
 export function getParameterWidgetTitle(parameter: UiParameter) {

--- a/frontend/src/metabase/parameters/utils/ui.unit.spec.ts
+++ b/frontend/src/metabase/parameters/utils/ui.unit.spec.ts
@@ -54,10 +54,6 @@ describe("parameters/utils/ui", () => {
         id: "4",
         slug: "qux",
       }),
-      createMockUiParameter({
-        id: "5",
-        hidden: true,
-      }),
     ];
 
     const hiddenParameterSlugs = "bar,baz";


### PR DESCRIPTION
After #25873 we don't show data app page parameters marked as `hidden: true` on the FE. In practice, it appeared to be handy to have them visible/manageable in page editing mode.

### To Verify

1. New > App > Pick a table > Create
2. Open a details page
3. Ensure you can't see any ID filters
4. Enter page editing mode, ensure you can see and manage the ID filters
5. Ensure regular dashboards work as expected

### Demo

https://user-images.githubusercontent.com/17258145/195909015-f00fbc82-af40-4e86-bc2c-f99d8f88fba6.mp4

