### PR TITLE
Fix dropped joins when saving model after updating its metadata

### DIFF
--- a/frontend/src/metabase/query_builder/actions/core/core.js
+++ b/frontend/src/metabase/query_builder/actions/core/core.js
@@ -231,7 +231,10 @@ export const apiUpdateQuestion = (question, { rerunQuery } = {}) => {
 
     const resultsMetadata = getResultsMetadata(getState());
     const questionToUpdate = questionWithVizSettings
-      .setQuery(question.query().clean())
+      // Before we clean the query, we make sure question is not treated as a dataset
+      // as calling table() method down the line would bring unwanted consequences
+      // such as dropping joins (as joins are treated differently between pure questions and datasets)
+      .setQuery(question.setDataset(false).query().clean())
       .setResultsMetadata(resultsMetadata);
 
     // When viewing a dataset, its dataset_query is swapped with a clean query using the dataset as a source table


### PR DESCRIPTION
### How to test

1. Create a model like below:
  a. Data: Orders (pick just Total and Quantity fields from it) 
  b. Join Orders › Products (pick just Category and Vendor fields from it)
  c. Row limit: 4 or thereabouts
  
2. Save

3. Edit Metadata

4. Change a field's display name or description

5. Rerun query

Join should not be lost, metadata should not be lost.

Loom of issue: https://www.loom.com/share/490f68ecc3a549c989e22cf78d3c9de3