### PR TITLE
Add basic search to scaffolding data picker

### DIFF
--- a/frontend/src/metabase/containers/DataPicker/DataPickerContainer.tsx
+++ b/frontend/src/metabase/containers/DataPicker/DataPickerContainer.tsx
@@ -22,6 +22,7 @@ import type {
   DataPickerDataType,
 } from "./types";
 
+import { DataPickerContextProvider, useDataPicker } from "./DataPickerContext";
 import { getDataTypes, DEFAULT_DATA_PICKER_FILTERS } from "./utils";
 
 import DataPickerView from "./DataPickerView";
@@ -124,7 +125,7 @@ function DataPicker({
   );
 }
 
-export default _.compose(
+const DataPickerContainer = _.compose(
   // Required for `hasDataAccess` check
   Databases.loadList(),
 
@@ -139,3 +140,7 @@ export default _.compose(
 
   connect(mapStateToProps),
 )(DataPicker);
+
+export default Object.assign(DataPickerContainer, {
+  Provider: DataPickerContextProvider,
+});

--- a/frontend/src/metabase/containers/DataPicker/DataPickerContainer.tsx
+++ b/frontend/src/metabase/containers/DataPicker/DataPickerContainer.tsx
@@ -56,6 +56,8 @@ function DataPicker({
 }: DataPickerProps) {
   const { onChange } = props;
 
+  const { search } = useDataPicker();
+
   const filters = useMemo(
     () => ({
       ...DEFAULT_DATA_PICKER_FILTERS,
@@ -118,6 +120,7 @@ function DataPicker({
     <DataPickerView
       {...props}
       dataTypes={dataTypes}
+      searchQuery={search.query}
       hasDataAccess={hasDataAccess}
       onDataTypeChange={handleDataTypeChange}
       onBack={handleBack}

--- a/frontend/src/metabase/containers/DataPicker/DataPickerContext/DataPickerContext.ts
+++ b/frontend/src/metabase/containers/DataPicker/DataPickerContext/DataPickerContext.ts
@@ -1,0 +1,20 @@
+import { createContext, useContext } from "react";
+import _ from "underscore";
+
+export interface IDataPickerContext {
+  search: {
+    query: string;
+    setQuery: (query: string) => void;
+  };
+}
+
+export const DataPickerContext = createContext<IDataPickerContext>({
+  search: {
+    query: "",
+    setQuery: _.noop,
+  },
+});
+
+export function useDataPicker() {
+  return useContext(DataPickerContext);
+}

--- a/frontend/src/metabase/containers/DataPicker/DataPickerContext/DataPickerContextProvider.tsx
+++ b/frontend/src/metabase/containers/DataPicker/DataPickerContext/DataPickerContextProvider.tsx
@@ -1,0 +1,28 @@
+import React, { useMemo, useState } from "react";
+import { DataPickerContext, IDataPickerContext } from "./DataPickerContext";
+
+function DataPickerContextProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [searchQuery, setSearchQuery] = useState("");
+
+  const value: IDataPickerContext = useMemo(
+    () => ({
+      search: {
+        query: searchQuery,
+        setQuery: setSearchQuery,
+      },
+    }),
+    [searchQuery],
+  );
+
+  return (
+    <DataPickerContext.Provider value={value}>
+      {children}
+    </DataPickerContext.Provider>
+  );
+}
+
+export default DataPickerContextProvider;

--- a/frontend/src/metabase/containers/DataPicker/DataPickerContext/index.ts
+++ b/frontend/src/metabase/containers/DataPicker/DataPickerContext/index.ts
@@ -1,0 +1,2 @@
+export { useDataPicker } from "./DataPickerContext";
+export { default as DataPickerContextProvider } from "./DataPickerContextProvider";

--- a/frontend/src/metabase/containers/DataPicker/DataPickerView.tsx
+++ b/frontend/src/metabase/containers/DataPicker/DataPickerView.tsx
@@ -6,14 +6,18 @@ import EmptyState from "metabase/components/EmptyState";
 import type { DataPickerProps, DataPickerDataType } from "./types";
 import type { DataTypeInfoItem } from "./utils";
 
+import { MIN_SEARCH_LENGTH } from "./utils";
+
 import CardPicker from "./CardPicker";
 import DataTypePicker from "./DataTypePicker";
+import DataSearch from "./DataSearch";
 import RawDataPicker from "./RawDataPicker";
 
 import { Root, EmptyStateContainer } from "./DataPickerView.styled";
 
 interface DataPickerViewProps extends DataPickerProps {
   dataTypes: DataTypeInfoItem[];
+  searchQuery: string;
   hasDataAccess: boolean;
   onDataTypeChange: (type: DataPickerDataType) => void;
   onBack?: () => void;
@@ -21,11 +25,12 @@ interface DataPickerViewProps extends DataPickerProps {
 
 function DataPickerViewContent({
   dataTypes,
+  searchQuery,
   hasDataAccess,
   onDataTypeChange,
   ...props
 }: DataPickerViewProps) {
-  const { value } = props;
+  const { value, onChange } = props;
 
   if (!hasDataAccess) {
     return (
@@ -35,6 +40,12 @@ function DataPickerViewContent({
           icon="database"
         />
       </EmptyStateContainer>
+    );
+  }
+
+  if (searchQuery.trim().length > MIN_SEARCH_LENGTH) {
+    return (
+      <DataSearch value={value} searchQuery={searchQuery} onChange={onChange} />
     );
   }
 

--- a/frontend/src/metabase/containers/DataPicker/DataPickerView.tsx
+++ b/frontend/src/metabase/containers/DataPicker/DataPickerView.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { t } from "ttag";
 
 import EmptyState from "metabase/components/EmptyState";
@@ -32,6 +32,11 @@ function DataPickerViewContent({
 }: DataPickerViewProps) {
   const { value, onChange } = props;
 
+  const availableDataTypes = useMemo(
+    () => dataTypes.map(type => type.id),
+    [dataTypes],
+  );
+
   if (!hasDataAccess) {
     return (
       <EmptyStateContainer>
@@ -45,7 +50,12 @@ function DataPickerViewContent({
 
   if (searchQuery.trim().length > MIN_SEARCH_LENGTH) {
     return (
-      <DataSearch value={value} searchQuery={searchQuery} onChange={onChange} />
+      <DataSearch
+        value={value}
+        searchQuery={searchQuery}
+        availableDataTypes={availableDataTypes}
+        onChange={onChange}
+      />
     );
   }
 

--- a/frontend/src/metabase/containers/DataPicker/DataPickerView.tsx
+++ b/frontend/src/metabase/containers/DataPicker/DataPickerView.tsx
@@ -3,10 +3,10 @@ import { t } from "ttag";
 
 import EmptyState from "metabase/components/EmptyState";
 
+import { MIN_SEARCH_LENGTH } from "./constants";
+
 import type { DataPickerProps, DataPickerDataType } from "./types";
 import type { DataTypeInfoItem } from "./utils";
-
-import { MIN_SEARCH_LENGTH } from "./utils";
 
 import CardPicker from "./CardPicker";
 import DataTypePicker from "./DataTypePicker";

--- a/frontend/src/metabase/containers/DataPicker/DataSearch/DataSearch.tsx
+++ b/frontend/src/metabase/containers/DataPicker/DataSearch/DataSearch.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useMemo } from "react";
 
 import { SearchResults } from "metabase/query_builder/components/DataSelector/data-search";
 
@@ -29,7 +29,13 @@ type TableSearchResult = {
   collection: Collection | null;
 };
 
-const SEARCH_MODELS = ["table", "dataset", "card"];
+type SearchModel = "card" | "dataset" | "table";
+
+const DATA_TYPE_SEARCH_MODEL_MAP: Record<DataPickerDataType, SearchModel> = {
+  "raw-data": "table",
+  models: "dataset",
+  questions: "card",
+};
 
 function getDataTypeForSearchResult(
   table: TableSearchResult,
@@ -76,9 +82,16 @@ function getNextValue(table: TableSearchResult): DataPickerValue {
     : getValueForRawTable(table);
 }
 
-function DataSearch({ searchQuery, onChange }: DataSearchProps) {
+function DataSearch({ value, searchQuery, onChange }: DataSearchProps) {
   const { search } = useDataPicker();
   const { setQuery } = search;
+
+  const searchModels: SearchModel[] = useMemo(() => {
+    if (!value.type) {
+      return Object.values(DATA_TYPE_SEARCH_MODEL_MAP);
+    }
+    return [DATA_TYPE_SEARCH_MODEL_MAP[value.type]];
+  }, [value.type]);
 
   const onSelect = useCallback(
     (table: TableSearchResult) => {
@@ -91,7 +104,7 @@ function DataSearch({ searchQuery, onChange }: DataSearchProps) {
 
   return (
     <SearchResults
-      searchModels={SEARCH_MODELS as any}
+      searchModels={searchModels}
       searchQuery={searchQuery.trim()}
       onSelect={onSelect}
     />

--- a/frontend/src/metabase/containers/DataPicker/DataSearch/DataSearch.tsx
+++ b/frontend/src/metabase/containers/DataPicker/DataSearch/DataSearch.tsx
@@ -76,11 +76,9 @@ function getNextValue(table: TableSearchResult): DataPickerValue {
     : getValueForRawTable(table);
 }
 
-function DataSearch({ value, searchQuery, onChange }: DataSearchProps) {
+function DataSearch({ searchQuery, onChange }: DataSearchProps) {
   const { search } = useDataPicker();
   const { setQuery } = search;
-
-  const databaseId = value.databaseId ? String(value.databaseId) : null;
 
   const onSelect = useCallback(
     (table: TableSearchResult) => {
@@ -95,7 +93,6 @@ function DataSearch({ value, searchQuery, onChange }: DataSearchProps) {
     <SearchResults
       searchModels={SEARCH_MODELS as any}
       searchQuery={searchQuery.trim()}
-      databaseId={databaseId}
       onSelect={onSelect}
     />
   );

--- a/frontend/src/metabase/containers/DataPicker/DataSearch/DataSearch.tsx
+++ b/frontend/src/metabase/containers/DataPicker/DataSearch/DataSearch.tsx
@@ -13,11 +13,12 @@ import { generateSchemaId } from "metabase-lib/lib/metadata/utils/schema";
 
 import { useDataPicker } from "../DataPickerContext";
 
-import { DataPickerValue, DataPickerDataType } from "../types";
+import type { DataPickerValue, DataPickerDataType } from "../types";
 
 interface DataSearchProps {
   value: DataPickerValue;
   searchQuery: string;
+  availableDataTypes: DataPickerDataType[];
   onChange: (value: DataPickerValue) => void;
 }
 
@@ -82,16 +83,21 @@ function getNextValue(table: TableSearchResult): DataPickerValue {
     : getValueForRawTable(table);
 }
 
-function DataSearch({ value, searchQuery, onChange }: DataSearchProps) {
+function DataSearch({
+  value,
+  searchQuery,
+  availableDataTypes,
+  onChange,
+}: DataSearchProps) {
   const { search } = useDataPicker();
   const { setQuery } = search;
 
   const searchModels: SearchModel[] = useMemo(() => {
     if (!value.type) {
-      return Object.values(DATA_TYPE_SEARCH_MODEL_MAP);
+      return availableDataTypes.map(type => DATA_TYPE_SEARCH_MODEL_MAP[type]);
     }
     return [DATA_TYPE_SEARCH_MODEL_MAP[value.type]];
-  }, [value.type]);
+  }, [value.type, availableDataTypes]);
 
   const onSelect = useCallback(
     (table: TableSearchResult) => {

--- a/frontend/src/metabase/containers/DataPicker/DataSearch/DataSearch.tsx
+++ b/frontend/src/metabase/containers/DataPicker/DataSearch/DataSearch.tsx
@@ -1,0 +1,104 @@
+import React, { useCallback } from "react";
+
+import { SearchResults } from "metabase/query_builder/components/DataSelector/data-search";
+
+import type { Collection } from "metabase-types/api";
+
+import {
+  getCollectionVirtualSchemaId,
+  getQuestionVirtualTableId,
+  SAVED_QUESTIONS_VIRTUAL_DB_ID,
+} from "metabase-lib/lib/metadata/utils/saved-questions";
+import { generateSchemaId } from "metabase-lib/lib/metadata/utils/schema";
+
+import { useDataPicker } from "../DataPickerContext";
+
+import { DataPickerValue, DataPickerDataType } from "../types";
+
+interface DataSearchProps {
+  value: DataPickerValue;
+  searchQuery: string;
+  onChange: (value: DataPickerValue) => void;
+}
+
+type TableSearchResult = {
+  database_id: number;
+  table_schema: string;
+  table_id: number;
+  model: "table" | "dataset" | "card";
+  collection: Collection | null;
+};
+
+const SEARCH_MODELS = ["table", "dataset", "card"];
+
+function getDataTypeForSearchResult(
+  table: TableSearchResult,
+): DataPickerDataType {
+  switch (table.model) {
+    case "table":
+      return "raw-data";
+    case "card":
+      return "questions";
+    case "dataset":
+      return "models";
+  }
+}
+
+function getValueForRawTable(table: TableSearchResult): DataPickerValue {
+  return {
+    type: "raw-data",
+    databaseId: table.database_id,
+    schemaId: generateSchemaId(table.database_id, table.table_schema),
+    collectionId: undefined,
+    tableIds: [table.table_id],
+  };
+}
+
+function getValueForVirtualTable(table: TableSearchResult): DataPickerValue {
+  const type = getDataTypeForSearchResult(table);
+  const schemaId = getCollectionVirtualSchemaId(table.collection, {
+    isDatasets: type === "models",
+  });
+  return {
+    type: "models",
+    databaseId: SAVED_QUESTIONS_VIRTUAL_DB_ID,
+    schemaId,
+    collectionId: table.collection?.id || "root",
+    tableIds: [getQuestionVirtualTableId(table)],
+  };
+}
+
+function getNextValue(table: TableSearchResult): DataPickerValue {
+  const type = getDataTypeForSearchResult(table);
+  const isVirtualTable = type === "models" || type === "questions";
+  return isVirtualTable
+    ? getValueForVirtualTable(table)
+    : getValueForRawTable(table);
+}
+
+function DataSearch({ value, searchQuery, onChange }: DataSearchProps) {
+  const { search } = useDataPicker();
+  const { setQuery } = search;
+
+  const databaseId = value.databaseId ? String(value.databaseId) : null;
+
+  const onSelect = useCallback(
+    (table: TableSearchResult) => {
+      const nextValue = getNextValue(table);
+      onChange(nextValue);
+      setQuery("");
+    },
+    [onChange, setQuery],
+  );
+
+  return (
+    <SearchResults
+      searchModels={SEARCH_MODELS as any}
+      searchQuery={searchQuery.trim()}
+      databaseId={databaseId}
+      onSelect={onSelect}
+    />
+  );
+}
+
+export default DataSearch;

--- a/frontend/src/metabase/containers/DataPicker/DataSearch/index.ts
+++ b/frontend/src/metabase/containers/DataPicker/DataSearch/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DataSearch";

--- a/frontend/src/metabase/containers/DataPicker/constants.ts
+++ b/frontend/src/metabase/containers/DataPicker/constants.ts
@@ -1,0 +1,1 @@
+export const MIN_SEARCH_LENGTH = 2;

--- a/frontend/src/metabase/containers/DataPicker/index.ts
+++ b/frontend/src/metabase/containers/DataPicker/index.ts
@@ -1,4 +1,11 @@
 export { default } from "./DataPickerContainer";
-export type { DataPickerProps, DataPickerFiltersProp } from "./types";
 export { useDataPicker } from "./DataPickerContext";
+
 export { default as useDataPickerValue } from "./useDataPickerValue";
+
+export type {
+  DataPickerDataType,
+  DataPickerValue,
+  DataPickerProps,
+  DataPickerFiltersProp,
+} from "./types";

--- a/frontend/src/metabase/containers/DataPicker/index.ts
+++ b/frontend/src/metabase/containers/DataPicker/index.ts
@@ -1,3 +1,4 @@
 export { default } from "./DataPickerContainer";
 export type { DataPickerProps, DataPickerFiltersProp } from "./types";
+export { useDataPicker } from "./DataPickerContext";
 export { default as useDataPickerValue } from "./useDataPickerValue";

--- a/frontend/src/metabase/containers/DataPicker/utils.ts
+++ b/frontend/src/metabase/containers/DataPicker/utils.ts
@@ -2,6 +2,8 @@ import { t } from "ttag";
 
 import type { DataPickerDataType, DataPickerFilters } from "./types";
 
+export const MIN_SEARCH_LENGTH = 2;
+
 export type DataTypeInfoItem = {
   id: DataPickerDataType;
   icon: string;

--- a/frontend/src/metabase/containers/DataPicker/utils.ts
+++ b/frontend/src/metabase/containers/DataPicker/utils.ts
@@ -2,8 +2,6 @@ import { t } from "ttag";
 
 import type { DataPickerDataType, DataPickerFilters } from "./types";
 
-export const MIN_SEARCH_LENGTH = 2;
-
 export type DataTypeInfoItem = {
   id: DataPickerDataType;
   icon: string;

--- a/frontend/src/metabase/query_builder/components/DataSelector/data-search/SearchResults.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/data-search/SearchResults.jsx
@@ -13,7 +13,7 @@ const propTypes = {
   searchQuery: PropTypes.string.required,
   onSelect: PropTypes.func.required,
   searchModels: PropTypes.arrayOf(
-    PropTypes.arrayOf(PropTypes.oneOf(["card", "table"])),
+    PropTypes.oneOf(["card", "dataset", "table"]),
   ),
 };
 

--- a/frontend/src/metabase/writeback/containers/CreateDataAppModal/CreateDataAppModal.styled.tsx
+++ b/frontend/src/metabase/writeback/containers/CreateDataAppModal/CreateDataAppModal.styled.tsx
@@ -11,6 +11,7 @@ export const ModalRoot = styled.div`
 export const ModalHeader = styled.div`
   display: flex;
   align-items: center;
+  justify-content: space-between;
   padding: 1.5rem 2rem;
 `;
 

--- a/frontend/src/metabase/writeback/containers/CreateDataAppModal/CreateDataAppModal.styled.tsx
+++ b/frontend/src/metabase/writeback/containers/CreateDataAppModal/CreateDataAppModal.styled.tsx
@@ -1,5 +1,9 @@
 import styled from "@emotion/styled";
+
+import Icon from "metabase/components/Icon";
+
 import { color } from "metabase/lib/colors";
+import { space } from "metabase/styled-components/theme";
 
 export const ModalRoot = styled.div`
   display: flex;
@@ -40,4 +44,41 @@ export const ModalFooter = styled.div`
   padding: 1.5rem 2rem;
 
   border-top: 1px solid ${color("border")};
+`;
+
+export const SearchInputContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  position: relative;
+
+  max-width: 14rem;
+  padding: 12px 14px;
+
+  border: 1px solid ${color("border")};
+  border-radius: 8px;
+`;
+
+export const SearchIcon = styled(Icon)`
+  color: ${color("text-light")};
+`;
+
+export const SearchInput = styled.input`
+  background-color: transparent;
+  border: none;
+
+  color: ${color("text-medium")};
+  font-weight: 700;
+
+  width: 100%;
+  margin-left: 8px;
+
+  &:focus {
+    outline: none;
+  }
+
+  &::placeholder {
+    color: ${color("text-light")};
+    font-weight: 700;
+  }
 `;

--- a/frontend/src/metabase/writeback/containers/CreateDataAppModal/CreateDataAppModal.tsx
+++ b/frontend/src/metabase/writeback/containers/CreateDataAppModal/CreateDataAppModal.tsx
@@ -10,7 +10,10 @@ import * as Urls from "metabase/lib/urls";
 
 import DataApps, { ScaffoldNewAppParams } from "metabase/entities/data-apps";
 
-import { useDataPickerValue } from "metabase/containers/DataPicker";
+import DataPicker, {
+  useDataPicker,
+  useDataPickerValue,
+} from "metabase/containers/DataPicker";
 import DataAppScaffoldingDataPicker from "metabase/writeback/components/DataAppScaffoldingDataPicker";
 
 import type { DataApp } from "metabase-types/api";
@@ -48,6 +51,17 @@ function mapDispatchToProps(dispatch: Dispatch) {
   };
 }
 
+function DataPickerSearchInput() {
+  const { search } = useDataPicker();
+  return (
+    <input
+      value={search.query}
+      onChange={e => search.setQuery(e.target.value)}
+      placeholder={t`Search`}
+    />
+  );
+}
+
 function CreateDataAppModal({ onCreate, onChangeLocation, onClose }: Props) {
   const [value, setValue] = useDataPickerValue();
 
@@ -65,22 +79,25 @@ function CreateDataAppModal({ onCreate, onChangeLocation, onClose }: Props) {
   const canSubmit = tableIds.length > 0;
 
   return (
-    <ModalRoot>
-      <ModalHeader>
-        <ModalTitle>{t`Pick your starting data`}</ModalTitle>
-      </ModalHeader>
-      <ModalBody>
-        <DataAppScaffoldingDataPicker value={value} onChange={setValue} />
-      </ModalBody>
-      <ModalFooter>
-        <Button onClick={onClose}>{t`Cancel`}</Button>
-        <Button
-          primary
-          disabled={!canSubmit}
-          onClick={handleCreate}
-        >{t`Create`}</Button>
-      </ModalFooter>
-    </ModalRoot>
+    <DataPicker.Provider>
+      <ModalRoot>
+        <ModalHeader>
+          <ModalTitle>{t`Pick your starting data`}</ModalTitle>
+          <DataPickerSearchInput />
+        </ModalHeader>
+        <ModalBody>
+          <DataAppScaffoldingDataPicker value={value} onChange={setValue} />
+        </ModalBody>
+        <ModalFooter>
+          <Button onClick={onClose}>{t`Cancel`}</Button>
+          <Button
+            primary
+            disabled={!canSubmit}
+            onClick={handleCreate}
+          >{t`Create`}</Button>
+        </ModalFooter>
+      </ModalRoot>
+    </DataPicker.Provider>
   );
 }
 

--- a/frontend/src/metabase/writeback/containers/CreateDataAppModal/CreateDataAppModal.tsx
+++ b/frontend/src/metabase/writeback/containers/CreateDataAppModal/CreateDataAppModal.tsx
@@ -13,6 +13,7 @@ import DataApps, { ScaffoldNewAppParams } from "metabase/entities/data-apps";
 import DataPicker, {
   useDataPicker,
   useDataPickerValue,
+  DataPickerValue,
 } from "metabase/containers/DataPicker";
 import DataAppScaffoldingDataPicker from "metabase/writeback/components/DataAppScaffoldingDataPicker";
 
@@ -25,6 +26,9 @@ import {
   ModalTitle,
   ModalBody,
   ModalFooter,
+  SearchInputContainer,
+  SearchInput,
+  SearchIcon,
 } from "./CreateDataAppModal.styled";
 
 interface OwnProps {
@@ -51,14 +55,28 @@ function mapDispatchToProps(dispatch: Dispatch) {
   };
 }
 
-function DataPickerSearchInput() {
+function getSearchInputPlaceholder(value: DataPickerValue) {
+  if (value?.type === "models") {
+    return t`Search for a model…`;
+  }
+  if (value?.type === "raw-data") {
+    return t`Search for a table…`;
+  }
+  return t`Search for some data…`;
+}
+
+function DataPickerSearchInput({ value }: { value: DataPickerValue }) {
   const { search } = useDataPicker();
+
   return (
-    <input
-      value={search.query}
-      onChange={e => search.setQuery(e.target.value)}
-      placeholder={t`Search`}
-    />
+    <SearchInputContainer>
+      <SearchIcon name="search" size={16} />
+      <SearchInput
+        value={search.query}
+        onChange={e => search.setQuery(e.target.value)}
+        placeholder={getSearchInputPlaceholder(value)}
+      />
+    </SearchInputContainer>
   );
 }
 
@@ -83,7 +101,7 @@ function CreateDataAppModal({ onCreate, onChangeLocation, onClose }: Props) {
       <ModalRoot>
         <ModalHeader>
           <ModalTitle>{t`Pick your starting data`}</ModalTitle>
-          <DataPickerSearchInput />
+          <DataPickerSearchInput value={value} />
         </ModalHeader>
         <ModalBody>
           <DataAppScaffoldingDataPicker value={value} onChange={setValue} />


### PR DESCRIPTION
Adds app-wide search support to scaffolding data picker. Also introduces a shareable `DataPickerContext` that can be used to customize the data picker layout. In our case, we want to render the search input outside the picker itself. For now, the context only keeps track of search-related stuff, but can eventually be extended.

The behavior should mirror what we have in QB `DataSelector` component (and we're re-using the underlying search component doing all the work):

* the search is going to happen only when more than two characters are filled in
* the search requests are debounced
* the search is scoped to the currently selected data type (in the model picker, we're only going to search for models; in the raw data picker we'll be looking for tables, etc. If no type is selected, we're going to search for everything)

### Demo

https://user-images.githubusercontent.com/17258145/197219838-34cbe539-8a2a-46f0-a790-02c29541e625.mp4

