### PR TITLE
Fix back navigation to root of data reference tree

### DIFF
--- a/frontend/src/metabase/query_builder/actions/native.js
+++ b/frontend/src/metabase/query_builder/actions/native.js
@@ -13,6 +13,7 @@ import {
   getTemplateTagParameters,
 } from "metabase-lib/lib/parameters/utils/template-tags";
 import {
+  getDataReferenceStack,
   getNativeEditorCursorOffset,
   getNativeEditorSelectedText,
   getQuestion,
@@ -27,12 +28,27 @@ export const toggleDataReference = createAction(TOGGLE_DATA_REFERENCE, () => {
   MetabaseAnalytics.trackStructEvent("QueryBuilder", "Toggle Data Reference");
 });
 
+export const SET_DATA_REFERENCE_STACK = "metabase/qb/SET_DATA_REFERENCE_STACK";
+export const setDataReferenceStack = createAction(SET_DATA_REFERENCE_STACK);
+
 export const POP_DATA_REFERENCE_STACK = "metabase/qb/POP_DATA_REFERENCE_STACK";
-export const popDataReferenceStack = createAction(POP_DATA_REFERENCE_STACK);
+export const popDataReferenceStack = createThunkAction(
+  POP_DATA_REFERENCE_STACK,
+  () => (dispatch, getState) => {
+    const stack = getDataReferenceStack(getState());
+    dispatch(setDataReferenceStack(stack.slice(0, -1)));
+  },
+);
 
 export const PUSH_DATA_REFERENCE_STACK =
   "metabase/qb/PUSH_DATA_REFERENCE_STACK";
-export const pushDataReferenceStack = createAction(PUSH_DATA_REFERENCE_STACK);
+export const pushDataReferenceStack = createThunkAction(
+  PUSH_DATA_REFERENCE_STACK,
+  item => (dispatch, getState) => {
+    const stack = getDataReferenceStack(getState());
+    dispatch(setDataReferenceStack(stack.concat([item])));
+  },
+);
 
 export const OPEN_DATA_REFERENCE_AT_QUESTION =
   "metabase/qb/OPEN_DATA_REFERENCE_AT_QUESTION";

--- a/frontend/src/metabase/query_builder/components/SidebarHeader/SidebarHeader.tsx
+++ b/frontend/src/metabase/query_builder/components/SidebarHeader/SidebarHeader.tsx
@@ -43,7 +43,11 @@ function SidebarHeader({ className, title, icon, onBack, onClose }: Props) {
 
   return (
     <HeaderRoot className={className}>
-      <HeaderTitleContainer variant={headerVariant} onClick={onBack}>
+      <HeaderTitleContainer
+        variant={headerVariant}
+        onClick={onBack}
+        data-testid="sidebar-header-title"
+      >
         {onBack && <HeaderIcon name="chevronleft" />}
         {icon && <HeaderIcon name={icon} />}
         {hasDefaultBackButton ? t`Back` : title}

--- a/frontend/src/metabase/query_builder/reducers.js
+++ b/frontend/src/metabase/query_builder/reducers.js
@@ -6,8 +6,7 @@ import Utils from "metabase/lib/utils";
 import {
   RESET_QB,
   INITIALIZE_QB,
-  POP_DATA_REFERENCE_STACK,
-  PUSH_DATA_REFERENCE_STACK,
+  SET_DATA_REFERENCE_STACK,
   OPEN_DATA_REFERENCE_AT_QUESTION,
   TOGGLE_DATA_REFERENCE,
   TOGGLE_TEMPLATE_TAGS_EDITOR,
@@ -161,16 +160,10 @@ export const uiControls = handleActions(
         isShowingDataReference: !state.isShowingDataReference,
       }),
     },
-    [POP_DATA_REFERENCE_STACK]: {
+    [SET_DATA_REFERENCE_STACK]: {
       next: (state, { payload }) => ({
         ...state,
-        dataReferenceStack: state.dataReferenceStack.slice(0, -1),
-      }),
-    },
-    [PUSH_DATA_REFERENCE_STACK]: {
-      next: (state, { payload }) => ({
-        ...state,
-        dataReferenceStack: (state.dataReferenceStack || []).concat([payload]),
+        dataReferenceStack: payload,
       }),
     },
     [OPEN_DATA_REFERENCE_AT_QUESTION]: {

--- a/frontend/test/metabase/scenarios/native/data_ref.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/data_ref.cy.spec.js
@@ -9,6 +9,9 @@ describe("scenarios > native question > data reference sidebar", () => {
   it("should show tables", () => {
     openNativeEditor();
     cy.icon("reference").click();
+    cy.get("[data-testid='sidebar-header-title']").findByText(
+      "Sample Database",
+    );
     cy.findByText("ORDERS").click();
     cy.findByText(
       "Confirmed Sample Company orders for a product, from a user.",
@@ -16,6 +19,13 @@ describe("scenarios > native question > data reference sidebar", () => {
     cy.findByText("9 columns");
     cy.findByText("QUANTITY").click();
     cy.findByText("Number of products bought.");
+    // clicking the title should navigate back
+    cy.findByText("QUANTITY").click();
+    cy.findByText("ORDERS").click();
+    cy.get("[data-testid='sidebar-header-title']")
+      .findByText("Sample Database")
+      .click();
+    cy.findByText("Data Reference");
   });
 
   it("should show models", () => {


### PR DESCRIPTION
### Bug description:
If you open the data reference in the native query editor after selecting a database, pressing the back button (or the database name) doesn't navigate to the root as expected.

### Expected behaviour:
Clicking on the title of the database should navigate to the data reference root.

That is,
Clicking here:
<img width="416" alt="image" src="https://user-images.githubusercontent.com/39073188/197157150-7953330f-1fb7-4290-9040-28f93d5c61fc.png">

Should navigate here:
<img width="477" alt="image" src="https://user-images.githubusercontent.com/39073188/197157035-c8ee6870-1457-4122-92e0-9cb9ab3ac885.png">

Here's [a loom](https://www.loom.com/share/7750b7db44e948d0b7cefc8bc6bd19bd) demoing the bug in full.

I've updated the tests to check the back navigation is working.