### PR TITLE
Fix Collection created_at migrations for H2 and MySQL/MariaDB

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -13127,6 +13127,7 @@ databaseChangeLog:
   - changeSet:
       id: v45.00-050
       author: camsaul
+      validCheckSum: ANY
       comment: Added 0.45.0 -- seed Collection.created_at with value of oldest item for non-Personal Collections
       changes:
         - sql:
@@ -13169,6 +13170,9 @@ databaseChangeLog:
               WHERE c.personal_owner_id IS NULL;
         - sql:
             dbms: h2
+            # I would have preferred using MERGE ... USING instead of WHERE EXISTS ... but it's broken in 1.4.197
+            # because of https://github.com/h2database/h2database/issues/1034, which is fixed in 1.4.198. So this will
+            # have to do for now, even if it's a little ugly.
             sql: >-
               WITH created_ats AS (
                 SELECT min(created_at) AS created_at, collection_id
@@ -13188,7 +13192,12 @@ databaseChangeLog:
                 FROM created_ats
                 WHERE created_ats.collection_id = c.id
               )
-              WHERE c.personal_owner_id IS NULL;
+              WHERE EXISTS (
+                SELECT created_ats.collection_id
+                FROM created_ats
+                WHERE c.id = created_ats.collection_id
+                  AND c.personal_owner_id IS NULL
+              );
 
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -13168,7 +13168,7 @@ databaseChangeLog:
               ON c.id = created_ats.collection_id
               SET c.created_at = created_ats.created_at
               WHERE c.personal_owner_id IS NULL
-                AND c.created_at IS NOT NULL;
+                AND created_ats.created_at IS NOT NULL;
         - sql:
             dbms: h2
             # I would have preferred using MERGE ... USING instead of WHERE EXISTS ... but it's broken in 1.4.197

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -13167,7 +13167,8 @@ databaseChangeLog:
               ) created_ats
               ON c.id = created_ats.collection_id
               SET c.created_at = created_ats.created_at
-              WHERE c.personal_owner_id IS NULL;
+              WHERE c.personal_owner_id IS NULL
+                AND c.created_at IS NOT NULL;
         - sql:
             dbms: h2
             # I would have preferred using MERGE ... USING instead of WHERE EXISTS ... but it's broken in 1.4.197

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -712,7 +712,10 @@
                                                                     :slug              "personal_collection"})
             impersonal-collection-id (db/simple-insert! Collection {:name  "Regular Collection"
                                                                     :color "#ff0000"
-                                                                    :slug  "personal_collection"})
+                                                                    :slug  "regular_collection"})
+            empty-collection-id      (db/simple-insert! Collection {:name  "Empty Collection"
+                                                                    :color "#ff0000"
+                                                                    :slug  "empty_collection"})
             _                        (db/simple-insert! Card {:collection_id          impersonal-collection-id
                                                               :name                   "Card 1"
                                                               :display                "table"
@@ -737,4 +740,10 @@
                  (t/offset-date-time (db/select-one-field :created_at Collection :id personal-collection-id)))))
         (testing "A non-personal Collection should get created_at set to its oldest object"
           (is (= (t/offset-date-time #t "2021-10-20T02:09Z")
-                 (t/offset-date-time (db/select-one-field :created_at Collection :id impersonal-collection-id)))))))))
+                 (t/offset-date-time (db/select-one-field :created_at Collection :id impersonal-collection-id)))))
+        (testing "Empty Collection should not have been updated"
+          (let [empty-collection-created-at (t/offset-date-time (db/select-one-field :created_at Collection :id empty-collection-id))]
+            (is (not= (t/offset-date-time #t "2021-10-20T02:09Z")
+                      empty-collection-created-at))
+            (is (not= (t/offset-date-time #t "2022-10-20T02:09Z")
+                      empty-collection-created-at))))))))


### PR DESCRIPTION
Fixes the migration that populates `created_at` for empty Collections. Adds test