### PR TITLE
Update dashboard copy modal title from collection page

### DIFF
--- a/frontend/src/metabase/collections/components/CollectionCopyEntityModal.jsx
+++ b/frontend/src/metabase/collections/components/CollectionCopyEntityModal.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import React from "react";
+import React, { useState } from "react";
 import { connect } from "react-redux";
 import { dissoc } from "icepick";
 import { t } from "ttag";
@@ -30,6 +30,21 @@ function CollectionCopyEntityModal({
   onSaved,
   triggerToast,
 }) {
+  const [isShallowCopy, setIsShallowCopy] = useState(true);
+  const handleValuesChange = ({ is_shallow_copy }) => {
+    setIsShallowCopy(is_shallow_copy);
+  };
+
+  const getTitle = () => {
+    if (entityObject.model !== "dashboard") {
+      return "";
+    } else if (isShallowCopy) {
+      return t`Duplicate "${entityObject.name}"`;
+    } else {
+      return t`Duplicate "${entityObject.name}" and its questions`;
+    }
+  };
+
   return (
     <EntityCopyModal
       overwriteOnInitialValuesChange
@@ -39,6 +54,7 @@ function CollectionCopyEntityModal({
         collection_id: initialCollectionId,
       }}
       form={Dashboards.forms.duplicate}
+      title={getTitle()}
       copy={async values => {
         return entityObject.copy(dissoc(values, "id"));
       }}
@@ -60,6 +76,7 @@ function CollectionCopyEntityModal({
 
         onSaved(newEntityObject);
       }}
+      onValuesChange={handleValuesChange}
     />
   );
 }

--- a/frontend/src/metabase/dashboard/components/DashboardCopyModal.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardCopyModal.jsx
@@ -49,7 +49,7 @@ const DashboardCopyModalInner = ({
   };
 
   const getTitle = () => {
-    if (!dashboard || !dashboard?.name) {
+    if (!dashboard?.name) {
       return "";
     } else if (isShallowCopy) {
       return t`Duplicate "${dashboard.name}"`;

--- a/frontend/test/metabase/scenarios/collections/collection-pinned-overview.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collection-pinned-overview.cy.spec.js
@@ -138,7 +138,9 @@ describe("scenarios > collection pinned items overview", () => {
     openPinnedItemMenu(DASHBOARD_NAME);
     popover().findByText("Duplicate").click();
 
-    cy.findByText(`Duplicate "${DASHBOARD_NAME}"`).should("be.visible");
+    cy.findByText(`Duplicate "${DASHBOARD_NAME}" and its questions`).should(
+      "be.visible",
+    );
   });
 
   it("should be able to archive a pinned dashboard", () => {


### PR DESCRIPTION
This PR is a sibling of https://github.com/metabase/metabase/pull/26021, only the duplicate action is triggered from a collection page.

### How to Test

1. Create a dashboard
2. From its collection page, click on the `…` icon by the dashboard list entry
3. Click on `Duplicate`
4. Toggle the checkbox at the bottom of the duplicate modal

Modal title should toggle from

Duplicate "dashboard_name" and its questions

to 

Duplicate "dashboard_name"