### PR TITLE
Show collection name in question tag autocomplete results

### DIFF
--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor.css
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor.css
@@ -4,7 +4,7 @@
   border-radius: 4px;
   background-color: white;
   color: #4c5773;
-  width: 400px;
+  width: 520px;
 }
 
 .ace_editor.ace_autocomplete .ace_marker-layer .ace_active-line,

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
@@ -403,16 +403,21 @@ class NativeQueryEditor extends Component {
     // Note we need to drop the leading `#` from the card tag name because the prefix only includes alphanumerics
     if (prefix !== this.getCardTagNameAtCursor(pos).substring(1)) {
       callback(null, null);
-      return null;
     }
     const apiResults = await this.props.cardAutocompleteResultsFn(prefix);
-    // Convert to format ace expects
-    const resultsForAce = apiResults.map(({ id, name, dataset }) => ({
-      name: `${id}-${slugg(name)}`,
-      value: `${id}-${slugg(name)}`,
-      meta: dataset ? t`Model` : t`Question`,
-      score: dataset ? 100000 : 0, // prioritize models above questions
-    }));
+    const resultsForAce = apiResults.map(
+      ({ id, name, dataset, collection_name }) => {
+        const collectionName = collection_name || t`Our analytics`;
+        return {
+          name: `${id}-${slugg(name)}`,
+          value: `${id}-${slugg(name)}`,
+          meta: dataset
+            ? t`Model in ${collectionName}`
+            : t`Question in ${collectionName}`,
+          score: dataset ? 100000 : 0, // prioritize models above questions
+        };
+      },
+    );
     callback(null, resultsForAce);
   };
 

--- a/frontend/test/metabase/scenarios/native/native_subquery.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/native_subquery.cy.spec.js
@@ -1,4 +1,8 @@
-import { restore, visitQuestion } from "__support__/e2e/helpers";
+import {
+  openQuestionActions,
+  restore,
+  visitQuestion,
+} from "__support__/e2e/helpers";
 
 describe("scenarios > question > native subquery", () => {
   beforeEach(() => {
@@ -39,7 +43,7 @@ describe("scenarios > question > native subquery", () => {
           // typing a template tag id should open the editor
           cy.get(".ace_editor:not(.ace_autocomplete)")
             .type(" ")
-            .type(`{{#`, { parseSpecialCharSequences: false })
+            .type("{{#")
             .type(`{leftarrow}{leftarrow}${questionId2}`);
           cy.findByText("A People Model");
         });
@@ -47,53 +51,41 @@ describe("scenarios > question > native subquery", () => {
     });
   });
 
-  it("autocomplete should work for question slugs inside template tags", () => {
-    // Create two saved questions, the first will be referenced in the query when it is opened, and the second will be added to the query after it is opened.
+  it("autocomplete should complete question slugs inside template tags", () => {
+    // Create a question and a model.
     cy.createNativeQuestion({
       name: "A People Question",
       native: {
-        query: "SELECT id AS a_unique_column_name FROM PEOPLE",
+        query: "SELECT id FROM PEOPLE",
       },
     }).then(({ body: { id: questionId1 } }) => {
       cy.createNativeQuestion({
-        name: "A People Question 2",
+        name: "A People Model",
         native: {
-          query: "SELECT id AS another_unique_column_name FROM PEOPLE",
+          query: "SELECT id FROM PEOPLE",
         },
+        dataset: true,
       }).then(({ body: { id: questionId2 } }) => {
-        const tagID = `#${questionId1}`;
-
-        // create a question with a template tag
         cy.createNativeQuestion({
-          name: "Count of People",
+          name: "Count ",
           native: {
             query: `select COUNT(*) from `,
-            "template-tags": {
-              [tagID]: {
-                id: "10422a0f-292d-10a3-fd90-407cc9e3e20e",
-                name: tagID,
-                "display-name": tagID,
-                type: "card",
-                "card-id": questionId1,
-              },
-            },
           },
         }).then(({ body: { id: questionId3 } }) => {
-          cy.wrap(questionId3).as("toplevelQuestionId");
+          // Move question 2 to personal collection
+          cy.visit(`/question/${questionId2}`);
+          openQuestionActions();
+          cy.findByTestId("move-button").click();
+          cy.findByText("My personal collection").click();
+          cy.findByText("Move").click();
+
           cy.visit(`/question/${questionId3}`);
-
-          // Refresh the state, so previously created questions need to be loaded again.
-          cy.reload();
+          cy.reload(); // Refresh the state, so previously created questions need to be loaded again.
           cy.findByText("Open Editor").click();
-          cy.get(".ace_editor").should("be.visible").type(" {{#");
-
-          // Can't use cy.type here as it doesn't consistently keep the autocomplete open
-          cy.realPress("p");
-          cy.realPress("e");
-          cy.realPress("o");
-          cy.realPress("p");
-          cy.realPress("l");
-          cy.realPress("e");
+          cy.get(".ace_editor")
+            .should("be.visible")
+            .type(" ")
+            .type("{{#people");
 
           // Wait until another explicit autocomplete is triggered
           // (slightly longer than AUTOCOMPLETE_DEBOUNCE_DURATION)
@@ -101,16 +93,22 @@ describe("scenarios > question > native subquery", () => {
           cy.wait(1000);
           cy.get(".ace_autocomplete")
             .should("be.visible")
+            .findByText(`${questionId2}-a-`);
+          cy.get(".ace_autocomplete")
+            .should("be.visible")
+            .findByText("Model in Bobby Tables's Personal Collection");
+          cy.get(".ace_autocomplete")
+            .should("be.visible")
             .findByText(`${questionId1}-a-`);
           cy.get(".ace_autocomplete")
             .should("be.visible")
-            .findByText(`${questionId2}-a-`);
+            .findByText("Question in Our analytics");
         });
       });
     });
   });
 
-  it("autocomplete should work for referencing saved questions", () => {
+  it("autocomplete should work for columns from referenced questions", () => {
     // Create two saved questions, the first will be referenced in the query when it is opened, and the second will be added to the query after it is opened.
     cy.createNativeQuestion({
       name: "A People Question 1",
@@ -147,9 +145,7 @@ describe("scenarios > question > native subquery", () => {
 
           // Refresh the state, so previously created questions need to be loaded again.
           cy.reload();
-
           cy.findByText("Open Editor").click();
-
           cy.get(".ace_editor").should("be.visible").type(" ").type("a_unique");
 
           // Wait until another explicit autocomplete is triggered
@@ -164,9 +160,7 @@ describe("scenarios > question > native subquery", () => {
           // For some reason, typing `{{#${questionId2}}}` in one go isn't deterministic,
           // so type it in two parts
           cy.get(".ace_editor:not(.ace_autocomplete)")
-            .type(` {{#`, {
-              parseSpecialCharSequences: false,
-            })
+            .type(` {{#`)
             .type(`{leftarrow}{leftarrow}${questionId2}`);
 
           // Wait until another explicit autocomplete is triggered

--- a/frontend/test/metabase/scenarios/native/native_subquery.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/native_subquery.cy.spec.js
@@ -1,4 +1,5 @@
 import {
+  openNativeEditor,
   openQuestionActions,
   restore,
   visitQuestion,
@@ -66,44 +67,33 @@ describe("scenarios > question > native subquery", () => {
         },
         dataset: true,
       }).then(({ body: { id: questionId2 } }) => {
-        cy.createNativeQuestion({
-          name: "Count ",
-          native: {
-            query: `select COUNT(*) from `,
-          },
-        }).then(({ body: { id: questionId3 } }) => {
-          // Move question 2 to personal collection
-          cy.visit(`/question/${questionId2}`);
-          openQuestionActions();
-          cy.findByTestId("move-button").click();
-          cy.findByText("My personal collection").click();
-          cy.findByText("Move").click();
+        // Move question 2 to personal collection
+        cy.visit(`/question/${questionId2}`);
+        openQuestionActions();
+        cy.findByTestId("move-button").click();
+        cy.findByText("My personal collection").click();
+        cy.findByText("Move").click();
 
-          cy.visit(`/question/${questionId3}`);
-          cy.reload(); // Refresh the state, so previously created questions need to be loaded again.
-          cy.findByText("Open Editor").click();
-          cy.get(".ace_editor")
-            .should("be.visible")
-            .type(" ")
-            .type("{{#people");
+        openNativeEditor();
+        cy.reload(); // Refresh the state, so previously created questions need to be loaded again.
+        cy.get(".ace_editor").should("be.visible").type(" ").type("{{#people");
 
-          // Wait until another explicit autocomplete is triggered
-          // (slightly longer than AUTOCOMPLETE_DEBOUNCE_DURATION)
-          // See https://github.com/metabase/metabase/pull/20970
-          cy.wait(1000);
-          cy.get(".ace_autocomplete")
-            .should("be.visible")
-            .findByText(`${questionId2}-a-`);
-          cy.get(".ace_autocomplete")
-            .should("be.visible")
-            .findByText("Model in Bobby Tables's Personal Collection");
-          cy.get(".ace_autocomplete")
-            .should("be.visible")
-            .findByText(`${questionId1}-a-`);
-          cy.get(".ace_autocomplete")
-            .should("be.visible")
-            .findByText("Question in Our analytics");
-        });
+        // Wait until another explicit autocomplete is triggered
+        // (slightly longer than AUTOCOMPLETE_DEBOUNCE_DURATION)
+        // See https://github.com/metabase/metabase/pull/20970
+        cy.wait(1000);
+        cy.get(".ace_autocomplete")
+          .should("be.visible")
+          .findByText(`${questionId2}-a-`);
+        cy.get(".ace_autocomplete")
+          .should("be.visible")
+          .findByText("Model in Bobby Tables's Personal Collection");
+        cy.get(".ace_autocomplete")
+          .should("be.visible")
+          .findByText(`${questionId1}-a-`);
+        cy.get(".ace_autocomplete")
+          .should("be.visible")
+          .findByText("Question in Our analytics");
       });
     });
   });

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -430,26 +430,27 @@
                         second
                         (str/replace #"-" " ")
                         str/lower-case)]
-    (db/select [Card :id :dataset :database_id :name :collection_id]
+    (db/select [Card :id :dataset :database_id :name :collection_id [:collection.name :collection_name]]
                {:where    [:and
-                           [:= :database_id database-id]
-                           [:= :archived false]
+                           [:= :report_card.database_id database-id]
+                           [:= :report_card.archived false]
                            (cond
                              ;; e.g. search-string = "123"
                              (and (not-empty search-id) (empty? search-name))
-                             [:like (hx/cast (if (= (mdb.connection/db-type) :mysql) :char :text) :id) (str search-id "%")]
+                             [:like (hx/cast (if (= (mdb.connection/db-type) :mysql) :char :text) :report_card.id) (str search-id "%")]
 
                              ;; e.g. search-string = "123-foo"
                              (and (not-empty search-id) (not-empty search-name))
                              [:and
-                              [:= :id (Integer/parseInt search-id)]
+                              [:= :report_card.id (Integer/parseInt search-id)]
                               ;; this is a prefix match to be consistent with substring matches on the entire slug
-                              [:like :%lower.name (str search-name "%")]]
+                              [:like :%lower.report_card.name (str search-name "%")]]
 
                              ;; e.g. search-string = "foo"
                              (and (empty? search-id) (not-empty search-name))
-                             [:like :%lower.name (str "%" search-name "%")])]
-                :order-by [[:id :desc]]
+                             [:like :%lower.report_card.name (str "%" search-name "%")])]
+                :left-join [[:collection :collection] [:= :collection.id :report_card.collection_id]]
+                :order-by [[:report_card.id :desc]]
                 :limit    50})))
 
 (defn- autocomplete-fields [db-id search-string limit]
@@ -544,7 +545,8 @@
   (try
     (->> (autocomplete-cards id query)
          (filter mi/can-read?)
-         (map #(select-keys % [:id :name :dataset])))
+        ;;  ((fn [xs] (prn (map mi/can-read? xs)) xs))
+         (map #(select-keys % [:id :name :dataset :collection_name])))
     (catch Throwable t
       (log/warn "Error with autocomplete: " (.getMessage t)))))
 

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -545,7 +545,6 @@
   (try
     (->> (autocomplete-cards id query)
          (filter mi/can-read?)
-        ;;  ((fn [xs] (prn (map mi/can-read? xs)) xs))
          (map #(select-keys % [:id :name :dataset :collection_name])))
     (catch Throwable t
       (log/warn "Error with autocomplete: " (.getMessage t)))))

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -3,7 +3,6 @@
   (:require [clojure.string :as str]
             [clojure.test :refer :all]
             [medley.core :as m]
-            [metabase.api.card-test :as api.card-test]
             [metabase.api.database :as api.database]
             [metabase.api.table :as api.table]
             [metabase.driver :as driver]

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -410,27 +410,28 @@
                                                      :substring "a")))))))))))
 
 (deftest card-autocomplete-suggestions-test
-  (let [result (fn [card] (select-keys card [:id :name :dataset]))]
-    (testing "GET /api/database/:id/card_autocomplete_suggestions"
-      (mt/with-temp* [Card [card-1 (card-with-native-query "Kanye West Quote Views Per Month")]
-                      Card [card-2 (card-with-native-query "Kanye West Quote Views Per Day")]]
+  (testing "GET /api/database/:id/card_autocomplete_suggestions"
+    (mt/with-temp* [Collection [collection {:name "Kanye West Analytics"}]
+                    Card       [card-1 (card-with-native-query "Kanye West Quote Views Per Month")]
+                    Card       [card-2 (card-with-native-query "Kanye West Quote Views Per Day" :collection_id (:id collection))]]
+      (let [card->result {card-1 (assoc (select-keys card-1 [:id :name :dataset]) :collection_name nil)
+                          card-2 (assoc (select-keys card-2 [:id :name :dataset]) :collection_name (:name collection))}]
         (testing "exclude cards without perms"
           (mt/with-non-admin-groups-no-root-collection-perms
-            (api.card-test/with-cards-in-readable-collection [card-1]
-              (is (= [(result card-1)]
-                     (mt/user-http-request :rasta :get 200
-                                           (format "database/%d/card_autocomplete_suggestions" (mt/id))
-                                           :query "kanye")))))
-        (testing "cards should match the query"
-          (doseq [[query expected-cards] {"QUOTE-views"               [card-2 card-1]
-                                          "per-day"                   [card-2]
-                                          (str (:id card-1))          [card-1]
-                                          (str (:id card-2) "-kanye") [card-2]
-                                          (str (:id card-2) "-west")  []}]
-            (is (= (map result expected-cards)
+            (is (= [(card->result card-2)]
                    (mt/user-http-request :rasta :get 200
                                          (format "database/%d/card_autocomplete_suggestions" (mt/id))
-                                         :query query))))))
+                                         :query "kanye"))))
+          (testing "cards should match the query"
+            (doseq [[query expected-cards] {"QUOTE-views"               [card-2 card-1]
+                                            "per-day"                   [card-2]
+                                            (str (:id card-1))          [card-1]
+                                            (str (:id card-2) "-kanye") [card-2]
+                                            (str (:id card-2) "-west")  []}]
+              (is (= (map card->result expected-cards)
+                     (mt/user-http-request :rasta :get 200
+                                           (format "database/%d/card_autocomplete_suggestions" (mt/id))
+                                           :query query)))))))
       (testing "should reject requests for databases for which the user has no perms"
         (mt/with-temp* [Database [{database-id :id}]
                         Card     [_ (card-with-native-query "Kanye West Quote Views Per Month" :database_id database-id)]]
@@ -438,7 +439,7 @@
           (is (= "You don't have permissions to do that."
                  (mt/user-http-request :rasta :get 403
                                        (format "database/%d/card_autocomplete_suggestions" database-id)
-                                       :query "kanye")))))))))
+                                       :query "kanye"))))))))
 
 (driver/register! ::no-nested-query-support
                   :parent :sql-jdbc


### PR DESCRIPTION
Shows the collection name in question tag autocomplete results in the native query editor.

Part of [this epic](https://github.com/metabase/metabase/issues/25050).

Before:
<img width="511" alt="image" src="https://user-images.githubusercontent.com/39073188/197273540-1e68569a-6031-4202-84ac-660b9ae4ee89.png">

After:
<img width="537" alt="image" src="https://user-images.githubusercontent.com/39073188/197273696-431a6bcb-34ed-4631-8346-8b503b182277.png">
