### PR TITLE
Improve collection selection for scaffolding data picker

### DIFF
--- a/frontend/src/metabase-lib/lib/metadata/utils/saved-questions.js
+++ b/frontend/src/metabase-lib/lib/metadata/utils/saved-questions.js
@@ -24,6 +24,10 @@ export function getCollectionVirtualSchemaId(collection, { isDatasets } = {}) {
   );
 }
 
+export function getRootCollectionVirtualSchemaId({ isModels }) {
+  return getCollectionVirtualSchemaId(null, { isDatasets: isModels });
+}
+
 export function getQuestionVirtualTableId(card) {
   return `card__${card.id}`;
 }

--- a/frontend/src/metabase/containers/DataPicker/CardPicker/CardPickerContainer.tsx
+++ b/frontend/src/metabase/containers/DataPicker/CardPicker/CardPickerContainer.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useMemo } from "react";
 import _ from "underscore";
 import { connect } from "react-redux";
 
@@ -65,9 +65,7 @@ function CardPickerContainer({
   onChange,
   onBack,
 }: CardPickerProps) {
-  const [selectedCollectionId, setSelectedCollectionId] = useState<
-    Collection["id"] | undefined
-  >();
+  const { collectionId } = value;
 
   const { selectedTableIds, toggleTableIdSelection } = useSelectedTables({
     initialValues: value.tableIds,
@@ -93,8 +91,8 @@ function CardPickerContainer({
   const selectedItems = useMemo(() => {
     const items: DataPickerSelectedItem[] = [];
 
-    if (selectedCollectionId) {
-      items.push({ type: "schema", id: selectedCollectionId });
+    if (collectionId) {
+      items.push({ type: "collection", id: collectionId });
     }
 
     const tables: DataPickerSelectedItem[] = selectedTableIds.map(id => ({
@@ -105,17 +103,16 @@ function CardPickerContainer({
     items.push(...tables);
 
     return items;
-  }, [selectedCollectionId, selectedTableIds]);
+  }, [collectionId, selectedTableIds]);
 
   const handleSelectedCollectionChange = useCallback(
     (id: Collection["id"]) => {
       const collection = id === "root" ? rootCollection : collectionsMap[id];
       if (collection) {
-        setSelectedCollectionId(id);
         const schemaId = getCollectionVirtualSchemaId(collection, {
           isDatasets: targetModel === "model",
         });
-        onChange({ ...value, schemaId, tableIds: [] });
+        onChange({ ...value, schemaId, collectionId: id, tableIds: [] });
       }
     },
     [value, collectionsMap, rootCollection, targetModel, onChange],

--- a/frontend/src/metabase/containers/DataPicker/CardPicker/CardPickerView.tsx
+++ b/frontend/src/metabase/containers/DataPicker/CardPicker/CardPickerView.tsx
@@ -78,7 +78,7 @@ function CardPickerView({
   onBack,
 }: CardPickerViewProps) {
   const { selectedCollectionId, selectedVirtualTableIds } = useMemo(() => {
-    const { schema: collections = [], table: tables = [] } = _.groupBy(
+    const { collection: collections = [], table: tables = [] } = _.groupBy(
       selectedItems,
       "type",
     );

--- a/frontend/src/metabase/containers/DataPicker/DataPickerContainer.tsx
+++ b/frontend/src/metabase/containers/DataPicker/DataPickerContainer.tsx
@@ -12,7 +12,10 @@ import Search from "metabase/entities/search";
 
 import type { State } from "metabase-types/store";
 
-import { SAVED_QUESTIONS_VIRTUAL_DB_ID } from "metabase-lib/lib/metadata/utils/saved-questions";
+import {
+  getRootCollectionVirtualSchemaId,
+  SAVED_QUESTIONS_VIRTUAL_DB_ID,
+} from "metabase-lib/lib/metadata/utils/saved-questions";
 
 import type {
   DataPickerProps as DataPickerOwnProps,
@@ -71,13 +74,24 @@ function DataPicker({
 
   const handleDataTypeChange = useCallback(
     (type: DataPickerDataType) => {
-      const isUsingVirtualTables = type === "models" || type === "questions";
+      const isModels = type === "models";
+      const isUsingVirtualTables = isModels || type === "questions";
+
+      // When switching to models or questions,
+      // we want to automatically open Our analytics collection
+      const databaseId = isUsingVirtualTables
+        ? SAVED_QUESTIONS_VIRTUAL_DB_ID
+        : undefined;
+      const schemaId = isUsingVirtualTables
+        ? getRootCollectionVirtualSchemaId({ isModels })
+        : undefined;
+      const collectionId = isUsingVirtualTables ? "root" : undefined;
+
       onChange({
         type,
-        databaseId: isUsingVirtualTables
-          ? SAVED_QUESTIONS_VIRTUAL_DB_ID
-          : undefined,
-        schemaId: undefined,
+        databaseId,
+        schemaId,
+        collectionId,
         tableIds: [],
       });
     },

--- a/frontend/src/metabase/containers/DataPicker/types.ts
+++ b/frontend/src/metabase/containers/DataPicker/types.ts
@@ -1,3 +1,5 @@
+import type { Collection } from "metabase-types/api";
+
 import type Database from "metabase-lib/lib/metadata/Database";
 import type Table from "metabase-lib/lib/metadata/Table";
 import type Schema from "metabase-lib/lib/metadata/Schema";
@@ -8,6 +10,7 @@ export type DataPickerValue = {
   type?: DataPickerDataType;
   databaseId?: Database["id"];
   schemaId?: Schema["id"];
+  collectionId?: Collection["id"];
   tableIds: Table["id"][];
 };
 
@@ -35,6 +38,6 @@ export interface DataPickerProps {
 }
 
 export type DataPickerSelectedItem = {
-  type: "database" | "schema" | "table";
+  type: "database" | "schema" | "collection" | "table";
   id: string | number;
 };

--- a/frontend/src/metabase/containers/DataPicker/useDataPickerValue.ts
+++ b/frontend/src/metabase/containers/DataPicker/useDataPickerValue.ts
@@ -27,11 +27,24 @@ function cleanTablesValue({
   return databaseId && schemaId ? tableIds : [];
 }
 
+function cleanCollectionValue({
+  type,
+  databaseId,
+  collectionId,
+}: Partial<DataPickerValue>) {
+  const isUsingVirtualTables = type === "models" || type === "questions";
+  if (isUsingVirtualTables && databaseId === SAVED_QUESTIONS_VIRTUAL_DB_ID) {
+    return collectionId;
+  }
+  return undefined;
+}
+
 function cleanValue(value: Partial<DataPickerValue>): DataPickerValue {
   return {
     type: value.type,
     databaseId: cleanDatabaseValue(value),
     schemaId: cleanSchemaValue(value),
+    collectionId: cleanCollectionValue(value),
     tableIds: cleanTablesValue(value),
   };
 }


### PR DESCRIPTION
The PR adds `collectionId` to the data picker value, so the model/question picker should now gracefully react to `value` changes. What that means is that if we pass a `value` prop like:

```jsx
const value = {
   databaseId: SAVED_QUESTIONS_VIRTUAL_DB_ID,
   schemaId: getCollectionVirtualSchemaId(collection),
   collectionId: collection.id,
   tableIds: ["card__123"],
}
```

then the picker will automatically open the specified collection. 

One more tweak this PR does is that when a user would pick Models / Saved Questions, it'd automatically prefill the `value`, so "Our analytics" is open by default

### To Verify

1. New > App > Models
2. Make sure Our analytics collection is selected by default
3. Optionally, pass an initial value to the data picker [here](https://github.com/metabase/metabase/blob/f912d2766e32fa236ef0e53b9d4a02e979399bef/frontend/src/metabase/writeback/containers/CreateDataAppModal/CreateDataAppModal.tsx#L52). I'd recommend to use constants and utilities from the code snippet above
4. New > App
5. Ensure the picker opens a specified collection