### PR TITLE
Serdes v2: Refactor entire serdes flow to use real Toucan, not low level

### DIFF
--- a/dev/src/dev/render_png.clj
+++ b/dev/src/dev/render_png.clj
@@ -80,7 +80,7 @@
   [img-bytes]
   (str "data:image/png;base64," (String. (Base64Coder/encode img-bytes))))
 
-(defn svg-image [kind]
+#_(defn svg-image [kind]
   (let [line|bar-data [["2015-02-01T00:00:00-08:00" 443]
                        ["2015-03-01T00:00:00-08:00" 875]
                        ["2015-04-01T00:00:00-07:00" 483]
@@ -100,7 +100,7 @@
       (throw (ex-info (str "Invalid chart type: " kind "\n Valid choices are :line, :bar, :donut")
                       {})))))
 
-(defn preview-html
+#_(defn preview-html
   "Chart type is one of :line, :bar, :donut. Html is a string with a placeholder {{chart}} which will be replaced with
   the [:img {:src chart-placeholder}] and the resulting html will be opened."
   [{:keys [chart html-file html-inline]}]

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e/yaml_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e/yaml_test.clj
@@ -1,19 +1,17 @@
 (ns metabase-enterprise.serialization.v2.e2e.yaml-test
   (:require [clojure.java.io :as io]
             [clojure.test :refer :all]
-            [java-time :as t]
+            [medley.core :as m]
             [metabase-enterprise.serialization.test-util :as ts]
             [metabase-enterprise.serialization.v2.extract :as extract]
-            [metabase-enterprise.serialization.v2.ingest :as ingest]
             [metabase-enterprise.serialization.v2.ingest.yaml :as ingest.yaml]
+            [metabase-enterprise.serialization.v2.load :as serdes.load]
             [metabase-enterprise.serialization.v2.storage.yaml :as storage.yaml]
-            [metabase-enterprise.serialization.v2.utils.yaml :as u.yaml]
             [metabase.models.serialization.base :as serdes.base]
             [metabase.test.generate :as test-gen]
-            [metabase.util.date-2 :as u.date]
             [reifyhealth.specmonstah.core :as rs]
-            [yaml.core :as yaml])
-  (:import java.time.ZoneId))
+            [toucan.db :as db]
+            [yaml.core :as yaml]))
 
 (defn- dir->file-set [dir]
   (->> dir
@@ -27,244 +25,335 @@
        .listFiles
        (remove #(.isFile %))))
 
-(defn- strip-labels [path]
-  (mapv #(dissoc % :label) path))
-
-(defn- clean-up-expected [entity]
-  (cond-> entity
-    true                 (dissoc :serdes/meta :updated_at)
-    (:created_at entity) (update :created_at u.date/format)))
-
 (defn- random-keyword
   ([prefix n] (random-keyword prefix n 0))
-  ([prefix n floor] (keyword (str prefix (+ floor (rand-int n))))))
+  ([prefix n floor] (keyword (str (name prefix) (+ floor (rand-int n))))))
+
+(defn- random-fks
+  "Generates a specmonstah query with the :refs populated with the randomized bindings.
+  `(random-fks {:spec-gen {:foo :bar}}
+               {:creator_id [:u 10]
+                :db_id      [:db 20 15]})`
+  this will return a query like:
+  `{:spec-gen {:foo :bar}
+    :refs {:creator_id :u6  :db_id 17}}`
+
+  The bindings map has the same keys as `:refs`, but the values are `[base-keyword width]` pairs or
+  `[base-keyword width floor]` triples. These are passed to [[random-keyword]]."
+  [base bindings]
+  (update base :refs merge (m/map-vals #(apply random-keyword %) bindings)))
+
+(defn- many-random-fks [n base bindings]
+  (vec (repeatedly n #(vector 1 (random-fks base bindings)))))
+
+(defn- table->db [{:keys [table_id] :as refs}]
+  (let [table-number (-> table_id
+                         name
+                         (subs 1)
+                         (Integer/parseInt))]
+    (assoc refs :database_id (keyword (str "db" (quot table-number 10))))))
+
+(defn- clean-entity
+ "Removes any comparison-confounding fields, like `:created_at`."
+ [entity]
+ (dissoc entity :created_at))
 
 (deftest e2e-storage-ingestion-test
   (ts/with-random-dump-dir [dump-dir "serdesv2-"]
-    (ts/with-empty-h2-app-db
-      ;; TODO Generating some nested collections would make these tests more robust.
-      (test-gen/insert!
-        {:collection              [[100 {:refs {:personal_owner_id ::rs/omit}}]
-                                   [10  {:refs     {:personal_owner_id ::rs/omit}
-                                         :spec-gen {:namespace :snippets}}]]
-         :database                [[10]]
-         :table                   (into [] (for [db [:db0 :db1 :db2 :db3 :db4 :db5 :db6 :db7 :db8 :db9]]
-                                             [10 {:refs {:db_id db}}]))
-         :field                   (into [] (for [n     (range 100)
-                                                 :let [table (keyword (str "t" n))]]
-                                             [10 {:refs {:table_id table}}]))
-         :core-user               [[10]]
-         :card                    [[100 {:refs (let [db (rand-int 10)
-                                                     t  (rand-int 10)]
-                                                 {:database_id   (keyword (str "db" db))
-                                                  :table_id      (keyword (str "t" (+ t (* 10 db))))
-                                                  :collection_id (random-keyword "coll" 100)
-                                                  :creator_id    (random-keyword "u" 10)})}]]
-         :dashboard               [[100 {:refs {:collection_id   (random-keyword "coll" 100)
-                                                :creator_id      (random-keyword "u" 10)}}]]
-         :dashboard-card          [[300 {:refs {:card_id      (random-keyword "c" 100)
-                                                :dashboard_id (random-keyword "d" 100)}}]]
-         :dimension               [;; 20 with both IDs set
-                                   [20 {:refs {:field_id                (random-keyword "field" 1000)
-                                               :human_readable_field_id (random-keyword "field" 1000)}}]
-                                   ;; 20 with just :field_id
-                                   [20 {:refs {:field_id                (random-keyword "field" 1000)
-                                               :human_readable_field_id ::rs/omit}}]]
-         :metric                  [[30 {:refs {:table_id   (random-keyword "t" 100)
-                                               :creator_id (random-keyword "u" 10)}}]]
-         :segment                 [[30 {:refs {:table_id   (random-keyword "t" 100)
-                                               :creator_id (random-keyword "u" 10)}}]]
-         :native-query-snippet    [[10 {:refs {:creator_id    (random-keyword "u" 10)
-                                               :collection_id (random-keyword "coll" 10 100)}}]]
-         :timeline                [[10 {:refs {:creator_id    (random-keyword "u" 10)
-                                               :collection_id (random-keyword "coll" 100)}}]]
-         :timeline-event          [[90 {:refs {:timeline_id   (random-keyword "timeline" 10)}}]]
-         :pulse                   [[10 {:refs {:collection_id (random-keyword "coll" 100)}}]
-                                   [10 {:refs {:collection_id ::rs/omit}}]
-                                   [10 {:refs {:collection_id ::rs/omit
-                                               :dashboard_id  (random-keyword "d" 100)}}]]
-         :pulse-card              [[60 {:refs {:card_id       (random-keyword "c" 100)
-                                               :pulse_id      (random-keyword "pulse" 10)}}]
-                                   [60 {:refs {:card_id       (random-keyword "c" 100)
-                                               :pulse_id      (random-keyword "pulse" 10 20)
-                                               :dashboard_card_id (random-keyword "dc" 300)}}]]
-         :pulse-channel           [[15 {:refs {:pulse_id      (random-keyword "pulse" 10)}}]
-                                   [15 {:refs {:pulse_id      (random-keyword "pulse" 10 20)}}]]
-         :pulse-channel-recipient [[40 {:refs {:pulse_channel_id (random-keyword "pulse-channel" 30)
-                                               :user_id          (random-keyword "u" 10)}}]]})
-      (let [extraction (into [] (extract/extract-metabase {}))
-            entities   (reduce (fn [m entity]
-                                 (update m (-> entity :serdes/meta last :model)
-                                         (fnil conj []) entity))
-                               {} extraction)]
-        (is (= 110 (-> entities (get "Collection") count)))
+    (let [extraction (atom nil)
+          entities   (atom nil)]
+      (ts/with-source-and-dest-dbs
+        ;; TODO Generating some nested collections would make these tests more robust.
+        (ts/with-source-db
+          (testing "insert"
+            (test-gen/insert!
+              {:collection              [[100 {:refs {:personal_owner_id ::rs/omit}}]
+                                         [10  {:refs     {:personal_owner_id ::rs/omit}
+                                               :spec-gen {:namespace :snippets}}]]
+               :database                [[10]]
+               ;; Tables are special - we define table 0-9 under db0, 10-19 under db1, etc. The :card spec below
+               ;; depends on this relationship.
+               :table                   (into [] (for [db [:db0 :db1 :db2 :db3 :db4 :db5 :db6 :db7 :db8 :db9]]
+                                                   [10 {:refs {:db_id db}}]))
+               :field                   (many-random-fks 1000 {} {:table_id [:t 100]})
+               :core-user               [[100]]
+               :card                    (mapv #(update-in % [1 :refs] table->db)
+                                              (many-random-fks
+                                                100
+                                                {:spec-gen {:dataset_query {:database 1
+                                                                            :query {:source-table 3
+                                                                                    :aggregation [[:count]]
+                                                                                    :breakout [[:field 16 nil]]}
+                                                                            :type :query}}}
+                                                {:table_id      [:t    100]
+                                                 :collection_id [:coll 100]
+                                                 :creator_id    [:u    10]}))
+               :dashboard               (many-random-fks 100 {} {:collection_id [:coll 100]
+                                                                 :creator_id    [:u    10]})
+               :dashboard-card          (many-random-fks 300 {} {:card_id      [:c 100]
+                                                                 :dashboard_id [:d 100]})
+               :dimension               (vec (concat
+                                               ;; 20 with both IDs set
+                                               (many-random-fks 20 {}
+                                                                {:field_id                [:field 1000]
+                                                                 :human_readable_field_id [:field 1000]})
+                                               ;; 20 with just :field_id
+                                               (many-random-fks 20 {:refs {:human_readable_field_id ::rs/omit}}
+                                                                {:field_id [:field 1000]})))
+               :metric                  (many-random-fks 30 {:spec-gen {:definition {:aggregation  [[:count]]
+                                                                                     :source-table 9}}}
+                                                         {:table_id   [:t 100]
+                                                          :creator_id [:u 10]})
+               :segment                 (many-random-fks 30 {:spec-gen {:definition {:filter [:!= [:field 60 nil] 50],
+                                                                                     :source-table 4}}}
+                                                         {:table_id   [:t 100]
+                                                          :creator_id [:u 10]})
+               :native-query-snippet    (many-random-fks 10 {} {:creator_id    [:u 10]
+                                                                :collection_id [:coll 10 100]})
+               :timeline                (many-random-fks 10 {} {:creator_id    [:u 10]
+                                                                :collection_id [:coll 100]})
+               :timeline-event          (many-random-fks 90 {} {:timeline_id   [:timeline 10]})
+               :pulse                   (vec (concat
+                                               ;; 10 classic pulses, from collections
+                                               (many-random-fks 10 {} {:collection_id [:coll 100]})
+                                               ;; 10 classic pulses, no collection
+                                               (many-random-fks 10 {:refs {:collection_id ::rs/omit}} {})
+                                               ;; 10 dashboard subs
+                                               (many-random-fks 10 {:refs {:collection_id ::rs/omit}}
+                                                                {:dashboard_id  [:d 100]})))
+               :pulse-card              (vec (concat
+                                               ;; 60 pulse cards for the classic pulses
+                                               (many-random-fks 60 {} {:card_id       [:c 100]
+                                                                       :pulse_id      [:pulse 10]})
+                                               ;; 60 pulse cards connected to dashcards for the dashboard subs
+                                               (many-random-fks 60 {} {:card_id           [:c 100]
+                                                                       :pulse_id          [:pulse 10 20]
+                                                                       :dashboard_card_id [:dc 300]})))
+               :pulse-channel           (vec (concat
+                                               ;; 15 channels for the classic pulses
+                                               (many-random-fks 15 {} {:pulse_id  [:pulse 10]})
+                                               ;; 15 channels for the dashboard subs
+                                               (many-random-fks 15 {} {:pulse_id  [:pulse 10 20]})))
+               :pulse-channel-recipient (many-random-fks 40 {} {:pulse_channel_id [:pulse-channel 30]
+                                                                :user_id          [:u 100]})}))
+
+          (is (= 100 (count (db/select-field :email 'User))))
+
+          (testing "extraction"
+            (reset! extraction (into [] (extract/extract-metabase {})))
+            (reset! entities   (reduce (fn [m entity]
+                                         (update m (-> entity :serdes/meta last :model)
+                                                 (fnil conj []) entity))
+                                       {} @extraction))
+            (is (= 110 (-> @entities (get "Collection") count)))))
 
         (testing "storage"
-          (storage.yaml/store! (seq extraction) dump-dir)
+          (storage.yaml/store! (seq @extraction) dump-dir)
+
           (testing "for Collections"
-            (is (= 110 (count (dir->file-set (io/file dump-dir "Collection")))))
-            (doseq [{:keys [entity_id slug] :as coll} (get entities "Collection")
-                    :let [filename (#'u.yaml/leaf-file-name entity_id slug)]]
-              (is (= (clean-up-expected coll)
-                     (yaml/from-file (io/file dump-dir "Collection" filename))))))
+            (is (= 110 (count (dir->file-set (io/file dump-dir "Collection"))))))
 
           (testing "for Databases"
-            (is (= 10 (count (dir->file-set (io/file dump-dir "Database")))))
-            (doseq [{:keys [name] :as coll} (get entities "Database")
-                    :let [filename (#'u.yaml/leaf-file-name name)]]
-              (is (= (clean-up-expected coll)
-                     (yaml/from-file (io/file dump-dir "Database" filename))))))
+            (is (= 10 (count (dir->file-set (io/file dump-dir "Database"))))))
 
           (testing "for Tables"
             (is (= 100
-                   (reduce + (for [db    (get entities "Database")
+                   (reduce + (for [db    (get @entities "Database")
                                    :let [tables (dir->file-set (io/file dump-dir "Database" (:name db) "Table"))]]
                                (count tables))))
-                "Tables are scattered, so the directories are harder to count")
-
-            (doseq [{:keys [db_id name] :as coll} (get entities "Table")]
-              (is (= (clean-up-expected coll)
-                     (yaml/from-file (io/file dump-dir "Database" db_id "Table" (str name ".yaml")))))))
+                "Tables are scattered, so the directories are harder to count"))
 
           (testing "for Fields"
             (is (= 1000
-                   (reduce + (for [db    (get entities "Database")
+                   (reduce + (for [db    (get @entities "Database")
                                    table (subdirs (io/file dump-dir "Database" (:name db) "Table"))]
                                (->> (io/file table "Field")
                                     dir->file-set
                                     count))))
-                "Fields are scattered, so the directories are harder to count")
-
-            (doseq [{[db schema table] :table_id name :name :as coll} (get entities "Field")]
-              (is (nil? schema))
-              (is (= (clean-up-expected coll)
-                     (yaml/from-file (io/file dump-dir "Database" db "Table" table "Field" (str name ".yaml")))))))
+                "Fields are scattered, so the directories are harder to count"))
 
           (testing "for cards"
-            (is (= 100 (count (dir->file-set (io/file dump-dir "Card")))))
-            (doseq [{:keys [entity_id] :as card} (get entities "Card")
-                    :let [filename (#'u.yaml/leaf-file-name entity_id)]]
-              (is (= (clean-up-expected card)
-                     (yaml/from-file (io/file dump-dir "Card" filename))))))
+            (is (= 100 (count (dir->file-set (io/file dump-dir "Card"))))))
 
           (testing "for dashboards"
-            (is (= 100 (count (dir->file-set (io/file dump-dir "Dashboard")))))
-            (doseq [{:keys [entity_id] :as dash} (get entities "Dashboard")
-                    :let [filename (#'u.yaml/leaf-file-name entity_id)]]
-              (is (= (clean-up-expected dash)
-                     (yaml/from-file (io/file dump-dir "Dashboard" filename))))))
+            (is (= 100 (count (dir->file-set (io/file dump-dir "Dashboard"))))))
 
           (testing "for dashboard cards"
             (is (= 300
-                   (reduce + (for [dash (get entities "Dashboard")
+                   (reduce + (for [dash (get @entities "Dashboard")
                                    :let [card-dir (io/file dump-dir "Dashboard" (:entity_id dash) "DashboardCard")]]
                                (if (.exists card-dir)
                                  (count (dir->file-set card-dir))
-                                 0)))))
-
-            (doseq [{:keys [dashboard_id entity_id]
-                     :as   dashcard}                (get entities "DashboardCard")
-                    :let [filename (#'u.yaml/leaf-file-name entity_id)]]
-              (is (= (clean-up-expected dashcard)
-                     (yaml/from-file (io/file dump-dir "Dashboard" dashboard_id "DashboardCard" filename))))))
+                                 0))))))
 
           (testing "for dimensions"
-            (is (= 40 (count (dir->file-set (io/file dump-dir "Dimension")))))
-            (doseq [{:keys [entity_id] :as dim} (get entities "Dimension")
-                    :let [filename (#'u.yaml/leaf-file-name entity_id)]]
-              (is (= (clean-up-expected dim)
-                     (yaml/from-file (io/file dump-dir "Dimension" filename))))))
+            (is (= 40 (count (dir->file-set (io/file dump-dir "Dimension"))))))
 
           (testing "for metrics"
-            (is (= 30 (count (dir->file-set (io/file dump-dir "Metric")))))
-            (doseq [{:keys [entity_id name] :as metric} (get entities "Metric")
-                    :let [filename (#'u.yaml/leaf-file-name entity_id name)]]
-              (is (= (clean-up-expected metric)
-                     (yaml/from-file (io/file dump-dir "Metric" filename))))))
+            (is (= 30 (count (dir->file-set (io/file dump-dir "Metric"))))))
 
           (testing "for segments"
-            (is (= 30 (count (dir->file-set (io/file dump-dir "Segment")))))
-            (doseq [{:keys [entity_id name] :as segment} (get entities "Segment")
-                    :let [filename (#'u.yaml/leaf-file-name entity_id name)]]
-              (is (= (clean-up-expected segment)
-                     (yaml/from-file (io/file dump-dir "Segment" filename))))))
+            (is (= 30 (count (dir->file-set (io/file dump-dir "Segment"))))))
 
           (testing "for pulses"
-            (is (= 30 (count (dir->file-set (io/file dump-dir "Pulse")))))
-            (doseq [{:keys [entity_id] :as pulse} (get entities "Pulse")
-                    :let [filename (#'u.yaml/leaf-file-name entity_id)]]
-              (is (= (clean-up-expected pulse)
-                     (yaml/from-file (io/file dump-dir "Pulse" filename))))))
+            (is (= 30 (count (dir->file-set (io/file dump-dir "Pulse"))))))
 
           (testing "for pulse cards"
-            (is (= 120 (reduce + (for [pulse (get entities "Pulse")]
+            (is (= 120 (reduce + (for [pulse (get @entities "Pulse")]
                                    (->> (io/file dump-dir "Pulse" (:entity_id pulse) "PulseCard")
                                         dir->file-set
-                                        count)))))
-            (doseq [{:keys [entity_id pulse_id] :as card} (get entities "PulseCard")
-                    :let [filename (#'u.yaml/leaf-file-name entity_id)]]
-              (is (= (clean-up-expected card)
-                     (yaml/from-file (io/file dump-dir "Pulse" pulse_id "PulseCard" filename))))))
+                                        count))))))
 
           (testing "for pulse channels"
-            (is (= 30 (reduce + (for [pulse (get entities "Pulse")]
+            (is (= 30 (reduce + (for [pulse (get @entities "Pulse")]
                                   (->> (io/file dump-dir "Pulse" (:entity_id pulse) "PulseChannel")
                                        dir->file-set
                                        count)))))
-            (is (= 40 (reduce + (for [{:keys [recipients]} (get entities "PulseChannel")]
-                                  (count recipients)))))
-            (doseq [{:keys [entity_id pulse_id] :as channel} (get entities "PulseChannel")
-                    :let [filename (#'u.yaml/leaf-file-name entity_id)]]
-              (is (= (clean-up-expected channel)
-                     (yaml/from-file (io/file dump-dir "Pulse" pulse_id "PulseChannel" filename))))))
+            (is (= 40 (reduce + (for [{:keys [recipients]} (get @entities "PulseChannel")]
+                                  (count recipients))))))
 
           (testing "for native query snippets"
-            (is (= 10 (count (dir->file-set (io/file dump-dir "NativeQuerySnippet")))))
-            (doseq [{:keys [entity_id name] :as snippet} (get entities "NativeQuerySnippet")
-                    :let [filename (#'u.yaml/leaf-file-name entity_id name)]]
-              (is (= (clean-up-expected snippet)
-                     (yaml/from-file (io/file dump-dir "NativeQuerySnippet" filename))))))
+            (is (= 10 (count (dir->file-set (io/file dump-dir "NativeQuerySnippet"))))))
 
           (testing "for timelines and events"
             (is (= 10 (count (dir->file-set (io/file dump-dir "Timeline")))))
-            (doseq [{:keys [entity_id] :as timeline} (get entities "Timeline")
-                    :let [filename (#'u.yaml/leaf-file-name entity_id)]]
-              (is (= (clean-up-expected timeline)
-                     (yaml/from-file (io/file dump-dir "Timeline" filename)))))
 
-            (is (= 90 (reduce + (for [timeline (get entities "Timeline")]
+            (is (= 90 (reduce + (for [timeline (get @entities "Timeline")]
                                   (->> (io/file dump-dir "Timeline" (:entity_id timeline) "TimelineEvent")
                                        dir->file-set
-                                       count)))))
-            (doseq [{:keys [name timeline_id timestamp] :as event} (get entities "TimelineEvent")
-                    :let [filename (#'u.yaml/leaf-file-name timestamp name)]]
-              (is (= (clean-up-expected event)
-                     (yaml/from-file (io/file dump-dir "Timeline" timeline_id "TimelineEvent" filename))))))
+                                       count))))))
 
           (testing "for settings"
-            (is (= (into {} (for [{:keys [key value]} (get entities "Setting")]
-                              [key value]))
-                   (yaml/from-file (io/file dump-dir "settings.yaml"))))))
+            (is (.exists (io/file dump-dir "settings.yaml")))))
 
-        (testing "ingestion"
-          (let [ingestable (ingest.yaml/ingest-yaml dump-dir)]
-            (testing "ingest-list is accurate"
-              (is (= (into #{} (comp cat
-                                     (map (fn [entity]
-                                            (mapv #(cond-> %
-                                                     (:label %) (update :label #'u.yaml/truncate-label))
-                                                  (serdes.base/serdes-path entity)))))
-                           (vals entities))
-                     (into #{} (ingest/ingest-list ingestable)))))
+          (testing "ingest and load"
+            (ts/with-dest-db
+              (testing "doing ingestion"
+                (is (serdes.load/load-metabase (ingest.yaml/ingest-yaml dump-dir))
+                    "successful"))
 
+              (testing "for Collections"
+                (doseq [{:keys [entity_id] :as coll} (get @entities "Collection")]
+                  (is (= (clean-entity coll)
+                         (->> (db/select-one 'Collection :entity_id entity_id)
+                              (serdes.base/extract-one "Collection" {})
+                              clean-entity)))))
 
-            (testing "each entity matches its in-memory original"
-              (doseq [entity extraction]
-                (let [->utc   #(t/zoned-date-time % (ZoneId/of "UTC"))]
-                  (is (= (cond-> entity
-                           true                                       (update :serdes/meta strip-labels)
-                           true                                       (dissoc :updated_at)
-                           ;; TIMESTAMP WITH TIME ZONE columns come out of the database as OffsetDateTime, but read back
-                           ;; from YAML as ZonedDateTimes; coerce the expected value to match.
-                           (t/offset-date-time? (:created_at entity)) (update :created_at ->utc))
-                         (ingest/ingest-one ingestable (serdes.base/serdes-path entity)))))))))))))
+              (testing "for Databases"
+                (doseq [{:keys [name] :as coll} (get @entities "Database")]
+                  (is (= (clean-entity coll)
+                         (->> (db/select-one 'Database :name name)
+                              (serdes.base/extract-one "Database" {})
+                              clean-entity)))))
+
+              (testing "for Tables"
+                (doseq [{:keys [db_id name] :as coll} (get @entities "Table")]
+                  (is (= (clean-entity coll)
+                         (->> (db/select-one-field :id 'Database :name db_id)
+                              (db/select-one 'Table :name name :db_id)
+                              (serdes.base/extract-one "Table" {})
+                              clean-entity)))))
+
+              (testing "for Fields"
+                (doseq [{[db schema table] :table_id name :name :as coll} (get @entities "Field")]
+                  (is (nil? schema))
+                  (is (= (clean-entity coll)
+                         (->> (db/select-one-field :id 'Database :name db)
+                              (db/select-one-field :id 'Table :schema schema :name table :db_id)
+                              (db/select-one 'Field :name name :table_id)
+                              (serdes.base/extract-one "Field" {})
+                              clean-entity)))))
+
+              (testing "for cards"
+                (doseq [{:keys [entity_id] :as card} (get @entities "Card")]
+                  (is (= (clean-entity card)
+                         (->> (db/select-one 'Card :entity_id entity_id)
+                              (serdes.base/extract-one "Card" {})
+                              clean-entity)))))
+
+              (testing "for dashboards"
+                (doseq [{:keys [entity_id] :as dash} (get @entities "Dashboard")]
+                  (is (= (clean-entity dash)
+                         (->> (db/select-one 'Dashboard :entity_id entity_id)
+                              (serdes.base/extract-one "Dashboard" {})
+                              clean-entity)))))
+
+              (testing "for dashboard cards"
+                (doseq [{:keys [entity_id] :as dashcard} (get @entities "DashboardCard")]
+                  (is (= (clean-entity dashcard)
+                         (->> (db/select-one 'DashboardCard :entity_id entity_id)
+                              (serdes.base/extract-one "DashboardCard" {})
+                              clean-entity)))))
+
+              (testing "for dimensions"
+                (doseq [{:keys [entity_id] :as dim} (get @entities "Dimension")]
+                  (is (= (clean-entity dim)
+                         (->> (db/select-one 'Dimension :entity_id entity_id)
+                              (serdes.base/extract-one "Dimension" {})
+                              clean-entity)))))
+
+              (testing "for metrics"
+                (doseq [{:keys [entity_id] :as metric} (get @entities "Metric")]
+                  (is (= (clean-entity metric)
+                         (->> (db/select-one 'Metric :entity_id entity_id)
+                              (serdes.base/extract-one "Metric" {})
+                              clean-entity)))))
+
+              (testing "for segments"
+                (doseq [{:keys [entity_id] :as segment} (get @entities "Segment")]
+                  (is (= (clean-entity segment)
+                         (->> (db/select-one 'Segment :entity_id entity_id)
+                              (serdes.base/extract-one "Segment" {})
+                              clean-entity)))))
+
+              (testing "for pulses"
+                (doseq [{:keys [entity_id] :as pulse} (get @entities "Pulse")]
+                  (is (= (clean-entity pulse)
+                         (->> (db/select-one 'Pulse :entity_id entity_id)
+                              (serdes.base/extract-one "Pulse" {})
+                              clean-entity)))))
+
+              (testing "for pulse cards"
+                (doseq [{:keys [entity_id] :as card} (get @entities "PulseCard")]
+                  (is (= (clean-entity card)
+                         (->> (db/select-one 'PulseCard :entity_id entity_id)
+                              (serdes.base/extract-one "PulseCard" {})
+                              clean-entity)))))
+
+              (testing "for pulse channels"
+                (doseq [{:keys [entity_id] :as channel} (get @entities "PulseChannel")]
+                  ;; The :recipients list is in arbitrary order - turn them into sets for comparison.
+                  (is (= (-> channel
+                             (update :recipients set)
+                             clean-entity)
+                         (let [loaded-channel (->> (db/select-one 'PulseChannel :entity_id entity_id)
+                                                   (serdes.base/extract-one "PulseChannel" {}))]
+                           (-> loaded-channel
+                               (update :recipients set)
+                               clean-entity))))))
+
+              (testing "for native query snippets"
+                (doseq [{:keys [entity_id] :as snippet} (get @entities "NativeQuerySnippet")]
+                  (is (= (clean-entity snippet)
+                         (->> (db/select-one 'NativeQuerySnippet :entity_id entity_id)
+                              (serdes.base/extract-one "NativeQuerySnippet" {})
+                              clean-entity)))))
+
+              (testing "for timelines and events"
+                (doseq [{:keys [entity_id] :as timeline} (get @entities "Timeline")]
+                  (is (= (clean-entity timeline)
+                         (->> (db/select-one 'Timeline :entity_id entity_id)
+                              (serdes.base/extract-one "Timeline" {})
+                              clean-entity))))
+
+                (doseq [{:keys [timeline_id timestamp] :as event} (get @entities "TimelineEvent")]
+                  (is (= (clean-entity event)
+                         (->> (db/select-one-id 'Timeline :entity_id timeline_id)
+                              (db/select-one 'TimelineEvent :timestamp timestamp :timeline_id)
+                              (serdes.base/extract-one "TimelineEvent" {})
+                              clean-entity)))))
+
+              (testing "for settings"
+                (is (= (into {} (for [{:keys [key value]} (get @entities "Setting")]
+                                  [key value]))
+                       (yaml/from-file (io/file dump-dir "settings.yaml")))))))))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -303,9 +303,9 @@
             (reset! serialized (into [] (serdes.extract/extract-metabase {})))))
 
         (testing "the serialized form is as desired"
-          (is (= {:type "query"
+          (is (= {:type  :query
                   :query {:source-table ["my-db" nil "customers"]
-                          :filter       [">=" [:field ["my-db" nil "customers" "age"] nil] 18]
+                          :filter       [:>= [:field ["my-db" nil "customers" "age"] nil] 18]
                           :aggregation  [[:count]]}
                   :database "my-db"}
                  (->> (by-model @serialized "Card")
@@ -385,7 +385,7 @@
         (testing "exported form is properly converted"
           (is (= {:source-table ["my-db" nil "customers"]
                   :aggregation [[:count]]
-                  :filter ["<" [:field ["my-db" nil "customers" "age"] nil] 18]}
+                  :filter [:< [:field ["my-db" nil "customers" "age"] nil] 18]}
                  (-> @serialized
                      (by-model "Segment")
                      first
@@ -598,16 +598,16 @@
                                 :table.cell_column "sum"
                                 :table.columns
                                 [{:name "SOME_FIELD"
-                                  :fieldRef ["field" ["my-db" nil "orders" "subtotal"] nil]
+                                  :fieldRef [:field ["my-db" nil "orders" "subtotal"] nil]
                                   :enabled true}
                                  {:name "sum"
-                                  :fieldRef ["field" "sum" {:base-type "type/Float"}]
+                                  :fieldRef [:field "sum" {:base-type :type/Float}]
                                   :enabled true}
                                  {:name "count"
-                                  :fieldRef ["field" "count" {:base-type "type/BigInteger"}]
+                                  :fieldRef [:field "count" {:base-type :type/BigInteger}]
                                   :enabled true}
                                  {:name "Average order total"
-                                  :fieldRef ["field" "Average order total" {:base-type "type/Float"}]
+                                  :fieldRef [:field "Average order total" {:base-type :type/Float}]
                                   :enabled true}]
                                 :column_settings
                                 {"[\"ref\",[\"field\",[\"my-db\",null,\"orders\",\"invoice\"],null]]" {:column_title "Locus"}}}]
@@ -678,8 +678,8 @@
           (ts/with-source-db
             (reset! user1s    (ts/create! User :first_name "Tom" :last_name "Scholz" :email "tom@bost.on"))
             (reset! user2s    (ts/create! User :first_name "Neil"  :last_name "Peart"   :email "neil@rush.yyz"))
-            (reset! metric1s  (ts/create! Metric :name "Large Users"       :creator_id (:id @user1s)))
-            (reset! metric2s  (ts/create! Metric :name "Support Headaches" :creator_id (:id @user2s)))
+            (reset! metric1s  (ts/create! Metric :name "Large Users"       :creator_id (:id @user1s) :definition {:aggregation [[:count]]}))
+            (reset! metric2s  (ts/create! Metric :name "Support Headaches" :creator_id (:id @user2s) :definition {:aggregation [[:count]]}))
             (reset! serialized (into [] (serdes.extract/extract-metabase {})))))
 
         (testing "exported form is properly converted"

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -331,15 +331,8 @@
   [:name (serdes.hash/hydrated-hash :collection)])
 
 ;;; ------------------------------------------------- Serialization --------------------------------------------------
-(defmethod serdes.base/extract-query "Card" [_ {:keys [user]}]
-  (serdes.base/raw-reducible-query
-   "Card"
-   {:select     [:card.*]
-    :from       [[:report_card :card]]
-    :left-join  [[:collection :coll] [:= :coll.id :card.collection_id]]
-    :where      (if user
-                  [:or [:= :coll.personal_owner_id user] [:is :coll.personal_owner_id nil]]
-                  [:is :coll.personal_owner_id nil])}))
+(defmethod serdes.base/extract-query "Card" [_ {:keys [collection-set]}]
+  (db/select-reducible Card :collection_id [:in collection-set]))
 
 (defmethod serdes.base/extract-one "Card"
   [_model-name _opts card]
@@ -353,7 +346,7 @@
       (update :collection_id          serdes.util/export-fk 'Collection)
       (update :creator_id             serdes.util/export-user)
       (update :made_public_by_id      serdes.util/export-user)
-      (update :dataset_query          serdes.util/export-json-mbql)
+      (update :dataset_query          serdes.util/export-mbql)
       (update :parameter_mappings     serdes.util/export-parameter-mappings)
       (update :visualization_settings serdes.util/export-visualization-settings)
       (dissoc :result_metadata))) ; Not portable, and can be rebuilt on the other side.
@@ -367,7 +360,7 @@
       (update :creator_id             serdes.util/import-user)
       (update :made_public_by_id      serdes.util/import-user)
       (update :collection_id          serdes.util/import-fk 'Collection)
-      (update :dataset_query          serdes.util/import-json-mbql)
+      (update :dataset_query          serdes.util/import-mbql)
       (update :parameter_mappings     serdes.util/import-parameter-mappings)
       (update :visualization_settings serdes.util/import-visualization-settings)))
 

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -409,16 +409,8 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                               SERIALIZATION                                                    |
 ;;; +----------------------------------------------------------------------------------------------------------------+
-(defmethod serdes.base/extract-query "Dashboard" [_ {:keys [user]}]
-  ;; TODO This join over the subset of collections this user can see is shared by a few things - factor it out?
-  (serdes.base/raw-reducible-query
-    "Dashboard"
-    {:select     [:dash.*]
-     :from       [[:report_dashboard :dash]]
-     :left-join  [[:collection :coll] [:= :coll.id :dash.collection_id]]
-     :where      (if user
-                   [:or [:= :coll.personal_owner_id user] [:is :coll.personal_owner_id nil]]
-                   [:is :coll.personal_owner_id nil])}))
+(defmethod serdes.base/extract-query "Dashboard" [_ {:keys [collection-set]}]
+  (db/select-reducible Dashboard :collection_id [:in collection-set]))
 
 ;; TODO Maybe nest collections -> dashboards -> dashcards?
 (defmethod serdes.base/extract-one "Dashboard"

--- a/src/metabase/models/dashboard_card.clj
+++ b/src/metabase/models/dashboard_card.clj
@@ -52,7 +52,7 @@
 
 (defmethod serdes.hash/identity-hash-fields DashboardCard
   [_dashboard-card]
-  [(serdes.hash/hydrated-hash :card)
+  [(serdes.hash/hydrated-hash :card "<none>") ; :card is optional, eg. text cards
    (comp serdes.hash/identity-hash
          #(db/select-one 'Dashboard :id %)
          :dashboard_id)
@@ -219,17 +219,9 @@
     (events/publish-event! :dashboard-remove-cards {:id id :actor_id user-id :dashcards [dashboard-card]})))
 
 ;;; ----------------------------------------------- SERIALIZATION ----------------------------------------------------
-(defmethod serdes.base/extract-query "DashboardCard" [_ {:keys [user]}]
-  ;; TODO This join over the subset of collections this user can see is shared by a few things - factor it out?
-  (serdes.base/raw-reducible-query
-    "DashboardCard"
-    {:select     [:dc.*]
-     :from       [[:report_dashboardcard :dc]]
-     :left-join  [[:report_dashboard :dash] [:= :dash.id :dc.dashboard_id]
-                  [:collection :coll]       [:= :coll.id :dash.collection_id]]
-     :where      (if user
-                   [:or [:= :coll.personal_owner_id user] [:is :coll.personal_owner_id nil]]
-                   [:is :coll.personal_owner_id nil])}))
+(defmethod serdes.base/extract-query "DashboardCard" [_ {:keys [collection-set]}]
+  (let [dashboards (db/select-ids 'Dashboard :collection_id [:in collection-set])]
+    (db/select-reducible DashboardCard :dashboard_id [:in dashboards])))
 
 (defmethod serdes.base/serdes-dependencies "DashboardCard"
   [{:keys [card_id dashboard_id parameter_mappings visualization_settings]}]
@@ -260,7 +252,11 @@
       (update :visualization_settings serdes.util/import-visualization-settings)))
 
 (defmethod serdes.base/serdes-descendants "DashboardCard" [_model-name id]
-  (let [{:keys [card_id dashboard_id]} (db/select-one DashboardCard :id id)]
+  (let [{:keys [card_id dashboard_id parameter_mappings]} (db/select-one DashboardCard :id id)
+        cards-in-params (set (for [{:keys [card_id]} parameter_mappings
+                                   :when card_id]
+                               ["Card" card_id]))]
     (cond-> #{["Dashboard" dashboard_id]}
       ;; card_id is nil for text cards; in that case there's no Card to depend on.
-      card_id (conj ["Card" card_id]))))
+      card_id               (conj ["Card" card_id])
+      (seq cards-in-params) (set/union cards-in-params))))

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -293,6 +293,7 @@
   ;; There's one optional foreign key: creator_id. Resolve it as an email.
   (cond-> (serdes.base/extract-one-basics "Database" entity)
     true                 (update :creator_id serdes.util/export-user)
+    true                 (dissoc :features) ; This is a synthetic column that isn't in the real schema.
     (= :exclude secrets) (dissoc :details)))
 
 (defmethod serdes.base/serdes-entity-id "Database"

--- a/src/metabase/models/dimension.clj
+++ b/src/metabase/models/dimension.clj
@@ -24,8 +24,8 @@
 
 (defmethod serdes.hash/identity-hash-fields Dimension
   [_dimension]
-  [(serdes.hash/hydrated-hash :field)
-   (serdes.hash/hydrated-hash :human_readable_field)])
+  [(serdes.hash/hydrated-hash :field "<none>")
+   (serdes.hash/hydrated-hash :human_readable_field "<none>")])
 
 ;;; ------------------------------------------------- Serialization --------------------------------------------------
 (defmethod serdes.base/extract-one "Dimension"

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -30,6 +30,12 @@
   model
   instance])
 
+(def ^:dynamic *deserializing?*
+  "This is dynamically bound to true when deserializing. A few pieces of the Toucan magic are undesirable for
+  deserialization. Most notably, we don't want to generate an `:entity_id`, as that would lead to duplicated entities
+  on a future deserialization."
+  false)
+
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                               Toucan Extensions                                                |
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -249,7 +255,10 @@
   :update add-updated-at-timestamp)
 
 (defn- add-entity-id [obj & _]
-  (if (contains? obj :entity_id)
+  (if (or (contains? obj :entity_id)
+          *deserializing?*)
+    ;; Don't generate a new entity_id if either: (a) there's already one set; or (b) we're deserializing.
+    ;; Generating them at deserialization time can lead to duplicated entities if they're deserialized again.
     obj
     (assoc obj :entity_id (u/generate-nano-id))))
 

--- a/src/metabase/models/metric.clj
+++ b/src/metabase/models/metric.clj
@@ -48,7 +48,7 @@
 
 (defmethod serdes.hash/identity-hash-fields Metric
   [_metric]
-  [:name (serdes.hash/hydrated-hash :table)])
+  [:name (serdes.hash/hydrated-hash :table "<none>")])
 
 
 ;;; --------------------------------------------------- REVISIONS ----------------------------------------------------
@@ -82,22 +82,19 @@
   (let [base (serdes.base/infer-self-path "Metric" metric)]
     [(assoc base :label (:name metric))]))
 
-(defmethod serdes.base/extract-query "Metric" [_model-name _opts]
-  (serdes.base/raw-reducible-query "Metric" {:where [:= :archived false]}))
-
 (defmethod serdes.base/extract-one "Metric"
   [_model-name _opts metric]
   (-> (serdes.base/extract-one-basics "Metric" metric)
       (update :table_id   serdes.util/export-table-fk)
       (update :creator_id serdes.util/export-user)
-      (update :definition serdes.util/export-json-mbql)))
+      (update :definition serdes.util/export-mbql)))
 
 (defmethod serdes.base/load-xform "Metric" [metric]
   (-> metric
       serdes.base/load-xform-basics
       (update :table_id   serdes.util/import-table-fk)
       (update :creator_id serdes.util/import-user)
-      (update :definition serdes.util/import-json-mbql)))
+      (update :definition serdes.util/import-mbql)))
 
 (defmethod serdes.base/serdes-dependencies "Metric" [{:keys [definition table_id]}]
   (into [] (set/union #{(serdes.util/table->path table_id)}

--- a/src/metabase/models/native_query_snippet.clj
+++ b/src/metabase/models/native_query_snippet.clj
@@ -43,7 +43,7 @@
 
 (defmethod serdes.hash/identity-hash-fields NativeQuerySnippet
   [_snippet]
-  [:name (serdes.hash/hydrated-hash :collection)])
+  [:name (serdes.hash/hydrated-hash :collection "<none>")])
 
 (defmethod mi/can-read? NativeQuerySnippet
   [& args]
@@ -75,18 +75,10 @@
 
 ;;; ------------------------------------------------- Serialization --------------------------------------------------
 
-(defmethod serdes.base/extract-query "NativeQuerySnippet" [_ {:keys [user]}]
-  ;; TODO This join over the subset of collections this user can see is shared by a few things - factor it out?
-  (serdes.base/raw-reducible-query
-    "NativeQuerySnippet"
-    {:select     [:snippet.*]
-     :from       [[:native_query_snippet :snippet]]
-     :left-join  [[:collection :coll] [:= :coll.id :snippet.collection_id]]
-     :where      (if user
-                   ;; :snippet.collection_id is nullable, but this is a left join, so it works out neatly:
-                   ;; if this snippet has no collection, :coll.personal_owner_id is effectively NULL.
-                   [:or [:= :coll.personal_owner_id user] [:is :coll.personal_owner_id nil]]
-                   [:is :coll.personal_owner_id nil])}))
+(defmethod serdes.base/extract-query "NativeQuerySnippet" [_ {:keys [collection-set]}]
+  (eduction cat [(db/select-reducible NativeQuerySnippet :collection_id nil)
+                 (when (seq collection-set)
+                   (db/select-reducible NativeQuerySnippet :collection_id [:in collection-set]))]))
 
 (defmethod serdes.base/serdes-generate-path "NativeQuerySnippet" [_ snippet]
   [(assoc (serdes.base/infer-self-path "NativeQuerySnippet" snippet)

--- a/src/metabase/models/pulse.clj
+++ b/src/metabase/models/pulse.clj
@@ -137,7 +137,7 @@
 
 (defmethod serdes.hash/identity-hash-fields Pulse
   [_pulse]
-  [:name (serdes.hash/hydrated-hash :collection)])
+  [:name (serdes.hash/hydrated-hash :collection "<none>")])
 
 (def ^:private ^:dynamic *automatically-archive-when-last-channel-is-deleted*
   "Should we automatically archive a Pulse when its last `PulseChannel` is deleted? Normally we do, but this is disabled

--- a/src/metabase/models/pulse_card.clj
+++ b/src/metabase/models/pulse_card.clj
@@ -67,12 +67,13 @@
   (cond-> (serdes.base/load-xform-basics card)
     true                      (update :card_id            serdes.util/import-fk 'Card)
     true                      (update :pulse_id           serdes.util/import-fk 'Pulse)
+    true                      (dissoc :dashboard_id)
     (:dashboard_card_id card) (update :dashboard_card_id  serdes.util/import-fk 'DashboardCard)))
 
 ;; Depends on the Pulse, Card and (optional) dashboard card.
 (defmethod serdes.base/serdes-dependencies "PulseCard" [{:keys [card_id dashboard_card_id pulse_id]}]
   (let [base [[{:model "Card" :id card_id}]
               [{:model "Pulse" :id pulse_id}]]]
-    (if dashboard_card_id
-      (conj base [{:model "DashboardCard" :id dashboard_card_id}])
+    (if-let [[dash-id dc-id] dashboard_card_id]
+      (conj base [{:model "Dashboard" :id dash-id} {:model "DashboardCard" :id dc-id}])
       base)))

--- a/src/metabase/models/pulse_channel.clj
+++ b/src/metabase/models/pulse_channel.clj
@@ -376,7 +376,10 @@
       (update :pulse_id serdes.util/import-fk 'Pulse)))
 
 (defn- import-recipients [channel-id emails]
-  (let [incoming-users (db/select-ids 'User :email [:in emails])
+  (let [incoming-users (set (for [email emails
+                                  :let [id (db/select-one-id 'User :email email)]]
+                              (or id
+                                  (:id (user/serdes-synthesize-user! {:email email})))))
         current-users  (set (db/select-field :user_id PulseChannelRecipient :pulse_channel_id channel-id))
         combined       (set/union incoming-users current-users)]
     (when-not (empty? combined)
@@ -385,14 +388,15 @@
 ;; Customized load-insert! and load-update! to handle the embedded recipients field - it's really a separate table.
 (defmethod serdes.base/load-insert! "PulseChannel" [_ ingested]
   (let [;; Call through to the default load-insert!
-        id ((get-method serdes.base/load-insert! "") "PulseChannel" (dissoc ingested :recipients))]
-    (import-recipients id (:recipients ingested))))
+        chan ((get-method serdes.base/load-insert! "") "PulseChannel" (dissoc ingested :recipients))]
+    (import-recipients (:id chan) (:recipients ingested))
+    chan))
 
 (defmethod serdes.base/load-update! "PulseChannel" [_ ingested local]
   ;; Call through to the default load-update!
-  ((get-method serdes.base/load-update! "") "PulseChannel" (dissoc ingested :recipients) local)
-  (import-recipients (:id local) (:recipients ingested))
-  (:id local))
+  (let [chan ((get-method serdes.base/load-update! "") "PulseChannel" (dissoc ingested :recipients) local)]
+    (import-recipients (:id local) (:recipients ingested))
+    chan))
 
 ;; Depends on the Pulse.
 (defmethod serdes.base/serdes-dependencies "PulseChannel" [{:keys [pulse_id]}]

--- a/src/metabase/models/segment.clj
+++ b/src/metabase/models/segment.clj
@@ -87,14 +87,14 @@
   (-> (serdes.base/extract-one-basics "Segment" segment)
       (update :table_id   serdes.util/export-table-fk)
       (update :creator_id serdes.util/export-user)
-      (update :definition serdes.util/export-json-mbql)))
+      (update :definition serdes.util/export-mbql)))
 
 (defmethod serdes.base/load-xform "Segment" [segment]
   (-> segment
       serdes.base/load-xform-basics
       (update :table_id   serdes.util/import-table-fk)
       (update :creator_id serdes.util/import-user)
-      (update :definition serdes.util/import-json-mbql)))
+      (update :definition serdes.util/import-mbql)))
 
 (defmethod serdes.base/serdes-dependencies "Segment" [{:keys [definition table_id]}]
   (into [] (set/union #{(serdes.util/table->path table_id)}

--- a/src/metabase/models/serialization/base.clj
+++ b/src/metabase/models/serialization/base.clj
@@ -166,20 +166,11 @@
 
   Keyed on the model name, the first argument.
 
-  Returns a reducible stream of maps with `:serdes/meta` keys on them. It should *not* be a stream of Toucan entities,
-  but vanilla Clojure maps.
+  Returns a reducible stream of modeled Toucan maps.
 
-  In fact, Toucan's high-level niceties (eg. expanding JSON-encoded fields to Clojure data, decrypting, type
-  conversions, or hydrating some relationship by default) are counterproductive when our goal is a database-level
-  export. As a specific example, [[db/simple-select]] expands JSON but [[db/simple-insert!]] doesn't put it back.
-  There's also no `simple-update!`, making a fresh insert diverge from an update.
+  Defaults to using `(toucan.db/select model)` for the entire table.
 
-  Defaults to using the helper `(raw-reducible-query model)` for the entire table, which is equivalent to
-  `(db/simple-select-reducible model)` but without running post-select handlers. This returns vanilla maps, not
-  [[db/IModel]] instances.
-
-  You may want to override this to eg. skip archived entities, or otherwise filter what gets serialized. Prefer using
-  the two-argument form of [[raw-reducible-query]]."
+  You may want to override this to eg. skip archived entities, or otherwise filter what gets serialized."
   (fn [model _] model))
 
 (defmulti extract-one
@@ -205,27 +196,8 @@
   (eduction (map (partial extract-one model opts))
             (extract-query model opts)))
 
-(defn- model-name->table
-  "The model name is not necessarily the table name. This pulls the table name from the Toucan model."
-  [model-name]
-  (-> model-name
-      symbol
-      db/resolve-model
-      :table))
-
-(defn raw-reducible-query
-  "Helper for calling Toucan's raw [[db/reducible-query]]. With just the model name, fetches everything. You can filter
-  with a HoneySQL map like `{:where [:= :archived true]}`.
-
-  Returns a reducible stream of JDBC row maps."
-  ([model-name]
-   (raw-reducible-query model-name nil))
-  ([model-name honeysql-form]
-   (db/reducible-query (merge {:select [:*] :from [(model-name->table model-name)]}
-                              honeysql-form))))
-
 (defmethod extract-query :default [model-name _]
-  (raw-reducible-query model-name))
+  (db/select (symbol model-name)))
 
 (defn extract-one-basics
   "A helper for writing [[extract-one]] implementations. It takes care of the basics:
@@ -238,9 +210,9 @@
   [model-name entity]
   (let [model (db/resolve-model (symbol model-name))
         pk    (models/primary-key model)]
-    (-> entity
-      (assoc :serdes/meta (serdes-generate-path model-name entity))
-      (dissoc pk :updated_at))))
+    (-> (into {} entity)
+        (assoc :serdes/meta (serdes-generate-path model-name entity))
+        (dissoc pk :updated_at))))
 
 (defmethod extract-one :default [model-name _opts entity]
   (extract-one-basics model-name entity))
@@ -292,7 +264,6 @@
 ;;;     - `(load-update! ingested local-entity)` if the local entity exists, or
 ;;;     - `(load-insert! ingested)` if the entity is new.
 ;;;   Both of these have the obvious defaults of [[jdbc/update!]] or [[jdbc/insert!]].
-
 (defn- ingested-model
   "The dispatch function for several of the load multimethods: dispatching on the model of the incoming entity."
   [ingested]
@@ -341,7 +312,7 @@
 
 (defmulti load-xform
   "Given the incoming vanilla map as ingested, transform it so it's suitable for sending to the database (in eg.
-  [[db/simple-insert!]]).
+  [[db/insert!]]).
   For example, this should convert any foreign keys back from a portable entity ID or identity hash into a numeric
   database ID. This is the mirror of [[extract-one]], in spirit. (They're not strictly inverses - [[extract-one]] drops
   the primary key but this need not put one back, for example.)
@@ -372,49 +343,36 @@
 
   Keyed on the model name (the first argument), because the second argument doesn't have its `:serdes/meta` anymore.
 
-  Returns the primary key of the updated entity."
+  Returns the updated entity."
   {:arglists '([model-name ingested local])}
   (fn [model _ _] model))
 
 (defmethod load-update! :default [model-name ingested local]
   (let [model    (db/resolve-model (symbol model-name))
         pk       (models/primary-key model)
-        id       (get local pk)
-        adjusted (if (-> model models/properties :timestamped?)
-                   (assoc ingested :updated_at (mi/now))
-                   ingested)]
+        id       (get local pk)]
     (log/tracef "Upserting %s %d: old %s new %s" model-name id (pr-str local) (pr-str ingested))
-    ;; Using the two-argument form of [[db/update!]] that takes the model and a HoneySQL form for the actual update.
-    ;; It works differently from the more typical `(db/update! 'Model id updates...)` form: this form doesn't run any of
-    ;; the pre-update magic, it just updates the database directly.
-    ;; Therefore we manually set the :updated_at time.
-    (db/update! model {:where [:= pk id] :set adjusted})
-    id))
+    (db/update! model id ingested)
+    (db/select-one model pk id)))
 
 (defmulti load-insert!
   "Called by the default [[load-one!]] if there is no corresponding entity already in the appdb.
   `(load-insert! \"ModelName\" ingested-and-xformed)`
 
-  Defaults to a straightforward [[db/simple-insert!]], and you probably don't need to implement this.
-  Note that [[db/insert!]] should be avoided - we don't want to populate the `:entity_id` field if it wasn't already
-  set!
+  Defaults to a straightforward [[db/insert!]], and you probably don't need to implement this.
+
+  Note that any [[db/insert!]] behavior we don't want to run (like generating an `:entity_id`!) should be skipped based
+  on the [[mi/*deserializing?*]] dynamic var.
 
   Keyed on the model name (the first argument), because the second argument doesn't have its `:serdes/meta` anymore.
 
-  Returns the primary key of the newly inserted entity."
+  Returns the newly inserted entity."
   {:arglists '([model ingested])}
   (fn [model _] model))
 
-(defmethod load-insert! :default [model ingested]
-  (log/tracef "Inserting %s: %s" model (pr-str ingested))
-  ; Toucan's simple-insert! actually does the right thing for our purposes: it doesn't call pre-insert or post-insert,
-  ; and it returns the new primary key.
-  (let [model    (db/resolve-model (symbol model))
-        adjusted (if (-> model models/properties :timestamped?)
-                   (let [now (mi/now)]
-                     (assoc ingested :created_at now :updated_at now))
-                   ingested)]
-    (db/simple-insert! model adjusted)))
+(defmethod load-insert! :default [model-name ingested]
+  (log/tracef "Inserting %s: %s" model-name (pr-str ingested))
+  (db/insert! (symbol model-name) ingested))
 
 (defmulti load-one!
   "Black box for integrating a deserialized entity into this appdb.
@@ -438,9 +396,10 @@
   (let [model    (ingested-model ingested)
         pkey     (models/primary-key (db/resolve-model (symbol model)))
         adjusted (load-xform ingested)]
-    (if (nil? maybe-local-id)
-      (load-insert! model adjusted)
-      (load-update! model adjusted (db/select-one (symbol model) pkey maybe-local-id)))))
+    (binding [mi/*deserializing?* true]
+      (if (nil? maybe-local-id)
+        (load-insert! model adjusted)
+        (load-update! model adjusted (db/select-one (symbol model) pkey maybe-local-id))))))
 
 (defmulti serdes-descendants
   "Captures the notion that eg. a dashboard \"contains\" its cards.

--- a/src/metabase/models/serialization/hash.clj
+++ b/src/metabase/models/serialization/hash.clj
@@ -81,13 +81,15 @@
 (defn hydrated-hash
   "Many entities reference other entities. Using the autoincrementing ID is not portable, so we use the identity hash
   of the referenced entity. This is a helper for writing [[identity-hash-fields]]."
-  [hydration-key]
-  (fn [entity]
-    (let [hydrated-value (get (hydrate entity hydration-key) hydration-key)]
-      (when (nil? hydrated-value)
-        (throw (ex-info (tru "Error calculating hydrated hash: {0} is nil after hydrating {1}"
-                             (pr-str hydration-key)
-                             (name entity))
-                        {:entity        entity
-                         :hydration-key hydration-key})))
-      (identity-hash hydrated-value))))
+  ([hydration-key] (hydrated-hash hydration-key nil))
+  ([hydration-key default]
+   (fn [entity]
+     (let [hydrated-value (get (hydrate entity hydration-key) hydration-key)]
+       (cond
+         hydrated-value (identity-hash hydrated-value)
+         default        default
+         :else          (throw (ex-info (tru "Error calculating hydrated hash: {0} is nil after hydrating {1}"
+                                             (pr-str hydration-key)
+                                             (name entity))
+                                        {:entity        entity
+                                         :hydration-key hydration-key})))))))

--- a/src/metabase/models/timeline_event.clj
+++ b/src/metabase/models/timeline_event.clj
@@ -35,6 +35,14 @@
 
 ;;;; hydration
 
+(defn timeline
+  "Attach the parent `:timeline` to this [[TimelineEvent]]."
+  {:hydrate :timeline}
+  [{:keys [timeline_id]}]
+  (db/select-one 'Timeline :id timeline_id))
+
+;(hydrate (db/select-one 'TimelineEvent))
+
 (defn- fetch-events
   "Fetch events for timelines in `timeline-ids`. Can include optional `start` and `end` dates in the options map, as
   well as `all?`. By default, will return only unarchived events, unless `all?` is truthy and will return all events

--- a/test/metabase/test/generate.clj
+++ b/test/metabase/test/generate.clj
@@ -301,7 +301,7 @@
                (get-in [:table-fields (:table_id visit-val)])))
 
     ;; Users' emails need to be unique. This enforces it, and appends junk to before the @ if needed.
-    (= ent-type :core_user)
+    (= ent-type :core-user)
     (update :email unique-email)
 
     ;; Database names need to be unique. This enforces it, and appends junk to names if needed.


### PR DESCRIPTION
Previously, some automatic behavior was causing problems in serdes.
(The worst example is generating an `entity_id` on insert while
deserializing an entity we don't own - if deserialized again it would be
duplicated.)

A whole cascade of design choices fell out of this problem:
- `insert!` would generate `entity_id`s, so use `simple-insert!`
- But `simple-insert!` doesn't convert eg. MBQL `:definition` maps back
  into JSON strings
- We got the maps as Clojure data and not JSON strings because `select`
  and `simple-select` both run `post-select` and parse the JSON.
- So we ended up with a raw query on the select side and `simple-insert!`
  on the storage side.

This change unwinds that whole stack, and instead uses a dynamic
var to suppress the few pieces of `pre-insert` and `pre-update` logic
that causes problems.

The end result is much cleaner, and much more consistent with the rest
of Metabase's backend logic.
