### PR TITLE
Frontend for deep copying dashboards

### DIFF
--- a/frontend/src/metabase/collections/components/CollectionCopyEntityModal.jsx
+++ b/frontend/src/metabase/collections/components/CollectionCopyEntityModal.jsx
@@ -10,6 +10,7 @@ import { entityTypeForObject } from "metabase/lib/schema";
 
 import Link from "metabase/core/components/Link";
 
+import Dashboards from "metabase/entities/dashboards";
 import Collections from "metabase/entities/collections";
 import EntityCopyModal from "metabase/entities/containers/EntityCopyModal";
 
@@ -37,6 +38,7 @@ function CollectionCopyEntityModal({
         ...entityObject,
         collection_id: initialCollectionId,
       }}
+      form={Dashboards.forms.duplicate}
       copy={async values => {
         return entityObject.copy(dissoc(values, "id"));
       }}

--- a/frontend/src/metabase/dashboard/components/DashboardCopyModal.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardCopyModal.jsx
@@ -43,6 +43,7 @@ class DashboardCopyModalInner extends React.Component {
       ...props
     } = this.props;
     const initialDashboardId = Urls.extractEntityId(params.slug);
+    console.log("🚀", { props });
     return (
       <EntityCopyModal
         entityType="dashboards"
@@ -51,11 +52,18 @@ class DashboardCopyModalInner extends React.Component {
           collection_id: initialCollectionId,
         }}
         overwriteOnInitialValuesChange
-        copy={object =>
-          copyDashboard({ id: initialDashboardId }, dissoc(object, "id"))
-        }
+        copy={object => {
+          console.log("🚀", "copied");
+          /* eslint-disable */
+          return;
+          copyDashboard({ id: initialDashboardId }, dissoc(object, "id"));
+        }}
         onClose={onClose}
-        onSaved={dashboard => onReplaceLocation(Urls.dashboard(dashboard))}
+        onSaved={dashboard => {
+          console.log("🚀", "pretend it's saved");
+          return;
+          onReplaceLocation(Urls.dashboard(dashboard));
+        }}
         {...props}
       />
     );

--- a/frontend/src/metabase/dashboard/components/DashboardCopyModal.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardCopyModal.jsx
@@ -51,6 +51,7 @@ class DashboardCopyModalInner extends React.Component {
           ...dashboard,
           collection_id: initialCollectionId,
         }}
+        form={Dashboards.forms.duplicate}
         overwriteOnInitialValuesChange
         copy={object => {
           console.log("🚀", "copied");

--- a/frontend/src/metabase/dashboard/components/DashboardCopyModal.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardCopyModal.jsx
@@ -42,8 +42,9 @@ class DashboardCopyModalInner extends React.Component {
       params,
       ...props
     } = this.props;
+
     const initialDashboardId = Urls.extractEntityId(params.slug);
-    console.log("🚀", { props });
+
     return (
       <EntityCopyModal
         entityType="dashboards"
@@ -54,13 +55,11 @@ class DashboardCopyModalInner extends React.Component {
         form={Dashboards.forms.duplicate}
         overwriteOnInitialValuesChange
         copy={object => {
-          console.log("🚀", "copied");
-          /* eslint-disable */
-          return;
           copyDashboard({ id: initialDashboardId }, dissoc(object, "id"));
         }}
         onClose={onClose}
         onSaved={dashboard => {
+          /* eslint-disable */
           console.log("🚀", "pretend it's saved");
           return;
           onReplaceLocation(Urls.dashboard(dashboard));

--- a/frontend/src/metabase/dashboard/components/DashboardCopyModal.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardCopyModal.jsx
@@ -58,9 +58,7 @@ class DashboardCopyModalInner extends React.Component {
           copyDashboard({ id: initialDashboardId }, dissoc(object, "id"))
         }
         onClose={onClose}
-        onSaved={dashboard => {
-          onReplaceLocation(Urls.dashboard(dashboard));
-        }}
+        onSaved={dashboard => onReplaceLocation(Urls.dashboard(dashboard))}
         {...props}
       />
     );

--- a/frontend/src/metabase/dashboard/components/DashboardCopyModal.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardCopyModal.jsx
@@ -55,13 +55,14 @@ class DashboardCopyModalInner extends React.Component {
         form={Dashboards.forms.duplicate}
         overwriteOnInitialValuesChange
         copy={object => {
-          copyDashboard({ id: initialDashboardId }, dissoc(object, "id"));
+          console.log("🚀", { object });
+          return copyDashboard(
+            { id: initialDashboardId },
+            dissoc(object, "id"),
+          );
         }}
         onClose={onClose}
         onSaved={dashboard => {
-          /* eslint-disable */
-          console.log("🚀", "pretend it's saved");
-          return;
           onReplaceLocation(Urls.dashboard(dashboard));
         }}
         {...props}

--- a/frontend/src/metabase/dashboard/components/DashboardCopyModal.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardCopyModal.jsx
@@ -54,13 +54,9 @@ class DashboardCopyModalInner extends React.Component {
         }}
         form={Dashboards.forms.duplicate}
         overwriteOnInitialValuesChange
-        copy={object => {
-          console.log("🚀", { object });
-          return copyDashboard(
-            { id: initialDashboardId },
-            dissoc(object, "id"),
-          );
-        }}
+        copy={object =>
+          copyDashboard({ id: initialDashboardId }, dissoc(object, "id"))
+        }
         onClose={onClose}
         onSaved={dashboard => {
           onReplaceLocation(Urls.dashboard(dashboard));

--- a/frontend/src/metabase/entities/containers/EntityForm.jsx
+++ b/frontend/src/metabase/entities/containers/EntityForm.jsx
@@ -36,6 +36,8 @@ const EForm = ({
       />
     );
   }
+  console.log("🚀", { entityDef, entityObject, form, props });
+
   return (
     <Form
       {...props}

--- a/frontend/src/metabase/entities/containers/EntityForm.jsx
+++ b/frontend/src/metabase/entities/containers/EntityForm.jsx
@@ -36,7 +36,6 @@ const EForm = ({
       />
     );
   }
-  console.log("🚀", { entityDef, entityObject, form, props });
 
   return (
     <Form

--- a/frontend/src/metabase/entities/dashboards.js
+++ b/frontend/src/metabase/entities/dashboards.js
@@ -114,6 +114,16 @@ const Dashboards = createEntity({
         payload: savedDashboard,
       };
     },
+
+    copy: dashboard => async dispatch => {
+      console.log("🚀", "In the copy function");
+      // const savedDashboard = await Dashboards.api.save(dashboard);
+      // dispatch({ type: Dashboards.actionTypes.INVALIDATE_LISTS_ACTION });
+      // return {
+      //   type: "metabase/entities/dashboards/SAVE_DASHBOARD",
+      //   payload: savedDashboard,
+      // };
+    },
   },
 
   reducer: (state = {}, { type, payload, error }) => {

--- a/frontend/src/metabase/entities/dashboards.js
+++ b/frontend/src/metabase/entities/dashboards.js
@@ -90,12 +90,16 @@ const Dashboards = createEntity({
     )(
       (entityObject, overrides, { notify } = {}) =>
         async (dispatch, getState) => {
+          console.log("🚀", { entityObject, overrides, notify });
+          const copyStyle = overrides.shallow_copy ? "shallow" : "deep";
           const result = Dashboards.normalize(
             await Dashboards.api.copy({
               id: entityObject.id,
               ...overrides,
+              "copy-style": copyStyle,
             }),
           );
+          console.log("🚀", { result });
           if (notify) {
             dispatch(addUndo(notify));
           }
@@ -113,16 +117,6 @@ const Dashboards = createEntity({
         type: "metabase/entities/dashboards/SAVE_DASHBOARD",
         payload: savedDashboard,
       };
-    },
-
-    copy: dashboard => async dispatch => {
-      console.log("🚀", "In the copy function");
-      // const savedDashboard = await Dashboards.api.save(dashboard);
-      // dispatch({ type: Dashboards.actionTypes.INVALIDATE_LISTS_ACTION });
-      // return {
-      //   type: "metabase/entities/dashboards/SAVE_DASHBOARD",
-      //   payload: savedDashboard,
-      // };
     },
   },
 

--- a/frontend/src/metabase/entities/dashboards.js
+++ b/frontend/src/metabase/entities/dashboards.js
@@ -90,16 +90,13 @@ const Dashboards = createEntity({
     )(
       (entityObject, overrides, { notify } = {}) =>
         async (dispatch, getState) => {
-          console.log("🚀", { entityObject, overrides, notify });
-          const copyStyle = overrides.shallow_copy ? "shallow" : "deep";
           const result = Dashboards.normalize(
             await Dashboards.api.copy({
               id: entityObject.id,
               ...overrides,
-              "copy-style": copyStyle,
+              is_deep_copy: !overrides.is_shallow_copy,
             }),
           );
-          console.log("🚀", { result });
           if (notify) {
             dispatch(addUndo(notify));
           }

--- a/frontend/src/metabase/entities/dashboards/forms.js
+++ b/frontend/src/metabase/entities/dashboards/forms.js
@@ -34,13 +34,13 @@ function createCollectionIdField() {
 function createShallowCopyField() {
   return {
     name: "shallow_copy",
-    title: t`Shallow copy`,
-    type: "text",
-    placeholder: t`Make a shallow copy?`,
+    type: "checkbox",
+    label: t`Only duplicate the dashboard`,
+    tooltip: t`This is a tooltip`,
   };
 }
 
-function createForm() {
+function duplicateForm() {
   return [
     createNameField(),
     createDescriptionField(),
@@ -49,7 +49,7 @@ function createForm() {
   ];
 }
 
-function createFormTwo() {
+function createForm() {
   return [
     createNameField(),
     createDescriptionField(),
@@ -59,10 +59,10 @@ function createFormTwo() {
 
 export default {
   create: {
-    fields: () => createFormTwo(),
+    fields: createForm,
   },
   duplicate: {
-    fields: () => createForm(),
+    fields: duplicateForm,
   },
   edit: {
     fields: () => {

--- a/frontend/src/metabase/entities/dashboards/forms.js
+++ b/frontend/src/metabase/entities/dashboards/forms.js
@@ -61,6 +61,9 @@ export default {
   create: {
     fields: () => createFormTwo(),
   },
+  duplicate: {
+    fields: () => createForm(),
+  },
   edit: {
     fields: () => {
       const fields = [...createForm()];

--- a/frontend/src/metabase/entities/dashboards/forms.js
+++ b/frontend/src/metabase/entities/dashboards/forms.js
@@ -31,7 +31,25 @@ function createCollectionIdField() {
   };
 }
 
+function createShallowCopyField() {
+  return {
+    name: "shallow_copy",
+    title: t`Shallow copy`,
+    type: "text",
+    placeholder: t`Make a shallow copy?`,
+  };
+}
+
 function createForm() {
+  return [
+    createNameField(),
+    createDescriptionField(),
+    createCollectionIdField(),
+    createShallowCopyField(),
+  ];
+}
+
+function createFormTwo() {
   return [
     createNameField(),
     createDescriptionField(),
@@ -41,7 +59,7 @@ function createForm() {
 
 export default {
   create: {
-    fields: createForm,
+    fields: () => createFormTwo(),
   },
   edit: {
     fields: () => {

--- a/frontend/src/metabase/entities/dashboards/forms.js
+++ b/frontend/src/metabase/entities/dashboards/forms.js
@@ -33,7 +33,7 @@ function createCollectionIdField() {
 
 function createShallowCopyField() {
   return {
-    name: "shallow_copy",
+    name: "is_shallow_copy",
     type: "checkbox",
     label: t`Only duplicate the dashboard`,
     tooltip: t`This is a tooltip`,

--- a/frontend/test/metabase/scenarios/dashboard/duplicate.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/duplicate.cy.spec.js
@@ -1,0 +1,52 @@
+import {
+  restore,
+  visitCollection,
+  visitDashboard,
+} from "__support__/e2e/helpers";
+
+describe("scenarios > dashboard > duplicate", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("shallow (duplicate dashboard but not its cards)", () => {
+    visitDashboard(1);
+
+    cy.get("main header").within(() => {
+      cy.icon("ellipsis").click();
+    });
+
+    cy.findByText("Duplicate").click();
+
+    cy.findByRole("checkbox").click();
+
+    cy.button("Duplicate").click();
+
+    cy.findByText("Orders in a dashboard - Duplicate");
+  });
+
+  it("deep (duplicate dashboard and its card)", () => {
+    visitDashboard(1);
+
+    cy.get("main header").within(() => {
+      cy.icon("ellipsis").click();
+    });
+
+    cy.findByText("Duplicate").click();
+
+    // Change destination collection
+    cy.findByTestId("select-button").click();
+    cy.findByText("My personal collection").click();
+
+    cy.button("Duplicate").click();
+
+    cy.findByText("Orders in a dashboard - Duplicate");
+
+    // Duplicated dashboard and question should live in personal collection
+    visitCollection(1);
+
+    cy.findByText("Orders");
+    cy.findByText("Orders in a dashboard - Duplicate");
+  });
+});


### PR DESCRIPTION
### How to Test

1. Create a dashboard and have cards in it
2. Click `Duplicate`, either from its page or from its entry in a collection page

At the bottom of the duplicate modal, you should now see a checkbox about copying only the dashboard.

#### Deep copying

Leave checkbox unchecked and duplicate.
You should see that not only the dashboard has been duplicated, but also all its questions which should appear in the same collection targeted for the duplicated dashboard. (Models will not be duplicated, and there are other exceptions as well. This PR is about the basics of the feature as seen from the frontend)

#### Shallow copying

Check checkbox and duplicate.
Dashboard copy should behave as it does today. Dashboard is duplicated and points to already existing questions.

<hr> 

🎗️ There are refinements on labels, tooltips on the checkbox and so on that will be handled in separate PRs pointed at this feature branch.