### PR TITLE
Add `saml-configured`, `jwt-configured` and `google-auth-configured` settings, and some general setting refactor

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sso/api/interface.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/api/interface.clj
@@ -7,9 +7,9 @@
   complex logic around this, but now it's just a simple priority. If SAML is configured use that otherwise JWT"
   [_]
   (cond
-    (sso-settings/saml-configured?) :saml
-    (sso-settings/jwt-enabled)      :jwt
-    :else                           nil))
+    (sso-settings/saml-enabled) :saml
+    (sso-settings/jwt-enabled)  :jwt
+    :else                       nil))
 
 (defmulti sso-get
   "Multi-method for supporting the first part of an SSO signin request. An implementation of this method will usually

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
@@ -18,7 +18,7 @@
 (defn fetch-or-create-user!
   "Returns a session map for the given `email`. Will create the user if needed."
   [first-name last-name email user-attributes]
-  (when-not (sso-settings/jwt-configured?)
+  (when-not (sso-settings/jwt-enabled)
     (throw (IllegalArgumentException. (str (tru "Can't create new JWT user when JWT is not configured")))))
   (let [user {:first_name       first-name
               :last_name        last-name
@@ -90,7 +90,7 @@
       (mw.session/set-session-cookies request (response/redirect redirect-url) session (t/zoned-date-time (t/zone-id "GMT"))))))
 
 (defn- check-jwt-enabled []
-  (api/check (sso-settings/jwt-configured?)
+  (api/check (sso-settings/jwt-enabled)
     [400 (tru "JWT SSO has not been enabled and/or configured")]))
 
 (defmethod sso.i/sso-get :jwt
@@ -101,7 +101,7 @@
     (let [idp (sso-settings/jwt-identity-provider-uri)
           return-to-param (if (str/includes? idp "?") "&return_to=" "?return_to=")]
       (response/redirect (str idp (when redirect
-                                (str return-to-param redirect)))))))
+                                   (str return-to-param redirect)))))))
 
 (defmethod sso.i/sso-post :jwt
   [_]

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
@@ -95,9 +95,18 @@
              (client :get 403 "/auth/sso"))))))
 
 (deftest require-saml-enabled-test
-  (testing "SSO requests fail if SAML hasn't been enabled"
+  (testing "SSO requests fail if SAML hasn't been configured or enabled"
     (with-valid-premium-features-token
-      (mt/with-temporary-setting-values [saml-enabled false]
+      (mt/with-temporary-setting-values [saml-enabled                       false
+                                         saml-identity-provider-uri         nil
+                                         saml-identity-provider-certificate nil]
+        (is (some? (client :get 400 "/auth/sso"))))))
+
+  (testing "SSO requests fail if SAML has been configured but not enabled"
+    (with-valid-premium-features-token
+      (mt/with-temporary-setting-values [saml-enabled                       false
+                                         saml-identity-provider-uri         default-idp-uri
+                                         saml-identity-provider-certificate default-idp-cert]
         (is (some? (client :get 400 "/auth/sso"))))))
 
   (testing "SSO requests fail if SAML is enabled but hasn't been configured"

--- a/enterprise/frontend/src/metabase-enterprise/auth/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/auth/index.js
@@ -255,7 +255,7 @@ const SSO_PROVIDER = {
 };
 
 PLUGIN_AUTH_PROVIDERS.push(providers => {
-  if (MetabaseSettings.get("other-sso-configured?")) {
+  if (MetabaseSettings.get("other-sso-enabled?")) {
     providers = [SSO_PROVIDER, ...providers];
   }
   if (

--- a/frontend/src/metabase/lib/settings.ts
+++ b/frontend/src/metabase/lib/settings.ts
@@ -79,7 +79,7 @@ export type SettingName =
   | "is-hosted?"
   | "ldap-enabled"
   | "ldap-configured?"
-  | "other-sso-configured?"
+  | "other-sso-enabled?"
   | "enable-password-login"
   | "map-tile-server-url"
   | "password-complexity"

--- a/frontend/src/metabase/lib/settings.ts
+++ b/frontend/src/metabase/lib/settings.ts
@@ -196,9 +196,9 @@ class Settings {
     return this.get("ldap-configured?");
   }
 
-  // JWT or SAML is configured
-  isOtherSsoConfigured() {
-    return this.get("other-sso-configured?");
+  // JWT or SAML is enabled
+  isOtherSsoEnabled() {
+    return this.get("other-sso-enabled?");
   }
 
   isSsoEnabled() {

--- a/src/metabase/integrations/google.clj
+++ b/src/metabase/integrations/google.clj
@@ -34,6 +34,12 @@
                    (setting/set-value-of-type! :string :google-auth-client-id nil)
                    (setting/set-value-of-type! :boolean :google-auth-enabled false)))))
 
+(defsetting google-auth-configured
+  (deferred-tru "Is Google Sign-In configured?")
+  :type   :boolean
+  :setter :none
+  :getter (fn [] (boolean (google-auth-client-id))))
+
 (defsetting google-auth-enabled
   (deferred-tru "Is Google Sign-in currently enabled?")
   :visibility :public

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -29,7 +29,7 @@
 (defn- ee-sso-configured? []
   (u/ignore-exceptions
     (classloader/require 'metabase-enterprise.sso.integrations.sso-settings))
-  (when-let [varr (resolve 'metabase-enterprise.sso.integrations.sso-settings/other-sso-configured?)]
+  (when-let [varr (resolve 'metabase-enterprise.sso.integrations.sso-settings/other-sso-enabled?)]
     (varr)))
 
 (defn sso-enabled?


### PR DESCRIPTION
This PR contains some refactor of various SSO settings to support FE changes being done by @ranquild in #26040 and #26064. This is a replacement for #25869 which was the wrong approach.

The end state of this PR is: For JWT and SAML, there is both a `jwt/saml-configured` setting and a `jwt/saml-enabled` setting. The `-configured` settings just check that a couple of the required settings are set for each SSO method. The `-enabled` settings are simple booleans controlled by toggles on the UI, but only returns `true` if the `configured` setting is also `true`, and these are the settings that should be used when determining whether a given SSO method should be allowed for logins. I've also added `google-auth-configured` which just checks for the presence of the client ID, as a convenience for the frontend.