### PR TITLE
premium features need to be set to off when testing oss search sorting

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/search/scoring_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/search/scoring_test.clj
@@ -26,7 +26,7 @@
 (defn- oss-score
   [search-string]
   (fn [item]
-    (with-redefs [#_{:clj-kondo/ignore [:deprecated-var]} premium-features/enable-enhancements? (constantly true)]
+    (with-redefs [#_{:clj-kondo/ignore [:deprecated-var]} premium-features/enable-enhancements? (constantly false)]
       (-> (scoring/score-and-result search-string item) :score))))
 
 (deftest official-collection-tests


### PR DESCRIPTION
Flipping this test function around to be correct