### PR TITLE
Use "apps" collection namespace for app collections

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -455,6 +455,7 @@
    metabase.api.public-test/with-temp-public-dashboard                                                                       hooks.common/let-one-with-optional-value
    metabase.api.public-test/with-temp-public-dashboard-and-card                                                              hooks.common/with-three-bindings
    metabase.api.search-test/with-search-items-in-collection                                                                  hooks.metabase.api.search-test/with-search-items-in-collection
+   metabase.api.search-test/with-search-items-in-app-collection                                                              hooks.metabase.api.search-test/with-search-items-in-collection
    metabase.api.search-test/with-search-items-in-root-collection                                                             hooks.common/do*
    metabase.api.user-test/with-temp-user-email                                                                               hooks.common/with-one-binding
    metabase.async.streaming-response-test/with-start-execution-chan                                                          hooks.common/with-one-binding

--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions/app_permissions.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions/app_permissions.clj
@@ -14,7 +14,6 @@
             [toucan.db :as db]))
 
 (defn- check-advanced-permissions []
-  (log/fatal "checking advanced permsissions")
   (when-not (premium-features/has-feature? :advanced-permissions)
     (throw (ex-info (i18n/tru "The granular app permission functionality is only enabled if you have a premium token with the advanced-permissions feature.")
                     {:status-code 402}))))

--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions/app_permissions.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions/app_permissions.clj
@@ -17,7 +17,7 @@
 
 (def ^:private GroupPermissionsGraph
   "collection-id -> status"
-  {su/IntGreaterThanZero app.graph/AppPermissions}) ; be present, which is why it's *optional*
+  {su/IntGreaterThanZero app.graph/RootPermissions}) ; be present, which is why it's *optional*
 
 (def ^:private PermissionsGraph
   {:revision s/Int

--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions/app_permissions.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions/app_permissions.clj
@@ -3,8 +3,8 @@
   on the app collections."
   (:require [clojure.data :as data]
             [clojure.set :as set]
-            [metabase.models.collection-permission-graph-revision :as c-perm-revision
-             :refer [CollectionPermissionGraphRevision]]
+            [metabase.models.app-permission-graph-revision :as app-perm-revision
+             :refer [AppPermissionGraphRevision]]
             [metabase.models.collection.graph :as graph]
             [metabase.models.permissions :as perms]
             [metabase.public-settings.premium-features :as premium-features]
@@ -71,6 +71,6 @@
                   [app-id new-perms] new-group-perms
                   :let [collection-id (app-id->collection-id app-id)]]
             (graph/update-collection-permissions! :apps group-id collection-id new-perms))
-          (perms/save-perms-revision! CollectionPermissionGraphRevision (:revision old-graph)
-                                      (assoc old-graph :namespace :apps) changes))))
+          (perms/save-perms-revision! AppPermissionGraphRevision (:revision old-graph)
+                                      old-graph changes))))
     (graph)))

--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions/app_permissions.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions/app_permissions.clj
@@ -3,7 +3,6 @@
   on the app collections."
   (:require [clojure.data :as data]
             [clojure.set :as set]
-            [clojure.tools.logging :as log]
             [metabase.models.collection-permission-graph-revision :as c-perm-revision
              :refer [CollectionPermissionGraphRevision]]
             [metabase.models.collection.graph :as graph]

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions/app_permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions/app_permissions_test.clj
@@ -4,7 +4,8 @@
             [metabase.models :refer [App Collection PermissionsGroup]]
             [metabase.models.permissions-group :as perms-group]
             [metabase.public-settings.premium-features-test :as premium-features-test]
-            [metabase.test :as mt]))
+            [metabase.test :as mt]
+            [toucan.db :as db]))
 
 (deftest graph-test
   (testing "GET /api/app/graph works only with advanced permissions"
@@ -37,7 +38,7 @@
                          (:id (perms-group/all-users)) {app-id "none"}
                          group-id {app-id "none"}}
                         group-perms))
-          (is (= #{app-id} (into #{} (mapcat keys) (vals group-perms)))
+          (is (= #{app-id :root} (into #{} (mapcat keys) (vals group-perms)))
               "Shouldn't confuse collection IDs and app IDs"))))))
 
 (deftest graph-update-test
@@ -48,24 +49,41 @@
                                                                     :groups {1 {1 "write"}}})))))
 
   (premium-features-test/with-premium-features #{:advanced-permissions}
-    (mt/with-temp* [Collection [{app-coll-id :id} {:location "/", :namespace :apps}]
-                    App [{app-id :id} {:collection_id app-coll-id}]
-                    PermissionsGroup [{group-id :id}]]
-      (testing "PUT /api/app/graph\n"
-        (testing "Should be able to update the permissions graph for apps\n"
-          (let [initial-graph (mt/user-http-request :crowberto :get 200 "app/graph")
-                updated-graph (assoc-in initial-graph [:groups group-id app-id] "read")]
-            (testing "Initial assumptions should hold"
+    (let [max-coll-id (:id (db/select-one [Collection [:%max.id :id]]))
+          max-app-id (:id (db/select-one [App [:%max.id :id]]))]
+      (mt/with-temp* [Collection [{coll0-id :id} {:location "/", :namespace :apps}]
+                      Collection [{coll1-id :id} {:location "/", :namespace :apps}]
+                      App [{app-id :id :as app} {:collection_id (if (= max-app-id max-coll-id) coll1-id coll0-id)}]
+                      PermissionsGroup [{group-id :id}]]
+        (testing "PUT /api/app/graph\n"
+          (testing "Initial assumptions should hold"
+            (let [initial-graph (mt/user-http-request :crowberto :get 200 "app/graph")]
+              (is (not= app-id (:collection_id app))
+                  "The IDs of the app and its collection should be different. Fix the test!")
               (is (partial= {(:id (perms-group/admin)) {app-id "write"}
                              (:id (perms-group/all-users)) {app-id "none"}
                              group-id {app-id "none"}}
                             (:groups initial-graph))
-                  "Unexpected initial state"))
+                  "Unexpected initial state")))
 
-            (testing "Have to be a superuser"
-              (is (= "You don't have permissions to do that."
-                     (mt/user-http-request :rasta :put 403 "app/graph" updated-graph))))
+          (testing "Should be able to update the permissions graph for a specific app\n"
+            (let [initial-graph (mt/user-http-request :crowberto :get 200 "app/graph")
+                  updated-graph (assoc-in initial-graph [:groups group-id app-id] "read")]
+              (testing "Have to be a superuser"
+                (is (= "You don't have permissions to do that."
+                       (mt/user-http-request :rasta :put 403 "app/graph" updated-graph))))
 
-            (testing "Superuser can update"
-              (is (= (:groups updated-graph)
-                     (:groups (mt/user-http-request :crowberto :put 200 "app/graph" updated-graph)))))))))))
+              (testing "Superuser can update permissions for an app"
+                (is (= (:groups updated-graph)
+                       (:groups (mt/user-http-request :crowberto :put 200 "app/graph" updated-graph)))))))
+
+          (testing "Should be able to update the permissions graph for the root\n"
+            (let [initial-graph (mt/user-http-request :crowberto :get 200 "app/graph")
+                  updated-graph (assoc-in initial-graph [:groups group-id :root] "read")]
+              (testing "Have to be a superuser"
+                (is (= "You don't have permissions to do that."
+                       (mt/user-http-request :rasta :put 403 "app/graph" updated-graph))))
+
+              (testing "Superuser can update permissions for the root"
+                (is (= (:groups updated-graph)
+                       (:groups (mt/user-http-request :crowberto :put 200 "app/graph" updated-graph))))))))))))

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions/app_permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions/app_permissions_test.clj
@@ -40,8 +40,10 @@
                          (:id (perms-group/all-users)) {app-id "none"}
                          group-id {app-id "none"}}
                         group-perms))
-          (is (= #{app-id :root} (into #{} (mapcat keys) (vals group-perms)))
-              "Shouldn't confuse collection IDs and app IDs"))))))
+          (let [app-ids (into #{} (mapcat keys) (vals group-perms))]
+            (is (every? #(contains? app-ids %) [:root app-id]))
+            (is (not (contains? app-ids app-coll-id))
+                "Shouldn't confuse collection IDs and app IDs")))))))
 
 (deftest graph-update-test
   (testing "PUT /api/app/graph works only with advanced permissions"

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions/app_permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions/app_permissions_test.clj
@@ -13,7 +13,7 @@
              (mt/user-http-request :crowberto :get 402 "app/graph")))))
 
   (premium-features-test/with-premium-features #{:advanced-permissions}
-    (mt/with-temp* [Collection [{app-coll-id :id} {:location "/"}]
+    (mt/with-temp* [Collection [{app-coll-id :id} {:location "/", :namespace :apps}]
                     App [{app-id :id} {:collection_id app-coll-id}]
                     PermissionsGroup [{group-id :id}]]
       (testing "GET /api/app/graph\n"
@@ -29,7 +29,7 @@
 
     (mt/with-non-admin-groups-no-root-collection-perms
       (mt/with-temp* [Collection [_ {:location "/"}]
-                      Collection [{app-coll-id :id} {:location "/"}]
+                      Collection [{app-coll-id :id} {:location "/", :namespace :apps}]
                       App [{app-id :id} {:collection_id app-coll-id}]
                       PermissionsGroup [{group-id :id}]]
         (testing "All users' right to root collection is respected"
@@ -49,7 +49,7 @@
                                                                     :groups {1 {1 "write"}}})))))
 
   (premium-features-test/with-premium-features #{:advanced-permissions}
-    (mt/with-temp* [Collection [{app-coll-id :id} {:location "/"}]
+    (mt/with-temp* [Collection [{app-coll-id :id} {:location "/", :namespace :apps}]
                     App [{app-id :id} {:collection_id app-coll-id}]
                     PermissionsGroup [{group-id :id}]]
       (testing "PUT /api/app/graph\n"

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions/app_permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions/app_permissions_test.clj
@@ -58,6 +58,7 @@
             max-app-id (:id (db/select-one [App [:%max.id :id]]))]
         (mt/with-temp* [Collection [{coll0-id :id} {:location "/", :namespace :apps}]
                         Collection [{coll1-id :id} {:location "/", :namespace :apps}]
+                        ;; make sure that the :id and :collection_id of the app are different
                         App [{app-id :id :as app} {:collection_id (if (= max-app-id max-coll-id)
                                                                     coll1-id
                                                                     coll0-id)}]

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions/app_permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions/app_permissions_test.clj
@@ -1,10 +1,12 @@
 (ns metabase-enterprise.advanced-permissions.models.permissions.app-permissions-test
   "Tests for /api/collection endpoints."
   (:require [clojure.test :refer :all]
-            [metabase.models :refer [App Collection PermissionsGroup]]
+            [metabase.models :refer [App Card Collection Dashboard
+                                     Permissions PermissionsGroup PermissionsGroupMembership]]
             [metabase.models.permissions-group :as perms-group]
             [metabase.public-settings.premium-features-test :as premium-features-test]
             [metabase.test :as mt]
+            [metabase.test.data :as data]
             [toucan.db :as db]))
 
 (deftest graph-test
@@ -48,42 +50,59 @@
              (mt/user-http-request :crowberto :put 402 "app/graph" {:revision 0
                                                                     :groups {1 {1 "write"}}})))))
 
-  (premium-features-test/with-premium-features #{:advanced-permissions}
-    (let [max-coll-id (:id (db/select-one [Collection [:%max.id :id]]))
-          max-app-id (:id (db/select-one [App [:%max.id :id]]))]
-      (mt/with-temp* [Collection [{coll0-id :id} {:location "/", :namespace :apps}]
-                      Collection [{coll1-id :id} {:location "/", :namespace :apps}]
-                      App [{app-id :id :as app} {:collection_id (if (= max-app-id max-coll-id) coll1-id coll0-id)}]
-                      PermissionsGroup [{group-id :id}]]
-        (testing "PUT /api/app/graph\n"
-          (testing "Initial assumptions should hold"
-            (let [initial-graph (mt/user-http-request :crowberto :get 200 "app/graph")]
-              (is (not= app-id (:collection_id app))
-                  "The IDs of the app and its collection should be different. Fix the test!")
-              (is (partial= {(:id (perms-group/admin)) {app-id "write"}
-                             (:id (perms-group/all-users)) {app-id "none"}
-                             group-id {app-id "none"}}
-                            (:groups initial-graph))
-                  "Unexpected initial state")))
+  (mt/with-model-cleanup [Card Dashboard Collection Permissions]
+    (premium-features-test/with-premium-features #{:advanced-permissions}
+      (let [max-coll-id (:id (db/select-one [Collection [:%max.id :id]]))
+            max-app-id (:id (db/select-one [App [:%max.id :id]]))]
+        (mt/with-temp* [Collection [{coll0-id :id} {:location "/", :namespace :apps}]
+                        Collection [{coll1-id :id} {:location "/", :namespace :apps}]
+                        App [{app-id :id :as app} {:collection_id (if (= max-app-id max-coll-id)
+                                                                    coll1-id
+                                                                    coll0-id)}]
+                        PermissionsGroup [{group-id :id}]
+                        PermissionsGroupMembership [_ {:user_id (mt/user->id :rasta)
+                                                       :group_id group-id}]]
+          (testing "PUT /api/app/graph\n"
+            (testing "Initial assumptions should hold"
+              (let [initial-graph (mt/user-http-request :crowberto :get 200 "app/graph")]
+                (is (not= app-id (:collection_id app))
+                    "The IDs of the app and its collection should be different. Fix the test!")
+                (is (partial= {(:id (perms-group/admin)) {app-id "write"}
+                               (:id (perms-group/all-users)) {app-id "none"}
+                               group-id {app-id "none"}}
+                              (:groups initial-graph))
+                    "Unexpected initial state")))
 
-          (testing "Should be able to update the permissions graph for a specific app\n"
-            (let [initial-graph (mt/user-http-request :crowberto :get 200 "app/graph")
-                  updated-graph (assoc-in initial-graph [:groups group-id app-id] "read")]
-              (testing "Have to be a superuser"
-                (is (= "You don't have permissions to do that."
-                       (mt/user-http-request :rasta :put 403 "app/graph" updated-graph))))
+            (testing "Should be able to update the permissions graph for a specific app\n"
+              (let [initial-graph (mt/user-http-request :crowberto :get 200 "app/graph")
+                    updated-graph (assoc-in initial-graph [:groups group-id app-id] "write")]
+                (testing "Have to be a superuser"
+                  (is (= "You don't have permissions to do that."
+                         (mt/user-http-request :rasta :put 403 "app/graph" updated-graph))))
 
-              (testing "Superuser can update permissions for an app"
-                (is (= (:groups updated-graph)
-                       (:groups (mt/user-http-request :crowberto :put 200 "app/graph" updated-graph)))))))
+                (testing "Cannot scaffold an app without write permission"
+                  (is (= "You don't have permissions to do that."
+                         (mt/user-http-request :rasta :post 403 (format "app/%s/scaffold" app-id)
+                                               {:table-ids [(data/id :venues)]}))))
 
-          (testing "Should be able to update the permissions graph for the root\n"
-            (let [initial-graph (mt/user-http-request :crowberto :get 200 "app/graph")
-                  updated-graph (assoc-in initial-graph [:groups group-id :root] "read")]
-              (testing "Have to be a superuser"
-                (is (= "You don't have permissions to do that."
-                       (mt/user-http-request :rasta :put 403 "app/graph" updated-graph))))
+                (testing "Superuser can update permissions for an app"
+                  (is (= (:groups updated-graph)
+                         (:groups (mt/user-http-request :crowberto :put 200 "app/graph"
+                                                        updated-graph)))))
 
-              (testing "Superuser can update permissions for the root"
-                (is (= (:groups updated-graph)
-                       (:groups (mt/user-http-request :crowberto :put 200 "app/graph" updated-graph))))))))))))
+                (testing "Normal user can scaffold an app with write permission"
+                  (is (partial= (dissoc app :updated_at :nav_items)
+                                (mt/user-http-request :rasta :post 200 (format "app/%s/scaffold" app-id)
+                                                      {:table-ids [(data/id :venues)]}))))))
+
+            (testing "Should be able to update the permissions graph for the root\n"
+              (let [initial-graph (mt/user-http-request :crowberto :get 200 "app/graph")
+                    updated-graph (assoc-in initial-graph [:groups group-id :root] "read")]
+                (testing "Have to be a superuser"
+                  (is (= "You don't have permissions to do that."
+                         (mt/user-http-request :rasta :put 403 "app/graph" updated-graph))))
+
+                (testing "Superuser can update permissions for the root"
+                  (is (= (:groups updated-graph)
+                         (:groups (mt/user-http-request :crowberto :put 200 "app/graph"
+                                                        updated-graph)))))))))))))

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions/app_permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions/app_permissions_test.clj
@@ -19,7 +19,7 @@
       (testing "GET /api/app/graph\n"
         (testing "Should be able to fetch the permissions graph for apps"
           (is (partial= {(:id (perms-group/admin)) {app-id "write"}
-                         (:id (perms-group/all-users)) {app-id "write"}
+                         (:id (perms-group/all-users)) {app-id "none"}
                          group-id {app-id "none"}}
                         (:groups (mt/user-http-request :crowberto :get 200 "app/graph")))))
 

--- a/enterprise/backend/test/metabase_enterprise/models/entity_id_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/models/entity_id_test.clj
@@ -35,6 +35,7 @@
     metabase.models.action.HTTPActionInstance
     metabase.models.action.QueryActionInstance
     metabase.models.activity.ActivityInstance
+    metabase.models.app_permission_graph_revision.AppPermissionGraphRevisionInstance
     metabase.models.application_permissions_revision.ApplicationPermissionsRevisionInstance
     metabase.models.bookmark.BookmarkOrderingInstance
     metabase.models.bookmark.CardBookmarkInstance

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -12993,6 +12993,53 @@ databaseChangeLog:
             tableName: metabase_database
             columnName: details
 
+  - changeSet:
+      id: v45.00-044
+      author: metamben
+      changes:
+        - createTable:
+            tableName: app_permission_graph_revision
+            remarks: 'Used to keep track of changes made to app permissions.'
+            columns:
+              - column:
+                  name: id
+                  type: int
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: before
+                  type: text
+                  remarks: 'Serialized JSON of the apps graph before the changes.'
+                  constraints:
+                    nullable: false
+              - column:
+                  name: after
+                  type: text
+                  remarks: 'Serialized JSON of the apps graph after the changes.'
+                  constraints:
+                    nullable: false
+              - column:
+                  name: user_id
+                  type: int
+                  remarks: 'The ID of the admin who made this set of changes.'
+                  constraints:
+                    nullable: false
+                    referencedTableName: core_user
+                    referencedColumnNames: id
+                    foreignKeyName: fk_app_permission_graph_revision_user_id
+              - column:
+                  name: created_at
+                  type: datetime
+                  remarks: 'The timestamp of when these changes were made.'
+                  constraints:
+                    nullable: false
+              - column:
+                  name: remark
+                  type: text
+                  remarks: 'Optional remarks explaining why these changes were made.'
+
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -12996,6 +12996,7 @@ databaseChangeLog:
   - changeSet:
       id: v45.00-044
       author: metamben
+      comment: Added 0.45.0 -- create app permission graph revision table
       changes:
         - createTable:
             tableName: app_permission_graph_revision
@@ -13010,13 +13011,13 @@ databaseChangeLog:
                     nullable: false
               - column:
                   name: before
-                  type: text
+                  type: ${text.type}
                   remarks: 'Serialized JSON of the apps graph before the changes.'
                   constraints:
                     nullable: false
               - column:
                   name: after
-                  type: text
+                  type: ${text.type}
                   remarks: 'Serialized JSON of the apps graph after the changes.'
                   constraints:
                     nullable: false
@@ -13037,7 +13038,7 @@ databaseChangeLog:
                     nullable: false
               - column:
                   name: remark
-                  type: text
+                  type: ${text.type}
                   remarks: 'Optional remarks explaining why these changes were made.'
 
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -13032,8 +13032,9 @@ databaseChangeLog:
                     foreignKeyName: fk_app_permission_graph_revision_user_id
               - column:
                   name: created_at
-                  type: datetime
+                  type: ${timestamp_type}
                   remarks: 'The timestamp of when these changes were made.'
+                  defaultValueComputed: current_timestamp
                   constraints:
                     nullable: false
               - column:

--- a/src/metabase/api/app.clj
+++ b/src/metabase/api/app.clj
@@ -26,8 +26,9 @@
 
 (defn- create-app! [{:keys [collection] :as app}]
   (db/transaction
-   (let [coll-params (select-keys collection [:name :color :description :namespace :authority_level])
-         collection-instance (api.collection/create-collection! coll-params)
+   (let [coll-params (select-keys collection [:name :color :description :authority_level])
+         collection-instance (api.collection/create-collection!
+                              (assoc coll-params :namespace :apps))
          app-params (-> app
                         (select-keys [:dashboard_id :options :nav_items])
                         (assoc :collection_id (:id collection-instance)))

--- a/src/metabase/api/app.clj
+++ b/src/metabase/api/app.clj
@@ -328,12 +328,12 @@
   (let [graph (resolve-advanced-app-permission-function 'graph)]
     (graph)))
 
-(defn- ->int [id] (Integer/parseInt (name id)))
+(defn- ->int [id] (parse-long (name id)))
 
 (defn- dejsonify-with [f m]
   (into {}
         (map (fn [[k v]]
-               [(->int k) (f v)]))
+               [(or (->int k) k) (f v)]))
         m))
 
 (defn- dejsonify-id->permission-map [m]
@@ -341,12 +341,6 @@
 
 (defn- dejsonify-groups-map [m]
   (dejsonify-with dejsonify-id->permission-map m))
-
-(defn- dejsonify-global-graph
-  "Fix the types in the graph when it comes in from the API, e.g. converting things like `\"none\"` to `:none` and
-  parsing object keys as integers."
-  [graph]
-  (update graph :groups dejsonify-id->permission-map))
 
 (defn- dejsonify-graph
   "Fix the types in the graph when it comes in from the API, e.g. converting things like `\"none\"` to `:none` and
@@ -360,7 +354,7 @@
   {body su/Map}
   (api/check-superuser)
   (-> body
-      dejsonify-global-graph
+      dejsonify-graph
       app.graph/update-global-graph!))
 
 (api/defendpoint PUT "/graph"

--- a/src/metabase/api/app.clj
+++ b/src/metabase/api/app.clj
@@ -8,7 +8,7 @@
     [metabase.api.collection :as api.collection]
     [metabase.api.common :as api]
     [metabase.mbql.schema :as mbql.s]
-    [metabase.models :refer [App Collection Dashboard ModelAction Table]]
+    [metabase.models :refer [App Dashboard ModelAction Table]]
     [metabase.models.app.graph :as app.graph]
     [metabase.models.collection :as collection]
     [metabase.models.dashboard :as dashboard]

--- a/src/metabase/api/app.clj
+++ b/src/metabase/api/app.clj
@@ -57,7 +57,7 @@
    dashboard_id (s/maybe su/IntGreaterThanOrEqualToZero)
    options (s/maybe su/Map)
    nav_items (s/maybe [(s/maybe su/Map)])}
-  (api/write-check Collection (db/select-one-field :collection_id App :id app-id))
+  (api/write-check App app-id)
   (db/update! App app-id (select-keys body [:dashboard_id :options :nav_items]))
   (hydrate-details (db/select-one App :id app-id)))
 
@@ -287,6 +287,7 @@
 (api/defendpoint POST "/:app-id/scaffold"
   "Endpoint to scaffold a new table onto an existing data-app"
   [app-id :as {{:keys [table-ids]} :body}]
+  (api/write-check App app-id)
   (db/transaction
     (let [{app-id :id app-name :name nav-items :nav_items {collection-id :id} :collection} (hydrate-details (db/select-one App :id app-id))
           ;; We can scaffold this as a new app, but use the existing collection-id and nav-items to merge into the existing app

--- a/src/metabase/api/app.clj
+++ b/src/metabase/api/app.clj
@@ -33,7 +33,6 @@
                         (select-keys [:dashboard_id :options :nav_items])
                         (assoc :collection_id (:id collection-instance)))
          app (db/insert! App app-params)]
-     (app.graph/set-default-permissions! app)
      (hydrate-details app))))
 
 (api/defendpoint POST "/"

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -755,16 +755,17 @@
 (defn- write-check-collection-or-root-collection
   "Check that you're allowed to write Collection with `collection-id`; if `collection-id` is `nil`, check that you have
   Root Collection perms."
-  [collection-id]
+  [collection-id collection-namespace]
   (api/write-check (if collection-id
                      (db/select-one Collection :id collection-id)
-                     collection/root-collection)))
+                     (cond-> collection/root-collection
+                       collection-namespace (assoc :namespace collection-namespace)))))
 
 (defn create-collection!
   "Create a new collection."
   [{:keys [name color description parent_id namespace authority_level]}]
   ;; To create a new collection, you need write perms for the location you are going to be putting it in...
-  (write-check-collection-or-root-collection parent_id)
+  (write-check-collection-or-root-collection parent_id namespace)
   ;; Now create the new Collection :)
   (api/check-403 (or (nil? authority_level)
                      (and api/*is-superuser?* authority_level)))

--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -230,7 +230,9 @@
                                   visible-collections)
         honeysql-query           (-> honeysql-query
                                      (hh/merge-where collection-filter-clause)
-                                     (hh/merge-where [:= :collection.namespace nil]))]
+                                     (hh/merge-where [:or
+                                                      [:= :collection.namespace nil]
+                                                      [:= :collection.namespace "apps"]]))]
     ;; add a JOIN against Collection *unless* the source table is already Collection
     (cond-> honeysql-query
       (not= collection-id-column :collection.id)

--- a/src/metabase/cmd/copy.clj
+++ b/src/metabase/cmd/copy.clj
@@ -11,6 +11,7 @@
             [metabase.db.setup :as mdb.setup]
             [metabase.models :refer [Activity
                                      App
+                                     AppPermissionGraphRevision
                                      ApplicationPermissionsRevision
                                      BookmarkOrdering
                                      Card
@@ -107,6 +108,7 @@
    DashboardCardSeries
    Activity
    App
+   AppPermissionGraphRevision
    Pulse
    PulseCard
    PulseChannel

--- a/src/metabase/models.clj
+++ b/src/metabase/models.clj
@@ -2,6 +2,7 @@
   (:require [metabase.models.action :as action]
             [metabase.models.activity :as activity]
             [metabase.models.app :as app]
+            [metabase.models.app-permission-graph-revision :as app-perm-revision]
             [metabase.models.application-permissions-revision :as a-perm-revision]
             [metabase.models.bookmark :as bookmark]
             [metabase.models.card :as card]
@@ -48,6 +49,7 @@
 (comment action/keep-me
          activity/keep-me
          app/keep-me
+         app-perm-revision/keep-me
          card/keep-me
          bookmark/keep-me
          collection/keep-me
@@ -93,6 +95,7 @@
  [action Action HTTPAction ModelAction QueryAction]
  [activity Activity]
  [app App]
+ [app-perm-revision AppPermissionGraphRevision]
  [bookmark CardBookmark]
  [bookmark DashboardBookmark]
  [bookmark CollectionBookmark]

--- a/src/metabase/models/app.clj
+++ b/src/metabase/models/app.clj
@@ -1,5 +1,6 @@
 (ns metabase.models.app
-  (:require [metabase.models.interface :as mi]
+  (:require [metabase.models.collection :as collection :refer [Collection]]
+            [metabase.models.interface :as mi]
             [metabase.models.query :as query]
             [metabase.models.serialization.hash :as serdes.hash]
             [metabase.util :as u]
@@ -15,7 +16,9 @@
 
 (defmethod mi/perms-objects-set App
   [instance read-or-write]
-  (let [collection (db/select-one 'Collection :id (:collection_id instance))]
+  (let [collection (if-let [collection-id (:collection_id instance)]
+                     (mi/instance Collection {:id collection-id, :namespace :apps})
+                     (assoc collection/root-collection :namespace :apps))]
     (mi/perms-objects-set collection read-or-write)))
 
 (u/strict-extend #_{:clj-kondo/ignore [:metabase/disallow-class-or-type-on-model]} (class App)

--- a/src/metabase/models/app.clj
+++ b/src/metabase/models/app.clj
@@ -1,5 +1,5 @@
 (ns metabase.models.app
-  (:require [metabase.models.permissions :as perms]
+  (:require [metabase.models.interface :as mi]
             [metabase.models.query :as query]
             [metabase.models.serialization.hash :as serdes.hash]
             [metabase.util :as u]
@@ -9,7 +9,14 @@
 (models/defmodel App :app)
 
 ;;; You can read/write an App if you can read/write its Collection
-(derive App ::perms/use-parent-collection-perms)
+(doto App
+  (derive ::mi/read-policy.full-perms-for-perms-set)
+  (derive ::mi/write-policy.full-perms-for-perms-set))
+
+(defmethod mi/perms-objects-set App
+  [instance read-or-write]
+  (let [collection (db/select-one 'Collection :id (:collection_id instance))]
+    (mi/perms-objects-set collection read-or-write)))
 
 (u/strict-extend #_{:clj-kondo/ignore [:metabase/disallow-class-or-type-on-model]} (class App)
   models/IModel

--- a/src/metabase/models/app/graph.clj
+++ b/src/metabase/models/app/graph.clj
@@ -7,49 +7,29 @@
             [metabase.models.collection.graph :as graph]
             [metabase.models.permissions :as perms]
             [metabase.models.permissions-group :as perms-group]
-            [metabase.models.setting :as setting :refer [defsetting]]
-            [metabase.public-settings.premium-features :as premium-features]
             [metabase.util.i18n :as i18n :refer [tru]]
             [metabase.util.schema :as su]
             [schema.core :as s]
             [toucan.db :as db]))
 
-(def AppPermissions
+(def RootPermissions
   "The valid app permissions. Currently corresponds 1:1 to `CollectionPermissions`
   since app permissions are implemented in terms of collection permissions."
-  graph/CollectionPermissions)
+  {:root graph/CollectionPermissions})
 
 (def ^:private GlobalPermissionsGraph
   {:revision s/Int
-   :groups   {su/IntGreaterThanZero AppPermissions}})
-
-(s/defn ^:private set-all-users-app-permission!
-  [permission :- AppPermissions]
-  (setting/set-value-of-type! :keyword :all-users-app-permission permission))
-
-(defsetting all-users-app-permission
-  "App permission of the All Users group"
-  :type :keyword
-  :visibility :internal
-  :default :none
-  :setter (fn [v]
-            (set-all-users-app-permission! (cond-> v (string? v) keyword))))
-
-(defn set-default-permissions!
-  "Sets the default permissions for the ''All Users'' group on`app` as specified
-  by `all-users-app-permission` if advanced permissions are not available."
-  [app]
-  (when-not (premium-features/has-feature? :advanced-permissions)
-    (graph/update-collection-permissions! (:id (perms-group/all-users))
-                                          (:collection_id app)
-                                          (all-users-app-permission))))
+   :groups   {su/IntGreaterThanZero RootPermissions}})
 
 (s/defn global-graph :- GlobalPermissionsGraph
   "Fetch the global app permission graph."
   []
-  {:revision (c-perm-revision/latest-id)
-   :groups   {(:id (perms-group/admin)) :write
-              (:id (perms-group/all-users)) (all-users-app-permission)}})
+  (-> (graph/graph :apps)
+      (update :groups (fn [group-perms]
+                        (-> group-perms
+                            (select-keys [(:id (perms-group/admin))
+                                          (:id (perms-group/all-users))])
+                            (update-vals #(select-keys % [:root])))))))
 
 (s/defn update-global-graph!
   "Update the global app permission graph to the state specified by
@@ -59,17 +39,17 @@
         [diff-old changes] (data/diff (:groups old-graph) (:groups new-graph))]
     (perms/log-permissions-changes diff-old changes)
     (perms/check-revision-numbers old-graph new-graph)
-    (when-let [[[group-id permission] & other-groups] (seq changes)]
+    (when-let [[[group-id [[root permission] & other-colls]] & other-groups] (seq changes)]
       (when (or (not= group-id (:id (perms-group/all-users)))
+                (not= root :root)
+                (seq other-colls)
                 (seq other-groups))
-        (throw (ex-info (tru "You can configure for the ''All Users'' group only")
+        (throw (ex-info (tru "You can configure permissions only on the root and only for the ''All Users'' group")
                         {:group-ids (keys changes)
                          :status-code 400})))
       (db/transaction
-        (when (not= permission (all-users-app-permission))
-          (all-users-app-permission! permission)
-          (doseq [collection-id (db/select-field :collection_id 'App)]
-            (graph/update-collection-permissions! group-id collection-id permission))
-          (perms/save-perms-revision!
-           CollectionPermissionGraphRevision (:revision old-graph) old-graph changes))
-        (global-graph)))))
+       (doseq [collection-id (cons :root (db/select-field :collection_id 'App))]
+         (graph/update-collection-permissions! group-id collection-id permission))
+       (perms/save-perms-revision!
+        CollectionPermissionGraphRevision (:revision old-graph) old-graph changes)
+       (global-graph)))))

--- a/src/metabase/models/app/graph.clj
+++ b/src/metabase/models/app/graph.clj
@@ -43,8 +43,8 @@
         [diff-old changes] (data/diff (:groups old-graph) (:groups new-graph))]
     (perms/log-permissions-changes diff-old changes)
     (perms/check-revision-numbers old-graph new-graph)
-    (when-let [[[group-id [[root permission] & other-colls]] & other-groups] (seq changes)]
-      (when (or (not= group-id (:id (perms-group/all-users)))
+    (when-let [[[all-users-group-id [[root permission] & other-colls]] & other-groups] (seq changes)]
+      (when (or (not= all-users-group-id (:id (perms-group/all-users)))
                 (not= root :root)
                 (seq other-colls)
                 (seq other-groups))
@@ -52,7 +52,7 @@
                         {:group-ids (keys changes)
                          :status-code 400})))
       (db/transaction
-        (graph/update-collection-permissions! :apps group-id :root permission)
+        (graph/update-collection-permissions! :apps all-users-group-id root permission)
         (perms/save-perms-revision! AppPermissionGraphRevision (:revision old-graph)
                                     old-graph changes)
         (global-graph)))))

--- a/src/metabase/models/app/graph.clj
+++ b/src/metabase/models/app/graph.clj
@@ -49,6 +49,6 @@
                          :status-code 400})))
       (db/transaction
         (graph/update-collection-permissions! :apps group-id :root permission)
-        (perms/save-perms-revision!
-         CollectionPermissionGraphRevision (:revision old-graph) old-graph changes)
+        (perms/save-perms-revision! CollectionPermissionGraphRevision (:revision old-graph)
+                                    (assoc old-graph :namespace :apps) changes)
         (global-graph)))))

--- a/src/metabase/models/app/graph.clj
+++ b/src/metabase/models/app/graph.clj
@@ -22,9 +22,13 @@
    :groups   {su/IntGreaterThanZero RootPermissions}})
 
 (s/defn global-graph :- GlobalPermissionsGraph
-  "Fetch the global app permission graph."
+  "Fetch the global app permission graph.
+
+  This works by reading the permissions for app collections, restricting
+  the groups to admin and ''All Users'' and the collections to the root."
   []
   (-> (graph/graph :apps)
+      (assoc :revision (app-perm-revision/latest-id))
       (update :groups (fn [group-perms]
                         (-> group-perms
                             (select-keys [(:id (perms-group/admin))

--- a/src/metabase/models/app/graph.clj
+++ b/src/metabase/models/app/graph.clj
@@ -2,8 +2,8 @@
   "Code for generating and updating the App permissions graph. App permissions
   are based on the permissions of the app's collection."
   (:require [clojure.data :as data]
-            [metabase.models.collection-permission-graph-revision :as c-perm-revision
-             :refer [CollectionPermissionGraphRevision]]
+            [metabase.models.app-permission-graph-revision :as app-perm-revision
+             :refer [AppPermissionGraphRevision]]
             [metabase.models.collection.graph :as graph]
             [metabase.models.permissions :as perms]
             [metabase.models.permissions-group :as perms-group]
@@ -53,6 +53,6 @@
                          :status-code 400})))
       (db/transaction
         (graph/update-collection-permissions! :apps group-id :root permission)
-        (perms/save-perms-revision! CollectionPermissionGraphRevision (:revision old-graph)
-                                    (assoc old-graph :namespace :apps) changes)
+        (perms/save-perms-revision! AppPermissionGraphRevision (:revision old-graph)
+                                    old-graph changes)
         (global-graph)))))

--- a/src/metabase/models/app/graph.clj
+++ b/src/metabase/models/app/graph.clj
@@ -48,8 +48,7 @@
                         {:group-ids (keys changes)
                          :status-code 400})))
       (db/transaction
-       (doseq [collection-id (cons :root (db/select-field :collection_id 'App))]
-         (graph/update-collection-permissions! group-id collection-id permission))
-       (perms/save-perms-revision!
-        CollectionPermissionGraphRevision (:revision old-graph) old-graph changes)
-       (global-graph)))))
+        (graph/update-collection-permissions! :apps group-id :root permission)
+        (perms/save-perms-revision!
+         CollectionPermissionGraphRevision (:revision old-graph) old-graph changes)
+        (global-graph)))))

--- a/src/metabase/models/app_permission_graph_revision.clj
+++ b/src/metabase/models/app_permission_graph_revision.clj
@@ -1,0 +1,22 @@
+(ns metabase.models.app-permission-graph-revision
+  (:require [metabase.util :as u]
+            [metabase.util.i18n :refer [tru]]
+            [toucan.db :as db]
+            [toucan.models :as models]))
+
+(models/defmodel AppPermissionGraphRevision :app_permission_graph_revision)
+
+(u/strict-extend #_{:clj-kondo/ignore [:metabase/disallow-class-or-type-on-model]} (class AppPermissionGraphRevision)
+  models/IModel
+  (merge models/IModelDefaults
+         {:types      (constantly {:before :json
+                                   :after  :json})
+          :properties (constantly {:created-at-timestamped? true})
+          :pre-update (fn [& _] (throw (Exception. (tru "You cannot update an AppPermissionGraphRevision!"))))}))
+
+(defn latest-id
+  "Return the ID of the newest `AppPermissionGraphRevision`, or zero if none have been made yet.
+   (This is used by the app graph update logic that checks for changes since the original graph was fetched)."
+  []
+  (or (:id (db/select-one [AppPermissionGraphRevision [:%max.id :id]]))
+      0))

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -1131,7 +1131,7 @@
 
 (defmethod allowed-namespaces :default
   [_]
-  #{nil})
+  #{nil :apps})
 
 (defn check-collection-namespace
   "Check that object's `:collection_id` refers to a Collection in an allowed namespace (see

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -192,6 +192,7 @@
   (m/assoc-some root-collection
                 :name (case (keyword collection-namespace)
                         :snippets (tru "Top folder")
+                        :apps (tru "All apps")
                         (tru "Our analytics"))
                 :namespace collection-namespace
                 :id   "root"))

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -26,8 +26,7 @@
             [schema.core :as s]
             [toucan.db :as db]
             [toucan.hydrate :refer [hydrate]]
-            [toucan.models :as models]
-            [metabase.models.collection :as collection])
+            [toucan.models :as models])
   (:import metabase.models.collection.root.RootCollection))
 
 (comment collection.root/keep-me)
@@ -883,7 +882,7 @@
       ;; Collections in the "apps" namespace use the permissions of the root unless advanced permissions are enabled
       (and (= (u/qualified-name (:namespace collection)) "apps")
            (not (premium-features/has-feature? :advanced-permissions)))
-      #{(let [root (assoc collection/root-collection :namespace :apps)]
+      #{(let [root (assoc root-collection :namespace :apps)]
           (case read-or-write
             :read  (perms/collection-read-path root)
             :write (perms/collection-readwrite-path root)))}

--- a/src/metabase/models/collection/graph.clj
+++ b/src/metabase/models/collection/graph.clj
@@ -29,7 +29,7 @@
   {(s/optional-key :root) CollectionPermissions   ; when doing a delta between old graph and new graph root won't always
    su/IntGreaterThanZero  CollectionPermissions}) ; be present, which is why it's *optional*
 
-(def ^:private PermissionsGraph
+(def PermissionsGraph
   {:revision s/Int
    :groups   {su/IntGreaterThanZero GroupPermissionsGraph}})
 

--- a/src/metabase/models/collection/graph.clj
+++ b/src/metabase/models/collection/graph.clj
@@ -120,21 +120,19 @@
 (s/defn update-collection-permissions!
   "Update the permissions for group ID with `group-id` on collection with ID
   `collection-id` in the optional `collection-namespace` to `new-collection-perms`."
-  ([group-id collection-id new-collection-perms]
-   (update-collection-permissions! nil group-id collection-id new-collection-perms))
-  ([collection-namespace :- (s/maybe su/KeywordOrString)
-    group-id             :- su/IntGreaterThanZero
-    collection-id        :- (s/cond-pre (s/eq :root) su/IntGreaterThanZero)
-    new-collection-perms :- CollectionPermissions]
-   (let [collection-id (if (= collection-id :root)
-                         (assoc collection/root-collection :namespace collection-namespace)
-                         collection-id)]
-     ;; remove whatever entry is already there (if any) and add a new entry if applicable
-     (perms/revoke-collection-permissions! group-id collection-id)
-     (case new-collection-perms
-       :write (perms/grant-collection-readwrite-permissions! group-id collection-id)
-       :read  (perms/grant-collection-read-permissions! group-id collection-id)
-       :none  nil))))
+  [collection-namespace :- (s/maybe su/KeywordOrString)
+   group-id             :- su/IntGreaterThanZero
+   collection-id        :- (s/cond-pre (s/eq :root) su/IntGreaterThanZero)
+   new-collection-perms :- CollectionPermissions]
+  (let [collection-id (if (= collection-id :root)
+                        (assoc collection/root-collection :namespace collection-namespace)
+                        collection-id)]
+    ;; remove whatever entry is already there (if any) and add a new entry if applicable
+    (perms/revoke-collection-permissions! group-id collection-id)
+    (case new-collection-perms
+      :write (perms/grant-collection-readwrite-permissions! group-id collection-id)
+      :read  (perms/grant-collection-read-permissions! group-id collection-id)
+      :none  nil)))
 
 (s/defn ^:private update-group-permissions!
   [collection-namespace :- (s/maybe su/KeywordOrString)

--- a/src/metabase/models/collection/graph.clj
+++ b/src/metabase/models/collection/graph.clj
@@ -30,6 +30,7 @@
    su/IntGreaterThanZero  CollectionPermissions}) ; be present, which is why it's *optional*
 
 (def PermissionsGraph
+  "A versioned map of group permissions. See [[GroupPermissionsGraph]]."
   {:revision s/Int
    :groups   {su/IntGreaterThanZero GroupPermissionsGraph}})
 

--- a/src/metabase/models/collection/graph.clj
+++ b/src/metabase/models/collection/graph.clj
@@ -69,7 +69,7 @@
                                                  [:not [:like :location (hx/literal (format "/%d/%%" collection-id))]]))}]
     (set (map :id (db/query honeysql-form)))))
 
-(defn collection-permission-graph
+(defn- collection-permission-graph
   "Return the permission graph for the collections with id in `collection-ids` and the root collection."
   ([collection-ids] (collection-permission-graph collection-ids nil))
   ([collection-ids collection-namespace]

--- a/src/metabase/models/permissions.clj
+++ b/src/metabase/models/permissions.clj
@@ -1227,7 +1227,8 @@
   "Save changes made to permission graph for logging/auditing purposes.
   This doesn't do anything if `*current-user-id*` is unset (e.g. for testing or REPL usage).
   *  `model`   -- revision model, should be one of
-                  [PermissionsRevision, CollectionPermissionGraphRevision, ApplicationPermissionsRevision]
+                  [PermissionsRevision, CollectionPermissionGraphRevision, ApplicationPermissionsRevision
+                   AppPermissionGraphRevision]
   *  `before`  -- the graph before the changes
   *  `changes` -- set of changes applied in this revision."
   [model current-revision before changes]

--- a/src/metabase/models/permissions.clj
+++ b/src/metabase/models/permissions.clj
@@ -408,6 +408,14 @@
   [collection-or-id :- MapOrID]
   (str (collection-readwrite-path collection-or-id) "read/"))
 
+(s/defn app-root-collection-permission :- Path
+  "Return path for the app root collection permission `read-or-write`."
+  [read-or-write :- (s/enum :read :write)]
+  (let [app-root-collection {:metabase.models.collection.root/is-root? true, :namespace :apps}]
+    (case read-or-write
+      :write (collection-readwrite-path app-root-collection)
+      :read  (collection-read-path app-root-collection))))
+
 (s/defn table-read-path :- Path
   "Return the permissions path required to fetch the Metadata for a Table."
   ([table-or-id]

--- a/test/metabase/api/activity_test.clj
+++ b/test/metabase/api/activity_test.clj
@@ -135,7 +135,7 @@
                                         :display                "table"
                                         :archived               true
                                         :visualization_settings {}}]
-                  Collection [{coll-id :id} {}]
+                  Collection [{coll-id :id} {:namespace :apps}]
                   App [{app-id :id} {:collection_id coll-id}]
                   Dashboard [page {:name        "rand-name"
                                    :description "rand-name"
@@ -186,7 +186,7 @@
                   Dashboard [dash1 {:name        "rand-name"
                                     :description "rand-name"
                                     :creator_id  (mt/user->id :crowberto)}]
-                  Collection [{coll-id :id} {}]
+                  Collection [{coll-id :id} {:namespace :apps}]
                   App [{app-id :id} {:collection_id coll-id}]
                   Dashboard [dash2 {:name        "other-dashboard"
                                     :description "just another dashboard"

--- a/test/metabase/api/app_test.clj
+++ b/test/metabase/api/app_test.clj
@@ -60,7 +60,7 @@
   (mt/test-drivers (mt/normal-drivers-with-feature :actions/custom)
     (let [app-data {:nav_items [{:options {:item "stuff"}}]
                     :options {:frontend "stuff"}}]
-      (mt/with-temp* [Collection [{collection_id :id}]
+      (mt/with-temp* [Collection [{collection_id :id} {:namespace :apps}]
                       App [{app_id :id} (assoc app-data :collection_id collection_id)]
                       Dashboard [{dashboard_id :id}]]
         (let [expected (assoc app-data :collection_id collection_id :dashboard_id dashboard_id)]
@@ -77,11 +77,11 @@
                                                                                          :options nil})))))))
     (testing "Collection permissions"
       (mt/with-non-admin-groups-no-root-collection-perms
-        (mt/with-temp* [Collection [{collection_id :id}]
+        (mt/with-temp* [Collection [{collection_id :id} {:namespace :apps}]
                         App [{app_id :id} {:collection_id collection_id}]]
           (is (= "You don't have permissions to do that."
                  (mt/user-http-request :rasta :put 403 (str "app/" app_id) {})))))
-      (mt/with-temp* [Collection [{collection_id :id}]
+      (mt/with-temp* [Collection [{collection_id :id} {:namespace :apps}]
                       App [{app_id :id} {:collection_id collection_id}]]
         (is (partial= {:collection_id collection_id}
                       (mt/user-http-request :rasta :put 200 (str "app/" app_id) {})))))))
@@ -90,7 +90,7 @@
   (mt/test-drivers (mt/normal-drivers-with-feature :actions/custom)
     (let [app-data {:nav_items [{:options {:item "stuff"}}]
                     :options {:frontend "stuff"}}]
-      (mt/with-temp* [Collection [{collection_id :id :as collection}]
+      (mt/with-temp* [Collection [{collection_id :id :as collection} {:namespace :apps}]
                       Dashboard [{dashboard_id :id}]
                       App [{app-id :id} (assoc app-data :collection_id collection_id :dashboard_id dashboard_id)]]
         (let [expected (merge app-data {:id app-id
@@ -102,8 +102,8 @@
                           (mt/user-http-request :crowberto :get 200 "app"))))))
       (testing "can only see apps with permission for"
         (mt/with-non-admin-groups-no-root-collection-perms
-          (mt/with-temp* [Collection [collection-1 {:name "Collection 1"}]
-                          Collection [collection-2 {:name "Collection 2"}]
+          (mt/with-temp* [Collection [collection-1 {:name "Collection 1", :namespace :apps}]
+                          Collection [collection-2 {:name "Collection 2", :namespace :apps}]
                           Dashboard [{dashboard_id :id}]
                           App [{app-id :id} (assoc app-data :collection_id (:id collection-1) :dashboard_id dashboard_id)]
                           App [_            (assoc app-data :collection_id (:id collection-2) :dashboard_id dashboard_id)]]
@@ -115,8 +115,8 @@
               (is (partial= [expected]
                             (mt/user-http-request :rasta :get 200 "app")))))))
       (testing "archives"
-        (mt/with-temp* [Collection [collection-1 {:name "Collection 1"}]
-                        Collection [collection-2 {:name "Collection 2" :archived true}]
+        (mt/with-temp* [Collection [collection-1 {:name "Collection 1", :namespace :apps}]
+                        Collection [collection-2 {:name "Collection 2", :namespace :apps, :archived true}]
                         Dashboard [{dashboard_id :id}]
                         App [{app-1-id :id} (assoc app-data :collection_id (:id collection-1) :dashboard_id dashboard_id)]
                         App [{app-2-id :id} (assoc app-data :collection_id (:id collection-2) :dashboard_id dashboard_id)]]
@@ -139,7 +139,7 @@
   (let [app-data {:nav_items [{:options {:item "stuff"}}]
                   :options {:frontend "stuff"}}]
     (mt/with-non-admin-groups-no-root-collection-perms
-      (mt/with-temp* [Collection [{collection_id :id :as collection}]
+      (mt/with-temp* [Collection [{collection_id :id :as collection} {:namespace :apps}]
                       Dashboard [{dashboard_id :id}]
                       App [{app-id :id} (assoc app-data :collection_id collection_id :dashboard_id dashboard_id)]]
         (testing "that we can see app details"
@@ -218,7 +218,7 @@
 
 (deftest scaffold-app-test
   (mt/with-model-cleanup [Card Dashboard]
-    (mt/with-temp* [Collection [{collection-id :id}]
+    (mt/with-temp* [Collection [{collection-id :id} {:namespace :apps}]
                     App [{app-id :id} {:collection_id collection-id}]]
       (testing "Without existing pages"
         (let [app (mt/user-http-request

--- a/test/metabase/api/app_test.clj
+++ b/test/metabase/api/app_test.clj
@@ -36,7 +36,7 @@
                             (graph/graph :apps))
                   "''All Users'' should have the default permission on the app collection"))))
         (testing "Create app in the root"
-          (mt/with-all-users-app-root-permission :read
+          (mt/with-all-users-permission (perms/app-root-collection-permission :read)
             (let [response (mt/user-http-request :crowberto :post 200 "app" {:collection base-params})]
               (is (pos-int? (:id response)))
               (is (pos-int? (:collection_id response)))
@@ -46,7 +46,7 @@
                             (graph/graph :apps))
                   "''All Users'' should have the default permission on the app collection"))))
         (testing "With initial dashboard and nav_items"
-          (mt/with-all-users-app-root-permission :write
+          (mt/with-all-users-permission (perms/app-root-collection-permission :write)
             (mt/with-temp* [Dashboard [{dashboard-id :id}]]
               (let [nav_items [{:options {:click_behavior {}}}]]
                 (is (partial= {:collection (assoc base-params :location "/")
@@ -80,7 +80,7 @@
                       App [{app_id :id} {:collection_id collection_id}]]
         (is (= "You don't have permissions to do that."
                (mt/user-http-request :rasta :put 403 (str "app/" app_id) {}))))
-      (mt/with-all-users-app-root-permission :write
+      (mt/with-all-users-permission (perms/app-root-collection-permission :write)
         (mt/with-temp* [Collection [{collection_id :id} {:namespace :apps}]
                         App [{app_id :id} {:collection_id collection_id}]]
           (is (partial= {:collection_id collection_id}
@@ -120,7 +120,7 @@
                             (mt/user-http-request :rasta :get 200 "app")))))))
       (testing "archives"
         (mt/with-model-cleanup [Permissions]
-          (mt/with-all-users-app-root-permission :write
+          (mt/with-all-users-permission (perms/app-root-collection-permission :write)
             (mt/with-temp* [Collection [collection-1 {:name "Collection 1", :namespace :apps}]
                             Collection [collection-2 {:name "Collection 2", :namespace :apps, :archived true}]
                             Dashboard [{dashboard_id :id}]
@@ -181,7 +181,7 @@
 
 (deftest scaffold-test
   (mt/with-model-cleanup [Card Dashboard Collection Permissions]
-    (mt/with-all-users-app-root-permission :read
+    (mt/with-all-users-permission (perms/app-root-collection-permission :read)
       (testing "Golden path"
         (let [app (mt/user-http-request
                    :crowberto :post 200 "app/scaffold"

--- a/test/metabase/api/app_test.clj
+++ b/test/metabase/api/app_test.clj
@@ -25,27 +25,27 @@
                        :color "#123456"}]
       (mt/test-drivers (mt/normal-drivers-with-feature :actions/custom)
         (testing "parent_id is ignored when creating apps"
-          (mt/with-temporary-setting-values [all-users-app-permission :none]
-            (mt/with-temp* [Collection [{collection-id :id}]]
-             (let [coll-params (assoc base-params :parent_id collection-id)
-                   response (mt/user-http-request :crowberto :post 200 "app" {:collection coll-params})]
-               (is (pos-int? (:id response)))
-               (is (pos-int? (:collection_id response)))
-               (is (partial= (assoc base-params :location "/")
-                             (:collection response)))
-               (is (partial= {:groups {(:id (perms-group/all-users)) {(:collection_id response) :none}}}
-                             (graph/graph))
-                   "''All Users'' should have the default permission on the app collection")))))
+          (mt/with-temp* [Collection [{collection-id :id}]]
+            (let [coll-params (assoc base-params :parent_id collection-id)
+                  response (mt/user-http-request :crowberto :post 200 "app" {:collection coll-params})]
+              (is (pos-int? (:id response)))
+              (is (pos-int? (:collection_id response)))
+              (is (partial= (assoc base-params :location "/")
+                            (:collection response)))
+              (is (partial= {:groups {(:id (perms-group/all-users)) {(:collection_id response) :none}}}
+                            (graph/graph :apps))
+                  "''All Users'' should have the default permission on the app collection"))))
         (testing "Create app in the root"
-          (mt/with-temporary-setting-values [all-users-app-permission :read]
+          (mt/with-temp* [Permissions [_ {:group_id (:id (perms-group/all-users))
+                                          :object "/collection/namespace/apps/root/read/"}]]
             (let [response (mt/user-http-request :crowberto :post 200 "app" {:collection base-params})]
-             (is (pos-int? (:id response)))
-             (is (pos-int? (:collection_id response)))
-             (is (partial= (assoc base-params :location "/")
-                           (:collection response)))
-             (is (partial= {:groups {(:id (perms-group/all-users)) {(:collection_id response) :read}}}
-                           (graph/graph))
-                 "''All Users'' should have the default permission on the app collection"))))
+              (is (pos-int? (:id response)))
+              (is (pos-int? (:collection_id response)))
+              (is (partial= (assoc base-params :location "/")
+                            (:collection response)))
+              (is (partial= {:groups {(:id (perms-group/all-users)) {(:collection_id response) :read}}}
+                            (graph/graph :apps))
+                  "''All Users'' should have the default permission on the app collection"))))
         (testing "With initial dashboard and nav_items"
           (mt/with-temp Dashboard [{dashboard-id :id}]
             (let [nav_items [{:options {:click_behavior {}}}]]
@@ -76,12 +76,13 @@
                           (mt/user-http-request :crowberto :put 200 (str "app/" app_id) {:dashboard_id dashboard_id
                                                                                          :options nil})))))))
     (testing "Collection permissions"
-      (mt/with-non-admin-groups-no-root-collection-perms
-        (mt/with-temp* [Collection [{collection_id :id} {:namespace :apps}]
-                        App [{app_id :id} {:collection_id collection_id}]]
-          (is (= "You don't have permissions to do that."
-                 (mt/user-http-request :rasta :put 403 (str "app/" app_id) {})))))
       (mt/with-temp* [Collection [{collection_id :id} {:namespace :apps}]
+                      App [{app_id :id} {:collection_id collection_id}]]
+        (is (= "You don't have permissions to do that."
+               (mt/user-http-request :rasta :put 403 (str "app/" app_id) {}))))
+      (mt/with-temp* [Permissions [_ {:group_id (:id (perms-group/all-users))
+                                      :object "/collection/namespace/apps/root/"}]
+                      Collection [{collection_id :id} {:namespace :apps}]
                       App [{app_id :id} {:collection_id collection_id}]]
         (is (partial= {:collection_id collection_id}
                       (mt/user-http-request :rasta :put 200 (str "app/" app_id) {})))))))
@@ -96,12 +97,14 @@
         (let [expected (merge app-data {:id app-id
                                         :collection_id collection_id
                                         :dashboard_id dashboard_id
-                                        :collection (assoc collection :can_write true)})]
+                                        :collection (-> collection
+                                                        (assoc :can_write true)
+                                                        (update :namespace name))})]
           (testing "can query non-archived apps"
             (is (partial= [expected]
                           (mt/user-http-request :crowberto :get 200 "app"))))))
       (testing "can only see apps with permission for"
-        (mt/with-non-admin-groups-no-root-collection-perms
+        (mt/with-model-cleanup [Permissions]
           (mt/with-temp* [Collection [collection-1 {:name "Collection 1", :namespace :apps}]
                           Collection [collection-2 {:name "Collection 2", :namespace :apps}]
                           Dashboard [{dashboard_id :id}]
@@ -111,47 +114,57 @@
             (let [expected (merge app-data {:id app-id
                                             :collection_id (:id collection-1)
                                             :dashboard_id dashboard_id
-                                            :collection (assoc collection-1 :can_write false)})]
+                                            :collection (-> collection-1
+                                                            (assoc :can_write false)
+                                                            (update :namespace name))})]
               (is (partial= [expected]
                             (mt/user-http-request :rasta :get 200 "app")))))))
       (testing "archives"
-        (mt/with-temp* [Collection [collection-1 {:name "Collection 1", :namespace :apps}]
-                        Collection [collection-2 {:name "Collection 2", :namespace :apps, :archived true}]
-                        Dashboard [{dashboard_id :id}]
-                        App [{app-1-id :id} (assoc app-data :collection_id (:id collection-1) :dashboard_id dashboard_id)]
-                        App [{app-2-id :id} (assoc app-data :collection_id (:id collection-2) :dashboard_id dashboard_id)]]
-          (testing "listing normal apps"
-            (let [expected (merge app-data {:id app-1-id
-                                            :collection_id (:id collection-1)
-                                            :dashboard_id dashboard_id
-                                            :collection (assoc collection-1 :can_write true)})]
-              (is (partial= [expected]
-                            (mt/user-http-request :rasta :get 200 "app")))))
-          (testing "listing archived"
-            (let [expected (merge app-data {:id app-2-id
-                                            :collection_id (:id collection-2)
-                                            :dashboard_id dashboard_id
-                                            :collection (assoc collection-2 :can_write true)})]
-              (is (partial= [expected]
-                            (mt/user-http-request :rasta :get 200 "app/?archived=true"))))))))))
+        (mt/with-model-cleanup [Permissions]
+          (mt/with-temp* [Collection [collection-1 {:name "Collection 1", :namespace :apps}]
+                          Collection [collection-2 {:name "Collection 2", :namespace :apps, :archived true}]
+                          Dashboard [{dashboard_id :id}]
+                          App [{app-1-id :id} (assoc app-data :collection_id (:id collection-1) :dashboard_id dashboard_id)]
+                          App [{app-2-id :id} (assoc app-data :collection_id (:id collection-2) :dashboard_id dashboard_id)]]
+            (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection-1)
+            (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection-2)
+            (testing "listing normal apps"
+              (let [expected (merge app-data {:id app-1-id
+                                              :collection_id (:id collection-1)
+                                              :dashboard_id dashboard_id
+                                              :collection (-> collection-1
+                                                              (assoc :can_write true)
+                                                              (update :namespace name))})]
+                (is (partial= [expected]
+                              (mt/user-http-request :rasta :get 200 "app")))))
+            (testing "listing archived"
+              (let [expected (merge app-data {:id app-2-id
+                                              :collection_id (:id collection-2)
+                                              :dashboard_id dashboard_id
+                                              :collection (-> collection-2
+                                                              (assoc :can_write true)
+                                                              (update :namespace name))})]
+                (is (partial= [expected]
+                              (mt/user-http-request :rasta :get 200 "app/?archived=true")))))))))))
 
 (deftest fetch-app-test
   (let [app-data {:nav_items [{:options {:item "stuff"}}]
                   :options {:frontend "stuff"}}]
-    (mt/with-non-admin-groups-no-root-collection-perms
-      (mt/with-temp* [Collection [{collection_id :id :as collection} {:namespace :apps}]
-                      Dashboard [{dashboard_id :id}]
-                      App [{app-id :id} (assoc app-data :collection_id collection_id :dashboard_id dashboard_id)]]
-        (testing "that we can see app details"
-          (let [expected (merge app-data {:id app-id
-                                          :collection_id collection_id
-                                          :dashboard_id dashboard_id
-                                          :collection (assoc collection :can_write true)})]
-            (is (partial= expected
-                          (mt/user-http-request :crowberto :get 200 (str "app/" app-id))))))
-        (testing "that app detail properly checks permissions"
-          (is (= "You don't have permissions to do that."
-                 (mt/user-http-request :rasta :get 403 (str "app/" app-id)))))))))
+    (mt/with-temp* [Collection [{collection_id :id :as collection} {:namespace :apps}]
+                    Dashboard [{dashboard_id :id}]
+                    App [{app-id :id} (assoc app-data :collection_id collection_id :dashboard_id dashboard_id)]]
+      (testing "that we can see app details"
+        (let [expected (merge app-data {:id app-id
+                                        :collection_id collection_id
+                                        :dashboard_id dashboard_id
+                                        :collection (-> collection
+                                                        (assoc :can_write true)
+                                                        (update :namespace name))})]
+          (is (partial= expected
+                        (mt/user-http-request :crowberto :get 200 (str "app/" app-id))))))
+      (testing "that app detail properly checks permissions"
+        (is (= "You don't have permissions to do that."
+               (mt/user-http-request :rasta :get 403 (str "app/" app-id))))))))
 
 (defn- normalized-models [models]
   (->> models (sort-by :id) json/generate-string))
@@ -171,7 +184,8 @@
 (deftest scaffold-test
   (mt/with-model-cleanup [Card Dashboard Collection Permissions]
     (testing "Golden path"
-      (mt/with-temporary-setting-values [all-users-app-permission :read]
+      (mt/with-temp* [Permissions [_ {:group_id (:id (perms-group/all-users))
+                                      :object "/collection/namespace/apps/root/read/"}]]
         (let [app (mt/user-http-request
                    :crowberto :post 200 "app/scaffold"
                    {:table-ids [(data/id :venues)]
@@ -202,7 +216,7 @@
                                                           [:= :dataset true]]}]
                                          :order-by [:id]}))))
           (is (partial= {:groups {(:id (perms-group/all-users)) {(:collection_id app) :read}}}
-                        (graph/graph))
+                        (graph/graph :apps))
               "''All Users'' should have the default permission on the app collection")
           (is (= (scaffolded-models app)
                  (api-models app))))))
@@ -313,11 +327,11 @@
                   response2 (mt/user-http-request :crowberto :post 200 "app" {:collection base-params})]
               (is (partial= {:groups {(:id (perms-group/all-users)) {(:collection_id response1) :none
                                                                      (:collection_id response2) :none}}}
-                            (graph/graph)))
+                            (graph/graph :apps)))
               (mt/user-http-request :crowberto :put 200 "app/global-graph"
                                     (assoc-in (mt/user-http-request :crowberto :get 200 "app/global-graph")
                                               [:groups (:id (perms-group/all-users))]
                                               :write))
               (is (partial= {:groups {(:id (perms-group/all-users)) {(:collection_id response1) :write
                                                                      (:collection_id response2) :write}}}
-                            (graph/graph))))))))))
+                            (graph/graph :apps))))))))))

--- a/test/metabase/api/app_test.clj
+++ b/test/metabase/api/app_test.clj
@@ -47,7 +47,9 @@
                             (graph/graph :apps))
                   "''All Users'' should have the default permission on the app collection"))))
         (testing "With initial dashboard and nav_items"
-          (mt/with-temp Dashboard [{dashboard-id :id}]
+          (mt/with-temp* [Permissions [_ {:group_id (:id (perms-group/all-users))
+                                          :object "/collection/namespace/apps/root/"}]
+                          Dashboard [{dashboard-id :id}]]
             (let [nav_items [{:options {:click_behavior {}}}]]
               (is (partial= {:collection (assoc base-params :location "/")
                              :dashboard_id dashboard-id
@@ -121,13 +123,13 @@
                             (mt/user-http-request :rasta :get 200 "app")))))))
       (testing "archives"
         (mt/with-model-cleanup [Permissions]
-          (mt/with-temp* [Collection [collection-1 {:name "Collection 1", :namespace :apps}]
+          (mt/with-temp* [Permissions [_ {:group_id (:id (perms-group/all-users))
+                                          :object "/collection/namespace/apps/root/"}]
+                          Collection [collection-1 {:name "Collection 1", :namespace :apps}]
                           Collection [collection-2 {:name "Collection 2", :namespace :apps, :archived true}]
                           Dashboard [{dashboard_id :id}]
                           App [{app-1-id :id} (assoc app-data :collection_id (:id collection-1) :dashboard_id dashboard_id)]
                           App [{app-2-id :id} (assoc app-data :collection_id (:id collection-2) :dashboard_id dashboard_id)]]
-            (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection-1)
-            (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection-2)
             (testing "listing normal apps"
               (let [expected (merge app-data {:id app-1-id
                                               :collection_id (:id collection-1)
@@ -331,7 +333,7 @@
               (mt/user-http-request :crowberto :put 200 "app/global-graph"
                                     (assoc-in (mt/user-http-request :crowberto :get 200 "app/global-graph")
                                               [:groups (:id (perms-group/all-users))]
-                                              :write))
+                                              {:root :write}))
               (is (partial= {:groups {(:id (perms-group/all-users)) {(:collection_id response1) :write
                                                                      (:collection_id response2) :write}}}
                             (graph/graph :apps))))))))))

--- a/test/metabase/api/bookmark_test.clj
+++ b/test/metabase/api/bookmark_test.clj
@@ -9,13 +9,18 @@
             [metabase.models.collection :refer [Collection]]
             [metabase.models.dashboard :refer [Dashboard]]
             [metabase.models.interface :as mi]
+            [metabase.models.permissions :refer [Permissions]]
+            [metabase.models.permissions-group :as perms-group]
             [metabase.test :as mt]
             [metabase.util :as u]
             [toucan.db :as db]))
 
 (deftest bookmarks-test
+  (mt/initialize-if-needed! :db)
   (testing "POST /api/bookmark/:model/:model-id"
-    (mt/with-temp* [Collection [{coll-id :id :as collection} {:name "Test Collection", :namespace :apps}]
+    (mt/with-temp* [Permissions [_ {:group_id (:id (perms-group/all-users))
+                                    :object "/collection/namespace/apps/root/"}]
+                    Collection [{coll-id :id :as collection} {:name "Test Collection", :namespace :apps}]
                     Card       [card {:name "Test Card", :display "area", :collection_id coll-id}]
                     Dashboard  [dashboard {:name "Test Dashboard", :is_app_page true, :collection_id coll-id}]
                     App        [app {:collection_id coll-id, :dashboard_id (:id dashboard)}]]

--- a/test/metabase/api/bookmark_test.clj
+++ b/test/metabase/api/bookmark_test.clj
@@ -15,7 +15,7 @@
 
 (deftest bookmarks-test
   (testing "POST /api/bookmark/:model/:model-id"
-    (mt/with-temp* [Collection [{coll-id :id :as collection} {:name "Test Collection"}]
+    (mt/with-temp* [Collection [{coll-id :id :as collection} {:name "Test Collection", :namespace :apps}]
                     Card       [card {:name "Test Card", :display "area", :collection_id coll-id}]
                     Dashboard  [dashboard {:name "Test Dashboard", :is_app_page true, :collection_id coll-id}]
                     App        [app {:collection_id coll-id, :dashboard_id (:id dashboard)}]]

--- a/test/metabase/api/bookmark_test.clj
+++ b/test/metabase/api/bookmark_test.clj
@@ -9,8 +9,6 @@
             [metabase.models.collection :refer [Collection]]
             [metabase.models.dashboard :refer [Dashboard]]
             [metabase.models.interface :as mi]
-            [metabase.models.permissions :refer [Permissions]]
-            [metabase.models.permissions-group :as perms-group]
             [metabase.test :as mt]
             [metabase.util :as u]
             [toucan.db :as db]))
@@ -18,53 +16,52 @@
 (deftest bookmarks-test
   (mt/initialize-if-needed! :db)
   (testing "POST /api/bookmark/:model/:model-id"
-    (mt/with-temp* [Permissions [_ {:group_id (:id (perms-group/all-users))
-                                    :object "/collection/namespace/apps/root/"}]
-                    Collection [{coll-id :id :as collection} {:name "Test Collection", :namespace :apps}]
-                    Card       [card {:name "Test Card", :display "area", :collection_id coll-id}]
-                    Dashboard  [dashboard {:name "Test Dashboard", :is_app_page true, :collection_id coll-id}]
-                    App        [app {:collection_id coll-id, :dashboard_id (:id dashboard)}]]
-      (testing "check that we can bookmark a Collection"
-        (is (= (u/the-id collection)
-               (->> (mt/user-http-request :rasta :post 200 (str "bookmark/collection/" (u/the-id collection)))
-                    :collection_id))))
-      (testing "check that we can bookmark a Card"
-        (is (= (u/the-id card)
-               (->> (mt/user-http-request :rasta :post 200 (str "bookmark/card/" (u/the-id card)))
-                    :card_id))))
-      (let [card-result (->> (mt/user-http-request :rasta :get 200 "bookmark")
-                             (filter #(= (:type %) "card"))
-                             first)]
-        (testing "check a card bookmark has `:display` key"
-          (is (contains? card-result :display)))
-        (testing "check a card bookmark has `:dataset` key"
-          (is (contains? card-result :dataset))))
-      (testing "check that we can bookmark a Dashboard"
-        (is (= (u/the-id dashboard)
-               (->> (mt/user-http-request :rasta :post 200 (str "bookmark/dashboard/" (u/the-id dashboard)))
-                    :dashboard_id))))
-      (testing "check that we can retreive the user's bookmarks"
-        (let [result (mt/user-http-request :rasta :get 200 "bookmark")]
-          (is (= #{"card" "collection" "dashboard"}
-                 (into #{} (map :type) result)))
-          (testing "that app_id is hydrated on app collections"
-            (is (partial= [{:item_id (:id collection), :name "Test Collection", :app_id (:id app)}]
-                          (filter #(= (:type %) "collection") result))))
-          (testing "that is_app_page is returned for dashboards"
-            (is (partial= [{:item_id (:id dashboard), :name "Test Dashboard", :is_app_page true, :app_id (:id app)}]
-                          (filter #(= (:type %) "dashboard") result))))))
-      (testing "check that we can delete bookmarks"
-        (mt/user-http-request :rasta :delete 204 (str "bookmark/card/" (u/the-id card)))
-        (is (= #{"collection" "dashboard"}
-               (->> (mt/user-http-request :rasta :get 200 "bookmark")
-                    (map :type)
-                    set)))
-        (mt/user-http-request :rasta :delete 204 (str "bookmark/collection/" (u/the-id collection)))
-        (mt/user-http-request :rasta :delete 204 (str "bookmark/dashboard/" (u/the-id dashboard)))
-        (is (= #{}
-               (->> (mt/user-http-request :rasta :get 200 "bookmark")
-                    (map :type)
-                    set)))))))
+    (mt/with-all-users-app-root-permission :write
+      (mt/with-temp* [Collection [{coll-id :id :as collection} {:name "Test Collection", :namespace :apps}]
+                      Card       [card {:name "Test Card", :display "area", :collection_id coll-id}]
+                      Dashboard  [dashboard {:name "Test Dashboard", :is_app_page true, :collection_id coll-id}]
+                      App        [app {:collection_id coll-id, :dashboard_id (:id dashboard)}]]
+        (testing "check that we can bookmark a Collection"
+          (is (= (u/the-id collection)
+                 (->> (mt/user-http-request :rasta :post 200 (str "bookmark/collection/" (u/the-id collection)))
+                      :collection_id))))
+        (testing "check that we can bookmark a Card"
+          (is (= (u/the-id card)
+                 (->> (mt/user-http-request :rasta :post 200 (str "bookmark/card/" (u/the-id card)))
+                      :card_id))))
+        (let [card-result (->> (mt/user-http-request :rasta :get 200 "bookmark")
+                               (filter #(= (:type %) "card"))
+                               first)]
+          (testing "check a card bookmark has `:display` key"
+            (is (contains? card-result :display)))
+          (testing "check a card bookmark has `:dataset` key"
+            (is (contains? card-result :dataset))))
+        (testing "check that we can bookmark a Dashboard"
+          (is (= (u/the-id dashboard)
+                 (->> (mt/user-http-request :rasta :post 200 (str "bookmark/dashboard/" (u/the-id dashboard)))
+                      :dashboard_id))))
+        (testing "check that we can retreive the user's bookmarks"
+          (let [result (mt/user-http-request :rasta :get 200 "bookmark")]
+            (is (= #{"card" "collection" "dashboard"}
+                   (into #{} (map :type) result)))
+            (testing "that app_id is hydrated on app collections"
+              (is (partial= [{:item_id (:id collection), :name "Test Collection", :app_id (:id app)}]
+                            (filter #(= (:type %) "collection") result))))
+            (testing "that is_app_page is returned for dashboards"
+              (is (partial= [{:item_id (:id dashboard), :name "Test Dashboard", :is_app_page true, :app_id (:id app)}]
+                            (filter #(= (:type %) "dashboard") result))))))
+        (testing "check that we can delete bookmarks"
+          (mt/user-http-request :rasta :delete 204 (str "bookmark/card/" (u/the-id card)))
+          (is (= #{"collection" "dashboard"}
+                 (->> (mt/user-http-request :rasta :get 200 "bookmark")
+                      (map :type)
+                      set)))
+          (mt/user-http-request :rasta :delete 204 (str "bookmark/collection/" (u/the-id collection)))
+          (mt/user-http-request :rasta :delete 204 (str "bookmark/dashboard/" (u/the-id dashboard)))
+          (is (= #{}
+                 (->> (mt/user-http-request :rasta :get 200 "bookmark")
+                      (map :type)
+                      set))))))))
 
 (defn bookmark-models [user-id & models]
   (doseq [model models]

--- a/test/metabase/api/bookmark_test.clj
+++ b/test/metabase/api/bookmark_test.clj
@@ -9,6 +9,7 @@
             [metabase.models.collection :refer [Collection]]
             [metabase.models.dashboard :refer [Dashboard]]
             [metabase.models.interface :as mi]
+            [metabase.models.permissions :as perms]
             [metabase.test :as mt]
             [metabase.util :as u]
             [toucan.db :as db]))
@@ -16,7 +17,7 @@
 (deftest bookmarks-test
   (mt/initialize-if-needed! :db)
   (testing "POST /api/bookmark/:model/:model-id"
-    (mt/with-all-users-app-root-permission :write
+    (mt/with-all-users-permission (perms/app-root-collection-permission :write)
       (mt/with-temp* [Collection [{coll-id :id :as collection} {:name "Test Collection", :namespace :apps}]
                       Card       [card {:name "Test Card", :display "area", :collection_id coll-id}]
                       Dashboard  [dashboard {:name "Test Dashboard", :is_app_page true, :collection_id coll-id}]

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -5,7 +5,7 @@
             [honeysql.core :as hsql]
             [metabase.api.collection :as api.collection]
             [metabase.models :refer [App Card Collection Dashboard DashboardCard ModerationReview NativeQuerySnippet
-                                     Permissions PermissionsGroup PermissionsGroupMembership
+                                     PermissionsGroup PermissionsGroupMembership
                                      Pulse PulseCard PulseChannel
                                      PulseChannelRecipient Revision Timeline TimelineEvent User]]
             [metabase.models.collection :as collection]
@@ -346,13 +346,12 @@
                 (mt/user-http-request :rasta :get 200 (str "collection/" (u/the-id collection))))))))
 
     (testing "check that we can see app collection details"
-      (mt/with-temp* [Permissions [_ {:group_id (:id (perms-group/all-users))
-                                      :object "/collection/namespace/apps/root/read/"}]
-                      Collection [collection {:name "Coin Collection", :namespace :apps}]
-                      App [{app-id :id} {:collection_id (:id collection)}]]
-        (is (= ["Coin Collection" app-id]
-               ((juxt :name :app_id)
-                (mt/user-http-request :rasta :get 200 (str "collection/" (u/the-id collection))))))))
+      (mt/with-all-users-app-root-permission :read
+        (mt/with-temp* [Collection [collection {:name "Coin Collection", :namespace :apps}]
+                        App [{app-id :id} {:collection_id (:id collection)}]]
+          (is (= ["Coin Collection" app-id]
+                 ((juxt :name :app_id)
+                  (mt/user-http-request :rasta :get 200 (str "collection/" (u/the-id collection)))))))))
 
     (testing "check that collections detail properly checks permissions"
       (mt/with-non-admin-groups-no-root-collection-perms

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -346,7 +346,7 @@
                 (mt/user-http-request :rasta :get 200 (str "collection/" (u/the-id collection))))))))
 
     (testing "check that we can see app collection details"
-      (mt/with-all-users-app-root-permission :read
+      (mt/with-all-users-permission (perms/app-root-collection-permission :read)
         (mt/with-temp* [Collection [collection {:name "Coin Collection", :namespace :apps}]
                         App [{app-id :id} {:collection_id (:id collection)}]]
           (is (= ["Coin Collection" app-id]

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -139,11 +139,11 @@
                       App [{app2-id :id} {:collection_id coll2-id}]]
         (letfn [(remove-other-collections [collections]
                   (filter (fn [{collection-name :name}]
-                            (or (#{"Our analytics" "Archived Collection" "Regular Collection"} collection-name)
+                            (or (#{"All apps" "Archived Collection" "Regular Collection"} collection-name)
                                 (str/includes? collection-name "Personal Collection")))
                           collections))]
           (testing "check that we don't see collections if they're archived"
-            (is (= [["Our analytics" nil]
+            (is (= [["All apps" nil]
                     ["Regular Collection" app2-id]]
                    (->> (mt/user-http-request :crowberto :get 200 "collection?namespace=apps")
                         remove-other-collections

--- a/test/metabase/models/card_test.clj
+++ b/test/metabase/models/card_test.clj
@@ -117,7 +117,7 @@
         (try
           (is (thrown-with-msg?
                clojure.lang.ExceptionInfo
-               #"A Card can only go in Collections in the \"default\" namespace"
+               #"A Card can only go in Collections in the \"default\" or :apps namespace"
                (db/insert! Card (assoc (tt/with-temp-defaults Card) :collection_id collection-id, :name card-name))))
           (finally
             (db/delete! Card :name card-name)))))
@@ -126,7 +126,7 @@
       (mt/with-temp Card [{card-id :id}]
         (is (thrown-with-msg?
              clojure.lang.ExceptionInfo
-             #"A Card can only go in Collections in the \"default\" namespace"
+             #"A Card can only go in Collections in the \"default\" or :apps namespace"
              (db/update! Card card-id {:collection_id collection-id})))))))
 
 (deftest normalize-result-metadata-test

--- a/test/metabase/models/collection/graph_test.clj
+++ b/test/metabase/models/collection/graph_test.clj
@@ -437,7 +437,7 @@
 
 (deftest modify-perms-for-app-collections-test
   (testing "that we cannot modify perms for app collections"
-    (mt/with-temp* [Collection [{coll-id :id}]
+    (mt/with-temp* [Collection [{coll-id :id} {:namespace :apps}]
                     App [_app {:collection_id coll-id}]]
       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Cannot set app permissions using this endpoint"
                             (graph/update-graph! (assoc-in (graph/graph)

--- a/test/metabase/models/collection/graph_test.clj
+++ b/test/metabase/models/collection/graph_test.clj
@@ -440,6 +440,7 @@
     (mt/with-temp* [Collection [{coll-id :id} {:namespace :apps}]
                     App [_app {:collection_id coll-id}]]
       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Cannot set app permissions using this endpoint"
-                            (graph/update-graph! (assoc-in (graph/graph)
+                            (graph/update-graph! :apps
+                                                 (assoc-in (graph/graph :apps)
                                                            [:groups (u/the-id (perms-group/all-users)) coll-id]
                                                            :read)))))))

--- a/test/metabase/models/collection_test.clj
+++ b/test/metabase/models/collection_test.clj
@@ -1468,7 +1468,7 @@
       (mt/with-temp Collection [{collection-id :id} {:namespace "x"}]
         (is (thrown-with-msg?
              clojure.lang.ExceptionInfo
-             #"A Card can only go in Collections in the \"default\" namespace"
+             #"A Card can only go in Collections in the \"default\" or :apps namespace"
              (collection/check-collection-namespace Card collection-id)))))
 
     (testing "Should throw exception if Collection does not exist"

--- a/test/metabase/models/dashboard_test.clj
+++ b/test/metabase/models/dashboard_test.clj
@@ -270,7 +270,7 @@
         (try
           (is (thrown-with-msg?
                clojure.lang.ExceptionInfo
-               #"A Dashboard can only go in Collections in the \"default\" namespace"
+               #"A Dashboard can only go in Collections in the \"default\" or :apps namespace"
                (db/insert! Dashboard (assoc (tt/with-temp-defaults Dashboard) :collection_id collection-id, :name dashboard-name))))
           (finally
             (db/delete! Dashboard :name dashboard-name)))))
@@ -279,7 +279,7 @@
       (mt/with-temp Dashboard [{card-id :id}]
         (is (thrown-with-msg?
              clojure.lang.ExceptionInfo
-             #"A Dashboard can only go in Collections in the \"default\" namespace"
+             #"A Dashboard can only go in Collections in the \"default\" or :apps namespace"
              (db/update! Dashboard card-id {:collection_id collection-id})))))))
 
 (deftest validate-parameters-test

--- a/test/metabase/models/pulse_test.clj
+++ b/test/metabase/models/pulse_test.clj
@@ -400,7 +400,7 @@
         (try
           (is (thrown-with-msg?
                clojure.lang.ExceptionInfo
-               #"A Pulse can only go in Collections in the \"default\" namespace"
+               #"A Pulse can only go in Collections in the \"default\" or :apps namespace"
                (db/insert! Pulse (assoc (tt/with-temp-defaults Pulse) :collection_id collection-id, :name pulse-name))))
           (finally
             (db/delete! Pulse :name pulse-name)))))
@@ -409,7 +409,7 @@
       (mt/with-temp Pulse [{card-id :id}]
         (is (thrown-with-msg?
              clojure.lang.ExceptionInfo
-             #"A Pulse can only go in Collections in the \"default\" namespace"
+             #"A Pulse can only go in Collections in the \"default\" or :apps namespace"
              (db/update! Pulse card-id {:collection_id collection-id})))))))
 
 

--- a/test/metabase/test.clj
+++ b/test/metabase/test.clj
@@ -202,6 +202,7 @@
   secret-value-equals?
   select-keys-sequentially
   throw-if-called
+  with-all-users-app-root-permission
   with-column-remappings
   with-discarded-collections-perms-changes
   with-env-keys-renamed-by

--- a/test/metabase/test.clj
+++ b/test/metabase/test.clj
@@ -202,7 +202,7 @@
   secret-value-equals?
   select-keys-sequentially
   throw-if-called
-  with-all-users-app-root-permission
+  with-all-users-permission
   with-column-remappings
   with-discarded-collections-perms-changes
   with-env-keys-renamed-by

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -806,24 +806,24 @@
            :namespace (name ~collection-namespace))
     (fn [] ~@body)))
 
-(defn do-with-all-users-app-root-permission
+(defn do-with-all-users-permission
   "Call `f` without arguments in a context where the ''All Users'' group
-  is granted the global app permission `permission`. `permission` can be one of
-  :read or :write."
-  [permission f]
-  (when-not (#{:read :write} permission)
-    (throw (ex-info (str "Unexpected app permission " permission)
-                    {:permission permission})))
+  is granted the permission specified by `permission-path`.
+
+  For most use cases see the macro [[with-all-users-permission]]."
+  [permission-path f]
   (tt/with-temp Permissions [_ {:group_id (:id (perms-group/all-users))
-                                :object (cond-> "/collection/namespace/apps/root/"
-                                          (= permission :read) (str "read/"))}]
+                                :object permission-path}]
     (f)))
 
-(defmacro with-all-users-app-root-permission
-  "Run `body` with the ''All Users'' group being granted the global app
-  permission `permission`. `permission` can be one of :read or :write."
-  [permission & body]
-  `(do-with-all-users-app-root-permission ~permission (fn [] ~@body)))
+(defmacro with-all-users-permission
+  "Run `body` with the ''All Users'' group being granted the permission
+  specified by `permission-path`.
+
+  (mt/with-all-users-permission (perms/app-root-collection-permission :read)
+    ...)"
+  [permission-path & body]
+  `(do-with-all-users-permission ~permission-path (fn [] ~@body)))
 
 (defn doall-recursive
   "Like `doall`, but recursively calls doall on map values and nested sequences, giving you a fully non-lazy object.

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -807,7 +807,7 @@
     (fn [] ~@body)))
 
 (defn do-with-all-users-app-root-permission
-  "Call `f without arguments in a context where the ''All Users'' group
+  "Call `f` without arguments in a context where the ''All Users'' group
   is granted the global app permission `permission`. `permission` can be one of
   :read or :write."
   [permission f]


### PR DESCRIPTION
This PR is a rewrite of the app permission system (originally implemented in #25679 and #25764) to use the `apps` namespace for app collections.

*Although the PR is against `master`, It is still to be decided where this PR should be merged.*

The main idea, using the permissions on the collections to represent permissions on the apps, is unchanged. Also unchanged is that the API for getting and updating app permissions hides the fact that permissions are saved on collections, that is, the granular permission graph uses app IDs instead of collection IDs.

This gives us better control over what can be put into an app (collection). This implementation allows everything by default.

