### PR TITLE
Fix data app nav items wrapping

### DIFF
--- a/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbar/DataAppNavbarView.styled.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbar/DataAppNavbarView.styled.tsx
@@ -8,6 +8,7 @@ export const Root = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 1rem;
 
   background-color: ${color("bg-white")};
   border-bottom: 1px solid ${color("border")};
@@ -17,7 +18,13 @@ export const Root = styled.div`
 export const NavItemsList = styled.ul`
   display: flex;
   flex-direction: row;
+  align-items: center;
   gap: 6px;
+
+  height: 3rem;
+
+  white-space: nowrap;
+  overflow-x: scroll;
 `;
 
 export const ActionPanelContainer = styled.div`


### PR DESCRIPTION
Adds `overflow-x: scroll` to data app navbar, so if there are a lot of pages and long names, the navbar doesn't wrap things.

### Demo

**Before**

<img width="1263" alt="CleanShot 2022-10-21 at 16 07 47@2x" src="https://user-images.githubusercontent.com/17258145/197231567-85122379-4a3b-42cf-b0bf-92d0f491aa43.png">

**After**

https://user-images.githubusercontent.com/17258145/197231551-e50df403-0c74-4f42-8176-ada59ccabbbf.mp4

