### PR TITLE
run linter on docs on pull request

### DIFF
--- a/.github/workflows/doc-md-links.yml
+++ b/.github/workflows/doc-md-links.yml
@@ -4,6 +4,9 @@ on:
   push:
     paths:
       - docs/**
+  pull_request:
+    paths:
+      - docs/**
 jobs:
   markdown-link-check:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Updates GitHub workflow for docs link linter to run on both push and pull request.