### PR TITLE
Allow category field drop-downs to be single-selection for dashboard filters

### DIFF
--- a/frontend/src/metabase-lib/parameters/constants.ts
+++ b/frontend/src/metabase-lib/parameters/constants.ts
@@ -155,6 +155,13 @@ export const TYPE_SUPPORTS_LINKED_FILTERS = [
   "location",
 ];
 
+export const SINGLE_OR_MULTI_SELECTABLE_TYPES = [
+  "string",
+  "category",
+  "id",
+  "location",
+];
+
 export const FIELD_FILTER_PARAMETER_TYPES = [
   "date",
   "string",

--- a/frontend/src/metabase-lib/parameters/constants.ts
+++ b/frontend/src/metabase-lib/parameters/constants.ts
@@ -155,12 +155,15 @@ export const TYPE_SUPPORTS_LINKED_FILTERS = [
   "location",
 ];
 
-export const SINGLE_OR_MULTI_SELECTABLE_TYPES = [
-  "string",
-  "category",
-  "id",
-  "location",
-];
+export const SINGLE_OR_MULTI_SELECTABLE_TYPES: Record<
+  string,
+  string | string[]
+> = {
+  string: ["=", "!="],
+  category: ["=", "!="],
+  id: "any",
+  location: ["=", "!="],
+};
 
 export const FIELD_FILTER_PARAMETER_TYPES = [
   "date",

--- a/frontend/src/metabase-lib/parameters/utils/operators.ts
+++ b/frontend/src/metabase-lib/parameters/utils/operators.ts
@@ -1,5 +1,5 @@
+import { getIsMultiSelect } from "metabase/parameters/utils/dashboards";
 import { Parameter } from "metabase-types/types/Parameter";
-
 import {
   doesOperatorExist,
   getOperatorByTypeAndName,
@@ -37,7 +37,8 @@ export function deriveFieldOperatorFromParameter(parameter: Parameter) {
   const operatorType = getParameterOperatorType(type);
   const operatorName = getParameterOperatorName(subtype);
 
-  return getOperatorByTypeAndName(operatorType, operatorName);
+  const operator = getOperatorByTypeAndName(operatorType, operatorName);
+  return { ...operator, multi: operator.multi && getIsMultiSelect(parameter) };
 }
 
 function getParameterOperatorType(parameterType?: string) {

--- a/frontend/src/metabase-lib/parameters/utils/operators.ts
+++ b/frontend/src/metabase-lib/parameters/utils/operators.ts
@@ -36,9 +36,13 @@ export function deriveFieldOperatorFromParameter(parameter: Parameter) {
   const subtype = getParameterSubType(parameter);
   const operatorType = getParameterOperatorType(type);
   const operatorName = getParameterOperatorName(subtype);
-
   const operator = getOperatorByTypeAndName(operatorType, operatorName);
-  return { ...operator, multi: operator.multi && getIsMultiSelect(parameter) };
+  return (
+    operator && {
+      ...operator,
+      multi: operator.multi && getIsMultiSelect(parameter),
+    }
+  );
 }
 
 function getParameterOperatorType(parameterType?: string) {

--- a/frontend/src/metabase-lib/parameters/utils/operators.ts
+++ b/frontend/src/metabase-lib/parameters/utils/operators.ts
@@ -1,4 +1,3 @@
-import { getIsMultiSelect } from "metabase/parameters/utils/dashboards";
 import { Parameter } from "metabase-types/types/Parameter";
 import {
   doesOperatorExist,
@@ -10,6 +9,7 @@ import {
   getParameterSubType,
 } from "metabase-lib/parameters/utils/parameter-type";
 import { PARAMETER_OPERATOR_TYPES } from "metabase-lib/parameters/constants";
+import { getIsMultiSelect } from "../../../metabase/parameters/utils/dashboards";
 
 type OperatorType = "date" | "number" | "string";
 

--- a/frontend/src/metabase-types/types/Parameter.ts
+++ b/frontend/src/metabase-types/types/Parameter.ts
@@ -45,6 +45,7 @@ export interface Parameter {
   sectionId?: string;
   default?: any;
   filteringParameters?: ParameterId[];
+  isMultiSelect?: boolean;
   value?: any;
 }
 

--- a/frontend/src/metabase/components/FieldValuesWidget.jsx
+++ b/frontend/src/metabase/components/FieldValuesWidget.jsx
@@ -10,6 +10,7 @@ import TokenField, {
   parseStringValue,
 } from "metabase/components/TokenField";
 import ListField from "metabase/components/ListField";
+import SingleSelectListField from "metabase/components/SingleSelectListField";
 import ValueComponent from "metabase/components/Value";
 import LoadingSpinner from "metabase/components/LoadingSpinner";
 
@@ -316,12 +317,21 @@ class FieldValuesWidgetInner extends Component {
       >
         {isListMode && isLoading ? (
           <LoadingState />
-        ) : isListMode && hasListValues ? (
+        ) : isListMode && hasListValues && multi ? (
           <ListField
             isDashboardFilter={parameter}
             placeholder={tokenFieldPlaceholder}
             value={value.filter(v => v != null)}
-            multi={multi} // TODO: this probably needs changing, but it's an example of how the isMultiSelect property can be passed to the UI
+            onChange={onChange}
+            options={options}
+            optionRenderer={optionRenderer}
+            checkedColor={checkedColor}
+          />
+        ) : isListMode && hasListValues && !multi ? (
+          <SingleSelectListField
+            isDashboardFilter={parameter}
+            placeholder={tokenFieldPlaceholder}
+            value={value.filter(v => v != null)}
             onChange={onChange}
             options={options}
             optionRenderer={optionRenderer}

--- a/frontend/src/metabase/components/FieldValuesWidget.jsx
+++ b/frontend/src/metabase/components/FieldValuesWidget.jsx
@@ -20,6 +20,7 @@ import { addRemappings, fetchFieldValues } from "metabase/redux/metadata";
 import { defer } from "metabase/lib/promise";
 import { stripId } from "metabase/lib/formatting";
 import { fetchDashboardParameterValues } from "metabase/dashboard/actions";
+import { getIsMultiSelect } from "metabase/parameters/utils/dashboards";
 
 import Fields from "metabase/entities/fields";
 
@@ -321,6 +322,7 @@ class FieldValuesWidgetInner extends Component {
             isDashboardFilter={parameter}
             placeholder={tokenFieldPlaceholder}
             value={value.filter(v => v != null)}
+            isMultiSelect={getIsMultiSelect(parameter)}
             onChange={onChange}
             options={options}
             optionRenderer={optionRenderer}

--- a/frontend/src/metabase/components/FieldValuesWidget.jsx
+++ b/frontend/src/metabase/components/FieldValuesWidget.jsx
@@ -322,7 +322,7 @@ class FieldValuesWidgetInner extends Component {
             isDashboardFilter={parameter}
             placeholder={tokenFieldPlaceholder}
             value={value.filter(v => v != null)}
-            isMultiSelect={getIsMultiSelect(parameter)}
+            isMultiSelect={getIsMultiSelect(parameter)} // TODO: this probably needs changing, but it's an example of how the isMultiSelect property can be passed to the UI
             onChange={onChange}
             options={options}
             optionRenderer={optionRenderer}

--- a/frontend/src/metabase/components/FieldValuesWidget.jsx
+++ b/frontend/src/metabase/components/FieldValuesWidget.jsx
@@ -20,7 +20,6 @@ import { addRemappings, fetchFieldValues } from "metabase/redux/metadata";
 import { defer } from "metabase/lib/promise";
 import { stripId } from "metabase/lib/formatting";
 import { fetchDashboardParameterValues } from "metabase/dashboard/actions";
-import { getIsMultiSelect } from "metabase/parameters/utils/dashboards";
 
 import Fields from "metabase/entities/fields";
 
@@ -322,7 +321,7 @@ class FieldValuesWidgetInner extends Component {
             isDashboardFilter={parameter}
             placeholder={tokenFieldPlaceholder}
             value={value.filter(v => v != null)}
-            isMultiSelect={getIsMultiSelect(parameter)} // TODO: this probably needs changing, but it's an example of how the isMultiSelect property can be passed to the UI
+            multi={multi} // TODO: this probably needs changing, but it's an example of how the isMultiSelect property can be passed to the UI
             onChange={onChange}
             options={options}
             optionRenderer={optionRenderer}

--- a/frontend/src/metabase/components/ListField/types.ts
+++ b/frontend/src/metabase/components/ListField/types.ts
@@ -4,6 +4,7 @@ export interface ListFieldProps {
   onChange: (value: string[]) => void;
   value: string[];
   options: Option;
+  multi: boolean;
   optionRenderer: (option: any) => JSX.Element;
   placeholder: string;
   isDashboardFilter?: boolean;

--- a/frontend/src/metabase/components/SingleSelectListField/SingleSelectListField.styled.tsx
+++ b/frontend/src/metabase/components/SingleSelectListField/SingleSelectListField.styled.tsx
@@ -1,0 +1,36 @@
+import styled from "@emotion/styled";
+import TextInput from "metabase/components/TextInput";
+import { color } from "metabase/lib/colors";
+
+export const EmptyStateContainer = styled.div`
+  padding: 2rem 2rem 0 2rem;
+`;
+
+interface FilterInputProps {
+  isDashboardFilter?: boolean;
+}
+
+export const FilterInput = styled(TextInput)<FilterInputProps>`
+  margin-bottom: ${props => (props.isDashboardFilter ? "0" : "0.5rem")};
+  border: ${props =>
+    props.isDashboardFilter ? `1px solid ${color("border")}` : "none"};
+` as any;
+
+interface OptionListProps {
+  isDashboardFilter?: boolean;
+}
+
+export const OptionsList = styled.ul<OptionListProps>`
+  overflow: auto;
+  list-style: none;
+  max-height: ${props => (props.isDashboardFilter ? "300px" : "none")};
+  padding: ${props => (props.isDashboardFilter ? "0.5rem" : "0")};
+`;
+
+export const OptionContainer = styled.li`
+  padding: 0.5rem 0.125rem;
+`;
+
+export const LabelWrapper = styled.div`
+  padding-left: 0.5rem;
+`;

--- a/frontend/src/metabase/components/SingleSelectListField/SingleSelectListField.styled.tsx
+++ b/frontend/src/metabase/components/SingleSelectListField/SingleSelectListField.styled.tsx
@@ -31,6 +31,20 @@ export const OptionContainer = styled.li`
   padding: 0.5rem 0.125rem;
 `;
 
-export const LabelWrapper = styled.div`
-  padding-left: 0.5rem;
+interface OptionItemProps {
+  selected?: boolean;
+  selectedColor: string;
+}
+
+export const OptionItem = styled.div<OptionItemProps>`
+  border-radius: var(--default-border-radius);
+  display: inline-block;
+  width: 100%;
+  cursor: pointer;
+  &:hover {
+    background-color: ${props =>
+      color(props.selected ? props.selectedColor : "var(--color-bg-light)")};
+  }
+  background-color: ${props =>
+    color(props.selected ? props.selectedColor : "bg-white")};
 `;

--- a/frontend/src/metabase/components/SingleSelectListField/SingleSelectListField.styled.tsx
+++ b/frontend/src/metabase/components/SingleSelectListField/SingleSelectListField.styled.tsx
@@ -24,11 +24,11 @@ export const OptionsList = styled.ul<OptionListProps>`
   overflow: auto;
   list-style: none;
   max-height: ${props => (props.isDashboardFilter ? "300px" : "none")};
-  padding: ${props => (props.isDashboardFilter ? "0.5rem" : "0")};
+  padding: 0.5rem 0 0;
 `;
 
 export const OptionContainer = styled.li`
-  padding: 0.5rem 0.125rem;
+  padding: 0;
 `;
 
 interface OptionItemProps {
@@ -37,14 +37,18 @@ interface OptionItemProps {
 }
 
 export const OptionItem = styled.div<OptionItemProps>`
-  border-radius: var(--default-border-radius);
-  display: inline-block;
-  width: 100%;
+  border-radius: 4px;
   cursor: pointer;
+  display: inline-block;
+  margin: 0;
+  padding: 0.5rem 0.6rem;
+  width: 100%;
+  background-color: ${props =>
+    color(props.selected ? props.selectedColor : color("white"))};
+  color: ${props => color(props.selected ? "white" : color("text"))};
+
   &:hover {
     background-color: ${props =>
-      color(props.selected ? props.selectedColor : "var(--color-bg-light)")};
+      color(props.selected ? props.selectedColor : color("bg-light"))};
   }
-  background-color: ${props =>
-    color(props.selected ? props.selectedColor : "bg-white")};
 `;

--- a/frontend/src/metabase/components/SingleSelectListField/SingleSelectListField.tsx
+++ b/frontend/src/metabase/components/SingleSelectListField/SingleSelectListField.tsx
@@ -1,0 +1,147 @@
+import React, { useMemo, useState } from "react";
+import _ from "underscore";
+import { t } from "ttag";
+import { useDebouncedValue } from "metabase/hooks/use-debounced-value";
+import { SEARCH_DEBOUNCE_DURATION } from "metabase/lib/constants";
+import Checkbox from "metabase/core/components/CheckBox";
+import EmptyState from "metabase/components/EmptyState";
+
+import {
+  OptionContainer,
+  LabelWrapper,
+  OptionsList,
+  EmptyStateContainer,
+  FilterInput,
+} from "./SingleSelectListField.styled";
+import { SingleSelectListFieldProps, Option } from "./types";
+import { isValidOptionItem } from "./utils";
+
+function createOptionsFromValuesWithoutOptions(
+  values: string[],
+  options: Option[],
+): Option {
+  const optionsMap = _.indexBy(options, "0");
+  return values.filter(value => !optionsMap[value]).map(value => [value]);
+}
+
+const SingleSelectListField = ({
+  onChange,
+  value,
+  options,
+  optionRenderer,
+  placeholder,
+  isDashboardFilter,
+  checkedColor,
+}: SingleSelectListFieldProps) => {
+  const [selectedValues, setSelectedValues] = useState(new Set(value));
+  const [addedOptions, setAddedOptions] = useState<Option>(() =>
+    createOptionsFromValuesWithoutOptions(value, options),
+  );
+
+  const augmentedOptions = useMemo(() => {
+    return [...options.filter(option => option[0] != null), ...addedOptions];
+  }, [addedOptions, options]);
+
+  const sortedOptions = useMemo(() => {
+    if (selectedValues.size === 0) {
+      return augmentedOptions;
+    }
+
+    const [selected, unselected] = _.partition(augmentedOptions, option =>
+      selectedValues.has(option[0]),
+    );
+
+    return [...selected, ...unselected];
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [augmentedOptions.length]);
+
+  const [filter, setFilter] = useState("");
+  const debouncedFilter = useDebouncedValue(filter, SEARCH_DEBOUNCE_DURATION);
+
+  const filteredOptions = useMemo(() => {
+    const formattedFilter = debouncedFilter.trim().toLowerCase();
+    if (formattedFilter.length === 0) {
+      return sortedOptions;
+    }
+
+    return augmentedOptions.filter(option => {
+      if (!option || option.length === 0) {
+        return false;
+      }
+
+      // option as: [id, name]
+      if (
+        option.length > 1 &&
+        option[1] &&
+        isValidOptionItem(option[1], formattedFilter)
+      ) {
+        return true;
+      }
+
+      // option as: [id]
+      return isValidOptionItem(option[0], formattedFilter);
+    });
+  }, [augmentedOptions, debouncedFilter, sortedOptions]);
+
+  const shouldShowEmptyState =
+    augmentedOptions.length > 0 && filteredOptions.length === 0;
+
+  const handleToggleOption = (option: any) => {
+    const newSelectedValues = selectedValues.has(option)
+      ? Array.from(selectedValues).filter(value => value !== option)
+      : [...selectedValues, option];
+
+    setSelectedValues(new Set(newSelectedValues));
+    onChange?.(newSelectedValues);
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    if (
+      event.key === "Enter" &&
+      !_.find(augmentedOptions, option => option[0] === filter)
+    ) {
+      setAddedOptions([...addedOptions, [filter]]);
+    }
+  };
+
+  return (
+    <>
+      <FilterInput
+        isDashboardFilter={isDashboardFilter}
+        padding={isDashboardFilter ? "md" : "sm"}
+        borderRadius={isDashboardFilter ? "md" : "sm"}
+        colorScheme={isDashboardFilter ? "transparent" : "admin"}
+        placeholder={placeholder}
+        value={filter}
+        onChange={setFilter}
+        onKeyDown={handleKeyDown}
+        hasClearButton
+        autoFocus
+      />
+
+      {shouldShowEmptyState && (
+        <EmptyStateContainer>
+          <EmptyState message={t`Didn't find anything`} icon="search" />
+        </EmptyStateContainer>
+      )}
+
+      <OptionsList isDashboardFilter={isDashboardFilter}>
+        {filteredOptions.map(option => (
+          <OptionContainer key={option[0]}>
+            <Checkbox
+              data-testid={`${option[0]}-filter-value`}
+              checkedColor={
+                checkedColor ?? isDashboardFilter ? "brand" : "filter"
+              }
+              checked={selectedValues.has(option[0])}
+              label={<LabelWrapper>{optionRenderer(option)}</LabelWrapper>}
+              onChange={() => handleToggleOption(option[0])}
+            />
+          </OptionContainer>
+        ))}
+      </OptionsList>
+    </>
+  );
+};
+
+export default SingleSelectListField;

--- a/frontend/src/metabase/components/SingleSelectListField/SingleSelectListField.unit.spec.js
+++ b/frontend/src/metabase/components/SingleSelectListField/SingleSelectListField.unit.spec.js
@@ -1,0 +1,56 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import ValueComponent from "metabase/components/Value";
+import SingleSelectListField from ".";
+
+const value = [];
+const firstOption = "AK";
+const secondOption = "AL";
+const options = [[firstOption], [secondOption]];
+const fields = [];
+const formatOptions = {};
+
+function showRemapping(fields) {
+  return fields.length === 1;
+}
+
+function renderValue(fields, formatOptions, value, options) {
+  return (
+    <ValueComponent
+      value={value}
+      column={fields[0]}
+      maximumFractionDigits={20}
+      remap={showRemapping(fields)}
+      {...formatOptions}
+      {...options}
+    />
+  );
+}
+
+describe("SingleSelectListField", () => {
+  it("displays search input", () => {
+    render(
+      <SingleSelectListField
+        value={value}
+        options={options}
+        optionRenderer={option => renderValue(fields, formatOptions, option[0])}
+      />,
+    );
+
+    expect(screen.getByPlaceholderText("Find...")).toBeInTheDocument();
+  });
+
+  it("displays options", () => {
+    render(
+      <SingleSelectListField
+        value={value}
+        options={options}
+        optionRenderer={option => renderValue(fields, formatOptions, option[0])}
+      />,
+    );
+
+    expect(screen.getByText(firstOption)).toBeInTheDocument();
+    expect(screen.getByText(secondOption)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/components/SingleSelectListField/index.ts
+++ b/frontend/src/metabase/components/SingleSelectListField/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SingleSelectListField";

--- a/frontend/src/metabase/components/SingleSelectListField/types.ts
+++ b/frontend/src/metabase/components/SingleSelectListField/types.ts
@@ -1,6 +1,6 @@
 export type Option = any[];
 
-export interface ListFieldProps {
+export interface SingleSelectListFieldProps {
   onChange: (value: string[]) => void;
   value: string[];
   options: Option;

--- a/frontend/src/metabase/components/SingleSelectListField/utils.ts
+++ b/frontend/src/metabase/components/SingleSelectListField/utils.ts
@@ -1,0 +1,3 @@
+export function isValidOptionItem(optionItem: any, filter: string): boolean {
+  return String(optionItem).toLowerCase().includes(filter);
+}

--- a/frontend/src/metabase/components/SingleSelectListField/utils.unit.spec.ts
+++ b/frontend/src/metabase/components/SingleSelectListField/utils.unit.spec.ts
@@ -1,0 +1,22 @@
+import { isValidOptionItem } from "./utils";
+
+describe("ListField - utils", () => {
+  describe("isValidOptionItem", () => {
+    const TEST_CASES = [
+      ["Marble Shoes", "marble", true],
+      [[6, "Marble Shoes"], "marble", true],
+      [[6, "Marble Shoes"], "6", true],
+      [[6], "6", true],
+      [[null, "Marble Shoes"], "marble", true],
+      [[6, null], "6", true],
+      [[6, "Marble Shoes"], "abcde", false],
+    ];
+
+    TEST_CASES.map(([optionItem, filter, expectedResult]) => {
+      it(`includes "${filter}" in: ${optionItem}`, () => {
+        const result = isValidOptionItem(optionItem, String(filter));
+        expect(result).toEqual(expectedResult);
+      });
+    });
+  });
+});

--- a/frontend/src/metabase/dashboard/actions/parameters.js
+++ b/frontend/src/metabase/dashboard/actions/parameters.js
@@ -6,7 +6,6 @@ import { createAction, createThunkAction } from "metabase/lib/redux";
 import {
   createParameter,
   setParameterName as setParamName,
-  setParameterDefaultValue as setParamDefaultValue,
   getFilteringParameterValuesMap,
   getParameterValuesSearchKey,
 } from "metabase/parameters/utils/dashboards";
@@ -137,14 +136,6 @@ export const setParameterMapping = createThunkAction(
 );
 
 export const SET_PARAMETER_NAME = "metabase/dashboard/SET_PARAMETER_NAME";
-export const setParameter = createThunkAction(
-  SET_PARAMETER_NAME,
-  (parameterId, parameter) => (dispatch, getState) => {
-    updateParameter(dispatch, getState, parameterId, () => parameter);
-    return { id: parameterId, ...parameter };
-  },
-);
-
 export const setParameterName = createThunkAction(
   SET_PARAMETER_NAME,
   (parameterId, name) => (dispatch, getState) => {
@@ -182,10 +173,24 @@ export const SET_PARAMETER_DEFAULT_VALUE =
 export const setParameterDefaultValue = createThunkAction(
   SET_PARAMETER_DEFAULT_VALUE,
   (parameterId, defaultValue) => (dispatch, getState) => {
-    updateParameter(dispatch, getState, parameterId, parameter =>
-      setParamDefaultValue(parameter, defaultValue),
-    );
+    updateParameter(dispatch, getState, parameterId, parameter => ({
+      ...parameter,
+      default: defaultValue,
+    }));
     return { id: parameterId, defaultValue };
+  },
+);
+
+export const SET_PARAMETER_IS_MULTI_SELECT =
+  "metabase/dashboard/SET_PARAMETER_DEFAULT_VALUE";
+export const setParameterIsMultiSelect = createThunkAction(
+  SET_PARAMETER_DEFAULT_VALUE,
+  (parameterId, isMultiSelect) => (dispatch, getState) => {
+    updateParameter(dispatch, getState, parameterId, parameter => ({
+      ...parameter,
+      isMultiSelect: isMultiSelect,
+    }));
+    return { id: parameterId, isMultiSelect };
   },
 );
 

--- a/frontend/src/metabase/dashboard/components/DashboardSidebars.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardSidebars.jsx
@@ -28,6 +28,7 @@ DashboardSidebars.propTypes = {
   setParameter: PropTypes.func.isRequired,
   setParameterName: PropTypes.func.isRequired,
   setParameterDefaultValue: PropTypes.func.isRequired,
+  setParameterIsMultiSelect: PropTypes.func.isRequired,
   dashcardData: PropTypes.object,
   setParameterFilteringParameters: PropTypes.func.isRequired,
   isSharing: PropTypes.bool.isRequired,
@@ -58,6 +59,7 @@ export function DashboardSidebars({
   setParameter,
   setParameterName,
   setParameterDefaultValue,
+  setParameterIsMultiSelect,
   dashcardData,
   setParameterFilteringParameters,
   isFullscreen,
@@ -138,6 +140,9 @@ export function DashboardSidebars({
           setName={name => setParameterName(editingParameterId, name)}
           setDefaultValue={value =>
             setParameterDefaultValue(editingParameterId, value)
+          }
+          setIsMultiSelect={value =>
+            setParameterIsMultiSelect(editingParameterId, value)
           }
           setFilteringParameters={ids =>
             setParameterFilteringParameters(editingParameterId, ids)

--- a/frontend/src/metabase/parameters/components/ParameterSidebar.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterSidebar.jsx
@@ -53,6 +53,7 @@ class ParameterSidebar extends React.Component {
       done,
       setName,
       setDefaultValue,
+      setIsMultiSelect,
       setFilteringParameters,
     } = this.props;
     const { currentTab } = this.state;
@@ -93,9 +94,23 @@ class ParameterSidebar extends React.Component {
                   className="input bg-white"
                 />
               </div>
+              <label className="mt2 mb1 block text-bold">{t`Users can pick`}</label>
+              <Radio
+                value={
+                  parameter.isMultiSelect == null
+                    ? true
+                    : parameter.isMultiSelect
+                } // TODO: should the default be somewhere else?
+                onChange={setIsMultiSelect}
+                options={[
+                  { name: t`Multiple values`, value: true },
+                  { name: t`A single value`, value: false },
+                ]}
+                vertical
+              />
               <a
                 borderless
-                className="mt2 block text-medium text-error-hover text-bold"
+                className="mt4 block text-medium text-error-hover text-bold"
                 onClick={remove}
               >
                 {t`Remove`}

--- a/frontend/src/metabase/parameters/components/ParameterSidebar.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterSidebar.jsx
@@ -17,6 +17,7 @@ import InputBlurChange from "metabase/components/InputBlurChange";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 
 import ParameterValueWidget from "metabase/parameters/components/ParameterValueWidget";
+import { isSingleOrMultiSelectable } from "metabase/parameters/utils/parameter-type";
 import Sidebar from "metabase/dashboard/components/Sidebar";
 import { getIsMultiSelect } from "metabase/parameters/utils/dashboards";
 
@@ -95,19 +96,23 @@ class ParameterSidebar extends React.Component {
                   className="input bg-white"
                 />
               </div>
-              <label className="mt2 mb1 block text-bold">{t`Users can pick`}</label>
-              <Radio
-                value={getIsMultiSelect(parameter)}
-                onChange={setIsMultiSelect}
-                options={[
-                  { name: t`Multiple values`, value: true },
-                  { name: t`A single value`, value: false },
-                ]}
-                vertical
-              />
+              {isSingleOrMultiSelectable(parameter) && (
+                <div className="pb2">
+                  <label className="mt2 mb1 block text-bold">{t`Users can pick`}</label>
+                  <Radio
+                    value={getIsMultiSelect(parameter)}
+                    onChange={setIsMultiSelect}
+                    options={[
+                      { name: t`Multiple values`, value: true },
+                      { name: t`A single value`, value: false },
+                    ]}
+                    vertical
+                  />
+                </div>
+              )}
               <a
                 borderless
-                className="mt4 block text-medium text-error-hover text-bold"
+                className="mt2 block text-medium text-error-hover text-bold"
                 onClick={remove}
               >
                 {t`Remove`}

--- a/frontend/src/metabase/parameters/components/ParameterSidebar.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterSidebar.jsx
@@ -18,6 +18,7 @@ import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 
 import ParameterValueWidget from "metabase/parameters/components/ParameterValueWidget";
 import Sidebar from "metabase/dashboard/components/Sidebar";
+import { getIsMultiSelect } from "metabase/parameters/utils/dashboards";
 
 const LINKED_FILTER = "linked-filters";
 const TABS = [
@@ -96,11 +97,7 @@ class ParameterSidebar extends React.Component {
               </div>
               <label className="mt2 mb1 block text-bold">{t`Users can pick`}</label>
               <Radio
-                value={
-                  parameter.isMultiSelect == null
-                    ? true
-                    : parameter.isMultiSelect
-                } // TODO: should the default be somewhere else?
+                value={getIsMultiSelect(parameter)}
                 onChange={setIsMultiSelect}
                 options={[
                   { name: t`Multiple values`, value: true },

--- a/frontend/src/metabase/parameters/utils/dashboards.ts
+++ b/frontend/src/metabase/parameters/utils/dashboards.ts
@@ -66,16 +66,6 @@ export function setParameterName(
   };
 }
 
-export function setParameterDefaultValue(
-  parameter: Parameter,
-  value: any,
-): Parameter {
-  return {
-    ...parameter,
-    default: value,
-  };
-}
-
 export function hasMapping(parameter: Parameter, dashboard: Dashboard) {
   return dashboard.ordered_cards.some(ordered_card => {
     return ordered_card?.parameter_mappings?.some(parameter_mapping => {

--- a/frontend/src/metabase/parameters/utils/dashboards.ts
+++ b/frontend/src/metabase/parameters/utils/dashboards.ts
@@ -66,6 +66,10 @@ export function setParameterName(
   };
 }
 
+export function getIsMultiSelect(parameter: Parameter): boolean {
+  return parameter.isMultiSelect == null ? true : parameter.isMultiSelect;
+}
+
 export function hasMapping(parameter: Parameter, dashboard: Dashboard) {
   return dashboard.ordered_cards.some(ordered_card => {
     return ordered_card?.parameter_mappings?.some(parameter_mapping => {

--- a/frontend/src/metabase/parameters/utils/dashboards.unit.spec.js
+++ b/frontend/src/metabase/parameters/utils/dashboards.unit.spec.js
@@ -1,7 +1,6 @@
 import {
   createParameter,
   setParameterName,
-  setParameterDefaultValue,
   hasMapping,
   isDashboardParameterWithoutMapping,
   getParametersMappedToDashcard,
@@ -96,15 +95,6 @@ describe("metabase/parameters/utils/dashboards", () => {
       expect(setParameterName({}, "")).toEqual({
         name: "unnamed",
         slug: "unnamed",
-      });
-    });
-  });
-
-  describe("setParameterDefaultValue", () => {
-    it("should set a `default` property on a parameter", () => {
-      expect(setParameterDefaultValue({ foo: "bar" }, 123)).toEqual({
-        foo: "bar",
-        default: 123,
       });
     });
   });

--- a/frontend/src/metabase/parameters/utils/parameter-type.ts
+++ b/frontend/src/metabase/parameters/utils/parameter-type.ts
@@ -5,7 +5,10 @@ import {
   FIELD_FILTER_PARAMETER_TYPES,
   SINGLE_OR_MULTI_SELECTABLE_TYPES,
 } from "metabase-lib/lib/parameters/constants";
-import { getParameterType } from "metabase-lib/lib/parameters/utils/parameter-type";
+import {
+  getParameterType,
+  getParameterSubType,
+} from "metabase-lib/lib/parameters/utils/parameter-type";
 
 export function isFieldFilterParameter(
   parameter: Parameter,
@@ -14,8 +17,15 @@ export function isFieldFilterParameter(
   return FIELD_FILTER_PARAMETER_TYPES.includes(type);
 }
 
-// TODO: maybe move to the dashboard component?
 export function isSingleOrMultiSelectable(parameter: Parameter): boolean {
-  const type = getParameterType(parameter);
-  return SINGLE_OR_MULTI_SELECTABLE_TYPES.includes(type);
+  const type: string = getParameterType(parameter);
+  const subType: string = getParameterSubType(parameter);
+
+  if (!SINGLE_OR_MULTI_SELECTABLE_TYPES[type]) {
+    return false;
+  }
+  if (SINGLE_OR_MULTI_SELECTABLE_TYPES[type] === "any") {
+    return true;
+  }
+  return SINGLE_OR_MULTI_SELECTABLE_TYPES[type].includes(subType);
 }

--- a/frontend/src/metabase/parameters/utils/parameter-type.ts
+++ b/frontend/src/metabase/parameters/utils/parameter-type.ts
@@ -1,0 +1,21 @@
+import _ from "underscore";
+import { FieldFilterUiParameter } from "metabase/parameters/types";
+import { Parameter } from "metabase-types/types/Parameter";
+import {
+  FIELD_FILTER_PARAMETER_TYPES,
+  SINGLE_OR_MULTI_SELECTABLE_TYPES,
+} from "metabase-lib/lib/parameters/constants";
+import { getParameterType } from "metabase-lib/lib/parameters/utils/parameter-type";
+
+export function isFieldFilterParameter(
+  parameter: Parameter,
+): parameter is FieldFilterUiParameter {
+  const type = getParameterType(parameter);
+  return FIELD_FILTER_PARAMETER_TYPES.includes(type);
+}
+
+// TODO: maybe move to the dashboard component?
+export function isSingleOrMultiSelectable(parameter: Parameter): boolean {
+  const type = getParameterType(parameter);
+  return SINGLE_OR_MULTI_SELECTABLE_TYPES.includes(type);
+}

--- a/frontend/src/metabase/parameters/utils/parameter-type.ts
+++ b/frontend/src/metabase/parameters/utils/parameter-type.ts
@@ -1,14 +1,14 @@
 import _ from "underscore";
 import { Parameter } from "metabase-types/types/Parameter";
-import { FieldFilterUiParameter } from "metabase-lib/lib/parameters/types";
+import { FieldFilterUiParameter } from "metabase-lib/parameters/types";
 import {
   FIELD_FILTER_PARAMETER_TYPES,
   SINGLE_OR_MULTI_SELECTABLE_TYPES,
-} from "metabase-lib/lib/parameters/constants";
+} from "metabase-lib/parameters/constants";
 import {
   getParameterType,
   getParameterSubType,
-} from "metabase-lib/lib/parameters/utils/parameter-type";
+} from "metabase-lib/parameters/utils/parameter-type";
 
 export function isFieldFilterParameter(
   parameter: Parameter,

--- a/frontend/src/metabase/parameters/utils/parameter-type.ts
+++ b/frontend/src/metabase/parameters/utils/parameter-type.ts
@@ -1,6 +1,6 @@
 import _ from "underscore";
-import { FieldFilterUiParameter } from "metabase/parameters/types";
 import { Parameter } from "metabase-types/types/Parameter";
+import { FieldFilterUiParameter } from "metabase-lib/lib/parameters/types";
 import {
   FIELD_FILTER_PARAMETER_TYPES,
   SINGLE_OR_MULTI_SELECTABLE_TYPES,

--- a/frontend/src/metabase/parameters/utils/parameter-type.unit.spec.ts
+++ b/frontend/src/metabase/parameters/utils/parameter-type.unit.spec.ts
@@ -1,0 +1,18 @@
+import { isSingleOrMultiSelectable } from "./parameter-type.ts";
+
+describe("isSingleOrMultiSelectable", () => {
+  it("is false for parameters with types not included", () => {
+    const parameter = { sectionId: "number", subType: "!=" };
+    expect(isSingleOrMultiSelectable(parameter)).toBe(false);
+  });
+
+  it("is false for parameters with acceptable types and rejected subTypes", () => {
+    const parameter = { sectionId: "string", subType: "ends-with" };
+    expect(isSingleOrMultiSelectable(parameter)).toBe(false);
+  });
+
+  it("is true for parameters with acceptable types and corresponding subTypes ", () => {
+    const parameter = { sectionId: "location", type: "string/=" };
+    expect(isSingleOrMultiSelectable(parameter)).toBe(true);
+  });
+});

--- a/frontend/src/metabase/parameters/utils/parameter-type.unit.spec.ts
+++ b/frontend/src/metabase/parameters/utils/parameter-type.unit.spec.ts
@@ -1,18 +1,37 @@
-import { isSingleOrMultiSelectable } from "./parameter-type.ts";
+import { isSingleOrMultiSelectable } from "./parameter-type";
+
+const requiredParameterAttributes = {
+  id: "1",
+  name: "Name",
+  slug: "slug",
+  type: "a type",
+};
 
 describe("isSingleOrMultiSelectable", () => {
   it("is false for parameters with types not included", () => {
-    const parameter = { sectionId: "number", subType: "!=" };
+    const parameter = {
+      ...requiredParameterAttributes,
+      sectionId: "number",
+      subType: "!=",
+    };
     expect(isSingleOrMultiSelectable(parameter)).toBe(false);
   });
 
   it("is false for parameters with acceptable types and rejected subTypes", () => {
-    const parameter = { sectionId: "string", subType: "ends-with" };
+    const parameter = {
+      ...requiredParameterAttributes,
+      sectionId: "string",
+      subType: "ends-with",
+    };
     expect(isSingleOrMultiSelectable(parameter)).toBe(false);
   });
 
   it("is true for parameters with acceptable types and corresponding subTypes ", () => {
-    const parameter = { sectionId: "location", type: "string/=" };
+    const parameter = {
+      ...requiredParameterAttributes,
+      sectionId: "location",
+      type: "string/=",
+    };
     expect(isSingleOrMultiSelectable(parameter)).toBe(true);
   });
 });

--- a/frontend/test/metabase/scenarios/dashboard-filters/parameters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/parameters.cy.spec.js
@@ -38,6 +38,7 @@ describe("scenarios > dashboard > parameters", () => {
     cy.icon("filter").click();
     cy.contains("Text or Category").click();
     cy.findByText("Dropdown").click();
+    cy.findByText("A single value").click();
 
     // connect it to people.name and product.category
     // (this doesn't make sense to do, but it illustrates the feature)


### PR DESCRIPTION
Solves #13840

### How to Test

1. Create dashboard and populate it with, say, a plain People question card.
2. Edit dashboard
3. Add filter › Location › Dropdown › A single value › Connect filter to "State" field
4. Add filter › ID › A single value › Connect filter to "ID" field
5. Add filter › Text or Category › Dropdown ›  A single value › Connect filter to "Address" field
6. Save changes to Dashboard

You should be able to use these filters as you'd expect, behaving appropriately for a single option picker.
For the time being at least, pickers will show the "Add filter" button to commit the choice.

[Notion](https://www.notion.so/metabase/Allow-category-field-dropdowns-to-be-single-selection-ffce517a8aca40628c3c0499d5a8eb5b)