### PR TITLE
[E2E] Fix cache ttl test (flake)

### DIFF
--- a/frontend/test/metabase/scenarios/admin/databases/edit.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/edit.cy.spec.js
@@ -95,17 +95,15 @@ describe("scenarios > admin > databases > edit", () => {
         cy.wait("@databaseUpdate").then(({ request, response }) => {
           expect(request.body.cache_ttl).to.equal(32);
           expect(response.body.cache_ttl).to.equal(32);
+        });
 
-          cy.visit("/admin/databases");
-          cy.findByTextEnsureVisible("Sample Database").click();
+        cy.findByTextEnsureVisible("Custom").click();
+        popover().findByText("Use instance default (TTL)").click();
 
-          cy.findByTextEnsureVisible("Custom").click();
-          popover().findByText("Use instance default (TTL)").click();
-
-          cy.button("Save changes").click();
-          cy.wait("@databaseUpdate").then(({ request }) => {
-            expect(request.body.cache_ttl).to.equal(null);
-          });
+        // We need to wait until "Success" button state is gone first
+        cy.button("Save changes", { timeout: 10000 }).click();
+        cy.wait("@databaseUpdate").then(({ request }) => {
+          expect(request.body.cache_ttl).to.equal(null);
         });
       });
     });


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Fixes the flake in cache ttl E2E tests while speeding the test up

The previous "technique" for waiting until the "Success" button is removed from the DOM and is replaced by "Save changes" again was to visit databases page, and then to click on the "Sample Database". Usually, switching pages is quite expensive in Cypress. It was also completely unnecessary in this case.

> **Note**
> This test is the perfect candidate for a pure API test.
