### PR TITLE
Data apps/prefetch values frontend

### DIFF
--- a/frontend/src/metabase/modes/components/drill/ActionClickDrill/utils.ts
+++ b/frontend/src/metabase/modes/components/drill/ActionClickDrill/utils.ts
@@ -22,7 +22,11 @@ export function getDashcardParamValues(
   dashcard: ActionDashboardCard,
   parameterValues: { [id: string]: ParameterValueOrArray },
 ): ParametersForActionExecution {
-  if (!dashcard.action || !dashcard?.parameter_mappings?.length) {
+  if (
+    !dashcard.action ||
+    !dashcard?.parameter_mappings?.length ||
+    !parameterValues
+  ) {
     return {};
   }
   const { action, parameter_mappings } = dashcard;
@@ -39,6 +43,9 @@ export function prepareParameter(
   action: WritebackAction,
   parameterValues: { [id: string]: ParameterValueOrArray },
 ): ActionParameterTuple | undefined {
+  if (!action?.parameters?.length) {
+    return;
+  }
   const { parameter_id: sourceParameterId, target: actionParameterTarget } =
     mapping;
 


### PR DESCRIPTION
## Description

After https://github.com/metabase/metabase/pull/25924, this became pretty simply a matter of loading in initialValues for the ActionParametersInputForm when we have an action with the slug `update`.

In the future, we should be able to change what triggers the value prefetch to allow custom actions to use this endpoint as well.

Prefetches values in inline forms

![inline update](https://user-images.githubusercontent.com/30528226/196522973-34a48253-0c21-463c-9cec-f53b4181e5bf.gif)

Prefetches values in modal forms

![modalUpdate](https://user-images.githubusercontent.com/30528226/196523007-1a45df76-625a-4ed1-a37e-d487e473099a.gif)


prefetches values for scaffolded tables

![Screen Shot 2022-10-18 at 1 12 06 PM](https://user-images.githubusercontent.com/30528226/196523047-99fa60bc-9899-476e-8e27-4b5115fb2fc5.png)


