### PR TITLE
Automatically set initial sync status of crufty tables to `complete`

### DIFF
--- a/src/metabase/sync/sync_metadata/tables.clj
+++ b/src/metabase/sync/sync_metadata/tables.clj
@@ -110,14 +110,16 @@
       (db/update! Table existing-id
         :active true)
       ;; otherwise create a new Table
-      (db/insert! Table
-        :db_id           (u/the-id database)
-        :schema          schema
-        :name            table-name
-        :display_name    (humanization/name->human-readable-name table-name)
-        :active          true
-        :visibility_type (when (is-crufty-table? table)
-                           :cruft)))))
+      (let [is-crufty? (is-crufty-table? table)]
+       (db/insert! Table
+         :db_id               (u/the-id database)
+         :schema              schema
+         :name                table-name
+         :display_name        (humanization/name->human-readable-name table-name)
+         :active              true
+         :visibility_type     (when is-crufty? :cruft)
+         ;; if this is a crufty table, mark initial sync as complete since we'll skip the subsequent sync steps
+         :initial_sync_status (if is-crufty? "complete" "incomplete"))))))
 
 
 (s/defn ^:private retire-tables!

--- a/test/metabase/sync/sync_metadata/tables_test.clj
+++ b/test/metabase/sync/sync_metadata/tables_test.clj
@@ -25,8 +25,8 @@
 (deftest crufty-tables-test
   (testing "south_migrationhistory, being a CRUFTY table, should still be synced, but marked as such"
     (mt/dataset metabase.sync.sync-metadata.tables-test/db-with-some-cruft
-      (is (= #{{:name "SOUTH_MIGRATIONHISTORY", :visibility_type :cruft}
-               {:name "ACQUIRED_TOUCANS",       :visibility_type nil}}
+      (is (= #{{:name "SOUTH_MIGRATIONHISTORY", :visibility_type :cruft, :initial_sync_status "complete"}
+               {:name "ACQUIRED_TOUCANS",       :visibility_type nil,    :initial_sync_status "complete"}}
              (set (for [table (db/select [Table :name :visibility_type], :db_id (mt/id))]
                     (into {} table))))))))
 

--- a/test/metabase/sync/sync_metadata/tables_test.clj
+++ b/test/metabase/sync/sync_metadata/tables_test.clj
@@ -27,7 +27,7 @@
     (mt/dataset metabase.sync.sync-metadata.tables-test/db-with-some-cruft
       (is (= #{{:name "SOUTH_MIGRATIONHISTORY", :visibility_type :cruft, :initial_sync_status "complete"}
                {:name "ACQUIRED_TOUCANS",       :visibility_type nil,    :initial_sync_status "complete"}}
-             (set (for [table (db/select [Table :name :visibility_type], :db_id (mt/id))]
+             (set (for [table (db/select [Table :name :visibility_type :initial_sync_status], :db_id (mt/id))]
                     (into {} table))))))))
 
 (deftest retire-tables-test


### PR DESCRIPTION
Resolves #25291

Currently we set `initial_sync_status` of tables to `complete` after the FK sync step completes. But for tables which are detected as "crufty" automatically, subsequent sync steps are skipped, so the sync is never considered complete. This PR changes the logic to set `initial_sync_status` to `complete` automatically when crufty tables are created.