### PR TITLE
[Apps] Disable data-apps prior to release

### DIFF
--- a/src/metabase/actions.clj
+++ b/src/metabase/actions.clj
@@ -7,6 +7,7 @@
    [metabase.mbql.normalize :as mbql.normalize]
    [metabase.mbql.schema :as mbql.s]
    [metabase.mbql.util :as mbql.u]
+   [metabase.models.action :as action]
    [metabase.models.database :refer [Database]]
    [metabase.models.setting :as setting]
    [metabase.util :as u]
@@ -42,6 +43,17 @@
       (handler request respond raise)
       (raise (ex-info (i18n/tru "Actions are not enabled.")
                       {:status-code 400})))))
+
+(defn +check-data-apps-enabled
+  "Ring middleware that checks that the [[metabase.model.action/check-data-apps-enabled]], and
+  returns a 400 response if not"
+  [handler]
+  (fn [request respond raise]
+    (try
+      (action/check-data-apps-enabled)
+      (catch Exception e
+        (raise e)))
+    (handler request respond raise)))
 
 (defmulti normalize-action-arg-map
   "Normalize the `arg-map` passed to [[perform-action!]] for a specific `action`."

--- a/src/metabase/api/action.clj
+++ b/src/metabase/api/action.clj
@@ -110,4 +110,4 @@
   (db/update! HTTPAction id action)
   (first (hydrate (action/select-actions :id id) :action/emitter-usages)))
 
-(api/define-routes actions/+check-actions-enabled)
+(api/define-routes actions/+check-actions-enabled actions/+check-data-apps-enabled)

--- a/src/metabase/api/app.clj
+++ b/src/metabase/api/app.clj
@@ -4,6 +4,7 @@
     [clojure.walk :as walk]
     [compojure.core :refer [POST PUT]]
     [medley.core :as m]
+    [metabase.actions :as actions]
     [metabase.api.card :as api.card]
     [metabase.api.collection :as api.collection]
     [metabase.api.common :as api]
@@ -368,4 +369,4 @@
         dejsonify-graph
         update-graph!)))
 
-(api/define-routes)
+(api/define-routes actions/+check-data-apps-enabled)

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -13,6 +13,7 @@
             [metabase.automagic-dashboards.populate :as populate]
             [metabase.events :as events]
             [metabase.mbql.util :as mbql.u]
+            [metabase.models.action :as action]
             [metabase.models.card :refer [Card]]
             [metabase.models.collection :as collection]
             [metabase.models.dashboard :as dashboard :refer [Dashboard]]
@@ -76,6 +77,7 @@
    collection_id       (s/maybe su/IntGreaterThanZero)
    collection_position (s/maybe su/IntGreaterThanZero)
    is_app_page         (s/maybe s/Bool)}
+  (when is_app_page (action/check-data-apps-enabled))
   ;; if we're trying to save the new dashboard in a Collection make sure we have permissions to do that
   (collection/check-write-perms-for-collection collection_id)
   (let [dashboard-data {:name                name
@@ -287,6 +289,7 @@
    collection_position     (s/maybe su/IntGreaterThanZero)
    cache_ttl               (s/maybe su/IntGreaterThanZero)
    is_app_page             (s/maybe s/Bool)}
+  (when is_app_page (action/check-data-apps-enabled))
   (let [dash-before-update (api/write-check Dashboard id)]
     ;; Do various permissions checks as needed
     (collection/check-allowed-to-change-collection dash-before-update dash-updates)
@@ -704,6 +707,7 @@
   {dashboard-id su/IntGreaterThanZero
    dashcard-id su/IntGreaterThanZero
    slug su/NonBlankString}
+  (action/check-data-apps-enabled)
   (throw (UnsupportedOperationException. "Not implemented")))
 
 (api/defendpoint POST "/:dashboard-id/dashcard/:dashcard-id/execute/:slug"
@@ -716,6 +720,7 @@
    dashcard-id su/IntGreaterThanZero
    slug su/NonBlankString
    parameters (s/maybe {s/Keyword s/Any})}
+  (action/check-data-apps-enabled)
   ;; Undo middleware string->keyword coercion
   (actions.execution/execute-dashcard! dashboard-id dashcard-id slug (update-keys parameters name)))
 

--- a/src/metabase/api/model_action.clj
+++ b/src/metabase/api/model_action.clj
@@ -52,4 +52,4 @@
     (db/delete! Action :id action_id)
     api/generic-204-no-content))
 
-(api/define-routes actions/+check-actions-enabled)
+(api/define-routes actions/+check-actions-enabled actions/+check-data-apps-enabled)

--- a/src/metabase/api/permissions.clj
+++ b/src/metabase/api/permissions.clj
@@ -7,6 +7,7 @@
             [metabase.api.common.validation :as validation]
             [metabase.api.permission-graph :as api.permission-graph]
             [metabase.models :refer [PermissionsGroupMembership User]]
+            [metabase.models.action :as action]
             [metabase.models.permissions :as perms]
             [metabase.models.permissions-group :as perms-group :refer [PermissionsGroup]]
             [metabase.public-settings.premium-features :as premium-features]
@@ -221,6 +222,7 @@
   "Fetch a graph of execution permissions."
   []
   (api/check-superuser)
+  (action/check-data-apps-enabled)
   (perms/execution-perms-graph))
 
 (api/defendpoint PUT "/execution/graph"
@@ -233,6 +235,7 @@
   [:as {body :body}]
   {body su/Map}
   (api/check-superuser)
+  (action/check-data-apps-enabled)
   (let [graph (api.permission-graph/converted-json->graph ::api.permission-graph/execution-permissions-graph body)]
     (when (= graph :clojure.spec.alpha/invalid)
       (throw (ex-info (tru "Invalid execution permission graph: {0}"

--- a/src/metabase/models/action.clj
+++ b/src/metabase/models/action.clj
@@ -5,11 +5,23 @@
             [metabase.models.interface :as mi]
             [metabase.models.query :as query]
             [metabase.models.serialization.hash :as serdes.hash]
+            [metabase.shared.util.i18n :as i18n]
             [metabase.util :as u]
             [metabase.util.encryption :as encryption]
             [toucan.db :as db]
             [toucan.hydrate :refer [hydrate]]
             [toucan.models :as models]))
+
+(def ^:private ^:dynamic *data-apps-enabled*
+  "Should only be rebound from tests."
+  false)
+
+(defn check-data-apps-enabled
+  "Flag to short-circuit any data-apps functionality."
+  []
+  (when-not *data-apps-enabled*
+    (throw (ex-info (i18n/tru "Data apps are not enabled.")
+                    {:status-code 400}))))
 
 (models/defmodel QueryAction :query_action)
 (models/defmodel HTTPAction :http_action)
@@ -27,7 +39,8 @@
 (u/strict-extend #_{:clj-kondo/ignore [:metabase/disallow-class-or-type-on-model]} (class Action)
   models/IModel
   (merge models/IModelDefaults
-         {:types      (constantly {:type :keyword})
+         {:pre-insert (fn [action] (check-data-apps-enabled) action)
+          :types      (constantly {:type :keyword})
           :properties (constantly {:timestamped? true})}))
 
 (defn- pre-update
@@ -60,7 +73,8 @@
 (u/strict-extend #_{:clj-kondo/ignore [:metabase/disallow-class-or-type-on-model]} (class ModelAction)
   models/IModel
   (merge models/IModelDefaults
-         {:properties (constantly {:entity_id    true})
+         {:pre-insert (fn [model-action] (check-data-apps-enabled) model-action)
+          :properties (constantly {:entity_id    true})
           :types      (constantly {:parameter_mappings     :parameters-list
                                    :visualization_settings :visualization-settings})}))
 
@@ -73,6 +87,7 @@
 (defn insert!
   "Inserts an Action and related HTTPAction or QueryAction. Returns the action id."
   [action-data]
+  (check-data-apps-enabled)
   (db/transaction
     (let [action (db/insert! Action {:type (:type action-data)})
           model (case (keyword (:type action))

--- a/src/metabase/models/app.clj
+++ b/src/metabase/models/app.clj
@@ -1,5 +1,6 @@
 (ns metabase.models.app
-  (:require [metabase.models.collection :as collection :refer [Collection]]
+  (:require [metabase.models.action :as action]
+            [metabase.models.collection :as collection :refer [Collection]]
             [metabase.models.interface :as mi]
             [metabase.models.query :as query]
             [metabase.models.serialization.hash :as serdes.hash]
@@ -24,7 +25,8 @@
 (u/strict-extend #_{:clj-kondo/ignore [:metabase/disallow-class-or-type-on-model]} (class App)
   models/IModel
   (merge models/IModelDefaults
-         {:types (constantly {:options :json
+         {:pre-insert (fn [app] (action/check-data-apps-enabled) app)
+          :types (constantly {:options :json
                               :nav_items :json})
           :properties (constantly {:timestamped? true
                                    :entity_id    true})}))

--- a/test/metabase/test.clj
+++ b/test/metabase/test.clj
@@ -15,6 +15,7 @@
             [metabase.driver.sql.query-processor-test-util :as sql.qp-test-util]
             [metabase.email-test :as et]
             [metabase.http-client :as client]
+            [metabase.models.action :as action]
             [metabase.plugins.classloader :as classloader]
             [metabase.query-processor :as qp]
             [metabase.query-processor-test :as qp.test]
@@ -47,6 +48,7 @@
 
 (humane-are/install!)
 (humane-test-output/activate!)
+(alter-var-root #'action/*data-apps-enabled* (constantly true))
 
 ;; Fool the linters into thinking these namespaces are used! See discussion on
 ;; https://github.com/clojure-emacs/refactor-nrepl/pull/270


### PR DESCRIPTION
This ensures that the api endpoints and the relevant models cannot be created.

We enable during testing, so that we can ensure the integration points like permissions, search, collection items, etc... will continue to be tested.