### PR TITLE
Make data apps data picker controlled

### DIFF
--- a/frontend/src/metabase/containers/DataPicker/DataPicker.tsx
+++ b/frontend/src/metabase/containers/DataPicker/DataPicker.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+
+import type { DataPickerProps } from "./types";
+import RawDataPanePicker from "./RawDataPanePicker";
+
+function DataPicker(props: DataPickerProps) {
+  return <RawDataPanePicker {...props} />;
+}
+
+export default DataPicker;

--- a/frontend/src/metabase/containers/DataPicker/RawDataPanePicker/useSelectedTables.ts
+++ b/frontend/src/metabase/containers/DataPicker/RawDataPanePicker/useSelectedTables.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import type { TableId } from "metabase-types/api";
 
@@ -14,6 +14,10 @@ function useSelectedTables({
   const [selectedTableIds, setSelectedTableIds] = useState(
     new Set(initialValues),
   );
+
+  useEffect(() => {
+    setSelectedTableIds(new Set(initialValues));
+  }, [initialValues]);
 
   const addSelectedTableId = useCallback(
     (id: TableId) => {

--- a/frontend/src/metabase/containers/DataPicker/index.ts
+++ b/frontend/src/metabase/containers/DataPicker/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./DataPicker";
+export { default as useDataPickerValue } from "./useDataPickerValue";

--- a/frontend/src/metabase/containers/DataPicker/types.ts
+++ b/frontend/src/metabase/containers/DataPicker/types.ts
@@ -1,0 +1,14 @@
+import type Database from "metabase-lib/lib/metadata/Database";
+import type Table from "metabase-lib/lib/metadata/Table";
+import type Schema from "metabase-lib/lib/metadata/Schema";
+
+export type DataPickerValue = {
+  databaseId?: Database["id"];
+  schemaId?: Schema["id"];
+  tableIds: Table["id"][];
+};
+
+export interface DataPickerProps {
+  value: DataPickerValue;
+  onChange: (value: DataPickerValue) => void;
+}

--- a/frontend/src/metabase/containers/DataPicker/useDataPickerValue.ts
+++ b/frontend/src/metabase/containers/DataPicker/useDataPickerValue.ts
@@ -1,0 +1,44 @@
+import { useCallback, useState } from "react";
+
+import { DataPickerValue } from "./types";
+
+function cleanSchemaValue({ databaseId, schemaId }: Partial<DataPickerValue>) {
+  return databaseId ? schemaId : undefined;
+}
+
+function cleanTablesValue({
+  databaseId,
+  schemaId,
+  tableIds,
+}: Partial<DataPickerValue>) {
+  if (!tableIds) {
+    return [];
+  }
+  return databaseId && schemaId ? tableIds : [];
+}
+
+function cleanValue(value: Partial<DataPickerValue>): DataPickerValue {
+  return {
+    databaseId: value.databaseId,
+    schemaId: cleanSchemaValue(value),
+    tableIds: cleanTablesValue(value),
+  };
+}
+
+type HookResult = [DataPickerValue, (value: DataPickerValue) => void];
+
+function useDataPickerValue(
+  initialValue: Partial<DataPickerValue> = {},
+): HookResult {
+  const [value, _setValue] = useState<DataPickerValue>(
+    cleanValue(initialValue),
+  );
+
+  const setValue = useCallback((nextValue: DataPickerValue) => {
+    _setValue(cleanValue(nextValue));
+  }, []);
+
+  return [value, setValue];
+}
+
+export default useDataPickerValue;

--- a/frontend/src/metabase/writeback/containers/CreateDataAppModal/CreateDataAppModal.tsx
+++ b/frontend/src/metabase/writeback/containers/CreateDataAppModal/CreateDataAppModal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback } from "react";
 import { t } from "ttag";
 import { connect } from "react-redux";
 import { push } from "react-router-redux";
@@ -10,9 +10,9 @@ import * as Urls from "metabase/lib/urls";
 
 import DataApps, { ScaffoldNewAppParams } from "metabase/entities/data-apps";
 
-import RawDataPanePicker from "metabase/containers/DataPicker/RawDataPanePicker";
+import DataPicker, { useDataPickerValue } from "metabase/containers/DataPicker";
 
-import type { DataApp, TableId } from "metabase-types/api";
+import type { DataApp } from "metabase-types/api";
 import type { Dispatch, State } from "metabase-types/store";
 
 import {
@@ -48,7 +48,9 @@ function mapDispatchToProps(dispatch: Dispatch) {
 }
 
 function CreateDataAppModal({ onCreate, onChangeLocation, onClose }: Props) {
-  const [tableIds, setTableIds] = useState<TableId[]>([]);
+  const [value, setValue] = useDataPickerValue();
+
+  const { tableIds } = value;
 
   const handleCreate = useCallback(async () => {
     const dataApp = await onCreate({
@@ -67,7 +69,7 @@ function CreateDataAppModal({ onCreate, onChangeLocation, onClose }: Props) {
         <ModalTitle>{t`Pick your starting data`}</ModalTitle>
       </ModalHeader>
       <ModalBody>
-        <RawDataPanePicker onTablesChange={setTableIds} />
+        <DataPicker value={value} onChange={setValue} />
       </ModalBody>
       <ModalFooter>
         <Button onClick={onClose}>{t`Cancel`}</Button>

--- a/frontend/src/metabase/writeback/containers/ScaffoldDataAppPagesModal/ScaffoldDataAppPagesModal.tsx
+++ b/frontend/src/metabase/writeback/containers/ScaffoldDataAppPagesModal/ScaffoldDataAppPagesModal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback } from "react";
 import { t } from "ttag";
 import { connect } from "react-redux";
 
@@ -6,9 +6,9 @@ import Button from "metabase/core/components/Button";
 
 import DataApps, { ScaffoldNewPagesParams } from "metabase/entities/data-apps";
 
-import RawDataPanePicker from "metabase/containers/DataPicker/RawDataPanePicker";
+import DataPicker, { useDataPickerValue } from "metabase/containers/DataPicker";
 
-import type { DataApp, TableId } from "metabase-types/api";
+import type { DataApp } from "metabase-types/api";
 import type { Dispatch, State } from "metabase-types/store";
 
 import {
@@ -48,7 +48,8 @@ function ScaffoldDataAppPagesModal({
   onScaffold,
   onClose,
 }: Props) {
-  const [tableIds, setTableIds] = useState<TableId[]>([]);
+  const [value, setValue] = useDataPickerValue();
+  const { tableIds } = value;
 
   const handleAdd = useCallback(async () => {
     const dataApp = await onScaffold({
@@ -67,7 +68,7 @@ function ScaffoldDataAppPagesModal({
         <ModalTitle>{t`Pick your data`}</ModalTitle>
       </ModalHeader>
       <ModalBody>
-        <RawDataPanePicker onTablesChange={setTableIds} />
+        <DataPicker value={value} onChange={setValue} />
       </ModalBody>
       <ModalFooter>
         <Button onClick={onClose}>{t`Cancel`}</Button>


### PR DESCRIPTION
Essentially makes `DataPicker` introduced in #25997 a controlled component (accepting `value` via props and triggering updates via `onChange` callback).

The PR introduces a pair of `value` and `onChange` props as opposed to a set of props like `selectedDatabaseId` + `onDatabaseIdChange`, `selectedSchema` vs. `onSchemaChange`, etc. I believe stacking them together makes sense, as there are many cases when they need to be updated together. For example, we'd want to clear the selected table(s) state when a schema or database changes, the same way we also want to clear the schema selection when a database changes.

To simplify state managing, the PR also introduces `useDataPickerValue`:

```jsx
const [value, onChange] = useDataPickerValue(initialValue);
const { databaseId, tableIds } = value;
```

The hook would deal with internal value change logic.