### PR TITLE
Metadata Forms 3: Smarten up some form types

### DIFF
--- a/frontend/src/metabase-types/api/card.ts
+++ b/frontend/src/metabase-types/api/card.ts
@@ -1,4 +1,5 @@
-import { DatasetQuery } from "./query";
+import type { Field } from "../types/Field";
+import type { DatasetQuery } from "./query";
 
 export interface Card extends UnsavedCard {
   id: CardId;
@@ -8,6 +9,8 @@ export interface Card extends UnsavedCard {
   can_write: boolean;
   cache_ttl: number | null;
   last_query_start: string | null;
+  result_metadata?: Field[];
+
   archived: boolean;
 
   creator?: {

--- a/frontend/src/metabase-types/api/data-app.ts
+++ b/frontend/src/metabase-types/api/data-app.ts
@@ -7,6 +7,7 @@ import {
 } from "./dashboard";
 import { WritebackAction } from "./writeback";
 import { ActionDisplayType } from "./writeback-form-settings";
+import type { Card } from "./card";
 
 export type DataAppId = number;
 export type DataAppPage = Dashboard;
@@ -48,6 +49,7 @@ export interface ActionDashboardCard
   extends Omit<BaseDashboardOrderedCard, "parameter_mappings"> {
   action?: WritebackAction;
   card_id?: number; // model card id for the associated action
+  card?: Card;
 
   parameter_mappings?: ActionParametersMapping[] | null;
   visualization_settings: {

--- a/frontend/src/metabase-types/api/writeback-form-settings.ts
+++ b/frontend/src/metabase-types/api/writeback-form-settings.ts
@@ -1,3 +1,5 @@
+import type { Validator, FormFieldDefinition } from "metabase-types/forms";
+import type Field from "metabase-lib/lib/metadata/Field";
 import type { ParameterId } from "./parameters";
 
 export type ActionDisplayType = "form" | "button";
@@ -11,7 +13,11 @@ export type InputType =
   | "text"
   | "number"
   | "dropdown"
-  | "inline-select";
+  | "radio"
+  | "email"
+  | "password"
+  | "boolean"
+  | "category";
 
 export type Size = "small" | "medium" | "large";
 
@@ -20,8 +26,9 @@ export type NumberRange = [number, number];
 
 export interface FieldSettings {
   name: string;
+  title: string;
   order: number;
-  description?: string;
+  description?: string | null;
   placeholder?: string;
   fieldType: FieldType;
   inputType: InputType;
@@ -33,6 +40,7 @@ export interface FieldSettings {
   width?: Size;
   height?: number;
   hasSearch?: boolean;
+  fieldInstance?: Field;
 }
 
 export type FieldSettingsMap = Record<ParameterId, FieldSettings>;
@@ -46,3 +54,17 @@ export interface ActionFormSettings {
   successMessage?: string;
   errorMessage?: string;
 }
+
+export type ActionFormOption = {
+  name: string | number;
+  value: string | number;
+};
+
+export type ActionFormFieldProps = FormFieldDefinition & {
+  validator?: Validator;
+  fieldInstance?: Field;
+};
+
+export type ActionFormProps = {
+  fields: ActionFormFieldProps[];
+};

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarMainView/ClickBehaviorSidebarMainView.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarMainView/ClickBehaviorSidebarMainView.tsx
@@ -26,6 +26,12 @@ interface ClickBehaviorOptionsProps {
   updateSettings: (settings: Partial<ClickBehavior>) => void;
 }
 
+export function isActionDashboardCard(
+  dashcard: unknown,
+): dashcard is ActionDashboardCard {
+  return "action" in (dashcard as ActionDashboardCard);
+}
+
 function ClickBehaviorOptions({
   clickBehavior,
   dashboard,
@@ -33,13 +39,8 @@ function ClickBehaviorOptions({
   parameters,
   updateSettings,
 }: ClickBehaviorOptionsProps) {
-  if (dashcard.action) {
-    return (
-      <ActionOptions
-        dashcard={dashcard as ActionDashboardCard}
-        parameters={parameters}
-      />
-    );
+  if (isActionDashboardCard(dashcard)) {
+    return <ActionOptions dashcard={dashcard} parameters={parameters} />;
   }
   if (clickBehavior.type === "link") {
     return (

--- a/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/FieldSettingsPopover.tsx
+++ b/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/FieldSettingsPopover.tsx
@@ -84,8 +84,7 @@ export function FormCreatorPopoverBody({
     });
 
   const hasPlaceholder =
-    fieldSettings.fieldType !== "date" &&
-    fieldSettings.inputType !== "inline-select";
+    fieldSettings.fieldType !== "date" && fieldSettings.inputType !== "radio";
 
   return (
     <SettingsPopoverBody data-testid="field-settings-popover">

--- a/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/FormCreator.tsx
+++ b/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/FormCreator.tsx
@@ -90,7 +90,7 @@ function FormItem({
 
   const hasOptions =
     fieldSettings.inputType === "dropdown" ||
-    fieldSettings.inputType === "inline-select";
+    fieldSettings.inputType === "radio";
 
   return (
     <FormItemWrapper>

--- a/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/constants.ts
+++ b/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/constants.ts
@@ -54,7 +54,7 @@ const getSelectInputs = (): InputOptionType[] => [
     name: t`dropdown`,
   },
   {
-    value: "inline-select",
+    value: "radio",
     name: t`inline select`,
   },
 ];

--- a/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/utils.ts
+++ b/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/utils.ts
@@ -36,6 +36,7 @@ export const getDefaultFieldSettings = (
   overrides: Partial<FieldSettings> = {},
 ): FieldSettings => ({
   name: "",
+  title: "",
   order: 0,
   description: "",
   placeholder: "",

--- a/frontend/src/metabase/writeback/containers/ActionParametersInputForm/utils.ts
+++ b/frontend/src/metabase/writeback/containers/ActionParametersInputForm/utils.ts
@@ -3,9 +3,8 @@ import { isEmpty } from "metabase/lib/validate";
 import type {
   FieldSettings,
   ParametersForActionExecution,
+  ActionFormProps,
 } from "metabase-types/api";
-
-import type { StandardFormFieldDefinition } from "metabase-types/forms";
 
 // set user-defined default values for any non-required empty parameters
 export function setDefaultValues(
@@ -48,13 +47,9 @@ export const getChangedValues = (
   return Object.fromEntries(changedValues);
 };
 
-type BasicForm = {
-  fields: StandardFormFieldDefinition[];
-};
-
 // maps intial values, if any, into an intialValues map
 export const getInitialValues = (
-  form: BasicForm,
+  form: ActionFormProps,
   prefetchValues: ParametersForActionExecution,
 ) => {
   return Object.fromEntries(


### PR DESCRIPTION
## Description

I just love typescript and how it babysits me and keeps me from doing dumb things. As we do more complicated things with forms and metadata, our types need to get better.

This also changes the key for a radio input in action form settings from `inline-select` to `radio` ... because it just makes more sense.  Small breaking change for existing forms, but I think it's fine at this point.
