### PR TITLE
Don't require the table_id on result_metadata elements

### DIFF
--- a/src/metabase/models/action.clj
+++ b/src/metabase/models/action.clj
@@ -178,9 +178,9 @@
                 ;; Skip tables for have conflicting slugified columns i.e. table has "name" and "NAME" columns.
                 :when (unique-field-slugs? fields)
                 :let [card (get card-by-table-id (:id table))
-                      exposed-fields (set (map (juxt :table_id :id) (remove (comp nil? :id) (:result_metadata card))))
+                      exposed-fields (into #{} (keep :id) (:result_metadata card))
                       parameters (->> fields
-                                      (filter #(contains? exposed-fields [(:id table) (:id %)]))
+                                      (filter #(contains? exposed-fields (:id %)))
                                       (map (fn [field]
                                              {:id (u/slugify (:name field))
                                               :target [:variable [:template-tag (u/slugify (:name field))]]


### PR DESCRIPTION
In some cases (which ones still has to be clarified) the result metadata doesn't contain the `table_id` and so no parameters are provided. In fact the table ID is probably not needed anyway because fields are already table specific.

This is a temporary work around until the root cause (unstable `result_metadata`) is clarified.