### PR TITLE
Update duplicate modal title if dashboard copy is set to deep or shallow

### DIFF
--- a/frontend/src/metabase/containers/FormikForm/FormikForm.tsx
+++ b/frontend/src/metabase/containers/FormikForm/FormikForm.tsx
@@ -33,6 +33,7 @@ interface FormContainerProps<Values extends BaseFieldValues>
   initial?: () => void;
   normalize?: () => void;
 
+  onValuesChange?: (newValues: Record<string, any>) => void;
   onSubmit: (
     values: Values,
     formikHelpers?: FormikHelpers<Values>,
@@ -92,12 +93,18 @@ function Form<Values extends BaseFieldValues>({
   validate,
   initial,
   normalize,
+  onValuesChange,
   onSubmit,
   onSubmitSuccess,
   ...props
 }: FormContainerProps<Values>) {
   const [error, setError] = useState<string | null>(null);
   const [values, setValues] = useState({});
+
+  const handleValuesChange = (newValues: any) => {
+    onValuesChange?.(newValues);
+    setValues(newValues);
+  };
 
   const { inlineFields, registerFormField, unregisterFormField } =
     useInlineFields();
@@ -249,7 +256,7 @@ function Form<Values extends BaseFieldValues>({
           error={error}
           registerFormField={registerFormField}
           unregisterFormField={unregisterFormField}
-          onValuesChange={setValues}
+          onValuesChange={handleValuesChange}
         />
       )}
     </Formik>

--- a/frontend/src/metabase/dashboard/components/DashboardCopyModal.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardCopyModal.jsx
@@ -41,16 +41,20 @@ const DashboardCopyModalInner = ({
   params,
   ...props
 }) => {
-  const [title, setTitle] = useState("");
+  const [isShallowCopy, setIsShallowCopy] = useState(true);
   const initialDashboardId = Urls.extractEntityId(params.slug);
 
   const handleValuesChange = ({ is_shallow_copy }) => {
-    if (!dashboard) {
-      setTitle("");
-    } else if (is_shallow_copy) {
-      setTitle(t`Duplicate "${dashboard.name}"`);
+    setIsShallowCopy(is_shallow_copy);
+  };
+
+  const getTitle = () => {
+    if (!dashboard || !dashboard?.name) {
+      return "";
+    } else if (isShallowCopy) {
+      return t`Duplicate "${dashboard.name}"`;
     } else {
-      setTitle(t`Duplicate "${dashboard.name}" and its questions`);
+      return t`Duplicate "${dashboard.name}" and its questions`;
     }
   };
 
@@ -62,7 +66,7 @@ const DashboardCopyModalInner = ({
         collection_id: initialCollectionId,
       }}
       form={Dashboards.forms.duplicate}
-      title={title}
+      title={getTitle()}
       overwriteOnInitialValuesChange
       copy={object =>
         copyDashboard({ id: initialDashboardId }, dissoc(object, "id"))

--- a/frontend/src/metabase/dashboard/components/DashboardCopyModal.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardCopyModal.jsx
@@ -1,9 +1,10 @@
 /* eslint-disable react/prop-types */
-import React from "react";
+import React, { useState } from "react";
 import { withRouter } from "react-router";
 import { connect } from "react-redux";
 import { dissoc } from "icepick";
 import _ from "underscore";
+import { t } from "ttag";
 
 import { replace } from "react-router-redux";
 import * as Urls from "metabase/lib/urls";
@@ -31,39 +32,48 @@ const mapDispatchToProps = {
   onReplaceLocation: replace,
 };
 
-class DashboardCopyModalInner extends React.Component {
-  render() {
-    const {
-      onClose,
-      onReplaceLocation,
-      copyDashboard,
-      dashboard,
-      initialCollectionId,
-      params,
-      ...props
-    } = this.props;
+const DashboardCopyModalInner = ({
+  onClose,
+  onReplaceLocation,
+  copyDashboard,
+  dashboard,
+  initialCollectionId,
+  params,
+  ...props
+}) => {
+  const [title, setTitle] = useState("");
+  const initialDashboardId = Urls.extractEntityId(params.slug);
 
-    const initialDashboardId = Urls.extractEntityId(params.slug);
+  const handleValuesChange = ({ is_shallow_copy }) => {
+    if (!dashboard) {
+      setTitle("");
+    } else if (is_shallow_copy) {
+      setTitle(t`Duplicate "${dashboard.name}"`);
+    } else {
+      setTitle(t`Duplicate "${dashboard.name}" and its questions`);
+    }
+  };
 
-    return (
-      <EntityCopyModal
-        entityType="dashboards"
-        entityObject={{
-          ...dashboard,
-          collection_id: initialCollectionId,
-        }}
-        form={Dashboards.forms.duplicate}
-        overwriteOnInitialValuesChange
-        copy={object =>
-          copyDashboard({ id: initialDashboardId }, dissoc(object, "id"))
-        }
-        onClose={onClose}
-        onSaved={dashboard => onReplaceLocation(Urls.dashboard(dashboard))}
-        {...props}
-      />
-    );
-  }
-}
+  return (
+    <EntityCopyModal
+      entityType="dashboards"
+      entityObject={{
+        ...dashboard,
+        collection_id: initialCollectionId,
+      }}
+      form={Dashboards.forms.duplicate}
+      title={title}
+      overwriteOnInitialValuesChange
+      copy={object =>
+        copyDashboard({ id: initialDashboardId }, dissoc(object, "id"))
+      }
+      onClose={onClose}
+      onSaved={dashboard => onReplaceLocation(Urls.dashboard(dashboard))}
+      {...props}
+      onValuesChange={handleValuesChange}
+    />
+  );
+};
 
 const DashboardCopyModal = _.compose(
   withRouter,

--- a/frontend/src/metabase/entities/containers/EntityCopyModal.jsx
+++ b/frontend/src/metabase/entities/containers/EntityCopyModal.jsx
@@ -10,11 +10,15 @@ const EntityCopyModal = ({
   entityType,
   entityObject,
   copy,
+  title,
   onClose,
   onSaved,
   ...props
 }) => (
-  <ModalContent title={t`Duplicate "${entityObject.name}"`} onClose={onClose}>
+  <ModalContent
+    title={title || t`Duplicate "${entityObject.name}"`}
+    onClose={onClose}
+  >
     <EntityForm
       entityType={entityType}
       entityObject={{

--- a/frontend/test/metabase/scenarios/dashboard/duplicate.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/duplicate.cy.spec.js
@@ -18,8 +18,10 @@ describe("scenarios > dashboard > duplicate", () => {
     });
 
     cy.findByText("Duplicate").click();
+    cy.findByText('Duplicate "Orders in a dashboard" and its questions');
 
     cy.findByRole("checkbox").click();
+    cy.findByText('Duplicate "Orders in a dashboard"');
 
     cy.button("Duplicate").click();
 


### PR DESCRIPTION
This is for duplications started in a Dashboard's page.

For duplications started in a Collection's page, a separate PR will follow.

### How to Test

1. Create a dashboard
2. From its page, click on `Duplicate`
3. Toggle the checkbox at the bottom of the duplicate modal

Modal title should toggle from

Duplicate dashboard_name and its questions

to 

Duplicate dashboard_name