### PR TITLE
Add data app and page archiving

### DIFF
--- a/frontend/src/metabase/entities/data-apps/utils.ts
+++ b/frontend/src/metabase/entities/data-apps/utils.ts
@@ -68,3 +68,29 @@ export function getParentDataAppPageId(
 
   return pagesBeforeTarget[parentPageIndex]?.page_id || null;
 }
+
+export function getChildNavItems(
+  navItems: DataAppNavItem[],
+  pageId: DataAppPageId,
+) {
+  const targetIndex = navItems.findIndex(navItem => navItem.page_id === pageId);
+  if (targetIndex === -1) {
+    return [];
+  }
+
+  const targetNavItem = navItems[targetIndex];
+  const targetIndent = targetNavItem.indent || 0;
+
+  const navItemsAfterTarget = navItems.slice(targetIndex + 1);
+
+  const nextNavItemWithSameIndentIndex = navItemsAfterTarget.findIndex(
+    navItem => (navItem.indent || 0) === targetIndent,
+  );
+
+  const endIndex =
+    nextNavItemWithSameIndentIndex === -1
+      ? undefined
+      : nextNavItemWithSameIndentIndex;
+
+  return navItemsAfterTarget.slice(0, endIndex);
+}

--- a/frontend/src/metabase/entities/data-apps/utils.ts
+++ b/frontend/src/metabase/entities/data-apps/utils.ts
@@ -15,16 +15,20 @@ export function isDataAppCollection(collection: Collection) {
   return typeof collection.app_id === "number";
 }
 
+export function isTopLevelNavItem(navItem: DataAppNavItem) {
+  return (!navItem.indent || navItem.indent === 0) && !navItem.hidden;
+}
+
 export function getDataAppHomePageId(dataApp: DataApp, pages: Dashboard[]) {
   if (dataApp.dashboard_id) {
     return dataApp.dashboard_id;
   }
+  const navItem = dataApp.nav_items.find(isTopLevelNavItem);
+  if (navItem) {
+    return navItem.page_id;
+  }
   const [firstPage] = _.sortBy(pages, "name");
   return firstPage?.id;
-}
-
-export function isTopLevelNavItem(navItem: DataAppNavItem) {
-  return (!navItem.indent || navItem.indent === 0) && !navItem.hidden;
 }
 
 function isParentPage(

--- a/frontend/src/metabase/entities/data-apps/utils.ts
+++ b/frontend/src/metabase/entities/data-apps/utils.ts
@@ -94,3 +94,24 @@ export function getChildNavItems(
 
   return navItemsAfterTarget.slice(0, endIndex);
 }
+
+export function getPreviousNavItem(
+  navItems: DataAppNavItem[],
+  pageId: DataAppPageId,
+): DataAppNavItem | null {
+  const navItemIndex = navItems.findIndex(
+    navItem => navItem.page_id === pageId,
+  );
+
+  if (navItemIndex === -1) {
+    return navItems[navItems.length - 1] || null;
+  }
+
+  const navItemsBeforeTarget = navItems.slice(0, navItemIndex);
+  const previousNavItem = _.findLastIndex(
+    navItemsBeforeTarget,
+    isTopLevelNavItem,
+  );
+
+  return navItemsBeforeTarget[previousNavItem] || null;
+}

--- a/frontend/src/metabase/entities/data-apps/utils.ts
+++ b/frontend/src/metabase/entities/data-apps/utils.ts
@@ -23,6 +23,10 @@ export function getDataAppHomePageId(dataApp: DataApp, pages: Dashboard[]) {
   return firstPage?.id;
 }
 
+export function isTopLevelNavItem(navItem: DataAppNavItem) {
+  return (!navItem.indent || navItem.indent === 0) && !navItem.hidden;
+}
+
 function isParentPage(
   targetPageIndent: number,
   maybeParentNavItem: DataAppNavItem,

--- a/frontend/src/metabase/entities/data-apps/utils.unit.spec.ts
+++ b/frontend/src/metabase/entities/data-apps/utils.unit.spec.ts
@@ -7,6 +7,7 @@ import {
   isTopLevelNavItem,
   getDataAppHomePageId,
   getParentDataAppPageId,
+  getChildNavItems,
 } from "./utils";
 
 describe("data app utils", () => {
@@ -123,6 +124,51 @@ describe("data app utils", () => {
 
     it("skips hidden pages when looking for a parent", () => {
       expect(getParentDataAppPageId(6, navItems)).toBe(4);
+    });
+  });
+
+  describe("getChildNavItems", () => {
+    it("returns child nav items for a given nav item", () => {
+      const children = [
+        { page_id: 4, indent: 1 },
+        { page_id: 5, indent: 1 },
+        { page_id: 6, indent: 2 },
+      ];
+
+      const navItems = [
+        { page_id: 1 },
+        { page_id: 2 },
+        { page_id: 3 },
+        ...children,
+        { page_id: 7 },
+        { page_id: 8 },
+      ];
+
+      expect(getChildNavItems(navItems, 3)).toEqual(children);
+    });
+
+    it("returns child nav items for a nested nav item", () => {
+      const navItems = [
+        { page_id: 1 },
+        { page_id: 2, indent: 1 },
+        { page_id: 3, indent: 2 },
+      ];
+
+      expect(getChildNavItems(navItems, 2)).toEqual([
+        { page_id: 3, indent: 2 },
+      ]);
+    });
+
+    it("returns an empty list if can't find nav item", () => {
+      expect(getChildNavItems([{ page_id: 1 }, { page_id: 2 }], 3)).toEqual([]);
+    });
+
+    it("returns an empty list when there are no child pages", () => {
+      const navItems = [{ page_id: 1 }, { page_id: 2 }, { page_id: 3 }];
+
+      expect(getChildNavItems(navItems, 1)).toEqual([]);
+      expect(getChildNavItems(navItems, 2)).toEqual([]);
+      expect(getChildNavItems(navItems, 3)).toEqual([]);
     });
   });
 });

--- a/frontend/src/metabase/entities/data-apps/utils.unit.spec.ts
+++ b/frontend/src/metabase/entities/data-apps/utils.unit.spec.ts
@@ -3,7 +3,11 @@ import {
   createMockDataApp,
   createMockDataAppPage,
 } from "metabase-types/api/mocks";
-import { getDataAppHomePageId, getParentDataAppPageId } from "./utils";
+import {
+  isTopLevelNavItem,
+  getDataAppHomePageId,
+  getParentDataAppPageId,
+} from "./utils";
 
 describe("data app utils", () => {
   const dataAppWithoutHomepage = createMockDataApp({ dashboard_id: null });
@@ -13,6 +17,36 @@ describe("data app utils", () => {
   const page2 = createMockDataAppPage({ id: 2, name: "B" });
   const page3 = createMockDataAppPage({ id: 3, name: "C" });
   const pages = [page1, page2, page3];
+
+  describe("isTopLevelNavItem", () => {
+    it("returns true for items without indent", () => {
+      expect(isTopLevelNavItem({ page_id: 1 })).toBe(true);
+    });
+
+    it("returns true for items with zero indent", () => {
+      expect(isTopLevelNavItem({ page_id: 1, indent: 0 })).toBe(true);
+    });
+
+    it("returns false for nested items", () => {
+      expect(isTopLevelNavItem({ page_id: 1, indent: 1 })).toBe(false);
+    });
+
+    it("returns false for nested hidden items", () => {
+      expect(isTopLevelNavItem({ page_id: 1, hidden: true, indent: 1 })).toBe(
+        false,
+      );
+    });
+
+    it("returns false for hidden items without indent", () => {
+      expect(isTopLevelNavItem({ page_id: 1, hidden: true })).toBe(false);
+    });
+
+    it("returns false for hidden items with zero indent", () => {
+      expect(isTopLevelNavItem({ page_id: 1, hidden: true, indent: 0 })).toBe(
+        false,
+      );
+    });
+  });
 
   describe("getDataAppHomePageId", () => {
     describe("with explicit homepage", () => {

--- a/frontend/src/metabase/entities/data-apps/utils.unit.spec.ts
+++ b/frontend/src/metabase/entities/data-apps/utils.unit.spec.ts
@@ -66,6 +66,14 @@ describe("data app utils", () => {
     });
 
     describe("without explicit homepage", () => {
+      it("returns first top-level nav item page ID", () => {
+        const dataApp = createMockDataApp({
+          ...dataAppWithoutHomepage,
+          nav_items: [{ page_id: 1, hidden: true }, { page_id: 8 }],
+        });
+        expect(getDataAppHomePageId(dataApp, pages)).toEqual(8);
+      });
+
       it("returns fist page in alphabetical order", () => {
         expect(getDataAppHomePageId(dataAppWithoutHomepage, pages)).toEqual(
           page1.id,

--- a/frontend/src/metabase/entities/data-apps/utils.unit.spec.ts
+++ b/frontend/src/metabase/entities/data-apps/utils.unit.spec.ts
@@ -7,6 +7,7 @@ import {
   isTopLevelNavItem,
   getDataAppHomePageId,
   getParentDataAppPageId,
+  getPreviousNavItem,
   getChildNavItems,
 } from "./utils";
 
@@ -169,6 +170,39 @@ describe("data app utils", () => {
       expect(getChildNavItems(navItems, 1)).toEqual([]);
       expect(getChildNavItems(navItems, 2)).toEqual([]);
       expect(getChildNavItems(navItems, 3)).toEqual([]);
+    });
+  });
+
+  describe("getPreviousNavItem", () => {
+    it("should return previous nav item", () => {
+      const navItems: DataAppNavItem[] = [
+        { page_id: 1 },
+        { page_id: 2 },
+        { page_id: 3 },
+      ];
+
+      expect(getPreviousNavItem(navItems, 3)).toEqual(navItems[1]);
+    });
+
+    it("should return null if there are no nav items", () => {
+      expect(getPreviousNavItem([], 1)).toBeNull();
+    });
+
+    it("should return last nav item if unknown page ID was provided", () => {
+      const navItems: DataAppNavItem[] = [{ page_id: 1 }, { page_id: 2 }];
+
+      expect(getPreviousNavItem(navItems, 3)).toEqual(navItems[1]);
+    });
+
+    it("should return previous top-level nav item", () => {
+      const navItems: DataAppNavItem[] = [
+        { page_id: 1 },
+        { page_id: 2, indent: 1 },
+        { page_id: 3, indent: 1 },
+        { page_id: 4 },
+      ];
+
+      expect(getPreviousNavItem(navItems, 3)).toEqual(navItems[0]);
     });
   });
 });

--- a/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbar/DataAppActionPanel/DataAppActionPanel.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbar/DataAppActionPanel/DataAppActionPanel.tsx
@@ -8,6 +8,7 @@ import Tooltip from "metabase/components/Tooltip";
 
 import * as Urls from "metabase/lib/urls";
 
+import ArchiveDataAppModal from "metabase/writeback/containers/ArchiveDataAppModal";
 import ArchiveDataAppPageModal from "metabase/writeback/containers/ArchiveDataAppPageModal";
 
 import type { DataApp, DataAppPage } from "metabase-types/api";
@@ -17,9 +18,11 @@ import { Root } from "./DataAppActionPanel.styled";
 interface Props {
   dataApp: DataApp;
   selectedPageId?: DataAppPage["id"];
+  archiveActionTarget: "app" | "page";
   hasManageContentAction?: boolean;
   onEditAppPage: () => void;
   onEditAppSettings: () => void;
+  onAppArchived: () => void;
   onPageArchived: (pageId: DataAppPage["id"]) => void;
 }
 
@@ -33,9 +36,11 @@ type MenuItem = {
 function DataAppActionPanel({
   dataApp,
   selectedPageId,
+  archiveActionTarget,
   hasManageContentAction = true,
   onEditAppPage,
   onEditAppSettings,
+  onAppArchived,
   onPageArchived,
 }: Props) {
   const [isArchiveModalOpen, setIsArchiveModalOpen] = useState(false);
@@ -61,14 +66,23 @@ function DataAppActionPanel({
 
     if (hasSelectedPage) {
       items.push({
-        title: t`Archive this page`,
+        title:
+          archiveActionTarget === "app"
+            ? t`Archive this app`
+            : t`Archive this page`,
         icon: "archive",
         action: () => setIsArchiveModalOpen(true),
       });
     }
 
     return items;
-  }, [dataApp, hasSelectedPage, hasManageContentAction, onEditAppSettings]);
+  }, [
+    dataApp,
+    archiveActionTarget,
+    hasSelectedPage,
+    hasManageContentAction,
+    onEditAppSettings,
+  ]);
 
   const handleCloseArchiveModal = useCallback(() => {
     setIsArchiveModalOpen(false);
@@ -94,12 +108,20 @@ function DataAppActionPanel({
       />
       {hasSelectedPage && isArchiveModalOpen && (
         <Modal onClose={handleCloseArchiveModal}>
-          <ArchiveDataAppPageModal
-            appId={dataApp.id}
-            pageId={selectedPageId}
-            onArchive={handleArchive}
-            onClose={handleCloseArchiveModal}
-          />
+          {archiveActionTarget === "app" ? (
+            <ArchiveDataAppModal
+              appId={dataApp.id}
+              onArchive={onAppArchived}
+              onClose={handleCloseArchiveModal}
+            />
+          ) : (
+            <ArchiveDataAppPageModal
+              appId={dataApp.id}
+              pageId={selectedPageId}
+              onArchive={handleArchive}
+              onClose={handleCloseArchiveModal}
+            />
+          )}
         </Modal>
       )}
     </Root>

--- a/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbar/DataAppActionPanel/DataAppActionPanel.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbar/DataAppActionPanel/DataAppActionPanel.tsx
@@ -1,15 +1,11 @@
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useMemo } from "react";
 import { t } from "ttag";
 
 import Button from "metabase/core/components/Button";
 import EntityMenu from "metabase/components/EntityMenu";
-import Modal from "metabase/components/Modal";
 import Tooltip from "metabase/components/Tooltip";
 
 import * as Urls from "metabase/lib/urls";
-
-import ArchiveDataAppModal from "metabase/writeback/containers/ArchiveDataAppModal";
-import ArchiveDataAppPageModal from "metabase/writeback/containers/ArchiveDataAppPageModal";
 
 import type { DataApp, DataAppPage } from "metabase-types/api";
 
@@ -22,8 +18,8 @@ interface Props {
   hasManageContentAction?: boolean;
   onEditAppPage: () => void;
   onEditAppSettings: () => void;
-  onAppArchived: () => void;
-  onPageArchived: (pageId: DataAppPage["id"]) => void;
+  onArchiveApp: () => void;
+  onArchivePage: () => void;
 }
 
 type MenuItem = {
@@ -40,11 +36,9 @@ function DataAppActionPanel({
   hasManageContentAction = true,
   onEditAppPage,
   onEditAppSettings,
-  onAppArchived,
-  onPageArchived,
+  onArchiveApp,
+  onArchivePage,
 }: Props) {
-  const [isArchiveModalOpen, setIsArchiveModalOpen] = useState(false);
-
   const hasSelectedPage = typeof selectedPageId === "number";
 
   const menuItems = useMemo(() => {
@@ -65,13 +59,11 @@ function DataAppActionPanel({
     }
 
     if (hasSelectedPage) {
+      const isArchiveApp = archiveActionTarget === "app";
       items.push({
-        title:
-          archiveActionTarget === "app"
-            ? t`Archive this app`
-            : t`Archive this page`,
+        title: isArchiveApp ? t`Archive this app` : t`Archive this page`,
         icon: "archive",
-        action: () => setIsArchiveModalOpen(true),
+        action: isArchiveApp ? onArchiveApp : onArchivePage,
       });
     }
 
@@ -82,17 +74,9 @@ function DataAppActionPanel({
     hasSelectedPage,
     hasManageContentAction,
     onEditAppSettings,
+    onArchiveApp,
+    onArchivePage,
   ]);
-
-  const handleCloseArchiveModal = useCallback(() => {
-    setIsArchiveModalOpen(false);
-  }, []);
-
-  const handleArchive = useCallback(() => {
-    if (selectedPageId) {
-      onPageArchived(selectedPageId);
-    }
-  }, [selectedPageId, onPageArchived]);
 
   return (
     <Root>
@@ -106,24 +90,6 @@ function DataAppActionPanel({
         triggerIcon="ellipsis"
         tooltip={t`Manage content, settings and more…`}
       />
-      {hasSelectedPage && isArchiveModalOpen && (
-        <Modal onClose={handleCloseArchiveModal}>
-          {archiveActionTarget === "app" ? (
-            <ArchiveDataAppModal
-              appId={dataApp.id}
-              onArchive={onAppArchived}
-              onClose={handleCloseArchiveModal}
-            />
-          ) : (
-            <ArchiveDataAppPageModal
-              appId={dataApp.id}
-              pageId={selectedPageId}
-              onArchive={handleArchive}
-              onClose={handleCloseArchiveModal}
-            />
-          )}
-        </Modal>
-      )}
     </Root>
   );
 }

--- a/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbar/DataAppNavbarContainer.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbar/DataAppNavbarContainer.tsx
@@ -163,7 +163,9 @@ function DataAppNavbarContainer({
     (pageId: DataAppPage["id"]) => {
       const navItemToOpen =
         getPreviousNavItem(dataApp.nav_items, pageId) ||
-        dataApp.nav_items.find(isTopLevelNavItem);
+        dataApp.nav_items.find(
+          navItem => isTopLevelNavItem(navItem) && navItem.page_id !== pageId,
+        );
 
       const nextUrl = navItemToOpen
         ? Urls.dataAppPage(dataApp, navItemToOpen)

--- a/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbar/DataAppNavbarContainer.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbar/DataAppNavbarContainer.tsx
@@ -137,6 +137,10 @@ function DataAppNavbarContainer({
     setModal("MODAL_NEW_PAGE");
   }, []);
 
+  const handleAppArchive = useCallback(() => {
+    onChangeLocation("/");
+  }, [onChangeLocation]);
+
   const handlePageArchive = useCallback(
     (pageId: DataAppPage["id"]) => {
       const navItemToOpen =
@@ -207,6 +211,7 @@ function DataAppNavbarContainer({
         onNewPage={onNewPage}
         onEditAppPage={handleEnablePageEditing}
         onEditAppSettings={onEditAppSettings}
+        onAppArchived={handleAppArchive}
         onPageArchived={handlePageArchive}
       />
       {modal && <Modal onClose={closeModal}>{renderModalContent()}</Modal>}

--- a/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbar/DataAppNavbarContainer.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbar/DataAppNavbarContainer.tsx
@@ -18,6 +18,9 @@ import Dashboards from "metabase/entities/dashboards";
 import Search from "metabase/entities/search";
 
 import { setEditingDashboard as setEditingDataAppPage } from "metabase/dashboard/actions";
+
+import ArchiveDataAppModal from "metabase/writeback/containers/ArchiveDataAppModal";
+import ArchiveDataAppPageModal from "metabase/writeback/containers/ArchiveDataAppPageModal";
 import ScaffoldDataAppPagesModal from "metabase/writeback/containers/ScaffoldDataAppPagesModal";
 
 import type { DataApp, DataAppPage } from "metabase-types/api";
@@ -42,6 +45,8 @@ type NavbarModal =
   | "MODAL_ADD_DATA"
   | "MODAL_APP_SETTINGS"
   | "MODAL_NEW_PAGE"
+  | "MODAL_ARCHIVE_PAGE"
+  | "MODAL_ARCHIVE_APP"
   | null;
 
 interface DataAppNavbarContainerOwnProps extends MainNavbarProps {
@@ -101,6 +106,11 @@ function DataAppNavbarContainer({
     [dataApp, pages, location, params],
   );
 
+  const selectedPageId = useMemo(() => {
+    const pageItem = selectedItems.find(item => item.type === "data-app-page");
+    return (pageItem?.id as DataAppPage["id"]) || null;
+  }, [selectedItems]);
+
   const handleEnablePageEditing = useCallback(() => {
     setEditingDataAppPage(true);
   }, [setEditingDataAppPage]);
@@ -135,6 +145,14 @@ function DataAppNavbarContainer({
 
   const onNewPage = useCallback(() => {
     setModal("MODAL_NEW_PAGE");
+  }, []);
+
+  const onArchiveApp = useCallback(() => {
+    setModal("MODAL_ARCHIVE_APP");
+  }, []);
+
+  const onArchivePage = useCallback(() => {
+    setModal("MODAL_ARCHIVE_PAGE");
   }, []);
 
   const handleAppArchive = useCallback(() => {
@@ -196,8 +214,43 @@ function DataAppNavbarContainer({
         />
       );
     }
+
+    if (!selectedPageId) {
+      return null;
+    }
+
+    if (modal === "MODAL_ARCHIVE_APP") {
+      return (
+        <ArchiveDataAppModal
+          appId={dataApp.id}
+          onArchive={handleAppArchive}
+          onClose={closeModal}
+        />
+      );
+    }
+
+    if (modal === "MODAL_ARCHIVE_PAGE") {
+      return (
+        <ArchiveDataAppPageModal
+          appId={dataApp.id}
+          pageId={selectedPageId}
+          onArchive={() => handlePageArchive(selectedPageId)}
+          onClose={closeModal}
+        />
+      );
+    }
+
     return null;
-  }, [dataApp, modal, handleNewDataAdded, closeModal, onChangeLocation]);
+  }, [
+    dataApp,
+    selectedPageId,
+    modal,
+    handleNewDataAdded,
+    handleAppArchive,
+    handlePageArchive,
+    closeModal,
+    onChangeLocation,
+  ]);
 
   return (
     <>
@@ -211,8 +264,8 @@ function DataAppNavbarContainer({
         onNewPage={onNewPage}
         onEditAppPage={handleEnablePageEditing}
         onEditAppSettings={onEditAppSettings}
-        onAppArchived={handleAppArchive}
-        onPageArchived={handlePageArchive}
+        onArchiveApp={onArchiveApp}
+        onArchivePage={onArchivePage}
       />
       {modal && <Modal onClose={closeModal}>{renderModalContent()}</Modal>}
     </>

--- a/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbar/DataAppNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbar/DataAppNavbarView.tsx
@@ -25,6 +25,7 @@ interface Props extends Omit<MainNavbarProps, "location" | "params"> {
   onEditAppSettings: () => void;
   onAddData: () => void;
   onNewPage: () => void;
+  onPageArchived: (pageId: DataAppPageId) => void;
 }
 
 function DataAppNavbarView({
@@ -36,6 +37,7 @@ function DataAppNavbarView({
   onEditAppSettings,
   onAddData,
   onNewPage,
+  onPageArchived,
 }: Props) {
   const { "data-app-page": dataAppPage } = _.indexBy(
     selectedItems,
@@ -90,6 +92,7 @@ function DataAppNavbarView({
         hasManageContentAction={mode !== "manage-content"}
         onEditAppPage={onEditAppPage}
         onEditAppSettings={onEditAppSettings}
+        onPageArchived={onPageArchived}
       />
     </Root>
   );

--- a/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbar/DataAppNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbar/DataAppNavbarView.tsx
@@ -25,8 +25,8 @@ interface Props extends Omit<MainNavbarProps, "location" | "params"> {
   onEditAppSettings: () => void;
   onAddData: () => void;
   onNewPage: () => void;
-  onAppArchived: () => void;
-  onPageArchived: (pageId: DataAppPageId) => void;
+  onArchiveApp: () => void;
+  onArchivePage: () => void;
 }
 
 function DataAppNavbarView({
@@ -38,8 +38,8 @@ function DataAppNavbarView({
   onEditAppSettings,
   onAddData,
   onNewPage,
-  onAppArchived,
-  onPageArchived,
+  onArchiveApp,
+  onArchivePage,
 }: Props) {
   const { "data-app-page": dataAppPage } = _.indexBy(
     selectedItems,
@@ -95,8 +95,8 @@ function DataAppNavbarView({
         hasManageContentAction={mode !== "manage-content"}
         onEditAppPage={onEditAppPage}
         onEditAppSettings={onEditAppSettings}
-        onAppArchived={onAppArchived}
-        onPageArchived={onPageArchived}
+        onArchiveApp={onArchiveApp}
+        onArchivePage={onArchivePage}
       />
     </Root>
   );

--- a/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbar/DataAppNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbar/DataAppNavbarView.tsx
@@ -25,6 +25,7 @@ interface Props extends Omit<MainNavbarProps, "location" | "params"> {
   onEditAppSettings: () => void;
   onAddData: () => void;
   onNewPage: () => void;
+  onAppArchived: () => void;
   onPageArchived: (pageId: DataAppPageId) => void;
 }
 
@@ -37,6 +38,7 @@ function DataAppNavbarView({
   onEditAppSettings,
   onAddData,
   onNewPage,
+  onAppArchived,
   onPageArchived,
 }: Props) {
   const { "data-app-page": dataAppPage } = _.indexBy(
@@ -89,9 +91,11 @@ function DataAppNavbarView({
       <DataAppActionPanel
         dataApp={dataApp}
         selectedPageId={dataAppPage?.id as DataAppPageId}
+        archiveActionTarget={navItems.length > 1 ? "page" : "app"}
         hasManageContentAction={mode !== "manage-content"}
         onEditAppPage={onEditAppPage}
         onEditAppSettings={onEditAppSettings}
+        onAppArchived={onAppArchived}
         onPageArchived={onPageArchived}
       />
     </Root>

--- a/frontend/src/metabase/writeback/actions.ts
+++ b/frontend/src/metabase/writeback/actions.ts
@@ -1,6 +1,9 @@
 import { ActionsApi } from "metabase/services";
 
-import DataApps, { getChildNavItems } from "metabase/entities/data-apps";
+import DataApps, {
+  getChildNavItems,
+  isTopLevelNavItem,
+} from "metabase/entities/data-apps";
 import Dashboards from "metabase/entities/dashboards";
 
 import type { DataApp, DataAppPage } from "metabase-types/api";
@@ -158,10 +161,14 @@ export const archiveDataAppPage = ({
       ),
     );
 
+    const isHomepageArchived =
+      dataApp.dashboard_id && archivedPageIds.includes(dataApp.dashboard_id);
+
     await dispatch(
       DataApps.actions.update({
         id: appId,
         nav_items: nextNavItems,
+        dashboard_id: isHomepageArchived ? null : dataApp.dashboard_id,
       }),
     );
   };

--- a/frontend/src/metabase/writeback/actions.ts
+++ b/frontend/src/metabase/writeback/actions.ts
@@ -105,6 +105,30 @@ export const deleteManyRows = (payload: BulkDeletePayload) => {
   );
 };
 
+export type ArchiveDataAppPayload = {
+  id: DataApp["id"];
+};
+
+export const archiveDataApp = ({ id }: ArchiveDataAppPayload) => {
+  return async (dispatch: Dispatch, getState: GetState) => {
+    const state = getState();
+
+    const dataApp: DataApp = DataApps.selectors.getObject(state, {
+      entityId: id,
+    });
+
+    await dispatch(
+      DataApps.actions.update({
+        id,
+        collection_id: dataApp.collection_id,
+        collection: {
+          archived: true,
+        },
+      }),
+    );
+  };
+};
+
 export type ArchiveDataAppPagePayload = {
   appId: DataApp["id"];
   pageId: DataAppPage["id"];

--- a/frontend/src/metabase/writeback/containers/ArchiveDataAppModal.tsx
+++ b/frontend/src/metabase/writeback/containers/ArchiveDataAppModal.tsx
@@ -1,0 +1,60 @@
+import React, { useCallback } from "react";
+import { t } from "ttag";
+import { connect } from "react-redux";
+
+import ArchiveModal from "metabase/components/ArchiveModal";
+
+import {
+  archiveDataApp,
+  ArchiveDataAppPayload,
+} from "metabase/writeback/actions";
+
+import type { DataApp } from "metabase-types/api";
+import type { State } from "metabase-types/store";
+
+interface OwnProps {
+  appId: DataApp["id"];
+  onArchive?: () => void;
+  onClose: () => void;
+}
+
+interface DispatchProps {
+  archiveDataApp: (payload: ArchiveDataAppPayload) => Promise<void>;
+}
+
+type Props = OwnProps & DispatchProps;
+
+const mapDispatchToProps = {
+  archiveDataApp,
+};
+
+function ArchiveDataAppModal({
+  appId,
+  archiveDataApp,
+  onArchive,
+  onClose,
+}: Props) {
+  const handleArchive = useCallback(async () => {
+    await archiveDataApp({ id: appId });
+    onArchive?.();
+    onClose();
+  }, [appId, archiveDataApp, onArchive, onClose]);
+
+  return (
+    <ArchiveModal
+      title={t`Archive this app?`}
+      message={t`The pages, questions, and models in this app will also be archived.`}
+      onArchive={handleArchive}
+      onClose={onClose}
+    />
+  );
+}
+
+export default connect<unknown, DispatchProps, OwnProps, State>(
+  null,
+
+  // Need to figure out how to properly type curried actions
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  mapDispatchToProps,
+)(ArchiveDataAppModal);

--- a/frontend/src/metabase/writeback/containers/ArchiveDataAppPageModal.tsx
+++ b/frontend/src/metabase/writeback/containers/ArchiveDataAppPageModal.tsx
@@ -44,8 +44,8 @@ function ArchiveDataAppPageModal({
 
   return (
     <ArchiveModal
-      title={t`Are you sure you want to archive this page?`}
-      message={t`All of its sub-pages are going to be archived as well.`}
+      title={t`Archive this page?`}
+      message={t`All of its sub-pages will also to archived.`}
       onArchive={handleArchive}
       onClose={onClose}
     />

--- a/frontend/src/metabase/writeback/containers/ArchiveDataAppPageModal.tsx
+++ b/frontend/src/metabase/writeback/containers/ArchiveDataAppPageModal.tsx
@@ -1,0 +1,64 @@
+import React, { useCallback } from "react";
+import { t } from "ttag";
+import { connect } from "react-redux";
+
+import ArchiveModal from "metabase/components/ArchiveModal";
+
+import {
+  archiveDataAppPage,
+  ArchiveDataAppPagePayload,
+} from "metabase/writeback/actions";
+
+import type { DataApp, DataAppPage } from "metabase-types/api";
+import type { State } from "metabase-types/store";
+
+interface OwnProps {
+  appId: DataApp["id"];
+  pageId: DataAppPage["id"];
+  onArchive?: () => void;
+  onClose: () => void;
+}
+
+interface DispatchProps {
+  archiveDataAppPage: (
+    payload: ArchiveDataAppPagePayload,
+  ) => Promise<{ dataApp: DataApp }>;
+}
+
+type Props = OwnProps & DispatchProps;
+
+const mapDispatchToProps = {
+  archiveDataAppPage,
+};
+
+function ArchiveDataAppPageModal({
+  appId,
+  pageId,
+  archiveDataAppPage,
+  onArchive,
+  onClose,
+}: Props) {
+  const handleArchive = useCallback(async () => {
+    await archiveDataAppPage({ appId, pageId });
+    onArchive?.();
+    onClose();
+  }, [appId, pageId, archiveDataAppPage, onArchive, onClose]);
+
+  return (
+    <ArchiveModal
+      title={t`Are you sure you want to archive this page?`}
+      message={t`All of its sub-pages are going to be archived as well.`}
+      onArchive={handleArchive}
+      onClose={onClose}
+    />
+  );
+}
+
+export default connect<unknown, DispatchProps, OwnProps, State>(
+  null,
+
+  // Need to figure out how to properly type curried actions
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  mapDispatchToProps,
+)(ArchiveDataAppPageModal);

--- a/frontend/src/metabase/writeback/containers/ArchiveDataAppPageModal.tsx
+++ b/frontend/src/metabase/writeback/containers/ArchiveDataAppPageModal.tsx
@@ -20,9 +20,7 @@ interface OwnProps {
 }
 
 interface DispatchProps {
-  archiveDataAppPage: (
-    payload: ArchiveDataAppPagePayload,
-  ) => Promise<{ dataApp: DataApp }>;
+  archiveDataAppPage: (payload: ArchiveDataAppPagePayload) => Promise<void>;
 }
 
 type Props = OwnProps & DispatchProps;


### PR DESCRIPTION
Implements page and data app archiving. Works in a similar way to dashboard archiving, but with a few nuances:

1. For a given page, all of its sub-pages will be archived as well
2. When archiving an app homepage, we set the homepage ID to `null` on the dashboard level
3. Archiving pages doesn't really work well yet

### To Verify

1. New > App > Pick a bunch of tables > Create
4. Try archiving pages at the beginning or end of the nav list, try archiving pages in the middle. Ensure a page that gets selected next makes sense
5. Archive a homepage (set automatically when scaffolding on the app's `dashboard_id` column). Ensure you can still open the app (the first page should be selected)
6. When there's only one top-level page left, make sure you see "Archive app" actions instead of "Archive page"

### Demo

https://user-images.githubusercontent.com/17258145/197811479-4efa6aa0-48df-40e6-ae6f-2143182befd6.mp4

