### PR TITLE
Add items filters API to data app scaffolding data picker

### DIFF
--- a/frontend/src/metabase/containers/DataPicker/DataPickerContainer.tsx
+++ b/frontend/src/metabase/containers/DataPicker/DataPickerContainer.tsx
@@ -5,6 +5,8 @@ import _ from "underscore";
 import { getSetting } from "metabase/selectors/settings";
 import { getHasDataAccess } from "metabase/new_query/selectors";
 
+import { useOnMount } from "metabase/hooks/use-on-mount";
+
 import Databases from "metabase/entities/databases";
 import Search from "metabase/entities/search";
 
@@ -81,6 +83,12 @@ function DataPicker({
     },
     [onChange],
   );
+
+  useOnMount(() => {
+    if (dataTypes.length === 1) {
+      handleDataTypeChange(dataTypes[0].id);
+    }
+  });
 
   const handleBack = useCallback(() => {
     onChange({

--- a/frontend/src/metabase/containers/DataPicker/DataPickerContainer.tsx
+++ b/frontend/src/metabase/containers/DataPicker/DataPickerContainer.tsx
@@ -17,7 +17,7 @@ import type {
   DataPickerDataType,
 } from "./types";
 
-import { getDataTypes } from "./utils";
+import { getDataTypes, DEFAULT_DATA_PICKER_FILTERS } from "./utils";
 
 import DataPickerView from "./DataPickerView";
 
@@ -43,19 +43,28 @@ function mapStateToProps(state: State) {
 
 function DataPicker({
   search: modelLookupResult,
+  filters: customFilters = {},
   hasNestedQueriesEnabled,
   hasDataAccess,
   ...props
 }: DataPickerProps) {
   const { onChange } = props;
 
+  const filters = useMemo(
+    () => ({
+      ...DEFAULT_DATA_PICKER_FILTERS,
+      ...customFilters,
+    }),
+    [customFilters],
+  );
+
   const dataTypes = useMemo(
     () =>
       getDataTypes({
         hasModels: modelLookupResult.length > 0,
         hasNestedQueriesEnabled,
-      }),
-    [modelLookupResult, hasNestedQueriesEnabled],
+      }).filter(type => filters.types(type.id)),
+    [filters, modelLookupResult, hasNestedQueriesEnabled],
   );
 
   const handleDataTypeChange = useCallback(

--- a/frontend/src/metabase/containers/DataPicker/index.ts
+++ b/frontend/src/metabase/containers/DataPicker/index.ts
@@ -1,2 +1,3 @@
 export { default } from "./DataPickerContainer";
+export type { DataPickerProps, DataPickerFiltersProp } from "./types";
 export { default as useDataPickerValue } from "./useDataPickerValue";

--- a/frontend/src/metabase/containers/DataPicker/types.ts
+++ b/frontend/src/metabase/containers/DataPicker/types.ts
@@ -19,9 +19,19 @@ export interface VirtualTable {
   };
 }
 
+export interface DataPickerFilters {
+  types: (type: DataPickerDataType) => boolean;
+  databases: (database: Database) => boolean;
+  schemas: (schema: Schema) => boolean;
+  tables: (table: Table | VirtualTable) => boolean;
+}
+
+export type DataPickerFiltersProp = Partial<DataPickerFilters>;
+
 export interface DataPickerProps {
   value: DataPickerValue;
   onChange: (value: DataPickerValue) => void;
+  filters?: DataPickerFiltersProp;
 }
 
 export type DataPickerSelectedItem = {

--- a/frontend/src/metabase/containers/DataPicker/utils.ts
+++ b/frontend/src/metabase/containers/DataPicker/utils.ts
@@ -1,6 +1,6 @@
 import { t } from "ttag";
 
-import type { DataPickerDataType } from "./types";
+import type { DataPickerDataType, DataPickerFilters } from "./types";
 
 export type DataTypeInfoItem = {
   id: DataPickerDataType;
@@ -45,3 +45,10 @@ export function getDataTypes({
 
   return dataTypes;
 }
+
+export const DEFAULT_DATA_PICKER_FILTERS: DataPickerFilters = {
+  types: () => true,
+  databases: () => true,
+  schemas: () => true,
+  tables: () => true,
+};

--- a/frontend/src/metabase/containers/DataPicker/utils.ts
+++ b/frontend/src/metabase/containers/DataPicker/utils.ts
@@ -35,13 +35,12 @@ export function getDataTypes({
       });
     }
 
-    // TODO enable when DataPicker has items filtering API
-    // dataTypes.push({
-    //   id: "questions",
-    //   name: t`Saved Questions`,
-    //   icon: "folder",
-    //   description: t`Use any question’s results to start a new question.`,
-    // });
+    dataTypes.push({
+      id: "questions",
+      name: t`Saved Questions`,
+      icon: "folder",
+      description: t`Use any question’s results to start a new question.`,
+    });
   }
 
   return dataTypes;

--- a/frontend/src/metabase/writeback/components/DataAppScaffoldingDataPicker/DataAppScaffoldingDataPicker.tsx
+++ b/frontend/src/metabase/writeback/components/DataAppScaffoldingDataPicker/DataAppScaffoldingDataPicker.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+
+import DataPicker, {
+  DataPickerProps,
+  DataPickerFiltersProp,
+} from "metabase/containers/DataPicker";
+
+const FILTERS: DataPickerFiltersProp = {
+  types: type => type !== "questions",
+};
+
+type DataAppScaffoldingDataPickerProps = Omit<DataPickerProps, "filters">;
+
+function DataAppScaffoldingDataPicker(
+  props: DataAppScaffoldingDataPickerProps,
+) {
+  return <DataPicker {...props} filters={FILTERS} />;
+}
+
+export default DataAppScaffoldingDataPicker;

--- a/frontend/src/metabase/writeback/components/DataAppScaffoldingDataPicker/index.ts
+++ b/frontend/src/metabase/writeback/components/DataAppScaffoldingDataPicker/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DataAppScaffoldingDataPicker";

--- a/frontend/src/metabase/writeback/containers/CreateDataAppModal/CreateDataAppModal.tsx
+++ b/frontend/src/metabase/writeback/containers/CreateDataAppModal/CreateDataAppModal.tsx
@@ -10,7 +10,8 @@ import * as Urls from "metabase/lib/urls";
 
 import DataApps, { ScaffoldNewAppParams } from "metabase/entities/data-apps";
 
-import DataPicker, { useDataPickerValue } from "metabase/containers/DataPicker";
+import { useDataPickerValue } from "metabase/containers/DataPicker";
+import DataAppScaffoldingDataPicker from "metabase/writeback/components/DataAppScaffoldingDataPicker";
 
 import type { DataApp } from "metabase-types/api";
 import type { Dispatch, State } from "metabase-types/store";
@@ -69,7 +70,7 @@ function CreateDataAppModal({ onCreate, onChangeLocation, onClose }: Props) {
         <ModalTitle>{t`Pick your starting data`}</ModalTitle>
       </ModalHeader>
       <ModalBody>
-        <DataPicker value={value} onChange={setValue} />
+        <DataAppScaffoldingDataPicker value={value} onChange={setValue} />
       </ModalBody>
       <ModalFooter>
         <Button onClick={onClose}>{t`Cancel`}</Button>

--- a/frontend/src/metabase/writeback/containers/ScaffoldDataAppPagesModal/ScaffoldDataAppPagesModal.tsx
+++ b/frontend/src/metabase/writeback/containers/ScaffoldDataAppPagesModal/ScaffoldDataAppPagesModal.tsx
@@ -6,7 +6,8 @@ import Button from "metabase/core/components/Button";
 
 import DataApps, { ScaffoldNewPagesParams } from "metabase/entities/data-apps";
 
-import DataPicker, { useDataPickerValue } from "metabase/containers/DataPicker";
+import { useDataPickerValue } from "metabase/containers/DataPicker";
+import DataAppScaffoldingDataPicker from "metabase/writeback/components/DataAppScaffoldingDataPicker";
 
 import type { DataApp } from "metabase-types/api";
 import type { Dispatch, State } from "metabase-types/store";
@@ -68,7 +69,7 @@ function ScaffoldDataAppPagesModal({
         <ModalTitle>{t`Pick your data`}</ModalTitle>
       </ModalHeader>
       <ModalBody>
-        <DataPicker value={value} onChange={setValue} />
+        <DataAppScaffoldingDataPicker value={value} onChange={setValue} />
       </ModalBody>
       <ModalFooter>
         <Button onClick={onClose}>{t`Cancel`}</Button>


### PR DESCRIPTION
The more I work on this new `DataPicker`, the more I dream about eventually replacing QB `DataSelector` with it. One of the common feature requests for `DataSelector` is filtering out some kind of items. For instance, we don't want to let you pick Saved Questions for scaffolding data apps. And when creating actions, we want to filter out databases that don't have writeback enabled.

This PR adds a filters API to the `DataPicker` component that should hopefully be a straightforward way to achieve this kind of behavior without introducing a ton of `withSomething` / `withoutSomething` props.

**Example:**

```jsx
<DataPicker 
   {...props}
   filters={{
      type: type => type !== "questions",
      database: db => hasWritebackEnabled(db),
   }}
/>
```

### To Verify

1. New > App
2. Ensure you can't see Saved Questions 🤷 