### PR TITLE
Disable data apps

### DIFF
--- a/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.jsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.jsx
@@ -8,10 +8,6 @@ import ActionButton from "metabase/components/ActionButton";
 import ModalWithTrigger from "metabase/components/ModalWithTrigger";
 import ConfirmContent from "metabase/components/ConfirmContent";
 import Button from "metabase/core/components/Button";
-import {
-  isDatabaseWritebackEnabled,
-  isWritebackSupported,
-} from "metabase/writeback/utils";
 
 import ModelCachingControl from "./ModelCachingControl";
 import { SidebarRoot } from "./Sidebar.styled";
@@ -32,7 +28,6 @@ const propTypes = {
 const DatabaseEditAppSidebar = ({
   database,
   deleteDatabase,
-  updateDatabase,
   syncDatabaseSchema,
   dismissSyncSpinner,
   rescanDatabaseFields,
@@ -42,14 +37,7 @@ const DatabaseEditAppSidebar = ({
   isModelPersistenceEnabled,
 }) => {
   const discardSavedFieldValuesModal = useRef();
-  const enableWritebackModal = useRef();
   const deleteDatabaseModal = useRef();
-
-  const hasWriteback = isDatabaseWritebackEnabled(database);
-  const showWriteback =
-    isWritebackEnabled &&
-    typeof database.id === "number" &&
-    isWritebackSupported(database);
 
   return (
     <SidebarRoot>
@@ -134,38 +122,6 @@ const DatabaseEditAppSidebar = ({
                     database={database}
                     onClose={() => deleteDatabaseModal.current.toggle()}
                     onDelete={() => deleteDatabase(database.id, true)}
-                  />
-                </ModalWithTrigger>
-              </li>
-            )}
-
-            {showWriteback && (
-              <li className="mt2">
-                <ModalWithTrigger
-                  ref={enableWritebackModal}
-                  triggerClasses="Button Button--danger Button--discardSavedFieldValues"
-                  triggerElement={
-                    hasWriteback ? t`Disable actions` : t`Enable actions`
-                  }
-                >
-                  <ConfirmContent
-                    title={
-                      hasWriteback
-                        ? t`Disable Actions`
-                        : t`[EXPERIMENTAL] Enable Actions`
-                    }
-                    message={
-                      hasWriteback
-                        ? undefined
-                        : t`Are you sure you want to enable EXPERIMENTAL Actions? This will enable Metabase features that write to your database`
-                    }
-                    onClose={() => enableWritebackModal.current.toggle()}
-                    onAction={() =>
-                      updateDatabase({
-                        id: database.id,
-                        settings: { "database-enable-actions": !hasWriteback },
-                      })
-                    }
                   />
                 </ModalWithTrigger>
               </li>

--- a/frontend/src/metabase/components/NewItemMenu/NewItemMenu.tsx
+++ b/frontend/src/metabase/components/NewItemMenu/NewItemMenu.tsx
@@ -8,11 +8,8 @@ import CreateDashboardModal from "metabase/components/CreateDashboardModal";
 import * as Urls from "metabase/lib/urls";
 
 import CollectionCreate from "metabase/collections/containers/CollectionCreate";
-import CreateDataAppModal from "metabase/writeback/containers/CreateDataAppModal";
 
 import type { Collection, CollectionId } from "metabase-types/api";
-
-import { WideModal } from "./NewItemMenu.styled";
 
 type ModalType = "new-app" | "new-dashboard" | "new-collection";
 
@@ -84,15 +81,6 @@ const NewItemMenu = ({
         event: `${analyticsContext};New SQL Query Click;`,
         onClose: onCloseNavbar,
       });
-
-      // we should probably get more granular with who sees this
-      items.push({
-        title: t`Action`,
-        icon: "play",
-        link: "/action/create",
-        event: `${analyticsContext};New Action Click;`,
-        onClose: onCloseNavbar,
-      });
     }
 
     items.push(
@@ -107,12 +95,6 @@ const NewItemMenu = ({
         icon: "folder",
         action: () => setModal("new-collection"),
         event: `${analyticsContext};New Collection Click;`,
-      },
-      {
-        title: t`App`,
-        icon: "star",
-        action: () => setModal("new-app"),
-        event: `${analyticsContext};New App Click;`,
       },
     );
 
@@ -161,10 +143,6 @@ const NewItemMenu = ({
                 onClose={handleModalClose}
               />
             </Modal>
-          ) : modal === "new-app" ? (
-            <WideModal onClose={handleModalClose}>
-              <CreateDataAppModal onClose={handleModalClose} />
-            </WideModal>
           ) : null}
         </>
       )}

--- a/frontend/src/metabase/dashboard/actions/save.js
+++ b/frontend/src/metabase/dashboard/actions/save.js
@@ -158,12 +158,8 @@ export const saveDashboardAndCards = createThunkAction(
 
       await dispatch(Dashboards.actions.update(dashboard));
 
-      if (dashboard.is_app_page) {
-        dispatch(fetchDashboard(dashboard.id, window.location.search, true));
-      } else {
-        // make sure that we've fully cleared out any dirty state from editing (this is overkill, but simple)
-        dispatch(fetchDashboard(dashboard.id, null)); // disable using query parameters when saving
-      }
+      // make sure that we've fully cleared out any dirty state from editing (this is overkill, but simple)
+      dispatch(fetchDashboard(dashboard.id, null)); // disable using query parameters when saving
     };
   },
 );

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkOptions.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkOptions.tsx
@@ -32,7 +32,6 @@ function LinkTypeOptions({
   const linkTypeOptions: LinkTypeOption[] = [
     { type: "dashboard", icon: "dashboard", name: t`Dashboard` },
     { type: "question", icon: "bar", name: t`Saved question` },
-    { type: "page", icon: "document", name: t`Page` },
     { type: "url", icon: "link", name: t`URL` },
   ];
   return (

--- a/frontend/src/metabase/dashboard/components/DashCard.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard.jsx
@@ -234,10 +234,10 @@ export default class DashCard extends Component {
           headerIcon={headerIcon}
           errorIcon={errorIcon}
           isSlow={isSlow}
-          isDataApp={dashboard.is_app_page}
+          isDataApp={false}
           expectedDuration={expectedDuration}
           rawSeries={series}
-          showTitle={!dashboard.is_app_page}
+          showTitle
           isFullscreen={isFullscreen}
           isNightMode={isNightMode}
           isDashboard

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
@@ -263,7 +263,7 @@ class Dashboard extends Component {
               <HeaderContainer
                 isFullscreen={isFullscreen}
                 isNightMode={shouldRenderAsNightMode}
-                isDataApp={dashboard.is_app_page}
+                isDataApp={false}
               >
                 <DashboardHeader
                   {...this.props}
@@ -313,7 +313,7 @@ class Dashboard extends Component {
                     />
                   ) : (
                     <DashboardEmptyState
-                      isDataApp={dashboard.is_app_page}
+                      isDataApp={false}
                       isNightMode={shouldRenderAsNightMode}
                     />
                   )}

--- a/frontend/src/metabase/dashboard/components/DashboardHeader.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader.tsx
@@ -113,7 +113,7 @@ const DashboardHeader = ({
     return () => clearTimeout(timerId);
   });
 
-  const isDataApp = dashboard.is_app_page;
+  const isDataApp = false;
 
   return (
     <div>

--- a/frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx
@@ -21,9 +21,7 @@ const mapDispatchToProps = {
 class DashboardMoveModalInner extends React.Component {
   render() {
     const { dashboard, onClose, setDashboardCollection } = this.props;
-    const title = dashboard.is_app_page
-      ? t`Move page to…`
-      : t`Move dashboard to…`;
+    const title = t`Move dashboard to…`;
     return (
       <CollectionMoveModal
         title={title}

--- a/frontend/src/metabase/dashboard/containers/DashboardHeader.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardHeader.jsx
@@ -35,7 +35,7 @@ import {
 } from "./DashboardHeader.styled";
 
 const mapStateToProps = (state, props) => {
-  const isDataApp = props.dashboard.is_app_page;
+  const isDataApp = false;
   const isShowingDashboardInfoSidebar =
     !isDataApp && getIsShowDashboardInfoSidebar(state);
   return {
@@ -188,7 +188,6 @@ class DashboardHeader extends Component {
       dashboard,
       parametersWidget,
       isBookmarked,
-      isAdmin,
       isEditing,
       isFullscreen,
       isEditable,
@@ -203,7 +202,7 @@ class DashboardHeader extends Component {
       closeSidebar,
     } = this.props;
 
-    const isDataAppPage = dashboard.is_app_page;
+    const isDataAppPage = false;
     const canEdit = dashboard.can_write && isEditable && !!dashboard;
 
     const buttons = [];
@@ -282,32 +281,6 @@ class DashboardHeader extends Component {
         </span>,
       );
 
-      if (isAdmin && dashboard.is_app_page) {
-        buttons.push(
-          <>
-            <DashboardHeaderActionDivider />
-            <Tooltip key="add-action-form" tooltip={t`Add action form`}>
-              <DashboardHeaderButton
-                isActive={activeSidebarName === SIDEBAR_NAME.addActionForm}
-                onClick={() => toggleSidebar(SIDEBAR_NAME.addActionForm)}
-                data-metabase-event="Dashboard;Add Card Sidebar"
-              >
-                <Icon name="list" size={18} />
-              </DashboardHeaderButton>
-            </Tooltip>
-            <Tooltip key="add-action-button" tooltip={t`Add action button`}>
-              <DashboardHeaderButton
-                isActive={activeSidebarName === SIDEBAR_NAME.addActionButton}
-                onClick={() => toggleSidebar(SIDEBAR_NAME.addActionButton)}
-                data-metabase-event="Dashboard;Add Card Sidebar"
-              >
-                <Icon name="click" size={18} />
-              </DashboardHeaderButton>
-            </Tooltip>
-          </>,
-        );
-      }
-
       extraButtons.push({
         title: t`Revision history`,
         icon: "history",
@@ -318,10 +291,7 @@ class DashboardHeader extends Component {
 
     if (!isFullscreen && !isEditing && canEdit) {
       buttons.push(
-        <Tooltip
-          key="edit-dashboard"
-          tooltip={dashboard.is_app_page ? t`Edit page` : t`Edit dashboard`}
-        >
+        <Tooltip key="edit-dashboard" tooltip={t`Edit dashboard`}>
           <DashboardHeaderButton
             key="edit"
             data-metabase-event="Dashboard;Edit"
@@ -334,14 +304,12 @@ class DashboardHeader extends Component {
     }
 
     if (!isFullscreen && !isEditing) {
-      if (!dashboard.is_app_page) {
-        extraButtons.push({
-          title: t`Enter fullscreen`,
-          icon: "expand",
-          action: e => onFullscreenChange(!isFullscreen, !e.altKey),
-          event: `Dashboard;Fullscreen Mode;${!isFullscreen}`,
-        });
-      }
+      extraButtons.push({
+        title: t`Enter fullscreen`,
+        icon: "expand",
+        action: e => onFullscreenChange(!isFullscreen, !e.altKey),
+        event: `Dashboard;Fullscreen Mode;${!isFullscreen}`,
+      });
 
       extraButtons.push({
         title: t`Duplicate`,
@@ -416,7 +384,7 @@ class DashboardHeader extends Component {
       setSidebar,
     } = this.props;
 
-    const isDataAppPage = dashboard.is_app_page;
+    const isDataAppPage = false;
     const hasLastEditInfo = dashboard["last-edit-info"] != null;
 
     return (
@@ -434,11 +402,7 @@ class DashboardHeader extends Component {
         isNavBarOpen={this.props.isNavBarOpen}
         headerButtons={this.getHeaderButtons()}
         editWarning={this.getEditWarning(dashboard)}
-        editingTitle={
-          dashboard.is_app_page
-            ? t`You're editing this page.`
-            : t`You're editing this dashboard.`
-        }
+        editingTitle={t`You're editing this dashboard.`}
         editingButtons={this.getEditingButtons()}
         setDashboardAttribute={setDashboardAttribute}
         onLastEditInfoClick={() => setSidebar({ name: SIDEBAR_NAME.info })}

--- a/frontend/src/metabase/entities/dashboards.js
+++ b/frontend/src/metabase/entities/dashboards.js
@@ -133,12 +133,7 @@ const Dashboards = createEntity({
     getUrl: dashboard => dashboard && Urls.dashboard(dashboard),
     getCollection: dashboard =>
       dashboard && normalizedCollection(dashboard.collection),
-    getIcon: dashboard => ({
-      name:
-        dashboard.is_app_page || dashboard.model === "page"
-          ? "document"
-          : "dashboard",
-    }),
+    getIcon: () => ({ name: "dashboard" }),
     getColor: () => color("dashboard"),
   },
 

--- a/frontend/src/metabase/lib/urls/questions.ts
+++ b/frontend/src/metabase/lib/urls/questions.ts
@@ -79,9 +79,7 @@ export function question(
     path = appendSlug(path, slugg(name));
   }
 
-  if (isModel && isModelDetail) {
-    path = `${path}/detail`;
-  } else if (objectId) {
+  if (objectId) {
     path = `${path}/${objectId}`;
   }
 

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarContainer.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarContainer.tsx
@@ -8,10 +8,10 @@ import Modal from "metabase/components/Modal";
 
 import * as Urls from "metabase/lib/urls";
 
-import type { Bookmark, Collection, DataApp, User } from "metabase-types/api";
+import type { Bookmark, Collection, User } from "metabase-types/api";
 import type { State } from "metabase-types/store";
 
-import DataApps, { isDataAppCollection } from "metabase/entities/data-apps";
+import { isDataAppCollection } from "metabase/entities/data-apps";
 import Bookmarks, { getOrderedBookmarks } from "metabase/entities/bookmarks";
 import Collections, {
   buildCollectionTree,
@@ -65,7 +65,6 @@ interface Props extends MainNavbarProps {
   bookmarks: Bookmark[];
   collections: Collection[];
   rootCollection: Collection;
-  dataApps: DataApp[];
   hasDataAccess: boolean;
   hasOwnDatabase: boolean;
   allFetched: boolean;
@@ -83,7 +82,6 @@ function MainNavbarContainer({
   hasOwnDatabase,
   collections = [],
   rootCollection,
-  dataApps = [],
   hasDataAccess,
   allFetched,
   location,
@@ -173,7 +171,6 @@ function MainNavbarContainer({
         isOpen={isOpen}
         currentUser={currentUser}
         collections={collectionTree}
-        dataApps={dataApps}
         hasOwnDatabase={hasOwnDatabase}
         selectedItems={selectedItems}
         hasDataAccess={hasDataAccess}
@@ -199,9 +196,6 @@ export default _.compose(
   }),
   Collections.loadList({
     query: () => ({ tree: true, "exclude-archived": true }),
-    loadingAndErrorWrapper: false,
-  }),
-  DataApps.loadList({
     loadingAndErrorWrapper: false,
   }),
   connect(mapStateToProps, mapDispatchToProps),

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
@@ -13,14 +13,10 @@ import {
 import { isSmallScreen } from "metabase/lib/dom";
 import * as Urls from "metabase/lib/urls";
 
-import type { Bookmark, Collection, DataApp, User } from "metabase-types/api";
+import type { Bookmark, Collection, User } from "metabase-types/api";
 
 import { SelectedItem } from "../types";
-import {
-  SidebarCollectionLink,
-  SidebarDataAppLink,
-  SidebarLink,
-} from "../SidebarItems";
+import { SidebarCollectionLink, SidebarLink } from "../SidebarItems";
 
 import {
   AddYourOwnDataLink,
@@ -49,7 +45,6 @@ type Props = {
   hasDataAccess: boolean;
   hasOwnDatabase: boolean;
   collections: CollectionTreeItem[];
-  dataApps: DataApp[];
   selectedItems: SelectedItem[];
   handleCloseNavbar: () => void;
   handleLogout: () => void;
@@ -73,7 +68,6 @@ function MainNavbarView({
   currentUser,
   bookmarks,
   collections,
-  dataApps,
   hasOwnDatabase,
   selectedItems,
   hasDataAccess,
@@ -85,7 +79,6 @@ function MainNavbarView({
     card: cardItem,
     collection: collectionItem,
     dashboard: dashboardItem,
-    "data-app": dataAppItem,
     "non-entity": nonEntityItem,
   } = _.indexBy(selectedItems, item => item.type);
 
@@ -115,9 +108,7 @@ function MainNavbarView({
           <SidebarSection>
             <BookmarkList
               bookmarks={bookmarks}
-              selectedItem={
-                cardItem ?? dashboardItem ?? dataAppItem ?? collectionItem
-              }
+              selectedItem={cardItem ?? dashboardItem ?? collectionItem}
               onSelect={onItemSelect}
               reorderBookmarks={reorderBookmarks}
             />
@@ -137,23 +128,6 @@ function MainNavbarView({
             role="tree"
           />
         </SidebarSection>
-
-        {dataApps.length > 0 && (
-          <SidebarSection>
-            <SidebarHeadingWrapper>
-              <SidebarHeading>{t`Apps`}</SidebarHeading>
-            </SidebarHeadingWrapper>
-            <ul>
-              {dataApps.map(app => (
-                <SidebarDataAppLink
-                  key={`app-${app.id}`}
-                  dataApp={app}
-                  isSelected={dataAppItem?.id === app.id}
-                />
-              ))}
-            </ul>
-          </SidebarSection>
-        )}
 
         {hasDataAccess && (
           <SidebarSection>

--- a/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx
@@ -16,7 +16,7 @@ import {
 const FIXED_LAYOUT = [
   ["line", "bar", "combo", "area", "row", "waterfall"],
   ["scatter", "pie", "funnel", "smartscalar", "progress", "gauge"],
-  ["scalar", "table", "pivot", "map", "list", "object"],
+  ["scalar", "table", "pivot", "map"],
 ];
 const FIXED_TYPES = new Set(_.flatten(FIXED_LAYOUT));
 

--- a/frontend/src/metabase/routes.jsx
+++ b/frontend/src/metabase/routes.jsx
@@ -89,8 +89,6 @@ import SearchApp from "metabase/home/containers/SearchApp";
 import { trackPageView } from "metabase/lib/analytics";
 import { getAdminPaths } from "metabase/admin/app/selectors";
 
-import ActionPage from "metabase/writeback/containers/ActionCreatorPage";
-
 import ModelDetailPage from "metabase/models/containers/ModelDetailPage";
 
 const MetabaseIsSetup = UserAuthWrapper({
@@ -366,12 +364,6 @@ export const getRoutes = store => (
 
         {/* ADMIN */}
         {getAdminRoutes(store, CanAccessSettings, IsAdmin)}
-
-        {/* ACTION */}
-        <Route path="/action">
-          <Route path="create" component={ActionPage} />
-          <Route path=":actionId" component={ActionPage} />
-        </Route>
       </Route>
     </Route>
 

--- a/frontend/src/metabase/routes.jsx
+++ b/frontend/src/metabase/routes.jsx
@@ -70,8 +70,6 @@ import TableQuestionsContainer from "metabase/reference/databases/TableQuestions
 import FieldListContainer from "metabase/reference/databases/FieldListContainer";
 import FieldDetailContainer from "metabase/reference/databases/FieldDetailContainer";
 
-import DataAppLanding from "metabase/writeback/containers/DataAppLanding";
-
 import getAccountRoutes from "metabase/account/routes";
 import getAdminRoutes from "metabase/admin/routes";
 import getCollectionTimelineRoutes from "metabase/timelines/collections/routes";
@@ -227,32 +225,6 @@ export const getRoutes = store => (
           <ModalRoute path="new_dashboard" modal={CreateDashboardModal} />
           <ModalRoute path="permissions" modal={CollectionPermissionsModal} />
           {getCollectionTimelineRoutes()}
-        </Route>
-
-        <Route path="apps/:slug">
-          <IndexRoute component={DataAppLanding} />
-          <ModalRoute path="move" modal={MoveCollectionModal} />
-          <ModalRoute path="archive" modal={ArchiveCollectionModal} />
-          <ModalRoute path="new_collection" modal={CollectionCreate} />
-          <ModalRoute path="new_dashboard" modal={CreateDashboardModal} />
-          <ModalRoute path="permissions" modal={CollectionPermissionsModal} />
-          {getCollectionTimelineRoutes()}
-        </Route>
-
-        <Route path="a/:slug">
-          <IndexRoute component={DataAppLanding} />
-          <ModalRoute path="move" modal={MoveCollectionModal} />
-          <ModalRoute path="archive" modal={ArchiveCollectionModal} />
-          <ModalRoute path="new_collection" modal={CollectionCreate} />
-          <ModalRoute path="new_dashboard" modal={CreateDashboardModal} />
-          <ModalRoute path="permissions" modal={CollectionPermissionsModal} />
-          {getCollectionTimelineRoutes()}
-
-          <Route path="page/:pageId" component={DashboardApp}>
-            <ModalRoute path="move" modal={DashboardMoveModal} />
-            <ModalRoute path="copy" modal={DashboardCopyModal} />
-            <ModalRoute path="archive" modal={ArchiveDashboardModal} />
-          </Route>
         </Route>
 
         <Route path="activity" component={ActivityApp} />

--- a/frontend/src/metabase/routes.jsx
+++ b/frontend/src/metabase/routes.jsx
@@ -89,8 +89,6 @@ import SearchApp from "metabase/home/containers/SearchApp";
 import { trackPageView } from "metabase/lib/analytics";
 import { getAdminPaths } from "metabase/admin/app/selectors";
 
-import ModelDetailPage from "metabase/models/containers/ModelDetailPage";
-
 const MetabaseIsSetup = UserAuthWrapper({
   predicate: authData => authData.hasUserSetup,
   failureRedirectPath: "/setup",
@@ -250,8 +248,6 @@ export const getRoutes = store => (
           <Route path=":slug/notebook" component={QueryBuilder} />
           <Route path=":slug/:objectId" component={QueryBuilder} />
         </Route>
-
-        <Route path="/model/:slug/detail" component={ModelDetailPage} />
 
         <Route path="/model">
           <IndexRoute component={QueryBuilder} />

--- a/frontend/src/metabase/visualizations/visualizations/List.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/List.tsx
@@ -49,6 +49,8 @@ export default Object.assign(ListViz, {
   identifier: "list",
   iconName: "list",
 
+  hidden: true,
+
   minSize: {
     width: 4,
     height: 3,


### PR DESCRIPTION
Removes data app feature entry points from `master` as we're not going to release it in 45:

* removes app and action options from the new item menu
* removes corresponding routes (app, action routes)
* removes model detail page
* removes List and Object visualizations from the viz picker
* removes UI for enabling write-back per-database
* removes apps from the main navbar (we won't show app collections alongside regular ones just in case)
* removes the notion of pages from the dashboard code (basically hardcoding every `isDataAppPage` check to `false`

### To Verify

1. Ensure there is no way to enter data-apps-related experience or trigger any code path from the UI. 
2. Ensure you can't see a "dashboard" called "page" anywhere on the UI