### PR TITLE
Static-viz Row, Gauge, and Other Render Unit tests

### DIFF
--- a/dev/src/dev/render_png.clj
+++ b/dev/src/dev/render_png.clj
@@ -72,9 +72,9 @@
       (.write w html-str))
     (.deleteOnExit tmp-file)
     (open tmp-file)))
-    
+
 (comment
-  (render-card-to-png 1) 
+  (render-card-to-png 1)
   ;; open viz in your browser
   (-> [["A" "B"]
        [1 2]

--- a/test/metabase/pulse/render/body_test.clj
+++ b/test/metabase/pulse/render/body_test.clj
@@ -423,8 +423,8 @@
           "leftmost bar is shortest, rightmost bar is tallest, as expected by rows passed in")
       (let [first-height (second (first rows))
             first-rendered-height (:height (first rendered-bars))]
-        (is (= (map #(int (/ (second %) (double first-height))) rows)
-               (map #(int (/ (:height %) (double first-rendered-height))) rendered-bars))
+        (is (= (map #(Math/ceil (/ (second %) (double first-height))) rows)
+               (map #(Math/ceil (/ (:height %) (double first-rendered-height))) rendered-bars))
             "bar height ratios match the input row value ratios"))))
 
   (testing "Check to make sure we allow nil values for the y-axis"
@@ -444,6 +444,26 @@
           (render-multiseries-bar-graph
             {:cols default-multi-columns
              :rows [[10.0 1 1231 1] [5.0 10 nil 111] [2.50 20 11 1] [1.25 nil 1231 11]]})))))
+
+(deftest render-row-graph-test
+  (testing "Render a row graph with non-nil values for the x and y axis"
+    (let [col-headers ["Price" "NumPurchased"]
+          rows [[10.0 1] [5.0 10] [2.50 20] [1.25 30]]
+          rendered-bars (-> (concat [col-headers] rows)
+                            (render.tu/make-card-and-data :row)
+                            render.tu/render-as-hiccup
+                            (render.tu/nodes-with-tag :rect)
+                            (->> (map #(select-keys (second %) [:y :width]))))]
+      (is (= (count rows) (count rendered-bars))
+          "correct number of bars are rendered")
+      (is (= (sort-by :y rendered-bars)
+             (sort-by :width rendered-bars))
+          "leftmost bar is shortest, rightmost bar is tallest, as expected by rows passed in")
+      (let [first-width (second (first rows))
+            first-rendered-width (:width (first rendered-bars))]
+        (is (= (map #(Math/ceil (/ (second %) (double first-width))) rows)
+               (map #(Math/ceil (/ (:width %) (double first-rendered-width))) rendered-bars))
+            "bar height ratios match the input row value ratios")))))
 
 (defn- render-area-graph [results]
   (body/render :area :inline pacific-tz render.tu/test-card nil results))

--- a/test/metabase/pulse/render/body_test.clj
+++ b/test/metabase/pulse/render/body_test.clj
@@ -465,6 +465,22 @@
                (map #(Math/ceil (/ (:width %) (double first-rendered-width))) rendered-bars))
             "bar height ratios match the input row value ratios")))))
 
+(deftest render-gauge-chart-test
+  (testing "Render a gauge chart"
+    (let [render (-> [["A"] [12.34]]
+                     (render.tu/make-card-and-data :gauge)
+                     (assoc-in [:card :visualization_settings :gauge.segments] [{:min 0 :max 100 :color "green" :label ""}])
+                     render.tu/render-as-hiccup)]
+      (is (= 2 ;; 2 nodes because there is a second text element w/ large white stroke to improve legibility
+             (-> render
+                 (render.tu/nodes-with-text "12.34")
+                 count))
+          "Gauge value is rendered.")
+      (is (= 4 ;; 4 nodes because there are 2 for the arrow, 1 for the background of the gauge, and 1 for the gauge segment
+             (-> render
+                 (render.tu/nodes-with-tag :path)
+                 count))))))
+
 (defn- render-area-graph [results]
   (body/render :area :inline pacific-tz render.tu/test-card nil results))
 

--- a/test/metabase/pulse/render/test_util.clj
+++ b/test/metabase/pulse/render/test_util.clj
@@ -99,7 +99,9 @@
       :progress    {}
       :scalar      {}
       :smartscalar {}
-      :gauge       {}
+      :gauge       {:gauge.segments [{:min 0, :max 10, :color "#ED6E6E", :label ""}
+                                     {:min 10, :max 20, :color "#F9CF48", :label ""}
+                                     {:min 20, :max 40, :color "#84BB4C", :label ""}]}
       :table       {}
       :scatter     {}
       :row         {:graph.dimensions [(first header-row)]
@@ -136,7 +138,7 @@
    :gauge       #{}
    :table       #{:custom-column-names :reordered-columns :hidden-columns :custom-column-formatting}
    :scatter     #{}
-   :row         #{}
+   :row         #{:goal-line :multi-series :stack}
    :list        #{}
    :pivot       #{}})
 

--- a/test/metabase/pulse/render/test_util.clj
+++ b/test/metabase/pulse/render/test_util.clj
@@ -102,7 +102,8 @@
       :gauge       {}
       :table       {}
       :scatter     {}
-      :row         {}
+      :row         {:graph.dimensions [(first header-row)]
+                    :graph.metrics (vec (rest header-row))}
       :list        {}
       :pivot       {}} display-type)))
 

--- a/test/metabase/pulse/render/test_util.clj
+++ b/test/metabase/pulse/render/test_util.clj
@@ -376,8 +376,12 @@
   [attrs]
   (when attrs
     (into {} (map (fn [i]
-                    (let [item (bean (.item attrs i))]
-                      [(keyword (:name item)) (:value item)]))
+                    (let [item (bean (.item attrs i))
+                          unparsed-value (:value item)
+                          value (or (parse-long unparsed-value)
+                                    (parse-double unparsed-value)
+                                    unparsed-value)]
+                      [(keyword (:name item)) value]))
                   (range (.getLength attrs))))))
 
 (defn- hiccup-zip


### PR DESCRIPTION
Many of the body-tests just assert that an image was actually rendered. This isn't particularly powerful, because it doesn't say anything about the actual contents of the render. In fact, we render an error image when something goes wrong, so we might have hidden failures that pass in these tests simply because we're just checking that any image exists.

Using some render test utils, we can re-write these tests and inspect a hiccup tree that is representative of the rendered result and assert on the nodes and the attributes within each node.

This PR is meant to do 3 things:

1. clean up some existing tests to be more useful, as discussed
2. Add tests for the recently added row chart static viz
3. Add tests for the recently added gauge chart static viz

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/26075)
<!-- Reviewable:end -->
