### PR TITLE
Serves v2: Add :created_at to the hashes of all serialized models

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/seed_entity_ids_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/seed_entity_ids_test.clj
@@ -6,32 +6,40 @@
     :as v2.seed-entity-ids]
    [metabase.models :refer [Collection]]
    [metabase.test :as mt]
-   [toucan.db :as db]))
+   [toucan.db :as db])
+  (:import java.time.LocalDateTime))
 
 (deftest seed-entity-ids-test
   (testing "Sanity check: should succeed before we go around testing specific situations"
     (is (true? (v2.seed-entity-ids/seed-entity-ids! nil))))
   (testing "With a temp Collection with no entity ID"
-    (mt/with-temp Collection [c {:name "No Entity ID Collection", :slug "no_entity_id_collection", :color "#FF0000"}]
-      (db/update! Collection (:id c) :entity_id nil)
-      (letfn [(entity-id []
-                (some-> (db/select-one-field :entity_id Collection :id (:id c)) str/trim))]
-        (is (= nil
-               (entity-id)))
-        (testing "Should return truthy on success"
-          (is (= true
-                 (v2.seed-entity-ids/seed-entity-ids! nil))))
-        (is (= "c03d4632"
-               (entity-id))))
-      (testing "Error: duplicate entity IDs"
-        (mt/with-temp Collection [c2 {:name "No Entity ID Collection", :slug "no_entity_id_collection", :color "#FF0000"}]
-          (db/update! Collection (:id c2) :entity_id nil)
-          (letfn [(entity-id []
-                    (some-> (db/select-one-field :entity_id Collection :id (:id c2)) str/trim))]
-            (is (= nil
-                   (entity-id)))
-            (testing "Should return falsey on error"
-              (is (= false
-                     (v2.seed-entity-ids/seed-entity-ids! nil))))
-            (is (= nil
-                   (entity-id)))))))))
+    (let [now (LocalDateTime/of 2022 9 1 12 34 56)]
+      (mt/with-temp Collection [c {:name       "No Entity ID Collection"
+                                   :slug       "no_entity_id_collection"
+                                   :created_at now
+                                   :color      "#FF0000"}]
+        (db/update! Collection (:id c) :entity_id nil)
+        (letfn [(entity-id []
+                  (some-> (db/select-one-field :entity_id Collection :id (:id c)) str/trim))]
+          (is (= nil
+                 (entity-id)))
+          (testing "Should return truthy on success"
+            (is (= true
+                   (v2.seed-entity-ids/seed-entity-ids! nil))))
+          (is (= "998b109c"
+                 (entity-id))))
+        (testing "Error: duplicate entity IDs"
+          (mt/with-temp Collection [c2 {:name       "No Entity ID Collection"
+                                        :slug       "no_entity_id_collection"
+                                        :created_at now
+                                        :color      "#FF0000"}]
+            (db/update! Collection (:id c2) :entity_id nil)
+            (letfn [(entity-id []
+                      (some-> (db/select-one-field :entity_id Collection :id (:id c2)) str/trim))]
+              (is (= nil
+                     (entity-id)))
+              (testing "Should return falsey on error"
+                (is (= false
+                       (v2.seed-entity-ids/seed-entity-ids! nil))))
+              (is (= nil
+                     (entity-id))))))))))

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -328,7 +328,7 @@
 
 (defmethod serdes.hash/identity-hash-fields Card
   [_card]
-  [:name (serdes.hash/hydrated-hash :collection)])
+  [:name (serdes.hash/hydrated-hash :collection "<none>") :created_at])
 
 ;;; ------------------------------------------------- Serialization --------------------------------------------------
 (defmethod serdes.base/extract-query "Card" [_ {:keys [collection-set]}]

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -893,7 +893,7 @@
 
 (defmethod serdes.hash/identity-hash-fields Collection
   [_collection]
-  [:name :namespace parent-identity-hash])
+  [:name :namespace parent-identity-hash :created_at])
 
 (u/strict-extend #_{:clj-kondo/ignore [:metabase/disallow-class-or-type-on-model]} (class Collection)
   models/IModel

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -145,7 +145,7 @@
 
 (defmethod serdes.hash/identity-hash-fields Dashboard
   [_dashboard]
-  [:name (serdes.hash/hydrated-hash :collection)])
+  [:name (serdes.hash/hydrated-hash :collection "<none>") :created_at])
 
 
 ;;; --------------------------------------------------- Revisions ----------------------------------------------------

--- a/src/metabase/models/dashboard_card.clj
+++ b/src/metabase/models/dashboard_card.clj
@@ -56,7 +56,9 @@
    (comp serdes.hash/identity-hash
          #(db/select-one 'Dashboard :id %)
          :dashboard_id)
-   :visualization_settings])
+   :visualization_settings
+   :row :col
+   :created_at])
 
 
 ;;; --------------------------------------------------- HYDRATION ----------------------------------------------------

--- a/src/metabase/models/dashboard_card_series.clj
+++ b/src/metabase/models/dashboard_card_series.clj
@@ -12,4 +12,5 @@
 (defmethod serdes.hash/identity-hash-fields DashboardCardSeries
   [_dashboard-card-series]
   [(comp serdes.hash/identity-hash dashboard-card)
-   (serdes.hash/hydrated-hash :card)])
+   (serdes.hash/hydrated-hash :card)
+   :position])

--- a/src/metabase/models/dimension.clj
+++ b/src/metabase/models/dimension.clj
@@ -25,7 +25,8 @@
 (defmethod serdes.hash/identity-hash-fields Dimension
   [_dimension]
   [(serdes.hash/hydrated-hash :field "<none>")
-   (serdes.hash/hydrated-hash :human_readable_field "<none>")])
+   (serdes.hash/hydrated-hash :human_readable_field "<none>")
+   :created_at])
 
 ;;; ------------------------------------------------- Serialization --------------------------------------------------
 (defmethod serdes.base/extract-one "Dimension"

--- a/src/metabase/models/metric.clj
+++ b/src/metabase/models/metric.clj
@@ -48,7 +48,7 @@
 
 (defmethod serdes.hash/identity-hash-fields Metric
   [_metric]
-  [:name (serdes.hash/hydrated-hash :table "<none>")])
+  [:name (serdes.hash/hydrated-hash :table "<none>") :created_at])
 
 
 ;;; --------------------------------------------------- REVISIONS ----------------------------------------------------

--- a/src/metabase/models/native_query_snippet.clj
+++ b/src/metabase/models/native_query_snippet.clj
@@ -43,7 +43,7 @@
 
 (defmethod serdes.hash/identity-hash-fields NativeQuerySnippet
   [_snippet]
-  [:name (serdes.hash/hydrated-hash :collection "<none>")])
+  [:name (serdes.hash/hydrated-hash :collection "<none>") :created_at])
 
 (defmethod mi/can-read? NativeQuerySnippet
   [& args]

--- a/src/metabase/models/pulse.clj
+++ b/src/metabase/models/pulse.clj
@@ -137,7 +137,7 @@
 
 (defmethod serdes.hash/identity-hash-fields Pulse
   [_pulse]
-  [:name (serdes.hash/hydrated-hash :collection "<none>")])
+  [:name (serdes.hash/hydrated-hash :collection "<none>") :created_at])
 
 (def ^:private ^:dynamic *automatically-archive-when-last-channel-is-deleted*
   "Should we automatically archive a Pulse when its last `PulseChannel` is deleted? Normally we do, but this is disabled

--- a/src/metabase/models/pulse_card.clj
+++ b/src/metabase/models/pulse_card.clj
@@ -17,7 +17,9 @@
 
 (defmethod serdes.hash/identity-hash-fields PulseCard
   [_pulse-card]
-  [(serdes.hash/hydrated-hash :pulse) (serdes.hash/hydrated-hash :card)])
+  [(serdes.hash/hydrated-hash :pulse)
+   (serdes.hash/hydrated-hash :card)
+   :position])
 
 (defn next-position-for
   "Return the next available `pulse_card.position` for the given `pulse`"

--- a/src/metabase/models/pulse_channel.clj
+++ b/src/metabase/models/pulse_channel.clj
@@ -198,7 +198,7 @@
 
 (defmethod serdes.hash/identity-hash-fields PulseChannel
   [_pulse-channel]
-  [(serdes.hash/hydrated-hash :pulse) :channel_type :details])
+  [(serdes.hash/hydrated-hash :pulse) :channel_type :details :created_at])
 
 (defn will-delete-recipient
   "This function is called by [[metabase.models.pulse-channel-recipient/pre-delete]] when a `PulseChannelRecipient` is

--- a/src/metabase/models/segment.clj
+++ b/src/metabase/models/segment.clj
@@ -48,7 +48,7 @@
 
 (defmethod serdes.hash/identity-hash-fields Segment
   [_segment]
-  [:name (serdes.hash/hydrated-hash :table)])
+  [:name (serdes.hash/hydrated-hash :table) :created_at])
 
 
 ;;; --------------------------------------------------- Revisions ----------------------------------------------------

--- a/src/metabase/models/timeline.clj
+++ b/src/metabase/models/timeline.clj
@@ -60,7 +60,7 @@
 
 (defmethod serdes.hash/identity-hash-fields Timeline
   [_timeline]
-  [:name (serdes.hash/hydrated-hash :collection)])
+  [:name (serdes.hash/hydrated-hash :collection "<none>") :created_at])
 
 ;;;; serialization
 (defmethod serdes.base/extract-one "Timeline"

--- a/src/metabase/models/timeline_event.clj
+++ b/src/metabase/models/timeline_event.clj
@@ -102,7 +102,7 @@
 
 (defmethod serdes.hash/identity-hash-fields TimelineEvent
   [_timeline-event]
-  [:name :timestamp (serdes.hash/hydrated-hash :timeline)])
+  [:name :timestamp (serdes.hash/hydrated-hash :timeline) :created_at])
 
 ;;;; serialization
 (defmethod serdes.base/serdes-entity-id "TimelineEvent" [_model-name {:keys [timestamp]}]

--- a/test/metabase/models/card_test.clj
+++ b/test/metabase/models/card_test.clj
@@ -10,7 +10,8 @@
             [metabase.test.util :as tu]
             [metabase.util :as u]
             [toucan.db :as db]
-            [toucan.util.test :as tt]))
+            [toucan.util.test :as tt])
+  (:import java.time.LocalDateTime))
 
 (deftest dashboard-count-test
   (testing "Check that the :dashboard_count delay returns the correct count of Dashboards a Card is in"
@@ -357,11 +358,12 @@
 
 (deftest identity-hash-test
   (testing "Card hashes are composed of the name and the collection's hash"
-    (mt/with-temp* [Collection  [coll  {:name "field-db" :location "/"}]
-                    Card        [card  {:name "the card" :collection_id (:id coll)}]]
-      (is (= "ead6cc05"
-             (serdes.hash/raw-hash ["the card" (serdes.hash/identity-hash coll)])
-             (serdes.hash/identity-hash card))))))
+    (let [now (LocalDateTime/of 2022 9 1 12 34 56)]
+      (mt/with-temp* [Collection  [coll  {:name "field-db" :location "/" :created_at now}]
+                      Card        [card  {:name "the card" :collection_id (:id coll) :created_at now}]]
+        (is (= "5199edf0"
+               (serdes.hash/raw-hash ["the card" (serdes.hash/identity-hash coll) now])
+               (serdes.hash/identity-hash card)))))))
 
 (deftest serdes-descendants-test
   (testing "regular cards don't depend on anything"

--- a/test/metabase/models/collection_test.clj
+++ b/test/metabase/models/collection_test.clj
@@ -15,7 +15,8 @@
             [metabase.util.schema :as su]
             [schema.core :as s]
             [toucan.db :as db]
-            [toucan.hydrate :refer [hydrate]]))
+            [toucan.hydrate :refer [hydrate]])
+  (:import java.time.LocalDateTime))
 
 (use-fixtures :once (fixtures/initialize :db :test-users :test-users-personal-collections))
 
@@ -1624,18 +1625,28 @@
 
 (deftest identity-hash-test
   (testing "Collection hashes are composed of the name, namespace, and parent collection's hash"
-    (mt/with-temp* [Collection [c1  {:name "top level"  :namespace "yolocorp" :location "/"}]
-                    Collection [c2  {:name "nested"     :namespace "yolocorp" :location (format "/%s/" (:id c1))}]
-                    Collection [c3  {:name "grandchild" :namespace "yolocorp" :location (format "/%s/%s/" (:id c1) (:id c2))}]]
-      (let [c1-hash (serdes.hash/identity-hash c1)
-            c2-hash (serdes.hash/identity-hash c2)]
-        (is (= "37e57249"
-               (serdes.hash/raw-hash ["top level" :yolocorp "ROOT"])
-               c1-hash)
-            "Top-level collections should use a parent hash of 'ROOT'")
-        (is (= "ce76f360"
-               (serdes.hash/raw-hash ["nested" :yolocorp c1-hash])
-               c2-hash))
-        (is (= "acb1ea3e"
-               (serdes.hash/raw-hash ["grandchild" :yolocorp c2-hash])
-               (serdes.hash/identity-hash c3)))))))
+    (let [now (LocalDateTime/of 2022 9 1 12 34 56)]
+      (mt/with-temp* [Collection [c1  {:name       "top level"
+                                       :created_at now
+                                       :namespace  "yolocorp"
+                                       :location   "/"}]
+                      Collection [c2  {:name       "nested"
+                                       :created_at now
+                                       :namespace  "yolocorp"
+                                       :location   (format "/%s/" (:id c1))}]
+                      Collection [c3  {:name       "grandchild"
+                                       :created_at now
+                                       :namespace  "yolocorp"
+                                       :location   (format "/%s/%s/" (:id c1) (:id c2))}]]
+        (let [c1-hash (serdes.hash/identity-hash c1)
+              c2-hash (serdes.hash/identity-hash c2)]
+          (is (= "f2620cc6"
+                 (serdes.hash/raw-hash ["top level" :yolocorp "ROOT" now])
+                 c1-hash)
+              "Top-level collections should use a parent hash of 'ROOT'")
+          (is (= "a27aef0f"
+                 (serdes.hash/raw-hash ["nested" :yolocorp c1-hash now])
+                 c2-hash))
+          (is (= "e816af2d"
+                 (serdes.hash/raw-hash ["grandchild" :yolocorp c2-hash now])
+                 (serdes.hash/identity-hash c3))))))))

--- a/test/metabase/models/dashboard_test.clj
+++ b/test/metabase/models/dashboard_test.clj
@@ -21,7 +21,8 @@
             [metabase.test.util :as tu]
             [metabase.util :as u]
             [toucan.db :as db]
-            [toucan.util.test :as tt]))
+            [toucan.util.test :as tt])
+  (:import java.time.LocalDateTime))
 
 ;; ## Dashboard Revisions
 
@@ -315,8 +316,9 @@
 
 (deftest identity-hash-test
   (testing "Dashboard hashes are composed of the name and parent collection's hash"
-    (mt/with-temp* [Collection [c1   {:name "top level" :location "/"}]
-                    Dashboard  [dash {:name "my dashboard" :collection_id (:id c1)}]]
-      (is (= "38c0adf9"
-             (serdes.hash/raw-hash ["my dashboard" (serdes.hash/identity-hash c1)])
-             (serdes.hash/identity-hash dash))))))
+    (let [now (LocalDateTime/of 2022 9 1 12 34 56)]
+      (mt/with-temp* [Collection [c1   {:name "top level" :location "/" :created_at now}]
+                      Dashboard  [dash {:name "my dashboard" :collection_id (:id c1) :created_at now}]]
+        (is (= "8cbf93b7"
+               (serdes.hash/raw-hash ["my dashboard" (serdes.hash/identity-hash c1) now])
+               (serdes.hash/identity-hash dash)))))))

--- a/test/metabase/models/dimension_test.clj
+++ b/test/metabase/models/dimension_test.clj
@@ -5,15 +5,19 @@
             [metabase.models.field :refer [Field]]
             [metabase.models.serialization.hash :as serdes.hash]
             [metabase.models.table :refer [Table]]
-            [metabase.test :as mt]))
+            [metabase.test :as mt])
+  (:import java.time.LocalDateTime))
 
 (deftest identity-hash-test
   (testing "Dimension hashes are composed of the proper field hash, and the human-readable field hash"
-    (mt/with-temp* [Database  [db     {:name "field-db" :engine :h2}]
-                    Table     [table  {:schema "PUBLIC" :name "widget" :db_id (:id db)}]
-                    Field     [field1 {:name "sku" :table_id (:id table)}]
-                    Field     [field2 {:name "human" :table_id (:id table)}]
-                    Dimension [dim    {:field_id (:id field1) :human_readable_field_id (:id field2)}]]
-      (is (= "d579f125"
-             (serdes.hash/raw-hash [(serdes.hash/identity-hash field1) (serdes.hash/identity-hash field2)])
-             (serdes.hash/identity-hash dim))))))
+    (let [now (LocalDateTime/of 2022 9 1 12 34 56)]
+      (mt/with-temp* [Database  [db     {:name "field-db" :engine :h2}]
+                      Table     [table  {:schema "PUBLIC" :name "widget" :db_id (:id db)}]
+                      Field     [field1 {:name "sku" :table_id (:id table)}]
+                      Field     [field2 {:name "human" :table_id (:id table)}]
+                      Dimension [dim    {:field_id                (:id field1)
+                                         :human_readable_field_id (:id field2)
+                                         :created_at              now}]]
+        (is (= "c52f8889"
+               (serdes.hash/raw-hash [(serdes.hash/identity-hash field1) (serdes.hash/identity-hash field2) now])
+               (serdes.hash/identity-hash dim)))))))

--- a/test/metabase/models/metric_test.clj
+++ b/test/metabase/models/metric_test.clj
@@ -7,7 +7,8 @@
             [metabase.models.table :refer [Table]]
             [metabase.test :as mt]
             [metabase.util :as u]
-            [toucan.db :as db]))
+            [toucan.db :as db])
+  (:import java.time.LocalDateTime))
 
 (def ^:private metric-defaults
   {:description             nil
@@ -136,9 +137,10 @@
 
 (deftest identity-hash-test
   (testing "Metric hashes are composed of the metric name and table identity-hash"
-    (mt/with-temp* [Database [db    {:name "field-db" :engine :h2}]
-                    Table    [table {:schema "PUBLIC" :name "widget" :db_id (:id db)}]
-                    Metric   [metric {:name "measurement" :table_id (:id table)}]]
-      (is (= "8fb4650a"
-             (serdes.hash/raw-hash ["measurement" (serdes.hash/identity-hash table)])
-             (serdes.hash/identity-hash metric))))))
+    (let [now (LocalDateTime/of 2022 9 1 12 34 56)]
+      (mt/with-temp* [Database [db    {:name "field-db" :engine :h2}]
+                      Table    [table {:schema "PUBLIC" :name "widget" :db_id (:id db)}]
+                      Metric   [metric {:name "measurement" :table_id (:id table) :created_at now}]]
+        (is (= "a2318866"
+               (serdes.hash/raw-hash ["measurement" (serdes.hash/identity-hash table) now])
+               (serdes.hash/identity-hash metric)))))))

--- a/test/metabase/models/native_query_snippet_test.clj
+++ b/test/metabase/models/native_query_snippet_test.clj
@@ -3,7 +3,8 @@
             [metabase.models :refer [Collection NativeQuerySnippet]]
             [metabase.models.serialization.hash :as serdes.hash]
             [metabase.test :as mt]
-            [toucan.db :as db]))
+            [toucan.db :as db])
+  (:import java.time.LocalDateTime))
 
 (deftest disallow-updating-creator-id-test
   (testing "You shouldn't be allowed to update the creator_id of a NativeQuerySnippet"
@@ -60,8 +61,9 @@
 
 (deftest identity-hash-test
   (testing "Native query snippet hashes are composed of the name and the collection's hash"
-    (mt/with-temp* [Collection         [coll    {:name "field-db" :namespace :snippets :location "/"}]
-                    NativeQuerySnippet [snippet {:name "my snippet" :collection_id (:id coll)}]]
-      (is (= "0e4562b1"
-             (serdes.hash/raw-hash ["my snippet" (serdes.hash/identity-hash coll)])
-             (serdes.hash/identity-hash snippet))))))
+    (let [now (LocalDateTime/of 2022 9 1 12 34 56)]
+      (mt/with-temp* [Collection         [coll    {:name "field-db" :namespace :snippets :location "/" :created_at now}]
+                      NativeQuerySnippet [snippet {:name "my snippet" :collection_id (:id coll) :created_at now}]]
+        (is (= "7ac51ad0"
+               (serdes.hash/raw-hash ["my snippet" (serdes.hash/identity-hash coll) now])
+               (serdes.hash/identity-hash snippet)))))))

--- a/test/metabase/models/pulse_card_test.clj
+++ b/test/metabase/models/pulse_card_test.clj
@@ -8,7 +8,8 @@
             [metabase.models.pulse-card :as pulse-card :refer [PulseCard]]
             [metabase.models.serialization.hash :as serdes.hash]
             [metabase.test :as mt]
-            [toucan.util.test :as tt]))
+            [toucan.util.test :as tt])
+  (:import java.time.LocalDateTime))
 
 (deftest test-next-position-for
   (testing "No existing cards"
@@ -27,11 +28,12 @@
 
 (deftest identity-hash-test
   (testing "Pulse card hashes are composed of the pulse's hash and the card's hash"
-    (mt/with-temp* [Collection  [coll1      {:name "field-db" :location "/"}]
-                    Collection  [coll2      {:name "other collection" :location "/"}]
-                    Card        [card       {:name "the card" :collection_id (:id coll1)}]
-                    Pulse       [pulse      {:name "my pulse" :collection_id (:id coll2)}]
-                    PulseCard   [pulse-card {:card_id (:id card) :pulse_id (:id pulse)}]]
-      (is (= "cd532201"
-             (serdes.hash/raw-hash [(serdes.hash/identity-hash pulse) (serdes.hash/identity-hash card)])
-             (serdes.hash/identity-hash pulse-card))))))
+    (let [now (LocalDateTime/of 2022 9 1 12 34 56)]
+      (mt/with-temp* [Collection  [coll1      {:name "field-db" :location "/" :created_at now}]
+                      Collection  [coll2      {:name "other collection" :location "/" :created_at now}]
+                      Card        [card       {:name "the card" :collection_id (:id coll1) :created_at now}]
+                      Pulse       [pulse      {:name "my pulse" :collection_id (:id coll2) :created_at now}]
+                      PulseCard   [pulse-card {:card_id (:id card) :pulse_id (:id pulse) :position 4}]]
+        (is (= "9ad1b5a4"
+               (serdes.hash/raw-hash [(serdes.hash/identity-hash pulse) (serdes.hash/identity-hash card) 4])
+               (serdes.hash/identity-hash pulse-card)))))))

--- a/test/metabase/models/pulse_channel_test.clj
+++ b/test/metabase/models/pulse_channel_test.clj
@@ -10,7 +10,8 @@
             [metabase.test :as mt]
             [metabase.util :as u]
             [toucan.db :as db]
-            [toucan.hydrate :refer [hydrate]]))
+            [toucan.hydrate :refer [hydrate]])
+  (:import java.time.LocalDateTime))
 
 ;; Test out our predicate functions
 
@@ -454,11 +455,13 @@
 
 (deftest identity-hash-test
   (testing "Pulse channel hashes are composed of the pulse's hash, the channel type, and the details and the collection hash"
-    (mt/with-temp* [Collection   [coll  {:name "field-db" :location "/"}]
-                    Pulse        [pulse {:name "my pulse" :collection_id (:id coll)}]
-                    PulseChannel [chan  {:pulse_id     (:id pulse)
-                                         :channel_type :email
-                                         :details      {:emails ["cam@test.com"]}}]]
-      (is (= "ab5e6ff0"
-             (serdes.hash/raw-hash [(serdes.hash/identity-hash pulse) :email {:emails ["cam@test.com"]}])
-             (serdes.hash/identity-hash chan))))))
+    (let [now (LocalDateTime/of 2022 9 1 12 34 56)]
+      (mt/with-temp* [Collection   [coll  {:name "field-db" :location "/" :created_at now}]
+                      Pulse        [pulse {:name "my pulse" :collection_id (:id coll) :created_at now}]
+                      PulseChannel [chan  {:pulse_id     (:id pulse)
+                                           :channel_type :email
+                                           :details      {:emails ["cam@test.com"]}
+                                           :created_at   now}]]
+        (is (= "2f5f0269"
+               (serdes.hash/raw-hash [(serdes.hash/identity-hash pulse) :email {:emails ["cam@test.com"]} now])
+               (serdes.hash/identity-hash chan)))))))

--- a/test/metabase/models/pulse_test.clj
+++ b/test/metabase/models/pulse_test.clj
@@ -14,7 +14,8 @@
             [schema.core :as s]
             [toucan.db :as db]
             [toucan.hydrate :refer [hydrate]]
-            [toucan.util.test :as tt]))
+            [toucan.util.test :as tt])
+  (:import java.time.LocalDateTime))
 
 (defn- user-details
   [username]
@@ -459,8 +460,9 @@
 
 (deftest identity-hash-test
   (testing "Pulse hashes are composed of the name and the collection hash"
-    (mt/with-temp* [Collection  [coll  {:name "field-db" :location "/"}]
-                    Pulse       [pulse {:name "my pulse" :collection_id (:id coll)}]]
-      (is (= "6432d0a9"
-             (serdes.hash/raw-hash ["my pulse" (serdes.hash/identity-hash coll)])
-             (serdes.hash/identity-hash pulse))))))
+    (let [now (LocalDateTime/of 2022 9 1 12 34 56)]
+      (mt/with-temp* [Collection  [coll  {:name "field-db" :location "/" :created_at now}]
+                      Pulse       [pulse {:name "my pulse" :collection_id (:id coll) :created_at now}]]
+        (is (= "82553101"
+               (serdes.hash/raw-hash ["my pulse" (serdes.hash/identity-hash coll) now])
+               (serdes.hash/identity-hash pulse)))))))

--- a/test/metabase/models/segment_test.clj
+++ b/test/metabase/models/segment_test.clj
@@ -7,7 +7,8 @@
             [metabase.models.table :refer [Table]]
             [metabase.test :as mt]
             [metabase.util :as u]
-            [toucan.db :as db]))
+            [toucan.db :as db])
+  (:import java.time.LocalDateTime))
 
 (defn- user-details
   [username]
@@ -128,9 +129,10 @@
 
 (deftest identity-hash-test
   (testing "Segment hashes are composed of the segment name and table identity-hash"
-    (mt/with-temp* [Database [db      {:name "field-db" :engine :h2}]
-                    Table    [table   {:schema "PUBLIC" :name "widget" :db_id (:id db)}]
-                    Segment  [segment {:name "big customers" :table_id (:id table)}]]
-      (is (= "a40066a4"
-             (serdes.hash/raw-hash ["big customers" (serdes.hash/identity-hash table)])
-             (serdes.hash/identity-hash segment))))))
+    (let [now (LocalDateTime/of 2022 9 1 12 34 56)]
+      (mt/with-temp* [Database [db      {:name "field-db" :engine :h2}]
+                      Table    [table   {:schema "PUBLIC" :name "widget" :db_id (:id db)}]
+                      Segment  [segment {:name "big customers" :table_id (:id table) :created_at now}]]
+        (is (= "be199b7c"
+               (serdes.hash/raw-hash ["big customers" (serdes.hash/identity-hash table) now])
+               (serdes.hash/identity-hash segment)))))))


### PR DESCRIPTION
This makes them less likely to collide, which was a problem on some
larger instances.

A following PR will generate `entity_id` from the hashes before
(de)serialization, allowing for easier merging later (since `entity_id`
is indexed in the database).

