### PR TITLE
Use NodeJS `http` module for Cypress backend

### DIFF
--- a/frontend/test/__runner__/cypress-runner-backend.js
+++ b/frontend/test/__runner__/cypress-runner-backend.js
@@ -5,7 +5,7 @@ const { spawn } = require("child_process");
 const os = require("os");
 const path = require("path");
 
-const fetch = require("isomorphic-fetch");
+const http = require("http");
 
 const CypressBackend = {
   createServer(port = 4000) {
@@ -107,9 +107,30 @@ const CypressBackend = {
     }
 
     async function isReady(host) {
+      // This is needed until we can use NodeJS native `fetch`.
+      function request(url) {
+        return new Promise((resolve, reject) => {
+          const req = http.get(url, res => {
+            let body = "";
+
+            res.on("data", chunk => {
+              body += chunk;
+            });
+
+            res.on("end", () => {
+              resolve(JSON.parse(body));
+            });
+          });
+
+          req.on("error", e => {
+            reject(e);
+          });
+        });
+      }
+
       try {
-        const { status } = await fetch(`${host}/api/health`);
-        if (status === 200) {
+        const { status } = await request(`${host}/api/health`);
+        if (status === "ok") {
           return true;
         }
       } catch (e) {}


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Replaces outdated `isomorphic-fetch` with the built-in NodeJS `http` module

There have been several attempts to get rid of `isomorphic-fetch` and to replace it with something else.
- https://github.com/metabase/metabase/pull/25086
- https://github.com/metabase/metabase/pull/25837
- https://github.com/metabase/metabase/pull/25898

The ideal goal is to be able to use Node's native `fetch` but it's available only in NodeJS v18. Until we're able to safely upgrade to that version of NodeJS, we need to find an alternative solution.

`http` module is perfect for this.
We don't need any replacement library (hence, we're not polluting the dependency graph). One approach was to use `XMLHttpRequest` but it doesn't work in a pure NodeJS environment and that's exactly where `cypress-runner-backend.js` operates in.

### How to tests?
- All E2E tests should work in the CI and locally
- You should see these messages in this order:
1. Starting backend
2. ....
3. Backend Ready
4. Generating snapshots

### Notes
- https://github.com/metabase/metabase/pull/25837 should focus only on replacing the `isomorphic-fetch` in the context of PoEditor (translation) script. This PR takes care of Cypress.
- Since those were the last two remaining instances of said isomorphic fetch, it should be removed after both PRs are merged