### PR TITLE
Add safety checks to scaffolding data picker

### DIFF
--- a/frontend/src/metabase/containers/DataPicker/DataPicker.tsx
+++ b/frontend/src/metabase/containers/DataPicker/DataPicker.tsx
@@ -1,8 +1,16 @@
 import React, { useCallback, useMemo } from "react";
+import { connect } from "react-redux";
+
+import { getSetting } from "metabase/selectors/settings";
+
+import type { State } from "metabase-types/store";
 
 import { SAVED_QUESTIONS_VIRTUAL_DB_ID } from "metabase-lib/lib/metadata/utils/saved-questions";
 
-import type { DataPickerProps, DataPickerDataType } from "./types";
+import type {
+  DataPickerProps as DataPickerOwnProps,
+  DataPickerDataType,
+} from "./types";
 
 import { getDataTypes } from "./utils";
 
@@ -10,10 +18,25 @@ import CardPicker from "./CardPicker";
 import DataTypePicker from "./DataTypePicker";
 import RawDataPicker from "./RawDataPicker";
 
-function DataPicker(props: DataPickerProps) {
+interface DataPickerStateProps {
+  hasNestedQueriesEnabled: boolean;
+}
+
+type DataPickerProps = DataPickerOwnProps & DataPickerStateProps;
+
+function mapStateToProps(state: State) {
+  return {
+    hasNestedQueriesEnabled: getSetting(state, "enable-nested-queries"),
+  };
+}
+
+function DataPicker({ hasNestedQueriesEnabled, ...props }: DataPickerProps) {
   const { value, onChange } = props;
 
-  const dataTypes = useMemo(() => getDataTypes(), []);
+  const dataTypes = useMemo(
+    () => getDataTypes({ hasNestedQueriesEnabled }),
+    [hasNestedQueriesEnabled],
+  );
 
   const handleDataTypeChange = useCallback(
     (type: DataPickerDataType) => {
@@ -58,4 +81,4 @@ function DataPicker(props: DataPickerProps) {
   return null;
 }
 
-export default DataPicker;
+export default connect(mapStateToProps)(DataPicker);

--- a/frontend/src/metabase/containers/DataPicker/DataPicker.tsx
+++ b/frontend/src/metabase/containers/DataPicker/DataPicker.tsx
@@ -1,8 +1,10 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useMemo } from "react";
 
 import { SAVED_QUESTIONS_VIRTUAL_DB_ID } from "metabase-lib/lib/metadata/utils/saved-questions";
 
 import type { DataPickerProps, DataPickerDataType } from "./types";
+
+import { getDataTypes } from "./utils";
 
 import CardPicker from "./CardPicker";
 import DataTypePicker from "./DataTypePicker";
@@ -10,6 +12,8 @@ import RawDataPicker from "./RawDataPicker";
 
 function DataPicker(props: DataPickerProps) {
   const { value, onChange } = props;
+
+  const dataTypes = useMemo(() => getDataTypes(), []);
 
   const handleDataTypeChange = useCallback(
     (type: DataPickerDataType) => {
@@ -36,7 +40,7 @@ function DataPicker(props: DataPickerProps) {
   }, [onChange]);
 
   if (!value.type) {
-    return <DataTypePicker onChange={handleDataTypeChange} />;
+    return <DataTypePicker types={dataTypes} onChange={handleDataTypeChange} />;
   }
 
   if (value.type === "raw-data") {

--- a/frontend/src/metabase/containers/DataPicker/DataPickerContainer.tsx
+++ b/frontend/src/metabase/containers/DataPicker/DataPickerContainer.tsx
@@ -1,9 +1,6 @@
 import React, { useCallback, useMemo } from "react";
-import { t } from "ttag";
 import { connect } from "react-redux";
 import _ from "underscore";
-
-import EmptyState from "metabase/components/EmptyState";
 
 import { getSetting } from "metabase/selectors/settings";
 import { getHasDataAccess } from "metabase/new_query/selectors";
@@ -22,9 +19,7 @@ import type {
 
 import { getDataTypes } from "./utils";
 
-import CardPicker from "./CardPicker";
-import DataTypePicker from "./DataTypePicker";
-import RawDataPicker from "./RawDataPicker";
+import DataPickerView from "./DataPickerView";
 
 interface DataPickerStateProps {
   hasNestedQueriesEnabled: boolean;
@@ -52,7 +47,7 @@ function DataPicker({
   hasDataAccess,
   ...props
 }: DataPickerProps) {
-  const { value, onChange } = props;
+  const { onChange } = props;
 
   const dataTypes = useMemo(
     () =>
@@ -87,32 +82,15 @@ function DataPicker({
     });
   }, [onChange]);
 
-  if (!hasDataAccess) {
-    return (
-      <EmptyState
-        message={t`To pick some data, you'll need to add some first`}
-        icon="database"
-      />
-    );
-  }
-
-  if (!value.type) {
-    return <DataTypePicker types={dataTypes} onChange={handleDataTypeChange} />;
-  }
-
-  if (value.type === "raw-data") {
-    return <RawDataPicker {...props} onBack={handleBack} />;
-  }
-
-  if (value.type === "models") {
-    return <CardPicker {...props} targetModel="model" onBack={handleBack} />;
-  }
-
-  if (value.type === "questions") {
-    return <CardPicker {...props} targetModel="question" onBack={handleBack} />;
-  }
-
-  return null;
+  return (
+    <DataPickerView
+      {...props}
+      dataTypes={dataTypes}
+      hasDataAccess={hasDataAccess}
+      onDataTypeChange={handleDataTypeChange}
+      onBack={handleBack}
+    />
+  );
 }
 
 export default _.compose(

--- a/frontend/src/metabase/containers/DataPicker/DataPickerView.styled.tsx
+++ b/frontend/src/metabase/containers/DataPicker/DataPickerView.styled.tsx
@@ -1,0 +1,13 @@
+import styled from "@emotion/styled";
+
+export const Root = styled.div`
+  display: flex;
+  flex: 1;
+`;
+
+export const EmptyStateContainer = styled.div`
+  display: flex;
+  flex: 1;
+  align-items: center;
+  justify-content: center;
+`;

--- a/frontend/src/metabase/containers/DataPicker/DataPickerView.tsx
+++ b/frontend/src/metabase/containers/DataPicker/DataPickerView.tsx
@@ -10,6 +10,8 @@ import CardPicker from "./CardPicker";
 import DataTypePicker from "./DataTypePicker";
 import RawDataPicker from "./RawDataPicker";
 
+import { Root, EmptyStateContainer } from "./DataPickerView.styled";
+
 interface DataPickerViewProps extends DataPickerProps {
   dataTypes: DataTypeInfoItem[];
   hasDataAccess: boolean;
@@ -17,7 +19,7 @@ interface DataPickerViewProps extends DataPickerProps {
   onBack?: () => void;
 }
 
-function DataPickerView({
+function DataPickerViewContent({
   dataTypes,
   hasDataAccess,
   onDataTypeChange,
@@ -27,10 +29,12 @@ function DataPickerView({
 
   if (!hasDataAccess) {
     return (
-      <EmptyState
-        message={t`To pick some data, you'll need to add some first`}
-        icon="database"
-      />
+      <EmptyStateContainer>
+        <EmptyState
+          message={t`To pick some data, you'll need to add some first`}
+          icon="database"
+        />
+      </EmptyStateContainer>
     );
   }
 
@@ -51,6 +55,14 @@ function DataPickerView({
   }
 
   return null;
+}
+
+function DataPickerView(props: DataPickerViewProps) {
+  return (
+    <Root>
+      <DataPickerViewContent {...props} />
+    </Root>
+  );
 }
 
 export default DataPickerView;

--- a/frontend/src/metabase/containers/DataPicker/DataPickerView.tsx
+++ b/frontend/src/metabase/containers/DataPicker/DataPickerView.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import { t } from "ttag";
+
+import EmptyState from "metabase/components/EmptyState";
+
+import type { DataPickerProps, DataPickerDataType } from "./types";
+import type { DataTypeInfoItem } from "./utils";
+
+import CardPicker from "./CardPicker";
+import DataTypePicker from "./DataTypePicker";
+import RawDataPicker from "./RawDataPicker";
+
+interface DataPickerViewProps extends DataPickerProps {
+  dataTypes: DataTypeInfoItem[];
+  hasDataAccess: boolean;
+  onDataTypeChange: (type: DataPickerDataType) => void;
+  onBack?: () => void;
+}
+
+function DataPickerView({
+  dataTypes,
+  hasDataAccess,
+  onDataTypeChange,
+  ...props
+}: DataPickerViewProps) {
+  const { value } = props;
+
+  if (!hasDataAccess) {
+    return (
+      <EmptyState
+        message={t`To pick some data, you'll need to add some first`}
+        icon="database"
+      />
+    );
+  }
+
+  if (!value.type) {
+    return <DataTypePicker types={dataTypes} onChange={onDataTypeChange} />;
+  }
+
+  if (value.type === "raw-data") {
+    return <RawDataPicker {...props} />;
+  }
+
+  if (value.type === "models") {
+    return <CardPicker {...props} targetModel="model" />;
+  }
+
+  if (value.type === "questions") {
+    return <CardPicker {...props} targetModel="question" />;
+  }
+
+  return null;
+}
+
+export default DataPickerView;

--- a/frontend/src/metabase/containers/DataPicker/DataTypePicker/DataTypePicker.tsx
+++ b/frontend/src/metabase/containers/DataPicker/DataTypePicker/DataTypePicker.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { t } from "ttag";
 
+import type { DataTypeInfoItem } from "../utils";
 import type { DataPickerDataType } from "../types";
 
 import {
@@ -14,39 +14,12 @@ import {
 } from "./DataTypePicker.styled";
 
 interface DataTypePickerProps {
+  types: DataTypeInfoItem[];
   onChange: (value: DataPickerDataType) => void;
 }
 
-interface ListItemProps {
-  id: DataPickerDataType;
-  icon: string;
-  name: string;
-  description: string;
+interface ListItemProps extends DataTypeInfoItem {
   onSelect: () => void;
-}
-
-function getDataTypes(): Omit<ListItemProps, "onSelect">[] {
-  return [
-    {
-      id: "models",
-      icon: "model",
-      name: t`Models`,
-      description: t`The best starting place for new questions.`,
-    },
-    {
-      id: "raw-data",
-      icon: "database",
-      name: t`Raw Data`,
-      description: t`Unaltered tables in connected databases.`,
-    },
-    // TODO enable when DataPicker has items filtering API
-    // {
-    //   id: "questions",
-    //   name: t`Saved Questions`,
-    //   icon: "folder",
-    //   description: t`Use any question’s results to start a new question.`,
-    // },
-  ];
 }
 
 function DataTypePickerListItem({
@@ -69,10 +42,10 @@ function DataTypePickerListItem({
   );
 }
 
-function DataTypePicker({ onChange }: DataTypePickerProps) {
+function DataTypePicker({ types, onChange }: DataTypePickerProps) {
   return (
     <List>
-      {getDataTypes().map(dataType => (
+      {types.map(dataType => (
         <DataTypePickerListItem
           {...dataType}
           key={dataType.id}

--- a/frontend/src/metabase/containers/DataPicker/index.ts
+++ b/frontend/src/metabase/containers/DataPicker/index.ts
@@ -1,2 +1,2 @@
-export { default } from "./DataPicker";
+export { default } from "./DataPickerContainer";
 export { default as useDataPickerValue } from "./useDataPickerValue";

--- a/frontend/src/metabase/containers/DataPicker/utils.ts
+++ b/frontend/src/metabase/containers/DataPicker/utils.ts
@@ -1,0 +1,34 @@
+import { t } from "ttag";
+
+import type { DataPickerDataType } from "./types";
+
+export type DataTypeInfoItem = {
+  id: DataPickerDataType;
+  icon: string;
+  name: string;
+  description: string;
+};
+
+export function getDataTypes(): DataTypeInfoItem[] {
+  return [
+    {
+      id: "models",
+      icon: "model",
+      name: t`Models`,
+      description: t`The best starting place for new questions.`,
+    },
+    {
+      id: "raw-data",
+      icon: "database",
+      name: t`Raw Data`,
+      description: t`Unaltered tables in connected databases.`,
+    },
+    // TODO enable when DataPicker has items filtering API
+    // {
+    //   id: "questions",
+    //   name: t`Saved Questions`,
+    //   icon: "folder",
+    //   description: t`Use any question’s results to start a new question.`,
+    // },
+  ];
+}

--- a/frontend/src/metabase/containers/DataPicker/utils.ts
+++ b/frontend/src/metabase/containers/DataPicker/utils.ts
@@ -9,26 +9,36 @@ export type DataTypeInfoItem = {
   description: string;
 };
 
-export function getDataTypes(): DataTypeInfoItem[] {
-  return [
-    {
-      id: "models",
-      icon: "model",
-      name: t`Models`,
-      description: t`The best starting place for new questions.`,
-    },
+export function getDataTypes({
+  hasNestedQueriesEnabled,
+}: {
+  hasNestedQueriesEnabled: boolean;
+}): DataTypeInfoItem[] {
+  const dataTypes: DataTypeInfoItem[] = [
     {
       id: "raw-data",
       icon: "database",
       name: t`Raw Data`,
       description: t`Unaltered tables in connected databases.`,
     },
+  ];
+
+  if (hasNestedQueriesEnabled) {
+    dataTypes.unshift({
+      id: "models",
+      icon: "model",
+      name: t`Models`,
+      description: t`The best starting place for new questions.`,
+    });
+
     // TODO enable when DataPicker has items filtering API
-    // {
+    // dataTypes.push({
     //   id: "questions",
     //   name: t`Saved Questions`,
     //   icon: "folder",
     //   description: t`Use any question’s results to start a new question.`,
-    // },
-  ];
+    // });
+  }
+
+  return dataTypes;
 }

--- a/frontend/src/metabase/containers/DataPicker/utils.ts
+++ b/frontend/src/metabase/containers/DataPicker/utils.ts
@@ -11,8 +11,10 @@ export type DataTypeInfoItem = {
 
 export function getDataTypes({
   hasNestedQueriesEnabled,
+  hasModels,
 }: {
   hasNestedQueriesEnabled: boolean;
+  hasModels: boolean;
 }): DataTypeInfoItem[] {
   const dataTypes: DataTypeInfoItem[] = [
     {
@@ -24,12 +26,14 @@ export function getDataTypes({
   ];
 
   if (hasNestedQueriesEnabled) {
-    dataTypes.unshift({
-      id: "models",
-      icon: "model",
-      name: t`Models`,
-      description: t`The best starting place for new questions.`,
-    });
+    if (hasModels) {
+      dataTypes.unshift({
+        id: "models",
+        icon: "model",
+        name: t`Models`,
+        description: t`The best starting place for new questions.`,
+      });
+    }
 
     // TODO enable when DataPicker has items filtering API
     // dataTypes.push({


### PR DESCRIPTION
Ports some sanity checks from `DataSelector` to the new scaffolding data picker:

* not going to offer to pick models if there are no models available on the instance
* not going to offer to pick models if nested queries are disabled
* not going to offer to pick anything if a user is missing data permissions (checked via the `getHasDataPermission` selector)

> **Warning**
> You might have trouble with the picker's model list getting out of sync as you're adding/removing models. This is a known issue in our entity framework :(

### To Verify

1. New > App
2. Ensure you can select both models and raw tables
3. Admin Settings > General > Disable nested queries (2nd option from the bottom)
4. In the core app: New > App
5. Ensure you can only pick raw data
6. Revert step 3 (enable nested queries back) 
7. Archive all models you have, reload the page, New > App
8. Ensure you can only pick raw data as there are no models to pick now

### Demo

https://user-images.githubusercontent.com/17258145/196778639-0aca7599-d8dc-458b-89aa-857718ca41f5.mp4

