### PR TITLE
Metadata Forms 4: Use Field Metadata to build implicit action forms 🎈 

### DIFF
--- a/frontend/src/metabase/components/form/FormWidget.jsx
+++ b/frontend/src/metabase/components/form/FormWidget.jsx
@@ -42,7 +42,7 @@ const WIDGETS = {
   hidden: FormHiddenWidget,
   textFile: FormTextFileWidget,
   model: FormModelWidget,
-  category: CategoryFieldPicker,
+  categoryPillOrSearch: CategoryFieldPicker,
 };
 
 export function getWidgetComponent(formField) {

--- a/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/FormField.tsx
+++ b/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/FormField.tsx
@@ -4,7 +4,7 @@ import type { TemplateTag } from "metabase-types/types/Query";
 
 import { getWidgetComponent } from "metabase/components/form/FormWidget";
 
-import { getFormFieldForParameter } from "./utils";
+import { getFormField } from "./utils";
 
 // sample form fields
 export function FormField({
@@ -14,7 +14,7 @@ export function FormField({
   tag: TemplateTag;
   fieldSettings: FieldSettings;
 }) {
-  const fieldProps = getFormFieldForParameter(tag, fieldSettings);
+  const fieldProps = getFormField(tag, fieldSettings);
   const InputField = getWidgetComponent(fieldProps);
   return <InputField field={fieldProps} {...fieldProps} />;
 }

--- a/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/utils.unit.spec.ts
+++ b/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/utils.unit.spec.ts
@@ -1,0 +1,264 @@
+import Field from "metabase-lib/lib/metadata/Field";
+
+import {
+  getFormField,
+  getForm,
+  generateFieldSettingsFromParameters,
+  getInputType,
+} from "./utils";
+
+const createField = (options?: any) => {
+  return new Field({
+    name: "test_field",
+    display_name: "Test Field",
+    base_type: "type/Text",
+    semantic_type: "type/Text",
+    ...options,
+  });
+};
+
+const createParameter = (options?: any) => {
+  return {
+    id: "test_parameter",
+    name: "Test Parameter",
+    type: "type/Text",
+    ...options,
+  };
+};
+
+const getFirstEntry = (obj: any): any => {
+  return Object.entries(obj)[0];
+};
+
+describe("writeback > ActionCreator > FormCreator > utils", () => {
+  describe("generateFieldSettingsFromParameters", () => {
+    it("should generate settings for a string field", () => {
+      const fields = [createField({ name: "test-field" })];
+      const params = [createParameter({ id: "test-field" })];
+      const [id, settings] = getFirstEntry(
+        generateFieldSettingsFromParameters(params, fields),
+      );
+
+      expect(settings.fieldType).toBe("string");
+      expect(settings.inputType).toBe("string");
+    });
+
+    it("should generate settings for an Integer field", () => {
+      const fields = [
+        createField({
+          name: "test-field",
+          base_type: "type/Integer",
+          semantic_type: "type/Integer",
+        }),
+      ];
+      const params = [
+        createParameter({ id: "test-field", type: "type/Integer" }),
+      ];
+      const [id, settings] = getFirstEntry(
+        generateFieldSettingsFromParameters(params, fields),
+      );
+
+      expect(settings.fieldType).toBe("number");
+      expect(settings.inputType).toBe("number");
+    });
+
+    it("should generate settings for a float field", () => {
+      const fields = [
+        createField({
+          name: "test-field",
+          base_type: "type/Float",
+          semantic_type: "type/Float",
+        }),
+      ];
+      const params = [
+        createParameter({ id: "test-field", type: "type/Float" }),
+      ];
+      const [id, settings] = getFirstEntry(
+        generateFieldSettingsFromParameters(params, fields),
+      );
+
+      expect(settings.fieldType).toBe("number");
+      expect(settings.inputType).toBe("number");
+    });
+
+    it("should generate settings for a category field", () => {
+      const fields = [
+        createField({ name: "test-field", semantic_type: "type/Category" }),
+      ];
+      const params = [createParameter({ id: "test-field", type: "type/Text" })];
+      const [id, settings] = getFirstEntry(
+        generateFieldSettingsFromParameters(params, fields),
+      );
+
+      expect(settings.fieldType).toBe("string");
+      expect(settings.inputType).toBe("category");
+    });
+
+    it("should set the parameter id as the object key", () => {
+      const fields = [createField({ name: "test-field" })];
+      const params = [createParameter({ id: "test-field" })];
+      const [id, settings] = getFirstEntry(
+        generateFieldSettingsFromParameters(params, fields),
+      );
+
+      expect(id).toEqual("test-field");
+    });
+
+    it("should get display name from field metadata", () => {
+      const fields = [createField({ name: "test-field" })];
+      const params = [createParameter({ id: "test-field" })];
+      const [id, settings] = getFirstEntry(
+        generateFieldSettingsFromParameters(params, fields),
+      );
+
+      expect(settings.placeholder).toBe("Test Field");
+      expect(settings.title).toBe("Test Field");
+    });
+
+    it("matches field names to parameter ids case-insensitively", () => {
+      const fields = [createField({ name: "TEST-field" })];
+      const params = [createParameter({ id: "test-field" })];
+      const [id, settings] = getFirstEntry(
+        generateFieldSettingsFromParameters(params, fields),
+      );
+
+      expect(id).toEqual("test-field");
+      expect(settings.placeholder).toBe("Test Field");
+      expect(settings.title).toBe("Test Field");
+      expect(settings.name).toBe("Test Parameter");
+    });
+
+    it("sets settings from parameter if there is no corresponding field", () => {
+      const fields = [createField({ name: "xyz", description: "foo bar baz" })];
+      const params = [createParameter({ id: "test-field", name: null })];
+      const [id, settings] = getFirstEntry(
+        generateFieldSettingsFromParameters(params, fields),
+      );
+
+      expect(settings.placeholder).toBe("test-field");
+      expect(settings.title).toBe("test-field");
+      expect(settings.name).toBe("test-field");
+    });
+
+    it("sets required prop", () => {
+      const fields = [
+        createField({ name: "test-field", database_required: true }),
+      ];
+      const params = [createParameter({ id: "test-field" })];
+      const [id, settings] = getFirstEntry(
+        generateFieldSettingsFromParameters(params, fields),
+      );
+
+      expect(settings.required).toBe(true);
+    });
+
+    it("sets required prop", () => {
+      const fields = [
+        createField({ name: "test-field", database_required: false }),
+      ];
+      const params = [createParameter({ id: "test-field" })];
+      const [id, settings] = getFirstEntry(
+        generateFieldSettingsFromParameters(params, fields),
+      );
+
+      expect(settings.required).toBe(false);
+    });
+
+    it("sets description text", () => {
+      const fields = [
+        createField({ name: "test-field", description: "foo bar baz" }),
+      ];
+      const params = [createParameter({ id: "test-field" })];
+      const [id, settings] = getFirstEntry(
+        generateFieldSettingsFromParameters(params, fields),
+      );
+
+      expect(settings.description).toBe("foo bar baz");
+    });
+  });
+
+  describe("getInputType", () => {
+    it('should return "number" for numeric parameters', () => {
+      const intParam = createParameter({ type: "type/Integer" });
+      expect(getInputType(intParam)).toEqual("number");
+
+      const floatParam = createParameter({ type: "type/Float" });
+      expect(getInputType(floatParam)).toEqual("number");
+    });
+
+    it('should return "string" for non-numeric parameters', () => {
+      const textParam = createParameter({ type: "type/Text" });
+      expect(getInputType(textParam)).toEqual("string");
+
+      const turtleParam = createParameter({ type: "type/Turtle" });
+      expect(getInputType(turtleParam)).toEqual("string");
+    });
+
+    it('should return "number" for numeric foreign keys', () => {
+      const field = createField({
+        semantic_type: "type/FK",
+        base_type: "type/Integer",
+      });
+      expect(getInputType(createParameter(), field)).toEqual("number");
+    });
+
+    it('should return "string" for string foreign keys', () => {
+      const field = createField({
+        semantic_type: "type/FK",
+        base_type: "type/Text",
+      });
+      expect(getInputType(createParameter(), field)).toEqual("string");
+    });
+
+    it('should return "number" for floating point numbers', () => {
+      const field = createField({
+        base_type: "type/Float",
+      });
+      expect(getInputType(createParameter(), field)).toEqual("number");
+    });
+
+    it('should return "boolean" for booleans', () => {
+      const field = createField({
+        base_type: "type/Boolean",
+      });
+      expect(getInputType(createParameter(), field)).toEqual("boolean");
+    });
+
+    it('should return "date" for dates', () => {
+      const dateTypes = [
+        "type/Date",
+        "type/DateTime",
+        "type/Time",
+        "type/DateTimeWithLocalTZ",
+        "type/TimeWithLocalTZ",
+      ];
+      const param = createParameter();
+
+      dateTypes.forEach(type => {
+        const field = createField({ base_type: type });
+        expect(getInputType(param, field)).toEqual("date");
+      });
+    });
+
+    it('should return "email" for email', () => {
+      const field = createField({
+        semantic_type: "type/Email",
+      });
+      expect(getInputType(createParameter(), field)).toEqual("email");
+    });
+
+    it('should return "category" for categories', () => {
+      const field = createField({
+        semantic_type: "type/Category",
+      });
+      expect(getInputType(createParameter(), field)).toEqual("category");
+    });
+
+    it('should return "text" for description', () => {
+      const field = createField({
+        semantic_type: "type/Description",
+      });
+      expect(getInputType(createParameter(), field)).toEqual("text");
+    });
+  });
+});

--- a/frontend/src/metabase/writeback/containers/ActionParametersInputForm/ActionParametersInputForm.tsx
+++ b/frontend/src/metabase/writeback/containers/ActionParametersInputForm/ActionParametersInputForm.tsx
@@ -5,7 +5,7 @@ import Form from "metabase/containers/FormikForm";
 import {
   getSubmitButtonLabel,
   generateFieldSettingsFromParameters,
-  getFormFromParameters,
+  getForm,
 } from "metabase/writeback/components/ActionCreator/FormCreator";
 import EmptyState from "metabase/components/EmptyState";
 
@@ -78,12 +78,16 @@ function ActionParametersInputForm({
   const fieldSettings = useMemo(
     () =>
       action.visualization_settings?.fields ??
-      generateFieldSettingsFromParameters(missingParameters),
-    [action, missingParameters],
+      // if there are no field settings, we generate them from the parameters and field metadata
+      generateFieldSettingsFromParameters(
+        missingParameters,
+        dashcard?.card?.result_metadata,
+      ),
+    [action, missingParameters, dashcard],
   );
 
   const form = useMemo(
-    () => getFormFromParameters(missingParameters, fieldSettings),
+    () => getForm(missingParameters, fieldSettings),
     [missingParameters, fieldSettings],
   );
 


### PR DESCRIPTION
## Description

The grand finale!

This uses the `result_metadata` returned from the dashboard api endpoint to smartly build out implicit action forms. This is done in such a way that we can likely use this to do smart things with custom actions as well if we can figure out a way to map custom action fields to DB fields.

A quick overview of how `ActionParametersInputForm` builds a form. Namely, the difference between field **settings** and form **props**. (tl;dr: we use field settings to build form props)
- first, it looks if there are custom action visualization_settings for a given action, if there are, it uses those to build the form
- if an action lacks visualization_settings, it tries to build some basic form settings from a combination of the action parameters and field metadata, if there is any
- now that we have field **settings**, we use those, wherever they came from, and build those settings into form **props**. Those form props then get passed to the standard form component, which builds us a snazzy form in the same way that any other form in metabase gets built.

And voila! we get nice-looking forms with appropriate input types, field names, and descriptions, depending on what information we have available.

![Screen Shot 2022-10-21 at 1 37 35 PM](https://user-images.githubusercontent.com/30528226/197275963-9dd63df4-e4a9-427f-bc5a-bea6582e59c8.png)
![Screen Shot 2022-10-21 at 1 37 20 PM](https://user-images.githubusercontent.com/30528226/197275964-3797c3aa-cb19-477c-8187-9ed22cefeb66.png)

## Testing steps

- should just work with any implicit insert or update forms, so scaffold out an app and go ham!
- should use display names for field names
- should have appropriate inputs for each field type
- should load field descriptions where they exist (see footnote below)
- saving data should work!

**Caveats**
- there's an interesting bug where the backend seems to not supply field descriptions for some fields, even when they exist in the data reference
- there's some UI iteration that still needs to be done on the category picker, (like adding new options)
