### PR TITLE
hide pie chart legend on small dashboard cards

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChartWithLegend.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartWithLegend.jsx
@@ -16,6 +16,7 @@ class ChartWithLegend extends Component {
   static defaultProps = {
     aspectRatio: 1,
     style: {},
+    showLegend: true,
   };
 
   render() {
@@ -52,12 +53,11 @@ class ChartWithLegend extends Component {
     let type;
     let LegendComponent;
     const isHorizontal = gridSize.width > gridSize.height / GRID_ASPECT_RATIO;
-    if (showLegend === false) {
+    if (!showLegend) {
       type = "small";
     } else if (
       !gridSize ||
-      (isHorizontal &&
-        (showLegend || gridSize.width > 4 || gridSize.height > 4))
+      (isHorizontal && (gridSize.width > 4 || gridSize.height > 4))
     ) {
       type = "horizontal";
       LegendComponent = LegendVertical;
@@ -73,10 +73,7 @@ class ChartWithLegend extends Component {
         chartWidth = desiredWidth;
       }
       chartHeight = height;
-    } else if (
-      !isHorizontal &&
-      (showLegend || (gridSize.height > 3 && gridSize.width > 2))
-    ) {
+    } else if (!isHorizontal && gridSize.height > 3 && gridSize.width > 2) {
       type = "vertical";
       LegendComponent = LegendHorizontal;
       legendTitles = legendTitles.map(title =>
@@ -84,7 +81,6 @@ class ChartWithLegend extends Component {
       );
       const desiredHeight = width * (1 / aspectRatio);
       if (desiredHeight > height * (3 / 4)) {
-        // chartHeight = height * (3 / 4);
         flexChart = true;
       } else {
         chartHeight = desiredHeight;


### PR DESCRIPTION
Fixes [Slack thread](https://metaboat.slack.com/archives/C03SD8HDJLC/p1666025410159739)

## Changes

The `ChartWithLegend` component used for Pie and ChoroplethMap legends supported generally 3 states with `showLegend` boolean prop:
- `undefined`: chart legend is generally visible except for small dashboard cards
- `true`: chart legend is always visible
- `false`: chart legend is always invisible

`ChoroplethMap` did not provide the prop, so it was undefined. On the other hand, the pie visualization allowed all 3 states. When the setting has not changed it was undefined and it showed the legend even though the setting toggle was turned off. So when I added a default `true` value in this PR https://github.com/metabase/metabase/pull/25202 the first behavior for `undefined` has become unavailable but this is actually the behavior we want to have for enabled legend.

## How to verify

1) Create a pie chart, don't touch the "Show legend" setting but ensure it is enabled by default
2) Add it to a dashboard
3) Ensure on small dashboard cards we hide the legend but show it when a card is large enough
4) Disable the setting, and ensure it is not visible on any size dashboard cards
5) Enable the setting again, and ensure it behaves as it is described in the third step

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/25983)
<!-- Reviewable:end -->
