### PR TITLE
Show Card Titles in Data Apps

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard.jsx
@@ -28,7 +28,10 @@ import { isVirtualDashCard } from "metabase/dashboard/utils";
 
 import { IS_EMBED_PREVIEW } from "metabase/lib/embed";
 
-import { isActionCard } from "metabase/writeback/utils";
+import {
+  isActionCard,
+  shouldHideDashcardHeader,
+} from "metabase/writeback/utils";
 
 import Utils from "metabase/lib/utils";
 import { getClickBehaviorDescription } from "metabase/lib/click-behavior";
@@ -192,6 +195,8 @@ export default class DashCard extends Component {
 
     const gridSize = { width: dashcard.size_x, height: dashcard.size_y };
 
+    const showTitle = !shouldHideDashcardHeader(dashboard, dashcard);
+
     return (
       <DashCardRoot
         className="Card rounded flex flex-column hover-parent hover--visibility"
@@ -237,7 +242,7 @@ export default class DashCard extends Component {
           isDataApp={dashboard.is_app_page}
           expectedDuration={expectedDuration}
           rawSeries={series}
-          showTitle={!dashboard.is_app_page}
+          showTitle={showTitle}
           isFullscreen={isFullscreen}
           isNightMode={isNightMode}
           isDashboard

--- a/frontend/src/metabase/writeback/utils.ts
+++ b/frontend/src/metabase/writeback/utils.ts
@@ -1,11 +1,13 @@
 import type {
   ActionDashboardCard,
   BaseDashboardOrderedCard,
-  ClickBehavior,
+  Dashboard,
   Database as IDatabase,
   WritebackAction,
 } from "metabase-types/api";
 import type { SavedCard } from "metabase-types/types/Card";
+import type { DashCard } from "metabase-types/types/Dashboard";
+
 import { TYPE } from "metabase-lib/lib/types/constants";
 import type Database from "metabase-lib/lib/metadata/Database";
 import type Field from "metabase-lib/lib/metadata/Field";
@@ -103,3 +105,12 @@ export const shouldPrefetchValues = (action: WritebackAction) => {
   // for custom actions
   return action.slug === "update";
 };
+
+export const shouldHideDashcardHeader = (
+  dashboard: Dashboard,
+  dashcard: DashCard,
+): boolean =>
+  !!(
+    dashboard.is_app_page &&
+    ["list", "object"].includes(dashcard?.card?.display ?? "")
+  );


### PR DESCRIPTION
## Description

This replaces card titles in data apps for everything except: object detail and lists

![Screen Shot 2022-10-24 at 2 26 03 PM](https://user-images.githubusercontent.com/30528226/197623354-f2d6e4fd-6292-40fa-83b8-2ada9c987237.png)

In non-app dashboards, everything should still have titles.
